### PR TITLE
selfhost: Parse function calls properly

### DIFF
--- a/selfhost/main.jakt
+++ b/selfhost/main.jakt
@@ -2047,7 +2047,9 @@ struct Parser {
             ForwardSlashEqual => BinaryOperator::DivideAssign
             PercentSignEqual => BinaryOperator::ModuloAssign
             QuestionMarkQuestionMarkEqual => BinaryOperator::NoneCoalescingAssign
-            else => BinaryOperator::Garbage
+            else => {
+                return ParsedExpression::Garbage(span)
+            }
         }
 
         .index++


### PR DESCRIPTION
This commit fixes a small bug where parsing expressions with no right-hand side would produce garbage. Previously, `parse_operator` would return a `ParsedExpression(BinaryOperator::Garbage)` when parsing an expression that isn't binary. This meant that it wouldn't actually get treated as a garbage `ParsedExpression` and would skip the checks for Garbage in `parse_expression()`. Additionally, when the result of parsing an operator returns garbage it shouldn't increment the index whcih this commit resolves as well.

With this commit parsing `samples/basics/hello.jakt` happens successfully whereas previously it would error:

Before this commit:
```
token: Token::Eol(JaktSpan(start: 51, end: 52))
token: Token::Function(JaktSpan(start: 52, end: 60))
token: Token::Identifier(name: "main", span: JaktSpan(start: 61, end: 65))
token: Token::LParen(JaktSpan(start: 65, end: 66))
token: Token::RParen(JaktSpan(start: 66, end: 67))
token: Token::LCurly(JaktSpan(start: 68, end: 69))
token: Token::Eol(JaktSpan(start: 69, end: 70))
token: Token::Identifier(name: "println", span: JaktSpan(start: 74, end: 81))
token: Token::LParen(JaktSpan(start: 81, end: 82))
token: Token::QuotedString(quote: "Well, hello friends.", span: JaktSpan(start: 82, end: 103))
token: Token::RParen(JaktSpan(start: 104, end: 105))
token: Token::Eol(JaktSpan(start: 105, end: 106))
token: Token::RCurly(JaktSpan(start: 106, end: 107))
token: Token::Eol(JaktSpan(start: 107, end: 108))
token: Token::Eof(JaktSpan(start: 108, end: 108))
parse_statement: Token::Identifier(name: "println", span: JaktSpan(start: 74, end: 81))
Error: Expected complete block
----- samples/basics/hello.jakt:4:17
 3 |
 4 | function main() {
                     ^- Expected complete block
 5 |     println("Well, hello friends.")
-----
```

After this commit:
```
token: Token::Eol(JaktSpan(start: 51, end: 52))
token: Token::Function(JaktSpan(start: 52, end: 60))
token: Token::Identifier(name: "main", span: JaktSpan(start: 61, end: 65))
token: Token::LParen(JaktSpan(start: 65, end: 66))
token: Token::RParen(JaktSpan(start: 66, end: 67))
token: Token::LCurly(JaktSpan(start: 68, end: 69))
token: Token::Eol(JaktSpan(start: 69, end: 70))
token: Token::Identifier(name: "println", span: JaktSpan(start: 74, end: 81))
token: Token::LParen(JaktSpan(start: 81, end: 82))
token: Token::QuotedString(quote: "Well, hello friends.", span: JaktSpan(start: 82, end: 103))
token: Token::RParen(JaktSpan(start: 104, end: 105))
token: Token::Eol(JaktSpan(start: 105, end: 106))
token: Token::RCurly(JaktSpan(start: 106, end: 107))
token: Token::Eol(JaktSpan(start: 107, end: 108))
token: Token::Eof(JaktSpan(start: 108, end: 108))
parse_statement: Token::Identifier(name: "println", span: JaktSpan(start: 74, end: 81))
ParsedNamespace(name: "", functions: [ParsedFunction(name: "main", name_span: JaktSpan(start: 61, end: 65), params: [], generic_parameters: [], block: ParsedBlock(stmts: [ParsedStatement::Expression(ParsedExpression::Call(call: ParsedCall(name: "println", args: [("", ParsedExpression::QuotedString(val: "Well, hello friends.", span: JaktSpan(start: 82, end: 103)))]), span: JaktSpan(start: 74, end: 81)))]), return_type: ParsedType::Empty, return_type_span: JaktSpan(start: 0, end: 0), throws: true)], structs: [])
```