### PR TITLE
parser+vscode: Fix incorrect span calculations

### DIFF
--- a/editors/vscode/server/src/server.ts
+++ b/editors/vscode/server/src/server.ts
@@ -38,6 +38,7 @@ import fs = require('fs');
 import tmp = require('tmp');
 
 import util = require('node:util');
+import { TextEncoder } from 'node:util';
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 const exec = util.promisify(require('node:child_process').exec);
 
@@ -202,6 +203,7 @@ documents.onDidChangeContent(change => {
 
 
 function convertSpan(index: number, text: string): Position {
+	let buffer = new TextEncoder().encode(text);
 	let line = 0;
 	let character = 0;
 
@@ -211,7 +213,7 @@ function convertSpan(index: number, text: string): Position {
 			return { line, character };
 		}
 
-		if (text[i] == '\n') {
+		if (buffer.at(i) == 0x0A) {
 			line++;
 			character = 0;
 		} else {
@@ -227,6 +229,7 @@ function convertSpan(index: number, text: string): Position {
 function convertPosition(position: Position, text: string): number {
 	let line = 0;
 	let character = 0;
+	let buffer = new TextEncoder().encode(text);
 
 	let i = 0;
 	while (i < text.length) {
@@ -234,7 +237,7 @@ function convertPosition(position: Position, text: string): number {
 			return i;
 		}
 
-		if (text[i] == '\n') {
+		if (buffer.at(i) == 0x0A) {
 			line++;
 			character = 0;
 		} else {

--- a/src/ide.rs
+++ b/src/ide.rs
@@ -86,9 +86,11 @@ pub fn find_span_in_project(project: &Project, span: Span) -> Option<Usage> {
     // at hand.
 
     for scope_id in project.file_ids.values() {
-        let scope = &project.scopes[*scope_id];
+        if *scope_id != 0 {
+            let scope = &project.scopes[*scope_id];
 
-        return find_span_in_scope(project, scope, span);
+            return find_span_in_scope(project, scope, span);
+        }
     }
 
     None

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -3460,7 +3460,7 @@ pub fn parse_operand(tokens: &[Token], index: &mut usize) -> (ParsedExpression, 
 
                     let end;
                     if *index < tokens.len() {
-                        end = *index;
+                        end = tokens[*index].span;
                         match &tokens[*index].contents {
                             TokenContents::RSquare => {
                                 *index += 1;
@@ -3473,7 +3473,7 @@ pub fn parse_operand(tokens: &[Token], index: &mut usize) -> (ParsedExpression, 
                             }
                         }
                     } else {
-                        end = *index - 1;
+                        end = tokens[*index - 1].span;
                         error = error.or(Some(JaktError::ParserError(
                             "expected ']'".to_string(),
                             tokens[*index - 1].span,
@@ -3486,7 +3486,7 @@ pub fn parse_operand(tokens: &[Token], index: &mut usize) -> (ParsedExpression, 
                         Span {
                             file_id: span.file_id,
                             start: span.start,
-                            end,
+                            end: end.end,
                         },
                     );
                 }


### PR DESCRIPTION
This fixes the incorrect span calculations in VSCode, which was counting characters but the compiler was counting bytes.

Also found an incorrect span in the parser and went ahead and fixed that as well.