### PR TITLE
typechecker: Error when prefilling array in functions that don't throw

### DIFF
--- a/src/typechecker.rs
+++ b/src/typechecker.rs
@@ -4772,6 +4772,14 @@ pub fn typecheck_expression(
                     typecheck_expression(fill_size_expr, scope_id, project, safety_mode, None);
                 checked_fill_size_expr = Some(Box::new(checked_expr));
                 error = error.or(err);
+
+                let parent_throws = project.get_scope(scope_id).throws;
+                if !parent_throws {
+                    error = error.or(Some(JaktError::TypecheckError(
+                        "Prefilling an array may throw and needs to be in a try statement or a function marked as throws".to_string(),
+                        fill_size_expr.span(),
+                    )))
+                }
             }
 
             for v in vec {


### PR DESCRIPTION
Prefilling an array is wrapped inside a TRY() in generated cpp code so its scope should throw

This also should fix issue #137