### PR TITLE
typechecker+codegen+tests: Mark `format` as `throws`

### DIFF
--- a/src/codegen.rs
+++ b/src/codegen.rs
@@ -2883,7 +2883,7 @@ fn codegen_expr(
                 }
                 output.push(')');
             } else if call.name == "format" {
-                output.push_str("TRY(String::formatted(");
+                output.push_str("(String::formatted(");
                 for (i, param) in call.args.iter().enumerate() {
                     output.push_str(&codegen_expr(indent, &param.1, project, context));
                     if i != call.args.len() - 1 {

--- a/tests/typechecker/format_throws.jakt
+++ b/tests/typechecker/format_throws.jakt
@@ -1,0 +1,10 @@
+/// Expect:
+/// - error: "Call to function that may throw needs to be in a try statement or a function marked as throws"
+
+function my_format(value: i64) => format("value is {}", value)
+
+function main() {
+    println("{}", my_format(value: 42))
+}
+
+// Fixes #517.


### PR DESCRIPTION
Made the typechecker mark `format` as `throws` because `runtime/lib.h`
declares `String::format` to return `ErrorOr`.

Removed the generation of `TRY` from codegen since it's now
marked as `throws` by the typechecker.

Fixes #517.
