### PR TITLE
Runtime integer overflow detection, the first

### DIFF
--- a/runtime/jakt_math.h
+++ b/runtime/jakt_math.h
@@ -1,0 +1,15 @@
+#pragma once
+
+#include <AK/Assertions.h>
+#include <AK/Concepts.h>
+#include <AK/NumericLimits.h>
+
+template<Integral T>
+T __checked_add(T lhs, T rhs)
+{
+    if ((rhs > 0) && (lhs > NumericLimits<T>::max() - rhs))
+        VERIFY(false && "Integer overflow");
+    if ((rhs < 0) && (lhs < NumericLimits<T>::min() - rhs))
+        VERIFY(false && "Integer underflow");
+    return lhs + rhs;
+}

--- a/runtime/lib.h
+++ b/runtime/lib.h
@@ -156,7 +156,7 @@ struct _JaktExplicitValueOrReturn {
     }
 
     _JaktExplicitValueOrReturn(_JaktExplicitValue<void>&&)
-        : value(_JaktExplicitValue<void> { })
+        : value(_JaktExplicitValue<void> {})
     {
     }
 
@@ -171,7 +171,8 @@ struct _JaktExplicitValueOrReturn {
     {
     }
 
-    bool is_return() const {
+    bool is_return() const
+    {
         return value.template has<Conditional<IsVoid<Return>, Empty, Return>>();
     }
 

--- a/runtime/lib.h
+++ b/runtime/lib.h
@@ -82,6 +82,8 @@
 
 #include <IO/File.cpp>
 
+#include <jakt_math.h>
+
 using f32 = float;
 using f64 = double;
 

--- a/samples/math/overflow.error_out
+++ b/samples/math/overflow.error_out
@@ -1,0 +1,1 @@
+Integer overflow

--- a/samples/math/overflow.jakt
+++ b/samples/math/overflow.jakt
@@ -1,0 +1,5 @@
+function main() {
+	let x: u32 = 0xffffffff
+	let y: u32 = x + 1
+	println("{} + 1 = {}", x, y)
+}

--- a/samples/math/underflow.error_out
+++ b/samples/math/underflow.error_out
@@ -1,0 +1,1 @@
+Integer underflow

--- a/samples/math/underflow.jakt
+++ b/samples/math/underflow.jakt
@@ -1,0 +1,6 @@
+function main() {
+	let x: i32 = -0x7fffffff - 1
+	// FIXME: The typechecker doesn't decuce the correct type for the literal yet.
+	let y: i32 = x + -1 as! i32
+	println("{} - 1 = {}", x, y)
+}

--- a/src/codegen.rs
+++ b/src/codegen.rs
@@ -1491,7 +1491,17 @@ fn codegen_expr(indent: usize, expr: &CheckedExpression, project: &Project) -> S
             output.push(')');
         }
         CheckedExpression::BinaryOp(lhs, op, rhs, ..) => {
-            output.push('(');
+            let is_integer_op = is_integer(expr.ty());
+            // FIXME: Do the same for other binary ops.
+            if let BinaryOperator::Add = op {
+                if is_integer_op {
+                    output.push_str("__checked_add(");
+                } else {
+                    output.push('(');
+                }
+            } else {
+                output.push('(');
+            }
 
             match op {
                 BinaryOperator::NoneCoalescing => {
@@ -1510,7 +1520,14 @@ fn codegen_expr(indent: usize, expr: &CheckedExpression, project: &Project) -> S
                 _ => {
                     output.push_str(&codegen_expr(indent, lhs, project));
                     match op {
-                        BinaryOperator::Add => output.push_str(" + "),
+                        // FIXME: Do the same for other binary ops.
+                        BinaryOperator::Add => {
+                            if is_integer_op {
+                                output.push_str(", ")
+                            } else {
+                                output.push_str(" + ")
+                            }
+                        }
                         BinaryOperator::Subtract => output.push_str(" - "),
                         BinaryOperator::Multiply => output.push_str(" * "),
                         BinaryOperator::Modulo => output.push_str(" % "),


### PR DESCRIPTION
As per the README, we want to make integer overflow or underflow a runtime error. This PR is the first step in this direction, as it adds overflow detection and a hard error (VERIFY) to integer addition. The implementation in the code generator is slightly hacked, as we can only simplify the match statements once we have the checked arithmetic functions for all operations. But nevertheless, it detects both integer overflow and underflow for all integer types.

Note that due to typechecker bugs/incompleteness, we can generate code that adds integers of different sizes. That's what would happen in the new underflow test if it weren't for the literal cast. The usage of __checked_add makes this a C++ compilation failure due to template substitution failure. As it is much more involved to check overflow with two different types being added, along with the implied language semantics (which of the two is the resulting type?), I believe this is fine, especially because it doesn't regress any tests and the typechecker should make the literal have the correct type anyways.