### PR TITLE
typechecker+tests: Ensure all function types are known before typechecking declarations

### DIFF
--- a/src/compiler.rs
+++ b/src/compiler.rs
@@ -201,7 +201,13 @@ impl Compiler {
         let scope = Scope::new(Some(PRELUDE_SCOPE_ID), false);
         project.current_module_mut().scopes.push(scope);
 
-        let err = typecheck_module(&parsed_namespace, file_scope_id, project, self);
+        let err = typecheck_module(
+            &parsed_namespace,
+            project.current_module().id,
+            file_scope_id,
+            project,
+            self,
+        );
         error = error.or(err);
 
         (file_scope_id, error)

--- a/tests/typechecker/infer_arrow_functions_return_type.jakt
+++ b/tests/typechecker/infer_arrow_functions_return_type.jakt
@@ -1,0 +1,10 @@
+/// Expected:
+/// - output: "OK\n"
+
+function foop() => true
+
+function main() {
+    if foop() {
+        println("OK")
+    }
+}


### PR DESCRIPTION
Fixes #380 (again). PR #388 introduced a bug where it would use the function's *parent* scope when the function was not generic, but now it was reverted and the typechecker does a separate pass after registering functions to infer types of fat arrow functions that don't have their type stated explicitly in the source code.
