### PR TITLE
all: Rename anonymous to anon globally

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ rect.set_size(width: 640, height: 480)
 
 There are two exceptions to this:
 
-- [x] If the parameter in the function declaration is declared as `anonymous`, omitting the argument label is allowed.
+- [x] If the parameter in the function declaration is declared as `anon`, omitting the argument label is allowed.
 - [x] When passing a variable with the same name as the parameter.
 
 ## Structures and classes
@@ -168,7 +168,7 @@ x.func()
 class Foo {
     x: i64
 
-    function set(mutable this, anonymous x: i64) {
+    function set(mutable this, anon x: i64) {
         this.x = x
     }
 }
@@ -285,7 +285,7 @@ enum MyOptional<T> {
     None
 }
 
-function value_or_default<T>(anonymous x: MyOptional<T>, default: T) -> T {
+function value_or_default<T>(anon x: MyOptional<T>, default: T) -> T {
     return match x {
         Some(value) => {
             let stuff = maybe_do_stuff_with(value)
@@ -303,7 +303,7 @@ enum Foo {
     )
 }
 
-function look_at_foo(anonymous x: Foo) -> i32 {
+function look_at_foo(anon x: Foo) -> i32 {
     match x {
         StructLikeThingy(field_a: a, field_b) => {
             return a + field_b
@@ -335,7 +335,7 @@ function do_nothing_in_particular() => match AlertDescription::CloseNotify {
 **Jakt** supports both generic structures and generic functions.
 
 ```jakt
-function id<T>(anonymous x: T) -> T {
+function id<T>(anon x: T) -> T {
     return x
 }
 

--- a/editors/vim/syntax/jakt.vim
+++ b/editors/vim/syntax/jakt.vim
@@ -46,7 +46,7 @@ let s:jakt_syntax_keywords = {
     \ ,                     ]
     \ , 'jaktVarDecl' :["mutable"
     \ ,                 "let"
-    \ ,                 "anonymous"
+    \ ,                 "anon"
     \ ,                 "raw"
     \ ,                ]
     \ , 'jaktType' :["String"

--- a/editors/vscode/syntaxes/jakt.tmLanguage.json
+++ b/editors/vscode/syntaxes/jakt.tmLanguage.json
@@ -482,8 +482,8 @@
     "argument-list": {
       "patterns": [
         {
-          "name": "storage.modifier.anonymous.argument.jakt",
-          "match": "\\banonymous\\b"
+          "name": "storage.modifier.anon.argument.jakt",
+          "match": "\\banon\\b"
         },
         {
           "include": "#this"

--- a/runtime/AK/Format.cpp
+++ b/runtime/AK/Format.cpp
@@ -95,7 +95,7 @@ ErrorOr<void> vformat_impl(TypeErasedFormatParams& params, FormatBuilder& builde
     return {};
 }
 
-} // namespace AK::{anonymous}
+} // namespace AK::{anon}
 
 FormatParser::FormatParser(StringView input)
     : GenericLexer(input)

--- a/runtime/prelude.jakt
+++ b/runtime/prelude.jakt
@@ -1,6 +1,6 @@
 extern struct String {
-    function number(anonymous number: i64) throws -> String
-    function split(this, anonymous c: c_char) throws -> [String]
+    function number(anon number: i64) throws -> String
+    function split(this, anon c: c_char) throws -> [String]
     function c_string(this) -> raw c_char
     function to_int(this) -> i32?
     function to_uint(this) -> u32?
@@ -10,7 +10,7 @@ extern struct String {
     function repeated(character: c_char, count: usize) throws -> String
     function is_empty(this) -> bool
     function length(this) -> usize
-    function byte_at(this, anonymous index: usize) -> u8
+    function byte_at(this, anon index: usize) -> u8
 }
 
 extern struct ArrayIterator<T> {
@@ -19,13 +19,13 @@ extern struct ArrayIterator<T> {
 
 extern struct Array<T> {
     function is_empty(this) -> bool
-    function contains(this, anonymous value: T) -> bool
+    function contains(this, anon value: T) -> bool
     function size(this) -> usize
     function capacity(this) -> usize
-    function ensure_capacity(this, anonymous capacity: usize) throws
-    function add_capacity(this, anonymous capacity: usize) throws
-    function resize(mutable this, anonymous size: usize) throws
-    function push(mutable this, anonymous value: T) throws
+    function ensure_capacity(this, anon capacity: usize) throws
+    function add_capacity(this, anon capacity: usize) throws
+    function resize(mutable this, anon size: usize) throws
+    function push(mutable this, anon value: T) throws
     function pop(mutable this) -> T?
     function iterator(this) -> ArrayIterator<T>
 }
@@ -33,8 +33,8 @@ extern struct Array<T> {
 extern struct Optional<T> {
     function has_value(this) -> bool
     function value(this) -> T
-    function value_or(this, anonymous x: T) -> T
-    function Optional<S>(anonymous x: S) -> Optional<S>
+    function value_or(this, anon x: T) -> T
+    function Optional<S>(anon x: S) -> Optional<S>
 }
 
 extern struct WeakPtr<T> {
@@ -48,11 +48,11 @@ extern struct DictionaryIterator<K, V> {
 
 extern struct Dictionary<K, V> {
     function is_empty(this) -> bool
-    function get(this, anonymous key: K) -> V?
-    function contains(this, anonymous key: K) -> bool
+    function get(this, anon key: K) -> V?
+    function contains(this, anon key: K) -> bool
     function set(mutable this, key: K, value: V) throws
-    function remove(mutable this, anonymous key: K) -> bool
-    function ensure_capacity(mutable this, anonymous capacity: usize) throws
+    function remove(mutable this, anon key: K) -> bool
+    function ensure_capacity(mutable this, anon capacity: usize) throws
     function clear(mutable this)
     function size(this) -> usize
     function capacity(this) -> usize
@@ -68,10 +68,10 @@ extern struct SetIterator<T> {
 
 extern struct Set<V> {
     function is_empty(this) -> bool
-    function contains(this, anonymous value: V) -> bool
-    function add(mutable this, anonymous value: V) throws
-    function remove(mutable this, anonymous value: V) -> bool
-    function ensure_capacity(mutable this, anonymous capacity: usize) throws
+    function contains(this, anon value: V) -> bool
+    function add(mutable this, anon value: V) throws
+    function remove(mutable this, anon value: V) -> bool
+    function ensure_capacity(mutable this, anon capacity: usize) throws
     function clear(mutable this)
     function size(this) -> usize
     function capacity(this) -> usize
@@ -88,18 +88,18 @@ extern struct Range<T> {
 
 extern struct Error {
     function code(this) -> i32
-    function from_errno(anonymous errno: i32) -> Error
+    function from_errno(anon errno: i32) -> Error
 }
 
 extern class File {
-    public function open_for_reading(anonymous path: String) throws -> File
-    public function open_for_writing(anonymous path: String) throws -> File
+    public function open_for_reading(anon path: String) throws -> File
+    public function open_for_writing(anon path: String) throws -> File
 
-    public function read(mutable this, anonymous buffer: [u8]) throws -> usize
-    public function write(mutable this, anonymous data: [u8]) throws -> usize
+    public function read(mutable this, anon buffer: [u8]) throws -> usize
+    public function write(mutable this, anon data: [u8]) throws -> usize
 
     public function read_all(mutable this) throws -> [u8]
 }
 
-extern function as_saturated<U, T>(anonymous input: T) -> U
-extern function as_truncated<U, T>(anonymous input: T) -> U
+extern function as_saturated<U, T>(anon input: T) -> U
+extern function as_truncated<U, T>(anon input: T) -> U

--- a/samples/apps/cat.jakt
+++ b/samples/apps/cat.jakt
@@ -1,10 +1,10 @@
 extern struct FILE {}
 
-extern function fopen(anonymous str: raw c_char, anonymous mode: raw c_char) -> raw FILE
-extern function fgetc(anonymous file: mutable raw FILE) -> c_int
-extern function fclose(anonymous file: mutable raw FILE) -> c_int
-extern function feof(anonymous file: mutable raw FILE) -> c_int
-extern function putchar(anonymous ch: c_int) -> c_int
+extern function fopen(anon str: raw c_char, anon mode: raw c_char) -> raw FILE
+extern function fgetc(anon file: mutable raw FILE) -> c_int
+extern function fclose(anon file: mutable raw FILE) -> c_int
+extern function feof(anon file: mutable raw FILE) -> c_int
+extern function putchar(anon ch: c_int) -> c_int
 
 function main(args: [String]) {
     if args.size() <= 1 {

--- a/samples/apps/crc32.jakt
+++ b/samples/apps/crc32.jakt
@@ -1,10 +1,10 @@
 extern struct FILE {}
 
-extern function fopen(anonymous str: raw c_char, anonymous mode: raw c_char) -> raw FILE
-extern function fgetc(anonymous file: mutable raw FILE) -> c_int
-extern function fclose(anonymous file: mutable raw FILE) -> c_int
-extern function feof(anonymous file: mutable raw FILE) -> c_int
-extern function putchar(anonymous ch: c_int) -> c_int
+extern function fopen(anon str: raw c_char, anon mode: raw c_char) -> raw FILE
+extern function fgetc(anon file: mutable raw FILE) -> c_int
+extern function fclose(anon file: mutable raw FILE) -> c_int
+extern function feof(anon file: mutable raw FILE) -> c_int
+extern function putchar(anon ch: c_int) -> c_int
 
 function make_lookup_table() throws -> [u32] {
     let mutable data = [0u32; 256]

--- a/samples/apps/json.jakt
+++ b/samples/apps/json.jakt
@@ -1,6 +1,6 @@
 extern struct StringBuilder {
     // FIXME: AK::StringBuilder::append() actually takes a c_char, not a u8, but nobody complains
-    function append(mutable this, anonymous c: u8)
+    function append(mutable this, anon c: u8)
     function to_string(this) throws -> String
     function StringBuilder() -> StringBuilder
 }
@@ -18,7 +18,7 @@ enum JsonValue {
     Object([String:JsonValue])
 }
 
-function is_whitespace(anonymous c: u8) -> bool {
+function is_whitespace(anon c: u8) -> bool {
     return match c {
         b'\t' | b'\n' | b'\r' | b' ' => true
         else => false
@@ -144,7 +144,7 @@ class JsonParser {
         return ch
     }
 
-    function consume_specific(mutable this, anonymous expected: u8) -> bool {
+    function consume_specific(mutable this, anon expected: u8) -> bool {
         if .peek() != expected {
             return false
         }

--- a/samples/arrays/array_param.jakt
+++ b/samples/arrays/array_param.jakt
@@ -1,7 +1,7 @@
 /// Expect:
 /// - output: "one\n"
 
-function get_first(anonymous v: [String]) => v[0]
+function get_first(anon v: [String]) => v[0]
 
 function main() {
     println("{}", get_first(["one", "two"]))

--- a/samples/control_flow/defer_in_defer.jakt
+++ b/samples/control_flow/defer_in_defer.jakt
@@ -1,7 +1,7 @@
 /// Expect:
 /// - output: "foo called with 1\nfoo called with 2\nfoo called with 3\nfoo called with 4\nfoo called with 5\n"
 
-function foo(anonymous n: i8) {
+function foo(anon n: i8) {
     println("foo called with {}", n)
 }
 

--- a/samples/control_flow/try_catch.jakt
+++ b/samples/control_flow/try_catch.jakt
@@ -8,7 +8,7 @@ function notoss() throws -> i32 {
     return 5
 }
 
-function toss(anonymous value: i32) throws {
+function toss(anon value: i32) throws {
     throw Error::from_errno(value)
 }
 

--- a/samples/enums/recursive_enums.jakt
+++ b/samples/enums/recursive_enums.jakt
@@ -10,7 +10,7 @@ boxed enum AST {
     BinaryOperation(lhs: AST, op: Operation, rhs: AST)
 }
 
-function eval(anonymous ast: AST) -> i64 {
+function eval(anon ast: AST) -> i64 {
     match ast {
         AST::Int(i) => {
             return i

--- a/samples/enums/recursive_enums_bad.jakt
+++ b/samples/enums/recursive_enums_bad.jakt
@@ -10,7 +10,7 @@ enum AST {
     BinaryOperation(lhs: AST, op: Operation, rhs: AST)
 }
 
-function eval(anonymous ast: AST) -> i64 {
+function eval(anon ast: AST) -> i64 {
     match ast {
         AST::Int(i) => {
             return i

--- a/samples/enums/simple_match.jakt
+++ b/samples/enums/simple_match.jakt
@@ -26,14 +26,14 @@ function make_result(okay: bool) -> BetterResult<i64, String> {
     return BetterResult::TheWorldIsBurning("666")
 }
 
-function better_optional_from<T>(anonymous optional: T?) -> BetterOptional<T> {
+function better_optional_from<T>(anon optional: T?) -> BetterOptional<T> {
     if optional.has_value() {
         return BetterOptional::Some(optional!)
     }
     return BetterOptional::None()
 }
 
-function to_objectively_better_optional<T>(anonymous optional: BetterOptional<T>) -> ObjectivelyBetterOptional<T> {
+function to_objectively_better_optional<T>(anon optional: BetterOptional<T>) -> ObjectivelyBetterOptional<T> {
     return match optional {
         BetterOptional::Some(value) => ObjectivelyBetterOptional::Some(value: value, joke_metadata: "I'm a joke")
         BetterOptional::None => ObjectivelyBetterOptional::None()

--- a/samples/functions/argument_labels.jakt
+++ b/samples/functions/argument_labels.jakt
@@ -4,10 +4,10 @@
 function foo(a: bool, b: bool) {
 }
 
-function bar(anonymous a: bool, b: bool) {
+function bar(anon a: bool, b: bool) {
 }
 
-function baz(anonymous a: bool, anonymous b: bool) {
+function baz(anon a: bool, anon b: bool) {
 }
 
 function qux(a: bool) {

--- a/samples/generics/generic_fun.jakt
+++ b/samples/generics/generic_fun.jakt
@@ -1,7 +1,7 @@
 /// Expect:
 /// - output: "3\n"
 
-function id<T>(anonymous x: T) => x
+function id<T>(anon x: T) => x
 
 function main() {
     println("{}", id(3))

--- a/samples/generics/generic_fun2.jakt
+++ b/samples/generics/generic_fun2.jakt
@@ -1,7 +1,7 @@
 /// Expect:
 /// - output: "13\n"
 
-function id<T>(anonymous x: T) => x
+function id<T>(anon x: T) => x
 
 function main() {
     println("{}", id(3) + 10)

--- a/samples/generics/generic_fun3.jakt
+++ b/samples/generics/generic_fun3.jakt
@@ -1,7 +1,7 @@
 /// Expect:
 /// - output: "103\n"
 
-function id<T>(anonymous x: T) -> T {
+function id<T>(anon x: T) -> T {
     return x;
 }
 

--- a/samples/generics/generic_fun4.jakt
+++ b/samples/generics/generic_fun4.jakt
@@ -1,7 +1,7 @@
 /// Expect:
 /// - output: "1003\n"
 
-function id<T>(anonymous x: T) -> T {
+function id<T>(anon x: T) -> T {
     return x;
 }
 

--- a/samples/generics/generic_types.jakt
+++ b/samples/generics/generic_types.jakt
@@ -1,7 +1,7 @@
 /// Expect:
 /// - output: "3\n"
 
-function do_pop<T>(anonymous arr: mutable [T]) -> Optional<T> {
+function do_pop<T>(anon arr: mutable [T]) -> Optional<T> {
   return arr.pop()
 }
 

--- a/samples/generics/passing_arrays.jakt
+++ b/samples/generics/passing_arrays.jakt
@@ -1,7 +1,7 @@
 /// Expect:
 /// - output: "1\n"
 
-function dump<T>(anonymous v: [T]) { return v[0] }
+function dump<T>(anon v: [T]) { return v[0] }
 
 function main() {
     println("{}", dump([1, 2, 3]))

--- a/samples/match/match_generic_codegen.jakt
+++ b/samples/match/match_generic_codegen.jakt
@@ -1,7 +1,7 @@
 /// Expect:
 /// - output: "1\n2\n3\n2\n2\n4\n2\n"
 
-function generic_value_match<T>(anonymous x: T) -> i64 {
+function generic_value_match<T>(anon x: T) -> i64 {
     return match x {
         (3) => 1
         (2) => 2
@@ -10,7 +10,7 @@ function generic_value_match<T>(anonymous x: T) -> i64 {
     }
 }
 
-function generic_enum_match<T>(anonymous x: T) -> i64 {
+function generic_enum_match<T>(anon x: T) -> i64 {
     return match x {
         A(y) => y
         B => 2

--- a/samples/math/bitwise.jakt
+++ b/samples/math/bitwise.jakt
@@ -1,7 +1,7 @@
 /// Expect:
 /// - output: "No error\n"
 
-function check(anonymous a: i64, anonymous b: i64) -> i64 {
+function check(anon a: i64, anon b: i64) -> i64 {
     if a != b {
         println("Not equal!")
         println("{}", a)

--- a/samples/strings/string_builder.jakt
+++ b/samples/strings/string_builder.jakt
@@ -3,7 +3,7 @@
 
 extern struct StringBuilder {
     function StringBuilder() -> StringBuilder
-    function append(mutable this, anonymous s: raw c_char)
+    function append(mutable this, anon s: raw c_char)
     function to_string(mutable this) throws -> String
 }
 

--- a/selfhost/main.jakt
+++ b/selfhost/main.jakt
@@ -2,28 +2,28 @@
 /// - output: ""
 
 extern struct StringBuilder {
-    function append(mutable this, anonymous s: u8)
+    function append(mutable this, anon s: u8)
     function to_string(mutable this) throws -> String
     function StringBuilder() -> StringBuilder
 }
 
 extern function abort()
 
-function todo(anonymous message: String) {
+function todo(anon message: String) {
     eprintln("TODO: {}", message)
     abort()
 }
 
-function panic(anonymous message: String) -> void {
+function panic(anon message: String) -> void {
     eprintln("internal error: {}", message)
     abort()
 }
 
 // FIXME: These should not need explicit "-> bool" return types.
-function is_ascii_alpha(anonymous c: u8) -> bool => (c >= b'a' and c <= b'z') or (c >= b'A' and c <= b'Z')
-function is_ascii_digit(anonymous c: u8) -> bool => (c >= b'0' and c <= b'9')
-function is_ascii_hexdigit(anonymous c: u8) -> bool => (c >= b'0' and c <= b'9') or (c >= b'a' and c <= b'f') or (c >= b'A' and c <= b'F')
-function is_ascii_alphanumeric(anonymous c: u8) -> bool => is_ascii_alpha(c) or is_ascii_digit(c)
+function is_ascii_alpha(anon c: u8) -> bool => (c >= b'a' and c <= b'z') or (c >= b'A' and c <= b'Z')
+function is_ascii_digit(anon c: u8) -> bool => (c >= b'0' and c <= b'9')
+function is_ascii_hexdigit(anon c: u8) -> bool => (c >= b'0' and c <= b'9') or (c >= b'a' and c <= b'f') or (c >= b'A' and c <= b'F')
+function is_ascii_alphanumeric(anon c: u8) -> bool => is_ascii_alpha(c) or is_ascii_digit(c)
 
 //FIXME: Would be nice to name this Span and not have conflict
 struct JaktSpan {
@@ -31,7 +31,7 @@ struct JaktSpan {
     end: usize
 }
 
-function merge_spans(anonymous start: JaktSpan, anonymous end: JaktSpan) -> JaktSpan => JaktSpan(start: start.start, end: end.end)
+function merge_spans(anon start: JaktSpan, anon end: JaktSpan) -> JaktSpan => JaktSpan(start: start.start, end: end.end)
 function empty_span() -> JaktSpan => JaktSpan(start: 0, end: 0)
 
 enum Token {
@@ -95,7 +95,7 @@ enum Token {
 
     // Keywords
     And(JaktSpan)
-    Anonymous(JaktSpan)
+    anon(JaktSpan)
     Boxed(JaktSpan)
     Break(JaktSpan)
     Catch(JaktSpan)
@@ -197,7 +197,7 @@ enum Token {
         Eof(span) => span
         FatArrow(span) => span
         And(span) => span
-        Anonymous(span) => span
+        anon(span) => span
         Boxed(span) => span
         Break(span) => span
         Catch(span) => span
@@ -239,7 +239,7 @@ enum Token {
 
     function from_keyword_or_identifier(string: String, span: JaktSpan) => match string {
         "and" => Token::And(span)
-        "anonymous" => Token::Anonymous(span)
+        "anon" => Token::anon(span)
         "boxed" => Token::Boxed(span)
         "break" => Token::Break(span)
         "catch" => Token::Catch(span)
@@ -291,7 +291,7 @@ struct Lexer {
     input: [u8]
     errors: [JaktError]
 
-    function error(mutable this, anonymous message: String, anonymous span: JaktSpan) throws {
+    function error(mutable this, anon message: String, anon span: JaktSpan) throws {
         .errors.push(JaktError::Message(message, span))
     }
 
@@ -305,7 +305,7 @@ struct Lexer {
 
     // Peek at upcoming characters, N steps ahead in the stream
     // FIXME: This could be merged with peek() once we support default arguments
-    function peek_ahead(this, anonymous steps: usize) -> u8 {
+    function peek_ahead(this, anon steps: usize) -> u8 {
         if .index + steps >= .input.size() {
             return 0
         }
@@ -660,7 +660,7 @@ function ansi_color_code(severity: MessageSeverity) throws => match severity {
     Error => "31" // Red
 }
 
-function display_message_with_span(anonymous severity: MessageSeverity, file_name: String, file_contents: [u8], message: String, span: JaktSpan) throws {
+function display_message_with_span(anon severity: MessageSeverity, file_name: String, file_contents: [u8], message: String, span: JaktSpan) throws {
     println("{}: {}", severity_name(severity), message)
 
     let line_spans = gather_line_spans(file_contents)
@@ -1012,11 +1012,11 @@ struct Parser {
     tokens: [Token]
     errors: [JaktError]
 
-    function error(mutable this, anonymous message: String, anonymous span: JaktSpan) throws {
+    function error(mutable this, anon message: String, anon span: JaktSpan) throws {
         .errors.push(JaktError::Message(message, span))
     }
 
-    function error_with_hint(mutable this, anonymous message: String, anonymous span: JaktSpan, anonymous hint: String, anonymous hint_span: JaktSpan) throws {
+    function error_with_hint(mutable this, anon message: String, anon span: JaktSpan, anon hint: String, anon hint_span: JaktSpan) throws {
         .errors.push(JaktError::MessageWithHint(message, span, hint, hint_span))
     }
 
@@ -1024,7 +1024,7 @@ struct Parser {
 
     function eol(this) => .eof() or .tokens[.index] is Eol
 
-    function peek(this, anonymous steps: usize) -> Token {
+    function peek(this, anon steps: usize) -> Token {
         if .eof() or (steps + .index) >= .tokens.size()  {
             return .tokens[.tokens.size() - 1]
         }
@@ -1076,7 +1076,7 @@ struct Parser {
         return parsed_namespace
     }
 
-    public function parse_struct(mutable this, anonymous definition_linkage: DefinitionLinkage, anonymous definition_type: DefinitionType) throws -> ParsedStruct {
+    public function parse_struct(mutable this, anon definition_linkage: DefinitionLinkage, anon definition_type: DefinitionType) throws -> ParsedStruct {
         let mutable parsed_struct = ParsedStruct(
             name: "",
             name_span: empty_span(),
@@ -1227,7 +1227,7 @@ struct Parser {
         return parsed_struct
     }
 
-    public function parse_function(mutable this, anonymous linkage: FunctionLinkage) throws -> ParsedFunction {
+    public function parse_function(mutable this, anon linkage: FunctionLinkage) throws -> ParsedFunction {
         let mutable parsed_function = ParsedFunction(
             name: "",
             name_span: empty_span(),
@@ -1281,7 +1281,7 @@ struct Parser {
                     .index++
                     current_param_requires_label = true
                 }
-                Anonymous => {
+                anon => {
                     .index++
                     current_param_requires_label = false
                 }
@@ -1357,7 +1357,7 @@ struct Parser {
         return ParsedBlock(stmts: [return_statement])
     }
 
-    function parse_field(mutable this, anonymous visibility: Visibility) throws -> ParsedField {
+    function parse_field(mutable this, anon visibility: Visibility) throws -> ParsedField {
         let parsed_variable_declaration = .parse_variable_declaration()
 
         if parsed_variable_declaration.parsed_type is Empty {
@@ -1370,7 +1370,7 @@ struct Parser {
         )
     }
 
-    function parse_method(mutable this, anonymous linkage: FunctionLinkage, anonymous visibility: Visibility) throws -> ParsedMethod {
+    function parse_method(mutable this, anon linkage: FunctionLinkage, anon visibility: Visibility) throws -> ParsedMethod {
         let parsed_function = .parse_function(linkage)
 
         // TODO: The bootstrap compiler sets parsed_function.must_instantiate here if the linkage is External.
@@ -2309,8 +2309,8 @@ struct Typechecker {
     variables: [CheckedVarDecl]
     structures: [CheckedStruct]
 
-    function get_function(this, anonymous id: FunctionId) -> CheckedFunction => .functions[id.id]
-    function get_variable(this, anonymous id: VarId) -> CheckedVarDecl => .variables[id.id]
+    function get_function(this, anon id: FunctionId) -> CheckedFunction => .functions[id.id]
+    function get_variable(this, anon id: VarId) -> CheckedVarDecl => .variables[id.id]
 
 
 }

--- a/src/ide.rs
+++ b/src/ide.rs
@@ -569,11 +569,7 @@ pub fn get_function_signature(project: &Project, function_id: FunctionId) -> Str
     is_first_param = true;
 
     for param in &function.params {
-        let anonymous = if !param.requires_label {
-            "anonymous "
-        } else {
-            ""
-        };
+        let anon = if !param.requires_label { "anon " } else { "" };
         let mutable = if param.variable.mutable {
             "mutable "
         } else {
@@ -590,7 +586,7 @@ pub fn get_function_signature(project: &Project, function_id: FunctionId) -> Str
         let seperator = if is_first_param { "" } else { ", " };
         parameters.push_str(&format!(
             "{}{}{}{}{}",
-            seperator, anonymous, mutable, param.variable.name, variable_type
+            seperator, anon, mutable, param.variable.name, variable_type
         ));
         is_first_param = false;
     }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1659,7 +1659,7 @@ pub fn parse_function(
                             current_param_requires_label = true;
                         }
 
-                        TokenContents::Name(name) if name == "anonymous" => {
+                        TokenContents::Name(name) if name == "anon" => {
                             current_param_requires_label = false;
                             *index += 1;
                         }

--- a/src/typechecker.rs
+++ b/src/typechecker.rs
@@ -4948,7 +4948,7 @@ pub fn typecheck_expression(
                                                             .any(|field| field.name == arg.1)
                                                     {
                                                         error = error.or(Some(JaktError::TypecheckError(
-                                                            format!("match case argument '{}' for struct-like enum variant cannot be anonymous", arg.1),
+                                                            format!("match case argument '{}' for struct-like enum variant cannot be anon", arg.1),
                                                             *arg_span,
                                                         )));
                                                         continue;

--- a/tests/codegen/extern_generic_function.jakt
+++ b/tests/codegen/extern_generic_function.jakt
@@ -3,8 +3,8 @@
 
 // These generic extern functions shouldn't compile to anything.
 
-extern function do_thing_with_type<T>(anonymous input: T) -> T
+extern function do_thing_with_type<T>(anon input: T) -> T
 
-extern function do_more_things<T, U>(anonymous input: U) -> T
+extern function do_more_things<T, U>(anon input: U) -> T
 
 function main() {}

--- a/tests/codegen/ns_level_circular_dependency.jakt
+++ b/tests/codegen/ns_level_circular_dependency.jakt
@@ -6,20 +6,20 @@ enum Test {
 }
 
 namespace Foo {
-    function foo(anonymous x: i32) -> Test {
+    function foo(anon x: i32) -> Test {
         return Bar::bar(x)
     }
-    function bar(anonymous x: i32) -> i32 {
+    function bar(anon x: i32) -> i32 {
         return x + 1
     }
 }
 
 namespace Bar {
-    function bar(anonymous x: i32) -> Test {
+    function bar(anon x: i32) -> Test {
         let y = Foo::bar(x)
         return Test::X(y)
     }
-    function foo(anonymous x: i32) -> Test {
+    function foo(anon x: i32) -> Test {
         return Foo::foo(x)
     }
 }

--- a/tests/parser/non_parameter_1.jakt
+++ b/tests/parser/non_parameter_1.jakt
@@ -1,7 +1,7 @@
 /// Expect:
 /// - error: "expected parameter\n"
 
-function foo(= anonymous n: i32) {
+function foo(= anon n: i32) {
     println("{}", n)
 }
 

--- a/tests/parser/non_parameter_2.jakt
+++ b/tests/parser/non_parameter_2.jakt
@@ -1,7 +1,7 @@
 /// Expect:
 /// - error: "expected parameter\n"
 
-function foo(anonymous = n: i32) {
+function foo(anon = n: i32) {
     println("{}", n)
 }
 

--- a/tests/parser/non_parameter_3.jakt
+++ b/tests/parser/non_parameter_3.jakt
@@ -1,7 +1,7 @@
 /// Expect:
 /// - error: "expected parameter\n"
 
-function foo(anonymous n: i32 = 1) {
+function foo(anon n: i32 = 1) {
     println("{}", n)
 }
 

--- a/tests/typechecker/generic_late_type_check.jakt
+++ b/tests/typechecker/generic_late_type_check.jakt
@@ -2,12 +2,12 @@
 /// - output: "3 2 1 0\n"
 
 // This should not be typechecked here, but rather when it's fully instantiated and used.
-function foo<T>(anonymous x: T, anonymous y: T) -> T {
+function foo<T>(anon x: T, anon y: T) -> T {
     return x + y
 }
 
 // Make sure type inference kinda works
-function bar<T>(anonymous x: T) {
+function bar<T>(anon x: T) {
     return x + 1
 }
 
@@ -15,7 +15,7 @@ function bar<T>(anonymous x: T) {
 struct Test {
     a: i32
 }
-function baz<T>(anonymous x: T) -> i32 {
+function baz<T>(anon x: T) -> i32 {
     return x.a
 }
 

--- a/tests/typechecker/generic_late_type_check_bad.jakt
+++ b/tests/typechecker/generic_late_type_check_bad.jakt
@@ -4,7 +4,7 @@
 struct Foo<T> {
     a: T
 
-    function test<U>(this, anonymous x: U) -> T {
+    function test<U>(this, anon x: U) -> T {
         return this.a + x
     }
 }

--- a/tests/typechecker/missing_type_in_namespace.jakt
+++ b/tests/typechecker/missing_type_in_namespace.jakt
@@ -2,7 +2,7 @@
 /// - error: "Unknown type"
 
 extern struct StringBuilder {
-    function append(mutable this, anonymous s: u8)
+    function append(mutable this, anon s: u8)
     function to_string(mutable this) throws -> String
     function StringBuilder() -> StringBuilder
 }


### PR DESCRIPTION
We've gone back and forth on this one. I propose we try `anon` again. Some trade-offs:

* `anonymous` is more clear but much harder to type (I regularly mistype it as `anonymouse` 🐭 )
* `anon` is shorter though perhaps a little vague? I think it should be obvious with a little time, but we should pay attention to if code gets harder to read or stays the same
