### PR TITLE
runtime: Add a simple File class for basic I/O

### DIFF
--- a/runtime/IO/File.cpp
+++ b/runtime/IO/File.cpp
@@ -1,0 +1,81 @@
+/*
+ * Copyright (c) 2022, Andreas Kling <kling@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <IO/File.h>
+#include <errno.h>
+
+File::File()
+{
+}
+
+File::~File()
+{
+    fclose(m_stdio_file);
+}
+
+ErrorOr<NonnullRefPtr<File>> File::open_for_reading(String path)
+{
+    auto* stdio_file = fopen(path.characters(), "r");
+    if (!stdio_file) {
+        return Error::from_errno(errno);
+    }
+    auto file = TRY(adopt_nonnull_ref_or_enomem(new (nothrow) File));
+    file->m_stdio_file = stdio_file;
+    return file;
+}
+
+ErrorOr<NonnullRefPtr<File>> File::open_for_writing(String path)
+{
+    auto* stdio_file = fopen(path.characters(), "w");
+    if (!stdio_file) {
+        return Error::from_errno(errno);
+    }
+    auto file = TRY(adopt_nonnull_ref_or_enomem(new (nothrow) File));
+    file->m_stdio_file = stdio_file;
+    return file;
+}
+
+ErrorOr<Array<u8>> File::read_all()
+{
+    Array<u8> entire_file;
+
+    while (true) {
+        u8 buffer[4096];
+        auto nread = fread(buffer, 1, sizeof(buffer), m_stdio_file);
+        if (nread == 0) {
+            if (feof(m_stdio_file)) {
+                return entire_file;
+            }
+            auto error = ferror(m_stdio_file);
+            return Error::from_errno(error);
+        }
+        size_t old_size = entire_file.size();
+        TRY(entire_file.add_size(nread));
+        memcpy(entire_file.unsafe_data() + old_size, buffer, nread);
+    }
+}
+
+ErrorOr<size_t> File::read(Array<u8> buffer)
+{
+    auto nread = fread(buffer.unsafe_data(), 1, buffer.size(), m_stdio_file);
+    if (nread == 0) {
+        if (feof(m_stdio_file))
+            return 0;
+        auto error = ferror(m_stdio_file);
+        return Error::from_errno(error);
+    }
+    return nread;
+}
+
+ErrorOr<size_t> File::write(Array<u8> data)
+{
+    auto nwritten = fwrite(data.unsafe_data(), 1, data.size(), m_stdio_file);
+    if (nwritten == 0) {
+        auto error = ferror(m_stdio_file);
+        return Error::from_errno(error);
+    }
+    return nwritten;
+}

--- a/runtime/IO/File.h
+++ b/runtime/IO/File.h
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2022, Andreas Kling <kling@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/Array.h>
+#include <AK/Error.h>
+#include <AK/RefCounted.h>
+#include <AK/String.h>
+#include <stdio.h>
+
+class File final : public RefCounted<File> {
+public:
+    static ErrorOr<NonnullRefPtr<File>> open_for_reading(String path);
+    static ErrorOr<NonnullRefPtr<File>> open_for_writing(String path);
+
+    ErrorOr<size_t> read(Array<u8>);
+    ErrorOr<size_t> write(Array<u8>);
+
+    ErrorOr<Array<u8>> read_all();
+
+    ~File();
+
+private:
+    File();
+
+    FILE* m_stdio_file { nullptr };
+};

--- a/runtime/lib.h
+++ b/runtime/lib.h
@@ -77,6 +77,10 @@
 #include <AK/Utf8View.cpp>
 #include <AK/kmalloc.cpp>
 
+#include <IO/File.h>
+
+#include <IO/File.cpp>
+
 using f32 = float;
 using f64 = double;
 

--- a/runtime/prelude.jakt
+++ b/runtime/prelude.jakt
@@ -56,3 +56,13 @@ extern struct Error {
     function code(this) -> i32
     function from_errno(anonymous errno: i32)
 }
+
+extern class File {
+    function open_for_reading(anonymous path: String) throws -> File
+    function open_for_writing(anonymous path: String) throws -> File
+
+    function read(mutable this, anonymous buffer: [u8]) throws -> usize
+    function write(mutable this, anonymous data: [u8]) throws -> usize
+
+    function read_all(mutable this) throws -> [u8]
+}


### PR DESCRIPTION
Here's something a little bit nicer than using the standard C library.
Note that we're limited by what's supported on all of macOS, Linux and Windows.