### PR TITLE
typechecker: Search for a type in all modules

### DIFF
--- a/samples/imports/assign_across_import/helper.jakt
+++ b/samples/imports/assign_across_import/helper.jakt
@@ -1,0 +1,3 @@
+struct S {
+    value: String? // let's force the typechecker to create a typeid for this one.
+}

--- a/samples/imports/assign_across_import/main.jakt
+++ b/samples/imports/assign_across_import/main.jakt
@@ -1,0 +1,12 @@
+/// Expect: selfhost-only
+/// - output: ""
+import helper { S }
+
+function main() {
+    mut s = S(value: None)
+    // String? is not instantiated in the current module
+    // but was in the helper. Let's see if typechecker
+    // still thinks they are the same.
+    let opt: String? = None
+    s.value = opt
+}

--- a/selfhost/typechecker.jakt
+++ b/selfhost/typechecker.jakt
@@ -1547,28 +1547,18 @@ struct Typechecker {
     }
 
     function find_or_add_type_id(mut this, anon type: Type) throws -> TypeId {
-        let module = .program.modules[.current_module_id.id]
-        let module_id = module.id
 
-        mut idx = 0uz
-        for item in module.types.iterator() {
-            if item.equals(type) {
-                return TypeId(module: module_id, id: idx)
+        for module in .program.modules.iterator() {
+            for id in 0..module.types.size() {
+                if module.types[id].equals(type) {
+                    return TypeId(module: module.id, id)
+                }
             }
-            ++idx
-        }
-
-        idx = 0uz
-        for item in .program.modules[0].types.iterator() {
-            if item.equals(type) {
-                return TypeId(module: .program.modules[0].id, id: idx)
-            }
-            ++idx
         }
 
         .program.modules[.current_module_id.id].types.push(type)
 
-        return TypeId(module: module_id, id: .current_module().types.size() - 1)
+        return TypeId(module: .current_module_id, id: .current_module().types.size() - 1)
     }
 
     function find_type_in_scope(this, scope_id: ScopeId, name: String) throws -> TypeId? {


### PR DESCRIPTION
This prevents situations in which a generic type is instantiated across
two different modules and the typechecker will reject any assignments
between those two "different" types.
