### PR TITLE
main: Exit with non-zero exit if clang fails

### DIFF
--- a/selfhost/main.jakt
+++ b/selfhost/main.jakt
@@ -397,7 +397,13 @@ function main(args: [String]) {
         )
 
         if run_executable and compiler_status == 0 {
-            system(output_filename.c_string())
+            return system(output_filename.c_string())
+        } else {
+            if compiler_status == 0 {
+                return 0
+            } else {
+                return 1
+            }
         }
     }
 }


### PR DESCRIPTION
With this PR, if clang exits with a non-zero exit code, we'll exit jakt with a non-zero exit code. This will allow shell scripts, CI, etc to pick up on compiler errors that are coming from clang and not just directly from jakt.