### PR TITLE
typechecker+codegen: Call ::create on external class constructor

### DIFF
--- a/src/codegen.rs
+++ b/src/codegen.rs
@@ -1843,7 +1843,9 @@ fn codegen_expr(indent: usize, expr: &CheckedExpression, project: &Project) -> S
                 }
                 output.push(')');
             } else {
-                if call.linkage == FunctionLinkage::ImplicitConstructor {
+                if call.linkage == FunctionLinkage::ImplicitConstructor
+                    || call.linkage == FunctionLinkage::ExternalClassConstructor
+                {
                     let type_id = call.type_id;
                     let ty = &project.types[type_id];
 

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -132,6 +132,7 @@ pub enum FunctionLinkage {
     External,
     ImplicitConstructor,
     ImplicitEnumConstructor,
+    ExternalClassConstructor,
 }
 
 #[derive(Copy, Clone, Debug, PartialEq)]

--- a/src/typechecker.rs
+++ b/src/typechecker.rs
@@ -1883,10 +1883,19 @@ fn typecheck_struct(
         });
     }
 
-    if project
-        .find_function_in_scope(checked_struct_scope_id, &structure.name)
-        .is_none()
+    if let Some(constructor_id) =
+        project.find_function_in_scope(checked_struct_scope_id, &structure.name)
     {
+        if structure.definition_type == DefinitionType::Class
+            && structure.definition_linkage == DefinitionLinkage::External
+        {
+            // XXX: The parser always sets the linkage type of an extern class'
+            //      constructor to External, but we actually want to call the
+            //      class' ::create function, just like we do with a
+            //      ImplicitConstructor class.
+            project.functions[constructor_id].linkage = FunctionLinkage::ExternalClassConstructor;
+        }
+    } else {
         // No constructor found, so let's make one
 
         let mut constructor_params = Vec::new();


### PR DESCRIPTION
External class constructor calls will now be codegened as calling the
class' static ::create method. This mirrors how we do implicit
constructors for regular Jakt classes, and also meshes well with how
many ref-counted Serenity classes work.