### PR TITLE
Parser: Fix infinite loop while parsing illegal function parameters

### DIFF
--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1539,6 +1539,8 @@ pub fn parse_function(
                                 "expected parameter".to_string(),
                                 tokens[*index].span,
                             )));
+
+                            break;
                         }
                     }
                 }

--- a/tests/parser/non_parameter_1.error
+++ b/tests/parser/non_parameter_1.error
@@ -1,0 +1,1 @@
+expected parameter

--- a/tests/parser/non_parameter_1.jakt
+++ b/tests/parser/non_parameter_1.jakt
@@ -1,0 +1,7 @@
+function foo(= anonymous n: i32) {
+    println("{}", n)
+}
+
+function main() {
+    foo(2)
+}

--- a/tests/parser/non_parameter_2.error
+++ b/tests/parser/non_parameter_2.error
@@ -1,0 +1,1 @@
+expected parameter

--- a/tests/parser/non_parameter_2.jakt
+++ b/tests/parser/non_parameter_2.jakt
@@ -1,0 +1,7 @@
+function foo(anonymous = n: i32) {
+    println("{}", n)
+}
+
+function main() {
+    foo(2)
+}

--- a/tests/parser/non_parameter_3.error
+++ b/tests/parser/non_parameter_3.error
@@ -1,0 +1,1 @@
+expected parameter

--- a/tests/parser/non_parameter_3.jakt
+++ b/tests/parser/non_parameter_3.jakt
@@ -1,0 +1,7 @@
+function foo(anonymous n: i32 = 1) {
+    println("{}", n)
+}
+
+function main() {
+    foo(2)
+}


### PR DESCRIPTION
Previously, the compiler would get stuck in an infinite loop when
trying to compile a function parameter list and encountering
something that's not a parameter due to the parser being stuck in the
loop once the error was encountered. An example of this would be
trying to use default parameters, which are not a part of the language
yet. This commit fixes that by breaking out of the loop once the error
is encountered and introduces appropriate test cases.