### PR TITLE
Parser: Fix an extern keyword followed by EOF entering an infinite loop

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -235,7 +235,7 @@ fn display_message_with_span(
     println!("{}", "-".repeat(width + 3));
 
     while line_index < line_spans.len() {
-        if span.start >= line_spans[line_index].0 && span.start < line_spans[line_index].1 {
+        if span.start >= line_spans[line_index].0 && span.start <= line_spans[line_index].1 {
             if line_index > 0 {
                 print_source_line(
                     &severity,
@@ -284,17 +284,6 @@ fn display_message_with_span(
         } else {
             line_index += 1
         }
-    }
-
-    if span.start == span.end && span.start == file_contents.len() && line_index > 0 {
-        print_source_line(
-            &severity,
-            file_contents,
-            line_spans[line_index - 1],
-            span,
-            line_index - 1,
-            largest_line_number,
-        );
     }
 
     println!("\u{001b}[0m{}", "-".repeat(width + 3));

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -636,6 +636,7 @@ pub fn parse_namespace(
                                 _ => {
                                     trace!("ERROR: unexpected keyword");
 
+                                    *index += 1;
                                     error = error.or(Some(JaktError::ParserError(
                                         "unexpected keyword".to_string(),
                                         *span,
@@ -643,11 +644,12 @@ pub fn parse_namespace(
                                 }
                             },
                             _ => {
-                                trace!("ERROR: unexpected keyword");
+                                trace!("ERROR: unexpected token");
 
+                                *index += 1;
                                 error = error.or(Some(JaktError::ParserError(
-                                    "unexpected keyword".to_string(),
-                                    *span,
+                                    "unexpected token".to_string(),
+                                    tokens[*index].span,
                                 )));
                             }
                         }


### PR DESCRIPTION
Add the missing token index increment in the default cases of the extern parsing match statements.

Resolves #231.