### PR TITLE
Typechecker: Don't discard typechecking errors in variable declarations & Always use err() to handle return of add_var_to_scope()

### DIFF
--- a/src/typechecker.rs
+++ b/src/typechecker.rs
@@ -3016,6 +3016,7 @@ pub fn typecheck_statement(
         ParsedStatement::VarDecl(var_decl, init) => {
             let (mut checked_type_id, typename_err) =
                 typecheck_typename(&var_decl.parsed_type, scope_id, project);
+            error = error.or(typename_err);
 
             let (mut checked_expression, err) =
                 typecheck_expression(init, scope_id, project, safety_mode, Some(checked_type_id));
@@ -3025,8 +3026,6 @@ pub fn typecheck_statement(
                 && checked_expression.type_id(scope_id, project) != UNKNOWN_TYPE_ID
             {
                 checked_type_id = checked_expression.type_id(scope_id, project)
-            } else {
-                error = error.or(typename_err);
             }
 
             let err = try_promote_constant_expr_to_type(

--- a/src/typechecker.rs
+++ b/src/typechecker.rs
@@ -1685,18 +1685,20 @@ fn typecheck_enum(
                             next_constant_value = Some(next_constant_value? + 1);
 
                             // This has a value, so generate a "variable" for it.
-                            let err = project.add_var_to_scope(
-                                enum_scope_id,
-                                CheckedVariable {
-                                    name: name.clone(),
-                                    type_id: enum_type_id,
-                                    mutable: false,
-                                    visibility: Visibility::Public,
-                                    definition_span: *span,
-                                },
-                                *span,
-                            );
-                            error = error.or(err.err());
+                            let err = project
+                                .add_var_to_scope(
+                                    enum_scope_id,
+                                    CheckedVariable {
+                                        name: name.clone(),
+                                        type_id: enum_type_id,
+                                        mutable: false,
+                                        visibility: Visibility::Public,
+                                        definition_span: *span,
+                                    },
+                                    *span,
+                                )
+                                .err();
+                            error = error.or(err);
                         }
                     } else {
                         variants.push(CheckedEnumVariant::Untyped(name.clone(), *span));
@@ -1779,18 +1781,20 @@ fn typecheck_enum(
                     ));
 
                     // This has a value, so generate a "variable" for it.
-                    let err = project.add_var_to_scope(
-                        enum_scope_id,
-                        CheckedVariable {
-                            name: name.clone(),
-                            type_id: enum_type_id,
-                            mutable: false,
-                            visibility: Visibility::Public,
-                            definition_span: *span,
-                        },
-                        *span,
-                    );
-                    error = error.or(err.err());
+                    let err = project
+                        .add_var_to_scope(
+                            enum_scope_id,
+                            CheckedVariable {
+                                name: name.clone(),
+                                type_id: enum_type_id,
+                                mutable: false,
+                                visibility: Visibility::Public,
+                                definition_span: *span,
+                            },
+                            *span,
+                        )
+                        .err();
+                    error = error.or(err);
                 }
             }
             EnumVariant::StructLike(name, members, span) => {
@@ -2547,10 +2551,10 @@ fn typecheck_function(
     }
 
     for variable in param_vars.into_iter() {
-        if let Err(err) = project.add_var_to_scope(function_scope_id, variable, function.name_span)
-        {
-            error = error.or(Some(err));
-        }
+        let err = project
+            .add_var_to_scope(function_scope_id, variable, function.name_span)
+            .err();
+        error = error.or(err);
     }
 
     // Do this once to resolve concrete types (if any)
@@ -2685,10 +2689,10 @@ fn typecheck_method(
     }
 
     for variable in param_vars.into_iter() {
-        if let Err(err) = project.add_var_to_scope(function_scope_id, variable, function.name_span)
-        {
-            error = error.or(Some(err));
-        }
+        let err = project
+            .add_var_to_scope(function_scope_id, variable, function.name_span)
+            .err();
+        error = error.or(err);
     }
 
     // Set current function index before a block type check so that
@@ -2803,9 +2807,10 @@ pub fn typecheck_statement(
 
             let catch_scope_id = project.create_scope(scope_id);
 
-            if let Err(err) = project.add_var_to_scope(catch_scope_id, error_decl, *error_span) {
-                error = error.or(Some(err));
-            }
+            let err = project
+                .add_var_to_scope(catch_scope_id, error_decl, *error_span)
+                .err();
+            error = error.or(err);
 
             let (checked_catch_block, err) =
                 typecheck_block(catch_block, catch_scope_id, project, safety_mode);
@@ -3057,19 +3062,20 @@ pub fn typecheck_statement(
                 visibility: var_decl.visibility.clone(),
             };
 
-            if let Err(err) = project.add_var_to_scope(
-                scope_id,
-                CheckedVariable {
-                    name: checked_var_decl.name.clone(),
-                    type_id: checked_var_decl.type_id,
-                    mutable: checked_var_decl.mutable,
-                    visibility: checked_var_decl.visibility.clone(),
-                    definition_span: checked_var_decl.span,
-                },
-                checked_var_decl.span,
-            ) {
-                error = error.or(Some(err));
-            }
+            let err = project
+                .add_var_to_scope(
+                    scope_id,
+                    CheckedVariable {
+                        name: checked_var_decl.name.clone(),
+                        type_id: checked_var_decl.type_id,
+                        mutable: checked_var_decl.mutable,
+                        visibility: checked_var_decl.visibility.clone(),
+                        definition_span: checked_var_decl.span,
+                    },
+                    checked_var_decl.span,
+                )
+                .err();
+            error = error.or(err);
 
             (
                 CheckedStatement::VarDecl(checked_var_decl, checked_expression),
@@ -4361,11 +4367,9 @@ pub fn typecheck_expression(
 
                                 let new_scope_id = project.create_scope(scope_id);
                                 for (var, span) in vars {
-                                    if let Err(err) =
-                                        project.add_var_to_scope(new_scope_id, var, span)
-                                    {
-                                        error = error.or(Some(err));
-                                    }
+                                    let err =
+                                        project.add_var_to_scope(new_scope_id, var, span).err();
+                                    error = error.or(err);
                                 }
 
                                 match body {

--- a/tests/typechecker/nonexistent_type.error
+++ b/tests/typechecker/nonexistent_type.error
@@ -1,0 +1,1 @@
+unknown type

--- a/tests/typechecker/nonexistent_type.jakt
+++ b/tests/typechecker/nonexistent_type.jakt
@@ -1,0 +1,4 @@
+function main() {
+    let foo: ThisTypeDoesNotExist = 42
+    println("{}", foo)
+}


### PR DESCRIPTION
**Typechecker: Don't discard typechecking errors in variable declarations**

Previously, we would sometimes discard typechecking errors of the
typename in variable declarations. This commit fixes that and adds a
test for it.

**Typechecker: Always use err() to handle return of add_var_to_scope()**

Fixes #403.