### PR TITLE
selfhost/parser: Implement some `todo()`s

### DIFF
--- a/samples/generics/generic_static_with_explicit_types.jakt
+++ b/samples/generics/generic_static_with_explicit_types.jakt
@@ -1,0 +1,12 @@
+/// Expect:
+/// - output: "1\n"
+
+struct Test {
+    function test<T>(foo: T) -> T {
+        return foo;
+    }
+}
+
+function main() {
+    println("{}", Test::test<i64>(foo: 1));
+}

--- a/samples/tuples/namespaced_values.jakt
+++ b/samples/tuples/namespaced_values.jakt
@@ -1,0 +1,16 @@
+/// Expect:
+/// - output: "Trogdor burninated 1337 peasants\n"
+
+namespace Kingdom {
+    namespace Dragons {
+        function most_majestic() => "Trogdor"
+    }
+
+    function peasant_population() => 1337
+}
+
+function main() {
+    let x = (Kingdom::Dragons::most_majestic(), Kingdom::peasant_population())
+
+    println("{} burninated {} peasants", x.0, x.1)
+}

--- a/selfhost/parser.jakt
+++ b/selfhost/parser.jakt
@@ -342,6 +342,7 @@ struct ParsedCall {
     namespace_: [String]
     name: String
     args: [(String, ParsedExpression)]
+    type_args: [ParsedType]
 }
 
 boxed enum ParsedType {
@@ -2013,6 +2014,7 @@ struct Parser {
             namespace_: []
             name: ""
             args: []
+            type_args: []
         )
 
         match .current() {
@@ -2020,8 +2022,38 @@ struct Parser {
                 call.name = name
                 .index++
 
+                // This is to allow the lookahead. Without it, we may see something like
+                // foo < Bar, and think the start of a generic call when it actually isn't.
+                let index_reset = .index
+
                 if .current() is LessThan {
-                    todo("parse_call generics")
+                    // Generic type
+                    .index++
+                    mut inner_types: [ParsedType] = []
+
+                    while not .eof() {
+                        match .current() {
+                            GreaterThan => {
+                                .index++
+                                break
+                            }
+                            Comma | Eol => {
+                                .index++
+                            }
+                            else => {
+                                let index_before = .index
+                                let inner_type = .parse_typename()
+                                if index_before == .index {
+                                    // Can't parse further, this is not a generic call.
+                                    .index = index_reset;
+                                    break
+                                }
+                                inner_types.push(inner_type)
+                            }
+                        }
+                    }
+
+                    call.type_args = inner_types
                 }
 
                 if .current() is LParen {

--- a/selfhost/parser.jakt
+++ b/selfhost/parser.jakt
@@ -230,6 +230,7 @@ boxed enum ParsedExpression {
     OptionalNone(Span)
     JaktArray(values: [ParsedExpression], fill_size: ParsedExpression?, span: Span)
     JaktDictionary(values: [(ParsedExpression, ParsedExpression)], span: Span)
+    JaktTuple(values: [ParsedExpression], span: Span)
     Range(from: ParsedExpression, to: ParsedExpression, span: Span)
     ForcedUnwrap(expr: ParsedExpression, span: Span)
     Match(expr: ParsedExpression, cases: [ParsedMatchCase], span: Span)
@@ -252,6 +253,7 @@ boxed enum ParsedExpression {
         OptionalNone(span) => span
         JaktArray(values, fill_size, span) => span
         JaktDictionary(values, span) => span
+        JaktTuple(values, span) => span
         Range(from, to, span) => span
         ForcedUnwrap(expr, span) => span
         Garbage(span) => span
@@ -1537,15 +1539,49 @@ struct Parser {
             yield ParsedExpression::Var(name, span)
         }
         LParen(span) => {
+            let start_span = .current().span()
             .index++
+            
+            mut expr = .parse_expression(allow_assignments: false)
 
-            let expr = .parse_expression(allow_assignments: false)
+            .skip_newlines()
+
             match .current() {
                 RParen => {
                     .index++
                 }
                 Comma => {
-                    todo("parse_operand_base tuple")
+                    // We have a tuple
+                    .index++
+
+                    mut tuple_exprs: [ParsedExpression] = [expr]
+                    mut end_span = start_span
+
+                    while not .eof() {
+                        match .current() {
+                            Eol | Comma => {
+                                .index++
+                            }
+                            RParen => {
+                                .index++
+                                break
+                            }
+                            else => {
+                                let expr = .parse_expression(allow_assignments: false)
+                                end_span = expr.span()
+                                tuple_exprs.push(expr)
+                            }
+                        }
+                    }
+
+                    if .eof() {
+                        .error("Expected ')'", .current().span());
+                    }
+
+                    expr = ParsedExpression::JaktTuple(
+                        values: tuple_exprs,
+                        span: merge_spans(start_span, end_span)
+                    )
                 }
                 else => {
                     .error("Expected ')'", .current().span())

--- a/selfhost/parser.jakt
+++ b/selfhost/parser.jakt
@@ -1767,7 +1767,15 @@ struct Parser {
                 continue
             }
             if .current() is LessThan {
-                todo("ColonColon generic")
+                // Generic function arguments
+                .index--
+                let maybe_call = .parse_call()
+                if maybe_call.has_value() {
+                    mut call = maybe_call!
+                    call.namespace_ = namespace_
+                    return ParsedExpression::Call(call, span: merge_spans(expr.span(), .current().span()))
+                }
+                return ParsedExpression::Garbage(.current().span())
             }
             return ParsedExpression::NamespacedVar(
                 name: current_name,


### PR DESCRIPTION
This implements all of the `todo()`s that were in `selfhost/parser.jakt` :^)