### PR TITLE
selfhost: Implement different number types

### DIFF
--- a/selfhost/lexer.jakt
+++ b/selfhost/lexer.jakt
@@ -424,20 +424,8 @@ struct Lexer {
             .error("unexpected eof", Span(start, end: start))
             return Token::Garbage(Span(start, end: start))
         }
-        if is_ascii_digit(.peek()) {
-            mut total = 0i64
-
-            while is_ascii_digit(.peek()) {
-                let value = .input[.index]
-                ++.index
-                let digit: i64 = as_saturated(value - b'0')
-                total = total * 10 + digit
-            }
-            let end = .index
-            let suffix = .consume_numeric_literal_suffix() ?? LiteralSuffix::I64
-
-            return make_number_token(number: total, suffix, span: Span(start, end))
-
+        if is_ascii_digit(.peek()) {  
+            return .lex_number()
         } else if is_ascii_alpha(.peek()) or .peek() == b'_' {
             mut string_builder = StringBuilder::create()
 
@@ -457,6 +445,48 @@ struct Lexer {
         let end = ++.index
         .error(format("unknown character: {:c}", unknown_char), Span(start, end))
         return Token::Garbage(Span(start, end))
+    }
+
+    function lex_number(mut this) throws -> Token {
+        let start = .index
+        mut total = 0i64
+
+        if .peek() == b'0' {
+            match .peek_ahead(1) {
+                // Hexadecimal number
+                b'x' => {
+                    .index += 2
+                    while(is_ascii_hexdigit(.peek())) {
+                        mut offset: u8 = 0
+                        if (.peek() >= b'a' and .peek() <= b'z') {
+                            offset = 39
+                        } else if (.peek() >= b'A' and .peek() <= b'Z') {
+                            offset = 7
+                        }
+                        let value = .input[.index] - offset
+                        ++.index
+                        let digit: i64 = as_saturated(value - b'0')
+                        total = total * 16 + digit
+                    }
+                    let end = .index
+                    let suffix = .consume_numeric_literal_suffix() ?? LiteralSuffix::I64
+
+                    return make_number_token(number: total, suffix, span: Span(start, end))
+                }
+                else => {}
+            }
+        }
+
+        while is_ascii_digit(.peek()) {
+            let value = .input[.index]
+            ++.index
+            let digit: i64 = as_saturated(value - b'0')
+            total = total * 10 + digit
+        }
+        let end = .index
+        let suffix = .consume_numeric_literal_suffix() ?? LiteralSuffix::I64
+
+        return make_number_token(number: total, suffix, span: Span(start, end))
     }
 
     function consume_numeric_literal_suffix(mut this) -> LiteralSuffix? {

--- a/selfhost/lexer.jakt
+++ b/selfhost/lexer.jakt
@@ -484,6 +484,16 @@ struct Lexer {
                         total = total * 8 + digit
                     }
                 }
+                // Binary Number
+                b'b' => {
+                    .index += 2
+                    while(.peek() == b'0' or .peek() == b'1') {
+                        let value = .input[.index]
+                        ++.index
+                        let digit: i64 = as_saturated(value - b'0')
+                        total = total * 2 + digit
+                    }
+                }
                 else => {}
             }
         }

--- a/selfhost/lexer.jakt
+++ b/selfhost/lexer.jakt
@@ -10,6 +10,7 @@ import utility { Span }
 function is_ascii_alpha(anon c: u8) -> bool => (c >= b'a' and c <= b'z') or (c >= b'A' and c <= b'Z')
 function is_ascii_digit(anon c: u8) -> bool => (c >= b'0' and c <= b'9')
 function is_ascii_hexdigit(anon c: u8) -> bool => (c >= b'0' and c <= b'9') or (c >= b'a' and c <= b'f') or (c >= b'A' and c <= b'F')
+function is_ascii_octdigit(anon c: u8) -> bool => (c >= b'0' and c <= b'8')
 function is_ascii_alphanumeric(anon c: u8) -> bool => is_ascii_alpha(c) or is_ascii_digit(c)
 
 enum Token {
@@ -472,6 +473,16 @@ struct Lexer {
                     let suffix = .consume_numeric_literal_suffix() ?? LiteralSuffix::I64
 
                     return make_number_token(number: total, suffix, span: Span(start, end))
+                }
+                // Octal Number
+                b'o' => {
+                    .index += 2
+                    while(is_ascii_octdigit(.peek())) {
+                        let value = .input[.index]
+                        ++.index
+                        let digit: i64 = as_saturated(value - b'0')
+                        total = total * 8 + digit
+                    }
                 }
                 else => {}
             }


### PR DESCRIPTION
With this patch the lexer can handle hexadecimal, octal and binary numbers