### PR TITLE
tests: Speed up test suite using precompiled headers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -23,9 +23,16 @@ dependencies = [
 name = "jakt"
 version = "0.1.0"
 dependencies = [
+ "lazy_static",
  "pico-args",
  "uuid",
 ]
+
+[[package]]
+name = "lazy_static"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ pico-args = { version = "0.4.2", features = ["combined-flags"] }
 
 [dev-dependencies]
 uuid = {version = "1.0.0", features=["v4"]}
+lazy_static = "1.4.0"
 
 [features]
 default = []


### PR DESCRIPTION
I noticed that for the test suite, clang spent almost 30% of its runtime parsing lib.h over and over again. By using a precompiled header, the compiler only needs to do that work once.

This reduces the test suite's runtime from 60 seconds to under 40 seconds on my computer.

We want to store each PCH file in a unique directory to prevent issues when multiple test suites are running in parallel. The way this temporary directory is created is a bit hacky. The proper way to do it is to use the `tempfile` crate, but it wants to pull in a bunch of dependencies.

This commit adds `lazy_static` as a dev dependency, which is needed because the various `test_foo` functions are run in parallel, so we need a thread-safe way to generate the PCH. 