### PR TITLE
vscode: Fix enum and function that `throws` highlighting

### DIFF
--- a/editors/vscode/syntaxes/jakt.tmLanguage.json
+++ b/editors/vscode/syntaxes/jakt.tmLanguage.json
@@ -243,37 +243,16 @@
     "enum-field": {
       "patterns": [
         {
-          "name": "meta.field.enum.jakt",
-          "begin": "\\b((?:\\w|_)(?:\\w|_|[0-9])*)\\s*(\\{)",
-          "beginCaptures": {
+          "name": "meta.field.assigned.enum.jakt",
+          "match": "\\b((?:\\w|_)(?:\\w|_|[0-9])*)\\s*(=)",
+          "captures": {
             "1": {
               "name": "variable.field.enum.jakt"
             },
             "2": {
-              "name": "punctuation.begin.brace.jakt"
+              "name": "keyword.operator.assignment.jakt"
             }
           },
-          "end": "(\\})",
-          "endCaptures": {
-            "1": {
-              "name": "punctuation.end.brace.jakt"
-            }
-          },
-          "patterns": [
-            {
-              "include": "#field"
-            }
-          ]
-        },
-        {
-          "name": "meta.field.assigned.enum.jakt",
-          "begin": "(=)",
-          "beginCaptures": {
-            "1": {
-              "name": "punctuation.equals.jakt"
-            }
-          },
-          "end": "$",
           "patterns": [
             {
               "include": "#number"
@@ -285,7 +264,7 @@
         },
         {
           "name": "meta.field.enum.jakt",
-          "match": "\\b((?:\\w|_)(?:\\w|_|[0-9])*)\\s*$",
+          "match": "(?<!\\)\\s*)(?<!\\=\\s*)\\b((?:\\w|_)(?:\\w|_|[0-9])*)(?:\\s*$|\\s*\\(|\\,)",
           "captures": {
             "1": {
               "name": "variable.field.enum.jakt"

--- a/editors/vscode/syntaxes/jakt.tmLanguage.json
+++ b/editors/vscode/syntaxes/jakt.tmLanguage.json
@@ -438,6 +438,21 @@
           ]
         },
         {
+          "name": "meta.function.return-throws.jakt",
+          "begin": "(?<=\\)\\s*)(throws)",
+          "beginCaptures": {
+            "1": {
+              "name": "keyword.type.throws.jakt"
+            }
+          },
+          "end": "(?=\\{|$)",
+          "patterns": [
+            {
+              "include": "#types"
+            }
+          ]
+        },
+        {
           "name": "meta.function.body.jakt",
           "begin": "(?<=function.*?)(\\{)",
           "beginCaptures": {


### PR DESCRIPTION
Image for reference: https://imgur.com/a/WE9i53U
This makes underlined words from section 1 "variable.field.enum.jakt". Words from section 2 are "entity.name.type.enum.jakt" (no change here).
The only thing I'm not sure is, if underlined words in sections 1 and 2 should be both "variable.field.enum.jakt" or "entity.name.type.enum.jakt", or the way it is on the screenshot, or maybe even something else.
Marking them both as a type makes some sense, but I don't like (a bit) how it looks after that: https://imgur.com/a/Bi7fLcx

Apart from enum highlighting, this also fixes
`function Foo() throws {`
where `throws` was not highlighted but when we had something like:
`function Foo() throws -> String {`
it was highlighted.

Before: https://imgur.com/a/GWTI2V5
After: https://imgur.com/a/jdW8Fu7