### PR TITLE
selfhost/typechecker: Reverse logic for is_static

### DIFF
--- a/selfhost/typechecker.jakt
+++ b/selfhost/typechecker.jakt
@@ -180,10 +180,10 @@ class CheckedFunction {
 
     public function is_static(this) -> bool {
         if .params.size() < 1 {
-            return false
+            return true
         }
 
-        return .params[0].variable.name == "this"
+        return .params[0].variable.name != "this"
     }
 
     public function is_mutating(this) -> bool {


### PR DESCRIPTION
A function is considered static if the first parameter is not "this"
or "mut this". The previous logic was inverted. Oops!