### PR TITLE
runtime: Avoid some gcc specific errors

### DIFF
--- a/runtime/Jakt/Platform.h
+++ b/runtime/Jakt/Platform.h
@@ -42,7 +42,7 @@
 #ifdef ALWAYS_INLINE
 #    undef ALWAYS_INLINE
 #endif
-#define ALWAYS_INLINE
+#define ALWAYS_INLINE __attribute__((always_inline)) inline
 
 #ifdef NEVER_INLINE
 #    undef NEVER_INLINE

--- a/runtime/Jakt/String.h
+++ b/runtime/Jakt/String.h
@@ -19,6 +19,11 @@
 
 namespace Jakt {
 
+bool operator<(char const* characters, String const& string);
+bool operator>=(char const* characters, String const& string);
+bool operator>(char const* characters, String const& string);
+bool operator<=(char const* characters, String const& string);
+
 class StringStorage : public RefCounted<StringStorage> {
 public:
     static ErrorOr<NonnullRefPtr<StringStorage>> create_uninitialized(size_t length, char*& buffer);

--- a/runtime/Jakt/StringBuilder.h
+++ b/runtime/Jakt/StringBuilder.h
@@ -59,6 +59,8 @@ public:
                 append(separator);
             appendff(fmtstr, item);
         }
+
+        return {};
     }
 
     // FIXME: These only exist because we don't support function overloading in Jakt yet.


### PR DESCRIPTION
For better support with building with gcc as part of a serenity build