### PR TITLE
Parser: Disallow keywords to be set as names

### DIFF
--- a/tests/parser/disallow_keyword_function.jakt
+++ b/tests/parser/disallow_keyword_function.jakt
@@ -1,0 +1,10 @@
+/// Expect:
+/// - error: "expected name, found keyword"
+
+function function() {
+    println("What")
+}
+
+function main() {
+    function()
+}

--- a/tests/parser/disallow_keyword_import.jakt
+++ b/tests/parser/disallow_keyword_import.jakt
@@ -1,0 +1,7 @@
+/// Expect:
+/// - error: "expected name, found keyword"
+import cpp
+
+function main() {
+    println("What")
+}

--- a/tests/parser/disallow_keyword_import_as.jakt
+++ b/tests/parser/disallow_keyword_import_as.jakt
@@ -1,0 +1,7 @@
+/// Expect:
+/// - error: "expected name, found keyword"
+import A as throws
+
+function main() {
+    println("What")
+}

--- a/tests/parser/disallow_keyword_namespace.jakt
+++ b/tests/parser/disallow_keyword_namespace.jakt
@@ -1,0 +1,12 @@
+/// Expect:
+/// - error: "expected name, found keyword"
+
+namespace namespace {
+    function what() {
+        println("What")
+    }
+}
+
+function main() {
+    namespace::what()
+}

--- a/tests/parser/disallow_keyword_struct.jakt
+++ b/tests/parser/disallow_keyword_struct.jakt
@@ -1,0 +1,8 @@
+/// Expect:
+/// - error: "expected name, found keyword"
+
+struct unsafe {}
+
+function main() {
+    let x = unsafe()
+}

--- a/tests/parser/disallow_keyword_struct_property.jakt
+++ b/tests/parser/disallow_keyword_struct_property.jakt
@@ -1,0 +1,11 @@
+/// Expect:
+/// - error: "expected name, found keyword"
+
+struct A {
+    defer: String
+}
+
+function main() {
+    let x = A(defer: "What")
+    println("{}", x.defer)
+}

--- a/tests/parser/disallow_keyword_variable.jakt
+++ b/tests/parser/disallow_keyword_variable.jakt
@@ -1,0 +1,7 @@
+/// Expect:
+/// - error: "expected name, found keyword"
+
+function main() {
+    let i32 = "What"
+    println("{}", i32)
+}


### PR DESCRIPTION
I noticed, that the parser does not check if the name is a keyword.
Note: The error does not report on modules.
Hopefully I will solve this issue next PR.
Partially fixes https://github.com/SerenityOS/jakt/issues/545. C++ keywords are not handled yet