### PR TITLE
all: Add hover and dot completion support

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,6 +24,8 @@ mod typechecker;
 
 pub use compiler::Compiler;
 pub use error::JaktError;
-pub use ide::find_definition_in_project;
+pub use ide::{
+    find_definition_in_project, find_dot_completions_in_project, find_typename_in_project,
+};
 pub use lexer::Span;
 pub use typechecker::Project;


### PR DESCRIPTION
This adds support for typename on hover and dot (`.`) completions to the compiler and VSCode.

Typenames are still rudimentary and display the typename we would show in the terminal.

Completions are triggered via `.` and currently intended to retrieve fields and method names from a structure.