### PR TITLE
codegen: Improve selfhost codegen towards jakt-in-jakt

### DIFF
--- a/selfhost/codegen.jakt
+++ b/selfhost/codegen.jakt
@@ -1294,23 +1294,33 @@ struct CodeGenerator {
                     yield "is<" + is_type + ">("
                 }
                 TypeCast(cast) => {
-                    let is_integer = .program.is_integer(cast.type_id())
+                    mut final_type_id = cast.type_id();
                     yield match cast {
                         Fallible => {
+                            let ty = .program.get_type(cast.type_id())
+                            let type_id = match ty {
+                                GenericInstance(args) => args[0]
+                                else => {
+                                    panic("Fallible type cast must have Optional result.")
+                                    yield type_id
+                                }
+                            }
                             mut cast_type = "dynamic_cast"
-                            if is_integer {
+                            if .program.is_integer(type_id) {
+                                final_type_id = type_id
                                 cast_type = "fallible_integer_cast"
                             }
+
                             yield cast_type
                         }
                         Infallible => {
                             mut cast_type = "verify_cast"
-                            if is_integer {
+                            if .program.is_integer(type_id) {
                                 cast_type = "infallible_integer_cast"
                             }
                             yield cast_type
                         }
-                    } + "<" + .codegen_type(cast.type_id()) + ">("
+                    } + "<" + .codegen_type(final_type_id) + ">("
                 }
                 else => ""
             }

--- a/selfhost/codegen.jakt
+++ b/selfhost/codegen.jakt
@@ -1332,7 +1332,7 @@ struct CodeGenerator {
                 IsEnumVariant(name, enum_type_id) => {
                     mut suffix = ")"
                     let is_boxed = match .program.get_type(enum_type_id) {
-                        Enum(enum_id) => .program.get_enum(enum_id).record_type is Class
+                        Enum(enum_id) => .program.get_enum(enum_id).is_boxed
                         else => false
                     }
                     if is_boxed {
@@ -1948,7 +1948,7 @@ struct CodeGenerator {
                 }
                 Enum(id) => {
                     let enum_ = .program.get_enum(id)
-                    if enum_.record_type is Class {
+                    if enum_.is_boxed {
                         output += "->"
                     } else {
                         output += "."

--- a/selfhost/codegen.jakt
+++ b/selfhost/codegen.jakt
@@ -1670,9 +1670,14 @@ struct CodeGenerator {
                                     name)
                                 
                                 if not args.is_empty() {
-                                    for arg in fields.iterator() {
-                                        let var = .program.get_variable(arg)
-                                        output += format("{} const& {} = __jakt_match_value.{};\n", .codegen_type(var.type_id), var.name, var.name)
+                                    for arg in args.iterator() {
+                                        let var = .program.find_var_in_scope(scope_id, var: arg.binding)!
+                                        output += .codegen_type(var.type_id)
+                                        output += " const& "
+                                        output += arg.binding
+                                        output += " = __jakt_match_value."
+                                        output += arg.name.value_or(arg.binding)
+                                        output += ";\n"
                                     }
                                 }
                             }


### PR DESCRIPTION
This fixes a handful of different codegen bugs that are preventing jakt-in-jakt:

* Fallible casts now use the proper inner type for the cast
* Struct-like enums that have field renames are now respected
* Proper arrows in invocations when a boxed enum