### PR TITLE
typechecker: Reject `return` inside a `defer` as an error

### DIFF
--- a/samples/control_flow/defer_return_error.error
+++ b/samples/control_flow/defer_return_error.error
@@ -1,0 +1,1 @@
+‘return’ is not allowed inside ‘defer’

--- a/samples/control_flow/defer_return_error.jakt
+++ b/samples/control_flow/defer_return_error.jakt
@@ -1,0 +1,11 @@
+function foo() {
+    defer {
+        return 2
+    }
+
+    return 1
+}
+
+function main() {
+    println("foo returned {}", foo())
+}

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -213,7 +213,7 @@ pub enum ParsedStatement {
     For((String, Span), ParsedExpression, ParsedBlock),
     Break,
     Continue,
-    Return(ParsedExpression),
+    Return(ParsedExpression, Span),
     Throw(ParsedExpression),
     Try(Box<ParsedStatement>, String, Span, ParsedBlock),
     InlineCpp(ParsedBlock, Span),
@@ -1555,7 +1555,7 @@ pub fn parse_function(
                 let (block, err) = match fat_arrow_expr {
                     Some(expr) => {
                         let mut block = ParsedBlock::new();
-                        block.stmts.push(ParsedStatement::Return(expr));
+                        block.stmts.push(ParsedStatement::Return(expr, name_span));
                         (block, None)
                     }
                     None => parse_block(tokens, index),
@@ -1672,6 +1672,7 @@ pub fn parse_statement(
     trace!(format!("parse_statement: {:?}", tokens[*index]));
 
     let mut error = None;
+    let start = tokens[*index].span;
 
     match &tokens[*index].contents {
         TokenContents::Name(name) if name == "throw" => {
@@ -1820,7 +1821,17 @@ pub fn parse_statement(
                 parse_expression(tokens, index, ExpressionKind::ExpressionWithoutAssignment);
             error = error.or(err);
 
-            (ParsedStatement::Return(expr), error)
+            (
+                ParsedStatement::Return(
+                    expr,
+                    Span {
+                        file_id: start.file_id,
+                        start: start.start,
+                        end: tokens[(*index - 1)].span.end,
+                    },
+                ),
+                error,
+            )
         }
         TokenContents::Name(name) if name == "let" => {
             trace!("parsing let");

--- a/src/typechecker.rs
+++ b/src/typechecker.rs
@@ -153,6 +153,7 @@ pub struct Project {
     pub types: Vec<Type>,
 
     pub current_function_index: Option<usize>,
+    pub inside_defer: bool,
 }
 
 impl Project {
@@ -168,6 +169,7 @@ impl Project {
             scopes: vec![project_global_scope],
             types: Vec::new(),
             current_function_index: None,
+            inside_defer: false,
         }
     }
 
@@ -2607,8 +2609,11 @@ pub fn typecheck_statement(
             (CheckedStatement::Expression(checked_expr), err)
         }
         ParsedStatement::Defer(statement) => {
+            let was_inside_defer = project.inside_defer;
+            project.inside_defer = true;
             let (checked_statement, err) =
                 typecheck_statement(statement, scope_id, project, safety_mode);
+            project.inside_defer = was_inside_defer;
 
             (CheckedStatement::Defer(Box::new(checked_statement)), err)
         }
@@ -2721,7 +2726,7 @@ pub fn typecheck_statement(
 
             (CheckedStatement::While(checked_cond, checked_block), error)
         }
-        ParsedStatement::Return(expr) => {
+        ParsedStatement::Return(expr, span) => {
             let (output, err) = typecheck_expression(
                 expr,
                 scope_id,
@@ -2731,8 +2736,16 @@ pub fn typecheck_statement(
                     .current_function_index
                     .map(|i| project.functions[i].return_type_id),
             );
+            error = error.or(err);
 
-            (CheckedStatement::Return(output), err)
+            if project.inside_defer {
+                error = error.or(Some(JaktError::TypecheckError(
+                    "‘return’ is not allowed inside ‘defer’".to_string(),
+                    *span,
+                )));
+            }
+
+            (CheckedStatement::Return(output), error)
         }
         ParsedStatement::Block(block) => {
             let (checked_block, err) = typecheck_block(block, scope_id, project, safety_mode);


### PR DESCRIPTION
Closes #216

This is my first attempt at Rust so there's probably a smarter way of doing this!
![image](https://user-images.githubusercontent.com/222642/169865494-53b190a1-9ca3-4046-9657-b389dd8bf3ea.png)