### PR TITLE
selfhost: Implement match on Optional Enums

### DIFF
--- a/samples/match/match_optional_enum.jakt
+++ b/samples/match/match_optional_enum.jakt
@@ -1,0 +1,30 @@
+/// Expect: selfhost-only
+/// - output: "PASS, PASS, PASS"
+
+enum A {
+    B
+    C
+}
+
+function main() {
+    let a: A? = None
+    let b: A? = A::B
+
+    let res_a: String = match a {
+        B => "FAIL"
+        else => "PASS"
+    }
+
+    let res_b: String = match b {
+        B => "PASS"
+        else => "FAIL"
+    }
+
+    let res_c: String = match a {
+        B => "FAIL"
+        C => "FAIL"
+        None => "PASS"
+    }
+
+    print("{}, {}, {}", res_a, res_b, res_c)
+}

--- a/samples/match/match_optional_enum_none_variant.jakt
+++ b/samples/match/match_optional_enum_none_variant.jakt
@@ -1,0 +1,26 @@
+/// Expect: selfhost-only
+/// - output: "PASS, PASS"
+
+enum A {
+    B
+    C
+    None
+}
+
+function main() {
+    let a: A? = None
+    let b: A? = A::None
+
+    let res_a: String = match a {
+        B => "FAIL"
+        None => "FAIL"
+        else => "PASS"
+    }
+
+    let res_b: String = match b {
+        None => "PASS"
+        else => "FAIL"
+    }
+
+    print("{}, {}", res_a, res_b)
+}

--- a/selfhost/codegen.jakt
+++ b/selfhost/codegen.jakt
@@ -1527,7 +1527,41 @@ struct CodeGenerator {
                     match_cases
                     type_id
                     all_variants_constant
+                    is_optional: false
                 )
+            }
+            GenericInstance(id, args) => {
+                let struct_ = .program.get_struct(id)
+                if struct_.name == "Optional" {
+                    let arg_type = .program.get_type(args.first()!)
+                    match arg_type {
+                        Enum(enum_id) => {
+                            output += .codegen_enum_match(
+                                enum_: .program.get_enum(enum_id)
+                                expr
+                                match_cases
+                                type_id
+                                all_variants_constant
+                                is_optional: true
+                            )
+                        }
+                        else => {
+                            output += .codegen_generic_match(
+                                expr
+                                cases: match_cases
+                                return_type_id: type_id
+                                all_variants_constant
+                            )
+                        }
+                    }
+                } else {
+                    output += .codegen_generic_match(
+                        expr
+                        cases: match_cases
+                        return_type_id: type_id
+                        all_variants_constant
+                    )
+                }
             }
             else => {
                 output += .codegen_generic_match(
@@ -1635,7 +1669,7 @@ struct CodeGenerator {
         return output
     }
 
-    function codegen_enum_match(mut this, enum_: CheckedEnum, expr: CheckedExpression, match_cases: [CheckedMatchCase], type_id: TypeId, all_variants_constant: bool) throws -> String {
+    function codegen_enum_match(mut this, enum_: CheckedEnum, expr: CheckedExpression, match_cases: [CheckedMatchCase], type_id: TypeId, all_variants_constant: bool, is_optional: bool) throws -> String {
         mut output = ""
         output += .control_flow_state.choose_control_flow_macro()
 
@@ -1648,19 +1682,46 @@ struct CodeGenerator {
             output += .codegen_function_return_type(function_: .current_function!)
             output += ">{\n"
             output += "auto&& __jakt_match_variant_maybe_deref = " + .codegen_expression(expr) + ";"
-            output += "auto&& __jakt_match_variant = "
+            output += "auto&& __jakt_match_variant_maybe_value = "
             if needs_deref {
                 output += "*"
             }
-            output += "__jakt_match_variant_maybe_deref;\nswitch(__jakt_match_variant.index()) {\n"
+            output += "__jakt_match_variant_maybe_deref;\n"
 
-            mut has_default = false
-            for match_case in match_cases.iterator() {
-                match match_case {
+            mut enum_id: EnumId = EnumId(module: ModuleId(id: 0), id: 0)
+            mut optional_subject_type_id = TypeId(module: ModuleId(id: 0), id: 0)
+            mut should_handle_none = false
+            mut none_body: CheckedMatchBody? = None
+            mut catch_all_body: CheckedMatchBody? = None
+
+            for case_ in match_cases.iterator() {
+                match case_ {
                     EnumVariant(name, args, subject_type_id, index, scope_id, body) => {
+                        if name == "None" {
+                            should_handle_none = true
+                            none_body = body
+                        }
+
+                        optional_subject_type_id = subject_type_id
+
                         let enum_type = .program.get_type(subject_type_id)
-                        let enum_id = match enum_type {
+                        enum_id = match enum_type {
                             Enum(id) => id
+                            GenericInstance(id, args) => {
+                                let arg_type_id = args.first()!
+                                let arg_type = .program.get_type(arg_type_id)
+                                yield match arg_type {
+                                    Enum(id) => {
+                                        optional_subject_type_id = arg_type_id
+                                        yield id
+                                    }
+                                    else => {
+                                        panic("Expected enum type")
+                                        // FIXME: unreachable
+                                        yield EnumId(module: ModuleId(id: 0), id: 0)
+                                    }
+                                }
+                            }
                             else => {
                                 panic("Expected enum type")
                                 // FIXME: unreachable
@@ -1669,18 +1730,49 @@ struct CodeGenerator {
                         }
                         let match_case_enum = .program.get_enum(enum_id)
                         let variant = match_case_enum.variants[index]
+                        if variant.name() == "None" {
+                            should_handle_none = false
+                        }
+                    }
+                    CatchAll(body) => {
+                        catch_all_body = body
+                    }
+                    else => {}
+                }
+            }
+
+            if is_optional {
+                output += "if (__jakt_match_variant_maybe_value.has_value()) {\n"
+                output += "auto&& __jakt_match_variant = __jakt_match_variant_maybe_value.value();"
+            } else {
+                output += "auto&& __jakt_match_variant = __jakt_match_variant_maybe_value;"
+            }
+
+            output += "switch(__jakt_match_variant.index()) {\n"
+
+            mut has_default = false
+            for match_case in match_cases.iterator() {
+                match match_case {
+                    EnumVariant(name, args, subject_type_id, index, scope_id, body) => {
+                        
+                        if should_handle_none and name == "None" {
+                            continue
+                        }
+
+                        let match_case_enum = .program.get_enum(enum_id)
+                        let variant = match_case_enum.variants[index]
                         output += format("case {}: ", index) + "{\n"
                         match variant {
                             Untyped(name) => {
                                 output += format("auto&& __jakt_match_value = __jakt_match_variant.template get<typename {}::{}>();\n",
-                                    .codegen_type_possibly_as_namespace(type_id: subject_type_id, as_namespace: true),
+                                    .codegen_type_possibly_as_namespace(type_id: optional_subject_type_id, as_namespace: true),
                                     name
                                 )
                             }
                             Typed(name, type_id) => {
                                 output += format(
                                     "auto&& __jakt_match_value = __jakt_match_variant.template get<typename {}::{}>();\n",
-                                    .codegen_type_possibly_as_namespace(type_id: subject_type_id, as_namespace: true),
+                                    .codegen_type_possibly_as_namespace(type_id: optional_subject_type_id, as_namespace: true),
                                     name
                                 )
                                 if not args.is_empty() {
@@ -1730,12 +1822,21 @@ struct CodeGenerator {
                 }
             }
             if not has_default {
-                if enum_.variants.size() != match_cases.size() {
+                if is_optional and enum_.variants.size() != match_cases.size() - 1 {
+                    panic("Inexhaustive match statement")
+                } else if not is_optional and enum_.variants.size() != match_cases.size() {
                     panic("Inexhaustive match statement")
                 }
                 output += "default: VERIFY_NOT_REACHED();"
             }
             output += "}/*switch end*/\n"
+
+            if should_handle_none {
+                output += "} else {\n" + .codegen_match_body(body: none_body!, return_type_id: type_id) + "\n}"
+            } else if not should_handle_none and is_optional {
+                output += "} else {\n" + .codegen_match_body(body: catch_all_body!, return_type_id: type_id) + "\n}"
+            }
+
             output += "}()\n))"
         } else {
             todo("underlying type enum match")

--- a/selfhost/typechecker.jakt
+++ b/selfhost/typechecker.jakt
@@ -5405,6 +5405,8 @@ struct Typechecker {
         mut final_result_type: TypeId? = None
 
         mut is_optional = false
+        mut seen_none_variant = false
+        mut added_none_variant = false
 
         match type_to_match_on {
             GenericEnumInstance(id, args) => {
@@ -5430,6 +5432,15 @@ struct Typechecker {
                 mut seen_catch_all = false
                 mut catch_all_span: Span? = None
                 mut covered_variants: {String} = {}
+
+                if is_optional {
+                    for variant in enum_.variants.iterator() {
+                        if variant.name() == "None" {
+                            seen_none_variant = true
+                        }
+                    }
+                }
+
                 for case_ in cases.iterator() {
                     for pattern in case_.patterns.iterator() {
                         match pattern {
@@ -5457,6 +5468,10 @@ struct Typechecker {
                                     if v.name() == variant_names[1].0 {
                                         matched_variant = v
                                         variant_index = i
+                                    } else if variant_names[1].0 == "None" and is_optional {
+                                        matched_variant = CheckedEnumVariant::Untyped(name: "None", span: variant_names[1].1)
+                                        variant_index = i
+                                        added_none_variant = true
                                     }
                                     i++
                                 }
@@ -5627,6 +5642,14 @@ struct Typechecker {
                 for variant in enum_variant_names.iterator() {
                     if not covered_variants.contains(variant) {
                         missing_variants.push(variant)
+                    }
+                }
+
+                if is_optional {
+                    if seen_none_variant and not seen_catch_all {
+                        .error("match on optional enum with none variant requires irrefutable else", span)
+                    } else if not added_none_variant {
+                        missing_variants.push("None")
                     }
                 }
 

--- a/selfhost/typechecker.jakt
+++ b/selfhost/typechecker.jakt
@@ -5398,11 +5398,13 @@ struct Typechecker {
     function typecheck_match(mut this, expr: ParsedExpression, cases: [ParsedMatchCase], span: Span, scope_id: ScopeId, safety_mode: SafetyMode) throws -> CheckedExpression {
         let checked_expr = .typecheck_expression(expr, scope_id, safety_mode, type_hint: None)
         let subject_type_id = expression_type(checked_expr)
-        let type_to_match_on = .get_type(subject_type_id)
+        mut type_to_match_on = .get_type(subject_type_id)
         mut checked_cases: [CheckedMatchCase] = []
 
         mut generic_inferences: [String: String] = [:]
         mut final_result_type: TypeId? = None
+
+        mut is_optional = false
 
         match type_to_match_on {
             GenericEnumInstance(id, args) => {
@@ -5411,6 +5413,12 @@ struct Typechecker {
                     let generic = enum_.generic_parameters[i].to_string()
                     let argument_type = args[i].to_string()
                     generic_inferences.set(generic, argument_type)
+                }
+            }
+            GenericInstance(id, args) => {
+                if .get_struct(id).name == "Optional" {
+                    type_to_match_on = .get_type(args.first()!)
+                    is_optional = true
                 }
             }
             else => {}

--- a/tests/typechecker/match_optional_missing_else.jakt
+++ b/tests/typechecker/match_optional_missing_else.jakt
@@ -1,0 +1,20 @@
+/// Expect: selfhost-only
+/// - error: "match on optional enum with none variant requires irrefutable else"
+
+enum A {
+    B
+    C
+    None
+}
+
+function main() {
+    let a: A? = None
+
+    let res_a = match a {
+        B => "FAIL"
+        C => "FAIL"
+        None => "FAIL"
+    }
+
+    println("{}", res_a)
+}

--- a/tests/typechecker/match_optional_missing_none.jakt
+++ b/tests/typechecker/match_optional_missing_none.jakt
@@ -1,0 +1,18 @@
+/// Expect: selfhost-only
+/// - error: "match expression is not exhaustive, missing variants are: None"
+
+enum A {
+    B
+    C
+}
+
+function main() {
+    let a: A? = A::B
+
+    let res_a = match a {
+        B => "FAIL"
+        C => "FAIL"
+    }
+
+    println("{}", res_a)
+}


### PR DESCRIPTION
Unwraps the Optional into an enum and handles the no value case with a default- or None-case.
Enables things like this:
```
enum A {
    B
    C
}

function main() {
    let a: A? = None
    let b: A? = A::B

    let res_a: String = match a {
        B => "FAIL"
        else => "PASS"
    }

    let res_b: String = match b {
        None => "NONE"
        B => "PASS"
        else => "FAIL"
    }

    print("{}, {}", res_a, res_b)
}
```