### PR TITLE
Parser: Fix infinite loop on arrays with multiple expressions

### DIFF
--- a/src/parser.rs
+++ b/src/parser.rs
@@ -3817,6 +3817,7 @@ pub fn parse_array(tokens: &[Token], index: &mut usize) -> (ParsedExpression, Op
                         "Can't fill an Array with more than one expression".to_string(),
                         tokens[*index].span,
                     )));
+                    *index += 1;
                 }
             }
             _ => {

--- a/tests/parser/multiple-expressions-in-array.error
+++ b/tests/parser/multiple-expressions-in-array.error
@@ -1,0 +1,1 @@
+Can't fill an Array with more than one expression

--- a/tests/parser/multiple-expressions-in-array.jakt
+++ b/tests/parser/multiple-expressions-in-array.jakt
@@ -1,0 +1,3 @@
+function foo() {
+    let a = [1, 2, 3;1]
+}


### PR DESCRIPTION
This fix makes the parser not go into an infinite loop after
encountering an array item with multiple expressions.

Fixes #300