### PR TITLE
build: Be sure to build stage1 compiler with bootstrap

### DIFF
--- a/build.ninja
+++ b/build.ninja
@@ -8,6 +8,9 @@ cxxflags = -fcolor-diagnostics -std=c++20 -Wno-user-defined-literals -Wno-deprec
 rule cxx
     command = clang++ $cxxflags -o $out -I ./bootstrap/stage0/runtime $in
 
+rule stage0
+    command = ./build/stage0 -b -o jakt $in
+
 rule mkdir
     command = mkdir $out
 
@@ -15,5 +18,6 @@ rule mkdir
 build build: mkdir
 # NOTE: pipe `|` is for implicit dependencies, so that ninja considers the target outdated if any
 # of those have changed, even if it's not stated as an input.
-build build/jakt: cxx ./bootstrap/stage0/jakt.cpp
+build build/stage0: cxx ./bootstrap/stage0/jakt.cpp
+build build/jakt: stage0 ./selfhost/main.jakt | build/stage0
 default build/jakt


### PR DESCRIPTION
This renames the bootstrap's output to `build/stage0` and then uses stage0 to build `build/jakt` which is the bootstrapped build of the real jakt compiler.

From here, we can test using `build/jakt` and we should be running the tests against the latest compiler.