### PR TITLE
Namespace refactor, part 2

### DIFF
--- a/src/codegen.rs
+++ b/src/codegen.rs
@@ -112,7 +112,8 @@ fn codegen_struct(structure: &CheckedStruct, project: &Project) -> String {
         output.push_str(";\n");
     }
 
-    for (_, fun_id) in &structure.scope.funs {
+    let scope = &project.scopes[structure.scope_id];
+    for (_, fun_id) in &scope.funs {
         let fun = &project.funs[*fun_id];
         if fun.linkage == FunctionLinkage::ImplicitConstructor {
             let fun_output = codegen_constructor(fun, project);


### PR DESCRIPTION
This is the next part of the refactor to prepare for more advanced features.

In this one, we move away from passing stacks around to having a central place for scopes. This gives us the ability to have pretty precise control over where we look for symbols in scope. For most things, this means instead of carrying their scope with them, they now carry a `ScopeId` which is the identifier for the interned scope in the `Project` (similar to function and struct Ids)

Having the ID also gives us the ability to circumvent lookups when we need to. For example `String` and `RefVector` live in the prelude. We don't want to accidentally let the user declare a type with these names and stomp on the definition that the built-ins should see. Now, this is handled by looking in ScopeId 0, the Id of the top-level scope that is the parent of all file scopes.

I've moved the lookups into `Project` for now. We may find a better home, but I found it convenient to centralise where we looked.