### PR TITLE
typechecker: Report error for arrays in non-throwing scope

### DIFF
--- a/samples/arrays/throws.jakt
+++ b/samples/arrays/throws.jakt
@@ -1,0 +1,6 @@
+/// Expect: selfhost-only
+/// - error: "Array initialization inside non-throwing scope\n"
+
+function a() -> [u8] => []
+
+function main() {}

--- a/selfhost/typechecker.jakt
+++ b/selfhost/typechecker.jakt
@@ -5771,6 +5771,19 @@ struct Typechecker {
         if .dump_try_hints {
             .dump_try_hint(span)
         }
+        if not .get_scope(scope_id).can_throw {
+            let message = "Array initialization inside non-throwing scope"
+            if .current_function_id.has_value() {
+                let current_function = .get_function(.current_function_id!)
+                .error_with_hint(
+                    message
+                    span
+                    format("Add `throws` keyword to function {}", current_function.name),
+                    current_function.name_span)
+            } else {
+                .error(message, span)
+            }
+        }
         mut repeat: CheckedExpression? = None
         if fill_size.has_value() {
             // Check fill size is an integer.


### PR DESCRIPTION
Previously, this would error in c++ compilation.