### PR TITLE
main: Add ability to specify include paths through CLI

### DIFF
--- a/src/compiler.rs
+++ b/src/compiler.rs
@@ -42,9 +42,9 @@ pub struct Compiler {
 }
 
 impl Compiler {
-    pub fn new() -> Self {
+    pub fn new(include_paths: Vec<PathBuf>) -> Self {
         Self {
-            include_paths: Vec::new(),
+            include_paths,
             raw_files: Vec::new(),
         }
     }

--- a/tests/main.rs
+++ b/tests/main.rs
@@ -30,7 +30,7 @@ fn test_samples(path: &str) -> Result<(), JaktError> {
                 if output_path.exists() || error_output_path.exists() || stderr_output_path.exists()
                 {
                     // We have an output to compare to, let's do it.
-                    let mut compiler = Compiler::new();
+                    let mut compiler = Compiler::new(Vec::new());
                     let cpp_string = compiler.convert_to_cpp(&path);
 
                     let cpp_string = match cpp_string {


### PR DESCRIPTION
You can now specify include paths with `-I path/to/dir`, similar to gcc/clang

I'm not quite sure how to add tests for this without reworking a bunch of the stuff in the current testing infrastructure to allow adding custom command line arguments, if anyone's got any ideas I'm all ears.