### PR TITLE
jakttest: Remove clutter from Jakttest's output

### DIFF
--- a/jakttest/jakttest.jakt
+++ b/jakttest/jakttest.jakt
@@ -243,7 +243,7 @@ struct TestScheduler {
 
                 // unknown exit code. Assume that the job exited abruptly.
                 if exit_code < 0 or exit_code > 3 {
-                    eprintln("[ \x1b[31;1mFAIL\x1b[m ] {}", test.file_name)
+                    eprintln("\r\x1b[2K[ \x1b[31;1mFAIL\x1b[m ] {}", test.file_name)
                     if .failed_reasons.has_value() {
                         .failed_reasons![test.file_name] = TestFailedReason::AbruptExit(exit_code)
                     }
@@ -251,7 +251,7 @@ struct TestScheduler {
                 }
                 // clang++ error
                 if exit_code == 2 {
-                    eprintln("[ \x1b[31;1mFAIL\x1b[m ] {}", test.file_name)
+                    eprintln("\r\x1b[2K[ \x1b[31;1mFAIL\x1b[m ] {}", test.file_name)
                     if .failed_reasons.has_value() {
                         mut file = File::open_for_reading("compile_cpp.err")
                         let had = bytes_to_string(file.read_all())
@@ -277,10 +277,9 @@ struct TestScheduler {
                         RuntimeError | CompileError => compare_error(bytes: output, expected)
                     }
                     if passed_test {
-                        eprintln("[ \x1b[32;1mPASS\x1b[m ] {}", test.file_name)
                         .passed_count++
                     } else {
-                        eprintln("[ \x1b[31;1mFAIL\x1b[m ] {}", test.file_name)
+                        eprintln("\r\x1b[2K[ \x1b[31;1mFAIL\x1b[m ] {}", test.file_name)
                         if .failed_reasons.has_value() {
                             .failed_reasons![test.file_name] = match test.result.kind {
                                 Okay => TestFailedReason::StdoutUnmatched(had: bytes_to_string(output)
@@ -329,6 +328,7 @@ struct TestScheduler {
     }
 
     public function run_tests(mut tests: [Test], directories: [String], collect_reasons: bool) throws -> TestsRunResult {
+        let total_test_count = tests.size()
         mut scheduler = TestScheduler::create(directories, collect_reasons)
         // pre-allocate the command buffer to avoid allocating inside a loop
         mut command_buffer: [String] = ["./jakttest/run-one.sh" "" ""]
@@ -343,6 +343,12 @@ struct TestScheduler {
                 command_buffer[2] = test.file_name
                 let pid = process::start_background_process(args: command_buffer)
                 scheduler.running_tests[pid] = test
+                eprint("\r\x1b[2K[ \x1b[1;31m{}\x1b[m/\x1b[1;32m{}\x1b[m/{} ] Testing {}"
+                        scheduler.failed_count
+                        scheduler.passed_count
+                        total_test_count
+                        test.file_name)
+                unsafe { cpp { "fflush(stderr);" }}
                 continue
             }
 
@@ -352,6 +358,8 @@ struct TestScheduler {
         while not scheduler.running_tests.is_empty() {
             scheduler.poll_running_tests()
         }
+        eprint("\r\x1b[2K")
+        unsafe { cpp { "fflush(stderr);" }}
 
         return TestsRunResult(passed_count: scheduler.passed_count
                               failed_count: scheduler.failed_count


### PR DESCRIPTION
Now Jakttest only outputs the tests that were skipped/failed, and
doesn't output anything for passed tests, similar to how Ninja only
outputs one line if everything goes fine without output.

![sample screenshot](https://cdn.discordapp.com/attachments/977605897964617771/998355532102504528/unknown.png)
