### PR TITLE
Add .idea to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 target
 a.out
 output.cpp
+
+.idea/


### PR DESCRIPTION
Since a non-trivial amount of Serenity developers use CLion as their IDE, this may be a good idea.