### PR TITLE
parser+typechecker+codegen+tests: Basic module support

### DIFF
--- a/samples/math/too_small_literal.jakt
+++ b/samples/math/too_small_literal.jakt
@@ -1,5 +1,5 @@
 /// Expect:
-/// - error: "Literal Unsigned(9223372036854775809) too small for unsigned integer type 10"
+/// - error: "Literal Unsigned(9223372036854775809) too small for unsigned integer type u64"
 
 function main() {
     let too_small_i64 = -9_223_372_036_854_775_809;

--- a/samples/modules/a.jakt
+++ b/samples/modules/a.jakt
@@ -1,0 +1,6 @@
+import b
+
+function use_cool_things() {
+    b::something_cool()
+    b::something_else_cool()
+}

--- a/samples/modules/b.jakt
+++ b/samples/modules/b.jakt
@@ -1,0 +1,11 @@
+function something_cool() {
+    println("something_cool")
+}
+
+function something_else_cool() {
+    println("something_else_cool")
+}
+
+function not_cool() {
+    println("not_cool")
+}

--- a/samples/modules/basic_modules.jakt
+++ b/samples/modules/basic_modules.jakt
@@ -1,0 +1,9 @@
+/// Expect:
+/// - output: "not_cool\n"
+
+
+import b
+
+function main() {
+    b::not_cool()
+}

--- a/samples/modules/sub_modules.jakt
+++ b/samples/modules/sub_modules.jakt
@@ -1,0 +1,10 @@
+/// Expect:
+/// - output: "something_cool\nsomething_else_cool\nnot_cool\n"
+
+import a
+import b
+
+function main() {
+    a::use_cool_things()
+    b::not_cool()
+}

--- a/src/compiler.rs
+++ b/src/compiler.rs
@@ -5,113 +5,165 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-use std::path::{Path, PathBuf};
+use std::{
+    path::{Path, PathBuf},
+    vec,
+};
 
 use crate::{
     codegen::codegen,
     error::JaktError,
-    lexer::{lex, Span},
+    lexer::lex,
     parser::{parse_namespace, ParsedNamespace},
     typechecker::{
-        typecheck_namespace_declarations, typecheck_namespace_predecl, Project, Scope, ScopeId,
-        Type,
+        typecheck_module, typecheck_namespace_declarations, typecheck_namespace_predecl, Module,
+        ModuleId, Project, Scope, ScopeId, Type, TypeId,
     },
 };
 
 pub type FileId = usize;
 
-pub const UNKNOWN_TYPE_ID: usize = 0;
-pub const VOID_TYPE_ID: usize = 1;
-pub const BOOL_TYPE_ID: usize = 2;
-pub const I8_TYPE_ID: usize = 3;
-pub const I16_TYPE_ID: usize = 4;
-pub const I32_TYPE_ID: usize = 5;
-pub const I64_TYPE_ID: usize = 6;
-pub const U8_TYPE_ID: usize = 7;
-pub const U16_TYPE_ID: usize = 8;
-pub const U32_TYPE_ID: usize = 9;
-pub const U64_TYPE_ID: usize = 10;
-pub const F32_TYPE_ID: usize = 11;
-pub const F64_TYPE_ID: usize = 12;
-pub const CCHAR_TYPE_ID: usize = 13;
-pub const CINT_TYPE_ID: usize = 14;
-pub const USIZE_TYPE_ID: usize = 15;
+pub const UNKNOWN_TYPE_ID: TypeId = TypeId(ModuleId(0), 0);
+pub const VOID_TYPE_ID: TypeId = TypeId(ModuleId(0), 1);
+pub const BOOL_TYPE_ID: TypeId = TypeId(ModuleId(0), 2);
+pub const I8_TYPE_ID: TypeId = TypeId(ModuleId(0), 3);
+pub const I16_TYPE_ID: TypeId = TypeId(ModuleId(0), 4);
+pub const I32_TYPE_ID: TypeId = TypeId(ModuleId(0), 5);
+pub const I64_TYPE_ID: TypeId = TypeId(ModuleId(0), 6);
+pub const U8_TYPE_ID: TypeId = TypeId(ModuleId(0), 7);
+pub const U16_TYPE_ID: TypeId = TypeId(ModuleId(0), 8);
+pub const U32_TYPE_ID: TypeId = TypeId(ModuleId(0), 9);
+pub const U64_TYPE_ID: TypeId = TypeId(ModuleId(0), 10);
+pub const F32_TYPE_ID: TypeId = TypeId(ModuleId(0), 11);
+pub const F64_TYPE_ID: TypeId = TypeId(ModuleId(0), 12);
+pub const CCHAR_TYPE_ID: TypeId = TypeId(ModuleId(0), 13);
+pub const CINT_TYPE_ID: TypeId = TypeId(ModuleId(0), 14);
+pub const USIZE_TYPE_ID: TypeId = TypeId(ModuleId(0), 15);
 // Note: keep STRING_TYPE_ID last as it is how we know how many slots to pre-fill
-pub const STRING_TYPE_ID: usize = 16;
+pub const STRING_TYPE_ID: TypeId = TypeId(ModuleId(0), 16);
+
+pub const PRELUDE_SCOPE_ID: ScopeId = ScopeId(ModuleId(0), 0);
+
+pub struct SourceInfo {
+    pub module_id: ModuleId,
+    pub file_id: FileId,
+    pub path: PathBuf,
+    pub content: String,
+}
 
 pub struct Compiler {
     include_paths: Vec<PathBuf>,
-    raw_files: Vec<(String, Vec<u8>)>,
+    pub loaded_files: Vec<SourceInfo>,
 }
 
 impl Compiler {
     pub fn new(include_paths: Vec<PathBuf>) -> Self {
         Self {
             include_paths,
-            raw_files: Vec::new(),
+            loaded_files: vec![],
         }
     }
 
-    fn include_file(&mut self, fname: &Path) -> (ParsedNamespace, Option<JaktError>) {
-        let contents = std::fs::read(fname).unwrap();
-        self.raw_files
-            .push((fname.to_string_lossy().to_string(), contents));
-
-        let (lexed, err) = lex(
-            self.raw_files.len() - 1,
-            &self.raw_files[self.raw_files.len() - 1].1,
-        );
-
-        if err.is_some() {
-            return (ParsedNamespace::new(), err);
-        }
-
-        parse_namespace(&lexed, &mut 0, self)
-    }
-
-    pub fn find_and_include_module(
-        &mut self,
-        module_name: &str,
-        span: Span,
-    ) -> (ParsedNamespace, Option<JaktError>) {
-        for path in &self.include_paths {
-            let fname = path.join(module_name).with_extension("jakt");
-            if fname.exists() {
-                return self.include_file(&fname);
+    pub fn is_file_loaded(&self, path: &Path) -> bool {
+        for info in self.loaded_files.iter() {
+            if info.path == path {
+                return true;
             }
         }
-        return (
-            ParsedNamespace::new(),
-            Some(JaktError::ParserError(
-                format!("Module '{}' not found", module_name),
-                span,
-            )),
-        );
+        false
+    }
+
+    pub fn search_for_path(&self, name: &str) -> Option<PathBuf> {
+        for path in &self.include_paths {
+            let fname = path.join(name).with_extension("jakt");
+            if fname.exists() {
+                return Some(fname);
+            }
+        }
+        None
+    }
+
+    /// return the file id of a file. Loading it if it isn't loaded already.
+    pub fn find_or_load_file<P: AsRef<Path> + Clone>(&mut self, p: P) -> Result<FileId, JaktError> {
+        if self.is_file_loaded(p.as_ref()) {
+            for (idx, info) in self.loaded_files.iter().enumerate() {
+                if info.path == p.as_ref() {
+                    return Ok(idx);
+                }
+            }
+            unreachable!()
+        }
+        let content = std::fs::read_to_string(p.clone()).map_err(JaktError::IOError)?;
+        self.loaded_files.push(SourceInfo {
+            module_id: ModuleId::invalid(),
+            file_id: self.loaded_files.len(),
+            path: p.as_ref().to_path_buf(),
+            content,
+        });
+        Ok(self.loaded_files.len() - 1)
     }
 
     pub fn include_prelude(&mut self, project: &mut Project) -> Option<JaktError> {
         let mut error = None;
+        let mut module = Module::new(ModuleId(0), "__prelude__".to_string());
         // First, let's make types for all the builtin types
         // This order *must* match the order of the constants the typechecker expects
-        project.types.resize(STRING_TYPE_ID + 1, Type::Builtin);
+        module.types.resize(STRING_TYPE_ID.1 + 1, Type::Builtin);
+
+        module.scopes.push(Scope::new(None, false));
+
+        project.modules.push(module);
+        project.current_module_index = 0;
 
         let prelude = Compiler::prelude();
 
-        // Not sure where to put prelude, but we're hoping its parsing is infallible
-        self.raw_files.push(("<prelude>".to_string(), prelude));
+        self.loaded_files.push(SourceInfo {
+            module_id: ModuleId(0),
+            file_id: self.loaded_files.len(),
+            path: PathBuf::new(),
+            content: prelude.to_string(),
+        });
 
         // Compile the prelude
-        let (lexed, _) = lex(
-            self.raw_files.len() - 1,
-            &self.raw_files[self.raw_files.len() - 1].1,
-        );
-        let (file, _) = parse_namespace(&lexed, &mut 0, self);
+        project.checking_prelude = true;
+
+        // Not sure where to put prelude, but we're hoping its parsing is infallible
+        let (lexed, _) = lex(0, prelude.as_bytes());
+        let (file, _) = parse_namespace(&lexed, &mut 0);
 
         // Scope ID 0 is the global project-level scope that all files can see
-        error = error.or(typecheck_namespace_predecl(&file, 0, project));
-        error = error.or(typecheck_namespace_declarations(&file, 0, project));
+        error = error.or(typecheck_namespace_predecl(
+            &file,
+            ScopeId(ModuleId(0), 0),
+            project,
+        ));
+        error = error.or(typecheck_namespace_declarations(
+            &file,
+            ScopeId(ModuleId(0), 0),
+            project,
+        ));
+
+        project.checking_prelude = false;
 
         error
+    }
+
+    pub fn parse_file(&self, file_id: FileId) -> Result<ParsedNamespace, JaktError> {
+        let info = &self.loaded_files[file_id];
+
+        let (lexed, err) = lex(file_id, info.content.as_bytes());
+
+        if let Some(err) = err {
+            return Err(err);
+        }
+
+        let (namespace, err) = parse_namespace(&lexed, &mut 0);
+
+        if let Some(err) = err {
+            return Err(err);
+        }
+
+        Ok(namespace)
     }
 
     pub fn check_project(
@@ -124,28 +176,30 @@ impl Compiler {
         let err = self.include_prelude(project);
         error = error.or(err);
 
+        // find a better way to look this up.
         // TODO: We also want to be able to accept include paths from CLI
         let parent_dir = fname
             .parent()
             .expect("Cannot find parent directory of file");
         self.include_paths.push(parent_dir.to_path_buf());
 
-        let (file, err) = self.include_file(fname);
-        error = error.or(err);
+        // should always be 0
+        let file_scope_id = ScopeId(project.current_module().id, 0);
 
-        let scope = Scope::new(Some(0), false);
-        project.scopes.push(scope);
+        let file_id = match self.find_or_load_file(fname) {
+            Ok(file_id) => file_id,
+            Err(e) => return (file_scope_id, Some(e)),
+        };
 
-        let file_scope_id = project.scopes.len() - 1;
+        let parsed_namespace = match self.parse_file(file_id) {
+            Ok(namespace) => namespace,
+            Err(e) => return (file_scope_id, Some(e)),
+        };
 
-        project
-            .file_ids
-            .insert(fname.to_string_lossy().to_string(), file_scope_id);
+        let scope = Scope::new(Some(PRELUDE_SCOPE_ID), false);
+        project.current_module_mut().scopes.push(scope);
 
-        let err = typecheck_namespace_predecl(&file, file_scope_id, project);
-        error = error.or(err);
-
-        let err = typecheck_namespace_declarations(&file, file_scope_id, project);
+        let err = typecheck_module(&parsed_namespace, file_scope_id, project, self);
         error = error.or(err);
 
         (file_scope_id, error)
@@ -154,7 +208,7 @@ impl Compiler {
     pub fn convert_to_cpp(&mut self, fname: &Path) -> Result<String, JaktError> {
         let mut project = Project::new();
 
-        let (file_scope_id, err) = self.check_project(fname, &mut project);
+        let (_, err) = self.check_project(fname, &mut project);
         if let Some(err) = err {
             return Err(err);
         }
@@ -164,31 +218,33 @@ impl Compiler {
         }
 
         // Hardwire to first file for now
-        Ok(codegen(&project, &project.scopes[file_scope_id]))
+        Ok(codegen(&project))
     }
 
     pub fn get_file_contents(&self, file_id: FileId) -> &[u8] {
-        &self.raw_files[file_id].1
+        self.loaded_files[file_id].content.as_bytes()
     }
 
-    pub fn get_file_name(&self, file_id: FileId) -> &String {
-        &self.raw_files[file_id].0
+    pub fn get_file_name(&self, file_id: FileId) -> &Path {
+        self.loaded_files[file_id].path.as_path()
     }
 
-    pub fn prelude() -> Vec<u8> {
-        include_bytes!("../runtime/prelude.jakt").to_vec()
+    pub fn prelude() -> &'static str {
+        include_str!("../runtime/prelude.jakt")
     }
 }
 
 fn check_codegen_preconditions(project: &Project) -> Option<JaktError> {
     // Make sure all functions have a known return type
-    for function in &project.functions {
-        if function.return_type_id == UNKNOWN_TYPE_ID {
-            return Some(JaktError::TypecheckError(
-                format!("Could not infer the return type of function '{}', please explicitly specify it",
-                function.name),
-                function.parsed_function.as_ref().expect("Typechecking non-parsed function").name_span,
-            ));
+    for module in project.modules.iter() {
+        for function in module.functions.iter() {
+            if function.return_type_id == UNKNOWN_TYPE_ID {
+                return Some(JaktError::TypecheckError(
+                    format!("Could not infer the return type of function '{}', please explicitly specify it",
+                    function.name),
+                    function.parsed_function.as_ref().expect("Typechecking non-parsed function").name_span,
+                ));
+            }
         }
     }
 

--- a/src/lexer.rs
+++ b/src/lexer.rs
@@ -7,7 +7,7 @@
 
 use crate::{compiler::FileId, error::JaktError, typechecker::NumericConstant};
 
-#[derive(Debug, Clone, Copy, PartialEq)]
+#[derive(Debug, Clone, Copy, PartialEq, Default)]
 pub struct Span {
     pub file_id: FileId,
     pub start: usize,

--- a/src/main.rs
+++ b/src/main.rs
@@ -388,7 +388,7 @@ fn parse_arguments() -> JaktArguments {
         if !filename.exists() {
             eprintln!(
                 "jakt: error: file '{}' not found or inaccessible",
-                filename.to_string_lossy()
+                filename.display()
             );
             exit(1);
         }
@@ -459,7 +459,7 @@ fn display_message_with_span(
             println!(
                 "{} \u{001b}[33m{}:{}:{}\u{001b}[0m",
                 "-".repeat(width + 3),
-                file_name,
+                file_name.display(),
                 line_index + 1,
                 column_index + 1
             );

--- a/tests/main.rs
+++ b/tests/main.rs
@@ -446,6 +446,11 @@ fn test_imports() -> Result<(), JaktError> {
 }
 
 #[test]
+fn test_modules() -> Result<(), JaktError> {
+    test_samples("samples/modules")
+}
+
+#[test]
 fn test_selfhost() -> Result<(), JaktError> {
     test_samples("selfhost")
 }


### PR DESCRIPTION
Adds basic module support to typecheck and codegen.

The project is now split into modules and every id now has the module it comes from. Codegen generates the code for each module and wraps it in a namespace. The only module that doesn't get a namespace is prelude (which is its own module).