### PR TITLE
compiler+typechecker: Improve name resolution around namespaces

### DIFF
--- a/tests/typechecker/missing_type_in_namespace.error
+++ b/tests/typechecker/missing_type_in_namespace.error
@@ -1,0 +1,1 @@
+Unknown type

--- a/tests/typechecker/missing_type_in_namespace.jakt
+++ b/tests/typechecker/missing_type_in_namespace.jakt
@@ -1,0 +1,14 @@
+extern struct StringBuilder {
+    function append(mutable this, anonymous s: u8)
+    function to_string(mutable this) throws -> String
+    function StringBuilder() -> StringBuilder
+}
+
+namespace lexer {
+struct Lexer {
+}
+}
+
+function main(args: [String]) {
+    let mutable tokens: [Token] = []
+}


### PR DESCRIPTION
Previously, we did a full typecheck of child namespaces before we checked any definitions in the parent scope. This meant we were prematurely trying to figure out things like function bodies before we even know what all functions and types were available.

With this PR, we now do typecheck of the namespace in two phases:

* Phase 1: the "predecl" phase. This establishes what declarations will be available in the namespace before they're actually fully checked.
* Phase 2: the "full" check phase. Here we finish checking the bodies of the definitions

With this, we now at least have the knowledge of what is in scope. This prevents an internal compiler panic when we mix namespaces, externs, and functions together in the same sample (as shown by the new test)
