### PR TITLE
Editors: updates to vim syntax highlighting

### DIFF
--- a/editors/vim/syntax/jakt.vim
+++ b/editors/vim/syntax/jakt.vim
@@ -1,6 +1,6 @@
 " Vim syntax file
 " Language: Jakt
-" Latest Revision: 2022-05-21
+" Latest Revision: 2022-05-25
 
 if exists("b:current_syntax")
   finish
@@ -10,54 +10,70 @@ let s:cpo_save = &cpo
 set cpo&vim
 
 let s:jakt_syntax_keywords = {
-    \   'jaktConditional': ["if"
-    \ ,                    "else"]
-    \ , 'jaktRepeat': ["while"
-    \ ,               "for"
-    \ ,               "loop"]
-    \ , 'jaktExecution': ["return"
-    \ ,                  "break"
-    \ ,                  "continue"]
-    \ , 'jaktBoolean': ["true"
-    \ ,                "false"]
-    \ , 'jaktKeyword': ["function"
-    \ ,                 "extern"]
-    \ , 'jaktException': ["throws"]
-    \ , 'jaktMacro': ["defer"
-    \ ,              "unsafe"
-    \ ,              "throw"
-    \ ,              "try"
-    \ ,              "catch"
-    \ ,              "cpp"]
-    \ , 'jaktOperator': ["not"
-    \ ,                 "and"
-    \ ,                 "or"]
-    \ , 'jaktVarDecl': ["mutable"
+    \   'jaktConditional' :["if"
+    \ ,                     "else"
+    \ ,                     "match"
+    \ ,                    ]
+    \ , 'jaktRepeat' :["while"
+    \ ,                "for"
+    \ ,                "loop"
+    \ ,               ]
+    \ , 'jaktExecution' :["return"
+    \ ,                   "break"
+    \ ,                   "continue"
+    \ ,                   "throw"
+    \ ,                  ]
+    \ , 'jaktBoolean' :["true"
+    \ ,                 "false"
+    \ ,                ]
+    \ , 'jaktKeyword' :["function"
+    \ ,                 "extern"
+    \ ,                ]
+    \ , 'jaktException' :["throws"
+    \ ,                  ]
+    \ , 'jaktMacro' :["defer"
+    \ ,               "unsafe"
+    \ ,               "try"
+    \ ,               "catch"
+    \ ,               "cpp"
+    \ ,              ]
+    \ , 'jaktWordOperator' :["not"
+    \ ,                      "and"
+    \ ,                      "or"
+    \ ,                      "as"
+    \ ,                      "in"
+    \ ,                     ]
+    \ , 'jaktVarDecl' :["mutable"
     \ ,                 "let"
     \ ,                 "anonymous"
-    \ ,                 "raw"]
-    \ , 'jaktType': ["String"
-    \ ,             "i8"
-    \ ,             "i16"
-    \ ,             "i32"
-    \ ,             "i64"
-    \ ,             "u8"
-    \ ,             "u16"
-    \ ,             "u32"
-    \ ,             "u64"
-    \ ,             "f32"
-    \ ,             "f64"
-    \ ,             "bool"
-    \ ,             "c_int"
-    \ ,             "c_char"
-    \ ,             "usize"]
-    \ , 'jaktBuiltinFn': ["print"
-    \ ,                   "println"]
-    \ , 'jaktConstant': ["this"]
-    \ , 'jaktStructure': ["struct"
-    \ ,                 "class"
-    \ ,                 "enum"]
-    \ }
+    \ ,                 "raw"
+    \ ,                ]
+    \ , 'jaktType' :["String"
+    \ ,              "i8"
+    \ ,              "i16"
+    \ ,              "i32"
+    \ ,              "i64"
+    \ ,              "u8"
+    \ ,              "u16"
+    \ ,              "u32"
+    \ ,              "u64"
+    \ ,              "f32"
+    \ ,              "f64"
+    \ ,              "bool"
+    \ ,              "c_int"
+    \ ,              "c_char"
+    \ ,              "usize"
+    \ ,             ]
+    \ , 'jaktConstant' :["this"
+    \ ,                 ]
+    \ , 'jaktStructure' :["struct"
+    \ ,                   "class"
+    \ ,                   "enum"
+    \ ,                  ]
+    \ , 'jaktVisModifier': ["public"
+    \ ,                     "private"
+    \ ,                    ]
+    \ , }
 
 function! s:syntax_keyword(dict)
   for key in keys(a:dict)
@@ -71,6 +87,16 @@ syntax match jaktDecNumber display   "\v<\d%(_?\d)*"
 syntax match jaktHexNumber display "\v<0x\x%(_?\x)*"
 syntax match jaktOctNumber display "\v<0o\o%(_?\o)*"
 syntax match jaktBinNumber display "\v<0b[01]%(_?[01])*"
+
+syntax match jaktFatArrowOperator display "\V=>"
+syntax match jaktRangeOperator display "\V.."
+syntax match jaktOperator display "\V\[-+/*=^&?|!><%~:;,]"
+
+syntax match jaktFunction /\w\+\s*(/me=e-1,he=e-1
+
+syntax match jaktEnumDecl /enum\s\+\w\+/lc=4
+syntax match jaktStructDecl /struct\s\+\w\+/lc=6
+syntax match jaktClassDecl /class\s\+\w\+/lc=5
 
 syntax region jaktBlock start="{" end="}" transparent fold
 
@@ -86,7 +112,14 @@ highlight default link jaktHexNumber jaktNumber
 highlight default link jaktOctNumber jaktNumber
 highlight default link jaktBinNumber jaktNumber
 
-highlight default link jaktBuiltinFn Statement
+highlight default link jaktWordOperator jaktOperator
+highlight default link jaktFatArrowOperator jaktOperator
+highlight default link jaktRangeOperator jaktOperator
+
+highlight default link jaktStructDecl jaktType
+highlight default link jaktClassDecl jaktType
+highlight default link jaktEnumDecl jaktType
+
 highlight default link jaktKeyword Keyword
 highlight default link jaktType Type
 highlight default link jaktCommentLine Comment
@@ -96,15 +129,16 @@ highlight default link jaktEscape Special
 highlight default link jaktBoolean Boolean
 highlight default link jaktConstant Constant
 highlight default link jaktNumber Number
-highlight default link jaktArrowCharacter jaktOperator
 highlight default link jaktOperator Operator
 highlight default link jaktStructure Structure
 highlight default link jaktExecution Special
 highlight default link jaktMacro Macro
 highlight default link jaktConditional Conditional
 highlight default link jaktRepeat Repeat
-highlight default link jaktVarDecl Function
+highlight default link jaktVarDecl Define
 highlight default link jaktException Exception
+highlight default link jaktFunction Function
+highlight default link jaktVisModifier Label
 
 delfunction s:syntax_keyword
 


### PR DESCRIPTION
* Added missing keywords and operators.
* Added highlighting for function calls and declarations.
* Added highlighting for enum, struct and class declarations.
* Changed highlight group for variable declaration keywords.
  Was `Function`, now `Define`.
* Removed builtin function highlighting. Builtin functions now
  highlighted same as regular functions.