### PR TITLE
typechecker+tests: Use the most specific known scope id for unknown namespaces

### DIFF
--- a/src/typechecker.rs
+++ b/src/typechecker.rs
@@ -4594,9 +4594,13 @@ pub fn typecheck_expression(
             let checked_namespace = scopes
                 .iter()
                 .zip(ns.iter())
-                .map(|(scope, ns)| CheckedNamespace {
-                    name: Some(ns.clone()),
-                    scope: scope.unwrap(),
+                .scan(scope_id, |last_scope, (scope, ns)| {
+                    let scope = scope.unwrap_or(*last_scope);
+                    *last_scope = scope;
+                    Some(CheckedNamespace {
+                        name: Some(ns.clone()),
+                        scope,
+                    })
                 })
                 .collect();
 

--- a/tests/typechecker/unknown_namespace_in_ns_chain.crash.jakt
+++ b/tests/typechecker/unknown_namespace_in_ns_chain.crash.jakt
@@ -1,0 +1,9 @@
+/// Expect:
+/// - error: "namespace not found"
+
+
+function main() {
+  let x = some::unknown::ns
+}
+
+// Fixes #560.


### PR DESCRIPTION
`unwrap`ping isn't an option if one of the namespaces in the access
chain isn't found. Since `checked_namespaces` is emmited even when
the namespace wasn't found (so that typecheck/IDE can continue knowing
there was a namespace access), using the last scope id
from the last known namespace when the next one wasn't found.

Fixes #560.
