### PR TITLE
typechecker: Allow omitting bound variable name on struct-like matches

### DIFF
--- a/README.md
+++ b/README.md
@@ -300,8 +300,8 @@ enum Foo {
 
 function look_at_foo(anonymous x: Foo) -> i32 {
     match x {
-        StructLikeThingy(field_a: a, field_b: b) => {
-            return a + b
+        StructLikeThingy(field_a: a, field_b) => {
+            return a + field_b
         }
     }
 }

--- a/src/codegen.rs
+++ b/src/codegen.rs
@@ -2259,7 +2259,7 @@ fn codegen_enum_match(
                                         output.push_str(" const& ");
                                         output.push_str(arg.1.as_str());
                                         output.push_str(" = __jakt_match_value.");
-                                        output.push_str(arg.0.as_ref().unwrap());
+                                        output.push_str(arg.0.as_ref().unwrap_or(&arg.1));
                                         output.push_str(";\n");
                                     }
                                 }

--- a/src/typechecker.rs
+++ b/src/typechecker.rs
@@ -4575,14 +4575,19 @@ pub fn typecheck_expression(
                                                 let mut names_seen = HashMap::new();
                                                 for arg in args {
                                                     let name = &arg.0;
-                                                    if name.is_none() {
+                                                    if name.is_none()
+                                                        && !fields
+                                                            .iter()
+                                                            .any(|field| field.name == arg.1)
+                                                    {
                                                         error = error.or(Some(JaktError::TypecheckError(
                                                             format!("match case argument '{}' for struct-like enum variant cannot be anonymous", arg.1),
                                                             *arg_span,
                                                         )));
                                                         continue;
                                                     }
-                                                    let name = name.as_ref().unwrap().clone();
+                                                    let name =
+                                                        name.as_ref().unwrap_or(&arg.1).clone();
                                                     if names_seen.contains_key(&name) {
                                                         error = error.or(Some(JaktError::TypecheckError(
                                                             format!(

--- a/tests/typechecker/match_struct_like_enum_with_variable.jakt
+++ b/tests/typechecker/match_struct_like_enum_with_variable.jakt
@@ -1,0 +1,21 @@
+/// Expect:
+/// - output: "PASS\n"
+
+enum Foo {
+    Bar(
+        x: i32
+        y: i64
+    )
+}
+
+function main() {
+    let x = Foo::Bar(x: 0i32, y: 42)
+    match x {
+        Bar(y, x) => {
+            if y == 42 and x == 0i32 {
+                println("PASS")
+                return 0
+            }
+        }
+    }
+}


### PR DESCRIPTION
Doing so just binds the named field with the field name into the match
scope.