### PR TITLE
selfhost/typechecker: Fix function return typecheck

### DIFF
--- a/selfhost/typechecker.jakt
+++ b/selfhost/typechecker.jakt
@@ -1431,6 +1431,22 @@ struct Typechecker {
         }
     }
 
+    function unify_with_type(mut this, found_type: TypeId, expected_type: TypeId?, span: Span) throws -> TypeId {
+        if expected_type.has_value() {
+            if expected_type!.equals(unknown_type_id()) {
+                return found_type
+            }
+            let generic_inferences: [String:String] = [:]
+            if .check_types_for_compat(lhs_type_id: expected_type!, rhs_type_id: found_type, generic_inferences, span) {
+                return found_type
+            }
+
+            return .substitute_typevars_in_type(type_id: found_type, generic_inferences)
+        } else {
+            return found_type
+        }
+    }
+
     function find_or_add_type_id(mut this, anon type: Type) throws -> TypeId {
         let module = .program.modules[.current_module_id.id]
         let module_id = module.id
@@ -2235,7 +2251,9 @@ struct Typechecker {
         }
 
         for fun in parsed_namespace.functions.iterator() {
+            .current_function_id = .find_function_in_scope(parent_scope_id: scope_id, function_name: fun.name)
             .typecheck_function(parsed_function: fun, parent_scope_id: scope_id)
+            .current_function_id = None
         }
     }
 
@@ -4175,7 +4193,10 @@ struct Typechecker {
         }
         SingleQuotedString(val, span) => CheckedExpression::CharacterConstant(val, span)
         SingleQuotedByteString(val, span) => CheckedExpression::ByteConstant(val, span)
-        QuotedString(val, span) => CheckedExpression::QuotedString(val, span)
+        QuotedString(val, span) => {
+            .unify_with_type(found_type: builtin(BuiltinType::String), expected_type: type_hint, rhs_span: span)
+            yield CheckedExpression::QuotedString(val, span)
+        }
         Call(call, span) => {
             let none_expr: CheckedExpression? = None
             let parent_id: StructOrEnumId? = None


### PR DESCRIPTION
This fix some bugs on function return type typeckecking and adds a PASS for the following tests:

**tests/typechecker/return_value_type_mismatch.jakt
tests/typechecker/function_return_type_with_fat_arrow.jakt**

Previously, when going through the typechecking namespaces declaration, the current_function_id was not being updated so the typechecker didn't got the return type hint correctly.

Also, in order for this to work correctly I created the function unify_with_type based on the same function on the Rust compiler. This function properly check for type compatibility.

There is a unify function that just compares type_id's and is being used on several places as a placeholder. We should probably start replacing it for the new one.


Before:
273 passed
60 failed
7 skipped

After
275 passed
58 failed
7 skipped
