### PR TITLE
vscode: Separate function and field autocompletions

### DIFF
--- a/editors/vscode/server/src/server.ts
+++ b/editors/vscode/server/src/server.ts
@@ -363,7 +363,7 @@ connection.onCompletion(
 				for (const completion of obj.completions) {
 					output.push({
 						label: completion,
-						kind: CompletionItemKind.Field,
+						kind: completion.includes('(') ? CompletionItemKind.Function : CompletionItemKind.Field,
 						data: index
 					});
 					index++;


### PR DESCRIPTION
Simple yet effective way to get field and function completions separately:
![abc](https://i.imgur.com/ApVPo8s.png)