### PR TITLE
selfhost/typechecker+codegen: Generate boxed enums

### DIFF
--- a/selfhost/codegen.jakt
+++ b/selfhost/codegen.jakt
@@ -224,11 +224,171 @@ struct CodeGenerator {
         return output
     }
 
+    function postorder_traversal(this, encoded_type_id: String, mut visited: {usize}, encoded_dependency_graph: [String: [String]], mut output: [TypeId]) throws {
+        let type_id = TypeId::from_string(encoded_type_id)
+        if visited.contains(type_id.id) {
+            return
+        }
+        visited.add(type_id.id)
+        if encoded_dependency_graph.contains(encoded_type_id) {
+            for dependency in encoded_dependency_graph.get(encoded_type_id)!.iterator() {
+                .postorder_traversal(encoded_type_id: dependency, visited, encoded_dependency_graph, output)
+            }
+        }
+        output.push(type_id)
+    }
+
+    function produce_codegen_dependency_graph(this, scope: Scope) throws -> [String : [String]] {
+        mut dependency_graph: [String : [String]] = [:]
+
+        for type_ in scope.types.iterator() {
+            dependency_graph.set(type_.1.to_string(), .extract_dependencies_from(type_id: type_.1, dependency_graph, top_level: true))
+        }
+
+        return dependency_graph
+    }
+
+    function extract_dependencies_from(this, type_id: TypeId, dependency_graph: [String : [String]], top_level: bool) throws -> [String] {
+        mut dependencies: [String] = []
+
+        if dependency_graph.contains(type_id.to_string()) {
+            for dependency in dependency_graph.get(type_id.to_string())!.iterator() {
+                dependencies.push(dependency)
+            }
+            return dependencies
+        }
+
+        let type_ = .program.get_type(type_id)
+        let inner_dependencies = match type_ {
+            Enum(enum_id) => .extract_dependencies_from_enum(enum_id, dependency_graph, top_level)
+            GenericEnumInstance(id) => .extract_dependencies_from_enum(enum_id: id, dependency_graph, top_level)
+            Struct(id) => .extract_dependencies_from_struct(struct_id: id, dependency_graph, top_level)
+            GenericInstance(id) => .extract_dependencies_from_struct(struct_id: id, dependency_graph, top_level)
+            else => []
+        }
+
+        for dependency in inner_dependencies.iterator() {
+            dependencies.push(dependency)
+        }
+
+        return dependencies
+    }
+
+    function extract_dependencies_from_enum(this, enum_id: EnumId, dependency_graph: [String : [String]], top_level: bool) throws -> [String] {
+        mut dependencies: [String] = []
+
+        let enum_ = .program.get_enum(enum_id)
+        if enum_.definition_linkage is External {
+            // This type is defined somewhere else,
+            // so we can skip marking it as a dependency.
+            return dependencies
+        }
+        if enum_.is_boxed and not top_level {
+            // We store and pass these as pointers, so we don't need to
+            // include them in the dependency graph.
+            return dependencies
+        }
+        dependencies.push(enum_.type_id.to_string())
+        if not enum_.underlying_type_id.equals(unknown_type_id()) {
+            let inner_dependencies = .extract_dependencies_from(type_id: enum_.underlying_type_id, dependency_graph, top_level: false)
+            for dependency in inner_dependencies.iterator() {
+                dependencies.push(dependency)
+            }
+        }
+        for variant in enum_.variants.iterator() {
+            match variant {
+                Typed(type_id) => {
+                    let inner_dependencies = .extract_dependencies_from(type_id, dependency_graph, top_level: false)
+                    for dependency in inner_dependencies.iterator() {
+                        dependencies.push(dependency)
+                    }
+                }
+                StructLike(fields) => {
+                    for field in fields.iterator() {
+                        let type_id = .program.get_variable(field).type_id
+                        let inner_dependencies = .extract_dependencies_from(type_id, dependency_graph, top_level: false)
+                        for dependency in inner_dependencies.iterator() {
+                            dependencies.push(dependency)
+                        }
+                    }
+                }
+                else => {}
+            }
+        }
+
+        return dependencies
+    }
+
+    function extract_dependencies_from_struct(this, struct_id: StructId, dependency_graph: [String : [String]], top_level: bool) throws -> [String] {
+        mut dependencies: [String] = []
+        let struct_ = .program.get_struct(struct_id)
+        if struct_.definition_linkage is External {
+            // This type is defined somewhere else,
+            // so we can skip marking it as a dependency.
+            return dependencies
+        }
+
+        if struct_.record_type is Class and not top_level {
+            // We store and pass these as pointers, so we don't need to
+            // include them in the dependency graph.
+            return dependencies
+        }
+
+        dependencies.push(struct_.type_id.to_string())
+        // The struct's fields are also dependencies.
+        for field in struct_.fields.iterator() {
+            let type_id = .program.get_variable(field).type_id
+            let inner_dependencies = .extract_dependencies_from(type_id, dependency_graph, top_level: false)
+            for dependency in inner_dependencies.iterator() {
+                dependencies.push(dependency)
+            }
+        }
+        return dependencies
+    }
+
     function codegen_namespace(mut this, scope: Scope, current_module: Module) throws -> String {
         mut output = ""
 
+        let encoded_dependency_graph = .produce_codegen_dependency_graph(scope)
         // FIXME: This wants to be a {TypeId}
         mut seen_types: {usize} = {}
+        for entry in encoded_dependency_graph.iterator() {
+            let traversal: [TypeId] = []
+            .postorder_traversal(encoded_type_id: entry.0, visited: seen_types, dependency_graph: encoded_dependency_graph, output: traversal)
+            for type_id in traversal.iterator() {
+                let type_ = .program.get_type(type_id)
+                match type_ {
+                    Enum(enum_id) => {
+                        if not enum_id.module.equals(current_module.id) {
+                            // Skip over imports from other modules
+                            continue
+                        }
+                        let enum_ = .program.get_enum(enum_id)
+                        let enum_output = .codegen_enum(enum_)
+                        if not enum_output.is_empty() {
+                            output += enum_output
+                        }
+                    }
+                    Struct(struct_id) => {
+                        if not struct_id.module.equals(current_module.id) {
+                            // Skip over imports from other modules
+                            continue
+                        }
+
+                        let struct_ = .program.get_struct(struct_id)
+                        let struct_output = .codegen_struct(struct_)
+
+                        if not struct_output.is_empty() {
+                            output += struct_output
+                        }
+                    }
+                    else => {
+                        panic(format("Unexpected type in dependency graph: {}", type_))
+                    }
+                }
+                seen_types.add(type_id.id)
+            }
+        }
 
         for name_and_struct_id in scope.structs.iterator() {
             let struct_id = name_and_struct_id.1

--- a/selfhost/codegen.jakt
+++ b/selfhost/codegen.jakt
@@ -8,7 +8,8 @@ import typechecker {
     BuiltinType, CheckedBlock, CheckedCall, CheckedExpression,
     CheckedFunction, CheckedProgram, CheckedStatement, CheckedStruct,
     Module, ModuleId, Scope, ScopeId, StructId, EnumId, Type, TypeId, expression_type,
-    CheckedEnum, unknown_type_id, CheckedMatchCase, FunctionId, CheckedMatchBody, void_type_id }
+    CheckedEnum, unknown_type_id, CheckedMatchCase, FunctionId, CheckedMatchBody, void_type_id,
+    CheckedVariable }
 import utility { panic, todo, join, prepend_to_each, Span }
 import compiler { Compiler }
 
@@ -614,25 +615,12 @@ struct CodeGenerator {
         return output
     }
 
-    function codegen_enum_predecl(mut this, enum_: CheckedEnum) throws -> String => match enum_.record_type {
-        Class => {
-            todo("codegen_enum_predecl class record type")
-            yield ""
-        }
-        else => .codegen_nonrecursive_enum_predecl(enum_)
-    }
-
-    function codegen_nonrecursive_enum_predecl(mut this, enum_: CheckedEnum) throws -> String {
+    function codegen_enum_predecl(mut this, enum_: CheckedEnum) throws -> String {
         mut output = ""
 
         if not enum_.underlying_type_id.equals(unknown_type_id()) {
             if .program.is_integer(enum_.underlying_type_id) {
-                output += "enum class "
-                output += enum_.name
-                output += ": "
-                output += .codegen_type(enum_.underlying_type_id)
-                output += ";\n"
-                return output
+                return format("enum class {}: {};", enum_.name, .codegen_type(enum_.underlying_type_id))
             } else {
                 todo("Enums with a non-integer underlying type")
             }
@@ -755,7 +743,6 @@ struct CodeGenerator {
         if is_generic {
             output += "template<" + template_args + ">\n"
         }
-        output += "struct " + enum_.name + " : public Variant<"
         mut variant_names: [String] = []
         mut variant_arguments_array: [String] = []
         for variant in enum_.variants.iterator() {
@@ -767,7 +754,16 @@ struct CodeGenerator {
             variant_names.push(variant.name())
         }
         let variant_args = join(variant_arguments_array, separator: ", ")
-        output += variant_args + "> {\n"
+
+        output += format("struct {} : public Variant<{}>", enum_.name, variant_args)
+        if enum_.is_boxed {
+            output += format(", public RefCounted<{}", enum_.name)
+            if is_generic {
+                output += format("<{}>", join(generic_parameter_names, separator: ", "))
+            }
+            output += ">"
+        }
+        output += " {\n"
         output += "using Variant<" + variant_args + ">::Variant;\n"
 
         for name in variant_names.iterator() {
@@ -778,6 +774,16 @@ struct CodeGenerator {
                 output += ">"
             }
             output += ";\n"
+        }
+
+        if enum_.is_boxed {
+            mut fully_instantiated_name = enum_.name
+            if is_generic {
+                fully_instantiated_name += format("<{}>", join(generic_parameter_names, separator: ", "))
+            }
+            output += "template<typename V, typename... Args> static auto create(Args&&... args) {\n"
+            output += format("return adopt_nonnull_ref_or_enomem(new (nothrow) {}(V(forward<Args>(args)...)));\n", fully_instantiated_name)
+            output += "}\n"
         }
 
         output += .codegen_enum_debug_description_getter(enum_)
@@ -1297,7 +1303,9 @@ struct CodeGenerator {
             output += ">{\n"
             output += "auto&& __jakt_match_variant_maybe_deref = " + .codegen_expression(expr) + ";"
             output += "auto&& __jakt_match_variant = "
-            // FIXME: needs deref
+            if enum_.is_boxed {
+                output += "*"
+            }
             output += "__jakt_match_variant_maybe_deref;\nswitch(__jakt_match_variant.index()) {\n"
 
             mut has_default = false
@@ -1333,6 +1341,22 @@ struct CodeGenerator {
                                     let arg = args[0]
                                     let var = .program.find_var_in_scope(scope_id, var: arg.binding)!
                                     output += format("{} const& {} = __jakt_match_value.value;\n", .codegen_type(var.type_id), arg.binding)
+                                }
+                            }
+                            StructLike(name, fields) => {
+                                output += format(
+                                    "auto&& __jakt_match_value = __jakt_match_variant.template get<typename {}::{}>();",
+                                    .codegen_type_possibly_as_namespace(
+                                        type_id: subject_type_id,
+                                        as_namespace: true,
+                                    ),
+                                    name)
+                                
+                                if not args.is_empty() {
+                                    for arg in fields.iterator() {
+                                        let var = .program.get_variable(arg)
+                                        output += format("{} const& {} = __jakt_match_value.{};\n", .codegen_type(var.type_id), var.name, var.name)
+                                    }
                                 }
                             }
                             else => {
@@ -1690,10 +1714,22 @@ struct CodeGenerator {
                         match .program.get_type(function_.return_type_id) {
                             Enum(enum_id) => {
                                 let enum_ = .program.get_enum(enum_id)
-                                output += "typename "
                                 let enum_type_module = .program.get_module(enum_id.module)
-                                if not (enum_type_module.is_root or enum_type_module.id.equals(ModuleId(id: 0))) {
-                                    output += enum_type_module.name + "::"
+
+                                if enum_.is_boxed {
+                                    if not (enum_type_module.is_root or enum_type_module.id.equals(ModuleId(id: 0))) {
+                                        output += enum_type_module.name + "::"
+                                    }
+                                    output += .codegen_namespace_path(call)
+                                    output += "template create<typename "
+                                    output += .codegen_type_possibly_as_namespace(type_id: call.return_type, as_namespace: true)
+                                    output += "::" + call.name + ">"
+                                } else {
+                                    output += "typename "
+                                    if not (enum_type_module.is_root or enum_type_module.id.equals(ModuleId(id: 0))) {
+                                        output += enum_type_module.name + "::"
+                                    }
+                                    output += .codegen_namespace_path(call) + call.name
                                 }
                             }
                             GenericEnumInstance(id) => {
@@ -1703,9 +1739,6 @@ struct CodeGenerator {
                                 panic("constructor expected enum type")
                             }
                         }
-
-                        output += .codegen_namespace_path(call)
-                        output += call.name
                     } else {
                         if not (type_module.is_root or type_module.id.id == 0 or function_.linkage is External or (not call.namespace_.is_empty() and call.namespace_[0].name == type_module.name))
                         {
@@ -2074,7 +2107,7 @@ struct CodeGenerator {
         let type_module = .program.get_module(id.module)
         let checked_enum = .program.get_enum(id)
 
-        if not as_namespace and checked_enum.record_type is Class {
+        if not as_namespace and checked_enum.is_boxed {
             output += "NonnullRefPtr<"
             if not (type_module.is_root or type_module.id.equals(ModuleId(id: 0))) {
                 output += type_module.name

--- a/selfhost/typechecker.jakt
+++ b/selfhost/typechecker.jakt
@@ -2248,9 +2248,12 @@ struct Typechecker {
                         continue
                     } 
                     seen_names.add(variant.name)
-                    if variant.params.has_value() and variant.params!.size() > 0 and variant.params![0].name != "" {
+                    let is_structlike = variant.params.has_value() and variant.params!.size() > 0 and variant.params![0].name != ""
+                    let is_typed = variant.params.has_value() and variant.params!.size() == 1 and variant.params![0].name == ""
+                    if is_structlike {
                         mut seen_fields: {String} = {}
                         mut fields: [VarId] = []
+                        mut params: [CheckedParameter] = []
                         for param in variant.params!.iterator() {
                             if seen_fields.contains(param.name) {
                                 .error(format("Enum variant '{}' has a member named '{}' more than once", variant.name, param.name), param.span)
@@ -2266,6 +2269,7 @@ struct Typechecker {
                                 definition_span: param.span
                                 visibility: Visibility::Public
                             )
+                            params.push(CheckedParameter(requires_label: true, variable: checked_var))
 
                             // TODO: dump type hints
 
@@ -2286,7 +2290,7 @@ struct Typechecker {
                                 name_span: variant.span,
                                 visibility: Visibility::Public,
                                 return_type_id: .find_or_add_type_id(Type::Enum(enum_id)),
-                                params: [], // TODO: params @nocommit
+                                params,
                                 generic_params: [],
                                 block: CheckedBlock(statements: [], scope_id: block_scope_id, definitely_returns: true, yielded_type: none_type_id),
                                 can_throw: can_function_throw,
@@ -2297,23 +2301,30 @@ struct Typechecker {
                             let function_id = module.add_function(checked_function)
                             .add_function_to_scope(parent_scope_id: enum_.scope_id, name: variant.name, function_id, span: variant.span)
                         }
-                    } else if variant.params.has_value() and variant.params!.size() == 1 and variant.params![0].name == "" {
+                    } else if is_typed {
                         let param = variant.params![0]
                         let type_id = .typecheck_typename(parsed_type: param.parsed_type, scope_id: enum_.scope_id, ignore_errors: false)
                         enum_.variants.push(CheckedEnumVariant::Typed(name: variant.name, type_id, span: param.span))
-                        
+
                         let maybe_enum_variant_constructor = .find_function_in_scope(parent_scope_id: enum_.scope_id, function_name: variant.name)
                         if not maybe_enum_variant_constructor.has_value() {
                             let can_function_throw = false // TODO: is_boxed
                             let function_scope_id = .create_scope(parent_scope_id, can_throw: can_function_throw)
                             let block_scope_id = .create_scope(parent_scope_id: function_scope_id, can_throw: can_function_throw)
                             let none_type_id: TypeId? = None
+                            let variable = CheckedVariable(
+                                name: "value"
+                                type_id
+                                is_mutable: false
+                                definition_span: param.span
+                                visibility: Visibility::Public
+                            )
                             let checked_function = CheckedFunction(
                                 name: variant.name,
                                 name_span: variant.span,
                                 visibility: Visibility::Public,
                                 return_type_id: .find_or_add_type_id(Type::Enum(enum_id)),
-                                params: [], // TODO: params @nocommit
+                                params: [CheckedParameter(requires_label: false, variable)],
                                 generic_params: [],
                                 block: CheckedBlock(statements: [], scope_id: block_scope_id, definitely_returns: true, yielded_type: none_type_id),
                                 can_throw: can_function_throw,

--- a/selfhost/typechecker.jakt
+++ b/selfhost/typechecker.jakt
@@ -83,7 +83,7 @@ struct TypeId {
 
         let module_id = parts[0].to_uint()
         let type_id = parts[1].to_uint()
-        if module_id.has_value() or not type_id.has_value() {
+        if not module_id.has_value() or not type_id.has_value() {
             throw Error::from_errno(9999) // FIXME: good error message
         }
 
@@ -4868,8 +4868,7 @@ struct Typechecker {
                 yield CheckedMatchBody::Expression(checked_expression)
             }
         }
-
-        return (checked_match_body, result_type!)
+        return (checked_match_body, result_type ?? unknown_type_id())
     }
 
     function typecheck_dictionary(mut this, values: [(ParsedExpression, ParsedExpression)], span: Span, scope_id: ScopeId, safety_mode: SafetyMode) throws -> CheckedExpression {

--- a/selfhost/typechecker.jakt
+++ b/selfhost/typechecker.jakt
@@ -468,6 +468,7 @@ struct CheckedEnum {
     record_type: RecordType
     underlying_type_id: TypeId
     type_id: TypeId
+    is_boxed: bool
 }
 
 enum CheckedEnumVariant {
@@ -1873,6 +1874,10 @@ struct Typechecker {
         let enum_type_id = TypeId(module: module_id, id: .current_module().types.size() - 1)
         .add_type_to_scope(scope_id, type_name: parsed_record.name, type_id: enum_type_id, span: parsed_record.name_span)
 
+        let is_boxed = match parsed_record.record_type {
+            SumEnum(is_boxed) => is_boxed
+            else => false
+        }
         // Add a placeholder entry, this will be replaced later.
         module.enums.push(CheckedEnum(
             name: parsed_record.name
@@ -1884,6 +1889,7 @@ struct Typechecker {
             record_type: parsed_record.record_type
             underlying_type_id: enum_type_id
             type_id: enum_type_id
+            is_boxed
         ))
     }
 
@@ -1899,6 +1905,10 @@ struct Typechecker {
             else => builtin(BuiltinType::Void)
         }
 
+        let is_boxed = match parsed_record.record_type {
+            SumEnum(is_boxed) => is_boxed
+            else => false
+        }
         mut module = .current_module()
         module.enums[enum_id.id] = CheckedEnum(
             name: parsed_record.name
@@ -1910,6 +1920,7 @@ struct Typechecker {
             record_type: parsed_record.record_type
             underlying_type_id
             type_id: enum_type_id
+            is_boxed
         )
 
         mut generic_parameters: [TypeId] = module.enums[enum_id.id].generic_parameters
@@ -2240,7 +2251,7 @@ struct Typechecker {
                     }
                 }
             }
-            SumEnum(variants) => {
+            SumEnum(is_boxed, variants) => {
                 mut module = .current_module()
                 for variant in variants.iterator() {
                     if seen_names.contains(variant.name) {
@@ -2281,7 +2292,7 @@ struct Typechecker {
                         enum_.variants.push(CheckedEnumVariant::StructLike(name: variant.name, fields, span: variant.span))
                         let maybe_enum_variant_constructor = .find_function_in_scope(parent_scope_id: enum_.scope_id, function_name: variant.name)
                         if not maybe_enum_variant_constructor.has_value() {
-                            let can_function_throw = false // TODO: is_boxed
+                            let can_function_throw = is_boxed
                             let function_scope_id = .create_scope(parent_scope_id, can_throw: can_function_throw)
                             let block_scope_id = .create_scope(parent_scope_id: function_scope_id, can_throw: can_function_throw)
                             let none_type_id: TypeId? = None
@@ -2308,7 +2319,7 @@ struct Typechecker {
 
                         let maybe_enum_variant_constructor = .find_function_in_scope(parent_scope_id: enum_.scope_id, function_name: variant.name)
                         if not maybe_enum_variant_constructor.has_value() {
-                            let can_function_throw = false // TODO: is_boxed
+                            let can_function_throw = is_boxed
                             let function_scope_id = .create_scope(parent_scope_id, can_throw: can_function_throw)
                             let block_scope_id = .create_scope(parent_scope_id: function_scope_id, can_throw: can_function_throw)
                             let none_type_id: TypeId? = None
@@ -2339,7 +2350,7 @@ struct Typechecker {
                         enum_.variants.push(CheckedEnumVariant::Untyped(name: variant.name, span: variant.span))
                         let maybe_enum_variant_constructor = .find_function_in_scope(parent_scope_id: enum_.scope_id, function_name: variant.name)
                         if not maybe_enum_variant_constructor.has_value() {
-                            let can_function_throw = false // TODO: is_boxed
+                            let can_function_throw = is_boxed
                             let function_scope_id = .create_scope(parent_scope_id, can_throw: can_function_throw)
                             let block_scope_id = .create_scope(parent_scope_id: function_scope_id, can_throw: can_function_throw)
                             let none_type_id: TypeId? = None

--- a/selfhost/typechecker.jakt
+++ b/selfhost/typechecker.jakt
@@ -4978,7 +4978,7 @@ struct Typechecker {
         let maybe_function_id = .find_function_in_scope(parent_scope_id: current_scope_id, function_name: call.name)
         if maybe_function_id.has_value() {
             let function_id = maybe_function_id!
-            if not (must_be_enum_constructor or .get_function(function_id).type is ImplicitEnumConstructor) {
+            if not must_be_enum_constructor or .get_function(function_id).type is ImplicitEnumConstructor {
                 return function_id
             }
         }


### PR DESCRIPTION
This change adds support for typechecking and generating boxed enums. The `samples/enums/recursive_enums.jakt` sample still does not pass because we need support for `produce_codegen_dependency_graph` which relies on the `BTreeMap` and `BTreeSet` data structures.

when I manually put the generated code in the correct order, the test passes. :^)

Update: I finished the dependency graph and now more tests pass
```
[ PASS ] samples/enums/recursive_enums.jakt
[ PASS ] samples/enums/one_line_enum_declaration.jakt
[ PASS ] samples/enums/parse.jakt
[ PASS ] samples/enums/is_variant.jakt
[ PASS ] samples/enums/empty_enum.jakt
[ PASS ] samples/enums/recursive_enums_bad.jakt
[ FAIL ] samples/enums/methods.jakt
[ PASS ] samples/enums/underlying.jakt
[ FAIL ] samples/enums/simple_match.jakt
[ PASS ] samples/enums/simple_constructor.jakt
[ FAIL ] samples/enums/methods_access_violation.jakt
```