### PR TITLE
selfhost/lexer+parser: Add support for parsing typecasts

### DIFF
--- a/selfhost/lexer.jakt
+++ b/selfhost/lexer.jakt
@@ -209,6 +209,7 @@ enum Token {
     // Keywords
     And(Span)
     Anon(Span)
+    As(Span)
     Boxed(Span)
     Break(Span)
     Catch(Span)
@@ -313,6 +314,7 @@ enum Token {
         FatArrow(span) => span
         And(span) => span
         Anon(span) => span
+        As(span) => span
         Boxed(span) => span
         Break(span) => span
         Catch(span) => span
@@ -356,6 +358,7 @@ enum Token {
     function from_keyword_or_identifier(string: String, span: Span) => match string {
         "and" => Token::And(span)
         "anon" => Token::Anon(span)
+        "as" => Token::As(span)
         "boxed" => Token::Boxed(span)
         "break" => Token::Break(span)
         "catch" => Token::Catch(span)

--- a/selfhost/parser.jakt
+++ b/selfhost/parser.jakt
@@ -154,6 +154,11 @@ enum BinaryOperator {
     }
 }
 
+enum TypeCast {
+    Fallible(ParsedType)
+    Infallible(ParsedType)
+}
+
 enum UnaryOperator {
     PreIncrement
     PostIncrement
@@ -164,6 +169,7 @@ enum UnaryOperator {
     RawAddress
     LogicalNot
     BitwiseNot
+    TypeCast(TypeCast)
     Is(ParsedType)
 }
 
@@ -1524,6 +1530,30 @@ struct Parser {
                     expr,
                     op: UnaryOperator::PostDecrement,
                     span: merge_spans(start, .previous().span()),
+                )
+            }
+            As => {
+                .index++
+                let cast_span = merge_spans(.previous().span(), .current().span())
+                let cast = match .current() {
+                    ExclamationPoint => {
+                        .index++
+                        yield TypeCast::Infallible(.parse_typename())
+                    }
+                    QuestionMark => {
+                        .index++
+                        yield TypeCast::Fallible(.parse_typename())
+                    }
+                    else => {
+                        .error("Invalid cast syntax", cast_span)
+                        yield TypeCast::Fallible(ParsedType::Empty)
+                    }
+                }
+                let span = merge_spans(start, merge_spans(cast_span, .current().span()))
+                yield ParsedExpression::UnaryOp(
+                    expr,
+                    op: UnaryOperator::TypeCast(cast),
+                    span
                 )
             }
             Is => {


### PR DESCRIPTION
A new token for the `as` keyword is added, and the parser is adjusted
to recognize it during the check for postfix operators. A new UnaryOperator
Typecast is added to represent the result of parsing.