### PR TITLE
editors/nano: Enhance string syntax highlighting

### DIFF
--- a/editors/nano/jakt.nanorc
+++ b/editors/nano/jakt.nanorc
@@ -15,7 +15,7 @@ color magenta "[A-Z][A-Z_0-9]+"
 color magenta "[A-Z][A-Za-z0-9]+"
 
 # Strings
-color green "".*""
+color green ""(\\.|[^"])*""
 
 # Comments
 color blue "//.*"


### PR DESCRIPTION
The previous syntax highlighting regex was exceeding the string
quotes, which made the variables or function names have the same
color as the string. With this change the color for string syntax
highlighting remains inside the quotes as it should.