### PR TITLE
runtime+codegen+tests: Support `continue`/`break` inside matches

### DIFF
--- a/runtime/lib.h
+++ b/runtime/lib.h
@@ -308,6 +308,17 @@ struct ExplicitValueOrControlFlow {
     _jakt_value.release_value(); \
 })
 
+#define JAKT_RESOLVE_EXPLICIT_VALUE_OR_CONTROL_FLOW_AT_LOOP_NESTED_MATCH(x) ({ \
+    auto&& _jakt_value = x; \
+    if (_jakt_value.is_return()) \
+      return _jakt_value.release_return(); \
+    else if (_jakt_value.is_loop_break()) \
+      return JaktInternal::LoopBreak{}; \
+    else if (_jakt_value.is_loop_continue()) \
+      return JaktInternal::LoopContinue{}; \
+    _jakt_value.release_value(); \
+})
+
 template<typename OutputType, typename InputType>
 ALWAYS_INLINE Optional<OutputType> fallible_integer_cast(InputType input)
 {

--- a/runtime/lib.h
+++ b/runtime/lib.h
@@ -290,33 +290,33 @@ struct ExplicitValueOrControlFlow {
 };
 
 #define JAKT_RESOLVE_EXPLICIT_VALUE_OR_CONTROL_FLOW_RETURN_ONLY(x) ({ \
-    auto&& _jakt_value = x;                         \
-    if (_jakt_value.is_return())                    \
-        return _jakt_value.release_return();        \
-    _jakt_value.release_value();                    \
+    auto&& _jakt_value = x;                                           \
+    if (_jakt_value.is_return())                                      \
+        return _jakt_value.release_return();                          \
+    _jakt_value.release_value();                                      \
 })
 
 // XXX: `break` might not work if codegen is inside a switch block.
 #define JAKT_RESOLVE_EXPLICIT_VALUE_OR_CONTROL_FLOW_AT_LOOP(x) ({ \
-    auto&& _jakt_value = x; \
-    if (_jakt_value.is_return()) \
-        return _jakt_value.release_return(); \
-    else if (_jakt_value.is_loop_break()) \
-        break; \
-    else if (_jakt_value.is_loop_continue()) \
-        continue; \
-    _jakt_value.release_value(); \
+    auto&& _jakt_value = x;                                       \
+    if (_jakt_value.is_return())                                  \
+        return _jakt_value.release_return();                      \
+    else if (_jakt_value.is_loop_break())                         \
+        break;                                                    \
+    else if (_jakt_value.is_loop_continue())                      \
+        continue;                                                 \
+    _jakt_value.release_value();                                  \
 })
 
 #define JAKT_RESOLVE_EXPLICIT_VALUE_OR_CONTROL_FLOW_AT_LOOP_NESTED_MATCH(x) ({ \
-    auto&& _jakt_value = x; \
-    if (_jakt_value.is_return()) \
-      return _jakt_value.release_return(); \
-    else if (_jakt_value.is_loop_break()) \
-      return JaktInternal::LoopBreak{}; \
-    else if (_jakt_value.is_loop_continue()) \
-      return JaktInternal::LoopContinue{}; \
-    _jakt_value.release_value(); \
+    auto&& _jakt_value = x;                                                    \
+    if (_jakt_value.is_return())                                               \
+        return _jakt_value.release_return();                                   \
+    else if (_jakt_value.is_loop_break())                                      \
+        return JaktInternal::LoopBreak {};                                     \
+    else if (_jakt_value.is_loop_continue())                                   \
+        return JaktInternal::LoopContinue {};                                  \
+    _jakt_value.release_value();                                               \
 })
 
 template<typename OutputType, typename InputType>

--- a/src/codegen.rs
+++ b/src/codegen.rs
@@ -72,6 +72,13 @@ impl ControlFlowState {
             ..self
         }
     }
+    const fn enter_loop(self) -> Self {
+        Self {
+            allowed_exits: AllowedControlExits::AtLoop,
+            passes_through_match: false,
+            match_nest_level: 0,
+        }
+    }
     const fn enter_match(self) -> Self {
         Self {
             allowed_exits: self.allowed_exits.allow_return(),
@@ -2112,7 +2119,7 @@ fn codegen_statement(
         CheckedStatement::Loop(block) => {
             output.push_str("for (;;) {");
             let last_control_flow = context.control_flow_state;
-            context.control_flow_state.allowed_exits = AllowedControlExits::AtLoop;
+            context.control_flow_state = last_control_flow.enter_loop();
             let block = codegen_block(indent, block, project, context);
             context.control_flow_state = last_control_flow;
             output.push_str(&block);
@@ -2126,7 +2133,7 @@ fn codegen_statement(
 
             {
                 let last_control_flow = context.control_flow_state;
-                context.control_flow_state.allowed_exits = AllowedControlExits::AtLoop;
+                context.control_flow_state = last_control_flow.enter_loop();
                 let block = codegen_block(indent, block, project, context);
                 context.control_flow_state = last_control_flow;
                 output.push_str(&block);

--- a/src/codegen.rs
+++ b/src/codegen.rs
@@ -23,6 +23,42 @@ use std::collections::{HashMap, HashSet};
 
 const INDENT_SIZE: usize = 4;
 
+#[derive(Clone, Copy)]
+enum ControlExitFlags {
+    /// No control exit statements allowed
+    Nothing,
+    /// Only `return` allowed
+    JustReturn,
+    /// `continue`/`break` allowed: `return` is also allowed in this context
+    AtLoop,
+}
+
+impl ControlExitFlags {
+    const fn is_return_allowed(&self) -> bool {
+        !matches!(self, Self::Nothing)
+    }
+    const fn are_loop_exits_allowed(&self) -> bool {
+        matches!(self, Self::AtLoop)
+    }
+    fn choose_control_flow_macro(&self) -> &str {
+        assert!(
+            self.is_return_allowed(),
+            "at least return should be allowed in this context"
+        );
+        if self.are_loop_exits_allowed() {
+            "JAKT_RESOLVE_EXPLICIT_VALUE_OR_CONTROL_FLOW_AT_LOOP"
+        } else {
+            "JAKT_RESOLVE_EXPLICIT_VALUE_OR_CONTROL_FLOW_RETURN_ONLY"
+        }
+    }
+}
+
+impl Default for ControlExitFlags {
+    fn default() -> Self {
+        Self::Nothing
+    }
+}
+
 struct CodegenContext {
     namespace_stack: Vec<String>,
     deferred_output: String,
@@ -324,7 +360,14 @@ fn codegen_nonrecursive_enum(
                         output.push_str("    ");
                         output.push_str(name);
                         output.push_str(" = ");
-                        output.push_str(&codegen_expr(0, value, project, context));
+                        output.push_str(&codegen_expr(
+                            0,
+                            value,
+                            project,
+                            context,
+                            true,
+                            ControlExitFlags::Nothing,
+                        ));
                         output.push_str(",\n");
                     }
                     _ => unreachable!(),
@@ -736,7 +779,14 @@ fn codegen_recursive_enum(
                         output.push_str("    ");
                         output.push_str(name);
                         output.push_str(" = ");
-                        output.push_str(&codegen_expr(0, value, project, context));
+                        output.push_str(&codegen_expr(
+                            0,
+                            value,
+                            project,
+                            context,
+                            true,
+                            ControlExitFlags::Nothing,
+                        ));
                         output.push_str(",\n");
                     }
                     _ => unreachable!(),
@@ -1509,6 +1559,8 @@ fn codegen_function_in_namespace(
             .expect("Function being generated must be checked"),
         project,
         context,
+        false,
+        ControlExitFlags::JustReturn,
     );
     output.push_str(&block);
 
@@ -1876,6 +1928,8 @@ fn codegen_block(
     checked_block: &CheckedBlock,
     project: &Project,
     context: &mut CodegenContext,
+    control_flow_runs_through_match: bool,
+    control_exit_flags: ControlExitFlags,
 ) -> String {
     let mut output = String::new();
 
@@ -1899,7 +1953,14 @@ fn codegen_block(
     output.push_str("{\n");
 
     for stmt in &checked_block.stmts {
-        let stmt = codegen_statement(indent + INDENT_SIZE, stmt, project, context);
+        let stmt = codegen_statement(
+            indent + INDENT_SIZE,
+            stmt,
+            project,
+            context,
+            control_flow_runs_through_match,
+            control_exit_flags,
+        );
 
         output.push_str(&stmt);
     }
@@ -1924,6 +1985,9 @@ fn codegen_statement(
     stmt: &CheckedStatement,
     project: &Project,
     context: &mut CodegenContext,
+    control_flow_runs_through_match: bool, // whether `ExplicitValueOrControlFlow` should be
+    // returned when getting a `continue`/`break`
+    control_exit_flags: ControlExitFlags,
 ) -> String {
     let mut output = String::new();
 
@@ -1933,7 +1997,14 @@ fn codegen_statement(
         CheckedStatement::Try(stmt, error_name, catch_block) => {
             output.push('{');
             output.push_str("auto _jakt_try_result = [&]() -> ErrorOr<void> {");
-            output.push_str(&codegen_statement(indent, stmt, project, context));
+            output.push_str(&codegen_statement(
+                indent,
+                stmt,
+                project,
+                context,
+                false,
+                control_exit_flags,
+            ));
             output.push(';');
             output.push_str("return {};");
             output.push_str("}();");
@@ -1943,23 +2014,52 @@ fn codegen_statement(
                 output.push_str(error_name);
                 output.push_str(" = _jakt_try_result.release_error();");
             }
-            output.push_str(&codegen_block(indent, catch_block, project, context));
+            output.push_str(&codegen_block(
+                indent,
+                catch_block,
+                project,
+                context,
+                false,
+                control_exit_flags,
+            ));
             output.push('}');
             output.push('}');
         }
         CheckedStatement::Throw(expr) => {
             output.push_str("return ");
-            output.push_str(&codegen_expr(indent, expr, project, context));
+            output.push_str(&codegen_expr(
+                indent,
+                expr,
+                project,
+                context,
+                control_flow_runs_through_match,
+                control_exit_flags,
+            ));
             output.push(';');
         }
         CheckedStatement::Continue => {
-            output.push_str("continue;");
+            output.push_str(if control_flow_runs_through_match {
+                "return JaktInternal::LoopContinue{};"
+            } else {
+                "continue;"
+            });
         }
         CheckedStatement::Break => {
-            output.push_str("break;");
+            output.push_str(if control_flow_runs_through_match {
+                "return JaktInternal::LoopBreak{};"
+            } else {
+                "break;"
+            });
         }
         CheckedStatement::Expression(expr) => {
-            let expr = codegen_expr(indent, expr, project, context);
+            let expr = codegen_expr(
+                indent,
+                expr,
+                project,
+                context,
+                control_flow_runs_through_match,
+                control_exit_flags,
+            );
             output.push_str(&expr);
             output.push_str(";\n");
         }
@@ -1968,18 +2068,39 @@ fn codegen_statement(
             output.push_str("#define __SCOPE_GUARD_NAME __scope_guard_ ## __COUNTER__\n");
             output.push_str("ScopeGuard __SCOPE_GUARD_NAME ([&] \n");
             output.push_str("#undef __SCOPE_GUARD_NAME\n{");
-            output.push_str(&codegen_statement(indent, statement, project, context));
+            output.push_str(&codegen_statement(
+                indent,
+                statement,
+                project,
+                context,
+                false,
+                control_exit_flags,
+            ));
             output.push_str("});\n");
         }
         CheckedStatement::Return(expr) => {
-            let expr = codegen_expr(indent, expr, project, context);
+            let expr = codegen_expr(
+                indent,
+                expr,
+                project,
+                context,
+                control_flow_runs_through_match,
+                control_exit_flags,
+            );
             output.push_str("return (");
             output.push_str(&expr);
             output.push_str(");\n")
         }
         CheckedStatement::Yield(expr) => {
             // yield expr -> block_var = expr; goto block_end;
-            let expr = codegen_expr(indent, expr, project, context);
+            let expr = codegen_expr(
+                indent,
+                expr,
+                project,
+                context,
+                control_flow_runs_through_match,
+                control_exit_flags,
+            );
             let (block_var_name, block_end_label) = context
                 .entered_yieldable_blocks
                 .last()
@@ -1992,33 +2113,75 @@ fn codegen_statement(
             output.push_str(";\n");
         }
         CheckedStatement::If(cond, block, else_stmt) => {
-            let expr = codegen_expr(indent, cond, project, context);
+            let expr = codegen_expr(
+                indent,
+                cond,
+                project,
+                context,
+                control_flow_runs_through_match,
+                control_exit_flags,
+            );
             output.push_str("if (");
             output.push_str(&expr);
             output.push_str(") ");
 
-            let block = codegen_block(indent, block, project, context);
+            let block = codegen_block(
+                indent,
+                block,
+                project,
+                context,
+                control_flow_runs_through_match,
+                control_exit_flags,
+            );
             output.push_str(&block);
 
             if let Some(else_stmt) = else_stmt {
                 output.push_str(" else ");
-                let else_string = codegen_statement(indent, else_stmt, project, context);
+                let else_string = codegen_statement(
+                    indent,
+                    else_stmt,
+                    project,
+                    context,
+                    false,
+                    control_exit_flags,
+                );
                 output.push_str(&else_string);
             }
         }
         CheckedStatement::Loop(block) => {
             output.push_str("for (;;) {");
-            let block = codegen_block(indent, block, project, context);
+            let block = codegen_block(
+                indent,
+                block,
+                project,
+                context,
+                control_flow_runs_through_match,
+                ControlExitFlags::AtLoop,
+            );
             output.push_str(&block);
             output.push('}');
         }
         CheckedStatement::While(cond, block) => {
-            let expr = codegen_expr(indent, cond, project, context);
+            let expr = codegen_expr(
+                indent,
+                cond,
+                project,
+                context,
+                control_flow_runs_through_match,
+                control_exit_flags,
+            );
             output.push_str("while (");
             output.push_str(&expr);
             output.push_str(") ");
 
-            let block = codegen_block(indent, block, project, context);
+            let block = codegen_block(
+                indent,
+                block,
+                project,
+                context,
+                control_flow_runs_through_match,
+                ControlExitFlags::AtLoop,
+            );
             output.push_str(&block);
         }
         CheckedStatement::VarDecl(var_decl, expr) => {
@@ -2029,11 +2192,25 @@ fn codegen_statement(
             output.push(' ');
             output.push_str(&var_decl.name);
             output.push_str(" = ");
-            output.push_str(&codegen_expr(indent, expr, project, context));
+            output.push_str(&codegen_expr(
+                indent,
+                expr,
+                project,
+                context,
+                control_flow_runs_through_match,
+                control_exit_flags,
+            ));
             output.push_str(";\n");
         }
         CheckedStatement::Block(checked_block) => {
-            let block = codegen_block(indent, checked_block, project, context);
+            let block = codegen_block(
+                indent,
+                checked_block,
+                project,
+                context,
+                control_flow_runs_through_match,
+                control_exit_flags,
+            );
             output.push('{');
             output.push_str(&block);
             output.push('}');
@@ -2061,6 +2238,8 @@ fn codegen_checked_binary_op(
     op: &BinaryOperator,
     project: &Project,
     context: &mut CodegenContext,
+    control_flow_runs_through_match: bool,
+    control_exit_flags: ControlExitFlags,
 ) -> String {
     let mut output = String::new();
 
@@ -2081,9 +2260,23 @@ fn codegen_checked_binary_op(
     output.push('<');
     output.push_str(&codegen_type(type_id, project));
     output.push_str(">(");
-    output.push_str(&codegen_expr(indent, lhs, project, context));
+    output.push_str(&codegen_expr(
+        indent,
+        lhs,
+        project,
+        context,
+        control_flow_runs_through_match,
+        control_exit_flags,
+    ));
     output.push_str(", ");
-    output.push_str(&codegen_expr(indent, rhs, project, context));
+    output.push_str(&codegen_expr(
+        indent,
+        rhs,
+        project,
+        context,
+        control_flow_runs_through_match,
+        control_exit_flags,
+    ));
     output.push(')');
 
     output
@@ -2097,12 +2290,21 @@ fn codegen_checked_binary_op_assign(
     op: &BinaryOperator,
     project: &Project,
     context: &mut CodegenContext,
+    control_flow_runs_through_match: bool,
+    control_exit_flags: ControlExitFlags,
 ) -> String {
     let mut output = String::new();
 
     output.push('{');
     output.push_str("auto& _jakt_ref = ");
-    output.push_str(&codegen_expr(indent, lhs, project, context));
+    output.push_str(&codegen_expr(
+        indent,
+        lhs,
+        project,
+        context,
+        control_flow_runs_through_match,
+        control_exit_flags,
+    ));
     output.push(';');
     output.push_str("_jakt_ref = JaktInternal::");
 
@@ -2121,7 +2323,14 @@ fn codegen_checked_binary_op_assign(
     output.push('<');
     output.push_str(&codegen_type(type_id, project));
     output.push_str(">(_jakt_ref, ");
-    output.push_str(&codegen_expr(indent, rhs, project, context));
+    output.push_str(&codegen_expr(
+        indent,
+        rhs,
+        project,
+        context,
+        control_flow_runs_through_match,
+        control_exit_flags,
+    ));
     output.push_str(");");
     output.push('}');
 
@@ -2140,16 +2349,37 @@ fn codegen_match_body(
         CheckedMatchBody::Expression(expr) => {
             if expr.type_id_or_type_var() == VOID_TYPE_ID {
                 output.push_str("   return (");
-                output.push_str(&codegen_expr(indent + 1, expr, project, context));
+                output.push_str(&codegen_expr(
+                    indent + 1,
+                    expr,
+                    project,
+                    context,
+                    true,
+                    ControlExitFlags::JustReturn,
+                ));
                 output.push_str("), JaktInternal::ExplicitValue<void>();\n");
             } else {
                 output.push_str("   return JaktInternal::ExplicitValue(");
-                output.push_str(&codegen_expr(indent + 1, expr, project, context));
+                output.push_str(&codegen_expr(
+                    indent + 1,
+                    expr,
+                    project,
+                    context,
+                    true,
+                    ControlExitFlags::JustReturn,
+                ));
                 output.push_str(");\n");
             }
         }
         CheckedMatchBody::Block(block) => {
-            output.push_str(&codegen_block(indent, block, project, context));
+            output.push_str(&codegen_block(
+                indent,
+                block,
+                project,
+                context,
+                true,
+                ControlExitFlags::JustReturn,
+            ));
 
             if return_type_id == VOID_TYPE_ID {
                 output.push_str("return JaktInternal::ExplicitValue<void>();\n");
@@ -2168,15 +2398,18 @@ fn codegen_enum_match(
     indent: usize,
     project: &Project,
     context: &mut CodegenContext,
+    control_exit_flags: ControlExitFlags,
 ) -> String {
     let mut output = String::new();
     let needs_deref = enum_.definition_type == DefinitionType::Class
         || matches!(expr, CheckedExpression::Var(CheckedVariable{name,..}, ..) if name == "this");
+    let used_macro = control_exit_flags.choose_control_flow_macro();
+    output.push_str(used_macro);
     match enum_.underlying_type_id {
         Some(_) => {
             if match_values_are_all_constant {
                 // Use a switch statement instead of if-else chains
-                output.push_str("JAKT_RESOLVE_EXPLICIT_VALUE_OR_RETURN(([&]() -> JaktInternal::ExplicitValueOrReturn<");
+                output.push_str("(([&]() -> JaktInternal::ExplicitValueOrControlFlow<");
                 output.push_str(&codegen_type(*return_type_id, project));
                 output.push_str(", ");
                 output.push_str("_JaktCurrentFunctionReturnType");
@@ -2185,10 +2418,17 @@ fn codegen_enum_match(
                 if needs_deref {
                     output.push('*');
                 }
-                output.push_str(&codegen_expr(indent, expr, project, context));
+                output.push_str(&codegen_expr(
+                    indent,
+                    expr,
+                    project,
+                    context,
+                    true,
+                    control_exit_flags,
+                ));
                 output.push_str(") {\n");
             } else {
-                output.push_str("JAKT_RESOLVE_EXPLICIT_VALUE_OR_RETURN(([&]() -> JaktInternal::ExplicitValueOrReturn<");
+                output.push_str("(([&]() -> JaktInternal::ExplicitValueOrControlFlow<");
                 output.push_str(&codegen_type(*return_type_id, project));
                 output.push_str(", ");
                 output.push_str("_JaktCurrentFunctionReturnType");
@@ -2197,7 +2437,14 @@ fn codegen_enum_match(
                 if needs_deref {
                     output.push('*');
                 }
-                output.push_str(&codegen_expr(indent, expr, project, context));
+                output.push_str(&codegen_expr(
+                    indent,
+                    expr,
+                    project,
+                    context,
+                    true,
+                    ControlExitFlags::JustReturn,
+                ));
                 output.push_str(";\n");
             }
             let mut first = true;
@@ -2276,7 +2523,14 @@ fn codegen_enum_match(
                             }
                             output.push_str("if (__jakt_enum_value == ");
                         }
-                        output.push_str(&codegen_expr(indent, expression, project, context));
+                        output.push_str(&codegen_expr(
+                            indent,
+                            expression,
+                            project,
+                            context,
+                            true,
+                            control_exit_flags,
+                        ));
                         if match_values_are_all_constant {
                             output.push_str(":\n");
                         } else {
@@ -2305,14 +2559,21 @@ fn codegen_enum_match(
             output.push_str("}()))");
         }
         None => {
-            output.push_str("JAKT_RESOLVE_EXPLICIT_VALUE_OR_RETURN(([&]() -> JaktInternal::ExplicitValueOrReturn<");
+            output.push_str("(([&]() -> JaktInternal::ExplicitValueOrControlFlow<");
             output.push_str(&codegen_type(*return_type_id, project));
             output.push_str(", ");
             output.push_str("_JaktCurrentFunctionReturnType");
             output.push_str(">{\n");
 
             output.push_str("auto&& __jakt_match_variant_maybe_deref = ");
-            output.push_str(&codegen_expr(indent, expr, project, context));
+            output.push_str(&codegen_expr(
+                indent,
+                expr,
+                project,
+                context,
+                true,
+                control_exit_flags,
+            ));
             output.push(';');
 
             output.push_str("auto&& __jakt_match_variant = ");
@@ -2451,6 +2712,7 @@ fn codegen_generic_match(
     indent: usize,
     project: &Project,
     context: &mut CodegenContext,
+    control_exit_flags: ControlExitFlags,
 ) -> String {
     let mut output = String::new();
 
@@ -2458,23 +2720,26 @@ fn codegen_generic_match(
         .iter()
         .any(|c| matches!(c, CheckedMatchCase::EnumVariant { .. }));
     let match_values_are_all_constant = match_values_are_all_constant && !is_generic_enum;
-
+    output.push_str(control_exit_flags.choose_control_flow_macro());
     if match_values_are_all_constant && !is_generic_enum {
         // Use a switch statement instead of if-else chains
-        output.push_str(
-            "JAKT_RESOLVE_EXPLICIT_VALUE_OR_RETURN(([&]() -> JaktInternal::ExplicitValueOrReturn<",
-        );
+        output.push_str("(([&]() -> JaktInternal::ExplicitValueOrControlFlow<");
         output.push_str(&codegen_type(*return_type_id, project));
         output.push_str(", ");
         output.push_str("_JaktCurrentFunctionReturnType");
         output.push_str("> { \n");
         output.push_str("switch (");
-        output.push_str(&codegen_expr(indent, expr, project, context));
+        output.push_str(&codegen_expr(
+            indent,
+            expr,
+            project,
+            context,
+            true,
+            ControlExitFlags::JustReturn,
+        ));
         output.push_str(") {\n");
     } else {
-        output.push_str(
-            "JAKT_RESOLVE_EXPLICIT_VALUE_OR_RETURN(([&]() -> JaktInternal::ExplicitValueOrReturn<",
-        );
+        output.push_str("(([&]() -> JaktInternal::ExplicitValueOrControlFlow<");
         output.push_str(&codegen_type(*return_type_id, project));
         output.push_str(", ");
         output.push_str("_JaktCurrentFunctionReturnType");
@@ -2484,7 +2749,14 @@ fn codegen_generic_match(
         } else {
             output.push_str("auto __jakt_enum_value = (");
         }
-        output.push_str(&codegen_expr(indent, expr, project, context));
+        output.push_str(&codegen_expr(
+            indent,
+            expr,
+            project,
+            context,
+            true,
+            ControlExitFlags::JustReturn,
+        ));
         output.push_str(");\n");
     }
     let mut first = true;
@@ -2568,7 +2840,14 @@ fn codegen_generic_match(
                     }
                     output.push_str("if (__jakt_enum_value == ");
                 }
-                output.push_str(&codegen_expr(indent, expression, project, context));
+                output.push_str(&codegen_expr(
+                    indent,
+                    expression,
+                    project,
+                    context,
+                    true,
+                    ControlExitFlags::JustReturn,
+                ));
                 if match_values_are_all_constant {
                     output.push_str(":\n");
                 } else {
@@ -2607,6 +2886,8 @@ fn codegen_expr(
     expr: &CheckedExpression,
     project: &Project,
     context: &mut CodegenContext,
+    control_flow_runs_through_match: bool,
+    control_exit_flags: ControlExitFlags,
 ) -> String {
     let mut output = String::new();
 
@@ -2624,11 +2905,25 @@ fn codegen_expr(
             output.push_str("static_cast<");
             output.push_str(&codegen_type(index_type, project));
             output.push_str(">(");
-            output.push_str(&codegen_expr(indent, start_expr, project, context));
+            output.push_str(&codegen_expr(
+                indent,
+                start_expr,
+                project,
+                context,
+                control_flow_runs_through_match,
+                control_exit_flags,
+            ));
             output.push_str("),static_cast<");
             output.push_str(&codegen_type(index_type, project));
             output.push_str(">(");
-            output.push_str(&codegen_expr(indent, end_expr, project, context));
+            output.push_str(&codegen_expr(
+                indent,
+                end_expr,
+                project,
+                context,
+                control_flow_runs_through_match,
+                control_exit_flags,
+            ));
             output.push_str(")})");
         }
         CheckedExpression::OptionalNone(_, _) => {
@@ -2636,12 +2931,26 @@ fn codegen_expr(
         }
         CheckedExpression::OptionalSome(expr, _, _) => {
             output.push('(');
-            output.push_str(&codegen_expr(indent, expr, project, context));
+            output.push_str(&codegen_expr(
+                indent,
+                expr,
+                project,
+                context,
+                control_flow_runs_through_match,
+                control_exit_flags,
+            ));
             output.push(')');
         }
         CheckedExpression::ForcedUnwrap(expr, _, _) => {
             output.push('(');
-            output.push_str(&codegen_expr(indent, expr, project, context));
+            output.push_str(&codegen_expr(
+                indent,
+                expr,
+                project,
+                context,
+                control_flow_runs_through_match,
+                control_exit_flags,
+            ));
             output.push_str(".value())");
         }
         CheckedExpression::QuotedString(qs, _) => {
@@ -2742,7 +3051,14 @@ fn codegen_expr(
             if call.name == "print" {
                 output.push_str("out(");
                 for (i, param) in call.args.iter().enumerate() {
-                    output.push_str(&codegen_expr(indent, &param.1, project, context));
+                    output.push_str(&codegen_expr(
+                        indent,
+                        &param.1,
+                        project,
+                        context,
+                        control_flow_runs_through_match,
+                        control_exit_flags,
+                    ));
                     if i != call.args.len() - 1 {
                         output.push(',');
                     }
@@ -2751,7 +3067,14 @@ fn codegen_expr(
             } else if call.name == "println" {
                 output.push_str("outln(");
                 for (i, param) in call.args.iter().enumerate() {
-                    output.push_str(&codegen_expr(indent, &param.1, project, context));
+                    output.push_str(&codegen_expr(
+                        indent,
+                        &param.1,
+                        project,
+                        context,
+                        control_flow_runs_through_match,
+                        control_exit_flags,
+                    ));
                     if i != call.args.len() - 1 {
                         output.push(',');
                     }
@@ -2760,7 +3083,14 @@ fn codegen_expr(
             } else if call.name == "eprintln" {
                 output.push_str("warnln(");
                 for (i, param) in call.args.iter().enumerate() {
-                    output.push_str(&codegen_expr(indent, &param.1, project, context));
+                    output.push_str(&codegen_expr(
+                        indent,
+                        &param.1,
+                        project,
+                        context,
+                        control_flow_runs_through_match,
+                        control_exit_flags,
+                    ));
                     if i != call.args.len() - 1 {
                         output.push(',');
                     }
@@ -2769,7 +3099,14 @@ fn codegen_expr(
             } else if call.name == "format" {
                 output.push_str("TRY(String::formatted(");
                 for (i, param) in call.args.iter().enumerate() {
-                    output.push_str(&codegen_expr(indent, &param.1, project, context));
+                    output.push_str(&codegen_expr(
+                        indent,
+                        &param.1,
+                        project,
+                        context,
+                        control_flow_runs_through_match,
+                        control_exit_flags,
+                    ));
                     if i != call.args.len() - 1 {
                         output.push(',');
                     }
@@ -2882,7 +3219,14 @@ fn codegen_expr(
                         first = false;
                     }
 
-                    output.push_str(&codegen_expr(indent, &param.1, project, context));
+                    output.push_str(&codegen_expr(
+                        indent,
+                        &param.1,
+                        project,
+                        context,
+                        control_flow_runs_through_match,
+                        control_exit_flags,
+                    ));
                 }
                 output.push(')');
             }
@@ -2898,7 +3242,14 @@ fn codegen_expr(
             output.push('(');
 
             output.push('(');
-            output.push_str(&codegen_expr(indent, expr, project, context));
+            output.push_str(&codegen_expr(
+                indent,
+                expr,
+                project,
+                context,
+                control_flow_runs_through_match,
+                control_exit_flags,
+            ));
             output.push(')');
 
             match &**expr {
@@ -2942,7 +3293,14 @@ fn codegen_expr(
                     first = false;
                 }
 
-                output.push_str(&codegen_expr(indent, &param.1, project, context));
+                output.push_str(&codegen_expr(
+                    indent,
+                    &param.1,
+                    project,
+                    context,
+                    control_flow_runs_through_match,
+                    control_exit_flags,
+                ));
             }
             output.push_str("))");
 
@@ -2965,6 +3323,7 @@ fn codegen_expr(
                         indent,
                         project,
                         context,
+                        control_exit_flags,
                     ));
                 }
                 _ => {
@@ -2976,6 +3335,7 @@ fn codegen_expr(
                         indent,
                         project,
                         context,
+                        control_exit_flags,
                     ));
                 }
             };
@@ -3032,7 +3392,14 @@ fn codegen_expr(
                 }
                 _ => {}
             }
-            output.push_str(&codegen_expr(indent, expr, project, context));
+            output.push_str(&codegen_expr(
+                indent,
+                expr,
+                project,
+                context,
+                control_flow_runs_through_match,
+                control_exit_flags,
+            ));
             match op {
                 CheckedUnaryOperator::PostIncrement => {
                     output.push_str("++");
@@ -3055,7 +3422,14 @@ fn codegen_expr(
                     let rhs_type = &project.types[rhs.type_id_or_type_var()];
                     let optional_struct_id = project.cached_optional_struct_id.unwrap();
 
-                    output.push_str(&codegen_expr(indent, lhs, project, context));
+                    output.push_str(&codegen_expr(
+                        indent,
+                        lhs,
+                        project,
+                        context,
+                        control_flow_runs_through_match,
+                        control_exit_flags,
+                    ));
 
                     match rhs_type {
                         Type::GenericInstance(struct_id, _) if *struct_id == optional_struct_id => {
@@ -3065,20 +3439,55 @@ fn codegen_expr(
                             output.push_str(".value_or_lazy_evaluated([&] { return ");
                         }
                     }
-                    output.push_str(&codegen_expr(indent, rhs, project, context));
+                    output.push_str(&codegen_expr(
+                        indent,
+                        rhs,
+                        project,
+                        context,
+                        control_flow_runs_through_match,
+                        control_exit_flags,
+                    ));
                     output.push_str("; })");
                 }
                 BinaryOperator::NoneCoalescingAssign => {
-                    output.push_str(&codegen_expr(indent, lhs, project, context));
+                    output.push_str(&codegen_expr(
+                        indent,
+                        lhs,
+                        project,
+                        context,
+                        control_flow_runs_through_match,
+                        control_exit_flags,
+                    ));
                     output.push_str(".lazy_emplace([&] { return ");
-                    output.push_str(&codegen_expr(indent, rhs, project, context));
+                    output.push_str(&codegen_expr(
+                        indent,
+                        rhs,
+                        project,
+                        context,
+                        control_flow_runs_through_match,
+                        control_exit_flags,
+                    ));
                     output.push_str("; })");
                 }
                 BinaryOperator::ArithmeticRightShift => {
                     output.push_str("JaktInternal::arithmetic_shift_right(");
-                    output.push_str(&codegen_expr(indent, lhs, project, context));
+                    output.push_str(&codegen_expr(
+                        indent,
+                        lhs,
+                        project,
+                        context,
+                        control_flow_runs_through_match,
+                        control_exit_flags,
+                    ));
                     output.push_str(", ");
-                    output.push_str(&codegen_expr(indent, rhs, project, context));
+                    output.push_str(&codegen_expr(
+                        indent,
+                        rhs,
+                        project,
+                        context,
+                        control_flow_runs_through_match,
+                        control_exit_flags,
+                    ));
                     output.push(')');
                 }
                 BinaryOperator::Add
@@ -3096,6 +3505,8 @@ fn codegen_expr(
                         op,
                         project,
                         context,
+                        control_flow_runs_through_match,
+                        control_exit_flags,
                     ))
                 }
                 BinaryOperator::AddAssign
@@ -3113,23 +3524,53 @@ fn codegen_expr(
                         op,
                         project,
                         context,
+                        control_flow_runs_through_match,
+                        control_exit_flags,
                     ))
                 }
                 _ => {
                     if *op == BinaryOperator::Assign {
                         if let CheckedExpression::IndexedDictionary(expr, index, ..) = lhs.as_ref()
                         {
-                            output.push_str(&codegen_expr(0, expr, project, context));
+                            output.push_str(&codegen_expr(
+                                0,
+                                expr,
+                                project,
+                                context,
+                                control_flow_runs_through_match,
+                                control_exit_flags,
+                            ));
                             output.push_str(".set(");
-                            output.push_str(&codegen_expr(0, index, project, context));
+                            output.push_str(&codegen_expr(
+                                0,
+                                index,
+                                project,
+                                context,
+                                control_flow_runs_through_match,
+                                control_exit_flags,
+                            ));
                             output.push_str(", ");
-                            output.push_str(&codegen_expr(0, rhs, project, context));
+                            output.push_str(&codegen_expr(
+                                0,
+                                rhs,
+                                project,
+                                context,
+                                control_flow_runs_through_match,
+                                control_exit_flags,
+                            ));
                             output.push_str("))");
                             return output;
                         }
                     }
 
-                    output.push_str(&codegen_expr(indent, lhs, project, context));
+                    output.push_str(&codegen_expr(
+                        indent,
+                        lhs,
+                        project,
+                        context,
+                        control_flow_runs_through_match,
+                        control_exit_flags,
+                    ));
                     match op {
                         BinaryOperator::Add => output.push_str(" + "),
                         BinaryOperator::Subtract => output.push_str(" - "),
@@ -3163,7 +3604,14 @@ fn codegen_expr(
                         BinaryOperator::BitwiseRightShift => output.push_str(" >> "),
                         _ => {}
                     }
-                    output.push_str(&codegen_expr(indent, rhs, project, context));
+                    output.push_str(&codegen_expr(
+                        indent,
+                        rhs,
+                        project,
+                        context,
+                        control_flow_runs_through_match,
+                        control_exit_flags,
+                    ));
                 }
             }
             output.push(')');
@@ -3178,13 +3626,22 @@ fn codegen_expr(
                 output.push_str("(TRY(Array<");
                 output.push_str(&codegen_type(value_type_id, project));
                 output.push_str(">::filled(");
-                output.push_str(&codegen_expr(indent, fill_size_expr, project, context));
+                output.push_str(&codegen_expr(
+                    indent,
+                    fill_size_expr,
+                    project,
+                    context,
+                    control_flow_runs_through_match,
+                    control_exit_flags,
+                ));
                 output.push_str(", ");
                 output.push_str(&codegen_expr(
                     indent,
                     vals.first().unwrap(),
                     project,
                     context,
+                    control_flow_runs_through_match,
+                    control_exit_flags,
                 ));
                 output.push_str(")))");
             } else {
@@ -3200,7 +3657,14 @@ fn codegen_expr(
                         first = false;
                     }
 
-                    output.push_str(&codegen_expr(indent, val, project, context))
+                    output.push_str(&codegen_expr(
+                        indent,
+                        val,
+                        project,
+                        context,
+                        control_flow_runs_through_match,
+                        control_exit_flags,
+                    ))
                 }
                 output.push_str("}))");
             }
@@ -3226,9 +3690,23 @@ fn codegen_expr(
                 }
 
                 output.push('{');
-                output.push_str(&codegen_expr(indent, key, project, context));
+                output.push_str(&codegen_expr(
+                    indent,
+                    key,
+                    project,
+                    context,
+                    control_flow_runs_through_match,
+                    control_exit_flags,
+                ));
                 output.push_str(", ");
-                output.push_str(&codegen_expr(indent, value, project, context));
+                output.push_str(&codegen_expr(
+                    indent,
+                    value,
+                    project,
+                    context,
+                    control_flow_runs_through_match,
+                    control_exit_flags,
+                ));
                 output.push('}');
             }
             output.push_str("})))");
@@ -3251,7 +3729,14 @@ fn codegen_expr(
                 } else {
                     first = false;
                 }
-                output.push_str(&codegen_expr(indent, value, project, context));
+                output.push_str(&codegen_expr(
+                    indent,
+                    value,
+                    project,
+                    context,
+                    control_flow_runs_through_match,
+                    control_exit_flags,
+                ));
             }
             output.push_str("})))");
         }
@@ -3266,34 +3751,83 @@ fn codegen_expr(
                     first = false;
                 }
 
-                output.push_str(&codegen_expr(indent, val, project, context))
+                output.push_str(&codegen_expr(
+                    indent,
+                    val,
+                    project,
+                    context,
+                    control_flow_runs_through_match,
+                    control_exit_flags,
+                ))
             }
             output.push_str("})");
         }
         CheckedExpression::IndexedExpression(expr, idx, _, _) => {
             output.push_str("((");
-            output.push_str(&codegen_expr(indent, expr, project, context));
+            output.push_str(&codegen_expr(
+                indent,
+                expr,
+                project,
+                context,
+                control_flow_runs_through_match,
+                control_exit_flags,
+            ));
             output.push_str(")[");
-            output.push_str(&codegen_expr(indent, idx, project, context));
+            output.push_str(&codegen_expr(
+                indent,
+                idx,
+                project,
+                context,
+                control_flow_runs_through_match,
+                control_exit_flags,
+            ));
             output.push_str("])");
         }
         CheckedExpression::IndexedDictionary(expr, idx, _, _) => {
             output.push_str("((");
-            output.push_str(&codegen_expr(indent, expr, project, context));
+            output.push_str(&codegen_expr(
+                indent,
+                expr,
+                project,
+                context,
+                control_flow_runs_through_match,
+                control_exit_flags,
+            ));
             output.push_str(")[");
-            output.push_str(&codegen_expr(indent, idx, project, context));
+            output.push_str(&codegen_expr(
+                indent,
+                idx,
+                project,
+                context,
+                control_flow_runs_through_match,
+                control_exit_flags,
+            ));
             output.push_str("])");
         }
         CheckedExpression::IndexedTuple(expr, idx, _, _) => {
             // x.get<1>()
             output.push_str("((");
-            output.push_str(&codegen_expr(indent, expr, project, context));
+            output.push_str(&codegen_expr(
+                indent,
+                expr,
+                project,
+                context,
+                control_flow_runs_through_match,
+                control_exit_flags,
+            ));
             output.push_str(&format!(").get<{}>())", idx));
         }
         CheckedExpression::IndexedStruct(expr, name, _, _) => {
             // x.foo or x->foo
             output.push_str("((");
-            output.push_str(&codegen_expr(indent, expr, project, context));
+            output.push_str(&codegen_expr(
+                indent,
+                expr,
+                project,
+                context,
+                control_flow_runs_through_match,
+                control_exit_flags,
+            ));
             output.push(')');
 
             match &**expr {
@@ -3322,7 +3856,14 @@ fn codegen_expr(
             output.push_str(&format!("{})", name));
         }
         CheckedExpression::Block(block, _, _) => {
-            output.push_str(&codegen_block(indent, block, project, context));
+            output.push_str(&codegen_block(
+                indent,
+                block,
+                project,
+                context,
+                control_flow_runs_through_match,
+                control_exit_flags,
+            ));
         }
         CheckedExpression::Garbage(_) => {
             // Incorrect parse/typecheck

--- a/tests/codegen/control_flow_inside_match.jakt
+++ b/tests/codegen/control_flow_inside_match.jakt
@@ -1,7 +1,7 @@
 /// Expect:
-/// - out: "42\n"
+/// - out: "OK\n"
 
-function main() {
+function test_continue() -> i64 {
   let mutable x: i64 = 10
   loop {
     match x {
@@ -10,10 +10,32 @@ function main() {
         continue
       }
       else => {
-        println("{}", x)
-        return 0
+        return x
       }
     }
   }
 }
-// Submitted by https://github.com/SerenityOS/jakt/issues/402.
+
+function test_break() -> i64 {
+  let mutable x: i64 = 10
+  loop {
+    match x {
+      42 => {
+        break
+      }
+      else => { x = 42 }
+    }
+  }
+  return x
+}
+
+function main() {
+  let res_continue = test_continue()
+  let res_break = test_break()
+  if res_continue == res_break && res_continue == 42 {
+    println("OK")
+  } else {
+    println("continue({}) != break({})", res_continue, res_break)
+  }
+}
+// Fixes https://github.com/SerenityOS/jakt/issues/402.

--- a/tests/codegen/control_flow_inside_match.jakt
+++ b/tests/codegen/control_flow_inside_match.jakt
@@ -1,0 +1,19 @@
+/// Expect:
+/// - out: "42\n"
+
+function main() {
+  let mutable x: i64 = 10
+  loop {
+    match x {
+      10 => {
+        x = 42
+        continue
+      }
+      else => {
+        println("{}", x)
+        return 0
+      }
+    }
+  }
+}
+// Submitted by https://github.com/SerenityOS/jakt/issues/402.

--- a/tests/codegen/control_flow_inside_nested_match_block.jakt
+++ b/tests/codegen/control_flow_inside_nested_match_block.jakt
@@ -1,26 +1,52 @@
 /// Expect:
-/// - output: "1\n"
-enum Foo {
-    Bar
-    Baz
+/// - output: "OK\n"
+
+function test_continue() -> bool {
+    let mutable break_out = false
+    while not break_out {
+        match 10 {
+            10 => {
+                match 15 {
+                    16 => { }
+                    else => { 
+                        break_out = true
+                        continue
+                    }
+                }
+            }
+            else => {}
+        }
+        println("test_continue: must be unreachable")
+        return false
+    }
+    return true
 }
 
-function foop(foo: mutable Foo) -> i64 {
+
+function test_break() -> bool {
     loop {
-        match foo {
-            Bar => {match 42 {
-                42 => { 
-                    foo = Foo::Baz
-                    continue 
+        match 10 {
+            10 => {
+                match 15 {
+                    15 => { break }
+                    else => {}
                 }
-                else  => { return 0 }
-            }}
-            else => { return 1 }
+            }
+            else => {}
         }
+        println("test_break: must be unreachable")
+        return false
     }
-    return 3
+    return true
 }
+
+
 
 function main() {
-    println("{}", foop(foo: Foo::Bar))
+    if test_break() and test_continue() {
+        println("OK")
+    } else {
+        println("Something happened. Check above log and codegen code.")
+    }
+
 }

--- a/tests/codegen/control_flow_inside_nested_match_block.jakt
+++ b/tests/codegen/control_flow_inside_nested_match_block.jakt
@@ -1,0 +1,26 @@
+/// Expect:
+/// - output: "1\n"
+enum Foo {
+    Bar
+    Baz
+}
+
+function foop(foo: mutable Foo) -> i64 {
+    loop {
+        match foo {
+            Bar => {match 42 {
+                42 => { 
+                    foo = Foo::Baz
+                    continue 
+                }
+                else  => { return 0 }
+            }}
+            else => { return 1 }
+        }
+    }
+    return 3
+}
+
+function main() {
+    println("{}", foop(foo: Foo::Bar))
+}


### PR DESCRIPTION
Refactored `ExplicitValueOrReturn` -> `ExplicitValueOrControlFlow`
with `LoopContinue` and `LoopBreak` as new variants, and now there
are three macros that exist to handle those values: one with just
`return` (for codegen places outside loop) and one with `return`,
`continue` and `break`, as well as another one that returns the same
control flow information by using `return LoopBreak` and 
`return LoopContinue` for instances where matches are 
nested.

Codegen has been updated to track whether `continue`/`break` is
allowed in the context of the code that's being generated and whether
it should use a `return LoopBreak` or `return LoopContinue` when
generating `Break` and `Continue` statements, since matches run through
lambdas and we have to return that control flow information to the
runtime.

Should fix #402.
