### PR TITLE
docs: Update readme to describe clang as a dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ It currently transpiles to C++.
 **NOTE:** The language is under heavy development.
 
 ## Usage
-
+The transpilation to C++ requires `clang`. Make sure you have that installed.
 ```
 jakt file.jakt
 ./build/file


### PR DESCRIPTION
Since the build steps were updated in PR #358, it is not immediately apparent that `clang` is a dependency. We make sure to add
that in the docs. The build process otherwise creates confusion within users as it spits errors without `clang`. For example, Discord user _Smiley1000_ faced these errors today. 

```
---- test_classes stdout ----
Error: IOError(Os { code: 2, kind: NotFound, message: "No such file or directory" })
thread 'test_classes' panicked at 'assertion failed: `(left == right)`
  left: `1`,
 right: `0`: the test returned a termination value with a non-zero status code (1) which indicates a failure', /rustc/fe5b13d681f25ee6474be29d748c65adcd91f69e/library/test/src/lib.rs:186:5
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```