### PR TITLE
selfhost: Don't require argument label for same-name references

### DIFF
--- a/README.md
+++ b/README.md
@@ -537,9 +537,9 @@ function zero_out(foo: &mut Foo) {
 - [x] No references in structs
 - [x] No references in return types
 - [x] No mutable references to immutable values
+- [x] Allow `&foo` and `&mut foo` without argument label for parameters named `foo`
 
 ### References TODO:
 
-- [ ] Allow `&foo` and `&mut foo` without argument label for parameters named `foo`
 - [ ] (`unsafe`) references and raw pointers bidirectionally convertible
 - [ ] No capture-by-reference in persistent closures

--- a/samples/references/implied_argument_label.jakt
+++ b/samples/references/implied_argument_label.jakt
@@ -1,0 +1,18 @@
+/// Expect:
+/// - output: "PASS\n"
+
+function foo(a: &i64) {
+}
+
+function bar(b: &mut i64) {
+}
+
+function main() {
+    let a = 0
+    foo(&a)
+
+    mut b = 0
+    bar(&mut b)
+
+    println("PASS")
+}

--- a/selfhost/typechecker.jakt
+++ b/selfhost/typechecker.jakt
@@ -6172,6 +6172,21 @@ struct Typechecker {
                     return true
                 }
                 .error(format("Wrong parameter name in argument label (got '{}', expected '{}')", name, param.variable.name), span)
+                return false
+            }
+            UnaryOp(expr, op) => {
+                if op is Reference or op is MutableReference {
+                    match expr {
+                        Var(name, span) => {
+                            if name == param.variable.name {
+                                return true
+                            }
+                            .error(format("Wrong parameter name in argument label (got ‘{}’, expected ‘{}’)", name, param.variable.name), span)
+                            return false
+                        }
+                        else => {}
+                    }
+                }
             }
             else => {}
         }


### PR DESCRIPTION
Just how we allow you to omit the argument label when passing a variable
with the same name as the parameter, we now also allow it when passing
a reference to such a variable.