### PR TITLE
lexer: Better string/char error handling

### DIFF
--- a/selfhost/lexer.jakt
+++ b/selfhost/lexer.jakt
@@ -388,6 +388,12 @@ struct Lexer {
         mut escaped = false;
 
         while not .eof() and (escaped or .peek() != b'\'') {
+            if escaped and (.index - start > 3) {
+                break
+            } else if .index - start > 2 {
+                break
+            }
+
             if not escaped and .peek() == b'\\' {
                 escaped = true
             } else {

--- a/selfhost/lexer.jakt
+++ b/selfhost/lexer.jakt
@@ -585,7 +585,20 @@ struct Lexer {
         }
 
         mut escaped = false
+        mut found_newline = false
+
         while not .eof() and (escaped or .peek() != delimiter) {
+            // Ignore a standalone carriage return
+            if .peek() == b'\r' {
+                ++.index
+            }
+
+            // Strings can't span multiple lines
+            if .peek() == b'\n' {
+                found_newline = true
+                break
+            }
+
             if not escaped and .peek() == b'\\' {
                 escaped = true
             } else {
@@ -595,6 +608,11 @@ struct Lexer {
         }
 
         let end = .index
+
+        if found_newline {
+            .error("expected end quote", Span(start, end))
+            return Token::Garbage(Span(start, end))
+        }
 
         let str = .substring(start: start + 1, length: .index)
 

--- a/src/lexer.rs
+++ b/src/lexer.rs
@@ -980,7 +980,10 @@ fn lex_item(file_id: FileId, bytes: &[u8], index: &mut usize) -> (Token, Option<
 
         let mut escaped = false;
 
-        while *index < bytes.len() && (escaped || bytes[*index] != b'\'') {
+        while *index < bytes.len()
+            && (escaped || bytes[*index] != b'\'')
+            && *index - start < if escaped { 3 } else { 2 }
+        {
             if !escaped && bytes[*index] == b'\\' {
                 escaped = true;
             } else {


### PR DESCRIPTION
Previously when parsing a string, the lexer would just continue to eat characters until a closing quote or EOF was found. It did produce a correct error for such a case, however this meant it could possible consume a _lot_ of input if there were no more strings for a while. This commit makes the lexer stop parsing if a newline is encountered. 

This was causing issues for my IntelliJ plugin, here are the results of this change: 

<details>
<summary>Before</summary>
<img src="https://i.imgur.com/NN24Pus.png" />
</details>

<details>
<summary>After</summary>
<img src="https://i.imgur.com/sXrZO2W.png" />
</details>

Also,  better invalid char escape errors:

<details>
<summary>Before</summary>
<img src="https://i.imgur.com/enAlBoh.png" />
<br />
Idk why there's no pretty error message for this one
<img src="https://i.imgur.com/4Q5c9vd.png" />
</details>

<details>
<summary>After</summary>
<img src="https://i.imgur.com/5EFYvdO.png" />
<br />
<img src="https://i.imgur.com/lFxRvFC.png" />
</details>