### PR TITLE
selfhost/codegen+typecheck: Add support for eprint

### DIFF
--- a/selfhost/codegen.jakt
+++ b/selfhost/codegen.jakt
@@ -1924,10 +1924,11 @@ struct CodeGenerator {
             output += "TRY("
         }
         match call.name {
-            "print" | "println" | "eprintln" | "format" => {
+            "print" | "println" | "eprintln" | "eprint" | "format" => {
                 let helper = match call.name {
                     "print" => "out"
                     "println" => "outln"
+                    "eprint" => "warn"
                     "eprintln" => "warnln"
                     "format" => "String::formatted"
                     else => ""

--- a/selfhost/typechecker.jakt
+++ b/selfhost/typechecker.jakt
@@ -5478,7 +5478,7 @@ struct Typechecker {
         }
 
         match call.name {
-            "print" | "println" | "eprintln" | "format" => {
+            "print" | "println" | "eprintln" | "eprint" | "format" => {
                 let none_type_hint: TypeId? = None
                 for arg in call.args.iterator() {
                     let checked_arg = .typecheck_expression(expr: arg.2, scope_id: caller_scope_id, safety_mode, type_hint: none_type_hint)


### PR DESCRIPTION
Adds support for `eprint` to codegen+typecheck.

We'll need this for selfhost compiling selfhost.