### PR TITLE
typechecker: Make throw statement expect Error

### DIFF
--- a/runtime/prelude.jakt
+++ b/runtime/prelude.jakt
@@ -73,7 +73,7 @@ extern struct Range {}
 
 extern struct Error {
     function code(this) -> i32
-    function from_errno(anonymous errno: i32)
+    function from_errno(anonymous errno: i32) -> Error
 }
 
 extern class File {

--- a/src/typechecker.rs
+++ b/src/typechecker.rs
@@ -2160,7 +2160,17 @@ pub fn typecheck_statement(
                 typecheck_expression(expr, scope_id, project, safety_mode, None);
             error = error.or(err);
 
-            // FIXME: Verify that the expression produces an Error
+            let error_struct_type_id = project
+                .find_type_in_scope(0, "Error")
+                .expect("internal error: Error builtin definition not found");
+
+            if checked_expr.type_id() != error_struct_type_id {
+                error = error.or(Some(JaktError::TypecheckError(
+                    "throw expression does not produce an error".to_string(),
+                    expr.span(),
+                )));
+            }
+
             (CheckedStatement::Throw(checked_expr), error)
         }
         ParsedStatement::For(iterator_name, range_expr, block) => {

--- a/tests/typechecker/throw_no_error.error
+++ b/tests/typechecker/throw_no_error.error
@@ -1,0 +1,1 @@
+throw expression does not produce an error

--- a/tests/typechecker/throw_no_error.jakt
+++ b/tests/typechecker/throw_no_error.jakt
@@ -1,0 +1,9 @@
+function foo() throws -> u32 {
+    throw 1
+    return 2
+}
+
+function main() {
+    let x = foo()
+    println("{}", x)
+}


### PR DESCRIPTION
A throw statement requires the type of its
expression to be the Error struct.
Other types of expression will be rejected
by the typechecker.

Add a test to check for this behaviour.

Resolves  #147 