### PR TITLE
typechecker: Do not generate an implicit constructor for extern classes

### DIFF
--- a/samples/strings/string_builder.jakt
+++ b/samples/strings/string_builder.jakt
@@ -1,4 +1,5 @@
 extern struct StringBuilder {
+    function StringBuilder() -> StringBuilder
     function append(mutable this, anonymous s: raw c_char)
     function to_string(mutable this) -> String
 }

--- a/src/typechecker.rs
+++ b/src/typechecker.rs
@@ -1954,7 +1954,7 @@ fn typecheck_struct(
             //      ImplicitConstructor class.
             project.functions[constructor_id].linkage = FunctionLinkage::ExternalClassConstructor;
         }
-    } else {
+    } else if structure.definition_linkage != DefinitionLinkage::External {
         // No constructor found, so let's make one
 
         let mut constructor_params = Vec::new();


### PR DESCRIPTION
Extern classes and structs should not have any generated methods for
them, including constructors. This commit prevents implicit constructors
from being generated for them.

Depends on #302 