### PR TITLE
typechecker: Support for basic definite returns

### DIFF
--- a/tests/typechecker/return_if_missing_else_prong.jakt
+++ b/tests/typechecker/return_if_missing_else_prong.jakt
@@ -1,5 +1,5 @@
 function foo() -> i32 {
-    if true {
+    if false {
         return 123
     }
 }


### PR DESCRIPTION
The typechecker will now detect blocks containing if statements with
literal boolean conditions as definitely returning if the respective
branch definitely returns.

We could probably check Variables, Unary- and BinaryOps as well, but that might be overkill.