### PR TITLE
parser+typechecker: Implement `restricted(Foo,Bar,Baz)` visibility qualifier

### DIFF
--- a/samples/classes/restricted_method.jakt
+++ b/samples/classes/restricted_method.jakt
@@ -1,0 +1,17 @@
+class Limited {
+    restricted(A) function get_secret() => "Shhhh! Don't tell anyone!"
+    restricted(A,B) function open_the_bank_vault() => "Open sesame!"
+}
+
+class A {
+    public function do_things() {
+        println("The secret is: {}", Limited::get_secret())
+        println("{}", Limited::open_the_bank_vault())
+    }
+}
+
+class B {}
+
+function main() {
+    A::do_things()
+}

--- a/samples/classes/restricted_method.out
+++ b/samples/classes/restricted_method.out
@@ -1,0 +1,2 @@
+The secret is: Shhhh! Don't tell anyone!
+Open sesame!

--- a/samples/classes/restricted_method_inaccessible.error
+++ b/samples/classes/restricted_method_inaccessible.error
@@ -1,0 +1,1 @@
+Can't access function ‘get_secret’ from ‘C’, because ‘C’ is not in the restricted whitelist

--- a/samples/classes/restricted_method_inaccessible.jakt
+++ b/samples/classes/restricted_method_inaccessible.jakt
@@ -1,0 +1,19 @@
+class Limited {
+    restricted(A) function get_secret() => "Shhhh! Don't tell anyone!"
+    restricted(A,B) function open_the_bank_vault() => "Open sesame!"
+}
+
+class A {}
+
+class B {}
+
+class C {
+    public function do_things() {
+        println("The secret is: {}", Limited::get_secret())
+        println("{}", Limited::open_the_bank_vault())
+    }
+}
+
+function main() {
+    C::do_things()
+}

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -161,10 +161,11 @@ pub struct ParsedFunction {
     pub must_instantiate: bool,
 }
 
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq)]
 pub enum Visibility {
     Public,
     Private,
+    Restricted(Vec<ParsedType>, Span),
 }
 
 #[derive(Clone, Debug)]
@@ -1216,6 +1217,75 @@ pub fn parse_struct(
                         TokenContents::Name(name) if name == "private" => {
                             last_visibility = Some(Visibility::Private);
                             *index += 1;
+                            // By using continue, we skip the "visibility consumed"-check
+                            continue;
+                        }
+
+                        TokenContents::Name(name) if name == "restricted" => {
+                            let restricted_start = &tokens[*index].span;
+                            *index += 1;
+
+                            if tokens[*index].contents != TokenContents::LParen {
+                                error = error.or(Some(JaktError::ParserError(
+                                    "Expected ‘(’".to_string(),
+                                    tokens[*index].span,
+                                )));
+                                break;
+                            }
+                            *index += 1;
+
+                            let mut whitelisted_types: Vec<ParsedType> = vec![];
+                            while !matches!(
+                                tokens.get(*index),
+                                Some(Token {
+                                    contents: TokenContents::RParen,
+                                    ..
+                                }) | None
+                            ) {
+                                skip_newlines(tokens, index);
+                                let (parsed_type, err) = parse_typename(tokens, index);
+                                if err.is_some() {
+                                    error = error.or(err);
+                                    break;
+                                } else {
+                                    whitelisted_types.push(parsed_type);
+                                }
+
+                                skip_newlines(tokens, index);
+                                if tokens.get(*index).is_some()
+                                    && tokens[*index].contents == TokenContents::Comma
+                                {
+                                    *index += 1;
+                                }
+
+                                skip_newlines(tokens, index);
+                            }
+
+                            if whitelisted_types.is_empty() {
+                                error = error.or(Some(JaktError::ParserError(
+                                    "Type list cannot be empty".to_string(),
+                                    tokens[*index].span,
+                                )));
+                                break;
+                            }
+
+                            if tokens[*index].contents != TokenContents::RParen {
+                                error = error.or(Some(JaktError::ParserError(
+                                    "Expected ‘)’".to_string(),
+                                    tokens[*index].span,
+                                )));
+                                break;
+                            }
+                            *index += 1;
+
+                            last_visibility = Some(Visibility::Restricted(
+                                whitelisted_types,
+                                Span::new(
+                                    restricted_start.file_id,
+                                    restricted_start.start,
+                                    tokens[*index - 1].span.end,
+                                ),
+                            ));
                             // By using continue, we skip the "visibility consumed"-check
                             continue;
                         }

--- a/src/typechecker.rs
+++ b/src/typechecker.rs
@@ -1174,15 +1174,15 @@ impl Scope {
 
 /// A trait to collect common namespace member properties.
 trait NamespaceMember {
-    fn visibility(&self) -> Visibility;
+    fn visibility(&self) -> &Visibility;
     fn name(&self) -> String;
     /// e.g. variable, function etc.
     fn kind(&self) -> &'static str;
 }
 
 impl NamespaceMember for CheckedVarDecl {
-    fn visibility(&self) -> Visibility {
-        self.visibility
+    fn visibility(&self) -> &Visibility {
+        &self.visibility
     }
 
     fn name(&self) -> String {
@@ -1194,8 +1194,8 @@ impl NamespaceMember for CheckedVarDecl {
     }
 }
 impl NamespaceMember for CheckedVariable {
-    fn visibility(&self) -> Visibility {
-        self.visibility
+    fn visibility(&self) -> &Visibility {
+        &self.visibility
     }
 
     fn name(&self) -> String {
@@ -1207,8 +1207,8 @@ impl NamespaceMember for CheckedVariable {
     }
 }
 impl NamespaceMember for CheckedFunction {
-    fn visibility(&self) -> Visibility {
-        self.visibility
+    fn visibility(&self) -> &Visibility {
+        &self.visibility
     }
 
     fn name(&self) -> String {
@@ -1227,21 +1227,20 @@ fn check_accessibility(
     span: &Span,
     project: &Project,
 ) -> Option<JaktError> {
-    if member.visibility() != Visibility::Public
-        && !Scope::can_access(own_scope, member_scope, project)
-    {
-        Some(JaktError::TypecheckError(
-            // FIXME: Improve this error
-            format!(
-                "Can't access {} '{}' from scope {:?}",
-                member.kind(),
-                member.name(),
-                project.scopes[own_scope].namespace_name,
-            ),
-            *span,
-        ))
-    } else {
-        None
+    match member.visibility() {
+        Visibility::Private if !Scope::can_access(own_scope, member_scope, project) => {
+            Some(JaktError::TypecheckError(
+                // FIXME: Improve this error
+                format!(
+                    "Can't access {} '{}' from scope {:?}",
+                    member.kind(),
+                    member.name(),
+                    project.scopes[own_scope].namespace_name,
+                ),
+                *span,
+            ))
+        }
+        _ => None,
     }
 }
 
@@ -1615,7 +1614,7 @@ fn typecheck_enum(
                                 type_id: decl,
                                 mutable: member.mutable,
                                 span: member.span,
-                                visibility: member.visibility,
+                                visibility: member.visibility.clone(),
                             })
                         }
                     }
@@ -1639,7 +1638,7 @@ fn typecheck_enum(
                                     name: member.name.clone(),
                                     type_id: member.type_id,
                                     mutable: false,
-                                    visibility: member.visibility,
+                                    visibility: member.visibility.clone(),
                                     definition_span: *span,
                                 },
                             })
@@ -1822,7 +1821,7 @@ fn typecheck_struct_predecl(
             params: vec![],
             throws: function.throws,
             return_type_id: UNKNOWN_TYPE_ID,
-            visibility: function.visibility,
+            visibility: function.visibility.clone(),
             function_scope_id: method_scope_id,
             generic_parameters: vec![],
             block: Some(CheckedBlock::new()),
@@ -2022,7 +2021,7 @@ fn typecheck_struct(
             type_id: checked_member_type,
             mutable: unchecked_member.mutable,
             span: unchecked_member.span,
-            visibility: unchecked_member.visibility,
+            visibility: unchecked_member.visibility.clone(),
         });
     }
 
@@ -2122,7 +2121,7 @@ fn typecheck_function_predecl(
         params: vec![],
         throws: function.throws,
         return_type_id: UNKNOWN_TYPE_ID,
-        visibility: function.visibility,
+        visibility: function.visibility.clone(),
         function_scope_id,
         generic_parameters: vec![],
         block: Some(CheckedBlock::new()),
@@ -2812,7 +2811,7 @@ pub fn typecheck_statement(
                 type_id: checked_type_id,
                 span: var_decl.span,
                 mutable: var_decl.mutable,
-                visibility: var_decl.visibility,
+                visibility: var_decl.visibility.clone(),
             };
 
             if let Err(err) = project.add_var_to_scope(
@@ -2821,7 +2820,7 @@ pub fn typecheck_statement(
                     name: checked_var_decl.name.clone(),
                     type_id: checked_var_decl.type_id,
                     mutable: checked_var_decl.mutable,
-                    visibility: checked_var_decl.visibility,
+                    visibility: checked_var_decl.visibility.clone(),
                     definition_span: checked_var_decl.span,
                 },
                 checked_var_decl.span,

--- a/src/typechecker.rs
+++ b/src/typechecker.rs
@@ -1230,9 +1230,8 @@ fn check_accessibility(
     match member.visibility() {
         Visibility::Private if !Scope::can_access(own_scope, member_scope, project) => {
             Some(JaktError::TypecheckError(
-                // FIXME: Improve this error
                 format!(
-                    "Can't access {} '{}' from scope {:?}",
+                    "Can't access {} ‘{}’ from scope {:?}, because it is marked private",
                     member.kind(),
                     member.name(),
                     project.scopes[own_scope].namespace_name,

--- a/src/typechecker.rs
+++ b/src/typechecker.rs
@@ -162,6 +162,7 @@ pub struct Project {
     pub types: Vec<Type>,
 
     pub current_function_index: Option<usize>,
+    pub current_struct_type_id: Option<TypeId>,
     pub inside_defer: bool,
 
     pub cached_array_struct_id: Option<StructId>,
@@ -187,6 +188,7 @@ impl Project {
             scopes: vec![project_global_scope],
             types: Vec::new(),
             current_function_index: None,
+            current_struct_type_id: None,
             inside_defer: false,
 
             cached_array_struct_id: None,
@@ -1772,6 +1774,7 @@ fn typecheck_struct_predecl(
     let mut error = None;
 
     let struct_type_id = project.find_or_add_type_id(Type::Struct(struct_id));
+    project.current_struct_type_id = Some(struct_type_id);
 
     let struct_scope_id = project.create_scope(parent_scope_id);
 
@@ -1990,6 +1993,8 @@ fn typecheck_struct_predecl(
         }
     }
 
+    project.current_struct_type_id = None;
+
     error
 }
 
@@ -2006,6 +2011,7 @@ fn typecheck_struct(
     let checked_struct = &mut project.structs[struct_id];
     let checked_struct_scope_id = checked_struct.scope_id;
     let struct_type_id = project.find_or_add_type_id(Type::Struct(struct_id));
+    project.current_struct_type_id = Some(struct_type_id);
 
     for unchecked_member in &structure.fields {
         let (checked_member_type, err) = typecheck_typename(
@@ -2092,6 +2098,7 @@ fn typecheck_struct(
         error = error.or(typecheck_method(function, project, struct_id));
     }
 
+    project.current_struct_type_id = None;
     error
 }
 

--- a/src/typechecker.rs
+++ b/src/typechecker.rs
@@ -1227,7 +1227,7 @@ fn check_accessibility(
     member_scope: ScopeId,
     member: impl NamespaceMember,
     span: &Span,
-    project: &Project,
+    project: &mut Project,
 ) -> Option<JaktError> {
     match member.visibility() {
         Visibility::Private if !Scope::can_access(own_scope, member_scope, project) => {
@@ -1240,6 +1240,60 @@ fn check_accessibility(
                 ),
                 *span,
             ))
+        }
+        Visibility::Restricted(whitelisted_types, restricted_span) => {
+            return match project.current_struct_type_id {
+                Some(own_type_id) => {
+                    // Only structs/classes can be listed in `restricted()`.
+                    if let Type::Struct(struct_id) = project.types[own_type_id] {
+                        for whitelisted_type in whitelisted_types {
+                            let (type_id, err) =
+                                typecheck_typename(whitelisted_type, member_scope, project);
+                            if err.is_some() {
+                                return err;
+                            }
+                            if type_id == own_type_id {
+                                return None;
+                            }
+                        }
+
+                        Some(JaktError::TypecheckErrorWithHint(
+                            format!(
+                                "Can't access {} ‘{}’ from ‘{}’, because ‘{2}’ is not in the restricted whitelist",
+                                member.kind(),
+                                member.name(),
+                                project.structs[struct_id].name,
+                            ),
+                            *span,
+                            "Whitelist declared here".to_string(),
+                            *restricted_span,
+                        ))
+                    } else {
+                        Some(JaktError::TypecheckErrorWithHint(
+                            format!(
+                                "Can't access {} ‘{}’ from scope ‘{:?}’, because it is not in the restricted whitelist",
+                                member.kind(),
+                                member.name(),
+                                project.scopes[own_scope].namespace_name,
+                            ),
+                            *span,
+                            "Whitelist declared here".to_string(),
+                            *restricted_span,
+                        ))
+                    }
+                }
+                _ => Some(JaktError::TypecheckErrorWithHint(
+                    format!(
+                        "Can't access {} ‘{}’ from scope ‘{:?}’, because it is marked restricted",
+                        member.kind(),
+                        member.name(),
+                        project.scopes[own_scope].namespace_name,
+                    ),
+                    *span,
+                    "Whitelist declared here".to_string(),
+                    *restricted_span,
+                )),
+            };
         }
         _ => None,
     }
@@ -5336,6 +5390,9 @@ pub fn typecheck_call(
                 if !callee.is_instantiated {
                     generic_checked_function_to_instantiate = Some(callee_id);
                 }
+                callee_throws = callee.throws;
+                return_type_id = callee.return_type_id;
+                linkage = callee.linkage;
 
                 // Make sure we are allowed to access this method.
                 error = error.or(check_accessibility(
@@ -5345,10 +5402,6 @@ pub fn typecheck_call(
                     span,
                     project,
                 ));
-
-                callee_throws = callee.throws;
-                return_type_id = callee.return_type_id;
-                linkage = callee.linkage;
 
                 // If the user gave us explicit type arguments, let's use them in our substitutions
                 for (idx, type_arg) in call.type_args.iter().enumerate() {

--- a/tests/typechecker/class_private_default.error
+++ b/tests/typechecker/class_private_default.error
@@ -1,1 +1,1 @@
-Can't access function 'cant_touch' from scope None
+Can't access function ‘cant_touch’ from scope None, because it is marked private

--- a/tests/typechecker/class_private_field_default.error
+++ b/tests/typechecker/class_private_field_default.error
@@ -1,1 +1,1 @@
-Can't access variable 'muda_amount' from scope None
+Can't access variable ‘muda_amount’ from scope None, because it is marked private

--- a/tests/typechecker/class_private_static.error
+++ b/tests/typechecker/class_private_static.error
@@ -1,1 +1,1 @@
-Can't access function 'private_static_function' from scope None
+Can't access function ‘private_static_function’ from scope None, because it is marked private

--- a/tests/typechecker/struct_private.error
+++ b/tests/typechecker/struct_private.error
@@ -1,1 +1,1 @@
-Can't access function 'parts' from scope None
+Can't access function ‘parts’ from scope None, because it is marked private

--- a/tests/typechecker/struct_private_field.error
+++ b/tests/typechecker/struct_private_field.error
@@ -1,1 +1,1 @@
-Can't access variable 'age' from scope None
+Can't access variable ‘age’ from scope None, because it is marked private


### PR DESCRIPTION
This corresponds to the `Badge<Foo>` pattern in Serenity. A `restricted` method or field is only accessible to the types listed, allowing more granular access control than `public` and `private`.

As implemented, a `restricted(Foo, Bar) function hello() {}` is only accessible to `Foo` and `Bar`. Their subclasses cannot access it, and nor can the class where `hello()` was defined, unless it's listed. Neither of those can be done with Serenity's `Badge` either, but it might be nice to support them.