### PR TITLE
parser+typechecker+codegen: Make generic extern functions actually work

### DIFF
--- a/src/codegen.rs
+++ b/src/codegen.rs
@@ -948,6 +948,17 @@ fn codegen_struct(structure: &CheckedStruct, project: &Project) -> String {
 fn codegen_function_predecl(function: &CheckedFunction, project: &Project) -> String {
     let mut output = String::new();
 
+    // Extern generics need to be in the header anyways, so we can't codegen for them.
+    if [
+        FunctionLinkage::External,
+        FunctionLinkage::ExternalClassConstructor,
+    ]
+    .contains(&function.linkage)
+        && !function.generic_parameters.is_empty()
+    {
+        return output;
+    }
+
     if function.linkage == FunctionLinkage::External {
         output.push_str("extern ");
     }
@@ -1032,6 +1043,17 @@ fn codegen_function_in_namespace(
     containing_struct: Option<TypeId>,
     project: &Project,
 ) -> String {
+    // Extern generics need to be in the header anyways, so we can't codegen for them.
+    if [
+        FunctionLinkage::External,
+        FunctionLinkage::ExternalClassConstructor,
+    ]
+    .contains(&function.linkage)
+        && !function.generic_parameters.is_empty()
+    {
+        return String::new();
+    }
+
     let mut output = String::new();
 
     if !function.generic_parameters.is_empty() {

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -602,7 +602,7 @@ pub fn parse_namespace(
                             } => match name.as_str() {
                                 "function" => {
                                     *index += 1;
-                                    let (fun, err) = parse_function(
+                                    let (mut fun, err) = parse_function(
                                         tokens,
                                         index,
                                         FunctionLinkage::External,
@@ -610,6 +610,7 @@ pub fn parse_namespace(
                                     );
                                     error = error.or(err);
 
+                                    fun.must_instantiate = true;
                                     parsed_namespace.functions.push(fun);
                                 }
                                 "struct" => {

--- a/src/typechecker.rs
+++ b/src/typechecker.rs
@@ -2063,7 +2063,7 @@ fn typecheck_function_predecl(
 
         generic_parameters.push(FunctionGenericParameter::Parameter(type_var_type_id));
 
-        if !function.must_instantiate {
+        if !function.must_instantiate || function.linkage == FunctionLinkage::External {
             if let Err(err) = project.add_type_to_scope(
                 checked_function_scope_id,
                 generic_parameter.to_string(),

--- a/tests/codegen/extern_generic_function.jakt
+++ b/tests/codegen/extern_generic_function.jakt
@@ -1,0 +1,7 @@
+// These generic extern functions shouldn't compile to anything.
+
+extern function do_thing_with_type<T>(anonymous input: T) -> T
+
+extern function do_more_things<T, U>(anonymous input: U) -> T
+
+function main() {}


### PR DESCRIPTION
This should make generic extern functions work in all circumstances. And now they don't generate any code, because that doesn't make any sense with templates.