### PR TITLE
selfhost: Add basic CLI to selfhosted compiler

### DIFF
--- a/selfhost/main.jakt
+++ b/selfhost/main.jakt
@@ -10,22 +10,76 @@ import lexer { JaktError, Lexer, Span, Token, empty_span, merge_spans, print_err
 import parser { BinaryOperator, DefinitionLinkage, DefinitionType, ParsedCall, ParsedExpression, Parser }
 import utility { panic, todo }
 
+function usage() {
+    eprintln("usage: jakt [-l] [-p] <path>")
+    return 1
+}
+
 function main(args: [String]) {
     if args.size() <= 1 {
-        eprintln("usage: jakt <path>")
-        return 1
+        return usage()
+    }
+    mut lexer_debug = false
+    mut parser_debug = false
+    mut file_name: String? = None
+    mut first_arg = true
+    for arg in args.iterator() {
+        if first_arg {
+            first_arg = false
+            continue
+        }
+        match arg {
+            "-l" => {
+                if lexer_debug {
+                    eprintln("you can only have the -l option once")
+                    return usage()
+                } else {
+                    lexer_debug = true
+                }
+            }
+            "-p" => {
+                if parser_debug {
+                    eprintln("you can only have the -p option once")
+                    return usage()
+                } else {
+                    parser_debug = true
+                }
+            }
+            else => {
+                if file_name.has_value() {
+                    eprintln("you can only pass one file")
+                    return usage()
+                } else {
+                    file_name = arg
+                }
+            }
+        }
+    }
+    if not file_name.has_value() {
+        eprintln("you must pass a source file")
+        return usage()
     }
 
-    mut file = File::open_for_reading(args[1])
+    mut file = File::open_for_reading(file_name!)
     let file_contents = file.read_all()
 
     mut errors: [JaktError] = []
 
     let tokens = Lexer::lex(input: file_contents, errors)
 
+    if lexer_debug {
+        for token in tokens.iterator() {
+            println("token: {}", token)
+        }
+    }
+
     mut parser = Parser(index: 0, tokens, errors)
 
     let parsed_namespace = parser.parse_namespace()
+
+    if parser_debug {
+        println("parsed namespace: {}", parsed_namespace)
+    }
 
     for error in errors.iterator() {
         print_error(file_name: args[1], file_contents, error)
@@ -34,6 +88,4 @@ function main(args: [String]) {
     if not errors.is_empty() {
         return 1
     }
-
-    println("{}", parsed_namespace)
 }

--- a/selfhost/parser.jakt
+++ b/selfhost/parser.jakt
@@ -1219,7 +1219,6 @@ struct Parser {
     }
 
     function parse_statement(mut this, inside_block: bool) throws -> ParsedStatement {
-        println("parse_statement: {}", .current())
         let start = .current().span()
 
         return match .current() {
@@ -1493,7 +1492,6 @@ struct Parser {
                         match name {
                             "Some" => {
                                 .index++
-                                println("{}", .current())
                                 let expr = .parse_expression(allow_assignments: false)
                                 return ParsedExpression::OptionalSome(expr, span)
                             }


### PR DESCRIPTION
You can now re-enable dumping the tokens from the lexer, using the `-l`
flag, and for consistency's sake the dumping of the final parsed
namespace is also toggled by a flag (`-p`).

If neither option is passed, then the compiler simply prints nothing and
returns zero if it was successful, or prints the errors and returns one if
there were issues with the code.