### PR TITLE
selfhost/typechecker+codegen: Add enum methods

### DIFF
--- a/selfhost/codegen.jakt
+++ b/selfhost/codegen.jakt
@@ -986,7 +986,17 @@ struct CodeGenerator {
 
         output += .codegen_enum_debug_description_getter(enum_)
 
-        // FIXME: scope functions
+        let enum_scope = .program.get_scope(enum_.scope_id)
+        for function_item in enum_scope.functions.iterator() {
+            let function_ = .program.get_function(function_item.1)
+            if not function_.type is ImplicitEnumConstructor {
+                if enum_.generic_parameters.is_empty() {
+                    output += .codegen_function_predecl(function_)
+                } else {
+                    output += .codegen_function(function_)
+                }
+            }
+        }
 
         output += "};\n"
 

--- a/selfhost/codegen.jakt
+++ b/selfhost/codegen.jakt
@@ -1547,6 +1547,11 @@ struct CodeGenerator {
         mut output = ""
         output += .control_flow_state.choose_control_flow_macro()
 
+        mut needs_deref = enum_.is_boxed
+        if .codegen_expression(expr) == "this" {
+            needs_deref = true
+        }
+
         if enum_.underlying_type_id.equals(unknown_type_id()) {
             output += "(([&]() -> JaktInternal::ExplicitValueOrControlFlow<"
             output += .codegen_type(type_id)
@@ -1555,7 +1560,7 @@ struct CodeGenerator {
             output += ">{\n"
             output += "auto&& __jakt_match_variant_maybe_deref = " + .codegen_expression(expr) + ";"
             output += "auto&& __jakt_match_variant = "
-            if enum_.is_boxed {
+            if needs_deref {
                 output += "*"
             }
             output += "__jakt_match_variant_maybe_deref;\nswitch(__jakt_match_variant.index()) {\n"

--- a/selfhost/typechecker.jakt
+++ b/selfhost/typechecker.jakt
@@ -2495,6 +2495,13 @@ struct Typechecker {
             }
             else => {}
         }
+
+        for method in record.methods.iterator() {
+            .typecheck_method(
+                func: method.parsed_function
+                parent_id: StructOrEnumId::Enum(enum_id)
+            )
+        }
     }
 
     function cast_to_underlying(mut this, anon expr: ParsedExpression, scope_id: ScopeId, parsed_type: ParsedType) throws -> CheckedExpression {
@@ -2589,8 +2596,11 @@ struct Typechecker {
                 scope_id = structure.scope_id
                 definition_linkage = structure.definition_linkage
             }
-            Enum => {
-                todo("typecheck_method implement enum case")
+            Enum(enum_id) => {
+                let enum_ = .get_enum(enum_id)
+                definition_linkage = enum_.definition_linkage
+                scope_id = enum_.scope_id
+                parent_generic_parameters = enum_.generic_parameters
             }
         }
 

--- a/selfhost/typechecker.jakt
+++ b/selfhost/typechecker.jakt
@@ -2024,6 +2024,23 @@ struct Typechecker {
                 id: .current_module().functions.size() - 1
             )
 
+            for param in func.params.iterator() {
+                if param.variable.name == "this" {
+                    let checked_variable = CheckedVariable(
+                        name: param.variable.name
+                        type_id: enum_type_id
+                        is_mutable: param.variable.is_mutable
+                        definition_span: param.variable.span
+                        visibility: Visibility::Public
+                    )
+
+                    checked_function.params.push(CheckedParameter(
+                        requires_label: param.requires_label
+                        variable: checked_variable
+                    ))
+                }
+            }
+
             .add_function_to_scope(
                 parent_scope_id: enum_scope_id
                 name: func.name

--- a/selfhost/typechecker.jakt
+++ b/selfhost/typechecker.jakt
@@ -1941,6 +1941,8 @@ struct Typechecker {
 
         .add_enum_to_scope(scope_id, name: parsed_record.name, enum_id, span: parsed_record.name_span)
 
+        let is_extern = parsed_record.definition_linkage is External
+
         let underlying_type_id = match parsed_record.record_type {
             ValueEnum(underlying_type) => .typecheck_typename(parsed_type: underlying_type, scope_id, ignore_errors: false)
             else => builtin(BuiltinType::Void)
@@ -1978,6 +1980,56 @@ struct Typechecker {
             generic_parameters.push(parameter_type_id)
 
             .add_type_to_scope(scope_id: enum_scope_id, type_name: gen_parameter.name, type_id: parameter_type_id, span: gen_parameter.span)
+        }
+
+        for method in parsed_record.methods.iterator() {
+            let func = method.parsed_function
+            let method_scope_id = .create_scope(
+                parent_scope_id: enum_scope_id
+                can_throw: func.can_throw
+                debug_name: format("method({}::{})", parsed_record.name, func.name)
+            )
+            let block_scope_id = .create_scope(
+                parent_scope_id: method_scope_id
+                can_throw: func.can_throw
+                debug_name: format("method-block({}::{})", parsed_record.name, func.name)
+            )
+            let is_generic = not parsed_record.generic_parameters.is_empty() or not func.generic_parameters.is_empty()
+
+            mut checked_function = CheckedFunction(
+                name: func.name
+                name_span: func.name_span
+                visibility: method.visibility
+                return_type_id: unknown_type_id()
+                params: []
+                generic_params: []
+                block: CheckedBlock(
+                    statements: []
+                    scope_id: block_scope_id
+                    definitely_returns: false
+                    yielded_type: TypeId::none()
+                )
+                can_throw: func.can_throw
+                type: func.type
+                linkage: func.linkage
+                function_scope_id: method_scope_id
+                is_instantiated: not is_generic or is_extern
+                parsed_function: func
+            )
+
+            module.functions.push(checked_function)
+
+            let function_id = FunctionId(
+                module: .current_module_id
+                id: .current_module().functions.size() - 1
+            )
+
+            .add_function_to_scope(
+                parent_scope_id: enum_scope_id
+                name: func.name
+                function_id
+                span: parsed_record.name_span
+            )
         }
     }
 


### PR DESCRIPTION
Add enum methods and make `samples/enum/methods.jakt` pass