### PR TITLE
random fixes / GDB pretty printer

### DIFF
--- a/meta/jakt_gdb.py
+++ b/meta/jakt_gdb.py
@@ -1,0 +1,223 @@
+# Copyright (c) 2021, Gunnar Beutner <gunnar@beutner.name>
+# Copyright (c) 2021-2022, Ali Mohammad Pur <mpfard@jakt.org>
+#
+# SPDX-License-Identifier: BSD-2-Clause
+
+import gdb
+import gdb.types
+import re
+
+
+def handler_class_for_type(type, re=re.compile('^([^<]+)(<.*>)?$')):
+    typename = str(type.tag)
+
+    match = re.match(typename)
+    if not match:
+        return UnhandledType
+
+    klass = match.group(1)
+
+    if klass == 'Jakt::Array':
+        return JaktArray
+    elif klass == 'Jakt::RefCounted':
+        return JaktRefCounted
+    elif klass == 'Jakt::RefPtr':
+        return JaktRefPtr
+    elif klass == 'Jakt::NonnullRefPtr':
+        return JaktRefPtr
+    elif klass == 'Jakt::String':
+        return JaktString
+    elif klass == 'Jakt::StringStorage':
+        return JaktStringStorage
+    elif klass == 'Jakt::Variant':
+        return JaktVariant
+    else:
+        return UnhandledType
+
+
+class UnhandledType:
+    @classmethod
+    def prettyprint_type(cls, type):
+        return type.name
+
+
+class JaktRefCounted:
+    def __init__(self, val):
+        self.val = val
+
+    def to_string(self):
+        return self.val["m_ref_count"]
+
+    @classmethod
+    def prettyprint_type(cls, type):
+        contained_type = type.template_argument(0)
+        return f'Jakt::RefCounted<{handler_class_for_type(contained_type).prettyprint_type(contained_type)}>'
+
+
+class JaktString:
+    def __init__(self, val):
+        self.val = val
+
+    def to_string(self):
+        if int(self.val["m_storage"]["m_ptr"]) == 0:
+            return '""'
+        else:
+            impl = JaktRefPtr(self.val["m_storage"]).get_pointee().dereference()
+            return JaktStringStorage(impl).to_string()
+
+    @classmethod
+    def prettyprint_type(cls, type):
+        return 'Jakt::String'
+
+
+class JaktStringView:
+    def __init__(self, val):
+        self.val = val
+
+    def to_string(self):
+        if int(self.val["m_length"]) == 0:
+            return '""'
+        else:
+            characters = self.val["m_characters"]
+            str_type = characters.type.target().array(self.val["m_length"]).pointer()
+            return str(characters.cast(str_type).dereference())
+
+    @classmethod
+    def prettyprint_type(cls, type):
+        return 'Jakt::StringView'
+
+
+def get_field_unalloced(val, member, type):
+    # Trying to access a variable-length field seems to fail with
+    # Python Exception <class 'gdb.error'> value requires 4294967296 bytes, which is more than max-value-size
+    # This works around that issue.
+    return gdb.parse_and_eval(f"*({type}*)(({val.type.name}*){int(val.address)})->{member}")
+
+
+class JaktStringStorage:
+    def __init__(self, val):
+        self.val = val
+
+    def to_string(self):
+        if int(self.val["m_length"]) == 0:
+            return '""'
+        else:
+            str_type = gdb.lookup_type("char").array(self.val["m_length"])
+            return get_field_unalloced(self.val, "m_inline_buffer", str_type)
+
+    @classmethod
+    def prettyprint_type(cls, type):
+        return 'Jakt::StringStorage'
+
+
+class JaktRefPtr:
+    def __init__(self, val):
+        self.val = val
+
+    def to_string(self):
+        return JaktRefPtr.prettyprint_type(self.val.type)
+
+    def get_pointee(self):
+        inner_type = self.val.type.template_argument(0)
+        inner_type_ptr = inner_type.pointer()
+        return self.val["m_ptr"].cast(inner_type_ptr)
+
+    def children(self):
+        return [('*', self.get_pointee())]
+
+    @classmethod
+    def prettyprint_type(cls, type):
+        contained_type = type.template_argument(0)
+        return f'Jakt::RefPtr<{handler_class_for_type(contained_type).prettyprint_type(contained_type)}>'
+
+
+class JaktVariant:
+    def __init__(self, val):
+        self.val = val
+        self.index = int(self.val["m_index"])
+        self.contained_types = self.resolve_types(self.val.type)
+
+    def to_string(self):
+        return JaktVariant.prettyprint_type(self.val.type)
+
+    def children(self):
+        data = self.val["m_data"]
+        ty = self.contained_types[self.index]
+        return [(JaktVariant.variant_name(ty), data.cast(ty.pointer()).referenced_value())]
+
+    @classmethod
+    def resolve_types(cls, ty):
+        contained_types = []
+        type_resolved = ty.strip_typedefs()
+        index = 0
+        while True:
+            try:
+                arg = type_resolved.template_argument(index)
+                index += 1
+                contained_types.append(arg)
+            except RuntimeError:
+                break
+        return contained_types
+
+    @classmethod
+    def variant_name(cls, t, re=re.compile(r'^Jakt::.*?([^:]*)_Details::(\w+)$')):
+        match = re.match(t.name)
+        if match:
+            klass = match.group(1)
+            variant = match.group(2)
+            return f'{klass}::{variant}'
+        return handler_class_for_type(t).prettyprint_type(t)
+
+    @classmethod
+    def prettyprint_type(cls, ty):
+        names = ", ".join(JaktVariant.variant_name(t) for t in JaktVariant.resolve_types(ty))
+        return f'Jakt::Variant<{names}>'
+
+
+class JaktArray:
+    def __init__(self, val):
+        self.val = val
+        self.storage_type = self.val.type.template_argument(0)
+
+    def to_string(self):
+        impl = JaktRefPtr(self.val["m_storage"]).get_pointee().dereference()
+        return JaktArrayStorage(impl).to_string()
+
+    @classmethod
+    def prettyprint_type(cls, type):
+        t = type.template_argument(0)
+        type_name = handler_class_for_type(t).prettyprint_type(t)
+        return f'Jakt::Array<{type_name}>'
+
+class JaktArrayStorage:
+    def __init__(self, val):
+        self.val = val
+        self.storage_type = self.val.type.template_argument(0)
+
+    def to_string(self):
+        return JaktArrayStorage.prettyprint_type(self.val.type)
+
+    def children(self):
+        array_type = self.storage_type.array(self.val["m_length"])
+        return get_field_unalloced(self.val, "m_elements", array_type)
+
+    @classmethod
+    def prettyprint_type(cls, type):
+        t = type.template_argument(0)
+        type_name = handler_class_for_type(t).prettyprint_type(t)
+        return f'Jakt::ArrayStorage<{type_name}>'
+
+
+class JaktPrettyPrinterLocator(gdb.printing.PrettyPrinter):
+    def __init__(self):
+        super(JaktPrettyPrinterLocator, self).__init__("jakt_pretty_printers", [])
+
+    def __call__(self, val):
+        type = gdb.types.get_basic_type(val.type)
+        handler = handler_class_for_type(type)
+        if handler is UnhandledType:
+            return None
+        return handler(val)
+
+
+gdb.printing.register_pretty_printer(None, JaktPrettyPrinterLocator(), replace=True)

--- a/selfhost/codegen.jakt
+++ b/selfhost/codegen.jakt
@@ -2440,7 +2440,7 @@ struct CodeGenerator {
         RawPtr(type_id) => .codegen_type(type_id) + "*"
         Reference(type_id) => .codegen_type(type_id) + " const&"
         MutableReference(type_id) => .codegen_type(type_id) + "&"
-        GenericInstance(id, args) => .codegen_generic_type_instance(id, args, as_namespace)
+        GenericResolvedType(id, args) | GenericInstance(id, args) => .codegen_generic_type_instance(id, args, as_namespace)
         Struct(id) => .codegen_struct_type(id, as_namespace)
         Enum(id) => .codegen_enum_type(id, as_namespace)
         GenericEnumInstance(id, args) => .codegen_generic_enum_instance(id, args, as_namespace)

--- a/selfhost/codegen.jakt
+++ b/selfhost/codegen.jakt
@@ -2038,89 +2038,94 @@ struct CodeGenerator {
                 output += ")"
             }
             else => {
-                let function_id = call.function_id!
-                let function_ = .program.get_function(function_id)
-                let type_module = .program.get_module(function_id.module)
-                if function_.type is ImplicitConstructor or function_.type is ExternalClassConstructor {
-                    let type_id = call.return_type
-                    let type = .program.get_type(type_id)
+                if call.function_id.has_value() {
+                    let function_id = call.function_id!
+                    let function_ = .program.get_function(function_id)
                     let type_module = .program.get_module(function_id.module)
-                    if not (type_module.is_root or type_module.id.equals(ModuleId(id: 0))) {
-                        output += type_module.name
-                        output += "::"
-                    }
-                    output += .codegen_namespace_path(call)
-                    match type {
-                        Struct(struct_id) => {
-                            let struct_ = .program.get_struct(struct_id)
-                            if struct_.record_type is Class {
-                                output += call.name
-                                output += "::"
-                                output += "create"
-                            } else {
-                                output += call.name
-                            }
+                    if function_.type is ImplicitConstructor or function_.type is ExternalClassConstructor {
+                        let type_id = call.return_type
+                        let type = .program.get_type(type_id)
+                        let type_module = .program.get_module(function_id.module)
+                        if not (type_module.is_root or type_module.id.equals(ModuleId(id: 0))) {
+                            output += type_module.name
+                            output += "::"
                         }
-                        GenericInstance(id, args) => {
-                            let struct_ = .program.get_struct(id)
-                            if struct_.record_type is Class {
-                                output += .codegen_namespace_qualifier(scope_id: struct_.scope_id)
-                                output += struct_.name
-                                output += "<"
-                                mut first = true
-                                for arg in args.iterator() {
-                                    if not first {
-                                        output += ", "
-                                    } else {
-                                        first = false
-                                    }
-                                    output += .codegen_type(arg)
-                                }
-                                output += ">::create"
-                            } else {
-                                output += call.name
-                            }
-                        }
-                        else => {
-                            panic("Should be unreachable")
-                        }
-                    }
-                } else if function_.type is ImplicitEnumConstructor {
-                    match .program.get_type(function_.return_type_id) {
-                        Enum(enum_id) => {
-                            let enum_ = .program.get_enum(enum_id)
-                            let enum_type_module = .program.get_module(enum_id.module)
-                            if enum_.is_boxed {
-                                let type_module = .program.get_module(function_id.module)
-                                if not (type_module.is_root or type_module.id.equals(ModuleId(id: 0))) {
-                                    output += type_module.name
+                        output += .codegen_namespace_path(call)
+                        match type {
+                            Struct(struct_id) => {
+                                let struct_ = .program.get_struct(struct_id)
+                                if struct_.record_type is Class {
+                                    output += call.name
                                     output += "::"
+                                    output += "create"
+                                } else {
+                                    output += call.name
                                 }
-
-                                output += .codegen_namespace_path(call)
-                                output += "template create<typename "
-                                output += .codegen_type_possibly_as_namespace(type_id: call.return_type, as_namespace: true)
-                                output += "::" + call.name + ">"
-                            } else {
-                                output += "typename "
-                                output += .codegen_type(call.return_type)
-                                output += "::"
-                                output += call.name
+                            }
+                            GenericInstance(id, args) => {
+                                let struct_ = .program.get_struct(id)
+                                if struct_.record_type is Class {
+                                    output += .codegen_namespace_qualifier(scope_id: struct_.scope_id)
+                                    output += struct_.name
+                                    output += "<"
+                                    mut first = true
+                                    for arg in args.iterator() {
+                                        if not first {
+                                            output += ", "
+                                        } else {
+                                            first = false
+                                        }
+                                        output += .codegen_type(arg)
+                                    }
+                                    output += ">::create"
+                                } else {
+                                    output += call.name
+                                }
+                            }
+                            else => {
+                                panic("Should be unreachable")
                             }
                         }
-                        GenericEnumInstance(id) => {
-                            todo("codegen generic enum instance")
+                    } else if function_.type is ImplicitEnumConstructor {
+                        match .program.get_type(function_.return_type_id) {
+                            Enum(enum_id) => {
+                                let enum_ = .program.get_enum(enum_id)
+                                let enum_type_module = .program.get_module(enum_id.module)
+                                if enum_.is_boxed {
+                                    let type_module = .program.get_module(function_id.module)
+                                    if not (type_module.is_root or type_module.id.equals(ModuleId(id: 0))) {
+                                        output += type_module.name
+                                        output += "::"
+                                    }
+
+                                    output += .codegen_namespace_path(call)
+                                    output += "template create<typename "
+                                    output += .codegen_type_possibly_as_namespace(type_id: call.return_type, as_namespace: true)
+                                    output += "::" + call.name + ">"
+                                } else {
+                                    output += "typename "
+                                    output += .codegen_type(call.return_type)
+                                    output += "::"
+                                    output += call.name
+                                }
+                            }
+                            GenericEnumInstance(id) => {
+                                todo("codegen generic enum instance")
+                            }
+                            else => {
+                                panic("constructor expected enum type")
+                            }
                         }
-                        else => {
-                            panic("constructor expected enum type")
+                    } else {
+                        if not (type_module.is_root or type_module.id.id == 0 or function_.linkage is External or (not call.namespace_.is_empty() and call.namespace_[0].name == type_module.name))
+                        {
+                            output += type_module.name
+                            output += "::"
                         }
+                        output += .codegen_namespace_path(call)
+                        output += call.name
                     }
                 } else {
-                    if not (type_module.is_root or type_module.id.id == 0 or function_.linkage is External or (not call.namespace_.is_empty() and call.namespace_[0].name == type_module.name))
-                    {
-                        output += type_module.name
-                        output += "::"
-                    }
                     output += .codegen_namespace_path(call)
                     output += call.name
                 }

--- a/selfhost/codegen.jakt
+++ b/selfhost/codegen.jakt
@@ -2135,7 +2135,7 @@ struct CodeGenerator {
                 if not generic_parameters.is_empty() {
                     mut types: [String] = []
                     for gen_param in generic_parameters.iterator() {
-                        types.push(.codegen_type_possibly_as_namespace(type_id: gen_param, as_namespace: true))
+                        types.push(.codegen_type_possibly_as_namespace(type_id: gen_param, as_namespace: false))
                     }
                     output += format("<{}>", join(types, separator: ", "))
                 }

--- a/selfhost/parser.jakt
+++ b/selfhost/parser.jakt
@@ -1674,13 +1674,22 @@ struct Parser {
             .index++
             mut parsed_type =  ParsedType::Name(name, span)
             if .current() is LessThan {
-                mut parsed_generics = .parse_generic_parameters()
-                // FIXME: clean this up when ParsedType::GenericType can have [[String:Span]] generic parameters
-                mut generic_parameters: [ParsedType] = []
-                for parsed_generic in parsed_generics.iterator() {
-                    generic_parameters.push(ParsedType::Name(name: parsed_generic.name, span: parsed_generic.span))
+                mut params: [ParsedType] = []
+                if .current() is LessThan {
+                    .index++
+                    while not .current() is GreaterThan and not .eof() {
+                        params.push(.parse_typename())
+                        if .current() is Comma {
+                            .index++
+                        }
+                    }
+                    if .current() is GreaterThan {
+                        .index++
+                    } else {
+                        .error("Expected `>` after type parameters", .current().span())
+                    }
                 }
-                parsed_type = ParsedType::GenericType(name, generic_parameters, span)
+                parsed_type = ParsedType::GenericType(name, generic_parameters: params, span)
             }
 
             if .current() is ColonColon {

--- a/selfhost/typechecker.jakt
+++ b/selfhost/typechecker.jakt
@@ -1604,6 +1604,7 @@ struct Typechecker {
             Dereference => .get_type(expression_type(expr)) is MutableReference
             else => false
         }
+        MethodCall(expr) => .expression_is_mutable(expr)
         else => false
     }
 


### PR DESCRIPTION
Before in gdb:

<details>
<summary>Open for horror story</summary>

```
(gdb) p/r *(Jakt::parser::ParsedType*)parsed_type.m_ptr
$3 = {
  <Jakt::Variant<Jakt::parser::ParsedType_Details::Name, Jakt::parser::ParsedType_Details::NamespacedName, Jakt::parser::ParsedType_Details::GenericType, Jakt::parser::ParsedType_Details::JaktArray, Jakt::parser::ParsedType_Details::Dictionary, Jakt::parser::ParsedType_Details::JaktTuple, Jakt::parser::ParsedType_Details::Set, Jakt::parser::ParsedType_Details::Optional, Jakt::parser::ParsedType_Details::Reference, Jakt::parser::ParsedType_Details::MutableReference, Jakt::parser::ParsedType_Details::RawPtr, Jakt::parser::ParsedType_Details::WeakPtr, Jakt::parser::ParsedType_Details::Empty>> = {
    <Jakt::Detail::VariantConstructors<Jakt::parser::ParsedType_Details::Name, Jakt::Variant<Jakt::parser::ParsedType_Details::Name, Jakt::parser::ParsedType_Details::NamespacedName, Jakt::parser::ParsedType_Details::GenericType, Jakt::parser::ParsedType_Details::JaktArray, Jakt::parser::ParsedType_Details::Dictionary, Jakt::parser::ParsedType_Details::JaktTuple, Jakt::parser::ParsedType_Details::Set, Jakt::parser::ParsedType_Details::Optional, Jakt::parser::ParsedType_Details::Reference, Jakt::parser::ParsedType_Details::MutableReference, Jakt::parser::ParsedType_Details::RawPtr, Jakt::parser::ParsedType_Details::WeakPtr, Jakt::parser::ParsedType_Details::Empty> >> = {<No data fields>}, 
    <Jakt::Detail::VariantConstructors<Jakt::parser::ParsedType_Details::NamespacedName, Jakt::Variant<Jakt::parser::ParsedType_Details::Name, Jakt::parser::ParsedType_Details::NamespacedName, Jakt::parser::ParsedType_Details::GenericType, Jakt::parser::ParsedType_Details::JaktArray, Jakt::parser::ParsedType_Details::Dictionary, Jakt::parser::ParsedType_Details::JaktTuple, Jakt::parser::ParsedType_Details::Set, Jakt::parser::ParsedType_Details::Optional, Jakt::parser::ParsedType_Details::Reference, Jakt::parser::ParsedType_Details::MutableReference, Jakt::parser::ParsedType_Details::RawPtr, Jakt::parser::ParsedType_Details::WeakPtr, Jakt::parser::ParsedType_Details::Empty> >> = {<No data fields>}, 
    <Jakt::Detail::VariantConstructors<Jakt::parser::ParsedType_Details::GenericType, Jakt::Variant<Jakt::parser::ParsedType_Details::Name, Jakt::parser::ParsedType_Details::NamespacedName, Jakt::parser::ParsedType_Details::GenericType, Jakt::parser::ParsedType_Details::JaktArray, Jakt::parser::ParsedType_Details::Dictionary, Jakt::parser::ParsedType_Details::JaktTuple, Jakt::parser::ParsedType_Details::Set, Jakt::parser::ParsedType_Details::Optional, Jakt::parser::ParsedType_Details::Reference, Jakt::parser::ParsedType_Details::MutableReference, Jakt::parser::ParsedType_Details::RawPtr, Jakt::parser::ParsedType_Details::WeakPtr, Jakt::parser::ParsedType_Details::Empty> >> = {<No data fields>}, 
    <Jakt::Detail::VariantConstructors<Jakt::parser::ParsedType_Details::JaktArray, Jakt::Variant<Jakt::parser::ParsedType_Details::Name, Jakt::parser::ParsedType_Details::NamespacedName, Jakt::parser::ParsedType_Details::GenericType, Jakt::parser::ParsedType_Details::JaktArray, Jakt::parser::ParsedType_Details::Dictionary, Jakt::parser::ParsedType_Details::JaktTuple, Jakt::parser::ParsedType_Details::Set, Jakt::parser::ParsedType_Details::Optional, Jakt::parser::ParsedType_Details::Reference, Jakt::parser::ParsedType_Details::MutableReference, Jakt::parser::ParsedType_Details::RawPtr, Jakt::parser::ParsedType_Details::WeakPtr, Jakt::parser::ParsedType_Details::Empty> >> = {<No data fields>}, 
    <Jakt::Detail::VariantConstructors<Jakt::parser::ParsedType_Details::Dictionary, Jakt::Variant<Jakt::parser::ParsedType_Details::Name, Jakt::parser::ParsedType_Details::NamespacedName, Jakt::parser::ParsedType_Details::GenericType, Jakt::parser::ParsedType_Details::JaktArray, Jakt::parser::ParsedType_Details::Dictionary, Jakt::parser::ParsedType_Details::JaktTuple, Jakt::parser::ParsedType_Details::Set, Jakt::parser::ParsedType_Details::Optional, Jakt::parser::ParsedType_Details::Reference, Jakt::parser::ParsedType_Details::MutableReference, Jakt::parser::ParsedType_Details::RawPtr, Jakt::parser::ParsedType_Details::WeakPtr, Jakt::parser::ParsedType_Details::Empty> >> = {<No data fields>}, 
    <Jakt::Detail::VariantConstructors<Jakt::parser::ParsedType_Details::JaktTuple, Jakt::Variant<Jakt::parser::ParsedType_Details::Name, Jakt::parser::ParsedType_Details::NamespacedName, Jakt::parser::ParsedType_Details::GenericType, Jakt::parser::ParsedType_Details::JaktArray, Jakt::parser::ParsedType_Details::Dictionary, Jakt::parser::ParsedType_Details::JaktTuple, Jakt::parser::ParsedType_Details::Set, Jakt::parser::ParsedType_Details::Optional, Jakt::parser::ParsedType_Details::Reference, Jakt::parser::ParsedType_Details::MutableReference, Jakt::parser::ParsedType_Details::RawPtr, Jakt::parser::ParsedType_Details::WeakPtr, Jakt::parser::ParsedType_Details::Empty> >> = {<No data fields>}, 
    <Jakt::Detail::VariantConstructors<Jakt::parser::ParsedType_Details::Set, Jakt::Variant<Jakt::parser::ParsedType_Details::Name, Jakt::parser::ParsedType_Details::NamespacedName, Jakt::parser::ParsedType_Details::GenericType, Jakt::parser::ParsedType_Details::JaktArray, Jakt::parser::ParsedType_Details::Dictionary, Jakt::parser::ParsedType_Details::JaktTuple, Jakt::parser::ParsedType_Details::Set, Jakt::parser::ParsedType_Details::Optional, Jakt::parser::ParsedType_Details::Reference, Jakt::parser::ParsedType_Details::MutableReference, Jakt::parser::ParsedType_Details::RawPtr, Jakt::parser::ParsedType_Details::WeakPtr, Jakt::parser::ParsedType_Details::Empty> >> = {<No data fields>}, 
    <Jakt::Detail::VariantConstructors<Jakt::parser::ParsedType_Details::Optional, Jakt::Variant<Jakt::parser::ParsedType_Details::Name, Jakt::parser::ParsedType_Details::NamespacedName, Jakt::parser::ParsedType_Details::GenericType, Jakt::parser::ParsedType_Details::JaktArray, Jakt::parser::ParsedType_Details::Dictionary, Jakt::parser::ParsedType_Details::JaktTuple, Jakt::parser::ParsedType_Details::Set, Jakt::parser::ParsedType_Details::Optional, Jakt::parser::ParsedType_Details::Reference, Jakt::parser::ParsedType_Details::MutableReference, Jakt::parser::ParsedType_Details::RawPtr, Jakt::parser::ParsedType_Details::WeakPtr, Jakt::parser::ParsedType_Details::Empty> >> = {<No data fields>}, 
    <Jakt::Detail::VariantConstructors<Jakt::parser::ParsedType_Details::Reference, Jakt::Variant<Jakt::parser::ParsedType_Details::Name, Jakt::parser::ParsedType_Details::NamespacedName, Jakt::parser::ParsedType_Details::GenericType, Jakt::parser::ParsedType_Details::JaktArray, Jakt::parser::ParsedType_Details::Dictionary, Jakt::parser::ParsedType_Details::JaktTuple, Jakt::parser::ParsedType_Details::Set, Jakt::parser::ParsedType_Details::Optional, Jakt::parser::ParsedType_Details::Reference, Jakt::parser::ParsedType_Details::MutableReference, Jakt::parser::ParsedType_Details::RawPtr, Jakt::parser::ParsedType_Details::WeakPtr, Jakt::parser::ParsedType_Details::Empty> >> = {<No data fields>}, 
    <Jakt::Detail::VariantConstructors<Jakt::parser::ParsedType_Details::MutableReference, Jakt::Variant<Jakt::parser::ParsedType_Details::Name, Jakt::parser::ParsedType_Details::NamespacedName, Jakt::parser::ParsedType_Details::GenericType, Jakt::parser::ParsedType_Details::JaktArray, Jakt::parser::ParsedType_Details::Dictionary, Jakt::parser::ParsedType_Details::JaktTuple, Jakt::parser::ParsedType_Details::Set, Jakt::parser::ParsedType_Details::Optional, Jakt::parser::ParsedType_Details::Reference, Jakt::parser::ParsedType_Details::MutableReference, Jakt::parser::ParsedType_Details::RawPtr, Jakt::parser::ParsedType_Details::WeakPtr, Jakt::parser::ParsedType_Details::Empty> >> = {<No data fields>}, 
    <Jakt::Detail::VariantConstructors<Jakt::parser::ParsedType_Details::RawPtr, Jakt::Variant<Jakt::parser::ParsedType_Details::Name, Jakt::parser::ParsedType_Details::NamespacedName, Jakt::parser::ParsedType_Details::GenericType, Jakt::parser::ParsedType_Details::JaktArray, Jakt::parser::ParsedType_Details::Dictionary, Jakt::parser::ParsedType_Details::JaktTuple, Jakt::parser::ParsedType_Details::Set, Jakt::parser::ParsedType_Details::Optional, Jakt::parser::ParsedType_Details::Reference, Jakt::parser::ParsedType_Details::MutableReference, Jakt::parser::ParsedType_Details::RawPtr, Jakt::parser::ParsedType_Details::WeakPtr, Jakt::parser::ParsedType_Details::Empty> >> = {<No data fields>}, 
    <Jakt::Detail::VariantConstructors<Jakt::parser::ParsedType_Details::WeakPtr, Jakt::Variant<Jakt::parser::ParsedType_Details::Name, Jakt::parser::ParsedType_Details::NamespacedName, Jakt::parser::ParsedType_Details::GenericType, Jakt::parser::ParsedType_Details::JaktArray, Jakt::parser::ParsedType_Details::Dictionary, Jakt::parser::ParsedType_Details::JaktTuple, Jakt::parser::ParsedType_Details::Set, Jakt::parser::ParsedType_Details::Optional, Jakt::parser::ParsedType_Details::Reference, Jakt::parser::ParsedType_Details::MutableReference, Jakt::parser::ParsedType_Details::RawPtr, Jakt::parser::ParsedType_Details::WeakPtr, Jakt::parser::ParsedType_Details::Empty> >> = {<No data fields>}, 
    <Jakt::Detail::VariantConstructors<Jakt::parser::ParsedType_Details::Empty, Jakt::Variant<Jakt::parser::ParsedType_Details::Name, Jakt::parser::ParsedType_Details::NamespacedName, Jakt::parser::ParsedType_Details::GenericType, Jakt::parser::ParsedType_Details::JaktArray, Jakt::parser::ParsedType_Details::Dictionary, Jakt::parser::ParsedType_Details::JaktTuple, Jakt::parser::ParsedType_Details::Set, Jakt::parser::ParsedType_Details::Optional, Jakt::parser::ParsedType_Details::Reference, Jakt::parser::ParsedType_Details::MutableReference, Jakt::parser::ParsedType_Details::RawPtr, Jakt::parser::ParsedType_Details::WeakPtr, Jakt::parser::ParsedType_Details::Empty> >> = {<No data fields>}, 
    members of Jakt::Variant<Jakt::parser::ParsedType_Details::Name, Jakt::parser::ParsedType_Details::NamespacedName, Jakt::parser::ParsedType_Details::GenericType, Jakt::parser::ParsedType_Details::JaktArray, Jakt::parser::ParsedType_Details::Dictionary, Jakt::parser::ParsedType_Details::JaktTuple, Jakt::parser::ParsedType_Details::Set, Jakt::parser::ParsedType_Details::Optional, Jakt::parser::ParsedType_Details::Reference, Jakt::parser::ParsedType_Details::MutableReference, Jakt::parser::ParsedType_Details::RawPtr, Jakt::parser::ParsedType_Details::WeakPtr, Jakt::parser::ParsedType_Details::Empty>:
    static invalid_index = 13 '\r',
    static data_size = 48,
    static data_alignment = 8,
    m_data = "\000.\317UUU\000\000 /\317UUU\000\000\003\000\000\000\000\000\000\000\355\001\000\000\000\000\000\000\370\001", '\000' <repeats 13 times>,
    m_index = 4 '\004'
  }, 
--Type <RET> for more, q to quit, c to continue without paging--
  <Jakt::RefCounted<Jakt::parser::ParsedType>> = {
    <Jakt::RefCountedBase> = {
      m_ref_count = 3
    }, <No data fields>}, <No data fields>}
```

</details>

After:
```
(gdb) p *(Jakt::parser::ParsedType*)parsed_type.m_ptr
$2 = {
  <Jakt::Variant<Jakt::parser::ParsedType_Details::Name, Jakt::parser::ParsedType_Details::NamespacedName, Jakt::parser::ParsedType_Details::GenericType, Jakt::parser::ParsedType_Details::JaktArray, Jakt::parser::ParsedType_Details::Dictionary, Jakt::parser::ParsedType_Details::JaktTuple, Jakt::parser::ParsedType_Details::Set, Jakt::parser::ParsedType_Details::Optional, Jakt::parser::ParsedType_Details::Reference, Jakt::parser::ParsedType_Details::MutableReference, Jakt::parser::ParsedType_Details::RawPtr, Jakt::parser::ParsedType_Details::WeakPtr, Jakt::parser::ParsedType_Details::Empty>> = Jakt::Variant<ParsedType::Name, ParsedType::NamespacedName, ParsedType::GenericType, ParsedType::JaktArray, ParsedType::Dictionary, ParsedType::JaktTuple, ParsedType::Set, ParsedType::Optional, ParsedType::Reference, ParsedType::MutableReference, ParsedType::RawPtr, ParsedType::WeakPtr, ParsedType::Empty> = {
    Jakt::parser::ParsedType_Details::Dictionary = {
      key = Jakt::RefPtr<Jakt::parser::ParsedType> = {
        * = 0x555555cf2e00
      },
      value = Jakt::RefPtr<Jakt::parser::ParsedType> = {
        * = 0x555555cf2f20
      },
      span = {
        file_id = {
          id = 3
        },
        start = 493,
        end = 504
      }
    }
  }, 
  <Jakt::RefCounted<Jakt::parser::ParsedType>> = 3, <No data fields>}
```
(I can't convince gdb to stop showing the `<Jakt::Variant<Jakt::parser::ParsedType_Details::Name, Jakt::parser::ParsedType_Details::NamespacedName, Jakt::parser::ParsedType_Details::GenericType, Jakt::parser::ParsedType_Details::JaktArray, Jakt::parser::ParsedType_Details::Dictionary, Jakt::parser::ParsedType_Details::JaktTuple, Jakt::parser::ParsedType_Details::Set, Jakt::parser::ParsedType_Details::Optional, Jakt::parser::ParsedType_Details::Reference, Jakt::parser::ParsedType_Details::MutableReference, Jakt::parser::ParsedType_Details::RawPtr, Jakt::parser::ParsedType_Details::WeakPtr, Jakt::parser::ParsedType_Details::Empty>>` at the beginning, maybe someone more familiar with it can do so)