### PR TITLE
Add simplified function syntax (fat arrows)

### DIFF
--- a/samples/functions/arrow_function.jakt
+++ b/samples/functions/arrow_function.jakt
@@ -1,0 +1,10 @@
+fun area(width: i64, height: i64) => width * height
+fun greeting(name: String) => "Hello, " + name + "!"
+fun greet(name: String) => print(greeting(name: name))
+
+fun main() {
+    let a = area(width: 5, height: 10)
+    print(a)
+
+    greet(name: "friends")
+}

--- a/samples/functions/arrow_function.out
+++ b/samples/functions/arrow_function.out
@@ -1,0 +1,2 @@
+50
+Hello, friends!

--- a/src/typechecker.rs
+++ b/src/typechecker.rs
@@ -229,10 +229,22 @@ fn typecheck_fun(
 
     stack.pop_frame();
 
+    // If the return type is unknown, and the function starts with a return statement,
+    // we infer the return type from its expression.
+    let return_type = if fun.return_type == Type::Unknown {
+        if let Some(CheckedStatement::Return(ret)) = block.stmts.first() {
+            ret.ty()
+        } else {
+            Type::Unknown
+        }
+    } else {
+        fun.return_type.clone()
+    };
+
     let output = CheckedFunction {
         name: fun.name.clone(),
         params: fun.params.clone(),
-        return_type: fun.return_type.clone(),
+        return_type: return_type,
         block,
     };
 


### PR DESCRIPTION
These are now equivalent:

    fun sum(a: i64, b: i64) -> i64 {
        return a + b
    }

    fun sum(a: i64, b: i64) => a + b

Note that the return type is inferred from the expression as well.