### PR TITLE
Parser: Move member shorthand from dollar to dot

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ class Size {
     width: i64
     height: i64
 
-    public function area(this) => $width * $height
+    public function area(this) => .width * .height
 }
 ```
 
@@ -180,7 +180,7 @@ foo.set(9)
 
 ### Shorthand for accessing member variables
 
-To reduce repetitive `this.` spam in methods, the shorthand `$foo` expands to `this.foo`.
+To reduce repetitive `this.` spam in methods, the shorthand `.foo` expands to `this.foo`.
 
 ## Arrays
 

--- a/samples/basics/this_dot_shorthand.jakt
+++ b/samples/basics/this_dot_shorthand.jakt
@@ -2,7 +2,7 @@ struct Size {
     width: i64
     height: i64
 
-    function area(this) => $width * $height
+    function area(this) => .width * .height
 }
 
 

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -2550,7 +2550,7 @@ pub fn parse_operand(tokens: &[Token], index: &mut usize) -> (ParsedExpression, 
     }
 
     let mut expr = match &tokens[*index].contents {
-        TokenContents::Dollar => {
+        TokenContents::Dot => {
             let this_expr = ParsedExpression::Var("this".to_string(), tokens[*index].span);
             *index += 1;
             match &tokens[*index].contents {
@@ -2564,7 +2564,7 @@ pub fn parse_operand(tokens: &[Token], index: &mut usize) -> (ParsedExpression, 
                 }
                 _ => {
                     error = error.or(Some(JaktError::ParserError(
-                        "Missing member name after '$'".to_string(),
+                        "Missing member name after '.'".to_string(),
                         tokens[*index - 1].span,
                     )));
                     ParsedExpression::Garbage(tokens[*index].span)


### PR DESCRIPTION
This moves the member shorthand from `$foo` to `.foo`.