### PR TITLE
all: Add support for prelude to selfhost

### DIFF
--- a/selfhost/codegen.jakt
+++ b/selfhost/codegen.jakt
@@ -925,7 +925,11 @@ struct CodeGenerator {
         OptionalNone => "JaktInternal::OptionalNone()"
         OptionalSome(expr, type_id) => "(" + .codegen_expression(expr) + ")"
         ForcedUnwrap(expr, type_id) => "(" + .codegen_expression(expr) + ".value())"
-        QuotedString(val) => "String(\"" + val + "\")"
+        QuotedString(val) => {
+            // FIXME: this should replace newlines to allow for multiline strings
+            //"String(\"" + val.replace(replace: "\n", with: "\\n") + "\")"
+            yield "String(\"" + val + "\")"
+        }
         ByteConstant(val) => "'" + val + "'"
         CharacterConstant(val) => "'" + val + "'"
         Var(var) => var.name

--- a/selfhost/lexer.jakt
+++ b/selfhost/lexer.jakt
@@ -591,18 +591,12 @@ struct Lexer {
         }
 
         mut escaped = false
-        mut found_newline = false
 
         while not .eof() and (escaped or .peek() != delimiter) {
             // Ignore a standalone carriage return
-            if .peek() == b'\r' {
+            if .peek() == b'\r' or .peek() == b'\n' {
                 ++.index
-            }
-
-            // Strings can't span multiple lines
-            if .peek() == b'\n' {
-                found_newline = true
-                break
+                continue;
             }
 
             if not escaped and .peek() == b'\\' {
@@ -614,11 +608,6 @@ struct Lexer {
         }
 
         let end = .index
-
-        if found_newline {
-            .error("Expected end quote", Span(start, end))
-            return Token::Garbage(Span(start, end))
-        }
 
         let str = .substring(start: start + 1, length: .index)
 

--- a/selfhost/main.jakt
+++ b/selfhost/main.jakt
@@ -26,6 +26,127 @@ function help() -> String{
 
 function flag(args: [String], anon name: String) => args.contains("-" + name)
 
+//FIXME: Include the full prelude when we support it
+function prelude() => "
+extern struct Optional<T> {
+    function has_value(this) -> bool
+    function value(this) -> T
+    function value_or(this, anon x: T) -> T
+    function Optional<S>(anon x: S) -> Optional<S>
+}
+
+extern struct ArrayIterator<T> {
+    function next(mut this) -> T?
+}
+
+extern struct Array<T> {
+    function is_empty(this) -> bool
+    function contains(this, anon value: T) -> bool
+    function size(this) -> usize
+    function capacity(this) -> usize
+    function ensure_capacity(this, anon capacity: usize) throws
+    function add_capacity(this, anon capacity: usize) throws
+    function resize(mut this, anon size: usize) throws
+    function push(mut this, anon value: T) throws
+    function pop(mut this) -> T?
+    function iterator(this) -> ArrayIterator<T>
+}
+
+extern struct String {
+    function number(anon number: i64) throws -> String
+    function split(this, anon c: c_char) throws -> [String]
+    function c_string(this) -> raw c_char
+    function to_int(this) -> i32?
+    function to_uint(this) -> u32?
+    function is_whitespace(this) -> bool
+    function hash(this) -> u32
+    function substring(this, start: usize, length: usize) throws -> String
+    function repeated(character: c_char, count: usize) throws -> String
+    function is_empty(this) -> bool
+    function length(this) -> usize
+    function byte_at(this, anon index: usize) -> u8
+    function contains(this, anon needle: String) -> bool
+}
+
+extern struct StringBuilder {
+    function append(mut this, anon b: u8) throws
+    function append_string(mut this, anon s: String) throws
+    function append_c_string(mut this, anon s: raw c_char) throws
+    function append_code_point(mut this, anon code_point: u32) throws
+    function append_escaped_for_json(mut this, anon s: String) throws
+    function to_string(this) throws -> String
+    function is_empty(this) -> bool
+    function length(this) -> usize
+    function clear(mut this)
+    function create() throws -> StringBuilder
+}
+
+extern struct WeakPtr<T> {
+    function has_value(this) -> bool
+    function clear(mut this)
+}
+
+extern struct Tuple {}
+
+extern struct DictionaryIterator<K, V> {
+    function next(mut this) -> (K, V)?
+}
+
+extern struct Dictionary<K, V> {
+    function is_empty(this) -> bool
+    function get(this, anon key: K) -> V?
+    function contains(this, anon key: K) -> bool
+    function set(mut this, anon key: K, anon value: V) throws
+    function remove(mut this, anon key: K) -> bool
+    function ensure_capacity(mut this, anon capacity: usize) throws
+    function clear(mut this)
+    function size(this) -> usize
+    function capacity(this) -> usize
+    function keys(this) throws -> [K]
+    function hash(this) -> u32
+    function Dictionary<A, B>() -> Dictionary<A, B>
+    function iterator(this) -> DictionaryIterator<K, V>
+}
+
+extern struct SetIterator<T> {
+    function next(mut this) -> T?
+}
+
+extern struct Set<V> {
+    function is_empty(this) -> bool
+    function contains(this, anon value: V) -> bool
+    function add(mut this, anon value: V) throws
+    function remove(mut this, anon value: V) -> bool
+    function ensure_capacity(mut this, anon capacity: usize) throws
+    function clear(mut this)
+    function size(this) -> usize
+    function capacity(this) -> usize
+    function hash(this) -> u32
+    function Set<A>() -> Set<A>
+    function iterator(this) -> SetIterator<V>
+}
+
+extern struct Range<T> {
+    function next(mut this) -> T?
+}
+
+extern struct Error {
+    function code(this) -> i32
+    function from_errno(anon errno: i32) -> Error
+}
+
+extern class File {
+    public function open_for_reading(anon path: String) throws -> File
+    public function open_for_writing(anon path: String) throws -> File
+
+    public function read(mut this, anon buffer: [u8]) throws -> usize
+    public function write(mut this, anon data: [u8]) throws -> usize
+
+    public function read_all(mut this) throws -> [u8]
+}
+"
+
+
 function main(args: [String]) {
     if args.size() <= 1 {
         eprintln("{}", usage())
@@ -73,6 +194,30 @@ function main(args: [String]) {
 
     mut errors: [JaktError] = []
 
+    // Handle the prelude
+    // FIXME: we need a way to get to the bytes
+    mut prelude_bytes: [u8] = []
+
+    let prelude_string = prelude()
+
+    mut index = 0uz
+    while index < prelude_string.length() {
+        prelude_bytes.push(prelude_string.byte_at(index))
+        ++index
+    }
+
+    let prelude_tokens = Lexer::lex(input: prelude_bytes, errors)
+    for error in errors.iterator() {
+        print_error(file_name: "<prelude>", file_contents: prelude_bytes, error)
+    }
+
+    let parsed_prelude = Parser::parse(tokens: prelude_tokens, errors)
+    for error in errors.iterator() {
+        print_error(file_name: "<prelude>", file_contents: prelude_bytes, error)
+    }
+
+    // Handle the user's file
+
     let tokens = Lexer::lex(input: file_contents, errors)
 
     if lexer_debug {
@@ -87,7 +232,7 @@ function main(args: [String]) {
         println("{:#}", parsed_namespace);
     }
 
-    let checked_program = Typechecker::typecheck(parsed_namespace, errors)
+    let checked_program = Typechecker::typecheck(parsed_namespace, parsed_prelude, errors)
 
     for error in errors.iterator() {
         print_error(file_name: file_name!, file_contents, error)

--- a/selfhost/typechecker.jakt
+++ b/selfhost/typechecker.jakt
@@ -929,7 +929,7 @@ struct Typechecker {
     inside_defer: bool
     errors: [JaktError]
 
-    function typecheck(parsed_namespace: ParsedNamespace, errors: [JaktError]) throws -> CheckedProgram {
+    function typecheck(parsed_namespace: ParsedNamespace, parsed_prelude: ParsedNamespace, errors: [JaktError]) throws -> CheckedProgram {
         let root_module_id = ModuleId(id: 0)
         let module = Module(
             id: root_module_id,
@@ -975,6 +975,7 @@ struct Typechecker {
 
         let none: ScopeId? = None
         typechecker.create_scope(parent_scope_id: none, can_throw: false)
+        typechecker.typecheck_module(parsed_namespace: parsed_prelude, scope_id: ScopeId(module: root_module_id, id: 0))
 
         typechecker.typecheck_module(parsed_namespace, scope_id: ScopeId(module: root_module_id, id: 0))
 
@@ -1055,9 +1056,6 @@ struct Typechecker {
     }
 
     function find_struct_in_prelude(this, anon name: String) throws -> StructId {
-        // FIXME: Remove this short-circuit once we actually start parsing the prelude!
-        return StructId(module: ModuleId(id: 0), id: 0)
-
         // start at the prelude scope id
         let scope_id = ScopeId(module: ModuleId(id: 0), id: 0)
         let struct_id = .find_struct_in_scope(scope_id, name)
@@ -1070,9 +1068,6 @@ struct Typechecker {
     }
 
     function find_type_in_prelude(this, anon name: String) throws -> TypeId {
-        // FIXME: Remove this short-circuit once we actually start parsing the prelude!
-        return TypeId(module: ModuleId(id: 0), id: 0)
-
         // start at the prelude scope id
         let scope_id = ScopeId(module: ModuleId(id: 0), id: 0)
         let type_id = .find_type_in_scope(scope_id, name)
@@ -1436,8 +1431,8 @@ struct Typechecker {
         mut scope = .get_scope(id: parent_scope_id)
         for existing_function in scope.functions.iterator() {
             if name == existing_function.0 {
-                // FIXME: Show hint of the original definition, once we store the name span.
-                .error(format("Redefinition of function ‘{}’", name), span)
+                let function_ = .get_function(existing_function.1)
+                .error_with_hint(message: format("Redefinition of function ‘{}’", name), span, hint: "previous definition here", hint_span: function_.name_span)
                 return false
             }
         }
@@ -1449,8 +1444,8 @@ struct Typechecker {
         mut scope = .get_scope(scope_id)
         for existing_var in scope.vars.iterator() {
             if name == existing_var.0 {
-                // FIXME: Show hint of the original definition, once we store the name span.
-                .error(format("Redefinition of variable ‘{}’", name), span)
+                let variable_ = .get_variable(existing_var.1)
+                .error_with_hint(message: format("Redefinition of variable ‘{}’", name), span, hint: "previous definition here", hint_span: variable_.definition_span)
             }
         }
         scope.vars.set(key: name, value: var_id)
@@ -3794,8 +3789,9 @@ struct Typechecker {
             let parent_id = match .get_type(expression_type(checked_expr)) {
                 Struct(id) => StructOrEnumId::Struct(id)
                 Enum(id) => StructOrEnumId::Enum(id)
+                JaktString => StructOrEnumId::Struct(.find_struct_in_prelude("String"))
                 else => {
-                    panic("Method call on unsupported base")
+                    panic(format("Method call on unsupported base {}", .get_type(expression_type(checked_expr))))
                     yield StructOrEnumId::Struct(StructId(module: ModuleId(id: 0), id: 0))
                 }
             }

--- a/src/codegen.rs
+++ b/src/codegen.rs
@@ -3061,7 +3061,9 @@ fn codegen_expr(
         }
         CheckedExpression::QuotedString(qs, _) => {
             output.push_str("String(\"");
-            output.push_str(qs);
+            let tmp = qs.replace("\r\n", "\\n");
+            let tmp = tmp.replace('\n', "\\n");
+            output.push_str(&tmp);
             output.push_str("\")");
         }
         CheckedExpression::ByteConstant(b, _) => {

--- a/src/lexer.rs
+++ b/src/lexer.rs
@@ -1019,18 +1019,12 @@ fn lex_item(file_id: FileId, bytes: &[u8], index: &mut usize) -> (Token, Option<
         *index += 1;
 
         let mut escaped = false;
-        let mut found_newline = false;
 
         while *index < bytes.len() && (escaped || bytes[*index] != b'"') {
             // Ignore a standalone carriage return
-            if bytes[*index] == b'\r' {
+            if bytes[*index] == b'\r' || bytes[*index] == b'\n' {
                 *index += 1;
-            }
-
-            // Strings can't span multiple lines
-            if bytes[*index] == b'\n' {
-                found_newline = true;
-                break;
+                continue;
             }
 
             if !escaped && bytes[*index] == b'\\' {
@@ -1040,13 +1034,6 @@ fn lex_item(file_id: FileId, bytes: &[u8], index: &mut usize) -> (Token, Option<
             }
 
             *index += 1;
-        }
-
-        if found_newline {
-            error = error.or(Some(JaktError::ParserError(
-                "strings spanning multiple lines are not allowed".to_string(),
-                Span::new(file_id, start, *index),
-            )));
         }
 
         if *index == bytes.len() || bytes[*index] != b'"' {

--- a/tests/parser/multiline_string_with_double_quotes.jakt
+++ b/tests/parser/multiline_string_with_double_quotes.jakt
@@ -1,6 +1,0 @@
-/// Expect:
-/// - error: "strings spanning multiple lines are not allowed\n"
-
-// Strings defined using a single pair of quotes should not span multiple lines
-"hello
-world"


### PR DESCRIPTION
This adds support to the selfhost compiler to include the prelude and get definitions from it. As a result, it's able to pass a few more tests.

```
==============================
162 passed
169 failed
7 skipped
==============================
```

This PR also:

* adds support for multiline strings
* removes a test that's no longer valid (that prevented multiline strings)
* improves a few error messages