### PR TITLE
jakttest: Merge imports & namespaces when equivalent

### DIFF
--- a/samples/imports/same_imports.jakt
+++ b/samples/imports/same_imports.jakt
@@ -1,0 +1,11 @@
+/// Expect:
+/// - output: "PASS\nPASS\n"
+
+// sanity check: importing twice should not exclude anything previously imported
+import foo { bar }
+import foo { Bar }
+
+function main() {
+    bar()
+    println("{}", Bar::foo())
+}

--- a/samples/namespaces/extend_namespace.jakt
+++ b/samples/namespaces/extend_namespace.jakt
@@ -1,0 +1,20 @@
+/// Expect: selfhost-only
+/// - output: "PASS\n"
+
+namespace foo {
+    namespace bar {
+        function baz() {
+            println("PASS")
+        }
+    }
+}
+
+namespace foo {
+    function run() {
+        bar::baz()
+    }
+}
+
+function main() {
+    foo::run()
+}

--- a/selfhost/parser.jakt
+++ b/selfhost/parser.jakt
@@ -9,7 +9,7 @@
 
 import error { JaktError, print_error}
 import lexer { Token, NumericConstant }
-import utility { panic, todo, FileId, Span }
+import utility { panic, todo, FileId, Span, extend_array }
 import compiler { Compiler }
 import prelude { JaktPrelude }
 
@@ -35,11 +35,53 @@ struct ParsedModuleImport {
     module_name: ImportName
     alias_name: ImportName?
     import_list: [ImportName]
+
+    function is_equivalent_to(this, anon other: ParsedModuleImport) -> bool =>
+        .module_name.name == other.module_name.name and .has_same_alias_than(other) and .has_same_import_semantics(other)
+
+    // we do this because imports with an empty import list mean a namespaced
+    // import
+    function has_same_import_semantics(this, anon other: ParsedModuleImport) -> bool =>
+        .import_list.is_empty() == other.import_list.is_empty()
+
+
+    function has_same_alias_than(this, anon other: ParsedModuleImport) -> bool  {
+        if .alias_name.has_value() {
+            return other.alias_name.has_value() and other.alias_name!.name == .alias_name!.name
+        } else {
+            return not other.alias_name.has_value()
+        }
+    }
+
+    function merge_import_list(mut this, anon list: [ImportName]) throws {
+        .import_list.add_capacity(list.size())
+        // generate a set of the names that exist
+        mut name_set: {String} = {}
+        for import_ in .import_list.iterator() {
+            name_set.add(import_.name)
+        }
+
+        for import_ in list.iterator() {
+            if not name_set.contains(import_.name) {
+                name_set.add(import_.name)
+                .import_list.push(import_)
+            }
+        }
+    }
 }
 
 struct ParsedExternImport {
     is_c: bool
     assigned_namespace: ParsedNamespace
+
+
+    function get_path(this) -> String => .assigned_namespace.import_path_if_extern!
+
+    function get_name(this) -> String => .assigned_namespace.name!
+
+    function is_equivalent_to(this, anon other: ParsedExternImport) throws {
+        return .is_c and other.is_c and .get_path() == other.get_path() and .get_name() == other.get_name()
+    }
 }
 
 struct ParsedNamespace {
@@ -51,6 +93,58 @@ struct ParsedNamespace {
     module_imports: [ParsedModuleImport]
     extern_imports: [ParsedExternImport]
     import_path_if_extern: String?
+
+    function is_equivalent_to(this, anon other: ParsedNamespace) -> bool =>
+        .name == other.name and .import_path_if_extern == other.import_path_if_extern
+
+    function add_module_import(mut this, anon import_: ParsedModuleImport) throws {
+        for module_import in .module_imports.iterator() {
+            if module_import.is_equivalent_to(import_) {
+                module_import.merge_import_list(import_.import_list)
+                return
+            }
+        }
+        .module_imports.push(import_)
+    }
+
+    function add_extern_import(mut this, anon import_: ParsedExternImport) throws {
+        for extern_import in .extern_imports.iterator() {
+            if extern_import.is_equivalent_to(import_) {
+                extern_import.assigned_namespace.merge_with(import_.assigned_namespace)
+                return
+            }
+        }
+        .extern_imports.push(import_)
+    }
+
+    function add_child_namespace(mut this, anon namespace_: ParsedNamespace) throws {
+        for child_namespace in .namespaces.iterator() {
+            if child_namespace.is_equivalent_to(namespace_) {
+                child_namespace.merge_with(namespace_)
+                return
+            }
+        }
+        .namespaces.push(namespace_)
+    }
+
+    function merge_with(mut this, anon namespace_: ParsedNamespace) throws {
+        extend_array(target: .functions, extend_with: namespace_.functions)
+        extend_array(target: .records, extend_with: namespace_.records)
+
+        .module_imports.add_capacity(namespace_.module_imports.size())
+        for import_ in namespace_.module_imports.iterator() {
+            .add_module_import(import_)
+        }
+
+        .extern_imports.add_capacity(namespace_.extern_imports.size())
+        for import_ in namespace_.extern_imports.iterator() {
+            .add_extern_import(import_)
+        }
+
+        for child_namespace in namespace_.namespaces.iterator() {
+            .add_child_namespace(child_namespace)
+        }
+    }
 }
 
 
@@ -581,7 +675,7 @@ struct Parser {
                         namespace_.name = name!.0
                         namespace_.name_span = name!.1
                     }
-                    parsed_namespace.namespaces.push(namespace_)
+                    parsed_namespace.add_child_namespace(namespace_)
                 }
                 Extern => {
                     .index++
@@ -647,10 +741,10 @@ struct Parser {
         match .current() {
             Extern => {
                 .index++
-                parent.extern_imports.push(.parse_extern_import())
+                parent.add_extern_import(.parse_extern_import())
             }
             else => {
-                parent.module_imports.push(.parse_module_import())
+                parent.add_module_import(.parse_module_import())
             }
         }
     }

--- a/selfhost/parser.jakt
+++ b/selfhost/parser.jakt
@@ -31,11 +31,6 @@ struct ImportName {
     span: Span
 }
 
-enum ParsedImport {
-    Module(ParsedModuleImport)
-    Extern(ParsedExternImport)
-}
-
 struct ParsedModuleImport {
     module_name: ImportName
     alias_name: ImportName?
@@ -53,9 +48,12 @@ struct ParsedNamespace {
     functions: [ParsedFunction]
     records: [ParsedRecord]
     namespaces: [ParsedNamespace]
-    imports: [ParsedImport]
+    module_imports: [ParsedModuleImport]
+    extern_imports: [ParsedExternImport]
     import_path_if_extern: String?
 }
+
+
 struct ValueEnumVariant {
     name: String
     span: Span
@@ -536,7 +534,8 @@ struct Parser {
             functions: []
             records: []
             namespaces: []
-            imports: []
+            module_imports: []
+            extern_imports: []
             import_path_if_extern: None
         )
 
@@ -544,7 +543,7 @@ struct Parser {
             match .current() {
                 Import => {
                     .index++
-                    parsed_namespace.imports.push(.parse_import())
+                    .parse_import(parent: parsed_namespace)
                 }
                 Function => {
                     let parsed_function = .parse_function(FunctionLinkage::Internal, Visibility::Public)
@@ -643,18 +642,17 @@ struct Parser {
         }
     }
 
-    function parse_import(mut this) throws -> ParsedImport {
+    function parse_import(mut this, mut parent: ParsedNamespace) throws  {
         // import . <extern <extern-import> | <module-import>>
         match .current() {
             Extern => {
                 .index++
-                let res =  ParsedImport::Extern(.parse_extern_import())
-                return res
+                parent.extern_imports.push(.parse_extern_import())
             }
-            else => {}
+            else => {
+                parent.module_imports.push(.parse_module_import())
+            }
         }
-
-        return ParsedImport::Module(.parse_module_import())
     }
 
 
@@ -668,7 +666,8 @@ struct Parser {
                 functions: []
                 records: []
                 namespaces: []
-                imports: []
+                module_imports: []
+                extern_imports: []
                 import_path_if_extern: None))
 
         

--- a/selfhost/typechecker.jakt
+++ b/selfhost/typechecker.jakt
@@ -2,6 +2,7 @@
 // Copyright (c) 2022, Andreas Kling <kling@serenityos.org>
 // Copyright (c) 2022, Kyle Lanmon <kyle.lanmon@gmail.com>
 // Copyright (c) 2022, Adler Oliveira <adler.rs.oliveira@gmail.com>
+// Copyright (c) 2022, Jesús Lapastora <cyber.gsuscode@gmail.com>
 //
 // SPDX-License-Identifier: BSD-2-Clause
 
@@ -2027,7 +2028,7 @@ struct Typechecker {
 
 
         // typecheck the new namespace, adding it to the parent's children
-        parent.namespaces.push(import_.assigned_namespace)
+        parent.add_child_namespace(import_.assigned_namespace)
     }
 
     function typecheck_namespace_imports(mut this, parsed_namespace: ParsedNamespace, scope_id: ScopeId) throws  {

--- a/selfhost/typechecker.jakt
+++ b/selfhost/typechecker.jakt
@@ -1866,7 +1866,7 @@ struct Typechecker {
         }
     }
 
-    function typecheck_module_import(mut this, import_: ParsedModuleImport, scope_id: ScopeId) throws {
+    function typecheck_module_import(mut this, anon import_: ParsedModuleImport, scope_id: ScopeId) throws {
         // load the module if not present
         // FIXME: use match
         mut imported_module_id = ModuleId(id: 0)
@@ -1988,7 +1988,7 @@ struct Typechecker {
         }
     }
 
-    function typecheck_extern_import(mut this, import_: ParsedExternImport, scope_id: ScopeId, mut parent_children: [ParsedNamespace]) throws {
+    function typecheck_extern_import(mut this, anon import_: ParsedExternImport, scope_id: ScopeId, mut parent: ParsedNamespace) throws {
         for f in import_.assigned_namespace.functions.iterator() {
             if not f.linkage is External {
                 .error("Expected all functions in an `import extern` to be be external", f.name_span)
@@ -2027,15 +2027,16 @@ struct Typechecker {
 
 
         // typecheck the new namespace, adding it to the parent's children
-        parent_children.push(import_.assigned_namespace)
+        parent.namespaces.push(import_.assigned_namespace)
     }
 
     function typecheck_namespace_imports(mut this, parsed_namespace: ParsedNamespace, scope_id: ScopeId) throws  {
-        for import_ in parsed_namespace.imports.iterator() {
-            match import_ {
-                Module(import_) => .typecheck_module_import(import_, scope_id)
-                Extern(import_) => .typecheck_extern_import(import_, scope_id, parent_children: parsed_namespace.namespaces)
-            }
+        for module_import in parsed_namespace.module_imports.iterator() {
+            .typecheck_module_import(module_import, scope_id)
+        }
+
+        for extern_import in parsed_namespace.extern_imports.iterator() {
+            .typecheck_extern_import(extern_import, scope_id, parent: parsed_namespace)
         }
     }
 

--- a/selfhost/utility.jakt
+++ b/selfhost/utility.jakt
@@ -111,6 +111,13 @@ class FilePath {
     }
 }
 
+function extend_array<T>(mut target: [T], extend_with: [T]) throws {
+    target.add_capacity(extend_with.size())
+    for v in extend_with.iterator() {
+        target.push(v)
+    }
+}
+
 // FIXME: Use jakt stdlib if available
 struct ArgsParser {
     args: [String]


### PR DESCRIPTION
If a namespace or import is added, it is checked against the pre-existing
namespaces/imports in the same (parsed) scope, and if there is one that matches
the same characteristics, it is merged with it. This way we avoid creating two
different scopes for the same namespace, which results in false negatives, and
we avoid creating redundant import lists.
