### PR TITLE
runtime: Open files as binary

### DIFF
--- a/runtime/IO/File.cpp
+++ b/runtime/IO/File.cpp
@@ -18,7 +18,7 @@ File::~File()
 
 ErrorOr<NonnullRefPtr<File>> File::open_for_reading(String path)
 {
-    auto* stdio_file = fopen(path.characters(), "r");
+    auto* stdio_file = fopen(path.characters(), "rb");
     if (!stdio_file) {
         return Error::from_errno(errno);
     }
@@ -29,7 +29,7 @@ ErrorOr<NonnullRefPtr<File>> File::open_for_reading(String path)
 
 ErrorOr<NonnullRefPtr<File>> File::open_for_writing(String path)
 {
-    auto* stdio_file = fopen(path.characters(), "w");
+    auto* stdio_file = fopen(path.characters(), "wb");
     if (!stdio_file) {
         return Error::from_errno(errno);
     }


### PR DESCRIPTION
This ensures the bytes written are not modified, i.e. `\n` being replaced by `\r\n` on Windows.

Since the current File API only supports reading and writing raw bytes it feels like a sensible default.