### PR TITLE
Everywhere: Added `build.sh` for ease-of-use installation

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+includepath="/usr/include/"
+runtime="./runtime/*"
+cargo install --path . &&
+sudo cp -r $runtime $includepath
+


### PR DESCRIPTION
I've added a `build.sh` script so that the Jakt installation will be so
mush easier.