### PR TITLE
editors: Add README for CLion plugin so it's easier to find

### DIFF
--- a/editors/clion-or-jetbrains-ides/README.md
+++ b/editors/clion-or-jetbrains-ides/README.md
@@ -1,0 +1,13 @@
+# Jakt plugin for CLion and other Jetbrains IDEs
+
+This plugin provides syntax highlighting, autocomplete, type inlays and other things you would expect from an IDE.
+It should be compatible with all the IntelliJ-based IDEs, but for simplicity we refer to CLion here.
+
+The source code is contained in a separate repo here: https://github.com/mattco98/jakt-intellij-plugin
+
+## Installation
+
+This is a packaged plugin available on the [Jetbrains Marketplace](https://plugins.jetbrains.com/plugin/19462-jakt).
+You can either click that link and install it from there, or install it from inside CLion itself:
+`File > Settings… > Plugins`, choose the "Marketplace" tab, and search for "Jakt".
+CLion will periodically check for plugin updates automatically.


### PR DESCRIPTION
This plugin is not contained in the Jakt repo, so let's make it easier
to find.