### PR TITLE
selfhost: Parse fat arrow in function definition

### DIFF
--- a/samples/functions/fat_arrow.jakt
+++ b/samples/functions/fat_arrow.jakt
@@ -1,0 +1,10 @@
+/// Expect:
+/// - output: "Well, hello friends.\n5\n"
+
+function greet() => println("Well, hello friends.")
+function num() -> i64 => 5
+
+function main() {
+    greet()
+    println("{}", num())
+}

--- a/selfhost/main.jakt
+++ b/selfhost/main.jakt
@@ -1366,17 +1366,25 @@ struct Parser {
                 return_type = .parse_typename()
                 return_type_span = JaktSpan(start, end: .index)
             }
-            else => {
-                .error("Expected ->", .current().span())
-            }
+            else => {}
         }
 
-        // FIXME: Accept an (optional) fat arrow ('=>')
-
-        parsed_function.block = .parse_block()
+        parsed_function.block = match .current() {
+            FatArrow => .parse_fat_arrow()
+            else => .parse_block()
+        }
+        
         parsed_function.params = params
 
         return parsed_function
+    }
+
+    function parse_fat_arrow(mutable this) throws -> ParsedBlock {
+        .index++
+        let start = .current().span().start
+        let expr = .parse_expression()
+        let return_statement = ParsedStatement::Return(expr, span: JaktSpan(start, end: .index))
+        return ParsedBlock(stmts: [return_statement])
     }
 
     function parse_field(mutable this, anonymous visibility: Visibility) throws -> ParsedField {


### PR DESCRIPTION
Parse the fat arrow token, and the following expression.
Make a new block and set the parsed expression as the only
statement so that return type inference can operate on the block.