### PR TITLE
errors: Make error reporting nicer

### DIFF
--- a/src/lexer.rs
+++ b/src/lexer.rs
@@ -881,8 +881,8 @@ fn lex_item(file_id: FileId, bytes: &[u8], index: &mut usize) -> (Token, Option<
 
         if *index == bytes.len() || bytes[*index] != b'"' {
             error = error.or(Some(JaktError::ParserError(
-                "expected quote".to_string(),
-                Span::new(file_id, *index, *index),
+                "expected end quote".to_string(),
+                Span::new(file_id, start, start + 1),
             )));
         }
 


### PR DESCRIPTION
This changes the error reporter to:

* print out only nearby lines rather than the whole file
* print line numbers for each line
* print a label on the error

This PR also cleans up the missing quote error message.

Example:

![image](https://user-images.githubusercontent.com/547158/169746192-0e02ffca-aea2-45a1-ae1b-f5ae1b64af57.png)
