### PR TITLE
Pass command line arguments as Vector<String> to main()

### DIFF
--- a/runtime/lib.h
+++ b/runtime/lib.h
@@ -83,3 +83,14 @@ inline String runtime_helper_number_to_string(i64 number)
 {
     return String::number(number);
 }
+
+int __jakt_main(Vector<String>);
+
+int main(int argc, char** argv)
+{
+    Vector<String> args;
+    for (int i = 0; i < argc; ++i) {
+        args.append(argv[i]);
+    }
+    return __jakt_main(move(args));
+}

--- a/src/codegen.rs
+++ b/src/codegen.rs
@@ -34,7 +34,7 @@ pub fn translate(file: &CheckedFile) -> String {
     for fun in &file.funs {
         let fun_output = translate_function_predecl(fun, file);
 
-        if fun.linkage != FunctionLinkage::ImplicitConstructor {
+        if fun.linkage != FunctionLinkage::ImplicitConstructor && fun.name != "main" {
             output.push_str(&fun_output);
             output.push('\n');
         }
@@ -142,8 +142,16 @@ fn translate_function(fun: &CheckedFunction, file: &CheckedFile) -> String {
         output.push_str(&translate_type(&fun.return_type, file));
     }
     output.push(' ');
-    output.push_str(&fun.name);
+    if fun.name == "main" {
+        output.push_str("__jakt_main");
+    } else {
+        output.push_str(&fun.name);
+    }
     output.push('(');
+
+    if fun.name == "main" && fun.params.is_empty() {
+        output.push_str("Vector<String>");
+    }
 
     let mut first = true;
     for param in &fun.params {
@@ -160,8 +168,16 @@ fn translate_function(fun: &CheckedFunction, file: &CheckedFile) -> String {
     }
     output.push(')');
 
+    if fun.name == "main" {
+        output.push_str("\n{");
+    }
+
     let block = translate_block(0, &fun.block, file);
     output.push_str(&block);
+
+    if fun.name == "main" {
+        output.push_str("return 0; }");
+    }
 
     output
 }


### PR DESCRIPTION
This is achieved by moving the real main() function to runtime/lib.h
and having the compiler emit a `__jakt_main(Vector<String>)` function
for the "main" jakt function.

For convenience, we allow omitting the arguments parameter to "main".
These are both valid programs:

    fun main() { }

    fun main(args: [String]) { }