### PR TITLE
build: Use -fno-exceptions when compiling jakt-generated cpp code

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,6 +11,7 @@ set(FINAL_STAGE "1" CACHE STRING "Compiler stage to stop at, either 1 (default) 
 
 macro(add_jakt_compiler_flags target)
   target_compile_options("${target}" PRIVATE
+    -fno-exceptions
     -Wno-unused-local-typedefs
     -Wno-unused-function
     -Wno-unknown-warning-option

--- a/build.ninja
+++ b/build.ninja
@@ -3,7 +3,7 @@
 # Copyright (c) 2022, JT <jt@serenityos.org>
 #
 # SPDX-License-Identifier: BSD-2-Clause
-cxxflags = -fcolor-diagnostics -std=c++20 -Wno-user-defined-literals -Wno-deprecated-declarations -Wno-parentheses-equality -Wno-unqualified-std-cast-call -Wno-unknown-warning-option -Wno-trigraphs
+cxxflags = -fcolor-diagnostics -std=c++20 -fno-exceptions -Wno-user-defined-literals -Wno-deprecated-declarations -Wno-parentheses-equality -Wno-unqualified-std-cast-call -Wno-unknown-warning-option -Wno-trigraphs
 
 rule cxx
     command = clang++ $cxxflags -o $out -I ./bootstrap/stage0/runtime $in

--- a/jakttest/build.ninja
+++ b/jakttest/build.ninja
@@ -2,7 +2,7 @@
 # Copyright (c) 2022, Jesús Lapastora <cyber.gsuscode@gmail.com>
 #
 # SPDX-License-Identifier: BSD-2-Clause
-cxxflags = -fcolor-diagnostics -std=c++20 -Wno-user-defined-literals -Wno-deprecated-declarations -Wno-parentheses-equality -Wno-unqualified-std-cast-call -Wno-unknown-warning-option
+cxxflags = -fcolor-diagnostics -std=c++20 -fno-exceptions -Wno-user-defined-literals -Wno-deprecated-declarations -Wno-parentheses-equality -Wno-unqualified-std-cast-call -Wno-unknown-warning-option
 
 rule cxx
     command = clang++ $cxxflags -o $out -I ../runtime -I . $in 

--- a/selfhost/main.jakt
+++ b/selfhost/main.jakt
@@ -312,6 +312,7 @@ function run_compiler(cxx_compiler_path: String, cpp_filename: String, output_fi
         cxx_compiler_path
         color_flag
         "-std=c++20"
+        "-fno-exceptions"
         "-Wno-unknown-warning-option"
         "-Wno-trigraphs"
         "-Wno-parentheses-equality"


### PR DESCRIPTION
This cuts down build time spent in Clang by 2.7s, or 23%.

The open question is if jakt will ever support C++ exceptions (generated, for example, int the inline c++ code blocks, or third party c++ libraries called from jakt code)

```
hyperfine -r 5 "cd jakt/build/ && clang++ -std=c++20 -I ../runtime/ -Wno-parentheses-equality -Wno-trigraphs -Wno-user-defined-literalsi jakt.cpp" "cd jakt/build/ && clang++ -std=c++20 -I ../runtime/ -Wno-parentheses-equality -Wno-trigraphs -Wno-user-defined-literals -fno-exceptions jakt.cpp"
Benchmark 1: cd jakt/build/ && clang++ -std=c++20 -I ../runtime/ -Wno-parentheses-equality -Wno-trigraphs -Wno-user-defined-literalsi jakt.cpp
  Time (mean ± σ):     14.772 s ±  0.092 s    [User: 14.208 s, System: 0.552 s]
  Range (min … max):   14.666 s … 14.881 s    5 runs
 
Benchmark 2: cd jakt/build/ && clang++ -std=c++20 -I ../runtime/ -Wno-parentheses-equality -Wno-trigraphs -Wno-user-defined-literals -fno-exceptions jakt.cpp
  Time (mean ± σ):     11.989 s ±  0.069 s    [User: 11.431 s, System: 0.541 s]
  Range (min … max):   11.874 s … 12.059 s    5 runs
 
Summary
  'cd jakt/build/ && clang++ -std=c++20 -I ../runtime/ -Wno-parentheses-equality -Wno-trigraphs -Wno-user-defined-literals -fno-exceptions jakt.cpp' ran
    1.23 ± 0.01 times faster than 'cd jakt/build/ && clang++ -std=c++20 -I ../runtime/ -Wno-parentheses-equality -Wno-trigraphs -Wno-user-defined-literalsi jakt.cpp'
```