### PR TITLE
parser: Tweak `import` syntax to use curlies for import lists

### DIFF
--- a/selfhost/main.jakt
+++ b/selfhost/main.jakt
@@ -6,9 +6,9 @@
 //
 // SPDX-License-Identifier: BSD-2-Clause
 
-import lexer with Span, Token, JaktError, empty_span, merge_spans, Lexer, print_error
-import parser with Parser, ParsedCall, ParsedExpression, BinaryOperator, DefinitionLinkage, DefinitionType
-import utility with panic, todo
+import lexer { JaktError, Lexer, Span, Token, empty_span, merge_spans, print_error }
+import parser { BinaryOperator, DefinitionLinkage, DefinitionType, ParsedCall, ParsedExpression, Parser }
+import utility { panic, todo }
 
 function main(args: [String]) {
     if args.size() <= 1 {

--- a/selfhost/parser.jakt
+++ b/selfhost/parser.jakt
@@ -3,8 +3,8 @@
 //
 // SPDX-License-Identifier: BSD-2-Clause
 
-import lexer with Token, Span, merge_spans, empty_span, JaktError
-import utility with panic, todo
+import lexer { JaktError, Span, Token, empty_span, merge_spans }
+import utility { panic, todo }
 
 enum DefinitionLinkage {
     Internal

--- a/selfhost/typechecker.jakt
+++ b/selfhost/typechecker.jakt
@@ -1,6 +1,6 @@
-import lexer with Span, JaktError
-import parser with ParsedExpression, ParsedCall, BinaryOperator, DefinitionLinkage, DefinitionType
-import utility with panic, todo
+import lexer { JaktError, Span }
+import parser { BinaryOperator, DefinitionLinkage, DefinitionType, ParsedExpression, ParsedCall }
+import utility { panic, todo }
 
 struct ModuleId {
     id: usize


### PR DESCRIPTION
This gets rid of the awkward "with" that was previously used to mark
the start of an import list. The list is now wrapped in curlies instead.

The module is specified first, to allow IDE auto-completion to provide
relevant suggestions as soon as possible.

Before:

    import module with symbol1, symbol2

After:

    import module { symbol1, symbol2 }