### PR TITLE
editors/emacs: Add syntax highlighting for `void`

### DIFF
--- a/editors/emacs/README.md
+++ b/editors/emacs/README.md
@@ -5,5 +5,5 @@ Clone this repository and add this to your `init.el`.
 ```
 (add-to-list 'load-path "/path/to/jakt-mode/")
 (autoload 'jakt-mode "jakt-mode" nil t)
-(add-to-list 'auto-mode-alist '("\\.rs\\'" . rust-mode))
+(add-to-list 'auto-mode-alist '("\\.jakt\\'" . jakt-mode))
 ```

--- a/editors/emacs/jakt_mode.el
+++ b/editors/emacs/jakt_mode.el
@@ -49,7 +49,7 @@
              (jakt-var-decls '("mutable" "let" "anonymous" "raw")) 
              (jakt-types '("i8" "i16" "i32" "i16" "i32" "i64" "u8" "u16" "u32"
                            "u64" "f32" "f64" "bool" "c_int" "c_char" "usize"
-                           "String"))
+                           "String" "void"))
              (jakt-builtin-fn '("print" "println")) 
              (jakt-operators '("not" "and" "or" "as" "in")) 
              (jakt-structure '("struct" "class" "enum" "namespace")) 


### PR DESCRIPTION
Also, fix installation instruction in readme.