### PR TITLE
selfhost/parser: Support comma in import list

### DIFF
--- a/selfhost/parser.jakt
+++ b/selfhost/parser.jakt
@@ -531,6 +531,9 @@ struct Parser {
                 Identifier(name, span) => {
                     parsed_import.import_list.push(ImportName(name, span))
                     .index++
+                    if .current() is Comma {
+                      .index++
+                    }
                 }
                 Comma => {
                     .index++


### PR DESCRIPTION
Quick change to make parser recognize a comma after an import list name.
