### PR TITLE
jakttest: Build selfhost if binary does not exist

### DIFF
--- a/jakttest/run-all.sh
+++ b/jakttest/run-all.sh
@@ -5,6 +5,11 @@ if [ ! -x ./build/jakttest ]; then
     cargo run jakttest/jakttest.jakt
 fi
 
+if [ ! -x ./build/main ]; then
+    echo "selfhost binary does not exist. Building it now."
+    cargo run selfhost/main.jakt
+fi
+
 stat_format_flags="-c %Y"
 if [[ $OSTYPE == 'darwin'* ]]; then
   stat_format_flags="-f %m"


### PR DESCRIPTION
run-all.sh script doesn't check for if selfhost binary is
already built when comparing if it is updated or not. This
results with tests failing without ever using the selfhosted
binary. Building selfhost before running the tests fixes
the issue.