### PR TITLE
selfhost: Bunch of fixes to the IDE integration

### DIFF
--- a/selfhost/compiler.jakt
+++ b/selfhost/compiler.jakt
@@ -1,4 +1,5 @@
 import error { JaktError, print_error, print_error_json }
+import prelude { JaktPrelude }
 import utility
 import utility { FilePath, FileId }
 
@@ -121,5 +122,12 @@ class Compiler {
         if .debug_print {
             println("{}", message)
         }
+    }
+
+    public function load_prelude(mut this) throws {
+        let module_name = "__prelude__"
+        let file_name = FilePath::make(module_name)
+        let file_contents = JaktPrelude::to_bytes()
+        .get_file_id_or_register(file_name)
     }
 }

--- a/selfhost/error.jakt
+++ b/selfhost/error.jakt
@@ -56,7 +56,7 @@ enum MessageSeverity {
 
 function display_message_with_span_json(anon severity: MessageSeverity, file_name: String, file_contents: [u8], message: String, span: Span) throws
 {
-    println("{{\"type\":\"diagnostics\",\"message\":\"{}\",\"severity\":\"{}\",\"file_id\":{},\"span\":{{\"start\":{},\"end\":{}}}}}"
+    println("{{\"type\":\"diagnostic\",\"message\":\"{}\",\"severity\":\"{}\",\"file_id\":{},\"span\":{{\"start\":{},\"end\":{}}}}}"
         message, severity.name(), span.file_id.id, span.start, span.end)
 }
 

--- a/selfhost/main.jakt
+++ b/selfhost/main.jakt
@@ -144,6 +144,8 @@ function main(args: [String]) {
         dump_try_hints
     )
 
+    compiler.load_prelude()
+
     let main_file_id = compiler.get_file_id_or_register(file_path)
     let file_is_set = compiler.set_current_file(main_file_id)
     if not file_is_set {

--- a/selfhost/parser.jakt
+++ b/selfhost/parser.jakt
@@ -1844,19 +1844,17 @@ struct Parser {
         match .current() {
             Identifier(name) => {
                 let var_name = name
-                mut inlay_span: Span? = None
                 let decl_span = .current().span()
 
                 .index++
                 if .current() is Colon {
                     .index++
-                    inlay_span = .current().span()
                 } else {
                     return ParsedVarDecl(
                         name: var_name,
                         parsed_type: ParsedType::Empty,
                         is_mutable,
-                        inlay_span: None
+                        inlay_span: decl_span
                         span: decl_span
                     )
                 }
@@ -1870,7 +1868,7 @@ struct Parser {
                     name: var_name,
                     parsed_type: var_type,
                     is_mutable,
-                    inlay_span,
+                    inlay_span: None,
                     span: decl_span,
                 )
             }

--- a/selfhost/typechecker.jakt
+++ b/selfhost/typechecker.jakt
@@ -1322,12 +1322,12 @@ struct Typechecker {
 
     function dump_type_hint(this, type_id: TypeId, span: Span) throws {
         println("{{\"type\":\"hint\",\"file_id\":{},\"position\":{},\"typename\":\"{}\"}}"
-                span.file_id, span.end, .type_name(type_id))
+                span.file_id.id, span.end, .type_name(type_id))
     }
 
-    function dump_try_hint(this, span: Span) throws {
+    function dump_try_hint( this, span: Span) throws {
         println("{{\"type\":\"try\",\"file_id\":{},\"position\":{}}}"
-                span.file_id, span.start)
+                span.file_id.id, span.start)
     }
 
     function typecheck(mut compiler: Compiler, parsed_namespace: ParsedNamespace) throws -> CheckedProgram {


### PR DESCRIPTION
With these fixes, we can now show diagnostics, type hints, and try hints when using selfhost as the backend for the IDE extension.

There are still some little issues to figure out, but this is a huge step towards usability.