### PR TITLE
selfhost: Avoid underflowing when filename doesn't contain extension

### DIFF
--- a/runtime/lib.h
+++ b/runtime/lib.h
@@ -82,24 +82,45 @@ struct Range {
     T end {};
     T current {};
     bool forwards { true };
+    bool is_inclusive { false };
+    bool has_reached_end { false };
 
-    Range(T start, T end)
+    Range(T start, T end, bool inclusive = false)
         : start(start)
         , end(end)
         , current(start)
+        , is_inclusive(inclusive)
     {
         normalize();
     }
 
     Optional<T> next()
     {
-        if (current == end)
+        if (current == end) {
+            if (is_inclusive) {
+                if (has_reached_end)
+                    return {};
+                has_reached_end = true;
+                return end;
+            }
+
             return {};
+        }
 
         if (forwards)
             return current++;
 
         return current--;
+    }
+
+    Range inclusive()
+    {
+        return Range { start, end, true };
+    }
+
+    Range exclusive()
+    {
+        return Range { start, end, false };
     }
 
 private:

--- a/runtime/prelude.jakt
+++ b/runtime/prelude.jakt
@@ -101,6 +101,8 @@ extern struct Set<V> {
 
 extern struct Range<T> {
     function next(mut this) -> T?
+    function inclusive(this) -> Range<T>
+    function exclusive(this) -> Range<T>
 }
 
 extern struct Error {

--- a/selfhost/prelude.jakt
+++ b/selfhost/prelude.jakt
@@ -119,6 +119,8 @@ extern struct Set<V> {
 
 extern struct Range<T> {
     function next(mut this) -> T?
+    function inclusive(this) -> Range<T>
+    function exclusive(this) -> Range<T>
 }
 
 extern struct Error {

--- a/selfhost/utility.jakt
+++ b/selfhost/utility.jakt
@@ -81,13 +81,17 @@ class FilePath {
     }
 
     public function ext(this) throws -> String {
-        mut i = .path.length() -1
-        while (i >= 0 and .path.byte_at(i) != b'/')  {
-            if .path.byte_at(i) == b'.' {
-                return .path.substring(start: (i + 1), length: (.path.length() - 1 - i))
+        for i in ((.path.length() - 1)..0).inclusive() {
+            let c = .path.byte_at(i)
+            if c == b'/' {
+                break
             }
-            i--
+
+            if c == b'.' {
+                return .path.substring(start: i + 1, length: (.path.length() - 1 - i))
+            }
         }
+
         return ""
     }
 


### PR DESCRIPTION
Because i was a usize (through String::length()) the condition i >= 0
would always be true and we'd hit an out-of-bounds error.