### PR TITLE
Convert the sample apps to explicit int comparisons

### DIFF
--- a/samples/apps/cat.jakt
+++ b/samples/apps/cat.jakt
@@ -18,7 +18,7 @@ function main(args: [String]) {
     defer fclose(file)
 
     let mutable c = fgetc(file)
-    while not feof(file) {
+    while feof(file) == 0 {
         putchar(c)
         c = fgetc(file)
     }

--- a/samples/apps/crc32.jakt
+++ b/samples/apps/crc32.jakt
@@ -6,7 +6,7 @@ extern function fclose(anonymous file: mutable raw FILE) -> c_int
 extern function feof(anonymous file: mutable raw FILE) -> c_int
 extern function putchar(anonymous ch: c_int) -> c_int
 
-function make_lookup_table() -> [u32] {
+function make_lookup_table() throws -> [u32] {
     let mutable data = [0u32; 256]
     for i in 0..data.size() {
         let mutable value = i as! u32

--- a/samples/apps/crc32.jakt
+++ b/samples/apps/crc32.jakt
@@ -11,7 +11,7 @@ function make_lookup_table() -> [u32] {
     for i in 0..data.size() {
         let mutable value = i as! u32
         for j in 0..8 {
-            if value & 1 {
+            if (value & 1) != 0 {
                 value = 0xedb88320u32 ^ (value >> 1)
             } else {
                 value >>= 1
@@ -35,7 +35,7 @@ function main(args: [String]) {
     
     let mutable state = 0xffffffffu32
     let mutable c = fgetc(file)
-    while not feof(file) {
+    while feof(file) == 0 {
         state = table[(state ^ c) & 0xff] ^ (state >> 8);
         c = fgetc(file)
     }


### PR DESCRIPTION
- Change the sample apps to use explicit `c_int` comparisons instead of relying on an implicit cast which is not implemented at the moment
- Add support for `c_int` types in numeric compare expressions
- Make `make_lookup_table` throws (see #137)

Closes #131