### PR TITLE
Everywhere: Allow yielding values from blocks in select places / parser: Allow specifying multiple patterns before '=>' in match cases

### DIFF
--- a/README.md
+++ b/README.md
@@ -274,6 +274,7 @@ function main() {
 - [x] Enums as names for values of an underlying type
 - [x] `match` expressions
 - [x] Enum scope inference in `match` arms
+- [x] Yielding values from match blocks
 - [ ] Nested `match` patterns
 - [ ] Traits as `match` patterns
 - [ ] Support for interop with the `?`, `??` and `!` operators
@@ -286,7 +287,11 @@ enum MyOptional<T> {
 
 function value_or_default<T>(anonymous x: MyOptional<T>, default: T) -> T {
     return match x {
-        Some(value) => value
+        Some(value) => {
+            let stuff = maybe_do_stuff_with(value)
+            let more_stuff = stuff.do_some_more_processing()
+            yield more_stuff
+        }
         None => default
     }
 }

--- a/editors/vim/syntax/jakt.vim
+++ b/editors/vim/syntax/jakt.vim
@@ -22,6 +22,7 @@ let s:jakt_syntax_keywords = {
     \ ,                   "break"
     \ ,                   "continue"
     \ ,                   "throw"
+    \ ,                   "yield"
     \ ,                  ]
     \ , 'jaktBoolean' :["true"
     \ ,                 "false"

--- a/editors/vscode/syntaxes/jakt.tmLanguage.json
+++ b/editors/vscode/syntaxes/jakt.tmLanguage.json
@@ -717,7 +717,7 @@
         },
         {
           "name": "keyword.control.jakt",
-          "match": "\\b(return|throw|continue|break)\\b"
+          "match": "\\b(return|throw|continue|break|yield)\\b"
         },
         {
           "name": "meta.control.match.jakt",

--- a/samples/match/match_block_yield.jakt
+++ b/samples/match/match_block_yield.jakt
@@ -1,0 +1,11 @@
+/// Expect:
+/// - output: "PASS\n"
+
+function main() {
+    println("{}", match "test" {
+        "test" => {
+            yield "PASS"
+        }
+        else => "FAIL"
+    })
+}

--- a/samples/match/match_pattern_or.jakt
+++ b/samples/match/match_pattern_or.jakt
@@ -1,0 +1,23 @@
+/// Expect:
+/// - output: "PASS\nPASS\n"
+
+enum Foo {
+    Bar
+    Baz
+    Bat
+}
+
+function main() {
+    println("{}", match "foo" {
+        "foo" | "bar" | "baz" => {
+            yield "PASS"
+        }
+        else => "FAIL"
+    })
+
+    let p = Foo::Bar
+    println("{}", match p {
+        Bar => "PASS"
+        Baz | else => "FAIL"
+    })
+}

--- a/tests/typechecker/block_yield_type_mismatch.jakt
+++ b/tests/typechecker/block_yield_type_mismatch.jakt
@@ -1,0 +1,16 @@
+/// Expect:
+/// - error: "Type mismatch: expected ‘i64’, but got ‘String’"
+
+function main() {
+    match 123 {
+        1 => {
+            yield "foo"
+        }
+        2 => {
+            yield "bar"
+        }
+        else => {
+            yield 123
+        }
+    }
+}

--- a/tests/typechecker/block_yield_unobservable_if.jakt
+++ b/tests/typechecker/block_yield_unobservable_if.jakt
@@ -1,0 +1,8 @@
+/// Expect:
+/// - error: "an 'if' block is not allowed to yield values"
+
+function main() {
+    if true {
+        yield "foo"
+    }
+}

--- a/tests/typechecker/block_yield_unobservable_stmt.jakt
+++ b/tests/typechecker/block_yield_unobservable_stmt.jakt
@@ -1,0 +1,8 @@
+/// Expect:
+/// - error: "A block used as a statement cannot yield values, as the value cannot be observed in any way"
+
+function main() {
+    {
+        yield "foo"
+    }
+}

--- a/tests/typechecker/yield_inside_defer.jakt
+++ b/tests/typechecker/yield_inside_defer.jakt
@@ -1,0 +1,8 @@
+/// Expect:
+/// - error: "A block used as a statement cannot yield values, as the value cannot be observed in any way"
+
+function main() {
+    defer {
+        yield "foo"
+    }
+}


### PR DESCRIPTION
```rs
match cut(.life) {
    Into | Pieces => this is MyLastResort
    Suffocation | No(breathing) => {
        if .cut(.arm) and .bleeding { return not give("a fuck") }
        yield this is MyLastResort
    }
    // I got bored
}
```