### PR TITLE
all: Fix breakage in module imports

### DIFF
--- a/selfhost/main.jakt
+++ b/selfhost/main.jakt
@@ -1,9 +1,8 @@
-import lexer with JaktSpan, Token, JaktError, empty_span, merge_spans, Lexer, print_error
-
 /// Expect:
 /// - output: ""
 
-extern function abort()
+import lexer with JaktSpan, Token, JaktError, empty_span, merge_spans, Lexer, print_error
+
 extern struct StringBuilder {
     function append(mut this, anon s: u8)
     function to_string(mut this) throws -> String

--- a/src/codegen.rs
+++ b/src/codegen.rs
@@ -3141,7 +3141,8 @@ fn codegen_expr(
                             || type_module.id == ModuleId(0)
                             || project.get_function(function_id).linkage
                                 == FunctionLinkage::External
-                            || !call.namespace.is_empty())
+                            || (!call.namespace.is_empty()
+                                && (call.namespace[0].name == type_module.name.as_str())))
                         {
                             output.push_str(type_module.name.as_str());
                             output.push_str("::");

--- a/src/typechecker.rs
+++ b/src/typechecker.rs
@@ -1797,9 +1797,11 @@ pub fn typecheck_namespace_imports(
                                     id,
                                     imported_name.span,
                                 ) {
-                                    return Some(e);
+                                    error = error.or(Some(e));
                                 }
-                            } else if let Some(id) = project
+                            }
+
+                            if let Some(id) = project
                                 .find_enum_in_scope(import_scope_id, imported_name.name.as_str())
                             {
                                 if let Err(e) = project.add_enum_to_scope(
@@ -1808,9 +1810,11 @@ pub fn typecheck_namespace_imports(
                                     id,
                                     imported_name.span,
                                 ) {
-                                    return Some(e);
+                                    error = error.or(Some(e));
                                 }
-                            } else if let Some(id) = project
+                            }
+
+                            if let Some(id) = project
                                 .find_type_in_scope(import_scope_id, imported_name.name.as_str())
                             {
                                 if let Err(e) = project.add_type_to_scope(
@@ -1819,9 +1823,11 @@ pub fn typecheck_namespace_imports(
                                     id,
                                     imported_name.span,
                                 ) {
-                                    return Some(e);
+                                    error = error.or(Some(e));
                                 }
-                            } else if let Some(id) = project
+                            }
+
+                            if let Some(id) = project
                                 .find_struct_in_scope(import_scope_id, imported_name.name.as_str())
                             {
                                 if let Err(e) = project.add_struct_to_scope(
@@ -1830,7 +1836,7 @@ pub fn typecheck_namespace_imports(
                                     id,
                                     imported_name.span,
                                 ) {
-                                    return Some(e);
+                                    error = error.or(Some(e));
                                 }
                             }
                         }


### PR DESCRIPTION
This fixes a few breakages in module imports:

* Fix suggested improvement on the PR that I missed had subtle differences with the original. Now it no longer does early returns and imports all kinds of definitions that match the name
* codegen workaround when a call is behind a namespace and a module
* fix for selfhost unit test that didn't catch build break. Now selfhost should be again tested as a unit test