### PR TITLE
typechecker: Improve typenames for common types

### DIFF
--- a/tests/typechecker/constructor_with_different_generic_instance.jakt
+++ b/tests/typechecker/constructor_with_different_generic_instance.jakt
@@ -1,5 +1,5 @@
 /// Expect:
-/// - error: "Type mismatch: expected ‘B’, but got ‘Array<unknown>’"
+/// - error: "Type mismatch: expected ‘B’, but got ‘[unknown]’"
 
 class B {
 }


### PR DESCRIPTION
This renames builtin/common typenames to something more readable. 

Eg) instead of `Array<Foo>` we now show the shorthand `[Foo]`