### PR TITLE
selfhost: Parse structs and classes

### DIFF
--- a/selfhost/main.jakt
+++ b/selfhost/main.jakt
@@ -115,6 +115,7 @@ enum Token {
     Public(JaktSpan)
     Raw(JaktSpan)
     Return(JaktSpan)
+    Restricted(JaktSpan)
     Struct(JaktSpan)
     This(JaktSpan)
     Throw(JaktSpan)
@@ -215,6 +216,7 @@ enum Token {
             Private(span) => span
             Public(span) => span
             Raw(span) => span
+            Restricted(span) => span
             Return(span) => span
             Struct(span) => span
             This(span) => span
@@ -377,6 +379,7 @@ struct Lexer {
                 "public" => Token::Public(span)
                 "raw" => Token::Raw(span)
                 "return" => Token::Return(span)
+                "restricted" => Token::Restricted(span)
                 "struct" => Token::Struct(span)
                 "this" => Token::This(span)
                 "throw" => Token::Throw(span)
@@ -1187,8 +1190,8 @@ struct Parser {
                     if last_visibility.has_value() {
                         .error_with_hint("Multiple visibility modifiers on one field or method are not allowed", span, "Previous modifier is here", last_visibility_span!)
                     }
-                    todo("Implement restricted() visibility modifier")
-                    .index++
+                    last_visibility = .parse_restricted_visibility_modifier()
+                    last_visibility_span = span
                 }
                 Identifier => {
                     // Parse a field
@@ -2063,6 +2066,68 @@ struct Parser {
             }
             else => ""
         }
+    }
+
+    function parse_restricted_visibility_modifier(mutable this) throws -> Visibility {
+        let mutable restricted_span = .current().span()
+        
+        .index++
+
+        match .current() {
+            LParen => {
+                .index++
+            }
+            else => {
+                .error("Expected ‘(’", .current().span())
+            }
+        }
+
+        let mutable whitelist: [ParsedType] = []
+        let mutable should_break = false
+        let mutable expect_comma = false
+
+        while not should_break and .index < .tokens.size() {
+            match .current() {
+                RParen => {
+                    should_break = true
+                }
+                Comma(span) => {
+                    if expect_comma {
+                        expect_comma = false
+                    } else {
+                        .error("Unexpected comma", span)
+                    }
+                    .index++
+                }
+                else => {
+                    if expect_comma {
+                        .error("Expected comma", .current().span())
+                    }
+
+                    .skip_newlines()
+                    let parsed_type = .parse_typename()
+                    whitelist.push(parsed_type)
+                    expect_comma = true
+                }
+            }
+        }
+
+        restricted_span.end = .current().span().end
+
+        if whitelist.is_empty() {
+            .error("Type list cannot be empty", restricted_span)
+        }
+
+        match .current() {
+            RParen => {
+                .index++
+            }
+            else => {
+                .error("Expected ‘)’", .current().span())
+            }
+        }
+
+        return Visibility::Restricted(whitelist, span: restricted_span)
     }
 }
 

--- a/selfhost/main.jakt
+++ b/selfhost/main.jakt
@@ -25,6 +25,7 @@ struct JaktSpan {
     start: usize
     end: usize
 }
+function empty_span() -> JaktSpan => JaktSpan(start: 0, end: 0)
 
 enum Token {
     SingleQuotedString(quote: String, span: JaktSpan)
@@ -781,12 +782,13 @@ struct ParsedNamespace {
 }
 
 struct ParsedFunction {
-    public name: String
-    public params: [ParsedParameter]
-    public generic_parameters: [[String:JaktSpan]]
-    public block: ParsedBlock
-    public return_type: ParsedType
-    public throws: bool
+    name: String
+    name_span: JaktSpan
+    params: [ParsedParameter]
+    generic_parameters: [[String:JaktSpan]]
+    block: ParsedBlock
+    return_type: ParsedType
+    throws: bool
 }
 
 struct ParsedParameter {
@@ -1035,6 +1037,7 @@ struct Parser {
     public function parse_function(mutable this, anonymous linkage: FunctionLinkage, anonymous visibility: Visibility) throws -> ParsedFunction {
         let mutable parsed_function = ParsedFunction(
             name: "",
+            name_span: empty_span(),
             params: [],
             generic_parameters: [],
             block: ParsedBlock(stmts: []),
@@ -1054,7 +1057,7 @@ struct Parser {
             else => { return parsed_function }
         }
         parsed_function.name = function_name
-        let function_name_span = .current().span()
+        parsed_function.name_span = .current().span()
 
         .index++
 

--- a/selfhost/main.jakt
+++ b/selfhost/main.jakt
@@ -1079,6 +1079,11 @@ struct Parser {
             Class => "class"
         }
 
+        let default_visibility = match definition_type {
+            Struct => Visibility::Public
+            Class => Visibility::Private
+        }
+
         .index++
 
         // Struct name
@@ -1164,8 +1169,20 @@ struct Parser {
                     .index++
                 }
                 Identifier => {
-                    todo("Implement struct parameter parsing")
-                    should_break = true
+                    // Parse a field
+                    let visibility = last_visibility ?? default_visibility
+                    last_visibility = None
+
+                    let field = .parse_variable_declaration()
+
+                    match field.parsed_type {
+                        Empty => {
+                            .error("Field missing type", field.span)
+                        }
+                        else => {}
+                    }
+
+                    fields.push(field)
                 }
                 else => {
                     .error(format("Invalid struct member, did not expect a {} here", token), token.span())

--- a/selfhost/main.jakt
+++ b/selfhost/main.jakt
@@ -1013,6 +1013,10 @@ struct Parser {
         .errors.push(JaktError::Message(message, span))
     }
 
+    function error_with_hint(mutable this, anonymous message: String, anonymous span: JaktSpan, anonymous hint: String, anonymous hint_span: JaktSpan) throws {
+        .errors.push(JaktError::MessageWithHint(message, span, hint, hint_span))
+    }
+
     function peek(this, anonymous steps: usize) -> Token {
         if .eof() or (steps + .index) >= .tokens.size()  {
             return .tokens[.tokens.size() - 1]
@@ -1132,6 +1136,8 @@ struct Parser {
 
         // This gets reset after each loop. If someone doesn't consume it, we error out.
         let mutable last_visibility: Visibility? = None
+        let mutable last_visibility_span: JaktSpan? = None
+
         let mutable should_break = false
         while not should_break and .index < .tokens.size() {
             let token = .current()
@@ -1153,18 +1159,26 @@ struct Parser {
                     todo("Implement struct method parsing")
                     should_break = true
                 }
-                Public => {
-                    // FIXME: Reject multiple visibility modifiers
+                Public(span) => {
+                    if last_visibility.has_value() {
+                        .error_with_hint("Multiple visibility modifiers on one field or method are not allowed", span, "Previous modifier is here", last_visibility_span!)
+                    }
                     last_visibility = Visibility::Public
+                    last_visibility_span = span
                     .index++
                 }
-                Private => {
-                    // FIXME: Reject multiple visibility modifiers
+                Private(span) => {
+                    if last_visibility.has_value() {
+                        .error_with_hint("Multiple visibility modifiers on one field or method are not allowed", span, "Previous modifier is here", last_visibility_span!)
+                    }
                     last_visibility = Visibility::Private
+                    last_visibility_span = span
                     .index++
                 }
-                Restricted => {
-                    // FIXME: Reject multiple visibility modifiers
+                Restricted(span) => {
+                    if last_visibility.has_value() {
+                        .error_with_hint("Multiple visibility modifiers on one field or method are not allowed", span, "Previous modifier is here", last_visibility_span!)
+                    }
                     todo("Implement restricted() visibility modifier")
                     .index++
                 }
@@ -1172,6 +1186,7 @@ struct Parser {
                     // Parse a field
                     let visibility = last_visibility ?? default_visibility
                     last_visibility = None
+                    last_visibility_span = None
 
                     let field = .parse_variable_declaration()
 

--- a/selfhost/main.jakt
+++ b/selfhost/main.jakt
@@ -796,8 +796,8 @@ struct ParsedStruct {
     name: String
     name_span: JaktSpan
     generic_parameters: [[String:JaktSpan]]
-    fields: [ParsedVarDecl]
-    methods: [ParsedFunction]
+    fields: [ParsedField]
+    methods: [ParsedMethod]
     definition_linkage: DefinitionLinkage
     definition_type: DefinitionType
 }
@@ -914,6 +914,18 @@ struct ParsedVarDecl {
     parsed_type: ParsedType
     is_mutable: bool
     span: JaktSpan
+}
+
+struct ParsedField {
+    // FIXME: It would be nice to extend the ParsedVarDecl struct instead.
+    var_decl: ParsedVarDecl
+    visibility: Visibility
+}
+
+struct ParsedMethod {
+    // FIXME: It would be nice to extend the ParsedVarDecl struct instead.
+    parsed_function: ParsedFunction
+    visibility: Visibility
 }
 
 struct ParsedVariable {
@@ -1039,7 +1051,7 @@ struct Parser {
         while not should_break and not .eof() {
             match .current() {
                 Function => {
-                    let function = .parse_function(FunctionLinkage::Internal, Visibility::Public)
+                    let function = .parse_function(FunctionLinkage::Internal)
                     parsed_namespace.functions.push(function)
                 }
                 Struct => {
@@ -1131,8 +1143,8 @@ struct Parser {
             }
         }
 
-        let mutable fields: [ParsedVarDecl] = []
-        let mutable methods: [ParsedFunction] = []
+        let mutable fields: [ParsedField] = []
+        let mutable methods: [ParsedMethod] = []
 
         // This gets reset after each loop. If someone doesn't consume it, we error out.
         let mutable last_visibility: Visibility? = None
@@ -1184,14 +1196,7 @@ struct Parser {
                     last_visibility = None
                     last_visibility_span = None
 
-                    let field = .parse_variable_declaration()
-
-                    match field.parsed_type {
-                        Empty => {
-                            .error("Field missing type", field.span)
-                        }
-                        else => {}
-                    }
+                    let field = .parse_field(visibility)
 
                     fields.push(field)
                 }
@@ -1199,17 +1204,15 @@ struct Parser {
                     // Parse a method
 
                     let function_linkage = match definition_linkage {
-                        DefinitionLinkage::Internal => FunctionLinkage::Internal
-                        DefinitionLinkage::External => FunctionLinkage::External
+                        Internal => FunctionLinkage::Internal
+                        External => FunctionLinkage::External
                     }
 
                     let visibility = last_visibility ?? default_visibility
                     last_visibility = None
                     last_visibility_span = None
 
-                    let parsed_method = .parse_function(function_linkage, visibility)
-
-                    // TODO: The bootstrap compiler sets parsed_method.must_instantiate here if the linkage is External.
+                    let parsed_method = .parse_method(function_linkage, visibility)
 
                     methods.push(parsed_method)
                 }
@@ -1237,7 +1240,7 @@ struct Parser {
         return parsed_struct
     }
 
-    public function parse_function(mutable this, anonymous linkage: FunctionLinkage, anonymous visibility: Visibility) throws -> ParsedFunction {
+    public function parse_function(mutable this, anonymous linkage: FunctionLinkage) throws -> ParsedFunction {
         let mutable parsed_function = ParsedFunction(
             name: "",
             name_span: empty_span(),
@@ -1371,6 +1374,34 @@ struct Parser {
         parsed_function.params = params
 
         return parsed_function
+    }
+
+    function parse_field(mutable this, anonymous visibility: Visibility) throws -> ParsedField {
+        let parsed_variable_declaration = .parse_variable_declaration()
+
+        match parsed_variable_declaration.parsed_type {
+            Empty => {
+                .error("Field missing type", parsed_variable_declaration.span)
+            }
+            else => {}
+        }
+
+        return ParsedField(
+            var_decl: parsed_variable_declaration,
+            visibility,
+        )
+    }
+
+    function parse_method(mutable this, anonymous linkage: FunctionLinkage, anonymous visibility: Visibility) throws -> ParsedMethod {
+        let parsed_function = .parse_function(linkage)
+
+        // TODO: The bootstrap compiler sets parsed_function.must_instantiate here if the linkage is External.
+        //       Do we still need to do that?
+
+        return ParsedMethod(
+            parsed_function,
+            visibility,
+        )
     }
 
     function parse_typename(mutable this) throws -> ParsedType {

--- a/selfhost/main.jakt
+++ b/selfhost/main.jakt
@@ -775,10 +775,31 @@ enum Type {
     Builtin
 }
 
+enum DefinitionLinkage {
+    Internal
+    External
+}
+
+enum DefinitionType {
+    Class
+    Struct
+}
+
 // Parsed Types
 struct ParsedNamespace {
-    public name: String
-    public functions: [ParsedFunction]
+    name: String
+    functions: [ParsedFunction]
+    structs: [ParsedStruct]
+}
+
+struct ParsedStruct {
+    name: String
+    name_span: JaktSpan
+    generic_parameters: [[String:JaktSpan]]
+    fields: [ParsedVarDecl]
+    methods: [ParsedFunction]
+    definition_linkage: DefinitionLinkage
+    definition_type: DefinitionType
 }
 
 struct ParsedFunction {
@@ -1008,7 +1029,7 @@ struct Parser {
     } 
 
     public function parse_namespace(mutable this) throws -> ParsedNamespace {
-        let mutable parsed_namespace = ParsedNamespace(name: "", functions: [])
+        let mutable parsed_namespace = ParsedNamespace(name: "", functions: [], structs: [])
 
         let mutable should_break = false
         while not should_break and not .eof() {
@@ -1016,6 +1037,14 @@ struct Parser {
                 Function => {
                     let function = .parse_function(FunctionLinkage::Internal, Visibility::Public)
                     parsed_namespace.functions.push(function)
+                }
+                Struct => {
+                    let parsed_struct = .parse_struct(DefinitionLinkage::Internal, DefinitionType::Struct)
+                    parsed_namespace.structs.push(parsed_struct)
+                }
+                Class => {
+                    let parsed_struct = .parse_struct(DefinitionLinkage::Internal, DefinitionType::Class)
+                    parsed_namespace.structs.push(parsed_struct)
                 }
                 Eol => {
                     // Ignore
@@ -1032,6 +1061,134 @@ struct Parser {
         }
 
         return parsed_namespace
+    }
+
+    public function parse_struct(mutable this, anonymous definition_linkage: DefinitionLinkage, anonymous definition_type: DefinitionType) throws -> ParsedStruct {
+        let mutable parsed_struct = ParsedStruct(
+            name: "",
+            name_span: empty_span(),
+            generic_parameters: [],
+            fields: [],
+            methods: [],
+            definition_linkage,
+            definition_type,
+        )
+
+        let definition_type_name = match definition_type {
+            Struct => "struct"
+            Class => "class"
+        }
+
+        .index++
+
+        // Struct name
+        if .index >= .tokens.size() {
+            .error(format("Incomplete {} definition", definition_type_name), .current().span())
+            return parsed_struct
+        }
+
+        let struct_name = match .current() {
+            Identifier(name) => name
+            else => {
+                .error(format("Invalid {} name", definition_type_name), .current().span())
+                return parsed_struct
+            }
+        }
+        parsed_struct.name = struct_name
+        parsed_struct.name_span = .current().span()
+
+        .index++
+
+        if .index >= .tokens.size() {
+            .error(format("Incomplete {} definition", definition_type_name), .current().span())
+            return parsed_struct
+        }
+
+        // Generic parameters
+        parsed_struct.generic_parameters = .parse_generic_parameters()
+
+        if .index >= .tokens.size() {
+            .error(format("Incomplete {} definition", definition_type_name), .current().span())
+            return parsed_struct
+        }
+
+        // Struct body
+        match .current() {
+            LCurly(span) => {
+                .index++
+            }
+            else => {
+                .error("Expected ‘{’", .current().span())
+            }
+        }
+
+        let mutable fields: [ParsedVarDecl] = []
+        let mutable methods: [ParsedFunction] = []
+
+        // This gets reset after each loop. If someone doesn't consume it, we error out.
+        let mutable last_visibility: Visibility? = None
+        let mutable should_break = false
+        while not should_break and .index < .tokens.size() {
+            let token = .current()
+            match token {
+                Eof => {
+                    should_break = true
+                }
+                RCurly => {
+                    if last_visibility.has_value() {
+                        .error("Expected function or parameter after visibility modifier", token.span())
+                    }
+                    should_break = true
+                }
+                Comma | Eol => {
+                    // Treat comma as whitespace? Might require them in the future
+                    .index++
+                }
+                Function => {
+                    todo("Implement struct method parsing")
+                    should_break = true
+                }
+                Public => {
+                    // FIXME: Reject multiple visibility modifiers
+                    last_visibility = Visibility::Public
+                    .index++
+                }
+                Private => {
+                    // FIXME: Reject multiple visibility modifiers
+                    last_visibility = Visibility::Private
+                    .index++
+                }
+                Restricted => {
+                    // FIXME: Reject multiple visibility modifiers
+                    todo("Implement restricted() visibility modifier")
+                    .index++
+                }
+                Identifier => {
+                    todo("Implement struct parameter parsing")
+                    should_break = true
+                }
+                else => {
+                    .error(format("Invalid struct member, did not expect a {} here", token), token.span())
+                }
+            }
+        }
+
+        if .index == .tokens.size() {
+            .error("Incomplete struct", .tokens[.index - 1].span())
+        }
+        match .current() {
+            Token::RCurly(span) => {
+                .index++
+            }
+            else => {
+                .error("Incomplete struct", .tokens[.index - 1].span())
+            }
+        }
+
+        parsed_struct.fields = fields
+        parsed_struct.methods = methods
+
+        return parsed_struct
     }
 
     public function parse_function(mutable this, anonymous linkage: FunctionLinkage, anonymous visibility: Visibility) throws -> ParsedFunction {

--- a/selfhost/main.jakt
+++ b/selfhost/main.jakt
@@ -1155,10 +1155,6 @@ struct Parser {
                     // Treat comma as whitespace? Might require them in the future
                     .index++
                 }
-                Function => {
-                    todo("Implement struct method parsing")
-                    should_break = true
-                }
                 Public(span) => {
                     if last_visibility.has_value() {
                         .error_with_hint("Multiple visibility modifiers on one field or method are not allowed", span, "Previous modifier is here", last_visibility_span!)
@@ -1198,6 +1194,24 @@ struct Parser {
                     }
 
                     fields.push(field)
+                }
+                Function => {
+                    // Parse a method
+
+                    let function_linkage = match definition_linkage {
+                        DefinitionLinkage::Internal => FunctionLinkage::Internal
+                        DefinitionLinkage::External => FunctionLinkage::External
+                    }
+
+                    let visibility = last_visibility ?? default_visibility
+                    last_visibility = None
+                    last_visibility_span = None
+
+                    let parsed_method = .parse_function(function_linkage, visibility)
+
+                    // TODO: The bootstrap compiler sets parsed_method.must_instantiate here if the linkage is External.
+
+                    methods.push(parsed_method)
                 }
                 else => {
                     .error(format("Invalid struct member, did not expect a {} here", token), token.span())

--- a/selfhost/main.jakt
+++ b/selfhost/main.jakt
@@ -1023,6 +1023,8 @@ struct Parser {
                     should_break = true
                 }
                 else => {
+                    .error("Unrecognized token in namespace (probably not implemented yet)", .current().span())
+                    should_break = true
                 }
             }
         }


### PR DESCRIPTION
Some work towards struct and class support. This does *not* include parsing member access, so most of the samples/tests for structs and classes will still fail to compile. But, I figured it was better to get this submitted sooner rather than later to not hold anyone else up.

This is my first contribution to the self-hosted compiler/using Jakt, so I'm 100% sure I've done some things wrong/weirdly, so don't hesitate to tell me. :^)

