### PR TITLE
main: A bunch of miscellaneous improvements 

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -175,7 +175,7 @@ fn compiler_exists(path: &PathBuf) -> bool {
 }
 
 /// Make sure to keep these up-to-date if you're adding arguments.
-const USAGE: &str = "usage: jakt [-h,-S] [OPTIONS] [FILES...]";
+const USAGE: &str = "usage: jakt [-h,-p,-S] [OPTIONS] [FILES...]";
 
 // FIXME: Once format is stable as a const function, include USAGE in this string.
 const HELP: &str = "\

--- a/src/main.rs
+++ b/src/main.rs
@@ -116,9 +116,8 @@ fn main() -> Result<(), JaktError> {
                         let mut cxx_compiler = Command::new(cxx_compiler)
                             .args([
                                 "-std=c++2a",
-                                // This warning can happen for functions like fopen which Windows has deprecated but others not.
-                                // Specifically, it will happen if clang uses the MSVC runtime and/or linker.
-                                "-Wno-deprecated-declarations",
+                                // Disable CRT depreciation warnings for functions like fopen which Windows has deprecated.
+                                "-D_CRT_SECURE_NO_DEPRECATE=1",
                                 "-I",
                                 &runtime_path,
                                 &input_cpp,


### PR DESCRIPTION
- Now supports using `g++` to compile the generated C++
- Allow setting the compiler to use via the `CXX` environment variable
- Disable windows deprecation warnings with `_CRT_SECURE_NO_DEPRECATE=1` rather than blanket deprecation disable  
- Better error messages for when the clang++ or the runtime can't be found
- Add the -p flag to the short usage help 