### PR TITLE
selfhost/parser: Fix bug in tuple parsing

### DIFF
--- a/selfhost/parser.jakt
+++ b/selfhost/parser.jakt
@@ -1499,7 +1499,7 @@ struct Parser {
             if index_before == index_after {
                 break
             }
-            types.push(.parse_typename())
+            types.push(type)
         }
         .error("Expected ‘)’", .current().span())
         return ParsedType::Empty


### PR DESCRIPTION
_(sjakt is my local alias for selfhost build/main)_

Before (Tuples Shorthand Test):
```
$ sjakt samples/tuples/shorthand.jakt 
Error: Expected type name
----- samples/tuples/shorthand.jakt:4:23
 3 |  
 4 | function foo() -> (i64, String) { 
                            ^- Expected type name
 5 |     return (1, "hello") 
-----
Error: Expected type name
----- samples/tuples/shorthand.jakt:4:31
 3 |  
 4 | function foo() -> (i64, String) { 
                                    ^- Expected type name
 5 |     return (1, "hello") 
-----
Error: Weak reference must be mutable
----- samples/tuples/shorthand.jakt:9:11
 8 | function main() { 
 9 |     let x = foo() 
                ^- Weak reference must be mutable
 10 |     println("{} {}", x.0, x.1) 
-----
```

After:
```
$ sjakt samples/tuples/shorthand.jakt 
Error: Weak reference must be mutable
----- samples/tuples/shorthand.jakt:9:11
 8 | function main() { 
 9 |     let x = foo() 
                ^- Weak reference must be mutable
 10 |     println("{} {}", x.0, x.1)
```

```
$ sjakt -p samples/tuples/shorthand.jakt
...
      return_type: ParsedType::JaktTuple(
        types: [
          ParsedType::Name(
            name: "i64", 
            span: Span(
              start: 58, 
              end: 61)), 
          ParsedType::Name(
            name: "String", 
            span: Span(
              start: 63, 
              end: 69))],
...
```

Test-Results

Before
```
==============================
113 passed
219 failed
8 skipped
==============================
```

After
```
==============================
113 passed
219 failed
8 skipped
==============================
```