### PR TITLE
typechecker: Show nicer type names in compiler diagnostics

### DIFF
--- a/samples/functions/call_with_bad_args.error
+++ b/samples/functions/call_with_bad_args.error
@@ -1,1 +1,1 @@
-Type mismatch: expected String, but got i64
+Type mismatch: expected ‘String’, but got ‘i64’

--- a/samples/math/incompatible_literal.error
+++ b/samples/math/incompatible_literal.error
@@ -1,1 +1,1 @@
-binary arithmetic operation between incompatible types u8 and u16
+Binary arithmetic operation between incompatible types (‘u8’ and ‘u16’)

--- a/src/typechecker.rs
+++ b/src/typechecker.rs
@@ -4334,7 +4334,7 @@ pub fn typecheck_binary_operation(
                     lhs_type_id,
                     Some(JaktError::TypecheckError(
                         format!(
-                            "binary comparison operation between incompatible types {} and {}",
+                            "Binary comparison operation between incompatible types (‘{}’ and ‘{}’)",
                             project.typename_for_type_id(lhs_type_id),
                             project.typename_for_type_id(rhs_type_id)
                         ),
@@ -4402,8 +4402,9 @@ pub fn typecheck_binary_operation(
                     lhs_type_id,
                     Some(JaktError::TypecheckError(
                         format!(
-                            "assignment between incompatible types ({:?} and {:?})",
-                            lhs_type_id, rhs_type_id
+                            "Assignment between incompatible types (‘{}’ and ‘{}’)",
+                            project.typename_for_type_id(lhs_type_id),
+                            project.typename_for_type_id(rhs_type_id),
                         ),
                         span,
                     )),
@@ -4430,9 +4431,9 @@ pub fn typecheck_binary_operation(
                     lhs_type_id,
                     Some(JaktError::TypecheckError(
                         format!(
-                            "binary arithmetic operation between incompatible types {} and {}",
+                            "Binary arithmetic operation between incompatible types (‘{}’ and ‘{}’)",
                             project.typename_for_type_id(lhs_type_id),
-                            project.typename_for_type_id(rhs_type_id)
+                            project.typename_for_type_id(rhs_type_id),
                         ),
                         span,
                     )),

--- a/src/typechecker.rs
+++ b/src/typechecker.rs
@@ -427,6 +427,9 @@ impl Project {
         let optional_struct_id = self
             .find_struct_in_scope(0, "Optional")
             .expect("internal error: can't find builtin Optional type");
+        let weak_ptr_struct_id = self
+            .find_struct_in_scope(0, "WeakPtr")
+            .expect("internal error: can't find builtin WeakPtr type");
 
         match &self.types[type_id] {
             Type::Builtin => match type_id {
@@ -475,6 +478,9 @@ impl Project {
             }
             Type::GenericInstance(struct_id, type_args) if *struct_id == optional_struct_id => {
                 format!("{}?", self.typename_for_type_id(type_args[0]))
+            }
+            Type::GenericInstance(struct_id, type_args) if *struct_id == weak_ptr_struct_id => {
+                format!("weak {}?", self.typename_for_type_id(type_args[0]))
             }
             Type::GenericInstance(struct_id, type_args) => {
                 let mut output =

--- a/src/typechecker.rs
+++ b/src/typechecker.rs
@@ -424,6 +424,10 @@ impl Project {
     }
 
     pub fn typename_for_type_id(&self, type_id: TypeId) -> String {
+        let optional_struct_id = self
+            .find_struct_in_scope(0, "Optional")
+            .expect("internal error: can't find builtin Optional type");
+
         match &self.types[type_id] {
             Type::Builtin => match type_id {
                 crate::compiler::VOID_TYPE_ID => "void".to_string(),
@@ -468,6 +472,9 @@ impl Project {
                 output.push('>');
 
                 output
+            }
+            Type::GenericInstance(struct_id, type_args) if *struct_id == optional_struct_id => {
+                format!("{}?", self.typename_for_type_id(type_args[0]))
             }
             Type::GenericInstance(struct_id, type_args) => {
                 let mut output =

--- a/src/typechecker.rs
+++ b/src/typechecker.rs
@@ -4994,7 +4994,7 @@ pub fn check_types_for_compat(
                 if rhs_type_id != *seen_type_id {
                     error = error.or(Some(JaktError::TypecheckError(
                         format!(
-                            "Type mismatch: expected {}, but got {}",
+                            "Type mismatch: expected ‘{}’, but got ‘{}’",
                             project.typename_for_type_id(*seen_type_id),
                             project.typename_for_type_id(rhs_type_id),
                         ),
@@ -5051,7 +5051,7 @@ pub fn check_types_for_compat(
                         // They're the same type, might be okay to just leave now
                         error = error.or(Some(JaktError::TypecheckError(
                             format!(
-                                "Type mismatch: expected {}, but got {}",
+                                "Type mismatch: expected ‘{}’, but got ‘{}’",
                                 project.typename_for_type_id(lhs_type_id),
                                 project.typename_for_type_id(rhs_type_id),
                             ),
@@ -5105,7 +5105,7 @@ pub fn check_types_for_compat(
                         // They're the same type, might be okay to just leave now
                         error = error.or(Some(JaktError::TypecheckError(
                             format!(
-                                "Type mismatch: expected {}, but got {}",
+                                "Type mismatch: expected ‘{}’, but got ‘{}’",
                                 project.typename_for_type_id(lhs_type_id),
                                 project.typename_for_type_id(rhs_type_id),
                             ),
@@ -5163,7 +5163,7 @@ pub fn check_types_for_compat(
                         // They're the same type, might be okay to just leave now
                         error = error.or(Some(JaktError::TypecheckError(
                             format!(
-                                "Type mismatch: expected {}, but got {}",
+                                "Type mismatch: expected ‘{}’, but got ‘{}’",
                                 project.typename_for_type_id(lhs_type_id),
                                 project.typename_for_type_id(rhs_type_id),
                             ),
@@ -5221,7 +5221,7 @@ pub fn check_types_for_compat(
                         // They're the same type, might be okay to just leave now
                         error = error.or(Some(JaktError::TypecheckError(
                             format!(
-                                "Type mismatch: expected {}, but got {}",
+                                "Type mismatch: expected ‘{}’, but got ‘{}’",
                                 project.typename_for_type_id(lhs_type_id),
                                 project.typename_for_type_id(rhs_type_id),
                             ),
@@ -5235,7 +5235,7 @@ pub fn check_types_for_compat(
             if rhs_type_id != lhs_type_id {
                 error = error.or(Some(JaktError::TypecheckError(
                     format!(
-                        "Type mismatch: expected {}, but got {}",
+                        "Type mismatch: expected ‘{}’, but got ‘{}’",
                         project.typename_for_type_id(lhs_type_id),
                         project.typename_for_type_id(rhs_type_id),
                     ),

--- a/tests/typechecker/assign_incompatible_to_optional.error
+++ b/tests/typechecker/assign_incompatible_to_optional.error
@@ -1,0 +1,1 @@
+Assignment between incompatible types (‘class Foo?’ and ‘i64’)

--- a/tests/typechecker/assign_incompatible_to_optional.jakt
+++ b/tests/typechecker/assign_incompatible_to_optional.jakt
@@ -1,0 +1,7 @@
+class Foo {
+}
+
+function main() {
+    let mutable x: Foo? = None
+    x = 5
+}

--- a/tests/typechecker/assign_integer_to_weak.error
+++ b/tests/typechecker/assign_integer_to_weak.error
@@ -1,0 +1,1 @@
+Assignment between incompatible types (‘weak class Foo?’ and ‘i64’)

--- a/tests/typechecker/assign_integer_to_weak.jakt
+++ b/tests/typechecker/assign_integer_to_weak.jakt
@@ -1,0 +1,7 @@
+class Foo {
+}
+
+function main() {
+    let mutable x: weak Foo? = None
+    x = 5
+}

--- a/tests/typechecker/generic_late_type_check_bad.error
+++ b/tests/typechecker/generic_late_type_check_bad.error
@@ -1,1 +1,1 @@
-binary arithmetic operation between incompatible types String and i64
+Binary arithmetic operation between incompatible types (‘String’ and ‘i64’)

--- a/tests/typechecker/return-value-type-mismatch.error
+++ b/tests/typechecker/return-value-type-mismatch.error
@@ -1,1 +1,1 @@
-Type mismatch: expected u64, but got String
+Type mismatch: expected ‘u64’, but got ‘String’

--- a/tests/typechecker/vardecl-type-mismatch.error
+++ b/tests/typechecker/vardecl-type-mismatch.error
@@ -1,1 +1,1 @@
-Type mismatch: expected String, but got u64
+Type mismatch: expected ‘String’, but got ‘u64’


### PR DESCRIPTION
- Fix a couple of situations where we were showing numeric type IDs in build errors instead of type names.
- Use `T?` shorthand for `Optional<T>` in diagnostics
- Use `weak T?` shorthand for `WeakPtr<T>` in diagnostics