### PR TITLE
Create a VSCode launch configuration to debug current file compilation

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,18 @@
+{
+	"version": "0.2.0",
+	"configurations": [
+		{
+			"type": "lldb",
+			"request": "launch",
+			"name": "Debug current file compilation (Jakt)",
+			"cargo": {
+				"args": [
+					"run"
+				]
+			},
+			"program": "${cargo:program}",
+			"args": ["${file}"]
+		}
+		
+	]
+}


### PR DESCRIPTION
This launch configuration utilizes the CodeLLDB extension, the default debugging extension for Rust in VSCode. It will debug the jakt compiler running on the open file. So to debug any given file that has bugs in its compilation, simply open it and start the launch configuration from the "Run/Debug" window.