### PR TITLE
selfhost/typechecker: Add Dictionary check

### DIFF
--- a/selfhost/typechecker.jakt
+++ b/selfhost/typechecker.jakt
@@ -4097,6 +4097,7 @@ struct Typechecker {
 
         }
         Match(expr, cases, span) => .typecheck_match(expr, cases, span, scope_id, safety_mode)
+        JaktDictionary(values, span) => .typecheck_dictionary(values, span, scope_id, safety_mode)
         else => {
             panic(format("typechecker needs support for {}", expr))
 
@@ -4285,6 +4286,76 @@ struct Typechecker {
             todo("implement typecheck match body expression")
             yield CheckedMatchBody::Expression(CheckedExpression::Garbage(span))
         }
+    }
+
+    function typecheck_dictionary(mut this, values: [(ParsedExpression, ParsedExpression)], span: Span, scope_id: ScopeId, safety_mode: SafetyMode) throws -> CheckedExpression {
+        let dictionary_struct_id = .find_struct_in_prelude("Dictionary")
+        mut checked_kv_pairs: [(CheckedExpression, CheckedExpression)] = []
+        mut key_type_id = unknown_type_id()
+        mut key_type_span: Span? = None
+        mut value_type_id = unknown_type_id()
+        mut value_type_span: Span? = None
+
+        // TODO: hint type logic
+
+        for kv_pair in values.iterator() {
+            let key = kv_pair.0
+            let value = kv_pair.1
+            let checked_key = .typecheck_expression(key, scope_id, safety_mode)
+            let current_key_type_id = expression_type(checked_key)
+
+            let checked_value = .typecheck_expression(value, scope_id, safety_mode)
+            let current_value_type_id = expression_type(checked_value)
+            let VOID_TYPE_ID = builtin(BuiltinType::Void)
+
+            if key_type_id.equals(unknown_type_id()) and value_type_id.equals(unknown_type_id()) {
+                if current_key_type_id.equals(VOID_TYPE_ID) {
+                    .error("Can't create a dictionary with keys of type void", span: key.span())
+                }
+                if current_value_type_id.equals(VOID_TYPE_ID) {
+                    .error("Can't create a dictionary with values of type void", span: value.span())
+                }
+                key_type_id = current_key_type_id
+                key_type_span = Some(key.span())
+                value_type_id = current_value_type_id
+                value_type_span = Some(value.span())
+            } else {
+                if not key_type_id.equals(current_key_type_id) {
+                    let key_type_name = .type_name(key_type_id)
+                    let current_key_type_name = .type_name(current_key_type_id)
+                    .error_with_hint(
+                        message: format("Type '{}' does not match type '{}' of previous keys in dictionary", current_key_type_name, key_type_name)
+                        span: key.span()
+                        hint: format("Dictionary was inferred to store keys of type '{}' here", key_type_name)
+                        span: key_type_span!
+                    )
+                }
+                if not value_type_id.equals(current_value_type_id) {
+                    let value_type_name = .type_name(value_type_id)
+                    let current_value_type_name = .type_name(current_value_type_id)
+                    .error_with_hint(
+                        message: format("Type '{}' does not match type '{}' of previous values in dictionary", current_value_type_name, value_type_name)
+                        span: value.span()
+                        hint: format("Dictionary was inferred to store values of type '{}' here", value_type_name)
+                        span: value_type_span!
+                    )
+                }
+            }
+            checked_kv_pairs.push((checked_key, checked_value))
+        }
+
+        let type_id = .find_or_add_type_id(Type::GenericInstance(
+            id: dictionary_struct_id,
+            args: [key_type_id, value_type_id]
+        ))
+
+        // TODO: unify type with hint type
+
+        return CheckedExpression::JaktDictionary(
+            vals: checked_kv_pairs
+            span
+            type_id
+        )
     }
 
     function resolve_call(mut this, call: ParsedCall, namespaces: [ResolvedNamespace], span: Span, scope_id: ScopeId, must_be_enum_constructor: bool) throws -> FunctionId? {

--- a/src/typechecker.rs
+++ b/src/typechecker.rs
@@ -4939,14 +4939,14 @@ pub fn typecheck_expression(
                 if (key_type_id, value_type_id) == (UNKNOWN_TYPE_ID, UNKNOWN_TYPE_ID) {
                     if current_key_type_id == VOID_TYPE_ID {
                         error = error.or(Some(JaktError::TypecheckError(
-                            "cannot create a dictionary with keys of type void".to_string(),
+                            "Can't create a dictionary with keys of type void".to_string(),
                             key.span(),
                         )))
                     }
 
                     if current_value_type_id == VOID_TYPE_ID {
                         error = error.or(Some(JaktError::TypecheckError(
-                            "cannot create a dictionary with values of type void".to_string(),
+                            "Can't create a dictionary with values of type void".to_string(),
                             value.span(),
                         )))
                     }
@@ -4976,9 +4976,9 @@ pub fn typecheck_expression(
                     if value_type_id != current_value_type_id {
                         let value_type_name = project.typename_for_type_id(value_type_id);
                         error = error.or(Some(JaktError::TypecheckErrorWithHint(
-                            format!("type '{}' does not match type '{}' of previous values in dictionary", project.typename_for_type_id(current_value_type_id), value_type_name),
+                            format!("Type '{}' does not match type '{}' of previous values in dictionary", project.typename_for_type_id(current_value_type_id), value_type_name),
                             value.span(),
-                            format!("dictionary was inferred to store values of type '{}' here", value_type_name),
+                            format!("Dictionary was inferred to store values of type '{}' here", value_type_name),
                             value_type_span.unwrap(),
                         )))
                     }

--- a/tests/typechecker/dict_with_void_keys.jakt
+++ b/tests/typechecker/dict_with_void_keys.jakt
@@ -1,5 +1,5 @@
 /// Expect:
-/// - error: "cannot create a dictionary with keys of type void\n"
+/// - error: "Can't create a dictionary with keys of type void\n"
 
 enum Bar {
     Value

--- a/tests/typechecker/dict_with_void_values.jakt
+++ b/tests/typechecker/dict_with_void_values.jakt
@@ -1,5 +1,5 @@
 /// Expect:
-/// - error: "cannot create a dictionary with values of type void\n"
+/// - error: "Can't create a dictionary with values of type void\n"
 
 enum Bar {
     Value

--- a/tests/typechecker/dictionary_mismatching_value_types.jakt
+++ b/tests/typechecker/dictionary_mismatching_value_types.jakt
@@ -1,5 +1,5 @@
 /// Expect:
-/// - error: "type 'String' does not match type 'i64' of previous values in dictionary\n"
+/// - error: "Type 'String' does not match type 'i64' of previous values in dictionary\n"
 
 function main() {
     let x = [1: 1, 2: "2", 3: 3]


### PR DESCRIPTION
_I hope this is not very bad form, but there is already a PR #782 that I reviewed as I was in the midst of cleaning up my own implementation to be up-streamed._

It is also the same as rust version without the type hint logic but with updated error messages. Test cases have been updated accordingly.

Before:
```
...
[ FAIL ] samples/dictionaries/contains.jakt
[ FAIL ] samples/dictionaries/count_words.jakt
[ FAIL ] samples/dictionaries/dict_index_unwrap.jakt
[ FAIL ] samples/dictionaries/dict.jakt
[ FAIL ] samples/dictionaries/empty_literal.jakt
[ FAIL ] samples/dictionaries/empty_literal_without_hint.jakt
[ FAIL ] samples/dictionaries/indexed.jakt
[ FAIL ] samples/dictionaries/iterator.jakt
[ FAIL ] samples/dictionaries/lvalue2.jakt
[ FAIL ] samples/dictionaries/lvalue.jakt
[ FAIL ] samples/dictionaries/reference_semantics.jakt
[ FAIL ] samples/dictionaries/set.jakt
[ FAIL ] tests/typechecker/dictionary_mismatching_key_types.jakt
[ FAIL ] tests/typechecker/dictionary_mismatching_value_types.jakt
[ FAIL ] tests/typechecker/dict_with_void_keys.jakt
[ FAIL ] tests/typechecker/dict_with_void_values.jakt
...
==============================
140 passed
192 failed
8 skipped
==============================
```

After:
```
...
[ FAIL ] samples/dictionaries/contains.jakt
[ FAIL ] samples/dictionaries/count_words.jakt
[ PASS ] samples/dictionaries/dict_index_unwrap.jakt
[ FAIL ] samples/dictionaries/dict.jakt
[ FAIL ] samples/dictionaries/empty_literal.jakt
[ FAIL ] samples/dictionaries/empty_literal_without_hint.jakt
[ FAIL ] samples/dictionaries/indexed.jakt
[ FAIL ] samples/dictionaries/iterator.jakt
[ FAIL ] samples/dictionaries/lvalue2.jakt
[ FAIL ] samples/dictionaries/lvalue.jakt
[ FAIL ] samples/dictionaries/reference_semantics.jakt
[ FAIL ] samples/dictionaries/set.jakt
[ FAIL ] tests/typechecker/dictionary_mismatching_key_types.jakt
[ PASS ] tests/typechecker/dictionary_mismatching_value_types.jakt
[ PASS ] tests/typechecker/dict_with_void_keys.jakt
[ PASS ] tests/typechecker/dict_with_void_values.jakt
...
==============================
144 passed
188 failed
8 skipped
==============================
```