### PR TITLE
 jakttest: Catch test failures that happen in an earlier stage

### DIFF
--- a/jakttest/fs.cpp
+++ b/jakttest/fs.cpp
@@ -4,18 +4,10 @@
 #include <sys/stat.h>
 
 namespace Jakt::fs {
-ErrorOr<void> touch(String path)
+ErrorOr<void> mkdir(String path)
 {
-    int const fd = open(path.c_string(), O_WRONLY | O_CREAT | O_NOCTTY | O_NONBLOCK | O_TRUNC, 0666);
-    if (fd == -1)
-        return Error::from_errno(errno);
-    close(fd);
-    return ErrorOr<void> {};
-}
-
-ErrorOr<void> mkdir(String path) {
     if (::mkdir(path.c_string(), S_IRWXU) == -1)
         return Error::from_errno(errno);
-    return ErrorOr<void>{};
+    return ErrorOr<void> {};
 }
 }

--- a/jakttest/fs.h
+++ b/jakttest/fs.h
@@ -1,6 +1,5 @@
 #include <Jakt/Forward.h>
 
 namespace Jakt::fs {
-    ErrorOr<void> touch(String path);;
-    ErrorOr<void> mkdir(String path);
+ErrorOr<void> mkdir(String path);
 }

--- a/jakttest/jakttest.jakt
+++ b/jakttest/jakttest.jakt
@@ -15,7 +15,6 @@ namespace process {
 }
 
 namespace fs {
-    extern function touch(path: String) throws
     extern function mkdir(path: String) throws
 }
 
@@ -188,16 +187,57 @@ struct Options {
     }
 }
 
+enum TestStage {
+    TranspileJakt
+    CompileCpp
+    TestRun
+
+    function equals(this, anon other: TestStage) => match this {
+        TranspileJakt => other is TranspileJakt
+        CompileCpp => other is CompileCpp
+        TestRun => other is TestRun
+    }
+
+    function to_string(this) => match this {
+        TranspileJakt => "Jakt transpilation to C++"
+        CompileCpp => "Clang++ compilation of generated C++ source"
+        TestRun => "Test binary run"
+    }
+
+    function from_exit_code(exit_code: i32) => match exit_code {
+        0i32 => Some(TestStage::TestRun)
+        1i32 => Some(TestStage::TestRun)
+        2i32 => Some(TestStage::CompileCpp)
+        3i32 => Some(TestStage::TranspileJakt)
+        else => {
+            let nothing: TestStage? = None
+            yield nothing
+        }
+    }
+}
+
 enum ResultKind {
     Okay
     CompileError
     RuntimeError
+
+    function output_filename(this) => match this {
+        Okay => "runtest.out"
+        RuntimeError => "runtest.err"
+        CompileError => "compile_jakt.err"
+    }
+
+    function to_stage(this) => match this {
+        Okay | RuntimeError => TestStage::TestRun
+        CompileError => TestStage::TranspileJakt
+    }
 }
 
 struct ExpectedResult {
     kind: ResultKind
     output: String
 }
+
 
 struct Test {
     result: ExpectedResult
@@ -216,6 +256,7 @@ enum TestFailedReason {
     ClangError(String)
     StderrUnmatched(had: String, expected: String)
     StdoutUnmatched(had: String, expected: String)
+    ErroredAtEarlierStage(failed_stage: String, error: String)
     AbruptExit(i32)
 }
 
@@ -239,65 +280,97 @@ struct TestScheduler {
             if poll_result.has_value() {
                 let exit_code = poll_result!
                 let test = .running_tests[pid]
+                .free_directories.push(test.directory_index)
+                .running_tests.remove(pid)
 
+                let maybe_stage = TestStage::from_exit_code(exit_code)
 
                 // unknown exit code. Assume that the job exited abruptly.
-                if exit_code < 0 or exit_code > 3 {
+                if not maybe_stage.has_value() {
                     eprintln("\r\x1b[2K[ \x1b[31;1mFAIL\x1b[m ] {}", test.file_name)
                     if .failed_reasons.has_value() {
                         .failed_reasons![test.file_name] = TestFailedReason::AbruptExit(exit_code)
                     }
                     .failed_count++
+                    continue
                 }
-                // clang++ error
-                if exit_code == 2 {
+                let stage = maybe_stage!
+
+                if stage is CompileCpp {
                     eprintln("\r\x1b[2K[ \x1b[31;1mFAIL\x1b[m ] {}", test.file_name)
                     if .failed_reasons.has_value() {
-                        mut file = File::open_for_reading("compile_cpp.err")
+                        let path = format("{}/compile_cpp.err",
+                            .directories[test.directory_index])
+                        mut file = File::open_for_reading(path)
                         let had = bytes_to_string(file.read_all())
                         .failed_reasons![test.file_name] = TestFailedReason::ClangError(had)
                     }
                     .failed_count++
-                } else {
-                    // check the test result
-                    let file_to_check = format("{}/{}"
-                                        .directories[test.directory_index]
-                                        match test.result.kind {
-                                            Okay => "runtest.out"
-                                            RuntimeError => "runtest.err"
-                                            CompileError => "compile_jakt.err"
-                                        })
+                    continue
+                }
 
-                    mut file = File::open_for_reading(file_to_check)
-                    let output = file.read_all()
-                    let expected = test.result.output
+                // check the exit code before anything
+                let expected_stage = test.result.kind.to_stage()
 
-                    let passed_test = match test.result.kind {
-                        Okay => compare_test(bytes: output, expected)
-                        RuntimeError | CompileError => compare_error(bytes: output, expected)
-                    }
-                    if passed_test {
-                        .passed_count++
-                    } else {
-                        eprintln("\r\x1b[2K[ \x1b[31;1mFAIL\x1b[m ] {}", test.file_name)
-                        if .failed_reasons.has_value() {
-                            .failed_reasons![test.file_name] = match test.result.kind {
-                                Okay => TestFailedReason::StdoutUnmatched(had: bytes_to_string(output)
-                                                                          expected)
-                                RuntimeError => TestFailedReason::StderrUnmatched(had: bytes_to_string(output)
-                                                                          expected)
-                                CompileError => TestFailedReason::CompilerErrorUnmatched(had: bytes_to_string(output)
-                                                                                 expected)
-                            }
+
+                if not stage.equals(expected_stage) {
+                    eprintln("\r\x1b[2K[ \x1b[31;1mFAIL\x1b[m ] {}", test.file_name)
+                    if .failed_reasons.has_value() {
+
+                        if not (stage is TranspileJakt) {
+                            panic("unreachable: Since clang++ errors and other codes get handled otherwise, only thing that could fail before its expected stage is Jakt to C++.")
                         }
+
+                        let file_to_check = format("{}/compile_jakt.err"
+                                                   .directories[test.directory_index])
+
+                        mut file = File::open_for_reading(file_to_check)
+                        let error = bytes_to_string(file.read_all())
+
+                        .failed_reasons![test.file_name] = 
+                            TestFailedReason::ErroredAtEarlierStage(
+                                failed_stage: stage.to_string()
+                                error)
+
+                    }
+                    .failed_count++
+                    continue
+                }
+
+                // check the test result
+                let file_to_check = format("{}/{}"
+                                    .directories[test.directory_index]
+                                    test.result.kind.output_filename())
+
+
+                mut file = File::open_for_reading(file_to_check)
+                let output = file.read_all()
+                let expected = test.result.output
+
+
+                let passed_test = match test.result.kind {
+                    Okay => compare_test(bytes: output, expected)
+                    RuntimeError | CompileError => compare_error(bytes: output, expected)
+                }
+                if passed_test {
+                    .passed_count++
+                } else {
+                    eprintln("\r\x1b[2K[ \x1b[31;1mFAIL\x1b[m ] {}", test.file_name)
+                    if .failed_reasons.has_value() {
+                        .failed_reasons![test.file_name] = match test.result.kind {
+                            Okay => TestFailedReason::StdoutUnmatched(had: bytes_to_string(output)
+                                                                      expected)
+                            RuntimeError => TestFailedReason::StderrUnmatched(had: bytes_to_string(output)
+                                                                      expected)
+                            CompileError => TestFailedReason::CompilerErrorUnmatched(had: bytes_to_string(output)
+                                                                             expected)
+                        }
+                    }
                     .failed_count++
                 }
-                }
 
 
 
-                .free_directories.push(test.directory_index)
-                .running_tests.remove(pid)
             }
         }
     }
@@ -424,11 +497,6 @@ function main(args: [String]) {
     for i in 0..parsed_options.job_count {
         let path = format("{}/jakttest-tmp-{}",  parsed_options.temp_dir, i)
         fs::mkdir(path)
-        // create the output files
-        fs::touch(path: path + "/compile_jakt.err")
-        fs::touch(path: path + "/compile_cpp.err")
-        fs::touch(path: path + "/runtest.err")
-        fs::touch(path: path + "/runtest.out")
         directories.push(path)
     }
 
@@ -472,6 +540,11 @@ function main(args: [String]) {
                     output += expected
                     output += "\nGot:"
                     output += had
+                }
+                ErroredAtEarlierStage(failed_stage, error) => {
+                    output += "Test failed at an earlier stage than expected:\n"
+                    output +=  failed_stage + " failed with output:\n"
+                    output += error
                 }
                 AbruptExit(exit_code) => {
                     output += "Test job exited with an unexpected code.\n"


### PR DESCRIPTION
There might be cases where the test that we launched fails at a different
stage than what we are told to check; in that case we get the error output
of the stage that failed and store that if --show-reasons is set.

Reverts the changes from #900, since it fixes the actual bug instead of being a
mere workaround.

EDIT(2): test summary when rebasing with `main`:
```
==============================
330 passed
7 failed
3 skipped
==============================
```