### PR TITLE
Improvements to IDE auto-completion

### DIFF
--- a/src/parser.rs
+++ b/src/parser.rs
@@ -2889,7 +2889,10 @@ pub fn parse_operand(tokens: &[Token], index: &mut usize) -> (ParsedExpression, 
                             let (call, err) = parse_call(tokens, index);
                             error = error.or(err);
 
-                            ParsedExpression::Call(call, span)
+                            ParsedExpression::Call(
+                                call,
+                                Span::new(span.file_id, span.start, tokens[*index - 1].span.end),
+                            )
                         }
                     },
                     TokenContents::LessThan => {
@@ -3391,14 +3394,14 @@ pub fn parse_operand(tokens: &[Token], index: &mut usize) -> (ParsedExpression, 
                                 if tokens[*index].contents == TokenContents::LParen {
                                     *index -= 1;
 
+                                    let (method, err) = parse_call(tokens, index);
+                                    error = error.or(err);
+
                                     let span = Span {
                                         file_id: expr.span().file_id,
                                         start: expr.span().start,
                                         end: tokens[*index].span.end,
                                     };
-
-                                    let (method, err) = parse_call(tokens, index);
-                                    error = error.or(err);
 
                                     expr =
                                         ParsedExpression::MethodCall(Box::new(expr), method, span)

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1900,7 +1900,7 @@ pub fn parse_block(tokens: &[Token], index: &mut usize) -> (ParsedBlock, Option<
 
     trace!("ERROR: expected complete block");
     (
-        ParsedBlock::new(),
+        block,
         Some(JaktError::ParserError(
             "expected complete block".to_string(),
             Span {

--- a/src/typechecker.rs
+++ b/src/typechecker.rs
@@ -4991,18 +4991,16 @@ pub fn typecheck_expression(
                                     }
                                 }
 
-                                checked_cases.push(CheckedMatchCase::EnumVariant {
-                                    variant_name: variant_name
-                                        .last()
-                                        .expect("Must have at least one enum variant name here")
-                                        .0
-                                        .clone(),
-                                    subject_type_id,
-                                    variant_arguments: variant_arguments.clone(),
-                                    variant_index: 0,
-                                    scope_id,
-                                    body,
-                                });
+                                if !variant_name.is_empty() {
+                                    checked_cases.push(CheckedMatchCase::EnumVariant {
+                                        variant_name: variant_name.last().unwrap().0.clone(),
+                                        subject_type_id,
+                                        variant_arguments: variant_arguments.clone(),
+                                        variant_index: 0,
+                                        scope_id,
+                                        body,
+                                    });
+                                }
                             }
                             MatchCase::CatchAll { body, marker_span } => {
                                 if seen_catch_all {


### PR DESCRIPTION
Some improvements:
- We now keep blocks with parse errors instead of wiping them. That allows you to use autocompletion in more places, even when the surrounding code is broken.
- Call spans are extended to the right `)`. This allows autocomplete to trigger on `foo().` where `foo()` returns something that supports dot access.
- Enum-scoped functions are now considered for autocompletion when doing dot access on a value of some enum type.