### PR TITLE
jakttest: Pre-touch output files

### DIFF
--- a/jakttest/build.ninja
+++ b/jakttest/build.ninja
@@ -18,6 +18,6 @@ build build: mkdir
 # NOTE: pipe `|` is for implicit dependencies, so that ninja considers the target outdated if any
 # of those have changed, even if it's not stated as an input.
 build build/jakttest.cpp: jakttest | jakttest.jakt utility.jakt parser.jakt lexer.jakt error.jakt
-build build/jakttest: cxx build/jakttest-patched.cpp process.cpp | process.h
-build build/jakttest-patched.cpp: patch-includes build/jakttest.cpp
+build build/jakttest: cxx build/jakttest-patched.cpp process.cpp fs.cpp | process.h fs.h
+build build/jakttest-patched.cpp: patch-includes build/jakttest.cpp | patch-includes.py
 default build/jakttest

--- a/jakttest/fs.cpp
+++ b/jakttest/fs.cpp
@@ -1,0 +1,21 @@
+#include "fs.h"
+#include <Jakt/String.h>
+#include <fcntl.h>
+#include <sys/stat.h>
+
+namespace Jakt::fs {
+ErrorOr<void> touch(String path)
+{
+    int const fd = open(path.c_string(), O_WRONLY | O_CREAT | O_NOCTTY | O_NONBLOCK | O_TRUNC, 0666);
+    if (fd == -1)
+        return Error::from_errno(errno);
+    close(fd);
+    return ErrorOr<void> {};
+}
+
+ErrorOr<void> mkdir(String path) {
+    if (::mkdir(path.c_string(), S_IRWXU) == -1)
+        return Error::from_errno(errno);
+    return ErrorOr<void>{};
+}
+}

--- a/jakttest/fs.h
+++ b/jakttest/fs.h
@@ -1,0 +1,6 @@
+#include <Jakt/Forward.h>
+
+namespace Jakt::fs {
+    ErrorOr<void> touch(String path);;
+    ErrorOr<void> mkdir(String path);
+}

--- a/jakttest/jakttest.jakt
+++ b/jakttest/jakttest.jakt
@@ -14,6 +14,11 @@ namespace process {
     extern function forcefully_kill_process(pid: i32) throws
 }
 
+namespace fs {
+    extern function touch(path: String) throws
+    extern function mkdir(path: String) throws
+}
+
 function print_usage()  {
     eprintln("usage: jakttest [OPTIONS...] <temp-dir> <path> [... <path>]")
     eprintln("OPTIONS:")
@@ -409,10 +414,14 @@ function main(args: [String]) {
     mut directories: [String] = []
     directories.ensure_capacity(parsed_options.job_count as! usize)
     for i in 0..parsed_options.job_count {
-        let name = format("{}/jakttest-tmp-{}",  parsed_options.temp_dir, i)
-        // FIXME: Does this work in Windows?
-        system(("mkdir -p " + name).c_string())
-        directories.push(name)
+        let path = format("{}/jakttest-tmp-{}",  parsed_options.temp_dir, i)
+        fs::mkdir(path)
+        // create the output files
+        fs::touch(path: path + "/compile_jakt.err")
+        fs::touch(path: path + "/compile_cpp.err")
+        fs::touch(path: path + "/runtest.err")
+        fs::touch(path: path + "/runtest.out")
+        directories.push(path)
     }
 
     let run_result = TestScheduler::run_tests(tests, directories, collect_reasons: parsed_options.show_reasons)

--- a/jakttest/patch-includes.py
+++ b/jakttest/patch-includes.py
@@ -8,4 +8,5 @@ target_output = sys.argv[2]
 
 with open(target_file) as source, open(target_output, "w") as sink:
     sink.write('#include "../process.h"\n')
+    sink.write('#include "../fs.h"\n')
     sink.write(source.read())


### PR DESCRIPTION
For one test Jakttest might expect its output to be somewhere that the
shell script hasn't yet gotten to. This seems to avoid Jakttest erroring
out but it's only a temporary fix, since seems that it's not the *real*
reason why Jakttest fails to find an output file.
