### PR TITLE
selfhost: Show an error if unable to write C++ file

### DIFF
--- a/selfhost/main.jakt
+++ b/selfhost/main.jakt
@@ -262,7 +262,12 @@ function main(args: [String]) {
             output_filename = binary_dir + "/" + basename_without_extension
         }
 
-        write_to_file(data: output, output_filename: cpp_filename)
+        try {
+            write_to_file(data: output, output_filename: cpp_filename)
+        } catch error {
+            eprintln("Could not write file: {} ({})", cpp_filename, error);
+            return error.code();
+        }
 
         if prettify_cpp_source {
             mut command = clang_format_path + " -i " + cpp_filename


### PR DESCRIPTION
Hello friends! I built and ran `jakt` from a different directory and got an error.

```bash
→ cat noop.jakt
function main() {
    return 0;
}
```

**Before**:

```bash
→ cmake -B build
→ cd build && make
→ ./jakt -r ../noop.jakt
Runtime error: Error(code=2)
```

**After:**

```bash
→ cmake -B build
→ cd build && make
→ ./jakt -r ../noop.jakt
Could not write file: build/noop.cpp (Error(code=2))
```

I might try to figure out why it's trying to write to the `build` directory when I'm already in the `build` directory, but now I know I should probably just run it from the source dir. 😄 