### PR TITLE
typechecker: Resolve calls into nested namespaces

### DIFF
--- a/samples/namespaces/bogus_namespace1.error
+++ b/samples/namespaces/bogus_namespace1.error
@@ -1,0 +1,1 @@
+Not a namespace, enum, class, or struct: ‘NS::Foo’

--- a/samples/namespaces/bogus_namespace1.jakt
+++ b/samples/namespaces/bogus_namespace1.jakt
@@ -1,0 +1,8 @@
+namespace NS {
+    function foo() {}
+}
+
+function main() {
+    NS::foo()
+    NS::Foo::foo()
+}

--- a/samples/namespaces/bogus_namespace2.error
+++ b/samples/namespaces/bogus_namespace2.error
@@ -1,0 +1,1 @@
+Not a namespace, enum, class, or struct: ‘NS’

--- a/samples/namespaces/bogus_namespace2.jakt
+++ b/samples/namespaces/bogus_namespace2.jakt
@@ -1,0 +1,3 @@
+function main() {
+    NS::foo()
+}

--- a/samples/namespaces/call_functions_in_nested_namespaces.jakt
+++ b/samples/namespaces/call_functions_in_nested_namespaces.jakt
@@ -1,0 +1,18 @@
+namespace Outer {
+    namespace Inner {
+        struct Struct {
+            function method(this) => println("PASS 1")
+            function static_function() => println("PASS 2")
+        }
+        function free_function_in_inner_namespace() => println("PASS 3")
+    }
+    function free_function_in_outer_namespace() => println("PASS 4")
+}
+
+function main() {
+    let mutable s = Outer::Inner::Struct()
+    s.method()
+    Outer::Inner::Struct::static_function()
+    Outer::Inner::free_function_in_inner_namespace()
+    Outer::free_function_in_outer_namespace()
+}

--- a/samples/namespaces/call_functions_in_nested_namespaces.out
+++ b/samples/namespaces/call_functions_in_nested_namespaces.out
@@ -1,0 +1,4 @@
+PASS 1
+PASS 2
+PASS 3
+PASS 4


### PR DESCRIPTION
This patch adds support for calling functions (including constructors) within nested namespaces.

Call resolution now starts by walking the qualifiers from left-to-right, recursing into each namespace as it goes.

Note that generics still need some work here, so I've left a FIXME.