### PR TITLE
ide+typechecker: Miscellaneous span fixes

### DIFF
--- a/selfhost/ide.jakt
+++ b/selfhost/ide.jakt
@@ -396,11 +396,11 @@ function find_span_in_enum(program: CheckedProgram, checked_enum: CheckedEnum, s
                 }
             }
             Untyped(name, span: variant_span) => {
-                let number_constant_none: NumberConstant? = None
-                return Some(Usage::EnumVariant(span: variant_span, name, type_id: checked_enum.type_id, variants: [], number_constant: number_constant_none))
+                if variant_span.contains(span) {
+                    return Some(Usage::EnumVariant(span: variant_span, name, type_id: checked_enum.type_id, variants: [], number_constant: None))
+                }
             }
             WithValue(name, expr, span: variant_span) => {
-
                 if variant_span.contains(span) {
                     return Some(Usage::EnumVariant(span: variant_span, name, type_id: checked_enum.type_id, variants: enum_variant_fields(program, checked_enum_variant: variant), number_constant: expr.to_number_constant(program)))
                 }

--- a/selfhost/typechecker.jakt
+++ b/selfhost/typechecker.jakt
@@ -2863,7 +2863,7 @@ struct Typechecker {
                     } else if is_typed {
                         let param = variant.params![0]
                         let type_id = .typecheck_typename(parsed_type: param.parsed_type, scope_id: enum_.scope_id, name: param.name)
-                        enum_.variants.push(CheckedEnumVariant::Typed(enum_id, name: variant.name, type_id, span: param.span))
+                        enum_.variants.push(CheckedEnumVariant::Typed(enum_id, name: variant.name, type_id, span: variant.span))
 
                         let maybe_enum_variant_constructor = .find_function_in_scope(parent_scope_id: enum_.scope_id, function_name: variant.name)
                         if not maybe_enum_variant_constructor.has_value() {


### PR DESCRIPTION
Previously many spans would appear as part of an enum, when they were, in fact, not a part of it.

For example:
![enum](https://user-images.githubusercontent.com/36564831/183247240-44aed9b1-96d2-40d1-ba2a-298bc2ee7e67.png)

Another fix refers to Typed enum variant span, which I think was wrong (please, check if I am correct here). Due to this, signatures for Typed enum variants were not present. After the change I made, they work:

![obraz](https://user-images.githubusercontent.com/36564831/183247420-544b789b-8396-457c-b928-ed1c813fc57d.png)