### PR TITLE
tests/codegen: Fix invalid test

### DIFF
--- a/tests/codegen/control_flow_inside_match.jakt
+++ b/tests/codegen/control_flow_inside_match.jakt
@@ -1,41 +1,42 @@
 /// Expect:
-/// - out: "OK\n"
+/// - output: "OK\n"
 
 function test_continue() -> i64 {
-  mut x: i64 = 10
-  loop {
-    match x {
-      10 => {
-        x = 42
-        continue
-      }
-      else => {
-        return x
-      }
+    mut x: i64 = 10
+    loop {
+        match x {
+            10 => {
+                x = 42
+                continue
+            }
+            else => {
+                return x
+            }
+        }
     }
-  }
+    return -1 // TODO: control flow analysis sholud know that we never get here.
 }
 
 function test_break() -> i64 {
-  mut x: i64 = 10
-  loop {
-    match x {
-      42 => {
-        break
-      }
-      else => { x = 42 }
+    mut x: i64 = 10
+    loop {
+        match x {
+            42 => {
+                break
+            }
+            else => { x = 42 }
+        }
     }
-  }
-  return x
+    return x
 }
 
 function main() {
-  let res_continue = test_continue()
-  let res_break = test_break()
-  if res_continue == res_break && res_continue == 42 {
-    println("OK")
-  } else {
-    println("continue({}) != break({})", res_continue, res_break)
-  }
+    let res_continue = test_continue()
+    let res_break = test_break()
+    if res_continue == res_break and res_continue == 42 {
+        println("OK")
+    } else {
+        println("continue({}) != break({})", res_continue, res_break)
+    }
 }
 // Fixes https://github.com/SerenityOS/jakt/issues/402.


### PR DESCRIPTION
Test `codegen/control_flow_inside_match` was being skipped due to
using `out` instead of `output` inside the `Expect` specification.
Plus other issues like `&&`/`and` and control flow analysis not knowing
that `test_continue`'s loop is unreachable, so I added a `TODO` and an
explicit return with an invalid value so it fails if it get there due
to any other bug.
