### PR TITLE
main+editors/vscode: Change hover argument from -v to -e

### DIFF
--- a/editors/vscode/server/src/server.ts
+++ b/editors/vscode/server/src/server.ts
@@ -195,7 +195,7 @@ connection.onHover(async (request) => {
 		// console.log("request: ");
 		// console.log(request);
 		// console.log("index: " + convertPosition(request.position, text));
-		const stdout = await runCompiler(text, "-v " + convertPosition(request.position, text) + includeFlagForPath(request.textDocument.uri), settings);
+		const stdout = await runCompiler(text, "-e " + convertPosition(request.position, text) + includeFlagForPath(request.textDocument.uri), settings);
 		// console.log("got: ", stdout);
 
 		const lines = stdout.split('\n').filter(l => l.length > 0);

--- a/src/main.rs
+++ b/src/main.rs
@@ -397,7 +397,7 @@ fn parse_arguments() -> JaktArguments {
         }
     }
 
-    if let Ok(Some(index)) = get_path_arg(["-v", "--hover"]) {
+    if let Ok(Some(index)) = get_path_arg(["-e", "--hover"]) {
         if let Ok(val) = index.to_string_lossy().parse::<usize>() {
             arguments.hover_index = Some(val);
         }


### PR DESCRIPTION
-v is currently used by --version. This caused hover to fail because of
argument ambiguity.