### PR TITLE
main: Add ".exe" to the executable file name on Windows

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -41,7 +41,17 @@ fn main() -> Result<(), JaktError> {
                         |path: &PathBuf| path.clone().into_os_string().into_string().unwrap();
 
                     let input_cpp = path_as_string(&out_filepath);
-                    let output_executable = path_as_string(&out_filepath.with_extension(""));
+
+                    let output_executable;
+                    #[cfg(target_os = "windows")]
+                    {
+                        output_executable = path_as_string(&out_filepath.with_extension("exe"));
+                    }
+                    #[cfg(not(target_os = "windows"))]
+                    {
+                        output_executable = path_as_string(&out_filepath.with_extension(""));
+                    }
+
                     let runtime_path = if let Some(ref runtime_path) = arguments.runtime_path {
                         path_as_string(runtime_path)
                     } else {


### PR DESCRIPTION
The purpose of this is to avoid having to rename executable files all the time.