### PR TITLE
selfhost+runtime: Don't panic on too-large numeric literals

### DIFF
--- a/runtime/lib.h
+++ b/runtime/lib.h
@@ -24,6 +24,7 @@
 #include <Jakt/NumericLimits.h>
 #include <Jakt/Optional.h>
 #include <Jakt/Platform.h>
+#include <Jakt/PrettyPrint.h>
 #include <Jakt/RefCounted.h>
 #include <Jakt/RefPtr.h>
 #include <Jakt/ScopeGuard.h>
@@ -48,7 +49,6 @@
 #include <Jakt/Weakable.h>
 #include <Jakt/kmalloc.h>
 #include <Jakt/kstdio.h>
-#include <Jakt/PrettyPrint.h>
 
 #include <Jakt/Format.cpp>
 #include <Jakt/GenericLexer.cpp>
@@ -119,6 +119,18 @@ inline void panic(StringView message)
 inline void abort()
 {
     ::abort();
+}
+
+template<typename T>
+inline constexpr T unchecked_add(T value, T other)
+{
+    return value + other;
+}
+
+template<typename T>
+inline constexpr T unchecked_mul(T value, T other)
+{
+    return value * other;
 }
 
 template<typename T>
@@ -420,6 +432,8 @@ using JaktInternal::as_truncated;
 using JaktInternal::fallible_integer_cast;
 using JaktInternal::infallible_integer_cast;
 using JaktInternal::Range;
+using JaktInternal::unchecked_add;
+using JaktInternal::unchecked_mul;
 }
 
 // We place main in a separate namespace to ensure it has access to the same identifiers as other functions

--- a/runtime/prelude.jakt
+++ b/runtime/prelude.jakt
@@ -121,6 +121,8 @@ extern class File {
 extern function abort()
 extern function as_saturated<U, T>(anon input: T) -> U
 extern function as_truncated<U, T>(anon input: T) -> U
+extern function unchecked_add<T>(anon a: T, anon b: T) -> T
+extern function unchecked_mul<T>(anon a: T, anon b: T) -> T
 
 // FIXME: Remove from prelude once extern C functions are working again
 extern struct FILE {}

--- a/samples/math/too_large_literal.jakt
+++ b/samples/math/too_large_literal.jakt
@@ -1,5 +1,5 @@
 /// Expect:
-/// - error: "Integer literal 18446744073709551616 too large"
+/// - error: "Integer literal too large"
 
 function main() {
     let too_large_u64 = 18_446_744_073_709_551_616;

--- a/selfhost/lexer.jakt
+++ b/selfhost/lexer.jakt
@@ -606,6 +606,7 @@ struct Lexer {
             }
         }
 
+        mut number_too_large = false
         mut floating: bool = false
 
         mut fraction_nominator: u64 = 0
@@ -630,7 +631,13 @@ struct Lexer {
 
             let digit: u64 = as_saturated(value - b'0')
             if not floating {
-                total = total * 10 + digit
+                // NOTE: We use unchecked arithmetic here to see if the number is too large
+                //       for our u64 storage type.
+                let old_total = total
+                total = unchecked_add(unchecked_mul(total, 10u64), digit)
+                if total < old_total {
+                    number_too_large = true
+                }
             } else {
                 fraction_nominator = fraction_nominator * 10u64 + digit
                 fraction_denominator *= 10u64
@@ -647,6 +654,11 @@ struct Lexer {
         // FIXME: Change match to if statements or similar when available
         let end = .index
         let span = .span(start, end)
+
+        if number_too_large {
+            .error(format("Integer literal too large"), span)
+            return Token::Garbage(span)
+        }
 
         if .peek() == b'_' {
             .error(

--- a/selfhost/prelude.jakt
+++ b/selfhost/prelude.jakt
@@ -139,6 +139,8 @@ extern class File {
 extern function abort()
 extern function as_saturated<U, T>(anon input: T) -> U
 extern function as_truncated<U, T>(anon input: T) -> U
+extern function unchecked_add<T>(anon a: T, anon b: T) -> T
+extern function unchecked_mul<T>(anon a: T, anon b: T) -> T
 
 // FIXME: Remove from prelude once extern C functions are working again
 extern struct FILE {}

--- a/src/lexer.rs
+++ b/src/lexer.rs
@@ -696,7 +696,7 @@ fn make_number_token(
                             TokenContents::Number(NumericConstant::U64(number as u64))
                         } else {
                             error = Some(JaktError::ParserError(
-                                format!("Integer literal {} too large", number),
+                                "Integer literal too large".to_string(),
                                 span,
                             ));
                             TokenContents::Garbage


### PR DESCRIPTION
This patch adds two runtime helpers for unchecked integer arithmetic
so we can use them to see if a numeric literal is too large for our
normal u64 storage.

Fixes samples/math/too_large_literal.jakt