### PR TITLE
typechecker: Introduce the ability to add a hint to a typechecker error and start making use of it

### DIFF
--- a/samples/arrays/array_bad.error
+++ b/samples/arrays/array_bad.error
@@ -1,1 +1,1 @@
-does not match type of previous values in vector
+type 'String' does not match type 'i64' of previous values in array

--- a/src/codegen.rs
+++ b/src/codegen.rs
@@ -57,7 +57,7 @@ fn codegen_namespace(project: &Project, scope: &Scope) -> String {
         }
     }
 
-    for (_, enum_id) in &scope.enums {
+    for (_, enum_id, _) in &scope.enums {
         let enum_ = &project.enums[*enum_id];
         let enum_output = codegen_enum_predecl(enum_, project);
 
@@ -126,7 +126,7 @@ fn codegen_namespace(project: &Project, scope: &Scope) -> String {
 
     output.push('\n');
 
-    for (_, enum_id) in &scope.enums {
+    for (_, enum_id, _) in &scope.enums {
         let enum_ = &project.enums[*enum_id];
         if seen_types.contains(&enum_.type_id) {
             continue;

--- a/src/codegen.rs
+++ b/src/codegen.rs
@@ -2632,7 +2632,7 @@ fn extract_dependencies_from(
 fn produce_type_dependency_graph(project: &Project, scope: &Scope) -> HashMap<TypeId, Vec<TypeId>> {
     let mut graph = HashMap::new();
 
-    for (_, type_id) in &scope.types {
+    for (_, type_id, _) in &scope.types {
         let mut deps = HashSet::new();
         extract_dependencies_from(project, *type_id, &mut deps, &graph, true);
         graph.insert(*type_id, deps.into_iter().collect());

--- a/src/codegen.rs
+++ b/src/codegen.rs
@@ -140,7 +140,7 @@ fn codegen_namespace(project: &Project, scope: &Scope) -> String {
 
     output.push('\n');
 
-    for (_, function_id) in &scope.functions {
+    for (_, function_id, _) in &scope.functions {
         let function = &project.functions[*function_id];
         if function.linkage == FunctionLinkage::ImplicitEnumConstructor {
             continue;
@@ -156,7 +156,7 @@ fn codegen_namespace(project: &Project, scope: &Scope) -> String {
 
     output.push('\n');
 
-    for (_, function_id) in &scope.functions {
+    for (_, function_id, _) in &scope.functions {
         let function = &project.functions[*function_id];
         if function.linkage == FunctionLinkage::External
             || function.linkage == FunctionLinkage::ImplicitConstructor
@@ -182,7 +182,7 @@ fn codegen_namespace(project: &Project, scope: &Scope) -> String {
         }
 
         let scope = &project.scopes[structure.scope_id];
-        for (_, function_id) in &scope.functions {
+        for (_, function_id, _) in &scope.functions {
             let function = &project.functions[*function_id];
             if function.linkage != FunctionLinkage::ImplicitConstructor {
                 let function_output =
@@ -922,7 +922,7 @@ fn codegen_struct(structure: &CheckedStruct, project: &Project) -> String {
     }
 
     let scope = &project.scopes[structure.scope_id];
-    for (_, function_id) in &scope.functions {
+    for (_, function_id, _) in &scope.functions {
         let function = &project.functions[*function_id];
         if function.linkage == FunctionLinkage::ImplicitConstructor {
             let function_output = codegen_constructor(function, project);

--- a/src/codegen.rs
+++ b/src/codegen.rs
@@ -47,7 +47,7 @@ fn codegen_namespace(project: &Project, scope: &Scope) -> String {
         }
     }
 
-    for (_, struct_id) in &scope.structs {
+    for (_, struct_id, _) in &scope.structs {
         let structure = &project.structs[*struct_id];
         let struct_output = codegen_struct_predecl(structure, project);
 
@@ -111,7 +111,7 @@ fn codegen_namespace(project: &Project, scope: &Scope) -> String {
         }
     }
 
-    for (_, struct_id) in &scope.structs {
+    for (_, struct_id, _) in &scope.structs {
         let structure = &project.structs[*struct_id];
         if seen_types.contains(&structure.type_id) {
             continue;
@@ -171,7 +171,7 @@ fn codegen_namespace(project: &Project, scope: &Scope) -> String {
         }
     }
 
-    for (_, struct_id) in &scope.structs {
+    for (_, struct_id, _) in &scope.structs {
         let struct_id = *struct_id;
         let structure = &project.structs[struct_id];
         if structure.definition_linkage == DefinitionLinkage::External {

--- a/src/error.rs
+++ b/src/error.rs
@@ -13,6 +13,7 @@ pub enum JaktError {
     ParserError(String, Span),
     ValidationError(String, Span),
     TypecheckError(String, Span),
+    TypecheckErrorWithHint(String, Span, String, Span),
 }
 
 impl From<std::io::Error> for JaktError {

--- a/src/typechecker.rs
+++ b/src/typechecker.rs
@@ -352,15 +352,17 @@ impl Project {
     ) -> Result<(), JaktError> {
         let scope = &mut self.scopes[scope_id];
 
-        for (existing_function, _) in &scope.functions {
+        for (existing_function, _, definition_span) in &scope.functions {
             if &name == existing_function {
-                return Err(JaktError::TypecheckError(
+                return Err(JaktError::TypecheckErrorWithHint(
                     format!("redefinition of function {}", name),
                     span,
+                    format!("function {} was first defined here", name),
+                    *definition_span,
                 ));
             }
         }
-        scope.functions.push((name, function_id));
+        scope.functions.push((name, function_id, span));
 
         Ok(())
     }
@@ -1018,7 +1020,7 @@ pub struct Scope {
     pub namespace_name: Option<String>,
     pub vars: Vec<CheckedVariable>,
     pub structs: Vec<(String, StructId)>,
-    pub functions: Vec<(String, FunctionId)>,
+    pub functions: Vec<(String, FunctionId, Span)>,
     pub enums: Vec<(String, EnumId)>,
     pub types: Vec<(String, TypeId)>,
     pub parent: Option<ScopeId>,

--- a/src/typechecker.rs
+++ b/src/typechecker.rs
@@ -257,15 +257,17 @@ impl Project {
         span: Span,
     ) -> Result<(), JaktError> {
         let scope = &mut self.scopes[scope_id];
-        for (existing_enum, _) in &scope.enums {
+        for (existing_enum, _, definition_span) in &scope.enums {
             if &name == existing_enum {
-                return Err(JaktError::TypecheckError(
+                return Err(JaktError::TypecheckErrorWithHint(
                     format!("redefinition of enum {}", name),
                     span,
+                    format!("enum {} was first defined here", name),
+                    *definition_span,
                 ));
             }
         }
-        scope.enums.push((name, enum_id));
+        scope.enums.push((name, enum_id, span));
 
         Ok(())
     }
@@ -1023,7 +1025,7 @@ pub struct Scope {
     pub vars: Vec<CheckedVariable>,
     pub structs: Vec<(String, StructId, Span)>,
     pub functions: Vec<(String, FunctionId, Span)>,
-    pub enums: Vec<(String, EnumId)>,
+    pub enums: Vec<(String, EnumId, Span)>,
     pub types: Vec<(String, TypeId)>,
     pub parent: Option<ScopeId>,
     // Namespaces may also have children that are also namespaces

--- a/src/typechecker.rs
+++ b/src/typechecker.rs
@@ -234,15 +234,17 @@ impl Project {
         span: Span,
     ) -> Result<(), JaktError> {
         let scope = &mut self.scopes[scope_id];
-        for (existing_struct, _) in &scope.structs {
+        for (existing_struct, _, definition_span) in &scope.structs {
             if &name == existing_struct {
-                return Err(JaktError::TypecheckError(
+                return Err(JaktError::TypecheckErrorWithHint(
                     format!("redefinition of struct/class {}", name),
                     span,
+                    format!("struct/class {} was first defined here", name),
+                    *definition_span,
                 ));
             }
         }
-        scope.structs.push((name, struct_id));
+        scope.structs.push((name, struct_id, span));
 
         Ok(())
     }
@@ -1019,7 +1021,7 @@ pub struct CheckedCall {
 pub struct Scope {
     pub namespace_name: Option<String>,
     pub vars: Vec<CheckedVariable>,
-    pub structs: Vec<(String, StructId)>,
+    pub structs: Vec<(String, StructId, Span)>,
     pub functions: Vec<(String, FunctionId, Span)>,
     pub enums: Vec<(String, EnumId)>,
     pub types: Vec<(String, TypeId)>,

--- a/src/typechecker.rs
+++ b/src/typechecker.rs
@@ -400,15 +400,17 @@ impl Project {
     ) -> Result<(), JaktError> {
         let scope = &mut self.scopes[scope_id];
 
-        for (existing_type, _) in &scope.types {
+        for (existing_type, _, definition_span) in &scope.types {
             if &type_name == existing_type {
-                return Err(JaktError::TypecheckError(
+                return Err(JaktError::TypecheckErrorWithHint(
                     format!("redefinition of type {}", type_name),
                     span,
+                    format!("type {} was first defined here", type_name),
+                    *definition_span,
                 ));
             }
         }
-        scope.types.push((type_name, type_id));
+        scope.types.push((type_name, type_id, span));
 
         Ok(())
     }
@@ -1026,7 +1028,7 @@ pub struct Scope {
     pub structs: Vec<(String, StructId, Span)>,
     pub functions: Vec<(String, FunctionId, Span)>,
     pub enums: Vec<(String, EnumId, Span)>,
-    pub types: Vec<(String, TypeId)>,
+    pub types: Vec<(String, TypeId, Span)>,
     pub parent: Option<ScopeId>,
     // Namespaces may also have children that are also namespaces
     pub children: Vec<ScopeId>,

--- a/tests/typechecker/dictionary_mismatching_key_types.error
+++ b/tests/typechecker/dictionary_mismatching_key_types.error
@@ -1,0 +1,1 @@
+type 'String' does not match type 'i64' of previous keys in dictionary

--- a/tests/typechecker/dictionary_mismatching_key_types.jakt
+++ b/tests/typechecker/dictionary_mismatching_key_types.jakt
@@ -1,0 +1,3 @@
+function main() {
+    let x = [1: 1, "2": 2, 3: 3]
+}

--- a/tests/typechecker/dictionary_mismatching_value_types.error
+++ b/tests/typechecker/dictionary_mismatching_value_types.error
@@ -1,0 +1,1 @@
+type 'String' does not match type 'i64' of previous values in dictionary

--- a/tests/typechecker/dictionary_mismatching_value_types.jakt
+++ b/tests/typechecker/dictionary_mismatching_value_types.jakt
@@ -1,0 +1,3 @@
+function main() {
+    let x = [1: 1, 2: "2", 3: 3]
+}

--- a/tests/typechecker/set_mismatching_value_types.error
+++ b/tests/typechecker/set_mismatching_value_types.error
@@ -1,0 +1,1 @@
+type 'String' does not match type 'i64' of previous values in set

--- a/tests/typechecker/set_mismatching_value_types.jakt
+++ b/tests/typechecker/set_mismatching_value_types.jakt
@@ -1,0 +1,3 @@
+function main() {
+    let x = {1, "2", 3}
+}


### PR DESCRIPTION
This allows you to show a hint on how to fix an error, for example:
```
Error: type 'String' does not match type 'i64' of previous values in array
----
 2 | function foo() throws {
 3 |     let p = [1, 2, "foo"]
                        ^- type 'String' does not match type 'i64' of previous values in array
 4 | }
----
Hint: array was inferred to store type 'i64' here
----
 2 | function foo() throws {
 3 |     let p = [1, 2, "foo"]
                  ^- array was inferred to store type 'i64' here
 4 | }
----
```
```
Error: redefinition of function foo
----
 3 |  
 4 | function foo() { 
              ^- redefinition of function foo
 5 |      
----
Hint: function foo was first defined here
----
 0 | function foo() { 
              ^- function foo was first defined here
 1 |  
----
```
```
Error: redefinition of variable a
----
 1 |     let a = 1; 
 2 |     let a = 2; 
             ^- redefinition of variable a
 3 | } 
----
Hint: variable a was first defined here
----
 0 | function foo() { 
 1 |     let a = 1; 
             ^- variable a was first defined here
 2 |     let a = 2; 
----
```