### PR TITLE
selfhost/typechecker: Fix typo in error message

### DIFF
--- a/selfhost/typechecker.jakt
+++ b/selfhost/typechecker.jakt
@@ -3881,7 +3881,7 @@ struct Typechecker {
 
         let scope = .get_scope(scope_id)
         if not scope.can_throw {
-            .error("Throw statment needs to be in a try statement or a function marked as throws", expr.span())
+            .error("Throw statement needs to be in a try statement or a function marked as throws", expr.span())
         }
 
         return CheckedStatement::Throw(expr: checked_expr, span)


### PR DESCRIPTION
Makes `tests/typechecker/throw_without_throws_function.jakt` pass