### PR TITLE
typechecker+tests: check throwing of function calls

### DIFF
--- a/samples/arrays/array_push.jakt
+++ b/samples/arrays/array_push.jakt
@@ -2,7 +2,7 @@ function main() {
     let mutable values = [0; 0]
 
     for i in 0..10 {
-        values.push(i)
+        try values.push(i) catch err {}
     }
 
     while not values.is_empty() {

--- a/samples/basics/is.jakt
+++ b/samples/basics/is.jakt
@@ -7,21 +7,23 @@ class Bar {
 }
 
 function main() {
-    let foo = Foo(x: 1)
+    try {
+        let foo = Foo(x: 1)
 
-    if foo is Foo {
-        println("OK")
-    }
+        if foo is Foo {
+            println("OK")
+        }
 
-    if foo is Bar {
-        println("Error: Foo should not be Bar")
-    }
+        if foo is Bar {
+            println("Error: Foo should not be Bar")
+        }
 
-    if Bar(y: 5) is Bar {
-        println("OK")
-    }
+        if Bar(y: 5) is Bar {
+            println("OK")
+        }
 
-    if Bar(y: 10) is Foo {
-        println("Error: Bar should not be Foo")
-    }
+        if Bar(y: 10) is Foo {
+            println("Error: Bar should not be Foo")
+        }
+    } catch err {}
 }

--- a/samples/classes/class.jakt
+++ b/samples/classes/class.jakt
@@ -4,8 +4,10 @@ class Person {
 }
 
 function main() {
-    let p = Person(name: "Jane", age: 100)
+    try {
+        let p = Person(name: "Jane", age: 100)
 
-    println("{}", p.name)
-    println("{}", p.age)
+        println("{}", p.name)
+        println("{}", p.age)
+    } catch err {}
 }

--- a/samples/classes/method.jakt
+++ b/samples/classes/method.jakt
@@ -8,9 +8,11 @@ class Person {
 }
 
 function main() {
-    let mutable p = Person(name: "Bob", age: 1000)
+    try {
+        let mutable p = Person(name: "Bob", age: 1000)
 
-    p.birthday()
+        p.birthday()
 
-    println("{}", p.age)
+        println("{}", p.age)
+    } catch err {}
 }

--- a/samples/classes/mutating_method_called_on_immutable_object_instance.jakt
+++ b/samples/classes/mutating_method_called_on_immutable_object_instance.jakt
@@ -3,6 +3,8 @@ class Foo {
 }
 
 function main() {
-    let foo = Foo()
-    foo.bar()
+    try {
+        let foo = Foo()
+        foo.bar()
+    } catch err {}
 }

--- a/samples/classes/static_method.jakt
+++ b/samples/classes/static_method.jakt
@@ -8,8 +8,10 @@ class Person {
 }
 
 function main() {
-    let p = Person::generate(name: "Jane", age: 100)
+    try {
+        let p = Person::generate(name: "Jane", age: 100)
 
-    println("{}", p.name)
-    println("{}", p.age)
+        println("{}", p.name)
+        println("{}", p.age)
+    } catch err {}
 }

--- a/samples/classes/static_method_called_on_object_instance.jakt
+++ b/samples/classes/static_method_called_on_object_instance.jakt
@@ -5,6 +5,8 @@ class Foo {
 }
 
 function main() {
-    let foo = Foo()
-    foo.bar()
+    try {
+        let foo = Foo()
+        foo.bar()
+    } catch err {}
 }

--- a/samples/classes/throwing_method.jakt
+++ b/samples/classes/throwing_method.jakt
@@ -5,8 +5,10 @@ class Foo {
 }
 
 function main() {
-    let foo = Foo()
-    try foo.toss() catch error {
+    try {
+        let foo = Foo()
+        foo.toss()
+    } catch err {
         println("PASS")
     }
 }

--- a/samples/control_flow/call_throw_outside_throw.error
+++ b/samples/control_flow/call_throw_outside_throw.error
@@ -1,0 +1,1 @@
+try to call a throwing function bar in a non-throw function foo

--- a/samples/control_flow/call_throw_outside_throw.jakt
+++ b/samples/control_flow/call_throw_outside_throw.jakt
@@ -1,0 +1,2 @@
+function bar() throws -> i64 { return 5 }
+function foo() -> i64 { return bar() }

--- a/samples/dictionaries/count_words.jakt
+++ b/samples/dictionaries/count_words.jakt
@@ -3,9 +3,12 @@ function main() {
     let words = text.split(' ')
 
     let mutable counts = Dictionary<String, i64>();
-
-    for i in 0..words.size() {
-        counts.set(key: words[i], value: counts.get(words[i]).value_or(0) + 1)
+    try {
+        for i in 0..words.size() {
+            counts.set(key: words[i], value: counts.get(words[i]).value_or(0) + 1)
+        }
+    } catch err {
+        println("err {}", err)
     }
 
     println("the: {}", counts["the"])

--- a/samples/dictionaries/reference_semantics.jakt
+++ b/samples/dictionaries/reference_semantics.jakt
@@ -4,7 +4,7 @@ function change_value(dictionary: mutable [String:String]) throws {
 
 function main() {
     let mutable dictionary = ["foo": "FAIL", "bar": ":^)"]
-    change_value(dictionary)
+    try change_value(dictionary) catch err {}
 
     println("{}", dictionary["foo"]);
 }

--- a/samples/dictionaries/set.jakt
+++ b/samples/dictionaries/set.jakt
@@ -1,7 +1,7 @@
 function main() {
     let mutable dict = ["a": 1, "b": 2]
 
-    dict.set(key: "c", value: 3);
+    try dict.set(key: "c", value: 3) catch err {}
 
     println("{}", dict.get("c")!)
 }

--- a/samples/generics/explicit_type_vars.jakt
+++ b/samples/generics/explicit_type_vars.jakt
@@ -1,7 +1,7 @@
 function main() {
-    let mutable item = Dictionary<String, i64>();
+    let mutable item = Dictionary<String, i64>()
 
-    item.set(key: "bob", value: 123);
+    try item.set(key: "bob", value: 123) catch err {}
 
     println("{}", item.get("bob")!)
 }

--- a/samples/optional/mutable_unwrap.jakt
+++ b/samples/optional/mutable_unwrap.jakt
@@ -11,10 +11,12 @@ class Foo {
 }
 
 function main() {
-    let mutable foo = Foo(x: 1)
-    let mutable opt_foo: Foo? = foo
+    try {
+        let mutable foo = Foo(x: 1)
+        let mutable opt_foo: Foo? = foo
 
-    opt_foo!.set(value: 2)
+        opt_foo!.set(value: 2)
 
-    println("{}", opt_foo!.get())
+        println("{}", opt_foo!.get())
+    } catch err {}
 }

--- a/samples/sets/add.jakt
+++ b/samples/sets/add.jakt
@@ -1,9 +1,11 @@
 function main() {
-    let mutable set = {"b", "c"}
-    set.add("a")
-    println("{}", set.size())
+    try {
+        let mutable set = {"b", "c"}
+        set.add("a")
+        println("{}", set.size())
 
-    set.add("b")
-    set.add("c")
-    println("{}", set.size())
+        set.add("b")
+        set.add("c")
+        println("{}", set.size())
+    } catch err {}
 }

--- a/samples/sets/shorthand.jakt
+++ b/samples/sets/shorthand.jakt
@@ -1,13 +1,15 @@
 function get_unique(nums: [i64]) throws -> {i64} {
     let mutable set = {nums[0]}
     for i in 1..nums.size() {
-        set.add(nums[i])
+        try set.add(nums[i]) catch err {}
     }
     return set
 }
 
 function main() {
     let nums = [1, 2, 3, 4, 5, 5]
-    let set = get_unique(nums)
-    println("{}", set.size())
+    try {
+        let set = get_unique(nums)
+        println("{}", set.size())
+    } catch err {}
 }

--- a/samples/sets/unique_numbers.jakt
+++ b/samples/sets/unique_numbers.jakt
@@ -1,8 +1,8 @@
 function main() {
     let nums = [1, 2, 1, 2, 1, 2, 3, 4, 5, 1, 2]
     let mutable set = {nums[0]}
-    for i in 0..nums.size() {
-        set.add(nums[i])
-    }
+        for i in 0..nums.size() {
+            try set.add(nums[i]) catch err {}
+        }
     println("{}", set.size())
 }

--- a/src/typechecker.rs
+++ b/src/typechecker.rs
@@ -1817,6 +1817,9 @@ fn typecheck_method(
     let method_id = method_id
         .expect("Internal error: we just pushed the checked function, but it's not present");
 
+    let previous_function_id = project.current_function_index;
+    project.current_function_index = Some(method_id);
+
     let checked_function = &mut project.functions[method_id];
     let function_scope_id = checked_function.function_scope_id;
 
@@ -1871,6 +1874,8 @@ fn typecheck_method(
 
     checked_function.block = block;
     checked_function.return_type = return_type;
+
+    project.current_function_index = previous_function_id;
 
     error
 }
@@ -3691,7 +3696,10 @@ pub fn resolve_call<'a>(
                         ));
                     }
                 } else {
-                    unreachable!("should always be calling another function from a function");
+                    unreachable!(
+                        "should always be calling another function from a function {}",
+                        call.name
+                    );
                 }
             }
         }


### PR DESCRIPTION
Function calls get checked for if they throw and if they can be safely handled at the call site.
Situations:
* calling function throws: call as normal
* calling function doesn't throw: must be called within a try-catch block

Adds error message: `try to call a throwing function <called-function> in a non-throw function <calling-function>`

All tests were updated with try-catch blocks that were calling throwing function/methods in non-throwing functions.
Resolves #153 
