### PR TITLE
editors/vscode: Specify global vsce installation needed

### DIFF
--- a/editors/vscode/README.md
+++ b/editors/vscode/README.md
@@ -7,7 +7,7 @@ There are no pre-packaged versions of this extension, as changes to language and
 To build:
 
 ```
-> npm install vsce
+> npm install vsce -g
 > vsce package
 ```
 


### PR DESCRIPTION
Specifies that in order to call `vsce` from terminal on windows, you have to install it globally. If you don't install it globally, you can only reference it via package.json scripts, which isn't done currently.