### PR TITLE
Everywhere: Implement from block expressions

### DIFF
--- a/samples/block_exprs/block_expression_with_return.jakt
+++ b/samples/block_exprs/block_expression_with_return.jakt
@@ -1,0 +1,15 @@
+/// Expect:
+/// - output: "100\n"
+
+function mayFail() throws {
+    return 10;
+}
+
+function main() {
+    let x = y from {
+        // may return here
+        let mutable y = mayFail()
+        y *= 10
+    }
+    println("{}", x)
+}

--- a/samples/block_exprs/match_with_block_expressions.jakt
+++ b/samples/block_exprs/match_with_block_expressions.jakt
@@ -1,0 +1,23 @@
+/// Expect:
+/// - output: "3\n"
+
+enum Op {
+    Add,
+    Sub
+}
+
+// (Obviously could do the expression directly here)
+function do_operation(op: Op, a: i32, b: i32) {
+    return match op {
+        Add => result from {
+            let result = a + b
+        }
+        Sub => result from {
+            let result = a - b
+        }
+    }
+}
+
+function main() {
+    println("{}", do_operation(op: Op::Add, a: 1, b: 2))
+}

--- a/samples/block_exprs/simple_block_expression.jakt
+++ b/samples/block_exprs/simple_block_expression.jakt
@@ -1,0 +1,12 @@
+/// Expect:
+/// - output: "102\n"
+
+function main() {
+    let x = y from {
+        let mutable y = 0;
+        while y < 100 {
+            y += 3;
+        }
+    }
+    println("{}", x)
+}

--- a/src/codegen.rs
+++ b/src/codegen.rs
@@ -1818,6 +1818,28 @@ fn codegen_block(indent: usize, checked_block: &CheckedBlock, project: &Project)
     output
 }
 
+fn codegen_block_expr(
+    indent: usize,
+    checked_block: &CheckedBlock,
+    yeilding: &CheckedVariable,
+    project: &Project,
+) -> String {
+    let mut output = String::new();
+
+    output.push_str("({\n");
+    for stmt in &checked_block.stmts {
+        let stmt = codegen_statement(indent + INDENT_SIZE, stmt, project);
+        output.push_str(&stmt);
+    }
+    output.push_str(&codegen_indent(indent + 4));
+    output.push_str(&yeilding.name);
+    output.push_str(";\n");
+    output.push_str(&codegen_indent(indent));
+    output.push_str("})");
+
+    output
+}
+
 fn codegen_statement(indent: usize, stmt: &CheckedStatement, project: &Project) -> String {
     let mut output = String::new();
 
@@ -2821,6 +2843,9 @@ fn codegen_expr(indent: usize, expr: &CheckedExpression, project: &Project) -> S
                     ));
                 }
             };
+        }
+        CheckedExpression::FromBlock(var, block, _) => {
+            output.push_str(&codegen_block_expr(indent, block, var, project));
         }
         CheckedExpression::UnaryOp(expr, op, _, type_id) => {
             output.push('(');

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -290,6 +290,7 @@ pub enum ParsedExpression {
     Tuple(Vec<ParsedExpression>, Span),
     Range(Box<ParsedExpression>, Box<ParsedExpression>, Span),
     Match(Box<ParsedExpression>, Vec<MatchCase>, Span),
+    FromBlock(String, ParsedBlock, Span),
 
     IndexedTuple(Box<ParsedExpression>, usize, Span),
     IndexedStruct(Box<ParsedExpression>, String, Span),
@@ -337,6 +338,7 @@ impl ParsedExpression {
             ParsedExpression::OptionalSome(_, span) => *span,
             ParsedExpression::ForcedUnwrap(_, span) => *span,
             ParsedExpression::Match(_, _, span) => *span,
+            ParsedExpression::FromBlock(_, _, span) => *span,
             ParsedExpression::Garbage(span) => *span,
         }
     }
@@ -2824,6 +2826,12 @@ pub fn parse_operand(tokens: &[Token], index: &mut usize) -> (ParsedExpression, 
 
                             ParsedExpression::Call(call, span)
                         }
+                    }
+                    TokenContents::Name(keyword) if keyword == "from" => {
+                        *index += 2;
+                        let (block, err) = parse_block(tokens, index);
+                        error = error.or(err);
+                        ParsedExpression::FromBlock(name.to_string(), block, span)
                     }
                     _ => {
                         *index += 1;


### PR DESCRIPTION
This implements `var from { ... }` expressions that allow blocks to to be used as expressions. Where the expression evaluates to the variable `var` from the following block.

This maps directly on the the GCC block expression extension `({ ...; var; })`. This can be useful for match cases and for initialising stuff that you may want to bail out from.

This was one of the syntaxes mentioned yesterday in the `#jakt` channel on Discord, that I was rather fond of, so I wanted to try implementing a little proof of concept. I'm not sure this will survive the court of public option though :sweat_smile: 

