### PR TITLE
all: Rename `let mutable` to `mut` globally

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,18 +163,18 @@ let x = Foo()
 x.func()
 ```
 
-**Mutating member functions** require an object to be called, and may modify the object. The first parameter is `mutable this`.
+**Mutating member functions** require an object to be called, and may modify the object. The first parameter is `mut this`.
 ```jakt
 class Foo {
     x: i64
 
-    function set(mutable this, anon x: i64) {
+    function set(mut this, anon x: i64) {
         this.x = x
     }
 }
 
-// Foo::set() can only be called on a mutable Foo:
-let mutable foo = Foo(x: 3)
+// Foo::set() can only be called on a mut Foo:
+mut foo = Foo(x: 3)
 foo.set(9)
 ```
 
@@ -483,7 +483,7 @@ try task_that_might_fail() catch error {
 For better interoperability with existing C++ code, as well as situations where the capabilities of **Jakt** within `unsafe` blocks are not powerful enough, the possibility of embedding inline C++ code into the program exists in the form of `cpp` blocks:
 
 ```jakt
-let mutable x = 0
+mut x = 0
 unsafe {
     cpp {
         "x = (i64)&x;"

--- a/editors/emacs/test.jakt
+++ b/editors/emacs/test.jakt
@@ -76,7 +76,7 @@ try {
     println("Caught error: {}", error)
 }
 
-let mutable x = 0
+mut x = 0
 unsafe {
     cpp {
         "x = (i64)&x;"

--- a/editors/vscode/syntaxes/jakt.tmLanguage.json
+++ b/editors/vscode/syntaxes/jakt.tmLanguage.json
@@ -89,18 +89,15 @@
     "variable-declaration": {
       "name": "meta.variable.definition.jakt",
       "comment": "FIXME: The identifier matching is identical to the lexer but more characters may be allowed in the future.",
-      "begin": "\\b(let)(\\s+mutable)?\\s+((?:\\w|_)(?:\\w|_|[0-9])*)\\s*(:)?",
+      "begin": "\\b(let|mut)\\s+((?:\\w|_)(?:\\w|_|[0-9])*)\\s*(:)?",
       "beginCaptures": {
         "1": {
           "name": "keyword.let.jakt"
         },
         "2": {
-          "name": "storage.modifier.mutable.jakt"
-        },
-        "3": {
           "name": "variable.other.jakt"
         },
-        "4": {
+        "3": {
           "name": "punctuation.colon.jakt"
         }
       },
@@ -339,8 +336,8 @@
     "types": {
       "patterns": [
         {
-          "name": "storage.modifier.mutable.jakt",
-          "match": "\\bmutable\\b"
+          "name": "storage.modifier.mut.jakt",
+          "match": "\\bmut\\b"
         },
         {
           "name": "storage.modifier.pointer.jakt",
@@ -531,10 +528,10 @@
           "include": "#this"
         },
         {
-          "match": "\\b(mutable)\\s+(this)\\b",
+          "match": "\\b(mut)\\s+(this)\\b",
           "captures": {
             "1": {
-              "name": "storage.modifier.mutable.argument.jakt"
+              "name": "storage.modifier.mut.argument.jakt"
             },
             "2": {
               "name": "variable.language.this.jakt"

--- a/runtime/prelude.jakt
+++ b/runtime/prelude.jakt
@@ -14,7 +14,7 @@ extern struct String {
 }
 
 extern struct ArrayIterator<T> {
-    function next(mutable this) -> T?
+    function next(mut this) -> T?
 }
 
 extern struct Array<T> {
@@ -24,9 +24,9 @@ extern struct Array<T> {
     function capacity(this) -> usize
     function ensure_capacity(this, anon capacity: usize) throws
     function add_capacity(this, anon capacity: usize) throws
-    function resize(mutable this, anon size: usize) throws
-    function push(mutable this, anon value: T) throws
-    function pop(mutable this) -> T?
+    function resize(mut this, anon size: usize) throws
+    function push(mut this, anon value: T) throws
+    function pop(mut this) -> T?
     function iterator(this) -> ArrayIterator<T>
 }
 
@@ -39,21 +39,21 @@ extern struct Optional<T> {
 
 extern struct WeakPtr<T> {
     function has_value(this) -> bool
-    function clear(mutable this)
+    function clear(mut this)
 }
 
 extern struct DictionaryIterator<K, V> {
-    function next(mutable this) -> (K, V)?
+    function next(mut this) -> (K, V)?
 }
 
 extern struct Dictionary<K, V> {
     function is_empty(this) -> bool
     function get(this, anon key: K) -> V?
     function contains(this, anon key: K) -> bool
-    function set(mutable this, key: K, value: V) throws
-    function remove(mutable this, anon key: K) -> bool
-    function ensure_capacity(mutable this, anon capacity: usize) throws
-    function clear(mutable this)
+    function set(mut this, key: K, value: V) throws
+    function remove(mut this, anon key: K) -> bool
+    function ensure_capacity(mut this, anon capacity: usize) throws
+    function clear(mut this)
     function size(this) -> usize
     function capacity(this) -> usize
     function keys(this) throws -> [K]
@@ -63,16 +63,16 @@ extern struct Dictionary<K, V> {
 }
 
 extern struct SetIterator<T> {
-    function next(mutable this) -> T?
+    function next(mut this) -> T?
 }
 
 extern struct Set<V> {
     function is_empty(this) -> bool
     function contains(this, anon value: V) -> bool
-    function add(mutable this, anon value: V) throws
-    function remove(mutable this, anon value: V) -> bool
-    function ensure_capacity(mutable this, anon capacity: usize) throws
-    function clear(mutable this)
+    function add(mut this, anon value: V) throws
+    function remove(mut this, anon value: V) -> bool
+    function ensure_capacity(mut this, anon capacity: usize) throws
+    function clear(mut this)
     function size(this) -> usize
     function capacity(this) -> usize
     function hash(this) -> u32
@@ -83,7 +83,7 @@ extern struct Set<V> {
 extern struct Tuple {}
 
 extern struct Range<T> {
-    function next(mutable this) -> T?
+    function next(mut this) -> T?
 }
 
 extern struct Error {
@@ -95,10 +95,10 @@ extern class File {
     public function open_for_reading(anon path: String) throws -> File
     public function open_for_writing(anon path: String) throws -> File
 
-    public function read(mutable this, anon buffer: [u8]) throws -> usize
-    public function write(mutable this, anon data: [u8]) throws -> usize
+    public function read(mut this, anon buffer: [u8]) throws -> usize
+    public function write(mut this, anon data: [u8]) throws -> usize
 
-    public function read_all(mutable this) throws -> [u8]
+    public function read_all(mut this) throws -> [u8]
 }
 
 extern function as_saturated<U, T>(anon input: T) -> U

--- a/samples/apps/cat-std.jakt
+++ b/samples/apps/cat-std.jakt
@@ -4,8 +4,8 @@ function main(args: [String]) {
         return 1
     }
 
-    let mutable file = File::open_for_reading(args[1])
-    let mutable array: [u8] = [0u8]
+    mut file = File::open_for_reading(args[1])
+    mut array: [u8] = [0u8]
 
     while file.read(array) != 0 {
         for idx in 0..array.size() {

--- a/samples/apps/cat.jakt
+++ b/samples/apps/cat.jakt
@@ -1,9 +1,9 @@
 extern struct FILE {}
 
 extern function fopen(anon str: raw c_char, anon mode: raw c_char) -> raw FILE
-extern function fgetc(anon file: mutable raw FILE) -> c_int
-extern function fclose(anon file: mutable raw FILE) -> c_int
-extern function feof(anon file: mutable raw FILE) -> c_int
+extern function fgetc(anon file: mut raw FILE) -> c_int
+extern function fclose(anon file: mut raw FILE) -> c_int
+extern function feof(anon file: mut raw FILE) -> c_int
 extern function putchar(anon ch: c_int) -> c_int
 
 function main(args: [String]) {
@@ -14,10 +14,10 @@ function main(args: [String]) {
 
     let filename = args[1]
 
-    let mutable file = fopen(filename.c_string(), "r".c_string())
+    mut file = fopen(filename.c_string(), "r".c_string())
     defer fclose(file)
 
-    let mutable c = fgetc(file)
+    mut c = fgetc(file)
     while feof(file) == 0 {
         putchar(c)
         c = fgetc(file)

--- a/samples/apps/crc32.jakt
+++ b/samples/apps/crc32.jakt
@@ -1,15 +1,15 @@
 extern struct FILE {}
 
 extern function fopen(anon str: raw c_char, anon mode: raw c_char) -> raw FILE
-extern function fgetc(anon file: mutable raw FILE) -> c_int
-extern function fclose(anon file: mutable raw FILE) -> c_int
-extern function feof(anon file: mutable raw FILE) -> c_int
+extern function fgetc(anon file: mut raw FILE) -> c_int
+extern function fclose(anon file: mut raw FILE) -> c_int
+extern function feof(anon file: mut raw FILE) -> c_int
 extern function putchar(anon ch: c_int) -> c_int
 
 function make_lookup_table() throws -> [u32] {
-    let mutable data = [0u32; 256]
+    mut data = [0u32; 256]
     for i in 0..data.size() {
-        let mutable value = i as! u32
+        mut value = i as! u32
         for j in 0..8 {
             if (value & 1) != 0 {
                 value = 0xedb88320u32 ^ (value >> 1)
@@ -28,13 +28,13 @@ function main(args: [String]) {
         return 1
     }
 
-    let mutable file = fopen(args[1].c_string(), "r".c_string())
+    mut file = fopen(args[1].c_string(), "r".c_string())
     defer fclose(file)
 
     let table = make_lookup_table()
     
-    let mutable state = 0xffffffffu32
-    let mutable c = fgetc(file)
+    mut state = 0xffffffffu32
+    mut c = fgetc(file)
     while feof(file) == 0 {
         state = table[(state ^ c) & 0xff] ^ (state >> 8);
         c = fgetc(file)

--- a/samples/apps/json.jakt
+++ b/samples/apps/json.jakt
@@ -1,6 +1,6 @@
 extern struct StringBuilder {
     // FIXME: AK::StringBuilder::append() actually takes a c_char, not a u8, but nobody complains
-    function append(mutable this, anon c: u8)
+    function append(mut this, anon c: u8)
     function to_string(this) throws -> String
     function StringBuilder() -> StringBuilder
 }
@@ -33,7 +33,7 @@ class JsonParser {
         return .index >= .input.length()
     }
 
-    public function parse(mutable this) throws -> JsonValue {
+    public function parse(mut this) throws -> JsonValue {
         // FIXME: AK::JsonParser ignores trailing whitespace for some reason.
         let value = .parse_helper()
         if not .eof() {
@@ -43,7 +43,7 @@ class JsonParser {
         return value
     }
 
-    function skip_whitespace(mutable this) {
+    function skip_whitespace(mut this) {
         while not .eof() {
             if not is_whitespace(.input.byte_at(.index)) {
                 break
@@ -52,17 +52,17 @@ class JsonParser {
         }
     }
 
-    function consume_and_unescape_string(mutable this) throws -> String {
+    function consume_and_unescape_string(mut this) throws -> String {
         if not .consume_specific(b'"') {
             // FIXME: "Expected '"'
             throw Error::from_errno(9007)
         }
 
-        let mutable builder = StringBuilder()
+        mut builder = StringBuilder()
 
         loop {
-            let mutable ch = 0u8
-            let mutable peek_index = .index
+            mut ch = 0u8
+            mut peek_index = .index
             while peek_index < .input.length() {
                 ch = .input.byte_at(peek_index)
                 if ch == b'"' or ch == b'\\' {
@@ -127,7 +127,7 @@ class JsonParser {
         return builder.to_string()
     }
 
-    function ignore(mutable this) {
+    function ignore(mut this) {
         .index++
     }
 
@@ -138,13 +138,13 @@ class JsonParser {
         return .input.byte_at(.index)
     }
 
-    function consume(mutable this) -> u8 {
+    function consume(mut this) -> u8 {
         let ch = .peek()
         .index++
         return ch
     }
 
-    function consume_specific(mutable this, anon expected: u8) -> bool {
+    function consume_specific(mut this, anon expected: u8) -> bool {
         if .peek() != expected {
             return false
         }
@@ -152,7 +152,7 @@ class JsonParser {
         return true
     }
 
-    function parse_helper(mutable this) throws -> JsonValue {
+    function parse_helper(mut this) throws -> JsonValue {
         .skip_whitespace()
         return match .peek() {
             b'{' => .parse_object()
@@ -173,17 +173,17 @@ class JsonParser {
         return JsonValue::Null
     }
 
-    function parse_array(mutable this) throws -> JsonValue {
+    function parse_array(mut this) throws -> JsonValue {
         return JsonValue::Null
     }
 
-    function parse_object(mutable this) throws -> JsonValue {
+    function parse_object(mut this) throws -> JsonValue {
         if not .consume_specific(b'{') {
             // FIXME: "Expected '{'"
             throw Error::from_errno(9002)
         }
 
-        let mutable values: [String:JsonValue] = [:]
+        mut values: [String:JsonValue] = [:]
 
         loop {
             .skip_whitespace()
@@ -222,10 +222,10 @@ class JsonParser {
         return JsonValue::Object(values)
     }
 
-    function parse_number(mutable this) throws -> JsonValue {
+    function parse_number(mut this) throws -> JsonValue {
         let is_negative = .consume_specific(b'-')
 
-        let mutable value = 0
+        mut value = 0
 
         while not .eof() {
             let ch = .peek()
@@ -240,25 +240,25 @@ class JsonParser {
         return JsonValue::Number(value)
     }
 
-    function parse_string(mutable this) throws -> JsonValue {
+    function parse_string(mut this) throws -> JsonValue {
         return JsonValue::Null
     }
 
-    function parse_false(mutable this) throws -> JsonValue {
+    function parse_false(mut this) throws -> JsonValue {
         return JsonValue::Null
     }
 
-    function parse_true(mutable this) throws -> JsonValue {
+    function parse_true(mut this) throws -> JsonValue {
         return JsonValue::Null
     }
 
-    function parse_null(mutable this) throws -> JsonValue {
+    function parse_null(mut this) throws -> JsonValue {
         return JsonValue::Null
     }
 }
 
 function parse_json(input: String) throws -> JsonValue {
-    let mutable parser = JsonParser(input, index: 0)
+    mut parser = JsonParser(input, index: 0)
     return parser.parse()
 }
 

--- a/samples/arrays/array_pop.jakt
+++ b/samples/arrays/array_pop.jakt
@@ -2,7 +2,7 @@
 /// - output: "3\n"
 
 function main() {
-    let mutable v = [1, 2, 3]
+    mut v = [1, 2, 3]
 
     let last = v.pop()
 

--- a/samples/arrays/array_push.jakt
+++ b/samples/arrays/array_push.jakt
@@ -2,7 +2,7 @@
 /// - output: "9\n8\n7\n6\n5\n4\n3\n2\n1\n0\n"
 
 function main() {
-    let mutable values = [0; 0]
+    mut values = [0; 0]
 
     for i in 0..10 {
         values.push(i)

--- a/samples/arrays/array_shorthand.jakt
+++ b/samples/arrays/array_shorthand.jakt
@@ -7,7 +7,7 @@ function make_v() -> [String] {
 
 function main() {
     let v: [String] = make_v()
-    let mutable i = 0
+    mut i = 0
     while i < 2 {
         println("{}", v[i])
         ++i

--- a/samples/arrays/inference_empty.jakt
+++ b/samples/arrays/inference_empty.jakt
@@ -2,10 +2,10 @@
 /// - output: "2 2\n"
 
 function main() {
-    let mutable set1: [i64] = []
+    mut set1: [i64] = []
     set1.push(1)
     set1.push(2)
-    let mutable set2: [[[String]]] = []
+    mut set2: [[[String]]] = []
     set2.push([["hello"]])
     set2.push([["world"]])
     println("{} {}", set1.size(), set2.size())

--- a/samples/arrays/lvalue.jakt
+++ b/samples/arrays/lvalue.jakt
@@ -2,7 +2,7 @@
 /// - output: "55\n"
 
 function main() {
-    let mutable x = [1, 2, 3]
+    mut x = [1, 2, 3]
     x[1] = 55
 
     println("{}", x[1])

--- a/samples/arrays/pop_class_instance.jakt
+++ b/samples/arrays/pop_class_instance.jakt
@@ -6,7 +6,7 @@ class C {
 }
 
 function main() {
-    let mutable a: [C] = []
+    mut a: [C] = []
     a.push(C(message: "PASS"))
     println("{}", a.pop()!.message)
 }

--- a/samples/arrays/prefill.jakt
+++ b/samples/arrays/prefill.jakt
@@ -4,7 +4,7 @@
 function main() {
     let v = [85; 3]
     println("{}", v.size())
-    let mutable i = 0
+    mut i = 0
     while i < v.size() as! i64 {
         println("{}", v[i++])
     }

--- a/samples/arrays/reference_semantics.jakt
+++ b/samples/arrays/reference_semantics.jakt
@@ -1,15 +1,15 @@
 /// Expect:
 /// - output: "foo\nbar\n"
 
-function change_value(vector: mutable [String]) {
+function change_value(vector: mut [String]) {
     vector[1] = "bar"
 }
 
 function main() {
-    let mutable v = ["foo", "foo"]
+    mut v = ["foo", "foo"]
     change_value(vector: v)
 
-    let mutable i = 0
+    mut i = 0
     while i < v.size() as! i64 {
         println("{}", v[i])
         ++i

--- a/samples/basics/bubble_sort.jakt
+++ b/samples/basics/bubble_sort.jakt
@@ -1,10 +1,10 @@
 /// Expect:
 /// - output: "1\n2\n8\n9\n13\n22\n25\n50\n"
 
-function bubble_sort(values: mutable [i64]) {
-    let mutable i = 0
+function bubble_sort(values: mut [i64]) {
+    mut i = 0
     while i < values.size() as! i64 - 1 {
-        let mutable j = 0
+        mut j = 0
         while j < (values.size() as! i64) - i - 1 {
             if values[j] > values[j + 1] {
                 let tmp = values[j]
@@ -18,9 +18,9 @@ function bubble_sort(values: mutable [i64]) {
 }
 
 function main() {
-    let mutable v = [25, 13, 8, 1, 9, 22, 50, 2]
+    mut v = [25, 13, 8, 1, 9, 22, 50, 2]
     bubble_sort(values: v)
-    let mutable i = 0
+    mut i = 0
     while i < v.size() as! i64 {
         println("{}", v[i])
         ++i

--- a/samples/basics/byte_literals.jakt
+++ b/samples/basics/byte_literals.jakt
@@ -2,7 +2,7 @@
 /// - output: "b b\n63\n"
 
 function main() {
-    let mutable b = b'b'
+    mut b = b'b'
     println("{:c} {:c}", b, b'b')
     ++b 
     println("{:x}", b)

--- a/samples/basics/numeric_literal_suffixes.jakt
+++ b/samples/basics/numeric_literal_suffixes.jakt
@@ -2,15 +2,15 @@
 /// - output: "5\n5\n5\n5\n5\n5\n5\n5\n5\n"
 
 function main() {
-    let mutable a = 0uz
+    mut a = 0uz
     a += 5 as! usize
     println("{}", a)
 
     {
-        let mutable i = 0u8
-        let mutable j = 0u16
-        let mutable k = 0u32
-        let mutable l = 0u64
+        mut i = 0u8
+        mut j = 0u16
+        mut k = 0u32
+        mut l = 0u64
 
         i += 5 as! u8
         j += 5 as! u16
@@ -23,10 +23,10 @@ function main() {
         println("{}", l)
     }
     {
-        let mutable i = 0i8
-        let mutable j = 0i16
-        let mutable k = 0i32
-        let mutable l = 0i64
+        mut i = 0i8
+        mut j = 0i16
+        mut k = 0i32
+        mut l = 0i64
 
         i += 5 as! i8
         j += 5 as! i16

--- a/samples/classes/method.jakt
+++ b/samples/classes/method.jakt
@@ -5,13 +5,13 @@ class Person {
     public name: String
     public age: i64
 
-    public function birthday(mutable this) {
+    public function birthday(mut this) {
         ++this.age
     }
 }
 
 function main() {
-    let mutable p = Person(name: "Bob", age: 1000)
+    mut p = Person(name: "Bob", age: 1000)
 
     p.birthday()
 

--- a/samples/classes/mutating_method_called_on_immutable_object_instance.jakt
+++ b/samples/classes/mutating_method_called_on_immutable_object_instance.jakt
@@ -2,7 +2,7 @@
 /// - error: "Cannot call mutating method on an immutable object instance"
 
 class Foo {
-    public function bar(mutable this) {}
+    public function bar(mut this) {}
 }
 
 function main() {

--- a/samples/control_flow/continue.jakt
+++ b/samples/control_flow/continue.jakt
@@ -2,7 +2,7 @@
 /// - output: "1\n3\n5\n7\n9\n"
 
 function main() {
-    let mutable i = 0
+    mut i = 0
     while i < 10 {
         i++
         if i % 2 == 0 {

--- a/samples/control_flow/fizzbuzz.jakt
+++ b/samples/control_flow/fizzbuzz.jakt
@@ -2,7 +2,7 @@
 /// - output: "1\n2\nFizz\n4\nBuzz\nFizz\n7\n8\nFizz\nBuzz\n11\nFizz\n13\n14\nFizzBuzz\n16\n17\nFizz\n19\nBuzz\n"
 
 function main() {
-    let mutable i = 1
+    mut i = 1
     while i <= 20 {
         if i % 15 == 0 {
             println("FizzBuzz")

--- a/samples/control_flow/for.jakt
+++ b/samples/control_flow/for.jakt
@@ -4,7 +4,7 @@
 struct Countdown {
     from: i64
 
-    function next(mutable this) -> i64? {
+    function next(mut this) -> i64? {
         if this.from == -1 {
             return None
         }

--- a/samples/control_flow/if_with_bad_assignment.jakt
+++ b/samples/control_flow/if_with_bad_assignment.jakt
@@ -2,7 +2,7 @@
 /// - error: "assignment is not allowed in this position"
 
 function main() {
-    let mutable x = 100;
+    mut x = 100;
 
     if (x = 99) {
         println("true")

--- a/samples/control_flow/loop.jakt
+++ b/samples/control_flow/loop.jakt
@@ -2,7 +2,7 @@
 /// - output: "0\n1\n2\n3\n4\n"
 
 function main() {
-    let mutable i = 0
+    mut i = 0
     loop {
         if i == 5 {
             break

--- a/samples/control_flow/while.jakt
+++ b/samples/control_flow/while.jakt
@@ -2,7 +2,7 @@
 /// - output: "10\n9\n8\n7\n6\n5\n4\n3\n2\n1\n"
 
 function main() {
-    let mutable x: i64 = 10
+    mut x: i64 = 10
 
     while (x > 0) {
         println("{}", x)

--- a/samples/control_flow/while2.jakt
+++ b/samples/control_flow/while2.jakt
@@ -2,7 +2,7 @@
 /// - output: "10\n9\n8\n7\n6\n5\n4\n3\n2\n1\n"
 
 function main() {
-    let mutable x: i64 = 10
+    mut x: i64 = 10
 
     while (x > 0) {
         println("{}", x)

--- a/samples/control_flow/while3.jakt
+++ b/samples/control_flow/while3.jakt
@@ -2,7 +2,7 @@
 /// - output: "0\n1\n2\n3\n4\n5\n6\n7\n8\n9\n"
 
 function main() {
-    let mutable x: i64 = 0
+    mut x: i64 = 0
 
     while (x < 10) {
         println("{}", x)

--- a/samples/dictionaries/count_words.jakt
+++ b/samples/dictionaries/count_words.jakt
@@ -5,7 +5,7 @@ function main() {
     let text = "midway upon the journey of our life I found myself within a forest dark for the straightforward pathway had been lost"
     let words = text.split(' ')
 
-    let mutable counts = Dictionary<String, i64>();
+    mut counts = Dictionary<String, i64>();
 
     for i in 0..words.size() {
         counts.set(key: words[i], value: counts.get(words[i]).value_or(0) + 1)

--- a/samples/dictionaries/empty_literal.jakt
+++ b/samples/dictionaries/empty_literal.jakt
@@ -2,7 +2,7 @@
 /// - output: "20\n"
 
 function main() {
-    let mutable dict: [String: [i64: i64]] = [:]
+    mut dict: [String: [i64: i64]] = [:]
     dict.set(key: "a", value: [10: 20])
     println("{}", dict.get("a")!.get(10)!)
 }

--- a/samples/dictionaries/lvalue.jakt
+++ b/samples/dictionaries/lvalue.jakt
@@ -2,7 +2,7 @@
 /// - output: "0: foo\n"
 
 function main() {
-    let mutable dict = Dictionary<i32, String>()
+    mut dict = Dictionary<i32, String>()
     dict[0] = "foo"
     println("0: {}", dict[0])
 }

--- a/samples/dictionaries/lvalue2.jakt
+++ b/samples/dictionaries/lvalue2.jakt
@@ -2,7 +2,7 @@
 /// - output: "5\n"
 
 function main() {
-    let mutable dict = ["a": 1]
+    mut dict = ["a": 1]
     dict["a"] += 4
     println("{}", dict["a"])
 }

--- a/samples/dictionaries/reference_semantics.jakt
+++ b/samples/dictionaries/reference_semantics.jakt
@@ -1,12 +1,12 @@
 /// Expect:
 /// - output: "PASS\n"
 
-function change_value(dictionary: mutable [String:String]) throws {
+function change_value(dictionary: mut [String:String]) throws {
     dictionary.set(key: "foo", value: "PASS")
 }
 
 function main() {
-    let mutable dictionary = ["foo": "FAIL", "bar": ":^)"]
+    mut dictionary = ["foo": "FAIL", "bar": ":^)"]
     change_value(dictionary)
 
     println("{}", dictionary["foo"]);

--- a/samples/dictionaries/set.jakt
+++ b/samples/dictionaries/set.jakt
@@ -2,7 +2,7 @@
 /// - output: "3\n"
 
 function main() {
-    let mutable dict = ["a": 1, "b": 2]
+    mut dict = ["a": 1, "b": 2]
 
     dict.set(key: "c", value: 3);
 

--- a/samples/enums/empty_enum.jakt
+++ b/samples/enums/empty_enum.jakt
@@ -2,7 +2,7 @@
 /// - error: "Empty enums are not allowed"
 
 enum Foo {
-    function oops(mutable this) { }
+    function oops(mut this) { }
 }
 
 function main() { }

--- a/samples/generics/explicit_type_vars.jakt
+++ b/samples/generics/explicit_type_vars.jakt
@@ -2,7 +2,7 @@
 /// - output: "123\n"
 
 function main() {
-    let mutable item = Dictionary<String, i64>();
+    mut item = Dictionary<String, i64>();
 
     item.set(key: "bob", value: 123);
 

--- a/samples/generics/generic_types.jakt
+++ b/samples/generics/generic_types.jakt
@@ -1,12 +1,12 @@
 /// Expect:
 /// - output: "3\n"
 
-function do_pop<T>(anon arr: mutable [T]) -> Optional<T> {
+function do_pop<T>(anon arr: mut [T]) -> Optional<T> {
   return arr.pop()
 }
 
 function main() {
-  let mutable arr = [1, 2, 3];
+  mut arr = [1, 2, 3];
 
   println("{}", do_pop(arr)!)
 }

--- a/samples/inline_cpp/inline_cpp.jakt
+++ b/samples/inline_cpp/inline_cpp.jakt
@@ -2,7 +2,7 @@
 /// - output: "42\n"
 
 function main() {
-    let mutable i: i32? = None
+    mut i: i32? = None
     unsafe {
         cpp {
             "i = 32;"

--- a/samples/math/arithmetic_assignment.jakt
+++ b/samples/math/arithmetic_assignment.jakt
@@ -2,15 +2,15 @@
 /// - output: "133\n113\n1230\n12\n3\n"
 
 function main() {
-    let mutable a = 123
+    mut a = 123
     a += 10
-    let mutable b = 123
+    mut b = 123
     b -= 10
-    let mutable c = 123
+    mut c = 123
     c *= 10
-    let mutable d = 123
+    mut d = 123
     d /= 10
-    let mutable e = 123
+    mut e = 123
     e %= 10
 
     println("{}", a)

--- a/samples/math/bitwise.jakt
+++ b/samples/math/bitwise.jakt
@@ -12,21 +12,21 @@ function check(anon a: i64, anon b: i64) -> i64 {
 }
 
 function main() {
-    let mutable errors = 0
+    mut errors = 0
 
-    let mutable a = 1
+    mut a = 1
     a <<= 5
     errors += check(a, 1 << 5)
 
-    let mutable b = 0x8000
+    mut b = 0x8000
     b >>= 5
     errors += check(b, 0x8000 >> 5)
 
-    let mutable c = 0xffc0c0
+    mut c = 0xffc0c0
     c &= 0x777777
     errors += check(c, 0xffc0c0 & 0x777777)
 
-    let mutable d = 0xffc0c0
+    mut d = 0xffc0c0
     d ^= 0x777777
     errors += check(d, 0xffc0c0 ^ 0x777777)
 

--- a/samples/math/increment_decrement.jakt
+++ b/samples/math/increment_decrement.jakt
@@ -2,7 +2,7 @@
 /// - output: "11\n11\n12\n11\n11\n10\n"
 
 function main() {
-    let mutable x = 10
+    mut x = 10
 
     println("{}", ++x)
     println("{}", x++)

--- a/samples/math/overflow.jakt
+++ b/samples/math/overflow.jakt
@@ -39,7 +39,7 @@ function main() {
     }
     {
         // FIXME: The max value as a literal (18_446_744_073_709_551_615) fails to parse with 'could not parse int'
-        let mutable a: u64 = 9_223_372_036_854_775_807
+        mut a: u64 = 9_223_372_036_854_775_807
         a *= 2
         a += 1
         let b: u64 = 1

--- a/samples/math/zero_division.jakt
+++ b/samples/math/zero_division.jakt
@@ -39,7 +39,7 @@ function main() {
     }
     {
         // FIXME: The max value as a literal (18_446_744_073_709_551_615) fails to parse with 'could not parse int'
-        let mutable a: u64 = 9_223_372_036_854_775_807
+        mut a: u64 = 9_223_372_036_854_775_807
         a *= 2
         a += 1
         let b: u64 = 0

--- a/samples/namespaces/call_functions_in_nested_namespaces.jakt
+++ b/samples/namespaces/call_functions_in_nested_namespaces.jakt
@@ -13,7 +13,7 @@ namespace Outer {
 }
 
 function main() {
-    let mutable s = Outer::Inner::Struct()
+    mut s = Outer::Inner::Struct()
     s.method()
     Outer::Inner::Struct::static_function()
     Outer::Inner::free_function_in_inner_namespace()

--- a/samples/optional/assignment.jakt
+++ b/samples/optional/assignment.jakt
@@ -2,7 +2,7 @@
 /// - output: "hello\nPASS\n"
 
 function main() {
-    let mutable a: String? = None
+    mut a: String? = None
     a = "hello"
     println("{}", a!)
     a = None

--- a/samples/optional/mutable_unwrap.jakt
+++ b/samples/optional/mutable_unwrap.jakt
@@ -4,7 +4,7 @@
 class Foo {
     x: i64
 
-    public function set(mutable this, value: i64) {
+    public function set(mut this, value: i64) {
         this.x = value
     }
 
@@ -14,8 +14,8 @@ class Foo {
 }
 
 function main() {
-    let mutable foo = Foo(x: 1)
-    let mutable opt_foo: Foo? = foo
+    mut foo = Foo(x: 1)
+    mut opt_foo: Foo? = foo
 
     opt_foo!.set(value: 2)
 

--- a/samples/optional/none_coalescing.jakt
+++ b/samples/optional/none_coalescing.jakt
@@ -10,7 +10,7 @@ function main() {
 
 
     // The right hand side is lazily evaluated.
-    let mutable zero = 0
+    mut zero = 0
     let z: i64? = 69
     let q = z ?? ++zero
 

--- a/samples/ranges/range.jakt
+++ b/samples/ranges/range.jakt
@@ -2,7 +2,7 @@
 /// - output: "45\n"
 
 function main() {
-    let mutable total = 0
+    mut total = 0
 
     for x in 1..10 {
         total += x

--- a/samples/sets/add.jakt
+++ b/samples/sets/add.jakt
@@ -2,7 +2,7 @@
 /// - output: "3\n3\n"
 
 function main() {
-    let mutable set = {"b", "c"}
+    mut set = {"b", "c"}
     set.add("a")
     println("{}", set.size())
 

--- a/samples/sets/inference_empty.jakt
+++ b/samples/sets/inference_empty.jakt
@@ -2,10 +2,10 @@
 /// - output: "2 2\n"
 
 function main() {
-    let mutable set1: {String} = {}
+    mut set1: {String} = {}
     set1.add("hello")
     set1.add("World")
-    let mutable set2: {i64} = {}
+    mut set2: {i64} = {}
     set2.add(1)
     set2.add(2)
     println("{} {}", set1.size(), set2.size())

--- a/samples/sets/reference_semantics.jakt
+++ b/samples/sets/reference_semantics.jakt
@@ -1,13 +1,13 @@
 /// Expect:
 /// - output: "5\n"
 
-function foo(set: mutable {i64}) throws {
+function foo(set: mut {i64}) throws {
     set.add(4)
     set.add(5)
 }
 
 function main() {
-    let mutable set = {1, 2, 3}
+    mut set = {1, 2, 3}
     foo(set)
     println("{}", set.size());
 }

--- a/samples/sets/shorthand.jakt
+++ b/samples/sets/shorthand.jakt
@@ -2,7 +2,7 @@
 /// - output: "5\n"
 
 function get_unique(nums: [i64]) throws -> {i64} {
-    let mutable set = {nums[0]}
+    mut set = {nums[0]}
     for i in 1..nums.size() {
         set.add(nums[i])
     }

--- a/samples/sets/unique_numbers.jakt
+++ b/samples/sets/unique_numbers.jakt
@@ -3,7 +3,7 @@
 
 function main() {
     let nums = [1, 2, 1, 2, 1, 2, 3, 4, 5, 1, 2]
-    let mutable set = {nums[0]}
+    mut set = {nums[0]}
     for i in 0..nums.size() {
         set.add(nums[i])
     }

--- a/samples/strings/string_builder.jakt
+++ b/samples/strings/string_builder.jakt
@@ -3,12 +3,12 @@
 
 extern struct StringBuilder {
     function StringBuilder() -> StringBuilder
-    function append(mutable this, anon s: raw c_char)
-    function to_string(mutable this) throws -> String
+    function append(mut this, anon s: raw c_char)
+    function to_string(mut this) throws -> String
 }
 
 function main() {
-    let mutable s = StringBuilder()
+    mut s = StringBuilder()
 
     s.append("abc".c_string());
     s.append("123".c_string());

--- a/samples/structs/lvalue.jakt
+++ b/samples/structs/lvalue.jakt
@@ -7,7 +7,7 @@ struct Person {
 }
 
 function main() {
-    let mutable p = Person(name: "Jane", age: 100)
+    mut p = Person(name: "Jane", age: 100)
 
     p.age = 99;
 

--- a/samples/structs/method_mutable.jakt
+++ b/samples/structs/method_mutable.jakt
@@ -5,7 +5,7 @@ struct Rectangle {
     width: i64,
     height: i64,
 
-    function grow(mutable this) {
+    function grow(mut this) {
         this.width *= 2;
         this.height *= 2;
     }
@@ -14,7 +14,7 @@ struct Rectangle {
 }
 
 function main() {
-    let mutable rect = Rectangle(width: 4, height: 8)
+    mut rect = Rectangle(width: 4, height: 8)
 
     rect.grow()
 

--- a/samples/structs/value_semantics.jakt
+++ b/samples/structs/value_semantics.jakt
@@ -5,7 +5,7 @@ struct Foo {
     x: i64
 }
 
-function set_x(foo: mutable Foo, x: i64) {
+function set_x(foo: mut Foo, x: i64) {
     foo.x = x
 }
 
@@ -16,7 +16,7 @@ function main() {
     set_x(foo: foo, x: 10)
     println("{}", foo.x)
 
-    let mutable bar = foo
+    mut bar = foo
     bar.x = 15
     println("{}", foo.x)
 }

--- a/samples/structs/vec_and_struct_lvalue.jakt
+++ b/samples/structs/vec_and_struct_lvalue.jakt
@@ -7,7 +7,7 @@ struct Person {
 }
 
 function main() {
-    let mutable arr = [
+    mut arr = [
         Person(name: "Jane", age: 100), 
         Person(name: "Björn", age: 200)
     ]

--- a/samples/variables/integer_promotion.jakt
+++ b/samples/variables/integer_promotion.jakt
@@ -6,16 +6,16 @@ struct Foo {
 }
 
 function main() {
-    let mutable a: u8 = 100
+    mut a: u8 = 100
     a += 100
 
-    let mutable b: u16 = 1000
+    mut b: u16 = 1000
     b += 1000
 
-    let mutable c: u32 = 100000
+    mut c: u32 = 100000
     c += 100000
 
-    let mutable f = Foo(x: 123)
+    mut f = Foo(x: 123)
     f.x += 2
 
     println("{}", a)

--- a/samples/variables/integer_promotion_bad2.jakt
+++ b/samples/variables/integer_promotion_bad2.jakt
@@ -2,6 +2,6 @@
 /// - error: "Integer promotion failed\n"
 
 function main() {
-    let mutable i: u8 = 0;
+    mut i: u8 = 0;
     i += 1000;
 }

--- a/samples/variables/integer_promotion_bad3.jakt
+++ b/samples/variables/integer_promotion_bad3.jakt
@@ -2,6 +2,6 @@
 /// - error: "Integer promotion failed"
 
 function main() {
-    let mutable i: u8 = 0;
+    mut i: u8 = 0;
     i += 1000;
 }

--- a/samples/variables/var2.jakt
+++ b/samples/variables/var2.jakt
@@ -2,7 +2,7 @@
 /// - output: "101\n"
 
 function main() {
-    let mutable x: i64 = 100
+    mut x: i64 = 100
     x = x + 1
     println("{}", x)
 }

--- a/samples/variables/var3.jakt
+++ b/samples/variables/var3.jakt
@@ -2,7 +2,7 @@
 /// - output: "101\n"
 
 function main() {
-    let mutable x: i64 = 100
+    mut x: i64 = 100
     x += 1
     println("{}", x)
 }

--- a/samples/variables/var_inference.jakt
+++ b/samples/variables/var_inference.jakt
@@ -2,6 +2,6 @@
 /// - output: "100\n"
 
 function main() {
-    let mutable x = 100
+    mut x = 100
     println("{}", x)
 }

--- a/samples/weak/assign_weak_to_weak.jakt
+++ b/samples/weak/assign_weak_to_weak.jakt
@@ -7,8 +7,8 @@ class Foo {
 
 function main() {
 
-    let mutable foo: weak Foo? = None
-    let mutable bar = foo
+    mut foo: weak Foo? = None
+    mut bar = foo
 
     println("OK")
     

--- a/samples/weak/basic.jakt
+++ b/samples/weak/basic.jakt
@@ -6,7 +6,7 @@ class Foo {
 }
 
 function main() {
-    let mutable weak_foo: weak Foo? = None
+    mut weak_foo: weak Foo? = None
 
     println("weak_foo has_value? {}", weak_foo.has_value())
 

--- a/samples/weak/question_mark_required.jakt
+++ b/samples/weak/question_mark_required.jakt
@@ -7,7 +7,7 @@ class Foo {
 
 function main() {
 
-   let mutable foo: weak Foo = None
+   mut foo: weak Foo = None
 
    println("Oh no!")
 

--- a/samples/weak/reassign.jakt
+++ b/samples/weak/reassign.jakt
@@ -9,7 +9,7 @@ function main() {
     let foo1 = Foo(x: 1)
     let foo2 = Foo(x: 2)
 
-    let mutable weak_foo: weak Foo? = None
+    mut weak_foo: weak Foo? = None
     weak_foo = foo1
     println("{}", weak_foo!.x)
 

--- a/selfhost/main.jakt
+++ b/selfhost/main.jakt
@@ -2,8 +2,8 @@
 /// - output: ""
 
 extern struct StringBuilder {
-    function append(mutable this, anon s: u8)
-    function to_string(mutable this) throws -> String
+    function append(mut this, anon s: u8)
+    function to_string(mut this) throws -> String
     function StringBuilder() -> StringBuilder
 }
 
@@ -116,7 +116,7 @@ enum Token {
     Let(JaktSpan)
     Loop(JaktSpan)
     Match(JaktSpan)
-    Mutable(JaktSpan)
+    Mut(JaktSpan)
     Not(JaktSpan)
     Or(JaktSpan)
     Private(JaktSpan)
@@ -218,7 +218,7 @@ enum Token {
         Let(span) => span
         Loop(span) => span
         Match(span) => span
-        Mutable(span) => span
+        Mut(span) => span
         Not(span) => span
         Or(span) => span
         Private(span) => span
@@ -261,7 +261,7 @@ enum Token {
         "let" => Token::Let(span)
         "loop" => Token::Loop(span)
         "match" => Token::Match(span)
-        "mutable" => Token::Mutable(span)
+        "mut" => Token::Mut(span)
         "not" => Token::Not(span)
         "or" => Token::Or(span)
         "private" => Token::Private(span)
@@ -293,7 +293,7 @@ struct Lexer {
     input: [u8]
     errors: [JaktError]
 
-    function error(mutable this, anon message: String, anon span: JaktSpan) throws {
+    function error(mut this, anon message: String, anon span: JaktSpan) throws {
         .errors.push(JaktError::Message(message, span))
     }
 
@@ -319,14 +319,14 @@ struct Lexer {
     }
 
     function substring(this, start: usize, length: usize) throws -> String {
-        let mutable builder = StringBuilder()
+        mut builder = StringBuilder()
         for i in start..length {
             builder.append(.input[i])
         }
         return builder.to_string()
     }
 
-    function lex_character_constant_or_name(mutable this) throws -> Token {
+    function lex_character_constant_or_name(mut this) throws -> Token {
         if .peek_ahead(1) != b'\'' {
             return .lex_number_or_name()
         }
@@ -339,7 +339,7 @@ struct Lexer {
         let start = .index
         .index++
 
-        let mutable escaped = false;
+        mut escaped = false;
 
         while not .eof() and (escaped or .peek() != b'\'') {
             if not escaped and .peek() == b'\\' {
@@ -356,7 +356,7 @@ struct Lexer {
         }
 
         // Everything but the quotes
-        let mutable builder = StringBuilder()
+        mut builder = StringBuilder()
         builder.append(.input[start + 1])
         let str = builder.to_string()
 
@@ -370,7 +370,7 @@ struct Lexer {
         return Token::SingleQuotedString(quote: str, span: JaktSpan(start, end))
     }
 
-    function lex_number_or_name(mutable this) throws -> Token {
+    function lex_number_or_name(mut this) throws -> Token {
         let start = .index
 
         if .eof() {
@@ -378,7 +378,7 @@ struct Lexer {
             return Token::Garbage(JaktSpan(start, end: start))
         }
         if is_ascii_digit(.peek()) {
-            let mutable total = 0i64
+            mut total = 0i64
 
             while is_ascii_digit(.peek()) {
                 let value = .input[.index]
@@ -389,7 +389,7 @@ struct Lexer {
             let end = .index
             return Token::Number(number: total, span: JaktSpan(start, end))
         } else if is_ascii_alpha(.peek()) or .peek() == b'_' {
-            let mutable string_builder = StringBuilder()
+            mut string_builder = StringBuilder()
 
             while is_ascii_alphanumeric(.peek()) or .peek() == b'_' {
                 let value = .input[.index]
@@ -409,7 +409,7 @@ struct Lexer {
         return Token::Garbage(JaktSpan(start, end))
     }
 
-    function lex_quoted_string(mutable this, delimiter: u8) throws -> Token {
+    function lex_quoted_string(mut this, delimiter: u8) throws -> Token {
         let start = .index
 
         ++.index
@@ -419,7 +419,7 @@ struct Lexer {
             return Token::Garbage(JaktSpan(start, end: start))
         }
 
-        let mutable escaped = false
+        mut escaped = false
         while not .eof() and (escaped or .peek() != delimiter) {
             if not escaped and .peek() == b'\\' {
                 escaped = true
@@ -442,7 +442,7 @@ struct Lexer {
         return Token::QuotedString(quote: str, span: JaktSpan(start, end))
     }
 
-    function lex_plus(mutable this) -> Token {
+    function lex_plus(mut this) -> Token {
         let start = .index++
         return match .peek() {
             b'=' => Token::PlusEqual(JaktSpan(start, end: ++.index))
@@ -451,7 +451,7 @@ struct Lexer {
         }
     }
 
-    function lex_minus(mutable this) -> Token {
+    function lex_minus(mut this) -> Token {
         let start = .index++
         return match .peek() {
             b'=' => Token::MinusEqual(JaktSpan(start, end: ++.index))
@@ -461,7 +461,7 @@ struct Lexer {
         }
     }
 
-    function lex_asterisk(mutable this) -> Token {
+    function lex_asterisk(mut this) -> Token {
         let start = .index++
         return match .peek() {
             b'=' => Token::AsteriskEqual(JaktSpan(start, end: ++.index))
@@ -469,7 +469,7 @@ struct Lexer {
         }
     }
 
-    function lex_forward_slash(mutable this) throws -> Token {
+    function lex_forward_slash(mut this) throws -> Token {
         let start = .index++
         if .peek() == b'=' {
             return Token::ForwardSlashEqual(JaktSpan(start, end: ++.index))
@@ -488,7 +488,7 @@ struct Lexer {
         return .next() ?? Token::Eof(JaktSpan(start: .index, end: .index))
     }
 
-    function lex_caret(mutable this) -> Token {
+    function lex_caret(mut this) -> Token {
         let start = .index++
         return match .peek() {
             b'=' => Token::CaretEqual(JaktSpan(start, end: ++.index))
@@ -496,7 +496,7 @@ struct Lexer {
         }
     }
 
-    function lex_pipe(mutable this) -> Token {
+    function lex_pipe(mut this) -> Token {
         let start = .index++
         return match .peek() {
             b'=' => Token::PipeEqual(JaktSpan(start, end: ++.index))
@@ -504,7 +504,7 @@ struct Lexer {
         }
     }
 
-    function lex_percent_sign(mutable this) -> Token {
+    function lex_percent_sign(mut this) -> Token {
         let start = .index++
         return match .peek() {
             b'=' => Token::PercentSignEqual(JaktSpan(start, end: ++.index))
@@ -512,7 +512,7 @@ struct Lexer {
         }
     }
 
-    function lex_exclamation_point(mutable this) -> Token {
+    function lex_exclamation_point(mut this) -> Token {
         let start = .index++
         return match .peek() {
             b'=' => Token::NotEqual(JaktSpan(start, end: ++.index))
@@ -520,7 +520,7 @@ struct Lexer {
         }
     }
 
-    function lex_ampersand(mutable this) -> Token {
+    function lex_ampersand(mut this) -> Token {
         let start = .index++
         return match .peek() {
             b'=' => Token::AmpersandEqual(JaktSpan(start, end: ++.index))
@@ -528,7 +528,7 @@ struct Lexer {
         }
     }
 
-    function lex_less_than(mutable this) -> Token {
+    function lex_less_than(mut this) -> Token {
         let start = .index++
         return match .peek() {
             b'=' => Token::LessThanOrEqual(JaktSpan(start, end: ++.index))
@@ -537,7 +537,7 @@ struct Lexer {
         }
     }
 
-    function lex_greater_than(mutable this) -> Token {
+    function lex_greater_than(mut this) -> Token {
         let start = .index++
         return match .peek() {
             b'=' => Token::GreaterThanOrEqual(JaktSpan(start, end: ++.index))
@@ -546,7 +546,7 @@ struct Lexer {
         }
     }
 
-    function lex_dot(mutable this) -> Token {
+    function lex_dot(mut this) -> Token {
         let start = .index++
         return match .peek() {
             b'.' => Token::DotDot(JaktSpan(start, end: ++.index))
@@ -554,7 +554,7 @@ struct Lexer {
         }
     }
 
-    function lex_colon(mutable this) -> Token {
+    function lex_colon(mut this) -> Token {
         let start = .index++
         return match .peek() {
             b':' => Token::ColonColon(JaktSpan(start, end: ++.index))
@@ -562,7 +562,7 @@ struct Lexer {
         }
     }
 
-    function lex_question_mark(mutable this) -> Token {
+    function lex_question_mark(mut this) -> Token {
         let start = .index++
         return match .peek() {
             b'?' => {
@@ -576,7 +576,7 @@ struct Lexer {
         }
     }
 
-    function lex_equals(mutable this) -> Token {
+    function lex_equals(mut this) -> Token {
         let start = .index++
         return match .peek() {
             b'=' => Token::DoubleEqual(JaktSpan(start, end: ++.index))
@@ -585,7 +585,7 @@ struct Lexer {
         }
     }
 
-    function next(mutable this) throws -> Token? {
+    function next(mut this) throws -> Token? {
         if .index == .input.size() {
             ++.index
             return Token::Eof(JaktSpan(start: .index - 1, end: .index - 1))
@@ -672,7 +672,7 @@ function display_message_with_span(anon severity: MessageSeverity, file_name: St
 
     let line_spans = gather_line_spans(file_contents)
 
-    let mutable line_index = 1uz
+    mut line_index = 1uz
     let largest_line_number = line_spans.size()
 
     let width = format("{}", largest_line_number).length()
@@ -714,14 +714,14 @@ function display_message_with_span(anon severity: MessageSeverity, file_name: St
 }
 
 function print_source_line(severity: MessageSeverity, file_contents: [u8], file_span: (usize, usize), error_span: JaktSpan, line_number: usize, largest_line_number: usize) throws {
-    let mutable index = file_span.0
+    mut index = file_span.0
 
     let width = format("{}", largest_line_number).length()
 
     print(" {} | ", line_number)
 
     while index <= file_span.1 {
-        let mutable c = b' '
+        mut c = b' '
         if index < file_span.1 {
             c = file_contents[index]
         } else if error_span.start == error_span.end and index == error_span.start {
@@ -740,10 +740,10 @@ function print_source_line(severity: MessageSeverity, file_contents: [u8], file_
 }
 
 function gather_line_spans(file_contents: [u8]) throws -> [(usize, usize)] {
-    let mutable idx = 0uz
-    let mutable output: [(usize, usize)] = []
+    mut idx = 0uz
+    mut output: [(usize, usize)] = []
 
-    let mutable start = idx
+    mut start = idx
     while idx < file_contents.size() {
         if file_contents[idx] == b'\n' {
             output.push((start, idx))
@@ -1036,11 +1036,11 @@ struct Parser {
     tokens: [Token]
     errors: [JaktError]
 
-    function error(mutable this, anon message: String, anon span: JaktSpan) throws {
+    function error(mut this, anon message: String, anon span: JaktSpan) throws {
         .errors.push(JaktError::Message(message, span))
     }
 
-    function error_with_hint(mutable this, anon message: String, anon span: JaktSpan, anon hint: String, anon hint_span: JaktSpan) throws {
+    function error_with_hint(mut this, anon message: String, anon span: JaktSpan, anon hint: String, anon hint_span: JaktSpan) throws {
         .errors.push(JaktError::MessageWithHint(message, span, hint, hint_span))
     }
 
@@ -1066,8 +1066,8 @@ struct Parser {
         return .peek(0)
     }
 
-    public function parse_namespace(mutable this) throws -> ParsedNamespace {
-        let mutable parsed_namespace = ParsedNamespace(name: "", functions: [], structs: [])
+    public function parse_namespace(mut this) throws -> ParsedNamespace {
+        mut parsed_namespace = ParsedNamespace(name: "", functions: [], structs: [])
 
         while not .eof() {
             match .current() {
@@ -1120,8 +1120,8 @@ struct Parser {
         return parsed_namespace
     }
 
-    public function parse_struct(mutable this, anon definition_linkage: DefinitionLinkage, anon definition_type: DefinitionType) throws -> ParsedStruct {
-        let mutable parsed_struct = ParsedStruct(
+    public function parse_struct(mut this, anon definition_linkage: DefinitionLinkage, anon definition_type: DefinitionType) throws -> ParsedStruct {
+        mut parsed_struct = ParsedStruct(
             name: "",
             name_span: empty_span(),
             generic_parameters: [],
@@ -1181,12 +1181,12 @@ struct Parser {
             .error("Expected ‘{’", .current().span())
         }
 
-        let mutable fields: [ParsedField] = []
-        let mutable methods: [ParsedMethod] = []
+        mut fields: [ParsedField] = []
+        mut methods: [ParsedMethod] = []
 
         // This gets reset after each loop. If someone doesn't consume it, we error out.
-        let mutable last_visibility: Visibility? = None
-        let mutable last_visibility_span: JaktSpan? = None
+        mut last_visibility: Visibility? = None
+        mut last_visibility_span: JaktSpan? = None
 
         while not .eof() {
             let token = .current()
@@ -1271,8 +1271,8 @@ struct Parser {
         return parsed_struct
     }
 
-    public function parse_function(mutable this, anon linkage: FunctionLinkage) throws -> ParsedFunction {
-        let mutable parsed_function = ParsedFunction(
+    public function parse_function(mut this, anon linkage: FunctionLinkage) throws -> ParsedFunction {
+        mut parsed_function = ParsedFunction(
             name: "",
             name_span: empty_span(),
             params: [],
@@ -1311,9 +1311,9 @@ struct Parser {
             .error("Expected '('", .current().span())
         }
 
-        let mutable params: [ParsedParameter] = []
-        let mutable current_param_requires_label = true
-        let mutable current_param_is_mutable = true
+        mut params: [ParsedParameter] = []
+        mut current_param_requires_label = true
+        mut current_param_is_mutable = true
 
         while not .eof() {
             match .current() {
@@ -1329,7 +1329,7 @@ struct Parser {
                     .index++
                     current_param_requires_label = false
                 }
-                Mutable => {
+                Mut => {
                     .index++
                     current_param_is_mutable = true
                 }
@@ -1397,7 +1397,7 @@ struct Parser {
         return parsed_function
     }
 
-    function parse_fat_arrow(mutable this) throws -> ParsedBlock {
+    function parse_fat_arrow(mut this) throws -> ParsedBlock {
         .index++
         let start = .current().span()
         let expr = .parse_expression(allow_assignments: false)
@@ -1405,7 +1405,7 @@ struct Parser {
         return ParsedBlock(stmts: [return_statement])
     }
 
-    function parse_field(mutable this, anon visibility: Visibility) throws -> ParsedField {
+    function parse_field(mut this, anon visibility: Visibility) throws -> ParsedField {
         let parsed_variable_declaration = .parse_variable_declaration()
 
         if parsed_variable_declaration.parsed_type is Empty {
@@ -1418,7 +1418,7 @@ struct Parser {
         )
     }
 
-    function parse_method(mutable this, anon linkage: FunctionLinkage, anon visibility: Visibility) throws -> ParsedMethod {
+    function parse_method(mut this, anon linkage: FunctionLinkage, anon visibility: Visibility) throws -> ParsedMethod {
         let parsed_function = .parse_function(linkage)
 
         // TODO: The bootstrap compiler sets parsed_function.must_instantiate here if the linkage is External.
@@ -1430,8 +1430,8 @@ struct Parser {
         )
     }
 
-    function parse_typename(mutable this) throws -> ParsedType {
-        let mutable parsed_type = .parse_type_shorthand()
+    function parse_typename(mut this) throws -> ParsedType {
+        mut parsed_type = .parse_type_shorthand()
 
         if not parsed_type is Empty {
             return parsed_type
@@ -1483,7 +1483,7 @@ struct Parser {
         return parsed_type
     }
 
-    function parse_variable_declaration(mutable this) throws -> ParsedVarDecl {
+    function parse_variable_declaration(mut this) throws -> ParsedVarDecl {
         match .current() {
             Identifier(name) => {
                 let var_name = name
@@ -1502,8 +1502,8 @@ struct Parser {
                 let decl_span = .previous().span()
 
                 // We have "name:" so far.
-                let mutable is_mutable = false
-                if .current() is Mutable {
+                mut is_mutable = false
+                if .current() is Mut {
                     .index++
                     is_mutable = true
                 }
@@ -1526,14 +1526,14 @@ struct Parser {
         )
     }
 
-    function parse_type_shorthand(mutable this) throws -> ParsedType => match .current() {
+    function parse_type_shorthand(mut this) throws -> ParsedType => match .current() {
         LSquare => .parse_type_shorthand_array_or_dictionary()
         LCurly => .parse_type_shorthand_set()
         LParen => .parse_type_shorthand_tuple()
         else => ParsedType::Empty
     }
 
-    function parse_type_shorthand_array_or_dictionary(mutable this) throws -> ParsedType {
+    function parse_type_shorthand_array_or_dictionary(mut this) throws -> ParsedType {
         // [T] is shorthand for Array<T>
         // [K:V] is shorthand for Dictionary<K, V>
         let start = .current().span()
@@ -1557,7 +1557,7 @@ struct Parser {
         return ParsedType::Empty
     }
 
-    function parse_type_shorthand_set(mutable this) throws -> ParsedType {
+    function parse_type_shorthand_set(mut this) throws -> ParsedType {
         // {T} is shorthand for Set<T>
         let start = .current().span()
         let inner = .parse_typename()
@@ -1569,11 +1569,11 @@ struct Parser {
         return ParsedType::Empty
     }
 
-    function parse_type_shorthand_tuple(mutable this) throws -> ParsedType {
+    function parse_type_shorthand_tuple(mut this) throws -> ParsedType {
         // (A, B, C) is shorthand for Tuple<A, B, C>
         let start = .current().span()
         .index++
-        let mutable types: [ParsedType] = []
+        mut types: [ParsedType] = []
         while not .eof() {
             if .current() is RParen {
                 .index++
@@ -1588,9 +1588,9 @@ struct Parser {
         return ParsedType::Empty
     }
 
-    function parse_block(mutable this) throws -> ParsedBlock {
+    function parse_block(mut this) throws -> ParsedBlock {
         let start = .current().span()
-        let mutable block = ParsedBlock(stmts: [])
+        mut block = ParsedBlock(stmts: [])
 
         if .eof() {
             .error("Incomplete block", start)
@@ -1624,7 +1624,7 @@ struct Parser {
         return block
     }
 
-    function parse_statement(mutable this, inside_block: bool) throws -> ParsedStatement {
+    function parse_statement(mut this, inside_block: bool) throws -> ParsedStatement {
         println("parse_statement: {}", .current())
         let start = .current().span()
 
@@ -1679,13 +1679,13 @@ struct Parser {
             Let => {
                 .index++
                 let is_mutable = match .current() {
-                    Mutable => {
+                    Mut => {
                         .index++
                         yield true
                     }
                     else => false
                 }
-                let mutable var = .parse_variable_declaration()
+                mut var = .parse_variable_declaration()
                 var.is_mutable = is_mutable
 
                 let init = match .current() {
@@ -1709,13 +1709,13 @@ struct Parser {
         }
     }
 
-    function parse_try_statement(mutable this) throws -> ParsedStatement {
+    function parse_try_statement(mut this) throws -> ParsedStatement {
         .index++
 
         let stmt = .parse_statement(inside_block: false)
 
-        let mutable error_name = ""
-        let mutable error_span = .current().span()
+        mut error_name = ""
+        mut error_span = .current().span()
 
         if .current() is Catch {
             .index++
@@ -1735,7 +1735,7 @@ struct Parser {
         return ParsedStatement::Try(stmt, error_name, error_span, catch_block)
     }
 
-    function parse_for_statement(mutable this) throws -> ParsedStatement {
+    function parse_for_statement(mut this) throws -> ParsedStatement {
         .index++
 
         return match .current() {
@@ -1762,7 +1762,7 @@ struct Parser {
         }
     }
 
-    function parse_if_statement(mutable this) throws -> ParsedStatement {
+    function parse_if_statement(mut this) throws -> ParsedStatement {
         if not .current() is If {
             .error("Expected ‘if’ statement", .current().span())
             return ParsedStatement::Garbage
@@ -1774,7 +1774,7 @@ struct Parser {
         let condition = .parse_expression(allow_assignments: false)
         let then_block = .parse_block()
 
-        let mutable else_statement: ParsedStatement? = None
+        mut else_statement: ParsedStatement? = None
 
         if .current() is Else {
             .index++
@@ -1796,9 +1796,9 @@ struct Parser {
         return ParsedStatement::If(condition, then_block, else_statement)
     }
 
-    function parse_expression(mutable this, allow_assignments: bool) throws -> ParsedExpression {
-        let mutable expr_stack: [ParsedExpression] = []
-        let mutable last_precedence = 1000000
+    function parse_expression(mut this, allow_assignments: bool) throws -> ParsedExpression {
+        mut expr_stack: [ParsedExpression] = []
+        mut last_precedence = 1000000
 
         let lhs = .parse_operand()
         expr_stack.push(lhs)
@@ -1863,7 +1863,7 @@ struct Parser {
         return expr_stack[0]
     }
 
-    function parse_operand_base(mutable this) throws -> ParsedExpression {
+    function parse_operand_base(mut this) throws -> ParsedExpression {
         let span = .current().span()
         match .current() {
             Dot => {
@@ -1944,12 +1944,12 @@ struct Parser {
         return ParsedExpression::Garbage(span)
     }
 
-    function parse_operand(mutable this) throws -> ParsedExpression {
+    function parse_operand(mut this) throws -> ParsedExpression {
         .skip_newlines()
         let span = .current().span()
         let start = .current().span()
         .skip_newlines()
-        let mutable expr = .parse_operand_base()
+        mut expr = .parse_operand_base()
 
         // Check for postfix operators, while we're at it
         return match .current() {
@@ -2035,7 +2035,7 @@ struct Parser {
         }
     }
 
-    function parse_operator(mutable this, allow_assignments: bool) throws -> ParsedExpression {
+    function parse_operator(mut this, allow_assignments: bool) throws -> ParsedExpression {
         let span = .current().span()
         let op = match .current() {
             QuestionMarkQuestionMark => BinaryOperator::NoneCoalescing
@@ -2086,8 +2086,8 @@ struct Parser {
         return ParsedExpression::Operator(op, span)
     }
 
-    function parse_call(mutable this) throws -> ParsedCall {
-        let mutable call = ParsedCall(
+    function parse_call(mut this) throws -> ParsedCall {
+        mut call = ParsedCall(
             name: "",
             args: [],
         )
@@ -2133,18 +2133,18 @@ struct Parser {
         return call
     }
 
-    function skip_newlines(mutable this) {
+    function skip_newlines(mut this) {
         while .current() is Eol {
             .index++
         }
     }
 
-    function parse_generic_parameters(mutable this) throws -> [[String:JaktSpan]] {
+    function parse_generic_parameters(mut this) throws -> [[String:JaktSpan]] {
         if not .current() is LessThan {
             return []
         }
         .index++
-        let mutable generic_parameters: [[String:JaktSpan]] = []
+        mut generic_parameters: [[String:JaktSpan]] = []
         .skip_newlines()
         while not .current() is GreaterThan and not .current() is Garbage {
             match .current() {
@@ -2172,7 +2172,7 @@ struct Parser {
         return generic_parameters
     }
 
-    function parse_argument_label(mutable this) throws -> String {
+    function parse_argument_label(mut this) throws -> String {
         // FIXME: Tidy this up once we can match on tuples:
         //        match (.current(), .peek(1)) {
         //            (Name(name), Colon) => ...
@@ -2189,8 +2189,8 @@ struct Parser {
         }
     }
 
-    function parse_restricted_visibility_modifier(mutable this) throws -> Visibility {
-        let mutable restricted_span = .current().span()
+    function parse_restricted_visibility_modifier(mut this) throws -> Visibility {
+        mut restricted_span = .current().span()
         
         .index++
 
@@ -2200,8 +2200,8 @@ struct Parser {
             .error("Expected ‘(’", .current().span())
         }
 
-        let mutable whitelist: [ParsedType] = []
-        let mutable expect_comma = false
+        mut whitelist: [ParsedType] = []
+        mut expect_comma = false
 
         while .index < .tokens.size() {
             match .current() {
@@ -2244,8 +2244,8 @@ struct Parser {
         return Visibility::Restricted(whitelist, span: restricted_span)
     }
 
-    function parse_array_or_dictionary_literal(mutable this) throws -> ParsedExpression {
-        let mutable is_dictionary = false
+    function parse_array_or_dictionary_literal(mut this) throws -> ParsedExpression {
+        mut is_dictionary = false
         let start = .current().span()
 
         if not .current() is LSquare {
@@ -2254,9 +2254,9 @@ struct Parser {
         }
         .index++
 
-        let mutable fill_size_expr: ParsedExpression? = None
-        let mutable output: [ParsedExpression] = []
-        let mutable dict_output: [(ParsedExpression, ParsedExpression)] = []
+        mut fill_size_expr: ParsedExpression? = None
+        mut output: [ParsedExpression] = []
+        mut dict_output: [(ParsedExpression, ParsedExpression)] = []
 
         while not .eof() {
             match .current() {
@@ -2536,18 +2536,18 @@ function main(args: [String]) {
         return 1
     }
 
-    let mutable file = File::open_for_reading(args[1])
+    mut file = File::open_for_reading(args[1])
     let file_contents = file.read_all()
 
-    let mutable lexer = Lexer(index: 0, input: file_contents, errors: [])
-    let mutable tokens: [Token] = []
+    mut lexer = Lexer(index: 0, input: file_contents, errors: [])
+    mut tokens: [Token] = []
 
     for token in lexer {
         println("token: {}", token)
         tokens.push(token)
     }
 
-    let mutable parser = Parser(index: 0, tokens, errors: [])
+    mut parser = Parser(index: 0, tokens, errors: [])
 
     let parsed_namespace = parser.parse_namespace()
 

--- a/src/ide.rs
+++ b/src/ide.rs
@@ -578,11 +578,7 @@ pub fn get_function_signature(project: &Project, function_id: FunctionId) -> Str
 
     for param in &function.params {
         let anon = if !param.requires_label { "anon " } else { "" };
-        let mutable = if param.variable.mutable {
-            "mutable "
-        } else {
-            ""
-        };
+        let mutable = if param.variable.mutable { "mut " } else { "" };
 
         let mut variable_type = project.typename_for_type_id(param.variable.type_id);
         if variable_type != "void" {

--- a/tests/codegen/control_flow_inside_match.jakt
+++ b/tests/codegen/control_flow_inside_match.jakt
@@ -2,7 +2,7 @@
 /// - out: "OK\n"
 
 function test_continue() -> i64 {
-  let mutable x: i64 = 10
+  mut x: i64 = 10
   loop {
     match x {
       10 => {
@@ -17,7 +17,7 @@ function test_continue() -> i64 {
 }
 
 function test_break() -> i64 {
-  let mutable x: i64 = 10
+  mut x: i64 = 10
   loop {
     match x {
       42 => {

--- a/tests/codegen/control_flow_inside_nested_match_block.jakt
+++ b/tests/codegen/control_flow_inside_nested_match_block.jakt
@@ -2,7 +2,7 @@
 /// - output: "OK\n"
 
 function test_continue() -> bool {
-    let mutable break_out = false
+    mut break_out = false
     while not break_out {
         match 10 {
             10 => {

--- a/tests/parser/dont_get_stuck_in_match_patterns.jakt
+++ b/tests/parser/dont_get_stuck_in_match_patterns.jakt
@@ -1,7 +1,7 @@
 /// Expect:
 /// - error: "expected complete block"
 struct Parser {
-    function parse_call_parameter_name(mutable this) throws -> String {
+    function parse_call_parameter_name(mut this) throws -> String {
         match .current() {
             Name(name) => {
                 match .peek(1) {

--- a/tests/typechecker/array_with_float_values.jakt
+++ b/tests/typechecker/array_with_float_values.jakt
@@ -6,6 +6,6 @@ class A {
 }
 
 function main() {
-    let mutable a2 = A(elements: [0f64, 1f64, 2f64])
+    mut a2 = A(elements: [0f64, 1f64, 2f64])
     println("{}", a2.elements[1])
 }

--- a/tests/typechecker/assign_incompatible_to_optional.jakt
+++ b/tests/typechecker/assign_incompatible_to_optional.jakt
@@ -5,6 +5,6 @@ class Foo {
 }
 
 function main() {
-    let mutable x: Foo? = None
+    mut x: Foo? = None
     x = 5
 }

--- a/tests/typechecker/assign_integer_to_weak.jakt
+++ b/tests/typechecker/assign_integer_to_weak.jakt
@@ -5,6 +5,6 @@ class Foo {
 }
 
 function main() {
-    let mutable x: weak Foo? = None
+    mut x: weak Foo? = None
     x = 5
 }

--- a/tests/typechecker/assign_to_weak_on_declaration.jakt
+++ b/tests/typechecker/assign_to_weak_on_declaration.jakt
@@ -7,7 +7,7 @@ class Foo {
 
 function main() {
     let foo = Foo()
-    let mutable weak_foo: weak Foo? = foo
+    mut weak_foo: weak Foo? = foo
 
     println("{}", weak_foo!.call())
 }

--- a/tests/typechecker/constructor_with_different_generic_instance.jakt
+++ b/tests/typechecker/constructor_with_different_generic_instance.jakt
@@ -9,5 +9,5 @@ class A {
 }
 
 function main() {
-    let mutable a = A(b: [])
+    mut a = A(b: [])
 }

--- a/tests/typechecker/function_class_function.jakt
+++ b/tests/typechecker/function_class_function.jakt
@@ -6,7 +6,7 @@ function test(i : i32) -> i32 {
 }
 
 class TestClass {
-    function init(mutable this) {}
+    function init(mut this) {}
 }
 
 function main() {

--- a/tests/typechecker/increment_integer_types.jakt
+++ b/tests/typechecker/increment_integer_types.jakt
@@ -3,47 +3,47 @@
 
 function main() {
     {
-        let mutable x = 0i8
+        mut x = 0i8
         x++
     }
     {
-        let mutable x = 0i16
+        mut x = 0i16
         x++
     }
     {
-        let mutable x = 0i32
+        mut x = 0i32
         x++
     }
     {
-        let mutable x = 0i64
+        mut x = 0i64
         x++
     }
     {
-        let mutable x = 0u8
+        mut x = 0u8
         x++
     }
     {
-        let mutable x = 0u16
+        mut x = 0u16
         x++
     }
     {
-        let mutable x = 0u32
+        mut x = 0u32
         x++
     }
     {
-        let mutable x = 0u64
+        mut x = 0u64
         x++
     }
     {
-        let mutable x = 0uz
+        mut x = 0uz
         x++
     }
     {
-        let mutable x: c_int = 0
+        mut x: c_int = 0
         x++
     }
     {
-        let mutable x: c_char = 0
+        mut x: c_char = 0
         x++
     }
 }

--- a/tests/typechecker/missing_type_in_namespace.jakt
+++ b/tests/typechecker/missing_type_in_namespace.jakt
@@ -2,8 +2,8 @@
 /// - error: "Unknown type"
 
 extern struct StringBuilder {
-    function append(mutable this, anon s: u8)
-    function to_string(mutable this) throws -> String
+    function append(mut this, anon s: u8)
+    function to_string(mut this) throws -> String
     function StringBuilder() -> StringBuilder
 }
 
@@ -13,5 +13,5 @@ struct Lexer {
 }
 
 function main(args: [String]) {
-    let mutable tokens: [Token] = []
+    mut tokens: [Token] = []
 }

--- a/tests/typechecker/none_coalescing_assign.jakt
+++ b/tests/typechecker/none_coalescing_assign.jakt
@@ -2,7 +2,7 @@
 /// - output: "mayb\n"
 
 function main() {
-    let mutable i: String? = None
+    mut i: String? = None
     i ??= "mayb"
     println(i ?? "hello")
 }

--- a/tests/typechecker/type_predecl_visibility.jakt
+++ b/tests/typechecker/type_predecl_visibility.jakt
@@ -2,7 +2,7 @@
 /// - output: "OK\n"
 
 struct Foo {
-    function bar(mutable this, baz: mutable Bar) {
+    function bar(mut this, baz: mut Bar) {
         println("OK")
     }
 }
@@ -10,7 +10,7 @@ struct Foo {
 class Bar {}
 
 function main() {
-    let mutable foo = Foo()
+    mut foo = Foo()
     let baz = Bar()
     foo.bar(baz)
 }


### PR DESCRIPTION
After writing a couple thousand lines of Jakt, the main thing that
annoys me (other than compiler bugs) is definitely `let mutable`.
It takes up an inordinate amount of horizontal space, and I find
myself frequently "pausing" while my eyes search for the actual
identifier part of variable declarations.

To reduce this friction, this patch shortens `let mutable` to `mut`.

Likewise, `mutable` modifiers on function parameters become `mut`.