### PR TITLE
selfhost/typechecker: Fix infinite recursion in typecheck_typename

### DIFF
--- a/selfhost/typechecker.jakt
+++ b/selfhost/typechecker.jakt
@@ -2629,10 +2629,13 @@ struct Typechecker {
             GenericType(name, generic_parameters, span) => {
                 mut checked_inner_types: [TypeId] = []
 
+                // FIXME: This expects the gerneric_paramters to be parsed as [ParseType] not [(String:Span)]
+                //        as in the rust version
                 for inner_type in generic_parameters.iterator() {
-                    let inner_type_id = .typecheck_typename(parsed_type, scope_id)
-                    checked_inner_types.push(inner_type_id)
+                    //let inner_type_id = .typecheck_typename(inner_type, scope_id)
+                    //checked_inner_types.push(inner_type_id)
                 }
+
                 // FIXME: add support for "GenericResolvedType", though the Rust version
                 // puts this in the parser even though it should be in the typechecker
                 // as the parser doesn't have a concept of type ids


### PR DESCRIPTION
Fix infinite recursion bug for GenericType in typecheck_typename.
Add a FIXME in place as the given data from the parser is also not what the typechecker would expect.
The existing parser FIXME at the corresponding spot has a third opinion.