### PR TITLE
src: Implement struct-like enum variants / misc parsing stuff

### DIFF
--- a/README.md
+++ b/README.md
@@ -257,7 +257,6 @@ function value_or_default<T>(anonymous x: MyOptional<T>, default: T) -> T {
     }
 }
 
-// Not yet implemented:
 enum Foo {
     StructLikeThingy {
         field_a: i32
@@ -267,7 +266,7 @@ enum Foo {
 
 function look_at_foo(anonymous x: Foo) -> i32 {
     match x {
-        StructureLikeThingy(field_a: a, field_b: b) => {
+        StructLikeThingy(field_a: a, field_b: b) => {
             return a + b
         }
     }

--- a/runtime/AK/Variant.h
+++ b/runtime/AK/Variant.h
@@ -148,7 +148,7 @@ private:
     {
         // Warning: Internal type shenanigans - VariantsConstrutors<T, Base> <- Base
         //          Not the other way around, so be _really_ careful not to cause issues.
-        return *reinterpret_cast<Base*>(this);
+        return *static_cast<Base*>(this);
     }
 };
 

--- a/runtime/lib.h
+++ b/runtime/lib.h
@@ -144,8 +144,14 @@ struct _JaktExplicitValue<void> {
 
 template<typename Value, typename Return>
 struct _JaktExplicitValueOrReturn {
-    _JaktExplicitValueOrReturn(_JaktExplicitValue<Value>&& v)
-        : value(move(v))
+    template<typename U>
+    _JaktExplicitValueOrReturn(_JaktExplicitValue<U>&& v)
+        : value(_JaktExplicitValue<Value> { move(v.value) })
+    {
+    }
+
+    _JaktExplicitValueOrReturn(_JaktExplicitValue<void>&&)
+        : value(_JaktExplicitValue<void> { })
     {
     }
 

--- a/runtime/lib.h
+++ b/runtime/lib.h
@@ -162,7 +162,10 @@ struct _JaktExplicitValueOrReturn {
     {
     }
 
-    bool is_return() const { return value.template has<Return>(); }
+    bool is_return() const {
+        return value.template has<Conditional<IsVoid<Return>, Empty, Return>>();
+    }
+
     Return release_return()
     {
         if constexpr (IsVoid<Return>)
@@ -171,6 +174,7 @@ struct _JaktExplicitValueOrReturn {
             return move(value).template get<Return>();
     }
     Value release_value()
+
     {
         if constexpr (IsVoid<Value>)
             return;

--- a/samples/enums/simple_match.jakt
+++ b/samples/enums/simple_match.jakt
@@ -8,6 +8,14 @@ enum BetterResult<T, E> {
     TheWorldIsBurning: E
 }
 
+enum ObjectivelyBetterOptional<T> {
+    Some {
+        value: T
+        joke_metadata: String
+    }
+    None
+}
+
 function make_result(okay: bool) -> BetterResult<i64, String> {
     if okay {
         return BetterResult::ImFineHowAreYou(42)
@@ -22,12 +30,19 @@ function better_optional_from<T>(anonymous optional: T?) -> BetterOptional<T> {
     return BetterOptional::None()
 }
 
+function to_objectively_better_optional<T>(anonymous optional: BetterOptional<T>) -> ObjectivelyBetterOptional<T> {
+    return match optional {
+        BetterOptional::Some(value) => ObjectivelyBetterOptional::Some(value: value, joke_metadata: "I'm a joke")
+        BetterOptional::None => ObjectivelyBetterOptional::None()
+    }
+}
+
 function main() {
     match make_result(okay: true) {
         ImFineHowAreYou(x) => {
             let a: i64? = x
-            match better_optional_from(a) {
-                Some(x) => println("Success! we're fine and there's a {} in our optional", x)
+            match to_objectively_better_optional(better_optional_from(a)) {
+                Some(value: x) => println("Success! we're fine and there's a {} in our optional", x)
                 None => println("What??????")
             }
         }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -2002,9 +2002,9 @@ pub fn parse_pattern_case(tokens: &[Token], index: &mut usize) -> (MatchCase, Op
                     }
 
                     if let Some(Token {
-                                    contents: TokenContents::Comma,
-                                    ..
-                                }) = tokens.get(*index)
+                        contents: TokenContents::Comma,
+                        ..
+                    }) = tokens.get(*index)
                     {
                         *index += 1;
                     }
@@ -3548,23 +3548,29 @@ pub fn parse_array_type(tokens: &[Token], index: &mut usize) -> (UncheckedType, 
         let (ty, err) = parse_typename(tokens, index);
         if let TokenContents::RSquare = &tokens[*index].contents {
             *index += 1;
-            return (UncheckedType::Array(
-                Box::new(ty),
-                Span {
-                    file_id: start.file_id,
-                    start: start.start,
-                    end: tokens[*index - 1].span.end,
-                }
-            ), err);
+            return (
+                UncheckedType::Array(
+                    Box::new(ty),
+                    Span {
+                        file_id: start.file_id,
+                        start: start.start,
+                        end: tokens[*index - 1].span.end,
+                    },
+                ),
+                err,
+            );
         }
 
-        (UncheckedType::Empty, err.or(Some(JaktError::ParserError(
-            "expected ]".to_string(),
-            tokens[*index].span,
-        ))))
+        (
+            UncheckedType::Empty,
+            err.or(Some(JaktError::ParserError(
+                "expected ]".to_string(),
+                tokens[*index].span,
+            ))),
+        )
     } else {
         (UncheckedType::Empty, None)
-    }
+    };
 }
 
 pub fn parse_typename(tokens: &[Token], index: &mut usize) -> (UncheckedType, Option<JaktError>) {
@@ -3659,7 +3665,7 @@ pub fn parse_typename(tokens: &[Token], index: &mut usize) -> (UncheckedType, Op
                             if i == *index {
                                 // This is not a generic parameter, reset and leave.
                                 error = error.or(err);
-                                break
+                                break;
                             }
                             error = error.or(err);
                             inner_types.push(inner_ty);
@@ -3757,7 +3763,7 @@ pub fn parse_call(tokens: &[Token], index: &mut usize) -> (Call, Option<JaktErro
                                 if i == *index {
                                     // Can't parse further, this is not a generic call.
                                     *index = index_reset;
-                                    break
+                                    break;
                                 }
                                 error = error.or(err);
                                 inner_types.push(inner_ty);

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -634,7 +634,6 @@ pub fn parse_enum(
                 enum_.underlying_type = type_;
                 error = error.or(parse_error);
                 trace!(format!("next token: {:?}", tokens[*index]));
-                *index += 1;
             }
             Some(Token {
                 contents: TokenContents::LessThan,
@@ -713,7 +712,6 @@ pub fn parse_enum(
                     trace!("variant with type");
                     *index += 1;
                     let (variant_type, type_error) = parse_typename(tokens, index);
-                    *index += 1;
                     error = error.or(type_error);
                     enum_.variants.push(EnumVariant::Typed(
                         name.to_string(),
@@ -1281,8 +1279,6 @@ pub fn parse_function(
                                     let (ret_type, err) = parse_typename(tokens, index);
                                     return_type = ret_type;
                                     error = error.or(err);
-
-                                    *index += 1;
                                 }
                                 _ => {
                                     trace!("ERROR: expected ->");
@@ -2004,6 +2000,14 @@ pub fn parse_pattern_case(tokens: &[Token], index: &mut usize) -> (MatchCase, Op
                         ));
                         break;
                     }
+
+                    if let Some(Token {
+                                    contents: TokenContents::Comma,
+                                    ..
+                                }) = tokens.get(*index)
+                    {
+                        *index += 1;
+                    }
                 } else {
                     if let Some(Token {
                         contents: TokenContents::Name(binding),
@@ -2547,8 +2551,6 @@ pub fn parse_operand(tokens: &[Token], index: &mut usize) -> (Expression, Option
 
                 let (typename, err) = parse_typename(tokens, index);
                 error = error.or(err);
-
-                *index += 1;
 
                 expr = Expression::UnaryOp(Box::new(expr), UnaryOperator::Is(typename), span)
             }
@@ -3483,6 +3485,7 @@ pub fn parse_variable_declaration(
             }
 
             if *index < tokens.len() {
+                let decl_span = tokens[*index - 1].span;
                 let mutable = *index + 1 < tokens.len()
                     && match &tokens[*index].contents {
                         TokenContents::Name(name) if name == "mutable" => {
@@ -3499,10 +3502,8 @@ pub fn parse_variable_declaration(
                     name: var_name,
                     ty: var_type,
                     mutable,
-                    span: tokens[*index - 3].span,
+                    span: decl_span,
                 };
-
-                *index += 1;
 
                 (result, error)
             } else {
@@ -3542,23 +3543,28 @@ pub fn parse_array_type(tokens: &[Token], index: &mut usize) -> (UncheckedType, 
         return (UncheckedType::Empty, None);
     }
     let start = tokens[*index].span;
-    if let TokenContents::LSquare = &tokens[*index].contents {
-        if let TokenContents::RSquare = &tokens[*index + 2].contents {
-            if let TokenContents::Name(name) = &tokens[*index + 1].contents {
-                let unchecked_type = UncheckedType::Array(
-                    Box::new(UncheckedType::Name(name.clone(), tokens[*index + 1].span)),
-                    Span {
-                        file_id: start.file_id,
-                        start: start.start,
-                        end: tokens[*index + 2].span.end,
-                    },
-                );
-                *index += 2;
-                return (unchecked_type, None);
-            }
+    return if let TokenContents::LSquare = &tokens[*index].contents {
+        *index += 1;
+        let (ty, err) = parse_typename(tokens, index);
+        if let TokenContents::RSquare = &tokens[*index].contents {
+            *index += 1;
+            return (UncheckedType::Array(
+                Box::new(ty),
+                Span {
+                    file_id: start.file_id,
+                    start: start.start,
+                    end: tokens[*index - 1].span.end,
+                }
+            ), err);
         }
+
+        (UncheckedType::Empty, err.or(Some(JaktError::ParserError(
+            "expected ]".to_string(),
+            tokens[*index].span,
+        ))))
+    } else {
+        (UncheckedType::Empty, None)
     }
-    (UncheckedType::Empty, None)
 }
 
 pub fn parse_typename(tokens: &[Token], index: &mut usize) -> (UncheckedType, Option<JaktError>) {
@@ -3601,6 +3607,7 @@ pub fn parse_typename(tokens: &[Token], index: &mut usize) -> (UncheckedType, Op
             } else {
                 typename = name.clone();
                 unchecked_type = UncheckedType::Name(name.clone(), tokens[*index].span);
+                *index += 1;
             }
         }
         _ => {
@@ -3613,10 +3620,9 @@ pub fn parse_typename(tokens: &[Token], index: &mut usize) -> (UncheckedType, Op
         }
     };
 
-    if *index + 1 < tokens.len() {
-        if let TokenContents::QuestionMark = tokens[*index + 1].contents {
+    if *index < tokens.len() {
+        if let TokenContents::QuestionMark = tokens[*index].contents {
             // T? is shorthand for Optional<T>
-            *index += 1;
             unchecked_type = UncheckedType::Optional(
                 Box::new(unchecked_type),
                 Span {
@@ -3625,13 +3631,14 @@ pub fn parse_typename(tokens: &[Token], index: &mut usize) -> (UncheckedType, Op
                     end: tokens[*index].span.end,
                 },
             );
+            *index += 1;
         }
 
-        if *index + 1 < tokens.len() {
-            if let TokenContents::LessThan = tokens[*index + 1].contents {
+        if *index < tokens.len() {
+            let previous_index = *index;
+            if let TokenContents::LessThan = tokens[*index].contents {
                 // Generic type
-                *index += 2;
-
+                *index += 1;
                 let mut inner_types = vec![];
 
                 while *index < tokens.len() {
@@ -3647,11 +3654,14 @@ pub fn parse_typename(tokens: &[Token], index: &mut usize) -> (UncheckedType, Op
                             *index += 1;
                         }
                         _ => {
+                            let i = *index;
                             let (inner_ty, err) = parse_typename(tokens, index);
+                            if i == *index {
+                                // This is not a generic parameter, reset and leave.
+                                error = error.or(err);
+                                break
+                            }
                             error = error.or(err);
-
-                            *index += 1;
-
                             inner_types.push(inner_ty);
                         }
                     }
@@ -3677,6 +3687,10 @@ pub fn parse_typename(tokens: &[Token], index: &mut usize) -> (UncheckedType, Op
                             end: tokens[*index].span.end,
                         },
                     )
+                }
+
+                if error.is_some() {
+                    *index = previous_index;
                 }
             }
         }
@@ -3738,11 +3752,14 @@ pub fn parse_call(tokens: &[Token], index: &mut usize) -> (Call, Option<JaktErro
                                 *index += 1;
                             }
                             _ => {
+                                let i = *index;
                                 let (inner_ty, err) = parse_typename(tokens, index);
+                                if i == *index {
+                                    // Can't parse further, this is not a generic call.
+                                    *index = index_reset;
+                                    break
+                                }
                                 error = error.or(err);
-
-                                *index += 1;
-
                                 inner_types.push(inner_ty);
                             }
                         }


### PR DESCRIPTION
- Clean up `parse_typename()`'s will-maybe-consume-all-the-type mess (play "yaaaaaaaay" soundtrack in your head please)
- Add codegen & ctor for `enum Foo { A { foo: i32 } }` plus support for it in `match`.
- Fix the weirdo windows failure