### PR TITLE
selfhost/typechecker: Fix find_namespace_in_scope() bug

### DIFF
--- a/selfhost/typechecker.jakt
+++ b/selfhost/typechecker.jakt
@@ -1167,7 +1167,7 @@ struct Typechecker {
                 let child_scope = .get_scope(child)
                 if child_scope.namespace_name.has_value() {
                     if name == child_scope.namespace_name.value() {
-                        return (current, false)
+                        return (child, false)
                     }
                 }
             }


### PR DESCRIPTION
There was a bug in find_namespace_in_scope() where we returned the
parent scope of the scope we were looking for instead of the scope
itself.