### PR TITLE
runtime: Use the correct data types in Jakt::bitap_bitwise()

### DIFF
--- a/runtime/Jakt/MemMem.h
+++ b/runtime/Jakt/MemMem.h
@@ -18,10 +18,10 @@ constexpr void const* bitap_bitwise(void const* haystack, size_t haystack_length
 {
     VERIFY(needle_length < 32);
 
-    u64 lookup = 0xfffffffe;
+    u32 lookup = 0xfffffffe;
 
     constexpr size_t mask_length = (size_t)((u8)-1) + 1;
-    u64 needle_mask[mask_length];
+    u32 needle_mask[mask_length];
 
     for (size_t i = 0; i < mask_length; ++i)
         needle_mask[i] = 0xffffffff;


### PR DESCRIPTION
Port of https://github.com/SerenityOS/serenity/pull/14580.
Fixes String::contains().

cc @jntrnr - your boog report :P