### PR TITLE
editors/vscode: Highlight modulo operator

### DIFF
--- a/editors/vscode/syntaxes/jakt.tmLanguage.json
+++ b/editors/vscode/syntaxes/jakt.tmLanguage.json
@@ -793,7 +793,7 @@
         },
         {
           "name": "keyword.operator.arithmetic.jakt",
-          "match": "(\\+|\\-|\\*|\\/|\\^|\\~)(=)?"
+          "match": "(\\+|\\-|\\*|\\/|\\^|\\~|\\%)(=)?"
         },
         {
           "name": "keyword.operator.comparison.jakt",


### PR DESCRIPTION
“Without highlighted modulo, life would be a mistake.”
― Friedrich Nietzsche