### PR TITLE
selfhost/prelude: Add String replace

### DIFF
--- a/samples/strings/replace.jakt
+++ b/samples/strings/replace.jakt
@@ -1,0 +1,8 @@
+/// Expect:
+/// - output: "Hello friends\n"
+
+function main() {
+    let original: String = "Hello darkness"
+    let corrected = original.replace(replace: "darkness", with: "friends")
+    println("{}", corrected);
+}

--- a/selfhost/prelude.jakt
+++ b/selfhost/prelude.jakt
@@ -54,6 +54,7 @@ extern struct String {
     function length(this) -> usize
     function byte_at(this, anon index: usize) -> u8
     function contains(this, anon needle: String) -> bool
+    function replace(this, replace: String, with: String) throws -> String
 }
 
 extern struct StringBuilder {


### PR DESCRIPTION
* add String replace also to selfhost prelude for feature parity
* add a String replace test sample application

```bash
$ jakttest/run-all.sh samples/strings
[ PASS ] samples/strings/repeated.jakt
[ PASS ] samples/strings/length_and_is_empty.jakt
[ PASS ] samples/strings/replace.jakt
[ PASS ] samples/strings/string_split.jakt
[ PASS ] samples/strings/string_builder.jakt
==============================
5 passed
0 failed
0 skipped
==============================
```