### PR TITLE
editors: Add syntax highlighting for emacs

### DIFF
--- a/editors/emacs/README.md
+++ b/editors/emacs/README.md
@@ -1,0 +1,9 @@
+# Jakt Mode
+`jakt-mode` is a emacs major mode that provides syntax highlighting and indentation.  
+## Installation
+Clone this repository and add this to your `init.el`. 
+```
+(add-to-list 'load-path "/path/to/jakt-mode/")
+(autoload 'jakt-mode "jakt-mode" nil t)
+(add-to-list 'auto-mode-alist '("\\.rs\\'" . rust-mode))
+```

--- a/editors/emacs/jakt_mode.el
+++ b/editors/emacs/jakt_mode.el
@@ -1,0 +1,103 @@
+(defvar jakt-mode-syntax-table nil "Syntax table for `jakt-mode`.")
+
+(setq jakt-mode-syntax-table
+      (let ((syntax-table (make-syntax-table)))
+        (modify-syntax-entry ?\/ ". 12b" syntax-table)
+        (modify-syntax-entry ?\n "> b" syntax-table)
+        (modify-syntax-entry ?_ "w" syntax-table)
+        syntax-table))
+
+(defcustom jakt-indent-offset 4
+  "Indent Jakt code by this number of spaces."
+  :type 'integer
+  :group 'jakt-mode
+  :safe #'integerp)
+
+(defun jakt-indent-line ()
+  "Indent a jakt line."
+  (let (indent
+        boi-p                         
+        move-eol-p
+        (point (point)))             
+    (save-excursion
+      (back-to-indentation)
+      (setq indent (car (syntax-ppss))
+            boi-p (= point (point)))
+      (when (and (eq (char-after) ?\n)
+                 (not boi-p))
+        (setq indent 0))
+      (when boi-p
+        (setq move-eol-p t))
+      (when (or (eq (char-after) ?\))
+                (eq (char-after) ?\}))
+        (setq indent (1- indent)))
+      (delete-region (line-beginning-position)
+                     (point))
+      (indent-to (* jakt-indent-offset indent)))
+    (when move-eol-p
+      (move-end-of-line nil))))
+
+(setq jakt-font-lock-defaults
+      (let* (
+             (jakt-conditional '("if" "else" "match"))
+             (jakt-repeat '("while" "for" "loop"))
+             (jakt-execution '("return" "break" "continue" "throw" "yield"))
+             (jakt-boolean '("true" "false"))
+             (jakt-keyword '("function" "extern"))
+             (jakt-exception '("throws"))
+             (jakt-macro '("defer" "unsafe" "throw" "try" "catch" "cpp")) 
+             (jakt-var-decls '("mutable" "let" "anonymous" "raw")) 
+             (jakt-types '("i8" "i16" "i32" "i16" "i32" "i64" "u8" "u16" "u32"
+                           "u64" "f32" "f64" "bool" "c_int" "c_char" "usize"
+                           "String"))
+             (jakt-builtin-fn '("print" "println")) 
+             (jakt-operators '("not" "and" "or" "as" "in")) 
+             (jakt-structure '("struct" "class" "enum" "namespace")) 
+             (jakt-constant '("this"))
+             (jakt-visibility '("public" "private")) 
+
+             (conditional-regex (regexp-opt jakt-conditional 'words))
+             (repeat-regex (regexp-opt jakt-repeat 'words))
+             (execution-regex (regexp-opt jakt-execution 'words))
+             (boolean-regex (regexp-opt jakt-boolean 'words))
+             (keyword-regex (regexp-opt jakt-keyword 'words))
+             (exception-regex (regexp-opt jakt-exception 'words))
+             (macro-regex (regexp-opt jakt-macro 'words))
+             (var-decls-regex (regexp-opt jakt-var-decls 'words))
+             (types-regex (regexp-opt jakt-types 'words))
+             (builtin-fn-regex (regexp-opt jakt-builtin-fn 'words))
+             (operators-regex (regexp-opt jakt-operators 'words))
+             (structure-regex (regexp-opt jakt-structure 'words))
+             (constant-regex (regexp-opt jakt-constant 'words))
+             (visibility-regex (regexp-opt jakt-visibility 'words)))
+
+        `(
+          ("[[:upper:]]\\w*" . 'font-lock-type-face)
+          (,exception-regex . 'font-lock-warning-face) 
+          (,operators-regex . 'font-lock-keyword-face)
+          (,conditional-regex . 'font-lock-keyword-face) 
+          (,repeat-regex . 'font-lock-keyword-face) 
+          (,boolean-regex . 'font-lock-keyword-face) 
+          (,types-regex . 'font-lock-type-face)
+          (,constant-regex . 'font-lock-constant-face)
+          (,builtin-fn-regex . 'font-lock-builtin-face)
+          (,keyword-regex . 'font-lock-keyword-face)
+          (,var-decls-regex . 'font-lock-variable-name-face)
+          (,macro-regex . 'font-lock-preprocessor-face) 
+          (,execution-regex . 'font-lock-keyword-face) 
+          (,structure-regex . 'font-lock-keyword-face)
+          (,visibility-regex . 'font-lock-keyword-face)
+          )))
+
+;;;###autoload
+(define-derived-mode jakt-mode prog-mode "Jakt"
+  "Major mode for Jakt code." 
+  :group 'jakt-mode
+  :syntax-table jakt-mode-syntax-table
+  (setq font-lock-defaults '((jakt-font-lock-defaults)))
+  (set-syntax-table jakt-mode-syntax-table)
+  (setq-local comment-start "//")
+  (setq-local comment-end "")
+  (setq-local indent-line-function #'jakt-indent-line))
+
+(provide 'jakt-mode)

--- a/editors/emacs/test.jakt
+++ b/editors/emacs/test.jakt
@@ -1,0 +1,85 @@
+function main() {
+    let set = {1, 2, 3}
+
+    println("{}", set.contains(1))
+    println("{}", set.contains(5))
+}
+
+enum MyOptional<T> {
+    Some(T)
+    None
+}
+
+function value_or_default<T>(anonymous x: MyOptional<T>, default: T) -> T {
+    return match x {
+        Some(value) => {
+            let stuff = maybe_do_stuff_with(value)
+            let more_stuff = stuff.do_some_more_processing()
+            yield more_stuff
+        }
+        None => default
+    }
+}
+
+enum Foo {
+    StructLikeThingy (
+        field_a: i32
+        field_b: i32
+    )
+}
+
+function look_at_foo(anonymous x: Foo) -> i32 {
+    match x {
+        StructLikeThingy(field_a: a, field_b) => {
+            return a + field_b
+        }
+    }
+}
+
+enum AlertDescription: i8 {
+    CloseNotify = 0
+    UnexpectedMessage = 10
+    BadRecordMAC = 20
+    // etc
+}
+
+// Use in match:
+function do_nothing_in_particular() => match AlertDescription::CloseNotify {
+    CloseNotify => { ... }
+    UnexpectedMessage => { ... }
+    BadRecordMAC => { ... }
+}
+
+namespace Greeters {
+    function greet() {
+        println("Well, hello friends")
+    }
+}
+
+function task_that_might_fail() throws -> usize {
+    if problem {
+        throw Error::from_errno(EPROBLEM)
+    }
+    ...
+    return result
+}
+
+
+function task_that_cannot_fail() -> usize {
+    ...
+    return result
+}
+
+try {
+    task_that_might_fail()
+} catch error {
+    println("Caught error: {}", error)
+}
+
+let mutable x = 0
+unsafe {
+    cpp {
+        "x = (i64)&x;"
+    }
+}
+println("{}", x)


### PR DESCRIPTION
This PR adds an emacs major mode for highlighting syntax and indentation. I've tried my best to highlight all keywords by looking at jakt extensions for other editors. The indentation offset defaults to 4 and can be changed by the user if need be. 