### PR TITLE
selfhost/typechecker: Fix panicking Optional unwrap in `typecheck_if`

### DIFF
--- a/selfhost/typechecker.jakt
+++ b/selfhost/typechecker.jakt
@@ -1876,8 +1876,9 @@ struct Typechecker {
         }
 
         let checked_block = .typecheck_block(then_block, parent_scope_id: scope_id, safety_mode)
-        if checked_block.yielded_type.has_value() {
-            .error("An ‘if’ block is not allowed to yield values", then_block.find_yield_span()!)
+        let yield_span = then_block.find_yield_span()
+        if yield_span.has_value() {
+            .error("An ‘if’ block is not allowed to yield values", yield_span!)
         }
 
         mut checked_else: CheckedStatement? = None


### PR DESCRIPTION
In `selfhost/main.jakt:54` there are these lines:
```jakt
if not file_name.has_value() {
  eprintln(...)
  eprintln(...)
  return 1
}
```

That `return 1` makes the block have a yielded type **without having
a yield span**. I've changed `typecheck_if` to find the *actual*
yield span and unwrap it when producing the error once we know it has
a value.
