### PR TITLE
selfhost: Reserve identifiers starting with __jakt

### DIFF
--- a/samples/basics/reserved_variable.jakt
+++ b/samples/basics/reserved_variable.jakt
@@ -1,0 +1,13 @@
+/// Expect:
+/// - error: "reserved identifier name"
+
+function main() {
+    let __jakt_var_1 = "hello"
+    try foo() catch {
+        print(__jakt_var_1)
+    }
+}
+
+function foo() throws -> void {
+    throw Error::from_errno(9000)
+}

--- a/selfhost/lexer.jakt
+++ b/selfhost/lexer.jakt
@@ -490,6 +490,11 @@ struct Lexer {
             let span = .span(start, end)
             let string = string_builder.to_string()
 
+            if end - start >= 6 and string.substring(start: 0, length: 6) == "__jakt" {
+                .error("reserved identifier name", span)
+                return Token::Garbage(span)
+            }
+
             return Token::from_keyword_or_identifier(string, span)
         }
 


### PR DESCRIPTION
This commit adds a small restriction on identifier names. They are no longer allowed to start with `__jakt` as names like these are used in codegen for fresh variables and etc.

This is to protect against like this that looks legal but fails in the C++ compile step:

```
function main() {
    let __jakt_var_1 = "hello"
    try foo() catch {
        print(__jakt_var_1)
    }
}

function foo() throws -> void {
    throw Error::from_errno(9000)
}
```

```
build/foo.cpp:15:6: error: redefinition of '__jakt_var_1'
auto __jakt_var_1 = [&]() -> ErrorOr<void> { return TRY((foo())), ErrorOr<void>{}; }();
     ^
build/foo.cpp:14:14: note: previous definition is here
const String __jakt_var_1 = String("hello");
             ^
build/foo.cpp:16:18: error: no member named 'is_error' in 'Jakt::String'
if (__jakt_var_1.is_error()) {{
    ~~~~~~~~~~~~ ^
2 errors generated.
```