### PR TITLE
Everywhere: Add very basic MVP Variadic Generics

### DIFF
--- a/runtime/IO/Print.h
+++ b/runtime/IO/Print.h
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2022, Ali Mohammad Pur <mpfard@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/Format.h>
+#include <AK/Tuple.h>
+
+namespace JaktInternal {
+
+template<SpecializationOf<Tuple> T>
+void println(String format, T values)
+{
+    values.apply_as_args([&](auto... values) {
+        outln(format, values...);
+    });
+}
+
+template<SpecializationOf<Tuple> T>
+void print(String format, T values)
+{
+    values.apply_as_args([&](auto... values) {
+        out(format, values...);
+    });
+}
+
+template<SpecializationOf<Tuple> T>
+void eprintln(String format, T values)
+{
+    values.apply_as_args([&](auto... values) {
+        warnln(format, values...);
+    });
+}
+
+}
+
+using JaktInternal::eprintln;
+using JaktInternal::print;
+using JaktInternal::println;

--- a/runtime/lib.h
+++ b/runtime/lib.h
@@ -82,6 +82,8 @@
 
 #include <IO/File.cpp>
 
+#include <IO/Print.h>
+
 using f32 = float;
 using f64 = double;
 

--- a/runtime/prelude.jakt
+++ b/runtime/prelude.jakt
@@ -1,3 +1,7 @@
+extern function println<Ts...>(anonymous format: String, anonymous args: Ts...)
+extern function print<Ts...>(anonymous format: String, anonymous args: Ts...)
+extern function eprintln<Ts...>(anonymous format: String, anonymous args: Ts...)
+
 extern struct String {
     function number(anonymous number: i64) -> String
 
@@ -62,7 +66,7 @@ extern struct Set<V> {
     function Set<A>() -> Set<A>
 }
 
-extern struct Tuple {}
+extern struct Tuple<Ts...> {}
 
 extern struct Range {}
 

--- a/samples/generics/variadic_generics.jakt
+++ b/samples/generics/variadic_generics.jakt
@@ -1,0 +1,8 @@
+function cat<Ts...>(anonymous a: Ts...) -> Ts {
+    return a
+}
+
+function main() {
+    let a: Tuple<i64, String> = (1, "hello")
+    println("{} world!", cat(a...).1)
+}

--- a/src/lexer.rs
+++ b/src/lexer.rs
@@ -70,6 +70,7 @@ pub enum TokenContents {
     Comma,
     Dot,
     DotDot,
+    DotDotDot,
     Eol,
     Eof,
     FatArrow,
@@ -448,6 +449,15 @@ pub fn lex(file_id: FileId, bytes: &[u8]) -> (Vec<Token>, Option<JaktError>) {
             index += 1;
             if index < bytes.len() && bytes[index] == b'.' {
                 index += 1;
+                if index < bytes.len() && bytes[index] == b'.' {
+                    index += 1;
+                    output.push(Token::new(
+                        TokenContents::DotDotDot,
+                        Span::new(file_id, start, start + 3),
+                    ));
+                    continue;
+                }
+
                 output.push(Token::new(
                     TokenContents::DotDot,
                     Span::new(file_id, start, start + 2),


### PR DESCRIPTION
Note: very early proof of concept

Implemented:
- `Ts...` generic parameter
- `(tuple)...` splat for variables and tuple literals (only if the type is a known tuple type **at function definition time**)
- calls correctly distribute arguments taking splats into account
- variadic functions

Not implemented:
- `Ts...` generic argument
- tuple splat on type vars (can't re-splat)