### PR TITLE
selfhost/codegen+typecheck: Add array support to selfhost

### DIFF
--- a/selfhost/codegen.jakt
+++ b/selfhost/codegen.jakt
@@ -1083,6 +1083,36 @@ struct CodeGenerator {
             yield output + var.name
         }
         Match(expr, match_cases, type_id, all_variants_constant) => .codegen_match(expr, match_cases, type_id, all_variants_constant)
+        JaktArray(vals, repeat, span, type_id, inner_type_id) => {
+            mut output = ""
+            if repeat.has_value() {
+                let repeat_val = repeat.value()
+                output += "(TRY(Array<"
+                output += .codegen_type(inner_type_id)
+                output += ">::filled("
+                output += .codegen_expression(repeat_val)
+                output += ", "
+                output += .codegen_expression(vals[0])
+                output += ")))"
+            } else {
+                output += "(TRY(Array<"
+                output += .codegen_type(inner_type_id)
+                output += ">::create_with({"
+                mut first = true
+                for val in vals.iterator() {
+                    if not first {
+                        output += ", "
+                    } else {
+                        first = false
+                    }
+
+                    output += .codegen_expression(val)
+                }
+                output += "})))"
+            }
+
+            yield output
+        }
         else => {
             todo(format("codegen_expression else: {}", expression))
             yield ""

--- a/selfhost/typechecker.jakt
+++ b/selfhost/typechecker.jakt
@@ -194,7 +194,7 @@ boxed enum Type {
                                 mut idx = 0uz
 
                                 while idx < lhs_args.size() {
-                                    if lhs_args[idx].equals(rhs_args[idx]) {
+                                    if not lhs_args[idx].equals(rhs_args[idx]) {
                                         return false
                                     }
                                     idx++
@@ -718,7 +718,7 @@ boxed enum CheckedExpression {
     BinaryOp(lhs: CheckedExpression, op: BinaryOperator, rhs: CheckedExpression, span: Span, type_id: TypeId)
     JaktTuple(vals: [CheckedExpression], span: Span, type_id: TypeId)
     Range(from: CheckedExpression, to: CheckedExpression, span: Span, type_id: TypeId)
-    JaktArray(vals: [CheckedExpression], repeat: CheckedExpression?, span: Span, type_id: TypeId)
+    JaktArray(vals: [CheckedExpression], repeat: CheckedExpression?, span: Span, type_id: TypeId, inner_type_id: TypeId)
     JaktDictionary(vals: [(CheckedExpression, CheckedExpression)], span: Span, type_id: TypeId)
     JaktSet(vals: [CheckedExpression], span: Span, type_id: TypeId)
     IndexedExpression(expr: CheckedExpression, index: CheckedExpression, span: Span, type_id: TypeId)
@@ -3982,7 +3982,7 @@ struct Typechecker {
                 vals.push(checked_expr)
             }
             let type_id = .find_or_add_type_id(Type::GenericInstance(id: array_struct_id, args: [inner_type_id]))
-            yield CheckedExpression::JaktArray(vals, repeat, span, type_id)
+            yield CheckedExpression::JaktArray(vals, repeat, span, type_id, inner_type_id)
         }
         JaktTuple(values, span) => {
             let VOID_TYPE_ID = builtin(BuiltinType::Void)


### PR DESCRIPTION
Adds array support to the selfhost codegen based off the Rust-based compiler.

Also, fixed bug in type equality.

Now:
```
==============================
178 passed
153 failed
7 skipped
==============================
```