### PR TITLE
selfhost/parser+typechecker+codegen: Add basic support for closures

### DIFF
--- a/samples/closures/basic.jakt
+++ b/samples/closures/basic.jakt
@@ -1,0 +1,12 @@
+/// Expect
+/// - output: "PASS\nPASS\n"
+
+function main() {
+    let x = function() {
+        return "PASS"
+    }
+    let y = function() => "PASS"
+
+    println("{}", x())
+    println("{}", y())
+}

--- a/samples/closures/function_as_parameter.jakt
+++ b/samples/closures/function_as_parameter.jakt
@@ -1,0 +1,10 @@
+/// Expect
+/// - output: "PASS the peas!\n"
+
+function a(anon cb: function(x: String) -> void) {
+    cb(x: " the peas!")
+}
+
+function main() {
+    a(function(x: String) => println("PASS{}", x))
+}

--- a/selfhost/codegen.jakt
+++ b/selfhost/codegen.jakt
@@ -675,8 +675,12 @@ struct CodeGenerator {
 
     function codegen_function_predecl(mut this, function_: CheckedFunction) throws -> String {
         mut output = ""
-
+        
         if not function_.generic_params.is_empty() and function_.linkage is External {
+            return ""
+        }
+
+        if not function_.parsed_function.has_value() {
             return ""
         }
 
@@ -1472,7 +1476,7 @@ struct CodeGenerator {
         Function(function_) => {
             mut params: [String] = []
             for param in function_.params.iterator() {
-                params.push(.codegen_type(param.variable.type_id) + param.variable.name)
+                params.push(format("{} {}", .codegen_type(param.variable.type_id), param.variable.name))
             }
             yield format("[&]({}) {}", join(params, separator: ", "), .codegen_block(block: function_.block))
         }
@@ -2375,7 +2379,7 @@ struct CodeGenerator {
         JaktString => "String"
         CChar => "char"
         CInt => "int"
-        Unknown => "auto"
+        Unknown | Function => "auto"
         RawPtr(type_id) => .codegen_type(type_id) + "*"
         GenericInstance(id, args) => .codegen_generic_type_instance(id, args, as_namespace)
         Struct(id) => .codegen_struct_type(id, as_namespace)
@@ -2715,6 +2719,9 @@ struct CodeGenerator {
                 External => { return "" }
                 else => {}
             }
+        }
+        if not function_.parsed_function.has_value() {
+            return ""
         }
 
         mut output = ""

--- a/selfhost/codegen.jakt
+++ b/selfhost/codegen.jakt
@@ -1469,6 +1469,13 @@ struct CodeGenerator {
 
             yield output
         }
+        Function(function_) => {
+            mut params: [String] = []
+            for param in function_.params.iterator() {
+                params.push(.codegen_type(param.variable.type_id) + param.variable.name)
+            }
+            yield format("[&]({}) {}", join(params, separator: ", "), .codegen_block(block: function_.block))
+        }
         else => {
             todo(format("codegen_expression else: {}", expression))
             yield ""
@@ -2368,6 +2375,7 @@ struct CodeGenerator {
         JaktString => "String"
         CChar => "char"
         CInt => "int"
+        Unknown => "auto"
         RawPtr(type_id) => .codegen_type(type_id) + "*"
         GenericInstance(id, args) => .codegen_generic_type_instance(id, args, as_namespace)
         Struct(id) => .codegen_struct_type(id, as_namespace)

--- a/selfhost/parser.jakt
+++ b/selfhost/parser.jakt
@@ -441,7 +441,7 @@ boxed enum ParsedType {
     Optional(inner: ParsedType, span: Span)
     RawPtr(inner: ParsedType, span: Span)
     WeakPtr(inner: ParsedType, span: Span)
-    Function(params: [ParsedType], return_type: ParsedType, span: Span)
+    Function(params: [ParsedParameter], return_type: ParsedType, span: Span)
     Empty
 
     function span(this) => match this {
@@ -1514,29 +1514,9 @@ struct Parser {
         Function => {
             let span = .current().span()
             .index++
-            mut params: [ParsedType] = []
             mut return_type = ParsedType::Empty
-            match .current() {
-                LParen => {
-                    .index++
-                }
-                else => {
-                    .error("Expected '('", .current().span())
-                    return ParsedType::Empty
-                }
-            }
 
-            while not .eof() {
-                match .current() {
-                    RParen => {
-                        .index++
-                        break
-                    }
-                    else => {
-                        params.push(.parse_typename())
-                    }
-                }
-            }
+            let params = .parse_function_parameters()
 
             match .current() {
                 Arrow => {
@@ -1562,6 +1542,7 @@ struct Parser {
                 if .current() is Colon {
                     .index++
                 } else {
+                    eprintln("here; {}", .current())
                     return ParsedVarDecl(
                         name: var_name,
                         parsed_type: ParsedType::Empty,

--- a/selfhost/parser.jakt
+++ b/selfhost/parser.jakt
@@ -317,6 +317,7 @@ boxed enum ParsedExpression {
     ForcedUnwrap(expr: ParsedExpression, span: Span)
     Match(expr: ParsedExpression, cases: [ParsedMatchCase], span: Span)
     NamespacedVar(name: String, namespace_: [String], span: Span)
+    Function(function_: ParsedFunction, span: Span)
     Garbage(Span)
 
     function span(this) => match this {
@@ -345,6 +346,7 @@ boxed enum ParsedExpression {
         IndexedTuple(expr, index, span) => span
         IndexedStruct(expr, field, span) => span
         NamespacedVar(name, namespace_, span) => span
+        Function(span) => span
     }
 
     function precedence(this) => match this {
@@ -439,6 +441,7 @@ boxed enum ParsedType {
     Optional(inner: ParsedType, span: Span)
     RawPtr(inner: ParsedType, span: Span)
     WeakPtr(inner: ParsedType, span: Span)
+    Function(params: [ParsedType], return_type: ParsedType, span: Span)
     Empty
 
     function span(this) => match this {
@@ -452,6 +455,7 @@ boxed enum ParsedType {
         Optional(inner, span) => span
         RawPtr(inner, span) => span
         WeakPtr(inner, span) => span
+        Function(span) => span
         Empty => Span(file_id: FileId(id: 0uz), start: 0, end: 0) // FIXME: For some reason we can't see `empty_span()` here.
     }
 }
@@ -460,9 +464,10 @@ struct Parser {
     index: usize
     tokens: [Token]
     compiler: Compiler
+    lamdba_count: usize
 
     function parse(compiler: Compiler, tokens: [Token]) throws -> ParsedNamespace {
-        mut parser = Parser(index: 0, tokens, compiler)
+        mut parser = Parser(index: 0, tokens, compiler, lamdba_count: 0)
         return parser.parse_namespace()
     }
 
@@ -1208,51 +1213,14 @@ struct Parser {
         return parsed_class
     }
 
-    public function parse_function(mut this, anon linkage: FunctionLinkage, anon visibility: Visibility) throws -> ParsedFunction {
-        mut parsed_function = ParsedFunction(
-            name: "",
-            name_span: .empty_span(),
-            visibility,
-            params: [],
-            generic_parameters: [],
-            block: ParsedBlock(stmts: []),
-            return_type: ParsedType::Empty,
-            return_type_span: .span(start: 0, end: 0),
-            can_throw: false,
-            type: FunctionType::Normal,
-            linkage,
-            must_instantiate: false,
-        )
-
-        .index++
-
-        if .eof() {
-            .error("Incomplete function definition", .current().span())
-            return parsed_function
-        }
-
-        let function_name = match .current() {
-            Identifier(name) => name
-            else => { return parsed_function }
-        }
-        parsed_function.name = function_name
-        parsed_function.name_span = .current().span()
-
-        .index++
-
-        parsed_function.generic_parameters = .parse_generic_parameters()
-
-        if .eof() {
-            .error("Incomplete function", .current().span())
-        }
-
-        if .current() is LParen {
-            .index++
-        } else {
+    function parse_function_parameters(mut this) throws -> [ParsedParameter] {
+        if not .current() is LParen {
             .error("Expected '('", .current().span())
+            return []
         }
-
+        .index++
         mut params: [ParsedParameter] = []
+
         mut current_param_requires_label = true
         mut current_param_is_mutable = false
 
@@ -1344,7 +1312,48 @@ struct Parser {
             }
         }
 
-        parsed_function.params = params
+        return params
+    }
+
+    public function parse_function(mut this, anon linkage: FunctionLinkage, anon visibility: Visibility) throws -> ParsedFunction {
+        mut parsed_function = ParsedFunction(
+            name: "",
+            name_span: .empty_span(),
+            visibility,
+            params: [],
+            generic_parameters: [],
+            block: ParsedBlock(stmts: []),
+            return_type: ParsedType::Empty,
+            return_type_span: .span(start: 0, end: 0),
+            can_throw: false,
+            type: FunctionType::Normal,
+            linkage,
+            must_instantiate: false,
+        )
+
+        .index++
+
+        if .eof() {
+            .error("Incomplete function definition", .current().span())
+            return parsed_function
+        }
+
+        let function_name = match .current() {
+            Identifier(name) => name
+            else => { return parsed_function }
+        }
+        parsed_function.name = function_name
+        parsed_function.name_span = .current().span()
+
+        .index++
+
+        parsed_function.generic_parameters = .parse_generic_parameters()
+
+        if .eof() {
+            .error("Incomplete function", .current().span())
+        }
+
+        parsed_function.params = .parse_function_parameters()
 
         // NOTE: main() always throws
         mut can_throw = function_name == "main"
@@ -1501,6 +1510,43 @@ struct Parser {
             }
 
             yield parsed_type
+        }
+        Function => {
+            let span = .current().span()
+            .index++
+            mut params: [ParsedType] = []
+            mut return_type = ParsedType::Empty
+            match .current() {
+                LParen => {
+                    .index++
+                }
+                else => {
+                    .error("Expected '('", .current().span())
+                    return ParsedType::Empty
+                }
+            }
+
+            while not .eof() {
+                match .current() {
+                    RParen => {
+                        .index++
+                        break
+                    }
+                    else => {
+                        params.push(.parse_typename())
+                    }
+                }
+            }
+
+            match .current() {
+                Arrow => {
+                    .index++
+                    return_type = .parse_typename()
+                }
+                else => {}
+            }
+
+            yield ParsedType::Function(params, return_type, span)
         }
         else => {
             .error("Expected type name", .current().span())
@@ -1717,7 +1763,10 @@ struct Parser {
                 let init = match .current() {
                     Equal => {
                         .index++
-                        yield .parse_expression(allow_assignments: false)
+                        yield match .current() {
+                            Function => .parse_function_expression(name: var.name, name_span: var.span)
+                            else => .parse_expression(allow_assignments: false)
+                        }
                     }
                     else => {
                         .error("Expected initializer", .current().span())
@@ -2062,12 +2111,56 @@ struct Parser {
         }
         Ampersand => .parse_ampersand()
         Asterisk => .parse_asterisk()
+        Function => .parse_function_expression(name: None, name_span: None)
         else => {
             let span = .current().span()
             .index++
             .error("Unsupported expression", span)
             yield ParsedExpression::Garbage(span)
         }
+    }
+
+    function parse_function_expression(mut this, name: String?, name_span: Span?) throws -> ParsedExpression {
+        let span = .current().span()
+        .index++
+        mut parsed_function = ParsedFunction(
+            name: name.value_or(format("lamdba{}", ++.lamdba_count)),
+            name_span: name_span ?? .empty_span(),
+            visibility: Visibility::Public,
+            params: [],
+            generic_parameters: [],
+            block: ParsedBlock(stmts: []),
+            return_type: ParsedType::Empty,
+            return_type_span: .span(start: 0, end: 0),
+            can_throw: false,
+            type: FunctionType::Normal,
+            linkage: FunctionLinkage::Internal,
+            must_instantiate: false,
+        )
+
+        parsed_function.generic_parameters = .parse_generic_parameters()
+        if .eof() {
+            .error("Incomplete function", .current().span())
+        }
+        parsed_function.params = .parse_function_parameters()
+        parsed_function.can_throw = .current() is Throws
+        if parsed_function.can_throw {
+            .index++
+        }
+        if .current() is Arrow {
+            .index++
+            let start = .current().span()
+            parsed_function.return_type = .parse_typename()
+            parsed_function.return_type_span = merge_spans(start, .previous().span())
+        }
+
+        if .current() is FatArrow {
+            parsed_function.block = .parse_fat_arrow()
+        } else {
+            parsed_function.block = .parse_block()
+        }
+
+        return ParsedExpression::Function(function_: parsed_function, span)
     }
 
     function parse_asterisk(mut this) throws -> ParsedExpression {
@@ -3103,6 +3196,10 @@ function parsed_expression_equals(anon lhs_expression: ParsedExpression, anon rh
             }
             yield lhs_name == rhs_name
         }
+        else => false
+    }
+    Function(function_) => match rhs_expression {
+        Function(function_: rhs_function) => true // FIXME: compare inputs, output, and body
         else => false
     }
     Garbage => rhs_expression is Garbage

--- a/selfhost/typechecker.jakt
+++ b/selfhost/typechecker.jakt
@@ -12,7 +12,7 @@ import parser { Parser, BinaryOperator, DefinitionLinkage, DefinitionType, Unary
                 ParsedExpression, ParsedFunction, ParsedNamespace,
                 ParsedType, ParsedStatement, ParsedVarDecl, RecordType,
                 ParsedRecord, ParsedField, TypeCast, EnumVariantPatternArgument,
-                ParsedMatchBody, ParsedMatchCase, Visibility }
+                ParsedMatchBody, ParsedMatchCase, Visibility, ParsedParameter }
 import utility { panic, todo, Span, join, FilePath, FileId }
 import compiler { Compiler }
 import prelude { JaktPrelude }
@@ -151,7 +151,7 @@ boxed enum Type {
     Struct(StructId)
     Enum(EnumId)
     RawPtr(TypeId)
-    Function(params: [TypeId], return_type_id: TypeId)
+    Function(params: [CheckedParameter], return_type_id: TypeId)
 
     function equals(this, anon rhs: Type) -> bool {
         if this is Void and rhs is Void {
@@ -278,9 +278,10 @@ boxed enum Type {
                             return false
                         }
                         for i in 0..params.size() {
-                            if not params[i].equals(rhs_params[i]) {
-                                return false
-                            }
+                            // FIXME: compare parameters
+                            // if not params[i].equals(rhs_params[i]) { 
+                            //     return false
+                            // }
                         }
                         return return_type_id.equals(rhs_return_type_id)
                     }
@@ -2835,6 +2836,73 @@ struct Typechecker {
         checked_function.return_type_id = return_type_id
     }
 
+    function typecheck_parameters(mut this, parsed_parameters: [ParsedParameter], parent_scope_id: ScopeId, checked_function_scope_id: ScopeId, block_scope_id: ScopeId, this_arg_type_id: TypeId?, check_scope: ScopeId?) throws -> [CheckedParameter] {
+        mut checked_parameters: [CheckedParameter] = []
+        mut first = true
+        mut module = .current_module()
+
+        for parameter in parsed_parameters.iterator() {
+            mut type_id = .typecheck_typename(parsed_type: parameter.variable.parsed_type, scope_id: checked_function_scope_id)
+
+            if first and parameter.variable.name == "this" {
+                if this_arg_type_id.has_value() {
+                    type_id = this_arg_type_id!
+                }
+            }
+            first = false
+
+            let variable = CheckedVariable(
+                name: parameter.variable.name
+                type_id
+                is_mutable: parameter.variable.is_mutable
+                definition_span: parameter.variable.span
+                visibility: Visibility::Public
+            )
+
+            let checked_parameter = CheckedParameter(
+                requires_label: parameter.requires_label
+                variable
+            )
+
+            checked_parameters.push(checked_parameter)
+
+            if check_scope.has_value() {
+                let var_id = module.add_variable(variable)
+                .add_var_to_scope(
+                    scope_id: check_scope!,
+                    name: parameter.variable.name,
+                    variable: var_id,
+                    span: parameter.variable.span,
+                )
+            }
+
+            match .get_type(type_id) {
+                Function(params, return_type_id) => {
+                    let function_parameter = CheckedFunction(
+                        name: parameter.variable.name
+                        name_span: parameter.variable.span
+                        visibility: Visibility::Public
+                        return_type_id
+                        params
+                        generic_params: [] // FIXME: support generics
+                        block: CheckedBlock(statements: [], scope_id: block_scope_id, definitely_returns: false, yielded_type: None)
+                        can_throw: false // FIXME: store this on the type?
+                        type: FunctionType::Normal // FIXME: lambda?
+                        linkage: FunctionLinkage::Internal
+                        function_scope_id: block_scope_id
+                        is_instantiated: false
+                        parsed_function: None
+                    )
+                    let function_id = module.add_function(checked_function: function_parameter)
+                    .add_function_to_scope(parent_scope_id, name: parameter.variable.name, function_id, span: function_parameter.name_span)
+                }
+                else => {}
+            }
+        }
+
+        return checked_parameters
+    }
+
     function typecheck_function_predecl(mut this, parsed_function: ParsedFunction, parent_scope_id: ScopeId, this_arg_type_id: TypeId?) throws {
         let function_scope_id = .create_scope(parent_scope_id, can_throw: parsed_function.can_throw, debug_name: format("function({})", parsed_function.name))
         let scope_debug_name = format("function-block({})", parsed_function.name)
@@ -2908,44 +2976,7 @@ struct Typechecker {
         }
 
         // Check parameters
-        mut first = true
-        mut module = .current_module()
-
-        for parameter in parsed_function.params.iterator() {
-            mut type_id = .typecheck_typename(parsed_type: parameter.variable.parsed_type, scope_id: checked_function_scope_id)
-
-            if first and parameter.variable.name == "this" {
-                if this_arg_type_id.has_value() {
-                    type_id = this_arg_type_id!
-                }
-            }
-            first = false
-
-            let variable = CheckedVariable(
-                name: parameter.variable.name
-                type_id
-                is_mutable: parameter.variable.is_mutable
-                definition_span: parameter.variable.span
-                visibility: Visibility::Public
-            )
-
-            let checked_parameter = CheckedParameter(
-                requires_label: parameter.requires_label
-                variable
-            )
-
-            checked_function.params.push(checked_parameter)
-
-            if check_scope.has_value() {
-                let var_id = module.add_variable(variable)
-                .add_var_to_scope(
-                    scope_id: check_scope!,
-                    name: parameter.variable.name,
-                    variable: var_id,
-                    span: parameter.variable.span,
-                )
-            }
-        }
+        checked_function.params = .typecheck_parameters(parsed_parameters: parsed_function.params, parent_scope_id, checked_function_scope_id, block_scope_id, this_arg_type_id, check_scope)
 
         // Check return type
         let function_return_type_id = .typecheck_typename(parsed_type: parsed_function.return_type, scope_id: checked_function_scope_id)
@@ -2990,6 +3021,9 @@ struct Typechecker {
         mut module = .current_module()
 
         let function_id = module.next_function_id()
+        if not checked_function.parsed_function.has_value() {
+            return
+        }
         mut parsed_function = checked_function.to_parsed_function()
         let scope_id = .create_scope(parent_scope_id, can_throw: parsed_function.can_throw, debug_name: format("function-specialization({})", parsed_function.name))
 
@@ -3776,11 +3810,15 @@ struct Typechecker {
                 return .typecheck_generic_resolved_type(name, checked_inner_types, scope_id, span)
             }
             Function(params, return_type) => {
-                mut checked_params: [TypeId] = []
-                for param in params.iterator() {
-                    let inner_type_id = .typecheck_typename(parsed_type: param, scope_id)
-                    checked_params.push(inner_type_id)
-                }
+                mut checked_params = .typecheck_parameters(
+                    parsed_parameters: params
+                    parent_scope_id: scope_id
+                    checked_function_scope_id: scope_id
+                    block_scope_id: scope_id
+                    this_arg_type_id: None
+                    check_scope: None
+                )
+
                 let return_type_id = .typecheck_typename(parsed_type: return_type, scope_id)
                 return .find_or_add_type_id(Type::Function(params: checked_params, return_type_id))
             }
@@ -4954,11 +4992,7 @@ struct Typechecker {
             .compiler.panic("Internal error: missing previously defined function")
         }
         let function_ = .get_function(function_id!)
-        mut params: [TypeId] = []
-        for param in function_.params.iterator() {
-            params.push(param.variable.type_id)
-        }
-        let type_id = .find_or_add_type_id(Type::Function(params, return_type_id: function_.return_type_id))
+        let type_id = .find_or_add_type_id(Type::Function(params: function_.params, return_type_id: function_.return_type_id))
         return CheckedExpression::Function(function_, span, type_id)
     }
 

--- a/selfhost/typechecker.jakt
+++ b/selfhost/typechecker.jakt
@@ -33,6 +33,8 @@ struct ModuleId {
 struct VarId {
     module: ModuleId
     id: usize
+
+    function equals(this, anon rhs: VarId) -> bool => .module.equals(rhs.module) and .id == rhs.id
 }
 
 struct FunctionId {
@@ -149,6 +151,7 @@ boxed enum Type {
     Struct(StructId)
     Enum(EnumId)
     RawPtr(TypeId)
+    Function(params: [TypeId], return_type_id: TypeId)
 
     function equals(this, anon rhs: Type) -> bool {
         if this is Void and rhs is Void {
@@ -268,6 +271,20 @@ boxed enum Type {
                             return false
                         }
                     }
+                }
+                Function(params, return_type_id) => match rhs {
+                    Function(params: rhs_params, return_type_id: rhs_return_type_id) => {
+                        if params.size() != rhs_params.size() {
+                            return false
+                        }
+                        for i in 0..params.size() {
+                            if not params[i].equals(rhs_params[i]) {
+                                return false
+                            }
+                        }
+                        return return_type_id.equals(rhs_return_type_id)
+                    }
+                    else => false
                 }
                 else => {
                     return false
@@ -790,6 +807,7 @@ boxed enum CheckedExpression {
     OptionalSome(expr: CheckedExpression, span: Span, type_id: TypeId)
     ForcedUnwrap(expr: CheckedExpression, span: Span, type_id: TypeId)
     Block(block: CheckedBlock, span: Span, type_id: TypeId)
+    Function(function_: CheckedFunction, span: Span, type_id: TypeId)
     Garbage(Span)
 
     // FIXME: rewrite this into a FAMF once we can yield None out of a match (https://github.com/SerenityOS/jakt/issues/669)
@@ -845,6 +863,7 @@ function expression_type(anon expr: CheckedExpression) -> TypeId => match expr {
     ForcedUnwrap(type_id) => type_id
     Match(type_id) => type_id
     Block(type_id) => type_id
+    Function(function_) => builtin(BuiltinType::Unknown) // FIXME add function type
     Garbage => builtin(BuiltinType::Void)
 }
 
@@ -1474,6 +1493,7 @@ struct Typechecker {
             }
             TypeVariable(name) => name
             RawPtr(type_id) => format("raw {}", .type_name(type_id))
+            Function => "auto"
         }
     }
 
@@ -1504,6 +1524,7 @@ struct Typechecker {
         ForcedUnwrap(span) => span
         Match(span) => span
         Block(span) => span
+        Function(span) => span
         Garbage(span) => span
     }
 
@@ -3754,6 +3775,15 @@ struct Typechecker {
 
                 return .typecheck_generic_resolved_type(name, checked_inner_types, scope_id, span)
             }
+            Function(params, return_type) => {
+                mut checked_params: [TypeId] = []
+                for param in params.iterator() {
+                    let inner_type_id = .typecheck_typename(parsed_type: param, scope_id)
+                    checked_params.push(inner_type_id)
+                }
+                let return_type_id = .typecheck_typename(parsed_type: return_type, scope_id)
+                return .find_or_add_type_id(Type::Function(params: checked_params, return_type_id))
+            }
         }
 
         // FIXME: This is unreachable but the generated C++ causes a warning.
@@ -4908,11 +4938,28 @@ struct Typechecker {
         Match(expr, cases, span) => .typecheck_match(expr, cases, span, scope_id, safety_mode)
         JaktDictionary(values, span) => .typecheck_dictionary(values, span, scope_id, safety_mode, type_hint)
         Set(values, span) => .typecheck_set(values, span, scope_id, safety_mode, type_hint)
+        Function(function_, span) => .typecheck_function_expression(function_, parent_scope_id: scope_id, span)
         else => {
             .compiler.panic(format("typechecker needs support for {}", expr))
 
             yield CheckedExpression::Boolean(val: false, span: Span(file_id: .compiler.current_file!, start: 0, end: 0))
         }
+    }
+
+    function typecheck_function_expression(mut this, function_: ParsedFunction, parent_scope_id: ScopeId, span: Span) throws -> CheckedExpression {
+        .typecheck_function_predecl(parsed_function: function_, parent_scope_id, this_arg_type_id: None)
+        .typecheck_function(parsed_function: function_, parent_scope_id)
+        let function_id = .find_function_in_scope(parent_scope_id, function_name: function_.name)
+        if not function_id.has_value() {
+            .compiler.panic("Internal error: missing previously defined function")
+        }
+        let function_ = .get_function(function_id!)
+        mut params: [TypeId] = []
+        for param in function_.params.iterator() {
+            params.push(param.variable.type_id)
+        }
+        let type_id = .find_or_add_type_id(Type::Function(params, return_type_id: function_.return_type_id))
+        return CheckedExpression::Function(function_, span, type_id)
     }
 
     function typecheck_namespaced_var_or_simple_enum_constructor_call(mut this, name: String, namespace_: [String], scope_id: ScopeId, safety_mode: SafetyMode, type_hint: TypeId?, span: Span) throws -> CheckedExpression {


### PR DESCRIPTION
Currently, the underlying cpp implementation captures everything by reference (`[&]`). The *ahem* plan for now is to keep it that way unless the closure is being returned from a function, wherein the capture will be `[=]`. 

Comments welcome!

- [x] assign functions to variable
- [x] function as a parameter
- [ ] return a function
