### PR TITLE
codegen: Emit empty return at the end of throwing void functions

### DIFF
--- a/samples/dictionaries/reference_semantics.jakt
+++ b/samples/dictionaries/reference_semantics.jakt
@@ -1,8 +1,5 @@
-// FIXME: change_value() returns a value because a function that `throws` can't return void
-
-function change_value(dictionary: mutable Dictionary<String, String>) throws -> i64 {
+function change_value(dictionary: mutable Dictionary<String, String>) throws {
     dictionary.set(key: "foo", value: "PASS")
-    return 123
 }
 
 function main() {

--- a/src/codegen.rs
+++ b/src/codegen.rs
@@ -602,6 +602,9 @@ fn codegen_function(function: &CheckedFunction, project: &Project) -> String {
     if function.name == "main" {
         output.push_str(&codegen_indent(INDENT_SIZE));
         output.push_str("return 0;\n");
+    } else if function.throws && function.return_type == VOID_TYPE_ID {
+        output.push_str(&codegen_indent(INDENT_SIZE));
+        output.push_str("return {};\n");
     }
 
     output.push_str("}\n");


### PR DESCRIPTION
Fixes #177.