### PR TITLE
codegen: Pass slices instead of Vec as function arguments

### DIFF
--- a/src/codegen.rs
+++ b/src/codegen.rs
@@ -1722,7 +1722,7 @@ fn codegen_match_body(
 fn codegen_enum_match(
     enum_: &CheckedEnum,
     expr: &CheckedExpression,
-    cases: &Vec<CheckedMatchCase>,
+    cases: &[CheckedMatchCase],
     return_type_id: &TypeId,
     match_values_are_all_constant: bool,
     indent: usize,
@@ -2016,7 +2016,7 @@ fn codegen_enum_match(
 
 fn codegen_generic_match(
     expr: &CheckedExpression,
-    cases: &Vec<CheckedMatchCase>,
+    cases: &[CheckedMatchCase],
     return_type_id: &TypeId,
     match_values_are_all_constant: bool,
     indent: usize,


### PR DESCRIPTION
Clippy has been showing me the following warning for a while, not sure why it's not been caught on CI:

```
error: writing `&Vec<_>` instead of `&[_]` involves one more reference and cannot be used with non-Vec-based slices
    --> src/codegen.rs:1725:12
     |
1725 |     cases: &Vec<CheckedMatchCase>,
     |            ^^^^^^^^^^^^^^^^^^^^^^ help: change this to: `&[CheckedMatchCase]`
     |
note: the lint level is defined here
    --> src/lib.rs:8:9
     |
8    | #![deny(clippy::all)]
     |         ^^^^^^^^^^^
     = note: `#[deny(clippy::ptr_arg)]` implied by `#[deny(clippy::all)]`
     = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#ptr_arg

error: writing `&Vec<_>` instead of `&[_]` involves one more reference and cannot be used with non-Vec-based slices
    --> src/codegen.rs:2019:12
     |
2019 |     cases: &Vec<CheckedMatchCase>,
     |            ^^^^^^^^^^^^^^^^^^^^^^ help: change this to: `&[CheckedMatchCase]`
     |
     = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#ptr_arg

error: could not compile `jakt` due to 2 previous errors
```