### PR TITLE
More enum samples

### DIFF
--- a/selfhost/codegen.jakt
+++ b/selfhost/codegen.jakt
@@ -393,15 +393,7 @@ struct CodeGenerator {
                 else => {}
             }
         }
-        mut template_args = ""
-        mut i = 0uz
-        for name in generic_parameter_names.iterator() {
-            template_args += "typename " + name
-            if i < generic_parameter_names.size() - 1 {
-                template_args += ", "
-            }
-            i++
-        }
+        mut template_args = join(prepend_to_each(generic_parameter_names, prefix: "typename "), separator: ", ")
         output += "namespace " + enum_.name + "_Details {\n"
         for variant in enum_.variants.iterator() {
             match variant {
@@ -459,24 +451,17 @@ struct CodeGenerator {
             output += "template<" + template_args + ">\n"
         }
         output += "struct " + enum_.name + " : public Variant<"
-        mut variant_args = ""
-        mut first = true
         mut variant_names: [String] = []
+        mut variant_arguments_array: [String] = []
         for variant in enum_.variants.iterator() {
-            if first {
-                first = false
-            } else {
-                variant_args += ", "
-            }
-            
-            variant_args += enum_.name + "_Details::" + variant.name()
-            variant_names.push(variant.name())
+            mut argument = enum_.name + "_Details::" + variant.name()
             if is_generic {
-                variant_args += "<"
-                output += join(generic_parameter_names, separator: ", ")
-                variant_args += ">"
+                argument += format("<{}>", join(generic_parameter_names, separator: ", "))
             }
+            variant_arguments_array.push(argument)
+            variant_names.push(variant.name())
         }
+        let variant_args = join(variant_arguments_array, separator: ", ")
         output += variant_args + "> {\n"
         output += "using Variant<" + variant_args + ">::Variant;\n"
 
@@ -575,7 +560,10 @@ struct CodeGenerator {
         let generic_type_args = join(generic_parameter_names, separator: ", ")
 
         // FIXME: track namespace_stack so we can generate qualified name
-        let qualified_name = name
+        mut qualified_name = name
+        if not generic_parameter_names.is_empty() {
+            qualified_name += format("<{}>\n", generic_type_args)
+        }
 
         output += format("template<{}>", template_args)
         output += format("struct Formatter<{}> : Formatter<StringView>", qualified_name)

--- a/selfhost/codegen.jakt
+++ b/selfhost/codegen.jakt
@@ -817,6 +817,18 @@ struct CodeGenerator {
                                     name
                                 )
                             }
+                            Typed(name, type_id) => {
+                                output += format(
+                                    "auto&& __jakt_match_value = __jakt_match_variant.template get<typename {}::{}>();\n",
+                                    .codegen_type_possibly_as_namespace(type_id: subject_type_id, as_namespace: true),
+                                    name
+                                )
+                                if not args.is_empty() {
+                                    let arg = args[0]
+                                    let var = .program.find_var_in_scope(scope_id, var: arg.binding)!
+                                    output += format("{} const& {} = __jakt_match_value.value;\n", .codegen_type(var.type_id), arg.binding)
+                                }
+                            }
                             else => {
                                 todo(format("codegen_enum_match match variant else: {}", variant))
                             }

--- a/selfhost/typechecker.jakt
+++ b/selfhost/typechecker.jakt
@@ -11,7 +11,7 @@ import parser { BinaryOperator, DefinitionLinkage, DefinitionType, UnaryOperator
                 ParsedType, ParsedStatement, ParsedVarDecl, RecordType,
                 ParsedRecord, ParsedField, TypeCast, EnumVariantPatternArgument,
                 ParsedMatchBody, ParsedMatchCase }
-import utility { panic, todo, Span }
+import utility { panic, todo, Span, join }
 
 enum SafetyMode {
     Safe
@@ -4076,6 +4076,74 @@ struct Typechecker {
                                             definition_span: span
                                         ))
                                         .add_var_to_scope(scope_id: new_scope_id, name: variant_argument.binding, var_id, span)
+                                    }
+                                    StructLike(name, fields) => {
+                                        covered_variants.push(name)
+
+                                        mut field_variables: [CheckedVariable] = []
+                                        for var_id in fields.iterator() {
+                                            field_variables.push(.program.get_variable(var_id))
+                                        }
+                                        mut seen_names: [String] = [] // FIXME: HashSet
+                                        for arg in variant_arguments.iterator() {
+                                            if not arg.name.has_value() {
+                                                mut found_field_name = false
+                                                mut field_names: [String] = []
+                                                for var in field_variables.iterator() {
+                                                    field_names.push(var.name)
+                                                    if var.name == arg.binding {
+                                                        found_field_name = true
+                                                    }
+                                                }
+                                                if not found_field_name {
+                                                    mut unused_field_names: [String] = []
+                                                    for field_name in field_names.iterator() {
+                                                        if seen_names.contains(field_name) {
+                                                            continue
+                                                        }
+                                                        unused_field_names.push(field_name)
+                                                    }
+                                                    .error_with_hint(
+                                                        "Match case argument '{}' for struct-like enum variant cannot be anon"
+                                                        arg.span
+                                                        format("Available arguments are: {}\n", join(unused_field_names, separator: ", "))
+                                                        arg.span
+                                                    )
+                                                    continue
+                                                }
+                                            }
+                                            let arg_name = arg.name ?? arg.binding
+                                            if seen_names.contains(arg_name) {
+                                                .error(format("match case argument '{}' is already defined", arg_name), arg.span)
+                                                continue
+                                            }
+                                            seen_names.push(arg_name)
+                                            mut matched_field_variable: CheckedVariable? = None
+                                            for var in field_variables.iterator() {
+                                                if var.name == arg_name {
+                                                    matched_field_variable = var
+                                                }
+                                            }
+
+                                            match matched_field_variable.has_value() {
+                                                true => {
+                                                    let substituted_type_id = .substitute_typevars_in_type(type_id: matched_field_variable!.type_id, generic_inferences: [:])
+                                                    let matched_span = matched_field_variable!.definition_span
+                                                    // FIXME: dump type hints
+
+                                                   let var_id = module.add_variable(CheckedVariable(
+                                                        name: arg_name
+                                                        type_id: substituted_type_id
+                                                        is_mutable: false
+                                                        definition_span: matched_span
+                                                    ))
+                                                    .add_var_to_scope(scope_id: new_scope_id, name: arg_name, var_id, span)
+                                                }
+                                                else => {
+                                                    .error(format("Match case argument '{}' does not exist in struct-like enum variant '{}'", arg_name, name), arg.span)
+                                                }
+                                            }
+                                        }
                                     }
                                     else => {
                                         todo(format("implement {} match case for matched variant", matched_variant))

--- a/selfhost/typechecker.jakt
+++ b/selfhost/typechecker.jakt
@@ -873,6 +873,23 @@ class CheckedProgram {
     public function get_struct(this, anon id: StructId) -> CheckedStruct => .modules[id.module.id].structures[id.id]
     public function get_scope(this, anon id: ScopeId) -> Scope => .modules[id.module.id].scopes[id.id]
 
+    public function find_var_in_scope(this, scope_id: ScopeId, var: String) -> CheckedVariable? {
+        mut current_scope_id = scope_id
+        loop {
+            let scope = .get_scope(current_scope_id)
+            for existing_var in scope.vars.iterator() {
+                if existing_var.0 == var {
+                    return .get_variable(existing_var.1)
+                }
+            }
+            if not scope.parent.has_value() {
+                break
+            }
+            current_scope_id = scope.parent!
+        }
+        return None
+    }
+
     public function is_integer(this, anon type_id: TypeId) -> bool {
         let type = .get_type(type_id)
 
@@ -968,6 +985,7 @@ struct Typechecker {
     function get_enum(this, anon id: EnumId) => .program.get_enum(id)
     function get_struct(this, anon id: StructId) => .program.get_struct(id)
     function get_scope(this, anon id: ScopeId) => .program.get_scope(id)
+    function find_var_in_scope(this, scope_id: ScopeId, var: String) => .program.find_var_in_scope(scope_id, var)
 
     function current_module(this) => .program.get_module(.current_module_id)
 
@@ -4102,23 +4120,6 @@ struct Typechecker {
             todo("implement typecheck match body expression")
             yield CheckedMatchBody::Expression(CheckedExpression::Garbage(span))
         }
-    }
-
-    function find_var_in_scope(mut this, scope_id: ScopeId, var: String) -> CheckedVariable? {
-        mut current_scope_id = scope_id
-        loop {
-            let scope = .get_scope(current_scope_id)
-            for existing_var in scope.vars.iterator() {
-                if existing_var.0 == var {
-                    return .program.get_variable(existing_var.1)
-                }
-            }
-            if not scope.parent.has_value() {
-                break
-            }
-            current_scope_id = scope.parent!
-        }
-        return None
     }
 
     function resolve_call(mut this, call: ParsedCall, namespaces: [ResolvedNamespace], span: Span, scope_id: ScopeId, must_be_enum_constructor: bool) throws -> FunctionId? {

--- a/selfhost/typechecker.jakt
+++ b/selfhost/typechecker.jakt
@@ -1919,7 +1919,7 @@ struct Typechecker {
     function typecheck_enum(mut this, record: ParsedRecord, enum_id: EnumId, parent_scope_id: ScopeId) throws {
         mut checked_variants: [CheckedEnumVariant] = []
         mut next_constant_value = 0u64
-        mut seen_names: [String] = [] // FIXME: HashSet
+        mut seen_names: {String} = {}
 
         mut enum_ = .get_enum(enum_id)
 
@@ -1931,7 +1931,7 @@ struct Typechecker {
                     if seen_names.contains(variant.name) {
                         .error(format("Enum variant '{}' is defined more than once", variant.name), variant.span)
                     } else {
-                        seen_names.push(variant.name)
+                        seen_names.add(variant.name)
 
                         let expr = match variant.value.has_value() {
                             true => {
@@ -1979,16 +1979,16 @@ struct Typechecker {
                         .error(format("Enum variant '{}' is defined more than once", variant.name), variant.span)
                         continue
                     } 
-                    seen_names.push(variant.name)
+                    seen_names.add(variant.name)
                     if variant.params.has_value() and variant.params!.size() > 0 and variant.params![0].name != "" {
-                        mut seen_fields: [String] = [] // FIXME: HashSet
+                        mut seen_fields: {String} = {}
                         mut fields: [VarId] = []
                         for param in variant.params!.iterator() {
                             if seen_fields.contains(param.name) {
                                 .error(format("Enum variant '{}' has a member named '{}' more than once", variant.name, param.name), param.span)
                                 continue
                             }
-                            seen_fields.push(param.name)
+                            seen_fields.add(param.name)
 
                             let type_id = .typecheck_typename(parsed_type: param.parsed_type, scope_id: enum_.scope_id)
                             let checked_var = CheckedVariable(
@@ -4020,7 +4020,7 @@ struct Typechecker {
                 let enum_ = .get_enum(enum_id)
                 mut seen_catch_all = false
                 mut catch_all_span: Span? = None
-                mut covered_variants: [String] = [] // FIXME: HashSet
+                mut covered_variants: {String} = {}
                 for case_ in cases.iterator() {
                     for pattern in case_.patterns.iterator() {
                         match pattern {
@@ -4057,13 +4057,13 @@ struct Typechecker {
                                 mut module = .current_module()
                                 match matched_variant! {
                                     Untyped(name) => {
-                                        covered_variants.push(name)
+                                        covered_variants.add(name)
                                         if not variant_arguments.is_empty() {
                                             .error(format("Match case '{}' cannot have arguments", name), span)
                                         }
                                     }
                                     Typed(name, type_id, span) => {
-                                        covered_variants.push(name)
+                                        covered_variants.add(name)
                                         if variant_arguments.size() != 1 {
                                             .error("Match case '{}' must have exactly one argument", span)
                                         }
@@ -4078,13 +4078,13 @@ struct Typechecker {
                                         .add_var_to_scope(scope_id: new_scope_id, name: variant_argument.binding, var_id, span)
                                     }
                                     StructLike(name, fields) => {
-                                        covered_variants.push(name)
+                                        covered_variants.add(name)
 
                                         mut field_variables: [CheckedVariable] = []
                                         for var_id in fields.iterator() {
                                             field_variables.push(.program.get_variable(var_id))
                                         }
-                                        mut seen_names: [String] = [] // FIXME: HashSet
+                                        mut seen_names: {String} = {}
                                         for arg in variant_arguments.iterator() {
                                             if not arg.name.has_value() {
                                                 mut found_field_name = false
@@ -4117,7 +4117,7 @@ struct Typechecker {
                                                 .error(format("match case argument '{}' is already defined", arg_name), arg.span)
                                                 continue
                                             }
-                                            seen_names.push(arg_name)
+                                            seen_names.add(arg_name)
                                             mut matched_field_variable: CheckedVariable? = None
                                             for var in field_variables.iterator() {
                                                 if var.name == arg_name {

--- a/selfhost/typechecker.jakt
+++ b/selfhost/typechecker.jakt
@@ -4,6 +4,7 @@
 // SPDX-License-Identifier: BSD-2-Clause
 
 import error { JaktError }
+import lexer { NumericConstant }
 import parser { BinaryOperator, DefinitionLinkage, DefinitionType, UnaryOperator,
                 FunctionLinkage, FunctionType, ParsedBlock, ParsedCall,
                 ParsedExpression, ParsedFunction, ParsedNamespace,
@@ -1935,7 +1936,11 @@ struct Typechecker {
                                 }
                                 yield value_expression
                             }
-                            else => CheckedExpression::NumericConstant(val: CheckedNumericConstant::U64(next_constant_value++), span: variant.span, type_id: underlying_type_id)
+                            else => .cast_to_underlying(
+                                expr: ParsedExpression::NumericConstant(val: NumericConstant::U64(next_constant_value++), span: variant.span)
+                                scope_id: parent_scope_id
+                                parsed_type: underlying_type
+                            )
                         }
                         
                         enum_.variants.push(CheckedEnumVariant::WithValue(name: variant.name, expr, span: variant.span))

--- a/selfhost/typechecker.jakt
+++ b/selfhost/typechecker.jakt
@@ -4019,17 +4019,15 @@ struct Typechecker {
                                     .error(format("Match case '{}' does not match enum '{}'", variant_names[0].0, enum_.name), variant_names[0].1)
                                     continue
                                 }
+                                mut i = 0uz
                                 mut matched_variant: CheckedEnumVariant? = None
+                                mut variant_index: usize? = None
                                 for v in enum_.variants.iterator() {
-                                    let name = match v {
-                                        WithValue(name) => name
-                                        Untyped(name) => name
-                                        Typed(name) => name
-                                        StructLike(name) => name
-                                    }
-                                    if name == variant_names[1].0 {
+                                    if v.name() == variant_names[1].0 {
                                         matched_variant = v
+                                        variant_index = i
                                     }
+                                    i++
                                 }
 
                                 if not matched_variant.has_value() {
@@ -4037,6 +4035,8 @@ struct Typechecker {
                                     return CheckedExpression::Match(expr: checked_expr, match_cases: [], span, type_id: unknown_type_id(), all_variants_constant: false)
                                 }
 
+                                let new_scope_id = .create_scope(parent_scope_id: scope_id, can_throw: .get_scope(scope_id).can_throw)
+                                mut module = .current_module()
                                 match matched_variant! {
                                     Untyped(name) => {
                                         covered_variants.push(name)
@@ -4044,22 +4044,25 @@ struct Typechecker {
                                             .error(format("Match case '{}' cannot have arguments", name), span)
                                         }
                                     }
+                                    Typed(name, type_id, span) => {
+                                        covered_variants.push(name)
+                                        if variant_arguments.size() != 1 {
+                                            .error("Match case '{}' must have exactly one argument", span)
+                                        }
+
+                                        let variant_argument = variant_arguments[0]
+                                        let var_id = module.add_variable(CheckedVariable(
+                                            name: variant_argument.binding
+                                            type_id
+                                            is_mutable: false
+                                            definition_span: span
+                                        ))
+                                        .add_var_to_scope(scope_id: new_scope_id, name: variant_argument.binding, var_id, span)
+                                    }
                                     else => {
                                         todo(format("implement {} match case for matched variant", matched_variant))
                                     }
                                 }
-                                mut variant_index: usize? = None
-                                mut i = 0uz
-                                for v in enum_.variants.iterator() {
-                                    if v.equals(matched_variant!) {
-                                        variant_index = i
-                                    }
-                                    i++
-                                }
-                                if not variant_index.has_value() {
-                                    panic("Can't find previously matched variant")
-                                }
-                                let new_scope_id = .create_scope(parent_scope_id: scope_id, can_throw: .get_scope(scope_id).can_throw)
 
                                 let checked_body = .typecheck_match_body(body: case_.body, scope_id: new_scope_id, safety_mode, span: case_.marker_span)
                                 let checked_match_case = CheckedMatchCase::EnumVariant(


### PR DESCRIPTION
main (424c891)
```
[ FAIL ] samples/enums/recursive_enums.jakt
[ PASS ] samples/enums/one_line_enum_declaration.jakt
[ FAIL ] samples/enums/parse.jakt
[ FAIL ] samples/enums/is_variant.jakt
[ PASS ] samples/enums/empty_enum.jakt
[ FAIL ] samples/enums/recursive_enums_bad.jakt
[ FAIL ] samples/enums/methods.jakt
[ PASS ] samples/enums/underlying.jakt
[ FAIL ] samples/enums/simple_match.jakt
[ FAIL ] samples/enums/simple_constructor.jakt
[ FAIL ] samples/enums/methods_access_violation.jakt
```

after these commits
```
[ FAIL ] samples/enums/recursive_enums.jakt
[ PASS ] samples/enums/one_line_enum_declaration.jakt
[ PASS ] samples/enums/parse.jakt
[ FAIL ] samples/enums/is_variant.jakt
[ PASS ] samples/enums/empty_enum.jakt
[ PASS ] samples/enums/recursive_enums_bad.jakt
[ FAIL ] samples/enums/methods.jakt
[ PASS ] samples/enums/underlying.jakt
[ FAIL ] samples/enums/simple_match.jakt
[ FAIL ] samples/enums/simple_constructor.jakt
[ FAIL ] samples/enums/methods_access_violation.jakt
```