### PR TITLE
selfhost/typechecker: Infer variable declarations

### DIFF
--- a/selfhost/typechecker.jakt
+++ b/selfhost/typechecker.jakt
@@ -1494,8 +1494,9 @@ struct Typechecker {
         let rhs = .expression_type(checked_expr)
         let UNKNOWN_TYPE_ID = TypeId(module: ModuleId(id: 0), id: 0)
 
-        if lhs.equals(UNKNOWN_TYPE_ID) and not rhs.equals(UNKNOWN_TYPE_ID) {
-            lhs = rhs
+        match .get_type(lhs) {
+            Inference(i) => {lhs = rhs}
+            else => {}
         }
 
         .try_to_promote_constant_expr_to_type(lhs_type: lhs, checked_rhs: checked_expr, span: init.span())


### PR DESCRIPTION
Since `typecheck_typename` creates an inference for `let` and `mut`
declarations, rather than checking for the unknown type we now check
for an inferred type before overwriting lhs type to equal rhs type

Example of what this fixes:

```
function main() {
  let a = 4
  println("{}", a)
}
```