### PR TITLE
neovim: Add LSP support for neovim

### DIFF
--- a/editors/vim/README.md
+++ b/editors/vim/README.md
@@ -27,4 +27,9 @@ directory, which is either `~/.vim/pack/plugins/start/` for vim or
     npm run compile
     ```
     So that the LSP server is built.
+
+    Neovim LSP attachment only tested in Neovim 0.7.2's Lua API, needing:
+      - `vim.notify_once`
+      - `vim.start_client`
+
  2. Run `:PackerSync`

--- a/editors/vim/README.md
+++ b/editors/vim/README.md
@@ -28,7 +28,7 @@ directory, which is either `~/.vim/pack/plugins/start/` for vim or
     ```
     So that the LSP server is built.
 
-    Neovim LSP attachment only tested in Neovim 0.7.2's Lua API, needing:
+    Neovim LSP attachment only tested in Neovim 0.7's Lua API, needing:
       - `vim.notify_once`
       - `vim.start_client`
 

--- a/editors/vim/README.md
+++ b/editors/vim/README.md
@@ -20,4 +20,11 @@ directory, which is either `~/.vim/pack/plugins/start/` for vim or
     ```
     Where `<path/to/jakt>` is to be substituted by the location of this repository in your
     local filesystem.
+
+    To get LSP support, make sure you `cd` into `editors/vscode` and run:
+    ```bash
+    npm install
+    npm run compile
+    ```
+    So that the LSP server is built.
  2. Run `:PackerSync`

--- a/editors/vim/ftdetect/jakt.vim
+++ b/editors/vim/ftdetect/jakt.vim
@@ -1,1 +1,12 @@
 au BufRead,BufNewFile *.jakt set filetype=jakt
+if has("nvim")
+  let s:started = 0
+  function! s:Start()
+    if s:started
+      return
+    end
+    let s:started = 1
+    lua require('lsp').start()
+  endfunction
+  au FileType jakt call s:Start()
+end

--- a/editors/vim/lua/lsp.lua
+++ b/editors/vim/lua/lsp.lua
@@ -1,23 +1,37 @@
+-- Set per Neovim *instance*, so that opening another Jakt file (buffer)
+-- in the same instance reuses the already spawned client.
 local client = nil
 
 local function start()
   if client == nil then
+    -- Resolve paths so we don't depend on neovim's CWD:
+    -- `script_dir` will always point to
+    --  <symlink by plugin manager>/lua
     local script_dir = debug.getinfo(1, "S").source:match('@?(.*/)')
+    -- We use `resolve` so that `plugin_dir` points to
+    -- <path/to/jakt>/editors/vim (since `resolve` resolves symlinks)
     local plugin_dir = vim.fn.resolve(script_dir .. '../')
+    -- From there we can point correctly to the LSP server.
     local ls_path = vim.fn.resolve(plugin_dir .. '/../vscode/out/server/src/server.js')
-    local file_readable = vim.fn.filereadable(ls_path) ~= 0
 
+    -- We need the file to be readable by node, otherwise we'll warn the user
+    -- and keep going without the client.
+    local file_readable = vim.fn.filereadable(ls_path) ~= 0
     if file_readable then
       client = vim.lsp.start_client {
         cmd = { 'node', ls_path, '--stdio' }
       }
     else
+      -- We use a starting `\n` because currently Neovim displays
+      -- this warning with some indent. This newline serves a workaround.
+      -- FIXME: Remove newline workaround once Neovim properly displays warnings
       vim.notify_once("\nCouldn't find Jakt language server.\nPlease make sure you follow the documentation at https://github.com/SerenityOS/jakt/blob/main/editors/vim/README.md",  
       vim.log.levels.WARN)
       return
     end
   end
-  
+  -- Attach our LSP client handle to the current buffer. 
+  -- See :help lsp and search for `buf_attach_client` for more info.
   vim.lsp.buf_attach_client(0, client)
 end
 

--- a/editors/vim/lua/lsp.lua
+++ b/editors/vim/lua/lsp.lua
@@ -16,8 +16,8 @@ local function start()
 
     -- We need the file to be readable by node, otherwise we'll warn the user
     -- and keep going without the client.
-    local file_readable = vim.fn.filereadable(ls_path) ~= 0
-    if file_readable then
+    local is_file_readable = vim.fn.filereadable(ls_path) ~= 0
+    if is_file_readable then
       client = vim.lsp.start_client {
         cmd = { 'node', ls_path, '--stdio' }
       }

--- a/editors/vim/lua/lsp.lua
+++ b/editors/vim/lua/lsp.lua
@@ -1,0 +1,21 @@
+local client = nil
+
+local function start()
+  if client == nil then
+    local script_dir = debug.getinfo(1, "S").source:match('@?(.*/)')
+    local plugin_dir = vim.fn.resolve(script_dir .. '../')
+    local ls_path = vim.fn.resolve(plugin_dir .. '/../vscode/out/server/src/server.js')
+    client = vim.lsp.start_client {
+      cmd = { 'node', ls_path, '--stdio' }
+    }
+  end
+  
+  vim.lsp.buf_attach_client(0, client)
+end
+
+
+return {
+  start = start
+}
+
+

--- a/editors/vim/lua/lsp.lua
+++ b/editors/vim/lua/lsp.lua
@@ -5,9 +5,17 @@ local function start()
     local script_dir = debug.getinfo(1, "S").source:match('@?(.*/)')
     local plugin_dir = vim.fn.resolve(script_dir .. '../')
     local ls_path = vim.fn.resolve(plugin_dir .. '/../vscode/out/server/src/server.js')
-    client = vim.lsp.start_client {
-      cmd = { 'node', ls_path, '--stdio' }
-    }
+    local file_readable = vim.fn.filereadable(ls_path) ~= 0
+
+    if file_readable then
+      client = vim.lsp.start_client {
+        cmd = { 'node', ls_path, '--stdio' }
+      }
+    else
+      vim.notify_once("\nCouldn't find Jakt language server.\nPlease make sure you follow the documentation at https://github.com/SerenityOS/jakt/blob/main/editors/vim/README.md",  
+      vim.log.levels.WARN)
+      return
+    end
   end
   
   vim.lsp.buf_attach_client(0, client)


### PR DESCRIPTION
When a jakt file is opened, the LSP server in
`editors/vscode/out/server/src/server.js` is spawned for the current
instance, and the buffer is attached to the client. Requires Nvim 0.7.2.

Before merging, it must be checked that:
  - [x] The neovim version where it works is notified in the documentation, 
      since Neovim's Lua API might change in the future.
  - [x] Instructions to run `npm run compile` so that the `out` path exists.
  - [x] Make `editors/vim/lua/lsp.lua` check for the existing of the script and 
      notifying if it's not there, before trying to start the client.

More yaks will be added to the stack if necessary.
