### PR TITLE
Add syntax highlighting for vim

### DIFF
--- a/editors/vim/README.md
+++ b/editors/vim/README.md
@@ -1,0 +1,7 @@
+# Vim syntax highlighting for jakt
+
+**Install**
+
+Copy or symlink `/path/to/jakt/editors/vim` directory to the vim plugins
+directory, which is either `~/.vim/pack/plugins/start/` for vim or
+`~/.local/share/nvim/site/pack/plugins/start/` for neovim.

--- a/editors/vim/ftdetect/jakt.vim
+++ b/editors/vim/ftdetect/jakt.vim
@@ -1,0 +1,1 @@
+au BufRead,BufNewFile *.jakt set filetype=jakt

--- a/editors/vim/indent/jakt.vim
+++ b/editors/vim/indent/jakt.vim
@@ -1,0 +1,30 @@
+" Only load this indent file when no other was loaded.
+if exists("b:did_indent")
+    finish
+endif
+let b:did_indent = 1
+
+if (!has("cindent") || !has("eval"))
+    finish
+endif
+
+setlocal cindent
+
+" L0 -> 0 indent for jump labels (i.e. case statement in c).
+" j1 -> indenting for "javascript object declarations"
+" J1 -> see j1
+" w1 -> starting a new line with `(` at the same indent as `(`
+" m1 -> if `)` starts a line, match its indent with the first char of its
+"       matching `(` line
+" (s -> use one indent, when starting a new line after a trailing `(`
+setlocal cinoptions=L0,m1,(s,j1,J1,l1
+
+" cinkeys: controls what keys trigger indent formatting
+" 0{ -> {
+" 0} -> }
+" 0) -> )
+" 0] -> ]
+" !^F -> make CTRL-F (^F) reindent the current line when typed
+" o -> when <CR> or `o` is used
+" O -> when the `O` command is used
+setlocal cinkeys=0{,0},0),0],!^F,o,O

--- a/editors/vim/syntax/jakt.vim
+++ b/editors/vim/syntax/jakt.vim
@@ -1,0 +1,114 @@
+" Vim syntax file
+" Language: Jakt
+" Latest Revision: 2022-05-21
+
+if exists("b:current_syntax")
+  finish
+endif
+
+let s:cpo_save = &cpo
+set cpo&vim
+
+let s:jakt_syntax_keywords = {
+    \   'jaktConditional': ["if"
+    \ ,                    "else"]
+    \ , 'jaktRepeat': ["while"
+    \ ,               "for"
+    \ ,               "loop"]
+    \ , 'jaktExecution': ["return"
+    \ ,                  "break"
+    \ ,                  "continue"]
+    \ , 'jaktBoolean': ["true"
+    \ ,                "false"]
+    \ , 'jaktKeyword': ["function"
+    \ ,                 "extern"]
+    \ , 'jaktException': ["throws"]
+    \ , 'jaktMacro': ["defer"
+    \ ,              "unsafe"
+    \ ,              "throw"
+    \ ,              "try"
+    \ ,              "catch"
+    \ ,              "cpp"]
+    \ , 'jaktOperator': ["not"
+    \ ,                 "and"
+    \ ,                 "or"]
+    \ , 'jaktVarDecl': ["mutable"
+    \ ,                 "let"
+    \ ,                 "anonymous"
+    \ ,                 "raw"]
+    \ , 'jaktType': ["String"
+    \ ,             "i8"
+    \ ,             "i16"
+    \ ,             "i32"
+    \ ,             "i64"
+    \ ,             "u8"
+    \ ,             "u16"
+    \ ,             "u32"
+    \ ,             "u64"
+    \ ,             "f32"
+    \ ,             "f64"
+    \ ,             "bool"
+    \ ,             "c_int"
+    \ ,             "c_char"
+    \ ,             "usize"]
+    \ , 'jaktBuiltinFn': ["print"
+    \ ,                   "println"]
+    \ , 'jaktConstant': ["this"]
+    \ , 'jaktStructure': ["struct"
+    \ ,                 "class"
+    \ ,                 "enum"]
+    \ }
+
+function! s:syntax_keyword(dict)
+  for key in keys(a:dict)
+    execute 'syntax keyword' key join(a:dict[key], ' ')
+  endfor
+endfunction
+
+call s:syntax_keyword(s:jakt_syntax_keywords)
+
+syntax match jaktDecNumber display   "\v<\d%(_?\d)*"
+syntax match jaktHexNumber display "\v<0x\x%(_?\x)*"
+syntax match jaktOctNumber display "\v<0o\o%(_?\o)*"
+syntax match jaktBinNumber display "\v<0b[01]%(_?[01])*"
+
+syntax region jaktBlock start="{" end="}" transparent fold
+
+syntax region jaktCommentLine start="//" end="$"
+
+
+
+syntax region jaktString matchgroup=jaktStringDelimiter start=+"+ skip=+\\\\\|\\"+ end=+"+ oneline contains=jaktEscape
+syntax match jaktEscape        display contained /\\./
+
+highlight default link jaktDecNumber jaktNumber
+highlight default link jaktHexNumber jaktNumber
+highlight default link jaktOctNumber jaktNumber
+highlight default link jaktBinNumber jaktNumber
+
+highlight default link jaktBuiltinFn Statement
+highlight default link jaktKeyword Keyword
+highlight default link jaktType Type
+highlight default link jaktCommentLine Comment
+highlight default link jaktString String
+highlight default link jaktStringDelimiter String
+highlight default link jaktEscape Special
+highlight default link jaktBoolean Boolean
+highlight default link jaktConstant Constant
+highlight default link jaktNumber Number
+highlight default link jaktArrowCharacter jaktOperator
+highlight default link jaktOperator Operator
+highlight default link jaktStructure Structure
+highlight default link jaktExecution Special
+highlight default link jaktMacro Macro
+highlight default link jaktConditional Conditional
+highlight default link jaktRepeat Repeat
+highlight default link jaktVarDecl Function
+highlight default link jaktException Exception
+
+delfunction s:syntax_keyword
+
+let b:current_syntax = "jakt"
+
+let &cpo = s:cpo_save
+unlet! s:cpo_save


### PR DESCRIPTION
Currently vim plugin is in the `editors` directory, but vscode one is not. I think in the end vscode plugin should also be moved to `editors`, but it was somewhat out side of the scope of this PR.