### PR TITLE
selfhost: Work on generic functions

### DIFF
--- a/selfhost/codegen.jakt
+++ b/selfhost/codegen.jakt
@@ -598,17 +598,8 @@ struct CodeGenerator {
         return output
     }
 
-    function codegen_function_predecl(mut this, function_: CheckedFunction) throws -> String {
+    function codegen_function_generic_parameters(mut this, function_: CheckedFunction) throws -> String {
         mut output = ""
-
-        // FIXME: for now, just exit early if we're a constructor
-        if function_.type is ImplicitConstructor {
-            return ""
-        }
-
-        if function_.linkage is External {
-            output += "extern "
-        }
 
         if not function_.generic_params.is_empty() {
             output += "template <"
@@ -626,8 +617,25 @@ struct CodeGenerator {
                 }
                 output += .codegen_type(type_id)
             }
-            output += ">"
+            output += ">\n"
         }
+
+        return output
+    }
+
+    function codegen_function_predecl(mut this, function_: CheckedFunction) throws -> String {
+        mut output = ""
+
+        // FIXME: for now, just exit early if we're a constructor
+        if function_.type is ImplicitConstructor {
+            return ""
+        }
+
+        if function_.linkage is External {
+            output += "extern "
+        }
+
+        output += .codegen_function_generic_parameters(function_)
 
         if function_.name == "main" {
             output += "ErrorOr<int>"
@@ -2531,7 +2539,17 @@ struct CodeGenerator {
     }
 
     function codegen_function_in_namespace(mut this, function_: CheckedFunction, containing_struct: TypeId?) throws -> String {
+        // Extern generics need to be in the header anyways, so we can't codegen for them.
+        if not function_.generic_params.is_empty() {
+            match function_.linkage {
+                External => { return "" }
+                else => {}
+            }
+        }
+
         mut output = ""
+
+        output += .codegen_function_generic_parameters(function_)
 
         let is_main = function_.name == "main" and not containing_struct.has_value()
 
@@ -2595,6 +2613,8 @@ struct CodeGenerator {
         }
 
         output += " {\n"
+
+        // FIXME: Panic if function type is unknown, and this isn't `main()`
 
         let last_control_flow = .control_flow_state
         .control_flow_state = last_control_flow.enter_function()

--- a/selfhost/parser.jakt
+++ b/selfhost/parser.jakt
@@ -6,7 +6,7 @@
 
 import error { JaktError, print_error}
 import lexer { Token, NumericConstant }
-import utility { panic, todo, Span }
+import utility { panic, todo, FileId, Span }
 import compiler { Compiler }
 import prelude { JaktPrelude }
 
@@ -439,6 +439,20 @@ boxed enum ParsedType {
     RawPtr(inner: ParsedType, span: Span)
     WeakPtr(inner: ParsedType, span: Span)
     Empty
+
+    function span(this) => match this {
+        Name(name, span) => span
+        NamespacedName(name, namespaces, params, span) => span
+        GenericType(name, generic_parameters, span) => span
+        JaktArray(inner, span) => span
+        Dictionary(key, value, span) => span
+        JaktTuple(types, span) => span
+        Set(inner, span) => span
+        Optional(inner, span) => span
+        RawPtr(inner, span) => span
+        WeakPtr(inner, span) => span
+        Empty => Span(file_id: FileId(id: 0uz), start: 0, end: 0) // FIXME: For some reason we can't see `empty_span()` here.
+    }
 }
 
 struct Parser {

--- a/selfhost/typechecker.jakt
+++ b/selfhost/typechecker.jakt
@@ -334,6 +334,8 @@ class Scope {
     public parent: ScopeId?
     public children: [ScopeId]
     public can_throw: bool
+
+    public debug_name: String
 }
 
 class Module {
@@ -1010,7 +1012,7 @@ struct Typechecker {
         )
 
         let PRELUDE_SCOPE_ID: ScopeId = typechecker.prelude_scope_id()
-        let root_scope_id = typechecker.create_scope(parent_scope_id: PRELUDE_SCOPE_ID, can_throw: false)
+        let root_scope_id = typechecker.create_scope(parent_scope_id: PRELUDE_SCOPE_ID, can_throw: false, debug_name: "root")
         typechecker.typecheck_module(parsed_namespace, scope_id: root_scope_id)
 
         return typechecker.program
@@ -1061,7 +1063,7 @@ struct Typechecker {
     function is_floating(this, anon type_id: TypeId) => .program.is_floating(type_id)
     function is_numeric(this, anon type_id: TypeId) => .program.is_numeric(type_id)
 
-    function create_scope(mut this, parent_scope_id: ScopeId?, can_throw: bool) throws -> ScopeId {
+    function create_scope(mut this, parent_scope_id: ScopeId?, can_throw: bool, debug_name: String) throws -> ScopeId {
         // Check that parent_scope_id is a valid ScopeId
         if parent_scope_id.has_value() {
             // Check that the ModuleId is valid
@@ -1090,6 +1092,7 @@ struct Typechecker {
             parent: parent_scope_id
             children: []
             can_throw
+            debug_name
         )
 
         .program.modules[.current_module_id.id].scopes.push(scope)
@@ -1164,6 +1167,7 @@ struct Typechecker {
         let prelude_scope_id = .create_scope(
             parent_scope_id: none_scope_id
             can_throw: false
+            debug_name: "prelude"
         )
 
         let tokens = Lexer::lex(compiler: .compiler)
@@ -1660,7 +1664,7 @@ struct Typechecker {
                 namespace_scope_id = namespace_scope_tuple!.0
             } else {
                 // Typecheck struct fields in the unnamed namespace
-                namespace_scope_id = .create_scope(parent_scope_id: scope_id, can_throw: false)
+                namespace_scope_id = .create_scope(parent_scope_id: scope_id, can_throw: false, debug_name: format("namespace({})", namespace_name))
                 mut scope = .get_scope(scope_id)
                 scope.children.push(namespace_scope_id)
             }
@@ -1754,7 +1758,7 @@ struct Typechecker {
 
                 .current_module_id = imported_module_id!
                 
-                let imported_scope_id = .create_scope(parent_scope_id: .root_scope_id(), can_throw: false)
+                let imported_scope_id = .create_scope(parent_scope_id: .root_scope_id(), can_throw: false, debug_name: format("module({})", import_.module_name.name))
                 .typecheck_module(parsed_namespace: parsed_namespace!, scope_id: imported_scope_id)
 
                 .current_module_id = original_current_module_id
@@ -1865,7 +1869,7 @@ struct Typechecker {
         for namespce in parsed_namespace.namespaces.iterator() {
             // Find all predeclarations in namespaces that are children of this namespace
             if namespce.name.has_value() {
-                let namespace_scope_id = .create_scope(parent_scope_id: scope_id, can_throw: false)
+                let namespace_scope_id = .create_scope(parent_scope_id: scope_id, can_throw: false, debug_name: format("namespace({})", namespce.name!))
 
                 mut child_scope = .get_scope(namespace_scope_id)
                 child_scope.namespace_name = namespce.name!
@@ -1933,7 +1937,7 @@ struct Typechecker {
     function typecheck_enum_predecl(mut this, parsed_record: ParsedRecord, enum_id: EnumId, scope_id: ScopeId) throws {
         let enum_type_id = .find_or_add_type_id(type: Type::Enum(enum_id))
 
-        let enum_scope_id = .create_scope(parent_scope_id: scope_id, can_throw: false)
+        let enum_scope_id = .create_scope(parent_scope_id: scope_id, can_throw: false, debug_name: format("enum({})", parsed_record.name))
 
         .add_enum_to_scope(scope_id, name: parsed_record.name, enum_id, span: parsed_record.name_span)
 
@@ -1982,7 +1986,7 @@ struct Typechecker {
         let struct_type_id = .find_or_add_type_id(type: Type::Struct(struct_id))
         .current_struct_type_id = struct_type_id
 
-        let struct_scope_id = .create_scope(parent_scope_id: scope_id, can_throw: false)
+        let struct_scope_id = .create_scope(parent_scope_id: scope_id, can_throw: false, debug_name: format("struct({})", parsed_record.name))
 
         .add_struct_to_scope(scope_id, name: parsed_record.name, struct_id, span: parsed_record.name_span)
 
@@ -2022,8 +2026,8 @@ struct Typechecker {
         for method in parsed_record.methods.iterator() {
             let func = method.parsed_function
 
-            let method_scope_id = .create_scope(parent_scope_id: struct_scope_id, can_throw: func.can_throw)
-            let block_scope_id = .create_scope(parent_scope_id: method_scope_id, can_throw: func.can_throw)
+            let method_scope_id = .create_scope(parent_scope_id: struct_scope_id, can_throw: func.can_throw, debug_name: format("method({}::{})", parsed_record.name, func.name))
+            let block_scope_id = .create_scope(parent_scope_id: method_scope_id, can_throw: func.can_throw, debug_name: format("method-block({}::{})", parsed_record.name, func.name))
 
             let is_generic = not parsed_record.generic_parameters.is_empty() or not func.generic_parameters.is_empty()
 
@@ -2058,7 +2062,7 @@ struct Typechecker {
 
             mut check_scope: ScopeId? = None
             if is_generic {
-                check_scope = .create_scope(parent_scope_id: method_scope_id, can_throw: func.can_throw)
+                check_scope = .create_scope(parent_scope_id: method_scope_id, can_throw: func.can_throw, debug_name: format("method-checking({}::{})", parsed_record.name, func.name))
             }
 
             for gen_parameter in func.generic_parameters.iterator() {
@@ -2199,7 +2203,7 @@ struct Typechecker {
                 namespace_scope_id = namespace_scope_tuple!.0
             } else {
                 // Create the unnamed namespace (aka a block scope)
-                namespace_scope_id = .create_scope(parent_scope_id: scope_id, can_throw: false)
+                namespace_scope_id = .create_scope(parent_scope_id: scope_id, can_throw: false, debug_name: "unnamed-namespace")
                 mut scope = .get_scope(scope_id)
                 scope.children.push(namespace_scope_id)
 
@@ -2334,8 +2338,8 @@ struct Typechecker {
                         let maybe_enum_variant_constructor = .find_function_in_scope(parent_scope_id: enum_.scope_id, function_name: variant.name)
                         if not maybe_enum_variant_constructor.has_value() {
                             let can_function_throw = is_boxed
-                            let function_scope_id = .create_scope(parent_scope_id, can_throw: can_function_throw)
-                            let block_scope_id = .create_scope(parent_scope_id: function_scope_id, can_throw: can_function_throw)
+                            let function_scope_id = .create_scope(parent_scope_id, can_throw: can_function_throw, debug_name: format("enum-variant-constructor({}::{})", enum_.name, variant.name))
+                            let block_scope_id = .create_scope(parent_scope_id: function_scope_id, can_throw: can_function_throw, debug_name: format("enum-variant-constructor-block({}::{})", enum_.name, variant.name))
                             let none_parsed_function: ParsedFunction? = None
                             let checked_function = CheckedFunction(
                                 name: variant.name,
@@ -2363,8 +2367,8 @@ struct Typechecker {
                         let maybe_enum_variant_constructor = .find_function_in_scope(parent_scope_id: enum_.scope_id, function_name: variant.name)
                         if not maybe_enum_variant_constructor.has_value() {
                             let can_function_throw = is_boxed
-                            let function_scope_id = .create_scope(parent_scope_id, can_throw: can_function_throw)
-                            let block_scope_id = .create_scope(parent_scope_id: function_scope_id, can_throw: can_function_throw)
+                            let function_scope_id = .create_scope(parent_scope_id, can_throw: can_function_throw, debug_name: format("enum-variant-constructor({}::{})", enum_.name, variant.name))
+                            let block_scope_id = .create_scope(parent_scope_id: function_scope_id, can_throw: can_function_throw, debug_name: format("enum-variant-constructor-block({}::{})", enum_.name, variant.name))
                             let variable = CheckedVariable(
                                 name: "value"
                                 type_id
@@ -2396,8 +2400,8 @@ struct Typechecker {
                         let maybe_enum_variant_constructor = .find_function_in_scope(parent_scope_id: enum_.scope_id, function_name: variant.name)
                         if not maybe_enum_variant_constructor.has_value() {
                             let can_function_throw = is_boxed
-                            let function_scope_id = .create_scope(parent_scope_id, can_throw: can_function_throw)
-                            let block_scope_id = .create_scope(parent_scope_id: function_scope_id, can_throw: can_function_throw)
+                            let function_scope_id = .create_scope(parent_scope_id, can_throw: can_function_throw, debug_name: format("enum-variant-constructor({}::{})", enum_.name, variant.name))
+                            let block_scope_id = .create_scope(parent_scope_id: function_scope_id, can_throw: can_function_throw, debug_name: format("enum-variant-constructor-block({}::{})", enum_.name, variant.name))
                             let none_parsed_function: ParsedFunction? = None
                             let checked_function = CheckedFunction(
                                 name: variant.name,
@@ -2449,8 +2453,8 @@ struct Typechecker {
             // No constructor found, so let's make one
 
             let constructor_can_throw = record.record_type is Class
-            let function_scope_id = .create_scope(parent_scope_id, can_throw: constructor_can_throw)
-            let block_scope_id = .create_scope(parent_scope_id: function_scope_id, can_throw: constructor_can_throw)
+            let function_scope_id = .create_scope(parent_scope_id, can_throw: constructor_can_throw, debug_name: format("generated-constructor({})", record.name))
+            let block_scope_id = .create_scope(parent_scope_id: function_scope_id, can_throw: constructor_can_throw, debug_name: format("generated-constructor-block({})", record.name))
 
             let none_parsed_function: ParsedFunction? = None
             let checked_constructor = CheckedFunction(
@@ -2581,8 +2585,8 @@ struct Typechecker {
     }
 
     function typecheck_function_predecl(mut this, parsed_function: ParsedFunction, parent_scope_id: ScopeId) throws {
-        let function_scope_id = .create_scope(parent_scope_id, can_throw: parsed_function.can_throw)
-        let block_scope_id = .create_scope(parent_scope_id: function_scope_id, can_throw: parsed_function.can_throw)
+        let function_scope_id = .create_scope(parent_scope_id, can_throw: parsed_function.can_throw, debug_name: format("function({})", parsed_function.name))
+        let block_scope_id = .create_scope(parent_scope_id: function_scope_id, can_throw: parsed_function.can_throw, debug_name: format("function-block({})", parsed_function.name))
         let module_id = .current_module_id.id
 
         // TODO: Make this true if it's a method of a generic class/struct.
@@ -3167,7 +3171,7 @@ struct Typechecker {
 
     function typecheck_block(mut this, anon parsed_block: ParsedBlock, parent_scope_id: ScopeId, safety_mode: SafetyMode) throws -> CheckedBlock {
         let parent_throws = .get_scope(parent_scope_id).can_throw
-        let block_scope_id = .create_scope(parent_scope_id, can_throw: parent_throws)
+        let block_scope_id = .create_scope(parent_scope_id, can_throw: parent_throws, debug_name: "block")
         mut checked_block = CheckedBlock(
             statements: []
             scope_id: block_scope_id
@@ -3905,7 +3909,7 @@ struct Typechecker {
     }
 
     function typecheck_try(mut this, stmt: ParsedStatement, error_name: String, error_span: Span, catch_block: ParsedBlock, scope_id: ScopeId, safety_mode: SafetyMode, span: Span) throws -> CheckedStatement {
-        let try_scope_id = .create_scope(parent_scope_id: scope_id, can_throw: true)
+        let try_scope_id = .create_scope(parent_scope_id: scope_id, can_throw: true, debug_name: "try")
         let checked_stmt = .typecheck_statement(stmt, scope_id, safety_mode)
         let error_struct_id = .find_struct_in_prelude("Error")
         let error_decl = CheckedVariable(
@@ -3918,7 +3922,7 @@ struct Typechecker {
         mut module = .current_module()
         let error_id = module.add_variable(name: error_decl)
 
-        let catch_scope_id = .create_scope(parent_scope_id: scope_id, can_throw: false)
+        let catch_scope_id = .create_scope(parent_scope_id: scope_id, can_throw: false, debug_name: "catch")
         .add_var_to_scope(scope_id: catch_scope_id, name: error_name, var_id: error_id, span: error_span)
         let checked_catch_block = .typecheck_block(catch_block, parent_scope_id: catch_scope_id, safety_mode)
 
@@ -4641,7 +4645,7 @@ struct Typechecker {
                                     return CheckedExpression::Match(expr: checked_expr, match_cases: [], span, type_id: unknown_type_id(), all_variants_constant: false)
                                 }
 
-                                let new_scope_id = .create_scope(parent_scope_id: scope_id, can_throw: .get_scope(scope_id).can_throw)
+                                let new_scope_id = .create_scope(parent_scope_id: scope_id, can_throw: .get_scope(scope_id).can_throw, debug_name: format("catch-enum-variant({})", variant_names))
                                 mut module = .current_module()
                                 match matched_variant! {
                                     Untyped(name) => {
@@ -4765,7 +4769,7 @@ struct Typechecker {
                                     seen_catch_all = true
                                     catch_all_span = case_.marker_span
                                 }
-                                let new_scope_id = .create_scope(parent_scope_id: scope_id, can_throw: .get_scope(scope_id).can_throw)
+                                let new_scope_id = .create_scope(parent_scope_id: scope_id, can_throw: .get_scope(scope_id).can_throw, debug_name: "catch-all")
                                 let checked_tuple = .typecheck_match_body(body: case_.body, scope_id: new_scope_id, safety_mode, generic_inferences, final_result_type, span: case_.marker_span)
                                 let checked_body = checked_tuple.0
                                 final_result_type = checked_tuple.1
@@ -4814,7 +4818,7 @@ struct Typechecker {
                                 // We don't know what the enum type is, but we have the type var for it, so generate a generic enum match.
                                 // note that this will be fully checked when this match expression is actually instantiated.
 
-                                let new_scope_id = .create_scope(parent_scope_id: scope_id, can_throw: .get_scope(scope_id).can_throw)
+                                let new_scope_id = .create_scope(parent_scope_id: scope_id, can_throw: .get_scope(scope_id).can_throw, debug_name: format("catch-enum-variant({})", variant_names))
                                 let checked_tuple = .typecheck_match_body(body: case_.body, scope_id: new_scope_id, safety_mode, generic_inferences, final_result_type, span: case_.marker_span)
                                 let checked_body = checked_tuple.0
                                 final_result_type = checked_tuple.1
@@ -4839,7 +4843,7 @@ struct Typechecker {
                                 }
                                 seen_catch_all = true
 
-                                let new_scope_id = .create_scope(parent_scope_id: scope_id, can_throw: .get_scope(scope_id).can_throw)
+                                let new_scope_id = .create_scope(parent_scope_id: scope_id, can_throw: .get_scope(scope_id).can_throw, debug_name: "catch-all")
                                 let checked_tuple = .typecheck_match_body(body: case_.body, scope_id: new_scope_id, safety_mode, generic_inferences, final_result_type, span: case_.marker_span)
                                 let checked_body = checked_tuple.0
                                 final_result_type = checked_tuple.1
@@ -4874,7 +4878,7 @@ struct Typechecker {
                                     span: case_.marker_span
                                 )
 
-                                let new_scope_id = .create_scope(parent_scope_id: scope_id, can_throw: .get_scope(scope_id).can_throw)
+                                let new_scope_id = .create_scope(parent_scope_id: scope_id, can_throw: .get_scope(scope_id).can_throw, debug_name: format("catch-expression({})", expr))
                                 let checked_tuple = .typecheck_match_body(body: case_.body, scope_id: new_scope_id, safety_mode, generic_inferences, final_result_type, span: case_.marker_span)
                                 let checked_body = checked_tuple.0
                                 final_result_type = checked_tuple.1

--- a/selfhost/typechecker.jakt
+++ b/selfhost/typechecker.jakt
@@ -357,12 +357,16 @@ class Module {
         return TypeId(module: .id, id: new_id)
     }
 
+    public function next_function_id(this) -> FunctionId {
+        return FunctionId(module: .id, id: .functions.size())
+    }
+
     public function add_function(mut this, checked_function: CheckedFunction) throws -> FunctionId {
-        let new_id = .functions.size()
+        let new_id = .next_function_id()
 
         .functions.push(checked_function)
 
-        return FunctionId(module: .id, id: new_id)
+        return new_id
     }
 
     public function add_variable(mut this, anon checked_variable: CheckedVariable) throws -> VarId {

--- a/selfhost/typechecker.jakt
+++ b/selfhost/typechecker.jakt
@@ -396,6 +396,8 @@ class CheckedFunction {
     public type: FunctionType
     public linkage: FunctionLinkage
     public function_scope_id: ScopeId
+    public is_instantiated: bool
+    public parsed_function: ParsedFunction?
 
     public function is_static(this) -> bool {
         if .params.size() < 1 {
@@ -413,6 +415,13 @@ class CheckedFunction {
         let first_param_variable = .params[0].variable
 
         return first_param_variable.name == "this" and first_param_variable.is_mutable
+    }
+
+    public function to_parsed_function(this) -> ParsedFunction {
+        if not .parsed_function.has_value() {
+            panic("to_parsed_function() called on a synthetic function")
+        }
+        return .parsed_function!
     }
 }
 
@@ -1973,7 +1982,10 @@ struct Typechecker {
 
         .add_struct_to_scope(scope_id, name: parsed_record.name, struct_id, span: parsed_record.name_span)
 
-        let is_extern = parsed_record.definition_linkage
+        let is_extern = match parsed_record.definition_linkage {
+            External => true
+            Internal => false
+        }
 
         mut module = .current_module()
         module.structures[struct_id.id] = CheckedStruct(
@@ -1982,7 +1994,7 @@ struct Typechecker {
             generic_parameters: []
             fields: []
             scope_id: struct_scope_id
-            definition_linkage: is_extern
+            definition_linkage: parsed_record.definition_linkage
             record_type: parsed_record.record_type
             type_id: struct_type_id
         )
@@ -2028,6 +2040,8 @@ struct Typechecker {
                 type: func.type
                 linkage: func.linkage
                 function_scope_id: method_scope_id
+                is_instantiated: not is_generic or is_extern
+                parsed_function: method.parsed_function
             )
 
             module.functions.push(checked_function)
@@ -2318,6 +2332,7 @@ struct Typechecker {
                             let can_function_throw = is_boxed
                             let function_scope_id = .create_scope(parent_scope_id, can_throw: can_function_throw)
                             let block_scope_id = .create_scope(parent_scope_id: function_scope_id, can_throw: can_function_throw)
+                            let none_parsed_function: ParsedFunction? = None
                             let checked_function = CheckedFunction(
                                 name: variant.name,
                                 name_span: variant.span,
@@ -2330,6 +2345,8 @@ struct Typechecker {
                                 type: FunctionType::ImplicitEnumConstructor,
                                 linkage: FunctionLinkage::Internal,
                                 function_scope_id
+                                is_instantiated: true
+                                parsed_function: none_parsed_function
                             )
                             let function_id = module.add_function(checked_function)
                             .add_function_to_scope(parent_scope_id: enum_.scope_id, name: variant.name, function_id, span: variant.span)
@@ -2351,6 +2368,7 @@ struct Typechecker {
                                 definition_span: param.span
                                 visibility: Visibility::Public
                             )
+                            let none_parsed_function: ParsedFunction? = None
                             let checked_function = CheckedFunction(
                                 name: variant.name,
                                 name_span: variant.span,
@@ -2363,6 +2381,8 @@ struct Typechecker {
                                 type: FunctionType::ImplicitEnumConstructor,
                                 linkage: FunctionLinkage::Internal,
                                 function_scope_id
+                                is_instantiated: true
+                                parsed_function: none_parsed_function
                             )
                             let function_id = module.add_function(checked_function)
                             .add_function_to_scope(parent_scope_id: enum_.scope_id, name: variant.name, function_id, span: variant.span)
@@ -2374,6 +2394,7 @@ struct Typechecker {
                             let can_function_throw = is_boxed
                             let function_scope_id = .create_scope(parent_scope_id, can_throw: can_function_throw)
                             let block_scope_id = .create_scope(parent_scope_id: function_scope_id, can_throw: can_function_throw)
+                            let none_parsed_function: ParsedFunction? = None
                             let checked_function = CheckedFunction(
                                 name: variant.name,
                                 name_span: variant.span,
@@ -2386,6 +2407,8 @@ struct Typechecker {
                                 type: FunctionType::ImplicitEnumConstructor,
                                 linkage: FunctionLinkage::Internal,
                                 function_scope_id
+                                is_instantiated: true
+                                parsed_function: none_parsed_function
                             )
                             let function_id = module.add_function(checked_function)
                             .add_function_to_scope(parent_scope_id: enum_.scope_id, name: variant.name, function_id, span: variant.span)
@@ -2425,6 +2448,7 @@ struct Typechecker {
             let function_scope_id = .create_scope(parent_scope_id, can_throw: constructor_can_throw)
             let block_scope_id = .create_scope(parent_scope_id: function_scope_id, can_throw: constructor_can_throw)
 
+            let none_parsed_function: ParsedFunction? = None
             let checked_constructor = CheckedFunction(
                 name: record.name
                 name_span: record.name_span
@@ -2442,6 +2466,8 @@ struct Typechecker {
                 type: FunctionType::ImplicitConstructor
                 linkage: FunctionLinkage::Internal
                 function_scope_id
+                is_instantiated: true
+                parsed_function: none_parsed_function
             )
 
             // Internal constructor
@@ -2575,6 +2601,8 @@ struct Typechecker {
             type: FunctionType::Normal
             linkage: parsed_function.linkage
             function_scope_id
+            is_instantiated: not is_generic
+            parsed_function
         )
         // FIXME: We can't return a `mut Foo` from a function right now, but assigning anything to a `mut` variable makes it mutable.
         //        AKA, working around one bug with another bug. :^)

--- a/selfhost/typechecker.jakt
+++ b/selfhost/typechecker.jakt
@@ -1337,7 +1337,7 @@ struct Typechecker {
                         } else {
                             first = false
                         }
-                        output += .type_name(type_id)
+                        output += .type_name(arg)
                     }
                     output += "}"
                 } else if id.equals(weak_ptr_struct_id) {
@@ -1353,7 +1353,7 @@ struct Typechecker {
                         } else {
                             first = false
                         }
-                        output += .type_name(type_id)
+                        output += .type_name(arg)
                     }
                     output += ">"
                 }

--- a/selfhost/typechecker.jakt
+++ b/selfhost/typechecker.jakt
@@ -2670,6 +2670,43 @@ struct Typechecker {
         .add_function_to_scope(parent_scope_id, name: parsed_function.name, function_id, span: parsed_function.name_span)
     }
 
+    function typecheck_and_specialize_generic_function(mut this, function_id: FunctionId, generic_arguments: [TypeId], parent_scope_id: ScopeId, this_type_id: TypeId?, generic_substitutions: [String: String]) throws {
+        mut checked_function = .get_function(function_id)
+        mut module = .current_module()
+
+        let function_id = module.next_function_id()
+        mut parsed_function = checked_function.to_parsed_function()
+        let scope_id = .create_scope(parent_scope_id, can_throw: parsed_function.can_throw, debug_name: format("function-specialization({})", parsed_function.name))
+
+        if parsed_function.generic_parameters.size() != generic_arguments.size() {
+            .error(
+                format("Generic function {} expects {} generic arguments, but {} were given",
+                    parsed_function.name, parsed_function.generic_parameters.size(), generic_arguments.size()),
+                parsed_function.name_span
+            )
+        }
+
+        let span = parsed_function.name_span
+        for substitution in generic_substitutions.iterator() {
+            match .get_type(TypeId::from_string(substitution.0)) {
+                TypeVariable(type_name) => {
+                    .add_type_to_scope(scope_id, type_name, type_id: TypeId::from_string(substitution.1), span)
+                }
+                else => {}
+            }
+        }
+
+        parsed_function.must_instantiate = true
+
+        .current_function_id = Some(function_id)
+        .typecheck_function_predecl(parsed_function, parent_scope_id: scope_id)
+        .typecheck_function(parsed_function, parent_scope_id: scope_id)
+        .current_function_id = None
+
+        checked_function.is_instantiated = true
+        checked_function.function_scope_id = scope_id
+    }
+
     function typecheck_jakt_main(mut this, parsed_function: ParsedFunction) throws {
         let param_type_error = "Main function must take a single array of strings as its parameter"
         if parsed_function.params.size() > 1 {
@@ -2844,7 +2881,6 @@ struct Typechecker {
 
         let optional_struct_id = .find_struct_in_prelude("Optional")
         let weakptr_struct_id = .find_struct_in_prelude("WeakPtr")
-
 
         match lhs_type {
             TypeVariable() => {
@@ -5134,11 +5170,13 @@ struct Typechecker {
     function typecheck_call(mut this, call: ParsedCall, caller_scope_id: ScopeId, span: Span, this_expr: CheckedExpression?, parent_id: StructOrEnumId?, safety_mode: SafetyMode, type_hint: TypeId?, must_be_enum_constructor: bool) throws -> CheckedExpression {
         mut args: [(String, CheckedExpression)] = []
         mut return_type = builtin(BuiltinType::Void)
+        mut generic_arguments: [TypeId] = []
         mut callee_throws = false
         mut resolved_namespaces: [ResolvedNamespace] = []
         mut resolved_function_id: FunctionId? = None
         mut maybe_this_type_id: TypeId? = None
         mut generic_inferences: [String:String] = [:]
+        mut generic_checked_function_to_instantiate: FunctionId? = None
         for name in call.namespace_.iterator() {
             let generic_parameters: [TypeId]? = None
             resolved_namespaces.push(ResolvedNamespace(name, generic_parameters))
@@ -5181,6 +5219,26 @@ struct Typechecker {
 
                 .check_method_access(accessor: caller_scope_id, accessee: scope_containing_callee, method: callee, span)
 
+                // If the user gave us explicit type arguments, let's use them in our substitutions
+                mut type_arg_index = 0uz
+                for parsed_type in call.type_args.iterator() {
+                    let checked_type = .typecheck_typename(parsed_type, scope_id: caller_scope_id, ignore_errors: false)
+                    if callee.generic_params.size() <= type_arg_index {
+                        .error("Trying to access generic parameter out of bounds", parsed_type.span())
+                        continue
+                    }
+
+                    // Find the associated type variable for this parameter, we'll use it in substitution
+                    let typevar_type_id = match callee.generic_params[type_arg_index] {
+                        InferenceGuide(id)
+                        | Parameter(id) => id
+                    }
+
+                    generic_inferences.set(typevar_type_id.to_string(), checked_type.to_string())
+
+                    type_arg_index += 1
+                }
+
                 // If this is a method, let's also add the types we know from our `this` pointer.
                 if this_expr.has_value() {
                     let type_id = expression_type(this_expr!)
@@ -5213,6 +5271,10 @@ struct Typechecker {
                 let arg_offset = match this_expr.has_value() {
                     true => 1uz
                     else => 0uz
+                }
+
+                if not callee.is_instantiated {
+                    generic_checked_function_to_instantiate = Some(function_id)
                 }
 
                 if callee.params.size() != (call.args.size() + arg_offset) {
@@ -5253,9 +5315,31 @@ struct Typechecker {
                     checked_arg = promoted_arg ?? checked_arg
 
                     // FIXME: It's super awkward that we have to pass "generic_inferences" here:
-                    .check_types_for_compat(lhs_type_id: param.variable.type_id, rhs_type_id: expression_type(checked_arg), generic_inferences: ["":""], span)
+                    .check_types_for_compat(lhs_type_id: param.variable.type_id, rhs_type_id: expression_type(checked_arg), generic_inferences, span)
 
                     args.push((call.name, checked_arg))
+                }
+
+                // We've now seen all the arguments and should be able to substitute the return type, if it's contains a
+                // type variable. For the moment, we'll just checked to see if it's a type variable.
+                // FIXME: `unknown_type_id()` and `None` are really the same thing. Can we remove `unknown_type_id()`?
+                if type_hint.has_value() and not type_hint.value().equals(unknown_type_id()) {
+                    .check_types_for_compat(lhs_type_id: return_type, rhs_type_id: type_hint!, generic_inferences, span)
+                }
+                return_type = .substitute_typevars_in_type(type_id: return_type, generic_inferences)
+                
+                for generic_typevar in callee.generic_params.iterator() {
+                    match generic_typevar {
+                        Parameter(id) => {
+                            let substitution = generic_inferences.get(id.to_string())
+                            if substitution.has_value() {
+                                generic_arguments.push(TypeId::from_string(substitution!))
+                            } else {
+                                .error("Not all generic parameters have known types", span)
+                            }
+                        }
+                        else => {}
+                    }
                 }
             }
         }
@@ -5267,6 +5351,22 @@ struct Typechecker {
 
         if callee_throws and not .get_scope(caller_scope_id).can_throw {
             .error("Call to function that may throw needs to be in a try statement or a function marked as throws", span)
+        }
+
+        if generic_checked_function_to_instantiate.has_value() {
+            // Clear the generic parameters and typecheck in the fully specialized scope.
+
+            if maybe_this_type_id.has_value() {
+                maybe_this_type_id = .substitute_typevars_in_type(type_id: maybe_this_type_id!, generic_inferences)
+            }
+
+            .typecheck_and_specialize_generic_function(
+                function_id: generic_checked_function_to_instantiate!
+                generic_arguments,
+                parent_scope_id: callee_scope_id,
+                this_type_id: maybe_this_type_id,
+                generic_substitutions: generic_inferences
+            )
         }
 
         return CheckedExpression::Call(call: CheckedCall(namespace_: resolved_namespaces, name: call.name, args, function_id: resolved_function_id, return_type, callee_throws), span, type_id: return_type)

--- a/selfhost/typechecker.jakt
+++ b/selfhost/typechecker.jakt
@@ -2430,7 +2430,8 @@ struct Typechecker {
 
     function cast_to_underlying(mut this, anon expr: ParsedExpression, scope_id: ScopeId, parsed_type: ParsedType) throws -> CheckedExpression {
         let cast_expression = ParsedExpression::UnaryOp(expr, op: UnaryOperator::TypeCast(TypeCast::Infallible(parsed_type)), span: expr.span())
-        return .typecheck_expression(cast_expression, scope_id, safety_mode: SafetyMode::Safe)
+        let type_hint: TypeId? = None
+        return .typecheck_expression(cast_expression, scope_id, safety_mode: SafetyMode::Safe, type_hint)
     }
 
     function typecheck_struct(mut this, record: ParsedRecord, struct_id: StructId, parent_scope_id: ScopeId) throws {
@@ -3606,9 +3607,15 @@ struct Typechecker {
     }
 
     function typecheck_statement(mut this, anon statement: ParsedStatement, scope_id: ScopeId, safety_mode: SafetyMode) throws -> CheckedStatement => match statement {
-        Expression(expr, span) => CheckedStatement::Expression(expr: .typecheck_expression(expr, scope_id, safety_mode), span)
+        Expression(expr, span) => {
+            let type_hint: TypeId? = None
+            yield CheckedStatement::Expression(expr: .typecheck_expression(expr, scope_id, safety_mode, type_hint), span)
+        }
         UnsafeBlock(block, span) => CheckedStatement::Block(block: .typecheck_block(block, parent_scope_id: scope_id, safety_mode: SafetyMode::Unsafe), span)
-        Yield(expr, span) => CheckedStatement::Yield(expr: .typecheck_expression(expr, scope_id, safety_mode), span)
+        Yield(expr, span) => {
+            let type_hint: TypeId? = None
+            yield CheckedStatement::Yield(expr: .typecheck_expression(expr, scope_id, safety_mode, type_hint), span)
+        }
         Return(expr, span) => .typecheck_return(expr, span, scope_id, safety_mode)
         Block(block, span) => .typecheck_block_statement(parsed_block: block, scope_id, safety_mode, span)
         InlineCpp(block, span) => .typecheck_inline_cpp(block, span, safety_mode)
@@ -3649,8 +3656,8 @@ struct Typechecker {
         //     1- Must respond to .next(); the mutability of the iterator is inferred from .next()'s signature
         //     2- The result of .next() must be an Optional.
 
-        // TODO: when optional type hint is available, add `None` as the type hint
-        let iterable_expr = .typecheck_expression(range, scope_id, safety_mode) 
+        let type_hint: TypeId? = None
+        let iterable_expr = .typecheck_expression(range, scope_id, safety_mode, type_hint) 
         mut iterable_should_be_mutable = false
 
 
@@ -3788,7 +3795,8 @@ struct Typechecker {
     }
 
     function typecheck_if(mut this, condition: ParsedExpression, then_block: ParsedBlock, else_statement: ParsedStatement?, scope_id: ScopeId, safety_mode: SafetyMode, span: Span) throws -> CheckedStatement {
-        let checked_condition = .typecheck_expression(condition, scope_id, safety_mode)
+        let type_hint: TypeId? = None
+        let checked_condition = .typecheck_expression(condition, scope_id, safety_mode, type_hint)
         if not expression_type(checked_condition).equals(builtin(BuiltinType::Bool)) {
             .error("Condition must be a boolean expression", condition.span())
         }
@@ -3822,7 +3830,7 @@ struct Typechecker {
                 }
                 yield .typecheck_array(scope_id, values, fill_size, span, safety_mode, default_inner_type_id)
             }
-            else => .typecheck_expression(expr: init, scope_id, safety_mode)
+            else => .typecheck_expression(expr: init, scope_id, safety_mode, type_hint: lhs_type_id)
         }
         let rhs_type_id = expression_type(checked_expr)
 
@@ -3895,7 +3903,8 @@ struct Typechecker {
     }
 
     function typecheck_while(mut this, condition: ParsedExpression, block: ParsedBlock, scope_id: ScopeId, safety_mode: SafetyMode, span: Span) throws -> CheckedStatement {
-        let checked_condition = .typecheck_expression(condition, scope_id, safety_mode)
+        let type_hint: TypeId? = None
+        let checked_condition = .typecheck_expression(condition, scope_id, safety_mode, type_hint)
         if not expression_type(checked_condition).equals(builtin(BuiltinType::Bool)) {
             .error("Condition must be a boolean expression", condition.span())
         }
@@ -3930,8 +3939,8 @@ struct Typechecker {
     }
 
     function typecheck_throw(mut this, expr: ParsedExpression, scope_id: ScopeId, safety_mode: SafetyMode, span: Span) throws -> CheckedStatement {
-
-        let checked_expr = .typecheck_expression(expr, scope_id, safety_mode)
+        let type_hint: TypeId? = None
+        let checked_expr = .typecheck_expression(expr, scope_id, safety_mode, type_hint)
 
         let error_type_id = .find_type_in_prelude("Error")
         if not expression_type(checked_expr).equals(error_type_id) {
@@ -4011,12 +4020,19 @@ struct Typechecker {
             let none_expr: CheckedExpression? = None
             return CheckedStatement::Return(val: none_expr, span)
         }
-        let checked_expr = .typecheck_expression(expr!, scope_id, safety_mode)
+
+        mut type_hint: TypeId? = None
+        if .current_function_id.has_value() {
+            type_hint = Some(.get_function(current_function_id!).return_type_id)
+        }
+
+        let checked_expr = .typecheck_expression(expr!, scope_id, safety_mode, type_hint)
         return CheckedStatement::Return(val: checked_expr, span)
     }
 
     function typecheck_indexed_struct(mut this, expr: ParsedExpression, field: String, scope_id: ScopeId, safety_mode: SafetyMode, span: Span) throws -> CheckedExpression {
-        let checked_expr = .typecheck_expression(expr, scope_id, safety_mode)
+        let type_hint: TypeId? = None
+        let checked_expr = .typecheck_expression(expr, scope_id, safety_mode, type_hint)
         let checked_expr_type_id = expression_type(checked_expr)
         let checked_expr_type = .get_type(checked_expr_type_id)
 
@@ -4102,7 +4118,7 @@ struct Typechecker {
         }
     }
 
-    function typecheck_expression(mut this, anon expr: ParsedExpression, scope_id: ScopeId, safety_mode: SafetyMode) throws -> CheckedExpression => match expr {
+    function typecheck_expression(mut this, anon expr: ParsedExpression, scope_id: ScopeId, safety_mode: SafetyMode, type_hint: TypeId?) throws -> CheckedExpression => match expr {
         IndexedStruct(expr, field, span) => .typecheck_indexed_struct(expr, field, scope_id, safety_mode, span)
         Boolean(val, span) => CheckedExpression::Boolean(val, span)
         NumericConstant(val, span) => {
@@ -4125,10 +4141,11 @@ struct Typechecker {
         Call(call, span) => {
             let none_expr: CheckedExpression? = None
             let parent_id: StructOrEnumId? = None
-            yield .typecheck_call(call, caller_scope_id: scope_id, span, this_expr: none_expr, parent_id, safety_mode, must_be_enum_constructor: false)
+            yield .typecheck_call(call, caller_scope_id: scope_id, span, this_expr: none_expr, parent_id, safety_mode, type_hint, must_be_enum_constructor: false)
         }
         MethodCall(expr, call, span) => {
-            let checked_expr = .typecheck_expression(expr, scope_id, safety_mode)
+            let none_type_hint: TypeId? = None
+            let checked_expr = .typecheck_expression(expr, scope_id, safety_mode, type_hint: none_type_hint)
             let checked_expr_type_id = expression_type(checked_expr)
 
             let parent_id = match .get_type(checked_expr_type_id) {
@@ -4143,7 +4160,7 @@ struct Typechecker {
                 }
             }
 
-            let checked_call_expr = .typecheck_call(call, caller_scope_id: scope_id, span, this_expr: checked_expr, parent_id, safety_mode, must_be_enum_constructor: false)
+            let checked_call_expr = .typecheck_call(call, caller_scope_id: scope_id, span, this_expr: checked_expr, parent_id, safety_mode, type_hint, must_be_enum_constructor: false)
             let type_id = expression_type(checked_call_expr)
             yield match checked_call_expr {
                 Call(call) => {
@@ -4165,8 +4182,9 @@ struct Typechecker {
             )
         }
         Range(from, to, span) => {
-            let checked_from = .typecheck_expression(from, scope_id, safety_mode)
-            let checked_to = .typecheck_expression(to, scope_id, safety_mode)
+            let none_type_hint: TypeId? = None
+            let checked_from = .typecheck_expression(from, scope_id, safety_mode, type_hint: none_type_hint)
+            let checked_to = .typecheck_expression(to, scope_id, safety_mode, type_hint: none_type_hint)
 
             let from_type = expression_type(checked_from)
             let to_type = expression_type(checked_to)
@@ -4190,7 +4208,8 @@ struct Typechecker {
             yield CheckedExpression::Range(from: checked_from, to: checked_to, span, type_id)
         }
         UnaryOp(expr, op, span) => {
-            let checked_expr = .typecheck_expression(expr, scope_id, safety_mode)
+            let none_type_hint: TypeId? = None
+            let checked_expr = .typecheck_expression(expr, scope_id, safety_mode, type_hint: none_type_hint)
             let checked_op = match op {
                 PreIncrement => CheckedUnaryOperator::PreIncrement
                 PostIncrement => CheckedUnaryOperator::PostIncrement
@@ -4251,8 +4270,9 @@ struct Typechecker {
             yield .typecheck_unary_operation(checked_expr, checked_op, span, scope_id, safety_mode)
         }
         BinaryOp(lhs, op, rhs, span) => {
-            let checked_lhs = .typecheck_expression(lhs, scope_id, safety_mode)
-            mut checked_rhs = .typecheck_expression(rhs, scope_id, safety_mode)
+            let none_type_hint: TypeId? = None
+            let checked_lhs = .typecheck_expression(lhs, scope_id, safety_mode, type_hint: none_type_hint)
+            mut checked_rhs = .typecheck_expression(rhs, scope_id, safety_mode, type_hint: none_type_hint)
 
             let lhs_type = expression_type(checked_lhs)
 
@@ -4269,7 +4289,8 @@ struct Typechecker {
             yield CheckedExpression::OptionalNone(span, type_id: unknown_type_id())
         }
         OptionalSome(expr, span) => {
-            let checked_expr = .typecheck_expression(expr, scope_id, safety_mode)
+            let none_type_hint: TypeId? = None
+            let checked_expr = .typecheck_expression(expr, scope_id, safety_mode, type_hint: none_type_hint)
             let type_id = expression_type(checked_expr)
             let optional_struct_id = .find_struct_in_prelude("Optional")
             let optional_type = Type::GenericInstance(id: optional_struct_id, args: [type_id])
@@ -4287,7 +4308,8 @@ struct Typechecker {
             }
         }
         ForcedUnwrap(expr, span) => {
-            let checked_expr = .typecheck_expression(expr, scope_id, safety_mode)
+            let none_type_hint: TypeId? = None
+            let checked_expr = .typecheck_expression(expr, scope_id, safety_mode, type_hint: none_type_hint)
             let type = .get_type(expression_type(checked_expr))
 
             let optional_struct_id = .find_struct_in_prelude("Optional")
@@ -4317,8 +4339,9 @@ struct Typechecker {
             mut checked_values: [CheckedExpression] = []
             mut checked_types: [TypeId] = []
 
+            let none_type_hint: TypeId? = None
             for value in values.iterator() {
-                let checked_value= .typecheck_expression(value, scope_id, safety_mode)
+                let checked_value= .typecheck_expression(value, scope_id, safety_mode, type_hint: none_type_hint)
                 let type_id = expression_type(checked_value)
                 if type_id.equals(VOID_TYPE_ID) {
                     .error("Cannot create a tuple that contains a value of type void", value.span())
@@ -4335,8 +4358,9 @@ struct Typechecker {
             yield CheckedExpression::JaktTuple(vals: checked_values, span, type_id)
         }
         IndexedExpression(base, index, span) => {
-            let checked_base = .typecheck_expression(base, scope_id, safety_mode)
-            let checked_index = .typecheck_expression(index, scope_id, safety_mode)
+            let none_type_hint: TypeId? = None
+            let checked_base = .typecheck_expression(base, scope_id, safety_mode, type_hint: none_type_hint)
+            let checked_index = .typecheck_expression(index, scope_id, safety_mode, type_hint: none_type_hint)
 
             let array_struct_id = .find_struct_in_prelude("Array")
             let dictionary_struct_id = .find_struct_in_prelude("Dictionary")
@@ -4362,7 +4386,8 @@ struct Typechecker {
             yield CheckedExpression::IndexedExpression(expr: checked_base, index: checked_index, span, type_id: expr_type_id)
         }
         IndexedTuple(expr, index, span) => {
-            let checked_expr = .typecheck_expression(expr, scope_id, safety_mode)
+            let none_type_hint: TypeId? = None
+            let checked_expr = .typecheck_expression(expr, scope_id, safety_mode, type_hint: none_type_hint)
 
             let tuple_struct_id = .find_struct_in_prelude("Tuple")
             mut expr_type_id = unknown_type_id()
@@ -4421,7 +4446,7 @@ struct Typechecker {
                     let implicit_constructor_call = ParsedCall(namespace_, name, args: [], type_args: [])
                     let none_expr: CheckedExpression? = None
                     let parent_id: StructOrEnumId? = None
-                    let call_expression = .typecheck_call(call: implicit_constructor_call, caller_scope_id: scope_id, span, this_expr: none_expr, parent_id, safety_mode, must_be_enum_constructor: true)
+                    let call_expression = .typecheck_call(call: implicit_constructor_call, caller_scope_id: scope_id, span, this_expr: none_expr, parent_id, safety_mode, type_hint, must_be_enum_constructor: true)
                     let type_id = expression_type(call_expression)
                     let checked_call = match call_expression {
                         Call(call) => call
@@ -4468,7 +4493,8 @@ struct Typechecker {
             // Check fill size is an integer.
             // TODO: Check fill size is positive when possible.
             let fill_size_value = fill_size.value()
-            let fill_size_checked = .typecheck_expression(fill_size_value, scope_id, safety_mode)
+                let none_type_hint: TypeId? = None
+            let fill_size_checked = .typecheck_expression(fill_size_value, scope_id, safety_mode, type_hint: none_type_hint)
             let fill_size_type = expression_type(fill_size_checked)
             if not .is_integer(fill_size_type) {
                 .error(
@@ -4482,9 +4508,12 @@ struct Typechecker {
         mut inner_type_id = unknown_type_id()
         mut inferred_type_span: Span? = None
 
+        // TODO: type hints
+        mut inner_hint: TypeId? = None
+
         mut vals: [CheckedExpression] = []
         for value in values.iterator() {
-            let checked_expr = .typecheck_expression(value, scope_id, safety_mode)
+            let checked_expr = .typecheck_expression(value, scope_id, safety_mode, type_hint: inner_hint)
             let current_value_type_id = expression_type(checked_expr)
 
             if inner_type_id.equals(unknown_type_id()) {
@@ -4521,9 +4550,10 @@ struct Typechecker {
         let set_struct_id = .find_struct_in_prelude("Set")
 
         // TODO: type hints
+        mut inner_hint: TypeId? = None
 
         for value in values.iterator() {
-            let checked_value = .typecheck_expression(expr: value, scope_id, safety_mode)
+            let checked_value = .typecheck_expression(expr: value, scope_id, safety_mode, type_hint: inner_hint)
             let current_value_type_id = expression_type(checked_value)
             if inner_type_id.equals(unknown_type_id()) {
                 if current_value_type_id.equals(void_type_id()) or current_value_type_id.equals(unknown_type_id()) {
@@ -4566,6 +4596,7 @@ struct Typechecker {
     function typecheck_generic_arguments_method_call(mut this, checked_expr: CheckedExpression, call: ParsedCall, scope_id: ScopeId, span: Span, safety_mode: SafetyMode) throws -> CheckedExpression {
         mut checked_args: [(String, CheckedExpression)] = []
         checked_args.ensure_capacity(call.args.size())
+        let type_hint: TypeId? = None
         for call_arg in call.args.iterator() {
             let name: String = call_arg.0
             let expr: ParsedExpression = call_arg.2
@@ -4573,6 +4604,7 @@ struct Typechecker {
                 expr
                 scope_id
                 safety_mode
+                type_hint
             )
             let checked_arg: (String, CheckedExpression) = (name, checked_arg_expr)
             checked_args.push(checked_arg)
@@ -4595,7 +4627,8 @@ struct Typechecker {
     }
 
     function typecheck_match(mut this, expr: ParsedExpression, cases: [ParsedMatchCase], span: Span, scope_id: ScopeId, safety_mode: SafetyMode) throws -> CheckedExpression {
-        let checked_expr = .typecheck_expression(expr, scope_id, safety_mode)
+        let type_hint: TypeId? = None
+        let checked_expr = .typecheck_expression(expr, scope_id, safety_mode, type_hint)
         let subject_type_id = expression_type(checked_expr)
         let type_to_match_on = .get_type(subject_type_id)
         mut checked_cases: [CheckedMatchCase] = []
@@ -4863,7 +4896,7 @@ struct Typechecker {
                                 }
                                 is_value_match = true
 
-                                let checked_expression = .typecheck_expression(expr, scope_id, safety_mode)
+                                let checked_expression = .typecheck_expression(expr, scope_id, safety_mode, type_hint: Some(subject_type_id))
 
                                 if not checked_expression.to_number_constant(program: .program).has_value() {
                                     all_variants_constant = false
@@ -4943,7 +4976,7 @@ struct Typechecker {
                 yield final_body!
             }
             Expression(expr) => {
-                let checked_expression = .typecheck_expression(expr, scope_id, safety_mode)
+                let checked_expression = .typecheck_expression(expr, scope_id, safety_mode, type_hint: result_type)
                 if result_type.has_value() {
                     .check_types_for_compat(
                         lhs_type_id: result_type!
@@ -4970,14 +5003,16 @@ struct Typechecker {
         mut value_type_span: Span? = None
 
         // TODO: hint type logic
+        mut key_hint: TypeId? = None
+        mut value_hint: TypeId? = None
 
         for kv_pair in values.iterator() {
             let key = kv_pair.0
             let value = kv_pair.1
-            let checked_key = .typecheck_expression(key, scope_id, safety_mode)
+            let checked_key = .typecheck_expression(key, scope_id, safety_mode, type_hint: key_hint)
             let current_key_type_id = expression_type(checked_key)
 
-            let checked_value = .typecheck_expression(value, scope_id, safety_mode)
+            let checked_value = .typecheck_expression(value, scope_id, safety_mode, type_hint: value_hint)
             let current_value_type_id = expression_type(checked_value)
             let VOID_TYPE_ID = builtin(BuiltinType::Void)
 
@@ -5096,7 +5131,7 @@ struct Typechecker {
         return None
     }
 
-    function typecheck_call(mut this, call: ParsedCall, caller_scope_id: ScopeId, span: Span, this_expr: CheckedExpression?, parent_id: StructOrEnumId?, safety_mode: SafetyMode, must_be_enum_constructor: bool) throws -> CheckedExpression {
+    function typecheck_call(mut this, call: ParsedCall, caller_scope_id: ScopeId, span: Span, this_expr: CheckedExpression?, parent_id: StructOrEnumId?, safety_mode: SafetyMode, type_hint: TypeId?, must_be_enum_constructor: bool) throws -> CheckedExpression {
         mut args: [(String, CheckedExpression)] = []
         mut return_type = builtin(BuiltinType::Void)
         mut callee_throws = false
@@ -5119,8 +5154,9 @@ struct Typechecker {
 
         match call.name {
             "print" | "println" | "eprintln" | "format" => {
+                let none_type_hint: TypeId? = None
                 for arg in call.args.iterator() {
-                    let checked_arg = .typecheck_expression(expr: arg.2, scope_id: caller_scope_id, safety_mode)
+                    let checked_arg = .typecheck_expression(expr: arg.2, scope_id: caller_scope_id, safety_mode, type_hint: none_type_hint)
 
                     args.push((call.name, checked_arg))
                 }
@@ -5210,7 +5246,7 @@ struct Typechecker {
                             }
                             yield .typecheck_array(scope_id: caller_scope_id, values, fill_size, span, safety_mode, default_inner_type_id)
                         }
-                        else => .typecheck_expression(expr: parsed_label_and_arg.2, scope_id: caller_scope_id, safety_mode)
+                        else => .typecheck_expression(expr: parsed_label_and_arg.2, scope_id: caller_scope_id, safety_mode, type_hint)
                     }
 
                     let promoted_arg = .try_to_promote_constant_expr_to_type(lhs_type: param.variable.type_id, checked_rhs: checked_arg, span)

--- a/selfhost/typechecker.jakt
+++ b/selfhost/typechecker.jakt
@@ -80,13 +80,13 @@ struct TypeId {
     function from_string(anon type_id_string: String) throws -> TypeId {
         let parts = type_id_string.split('_')
         if not (parts.size() == 2) {
-            throw Error::from_errno(999) // FIXME: good error message
+            panic(format("Failed to convert string `{}` to a TypeId: Wrong number of parts. (Wanted 2, got {})", type_id_string, parts.size()))
         }
 
         let module_id = parts[0].to_uint()
         let type_id = parts[1].to_uint()
         if not module_id.has_value() or not type_id.has_value() {
-            throw Error::from_errno(9999) // FIXME: good error message
+            panic(format("Failed to convert string `{}` to a TypeId. (module_id = {} ({}), type_id = {} ({}))", type_id_string, module_id, parts[0], type_id, parts[1]))
         }
 
         return TypeId(module: ModuleId(id: module_id.value() as! usize), id: type_id.value() as! usize)


### PR DESCRIPTION
I haven't met my original goal of making `samples/generics/generic_fun.jakt` succeed, but that turned out to be a much deeper yak-hole than I anticipated. :sweat_smile: 

The last commit causes an infinite loop in `substitute_typevars_in_type()`, so leaving this as a draft until that's figured out.