### PR TITLE
jakttest: Enable Windows execution by using a PowerShell script

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,7 +73,12 @@ jobs:
      - run: git config --global core.autocrlf false
      - uses: actions/checkout@v2
      - name: Configure CMake
-       run: cmake -B build -G "Visual Studio 17 2022" -A x64 -T ClangCL -DFINAL_STAGE=2
+       run: cmake -B build -G "Visual Studio 17 2022" -A x64 -T ClangCL -DFINAL_STAGE=1
 
-     - name: Build Jakt Stage 2 Selfhost
+     - name: Build Jakt Stage 1 Selfhost
        run: cmake --build build --config Release
+
+     - name: Test Jakt Stage 1
+       run: |
+         ls -l build
+         .\build\Release\jakttest.exe

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -125,7 +125,7 @@ endif()
 add_custom_command(
   TARGET "jakt_stage${FINAL_STAGE}"
   POST_BUILD
-  COMMAND "${CMAKE_COMMAND}" -E ${LINK_COMMAND}  "$<${LINK_GENEX}:jakt_stage${FINAL_STAGE}>" "${CMAKE_BINARY_DIR}/jakt"
+  COMMAND "${CMAKE_COMMAND}" -E ${LINK_COMMAND}  "$<${LINK_GENEX}:jakt_stage${FINAL_STAGE}>" "${CMAKE_BINARY_DIR}/jakt${CMAKE_EXECUTABLE_SUFFIX}"
   VERBATIM
 )
 

--- a/bootstrap/stage0/runtime/io.h
+++ b/bootstrap/stage0/runtime/io.h
@@ -1,0 +1,14 @@
+/*
+ * Copyright (c) 2022, Andrew Kaster <akaster@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+// This file is a workaround for missing os-detection logic for extern "C" imports in jakt
+// On Win32, we want the header, on Unix-like OS's we don't.
+// See #1015
+#ifdef _WIN32
+#    include_next <io.h>
+#endif

--- a/cmake/install-rules.cmake
+++ b/cmake/install-rules.cmake
@@ -68,5 +68,5 @@ endif()
 install(CODE "execute_process(COMMAND \
                               ${CMAKE_COMMAND} -E ${LINK_COMMAND} \
                                                   \"${final_stage_install_target}\" \
-                                                  ${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_BINDIR}/jakt)"
+                                                  ${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_BINDIR}/jakt${CMAKE_EXECUTABLE_SUFFIX})"
 )

--- a/jakttest/jakttest.jakt
+++ b/jakttest/jakttest.jakt
@@ -128,6 +128,9 @@ import extern "os.h" {
         extern function get_system_temporary_directory() throws -> String
 
         extern function ignore_sigchild() throws
+
+        /// Returns "./jakttest/run_once.sh" on Unix, and a complex PowerShell invocation on windows
+        extern function get_script_execution_string() throws -> String
     }
 }
 
@@ -148,7 +151,9 @@ function compare_test(bytes: [u8], expected: String) throws -> bool {
         builder.append(b)
     }
 
-    let builder_output = builder.to_string()
+    mut builder_output = builder.to_string()
+    // Strip windows newlines
+    builder_output = builder_output.replace(replace: "\r", with: "")
 
     if builder_output != expected {
         // TODO: return more information about expected/parsed
@@ -573,7 +578,8 @@ struct TestScheduler {
         os::ignore_sigchild()
         mut scheduler = TestScheduler::create(directories, collect_reasons)
         // pre-allocate the command buffer to avoid allocating inside a loop
-        mut command_buffer: [String] = ["./jakttest/run-one.sh" "" ""]
+        let run_once_script = os::get_script_execution_string()
+        mut command_buffer: [String] = [run_once_script "" ""]
         while not tests.is_empty() {
             let dir_index = scheduler.wait_for_free_directory()
             mut test = tests.pop()!

--- a/jakttest/os.cpp
+++ b/jakttest/os.cpp
@@ -16,6 +16,7 @@
 #define WIN32_LEAN_AND_MEAN
 #include <windows.h>
 #include <sysinfoapi.h>
+#include <direct.h>
 #endif
 
 namespace Jakt::os {
@@ -46,6 +47,11 @@ ErrorOr<void> ignore_sigchild()
         return Error::from_errno(errno);
     return {};
 }
+
+ErrorOr<String> get_script_execution_string()
+{
+    return String("./jakttest/run-one.sh");
+}
 #else
 ErrorOr<size_t> get_num_cpus()
 {
@@ -64,6 +70,15 @@ ErrorOr<String> get_system_temporary_directory()
 ErrorOr<void> ignore_sigchild()
 {
     return {};
+}
+
+ErrorOr<String> get_script_execution_string()
+{
+    char path[MAX_PATH];
+    char* cwd = getcwd(path, sizeof(path));
+    VERIFY(cwd != nullptr);
+    return String::formatted("powershell.exe -ExecutionPolicy RemoteSigned "
+                            "-File ./jakttest/run-one.ps1 {}", cwd);
 }
 #endif
 }

--- a/jakttest/os.h
+++ b/jakttest/os.h
@@ -9,4 +9,5 @@ namespace Jakt::os {
     ErrorOr<size_t> get_num_cpus();
     ErrorOr<String> get_system_temporary_directory();
     ErrorOr<void> ignore_sigchild();
+    ErrorOr<String> get_script_execution_string();
 }

--- a/jakttest/run-one.ps1
+++ b/jakttest/run-one.ps1
@@ -1,0 +1,64 @@
+# Run one jakt test
+
+# https://github.com/microsoft/vswhere/wiki/Start-Developer-Command-Prompt#using-powershell
+$installationPath = Invoke-Expression "& '${Env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe' -prerelease -latest -property installationPath"
+
+# https://developercommunity.visualstudio.com/t/x64-developer-powershell-for-vs-2019/943058#T-N1062776
+Import-Module "$installationPath\Common7\Tools\Microsoft.VisualStudio.DevShell.dll"
+Enter-VsDevShell -VsInstallPath "$installationPath" -DevCmdArguments '-arch=x64 -no_logo'
+
+cd $Args[0]
+
+# Since we're running the output binary from a different
+# working directory, we need the full path of the binary.
+$temp_dir = resolve-path $Args[1]
+$file = $Args[2]
+
+$jakt_args = @("$file",
+    "-B",
+    "$temp_dir",
+    "-o",
+    "output",
+    "-S"
+)
+
+# Generate C++ code
+$jakt_process = Start-Process .\build\jakt.exe -ArgumentList $jakt_args -RedirectStandardError "$temp_dir\compile_jakt.err" -PassThru -Wait -NoNewWindow
+if ($jakt_process.ExitCode -ne 0) {
+	exit 3
+}
+
+$clang_args = @( "-fcolor-diagnostics",
+    "--target=x86_64-pc-windows-msvc",
+    "-std=c++20",
+    "-Wno-unknown-warning-option",
+    "-Wno-trigraphs",
+    "-Wno-parentheses-equality",
+    "-Wno-unqualified-std-cast-call",
+    "-Wno-user-defined-literals",
+    "-Wno-deprecated-declarations",
+    "-Wno-unknown-attributes",
+    "-fuse-ld=lld",
+    "-fno-exceptions",
+    "-O0",
+    "-Iruntime",
+    "-DJAKT_CONTINUE_ON_PANIC",
+    "-o",
+    "$temp_dir/output.exe",
+    "$temp_dir\output.cpp"
+)
+
+$clang_process = Start-Process clang++ -ArgumentList $clang_args -RedirectStandardError "$temp_dir\compile_cpp.err" -PassThru -Wait -NoNewWindow
+
+if ($clang_process.ExitCode -ne 0) {
+	exit 2
+}
+
+# Run the executable inside the parent directory of the test file
+cd (Get-Item $file).DirectoryName
+$test_process = Start-Process "$temp_dir\output.exe" -RedirectStandardOutput "$temp_dir\runtest.out" -RedirectStandardError "$temp_dir\runtest.err" -PassThru -Wait -NoNewWindow
+
+if ($test_process.ExitCode -ne 0) {
+	exit 1
+}
+

--- a/runtime/io.h
+++ b/runtime/io.h
@@ -1,0 +1,14 @@
+/*
+ * Copyright (c) 2022, Andrew Kaster <akaster@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+// This file is a workaround for missing os-detection logic for extern "C" imports in jakt
+// On Win32, we want the header, on Unix-like OS's we don't.
+// See #1015
+#ifdef _WIN32
+#    include_next <io.h>
+#endif

--- a/samples/imports/import_extern_c.jakt
+++ b/samples/imports/import_extern_c.jakt
@@ -12,6 +12,10 @@ import extern c "fcntl.h"  {
     extern function close(fd: i32) -> i32
 }
 
+// FIXME: Windows-only, for open/read/close (#1015)
+import extern c "io.h" {
+}
+
 function main() {
     // NOTE: that zero is O_RDONLY.
     let fd = open(path: "import_extern_text.txt".c_string(),  flags: 0)


### PR DESCRIPTION
This feels even more hacky than run-one.sh, but does appear to work.

Also fix a few bugs in process.cpp along the way that were never
tested with the initial implementation.

Add CI as well.