### PR TITLE
runtime+tests: Fix and test the apps

### DIFF
--- a/runtime/prelude.jakt
+++ b/runtime/prelude.jakt
@@ -104,3 +104,12 @@ extern class File {
 extern function abort()
 extern function as_saturated<U, T>(anon input: T) -> U
 extern function as_truncated<U, T>(anon input: T) -> U
+
+// FIXME: Remove from prelude once extern C functions are working again
+extern struct FILE {}
+
+extern function fopen(anon str: raw c_char, anon mode: raw c_char) -> raw FILE
+extern function fgetc(anon file: mut raw FILE) -> c_int
+extern function fclose(anon file: mut raw FILE) -> c_int
+extern function feof(anon file: mut raw FILE) -> c_int
+extern function putchar(anon ch: c_int) -> c_int

--- a/samples/apps/cat-std.jakt
+++ b/samples/apps/cat-std.jakt
@@ -1,3 +1,6 @@
+/// Expect:
+/// - stderr: "usage: cat <path>\n"
+
 function main(args: [String]) {
     if args.size() <= 1 {
         eprintln("usage: cat <path>")

--- a/samples/apps/cat.jakt
+++ b/samples/apps/cat.jakt
@@ -1,10 +1,5 @@
-extern struct FILE {}
-
-extern function fopen(anon str: raw c_char, anon mode: raw c_char) -> raw FILE
-extern function fgetc(anon file: mut raw FILE) -> c_int
-extern function fclose(anon file: mut raw FILE) -> c_int
-extern function feof(anon file: mut raw FILE) -> c_int
-extern function putchar(anon ch: c_int) -> c_int
+/// Expect:
+/// - stderr: "usage: cat <path>\n"
 
 function main(args: [String]) {
     if args.size() <= 1 {

--- a/samples/apps/crc32.jakt
+++ b/samples/apps/crc32.jakt
@@ -1,10 +1,5 @@
-extern struct FILE {}
-
-extern function fopen(anon str: raw c_char, anon mode: raw c_char) -> raw FILE
-extern function fgetc(anon file: mut raw FILE) -> c_int
-extern function fclose(anon file: mut raw FILE) -> c_int
-extern function feof(anon file: mut raw FILE) -> c_int
-extern function putchar(anon ch: c_int) -> c_int
+/// Expect:
+/// - stderr: "usage: crc32 <path>\n"
 
 function make_lookup_table() throws -> [u32] {
     mut data = [0u32; 256]
@@ -32,7 +27,7 @@ function main(args: [String]) {
     defer fclose(file)
 
     let table = make_lookup_table()
-    
+
     mut state = 0xffffffffu32
     mut c = fgetc(file)
     while feof(file) == 0 {

--- a/samples/apps/json.jakt
+++ b/samples/apps/json.jakt
@@ -1,11 +1,12 @@
+/// Expect:
+/// - output: "JsonValue::Object([\"foo\": JsonValue::Number(123), \"bar\": JsonValue::Number(456)])\n"
+
 extern struct StringBuilder {
     // FIXME: Jakt::StringBuilder::append() actually takes a c_char, not a u8, but nobody complains
     function append(mut this, anon c: u8)
     function to_string(this) throws -> String
     function create() throws -> StringBuilder
 }
-
-extern function abort()
 
 enum JsonValue {
     Null

--- a/tests/main.rs
+++ b/tests/main.rs
@@ -20,6 +20,7 @@ static COMMON_ARGS: &[&str] = &[
     "runtime",
     "-std=c++20",
     "-Wno-user-defined-literals",
+    "-Wno-unqualified-std-cast-call",
     "-DJAKT_CONTINUE_ON_PANIC",
 ];
 
@@ -453,4 +454,9 @@ fn test_modules() -> Result<(), JaktError> {
 #[test]
 fn test_selfhost() -> Result<(), JaktError> {
     test_samples("selfhost")
+}
+
+#[test]
+fn test_apps() -> Result<(), JaktError> {
+    test_samples("samples/apps")
 }


### PR DESCRIPTION
This PR allows `cat.jakt`, `crc32.jakt`, and `json.jakt` to compile & run again. It also now tests that these apps at least compile and output their help message. 
