### PR TITLE
typechecker: Allow unary increment/decrement on all integer types

### DIFF
--- a/src/typechecker.rs
+++ b/src/typechecker.rs
@@ -3722,7 +3722,10 @@ pub fn typecheck_unary_operation(
             | crate::compiler::U32_TYPE_ID
             | crate::compiler::U64_TYPE_ID
             | crate::compiler::F32_TYPE_ID
-            | crate::compiler::F64_TYPE_ID => {
+            | crate::compiler::F64_TYPE_ID
+            | crate::compiler::USIZE_TYPE_ID
+            | crate::compiler::CCHAR_TYPE_ID
+            | crate::compiler::CINT_TYPE_ID => {
                 if !expr.is_mutable() {
                     (
                         CheckedExpression::UnaryOp(Box::new(expr), op, span, expr_type_id),

--- a/tests/typechecker/increment_integer_types.jakt
+++ b/tests/typechecker/increment_integer_types.jakt
@@ -1,0 +1,46 @@
+function main() {
+    {
+        let mutable x = 0i8
+        x++
+    }
+    {
+        let mutable x = 0i16
+        x++
+    }
+    {
+        let mutable x = 0i32
+        x++
+    }
+    {
+        let mutable x = 0i64
+        x++
+    }
+    {
+        let mutable x = 0u8
+        x++
+    }
+    {
+        let mutable x = 0u16
+        x++
+    }
+    {
+        let mutable x = 0u32
+        x++
+    }
+    {
+        let mutable x = 0u64
+        x++
+    }
+    {
+        let mutable x = 0uz
+        x++
+    }
+    {
+        let mutable x: c_int = 0
+        x++
+    }
+    {
+        let mutable x: c_char = 0
+        x++
+    }
+}


### PR DESCRIPTION
Previously it was not possible to use `x++` on `usize`, `c_int`, `c_char` primitives.