### PR TITLE
Un-shorten remaining keywords

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,18 +163,18 @@ let x = Foo()
 x.func()
 ```
 
-**Mutating member functions** require an object to be called, and may modify the object. The first parameter is `mut this`.
+**Mutating member functions** require an object to be called, and may modify the object. The first parameter is `mutable this`.
 ```jakt
 class Foo {
     x: i64
 
-    function set(mut this, anon x: i64) {
+    function set(mutable this, anonymous x: i64) {
         this.x = x
     }
 }
 
 // Foo::set() can only be called on a mutable Foo:
-let mut foo = Foo(x: 3)
+let mutable foo = Foo(x: 3)
 foo.set(9)
 ```
 
@@ -242,7 +242,7 @@ fun main() {
 Jakt supports both generic structures and generic functions. 
 
 ```jakt
-fun id<T>(anon x: T) -> T {
+fun id<T>(anonymous x: T) -> T {
     return x;
 }
 

--- a/runtime/prelude.jakt
+++ b/runtime/prelude.jakt
@@ -1,5 +1,5 @@
 extern class String {
-    function split(this, anon c: c_char) -> [String]
+    function split(this, anonymous c: c_char) -> [String]
     function characters(this) -> raw c_char
     function reverse(this) -> String
     function to_lowercase(this) -> String
@@ -20,27 +20,27 @@ extern class Array<T> {
     function is_empty(this) -> bool
     function size(this) -> usize
     function capacity(this) -> usize
-    function ensure_capacity(this, anon capacity: usize) throws
-    function add_capacity(this, anon capacity: usize) throws
-    function resize(mut this, anon size: usize) throws
-    function push(mut this, anon value: T) throws
-    function pop(mut this) -> T?
+    function ensure_capacity(this, anonymous capacity: usize) throws
+    function add_capacity(this, anonymous capacity: usize) throws
+    function resize(mutable this, anonymous size: usize) throws
+    function push(mutable this, anonymous value: T) throws
+    function pop(mutable this) -> T?
 }
 
 extern class Optional<T> {
     function has_value(this) -> bool
     function value(this) -> T
-    function value_or(this, anon x: T) -> T
-    function Optional<S>(anon x: S) -> Optional<S>
+    function value_or(this, anonymous x: T) -> T
+    function Optional<S>(anonymous x: S) -> Optional<S>
 }
 
 extern class Dictionary<K, V> {
-    function get(this, anon key: K) -> V?
-    function contains(this, anon key: K) -> bool
-    function set(mut this, key: K, value: V)
-    function remove(mut this, anon key: K) -> bool
-    function ensure_capacity(mut this, anon capacity: usize)
-    function clear(mut this)
+    function get(this, anonymous key: K) -> V?
+    function contains(this, anonymous key: K) -> bool
+    function set(mutable this, key: K, value: V)
+    function remove(mutable this, anonymous key: K) -> bool
+    function ensure_capacity(mutable this, anonymous capacity: usize)
+    function clear(mutable this)
     function size(this) -> usize
     function capacity(this) -> usize
     function keys(this) -> [K]
@@ -53,5 +53,5 @@ extern class Tuple {}
 extern class Range {}
 
 extern class Error {
-    function from_errno(anon errno: i32)
+    function from_errno(anonymous errno: i32)
 }

--- a/samples/apps/cat.jakt
+++ b/samples/apps/cat.jakt
@@ -1,10 +1,10 @@
 extern struct FILE {}
 
-extern function fopen(anon str: raw c_char, anon mode: raw c_char) -> raw FILE
-extern function fgetc(anon file: mut raw FILE) -> c_int
-extern function fclose(anon file: mut raw FILE) -> c_int
-extern function feof(anon file: mut raw FILE) -> c_int
-extern function putchar(anon ch: c_int) -> c_int
+extern function fopen(anonymous str: raw c_char, anonymous mode: raw c_char) -> raw FILE
+extern function fgetc(anonymous file: mutable raw FILE) -> c_int
+extern function fclose(anonymous file: mutable raw FILE) -> c_int
+extern function feof(anonymous file: mutable raw FILE) -> c_int
+extern function putchar(anonymous ch: c_int) -> c_int
 
 function main(args: [String]) {
     if args.size() <= 1 {
@@ -14,10 +14,10 @@ function main(args: [String]) {
 
     let filename = args[1]
 
-    let mut file = fopen(filename.characters(), "r".characters())
+    let mutable file = fopen(filename.characters(), "r".characters())
     defer fclose(file)
 
-    let mut c = fgetc(file)
+    let mutable c = fgetc(file)
     while not feof(file) {
         putchar(c)
         c = fgetc(file)

--- a/samples/apps/crc32.jakt
+++ b/samples/apps/crc32.jakt
@@ -1,15 +1,15 @@
 extern struct FILE {}
 
-extern function fopen(anon str: raw c_char, anon mode: raw c_char) -> raw FILE
-extern function fgetc(anon file: mut raw FILE) -> c_int
-extern function fclose(anon file: mut raw FILE) -> c_int
-extern function feof(anon file: mut raw FILE) -> c_int
-extern function putchar(anon ch: c_int) -> c_int
+extern function fopen(anonymous str: raw c_char, anonymous mode: raw c_char) -> raw FILE
+extern function fgetc(anonymous file: mutable raw FILE) -> c_int
+extern function fclose(anonymous file: mutable raw FILE) -> c_int
+extern function feof(anonymous file: mutable raw FILE) -> c_int
+extern function putchar(anonymous ch: c_int) -> c_int
 
 function make_lookup_table() -> [u32] {
-    let mut data = [0u32; 256]
+    let mutable data = [0u32; 256]
     for i in 0..data.size() {
-        let mut value = i as! u32
+        let mutable value = i as! u32
         for j in 0..8 {
             if value & 1 {
                 value = 0xedb88320u32 ^ (value >> 1)
@@ -28,13 +28,13 @@ function main(args: [String]) {
         return 1
     }
 
-    let mut file = fopen(args[1].characters(), "r".characters())
+    let mutable file = fopen(args[1].characters(), "r".characters())
     defer fclose(file)
 
     let table = make_lookup_table()
     
-    let mut state = 0xffffffffu32
-    let mut c = fgetc(file)
+    let mutable state = 0xffffffffu32
+    let mutable c = fgetc(file)
     while not feof(file) {
         state = table[(state ^ c) & 0xff] ^ (state >> 8);
         c = fgetc(file)

--- a/samples/arrays/array_param.jakt
+++ b/samples/arrays/array_param.jakt
@@ -1,4 +1,4 @@
-function get_first(anon v: [String]) => v[0]
+function get_first(anonymous v: [String]) => v[0]
 
 function main() {
     println("{}", get_first(["one", "two"]))

--- a/samples/arrays/array_pop.jakt
+++ b/samples/arrays/array_pop.jakt
@@ -1,5 +1,5 @@
 function main() {
-    let mut v = [1, 2, 3]
+    let mutable v = [1, 2, 3]
 
     let last = v.pop()
 

--- a/samples/arrays/array_push.jakt
+++ b/samples/arrays/array_push.jakt
@@ -1,5 +1,5 @@
 function main() {
-    let mut values = [0; 0]
+    let mutable values = [0; 0]
 
     for i in 0..10 {
         values.push(i)

--- a/samples/arrays/array_shorthand.jakt
+++ b/samples/arrays/array_shorthand.jakt
@@ -4,7 +4,7 @@ function make_v() -> [String] {
 
 function main() {
     let v: [String] = make_v()
-    let mut i = 0
+    let mutable i = 0
     while i < 2 {
         println("{}", v[i])
         ++i

--- a/samples/arrays/lvalue.jakt
+++ b/samples/arrays/lvalue.jakt
@@ -1,5 +1,5 @@
 function main() {
-    let mut x = [1, 2, 3]
+    let mutable x = [1, 2, 3]
     x[1] = 55
 
     println("{}", x[1])

--- a/samples/arrays/prefill.jakt
+++ b/samples/arrays/prefill.jakt
@@ -1,7 +1,7 @@
 function main() {
     let v = [85; 3]
     println("{}", v.size())
-    let mut i = 0
+    let mutable i = 0
     while i < v.size() {
         println("{}", v[i++])
     }

--- a/samples/arrays/reference_semantics.jakt
+++ b/samples/arrays/reference_semantics.jakt
@@ -1,12 +1,12 @@
-function change_value(vector: mut [String]) {
+function change_value(vector: mutable [String]) {
     vector[1] = "bar"
 }
 
 function main() {
-    let mut v = ["foo", "foo"]
+    let mutable v = ["foo", "foo"]
     change_value(vector: v)
 
-    let mut i = 0
+    let mutable i = 0
     while i < v.size() {
         println("{}", v[i])
         ++i

--- a/samples/basics/bubble_sort.jakt
+++ b/samples/basics/bubble_sort.jakt
@@ -1,7 +1,7 @@
-function bubble_sort(values: mut [i64]) {
-    let mut i = 0
+function bubble_sort(values: mutable [i64]) {
+    let mutable i = 0
     while i < values.size() - 1 {
-        let mut j = 0
+        let mutable j = 0
         while j < values.size() - i - 1 {
             if values[j] > values[j + 1] {
                 let tmp = values[j]
@@ -15,9 +15,9 @@ function bubble_sort(values: mut [i64]) {
 }
 
 function main() {
-    let mut v = [25, 13, 8, 1, 9, 22, 50, 2]
+    let mutable v = [25, 13, 8, 1, 9, 22, 50, 2]
     bubble_sort(values: v)
-    let mut i = 0
+    let mutable i = 0
     while i < v.size() {
         println("{}", v[i])
         ++i

--- a/samples/basics/numeric_literal_suffixes.jakt
+++ b/samples/basics/numeric_literal_suffixes.jakt
@@ -1,13 +1,13 @@
 function main() {
-    let mut a = 0uz
+    let mutable a = 0uz
     a += 5 as! usize
     println("{}", a)
 
     {
-        let mut i = 0u8
-        let mut j = 0u16
-        let mut k = 0u32
-        let mut l = 0u64
+        let mutable i = 0u8
+        let mutable j = 0u16
+        let mutable k = 0u32
+        let mutable l = 0u64
 
         i += 5 as! u8
         j += 5 as! u16
@@ -20,10 +20,10 @@ function main() {
         println("{}", l)
     }
     {
-        let mut i = 0i8
-        let mut j = 0i16
-        let mut k = 0i32
-        let mut l = 0i64
+        let mutable i = 0i8
+        let mutable j = 0i16
+        let mutable k = 0i32
+        let mutable l = 0i64
 
         i += 5 as! i8
         j += 5 as! i16

--- a/samples/classes/method.jakt
+++ b/samples/classes/method.jakt
@@ -2,13 +2,13 @@ class Person {
     name: String
     age: i64
 
-    function birthday(mut this) {
+    function birthday(mutable this) {
         ++this.age
     }
 }
 
 function main() {
-    let mut p = Person(name: "Bob", age: 1000)
+    let mutable p = Person(name: "Bob", age: 1000)
 
     p.birthday()
 

--- a/samples/control_flow/continue.jakt
+++ b/samples/control_flow/continue.jakt
@@ -1,5 +1,5 @@
 function main() {
-    let mut i = 0
+    let mutable i = 0
     while i < 10 {
         i++
         if i % 2 == 0 {

--- a/samples/control_flow/fizzbuzz.jakt
+++ b/samples/control_flow/fizzbuzz.jakt
@@ -1,5 +1,5 @@
 function main() {
-    let mut i = 1
+    let mutable i = 1
     while i <= 20 {
         if i % 15 == 0 {
             println("FizzBuzz")

--- a/samples/control_flow/if_with_bad_assignment.jakt
+++ b/samples/control_flow/if_with_bad_assignment.jakt
@@ -1,5 +1,5 @@
 function main() {
-    let mut x = 100;
+    let mutable x = 100;
 
     if (x = 99) {
         println("true")

--- a/samples/control_flow/loop.jakt
+++ b/samples/control_flow/loop.jakt
@@ -1,5 +1,5 @@
 function main() {
-    let mut i = 0
+    let mutable i = 0
     loop {
         if i == 5 {
             break

--- a/samples/control_flow/while.jakt
+++ b/samples/control_flow/while.jakt
@@ -1,5 +1,5 @@
 function main() {
-    let mut x: i64 = 10
+    let mutable x: i64 = 10
 
     while (x > 0) {
         println("{}", x)

--- a/samples/control_flow/while2.jakt
+++ b/samples/control_flow/while2.jakt
@@ -1,5 +1,5 @@
 function main() {
-    let mut x: i64 = 10
+    let mutable x: i64 = 10
 
     while (x > 0) {
         println("{}", x)

--- a/samples/control_flow/while3.jakt
+++ b/samples/control_flow/while3.jakt
@@ -1,5 +1,5 @@
 function main() {
-    let mut x: i64 = 0
+    let mutable x: i64 = 0
 
     while (x < 10) {
         println("{}", x)

--- a/samples/dictionaries/count_words.jakt
+++ b/samples/dictionaries/count_words.jakt
@@ -2,7 +2,7 @@ function main() {
     let text = "midway upon the journey of our life I found myself within a forest dark for the straightforward pathway had been lost"
     let words = text.split(' ')
 
-    let mut counts = Dictionary<String, i64>();
+    let mutable counts = Dictionary<String, i64>();
 
     for i in 0..words.size() {
         counts.set(key: words[i], value: counts[words[i]].value_or(0) + 1)

--- a/samples/dictionaries/set.jakt
+++ b/samples/dictionaries/set.jakt
@@ -1,5 +1,5 @@
 function main() {
-    let mut dict = ["a": 1, "b": 2]
+    let mutable dict = ["a": 1, "b": 2]
 
     dict.set(key: "c", value: 3);
 

--- a/samples/functions/argument_labels.jakt
+++ b/samples/functions/argument_labels.jakt
@@ -1,10 +1,10 @@
 function foo(a: bool, b: bool) {
 }
 
-function bar(anon a: bool, b: bool) {
+function bar(anonymous a: bool, b: bool) {
 }
 
-function baz(anon a: bool, anon b: bool) {
+function baz(anonymous a: bool, anonymous b: bool) {
 }
 
 function qux(a: bool) {

--- a/samples/generics/explicit_type_vars.jakt
+++ b/samples/generics/explicit_type_vars.jakt
@@ -1,5 +1,5 @@
 function main() {
-    let mut  item = Dictionary<String, i64>();
+    let mutable  item = Dictionary<String, i64>();
 
     item.set(key: "bob", value: 123);
 

--- a/samples/generics/generic_fun.jakt
+++ b/samples/generics/generic_fun.jakt
@@ -1,4 +1,4 @@
-function id<T>(anon x: T) => x
+function id<T>(anonymous x: T) => x
 
 function main() {
     println("{}", id(3))

--- a/samples/generics/generic_fun2.jakt
+++ b/samples/generics/generic_fun2.jakt
@@ -1,4 +1,4 @@
-function id<T>(anon x: T) => x
+function id<T>(anonymous x: T) => x
 
 function main() {
     println("{}", id(3) + 10)

--- a/samples/generics/generic_fun3.jakt
+++ b/samples/generics/generic_fun3.jakt
@@ -1,4 +1,4 @@
-function id<T>(anon x: T) -> T {
+function id<T>(anonymous x: T) -> T {
     return x;
 }
 

--- a/samples/generics/generic_fun4.jakt
+++ b/samples/generics/generic_fun4.jakt
@@ -1,4 +1,4 @@
-function id<T>(anon x: T) -> T {
+function id<T>(anonymous x: T) -> T {
     return x;
 }
 

--- a/samples/generics/generic_types.jakt
+++ b/samples/generics/generic_types.jakt
@@ -1,9 +1,9 @@
-function do_pop<T>(anon arr: mut [T]) -> Optional<T> {
+function do_pop<T>(anonymous arr: mutable [T]) -> Optional<T> {
   return arr.pop()
 }
 
 function main() {
-  let mut arr = [1, 2, 3];
+  let mutable arr = [1, 2, 3];
 
   println("{}", do_pop(arr)!)
 }

--- a/samples/generics/passing_arrays.jakt
+++ b/samples/generics/passing_arrays.jakt
@@ -1,4 +1,4 @@
-function dump<T>(anon v: [T]) { return v[0] }
+function dump<T>(anonymous v: [T]) { return v[0] }
 
 function main() {
     println("{}", dump([1, 2, 3]))

--- a/samples/math/bitwise.jakt
+++ b/samples/math/bitwise.jakt
@@ -1,4 +1,4 @@
-function check(anon a: i64, anon b: i64) -> i64 {
+function check(anonymous a: i64, anonymous b: i64) -> i64 {
     if a != b {
         println("Not equal!")
         println("{}", a)
@@ -9,21 +9,21 @@ function check(anon a: i64, anon b: i64) -> i64 {
 }
 
 function main() {
-    let mut errors = 0
+    let mutable errors = 0
 
-    let mut a = 1
+    let mutable a = 1
     a <<= 5
     errors += check(a, 1 << 5)
 
-    let mut b = 0x8000
+    let mutable b = 0x8000
     b >>= 5
     errors += check(b, 0x8000 >> 5)
 
-    let mut c = 0xffc0c0
+    let mutable c = 0xffc0c0
     c &= 0x777777
     errors += check(c, 0xffc0c0 & 0x777777)
 
-    let mut d = 0xffc0c0
+    let mutable d = 0xffc0c0
     d ^= 0x777777
     errors += check(d, 0xffc0c0 ^ 0x777777)
 

--- a/samples/math/increment_decrement.jakt
+++ b/samples/math/increment_decrement.jakt
@@ -1,5 +1,5 @@
 function main() {
-    let mut x = 10
+    let mutable x = 10
 
     println("{}", ++x)
     println("{}", x++)

--- a/samples/optional/mutable_unwrap.jakt
+++ b/samples/optional/mutable_unwrap.jakt
@@ -1,7 +1,7 @@
 class Foo {
     x: i64
 
-    function set(mut this, value: i64) {
+    function set(mutable this, value: i64) {
         this.x = value
     }
 
@@ -11,8 +11,8 @@ class Foo {
 }
 
 function main() {
-    let mut foo = Foo(x: 1)
-    let mut opt_foo: Foo? = foo
+    let mutable foo = Foo(x: 1)
+    let mutable opt_foo: Foo? = foo
 
     opt_foo!.set(value: 2)
 

--- a/samples/optional/none_coalescing.jakt
+++ b/samples/optional/none_coalescing.jakt
@@ -7,7 +7,7 @@ function main() {
 
 
     // The right hand side is lazily evaluated.
-    let mut zero = 0
+    let mutable zero = 0
     let z: i64? = 69
     let q = z ?? ++zero
 

--- a/samples/ranges/range.jakt
+++ b/samples/ranges/range.jakt
@@ -1,5 +1,5 @@
 function main() {
-    let mut total = 0
+    let mutable total = 0
 
     for x in 1..10 {
         total += x

--- a/samples/strings/string_append.jakt
+++ b/samples/strings/string_append.jakt
@@ -3,7 +3,7 @@ function main() {
     let b = "kt"
     println("{}", a + b)
 
-    let mut str = "programming "
+    let mutable str = "programming "
     str += "language"
     println("{}", str)
 }

--- a/samples/strings/string_builder.jakt
+++ b/samples/strings/string_builder.jakt
@@ -1,10 +1,10 @@
 extern struct StringBuilder {
-    function append(mut this, anon s: raw c_char)
-    function to_string(mut this) -> String
+    function append(mutable this, anonymous s: raw c_char)
+    function to_string(mutable this) -> String
 }
 
 function main() {
-    let mut s = StringBuilder()
+    let mutable s = StringBuilder()
 
     s.append("abc".characters());
     s.append("123".characters());

--- a/samples/structs/lvalue.jakt
+++ b/samples/structs/lvalue.jakt
@@ -4,7 +4,7 @@ struct Person {
 }
 
 function main() {
-    let mut p = Person(name: "Jane", age: 100)
+    let mutable p = Person(name: "Jane", age: 100)
 
     p.age = 99;
 

--- a/samples/structs/method_mutable.jakt
+++ b/samples/structs/method_mutable.jakt
@@ -2,7 +2,7 @@ struct Rectangle {
     width: i64,
     height: i64,
 
-    function grow(mut this) {
+    function grow(mutable this) {
         this.width *= 2;
         this.height *= 2;
     }
@@ -11,7 +11,7 @@ struct Rectangle {
 }
 
 function main() {
-    let mut rect = Rectangle(width: 4, height: 8)
+    let mutable rect = Rectangle(width: 4, height: 8)
 
     rect.grow()
 

--- a/samples/structs/value_semantics.jakt
+++ b/samples/structs/value_semantics.jakt
@@ -2,7 +2,7 @@ struct Foo {
     x: i64
 }
 
-function set_x(foo: mut Foo, x: i64) {
+function set_x(foo: mutable Foo, x: i64) {
     foo.x = x
 }
 
@@ -13,7 +13,7 @@ function main() {
     set_x(foo: foo, x: 10)
     println("{}", foo.x)
 
-    let mut bar = foo
+    let mutable bar = foo
     bar.x = 15
     println("{}", foo.x)
 }

--- a/samples/structs/vec_and_struct_lvalue.jakt
+++ b/samples/structs/vec_and_struct_lvalue.jakt
@@ -4,7 +4,7 @@ struct Person {
 }
 
 function main() {
-    let mut arr = [
+    let mutable arr = [
         Person(name: "Jane", age: 100), 
         Person(name: "Björn", age: 200)
     ]

--- a/samples/variables/integer_promotion.jakt
+++ b/samples/variables/integer_promotion.jakt
@@ -3,16 +3,16 @@ struct Foo {
 }
 
 function main() {
-    let mut a: u8 = 100
+    let mutable a: u8 = 100
     a += 100
 
-    let mut b: u16 = 1000
+    let mutable b: u16 = 1000
     b += 1000
 
-    let mut c: u32 = 100000
+    let mutable c: u32 = 100000
     c += 100000
 
-    let mut f = Foo(x: 123)
+    let mutable f = Foo(x: 123)
     f.x += 2
 
     println("{}", a)

--- a/samples/variables/integer_promotion_bad2.jakt
+++ b/samples/variables/integer_promotion_bad2.jakt
@@ -1,4 +1,4 @@
 function main() {
-    let mut i: u8 = 0;
+    let mutable i: u8 = 0;
     i += 1000;
 }

--- a/samples/variables/integer_promotion_bad3.jakt
+++ b/samples/variables/integer_promotion_bad3.jakt
@@ -1,4 +1,4 @@
 function main() {
-    let mut i: u8 = 0;
+    let mutable i: u8 = 0;
     i += 1000;
 }

--- a/samples/variables/var2.jakt
+++ b/samples/variables/var2.jakt
@@ -1,5 +1,5 @@
 function main() {
-    let mut x: i64 = 100
+    let mutable x: i64 = 100
     x = x + 1
     println("{}", x)
 }

--- a/samples/variables/var3.jakt
+++ b/samples/variables/var3.jakt
@@ -1,5 +1,5 @@
 function main() {
-    let mut x: i64 = 100
+    let mutable x: i64 = 100
     x += 1
     println("{}", x)
 }

--- a/samples/variables/var_inference.jakt
+++ b/samples/variables/var_inference.jakt
@@ -1,4 +1,4 @@
 function main() {
-    let mut x = 100
+    let mutable x = 100
     println("{}", x)
 }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -867,12 +867,12 @@ pub fn parse_function(
                             current_param_requires_label = true;
                         }
 
-                        TokenContents::Name(name) if name == "anon" => {
+                        TokenContents::Name(name) if name == "anonymous" => {
                             current_param_requires_label = false;
                             *index += 1;
                         }
 
-                        TokenContents::Name(name) if name == "mut" => {
+                        TokenContents::Name(name) if name == "mutable" => {
                             current_param_is_mutable = true;
                             *index += 1;
                         }
@@ -1252,7 +1252,7 @@ pub fn parse_statement(tokens: &[Token], index: &mut usize) -> (Statement, Optio
 
             let mutable = if *index + 1 < tokens.len() {
                 match &tokens[*index + 1].contents {
-                    TokenContents::Name(name) if name == "mut" => {
+                    TokenContents::Name(name) if name == "mutable" => {
                         *index += 1;
                         true
                     }
@@ -2858,7 +2858,7 @@ pub fn parse_variable_declaration(
             if *index < tokens.len() {
                 let mutable = *index + 1 < tokens.len()
                     && match &tokens[*index].contents {
-                        TokenContents::Name(name) if name == "mut" => {
+                        TokenContents::Name(name) if name == "mutable" => {
                             *index += 1;
                             true
                         }

--- a/vscode/syntaxes/jakt.tmLanguage.json
+++ b/vscode/syntaxes/jakt.tmLanguage.json
@@ -35,7 +35,7 @@
 				},
 				{
 					"name": "keyword.jakt",
-					"match": "\\b(mut|let|anon|raw)\\b"
+					"match": "\\b(mutable|let|anonymous|raw)\\b"
 				},
 				{
 					"name": "keyword.operator.new.jakt",


### PR DESCRIPTION
In keeping with the classic "spell everything out" style of SerenityOS, here goes:

`mut` => `mutable`
`anon` => `anonymous`