### PR TITLE
selfhost/typechecker+codegen: Match expression

### DIFF
--- a/selfhost/codegen.jakt
+++ b/selfhost/codegen.jakt
@@ -8,7 +8,7 @@ import typechecker {
     BuiltinType, CheckedBlock, CheckedCall, CheckedExpression,
     CheckedFunction, CheckedProgram, CheckedStatement, CheckedStruct,
     Module, ModuleId, Scope, ScopeId, StructId, EnumId, Type, TypeId, expression_type,
-    CheckedEnum, unknown_type_id, CheckedMatchCase, FunctionId, CheckedMatchBody }
+    CheckedEnum, unknown_type_id, CheckedMatchCase, FunctionId, CheckedMatchBody, void_type_id }
 import utility { panic, todo, join, prepend_to_each, Span }
 
 
@@ -1100,9 +1100,109 @@ struct CodeGenerator {
                 )
             }
             else => {
-                todo("codegen generic match")
+                output += .codegen_generic_match(
+                    expr
+                    cases: match_cases
+                    return_type_id: type_id
+                    all_variants_constant
+                )
             }
         }
+
+        return output
+    }
+
+    function codegen_generic_match(mut this, expr: CheckedExpression, cases: [CheckedMatchCase], return_type_id: TypeId, all_variants_constant: bool) throws -> String {
+        mut output = ""
+
+        mut is_generic_enum: bool = false
+        for case_ in cases.iterator() {
+            if case_ is EnumVariant {
+                is_generic_enum = true
+                break
+            }
+        }
+        let match_values_all_constant = all_variants_constant and not is_generic_enum
+
+        output += .control_flow_state.choose_control_flow_macro()
+
+        // TODO: Use switch statement if all values are constant
+
+        output += "(([&]() -> JaktInternal::ExplicitValueOrControlFlow<"
+        output += .codegen_type(return_type_id)
+        output += ", "
+        output += .codegen_function_return_type(function_: .current_function!)
+        output += ">{\n"
+        if is_generic_enum {
+            output += "auto&& __jakt_enum_value = JaktInternal::deref_if_ref_pointer("
+        } else {
+            output += "auto __jakt_enum_value = ("
+        }
+        output += .codegen_expression(expr)
+        output += ");\n"
+
+        mut first = true
+        for case_ in cases.iterator() {
+            let first_ = first
+            first = false
+
+            match case_ {
+                EnumVariant(name, args, subject_type_id, scope_id, body) => {
+                    output += "if (__jakt_enum_value.template has<"
+
+                    mut variant_type_name = ""
+                    let qualifier = .codegen_type_possibly_as_namespace(type_id: subject_type_id, as_namespace: true)
+                    if qualifier.length() > 0 {
+                        variant_type_name += "typename JaktInternal::RemoveRefPtr<"
+                        variant_type_name += qualifier
+                        variant_type_name += ">::"
+                    }
+                    variant_type_name += name
+
+                    output += variant_type_name
+                    output += ">()) {\n"
+                    output += "auto& __jakt_match_value = __jakt_enum_value.template get<"
+                    output += variant_type_name
+                    output += ">();\n"
+
+                    for arg in args.iterator() {
+                        output += "auto& "
+                        output += arg.binding
+                        output += " = __jakt_match_value."
+                        output += arg.name ?? "value"
+                        output += ";\n"
+                    }
+
+                    output += .codegen_match_body(body, return_type_id)
+                    output += "}\n"
+                }
+                CatchAll(body, marker_span) => {
+                    // TODO: Use default statement if all values are constant
+                    if first_ {
+                        output += "{"
+                    } else {
+                        output += "else {\n"
+                    }
+                    output += .codegen_match_body(body, return_type_id)
+                    output += "}\n"
+                }
+                Expression(expression, body, marker_span) => {
+                    // TODO: Use case statement if all values are constant
+                    if not first_ {
+                        output += "else "
+                    }
+                    output += "if (__jakt_enum_value == "
+                    output += .codegen_expression(expression)
+                    output += ") {\n"
+                    output += .codegen_match_body(body, return_type_id)
+                    output += "}\n"
+                }
+            }
+        }
+        if return_type_id.equals(void_type_id()) {
+            output += "return JaktInternal::ExplicitValue<void>();\n"
+        }
+        output += "}()))\n"
 
         return output
     }
@@ -1193,16 +1293,25 @@ struct CodeGenerator {
 
     function codegen_match_body(mut this, body: CheckedMatchBody, return_type_id: TypeId) throws -> String {
         mut output = ""
+
         match body {
             Block(block) => {
                 output += .codegen_block(block)
 
-                if return_type_id.equals(unknown_type_id()) {
+                if return_type_id.equals(void_type_id()) or return_type_id.equals(unknown_type_id()) {
                     output += "return JaktInternal::ExplicitValue<void>();\n"
                 }
             }
-            Expression => {
-                todo(format("codegen_match_body: {}", body))
+            Expression(expr) => {
+                if expression_type(expr).equals(void_type_id()) or expression_type(expr).equals(unknown_type_id()) {
+                    output += "return ("
+                    output += .codegen_expression(expr)
+                    output += "), JaktInternal::ExplicitValue<void>();\n"
+                } else {
+                    output += "return JaktInternal::ExplicitValue("
+                    output += .codegen_expression(expr)
+                    output += ");\n"
+                }
             }
         }
         return output

--- a/selfhost/typechecker.jakt
+++ b/selfhost/typechecker.jakt
@@ -859,6 +859,7 @@ struct CheckedCall {
 }
 
 function unknown_type_id() -> TypeId => TypeId(module: ModuleId(id: 0), id: 0)
+function void_type_id() -> TypeId => builtin(BuiltinType::Void)
 
 function builtin(anon builtin: BuiltinType) -> TypeId {
     return TypeId(module: ModuleId(id: 0), id: builtin as! usize)

--- a/selfhost/typechecker.jakt
+++ b/selfhost/typechecker.jakt
@@ -4143,6 +4143,9 @@ struct Typechecker {
         let type_to_match_on = .get_type(subject_type_id)
         mut checked_cases: [CheckedMatchCase] = []
 
+        mut generic_inferences: [String: String] = [:] // FIXME: Use correct generic_inferences dictionary
+        mut final_result_type: TypeId? = None
+
         match type_to_match_on {
             Enum(enum_id) => {
                 let enum_ = .get_enum(enum_id)
@@ -4284,7 +4287,10 @@ struct Typechecker {
                                     }
                                 }
 
-                                let checked_body = .typecheck_match_body(body: case_.body, scope_id: new_scope_id, safety_mode, span: case_.marker_span)
+                                let checked_tuple = .typecheck_match_body(body: case_.body, scope_id: new_scope_id, safety_mode, generic_inferences, final_result_type, span: case_.marker_span)
+                                let checked_body = checked_tuple.0
+                                final_result_type = checked_tuple.1
+
                                 let checked_match_case = CheckedMatchCase::EnumVariant(
                                     name: variant_names[1].0,
                                     args: variant_arguments,
@@ -4307,7 +4313,10 @@ struct Typechecker {
                                     catch_all_span = case_.marker_span
                                 }
                                 let new_scope_id = .create_scope(parent_scope_id: scope_id, can_throw: .get_scope(scope_id).can_throw)
-                                let checked_body = .typecheck_match_body(body: case_.body, scope_id: new_scope_id, safety_mode, span: case_.marker_span)
+                                let checked_tuple = .typecheck_match_body(body: case_.body, scope_id: new_scope_id, safety_mode, generic_inferences, final_result_type, span: case_.marker_span)
+                                let checked_body = checked_tuple.0
+                                final_result_type = checked_tuple.1
+
                                 let checked_match_case = CheckedMatchCase::CatchAll(
                                     body: checked_body
                                     marker_span: case_.marker_span
@@ -4329,8 +4338,6 @@ struct Typechecker {
                 mut seen_catch_all = false
 
                 mut all_variants_constant = true
-
-                mut final_result_type: TypeId? = None
 
                 for case_ in cases.iterator() {
                     for pattern in case_.patterns.iterator() {
@@ -4355,30 +4362,9 @@ struct Typechecker {
                                 // note that this will be fully checked when this match expression is actually instantiated.
 
                                 let new_scope_id = .create_scope(parent_scope_id: scope_id, can_throw: .get_scope(scope_id).can_throw)
-                                let checked_body = .typecheck_match_body(body: case_.body, scope_id: new_scope_id, safety_mode, span: case_.marker_span)
-
-                                let maybe_current_result_type = match checked_body {
-                                    Expression(expr) => Some(expression_type(expr))
-                                    Block(block) => block.yielded_type
-                                }
-                                let current_result_type = maybe_current_result_type ?? builtin(BuiltinType::Void)
-
-                                let maybe_current_yield_span = match case_.body {
-                                    Expression(expr) => Some(expr.span())
-                                    Block(block) => block.find_yield_span()
-                                }
-                                let current_yield_span = maybe_current_yield_span ?? case_.marker_span
-
-                                if not final_result_type.has_value() {
-                                    final_result_type = current_result_type
-                                } else {
-                                    .check_types_for_compat(
-                                        lhs_type_id: final_result_type!
-                                        rhs_type_id: current_result_type
-                                        generic_inferences: [:] // FIXME: use correct generic inferences
-                                        span: current_yield_span
-                                    )
-                                }
+                                let checked_tuple = .typecheck_match_body(body: case_.body, scope_id: new_scope_id, safety_mode, generic_inferences, final_result_type, span: case_.marker_span)
+                                let checked_body = checked_tuple.0
+                                final_result_type = checked_tuple.1
 
                                 let checked_match_case = CheckedMatchCase::EnumVariant(
                                     name: variant_names[variant_names.size() - 1].0
@@ -4401,30 +4387,9 @@ struct Typechecker {
                                 seen_catch_all = true
 
                                 let new_scope_id = .create_scope(parent_scope_id: scope_id, can_throw: .get_scope(scope_id).can_throw)
-                                let checked_body = .typecheck_match_body(body: case_.body, scope_id: new_scope_id, safety_mode, span: case_.marker_span)
-
-                                let maybe_current_result_type = match checked_body {
-                                    Expression(expr) => Some(expression_type(expr))
-                                    Block(block) => block.yielded_type
-                                }
-                                let current_result_type = maybe_current_result_type ?? builtin(BuiltinType::Void)
-
-                                let maybe_current_yield_span = match case_.body {
-                                    Expression(expr) => Some(expr.span())
-                                    Block(block) => block.find_yield_span()
-                                }
-                                let current_yield_span = maybe_current_yield_span ?? case_.marker_span
-
-                                if not final_result_type.has_value() {
-                                    final_result_type = current_result_type
-                                } else {
-                                    .check_types_for_compat(
-                                        lhs_type_id: final_result_type!
-                                        rhs_type_id: current_result_type
-                                        generic_inferences: [:] // FIXME: use correct generic inferences
-                                        span: current_yield_span
-                                    )
-                                }
+                                let checked_tuple = .typecheck_match_body(body: case_.body, scope_id: new_scope_id, safety_mode, generic_inferences, final_result_type, span: case_.marker_span)
+                                let checked_body = checked_tuple.0
+                                final_result_type = checked_tuple.1
 
                                 let checked_match_case = CheckedMatchCase::CatchAll(
                                     body: checked_body
@@ -4457,30 +4422,9 @@ struct Typechecker {
                                 )
 
                                 let new_scope_id = .create_scope(parent_scope_id: scope_id, can_throw: .get_scope(scope_id).can_throw)
-                                let checked_body = .typecheck_match_body(body: case_.body, scope_id: new_scope_id, safety_mode, span: case_.marker_span)
-
-                                let maybe_current_result_type = match checked_body {
-                                    Expression(expr) => Some(expression_type(expr))
-                                    Block(block) => block.yielded_type
-                                }
-                                let current_result_type = maybe_current_result_type ?? builtin(BuiltinType::Void)
-
-                                let maybe_current_yield_span = match case_.body {
-                                    Expression(expr) => Some(expr.span())
-                                    Block(block) => block.find_yield_span()
-                                }
-                                let current_yield_span = maybe_current_yield_span ?? case_.marker_span
-
-                                if not final_result_type.has_value() {
-                                    final_result_type = current_result_type
-                                } else {
-                                    .check_types_for_compat(
-                                        lhs_type_id: final_result_type!
-                                        rhs_type_id: current_result_type
-                                        generic_inferences: [:] // FIXME: use correct generic inferences
-                                        span: current_yield_span
-                                    )
-                                }
+                                let checked_tuple = .typecheck_match_body(body: case_.body, scope_id: new_scope_id, safety_mode, generic_inferences, final_result_type, span: case_.marker_span)
+                                let checked_body = checked_tuple.0
+                                final_result_type = checked_tuple.1
 
                                 let checked_match_case = CheckedMatchCase::Expression(
                                     expression: checked_expression
@@ -4505,15 +4449,48 @@ struct Typechecker {
         return CheckedExpression::Match(expr: checked_expr, match_cases: checked_cases, span, type_id: unknown_type_id(), all_variants_constant: true)
     }
 
-    function typecheck_match_body(mut this, body: ParsedMatchBody, scope_id: ScopeId, safety_mode: SafetyMode, span: Span) throws -> CheckedMatchBody => match body {
-        Block(block) => {
-            let checked_block = .typecheck_block(parsed_block: block, parent_scope_id: scope_id, safety_mode)
-            yield CheckedMatchBody::Block(checked_block)
+    function typecheck_match_body(mut this, body: ParsedMatchBody, scope_id: ScopeId, safety_mode: SafetyMode, generic_inferences: [String: String], final_result_type: TypeId?, span: Span) throws -> (CheckedMatchBody, TypeId) {
+        mut result_type = final_result_type
+        let checked_match_body = match body {
+            Block(block) => {
+                let checked_block = .typecheck_block(parsed_block: block, parent_scope_id: scope_id, safety_mode)
+
+                // FIXME: The rust compiler only checks this if the checked_block does NOT
+                //        definitely return. However, I think we should always check this.
+                let block_type_id = checked_block.yielded_type ?? builtin(BuiltinType::Void)
+                let yield_span = block.find_yield_span() ?? span
+
+                if result_type.has_value() {
+                    .check_types_for_compat(
+                        lhs_type_id: result_type!
+                        rhs_type_id: block_type_id
+                        generic_inferences
+                        span: yield_span
+                    )
+                } else {
+                    result_type = block_type_id
+                }
+
+                yield CheckedMatchBody::Block(checked_block)
+            }
+            Expression(expr) => {
+                let checked_expression = .typecheck_expression(expr, scope_id, safety_mode)
+                if result_type.has_value() {
+                    .check_types_for_compat(
+                        lhs_type_id: result_type!
+                        rhs_type_id: expression_type(checked_expression)
+                        generic_inferences
+                        span
+                    )
+                } else {
+                    result_type = expression_type(checked_expression)
+                }
+
+                yield CheckedMatchBody::Expression(checked_expression)
+            }
         }
-        Expression(expr) => {
-            let checked_expression = .typecheck_expression(expr, scope_id, safety_mode)
-            yield CheckedMatchBody::Expression(checked_expression)
-        }
+
+        return (checked_match_body, result_type!)
     }
 
     function typecheck_dictionary(mut this, values: [(ParsedExpression, ParsedExpression)], span: Span, scope_id: ScopeId, safety_mode: SafetyMode) throws -> CheckedExpression {

--- a/selfhost/typechecker.jakt
+++ b/selfhost/typechecker.jakt
@@ -4324,7 +4324,181 @@ struct Typechecker {
                 .error("Can't match on 'void' type", .expression_span(checked_expr))
             }
             else => {
-                todo(format("type to match on: {}", type_to_match_on))
+                mut is_enum_match = false
+                mut is_value_match = false
+                mut seen_catch_all = false
+
+                mut all_variants_constant = true
+
+                mut final_result_type: TypeId? = None
+
+                for case_ in cases.iterator() {
+                    for pattern in case_.patterns.iterator() {
+                        match pattern {
+                            EnumVariant(variant_name, variant_arguments, arguments_span) => {
+                                mut variant_names = variant_name
+
+                                if is_value_match {
+                                    .error(
+                                        "Cannot have an enum match case in a match expression containing value matches"
+                                        case_.marker_span
+                                    )
+                                }
+
+                                if variant_names.size() == 0 {
+                                    panic("typecheck_match - else - EnumVariant - variant_names.size() == 0")
+                                }
+
+                                is_enum_match = true
+
+                                // We don't know what the enum type is, but we have the type var for it, so generate a generic enum match.
+                                // note that this will be fully checked when this match expression is actually instantiated.
+
+                                let new_scope_id = .create_scope(parent_scope_id: scope_id, can_throw: .get_scope(scope_id).can_throw)
+                                let checked_body = .typecheck_match_body(body: case_.body, scope_id: new_scope_id, safety_mode, span: case_.marker_span)
+
+                                let maybe_current_result_type = match checked_body {
+                                    Expression(expr) => Some(expression_type(expr))
+                                    Block(block) => block.yielded_type
+                                }
+                                let current_result_type = maybe_current_result_type ?? builtin(BuiltinType::Void)
+
+                                let maybe_current_yield_span = match case_.body {
+                                    Expression(expr) => Some(expr.span())
+                                    Block(block) => block.find_yield_span()
+                                }
+                                let current_yield_span = maybe_current_yield_span ?? case_.marker_span
+
+                                if not final_result_type.has_value() {
+                                    final_result_type = current_result_type
+                                } else {
+                                    .check_types_for_compat(
+                                        lhs_type_id: final_result_type!
+                                        rhs_type_id: current_result_type
+                                        generic_inferences: [:] // FIXME: use correct generic inferences
+                                        span: current_yield_span
+                                    )
+                                }
+
+                                let checked_match_case = CheckedMatchCase::EnumVariant(
+                                    name: variant_names[variant_names.size() - 1].0
+                                    args: variant_arguments
+                                    subject_type_id
+                                    index: 0
+                                    scope_id: new_scope_id
+                                    body: checked_body
+                                    marker_span: case_.marker_span
+                                )
+                                checked_cases.push(checked_match_case)
+                            }
+                            CatchAll => {
+                                if seen_catch_all {
+                                    .error(
+                                        "Cannot have multiple catch-all match cases"
+                                        case_.marker_span
+                                    )
+                                }
+                                seen_catch_all = true
+
+                                let new_scope_id = .create_scope(parent_scope_id: scope_id, can_throw: .get_scope(scope_id).can_throw)
+                                let checked_body = .typecheck_match_body(body: case_.body, scope_id: new_scope_id, safety_mode, span: case_.marker_span)
+
+                                let maybe_current_result_type = match checked_body {
+                                    Expression(expr) => Some(expression_type(expr))
+                                    Block(block) => block.yielded_type
+                                }
+                                let current_result_type = maybe_current_result_type ?? builtin(BuiltinType::Void)
+
+                                let maybe_current_yield_span = match case_.body {
+                                    Expression(expr) => Some(expr.span())
+                                    Block(block) => block.find_yield_span()
+                                }
+                                let current_yield_span = maybe_current_yield_span ?? case_.marker_span
+
+                                if not final_result_type.has_value() {
+                                    final_result_type = current_result_type
+                                } else {
+                                    .check_types_for_compat(
+                                        lhs_type_id: final_result_type!
+                                        rhs_type_id: current_result_type
+                                        generic_inferences: [:] // FIXME: use correct generic inferences
+                                        span: current_yield_span
+                                    )
+                                }
+
+                                let checked_match_case = CheckedMatchCase::CatchAll(
+                                    body: checked_body
+                                    marker_span: case_.marker_span
+                                )
+                                checked_cases.push(checked_match_case)
+                            }
+                            Expression(expr) => {
+                                if is_enum_match {
+                                    .error(
+                                        "Cannot have a value match case in a match expression containing enum matches"
+                                        case_.marker_span
+                                    )
+                                }
+                                is_value_match = true
+
+                                let checked_expression = .typecheck_expression(expr, scope_id, safety_mode)
+
+                                if not checked_expression.to_number_constant(program: .program).has_value() {
+                                    all_variants_constant = false
+                                }
+
+                                // FIXME: In the future, we should really make this a "does it satisfy some trait" check.
+                                //        For now, we just check that the types are equal.
+                                .check_types_for_compat(
+                                    lhs_type_id: expression_type(checked_expression)
+                                    rhs_type_id: subject_type_id
+                                    generic_inferences: [:] // FIXME: use correct generic inferences
+                                    span: case_.marker_span
+                                )
+
+                                let new_scope_id = .create_scope(parent_scope_id: scope_id, can_throw: .get_scope(scope_id).can_throw)
+                                let checked_body = .typecheck_match_body(body: case_.body, scope_id: new_scope_id, safety_mode, span: case_.marker_span)
+
+                                let maybe_current_result_type = match checked_body {
+                                    Expression(expr) => Some(expression_type(expr))
+                                    Block(block) => block.yielded_type
+                                }
+                                let current_result_type = maybe_current_result_type ?? builtin(BuiltinType::Void)
+
+                                let maybe_current_yield_span = match case_.body {
+                                    Expression(expr) => Some(expr.span())
+                                    Block(block) => block.find_yield_span()
+                                }
+                                let current_yield_span = maybe_current_yield_span ?? case_.marker_span
+
+                                if not final_result_type.has_value() {
+                                    final_result_type = current_result_type
+                                } else {
+                                    .check_types_for_compat(
+                                        lhs_type_id: final_result_type!
+                                        rhs_type_id: current_result_type
+                                        generic_inferences: [:] // FIXME: use correct generic inferences
+                                        span: current_yield_span
+                                    )
+                                }
+
+                                let checked_match_case = CheckedMatchCase::Expression(
+                                    expression: checked_expression
+                                    body: checked_body
+                                    marker_span: case_.marker_span
+                                )
+                                checked_cases.push(checked_match_case)
+                            }
+                        }
+                    }
+                }
+
+                if is_value_match and not seen_catch_all {
+                    .error(
+                        "match expression is not exhaustive, a value match must contain an irrefutable 'else' pattern"
+                        span
+                    )
+                }
             }
         }
 
@@ -4336,9 +4510,9 @@ struct Typechecker {
             let checked_block = .typecheck_block(parsed_block: block, parent_scope_id: scope_id, safety_mode)
             yield CheckedMatchBody::Block(checked_block)
         }
-        Expression => {
-            todo("implement typecheck match body expression")
-            yield CheckedMatchBody::Expression(CheckedExpression::Garbage(span))
+        Expression(expr) => {
+            let checked_expression = .typecheck_expression(expr, scope_id, safety_mode)
+            yield CheckedMatchBody::Expression(checked_expression)
         }
     }
 


### PR DESCRIPTION
Typecheck and codegen match statements on expressions.

With these changes three additional checks pass :^)
before
```
==============================
157 passed
176 failed
7 skipped
==============================
```
after
```
==============================
160 passed
173 failed
7 skipped
==============================
```