### PR TITLE
jakttest+tests: Add ability to mark tests as selfhost only

### DIFF
--- a/jakttest/parser.jakt
+++ b/jakttest/parser.jakt
@@ -80,8 +80,9 @@ struct Parser {
             if not .lex_literal("Expect:") {
                 continue
             }
-            if .is_eof() or .current() != b'\n' {
-                continue
+
+            while not .is_eof() and .current() != b'\n' {
+                .index++
             }
             .index++
             if not .lex_literal("///") {

--- a/tests/main.rs
+++ b/tests/main.rs
@@ -109,12 +109,8 @@ fn find_results(
             if state & SEEN_MARKER == 0 {
                 if line.starts_with("/// Expect:") {
                     state |= SEEN_MARKER;
-                    if line
-                        .split_once(':')
-                        .unwrap()
-                        .1
-                        .trim_start()
-                        .starts_with("Skip")
+                    let after_expect = line.split_once(':').unwrap().1.trim();
+                    if after_expect.starts_with("Skip") || after_expect.starts_with("selfhost-only")
                     {
                         // Not a test.
                         return Ok((None, None, None));


### PR DESCRIPTION
While selfhost is near to compile itself, some features are leaking into
the new selfhost, but their tests are (obviously) not passing in the
Rust based compiler. I figured out we can slap "selfhost-only" after
"Expect:" and have the Rust test driver skip over that one, but have
Jakttest run it.
