### PR TITLE
typechecker: Don't lose typechecking errors in imported files

### DIFF
--- a/src/typechecker.rs
+++ b/src/typechecker.rs
@@ -1862,7 +1862,7 @@ pub fn typecheck_namespace_imports(
         }
     }
 
-    None
+    error
 }
 
 pub fn typecheck_module(


### PR DESCRIPTION
Until now, we've been ignoring any typechecking errors that occur
in imported files. Since codegen didn't do any validation, this meant
that totally invalid programs could still build.