### PR TITLE
main: print better error if c++ compiler not found

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -208,34 +208,40 @@ fn main() -> Result<(), JaktError> {
                             String::from("runtime")
                         };
                         let default_cxx_compiler_path = PathBuf::from("clang++");
-                        let clang_output = Command::new(
-                            arguments
-                                .cxx_compiler_path
-                                .as_ref()
-                                .unwrap_or(&default_cxx_compiler_path),
-                        )
-                        .args([
-                            "-fcolor-diagnostics",
-                            "-std=c++20",
-                            // Don't complain about unsupported -W flags below.
-                            "-Wno-unknown-warning-option",
-                            // Don't complain about accidental trigraphs (e.g "??=")
-                            "-Wno-trigraphs",
-                            // Sometimes our generated C++ has a lot of harmless parentheses.
-                            "-Wno-parentheses-equality",
-                            // These warnings if enabled create loads of unnecessary noise:
-                            "-Wno-unqualified-std-cast-call",
-                            "-Wno-user-defined-literals",
-                            // This warning can happen for functions like fopen which Windows has deprecated but others not.
-                            // Specifically, it will happen if clang uses the MSVC runtime and/or linker.
-                            "-Wno-deprecated-declarations",
-                            "-I",
-                            &runtime_path,
-                            &input_cpp,
-                            "-o",
-                            &output_executable,
-                        ])
-                        .output()?;
+                        let cxx_compiler_path = arguments
+                            .cxx_compiler_path
+                            .as_ref()
+                            .unwrap_or(&default_cxx_compiler_path);
+                        if !cxx_compiler_path.exists() {
+                            eprintln!(
+                                "jakt: error: C++ compiler {:?} not found",
+                                cxx_compiler_path
+                            );
+                            exit(1);
+                        }
+                        let clang_output = Command::new(cxx_compiler_path)
+                            .args([
+                                "-fcolor-diagnostics",
+                                "-std=c++20",
+                                // Don't complain about unsupported -W flags below.
+                                "-Wno-unknown-warning-option",
+                                // Don't complain about accidental trigraphs (e.g "??=")
+                                "-Wno-trigraphs",
+                                // Sometimes our generated C++ has a lot of harmless parentheses.
+                                "-Wno-parentheses-equality",
+                                // These warnings if enabled create loads of unnecessary noise:
+                                "-Wno-unqualified-std-cast-call",
+                                "-Wno-user-defined-literals",
+                                // This warning can happen for functions like fopen which Windows has deprecated but others not.
+                                // Specifically, it will happen if clang uses the MSVC runtime and/or linker.
+                                "-Wno-deprecated-declarations",
+                                "-I",
+                                &runtime_path,
+                                &input_cpp,
+                                "-o",
+                                &output_executable,
+                            ])
+                            .output()?;
                         io::stderr().write_all(&clang_output.stderr)?;
                         if !clang_output.status.success() {
                             std::process::exit(


### PR DESCRIPTION
When getting started with this project, I tried to run `cargo run selfhost/main.jakt` and was presented with the following error:

```
Error: IOError(Os { code: 2, kind: NotFound, message: "No such file or directory" })
```

It turns out, I did not have `clang` installed. This change makes the error a little more helpful.

```
$ ./target/debug/jakt -C foo selfhost/main.jakt

jakt: error: C++ compiler "foo" not found
```