### PR TITLE
selfhost: lexer: add token for `namespace` keyword

### DIFF
--- a/selfhost/lexer.jakt
+++ b/selfhost/lexer.jakt
@@ -225,6 +225,7 @@ enum Token {
     Loop(JaktSpan)
     Match(JaktSpan)
     Mut(JaktSpan)
+    Namespace(JaktSpan)
     Not(JaktSpan)
     Or(JaktSpan)
     Private(JaktSpan)
@@ -327,6 +328,7 @@ enum Token {
         Loop(span) => span
         Match(span) => span
         Mut(span) => span
+        Namespace(span) => span
         Not(span) => span
         Or(span) => span
         Private(span) => span
@@ -370,6 +372,7 @@ enum Token {
         "loop" => Token::Loop(span)
         "match" => Token::Match(span)
         "mut" => Token::Mut(span)
+        "namespace" => Token::Namespace(span)
         "not" => Token::Not(span)
         "or" => Token::Or(span)
         "private" => Token::Private(span)


### PR DESCRIPTION
This token did not exist, so the `namespace` keword in
samples/namespaces/hello_namespace.jakt was parsed as an identifier.
Adding this token and adding it to the list of keywords fixes this.