### PR TITLE
editor: Add single quote highlight for Vim

### DIFF
--- a/editors/vim/syntax/jakt.vim
+++ b/editors/vim/syntax/jakt.vim
@@ -1,6 +1,6 @@
 " Vim syntax file
 " Language: Jakt
-" Latest Revision: 2022-05-21
+" Latest Revision: 2022-05-25
 
 if exists("b:current_syntax")
   finish
@@ -79,6 +79,7 @@ syntax region jaktCommentLine start="//" end="$"
 
 
 syntax region jaktString matchgroup=jaktStringDelimiter start=+"+ skip=+\\\\\|\\"+ end=+"+ oneline contains=jaktEscape
+syntax region jaktChar matchgroup=jaktCharDelimiter start=+'+ skip=+\\\\\|\\'+ end=+'+ oneline contains=jaktEscape
 syntax match jaktEscape        display contained /\\./
 
 highlight default link jaktDecNumber jaktNumber
@@ -92,6 +93,8 @@ highlight default link jaktType Type
 highlight default link jaktCommentLine Comment
 highlight default link jaktString String
 highlight default link jaktStringDelimiter String
+highlight default link jaktChar String
+highlight default link jaktCharDelimiter String
 highlight default link jaktEscape Special
 highlight default link jaktBoolean Boolean
 highlight default link jaktConstant Constant


### PR DESCRIPTION
This is a duplicate of my earlier PR because I messed up there. Can @jntrnr have a look? :)

Add syntax highlighting for single quote character/byte literals. Highlight is similar to String type with double quotes.