### PR TITLE
editors/vscode: Add snippets

### DIFF
--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -68,7 +68,13 @@
 					"description": "The path to the jakt compiler executable."
 				}
 			}
-		}
+		},
+		"snippets": [
+			{
+				"language": "jakt",
+				"path": "./snippets/jakt.json"
+			}
+		]
 	},
 	"scripts": {
 		"vscode:prepublish": "npm run lint && npm run compile",

--- a/editors/vscode/snippets/jakt.json
+++ b/editors/vscode/snippets/jakt.json
@@ -1,0 +1,24 @@
+{
+    "Jakttest output header": {
+        "scope": "jakt",
+        "prefix": "jt",
+        "body": [
+            "/// Expect: selfhost-only",
+            "/// - output: \"$1\"",
+            "",
+            "$0"
+        ],
+        "description": "Jakttest output header"
+    },
+    "Jakttest error header": {
+        "scope": "jakt",
+        "prefix": "jte",
+        "body": [
+            "/// Expect: selfhost-only",
+            "/// - error: \"$1\"",
+            "",
+            "$0"
+        ],
+        "description": "Jakttest error header"
+    }
+}


### PR DESCRIPTION
This is a handy feature that can paste in a bunch of stuff for only a
few keypresses. This way you don't have to remember the correct
incantation to get a test to parse, just type `jt` (or `jte`).