### PR TITLE
Try catch

### DIFF
--- a/README.md
+++ b/README.md
@@ -372,4 +372,24 @@ If nothing else is specified, calling a function that `throws` from within a fun
 
 ### Syntax for catching errors
 
-To be determined.
+If you want to catch errors locally instead of letting them bubble up to the caller, use a `try`/`catch` construct like this:
+
+```jakt
+try {
+    task_that_might_fail()
+} catch error {
+    println("Caught error: {}", error)
+}
+```
+
+There's also a shorter form:
+
+```jakt
+try task_that_might_fail() catch error {
+    println("Caught error: {}", error)
+}
+```
+
+### Rethrowing errors
+
+**(Not yet implemented)**

--- a/runtime/prelude.jakt
+++ b/runtime/prelude.jakt
@@ -53,5 +53,6 @@ extern struct Tuple {}
 extern struct Range {}
 
 extern struct Error {
+    function code(this) -> i32
     function from_errno(anonymous errno: i32)
 }

--- a/samples/control_flow/try_catch.jakt
+++ b/samples/control_flow/try_catch.jakt
@@ -1,0 +1,30 @@
+function notoss() throws -> i32 {
+    if not true {
+        throw Error::from_errno(123456)
+    }
+    return 5
+}
+
+function toss(anonymous value: i32) throws {
+    throw Error::from_errno(value)
+}
+
+function main() {
+    try toss(1234) catch error {
+        println("Caught {}", error.code())
+    }
+
+    try {
+        toss(6969)
+    } catch error {
+        println("Caught {}", error.code())
+    }
+
+    try {
+        notoss()
+        toss(5252)
+        println("FAIL")
+    } catch error {
+        println("Caught {}", error.code())
+    }
+}

--- a/samples/control_flow/try_catch.out
+++ b/samples/control_flow/try_catch.out
@@ -1,0 +1,3 @@
+Caught 1234
+Caught 6969
+Caught 5252

--- a/src/codegen.rs
+++ b/src/codegen.rs
@@ -498,6 +498,21 @@ fn codegen_statement(indent: usize, stmt: &CheckedStatement, project: &Project) 
     output.push_str(&" ".repeat(indent));
 
     match stmt {
+        CheckedStatement::Try(stmt, error_name, catch_block) => {
+            output.push('{');
+            output.push_str("auto _jakt_try_result = [&]() -> ErrorOr<void> {");
+            output.push_str(&codegen_statement(indent, stmt, project));
+            output.push(';');
+            output.push_str("return {};");
+            output.push_str("}();");
+            output.push_str("if (_jakt_try_result.is_error()) {");
+            output.push_str("auto ");
+            output.push_str(error_name);
+            output.push_str(" = _jakt_try_result.release_error();");
+            output.push_str(&codegen_block(indent, catch_block, project));
+            output.push_str("}");
+            output.push('}');
+        }
         CheckedStatement::Throw(expr) => {
             output.push_str("return ");
             output.push_str(&codegen_expr(indent, expr, project));

--- a/vscode/syntaxes/jakt.tmLanguage.json
+++ b/vscode/syntaxes/jakt.tmLanguage.json
@@ -23,7 +23,7 @@
 			"patterns": [
 				{
 					"name": "keyword.control.jakt",
-					"match": "\\b(if|else|while|for|return|defer|unsafe|loop|throw|continue|break)\\b"
+					"match": "\\b(if|else|while|for|return|defer|unsafe|loop|throw|continue|break|try|catch)\\b"
 				},
 				{
 					"name": "keyword.jakt",


### PR DESCRIPTION
Explicit error handling with `try` and `catch`
    
We now allow you to handle errors locally instead of bubbling them
to the caller.
    
This is accomplished with the `try` keyword like so:

```    
try something() catch error {
    // `error` contains the error if one was thrown
}
```
    
You can also use `try` with a block if you have more things to do:

```
try {
    something()
    other()
} catch error {
    println("Caught error: {}", error)
}
```