### PR TITLE
codegen: Use move semantics in generated class constructors

### DIFF
--- a/samples/classes/class_with_move_only_enum_member.jakt
+++ b/samples/classes/class_with_move_only_enum_member.jakt
@@ -1,0 +1,11 @@
+enum E {
+    Okay
+}
+
+class C {
+    e: E
+}
+
+function main() {
+    let c = C(e: E::Okay())
+}


### PR DESCRIPTION
Previously it was not possible to create a class that had an enum
member, since the generated constructor would try to default-construct
the enum.

The generated C++ now has both a private constructor that uses move()
to slide everything into members, and a public factory function (the
same create() as before that wraps the constructor.)