### PR TITLE
all: Add support for goto type definition

### DIFF
--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -3,7 +3,7 @@
 	"displayName": "jakt",
 	"description": "Jakt language support",
 	"license": "BSD",
-	"version": "0.0.2",
+	"version": "0.0.3",
 	"repository": {
 		"type": "git",
 		"url": "https://github.com/SerenityOS/jakt/tree/main/editors/vscode"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,7 +25,8 @@ mod typechecker;
 pub use compiler::Compiler;
 pub use error::JaktError;
 pub use ide::{
-    find_definition_in_project, find_dot_completions_in_project, find_typename_in_project,
+    find_definition_in_project, find_dot_completions_in_project, find_type_definition_in_project,
+    find_typename_in_project,
 };
 pub use lexer::Span;
 pub use typechecker::Project;

--- a/src/typechecker.rs
+++ b/src/typechecker.rs
@@ -836,6 +836,7 @@ impl Project {
 #[derive(Clone, Debug)]
 pub struct CheckedStruct {
     pub name: String,
+    pub name_span: Span,
     pub generic_parameters: Vec<TypeId>,
     pub fields: Vec<CheckedVarDecl>,
     pub scope_id: ScopeId,
@@ -2319,6 +2320,7 @@ fn typecheck_struct_predecl(
 
     project.structs.push(CheckedStruct {
         name: structure.name.clone(),
+        name_span: structure.name_span,
         generic_parameters: vec![],
         fields: Vec::new(),
         scope_id: struct_scope_id,


### PR DESCRIPTION
Adds support for "goto type definition", which allows you to go to where the type is defined for the given symbol.

There are a few heuristic steps we take that languages like Rust also take: if it's a common container type like Array, we don't actually care about the type definition for arrays, we care about the type the array contained. For cases like this, we jump to the contained type instead.

Also bumped the vscode extension to 0.0.3 since we made so many changes would be nice to know which version people are using.