### PR TITLE
selhost: Some more generics

### DIFF
--- a/selfhost/codegen.jakt
+++ b/selfhost/codegen.jakt
@@ -2043,6 +2043,32 @@ struct CodeGenerator {
                     }
                 }
 
+                let type = .program.get_type(call.return_type)
+
+                let generic_parameters = match type {
+                    GenericInstance(args) => args
+                    GenericEnumInstance(args) => args
+                    GenericResolvedType(args) => args
+                    else => []
+                }
+
+                if not generic_parameters.is_empty() {
+                    output += "<"
+
+                    mut first = true
+                    for gen_param in generic_parameters.iterator() {
+                        if not first {
+                            output += ", "
+                        } else {
+                            first = false
+                        }
+
+                        output += .codegen_type_possibly_as_namespace(type_id: gen_param, as_namespace: true)
+                    }
+
+                    output += ">"
+                }
+
                 output += "("
 
                 mut first = true

--- a/selfhost/codegen.jakt
+++ b/selfhost/codegen.jakt
@@ -1975,7 +1975,27 @@ struct CodeGenerator {
                                 }
                             }
                             GenericInstance(id, args) => {
-                                todo("Implement codegen for constructor call to GenericInstance")
+                                let struct_ = .program.get_struct(id)
+                                if struct_.record_type is Class {
+                                    output += .codegen_namespace_qualifier(scope_id: struct_.scope_id)
+                                    output += struct_.name
+                                    output += "<"
+
+                                    mut first = true
+                                    for arg in args.iterator() {
+                                        if not first {
+                                            output += ", "
+                                        } else {
+                                            first = false
+                                        }
+
+                                        output += .codegen_type(arg)
+                                    }
+
+                                    output += ">::create"
+                                } else {
+                                    output += call.name
+                                }
                             }
                             else => {
                                 panic("Should be unreachable")

--- a/selfhost/typechecker.jakt
+++ b/selfhost/typechecker.jakt
@@ -2863,13 +2863,11 @@ struct Typechecker {
         let function_linkage = checked_function.linkage
 
         mut param_vars: [CheckedVariable] = []
-
+        mut module = .current_module()
         for param in checked_function.params.iterator() {
-            param_vars.push(param.variable)
-        }
+            let variable = param.variable
+            param_vars.push(variable)
 
-        for variable in param_vars.iterator() {
-            mut module = .current_module()
             let var_id = module.add_variable(variable)
             .add_var_to_scope(scope_id: function_scope_id, name: variable.name, var_id, span: variable.definition_span)
         }

--- a/selfhost/typechecker.jakt
+++ b/selfhost/typechecker.jakt
@@ -4003,9 +4003,12 @@ struct Typechecker {
                     if not lhs_type_id.equals(rhs_type_id) and not args[0].equals(rhs_type_id) and not rhs_type_id.equals(unknown_type_id()) {
                         .error(format("Type mismatch: expected ‘{}’, but got ‘{}’", .type_name(lhs_type_id), .type_name(rhs_type_id)), .expression_span(checked_expr))
                     }
-                }
-                if id.equals(optional_struct_id) {
+                } else if id.equals(optional_struct_id) {
                     if not lhs_type_id.equals(rhs_type_id) and not args[0].equals(rhs_type_id) and not rhs_type_id.equals(unknown_type_id()) {
+                        .error(format("Type mismatch: expected ‘{}’, but got ‘{}’", .type_name(lhs_type_id), .type_name(rhs_type_id)), .expression_span(checked_expr))
+                    }
+                } else {
+                    if not lhs_type_id.equals(rhs_type_id) and not rhs_type_id.equals(unknown_type_id()) {
                         .error(format("Type mismatch: expected ‘{}’, but got ‘{}’", .type_name(lhs_type_id), .type_name(rhs_type_id)), .expression_span(checked_expr))
                     }
                 }
@@ -4026,6 +4029,10 @@ struct Typechecker {
                     if not (.is_numeric(lhs_type_id) and is_rhs_zero) and (.is_integer(lhs_type_id) ^ .is_integer(rhs_type_id)) {
                         .error(format("Type mismatch: expected ‘{}’, but got ‘{}’", .type_name(lhs_type_id), .type_name(rhs_type_id)), .expression_span(checked_expr))
                         return CheckedStatement::Garbage(span)
+                    }
+                } else {
+                    if not lhs_type_id.equals(rhs_type_id) and not rhs_type_id.equals(unknown_type_id()) {
+                        .error(format("Type mismatch: expected ‘{}’, but got ‘{}’", .type_name(lhs_type_id), .type_name(rhs_type_id)), .expression_span(checked_expr))
                     }
                 }
             }

--- a/selfhost/typechecker.jakt
+++ b/selfhost/typechecker.jakt
@@ -2846,10 +2846,6 @@ struct Typechecker {
     }
 
     function typecheck_function(mut this, parsed_function: ParsedFunction, parent_scope_id: ScopeId) throws {
-        if not parsed_function.generic_parameters.is_empty() and not parsed_function.must_instantiate {
-            return
-        } 
-
         // FIXME: Optional.expect("...") would be nicer here.
         let function_id = .find_function_in_scope(parent_scope_id, function_name: parsed_function.name)
         if not function_id.has_value() {

--- a/selfhost/typechecker.jakt
+++ b/selfhost/typechecker.jakt
@@ -439,6 +439,11 @@ struct CheckedParameter {
 enum FunctionGenericParameter {
     InferenceGuide(TypeId)
     Parameter(TypeId)
+
+    function type_id(this) => match this {
+        InferenceGuide(id) => id
+        Parameter(id) => id
+    }
 }
 
 struct CheckedVariable {

--- a/selfhost/typechecker.jakt
+++ b/selfhost/typechecker.jakt
@@ -2716,6 +2716,11 @@ struct Typechecker {
         let function_id = current_module.add_function(checked_function)
         let checked_function_scope_id = checked_function.function_scope_id
 
+        let external_linkage = match parsed_function.linkage {
+            FunctionLinkage::External => true
+            else => false
+        }
+
         // Check generic parameters
         for generic_parameter in parsed_function.generic_parameters.iterator() {
 
@@ -2727,10 +2732,6 @@ struct Typechecker {
             )
             checked_function.generic_params.push(FunctionGenericParameter::Parameter(type_var_type_id))
 
-            let external_linkage = match parsed_function.linkage {
-                FunctionLinkage::External => true
-                else => false
-            }
             if not parsed_function.must_instantiate or external_linkage {
                 .add_type_to_scope(
                     scope_id: checked_function_scope_id


### PR DESCRIPTION
before:
```
==============================
286 passed
48 failed
7 skipped
==============================
```
after:
```
==============================
292 passed
42 failed
7 skipped
==============================
```
We now pass the following additional tests:
* `samples/generics/generic_fun2.jakt`
* `samples/generics/generic_fun3.jakt`
* `samples/generics/generic_fun4.jakt`
* `samples/generics/generic_struct.jakt`
* `samples/generics/generic_struct_mismatch.jakt`
* `samples/generics/generic_types.jakt`

The following two generic tests still fail and will need work on type unification to function properly.
* `tests/typechecker/generic_late_type_check_bad.jakt`
* `tests/typechecker/generic_late_type_check.jakt`