### PR TITLE
Allow using format strings with println()

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,7 +207,7 @@ let values = ["foo", "bar", "baz"]
 fun main() {
     let dict = ["a": 1, "b": 2]
 
-    println(dict["a"]!)
+    println("{}", dict["a"]!)
 }
 ```
 
@@ -227,7 +227,7 @@ fun id<T>(anon x: T) -> T {
 fun main() {
     let y = id(3);
 
-    println(y + 1000)
+    println("{}", y + 1000)
 }
 ```
 
@@ -239,7 +239,7 @@ struct Foo<T> {
 fun main() {
     let f = Foo(x: 100);
 
-    println(f.x);
+    println("{}", f.x);
 }
 ```
 ## Type casts

--- a/samples/apps/crc32.jakt
+++ b/samples/apps/crc32.jakt
@@ -41,5 +41,5 @@ fun main(args: [String]) {
     }
 
     let digest = ~state
-    println(digest)
+    println("{}", digest)
 }

--- a/samples/arrays/array1.jakt
+++ b/samples/arrays/array1.jakt
@@ -1,4 +1,4 @@
 fun main() {
     let x = [1, 2, 3]
-    println(x[1])
+    println("{}", x[1])
 }

--- a/samples/arrays/array2.jakt
+++ b/samples/arrays/array2.jakt
@@ -2,5 +2,5 @@ fun main() {
     let x = [1, 2, 3]
 
     let y = 2
-    println(x[y])
+    println("{}", x[y])
 }

--- a/samples/arrays/array_bad2.jakt
+++ b/samples/arrays/array_bad2.jakt
@@ -1,4 +1,4 @@
 fun main() {
     let x = [1, 2, 3]
-    println(x["bob"])
+    println("{}", x["bob"])
 }

--- a/samples/arrays/array_param.jakt
+++ b/samples/arrays/array_param.jakt
@@ -1,5 +1,5 @@
 fun get_first(anon v: [String]) => v[0]
 
 fun main() {
-    println(get_first(["one", "two"]))
+    println("{}", get_first(["one", "two"]))
 }

--- a/samples/arrays/array_pop.jakt
+++ b/samples/arrays/array_pop.jakt
@@ -3,5 +3,5 @@ fun main() {
 
     let last = v.pop()
 
-    println(last!)
+    println("{}", last!)
 }

--- a/samples/arrays/array_shorthand.jakt
+++ b/samples/arrays/array_shorthand.jakt
@@ -6,7 +6,7 @@ fun main() {
     let v: [String] = make_v()
     let mut i = 0
     while i < 2 {
-        println(v[i])
+        println("{}", v[i])
         ++i
     }
 }

--- a/samples/arrays/lvalue.jakt
+++ b/samples/arrays/lvalue.jakt
@@ -2,5 +2,5 @@ fun main() {
     let mut x = [1, 2, 3]
     x[1] = 55
 
-    println(x[1])
+    println("{}", x[1])
 }

--- a/samples/arrays/lvalue_bad.jakt
+++ b/samples/arrays/lvalue_bad.jakt
@@ -2,5 +2,5 @@ fun main() {
     let x = [1, 2, 3]
     x[1] = 55
 
-    println(x[1])
+    println("{}", x[1])
 }

--- a/samples/arrays/multidimension_array.jakt
+++ b/samples/arrays/multidimension_array.jakt
@@ -2,5 +2,5 @@ fun main() {
     let x = [[1, 2], 
              [3, 4]]
 
-    println(x[1][0])
+    println("{}", x[1][0])
 }

--- a/samples/arrays/prefill.jakt
+++ b/samples/arrays/prefill.jakt
@@ -1,8 +1,8 @@
 fun main() {
     let v = [85; 3]
-    println(v.size())
+    println("{}", v.size())
     let mut i = 0
     while i < v.size() {
-        println(v[i++])
+        println("{}", v[i++])
     }
 }

--- a/samples/arrays/reference_semantics.jakt
+++ b/samples/arrays/reference_semantics.jakt
@@ -8,7 +8,7 @@ fun main() {
 
     let mut i = 0
     while i < v.size() {
-        println(v[i])
+        println("{}", v[i])
         ++i
     }
 }

--- a/samples/arrays/size.jakt
+++ b/samples/arrays/size.jakt
@@ -1,5 +1,5 @@
 fun main() {
     let vec = [1, 2, 3, 4]
 
-    println(vec.size())
+    println("{}", vec.size())
 }

--- a/samples/basics/binary_literals.jakt
+++ b/samples/basics/binary_literals.jakt
@@ -1,5 +1,5 @@
 fun main() {
-    println(0b10000000)
-    println(0b111)
-    println(0b11111111111110101)
+    println("{}", 0b10000000)
+    println("{}", 0b111)
+    println("{}", 0b11111111111110101)
 }

--- a/samples/basics/bubble_sort.jakt
+++ b/samples/basics/bubble_sort.jakt
@@ -19,7 +19,7 @@ fun main() {
     bubble_sort(values: v)
     let mut i = 0
     while i < v.size() {
-        println(v[i])
+        println("{}", v[i])
         ++i
     }
 }

--- a/samples/basics/hello_number.jakt
+++ b/samples/basics/hello_number.jakt
@@ -1,3 +1,3 @@
 fun main() {
-    println(100)
+    println("{}", 100)
 }

--- a/samples/basics/hex_literals.jakt
+++ b/samples/basics/hex_literals.jakt
@@ -1,5 +1,5 @@
 fun main() {
-    println(0x123456789abcde)
-    println(0x0)
-    println(0xfffffffff)
+    println("{}", 0x123456789abcde)
+    println("{}", 0x0)
+    println("{}", 0xfffffffff)
 }

--- a/samples/basics/numeric_literal_suffixes.jakt
+++ b/samples/basics/numeric_literal_suffixes.jakt
@@ -1,7 +1,7 @@
 fun main() {
     let mut a = 0uz
     a += 5 as! usize
-    println(a)
+    println("{}", a)
 
     {
         let mut i = 0u8
@@ -14,10 +14,10 @@ fun main() {
         k += 5 as! u32
         l += 5 as! u64
         
-        println(i)
-        println(j)
-        println(k)
-        println(l)
+        println("{}", i)
+        println("{}", j)
+        println("{}", k)
+        println("{}", l)
     }
     {
         let mut i = 0i8
@@ -30,9 +30,9 @@ fun main() {
         k += 5 as! i32
         l += 5 as! i64
 
-        println(i)
-        println(j)
-        println(k)
-        println(l)
+        println("{}", i)
+        println("{}", j)
+        println("{}", k)
+        println("{}", l)
     }
 }

--- a/samples/classes/class.jakt
+++ b/samples/classes/class.jakt
@@ -6,6 +6,6 @@ class Person {
 fun main() {
     let p = Person(name: "Jane", age: 100)
 
-    println(p.name)
-    println(p.age)
+    println("{}", p.name)
+    println("{}", p.age)
 }

--- a/samples/classes/method.jakt
+++ b/samples/classes/method.jakt
@@ -12,5 +12,5 @@ fun main() {
 
     p.birthday()
 
-    println(p.age)
+    println("{}", p.age)
 }

--- a/samples/classes/static_method.jakt
+++ b/samples/classes/static_method.jakt
@@ -10,6 +10,6 @@ class Person {
 fun main() {
     let p = Person::generate(name: "Jane", age: 100)
 
-    println(p.name)
-    println(p.age)
+    println("{}", p.name)
+    println("{}", p.age)
 }

--- a/samples/control_flow/continue.jakt
+++ b/samples/control_flow/continue.jakt
@@ -5,6 +5,6 @@ fun main() {
         if i % 2 == 0 {
             continue
         }
-        println(i)
+        println("{}", i)
     }
 }

--- a/samples/control_flow/fizzbuzz.jakt
+++ b/samples/control_flow/fizzbuzz.jakt
@@ -8,7 +8,7 @@ fun main() {
         } else if i % 5 == 0 {
             println("Buzz")
         } else {
-            println(i)
+            println("{}", i)
         }
         ++i
     }

--- a/samples/control_flow/loop.jakt
+++ b/samples/control_flow/loop.jakt
@@ -4,7 +4,7 @@ fun main() {
         if i == 5 {
             break
         }
-        println(i)
+        println("{}", i)
         i++
     }
 }

--- a/samples/control_flow/while.jakt
+++ b/samples/control_flow/while.jakt
@@ -2,7 +2,7 @@ fun main() {
     let mut x: i64 = 10
 
     while (x > 0) {
-        println(x)
+        println("{}", x)
         x = x - 1
     }
 }

--- a/samples/control_flow/while2.jakt
+++ b/samples/control_flow/while2.jakt
@@ -2,7 +2,7 @@ fun main() {
     let mut x: i64 = 10
 
     while (x > 0) {
-        println(x)
+        println("{}", x)
         x -= 1
     }
 }

--- a/samples/control_flow/while3.jakt
+++ b/samples/control_flow/while3.jakt
@@ -2,7 +2,7 @@ fun main() {
     let mut x: i64 = 0
 
     while (x < 10) {
-        println(x)
+        println("{}", x)
         ++x
     }
 }

--- a/samples/dictionaries/contains.jakt
+++ b/samples/dictionaries/contains.jakt
@@ -1,5 +1,5 @@
 fun main() {
     let dict = ["a": 1, "b": 2]
-    println(dict.contains("b"))
-    println(dict.contains("c"))
+    println("{}", dict.contains("b"))
+    println("{}", dict.contains("c"))
 }

--- a/samples/dictionaries/dict.jakt
+++ b/samples/dictionaries/dict.jakt
@@ -1,5 +1,5 @@
 fun main() {
     let dict = ["a": 1, "b": 2]
 
-    println(dict.get("b")!)
+    println("{}", dict.get("b")!)
 }

--- a/samples/dictionaries/indexed.jakt
+++ b/samples/dictionaries/indexed.jakt
@@ -1,5 +1,5 @@
 fun main() {
     let dict = ["a": 1, "b": 2]
 
-    println(dict["a"]!)
+    println("{}", dict["a"]!)
 }

--- a/samples/dictionaries/set.jakt
+++ b/samples/dictionaries/set.jakt
@@ -3,5 +3,5 @@ fun main() {
 
     dict.set(key: "c", value: 3);
 
-    println(dict.get("c")!)
+    println("{}", dict.get("c")!)
 }

--- a/samples/functions/arrow_function.jakt
+++ b/samples/functions/arrow_function.jakt
@@ -1,10 +1,10 @@
 fun area(width: i64, height: i64) => width * height
 fun greeting(name: String) => "Hello, " + name + "!"
-fun greet(name: String) => println(greeting(name: name))
+fun greet(name: String) => println("{}", greeting(name: name))
 
 fun main() {
     let a = area(width: 5, height: 10)
-    println(a)
+    println("{}", a)
 
     greet(name: "friends")
 }

--- a/samples/functions/call_with_arg.jakt
+++ b/samples/functions/call_with_arg.jakt
@@ -1,5 +1,5 @@
 fun greet(msg: String) {
-    println(msg)
+    println("{}", msg)
 }
 
 fun main() {

--- a/samples/functions/call_with_bad_args.jakt
+++ b/samples/functions/call_with_bad_args.jakt
@@ -1,6 +1,6 @@
 fun greet(msg: String, msg2: String) {
-    println(msg)
-    println(msg2)
+    println("{}", msg)
+    println("{}", msg2)
 }
 
 fun main() {

--- a/samples/functions/call_with_return.jakt
+++ b/samples/functions/call_with_return.jakt
@@ -3,5 +3,5 @@ fun greet() -> String {
 }
 
 fun main() {
-    println(greet())
+    println("{}", greet())
 }

--- a/samples/functions/call_with_two_args.jakt
+++ b/samples/functions/call_with_two_args.jakt
@@ -1,6 +1,6 @@
 fun greet(msg: String, msg2: String) {
-    println(msg)
-    println(msg2)
+    println("{}", msg)
+    println("{}", msg2)
 }
 
 fun main() {

--- a/samples/functions/recursion.jakt
+++ b/samples/functions/recursion.jakt
@@ -3,7 +3,7 @@ fun main() {
 }
 
 fun recurse(count: i64) {
-    println(count)
+    println("{}", count)
     if count > 0 {
         recurse(count: count - 1)
     }

--- a/samples/generics/explicit_type_vars.jakt
+++ b/samples/generics/explicit_type_vars.jakt
@@ -3,5 +3,5 @@ fun main() {
 
     item.set(key: "bob", value: 123);
 
-    println(item.get("bob")!)
+    println("{}", item.get("bob")!)
 }

--- a/samples/generics/generic_fun.jakt
+++ b/samples/generics/generic_fun.jakt
@@ -1,5 +1,5 @@
 fun id<T>(anon x: T) => x
 
 fun main() {
-    println(id(3))
+    println("{}", id(3))
 }

--- a/samples/generics/generic_fun2.jakt
+++ b/samples/generics/generic_fun2.jakt
@@ -1,5 +1,5 @@
 fun id<T>(anon x: T) => x
 
 fun main() {
-    println(id(3) + 10)
+    println("{}", id(3) + 10)
 }

--- a/samples/generics/generic_fun3.jakt
+++ b/samples/generics/generic_fun3.jakt
@@ -3,5 +3,5 @@ fun id<T>(anon x: T) -> T {
 }
 
 fun main() {
-    println(id(3) + 100)
+    println("{}", id(3) + 100)
 }

--- a/samples/generics/generic_fun4.jakt
+++ b/samples/generics/generic_fun4.jakt
@@ -5,5 +5,5 @@ fun id<T>(anon x: T) -> T {
 fun main() {
     let y = id(3);
 
-    println(y + 1000)
+    println("{}", y + 1000)
 }

--- a/samples/generics/generic_instantiation.jakt
+++ b/samples/generics/generic_instantiation.jakt
@@ -1,5 +1,5 @@
 fun main() {
     let item = Optional(100);
 
-    println(item!)
+    println("{}", item!)
 }

--- a/samples/generics/generic_struct.jakt
+++ b/samples/generics/generic_struct.jakt
@@ -5,5 +5,5 @@ struct Foo<T> {
 fun main() {
     let f = Foo(x: 100);
 
-    println(f.x);
+    println("{}", f.x);
 }

--- a/samples/generics/generic_types.jakt
+++ b/samples/generics/generic_types.jakt
@@ -5,5 +5,5 @@ fun do_pop<T>(anon arr: mut [T]) -> Optional<T> {
 fun main() {
   let mut arr = [1, 2, 3];
 
-  println(do_pop(arr)!)
+  println("{}", do_pop(arr)!)
 }

--- a/samples/generics/passing_arrays.jakt
+++ b/samples/generics/passing_arrays.jakt
@@ -1,5 +1,5 @@
 fun dump<T>(anon v: [T]) { return v[0] }
 
 fun main() {
-    println(dump([1, 2, 3]))
+    println("{}", dump([1, 2, 3]))
 }

--- a/samples/math/arithmetic_shift.jakt
+++ b/samples/math/arithmetic_shift.jakt
@@ -1,6 +1,6 @@
 fun main() {
     let x: i64 = -100
 
-    println(x >>> 1)
-    println(x <<< 1)
+    println("{}", x >>> 1)
+    println("{}", x <<< 1)
 }

--- a/samples/math/bitwise.jakt
+++ b/samples/math/bitwise.jakt
@@ -1,8 +1,8 @@
 fun check(anon a: i64, anon b: i64) -> i64 {
     if a != b {
         println("Not equal!")
-        println(a)
-        println(b)
+        println("{}", a)
+        println("{}", b)
         return 1
     }
     return 0

--- a/samples/math/increment_decrement.jakt
+++ b/samples/math/increment_decrement.jakt
@@ -1,11 +1,11 @@
 fun main() {
     let mut x = 10
 
-    println(++x)
-    println(x++)
-    println(x)
+    println("{}", ++x)
+    println("{}", x++)
+    println("{}", x)
 
-    println(--x)
-    println(x--)
-    println(x)
+    println("{}", --x)
+    println("{}", x--)
+    println("{}", x)
 }

--- a/samples/math/increment_decrement_bad.jakt
+++ b/samples/math/increment_decrement_bad.jakt
@@ -1,5 +1,5 @@
 fun main() {
     let x = 10
 
-    println(++x)
+    println("{}", ++x)
 }

--- a/samples/math/integer_casts.jakt
+++ b/samples/math/integer_casts.jakt
@@ -7,11 +7,11 @@ fun main() {
     let f = -127 as truncated i8
     let g = 128 as truncated i8
 
-    println(a)
-    println(b)
-    println(c)
-    println(d)
-    println(e)
-    println(f)
-    println(g)
+    println("{}", a)
+    println("{}", b)
+    println("{}", c)
+    println("{}", d)
+    println("{}", e)
+    println("{}", f)
+    println("{}", g)
 }

--- a/samples/math/math.jakt
+++ b/samples/math/math.jakt
@@ -1,5 +1,5 @@
 fun subtract(x: i64, y: i64) {
-    println(x - y)
+    println("{}", x - y)
 }
 
 fun main() {

--- a/samples/math/math2.jakt
+++ b/samples/math/math2.jakt
@@ -1,4 +1,4 @@
 fun main() {
-    println(5 - 5 * 10 + 5)
-    println(2 * 8 - 12 / 2)
+    println("{}", 5 - 5 * 10 + 5)
+    println("{}", 2 * 8 - 12 / 2)
 }

--- a/samples/math/negate_negate.jakt
+++ b/samples/math/negate_negate.jakt
@@ -1,3 +1,3 @@
 fun main() {
-    println(-(-3))
+    println("{}", -(-3))
 }

--- a/samples/math/negate_unary_op.jakt
+++ b/samples/math/negate_unary_op.jakt
@@ -1,3 +1,3 @@
 fun main() {
-    println(-(4 + 10))
+    println("{}", -(4 + 10))
 }

--- a/samples/math/negative.jakt
+++ b/samples/math/negative.jakt
@@ -1,3 +1,3 @@
 fun main() {
-    println(-10 + 7)
+    println("{}", -10 + 7)
 }

--- a/samples/optional/basic.jakt
+++ b/samples/optional/basic.jakt
@@ -1,5 +1,5 @@
 fun main() {
     let foo : i64? = 123
     let bar = foo! + 2
-    println(bar)
+    println("{}", bar)
 }

--- a/samples/optional/mutable_unwrap.jakt
+++ b/samples/optional/mutable_unwrap.jakt
@@ -16,5 +16,5 @@ fun main() {
 
     opt_foo!.set(value: 2)
 
-    println(opt_foo!.get())
+    println("{}", opt_foo!.get())
 }

--- a/samples/pointers/bad_pointer_deref.jakt
+++ b/samples/pointers/bad_pointer_deref.jakt
@@ -1,5 +1,5 @@
 fun main() {
     let x = 4
 
-    println(*x)
+    println("{}", *x)
 }

--- a/samples/pointers/bad_raw_ptr.jakt
+++ b/samples/pointers/bad_raw_ptr.jakt
@@ -2,5 +2,5 @@ fun main() {
     let x = 10
     let y = &raw x
 
-    println(*y)
+    println("{}", *y)
 }

--- a/samples/pointers/raw_ptr.jakt
+++ b/samples/pointers/raw_ptr.jakt
@@ -3,6 +3,6 @@ fun main() {
     let y = &raw x
 
     unsafe {
-        println(*y)
+        println("{}", *y)
     }
 }

--- a/samples/ranges/range.jakt
+++ b/samples/ranges/range.jakt
@@ -5,5 +5,5 @@ fun main() {
         total += x
     }
 
-    println(total)
+    println("{}", total)
 }

--- a/samples/strings/length_and_is_empty.jakt
+++ b/samples/strings/length_and_is_empty.jakt
@@ -1,8 +1,8 @@
 fun main() {
     let x = "Well, hello friends"
 
-    println(x.length())
-    println(x.is_empty())
+    println("{}", x.length())
+    println("{}", x.is_empty())
 
-    println("".is_empty())
+    println("{}", "".is_empty())
 }

--- a/samples/strings/string_append.jakt
+++ b/samples/strings/string_append.jakt
@@ -1,9 +1,9 @@
 fun main() {
     let a = "ja"
     let b = "kt"
-    println(a + b)
+    println("{}", a + b)
 
     let mut str = "programming "
     str += "language"
-    println(str)
+    println("{}", str)
 }

--- a/samples/strings/string_builder.jakt
+++ b/samples/strings/string_builder.jakt
@@ -9,5 +9,5 @@ fun main() {
     s.append("abc".characters());
     s.append("123".characters());
 
-    println(s.to_string())
+    println("{}", s.to_string())
 }

--- a/samples/strings/string_split.jakt
+++ b/samples/strings/string_split.jakt
@@ -1,5 +1,5 @@
 fun main() {
     let result = "foo bar".split(' ')
 
-    println(result[1])
+    println("{}", result[1])
 }

--- a/samples/strings/uppercase_lowercase.jakt
+++ b/samples/strings/uppercase_lowercase.jakt
@@ -1,6 +1,6 @@
 fun main() {
     let name = "Andreas";
 
-    println(name.to_lowercase())
-    println(name.to_uppercase())
+    println("{}", name.to_lowercase())
+    println("{}", name.to_uppercase())
 }

--- a/samples/structs/lvalue.jakt
+++ b/samples/structs/lvalue.jakt
@@ -8,5 +8,5 @@ fun main() {
 
     p.age = 99;
 
-    println(p.age)
+    println("{}", p.age)
 }

--- a/samples/structs/method.jakt
+++ b/samples/structs/method.jakt
@@ -8,5 +8,5 @@ struct Rectangle {
 fun main() {
     let rect = Rectangle(width: 4, height: 8)
 
-    println(rect.area())
+    println("{}", rect.area())
 }

--- a/samples/structs/method_mutable.jakt
+++ b/samples/structs/method_mutable.jakt
@@ -15,5 +15,5 @@ fun main() {
 
     rect.grow()
 
-    println(rect.area())
+    println("{}", rect.area())
 }

--- a/samples/structs/struct.jakt
+++ b/samples/structs/struct.jakt
@@ -6,6 +6,6 @@ struct Person {
 fun main() {
     let p = Person(name: "Jane", age: 100)
 
-    println(p.name)
-    println(p.age)
+    println("{}", p.name)
+    println("{}", p.age)
 }

--- a/samples/structs/value_semantics.jakt
+++ b/samples/structs/value_semantics.jakt
@@ -8,12 +8,12 @@ fun set_x(foo: mut Foo, x: i64) {
 
 fun main() {
     let foo = Foo(x: 5)
-    println(foo.x)
+    println("{}", foo.x)
 
     set_x(foo: foo, x: 10)
-    println(foo.x)
+    println("{}", foo.x)
 
     let mut bar = foo
     bar.x = 15
-    println(foo.x)
+    println("{}", foo.x)
 }

--- a/samples/structs/vec_and_struct.jakt
+++ b/samples/structs/vec_and_struct.jakt
@@ -9,6 +9,6 @@ fun main() {
         Person(name: "Björn", age: 200)
     ]
 
-    println(arr[0].name)
-    println(arr[1].name)
+    println("{}", arr[0].name)
+    println("{}", arr[1].name)
 }

--- a/samples/structs/vec_and_struct_lvalue.jakt
+++ b/samples/structs/vec_and_struct_lvalue.jakt
@@ -11,6 +11,6 @@ fun main() {
 
     arr[1].name = "foobar";
 
-    println(arr[0].name)
-    println(arr[1].name)
+    println("{}", arr[0].name)
+    println("{}", arr[1].name)
 }

--- a/samples/tuples/tuple.jakt
+++ b/samples/tuples/tuple.jakt
@@ -1,5 +1,5 @@
 fun main() {
     let x = ("a", 2, true);
 
-    println(x.1)
+    println("{}", x.1)
 }

--- a/samples/variables/blocks_and_scopes.jakt
+++ b/samples/variables/blocks_and_scopes.jakt
@@ -2,7 +2,7 @@ fun main() {
     let x = 10
     {
         let x = 20
-        println(x)
+        println("{}", x)
     }
-    println(x)
+    println("{}", x)
 }

--- a/samples/variables/integer_promotion.jakt
+++ b/samples/variables/integer_promotion.jakt
@@ -15,8 +15,8 @@ fun main() {
     let mut f = Foo(x: 123)
     f.x += 2
 
-    println(a)
-    println(b)
-    println(c)
-    println(f.x)
+    println("{}", a)
+    println("{}", b)
+    println("{}", c)
+    println("{}", f.x)
 }

--- a/samples/variables/var.jakt
+++ b/samples/variables/var.jakt
@@ -1,4 +1,4 @@
 fun main() {
     let msg: String = "Well, hello friends."
-    println(msg)
+    println("{}", msg)
 }

--- a/samples/variables/var2.jakt
+++ b/samples/variables/var2.jakt
@@ -1,5 +1,5 @@
 fun main() {
     let mut x: i64 = 100
     x = x + 1
-    println(x)
+    println("{}", x)
 }

--- a/samples/variables/var3.jakt
+++ b/samples/variables/var3.jakt
@@ -1,5 +1,5 @@
 fun main() {
     let mut x: i64 = 100
     x += 1
-    println(x)
+    println("{}", x)
 }

--- a/samples/variables/var_bad_assignment.jakt
+++ b/samples/variables/var_bad_assignment.jakt
@@ -1,5 +1,5 @@
 fun main() {
     let x: i64 = 100
     x += 1
-    println(x)
+    println("{}", x)
 }

--- a/samples/variables/var_inference.jakt
+++ b/samples/variables/var_inference.jakt
@@ -1,4 +1,4 @@
 fun main() {
     let mut x = 100
-    println(x)
+    println("{}", x)
 }

--- a/samples/variables/var_redefinition.jakt
+++ b/samples/variables/var_redefinition.jakt
@@ -1,5 +1,5 @@
 fun main() {
     let x = 10
     let x = 20
-    println(x)
+    println("{}", x)
 }

--- a/src/codegen.rs
+++ b/src/codegen.rs
@@ -692,15 +692,21 @@ fn codegen_expr(indent: usize, expr: &CheckedExpression, project: &Project) -> S
         }
         CheckedExpression::Call(call, ..) => {
             if call.name == "println" {
-                output.push_str("outln(\"{}\", ");
-                for param in &call.args {
+                output.push_str("outln(");
+                for (i, param) in call.args.iter().enumerate() {
                     output.push_str(&codegen_expr(indent, &param.1, project));
+                    if i != call.args.len() - 1 {
+                        output.push(',');
+                    }
                 }
                 output.push(')');
             } else if call.name == "eprintln" {
-                output.push_str("warnln(\"{}\", ");
-                for param in &call.args {
+                output.push_str("warnln(");
+                for (i, param) in call.args.iter().enumerate() {
                     output.push_str(&codegen_expr(indent, &param.1, project));
+                    if i != call.args.len() - 1 {
+                        output.push(',');
+                    }
                 }
                 output.push(')');
             } else {


### PR DESCRIPTION
Instead of passing "{}" as the implicit format string, let's pass
through whatever format string the jakt program wants to use. :^)