### PR TITLE
all: rename 'ref enum' to 'recursive enum'

### DIFF
--- a/editors/vscode/syntaxes/jakt.tmLanguage.json
+++ b/editors/vscode/syntaxes/jakt.tmLanguage.json
@@ -192,7 +192,7 @@
         },
         {
           "name": "meta.type.enum.jakt",
-          "match": "(?:\\b(ref)\\s+)?\\b(enum)\\s+((?:\\w|_)(?:\\w|_|[0-9])*)\\s*(?:(:)\\s*((?:[ui](?:8|16|32|64))|usize))?",
+          "match": "(?:\\b(recursive)\\s+)?\\b(enum)\\s+((?:\\w|_)(?:\\w|_|[0-9])*)\\s*(?:(:)\\s*((?:[ui](?:8|16|32|64))|usize))?",
           "captures": {
             "1": {
               "name": "storage.modifier.pointer.jakt"
@@ -852,7 +852,7 @@
               "name": "constant.character.escape.jakt",
               "match": "\\\\."
             }
-          ]    
+          ]
         },
         {
           "name": "string.quoted.single.jakt",
@@ -873,7 +873,7 @@
               "name": "constant.character.escape.jakt",
               "match": "\\\\."
             }
-          ]    
+          ]
         }
       ]
     }

--- a/samples/enums/recursive_enums.jakt
+++ b/samples/enums/recursive_enums.jakt
@@ -5,7 +5,7 @@ enum Operation {
     Add
 }
 
-ref enum AST {
+recursive enum AST {
     Int(i64)
     BinaryOperation(lhs: AST, op: Operation, rhs: AST)
 }

--- a/samples/enums/recursive_enums_bad.jakt
+++ b/samples/enums/recursive_enums_bad.jakt
@@ -1,5 +1,5 @@
 /// Expect:
-/// - error: "use 'ref enum' to make the enum recursive"
+/// - error: "use 'recursive enum' to make the enum recursive"
 
 enum Operation {
     Add

--- a/samples/match/match_generic_codegen.jakt
+++ b/samples/match/match_generic_codegen.jakt
@@ -24,7 +24,7 @@ enum X {
     C
 }
 
-ref enum Y {
+recursive enum Y {
     A(i64)
     B
     C

--- a/selfhost/main.jakt
+++ b/selfhost/main.jakt
@@ -651,7 +651,7 @@ struct ParsedBlock {
     stmts: [ParsedStatement]
 }
 
-ref enum ParsedStatement {
+recursive enum ParsedStatement {
     Expression(ParsedExpression)
     Defer(ParsedStatement)
     UnsafeBlock(ParsedBlock)
@@ -668,7 +668,7 @@ ref enum ParsedStatement {
     Garbage
 }
 
-ref enum ParsedExpression {
+recursive enum ParsedExpression {
     Boolean(val: bool, span: JaktSpan)
     NumericConstant(val: i64, span: JaktSpan)
     QuotedString(val: String, span: JaktSpan)
@@ -697,7 +697,7 @@ struct ParsedCall {
     args: [(String, ParsedExpression)]
 }
 
-ref enum ParsedType {
+recursive enum ParsedType {
     Name(name: String, span: JaktSpan)
     Array(inner: ParsedType, span: JaktSpan)
     Dictionary(key: ParsedType, value: ParsedType, span: JaktSpan)
@@ -746,7 +746,7 @@ struct CheckedBlock {
     definitely_returns: bool
 }
 
-ref enum CheckedStatement {
+recursive enum CheckedStatement {
     Expression(CheckedExpression)
     Defer(CheckedStatement)
     VarDecl(var: CheckedVarDecl, init: CheckedExpression)
@@ -761,7 +761,7 @@ ref enum CheckedStatement {
     Garbage
 }
 
-ref enum CheckedExpression {
+recursive enum CheckedExpression {
     Boolean(val: bool, span: JaktSpan)
     QuotedString(val: String, span: JaktSpan)
     Call(call: CheckedCall, span: JaktSpan, type: usize)

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -578,7 +578,7 @@ pub fn parse_namespace(
 
                     parsed_namespace.functions.push(fun);
                 }
-                "ref" => {
+                "recursive" => {
                     *index += 1;
 
                     if let Some(Token {
@@ -1036,7 +1036,7 @@ pub fn parse_enum(
                             && !is_recursive
                         {
                             error = error.or(Some(JaktError::ParserError(
-                                "use 'ref enum' to make the enum recursive".into(),
+                                "use 'recursive enum' to make the enum recursive".into(),
                                 tokens[*index - 1].span,
                             )));
                         } else {
@@ -1045,7 +1045,7 @@ pub fn parse_enum(
                                     if decl_name == &enum_.name && !is_recursive =>
                                 {
                                     error = error.or(Some(JaktError::ParserError(
-                                        "use 'ref enum' to make the enum recursive".into(),
+                                        "use 'recursive enum' to make the enum recursive".into(),
                                         tokens[*index - 1].span,
                                     )));
                                 }

--- a/tests/codegen/out_of_order_generic_types.jakt
+++ b/tests/codegen/out_of_order_generic_types.jakt
@@ -18,7 +18,7 @@ enum MyEnum<T> {
     A(MyRecursiveEnum<T>)
 }
 
-ref enum MyRecursiveEnum<T> {
+recursive enum MyRecursiveEnum<T> {
     A(MyRecursiveEnum<T>)
     B
 }

--- a/tests/codegen/out_of_order_types.jakt
+++ b/tests/codegen/out_of_order_types.jakt
@@ -19,7 +19,7 @@ enum MyEnum {
     A(MyRecursiveEnum)
 }
 
-ref enum MyRecursiveEnum {
+recursive enum MyRecursiveEnum {
     A(MyRecursiveEnum)
     B
 }

--- a/tests/parser/enum_correct_typename_in_typed_variant.jakt
+++ b/tests/parser/enum_correct_typename_in_typed_variant.jakt
@@ -1,7 +1,7 @@
 /// Expect:
 /// - output: ""
 
-ref enum Foo<T> {
+recursive enum Foo<T> {
     A(T?)
     B([T])
     C([T:T])

--- a/tests/parser/ref_followed_by_eof_crash.jakt
+++ b/tests/parser/ref_followed_by_eof_crash.jakt
@@ -1,4 +1,0 @@
-/// Expect:
-/// - error: "expected enum keyword"
-
-ref


### PR DESCRIPTION
Renames `ref enum` to `recursive enum` for better readability