### PR TITLE
editors/vscode: Add syntax highlighting for namespace declarations

### DIFF
--- a/editors/vscode/syntaxes/jakt.tmLanguage.json
+++ b/editors/vscode/syntaxes/jakt.tmLanguage.json
@@ -1,9 +1,15 @@
 {
   "$schema": "https://raw.githubusercontent.com/martinring/tmlanguage/master/tmlanguage.json",
   "name": "jakt",
+  "fileTypes": [
+    "jakt"
+  ],
   "patterns": [
     {
       "include": "#function"
+    },
+    {
+      "include": "#namespace"
     },
     {
       "include": "#struct"
@@ -107,6 +113,42 @@
       "patterns": [
         {
           "include": "#types"
+        }
+      ]
+    },
+    "namespace": {
+      "patterns": [
+        {
+          "name": "meta.namespace.jakt",
+          "match": "\\b(namespace)\\s+((?:\\w|_)(?:\\w|_|[0-9])*)",
+          "captures": {
+            "1": {
+              "name": "keyword.namespace.jakt"
+            },
+            "2": {
+              "name": "entity.name.namespace.jakt"
+            }
+          }
+        },
+        {
+          "name": "meta.block.namespace.jakt",
+          "begin": "(?<=(?:namespace).*?)(\\{)",
+          "beginCaptures": {
+            "1": {
+              "name": "punctuation.begin.brace.jakt"
+            }
+          },
+          "end": "(\\})",
+          "endCaptures": {
+            "1": {
+              "name": "punctuation.end.brace.jakt"
+            }
+          },
+          "patterns": [
+            {
+              "include": "$self"
+            }
+          ]
         }
       ]
     },


### PR DESCRIPTION
Previously the keyword `namespace` would be gray in namespace declarations, now it is treated as a keyword in a similar way to struct definitions.

Before this commit:
<img width="177" alt="Screen Shot 2022-06-04 at 2 07 24 PM" src="https://user-images.githubusercontent.com/33611513/172020084-c9efdf0e-ca02-4906-96bd-ea953c112883.png">

Now:
<img width="188" alt="Screen Shot 2022-06-04 at 2 04 00 PM" src="https://user-images.githubusercontent.com/33611513/172019972-cdc8247d-1edf-4756-b7d2-24fe06b9171f.png">

