### PR TITLE
selfhost/typechecker: Align error message with RBC

### DIFF
--- a/selfhost/typechecker.jakt
+++ b/selfhost/typechecker.jakt
@@ -4721,7 +4721,7 @@ struct Typechecker {
                                         }
                                     }
                                     else => {
-                                        .error(format("Not a valid type name: {}", name), span)
+                                        .error(format("Unknown type or invalid type name: {}", name), span)
                                     }
                                 }
                             }


### PR DESCRIPTION
Aligns one of our error message to be more closely match what the rust-based compiler does.

Now:
```
==============================
334 passed
3 failed
3 skipped
==============================
```