### PR TITLE
lexer: Fix to lexing bin/oct number invalid digits

### DIFF
--- a/src/lexer.rs
+++ b/src/lexer.rs
@@ -689,7 +689,7 @@ fn lex_item(file_id: FileId, bytes: &[u8], index: &mut usize) -> (Token, Option<
             Err(_) => (
                 Token::unknown(span),
                 Some(JaktError::ParserError(
-                    "could not parse hex".to_string(),
+                    "could not parse hex number".to_string(),
                     span,
                 )),
             ),
@@ -714,6 +714,17 @@ fn lex_item(file_id: FileId, bytes: &[u8], index: &mut usize) -> (Token, Option<
                 )),
             );
         }
+
+        if bytes[*index].is_ascii_digit() {
+            return (
+                Token::unknown(Span::new(file_id, start, *index)),
+                Some(JaktError::ParserError(
+                    "could not parse octal number".to_string(),
+                    Span::new(file_id, start, *index),
+                )),
+            );
+        }
+
         let str = String::from_utf8_lossy(&bytes[start + 2..*index]).replace('_', "");
         let number = i128::from_str_radix(&str, 8);
         let suffix = consume_numeric_literal_suffix(bytes, index);
@@ -751,6 +762,17 @@ fn lex_item(file_id: FileId, bytes: &[u8], index: &mut usize) -> (Token, Option<
                 )),
             );
         }
+
+        if bytes[*index].is_ascii_digit() {
+            return (
+                Token::unknown(Span::new(file_id, start, *index)),
+                Some(JaktError::ParserError(
+                    "could not parse binary number".to_string(),
+                    Span::new(file_id, start, *index),
+                )),
+            );
+        }
+
         let str = String::from_utf8_lossy(&bytes[start + 2..*index]).replace('_', "");
         let number = i128::from_str_radix(&str, 2);
         let suffix = consume_numeric_literal_suffix(bytes, index);

--- a/tests/parser/invalid-digits-in-binary-number.error
+++ b/tests/parser/invalid-digits-in-binary-number.error
@@ -1,0 +1,1 @@
+could not parse binary number

--- a/tests/parser/invalid-digits-in-binary-number.jakt
+++ b/tests/parser/invalid-digits-in-binary-number.jakt
@@ -1,0 +1,2 @@
+// Binary number must not contain any digits other than 0 or 1
+0b13

--- a/tests/parser/invalid-digits-in-octal-number.error
+++ b/tests/parser/invalid-digits-in-octal-number.error
@@ -1,0 +1,1 @@
+could not parse octal number

--- a/tests/parser/invalid-digits-in-octal-number.jakt
+++ b/tests/parser/invalid-digits-in-octal-number.jakt
@@ -1,0 +1,2 @@
+// Octal number must not contain any digits other than 0-7
+0o78


### PR DESCRIPTION
Currently there is a bug when lexer tries to lex an invalid bin/oct number.

This (note the `56` in binary number)
```
function main() {
    let s = 0b0156
}
```

results in this
```cpp
const i64 s = static_cast<i64>(1LL);
static_cast<i64>(56LL);
```

Same fix applies to octal. Hex numbers are fine, since all digits get eaten anyways.
