### PR TITLE
runtime: Add formatters for remaining builtins

### DIFF
--- a/runtime/AK/StringBuilder.h
+++ b/runtime/AK/StringBuilder.h
@@ -10,7 +10,9 @@
 #include <AK/Forward.h>
 #include <AK/String.h>
 #include <AK/StringView.h>
+#include <AK/Tuple.h>
 #include <Builtins/Array.h>
+#include <Builtins/Dictionary.h>
 #include <Builtins/Set.h>
 #include <stdarg.h>
 
@@ -132,4 +134,24 @@ struct Formatter<JaktInternal::Set<T>> : Formatter<StringView> {
     }
 };
 
+template<typename K, typename V>
+struct Formatter<JaktInternal::Dictionary<K, V>> : Formatter<StringView> {
+    ErrorOr<void> format(FormatBuilder& builder, JaktInternal::Dictionary<K, V> const& dict)
+    {
+        StringBuilder string_builder;
+        string_builder.append("[");
+        auto iter = dict.iterator();
+
+        for (size_t i = 0; i < dict.size(); ++i) {
+            auto item = iter.next().value();
+            append_value(string_builder, item.template get<0>());
+            string_builder.append(": ");
+            append_value(string_builder, item.template get<1>());
+            if (i != dict.size() - 1)
+                string_builder.append(", ");
+        }
+        string_builder.append("]");
+        return Formatter<StringView>::format(builder, string_builder.to_string());
+    }
+};
 }

--- a/runtime/AK/StringBuilder.h
+++ b/runtime/AK/StringBuilder.h
@@ -11,6 +11,7 @@
 #include <AK/String.h>
 #include <AK/StringView.h>
 #include <Builtins/Array.h>
+#include <Builtins/Set.h>
 #include <stdarg.h>
 
 namespace AK {
@@ -109,6 +110,24 @@ struct Formatter<JaktInternal::Array<T>> : Formatter<StringView> {
                 string_builder.append(", ");
         }
         string_builder.append("]");
+        return Formatter<StringView>::format(builder, string_builder.to_string());
+    }
+};
+
+template<typename T>
+struct Formatter<JaktInternal::Set<T>> : Formatter<StringView> {
+    ErrorOr<void> format(FormatBuilder& builder, JaktInternal::Set<T> const& set)
+    {
+        StringBuilder string_builder;
+        string_builder.append("{");
+        auto iter = set.iterator();
+
+        for (size_t i = 0; i < set.size(); ++i) {
+            append_value(string_builder, iter.next().value());
+            if (i != set.size() - 1)
+                string_builder.append(", ");
+        }
+        string_builder.append("}");
         return Formatter<StringView>::format(builder, string_builder.to_string());
     }
 };

--- a/runtime/AK/StringBuilder.h
+++ b/runtime/AK/StringBuilder.h
@@ -88,23 +88,25 @@ using AK::StringBuilder;
 namespace AK {
 
 template<typename T>
+void append_value(StringBuilder& string_builder, T const& value)
+{
+    if constexpr (IsSame<String, T>)
+        string_builder.append("\"");
+    string_builder.appendff("{}", value);
+    if constexpr (IsSame<String, T>)
+        string_builder.append("\"");
+}
+
+template<typename T>
 struct Formatter<JaktInternal::Array<T>> : Formatter<StringView> {
     ErrorOr<void> format(FormatBuilder& builder, JaktInternal::Array<T> const& value)
     {
         StringBuilder string_builder;
         string_builder.append("[");
         for (size_t i = 0; i < value.size(); ++i) {
-            if constexpr (IsSame<String, T>) {
-                string_builder.append("\"");
-            }
-            string_builder.appendff("{}", value[i]);
-            if constexpr (IsSame<String, T>) {
-                string_builder.append("\"");
-            }
-
-            if (i != value.size() - 1) {
-                string_builder.append(",");
-            }
+            append_value(string_builder, value[i]);
+            if (i != value.size() - 1)
+                string_builder.append(", ");
         }
         string_builder.append("]");
         return Formatter<StringView>::format(builder, string_builder.to_string());

--- a/runtime/AK/StringBuilder.h
+++ b/runtime/AK/StringBuilder.h
@@ -154,4 +154,23 @@ struct Formatter<JaktInternal::Dictionary<K, V>> : Formatter<StringView> {
         return Formatter<StringView>::format(builder, string_builder.to_string());
     }
 };
+
+template<typename... Ts>
+struct Formatter<AK::Tuple<Ts...>> : Formatter<StringView> {
+    ErrorOr<void> format(FormatBuilder& builder, AK::Tuple<Ts...> const& tuple)
+    {
+        StringBuilder string_builder;
+        string_builder.append("(");
+        if constexpr (sizeof...(Ts) > 0) {
+            tuple.apply_as_args([&] (auto first, auto... args) {
+                append_value(string_builder, first);
+                ((string_builder.append(", "), append_value(string_builder, args)),...);
+            });
+        }
+
+        string_builder.append(")");
+        return Formatter<StringView>::format(builder, string_builder.to_string());
+    }
+};
+
 }


### PR DESCRIPTION
```
$ cat test.jakt
function main() {
    let arr = [1, 2, 3]
    let set = {1, 2, 3}
    let dict = [1: ("hello", "world"), 2: ("from", "jakt")]
    println("arr: {}", arr)
    println("set: {}", set)
    println("dict: {}", dict)
}
$ cargo run test.jakt && ./build/test
arr: [1, 2, 3]
set: {2, 3, 1}
dict: [1: ("hello", "world"), 2: ("from", "jakt")]
```