### PR TITLE
Fix helper function error

### DIFF
--- a/selfhost/typechecker.jakt
+++ b/selfhost/typechecker.jakt
@@ -169,6 +169,18 @@ struct CheckedNamespace {
     scope: ScopeId
 }
 
+struct CheckedParameter {
+    requires_label: bool
+    variable: CheckedVariable
+}
+
+struct CheckedVariable {
+    name: String
+    type_id: TypeId
+    is_mutable: bool
+    definition_span: Span
+}
+
 class CheckedFunction {
     public name: String
     public return_type_id: TypeId
@@ -195,18 +207,6 @@ class CheckedFunction {
 
         return first_param_variable.name == "this" and first_param_variable.is_mutable
     }
-}
-
-struct CheckedParameter {
-    requires_label: bool
-    variable: CheckedVariable
-}
-
-struct CheckedVariable {
-    name: String
-    type_id: TypeId
-    is_mutable: bool
-    definition_span: Span
 }
 
 struct CheckedVarDecl {


### PR DESCRIPTION
`CheckedFunction`'s method `is_static` did not know about the members of `CheckedParameter` because `CheckedParameter` was defined after `CheckedFunction`. Ideally the order would not matter, but this will get the error in the editor to go away for now.