### PR TITLE
selfhost: Simplify main() somewhat + add copyright headers

### DIFF
--- a/selfhost/lexer.jakt
+++ b/selfhost/lexer.jakt
@@ -1,3 +1,8 @@
+// Copyright (c) 2022, JT <jt@serenityos.org>
+// Copyright (c) 2022, Andreas Kling <kling@serenityos.org>
+//
+// SPDX-License-Identifier: BSD-2-Clause
+
 extern struct StringBuilder {
     function append(mut this, anon s: u8)
     function to_string(mut this) throws -> String

--- a/selfhost/lexer.jakt
+++ b/selfhost/lexer.jakt
@@ -398,6 +398,17 @@ struct Lexer {
     input: [u8]
     errors: [JaktError]
 
+    function lex(input: [u8], errors: [JaktError]) throws -> [Token] {
+        mut lexer = Lexer(index: 0, input, errors)
+        mut tokens: [Token] = []
+
+        for token in lexer {
+            tokens.push(token)
+        }
+
+        return tokens
+    }
+
     function error(mut this, anon message: String, anon span: Span) throws {
         .errors.push(JaktError::Message(message, span))
     }

--- a/selfhost/main.jakt
+++ b/selfhost/main.jakt
@@ -1,6 +1,11 @@
 /// Expect:
 /// - output: ""
 
+// Copyright (c) 2022, JT <jt@serenityos.org>
+// Copyright (c) 2022, Andreas Kling <kling@serenityos.org>
+//
+// SPDX-License-Identifier: BSD-2-Clause
+
 import lexer with Span, Token, JaktError, empty_span, merge_spans, Lexer, print_error
 import parser with Parser, ParsedCall, ParsedExpression, BinaryOperator, DefinitionLinkage, DefinitionType
 import utility with panic, todo

--- a/selfhost/main.jakt
+++ b/selfhost/main.jakt
@@ -14,27 +14,19 @@ function main(args: [String]) {
     mut file = File::open_for_reading(args[1])
     let file_contents = file.read_all()
 
-    mut lexer = Lexer(index: 0, input: file_contents, errors: [])
-    mut tokens: [Token] = []
+    mut errors: [JaktError] = []
 
-    for token in lexer {
-        println("token: {}", token)
-        tokens.push(token)
-    }
+    let tokens = Lexer::lex(input: file_contents, errors)
 
-    mut parser = Parser(index: 0, tokens, errors: [])
+    mut parser = Parser(index: 0, tokens, errors)
 
     let parsed_namespace = parser.parse_namespace()
 
-    for error in lexer.errors.iterator() {
+    for error in errors.iterator() {
         print_error(file_name: args[1], file_contents, error)
     }
 
-    for error in parser.errors.iterator() {
-        print_error(file_name: args[1], file_contents, error)
-    }
-
-    if not lexer.errors.is_empty() or not parser.errors.is_empty() {
+    if not errors.is_empty() {
         return 1
     }
 

--- a/selfhost/parser.jakt
+++ b/selfhost/parser.jakt
@@ -1,3 +1,8 @@
+// Copyright (c) 2022, JT <jt@serenityos.org>
+// Copyright (c) 2022, Andreas Kling <kling@serenityos.org>
+//
+// SPDX-License-Identifier: BSD-2-Clause
+
 import lexer with Token, Span, merge_spans, empty_span, JaktError
 import utility with panic, todo
 

--- a/selfhost/utility.jakt
+++ b/selfhost/utility.jakt
@@ -1,3 +1,8 @@
+// Copyright (c) 2022, JT <jt@serenityos.org>
+// Copyright (c) 2022, Andreas Kling <kling@serenityos.org>
+//
+// SPDX-License-Identifier: BSD-2-Clause
+
 function panic(anon message: String) -> void {
     eprintln("internal error: {}", message)
     abort()


### PR DESCRIPTION
- Add a Lexer::lex() helper function that gives you back an array of tokens.
- Create a single array to contain errors and have the lexer and parser fill it with errors.

And also...
- Add copyright headers to self-hosted compiler
As always, everyone is encouraged to add themselves when making substantial contributions to the code. :^)
