### PR TITLE
selfhost/typecheck: Don't add variable in enum variant

### DIFF
--- a/selfhost/typechecker.jakt
+++ b/selfhost/typechecker.jakt
@@ -2470,7 +2470,6 @@ struct Typechecker {
 
                             mut module = .current_module()
                             let var_id = module.add_variable(checked_var)
-                            .add_var_to_scope(scope_id: enum_.scope_id, name: checked_var.name, var_id, span: checked_var.definition_span)
                             fields.push(var_id)
                         }
                         enum_.variants.push(CheckedEnumVariant::StructLike(name: variant.name, fields, span: variant.span))


### PR DESCRIPTION
Align with what the Rust compiler does but not adding a variable when we see a struct-like enum variant's fields.