### PR TITLE
all: Add support for testing error messages to jakttest

### DIFF
--- a/jakttest/jakttest.jakt
+++ b/jakttest/jakttest.jakt
@@ -29,6 +29,31 @@ function compare_test(bytes: [u8], expected: String) throws -> bool {
     return true
 }
 
+function compare_error(bytes: [u8], expected: String) throws -> bool {
+    // first, build up the content to compare to
+    mut builder = StringBuilder::create()
+
+    for b in bytes.iterator() {
+        if b == 0xd {
+            // skip
+        } else if b == 0xa {
+            builder.append(b'\\')
+            builder.append(b'n')
+        } else {
+            builder.append(b)
+        }
+    }
+
+    let builder_output = builder.to_string()
+
+    if not builder_output.contains(expected) {
+        eprintln("expected: {}", expected)
+        eprintln("found:    {}", builder_output)
+        return false
+    }
+    return true
+}
+
 function main(args: [String]) {
     if args.size() <= 1 {
         eprintln("{}", usage())
@@ -71,13 +96,24 @@ function main(args: [String]) {
                 return 0
             }
         }
-        FailureTest(test) => {
+        FailureTest(expected) => {
             write_to_file(file_contents, output_filename: "output.jakt")
 
             run_compiler("output.jakt")
 
-            // Because we're having to skip failure tests, let's report that it's skipped now
-            return 2
+            mut compiler_error_file = File::open_for_reading("compiler.err")
+            let compiler_error_output = compiler_error_file.read_all()
+
+            let test_passes = compare_error(bytes: compiler_error_output, expected)
+
+            if not test_passes {
+                eprintln("Test failed: {}", file_name)
+                return 1
+            } else {
+                println("Test passed: {}", file_name)
+                return 0
+            }
+
         }
         SkipTest => {
             println("Expected output/error not found. Test skipped")
@@ -107,7 +143,8 @@ function run_test(anon filename: String, expected: String) throws {
 
 function run_compiler(anon output_filename: String) throws {
     mut compile_args = [
-        "jakt"
+        "build/main"
+        "-b"
     ]
     compile_args.push(output_filename)
     compile_args.push(">")

--- a/jakttest/run-all.sh
+++ b/jakttest/run-all.sh
@@ -1,7 +1,20 @@
 #!/bin/bash
 
+if [ ! -x ./build/jakttest ]; then
+    echo "jakttest binary does not exist."
+    echo 'You can build it with `cargo run jakttest/jakttest.jakt`'
+    exit 1
+fi
+
+if [ ! -x ./build/main ]; then
+    echo "selfhosted jakt binary does not exist."
+    echo 'You can build it with `cargo run selfhost/main.jakt`'
+    exit 1
+fi
+
 pass=0
 fail=0
+skipped=0
 
 count=0
 
@@ -15,13 +28,18 @@ set +m
 
 for f in samples/**/*.jakt tests/**/*.jakt; do
     i=$(expr $i + 1)
-    $(./build/jakttest $f >/dev/null 2>/dev/null) >/dev/null 2>/dev/null && result=pass || result=fail 
+    $(./build/jakttest $f >/dev/null 2>/dev/null) >/dev/null 2>/dev/null
+    
+    exitcode=$?
 
-    echo -n "($i/$count: $pass+$fail) "
+    echo -n "($i/$count: $pass+$fail+$skipped) "
 
-    if [ "x$result" == "xpass" ]; then
+    if [ $exitcode == 0 ]; then
         pass=$(expr $pass + 1)
         echo -ne "[ \033[32;1mPASS\033[0m ] "
+    elif [ $exitcode == 2 ]; then
+        skipped=$(expr $skipped + 1)
+        echo -ne "[ \033[33;1mSKIPPED\033[0m ] "
     else
         fail=$(expr $fail + 1)
         echo -ne "[ \033[31;1mFAIL\033[0m ] "
@@ -33,4 +51,5 @@ done
 echo ==============================
 echo $pass passed
 echo $fail failed
+echo $skipped skipped
 echo ==============================

--- a/runtime/prelude.jakt
+++ b/runtime/prelude.jakt
@@ -35,6 +35,7 @@ extern struct String {
     function is_empty(this) -> bool
     function length(this) -> usize
     function byte_at(this, anon index: usize) -> u8
+    function contains(this, anon needle: String) -> bool
 }
 
 extern struct StringBuilder {

--- a/selfhost/error.jakt
+++ b/selfhost/error.jakt
@@ -31,7 +31,7 @@ enum MessageSeverity {
 }
 
 function display_message_with_span(anon severity: MessageSeverity, file_name: String, file_contents: [u8], message: String, span: Span) throws {
-    println("{}: {}", severity.name(), message)
+    eprintln("{}: {}", severity.name(), message)
 
     let line_spans = gather_line_spans(file_contents)
 
@@ -44,7 +44,7 @@ function display_message_with_span(anon severity: MessageSeverity, file_name: St
         if span.start >= line_spans[line_index].0 and span.start <= line_spans[line_index].1 {
             let column_index = span.start - line_spans[line_index].0
 
-            println("----- \u001b[33m{}:{}:{}\u001b[0m", file_name, line_index + 1, column_index + 1)
+            eprintln("----- \u001b[33m{}:{}:{}\u001b[0m", file_name, line_index + 1, column_index + 1)
 
             if line_index > 0 {
                 print_source_line(severity, file_contents, file_span: line_spans[line_index - 1], error_span: span, line_number: line_index, largest_line_number)
@@ -53,10 +53,10 @@ function display_message_with_span(anon severity: MessageSeverity, file_name: St
             print_source_line(severity, file_contents, file_span: line_spans[line_index], error_span: span, line_number: line_index + 1, largest_line_number)
 
             for x in 0..(span.start - line_spans[line_index].0 + width + 4) {
-                print(" ")
+                eprint(" ")
             }
 
-            println("\u001b[{}m^- {}\u001b[0m", severity.ansi_color_code(), message)
+            eprintln("\u001b[{}m^- {}\u001b[0m", severity.ansi_color_code(), message)
 
             while line_index < line_spans.size() and span.end > line_spans[line_index].0 {
                 ++line_index
@@ -73,7 +73,7 @@ function display_message_with_span(anon severity: MessageSeverity, file_name: St
         }
 
     }
-    println("\u001b[0m-----")
+    eprintln("\u001b[0m-----")
 }
 
 function print_source_line(severity: MessageSeverity, file_contents: [u8], file_span: (usize, usize), error_span: Span, line_number: usize, largest_line_number: usize) throws {
@@ -81,7 +81,7 @@ function print_source_line(severity: MessageSeverity, file_contents: [u8], file_
 
     let width = format("{}", largest_line_number).length()
 
-    print(" {} | ", line_number)
+    eprint(" {} | ", line_number)
 
     while index <= file_span.1 {
         mut c = b' '
@@ -92,14 +92,14 @@ function print_source_line(severity: MessageSeverity, file_contents: [u8], file_
         }
 
         if (index >= error_span.start and index < error_span.end) or (error_span.start == error_span.end and index == error_span.start) {
-            print("\u001b[{}m{:c}", severity.ansi_color_code(), c)
+            eprint("\u001b[{}m{:c}", severity.ansi_color_code(), c)
         } else {
-            print("\u001b[0m{:c}", c)
+            eprint("\u001b[0m{:c}", c)
         }
 
         ++index
     }
-    println("")
+    eprintln("")
 }
 
 function gather_line_spans(file_contents: [u8]) throws -> [(usize, usize)] {

--- a/src/codegen.rs
+++ b/src/codegen.rs
@@ -3174,6 +3174,15 @@ fn codegen_expr(
                     }
                 }
                 output.push(')');
+            } else if call.name == "eprint" {
+                output.push_str("warn(");
+                for (i, param) in call.args.iter().enumerate() {
+                    output.push_str(&codegen_expr(indent, &param.1, project, context));
+                    if i != call.args.len() - 1 {
+                        output.push(',');
+                    }
+                }
+                output.push(')');
             } else if call.name == "format" {
                 output.push_str("(String::formatted(");
                 for (i, param) in call.args.iter().enumerate() {

--- a/src/typechecker.rs
+++ b/src/typechecker.rs
@@ -6768,7 +6768,7 @@ pub fn typecheck_call(
     let mut function_id = None;
 
     match call.name.as_str() {
-        "print" | "println" | "eprintln" | "format"
+        "print" | "println" | "eprint" | "eprintln" | "format"
             if !must_be_enum_constructor && parent_id.is_none() =>
         {
             // FIXME: This is a hack since println() and eprintln() are hard-coded into codegen at the moment.


### PR DESCRIPTION
This adds support for testing error messages to jakttest. To do so, it touches a few areas:

* Adds `eprint` to the Rust-based compiler
* Adds string.contains to the Rust-based compiler
* Uses `eprint` and string.contains in the selfhost compiler to output error messages
* Adds support to jakttest to redirect these error messages and search for expected error messages
* Updates the test harness to also notice skipped tests so we see the number of skipped tests

closes #713 