### PR TITLE
codegen+runtime: Fix array slice offsets

### DIFF
--- a/runtime/Builtins/Array.h
+++ b/runtime/Builtins/Array.h
@@ -150,13 +150,14 @@ public:
     ArrayIterator(NonnullRefPtr<Storage> storage, size_t offset, size_t size)
         : m_storage(move(storage))
         , m_index(offset)
+        , m_offset(offset)
         , m_size(size)
     {
     }
 
     Optional<T> next()
     {
-        if (m_index >= m_size) {
+        if (m_index >= (m_offset + m_size)) {
             return {};
         }
         auto current = m_storage->at(m_index);
@@ -166,6 +167,7 @@ public:
 
 private:
     NonnullRefPtr<Storage> m_storage;
+    size_t m_offset { 0 };
     size_t m_index { 0 };
     size_t m_size { 0 };
 };
@@ -186,7 +188,7 @@ public:
         , m_size(size)
     {
         VERIFY(m_storage);
-        VERIFY(m_offset < m_storage->size());
+        VERIFY(m_offset + m_size <= m_storage->size());
     }
 
     ArrayIterator<T> iterator() const
@@ -207,8 +209,8 @@ public:
 
     T const& at(size_t index) const { return m_storage->at(m_offset + index); }
     T& at(size_t index) { return m_storage->at(m_offset + index); }
-    T const& operator[](size_t index) const { return at(m_offset + index); }
-    T& operator[](size_t index) { return at(m_offset + index); }
+    T const& operator[](size_t index) const { return at(index); }
+    T& operator[](size_t index) { return at(index); }
 
     bool contains(T const& value) const
     {
@@ -322,12 +324,12 @@ public:
         return {};
     }
 
-    ArraySlice<T> slice(size_t offset, size_t size) const
+    ArraySlice<T> slice_range(size_t from, size_t to) const
     {
-        return { *m_storage, offset, size };
+        return slice(from, to-from);
     }
 
-    ArraySlice<T> slice(size_t offset, size_t size)
+    ArraySlice<T> slice(size_t offset, size_t size) const
     {
         return { *m_storage, offset, size };
     }

--- a/samples/arrays/slice.jakt
+++ b/samples/arrays/slice.jakt
@@ -1,9 +1,12 @@
 /// Expect:
-/// - output: "slice size: 2\n1\n2\n[1, 2]\nslice first: 1\nslice last: 2\nslice contains 2: true\nslice contains 3: false\narray index 0: 0\nslice index 0: 0\n"
+/// - output: "slice size: 2\n3\n4\n[3, 4]\nslice first: 3\nslice last: 4\nslice contains 4: true\nslice contains 5: false\narray index 0: 1\nslice index 0: 0\n[1, 2, 0, 4]\n"
+
+function start() => 0
+function end() => 4
 
 function main() {
     let x = [1, 2, 3, 4, 5]
-    mut slice = x[0..2]
+    mut slice = x[2..4] 
     
     println("slice size: {}", slice.size())
 
@@ -16,10 +19,12 @@ function main() {
     println("slice first: {}", slice.first())
     println("slice last: {}", slice.last())
 
-    println("slice contains 2: {}", slice.contains(2))
-    println("slice contains 3: {}", slice.contains(3))
+    println("slice contains 4: {}", slice.contains(4))
+    println("slice contains 5: {}", slice.contains(5))
 
     slice[0] = 0
     println("array index 0: {}", x[0])
     println("slice index 0: {}", slice[0])
+ 
+    println("{}", x[start()..end()])
 }

--- a/selfhost/codegen.jakt
+++ b/selfhost/codegen.jakt
@@ -1271,7 +1271,7 @@ struct CodeGenerator {
         }
         IndexedExpression(expr, index) => "((" + .codegen_expression(expr) + ")[" + .codegen_expression(index) + "])"
         IndexedRangeExpression(expr, from, to) => {
-            yield format("(({}).slice({}, {}-{}))", .codegen_expression(expr), .codegen_expression(from), .codegen_expression(to), .codegen_expression(from))
+            yield format("(({}).slice_range({}, {}))", .codegen_expression(expr), .codegen_expression(from), .codegen_expression(to))
         }
         IndexedDictionary(expr, index) => "((" + .codegen_expression(expr) + ")[" + .codegen_expression(index) + "])"
         IndexedTuple(expr, index, is_optional) => match is_optional {


### PR DESCRIPTION
`operator[]` and `at` were both applying the offset for a slice so the
values returned from the slice were incorrect for offsets other than 0

ArrayIterator `next` wasn't accounting for the offset when determining
if the end of the slice had been reached.

Added `slice_range` in `Array` to avoid subtraction underflow.