### PR TITLE
Allow functions to throw errors :^)

### DIFF
--- a/README.md
+++ b/README.md
@@ -348,8 +348,6 @@ To keep things safe, there are a few kinds of analysis we'd like to do (non-exha
 
 ## Error handling
 
-**(Not yet implemented)**
-
 Functions that can fail with an error instead of returning normally are marked with the `throws` keyword:
 
 ```jakt

--- a/runtime/lib.h
+++ b/runtime/lib.h
@@ -93,7 +93,7 @@ inline String runtime_helper_number_to_string(i64 number)
     return String::number(number);
 }
 
-int __jakt_main(Array<String>);
+ErrorOr<int> _jakt_main(Array<String>);
 
 template<typename T>
 inline constexpr T __arithmetic_shift_right(T value, size_t steps)
@@ -130,5 +130,10 @@ int main(int argc, char** argv)
     for (int i = 0; i < argc; ++i) {
         args.push(argv[i]);
     }
-    return __jakt_main(move(args));
+    auto result = _jakt_main(move(args));
+    if (result.is_error()) {
+        warnln("Runtime error: {}", result.error());
+        return 1;
+    }
+    return result.value();
 }

--- a/runtime/prelude.jakt
+++ b/runtime/prelude.jakt
@@ -51,3 +51,7 @@ extern class Dictionary<K, V> {
 extern class Tuple {}
 
 extern class Range {}
+
+extern class Error {
+    function from_errno(anon errno: i32)
+}


### PR DESCRIPTION
Functions can now have a trailing "throws" keyword before the return
type is declared. This is syntactic sugar for ErrorOr<T> where T is
the return type.

Errors are thrown with a "throw <expression>" statement.
    
Calls to functions that throw will now be automatically wrapped in
C++ TRY(). This causes errors to automatically bubble to the nearest
caller.
    
At present, there's no way to stop the bubbling, so all thrown errors
will bubble out to the runtime's main function and abort the process.
