### PR TITLE
vscode: Add syntax highlighting for "import" and "as"

### DIFF
--- a/editors/vscode/syntaxes/jakt.tmLanguage.json
+++ b/editors/vscode/syntaxes/jakt.tmLanguage.json
@@ -756,6 +756,14 @@
           "match": "\\b(return|throw|continue|break|yield)\\b"
         },
         {
+          "name": "keyword.control.other.jakt",
+          "match": "\\b(as)\\b\\s"
+        },
+        {
+          "name": "keyword.control.other.jakt",
+          "match": "\\b(import)\\b"
+        },
+        {
           "name": "meta.control.match.jakt",
           "begin": "(?<=match.*?)(\\{)",
           "beginCaptures": {


### PR DESCRIPTION
Should work with the current `as?` and `as!` highlighting.