### PR TITLE
ci: Deny warnings in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,9 @@ jobs:
 
     runs-on: ${{ matrix.platform }}
 
+    env:
+      RUSTFLAGS: --deny warnings
+
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v3
@@ -56,6 +59,10 @@ jobs:
           - stable
 
     runs-on: ubuntu-latest
+
+    env:
+      RUSTFLAGS: --deny warnings
+
     steps:
       - uses: actions/checkout@v2
 


### PR DESCRIPTION
From what I can tell we don't seem to accept PRs that introduce warnings.
This makes sure CI fails on them so we can see warnings instantly.