### PR TITLE
main: Show source code locations for errors/hints

### DIFF
--- a/src/compiler.rs
+++ b/src/compiler.rs
@@ -119,6 +119,10 @@ impl Compiler {
         &self.raw_files[file_id].1
     }
 
+    pub fn get_file_name(&self, file_id: FileId) -> &String {
+        &self.raw_files[file_id].0
+    }
+
     pub fn prelude() -> Vec<u8> {
         include_bytes!("../runtime/prelude.jakt").to_vec()
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -252,6 +252,7 @@ fn display_message_with_span(
     println!("{}: {}", severity.name(), msg);
 
     let file_contents = compiler.get_file_contents(span.file_id);
+    let file_name = compiler.get_file_name(span.file_id);
 
     let line_spans = line_spans(file_contents);
 
@@ -259,10 +260,17 @@ fn display_message_with_span(
     let largest_line_number = line_spans.len();
 
     let width = format!("{}", largest_line_number).len();
-    println!("{}", "-".repeat(width + 3));
 
     while line_index < line_spans.len() {
         if span.start >= line_spans[line_index].0 && span.start <= line_spans[line_index].1 {
+            let column_index = span.start - line_spans[line_index].0;
+            println!(
+                "{} \u{001b}[33m{}:{}:{}\u{001b}[0m",
+                "-".repeat(width + 3),
+                file_name,
+                line_index + 1,
+                column_index + 1
+            );
             if line_index > 0 {
                 print_source_line(
                     &severity,


### PR DESCRIPTION
We now get nice (coloured in your terminal!) source locations for errors / hints. If you're in VSCode / a similar editor, you should now just be able to Ctrl+Click on the the location to jump to that position in the file

Example output:
```
Error: type 'String' does not match type 'i64' of previous values in array
---- samples/arrays/array_bad.jakt:2:17
 0 | function main() {
 1 |     let x = [1, "2", 3]
                     ^- type 'String' does not match type 'i64' of previous values in array
 2 | } 
----
Hint: array was inferred to store type 'i64' here
---- samples/arrays/array_bad.jakt:2:14
 0 | function main() {
 1 |     let x = [1, "2", 3]
                  ^- array was inferred to store type 'i64' here
 2 | } 
----
```