### PR TITLE
samples: Verify that arrays are initialisable with size from a function

### DIFF
--- a/samples/arrays/array_size_from_function.jakt
+++ b/samples/arrays/array_size_from_function.jakt
@@ -1,0 +1,18 @@
+/// Expect:
+/// - output: "[0]\n"
+
+class C {
+    public e: [f64]
+
+    public function f(mut this) throws {
+        .e = [0f64; .n()]
+    }
+
+    function n(this) => 1    
+}
+
+function main() {
+    mut c: C = C(e: [0f64; 0])
+    c.f()
+    println("{}", c.e)
+}


### PR DESCRIPTION
A sample to show that a fat-arrow member function can be used to 
provide the size as an integer without indicating the type (e.g. via a
suffix), and hence must be inferred to be an integer. The initialiser of
the arrays must accept this integer. 

At the time of writing this works with the Rust-based compiler but 
not the self-hosted.