### PR TITLE
selfhost/parser: Avoid infinite loop in enum variants parser

### DIFF
--- a/selfhost/parser.jakt
+++ b/selfhost/parser.jakt
@@ -699,12 +699,12 @@ struct Parser {
                         }
                         variants.push(SumEnumVariant(name, span, params: var_decls))
                     } else {
+                        .index++
                         let none_decls: [ParsedVarDecl]? = None
                         variants.push(SumEnumVariant(name, span, params: none_decls))
                     }
                 }
                 RCurly => {
-                    .index++
                     break
                 }
                 Comma | Eol => {
@@ -747,10 +747,11 @@ struct Parser {
             }
         }
 
-        if .eof() {
+        if not .current() is RCurly {
             .error("Invalid enum definition, expected `}`", .current().span())
             return (variants, methods)
         }
+        .index++
 
         if variants.is_empty() {
             .error("Empty enums are not allowed", partial_enum.name_span)


### PR DESCRIPTION
The variants parser didn't advance the index when the variant that it
encountered was just a name:

```jakt
enum DefinitionLinkage {
  Internal
  External
}
```

It also couldn't differ between an unclosed enum and getting EOF after
closing it since it advanced the index before breaking on `RCurly`. Now
the `RCurly` check is done at the end of the loop, and it is not skipped
inside the loop.
