### PR TITLE
fix external constructors requiring namespacing

### DIFF
--- a/samples/generics/generic_instantiation.jakt
+++ b/samples/generics/generic_instantiation.jakt
@@ -1,5 +1,5 @@
 fun main() {
-    let item = Optional::Optional(100);
+    let item = Optional(100);
 
     println(item!)
 }


### PR DESCRIPTION
now, just look up the constructor by using the name of the type during function resolution