### PR TITLE
parser: Only allow yield to be used inside a block

### DIFF
--- a/tests/parser/yield_not_used_in_block_from_defer.jakt
+++ b/tests/parser/yield_not_used_in_block_from_defer.jakt
@@ -1,0 +1,6 @@
+/// Expect:
+/// - error: "yield can only be used inside a block"
+
+function main() {
+    defer yield 1
+}

--- a/tests/parser/yield_not_used_in_block_from_try.jakt
+++ b/tests/parser/yield_not_used_in_block_from_try.jakt
@@ -1,0 +1,6 @@
+/// Expect:
+/// - error: "yield can only be used inside a block"
+
+function main() {
+    try yield 1 catch {}
+}


### PR DESCRIPTION
Previously it would panic in codegen when it noticed there are no
entered yieldable blocks.