### PR TITLE
editors: Rename mutable to mut in vim syntax

### DIFF
--- a/editors/vim/syntax/jakt.vim
+++ b/editors/vim/syntax/jakt.vim
@@ -44,7 +44,7 @@ let s:jakt_syntax_keywords = {
     \ ,                      "as"
     \ ,                      "in"
     \ ,                     ]
-    \ , 'jaktVarDecl' :["mutable"
+    \ , 'jaktVarDecl' :["mut"
     \ ,                 "let"
     \ ,                 "anon"
     \ ,                 "raw"


### PR DESCRIPTION
Change vim syntax highlighting as well to correspond to the new Jakt syntax.