### PR TITLE
all: Move `mut` to before parameter names

### DIFF
--- a/runtime/prelude.jakt
+++ b/runtime/prelude.jakt
@@ -122,7 +122,7 @@ extern function as_truncated<U, T>(anon input: T) -> U
 extern struct FILE {}
 
 extern function fopen(anon str: raw c_char, anon mode: raw c_char) -> raw FILE
-extern function fgetc(anon file: mut raw FILE) -> c_int
-extern function fclose(anon file: mut raw FILE) -> c_int
-extern function feof(anon file: mut raw FILE) -> c_int
+extern function fgetc(anon mut file: raw FILE) -> c_int
+extern function fclose(anon mut file: raw FILE) -> c_int
+extern function feof(anon mut file: raw FILE) -> c_int
 extern function putchar(anon ch: c_int) -> c_int

--- a/samples/arrays/reference_semantics.jakt
+++ b/samples/arrays/reference_semantics.jakt
@@ -1,7 +1,7 @@
 /// Expect:
 /// - output: "foo\nbar\n"
 
-function change_value(vector: mut [String]) {
+function change_value(mut vector: [String]) {
     vector[1] = "bar"
 }
 

--- a/samples/basics/bubble_sort.jakt
+++ b/samples/basics/bubble_sort.jakt
@@ -1,7 +1,7 @@
 /// Expect:
 /// - output: "1\n2\n8\n9\n13\n22\n25\n50\n"
 
-function bubble_sort(values: mut [i64]) {
+function bubble_sort(mut values: [i64]) {
     mut i = 0
     while i < values.size() as! i64 - 1 {
         mut j = 0

--- a/samples/dictionaries/reference_semantics.jakt
+++ b/samples/dictionaries/reference_semantics.jakt
@@ -1,7 +1,7 @@
 /// Expect:
 /// - output: "PASS\n"
 
-function change_value(dictionary: mut [String:String]) throws {
+function change_value(mut dictionary: [String:String]) throws {
     dictionary.set(key: "foo", value: "PASS")
 }
 

--- a/samples/generics/generic_types.jakt
+++ b/samples/generics/generic_types.jakt
@@ -1,7 +1,7 @@
 /// Expect:
 /// - output: "3\n"
 
-function do_pop<T>(anon arr: mut [T]) -> Optional<T> {
+function do_pop<T>(anon mut arr: [T]) -> Optional<T> {
   return arr.pop()
 }
 

--- a/samples/sets/reference_semantics.jakt
+++ b/samples/sets/reference_semantics.jakt
@@ -1,7 +1,7 @@
 /// Expect:
 /// - output: "5\n"
 
-function foo(set: mut {i64}) throws {
+function foo(mut set: {i64}) throws {
     set.add(4)
     set.add(5)
 }

--- a/samples/structs/value_semantics.jakt
+++ b/samples/structs/value_semantics.jakt
@@ -5,7 +5,7 @@ struct Foo {
     x: i64
 }
 
-function set_x(foo: mut Foo, x: i64) {
+function set_x(mut foo: Foo, x: i64) {
     foo.x = x
 }
 

--- a/selfhost/main.jakt
+++ b/selfhost/main.jakt
@@ -17,7 +17,7 @@ function usage() {
     return 1
 }
 
-function pretty_print_new_line(anon string_builder: mut StringBuilder, anon level: i64) throws {
+function pretty_print_new_line(anon mut string_builder: StringBuilder, anon level: i64) throws {
     string_builder.append(b'\n')
     for indent in 0..level {
         string_builder.append_string("  ")

--- a/selfhost/parser.jakt
+++ b/selfhost/parser.jakt
@@ -73,7 +73,6 @@ struct ParsedFunction {
 struct ParsedParameter {
     requires_label: bool
     variable: ParsedVariable
-    is_mutable: bool
     span: Span
 }
 
@@ -1136,7 +1135,6 @@ struct Parser {
                             is_mutable: current_param_is_mutable,
                             span: .current().span(),
                         ),
-                        is_mutable: current_param_is_mutable,
                         span: .current().span(),
                     ))
                     .index++
@@ -1151,7 +1149,6 @@ struct Parser {
                             is_mutable: var_decl.is_mutable,
                             span: .previous().span(),
                         ),
-                        is_mutable: current_param_is_mutable,
                         span: .previous().span(),
                     ))
                 }

--- a/selfhost/parser.jakt
+++ b/selfhost/parser.jakt
@@ -1107,6 +1107,7 @@ struct Parser {
 
         // Have we already found an error?
         mut error = false
+        mut parameter_complete = false
 
         while not .eof() {
             match .current() {
@@ -1115,14 +1116,40 @@ struct Parser {
                     break
                 }
                 Comma => {
+                    if not parameter_complete and not error {
+                        .error("Expected parameter", .current().span())
+                        error = true
+                    }
                     .index++
                     current_param_requires_label = true
+                    current_param_is_mutable = false
+                    parameter_complete = false
                 }
                 Anon => {
+                    if parameter_complete and not error  {
+                        .error("‘anon’ must appear at start of parameter declaration, not the end", .current().span())
+                        error = true
+                    }
+                    if current_param_is_mutable and not error  {
+                        .error("‘anon’ must appear before ‘mut’", .current().span())
+                        error = true
+                    }
+                    if not current_param_requires_label and not error  {
+                        .error("‘anon’ cannot appear multiple times in one parameter declaration", .current().span())
+                        error = true
+                    }
                     .index++
                     current_param_requires_label = false
                 }
                 Mut => {
+                    if parameter_complete and not error  {
+                        .error("‘mut’ must appear at start of parameter declaration, not the end", .current().span())
+                        error = true
+                    }
+                    if current_param_is_mutable and not error  {
+                        .error("‘mut’ cannot appear multiple times in one parameter declaration", .current().span())
+                        error = true
+                    }
                     .index++
                     current_param_is_mutable = true
                 }
@@ -1138,6 +1165,7 @@ struct Parser {
                         span: .current().span(),
                     ))
                     .index++
+                    parameter_complete = true
                 }
                 Identifier(name, span) => {
                     let var_decl = .parse_variable_declaration(is_mutable: current_param_is_mutable)
@@ -1151,6 +1179,7 @@ struct Parser {
                         ),
                         span: .previous().span(),
                     ))
+                    parameter_complete = true
                 }
                 else => {
                     // TODO: Find a better way of only reporting the first error.

--- a/selfhost/typechecker.jakt
+++ b/selfhost/typechecker.jakt
@@ -397,7 +397,7 @@ struct Typechecker {
         return StructId(module: ModuleId(id: 0), id: 0)
     }
 
-    function try_to_promote_constant_expr_to_type(mut this, lhs_type: TypeId, checked_rhs: mut CheckedExpression, span: Span) throws {
+    function try_to_promote_constant_expr_to_type(mut this, lhs_type: TypeId, mut checked_rhs: CheckedExpression, span: Span) throws {
         if not .is_integer(lhs_type) {
             // TODO
         }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1774,7 +1774,7 @@ pub fn parse_function(
                                 variable: ParsedVariable {
                                     name: var_decl.name,
                                     parsed_type: var_decl.parsed_type,
-                                    mutable: var_decl.mutable,
+                                    mutable: current_param_is_mutable,
                                     span: tokens[*index - 1].span,
                                 },
                             });
@@ -4167,22 +4167,13 @@ pub fn parse_variable_declaration(
             }
 
             if *index < tokens.len() {
-                let mutable = *index + 1 < tokens.len()
-                    && match &tokens[*index].contents {
-                        TokenContents::Name(name) if name == "mut" => {
-                            *index += 1;
-                            true
-                        }
-                        _ => false,
-                    };
-
                 let (var_type, err) = parse_typename(tokens, index);
                 error = error.or(err);
 
                 let result = ParsedVarDecl {
                     name: var_name,
                     parsed_type: var_type,
-                    mutable,
+                    mutable: false,
                     span: name_span,
                     inlay_position: None,
                     visibility,

--- a/tests/typechecker/type_predecl_visibility.jakt
+++ b/tests/typechecker/type_predecl_visibility.jakt
@@ -2,7 +2,7 @@
 /// - output: "OK\n"
 
 struct Foo {
-    function bar(mut this, baz: mut Bar) {
+    function bar(mut this, mut baz: Bar) {
         println("OK")
     }
 }


### PR DESCRIPTION
Previously, the format was `[anon] foo: [mut] Bar`. This changes that to `[anon] [mut] foo: Bar`, which is consistent with mutable variable declarations.

Also, removed a redundant field, added some error checking for where the `anon` and `mut` keywords can appear in a parameter declaration, and fixed a bug.