### PR TITLE
selfhost: Update `help()` with build flag

### DIFF
--- a/selfhost/main.jakt
+++ b/selfhost/main.jakt
@@ -13,7 +13,7 @@ import parser { Parser }
 import typechecker { Typechecker }
 
 function usage() => "usage: jakt [-h] [OPTIONS] <path>"
-function help() => "Flags:\n  -h\t\tPrint this help and exit.\n  -l\t\tPrint debug info for the lexer.\n  -p\t\tPrint debug info for the parser."
+function help() => "Flags:\n  -h\t\tPrint this help and exit.\n  -l\t\tPrint debug info for the lexer.\n  -p\t\tPrint debug info for the parser.\n  -b\t\tBuild an executable file."
 
 function flag(args: [String], anon name: String) => args.contains("-" + name)
 


### PR DESCRIPTION
Passing `-h` now shows our shiny new `-b` flag for building executables :^)