### PR TITLE
selfhost/parser+typechecker: Pointers

### DIFF
--- a/samples/pointers/bad_pointer_deref.jakt
+++ b/samples/pointers/bad_pointer_deref.jakt
@@ -1,5 +1,5 @@
 /// Expect:
-/// - error: "dereference of a non-pointer value"
+/// - error: "Dereference of a non-pointer value"
 
 function main() {
     let x = 4

--- a/samples/pointers/bad_raw_ptr.jakt
+++ b/samples/pointers/bad_raw_ptr.jakt
@@ -1,5 +1,5 @@
 /// Expect:
-/// - error: "dereference of raw pointer outside of unsafe block"
+/// - error: "Dereference of raw pointer outside of unsafe block"
 
 function main() {
     let x = 10

--- a/selfhost/parser.jakt
+++ b/selfhost/parser.jakt
@@ -2057,12 +2057,20 @@ struct Parser {
             yield .parse_set_literal()
         }
         Ampersand => .parse_ampersand()
+        Asterisk => .parse_asterisk()
         else => {
             let span = .current().span()
             .index++
             .error("Unsupported expression", span)
             yield ParsedExpression::Garbage(span)
         }
+    }
+
+    function parse_asterisk(mut this) throws -> ParsedExpression {
+        let start = .current().span()
+        .index++
+        let expr = .parse_operand()
+        return ParsedExpression::UnaryOp(expr, op: UnaryOperator::Dereference, span: merge_spans(start, .current().span()))
     }
 
     function parse_ampersand(mut this) throws -> ParsedExpression {

--- a/selfhost/parser.jakt
+++ b/selfhost/parser.jakt
@@ -2056,12 +2056,25 @@ struct Parser {
         LCurly => {
             yield .parse_set_literal()
         }
+        Ampersand => .parse_ampersand()
         else => {
             let span = .current().span()
             .index++
             .error("Unsupported expression", span)
             yield ParsedExpression::Garbage(span)
         }
+    }
+
+    function parse_ampersand(mut this) throws -> ParsedExpression {
+        let start = .current().span()
+        .index++
+        if .current() is Raw {
+            .index++
+            let expr = .parse_operand()
+            return ParsedExpression::UnaryOp(expr, op: UnaryOperator::RawAddress, span: merge_spans(start, expr.span()))
+        }
+        .error("Ampersand not currently supported", start)
+        return ParsedExpression::Garbage(.current().span())
     }
 
     function parse_set_literal(mut this) throws -> ParsedExpression {

--- a/selfhost/typechecker.jakt
+++ b/selfhost/typechecker.jakt
@@ -3602,6 +3602,9 @@ struct Typechecker {
             Is | IsEnumVariant => {
                 return CheckedExpression::UnaryOp(expr: checked_expr, op: checked_op, span, type_id: builtin(BuiltinType::Bool))
             }
+            RawAddress => {
+                return CheckedExpression::UnaryOp(expr: checked_expr, op: checked_op, span, type_id: .find_or_add_type_id(Type::RawPtr(expr_type_id)))
+            }
             else => {
                 todo(format("typecheck_unary_operation: expr:{}, op:{}", checked_expr, checked_op))
             }

--- a/selfhost/typechecker.jakt
+++ b/selfhost/typechecker.jakt
@@ -3605,8 +3605,18 @@ struct Typechecker {
             RawAddress => {
                 return CheckedExpression::UnaryOp(expr: checked_expr, op: checked_op, span, type_id: .find_or_add_type_id(Type::RawPtr(expr_type_id)))
             }
-            else => {
-                todo(format("typecheck_unary_operation: expr:{}, op:{}", checked_expr, checked_op))
+            Dereference => {
+                match expr_type {
+                    RawPtr(type_id) => {
+                        if safety_mode is Safe {
+                            .error("Dereference of raw pointer outside of unsafe block", span)
+                        }
+                        return CheckedExpression::UnaryOp(expr: checked_expr, op: checked_op, span, type_id)
+                    }
+                    else => {
+                        .error("Dereference of a non-pointer value", span)
+                    }
+                }
             }
         }
         return CheckedExpression::UnaryOp(expr: checked_expr, op: checked_op, span, type_id: expr_type_id)

--- a/src/typechecker.rs
+++ b/src/typechecker.rs
@@ -6112,7 +6112,7 @@ pub fn typecheck_unary_operation(
                     (
                         CheckedExpression::UnaryOp(Box::new(expr), op, span, *x),
                         Some(JaktError::TypecheckError(
-                            "dereference of raw pointer outside of unsafe block".to_string(),
+                            "Dereference of raw pointer outside of unsafe block".to_string(),
                             span,
                         )),
                     )
@@ -6121,7 +6121,7 @@ pub fn typecheck_unary_operation(
             _ => (
                 CheckedExpression::UnaryOp(Box::new(expr), op, span, UNKNOWN_TYPE_ID),
                 Some(JaktError::TypecheckError(
-                    "dereference of a non-pointer value".to_string(),
+                    "Dereference of a non-pointer value".to_string(),
                     span,
                 )),
             ),


### PR DESCRIPTION
This change marks the last of the unary operations left to check.

passes all the pointers tests

```
[ PASS ] samples/pointers/raw_ptr.jakt
[ PASS ] samples/pointers/bad_raw_ptr.jakt
[ PASS ] samples/pointers/bad_pointer_deref.jakt
```