### PR TITLE
selfhost/typechecker: Fix bug in find_namespace_in_scope

### DIFF
--- a/selfhost/typechecker.jakt
+++ b/selfhost/typechecker.jakt
@@ -1357,7 +1357,7 @@ struct Typechecker {
         }
 
         // if we do not find it then check imports
-        let module_id = current.module
+        let module_id = scope_id.module
 
         for imp in .get_scope(ScopeId(module: module_id, id: 0)).imports.iterator() {
             if name == imp.0 {


### PR DESCRIPTION
Search with given scopes module instead of the last scopes module that didn't have the namespace we were looking for.