### PR TITLE
selfhost/typechecker: Typechecking for Dictionary

### DIFF
--- a/selfhost/typechecker.jakt
+++ b/selfhost/typechecker.jakt
@@ -3957,6 +3957,63 @@ struct Typechecker {
             let type_id = .find_or_add_type_id(Type::GenericInstance(id: array_struct_id, args: [inner_type_id]))
             yield CheckedExpression::JaktArray(vals, repeat, span, type_id)
         }
+        JaktDictionary(values, span) => {
+            let VOID_TYPE_ID = builtin(BuiltinType::Void)
+            mut key_type_id = unknown_type_id()
+            mut value_type_id = unknown_type_id()
+            mut vals: [(CheckedExpression, CheckedExpression)] = []
+            let dictionary_struct_id = .find_struct_in_prelude("Dictionary")
+
+            for kv in values.iterator() {
+                let key = kv.0
+                let value = kv.1
+
+                let checked_key = .typecheck_expression(key, scope_id, safety_mode)
+                let current_key_type_id = expression_type(checked_key)
+
+                let checked_value = .typecheck_expression(value, scope_id, safety_mode)
+                let current_value_type_id = expression_type(checked_value)
+
+                if key_type_id.equals(unknown_type_id()) and value_type_id.equals(unknown_type_id()) {
+                    if current_key_type_id.equals(VOID_TYPE_ID) {
+                        .error("Can't create a dictionary with keys of type void", span)
+                    }
+
+                    if current_value_type_id.equals(VOID_TYPE_ID) {
+                        .error("Can't create a dictionary with values of type void", span)
+                    }
+
+                    key_type_id = current_key_type_id
+                    value_type_id = current_value_type_id
+                } else {
+                    if not key_type_id.equals(current_key_type_id) {
+                        .error(
+                            format(
+                                "Type '{}' does not match type '{}' of previous keys in dictionary",
+                                .type_name(current_key_type_id)
+                                .type_name(key_type_id)
+                            )
+                        , span)
+                    }
+
+                    if not value_type_id.equals(current_value_type_id) {
+                        .error(
+                            format(
+                                "Type '{}' does not match type '{}' of previous values in dictionary",
+                                .type_name(current_value_type_id)
+                                .type_name(value_type_id)
+                            )
+                        , span)
+                    }
+                }
+
+                let checked = (checked_key, checked_value)
+                vals.push(checked)
+            }
+
+            let type_id = .find_or_add_type_id(Type::GenericInstance(id: dictionary_struct_id, args: [key_type_id, value_type_id]))
+            yield CheckedExpression::JaktDictionary(vals, span, type_id)
+        }
         JaktTuple(values, span) => {
             let VOID_TYPE_ID = builtin(BuiltinType::Void)
             mut checked_values: [CheckedExpression] = []

--- a/src/typechecker.rs
+++ b/src/typechecker.rs
@@ -4939,14 +4939,14 @@ pub fn typecheck_expression(
                 if (key_type_id, value_type_id) == (UNKNOWN_TYPE_ID, UNKNOWN_TYPE_ID) {
                     if current_key_type_id == VOID_TYPE_ID {
                         error = error.or(Some(JaktError::TypecheckError(
-                            "cannot create a dictionary with keys of type void".to_string(),
+                            "Can't create a dictionary with keys of type void".to_string(),
                             key.span(),
                         )))
                     }
 
                     if current_value_type_id == VOID_TYPE_ID {
                         error = error.or(Some(JaktError::TypecheckError(
-                            "cannot create a dictionary with values of type void".to_string(),
+                            "Can't create a dictionary with values of type void".to_string(),
                             value.span(),
                         )))
                     }
@@ -4976,9 +4976,9 @@ pub fn typecheck_expression(
                     if value_type_id != current_value_type_id {
                         let value_type_name = project.typename_for_type_id(value_type_id);
                         error = error.or(Some(JaktError::TypecheckErrorWithHint(
-                            format!("type '{}' does not match type '{}' of previous values in dictionary", project.typename_for_type_id(current_value_type_id), value_type_name),
+                            format!("Type '{}' does not match type '{}' of previous values in dictionary", project.typename_for_type_id(current_value_type_id), value_type_name),
                             value.span(),
-                            format!("dictionary was inferred to store values of type '{}' here", value_type_name),
+                            format!("Dictionary was inferred to store values of type '{}' here", value_type_name),
                             value_type_span.unwrap(),
                         )))
                     }

--- a/tests/typechecker/dict_with_void_keys.jakt
+++ b/tests/typechecker/dict_with_void_keys.jakt
@@ -1,5 +1,5 @@
 /// Expect:
-/// - error: "cannot create a dictionary with keys of type void\n"
+/// - error: "Can't create a dictionary with keys of type void\n"
 
 enum Bar {
     Value

--- a/tests/typechecker/dict_with_void_values.jakt
+++ b/tests/typechecker/dict_with_void_values.jakt
@@ -1,5 +1,5 @@
 /// Expect:
-/// - error: "cannot create a dictionary with values of type void\n"
+/// - error: "Can't create a dictionary with values of type void\n"
 
 enum Bar {
     Value

--- a/tests/typechecker/dictionary_mismatching_key_types.jakt
+++ b/tests/typechecker/dictionary_mismatching_key_types.jakt
@@ -1,5 +1,5 @@
 /// Expect:
-/// - error: "type 'String' does not match type 'i64' of previous keys in dictionary\n"
+/// - error: "Type 'String' does not match type 'i64' of previous keys in dictionary\n"
 
 function main() {
     let x = [1: 1, "2": 2, 3: 3]

--- a/tests/typechecker/dictionary_mismatching_value_types.jakt
+++ b/tests/typechecker/dictionary_mismatching_value_types.jakt
@@ -1,5 +1,5 @@
 /// Expect:
-/// - error: "type 'String' does not match type 'i64' of previous values in dictionary\n"
+/// - error: "Type 'String' does not match type 'i64' of previous values in dictionary\n"
 
 function main() {
     let x = [1: 1, 2: "2", 3: 3]


### PR DESCRIPTION
This is typechecking for Dictionary based on the rust compiler implementation. It lacks type hinting because as I understand this is a feature that is not yet implemented in the selfhost compiler.