### PR TITLE
selfhost/typechecker: Add hint for integer promotion errors and add a test for it

### DIFF
--- a/samples/math/integer_promotion_bad.jakt
+++ b/samples/math/integer_promotion_bad.jakt
@@ -1,0 +1,6 @@
+/// Expect:
+/// - error: "Integer promotion failed"
+
+function main() {
+    let a: i16 = 64000
+}

--- a/selfhost/typechecker.jakt
+++ b/selfhost/typechecker.jakt
@@ -878,7 +878,8 @@ struct Typechecker {
 
         let result = promote(rhs_constant, type_id: lhs_type, program: .program)
         if not result.has_value() {
-            .error("Integer promotion failed", span)
+            let type = .get_type(lhs_type)
+            .error_with_hint("Integer promotion failed", span, format("Cannot fit value into range [{}, {}] of type {}.", type.min(), type.max(), .type_name(lhs_type)), span)
             return None
         }
         let new_constant = result!


### PR DESCRIPTION
The rust compiler does not give a hint here, but I thought it might be nice to do so anyway. Especially since this is probably an issue that inexperienced programmers will run into primarily.