### PR TITLE
codegen+typechecker: Expose String::formatted() as format() for now

### DIFF
--- a/samples/basics/format.jakt
+++ b/samples/basics/format.jakt
@@ -1,0 +1,7 @@
+function main() {
+    let hello = "Hello"
+    let friends = "friends"
+    let number = 123
+    let s = format("{} {} {}", hello, friends, number)
+    println("{}", s)
+}

--- a/samples/basics/format.out
+++ b/samples/basics/format.out
@@ -1,0 +1,1 @@
+Hello friends 123

--- a/src/codegen.rs
+++ b/src/codegen.rs
@@ -2563,6 +2563,15 @@ fn codegen_expr(indent: usize, expr: &CheckedExpression, project: &Project) -> S
                     }
                 }
                 output.push(')');
+            } else if call.name == "format" {
+                output.push_str("String::formatted(");
+                for (i, param) in call.args.iter().enumerate() {
+                    output.push_str(&codegen_expr(indent, &param.1, project));
+                    if i != call.args.len() - 1 {
+                        output.push(',');
+                    }
+                }
+                output.push(')');
             } else {
                 if call.linkage == FunctionLinkage::ImplicitConstructor
                     || call.linkage == FunctionLinkage::ExternalClassConstructor

--- a/src/typechecker.rs
+++ b/src/typechecker.rs
@@ -5380,7 +5380,7 @@ pub fn typecheck_call(
     let mut maybe_this_type_id = None;
 
     match call.name.as_str() {
-        "print" | "println" | "eprintln" if struct_id.is_none() => {
+        "print" | "println" | "eprintln" | "format" if struct_id.is_none() => {
             // FIXME: This is a hack since println() and eprintln() are hard-coded into codegen at the moment.
             for arg in &call.args {
                 let (checked_arg, err) =
@@ -5399,7 +5399,12 @@ pub fn typecheck_call(
                         *span,
                     )));
                 }
-                return_type_id = VOID_TYPE_ID;
+
+                if call.name == "format" {
+                    return_type_id = STRING_TYPE_ID;
+                } else {
+                    return_type_id = VOID_TYPE_ID;
+                }
 
                 checked_args.push((arg.0.clone(), checked_arg));
             }


### PR DESCRIPTION
Let's give ourselves the ability to create formatted strings as well.
This is a hard-coded hack in the compiler, same as println() and co.