### PR TITLE
jakttest: Fix struct stat member naming on MacOS

### DIFF
--- a/jakttest/fs.cpp
+++ b/jakttest/fs.cpp
@@ -7,6 +7,11 @@
 #include <Jakt/StringBuilder.h>
 #include <fcntl.h>
 #include <sys/stat.h>
+#if defined(__APPLE__)
+#define st_atim st_atimespec
+#define st_ctim st_ctimespec
+#define st_mtim st_mtimespec
+#endif
 
 namespace Jakt::fs {
 ErrorOr<void> mkdir(String path)


### PR DESCRIPTION
Although it is supposed to follow POSIX.1-2008, struct stat in MacOS
headers doesn't have conforming names for struct stat timing members
(st_atime, st_mtime, st_ctime); leaving with us with no choice but to
patch our own headers to implement a fix that should've happened 16
years ago.