### PR TITLE
Basic support for reference types

### DIFF
--- a/README.md
+++ b/README.md
@@ -539,5 +539,6 @@ function zero_out(foo: &mut Foo) {
 
 ### References TODO:
 
+- [ ] Allow `&foo` and `&mut foo` without argument label for parameters named `foo`
 - [ ] (`unsafe`) references and raw pointers bidirectionally convertible
 - [ ] No capture-by-reference in persistent closures

--- a/README.md
+++ b/README.md
@@ -533,7 +533,7 @@ function zero_out(foo: &mut Foo) {
 
 - [x] Reference types
 - [x] Reference function parameters
-- [ ] No reference locals
+- [x] No reference locals
 - [x] No references in structs
 - [x] No references in return types
 

--- a/README.md
+++ b/README.md
@@ -535,7 +535,7 @@ function zero_out(foo: &mut Foo) {
 - [x] Reference function parameters
 - [ ] No reference locals
 - [ ] No references in structs
-- [ ] No references in return types
+- [x] No references in return types
 
 ### References TODO:
 

--- a/README.md
+++ b/README.md
@@ -534,7 +534,7 @@ function zero_out(foo: &mut Foo) {
 - [x] Reference types
 - [x] Reference function parameters
 - [ ] No reference locals
-- [ ] No references in structs
+- [x] No references in structs
 - [x] No references in return types
 
 ### References TODO:

--- a/README.md
+++ b/README.md
@@ -531,8 +531,8 @@ function zero_out(foo: &mut Foo) {
 
 ### References (first version) feature list:
 
-- [ ] Reference types
-- [ ] Reference function parameters
+- [x] Reference types
+- [x] Reference function parameters
 - [ ] No reference locals
 - [ ] No references in structs
 - [ ] No references in return types

--- a/README.md
+++ b/README.md
@@ -491,3 +491,53 @@ unsafe {
 }
 println("{}", x)
 ```
+
+## References
+
+Values and objects can be passed by reference in some situations where it's provably safe to do so.
+
+A reference is either immutable (default) or mutable.
+
+### Reference type syntax
+
+- `&T` is an immutable reference to a value of type `T`.
+- `&mut T` is a mutable reference to a value of type `T`.
+
+### Reference expression syntax
+
+- `&foo` creates an immutable reference to the variable `foo`.
+- `&mut foo` creates a mutable reference to the variable `foo`.
+
+### Dereferencing a reference
+
+To "get the value out" of a reference, it must be dereferenced using the `*` operator:
+
+```jakt
+function sum(a: &i64, b: &i64) -> i64 {
+    return *a + *b
+}
+```
+
+For mutable references to structs, you'll need to wrap the dereference in parentheses in order to do a field access:
+
+```jakt
+struct Foo {
+    x: i64
+}
+function zero_out(foo: &mut Foo) {
+    (*foo).x = 0
+}
+```
+
+### References (first version) feature list:
+
+- [ ] Reference types
+- [ ] Reference function parameters
+- [ ] No reference locals
+- [ ] No references in structs
+- [ ] No references in return types
+
+### References TODO:
+
+- [ ] (`unsafe`) references and raw pointers bidirectionally convertible
+- [ ] No capture-by-reference in persistent closures

--- a/README.md
+++ b/README.md
@@ -536,6 +536,7 @@ function zero_out(foo: &mut Foo) {
 - [x] No reference locals
 - [x] No references in structs
 - [x] No references in return types
+- [x] No mutable references to immutable values
 
 ### References TODO:
 

--- a/samples/references/basic.jakt
+++ b/samples/references/basic.jakt
@@ -1,0 +1,14 @@
+/// Expect:
+/// - output: "3\n"
+
+function sum(anon a: &i64, anon b: &i64, anon result: &mut i64) {
+    *result = *a + *b
+}
+
+function main() {
+    let x = 1
+    let y = 2
+    mut result = 0
+    sum(&x, &y, &mut result)
+    println("{}", result)
+}

--- a/samples/references/basic2.jakt
+++ b/samples/references/basic2.jakt
@@ -1,0 +1,16 @@
+/// Expect:
+/// - output: "PASS\n"
+
+struct Foo {
+    string: String
+}
+
+function overwrite(foo: &mut Foo) {
+    (*foo).string = "PASS"    
+}
+
+function main() {
+    mut foo = Foo(string: "FAIL")
+    overwrite(foo: &mut foo)
+    println("{}", foo.string)
+}

--- a/samples/references/no_mutable_reference_to_immutable_binding.jakt
+++ b/samples/references/no_mutable_reference_to_immutable_binding.jakt
@@ -1,0 +1,10 @@
+/// Expect:
+/// - error: "Cannot make mutable reference to immutable value"
+
+function foo(anon x: &mut i64) {
+}
+
+function main() {
+    let i = 0
+    foo(&mut i)
+}

--- a/samples/references/no_reference_locals.jakt
+++ b/samples/references/no_reference_locals.jakt
@@ -1,0 +1,12 @@
+/// Expect:
+/// - error: "Reference type ‘&i64’ not usable in this context"
+
+function main() {
+    let i = 0
+    mut ref = &i
+    {
+        let x = 1
+        ref = &x
+    }
+    println("{}", *ref)
+}

--- a/samples/references/no_reference_return_type.jakt
+++ b/samples/references/no_reference_return_type.jakt
@@ -1,0 +1,7 @@
+/// Expect:
+/// - error: "Reference type ‘&i64’ not usable in this context"
+
+function foo() -> &i64 {
+    let x = 1
+    return &x
+}

--- a/samples/references/no_reference_struct_fields.jakt
+++ b/samples/references/no_reference_struct_fields.jakt
@@ -1,0 +1,7 @@
+/// Expect:
+/// - error: "Reference type ‘&i64’ not usable in this context"
+
+struct Foo {
+    x: &i64
+    y: &mut i64
+}

--- a/selfhost/codegen.jakt
+++ b/selfhost/codegen.jakt
@@ -750,7 +750,7 @@ struct CodeGenerator {
                 output += ", "
             }
 
-            if not param.variable.is_mutable {
+            if not param.variable.is_mutable and not .program.get_type(param.variable.type_id) is Reference {
                 output += "const "
             }
 
@@ -1303,7 +1303,11 @@ struct CodeGenerator {
                 PreIncrement => "++"
                 PreDecrement => "--"
                 Negate => "-"
-                Dereference => "*"
+                Dereference => match .program.get_type(expression_type(expr)) {
+                    RawPtr => "*"
+                    Reference | MutableReference => ""
+                    else => ""
+                }
                 RawAddress => "&"
                 LogicalNot => "!"
                 BitwiseNot => "~"
@@ -2307,7 +2311,7 @@ struct CodeGenerator {
                 let var = .program.get_variable(var_id)
 
                 mut output = ""
-                if not var.is_mutable {
+                if not var.is_mutable and not .program.get_type(var.type_id) is Reference {
                     output += "const "
                 }
                 output += .codegen_type(var.type_id)
@@ -2427,6 +2431,8 @@ struct CodeGenerator {
         CChar => "char"
         CInt => "int"
         RawPtr(type_id) => .codegen_type(type_id) + "*"
+        Reference(type_id) => .codegen_type(type_id) + " const&"
+        MutableReference(type_id) => .codegen_type(type_id) + "&"
         GenericInstance(id, args) => .codegen_generic_type_instance(id, args, as_namespace)
         Struct(id) => .codegen_struct_type(id, as_namespace)
         Enum(id) => .codegen_enum_type(id, as_namespace)
@@ -2817,7 +2823,7 @@ struct CodeGenerator {
             } else {
                 first = false
             }
-            if not variable.is_mutable {
+            if not variable.is_mutable and not .program.get_type(variable.type_id) is Reference {
                 output += "const "
             }
             output += .codegen_type(variable.type_id)

--- a/selfhost/parser.jakt
+++ b/selfhost/parser.jakt
@@ -371,6 +371,8 @@ enum UnaryOperator {
     Negate
     Dereference
     RawAddress
+    Reference
+    MutableReference
     LogicalNot
     BitwiseNot
     TypeCast(TypeCast)
@@ -549,6 +551,8 @@ boxed enum ParsedType {
     JaktTuple(types: [ParsedType], span: Span)
     Set(inner: ParsedType, span: Span)
     Optional(inner: ParsedType, span: Span)
+    Reference(inner: ParsedType, span: Span)
+    MutableReference(inner: ParsedType, span: Span)
     RawPtr(inner: ParsedType, span: Span)
     WeakPtr(inner: ParsedType, span: Span)
     Empty
@@ -562,6 +566,8 @@ boxed enum ParsedType {
         JaktTuple(types, span) => span
         Set(inner, span) => span
         Optional(inner, span) => span
+        Reference(span) => span
+        MutableReference(span) => span
         RawPtr(inner, span) => span
         WeakPtr(inner, span) => span
         Empty => Span(file_id: FileId(id: 0uz), start: 0, end: 0) // FIXME: For some reason we can't see `empty_span()` here.
@@ -1507,12 +1513,19 @@ struct Parser {
                 }
                 Identifier(name, span) => {
                     let var_decl = .parse_variable_declaration(is_mutable: current_param_is_mutable)
+
+                    // FIXME: This is pretty sloppy, but basically allow `foo: &mut T` to make the parameter `mut` as well.
+                    let parameter_is_mutable = match var_decl.parsed_type {
+                        MutableReference => true
+                        else => var_decl.is_mutable
+                    }
+
                     params.push(ParsedParameter(
                         requires_label: current_param_requires_label,
                         variable: ParsedVariable(
                             name: var_decl.name,
                             parsed_type: var_decl.parsed_type,
-                            is_mutable: var_decl.is_mutable,
+                            is_mutable: parameter_is_mutable,
                             span: .previous().span(),
                         ),
                         span: .previous().span(),
@@ -1597,6 +1610,18 @@ struct Parser {
 
     function parse_typename(mut this) throws -> ParsedType {
         let start = .current().span()
+        mut is_reference = false
+        mut is_mutable_reference = false
+
+        if .current() is Ampersand {
+            is_reference = true
+            .index++
+            if .current() is Mut {
+                is_mutable_reference = true
+                .index++
+            }
+        }
+
         mut parsed_type = .parse_type_shorthand()
 
         if parsed_type is Empty {
@@ -1607,6 +1632,15 @@ struct Parser {
             .index++
             let span = merge_spans(start, .current().span())
             parsed_type = ParsedType::Optional(inner: parsed_type, span)
+        }
+
+        if is_reference {
+            let span = merge_spans(start, .current().span())
+            if is_mutable_reference {
+                parsed_type = ParsedType::MutableReference(inner: parsed_type, span)
+            } else {
+                parsed_type = ParsedType::Reference(inner: parsed_type, span)
+            }
         }
 
         return parsed_type
@@ -2358,8 +2392,13 @@ struct Parser {
             let expr = .parse_operand()
             return ParsedExpression::UnaryOp(expr, op: UnaryOperator::RawAddress, span: merge_spans(start, expr.span()))
         }
-        .error("Ampersand not currently supported", start)
-        return ParsedExpression::Garbage(.current().span())
+        if .current() is Mut {
+            .index++
+            let expr = .parse_operand()
+            return ParsedExpression::UnaryOp(expr, op: UnaryOperator::MutableReference, span: merge_spans(start, expr.span()))
+        }
+        let expr = .parse_operand()
+        return ParsedExpression::UnaryOp(expr, op: UnaryOperator::Reference, span: merge_spans(start, expr.span()))
     }
 
     function parse_set_literal(mut this) throws -> ParsedExpression {
@@ -3433,6 +3472,8 @@ function unary_operator_equals(anon lhs_op: UnaryOperator, anon rhs_op: UnaryOpe
     Negate => rhs_op is Negate
     Dereference => rhs_op is Dereference
     RawAddress => rhs_op is RawAddress
+    Reference => rhs_op is Reference
+    MutableReference => rhs_op is MutableReference
     LogicalNot => rhs_op is LogicalNot
     BitwiseNot => rhs_op is BitwiseNot
     // FIXME: Compare Types

--- a/selfhost/typechecker.jakt
+++ b/selfhost/typechecker.jakt
@@ -4491,6 +4491,8 @@ struct Typechecker {
 
         let lhs_type = .get_type(lhs_type_id)
 
+        .check_that_type_doesnt_contain_reference(type_id: lhs_type_id, span)
+
         match lhs_type {
             GenericInstance(id, args) => {
                 if id.equals(weak_ptr_struct_id) {

--- a/selfhost/typechecker.jakt
+++ b/selfhost/typechecker.jakt
@@ -3946,6 +3946,9 @@ struct Typechecker {
                 return CheckedExpression::UnaryOp(expr: checked_expr, op: checked_op, span, type_id: .find_or_add_type_id(Type::Reference(expr_type_id)))
             }
             MutableReference => {
+                if not .expression_is_mutable(checked_expr) {
+                    .error("Cannot make mutable reference to immutable value", span)
+                }
                 return CheckedExpression::UnaryOp(expr: checked_expr, op: checked_op, span, type_id: .find_or_add_type_id(Type::MutableReference(expr_type_id)))
             }
             Dereference => {

--- a/selfhost/typechecker.jakt
+++ b/selfhost/typechecker.jakt
@@ -3034,6 +3034,8 @@ struct Typechecker {
         let function_return_type_id = .typecheck_typename(parsed_type: parsed_function.return_type, scope_id: checked_function_scope_id)
         checked_function.return_type_id = function_return_type_id
 
+        .check_that_type_doesnt_contain_reference(type_id: function_return_type_id, span: parsed_function.return_type_span)
+
         if not parsed_function.generic_parameters.is_empty() {
             let old_ignore_errors = .ignore_errors
             .ignore_errors = true
@@ -3066,6 +3068,26 @@ struct Typechecker {
         }
 
         .add_function_to_scope(parent_scope_id, name: parsed_function.name, function_id, span: parsed_function.name_span)
+    }
+
+    function check_that_type_doesnt_contain_reference(mut this, type_id: TypeId, span: Span) throws {
+        let type = .get_type(type_id)
+
+        // FIXME: Check for any type that contains a reference as a generic parameter, etc.
+        let contains_reference = match type {
+            Reference | MutableReference => true
+            else => false
+        }
+
+        if contains_reference {
+            .error(
+                format(
+                    "Reference type ‘{}’ not usable in this context"
+                    .type_name(type_id)
+                )
+                span
+            )
+        }
     }
 
     function typecheck_and_specialize_generic_function(mut this, function_id: FunctionId, generic_arguments: [TypeId], parent_scope_id: ScopeId, this_type_id: TypeId?, generic_substitutions: [String: String]) throws {

--- a/selfhost/typechecker.jakt
+++ b/selfhost/typechecker.jakt
@@ -150,6 +150,8 @@ boxed enum Type {
     Struct(StructId)
     Enum(EnumId)
     RawPtr(TypeId)
+    Reference(TypeId)
+    MutableReference(TypeId)
 
     function equals(this, anon rhs: Type) -> bool {
         if this is Void and rhs is Void {
@@ -263,6 +265,26 @@ boxed enum Type {
                 RawPtr(lhs_id) => {
                     match rhs {
                         RawPtr(rhs_id) => {
+                            return lhs_id.equals(rhs_id)
+                        }
+                        else => {
+                            return false
+                        }
+                    }
+                }
+                Reference(lhs_id) => {
+                    match rhs {
+                        Reference(rhs_id) => {
+                            return lhs_id.equals(rhs_id)
+                        }
+                        else => {
+                            return false
+                        }
+                    }
+                }
+                MutableReference(lhs_id) => {
+                    match rhs {
+                        MutableReference(rhs_id) => {
                             return lhs_id.equals(rhs_id)
                         }
                         else => {
@@ -752,6 +774,8 @@ enum CheckedUnaryOperator {
     Negate
     Dereference
     RawAddress
+    Reference
+    MutableReference
     LogicalNot
     BitwiseNot
     TypeCast(CheckedTypeCast)
@@ -1487,6 +1511,8 @@ struct Typechecker {
             }
             TypeVariable(name) => name
             RawPtr(type_id) => format("raw {}", .type_name(type_id))
+            Reference(type_id) => format("&{}", .type_name(type_id))
+            MutableReference(type_id) => format("&mut {}", .type_name(type_id))
         }
     }
 
@@ -1527,6 +1553,10 @@ struct Typechecker {
         IndexedTuple(expr) => .expression_is_mutable(expr)
         IndexedDictionary(expr) => .expression_is_mutable(expr)
         ForcedUnwrap(expr) => .expression_is_mutable(expr)
+        UnaryOp(expr, op) => match op {
+            Dereference => .get_type(expression_type(expr)) is MutableReference
+            else => false
+        }
         else => false
     }
 
@@ -3689,6 +3719,16 @@ struct Typechecker {
 
     function typecheck_typename(mut this, parsed_type: ParsedType, scope_id: ScopeId) throws -> TypeId { 
         match parsed_type {
+            Reference(inner) => {
+                let inner_type_id = .typecheck_typename(parsed_type: inner, scope_id)
+                let type_id = .find_or_add_type_id(Type::Reference(id: inner_type_id))
+                return type_id
+            }
+            MutableReference(inner) => {
+                let inner_type_id = .typecheck_typename(parsed_type: inner, scope_id)
+                let type_id = .find_or_add_type_id(Type::MutableReference(id: inner_type_id))
+                return type_id
+            }
             NamespacedName(name, namespaces, params, span) => {
                 mut current_namespace_scope_id = scope_id
 
@@ -3878,12 +3918,21 @@ struct Typechecker {
             RawAddress => {
                 return CheckedExpression::UnaryOp(expr: checked_expr, op: checked_op, span, type_id: .find_or_add_type_id(Type::RawPtr(expr_type_id)))
             }
+            Reference => {
+                return CheckedExpression::UnaryOp(expr: checked_expr, op: checked_op, span, type_id: .find_or_add_type_id(Type::Reference(expr_type_id)))
+            }
+            MutableReference => {
+                return CheckedExpression::UnaryOp(expr: checked_expr, op: checked_op, span, type_id: .find_or_add_type_id(Type::MutableReference(expr_type_id)))
+            }
             Dereference => {
                 match expr_type {
                     RawPtr(type_id) => {
                         if safety_mode is Safe {
                             .error("Dereference of raw pointer outside of unsafe block", span)
                         }
+                        return CheckedExpression::UnaryOp(expr: checked_expr, op: checked_op, span, type_id)
+                    }
+                    Reference(type_id) | MutableReference(type_id) => {
                         return CheckedExpression::UnaryOp(expr: checked_expr, op: checked_op, span, type_id)
                     }
                     else => {
@@ -4817,6 +4866,8 @@ struct Typechecker {
                 Negate => CheckedUnaryOperator::Negate
                 Dereference => CheckedUnaryOperator::Dereference
                 RawAddress => CheckedUnaryOperator::RawAddress
+                Reference => CheckedUnaryOperator::Reference
+                MutableReference => CheckedUnaryOperator::MutableReference
                 LogicalNot => CheckedUnaryOperator::LogicalNot
                 BitwiseNot => CheckedUnaryOperator::BitwiseNot
                 TypeCast(cast) => {

--- a/selfhost/typechecker.jakt
+++ b/selfhost/typechecker.jakt
@@ -1882,6 +1882,8 @@ struct Typechecker {
             let parsed_var_decl = unchecked_member.var_decl
             let checked_member_type = .typecheck_typename(parsed_type: parsed_var_decl.parsed_type, scope_id: checked_struct_scope_id)
 
+            .check_that_type_doesnt_contain_reference(type_id: checked_member_type, span: parsed_var_decl.parsed_type.span())
+
             mut module = .current_module()
             let var_id = module.add_variable(checked_variable: CheckedVariable(
                 name: parsed_var_decl.name


### PR DESCRIPTION
This PR adds the following features:

- Reference types: `&T` and `&mut T` for immutable and mutable references to T.
- Reference expressions: `&foo` and `&mut foo` to create references to the variable `foo`.
- The dereference operator (`*`) now works on references as well.

Limitations:

- No reference locals
- No reference return values
- No reference struct fields

Basically, functions can now take parameters by reference, but we don't allow you to keep references around for long enough that they may become invalid.

This is meant to be a first, small set of reference features that we can make solid and safe before moving on to adding more complex features.