### PR TITLE
typechecker: Disallow storing void types in storage types

### DIFF
--- a/src/typechecker.rs
+++ b/src/typechecker.rs
@@ -2722,6 +2722,13 @@ pub fn typecheck_expression(
                     typecheck_expression(item, scope_id, project, safety_mode, None);
                 error = error.or(err);
 
+                if checked_item.ty() == VOID_TYPE_ID {
+                    error = error.or(Some(JaktError::TypecheckError(
+                        "cannot create a tuple that contains a value of type void".to_string(),
+                        item.span(),
+                    )))
+                }
+
                 checked_types.push(checked_item.ty());
                 checked_items.push(checked_item);
             }

--- a/src/typechecker.rs
+++ b/src/typechecker.rs
@@ -2622,6 +2622,13 @@ pub fn typecheck_expression(
                 error = error.or(err);
 
                 if inner_ty == UNKNOWN_TYPE_ID {
+                    if checked_value.ty() == VOID_TYPE_ID {
+                        error = error.or(Some(JaktError::TypecheckError(
+                            "cannot create a set with values of type void".to_string(),
+                            value.span(),
+                        )))
+                    }
+
                     inner_ty = checked_value.ty();
                 } else if inner_ty != checked_value.ty() {
                     error = error.or(Some(JaktError::TypecheckError(

--- a/src/typechecker.rs
+++ b/src/typechecker.rs
@@ -2665,6 +2665,20 @@ pub fn typecheck_expression(
                 error = error.or(err);
 
                 if inner_ty == (UNKNOWN_TYPE_ID, UNKNOWN_TYPE_ID) {
+                    if checked_key.ty() == VOID_TYPE_ID {
+                        error = error.or(Some(JaktError::TypecheckError(
+                            "cannot create a dictionary with keys of type void".to_string(),
+                            key.span(),
+                        )))
+                    }
+
+                    if checked_value.ty() == VOID_TYPE_ID {
+                        error = error.or(Some(JaktError::TypecheckError(
+                            "cannot create a dictionary with values of type void".to_string(),
+                            value.span(),
+                        )))
+                    }
+
                     inner_ty = (checked_key.ty(), checked_value.ty());
                 } else {
                     if inner_ty.0 != checked_key.ty() {

--- a/src/typechecker.rs
+++ b/src/typechecker.rs
@@ -2579,6 +2579,13 @@ pub fn typecheck_expression(
                 error = error.or(err);
 
                 if inner_ty == UNKNOWN_TYPE_ID {
+                    if checked_expr.ty() == VOID_TYPE_ID {
+                        error = error.or(Some(JaktError::TypecheckError(
+                            "cannot create an array with values of type void".to_string(),
+                            v.span(),
+                        )))
+                    }
+
                     inner_ty = checked_expr.ty();
                 } else if inner_ty != checked_expr.ty() {
                     error = error.or(Some(JaktError::TypecheckError(

--- a/tests/typechecker/array_with_void_values.error
+++ b/tests/typechecker/array_with_void_values.error
@@ -1,0 +1,1 @@
+cannot create an array with values of type void

--- a/tests/typechecker/array_with_void_values.jakt
+++ b/tests/typechecker/array_with_void_values.jakt
@@ -1,0 +1,8 @@
+enum Bar {
+    Value
+}
+
+function main() {
+    let foo = Bar::Value()
+    [match foo {}]
+}

--- a/tests/typechecker/dict_with_void_keys.error
+++ b/tests/typechecker/dict_with_void_keys.error
@@ -1,0 +1,1 @@
+cannot create a dictionary with keys of type void

--- a/tests/typechecker/dict_with_void_keys.jakt
+++ b/tests/typechecker/dict_with_void_keys.jakt
@@ -1,0 +1,8 @@
+enum Bar {
+    Value
+}
+
+function main() {
+    let foo = Bar::Value()
+    [match foo {}: 1]
+}

--- a/tests/typechecker/dict_with_void_values.error
+++ b/tests/typechecker/dict_with_void_values.error
@@ -1,0 +1,1 @@
+cannot create a dictionary with values of type void

--- a/tests/typechecker/dict_with_void_values.jakt
+++ b/tests/typechecker/dict_with_void_values.jakt
@@ -1,0 +1,8 @@
+enum Bar {
+    Value
+}
+
+function main() {
+    let foo = Bar::Value()
+    [1: match foo {}]
+}

--- a/tests/typechecker/set_with_void_values.error
+++ b/tests/typechecker/set_with_void_values.error
@@ -1,0 +1,1 @@
+cannot create a set with values of type void

--- a/tests/typechecker/set_with_void_values.jakt
+++ b/tests/typechecker/set_with_void_values.jakt
@@ -1,0 +1,8 @@
+enum Bar {
+    Value
+}
+
+function main() {
+    let foo = Bar::Value()
+    let b = {match foo {}}
+}

--- a/tests/typechecker/tuple_with_void_values.error
+++ b/tests/typechecker/tuple_with_void_values.error
@@ -1,0 +1,1 @@
+cannot create a tuple that contains a value of type void

--- a/tests/typechecker/tuple_with_void_values.jakt
+++ b/tests/typechecker/tuple_with_void_values.jakt
@@ -1,0 +1,8 @@
+enum Bar {
+    Value
+}
+
+function main() {
+    let foo = Bar::Value()
+    let b = (match foo {}, 1)
+}


### PR DESCRIPTION
Since you cannot form a reference to void, attempting to use a `void` type in any of the storage types is invalid and will not compile.