### PR TITLE
jakttest: Run test binaries with their CWD set to their parent directory

### DIFF
--- a/jakttest/run-one.sh
+++ b/jakttest/run-one.sh
@@ -7,8 +7,12 @@
 
 set -e
 
-temp_dir=$1
+# Since we're running the output binary from a different
+# working directory, we need the full path of the binary.
+temp_dir=$(realpath $1)
 file=$2
+
+file_cwd=$(dirname $file)
 
 # Generate C++ code into 
 build/main $2 > $temp_dir/output.cpp
@@ -26,5 +30,7 @@ clang++ -fcolor-diagnostics \
     -o $temp_dir/output \
     $temp_dir/output.cpp
 
+pushd $file_cwd >/dev/null 2>/dev/null
 # Run
 $temp_dir/output
+popd >/dev/null 2>/dev/null


### PR DESCRIPTION
Looks like tests/main.rs runs tests binaries this way. Makes
samples/apps/read_all.jakt pass.

Before:
```
==============================
321 passed
16 failed
3 skipped
==============================
```

After:
```
==============================
322 passed
15 failed
3 skipped
==============================
```
Diff:
```
samples/apps/read_all.jakt PASS (previously FAIL)
```