### PR TITLE
tests: Add selfhost-only test for out of order Optional type

### DIFF
--- a/tests/codegen/out_of_order_optional_type.jakt
+++ b/tests/codegen/out_of_order_optional_type.jakt
@@ -1,0 +1,29 @@
+/// Expect: selfhost-only
+/// - output: ""
+
+struct CheckedBlock {
+    statements: [CheckedStatement]
+    scope_id: ScopeId
+    yielded_type: TypeId?
+}
+
+struct CheckedStatement {
+    id: usize
+}
+
+struct ScopeId {
+    id: usize
+}
+
+struct ModuleId {
+    id: usize
+}
+
+struct TypeId {
+    module: ModuleId
+    id: usize
+}
+
+function main() {
+    // Should compile.
+}


### PR DESCRIPTION
Previously when a type was Optional it wasn't added as a dependency for
the parent type. selfhost-only as this ordering fails on the rust
version.