### PR TITLE
selfhost+runtime: Add support for inline cpp codegen

### DIFF
--- a/runtime/Jakt/String.cpp
+++ b/runtime/Jakt/String.cpp
@@ -262,4 +262,9 @@ void StringStorage::compute_hash() const
     m_has_hash = true;
 }
 
+ErrorOr<String> String::replace(StringView needle, StringView replacement, bool all_occurrences) const
+{
+    return Jakt::StringUtils::replace(*this, needle, replacement, all_occurrences);
+}
+
 }

--- a/runtime/Jakt/String.h
+++ b/runtime/Jakt/String.h
@@ -141,6 +141,8 @@ public:
     [[nodiscard]] bool is_empty() const { return length() == 0; }
     [[nodiscard]] size_t length() const { return m_storage->length(); }
 
+    [[nodiscard]] ErrorOr<String> replace(StringView needle, StringView replacement, bool all_occurrences = true) const;
+    
     // Guaranteed to include null terminator.
     [[nodiscard]] char const* c_string() const { return m_storage->c_string(); }
 

--- a/runtime/prelude.jakt
+++ b/runtime/prelude.jakt
@@ -36,6 +36,7 @@ extern struct String {
     function length(this) -> usize
     function byte_at(this, anon index: usize) -> u8
     function contains(this, anon needle: String) -> bool
+    function replace(this, replace: String, with: String) throws -> String
 }
 
 extern struct StringBuilder {

--- a/selfhost/codegen.jakt
+++ b/selfhost/codegen.jakt
@@ -1127,9 +1127,8 @@ struct CodeGenerator {
         OptionalSome(expr, type_id) => "(" + .codegen_expression(expr) + ")"
         ForcedUnwrap(expr, type_id) => "(" + .codegen_expression(expr) + ".value())"
         QuotedString(val) => {
-            // FIXME: this should replace newlines to allow for multiline strings
-            //"String(\"" + val.replace(replace: "\n", with: "\\n") + "\")"
-            yield "String(\"" + val + "\")"
+            let escaped_value = val.replace(replace: "\n", with: "\\n")
+            yield "String(\"" + escaped_value + "\")"
         }
         ByteConstant(val) => "'" + val + "'"
         CharacterConstant(val) => "'" + val + "'"
@@ -2125,8 +2124,7 @@ struct CodeGenerator {
             }
             Block(block) => .codegen_block(block)
             Garbage => {
-                panic("Garbage statement in codegen")
-                // FIXME: panic() should be `noreturn` and no `yield` should be necessary:
+                panic("Garbage statement in codegen") // FIXME: panic() should be `noreturn` and no `yield` should be necessary:
                 yield ""
             }
             VarDecl(var_id, init) => {
@@ -2142,6 +2140,16 @@ struct CodeGenerator {
                 output += " = "
                 output += .codegen_expression(init)
                 output += ";"
+                yield output
+            }
+            InlineCpp(lines) => {
+                mut output = ""
+                for line in lines.iterator() {
+                    mut escaped_line = line
+                    escaped_line = escaped_line.replace(replace: "\\\"", with: "\"")
+                    escaped_line = escaped_line.replace(replace: "\\\\", with: "\\")
+                    output += escaped_line
+                }
                 yield output
             }
             If(condition, then_block, else_statement) => {


### PR DESCRIPTION
This adds the `replace` method to the String runtime and then uses it to add support for inline cpp codegen.

Before:
```
==============================
239 passed
93 failed
7 skipped
==============================
```

After:
```
==============================
241 passed
91 failed
7 skipped
==============================
```