### PR TITLE
selfhost/typechecker: Implement most of typecheck_block

### DIFF
--- a/selfhost/typechecker.jakt
+++ b/selfhost/typechecker.jakt
@@ -2012,6 +2012,37 @@ struct Typechecker {
         }
     }
 
+    function statement_definitely_returns(this, anon statement: CheckedStatement) -> bool => match statement{
+        Return(expr) => true
+        // FIXME: CheckedStatement::If branches ugly implementation due to current compiler limitations
+        If(guard, then_block, else_statement) => {
+            mut ret = false
+            let guard_result = match guard {
+                Boolean(val) => {
+                    if val and then_block.definitely_returns {
+                        ret = true
+                    }
+                    yield ret
+                }
+                else => false
+            }
+            if not guard_result and else_statement.has_value(){
+                if then_block.definitely_returns and .statement_definitely_returns(else_statement.value()) {
+                    ret = true
+                }
+            }
+            yield ret
+        }
+        Block(block) => block.definitely_returns
+        Loop(block) => block.definitely_returns
+        While(guard, block) => block.definitely_returns
+        Expression(match_expr) => match match_expr {
+            Match() => checked_expression_definitely_returns(match_expr)
+            else => false
+        }
+        else => false
+    }
+
     function typecheck_block(mut this, anon parsed_block: ParsedBlock, parent_scope_id: ScopeId, safety_mode: SafetyMode) throws -> CheckedBlock {
         let parent_throws = .get_scope(parent_scope_id).can_throw
         let block_scope_id = .create_scope(parent_scope_id, can_throw: parent_throws)

--- a/selfhost/typechecker.jakt
+++ b/selfhost/typechecker.jakt
@@ -2399,26 +2399,54 @@ struct Typechecker {
             definitely_returns: false
             yielded_type: none_type_id
         )
+        // FIXME: Use [TypeId: TypeID] without TypeId.to_string()/TypeId::from_string() workaround
+        mut generic_inferences: [String: String] = [:]
 
         for parsed_statement in parsed_block.stmts.iterator() {
-            let statement = .typecheck_statement(parsed_statement, scope_id: block_scope_id, safety_mode)
-            
-            match statement {
-                Return(expr) => {
-                    checked_block.definitely_returns = true
-                    checked_block.yielded_type = match expr.has_value() {
-                        true => .expression_type(expr!)
-                        else => builtin(BuiltinType::Void)
-                    }
+
+            let checked_statement = .typecheck_statement(
+                statement: parsed_statement
+                scope_id: block_scope_id
+                safety_mode
+            )
+
+            // check that statment definitly returns
+            checked_block.definitely_returns = .statement_definitely_returns(checked_statement)
+
+            let none_yield: Span? = None // FIXME: Can't yield None directly
+            let yield_span: Span? = match parsed_statement {
+                ParsedStatement::Yield(expr) => Some(expr.span())
+                else => none_yield
+            }
+            let  none_expr: CheckedExpression? = None // FIXME: Can't yield None directly
+            let checked_yield_expression: CheckedExpression? = match checked_statement {
+                CheckedStatement::Yield(expr) => Some(expr)
+                else => none_expr
+            }
+            if yield_span.has_value() and checked_yield_expression.has_value() {
+                let type_var_type_id = .expression_type(checked_yield_expression.value())
+                let type_ = .resolve_type_var(type_var_type_id , scope_id: block_scope_id)
+                if checked_block.yielded_type.has_value() {
+                    // TODO check types for compat
+                    .check_types_for_compat(
+                        lhs_type_id: checked_block.yielded_type.value()
+                        rhs_type_id: type_
+                        generic_enferences: generic_inferences
+                        span: yield_span.value()
+                    )
+                } else {
+                    checked_block.yielded_type = Some(type_)
                 }
-                Yield(expr) => {
-                    checked_block.definitely_returns = true
-                    checked_block.yielded_type = .expression_type(expr)
-                }
-                else => {}
             }
 
-            checked_block.statements.push(statement)
+            checked_block.statements.push(checked_statement)
+        }
+
+        if checked_block.yielded_type.has_value() {
+             checked_block.yielded_type = Some(.substitute_typevars_in_type(
+                 type_id: checked_block.yielded_type.value()
+                 generic_inferences
+             ))
         }
 
         return checked_block

--- a/selfhost/typechecker.jakt
+++ b/selfhost/typechecker.jakt
@@ -681,6 +681,59 @@ boxed enum CheckedExpression {
 
         return None
     }
+
+}
+
+function checked_expression_definitely_returns(anon check_expression: CheckedExpression) -> bool {
+    mut ret = false
+
+    match check_expression {
+        Match(expr, match_cases, span, type_id, all_variants_constant) => {
+            mut case_ret = true
+            for case_ in match_cases.iterator() {
+                match case_ {
+                    EnumVariant(body) => match body {
+                        Block(block) => {
+                            if block.definitely_returns {
+                                continue
+                            }
+                        }
+                        else => {
+                            case_ret = false
+                            break
+                        }
+                    }
+                    Expression(body)  => match body {
+                        Block(block) => {
+                            if block.definitely_returns {
+                                continue
+                            }
+                        }
+                        else => {
+                            case_ret = false
+                            break
+                        }
+                    }
+                    CatchAll(body)  => match body {
+                        Block(block) => {
+                            if block.definitely_returns {
+                                continue
+                            }
+                        }
+                        else => {
+                            case_ret = false
+                            break
+                        }
+                    }
+                }
+            }
+            ret = case_ret
+        }
+        else => {
+            return false
+        }
+    }
+    return ret
 }
 
 struct ResolvedNamespace {

--- a/selfhost/typechecker.jakt
+++ b/selfhost/typechecker.jakt
@@ -55,6 +55,27 @@ struct TypeId {
     function equals(this, anon rhs: TypeId) -> bool {
         return this.module.id == rhs.module.id and this.id == rhs.id
     }
+
+    // FIXME: Remove when we have language support, used as workaround [String:String] <-> [TypeId:TypeId]
+    function to_string(this) throws -> String {
+        return format("{}_{}", .module.id, .id)
+    }
+
+    // FIXME: Remove when we have language support, used as workaround [String:String] <-> [TypeId:TypeId]
+    function from_string(anon type_id_string: String) throws -> TypeId {
+        let parts = type_id_string.split('_')
+        if not (parts.size() == 2) {
+            throw Error::from_errno(999) // FIXME: good error message
+        }
+
+        let module_id = parts[0].to_uint()
+        let type_id = parts[1].to_uint()
+        if module_id.has_value() or not type_id.has_value() {
+            throw Error::from_errno(9999) // FIXME: good error message
+        }
+
+        return TypeId(module: ModuleId(id: module_id.value() as! usize), id: type_id.value() as! usize)
+    }
 }
 
 struct ScopeId {
@@ -2041,6 +2062,252 @@ struct Typechecker {
             else => false
         }
         else => false
+    }
+
+    // FIXME: Use [TypeId: TypeID] without TypeId.to_string()/TypeId::from_string() workaround
+    function check_types_for_compat(mut this, lhs_type_id: TypeId, rhs_type_id: TypeId, mut generic_inferences: [String:String], span: Span) throws -> bool {
+        let lhs_type = .get_type(lhs_type_id)
+
+        let lhs_type_id_string = lhs_type_id.to_string()
+        let rhs_type_id_string = rhs_type_id.to_string()
+
+        let optional_struct_id = .find_struct_in_prelude("Optional")
+        let weakptr_struct_id = .find_struct_in_prelude("WeakPtr")
+
+        // TODO: Skip the type compatibility check if assigning a T to a T? or to a
+        //       weak T? without going through `Some`.
+
+        match lhs_type {
+            TypeVariable() => {
+                // If the call expects a generic type variable, let's see if we've already seen it
+                let seen_type_id_string = generic_inferences.get(lhs_type_id_string)
+                if seen_type_id_string.has_value() {
+                    // We've seen this type variable assigned something before
+                    // we should error if it's incompatible.
+
+                    if seen_type_id_string.value() != rhs_type_id_string {
+                        .error(
+                            format(
+                                "Type mismatch: expected ‘{}’ but got ‘{}’"
+                                .type_name(TypeId::from_string(seen_type_id_string.value()))
+                                .type_name(rhs_type_id)
+                            )
+                            span
+                        )
+                        return false
+                    }
+                } else {
+                    generic_inferences.set(key: lhs_type_id_string, value: rhs_type_id_string)
+                }
+            }
+            GenericEnumInstance(id, args) => {
+                let lhs_enum_id = id
+                let lhs_args = args
+                let rhs_type = .get_type(rhs_type_id)
+                match rhs_type {
+                    GenericEnumInstance(id, args) => {
+                        let rhs_enum_id = id
+                        let rhs_args = args
+                        if lhs_enum_id.equals(rhs_enum_id) {
+                            let lhs_enum = .get_enum(lhs_enum_id)
+                            if lhs_args.size() != rhs_args.size() {
+                                .error(format("mismatched number of generic parameters for {}", lhs_enum.name), span)
+                                return false
+                            }
+
+                            mut idx: usize = 0
+                            while idx < args.size() {
+                                if not .check_types_for_compat(
+                                    lhs_type_id: lhs_args[idx]
+                                    rhs_type_id: rhs_args[idx]
+                                    generic_inferences
+                                    span
+                                ) {
+                                    // FIXME: maybe emit secondary error?
+                                    return false
+                                }
+                                ++idx
+                            }
+                        }
+                    }
+                    else => {
+                        if not rhs_type_id.equals(lhs_type_id) {
+                            .error(
+                                format("Type mismatch: expected ‘{}’ but got ‘{}’", .type_name(lhs_type_id), .type_name(rhs_type_id))
+                                span
+                            )
+                            return false
+                        }
+                    }
+                }
+            }
+            GenericInstance(id, args) => {
+                let lhs_struct_id = id
+                let lhs_args = args
+                let rhs_type = .get_type(rhs_type_id)
+                match rhs_type {
+                    GenericInstance(id, args) => {
+                        let rhs_struct_id = id
+                        if lhs_struct_id.equals(rhs_struct_id) {
+                            let rhs_args = args
+                            let lhs_struct = .get_struct(lhs_struct_id)
+                            if lhs_args.size() != rhs_args.size() {
+                                .error(format("mismatched number of generic parameters for {}", lhs_struct.name), span)
+                                return false
+                            }
+
+                            mut idx: usize = 0
+                            while idx < args.size() {
+                                if not .check_types_for_compat(
+                                    lhs_type_id: lhs_args[idx]
+                                    rhs_type_id: rhs_args[idx]
+                                    generic_inferences
+                                    span
+                                ) {
+                                    // FIXME: maybe emit secondary error?
+                                    return false
+                                }
+                                ++idx
+                            }
+                        } else {
+                            .error(
+                                format("Type mismatch: expected ‘{}’ but got ‘{}’", .type_name(lhs_type_id), .type_name(rhs_type_id))
+                                span
+                            )
+                            return false
+                        }
+                    }
+                    else => {
+                        if not rhs_type_id.equals(lhs_type_id) {
+                            .error(
+                                format("Type mismatch: expected ‘{}’ but got ‘{}’", .type_name(lhs_type_id), .type_name(rhs_type_id))
+                                span
+                            )
+                            return false
+                        }
+                    }
+                }
+            }
+            Enum(enum_id) => {
+                if lhs_type_id.equals(rhs_type_id) {
+                    return true
+                }
+                let rhs_type = .get_type(rhs_type_id)
+                match rhs_type {
+                    GenericEnumInstance(id, args) => {
+                        if enum_id.equals(id) {
+                            let lhs_enum = .get_enum(enum_id)
+                            if args.size() != lhs_enum.generic_parameters.size() {
+                                .error(format("mismatched number of generic parameters for {}", lhs_enum.name), span)
+                                return false
+                            }
+
+                            mut idx: usize = 0
+                            while idx < args.size() {
+                                if not .check_types_for_compat(
+                                    lhs_type_id: lhs_enum.generic_parameters[idx]
+                                    rhs_type_id: args[idx]
+                                    generic_inferences
+                                    span
+                                ) {
+                                    // FIXME: maybe emit secondary error?
+                                    return false
+                                }
+                                ++idx
+                            }
+                        }
+                    }
+                    else => {
+                        if not rhs_type_id.equals(lhs_type_id) {
+                            .error(
+                                format("Type mismatch: expected ‘{}’ but got ‘{}’", .type_name(lhs_type_id), .type_name(rhs_type_id))
+                                span
+                            )
+                            return false
+                        }
+                    }
+                }
+            }
+            Struct(lhs_struct_id) => {
+                if lhs_type_id.equals(rhs_type_id) {
+                    return true
+                }
+                let rhs_type = .get_type(rhs_type_id)
+                match rhs_type {
+                    GenericInstance(id, args) => {
+                        let lhs_struct = .get_struct(lhs_struct_id)
+                        if args.size() != lhs_struct.generic_parameters.size() {
+                            .error(format("mismatched number of generic parameters for {}", lhs_struct.name), span)
+                            return false
+                        }
+
+                        mut idx: usize = 0
+                        while idx < args.size() {
+                            if not .check_types_for_compat(
+                                lhs_type_id: lhs_struct.generic_parameters[idx]
+                                rhs_type_id: args[idx]
+                                generic_inferences
+                                span
+                            ) {
+                                // FIXME: maybe emit secondary error?
+                                return false
+                            }
+                            ++idx
+                        }
+
+                    }
+                    else => {
+                        if not rhs_type_id.equals(lhs_type_id) {
+                            .error(
+                                format("Type mismatch: expected ‘{}’ but got ‘{}’", .type_name(lhs_type_id), .type_name(rhs_type_id))
+                                span
+                            )
+                            return false
+                        }
+                    }
+                }
+            }
+            RawPtr(lhs_rawptr_type_id) => {
+                if lhs_rawptr_type_id.equals(rhs_type_id) {
+                    return true
+                }
+
+                let rhs_type = .get_type(rhs_type_id)
+                match rhs_type {
+                    RawPtr(rhs_rawptr_type_id) => {
+                        if not .check_types_for_compat(
+                            lhs_type_id: lhs_rawptr_type_id
+                            rhs_type_id: rhs_rawptr_type_id
+                            generic_inferences
+                            span
+                        ) {
+                            // FIXME: maybe emit secondary error?
+                            return false
+                        }
+                    }
+                    else => {
+                        if not rhs_type_id.equals(lhs_type_id) {
+                            .error(
+                                format("Type mismatch: expected ‘{}’ but got ‘{}’", .type_name(lhs_type_id), .type_name(rhs_type_id))
+                                span
+                            )
+                            return false
+                        }
+                    }
+                }
+            }
+            else => {
+                if not rhs_type_id.equals(lhs_type_id) {
+                    .error(
+                        format("Type mismatch: expected ‘{}’ but got ‘{}’", .type_name(lhs_type_id), .type_name(rhs_type_id))
+                        span
+                    )
+                    return false
+                }
+            }
+        }
+
+        return true
     }
 
     function typecheck_block(mut this, anon parsed_block: ParsedBlock, parent_scope_id: ScopeId, safety_mode: SafetyMode) throws -> CheckedBlock {

--- a/selfhost/typechecker.jakt
+++ b/selfhost/typechecker.jakt
@@ -2310,6 +2310,85 @@ struct Typechecker {
         return true
     }
 
+    // FIXME: Use [TypeId: TypeID] without TypeId.to_string()/TypeId::from_string() workaround
+    function substitute_typevars_in_type(mut this, type_id: TypeId , generic_inferences: [String: String]) throws -> TypeId {
+        mut result = .substitute_typevars_in_type_helper(type_id, generic_inferences)
+
+        loop {
+            let fixed_point = .substitute_typevars_in_type_helper(type_id, generic_inferences)
+
+            if fixed_point.equals(result) {
+                break
+            } else {
+                result = fixed_point
+            }
+        }
+        return result
+    }
+
+    // FIXME: Use [TypeId: TypeID] without TypeId.to_string()/TypeId::from_string() workaround
+    function substitute_typevars_in_type_helper(mut this, type_id: TypeId , generic_inferences: [String: String]) throws -> TypeId {
+        let type_ = .get_type(type_id)
+
+        match type_ {
+            TypeVariable() => {
+                let replacment_type_id_string = generic_inferences.get(type_id.to_string())
+                if replacment_type_id_string.has_value() {
+                    return TypeId::from_string(replacment_type_id_string.value())
+                }
+            }
+            GenericInstance(id, args) => {
+                mut new_args:[TypeId] = []
+                new_args.ensure_capacity(args.size())
+                for arg in args.iterator() {
+                    new_args.push(.substitute_typevars_in_type(type_id: arg, generic_inferences))
+                }
+
+                return .find_or_add_type_id(Type::GenericInstance(id, args: new_args))
+            }
+            GenericEnumInstance(id, args) => {
+                mut new_args:[TypeId] = []
+                new_args.ensure_capacity(args.size())
+                for arg in args.iterator() {
+                    new_args.push(.substitute_typevars_in_type(type_id: arg, generic_inferences))
+                }
+                return .find_or_add_type_id(Type::GenericEnumInstance(id, args: new_args))
+            }
+            Struct(struct_id) => {
+                let struct_ = .get_struct(struct_id)
+                if not struct_.generic_parameters.is_empty() {
+                    mut new_args:[TypeId] = []
+                    new_args.ensure_capacity(struct_.generic_parameters.size())
+                    for arg in struct_.generic_parameters.iterator() {
+                        new_args.push(.substitute_typevars_in_type(type_id: arg, generic_inferences))
+                    }
+                    return .find_or_add_type_id(Type::GenericInstance(id: struct_id, args: new_args))
+                }
+            }
+            Enum(enum_id) => {
+                let enum_ = .get_enum(enum_id)
+                if not enum_.generic_parameters.is_empty() {
+                    mut new_args:[TypeId] = []
+                    new_args.ensure_capacity(enum_.generic_parameters.size())
+                    for arg in enum_.generic_parameters.iterator() {
+                        new_args.push(.substitute_typevars_in_type(type_id: arg, generic_inferences))
+                    }
+                    return .find_or_add_type_id(Type::GenericEnumInstance(id: enum_id, args: new_args))
+                }
+            }
+            RawPtr(rawptr_type_id) => {
+                let rawptr_type = Type::RawPtr(
+                    .substitute_typevars_in_type(type_id: rawptr_type_id, generic_inferences)
+                )
+                return .find_or_add_type_id(rawptr_type)
+            }
+            else => {
+                return type_id
+            }
+        }
+        return type_id
+    }
+
     function typecheck_block(mut this, anon parsed_block: ParsedBlock, parent_scope_id: ScopeId, safety_mode: SafetyMode) throws -> CheckedBlock {
         let parent_throws = .get_scope(parent_scope_id).can_throw
         let block_scope_id = .create_scope(parent_scope_id, can_throw: parent_throws)

--- a/selfhost/typechecker.jakt
+++ b/selfhost/typechecker.jakt
@@ -624,6 +624,17 @@ enum CheckedUnaryOperator {
     IsEnumVariant(String)
 }
 
+enum CheckedMatchBody {
+    Expression(CheckedExpression)
+    Block(CheckedBlock)
+}
+
+enum CheckedMatchCases {
+    EnumVariant(name: String, args: [(String?, String, Span)], subject_type_id: TypeId, index: usize, scope_id: ScopeId, body: CheckedMatchBody, marker_span: Span)
+    Expression(expression: CheckedExpression, body: CheckedMatchBody, marker_span: Span)
+    CatchAll(body: CheckedMatchBody, marker_span: Span)
+}
+
 boxed enum CheckedExpression {
     Boolean(val: bool, span: Span)
     NumericConstant(val: CheckedNumericConstant, span: Span, type_id: TypeId)
@@ -641,6 +652,7 @@ boxed enum CheckedExpression {
     IndexedDictionary(expr: CheckedExpression, index: CheckedExpression, span: Span, type_id: TypeId)
     IndexedTuple(expr: CheckedExpression, index: usize, span: Span, type_id: TypeId)
     IndexedStruct(expr: CheckedExpression, index: String, span: Span, type_id: TypeId)
+    Match(expr: CheckedExpression, match_cases: [CheckedMatchCases], span: Span, type_id: TypeId, all_variants_constant: bool)
     Call(call: CheckedCall, span: Span, type_id: TypeId)
     MethodCall(expr: CheckedExpression, call: CheckedCall, span: Span, type_id: TypeId)
     NamespacedVar(namespaces: [CheckedNamespace], var: CheckedVariable, span: Span)
@@ -1029,6 +1041,7 @@ struct Typechecker {
         OptionalNone(type_id) => type_id
         OptionalSome(type_id) => type_id
         ForcedUnwrap(type_id) => type_id
+        Match(type_id) => type_id
         Block(type_id) => type_id
         Garbage => builtin(BuiltinType::Void)
     }
@@ -1058,6 +1071,7 @@ struct Typechecker {
         OptionalNone(span) => span
         OptionalSome(span) => span
         ForcedUnwrap(span) => span
+        Match(span) => span
         Block(span) => span
         Garbage(span) => span
     }


### PR DESCRIPTION
This Implements the last big TODO left over by #701 and adds most of the type-checking to typecheck_block that exists in the rust version of the compiler, only one of the support functions has an optimization TODO.

It also adds the following on the way
* the Match expression
* a function to check if an expression definitely returns
* a function to check if statement definitely returns
* a function to check types for their compatibility
* a function to substitute type-vars in types 

**Before:**
```
==============================
75 passed
257 failed
7 skipped
==============================
```

**After:**
```
==============================
76 passed
256 failed
7 skipped
==============================
```

**This PR and #701**
```
==============================
81 passed
251 failed
7 skipped
==============================
```