### PR TITLE
parser+typechecker+codegen: add support for early returns in functions that return void

### DIFF
--- a/samples/control_flow/early_return.jakt
+++ b/samples/control_flow/early_return.jakt
@@ -1,0 +1,17 @@
+/// Expect:
+/// - output: "1\n2\n3\n4\n5\n"
+
+function f(){
+    let mutable i = 1;
+    while i <= 10{
+        if i > 5 {
+            return
+        }
+        println("{}", i)
+        i = i+1;
+    }
+}
+
+function main() {
+    f()
+}

--- a/src/codegen.rs
+++ b/src/codegen.rs
@@ -1865,12 +1865,15 @@ fn codegen_statement(indent: usize, stmt: &CheckedStatement, project: &Project) 
             output.push_str(&codegen_statement(indent, statement, project));
             output.push_str("});\n");
         }
-        CheckedStatement::Return(expr) => {
-            let expr = codegen_expr(indent, expr, project);
-            output.push_str("return (");
-            output.push_str(&expr);
-            output.push_str(");\n")
-        }
+        CheckedStatement::Return(expr) => match expr {
+            Some(e) => {
+                let expr = codegen_expr(indent, e, project);
+                output.push_str("return (");
+                output.push_str(&expr);
+                output.push_str(");\n")
+            }
+            None => output.push_str("return;\n"),
+        },
         CheckedStatement::If(cond, block, else_stmt) => {
             let expr = codegen_expr(indent, cond, project);
             output.push_str("if (");


### PR DESCRIPTION
I believe this fixes #436 by making Return statements optionally have an expression. I have made changes to the typechecker and codegen as well.