### PR TITLE
jakttest/parser: Handle escaped quotes

### DIFF
--- a/jakttest/parser.jakt
+++ b/jakttest/parser.jakt
@@ -85,7 +85,7 @@ function parse_quoted_string(anon quote: String) throws -> String {
             i += 1
             let ch = quote.byte_at(i)
             let escape = match ch {
-                b'"' => ""
+                b'"' => "\""
                 b'\\' => "\\"
                 b'a' => "\0x07"
                 b'b' => "\x08"


### PR DESCRIPTION
For tests with an escaped quote, the expected value would have no quote
and the test would fail if the actual value had a quote

samples/structs/serialize_string_in_struct is the test that brought
this to my attention.

This in combination with #777 causes serialize_string_in_struct to pass