### PR TITLE
Parser: Fix method call capturing spans incorrectly

### DIFF
--- a/src/parser.rs
+++ b/src/parser.rs
@@ -2731,14 +2731,15 @@ pub fn parse_operand(tokens: &[Token], index: &mut usize) -> (Expression, Option
                             if *index < tokens.len() {
                                 if tokens[*index].contents == TokenContents::LParen {
                                     *index -= 1;
-                                    let (method, err) = parse_call(tokens, index);
-                                    error = error.or(err);
 
                                     let span = Span {
                                         file_id: expr.span().file_id,
                                         start: expr.span().start,
                                         end: tokens[*index].span.end,
                                     };
+
+                                    let (method, err) = parse_call(tokens, index);
+                                    error = error.or(err);
 
                                     expr = Expression::MethodCall(Box::new(expr), method, span)
                                 } else {


### PR DESCRIPTION
Closes #107 

Prior to this patch, there was a one-off error for the end span, as well as inconsistent span capturing for method calls compared to function calls. This patch fixes this, making it more consistent.

By the way, huge fan of SerenityOS and @jntrnr's NuShell project. I hope my contribution is one of many to this project -  been on the lookout for a project like this for a while :) 