### PR TITLE
typechecker: Flip lhs and rhs type ids in match expression typecheck

### DIFF
--- a/src/typechecker.rs
+++ b/src/typechecker.rs
@@ -4305,8 +4305,8 @@ pub fn typecheck_match_body(
             match final_result_type {
                 Some(type_id) => {
                     if let Some(err) = check_types_for_compat(
-                        body.type_id(scope_id, project),
                         *type_id,
+                        body.type_id(scope_id, project),
                         generic_parameters,
                         span,
                         project,


### PR DESCRIPTION
In this case we're checking the yielded expression's type id against
the (known) match yielded type, and not viceversa.

Fixes #672.
