### PR TITLE
codegen+selfhost: Compiler generated struct pretty printing

### DIFF
--- a/runtime/Jakt/Format.cpp
+++ b/runtime/Jakt/Format.cpp
@@ -9,6 +9,7 @@
 #include <Jakt/GenericLexer.h>
 #include <Jakt/StringBuilder.h>
 #include <Jakt/kstdio.h>
+#include <Jakt/PrettyPrint.h>
 
 #if defined(__serenity__) && !defined(KERNEL)
 #    include <serenity.h>
@@ -607,8 +608,6 @@ void StandardFormatter::parse(TypeErasedFormatParams& params, FormatParser& pars
 ErrorOr<void> Formatter<StringView>::format(FormatBuilder& builder, StringView value)
 {
     if (m_sign_mode != FormatBuilder::SignMode::Default)
-        VERIFY_NOT_REACHED();
-    if (m_alternative_form)
         VERIFY_NOT_REACHED();
     if (m_zero_pad)
         VERIFY_NOT_REACHED();

--- a/runtime/Jakt/PrettyPrint.h
+++ b/runtime/Jakt/PrettyPrint.h
@@ -1,0 +1,20 @@
+#pragma once
+
+#include <Jakt/Error.h>
+
+namespace JaktInternal {
+
+static thread_local inline int _pretty_print_level = 0;
+static thread_local inline bool _pretty_print_enabled = false;
+
+ErrorOr<void> _output_pretty_indent(auto& builder) {
+    if (_pretty_print_enabled) {
+        if(_pretty_print_level > 0)
+            TRY(builder.appendff("\n{:{}}", "", _pretty_print_level * 2));
+        else
+            TRY(builder.append('\n'));
+    }
+    return {};
+}
+
+}

--- a/runtime/lib.h
+++ b/runtime/lib.h
@@ -48,6 +48,7 @@
 #include <Jakt/Weakable.h>
 #include <Jakt/kmalloc.h>
 #include <Jakt/kstdio.h>
+#include <Jakt/PrettyPrint.h>
 
 #include <Jakt/Format.cpp>
 #include <Jakt/GenericLexer.cpp>

--- a/selfhost/main.jakt
+++ b/selfhost/main.jakt
@@ -9,102 +9,11 @@
 import error { JaktError, print_error }
 import lexer { Lexer, Token }
 import parser { BinaryOperator, DefinitionLinkage, DefinitionType, ParsedCall, ParsedExpression, ParsedNamespace, Parser }
-import typechecker
 import utility { panic, todo, Span }
 
 function usage() {
     eprintln("usage: jakt [-l] [-p] <path>")
     return 1
-}
-
-function pretty_print_new_line(anon mut string_builder: StringBuilder, anon level: i64) throws {
-    string_builder.append(b'\n')
-    for indent in 0..level {
-        string_builder.append_string("  ")
-    }
-}
-
-function pretty_print_namespace(anon namespace_: ParsedNamespace) throws {
-    let dump_string = format("{}", namespace_)
-    mut indent_level = 0
-    mut string_builder = StringBuilder::create()
-
-    println("Parsed namespace:\n")
-
-    mut skip_spaces = false
-
-    mut i = 0uz
-    while i < dump_string.length() {
-        let c = dump_string.byte_at(i)
-        match c {
-            b'(' => {
-                string_builder.append(c)
-
-                // Keep empty `()` on a single line.
-                if i + 1 < dump_string.length() and dump_string.byte_at(i + 1) == b')' {
-                    i++
-                    string_builder.append(dump_string.byte_at(i))
-                } else {
-                    indent_level++
-                    pretty_print_new_line(string_builder, indent_level)
-                }
-            }
-            b'[' => {
-                string_builder.append(c)
-
-                // Keep empty `[]` on a single line.
-                if i + 1 < dump_string.length() and dump_string.byte_at(i + 1) == b']' {
-                    i++
-                    string_builder.append(dump_string.byte_at(i))
-                } else {
-                    indent_level++
-                    pretty_print_new_line(string_builder, indent_level)
-                }
-            }
-            b')' | b']' => {
-                indent_level--
-                pretty_print_new_line(string_builder, indent_level)
-
-                string_builder.append(c)
-            }
-            b',' => {
-                string_builder.append(c)
-                pretty_print_new_line(string_builder, indent_level)
-                while i + 1 < dump_string.length() and dump_string.byte_at(i + 1) == b' ' {
-                    i++
-                }
-            }
-            b'"' => {
-                string_builder.append(c)
-                i++
-                mut ended_string = false
-                while i < dump_string.length() and not ended_string {
-                    let c = dump_string.byte_at(i)
-                    match c {
-                        b'\\' => {
-                            string_builder.append(c)
-                            i++
-                            string_builder.append(dump_string.byte_at(i))
-                        }
-                        b'"' => {
-                            string_builder.append(c)
-                            break
-                        }
-                        else => {
-                            string_builder.append(c)
-                        }
-                    }
-
-                    i++
-                }
-            }
-            else => {
-                string_builder.append(c)
-            }
-        }
-        i++
-    }
-    println("{}", string_builder.to_string())
 }
 
 function main(args: [String]) {
@@ -170,7 +79,7 @@ function main(args: [String]) {
     let parsed_namespace = parser.parse_namespace()
 
     if parser_debug {
-        pretty_print_namespace(parsed_namespace)
+        println("{:#}", parsed_namespace);
     }
 
     for error in errors.iterator() {


### PR DESCRIPTION
This is a little bit of a hack with some globals involved, but this allows for pretty printing an object using the "alternate form" format parameter.

So this will pretty print:` println("{:#}", parsed_namespace);`
But this will not: `println("{}", parsed_namespace);`

This happens to be a lot simpler too. 

Example output with this pretty-printer.
```
╰─$ ./build/main -p ./selfhost/utility.jakt                                                                                                                                               130 ↵
ParsedNamespace(
  name: None, 
  name_span: None, 
  functions: [
    ParsedFunction(
      name: "panic", 
      name_span: Span(
        start: 160, 
        end: 165), 
      params: [
        ParsedParameter(
          requires_label: false, 
          variable: ParsedVariable(
            name: "message", 
            parsed_type: ParsedType::Name(
              name: "String", 
              span: Span(
                start: 180, 
                end: 186)), 
            is_mutable: false, 
            span: Span(
              start: 180, 
              end: 186)), 
          span: Span(
            start: 180, 
            end: 186))], 
      generic_parameters: [], 
      block: ParsedBlock(
        stmts: [
          ParsedStatement::Expression(ParsedExpression::Call(
            call: ParsedCall(
              namespace_: [], 
              name: "eprintln", 
              args: [
                (
                  "", 
                  ParsedExpression::QuotedString(
                    val: "internal error: {}", 
                    span: Span(
                      start: 211, 
                      end: 230))), 
                (
                  "", 
                  ParsedExpression::Var(
                    name: "message", 
                    span: Span(
                      start: 233, 
                      end: 240)))], 
              type_args: []), 
            span: Span(
              start: 202, 
              end: 210))), 
          ParsedStatement::Expression(ParsedExpression::Call(
            call: ParsedCall(
              namespace_: [], 
              name: "abort", 
              args: [], 
              type_args: []), 
            span: Span(
              start: 246, 
              end: 251)))]), 
      return_type: ParsedType::Name(
        name: "void", 
        span: Span(
          start: 191, 
          end: 195)), 
      return_type_span: Span(
        start: 191, 
        end: 195), 
      throws: false), 
    ParsedFunction(
      name: "todo", 
      name_span: Span(
        start: 266, 
        end: 270), 
      params: [
        ParsedParameter(
          requires_label: false, 
          variable: ParsedVariable(
            name: "message", 
            parsed_type: ParsedType::Name(
              name: "String", 
              span: Span(
                start: 285, 
                end: 291)), 
            is_mutable: false, 
            span: Span(
              start: 285, 
              end: 291)), 
          span: Span(
            start: 285, 
            end: 291))], 
      generic_parameters: [], 
      block: ParsedBlock(
        stmts: [
          ParsedStatement::Expression(ParsedExpression::Call(
            call: ParsedCall(
              namespace_: [], 
              name: "eprintln", 
              args: [
                (
                  "", 
                  ParsedExpression::QuotedString(
                    val: "TODO: {}", 
                    span: Span(
                      start: 308, 
                      end: 317))), 
                (
                  "", 
                  ParsedExpression::Var(
                    name: "message", 
                    span: Span(
                      start: 320, 
                      end: 327)))], 
              type_args: []), 
            span: Span(
              start: 299, 
              end: 307))), 
          ParsedStatement::Expression(ParsedExpression::Call(
            call: ParsedCall(
              namespace_: [], 
              name: "abort", 
              args: [], 
              type_args: []), 
            span: Span(
              start: 333, 
              end: 338)))]), 
      return_type: ParsedType::Empty, 
      return_type_span: Span(
        start: 0, 
        end: 0), 
      throws: false)], 
  records: [
    ParsedRecord(
      name: "Span", 
      name_span: Span(
        start: 351, 
        end: 355), 
      generic_parameters: [], 
      definition_linkage: DefinitionLinkage::Internal, 
      methods: [], 
      record_type: RecordType::Struct(
        fields: [
          ParsedField(
            var_decl: ParsedVarDecl(
              name: "start", 
              parsed_type: ParsedType::Name(
                name: "usize", 
                span: Span(
                  start: 369, 
                  end: 374)), 
              is_mutable: true, 
              span: Span(
                start: 369, 
                end: 374)), 
            visibility: Visibility::Public), 
          ParsedField(
            var_decl: ParsedVarDecl(
              name: "end", 
              parsed_type: ParsedType::Name(
                name: "usize", 
                span: Span(
                  start: 384, 
                  end: 389)), 
              is_mutable: true, 
              span: Span(
                start: 384, 
                end: 389)), 
            visibility: Visibility::Public)]))], 
  namespaces: [], 
  imports: [])
```