### PR TITLE
meta/vim: Add install instructions for `packer.nvim` (neovim only)

### DIFF
--- a/editors/vim/README.md
+++ b/editors/vim/README.md
@@ -10,3 +10,14 @@ directory, which is either `~/.vim/pack/plugins/start/` for vim or
 
  1. Add `Plug 'SerenityOS/jakt', { 'rtp': 'editors/vim' }` to your .vimrc
  2. Run `:PlugInstall`
+
+
+**[Neovim only] Install with [packer.nvim](https://github.com/wbthomason/packer.nvim)**
+
+ 1. Add the following to your packer startup:
+    ```lua
+    use { '<path/to/jakt>/editors/vim', as = 'Jakt' }
+    ```
+    Where `<path/to/jakt>` is to be substituted by the location of this repository in your
+    local filesystem.
+ 2. Run `:PackerSync`


### PR DESCRIPTION
I could figure it out myself but I think it's going to be a nice
touch for new contributors.
