### PR TITLE
Bounds check generic parameters before accessing

### DIFF
--- a/src/typechecker.rs
+++ b/src/typechecker.rs
@@ -3550,6 +3550,14 @@ pub fn typecheck_call(
                         typecheck_typename(type_arg, caller_scope_id, project);
                     error = error.or(err);
 
+                    if callee.generic_parameters.len() <= idx {
+                        error = error.or(Some(JaktError::TypecheckError(
+                            "Trying to access generic parameter out of bounds".to_string(),
+                            *span,
+                        )));
+                        continue;
+                    }
+
                     // Find the associated type variable for this parameter, we'll use it in substitution
                     let typevar_type_id = match callee.generic_parameters[idx] {
                         FunctionGenericParameter::InferenceGuide(typevar_type_id)

--- a/tests/typechecker/function_call_generic_type.error
+++ b/tests/typechecker/function_call_generic_type.error
@@ -1,0 +1,1 @@
+Trying to access generic parameter out of bounds

--- a/tests/typechecker/function_call_generic_type.jakt
+++ b/tests/typechecker/function_call_generic_type.jakt
@@ -1,0 +1,5 @@
+function foo() {}
+
+function main() {
+    foo<String>()
+}


### PR DESCRIPTION
Resolves an Issue, where calling a non-generic function with a type crashes the typechecker
resolves #180 