### PR TITLE
selfhost: Add help to command line arguments

### DIFF
--- a/selfhost/main.jakt
+++ b/selfhost/main.jakt
@@ -11,9 +11,12 @@ import lexer { Lexer, Token }
 import parser { BinaryOperator, DefinitionLinkage, DefinitionType, ParsedCall, ParsedExpression, ParsedNamespace, Parser }
 import utility { panic, todo, Span }
 
-function usage() {
-    eprintln("usage: jakt [-l] [-p] <path>")
-    return 1
+function usage() -> String {
+    return "usage: jakt [-h] [OPTIONS] <path>"
+}
+
+function help() -> String {
+    return "Flags:\n  -h\t\tPrint this help and exit.\nOptions:\n  -l\t\tPrint debug info for the lexer.\n  -p\t\tPrint debug info for the parser."
 }
 
 function pretty_print_new_line(anon string_builder: mut StringBuilder, anon level: i64) throws {
@@ -108,7 +111,7 @@ function pretty_print_namespace(anon namespace_: ParsedNamespace) throws {
 
 function main(args: [String]) {
     if args.size() <= 1 {
-        return usage()
+        eprintln("{}", usage())
     }
     mut lexer_debug = false
     mut parser_debug = false
@@ -123,7 +126,8 @@ function main(args: [String]) {
             "-l" => {
                 if lexer_debug {
                     eprintln("you can only have the -l option once")
-                    return usage()
+                    eprintln("{}", usage())
+                    return 1
                 } else {
                     lexer_debug = true
                 }
@@ -131,15 +135,22 @@ function main(args: [String]) {
             "-p" => {
                 if parser_debug {
                     eprintln("you can only have the -p option once")
-                    return usage()
+                    eprintln("{}", usage())
+                    return 1
                 } else {
                     parser_debug = true
                 }
             }
+            "-h" => {
+                println("{}\n", usage())
+                println("{}", help())
+                return 0
+            }
             else => {
                 if file_name.has_value() {
                     eprintln("you can only pass one file")
-                    return usage()
+                    eprintln("{}", usage())
+                    return 1
                 } else {
                     file_name = arg
                 }
@@ -148,7 +159,7 @@ function main(args: [String]) {
     }
     if not file_name.has_value() {
         eprintln("you must pass a source file")
-        return usage()
+        eprintln("{}", usage())
     }
 
     mut file = File::open_for_reading(file_name!)


### PR DESCRIPTION
Passing `-h` will now print the possible flags and options similarly to
how the Rust implementation does.

The `usage()` and `help()` functions now return the usage and help strings
rather than calling `println()` and returning an integer. This allows for
the usage message to be printed to stdout when `-h` is passed rather than
to stderr. Ideally this would be done with global constant strings as in
the Rust compiler, however that is not currently supported(?).