### PR TITLE
errors: Fix the pointer on the improve error reporter

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -155,7 +155,7 @@ fn display_error(compiler: &Compiler, msg: &str, span: Span) {
 
             print!(
                 "{}",
-                " ".repeat(line_spans[line_index].1 - line_spans[line_index].0 + width + 2)
+                " ".repeat(span.start - line_spans[line_index].0 + width + 4)
             );
             println!("\u{001b}[31m^- {}\u{001b}[0m", msg);
 


### PR DESCRIPTION
Had a bit of bad math for where to put the pointer in the error message. Corrected.

Before:

```
Error: Forced unwrap only works on Optional
-----
 20 |                 Operation::Add => {
 21 |                     return eval(lhs!) + eval(rhs!)
            return i
                                                      ^- Forced unwrap only works on Optional
 22 |                 }
-----
```
after:
```
Error: Forced unwrap only works on Optional
-----
 20 |                 Operation::Add => {
 21 |                     return eval(lhs!) + eval(rhs)
                                      ^- Forced unwrap only works on Optional
 22 |                 }
-----
```