### PR TITLE
editors/vim: Add syntax highlighting for void

### DIFF
--- a/editors/vim/syntax/jakt.vim
+++ b/editors/vim/syntax/jakt.vim
@@ -64,6 +64,7 @@ let s:jakt_syntax_keywords = {
     \ ,              "c_int"
     \ ,              "c_char"
     \ ,              "usize"
+    \ ,              "void"
     \ ,             ]
     \ , 'jaktConstant' :["this"
     \ ,                 ]


### PR DESCRIPTION
This fixes void not being highlighted in vim.