### PR TITLE
main: Check for gcc compiler and adjust args

### DIFF
--- a/selfhost/main.jakt
+++ b/selfhost/main.jakt
@@ -285,21 +285,39 @@ function main(args: [String]) {
 }
 
 function run_compiler(cxx_compiler_path: String, cpp_filename: String, output_filename: String, runtime_path: String, extra_include_paths: [String], extra_lib_paths: [String], extra_link_libs: [String]) throws {
+    mut file_path = FilePath(path: cxx_compiler_path)
+
+    mut color_flag: String = "-fcolor-diagnostics"
+    mut extra_flags: [String] = []
+    if file_path.basename() == "g++" {
+        color_flag = "-fdiagnostics-color=always"
+        extra_flags.push("-Wno-literal-suffix")
+    }
+
     mut compile_args = [
         cxx_compiler_path
-        "-fcolor-diagnostics"
+        color_flag
         "-std=c++20"
         "-Wno-unknown-warning-option"
         "-Wno-trigraphs"
         "-Wno-parentheses-equality"
         "-Wno-unqualified-std-cast-call"
         "-Wno-user-defined-literals"
-        "-Wno-deprecated-declarations"
-        "-I"
-        runtime_path
-        "-o"
-        output_filename
+        "-Wno-deprecated-declarations"  
     ]
+
+    if not extra_flags.is_empty() {
+        for flag in extra_flags.iterator() {
+            compile_args.push(flag)
+        }
+    }
+
+    compile_args.push("-I")
+    compile_args.push(runtime_path)
+
+    compile_args.push("-o")
+    compile_args.push(output_filename)
+
     compile_args.push(cpp_filename)
     if not extra_include_paths.is_empty() {
         compile_args.add_capacity(extra_include_paths.size() * 2)


### PR DESCRIPTION
gcc appears to use `-fdiagnostics-color=always` instead of
`-fcolor-diagnostics`
gcc requires `-Wno-literal-suffix` because of StringView `operator"" sv`

combined with https://github.com/SerenityOS/jakt/pull/969 allows stage 3 with gcc