### PR TITLE
assorted fixes

### DIFF
--- a/samples/basics/cat.jakt
+++ b/samples/basics/cat.jakt
@@ -1,10 +1,10 @@
 extern struct FILE {}
 
-extern fun fopen(anon str: raw char, anon mode: raw char) -> raw FILE
-extern fun fgetc(anon file: mut raw FILE) -> int
-extern fun fclose(anon file: mut raw FILE) -> int
-extern fun feof(anon file: mut raw FILE) -> int
-extern fun putchar(anon ch: int) -> int
+extern fun fopen(anon str: raw c_char, anon mode: raw c_char) -> raw FILE
+extern fun fgetc(anon file: mut raw FILE) -> c_int
+extern fun fclose(anon file: mut raw FILE) -> c_int
+extern fun feof(anon file: mut raw FILE) -> c_int
+extern fun putchar(anon ch: c_int) -> c_int
 
 fun main(args: [String]) {
     if args.size() <= 1 {

--- a/samples/functions/argument_labels.jakt
+++ b/samples/functions/argument_labels.jakt
@@ -7,8 +7,15 @@ fun bar(anon a: bool, b: bool) {
 fun baz(anon a: bool, anon b: bool) {
 }
 
+fun qux(a: bool) {
+
+}
+
 fun main() {
     foo(a: true, b: true)
     bar(true, b: true)
     baz(true, true)
+
+    let a = true
+    qux(a)
 }

--- a/samples/strings/string_builder.jakt
+++ b/samples/strings/string_builder.jakt
@@ -1,5 +1,5 @@
 extern struct StringBuilder {
-    fun append(mut this, anon s: raw char) {}
+    fun append(mut this, anon s: raw c_char) {}
     fun to_string(mut this) -> String {}
 }
 

--- a/samples/variables/integer_promotion_bad3.error
+++ b/samples/variables/integer_promotion_bad3.error
@@ -1,0 +1,1 @@
+Integer promotion failed

--- a/src/codegen.rs
+++ b/src/codegen.rs
@@ -16,8 +16,10 @@ pub fn codegen(file: &CheckedFile) -> String {
     for structure in &file.structs {
         let struct_output = codegen_struct_predecl(structure);
 
-        output.push_str(&struct_output);
-        output.push('\n');
+        if !struct_output.is_empty() {
+            output.push_str(&struct_output);
+            output.push('\n');
+        }
     }
 
     output.push('\n');
@@ -25,8 +27,10 @@ pub fn codegen(file: &CheckedFile) -> String {
     for structure in &file.structs {
         let struct_output = codegen_struct(structure, file);
 
-        output.push_str(&struct_output);
-        output.push('\n');
+        if !struct_output.is_empty() {
+            output.push_str(&struct_output);
+            output.push('\n');
+        }
     }
 
     output.push('\n');
@@ -147,6 +151,9 @@ fn codegen_function_predecl(fun: &CheckedFunction, file: &CheckedFile) -> String
             first = false;
         }
 
+        if !param.variable.mutable {
+            output.push_str("const ");
+        }
         let ty = codegen_type(&param.variable.ty, file);
         output.push_str(&ty);
         output.push(' ');
@@ -190,6 +197,10 @@ fn codegen_function(fun: &CheckedFunction, file: &CheckedFile) -> String {
             output.push_str(", ");
         } else {
             first = false;
+        }
+
+        if !param.variable.mutable {
+            output.push_str("const ");
         }
 
         let ty = codegen_type(&param.variable.ty, file);
@@ -264,8 +275,8 @@ fn codegen_type(ty: &Type, file: &CheckedFile) -> String {
     match ty {
         Type::Bool => String::from("bool"),
         Type::String => String::from("String"),
-        Type::Char => String::from("char"),
-        Type::Int => String::from("int"),
+        Type::CChar => String::from("char"),
+        Type::CInt => String::from("int"),
         Type::I8 => String::from("i8"),
         Type::I16 => String::from("i16"),
         Type::I32 => String::from("i32"),

--- a/src/compiler.rs
+++ b/src/compiler.rs
@@ -95,8 +95,8 @@ impl Compiler {
     pub fn prelude() -> Vec<u8> {
         r#"
 extern class String {
-    fun split(this, anon c: char) -> [String] {}
-    fun characters(this) -> raw char {}
+    fun split(this, anon c: c_char) -> [String] {}
+    fun characters(this) -> raw c_char {}
     fun to_lowercase(this) -> String {}
     fun to_uppercase(this) -> String {}
     fun is_empty(this) -> bool {}


### PR DESCRIPTION
A few different fixes:

* emit `const` in a few cases we weren't yet, but should have to align with the types
* allow labels to be given a variable of the same name
* add a test case for bad label 3
* rename char -> c_char and int -> c_int