### PR TITLE
jakttest: Fail if no explicit skip tag is set

### DIFF
--- a/jakttest/jakttest.jakt
+++ b/jakttest/jakttest.jakt
@@ -314,10 +314,11 @@ struct Options {
         }
 
         if options.files.is_empty() {
-            // find files under samples, tests, and selfhost
+            // find files under samples and tests
             get_jakt_files_under(directory: "samples",  results: &mut options.files)
             get_jakt_files_under(directory: "tests",    results: &mut options.files)
-            get_jakt_files_under(directory: "selfhost", results: &mut options.files)
+            // compile selfhost to check it can compile itself
+            options.files.push("selfhost/main.jakt")
         }
 
         if options.job_count == 0 {
@@ -599,11 +600,11 @@ struct TestScheduler {
                             failed_reasons)
     }
 
-    public function run_tests(mut tests: [Test], directories: [String], collect_reasons: bool) throws -> TestsRunResult {
-        let total_test_count = tests.size()
+    public function run_tests(mut tests: [Test], directories: [String], collect_reasons: bool, starting_failed_tests: usize, total_test_count: usize) throws -> TestsRunResult {
         // create an empty handler so SIGCHLD is not ignored
         os::ignore_sigchild()
         mut scheduler = TestScheduler::create(directories, collect_reasons)
+        scheduler.failed_count = starting_failed_tests
         // pre-allocate the command buffer to avoid allocating inside a loop
         let run_once_script = os::get_script_execution_string()
         mut command_buffer: [String] = [run_once_script "" ""]
@@ -655,6 +656,7 @@ function main(args: [String]) {
     mut skipped_count = 0uz
 
     mut tests: [Test] = []
+    mut bad_formatted_tests: [String] = []
     tests.ensure_capacity(parsed_options.files.size())
 
     // parse all files to collect the actual work we have to do
@@ -682,6 +684,10 @@ function main(args: [String]) {
                 eprintln("[ \x1b[33;1mSKIP\x1b[m ] {}", file_name)
                 skipped_count += 1
             }
+            NoExpectOrSkip => {
+                eprintln("[ \x1b[31;1mFAIL\x1b[m ] {}", file_name)
+                bad_formatted_tests.push(file_name)
+            }
         }
     }
 
@@ -695,7 +701,11 @@ function main(args: [String]) {
         directories.push(path)
     }
 
-    let run_result = TestScheduler::run_tests(tests, directories, collect_reasons: parsed_options.show_reasons)
+    let run_result = TestScheduler::run_tests(
+        tests, directories,
+        collect_reasons: parsed_options.show_reasons 
+        starting_failed_tests: bad_formatted_tests.size()
+        total_test_count: skipped_count + bad_formatted_tests.size() + tests.size())
 
     // delete directories
     for dir in directories.iterator() {
@@ -711,9 +721,11 @@ function main(args: [String]) {
 
     println("==============================")
     println("{} passed" , run_result.passed_count)
-    println("{} failed" run_result.failed_count)
+    println("{} failed" run_result.failed_count + bad_formatted_tests.size())
     println("{} skipped", skipped_count)
     println("==============================")
+
+    // FIXME: translate ANSI color codes to constants for easier comprehension
 
     if run_result.failed_reasons.has_value() and run_result.failed_count > 0 {
         eprintln("Showing why tests failed:")
@@ -722,6 +734,8 @@ function main(args: [String]) {
         for file in reasons.keys().iterator() {
             if not is_first {
                 eprintln("----------------------------------------")
+            } else {
+                is_first = false
             }
             eprintln("\x1b[1m{}\x1b[m:", file)
             mut output = ""
@@ -782,7 +796,15 @@ function main(args: [String]) {
             }
 
             for line in output.split('\n').iterator() {
-                eprintln("\x1b[1;0m|\x1b[m\t{}", line)
+                eprintln("\x1b[m\x1b[1m|\x1b[m\t{}", line)
+            }
+        }
+
+        if not bad_formatted_tests.is_empty() {
+            eprintln("==============================")
+            eprintln("These tests failed to parse because they didn't have an expectation or skip message:")
+            for file in bad_formatted_tests.iterator() {
+                eprintln("\x1b[1m|\x1b[m\t{}", file)
             }
         }
         eprintln("==============================")

--- a/jakttest/parser.jakt
+++ b/jakttest/parser.jakt
@@ -10,6 +10,7 @@ enum ParsedTest {
     CompileErrorTest(String),
     RuntimeErrorTest(String),
     SkipTest
+    NoExpectOrSkip
 }
 
 function is_whitespace(anon byte: u8) -> bool => byte == b' ' or byte == b'\t' or byte == b'\r'
@@ -79,8 +80,17 @@ struct Parser {
                 continue
             }
 
-            while not .is_eof() and .current() != b'\n' {
-                .index++
+            .skip_whitespace()
+
+            if .lex_literal("Skip") {
+                return ParsedTest::SkipTest
+            }
+
+            if .lex_literal("selfhost-only") {
+                .skip_whitespace()
+            }
+            if .is_eof() or .current() != b'\n' {
+                continue
             }
             .index++
             if not .lex_literal("///") {
@@ -92,6 +102,8 @@ struct Parser {
             }
             .index++
             .skip_whitespace()
+
+
             let is_error = not .lex_literal("output")
             let compile_error = .lex_literal("error")
             let runtime_error = .lex_literal("stderr")
@@ -126,7 +138,7 @@ struct Parser {
                 return ParsedTest::SuccessTest(output)
             }
         }
-        return ParsedTest::SkipTest
+        return ParsedTest::NoExpectOrSkip
     }
 
     function parse(input: [u8]) throws -> ParsedTest {

--- a/samples/guard/is_guard_no_exit.jakt
+++ b/samples/guard/is_guard_no_exit.jakt
@@ -1,5 +1,5 @@
 /// Expect:
-//  - error: "Else block of guard must either `return`, `break`, `continue`, or `throw`"
+/// - error: "Else block of guard must either `return`, `break`, `continue`, or `throw`"
 
 enum Foo {
     Bar(i64)

--- a/samples/imports/assign_across_import/helper.jakt
+++ b/samples/imports/assign_across_import/helper.jakt
@@ -1,3 +1,4 @@
+/// Expect: Skip
 struct S {
     value: String? // let's force the typechecker to create a typeid for this one.
 }

--- a/tests/typechecker/enum_with_type_from_prelude.jakt
+++ b/tests/typechecker/enum_with_type_from_prelude.jakt
@@ -1,3 +1,4 @@
+/// Expect: Skip
 enum test {
     Range(test: i64)
     Other(test: i64)


### PR DESCRIPTION
Now tests that have no skip tag and that have an incorrect
format (i.e Jakttest can't figure out what the test is expecting) are
not skipped but reported as failures.
