### PR TITLE
parser: Add explicit error for fat arrow after return type specification

### DIFF
--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1564,6 +1564,26 @@ pub fn parse_function(
                     );
                 }
 
+                // Check for a fat arrow to tell the user that fat arrows aren't
+                // compatible with specifying the type
+                // TODO: add a hint explaining that fat arrows have their type deducted
+                if return_type != ParsedType::Empty
+                    && matches!(
+                        tokens[*index],
+                        Token {
+                            contents: TokenContents::FatArrow,
+                            ..
+                        }
+                    )
+                {
+                    trace!("ERROR: Fat arrow after explicit return type");
+                    error = error.or(Some(JaktError::ParserError(
+                        "Fat arrow '=>' can't be combined with an explicit return type".to_string(),
+                        tokens[*index].span,
+                    )));
+                    *index += 1; // skip the arrow
+                }
+
                 let (block, err) = match fat_arrow_expr {
                     Some(expr) => {
                         let mut block = ParsedBlock::new();

--- a/tests/parser/fat-arrow-with-return-type.error
+++ b/tests/parser/fat-arrow-with-return-type.error
@@ -1,0 +1,1 @@
+Fat arrow '=>' can't be combined with an explicit return type

--- a/tests/parser/fat-arrow-with-return-type.jakt
+++ b/tests/parser/fat-arrow-with-return-type.jakt
@@ -1,0 +1,3 @@
+class S {
+  public function get_secret() -> i32 => 42
+}


### PR DESCRIPTION
Added an explicit match to catch situations in functions where the
return type for the function is specified and a fat arrow is matched
just after, to indicate the user that a fat arrow wasn't expected
in that context instead of erroring later on a different context.

Should close #331.
