### PR TITLE
Meta: Add lint-commits script and lintcommits Github Actions workflows

### DIFF
--- a/.github/workflows/lintcommits.yml
+++ b/.github/workflows/lintcommits.yml
@@ -1,0 +1,84 @@
+name: Commit linter
+
+on: [pull_request_target]
+
+# Make sure to update meta/lint-commit.sh to match this script when adding new checks!
+# (… but don't accept overlong 'fixup!' commit descriptions.)
+
+jobs:
+  lint_commits:
+    runs-on: ubuntu-20.04
+    if: always() && github.repository == 'SerenityOS/jakt'
+
+    steps:
+      - name: Lint PR commits
+        uses: actions/github-script@v5
+        with:
+          script: |
+            const rules = [
+              {
+                pattern: /^[^\r]*$/,
+                error: "Commit message contains CRLF line breaks (only unix-style LF linebreaks are allowed)",
+              },
+              {
+                pattern: /^.+(\r?\n(\r?\n.*)*)?$/,
+                error: "Empty line between commit title and body is missing",
+              },
+              {
+                pattern: /^.{0,72}(?:\r?\n(?:(.{0,72})|(.*?([a-z]+:\/\/)?(([a-zA-Z0-9_]|-)+\.)+[a-z]{2,}(:\d+)?([a-zA-Z_0-9@:%\+.~\?&/=]|-)+).*?))*$/,
+                error: "Commit message lines are too long (maximum allowed is 72 characters, except for URLs)",
+              },
+              {
+                pattern: /^\S.*?\S: .+/,
+                error: "Missing category in commit title (if this is a fix up of a previous commit, it should be squashed)",
+              },
+              {
+                pattern: /^\S.*?: [A-Z0-9]/,
+                error: "First word of commit after the subsystem is not capitalized",
+              },
+              {
+                pattern: /^.+[^.\n](\r?\n.*)*$/,
+                error: "Commit title ends in a period",
+              },
+              {
+                pattern: /^((?!Signed-off-by: )[\s\S])*$/,
+                error: "Commit body contains a Signed-off-by tag",
+              },
+            ];
+
+            const { repository, pull_request } = context.payload;
+
+            // NOTE: This maxes out at 250 commits. If this becomes a problem, see:
+            // https://octokit.github.io/rest.js/v18#pulls-list-commits
+            const opts = github.rest.pulls.listCommits.endpoint.merge({
+              owner: repository.owner.login,
+              repo: repository.name,
+              pull_number: pull_request.number,
+            });
+            const commits = await github.paginate(opts);
+
+            const errors = [];
+            for (const { sha, commit: { message } } of commits) {
+              const commitErrors = [];
+              for (const { pattern, error } of rules) {
+                if (!pattern.test(message)) {
+                  commitErrors.push(error);
+                }
+              }
+              if (commitErrors.length > 0) {
+                const title = message.split("\n")[0];
+                errors.push([`${title} (${sha}):`, ...commitErrors].join("\n  "));
+              }
+            }
+
+            if (errors.length > 0) {
+              core.setFailed(`One or more of the commits in this PR do not match the code submission policy:\n\n${errors.join("\n")}`);
+            }
+
+      - name: Comment on PR
+        if: ${{ failure() && !github.event.pull_request.draft }}
+        uses: IdanHo/comment-on-pr@5f51df338210754f519f721f8320d8f72525a4d0
+        env:
+          GITHUB_TOKEN: ${{ secrets.BUGGIEBOT }}
+        with:
+          msg: "Hello!\n\nOne or more of the commit messages in this PR do not match the Jakt [code submission policy](https://github.com/SerenityOS/jakt/blob/master/CONTRIBUTING.md#code-submission-policy), please check the `lint_commits` CI job for more details on which commits were flagged and why.\nPlease do not close this PR and open another, instead modify your commit message(s) with [git commit --amend](https://docs.github.com/en/pull-requests/committing-changes-to-your-project/creating-and-editing-commits/changing-a-commit-message) and force push those changes to update this PR."

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,13 @@
+repos:
+  - repo: local
+    hooks:
+      - id: meta-lint-commit
+        name: Lint commit message to ensure it will pass the commit linting on CI
+        entry: meta/lint-commit.sh
+        stages: [ commit-msg ]
+        language: system
+
+  - repo: https://github.com/doublify/pre-commit-rust
+    rev: v1.0
+    hooks:
+      - id: fmt

--- a/meta/lint-commit.sh
+++ b/meta/lint-commit.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+
+# the file containing the commit message is passed as the first argument
+commit_file="$1"
+commit_message=$(cat "$commit_file")
+
+error() {
+  echo -e "\033[0;31m$1:\033[0m"
+  echo "$commit_message"
+  exit 1
+}
+
+# fail if the commit message contains windows style line breaks (carriage returns)
+if grep -q -U $'\x0D' "$commit_file"; then
+  error "Commit message contains CRLF line breaks (only unix-style LF linebreaks are allowed)"
+fi
+
+line_number=0
+while read -r line; do
+  # break on git cut line, used by git commit --verbose
+  if [[ "$line" == "# ------------------------ >8 ------------------------" ]]; then
+    break
+  fi
+
+  # ignore comment lines
+  [[ "$line" =~ ^#.* ]] && continue
+  # ignore overlong 'fixup!' commit descriptions
+  [[ "$line" =~ ^fixup!\ .* ]] && continue
+
+  ((line_number += 1))
+  line_length=${#line}
+
+  if [[ $line_number -eq 2 ]] && [[ $line_length -ne 0 ]]; then
+    error "Empty line between commit title and body is missing"
+  fi
+
+  category_pattern="^\S.*?\S: .+"
+  if [[ $line_number -eq 1 ]] && (echo "$line" | grep -E -v -q "$category_pattern"); then
+    error "Missing category in commit title (if this is a fix up of a previous commit, it should be squashed)"
+  fi
+
+  title_case_pattern="^\S.*?: [A-Z0-9]"
+  if [[ $line_number -eq 1 ]] && (echo "$line" | grep -E -v -q "$title_case_pattern"); then
+    error "First word of commit after the subsystem is not capitalized"
+  fi
+
+  if [[ $line_number -eq 1 ]] && [[ "$line" =~ \.$ ]]; then
+    error "Commit title ends in a period"
+  fi
+
+  url_pattern="([a-z]+:\/\/)?(([a-zA-Z0-9_]|-)+\.)+[a-z]{2,}(:\d+)?([a-zA-Z_0-9@:%\+.~\?&\/=]|-)+"
+  if [[ $line_length -gt 72 ]] && (echo "$line" | grep -E -v -q "$url_pattern"); then
+    error "Commit message lines are too long (maximum allowed is 72 characters)"
+  fi
+
+  if [[ "$line" == "Signed-off-by: "* ]]; then
+    error "Commit body contains a Signed-off-by tag"
+  fi
+
+done <"$commit_file"
+exit 0


### PR DESCRIPTION
Copied from serenity with some light modifications :^)

Also add a pre-commit config to use the lint commits script and run cargo fmt.