### PR TITLE
Method/call refactor, index dicts, and more

### DIFF
--- a/samples/dictionaries/count_words.jakt
+++ b/samples/dictionaries/count_words.jakt
@@ -5,8 +5,8 @@ function main() {
     let mutable counts = Dictionary<String, i64>();
 
     for i in 0..words.size() {
-        counts.set(key: words[i], value: counts[words[i]].value_or(0) + 1)
+        counts.set(key: words[i], value: counts.get(words[i]).value_or(0) + 1)
     }
 
-    println("the: {}", counts["the"]!)
+    println("the: {}", counts["the"])
 }

--- a/samples/dictionaries/indexed.jakt
+++ b/samples/dictionaries/indexed.jakt
@@ -1,5 +1,5 @@
 function main() {
     let dict = ["a": 1, "b": 2]
 
-    println("{}", dict["a"]!)
+    println("{}", dict["a"])
 }

--- a/src/codegen.rs
+++ b/src/codegen.rs
@@ -1083,7 +1083,7 @@ fn codegen_expr(indent: usize, expr: &CheckedExpression, project: &Project) -> S
             output.push_str(&codegen_expr(indent, expr, project));
             output.push_str(").get(");
             output.push_str(&codegen_expr(indent, idx, project));
-            output.push_str("))");
+            output.push_str(").value())");
         }
         CheckedExpression::IndexedTuple(expr, idx, _, _) => {
             // x.get<1>()


### PR DESCRIPTION
This does a bit of cleanup:

* method/function call typechecking now uses the same function (and there was much rejoicing). No functional changes here, just the refactor
* dictionary indexing no longer returns an `Optional`, instead just returns `T` and may panic
* I changed substitution to run to a fixed point. Not sure if strictly necessary, but hopefully avoids subtle issues in the future