### PR TITLE
selfhost+parser: Connect typechecker to selfhost

### DIFF
--- a/selfhost/main.jakt
+++ b/selfhost/main.jakt
@@ -9,6 +9,7 @@
 import error { JaktError, print_error }
 import lexer { Lexer, Token }
 import parser { BinaryOperator, DefinitionLinkage, DefinitionType, ParsedCall, ParsedExpression, ParsedNamespace, Parser }
+import typechecker
 import utility { panic, todo, Span }
 
 function usage() {

--- a/selfhost/typechecker.jakt
+++ b/selfhost/typechecker.jakt
@@ -1,5 +1,7 @@
 import error { JaktError }
-import parser { BinaryOperator, DefinitionLinkage, FunctionLinkage, RecordType, ParsedExpression, ParsedCall, ParsedType }
+import parser { BinaryOperator, DefinitionLinkage, FunctionLinkage,
+                DefinitionType, ParsedExpression, ParsedCall,
+                ParsedType, ParsedNamespace, RecordType }
 import utility { panic, todo, Span }
 
 struct ModuleId {
@@ -93,6 +95,16 @@ boxed enum Type {
     Enum(EnumId)
     Inference(InferenceId)
     RawPtr(TypeId)
+
+    function equals(this, anon rhs: Type) -> bool {
+        if this is Void and rhs is Void {
+            return true
+        } else if this is Bool and rhs is Bool {
+            return true
+        } else {
+            return false
+        }
+    }
 }
 
 struct Scope {
@@ -105,7 +117,7 @@ struct Scope {
     imports: [String: (ModuleId, Span)]
     parent: ScopeId?
     children: [ScopeId]
-    throws: bool
+    can_throw: bool
 }
 
 struct Module {
@@ -156,7 +168,7 @@ struct CheckedParameter {
 }
 
 struct CheckedVariable {
-    var_id: VarId
+    id: VarId
     definition_span: Span
 }
 
@@ -341,6 +353,25 @@ struct Typechecker {
         }
     }
 
+    function create_scope(mut this, parent_id: ScopeId, can_throw: bool) throws -> ScopeId {
+        let scope = Scope(
+            namespace_name: ""
+            vars: [:]
+            structs: [:]
+            functions: [:]
+            enums: [:]
+            types: [:]
+            imports: [:]
+            parent: parent_id
+            children: []
+            can_throw
+        )
+
+        .program.modules[.current_module.id].scopes.push(scope)
+
+        return ScopeId(module: .current_module, id: .program.modules[.current_module.id].scopes.size() - 1)
+    }
+
     function new_inference(mut this) throws -> TypeId {
         let new_type_var = .program.modules[.current_module.id].new_type_variable()
 
@@ -372,7 +403,7 @@ struct Typechecker {
         }
     }
 
-    function typename(this, anon type_id: TypeId) throws -> String {
+    function type_name(this, anon type_id: TypeId) throws -> String {
         let type = .get_type(type_id)
 
         return match type {
@@ -397,19 +428,19 @@ struct Typechecker {
                 GenericEnumInstance(id, args) => {
                     mut output = format("enum {}", .get_enum(id).name)
 
-                    output += "<"
-                    mut first = true
-                    for arg in args.iterator() {
-                        if not first {
-                            output += ", "
-                        } else {
-                            first = false
-                        }
+                    // output += "<"
+                    // mut first = true
+                    // for arg in args.iterator() {
+                    //     if not first {
+                    //         output += ", "
+                    //     } else {
+                    //         first = false
+                    //     }
 
-                        output += .typename(arg)
-                    }
+                    //     output += .type_name(arg)
+                    // }
 
-                    output += ">"
+                    // output += ">"
 
                     yield output
                 }
@@ -437,8 +468,8 @@ struct Typechecker {
         IndexedStruct(type_id) => type_id
         Call(type_id) => type_id
         MethodCall(type_id) => type_id
-        NamespacedVar(var) => .get_variable(var.var_id).type_id
-        Var(var) => .get_variable(var.var_id).type_id
+        NamespacedVar(var) => .get_variable(var.id).type_id
+        Var(var) => .get_variable(var.id).type_id
         OptionalNone(type_id) => type_id
         OptionalSome(type_id) => type_id
         ForcedUnwrap(type_id) => type_id
@@ -501,7 +532,7 @@ struct Typechecker {
 
         mut idx = 0uz
         for item in module.types.iterator() {
-            if item == type {
+            if item.equals(type) {
                 return TypeId(module: module_id, id: idx)
             }
             ++idx
@@ -509,7 +540,7 @@ struct Typechecker {
 
         idx = 0uz
         for item in .program.modules[0].types.iterator() {
-            if item == type {
+            if item.equals(type) {
                 return TypeId(module: .program.modules[0].id, id: idx)
             }
             ++idx
@@ -577,141 +608,160 @@ struct Typechecker {
         return None
     }
 
-    function typecheck_typename(mut this, parsed_type: ParsedType, scope_id: ScopeId) throws -> TypeId => match parsed_type {
-        NamespacedName(name, namespaces, params, span) => {
-            mut current_namespace_scope_id = scope_id
+    function typecheck_module(mut this, parsed_namespace: ParsedNamespace, scope_id: ScopeId) throws {
+        .typecheck_namespace_predecl(parsed_namespace, scope_id)
+        .typecheck_namespace_declarations(parsed_namespace, scope_id)
+    }
 
-            for ns in namespaces.iterator() {
-                let result = .find_namespace_in_scope(scope_id: current_namespace_scope_id, name: ns)
-
-                if result.has_value() {
-                    current_namespace_scope_id = result.value()
-                } else {
-                    .error(format("Unknown namespace: '{}'", ns), span)
-                    return .new_inference()
-                }
-            }
-
-            mut generic_args: [TypeId] = []
-
-            for param in params.iterator() {
-                let checked_arg = .typecheck_typename(parsed_type: param, scope_id)
-
-                generic_args.push(checked_arg)
-            }
-
-            // TODO: add synthetic typename and generic support
-
-            return .typecheck_typename(parsed_type, scope_id)
+    function typecheck_namespace_predecl(mut this, parsed_namespace: ParsedNamespace, scope_id: ScopeId) throws {
+        for fun in parsed_namespace.functions.iterator() {
+            //.typecheck_function_predecl(fun, parent_scope_id: scope_id)
         }
-        Name(name, span) => {
-            return match name {
-                "i8" => builtin(BuiltinType::I8)
-                "i16" => builtin(BuiltinType::I16)
-                "i32" => builtin(BuiltinType::I32)
-                "i64" => builtin(BuiltinType::I64)
-                "u8" => builtin(BuiltinType::U8)
-                "u16" => builtin(BuiltinType::U16)
-                "u32" => builtin(BuiltinType::U32)
-                "u64" => builtin(BuiltinType::U64)
-                "f32" => builtin(BuiltinType::F32)
-                "f64" => builtin(BuiltinType::F64)
-                "c_char" => builtin(BuiltinType::CChar)
-                "c_int" => builtin(BuiltinType::CInt)
-                "usize" => builtin(BuiltinType::Usize)
-                "String" => builtin(BuiltinType::String)
-                "bool" => builtin(BuiltinType::Bool)
-                "void" => builtin(BuiltinType::Void)
-                else => {
-                    let type_id = .find_type_in_scope(scope_id, name)
+    }
 
-                    if type_id.has_value() {
-                        return type_id.value()
+    function typecheck_namespace_declarations(mut this, parsed_namespace: ParsedNamespace, scope_id: ScopeId) throws {
+        for fun in parsed_namespace.functions.iterator() {
+            //.typecheck_function(fun, parent_scope_id: scope_id)
+        }
+    }
+
+    function typecheck_typename(mut this, parsed_type: ParsedType, scope_id: ScopeId) throws -> TypeId { 
+        match parsed_type {
+            NamespacedName(name, namespaces, params, span) => {
+                mut current_namespace_scope_id = scope_id
+
+                for ns in namespaces.iterator() {
+                    let result = .find_namespace_in_scope(scope_id: current_namespace_scope_id, name: ns)
+
+                    if result.has_value() {
+                        current_namespace_scope_id = result.value()
                     } else {
-                        .error(format("Unknown type ‘{}’", name), span)
+                        .error(format("Unknown namespace: '{}'", ns), span)
                         return .new_inference()
                     }
                 }
+
+                mut generic_args: [TypeId] = []
+
+                for param in params.iterator() {
+                    let checked_arg = .typecheck_typename(parsed_type: param, scope_id)
+
+                    generic_args.push(checked_arg)
+                }
+
+                // TODO: add synthetic type_name and generic support
+
+                return .typecheck_typename(parsed_type, scope_id)
             }
-        }
-        Empty => {
-            return .new_inference()
-        }
-        JaktTuple(types, span) => {
-            mut checked_types: [TypeId] = []
-            for parsed_type in types.iterator() {
-                checked_types.push(.typecheck_typename(parsed_type, scope_id))
+            Name(name, span) => {
+                return match name {
+                    "i8" => builtin(BuiltinType::I8)
+                    "i16" => builtin(BuiltinType::I16)
+                    "i32" => builtin(BuiltinType::I32)
+                    "i64" => builtin(BuiltinType::I64)
+                    "u8" => builtin(BuiltinType::U8)
+                    "u16" => builtin(BuiltinType::U16)
+                    "u32" => builtin(BuiltinType::U32)
+                    "u64" => builtin(BuiltinType::U64)
+                    "f32" => builtin(BuiltinType::F32)
+                    "f64" => builtin(BuiltinType::F64)
+                    "c_char" => builtin(BuiltinType::CChar)
+                    "c_int" => builtin(BuiltinType::CInt)
+                    "usize" => builtin(BuiltinType::Usize)
+                    "String" => builtin(BuiltinType::String)
+                    "bool" => builtin(BuiltinType::Bool)
+                    "void" => builtin(BuiltinType::Void)
+                    else => {
+                        let type_id = .find_type_in_scope(scope_id, name)
+
+                        if type_id.has_value() {
+                            return type_id.value()
+                        } else {
+                            .error(format("Unknown type ‘{}’", name), span)
+                            return .new_inference()
+                        }
+                    }
+                }
             }
-            let tuple_struct_id = .find_struct_in_prelude("Tuple")
-
-            let type_id = .find_or_add_type_id(Type::GenericInstance(id: tuple_struct_id, args: checked_types))
-
-            return type_id
-        }
-        JaktArray(inner, span) => {
-            let inner_type_id = .typecheck_typename(parsed_type: inner, scope_id)
-
-            let array_struct_id = .find_struct_in_prelude("Array")
-
-            let type_id = .find_or_add_type_id(Type::GenericInstance(id: array_struct_id, args: [inner_type_id]))
-
-            return type_id
-        }
-        Dictionary(key, value, span) => {
-            let key_type_id = .typecheck_typename(parsed_type: key, scope_id)
-            let value_type_id = .typecheck_typename(parsed_type: value, scope_id)
-
-            let dict_struct_id = .find_struct_in_prelude("Dictionary")
-
-            let type_id = .find_or_add_type_id(Type::GenericInstance(id: dict_struct_id, args: [key_type_id, value_type_id]))
-
-            return type_id
-        }
-        Set(inner, span) => {
-            let inner_type_id = .typecheck_typename(parsed_type: inner, scope_id)
-
-            let set_struct_id = .find_struct_in_prelude("Set")
-
-            let type_id = .find_or_add_type_id(Type::GenericInstance(id: set_struct_id, args: [inner_type_id]))
-
-            return type_id
-        }
-        Optional(inner, span) => {
-            let inner_type_id = .typecheck_typename(parsed_type: inner, scope_id)
-
-            let optional_struct_id = .find_struct_in_prelude("Optional")
-
-            let type_id = .find_or_add_type_id(Type::GenericInstance(id: optional_struct_id, args: [inner_type_id]))
-
-            return type_id
-        }
-        WeakPtr(inner, span) => {
-            let inner_type_id = .typecheck_typename(parsed_type: inner, scope_id)
-
-            let weakptr_struct_id = .find_struct_in_prelude("WeakPtr")
-
-            let type_id = .find_or_add_type_id(Type::GenericInstance(id: weakptr_struct_id, args: [inner_type_id]))
-
-            return type_id
-        }
-        RawPtr(inner, span) => {
-            let inner_type_id = .typecheck_typename(parsed_type: inner, scope_id)
-
-            let type_id = .find_or_add_type_id(Type::RawPtr(id: inner_type_id))
-
-            return type_id
-        }
-        GenericType(name, generic_parameters, span) => {
-            mut checked_inner_types: [TypeId] = []
-
-            for inner_type in generic_parameters.iterator() {
-                let inner_type_id = .typecheck_typename(parsed_type, scope_id)
-                checked_inner_types.push(inner_type_id)
+            Empty => {
+                return .new_inference()
             }
-            // FIXME: add support for "GenericResolvedType", though the Rust version
-            // puts this in the parser even though it should be in the typechecker
-            // as the parser doesn't have a concept of type ids
-            return .new_inference()
+            JaktTuple(types, span) => {
+                mut checked_types: [TypeId] = []
+                for parsed_type in types.iterator() {
+                    checked_types.push(.typecheck_typename(parsed_type, scope_id))
+                }
+                let tuple_struct_id = .find_struct_in_prelude("Tuple")
+
+                let type_id = .find_or_add_type_id(Type::GenericInstance(id: tuple_struct_id, args: checked_types))
+
+                return type_id
+            }
+            JaktArray(inner, span) => {
+                let inner_type_id = .typecheck_typename(parsed_type: inner, scope_id)
+
+                let array_struct_id = .find_struct_in_prelude("Array")
+
+                let type_id = .find_or_add_type_id(Type::GenericInstance(id: array_struct_id, args: [inner_type_id]))
+
+                return type_id
+            }
+            Dictionary(key, value, span) => {
+                let key_type_id = .typecheck_typename(parsed_type: key, scope_id)
+                let value_type_id = .typecheck_typename(parsed_type: value, scope_id)
+
+                let dict_struct_id = .find_struct_in_prelude("Dictionary")
+
+                let type_id = .find_or_add_type_id(Type::GenericInstance(id: dict_struct_id, args: [key_type_id, value_type_id]))
+
+                return type_id
+            }
+            Set(inner, span) => {
+                let inner_type_id = .typecheck_typename(parsed_type: inner, scope_id)
+
+                let set_struct_id = .find_struct_in_prelude("Set")
+
+                let type_id = .find_or_add_type_id(Type::GenericInstance(id: set_struct_id, args: [inner_type_id]))
+
+                return type_id
+            }
+            Optional(inner, span) => {
+                let inner_type_id = .typecheck_typename(parsed_type: inner, scope_id)
+
+                let optional_struct_id = .find_struct_in_prelude("Optional")
+
+                let type_id = .find_or_add_type_id(Type::GenericInstance(id: optional_struct_id, args: [inner_type_id]))
+
+                return type_id
+            }
+            WeakPtr(inner, span) => {
+                let inner_type_id = .typecheck_typename(parsed_type: inner, scope_id)
+
+                let weakptr_struct_id = .find_struct_in_prelude("WeakPtr")
+
+                let type_id = .find_or_add_type_id(Type::GenericInstance(id: weakptr_struct_id, args: [inner_type_id]))
+
+                return type_id
+            }
+            RawPtr(inner, span) => {
+                let inner_type_id = .typecheck_typename(parsed_type: inner, scope_id)
+
+                let type_id = .find_or_add_type_id(Type::RawPtr(id: inner_type_id))
+
+                return type_id
+            }
+            GenericType(name, generic_parameters, span) => {
+                mut checked_inner_types: [TypeId] = []
+
+                for inner_type in generic_parameters.iterator() {
+                    let inner_type_id = .typecheck_typename(parsed_type, scope_id)
+                    checked_inner_types.push(inner_type_id)
+                }
+                // FIXME: add support for "GenericResolvedType", though the Rust version
+                // puts this in the parser even though it should be in the typechecker
+                // as the parser doesn't have a concept of type ids
+                return .new_inference()
+            }
         }
     }
 
@@ -750,7 +800,7 @@ struct Typechecker {
                     GenericInstance(id, args) => {
                         let optional_struct_id = .find_struct_in_prelude("Optional")
 
-                        if id == optional_struct_id {
+                        if id.equals(optional_struct_id) {
                             // Success: LHS is T? and RHS is T?.
                             if lhs_type_id.equals(rhs_type_id) {
                                 return lhs_type_id
@@ -766,8 +816,8 @@ struct Typechecker {
                         } else {
                             .error_with_hint(format(
                                 "None coalescing (??) with incompatible types (‘{}’ and ‘{}’)",
-                                .typename(lhs_type_id),
-                                .typename(rhs_type_id),
+                                .type_name(lhs_type_id),
+                                .type_name(rhs_type_id),
                             ), span,
                             "Left side of ?? must be an Optional but isn't",
                             lhs_span)
@@ -776,8 +826,8 @@ struct Typechecker {
                     else => {
                         .error_with_hint(format(
                             "None coalescing (??) with incompatible types (‘{}’ and ‘{}’)",
-                            .typename(lhs_type_id),
-                            .typename(rhs_type_id),
+                            .type_name(lhs_type_id),
+                            .type_name(rhs_type_id),
                         ), span,
                         "Left side of ?? must be an Optional but isn't",
                         lhs_span)
@@ -786,15 +836,15 @@ struct Typechecker {
 
                 .error(format(
                     "None coalescing (??) with incompatible types (‘{}’ and ‘{}’)",
-                    .typename(lhs_type_id),
-                    .typename(rhs_type_id),
+                    .type_name(lhs_type_id),
+                    .type_name(rhs_type_id),
                 ), span)
 
                 return lhs_type_id
             }
             LessThan | LessThanOrEqual | GreaterThan | GreaterThanOrEqual | Equal | NotEqual => {
                 if not lhs_type_id.equals(rhs_type_id) {
-                    .error(format("Binary comparison between incompatible types ({} vs {})", .typename(lhs_type_id), .typename(rhs_type_id)), span)
+                    .error(format("Binary comparison between incompatible types ({} vs {})", .type_name(lhs_type_id), .type_name(rhs_type_id)), span)
                 }
 
                 type_id = builtin(BuiltinType::Bool)
@@ -822,7 +872,7 @@ struct Typechecker {
 
                         match lhs_type {
                             GenericInstance(id, args) => {
-                                if id == optional_struct_id {
+                                if id.equals(optional_struct_id) {
                                     return lhs_type_id
                                 }
                             }
@@ -834,7 +884,7 @@ struct Typechecker {
 
                 let result = .unify(lhs: rhs_type_id, lhs_span: rhs_span, rhs: lhs_type_id, rhs_span: lhs_span)
                 if result.1 {
-                    .error(format("Assignment between incompatible types (‘{}’ and ‘{}’)", .typename(lhs_type_id), .typename(rhs_type_id)), span)
+                    .error(format("Assignment between incompatible types (‘{}’ and ‘{}’)", .type_name(lhs_type_id), .type_name(rhs_type_id)), span)
                 }
                 return result.0
             }
@@ -843,7 +893,7 @@ struct Typechecker {
 
                 match .get_type(lhs_type_id) {
                     GenericInstance(id, args) => {
-                        if id == weak_ptr_struct_id {
+                        if id.equals(weak_ptr_struct_id) {
                             let inner_type_id = args[0]
                             match .get_type(inner_type_id) {
                                 Type::Struct(struct_id: lhs_struct_id) => {
@@ -863,8 +913,8 @@ struct Typechecker {
                         if not lhs_type_id.equals(rhs_type_id) {
                             .error(format(
                                 "Assignment between incompatible types (‘{}’ and ‘{}’)",
-                                .typename(lhs_type_id),
-                                .typename(rhs_type_id),
+                                .type_name(lhs_type_id),
+                                .type_name(rhs_type_id),
                             ), span)
                         }
 
@@ -879,8 +929,8 @@ struct Typechecker {
                 if not lhs_type_id.equals(rhs_type_id) {
                     .error(format(
                         "Binary arithmetic operation between incompatible types (‘{}’ and ‘{}’)",
-                        .typename(lhs_type_id),
-                        .typename(rhs_type_id),
+                        .type_name(lhs_type_id),
+                        .type_name(rhs_type_id),
                     ),
                     span)
                 }

--- a/src/codegen.rs
+++ b/src/codegen.rs
@@ -27,7 +27,7 @@ use crate::{
         Project, Scope, Type, TypeId,
     },
 };
-use std::collections::{HashMap, HashSet, LinkedList};
+use std::collections::{BTreeMap, BTreeSet, LinkedList};
 
 const INDENT_SIZE: usize = 4;
 
@@ -145,7 +145,7 @@ fn topological_sort_modules<'a>(
     project: &'a Project,
     modules: &'a Vec<&'a Module>,
 ) -> Vec<&'a Module> {
-    let mut in_degrees = HashMap::new();
+    let mut in_degrees = BTreeMap::new();
     for module in modules {
         for imported_module in module.imports.iter() {
             *in_degrees.entry(imported_module).or_insert(0) += 1;
@@ -331,7 +331,7 @@ fn codegen_namespace(
     // This is necessary as C++ requires a type to be defined before it's used as a value type,
     // we can ignore the generic types as they are only resolved when used by other non-generic code.
     let type_dependency_graph = produce_codegen_dependency_graph(project, scope);
-    let mut seen_types = HashSet::new();
+    let mut seen_types = BTreeSet::new();
     for type_id in type_dependency_graph.keys() {
         let mut traversal = Vec::new();
         postorder_traversal(
@@ -3751,8 +3751,8 @@ fn codegen_indent(indent: usize) -> String {
 fn extract_dependencies_from(
     project: &Project,
     type_id: TypeId,
-    deps: &mut HashSet<TypeId>,
-    graph: &HashMap<TypeId, Vec<TypeId>>,
+    deps: &mut BTreeSet<TypeId>,
+    graph: &BTreeMap<TypeId, Vec<TypeId>>,
     top_level: bool,
 ) {
     if let Some(existing_deps) = graph.get(&type_id) {
@@ -3827,11 +3827,11 @@ fn extract_dependencies_from(
 fn produce_codegen_dependency_graph(
     project: &Project,
     scope: &Scope,
-) -> HashMap<TypeId, Vec<TypeId>> {
-    let mut graph = HashMap::new();
+) -> BTreeMap<TypeId, Vec<TypeId>> {
+    let mut graph = BTreeMap::new();
 
     for (_, type_id, _) in &scope.types {
-        let mut deps = HashSet::new();
+        let mut deps = BTreeSet::new();
         extract_dependencies_from(project, *type_id, &mut deps, &graph, true);
         graph.insert(*type_id, deps.into_iter().collect());
     }
@@ -3842,8 +3842,8 @@ fn produce_codegen_dependency_graph(
 fn postorder_traversal(
     project: &Project,
     type_id: TypeId,
-    visited: &mut HashSet<TypeId>,
-    graph: &HashMap<TypeId, Vec<TypeId>>,
+    visited: &mut BTreeSet<TypeId>,
+    graph: &BTreeMap<TypeId, Vec<TypeId>>,
     output: &mut Vec<TypeId>,
 ) {
     if visited.contains(&type_id) {

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -577,6 +577,7 @@ fn parse_import(tokens: &[Token], index: &mut usize) -> (ParsedImport, Option<Ja
                                 "expected name".to_string(),
                                 tokens[*index].span,
                             )));
+                            *index += 1;
                         }
                     }
                 } else {
@@ -607,6 +608,9 @@ fn parse_import(tokens: &[Token], index: &mut usize) -> (ParsedImport, Option<Ja
                     });
                     *index += 1;
                 }
+                TokenContents::Eol => {
+                    *index += 1;
+                }
                 TokenContents::Comma => {
                     *index += 1;
                 }
@@ -619,6 +623,7 @@ fn parse_import(tokens: &[Token], index: &mut usize) -> (ParsedImport, Option<Ja
                         "Expected name or ‘}’".to_string(),
                         tokens[*index - 1].span,
                     )));
+                    *index += 1;
                 }
             }
         }
@@ -1381,6 +1386,7 @@ pub fn parse_struct(
                                 "expected '{'".to_string(),
                                 tokens[*index].span,
                             )));
+                            *index += 1;
                         }
                     }
                 } else {
@@ -1564,6 +1570,7 @@ pub fn parse_struct(
                                 "expected field".to_string(),
                                 tokens[*index].span,
                             )));
+                            *index += 1;
                             break;
                         }
                     }


### PR DESCRIPTION
This connects the typechecker to the selfhost (with a couple workarounds for C++ codegen limitations)

It also fixes a couple infinite loops in the rust parser. As well as fixing codegen so that it was deterministic (using BTree* containers instead of Hash* containers)

Closes #613
(another attempt at fixing codegen to be deterministic)