### PR TITLE
selfhost: Add `error.jakt` file and move error code there

### DIFF
--- a/selfhost/error.jakt
+++ b/selfhost/error.jakt
@@ -1,0 +1,124 @@
+import utility { Span }
+
+enum JaktError {
+    Message(message: String, span: Span)
+    MessageWithHint(message: String, span: Span, hint: String, hint_span: Span)
+}
+
+function print_error(file_name: String, file_contents: [u8], error: JaktError) throws {
+    match error {
+        Message(message, span) => {
+            display_message_with_span(MessageSeverity::Error, file_name, file_contents, message, span)
+        }
+        MessageWithHint(message, span, hint, hint_span) => {
+            display_message_with_span(MessageSeverity::Error, file_name, file_contents, message, span)
+            display_message_with_span(MessageSeverity::Hint, file_name, file_contents, message: hint, span: hint_span)
+        }
+    }
+}
+
+enum MessageSeverity {
+    Hint
+    Error
+}
+
+function severity_name(severity: MessageSeverity) throws => match severity {
+    Hint => "Hint"
+    Error => "Error"
+}
+
+function ansi_color_code(severity: MessageSeverity) throws => match severity {
+    Hint => "94"  // Bright Blue
+    Error => "31" // Red
+}
+
+function display_message_with_span(anon severity: MessageSeverity, file_name: String, file_contents: [u8], message: String, span: Span) throws {
+    println("{}: {}", severity_name(severity), message)
+
+    let line_spans = gather_line_spans(file_contents)
+
+    mut line_index = 1uz
+    let largest_line_number = line_spans.size()
+
+    let width = format("{}", largest_line_number).length()
+
+    while line_index < line_spans.size() {
+        if span.start >= line_spans[line_index].0 and span.start <= line_spans[line_index].1 {
+            let column_index = span.start - line_spans[line_index].0
+
+            println("----- \u001b[33m{}:{}:{}\u001b[0m", file_name, line_index + 1, column_index + 1)
+
+            if line_index > 0 {
+                print_source_line(severity, file_contents, file_span: line_spans[line_index - 1], error_span: span, line_number: line_index, largest_line_number)
+            }
+
+            print_source_line(severity, file_contents, file_span: line_spans[line_index], error_span: span, line_number: line_index + 1, largest_line_number)
+
+            for x in 0..(span.start - line_spans[line_index].0 + width + 4) {
+                print(" ")
+            }
+
+            println("\u001b[{}m^- {}\u001b[0m", ansi_color_code(severity), message)
+
+            while line_index < line_spans.size() and span.end > line_spans[line_index].0 {
+                ++line_index
+                if line_index >= line_spans.size() {
+                    break
+                }
+
+                print_source_line(severity, file_contents, file_span: line_spans[line_index], error_span: span, line_number: line_index + 1, largest_line_number)
+
+                break
+            }
+        } else {
+            ++line_index
+        }
+
+    }
+    println("\u001b[0m-----")
+}
+
+function print_source_line(severity: MessageSeverity, file_contents: [u8], file_span: (usize, usize), error_span: Span, line_number: usize, largest_line_number: usize) throws {
+    mut index = file_span.0
+
+    let width = format("{}", largest_line_number).length()
+
+    print(" {} | ", line_number)
+
+    while index <= file_span.1 {
+        mut c = b' '
+        if index < file_span.1 {
+            c = file_contents[index]
+        } else if error_span.start == error_span.end and index == error_span.start {
+            c = b'_'
+        }
+
+        if (index >= error_span.start and index < error_span.end) or (error_span.start == error_span.end and index == error_span.start) {
+            print("\u001b[{}m{:c}", ansi_color_code(severity), c)
+        } else {
+            print("\u001b[0m{:c}", c)
+        }
+
+        ++index
+    }
+    println("")
+}
+
+function gather_line_spans(file_contents: [u8]) throws -> [(usize, usize)] {
+    mut idx = 0uz
+    mut output: [(usize, usize)] = []
+
+    mut start = idx
+    while idx < file_contents.size() {
+        if file_contents[idx] == b'\n' {
+            output.push((start, idx))
+            start = idx + 1
+        }
+        idx += 1
+    }
+    if start < idx {
+        output.push((start, idx))
+    }
+
+    return output
+}

--- a/selfhost/lexer.jakt
+++ b/selfhost/lexer.jakt
@@ -3,6 +3,9 @@
 //
 // SPDX-License-Identifier: BSD-2-Clause
 
+import error { JaktError }
+import utility { Span }
+
 extern struct StringBuilder {
     function append(mut this, anon s: u8)
     function to_string(mut this) throws -> String
@@ -14,137 +17,6 @@ function is_ascii_alpha(anon c: u8) -> bool => (c >= b'a' and c <= b'z') or (c >
 function is_ascii_digit(anon c: u8) -> bool => (c >= b'0' and c <= b'9')
 function is_ascii_hexdigit(anon c: u8) -> bool => (c >= b'0' and c <= b'9') or (c >= b'a' and c <= b'f') or (c >= b'A' and c <= b'F')
 function is_ascii_alphanumeric(anon c: u8) -> bool => is_ascii_alpha(c) or is_ascii_digit(c)
-
-enum JaktError {
-    Message(message: String, span: Span)
-    MessageWithHint(message: String, span: Span, hint: String, hint_span: Span)
-}
-
-function print_error(file_name: String, file_contents: [u8], error: JaktError) throws {
-    match error {
-        Message(message, span) => {
-            display_message_with_span(MessageSeverity::Error, file_name, file_contents, message, span)
-        }
-        MessageWithHint(message, span, hint, hint_span) => {
-            display_message_with_span(MessageSeverity::Error, file_name, file_contents, message, span)
-            display_message_with_span(MessageSeverity::Hint, file_name, file_contents, message: hint, span: hint_span)
-        }
-    }
-}
-
-enum MessageSeverity {
-    Hint
-    Error
-}
-
-function severity_name(severity: MessageSeverity) throws => match severity {
-    Hint => "Hint"
-    Error => "Error"
-}
-
-function ansi_color_code(severity: MessageSeverity) throws => match severity {
-    Hint => "94"  // Bright Blue
-    Error => "31" // Red
-}
-
-function display_message_with_span(anon severity: MessageSeverity, file_name: String, file_contents: [u8], message: String, span: Span) throws {
-    println("{}: {}", severity_name(severity), message)
-
-    let line_spans = gather_line_spans(file_contents)
-
-    mut line_index = 1uz
-    let largest_line_number = line_spans.size()
-
-    let width = format("{}", largest_line_number).length()
-
-    while line_index < line_spans.size() {
-        if span.start >= line_spans[line_index].0 and span.start <= line_spans[line_index].1 {
-            let column_index = span.start - line_spans[line_index].0
-
-            println("----- \u001b[33m{}:{}:{}\u001b[0m", file_name, line_index + 1, column_index + 1)
-
-            if line_index > 0 {
-                print_source_line(severity, file_contents, file_span: line_spans[line_index - 1], error_span: span, line_number: line_index, largest_line_number)
-            }
-
-            print_source_line(severity, file_contents, file_span: line_spans[line_index], error_span: span, line_number: line_index + 1, largest_line_number)
-
-            for x in 0..(span.start - line_spans[line_index].0 + width + 4) {
-                print(" ")
-            }
-
-            println("\u001b[{}m^- {}\u001b[0m", ansi_color_code(severity), message)
-
-            while line_index < line_spans.size() and span.end > line_spans[line_index].0 {
-                ++line_index
-                if line_index >= line_spans.size() {
-                    break
-                }
-
-                print_source_line(severity, file_contents, file_span: line_spans[line_index], error_span: span, line_number: line_index + 1, largest_line_number)
-
-                break
-            }
-        } else {
-            ++line_index
-        }
-
-    }
-    println("\u001b[0m-----")
-}
-
-function print_source_line(severity: MessageSeverity, file_contents: [u8], file_span: (usize, usize), error_span: Span, line_number: usize, largest_line_number: usize) throws {
-    mut index = file_span.0
-
-    let width = format("{}", largest_line_number).length()
-
-    print(" {} | ", line_number)
-
-    while index <= file_span.1 {
-        mut c = b' '
-        if index < file_span.1 {
-            c = file_contents[index]
-        } else if error_span.start == error_span.end and index == error_span.start {
-            c = b'_'
-        }
-
-        if (index >= error_span.start and index < error_span.end) or (error_span.start == error_span.end and index == error_span.start) {
-            print("\u001b[{}m{:c}", ansi_color_code(severity), c)
-        } else {
-            print("\u001b[0m{:c}", c)
-        }
-
-        ++index
-    }
-    println("")
-}
-
-function gather_line_spans(file_contents: [u8]) throws -> [(usize, usize)] {
-    mut idx = 0uz
-    mut output: [(usize, usize)] = []
-
-    mut start = idx
-    while idx < file_contents.size() {
-        if file_contents[idx] == b'\n' {
-            output.push((start, idx))
-            start = idx + 1
-        }
-        idx += 1
-    }
-    if start < idx {
-        output.push((start, idx))
-    }
-
-    return output
-}
-
-struct Span {
-    start: usize
-    end: usize
-}
-
-function merge_spans(anon start: Span, anon end: Span) -> Span => Span(start: start.start, end: end.end)
-function empty_span() -> Span => Span(start: 0, end: 0)
 
 enum Token {
     SingleQuotedString(quote: String, span: Span)

--- a/selfhost/main.jakt
+++ b/selfhost/main.jakt
@@ -6,9 +6,10 @@
 //
 // SPDX-License-Identifier: BSD-2-Clause
 
-import lexer { JaktError, Lexer, Span, Token, empty_span, merge_spans, print_error }
+import error { JaktError, print_error }
+import lexer { Lexer, Token }
 import parser { BinaryOperator, DefinitionLinkage, DefinitionType, ParsedCall, ParsedExpression, Parser }
-import utility { panic, todo }
+import utility { panic, todo, Span }
 
 function usage() {
     eprintln("usage: jakt [-l] [-p] <path>")

--- a/selfhost/parser.jakt
+++ b/selfhost/parser.jakt
@@ -3,8 +3,12 @@
 //
 // SPDX-License-Identifier: BSD-2-Clause
 
-import lexer { JaktError, Span, Token, empty_span, merge_spans }
-import utility { panic, todo }
+import error { JaktError }
+import lexer { Token }
+import utility { panic, todo, Span }
+
+function merge_spans(anon start: Span, anon end: Span) -> Span => Span(start: start.start, end: end.end)
+function empty_span() -> Span => Span(start: 0, end: 0)
 
 enum DefinitionLinkage {
     Internal

--- a/selfhost/typechecker.jakt
+++ b/selfhost/typechecker.jakt
@@ -1,6 +1,6 @@
-import lexer { JaktError, Span }
+import error { JaktError }
 import parser { BinaryOperator, DefinitionLinkage, DefinitionType, ParsedExpression, ParsedCall, ParsedType }
-import utility { panic, todo }
+import utility { panic, todo, Span }
 
 struct ModuleId {
     id: usize

--- a/selfhost/utility.jakt
+++ b/selfhost/utility.jakt
@@ -12,3 +12,8 @@ function todo(anon message: String) {
     eprintln("TODO: {}", message)
     abort()
 }
+
+struct Span {
+    start: usize
+    end: usize
+}


### PR DESCRIPTION
Similar to `error.rs` in the boostrap compiler `error.jakt` contains
the code for the `JaktError` enum and for printing error messages.

This code was cluttering up the top of `lexer.jakt` so it is much
nicer to have a proper home for it.

Note: this did require moving the `Span` struct out of the lexer.
Since the error code and lexer both need the span, and the lexer
also needs the error code, `Span` was moved into `utility.jakt`
at least for the time being until we are able to handle circular
imports. Not completely ideal, but I think the improvements to
`lexer.jakt` are worth it.