### PR TITLE
Fix: main function does not check inferred return type nor namespacevar type

### DIFF
--- a/src/typechecker.rs
+++ b/src/typechecker.rs
@@ -4682,10 +4682,16 @@ pub fn typecheck_expression(
             match scope {
                 Some(variable_scope_id) => {
                     if let Some(var) = project.find_var_in_scope(variable_scope_id, v) {
-                        (
-                            CheckedExpression::NamespacedVar(checked_namespace, var.clone(), *span),
-                            check_accessibility(scope_id, variable_scope_id, var, span, project),
-                        )
+                        let checked_namespaced_var = CheckedExpression::NamespacedVar(checked_namespace, var.clone(), *span);
+                        let (_, unify_error) = unify_with_type(var.type_id, type_hint, *span, project);
+                        let access_error = check_accessibility(scope_id, variable_scope_id, var, span, project);
+
+                        let namespaced_var_error: Option<JaktError> = match unify_error {
+                            Some(_) => unify_error,
+                            None => access_error,
+                        };
+
+                        (checked_namespaced_var, namespaced_var_error)
                     } else {
                         // Check if there's a constructor with this name.
 

--- a/tests/typechecker/main_wrong_inferred_type.jakt
+++ b/tests/typechecker/main_wrong_inferred_type.jakt
@@ -1,0 +1,6 @@
+/// Expect:
+/// - error: "Main function must return c_int\n"
+
+function main() {
+    return "0"
+}

--- a/tests/typechecker/return_enum_from_function_wrong_type.jakt
+++ b/tests/typechecker/return_enum_from_function_wrong_type.jakt
@@ -1,0 +1,10 @@
+/// Expect:
+/// - error: "Type mismatch: expected ‘c_int’, but got ‘MyEnum’\n"
+
+enum MyEnum : u64 {
+  Abc = 1
+}
+
+function main () -> c_int {
+  return MyEnum::Abc
+}


### PR DESCRIPTION
# What does this PR do?
It fixes [issue 483](https://github.com/SerenityOS/jakt/issues/483)

# Description of the bug it fixes
On the main function, given no explicit return value it does not check the inferred type against `is_integer`, it is related to another bug I found where if the expression is a `NamespacedVar` it does not check for its type either.
