### PR TITLE
editor/vscode: Fix collition of generic argument opening and any `<`

### DIFF
--- a/editors/vscode/syntaxes/jakt.tmLanguage.json
+++ b/editors/vscode/syntaxes/jakt.tmLanguage.json
@@ -492,7 +492,7 @@
         },
         {
           "name": "meta.function.generic-arguments.jakt",
-          "begin": "(?<=function.*?)(<)",
+          "begin": "(?<=function\\s+(\\w)*?)(<)",
           "beginCaptures": {
             "1": {
               "name": "punctuation.begin.angle-bracket.jakt"


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/41299302/172512646-40cab896-a8c9-4813-bae3-309a31b67b44.png)

This small change fixes a syntax highlighting issue in vscode. As shown in the image, the second function keyword previously didn't get highlighted correctly. This happened because with the rule `(?<=function.*?)(<)` the gerneric-aguments list started at the operator `<`, since we match everything with the `.` up until this point. There is no `>`, so we also never exit the (non-existent) generic argument list.