### PR TITLE
parser+typechecker+compiler+tests: Fix unnamed namespaces

### DIFF
--- a/src/typechecker.rs
+++ b/src/typechecker.rs
@@ -1923,7 +1923,7 @@ pub fn typecheck_namespace_fields(
                 .push(namespace_scope_id);
 
             error = error.or(typecheck_namespace_fields(
-                parsed_namespace,
+                namespace,
                 namespace_scope_id,
                 project,
             ))
@@ -2096,7 +2096,7 @@ pub fn typecheck_namespace_declarations(
                 .push(namespace_scope_id);
             typecheck_namespace_predecl(namespace, namespace_scope_id, project);
             error = error.or(typecheck_namespace_declarations(
-                parsed_namespace,
+                namespace,
                 namespace_scope_id,
                 project,
             ))

--- a/tests/typechecker/unnamed_namespace.jakt
+++ b/tests/typechecker/unnamed_namespace.jakt
@@ -1,0 +1,12 @@
+/// Expect:
+/// - output: "Well hello friends!\n"
+
+namespace {
+    struct Foo {
+        bar: i64
+    }
+}
+
+function main() {
+    println("Well hello friends!")
+}


### PR DESCRIPTION
After looking deeper into the issue of unnamed namespaces that I brought up in #703, there were some more issues that had to be fixed in order to make a test for this bug.
Importantly I added a `uid: u64` field to parsed namespaces and checked namespaces in order to identify unnamed namespaces in the typechecker. Before we did not even try and instead created a new scope each time we encountered the namespaces again in the typechecker (which naturally caused some bugs).
Thanks to @jntrnr for making me look deeper into this issue. I didn't really think about it as much more than fixing a typo when I opened #703.