### PR TITLE
typechecker: Added cint type id to negate

### DIFF
--- a/src/typechecker.rs
+++ b/src/typechecker.rs
@@ -5394,7 +5394,8 @@ pub fn typecheck_unary_operation(
                 | crate::compiler::U32_TYPE_ID
                 | crate::compiler::U64_TYPE_ID
                 | crate::compiler::F32_TYPE_ID
-                | crate::compiler::F64_TYPE_ID => {
+                | crate::compiler::F64_TYPE_ID
+                | crate::compiler::CINT_TYPE_ID => {
                     // FIXME: This at least allows us to check out-of-bounds constants at compile time.
                     //        We should expand it to check any compile-time known value.
                     if let CheckedExpression::NumericConstant(ref number, span, type_id) = expr {

--- a/tests/typechecker/array_negative_c_int.jakt
+++ b/tests/typechecker/array_negative_c_int.jakt
@@ -1,0 +1,9 @@
+/// Expect:
+/// - output: "-1\n2\n"
+
+function main() {
+    let array: [c_int] = [-1 as! c_int, 2 as! c_int]
+
+    println("{}", array[0])
+    println("{}", array[1])
+}


### PR DESCRIPTION
Before we couldn't typecast negative constants to c_int.
This fix makes it so now we can do things like `-1 as! c_int`.
Fixes #465.