### PR TITLE
typechecker: Make dictionary index return non-optional value

### DIFF
--- a/samples/dictionaries/dict_index_unwrap.error
+++ b/samples/dictionaries/dict_index_unwrap.error
@@ -1,0 +1,1 @@
+Forced unwrap only works on Optional

--- a/samples/dictionaries/dict_index_unwrap.jakt
+++ b/samples/dictionaries/dict_index_unwrap.jakt
@@ -1,0 +1,4 @@
+function main() {
+    let a = [1:2, 3:4]
+    println("{}", a[1]!)
+}

--- a/src/typechecker.rs
+++ b/src/typechecker.rs
@@ -3677,16 +3677,7 @@ pub fn typecheck_expression(
                 Type::GenericInstance(parent_struct_id, inner_type_ids)
                     if parent_struct_id == &dict_struct_id =>
                 {
-                    let value_type_id = inner_type_ids[1];
-                    let optional_struct_id = project
-                        .find_struct_in_scope(0, "Optional")
-                        .expect("internal error: Optional builtin definition not found");
-
-                    let inner_type_id = project.find_or_add_type_id(Type::GenericInstance(
-                        optional_struct_id,
-                        vec![value_type_id],
-                    ));
-                    expr_type_id = inner_type_id;
+                    expr_type_id = inner_type_ids[1];
 
                     let (expr_type_id, err) = unify_with_type_hint(project, &expr_type_id);
                     error = error.or(err);


### PR DESCRIPTION
Previously we were returning Optional<ValueType> even though the
generated code actually unwrapped the value.

Closes #314