### PR TITLE
Typechecker: add typechecking for binary operations

### DIFF
--- a/samples/arrays/prefill.jakt
+++ b/samples/arrays/prefill.jakt
@@ -2,7 +2,7 @@ function main() {
     let v = [85; 3]
     println("{}", v.size())
     let mutable i = 0
-    while i < v.size() {
+    while i < v.size() as! i64 {
         println("{}", v[i++])
     }
 }

--- a/samples/arrays/reference_semantics.jakt
+++ b/samples/arrays/reference_semantics.jakt
@@ -7,7 +7,7 @@ function main() {
     change_value(vector: v)
 
     let mutable i = 0
-    while i < v.size() {
+    while i < v.size() as! i64 {
         println("{}", v[i])
         ++i
     }

--- a/samples/basics/bubble_sort.jakt
+++ b/samples/basics/bubble_sort.jakt
@@ -1,6 +1,6 @@
 function bubble_sort(values: mutable [i64]) {
     let mutable i = 0
-    while i < values.size() - 1 {
+    while i < values.size() as! i64 - 1 {
         let mutable j = 0
         while j < (values.size() as! i64) - i - 1 {
             if values[j] > values[j + 1] {
@@ -18,7 +18,7 @@ function main() {
     let mutable v = [25, 13, 8, 1, 9, 22, 50, 2]
     bubble_sort(values: v)
     let mutable i = 0
-    while i < v.size() {
+    while i < v.size() as! i64 {
         println("{}", v[i])
         ++i
     }

--- a/samples/basics/bubble_sort.jakt
+++ b/samples/basics/bubble_sort.jakt
@@ -2,7 +2,7 @@ function bubble_sort(values: mutable [i64]) {
     let mutable i = 0
     while i < values.size() - 1 {
         let mutable j = 0
-        while j < values.size() - i - 1 {
+        while j < (values.size() as! i64) - i - 1 {
             if values[j] > values[j + 1] {
                 let tmp = values[j]
                 values[j] = values[j + 1]

--- a/samples/math/incompatible_literal.error
+++ b/samples/math/incompatible_literal.error
@@ -1,0 +1,1 @@
+binary operation between incompatible types

--- a/samples/math/incompatible_literal.jakt
+++ b/samples/math/incompatible_literal.jakt
@@ -1,0 +1,8 @@
+function main() {
+    let x: u8 = 12;
+    let y: u16 = 34;
+    println("{}", x + y);
+    println("{}", x - y);
+    println("{}", x * y);
+    println("{}", x / y);
+}

--- a/src/typechecker.rs
+++ b/src/typechecker.rs
@@ -3634,14 +3634,45 @@ pub fn typecheck_binary_operation(
 
     let mut ty = lhs.ty();
     match op {
-        BinaryOperator::LogicalAnd
-        | BinaryOperator::LogicalOr
-        | BinaryOperator::LessThan
+        BinaryOperator::LessThan
         | BinaryOperator::LessThanOrEqual
         | BinaryOperator::GreaterThan
         | BinaryOperator::GreaterThanOrEqual
         | BinaryOperator::Equal
         | BinaryOperator::NotEqual => {
+            if lhs_ty != rhs_ty {
+                return (
+                    lhs.ty(),
+                    Some(JaktError::TypecheckError(
+                        "binary comparison operation between incompatible types".to_string(),
+                        span,
+                    )),
+                );
+            }
+
+            ty = BOOL_TYPE_ID;
+        }
+        BinaryOperator::LogicalAnd | BinaryOperator::LogicalOr => {
+            if lhs_ty != BOOL_TYPE_ID {
+                return (
+                    lhs.ty(),
+                    Some(JaktError::TypecheckError(
+                        "left side of logical binary operation is not a boolean".to_string(),
+                        span,
+                    )),
+                );
+            }
+
+            if rhs_ty != BOOL_TYPE_ID {
+                return (
+                    rhs.ty(),
+                    Some(JaktError::TypecheckError(
+                        "right side of logical binary operation is not a boolean".to_string(),
+                        span,
+                    )),
+                );
+            }
+
             ty = BOOL_TYPE_ID;
         }
         BinaryOperator::Assign
@@ -3655,9 +3686,6 @@ pub fn typecheck_binary_operation(
         | BinaryOperator::BitwiseXorAssign
         | BinaryOperator::BitwiseLeftShiftAssign
         | BinaryOperator::BitwiseRightShiftAssign => {
-            let lhs_ty = lhs.ty();
-            let rhs_ty = rhs.ty();
-
             if lhs_ty != rhs_ty {
                 return (
                     lhs.ty(),
@@ -3690,7 +3718,7 @@ pub fn typecheck_binary_operation(
                 return (
                     lhs.ty(),
                     Some(JaktError::TypecheckError(
-                        format!("binary operation between incompatible types",),
+                        "binary operation between incompatible types".to_string(),
                         span,
                     )),
                 );

--- a/src/typechecker.rs
+++ b/src/typechecker.rs
@@ -3629,6 +3629,9 @@ pub fn typecheck_binary_operation(
     rhs: &CheckedExpression,
     span: Span,
 ) -> (TypeId, Option<JaktError>) {
+    let lhs_ty = lhs.ty();
+    let rhs_ty = rhs.ty();
+
     let mut ty = lhs.ty();
     match op {
         BinaryOperator::LogicalAnd
@@ -3677,6 +3680,23 @@ pub fn typecheck_binary_operation(
                     )),
                 );
             }
+        }
+        BinaryOperator::Add
+        | BinaryOperator::Subtract
+        | BinaryOperator::Multiply
+        | BinaryOperator::Divide
+        | BinaryOperator::Modulo => {
+            if lhs_ty != rhs_ty {
+                return (
+                    lhs.ty(),
+                    Some(JaktError::TypecheckError(
+                        format!("binary operation between incompatible types",),
+                        span,
+                    )),
+                );
+            }
+
+            ty = lhs_ty;
         }
         _ => {}
     }

--- a/tests/main.rs
+++ b/tests/main.rs
@@ -112,12 +112,11 @@ fn test_samples(path: &str) -> Result<(), JaktError> {
                     let binary_stderr_output = binary_stderr_output.replace("\r\n", "\n");
 
                     let baseline_text = std::fs::read_to_string(&output_path);
-                    let baseline_text =
-                        baseline_text.and_then(|text| Ok(text.replace("\r\n", "\n")));
+                    let baseline_text = baseline_text.map(|text| text.replace("\r\n", "\n"));
 
                     let baseline_stderr_text = std::fs::read_to_string(&stderr_output_path);
                     let baseline_stderr_text =
-                        baseline_stderr_text.and_then(|text| Ok(text.replace("\r\n", "\n")));
+                        baseline_stderr_text.map(|text| text.replace("\r\n", "\n"));
 
                     let mut stderr_checked = false;
                     if let Ok(baseline_stderr_text) = baseline_stderr_text {


### PR DESCRIPTION
Add typechecking for:

- Comparison operators (left and right have to be the same type)
- Logical and and or (left and right have to be booleans)
- +, -, *, /, % (left and right have to be the same type)

The mathematical binary operators (+, -, *, /, ...) are still somewhat explicit as casts have to be inserted in some places. While this makes it more explicit, especially when working with multiple different integer types, this might not be desired.

Right now it is not possible to do the following:

```jakt
let x: i64 = array.size() + 12;
```

A cast would be needed to cast the `usize` to an `i64`.

Closes #217