### PR TITLE
selfhost/lexer: Support escape character in byte literal

### DIFF
--- a/selfhost/lexer.jakt
+++ b/selfhost/lexer.jakt
@@ -351,6 +351,10 @@ struct Lexer {
         // Everything but the quotes
         mut builder = StringBuilder::create()
         builder.append(.input[start + 1])
+        if .input[start + 1] == b'\\' {
+            builder.append(.input[start + 2])
+            .index++
+        }
         let str = builder.to_string()
 
         .index++


### PR DESCRIPTION
This patch allows for `b'\n'` to be lexed as SingleQuoteByteString(quote: "\n", ...).
Previously, it was reading only the backslash and skipping the rest.