### PR TITLE
selfhost: Prevent infinite loops due to unhandled tokens in blocks

### DIFF
--- a/selfhost/main.jakt
+++ b/selfhost/main.jakt
@@ -1657,7 +1657,10 @@ struct Parser {
             For => .parse_for_statement()
             Try => .parse_try_statement()
             LCurly => ParsedStatement::Block(.parse_block())
-            else => ParsedStatement::Expression(.parse_expression())
+            else => {
+                .index++
+                yield ParsedStatement::Expression(.parse_expression())
+            }
         }
     }
 


### PR DESCRIPTION
Previously, when parsing a statement, if the parser encountered an unknown token it would return garbage without advancing the index. This lead to infinite loops namely when parsing blocks. This commit fixes this by incrementing the index when generating a `Garbage` expression.

Before this commit, running `samples/basics/error.jakt` would result in an infinite loop, now it produces the expected error output.

`samples/basics/error.jakt:`
```jakt
function main() {
	!@#$!@@#%#$@
}
```

Before this commit: Infinite loop

Output after this commit:
```Error: unknown character: @
----- samples/basics/error.jakt:5:6
 4 | function main() {
 5 |     !@#$!@@#%#$@
          ^- unknown character: @
 6 | }
-----
Error: unknown character: #
----- samples/basics/error.jakt:5:7
 4 | function main() {
 5 |     !@#$!@@#%#$@
           ^- unknown character: #
 6 | }
-----
Error: unknown character: @
----- samples/basics/error.jakt:5:10
 4 | function main() {
 5 |     !@#$!@@#%#$@
              ^- unknown character: @
 6 | }
-----
Error: unknown character: @
----- samples/basics/error.jakt:5:11
 4 | function main() {
 5 |     !@#$!@@#%#$@
               ^- unknown character: @
 6 | }
-----
Error: unknown character: #
----- samples/basics/error.jakt:5:12
 4 | function main() {
 5 |     !@#$!@@#%#$@
                ^- unknown character: #
 6 | }
-----
Error: unknown character: #
----- samples/basics/error.jakt:5:14
 4 | function main() {
 5 |     !@#$!@@#%#$@
                  ^- unknown character: #
 6 | }
-----
Error: unknown character: @
----- samples/basics/error.jakt:5:16
 4 | function main() {
 5 |     !@#$!@@#%#$@
                    ^- unknown character: @
 6 | }
-----
```