### PR TITLE
typechecker: Typecheck all struct fields before looking at methods

### DIFF
--- a/tests/typechecker/struct_file_order.jakt
+++ b/tests/typechecker/struct_file_order.jakt
@@ -1,0 +1,18 @@
+/// Expect:
+/// - output: "PASS\n"
+
+struct Foo {
+    function go(anon bar: Bar) throws {
+        if bar.x == 1 {
+            println("PASS")
+        }
+    }
+}
+
+struct Bar {
+    x: i64
+}
+
+function main() {
+    Foo::go(Bar(x: 1))
+}


### PR DESCRIPTION
This patch adds a separate pass that populates all the `CheckedStruct`
field vectors before actually typechecking struct methods.

This ensures that methods can refer to fields in other structs, even
if those other structs occur after the current struct in file order.