### PR TITLE
selfhost/typechecker: Add basic typechecking of enums

### DIFF
--- a/selfhost/typechecker.jakt
+++ b/selfhost/typechecker.jakt
@@ -807,6 +807,7 @@ struct CheckedCall {
 }
 
 function unknown_type_id() -> TypeId => TypeId(module: ModuleId(id: 0), id: 0)
+function unknown_scope_id() -> ScopeId => ScopeId(module: ModuleId(id: 0), id: 0)
 
 function builtin(anon builtin: BuiltinType) -> TypeId {
     return TypeId(module: ModuleId(id: 0), id: builtin as! usize)

--- a/selfhost/typechecker.jakt
+++ b/selfhost/typechecker.jakt
@@ -1,9 +1,10 @@
 import error { JaktError }
+import lexer { NumericConstant }
 import parser { BinaryOperator, DefinitionLinkage, DefinitionType, UnaryOperator,
                 FunctionLinkage, FunctionType, ParsedBlock, ParsedCall,
                 ParsedExpression, ParsedFunction, ParsedNamespace,
                 ParsedType, ParsedStatement, ParsedVarDecl, RecordType,
-                ParsedRecord, ParsedField }
+                ParsedRecord, ParsedField, TypeCast }
 import utility { panic, todo, Span }
 
 enum SafetyMode {
@@ -481,6 +482,16 @@ enum NumberConstant {
     Signed(i64)
     Unsigned(u64)
     Floating(f64)
+
+    // FIXME: Maybe we should not assume the type cast always succeeds
+    function to_usize(this) -> usize => match this {
+        Signed(value) => value as! usize
+        Unsigned(value) => value as! usize
+        else => {
+            panic("Cannot convert floating point constants to usize")
+            yield 0uz
+        }
+    }
 
     function can_fit_number(this, type_id: TypeId, program: CheckedProgram) -> bool {
         let type_ = program.get_type(type_id)
@@ -1369,6 +1380,20 @@ struct Typechecker {
         return None
     }
 
+    function find_enum_in_scope(this, scope_id: ScopeId, name: String) -> EnumId? {
+        mut current_scope_id = Some(scope_id)
+        while current_scope_id.has_value() {
+            let scope = .get_scope(id: current_scope_id!)
+
+            if scope.enums.contains(name) {
+                return scope.enums[name]
+            }
+
+            current_scope_id = scope.parent
+        }
+        return None
+    }
+
     function find_struct_in_scope(this, scope_id: ScopeId, name: String) -> StructId? {
         mut current_scope_id = Some(scope_id)
         while current_scope_id.has_value() {
@@ -1938,8 +1963,15 @@ struct Typechecker {
                     }
                     .typecheck_struct(record, struct_id: struct_id!, parent_scope_id: scope_id)
                 }
-                else => {
-                    todo(format("typecheck_namespace_declarations implement parsion of record type {}", record.record_type))
+                ValueEnum | SumEnum => {
+                    let enum_id = .find_enum_in_scope(scope_id, name: record.name)
+                    if not enum_id.has_value() {
+                        panic("Can't find enum that has been previous added")
+                    }
+                    .typecheck_enum(record, enum_id: enum_id!, parent_scope_id: scope_id)
+                }
+                Garbage => {
+                    panic("Trying to typecheck a garbage record")
                 }
             }
         }
@@ -1947,6 +1979,271 @@ struct Typechecker {
         for fun in parsed_namespace.functions.iterator() {
             .typecheck_function(parsed_function: fun, parent_scope_id: scope_id)
         }
+    }
+
+    function typecheck_enum(mut this, record: ParsedRecord, enum_id: EnumId, parent_scope_id: ScopeId) throws {
+        let enum_type_id = .find_type_in_scope(scope_id: parent_scope_id, name: record.name)!
+        let enum_scope_id = .get_enum(enum_id).scope_id
+        mut module = .current_module()
+        mut enum_variants = module.enums[enum_id.id].variants
+        mut next_constant_value: u64? = 0u64
+        mut seen_names: [String:Span] = [:]
+
+        match record.record_type {
+            ValueEnum(variants) => {
+                for variant in variants.iterator() {
+                    if seen_names.contains(variant.name) {
+                        .error_with_hint(
+                            format("Enum variant '{}' is defined more than once", variant.name)
+                            variant.span
+                            "Previously seen here"
+                            seen_names[variant.name]
+                        )
+                        continue
+                    }
+
+                    seen_names.set(variant.name, variant.span)
+
+                    if variant.value.has_value() {
+                        // EnumVariant::WithValue
+                        let checked_tuple = .typecheck_enum_variant_with_value(
+                            name: variant.name
+                            span: variant.span
+                            value: variant.value!
+                            next_constant_value
+                            record
+                            enum_id
+                            enum_scope_id
+                            enum_type_id
+                            parent_scope_id
+                        )
+                        let checked_variant = checked_tuple.0
+                        next_constant_value = checked_tuple.1
+                        if checked_variant.has_value() {
+                            enum_variants.push(checked_variant!)
+                        }
+                    } else {
+                        // EnumVariant::Untyped
+                        let checked_tuple = .typecheck_enum_variant_untyped(
+                            name: variant.name
+                            span: variant.span
+                            next_constant_value
+                            record
+                            enum_id
+                            enum_scope_id
+                            enum_type_id
+                            parent_scope_id
+                        )
+                        let checked_variant = checked_tuple.0
+                        next_constant_value = checked_tuple.1
+                        if checked_variant.has_value() {
+                            enum_variants.push(checked_variant!)
+                        }
+                    }
+                }
+            }
+            SumEnum(variants) => {
+                for variant in variants.iterator() {
+                    if seen_names.contains(variant.name) {
+                        .error_with_hint(
+                            format("Enum variant '{}' is defined more than once", variant.name)
+                            variant.span
+                            "Previously seen here"
+                            seen_names[variant.name]
+                        )
+                        continue
+                    }
+
+                    seen_names.set(variant.name, variant.span)
+
+                    if variant.params.has_value() {
+                        // EnumVariant::StructLike
+                        let checked_tuple = .typecheck_enum_variant_struct_like(
+                            name: variant.name
+                            span: variant.span
+                            params: variant.params!
+                            next_constant_value
+                            record
+                            enum_id
+                            enum_scope_id
+                            enum_type_id
+                            parent_scope_id
+                        )
+                        let checked_variant = checked_tuple.0
+                        next_constant_value = checked_tuple.1
+                        if checked_variant.has_value() {
+                            enum_variants.push(checked_variant!)
+                        }
+                    } else {
+                        // EnumVariant::Untyped
+                        let checked_tuple = .typecheck_enum_variant_untyped(
+                            name: variant.name
+                            span: variant.span
+                            next_constant_value
+                            record
+                            enum_id
+                            enum_scope_id
+                            enum_type_id
+                            parent_scope_id
+                        )
+                        let checked_variant = checked_tuple.0
+                        next_constant_value = checked_tuple.1
+                        if checked_variant.has_value() {
+                            enum_variants.push(checked_variant!)
+                        }
+                    }
+                }
+            }
+            else => {
+                panic("typecheck_enum: illegal record type")
+            }
+        }
+    }
+
+    function cast_to_underlying(mut this, anon expr: ParsedExpression, parsed_type: ParsedType, enum_scope_id: ScopeId, span: Span) throws -> CheckedExpression {
+        let expression = ParsedExpression::UnaryOp(
+            expr
+            op: UnaryOperator::TypeCast(TypeCast::Infallible(parsed_type))
+            span
+        )
+
+        return .typecheck_expression(expression, scope_id: enum_scope_id, safety_mode: SafetyMode::Safe)
+    }
+
+    function typecheck_enum_variant_untyped(mut this, name: String, span: Span, next_constant_value: u64?, record: ParsedRecord, enum_id: EnumId, enum_scope_id: ScopeId, enum_type_id: TypeId, parent_scope_id: ScopeId) throws -> (CheckedEnumVariant?, u64?) {
+        let underlying_type_id = .get_enum(enum_id).underlying_type_id
+
+        mut output_variant: CheckedEnumVariant? = None
+        if not underlying_type_id.equals(unknown_type_id()) {
+            if not next_constant_value.has_value() {
+                .error(
+                    "Missing enum variant value, the enum underlying type is not numeric, and so all enum variants must have explicit values"
+                    span
+                )
+                let none_enum_variant: CheckedEnumVariant? = None
+                return (none_enum_variant, next_constant_value)
+            }
+
+            let underlying_type = match record.record_type {
+                ValueEnum(underlying_type) => underlying_type
+                else => ParsedType::Empty
+            }
+
+            let checked_expression = .cast_to_underlying(
+                ParsedExpression::NumericConstant(val: NumericConstant::U64(next_constant_value!), span)
+                parsed_type: underlying_type
+                enum_scope_id
+                span
+            )
+
+            output_variant = CheckedEnumVariant::WithValue(
+                name
+                expr: checked_expression
+                span
+            )
+
+            next_constant_value = next_constant_value! + 1
+
+            mut module = .current_module()
+            let var_id = module.add_variable(CheckedVariable(
+                name
+                type_id: enum_type_id
+                is_mutable: false
+                definition_span: span
+            ))
+            .add_var_to_scope(scope_id: enum_scope_id, name, var_id, span)
+        } else {
+            output_variant = CheckedEnumVariant::Untyped(name, span)
+        }
+
+        if not .find_function_in_scope(parent_scope_id: enum_scope_id, function_name: name).has_value() {
+            let is_boxed = match record.record_type {
+                SumEnum(is_boxed) => is_boxed
+                else => false
+            }
+            let function_scope_id = .create_scope(parent_scope_id: enum_scope_id, can_throw: is_boxed)
+            let block_scope_id = .create_scope(parent_scope_id: function_scope_id, can_throw: is_boxed)
+
+            let none_type: TypeId? = None
+
+            // TODO: remove this check once we support generic parameters in the constructor below
+            if not record.generic_parameters.is_empty() {
+                todo("typecheck_enum_variant_untyped implement support for generic parameters")
+            }
+
+            let checked_constructor = CheckedFunction(
+                name
+                name_span: span
+                return_type_id: enum_type_id
+                params: []
+                // TODO: support generic parameters
+                generic_params: []
+                block: CheckedBlock(
+                    statements: []
+                    scope_id: block_scope_id
+                    definitely_returns: false
+                    yielded_type: none_type
+                )
+                can_throw: is_boxed
+                type: FunctionType::ImplicitEnumConstructor
+                linkage: FunctionLinkage::Internal
+                function_scope_id
+            )
+
+            mut module = .current_module()
+            module.functions.push(checked_constructor)
+
+            let function_id = FunctionId(module: .current_module_id, id: module.functions.size() - 1)
+
+            .add_function_to_scope(parent_scope_id: enum_scope_id, name, function_id, span)
+        }
+        return (output_variant, next_constant_value)
+    }
+
+    function typecheck_enum_variant_with_value(mut this, name: String, span: Span, value: ParsedExpression, next_constant_value: u64?, record: ParsedRecord, enum_id: EnumId, enum_scope_id: ScopeId, enum_type_id: TypeId, parent_scope_id: ScopeId) throws -> (CheckedEnumVariant?, u64?) {
+        let underlying_type = match record.record_type {
+            ValueEnum(underlying_type) => underlying_type
+            else => ParsedType::Empty
+        }
+        let checked_expression = .cast_to_underlying(
+            ParsedExpression::NumericConstant(val: NumericConstant::U64(next_constant_value!), span)
+            parsed_type: underlying_type
+            enum_scope_id
+            span
+        )
+
+        let constant = checked_expression.to_number_constant(program: .program)
+
+        if constant.has_value() {
+            next_constant_value = constant!.to_usize() as! u64
+        } else {
+            .error(
+                format("Enum variant '{}' in enum '{}' has a non-constant value: {}", name, record.name, checked_expression)
+                span
+            )
+        }
+        let output_variant: CheckedEnumVariant? = CheckedEnumVariant::WithValue(
+            name
+            expr: checked_expression
+            span
+        )
+
+        mut module = .current_module()
+        let var_id = module.add_variable(CheckedVariable(
+            name
+            type_id: enum_type_id
+            is_mutable: false
+            definition_span: span
+        ))
+        .add_var_to_scope(scope_id: enum_scope_id, name, var_id, span)
+
+        return (output_variant, next_constant_value)
+    }
+
+    function typecheck_enum_variant_struct_like(mut this, name: String, span: Span, params: [ParsedVarDecl], next_constant_value: u64?, record: ParsedRecord, enum_id: EnumId, enum_scope_id: ScopeId, enum_type_id: TypeId, parent_scope_id: ScopeId) throws -> (CheckedEnumVariant?, u64?) {
+        todo("implement typecheck_enum_variant_struct_like()")
+        let none_enum_variant: CheckedEnumVariant? = None
+        return (none_enum_variant, next_constant_value)
     }
 
     function typecheck_struct(mut this, record: ParsedRecord, struct_id: StructId, parent_scope_id: ScopeId) throws {

--- a/selfhost/typechecker.jakt
+++ b/selfhost/typechecker.jakt
@@ -1262,6 +1262,25 @@ struct Typechecker {
         return None
     }
 
+    function add_enum_to_scope(mut this, scope_id: ScopeId, name: String, enum_id: EnumId, span: Span) throws -> bool {
+        mut scope = .get_scope(scope_id)
+
+        if scope.enums.contains(name) {
+            let existing_enum_id = scope.enums[name]
+            let definition_span = .get_enum(existing_enum_id).name_span
+
+            .error_with_hint(
+                format("redefinition of enum {}", name)
+                span
+                format("enum {} was first defined here", name)
+                definition_span
+            )
+            return false
+        }
+        scope.enums.set(name, enum_id)
+        return true
+    }
+
     function add_struct_to_scope(mut this, scope_id: ScopeId, name: String, struct_id: StructId, span: Span) throws -> bool {
         mut scope = .get_scope(scope_id)
 
@@ -1465,23 +1484,200 @@ struct Typechecker {
                 .typecheck_namespace_predecl(parsed_namespace: namespce, scope_id: namespace_scope_id)
             }
         }
-        // 3. Typecheck struct predeclaration
+        // 3. Typecheck struct and enum predeclaration
         struct_index = 0
+        enum_index = 0
         for parsed_record in parsed_namespace.records.iterator() {
             let struct_id = StructId(module: .current_module_id, id: struct_index + module_struct_len)
+            let enum_id = EnumId(module: .current_module_id, id: enum_index + module_enum_len)
             match parsed_record.record_type {
                 Struct | Class => {
                     .typecheck_struct_predecl(parsed_record, struct_id, scope_id)
                     struct_index++
                 }
-                else => {
-                    todo(format("typecheck_namespace_predecl: else {}", parsed_record.record_type))
+                ValueEnum | SumEnum => {
+                    .typecheck_enum_predecl(parsed_record, enum_id, scope_id)
+                    enum_index++
+                }
+                Garbage => {
+                    panic("Trying to typecheck a garbage record")
                 }
             }
         }
         // 4. Typecheck functions
         for fun in parsed_namespace.functions.iterator() {
             .typecheck_function_predecl(parsed_function: fun, parent_scope_id: scope_id)
+        }
+    }
+
+    function typecheck_enum_predecl(mut this, parsed_record: ParsedRecord, enum_id: EnumId, scope_id: ScopeId) throws {
+        let enum_scope_id = .create_scope(parent_scope_id: scope_id, can_throw: false)
+        let module_id = .current_module_id
+
+        mut module = .current_module()
+        mut generic_parameters = module.enums[enum_id.id].generic_parameters
+
+        let has_variants = match parsed_record.record_type {
+            ValueEnum(variants) => not variants.is_empty()
+            SumEnum(variants) => not variants.is_empty()
+            else => {
+                panic("Trying typecheck_enum_predecl on non-enum record")
+                yield false
+            }
+        }
+
+        if not has_variants {
+            .error_with_hint(
+                "Empty enums are not allowed"
+                parsed_record.name_span
+                "Add at least one enum variant"
+                parsed_record.name_span
+            )
+        }
+
+        for gen_para in parsed_record.generic_parameters.iterator() {
+            module.types.push(Type::TypeVariable(gen_para.name))
+            let parameter_type_id = TypeId(module: module_id, id: module.types.size() - 1)
+            .add_type_to_scope(scope_id: enum_scope_id, type_name: gen_para.name, type_id: parameter_type_id, span: gen_para.span)
+            generic_parameters.push(parameter_type_id)
+        }
+
+        mut underlying_type_id: TypeId? = None
+        match parsed_record.record_type {
+            ValueEnum(underlying_type) => {
+                underlying_type_id = .typecheck_typename(parsed_type: underlying_type, scope_id: enum_scope_id)
+            }
+            else => {}
+        }
+
+        let enum_type_id = .find_type_in_scope(scope_id, name: parsed_record.name)
+        if not enum_type_id.has_value() {
+            panic("Enum must exist before predeclaration")
+        }
+
+        module.enums[enum_id.id].scope_id = enum_scope_id
+        module.enums[enum_id.id].underlying_type_id = underlying_type_id ?? unknown_type_id()
+
+        .add_enum_to_scope(parent_scope_id: scope_id, name: parsed_record.name, enum_id, span: parsed_record.name_span)
+
+        for method in parsed_record.methods.iterator() {
+            let func = method.parsed_function
+            let method_scope_id = .create_scope(parent_scope_id: enum_scope_id, can_throw: func.can_throw)
+            let block_scope_id = .create_scope(parent_scope_id: method_scope_id, can_throw: func.can_throw)
+
+            let is_generic = not parsed_record.generic_parameters.is_empty() or not func.generic_parameters.is_empty()
+            let none_type_id: TypeId? = None
+            module.functions.push(CheckedFunction(
+                name: func.name
+                name_span: func.name_span
+                return_type_id: unknown_type_id()
+                params: []
+                generic_params: []
+                block: CheckedBlock(
+                    statements: []
+                    scope_id: block_scope_id
+                    definitely_returns: false
+                    yielded_type: none_type_id
+                )
+                can_throw: func.can_throw
+                type: FunctionType::Normal
+                linkage: func.linkage
+                function_scope_id: method_scope_id
+            ))
+
+            let function_id = FunctionId(module: module_id, id: module.functions.size() - 1)
+            mut checked_function = module.functions[function_id.id]
+            let previous_index = .current_function_id
+            .current_function_id = function_id
+
+            mut generic_parameters = checked_function.generic_params
+            for gen_param in func.generic_parameters.iterator() {
+                module.types.push(Type::TypeVariable(gen_param.name))
+                let type_var_type_id = TypeId(module: module_id, id: module.types.size() - 1)
+
+                generic_parameters.push(FunctionGenericParameter::Parameter(type_var_type_id))
+
+                if not func.must_instantiate {
+                    .add_type_to_scope(scope_id: method_scope_id, type_name: gen_param.name, type_id: type_var_type_id, span: gen_param.span)
+                }
+            }
+
+            mut check_scope: ScopeId? = None
+            if is_generic {
+                check_scope = .create_scope(parent_scope_id: method_scope_id, can_throw: func.can_throw)
+            }
+
+            for param in func.params.iterator() {
+                if param.variable.name == "this" {
+                    let checked_variable = CheckedVariable(
+                        name: param.variable.name
+                        type_id: enum_type_id!
+                        is_mutable: param.variable.is_mutable
+                        definition_span: param.variable.span
+                    )
+
+                    checked_function.params.push(CheckedParameter(
+                        requires_label: param.requires_label
+                        variable: checked_variable
+                    ))
+
+                    if check_scope.has_value() {
+                        let var_id = module.add_variable(checked_variable)
+                        .add_var_to_scope(scope_id: check_scope!, name: param.variable.name, var_id, span: param.variable.span)
+                    }
+                } else {
+                    let param_type_id = .typecheck_typename(parsed_type: param.variable.parsed_type, scope_id: method_scope_id)
+
+                    let checked_variable = CheckedVariable(
+                        name: param.variable.name
+                        type_id: param_type_id
+                        is_mutable: param.variable.is_mutable
+                        definition_span: param.variable.span
+                    )
+
+                    checked_function.params.push(CheckedParameter(
+                        requires_label: param.requires_label
+                        variable: checked_variable
+                    ))
+
+                    if check_scope.has_value() {
+                        let var_id = module.add_variable(checked_variable)
+                        .add_var_to_scope(scope_id: check_scope!, name: param.variable.name, var_id, span: param.variable.span)
+                    }
+                }
+            }
+
+            .add_function_to_scope(parent_scope_id: enum_scope_id, name: func.name, function_id, span: parsed_record.name_span)
+
+            let function_return_type_id = .typecheck_typename(parsed_type: func.return_type, scope_id: method_scope_id)
+            checked_function.return_type_id = function_return_type_id
+
+            if is_generic {
+                let block = .typecheck_block(func.block, parent_scope_id: check_scope!, safety_mode: SafetyMode::Safe)
+
+                mut return_type_id = builtin(BuiltinType::Void)
+                if function_return_type_id.equals(unknown_type_id()) {
+                    if not block.statements.is_empty() {
+                        let ret = block.statements[block.statements.size() - 1]
+                        // expression_type
+                        match ret {
+                            Return(val) => {
+                                if val.has_value() {
+                                    return_type_id = .resolve_type_var(type_var_type_id: expression_type(val!), scope_id: method_scope_id)
+                                }
+                            }
+                            else => {}
+                        }
+                    }
+                } else {
+                    return_type_id = .resolve_type_var(type_var_type_id: function_return_type_id, scope_id)
+                }
+
+                checked_function.block = block
+                checked_function.return_type_id = return_type_id
+            }
+
+            .current_function_id = previous_index
         }
     }
 

--- a/selfhost/typechecker.jakt
+++ b/selfhost/typechecker.jakt
@@ -3167,6 +3167,9 @@ struct Typechecker {
                 mut checked_inner_types: [TypeId] = []
 
                 for inner_type in generic_parameters.iterator() {
+                    // FIXME: Typecheck the inner type here instead of recursively calling
+                    // typecheck_typename() with the same parameters.
+                    todo("typecheck_typename GenericType")
                     let inner_type_id = .typecheck_typename(parsed_type, scope_id)
                     checked_inner_types.push(inner_type_id)
                 }

--- a/selfhost/typechecker.jakt
+++ b/selfhost/typechecker.jakt
@@ -4092,6 +4092,12 @@ struct Typechecker {
                 current_scope_id = structure.scope_id
                 continue
             }
+            let maybe_enum_scope = .find_enum_in_scope(scope_id, name: scope_name)
+            if maybe_enum_scope.has_value() {
+                let enum_ = .get_enum(maybe_enum_scope!)
+                current_scope_id = enum_.scope_id
+                continue
+            }
 
             .error(format("Not a namespace, enum, class, or struct: ‘{}’", call.namespace_), span)
         }
@@ -4120,6 +4126,20 @@ struct Typechecker {
                 return maybe_function_id!
             }
             return callee
+        }
+
+        if call.namespace_.size() >= 1 {
+            let enum_name = call.namespace_[call.namespace_.size() - 1]
+            let maybe_enum_id = .find_enum_in_scope(scope_id: current_scope_id, name: enum_name)
+            if maybe_enum_id.has_value() {
+                let enum_id = maybe_enum_id!
+                let enum_ = .get_enum(enum_id)
+                let maybe_function_id = .find_function_in_scope(parent_scope_id: enum_.scope_id, function_name: call.name)
+                if maybe_function_id.has_value() {
+                    return maybe_function_id!
+                }
+                return callee
+            }
         }
 
         .error(format("Call to unknown function: ‘{}’", call.name), span)

--- a/selfhost/typechecker.jakt
+++ b/selfhost/typechecker.jakt
@@ -1436,14 +1436,17 @@ struct Typechecker {
 
     function typecheck_namespace_predecl(mut this, parsed_namespace: ParsedNamespace, scope_id: ScopeId) throws {
         let module_struct_len = .current_module().structures.size()
+        let module_enum_len = .current_module().enums.size()
 
-        // 1. Initialize structs
+        // 1. Initialize structs and enums
         mut struct_index: usize = 0
+        mut enum_index: usize = 0
         for parsed_record in parsed_namespace.records.iterator() {
             match parsed_record.record_type {
                 Struct | Class => { .typecheck_struct_predecl_initial(parsed_record, struct_index: struct_index++, module_struct_len, scope_id) }
-                else => {
-                    todo(format("typecheck_namespace_predecl: else {}", parsed_record.record_type))
+                ValueEnum | SumEnum => { .typecheck_enum_predecl_initial(parsed_record, enum_index: enum_index++, module_enum_len, scope_id) }
+                Garbage => {
+                    panic("Trying to typecheck a garbage record")
                 }
             }
         }
@@ -1659,6 +1662,30 @@ struct Typechecker {
         module.structures[struct_id.id].generic_parameters = generic_parameters
 
         .current_struct_type_id = None
+    }
+
+    function typecheck_enum_predecl_initial(mut this, parsed_record: ParsedRecord, enum_index: usize, module_enum_len: usize, scope_id: ScopeId) throws {
+        // Bring the enum names into scope for future typechecking
+        let module_id = .current_module_id
+        let enum_id = EnumId(module: module_id, id: enum_index + module_enum_len)
+        mut module = .current_module()
+        module.types.push(Type::Enum(enum_id))
+
+        let enum_type_id = TypeId(module: module_id, id: .current_module().types.size() - 1)
+        .add_type_to_scope(scope_id, type_name: parsed_record.name, type_id: enum_type_id, span: parsed_record.name_span)
+
+        // Add a placeholder entry, this will be replaced later.
+        module.enums.push(CheckedEnum(
+            name: parsed_record.name
+            name_span: parsed_record.name_span
+            generic_parameters: []
+            variants: []
+            scope_id: unknown_scope_id()
+            definition_linkage: parsed_record.definition_linkage
+            record_type: parsed_record.record_type
+            underlying_type_id: unknown_type_id()
+            type_id: enum_type_id
+        ))
     }
 
     function typecheck_struct_predecl_initial(mut this, parsed_record: ParsedRecord, struct_index: usize, module_struct_len: usize, scope_id: ScopeId) throws {


### PR DESCRIPTION
This adds most of the necessary components to typecheck enums, it still needs support for generic parameters and struct-like enums however.
The test results with these commits are
```
==============================
107 passed
225 failed
7 skipped
==============================
```
as opposed to the current main results
```
==============================
104 passed
228 failed
7 skipped
==============================
```
with the following additional tests passing:
* `samples/enums/empty_enum.jakt`
* `tests/parser/unclosed_brace_in_enum.jakt`
* `tests/parser/unclosed_brace_in_ref_enum.jakt`