### PR TITLE
selfhost/codegen: Hacky AK Formatter fix

### DIFF
--- a/selfhost/codegen.jakt
+++ b/selfhost/codegen.jakt
@@ -206,9 +206,15 @@ struct CodeGenerator {
                 output += "namespace "
                 output += module.name
                 output += " {\n"
+                generator.namespace_stack.push(module.name)
             }
 
             output += generator.codegen_namespace(scope, current_module: module)
+
+            if not module.is_root {
+                // FIXME: It's awkward that we need a temporary to avoid the C++ nodiscard warning
+                let dummy = generator.namespace_stack.pop()
+            }
 
             if not module.is_root {
                 output += "}\n"
@@ -904,10 +910,12 @@ struct CodeGenerator {
         let template_args = join(prepend_to_each(generic_parameter_names, prefix: "typename "), separator: ", ")
         let generic_type_args = join(generic_parameter_names, separator: ", ")
 
-        mut qualified_name = name
+        mut qualified_name = ""
         for namespace_ in .namespace_stack.iterator() {
             qualified_name += format("{}::", namespace_)
         }
+
+        qualified_name += name
 
         if not generic_parameter_names.is_empty() {
             qualified_name += format("<{}>\n", generic_type_args)


### PR DESCRIPTION
```diff
++ [ PASS ] samples/imports/import_alias.jakt
++ [ PASS ] samples/imports/import_alias_list.jakt
++ [ PASS ] samples/imports/valid_import.jakt
++ [ PASS ] samples/namespaces/namespace_struct.jakt
```

Before (7a5a0e03b129260c506028b7bc37fa01cb62db89):
```
==============================
203 passed
129 failed
8 skipped
==============================
```

After:
```
==============================
207 passed
125 failed
8 skipped
==============================
```

