### PR TITLE
typechecker: Bubble up errors in more cases

### DIFF
--- a/samples/namespaces/namespace_struct.jakt
+++ b/samples/namespaces/namespace_struct.jakt
@@ -7,7 +7,7 @@ namespace Greeters {
         age: i64
 
         function greet(this) {
-            println("I am {} and my age is {}", name, age)
+            println("I am {} and my age is {}", .name, .age)
         }
     }
 }


### PR DESCRIPTION
This changes the typechecker to return errors in more cases where they previously were being ignored. This uncovered an issue with one of the tests which wasn't properly using the correct shorthand and another test that assumed a different order to the typecheck.

I've also corrected the typechecker to check types first when it comes into a namespace, allowing inner namespaces to see those types.