### PR TITLE
selfhost/parser: Fix error message for Array literals

### DIFF
--- a/selfhost/parser.jakt
+++ b/selfhost/parser.jakt
@@ -2688,7 +2688,7 @@ struct Parser {
                         .index++
                         fill_size_expr = .parse_expression(allow_assignments: false);
                     } else {
-                        .error("Can't fill array with more than one expression", .current().span())
+                        .error("Can't fill an Array with more than one expression", .current().span())
                         .index++
                     }
                 }


### PR DESCRIPTION
Fix error message for Array literals with more than one expression.

Before:
`[ FAIL ] tests/parser/multiple_expressions_in_array.jakt`

After
`[ PASS ] tests/parser/multiple_expressions_in_array.jakt`