### PR TITLE
Parser: Fix infinite loop in `parse_set()`

### DIFF
--- a/src/parser.rs
+++ b/src/parser.rs
@@ -3770,9 +3770,16 @@ pub fn parse_set(tokens: &[Token], index: &mut usize) -> (ParsedExpression, Opti
                 *index += 1;
             }
             _ => {
+                let previous_index = *index;
+
                 let (expr, err) =
                     parse_expression(tokens, index, ExpressionKind::ExpressionWithoutAssignment);
                 error = error.or(err);
+
+                if *index == previous_index {
+                    break;
+                }
+
                 output.push(expr);
             }
         }


### PR DESCRIPTION
```
function main() {
    return {1:1}
}
```
Make code above error out instead of infinitely looping.