### PR TITLE
Disallow assignment in expressions

### DIFF
--- a/samples/if_with_bad_assignment.error
+++ b/samples/if_with_bad_assignment.error
@@ -1,0 +1,1 @@
+assignment is not allowed in this position

--- a/samples/if_with_bad_assignment.jakt
+++ b/samples/if_with_bad_assignment.jakt
@@ -1,0 +1,7 @@
+fun main() {
+    var x = 100;
+
+    if (x = 99) {
+        print("true")
+    }
+}

--- a/src/error.rs
+++ b/src/error.rs
@@ -4,6 +4,7 @@ use crate::parser::Span;
 pub enum JaktError {
     IOError(std::io::Error),
     ParserError(String, Span),
+    ValidationError(String, Span),
     TypecheckError(String, Span),
 }
 

--- a/src/lexer.rs
+++ b/src/lexer.rs
@@ -297,7 +297,7 @@ fn lex_item(file_id: FileId, bytes: &[u8], index: &mut usize) -> (Token, Option<
 
         if *index == bytes.len() || bytes[*index] != b'"' {
             error = error.or(Some(JaktError::ParserError(
-                "Expected quote".to_string(),
+                "expected quote".to_string(),
                 Span::new(file_id, *index, *index),
             )));
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -14,6 +14,7 @@ fn main() -> Result<(), JaktError> {
                 JaktError::IOError(ioe) => println!("IO Error: {}", ioe),
                 JaktError::ParserError(msg, span) => display_error(&parser, &msg, span),
                 JaktError::TypecheckError(msg, span) => display_error(&parser, &msg, span),
+                JaktError::ValidationError(msg, span) => display_error(&parser, &msg, span),
             },
         }
     }


### PR DESCRIPTION
This prevents the assignment operator from being used in expressions that aren't statement-level.

For example, this will now error:
```
fun main() {
    var x = 100;

    if (x = 99) {
        print("true")
    }
}
```