### PR TITLE
parser+tests: Show an error if an enum is empty

### DIFF
--- a/samples/enums/empty_enum.jakt
+++ b/samples/enums/empty_enum.jakt
@@ -1,0 +1,8 @@
+/// Expect:
+/// - error: "Empty enums are not allowed"
+
+enum Foo {
+    function oops(mutable this) { }
+}
+
+function main() { }

--- a/src/typechecker.rs
+++ b/src/typechecker.rs
@@ -1665,6 +1665,15 @@ fn typecheck_enum_predecl(
     let enum_scope_id = project.create_scope(parent_scope_id, false);
     let mut generic_parameters = Vec::new();
 
+    if enum_.variants.is_empty() {
+        error = error.or(Some(JaktError::ParserErrorWithHint(
+            "Empty enums are not allowed".to_string(),
+            enum_.span,
+            "Add at least one enum variant".to_string(),
+            enum_.span,
+        )));
+    }
+
     for (generic_parameter, parameter_span) in &enum_.generic_parameters {
         project
             .types


### PR DESCRIPTION
After parsing something like:

`enum Foo { }`

a C++ error was visible. Now we check if an enum is empty and show a Jakt error with a hint.
Also add a test for this behaviour.