### PR TITLE
selfhost/typechecker: Expand type checking of variable declarations

### DIFF
--- a/selfhost/typechecker.jakt
+++ b/selfhost/typechecker.jakt
@@ -1246,21 +1246,43 @@ struct Typechecker {
             lhs = rhs
         }
 
-        if lhs.equals(rhs) {
-            let checked_var = CheckedVariable(
-                name: var.name
-                type_id: lhs
-                is_mutable: false
-                definition_span: var.span
-            )
-            mut module = .current_module()
-            let var_id = module.add_variable(checked_var)
-            .add_var_to_scope(scope_id, name: var.name, var_id, span: checked_var.definition_span)
-            return CheckedStatement::VarDecl(var_id, init: checked_expr)
+        .try_to_promote_constant_expr_to_type(lhs_type: lhs, checked_rhs: checked_expr, span: init.span())
+
+        let weak_ptr_struct_id = .find_struct_in_prelude("WeakPtr")
+        let optional_struct_id = .find_struct_in_prelude("Optional")
+
+        match .get_type(lhs) {
+            GenericInstance(id, args) => {
+                if id.equals(weak_ptr_struct_id) {
+                    if not var.is_mutable {
+                        .error("Weak reference must be mutable", var.span)
+                    }
+
+                    if not lhs.equals(rhs) and not args[0].equals(rhs) and not rhs.equals(UNKNOWN_TYPE_ID) {
+                        .error(format("Type mismatch: expected ‘{}’, but got ‘{}’", .type_name(lhs), .type_name(rhs)), .expression_span(checked_expr))
+                    }
+                }
+                if id.equals(optional_struct_id) {
+                    if not lhs.equals(rhs) and not args[0].equals(rhs) and not rhs.equals(UNKNOWN_TYPE_ID) {
+                        .error(format("Type mismatch: expected ‘{}’, but got ‘{}’", .type_name(lhs), .type_name(rhs)), .expression_span(checked_expr))
+                    }
+                }
+            }
+            else => {
+                todo("typecheck_var_decl implement builtin type checking")
+            }
         }
 
-        todo("implement typecheck var decl")
-        return CheckedStatement::Garbage
+        let checked_var = CheckedVariable(
+            name: var.name
+            type_id: lhs
+            is_mutable: var.is_mutable
+            definition_span: var.span
+        )
+        mut module = .current_module()
+        let var_id = module.add_variable(checked_var)
+        .add_var_to_scope(scope_id, name: var.name, var_id, span: checked_var.definition_span)
+        return CheckedStatement::VarDecl(var_id, init: checked_expr)
     }
 
     function typecheck_while(mut this, guard: ParsedExpression, block: ParsedBlock, scope_id: ScopeId, safety_mode: SafetyMode) throws -> CheckedStatement {

--- a/selfhost/typechecker.jakt
+++ b/selfhost/typechecker.jakt
@@ -1229,16 +1229,16 @@ struct Typechecker {
         While(guard, block) => .typecheck_while(guard, block, scope_id, safety_mode)
         Continue => CheckedStatement::Continue
         Break => CheckedStatement::Break
-        VarDecl(var, init) => .typecheck_var_decl(var, init, scope_id)
+        VarDecl(var, init) => .typecheck_var_decl(var, init, scope_id, safety_mode)
         else => {
             todo("typecheck_statement else")
             yield CheckedStatement::Garbage
         }
     }
 
-    function typecheck_var_decl(mut this, var: ParsedVarDecl, init: ParsedExpression, scope_id: ScopeId) throws -> CheckedStatement {
+    function typecheck_var_decl(mut this, var: ParsedVarDecl, init: ParsedExpression, scope_id: ScopeId, safety_mode: SafetyMode) throws -> CheckedStatement {
         let lhs = .typecheck_typename(parsed_type: var.parsed_type, scope_id)
-        let checked_expr = .typecheck_expression(expr: init, scope_id, safety_mode: SafetyMode::Safe)
+        let checked_expr = .typecheck_expression(expr: init, scope_id, safety_mode)
         let rhs = .expression_type(checked_expr)
 
         if lhs.equals(rhs) {

--- a/selfhost/typechecker.jakt
+++ b/selfhost/typechecker.jakt
@@ -1237,9 +1237,14 @@ struct Typechecker {
     }
 
     function typecheck_var_decl(mut this, var: ParsedVarDecl, init: ParsedExpression, scope_id: ScopeId, safety_mode: SafetyMode) throws -> CheckedStatement {
-        let lhs = .typecheck_typename(parsed_type: var.parsed_type, scope_id)
-        let checked_expr = .typecheck_expression(expr: init, scope_id, safety_mode)
+        mut lhs = .typecheck_typename(parsed_type: var.parsed_type, scope_id)
+        mut checked_expr = .typecheck_expression(expr: init, scope_id, safety_mode)
         let rhs = .expression_type(checked_expr)
+        let UNKNOWN_TYPE_ID = TypeId(module: ModuleId(id: 0), id: 0)
+
+        if lhs.equals(UNKNOWN_TYPE_ID) and not rhs.equals(UNKNOWN_TYPE_ID) {
+            lhs = rhs
+        }
 
         if lhs.equals(rhs) {
             let checked_var = CheckedVariable(


### PR DESCRIPTION
I expanded the existing type checking of variable declarations in the selfhosted compiler to get closer to functionality of the rust compiler.
The checking of builtin types is still missing and will require additional functions.

This is my first pull request, so I'd appreciate all the feedback I can get :^)