### PR TITLE
typechecker+tests+selfhost/parser+typechecker: Parse and typecheck sets

### DIFF
--- a/selfhost/parser.jakt
+++ b/selfhost/parser.jakt
@@ -302,6 +302,7 @@ boxed enum ParsedExpression {
     OptionalNone(Span)
     JaktArray(values: [ParsedExpression], fill_size: ParsedExpression?, span: Span)
     JaktDictionary(values: [(ParsedExpression, ParsedExpression)], span: Span)
+    Set(values: [ParsedExpression], span: Span)
     JaktTuple(values: [ParsedExpression], span: Span)
     Range(from: ParsedExpression, to: ParsedExpression, span: Span)
     ForcedUnwrap(expr: ParsedExpression, span: Span)
@@ -325,6 +326,7 @@ boxed enum ParsedExpression {
         OptionalNone(span) => span
         JaktArray(values, fill_size, span) => span
         JaktDictionary(values, span) => span
+        Set(span) => span
         JaktTuple(values, span) => span
         Range(from, to, span) => span
         ForcedUnwrap(expr, span) => span
@@ -1986,12 +1988,53 @@ struct Parser {
         Match => {
             yield .parse_match_expression()
         }
+        LCurly => {
+            yield .parse_set_literal()
+        }
         else => {
             let span = .current().span()
             .index++
             .error("Unsupported expression", span)
             yield ParsedExpression::Garbage(span)
         }
+    }
+
+    function parse_set_literal(mut this) throws -> ParsedExpression {
+        let start = .current().span()
+
+        if not .current() is LCurly {
+            .error("Expected ‘{’", .current().span())
+            return ParsedExpression::Garbage(.current().span())
+        }
+        .index++
+
+        mut output: [ParsedExpression] = []
+        while not .eof() {
+            match .current() {
+                RCurly => {
+                    .index++
+                    break
+                }
+                Comma | Eol => {
+                    .index++
+                }
+                else => {
+                    let expr = .parse_expression(allow_assignments: false)
+                    if expr is Garbage {
+                        break
+                    }
+
+                    output.push(expr)
+                }
+            }
+        }
+
+        let end = .index - 1
+        if end >= .tokens.size() or not .tokens[end] is RCurly {
+            .error("Expected ‘}’ to close the set", .tokens[end].span())
+        }
+
+        return ParsedExpression::Set(values: output, span: merge_spans(start, .tokens[end].span()))
     }
     
 

--- a/selfhost/typechecker.jakt
+++ b/selfhost/typechecker.jakt
@@ -4132,11 +4132,62 @@ struct Typechecker {
         }
         Match(expr, cases, span) => .typecheck_match(expr, cases, span, scope_id, safety_mode)
         JaktDictionary(values, span) => .typecheck_dictionary(values, span, scope_id, safety_mode)
+        Set(values, span) => .typecheck_set(values, span, scope_id, safety_mode)
         else => {
             panic(format("typechecker needs support for {}", expr))
 
             yield CheckedExpression::Boolean(val: false, span: Span(start: 0, end: 0))
         }
+    }
+
+    function typecheck_set(mut this, values: [ParsedExpression], span: Span, scope_id: ScopeId, safety_mode: SafetyMode) throws -> CheckedExpression {
+        mut inner_type_id = unknown_type_id()
+        mut inner_type_span: Span? = None
+        mut output: [CheckedExpression] = []
+
+        let set_struct_id = .find_struct_in_prelude("Set")
+
+        // TODO: type hints
+
+        for value in values.iterator() {
+            let checked_value = .typecheck_expression(expr: value, scope_id, safety_mode)
+            let current_value_type_id = expression_type(checked_value)
+            if inner_type_id.equals(unknown_type_id()) {
+                if current_value_type_id.equals(void_type_id()) or current_value_type_id.equals(unknown_type_id()) {
+                    .error(
+                        "Cannot create a set with values of type void"
+                        value.span()
+                    )
+                }
+
+                inner_type_id = current_value_type_id
+                inner_type_span = value.span()
+            } else if not inner_type_id.equals(current_value_type_id) {
+                let set_type_name = .type_name(inner_type_id)
+                .error_with_hint(
+                    format(
+                        "Type '{}' does not match type '{}' of previous values in set"
+                        .type_name(current_value_type_id)
+                        set_type_name
+                    )
+                    value.span()
+                    format("Set was inferred to store type '{}' here", set_type_name)
+                    inner_type_span!
+                )
+            }
+            output.push(checked_value)
+        }
+
+        if inner_type_id.equals(unknown_type_id()) {
+            .error("Cannot infer generic type for Set<T>", span)
+        }
+
+        let type_id = .find_or_add_type_id(Type::GenericInstance(
+            id: set_struct_id
+            args: [inner_type_id]
+        ))
+
+        return CheckedExpression::JaktSet(vals: output, span, type_id)
     }
 
     function typecheck_match(mut this, expr: ParsedExpression, cases: [ParsedMatchCase], span: Span, scope_id: ScopeId, safety_mode: SafetyMode) throws -> CheckedExpression {

--- a/src/typechecker.rs
+++ b/src/typechecker.rs
@@ -4860,7 +4860,7 @@ pub fn typecheck_expression(
                 if inner_type_id == UNKNOWN_TYPE_ID {
                     if current_value_type_id == VOID_TYPE_ID {
                         error = error.or(Some(JaktError::TypecheckError(
-                            "cannot create a set with values of type void".to_string(),
+                            "Cannot create a set with values of type void".to_string(),
                             value.span(),
                         )))
                     }
@@ -4871,12 +4871,12 @@ pub fn typecheck_expression(
                     let set_type_name = project.typename_for_type_id(inner_type_id);
                     error = error.or(Some(JaktError::TypecheckErrorWithHint(
                         format!(
-                            "type '{}' does not match type '{}' of previous values in set",
+                            "Type '{}' does not match type '{}' of previous values in set",
                             project.typename_for_type_id(current_value_type_id),
                             set_type_name
                         ),
                         value.span(),
-                        format!("set was inferred to store type '{}' here", set_type_name),
+                        format!("Set was inferred to store type '{}' here", set_type_name),
                         inner_type_span.unwrap(),
                     )))
                 }

--- a/tests/typechecker/set_mismatching_value_types.jakt
+++ b/tests/typechecker/set_mismatching_value_types.jakt
@@ -1,5 +1,5 @@
 /// Expect:
-/// - error: "type 'String' does not match type 'i64' of previous values in set\n"
+/// - error: "Type 'String' does not match type 'i64' of previous values in set\n"
 
 function main() {
     let x = {1, "2", 3}

--- a/tests/typechecker/set_with_void_values.jakt
+++ b/tests/typechecker/set_with_void_values.jakt
@@ -1,5 +1,5 @@
 /// Expect:
-/// - error: "cannot create a set with values of type void\n"
+/// - error: "Cannot create a set with values of type void\n"
 
 enum Bar {
     Value


### PR DESCRIPTION
As the name suggests we now parse and typecheck sets. With this there are three additional tests passing:
```
samples/sets/empty_literal_without_hint.jakt
tests/typechecker/set_mismatching_value_types.jakt
tests/typechecker/set_with_void_values.jakt
```
Generating code for sets does not make much sense right now, since all other tests rely on method calls which don't work yet. So the compiler never gets past the typechecking phase.