### PR TITLE
codegen: Generate lib.h include relative to documented include path

### DIFF
--- a/src/codegen.rs
+++ b/src/codegen.rs
@@ -25,7 +25,7 @@ const INDENT_SIZE: usize = 4;
 pub fn codegen(project: &Project, scope: &Scope) -> String {
     let mut output = String::new();
 
-    output.push_str("#include \"runtime/lib.h\"\n");
+    output.push_str("#include <lib.h>\n");
 
     output.push_str(&codegen_namespace(project, scope));
 


### PR DESCRIPTION
Commit adcaeb5 moved the generated C++ file from the project root to the
"build" subdirectory. This broke compilation with the documented command
in the README, which uses `-Iruntime` as the include path, because the
relative path from the C++ file to lib.h is now "../runtime/lib.h".

Also switch the include style to use angle brackets. This just avoids
letting the compiler search for a file called lib.h relative to the
generated C++ file before searching the `-I` path.