### PR TITLE
selfhost/typechecker+codegen: Pass on match result type and implement yield 

### DIFF
--- a/selfhost/codegen.jakt
+++ b/selfhost/codegen.jakt
@@ -130,6 +130,12 @@ struct CodeGenerator {
     current_function: CheckedFunction?
     debug_info: CodegenDebugInfo
     namespace_stack: [String]
+    fresh_var_counter: usize
+    fresh_label_counter: usize
+
+    function fresh_var(mut this) throws => format("__jakt_var_{}", .fresh_var_counter++) // FIXME: remove when vscode syntax highlighting works properly"
+
+    function fresh_label(mut this) throws => format("__jakt_label_{}", .fresh_label_counter++) // FIXME: remove when vscode syntax highlighting works properly"
 
     function generate(anon program: CheckedProgram, file_name: String, file_contents: [u8], debug_info: bool) throws -> String {
         let none_function: CheckedFunction? = None
@@ -150,6 +156,8 @@ struct CodeGenerator {
                 statement_span_comments: debug_info
             )
             namespace_stack: []
+            fresh_var_counter: 0
+            fresh_label_counter: 0
         )
 
         mut output = ""
@@ -1203,7 +1211,7 @@ struct CodeGenerator {
                 }
             }
         }
-        if return_type_id.equals(void_type_id()) {
+        if return_type_id.equals(void_type_id()) or return_type_id.equals(unknown_type_id()) {
             output += "return JaktInternal::ExplicitValue<void>();\n"
         }
         output += "}()))\n"
@@ -1702,7 +1710,20 @@ struct CodeGenerator {
     function codegen_block(mut this, block: CheckedBlock) throws -> String {
         mut output = ""
 
-        // FIXME: yielded_type
+        if block.yielded_type.has_value() {
+            let yielded_type = block.yielded_type!
+            let type_output = .codegen_type(yielded_type)
+            let fresh_var = .fresh_var()
+            let fresh_label = .fresh_label()
+
+            .entered_yieldable_blocks.push((fresh_var, fresh_label))
+
+            output += "({ Optional<"
+            output += type_output
+            output += "> "
+            output += fresh_var
+            output += "; "
+        }
 
         output += "{\n"
 
@@ -1712,7 +1733,16 @@ struct CodeGenerator {
 
         output += "}\n"
 
-        // FIXME: yielded_type
+        if block.yielded_type.has_value() {
+            let block_tuple = .entered_yieldable_blocks.pop()!
+            let block_var = block_tuple.0
+            let block_label = block_tuple.1
+
+            output += block_label
+            output += ":; "
+            output += block_var
+            output += ".release_value(); })"
+        }
 
         return output
     }
@@ -1821,6 +1851,26 @@ struct CodeGenerator {
                 }
 
                 add_newline = false
+
+                yield output
+            }
+            Yield(expr, span) => {
+                mut output = ""
+
+                if .entered_yieldable_blocks.size() == 0 {
+                    panic("Must be in a block to yield")
+                }
+
+                let block_tuple = .entered_yieldable_blocks[.entered_yieldable_blocks.size() - 1]
+                let block_var_name = block_tuple.0
+                let block_end_label = block_tuple.1
+
+                output += block_var_name
+                output += " = "
+                output += .codegen_expression(expr)
+                output += "; goto "
+                output += block_end_label
+                output += ";\n"
 
                 yield output
             }

--- a/selfhost/typechecker.jakt
+++ b/selfhost/typechecker.jakt
@@ -4443,7 +4443,7 @@ struct Typechecker {
             }
         }
 
-        return CheckedExpression::Match(expr: checked_expr, match_cases: checked_cases, span, type_id: unknown_type_id(), all_variants_constant: true)
+        return CheckedExpression::Match(expr: checked_expr, match_cases: checked_cases, span, type_id: final_result_type ?? void_type_id(), all_variants_constant: true)
     }
 
     function typecheck_match_body(mut this, body: ParsedMatchBody, scope_id: ScopeId, safety_mode: SafetyMode, generic_inferences: [String: String], final_result_type: TypeId?, span: Span) throws -> (CheckedMatchBody, TypeId) {
@@ -4452,23 +4452,35 @@ struct Typechecker {
             Block(block) => {
                 let checked_block = .typecheck_block(parsed_block: block, parent_scope_id: scope_id, safety_mode)
 
-                // FIXME: The rust compiler only checks this if the checked_block does NOT
-                //        definitely return. However, I think we should always check this.
-                let block_type_id = checked_block.yielded_type ?? builtin(BuiltinType::Void)
-                let yield_span = block.find_yield_span() ?? span
+                // FIXME: Check that this is not the wrong way around
+                if not checked_block.definitely_returns {
+                    let block_type_id = checked_block.yielded_type ?? builtin(BuiltinType::Void)
+                    let yield_span = block.find_yield_span() ?? span
 
-                if result_type.has_value() {
-                    .check_types_for_compat(
-                        lhs_type_id: result_type!
-                        rhs_type_id: block_type_id
-                        generic_inferences
-                        span: yield_span
-                    )
-                } else {
-                    result_type = block_type_id
+                    if result_type.has_value() {
+                        .check_types_for_compat(
+                            lhs_type_id: result_type!
+                            rhs_type_id: block_type_id
+                            generic_inferences
+                            span: yield_span
+                        )
+                    } else {
+                        result_type = block_type_id
+                    }
                 }
 
-                yield CheckedMatchBody::Block(checked_block)
+                mut final_body: CheckedMatchBody? = None
+                if checked_block.yielded_type.has_value() {
+                    final_body = CheckedMatchBody::Expression(CheckedExpression::Block(
+                        block: checked_block
+                        span
+                        type_id: checked_block.yielded_type!
+                    ))
+                } else {
+                    final_body = CheckedMatchBody::Block(checked_block)
+                }
+
+                yield final_body!
             }
             Expression(expr) => {
                 let checked_expression = .typecheck_expression(expr, scope_id, safety_mode)


### PR DESCRIPTION
@jntrnr I decided to work on the matches some more, but before I could push it you already merged the PR :D

This allows an additional test `match_block_yield.jakt` to pass, which means we now have 166 passing and 166 failing o.o
