### PR TITLE
typechecker+tests: Clean up error messages for private visibility

### DIFF
--- a/samples/enums/methods_access_violation.jakt
+++ b/samples/enums/methods_access_violation.jakt
@@ -1,5 +1,5 @@
 /// Expect:
-/// - error: "Can't access function ‘test’ from scope None, because it is marked private\n"
+/// - error: "Can't access method ‘test’, because it is marked private\n"
 
 enum Foo {
     Bar

--- a/selfhost/typechecker.jakt
+++ b/selfhost/typechecker.jakt
@@ -3777,11 +3777,11 @@ struct Typechecker {
         match member.visibility {
             Private => {
                 if not .scope_can_access(accessor, accessee) {
-                    .error(format("Can't access variable ‘{}’ from scope {}, because it is marked private", member.name, .get_scope(accessor).namespace_name), span)
+                    .error(format("Can't access field ‘{}’, because it is marked private", member.name), span)
                 }
             }
             Restricted(whitelist, span) => {
-                .check_restricted_access(accessor, accessee_kind: "variable", accessee, name: member.name, whitelist, span)
+                .check_restricted_access(accessor, accessee_kind: "field", accessee, name: member.name, whitelist, span)
             }
             else => {}
         }
@@ -3791,7 +3791,15 @@ struct Typechecker {
         match method.visibility {
             Private => {
                 if not .scope_can_access(accessor, accessee) {
-                    .error(format("Can't access function ‘{}’ from scope {}, because it is marked private", method.name, .get_scope(accessor).namespace_name), span)
+                    if not method.type is Normal {
+                        .error_with_hint(format("Can't access constructor ‘{}’, because it is marked private", method.name)
+                            span
+                            hint: "Private constructors are created if any fields are private"
+                            span
+                        )
+                    } else {
+                        .error(format("Can't access method ‘{}’, because it is marked private", method.name), span)
+                    }
                 }
             }
             Restricted(whitelist, span) => {

--- a/tests/typechecker/class_private_default.jakt
+++ b/tests/typechecker/class_private_default.jakt
@@ -1,5 +1,5 @@
 /// Expect:
-/// - error: "Can't access function ‘cant_touch’ from scope None, because it is marked private\n"
+/// - error: "Can't access method ‘cant_touch’, because it is marked private\n"
 
 class GoodEncapsulation {
     function cant_touch(this) {}

--- a/tests/typechecker/class_private_field_ctr.jakt
+++ b/tests/typechecker/class_private_field_ctr.jakt
@@ -1,5 +1,5 @@
 /// Expect:
-/// - error: "Can't access field ‘muda_amount’, because it is marked private\n"
+/// - error: "Can't access constructor ‘GoodEncapsulation’, because it is marked private\n"
 
 class GoodEncapsulation {
     muda_amount: u32
@@ -8,7 +8,4 @@ class GoodEncapsulation {
 
 function main() {
     let encapsulated = GoodEncapsulation(muda_amount: 20, ora_amount: 9001)
-    // This is okay!
-    encapsulated.ora_amount
-    encapsulated.muda_amount
 }

--- a/tests/typechecker/class_private_static.jakt
+++ b/tests/typechecker/class_private_static.jakt
@@ -1,5 +1,5 @@
 /// Expect:
-/// - error: "Can't access function ‘private_static_function’ from scope None, because it is marked private\n"
+/// - error: "Can't access method ‘private_static_function’, because it is marked private\n"
 
 class Foo {
     function private_static_function() {}

--- a/tests/typechecker/struct_private.jakt
+++ b/tests/typechecker/struct_private.jakt
@@ -1,5 +1,5 @@
 /// Expect:
-/// - error: "Can't access function ‘parts’ from scope None, because it is marked private\n"
+/// - error: "Can't access method ‘parts’, because it is marked private\n"
 
 struct WeirdEncapsulation {
     private function parts(this) {}

--- a/tests/typechecker/struct_private_field.jakt
+++ b/tests/typechecker/struct_private_field.jakt
@@ -1,5 +1,5 @@
 /// Expect:
-/// - error: "Can't access variable ‘age’ from scope None, because it is marked private\n"
+/// - error: "Can't access field ‘age’, because it is marked private\n"
 
 struct WeirdEncapsulation {
     private age: i32


### PR DESCRIPTION
This cleans up some error messages for private visibility.

* Removes `from scope None` since it doesn't make sense
* Adds hint for private constructors
* Renames `variable` to `field` and `function` to `method`, to be closer to terms people may expect

Before:
```
Error: Can't access function ‘JsonParser’ from scope None, because it is marked private
----- samples/apps/json.jakt:346:18
 345 | function parse_json(input: String) throws -> JsonValue {
 346 |     mut parser = JsonParser(input, index: 0)
                        ^- Can't access function ‘JsonParser’ from scope None, because it is marked private
 347 |     return parser.parse()
-----
```
Now:
```
Error: Can't access constructor ‘JsonParser’, because it is marked private
----- samples/apps/json.jakt:346:18
 345 | function parse_json(input: String) throws -> JsonValue {
 346 |     mut parser = JsonParser(input, index: 0)
                        ^- Can't access constructor ‘JsonParser’, because it is marked private
 347 |     return parser.parse()
-----
Hint: Private constructors are created if any fields are private
----- samples/apps/json.jakt:346:18
 345 | function parse_json(input: String) throws -> JsonValue {
 346 |     mut parser = JsonParser(input, index: 0)
                        ^- Private constructors are created if any fields are private
 347 |     return parser.parse()
-----
```
