### PR TITLE
Samples: Add 'cat' that uses jakt standard libary

### DIFF
--- a/samples/apps/cat_std.jakt
+++ b/samples/apps/cat_std.jakt
@@ -1,0 +1,15 @@
+function main(args: [String]) {
+    if args.size() <= 1 {
+        eprintln("usage: cat <path>")
+        return 1
+    }
+
+    let mutable file = File::open_for_reading(args[1])
+    let mutable array: [u8] = [0u8]
+
+    while file.read(array) != 0 {
+        for idx in 0..array.size() {
+            print("{:c}", array[idx])
+        }
+    }
+}

--- a/src/codegen.rs
+++ b/src/codegen.rs
@@ -1160,7 +1160,16 @@ fn codegen_expr(indent: usize, expr: &CheckedExpression, project: &Project) -> S
             if call.callee_throws {
                 output.push_str("TRY(");
             }
-            if call.name == "println" {
+            if call.name == "print" {
+                output.push_str("out(");
+                for (i, param) in call.args.iter().enumerate() {
+                    output.push_str(&codegen_expr(indent, &param.1, project));
+                    if i != call.args.len() - 1 {
+                        output.push(',');
+                    }
+                }
+                output.push(')');
+            } else if call.name == "println" {
                 output.push_str("outln(");
                 for (i, param) in call.args.iter().enumerate() {
                     output.push_str(&codegen_expr(indent, &param.1, project));

--- a/src/typechecker.rs
+++ b/src/typechecker.rs
@@ -3791,7 +3791,7 @@ pub fn typecheck_call(
     };
 
     match call.name.as_str() {
-        "println" | "eprintln" if struct_id.is_none() => {
+        "print" | "println" | "eprintln" if struct_id.is_none() => {
             // FIXME: This is a hack since println() and eprintln() are hard-coded into codegen at the moment.
             for arg in &call.args {
                 let (checked_arg, err) =


### PR DESCRIPTION
Adds a new cat sample, built only from the standard library

Also adds `print` builtin as a companion to `println`