### PR TITLE
parser+typechecker: Implement default args for functions/methods

### DIFF
--- a/samples/functions/default_arguments.jakt
+++ b/samples/functions/default_arguments.jakt
@@ -1,0 +1,10 @@
+/// Expect:
+/// - output: "WHF\n"
+
+function say(text: String = "WHF") {
+    println("{}", text)
+}
+
+function main() {
+    say()
+}

--- a/samples/functions/default_arguments_bad_type.jakt
+++ b/samples/functions/default_arguments_bad_type.jakt
@@ -1,0 +1,9 @@
+/// Expect:
+/// - output: error: "Type mismatch: expected ‘String’, but got ‘i64’\n"
+function say(text: String = 3) {
+    println("{}", text)
+}
+
+function main() {
+    say()
+}

--- a/samples/functions/default_arguments_bad_type.jakt
+++ b/samples/functions/default_arguments_bad_type.jakt
@@ -1,5 +1,6 @@
 /// Expect:
-/// - output: error: "Type mismatch: expected ‘String’, but got ‘i64’\n"
+/// - error: "Type mismatch: expected ‘String’, but got ‘i64’\n"
+
 function say(text: String = 3) {
     println("{}", text)
 }

--- a/samples/functions/default_arguments_complex.jakt
+++ b/samples/functions/default_arguments_complex.jakt
@@ -1,0 +1,10 @@
+/// Expect:
+/// - output: "WHF 5 false None\n"
+
+function say(text: String = "WHF", number: i64 = 5, boolean: bool = false, optional: String? = None) {
+    println("{} {} {} {}", text, number, boolean, optional)
+}
+
+function main() {
+    say()
+}

--- a/samples/functions/default_arguments_constructor.jakt
+++ b/samples/functions/default_arguments_constructor.jakt
@@ -1,0 +1,16 @@
+/// Expect:
+/// - output: "0, 0\n"
+
+class Point {
+    public x: i64
+    public y: i64
+
+    public function make(x: i64 = 0, y: i64 = 0) throws -> Point {
+        return Point(x, y)
+    }
+}
+
+function main() {
+    let p = Point::make()
+    println("{}, {}", p.x, p.y)
+}

--- a/samples/functions/default_arguments_default_before_required.jakt
+++ b/samples/functions/default_arguments_default_before_required.jakt
@@ -1,0 +1,10 @@
+/// Expect:
+/// - output: "Hello 5 false WHF 121\n"
+
+function say(text: String = "Hello", number: i64 = 5, boolean: bool = false, optional: String?, byte: u8) {
+    println("{} {} {} {} {}", text, number, boolean, optional, byte)
+}
+
+function main() {
+    say(optional: "WHF", byte: b'y')
+}

--- a/samples/functions/default_arguments_method.jakt
+++ b/samples/functions/default_arguments_method.jakt
@@ -1,0 +1,13 @@
+/// Expect:
+/// - output: "Well, hello friends. My name is Jane and I am 36 years old.\n"
+
+class Person {
+    public function greet(this, name: String = "Jane", age: i64 = 36) {
+        println("Well, hello friends. My name is {} and I am {} years old.", name, age)
+    }
+}
+
+function main() {
+    let p = Person()
+    p.greet()
+}

--- a/samples/functions/default_arguments_mixed.jakt
+++ b/samples/functions/default_arguments_mixed.jakt
@@ -1,8 +1,8 @@
 /// Expect:
-/// - output: "WHF 5 true None\n"
+/// - output: "WHF 5 true None 97\n"
 
 function say(text: String, number: i64 = 5, boolean: bool, optional: String?, byte: u8 = b'a') {
-    println("{} {} {} {}", text, number, boolean, optional, byte)
+    println("{} {} {} {} {}", text, number, boolean, optional, byte)
 }
 
 function main() {

--- a/samples/functions/default_arguments_mixed.jakt
+++ b/samples/functions/default_arguments_mixed.jakt
@@ -1,10 +1,10 @@
 /// Expect:
-/// - output: "WHF 5 false None\n"
+/// - output: "WHF 5 true None\n"
 
-function say(text: String, number: i64 = 5, bl: bool, opt: String?, byte: u8 = b'a') {
-    println("{} {} {} {}", text, number, bl, opt, byte)
+function say(text: String, number: i64 = 5, boolean: bool, optional: String?, byte: u8 = b'a') {
+    println("{} {} {} {}", text, number, boolean, optional, byte)
 }
 
 function main() {
-    say(text: "WHF", bl: true, opt: None)
+    say(text: "WHF", boolean: true, optional: None)
 }

--- a/samples/functions/default_arguments_mixed.jakt
+++ b/samples/functions/default_arguments_mixed.jakt
@@ -1,0 +1,10 @@
+/// Expect:
+/// - output: "WHF 5 false None\n"
+
+function say(text: String, number: i64 = 5, bl: bool, opt: String?, byte: u8 = b'a') {
+    println("{} {} {} {}", text, number, bl, opt, byte)
+}
+
+function main() {
+    say(text: "WHF", bl: true, opt: None)
+}

--- a/samples/functions/default_arguments_some_defaults.jakt
+++ b/samples/functions/default_arguments_some_defaults.jakt
@@ -1,0 +1,10 @@
+/// Expect:
+/// - output: "Hello 5 false World\n"
+
+function say(text: String = "WHF", number: i64 = 5, boolean: bool = false, optional: String? = None) {
+    println("{} {} {} {}", text, number, boolean, optional)
+}
+
+function main() {
+    say(text: "Hello", optional: "World")
+}

--- a/selfhost/parser.jakt
+++ b/selfhost/parser.jakt
@@ -207,6 +207,7 @@ struct ParsedFunction {
 struct ParsedParameter {
     requires_label: bool
     variable: ParsedVariable
+    default_argument: ParsedExpression?
     span: Span
 }
 
@@ -1500,6 +1501,7 @@ struct Parser {
                             is_mutable: current_param_is_mutable,
                             span: .current().span(),
                         ),
+                        default_argument: None,
                         span: .current().span(),
                     ))
                     .index++
@@ -1507,6 +1509,13 @@ struct Parser {
                 }
                 Identifier(name, span) => {
                     let var_decl = .parse_variable_declaration(is_mutable: current_param_is_mutable)
+
+                    mut default_argument: ParsedExpression? = None
+                    
+                    if .current() is Equal {
+                        .index++
+                        default_argument = .parse_expression(allow_assignments: false, allow_newlines: true)
+                    }
 
                     params.push(ParsedParameter(
                         requires_label: current_param_requires_label,
@@ -1516,6 +1525,7 @@ struct Parser {
                             is_mutable: var_decl.is_mutable,
                             span: .previous().span(),
                         ),
+                        default_argument,
                         span: .previous().span(),
                     ))
                     parameter_complete = true

--- a/selfhost/typechecker.jakt
+++ b/selfhost/typechecker.jakt
@@ -4613,10 +4613,30 @@ struct Typechecker {
                         visibility: Visibility::Public
                     )
 
+                    mut checked_default_value: CheckedExpression? = None
+                    if param.default_argument.has_value() {
+                        //FIXME: Get the real safety mode from somewhere, right now it assumes it is safe
+                        mut checked_default_value_expr = .typecheck_expression(param.default_argument!, scope_id, safety_mode: SafetyMode::Safe, type_hint: param_type)
+                        
+                        if checked_default_value_expr is OptionalNone(span: expr_span) {
+                            checked_default_value_expr = CheckedExpression::OptionalNone(span: expr_span, type_id: param_type)
+                        }
+                        
+                        let default_value_type_id = expression_type(checked_default_value_expr)
+                        checked_default_value = checked_default_value_expr
+                        if not default_value_type_id.equals(param_type) {
+                            checked_default_value = None
+                            .error(
+                                format("Type mismatch: expected ‘{}’, but got ‘{}’", .type_name(param_type), .type_name(default_value_type_id))
+                                param.span
+                            )
+                        }
+                    }
+
                     checked_function.params.push(CheckedParameter(
                         requires_label: param.requires_label
                         variable: checked_variable
-                        default_value: None
+                        default_value: checked_default_value
                     ))
 
                     if check_scope.has_value() {

--- a/selfhost/typechecker.jakt
+++ b/selfhost/typechecker.jakt
@@ -464,6 +464,7 @@ class CheckedFunction {
 struct CheckedParameter {
     requires_label: bool
     variable: CheckedVariable
+    default_value: CheckedExpression?
 }
 
 enum CheckedCapture {
@@ -4451,6 +4452,7 @@ struct Typechecker {
                     checked_function.params.push(CheckedParameter(
                         requires_label: param.requires_label
                         variable: checked_variable
+                        default_value: None
                     ))
                 } else {
                     let param_type = .typecheck_typename(parsed_type: param.variable.parsed_type, scope_id: method_scope_id, name: param.variable.name)
@@ -4467,6 +4469,7 @@ struct Typechecker {
                     checked_function.params.push(CheckedParameter(
                         requires_label: param.requires_label
                         variable: checked_variable
+                        default_value: None
                     ))
                 }
             }
@@ -4591,6 +4594,7 @@ struct Typechecker {
                     checked_function.params.push(CheckedParameter(
                         requires_label: param.requires_label
                         variable: checked_variable
+                        default_value: None
                     ))
 
                     if check_scope.has_value() {
@@ -4612,6 +4616,7 @@ struct Typechecker {
                     checked_function.params.push(CheckedParameter(
                         requires_label: param.requires_label
                         variable: checked_variable
+                        default_value: None
                     ))
 
                     if check_scope.has_value() {
@@ -4803,7 +4808,7 @@ struct Typechecker {
                                 type_span: None
                                 visibility: Visibility::Public
                             )
-                            params.push(CheckedParameter(requires_label: true, variable: checked_var))
+                            params.push(CheckedParameter(requires_label: true, variable: checked_var, default_value: None))
 
                             if .dump_type_hints {
                                 .dump_type_hint(type_id, span: param.span)
@@ -4867,7 +4872,7 @@ struct Typechecker {
                                 visibility: Visibility::Public,
                                 return_type_id: .find_or_add_type_id(Type::Enum(enum_id)),
                                 return_type_span: None,
-                                params: [CheckedParameter(requires_label: false, variable)],
+                                params: [CheckedParameter(requires_label: false, variable, default_value: None)],
                                 generic_params: [],
                                 block: CheckedBlock(
                                     statements: [],
@@ -4991,6 +4996,7 @@ struct Typechecker {
                 func.params.push(CheckedParameter(
                     requires_label: true
                     variable: field
+                    default_value: None
                 ))
             }
 
@@ -5106,9 +5112,27 @@ struct Typechecker {
             visibility: Visibility::Public
         )
 
+        mut checked_default_value: CheckedExpression? = None
+        if parameter.default_argument.has_value() {
+            //FIXME: Get the real safety mode from somewhere, right now it assumes it is safe
+            mut checked_default_value_expr = .typecheck_expression(parameter.default_argument!, scope_id, safety_mode: SafetyMode::Safe, type_hint: type_id)
+            
+            if checked_default_value_expr is OptionalNone(span: expr_span) {
+                checked_default_value_expr = CheckedExpression::OptionalNone(span: expr_span, type_id)
+            }
+            
+            let default_value_type_id = expression_type(checked_default_value_expr)
+            checked_default_value = checked_default_value_expr
+            if not default_value_type_id.equals(type_id) {
+                checked_default_value = None
+                .error(format("Type mismatch: expected ‘{}’, but got ‘{}’", .type_name(type_id), .type_name(default_value_type_id)), parameter.span)
+            }
+        }
+
         let checked_parameter = CheckedParameter(
             requires_label: parameter.requires_label
             variable
+            default_value: checked_default_value
         )
 
         if check_scope.has_value() {

--- a/selfhost/typechecker.jakt
+++ b/selfhost/typechecker.jakt
@@ -8728,35 +8728,20 @@ struct Typechecker {
                     generic_checked_function_to_instantiate = Some(function_id)
                 }
 
-                if callee.params.size() != (call.args.size() + arg_offset) {
-                    .error("Wrong number of arguments", span)
-                }
+                mut resolved_args: [(String, Span, CheckedExpression)] = .resolve_default_params(params: callee.params, args: call.args, scope_id: caller_scope_id, safety_mode, arg_offset, span)
 
-                for i in 0..call.args.size() {
-                    if (i + arg_offset) == callee.params.size() {
-                        break
+                if callee.params.size() == resolved_args.size() + arg_offset {
+                    for i in 0..callee.params.size()-arg_offset {
+                        let (name, span, checked_arg) = resolved_args[i]
+                        .check_types_for_compat(
+                            lhs_type_id: callee.params[i+arg_offset].variable.type_id
+                            rhs_type_id: expression_type(checked_arg)
+                            &mut generic_inferences
+                            span: .expression_span(checked_arg)
+                        )
+
+                        args.push((call.name, checked_arg))
                     }
-
-                    let parsed_label_and_arg = call.args[i]
-                    let param = callee.params[i + arg_offset]
-
-                    if param.requires_label {
-                        .validate_argument_label(param, label: parsed_label_and_arg.0, span: parsed_label_and_arg.1, expr: parsed_label_and_arg.2)
-                    }
-
-                    mut checked_arg = .typecheck_expression(expr: parsed_label_and_arg.2, scope_id: caller_scope_id, safety_mode, type_hint: param.variable.type_id)
-                    let promoted_arg = .try_to_promote_constant_expr_to_type(lhs_type: param.variable.type_id, checked_rhs: checked_arg, span)
-                    checked_arg = promoted_arg ?? checked_arg
-
-                    // FIXME: It's super awkward that we have to pass "generic_inferences" here:
-                    .check_types_for_compat(
-                        lhs_type_id: param.variable.type_id
-                        rhs_type_id: expression_type(checked_arg)
-                        &mut generic_inferences
-                        span: expression_span(checked_arg)
-                    )
-
-                    args.push((call.name, checked_arg))
                 }
 
                 // We've now seen all the arguments and should be able to substitute the return type, if it's contains a
@@ -8927,6 +8912,59 @@ struct Typechecker {
         return checked_call
     }
 
+    function resolve_default_params(mut this, params: [CheckedParameter], args: [(String, Span, ParsedExpression)], scope_id: ScopeId, safety_mode: SafetyMode, arg_offset: usize, span: Span) throws -> [(String, Span, CheckedExpression)] {
+        mut params_with_default_value = 0uz
+
+        for param in params.iterator() {
+            if param.default_value.has_value() {
+                params_with_default_value++
+            }
+        }
+
+        guard args.size() >= params.size() - arg_offset - params_with_default_value and args.size() <= params.size() - arg_offset else {
+            .error("Wrong number of arguments", span)
+            return []
+        }
+
+        mut consumed_arg = 0uz
+        mut resolved_args: [(String, Span, CheckedExpression)] = []
+
+        for i in arg_offset..params.size() {
+            let param = params[i]
+            mut maybe_checked_expr: CheckedExpression? = None
+            if not param.requires_label {
+                guard args.size() > consumed_arg else {
+                    .error(format("Missing argument for function parameter {}", param.variable.name), span)
+                    continue
+                }
+
+                let (name, span, expr) = args[consumed_arg]
+                maybe_checked_expr = .typecheck_expression(expr, scope_id, safety_mode, type_hint: param.variable.type_id)
+                consumed_arg++
+            } else {
+                maybe_checked_expr = param.default_value
+
+                if args.size() > consumed_arg {
+                    let (name, span, expr) = args[consumed_arg]
+                    
+                    if .validate_argument_label(param, label: name, span, expr, default_value: maybe_checked_expr) {
+                        maybe_checked_expr = .typecheck_expression(expr, scope_id, safety_mode, type_hint: param.variable.type_id)
+                        consumed_arg++
+                    }
+                }
+            }
+            
+            if maybe_checked_expr.has_value() {
+                mut checked_arg = maybe_checked_expr!
+                let promoted_arg = .try_to_promote_constant_expr_to_type(lhs_type: param.variable.type_id, checked_rhs: checked_arg, span)
+                checked_arg = promoted_arg ?? checked_arg
+                resolved_args.push((param.variable.name, span, checked_arg))
+            }
+        }
+
+        return resolved_args
+    }
+
     function resolve_type_var(this, type_var_type_id: TypeId, scope_id: ScopeId) throws -> TypeId {
         mut current_type_id = type_var_type_id
 
@@ -8950,7 +8988,7 @@ struct Typechecker {
         return current_type_id
     }
 
-    function validate_argument_label(mut this, param: CheckedParameter, label: String, span: Span, expr: ParsedExpression) throws -> bool {
+    function validate_argument_label(mut this, param: CheckedParameter, label: String, span: Span, expr: ParsedExpression, default_value: CheckedExpression?) throws -> bool {
         if label == param.variable.name {
             return true
         }
@@ -8959,7 +8997,9 @@ struct Typechecker {
                 if name == param.variable.name {
                     return true
                 }
-                .error(format("Wrong parameter name in argument label (got '{}', expected '{}')", name, param.variable.name), span)
+                if not default_value.has_value() {
+                    .error(format("Wrong parameter name in argument label (got '{}', expected '{}')", name, param.variable.name), span)
+                }
                 return false
             }
             UnaryOp(expr, op) => {
@@ -8968,14 +9008,18 @@ struct Typechecker {
                         if name == param.variable.name {
                             return true
                         }
-                        .error(format("Wrong parameter name in argument label (got ‘{}’, expected ‘{}’)", name, param.variable.name), span)
+                        if not default_value.has_value() {
+                            .error(format("Wrong parameter name in argument label (got ‘{}’, expected ‘{}’)", name, param.variable.name), span)
+                        }
                         return false
                     }
                 }
             }
             else => {}
         }
-        .error(format("Wrong parameter name in argument label (got '{}', expected '{}')", label, param.variable.name), span)
+        if not default_value.has_value() {
+            .error(format("Wrong parameter name in argument label (got '{}', expected '{}')", label, param.variable.name), span)
+        }
         return false
     }
 }

--- a/selfhost/typechecker.jakt
+++ b/selfhost/typechecker.jakt
@@ -8757,7 +8757,7 @@ struct Typechecker {
                             lhs_type_id: callee.params[i+arg_offset].variable.type_id
                             rhs_type_id: expression_type(checked_arg)
                             &mut generic_inferences
-                            span: .expression_span(checked_arg)
+                            span: expression_span(checked_arg)
                         )
 
                         args.push((call.name, checked_arg))

--- a/tests/parser/non_parameter_3.jakt
+++ b/tests/parser/non_parameter_3.jakt
@@ -1,7 +1,7 @@
 /// Expect:
 /// - error: "Expected parameter\n"
 
-function foo(anon n: i32 = 1) {
+function foo(anon n: i32 != 1) {
     println("{}", n)
 }
 


### PR DESCRIPTION
This PR adds the possibility to use default arguments for functions and method calls.

```
function say(text: String = "WHF", number: i64 = 5, boolean: bool = false, optional: String? = None) {
    println("{} {} {} {}", text, number, boolean, optional)
}

function main() {
    say()
}

// output: "WHF 5 false None\n"
```