### PR TITLE
samples: Remove integer_promotion_bad3.jakt file

### DIFF
--- a/samples/variables/integer_promotion_bad3.jakt
+++ b/samples/variables/integer_promotion_bad3.jakt
@@ -1,7 +1,0 @@
-/// Expect:
-/// - error: "Integer promotion failed"
-
-function main() {
-    mut i: u8 = 0;
-    i += 1000;
-}


### PR DESCRIPTION
As shown below the difference between integer_promotion_bad2.jakt
and integer_promotion_bad3.jakt is that a newline is missing, but
the code is identical in both of them. Hence deletion.

--- samples/variables/integer_promotion_bad2.jakt	2022-06-16 12:39:18.484476389 +0200
+++ samples/variables/integer_promotion_bad3.jakt	2022-06-16 12:39:18.484476389 +0200
@@ -1,5 +1,5 @@
 /// Expect:
-/// - error: "Integer promotion failed\n"
+/// - error: "Integer promotion failed"

 function main() {
     mut i: u8 = 0;