### PR TITLE
selfhost/error: Use member instead of free functions for `MessageSeverity`

### DIFF
--- a/selfhost/error.jakt
+++ b/selfhost/error.jakt
@@ -20,20 +20,18 @@ function print_error(file_name: String, file_contents: [u8], error: JaktError) t
 enum MessageSeverity {
     Hint
     Error
-}
-
-function severity_name(severity: MessageSeverity) throws => match severity {
-    Hint => "Hint"
-    Error => "Error"
-}
-
-function ansi_color_code(severity: MessageSeverity) throws => match severity {
-    Hint => "94"  // Bright Blue
-    Error => "31" // Red
+    public function name(this) throws => match this {
+        Hint => "Hint"
+        Error => "Error"
+    }
+    public function ansi_color_code(this) throws => match this {
+        Hint => "94"  // Bright Blue
+        Error => "31" // Red
+    }
 }
 
 function display_message_with_span(anon severity: MessageSeverity, file_name: String, file_contents: [u8], message: String, span: Span) throws {
-    println("{}: {}", severity_name(severity), message)
+    println("{}: {}", severity.name(), message)
 
     let line_spans = gather_line_spans(file_contents)
 
@@ -58,7 +56,7 @@ function display_message_with_span(anon severity: MessageSeverity, file_name: St
                 print(" ")
             }
 
-            println("\u001b[{}m^- {}\u001b[0m", ansi_color_code(severity), message)
+            println("\u001b[{}m^- {}\u001b[0m", severity.ansi_color_code(), message)
 
             while line_index < line_spans.size() and span.end > line_spans[line_index].0 {
                 ++line_index
@@ -94,7 +92,7 @@ function print_source_line(severity: MessageSeverity, file_contents: [u8], file_
         }
 
         if (index >= error_span.start and index < error_span.end) or (error_span.start == error_span.end and index == error_span.start) {
-            print("\u001b[{}m{:c}", ansi_color_code(severity), c)
+            print("\u001b[{}m{:c}", severity.ansi_color_code(), c)
         } else {
             print("\u001b[0m{:c}", c)
         }


### PR DESCRIPTION
The error code was written before enums supported member functions.
the `severity_name` and `ansi_color_code` functions were clearly
meant to be members of the `MessageSeverity` enum. Now that such
functions are supported, lets use them :^)