### PR TITLE
editors: Add single quote literal to vscode

### DIFF
--- a/editors/vscode/syntaxes/jakt.tmLanguage.json
+++ b/editors/vscode/syntaxes/jakt.tmLanguage.json
@@ -55,13 +55,21 @@
           "name": "meta.block.jakt",
           "begin": "(\\{)",
           "beginCaptures": {
-            "1": { "name": "punctuation.begin.brace.jakt" }
+            "1": {
+              "name": "punctuation.begin.brace.jakt"
+            }
           },
           "end": "(\\})",
           "endCaptures": {
-            "1": { "name": "punctuation.end.brace.jakt" }
+            "1": {
+              "name": "punctuation.end.brace.jakt"
+            }
           },
-          "patterns": [{ "include": "$self" }]
+          "patterns": [
+            {
+              "include": "$self"
+            }
+          ]
         }
       ]
     },
@@ -74,16 +82,30 @@
       "comment": "FIXME: The identifier matching is identical to the lexer but more characters may be allowed in the future.",
       "begin": "\\b(let)(\\s+mutable)?\\s+((?:\\w|_)(?:\\w|_|[0-9])*)\\s*(:)?",
       "beginCaptures": {
-        "1": { "name": "keyword.let.jakt" },
-        "2": { "name": "storage.modifier.mutable.jakt" },
-        "3": { "name": "variable.other.jakt" },
-        "4": { "name": "punctuation.colon.jakt" }
+        "1": {
+          "name": "keyword.let.jakt"
+        },
+        "2": {
+          "name": "storage.modifier.mutable.jakt"
+        },
+        "3": {
+          "name": "variable.other.jakt"
+        },
+        "4": {
+          "name": "punctuation.colon.jakt"
+        }
       },
       "end": "((?:\\+|\\-|\\*|\\/|%)?=)",
       "endCaptures": {
-        "1": { "name": "keyword.operator.assignment.jakt" }
+        "1": {
+          "name": "keyword.operator.assignment.jakt"
+        }
       },
-      "patterns": [{ "include": "#types" }]
+      "patterns": [
+        {
+          "include": "#types"
+        }
+      ]
     },
     "struct": {
       "patterns": [
@@ -91,20 +113,30 @@
           "name": "meta.type.struct.jakt",
           "match": "(\\bextern\\s+)?\\b(class|struct)\\s+((?:\\w|_)(?:\\w|_|[0-9])*)",
           "captures": {
-            "1": { "name": "storage.modifier.linkage.jakt" },
-            "2": { "name": "keyword.type.struct.jakt" },
-            "3": { "name": "entity.name.type.struct.jakt" }
+            "1": {
+              "name": "storage.modifier.linkage.jakt"
+            },
+            "2": {
+              "name": "keyword.type.struct.jakt"
+            },
+            "3": {
+              "name": "entity.name.type.struct.jakt"
+            }
           }
         },
         {
           "name": "meta.block.struct.jakt",
           "begin": "(?<=(?:class|struct).*?)(\\{)",
           "beginCaptures": {
-            "1": { "name": "punctuation.begin.brace.jakt" }
+            "1": {
+              "name": "punctuation.begin.brace.jakt"
+            }
           },
           "end": "(\\})",
           "endCaptures": {
-            "1": { "name": "punctuation.end.brace.jakt" }
+            "1": {
+              "name": "punctuation.end.brace.jakt"
+            }
           },
           "patterns": [
             {
@@ -115,41 +147,68 @@
             }
           ]
         },
-
         {
           "name": "meta.type.generic-arguments.jakt",
           "begin": "(?<=(?:class|struct|enum).*?)\\s*(<)",
           "beginCaptures": {
-            "1": { "name": "punctuation.begin.angle-bracket.jakt" }
+            "1": {
+              "name": "punctuation.begin.angle-bracket.jakt"
+            }
           },
           "end": "(>)",
           "endCaptures": {
-            "1": { "name": "punctuation.end.angle-bracket.jakt" }
+            "1": {
+              "name": "punctuation.end.angle-bracket.jakt"
+            }
           },
-          "patterns": [{ "include": "#types" }]
+          "patterns": [
+            {
+              "include": "#types"
+            }
+          ]
         },
         {
           "name": "meta.type.enum.body.jakt",
           "begin": "(?<=enum.*?)(\\{)",
           "beginCaptures": {
-            "1": { "name": "punctuation.begin.brace.jakt" }
+            "1": {
+              "name": "punctuation.begin.brace.jakt"
+            }
           },
           "end": "(\\})",
           "endCaptures": {
-            "1": { "name": "punctuation.end.brace.jakt" }
+            "1": {
+              "name": "punctuation.end.brace.jakt"
+            }
           },
-          "patterns": [{ "include": "#enum-field" }]
+          "patterns": [
+            {
+              "include": "#enum-field"
+            }
+          ]
         },
         {
           "name": "meta.type.enum.jakt",
           "match": "(?:\\b(ref)\\s+)?\\b(enum)\\s+((?:\\w|_)(?:\\w|_|[0-9])*)\\s*(?:(:)\\s*((?:[ui](?:8|16|32|64))|usize))?",
           "captures": {
-            "1": { "name": "storage.modifier.pointer.jakt" },
-            "2": { "name": "keyword.type.enum.jakt" },
-            "3": { "name": "entity.name.type.enum.jakt" },
-            "4": { "name": "punctuation.colon.jakt" },
-            "5": { "name": "storage.type.numeric.jakt" },
-            "6": { "name": "punctuation.begin.brace.jakt" }
+            "1": {
+              "name": "storage.modifier.pointer.jakt"
+            },
+            "2": {
+              "name": "keyword.type.enum.jakt"
+            },
+            "3": {
+              "name": "entity.name.type.enum.jakt"
+            },
+            "4": {
+              "name": "punctuation.colon.jakt"
+            },
+            "5": {
+              "name": "storage.type.numeric.jakt"
+            },
+            "6": {
+              "name": "punctuation.begin.brace.jakt"
+            }
           }
         }
       ]
@@ -158,12 +217,22 @@
       "name": "meta.field.jakt",
       "begin": "(?:\\b(public|private)\\s+)?\\b((?:\\w|_)(?:\\w|_|[0-9])*)\\s*(:)",
       "beginCaptures": {
-        "1": { "name": "storage.modifier.visibility.jakt" },
-        "2": { "name": "variable.field.jakt" },
-        "3": { "name": "punctuation.colon.jakt" }
+        "1": {
+          "name": "storage.modifier.visibility.jakt"
+        },
+        "2": {
+          "name": "variable.field.jakt"
+        },
+        "3": {
+          "name": "punctuation.colon.jakt"
+        }
       },
       "end": "$",
-      "patterns": [{ "include": "#types" }]
+      "patterns": [
+        {
+          "include": "#types"
+        }
+      ]
     },
     "enum-field": {
       "patterns": [
@@ -171,23 +240,39 @@
           "name": "meta.field.enum.jakt",
           "begin": "\\b((?:\\w|_)(?:\\w|_|[0-9])*)\\s*(\\{)",
           "beginCaptures": {
-            "1": { "name": "variable.field.enum.jakt" },
-            "2": { "name": "punctuation.begin.brace.jakt" }
+            "1": {
+              "name": "variable.field.enum.jakt"
+            },
+            "2": {
+              "name": "punctuation.begin.brace.jakt"
+            }
           },
           "end": "(\\})",
           "endCaptures": {
-            "1": { "name": "punctuation.end.brace.jakt" }
+            "1": {
+              "name": "punctuation.end.brace.jakt"
+            }
           },
-          "patterns": [{ "include": "#field" }]
+          "patterns": [
+            {
+              "include": "#field"
+            }
+          ]
         },
         {
           "name": "meta.field.assigned.enum.jakt",
           "begin": "(=)",
           "beginCaptures": {
-            "1": { "name": "punctuation.equals.jakt" }
+            "1": {
+              "name": "punctuation.equals.jakt"
+            }
           },
           "end": "$",
-          "patterns": [{ "include": "#number" }]
+          "patterns": [
+            {
+              "include": "#number"
+            }
+          ]
         },
         {
           "include": "#field"
@@ -196,7 +281,9 @@
           "name": "meta.field.enum.jakt",
           "match": "\\b((?:\\w|_)(?:\\w|_|[0-9])*)\\s*$",
           "captures": {
-            "1": { "name": "variable.field.enum.jakt" }
+            "1": {
+              "name": "variable.field.enum.jakt"
+            }
           }
         }
       ]
@@ -218,22 +305,36 @@
         {
           "match": "\\b(?:[A-Z]|_)(?:\\w|_|[0-9])*\\s*(::)",
           "captures": {
-            "1": { "name": "entity.name.namespace.jakt" },
-            "2": { "name": "punctuation.double-colon.jakt" }
+            "1": {
+              "name": "entity.name.namespace.jakt"
+            },
+            "2": {
+              "name": "punctuation.double-colon.jakt"
+            }
           }
         },
         {
           "name": "storage.type.generic.jakt",
           "begin": "\\b((?:[A-Z]|_)(?:\\w|_|[0-9])*)\\s*(<)",
           "beginCaptures": {
-            "1": { "name": "storage.type.other.jakt" },
-            "2": { "name": "punctuation.begin.angle-bracket.jakt" }
+            "1": {
+              "name": "storage.type.other.jakt"
+            },
+            "2": {
+              "name": "punctuation.begin.angle-bracket.jakt"
+            }
           },
           "end": "(>)",
           "endCaptures": {
-            "1": { "name": "punctuation.end.angle-bracket.jakt" }
+            "1": {
+              "name": "punctuation.end.angle-bracket.jakt"
+            }
           },
-          "patterns": [{ "include": "#types" }]
+          "patterns": [
+            {
+              "include": "#types"
+            }
+          ]
         },
         {
           "name": "storage.type.other.jakt",
@@ -243,13 +344,21 @@
           "name": "storage.type.array.jakt",
           "begin": "(\\[)",
           "beginCaptures": {
-            "1": { "name": "punctuation.begin.square-bracket.jakt" }
+            "1": {
+              "name": "punctuation.begin.square-bracket.jakt"
+            }
           },
           "end": "(\\])",
           "endCaptures": {
-            "1": { "name": "punctuation.end.square-bracket.jakt" }
+            "1": {
+              "name": "punctuation.end.square-bracket.jakt"
+            }
           },
-          "patterns": [{ "include": "#types" }]
+          "patterns": [
+            {
+              "include": "#types"
+            }
+          ]
         },
         {
           "name": "storage.type.optional.jakt",
@@ -267,58 +376,100 @@
           "name": "meta.function.declaration.jakt",
           "match": "(?:\\b(public|private)\\s+)?(\\bextern\\s+)?(\\bfunction)\\s+((?:\\w|_)(?:\\w|_|[0-9])*)",
           "captures": {
-            "1": { "name": "storage.modifier.visibility.jakt" },
-            "2": { "name": "storage.modifier.linkage.jakt" },
-            "3": { "name": "keyword.function.jakt" },
-            "4": { "name": "entity.name.function" },
-            "5": { "name": "punctuation.begin.bracket" }
+            "1": {
+              "name": "storage.modifier.visibility.jakt"
+            },
+            "2": {
+              "name": "storage.modifier.linkage.jakt"
+            },
+            "3": {
+              "name": "keyword.function.jakt"
+            },
+            "4": {
+              "name": "entity.name.function"
+            },
+            "5": {
+              "name": "punctuation.begin.bracket"
+            }
           }
         },
         {
           "name": "meta.function.argument-list.jakt",
           "begin": "(?<=function.*?)(\\()",
           "beginCaptures": {
-            "1": { "name": "punctuation.begin.bracket" }
+            "1": {
+              "name": "punctuation.begin.bracket"
+            }
           },
           "end": "(\\))",
           "endCaptures": {
-            "1": { "name": "punctuation.end.bracket" }
+            "1": {
+              "name": "punctuation.end.bracket"
+            }
           },
-          "patterns": [{ "include": "#argument-list" }]
+          "patterns": [
+            {
+              "include": "#argument-list"
+            }
+          ]
         },
         {
           "name": "meta.function.return-type.jakt",
           "begin": "(?<=\\)\\s*)(throws)?\\s*(\\-\\>)",
           "beginCaptures": {
-            "1": { "name": "keyword.type.throws.jakt" },
-            "2": { "name": "punctuation.arrow.thin.jakt" }
+            "1": {
+              "name": "keyword.type.throws.jakt"
+            },
+            "2": {
+              "name": "punctuation.arrow.thin.jakt"
+            }
           },
           "end": "(?=\\{|$)",
-          "patterns": [{ "include": "#types" }]
+          "patterns": [
+            {
+              "include": "#types"
+            }
+          ]
         },
         {
           "name": "meta.function.body.jakt",
           "begin": "(?<=function.*?)(\\{)",
           "beginCaptures": {
-            "1": { "name": "punctuation.begin.brace.jakt" }
+            "1": {
+              "name": "punctuation.begin.brace.jakt"
+            }
           },
           "end": "(\\})",
           "endCaptures": {
-            "1": { "name": "punctuation.end.brace.jakt" }
+            "1": {
+              "name": "punctuation.end.brace.jakt"
+            }
           },
-          "patterns": [{ "include": "$self" }]
+          "patterns": [
+            {
+              "include": "$self"
+            }
+          ]
         },
         {
           "name": "meta.function.generic-arguments.jakt",
           "begin": "(?<=function.*?)(<)",
           "beginCaptures": {
-            "1": { "name": "punctuation.begin.angle-bracket.jakt" }
+            "1": {
+              "name": "punctuation.begin.angle-bracket.jakt"
+            }
           },
           "end": "(>)",
           "endCaptures": {
-            "1": { "name": "punctuation.end.angle-bracket.jakt" }
+            "1": {
+              "name": "punctuation.end.angle-bracket.jakt"
+            }
           },
-          "patterns": [{ "include": "#types" }]
+          "patterns": [
+            {
+              "include": "#types"
+            }
+          ]
         }
       ]
     },
@@ -334,22 +485,36 @@
         {
           "match": "\\b(mutable)\\s+(this)\\b",
           "captures": {
-            "1": { "name": "storage.modifier.mutable.argument.jakt" },
-            "2": { "name": "variable.language.this.jakt" }
+            "1": {
+              "name": "storage.modifier.mutable.argument.jakt"
+            },
+            "2": {
+              "name": "variable.language.this.jakt"
+            }
           }
         },
         {
           "name": "meta.argument.jakt",
           "begin": "\\b((?:\\w|_)(?:\\w|_|[0-9])*)\\s*(:)",
           "beginCaptures": {
-            "1": { "name": "variable.parameter.jakt" },
-            "2": { "name": "punctuation.colon.jakt" }
+            "1": {
+              "name": "variable.parameter.jakt"
+            },
+            "2": {
+              "name": "punctuation.colon.jakt"
+            }
           },
           "end": "$|(,)|(?:(?=\\)))",
           "endCaptures": {
-            "1": { "name": "punctuation.comma.jakt" }
+            "1": {
+              "name": "punctuation.comma.jakt"
+            }
           },
-          "patterns": [{ "include": "#types" }]
+          "patterns": [
+            {
+              "include": "#types"
+            }
+          ]
         },
         {
           "name": "punctuation.comma.jakt",
@@ -363,14 +528,24 @@
           "name": "meta.parameter.jakt",
           "begin": "\\b((?:\\w|_)(?:\\w|_|[0-9])*)\\s*(:)(?!\\:)",
           "beginCaptures": {
-            "1": { "name": "variable.parameter.name.jakt" },
-            "2": { "name": "punctuation.colon.jakt" }
+            "1": {
+              "name": "variable.parameter.name.jakt"
+            },
+            "2": {
+              "name": "punctuation.colon.jakt"
+            }
           },
           "end": "$|(,)|(?=\\))",
           "endCaptures": {
-            "1": { "name": "punctuation.comma.jakt" }
+            "1": {
+              "name": "punctuation.comma.jakt"
+            }
           },
-          "patterns": [{ "include": "$self" }]
+          "patterns": [
+            {
+              "include": "$self"
+            }
+          ]
         },
         {
           "name": "punctuation.comma.jakt",
@@ -387,37 +562,59 @@
           "name": "meta.pattern.enum.jakt",
           "match": "\\b((?:[A-Z]|_)(?:\\w|_|[0-9])*)(::)",
           "captures": {
-            "1": { "name": "entity.name.type.enum.jakt" },
-            "2": { "name": "punctuation.double-colon.jakt" }
+            "1": {
+              "name": "entity.name.type.enum.jakt"
+            },
+            "2": {
+              "name": "punctuation.double-colon.jakt"
+            }
           }
         },
         {
           "name": "meta.pattern.enum.variant.tuple.jakt",
           "begin": "\\b((?:[A-Z]|_)(?:\\w|_|[0-9])*)\\s*(\\()",
           "beginCaptures": {
-            "1": { "name": "entity.name.type.enum.jakt" },
-            "2": { "name": "punctuation.begin.bracket.jakt" }
+            "1": {
+              "name": "entity.name.type.enum.jakt"
+            },
+            "2": {
+              "name": "punctuation.begin.bracket.jakt"
+            }
           },
           "end": "(\\))",
           "endCaptures": {
-            "1": { "name": "punctuation.end.bracket.jakt" }
+            "1": {
+              "name": "punctuation.end.bracket.jakt"
+            }
           },
-          "patterns": [{ "include": "#parameter-list" }]
+          "patterns": [
+            {
+              "include": "#parameter-list"
+            }
+          ]
         },
         {
           "name": "meta.pattern.enum.variant.jakt",
           "match": "\\b((?:[A-Z]|_)(?:\\w|_|[0-9])*)\\b",
           "captures": {
-            "1": { "name": "entity.name.type.enum.jakt" }
+            "1": {
+              "name": "entity.name.type.enum.jakt"
+            }
           }
         },
         {
           "begin": "(\\=\\>)",
           "beginCaptures": {
-            "1": { "name": "keyword.operator.fat-arrow.jakt" }
+            "1": {
+              "name": "keyword.operator.fat-arrow.jakt"
+            }
           },
           "end": "$",
-          "patterns": [{ "include": "$self" }]
+          "patterns": [
+            {
+              "include": "$self"
+            }
+          ]
         },
         {
           "include": "$self"
@@ -430,35 +627,53 @@
           "name": "meta.index.struct.jakt",
           "match": "\\b((?:\\w|_)(?:\\w|_|[0-9])*)\\s*(\\.)",
           "captures": {
-            "1": { "name": "variable.other.jakt" },
-            "2": { "name": "punctuation.period.jakt" }
+            "1": {
+              "name": "variable.other.jakt"
+            },
+            "2": {
+              "name": "punctuation.period.jakt"
+            }
           }
         },
         {
           "name": "meta.index.namespace.jakt",
           "match": "\\b((?:\\w|_)(?:\\w|_|[0-9])*)\\s*(::)",
           "captures": {
-            "1": { "name": "entity.name.namespace.jakt" },
-            "2": { "name": "punctuation.double-colon.jakt" }
+            "1": {
+              "name": "entity.name.namespace.jakt"
+            },
+            "2": {
+              "name": "punctuation.double-colon.jakt"
+            }
           }
         },
         {
           "name": "meta.index.array.jakt",
           "begin": "(\\[)",
           "beginCaptures": {
-            "1": { "name": "punctuation.begin.square-bracket.jakt" }
+            "1": {
+              "name": "punctuation.begin.square-bracket.jakt"
+            }
           },
           "end": "(\\])",
           "endCaptures": {
-            "1": { "name": "punctuation.end.square-bracket.jakt" }
+            "1": {
+              "name": "punctuation.end.square-bracket.jakt"
+            }
           },
-          "patterns": [{ "include": "$self" }]
+          "patterns": [
+            {
+              "include": "$self"
+            }
+          ]
         },
         {
           "name": "meta.index.other.jakt",
           "match": "(\\.)",
           "captures": {
-            "1": { "name": "punctuation.period.jakt" }
+            "1": {
+              "name": "punctuation.period.jakt"
+            }
           }
         }
       ]
@@ -467,14 +682,24 @@
       "name": "meta.call.jakt",
       "begin": "\\b((?:\\w|_)(?:\\w|_|[0-9])*)\\s*(\\()",
       "beginCaptures": {
-        "1": { "name": "entity.name.function.call.jakt" },
-        "2": { "name": "punctuation.begin.bracket.jakt" }
+        "1": {
+          "name": "entity.name.function.call.jakt"
+        },
+        "2": {
+          "name": "punctuation.begin.bracket.jakt"
+        }
       },
       "end": "(\\))",
       "endCaptures": {
-        "1": { "name": "punctuation.end.bracket.jakt" }
+        "1": {
+          "name": "punctuation.end.bracket.jakt"
+        }
       },
-      "patterns": [{ "include": "#parameter-list" }]
+      "patterns": [
+        {
+          "include": "#parameter-list"
+        }
+      ]
     },
     "control": {
       "patterns": [
@@ -482,7 +707,9 @@
           "name": "meta.control.jakt",
           "match": "\\b(if|else|while|for|loop|try|catch|cpp|unsafe|defer|match)(?=.*?(?:\\{|$))",
           "captures": {
-            "1": { "name": "keyword.control.block.jakt" }
+            "1": {
+              "name": "keyword.control.block.jakt"
+            }
           }
         },
         {
@@ -493,13 +720,21 @@
           "name": "meta.control.match.jakt",
           "begin": "(?<=match.*?)(\\{)",
           "beginCaptures": {
-            "2": { "name": "punctuation.begin.brace.jakt" }
+            "2": {
+              "name": "punctuation.begin.brace.jakt"
+            }
           },
           "end": "(\\})",
           "endCaptures": {
-            "1": { "name": "punctuation.end.brace.jakt" }
+            "1": {
+              "name": "punctuation.end.brace.jakt"
+            }
           },
-          "patterns": [{ "include": "#match-patterns" }]
+          "patterns": [
+            {
+              "include": "#match-patterns"
+            }
+          ]
         }
       ]
     },
@@ -545,28 +780,36 @@
           "name": "constant.numeric.hex.jakt",
           "match": "\\b(?<!\\$)0(?:x|X)[0-9a-fA-F][0-9a-fA-F_]*(n|(?:[ui](?:8|16|32|64))|usize)?\\b(?!\\$)",
           "captures": {
-            "1": { "name": "storage.type.numeric.jakt" }
+            "1": {
+              "name": "storage.type.numeric.jakt"
+            }
           }
         },
         {
           "name": "constant.numeric.binary.jakt",
           "match": "\\b(?<!\\$)0(?:b|B)[01][01_]*(n|(?:[ui](?:8|16|32|64))|usize)?\\b(?!\\$)",
           "captures": {
-            "1": { "name": "storage.type.numeric.jakt" }
+            "1": {
+              "name": "storage.type.numeric.jakt"
+            }
           }
         },
         {
           "name": "constant.numeric.octal.jakt",
           "match": "\\b(?<!\\$)0(?:o|O)?[0-7][0-7_]*(n|(?:[ui](?:8|16|32|64))|usize)?\\b(?!\\$)",
           "captures": {
-            "1": { "name": "storage.type.numeric.jakt" }
+            "1": {
+              "name": "storage.type.numeric.jakt"
+            }
           }
         },
         {
           "name": "constant.numeric.jakt",
           "match": "\\b(?<!\\$)[0-9][0-9_]*(n|(?:[ui](?:8|16|32|64))|usize)?\\b(?!\\$)",
           "captures": {
-            "1": { "name": "storage.type.numeric.jakt" }
+            "1": {
+              "name": "storage.type.numeric.jakt"
+            }
           }
         }
       ],
@@ -576,7 +819,9 @@
       "patterns": [
         {
           "captures": {
-            "1": { "name": "punctuation.definition.comment.jakt" }
+            "1": {
+              "name": "punctuation.definition.comment.jakt"
+            }
           },
           "match": "(//).*$\\n?",
           "name": "comment.line.double-slash.jakt"
@@ -584,19 +829,48 @@
       ]
     },
     "strings": {
-      "name": "string.quoted.double.jakt",
-      "begin": "(\")",
-      "beginCaptures": {
-        "1": { "name": "punctuation.begin.quote.double.jakt" }
-      },
-      "end": "(\")",
-      "endCaptures": {
-        "1": { "name": "punctuation.end.quote.double.jakt" }
-      },
       "patterns": [
         {
-          "name": "constant.character.escape.jakt",
-          "match": "\\\\."
+          "name": "string.quoted.double.jakt",
+          "begin": "(\")",
+          "beginCaptures": {
+            "1": {
+              "name": "punctuation.begin.quote.double.jakt"
+            }
+          },
+          "end": "(\")",
+          "endCaptures": {
+            "1": {
+              "name": "punctuation.end.quote.double.jakt"
+            }
+          },
+          "patterns": [
+            {
+              "name": "constant.character.escape.jakt",
+              "match": "\\\\."
+            }
+          ]    
+        },
+        {
+          "name": "string.quoted.single.jakt",
+          "begin": "(')",
+          "beginCaptures": {
+            "1": {
+              "name": "punctuation.begin.quote.single.jakt"
+            }
+          },
+          "end": "(')",
+          "endCaptures": {
+            "1": {
+              "name": "punctuation.end.quote.single.jakt"
+            }
+          },
+          "patterns": [
+            {
+              "name": "constant.character.escape.jakt",
+              "match": "\\\\."
+            }
+          ]    
         }
       ]
     }


### PR DESCRIPTION
Adds the single quote character literal to the VSCode extension.
This helps with both highlighting, and the support for escaping helps prevent stray highlighing of a character literal with a
double quote.