### PR TITLE
selhost/typechecker: Fix error message to match test

### DIFF
--- a/selfhost/typechecker.jakt
+++ b/selfhost/typechecker.jakt
@@ -4609,7 +4609,7 @@ struct Typechecker {
                     yield match .compiler.errors.is_empty() {
                         true => CheckedExpression::Call(call: checked_call, span, type_id)
                         else => {
-                            .error(format("Variable {} not found", name), span)
+                            .error(format("Variable '{}' not found", name), span)
                             yield CheckedExpression::NamespacedVar(
                                 namespaces: checked_namespaces,
                                 var: CheckedVariable(

--- a/src/typechecker.rs
+++ b/src/typechecker.rs
@@ -4619,7 +4619,7 @@ pub fn typecheck_expression(
                         *span,
                     ),
                     Some(JaktError::TypecheckErrorWithHint(
-                        format!("variable '{}' not found", v),
+                        format!("Variable '{}' not found", v),
                         *span,
                         format!("Did you mean '{}'?", most_similar_var),
                         *span,
@@ -4639,7 +4639,7 @@ pub fn typecheck_expression(
                         *span,
                     ),
                     Some(JaktError::TypecheckError(
-                        format!("variable '{}' not found", v),
+                        format!("Variable '{}' not found", v),
                         *span,
                     )),
                 )
@@ -4722,7 +4722,7 @@ pub fn typecheck_expression(
                                     *span,
                                 ),
                                 Some(JaktError::TypecheckError(
-                                    format!("variable '{}' not found", v),
+                                    format!("Variable '{}' not found", v),
                                     *span,
                                 )),
                             )

--- a/tests/typechecker/bad_simple_enum_constructor.jakt
+++ b/tests/typechecker/bad_simple_enum_constructor.jakt
@@ -1,5 +1,5 @@
 /// Expect:
-/// - error: "variable 'B' not found"
+/// - error: "Variable 'B' not found"
 
 enum E {
     A


### PR DESCRIPTION
This adds a PASS for the test/typechecker/bad_simple_enum_constructor.jakt

I also changed the error message and the rust compiler to add error capitalization