### PR TITLE
selfhost/codegen: Add support for tuples

### DIFF
--- a/selfhost/codegen.jakt
+++ b/selfhost/codegen.jakt
@@ -1121,6 +1121,23 @@ struct CodeGenerator {
 
             yield output
         }
+        JaktTuple(vals, span, type_id) => {
+            mut output = ""
+            output += "(Tuple{"
+            mut first = true
+            for val in vals.iterator() {
+                if not first {
+                    output += ", "
+                } else {
+                    first = false
+                }
+
+                output += .codegen_expression(val)
+            }
+            output += "})"
+
+            yield output
+        }
         else => {
             todo(format("codegen_expression else: {}", expression))
             yield ""


### PR DESCRIPTION
This adds tuple codgen support, allowing us to pass a few more tests:

Now:
```
==============================
187 passed
144 failed
7 skipped
==============================
```