### PR TITLE
types+codegen: Make checks for prelude module more explicit

### DIFF
--- a/selfhost/codegen.jakt
+++ b/selfhost/codegen.jakt
@@ -2333,7 +2333,7 @@ struct CodeGenerator {
                             }
                         }
                     } else {
-                        if not (type_module.is_root or type_module.id.id == 0 or function_.linkage is External or (not call.namespace_.is_empty() and call.namespace_[0].name == type_module.name))
+                        if not (type_module.is_root or type_module.is_prelude() or function_.linkage is External or (not call.namespace_.is_empty() and call.namespace_[0].name == type_module.name))
                         {
                             output += type_module.name
                             output += "::"
@@ -2649,7 +2649,7 @@ struct CodeGenerator {
         mut output = ""
         let type_module = .program.get_module(id.module)
         // For prelude generic instances prefix with "JaktInternal::" so that there aren't naming clashes
-        if type_module.id.id == 0 {
+        if type_module.is_prelude() {
             output += "JaktInternal::"
         } else if not type_module.is_root {
             output += type_module.name

--- a/selfhost/types.jakt
+++ b/selfhost/types.jakt
@@ -420,6 +420,7 @@ class Module {
     public imports: [ModuleId]
 
     public is_root: bool
+    public function is_prelude(this) -> bool => .id.id == 0
 
     public function new_type_variable(mut this) throws -> TypeId {
         let new_id = .types.size()


### PR DESCRIPTION
`module.is_prelude()` is a lot clearer than `module.id.id == 0`. :^)