### PR TITLE
all: Allow `return` without value

### DIFF
--- a/samples/control_flow/return_nothing.jakt
+++ b/samples/control_flow/return_nothing.jakt
@@ -1,0 +1,15 @@
+/// Expect:
+/// - output: "PASS\n"
+
+function foo() {
+    if true {
+        println("PASS")
+        return
+    }
+    println("FAIL")
+}
+
+function main() {
+    foo()
+    
+}

--- a/selfhost/parser.jakt
+++ b/selfhost/parser.jakt
@@ -94,7 +94,7 @@ boxed enum ParsedStatement {
     For(iterator_name: String, name_span: Span, range: ParsedExpression, block: ParsedBlock)
     Break
     Continue
-    Return(expr: ParsedExpression, span: Span)
+    Return(expr: ParsedExpression?, span: Span)
     Throw(ParsedExpression)
     Yield(ParsedExpression)
     InlineCpp(block: ParsedBlock, span: Span)
@@ -1527,8 +1527,11 @@ struct Parser {
             }
             Return => {
                 .index++
-                let expr = .parse_expression(allow_assignments: false)
-                yield ParsedStatement::Return(expr, span: merge_spans(start, .previous().span()))
+                let none_expr: ParsedExpression? = None
+                yield match .current() {
+                    Eol | Eof | RCurly => ParsedStatement::Return(expr: none_expr, span: .current().span())
+                    else => ParsedStatement::Return(expr: .parse_expression(allow_assignments: false), span: merge_spans(start, .previous().span()))
+                }
             }
             Let | Mut => {
                 let is_mutable = .current() is Mut

--- a/src/codegen.rs
+++ b/src/codegen.rs
@@ -2306,12 +2306,17 @@ fn codegen_statement(
                 context.control_flow_state = last_control_flow;
             }
         }
-        CheckedStatement::Return(expr) => {
-            let expr = codegen_expr(indent, expr, project, context);
-            output.push_str("return (");
-            output.push_str(&expr);
-            output.push_str(");\n")
-        }
+        CheckedStatement::Return(expr) => match expr {
+            Some(expr) => {
+                let expr = codegen_expr(indent, expr, project, context);
+                output.push_str("return (");
+                output.push_str(&expr);
+                output.push_str(");\n")
+            }
+            None => {
+                output.push_str("return;\n");
+            }
+        },
         CheckedStatement::Yield(expr) => {
             // yield expr -> block_var = expr; goto block_end;
             let expr = codegen_expr(indent, expr, project, context);

--- a/src/ide.rs
+++ b/src/ide.rs
@@ -327,7 +327,7 @@ pub fn find_span_in_statement(
         }
         CheckedStatement::InlineCpp(_) => None,
         CheckedStatement::Loop(block) => find_span_in_block(project, block, span),
-        CheckedStatement::Return(expr) | CheckedStatement::Throw(expr) => {
+        CheckedStatement::Return(Some(expr)) | CheckedStatement::Throw(expr) => {
             find_span_in_expression(project, expr, span)
         }
         CheckedStatement::Try(stmt, _, block) => {
@@ -362,6 +362,7 @@ pub fn find_span_in_statement(
         CheckedStatement::Yield(expr) => find_span_in_expression(project, expr, span),
         CheckedStatement::Break => None,
         CheckedStatement::Continue => None,
+        CheckedStatement::Return(..) => None,
         CheckedStatement::Garbage => None,
     }
 }

--- a/tests/parser/no_return_in_defer.jakt
+++ b/tests/parser/no_return_in_defer.jakt
@@ -1,0 +1,8 @@
+// Expect:
+// - error: "‘return’ is not allowed inside ‘defer’"
+
+function main() {
+    defer {
+        return
+    }
+}


### PR DESCRIPTION
Allow `return` with no argument in both baseline and selfhost.