### PR TITLE
selfhost/typechecker: Implicitly cast mutable references in calls

### DIFF
--- a/samples/references/mutable_to_immutable_reference.jakt
+++ b/samples/references/mutable_to_immutable_reference.jakt
@@ -1,0 +1,16 @@
+/// Expect:
+/// - output: "8\n"
+
+function add_number(anon a: &i64, anon b: &i64, anon result: &mut i64) {
+    result = a + b
+}
+
+function double_number(anon n: &mut i64) {
+    add_number(n, n, n)
+}
+
+function main() {
+    mut result = 4
+    double_number(&mut result)
+    println("{}", result)
+}

--- a/selfhost/typechecker.jakt
+++ b/selfhost/typechecker.jakt
@@ -2422,6 +2422,35 @@ struct Typechecker {
                     }
                 }
             }
+            Reference(lhs_reference_type_id) => {
+                if lhs_reference_type_id.equals(rhs_type_id) {
+                    return true
+                }
+
+                let rhs_type = .get_type(rhs_type_id)
+                match rhs_type {
+                    MutableReference(rhs_reference_type_id) => {
+                        if not .check_types_for_compat(
+                            lhs_type_id: lhs_reference_type_id
+                            rhs_type_id: rhs_reference_type_id
+                            generic_inferences
+                            span
+                        ) {
+                            // FIXME: maybe emit secondary error?
+                            return false
+                        }
+                    }
+                    else => {
+                        if not rhs_type_id.equals(lhs_type_id) {
+                            .error(
+                                format("Type mismatch: expected ‘{}’, but got ‘{}’", .type_name(lhs_type_id), .type_name(rhs_type_id))
+                                span
+                            )
+                            return false
+                        }
+                    }
+                }
+            }
             else => {
                 if not rhs_type_id.equals(lhs_type_id) {
                     .error(


### PR DESCRIPTION
This is a quality-of-life feature that allows mutable reference
parameters to be silently casted into immutable references when calling
another function. The feature is implemented using the same code used
with RawPtr.