### PR TITLE
editors/vscode: Fix npm install

### DIFF
--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -76,7 +76,7 @@
 		"esbuild": "npm run esbuild-base -- --sourcemap --minify",
 		"compile": "npm run esbuild",
 		"install-code-dep": "code --install-extension connor4312.esbuild-problem-matchers && code --install-extension dbaeumer.vscode-eslint",
-		"install": "cd server; npm install; cd ../client; npm install; cd ..; npm run install-code-dep",
+		"install": "cd server && npm install && cd ../client && npm install && cd .. && npm run install-code-dep",
 		"watch": "npm run esbuild-base -- --sourcemap --watch",
 		"lint": "npx eslint ./client/src ./server/src --ext .ts,.tsx",
 		"test": "sh ./scripts/e2e.sh"


### PR DESCRIPTION
Change the script used in npm install for the vscode extension so as to
use && instead of ; as separators for the commands. Perhaps ; works on linux
(it doesn't on windows) but apparently semicolons as separators means
the commands that come after will be executed regardless of whether the
previous one failed or not, which doesn't seem correct either.