### PR TITLE
vscode: fix comment highlighting in enum block

### DIFF
--- a/editors/vscode/syntaxes/jakt.tmLanguage.json
+++ b/editors/vscode/syntaxes/jakt.tmLanguage.json
@@ -187,6 +187,9 @@
           "patterns": [
             {
               "include": "#enum-field"
+            },
+            {
+              "include": "$self"
             }
           ]
         },

--- a/samples/apps/json.jakt
+++ b/samples/apps/json.jakt
@@ -1,5 +1,3 @@
-// FIXME: Syntax highlighting should understand inline comments in enum
-
 extern struct StringBuilder {
     // FIXME: AK::StringBuilder::append() actually takes a c_char, not a u8, but nobody complains
     function append(mutable this, anonymous c: u8)


### PR DESCRIPTION
AK noticed this whilst working on the JSON video, straight-forward fix.