### PR TITLE
selfhost/codegen: Add support for generic enums

### DIFF
--- a/selfhost/codegen.jakt
+++ b/selfhost/codegen.jakt
@@ -2338,6 +2338,7 @@ struct CodeGenerator {
         GenericInstance(id, args) => .codegen_generic_type_instance(id, args, as_namespace)
         Struct(id) => .codegen_struct_type(id, as_namespace)
         Enum(id) => .codegen_enum_type(id, as_namespace)
+        GenericEnumInstance(id, args) => .codegen_generic_enum_instance(id, args, as_namespace)
         TypeVariable(name) => name
         else => {
             todo(format("codegen_type else: {}", .program.get_type(type_id)))
@@ -2390,6 +2391,47 @@ struct CodeGenerator {
             }
         }
 
+        return output
+    }
+
+    function codegen_generic_enum_instance(this, id: EnumId, args: [TypeId], as_namespace: bool) throws -> String {
+        mut output = ""
+        mut close_tag = false
+        let enum_ = .program.get_enum(id)
+        if not as_namespace and enum_.is_boxed {
+            output += "NonnullRefPtr<"
+            let qualifier = .codegen_namespace_qualifier(scope_id: enum_.scope_id)
+
+            if not qualifier.is_empty() {
+                output += "typename "
+                output += qualifier
+            }
+            output += enum_.name
+            close_tag = true
+        } else {
+            let qualifier = .codegen_namespace_qualifier(scope_id: enum_.scope_id)
+
+            if not qualifier.is_empty() {
+                output += "typename "
+                output += qualifier
+            }
+            output += enum_.name
+        }
+        output += "<"
+        mut first = true
+        for type_id in args.iterator() {
+            if not first {
+                output += ", "
+            } else {
+                first = false
+            }
+
+            output += .codegen_type(type_id)
+        }
+        output += ">"
+        if close_tag {
+            output += ">"
+        }
         return output
     }
 


### PR DESCRIPTION
Adds support for generic enum instances to codegen. Fixes two tests.

Before:
```
==============================
322 passed
15 failed
3 skipped
==============================
```

Now:
```
==============================
324 passed
13 failed
3 skipped
==============================
```