### PR TITLE
Make the built-in arrays throw errors :^)

### DIFF
--- a/runtime/lib.h
+++ b/runtime/lib.h
@@ -128,7 +128,7 @@ int main(int argc, char** argv)
 {
     Array<String> args;
     for (int i = 0; i < argc; ++i) {
-        args.push(argv[i]);
+        MUST(args.push(argv[i]));
     }
     auto result = _jakt_main(move(args));
     if (result.is_error()) {

--- a/runtime/prelude.jakt
+++ b/runtime/prelude.jakt
@@ -20,10 +20,10 @@ extern class Array<T> {
     function is_empty(this) -> bool
     function size(this) -> usize
     function capacity(this) -> usize
-    function ensure_capacity(this, anon capacity: usize)
-    function add_capacity(this, anon capacity: usize)
-    function resize(mut this, anon size: usize)
-    function push(mut this, anon value: T)
+    function ensure_capacity(this, anon capacity: usize) throws
+    function add_capacity(this, anon capacity: usize) throws
+    function resize(mut this, anon size: usize) throws
+    function push(mut this, anon value: T) throws
     function pop(mut this) -> T?
 }
 

--- a/src/codegen.rs
+++ b/src/codegen.rs
@@ -982,13 +982,13 @@ fn codegen_expr(indent: usize, expr: &CheckedExpression, project: &Project) -> S
         }
         CheckedExpression::Array(vals, fill_size_expr, _, _) => {
             if let Some(fill_size_expr) = fill_size_expr {
-                output.push_str("(Array<");
+                output.push_str("(TRY(Array<");
                 output.push_str(&codegen_type(vals.first().unwrap().ty(), project));
                 output.push_str(">::filled(");
                 output.push_str(&codegen_expr(indent, fill_size_expr, project));
                 output.push_str(", ");
                 output.push_str(&codegen_expr(indent, vals.first().unwrap(), project));
-                output.push_str("))");
+                output.push_str(")))");
             } else {
                 // (Array({1, 2, 3}))
                 output.push_str("(Array({");


### PR DESCRIPTION
Operations that resize arrays may now throw ENOMEM or EOVERFLOW
if we run out of memory or we're asked for more memory than we
can calculate the size of.