### PR TITLE
selfhost/typecheck: Add method return types, and generic methods calls

### DIFF
--- a/selfhost/typechecker.jakt
+++ b/selfhost/typechecker.jakt
@@ -3791,6 +3791,8 @@ struct Typechecker {
                 Struct(id) => StructOrEnumId::Struct(id)
                 Enum(id) => StructOrEnumId::Enum(id)
                 JaktString => StructOrEnumId::Struct(.find_struct_in_prelude("String"))
+                GenericInstance(id) => StructOrEnumId::Struct(id)
+                GenericEnumInstance(id) => StructOrEnumId::Enum(id)
                 else => {
                     panic(format("Method call on unsupported base {}", .get_type(expression_type(checked_expr))))
                     yield StructOrEnumId::Struct(StructId(module: ModuleId(id: 0), id: 0))
@@ -3800,7 +3802,10 @@ struct Typechecker {
             let checked_call_expr = .typecheck_call(call, caller_scope_id: scope_id, span, this_expr: checked_expr, parent_id, safety_mode, must_be_enum_constructor: false)
             let type_id = expression_type(checked_call_expr)
             yield match checked_call_expr {
-                Call(call) => CheckedExpression::MethodCall(expr: checked_expr, call, span, type_id)
+                Call(call) => {
+                    let result_type = call.return_type
+                    yield CheckedExpression::MethodCall(expr: checked_expr, call, span, type_id: result_type)
+                }
                 else => {
                     panic("typecheck_call should return `CheckedExpression::Call()`")
                     yield CheckedExpression::Garbage(span)


### PR DESCRIPTION
This carries the return type from the checked call to the method expression, helping to fix a few tests.

Now:
```
==============================
183 passed
148 failed
7 skipped
==============================
```