### PR TITLE
selfhost: Use new `Parser::parse` function instead of `parse_namespace`

### DIFF
--- a/selfhost/main.jakt
+++ b/selfhost/main.jakt
@@ -70,9 +70,7 @@ function main(args: [String]) {
         }
     }
 
-    mut parser = Parser(index: 0, tokens, errors, ignore_errors: false)
-
-    let parsed_namespace = parser.parse_namespace()
+    let parsed_namespace = Parser::parse(tokens, errors)
 
     if parser_debug {
         println("{:#}", parsed_namespace);

--- a/selfhost/parser.jakt
+++ b/selfhost/parser.jakt
@@ -373,6 +373,11 @@ struct Parser {
     errors: [JaktError]
     ignore_errors: bool
 
+    function parse(tokens: [Token], errors: [JaktError]) throws -> ParsedNamespace {
+        mut parser = Parser(index: 0, tokens, errors, ignore_errors: false)
+        return parser.parse_namespace()
+    }
+
     function error(mut this, anon message: String, anon span: Span) throws {
         if not .ignore_errors {
             .errors.push(JaktError::Message(message, span))


### PR DESCRIPTION
This PR adds a new static `parse` function to `Parser` (similar to `Lexer::lex`, `TypeChecker::typecheck`, and `CodeGenerator::generate`) and uses it in main instead of having main muck around with the internals of the parser directly.