### PR TITLE
selfhost/typecheker: Adjust error to match test

### DIFF
--- a/selfhost/typechecker.jakt
+++ b/selfhost/typechecker.jakt
@@ -4185,8 +4185,7 @@ struct Typechecker {
             Type::GenericInstance(id) => id
             Type::Struct(struct_id) => struct_id
             else => {
-                .compiler.panic(format("typecheck_indexed_struct: {}", checked_expr_type))
-                // FIXME: This is unreachable
+                .error(format("Member field access on value of non-struct type ‘{}’", .type_name(checked_expr_type_id)), span)
                 yield StructId(module: ModuleId(id: 0), id: 0)
             }
         }


### PR DESCRIPTION
This adds a pass for the test tests/typechecker/field_access_on_enum.jakt
It adjust the error emited from a panic to a .error with a matching message to the test