### PR TITLE
Runtime: Supress Clang warning on Array resize call

### DIFF
--- a/runtime/AK/StringBuilder.cpp
+++ b/runtime/AK/StringBuilder.cpp
@@ -77,7 +77,7 @@ StringView StringBuilder::string_view() const
 
 void StringBuilder::clear()
 {
-    m_buffer.resize(0);
+    static_cast<void>(m_buffer.resize(0));
 }
 
 ErrorOr<void> StringBuilder::try_append_code_point(u32 code_point)

--- a/runtime/Builtins/Array.h
+++ b/runtime/Builtins/Array.h
@@ -245,7 +245,7 @@ public:
         if (is_empty())
             return {};
         auto value = move(at(size() - 1));
-        resize(size() - 1);
+        static_cast<void>(resize(size() - 1));
         return value;
     }
 


### PR DESCRIPTION
By casting void we tell the compiler that we are willingly discarding the value.

fixes #320