### PR TITLE
jakttest: Add macOS support.

### DIFF
--- a/jakttest/run-all.sh
+++ b/jakttest/run-all.sh
@@ -49,11 +49,14 @@ done
 
 
 # default JOBS to number of prossing units dictated by kernel
-[ -z "$JOBS" ] && JOBS=$(nproc)
+if [[ $OSTYPE == 'darwin'* ]]; then
+    [ -z "$JOBS" ] && JOBS=$(sysctl -n hw.ncpu)
+else
+    [ -z "$JOBS" ] && JOBS=$(nproc)
+fi
 
 tempdir=$(mktemp -d)
 
 trap "rm -rf $tempdir" EXIT
 
 ./jakttest/build/jakttest --jobs "$JOBS" "$tempdir" ${TEST_FILES[@]}
-


### PR DESCRIPTION
This PR aims to add macOS support to jakttest as `nproc` isnt a command on macOS. 
Details: 
- The `jakttest/run-all.sh` script checks if the operating system is macOS
- On that case, it replaces `nproc` with `sysctl -n hw.ncpu`

This successfully works on my mac. 
Details : macOS Monterey 12.4. Shell : zsh