### PR TITLE
runtime: Add back AK::String::operator+

### DIFF
--- a/runtime/AK/String.cpp
+++ b/runtime/AK/String.cpp
@@ -179,6 +179,14 @@ bool String::operator==(char const* c_string) const
     return view() == c_string;
 }
 
+String String::operator+(String const& other) const
+{
+    StringBuilder builder;
+    MUST(builder.try_append(*this));
+    MUST(builder.try_append(other));
+    return MUST(builder.to_string());
+}
+
 void StringStorage::operator delete(void* ptr)
 {
     free(ptr);

--- a/runtime/AK/String.h
+++ b/runtime/AK/String.h
@@ -173,6 +173,9 @@ public:
     bool operator==(char const* cstring) const;
     bool operator!=(char const* cstring) const { return !(*this == cstring); }
 
+    // FIXME: Return ErrorOr<String> when Jakt can automatically wrap String+String with TRY()
+    String operator+(String const&) const;
+
     [[nodiscard]] StringStorage& storage() { return *m_storage; }
     [[nodiscard]] StringStorage const& storage() const { return *m_storage; }
 

--- a/samples/strings/string_add.jakt
+++ b/samples/strings/string_add.jakt
@@ -1,0 +1,3 @@
+function main() {
+    println("{}", "Hello" + " " + "World!");
+}

--- a/samples/strings/string_add.out
+++ b/samples/strings/string_add.out
@@ -1,0 +1,1 @@
+Hello World!


### PR DESCRIPTION
This was removed from the String refactor. Currently, this fails
if String allocation is not successful, but this should be changed
once we can tell Jakt that `String + String` is fallible and get it
to wrap the operation in TRY()