### PR TITLE
editors/vscode: Fix comment highlighting

### DIFF
--- a/editors/vscode/syntaxes/jakt.tmLanguage.json
+++ b/editors/vscode/syntaxes/jakt.tmLanguage.json
@@ -22,6 +22,9 @@
     "expressions": {
       "patterns": [
         {
+          "include": "#comment"
+        },
+        {
           "include": "#strings"
         },
         {


### PR DESCRIPTION
I'm no TextMate grammar expert but this seems to fix the issue.