### PR TITLE
tests+lexer+selfhost/lexer+parser: Fix some small bugs

### DIFF
--- a/selfhost/lexer.jakt
+++ b/selfhost/lexer.jakt
@@ -365,6 +365,13 @@ struct Lexer {
         return .input[.index + steps]
     }
 
+    function peek_behind(this, anon steps: usize) -> u8 {
+        if .index < steps {
+            return 0
+        }
+        return .input[.index - steps]
+    }
+
     function eof(this) -> bool {
         return .index >= .input.size()
     }
@@ -482,9 +489,27 @@ struct Lexer {
                         }
                     }
                     let end = .index
+                    let span = .span(start, end)
+
+                    if .peek_behind(1) == b'_' {
+                        .error(
+                            "Hexadecimal number literal cannot end with underscore"
+                            span
+                        )
+                        return Token::Garbage(span)
+                    }
+
                     let suffix = .consume_numeric_literal_suffix() ?? LiteralSuffix::I64
 
-                    return make_number_token(number: total, suffix, span: .span(start, end))
+                    if is_ascii_alphanumeric(.peek()) or .peek() == b'_' {
+                        .error(
+                            "Could not parse hexadecimal number"
+                            span
+                        )
+                        return Token::Garbage(span)
+                    }
+
+                    return make_number_token(number: total, suffix, span)
                 }
                 // Octal Number
                 b'o' => {
@@ -498,6 +523,28 @@ struct Lexer {
                             ++.index
                         }
                     }
+                    let end = .index
+                    let span = .span(start, end)
+
+                    if .peek_behind(1) == b'_' {
+                        .error(
+                            "Octal number literal cannot end with underscore"
+                            span
+                        )
+                        return Token::Garbage(span)
+                    }
+
+                    let suffix = .consume_numeric_literal_suffix() ?? LiteralSuffix::I64
+
+                    if is_ascii_alphanumeric(.peek()) {
+                        .error(
+                            "Could not parse octal number"
+                            span
+                        )
+                        return Token::Garbage(span)
+                    }
+
+                    return make_number_token(number: total, suffix, span)
                 }
                 // Binary Number
                 b'b' => {
@@ -511,6 +558,29 @@ struct Lexer {
                             ++.index
                         }
                     }
+                    let end = .index
+                    let span = .span(start, end)
+
+                    if .peek_behind(1) == b'_' {
+                        .error(
+                            "Binary number literal cannot end with underscore"
+                            span
+                        )
+                        return Token::Garbage(span)
+                    }
+
+                    let suffix = .consume_numeric_literal_suffix() ?? LiteralSuffix::I64
+
+                    if is_ascii_alphanumeric(.peek()) {
+                        .error(
+                            "Could not parse binary number"
+                            span
+                        )
+
+                        return Token::Garbage(span)
+                    }
+
+                    return make_number_token(number: total, suffix, span)
                 }
                 else => {}
             }
@@ -526,7 +596,26 @@ struct Lexer {
             }
         }
         let end = .index
+        let span = .span(start, end)
+
+        if .peek_behind(1) == b'_' {
+            .error(
+                "Number literal cannot end with underscore"
+                span
+            )
+            return Token::Garbage(span)
+        }
+
         let suffix = .consume_numeric_literal_suffix() ?? LiteralSuffix::I64
+
+        if is_ascii_alphanumeric(.peek()) {
+            .error(
+                "Could not parse number"
+                span
+            )
+
+            return Token::Garbage(span)
+        }
 
         return make_number_token(number: total, suffix, span: .span(start, end))
     }
@@ -548,6 +637,11 @@ struct Lexer {
         mut width = 0i64
 
         while is_ascii_digit(.peek_ahead(local_index)) {
+            // Make sure we don't overflow the width
+            if local_index > 3 {
+                return None
+            }
+
             let value = .input[.index + local_index]
             ++local_index
             let digit: i64 = as_saturated(value - b'0')

--- a/selfhost/lexer.jakt
+++ b/selfhost/lexer.jakt
@@ -11,7 +11,7 @@ import compiler { Compiler }
 function is_ascii_alpha(anon c: u8) -> bool => (c >= b'a' and c <= b'z') or (c >= b'A' and c <= b'Z')
 function is_ascii_digit(anon c: u8) -> bool => (c >= b'0' and c <= b'9')
 function is_ascii_hexdigit(anon c: u8) -> bool => (c >= b'0' and c <= b'9') or (c >= b'a' and c <= b'f') or (c >= b'A' and c <= b'F')
-function is_ascii_octdigit(anon c: u8) -> bool => (c >= b'0' and c <= b'8')
+function is_ascii_octdigit(anon c: u8) -> bool => (c >= b'0' and c <= b'7')
 function is_ascii_alphanumeric(anon c: u8) -> bool => is_ascii_alpha(c) or is_ascii_digit(c)
 
 enum Token {

--- a/selfhost/lexer.jakt
+++ b/selfhost/lexer.jakt
@@ -401,8 +401,6 @@ struct Lexer {
 
             if not escaped and .peek() == b'\\' {
                 escaped = true
-            } else {
-                escaped = false
             }
 
             .index++

--- a/selfhost/parser.jakt
+++ b/selfhost/parser.jakt
@@ -2314,12 +2314,16 @@ struct Parser {
             let pattern_start_index = .index
             let patterns = .parse_match_patterns()
 
+            .skip_newlines()
+
             let marker_span = .current().span()
             if .current() is FatArrow {
                 .index++
             } else {
                 .error("Expected ‘=>’", .current().span())
             }
+
+            .skip_newlines()
 
             let body = match .current() {
                 LCurly => ParsedMatchBody::Block(.parse_block())
@@ -2336,6 +2340,8 @@ struct Parser {
             if .current() is Eol or .current() is Comma {
                 .index++
             }
+
+            .skip_newlines()
         }
 
         .skip_newlines()

--- a/src/lexer.rs
+++ b/src/lexer.rs
@@ -775,7 +775,7 @@ fn lex_item(file_id: FileId, bytes: &[u8], index: &mut usize) -> (Token, Option<
             return (
                 Token::unknown(Span::new(file_id, start, *index)),
                 Some(JaktError::ParserError(
-                    "hex number literal cannot end with underscore".to_string(),
+                    "Hexadecimal number literal cannot end with underscore".to_string(),
                     Span::new(file_id, start, *index),
                 )),
             );
@@ -793,7 +793,7 @@ fn lex_item(file_id: FileId, bytes: &[u8], index: &mut usize) -> (Token, Option<
             Err(_) => (
                 Token::unknown(span),
                 Some(JaktError::ParserError(
-                    "could not parse hex number".to_string(),
+                    "Could not parse hexadecimal number".to_string(),
                     span,
                 )),
             ),
@@ -813,7 +813,7 @@ fn lex_item(file_id: FileId, bytes: &[u8], index: &mut usize) -> (Token, Option<
             return (
                 Token::unknown(span),
                 Some(JaktError::ParserError(
-                    "octal number literal cannot end with underscore".to_string(),
+                    "Octal number literal cannot end with underscore".to_string(),
                     Span::new(file_id, start, *index),
                 )),
             );
@@ -823,7 +823,7 @@ fn lex_item(file_id: FileId, bytes: &[u8], index: &mut usize) -> (Token, Option<
             return (
                 Token::unknown(Span::new(file_id, start, *index)),
                 Some(JaktError::ParserError(
-                    "could not parse octal number".to_string(),
+                    "Could not parse octal number".to_string(),
                     Span::new(file_id, start, *index),
                 )),
             );
@@ -862,7 +862,7 @@ fn lex_item(file_id: FileId, bytes: &[u8], index: &mut usize) -> (Token, Option<
             return (
                 Token::unknown(Span::new(file_id, start, *index)),
                 Some(JaktError::ParserError(
-                    "binary number literal cannot end with underscore".to_string(),
+                    "Binary number literal cannot end with underscore".to_string(),
                     Span::new(file_id, start, *index),
                 )),
             );
@@ -872,7 +872,7 @@ fn lex_item(file_id: FileId, bytes: &[u8], index: &mut usize) -> (Token, Option<
             return (
                 Token::unknown(Span::new(file_id, start, *index)),
                 Some(JaktError::ParserError(
-                    "could not parse binary number".to_string(),
+                    "Could not parse binary number".to_string(),
                     Span::new(file_id, start, *index),
                 )),
             );
@@ -891,7 +891,7 @@ fn lex_item(file_id: FileId, bytes: &[u8], index: &mut usize) -> (Token, Option<
             Err(_) => (
                 Token::unknown(span),
                 Some(JaktError::ParserError(
-                    "could not parse binary number".to_string(),
+                    "Could not parse binary number".to_string(),
                     span,
                 )),
             ),

--- a/tests/parser/invalid_digits_in_binary_number.jakt
+++ b/tests/parser/invalid_digits_in_binary_number.jakt
@@ -1,5 +1,5 @@
 /// Expect:
-/// - error: "could not parse binary number"
+/// - error: "Could not parse binary number"
 
 // Binary number must not contain any digits other than 0 or 1
 0b13

--- a/tests/parser/invalid_digits_in_octal_number.jakt
+++ b/tests/parser/invalid_digits_in_octal_number.jakt
@@ -1,5 +1,5 @@
 /// Expect:
-/// - error: "could not parse octal number"
+/// - error: "Could not parse octal number"
 
 // Octal number must not contain any digits other than 0-7
 0o78


### PR DESCRIPTION
This PR makes every test in tests/parser pass :^)

before:
```
==============================
256 passed
78 failed
7 skipped
==============================
```
after:
```
==============================
260 passed
74 failed
7 skipped
==============================
```
