### PR TITLE
editors/vscode: Small highlighting improvements

### DIFF
--- a/editors/vscode/syntaxes/jakt.tmLanguage.json
+++ b/editors/vscode/syntaxes/jakt.tmLanguage.json
@@ -786,7 +786,7 @@
       "patterns": [
         {
           "name": "keyword.operator.logic.jakt",
-          "match": "\\b(not|and|or)\\b"
+          "match": "\\b(not|and|or|is)\\b"
         },
         {
           "name": "keyword.operator.arithmetic.jakt",

--- a/editors/vscode/syntaxes/jakt.tmLanguage.json
+++ b/editors/vscode/syntaxes/jakt.tmLanguage.json
@@ -522,13 +522,10 @@
           "include": "#this"
         },
         {
-          "match": "\\b(mut)\\s+(this)\\b",
+          "match": "\\b(mut)\\b",
           "captures": {
             "1": {
               "name": "storage.modifier.mut.argument.jakt"
-            },
-            "2": {
-              "name": "variable.language.this.jakt"
             }
           }
         },


### PR DESCRIPTION
This PR fixes "mut" highlighting in function argument lists (before only the "mut this" argument was highlighted) and adds highlighting for the "is" keyword.

Before:

![obraz](https://user-images.githubusercontent.com/36564831/185800788-d512eceb-e7a1-48ac-b703-d25f417b224e.png)

After:

![obraz](https://user-images.githubusercontent.com/36564831/185800808-59473fbf-12da-45db-82ad-bcb25779023d.png)