### PR TITLE
selfhost+rbc+editors: Add LSP inlay hints for implicit `try`

### DIFF
--- a/editors/vscode/server/src/server.ts
+++ b/editors/vscode/server/src/server.ts
@@ -418,7 +418,7 @@ async function validateTextDocument(textDocument: JaktTextDocument): Promise<voi
 
 	textDocument.jaktInlayHints = [];
 
-	const stdout = await runCompiler(text, "-c -H -j" + includeFlagForPath(textDocument.uri), settings);
+	const stdout = await runCompiler(text, "-c --type-hints --try-hints -j" + includeFlagForPath(textDocument.uri), settings);
 
 	const diagnostics: Diagnostic[] = [];
 
@@ -467,6 +467,15 @@ async function validateTextDocument(textDocument: JaktTextDocument): Promise<voi
 					seenTypeHintPositions.add(obj.position);
 					const position = convertSpan(obj.position, lineBreaks);
 					const hint_string = ": " + obj.typename;
+					const hint = InlayHint.create(position, [InlayHintLabelPart.create(hint_string)], InlayHintKind.Type);
+
+					textDocument.jaktInlayHints.push(hint);
+				}
+			} else if (obj.type == "try") {
+				if (!seenTypeHintPositions.has(obj.position)) {
+					seenTypeHintPositions.add(obj.position);
+					const position = convertSpan(obj.position, lineBreaks);
+					const hint_string = "try ";
 					const hint = InlayHint.create(position, [InlayHintLabelPart.create(hint_string)], InlayHintKind.Type);
 
 					textDocument.jaktInlayHints.push(hint);

--- a/selfhost/compiler.jakt
+++ b/selfhost/compiler.jakt
@@ -14,6 +14,7 @@ class Compiler {
     public debug_print: bool
     public json_errors: bool
     public dump_type_hints: bool
+    public dump_try_hints: bool
 
     public function panic(this, anon message: String) throws {
         .print_errors()

--- a/selfhost/main.jakt
+++ b/selfhost/main.jakt
@@ -30,6 +30,7 @@ function help() -> String{
     output += "  -c,--check-only\t\tOnly check the code for errors.\n"
     output += "  -j,--json-errors\t\tEmit machine-readable (JSON) errors.\n"
     output += "  -H,--type-hints\t\tEmit machine-readable type hints (for IDE integration).\n"
+    output += "  --try-hints\t\tEmit machine-readable try hints (for IDE integration).\n"
 
     output += "\nOptions:\n"
     output += "  -F,--clang-format-path PATH\t\tPath to clang-format executable.\n\t\tDefaults to clang-format\n"
@@ -77,6 +78,7 @@ function main(args: [String]) {
     let prettify_cpp_source = args_parser.flag(["--prettify-cpp-source"])
     let json_errors = args_parser.flag(["-j","--json-errors"])
     let dump_type_hints = args_parser.flag(["-H", "--type-hints"])
+    let dump_try_hints = args_parser.flag(["--try-hints"])
     let check_only = args_parser.flag(["-c", "--check-only"])
 
     let clang_format_path = args_parser.option(["-F", "--clang-format-path"]) ?? "clang-format"
@@ -138,6 +140,7 @@ function main(args: [String]) {
         debug_print: debug_print
         json_errors
         dump_type_hints
+        dump_try_hints
     )
 
     let main_file_id = compiler.get_file_id_or_register(file_path)

--- a/selfhost/typechecker.jakt
+++ b/selfhost/typechecker.jakt
@@ -1262,12 +1262,18 @@ struct Typechecker {
     checkidx: usize
     ignore_errors: bool
     dump_type_hints: bool
+    dump_try_hints: bool
 
     function type_name(this, anon type_id: TypeId) throws => .program.type_name(type_id)
 
     function dump_type_hint(this, type_id: TypeId, span: Span) throws {
         println("{{\"type\":\"hint\",\"file_id\":{},\"position\":{},\"typename\":\"{}\"}}"
                 span.file_id, span.end, .type_name(type_id))
+    }
+
+    function dump_try_hint(this, span: Span) throws {
+        println("{{\"type\":\"try\",\"file_id\":{},\"position\":{}}}"
+                span.file_id, span.start)
     }
 
     function typecheck(mut compiler: Compiler, parsed_namespace: ParsedNamespace) throws -> CheckedProgram {
@@ -1290,6 +1296,7 @@ struct Typechecker {
             checkidx: 0uz
             ignore_errors: false
             dump_type_hints: compiler.dump_type_hints
+            dump_try_hints: compiler.dump_try_hints
         )
 
         typechecker.include_prelude()
@@ -4827,6 +4834,10 @@ struct Typechecker {
         SingleQuotedString(val, span) => CheckedExpression::CharacterConstant(val, span)
         SingleQuotedByteString(val, span) => CheckedExpression::ByteConstant(val, span)
         QuotedString(val, span) => {
+            if .dump_try_hints {
+                .dump_try_hint(span)
+            }
+        
             .unify_with_type(found_type: builtin(BuiltinType::String), expected_type: type_hint, rhs_span: span)
             yield CheckedExpression::QuotedString(val, span)
         }
@@ -5212,6 +5223,9 @@ struct Typechecker {
     }
 
     function typecheck_array(mut this, scope_id: ScopeId, values: [ParsedExpression], fill_size: ParsedExpression?, span: Span, safety_mode: SafetyMode, type_hint: TypeId?) throws -> CheckedExpression {
+        if .dump_try_hints {
+            .dump_try_hint(span)
+        }
         mut repeat: CheckedExpression? = None
         if fill_size.has_value() {
             // Check fill size is an integer.
@@ -5279,6 +5293,9 @@ struct Typechecker {
     }
 
     function typecheck_set(mut this, values: [ParsedExpression], span: Span, scope_id: ScopeId, safety_mode: SafetyMode, type_hint: TypeId?) throws -> CheckedExpression {
+        if .dump_try_hints {
+            .dump_try_hint(span)
+        }
         mut inner_type_id = unknown_type_id()
         mut inner_type_span: Span? = None
         mut output: [CheckedExpression] = []
@@ -5800,6 +5817,9 @@ struct Typechecker {
     }
 
     function typecheck_dictionary(mut this, values: [(ParsedExpression, ParsedExpression)], span: Span, scope_id: ScopeId, safety_mode: SafetyMode, type_hint: TypeId?) throws -> CheckedExpression {
+        if .dump_try_hints {
+            .dump_try_hint(span)
+        }
         let dictionary_struct_id = .find_struct_in_prelude("Dictionary")
         mut checked_kv_pairs: [(CheckedExpression, CheckedExpression)] = []
         mut key_type_id = unknown_type_id()
@@ -6168,6 +6188,10 @@ struct Typechecker {
                 this_type_id: maybe_this_type_id,
                 generic_substitutions: generic_inferences
             )
+        }
+
+        if .dump_try_hints and callee_throws {
+            .dump_try_hint(span)
         }
 
         return CheckedExpression::Call(

--- a/src/main.rs
+++ b/src/main.rs
@@ -120,6 +120,7 @@ fn main() -> Result<(), JaktError> {
     } else if arguments.check_only {
         let mut project = Project::new();
         project.dump_type_hints = arguments.type_hints;
+        project.dump_try_hints = arguments.try_hints;
         for file in &arguments.input_files {
             match compiler.check_project(file, &mut project) {
                 (_, Some(err)) => {
@@ -308,6 +309,7 @@ Flags:
   -c,--check-only                   Only check the code for errors
   -j,--json-errors                  Emit machine-readable (JSON) errors
   -H,--type-hints                   Emit machine-readable type hints (for IDE integration)
+     --try-hints                    Emit machine-readable try hints (for IDE integration)
 
 Options:
   -o,--binary-dir PATH              Output directory for compiled files.
@@ -341,6 +343,7 @@ struct JaktArguments {
     emit_source_only: bool,
     check_only: bool,
     type_hints: bool,
+    try_hints: bool,
     json_errors: bool,
     goto_def_index: Option<usize>,
     goto_type_def_index: Option<usize>,
@@ -369,6 +372,7 @@ fn parse_arguments() -> JaktArguments {
 
     let check_only = pico_arguments.contains(["-c", "--check-only"]);
     let type_hints = pico_arguments.contains(["-H", "--type-hints"]);
+    let try_hints = pico_arguments.contains(["-T", "--try-hints"]);
     let json_errors = pico_arguments.contains(["-j", "--json-errors"]);
 
     let convert_to_pathbuf = |s: &str| -> Result<PathBuf, &'static str> { Ok(s.into()) };
@@ -383,6 +387,7 @@ fn parse_arguments() -> JaktArguments {
         emit_source_only,
         check_only,
         type_hints,
+        try_hints,
         json_errors,
         goto_def_index: None,
         goto_type_def_index: None,


### PR DESCRIPTION
The compiler now emits information about implicit `try` in the code
which then become inlay hints in the IDE.

This is default-on for now, so we can figure out what we think about it.