### PR TITLE
runtime: Move main to a separate namespace

### DIFF
--- a/runtime/lib.h
+++ b/runtime/lib.h
@@ -105,8 +105,6 @@ constexpr auto continue_on_panic = false;
 
 using OptionalNone = AK::NullOptional;
 
-ErrorOr<int> main(Array<String>);
-
 inline void panic(StringView message)
 {
     warnln("Panic: {}", message);
@@ -366,13 +364,18 @@ using JaktInternal::as_truncated;
 using JaktInternal::fallible_integer_cast;
 using JaktInternal::infallible_integer_cast;
 
+// We place main in a separate namespace to ensure it has access to the same identifiers as other functions
+namespace JaktMain {
+ErrorOr<int> main(Array<String>);
+}
+
 int main(int argc, char** argv)
 {
     Array<String> args;
     for (int i = 0; i < argc; ++i) {
         MUST(args.push(MUST(String::copy(StringView(argv[i])))));
     }
-    auto result = JaktInternal::main(move(args));
+    auto result = JaktMain::main(move(args));
     if (result.is_error()) {
         warnln("Runtime error: {}", result.error());
         return 1;

--- a/src/codegen.rs
+++ b/src/codegen.rs
@@ -1363,7 +1363,7 @@ fn codegen_function_in_namespace(
     output.push(' ');
     let is_main = function.name == "main" && containing_struct.is_none();
     if is_main {
-        output.push_str("JaktInternal::main");
+        output.push_str("JaktMain::main");
     } else {
         let qualifier = containing_struct
             .map(|type_id| codegen_type_possibly_as_namespace(type_id, project, true));


### PR DESCRIPTION
This ensures main has the same access to identifiers as other functions.

This serves to prevent cases where generated code is incorrect when something is used outside of main and prevent bugs like the one #427 fixed.