### PR TITLE
selfhost/parser: Fix expression order of operations

### DIFF
--- a/selfhost/parser.jakt
+++ b/selfhost/parser.jakt
@@ -1717,7 +1717,7 @@ struct Parser {
 
                 let lhs = expr_stack.pop()!
 
-                match parsed_operator {
+                match op {
                     Operator(op, span) => {
                         let new_span = merge_spans(lhs.span(), rhs.span())
 


### PR DESCRIPTION
We can now pass `samples/boolean/logical_and.jakt` :^)