### PR TITLE
interpreter: Allow void main return

### DIFF
--- a/selfhost/main.jakt
+++ b/selfhost/main.jakt
@@ -261,6 +261,9 @@ function main(args: [String]) {
                 CInt(ret_val) | I64(ret_val) => {
                     return ret_val
                 }
+                Void => {
+                    return 0
+                }
                 else => {
                     eprintln("Error: Main function must return an integer")
                     return 1


### PR DESCRIPTION
This updates the interpreter to allow main to have a void return as well, just as we do for compilation. If void, just return 0.