### PR TITLE
runtime: Remove some unused chunks of Variant to help compilation times

### DIFF
--- a/runtime/AK/Error.h
+++ b/runtime/AK/Error.h
@@ -74,10 +74,6 @@ public:
         VERIFY(!is_error());
         return release_value();
     }
-
-private:
-    // 'downcast' is fishy in this context. Let's hide it by making it private.
-    using Variant<T, ErrorType>::downcast;
 };
 
 // Partial specialization for void value type


### PR DESCRIPTION
This brings the compile time of the selfhosted impl from an average of
7.5s down to 4.7s, we should probably skip generating Variants for enums
in the near future as most of the compilation is spent instantiating the
58 (!) different function calls needed to visit these enum cases.