### PR TITLE
selfhost/typechecker: Adjust error to match test

### DIFF
--- a/selfhost/typechecker.jakt
+++ b/selfhost/typechecker.jakt
@@ -3948,7 +3948,7 @@ struct Typechecker {
 
         let checked_block = .typecheck_block(then_block, parent_scope_id: scope_id, safety_mode)
         if checked_block.yielded_type.has_value() {
-            .error("An ‘if’ block is not allowed to yield values", then_block.find_yield_span()!)
+            .error("An 'if' block is not allowed to yield values", then_block.find_yield_span()!)
         }
 
         mut checked_else: CheckedStatement? = None

--- a/src/typechecker.rs
+++ b/src/typechecker.rs
@@ -4094,7 +4094,7 @@ pub fn typecheck_statement(
             error = error.or(err);
             if checked_block.yielded_type.is_some() {
                 error = error.or(Some(JaktError::TypecheckError(
-                    "an 'if' block is not allowed to yield values".to_string(),
+                    "An 'if' block is not allowed to yield values".to_string(),
                     find_yield_span_in_block(block)
                         .expect("must have a yield if the block yields values"),
                 )))

--- a/tests/typechecker/block_yield_unobservable_if.jakt
+++ b/tests/typechecker/block_yield_unobservable_if.jakt
@@ -1,5 +1,5 @@
 /// Expect:
-/// - error: "an 'if' block is not allowed to yield values"
+/// - error: "An 'if' block is not allowed to yield values"
 
 function main() {
     if true {


### PR DESCRIPTION
This adds a pass for the test /tests/typechecker/block_yield_unobservable_if.jakt

I also changed the test and the rust typechecker to add error capitalization