### PR TITLE
selfhost/lexer: Define whitespace in a single function

### DIFF
--- a/selfhost/lexer.jakt
+++ b/selfhost/lexer.jakt
@@ -847,4 +847,8 @@ struct Lexer {
             else => .lex_number_or_name()
         }
     }
+
+    function is_whitespace(this, anon ch: u8) -> bool {
+        return ch == b' ' or ch == b'\t' or ch == b'\r' or ch == b'\f' or ch == b'\v'
+    }    
 }

--- a/selfhost/lexer.jakt
+++ b/selfhost/lexer.jakt
@@ -804,7 +804,7 @@ struct Lexer {
                 return None
             }
             let ch = .peek()
-            if ch == b' ' or ch == b'\t' or ch == b'\r' {
+            if .is_whitespace(ch) {
                 .index++
             } else {
                 break


### PR DESCRIPTION
A single location to define whitespace, and a name to make intent clear when scanning for the next token in the lexer. If useful, it could be made static to allow use from other parts of the compiler.