### PR TITLE
editors/vscode: Add syntax highlighting for `void`

### DIFF
--- a/editors/vscode/syntaxes/jakt.tmLanguage.json
+++ b/editors/vscode/syntaxes/jakt.tmLanguage.json
@@ -348,7 +348,7 @@
         },
         {
           "name": "storage.type.primitive.jakt",
-          "match": "\\b(String|i8|i16|i32|i64|u8|u16|u32|u64|f32|f64|bool|c_int|c_char|usize)\\b"
+          "match": "\\b(String|i8|i16|i32|i64|u8|u16|u32|u64|f32|f64|bool|c_int|c_char|usize|void)\\b"
         },
         {
           "match": "\\b(?:[A-Z]|_)(?:\\w|_|[0-9])*\\s*(::)",


### PR DESCRIPTION
The only primitive type not being highlighted in the TextMate grammar before was `void`.