### PR TITLE
debug: Add a newline before the closing bracket in debug prints

### DIFF
--- a/runtime/Jakt/StringBuilder.h
+++ b/runtime/Jakt/StringBuilder.h
@@ -106,6 +106,7 @@ struct Formatter<JaktInternal::Array<T>> : Formatter<StringView> {
                 TRY(string_builder.append(", "));
         }
         JaktInternal::_pretty_print_level--;
+        TRY(JaktInternal::_output_pretty_indent(string_builder));
         TRY(string_builder.append("]"));
         return Formatter<StringView>::format(builder, TRY(string_builder.to_string()));
     }
@@ -153,6 +154,7 @@ struct Formatter<JaktInternal::Dictionary<K, V>> : Formatter<StringView> {
                 TRY(string_builder.append(", "));
         }
         JaktInternal::_pretty_print_level--;
+        TRY(JaktInternal::_output_pretty_indent(string_builder));
         TRY(string_builder.append("]"));
         return Formatter<StringView>::format(builder, TRY(string_builder.to_string()));
     }
@@ -188,6 +190,7 @@ struct Formatter<Jakt::Tuple<Ts...>> : Formatter<StringView> {
             JaktInternal::_pretty_print_level--;
         }
 
+        TRY(JaktInternal::_output_pretty_indent(string_builder));
         TRY(string_builder.append(")"));
         return Formatter<StringView>::format(builder, TRY(string_builder.to_string()));
     }

--- a/selfhost/codegen.jakt
+++ b/selfhost/codegen.jakt
@@ -1122,6 +1122,7 @@ struct CodeGenerator {
         }
 
         output += "JaktInternal::_pretty_print_level--;\n"
+        output += "TRY(JaktInternal::_output_pretty_indent(builder));"
         output += "TRY(builder.append(\")\"));"
         output += "return builder.to_string();"
         output += " }"
@@ -1163,10 +1164,13 @@ struct CodeGenerator {
                         i++
                     }
                     lambda += "JaktInternal::_pretty_print_level--;"
+                    lambda += "TRY(JaktInternal::_output_pretty_indent(builder));"
                     lambda += "TRY(builder.append(\")\"));"
                 }
                 Typed(type_id) => {
                     lambda += "TRY(builder.append(\"(\"));"
+                    lambda += "JaktInternal::_pretty_print_level++;"
+                    lambda += "TRY(JaktInternal::_output_pretty_indent(builder));"
                     if .program.is_string(type_id) {
                         lambda += "TRY(builder.append(\"\\\"\"));"
                     }
@@ -1174,6 +1178,8 @@ struct CodeGenerator {
                     if .program.is_string(type_id) {
                         lambda += "TRY(builder.append(\"\\\"\"));"
                     }
+                    lambda += "JaktInternal::_pretty_print_level--;"
+                    lambda += "TRY(JaktInternal::_output_pretty_indent(builder));"
                     lambda += "TRY(builder.append(\")\"));"
                 }
                 else => {}


### PR DESCRIPTION
Add a newline and proper indentation in front of every closing bracket
in debug prints.

For example till now debug prints looked like this:
```
Point2(
  x: Point(
    x: 10,
    y: 5),
  y: Point(
    x: 10,
    y: 5))
```
This PR fixes the issue by adding a new line and indentations in front of closing brackets. The result looks like this:
```
Point2(
  x: Point(
    x: 10,
    y: 5
  ),
  y: Point(
    x: 10,
    y: 5
  )
)
```