### PR TITLE
selfhost/typechecker: Set return type and throws for format function

### DIFF
--- a/selfhost/typechecker.jakt
+++ b/selfhost/typechecker.jakt
@@ -3524,6 +3524,11 @@ struct Typechecker {
 
                     args.push((call.name, checked_arg))
                 }
+                
+                if call.name == "format" {
+                    return_type = builtin(BuiltinType::String)
+                    callee_throws = true
+                }
             }
             else => {
                 let maybe_function_id = .resolve_call(call, namespaces: resolved_namespaces, span, scope_id, must_be_enum_constructor)


### PR DESCRIPTION
The `format` builtin function returns String and could throw.