### PR TITLE
runtime: Add join function on Array and ArraySlice

### DIFF
--- a/runtime/Builtins/Array.cpp
+++ b/runtime/Builtins/Array.cpp
@@ -1,0 +1,43 @@
+#pragma once
+
+#include <Builtins/Array.h>
+#include <errno.h>
+
+namespace JaktInternal {
+using namespace Jakt;
+
+template<typename T>
+ErrorOr<String> Array<T>::join(String const& separator) const
+{
+    auto builder = MUST(StringBuilder::create());
+    
+    bool first = true;
+    for (size_t i = 0; i<size(); ++i) {
+        if (first)
+            first = false;
+        else
+            TRY(builder.append(separator));
+        TRY(builder.appendff("{}"sv, at(i)));
+    }
+
+    return TRY(builder.to_string());
+}
+
+template<typename T>
+ErrorOr<String> ArraySlice<T>::join(String const& separator) const
+{
+    auto builder = MUST(StringBuilder::create());
+    
+    bool first = true;
+    for (size_t i = 0; i<size(); ++i) {
+        if (first)
+            first = false;
+        else
+            TRY(builder.append(separator));
+        TRY(builder.appendff("{}"sv, at(i)));
+    }
+
+    return TRY(builder.to_string());
+}
+
+}

--- a/runtime/Builtins/Array.h
+++ b/runtime/Builtins/Array.h
@@ -206,6 +206,8 @@ public:
         return array;
     }
 
+    ErrorOr<String> join(String const& separator) const;
+
     bool is_empty() const { return m_storage->is_empty(); }
     size_t size() const { return m_storage->size(); }
     size_t capacity() const { return m_storage->capacity(); }
@@ -360,6 +362,8 @@ public:
     {
         return ArrayIterator<T> { *m_storage, m_offset, m_size };
     }
+
+    ErrorOr<String> join(String const& separator) const;
 
     bool is_empty() const { return size() == 0; }
     size_t size() const

--- a/runtime/lib.h
+++ b/runtime/lib.h
@@ -67,6 +67,8 @@ class Set;
 #include <Builtins/Dictionary.h>
 #include <Builtins/Set.h>
 
+#include <Builtins/Array.cpp>
+
 #include <IO/File.h>
 
 #include <IO/File.cpp>

--- a/runtime/prelude.jakt
+++ b/runtime/prelude.jakt
@@ -22,6 +22,7 @@ extern struct Array<T> {
     function iterator(this) -> ArrayIterator<T>
     function first(this) -> T?
     function last(this) -> T?
+    function join(this, anon separator: String) throws -> String
 }
 
 extern struct ArraySlice<T> {
@@ -32,6 +33,7 @@ extern struct ArraySlice<T> {
     function to_array(this) throws -> Array<T> 
     function first(this) -> T?
     function last(this) -> T?
+    function join(this, anon separator: String) throws -> String
 }
 
 extern struct String {

--- a/samples/arrays/array_join.jakt
+++ b/samples/arrays/array_join.jakt
@@ -1,0 +1,33 @@
+/// Expect:
+/// - output: "A-B\n1--2\nA(id: 1)|A(id: 2)\nFoo::AFoo::B\n23\n"
+
+struct A {
+    id: i64
+}
+
+enum Foo {
+    A
+    B
+}
+
+function main() {
+    let strings = ["A", "B"]
+
+    println("{}", strings.join("-"))
+
+    let ints = [1, 2]
+
+    println("{}", ints.join("--"))
+
+    let structs = [A(id:1), A(id:2)]
+
+    println("{}", structs.join("|"))
+
+    let enums = [Foo::A, Foo::B]
+
+    println("{}", enums.join(""))
+
+    let arr = [1, 2, 3, 4, 5]
+
+    println("{}", arr[1..3].join(""))
+}


### PR DESCRIPTION
This takes advantage of the existing string formatters to allow an Array
or ArraySlice of any type to be joined into a string.