### PR TITLE
Check if lexer index is out of bounds before checking for DotDot

### DIFF
--- a/src/lexer.rs
+++ b/src/lexer.rs
@@ -460,13 +460,15 @@ pub fn lex(file_id: FileId, bytes: &[u8]) -> (Vec<Token>, Option<JaktError>) {
         } else if c == b'.' {
             let start = index;
             index += 1;
-            if bytes[index] == b'.' {
-                index += 1;
-                output.push(Token::new(
-                    TokenContents::DotDot,
-                    Span::new(file_id, start, start + 2),
-                ));
-                continue;
+            if index < bytes.len() {
+                if bytes[index] == b'.' {
+                    index += 1;
+                    output.push(Token::new(
+                        TokenContents::DotDot,
+                        Span::new(file_id, start, start + 2),
+                    ));
+                    continue;
+                }
             }
             output.push(Token::new(
                 TokenContents::Dot,

--- a/tests/main.rs
+++ b/tests/main.rs
@@ -208,3 +208,8 @@ fn test_enums() -> Result<(), JaktError> {
 fn test_inline_cpp() -> Result<(), JaktError> {
     test_samples("samples/inline_cpp")
 }
+
+#[test]
+fn test_parser() -> Result<(), JaktError> {
+    test_samples("tests/parser")
+}

--- a/tests/parser/dot-followed-by-eof-crash.error
+++ b/tests/parser/dot-followed-by-eof-crash.error
@@ -1,0 +1,1 @@
+unexpected token (expected keyword)

--- a/tests/parser/dot-followed-by-eof-crash.jakt
+++ b/tests/parser/dot-followed-by-eof-crash.jakt
@@ -1,0 +1,5 @@
+// When the lexer sees the dot, it increments the index into the `bytes` array
+// and then uses the incremented index to check for another dot. However, it did not
+// check if this was out-of-bounds, meaning if a dot is followed by EOF, the lexer
+// would panic with an array OOB.
+.


### PR DESCRIPTION
When the lexer sees the dot, it increments the index into the `bytes`
array and then use the incremented index to check for another dot.
However, it did not check if this was out-of-bounds, meaning if a dot
is followed by EOF, the lexer would panic with an array OOB.