### PR TITLE
typechecker+codegen: Add support for the `is` operator

### DIFF
--- a/selfhost/codegen.jakt
+++ b/selfhost/codegen.jakt
@@ -252,10 +252,7 @@ struct CodeGenerator {
                 RawAddress => "&"
                 LogicalNot => "!"
                 BitwiseNot => "~"
-                Is => {
-                    todo("codegen Is")
-                    yield ""
-                }
+                Is(type_id) => "is<" + .codegen_type(type_id) + ">("
                 TypeCast(cast) => {
                     let is_integer = .program.is_integer(cast.type_id())
                     yield match cast {
@@ -282,9 +279,26 @@ struct CodeGenerator {
                 PostIncrement => "++"
                 PostDecrement => "--"
                 TypeCast | Is => ")"
-                IsEnumVariant => {
-                    todo("codegen IsEnumVariant")
-                    yield ""
+                IsEnumVariant(name) => {
+                    mut suffix = ")"
+                    let is_boxed = match .program.get_type(expression_type(expr)) {
+                        Enum(enum_id) => {
+                            let enum_ = .program.get_enum(enum_id)
+                            yield enum_.record_type is Class
+                        }
+                        else => false
+                    }
+                    if is_boxed {
+                        suffix += "->"
+                    } else {
+                        suffix += "."
+                    }
+                    suffix += "has<"
+                    suffix += .codegen_type_possibly_as_namespace(type_id, as_namespace: true)
+                    suffix += "::"
+                    suffix += name
+                    suffix += ">("
+                    yield suffix
                 }
                 else => ""
             }

--- a/selfhost/typechecker.jakt
+++ b/selfhost/typechecker.jakt
@@ -2683,6 +2683,9 @@ struct Typechecker {
             Negate => {
                 return CheckedExpression::UnaryOp(expr: checked_expr, op: checked_op, span, type_id: expr_type_id)
             }
+            Is => {
+                return CheckedExpression::UnaryOp(expr: checked_expr, op: checked_op, span, type_id: builtin(BuiltinType::Bool))
+            }
             else => {
                 todo(format("typecheck_unary_operation: expr:{}, op:{}", checked_expr, checked_op))
             }
@@ -3344,9 +3347,43 @@ struct Typechecker {
                     }
                     yield CheckedUnaryOperator::TypeCast(checked_cast)
                 }
-                else => {
-                    todo(format("UnaryOp else: {}", op))
-                    yield CheckedUnaryOperator::PreIncrement
+                Is(unchecked_type) => {
+                    let type_id = .typecheck_typename(parsed_type: unchecked_type, scope_id)
+                    mut operator_is = CheckedUnaryOperator::Is(type_id)
+                    if type_id.equals(unknown_type_id()) {
+                        match unchecked_type {
+                            ParsedType::Name(name) => {
+                                // Let's assume it's an enum variant
+                                let expr_type_id = expression_type(checked_expr)
+                                match .get_type(expr_type_id) {
+                                    Type::Enum(enum_id) => {
+                                        let enum_ = .get_enum(enum_id)
+                                        mut exists = false
+                                        for variant in enum_.variants.iterator() {
+                                            exists = match variant {
+                                                StructLike(name: var_name) | Typed(name: var_name) | Untyped(name: var_name) => var_name == name
+                                                else => false
+                                            }
+                                            if exists {
+                                                operator_is = CheckedUnaryOperator::IsEnumVariant(name)
+                                                break
+                                            }
+                                        }
+                                        if not exists {
+                                            .error(format("Enum variant '{}' does not exist on '{}'", name, .type_name(expr_type_id)), span)
+                                        }
+                                    }
+                                    else => {
+                                        .error(format("Not a valid type name: {}", name), span)
+                                    }
+                                }
+                            }
+                            else => {
+                                .error("The right-hand side of an `is` operator must be a type name or enum variant", span)
+                            }
+                        }
+                    }
+                    yield operator_is
                 }
             }
             yield .typecheck_unary_operation(checked_expr, checked_op, span, scope_id, safety_mode)


### PR DESCRIPTION
This implementation of the `is` operator differs from the Rust implementation
of jakt, in that any valid type name is accepted as the rhs of the `is` operator.