### PR TITLE
selfhost/codegen: Remove unnecessary MatchArm

### DIFF
--- a/selfhost/codegen.jakt
+++ b/selfhost/codegen.jakt
@@ -1306,7 +1306,6 @@ struct CodeGenerator {
                 Negate => "-"
                 Dereference => match .program.get_type(expression_type(expr)) {
                     RawPtr => "*"
-                    Reference | MutableReference => ""
                     else => ""
                 }
                 RawAddress => "&"


### PR DESCRIPTION
`else => ""` already covers everything.
There is no need to have another arm returning `""`