### PR TITLE
Add support for namespaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -319,6 +319,23 @@ function main() {
 }
 ```
 
+## Namespaces
+
+- [x] Namespace support for functions and struct/class/enum
+- [ ] Deep namespace support
+
+```
+namespace Greeters {
+    function greet() {
+        println("Well, hello friends")
+    }
+}
+
+function main() {
+    Greeters::greet()
+}
+```
+
 ## Type casts
 
 There are four built-in casting operators in **jakt**.
@@ -332,20 +349,6 @@ There are four built-in casting operators in **jakt**.
 
 - `as truncated T`: Returns a `T` with out-of-range values truncated in a manner specific to each type.
 - `as saturated T`: Returns a `T` with the out-of-range values saturated to the minimum or maximum value possible for `T`.
-
-## Namespaces
-
-**(Not yet implemented)**
-
-```jakt
-namespace Foo {
-    function bar() => 3
-}
-
-function main() {
-    println("{}", Foo::bar())
-}
-```
 
 ## Traits
 

--- a/samples/namespaces/hello_namespace.jakt
+++ b/samples/namespaces/hello_namespace.jakt
@@ -1,0 +1,9 @@
+namespace Greeters {
+    function greet() {
+        println("Well, hello friends")
+    }
+}
+
+function main() {
+    Greeters::greet()
+}

--- a/samples/namespaces/hello_namespace.out
+++ b/samples/namespaces/hello_namespace.out
@@ -1,0 +1,1 @@
+Well, hello friends

--- a/samples/namespaces/namespace_struct.jakt
+++ b/samples/namespaces/namespace_struct.jakt
@@ -1,0 +1,16 @@
+namespace Greeters {
+    struct Person {
+        name: String
+        age: i64
+
+        function greet(this) {
+            println("I am {} and my age is {}", name, age)
+        }
+    }
+}
+
+function main() {
+    let p = Greeters::Person(name: "Jane", age: 100)
+
+    p.greet()
+}

--- a/samples/namespaces/namespace_struct.out
+++ b/samples/namespaces/namespace_struct.out
@@ -1,0 +1,1 @@
+I am Jane and my age is 100

--- a/src/compiler.rs
+++ b/src/compiler.rs
@@ -4,8 +4,8 @@ use crate::{
     codegen::codegen,
     error::JaktError,
     lexer::lex,
-    parser::parse_file,
-    typechecker::{typecheck_file, Project, Scope, Type},
+    parser::parse_namespace,
+    typechecker::{typecheck_namespace, Project, Scope, Type},
 };
 
 pub type FileId = usize;
@@ -55,10 +55,10 @@ impl Compiler {
             self.raw_files.len() - 1,
             &self.raw_files[self.raw_files.len() - 1].1,
         );
-        let (file, _) = parse_file(&lexed);
+        let (file, _) = parse_namespace(&lexed, &mut 0);
 
         // Scope ID 0 is the global project-level scope that all files can see
-        typecheck_file(&file, 0, project)
+        typecheck_namespace(&file, 0, project)
     }
 
     pub fn convert_to_cpp(&mut self, fname: &Path) -> Result<String, JaktError> {
@@ -83,7 +83,7 @@ impl Compiler {
             return Err(err);
         }
 
-        let (file, err) = parse_file(&lexed);
+        let (file, err) = parse_namespace(&lexed, &mut 0);
 
         if let Some(err) = err {
             return Err(err);
@@ -94,7 +94,7 @@ impl Compiler {
 
         let file_scope_id = project.scopes.len() - 1;
 
-        let err = typecheck_file(&file, file_scope_id, &mut project);
+        let err = typecheck_namespace(&file, file_scope_id, &mut project);
 
         if let Some(err) = err {
             return Err(err);

--- a/tests/main.rs
+++ b/tests/main.rs
@@ -218,3 +218,8 @@ fn test_parser() -> Result<(), JaktError> {
 fn test_sets() -> Result<(), JaktError> {
     test_samples("samples/sets")
 }
+
+#[test]
+fn test_namespaces() -> Result<(), JaktError> {
+    test_samples("samples/namespaces")
+}


### PR DESCRIPTION
This adds support for simple namespaces:

```
namespace Greeters {
    struct Person {
        name: String
        age: i64

        function greet(this) {
            println("I am {} and my age is {}", name, age)
        }
    }
}

function main() {
    let p = Greeters::Person(name: "Jane", age: 100)

    p.greet()
}
```

and

```
namespace Greeters {
    function greet() {
        println("Well, hello friends")
    }
}

function main() {
    Greeters::greet()
}
```

This PR also makes the names for data structures for the parsing stage more clearly marked so in later stages it's obvious what has been parsed but not yet typechecked.