### PR TITLE
parser+typechecker: Accept fat arrow with explicit return type

### DIFF
--- a/src/parser.rs
+++ b/src/parser.rs
@@ -157,6 +157,7 @@ pub struct ParsedFunction {
     pub block: ParsedBlock,
     pub throws: bool,
     pub return_type: ParsedType,
+    pub return_type_span: Option<Span>,
     pub linkage: FunctionLinkage,
     pub must_instantiate: bool,
 }
@@ -196,6 +197,7 @@ impl ParsedFunction {
             block: ParsedBlock::new(),
             throws: false,
             return_type: ParsedType::Empty,
+            return_type_span: None,
             linkage,
             must_instantiate: false,
         }
@@ -1495,48 +1497,43 @@ pub fn parse_function(
 
                 let mut return_type = ParsedType::Empty;
 
-                let mut fat_arrow_expr = None;
-
-                if *index + 2 < tokens.len() {
-                    match &tokens[*index].contents {
-                        TokenContents::FatArrow => {
-                            *index += 1;
-
-                            let (expr, err) = parse_expression(
-                                tokens,
-                                index,
-                                ExpressionKind::ExpressionWithoutAssignment,
-                            );
-                            return_type = ParsedType::Empty;
-                            fat_arrow_expr = Some(expr);
-                            error = error.or(err);
-
-                            *index += 1;
-                        }
-                        TokenContents::Minus => {
-                            *index += 1;
-
-                            match &tokens[*index].contents {
-                                TokenContents::GreaterThan => {
-                                    *index += 1;
-
-                                    let (ret_type, err) = parse_typename(tokens, index);
-                                    return_type = ret_type;
-                                    error = error.or(err);
-                                }
-                                _ => {
-                                    trace!("ERROR: expected ->");
-
-                                    error = error.or(Some(JaktError::ParserError(
-                                        "expected ->".to_string(),
-                                        tokens[*index - 1].span,
-                                    )));
-                                }
-                            }
-                        }
-                        _ => {}
+                //  accept return type specification with '->'
+                let return_type_span = if tokens[*index].contents == TokenContents::Minus {
+                    *index += 1;
+                    if tokens[*index].contents != TokenContents::GreaterThan {
+                        error = error.or(Some(JaktError::ParserError(
+                            "expected ->".to_string(),
+                            tokens[*index - 1].span,
+                        )));
                     }
-                }
+                    let start = *index;
+                    let file_id = tokens[*index].span.file_id;
+                    *index += 1;
+                    let (ret_type, err) = parse_typename(tokens, index);
+                    return_type = ret_type;
+                    error = error.or(err);
+                    Some(Span {
+                        file_id,
+                        start,
+                        end: tokens[*index - 1].span.end,
+                    })
+                } else {
+                    None
+                };
+
+                // Accept an (optional) fat arrow
+                let fat_arrow_expr = if tokens[*index].contents == TokenContents::FatArrow {
+                    *index += 1;
+                    let (expr, err) = parse_expression(
+                        tokens,
+                        index,
+                        ExpressionKind::ExpressionWithoutAssignment,
+                    );
+                    error = error.or(err);
+                    Some(expr)
+                } else {
+                    None
+                };
 
                 if *index >= tokens.len() {
                     trace!("ERROR: incomplete function");
@@ -1557,6 +1554,7 @@ pub fn parse_function(
                             block: ParsedBlock::new(),
                             throws,
                             return_type,
+                            return_type_span,
                             linkage,
                             must_instantiate: true,
                         },
@@ -1584,6 +1582,7 @@ pub fn parse_function(
                         block,
                         throws,
                         return_type,
+                        return_type_span,
                         linkage,
                         must_instantiate: false,
                     },

--- a/src/typechecker.rs
+++ b/src/typechecker.rs
@@ -2368,6 +2368,10 @@ fn typecheck_method(
         }
     }
 
+    // Set current function index before a block type check so that
+    // method return type is checked against its implementation
+    project.current_function_index = Some(method_id);
+
     let (block, err) = typecheck_block(
         &function.block,
         function_scope_id,

--- a/tests/parser/fat-arrow-with-type-specifier.jakt
+++ b/tests/parser/fat-arrow-with-type-specifier.jakt
@@ -1,0 +1,9 @@
+class S {
+    public function get_answer() -> i32 => 42
+}
+
+function greeting() -> String => "Hello"
+
+function main() {
+    println("{} friends! The answer is {}", greeting(), S::get_answer())
+}

--- a/tests/parser/fat-arrow-with-type-specifier.out
+++ b/tests/parser/fat-arrow-with-type-specifier.out
@@ -1,0 +1,1 @@
+Hello friends! The answer is 42

--- a/tests/typechecker/function-return-type-with-fat-arrow.error
+++ b/tests/typechecker/function-return-type-with-fat-arrow.error
@@ -1,0 +1,1 @@
+Type mismatch: expected ‘i32’, but got ‘String’

--- a/tests/typechecker/function-return-type-with-fat-arrow.jakt
+++ b/tests/typechecker/function-return-type-with-fat-arrow.jakt
@@ -1,0 +1,3 @@
+class S {
+    public function get_value() -> i32 => "Hello"
+}


### PR DESCRIPTION
Now Jakt accepts specifying a return type explicitly for functions using a fat arrow to declare their block as a single expression with
a return, and makes sure that the type of the expression matches with the explicit type:

```jakt
class S {
  function get_secret() -> i32 => "World"
}
```

would result in a `Type mismatch` error with `i32` and `String`, but

```jakt
function secret() -> i32 => 42
```

won't throw any errors.

Works for both methods and standalone functions.
Will close #331.
