### PR TITLE
Use {K:V} for Dictionaries instead of [K:V]

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,7 +213,7 @@ let values = ["foo", "bar", "baz"]
 
 ```jakt
 function main() {
-    let dict = ["a": 1, "b": 2]
+    let dict = {"a": 1, "b": 2}
 
     println("{}", dict["a"]!)
 }
@@ -223,7 +223,7 @@ function main() {
 
 ```jakt
 // Function that takes a Dictionary<i64, String> and returns an Dictionary<String, bool>
-function foo(numbers: [i64:String]) -> [String:bool] {
+function foo(numbers: {i64:String}) -> {String:bool} {
     ...
 }
 ```
@@ -232,7 +232,7 @@ function foo(numbers: [i64:String]) -> [String:bool] {
 
 ```jakt
 // Dictionary<String, i64> with 3 entries.
-let values = ["foo": 500, "bar": 600, "baz": 700]
+let values = {"foo": 500, "bar": 600, "baz": 700}
 ```
 
 ## Sets

--- a/runtime/prelude.jakt
+++ b/runtime/prelude.jakt
@@ -47,7 +47,7 @@ extern struct Dictionary<K, V> {
     function capacity(this) -> usize
     function keys(this) -> [K]
     function hash(this) -> u32
-    function Dictionary<A, B>() -> [A:B]
+    function Dictionary<A, B>() -> {A:B}
 }
 
 extern struct Set<V> {

--- a/samples/dictionaries/contains.jakt
+++ b/samples/dictionaries/contains.jakt
@@ -1,5 +1,5 @@
 function main() {
-    let dict = ["a": 1, "b": 2]
+    let dict = {"a": 1, "b": 2}
     println("{}", dict.contains("b"))
     println("{}", dict.contains("c"))
 }

--- a/samples/dictionaries/dict.jakt
+++ b/samples/dictionaries/dict.jakt
@@ -1,5 +1,5 @@
 function main() {
-    let dict = ["a": 1, "b": 2]
+    let dict = {"a": 1, "b": 2}
 
     println("{}", dict.get("b")!)
 }

--- a/samples/dictionaries/indexed.jakt
+++ b/samples/dictionaries/indexed.jakt
@@ -1,5 +1,5 @@
 function main() {
-    let dict = ["a": 1, "b": 2]
+    let dict = {"a": 1, "b": 2}
 
     println("{}", dict["a"])
 }

--- a/samples/dictionaries/reference_semantics.jakt
+++ b/samples/dictionaries/reference_semantics.jakt
@@ -1,4 +1,4 @@
-function change_value(dictionary: mutable [String:String]) throws {
+function change_value(dictionary: mutable {String:String}) throws {
     dictionary.set(key: "foo", value: "PASS")
 }
 

--- a/samples/dictionaries/reference_semantics.jakt
+++ b/samples/dictionaries/reference_semantics.jakt
@@ -3,7 +3,7 @@ function change_value(dictionary: mutable [String:String]) throws {
 }
 
 function main() {
-    let mutable dictionary = ["foo": "FAIL", "bar": ":^)"]
+    let mutable dictionary = {"foo": "FAIL", "bar": ":^)"}
     change_value(dictionary)
 
     println("{}", dictionary["foo"]);

--- a/samples/dictionaries/set.jakt
+++ b/samples/dictionaries/set.jakt
@@ -1,5 +1,5 @@
 function main() {
-    let mutable dict = ["a": 1, "b": 2]
+    let mutable dict = {"a": 1, "b": 2}
 
     dict.set(key: "c", value: 3);
 


### PR DESCRIPTION
Based on a discussions we had on Discord yesterday, where I believe we came to a conclusion that is Sets are defined as `{a, b, c}`, then it makes sense to have Dictionaries be `{a:x, b:y, c:z}`. Also updating the shorthand types and README to reflect the syntax changes.