### PR TITLE
main: Silence "deprecated functions" warning on Windows

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -60,6 +60,9 @@ fn main() -> Result<(), JaktError> {
                         // These warnings if enabled create loads of unnecessary noise:
                         "-Wno-unqualified-std-cast-call",
                         "-Wno-user-defined-literals",
+                        // This warning can happen for functions like fopen which Windows has deprecated but others not.
+                        // Specifically, it will happen if clang uses the MSVC runtime and/or linker.
+                        "-Wno-deprecated-declarations",
                         "-I",
                         &runtime_path,
                         &input_cpp,


### PR DESCRIPTION
This warning can happen for functions like fopen which Windows has deprecated but others not. Specifically, it will happen if clang uses the MSVC runtime and/or linker.