### PR TITLE
Everywhere: fix compiler transpiling incorrect c_char value

### DIFF
--- a/samples/basics/escape_sequence.jakt
+++ b/samples/basics/escape_sequence.jakt
@@ -1,0 +1,5 @@
+function main() {
+    let str_c: c_char = '\n'
+    print("hello{}", str_c)
+    print("world")
+}

--- a/samples/basics/escape_sequence.out
+++ b/samples/basics/escape_sequence.out
@@ -1,0 +1,2 @@
+hello
+world

--- a/src/codegen.rs
+++ b/src/codegen.rs
@@ -1742,7 +1742,7 @@ fn codegen_expr(indent: usize, expr: &CheckedExpression, project: &Project) -> S
         }
         CheckedExpression::CharacterConstant(c, _) => {
             output.push('\'');
-            output.push(*c);
+            output.push_str(c);
             output.push('\'');
         }
         CheckedExpression::NumericConstant(constant, _, _) => match constant {

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -256,7 +256,7 @@ pub enum ParsedExpression {
     Boolean(bool, Span),
     NumericConstant(NumericConstant, Span),
     QuotedString(String, Span),
-    CharacterLiteral(char, Span),
+    CharacterLiteral(String, Span),
     ByteLiteral(u8, Span),
     Array(Vec<ParsedExpression>, Option<Box<ParsedExpression>>, Span),
     Dictionary(Vec<(ParsedExpression, ParsedExpression)>, Span),
@@ -2764,10 +2764,10 @@ pub fn parse_operand(tokens: &[Token], index: &mut usize) -> (ParsedExpression, 
         }
         TokenContents::SingleQuotedString(c) => {
             *index += 1;
-            if let Some(first) = c.chars().next() {
-                ParsedExpression::CharacterLiteral(first, span)
-            } else {
-                ParsedExpression::Garbage(span)
+            match c.chars().next() {
+                Some('\\') if c.len() == 2 => ParsedExpression::CharacterLiteral(c.clone(), span),
+                _ if c.len() == 1 => ParsedExpression::CharacterLiteral(c.clone(), span),
+                _ => ParsedExpression::Garbage(span),
             }
         }
         TokenContents::SingleQuotedByteString(c) => {

--- a/src/typechecker.rs
+++ b/src/typechecker.rs
@@ -855,7 +855,7 @@ pub enum CheckedExpression {
     NumericConstant(NumericConstant, Span, TypeId),
     QuotedString(String, Span),
     ByteConstant(u8, Span),
-    CharacterConstant(char, Span),
+    CharacterConstant(String, Span),
     UnaryOp(Box<CheckedExpression>, CheckedUnaryOperator, Span, TypeId),
     BinaryOp(
         Box<CheckedExpression>,
@@ -3084,7 +3084,7 @@ pub fn typecheck_expression(
         ParsedExpression::CharacterLiteral(c, span) => {
             let (_, err) = unify_with_type_hint(project, &CCHAR_TYPE_ID);
 
-            (CheckedExpression::CharacterConstant(*c, *span), err)
+            (CheckedExpression::CharacterConstant(c.clone(), *span), err)
         }
         ParsedExpression::Var(v, span) => {
             if let Some(var) = project.find_var_in_scope(scope_id, v) {


### PR DESCRIPTION
CharacterLiteral instead of storing a char it stores a string.
This way we can now store an escape sequence.

Solves #276