### PR TITLE
all: Add IDE support file, add goto-def support to compiler and VSCode

### DIFF
--- a/editors/vscode/package-lock.json
+++ b/editors/vscode/package-lock.json
@@ -7,11 +7,11 @@
 		"": {
 			"name": "jakt",
 			"version": "0.0.2",
-			"hasInstallScript": true,
 			"license": "BSD",
 			"devDependencies": {
 				"@types/mocha": "^9.1.0",
 				"@types/node": "^16.11.7",
+				"@types/tmp": "^0.2.3",
 				"@typescript-eslint/eslint-plugin": "^5.19.0",
 				"@typescript-eslint/parser": "^5.19.0",
 				"esbuild": "^0.14.42",
@@ -114,6 +114,12 @@
 			"version": "16.11.38",
 			"resolved": "https://registry.npmjs.org/@types/node/-/node-16.11.38.tgz",
 			"integrity": "sha512-hjO/0K140An3GWDw2HJfq7gko3wWeznbjXgg+rzPdVzhe198hp4x2i1dgveAOEiFKd8sOilAxzoSJiVv5P/CUg==",
+			"dev": true
+		},
+		"node_modules/@types/tmp": {
+			"version": "0.2.3",
+			"resolved": "https://registry.npmjs.org/@types/tmp/-/tmp-0.2.3.tgz",
+			"integrity": "sha512-dDZH/tXzwjutnuk4UacGgFRwV+JSLaXL1ikvidfJprkb7L9Nx1njcRHHmi3Dsvt7pgqqTEeucQuOrWHPFgzVHA==",
 			"dev": true
 		},
 		"node_modules/@typescript-eslint/eslint-plugin": {
@@ -2519,6 +2525,12 @@
 			"version": "16.11.38",
 			"resolved": "https://registry.npmjs.org/@types/node/-/node-16.11.38.tgz",
 			"integrity": "sha512-hjO/0K140An3GWDw2HJfq7gko3wWeznbjXgg+rzPdVzhe198hp4x2i1dgveAOEiFKd8sOilAxzoSJiVv5P/CUg==",
+			"dev": true
+		},
+		"@types/tmp": {
+			"version": "0.2.3",
+			"resolved": "https://registry.npmjs.org/@types/tmp/-/tmp-0.2.3.tgz",
+			"integrity": "sha512-dDZH/tXzwjutnuk4UacGgFRwV+JSLaXL1ikvidfJprkb7L9Nx1njcRHHmi3Dsvt7pgqqTEeucQuOrWHPFgzVHA==",
 			"dev": true
 		},
 		"@typescript-eslint/eslint-plugin": {

--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -76,6 +76,7 @@
 	"devDependencies": {
 		"@types/mocha": "^9.1.0",
 		"@types/node": "^16.11.7",
+		"@types/tmp": "^0.2.3",
 		"@typescript-eslint/eslint-plugin": "^5.19.0",
 		"@typescript-eslint/parser": "^5.19.0",
 		"esbuild": "^0.14.42",

--- a/src/compiler.rs
+++ b/src/compiler.rs
@@ -141,6 +141,10 @@ impl Compiler {
 
         let file_scope_id = project.scopes.len() - 1;
 
+        project
+            .file_ids
+            .insert(fname.to_string_lossy().to_string(), file_scope_id);
+
         let err = typecheck_namespace_predecl(&file, file_scope_id, project);
         if let Some(err) = err {
             return (file_scope_id, Some(err));

--- a/src/ide.rs
+++ b/src/ide.rs
@@ -1,0 +1,306 @@
+use crate::{
+    typechecker::{
+        CheckedBlock, CheckedExpression, CheckedFunction, CheckedMatchBody, CheckedMatchCase,
+        CheckedStatement, FunctionId, Scope, TypeId,
+    },
+    Project, Span,
+};
+
+pub fn find_definition_in_project(project: &Project, span: Span) -> Span {
+    match find_span_in_project(project, span) {
+        Some(Usage::Variable(span, type_id)) => span,
+        Some(Usage::Call(function_id)) => project.functions[function_id].name_span,
+        None => span,
+    }
+}
+
+pub fn find_span_in_project(project: &Project, span: Span) -> Option<Usage> {
+    // lol, for now since vscode is going to send us a url instead
+    // of a filepath, let's just assume we are going to look at the file
+    // at hand.
+
+    for (file_name, scope_id) in &project.file_ids {
+        let scope = &project.scopes[*scope_id];
+
+        return find_span_in_scope(project, scope, span);
+    }
+
+    None
+}
+
+pub fn find_span_in_scope(project: &Project, scope: &Scope, span: Span) -> Option<Usage> {
+    for (_, function_id, _) in &scope.functions {
+        let function = &project.functions[*function_id];
+
+        if let Some(usage) = find_span_in_function(project, function, span) {
+            return Some(usage);
+        }
+    }
+
+    for (_, struct_id, _) in &scope.structs {
+        let checked_struct = &project.structs[*struct_id];
+
+        let scope = &project.scopes[checked_struct.scope_id];
+
+        if let Some(usage) = find_span_in_scope(project, scope, span) {
+            return Some(usage);
+        }
+    }
+
+    for (_, enum_id, _) in &scope.enums {
+        let checked_enum = &project.enums[*enum_id];
+
+        let scope = &project.scopes[checked_enum.scope_id];
+
+        if let Some(usage) = find_span_in_scope(project, scope, span) {
+            return Some(usage);
+        }
+    }
+
+    for child in &scope.children {
+        let scope = &project.scopes[*child];
+
+        if let Some(usage) = find_span_in_scope(project, scope, span) {
+            return Some(usage);
+        }
+    }
+
+    None
+}
+
+pub fn find_span_in_function(
+    project: &Project,
+    function: &CheckedFunction,
+    span: Span,
+) -> Option<Usage> {
+    if let Some(block) = &function.block {
+        return find_span_in_block(project, block, span);
+    }
+
+    None
+}
+
+pub fn find_span_in_block(project: &Project, block: &CheckedBlock, span: Span) -> Option<Usage> {
+    for stmt in &block.stmts {
+        if let Some(usage) = find_span_in_statement(project, stmt, span) {
+            return Some(usage);
+        }
+    }
+
+    None
+}
+
+pub fn find_span_in_statement(
+    project: &Project,
+    statement: &CheckedStatement,
+    span: Span,
+) -> Option<Usage> {
+    match statement {
+        CheckedStatement::Block(block) => find_span_in_block(project, block, span),
+        CheckedStatement::Defer(deferred) => find_span_in_statement(project, deferred, span),
+        CheckedStatement::Expression(expr) => find_span_in_expression(project, expr, span),
+        CheckedStatement::If(expr, block, stmt) => {
+            if let Some(usage) = find_span_in_expression(project, expr, span) {
+                Some(usage)
+            } else if let Some(usage) = find_span_in_block(project, block, span) {
+                Some(usage)
+            } else if let Some(stmt) = stmt {
+                find_span_in_statement(project, stmt, span)
+            } else {
+                None
+            }
+        }
+        CheckedStatement::InlineCpp(_) => None,
+        CheckedStatement::Loop(block) => find_span_in_block(project, block, span),
+        CheckedStatement::Return(expr) | CheckedStatement::Throw(expr) => {
+            find_span_in_expression(project, expr, span)
+        }
+        CheckedStatement::Try(stmt, _, block) => {
+            if let Some(usage) = find_span_in_statement(project, stmt, span) {
+                Some(usage)
+            } else {
+                find_span_in_block(project, block, span)
+            }
+        }
+        CheckedStatement::VarDecl(_, expr) => find_span_in_expression(project, expr, span),
+        CheckedStatement::While(expr, block) => {
+            if let Some(usage) = find_span_in_expression(project, expr, span) {
+                Some(usage)
+            } else {
+                find_span_in_block(project, block, span)
+            }
+        }
+        CheckedStatement::Yield(expr) => find_span_in_expression(project, expr, span),
+        CheckedStatement::Break => None,
+        CheckedStatement::Continue => None,
+        CheckedStatement::Garbage => None,
+    }
+}
+
+pub fn find_span_in_expression(
+    project: &Project,
+    expression: &CheckedExpression,
+    span: Span,
+) -> Option<Usage> {
+    match expression {
+        CheckedExpression::Array(elems, repeat, _, _) => {
+            for elem in elems {
+                if let Some(usage) = find_span_in_expression(project, elem, span) {
+                    return Some(usage);
+                }
+
+                if let Some(repeat) = repeat {
+                    return find_span_in_expression(project, repeat, span);
+                }
+            }
+        }
+        CheckedExpression::BinaryOp(lhs, _, rhs, _, _) => {
+            if let Some(usage) = find_span_in_expression(project, lhs, span) {
+                return Some(usage);
+            }
+            if let Some(usage) = find_span_in_expression(project, rhs, span) {
+                return Some(usage);
+            }
+        }
+        CheckedExpression::Block(block, _, _) => return find_span_in_block(project, block, span),
+        CheckedExpression::Call(call, call_span, _) => {
+            for (_, arg) in &call.args {
+                if let Some(usage) = find_span_in_expression(project, arg, span) {
+                    return Some(usage);
+                }
+            }
+            if call_span.contains(span) {
+                if let Some(function_id) = call.function_id {
+                    return Some(Usage::Call(function_id));
+                } else {
+                    return None;
+                }
+            }
+        }
+        CheckedExpression::Dictionary(items, _, _) => {
+            for (key, value) in items {
+                if let Some(usage) = find_span_in_expression(project, key, span) {
+                    return Some(usage);
+                }
+
+                if let Some(usage) = find_span_in_expression(project, value, span) {
+                    return Some(usage);
+                }
+            }
+        }
+        CheckedExpression::IndexedExpression(obj, expr, _, _) => {
+            if let Some(usage) = find_span_in_expression(project, obj, span) {
+                return Some(usage);
+            }
+
+            if let Some(usage) = find_span_in_expression(project, expr, span) {
+                return Some(usage);
+            }
+        }
+        CheckedExpression::IndexedStruct(expr, _, _, _) => {
+            if let Some(usage) = find_span_in_expression(project, expr, span) {
+                return Some(usage);
+            }
+        }
+        CheckedExpression::IndexedDictionary(key, value, _, _) => {
+            if let Some(usage) = find_span_in_expression(project, key, span) {
+                return Some(usage);
+            }
+
+            if let Some(usage) = find_span_in_expression(project, value, span) {
+                return Some(usage);
+            }
+        }
+        CheckedExpression::Match(expr, cases, _, _, _) => {
+            for case in cases {
+                match case {
+                    CheckedMatchCase::EnumVariant {
+                        variant_name: _,
+                        variant_arguments: _,
+                        subject_type_id: _,
+                        variant_index: _,
+                        scope_id: _,
+                        body,
+                    } => match body {
+                        CheckedMatchBody::Block(block) => {
+                            if let Some(usage) = find_span_in_block(project, block, span) {
+                                return Some(usage);
+                            }
+                        }
+                        CheckedMatchBody::Expression(expr) => {
+                            if let Some(usage) = find_span_in_expression(project, expr, span) {
+                                return Some(usage);
+                            }
+                        }
+                    },
+                    CheckedMatchCase::Expression { expression, body } => {
+                        if let Some(usage) = find_span_in_expression(project, expression, span) {
+                            return Some(usage);
+                        }
+
+                        match body {
+                            CheckedMatchBody::Block(block) => {
+                                if let Some(usage) = find_span_in_block(project, block, span) {
+                                    return Some(usage);
+                                }
+                            }
+                            CheckedMatchBody::Expression(expr) => {
+                                if let Some(usage) = find_span_in_expression(project, expr, span) {
+                                    return Some(usage);
+                                }
+                            }
+                        }
+                    }
+                    CheckedMatchCase::CatchAll { body } => match body {
+                        CheckedMatchBody::Block(block) => {
+                            if let Some(usage) = find_span_in_block(project, block, span) {
+                                return Some(usage);
+                            }
+                        }
+                        CheckedMatchBody::Expression(expr) => {
+                            if let Some(usage) = find_span_in_expression(project, expr, span) {
+                                return Some(usage);
+                            }
+                        }
+                    },
+                }
+            }
+
+            if let Some(usage) = find_span_in_expression(project, expr, span) {
+                return Some(usage);
+            }
+        }
+        CheckedExpression::ForcedUnwrap(expr, _, _) => {
+            if let Some(usage) = find_span_in_expression(project, expr, span) {
+                return Some(usage);
+            }
+        }
+        CheckedExpression::MethodCall(object, call, method_span, _) => {
+            if let Some(usage) = find_span_in_expression(project, object, span) {
+                return Some(usage);
+            }
+            if method_span.contains(span) {
+                if let Some(function_id) = call.function_id {
+                    return Some(Usage::Call(function_id));
+                } else {
+                    return None;
+                }
+            } else {
+                return None;
+            }
+        }
+        CheckedExpression::Var(var, var_span) => {
+            if var_span.contains(span) {
+                return Some(Usage::Variable(var.definition_span, var.type_id));
+            }
+        }
+        _ => {}
+    }
+
+    None
+}
+
+pub enum Usage {
+    Variable(Span, TypeId),
+    Call(FunctionId),
+}

--- a/src/lexer.rs
+++ b/src/lexer.rs
@@ -22,6 +22,10 @@ impl Span {
             end,
         }
     }
+
+    pub fn contains(self, span: Span) -> bool {
+        self.file_id == span.file_id && span.start >= self.start && span.end <= self.end
+    }
 }
 
 #[derive(Debug, PartialEq)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,11 +17,13 @@ extern crate core;
 mod codegen;
 mod compiler;
 mod error;
+mod ide;
 mod lexer;
 mod parser;
 mod typechecker;
 
 pub use compiler::Compiler;
 pub use error::JaktError;
+pub use ide::find_definition_in_project;
 pub use lexer::Span;
 pub use typechecker::Project;

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -100,6 +100,7 @@ pub struct ParsedNamespace {
 #[derive(Debug)]
 pub struct ParsedStruct {
     pub name: String,
+    pub name_span: Span,
     pub generic_parameters: Vec<(String, Span)>,
     pub fields: Vec<ParsedVarDecl>,
     pub methods: Vec<ParsedFunction>,
@@ -1262,9 +1263,11 @@ pub fn parse_struct(
         match &tokens[*index] {
             Token {
                 contents: TokenContents::Name(struct_name),
-                ..
+                span,
             } => {
                 *index += 1;
+
+                let name_span = *span;
 
                 // Check for generic
                 let (params, parse_error) = parse_generic_parameters(tokens, index);
@@ -1498,6 +1501,7 @@ pub fn parse_struct(
                 (
                     ParsedStruct {
                         name: struct_name.clone(),
+                        name_span,
                         generic_parameters,
                         fields,
                         methods,
@@ -1519,6 +1523,7 @@ pub fn parse_struct(
                 (
                     ParsedStruct {
                         name: String::new(),
+                        name_span: tokens[*index].span,
                         generic_parameters,
                         fields: Vec::new(),
                         methods: Vec::new(),
@@ -1541,6 +1546,7 @@ pub fn parse_struct(
         (
             ParsedStruct {
                 name: String::new(),
+                name_span: tokens[*index].span,
                 generic_parameters,
                 fields: Vec::new(),
                 methods: Vec::new(),
@@ -4018,6 +4024,7 @@ pub fn parse_variable_declaration(
     match &tokens[*index].contents {
         TokenContents::Name(name) => {
             let var_name = name.to_string();
+            let name_span = tokens[*index].span;
 
             *index += 1;
 
@@ -4032,7 +4039,7 @@ pub fn parse_variable_declaration(
                                 name: name.to_string(),
                                 parsed_type: ParsedType::Empty,
                                 mutable: false,
-                                span: tokens[*index - 1].span,
+                                span: name_span,
                                 visibility,
                             },
                             None,
@@ -4045,7 +4052,7 @@ pub fn parse_variable_declaration(
                         name: name.to_string(),
                         parsed_type: ParsedType::Empty,
                         mutable: false,
-                        span: tokens[*index - 1].span,
+                        span: name_span,
                         visibility,
                     },
                     None,
@@ -4053,7 +4060,6 @@ pub fn parse_variable_declaration(
             }
 
             if *index < tokens.len() {
-                let decl_span = tokens[*index - 1].span;
                 let mutable = *index + 1 < tokens.len()
                     && match &tokens[*index].contents {
                         TokenContents::Name(name) if name == "mutable" => {
@@ -4070,7 +4076,7 @@ pub fn parse_variable_declaration(
                     name: var_name,
                     parsed_type: var_type,
                     mutable,
-                    span: decl_span,
+                    span: name_span,
                     visibility,
                 };
 

--- a/src/typechecker.rs
+++ b/src/typechecker.rs
@@ -2572,7 +2572,7 @@ fn typecheck_struct(
 
         let checked_constructor = CheckedFunction {
             name: structure.name.clone(),
-            name_span: structure.span,
+            name_span: structure.name_span,
             throws: structure.definition_type == DefinitionType::Class,
             return_type_id: struct_type_id,
             params: constructor_params,


### PR DESCRIPTION
This adds a new `ide.rs` file that handles IDE support calls, which you can reach from new flags in `main.rs`

The first of these is "goto def", the ability to jump to the definition side for a given location in the file. This should be considered rudimentary for now, but hopefully should be good enough to help location areas for the definition or near the definition.

I've added "goto def" support in VSCode and turned it on my default. This will require a build of the compiler with the new flag in the path to work properly.