### PR TITLE
docs: Fix dictionary example in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,7 +219,7 @@ let values = ["foo", "bar", "baz"]
 function main() {
     let dict = ["a": 1, "b": 2]
 
-    println("{}", dict["a"]!)
+    println("{}", dict["a"])
 }
 ```
 


### PR DESCRIPTION
Indexing into a dictionary does not return an optional value, so
having an `!` to unwrap it is incorrect.