### PR TITLE
editors/vim: Add installation directions for `vim-plug`

### DIFF
--- a/editors/vim/README.md
+++ b/editors/vim/README.md
@@ -1,7 +1,12 @@
 # Vim syntax highlighting for Jakt
 
-**Install**
+**Install Manually**
 
 Copy or symlink `/path/to/jakt/editors/vim` directory to the vim plugins
 directory, which is either `~/.vim/pack/plugins/start/` for vim or
 `~/.local/share/nvim/site/pack/plugins/start/` for neovim.
+
+**Install with [vim-plug](https://github.com/junegunn/vim-plug)**
+
+ 1. Add `Plug 'SerenityOS/jakt', { 'rtp': 'editors/vim' }` to your .vimrc
+ 2. Run `:PlugInstall`


### PR DESCRIPTION
Many folks use a package manager like vim-plug these days, it's
much easier to maintain a portable vim config this way as well.

Lets provide instructions on how to use one with the Jakt vim plugin.