### PR TITLE
samples/control_flow: Test defer in defer

### DIFF
--- a/samples/control_flow/defer_in_defer.jakt
+++ b/samples/control_flow/defer_in_defer.jakt
@@ -1,0 +1,15 @@
+function foo(anonymous n: i8) {
+    println("foo called with {}", n)
+}
+
+function main() {
+    foo(1)
+    defer {
+        foo(3)
+        defer {
+            foo(5)
+        }
+        foo(4)
+    }
+    foo(2)
+}

--- a/samples/control_flow/defer_in_defer.out
+++ b/samples/control_flow/defer_in_defer.out
@@ -1,0 +1,5 @@
+foo called with 1
+foo called with 2
+foo called with 3
+foo called with 4
+foo called with 5


### PR DESCRIPTION
Our current implementation of defer gives us this feature for free.
Since defer is block-scoped, there is no ambiguity as to what the
behavior of this is. Therefore, this commit adds a sample that tests
if this feature works correctly.