### PR TITLE
typechecker: Teach 'statement_definitely_returns' about Throw as well

### DIFF
--- a/selfhost/typechecker.jakt
+++ b/selfhost/typechecker.jakt
@@ -3110,7 +3110,7 @@ struct Typechecker {
     }
 
     function statement_definitely_returns(this, anon statement: CheckedStatement) -> bool => match statement{
-        Return => true
+        Return | Throw => true
         // FIXME: CheckedStatement::If branches ugly implementation due to current compiler limitations
         If(condition, then_block, else_statement) => {
             mut ret = false

--- a/src/typechecker.rs
+++ b/src/typechecker.rs
@@ -3607,7 +3607,7 @@ fn typecheck_method(
 
 pub fn statement_definitely_returns(stmt: &CheckedStatement) -> bool {
     match stmt {
-        CheckedStatement::Return(_) => true,
+        CheckedStatement::Return(_) | CheckedStatement::Throw(_) => true,
         CheckedStatement::If(CheckedExpression::Boolean(true, _), then_block, _) => {
             then_block.definitely_returns
         }


### PR DESCRIPTION
Throwing also transfers control the same way as returning does, this
makes the compiler no longer get mad about missing returns in throwing
branches:

    function foo() throws -> i32 {
        throw Error::from_errno(10)
    }