### PR TITLE
meta+runtime: Reduce number of warnings produced by Windows CI

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,6 +27,7 @@ macro(add_jakt_compiler_flags target)
   target_compile_options("${target}" PRIVATE
     -Wno-unused-local-typedefs
     -Wno-unused-function
+    -Wno-unused-variable
     -Wno-unknown-warning-option
     -Wno-trigraphs
     -Wno-parentheses-equality

--- a/bootstrap/stage0/runtime/Builtins/Array.h
+++ b/bootstrap/stage0/runtime/Builtins/Array.h
@@ -149,8 +149,8 @@ class ArrayIterator {
 public:
     ArrayIterator(NonnullRefPtr<Storage> storage, size_t offset, size_t size)
         : m_storage(move(storage))
-        , m_index(offset)
         , m_offset(offset)
+        , m_index(offset)
         , m_size(size)
     {
     }

--- a/bootstrap/stage0/runtime/Jakt/Assertions.h
+++ b/bootstrap/stage0/runtime/Jakt/Assertions.h
@@ -9,9 +9,15 @@
 #if defined(KERNEL)
 #    include <Kernel/Assertions.h>
 #else
-#    include <assert.h>
-#    define VERIFY assert
-#    define VERIFY_NOT_REACHED() assert(false) /* NOLINT(cert-dcl03-c,misc-static-assert) No, this can't be static_assert, it's a runtime check */
+#    define _TRAP_NORETURN \
+        []() __attribute__((noreturn)) \
+        {                              \
+            __builtin_trap();          \
+            __builtin_unreachable();   \
+        }                              \
+        ()
+#    define VERIFY(expr) (__builtin_expect(!(expr), 0) ? _TRAP_NORETURN : (void)0)
+#    define VERIFY_NOT_REACHED() VERIFY(false) /* NOLINT(cert-dcl03-c,misc-static-assert) No, this can't be static_assert, it's a runtime check */
 namespace Jakt {
 static constexpr bool TODO = false;
 }

--- a/bootstrap/stage0/runtime/Jakt/Error.h
+++ b/bootstrap/stage0/runtime/Jakt/Error.h
@@ -35,7 +35,6 @@ protected:
 
 private:
     int m_code { 0 };
-    bool m_syscall { false };
 };
 
 template<typename T, typename ErrorType>

--- a/runtime/Builtins/Array.h
+++ b/runtime/Builtins/Array.h
@@ -152,8 +152,8 @@ class ArrayIterator {
 public:
     ArrayIterator(NonnullRefPtr<Storage> storage, size_t offset, size_t size)
         : m_storage(move(storage))
-        , m_index(offset)
         , m_offset(offset)
+        , m_index(offset)
         , m_size(size)
     {
     }

--- a/runtime/Jakt/Assertions.h
+++ b/runtime/Jakt/Assertions.h
@@ -9,9 +9,15 @@
 #if defined(KERNEL)
 #    include <Kernel/Assertions.h>
 #else
-#    include <assert.h>
-#    define VERIFY assert
-#    define VERIFY_NOT_REACHED() assert(false) /* NOLINT(cert-dcl03-c,misc-static-assert) No, this can't be static_assert, it's a runtime check */
+#    define _TRAP_NORETURN \
+        []() __attribute__((noreturn)) \
+        {                              \
+            __builtin_trap();          \
+            __builtin_unreachable();   \
+        }                              \
+        ()
+#    define VERIFY(expr) (__builtin_expect(!(expr), 0) ? _TRAP_NORETURN : (void)0)
+#    define VERIFY_NOT_REACHED() VERIFY(false) /* NOLINT(cert-dcl03-c,misc-static-assert) No, this can't be static_assert, it's a runtime check */
 namespace Jakt {
 static constexpr bool TODO = false;
 }

--- a/runtime/Jakt/Error.h
+++ b/runtime/Jakt/Error.h
@@ -35,7 +35,6 @@ protected:
 
 private:
     int m_code { 0 };
-    bool m_syscall { false };
 };
 
 template<typename T, typename ErrorType>


### PR DESCRIPTION
CI was getting quite unreadable, so let's fix some warnings and suppress others.