### PR TITLE
main: Use pico-args for better CLI

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -23,6 +23,7 @@ dependencies = [
 name = "jakt"
 version = "0.1.0"
 dependencies = [
+ "pico-args",
  "uuid",
 ]
 
@@ -31,6 +32,12 @@ name = "libc"
 version = "0.2.125"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5916d2ae698f6de9bfb891ad7a8d65c09d232dc58cc4ac433c7da3b2fd84bc2b"
+
+[[package]]
+name = "pico-args"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db8bcd96cb740d03149cbad5518db9fd87126a10ab519c011893b1754134c468"
 
 [[package]]
 name = "uuid"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,8 @@ version = "0.1.0"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+[dependencies]
+pico-args = { version = "0.4.2", features = ["combined-flags"] }
 
 [dev-dependencies]
 uuid = {version = "1.0.0", features=["v4"]}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,13 +1,17 @@
-use std::path::PathBuf;
+use std::{path::PathBuf, process::exit};
+
+use pico_args::Arguments;
 
 use jakt::{Compiler, JaktError, Span};
 
 fn main() -> Result<(), JaktError> {
+    let arguments = parse_arguments();
+
     let mut compiler = Compiler::new();
     let mut first_error = None;
 
-    for arg in std::env::args_os().skip(1) {
-        match compiler.compile(&PathBuf::from(&arg)) {
+    for file in arguments.input_files {
+        match compiler.compile(&file) {
             Ok(_) => {}
             Err(err) => {
                 match &err {
@@ -26,6 +30,65 @@ fn main() -> Result<(), JaktError> {
     } else {
         Ok(())
     }
+}
+
+/// Make sure to keep these up-to-date if you're adding arguments.
+const USAGE: &str = "usage: jakt [-h] [FILES...]";
+
+// FIXME: Once format is stable as a const function, include USAGE in this string.
+const HELP: &str = "\
+Flags:
+  -h, --help           Print this help and exit 
+
+Options:
+  FILES...             List of files to compile. The output is `output.cpp`
+                       in the cwd.
+";
+
+#[derive(Debug)]
+struct JaktArguments {
+    input_files: Vec<PathBuf>,
+}
+
+/// Exits if the arguments are invalid or the user doesn't want to run Jakt (e.g. help output)
+fn parse_arguments() -> JaktArguments {
+    let mut pico_arguments = Arguments::from_env();
+    if pico_arguments.contains(["-h", "--help"]) {
+        println!("{}\n\n{}", USAGE, HELP);
+        exit(0);
+    }
+
+    let mut arguments = JaktArguments {
+        input_files: Vec::new(),
+    };
+
+    while let Ok(filename) = pico_arguments.free_from_str::<PathBuf>() {
+        if !filename.exists() {
+            eprintln!(
+                "jakt: error: file '{}' not found or inaccessible",
+                filename.to_string_lossy()
+            );
+            exit(1);
+        }
+        arguments.input_files.push(filename);
+    }
+
+    let extra_arguments = pico_arguments.finish();
+    if !extra_arguments.is_empty() {
+        eprintln!(
+            "jakt: error: extra arguments {}",
+            extra_arguments
+                .iter()
+                .map(|os_string| format!("'{}'", os_string.to_string_lossy()))
+                .collect::<Vec<_>>()
+                .join(", ")
+        )
+    } else if arguments.input_files.is_empty() {
+        println!("{}", USAGE);
+        exit(0);
+    }
+
+    arguments
 }
 
 fn display_error(compiler: &Compiler, msg: &str, span: Span) {


### PR DESCRIPTION
pico-args is a zero-dependency minimal argument parsing library that just handles the bare basics of argument parsing. We use it here to provide a basic CLI that's a little more ergonomic than before, plus some help output. This is mainly preparatory work for subcommands, specifying output files, etc. which require more sophistication than manual argsparsing.

The main two reasons for choosing pico-args is (1) it's super tiny and fast, keeping the development cycle snappy even with full builds, and (2) most argparsing things are handled in our own code, making it easier to port to jakt later on. We'd just have to replicate the low-level parsing facilities of pico-args, which are not too complex in comparison to things that structopt or clap would handle.

CC @ADKaster, can you rebase your work in #126 on this?

Compile times before:
```
❯ time cargo build; time cargo build --release
   Compiling jakt v0.1.0 (/home/kleines/jakt)
    Finished dev [unoptimized + debuginfo] target(s) in 1.96s

real    0m2.015s
user    0m3.539s
sys     0m0.237s
   Compiling jakt v0.1.0 (/home/kleines/jakt)
    Finished release [optimized] target(s) in 3.74s

real    0m3.797s
user    0m10.165s
sys     0m0.117s
```

Compile times after:
```
❯ time cargo build; time cargo build --release
   Compiling pico-args v0.4.2
   Compiling jakt v0.1.0 (/home/kleines/jakt)
    Finished dev [unoptimized + debuginfo] target(s) in 2.10s

real    0m2.156s
user    0m3.837s
sys     0m0.347s
   Compiling pico-args v0.4.2
   Compiling jakt v0.1.0 (/home/kleines/jakt)
    Finished release [optimized] target(s) in 3.83s

real    0m3.892s
user    0m10.717s
sys     0m0.209s
```

Binary size before and after is 4.2 MiB, so a difference of less than 100K (pico-args is 11K according to crates.io)