### PR TITLE
tests: Make skip explicit

### DIFF
--- a/samples/modules/a.jakt
+++ b/samples/modules/a.jakt
@@ -1,3 +1,5 @@
+/// Expect: Skip
+
 import b
 
 function use_cool_things() {

--- a/samples/modules/b.jakt
+++ b/samples/modules/b.jakt
@@ -1,3 +1,5 @@
+/// Expect: Skip
+
 function something_cool() {
     println("something_cool")
 }

--- a/tests/main.rs
+++ b/tests/main.rs
@@ -179,6 +179,12 @@ fn find_results(
         }
     }
 
+    if output.is_none() && error.is_none() && stderr.is_none() {
+        return Err(JaktError::StringError(
+            "Expected output, error, or stderr".into(),
+        ));
+    }
+
     Ok((output, error, stderr))
 }
 


### PR DESCRIPTION
Fixes #666 

This addresses the problem where tests are implicitly skipped when they don't have expectations.
Tests will now fail if they are not marked as skipped and don't have any expectations.

We also test the selfhosted compiler. In that case we only want to test `main.jakt`.
Instead of marking all other selfhost files as `skip` I've changed the test to target `main.jakt` instead.