### PR TITLE
typechecker: Add type hint for match statement return type

### DIFF
--- a/samples/match/match_optional_inference.jakt
+++ b/samples/match/match_optional_inference.jakt
@@ -1,0 +1,33 @@
+/// Expect:
+/// - output: "None\nNone\n"
+
+enum Foo {
+    Bar
+    Baz
+}
+
+function main() {
+    let a = Foo::Baz
+
+    let b = match a {
+        Bar => {
+            yield Some(2)
+        }
+        Baz => {
+            yield None
+        }
+    }
+
+    println("{}", b)
+
+    let c:i64? = match a {
+        Bar => {
+            yield 2
+        }
+        Baz => {
+            yield None
+        }
+    }
+
+    println("{}", c)
+}

--- a/samples/match/match_type_hint.jakt
+++ b/samples/match/match_type_hint.jakt
@@ -1,0 +1,18 @@
+/// Expect:
+/// - output: "2\n"
+
+enum Foo {
+    Bar
+    Baz
+}
+
+function main() {
+    let a = Foo::Bar
+
+    let b: i32? = match a {
+        Bar => 2
+        Baz => None
+    }
+
+    println("{}", b.value_or(0i32))
+}

--- a/selfhost/codegen.jakt
+++ b/selfhost/codegen.jakt
@@ -2440,7 +2440,10 @@ struct CodeGenerator {
             output += block_label
             output += ":; "
             output += block_var
-            output += ".release_value(); })"
+            if not block.yielded_none {
+                output += ".release_value()"
+            }
+            output += "; })"
         }
 
         return output

--- a/selfhost/interpreter.jakt
+++ b/selfhost/interpreter.jakt
@@ -1903,7 +1903,9 @@ class Interpreter {
                             statements: [else_statement!]
                             scope_id: then_block.scope_id
                             control_flow: BlockControlFlow::MayReturn
-                            yielded_type: None))
+                            yielded_type: None
+                            yielded_none: false
+                        ))
                         else => None
                     }
                 }

--- a/selfhost/typechecker.jakt
+++ b/selfhost/typechecker.jakt
@@ -952,6 +952,7 @@ struct Typechecker {
                     scope_id: block_scope_id
                     control_flow: BlockControlFlow::MayReturn
                     yielded_type: TypeId::none()
+                    yielded_none: false
                 )
                 can_throw: func.can_throw
                 type: func.type
@@ -1072,6 +1073,7 @@ struct Typechecker {
                     scope_id: block_scope_id
                     control_flow: BlockControlFlow::MayReturn
                     yielded_type: TypeId::none()
+                    yielded_none: false
                 )
                 can_throw: constructor_can_throw
                 type: FunctionType::ImplicitConstructor
@@ -1174,6 +1176,7 @@ struct Typechecker {
                     scope_id: block_scope_id
                     control_flow: BlockControlFlow::MayReturn
                     yielded_type: TypeId::none()
+                    yielded_none: false
                 )
                 can_throw: func.can_throw
                 type: func.type
@@ -1485,7 +1488,9 @@ struct Typechecker {
                                     statements: []
                                     scope_id: block_scope_id
                                     control_flow: BlockControlFlow::MayReturn
-                                    yielded_type: TypeId::none()),
+                                    yielded_type: TypeId::none()
+                                    yielded_none: false
+                                ),
                                 can_throw: can_function_throw,
                                 type: FunctionType::ImplicitEnumConstructor,
                                 linkage: FunctionLinkage::Internal,
@@ -1527,7 +1532,9 @@ struct Typechecker {
                                     statements: [],
                                     scope_id: block_scope_id,
                                     control_flow: BlockControlFlow::AlwaysReturns,
-                                    yielded_type: TypeId::none()),
+                                    yielded_type: TypeId::none()
+                                    yielded_none: false
+                                ),
                                 can_throw: can_function_throw,
                                 type: FunctionType::ImplicitEnumConstructor,
                                 linkage: FunctionLinkage::Internal,
@@ -1558,7 +1565,9 @@ struct Typechecker {
                                     statements: []
                                     scope_id: block_scope_id
                                     control_flow: BlockControlFlow::AlwaysReturns
-                                    yielded_type: TypeId::none()),
+                                    yielded_type: TypeId::none()
+                                    yielded_none: false
+                                ),
                                 can_throw: can_function_throw,
                                 type: FunctionType::ImplicitEnumConstructor,
                                 linkage: FunctionLinkage::Internal,
@@ -1762,6 +1771,7 @@ struct Typechecker {
                 scope_id: block_scope_id
                 control_flow: BlockControlFlow::MayReturn
                 yielded_type: TypeId::none()
+                yielded_none: false
             )
             can_throw: parsed_function.can_throw
             type: FunctionType::Normal
@@ -2573,7 +2583,7 @@ struct Typechecker {
         return type_id
     }
 
-    function typecheck_block(mut this, anon parsed_block: ParsedBlock, parent_scope_id: ScopeId, safety_mode: SafetyMode) throws -> CheckedBlock {
+    function typecheck_block(mut this, anon parsed_block: ParsedBlock, parent_scope_id: ScopeId, safety_mode: SafetyMode, yield_type_hint: TypeId? = None) throws -> CheckedBlock {
         let parent_throws = .get_scope(parent_scope_id).can_throw
         let block_scope_id = .create_scope(parent_scope_id, can_throw: parent_throws, debug_name: "block")
         mut checked_block = CheckedBlock(
@@ -2581,6 +2591,7 @@ struct Typechecker {
             scope_id: block_scope_id
             control_flow: BlockControlFlow::MayReturn
             yielded_type: TypeId::none()
+            yielded_none: false
         )
         // FIXME: Use [TypeId: TypeID] without TypeId.to_string()/TypeId::from_string() workaround
         mut generic_inferences: [String: String] = [:]
@@ -2593,6 +2604,7 @@ struct Typechecker {
                 statement: parsed_statement
                 scope_id: block_scope_id
                 safety_mode
+                type_hint: yield_type_hint
             )
 
             checked_block.control_flow = checked_block.control_flow.updated(.statement_control_flow(checked_statement))
@@ -2605,9 +2617,15 @@ struct Typechecker {
                 CheckedStatement::Yield(expr) => Some(expr)
                 else => None
             }
+
             if yield_span.has_value() and checked_yield_expression.has_value() {
                 let type_var_type_id = checked_yield_expression!.type()
                 let type_ = .resolve_type_var(type_var_type_id , scope_id: block_scope_id)
+
+                if checked_yield_expression! is OptionalNone {
+                    checked_block.yielded_none = true
+                }
+
                 if checked_block.yielded_type.has_value() {
                     // TODO check types for compat
                     .check_types_for_compat(
@@ -2820,7 +2838,9 @@ struct Typechecker {
                         statements: []
                         scope_id
                         control_flow: BlockControlFlow::MayReturn
-                        yielded_type: None)
+                        yielded_type: None
+                        yielded_none: false
+                    )
                     can_throw
                     type: FunctionType::Normal
                     linkage: FunctionLinkage::Internal
@@ -3116,10 +3136,10 @@ struct Typechecker {
         return type_id
     }
 
-    function typecheck_statement(mut this, anon statement: ParsedStatement, scope_id: ScopeId, safety_mode: SafetyMode) throws -> CheckedStatement => match statement {
+    function typecheck_statement(mut this, anon statement: ParsedStatement, scope_id: ScopeId, safety_mode: SafetyMode, type_hint: TypeId? = None) throws -> CheckedStatement => match statement {
         Expression(expr, span) => CheckedStatement::Expression(expr: .typecheck_expression(expr, scope_id, safety_mode, type_hint: TypeId::none()), span)
         UnsafeBlock(block, span) => CheckedStatement::Block(block: .typecheck_block(block, parent_scope_id: scope_id, safety_mode: SafetyMode::Unsafe), span)
-        Yield(expr, span) => CheckedStatement::Yield(expr: .typecheck_expression(expr, scope_id, safety_mode, type_hint: TypeId::none()), span)
+        Yield(expr, span) => CheckedStatement::Yield(expr: .typecheck_expression(expr, scope_id, safety_mode, type_hint: type_hint), span)
         Return(expr, span) => .typecheck_return(expr, span, scope_id, safety_mode)
         Block(block, span) => .typecheck_block_statement(parsed_block: block, scope_id, safety_mode, span)
         InlineCpp(block, span) => .typecheck_inline_cpp(block, span, safety_mode)
@@ -4274,7 +4294,15 @@ struct Typechecker {
             yield CheckedExpression::BinaryOp(lhs: checked_lhs, op, rhs: checked_rhs, span, type_id: output_type)
         }
         OptionalNone(span) => {
-            yield CheckedExpression::OptionalNone(span, type_id: unknown_type_id())
+            mut type_hint_unwrapped = type_hint
+            if type_hint.has_value() and .get_type(type_hint!) is GenericInstance(id, args) {
+                let optional_struct_id = .find_struct_in_prelude("Optional")
+                if id.equals(optional_struct_id) {
+                    type_hint_unwrapped = args[0]
+                }
+            }
+
+            yield CheckedExpression::OptionalNone(span, type_id: type_hint_unwrapped ?? unknown_type_id())
         }
         OptionalSome(expr, span) => {
             let checked_expr = .typecheck_expression(expr, scope_id, safety_mode, type_hint: None)
@@ -4433,7 +4461,7 @@ struct Typechecker {
         }
         Garbage(span) => CheckedExpression::Garbage(span)
         NamespacedVar(name, namespace_, span) => .typecheck_namespaced_var_or_simple_enum_constructor_call(name, namespace_, scope_id, safety_mode, type_hint, span)
-        Match(expr, cases, span) => .typecheck_match(expr, cases, span, scope_id, safety_mode)
+        Match(expr, cases, span) => .typecheck_match(expr, cases, span, scope_id, safety_mode, type_hint)
         EnumVariantArg(expr: inner_expr, arg, enum_variant, span) => {
             let checked_expr = .typecheck_expression_and_dereference_if_needed(inner_expr, scope_id, safety_mode, type_hint: None, span)
             mut checked_binding = CheckedEnumVariantBinding(name: "", binding: "", type_id: unknown_type_id(), span)
@@ -5232,7 +5260,7 @@ struct Typechecker {
         mut result_type = final_result_type
         let checked_match_body = match body {
             Block(block) => {
-                let checked_block = .typecheck_block(parsed_block: block, parent_scope_id: scope_id, safety_mode)
+                let checked_block = .typecheck_block(parsed_block: block, parent_scope_id: scope_id, safety_mode, yield_type_hint: final_result_type)
 
                 if checked_block.control_flow.may_return() or checked_block.yielded_type.has_value() {
                     let block_type_id = checked_block.yielded_type ?? void_type_id()

--- a/selfhost/typechecker.jakt
+++ b/selfhost/typechecker.jakt
@@ -4038,6 +4038,14 @@ struct Typechecker {
         IndexedStruct(expr, field, span, is_optional) => .typecheck_indexed_struct(expr, field, scope_id, is_optional, safety_mode, span)
         Boolean(val, span) => CheckedExpression::Boolean(val, span)
         NumericConstant(val, span) => {
+            mut type_hint_unwrapped = type_hint
+            if type_hint.has_value() and .get_type(type_hint!) is GenericInstance(id, args) {
+                let optional_struct_id = .find_struct_in_prelude("Optional")
+                if id.equals(optional_struct_id) {
+                    type_hint_unwrapped = args[0]
+                }
+            }
+
             yield match val {
                 I8(val) => CheckedExpression::NumericConstant(val: CheckedNumericConstant::I8(val), span, type_id: builtin(BuiltinType::I8))
                 I16(val) => CheckedExpression::NumericConstant(val: CheckedNumericConstant::I16(val), span, type_id: builtin(BuiltinType::I16))
@@ -4050,8 +4058,8 @@ struct Typechecker {
                 USize(val) => CheckedExpression::NumericConstant(val: CheckedNumericConstant::USize(val), span, type_id: builtin(BuiltinType::Usize))
                 F32(val) => CheckedExpression::NumericConstant(val: CheckedNumericConstant::F32(val), span, type_id: builtin(BuiltinType::F32))
                 F64(val) => CheckedExpression::NumericConstant(val: CheckedNumericConstant::F64(val), span, type_id: builtin(BuiltinType::F64))
-                UnknownSigned(val) => .infer_signed_int(val, span, type_hint)
-                UnknownUnsigned(val) => .infer_unsigned_int(val, span, type_hint)
+                UnknownSigned(val) => .infer_signed_int(val, span, type_hint: type_hint_unwrapped)
+                UnknownUnsigned(val) => .infer_unsigned_int(val, span, type_hint: type_hint_unwrapped)
             }
         }
         SingleQuotedString(val, span) => CheckedExpression::CharacterConstant(val, span)

--- a/selfhost/typechecker.jakt
+++ b/selfhost/typechecker.jakt
@@ -4825,14 +4825,18 @@ struct Typechecker {
         )
     }
 
-    function typecheck_match(mut this, expr: ParsedExpression, cases: [ParsedMatchCase], span: Span, scope_id: ScopeId, safety_mode: SafetyMode) throws -> CheckedExpression {
+    function typecheck_match(mut this, expr: ParsedExpression, cases: [ParsedMatchCase], span: Span, scope_id: ScopeId, safety_mode: SafetyMode, type_hint: TypeId?) throws -> CheckedExpression {
         let checked_expr = .typecheck_expression_and_dereference_if_needed(expr, scope_id, safety_mode, type_hint: None, span)
         let subject_type_id = checked_expr.type()
         let type_to_match_on = .get_type(subject_type_id)
         mut checked_cases: [CheckedMatchCase] = []
 
         mut generic_inferences: [String: String] = [:]
+
         mut final_result_type: TypeId? = None
+        if type_hint.has_value() and not type_hint!.equals(unknown_type_id()) and not .get_type(type_hint!) is TypeVariable {
+            final_result_type = type_hint
+        }
 
         if type_to_match_on is GenericEnumInstance(id, args) {
             let enum_ = .get_enum(id)
@@ -4975,7 +4979,7 @@ struct Typechecker {
                                                         .dump_type_hint(type_id: matched_field_variable!.type_id, span: arg.span)
                                                     }
 
-                                                   let var_id = module.add_variable(CheckedVariable(
+                                                    let var_id = module.add_variable(CheckedVariable(
                                                         name: arg.binding
                                                         type_id: substituted_type_id
                                                         is_mutable: false
@@ -5077,12 +5081,10 @@ struct Typechecker {
                             }
                         }
 
-                        .error(format("match expression is not exhaustive, missing variants are: {}", str_missing_values.to_string()), span)
+                        .error(format("Match expression is not exhaustive, missing variants are: {}", str_missing_values.to_string()), span)
                     }
-                } else {
-                    if seen_catch_all {
-                        .error("all variants are covered, but an irrefutable pattern is also present", span)
-                    }
+                } else if seen_catch_all {
+                    .error("All variants are covered, but an irrefutable pattern is also present", span)
                 }
             }
             Void => {
@@ -5177,7 +5179,6 @@ struct Typechecker {
                                 is_value_match = true
 
                                 let checked_expression = .typecheck_expression(expr, scope_id, safety_mode, type_hint: Some(subject_type_id))
-
                                 if not checked_expression.to_number_constant(program: .program).has_value() {
                                     all_variants_constant = false
                                 }

--- a/selfhost/types.jakt
+++ b/selfhost/types.jakt
@@ -664,6 +664,7 @@ struct CheckedBlock {
     scope_id: ScopeId
     control_flow: BlockControlFlow
     yielded_type: TypeId?
+    yielded_none: bool
 }
 
 struct CheckedStruct {

--- a/tests/typechecker/match_exhaustive_catchall.jakt
+++ b/tests/typechecker/match_exhaustive_catchall.jakt
@@ -1,5 +1,5 @@
 /// Expect:
-/// - error: "all variants are covered, but an irrefutable pattern is also present"
+/// - error: "All variants are covered, but an irrefutable pattern is also present"
 
 enum Foo {
     X

--- a/tests/typechecker/match_non_exhaustive.jakt
+++ b/tests/typechecker/match_non_exhaustive.jakt
@@ -1,5 +1,5 @@
 /// Expect:
-/// - error: "match expression is not exhaustive, missing variants are: X"
+/// - error: "Match expression is not exhaustive, missing variants are: X"
 
 enum Foo {
     X

--- a/tests/typechecker/numeric_inference_optional.jakt
+++ b/tests/typechecker/numeric_inference_optional.jakt
@@ -1,0 +1,8 @@
+/// Expect:
+/// - output: "2\n"
+
+function main() {
+    let foo: i32? = 2
+
+    println("{}", foo!)
+}


### PR DESCRIPTION
Previously for an Optional match you would need
```
let b = match a {
    Bar => Some(2)
    Baz => {
        let ret: i64? = None

        yield ret
    }
}
```

With a type hint it can now be written as
```
let b: i64? = match a {
    Bar => 2
    Baz => None
}
```

Also adds numeric inference on optional types.