### PR TITLE
selhost/typechecker: Implement more of type_name

### DIFF
--- a/selfhost/typechecker.jakt
+++ b/selfhost/typechecker.jakt
@@ -911,7 +911,72 @@ struct Typechecker {
 
                     yield output
                 }
-                else => "TODO"
+                GenericInstance(id, args) => {
+                    // FIXME: remove prelude_struct_id debugging branch once prelude is added
+                    let prelude_struct_id = StructId(module: ModuleId(id:0), id:0)
+
+                    let array_struct_id = .find_struct_in_prelude("Array")
+                    let dictionary_struct_id = .find_struct_in_prelude("Dictionary")
+                    let optional_struct_id = .find_struct_in_prelude("Optional")
+                    let range_struct_id = .find_struct_in_prelude("Range")
+                    let set_struct_id = .find_struct_in_prelude("Set")
+                    let tuple_struct_id = .find_struct_in_prelude("Tuple")
+                    let weak_ptr_struct_id = .find_struct_in_prelude("WeakPtr")
+
+                    mut output = ""
+
+                    if id.equals(prelude_struct_id) {
+                        mut arg_names: [String] = []
+                        for type_id in args.iterator() {
+                            arg_names.push(.type_name(type_id))
+                        }
+                        output = format("TODO prelude struct: {}, args: {}", id, arg_names)
+                    } else if id.equals(array_struct_id) {
+                        output = format("[{}]", .type_name(args[0]))
+                    } else if id.equals(dictionary_struct_id) {
+                        output = format("[{}:{}]", .type_name(args[0]), .type_name(args[1]))
+                    } else if id.equals(optional_struct_id) {
+                        output = format("{}?", .type_name(args[0]))
+                    } else if id.equals(range_struct_id) {
+                        output = format("{}..{}", .type_name(args[0]), .type_name(args[0]))
+                    } else if id.equals(set_struct_id) {
+                        output = format("{{{}}}", .type_name(args[0]))
+                    } else if id.equals(tuple_struct_id) {
+                        output = "("
+                        mut first = true
+                        for arg in args.iterator() {
+                            if not first {
+                                output += ", "
+                            } else {
+                                first = false
+                            }
+                            output += .type_name(type_id)
+                        }
+                        output += "}"
+                    } else if id.equals(weak_ptr_struct_id) {
+                        output = format("weak {}?", .type_name(args[0]))
+                    } else {
+                        let structure = .get_struct(id)
+                        output = structure.name
+                        output += "<"
+                        mut first = true
+                        for arg in args.iterator() {
+                            if not first {
+                                output += ", "
+                            } else {
+                                first = false
+                            }
+                            output += .type_name(type_id)
+                        }
+                        output += ">"
+                    }
+
+                    yield output
+                }
+                TypeVariable(name) => name
+                Inference(inference_id) => "TODO Inference"
+                RawPtr(type_id) => format("raw {}", .type_name(type_id))
+                else => format("TODO {}", type)
             }
         }
     }


### PR DESCRIPTION
Add the following implementations to type_name:
 * TypeVariable
 * RawPtr
 * GenericInstance with a debug/todo stop-gap output until prelude is available, and the actual implementation for the prelude structs.
 * Inference just as a TODO for easier debugging
 
Also the else branch now gives additional debug printing
until we know it is exhaustive/unreachable.