### PR TITLE
typechecker: Mark all class constructors as throwing

### DIFF
--- a/samples/classes/static_method.jakt
+++ b/samples/classes/static_method.jakt
@@ -2,7 +2,7 @@ class Person {
     name: String
     age: i64
 
-    function generate(name: String, age: i64) -> Person {
+    function generate(name: String, age: i64) throws -> Person {
         return Person(name: name, age: age + 1000);
     }
 }

--- a/src/codegen.rs
+++ b/src/codegen.rs
@@ -621,7 +621,7 @@ fn codegen_constructor(function: &CheckedFunction, project: &Project) -> String 
             let structure = &project.structs[*struct_id];
 
             if structure.definition_type == DefinitionType::Class {
-                let mut output = format!("static NonnullRefPtr<{}> create", function.name);
+                let mut output = format!("static ErrorOr<NonnullRefPtr<{}>> create", function.name);
 
                 output.push('(');
 
@@ -639,7 +639,7 @@ fn codegen_constructor(function: &CheckedFunction, project: &Project) -> String 
                     output.push_str(&param.variable.name);
                 }
                 output.push_str(&format!(
-                    ") {{ auto o = adopt_ref(*new {}); ",
+                    ") {{ auto o = TRY(adopt_nonnull_ref_or_enomem(new (nothrow) {})); ",
                     function.name
                 ));
 

--- a/src/typechecker.rs
+++ b/src/typechecker.rs
@@ -1503,7 +1503,7 @@ fn typecheck_struct(
 
         let checked_constructor = CheckedFunction {
             name: structure.name.clone(),
-            throws: false,
+            throws: structure.definition_type == DefinitionType::Class,
             return_type: struct_type_id,
             params: constructor_params,
             function_scope_id,


### PR DESCRIPTION
All class constructors perform a heap allocation, and since those can fail, all constructors can throw.