### PR TITLE
selfhost/typechecker: Align Typed enum typecheck with Rust-based

### DIFF
--- a/selfhost/typechecker.jakt
+++ b/selfhost/typechecker.jakt
@@ -5108,19 +5108,21 @@ struct Typechecker {
                                     }
                                     Typed(name, type_id, span) => {
                                         covered_variants.add(name)
-                                        if variant_arguments.size() != 1 {
-                                            .error(format("Match case ‘{}’ must have exactly one argument", name), span)
-                                        } else {
-                                            let variant_argument = variant_arguments[0]
-                                            let var_id = module.add_variable(CheckedVariable(
-                                                name: variant_argument.binding
-                                                type_id
-                                                is_mutable: false
-                                                definition_span: span
-                                                visibility: Visibility::Public
-                                            ))
-                                            .add_var_to_scope(scope_id: new_scope_id, name: variant_argument.binding, var_id, span)
-                                        }
+                                        if not variant_arguments.is_empty() {
+                                            if variant_arguments.size() != 1 {
+                                                .error(format("Match case ‘{}’ must have exactly one argument", name), span)
+                                            } else {
+                                                let variant_argument = variant_arguments[0]
+                                                let var_id = module.add_variable(CheckedVariable(
+                                                    name: variant_argument.binding
+                                                    type_id
+                                                    is_mutable: false
+                                                    definition_span: span
+                                                    visibility: Visibility::Public
+                                                ))
+                                                .add_var_to_scope(scope_id: new_scope_id, name: variant_argument.binding, var_id, span)
+                                            }
+                                        } 
                                     }
                                     StructLike(name, fields) => {
                                         covered_variants.add(name)


### PR DESCRIPTION
This was a recurring issue with selfhost compiling selfhost. Align the Typed enum case typecheck to be closer to what the Rust-based one does, which gets rid of the error.