### PR TITLE
Parser: Ensure `parse_function` doesn't enter infinite loops

### DIFF
--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1319,6 +1319,8 @@ pub fn parse_function(
                                 "expected '('".to_string(),
                                 tokens[*index].span,
                             )));
+
+                            *index += 1;
                         }
                     }
                 } else {
@@ -1328,6 +1330,10 @@ pub fn parse_function(
                         "incomplete function".to_string(),
                         tokens[*index - 1].span,
                     )));
+                }
+
+                if error.is_some() {
+                    return (ParsedFunction::new(FunctionLinkage::Internal), error);
                 }
 
                 let mut params = Vec::new();
@@ -1402,6 +1408,8 @@ pub fn parse_function(
                                 "expected parameter".to_string(),
                                 tokens[*index].span,
                             )));
+
+                            *index += 1;
                         }
                     }
                 }
@@ -1413,6 +1421,10 @@ pub fn parse_function(
                         "incomplete function".to_string(),
                         tokens[*index - 1].span,
                     )));
+                }
+
+                if error.is_some() {
+                    return (ParsedFunction::new(FunctionLinkage::Internal), error);
                 }
 
                 let mut throws = false;

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1320,7 +1320,7 @@ pub fn parse_function(
                                 tokens[*index].span,
                             )));
 
-                            *index += 1;
+                            return (ParsedFunction::new(FunctionLinkage::Internal), error);
                         }
                     }
                 } else {
@@ -1330,9 +1330,7 @@ pub fn parse_function(
                         "incomplete function".to_string(),
                         tokens[*index - 1].span,
                     )));
-                }
 
-                if error.is_some() {
                     return (ParsedFunction::new(FunctionLinkage::Internal), error);
                 }
 
@@ -1409,7 +1407,7 @@ pub fn parse_function(
                                 tokens[*index].span,
                             )));
 
-                            *index += 1;
+                            return (ParsedFunction::new(FunctionLinkage::Internal), error);
                         }
                     }
                 }
@@ -1421,9 +1419,7 @@ pub fn parse_function(
                         "incomplete function".to_string(),
                         tokens[*index - 1].span,
                     )));
-                }
 
-                if error.is_some() {
                     return (ParsedFunction::new(FunctionLinkage::Internal), error);
                 }
 


### PR DESCRIPTION
Fixes #226 and other instances where the parser was getting stuck
because an unexpected token was encountered, such as:

```
function foo<Ts..>(a: i32)
```
```
function foo<Ts, ..>(a: i32) 
```
```
function foo<Ts>(a: i32, ..)
```