### PR TITLE
builtins/Dictionary: Use `Array<K>::create_empty()` in `Dictionary::keys()` method

### DIFF
--- a/runtime/Builtins/Dictionary.h
+++ b/runtime/Builtins/Dictionary.h
@@ -69,7 +69,7 @@ public:
 
     ErrorOr<Array<K>> keys() const
     {
-        Array<K> keys;
+        Array<K> keys = TRY(Array<K>::create_empty());
         TRY(keys.ensure_capacity(m_storage->map.size()));
         for (auto& it : m_storage->map) {
             MUST(keys.push(it.key));


### PR DESCRIPTION
Array<K> has no default constructor, instead you have to use
Array<K>::create_empty which returns an error.
