### PR TITLE
samples: Change .characters() to .c_string()

### DIFF
--- a/samples/apps/cat.jakt
+++ b/samples/apps/cat.jakt
@@ -14,7 +14,7 @@ function main(args: [String]) {
 
     let filename = args[1]
 
-    let mutable file = fopen(filename.characters(), "r".characters())
+    let mutable file = fopen(filename.c_string(), "r".c_string())
     defer fclose(file)
 
     let mutable c = fgetc(file)

--- a/samples/apps/crc32.jakt
+++ b/samples/apps/crc32.jakt
@@ -28,7 +28,7 @@ function main(args: [String]) {
         return 1
     }
 
-    let mutable file = fopen(args[1].characters(), "r".characters())
+    let mutable file = fopen(args[1].c_string(), "r".c_string())
     defer fclose(file)
 
     let table = make_lookup_table()


### PR DESCRIPTION
characters() function in the runtime has been renamed to c_string() now.