### PR TITLE
documentation: Add note about line endings on Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ It currently transpiles to C++.
 
 **NOTE:** The language is under heavy development.
 
+**NOTE** If you're cloning to a Windows PC (not WSL), make sure that your Git client keeps the line endings as `\n`. You can set this as a global config via `git config --global core.autocrlf false`.
+
 ## Usage
 The transpilation to C++ requires `clang`. Make sure you have that installed.
 ```


### PR DESCRIPTION
Cloning the repository to a Windows machine with `core.autocrlf` enabled in your Git client results in compilation errors when attempting to build the stage1 compiler. I updated the README to explicitly mention the requirement to preserve `\n` line endings.