### PR TITLE
editors/vscode: Fix syntax highlighting for keyword enum

### DIFF
--- a/editors/vscode/syntaxes/jakt.tmLanguage.json
+++ b/editors/vscode/syntaxes/jakt.tmLanguage.json
@@ -211,7 +211,7 @@
         },
         {
           "name": "meta.type.enum.body.jakt",
-          "begin": "(?<=enum.*?)(\\{)",
+          "begin": "(?<=\\benum\\b.*?)(\\{)",
           "beginCaptures": {
             "1": {
               "name": "punctuation.begin.brace.jakt"


### PR DESCRIPTION
The syntax highlighting would break if a line had `enum` followed by `{`
in it, if it wasn't an actual enum declaration.
E.g. `if enum_id.has_value() {` would be falsely detected.