### PR TITLE
runtime: Expose Iterator classes globally

### DIFF
--- a/runtime/Builtins/Array.h
+++ b/runtime/Builtins/Array.h
@@ -326,3 +326,4 @@ private:
 }
 
 using JaktInternal::Array;
+using JaktInternal::ArrayIterator;

--- a/runtime/Builtins/Dictionary.h
+++ b/runtime/Builtins/Dictionary.h
@@ -121,3 +121,4 @@ private:
 }
 
 using JaktInternal::Dictionary;
+using JaktInternal::DictionaryIterator;

--- a/runtime/Builtins/Set.h
+++ b/runtime/Builtins/Set.h
@@ -98,3 +98,4 @@ private:
 }
 
 using JaktInternal::Set;
+using JaktInternal::SetIterator;


### PR DESCRIPTION
Currently using any iterator outside `main` generates invalid cpp since the `...Iterator` classes are in the `JaktInternal` namespace which `main` is also in but other functions are not. 

This change exposes them in the global namespace.

The problem was not detected by the tests since they all use `main` only. One way we could prevent such issues in the future is moving `main` from `JaktInternal` to a separate namespace. Does that sound like a good option?