### PR TITLE
codegen+typechecker: Stable compiler output

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -20,10 +20,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "holyhashmap"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ea8994862412b9179b9affdd94ffaab5fa95585d91d088269830addfebdc9d9"
+
+[[package]]
 name = "jakt"
 version = "0.1.0"
 dependencies = [
+ "holyhashmap",
  "lazy_static",
+ "linked_hash_set",
  "pico-args",
  "uuid",
 ]
@@ -39,6 +47,21 @@ name = "libc"
 version = "0.2.125"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5916d2ae698f6de9bfb891ad7a8d65c09d232dc58cc4ac433c7da3b2fd84bc2b"
+
+[[package]]
+name = "linked-hash-map"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7fb9b38af92608140b86b693604b9ffcc5824240a484d1ecd4795bacb2fe88f3"
+
+[[package]]
+name = "linked_hash_set"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47186c6da4d81ca383c7c47c1bfc80f4b95f4720514d860a5407aaf4233f9588"
+dependencies = [
+ "linked-hash-map",
+]
 
 [[package]]
 name = "pico-args"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,8 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [dependencies]
 pico-args = { version = "0.4.2", features = ["combined-flags"] }
+holyhashmap = "0.1.2"
+linked_hash_set = "0.1.4"
 
 [dev-dependencies]
 uuid = {version = "1.0.0", features=["v4"]}

--- a/src/codegen.rs
+++ b/src/codegen.rs
@@ -13,6 +13,9 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+use holyhashmap::HolyHashMap;
+use linked_hash_set::LinkedHashSet;
+
 use crate::compiler::{UNKNOWN_TYPE_ID, VOID_TYPE_ID};
 use crate::typechecker::{
     CheckedCall, CheckedEnum, CheckedEnumVariant, CheckedMatchBody, CheckedMatchCase,
@@ -1967,7 +1970,6 @@ pub fn codegen_namespace_qualifier(scope_id: ScopeId, project: &Project) -> Stri
     while let Some(current) = current_scope_id {
         // Walk backward, prepending the parents with names to the current output
         if let Some(namespace_name) = &project.get_scope(current).namespace_name {
-            println!("{}", namespace_name);
             output.insert_str(0, &format!("{}::", namespace_name));
         }
 
@@ -3751,8 +3753,8 @@ fn codegen_indent(indent: usize) -> String {
 fn extract_dependencies_from(
     project: &Project,
     type_id: TypeId,
-    deps: &mut HashSet<TypeId>,
-    graph: &HashMap<TypeId, Vec<TypeId>>,
+    deps: &mut LinkedHashSet<TypeId>,
+    graph: &HolyHashMap<TypeId, Vec<TypeId>>,
     top_level: bool,
 ) {
     if let Some(existing_deps) = graph.get(&type_id) {
@@ -3827,11 +3829,11 @@ fn extract_dependencies_from(
 fn produce_codegen_dependency_graph(
     project: &Project,
     scope: &Scope,
-) -> HashMap<TypeId, Vec<TypeId>> {
-    let mut graph = HashMap::new();
+) -> HolyHashMap<TypeId, Vec<TypeId>> {
+    let mut graph = HolyHashMap::new();
 
     for (_, type_id, _) in &scope.types {
-        let mut deps = HashSet::new();
+        let mut deps = LinkedHashSet::new();
         extract_dependencies_from(project, *type_id, &mut deps, &graph, true);
         graph.insert(*type_id, deps.into_iter().collect());
     }
@@ -3843,7 +3845,7 @@ fn postorder_traversal(
     project: &Project,
     type_id: TypeId,
     visited: &mut HashSet<TypeId>,
-    graph: &HashMap<TypeId, Vec<TypeId>>,
+    graph: &HolyHashMap<TypeId, Vec<TypeId>>,
     output: &mut Vec<TypeId>,
 ) {
     if visited.contains(&type_id) {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,6 +21,8 @@
 #![allow(clippy::never_loop)]
 
 extern crate core;
+extern crate holyhashmap;
+extern crate linked_hash_set;
 
 mod codegen;
 mod compiler;

--- a/src/typechecker.rs
+++ b/src/typechecker.rs
@@ -13,7 +13,8 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-use std::collections::{HashMap, HashSet};
+use holyhashmap::HolyHashMap;
+use std::collections::HashSet;
 
 use crate::compiler::{PRELUDE_SCOPE_ID, STRING_TYPE_ID};
 use crate::parser::{BinaryOperator, MatchBody, MatchCase, ParsedVarDecl, Visibility};
@@ -3262,7 +3263,7 @@ fn typecheck_and_specialize_generic_function(
     generic_arguments: Vec<TypeId>,
     parent_scope_id: ScopeId,
     this_type_id: Option<TypeId>,
-    generic_substitutions: &HashMap<TypeId, TypeId>,
+    generic_substitutions: &HolyHashMap<TypeId, TypeId>,
     project: &mut Project,
 ) -> Option<JaktError> {
     let function = project.get_function(function_id);
@@ -3564,7 +3565,7 @@ pub fn typecheck_block(
     let parent_throws = project.get_scope(parent_scope_id).throws;
     let block_scope_id = project.create_scope(parent_scope_id, parent_throws);
     let mut checked_block = CheckedBlock::new(block_scope_id);
-    let mut generic_inferences = HashMap::new();
+    let mut generic_inferences = HolyHashMap::new();
 
     for stmt in &block.stmts {
         let (checked_stmt, err) = typecheck_statement(stmt, block_scope_id, project, safety_mode);
@@ -4188,7 +4189,7 @@ pub fn typecheck_match_body(
     scope_id: ScopeId,
     project: &mut Project,
     safety_mode: SafetyMode,
-    generic_parameters: &mut HashMap<TypeId, TypeId>,
+    generic_parameters: &mut HolyHashMap<TypeId, TypeId>,
     final_result_type: &mut Option<TypeId>,
     span: Span,
 ) -> (CheckedMatchBody, Option<JaktError>) {
@@ -5127,12 +5128,12 @@ pub fn typecheck_expression(
                         .generic_parameters
                         .iter()
                         .zip(inner_type_ids.iter())
-                        .fold(HashMap::new(), |mut acc, (param, type_id)| {
+                        .fold(HolyHashMap::new(), |mut acc, (param, type_id)| {
                             acc.insert(*param, *type_id);
                             acc
                         })
                 }
-                _ => HashMap::new(),
+                _ => HolyHashMap::new(),
             };
             let mut final_result_type: Option<TypeId> = None;
             let mut all_variants_are_constants = true;
@@ -5359,7 +5360,7 @@ pub fn typecheck_expression(
                                                 let variant_name = variant_name.clone();
                                                 let fields = fields.clone();
 
-                                                let mut names_seen = HashMap::new();
+                                                let mut names_seen = HolyHashMap::new();
                                                 for arg in args {
                                                     let name = &arg.0;
                                                     if name.is_none()
@@ -6248,7 +6249,7 @@ fn unify_with_type(
             return (found_type, None);
         }
 
-        let mut generic_interface = HashMap::new();
+        let mut generic_interface = HolyHashMap::new();
         let err = check_types_for_compat(hint, found_type, &mut generic_interface, span, project);
         if err.is_some() {
             return (found_type, err);
@@ -6666,7 +6667,7 @@ pub fn typecheck_call(
     let mut error = None;
     let mut return_type_id = UNKNOWN_TYPE_ID;
     let mut linkage = FunctionLinkage::Internal;
-    let mut generic_substitutions = HashMap::new();
+    let mut generic_substitutions = HolyHashMap::new();
     let mut type_args = vec![];
     let mut callee_throws = false;
     let mut resolved_namespaces = call
@@ -7002,7 +7003,7 @@ pub fn typecheck_call(
 
 pub fn substitute_typevars_in_type(
     type_id: TypeId,
-    generic_inferences: &HashMap<TypeId, TypeId>,
+    generic_inferences: &HolyHashMap<TypeId, TypeId>,
     project: &mut Project,
 ) -> TypeId {
     let mut result = substitute_typevars_in_type_helper(type_id, generic_inferences, project);
@@ -7022,7 +7023,7 @@ pub fn substitute_typevars_in_type(
 
 fn substitute_typevars_in_type_helper(
     type_id: TypeId,
-    generic_inferences: &HashMap<TypeId, TypeId>,
+    generic_inferences: &HolyHashMap<TypeId, TypeId>,
     project: &mut Project,
 ) -> TypeId {
     let type_ = project.get_type(type_id);
@@ -7097,7 +7098,7 @@ fn substitute_typevars_in_type_helper(
 pub fn check_types_for_compat(
     lhs_type_id: TypeId,
     rhs_type_id: TypeId,
-    generic_inferences: &mut HashMap<TypeId, TypeId>,
+    generic_inferences: &mut HolyHashMap<TypeId, TypeId>,
     span: Span,
     project: &Project,
 ) -> Option<JaktError> {


### PR DESCRIPTION
This PR shows the HashMaps/HashSets that need changing to insertion order respecting ones to get a stable compiler output.

Leaving this as a draft since I just picked some random libs of crates.io to quickly test this.