### PR TITLE
Guard keyword

### DIFF
--- a/editors/emacs/jakt_mode.el
+++ b/editors/emacs/jakt_mode.el
@@ -39,7 +39,7 @@
 
 (setq jakt-font-lock-defaults
       (let* (
-             (jakt-conditional '("if" "else" "match"))
+             (jakt-conditional '("if" "else" "match" "guard"))
              (jakt-repeat '("while" "for" "loop"))
              (jakt-execution '("return" "break" "continue" "throw" "yield"))
              (jakt-boolean '("true" "false"))

--- a/editors/nano/jakt.nanorc
+++ b/editors/nano/jakt.nanorc
@@ -6,7 +6,7 @@ comment "//"
 color magenta "function [a-z_0-9]+"
 
 # Reserved words
-color yellow "\<(and|anon|boxed|break|catch|class|continue|cpp|defer|else|enum|extern|false|for|function|if|import|in|is|let|loop|match|mut|namespace|not|or|private|public|raw|return|restricted|struct|this|throw|throws|true|try|unsafe|weak|while|yield)\>"
+color yellow "\<(and|anon|boxed|break|catch|class|continue|cpp|defer|else|enum|extern|false|for|function|if|import|in|is|let|loop|match|mut|namespace|not|or|private|public|raw|return|restricted|struct|this|throw|throws|true|try|unsafe|weak|while|yield|guard)\>"
 
 # Constants
 color magenta "[A-Z][A-Z_0-9]+"

--- a/editors/sublime/sublime-for-yakt.sublime-syntax
+++ b/editors/sublime/sublime-for-yakt.sublime-syntax
@@ -1260,7 +1260,7 @@ contexts:
     - match: \b(mutable|public|unsafe|class|throws)\b
       scope: storage.modifier.jakt
 
-    - match: \b(else|for|if|loop|match|try|while|yield)\b
+    - match: \b(else|for|if|loop|match|try|while|yield|guard)\b
       scope: keyword.control.jakt
 
     - match: \b(break|continue)\b

--- a/editors/vim/syntax/jakt.vim
+++ b/editors/vim/syntax/jakt.vim
@@ -13,6 +13,7 @@ let s:jakt_syntax_keywords = {
     \   'jaktConditional' :["if"
     \ ,                     "else"
     \ ,                     "match"
+    \ ,                     "guard"
     \ ,                    ]
     \ , 'jaktRepeat' :["while"
     \ ,                "for"

--- a/editors/vscode/syntaxes/jakt.tmLanguage.json
+++ b/editors/vscode/syntaxes/jakt.tmLanguage.json
@@ -744,7 +744,7 @@
       "patterns": [
         {
           "name": "meta.control.jakt",
-          "match": "\\b(if|else|while|for|loop|try|catch|cpp|unsafe|defer|match)\\b(?=.*?(?:\\{|$))",
+          "match": "\\b(if|else|while|for|loop|try|catch|cpp|unsafe|defer|match|guard)\\b(?=.*?(?:\\{|$))",
           "captures": {
             "1": {
               "name": "keyword.control.block.jakt"

--- a/samples/guard/basic.jakt
+++ b/samples/guard/basic.jakt
@@ -1,0 +1,30 @@
+/// Expect:
+/// - output: "PASS\n0\n2\n4\n6\n8\n"
+
+function test1(anon x: i64) -> String {
+    guard x == 1 else {
+        return "FAIL"
+    }
+
+    return "PASS"
+}
+
+function test2() {
+    mut i = 0
+    loop {
+        guard i % 2 == 0 else {
+            i++
+            continue
+        }
+        guard i < 10 else {
+            break
+        }
+
+        println("{}", i++)
+    }
+}
+
+function main() {
+    println("{}", test1(1))
+    test2()
+}

--- a/samples/guard/no_else.jakt
+++ b/samples/guard/no_else.jakt
@@ -1,0 +1,8 @@
+/// Expect:
+/// - error: "Expected `else` keyword"
+
+function a() {
+    guard true
+}
+
+function main() {}

--- a/samples/guard/no_scope_exit.jakt
+++ b/samples/guard/no_scope_exit.jakt
@@ -1,0 +1,8 @@
+/// Expect:
+/// - error: "Else block of guard must either `return`, `break`, `continue`, or `throw`"
+
+function a() {
+    guard true else {}
+}
+
+function main() {}

--- a/selfhost/lexer.jakt
+++ b/selfhost/lexer.jakt
@@ -1,5 +1,6 @@
 // Copyright (c) 2022, JT <jt@serenityos.org>
 // Copyright (c) 2022, Andreas Kling <kling@serenityos.org>
+// Copyright (c) 2022, Kyle Lanmon <kyle.lanmon@gmail.com>
 //
 // SPDX-License-Identifier: BSD-2-Clause
 
@@ -117,6 +118,7 @@ enum Token {
     Weak(Span)
     While(Span)
     Yield(Span)
+    Guard(Span)
 
     // Catch-all for failed parses
     Garbage(Span)
@@ -222,6 +224,7 @@ enum Token {
         Weak(span) => span
         While(span) => span
         Yield(span) => span
+        Guard(span) => span
         Garbage(span) => span
     }
 
@@ -268,6 +271,7 @@ enum Token {
         "weak" => Token::Weak(span)
         "while" => Token::While(span)
         "yield" => Token::Yield(span)
+        "guard" => Token::Guard(span)
         else => Token::Identifier(name: string, span)
     }
 }

--- a/selfhost/parser.jakt
+++ b/selfhost/parser.jakt
@@ -1,6 +1,7 @@
 // Copyright (c) 2022, JT <jt@serenityos.org>
 // Copyright (c) 2022, Andreas Kling <kling@serenityos.org>
 // Copyright (c) 2022, Charles Mirabile <charlie.mirabile@gmail.com>
+// Copyright (c) 2022, Kyle Lanmon <kyle.lanmon@gmail.com>
 //
 // SPDX-License-Identifier: BSD-2-Clause
 
@@ -159,6 +160,7 @@ boxed enum ParsedStatement {
     Yield(expr: ParsedExpression, span: Span)
     InlineCpp(block: ParsedBlock, span: Span)
     Try(stmt: ParsedStatement, error_name: String, error_span: Span, catch_block: ParsedBlock, span: Span)
+    Guard(expr: ParsedExpression, else_block: ParsedBlock, span: Span)
     Garbage(Span)
 
     function span(this) -> Span => match this {
@@ -178,6 +180,7 @@ boxed enum ParsedStatement {
         Yield(span) => span
         InlineCpp(span) => span
         Try(span) => span
+        Guard(span) => span
         Garbage(span) => span
     }
 }
@@ -1734,11 +1737,29 @@ struct Parser {
                 let block = .parse_block()
                 yield ParsedStatement::Block(block, span: merge_spans(start, .previous().span()))
             }
+            Guard => .parse_guard_statement()
             else => {
                 let expr = .parse_expression(allow_assignments: true)
                 yield ParsedStatement::Expression(expr, span: merge_spans(start, .previous().span()))
             }
         }
+    }
+
+    function parse_guard_statement(mut this) throws -> ParsedStatement {
+        let span = .current().span()
+        .index++
+        let expr = .parse_expression(allow_assignments: false)
+        match .current() {
+            Else => {
+                .index++
+            }
+            else => {
+                .error("Expected `else` keyword", .current().span())
+            }
+        }
+        let else_block = .parse_block()
+
+        return ParsedStatement::Guard(expr, else_block, span)
     }
 
     function parse_try_statement(mut this) throws -> ParsedStatement {
@@ -2943,6 +2964,10 @@ function parsed_statement_equals(anon lhs_statement: ParsedStatement, anon rhs_s
         Try(stmt: rhs_stmt, error_name: rhs_error_name, catch_block: rhs_catch_block) => {
             yield lhs_error_name == rhs_error_name and parsed_statement_equals(lhs_stmt, rhs_stmt) and parsed_block_equals(lhs_catch_block, rhs_catch_block)
         }
+        else => false
+    }
+    Guard(expr, else_block) => match rhs_statement {
+        Guard(expr: rhs_expr, else_block: rhs_else_block) => parsed_expression_equals(expr, rhs_expr) and parsed_block_equals(else_block, rhs_else_block)
         else => false
     }
     Garbage => rhs_statement is Garbage

--- a/selfhost/typechecker.jakt
+++ b/selfhost/typechecker.jakt
@@ -4070,15 +4070,9 @@ struct Typechecker {
     }
 
     function typecheck_statement(mut this, anon statement: ParsedStatement, scope_id: ScopeId, safety_mode: SafetyMode) throws -> CheckedStatement => match statement {
-        Expression(expr, span) => {
-            let type_hint: TypeId? = None
-            yield CheckedStatement::Expression(expr: .typecheck_expression(expr, scope_id, safety_mode, type_hint), span)
-        }
+        Expression(expr, span) => CheckedStatement::Expression(expr: .typecheck_expression(expr, scope_id, safety_mode, type_hint: TypeId::none()), span)
         UnsafeBlock(block, span) => CheckedStatement::Block(block: .typecheck_block(block, parent_scope_id: scope_id, safety_mode: SafetyMode::Unsafe), span)
-        Yield(expr, span) => {
-            let type_hint: TypeId? = None
-            yield CheckedStatement::Yield(expr: .typecheck_expression(expr, scope_id, safety_mode, type_hint), span)
-        }
+        Yield(expr, span) => CheckedStatement::Yield(expr: .typecheck_expression(expr, scope_id, safety_mode, type_hint: TypeId::none()), span)
         Return(expr, span) => .typecheck_return(expr, span, scope_id, safety_mode)
         Block(block, span) => .typecheck_block_statement(parsed_block: block, scope_id, safety_mode, span)
         InlineCpp(block, span) => .typecheck_inline_cpp(block, span, safety_mode)

--- a/selfhost/typechecker.jakt
+++ b/selfhost/typechecker.jakt
@@ -4091,6 +4091,7 @@ struct Typechecker {
         If(condition, then_block, else_statement, span) => .typecheck_if(condition, then_block, else_statement, scope_id, safety_mode, span)
         Garbage(span) => CheckedStatement::Garbage(span)
         For(iterator_name, name_span, range, block, span) => .typecheck_for(iterator_name,  name_span, range, block, scope_id, safety_mode, span)
+        Guard(span) => CheckedStatement::Garbage(span) // TODO: implement
     }
 
     function typecheck_for(mut this, iterator_name: String, name_span: Span, range: ParsedExpression, block: ParsedBlock, scope_id: ScopeId, safety_mode: SafetyMode, span: Span) throws -> CheckedStatement {

--- a/selfhost/typechecker.jakt
+++ b/selfhost/typechecker.jakt
@@ -574,6 +574,8 @@ boxed enum CheckedStatement {
         InlineCpp(span) => span
         Garbage(span) => span
     }
+
+    function none() -> CheckedStatement? => None
 }
 
 enum NumberConstant {
@@ -4091,7 +4093,30 @@ struct Typechecker {
         If(condition, then_block, else_statement, span) => .typecheck_if(condition, then_block, else_statement, scope_id, safety_mode, span)
         Garbage(span) => CheckedStatement::Garbage(span)
         For(iterator_name, name_span, range, block, span) => .typecheck_for(iterator_name,  name_span, range, block, scope_id, safety_mode, span)
-        Guard(span) => CheckedStatement::Garbage(span) // TODO: implement
+        Guard(expr, else_block, span) => .typecheck_guard(expr, else_block, scope_id, safety_mode, span)
+    }
+
+    function typecheck_guard(mut this, expr: ParsedExpression, else_block: ParsedBlock, scope_id: ScopeId, safety_mode: SafetyMode, span: Span) throws -> CheckedStatement {
+        let checked_expr = .typecheck_expression(expr, scope_id, safety_mode, type_hint: TypeId::none())
+        let checked_else_block = .typecheck_block(parsed_block: else_block, parent_scope_id: scope_id, safety_mode)
+
+        mut seen_scope_exit = false
+        for statement in checked_else_block.statements.iterator() {
+            match statement {
+                Break | Continue | Return | Throw => {
+                    seen_scope_exit = true
+                    break
+                }
+                else => {}
+            }
+        }
+        if not seen_scope_exit {
+            .error("Else block of guard must either `return`, `break`, `continue`, or `throw`", span) // FIXME: better span?
+        }
+
+        let condition = CheckedExpression::UnaryOp(expr: checked_expr, op: CheckedUnaryOperator::LogicalNot(), span: expr.span(), type_id: builtin(BuiltinType::Bool))
+
+        return CheckedStatement::If(condition, then_block: checked_else_block, else_statement: CheckedStatement::none(), span)
     }
 
     function typecheck_for(mut this, iterator_name: String, name_span: Span, range: ParsedExpression, block: ParsedBlock, scope_id: ScopeId, safety_mode: SafetyMode, span: Span) throws -> CheckedStatement {


### PR DESCRIPTION
This patch adds support for the `guard` keyword from swift. Fixes #452.
```
[ PASS ] samples/guard/basic.jakt
[ PASS ] samples/guard/no_else.jakt
[ PASS ] samples/guard/no_scope_exit.jakt
```
I understand this probably won't get merged until the selfhost gets to 100% but that can't be too far away, right?