### PR TITLE
codegen+bootstrap+runtime: Use switch-statements in enum's debug_description + Remove Variant::visit

### DIFF
--- a/bootstrap/stage0/runtime/Jakt/Error.h
+++ b/bootstrap/stage0/runtime/Jakt/Error.h
@@ -41,6 +41,8 @@ private:
 template<typename T, typename ErrorType>
 class [[nodiscard]] ErrorOr final : public Variant<T, ErrorType> {
 public:
+    using ResultType = T;
+
     using Variant<T, ErrorType>::Variant;
 
     template<typename U>
@@ -80,6 +82,8 @@ public:
 template<typename ErrorType>
 class [[nodiscard]] ErrorOr<void, ErrorType> {
 public:
+    using ResultType = void;
+
     ErrorOr(ErrorType error)
         : m_error(move(error))
     {

--- a/bootstrap/stage0/runtime/Jakt/StringBuilder.h
+++ b/bootstrap/stage0/runtime/Jakt/StringBuilder.h
@@ -112,6 +112,27 @@ struct Formatter<JaktInternal::Array<T>> : Formatter<StringView> {
 };
 
 template<typename T>
+struct Formatter<JaktInternal::ArraySlice<T>> : Formatter<StringView> {
+    ErrorOr<void> format(FormatBuilder& builder, JaktInternal::ArraySlice<T> const& value)
+    {
+        if (m_alternative_form)
+            JaktInternal::_pretty_print_enabled = true;
+        auto string_builder = TRY(StringBuilder::create());
+        TRY(string_builder.append("["));
+        JaktInternal::_pretty_print_level++;
+        for (size_t i = 0; i < value.size(); ++i) {
+            TRY(JaktInternal::_output_pretty_indent(string_builder));
+            TRY(append_value(string_builder, value[i], m_alternative_form));
+            if (i != value.size() - 1)
+                TRY(string_builder.append(", "));
+        }
+        JaktInternal::_pretty_print_level--;
+        TRY(string_builder.append("]"));
+        return Formatter<StringView>::format(builder, TRY(string_builder.to_string()));
+    }
+};
+
+template<typename T>
 struct Formatter<JaktInternal::Set<T>> : Formatter<StringView> {
     ErrorOr<void> format(FormatBuilder& builder, JaktInternal::Set<T> const& set)
     {

--- a/bootstrap/stage0/runtime/lib.h
+++ b/bootstrap/stage0/runtime/lib.h
@@ -150,7 +150,7 @@ inline void panic(StringView message)
     VERIFY_NOT_REACHED();
 }
 
-inline void abort()
+[[noreturn]] inline void abort()
 {
     ::abort();
 }
@@ -278,18 +278,18 @@ struct LoopContinue { };
 template<typename Value, typename Return>
 struct ExplicitValueOrControlFlow {
     template<typename U>
-    ExplicitValueOrControlFlow(ExplicitValue<U>&& v)
+    ExplicitValueOrControlFlow(ExplicitValue<U>&& v) requires(!IsVoid<Value> && !IsVoid<U>)
         : value(ExplicitValue<Value> { move(v.value) })
     {
     }
 
-    ExplicitValueOrControlFlow(ExplicitValue<void>&&)
+    ExplicitValueOrControlFlow(ExplicitValue<void>&&) requires(IsVoid<Value>)
         : value(ExplicitValue<void> {})
     {
     }
 
     template<typename U>
-    ExplicitValueOrControlFlow(U&& v) requires(!IsVoid<Return>)
+    ExplicitValueOrControlFlow(U&& v) requires(!IsVoid<Return> && !IsSpecializationOf<U, ExplicitValue>)
         : value(Return { forward<U>(v) })
     {
     }

--- a/bootstrap/stage0/runtime/prelude.jakt
+++ b/bootstrap/stage0/runtime/prelude.jakt
@@ -24,6 +24,15 @@ extern struct Array<T> {
     function last(this) -> T?
 }
 
+extern struct ArraySlice<T> {
+    function is_empty(this) -> bool
+    function contains(this, anon value: T) -> bool
+    function size(this) -> usize
+    function iterator(this) -> ArrayIterator<T>
+    function first(this) -> T?
+    function last(this) -> T?
+}
+
 extern struct String {
     function number(anon number: i64) throws -> String
     function split(this, anon c: c_char) throws -> [String]

--- a/selfhost/codegen.jakt
+++ b/selfhost/codegen.jakt
@@ -1147,60 +1147,51 @@ struct CodeGenerator {
     function codegen_enum_debug_description_getter(mut this, enum_: CheckedEnum) throws -> String {
         mut output = ""
 
-        output += "ErrorOr<String> debug_description() const { "
-        output += "auto builder = TRY(StringBuilder::create());"
-        output += "TRY(this->visit("
+        output += "ErrorOr<String> debug_description() const {\n"
+        output += "auto builder = TRY(StringBuilder::create());\n"
+        output += "switch (this->index()) {"
 
-        mut variant_lambdas: [String] = []
-        for variant in enum_.variants.iterator() {
+        for i in 0..enum_.variants.size() {
+            let variant = enum_.variants[i]
             let name = variant.name()
-            mut lambda = format("[&]([[maybe_unused]] {} const& that)", name) + " -> ErrorOr<void> {\n"
-            lambda += format("TRY(builder.append(\"{}::{}\"));", enum_.name, name)
-
+            output += format("case {} /* {} */: {{\n", i, name)
+            output += format("[[maybe_unused]] auto const& that = this->template get<{}::{}>();\n", enum_.name, name)
+            output += format("TRY(builder.append(\"{}::{}\"));\n", enum_.name, name)
             match variant {
                 StructLike(fields) => {
-                    lambda += "TRY(builder.append(\"(\"));"
-                    lambda += "JaktInternal::_pretty_print_level++;"
+                    output += "TRY(builder.append(\"(\"));\n"
+                    output += "JaktInternal::_pretty_print_level++;\n"
                     mut i = 0uz
                     for field in fields.iterator() {
-                        lambda += "TRY(JaktInternal::_output_pretty_indent(builder));"
+                        output += "TRY(JaktInternal::_output_pretty_indent(builder));\n"
                         let var = .program.get_variable(field)
-                        lambda += format("TRY(builder.append(\"{}: \"));", var.name)
-                        if .program.is_string(var.type_id) {
-                            lambda += "TRY(builder.append(\"\\\"\"));"
-                        }
-                        lambda += "TRY(builder.appendff(\"{}\", that." + var.name + "));"
-                        if .program.is_string(var.type_id) {
-                            lambda += "TRY(builder.append(\"\\\"\"));"
+                        if .program.is_string(var.type_id){
+                            output += format("TRY(builder.appendff(\"{}: \\\"{{}}\\\"\", that.{}));\n", var.name, var.name)
+                        } else {
+                            output += format("TRY(builder.appendff(\"{}: {{}}\", that.{}));\n", var.name, var.name)
                         }
                         if i != fields.size() - 1 {
-                            lambda += "TRY(builder.append(\", \"));"
+                            output += "TRY(builder.append(\", \"));\n"
                         }
                         i++
                     }
-                    lambda += "JaktInternal::_pretty_print_level--;"
-                    lambda += "TRY(builder.append(\")\"));"
+                    output += "JaktInternal::_pretty_print_level--;\n"
+                    output += "TRY(builder.append(\")\"));\n"
                 }
                 Typed(type_id) => {
-                    lambda += "TRY(builder.append(\"(\"));"
-                    if .program.is_string(type_id) {
-                        lambda += "TRY(builder.append(\"\\\"\"));"
+                    if .program.is_string(type_id){
+                        output += "TRY(builder.appendff(\"(\\\"{}\\\")\", that.value));\n"
+                    } else {
+                        output += "TRY(builder.appendff(\"({})\", that.value));\n"
                     }
-                    lambda += "TRY(builder.appendff(\"{}\", that.value));"
-                    if .program.is_string(type_id) {
-                        lambda += "TRY(builder.append(\"\\\"\"));"
-                    }
-                    lambda += "TRY(builder.append(\")\"));"
                 }
                 else => {}
             }
 
-            lambda += "return {}; }"
-            variant_lambdas.push(lambda)
+            output += "break;}\n"
         }
-        output += join(variant_lambdas, separator: ",")
 
-        output += "));" + "return builder.to_string();" + "}"
+        output += "}\nreturn builder.to_string();\n}"
 
         return output
     }


### PR DESCRIPTION
#### codegen: Use a switch statement in enum's debug_description
This is the last occurrence of Variant::visit, which may be putting some
strain on compilers template engines


#### runtime+bootstrap: Update stage0 and remove Variant::visit

This is as of the last commit unused and we have a better way of
implementing this through our compiler without relying on the
c++-compiler's template engine.

----

I did not update the stage0 README. because the commit hashes may change during merging