### PR TITLE
tests: Fix invalid test oracles

### DIFF
--- a/tests/parser/no_return_in_defer.jakt
+++ b/tests/parser/no_return_in_defer.jakt
@@ -1,5 +1,5 @@
-// Expect:
-// - error: "‘return’ is not allowed inside ‘defer’"
+/// Expect:
+/// - error: "‘return’ is not allowed inside ‘defer’"
 
 function main() {
     defer {

--- a/tests/typechecker/vardecl_type_mismatch_literal.jakt
+++ b/tests/typechecker/vardecl_type_mismatch_literal.jakt
@@ -1,4 +1,4 @@
-/// Expect
+/// Expect:
 /// - error: "Type mismatch: expected ‘String’, but got ‘i64’\n"
 
 function main() {


### PR DESCRIPTION
The tests `typechecker/vardecl_type_mismatch_literal.jakt` and
`tests/parser/no_return_in_defer.jakt` were skipped because their
test oracles had an invalid syntax.
This is now fixed so that they are run as part of the test suite.