### PR TITLE
selfhost/typecheck+codegen: Add basic dictionary codegen

### DIFF
--- a/selfhost/codegen.jakt
+++ b/selfhost/codegen.jakt
@@ -1314,6 +1314,34 @@ struct CodeGenerator {
 
             yield output
         }
+        JaktDictionary(vals, span, type_id, key_type_id, value_type_id) => {
+            mut output = format("(TRY(Dictionary<{}, {}>::create_with_entries({{",
+                .codegen_type(key_type_id),
+                .codegen_type(value_type_id))
+
+            mut first = true
+            for val in vals.iterator() {
+                let key = val.0
+                let value = val.1
+
+                if not first {
+                    output += ", "
+                } else {
+                    first = false
+                }
+
+                output += "{"
+                output += .codegen_expression(key)
+                output += ", "
+                output += .codegen_expression(value)
+                output += "}"
+            }
+
+            output += "})))"
+
+            yield output
+        }
+
         JaktSet(vals, span, type_id, inner_type_id) => {
             mut output = ""
             output += format("(TRY(Set<{}>::create_with_values({{", .codegen_type(inner_type_id))

--- a/selfhost/typechecker.jakt
+++ b/selfhost/typechecker.jakt
@@ -728,8 +728,8 @@ boxed enum CheckedExpression {
     JaktTuple(vals: [CheckedExpression], span: Span, type_id: TypeId)
     Range(from: CheckedExpression, to: CheckedExpression, span: Span, type_id: TypeId)
     JaktArray(vals: [CheckedExpression], repeat: CheckedExpression?, span: Span, type_id: TypeId, inner_type_id: TypeId)
-    JaktDictionary(vals: [(CheckedExpression, CheckedExpression)], span: Span, type_id: TypeId)
     JaktSet(vals: [CheckedExpression], span: Span, type_id: TypeId, inner_type_id: TypeId)
+    JaktDictionary(vals: [(CheckedExpression, CheckedExpression)], span: Span, type_id: TypeId, key_type_id: TypeId, value_type_id: TypeId)
     IndexedExpression(expr: CheckedExpression, index: CheckedExpression, span: Span, type_id: TypeId)
     IndexedDictionary(expr: CheckedExpression, index: CheckedExpression, span: Span, type_id: TypeId)
     IndexedTuple(expr: CheckedExpression, index: usize, span: Span, type_id: TypeId)
@@ -4943,6 +4943,8 @@ struct Typechecker {
             vals: checked_kv_pairs
             span
             type_id
+            key_type_id
+            value_type_id
         )
     }
 


### PR DESCRIPTION
Adds some basic support for codegen'ing dictionaries.

Before:
```
==============================
232 passed
100 failed
7 skipped
==============================
```

Now:
```
==============================
238 passed
94 failed
7 skipped
==============================
```