### PR TITLE
selfhost/typechecker: Eval else condition on is op

### DIFF
--- a/samples/enums/is_variant_binding_untyped_variant.jakt
+++ b/samples/enums/is_variant_binding_untyped_variant.jakt
@@ -1,0 +1,16 @@
+/// Expect: selfhost-only
+/// - output: "PASS\n"
+
+enum E {
+    A(x: i64)
+    B
+}
+
+function main() {
+    let e = E::B
+    if e is A(x) and x == 5 {
+        println("FAIL")
+    } else {
+        println("PASS")
+    }
+}

--- a/selfhost/typechecker.jakt
+++ b/selfhost/typechecker.jakt
@@ -4825,7 +4825,6 @@ struct Typechecker {
                         if acc.has_value() {
                             inner_condition = acc!
                             outer_if_stmts.push(ParsedStatement::If(condition: inner_condition, then_block, else_statement, span))
-                            new_else_statement = None
                         } else {
                             for stmt in then_block.stmts.iterator() {
                                 outer_if_stmts.push(stmt)


### PR DESCRIPTION
This fixes a bug uncovered by AK on the following case:

```
enum E {
    A(x: i64)
    B
}

function main() {
    let e = E::B
    if e is A(x) and x == 5 {
        println("FAIL")
    } else {
        println("PASS")
    }
}
```

After the fix, the else statement gets evaluated when the
first condition is not true.

This works perfectly but it should be noted that it can
generate some redundant code during the code gen phase.

The redundant code probable gets optimized by llvm but
I will work on a more efficient solution in a later commit