### PR TITLE
fix: function parameter and argument separator parsing

### DIFF
--- a/samples/functions/argument_separation.jakt
+++ b/samples/functions/argument_separation.jakt
@@ -1,0 +1,19 @@
+/// Expect:
+/// - output: "13\n13\n11\n"
+
+function add(x: i64, y: i64) {
+    println("{}", x + y)
+}
+
+function main() {
+    add(
+        x: 10
+        y: 3
+    )
+    add(
+        x: 10
+
+        y: 3
+    )
+    add(x: 5, y: 6)
+}

--- a/samples/functions/argument_wrong_separation.jakt
+++ b/samples/functions/argument_wrong_separation.jakt
@@ -1,0 +1,10 @@
+/// Expect:
+/// - error: "Expected comma or newline before"
+
+function add(x: i64, y: i64) {
+    println("{}", x + y)
+}
+
+function main() {
+    add(x: 10 y: 3)
+}

--- a/samples/functions/parameters_separation_comma_newline.jakt
+++ b/samples/functions/parameters_separation_comma_newline.jakt
@@ -1,0 +1,27 @@
+/// Expect:
+/// - output: "7\n13\n30"
+
+function subtract(
+    x: i64,
+    y: i64
+) {
+    println("{}", x - y)
+}
+
+function add(x: i64, y: i64) {
+    println("{}", x + y)
+}
+
+function multiply(
+    x: i64
+
+    y: i64
+) {
+    println("{}", x * y)
+}
+
+function main() {
+    subtract(x: 10, y: 3)
+    add(x: 10, y: 3)
+    multiply(x: 10, y: 3)
+}

--- a/samples/functions/parameters_wrong_separation.jakt
+++ b/samples/functions/parameters_wrong_separation.jakt
@@ -1,0 +1,10 @@
+/// Expect:
+/// - error: "Expected comma or newline before"
+
+function subtract(x: i64 y: i64) {
+    println("{}", x - y)
+}
+
+function main() {
+    subtract(x: 10, y: 3)
+}

--- a/selfhost/parser.jakt
+++ b/selfhost/parser.jakt
@@ -1430,6 +1430,9 @@ struct Parser {
         match .current() {
             LParen => {
                 .index++
+                if .current() is Eol {
+                    .index++
+                }
             }
             else => {
                 .error("Expected '('", .current().span())
@@ -1449,7 +1452,7 @@ struct Parser {
                     .index++
                     break
                 }
-                Comma => {
+                Comma | Eol => {
                     if not parameter_complete and not error {
                         .error("Expected parameter", .current().span())
                         error = true
@@ -1458,6 +1461,10 @@ struct Parser {
                     current_param_requires_label = true
                     current_param_is_mutable = false
                     parameter_complete = false
+
+                    if .current() is Eol {
+                        .index++
+                    }
                 }
                 Anon => {
                     if parameter_complete and not error  {
@@ -1502,6 +1509,11 @@ struct Parser {
                     parameter_complete = true
                 }
                 Identifier(name, span) => {
+                    if parameter_complete and not error {
+                        .error_with_hint("Expected comma or newline before", .current().span(), "Consider adding a comma or newline after this", .previous().span())
+                        error = true
+                    }
+
                     let var_decl = .parse_variable_declaration(is_mutable: current_param_is_mutable)
 
                     params.push(ParsedParameter(

--- a/selfhost/parser.jakt
+++ b/selfhost/parser.jakt
@@ -3098,11 +3098,16 @@ struct Parser {
 
                 if .current() is LParen {
                     .index++
+                    if .current() is Eol {
+                        .index++
+                    }
                 } else {
                     .index = index_reset
                     .error("Expected '('", .current().span())
                     return None
                 }
+
+                mut argument_complete = false
 
                 while  not .eof() {
                     match .current() {
@@ -3111,15 +3116,27 @@ struct Parser {
                             break
                         }
                         Eol | Comma => {
+                            if not argument_complete {
+                                .error("Expected argument", .current().span())
+                            }
                             .index++
+                            argument_complete = false
+
+                            if .current() is Eol {
+                                .index++
+                            }
                         }
                         else => {
+                            if argument_complete {
+                                .error_with_hint("Expected comma or newline before", .current().span(), "Consider adding a comma or newline after this", .previous().span())
+                            }
+
                             let label_span = .current().span()
                             let label = .parse_argument_label()
 
                             let expr = .parse_expression(allow_assignments: false)
-
                             call.args.push((label, label_span, expr))
+                            argument_complete = true
                         }
                     }
                 }


### PR DESCRIPTION
- Fix parsing of parameters and argument separator parsing by restricting usage to comma and new line
- Should close https://github.com/SerenityOS/jakt/issues/966
- Would like to hear points on:
https://github.com/feniljain/jakt/blob/f3bc872739fb3a165bd5c30ae0c8d062e6e9af1b/selfhost/parser.jakt#L1465-L1472

I have tried to add appropriate testcases, if you feel something's wrong, do point out!