### PR TITLE
Add Discord notifications on new commits and PRs

### DIFF
--- a/.github/workflows/discord.yml
+++ b/.github/workflows/discord.yml
@@ -1,0 +1,17 @@
+name: Discord notifications
+
+on: [push, pull_request_target]
+
+jobs:
+  notify_discord:
+    runs-on: ubuntu-20.04
+    if: always() && github.repository == 'SerenityOS/jakt' && (github.event_name == 'pull_request_target' || (github.event_name == 'push' && github.ref == 'refs/heads/main'))
+
+    steps:
+      - name: Discord action notification
+        env:
+          DISCORD_WEBHOOK: ${{ secrets.JAKT_DISCORD_WEBHOOK }}
+          CUSTOM_GITHUB_EVENT_NAME: ${{ github.event_name == 'pull_request_target' && 'pull_request' || github.event_name }} # fake the event type as discord doesn't know how to parse the special pull_request_target context
+        uses: IdanHo/action-discord@754598254f288e6d8e9fca637832e3c163515ba8
+        # FIXME: Find a way to notify on 'ready_for_review', but rate-limited to once/twice per day.
+        if: ${{ (github.event['pull_request'] && github.event['action'] == 'opened') || github.event['commits'] }}


### PR DESCRIPTION
This is directly based on [Serenity's discord.yml file](https://github.com/SerenityOS/serenity/blob/master/.github/workflows/discord.yml).

The main missing thing is the "JAKT_DISCORD_WEBHOOK" secret that needs to be added to the organization and need to point to the right channel in Discord, but that's not something I can do much about!