### PR TITLE
selfhost/parser.jakt: Add support for `is not` expression

### DIFF
--- a/selfhost/parser.jakt
+++ b/selfhost/parser.jakt
@@ -1890,9 +1890,23 @@ struct Parser {
                 }
                 Is => {
                     .index++
-                    let parsed_type = .parse_typename()
-                    let span = merge_spans(start, .current().span())
-                    yield ParsedExpression::UnaryOp(expr: result, op: UnaryOperator::Is(parsed_type), span)
+                    yield match .current() {
+                        Not => {
+                            .index++
+                            let parsed_type = .parse_typename()
+                            let span = merge_spans(start, .current().span())
+                            yield ParsedExpression::UnaryOp(
+                                expr: ParsedExpression::UnaryOp(expr: result, op: UnaryOperator::Is(parsed_type), span),
+                                op: UnaryOperator::LogicalNot,
+                                span
+                            )
+                        }
+                        else => {
+                            let parsed_type = .parse_typename()
+                            let span = merge_spans(start, .current().span())
+                            yield ParsedExpression::UnaryOp(expr: result, op: UnaryOperator::Is(parsed_type), span)
+                        }
+                    }
                 }
                 ColonColon => .parse_postfix_colon_colon(start, expr: result)
                 Dot => {


### PR DESCRIPTION
`not x is EnumVariant` becomes `x is not EnumVariant`