### PR TITLE
docs: Update readme to use latest build steps

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ It currently transpiles to C++.
 
 ```
 jakt file.jakt
-clang++ -std=c++20 -Iruntime -Wno-user-defined-literals build/file.cpp
+clang++ -std=c++20 -I. -Iruntime -Wno-user-defined-literals ./build/file.cpp
 ```
 
 ## Goals


### PR DESCRIPTION
I had to add `-I.` to get the build to work, so I figure might as well add that to the readme