### PR TITLE
Make `samples/math/too_small_literal.jakt` pass with selfhost

### DIFF
--- a/samples/math/too_small_literal.jakt
+++ b/samples/math/too_small_literal.jakt
@@ -1,5 +1,5 @@
 /// Expect:
-/// - error: "Literal Unsigned(9223372036854775809) too small for unsigned integer type u64"
+/// - error: "Negative literal -9223372036854775809 too small for type ‘i64’"
 
 function main() {
     let too_small_i64 = -9_223_372_036_854_775_809;

--- a/selfhost/lexer.jakt
+++ b/selfhost/lexer.jakt
@@ -273,6 +273,7 @@ enum Token {
 }
 
 enum LiteralSuffix {
+    None
     UZ
     U8
     U16
@@ -312,22 +313,6 @@ enum NumericConstant {
         // FIXME: handle floats properly - if the function is used at all?
         else =>  0 as! usize
     }
-}
-
-function make_integer_token(number: u64, suffix: LiteralSuffix, span: Span) throws -> Token => match suffix {
-    // FIXME: consider unifying with make_float_token() to a single function
-    LiteralSuffix::U8 => Token::Number(number: NumericConstant::U8(number as! u8), span)
-    LiteralSuffix::U16 => Token::Number(number: NumericConstant::U16(number as! u16), span)
-    LiteralSuffix::U32 => Token::Number(number: NumericConstant::U32(number as! u32), span)
-    LiteralSuffix::U64 => Token::Number(number: NumericConstant::U64(number as! u64), span)
-    LiteralSuffix::UZ => Token::Number(number: NumericConstant::USize(number as! u64), span)
-
-    LiteralSuffix::I8 => Token::Number(number: NumericConstant::I8(number as! i8), span)
-    LiteralSuffix::I16 => Token::Number(number: NumericConstant::I16(number as! i16), span)
-    LiteralSuffix::I32 => Token::Number(number: NumericConstant::I32(number as! i32), span)
-    LiteralSuffix::I64 => Token::Number(number: NumericConstant::I64(number as! i64), span)
-
-    else => Token::Garbage(span)
 }
 
 function make_float_token(number: f64, suffix: LiteralSuffix, span: Span) throws -> Token => match suffix {
@@ -542,9 +527,9 @@ struct Lexer {
                         return Token::Garbage(span)
                     }
 
-                    let suffix = .consume_numeric_literal_suffix() ?? LiteralSuffix::I64
+                    let suffix = .consume_numeric_literal_suffix() ?? LiteralSuffix::None
 
-                    return make_integer_token(number: total, suffix, span: .span(start, end))
+                    return .make_integer_token(number: total, suffix, span: .span(start, end))
                 }
                 // Octal Number
                 b'o' => {
@@ -569,7 +554,7 @@ struct Lexer {
                         return Token::Garbage(span)
                     }
 
-                    let suffix = .consume_numeric_literal_suffix() ?? LiteralSuffix::I64
+                    let suffix = .consume_numeric_literal_suffix() ?? LiteralSuffix::None
 
                     if is_ascii_alphanumeric(.peek()) {
                         .error(
@@ -579,7 +564,7 @@ struct Lexer {
                         return Token::Garbage(span)
                     }
 
-                    return make_integer_token(number: total, suffix, span)
+                    return .make_integer_token(number: total, suffix, span)
                 }
                 // Binary Number
                 b'b' => {
@@ -604,7 +589,7 @@ struct Lexer {
                         return Token::Garbage(span)
                     }
 
-                    let suffix = .consume_numeric_literal_suffix() ?? LiteralSuffix::I64
+                    let suffix = .consume_numeric_literal_suffix() ?? LiteralSuffix::None
 
                     if is_ascii_alphanumeric(.peek()) {
                         .error(
@@ -615,7 +600,7 @@ struct Lexer {
                         return Token::Garbage(span)
                     }
 
-                    return make_integer_token(number: total, suffix, span)
+                    return .make_integer_token(number: total, suffix, span)
                 }
                 else => {}
             }
@@ -673,7 +658,7 @@ struct Lexer {
 
         let default_suffix = match floating {
             true => LiteralSuffix::F64
-            else => LiteralSuffix::I64
+            else => LiteralSuffix::None
         }
         let suffix = .consume_numeric_literal_suffix() ?? default_suffix
 
@@ -701,7 +686,7 @@ struct Lexer {
                 let number: f64 = u64_to_float<f64>(total) + u64_to_float<f64>(fraction_nominator)/u64_to_float<f64>(fraction_denominator)
                 yield make_float_token(number, suffix, span: .span(start, end))
             }
-            else => make_integer_token(number: total, suffix, span: .span(start, end))
+            else => .make_integer_token(number: total, suffix, span: .span(start, end))
         }
     }
 
@@ -1030,4 +1015,91 @@ struct Lexer {
     function is_whitespace(this, anon ch: u8) -> bool {
         return ch == b' ' or ch == b'\t' or ch == b'\r' or ch == b'\f' or ch == b'\v'
     }    
+
+    function make_integer_token(mut this, number: u64, suffix: LiteralSuffix, span: Span) throws -> Token {
+        // FIXME: consider unifying with make_float_token() to a single function
+        match suffix {
+            None => {
+                let n = number as? i64
+                if n.has_value() {
+                    return Token::Number(number: NumericConstant::I64(n!), span)
+                }
+                return Token::Number(number: NumericConstant::U64(number), span)
+            }
+            U8 => {
+                let n = number as? u8
+                if not n.has_value() {
+                    .error(format("Number {} cannot fit in integer type {}", number, suffix), span)
+                    return Token::Number(number: NumericConstant::U64(number), span)
+                }
+                return Token::Number(number: NumericConstant::U8(n!), span)
+            }
+            U16 => {
+                let n = number as? u16
+                if not n.has_value() {
+                    .error(format("Number {} cannot fit in integer type {}", number, suffix), span)
+                    return Token::Number(number: NumericConstant::U64(number), span)
+                }
+                return Token::Number(number: NumericConstant::U16(n!), span)
+            }
+            U32 => {
+                let n = number as? u32
+                if not n.has_value() {
+                    .error(format("Number {} cannot fit in integer type {}", number, suffix), span)
+                    return Token::Number(number: NumericConstant::U64(number), span)
+                }
+                return Token::Number(number: NumericConstant::U32(n!), span)
+            }
+            U64 => {
+                let n = number as? u64
+                if not n.has_value() {
+                    .error(format("Number {} cannot fit in integer type {}", number, suffix), span)
+                    return Token::Number(number: NumericConstant::U64(number), span)
+                }
+                return Token::Number(number: NumericConstant::U64(n!), span)
+            }
+            UZ => {
+                let n = number as? usize
+                if not n.has_value() {
+                    .error(format("Number {} cannot fit in integer type {}", number, suffix), span)
+                    return Token::Number(number: NumericConstant::U64(number), span)
+                }
+                return Token::Number(number: NumericConstant::USize(n! as! u64), span)
+            }
+            I8 => {
+                let n = number as? i8
+                if not n.has_value() {
+                    .error(format("Number {} cannot fit in integer type {}", number, suffix), span)
+                    return Token::Number(number: NumericConstant::U64(number), span)
+                }
+                return Token::Number(number: NumericConstant::I8(n!), span)
+            }
+            I16 => {
+                let n = number as? i16
+                if not n.has_value() {
+                    .error(format("Number {} cannot fit in integer type {}", number, suffix), span)
+                    return Token::Number(number: NumericConstant::U64(number), span)
+                }
+                return Token::Number(number: NumericConstant::I16(n!), span)
+            }
+            I32 => {
+                let n = number as? i32
+                if not n.has_value() {
+                    .error(format("Number {} cannot fit in integer type {}", number, suffix), span)
+                    return Token::Number(number: NumericConstant::U64(number), span)
+                }
+                return Token::Number(number: NumericConstant::I32(n!), span)
+            }
+            I64 => {
+                let n = number as? i64
+                if not n.has_value() {
+                    .error(format("Number {} cannot fit in integer type {}", number, suffix), span)
+                    return Token::Number(number: NumericConstant::U64(number), span)
+                }
+                return Token::Number(number: NumericConstant::I64(n!), span)
+            }
+            else => {}
+        }
+        return Token::Garbage(span)
+    }
 }

--- a/selfhost/typechecker.jakt
+++ b/selfhost/typechecker.jakt
@@ -327,6 +327,19 @@ boxed enum Type {
     }
 }
 
+// FIXME: This could be part of Type
+function flip_signedness(type: Type) throws -> TypeId => match type {
+    I8 => builtin(BuiltinType::U8)
+    I16 => builtin(BuiltinType::U16)
+    I32 => builtin(BuiltinType::U32)
+    I64 => builtin(BuiltinType::U64)
+    U8 => builtin(BuiltinType::I8)
+    U16 => builtin(BuiltinType::I16)
+    U32 => builtin(BuiltinType::I32)
+    U64 => builtin(BuiltinType::I64)
+    else => builtin(BuiltinType::Unknown)
+}
+
 class Scope {
     public namespace_name: String?
     public vars: [String: VarId]
@@ -589,6 +602,15 @@ enum NumberConstant {
                 F64 => true
                 else => false
             }
+        }
+    }
+
+    function to_usize(this) -> usize => match this {
+        Signed(value) => value as! usize
+        Unsigned(value) => value as! usize
+        Floating(value) => {
+            panic("to_usize on a floating point constant")
+            yield 0uz
         }
     }
 }
@@ -3770,7 +3792,7 @@ struct Typechecker {
                 return CheckedExpression::UnaryOp(expr: checked_expr, op: checked_op, span, type_id: cast.type_id())
             }
             Negate => {
-                return CheckedExpression::UnaryOp(expr: checked_expr, op: checked_op, span, type_id: expr_type_id)
+                return .typecheck_unary_negate(expr: checked_expr, span, type_id: expr_type_id)
             }
             Is | IsEnumVariant => {
                 return CheckedExpression::UnaryOp(expr: checked_expr, op: checked_op, span, type_id: builtin(BuiltinType::Bool))
@@ -3793,6 +3815,53 @@ struct Typechecker {
             }
         }
         return CheckedExpression::UnaryOp(expr: checked_expr, op: checked_op, span, type_id: expr_type_id)
+    }
+
+    function typecheck_unary_negate(mut this, expr: CheckedExpression, span: Span, type_id: TypeId) throws -> CheckedExpression {
+        if not .program.is_integer(type_id) or .program.is_signed(type_id) {
+            return CheckedExpression::UnaryOp(expr, op: CheckedUnaryOperator::Negate, span, type_id)
+        }
+
+        // Flipping the sign on a small enough unsigned constant is fine. We'll change the type to the signed variant.
+        let flipped_sign_type = flip_signedness(type: .get_type(type_id))
+
+        let constant = match expr {
+            NumericConstant(val) => val
+            else => {
+                return CheckedExpression::UnaryOp(expr, op: CheckedUnaryOperator::Negate, span, type_id)
+            }
+        }
+
+        let number = constant.number_constant()!
+        let raw_number = number.to_usize()
+
+        if not number.can_fit_number(type_id: flipped_sign_type, program: .program) {
+            .error(
+                format(
+                    "Negative literal -{} too small for type ‘{}’"
+                    raw_number
+                    .type_name(flipped_sign_type)
+                )
+                span
+            )
+            return CheckedExpression::UnaryOp(expr, op: CheckedUnaryOperator::Negate, span, type_id)
+        }
+
+        let negated_number = 0 - raw_number as! i64
+
+        let new_constant = match .get_type(flipped_sign_type) {
+            I8 => CheckedNumericConstant::I8(negated_number as! i8)
+            I16 => CheckedNumericConstant::I16(negated_number as! i16)
+            I32 => CheckedNumericConstant::I32(negated_number as! i32)
+            I64 => CheckedNumericConstant::I64(negated_number as! i64)
+            else => {
+                // FIXME: Unreachable
+                panic("Unreachable")
+                yield CheckedNumericConstant::I64(negated_number as! i64)
+            }
+        }
+
+        return CheckedExpression::UnaryOp(expr: CheckedExpression::NumericConstant(val: new_constant, span, type_id), op: CheckedUnaryOperator::Negate, span, type_id: flipped_sign_type)
     }
 
     function typecheck_binary_operation(mut this, checked_lhs: CheckedExpression, op: BinaryOperator, checked_rhs: CheckedExpression, scope_id: ScopeId, span: Span) throws -> TypeId {

--- a/src/codegen.rs
+++ b/src/codegen.rs
@@ -3471,9 +3471,17 @@ fn codegen_expr(
                     output.push_str(">(");
                 }
                 CheckedUnaryOperator::TypeCast(cast) => {
+                    let mut final_type_id = *type_id;
                     match cast {
                         CheckedTypeCast::Fallible(_) => {
-                            if is_integer(*type_id) {
+                            let type_id = match project.get_type(*type_id) {
+                                Type::GenericInstance(_, args) => args[0],
+                                _ => {
+                                    panic!("Fallible type cast must have Optional result.");
+                                }
+                            };
+                            if is_integer(type_id) {
+                                final_type_id = type_id;
                                 output.push_str("fallible_integer_cast");
                             } else {
                                 output.push_str("dynamic_cast");
@@ -3488,7 +3496,7 @@ fn codegen_expr(
                         }
                     }
                     output.push('<');
-                    output.push_str(&codegen_type(*type_id, project));
+                    output.push_str(&codegen_type(final_type_id, project));
                     output.push_str(">(");
                 }
                 _ => {}

--- a/src/typechecker.rs
+++ b/src/typechecker.rs
@@ -6210,9 +6210,9 @@ pub fn typecheck_unary_operation(
                                     Some(JaktError::TypecheckError(
                                         // FIXME: Print this more nicely
                                         format!(
-                                            "Literal {:?} too small for unsigned integer type {}",
-                                            number.number_constant().unwrap(),
-                                            project.typename_for_type_id(type_id)
+                                            "Negative literal -{} too small for type ‘{}’",
+                                            number.number_constant().unwrap().to_usize(),
+                                            project.typename_for_type_id(flipped_sign_type)
                                         ),
                                         span,
                                     )),

--- a/src/typechecker.rs
+++ b/src/typechecker.rs
@@ -1317,15 +1317,19 @@ pub enum CheckedTypeCast {
 }
 
 impl CheckedTypeCast {
-    pub fn type_id_or_type_var(&self) -> TypeId {
+    pub fn type_id_or_type_var(&self, project: &mut Project) -> TypeId {
         match self {
-            CheckedTypeCast::Fallible(type_id) => *type_id,
+            CheckedTypeCast::Fallible(type_id) => {
+                let optional_struct_id = project.find_struct_in_prelude("Optional");
+                let optional_type = Type::GenericInstance(optional_struct_id, vec![*type_id]);
+                project.find_or_add_type_id(optional_type)
+            }
             CheckedTypeCast::Infallible(type_id) => *type_id,
         }
     }
 
-    pub fn type_id(&self, scope_id: ScopeId, project: &Project) -> TypeId {
-        resolve_type_var(self.type_id_or_type_var(), scope_id, project)
+    pub fn type_id(&self, scope_id: ScopeId, project: &mut Project) -> TypeId {
+        resolve_type_var(self.type_id_or_type_var(project), scope_id, project)
     }
 }
 


### PR DESCRIPTION
It turns out that fallible integer casts never worked at all. This made them hard to use in selfhost, so this patch starts by fixing them in the rust-based compiler.

We then move on to fixing the `samples/math/too_small_literal.jakt` test in the selfhost compiler