### PR TITLE
runtime: Always allocate Array storage and make Array construction throw

### DIFF
--- a/runtime/IO/File.cpp
+++ b/runtime/IO/File.cpp
@@ -42,7 +42,7 @@ ErrorOr<NonnullRefPtr<File>> File::open_for_writing(String path)
 
 ErrorOr<Array<u8>> File::read_all()
 {
-    Array<u8> entire_file;
+    auto entire_file = TRY(Array<u8>::create_empty());
 
     while (true) {
         u8 buffer[4096];

--- a/runtime/Jakt/Format.cpp
+++ b/runtime/Jakt/Format.cpp
@@ -366,7 +366,7 @@ ErrorOr<void> FormatBuilder::put_f64(
     char fill,
     SignMode sign_mode)
 {
-    StringBuilder string_builder;
+    auto string_builder = TRY(StringBuilder::create());
     FormatBuilder format_builder { string_builder };
 
     if (__builtin_isnan(value) || __builtin_isinf(value)) {
@@ -433,7 +433,7 @@ ErrorOr<void> FormatBuilder::put_f80(
     char fill,
     SignMode sign_mode)
 {
-    StringBuilder string_builder;
+    auto string_builder = TRY(StringBuilder::create());
     FormatBuilder format_builder { string_builder };
 
     if (__builtin_isnan(value) || __builtin_isinf(value)) {
@@ -625,7 +625,7 @@ ErrorOr<void> Formatter<StringView>::format(FormatBuilder& builder, StringView v
 
 ErrorOr<void> Formatter<FormatString>::vformat(FormatBuilder& builder, StringView fmtstr, TypeErasedFormatParams& params)
 {
-    StringBuilder string_builder;
+    auto string_builder = TRY(StringBuilder::create());
     TRY(Jakt::vformat(string_builder, fmtstr, params));
     TRY(Formatter<StringView>::format(builder, string_builder.string_view()));
     return {};
@@ -711,7 +711,7 @@ ErrorOr<void> Formatter<wchar_t>::format(FormatBuilder& builder, wchar_t value)
         Formatter<u32> formatter { *this };
         return formatter.format(builder, static_cast<u32>(value));
     } else {
-        StringBuilder codepoint;
+        auto codepoint = TRY(StringBuilder::create());
         codepoint.append_code_point(value);
 
         Formatter<StringView> formatter { *this };
@@ -787,7 +787,7 @@ ErrorOr<void> Formatter<float>::format(FormatBuilder& builder, float value)
 #ifndef KERNEL
 void vout(FILE* file, StringView fmtstr, TypeErasedFormatParams& params, bool newline)
 {
-    StringBuilder builder;
+    auto builder = MUST(StringBuilder::create());
     MUST(vformat(builder, fmtstr, params));
 
     if (newline)
@@ -814,7 +814,7 @@ void vdbgln(StringView fmtstr, TypeErasedFormatParams& params)
     if (!is_debug_enabled)
         return;
 
-    StringBuilder builder;
+    auto builder = MUST(StringBuilder::create());
 
 #ifdef __serenity__
 #    ifdef KERNEL
@@ -867,7 +867,7 @@ void vdbgln(StringView fmtstr, TypeErasedFormatParams& params)
 #ifdef KERNEL
 void vdmesgln(StringView fmtstr, TypeErasedFormatParams& params)
 {
-    StringBuilder builder;
+    auto builder = MUST(StringBuilder::create());
 
 #    ifdef __serenity__
     struct timespec ts = {};
@@ -897,7 +897,7 @@ void v_critical_dmesgln(StringView fmtstr, TypeErasedFormatParams& params)
     // FIXME: Try to avoid memory allocations further to prevent faulting
     // at OOM conditions.
 
-    StringBuilder builder;
+    auto builder = MUST(StringBuilder::create());
 #    ifdef __serenity__
     if (Kernel::Processor::is_initialized() && Kernel::Thread::current()) {
         auto& thread = *Kernel::Thread::current();

--- a/runtime/Jakt/String.cpp
+++ b/runtime/Jakt/String.cpp
@@ -21,7 +21,7 @@ ErrorOr<String> String::copy(StringView view)
 
 ErrorOr<String> String::vformatted(StringView fmtstr, TypeErasedFormatParams& params)
 {
-    StringBuilder builder;
+    auto builder = TRY(StringBuilder::create());
     TRY(vformat(builder, fmtstr, params));
     return builder.to_string();
 }
@@ -62,7 +62,7 @@ ErrorOr<Array<String>> String::split(char separator, bool keep_empty) const
 
 ErrorOr<Array<String>> String::split_limit(char separator, size_t limit, bool keep_empty) const
 {
-    auto v = Array<String>();
+    auto v = TRY(Array<String>::create_empty());
     if (is_empty())
         return v;
 

--- a/runtime/Jakt/String.h
+++ b/runtime/Jakt/String.h
@@ -6,6 +6,7 @@
 
 #pragma once
 
+#include <Builtins/Array.h>
 #include <Jakt/Format.h>
 #include <Jakt/Forward.h>
 #include <Jakt/NonnullRefPtr.h>
@@ -15,7 +16,6 @@
 #include <Jakt/Traits.h>
 #include <Jakt/Types.h>
 #include <Jakt/kmalloc.h>
-#include <Builtins/Array.h>
 
 namespace Jakt {
 

--- a/runtime/Jakt/StringBuilder.cpp
+++ b/runtime/Jakt/StringBuilder.cpp
@@ -18,7 +18,8 @@ inline ErrorOr<void> StringBuilder::will_append(size_t size)
     return {};
 }
 
-StringBuilder::StringBuilder()
+StringBuilder::StringBuilder(Array<u8> buffer)
+    : m_buffer(buffer)
 {
 }
 

--- a/runtime/Jakt/StringUtils.cpp
+++ b/runtime/Jakt/StringUtils.cpp
@@ -324,7 +324,7 @@ Optional<size_t> find_last(StringView haystack, char needle)
 
 ErrorOr<JaktInternal::Array<size_t>> find_all(StringView haystack, StringView needle)
 {
-    JaktInternal::Array<size_t> positions;
+    auto positions = TRY(JaktInternal::Array<size_t>::create_empty());
     size_t current_position = 0;
     while (current_position <= haystack.length()) {
         auto maybe_position = Jakt::memmem_optional(

--- a/runtime/lib.h
+++ b/runtime/lib.h
@@ -428,7 +428,7 @@ ErrorOr<int> main(Array<String>);
 
 int main(int argc, char** argv)
 {
-    Jakt::Array<Jakt::String> args;
+    auto args = MUST(Jakt::Array<Jakt::String>::create_empty());
     for (int i = 0; i < argc; ++i) {
         MUST(args.push(MUST(Jakt::String::copy(Jakt::StringView(argv[i])))));
     }

--- a/samples/apps/json.jakt
+++ b/samples/apps/json.jakt
@@ -2,7 +2,7 @@ extern struct StringBuilder {
     // FIXME: Jakt::StringBuilder::append() actually takes a c_char, not a u8, but nobody complains
     function append(mut this, anon c: u8)
     function to_string(this) throws -> String
-    function StringBuilder() -> StringBuilder
+    function create() throws -> StringBuilder
 }
 
 extern function abort()
@@ -58,7 +58,7 @@ class JsonParser {
             throw Error::from_errno(9007)
         }
 
-        mut builder = StringBuilder()
+        mut builder = StringBuilder::create()
 
         loop {
             mut ch = 0u8

--- a/samples/arrays/array_shorthand.jakt
+++ b/samples/arrays/array_shorthand.jakt
@@ -1,7 +1,7 @@
 /// Expect:
 /// - output: "foo\nbar\n"
 
-function make_v() -> [String] {
+function make_v() throws -> [String] {
     return ["foo", "bar"]
 }
 

--- a/samples/strings/string_builder.jakt
+++ b/samples/strings/string_builder.jakt
@@ -2,13 +2,13 @@
 /// - output: "abc123\n"
 
 extern struct StringBuilder {
-    function StringBuilder() -> StringBuilder
+    function create() throws -> StringBuilder
     function append(mut this, anon s: raw c_char)
     function to_string(mut this) throws -> String
 }
 
 function main() {
-    mut s = StringBuilder()
+    mut s = StringBuilder::create()
 
     s.append("abc".c_string());
     s.append("123".c_string());

--- a/selfhost/lexer.jakt
+++ b/selfhost/lexer.jakt
@@ -1,7 +1,7 @@
 extern struct StringBuilder {
     function append(mut this, anon s: u8)
     function to_string(mut this) throws -> String
-    function StringBuilder() -> StringBuilder
+    function create() throws -> StringBuilder
 }
 
 // FIXME: These should not need explicit "-> bool" return types.
@@ -424,7 +424,7 @@ struct Lexer {
     }
 
     function substring(this, start: usize, length: usize) throws -> String {
-        mut builder = StringBuilder()
+        mut builder = StringBuilder::create()
         for i in start..length {
             builder.append(.input[i])
         }
@@ -461,7 +461,7 @@ struct Lexer {
         }
 
         // Everything but the quotes
-        mut builder = StringBuilder()
+        mut builder = StringBuilder::create()
         builder.append(.input[start + 1])
         let str = builder.to_string()
 
@@ -494,7 +494,7 @@ struct Lexer {
             let end = .index
             return Token::Number(number: total, span: Span(start, end))
         } else if is_ascii_alpha(.peek()) or .peek() == b'_' {
-            mut string_builder = StringBuilder()
+            mut string_builder = StringBuilder::create()
 
             while is_ascii_alphanumeric(.peek()) or .peek() == b'_' {
                 let value = .input[.index]

--- a/src/codegen.rs
+++ b/src/codegen.rs
@@ -1260,7 +1260,7 @@ fn codegen_enum_debug_description_getter(enum_: &CheckedEnum) -> String {
     let mut output = String::new();
     output.push_str("ErrorOr<String> debug_description() const { ");
 
-    output.push_str("StringBuilder builder;");
+    output.push_str("auto builder = TRY(StringBuilder::create());");
 
     output.push_str("this->visit(");
 
@@ -1321,7 +1321,7 @@ fn codegen_debug_description_getter(structure: &CheckedStruct, project: &Project
     let mut output = String::new();
     output.push_str("ErrorOr<String> debug_description() const { ");
 
-    output.push_str("StringBuilder builder;");
+    output.push_str("auto builder = MUST(StringBuilder::create());");
 
     output.push_str(&format!("builder.append(\"{}(\");", structure.name));
 
@@ -3562,9 +3562,9 @@ fn codegen_expr(
                 output.push_str(")))");
             } else {
                 // (Array({1, 2, 3}))
-                output.push_str("(Array<");
+                output.push_str("(TRY(Array<");
                 output.push_str(&codegen_type(value_type_id, project));
-                output.push_str(">({");
+                output.push_str(">::create_with({");
                 let mut first = true;
                 for val in vals {
                     if !first {
@@ -3575,7 +3575,7 @@ fn codegen_expr(
 
                     output.push_str(&codegen_expr(indent, val, project, context))
                 }
-                output.push_str("}))");
+                output.push_str("})))");
             }
         }
         CheckedExpression::Dictionary(vals, _, type_id) => {

--- a/tests/typechecker/missing_type_in_namespace.jakt
+++ b/tests/typechecker/missing_type_in_namespace.jakt
@@ -4,7 +4,7 @@
 extern struct StringBuilder {
     function append(mut this, anon s: u8)
     function to_string(mut this) throws -> String
-    function StringBuilder() -> StringBuilder
+    function create() throws -> StringBuilder
 }
 
 namespace lexer {


### PR DESCRIPTION
Since arrays have reference semantics, we have to ensure they always
have storage, or passing an empty array to a function that causes it
to allocate storage would not have those changes reflected in the
calling function.