### PR TITLE
Fix infinite loop while parsing illegal function call arguments

### DIFF
--- a/src/parser.rs
+++ b/src/parser.rs
@@ -3898,7 +3898,16 @@ pub fn parse_call(tokens: &[Token], index: &mut usize) -> (Call, Option<JaktErro
                             index,
                             ExpressionKind::ExpressionWithoutAssignment,
                         );
-                        error = error.or(err);
+
+                        if let Some(jakt_error) = err {
+                            trace!(
+                                "ERROR: error while parsing expression in function call parameter"
+                            );
+                            error = error.or(Some(jakt_error));
+                            break;
+                        } else {
+                            error = error.or(err);
+                        }
 
                         call.args.push((param_name, expr));
                     }

--- a/tests/parser/unclosed-paren-in-function.error
+++ b/tests/parser/unclosed-paren-in-function.error
@@ -1,0 +1,1 @@
+expected complete block

--- a/tests/parser/unclosed-paren-in-function.jakt
+++ b/tests/parser/unclosed-paren-in-function.jakt
@@ -1,0 +1,7 @@
+// When the parser tries to parse an expression from "}" (for the second argument of the function),
+// it errors out and doesn't increment the token index.
+// But because the inner loop that repeatedly parses function parameter expressions never considered errors,
+// it would get stuck in an infinite loop failing to parse "}".
+function main() {
+    println("test"
+}


### PR DESCRIPTION
When the parser tries to parse an expression from "}" (for the second argument of the function), it errors out and doesn't increment the token index. But because the inner loop that repeatedly parses function parameter expressions never considered errors, it would get stuck in an infinite loop failing to parse "}".

The solution is simply to check for errors and bail out of the loop if there is one. A regression test has been added to the parser tests.

Fixes #155