### PR TITLE
selfhost/typechecker: Match RBC for unknown vars

### DIFF
--- a/selfhost/codegen.jakt
+++ b/selfhost/codegen.jakt
@@ -2332,8 +2332,8 @@ struct CodeGenerator {
         GenericEnumInstance(id, args) => .codegen_generic_enum_instance(id, args, as_namespace)
         TypeVariable(name) => name
         else => {
-            todo(format("codegen_type else: {}", .program.get_type(type_id)))
-            yield ""
+            // The RBC uses 'auto' here but we probably want to improve in the future
+            yield "auto"
         }
     }
 

--- a/selfhost/typechecker.jakt
+++ b/selfhost/typechecker.jakt
@@ -4795,7 +4795,9 @@ struct Typechecker {
                 true => CheckedExpression::Var(var: var!, span)
                 else => {
                     .error(format("Variable '{}' not found", name), span)
-                    yield CheckedExpression::Garbage(span)
+                    yield CheckedExpression::Var(
+                        var: CheckedVariable(name, type_id: type_hint.value_or(unknown_type_id()), is_mutable: false, definition_span: span, visibility: Visibility::Public), span
+                    )
                 }
             }
         }
@@ -5898,7 +5900,6 @@ struct Typechecker {
                         span
                     )
                 }
-
                 
                 for generic_typevar in callee.generic_params.iterator() {
                     match generic_typevar {


### PR DESCRIPTION
This isn't a full fix, but gets us a step closer to getting samples/match/match_generic_codegen.jakt working