### PR TITLE
IDE: Porting the Rust-based IDE support to selfhost

### DIFF
--- a/selfhost/compiler.jakt
+++ b/selfhost/compiler.jakt
@@ -1,4 +1,4 @@
-import error { JaktError, print_error }
+import error { JaktError, print_error, print_error_json }
 import utility
 import utility { FilePath, FileId }
 
@@ -12,6 +12,8 @@ class Compiler {
     public dump_parser: bool
     public ignore_parser_errors: bool
     public debug_print: bool
+    public json_errors: bool
+    public dump_type_hints: bool
 
     public function panic(this, anon message: String) throws {
         .print_errors()
@@ -38,7 +40,11 @@ class Compiler {
                         file_contents = file.read_all()
                     }
 
-                    print_error(file_name, file_contents: file_contents!, error)
+                    if .json_errors {
+                        print_error_json(file_name, file_contents: file_contents!, error)
+                    } else {
+                        print_error(file_name, file_contents: file_contents!, error)
+                    }
                 }
             }
             idx++

--- a/selfhost/error.jakt
+++ b/selfhost/error.jakt
@@ -15,6 +15,19 @@ enum JaktError {
     }
 }
 
+
+function print_error_json(file_name: String, file_contents: [u8], error: JaktError) throws {
+    match error {
+        Message(message, span) => {
+            display_message_with_span_json(MessageSeverity::Error, file_name, file_contents, message, span)
+        }
+        MessageWithHint(message, span, hint, hint_span) => {
+            display_message_with_span_json(MessageSeverity::Error, file_name, file_contents, message, span)
+            display_message_with_span_json(MessageSeverity::Hint, file_name, file_contents, message: hint, span: hint_span)
+        }
+    }
+}
+
 function print_error(file_name: String, file_contents: [u8], error: JaktError) throws {
     match error {
         Message(message, span) => {
@@ -38,6 +51,13 @@ enum MessageSeverity {
         Hint => "94"  // Bright Blue
         Error => "31" // Red
     }
+}
+
+
+function display_message_with_span_json(anon severity: MessageSeverity, file_name: String, file_contents: [u8], message: String, span: Span) throws
+{
+    println("{{\"type\":\"diagnostics\",\"message\":\"{}\",\"severity\":\"{}\",\"file_id\":{},\"span\":{{\"start\":{},\"end\":{}}}}}"
+        message, severity.name(), span.file_id.id, span.start, span.end)
 }
 
 function display_message_with_span(anon severity: MessageSeverity, file_name: String, file_contents: [u8], message: String, span: Span) throws {

--- a/selfhost/ide.jakt
+++ b/selfhost/ide.jakt
@@ -1,0 +1,1241 @@
+import parser { BinaryOperator, FunctionLinkage }
+import typechecker {
+    BuiltinType, CheckedBlock, CheckedCall, CheckedExpression,
+    CheckedFunction, CheckedProgram, CheckedStatement, CheckedStruct,
+    Module, ModuleId, Scope, ScopeId, StructId, EnumId, Type, TypeId, expression_type,
+    CheckedEnum, unknown_type_id, CheckedMatchCase, FunctionId, CheckedMatchBody, void_type_id,
+    CheckedVariable, NumberConstant, CheckedEnumVariant}
+import utility { panic, todo, join, prepend_to_each, Span }
+import compiler { Compiler }
+
+enum Mutability {
+    DoesNotApply
+    Immutable
+    Mutable
+}
+
+enum VarType {
+    Variable
+    Field
+}
+
+enum VarVisibility {
+    DoesNotApply
+    Public
+    Private
+    Restricted
+}
+
+enum Usage {
+    Variable(
+        span: Span
+        name: String
+        type_id: TypeId
+        mutability: Mutability
+        var_type: VarType
+        visibility: VarVisibility
+        struct_type_id: TypeId?)
+    Call(FunctionId)
+    Typename(TypeId)
+    NameSet([String])
+    EnumVariant(
+        span: Span
+        name: String
+        type_id: TypeId
+        variants: [(String?, TypeId)]
+        number_constant: NumberConstant?
+    )
+}
+
+function find_definition_in_program(program: CheckedProgram, span: Span) throws -> Span {
+    let result = find_span_in_program(program, span)
+    if result.has_value() {
+        return match result! {
+            Variable(span) => span
+            Call(function_id) => program.get_function(function_id).name_span
+            Typename(type_id) => find_type_definition_for_type_id(program, type_id, span)
+            NameSet() => span
+            EnumVariant(span) => span
+        }
+    } else {
+        return span
+    }
+}
+
+function find_type_definition_for_type_id(program: CheckedProgram, type_id: TypeId, span: Span) throws -> Span {
+    let array_struct_id = program.find_struct_in_prelude("Array")
+    let dictionary_struct_id = program.find_struct_in_prelude("Dictionary")
+    let optional_struct_id = program.find_struct_in_prelude("Optional")
+    let range_struct_id = program.find_struct_in_prelude("Range")
+    let set_struct_id = program.find_struct_in_prelude("Set")
+    let tuple_struct_id = program.find_struct_in_prelude("Tuple")
+    let weak_ptr_struct_id = program.find_struct_in_prelude("WeakPtr")
+
+    return match program.get_type(type_id) {
+        F32 => span
+        F64 => span
+        I8 => span
+        I16 => span
+        I32 => span
+        I64 => span
+        U8 => span
+        U16 => span
+        U32 => span
+        U64 => span
+        Usize => span
+        CChar => span
+        CInt => span
+        Bool => span
+        Void => span
+        Unknown => span
+        JaktString => span
+        GenericInstance(id: struct_id, args) => {
+            mut output = span
+            if struct_id.equals(array_struct_id) or struct_id.equals(optional_struct_id) or struct_id.equals(range_struct_id) or struct_id.equals(set_struct_id) or struct_id.equals(tuple_struct_id) or struct_id.equals(weak_ptr_struct_id) {
+                output = find_type_definition_for_type_id(program, type_id: args[0], span)
+            } else if struct_id.equals(dictionary_struct_id) {
+                output = find_type_definition_for_type_id(program, type_id: args[1], span)
+            } else {
+                output = program.get_struct(struct_id).name_span
+            }
+            yield output
+        }
+        Struct(struct_id) => program.get_struct(struct_id).name_span
+        GenericEnumInstance(id) => program.get_enum(id).name_span
+        Enum(id) => program.get_enum(id).name_span
+        RawPtr(type_id) => find_type_definition_for_type_id(program, type_id, span)
+        TypeVariable() => span
+        GenericResolvedType(id) => program.get_struct(id).name_span
+        Reference(type_id) => find_type_definition_for_type_id(program, type_id, span)
+        MutableReference(type_id) => find_type_definition_for_type_id(program, type_id, span)
+    }
+}
+
+function find_type_definition_in_program(program: CheckedProgram, span: Span) throws -> Span {
+    let result = find_span_in_program(program, span)
+
+    if result.has_value() {
+        return match result! {
+            Variable(span, type_id) => {
+               yield find_type_definition_for_type_id(program, type_id, span)
+            }
+            Call(function_id) => {
+                yield program.get_function(function_id).name_span
+            }
+            Typename(type_id) => {
+                yield find_type_definition_for_type_id(program, type_id, span)
+            }
+            NameSet() => span
+            EnumVariant(span) => span
+        }
+    } else {
+        return span
+    }
+}
+
+function find_typename_in_program(program: CheckedProgram, span: Span) throws -> String? {
+    let result = find_span_in_program(program, span)
+
+    if result.has_value() {
+        return match result! {
+            Variable(name, type_id, mutability, var_type, visibility, struct_type_id) => {
+                let result = get_var_signature(program, name, var_type_id: type_id, mutability, var_type, visibility, struct_type_id)
+                yield Some(result)
+            }
+            Call(function_id) => {
+                let result = get_function_signature(program, function_id)
+                yield Some(result)
+            }
+            Typename(type_id) => {
+                let result = get_type_signature(program, type_id)
+                yield Some(result)
+            }
+            NameSet(names) => {
+                mut output = ""
+                mut first = true
+                for name in names.iterator() {
+                    if not first {
+                        output += " | "
+                    } else {
+                        first = false
+                    }
+                    output += name
+                }
+                yield Some(output)
+            }
+            EnumVariant(name, type_id, variants, number_constant) => {
+                let result = get_enum_variant_signature(program, name, type_id, variants, number_constant)
+                yield Some(result)
+            }
+        }
+    } else {
+        return None
+    }
+}
+
+function completions_for_type_id(program: CheckedProgram, type_id: TypeId) throws -> [String] {
+    mut output: [String] = []
+    let ty = program.get_type(type_id)
+
+    match ty {
+        Enum(enum_id) => {
+            let enum_ = program.get_enum(enum_id)
+            let scope = program.get_scope(enum_.scope_id)
+            for function_name in scope.functions.keys().iterator() {
+                let function_id = scope.functions.get(function_name)!
+
+                let checked_function = program.get_function(function_id)
+
+                if checked_function.params.first().has_value() {
+                    let param = checked_function.params.first()!
+                    if param.variable.name == "this" {
+                        mut full_call = checked_function.name
+                        mut first = true
+                        full_call += "("
+                        mut iter = checked_function.params.iterator()
+                        iter.next()
+                        for param in iter {
+                            if not first {
+                                full_call += ", "
+                            } else {
+                                first = false
+                            }
+                            full_call += param.variable.name
+                        }
+                        full_call += ")"
+                        output.push(full_call)
+                    }
+                } else {
+                    output.push(format("{}()", checked_function.name))
+                }
+            }
+        }
+        Struct(struct_id) => {
+            let structure = program.get_struct(struct_id)
+
+            for field in structure.fields.iterator() {
+                let field_var = program.get_variable(field)
+                output.push(field_var.name)
+            }
+
+            let scope = program.get_scope(structure.scope_id)
+
+            for function_name in scope.functions.keys().iterator() {
+                let function_id = scope.functions.get(function_name)!
+
+                let checked_function = program.get_function(function_id)
+
+                if checked_function.params.first().has_value() {
+                    let param = checked_function.params.first()!
+                    if param.variable.name == "this" {
+                        mut full_call = checked_function.name
+                        mut first = true
+                        full_call += "("
+                        mut iter = checked_function.params.iterator()
+                        iter.next()
+                        for param in iter {
+                            if not first {
+                                full_call += ", "
+                            } else {
+                                first = false
+                            }
+                            full_call += param.variable.name
+                        }
+                        full_call += ")"
+                        output.push(full_call)
+                    }
+                } else {
+                    output.push(format("{}()", checked_function.name))
+                }
+            }
+        }
+        GenericInstance(id: struct_id) => {
+            // FIXME: this is a copy of the above
+            let structure = program.get_struct(struct_id)
+
+            for field in structure.fields.iterator() {
+                let field_var = program.get_variable(field)
+                output.push(field_var.name)
+            }
+
+            let scope = program.get_scope(structure.scope_id)
+
+            for function_name in scope.functions.keys().iterator() {
+                let function_id = scope.functions.get(function_name)!
+
+                let checked_function = program.get_function(function_id)
+
+                if checked_function.params.first().has_value() {
+                    let param = checked_function.params.first()!
+                    if param.variable.name == "this" {
+                        mut full_call = checked_function.name
+                        mut first = true
+                        full_call += "("
+                        mut iter = checked_function.params.iterator()
+                        iter.next()
+                        for param in iter {
+                            if not first {
+                                full_call += ", "
+                            } else {
+                                first = false
+                            }
+                            full_call += param.variable.name
+                        }
+                        full_call += ")"
+                        output.push(full_call)
+                    }
+                } else {
+                    output.push(format("{}()", checked_function.name))
+                }
+            }
+        }
+        else => {}
+    }
+
+    return output
+}
+
+function find_dot_completions(program: CheckedProgram, span: Span) throws -> [String] {
+    let result = find_span_in_program(program, span)
+
+    if result.has_value() {
+        return match result! {
+            Variable(type_id) => {
+                yield completions_for_type_id(program, type_id)
+            }
+            Call(function_id) => {
+                let result_type_id = program.get_function(function_id).return_type_id
+                yield completions_for_type_id(program, type_id: result_type_id)
+            }
+            else => []
+        }
+    } else {
+        return []
+    }
+}
+
+function find_span_in_program(program: CheckedProgram, span: Span) throws -> Usage? {
+    mut iterator = program.modules.iterator()
+    iterator.next()
+    for module in iterator {
+        let scope = program.get_scope(ScopeId(module_id: module.id, id: 0))
+
+        return find_span_in_scope(program, scope, span)
+    }
+
+    return None
+}
+
+function find_span_in_scope(program: CheckedProgram, scope: Scope, span: Span) throws -> Usage? {
+    for scope_var in scope.vars.iterator() {
+        let var = program.get_variable(scope_var.1)
+        if var.definition_span.contains(span) {
+            return Some(Usage::Typename(var.type_id))
+        }
+    }
+
+    for function_id in scope.functions.iterator() {
+        let checked_function = program.get_function(function_id.1)
+        let usage = find_span_in_function(program, checked_function, span)
+        if usage.has_value() {
+            return usage!
+        }
+    }
+
+    for struct_id in scope.structs.iterator() {
+        let checked_struct = program.get_struct(struct_id.1)
+        let usage = find_span_in_struct(program, checked_struct, span)
+        if usage.has_value() {
+            return usage!
+        }
+    }
+
+    for enum_id in scope.enums.iterator() {
+        let checked_enum = program.get_enum(enum_id.1)
+        let usage = find_span_in_enum(program, checked_enum, span)
+        if usage.has_value() {
+            return usage!
+        }
+    }
+
+    for child in scope.children.iterator() {
+        let scope = program.get_scope(child)
+
+        let usage = find_span_in_scope(program, scope, span)
+        if usage.has_value() {
+            return usage!
+        }
+    }
+
+    return None
+}
+
+function find_span_in_enum(program: CheckedProgram, checked_enum: CheckedEnum, span: Span) throws -> Usage? {
+    let scope = program.get_scope(checked_enum.scope_id)
+
+    for variant in checked_enum.variants.iterator() {
+        match variant {
+            StructLike(name, fields, span: variant_span) => {
+                for field in fields.iterator() {
+                    let var = program.get_variable(field)
+
+                    if var.definition_span.contains(span) {
+                        return Some(Usage::Typename(var.type_id))
+                    }
+                }
+
+                if variant_span.contains(span) {
+                    return Some(Usage::EnumVariant(span, name, type_id: checked_enum.type_id, variants: [], number_constant: None))
+                }
+            }
+            Typed(name, span: variant_span) => {
+                if variant_span.contains(span) {
+                    return Some(Usage::EnumVariant(span: variant_span, name, type_id: checked_enum.type_id, variants: enum_variant_fields(program, checked_enum_variant: variant), number_constant: None))
+                }
+            }
+            Untyped(name, span: variant_span) => {
+                let number_constant_none: NumberConstant? = None
+                return Some(Usage::EnumVariant(span: variant_span, name, type_id: checked_enum.type_id, variants: [], number_constant: number_constant_none))
+            }
+            WithValue(name, expr, span: variant_span) => {
+
+                if variant_span.contains(span) {
+                    return Some(Usage::EnumVariant(span: variant_span, name, type_id: checked_enum.type_id, variants: enum_variant_fields(program, checked_enum_variant: variant), number_constant: expr.to_number_constant(program)))
+                }
+            }
+        }
+    }
+
+    let usage = find_span_in_scope(program, scope, span)
+    return usage
+}
+
+function find_span_in_struct(program: CheckedProgram, checked_struct: CheckedStruct, span: Span) throws -> Usage? {
+    let scope = program.get_scope(checked_struct.scope_id)
+
+    for field in checked_struct.fields.iterator() {
+        let variable = program.get_variable(field)
+
+        if variable.definition_span.contains(span) {
+            return Some(Usage::Typename(variable.type_id))
+        }
+    }
+
+    let usage = find_span_in_scope(program, scope, span)
+
+    return usage
+}
+
+function find_span_in_function(program: CheckedProgram, checked_function: CheckedFunction, span: Span) throws -> Usage? {
+    if checked_function.return_type_span.has_value() {
+        if checked_function.return_type_span!.contains(span) {
+            return Some(Usage::Typename(type_id: checked_function.return_type_id))
+        }
+    }
+
+    for param in checked_function.params.iterator() {
+        if param.variable.definition_span.contains(span) {
+            return Some(Usage::Typename(param.variable.type_id))
+        }
+    }
+
+    return find_span_in_block(program, block: checked_function.block, span)
+}
+
+function find_span_in_block(program: CheckedProgram, block: CheckedBlock, span: Span) throws -> Usage? {
+    for statement in block.statements.iterator() {
+        let found = find_span_in_statement(program, statement, span)
+        if found.has_value() {
+            return found
+        }
+    }
+    return None
+}
+
+function find_span_in_statement(program: CheckedProgram, statement: CheckedStatement, span: Span) throws -> Usage? {
+    let none: Usage? = None
+
+    return match statement {
+        Block(block) => find_span_in_block(program, block, span)
+        Defer(statement) => find_span_in_statement(program, statement, span)
+        Expression(expr) => find_span_in_expression(program, expr, span)
+        If(condition, then_block, else_statement) => {
+            mut found = find_span_in_expression(program, expr: condition, span)
+            if found.has_value() {
+                return found
+            }
+            found = find_span_in_block(program, block: then_block, span)
+            if found.has_value() {
+                return found
+            }
+            if else_statement.has_value() {
+                return find_span_in_statement(program, statement: else_statement!, span)
+            }
+            yield none
+        }
+        InlineCpp => {
+            let output: Usage? = None
+            yield output
+        }
+        Loop(block) => find_span_in_block(program, block, span)
+        Return(val) => match val.has_value() {
+            true => find_span_in_expression(program, expr: val!, span)
+            else => none
+        }
+        Throw(expr) => find_span_in_expression(program, expr, span)
+        Try(stmt, error_name, catch_block) => {
+            let found = find_span_in_statement(program, statement: stmt, span)
+            if found.has_value() {
+                return found
+            }
+            yield find_span_in_block(program, block: catch_block, span)
+        }
+        VarDecl(var_id, init) => {
+            let checked_var = program.get_variable(var_id)
+            let found = find_span_in_expression(program, expr: init, span)
+            if found.has_value() {
+                return found
+            }
+            if checked_var.type_span.has_value() {
+                let type_span = checked_var.type_span!
+                if type_span.contains(span) {
+                    return Some(Usage::Typename(checked_var.type_id))
+                }
+            }
+
+            if checked_var.definition_span.contains(span) {
+                let mutability = match checked_var.is_mutable {
+                    true => Mutability::Mutable
+                    else => Mutability::Immutable
+                }
+
+                return Some(Usage::Variable(
+                        span: checked_var.definition_span
+                        name: checked_var.name
+                        type_id: checked_var.type_id
+                        mutability
+                        var_type: VarType::Variable
+                        visibility: VarVisibility::DoesNotApply
+                        struct_type_id: None))
+            }
+            yield none
+        }
+        While(condition, block) => {
+            let found = find_span_in_expression(program, expr: condition, span)
+            if found.has_value() {
+                return found
+            }
+            yield find_span_in_block(program, block, span)
+        }
+        DestructuringAssignment(vars, var_decl) => {
+            for var in vars.iterator() {
+                let found = find_span_in_statement(program, statement: var, span)
+                if found.has_value() {
+                    return found
+                }
+            }
+            yield find_span_in_statement(program, statement: var_decl, span)
+        }
+        Yield(expr) => find_span_in_expression(program, expr, span)
+        Break | Continue | Garbage => none
+    }
+}
+function find_span_in_expression(program: CheckedProgram, expr: CheckedExpression, span: Span) throws -> Usage? { 
+    let none: Usage? = None
+
+    return match expr {
+        BinaryOp(lhs, op, rhs) => {
+            let found = find_span_in_expression(program, expr: lhs, span)
+            if found.has_value() {
+                return found
+            }
+            yield find_span_in_expression(program, expr: rhs, span)
+        }
+        JaktArray(vals, repeat) => {
+            for val in vals.iterator() {
+                let found = find_span_in_expression(program, expr: val, span)
+                if found.has_value() {
+                    return found
+                }
+            }
+            if repeat.has_value() {
+                return find_span_in_expression(program, expr: repeat!, span)
+            }
+            yield none
+        }
+        Block(block) => find_span_in_block(program, block, span)
+        Call(call, span: call_span) => {
+            for arg in call.args.iterator() {
+                let found = find_span_in_expression(program, expr: arg.1, span)
+                if found.has_value() {
+                    return found
+                }
+            }
+            if call.function_id.has_value() and call_span.contains(span) {
+                return Some(Usage::Call(call.function_id!))
+            }
+            yield none
+        }
+        JaktDictionary(vals) => {
+            for item in vals.iterator() {
+                let key = item.0
+                let value = item.1
+                mut found = find_span_in_expression(program, expr: key, span)
+                if found.has_value() {
+                    return found
+                }
+                found = find_span_in_expression(program, expr: value, span)
+                if found.has_value() {
+                    return found
+                }
+            }
+            yield none
+        }
+        IndexedExpression(expr, index) => {
+            mut found = find_span_in_expression(program, expr, span)
+            if found.has_value() {
+                return found
+            }
+            found = find_span_in_expression(program, expr: index, span)
+            if found.has_value() {
+                return found
+            }
+            yield none
+        }
+        IndexedStruct(expr, index, span: index_span) => {
+            let found = find_span_in_expression(program, expr, span)
+            if found.has_value() {
+                return found
+            }
+            if index_span.contains(span) {
+                let type_id = expression_type(expr)
+                match program.get_type(type_id) {
+                    Struct(struct_id) => {
+                        let struct_ = program.get_struct(struct_id)
+                        for field in struct_.fields.iterator() {
+                            let var = program.get_variable(field)
+                            if index == var.name {
+                                return Some(Usage::Variable(
+                                        span: var.definition_span
+                                        name: index
+                                        type_id: var.type_id
+                                        mutability: Mutability::DoesNotApply
+                                        var_type: VarType::Field
+                                        visibility: match var.visibility {
+                                            Public => VarVisibility::Public
+                                            Private => VarVisibility::Private
+                                            Restricted => VarVisibility::Restricted
+                                        }
+                                        struct_type_id: Some(type_id)))
+                            }
+                        }
+                    }
+                    else => {}
+                }
+            }
+            yield none
+        }
+        IndexedDictionary(expr, index) => {
+            let found = find_span_in_expression(program, expr, span)
+            if found.has_value() {
+                return found
+            }
+            yield find_span_in_expression(program, expr: index, span)
+        }
+        Match(expr, match_cases, span: match_span, type_id) => {
+            for match_case in match_cases.iterator() {
+                let found = match match_case {
+                    EnumVariant(name, args, subject_type_id, index, scope_id, body, marker_span) => {
+                        if marker_span.contains(span) {
+                            // FIXME: return Some(get_enum_variant_usage_from_type_id_and_name(program, type_id: subject_type_id, variant_index))
+                            return Some(get_enum_variant_usage_from_type_id_and_name(
+                                    program
+                                    type_id: subject_type_id
+                                    name))
+                        }
+
+                        yield match body {
+                            Block(block) => find_span_in_block(program, block, span)
+                            Expression(expr) => find_span_in_expression(program, expr, span)
+                        }
+                    }
+                    Expression(expression: expr, body) => {
+                        let found = find_span_in_expression(program, expr, span)
+                        if found.has_value() {
+                            return found
+                        }
+                        yield match body {
+                            Block(block) => find_span_in_block(program, block, span)
+                            Expression(expr) => find_span_in_expression(program, expr, span)
+                        }
+                    }
+                    CatchAll(body, marker_span) => match marker_span.contains(span) {
+                        true => {
+                            let all_cases = match program.get_type(type_id) {
+                                Enum(enum_id) | GenericEnumInstance(id: enum_id) => {
+                                    // NOTE: not sure why would we need a hashset if enum variants
+                                    // can't be duplicate, but I'll leave previous implementation from Rust based
+                                    mut names: {String} = {}
+                                    let enum_ = program.get_enum(enum_id)
+                                        for variant in enum_.variants.iterator() {
+                                            names.add(variant.name())
+                                        }
+                                    yield names
+                                }
+                                else => {yield {"else (expression)"}}
+                            }
+
+                            mut remaining_cases = all_cases
+
+                            for other_case in match_cases.iterator() {
+                                match other_case {
+                                    EnumVariant(name) => {
+                                        remaining_cases.remove(name)
+                                    }
+                                    else => {}
+                                }
+                            }
+
+                            yield match remaining_cases.is_empty() {
+                                false => {
+                                    mut cases_array: [String] = []
+                                        cases_array.ensure_capacity(remaining_cases.size())
+                                        for name in remaining_cases.iterator() {
+                                            cases_array.push(name)
+                                        }
+                                    yield Some(Usage::NameSet(cases_array))
+                                }
+                                else => None
+                            }
+                        }
+                        else => match body {
+                            Block(block) => find_span_in_block(program, block, span)
+                                Expression(expr) => find_span_in_expression(program, expr, span)
+                        }
+                    }
+
+                }
+                if found.has_value() {
+                    return found
+                }
+            }
+            yield find_span_in_expression(program, expr, span)
+        }
+
+        ForcedUnwrap(expr) => find_span_in_expression(program, expr, span)
+        UnaryOp(expr) => find_span_in_expression(program, expr, span)
+        MethodCall(expr, call, span: method_span, type_id) => {
+            mut found = find_span_in_expression(program, expr, span)
+            if found.has_value() {
+                return found
+            }
+            for arg in call.args.iterator() {
+                found = find_span_in_expression(program, expr: arg.1, span)
+                if found.has_value() {
+                    return found
+                }
+            }
+            if call.function_id.has_value() and method_span.contains(span) {
+                return Some(Usage::Call(call.function_id!))
+            }
+            return none
+        }
+        Var(var, span: var_span) => {
+            let none_type_id: TypeId? = None
+            if var_span.contains(span) {
+                let mutability = match var.is_mutable {
+                    true => Mutability::Mutable
+                    else => Mutability::Immutable
+                }
+                return Some(Usage::Variable(
+                        span: var.definition_span
+                        name: var.name
+                        type_id: var.type_id
+                        mutability
+                        var_type: VarType::Variable
+                        visibility: VarVisibility::DoesNotApply
+                        struct_type_id: none_type_id))
+            }
+            return none
+        }
+
+        NamespacedVar(namespaces, var, span: var_span) => {
+            if var_span.contains(span) and not namespaces.is_empty()  {
+                let last_ns = namespaces.last()!
+                if program.get_scope(last_ns.scope).namespace_name.has_value() {
+                    let enum_id = program.find_enum_in_scope(scope_id:
+                        last_ns.scope, name: last_ns.name)
+
+                    if enum_id.has_value() {
+                        let enum_ = program.get_enum(enum_id!)
+                        return Some(get_enum_variant_usage_from_type_id_and_name(program, type_id: enum_.type_id name: var.name))
+                    }
+
+                }
+            }
+            yield none
+        }
+        else => none
+    }
+}
+
+function get_function_signature(program: CheckedProgram, function_id: FunctionId) throws -> String {
+    let checked_function = program.get_function(function_id)
+
+    match checked_function.type {
+        ImplicitEnumConstructor => {
+            let type_id = checked_function.return_type_id
+            let name = checked_function.name
+            return get_enum_variant_signature_from_type_id_and_name(program, type_id, name)
+        }
+        ImplicitConstructor => {
+            return get_constructor_signature(program, function_id)
+        }
+        else => {}
+    }
+
+    mut generic_parameters = ""
+    mut is_first_param = true
+    if not checked_function.generic_params.is_empty() {
+        generic_parameters += "<"
+
+        for parameter in checked_function.generic_params.iterator() {
+            let generic_type = match parameter {
+                InferenceGuide(type_id) => {
+                    yield program.type_name(type_id)
+                }
+                Parameter(type_id) => {
+                    yield program.type_name(type_id)
+                }
+            }
+
+            let separator = match is_first_param {
+                true => ""
+                else => ", "
+            }
+
+            generic_parameters += format("{}{}", separator, generic_type)
+            is_first_param = false
+        }
+
+        generic_parameters += ">"
+    }
+
+    mut parameters = ""
+    is_first_param = true
+
+    for param in checked_function.params.iterator() {
+        let anon_value = match param.requires_label {
+            true => ""
+            else => "anon "
+        }
+
+        let is_mutable = match param.variable.is_mutable {
+            true => "mut "
+            else => ""
+        }
+
+        mut variable_type = program.type_name(type_id: param.variable.type_id)
+        if variable_type != "void" {
+            variable_type = ": " + variable_type
+        } else {
+            variable_type = ""
+        }
+
+        let separator = match is_first_param {
+            true => ""
+            else => ", "
+        }
+
+        parameters += format("{}{}{}{}{}", separator, anon_value, is_mutable, param.variable.name, variable_type)
+        is_first_param = false
+    }
+
+    let throws_str = match checked_function.can_throw {
+        true => " throws"
+        else => ""
+    }
+
+    mut returns = program.type_name(type_id: checked_function.return_type_id)
+
+    if returns != "void" {
+        returns = " -> " + returns
+    } else {
+        returns = ""
+    }
+
+    return format("function {}{}({}){}{}", checked_function.name, generic_parameters, parameters, throws_str, returns)
+}
+
+function get_var_signature(program: CheckedProgram, name: String, var_type_id: TypeId, mutability: Mutability, var_type: VarType, visibility: VarVisibility, struct_type_id: TypeId?) throws -> String {
+    return match var_type {
+        Variable => {
+            let mut_string = match mutability {
+                Mutable => "mut"
+                Immutable => "let"
+                else => ""
+            }
+            let type_name = get_type_signature(program, type_id: var_type_id)
+            yield format("{} {}: {}", mut_string, name, type_name)
+        }
+        Field => {
+            mut record_string = ""
+            if struct_type_id.has_value() {
+                record_string = get_type_signature(program, type_id: struct_type_id!)
+            }
+            let visibility_string = match visibility {
+                Public => "public "
+                Private => "private "
+                else => ""
+            }
+
+            let type_name = get_type_signature(program, type_id: var_type_id)
+            if record_string != "" {
+                return format("{}\\n\\t{}{}: {}", record_string, visibility_string, name, type_name)
+            } else {
+                return format("{}{}: {}", visibility_string, name, type_name)
+            }
+        }
+    }
+}
+
+function get_type_signature(program: CheckedProgram, type_id: TypeId) throws -> String {
+    let array_struct_id = program.find_struct_in_prelude("Array")
+    let dictionary_struct_id = program.find_struct_in_prelude("Dictionary")
+    let optional_struct_id = program.find_struct_in_prelude("Optional")
+    let range_struct_id = program.find_struct_in_prelude("Range")
+    let set_struct_id = program.find_struct_in_prelude("Set")
+    let tuple_struct_id = program.find_struct_in_prelude("Tuple")
+    let weak_ptr_struct_id = program.find_struct_in_prelude("WeakPtr")
+
+    let type = program.get_type(type_id)
+
+    return match type {
+        Void => "void"
+        Bool => "bool"
+        U8 => "u8"
+        U16 => "u16"
+        U32 => "u32"
+        U64 => "u64"
+        I8 => "i8"
+        I16 => "i16"
+        I32 => "i32"
+        I64 => "i64"
+        F32 => "f32"
+        F64 => "f64"
+        Usize => "usize"
+        JaktString => "String"
+        CInt => "c_int"
+        CChar => "c_char"
+        TypeVariable(name) => name
+        Unknown => ""
+        RawPtr(type_id) => "raw " + get_type_signature(program, type_id)
+        Enum(id) => {
+            let enum_ = program.get_enum(id)
+            yield match enum_.is_boxed {
+                true => "boxed "
+                else => ""
+            } + "enum " + enum_.name
+        }
+        Struct(id) => {
+            let struct_ = program.get_struct(id)
+            yield match struct_.record_type {
+                Class => "class "
+                Struct => "struct "
+                else => {
+                    panic("unreachable: should've been struct")
+                    yield ""
+                }
+            } + struct_.name
+        }
+        GenericResolvedType(id, args) => {
+            let record = program.get_struct(id)
+            mut output = record.name
+            output += "<"
+            if not args.is_empty() {
+                output += get_type_signature(program, type_id: args[0])
+                for i in 1..args.size() {
+                    output += ", "
+                    output += get_type_signature(program, type_id: args[i])
+                }
+            }
+            yield output + ">"
+        }
+        GenericEnumInstance(id, args) => {
+            let enum_ = program.get_enum(id)
+            mut output = ""
+            if enum_.is_boxed {
+                output += "boxed "
+            }
+            output += "enum "
+            output += enum_.name
+            output += "<"
+            if not args.is_empty() {
+                output += get_type_signature(program, type_id: args[0])
+                for i in 1..args.size() {
+                    output += ", "
+                    output += get_type_signature(program, type_id: args[i])
+                }
+            }
+            yield output + ">"
+        }
+        GenericInstance(id, args) => {
+            if id.equals(array_struct_id) {
+                if args.is_empty() {
+                    return "[]"
+                }
+                return format("[{}]", get_type_signature(program, type_id: args[0]))
+            }
+            if id.equals(dictionary_struct_id) {
+                if args.size() < 2 {
+                    return "[:]"
+                }
+                return format("[{}: {}]",
+                    get_type_signature(program, type_id: args[0])
+                    get_type_signature(program, type_id: args[1]))
+            }
+            if id.equals(optional_struct_id) {
+                if args.is_empty() {
+                    return ""
+                }
+                return format("{}?", get_type_signature(program, type_id: args[0]))
+            }
+            if id.equals(range_struct_id) {
+                if args.is_empty() {
+                    return ""
+                }
+                // Ranges probably only make sense for builtin types, but if not we use the format
+                // struct MyRangeStruct..MyRangeStruct
+                return format("{}..{}",
+                    get_type_signature(program, type_id: args[0])
+                    program.type_name(args[0]))
+            }
+            if id.equals(set_struct_id) {
+                if args.is_empty() {
+                    return ""
+                }
+                return format("{{{}}}", get_type_signature(program, type_id: args[0]))
+            }
+            if id.equals(tuple_struct_id) {
+                mut output = "("
+                if not args.is_empty() {
+                    output += get_type_signature(program, type_id: args[0])
+                    for i in 1..args.size() {
+                        output += ", "
+                        output += get_type_signature(program, type_id: args[i])
+                    }
+                }
+                return output + ")"
+            }
+            if id.equals(weak_ptr_struct_id) {
+                if args.is_empty() {
+                    return ""
+                }
+                return format("weak {}?", get_type_signature(program, type_id: args[0]))
+            }
+
+            let record = program.get_struct(id)
+            mut output = match record.record_type {
+                Class => "class "
+                Struct => "struct "
+                ValueEnum | SumEnum => {
+                    panic("unreachable: can't be an enum")
+                    yield ""
+                }
+                Garbage => ""
+            }
+            output += record.name
+            output += "<"
+            if not args.is_empty() {
+                output += get_type_signature(program, type_id: args[0])
+                for i in 1..args.size() {
+                    output += ", "
+                    output += get_type_signature(program, type_id: args[i])
+                }
+            }
+            yield output + ">"
+        }
+        Reference(type_id) => format("&{}", program.type_name(type_id))
+        MutableReference(type_id) => format("&mut {}", program.type_name(type_id))
+    }
+}
+
+function get_enum_variant_signature(program: CheckedProgram, name: String, type_id: TypeId, variants: [(String?, TypeId)], number_constant: NumberConstant?) throws -> String {
+    mut output = get_type_signature(program, type_id)
+    output += "::"
+    output += "name"
+
+    if not variants.is_empty() {
+        output += "("
+        mut first = true
+        for variant in variants.iterator() {
+            if first {
+                first = false
+            } else {
+                output += ", "
+            }
+
+            if variant.0.has_value() {
+                output += variant.0!
+                output += ": "
+            }
+
+            output += program.type_name(type_id: variant.1)
+        }
+        output += ")"
+    }
+    if number_constant.has_value() {
+        output += " = "
+        match number_constant! {
+            Signed(value) => {
+                output += format("{}", value)
+            }
+            Unsigned(value) => {
+                output += format("{}", value)
+            }
+            Floating(value) => {
+                output += format("{}", value)
+            }
+        }
+    }
+    return output
+}
+
+function get_enum_variant_signature_from_type_id_and_name(program: CheckedProgram, type_id: TypeId, name: String) throws -> String {
+    let mod = program.modules[type_id.module.id]
+    for enum_ in mod.enums.iterator() {
+        if enum_.type_id.equals(type_id) {
+            for variant in enum_.variants.iterator() {
+                match variant {
+                    Untyped(name: v_name) => {
+                        if v_name == name {
+                            let params = enum_variant_fields(program, checked_enum_variant: variant)
+
+                            let none: NumberConstant? = None
+
+                            return get_enum_variant_signature(program, name, type_id, variants: params, number_constant: none)
+                        }
+                    }
+                    Typed(name: v_name) => {
+                        if v_name == name {
+                            let params = enum_variant_fields(program, checked_enum_variant: variant)
+
+                            let none: NumberConstant? = None
+
+                            return get_enum_variant_signature(program, name, type_id, variants: params, number_constant: none)
+                        }
+                    }
+                    WithValue(name: v_name) => {
+                        if v_name == name {
+                            let params = enum_variant_fields(program, checked_enum_variant: variant)
+
+                            let value = match variant {
+                                WithValue(expr) => {
+                                    yield expr.to_number_constant(program)
+                                }
+                                else => {
+                                    let none: NumberConstant? = None
+                                    yield none
+                                }
+                            }
+
+                            return get_enum_variant_signature(program, name, type_id, variants: params, number_constant: value)
+                        }
+                    }
+                    StructLike(name: v_name) => {
+                        if v_name == name {
+                            let params = enum_variant_fields(program, checked_enum_variant: variant)
+
+                            let none: NumberConstant? = None
+
+                            return get_enum_variant_signature(program, name, type_id, variants: params, number_constant: none)
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    return ""
+}
+
+function get_enum_variant_usage_from_type_id_and_name(program: CheckedProgram, type_id: TypeId, name: String) throws -> Usage {
+    for enum_ in program.get_module(type_id.module).enums.iterator() {
+        if not enum_.type_id.equals(type_id) {
+            continue
+        }
+
+        for variant in enum_.variants.iterator() {
+            if variant.name() == name {
+                let variants = enum_variant_fields(program, checked_enum_variant: variant)
+                let number_constant = match variant {
+                    WithValue(name, expr) => expr.to_number_constant(program)
+                    else => None
+                }
+                let span = variant.span()
+                return Usage::EnumVariant(
+                    span
+                    name
+                    type_id
+                    variants
+                    number_constant)
+            }
+        }
+        panic("unreachable: should have found variant")
+    }
+    panic("unreachable: should have found enum")
+    return Usage::Typename(type_id)
+}
+
+function enum_variant_fields(program: CheckedProgram, checked_enum_variant: CheckedEnumVariant) throws -> [(String?, TypeId)] {
+    return match checked_enum_variant {
+        StructLike(fields) => {
+            mut output: [(String?, TypeId)] = []
+            for field in fields.iterator() {
+                let variable = program.get_variable(field)
+                let var_name = Some(variable.name)
+                let o = (var_name, variable.type_id)
+                output.push(o)
+            }
+            yield output
+        }
+        Typed(type_id) => {
+            let string_none: String? = None
+            yield [(string_none, type_id)]
+        }
+        else => []
+    }
+}
+
+function get_constructor_signature(program: CheckedProgram, function_id: FunctionId) throws -> String {
+    let checked_function = program.get_function(function_id)
+    let type_id = checked_function.return_type_id
+    let mod = program.modules[type_id.module.id]
+    for struct_ in mod.structures.iterator() {
+        if struct_.type_id.equals(type_id) {
+            mut output = get_type_signature(program, type_id)
+
+            output += "("
+
+            mut first = true
+            for field in struct_.fields.iterator() {
+                if first {
+                    first = false
+                } else {
+                    output += ", "
+                }
+
+                let variable = program.get_variable(field)
+                if variable.is_mutable {
+                    output += "mut "
+                }
+                output += format("{}: {}", variable.name, program.type_name(variable.type_id))
+            }
+            output += ")"
+
+            return output
+        }
+    }
+
+    return ""
+}

--- a/selfhost/main.jakt
+++ b/selfhost/main.jakt
@@ -9,15 +9,16 @@
 import compiler { Compiler, FileId }
 import codegen { CodeGenerator }
 import error { JaktError, print_error }
-import utility { FilePath, ArgsParser }
+import utility { FilePath, ArgsParser, Span }
 import lexer { Lexer }
 import parser { Parser }
 import typechecker { Typechecker }
+import ide
 
 function usage() => "usage: jakt [-h] [OPTIONS] <filename>"
 function help() -> String{
     mut output = "Flags:\n"
-    output += "  -h\t\tPrint this help and exit.\n"
+    output += "  -h,--help\t\tPrint this help and exit.\n"
     output += "  -dl\t\tPrint debug info for the lexer.\n"
     output += "  -dp\t\tPrint debug info for the parser.\n"
     output += "  -dt\t\tPrint debug info for the typechecker.\n"
@@ -26,6 +27,9 @@ function help() -> String{
     output += "  -d\t\tInsert debug statement spans in generated C++ code.\n"
     output += "  --debug-print\t\tOutput debug print.\n"
     output += "  --prettify-cpp-source\t\tRun emitted C++ source through clang-format.\n" // FIXME: Add -p flag to be the same as rust compiler.
+    output += "  -c,--check-only\t\tOnly check the code for errors.\n"
+    output += "  -j,--json-errors\t\tEmit machine-readable (JSON) errors.\n"
+    output += "  -H,--type-hints\t\tEmit machine-readable type hints (for IDE integration).\n"
 
     output += "\nOptions:\n"
     output += "  -F,--clang-format-path PATH\t\tPath to clang-format executable.\n\t\tDefaults to clang-format\n"
@@ -37,6 +41,10 @@ function help() -> String{
     output += "  -L PATH\t\tAdd PATH to linker's search list. Can be specified multiple times.\n"
     output += "  -l,--link-with LIB\t\tLink executable with LIB. Can be specified multiple times.\n"
     output += "  -o,--output-filename FILE\t\tName of the output C++ file and binary.\n\t\tDefaults to the input-filename.\n"
+    output += "  -g,--goto-def INDEX\t\tReturn the span for the definition at index.\n"
+    output += "  -t,--goto-type-def INDEX\t\tReturn the span for the type definition at index.\n"
+    output += "  -e,--hover INDEX                  Return the type of element at index.\n"
+    output += "  -m,--completions INDEX            Return dot completions at index.\n"
     return output
 } 
 
@@ -48,7 +56,7 @@ function main(args: [String]) {
 
     mut args_parser = ArgsParser::from_args(args)
     
-    if args_parser.flag(["-h"]) {
+    if args_parser.flag(["-h", "--help"]) {
         println("{}\n", usage())
         println("{}", help())
         return 0
@@ -67,6 +75,9 @@ function main(args: [String]) {
     let codegen_debug = args_parser.flag(["-d"])
     let debug_print = args_parser.flag(["--debug-print"])
     let prettify_cpp_source = args_parser.flag(["--prettify-cpp-source"])
+    let json_errors = args_parser.flag(["-j","--json-errors"])
+    let dump_type_hints = args_parser.flag(["-H", "--type-hints"])
+    let check_only = args_parser.flag(["-c", "--check-only"])
 
     let clang_format_path = args_parser.option(["-F", "--clang-format-path"]) ?? "clang-format"
     let runtime_path = args_parser.option(["-R", "--runtime-path"]) ?? "runtime"
@@ -77,6 +88,10 @@ function main(args: [String]) {
     let extra_lib_paths = args_parser.option_multiple(["-L"])
     let extra_link_libs = args_parser.option_multiple(["-l"])
     let set_output_filename = args_parser.option(["-o", "--output-filename"])
+    let goto_def = args_parser.option(["-g", "--goto-def"])
+    let goto_type_def = args_parser.option(["-t", "--goto-type-def"])
+    let hover = args_parser.option(["-e", "--hover"])
+    let completions = args_parser.option(["-m", "--completions"])
 
     let positional_arguments = args_parser.remaining_arguments()
 
@@ -103,11 +118,11 @@ function main(args: [String]) {
     }
 
     let file_path = FilePath::make(file_name!)
-    if file_path.ext() != "jakt" {
-        eprintln("the compiler expects files with file extension .jakt")
-        eprintln("{}", usage())
-        return 1
-    }
+    // if file_path.ext() != "jakt" {
+    //     eprintln("the compiler expects files with file extension .jakt")
+    //     eprintln("{}", usage())
+    //     return 1
+    // }
 
     mut errors: [JaktError] = []
 
@@ -121,6 +136,8 @@ function main(args: [String]) {
         dump_parser: parser_debug
         ignore_parser_errors: false
         debug_print: debug_print
+        json_errors
+        dump_type_hints
     )
 
     let main_file_id = compiler.get_file_id_or_register(file_path)
@@ -148,6 +165,63 @@ function main(args: [String]) {
         parsed_namespace
     )
 
+    if goto_def.has_value() {
+        let index = goto_def!.to_uint()! as! usize;
+
+        let result = ide::find_definition_in_program(program: checked_program, span: Span(file_id: FileId(id: 0uz), start: index, end: index))
+
+        if result.file_id.id == 0 {
+            println("{{\"start\": {}, \"end\": {}}}", result.start, result.end);
+        } else {
+            let file_path = compiler.get_file_path(result.file_id)
+            
+            println("{{\"start\": {}, \"end\": {}, \"file\": \"{}\"}}", result.start, result.end, file_path!);
+        }
+        return 0
+    }
+    if goto_type_def.has_value() {
+        let index = goto_type_def!.to_uint()! as! usize;
+
+        let result = ide::find_type_definition_in_program(program: checked_program, span: Span(file_id: FileId(id: 0uz), start: index, end: index))
+
+        if result.file_id.id == 0 {
+            println("{{\"start\": {}, \"end\": {}}}", result.start, result.end);
+        } else {
+            let file_path = compiler.get_file_path(result.file_id)
+
+            println("{{\"start\": {}, \"end\": {}, \"file\": \"{}\"}}", result.start, result.end, file_path!);
+        }
+        return 0
+    }
+    if hover.has_value() {
+        let index = hover!.to_uint()! as! usize;
+        
+        let result = ide::find_typename_in_program(program: checked_program, span: Span(file_id: FileId(id: 0uz), start: index, end: index))
+
+        if result.has_value() {
+            println("{{\"hover\": \"{}\"}}", result!)
+        }
+        return 0
+    }
+    if completions.has_value() {
+        let index = completions!.to_uint()! as! usize;
+
+        let result = ide::find_dot_completions(program: checked_program, span: Span(file_id: FileId(id: 0uz), start: index, end: index))
+
+        print("{{\"completions\": [");
+        mut first = true
+        for completion in result.iterator() {
+            if not first {
+                print(", ")
+            } else {
+                first = false
+            }
+            print("\"{}\"", completion)
+        }
+        println("]}}");
+        return 0
+    }
+
     if typechecker_debug {
         println("{:#}", checked_program);
     }
@@ -158,8 +232,12 @@ function main(args: [String]) {
         return 1
     }
 
-    let output = CodeGenerator::generate(compiler, checked_program, debug_info: codegen_debug)
+    if check_only {
+        return 0
+    }
 
+    let output = CodeGenerator::generate(compiler, checked_program, debug_info: codegen_debug)
+        
     if (build_executable or run_executable) {
         mut cpp_filename: String = ""
         mut output_filename: String = ""

--- a/selfhost/parser.jakt
+++ b/selfhost/parser.jakt
@@ -513,6 +513,7 @@ struct ParsedVarDecl {
     name: String
     parsed_type: ParsedType
     is_mutable: bool
+    inlay_span: Span?
     span: Span
 }
 
@@ -1003,9 +1004,10 @@ struct Parser {
 
                         while not .eof() {
                             if .peek(1) is Colon {
-                                let var_decl = .parse_variable_declaration(is_mutable: false)
+                                mut var_decl = .parse_variable_declaration(is_mutable: false)
                                 match var_decl.parsed_type {
-                                    Name(name) => {
+                                    Name(name, span) => {
+                                        var_decl.inlay_span = span
                                         if name == partial_enum.name and not is_boxed{
                                             .error("use 'boxed enum' to make the enum recursive", var_decl.span)
                                         }
@@ -1022,6 +1024,7 @@ struct Parser {
                                         name: ""
                                         parsed_type: .parse_typename()
                                         is_mutable: false
+                                        inlay_span: None
                                         span: .current().span()
                                     ))
                                 }
@@ -1767,6 +1770,7 @@ struct Parser {
             name: "",
             parsed_type: ParsedType::Empty,
             is_mutable: false,
+            inlay_span: None,
             span: .current().span(),
         )]
     }
@@ -1775,25 +1779,29 @@ struct Parser {
         match .current() {
             Identifier(name) => {
                 let var_name = name
+                mut inlay_span: Span? = None
+                let decl_span = .current().span()
+
                 .index++
                 if .current() is Colon {
                     .index++
+                    inlay_span = .current().span()
                 } else {
                     return ParsedVarDecl(
                         name: var_name,
                         parsed_type: ParsedType::Empty,
                         is_mutable,
-                        span: .current().span(),
+                        inlay_span: None
+                        span: decl_span
                     )
                 }
-
-                let decl_span = .current().span()
 
                 let var_type = .parse_typename()
                 return ParsedVarDecl(
                     name: var_name,
                     parsed_type: var_type,
                     is_mutable,
+                    inlay_span,
                     span: decl_span,
                 )
             }
@@ -1803,6 +1811,7 @@ struct Parser {
             name: "",
             parsed_type: ParsedType::Empty,
             is_mutable: false,
+            inlay_span: None,
             span: .current().span(),
         )
     }
@@ -1982,6 +1991,7 @@ struct Parser {
                     name: "",
                     parsed_type: ParsedType::Empty,
                     is_mutable: is_mutable,
+                    inlay_span: None,
                     span: .current().span(),
                 )
 

--- a/selfhost/typechecker.jakt
+++ b/selfhost/typechecker.jakt
@@ -436,6 +436,7 @@ class CheckedFunction {
     public name_span: Span
     public visibility: Visibility
     public return_type_id: TypeId
+    public return_type_span: Span?
     public params: [CheckedParameter]
     public generic_params: [FunctionGenericParameter]
     public block: CheckedBlock
@@ -492,6 +493,7 @@ struct CheckedVariable {
     type_id: TypeId
     is_mutable: bool
     definition_span: Span
+    type_span: Span?
     visibility: Visibility
 }
 
@@ -969,17 +971,17 @@ class CheckedProgram {
         if id.id > max_scope {
             .compiler.panic(format("scope_id {} does not exist in module", id))
         }
-        
+
         return .modules[id.module_id.id].scopes[id.id]
-    } 
+    }
 
     public function prelude_scope_id(this) -> ScopeId => ScopeId(module_id: ModuleId(id: 0), id: 0)
 
     public function set_loaded_module(mut this, module_name: String, loaded_module: LoadedModule) throws {
         .loaded_modules.set(
             key: module_name
-            value: loaded_module 
-        )  
+            value: loaded_module
+        )
     }
     public function get_loaded_module(this, anon module_name: String) -> LoadedModule? {
         return .loaded_modules.get(module_name)
@@ -998,6 +1000,35 @@ class CheckedProgram {
             }
             current_scope_id = scope.parent!
         }
+        return None
+    }
+
+    public function find_enum_in_scope(this, scope_id: ScopeId, name: String) throws -> EnumId? {
+        mut current = scope_id
+
+        loop {
+            let scope = .get_scope(current)
+            let maybe_enum = scope.enums.get(name)
+            if maybe_enum.has_value() {
+                return maybe_enum
+            }
+            for child_id in scope.children.iterator() {
+                let child_scope = .get_scope(id: child_id)
+                if not child_scope.namespace_name.has_value() {
+                    let maybe_enum = child_scope.enums.get(name)
+                    if maybe_enum.has_value() {
+                        return maybe_enum
+                    }
+                }
+            }
+
+            if scope.parent.has_value() {
+                current = scope.parent.value()
+            } else {
+                break
+            }
+        }
+
         return None
     }
 
@@ -1023,7 +1054,7 @@ class CheckedProgram {
         return .is_integer(type_id) or .is_floating(type_id)
     }
 
-    public function is_string(this, anon type_id: TypeId) -> bool => .get_type(type_id) is JaktString 
+    public function is_string(this, anon type_id: TypeId) -> bool => .get_type(type_id) is JaktString
 
     public function get_bits(this, anon type_id: TypeId) => .get_type(type_id).get_bits()
 
@@ -1093,11 +1124,130 @@ class CheckedProgram {
                     )
                 }
             }
-            
+
             .compiler.panic("should be unreachable")
             return None // FIXME: control flow analysis
         } else {
             return None
+        }
+    }
+
+    public function type_name(this, anon type_id: TypeId) throws -> String {
+        let type = .get_type(type_id)
+
+        return match type {
+            F32 => "f32"
+            F64 => "f64"
+            I8 => "i8"
+            I16 => "i16"
+            I32 => "i32"
+            I64 => "i64"
+            U8 => "u8"
+            U16 => "u16"
+            U32 => "u32"
+            U64 => "u64"
+            Usize => "usize"
+            CChar => "c_char"
+            CInt => "c_int"
+            Bool => "bool"
+            Void => "void"
+            Unknown => "unknown"
+            JaktString => "String"
+            Enum(id) => .get_enum(id).name
+            Struct(id) => .get_struct(id).name
+            GenericEnumInstance(id, args) => {
+                mut output = format("enum {}", .get_enum(id).name)
+
+                output += "<"
+                mut first = true
+                for arg in args.iterator() {
+                    if not first {
+                        output += ", "
+                    } else {
+                        first = false
+                    }
+
+                    output += .type_name(arg)
+                }
+
+                output += ">"
+
+                yield output
+            }
+            GenericInstance(id, args) => {
+
+                let array_struct_id = .find_struct_in_prelude("Array")
+                let dictionary_struct_id = .find_struct_in_prelude("Dictionary")
+                let optional_struct_id = .find_struct_in_prelude("Optional")
+                let range_struct_id = .find_struct_in_prelude("Range")
+                let set_struct_id = .find_struct_in_prelude("Set")
+                let tuple_struct_id = .find_struct_in_prelude("Tuple")
+                let weak_ptr_struct_id = .find_struct_in_prelude("WeakPtr")
+
+                mut output = ""
+
+                if id.equals(array_struct_id) {
+                    output = format("[{}]", .type_name(args[0]))
+                } else if id.equals(dictionary_struct_id) {
+                    output = format("[{}:{}]", .type_name(args[0]), .type_name(args[1]))
+                } else if id.equals(optional_struct_id) {
+                    output = format("{}?", .type_name(args[0]))
+                } else if id.equals(range_struct_id) {
+                    output = format("{}..{}", .type_name(args[0]), .type_name(args[0]))
+                } else if id.equals(set_struct_id) {
+                    output = format("{{{}}}", .type_name(args[0]))
+                } else if id.equals(tuple_struct_id) {
+                    output = "("
+                    mut first = true
+                    for arg in args.iterator() {
+                        if not first {
+                            output += ", "
+                        } else {
+                            first = false
+                        }
+                        output += .type_name(arg)
+                    }
+                    output += ")"
+                } else if id.equals(weak_ptr_struct_id) {
+                    output = format("weak {}?", .type_name(args[0]))
+                } else {
+                    let structure = .get_struct(id)
+                    output = structure.name
+                    output += "<"
+                    mut first = true
+                    for arg in args.iterator() {
+                        if not first {
+                            output += ", "
+                        } else {
+                            first = false
+                        }
+                        output += .type_name(arg)
+                    }
+                    output += ">"
+                }
+
+                yield output
+            }
+            GenericResolvedType(id, args) => {
+                mut output = .get_struct(id).name
+                mut first = true
+                output += "<"
+                for arg in args.iterator() {
+                    if not first {
+                        output += ", "
+                    } else {
+                        first = false
+                    }
+                    output += .type_name(type_id)
+                }
+                output += ">"
+
+                yield output
+            }
+            TypeVariable(name) => name
+            RawPtr(type_id) => format("raw {}", .type_name(type_id))
+            Reference(type_id) => format("&{}", .type_name(type_id))
+            MutableReference(type_id) => format("&mut {}", .type_name(type_id))
         }
     }
 }
@@ -1111,6 +1261,14 @@ struct Typechecker {
     inside_defer: bool
     checkidx: usize
     ignore_errors: bool
+    dump_type_hints: bool
+
+    function type_name(this, anon type_id: TypeId) throws => .program.type_name(type_id)
+
+    function dump_type_hint(this, type_id: TypeId, span: Span) throws {
+        println("{{\"type\":\"hint\",\"file_id\":{},\"position\":{},\"typename\":\"{}\"}}"
+                span.file_id, span.end, .type_name(type_id))
+    }
 
     function typecheck(mut compiler: Compiler, parsed_namespace: ParsedNamespace) throws -> CheckedProgram {
 
@@ -1131,6 +1289,7 @@ struct Typechecker {
             inside_defer: false
             checkidx: 0uz
             ignore_errors: false
+            dump_type_hints: compiler.dump_type_hints
         )
 
         typechecker.include_prelude()
@@ -1359,7 +1518,7 @@ struct Typechecker {
         .compiler.print_errors()
 
         return parsed_namespace
-    } 
+    }
 
     function find_struct_in_prelude(this, anon name: String) throws -> StructId =>
         .program.find_struct_in_prelude(name)
@@ -1395,125 +1554,6 @@ struct Typechecker {
         let new_constant = result!
 
         return CheckedExpression::NumericConstant(val: new_constant, span, type_id: lhs_type)
-    }
-
-    function type_name(this, anon type_id: TypeId) throws -> String {
-        let type = .get_type(type_id)
-
-        return match type {
-            F32 => "f32"
-            F64 => "f64"
-            I8 => "i8"
-            I16 => "i16"
-            I32 => "i32"
-            I64 => "i64"
-            U8 => "u8"
-            U16 => "u16"
-            U32 => "u32"
-            U64 => "u64"
-            Usize => "usize"
-            CChar => "c_char"
-            CInt => "c_int"
-            Bool => "bool"
-            Void => "void"
-            Unknown => "unknown"
-            JaktString => "String"
-            Enum(id) => .get_enum(id).name
-            Struct(id) => .get_struct(id).name
-            GenericEnumInstance(id, args) => {
-                mut output = format("enum {}", .get_enum(id).name)
-
-                output += "<"
-                mut first = true
-                for arg in args.iterator() {
-                    if not first {
-                        output += ", "
-                    } else {
-                        first = false
-                    }
-
-                    output += .type_name(arg)
-                }
-
-                output += ">"
-
-                yield output
-            }
-            GenericInstance(id, args) => {
-
-                let array_struct_id = .find_struct_in_prelude("Array")
-                let dictionary_struct_id = .find_struct_in_prelude("Dictionary")
-                let optional_struct_id = .find_struct_in_prelude("Optional")
-                let range_struct_id = .find_struct_in_prelude("Range")
-                let set_struct_id = .find_struct_in_prelude("Set")
-                let tuple_struct_id = .find_struct_in_prelude("Tuple")
-                let weak_ptr_struct_id = .find_struct_in_prelude("WeakPtr")
-
-                mut output = ""
-
-                if id.equals(array_struct_id) {
-                    output = format("[{}]", .type_name(args[0]))
-                } else if id.equals(dictionary_struct_id) {
-                    output = format("[{}:{}]", .type_name(args[0]), .type_name(args[1]))
-                } else if id.equals(optional_struct_id) {
-                    output = format("{}?", .type_name(args[0]))
-                } else if id.equals(range_struct_id) {
-                    output = format("{}..{}", .type_name(args[0]), .type_name(args[0]))
-                } else if id.equals(set_struct_id) {
-                    output = format("{{{}}}", .type_name(args[0]))
-                } else if id.equals(tuple_struct_id) {
-                    output = "("
-                    mut first = true
-                    for arg in args.iterator() {
-                        if not first {
-                            output += ", "
-                        } else {
-                            first = false
-                        }
-                        output += .type_name(arg)
-                    }
-                    output += ")"
-                } else if id.equals(weak_ptr_struct_id) {
-                    output = format("weak {}?", .type_name(args[0]))
-                } else {
-                    let structure = .get_struct(id)
-                    output = structure.name
-                    output += "<"
-                    mut first = true
-                    for arg in args.iterator() {
-                        if not first {
-                            output += ", "
-                        } else {
-                            first = false
-                        }
-                        output += .type_name(arg)
-                    }
-                    output += ">"
-                }
-
-                yield output
-            }
-            GenericResolvedType(id, args) => {
-                mut output = .program.get_struct(id).name
-                mut first = true
-                output += "<"
-                for arg in args.iterator() {
-                    if not first {
-                        output += ", "
-                    } else {
-                        first = false
-                    }
-                    output += .type_name(type_id)
-                }
-                output += ">"
-
-                yield output
-            }
-            TypeVariable(name) => name
-            RawPtr(type_id) => format("raw {}", .type_name(type_id))
-            Reference(type_id) => format("&{}", .type_name(type_id))
-            MutableReference(type_id) => format("&mut {}", .type_name(type_id))
-        }
     }
 
     // FIXME: not a method of expression because of https://github.com/SerenityOS/jakt/issues/527
@@ -1629,34 +1669,6 @@ struct Typechecker {
         return None
     }
 
-    function find_enum_in_scope(this, scope_id: ScopeId, name: String) throws -> EnumId? {
-        mut current = scope_id
-
-        loop {
-            let scope = .get_scope(current)
-            let maybe_enum = scope.enums.get(name)
-            if maybe_enum.has_value() {
-                return maybe_enum
-            }
-            for child_id in scope.children.iterator() {
-                let child_scope = .get_scope(id: child_id)
-                if not child_scope.namespace_name.has_value() {
-                    let maybe_enum = child_scope.enums.get(name)
-                    if maybe_enum.has_value() {
-                        return maybe_enum
-                    }
-                }
-            }
-
-            if scope.parent.has_value() {
-                current = scope.parent.value()
-            } else {
-                break
-            }
-        }
-
-        return None
-    }
 
     // Find the namespace in the current scope, or one of its parents,
     // and whether the found scope was an import.
@@ -1890,6 +1902,7 @@ struct Typechecker {
                 type_id: checked_member_type
                 is_mutable: parsed_var_decl.is_mutable
                 definition_span: parsed_var_decl.span
+                type_span: None
                 visibility: unchecked_member.visibility
             ))
             structure.fields.push(var_id)
@@ -1971,7 +1984,7 @@ struct Typechecker {
                     }
 
                 // if it is an enum, add enum to scope
-                let maybe_enum_id = .find_enum_in_scope(
+                let maybe_enum_id = .program.find_enum_in_scope(
                     scope_id: import_scope_id
                     name: imported_name.name
                 )
@@ -1981,7 +1994,7 @@ struct Typechecker {
                             parent_scope_id: scope_id
                             name: imported_name.name
                             enum_id: maybe_enum_id!
-                            span: imported_name.span 
+                            span: imported_name.span
                         )
                     }
 
@@ -1991,7 +2004,7 @@ struct Typechecker {
                     name: imported_name.name
                 )
                     if maybe_type_id.has_value() {
-                        // NOTE: what should we do if this returns false? error is already created in the type itself and rust compiler goes on 
+                        // NOTE: what should we do if this returns false? error is already created in the type itself and rust compiler goes on
                         .add_type_to_scope(
                             parent_scope_id: scope_id
                             type_name: imported_name.name
@@ -2006,7 +2019,7 @@ struct Typechecker {
                     name: imported_name.name
                 )
                     if maybe_struct_id.has_value() {
-                        // NOTE: what should we do if this returns false? error is already created in the struct itself and rust compiler goes on 
+                        // NOTE: what should we do if this returns false? error is already created in the struct itself and rust compiler goes on
                         .add_struct_to_scope(
                             parent_scope_id: scope_id
                             name: imported_name.name
@@ -2026,7 +2039,7 @@ struct Typechecker {
 
             if import_.is_c and not f.generic_parameters.is_empty() {
                 .error_with_hint(
-                    format("imported function '{}' is declared to have C linkage, but is generic",f.name) 
+                    format("imported function '{}' is declared to have C linkage, but is generic",f.name)
                     f.name_span
                     "this function may not be generic"
                     f.name_span)
@@ -2037,7 +2050,7 @@ struct Typechecker {
                         f.name_span)
             }
 
-        }       
+        }
 
         for record in import_.assigned_namespace.records.iterator() {
             if not record.definition_linkage is External {
@@ -2046,10 +2059,10 @@ struct Typechecker {
             }
             if import_.is_c and not record.generic_parameters.is_empty() {
                 .error_with_hint(
-                    format("imported {} '{}' is declared to have C linkage, but is generic", 
-                        record.record_type.record_type_name() 
+                    format("imported {} '{}' is declared to have C linkage, but is generic",
+                        record.record_type.record_type_name()
                         record.name)
-                    record.name_span, 
+                    record.name_span,
                     format("this {} may not be generic", record.record_type.record_type_name())
                     record.name_span)
             }
@@ -2097,8 +2110,8 @@ struct Typechecker {
             }
             debug_name += ")"
             let namespace_scope_id = .create_scope(
-                parent_scope_id: scope_id 
-                can_throw: false 
+                parent_scope_id: scope_id
+                can_throw: false
                 debug_name)
             mut child_scope = .get_scope(namespace_scope_id)
             child_scope.namespace_name = namespce.name
@@ -2131,7 +2144,7 @@ struct Typechecker {
         for record in parsed_namespace.records.iterator() {
             match record.record_type {
                 SumEnum | ValueEnum => {
-                    let enum_id = .find_enum_in_scope(scope_id, name: record.name)
+                    let enum_id = .program.find_enum_in_scope(scope_id, name: record.name)
                     if not enum_id.has_value() {
                         .compiler.panic("can't find enum that has been previous added")
                     }
@@ -2242,6 +2255,7 @@ struct Typechecker {
                 name_span: func.name_span
                 visibility: method.visibility
                 return_type_id: unknown_type_id()
+                return_type_span: None
                 params: []
                 generic_params: []
                 block: CheckedBlock(
@@ -2297,6 +2311,7 @@ struct Typechecker {
                         type_id: enum_type_id
                         is_mutable: param.variable.is_mutable
                         definition_span: param.variable.span
+                        type_span: None
                         visibility: Visibility::Public
                     )
 
@@ -2312,6 +2327,7 @@ struct Typechecker {
                         type_id: param_type
                         is_mutable: param.variable.is_mutable
                         definition_span: param.variable.span
+                        type_span: param.variable.parsed_type.span()
                         visibility: Visibility::Public
                     )
 
@@ -2386,6 +2402,7 @@ struct Typechecker {
                 name_span: func.name_span
                 visibility: method.visibility
                 return_type_id: unknown_type_id()
+                return_type_span: func.return_type_span
                 params: []
                 generic_params: []
                 block: CheckedBlock(
@@ -2433,6 +2450,7 @@ struct Typechecker {
                         type_id: struct_type_id
                         is_mutable: param.variable.is_mutable
                         definition_span: param.variable.span
+                        type_span: None
                         visibility: Visibility::Public
                     )
 
@@ -2453,6 +2471,7 @@ struct Typechecker {
                         type_id: param_type
                         is_mutable: param.variable.is_mutable
                         definition_span: param.variable.span
+                        type_span: param.variable.parsed_type.span()
                         visibility: Visibility::Public
                     )
 
@@ -2614,13 +2633,14 @@ struct Typechecker {
                                 parsed_type: underlying_type
                             )
                         }
-                        
+
                         enum_.variants.push(CheckedEnumVariant::WithValue(name: variant.name, expr, span: variant.span))
                         let var_id = module.add_variable(CheckedVariable(
                             name: variant.name
                             type_id: enum_.type_id
                             is_mutable: false
                             definition_span: variant.span
+                            type_span: None
                             visibility: Visibility::Public
                         ))
                         .add_var_to_scope(scope_id: enum_.scope_id, name: variant.name, var_id, span: variant.span)
@@ -2633,7 +2653,7 @@ struct Typechecker {
                     if seen_names.contains(variant.name) {
                         .error(format("Enum variant '{}' is defined more than once", variant.name), variant.span)
                         continue
-                    } 
+                    }
                     seen_names.add(variant.name)
                     let is_structlike = variant.params.has_value() and variant.params!.size() > 0 and variant.params![0].name != ""
                     let is_typed = variant.params.has_value() and variant.params!.size() == 1 and variant.params![0].name == ""
@@ -2654,11 +2674,14 @@ struct Typechecker {
                                 type_id
                                 is_mutable: param.is_mutable
                                 definition_span: param.span
+                                type_span: None
                                 visibility: Visibility::Public
                             )
                             params.push(CheckedParameter(requires_label: true, variable: checked_var))
 
-                            // TODO: dump type hints
+                            if .dump_type_hints {
+                                .dump_type_hint(type_id, span: param.span)
+                            }
 
                             mut module = .current_module()
                             let var_id = module.add_variable(checked_var)
@@ -2675,6 +2698,7 @@ struct Typechecker {
                                 name_span: variant.span,
                                 visibility: Visibility::Public,
                                 return_type_id: .find_or_add_type_id(Type::Enum(enum_id)),
+                                return_type_span: None
                                 params,
                                 generic_params: [],
                                 block: CheckedBlock(statements: [], scope_id: block_scope_id, definitely_returns: true, yielded_type: TypeId::none()),
@@ -2703,6 +2727,7 @@ struct Typechecker {
                                 type_id
                                 is_mutable: false
                                 definition_span: param.span
+                                type_span: None
                                 visibility: Visibility::Public
                             )
                             let checked_function = CheckedFunction(
@@ -2710,6 +2735,7 @@ struct Typechecker {
                                 name_span: variant.span,
                                 visibility: Visibility::Public,
                                 return_type_id: .find_or_add_type_id(Type::Enum(enum_id)),
+                                return_type_span: None,
                                 params: [CheckedParameter(requires_label: false, variable)],
                                 generic_params: [],
                                 block: CheckedBlock(statements: [], scope_id: block_scope_id, definitely_returns: true, yielded_type: TypeId::none()),
@@ -2735,6 +2761,7 @@ struct Typechecker {
                                 name_span: variant.span,
                                 visibility: Visibility::Public,
                                 return_type_id: .find_or_add_type_id(Type::Enum(enum_id)),
+                                return_type_span: None,
                                 params: [],
                                 generic_params: [],
                                 block: CheckedBlock(statements: [], scope_id: block_scope_id, definitely_returns: true, yielded_type: TypeId::none()),
@@ -2795,6 +2822,7 @@ struct Typechecker {
                 name_span: record.name_span
                 visibility: Visibility::Public
                 return_type_id: struct_type_id
+                return_type_span: None
                 params: []
                 generic_params: []
                 block: CheckedBlock(
@@ -2940,6 +2968,7 @@ struct Typechecker {
             name_span: parsed_function.name_span
             visibility: parsed_function.visibility
             return_type_id: unknown_type_id()
+            return_type_span: parsed_function.return_type_span
             params: []
             generic_params: []
             block: CheckedBlock(
@@ -3011,6 +3040,7 @@ struct Typechecker {
                 type_id
                 is_mutable: parameter.variable.is_mutable
                 definition_span: parameter.variable.span
+                type_span: None
                 visibility: Visibility::Public
             )
 
@@ -3374,7 +3404,7 @@ struct Typechecker {
                 let lhs_args = args
 
                 // If lhs is T? or weak T? and rhs is T, skip type compat check
-                if (lhs_struct_id.equals(optional_struct_id)) or 
+                if (lhs_struct_id.equals(optional_struct_id)) or
                     (lhs_struct_id.equals(weakptr_struct_id)) {
                     if lhs_args.size() > 0 {
                         if (lhs_args[0].equals(rhs_type_id)) {
@@ -3741,7 +3771,7 @@ struct Typechecker {
         return checked_block
     }
 
-    function typecheck_typename(mut this, parsed_type: ParsedType, scope_id: ScopeId) throws -> TypeId { 
+    function typecheck_typename(mut this, parsed_type: ParsedType, scope_id: ScopeId) throws -> TypeId {
         match parsed_type {
             Reference(inner) => {
                 let inner_type_id = .typecheck_typename(parsed_type: inner, scope_id)
@@ -3904,7 +3934,7 @@ struct Typechecker {
             return .find_or_add_type_id(Type::GenericInstance(id: struct_id!, args: checked_inner_types))
         }
 
-        let enum_id = .find_enum_in_scope(scope_id, name)
+        let enum_id = .program.find_enum_in_scope(scope_id, name)
         if enum_id.has_value() {
             return .find_or_add_type_id(Type::GenericEnumInstance(id: enum_id!, args: checked_inner_types))
         }
@@ -4284,7 +4314,7 @@ struct Typechecker {
         //     1- Must respond to .next(); the mutability of the iterator is inferred from .next()'s signature
         //     2- The result of .next() must be an Optional.
 
-        let iterable_expr = .typecheck_expression(range, scope_id, safety_mode, type_hint: None) 
+        let iterable_expr = .typecheck_expression(range, scope_id, safety_mode, type_hint: None)
         mut iterable_should_be_mutable = false
 
 
@@ -4325,6 +4355,7 @@ struct Typechecker {
                             name: "_magic",
                             parsed_type: ParsedType::Empty,
                             is_mutable: iterable_should_be_mutable,
+                            inlay_span: None,
                             span: name_span
                         ),
                         init: range
@@ -4340,6 +4371,7 @@ struct Typechecker {
                                         name: "_magic_value",
                                         parsed_type: ParsedType::Empty,
                                         is_mutable: iterable_should_be_mutable,
+                                        inlay_span: None,
                                         span: name_span
                                     ),
                                     init: ParsedExpression::MethodCall(
@@ -4393,6 +4425,7 @@ struct Typechecker {
                                     // FIXME: loop variable mutability should be independent
                                     // of iterable mutability
                                     is_mutable: iterable_should_be_mutable,
+                                    inlay_span: name_span,
                                     span: name_span
                                     ),
                                     init: ParsedExpression::ForcedUnwrap(
@@ -4471,7 +4504,7 @@ struct Typechecker {
         } else {
             .error("Tuple inner types sould have same size as tuple members", span)
         }
-        
+
         return CheckedStatement::DestructuringAssignment(vars: var_decls, var_decl: checked_tuple_var_decl, span)
     }
 
@@ -4546,16 +4579,20 @@ struct Typechecker {
             type_id: lhs_type_id
             is_mutable: var.is_mutable
             definition_span: var.span
+            type_span: None
             visibility: Visibility::Public
         )
 
-        // TODO: dump type hints
+        if .dump_type_hints and var.inlay_span.has_value() {
+            .dump_type_hint(type_id: lhs_type_id, span: var.inlay_span!)
+        }
 
         mut module = .current_module()
         let var_id = module.add_variable(checked_var)
         .add_var_to_scope(scope_id, name: var.name, var_id, span: checked_var.definition_span)
         return CheckedStatement::VarDecl(var_id, init: checked_expr, span)
     }
+
 
     function typecheck_while(mut this, condition: ParsedExpression, block: ParsedBlock, scope_id: ScopeId, safety_mode: SafetyMode, span: Span) throws -> CheckedStatement {
         let checked_condition = .typecheck_expression(condition, scope_id, safety_mode, type_hint: None)
@@ -4580,6 +4617,7 @@ struct Typechecker {
             type_id: .get_struct(error_struct_id).type_id
             is_mutable: false
             definition_span: error_span
+            type_span: None
             visibility: Visibility::Public
         )
         mut module = .current_module()
@@ -4990,7 +5028,11 @@ struct Typechecker {
                 else => {
                     .error(format("Variable '{}' not found", name), span)
                     yield CheckedExpression::Var(
-                        var: CheckedVariable(name, type_id: type_hint.value_or(unknown_type_id()), is_mutable: false, definition_span: span, visibility: Visibility::Public), span
+                        var: CheckedVariable(name, type_id:
+                            type_hint.value_or(unknown_type_id()), is_mutable:
+                            false, definition_span: span,
+                            type_span: None
+                            visibility: Visibility::Public), span
                     )
                 }
             }
@@ -5050,7 +5092,7 @@ struct Typechecker {
             let array_struct_id = .find_struct_in_prelude("Array")
             let dictionary_struct_id = .find_struct_in_prelude("Dictionary")
             mut expr_type_id = unknown_type_id()
-            
+
             yield match .get_type(expression_type(checked_base)) {
                 GenericInstance(id, args) => {
                     mut result = CheckedExpression::Garbage(span)
@@ -5110,7 +5152,7 @@ struct Typechecker {
         for ns in namespace_.iterator() {
             let scope = scopes[scopes.size() - 1]
             let ns_in_scope = .find_namespace_in_scope(scope_id: scope, name: ns)
-            let enum_in_scope = .find_enum_in_scope(scope_id: scope, name: ns)
+            let enum_in_scope = .program.find_enum_in_scope(scope_id: scope, name: ns)
             mut next_scope = scope
             if ns_in_scope.has_value() {
                 next_scope = ns_in_scope!.0
@@ -5162,6 +5204,7 @@ struct Typechecker {
                 type_id: unknown_type_id(),
                 is_mutable: false,
                 definition_span: span
+                type_span: None
                 visibility: Visibility::Public
             ),
             span
@@ -5178,7 +5221,7 @@ struct Typechecker {
             let fill_size_type = expression_type(fill_size_checked)
             if not .is_integer(fill_size_type) {
                 .error(
-                    format("Type '{}' is not convertible to an integer. Only integer values can be array fill size expressions.", .type_name(fill_size_type)), 
+                    format("Type '{}' is not convertible to an integer. Only integer values can be array fill size expressions.", .type_name(fill_size_type)),
                     fill_size_value.span()
                 )
             }
@@ -5423,11 +5466,12 @@ struct Typechecker {
                                                     type_id: variable_type_id
                                                     is_mutable: false
                                                     definition_span: span
+                                                    type_span: None
                                                     visibility: Visibility::Public
                                                 ))
                                                 .add_var_to_scope(scope_id: new_scope_id, name: variant_argument.binding, var_id, span)
                                             }
-                                        } 
+                                        }
                                     }
                                     StructLike(name, fields) => {
                                         covered_variants.add(name)
@@ -5481,13 +5525,17 @@ struct Typechecker {
                                                 true => {
                                                     let substituted_type_id = .substitute_typevars_in_type(type_id: matched_field_variable!.type_id, generic_inferences: [:])
                                                     let matched_span = matched_field_variable!.definition_span
-                                                    // FIXME: dump type hints
+                                                    if .dump_type_hints {
+                                                        .dump_type_hint(type_id:
+                                                            matched_field_variable!.type_id, span: arg.span)
+                                                    }
 
                                                    let var_id = module.add_variable(CheckedVariable(
                                                         name: arg.binding
                                                         type_id: substituted_type_id
                                                         is_mutable: false
                                                         definition_span: matched_span
+                                                        type_span: None
                                                         visibility: Visibility::Public
                                                     ))
                                                     .add_var_to_scope(scope_id: new_scope_id, name: arg.binding, var_id, span)
@@ -5693,7 +5741,7 @@ struct Typechecker {
                 }
             }
         }
-        
+
         return CheckedExpression::Match(expr: checked_expr, match_cases: checked_cases, span, type_id: final_result_type ?? void_type_id(), all_variants_constant: true)
     }
 
@@ -5873,7 +5921,7 @@ struct Typechecker {
                 current_scope_id = structure.scope_id
                 continue
             }
-            let maybe_enum_scope = .find_enum_in_scope(scope_id: current_scope_id, name: scope_name)
+            let maybe_enum_scope = .program.find_enum_in_scope(scope_id: current_scope_id, name: scope_name)
             if maybe_enum_scope.has_value() {
                 let enum_ = .get_enum(maybe_enum_scope!)
                 current_scope_id = enum_.scope_id
@@ -5944,7 +5992,7 @@ struct Typechecker {
 
                     args.push((call.name, checked_arg))
                 }
-                
+
                 if call.name == "format" {
                     return_type = builtin(BuiltinType::String)
                     callee_throws = true
@@ -6080,7 +6128,7 @@ struct Typechecker {
                         span
                     )
                 }
-                
+
                 for generic_typevar in callee.generic_params.iterator() {
                     match generic_typevar {
                         Parameter(id) => {

--- a/selfhost/utility.jakt
+++ b/selfhost/utility.jakt
@@ -48,10 +48,18 @@ struct Span {
     file_id: FileId
     start: usize
     end: usize
+
+    function contains(this, span: Span) -> bool {
+        return .file_id.equals(span.file_id) and span.start >= .start and span.end <= .end
+    }
 }
 
 struct FileId {
     id: usize
+
+    function equals(this, anon rhs: FileId) -> bool {
+        return .id == rhs.id
+    }
 }
 
 // FIXME: Use jakt stdlib if available


### PR DESCRIPTION
A port of the IDE support from the Rust-based compiler to the selfhost compiler.

Functionality is ported and connected to the commandline params. You can use it on simple tests, but more complex applications (namely selfhost itself) do not currently seem to yield info for hovers in all places it should.

Probably worth landing even though we're not at feature parity because it's big enough it'll bitrot quickly. We can continue to evolve it. With luck, we're only a few logic fixes away from being back to parity with the Rust-based compiler.

co-authored with: @cybergsus 