### PR TITLE
selfhost/codegen: Add comments to the C++ code that link back to the original Jakt statement

### DIFF
--- a/selfhost/codegen.jakt
+++ b/selfhost/codegen.jakt
@@ -1206,7 +1206,7 @@ struct CodeGenerator {
     }
 
     function codegen_statement(mut this, statement: CheckedStatement) throws -> String => match statement {
-        Throw(expression) => "return " + .codegen_expression(expression) + ";"
+        Throw(expr) => "return " + .codegen_expression(expr) + ";"
         Continue => match .control_flow_state.passes_through_match {
             true => "return JaktInternal::LoopContinue{};"
             else => "continue;"
@@ -1215,7 +1215,7 @@ struct CodeGenerator {
             true => "return JaktInternal::LoopBreak{};"
             else => "break;"
         }
-        Expression(expression) => .codegen_expression(expression) + ";\n"
+        Expression(expr) => .codegen_expression(expr) + ";\n"
         Defer(statement) => {
             // NOTE: We let the preprocessor generate a unique name for the RAII helper.
             mut output = ""
@@ -1231,8 +1231,8 @@ struct CodeGenerator {
             }
             yield output
         }
-        Return(expression) => match expression.has_value() {
-            true => "return (" + .codegen_expression(expression!) + ");\n"
+        Return(val) => match val.has_value() {
+            true => "return (" + .codegen_expression(val!) + ");\n"
             else => "return;\n"
         }
         Loop(block) => {

--- a/selfhost/codegen.jakt
+++ b/selfhost/codegen.jakt
@@ -1205,100 +1205,129 @@ struct CodeGenerator {
         return output
     }
 
-    function codegen_statement(mut this, statement: CheckedStatement) throws -> String => match statement {
-        Throw(expr) => "return " + .codegen_expression(expr) + ";"
-        Continue => match .control_flow_state.passes_through_match {
-            true => "return JaktInternal::LoopContinue{};"
-            else => "continue;"
-        }
-        Break => match .control_flow_state.passes_through_match {
-            true => "return JaktInternal::LoopBreak{};"
-            else => "break;"
-        }
-        Expression(expr) => .codegen_expression(expr) + ";\n"
-        Defer(statement) => {
-            // NOTE: We let the preprocessor generate a unique name for the RAII helper.
-            mut output = ""
-            output += "\n#define __SCOPE_GUARD_NAME __scope_guard_ ## __COUNTER__\n"
-            output += "ScopeGuard __SCOPE_GUARD_NAME ([&] \n"
-            output += "#undef __SCOPE_GUARD_NAME\n{"
-            {
-                let last_control_flow = .control_flow_state
-                .control_flow_state.passes_through_match = false
-                output += .codegen_statement(statement)
-                output += "});\n"
-                .control_flow_state = last_control_flow
+    function codegen_statement(mut this, statement: CheckedStatement) throws -> String {
+        mut add_newline = true
+        mut output = match statement {
+            Throw(expr) => "return " + .codegen_expression(expr) + ";"
+            Continue => match .control_flow_state.passes_through_match {
+                true => "return JaktInternal::LoopContinue{};"
+                else => "continue;"
             }
-            yield output
-        }
-        Return(val) => match val.has_value() {
-            true => "return (" + .codegen_expression(val!) + ");\n"
-            else => "return;\n"
-        }
-        Loop(block) => {
-            mut output = ""
-            output += "for (;;) {"
-            let last_control_flow = .control_flow_state
-            .control_flow_state = last_control_flow.enter_loop()
-            let block_str = .codegen_block(block)
-            .control_flow_state = last_control_flow
-            output += block_str
-            output += "}"
-            yield output
-        }
-        While(condition, block) => {
-            mut output = ""
-            output += "while ("
-            output += .codegen_expression(expression: condition)
-            output += ") "
-            {
+            Break => match .control_flow_state.passes_through_match {
+                true => "return JaktInternal::LoopBreak{};"
+                else => "break;"
+            }
+            Expression(expr) => .codegen_expression(expr) + ";"
+            Defer(statement) => {
+                // NOTE: We let the preprocessor generate a unique name for the RAII helper.
+                mut output = ""
+                output += "\n#define __SCOPE_GUARD_NAME __scope_guard_ ## __COUNTER__\n"
+                output += "ScopeGuard __SCOPE_GUARD_NAME ([&] \n"
+                output += "#undef __SCOPE_GUARD_NAME\n{"
+                {
+                    let last_control_flow = .control_flow_state
+                    .control_flow_state.passes_through_match = false
+                    output += .codegen_statement(statement)
+                    output += "});"
+                    .control_flow_state = last_control_flow
+                }
+                yield output
+            }
+            Return(val) => match val.has_value() {
+                true => "return (" + .codegen_expression(val!) + ");"
+                else => "return;"
+            }
+            Loop(block) => {
+                mut output = ""
+                output += "for (;;)"
+                if .debug_info.statement_span_comments and statement.span().has_value() {
+                    output += format(" /* {} */ ", .debug_info.span_to_source_location(statement.span()!))
+                }
+                add_newline = false
                 let last_control_flow = .control_flow_state
                 .control_flow_state = last_control_flow.enter_loop()
-                let code = .codegen_block(block)
+                let block_str = .codegen_block(block)
                 .control_flow_state = last_control_flow
-                output += code
+                output += block_str
+                yield output
             }
-            yield output
-        }
-        Block(block) => .codegen_block(block)
-        Garbage => {
-            panic("Garbage statement in codegen")
-            // FIXME: panic() should be `noreturn` and no `yield` should be necessary:
-            yield ""
-        }
-        VarDecl(var_id, init) => {
-            let var = .program.get_variable(var_id)
+            While(condition, block) => {
+                mut output = ""
+                output += "while ("
+                output += .codegen_expression(expression: condition)
+                output += ")"
 
-            mut output = ""
-            if not var.is_mutable {
-                output += "const "
+                if .debug_info.statement_span_comments and statement.span().has_value() {
+                    output += format(" /* {} */ ", .debug_info.span_to_source_location(statement.span()!))
+                }
+
+                {
+                    let last_control_flow = .control_flow_state
+                    .control_flow_state = last_control_flow.enter_loop()
+                    let code = .codegen_block(block)
+                    .control_flow_state = last_control_flow
+                    output += code
+                }
+                add_newline = false
+                yield output
             }
-            output += .codegen_type(var.type_id)
-            output += " "
-            output += var.name
-            output += " = "
-            output += .codegen_expression(init)
-            output += ";\n"
-            yield output
-        }
-        If(condition, then_block, else_statement) => {
-            mut output = "if ("
-            output += .codegen_expression(condition)
-            output += ") "
-            output += .codegen_block(block: then_block)
-
-            output += match else_statement.has_value() {
-                true => " else " + .codegen_statement(statement: else_statement!)
-                else => ""
+            Block(block) => .codegen_block(block)
+            Garbage => {
+                panic("Garbage statement in codegen")
+                // FIXME: panic() should be `noreturn` and no `yield` should be necessary:
+                yield ""
             }
+            VarDecl(var_id, init) => {
+                let var = .program.get_variable(var_id)
 
-            yield output
+                mut output = ""
+                if not var.is_mutable {
+                    output += "const "
+                }
+                output += .codegen_type(var.type_id)
+                output += " "
+                output += var.name
+                output += " = "
+                output += .codegen_expression(init)
+                output += ";"
+                yield output
+            }
+            If(condition, then_block, else_statement) => {
+                mut output = "if ("
+                output += .codegen_expression(condition)
+                output += ")"
+
+                if .debug_info.statement_span_comments and statement.span().has_value() {
+                    output += format(" /* {} */ ", .debug_info.span_to_source_location(statement.span()!))
+                }
+
+                output += .codegen_block(block: then_block)
+
+                output += match else_statement.has_value() {
+                    true => "else " + .codegen_statement(statement: else_statement!)
+                    else => ""
+                }
+
+                add_newline = false
+
+                yield output
+            }
+            else => {
+                todo(format("codegen_statement - Missing statement codegen for {}", statement))
+                // FIXME: panic() should be `noreturn` and no `yield` should be necessary:
+                yield ""
+            }
         }
-        else => {
-            todo(format("codegen_statement - Missing statement codegen for {}", statement))
-            // FIXME: panic() should be `noreturn` and no `yield` should be necessary:
-            yield ""
+
+        if .debug_info.statement_span_comments and statement.span().has_value() and add_newline {
+            output += format(" /* {} */", .debug_info.span_to_source_location(statement.span()!))
         }
+
+        if add_newline {
+            output += "\n"
+        }
+
+        return output
     }
 
 

--- a/selfhost/codegen.jakt
+++ b/selfhost/codegen.jakt
@@ -9,7 +9,8 @@ import typechecker {
     CheckedFunction, CheckedProgram, CheckedStatement, CheckedStruct,
     ModuleId, ScopeId, StructId, EnumId, Type, TypeId, expression_type,
     CheckedEnum, unknown_type_id, CheckedMatchCase, FunctionId, CheckedMatchBody }
-import utility { panic, todo, join, prepend_to_each }
+import utility { panic, todo, join, prepend_to_each, Span }
+
 
 enum AllowedControlExits {
     /// No control exit statements allowed
@@ -79,6 +80,47 @@ struct ControlFlowState {
     }
 }
 
+struct CodegenDebugInfo {
+    // FIXME: Add support for multiple source files
+    file_name: String
+    file_contents: [u8]
+    line_spans: [(usize, usize)]
+    statement_span_comments: bool
+
+    function span_to_source_location(mut this, anon span: Span) throws -> String {
+        if .line_spans.is_empty() {
+            .gather_line_spans()
+        }
+
+        mut line_index = 0uz
+        while line_index < .line_spans.size() {
+            if span.start >= .line_spans[line_index].0 and span.start <= .line_spans[line_index].1 {
+                let column_index = span.start - .line_spans[line_index].0
+                return format("{}:{}:{}", .file_name, line_index+1, column_index+1)
+            }
+            line_index += 1
+        }
+
+        panic("Reached end of file and could not find index")
+        return ""
+    }
+
+    function gather_line_spans(mut this) throws {
+        mut idx = 0uz
+        mut start = idx
+        while idx < .file_contents.size() {
+            if .file_contents[idx] == b'\n' {
+                .line_spans.push((start, idx))
+                start = idx + 1
+            }
+            idx += 1
+        }
+        if start < idx {
+            .line_spans.push((start, idx))
+        }
+    }
+}
+
 struct CodeGenerator {
 
     program: CheckedProgram
@@ -86,8 +128,9 @@ struct CodeGenerator {
     entered_yieldable_blocks: [(String, String)] // label, variable name
     deferred_output: String
     current_function: CheckedFunction?
+    debug_info: CodegenDebugInfo
 
-    function generate(anon program: CheckedProgram) throws -> String {
+    function generate(anon program: CheckedProgram, file_name: String, file_contents: [u8], debug_info: bool) throws -> String {
         let none_function: CheckedFunction? = None
         mut generator = CodeGenerator(
             program
@@ -99,6 +142,12 @@ struct CodeGenerator {
             entered_yieldable_blocks: []
             deferred_output: ""
             current_function: none_function
+            debug_info: CodegenDebugInfo(
+                file_name
+                file_contents
+                line_spans: []
+                statement_span_comments: debug_info
+            )
         )
 
         mut output = ""

--- a/selfhost/codegen.jakt
+++ b/selfhost/codegen.jakt
@@ -256,6 +256,8 @@ struct CodeGenerator {
             output += ";"
         }
 
+        output += "\n"
+
         return output
     }
 
@@ -1192,13 +1194,13 @@ struct CodeGenerator {
 
         // FIXME: yielded_type
 
-        output += "{"
+        output += "{\n"
 
         for statement in block.statements.iterator() {
             output += .codegen_statement(statement)
         }
 
-        output += "}"
+        output += "}\n"
 
         // FIXME: yielded_type
 
@@ -1539,7 +1541,7 @@ struct CodeGenerator {
             output += " const"
         }
 
-        output += "{"
+        output += " {\n"
 
         let last_control_flow = .control_flow_state
         .control_flow_state = last_control_flow.enter_function()
@@ -1548,15 +1550,15 @@ struct CodeGenerator {
         output += block
 
         if is_main {
-            output += "return 0;"
+            output += "return 0;\n"
         } else {
             // FIXME: This should check if the id is BuiltinType::Void, but the baseline compiler chokes on that.
             if function_.can_throw and function_.return_type_id.id == 0 {
-                output += "return {};"
+                output += "return {};\n"
             }
         }
 
-        output += "}"
+        output += "}\n"
 
         return output
     }

--- a/selfhost/main.jakt
+++ b/selfhost/main.jakt
@@ -32,6 +32,7 @@ function main(args: [String]) {
     let lexer_debug = flag(args, "l")
     let parser_debug = flag(args, "p")
     let build_executable = flag(args, "b")
+    let codegen_debug = flag(args, "d")
 
     mut file_name: String? = None
     mut first_arg = true
@@ -41,7 +42,7 @@ function main(args: [String]) {
             first_arg = false
             continue
         }
-        if arg != "-h" and arg != "-l" and arg != "-p" and arg != "-b" {
+        if arg != "-h" and arg != "-l" and arg != "-p" and arg != "-b" and arg != "-d" {
             if file_name.has_value() {
                 eprintln("you can only pass one file")
                 eprintln("{}", usage())
@@ -86,7 +87,7 @@ function main(args: [String]) {
         return 1
     }
 
-    let output = CodeGenerator::generate(checked_program, file_name: file_name!, file_contents, debug_info: true)
+    let output = CodeGenerator::generate(checked_program, file_name: file_name!, file_contents, debug_info: codegen_debug)
 
     if build_executable {
         let output_filename = "build/output.cpp"

--- a/selfhost/main.jakt
+++ b/selfhost/main.jakt
@@ -86,7 +86,7 @@ function main(args: [String]) {
         return 1
     }
 
-    let output = CodeGenerator::generate(checked_program)
+    let output = CodeGenerator::generate(checked_program, file_name: file_name!, file_contents, debug_info: true)
 
     if build_executable {
         let output_filename = "build/output.cpp"

--- a/selfhost/parser.jakt
+++ b/selfhost/parser.jakt
@@ -111,26 +111,65 @@ struct ParsedBlock {
         }
         return None
     }
+
+    function span(this) throws -> Span? {
+        mut start: usize? = None
+        mut end: usize = 0
+
+        for stmt in .stmts.iterator() {
+            let stmt_span = stmt.span()
+            if not start.has_value() {
+                start = stmt_span.start
+            }
+            end = stmt_span.end
+        }
+
+        if start.has_value() {
+            return Span(start: start!, end)
+        }
+
+        return None
+    }
 }
 
 boxed enum ParsedStatement {
-    Expression(ParsedExpression)
+    Expression(expr: ParsedExpression, span: Span)
     Defer(statement: ParsedStatement, span: Span)
-    UnsafeBlock(ParsedBlock)
-    VarDecl(var: ParsedVarDecl, init: ParsedExpression)
-    If(condition: ParsedExpression, then_block: ParsedBlock, else_statement: ParsedStatement?)
-    Block(ParsedBlock)
-    Loop(ParsedBlock)
-    While(condition: ParsedExpression, block: ParsedBlock)
-    For(iterator_name: String, name_span: Span, range: ParsedExpression, block: ParsedBlock)
-    Break
-    Continue
+    UnsafeBlock(block: ParsedBlock, span: Span)
+    VarDecl(var: ParsedVarDecl, init: ParsedExpression, span: Span)
+    If(condition: ParsedExpression, then_block: ParsedBlock, else_statement: ParsedStatement?, span: Span)
+    Block(block: ParsedBlock, span: Span)
+    Loop(block: ParsedBlock, span: Span)
+    While(condition: ParsedExpression, block: ParsedBlock, span: Span)
+    For(iterator_name: String, name_span: Span, range: ParsedExpression, block: ParsedBlock, span: Span)
+    Break(Span)
+    Continue(Span)
     Return(expr: ParsedExpression?, span: Span)
-    Throw(ParsedExpression)
-    Yield(ParsedExpression)
+    Throw(expr: ParsedExpression, span: Span)
+    Yield(expr: ParsedExpression, span: Span)
     InlineCpp(block: ParsedBlock, span: Span)
-    Try(stmt: ParsedStatement, error_name: String, error_span: Span, catch_block: ParsedBlock)
-    Garbage
+    Try(stmt: ParsedStatement, error_name: String, error_span: Span, catch_block: ParsedBlock, span: Span)
+    Garbage(Span)
+
+    function span(this) -> Span => match this {
+        Expression(span) => span
+        Defer(span) => span
+        UnsafeBlock(span) => span
+        VarDecl(span) => span
+        If(span) => span
+        Block(span) => span
+        Loop(span) => span
+        While(span) => span
+        For(span) => span
+        Break(span) => span
+        Continue(span) => span
+        Return(span) => span
+        Throw(span) => span
+        Yield(span) => span
+        InlineCpp(span) => span
+        Try(span) => span
+        Garbage(span) => span
+    }
 }
 
 enum BinaryOperator {
@@ -1556,29 +1595,32 @@ struct Parser {
             }
             Unsafe => {
                 .index++
-                yield ParsedStatement::UnsafeBlock(.parse_block())
+                let block = .parse_block()
+                yield ParsedStatement::UnsafeBlock(block, span: merge_spans(start, .previous().span()))
             }
             Break => {
                 .index++
-                yield ParsedStatement::Break
+                yield ParsedStatement::Break(start)
             }
             Continue => {
                 .index++
-                yield ParsedStatement::Continue
+                yield ParsedStatement::Continue(start)
             }
             Loop => {
                 .index++
-                yield ParsedStatement::Loop(.parse_block())
+                let block = .parse_block()
+                yield ParsedStatement::Loop(block, span: merge_spans(start, .previous().span()))
             }
             Throw => {
                 .index++
-                yield ParsedStatement::Throw(.parse_expression(allow_assignments: false))
+                let expr = .parse_expression(allow_assignments: false)
+                yield ParsedStatement::Throw(expr, span: merge_spans(start, .previous().span()))
             }
             While => {
                 .index++
                 let condition = .parse_expression(allow_assignments: false)
                 let block = .parse_block()
-                yield ParsedStatement::While(condition, block)
+                yield ParsedStatement::While(condition, block, span: merge_spans(start, .previous().span()))
             }
             Yield => {
                 .index++
@@ -1586,7 +1628,7 @@ struct Parser {
                 if not inside_block {
                     .error("‘yield’ can only be used inside a block", span: merge_spans(start, end: expr.span()))
                 }
-                yield ParsedStatement::Yield(expr)
+                yield ParsedStatement::Yield(expr, span: merge_spans(start, .previous().span()))
             }
             Return => {
                 .index++
@@ -1612,17 +1654,25 @@ struct Parser {
                     }
                 }
 
-                yield ParsedStatement::VarDecl(var, init)
+                yield ParsedStatement::VarDecl(var, init, span: merge_spans(start, .previous().span()))
             }
             If => .parse_if_statement()
             For => .parse_for_statement()
             Try => .parse_try_statement()
-            LCurly => ParsedStatement::Block(.parse_block())
-            else => ParsedStatement::Expression(.parse_expression(allow_assignments: true))
+            LCurly => {
+                let block = .parse_block()
+                yield ParsedStatement::Block(block, span: merge_spans(start, .previous().span()))
+            }
+            else => {
+                let expr = .parse_expression(allow_assignments: true)
+                yield ParsedStatement::Expression(expr, span: merge_spans(start, .previous().span()))
+            }
         }
     }
 
     function parse_try_statement(mut this) throws -> ParsedStatement {
+        let start_span = .current().span()
+
         .index++
 
         let stmt = .parse_statement(inside_block: false)
@@ -1645,10 +1695,11 @@ struct Parser {
         }
 
         let catch_block = .parse_block()
-        return ParsedStatement::Try(stmt, error_name, error_span, catch_block)
+        return ParsedStatement::Try(stmt, error_name, error_span, catch_block, span: merge_spans(start_span, .previous().span()))
     }
 
     function parse_for_statement(mut this) throws -> ParsedStatement {
+        let start_span = .current().span()
         .index++
 
         return match .current() {
@@ -1660,17 +1711,17 @@ struct Parser {
                     .index++
                 } else {
                     .error("Expected ‘in’", .current().span())
-                    return ParsedStatement::Garbage
+                    return ParsedStatement::Garbage(merge_spans(start_span, .current().span()))
                 }
 
                 let range = .parse_expression(allow_assignments: false)
                 let block = .parse_block();
 
-                yield ParsedStatement::For(iterator_name, name_span, range, block)
+                yield ParsedStatement::For(iterator_name, name_span, range, block, span: merge_spans(start_span, .previous().span()))
             }
             else => {
                 .error("Expected iterator name", .current().span())
-                yield ParsedStatement::Garbage
+                yield ParsedStatement::Garbage(merge_spans(start_span, .current().span()))
             }
         }
     }
@@ -1678,7 +1729,7 @@ struct Parser {
     function parse_if_statement(mut this) throws -> ParsedStatement {
         if not .current() is If {
             .error("Expected ‘if’ statement", .current().span())
-            return ParsedStatement::Garbage
+            return ParsedStatement::Garbage(span: .current().span())
         }
 
         let start_span = .current().span()
@@ -1698,7 +1749,8 @@ struct Parser {
                 }
                 LCurly => {
                     // FIXME: Lint: check that ‘if’ and ‘else’ blocks are not the same.
-                    else_statement = ParsedStatement::Block(.parse_block())
+                    let block = .parse_block()
+                    else_statement = ParsedStatement::Block(block, span: merge_spans(start_span, .previous().span()))
                 }
                 else => {
                     .error("‘else’ missing ‘if’ or block", .previous().span())
@@ -1706,7 +1758,7 @@ struct Parser {
             }
         }
 
-        return ParsedStatement::If(condition, then_block, else_statement)
+        return ParsedStatement::If(condition, then_block, else_statement, span: merge_spans(start_span, .previous().span()))
     }
 
     function parse_expression(mut this, allow_assignments: bool) throws -> ParsedExpression {

--- a/selfhost/typechecker.jakt
+++ b/selfhost/typechecker.jakt
@@ -490,21 +490,39 @@ enum CheckedEnumVariant {
 }
 
 boxed enum CheckedStatement {
-    Expression(CheckedExpression)
-    Defer(CheckedStatement)
-    VarDecl(var_id: VarId, init: CheckedExpression)
-    If(condition: CheckedExpression, then_block: CheckedBlock, else_statement: CheckedStatement?)
-    Block(CheckedBlock)
-    Loop(CheckedBlock)
-    While(condition: CheckedExpression, block: CheckedBlock)
-    Return(CheckedExpression?)
-    Break
-    Continue
-    Throw(CheckedExpression)
-    Yield(CheckedExpression)
-    Try(stmt: CheckedStatement, error_name: String, catch_block: CheckedBlock)
-    InlineCpp([String])
-    Garbage
+    Expression(expr: CheckedExpression, span: Span)
+    Defer(statement: CheckedStatement, span: Span)
+    VarDecl(var_id: VarId, init: CheckedExpression, span: Span)
+    If(condition: CheckedExpression, then_block: CheckedBlock, else_statement: CheckedStatement?, span: Span)
+    Block(block: CheckedBlock, span: Span)
+    Loop(block: CheckedBlock, span: Span)
+    While(condition: CheckedExpression, block: CheckedBlock, span: Span)
+    Return(val: CheckedExpression?, span: Span?)
+    Break(Span)
+    Continue(Span)
+    Throw(expr: CheckedExpression, span: Span)
+    Yield(expr: CheckedExpression, span: Span)
+    Try(stmt: CheckedStatement, error_name: String, catch_block: CheckedBlock, span: Span)
+    InlineCpp(lines: [String], span: Span)
+    Garbage(Span)
+
+    function span(this) => match this {
+        Expression(span) => Some(span)
+        Defer(span) => span
+        VarDecl(span) => span
+        If(span) => span
+        Block(span) => span
+        Loop(span) => span
+        While(span) => span
+        Return(span) => span
+        Break(span) => span
+        Continue(span) => span
+        Throw(span) => span
+        Yield(span) => span
+        Try(span) => span
+        InlineCpp(span) => span
+        Garbage(span) => span
+    }
 }
 
 enum NumberConstant {
@@ -2171,9 +2189,9 @@ struct Typechecker {
             // If the return type is unknown, and the function starts with a return statement,
             // we infer the return type from its expression.
             match block.statements[0] {
-                Return(ret) => {
-                    if ret.has_value() {
-                        return_type_id = expression_type(ret!)
+                Return(val) => {
+                    if val.has_value() {
+                        return_type_id = expression_type(val!)
                     } else {
                         return_type_id = VOID_TYPE_ID
                     }
@@ -2379,9 +2397,9 @@ struct Typechecker {
             } else {
                 let last_stmt: CheckedStatement = block.statements[block.statements.size() - 1]
                 match last_stmt {
-                    CheckedStatement::Return(ret) => {
-                        if ret.has_value() {
-                            return_type_id = expression_type(expr: ret.value())
+                    CheckedStatement::Return(val) => {
+                        if val.has_value() {
+                            return_type_id = expression_type(expr: val.value())
                         }
                     }
                     else => {
@@ -2411,7 +2429,7 @@ struct Typechecker {
     }
 
     function statement_definitely_returns(this, anon statement: CheckedStatement) -> bool => match statement{
-        Return(expr) => true
+        Return => true
         // FIXME: CheckedStatement::If branches ugly implementation due to current compiler limitations
         If(condition, then_block, else_statement) => {
             mut ret = false
@@ -2434,8 +2452,8 @@ struct Typechecker {
         Block(block) => block.definitely_returns
         Loop(block) => block.definitely_returns
         While(condition, block) => block.definitely_returns
-        Expression(match_expr) => match match_expr {
-            Match() => checked_expression_definitely_returns(match_expr)
+        Expression(expr) => match expr {
+            Match() => checked_expression_definitely_returns(expr)
             else => false
         }
         else => false
@@ -3194,26 +3212,26 @@ struct Typechecker {
     }
 
     function typecheck_statement(mut this, anon statement: ParsedStatement, scope_id: ScopeId, safety_mode: SafetyMode) throws -> CheckedStatement => match statement {
-        Expression(expr) => CheckedStatement::Expression(expr: .typecheck_expression(expr, scope_id, safety_mode))
-        UnsafeBlock(parsed_block) => CheckedStatement::Block(.typecheck_block(parsed_block, parent_scope_id: scope_id, safety_mode: SafetyMode::Unsafe))
-        Yield(expr) => CheckedStatement::Yield(.typecheck_expression(expr, scope_id, safety_mode))
+        Expression(expr, span) => CheckedStatement::Expression(expr: .typecheck_expression(expr, scope_id, safety_mode), span)
+        UnsafeBlock(block, span) => CheckedStatement::Block(block: .typecheck_block(block, parent_scope_id: scope_id, safety_mode: SafetyMode::Unsafe), span)
+        Yield(expr, span) => CheckedStatement::Yield(expr: .typecheck_expression(expr, scope_id, safety_mode), span)
         Return(expr, span) => .typecheck_return(expr, span, scope_id, safety_mode)
-        Block(parsed_block) => .typecheck_block_statement(parsed_block, scope_id, safety_mode)
+        Block(block, span) => .typecheck_block_statement(parsed_block: block, scope_id, safety_mode, span)
         InlineCpp(block, span) => .typecheck_inline_cpp(block, span, safety_mode)
         Defer(statement, span) => .typecheck_defer(statement, scope_id, safety_mode, span)
-        Loop(parsed_block) => .typecheck_loop(parsed_block, scope_id, safety_mode)
-        Try(stmt, error_name, error_span, catch_block) => .typecheck_try(stmt, error_name, error_span, catch_block, scope_id, safety_mode)
-        Throw(expr) => .typecheck_throw(expr, scope_id, safety_mode)
-        While(condition, block) => .typecheck_while(condition, block, scope_id, safety_mode)
-        Continue => CheckedStatement::Continue
-        Break => CheckedStatement::Break
-        VarDecl(var, init) => .typecheck_var_decl(var, init, scope_id, safety_mode)
-        If(condition, then_block, else_statement) => .typecheck_if(condition, then_block, else_statement, scope_id, safety_mode)
-        Garbage => CheckedStatement::Garbage
-        For(iterator_name, name_span, range, block) => .typecheck_for(iterator_name,  name_span, range, block, scope_id, safety_mode)
+        Loop(block, span) => .typecheck_loop(parsed_block: block, scope_id, safety_mode, span)
+        Try(stmt, error_name, error_span, catch_block, span) => .typecheck_try(stmt, error_name, error_span, catch_block, scope_id, safety_mode, span)
+        Throw(expr, span) => .typecheck_throw(expr, scope_id, safety_mode, span)
+        While(condition, block, span) => .typecheck_while(condition, block, scope_id, safety_mode, span)
+        Continue(span) => CheckedStatement::Continue(span)
+        Break(span) => CheckedStatement::Break(span)
+        VarDecl(var, init, span) => .typecheck_var_decl(var, init, scope_id, safety_mode, span)
+        If(condition, then_block, else_statement, span) => .typecheck_if(condition, then_block, else_statement, scope_id, safety_mode, span)
+        Garbage(span) => CheckedStatement::Garbage(span)
+        For(iterator_name, name_span, range, block, span) => .typecheck_for(iterator_name,  name_span, range, block, scope_id, safety_mode, span)
     }
 
-    function typecheck_for(mut this, iterator_name: String, name_span: Span, range: ParsedExpression, block: ParsedBlock, scope_id: ScopeId, safety_mode: SafetyMode) throws -> CheckedStatement {
+    function typecheck_for(mut this, iterator_name: String, name_span: Span, range: ParsedExpression, block: ParsedBlock, scope_id: ScopeId, safety_mode: SafetyMode, span: Span) throws -> CheckedStatement {
         let maybe_span = block.find_yield_span()
         if maybe_span.has_value() {
             .error("a 'for' loop block is not allowed to yield values", maybe_span!)
@@ -3274,7 +3292,8 @@ struct Typechecker {
         // FIXME: proper type inference for `None`
         let else_statement: ParsedStatement? = None
 
-        let rewritten_statement = ParsedStatement::Block(ParsedBlock(
+        let rewritten_statement = ParsedStatement::Block(
+            block: ParsedBlock(
                 stmts: [
                     // let (mutable) _magic = expr
                     ParsedStatement::VarDecl(
@@ -3285,87 +3304,96 @@ struct Typechecker {
                             span: name_span
                         ),
                         init: range
+                        span
                     )
                     // loop {
-                    ParsedStatement::Loop(ParsedBlock(
-                        stmts: [
-                            // let _magic_value = _magic.next()
-                            ParsedStatement::VarDecl(
-                                var: ParsedVarDecl(
-                                    name: "_magic_value",
-                                    parsed_type: ParsedType::Empty,
-                                    is_mutable: iterable_should_be_mutable,
-                                    span: name_span
-                                ),
-                                init: ParsedExpression::MethodCall(
-                                    expr: ParsedExpression::Var(
-                                        name: "_magic",
+                    ParsedStatement::Loop(
+                        block: ParsedBlock(
+                            stmts: [
+                                // let _magic_value = _magic.next()
+                                ParsedStatement::VarDecl(
+                                    var: ParsedVarDecl(
+                                        name: "_magic_value",
+                                        parsed_type: ParsedType::Empty,
+                                        is_mutable: iterable_should_be_mutable,
                                         span: name_span
                                     ),
-                                    call: ParsedCall(
-                                        namespace_: [],
-                                            name: "next",
-                                            args: [],
-                                        type_args: []
-                                    ),
-                                    span: name_span
-                                )
-                            ),
-                            // if not _magic_value.has_value() {
-                            ParsedStatement::If(
-                                condition: ParsedExpression::UnaryOp(
-                                    expr: ParsedExpression::MethodCall(
+                                    init: ParsedExpression::MethodCall(
                                         expr: ParsedExpression::Var(
-                                            name: "_magic_value",
+                                            name: "_magic",
                                             span: name_span
                                         ),
                                         call: ParsedCall(
                                             namespace_: [],
-                                            name: "has_value",
-                                            args: [],
+                                                name: "next",
+                                                args: [],
                                             type_args: []
-                                        )
-                                        span: name_span
-                                    ),
-                                    op: UnaryOperator::LogicalNot,
-                                    span: name_span
-                                ),
-                                then_block: ParsedBlock(
-                                    stmts: [
-                                        // break
-                                        ParsedStatement::Break
-                                    ]
-                                ),
-                                else_statement
-                            ),
-                           // let iterator_name = _magic_value!
-                           ParsedStatement::VarDecl(
-                               var: ParsedVarDecl(
-                                   name: iterator_name,
-                                   parsed_type: ParsedType::Empty,
-                                   // FIXME: loop variable mutability should be independent
-                                   // of iterable mutability
-                                   is_mutable: iterable_should_be_mutable,
-                                   span: name_span
-                                ),
-                                init: ParsedExpression::ForcedUnwrap(
-                                    expr: ParsedExpression::Var(
-                                        name: "_magic_value",
+                                        ),
                                         span: name_span
                                     )
+                                    span
+                                ),
+                                // if not _magic_value.has_value() {
+                                ParsedStatement::If(
+                                    condition: ParsedExpression::UnaryOp(
+                                        expr: ParsedExpression::MethodCall(
+                                            expr: ParsedExpression::Var(
+                                                name: "_magic_value",
+                                                span: name_span
+                                            ),
+                                            call: ParsedCall(
+                                                namespace_: [],
+                                                name: "has_value",
+                                                args: [],
+                                                type_args: []
+                                            )
+                                            span: name_span
+                                        ),
+                                        op: UnaryOperator::LogicalNot,
+                                        span: name_span
+                                    ),
+                                    then_block: ParsedBlock(
+                                        stmts: [
+                                            // break
+                                            ParsedStatement::Break(span)
+                                        ]
+                                    ),
+                                    else_statement
+                                    span
+                                ),
+                            // let iterator_name = _magic_value!
+                            ParsedStatement::VarDecl(
+                                var: ParsedVarDecl(
+                                    name: iterator_name,
+                                    parsed_type: ParsedType::Empty,
+                                    // FIXME: loop variable mutability should be independent
+                                    // of iterable mutability
+                                    is_mutable: iterable_should_be_mutable,
                                     span: name_span
-                                )
-                           ),
-                           ParsedStatement::Block(block)
-                        ]
-                    ))
+                                    ),
+                                    init: ParsedExpression::ForcedUnwrap(
+                                        expr: ParsedExpression::Var(
+                                            name: "_magic_value",
+                                            span: name_span
+                                        )
+                                        span: name_span
+                                    )
+                                    span
+                            ),
+                            ParsedStatement::Block(block, span)
+                            ]
+                        )
+                        span
+                    )
                 ]
-        ))
+            )
+            span
+        )
 
         return .typecheck_statement(rewritten_statement, scope_id, safety_mode)
     }
 
-    function typecheck_if(mut this, condition: ParsedExpression, then_block: ParsedBlock, else_statement: ParsedStatement?, scope_id: ScopeId, safety_mode: SafetyMode) throws -> CheckedStatement {
+    function typecheck_if(mut this, condition: ParsedExpression, then_block: ParsedBlock, else_statement: ParsedStatement?, scope_id: ScopeId, safety_mode: SafetyMode, span: Span) throws -> CheckedStatement {
         let checked_condition = .typecheck_expression(condition, scope_id, safety_mode)
         if not expression_type(checked_condition).equals(builtin(BuiltinType::Bool)) {
             .error("Condition must be a boolean expression", condition.span())
@@ -3380,10 +3408,10 @@ struct Typechecker {
         if else_statement.has_value() {
             checked_else = .typecheck_statement(else_statement!, scope_id, safety_mode)
         }
-        return CheckedStatement::If(condition: checked_condition, then_block: checked_block, else_statement: checked_else)
+        return CheckedStatement::If(condition: checked_condition, then_block: checked_block, else_statement: checked_else, span)
     }
 
-    function typecheck_var_decl(mut this, var: ParsedVarDecl, init: ParsedExpression, scope_id: ScopeId, safety_mode: SafetyMode) throws -> CheckedStatement {
+    function typecheck_var_decl(mut this, var: ParsedVarDecl, init: ParsedExpression, scope_id: ScopeId, safety_mode: SafetyMode, span: Span) throws -> CheckedStatement {
         mut lhs_type_id = .typecheck_typename(parsed_type: var.parsed_type, scope_id)
         mut checked_expr = .typecheck_expression(expr: init, scope_id, safety_mode)
         let rhs_type_id = expression_type(checked_expr)
@@ -3434,7 +3462,7 @@ struct Typechecker {
 
                     if not (.is_numeric(lhs_type_id) and is_rhs_zero) and (.is_integer(lhs_type_id) ^ .is_integer(rhs_type_id)) {
                         .error(format("Type mismatch: expected ‘{}’, but got ‘{}’", .type_name(lhs_type_id), .type_name(rhs_type_id)), .expression_span(checked_expr))
-                        return CheckedStatement::Garbage
+                        return CheckedStatement::Garbage(span)
                     }
                 }
             }
@@ -3452,10 +3480,10 @@ struct Typechecker {
         mut module = .current_module()
         let var_id = module.add_variable(checked_var)
         .add_var_to_scope(scope_id, name: var.name, var_id, span: checked_var.definition_span)
-        return CheckedStatement::VarDecl(var_id, init: checked_expr)
+        return CheckedStatement::VarDecl(var_id, init: checked_expr, span)
     }
 
-    function typecheck_while(mut this, condition: ParsedExpression, block: ParsedBlock, scope_id: ScopeId, safety_mode: SafetyMode) throws -> CheckedStatement {
+    function typecheck_while(mut this, condition: ParsedExpression, block: ParsedBlock, scope_id: ScopeId, safety_mode: SafetyMode, span: Span) throws -> CheckedStatement {
         let checked_condition = .typecheck_expression(condition, scope_id, safety_mode)
         if not expression_type(checked_condition).equals(builtin(BuiltinType::Bool)) {
             .error("Condition must be a boolean expression", condition.span())
@@ -3466,10 +3494,10 @@ struct Typechecker {
             .error("A ‘while’ block is not allowed to yield values", block.find_yield_span()!)
         }
 
-        return CheckedStatement::While(condition: checked_condition, block: checked_block)
+        return CheckedStatement::While(condition: checked_condition, block: checked_block, span)
     }
 
-    function typecheck_try(mut this, stmt: ParsedStatement, error_name: String, error_span: Span, catch_block: ParsedBlock, scope_id: ScopeId, safety_mode: SafetyMode) throws -> CheckedStatement {
+    function typecheck_try(mut this, stmt: ParsedStatement, error_name: String, error_span: Span, catch_block: ParsedBlock, scope_id: ScopeId, safety_mode: SafetyMode, span: Span) throws -> CheckedStatement {
         let try_scope_id = .create_scope(parent_scope_id: scope_id, can_throw: true)
         let checked_stmt = .typecheck_statement(stmt, scope_id, safety_mode)
         let error_struct_id = .find_struct_in_prelude("Error")
@@ -3486,10 +3514,10 @@ struct Typechecker {
         .add_var_to_scope(scope_id: catch_scope_id, name: error_name, var_id: error_id, span: error_span)
         let checked_catch_block = .typecheck_block(catch_block, parent_scope_id: catch_scope_id, safety_mode)
 
-        return CheckedStatement::Try(stmt: checked_stmt, error_name, catch_block: checked_catch_block)
+        return CheckedStatement::Try(stmt: checked_stmt, error_name, catch_block: checked_catch_block, span)
     }
 
-    function typecheck_throw(mut this, expr: ParsedExpression, scope_id: ScopeId, safety_mode: SafetyMode) throws -> CheckedStatement {
+    function typecheck_throw(mut this, expr: ParsedExpression, scope_id: ScopeId, safety_mode: SafetyMode, span: Span) throws -> CheckedStatement {
 
         let checked_expr = .typecheck_expression(expr, scope_id, safety_mode)
 
@@ -3503,15 +3531,15 @@ struct Typechecker {
             .error("Throw statment needs to be in a try statement or a function marked as throws", expr.span())
         }
 
-        return CheckedStatement::Throw(checked_expr)
+        return CheckedStatement::Throw(expr: checked_expr, span)
     }
 
-    function typecheck_loop(mut this, parsed_block: ParsedBlock, scope_id: ScopeId, safety_mode: SafetyMode) throws -> CheckedStatement {
+    function typecheck_loop(mut this, parsed_block: ParsedBlock, scope_id: ScopeId, safety_mode: SafetyMode, span: Span) throws -> CheckedStatement {
         let checked_block = .typecheck_block(parsed_block, parent_scope_id: scope_id, safety_mode)
         if checked_block.yielded_type.has_value() {
             .error("A ‘loop’ block is not allowed to yield values", parsed_block.find_yield_span()!)
         }
-        return CheckedStatement::Loop(checked_block)
+        return CheckedStatement::Loop(block: checked_block, span)
     }
 
     function typecheck_defer(mut this, statement: ParsedStatement, scope_id: ScopeId, safety_mode: SafetyMode, span: Span) throws -> CheckedStatement {
@@ -3527,15 +3555,15 @@ struct Typechecker {
             }
             else => { }
         }
-        return CheckedStatement::Defer(checked_statement)
+        return CheckedStatement::Defer(statement: checked_statement, span)
     }
 
-    function typecheck_block_statement(mut this, parsed_block: ParsedBlock, scope_id: ScopeId, safety_mode: SafetyMode) throws -> CheckedStatement {
+    function typecheck_block_statement(mut this, parsed_block: ParsedBlock, scope_id: ScopeId, safety_mode: SafetyMode, span: Span) throws -> CheckedStatement {
         let checked_block = .typecheck_block(parsed_block, parent_scope_id: scope_id, safety_mode)
         if checked_block.yielded_type.has_value() {
             .error("A block used as a statement cannot yield values, as the value cannot be observed in any way", parsed_block.find_yield_span()!)
         }
-        return CheckedStatement::Block(checked_block)
+        return CheckedStatement::Block(block: checked_block, span)
     }
 
     function typecheck_inline_cpp(mut this, block: ParsedBlock, span: Span, safety_mode: SafetyMode) throws -> CheckedStatement {
@@ -3546,8 +3574,8 @@ struct Typechecker {
         mut strings: [String] = []
         for statement in block.stmts.iterator() {
             match statement {
-                ParsedStatement::Expression(expression) => {
-                    match expression {
+                ParsedStatement::Expression(expr) => {
+                    match expr {
                         ParsedExpression::QuotedString(val, span) => {
                             strings.push(val)
                         }
@@ -3560,7 +3588,7 @@ struct Typechecker {
             }
         }
 
-        return CheckedStatement::InlineCpp(strings)
+        return CheckedStatement::InlineCpp(lines: strings, span)
     }
 
     function typecheck_return(mut this, expr: ParsedExpression?, span: Span, scope_id: ScopeId, safety_mode: SafetyMode) throws -> CheckedStatement {
@@ -3569,10 +3597,10 @@ struct Typechecker {
         }
         if not expr.has_value() {
             let none_expr: CheckedExpression? = None
-            return CheckedStatement::Return(none_expr)
+            return CheckedStatement::Return(val: none_expr, span)
         }
         let checked_expr = .typecheck_expression(expr!, scope_id, safety_mode)
-        return CheckedStatement::Return(checked_expr)
+        return CheckedStatement::Return(val: checked_expr, span)
     }
 
     function typecheck_indexed_struct(mut this, expr: ParsedExpression, field: String, scope_id: ScopeId, safety_mode: SafetyMode, span: Span) throws -> CheckedExpression {


### PR DESCRIPTION
This PR adds a flag `-d` to the selfhosted compiler that will put comments into the C++ code that link to the span of the corresponding statement in the Jakt source file.
This will be helpful for debugging compile errors of the generated C++ code as well as debugging runtime errors :^)
Example output:
```C++
#include <lib.h>
namespace Jakt {
ErrorOr<int> main();
ErrorOr<int> main(Array<String>) {
{
const i64 x = static_cast<i64>(80LL); /* samples/control_flow/if4.jakt:5:5 */
if ((x == static_cast<i64>(100LL))) /* samples/control_flow/if4.jakt:7:5 */ {
outln(String("true")); /* samples/control_flow/if4.jakt:8:9 */
}
else if ((x == static_cast<i64>(80LL))) /* samples/control_flow/if4.jakt:9:12 */ {
outln(String("it is 80")); /* samples/control_flow/if4.jakt:10:9 */
}
}
return 0;
}
}
```
The jakttest output is the same as the one of the current main branch independently of whether or not we pass the debug flag to the compiler
```
==============================
115 passed
217 failed
7 skipped
==============================
```