### PR TITLE
codegen: Prevent `typename typename Foo` from appearing in generated C++

### DIFF
--- a/selfhost/codegen.jakt
+++ b/selfhost/codegen.jakt
@@ -1671,7 +1671,7 @@ struct CodeGenerator {
                             }
                             StructLike(name, fields) => {
                                 output += format(
-                                    "auto&& __jakt_match_value = __jakt_match_variant.template get<typename {}::{}>();",
+                                    "auto&& __jakt_match_value = __jakt_match_variant.template get<{}::{}>();",
                                     .codegen_type_possibly_as_namespace(
                                         type_id: subject_type_id,
                                         as_namespace: true,

--- a/src/codegen.rs
+++ b/src/codegen.rs
@@ -2785,7 +2785,7 @@ fn codegen_enum_match(
                             CheckedEnumVariant::StructLike(name, _, _) => {
                                 let _ = writeln!(
                                     output,
-                                    "auto&& __jakt_match_value = __jakt_match_variant.template get<typename {}::{}>();",
+                                    "auto&& __jakt_match_value = __jakt_match_variant.template get<{}::{}>();",
                                     &codegen_type_possibly_as_namespace(
                                         *subject_type_id,
                                         project,


### PR DESCRIPTION
@RealBlueta came across this bug. Both `codegen_enum_match()` and
`codegen_type_possibly_as_namespace()` which it calls, add `typename `
before the type name itself, if the type was defined inside a
namespace, and it followed the `CheckedEnumVariant::StructLike` branch.
The other branches that output `typename ` are not affected, and
removing `typename ` from them causes tests to fail.

A proper solution would be to have one place for responsible for
outputting `typename ` but this works and doesn't break anything. :^)