### PR TITLE
Add type formatters for pretty-printing Jakt objects

### DIFF
--- a/runtime/AK/NonnullRefPtr.h
+++ b/runtime/AK/NonnullRefPtr.h
@@ -231,14 +231,6 @@ inline NonnullRefPtr<T> adopt_ref(T& object)
     return NonnullRefPtr<T>(NonnullRefPtr<T>::Adopt, object);
 }
 
-template<typename T>
-struct Formatter<NonnullRefPtr<T>> : Formatter<const T*> {
-    ErrorOr<void> format(FormatBuilder& builder, NonnullRefPtr<T> const& value)
-    {
-        return Formatter<const T*>::format(builder, value.ptr());
-    }
-};
-
 template<typename T, typename U>
 inline void swap(NonnullRefPtr<T>& a, NonnullRefPtr<U>& b) requires(IsConvertible<U*, T*>)
 {

--- a/runtime/AK/String.h
+++ b/runtime/AK/String.h
@@ -320,6 +320,15 @@ String operator+(String const&, String const&);
 
 String escape_html_entities(StringView html);
 
+template<typename T>
+struct Formatter<NonnullRefPtr<T>> : Formatter<StringView> {
+    ErrorOr<void> format(FormatBuilder& builder, NonnullRefPtr<T> const& value)
+    {
+        auto str = AK::String::formatted("{}", *value);
+        return Formatter<StringView>::format(builder, str);
+    }
+};
+
 }
 
 using AK::CaseInsensitiveStringTraits;

--- a/runtime/AK/String.h
+++ b/runtime/AK/String.h
@@ -9,7 +9,6 @@
 #include <AK/Format.h>
 #include <AK/Forward.h>
 #include <AK/RefPtr.h>
-#include <AK/StringBuilder.h>
 #include <AK/StringImpl.h>
 #include <AK/StringUtils.h>
 #include <AK/Traits.h>
@@ -97,14 +96,6 @@ public:
 
     [[nodiscard]] static String bijective_base_from(size_t value, unsigned base = 26, StringView map = {});
     [[nodiscard]] static String roman_number_from(size_t value);
-
-    template<class SeparatorType, class CollectionType>
-    [[nodiscard]] static String join(SeparatorType const& separator, CollectionType const& collection, StringView fmtstr = "{}"sv)
-    {
-        StringBuilder builder;
-        builder.join(separator, collection, fmtstr);
-        return builder.build();
-    }
 
     [[nodiscard]] bool matches(StringView mask, CaseSensitivity = CaseSensitivity::CaseInsensitive) const;
     [[nodiscard]] bool matches(StringView mask, Vector<MaskSpan>&, CaseSensitivity = CaseSensitivity::CaseInsensitive) const;

--- a/runtime/AK/StringBuilder.h
+++ b/runtime/AK/StringBuilder.h
@@ -8,6 +8,7 @@
 
 #include <AK/Format.h>
 #include <AK/Forward.h>
+#include <AK/String.h>
 #include <AK/StringView.h>
 #include <Builtins/Array.h>
 #include <stdarg.h>
@@ -83,3 +84,31 @@ private:
 }
 
 using AK::StringBuilder;
+
+namespace AK {
+
+template<typename T>
+struct Formatter<JaktInternal::Array<T>> : Formatter<StringView> {
+    ErrorOr<void> format(FormatBuilder& builder, JaktInternal::Array<T> const& value)
+    {
+        StringBuilder string_builder;
+        string_builder.append("[");
+        for (size_t i = 0; i < value.size(); ++i) {
+            if constexpr (IsSame<String, T>) {
+                string_builder.append("\"");
+            }
+            string_builder.appendff("{}", value[i]);
+            if constexpr (IsSame<String, T>) {
+                string_builder.append("\"");
+            }
+
+            if (i != value.size() - 1) {
+                string_builder.append(",");
+            }
+        }
+        string_builder.append("]");
+        return Formatter<StringView>::format(builder, string_builder.to_string());
+    }
+};
+
+}

--- a/tests/codegen/type_pretty_printers.jakt
+++ b/tests/codegen/type_pretty_printers.jakt
@@ -1,0 +1,35 @@
+class Size {
+    width: i64
+    height: i64
+}
+
+class Point {
+    x: i64
+    y: i64
+}
+
+class Rect {
+    location: Point
+    size: Size
+}
+
+enum Value {
+    Foo
+    Bar(values: [String])
+}
+
+enum Foo {
+    Bar
+    Baz(i64)
+}
+
+function main() {
+    let e = Value::Bar(values: ["hello"])
+    println("{}", e)
+
+    let r = Rect(location: Point(x: 0, y: 0), size: Size(width: 15, height: 30))
+    println("{}", r)
+
+    let foo = Foo::Baz(100)
+    println("{}", foo)
+}

--- a/tests/codegen/type_pretty_printers.out
+++ b/tests/codegen/type_pretty_printers.out
@@ -1,0 +1,3 @@
+Value::Bar(values: ["hello"])
+Rect(location: Point(x: 0, y: 0), size: Size(width: 15, height: 30))
+Foo::Baz(100)


### PR DESCRIPTION
This PR adds code generation of `AK::Formatter` specializations for every emitted Jakt `class`/`struct`/`enum`.
This means you can now pretty-print Jakt objects by doing:
```
class Size {
    width: i64
    height: i64
}

class Point {
    x: i64
    y: i64
}

class Rect {
    location: Point
    size: Size
}

function main() {
    let rect = Rect(location: Point(x: 0, y: 0), size: Size(width: 15, height: 30))
    println("{}", rect)
}
```

The program above prints this:
```
Rect(location: Point(x: 0, y: 0), size: Size(width: 15, height: 30))
```