### PR TITLE
Everywhere: More uniform formatting of the word "Jakt"

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ There are two exceptions to this:
 
 ## Structures and classes
 
-There are two main ways to declare a structure in Jakt: `struct` and `class`.
+There are two main ways to declare a structure in **Jakt**: `struct` and `class`.
 
 ### `struct`
 
@@ -91,7 +91,7 @@ struct Point {
 }
 ```
 
-Structs in Jakt have *value semantics*:
+Structs in **Jakt** have *value semantics*:
 - Variables that contain a struct always have a unique instance of the struct.
 - Copying a `struct` instance always makes a deep copy.
 
@@ -128,7 +128,7 @@ class Size {
 }
 ```
 
-Classes in Jakt have *reference semantics*:
+Classes in **Jakt** have *reference semantics*:
 - Copying a `class` instance (aka an "object") copies a reference to the object.
 - All objects are reference-counted by default. This ensures that objects don't get accessed after being deleted.
 
@@ -323,7 +323,7 @@ function do_nothing_in_particular() => match AlertDescription::CloseNotify {
 - [x] Generic type inference
 - [ ] Traits
 
-Jakt supports both generic structures and generic functions. 
+**Jakt** supports both generic structures and generic functions.
 
 ```jakt
 function id<T>(anonymous x: T) -> T {

--- a/editors/vim/README.md
+++ b/editors/vim/README.md
@@ -1,4 +1,4 @@
-# Vim syntax highlighting for jakt
+# Vim syntax highlighting for Jakt
 
 **Install**
 

--- a/runtime/AK/Dictionary.h
+++ b/runtime/AK/Dictionary.h
@@ -45,7 +45,7 @@ public:
         return {};
     }
 
-    // FIXME: Remove this constructor once jakt knows how to call Dictionary::create_empty()
+    // FIXME: Remove this constructor once Jakt knows how to call Dictionary::create_empty()
     Dictionary()
         : m_storage(MUST(adopt_nonnull_ref_or_enomem(new (nothrow) Storage)))
     {

--- a/samples/strings/string_append.jakt
+++ b/samples/strings/string_append.jakt
@@ -1,5 +1,5 @@
 function main() {
-    let a = "ja"
+    let a = "Ja"
     let b = "kt"
     println("{}", a + b)
 

--- a/samples/strings/string_append.out
+++ b/samples/strings/string_append.out
@@ -1,2 +1,2 @@
-jakt
+Jakt
 programming language


### PR DESCRIPTION
This pull request capitalizes all occurances of "jakt", execept for

- The file extension and references to it in code
- The cargo crate and npm package name
- Identifiers in the parser / syntax highlighters / codegen output
- The name of the compiler binary and other file paths
- The language of markdown code blocks
- The repository name and its occurances in code / documentation

as well as updates all uses of the word "Jakt" in the readme to use bold formatting

Resolves #258