### PR TITLE
selfhost: Improve error messages when using a reserved identifier

### DIFF
--- a/selfhost/lexer.jakt
+++ b/selfhost/lexer.jakt
@@ -492,7 +492,6 @@ struct Lexer {
 
             if end - start >= 6 and string.substring(start: 0, length: 6) == "__jakt" {
                 .error("reserved identifier name", span)
-                return Token::Garbage(span)
             }
 
             return Token::from_keyword_or_identifier(string, span)


### PR DESCRIPTION
This improves the error messages generated from #1076 when using a reserved identifier from 

```
----- foo.jakt:2:9
 1 | function main() {
 2 |     let __jakt_var_1 = "hello"
              ^- reserved identifier name
 3 |     try foo() catch {
-----
Error: reserved identifier name
----- foo.jakt:4:15
 3 |     try foo() catch {
 4 |         print(__jakt_var_1)
                    ^- reserved identifier name
 5 |     }
-----
Error: Expected initializer
----- foo.jakt:2:9
 1 | function main() {
 2 |     let __jakt_var_1 = "hello"
              ^- Expected initializer
 3 |     try foo() catch {
  1 selfhost: Improve error messages when using a reserved identifier
-----
Error: Unsupported expression
----- foo.jakt:2:9
 1 | function main() {
 2 |     let __jakt_var_1 = "hello"
              ^- Unsupported expression
 3 |     try foo() catch {
-----
Error: Unsupported expression
----- foo.jakt:4:15
 3 |     try foo() catch {
 4 |         print(__jakt_var_1)
                    ^- Unsupported expression
 5 |     }
-----
Error: Type mismatch: expected ‘void’, but got ‘String’
----- foo.jakt:2:24
 1 | function main() {
 2 |     let __jakt_var_1 = "hello"
                             ^- Type mismatch: expected ‘void’, but got ‘String’
 3 |     try foo() catch {
-----
Error: Assignment to immutable variable
----- foo.jakt:2:9
 1 | function main() {
 2 |     let __jakt_var_1 = "hello"
              ^- Assignment to immutable variable
 3 |     try foo() catch {
-----
```

To just 

```
----- foo.jakt:2:9
 1 | function main() {
 2 |     let __jakt_var_1 = "hello"
              ^- reserved identifier name
 3 |     try foo() catch {
-----
Error: reserved identifier name
----- foo.jakt:4:15
 3 |     try foo() catch {
 4 |         print(__jakt_var_1)
                    ^- reserved identifier name
 5 |     }
-----
```