### PR TITLE
jakttest/run-all: Use different format flags on macOS

### DIFF
--- a/jakttest/run-all.sh
+++ b/jakttest/run-all.sh
@@ -5,10 +5,15 @@ if [ ! -x ./build/jakttest ]; then
     cargo run jakttest/jakttest.jakt
 fi
 
+stat_format_flags="-c %Y"
+if [[ $OSTYPE == 'darwin'* ]]; then
+  stat_format_flags="-f %m"
+fi
+
 # check for jakttest/ mtime and build/jakttest mtime
 {
-    jakttest_binary_mtime=$(stat -c %Y build/jakttest)
-    latest_jakttest_source_mtime=$(stat -c %Y jakttest/*.jakt | sort | tail -n1)
+    jakttest_binary_mtime=$(stat "$stat_format_flags" build/jakttest)
+    latest_jakttest_source_mtime=$(stat "$stat_format_flags" jakttest/*.jakt | sort | tail -n1)
     if [ "$jakttest_binary_mtime" -lt "$latest_jakttest_source_mtime" ]; then
         echo "re-compiling jakttest to match source"
         cargo run jakttest/jakttest.jakt
@@ -18,8 +23,8 @@ fi
 
 # check for selfhost/ mtime and build/main mtime
 {
-    binary_mtime=$(stat -c %Y build/main)
-    latest_selfhost_mtime=$(stat -c %Y selfhost/*.jakt | sort | tail -n1)
+    binary_mtime=$(stat "$stat_format_flags" build/main)
+    latest_selfhost_mtime=$(stat "$stat_format_flags" selfhost/*.jakt | sort | tail -n1)
     if [ "$binary_mtime" -lt "$latest_selfhost_mtime" ]; then
         echo "re-compiling selfhost to match source"
         cargo run selfhost/main.jakt


### PR DESCRIPTION
The macOS version of `stat` uses different flags for formatting the
output. Check the OS type and set the flags accordingly.