### PR TITLE
selfhost/typechecker: Dupe prevention only in scope being added to

### DIFF
--- a/selfhost/typechecker.jakt
+++ b/selfhost/typechecker.jakt
@@ -1656,8 +1656,8 @@ struct Typechecker {
 
     function add_type_to_scope(mut this, scope_id: ScopeId, type_name: String, type_id: TypeId, span: Span) throws -> bool {
         mut scope = .get_scope(id: scope_id)
-        let found_type_id = .find_type_in_scope(scope_id, name: type_name)
-        if found_type_id.has_value() {
+        let found_type_id = scope.types.get(type_name)
+        if found_type_id.has_value() and not found_type_id!.equals(type_id) {
             // FIXME: Show hint of the original definition, once we store the name span.
             .error(
                 format("Redefinition of type ‘{}’", type_name)


### PR DESCRIPTION
This was originally using `.find_type_in_scope` which would check the full scope (including parents). This prevented generics from shadowing where they should.

This checks only the scope you're adding the type to for the duplicate.

No new tests pass, yet, but samples/math/integer_casts.jakt no longer exits with error code 2.