### PR TITLE
DRAFT: Traits MVP

### DIFF
--- a/samples/traits/basic.jakt
+++ b/samples/traits/basic.jakt
@@ -1,5 +1,5 @@
 /// Expect:
-/// - output: "100\n42\n69\n144\n"
+/// - output: "100\n69\n"
 
 // trait definition
 trait Hashable {
@@ -10,11 +10,6 @@ trait Bar {
     function bar(mut this)
 }
 
-
-// implementation on a class
-class Foo implements(Hashable) {
-    public function hash(this) => 42u64
-}
 
 // implementation on a struct
 struct S implements(Hashable, Bar) {
@@ -49,6 +44,5 @@ function print_hash<T requires(Hashable)>(anon value: T) {
 
 function main() {
     print_hash(S())
-    print_hash(Foo())
     print_hash(U64Hash(value: 69u64))
 }

--- a/samples/traits/basic.jakt
+++ b/samples/traits/basic.jakt
@@ -35,20 +35,7 @@ enum Baz implements(Hashable) {
 }
 
 // implementing traits for builtin types can be done
-// through a newtype pattern. Also, requirements also apply for
-// generic classes, structs and enums!
-struct SumHash<T requires(Hashable)> implements(Hashable) {
-    values: [T]
-
-    function hash(this) -> u64 {
-        mut value: u64 = 0
-        for item in .values.iterator() {
-            value += item.hash()
-        }
-        return value
-    }
-}
-
+// through a newtype pattern.
 struct U64Hash implements(Hashable) {
     value: u64
 
@@ -64,5 +51,4 @@ function main() {
     print_hash(S())
     print_hash(Foo())
     print_hash(U64Hash(value: 69u64))
-    print_hash(SumHash(values: [Baz::Foo, Baz::Bar]))
 }

--- a/samples/traits/basic.jakt
+++ b/samples/traits/basic.jakt
@@ -1,0 +1,68 @@
+/// Expect:
+/// - output: "100\n42\n69\n144\n"
+
+// trait definition
+trait Hashable {
+    function hash(this) -> u64
+}
+
+trait Bar {
+    function bar(mut this)
+}
+
+
+// implementation on a class
+class Foo implements(Hashable) {
+    public function hash(this) => 42u64
+}
+
+// implementation on a struct
+struct S implements(Hashable, Bar) {
+    function hash(this) => 100u64
+    function bar(mut this) {
+        println("S::bar")
+    }
+}
+
+enum Baz implements(Hashable) {
+    Foo
+    Bar
+
+    function hash(this) => match this {
+        Foo => 44u64
+        Bar => 100u64
+    }
+}
+
+// implementing traits for builtin types can be done
+// through a newtype pattern. Also, requirements also apply for
+// generic classes, structs and enums!
+struct SumHash<T requires(Hashable)> implements(Hashable) {
+    values: [T]
+
+    function hash(this) -> u64 {
+        mut value: u64 = 0
+        for item in .values.iterator() {
+            value += item.hash()
+        }
+        return value
+    }
+}
+
+struct U64Hash implements(Hashable) {
+    value: u64
+
+    function hash(this) => .value
+}
+
+// trait requiremennt on function
+function print_hash<T requires(Hashable)>(anon value: T) {
+    println("{}", value.hash())
+}
+
+function main() {
+    print_hash(S())
+    print_hash(Foo())
+    print_hash(U64Hash(value: 69u64))
+    print_hash(SumHash(values: [Baz::Foo, Baz::Bar]))
+}

--- a/selfhost/codegen.jakt
+++ b/selfhost/codegen.jakt
@@ -826,11 +826,7 @@ struct CodeGenerator {
                     output += ","
                 }
                 output += "typename "
-                let type_id = match generic_parameter {
-                    InferenceGuide(type_id) => type_id
-                    Parameter(type_id) => type_id
-                }
-                output += .codegen_type(type_id)
+                output += .codegen_type(generic_parameter.type_id())
             }
             output += ">\n"
         }
@@ -940,7 +936,7 @@ struct CodeGenerator {
                     output += ","
                 }
                 output += "typename "
-                output += .codegen_type(generic_parameter)
+                output += .codegen_type(generic_parameter.type_id)
             }
             output += ">"
         }
@@ -967,7 +963,7 @@ struct CodeGenerator {
         mut generic_parameter_names: [String] = []
         if not struct_.generic_parameters.is_empty() {
             for generic_parameter in struct_.generic_parameters.iterator() {
-                generic_parameter_names.push(.codegen_type(generic_parameter))
+                generic_parameter_names.push(.codegen_type(generic_parameter.type_id))
             }
 
             output += format("template <{}>", join(prepend_to_each(generic_parameter_names, prefix: "typename "), separator: ", "))
@@ -985,7 +981,7 @@ struct CodeGenerator {
                         class_name_with_generics += "<"
                         first = false
                     }
-                    class_name_with_generics += .codegen_type(generic_parameter)
+                    class_name_with_generics += .codegen_type(generic_parameter.type_id)
                 }
                 if not struct_.generic_parameters.is_empty() {
                     class_name_with_generics += ">"
@@ -1074,7 +1070,7 @@ struct CodeGenerator {
         let is_generic = not enum_.generic_parameters.is_empty()
         mut template_args_array: [String] = []
         for generic_parameter in enum_.generic_parameters.iterator() {
-            if .program.get_type(generic_parameter) is TypeVariable(name) {
+            if .program.get_type(generic_parameter.type_id) is TypeVariable(name) {
                 template_args_array.push("typename " + name)
             }
         }
@@ -1125,7 +1121,7 @@ struct CodeGenerator {
         let is_generic = not enum_.generic_parameters.is_empty()
         mut generic_parameter_names: [String] = []
         for generic_parameter in enum_.generic_parameters.iterator() {
-            if .program.get_type(generic_parameter) is TypeVariable(name) {
+            if .program.get_type(generic_parameter.type_id) is TypeVariable(name) {
                 generic_parameter_names.push(name)
             }
         }
@@ -1265,14 +1261,14 @@ struct CodeGenerator {
         if not is_inline and not struct_.generic_parameters.is_empty() {
             output += "template <"
             mut first = true
-            for type_id in struct_.generic_parameters.iterator() {
+            for param in struct_.generic_parameters.iterator() {
                 if first {
                     first = false
                 } else {
                     output += ","
                 }
                 output += "typename "
-                output += .codegen_type(type_id)
+                output += .codegen_type(param.type_id)
             }
             output += ">\n"
         }
@@ -1328,14 +1324,14 @@ struct CodeGenerator {
         if not is_inline and not enum_.generic_parameters.is_empty() {
             output += "template <"
             mut first = true
-            for type_id in enum_.generic_parameters.iterator() {
+            for param in enum_.generic_parameters.iterator() {
                 if first {
                     first = false
                 } else {
                     output += ","
                 }
                 output += "typename "
-                output += .codegen_type(type_id)
+                output += .codegen_type(param.type_id)
             }
             output += ">\n"
         }
@@ -3215,7 +3211,7 @@ struct CodeGenerator {
                     first = false
                 }
 
-                class_name_with_generics += .codegen_type(generic_parameter)
+                class_name_with_generics += .codegen_type(generic_parameter.type_id)
             }
             if not structure.generic_parameters.is_empty() {
                 class_name_with_generics += ">"
@@ -3278,14 +3274,14 @@ struct CodeGenerator {
         if not is_inline and not structure.generic_parameters.is_empty() {
             output += "template <"
             mut first = true
-            for type_id in structure.generic_parameters.iterator() {
+            for param in structure.generic_parameters.iterator() {
                 if first {
                     first = false
                 } else {
                     output += ","
                 }
                 output += "typename "
-                output += .codegen_type(type_id)
+                output += .codegen_type(param.type_id)
             }
             output += ">\n"
         }
@@ -3355,7 +3351,7 @@ struct CodeGenerator {
                     first = false
                 }
 
-                class_name_with_generics += .codegen_type(generic_parameter)
+                class_name_with_generics += .codegen_type(generic_parameter.type_id)
             }
             if not structure.generic_parameters.is_empty() {
                 class_name_with_generics += ">"

--- a/selfhost/codegen.jakt
+++ b/selfhost/codegen.jakt
@@ -581,6 +581,7 @@ struct CodeGenerator {
                                 output += struct_output
                             }
                         }
+                        Trait => { }
                         else => {
                             panic(format("Unexpected type in dependency graph: {}", type_))
                         }

--- a/selfhost/formatter.jakt
+++ b/selfhost/formatter.jakt
@@ -220,6 +220,9 @@ struct FormattedToken {
         Guard => "guard"
         Override => "override"
         Virtual => "virtual"
+        Implements => "implements"
+        Requires => "requires"
+        Trait => "trait"
         Garbage => ""
     }
 }

--- a/selfhost/ide.jakt
+++ b/selfhost/ide.jakt
@@ -227,6 +227,7 @@ function find_type_definition_for_type_id(program: CheckedProgram, type_id: Type
         Unknown => span
         JaktString => span
         Function => span
+        Trait(id) => program.get_trait(id).name_span
         GenericInstance(id: struct_id, args) => {
             mut output = span
             if struct_id.equals(array_struct_id) or struct_id.equals(optional_struct_id) or struct_id.equals(range_struct_id) or struct_id.equals(set_struct_id) or struct_id.equals(tuple_struct_id) or struct_id.equals(weak_ptr_struct_id) {
@@ -1090,6 +1091,7 @@ function get_type_signature(program: CheckedProgram, type_id: TypeId) throws -> 
         CChar => "c_char"
         TypeVariable(name) => name
         Unknown => ""
+        Trait(trait_id) => program.get_trait(trait_id).name
         Function(params, return_type_id) => {
             mut param_names: [String] = []
             for x in params.iterator() {

--- a/selfhost/ide.jakt
+++ b/selfhost/ide.jakt
@@ -961,14 +961,8 @@ function get_function_signature(program: CheckedProgram, function_id: FunctionId
         generic_parameters += "<"
 
         for parameter in checked_function.generics.params.iterator() {
-            let generic_type = match parameter {
-                InferenceGuide(type_id) => {
-                    yield program.type_name(type_id)
-                }
-                Parameter(type_id) => {
-                    yield program.type_name(type_id)
-                }
-            }
+
+            let generic_type = program.type_name(parameter.type_id())
 
             let separator = match is_first_param {
                 true => ""

--- a/selfhost/lexer.jakt
+++ b/selfhost/lexer.jakt
@@ -117,6 +117,9 @@ enum Token {
     While(Span)
     Yield(Span)
     Guard(Span)
+    Implements(Span)
+    Requires(Span)
+    Trait(Span)
 
     // Catch-all for failed parses
     Garbage(consumed: String?, span: Span)
@@ -172,6 +175,9 @@ enum Token {
         "while" => Token::While(span)
         "yield" => Token::Yield(span)
         "guard" => Token::Guard(span)
+        "requires" => Token::Requires(span)
+        "implements" => Token::Implements(span)
+        "trait" => Token::Trait(span)
         else => Token::Identifier(name: string, span)
     }
 }

--- a/selfhost/parser.jakt
+++ b/selfhost/parser.jakt
@@ -197,6 +197,7 @@ struct ParsedNamespace {
     name_span: Span?
     functions: [ParsedFunction]
     records: [ParsedRecord]
+    traits: [ParsedTrait]
     namespaces: [ParsedNamespace]
     module_imports: [ParsedModuleImport]
     extern_imports: [ParsedExternImport]
@@ -294,6 +295,8 @@ struct ParsedRecord {
     name_span: Span
     generic_parameters: [ParsedGenericParameter]
     definition_linkage: DefinitionLinkage
+    // if not empty, must have at least one value.
+    implements_list: [ParsedName]?
     methods: [ParsedMethod]
     record_type: RecordType
 }
@@ -306,6 +309,8 @@ enum FunctionType {
     Expression
     Closure
 }
+
+
 
 struct ParsedFunction {
     name: String
@@ -343,9 +348,23 @@ struct ParsedParameter {
     }
 }
 
+struct ParsedName {
+    name: String
+    span: Span
+}
+
 struct ParsedGenericParameter {
     name: String
     span: Span
+    // the list, if it exists, must have at least one element.
+    requires_list: [ParsedName]?
+}
+
+struct ParsedTrait {
+    name: String
+    name_span: Span
+
+    methods: [ParsedFunction]
 }
 
 struct ParsedBlock {
@@ -1302,6 +1321,7 @@ struct Parser {
             name_span: None
             functions: []
             records: []
+            traits: []
             namespaces: []
             module_imports: []
             extern_imports: []
@@ -1312,6 +1332,10 @@ struct Parser {
 
         while not .eof() {
             match .current() {
+                Trait => {
+                    .index++
+                    parsed_namespace.traits.push(.parse_trait())
+                }
                 Import => {
                     .index++
                     .parse_import(parent: &mut parsed_namespace)
@@ -1387,6 +1411,60 @@ struct Parser {
         return parsed_namespace
     }
 
+    function parse_trait(mut this) throws -> ParsedTrait {
+
+        mut parsed_trait = ParsedTrait(
+            name: ""
+            name_span: .empty_span()
+            methods: [])
+
+        guard .current() is Identifier(name, span: name_span) else {
+            .error("Expected trait name", .current().span())
+            return parsed_trait
+        }
+        parsed_trait.name = name
+        parsed_trait.name_span = name_span
+
+        .index++
+        guard .current() is LCurly else {
+            .error("Expected '{' to enter the body of the trait",
+                .current().span())
+            return parsed_trait
+        }
+
+
+        .index++
+
+        loop {
+            match .current() {
+                RCurly => { 
+                    .index++
+                    break
+                }
+                Eof(span) => {
+                    .error("Expected '}' to close the trait body", span)
+                }
+
+                Eol => {
+                    .index++
+                    continue
+                }
+                Function => {
+                    // pretend it's external so that we only parse the signature
+                    mut method = .parse_function(FunctionLinkage::External, Visibility::Public, is_comptime: false)
+                    parsed_trait.methods.push(method)
+                }
+                else(span) => {
+                    .error_with_hint("Expected 'function' keyword inside trait definition", span,
+                                     format("Inside '{}' trait's definition only function declarations can appear", parsed_trait.name), parsed_trait.name_span)
+                    return parsed_trait
+                }
+            }
+        }
+
+        return parsed_trait
+    }
+
     function parse_record(mut this, anon definition_linkage: DefinitionLinkage) throws -> ParsedRecord => match .current() {
         Struct => .parse_struct(definition_linkage)
         Class => .parse_class(definition_linkage)
@@ -1402,6 +1480,7 @@ struct Parser {
                 name_span: .empty_span(),
                 generic_parameters: [],
                 definition_linkage,
+                implements_list: None,
                 methods: [],
                 record_type: RecordType::Garbage
             )
@@ -1427,6 +1506,7 @@ struct Parser {
                 name_span: None
                 functions: []
                 records: []
+                traits: []
                 namespaces: []
                 module_imports: []
                 extern_imports: []
@@ -1939,6 +2019,7 @@ struct Parser {
             name_span: .empty_span(),
             generic_parameters: [],
             definition_linkage,
+            implements_list: None,
             methods: [],
             record_type: RecordType::Garbage
         )
@@ -1970,6 +2051,11 @@ struct Parser {
 
         if .current() is LessThan {
             parsed_enum.generic_parameters = .parse_generic_parameters()
+        }
+
+        if .current() is Implements {
+            .index++
+            parsed_enum.implements_list = .parse_trait_list()
         }
 
         if .eof() {
@@ -2142,6 +2228,7 @@ struct Parser {
             name_span: .empty_span(),
             generic_parameters: [],
             definition_linkage,
+            implements_list: None,
             methods: [],
             record_type: RecordType::Garbage
         )
@@ -2173,6 +2260,11 @@ struct Parser {
         // Generic parameters
         parsed_struct.generic_parameters = .parse_generic_parameters()
 
+        if .current() is Implements {
+            .index++
+            parsed_struct.implements_list = .parse_trait_list()
+        }
+
         .skip_newlines()
 
         if .eof() {
@@ -2195,6 +2287,7 @@ struct Parser {
             name_span: .empty_span(),
             generic_parameters: [],
             definition_linkage,
+            implements_list: None,
             methods: [],
             record_type: RecordType::Garbage
         )
@@ -2226,6 +2319,11 @@ struct Parser {
 
         // Generic parameters
         parsed_class.generic_parameters = .parse_generic_parameters()
+
+        if .current() is Implements {
+            .index++
+            parsed_class.implements_list = .parse_trait_list()
+        }
 
 
         if .eof() {
@@ -4320,6 +4418,48 @@ struct Parser {
         }
     }
 
+    function parse_trait_list(mut this) throws -> [ParsedName]? {
+        guard .current() is LParen else {
+            .error("Expected '(' to start the trait list", .current().span())
+            return None
+        }
+        .index++
+
+        mut result: [ParsedName] = []
+
+        while not .eof() {
+            match .current() {
+                Eol | Comma => {
+                    .index++
+                    continue
+                }
+                Eof(span) => {
+                    .error("Expected ')' to close the trait list", span)
+                    break
+                }
+                RParen => { 
+                    .index++
+                    break
+                }
+                Identifier(name, span) => {
+                    result.push(ParsedName(name, span))
+                    .index++
+                }
+                else(span) => {
+                    .error("Expected trait name", span)
+                    break
+                }
+            }
+        }
+        if result.is_empty() {
+            .error("Expected trait list to have at least one trait inside it",
+                .previous().span())
+            return None
+        } else {
+            return Some(result)
+        }
+    }
+
     function parse_generic_parameters(mut this) throws -> [ParsedGenericParameter] {
         if not .current() is LessThan {
             return []
@@ -4329,8 +4469,16 @@ struct Parser {
         .skip_newlines()
         while not .current() is GreaterThan and not .current() is Garbage {
             if .current() is Identifier(name, span) {
-                generic_parameters.push(ParsedGenericParameter(name, span))
+
+                mut requires_list: [ParsedName]? = None
+
                 .index++
+                if .current() is Requires {
+                    .index++
+                    requires_list = .parse_trait_list()
+                }
+
+                generic_parameters.push(ParsedGenericParameter(name, span, requires_list))
                 if .current() is Comma or .current() is Eol {
                     .index++
                 }

--- a/selfhost/typechecker.jakt
+++ b/selfhost/typechecker.jakt
@@ -14,14 +14,14 @@ import parser { Parser, BinaryOperator, DefinitionLinkage, UnaryOperator,
                 ParsedExternImport, ParsedType, ParsedStatement, ParsedVarDecl, RecordType,
                 ParsedRecord, ParsedField, TypeCast, EnumVariantPatternArgument,
                 ParsedMatchBody, ParsedMatchCase, Visibility, ParsedParameter, ParsedCapture,
-                ParsedMethod }
+                ParsedMethod, ParsedTrait }
 import types {
     BlockControlFlow, BuiltinType, CheckedBlock, CheckedCall, CheckedCapture, CheckedEnum, CheckedEnumVariant,
     CheckedEnumVariantBinding, CheckedExpression, CheckedFunction, CheckedField, FunctionGenerics, CheckedMatchBody, CheckedMatchCase,
     CheckedNamespace, CheckedNumericConstant, CheckedParameter, CheckedProgram, CheckedStatement, CheckedStruct,
-    CheckedTypeCast, CheckedUnaryOperator, CheckedVariable, CheckedVisibility, EnumId, FieldRecord, FunctionGenericParameter,
+    CheckedTypeCast, CheckedUnaryOperator, CheckedVariable, CheckedVisibility, EnumId, FieldRecord, FunctionGenericParameter, CheckedTrait,
     FunctionId, LoadedModule, Module, ModuleId, NumberConstant, ResolvedNamespace, SafetyMode, Scope, ScopeId, StructId,
-    GenericInferences, StructOrEnumId, Type, TypeId, VarId, Value, MaybeResolvedScope,
+    GenericInferences, StructOrEnumId, Type, TypeId, TraitId, VarId, Value, MaybeResolvedScope,
     builtin, never_type_id, unknown_type_id, void_type_id,
 }
 import types
@@ -211,6 +211,7 @@ struct Typechecker {
                 Type::Unknown,
                 Type::Never
             ],
+            traits: [],
             variables: [],
             imports: [],
             resolved_import_path: path ?? .compiler.current_file_path()!.to_string(),
@@ -982,7 +983,12 @@ struct Typechecker {
             .typecheck_namespace_predecl(parsed_namespace: namespace_, scope_id: namespace_scope_id)
         }
 
-        // 3. Typecheck struct predeclaration
+        // 3. Register traits
+        for parsed_trait in parsed_namespace.traits.iterator() {
+            .typecheck_trait_predecl(parsed_trait, scope_id)
+        }
+
+        // 4. Typecheck struct predeclaration
         struct_index = 0
         enum_index = 0
         for parsed_record in parsed_namespace.records.iterator() {
@@ -1002,6 +1008,44 @@ struct Typechecker {
                 }
             }
         }
+    }
+
+    function typecheck_trait_predecl(mut this, parsed_trait: ParsedTrait, scope_id: ScopeId) throws {
+        mut checked_trait = CheckedTrait(
+            name: parsed_trait.name,
+            name_span: parsed_trait.name_span,
+            methods: [:])
+
+        let trait_scope_id = .create_scope(parent_scope_id: scope_id, can_throw: false, debug_name: format("trait({})", parsed_trait.name))
+
+        // even though traits aren't types per-se, they represent the type that would implement the trait. So they have a type ID.
+        let trait_id = TraitId(
+            module: .current_module_id
+            id: .program.modules[.current_module_id.id].traits.size())
+
+
+
+        let trait_type_id = .find_or_add_type_id(Type::Trait(trait_id))
+
+        // register the trait
+        mut scope = .get_scope(scope_id)
+        scope.types.set(parsed_trait.name, trait_type_id)
+
+        for parsed_function in parsed_trait.methods.iterator() {
+            let method_scope_id = .create_scope(parent_scope_id: trait_scope_id, can_throw: parsed_function.can_throw, debug_name: format("trait-method({}::{})", parsed_trait.name, parsed_function.name))
+
+            let function_id = .program.get_module(.current_module_id).next_function_id()
+
+            // even though traits aren't types per-se, they act like a generic variable, since
+            // they represent the type that implements said trait
+            .typecheck_function_predecl(parsed_function, parent_scope_id: trait_scope_id, this_arg_type_id: None)
+
+            checked_trait.methods.set(parsed_function.name, function_id)
+
+        }
+
+        .program.modules[.current_module_id.id].traits.push(checked_trait)
+
     }
 
     function typecheck_enum_predecl_initial(mut this, parsed_record: ParsedRecord, enum_index: usize, module_enum_len: usize, scope_id: ScopeId) throws {

--- a/selfhost/typechecker.jakt
+++ b/selfhost/typechecker.jakt
@@ -14,7 +14,7 @@ import parser { Parser, BinaryOperator, DefinitionLinkage, UnaryOperator,
                 ParsedExternImport, ParsedType, ParsedStatement, ParsedVarDecl, RecordType,
                 ParsedRecord, ParsedField, TypeCast, EnumVariantPatternArgument,
                 ParsedMatchBody, ParsedMatchCase, Visibility, ParsedParameter, ParsedCapture,
-                ParsedMethod, ParsedTrait }
+                ParsedMethod, ParsedTrait, ParsedName }
 import types {
     BlockControlFlow, BuiltinType, CheckedBlock, CheckedCall, CheckedCapture, CheckedEnum, CheckedEnumVariant,
     CheckedEnumVariantBinding, CheckedExpression, CheckedFunction, CheckedField, FunctionGenerics, CheckedMatchBody, CheckedMatchCase,
@@ -1045,7 +1045,6 @@ struct Typechecker {
         }
 
         .program.modules[.current_module_id.id].traits.push(checked_trait)
-
     }
 
     function typecheck_enum_predecl_initial(mut this, parsed_record: ParsedRecord, enum_index: usize, module_enum_len: usize, scope_id: ScopeId) throws {
@@ -1069,6 +1068,7 @@ struct Typechecker {
             variants: []
             scope_id: .prelude_scope_id()
             definition_linkage: parsed_record.definition_linkage
+            trait_implementations: [:]
             record_type: parsed_record.record_type
             underlying_type_id: enum_type_id
             type_id: enum_type_id
@@ -1100,11 +1100,19 @@ struct Typechecker {
             variants: []
             scope_id: enum_scope_id
             definition_linkage: parsed_record.definition_linkage
+            trait_implementations: [:]
             record_type: parsed_record.record_type
             underlying_type_id
             type_id: enum_type_id
             is_boxed
         )
+
+        if parsed_record.implements_list.has_value() {
+            .fill_trait_implementation_list(
+                parsed_record.implements_list!,
+                &mut module.enums[enum_id.id].trait_implementations,
+                scope_id)
+        }
 
         mut generic_parameters: [TypeId] = module.enums[enum_id.id].generic_parameters
         generic_parameters.ensure_capacity(parsed_record.generic_parameters.size())
@@ -1362,6 +1370,25 @@ struct Typechecker {
         return .get_struct(struct_id).record_type is Struct
     }
 
+    function fill_trait_implementation_list(mut this, anon parsed_impl_list: [ParsedName], anon trait_implementations: &mut [String: TraitId], scope_id: ScopeId) throws {
+        // register the traits that this record is supposed to implement.
+        for trait_name in parsed_impl_list.iterator() {
+            // look for the trait.
+            let maybe_type_id = .find_type_in_scope(scope_id, name: trait_name.name)
+            guard maybe_type_id.has_value() else {
+                .error(format("Cannot find trait ‘{}’", trait_name.name), trait_name.span)
+                continue
+            }
+
+            guard .get_type(maybe_type_id!) is Trait(trait_id) else {
+                .error(format("Expected ‘{}’ to be a trait", trait_name.name), trait_name.span)
+                continue
+            }
+
+            trait_implementations.set(trait_name.name, trait_id)
+        }
+    }
+
     function typecheck_struct_predecl(mut this, parsed_record: ParsedRecord, struct_id: StructId, scope_id: ScopeId) throws {
         let old_generic_inferences = .generic_inferences.perform_checkpoint(reset: true)
         defer {
@@ -1417,10 +1444,18 @@ struct Typechecker {
             fields: []
             scope_id: struct_scope_id
             definition_linkage: parsed_record.definition_linkage
+            trait_implementations: [:]
             record_type: parsed_record.record_type
             type_id: struct_type_id
             super_struct_id
         )
+
+        if parsed_record.implements_list.has_value() {
+            .fill_trait_implementation_list(
+                    parsed_record.implements_list!,
+                    &mut module.structures[struct_id.id].trait_implementations,
+                    scope_id)
+        }
 
         mut generic_parameters: [TypeId] = module.structures[struct_id.id].generic_parameters
         generic_parameters.ensure_capacity(parsed_record.generic_parameters.size())
@@ -1633,6 +1668,7 @@ struct Typechecker {
             fields: []
             scope_id: struct_scope_id
             definition_linkage: parsed_record.definition_linkage
+            trait_implementations: [:]
             record_type: parsed_record.record_type
             type_id: struct_type_id
             super_struct_id: None

--- a/selfhost/typechecker.jakt
+++ b/selfhost/typechecker.jakt
@@ -19,7 +19,7 @@ import types {
     BlockControlFlow, BuiltinType, CheckedBlock, CheckedCall, CheckedCapture, CheckedEnum, CheckedEnumVariant,
     CheckedEnumVariantBinding, CheckedExpression, CheckedFunction, CheckedField, FunctionGenerics, CheckedMatchBody, CheckedMatchCase,
     CheckedNamespace, CheckedNumericConstant, CheckedParameter, CheckedProgram, CheckedStatement, CheckedStruct,
-    CheckedTypeCast, CheckedUnaryOperator, CheckedVariable, CheckedVisibility, EnumId, FieldRecord, FunctionGenericParameter, CheckedTrait,
+    CheckedTypeCast, CheckedUnaryOperator, CheckedVariable, CheckedVisibility, CheckedGenericParameter, EnumId, FieldRecord, FunctionGenericParameter, CheckedTrait,
     FunctionId, LoadedModule, Module, ModuleId, NumberConstant, ResolvedNamespace, SafetyMode, Scope, ScopeId, StructId,
     GenericInferences, StructOrEnumId, Type, TypeId, TraitId, VarId, Value, MaybeResolvedScope,
     builtin, never_type_id, unknown_type_id, void_type_id,
@@ -1114,7 +1114,7 @@ struct Typechecker {
                 scope_id)
         }
 
-        mut generic_parameters: [TypeId] = module.enums[enum_id.id].generic_parameters
+        mut generic_parameters: [CheckedGenericParameter] = module.enums[enum_id.id].generic_parameters
         generic_parameters.ensure_capacity(parsed_record.generic_parameters.size())
 
         for gen_parameter in parsed_record.generic_parameters.iterator() {
@@ -1125,7 +1125,16 @@ struct Typechecker {
                 id: .current_module().types.size() - 1
             )
 
-            generic_parameters.push(parameter_type_id)
+            mut checked_param = CheckedGenericParameter::make(parameter_type_id)
+
+            if gen_parameter.requires_list.has_value() {
+                .fill_trait_requirements(
+                    names: gen_parameter.requires_list!,
+                    trait_requirements: &mut checked_param.constraints,
+                    scope_id)
+            }
+
+            generic_parameters.push(checked_param)
 
             .add_type_to_scope(scope_id: enum_scope_id, type_name: gen_parameter.name, type_id: parameter_type_id, span: gen_parameter.span)
         }
@@ -1187,9 +1196,16 @@ struct Typechecker {
                     id: .current_module().types.size() - 1
                 )
 
-                generic_parameters.push(FunctionGenericParameter::Parameter(
-                    type_id: type_var_type_id
-                ))
+                mut parameter = FunctionGenericParameter::parameter(type_var_type_id)
+
+                if generic_parameter.requires_list.has_value() {
+                    .fill_trait_requirements(
+                        names: generic_parameter.requires_list!,
+                        trait_requirements: &mut parameter.checked_parameter.constraints,
+                        scope_id)
+                }
+
+                generic_parameters.push(parameter)
 
                 if not func.must_instantiate {
                     .add_type_to_scope(
@@ -1457,7 +1473,7 @@ struct Typechecker {
                     scope_id)
         }
 
-        mut generic_parameters: [TypeId] = module.structures[struct_id.id].generic_parameters
+        mut generic_parameters: [CheckedGenericParameter] = module.structures[struct_id.id].generic_parameters
         generic_parameters.ensure_capacity(parsed_record.generic_parameters.size())
 
         for gen_parameter in parsed_record.generic_parameters.iterator() {
@@ -1468,7 +1484,15 @@ struct Typechecker {
                 id: .current_module().types.size() - 1
             )
 
-            generic_parameters.push(parameter_type_id)
+            mut parameter = CheckedGenericParameter::make(parameter_type_id)
+            if gen_parameter.requires_list.has_value() {
+                .fill_trait_requirements(
+                    names: gen_parameter.requires_list!,
+                    trait_requirements: &mut parameter.constraints,
+                    scope_id)
+            }
+
+            generic_parameters.push(parameter)
 
             .add_type_to_scope(scope_id: struct_scope_id, type_name: gen_parameter.name, type_id: parameter_type_id, span: gen_parameter.span)
         }
@@ -1529,7 +1553,16 @@ struct Typechecker {
                     id: .current_module().types.size() - 1
                 )
 
-                checked_function.generics.params.push(FunctionGenericParameter::Parameter(type_var_type_id))
+                mut parameter = FunctionGenericParameter::parameter(type_var_type_id)
+
+                if gen_parameter.requires_list.has_value() {
+                    .fill_trait_requirements(
+                        names: gen_parameter.requires_list!,
+                        trait_requirements: &mut parameter.checked_parameter.constraints,
+                        scope_id)
+                }
+
+                checked_function.generics.params.push(parameter)
                 .add_type_to_scope(scope_id: method_scope_id, type_name: gen_parameter.name, type_id: type_var_type_id, span: gen_parameter.span)
             }
 
@@ -2013,7 +2046,7 @@ struct Typechecker {
     }
 
     function typecheck_method(mut this, func: ParsedFunction, parent_id: StructOrEnumId) throws -> FunctionId? {
-        mut parent_generic_parameters: [TypeId] = []
+        mut parent_generic_parameters: [CheckedGenericParameter] = []
         mut scope_id = .prelude_scope_id()
         mut definition_linkage = DefinitionLinkage::Internal
 
@@ -2150,6 +2183,24 @@ struct Typechecker {
         return checked_parameter
     }
 
+    function fill_trait_requirements(mut this, names: [ParsedName], trait_requirements: &mut [TraitId], scope_id: ScopeId) throws {
+        trait_requirements.ensure_capacity(names.size())
+        for name in names.iterator() {
+            let type_id = .find_type_in_scope(scope_id, name: name.name)
+            guard type_id.has_value() else {
+                .error(format("Couldn't find trait ‘{}’", name.name), name.span)
+                continue
+            }
+
+            guard .get_type(type_id!) is Trait(trait_id) else {
+                .error(format("Requirement ‘{}’ is not a trait", name.name), name.span)
+                continue
+            }
+
+            trait_requirements.push(trait_id)
+        }
+    }
+
     function typecheck_function_predecl(mut this, parsed_function: ParsedFunction, parent_scope_id: ScopeId, this_arg_type_id: TypeId?, mut generics: FunctionGenerics? = None) throws {
         let function_scope_id = .create_scope(parent_scope_id, can_throw: parsed_function.can_throw, debug_name: format("function({})", parsed_function.name))
         let scope_debug_name = format("function-block({})", parsed_function.name)
@@ -2219,10 +2270,17 @@ struct Typechecker {
             )
 
             if base_definition {
+                mut parameter = FunctionGenericParameter::parameter(type_var_type_id)
+                if generic_parameter.requires_list.has_value() {
+                    .fill_trait_requirements(
+                        names: generic_parameter.requires_list!,
+                        trait_requirements: &mut parameter.checked_parameter.constraints,
+                        scope_id: parent_scope_id)
+                }
                 current_module.types.push(Type::TypeVariable(generic_parameter.name))
-                checked_function.generics.params.push(FunctionGenericParameter::Parameter(type_var_type_id))
-            } else if checked_function.generics.params[i] is Parameter(var_type_id) {
-                type_var_type_id = var_type_id
+                checked_function.generics.params.push(parameter)
+            } else if checked_function.generics.params[i].kind is Parameter {
+                type_var_type_id = checked_function.generics.params[i].type_id()
             }
 
             if not parsed_function.must_instantiate or external_linkage {
@@ -2781,7 +2839,7 @@ struct Typechecker {
                             mut idx: usize = 0
                             while idx < args.size() {
                                 if not .check_types_for_compat(
-                                    lhs_type_id: lhs_enum.generic_parameters[idx]
+                                    lhs_type_id: lhs_enum.generic_parameters[idx].type_id
                                     rhs_type_id: args[idx]
                                     generic_inferences
                                     span
@@ -2843,7 +2901,7 @@ struct Typechecker {
                         mut idx: usize = 0
                         while idx < args.size() {
                             if not .check_types_for_compat(
-                                lhs_type_id: lhs_struct.generic_parameters[idx]
+                                lhs_type_id: lhs_struct.generic_parameters[idx].type_id
                                 rhs_type_id: args[idx]
                                 generic_inferences
                                 span
@@ -5549,7 +5607,7 @@ struct Typechecker {
         if type_to_match_on is GenericEnumInstance(id, args) {
             let enum_ = .get_enum(id)
             for i in 0..enum_.generic_parameters.size() {
-                let generic = enum_.generic_parameters[i].to_string()
+                let generic = enum_.generic_parameters[i].type_id.to_string()
                 let argument_type = args[i].to_string()
                 if generic != argument_type {
                     .generic_inferences.set(generic, argument_type)
@@ -6231,10 +6289,7 @@ struct Typechecker {
                     }
 
                     // Find the associated type variable for this parameter, we'll use it in substitution
-                    let typevar_type_id = match callee.generics.params[type_arg_index] {
-                        InferenceGuide(id)
-                        | Parameter(id) => id
-                    }
+                    let typevar_type_id = callee.generics.params[type_arg_index].type_id()
 
                     if not typevar_type_id.equals(checked_type) {
                         .generic_inferences.set(typevar_type_id.to_string(), checked_type.to_string())
@@ -6255,12 +6310,12 @@ struct Typechecker {
                     if param_type is GenericInstance(id, args) {
                         let structure = .get_struct(id)
                         for i in 0..structure.generic_parameters.size() {
-                            if structure.generic_parameters[i].equals(args[i]) {
+                            if structure.generic_parameters[i].type_id.equals(args[i]) {
                                 continue
                             }
 
                             .generic_inferences.set(
-                                structure.generic_parameters[i].to_string()
+                                structure.generic_parameters[i].type_id.to_string()
                                 args[i].to_string()
                             )
                         }
@@ -6334,8 +6389,8 @@ struct Typechecker {
                 }
 
                 for generic_typevar in callee.generics.params.iterator() {
-                    if generic_typevar is Parameter(id) {
-                        let substitution = .generic_inferences.get(id.to_string())
+                    if generic_typevar.kind is Parameter {
+                        let substitution = .generic_inferences.get(generic_typevar.type_id().to_string())
                         if substitution.has_value() {
                             generic_arguments.push(TypeId::from_string(substitution!))
                         } else {

--- a/selfhost/typechecker.jakt
+++ b/selfhost/typechecker.jakt
@@ -1978,6 +1978,17 @@ struct Typechecker {
             super_struct_id = super_struct.super_struct_id
         }
 
+        mut checks = TraitImplCheck::make()
+
+        {
+            let trait_implementations = .get_struct(struct_id).trait_implementations
+            checks.ensure_capacity(trait_implementations.size())
+
+            for (trait_name, trait_id) in trait_implementations.iterator() {
+                checks.register_trait(trait_id, trait_name, trait_methods: .program.get_trait(trait_id).methods)
+            }
+        }
+
         for method in record.methods.iterator() {
             if method.is_override {
                 if not all_virtuals.contains(method.parsed_function.name) {
@@ -1986,13 +1997,22 @@ struct Typechecker {
             } else if all_virtuals.contains(method.parsed_function.name) {
                 .error("Missing override keyword on function that is virtual", method.parsed_function.name_span)
             }
-            .typecheck_method(func: method.parsed_function, parent_id: StructOrEnumId::Struct(struct_id))
+            let method_id = .typecheck_method(func: method.parsed_function, parent_id: StructOrEnumId::Struct(struct_id))
+
+            if method_id.has_value() {
+                checks.register_method(
+                    method_name: method.parsed_function.name,
+                    method_id: method_id!,
+                    program: &.program)
+            }
         }
+
+        checks.throw_errors(record_decl_span: .get_struct(struct_id).name_span, typechecker: &mut this)
 
         .current_struct_type_id = None
     }
 
-    function typecheck_method(mut this, func: ParsedFunction, parent_id: StructOrEnumId) throws {
+    function typecheck_method(mut this, func: ParsedFunction, parent_id: StructOrEnumId) throws -> FunctionId? {
         mut parent_generic_parameters: [TypeId] = []
         mut scope_id = .prelude_scope_id()
         mut definition_linkage = DefinitionLinkage::Internal
@@ -2013,7 +2033,7 @@ struct Typechecker {
         }
 
         if (not func.generic_parameters.is_empty() or not parent_generic_parameters.is_empty()) and not func.must_instantiate {
-            return
+            return None
         }
 
         let structure_scope_id = scope_id
@@ -2067,6 +2087,8 @@ struct Typechecker {
 
         checked_function.block = block
         checked_function.return_type_id = return_type_id
+
+        return method_id!
     }
 
     function typecheck_parameter(mut this, parameter: ParsedParameter, scope_id: ScopeId, first: bool, this_arg_type_id: TypeId?, check_scope: ScopeId?) throws -> CheckedParameter {
@@ -6608,4 +6630,140 @@ struct Typechecker {
         }
         return false
     }
+}
+
+// NOTE: for some reason using (String, Span) would not compile the generated
+// C++, specifically the call to get(). I couldn't track down the error since
+// accessing a [String: (String, Span)] dictionary seemed fine in a separate
+// test file.
+struct AlreadyImplementedFor {
+    trait_name: String
+    encounter_span: Span
+}
+
+// helper struct to implement the checking of trait implementations
+struct TraitImplCheck {
+    // methods that don't yet have a specified implementation.
+    missing_methods: [String: [String: FunctionId]]
+    // same name, but signature doesn't match.
+    unmatched_signatures: [String: [String: Span]]
+    // same name, signature matches, but isn't marked public.
+    private_matching_methods: [String: [String: Span]]
+    // 'Cannot implement method X for trait Y since it already implements Z'
+    already_implemented_for: [String: AlreadyImplementedFor]
+
+    function make() throws -> TraitImplCheck => 
+        TraitImplCheck(
+            missing_methods: [:]
+            unmatched_signatures: [:]
+            private_matching_methods: [:]
+            already_implemented_for: [:])
+
+    function ensure_capacity(mut this, anon count: usize) throws {
+        .missing_methods.ensure_capacity(count)
+        .unmatched_signatures.ensure_capacity(count)
+        .private_matching_methods.ensure_capacity(count)
+        .already_implemented_for.ensure_capacity(count)
+    }
+
+    function register_trait(mut this, trait_id: TraitId, trait_name: String, trait_methods: [String: FunctionId]) throws {
+        .unmatched_signatures[trait_name] = [:]
+        .private_matching_methods[trait_name] = [:]
+
+        mut missing_methods: [String: FunctionId] = [:]
+        missing_methods.ensure_capacity(trait_methods.size())
+
+
+        for (method_name, method_id) in trait_methods.iterator() {
+            missing_methods.set(method_name, method_id)
+        }
+
+        .missing_methods.set(trait_name, missing_methods)
+    }
+
+    function throw_errors(mut this, record_decl_span: Span, typechecker: &mut Typechecker) throws {
+        for (trait_name, missing_methods) in .missing_methods.iterator() {
+            let unmatched_signatures = .unmatched_signatures[trait_name]
+            let private_matching_methods = .private_matching_methods[trait_name]
+            for (method_name, trait_method_id) in missing_methods.iterator() {
+                let already_implemented_for = .already_implemented_for.get(method_name)
+                let unmatched_signature = unmatched_signatures.get(method_name)
+                let private_matching_method = private_matching_methods.get(method_name)
+                if already_implemented_for.has_value() {
+                    typechecker.error(
+                        format("Cannot implement ‘{}’ for ‘{}’ because it's already implementing ‘{}’",
+                            method_name,
+                            trait_name,
+                            already_implemented_for!.trait_name),
+                        already_implemented_for!.encounter_span)
+                } else if private_matching_method.has_value() {
+                    let span = private_matching_method!
+                    typechecker.error_with_hint(
+                        format("Implementation of ‘{}’ for trait ‘{}’ is valid but is not public",
+                            method_name, trait_name),
+                        span,
+                        "Consider adding ‘public’ to make the method accessible",
+                        span)
+                } else {
+                    // The user didn't add an implementation for the desired method.
+                    // Check if we found an unmatching signature to report that to the user.
+                    // Otherwise give them a hint about what the method looks like.
+
+                    if unmatched_signature.has_value() {
+                        let method_span = unmatched_signature!
+
+                        typechecker.error_with_hint(
+                            format("Missing implementation for method ‘{}’ of trait ‘{}’",
+                                method_name, trait_name),
+                            record_decl_span,
+                            "The method is declared here, but its signature doesn't match",
+                            method_span)
+                    } else {
+                        let trait_method_span = typechecker.get_function(trait_method_id).name_span
+                        typechecker.error_with_hint(
+                            format("Missing implementation for method ‘{}’ of trait ‘{}’",
+                                method_name, trait_name),
+                            record_decl_span,
+                            "Consider implementing the method with the signature specified here",
+                            trait_method_span)
+                    }
+
+                }
+            }
+        }
+    }
+
+    function register_method(mut this, method_name: String, method_id: FunctionId, program: &CheckedProgram) throws {
+        let method = program.get_function(method_id)
+
+        // search for a matching method
+        for (trait_name, methods) in .missing_methods.iterator() {
+            let trait_method_id = methods.get(method_name)
+
+            guard trait_method_id.has_value() else {
+                continue
+            }
+            let trait_method = program.get_function(trait_method_id!)
+
+
+            guard trait_method.signature_matches(method) else {
+                .unmatched_signatures[trait_name].set(method_name, method.name_span)
+                continue
+            }
+
+            guard method.visibility is Public else {
+                .private_matching_methods[trait_name].set(method_name, method.name_span)
+                continue
+            }
+
+            // since we got here, this means we found the method implementation!
+            // Register it as already implemented so that the rest of the traits
+            // that needed a similar method know that the method was already implementing
+            // one trait.
+            .missing_methods[trait_name].remove(method_name)
+            .already_implemented_for[method_name] =  AlreadyImplementedFor(trait_name, encounter_span: method.name_span)
+            break
+        }
+    }
+
 }

--- a/selfhost/typechecker.jakt
+++ b/selfhost/typechecker.jakt
@@ -2370,7 +2370,48 @@ struct Typechecker {
         }
     }
 
-    function typecheck_and_specialize_generic_function(mut this, function_id: FunctionId, generic_arguments: [TypeId], parent_scope_id: ScopeId, this_type_id: TypeId?, generic_substitutions: GenericInferences) throws {
+    function check_type_argument_requirements(mut this, generic_argument: TypeId, constraints: [TraitId], arg_span: Span) throws {
+        // if the parameter has no trait requirements, then it's OK
+        guard not constraints.is_empty() else {
+            return
+        }
+
+        // only structs or enums can implement traits
+        let (implemented_traits, decl_span) = match .get_type(generic_argument) {
+            GenericEnumInstance(id) | Enum(id) => (.get_enum(id).trait_implementations, .get_enum(id).name_span)
+            GenericInstance(id) | Struct(id) => (.get_struct(id).trait_implementations, .get_struct(id).name_span)
+            else => {
+                .error(
+                    format("Cannot use ‘{}’ here as only enums, structs and classes can implement the required traits", 
+                        .type_name(generic_argument)),
+                    arg_span)
+                // NOTE: C++ rejects the 'return {}' because it cannot get a matching constructor
+                unsafe { cpp {
+                    "return ErrorOr<void>{};"
+                } }
+
+                // NOTE: unreachable due to the cpp above
+                let dict: [String: TraitId] = [:]
+
+                yield (dict, Span(file_id: FileId(id: 0), start: 0, end: 0))
+            }
+        }
+
+        for constraint in constraints.iterator() {
+            let trait_name = .program.get_trait(constraint).name
+            let implemented_trait = implemented_traits.get(trait_name)
+            if not implemented_trait.has_value() or not implemented_trait!.equals(constraint) {
+                .error_with_hint(
+                    format("Cannot use ‘{}’ here as it doesn't implement the trait ‘{}’", 
+                            .type_name(generic_argument), trait_name)
+                    arg_span,
+                    "Consider implementing the required trait for this type",
+                    decl_span)
+            }
+        }
+    }
+
+    function typecheck_and_specialize_generic_function(mut this, function_id: FunctionId, generic_arguments: [TypeId], parent_scope_id: ScopeId, this_type_id: TypeId?, generic_substitutions: GenericInferences, type_args: [ParsedType], call_span: Span) throws {
         mut checked_function = .get_function(function_id)
         checked_function.generics.specializations.push(generic_arguments)
 
@@ -2390,6 +2431,17 @@ struct Typechecker {
                 )
                 parsed_function.name_span
             )
+        }
+        
+        for i in 0..parsed_function.generic_parameters.size() {
+            mut arg_span = call_span
+            if type_args.size() > i {
+                arg_span = type_args[i].span()
+            }
+            .check_type_argument_requirements(
+                generic_argument: generic_arguments[i],
+                constraints: checked_function.generics.params[i].checked_parameter.constraints,
+                arg_span)
         }
 
         let span = parsed_function.name_span
@@ -6435,6 +6487,8 @@ struct Typechecker {
                 parent_scope_id: callee_scope_id,
                 this_type_id: maybe_this_type_id,
                 generic_substitutions: .generic_inferences
+                type_args: call.type_args,
+                call_span: span
             )
         }
 

--- a/selfhost/types.jakt
+++ b/selfhost/types.jakt
@@ -760,14 +760,19 @@ enum CheckedCapture {
     }
 }
 
-enum FunctionGenericParameter {
-    InferenceGuide(TypeId)
-    Parameter(TypeId)
+enum FunctionGenericParameterKind {
+    InferenceGuide
+    Parameter
+}
 
-    function type_id(this) => match this {
-        InferenceGuide(id) => id
-        Parameter(id) => id
-    }
+
+struct FunctionGenericParameter {
+    kind: FunctionGenericParameterKind
+    checked_parameter: CheckedGenericParameter
+
+    function type_id(this) => .checked_parameter.type_id
+
+    function parameter(anon type_id: TypeId) throws => FunctionGenericParameter(kind: FunctionGenericParameterKind::Parameter, checked_parameter: CheckedGenericParameter::make(type_id))
 }
 
 struct CheckedVariable {
@@ -921,7 +926,7 @@ struct CheckedField {
 struct CheckedStruct {
     name: String
     name_span: Span
-    generic_parameters: [TypeId]
+    generic_parameters: [CheckedGenericParameter]
     fields: [CheckedField]
     scope_id: ScopeId
     definition_linkage: DefinitionLinkage
@@ -934,7 +939,7 @@ struct CheckedStruct {
 struct CheckedEnum {
     name: String
     name_span: Span
-    generic_parameters: [TypeId]
+    generic_parameters: [CheckedGenericParameter]
     variants: [CheckedEnumVariant]
     scope_id: ScopeId
     definition_linkage: DefinitionLinkage
@@ -943,6 +948,13 @@ struct CheckedEnum {
     underlying_type_id: TypeId
     type_id: TypeId
     is_boxed: bool
+}
+
+struct CheckedGenericParameter {
+    type_id: TypeId
+    constraints: [TraitId]
+
+    function make(anon type_id: TypeId) throws => CheckedGenericParameter(type_id, constraints: [])
 }
 
 enum CheckedEnumVariant {
@@ -1783,7 +1795,7 @@ class CheckedProgram {
                     mut new_args:[TypeId] = []
                     new_args.ensure_capacity(struct_.generic_parameters.size())
                     for arg in struct_.generic_parameters.iterator() {
-                        new_args.push(.substitute_typevars_in_type(type_id: arg, generic_inferences, module_id))
+                        new_args.push(.substitute_typevars_in_type(type_id: arg.type_id, generic_inferences, module_id))
                     }
                     return .find_or_add_type_id(Type::GenericInstance(id: struct_id, args: new_args), module_id)
                 }
@@ -1794,7 +1806,7 @@ class CheckedProgram {
                     mut new_args:[TypeId] = []
                     new_args.ensure_capacity(enum_.generic_parameters.size())
                     for arg in enum_.generic_parameters.iterator() {
-                        new_args.push(.substitute_typevars_in_type(type_id: arg, generic_inferences, module_id))
+                        new_args.push(.substitute_typevars_in_type(type_id: arg.type_id, generic_inferences, module_id))
                     }
                     return .find_or_add_type_id(Type::GenericEnumInstance(id: enum_id, args: new_args), module_id)
                 }

--- a/selfhost/types.jakt
+++ b/selfhost/types.jakt
@@ -878,6 +878,7 @@ struct CheckedStruct {
     fields: [CheckedField]
     scope_id: ScopeId
     definition_linkage: DefinitionLinkage
+    trait_implementations: [String: TraitId]
     record_type: RecordType
     type_id: TypeId
     super_struct_id: StructId?
@@ -890,6 +891,7 @@ struct CheckedEnum {
     variants: [CheckedEnumVariant]
     scope_id: ScopeId
     definition_linkage: DefinitionLinkage
+    trait_implementations: [String: TraitId]
     record_type: RecordType
     underlying_type_id: TypeId
     type_id: TypeId

--- a/selfhost/types.jakt
+++ b/selfhost/types.jakt
@@ -140,6 +140,15 @@ struct TypeId {
     }
 }
 
+struct TraitId {
+    module: ModuleId
+    id: usize
+
+    function equals(this, anon other: TraitId) -> bool {
+        return this.module.id == other.module.id and this.id == other.id
+    }
+}
+
 struct ScopeId {
     module_id: ModuleId
     id: usize
@@ -217,6 +226,7 @@ boxed enum Type {
     Struct(StructId)
     Enum(EnumId)
     RawPtr(TypeId)
+    Trait(TraitId)
     Reference(TypeId)
     MutableReference(TypeId)
     Function(params: [TypeId], can_throw: bool, return_type_id: TypeId, pseudo_function_id: FunctionId)
@@ -247,6 +257,7 @@ boxed enum Type {
         Struct => "Struct"
         Enum => "Enum"
         RawPtr => "RawPtr"
+        Trait => "Trait"
         Reference => "Reference"
         MutableReference => "MutableReference"
         Function => "Function"
@@ -354,6 +365,13 @@ boxed enum Type {
             }
             MutableReference(lhs_id) => {
                 if rhs is MutableReference(rhs_id) {
+                    return lhs_id.equals(rhs_id)
+                } else {
+                    return false
+                }
+            }
+            Trait(lhs_id) => {
+                if rhs is Trait(rhs_id) {
                     return lhs_id.equals(rhs_id)
                 } else {
                     return false
@@ -468,6 +486,7 @@ class Module {
     public enums: [CheckedEnum]
     public scopes: [Scope]
     public types: [Type]
+    public traits: [CheckedTrait]
     public variables: [CheckedVariable]
     public imports: [ModuleId]
     public resolved_import_path: String
@@ -502,6 +521,12 @@ class Module {
 
         return VarId(module: .id, id: new_id)
     }
+}
+
+struct CheckedTrait {
+    name: String
+    name_span: Span
+    methods: [String: FunctionId]
 }
 
 struct LoadedModule {
@@ -1251,6 +1276,8 @@ class CheckedProgram {
         return .modules[id.module_id.id].scopes[id.id]
     }
 
+    public function get_trait(this, anon id: TraitId) -> CheckedTrait => .modules[id.module.id].traits[id.id]
+
     public function prelude_scope_id(this) -> ScopeId => ScopeId(module_id: ModuleId(id: 0), id: 0)
 
     public function set_loaded_module(mut this, module_name: String, loaded_module: LoadedModule) throws {
@@ -1534,6 +1561,7 @@ class CheckedProgram {
             Void => "void"
             Unknown => "unknown"
             JaktString => "String"
+            Trait(id) => .get_trait(id).name
             Function(params, return_type_id) => {
                 mut param_names: [String] = []
                 for x in params.iterator() {

--- a/selfhost/types.jakt
+++ b/selfhost/types.jakt
@@ -618,6 +618,53 @@ class CheckedFunction {
     public is_virtual: bool
     public is_override: bool
 
+    // NOTE: this currently can't match generic function signatures. E.g
+    // a<T>() -> T and b<T>() -> T won't be detected to have the same signature
+    // due to `T` having a different ID.
+    // NOTE: function trait requirements aren't currently taken into account.
+    public function signature_matches(this, anon other: CheckedFunction) -> bool {
+        guard .return_type_id.equals(other.return_type_id) else {
+            return false
+        }
+
+        guard .can_throw == other.can_throw else {
+            return false
+        }
+
+        guard .params.size() == other.params.size() else {
+            return false
+        }
+
+        // both static or both have 'this' parameter
+        mut arg_start = 0uz
+
+        if .is_static() {
+            guard other.is_static() else {
+                return false
+            }
+        } else {
+            guard not other.is_static() else {
+                return false
+            }
+
+            guard .is_mutating() == other.is_mutating() else {
+                return false
+            }
+            arg_start = 1uz
+        }
+
+        for i in arg_start...params.size() {
+            let this_param = .params[i].variable
+            let other_param = other.params[i].variable
+
+            guard this_param.type_id.equals(other_param.type_id) else {
+                return false
+            }
+        }
+
+        return true
+    }
+
     public function is_static(this) -> bool {
         if .params.size() < 1 {
             return true

--- a/tests/parser/disallow_empty_implements.jakt
+++ b/tests/parser/disallow_empty_implements.jakt
@@ -1,0 +1,5 @@
+/// Expect:
+/// - error: "Expected trait list to have at least one trait inside it"
+
+
+struct Foo implements() {}

--- a/tests/typechecker/missing_trait_impl.jakt
+++ b/tests/typechecker/missing_trait_impl.jakt
@@ -1,0 +1,11 @@
+/// Expect:
+/// - error: "Missing implementation for method ‘bar’ of trait ‘Bar’"
+
+
+trait Bar {
+    function bar(this)
+}
+
+class Foo implements(Bar) {}
+
+function main() {}

--- a/tests/typechecker/private_trait_impl.jakt
+++ b/tests/typechecker/private_trait_impl.jakt
@@ -1,0 +1,15 @@
+/// Expect:
+/// - error: "Implementation of ‘bar’ for trait ‘Bar’ is valid but is not public"
+
+
+trait Bar {
+    function bar(this)
+}
+
+class Foo implements(Bar) {
+    function bar(this) {
+        println("Foo::bar")
+    }
+}
+
+function main() {}

--- a/tests/typechecker/unmatched_requirements.jakt
+++ b/tests/typechecker/unmatched_requirements.jakt
@@ -1,0 +1,13 @@
+/// Expect:
+/// - error: "Cannot use ‘Foo’ here as it doesn't implement the trait ‘Bar’"
+trait Bar {}
+
+struct Foo {}
+
+function do_something_with_bar<T requires(Bar)>(value: T) { }
+
+function main() {
+    do_something_with_bar<Foo>(value: Foo())
+}
+
+


### PR DESCRIPTION
This is a draft PR to port over and extend the trait implementation. Used #378
with @kleinesfilmroellchen's work as a base, and I'd want to merge their commits
regarding documentation since there's no extra work for me to do there rather
than writing extra stuff or extra tests.

How it works (probably document this somewhere else?):
- Traits are registered almost at the top of the predecl chain, to ensure later passes know what traits exist.
- When the user tells that a type implements X trait, first assume it is correct, i.e register that trait as implemented, and let the rest of the typechecking run with that assumption.
- If an implementation for a given trait and a given type is incomplete/methods implementations aren't correct, errors will be reported and the code won't compile.

This way of deferring the typechecking makes sure we don't output more errors than strictly necessary:

When the user states that type `Foo` implements trait `Bar`, this means they want to use it in a generic function/struct that requires trait `Bar`.

If we prevented a trait implementation from being registered when such implementation didn't typecheck, we'll just confuse the user by telling them that `'Bar' trait is not implemented` (they'll think "But I *just* told you that it's implemented!").

By registering the implementation and later checking it without removing it from the assumptions our error report is much more clear: `Hey, I know you wanted to implement 'Bar' trait, but I can't compile because your implementation is wrong`.

---

Tasks:
- [x] Parser:
    - [x] Parse trait definitions
    - [x] Parse some way to know what traits are implemented for a record type (no duck typing!)
    - [x] Parse trait requirements
- [ ] Typechecker:
    - [x] Instantiate traits as types
    - [x] Register trait implementations for deferred checking
        - [x] Records
    - [x] Check that all trait methods are implemented for a struct that mentions that implements that trait
        - [x] Check that those methods' signatures correspond with the traits that each method implements
        - [x] Check that there are no missing methods to be implemented
        - [ ] Check that there are no extra methods than what the trait requires?
    - [ ] Check generic types' trait requirements upon instantiation
        - [x] Function
        - [ ] Struct/Class
        - [ ] Enum 
    - [x] Create tests for each of the errors possible from traits:
        - [x] Method not found
        - [x] Invalid signature
    - [ ] Codegen:
        - [ ] Make classes work (`Jakt::NonNullRefPtr`)
- [ ] Meta:
    - [ ] Merge documentation from original PR
    - [ ] Make it work with the REPL (?)