### PR TITLE
jakttest: Add a jakt-based test runner

### DIFF
--- a/jakttest/error.jakt
+++ b/jakttest/error.jakt
@@ -1,0 +1,122 @@
+import utility { Span }
+
+enum JaktError {
+    Message(message: String, span: Span)
+    MessageWithHint(message: String, span: Span, hint: String, hint_span: Span)
+}
+
+function print_error(file_name: String, file_contents: [u8], error: JaktError) throws {
+    match error {
+        Message(message, span) => {
+            display_message_with_span(MessageSeverity::Error, file_name, file_contents, message, span)
+        }
+        MessageWithHint(message, span, hint, hint_span) => {
+            display_message_with_span(MessageSeverity::Error, file_name, file_contents, message, span)
+            display_message_with_span(MessageSeverity::Hint, file_name, file_contents, message: hint, span: hint_span)
+        }
+    }
+}
+
+enum MessageSeverity {
+    Hint
+    Error
+    public function name(this) throws => match this {
+        Hint => "Hint"
+        Error => "Error"
+    }
+    public function ansi_color_code(this) throws => match this {
+        Hint => "94"  // Bright Blue
+        Error => "31" // Red
+    }
+}
+
+function display_message_with_span(anon severity: MessageSeverity, file_name: String, file_contents: [u8], message: String, span: Span) throws {
+    println("{}: {}", severity.name(), message)
+
+    let line_spans = gather_line_spans(file_contents)
+
+    mut line_index = 1uz
+    let largest_line_number = line_spans.size()
+
+    let width = format("{}", largest_line_number).length()
+
+    while line_index < line_spans.size() {
+        if span.start >= line_spans[line_index].0 and span.start <= line_spans[line_index].1 {
+            let column_index = span.start - line_spans[line_index].0
+
+            println("----- \u001b[33m{}:{}:{}\u001b[0m", file_name, line_index + 1, column_index + 1)
+
+            if line_index > 0 {
+                print_source_line(severity, file_contents, file_span: line_spans[line_index - 1], error_span: span, line_number: line_index, largest_line_number)
+            }
+
+            print_source_line(severity, file_contents, file_span: line_spans[line_index], error_span: span, line_number: line_index + 1, largest_line_number)
+
+            for x in 0..(span.start - line_spans[line_index].0 + width + 4) {
+                print(" ")
+            }
+
+            println("\u001b[{}m^- {}\u001b[0m", severity.ansi_color_code(), message)
+
+            while line_index < line_spans.size() and span.end > line_spans[line_index].0 {
+                ++line_index
+                if line_index >= line_spans.size() {
+                    break
+                }
+
+                print_source_line(severity, file_contents, file_span: line_spans[line_index], error_span: span, line_number: line_index + 1, largest_line_number)
+
+                break
+            }
+        } else {
+            ++line_index
+        }
+
+    }
+    println("\u001b[0m-----")
+}
+
+function print_source_line(severity: MessageSeverity, file_contents: [u8], file_span: (usize, usize), error_span: Span, line_number: usize, largest_line_number: usize) throws {
+    mut index = file_span.0
+
+    let width = format("{}", largest_line_number).length()
+
+    print(" {} | ", line_number)
+
+    while index <= file_span.1 {
+        mut c = b' '
+        if index < file_span.1 {
+            c = file_contents[index]
+        } else if error_span.start == error_span.end and index == error_span.start {
+            c = b'_'
+        }
+
+        if (index >= error_span.start and index < error_span.end) or (error_span.start == error_span.end and index == error_span.start) {
+            print("\u001b[{}m{:c}", severity.ansi_color_code(), c)
+        } else {
+            print("\u001b[0m{:c}", c)
+        }
+
+        ++index
+    }
+    println("")
+}
+
+function gather_line_spans(file_contents: [u8]) throws -> [(usize, usize)] {
+    mut idx = 0uz
+    mut output: [(usize, usize)] = []
+
+    mut start = idx
+    while idx < file_contents.size() {
+        if file_contents[idx] == b'\n' {
+            output.push((start, idx))
+            start = idx + 1
+        }
+        idx += 1
+    }
+    if start < idx {
+        output.push((start, idx))
+    }
+
+    return output
+}

--- a/jakttest/jakttest.jakt
+++ b/jakttest/jakttest.jakt
@@ -1,0 +1,124 @@
+import error { JaktError, print_error }
+import lexer { Lexer }
+import parser { Parser }
+
+function usage() => "usage: jakttest [-h] [OPTIONS] <path>"
+
+function compare_test(bytes: [u8], expected: String) throws -> bool {
+    // first, build up the content to compare to
+    mut builder = StringBuilder::create()
+
+    for b in bytes.iterator() {
+        if b == 0xd {
+            // skip
+        } else if b == 0xa {
+            builder.append(b'\\')
+            builder.append(b'n')
+        } else {
+            builder.append(b)
+        }
+    }
+
+    let builder_output = builder.to_string()
+
+    if builder_output != expected {
+        eprintln("expected: {}", expected)
+        eprintln("found:    {}", builder_output)
+        return false
+    }
+    return true
+}
+
+function main(args: [String]) {
+    if args.size() <= 1 {
+        eprintln("{}", usage())
+        return 1
+    }
+
+    let file_name = args[1];
+
+    mut file = File::open_for_reading(file_name)
+    let file_contents = file.read_all()
+
+    mut errors: [JaktError] = []
+
+    let tokens = Lexer::lex(input: file_contents, errors)
+
+    let parsed_test = Parser::parse(tokens, errors);
+
+    match parsed_test {
+        SuccessTest(expected) => {
+            write_to_file(file_contents, output_filename: "output.jakt")
+
+            run_compiler("output.jakt")
+
+            // Windows
+            // run_test("build\\output", expected)
+
+            // Unix
+            run_test("./build/output", expected)
+
+            mut runtest_file = File::open_for_reading("runtest.out")
+            let runtest_output = runtest_file.read_all()
+
+            let test_passes = compare_test(bytes: runtest_output, expected)
+
+            if not test_passes {
+                eprintln("Test failed: {}", file_name)
+                return 1
+            } else {
+                println("Test passed: {}", file_name)
+                return 0
+            }
+        }
+        FailureTest(test) => {
+            write_to_file(file_contents, output_filename: "output.jakt")
+
+            run_compiler("output.jakt")
+        }
+        SkipTest => {
+            println("Expected output/error not found. Test skipped")
+        }
+    }
+}
+
+function run_test(anon filename: String, expected: String) throws {
+    mut run_test_args = [filename]
+
+    run_test_args.push(">")
+    run_test_args.push("runtest.out")
+    run_test_args.push("2>")
+    run_test_args.push("runtest.err")
+
+    mut command = ""
+    for compile_arg in run_test_args.iterator() {
+        command += compile_arg
+        command += " "
+    }
+    
+    system(command.c_string())
+}
+
+function run_compiler(anon output_filename: String) throws {
+    mut compile_args = [
+        "jakt"
+    ]
+    compile_args.push(output_filename)
+    compile_args.push(">")
+    compile_args.push("compiler.out")
+    compile_args.push("2>")
+    compile_args.push("compiler.err")
+
+    mut command = ""
+    for compile_arg in compile_args.iterator() {
+        command += compile_arg
+        command += " "
+    }
+    
+    system(command.c_string())
+}
+
+function write_to_file(file_contents: [u8], output_filename: String) throws {
+    mut outfile = File::open_for_writing(output_filename)
+    outfile.write(file_contents)
+}

--- a/jakttest/lexer.jakt
+++ b/jakttest/lexer.jakt
@@ -1,0 +1,810 @@
+// Copyright (c) 2022, JT <jt@serenityos.org>
+// Copyright (c) 2022, Andreas Kling <kling@serenityos.org>
+//
+// SPDX-License-Identifier: BSD-2-Clause
+
+import error { JaktError }
+import utility { Span }
+
+// FIXME: These should not need explicit "-> bool" return types.
+function is_ascii_alpha(anon c: u8) -> bool => (c >= b'a' and c <= b'z') or (c >= b'A' and c <= b'Z')
+function is_ascii_digit(anon c: u8) -> bool => (c >= b'0' and c <= b'9')
+function is_ascii_hexdigit(anon c: u8) -> bool => (c >= b'0' and c <= b'9') or (c >= b'a' and c <= b'f') or (c >= b'A' and c <= b'F')
+function is_ascii_octdigit(anon c: u8) -> bool => (c >= b'0' and c <= b'8')
+function is_ascii_alphanumeric(anon c: u8) -> bool => is_ascii_alpha(c) or is_ascii_digit(c)
+
+enum Token {
+    SingleQuotedString(quote: String, span: Span)
+    SingleQuotedByteString(quote: String, span: Span)
+    QuotedString(quote: String, span: Span)
+    Number(number: NumericConstant, span: Span)
+    Identifier(name: String, span: Span)
+    Semicolon(Span)
+    Colon(Span)
+    ColonColon(Span)
+    LParen(Span)
+    RParen(Span)
+    LCurly(Span)
+    RCurly(Span)
+    LSquare(Span)
+    RSquare(Span)
+    PercentSign(Span)
+    Plus(Span)
+    Minus(Span)
+    Equal(Span)
+    PlusEqual(Span)
+    PlusPlus(Span)
+    MinusEqual(Span)
+    MinusMinus(Span)
+    AsteriskEqual(Span)
+    ForwardSlashEqual(Span)
+    PercentSignEqual(Span)
+    NotEqual(Span)
+    DoubleEqual(Span)
+    GreaterThan(Span)
+    GreaterThanOrEqual(Span)
+    LessThan(Span)
+    LessThanOrEqual(Span)
+    LeftArithmeticShift(Span)
+    LeftShift(Span)
+    LeftShiftEqual(Span)
+    RightShift(Span)
+    RightArithmeticShift(Span)
+    RightShiftEqual(Span)
+    Asterisk(Span)
+    Ampersand(Span)
+    AmpersandEqual(Span)
+    Pipe(Span)
+    PipeEqual(Span)
+    Caret(Span)
+    CaretEqual(Span)
+    Dollar(Span)
+    Tilde(Span)
+    ForwardSlash(Span)
+    ExclamationPoint(Span)
+    QuestionMark(Span)
+    QuestionMarkQuestionMark(Span)
+    QuestionMarkQuestionMarkEqual(Span)
+    Comma(Span)
+    Dot(Span)
+    DotDot(Span)
+    Eol(Span)
+    Eof(Span)
+    FatArrow(Span)
+    Arrow(Span)
+
+    // Keywords
+    And(Span)
+    Anon(Span)
+    As(Span)
+    Boxed(Span)
+    Break(Span)
+    Catch(Span)
+    Class(Span)
+    Continue(Span)
+    Cpp(Span)
+    Defer(Span)
+    Else(Span)
+    Enum(Span)
+    Extern(Span)
+    False(Span)
+    For(Span)
+    Function(Span)
+    If(Span)
+    Import(Span)
+    In(Span)
+    Is(Span)
+    Let(Span)
+    Loop(Span)
+    Match(Span)
+    Mut(Span)
+    Namespace(Span)
+    Not(Span)
+    Or(Span)
+    Private(Span)
+    Public(Span)
+    Raw(Span)
+    Return(Span)
+    Restricted(Span)
+    Struct(Span)
+    This(Span)
+    Throw(Span)
+    Throws(Span)
+    True(Span)
+    Try(Span)
+    Unsafe(Span)
+    Weak(Span)
+    While(Span)
+    Yield(Span)
+
+    // Catch-all for failed parses
+    Garbage(Span)
+
+    public function span(this) => match this {
+        SingleQuotedString(quote, span) => span
+        SingleQuotedByteString(quote, span) => span
+        QuotedString(quote, span) => span
+        Number(number, span) => span
+        Identifier(name, span) => span
+        Semicolon(span) => span
+        Colon(span) => span
+        ColonColon(span) => span
+        Cpp(span) => span
+        LParen(span) => span
+        RParen(span) => span
+        LCurly(span) => span
+        RCurly(span) => span
+        LSquare(span) => span
+        RSquare(span) => span
+        PercentSign(span) => span
+        Plus(span) => span
+        Minus(span) => span
+        Equal(span) => span
+        PlusEqual(span) => span
+        PlusPlus(span) => span
+        MinusEqual(span) => span
+        MinusMinus(span) => span
+        Arrow(span) => span
+        AsteriskEqual(span) => span
+        ForwardSlashEqual(span) => span
+        PercentSignEqual(span) => span
+        NotEqual(span) => span
+        DoubleEqual(span) => span
+        GreaterThan(span) => span
+        GreaterThanOrEqual(span) => span
+        LessThan(span) => span
+        LessThanOrEqual(span) => span
+        LeftArithmeticShift(span) => span
+        LeftShift(span) => span
+        LeftShiftEqual(span) => span
+        RightShift(span) => span
+        RightArithmeticShift(span) => span
+        RightShiftEqual(span) => span
+        Asterisk(span) => span
+        Ampersand(span) => span
+        AmpersandEqual(span) => span
+        Pipe(span) => span
+        PipeEqual(span) => span
+        Caret(span) => span
+        CaretEqual(span) => span
+        Dollar(span) => span
+        Tilde(span) => span
+        ForwardSlash(span) => span
+        ExclamationPoint(span) => span
+        QuestionMark(span) => span
+        QuestionMarkQuestionMark(span) => span
+        QuestionMarkQuestionMarkEqual(span) => span
+        Comma(span) => span
+        Dot(span) => span
+        DotDot(span) => span
+        Eol(span) => span
+        Eof(span) => span
+        FatArrow(span) => span
+        And(span) => span
+        Anon(span) => span
+        As(span) => span
+        Boxed(span) => span
+        Break(span) => span
+        Catch(span) => span
+        Class(span) => span
+        Continue(span) => span
+        Defer(span) => span
+        Else(span) => span
+        Enum(span) => span
+        Extern(span) => span
+        False(span) => span
+        For(span) => span
+        Function(span) => span
+        If(span) => span
+        Import(span) => span
+        In(span) => span
+        Is(span) => span
+        Let(span) => span
+        Loop(span) => span
+        Match(span) => span
+        Mut(span) => span
+        Namespace(span) => span
+        Not(span) => span
+        Or(span) => span
+        Private(span) => span
+        Public(span) => span
+        Raw(span) => span
+        Restricted(span) => span
+        Return(span) => span
+        Struct(span) => span
+        This(span) => span
+        Throw(span) => span
+        Throws(span) => span
+        True(span) => span
+        Try(span) => span
+        Unsafe(span) => span
+        Weak(span) => span
+        While(span) => span
+        Yield(span) => span
+        Garbage(span) => span
+    }
+
+    function from_keyword_or_identifier(string: String, span: Span) => match string {
+        "and" => Token::And(span)
+        "anon" => Token::Anon(span)
+        "as" => Token::As(span)
+        "boxed" => Token::Boxed(span)
+        "break" => Token::Break(span)
+        "catch" => Token::Catch(span)
+        "class" => Token::Class(span)
+        "continue" => Token::Continue(span)
+        "cpp" => Token::Cpp(span)
+        "defer" => Token::Defer(span)
+        "else" => Token::Else(span)
+        "enum" => Token::Enum(span)
+        "extern" => Token::Extern(span)
+        "false" => Token::False(span)
+        "for" => Token::For(span)
+        "function" => Token::Function(span)
+        "if" => Token::If(span)
+        "import" => Token::Import(span)
+        "in" => Token::In(span)
+        "is" => Token::Is(span)
+        "let" => Token::Let(span)
+        "loop" => Token::Loop(span)
+        "match" => Token::Match(span)
+        "mut" => Token::Mut(span)
+        "namespace" => Token::Namespace(span)
+        "not" => Token::Not(span)
+        "or" => Token::Or(span)
+        "private" => Token::Private(span)
+        "public" => Token::Public(span)
+        "raw" => Token::Raw(span)
+        "return" => Token::Return(span)
+        "restricted" => Token::Restricted(span)
+        "struct" => Token::Struct(span)
+        "this" => Token::This(span)
+        "throw" => Token::Throw(span)
+        "throws" => Token::Throws(span)
+        "true" => Token::True(span)
+        "try" => Token::Try(span)
+        "unsafe" => Token::Unsafe(span)
+        "weak" => Token::Weak(span)
+        "while" => Token::While(span)
+        "yield" => Token::Yield(span)
+        else => Token::Identifier(name: string, span)
+    }
+}
+
+enum LiteralSuffix {
+    // FIXME: Implement floats
+    UZ
+    U8
+    U16
+    U32
+    U64
+    I8
+    I16
+    I32
+    I64
+}
+
+enum NumericConstant {
+    // FIXME: Implement floats
+    I8(i8)
+    I16(i16)
+    I32(i32)
+    I64(i64)
+    U8(u8)
+    U16(u16)
+    U32(u32)
+    U64(u64)
+    USize(u64)
+
+    public function to_usize(this) => match this {
+        I8(num) => num as! usize
+        I16(num) => num as! usize
+        I32(num) => num as! usize
+        I64(num) => num as! usize
+        U8(num) => num as! usize
+        U16(num) => num as! usize
+        U32(num) => num as! usize
+        U64(num) => num as! usize
+        USize(num) => num as! usize
+    }
+}
+
+function make_number_token(number: i64, suffix: LiteralSuffix, span: Span) throws -> Token => match suffix {
+    // FIXME: Implement floats
+    LiteralSuffix::U8 => Token::Number(number: NumericConstant::U8(number as! u8), span)
+    LiteralSuffix::U16 => Token::Number(number: NumericConstant::U16(number as! u16), span)
+    LiteralSuffix::U32 => Token::Number(number: NumericConstant::U32(number as! u32), span)
+    LiteralSuffix::U64 => Token::Number(number: NumericConstant::U64(number as! u64), span)
+    LiteralSuffix::UZ => Token::Number(number: NumericConstant::USize(number as! u64), span)
+
+    LiteralSuffix::I8 => Token::Number(number: NumericConstant::I8(number as! i8), span)
+    LiteralSuffix::I16 => Token::Number(number: NumericConstant::I16(number as! i16), span)
+    LiteralSuffix::I32 => Token::Number(number: NumericConstant::I32(number as! i32), span)
+    LiteralSuffix::I64 => Token::Number(number: NumericConstant::I64(number as! i64), span)
+}
+
+struct Lexer {
+    index: usize
+    input: [u8]
+    errors: [JaktError]
+
+    function lex(input: [u8], errors: [JaktError]) throws -> [Token] {
+        mut lexer = Lexer(index: 0, input, errors)
+        mut tokens: [Token] = []
+
+        for token in lexer {
+            tokens.push(token)
+        }
+
+        return tokens
+    }
+
+    function error(mut this, anon message: String, anon span: Span) throws {
+        .errors.push(JaktError::Message(message, span))
+    }
+
+    // Peek at next upcoming character
+    function peek(this) -> u8 {
+        if .eof() {
+            return 0
+        }
+        return .input[.index]
+    }
+
+    // Peek at upcoming characters, N steps ahead in the stream
+    // FIXME: This could be merged with peek() once we support default arguments
+    function peek_ahead(this, anon steps: usize) -> u8 {
+        if .index + steps >= .input.size() {
+            return 0
+        }
+        return .input[.index + steps]
+    }
+
+    function eof(this) -> bool {
+        return .index >= .input.size()
+    }
+
+    function substring(this, start: usize, length: usize) throws -> String {
+        mut builder = StringBuilder::create()
+        for i in start..length {
+            builder.append(.input[i])
+        }
+        return builder.to_string()
+    }
+
+    function lex_character_constant_or_name(mut this) throws -> Token {
+        if .peek_ahead(1) != b'\'' {
+            return .lex_number_or_name()
+        }
+
+        let is_byte = .peek() == b'b'
+        if is_byte {
+            .index++
+        }
+
+        let start = .index
+        .index++
+
+        mut escaped = false;
+
+        while not .eof() and (escaped or .peek() != b'\'') {
+            if not escaped and .peek() == b'\\' {
+                escaped = true
+            } else {
+                escaped = false
+            }
+
+            .index++
+        }
+
+        if .eof() or .peek() != b'\'' {
+            .error("expected single quote", Span(start, end: start))
+        }
+        .index += 1
+
+        // Everything but the quotes
+        mut builder = StringBuilder::create()
+
+        builder.append(.input[start + 1])
+        if escaped {
+            builder.append(.input[start + 2])
+        }
+
+        let quote = builder.to_string()
+        let end = .index
+        if is_byte {
+            return Token::SingleQuotedByteString(quote, span: Span(start, end))
+        }
+        return Token::SingleQuotedString(quote, span: Span(start, end))
+    }
+
+    function lex_number_or_name(mut this) throws -> Token {
+        let start = .index
+
+        if .eof() {
+            .error("unexpected eof", Span(start, end: start))
+            return Token::Garbage(Span(start, end: start))
+        }
+        if is_ascii_digit(.peek()) {  
+            return .lex_number()
+        } else if is_ascii_alpha(.peek()) or .peek() == b'_' {
+            mut string_builder = StringBuilder::create()
+
+            while is_ascii_alphanumeric(.peek()) or .peek() == b'_' {
+                let value = .input[.index]
+                ++.index
+                string_builder.append(value)
+            }
+            let end = .index
+            let span = Span(start, end)
+            let string = string_builder.to_string()
+
+            return Token::from_keyword_or_identifier(string, span)
+        }
+
+        let unknown_char = .input[.index]
+        let end = ++.index
+        .error(format("unknown character: {:c}", unknown_char), Span(start, end))
+        return Token::Garbage(Span(start, end))
+    }
+
+    function lex_number(mut this) throws -> Token {
+        let start = .index
+        mut total = 0i64
+
+        if .peek() == b'0' {
+            match .peek_ahead(1) {
+                // Hexadecimal number
+                b'x' => {
+                    .index += 2
+                    while(is_ascii_hexdigit(.peek())) {
+                        mut offset: u8 = 0
+                        if (.peek() >= b'a' and .peek() <= b'z') {
+                            offset = 39
+                        } else if (.peek() >= b'A' and .peek() <= b'Z') {
+                            offset = 7
+                        }
+                        let value = .input[.index] - offset
+                        ++.index
+                        let digit: i64 = as_saturated(value - b'0')
+                        total = total * 16 + digit
+                        if .peek() == b'_' {
+                            ++.index
+                        }
+                    }
+                    let end = .index
+                    let suffix = .consume_numeric_literal_suffix() ?? LiteralSuffix::I64
+
+                    return make_number_token(number: total, suffix, span: Span(start, end))
+                }
+                // Octal Number
+                b'o' => {
+                    .index += 2
+                    while(is_ascii_octdigit(.peek())) {
+                        let value = .input[.index]
+                        ++.index
+                        let digit: i64 = as_saturated(value - b'0')
+                        total = total * 8 + digit
+                        if .peek() == b'_' {
+                            ++.index
+                        }
+                    }
+                }
+                // Binary Number
+                b'b' => {
+                    .index += 2
+                    while(.peek() == b'0' or .peek() == b'1') {
+                        let value = .input[.index]
+                        ++.index
+                        let digit: i64 = as_saturated(value - b'0')
+                        total = total * 2 + digit
+                        if .peek() == b'_' {
+                            ++.index
+                        }
+                    }
+                }
+                else => {}
+            }
+        }
+
+        while is_ascii_digit(.peek()) {
+            let value = .input[.index]
+            ++.index
+            let digit: i64 = as_saturated(value - b'0')
+            total = total * 10 + digit
+            if .peek() == b'_' {
+                .index += 1
+            }
+        }
+        let end = .index
+        let suffix = .consume_numeric_literal_suffix() ?? LiteralSuffix::I64
+
+        return make_number_token(number: total, suffix, span: Span(start, end))
+    }
+
+    function consume_numeric_literal_suffix(mut this) -> LiteralSuffix? {
+        match .peek() {
+            b'u' | b'i' => {}
+            else => {
+                return None
+            }
+        }
+
+        if .peek() == b'u' and .peek_ahead(1) == b'z' {
+            .index += 2
+            return LiteralSuffix::UZ
+        }
+
+        mut local_index = 1uz
+        mut width = 0i64
+
+        while is_ascii_digit(.peek_ahead(local_index)) {
+            let value = .input[.index + local_index]
+            ++local_index
+            let digit: i64 = as_saturated(value - b'0')
+            width = width * 10 + digit
+        }
+
+        let suffix = match .peek() {
+            b'u' => match width {
+                8 => LiteralSuffix::U8
+                16 => LiteralSuffix::U16
+                32 => LiteralSuffix::U32
+                64 => LiteralSuffix::U64
+                else => {
+                    return None
+                }
+            }
+            b'i' => match width {
+                8 => LiteralSuffix::I8
+                16 => LiteralSuffix::I16
+                32 => LiteralSuffix::I32
+                64 => LiteralSuffix::I64
+                else => {
+                    return None
+                }
+            }
+            else => {
+                return None
+            }
+        }
+
+        .index += local_index
+        return suffix
+    }
+
+
+    function lex_quoted_string(mut this, delimiter: u8) throws -> Token {
+        let start = .index
+
+        ++.index
+
+        if .eof() {
+            .error("unexpected eof", Span(start, end: start))
+            return Token::Garbage(Span(start, end: start))
+        }
+
+        mut escaped = false
+        while not .eof() and (escaped or .peek() != delimiter) {
+            if not escaped and .peek() == b'\\' {
+                escaped = true
+            } else {
+                escaped = false
+            }
+            ++.index
+        }
+
+        let end = .index
+
+        let str = .substring(start: start + 1, length: .index)
+
+        .index++
+
+        if delimiter == b'\'' {
+            return Token::SingleQuotedString(quote: str, span: Span(start, end))
+        }
+
+        return Token::QuotedString(quote: str, span: Span(start, end))
+    }
+
+    function lex_plus(mut this) -> Token {
+        let start = .index++
+        return match .peek() {
+            b'=' => Token::PlusEqual(Span(start, end: ++.index))
+            b'+' => Token::PlusPlus(Span(start, end: ++.index))
+            else => Token::Plus(Span(start: .index - 1, end: .index))
+        }
+    }
+
+    function lex_minus(mut this) -> Token {
+        let start = .index++
+        return match .peek() {
+            b'=' => Token::MinusEqual(Span(start, end: ++.index))
+            b'-' => Token::MinusMinus(Span(start, end: ++.index))
+            b'>' => Token::Arrow(Span(start, end: ++.index))
+            else => Token::Minus(Span(start: .index - 1, end: .index))
+        }
+    }
+
+    function lex_asterisk(mut this) -> Token {
+        let start = .index++
+        return match .peek() {
+            b'=' => Token::AsteriskEqual(Span(start, end: ++.index))
+            else => Token::Asterisk(Span(start: .index - 1, end: .index))
+        }
+    }
+
+    function lex_forward_slash(mut this) throws -> Token {
+        let start = .index++
+        if .peek() == b'=' {
+            return Token::ForwardSlashEqual(Span(start, end: ++.index))
+        }
+        if .peek() != b'/' {
+            return Token::ForwardSlash(Span(start, end: .index))
+        }
+        return .next() ?? Token::Eof(Span(start: .index, end: .index))
+    }
+
+    function lex_caret(mut this) -> Token {
+        let start = .index++
+        return match .peek() {
+            b'=' => Token::CaretEqual(Span(start, end: ++.index))
+            else => Token::Caret(Span(start: .index - 1, end: .index))
+        }
+    }
+
+    function lex_pipe(mut this) -> Token {
+        let start = .index++
+        return match .peek() {
+            b'=' => Token::PipeEqual(Span(start, end: ++.index))
+            else => Token::Pipe(Span(start: .index - 1, end: .index))
+        }
+    }
+
+    function lex_percent_sign(mut this) -> Token {
+        let start = .index++
+        return match .peek() {
+            b'=' => Token::PercentSignEqual(Span(start, end: ++.index))
+            else => Token::PercentSign(Span(start: .index - 1, end: .index))
+        }
+    }
+
+    function lex_exclamation_point(mut this) -> Token {
+        let start = .index++
+        return match .peek() {
+            b'=' => Token::NotEqual(Span(start, end: ++.index))
+            else => Token::ExclamationPoint(Span(start: .index - 1, end: .index))
+        }
+    }
+
+    function lex_ampersand(mut this) -> Token {
+        let start = .index++
+        return match .peek() {
+            b'=' => Token::AmpersandEqual(Span(start, end: ++.index))
+            else => Token::Ampersand(Span(start: .index - 1, end: .index))
+        }
+    }
+
+    function lex_less_than(mut this) -> Token {
+        let start = .index++
+        return match .peek() {
+            b'=' => Token::LessThanOrEqual(Span(start, end: ++.index))
+            b'>' => {
+                .index++
+                yield match .peek() {
+                    b'=' => Token::LeftShiftEqual(Span(start, end: ++.index))
+                    else => Token::LeftShift(Span(start: .index - 1, end: .index))
+                }
+            }
+            else => Token::LessThan(Span(start: .index - 1, end: .index))
+        }
+    }
+
+    function lex_greater_than(mut this) -> Token {
+        let start = .index++
+        return match .peek() {
+            b'=' => Token::GreaterThanOrEqual(Span(start, end: ++.index))
+            b'>' => {
+                .index++
+                yield match .peek() {
+                    b'=' => Token::RightShiftEqual(Span(start, end: ++.index))
+                    else => Token::RightShift(Span(start: .index - 1, end: .index))
+                }
+            }
+            else => Token::GreaterThan(Span(start: .index - 1, end: .index))
+        }
+    }
+
+    function lex_dot(mut this) -> Token {
+        let start = .index++
+        return match .peek() {
+            b'.' => Token::DotDot(Span(start, end: ++.index))
+            else => Token::Dot(Span(start: .index - 1, end: .index))
+        }
+    }
+
+    function lex_colon(mut this) -> Token {
+        let start = .index++
+        return match .peek() {
+            b':' => Token::ColonColon(Span(start, end: ++.index))
+            else => Token::Colon(Span(start: .index - 1, end: .index))
+        }
+    }
+
+    function lex_question_mark(mut this) -> Token {
+        let start = .index++
+        return match .peek() {
+            b'?' => {
+                .index++
+                yield match .peek() {
+                    b'=' => Token::QuestionMarkQuestionMarkEqual(Span(start, end: ++.index))
+                    else => Token::QuestionMarkQuestionMark(Span(start, end: .index))
+                }
+            }
+            else => Token::QuestionMark(Span(start: .index - 1, end: .index))
+        }
+    }
+
+    function lex_equals(mut this) -> Token {
+        let start = .index++
+        return match .peek() {
+            b'=' => Token::DoubleEqual(Span(start, end: ++.index))
+            b'>' => Token::FatArrow(Span(start, end: ++.index))
+            else => Token::Equal(Span(start: .index - 1, end: .index))
+        }
+    }
+
+    function next(mut this) throws -> Token? {
+        if .index == .input.size() {
+            ++.index
+            return Token::Eof(Span(start: .index - 1, end: .index - 1))
+        }
+        if .eof() {
+            return None
+        }
+        loop {
+            let ch = .peek()
+            if ch == b' ' or ch == b'\t' or ch == b'\r' {
+                .index++
+            } else {
+                break
+            }
+        }
+
+        let start = .index
+
+        return match .input[.index] {
+            b'(' => Token::LParen(Span(start, end: ++.index))
+            b')' => Token::RParen(Span(start, end: ++.index))
+            b'[' => Token::LSquare(Span(start, end: ++.index))
+            b']' => Token::RSquare(Span(start, end: ++.index))
+            b'{' => Token::LCurly(Span(start, end: ++.index))
+            b'}' => Token::RCurly(Span(start, end: ++.index))
+            b'<' => .lex_less_than()
+            b'>' => .lex_greater_than()
+            b'.' => .lex_dot()
+            b',' => Token::Comma(Span(start, end: ++.index))
+            b'~' => Token::Tilde(Span(start, end: ++.index))
+            b';' => Token::Semicolon(Span(start, end: ++.index))
+            b':' => .lex_colon()
+            b'?' => .lex_question_mark()
+            b'+' => .lex_plus()
+            b'-' => .lex_minus()
+            b'*' => .lex_asterisk()
+            b'/' => .lex_forward_slash()
+            b'^' => .lex_caret()
+            b'|' => .lex_pipe()
+            b'%' => .lex_percent_sign()
+            b'!' => .lex_exclamation_point()
+            b'&' => .lex_ampersand()
+            b'$' => Token::Dollar(Span(start, end: ++.index))
+            b'=' => .lex_equals()
+            b'\n' => Token::Eol(Span(start, end: ++.index))
+            b'\'' => .lex_quoted_string(delimiter: b'\'')
+            b'\"' => .lex_quoted_string(delimiter: b'"')
+            b'b' => .lex_character_constant_or_name()
+            b'c' => .lex_character_constant_or_name()
+            else => .lex_number_or_name()
+        }
+    }
+}

--- a/jakttest/parser.jakt
+++ b/jakttest/parser.jakt
@@ -1,0 +1,77 @@
+import error { JaktError }
+import lexer { Token, NumericConstant }
+import utility { panic, todo, Span }
+
+enum ParsedTest {
+    SuccessTest(String),
+    FailureTest(String),
+    SkipTest
+}
+
+struct Parser {
+    index: usize
+    tokens: [Token]
+    errors: [JaktError]
+    ignore_errors: bool
+
+    function parse(tokens: [Token], errors: [JaktError]) throws -> ParsedTest {
+        mut parser = Parser(index: 0, tokens, errors, ignore_errors: false)
+        return parser.parse_test()
+    }
+
+    function parse_test(mut this) -> ParsedTest {
+        loop {
+            match .tokens[.index] {
+                ForwardSlash(span) => {
+                    // We have a test
+                    .index += 2
+
+                    match .tokens[.index] {
+                        Identifier(name, span) => {
+                            if name == "output" {
+                                // skip colon and find the expected value
+                                .index += 2
+                                match .tokens[.index] {
+                                    QuotedString(quote) => {
+                                        return ParsedTest::SuccessTest(quote)
+                                    }
+                                    else => {
+                                        return ParsedTest::SkipTest
+                                    }
+                                }
+                            } else if name == "error" {
+                                // skip colon and find the expected value
+                                .index += 2
+                                match .tokens[.index] {
+                                    QuotedString(quote) => {
+                                        return ParsedTest::FailureTest(quote)
+                                    }
+                                    else => {
+                                        return ParsedTest::SkipTest
+                                    }
+                                }
+                            }
+                        }
+                        else => {}
+                    }
+                }
+                Eof => {
+                    break
+                }
+                else => {
+                    loop {
+                        if .tokens[.index] is Eol {
+                            .index++
+                            break
+                        } else if .tokens[.index] is Eof {
+                            break
+                        } else {
+                            .index++
+                        }
+                    }
+                }
+            }
+        }
+        return ParsedTest::SkipTest
+    }
+}

--- a/jakttest/utility.jakt
+++ b/jakttest/utility.jakt
@@ -1,0 +1,19 @@
+// Copyright (c) 2022, JT <jt@serenityos.org>
+// Copyright (c) 2022, Andreas Kling <kling@serenityos.org>
+//
+// SPDX-License-Identifier: BSD-2-Clause
+
+function panic(anon message: String) -> void {
+    eprintln("internal error: {}", message)
+    abort()
+}
+
+function todo(anon message: String) {
+    eprintln("TODO: {}", message)
+    abort()
+}
+
+struct Span {
+    start: usize
+    end: usize
+}


### PR DESCRIPTION
This adds a simple jakt-based test runner. Currently it will:

* parse the sample file passed to it
* read the expected output/error
* run the jakt compiler against the sample
* redirect the stdout/stderr of the compiler to output files
* for success tests: runs the created binary and checks its output against the expected string
