### PR TITLE
tests+jakttest: Minor fixes and changes

### DIFF
--- a/jakttest/README.md
+++ b/jakttest/README.md
@@ -5,16 +5,11 @@ It's also written in Jakt.
 
 ## Build dependencies
 
-To build Jakttest you should use the `ninja` build system which will use the provided `build.ninja` file.
-It needs the same `clang++` that is required to build any other Jakt file, and `python` 3.6+ to run the
-patch script that patches the generated C++ from Jakt code to accept the external C++ code.
+Jakttest is built along with Jakt and therefore needs the same dependencies.
+See [Jakt's build instructions](../documentation/cmake-bootstrap.md) for more
+information.
 
-As a list:
-
-- `ninja` (or `ninja-build` on some package managers)
-- `clang++`
-
-## How to run it?
+## Running Jakttest
 
 First, make sure that you have the generated build directory:
 

--- a/samples/guard/is_guard_no_exit.jakt
+++ b/samples/guard/is_guard_no_exit.jakt
@@ -1,5 +1,5 @@
-/// Expect:
-//  - error: "Else block of guard must either `return`, `break`, `continue`, or `throw`"
+/// Expect: selfhost-only
+///  - error: "Else block of guard must either `return`, `break`, `continue`, or `throw`"
 
 enum Foo {
     Bar(i64)

--- a/tests/typechecker/enum_with_type_from_prelude.jakt
+++ b/tests/typechecker/enum_with_type_from_prelude.jakt
@@ -1,3 +1,6 @@
+/// Expect:
+/// - output: "false\ntrue\n"
+
 enum test {
     Range(test: i64)
     Other(test: i64)


### PR DESCRIPTION
This PR changes a few small things:
1. I added back a missing slash in a test's header.
2. I removed every reference to "selfhost-only", because we don't use the selfhost compiler.
3. I removed the "Build Dependencies" section in Jakttest's README, since it's now built with the rest of Jakt.