### PR TITLE
lexer: Error out on compiling strings spanning multiple lines

### DIFF
--- a/src/lexer.rs
+++ b/src/lexer.rs
@@ -913,6 +913,13 @@ fn lex_item(file_id: FileId, bytes: &[u8], index: &mut usize) -> (Token, Option<
         // Everything but the quotes
         let str = String::from_utf8_lossy(&bytes[(start + 1)..(*index)]);
 
+        if str.lines().count() > 1 {
+            error = error.or(Some(JaktError::ParserError(
+                "strings spanning multiple lines are not allowed".to_string(),
+                Span::new(file_id, start, *index),
+            )));
+        }
+
         *index += 1;
 
         let end = *index;

--- a/tests/parser/multi-line-string-with-double-quotes.error
+++ b/tests/parser/multi-line-string-with-double-quotes.error
@@ -1,0 +1,1 @@
+strings spanning multiple lines are not allowed

--- a/tests/parser/multi-line-string-with-double-quotes.jakt
+++ b/tests/parser/multi-line-string-with-double-quotes.jakt
@@ -1,0 +1,3 @@
+// Strings defined using a single pair of quotes should not span multiple lines
+"hello
+world"


### PR DESCRIPTION
Previously we allowed string spanning multiple line such as

    let x="Hello
    world"

These strings miscompiled since they were copy-pasted as is in C++,
which does not allow strings like these