### PR TITLE
parser: Allow newlines in certain situations

### DIFF
--- a/selfhost/parser.jakt
+++ b/selfhost/parser.jakt
@@ -1184,6 +1184,8 @@ struct Parser {
             underlying_type = .parse_typename()
         }
 
+        .skip_newlines()
+
         if .eof() {
             .error("Incomplete enum definition, expected body", .current().span())
             return parsed_enum
@@ -1347,6 +1349,8 @@ struct Parser {
         // Generic parameters
         parsed_struct.generic_parameters = .parse_generic_parameters()
 
+        .skip_newlines()
+
         if .eof() {
             .error("Incomplete struct definition, expected body", .current().span())
             return parsed_struct
@@ -1412,6 +1416,8 @@ struct Parser {
             .index++
             super_class = .parse_typename()
         }
+
+        .skip_newlines()
 
         if .eof() {
             .error("Incomplete class definition, expected body", .current().span())

--- a/selfhost/parser.jakt
+++ b/selfhost/parser.jakt
@@ -2184,8 +2184,11 @@ struct Parser {
 
         mut else_statement: ParsedStatement? = None
 
+        .skip_newlines()
+
         if .current() is Else {
             .index++
+            .skip_newlines()
             match .current() {
                 If => {
                     // This is an `else if`


### PR DESCRIPTION
Make something like:

```
class Test
{
}
--
enum Test
{
}
--
struct Test
{
}
```

as well as:

```
if something == something_else
{
}
else
{
}
```

valid. Not sure if it is a design decision to not allow that 🤔 