### PR TITLE
selfhost/typecheker: Change error text to match test

### DIFF
--- a/selfhost/typechecker.jakt
+++ b/selfhost/typechecker.jakt
@@ -4401,7 +4401,7 @@ struct Typechecker {
                                             }
                                         }
                                         if not exists {
-                                            .error(format("Enum variant '{}' does not exist on '{}'", name, .type_name(expr_type_id)), span)
+                                            .error(format("Enum variant {} does not exist on {}", name, .type_name(expr_type_id)), span)
                                         }
                                     }
                                     else => {


### PR DESCRIPTION
This adds a PASS on the test: /tests/typechecker/enum_is_variant_nonexistent.jakt by just changing the error text to match that of the test.