### PR TITLE
parser+typechecker: Visibility round two, electric boogaloo

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ Struct members are *public* by default.
 ### `class`
 
 - [x] basic class support
-- [ ] private-by-default members
+- [x] private-by-default members
 - [ ] inheritance
 - [ ] class-based polymorphism (assign child instance to things requiring the parent type)
 - [ ] `Super` type

--- a/samples/classes/class.jakt
+++ b/samples/classes/class.jakt
@@ -1,6 +1,6 @@
 class Person {
-    name: String
-    age: i64
+    public name: String
+    public age: i64
 }
 
 function main() {

--- a/samples/classes/method.jakt
+++ b/samples/classes/method.jakt
@@ -1,6 +1,6 @@
 class Person {
-    name: String
-    age: i64
+    public name: String
+    public age: i64
 
     public function birthday(mutable this) {
         ++this.age

--- a/samples/classes/static_method.jakt
+++ b/samples/classes/static_method.jakt
@@ -1,6 +1,6 @@
 class Person {
-    name: String
-    age: i64
+    public name: String
+    public age: i64
 
     public function generate(name: String, age: i64) throws -> Person {
         return Person(name: name, age: age + 1000);

--- a/samples/weak/reassign.jakt
+++ b/samples/weak/reassign.jakt
@@ -1,5 +1,5 @@
 class Foo {
-    x: i64
+    public x: i64
 }
 
 function main() {

--- a/src/typechecker.rs
+++ b/src/typechecker.rs
@@ -589,6 +589,7 @@ pub struct CheckedVarDecl {
     pub type_id: TypeId,
     pub mutable: bool,
     pub span: Span,
+    pub visibility: Visibility,
 }
 
 #[derive(Clone, Debug)]
@@ -596,6 +597,7 @@ pub struct CheckedVariable {
     pub name: String,
     pub type_id: TypeId,
     pub mutable: bool,
+    pub visibility: Visibility,
 }
 
 #[derive(Debug, Clone)]
@@ -994,6 +996,79 @@ impl Scope {
     }
 }
 
+/// A trait to collect common namespace member properties.
+trait NamespaceMember {
+    fn visibility(&self) -> Visibility;
+    fn name(&self) -> String;
+    /// e.g. variable, function etc.
+    fn kind(&self) -> &'static str;
+}
+
+impl NamespaceMember for CheckedVarDecl {
+    fn visibility(&self) -> Visibility {
+        self.visibility
+    }
+
+    fn name(&self) -> String {
+        self.name.clone()
+    }
+
+    fn kind(&self) -> &'static str {
+        "variable"
+    }
+}
+impl NamespaceMember for CheckedVariable {
+    fn visibility(&self) -> Visibility {
+        self.visibility
+    }
+
+    fn name(&self) -> String {
+        self.name.clone()
+    }
+
+    fn kind(&self) -> &'static str {
+        "variable"
+    }
+}
+impl NamespaceMember for CheckedFunction {
+    fn visibility(&self) -> Visibility {
+        self.visibility
+    }
+
+    fn name(&self) -> String {
+        self.name.clone()
+    }
+
+    fn kind(&self) -> &'static str {
+        "function"
+    }
+}
+
+fn check_accessibility(
+    own_scope: ScopeId,
+    member_scope: ScopeId,
+    member: impl NamespaceMember,
+    span: &Span,
+    project: &Project,
+) -> Option<JaktError> {
+    if member.visibility() != Visibility::Public
+        && !Scope::can_access(own_scope, member_scope, project)
+    {
+        Some(JaktError::TypecheckError(
+            // FIXME: Improve this error
+            format!(
+                "Can't access {} '{}' from scope {:?}",
+                member.kind(),
+                member.name(),
+                project.scopes[own_scope].namespace_name,
+            ),
+            *span,
+        ))
+    } else {
+        None
+    }
+}
+
 pub fn typecheck_namespace(
     parsed_namespace: &ParsedNamespace,
     scope_id: ScopeId,
@@ -1222,6 +1297,7 @@ fn typecheck_enum(
                                     name: name.clone(),
                                     type_id: enum_type_id,
                                     mutable: false,
+                                    visibility: Visibility::Public,
                                 },
                                 *span,
                             );
@@ -1312,6 +1388,7 @@ fn typecheck_enum(
                             name: name.clone(),
                             type_id: enum_type_id,
                             mutable: false,
+                            visibility: Visibility::Public,
                         },
                         *span,
                     );
@@ -1347,6 +1424,7 @@ fn typecheck_enum(
                                 type_id: decl,
                                 mutable: member.mutable,
                                 span: member.span,
+                                visibility: member.visibility,
                             })
                         }
                     }
@@ -1370,6 +1448,7 @@ fn typecheck_enum(
                                     name: member.name.clone(),
                                     type_id: member.type_id,
                                     mutable: false,
+                                    visibility: member.visibility,
                                 },
                             })
                             .collect();
@@ -1441,6 +1520,7 @@ fn typecheck_enum(
                                 name: "value".to_string(),
                                 type_id: checked_type,
                                 mutable: false,
+                                visibility: Visibility::Public,
                             },
                         }];
                         let function_scope_id = project.create_scope(parent_scope_id);
@@ -1560,6 +1640,7 @@ fn typecheck_struct_predecl(
                     name: param.variable.name.clone(),
                     type_id: struct_type_id,
                     mutable: param.variable.mutable,
+                    visibility: Visibility::Public,
                 };
 
                 checked_function.params.push(CheckedParameter {
@@ -1575,6 +1656,7 @@ fn typecheck_struct_predecl(
                     name: param.variable.name.clone(),
                     type_id: param_type,
                     mutable: param.variable.mutable,
+                    visibility: Visibility::Public,
                 };
 
                 checked_function.params.push(CheckedParameter {
@@ -1641,6 +1723,7 @@ fn typecheck_struct(
             type_id: checked_member_type,
             mutable: unchecked_member.mutable,
             span: unchecked_member.span,
+            visibility: unchecked_member.visibility,
         });
     }
 
@@ -1658,6 +1741,8 @@ fn typecheck_struct(
                     name: field.name.clone(),
                     type_id: field.type_id,
                     mutable: field.mutable,
+                    // This is the constructor parameter, not the field. It can be public.
+                    visibility: Visibility::Public,
                 },
             });
         }
@@ -1754,6 +1839,7 @@ fn typecheck_function_predecl(
             name: param.variable.name.clone(),
             type_id: param_type,
             mutable: param.variable.mutable,
+            visibility: Visibility::Public,
         };
 
         checked_function.params.push(CheckedParameter {
@@ -1995,6 +2081,7 @@ pub fn typecheck_statement(
                 name: error_name.clone(),
                 mutable: false,
                 type_id: project.find_or_add_type_id(Type::Struct(error_struct_id)),
+                visibility: Visibility::Public,
             };
 
             let catch_scope_id = project.create_scope(scope_id);
@@ -2049,6 +2136,7 @@ pub fn typecheck_statement(
                 name: iterator_name.clone(),
                 mutable: true,
                 type_id: index_type,
+                visibility: Visibility::Public,
             };
 
             if let Err(err) =
@@ -2113,6 +2201,7 @@ pub fn typecheck_statement(
                 type_id: checked_type_id,
                 span: var_decl.span,
                 mutable: var_decl.mutable,
+                visibility: var_decl.visibility,
             };
 
             if let Err(err) = project.add_var_to_scope(
@@ -2121,6 +2210,7 @@ pub fn typecheck_statement(
                     name: checked_var_decl.name.clone(),
                     type_id: checked_var_decl.type_id,
                     mutable: checked_var_decl.mutable,
+                    visibility: checked_var_decl.visibility,
                 },
                 checked_var_decl.span,
             ) {
@@ -2518,6 +2608,7 @@ pub fn typecheck_expression(
                             name: v.clone(),
                             type_id: type_hint.unwrap_or(UNKNOWN_TYPE_ID),
                             mutable: false,
+                            visibility: Visibility::Public,
                         },
                         *span,
                     ),
@@ -2555,11 +2646,11 @@ pub fn typecheck_expression(
                 .collect();
 
             match scope {
-                Some(scope_id) => {
-                    if let Some(var) = project.find_var_in_scope(scope_id, v) {
+                Some(variable_scope_id) => {
+                    if let Some(var) = project.find_var_in_scope(variable_scope_id, v) {
                         (
-                            CheckedExpression::NamespacedVar(checked_namespace, var, *span),
-                            None,
+                            CheckedExpression::NamespacedVar(checked_namespace, var.clone(), *span),
+                            check_accessibility(scope_id, variable_scope_id, var, span, project),
                         )
                     } else {
                         (
@@ -2569,6 +2660,7 @@ pub fn typecheck_expression(
                                     name: v.clone(),
                                     type_id: type_hint.unwrap_or(UNKNOWN_TYPE_ID),
                                     mutable: false,
+                                    visibility: Visibility::Public,
                                 },
                                 *span,
                             ),
@@ -2586,6 +2678,7 @@ pub fn typecheck_expression(
                             name: v.clone(),
                             type_id: type_hint.unwrap_or(UNKNOWN_TYPE_ID),
                             mutable: false,
+                            visibility: Visibility::Public,
                         },
                         *span,
                     ),
@@ -3049,6 +3142,7 @@ pub fn typecheck_expression(
                                                             name: args[0].1.clone(),
                                                             type_id,
                                                             mutable: false,
+                                                            visibility: Visibility::Public,
                                                         },
                                                         span,
                                                     ));
@@ -3122,6 +3216,7 @@ pub fn typecheck_expression(
                                                                     name: arg.1.clone(),
                                                                     type_id,
                                                                     mutable: false,
+                                                                    visibility: Visibility::Public,
                                                                 },
                                                                 span,
                                                             ))
@@ -3297,7 +3392,13 @@ pub fn typecheck_expression(
                                     *span,
                                     member.type_id,
                                 ),
-                                None,
+                                check_accessibility(
+                                    scope_id,
+                                    structure.scope_id,
+                                    member.clone(),
+                                    span,
+                                    project,
+                                ),
                             );
                         }
                     }
@@ -3993,20 +4094,14 @@ pub fn typecheck_call(
             if let Some(callee) = callee {
                 // Borrow checker workaround, would be nice to clean this up
                 let callee = callee.clone();
-
                 // Make sure we are allowed to access this method.
-                if callee.visibility != Visibility::Public
-                    && !Scope::can_access(caller_scope_id, callee.function_scope_id, project)
-                {
-                    error = error.or(Some(JaktError::TypecheckError(
-                        // FIXME: Improve this error
-                        format!(
-                            "Can't access function `{}` from scope {:?}",
-                            callee.name, project.scopes[caller_scope_id].namespace_name,
-                        ),
-                        *span,
-                    )));
-                }
+                error = error.or(check_accessibility(
+                    caller_scope_id,
+                    callee.function_scope_id,
+                    callee.clone(),
+                    span,
+                    project,
+                ));
 
                 callee_throws = callee.throws;
                 return_type_id = callee.return_type_id;

--- a/tests/typechecker/class_private_default.error
+++ b/tests/typechecker/class_private_default.error
@@ -1,1 +1,1 @@
-Can't access function `cant_touch` from scope None
+Can't access function 'cant_touch' from scope None

--- a/tests/typechecker/class_private_field_default.error
+++ b/tests/typechecker/class_private_field_default.error
@@ -1,0 +1,1 @@
+Can't access variable 'muda_amount' from scope None

--- a/tests/typechecker/class_private_field_default.jakt
+++ b/tests/typechecker/class_private_field_default.jakt
@@ -1,0 +1,11 @@
+class GoodEncapsulation {
+    muda_amount: u32
+    public ora_amount: u32
+}
+
+function main() {
+    let encapsulated = GoodEncapsulation(muda_amount: 20, ora_amount: 9001)
+    // This is okay!
+    encapsulated.ora_amount
+    encapsulated.muda_amount
+}

--- a/tests/typechecker/class_private_static.error
+++ b/tests/typechecker/class_private_static.error
@@ -1,1 +1,1 @@
-Can't access function `private_static_function` from scope None
+Can't access function 'private_static_function' from scope None

--- a/tests/typechecker/struct_private.error
+++ b/tests/typechecker/struct_private.error
@@ -1,1 +1,1 @@
-Can't access function `parts` from scope None
+Can't access function 'parts' from scope None

--- a/tests/typechecker/struct_private_field.error
+++ b/tests/typechecker/struct_private_field.error
@@ -1,0 +1,1 @@
+Can't access variable 'age' from scope None

--- a/tests/typechecker/struct_private_field.jakt
+++ b/tests/typechecker/struct_private_field.jakt
@@ -1,0 +1,8 @@
+struct WeirdEncapsulation {
+    private age: i32
+}
+
+function main() {
+    let useless = WeirdEncapsulation(age: 2)
+    useless.age
+}


### PR DESCRIPTION
Now with 100% more JoJo references in tests, this PR brings you visibility modifiers on fields + some refactoring niceties to avoid rightwards drift. Visibility can now be considered fully implemented, unless we want `protected` once inheritance lands.