### PR TITLE
compiler: Show error if main function is not defined

### DIFF
--- a/samples/basics/no_main_function.error
+++ b/samples/basics/no_main_function.error
@@ -1,0 +1,1 @@
+the main function needs to be defined

--- a/samples/basics/no_main_function.jakt
+++ b/samples/basics/no_main_function.jakt
@@ -1,0 +1,3 @@
+function not_main() -> c_int {
+    return 42;
+}

--- a/src/compiler.rs
+++ b/src/compiler.rs
@@ -107,6 +107,14 @@ impl Compiler {
             return Err(err);
         }
 
+        let main_function_id = project.find_function_in_scope(file_scope_id, "main");
+        if main_function_id.is_none() {
+            return Err(JaktError::GlobalError(
+                "No program entry point was specified (the main function needs to be defined)"
+                    .to_string(),
+            ));
+        }
+
         // Hardwire to first file for now
         Ok(codegen(&project, &project.scopes[file_scope_id]))
     }

--- a/src/error.rs
+++ b/src/error.rs
@@ -13,6 +13,7 @@ pub enum JaktError {
     ParserError(String, Span),
     ValidationError(String, Span),
     TypecheckError(String, Span),
+    GlobalError(String),
 }
 
 impl From<std::io::Error> for JaktError {

--- a/src/main.rs
+++ b/src/main.rs
@@ -43,6 +43,7 @@ fn main() -> Result<(), JaktError> {
                     JaktError::ParserError(msg, span) => display_error(&compiler, msg, *span),
                     JaktError::TypecheckError(msg, span) => display_error(&compiler, msg, *span),
                     JaktError::ValidationError(msg, span) => display_error(&compiler, msg, *span),
+                    JaktError::GlobalError(msg) => println!("Error: {}", msg),
                 }
                 first_error = first_error.or(Some(err));
             }


### PR DESCRIPTION
This prints an error that is a bit friendlier than the one that you get
from the linker when main is not defined.