### PR TITLE
Parser: Switch to the new enum syntax

### DIFF
--- a/samples/enums/parse.jakt
+++ b/samples/enums/parse.jakt
@@ -5,20 +5,20 @@ enum Simple {
 }
 
 enum SimpleWithType {
-    A: i32
-    B: u32
+    A(i32)
+    B(u32)
 }
 
 enum SimpleWithStructType {
-    A {
+    A (
         a: i32
         b: u32
-    }
+    )
     B: i32
 }
 
 enum SimpleWithTypeParameter<T> {
-    A: T
+    A(T)
     B
 }
 

--- a/samples/enums/simple_match.jakt
+++ b/samples/enums/simple_match.jakt
@@ -1,18 +1,18 @@
 enum BetterOptional<T> {
-    Some: T
+    Some(T)
     None
 }
 
 enum BetterResult<T, E> {
-    ImFineHowAreYou: T
-    TheWorldIsBurning: E
+    ImFineHowAreYou(T)
+    TheWorldIsBurning(E)
 }
 
 enum ObjectivelyBetterOptional<T> {
-    Some {
+    Some (
         value: T
         joke_metadata: String
-    }
+    )
     None
 }
 


### PR DESCRIPTION
This moves us to the new enum syntax, based on the discord discussion.
With this, we now have a uniform syntax between the match and the enum.

```jakt
enum Foo {
    Int(i64)
    Struct(x: i64, y: i64)
}
...
match foo {
    Int(x) => { println("{}", x) }
    Struct(x: x, y: y) => { println!("{} and {}", x, y) }
}
```