### PR TITLE
main: Fix error printing when called with flags

### DIFF
--- a/selfhost/main.jakt
+++ b/selfhost/main.jakt
@@ -83,7 +83,7 @@ function main(args: [String]) {
     }
 
     for error in errors.iterator() {
-        print_error(file_name: args[1], file_contents, error)
+        print_error(file_name: file_name!, file_contents, error)
     }
 
     if not errors.is_empty() {


### PR DESCRIPTION
If you call the compiler with flags, the error printer would say that
the file name of where the error occurred would be the first flag.