### PR TITLE
selfhost/typechecker: Fix struct_id bug in namespace_predecl

### DIFF
--- a/selfhost/typechecker.jakt
+++ b/selfhost/typechecker.jakt
@@ -1460,7 +1460,10 @@ struct Typechecker {
         for parsed_record in parsed_namespace.records.iterator() {
             let struct_id = StructId(module: .current_module_id, id: struct_index + module_struct_len)
             match parsed_record.record_type {
-                Struct | Class => { .typecheck_struct_predecl(parsed_record, struct_id, scope_id) }
+                Struct | Class => {
+                    .typecheck_struct_predecl(parsed_record, struct_id, scope_id)
+                    struct_index++
+                }
                 else => {
                     todo(format("typecheck_namespace_predecl: else {}", parsed_record.record_type))
                 }


### PR DESCRIPTION
Fix a bug where we did not update the struct_id when going through all
structs in a namespace and predeclaring them.