### PR TITLE
jakttest: Move checking whether binary is updated to a separate function

### DIFF
--- a/jakttest/run-all.sh
+++ b/jakttest/run-all.sh
@@ -1,30 +1,33 @@
 #!/bin/bash
 
-if [ ! -x ./build/jakttest ]; then
-    echo "jakttest binary does not exist. Building it now."
+
+is_binary_behind_src() {
+    local binary_path=$1
+    local src_dir=$2
+    # if the target file does not exist, then
+    # we'll say yes
+    if [ ! -x "$binary_path" ]; then
+        return 0
+    else
+        local binary_mtime=$(stat -c %Y "$binary_path")
+        local latest_source_mtime=$(\
+            stat -c %Y $src_dir/*.jakt |\
+            sort |\
+            tail -n1)
+        [ "$binary_mtime" -lt "$latest_source_mtime" ]
+    fi
+}
+
+if is_binary_behind_src build/jakttest jakttest; then
+    echo "(re)compiling jakttest to match source"
     cargo run jakttest/jakttest.jakt
 fi
 
-# check for jakttest/ mtime and build/jakttest mtime
-{
-    jakttest_binary_mtime=$(stat -c %Y build/jakttest)
-    latest_jakttest_source_mtime=$(stat -c %Y jakttest/*.jakt | sort | tail -n1)
-    if [ "$jakttest_binary_mtime" -lt "$latest_jakttest_source_mtime" ]; then
-        echo "re-compiling jakttest to match source"
-        cargo run jakttest/jakttest.jakt
-    fi
-}
-
-
 # check for selfhost/ mtime and build/main mtime
-{
-    binary_mtime=$(stat -c %Y build/main)
-    latest_selfhost_mtime=$(stat -c %Y selfhost/*.jakt | sort | tail -n1)
-    if [ "$binary_mtime" -lt "$latest_selfhost_mtime" ]; then
-        echo "re-compiling selfhost to match source"
-        cargo run selfhost/main.jakt
-    fi
-}
+if is_binary_behind_src build/main selfhost; then
+    echo "(re)compiling selfhost to match source"
+    cargo run selfhost/main.jakt
+fi
 
 pass=0
 fail=0


### PR DESCRIPTION
Since there might be more checking work to do between source directories
and their binary targets, I moved the logic into a function that
pre-checks if the binary exists before checking its mtime.
It also can't do proper module dependency analysis yet but it's a starting point.

PD: This function *should* only be used when we don't know the state of the source or binary, and in that case it *should* be split up to avoid unnecessary work; e.g when we know that the binary exists or
we know the exact list of files we want to check.