### PR TITLE
parser: Properly handle shorthand in parse_typename

### DIFF
--- a/samples/arrays/shorthand_optional.jakt
+++ b/samples/arrays/shorthand_optional.jakt
@@ -1,0 +1,8 @@
+function main() {
+    let a: [i64]? = None
+    let b: [i64]? = [1, 2, 3]
+
+    println("{}", a.has_value())
+    println("{}", b.has_value())
+    println("{}", b.value()[2])
+}

--- a/samples/arrays/shorthand_optional.out
+++ b/samples/arrays/shorthand_optional.out
@@ -1,0 +1,3 @@
+false
+true
+3


### PR DESCRIPTION
Previously, we would exit early from `parse_typename` as soon as
we finished parsing a valid shorthand type. This commit makes it
so that we always run the remaining code checking for the post-fix
`?` indicating an optional.

Closes #311