### PR TITLE
jakttest: Remove run-all.sh from Jakttest

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,7 +75,7 @@ jobs:
           toolchain: ${{ matrix.rust }}
           override: true
       - name: Test Jakt Selfhost
-        run: ./jakttest/run-all.sh
+        run: ninja -C jakttest && ./jakttest/build/jakttest
   clippy:
     strategy:
       fail-fast: true

--- a/jakttest/build.ninja
+++ b/jakttest/build.ninja
@@ -22,6 +22,6 @@ build build: mkdir
 # NOTE: pipe `|` is for implicit dependencies, so that ninja considers the target outdated if any
 # of those have changed, even if it's not stated as an input.
 build build/jakttest.cpp: jakttest | jakttest.jakt utility.jakt parser.jakt lexer.jakt error.jakt
-build build/jakttest: cxx build/jakttest-patched.cpp process.cpp fs.cpp | process.h fs.h
+build build/jakttest: cxx build/jakttest-patched.cpp process.cpp fs.cpp os.cpp | process.h fs.h os.h
 build build/jakttest-patched.cpp: patch-includes build/jakttest.cpp | patch-includes.py
 default build/jakttest

--- a/jakttest/build.ninja
+++ b/jakttest/build.ninja
@@ -2,7 +2,7 @@
 # Copyright (c) 2022, Jesús Lapastora <cyber.gsuscode@gmail.com>
 #
 # SPDX-License-Identifier: BSD-2-Clause
-cxxflags = -fcolor-diagnostics -std=c++20 -Wno-user-defined-literals -Wno-deprecated-declarations -Wno-parentheses-equality -Wno-unqualified-std-cast-call
+cxxflags = -fcolor-diagnostics -std=c++20 -Wno-user-defined-literals -Wno-deprecated-declarations -Wno-parentheses-equality -Wno-unqualified-std-cast-call -Wno-unknown-warning-option
 
 rule cxx
     command = clang++ $cxxflags -o $out -I ../runtime $in 

--- a/jakttest/fs.cpp
+++ b/jakttest/fs.cpp
@@ -1,3 +1,6 @@
+// Copyright (c) 2022, Jesús Lapastora <cyber.gsuscode@gmail.com>
+//
+// SPDX-License-Identifier: BSD-2-Clause
 #include "fs.h"
 #include <Jakt/RefPtr.h>
 #include <Jakt/String.h>

--- a/jakttest/fs.cpp
+++ b/jakttest/fs.cpp
@@ -1,5 +1,7 @@
 #include "fs.h"
+#include <Jakt/RefPtr.h>
 #include <Jakt/String.h>
+#include <Jakt/StringBuilder.h>
 #include <fcntl.h>
 #include <sys/stat.h>
 
@@ -9,5 +11,51 @@ ErrorOr<void> mkdir(String path)
     if (::mkdir(path.c_string(), S_IRWXU) == -1)
         return Error::from_errno(errno);
     return ErrorOr<void> {};
+}
+
+ErrorOr<Optional<String>> DirectoryIterator::next()
+{
+    if (m_dirfd == NULL) {
+        return JaktInternal::NullOptional {};
+    }
+    auto const next_dir = readdir(m_dirfd);
+    if (next_dir == NULL) {
+        closedir(m_dirfd);
+        m_dirfd = NULL;
+        return JaktInternal::NullOptional {};
+    }
+    auto builder = TRY(StringBuilder::create());
+    TRY(builder.append_c_string(next_dir->d_name));
+    return Optional<String>(TRY(builder.to_string()));
+}
+DirectoryIterator::~DirectoryIterator()
+{
+    if (m_dirfd != NULL) {
+        closedir(m_dirfd);
+        m_dirfd = NULL;
+    }
+}
+
+ErrorOr<NonnullRefPtr<DirectoryIterator>> DirectoryIterator::from_raw_dirfd(DIR* dirfd)
+{
+    return adopt_nonnull_ref_or_enomem(new (nothrow) DirectoryIterator(dirfd));
+}
+
+ErrorOr<NonnullRefPtr<DirectoryIterator>> list_directory(String path)
+{
+    auto const dirfd = opendir(path.c_string());
+    if (dirfd == NULL) {
+        return Error::from_errno(errno);
+    }
+    return DirectoryIterator::from_raw_dirfd(dirfd);
+}
+
+ErrorOr<bool> is_directory(String path)
+{
+    struct stat st;
+    if (stat(path.c_string(), &st) < 0) {
+        return Error::from_errno(errno);
+    }
+    return S_ISDIR(st.st_mode);
 }
 }

--- a/jakttest/fs.cpp
+++ b/jakttest/fs.cpp
@@ -80,10 +80,6 @@ ErrorOr<Optional<StatResults>> stat_silencing_enoent(String path)
         }
         return Error::from_errno(errno);
     }
-    return Optional<StatResults>(StatResults(
-        /* modified_time */ st.st_atim.tv_sec,
-        /* is_executable */ (st.st_mode & S_IXUSR) != 0,
-        /* is_regular_file */ S_ISREG(st.st_mode),
-        /* exists */ true));
+    return Optional<StatResults>(StatResults(st.st_atim.tv_sec, st.st_mode));
 }
 }

--- a/jakttest/fs.cpp
+++ b/jakttest/fs.cpp
@@ -58,4 +58,25 @@ ErrorOr<bool> is_directory(String path)
     }
     return S_ISDIR(st.st_mode);
 }
+
+ErrorOr<void> mkdir(String path)
+{
+    int const result = ::mkdir(path.c_string(), S_IRWXU);
+    if (result == -1 && errno != EEXIST)
+        return Error::from_errno(errno);
+    return ErrorOr<void> {};
+}
+
+ErrorOr<void> rmdir(String path)
+{
+    if (::rmdir(path.c_string()) == -1)
+        return Error::from_errno(errno);
+    return ErrorOr<void> {};
+}
+ErrorOr<void> unlink(String path)
+{
+    if (::unlink(path.c_string()) == -1)
+        return Error::from_errno(errno);
+    return ErrorOr<void> {};
+}
 }

--- a/jakttest/fs.h
+++ b/jakttest/fs.h
@@ -27,4 +27,25 @@ ErrorOr<bool> is_directory(String path);
 ErrorOr<void> mkdir(String path);
 ErrorOr<void> rmdir(String path);
 ErrorOr<void> unlink(String path);
+
+class StatResults {
+    size_t m_modified_time;
+    bool m_is_executable;
+    bool m_is_regular_file;
+    bool m_exists;
+
+public:
+    constexpr StatResults(size_t modified_time, bool is_executable, bool is_regular_file, bool exists)
+        : m_modified_time(modified_time)
+        , m_is_executable(is_executable)
+        , m_is_regular_file(is_regular_file)
+        , m_exists(exists)
+    {
+    }
+    constexpr size_t modified_time() const { return m_modified_time; }
+    constexpr size_t is_executable() const { return m_is_executable; }
+    constexpr size_t is_regular_file() const { return m_is_regular_file; }
+    constexpr size_t exists() const { return m_exists; }
+};
+ErrorOr<Optional<StatResults>> stat_silencing_enoent(String path);
 }

--- a/jakttest/fs.h
+++ b/jakttest/fs.h
@@ -1,5 +1,27 @@
 #include <Jakt/Forward.h>
+#include <Jakt/String.h>
+#include <dirent.h>
 
 namespace Jakt::fs {
 ErrorOr<void> mkdir(String path);
+
+class DirectoryIterator : public RefCounted<DirectoryIterator> {
+    DIR* m_dirfd;
+    constexpr DirectoryIterator(DIR* dirfd)
+        : m_dirfd(dirfd)
+    {
+    }
+
+public:
+    static ErrorOr<NonnullRefPtr<DirectoryIterator>> from_raw_dirfd(DIR* dirfd);
+    ~DirectoryIterator();
+    constexpr DirectoryIterator(DirectoryIterator&& other)
+        : m_dirfd(other.m_dirfd)
+    {
+        other.m_dirfd = NULL;
+    }
+    ErrorOr<Optional<String>> next();
+};
+ErrorOr<NonnullRefPtr<DirectoryIterator>> list_directory(String path);
+ErrorOr<bool> is_directory(String path);
 }

--- a/jakttest/fs.h
+++ b/jakttest/fs.h
@@ -24,4 +24,7 @@ public:
 };
 ErrorOr<NonnullRefPtr<DirectoryIterator>> list_directory(String path);
 ErrorOr<bool> is_directory(String path);
+ErrorOr<void> mkdir(String path);
+ErrorOr<void> rmdir(String path);
+ErrorOr<void> unlink(String path);
 }

--- a/jakttest/fs.h
+++ b/jakttest/fs.h
@@ -1,6 +1,8 @@
+#pragma once
 #include <Jakt/Forward.h>
 #include <Jakt/String.h>
 #include <dirent.h>
+#include <sys/stat.h>
 
 namespace Jakt::fs {
 ErrorOr<void> mkdir(String path);
@@ -23,29 +25,24 @@ public:
     ErrorOr<Optional<String>> next();
 };
 ErrorOr<NonnullRefPtr<DirectoryIterator>> list_directory(String path);
-ErrorOr<bool> is_directory(String path);
 ErrorOr<void> mkdir(String path);
 ErrorOr<void> rmdir(String path);
 ErrorOr<void> unlink(String path);
 
 class StatResults {
     size_t m_modified_time;
-    bool m_is_executable;
-    bool m_is_regular_file;
-    bool m_exists;
+    mode_t m_mode;
 
 public:
-    constexpr StatResults(size_t modified_time, bool is_executable, bool is_regular_file, bool exists)
+    constexpr StatResults(size_t modified_time, mode_t mode)
         : m_modified_time(modified_time)
-        , m_is_executable(is_executable)
-        , m_is_regular_file(is_regular_file)
-        , m_exists(exists)
+        , m_mode(mode)
     {
     }
     constexpr size_t modified_time() const { return m_modified_time; }
-    constexpr size_t is_executable() const { return m_is_executable; }
-    constexpr size_t is_regular_file() const { return m_is_regular_file; }
-    constexpr size_t exists() const { return m_exists; }
+    constexpr size_t is_executable() const { return (m_mode & S_IXUSR) != 0; }
+    constexpr size_t is_regular_file() const { return S_ISREG(m_mode); }
+    constexpr size_t is_directory() const { return S_ISDIR(m_mode); }
 };
 ErrorOr<Optional<StatResults>> stat_silencing_enoent(String path);
 }

--- a/jakttest/fs.h
+++ b/jakttest/fs.h
@@ -1,3 +1,6 @@
+// Copyright (c) 2022, Jesús Lapastora <cyber.gsuscode@gmail.com>
+//
+// SPDX-License-Identifier: BSD-2-Clause
 #pragma once
 #include <Jakt/Forward.h>
 #include <Jakt/String.h>

--- a/jakttest/jakttest.jakt
+++ b/jakttest/jakttest.jakt
@@ -87,6 +87,9 @@ namespace process {
     extern function poll_process_exit(pid: i32) throws -> i32?
     /// Kills a process by sending SIGKILL to it
     extern function forcefully_kill_process(pid: i32) throws
+
+    /// Calls execvp() with the given argument array.
+    extern function exec(args: [String]) throws
 }
 
 namespace os {
@@ -106,6 +109,7 @@ function print_usage()  {
     eprintln("\t--temp-dir <DIR>\t\tUse DIR as the temporary directory.")
     eprintln("\t\t\tWill try to use $TMP_DIR or /tmp in UNIX-based systems, or %TEMP% in Windows")
     eprintln("\t--assume-updated-selfhost\t\tAssume selfhost is up to date, i.e don't check it.")
+    eprintln("\t--assume-updated\t\tAssume jakttest is up to date, i.e don't check it.")
 }
 
 function compare_test(bytes: [u8], expected: String) throws -> bool {
@@ -203,6 +207,7 @@ struct Options {
     job_count: usize
     help_wanted: bool
     assume_selfhost_updated: bool
+    assume_updated: bool
 
     function from_args(args: [String]) throws -> Options {
         let files: [String] = []
@@ -213,7 +218,8 @@ struct Options {
                               show_reasons: false
                               job_count: 0
                               help_wanted: false
-                              assume_selfhost_updated: false)
+                              assume_selfhost_updated: false
+                              assume_updated: false)
 
         mut index = 1uz
         while index != args.size() {
@@ -258,6 +264,12 @@ struct Options {
 
             if args[index] == "--assume-updated-selfhost" {
                 options.assume_selfhost_updated = true
+                index++
+                continue
+            }
+
+            if args[index] == "--assume-updated" {
+                options.assume_updated = true
                 index++
                 continue
             }
@@ -584,6 +596,25 @@ function main(args: [String]) {
     if not parsed_options.assume_selfhost_updated and does_selfhost_need_update() {
         eprintln("[ \x1b[1;94mINFO\x1b[m ] Compiling selfhost to match source...")
         system("cargo run --color=always selfhost/main.jakt".c_string())
+    }
+
+    if not parsed_options.assume_updated {
+        eprintln("[ \x1b[1;94mINFO\x1b[m ] Running incremental build on Jakttest")
+        let current_binary_stat = fs::stat_silencing_enoent(path: args[0])
+        system("ninja -C jakttest".c_string())
+        let latest_binary_stat = fs::stat_silencing_enoent(path: args[0])!
+
+        if not current_binary_stat.has_value() or
+            current_binary_stat!.modified_time() < latest_binary_stat.modified_time() {
+            eprintln("[ \x1b[1;94mINFO\x1b[m ] Jakttest updated; restarting")
+            mut forwarded_args: [String] = args
+            forwarded_args.add_capacity(2)
+            // we know at this point that we have selfhost updated and that we
+            // have updated jakttest, so don't re-check any of them.
+            forwarded_args.push("--assume-updated")
+            forwarded_args.push("--assume-updated-selfhost")
+            process::exec(args: forwarded_args)
+        }
     }
 
 

--- a/jakttest/jakttest.jakt
+++ b/jakttest/jakttest.jakt
@@ -17,6 +17,7 @@ namespace fs {
         // Whether the file is executable by the current user
         function is_executable(this) -> bool
         function is_regular_file(this) -> bool
+        function is_directory(this) -> bool
     }
 
     extern class DirectoryIterator {
@@ -27,7 +28,6 @@ namespace fs {
     // Get a listing of a directory, using readdir().
     extern function list_directory(path: String) throws -> DirectoryIterator
     // Returns whether the given path is a directory
-    extern function is_directory(path: String) throws -> bool
 
     // Create a directory
     extern function mkdir(path: String) throws
@@ -41,6 +41,19 @@ namespace fs {
     // Calls `stat` on a file. Silences `ENOENT` error by setting
     // StatResults.exists to false.
     extern function stat_silencing_enoent(path: String) throws -> StatResults?
+
+
+    function is_directory(path: String) throws -> bool {
+        let stat = stat_silencing_enoent(path)
+        return stat.has_value() and stat!.is_directory()
+    }
+
+    function mkdir_if_not_present(path: String) throws {
+        let stat = stat_silencing_enoent(path)
+        if not stat.has_value() or not stat!.is_directory() {
+            fs::mkdir(path)
+        }
+    }
 
 
     function has_jakt_extension(name: String) throws -> bool {
@@ -655,10 +668,10 @@ function main(args: [String]) {
 
     mut directories: [String] = []
     directories.ensure_capacity(parsed_options.job_count as! usize)
-    fs::mkdir(path: parsed_options.temp_dir)
+    fs::mkdir_if_not_present(path: parsed_options.temp_dir)
     for i in 0..parsed_options.job_count {
         let path = format("{}/jakttest-tmp-{}",  parsed_options.temp_dir, i)
-        fs::mkdir(path)
+        fs::mkdir_if_not_present(path)
         directories.push(path)
     }
 

--- a/jakttest/jakttest.jakt
+++ b/jakttest/jakttest.jakt
@@ -9,6 +9,16 @@ import lexer { Lexer }
 import utility { panic }
 
 namespace fs {
+
+    // subset of `struct stat` from <sys/stat.h> that contains
+    // just what is used.
+    extern struct StatResults {
+        function modified_time(this) -> usize
+        // Whether the file is executable by the current user
+        function is_executable(this) -> bool
+        function is_regular_file(this) -> bool
+    }
+
     extern class DirectoryIterator {
         // Get next listing name. Note that the full path is not given,
         // just the base name.
@@ -21,16 +31,20 @@ namespace fs {
 
     // Create a directory
     extern function mkdir(path: String) throws
-
+    
     // Remove a directory
     extern function rmdir(path: String) throws
 
     // Remove a file
     extern function unlink(path: String) throws
 
+    // Calls `stat` on a file. Silences `ENOENT` error by setting
+    // StatResults.exists to false.
+    extern function stat_silencing_enoent(path: String) throws -> StatResults?
+
+
     function has_jakt_extension(name: String) throws -> bool {
         if name.length() < 5 {
-            println("too short")
             return false
         }
         let extension = name.substring(start: name.length() - 5, length: 5)
@@ -91,6 +105,7 @@ function print_usage()  {
     eprintln("\t-j,--jobs <JOBS>\t\tUse JOBS processes. Defaults to the number of available CPUs.")
     eprintln("\t--temp-dir <DIR>\t\tUse DIR as the temporary directory.")
     eprintln("\t\t\tWill try to use $TMP_DIR or /tmp in UNIX-based systems, or %TEMP% in Windows")
+    eprintln("\t--assume-updated-selfhost\t\tAssume selfhost is up to date, i.e don't check it.")
 }
 
 function compare_test(bytes: [u8], expected: String) throws -> bool {
@@ -187,6 +202,7 @@ struct Options {
     show_reasons: bool
     job_count: usize
     help_wanted: bool
+    assume_selfhost_updated: bool
 
     function from_args(args: [String]) throws -> Options {
         let files: [String] = []
@@ -196,7 +212,8 @@ struct Options {
                               errors
                               show_reasons: false
                               job_count: 0
-                              help_wanted: false)
+                              help_wanted: false
+                              assume_selfhost_updated: false)
 
         mut index = 1uz
         while index != args.size() {
@@ -235,6 +252,12 @@ struct Options {
                     break
                 }
                 options.temp_dir = args[index]
+                index++
+                continue
+            }
+
+            if args[index] == "--assume-updated-selfhost" {
+                options.assume_selfhost_updated = true
                 index++
                 continue
             }
@@ -517,6 +540,30 @@ struct TestScheduler {
     }
 }
 
+function does_selfhost_need_update() throws -> bool {
+    let maybe_binary_stat = fs::stat_silencing_enoent(path: "build/main")
+    if not maybe_binary_stat.has_value() {
+        return true
+    }
+    let binary_stat = maybe_binary_stat!
+    if binary_stat.is_executable() and binary_stat.is_regular_file() {
+        // Looks like we've got the binary. Let's check the sources.
+        mut latest_mtime: usize = 0
+        mut selfhost_files: [String] = []
+        fs::get_jakt_files_under(directory: "selfhost", results: selfhost_files)
+        for file in selfhost_files.iterator() {
+            let stat = fs::stat_silencing_enoent(path: file)!
+            let mtime = stat.modified_time()
+            if mtime > latest_mtime {
+                latest_mtime = mtime
+            }
+        }
+
+        return latest_mtime > binary_stat.modified_time()
+    }
+    return true
+}
+
 
 function main(args: [String]) {
     let parsed_options = Options::from_args(args)
@@ -532,6 +579,11 @@ function main(args: [String]) {
         }
         print_usage()
         return 1
+    }
+
+    if not parsed_options.assume_selfhost_updated and does_selfhost_need_update() {
+        eprintln("[ \x1b[1;94mINFO\x1b[m ] Compiling selfhost to match source...")
+        system("cargo run --color=always selfhost/main.jakt".c_string())
     }
 
 

--- a/jakttest/jakttest.jakt
+++ b/jakttest/jakttest.jakt
@@ -8,6 +8,54 @@ import parser { Parser }
 import lexer { Lexer }
 import utility { panic }
 
+namespace fs {
+    extern class DirectoryIterator {
+        // Get next listing name. Note that the full path is not given,
+        // just the base name.
+        public function next(mut this) throws -> String?
+    }
+    // Get a listing of a directory, using readdir().
+    extern function list_directory(path: String) throws -> DirectoryIterator
+    // Returns whether the given path is a directory
+    extern function is_directory(path: String) throws -> bool
+
+    function has_jakt_extension(name: String) throws -> bool {
+        if name.length() < 5 {
+            println("too short")
+            return false
+        }
+        let extension = name.substring(start: name.length() - 5, length: 5)
+        return extension == ".jakt"
+    }
+
+    // Traverse directory in a DFS manner ta find files with the .jakt extension
+    // and store results into the given array
+    function get_jakt_files_under(directory: String, mut results: [String]) throws -> [String] {
+        mut path_stack: [String] = [directory]
+
+        while not path_stack.is_empty() {
+            let current = path_stack.pop()!
+            for child_name in list_directory(path: current) {
+                // avoid going back or re-visiting the same dir
+                if child_name == ".." or child_name == "." {
+                    continue
+                }
+                let full_child_path = current + "/" + child_name
+                if is_directory(path: full_child_path) {
+                    // add it to the stack so we traverse it
+                    path_stack.push(full_child_path)
+                } else if has_jakt_extension(name: child_name) {
+                    results.push(full_child_path)
+                }
+            }
+        }
+
+        return results
+    }
+
+}
+
+
 namespace process {
     /// Starts a background job by means of fork() and exec(). Returns
     /// the PID of the launched process.
@@ -24,7 +72,7 @@ namespace fs {
 }
 
 function print_usage()  {
-    eprintln("usage: jakttest [OPTIONS...] <temp-dir> <path> [... <path>]")
+    eprintln("usage: jakttest [OPTIONS...] <temp-dir> [<path> ...]")
     eprintln("OPTIONS:")
     eprintln("\t-h\t\tShow this message and exit.")
     eprintln("\t-j,--jobs <JOBS>\t\tUse JOBS processes. Defaults to 8.")
@@ -186,7 +234,9 @@ struct Options {
         }
 
         if options.files.is_empty() {
-            options.errors.push("At least one file <path> must be provided")
+            // find files under samples/ and tests/
+            fs::get_jakt_files_under(directory: "samples", results: options.files)
+            fs::get_jakt_files_under(directory: "tests",   results: options.files)
         }
         return options
     }

--- a/jakttest/jakttest.jakt
+++ b/jakttest/jakttest.jakt
@@ -1,4 +1,6 @@
 //
+// Copyright (c) 2022, JT <jt@serenityos.org>
+// Copyright (c) 2022, Andreas Kling <kling@serenityos.org>
 // Copyright (c) 2022, Jesús Lapastora <cyber.gsuscode@gmail.com>
 //
 // SPDX-License-Identifier: BSD-2-Clause

--- a/jakttest/jakttest.jakt
+++ b/jakttest/jakttest.jakt
@@ -19,6 +19,15 @@ namespace fs {
     // Returns whether the given path is a directory
     extern function is_directory(path: String) throws -> bool
 
+    // Create a directory
+    extern function mkdir(path: String) throws
+
+    // Remove a directory
+    extern function rmdir(path: String) throws
+
+    // Remove a file
+    extern function unlink(path: String) throws
+
     function has_jakt_extension(name: String) throws -> bool {
         if name.length() < 5 {
             println("too short")
@@ -52,9 +61,6 @@ namespace fs {
 
         return results
     }
-
-    extern function mkdir(path: String) throws
-
 }
 
 
@@ -72,6 +78,9 @@ namespace process {
 namespace os {
     /// Calls sysconf(_SC_NPROCESSORS_ONLN) to get the number of CPUs available
     extern function get_num_cpus() throws -> usize
+
+    /// Returns %TEMP% in Windows and $TMP_DIR or /tmp in macOS/linux
+    extern function get_system_temporary_directory() throws -> String
 }
 
 function print_usage()  {
@@ -80,6 +89,8 @@ function print_usage()  {
     eprintln("\t-h\t\tShow this message and exit.")
     eprintln("\t--show-reasons\t\tShow the reasons why tests that fail do so.")
     eprintln("\t-j,--jobs <JOBS>\t\tUse JOBS processes. Defaults to the number of available CPUs.")
+    eprintln("\t--temp-dir <DIR>\t\tUse DIR as the temporary directory.")
+    eprintln("\t\t\tWill try to use $TMP_DIR or /tmp in UNIX-based systems, or %TEMP% in Windows")
 }
 
 function compare_test(bytes: [u8], expected: String) throws -> bool {
@@ -217,23 +228,29 @@ struct Options {
                 continue
             }
 
-            // positional argument.
-
-            // if temp dir was empty, this means this is the first positional
-            // argument we encounter, which corresponds to the temporary directory
-            // we'll use for operations.
-            if options.temp_dir.is_empty() {
+            if args[index] == "--temp-dir" {
+                index++
+                if index == args.size() {
+                    options.errors.push("Used --temp-dir without an argument")
+                    break
+                }
                 options.temp_dir = args[index]
-            } else {
-                // otherwise it's a file path.
-                options.files.push(args[index])
+                index++
+                continue
             }
+            
+            if args[index].length() > 0 and args[index].byte_at(0) == b'-' {
+                options.errors.push(format("Unknown argument: {}", args[index]))
+            }
+
+            // positional argument: file path
+            options.files.push(args[index])
 
             index++
         }
 
         if options.temp_dir.is_empty() {
-            options.errors.push("Missing <temp-dir>")
+            options.temp_dir = os::get_system_temporary_directory() + "/jakttest"
         }
 
         if options.files.is_empty() {
@@ -517,6 +534,7 @@ function main(args: [String]) {
         return 1
     }
 
+
     mut skipped_count = 0uz
 
     mut tests: [Test] = []
@@ -554,6 +572,7 @@ function main(args: [String]) {
 
     mut directories: [String] = []
     directories.ensure_capacity(parsed_options.job_count as! usize)
+    fs::mkdir(path: parsed_options.temp_dir)
     for i in 0..parsed_options.job_count {
         let path = format("{}/jakttest-tmp-{}",  parsed_options.temp_dir, i)
         fs::mkdir(path)
@@ -561,6 +580,18 @@ function main(args: [String]) {
     }
 
     let run_result = TestScheduler::run_tests(tests, directories, collect_reasons: parsed_options.show_reasons)
+
+    // delete directories
+    for dir in directories.iterator() {
+        for file in fs::list_directory(path: dir) {
+            if file == "." or file == ".." {
+                continue
+            }
+            fs::unlink(path: dir + "/" + file)
+        }
+        fs::rmdir(path: dir)
+    }
+    fs::rmdir(path: parsed_options.temp_dir)
 
     println("==============================")
     println("{} passed" , run_result.passed_count)

--- a/jakttest/jakttest.jakt
+++ b/jakttest/jakttest.jakt
@@ -53,6 +53,8 @@ namespace fs {
         return results
     }
 
+    extern function mkdir(path: String) throws
+
 }
 
 
@@ -67,16 +69,17 @@ namespace process {
     extern function forcefully_kill_process(pid: i32) throws
 }
 
-namespace fs {
-    extern function mkdir(path: String) throws
+namespace os {
+    /// Calls sysconf(_SC_NPROCESSORS_ONLN) to get the number of CPUs available
+    extern function get_num_cpus() throws -> usize
 }
 
 function print_usage()  {
     eprintln("usage: jakttest [OPTIONS...] <temp-dir> [<path> ...]")
     eprintln("OPTIONS:")
     eprintln("\t-h\t\tShow this message and exit.")
-    eprintln("\t-j,--jobs <JOBS>\t\tUse JOBS processes. Defaults to 8.")
     eprintln("\t--show-reasons\t\tShow the reasons why tests that fail do so.")
+    eprintln("\t-j,--jobs <JOBS>\t\tUse JOBS processes. Defaults to the number of available CPUs.")
 }
 
 function compare_test(bytes: [u8], expected: String) throws -> bool {
@@ -142,19 +145,19 @@ function strip_line_breaks(anon input: String) throws -> String {
     return builder.to_string()
 }
 
-function u64_from_ascii_digit(anon byte: u8) -> u64? {
+function usize_from_ascii_digit(anon byte: u8) -> usize? {
     if byte >= b'0' and byte <= b'9' {
-        return (byte - b'0') as! u64
+        return (byte - b'0') as! usize
     }
     return None
 }
 
-function u64_from_ascii_digits(anon digits: String) -> u64? {
-    mut value = 0u64
+function usize_from_ascii_digits(anon digits: String) -> usize? {
+    mut value = 0uz
 
     for index in 0..digits.length() {
         let byte = digits.byte_at(index)
-        let digit = u64_from_ascii_digit(byte)
+        let digit = usize_from_ascii_digit(byte)
         if not digit.has_value() {
             return None
         }
@@ -171,7 +174,7 @@ struct Options {
     temp_dir: String
     errors: [String]
     show_reasons: bool
-    job_count: u64
+    job_count: usize
     help_wanted: bool
 
     function from_args(args: [String]) throws -> Options {
@@ -180,8 +183,8 @@ struct Options {
         mut options = Options(files
                               temp_dir: ""
                               errors
-                              show_reasons: true
-                              job_count: 8
+                              show_reasons: false
+                              job_count: 0
                               help_wanted: false)
 
         mut index = 1uz
@@ -198,7 +201,7 @@ struct Options {
                     options.errors.push("Used --jobs/-j without an argument")
                     break // we reached end of arguments
                 }
-                let jobs = u64_from_ascii_digits(args[index])
+                let jobs = usize_from_ascii_digits(args[index])
                 if not jobs.has_value() or jobs! == 0 {
                     options.errors.push("--jobs/-j needs a positive integer as its argument")
                 } else {
@@ -238,6 +241,11 @@ struct Options {
             fs::get_jakt_files_under(directory: "samples", results: options.files)
             fs::get_jakt_files_under(directory: "tests",   results: options.files)
         }
+
+        if options.job_count == 0 {
+            options.job_count = os::get_num_cpus()
+        }
+
         return options
     }
 }
@@ -423,9 +431,6 @@ struct TestScheduler {
                     }
                     .failed_count++
                 }
-
-
-
             }
         }
     }

--- a/jakttest/jakttest.jakt
+++ b/jakttest/jakttest.jakt
@@ -608,13 +608,19 @@ function main(args: [String]) {
 
     if not parsed_options.assume_selfhost_updated and does_selfhost_need_update() {
         eprintln("[ \x1b[1;94mINFO\x1b[m ] Compiling selfhost to match source...")
-        system("cargo run --color=always selfhost/main.jakt".c_string())
+        if system("cargo run --color=always selfhost/main.jakt".c_string()) != 0 {
+            eprintln("[ \x1b[1;31mFATAL\x1b[m ] Compiling selfhost failed!")
+            return 1
+        }
     }
 
     if not parsed_options.assume_updated {
         eprintln("[ \x1b[1;94mINFO\x1b[m ] Running incremental build on Jakttest")
         let current_binary_stat = fs::stat_silencing_enoent(path: args[0])
-        system("ninja -C jakttest".c_string())
+        if system("ninja -C jakttest".c_string()) != 0 {
+            eprintln("[ \x1b[1;31mFATAL\x1b[m ] Compiling new Jakttest failed!")
+            return 1
+        }
         let latest_binary_stat = fs::stat_silencing_enoent(path: args[0])!
 
         if not current_binary_stat.has_value() or

--- a/jakttest/os.cpp
+++ b/jakttest/os.cpp
@@ -1,0 +1,19 @@
+#include "os.h"
+#include <Jakt/String.h>
+// FIXME:  StringBuilder fails to compile because 
+// adopt_nonnull_ref_or_enomem isn't included.
+#include <Jakt/RefPtr.h>
+#include <Jakt/StringBuilder.h>
+#include <stdlib.h>
+#include <unistd.h>
+
+namespace Jakt::os {
+ErrorOr<size_t> get_num_cpus()
+{
+    long result = sysconf(_SC_NPROCESSORS_ONLN);
+    if (result == -1)
+        return Error::from_errno(errno);
+    return static_cast<size_t>(result);
+}
+
+}

--- a/jakttest/os.cpp
+++ b/jakttest/os.cpp
@@ -1,3 +1,6 @@
+// Copyright (c) 2022, Jesús Lapastora <cyber.gsuscode@gmail.com>
+//
+// SPDX-License-Identifier: BSD-2-Clause
 #include "os.h"
 #include <Jakt/String.h>
 // FIXME:  StringBuilder fails to compile because

--- a/jakttest/os.cpp
+++ b/jakttest/os.cpp
@@ -1,6 +1,6 @@
 #include "os.h"
 #include <Jakt/String.h>
-// FIXME:  StringBuilder fails to compile because 
+// FIXME:  StringBuilder fails to compile because
 // adopt_nonnull_ref_or_enomem isn't included.
 #include <Jakt/RefPtr.h>
 #include <Jakt/StringBuilder.h>
@@ -16,4 +16,15 @@ ErrorOr<size_t> get_num_cpus()
     return static_cast<size_t>(result);
 }
 
+ErrorOr<String> get_system_temporary_directory()
+{
+    auto builder = TRY(StringBuilder::create());
+#ifdef __WIN32
+    TRY(builder.append_c_string(getenv("TEMP")));
+#else
+    auto const result = getenv("TMP_DIR");
+    TRY(builder.append_c_string(result == NULL ? "/tmp" : result));
+#endif
+    return TRY(builder.to_string());
+}
 }

--- a/jakttest/os.h
+++ b/jakttest/os.h
@@ -1,0 +1,6 @@
+#include <Jakt/Types.h>
+#include <Jakt/Error.h>
+
+namespace Jakt::os {
+    ErrorOr<size_t> get_num_cpus();
+}

--- a/jakttest/os.h
+++ b/jakttest/os.h
@@ -3,4 +3,5 @@
 
 namespace Jakt::os {
     ErrorOr<size_t> get_num_cpus();
+    ErrorOr<String> get_system_temporary_directory();
 }

--- a/jakttest/os.h
+++ b/jakttest/os.h
@@ -1,3 +1,7 @@
+// Copyright (c) 2022, Jesús Lapastora <cyber.gsuscode@gmail.com>
+//
+// SPDX-License-Identifier: BSD-2-Clause
+#pragma once
 #include <Jakt/Types.h>
 #include <Jakt/Error.h>
 

--- a/jakttest/patch-includes.py
+++ b/jakttest/patch-includes.py
@@ -13,4 +13,5 @@ target_output = sys.argv[2]
 with open(target_file) as source, open(target_output, "w") as sink:
     sink.write('#include "../process.h"\n')
     sink.write('#include "../fs.h"\n')
+    sink.write('#include "../os.h"\n')
     sink.write(source.read())

--- a/jakttest/process.cpp
+++ b/jakttest/process.cpp
@@ -3,8 +3,9 @@
 //
 // SPDX-License-Identifier: BSD-2-Clause
 #include "process.h"
-#include <sys/wait.h>
+#include <Jakt/Assertions.h>
 #include <signal.h>
+#include <sys/wait.h>
 
 namespace Jakt::process {
 // Allocates & fills one array, which contains:
@@ -60,6 +61,51 @@ static ErrorOr<char**> dup_argv(Array<String> args)
     }
 
     return argv;
+}
+
+ErrorOr<void> exec(Array<String> args)
+{
+    // this time I don't have to use dup_argv, since
+    // none of the arguments will be deallocated if
+    // the process can be executed(because execvp gets in the way)
+    // We'll just allocate an array of pointers to `args`, plus the NULL pointer.
+    auto const argv_byte_size = (Checked<size_t>(args.size()) + Checked<size_t>(1)) * Checked<size_t>(sizeof(char*));
+    if (argv_byte_size.has_overflow()) {
+        return Error::from_errno(EOVERFLOW);
+    }
+
+    // SAFE: since `execvp` expects `char * const *`, we have to fill the argv
+    // array with pointers.
+    auto argv = reinterpret_cast<char**>(malloc(argv_byte_size.value_unchecked()));
+    if (argv == NULL) {
+        return Error::from_errno(ENOMEM);
+    }
+
+    for (size_t i = 0; i != args.size(); ++i) {
+        // SAFETY: const_cast is safe:
+        // If execvp() succeeds it doesn't return, and the argument strings
+        // can't be modified by us; ownership of this memory has been
+        // transferred to the executed program. Which means that we can cast
+        // them to `char *`; the memory is not touched by whoever passed args
+        // anymore (we're not returning control).
+        //
+        // If it doesn't, these pointers in `argv` become invalid, because the
+        // memory continues to be owned by whoever passed the references to the
+        // strings. These now invalid pointers are not used by this function (or
+        // future paths) once they're invalid; in fact; the memory of `argv` is
+        // released.
+        argv[i] = const_cast<char*>(args[i].c_string());
+    }
+    argv[args.size()] = NULL;
+
+    if (::execvp(argv[0], argv) == -1) {
+        // do not touch again this array. Its pointers are invalid (see safety
+        // comment above `const_cast`).
+        free(argv);
+        return Error::from_errno(errno);
+    }
+
+    VERIFY_NOT_REACHED();
 }
 
 ErrorOr<i32> start_background_process(Array<String> args)

--- a/jakttest/process.h
+++ b/jakttest/process.h
@@ -2,6 +2,7 @@
 // Copyright (c) 2022, Jesús Lapastora <cyber.gsuscode@gmail.com>
 //
 // SPDX-License-Identifier: BSD-2-Clause
+#pragma once
 #include <Builtins/Array.h>
 #include <Jakt/Error.h>
 #include <Jakt/String.h>

--- a/jakttest/process.h
+++ b/jakttest/process.h
@@ -10,4 +10,5 @@ namespace Jakt::process {
 ErrorOr<i32> start_background_process(Array<String> args);
 ErrorOr<Optional<i32>> poll_process_exit(i32 pid);
 ErrorOr<void> forcefully_kill_process(i32 pid);
+ErrorOr<void> exec(Array<String> args);
 }

--- a/jakttest/run-all.sh
+++ b/jakttest/run-all.sh
@@ -33,25 +33,6 @@ else
 }
 fi
 
-pass=0
-fail=0
-skipped=0
-
-count=0
-
-if [ -n "$1" ]
-then
-    TEST_FILES=$(find "$1" -type f -name "*.jakt")
-else
-    TEST_FILES="samples/**/*.jakt tests/**/*.jakt"
-fi
-
-for f in $TEST_FILES; do
-    count=$((count + 1))
-done
-
-
-
 # default JOBS to number of prossing units dictated by kernel
 if [[ $OSTYPE == 'darwin'* ]]; then
     [ -z "$JOBS" ] && JOBS=$(sysctl -n hw.ncpu)
@@ -63,4 +44,4 @@ tempdir=$(mktemp -d)
 
 trap "rm -rf $tempdir" EXIT
 
-./jakttest/build/jakttest --jobs "$JOBS" "$tempdir" ${TEST_FILES[@]}
+./jakttest/build/jakttest --jobs "$JOBS" "$tempdir"

--- a/jakttest/run-all.sh
+++ b/jakttest/run-all.sh
@@ -1,2 +1,0 @@
-#!/bin/sh
-ninja -C jakttest && ./jakttest/build/jakttest --assume-updated

--- a/jakttest/run-all.sh
+++ b/jakttest/run-all.sh
@@ -33,8 +33,5 @@ else
 }
 fi
 
-tempdir=$(mktemp -d)
 
-trap "rm -rf $tempdir" EXIT
-
-./jakttest/build/jakttest "$tempdir"
+exec ./jakttest/build/jakttest

--- a/jakttest/run-all.sh
+++ b/jakttest/run-all.sh
@@ -33,15 +33,8 @@ else
 }
 fi
 
-# default JOBS to number of prossing units dictated by kernel
-if [[ $OSTYPE == 'darwin'* ]]; then
-    [ -z "$JOBS" ] && JOBS=$(sysctl -n hw.ncpu)
-else
-    [ -z "$JOBS" ] && JOBS=$(nproc)
-fi
-
 tempdir=$(mktemp -d)
 
 trap "rm -rf $tempdir" EXIT
 
-./jakttest/build/jakttest --jobs "$JOBS" "$tempdir"
+./jakttest/build/jakttest "$tempdir"

--- a/jakttest/run-all.sh
+++ b/jakttest/run-all.sh
@@ -4,34 +4,9 @@
 #
 # SPDX-License-Identifier: BSD-2-Clause
 
-stat_format_flags="-c %Y"
-if [[ $OSTYPE == 'darwin'* ]]; then
-  stat_format_flags="-f %m"
-fi
-
 echo "Checking & building Jakttest if necessary"
 set -e
 ninja -C jakttest
 set +e
-
-if [ ! -x build/main ]; then
-    echo "Selfhost binary does not exist; compiling it"
-    set -e
-    cargo run selfhost/main.jakt
-    set +e
-else
-# check for selfhost/ mtime and build/main mtime
-{
-    binary_mtime=$(stat "$stat_format_flags" build/main)
-    latest_selfhost_mtime=$(stat "$stat_format_flags" selfhost/*.jakt | sort | tail -n1)
-    if [ "$binary_mtime" -lt "$latest_selfhost_mtime" ]; then
-        echo "re-compiling selfhost to match source"
-        set -e
-        cargo run selfhost/main.jakt
-        set +e
-    fi
-}
-fi
-
 
 exec ./jakttest/build/jakttest

--- a/jakttest/run-all.sh
+++ b/jakttest/run-all.sh
@@ -1,12 +1,2 @@
-#!/bin/bash
-#
-# Copyright (c) 2022, Jesús Lapastora <cyber.gsuscode@gmail.com>
-#
-# SPDX-License-Identifier: BSD-2-Clause
-
-echo "Checking & building Jakttest if necessary"
-set -e
-ninja -C jakttest
-set +e
-
-exec ./jakttest/build/jakttest
+#!/bin/sh
+ninja -C jakttest && ./jakttest/build/jakttest --assume-updated


### PR DESCRIPTION
This PR implements a series of steps to remove the `jakttest/run-all.sh` script
and make `jakttest` the entrypoint. These are the things that `jakttest` should
do by itself:

- [x] Discover tests by itself if not given explicitly
- [x] Discover the number of jobs if not given explicitly [^1]
- [x] Make a temporary directory and clean it up unless given explicitly
- [x] Re-compile selfhost if it's out of date
- [x] Re-compile jakttest & re-exec automatically if updated

[^1]: These are achieved through `sysconf`, which is specified by POSIX.1-2008.