### PR TITLE
jakttest: Parallelize Jakttest

### DIFF
--- a/jakttest/build.ninja
+++ b/jakttest/build.ninja
@@ -3,13 +3,20 @@ cxxflags = -fcolor-diagnostics -std=c++20 -Wno-user-defined-literals -Wno-deprec
 rule cxx
     command = clang++ $cxxflags -o $out -I ../runtime $in 
 
+rule mkdir
+    command = mkdir $out
+
 rule jakttest
     command = cargo run --color always -- -o build --emit-cpp-source-only jakttest.jakt
 
 rule patch-includes
-    command = sed -e '1a#include "../process.h"' $in > $out
+    command = python patch-includes.py $in $out
 
 
+# directory
+build build: mkdir
+# NOTE: pipe `|` is for implicit dependencies, so that ninja considers the target outdated if any
+# of those have changed, even if it's not stated as an input.
 build build/jakttest.cpp: jakttest | jakttest.jakt utility.jakt parser.jakt lexer.jakt error.jakt
 build build/jakttest: cxx build/jakttest-patched.cpp process.cpp | process.h
 build build/jakttest-patched.cpp: patch-includes build/jakttest.cpp

--- a/jakttest/build.ninja
+++ b/jakttest/build.ninja
@@ -1,0 +1,16 @@
+cxxflags = -fcolor-diagnostics -std=c++20 -Wno-user-defined-literals -Wno-deprecated-declarations
+
+rule cxx
+    command = clang++ $cxxflags -o $out -I ../runtime $in 
+
+rule jakttest
+    command = cargo run --color always -- -o build --emit-cpp-source-only jakttest.jakt
+
+rule patch-includes
+    command = sed -e '1a#include "../process.h"' $in > $out
+
+
+build build/jakttest.cpp: jakttest | jakttest.jakt utility.jakt parser.jakt lexer.jakt error.jakt
+build build/jakttest: cxx build/jakttest-patched.cpp process.cpp | process.h
+build build/jakttest-patched.cpp: patch-includes build/jakttest.cpp
+default build/jakttest

--- a/jakttest/build.ninja
+++ b/jakttest/build.ninja
@@ -1,4 +1,4 @@
-cxxflags = -fcolor-diagnostics -std=c++20 -Wno-user-defined-literals -Wno-deprecated-declarations
+cxxflags = -fcolor-diagnostics -std=c++20 -Wno-user-defined-literals -Wno-deprecated-declarations -Wno-parentheses-equality
 
 rule cxx
     command = clang++ $cxxflags -o $out -I ../runtime $in 

--- a/jakttest/jakttest.jakt
+++ b/jakttest/jakttest.jakt
@@ -1,7 +1,24 @@
 import error { JaktError, print_error }
 import parser { Parser }
+import lexer { Lexer }
 
-function usage() => "usage: jakttest [-h] [OPTIONS] <path>"
+namespace process {
+    /// Starts a background job by means of fork() and exec(). Returns
+    /// the PID of the launched process.
+    extern function start_background_process(args: [String]) throws -> i32
+    /// Checks whether a process has finished executing. Returns its
+    /// exit code if it has.
+    extern function poll_process_exit(pid: i32) throws -> i32?
+    /// Kills a process by sending SIGKILL to it
+    extern function forcefully_kill_process(pid: i32) throws
+}
+
+function print_usage()  {
+    eprintln("usage: jakttest [OPTIONS...] <temp-dir> <path> [... <path>]")
+    eprintln("OPTIONS:")
+    eprintln("\t-h\t\tShow this message and exit.")
+    eprintln("\t-j,--jobs <JOBS>\t\tUse JOBS processes. Defaults to 8.")
+}
 
 function compare_test(bytes: [u8], expected: String) throws -> bool {
     // first, build up the content to compare to
@@ -58,87 +75,281 @@ function strip_line_breaks(anon input: String) throws -> String {
     return builder.to_string()
 }
 
-function main(args: [String]) {
-    if args.size() <= 1 {
-        eprintln("{}", usage())
-        return 1
+function u64_from_ascii_digit(anon byte: u8) -> u64? {
+    if byte >= b'0' and byte <= b'9' {
+        return (byte - b'0') as! u64
+    }
+    return None
+}
+
+function u64_from_ascii_digits(anon digits: String) -> u64? {
+    mut value = 0u64
+
+    for index in 0..digits.length() {
+        let byte = digits.byte_at(index)
+        let digit = u64_from_ascii_digit(byte)
+        if not digit.has_value() {
+            return None
+        }
+        // FIXME: overflow check
+        value = value * 10 + digit!
     }
 
-    let file_name = args[1];
 
-    mut file = File::open_for_reading(file_name)
-    let file_contents = file.read_all()
-    let parsed_test = Parser::parse(input: file_contents)
+    return value
+}
 
-    // Windows
-    // system("del runtest.out runtest.err".c_string())
+struct Options {
+    files: [String]
+    temp_dir: String
+    errors: [String]
+    job_count: u64
+    help_wanted: bool
 
-    // Unix
-    system("rm -f runtest.out runtest.err".c_string())
+    function from_args(args: [String]) throws -> Options {
+        let files: [String] = []
+        let errors: [String] = []
+        mut options = Options(files, temp_dir: "", errors, job_count: 8, help_wanted: false)
 
-    match parsed_test {
-        SuccessTest(expected) => {
-
-            build_and_run(file_name)
-
-            mut build_and_run_output_file = File::open_for_reading("runtest.out")
-            let build_and_run_output = build_and_run_output_file.read_all()
-
-            let test_passes_output = compare_test(bytes: build_and_run_output, expected)
-
-            if not (test_passes_output) {
-                eprintln("Test failed: {}", file_name)
-                return 1
-            } else {
-                println("Test passed: {}", file_name)
-                return 0
-            }
-        }
-        FailureTest(expected) => {
-
-            build_and_run(file_name)
-
-            mut build_and_run_error_file = File::open_for_reading("runtest.err")
-            let build_and_run_output = build_and_run_error_file.read_all()
-
-            let test_passes = compare_error(bytes: build_and_run_output, expected)
-
-            if not test_passes {
-                eprintln("Test failed: {}", file_name)
-                return 1
-            } else {
-                println("Test passed: {}", file_name)
-                return 0
+        mut index = 1uz
+        while index != args.size() {
+            if args[index] == "-h" {
+                // end processing here since the user wants some help
+                options.help_wanted = true
+                return options
             }
 
-        }
-        SkipTest => {
-            println("Expected output/error not found. Test skipped")
+            if args[index] == "-j" or args[index] == "--jobs" {
+                index++
+                if index == args.size() {
+                    options.errors.push("Used --jobs/-j without an argument")
+                    break // we reached end of arguments
+                }
+                let jobs = u64_from_ascii_digits(args[index])
+                if not jobs.has_value() or jobs! == 0 {
+                    options.errors.push("--jobs/-j needs a positive integer as its argument")
+                } else {
+                    options.job_count = jobs!
+                }
+                index++
+                continue
+            }
 
-            // Can't understand test, so we skip it
-            return 2
+            // positional argument.
+
+            // if temp dir was empty, this means this is the first positional
+            // argument we encounter, which corresponds to the temporary directory
+            // we'll use for operations.
+            if options.temp_dir.is_empty() {
+                options.temp_dir = args[index]
+            } else {
+                // otherwise it's a file path.
+                options.files.push(args[index])
+            }
+
+            index++
         }
+
+        if options.temp_dir.is_empty() {
+            options.errors.push("Missing <temp-dir>")
+        }
+
+        if options.files.is_empty() {
+            options.errors.push("At least one file <path> must be provided")
+        }
+        return options
     }
 }
 
-function build_and_run(anon jakt_source_file: String) throws {
-    mut compile_args = [
-        "build/main"
-        "-r"
-    ]
-    compile_args.push(jakt_source_file)
-    compile_args.push(">")
-    compile_args.push("runtest.out")
-    compile_args.push("2>")
-    compile_args.push("runtest.err")
+enum ResultKind {
+    Success
+    Failure
+}
 
-    mut command = ""
-    for compile_arg in compile_args.iterator() {
-        command += compile_arg
-        command += " "
+struct ExpectedResult {
+    kind: ResultKind
+    output: String
+}
+
+struct Test {
+    result: ExpectedResult
+    file_name: String
+    directory_index: usize
+}
+
+struct TestsRunResult {
+    passed_count: usize
+    failed_count: usize
+}
+
+// A test scheduler that has its process rate limited by
+// the number of directories it has available.
+struct TestScheduler {
+    running_tests: [i32:Test]
+    free_directories: [usize]
+    directories: [String]
+    passed_count: usize
+    failed_count: usize
+    // TODO: timeout
+    // TODO: show reasons why tests fail
+
+    function poll_running_tests(mut this) throws {
+        // TODO: switch back to using dict iterator
+        // to debug weird String not having pointer
+        // (see https://discord.com/channels/830522505605283862/977605897964617771/995699296685011004)
+        for pid in .running_tests.keys().iterator() {
+            let poll_result = process::poll_process_exit(pid)
+            if poll_result.has_value() {
+                let test = .running_tests[pid]
+
+                // check the test result
+                let file_to_check = format("{}/{}"
+                                    .directories[test.directory_index]
+                                    match test.result.kind {
+                                        Success => "runtest.out"
+                                        Failure => "runtest.err"
+                                    })
+
+                mut file = File::open_for_reading(file_to_check)
+                let output = file.read_all()
+
+                let passed_test = match test.result.kind {
+                    Success => compare_test(bytes: output, expected: test.result.output)
+                    Failure => compare_error(bytes: output, expected: test.result.output)
+                }
+
+                if passed_test {
+                    eprintln("[ \x1b[32;1mPASS\x1b[m ] {}", test.file_name)
+                    .passed_count++
+                } else {
+                    eprintln("[ \x1b[31;1mFAIL\x1b[m ] {}", test.file_name)
+                    .failed_count++
+                }
+
+
+                .free_directories.push(test.directory_index)
+                .running_tests.remove(pid)
+            }
+        }
     }
-    
-    system(command.c_string())
+
+    function get_free_directory(mut this) -> usize? => .free_directories.pop()
+
+    function create(directories: [String]) throws -> TestScheduler {
+        mut running_tests: [i32:Test] = [:]
+        running_tests.ensure_capacity(directories.size())
+        mut free_directories: [usize] = []
+        free_directories.ensure_capacity(directories.size())
+        for i in 0..directories.size() {
+            free_directories.push(i)
+        }
+
+        return TestScheduler(running_tests
+                            free_directories
+                            directories
+                            passed_count: 0
+                            failed_count: 0)
+    }
+
+    public function run_tests(mut tests: [Test], directories: [String]) throws -> TestsRunResult {
+        mut scheduler = TestScheduler::create(directories)
+        while not tests.is_empty() {
+            let dir_index = scheduler.get_free_directory()
+            if dir_index.has_value() {
+                // we got a free directory! Let's launch a new test job!
+                mut test = tests.pop()!
+                test.directory_index = dir_index!
+                let directory = scheduler.directories[test.directory_index]
+                let command =
+                    format("./jakttest/run-one.sh {} {} >{}/runtest.out 2>{}/runtest.err"
+                           directory
+                           test.file_name
+                           directory,directory
+                           )
+                let pid = process::start_background_process(args: [
+                    "sh"
+                    "-c"
+                    command
+                ])
+                scheduler.running_tests[pid] = test
+                continue
+            }
+
+            scheduler.poll_running_tests()
+        }
+
+        while not scheduler.running_tests.is_empty() {
+            scheduler.poll_running_tests()
+        }
+
+        return TestsRunResult(passed_count: scheduler.passed_count
+                              failed_count: scheduler.failed_count)
+    }
+}
+
+
+function main(args: [String]) {
+    let parsed_options = Options::from_args(args)
+
+    if parsed_options.help_wanted {
+        print_usage()
+        return 0
+    }
+
+    if not parsed_options.errors.is_empty() {
+        for error in parsed_options.errors.iterator() {
+            eprintln("Error: {}.", error)
+        }
+        print_usage()
+        return 1
+    }
+
+    mut skipped_count = 0uz
+
+    mut tests: [Test] = []
+    tests.ensure_capacity(parsed_options.files.size())
+
+    // parse all files to collect the actual work we have to do
+    for file_name in parsed_options.files.iterator() {
+        mut file = File::open_for_reading(file_name)
+        let contents = file.read_all()
+        let result = Parser::parse(input: contents)
+        match result {
+            SuccessTest(output) => {
+                tests.push(Test(result: ExpectedResult(kind: ResultKind::Success, output)
+                                file_name
+                                directory_index: 0))
+            }
+            FailureTest(output) => {
+                tests.push(Test(result: ExpectedResult(kind: ResultKind::Failure, output)
+                                file_name
+                                directory_index: 0))
+            }
+            SkipTest => {
+                eprintln("[ \x1b[33;1mSKIP\x1b[m ] {}", file_name)
+                skipped_count += 1
+            }
+        }
+    }
+
+    // TODO: wrap logic in a TestScheduler class
+
+    mut directories: [String] = []
+    directories.ensure_capacity(parsed_options.job_count as! usize)
+    for i in 0..parsed_options.job_count {
+        let name = format("{}/jakttest-tmp-{}",  parsed_options.temp_dir, i)
+        // FIXME: Does this work in Windows?
+        system(("mkdir -p " + name).c_string())
+        directories.push(name)
+    }
+
+    let run_result = TestScheduler::run_tests(tests, directories)
+
+    println("==============================")
+    println("{} passed" , run_result.passed_count)
+    println("{} failed" run_result.failed_count)
+    println("{} skipped", skipped_count)
+    println("==============================")
 }
 
 function write_to_file(file_contents: [u8], output_filename: String) throws {

--- a/jakttest/jakttest.jakt
+++ b/jakttest/jakttest.jakt
@@ -30,8 +30,8 @@ function compare_test(bytes: [u8], expected: String) throws -> bool {
     let builder_output = builder.to_string()
 
     if builder_output != expected {
-        eprintln("expected: {}", expected)
-        eprintln("found:    {}", builder_output)
+        // TODO: return more information about expected/parsed
+        // for --show-reason flag
         return false
     }
     return true
@@ -56,8 +56,8 @@ function compare_error(bytes: [u8], expected: String) throws -> bool {
     let stripped_expected = strip_line_breaks(expected)
 
     if not builder_output.contains(stripped_expected) {
-        eprintln("expected: {}", stripped_expected)
-        eprintln("found:    {}", builder_output)
+        // TODO: return more information about expected/parsed
+        // for --show-reason flag
         return false
     }
     return true

--- a/jakttest/patch-includes.py
+++ b/jakttest/patch-includes.py
@@ -1,0 +1,11 @@
+#!/bin/env python
+# ./patch.sh $in $out
+# Add `#include "../process.h"` to the output file (.. because file is under build/)
+import sys
+
+target_file = sys.argv[1]
+target_output = sys.argv[2]
+
+with open(target_file) as source, open(target_output, "w") as sink:
+    sink.write('#include "../process.h"\n')
+    sink.write(source.read())

--- a/jakttest/process.cpp
+++ b/jakttest/process.cpp
@@ -8,8 +8,6 @@ namespace Jakt::process {
 // - the string arguments that follow the last argv NULL pointer, terminated by zeroes.
 static ErrorOr<char**> dup_argv(Array<String> args)
 {
-    // TODO: make this just one allocation by putting argv pointers at
-    // the front of the array, and then the strings.
 
     // 1. Calculate the total size  of all the pointers + all the strings, accounting
     // for the last NULL pointer and each argument's NUL terminator.

--- a/jakttest/process.cpp
+++ b/jakttest/process.cpp
@@ -1,5 +1,6 @@
 #include "process.h"
 #include <sys/wait.h>
+#include <signal.h>
 
 namespace Jakt::process {
 // Allocates & fills one array, which contains:

--- a/jakttest/process.cpp
+++ b/jakttest/process.cpp
@@ -1,0 +1,107 @@
+#include "process.h"
+#include <sys/wait.h>
+
+namespace Jakt::process {
+// Allocates & fills one array, which contains:
+// - the argv array with all the pointers into later offsets of the array, at the front
+// - the string arguments that follow the last argv NULL pointer, terminated by zeroes.
+static ErrorOr<char**> dup_argv(Array<String> args)
+{
+    // TODO: make this just one allocation by putting argv pointers at
+    // the front of the array, and then the strings.
+
+    // 1. Calculate the total size  of all the pointers + all the strings, accounting
+    // for the last NULL pointer and each argument's NUL terminator.
+    auto const argv_size = Checked(args.size()) + Checked(1ul);
+    auto const argv_malloc_size = argv_size * Checked(sizeof(char*));
+    // ensure argv malloc size has no overflow because we're going to use it
+    // as the offset for the start of the string array.
+    if (argv_malloc_size.has_overflow()) {
+        return Error::from_errno(EOVERFLOW);
+    }
+
+    // join all the strings in one allocation
+    auto total_string_size = Checked<size_t>(0);
+    for (size_t i = 0; i != args.size(); ++i) {
+        total_string_size += args[i].length();
+    }
+    total_string_size += args.size();
+
+    auto const total_allocation_size = argv_malloc_size + total_string_size;
+    if (total_allocation_size.has_overflow()) {
+        return Error::from_errno(EOVERFLOW);
+    }
+
+    // 2. Allocate the full array
+    auto const full_array = malloc(total_allocation_size.value_unchecked());
+    if (!full_array) {
+        return Error::from_errno(ENOMEM);
+    }
+
+    // 3. Fill all strings & argv offsets.
+    // NOTE: argv *is* the start of the allocation, so any free()s to this data structure must point to `argv`.
+    auto const argv = reinterpret_cast<char**>(full_array);
+
+    {
+        char* arg = reinterpret_cast<char*>(full_array) + argv_malloc_size.value_unchecked();
+        for (u64 i = 0; i != args.size(); ++i) {
+            // copy the string
+            memcpy(arg, args[i].c_string(), args[i].length());
+            arg[args[i].length()] = 0;
+            // set the argument pointer
+            argv[i] = arg;
+            // add the offset
+            arg += args[i].length() + 1;
+        }
+        argv[args.size()] = NULL;
+    }
+
+    return argv;
+}
+
+ErrorOr<i32> start_background_process(Array<String> args)
+{
+    // We have to fully duplicate argv because execvp wants
+    // *modifiable* arguments (char* const*)
+    auto const argv = TRY(dup_argv(args));
+    auto const pid = fork();
+    if (pid == -1) {
+        return Error::from_errno(errno);
+    }
+    if (pid == 0) {
+        // child process, execute the command
+        execvp(argv[0], argv);
+    }
+
+    // Allocated memory got dup'd, so we'll free the parent side.
+    // NOTE: See point 3 on dup_argv
+    free(argv);
+
+    return pid;
+}
+
+ErrorOr<Optional<i32>> poll_process_exit(i32 pid)
+{
+    i32 exit_code;
+    auto const result = waitpid(pid, &exit_code, WNOHANG);
+    if (result == -1) {
+        return Error::from_errno(errno);
+    }
+    // not exited.
+    if (result == 0) {
+        return JaktInternal::NullOptional {};
+    }
+    // NOTE: compiler seems to struggle to find a constructor when
+    // nesting error & optional
+    return Optional<i32>(exit_code);
+}
+
+ErrorOr<void> forcefully_kill_process(i32 pid)
+{
+    if (kill(pid, SIGKILL) < 0) {
+        return Error::from_errno(errno);
+    }
+    return ErrorOr<void> {};
+}
+
+}

--- a/jakttest/process.h
+++ b/jakttest/process.h
@@ -1,0 +1,9 @@
+#include <Builtins/Array.h>
+#include <Jakt/Error.h>
+#include <Jakt/String.h>
+
+namespace Jakt::process {
+ErrorOr<i32> start_background_process(Array<String> args);
+ErrorOr<Optional<i32>> poll_process_exit(i32 pid);
+ErrorOr<void> forcefully_kill_process(i32 pid);
+}

--- a/jakttest/run-all.sh
+++ b/jakttest/run-all.sh
@@ -10,7 +10,12 @@ set -e
 ninja -C jakttest
 set +e
 
-
+if [ ! -x build/main ]; then
+    echo "Selfhost binary does not exist; compiling it"
+    set -e
+    cargo run selfhost/main.jakt
+    set +e
+else
 # check for selfhost/ mtime and build/main mtime
 {
     binary_mtime=$(stat "$stat_format_flags" build/main)
@@ -22,6 +27,7 @@ set +e
         set +e
     fi
 }
+fi
 
 pass=0
 fail=0

--- a/jakttest/run-one.sh
+++ b/jakttest/run-one.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+# run-one.sh <temp-dir> <file>
+
+# NOTE: we need this because selfhost doesn't yet have a way to specify
+# build directories, and it doesn't use temporary directories for
+# temporary building (i.e building and running)
+
+set -e
+
+temp_dir=$1
+file=$2
+
+# Generate C++ code into 
+build/main $2 > $temp_dir/output.cpp
+
+# Compile C++ code
+clang++ -fcolor-diagnostics \
+    -std=c++20 \
+    -Wno-unknown-warning-option \
+    -Wno-trigraphs \
+    -Wno-parentheses-equality \
+    -Wno-unqualified-std-cast-call \
+    -Wno-user-defined-literals \
+    -Wno-deprecated-declarations \
+    -Iruntime \
+    -o $temp_dir/output \
+    $temp_dir/output.cpp
+
+# Run
+$temp_dir/output


### PR DESCRIPTION
Rewrote Jakttest so it accepts all the test files and runs them through a process scheduler to be able to run the tests in parallel. The binary gets a clean temporary directory where it places one temporary directory per job. It uses that to store both C++ temporaries from Jakt compiler's output and stderr/stdout results, which it will read once it knows the job has finished with the directory. Doesn't use any locks since it makes sure to only run one job per directory.

Most of the "changes" here are just removing unneeded files (mainly the 900loc from lexer/parser) since I wrote a custom `Expect` section parser that runs through each file to know what to expect from its output. This new parser does not care about the Jakt language; instead it only looks for the expect section, reducing the possibility of having a Jakt lexer bug propagate into Jakttest.
