### PR TITLE
typechecker: Allow yield after guard statement in block

### DIFF
--- a/samples/match/match_yield_after_guard.jakt
+++ b/samples/match/match_yield_after_guard.jakt
@@ -1,0 +1,24 @@
+/// Expect:
+/// - output: "3\n"
+
+enum Foo {
+    Bar(id: i64)
+    Baz
+}
+
+function main() {
+    let a = Foo::Bar(id: 3)
+
+    let b = match a {
+        Bar(id) => {
+            guard id > 2 else {
+                return 0
+            }
+
+            yield id
+        }
+        else => 0
+    }
+
+    println("{}", b)
+}

--- a/selfhost/codegen.jakt
+++ b/selfhost/codegen.jakt
@@ -1523,7 +1523,6 @@ struct CodeGenerator {
 
             yield output
         }
-
         JaktSet(vals, span, type_id, inner_type_id) => {
             mut output = ""
             output += format("({}((Set<{}>::create_with_values({{", .current_error_handler(), .codegen_type(inner_type_id))

--- a/selfhost/typechecker.jakt
+++ b/selfhost/typechecker.jakt
@@ -2611,6 +2611,7 @@ struct Typechecker {
 
             let yield_span: Span? = match parsed_statement {
                 ParsedStatement::Yield(expr) => Some(expr.span())
+                ParsedStatement::Guard(expr) => Some(expr.span())
                 else => None
             }
             let checked_yield_expression: CheckedExpression? = match checked_statement {
@@ -3183,15 +3184,34 @@ struct Typechecker {
         }
 
         let checked_block = .typecheck_block(new_then_block, parent_scope_id: scope_id, safety_mode)
-        if checked_block.yielded_type.has_value() {
-            .error("A 'guard' block is not allowed to yield values", new_then_block.find_yield_span()!)
-        }
-
         mut checked_else: CheckedStatement? = None
         if new_else_statement.has_value() {
             checked_else = .typecheck_statement(new_else_statement!, scope_id, safety_mode)
         }
-        
+
+        if checked_block.yielded_type.has_value() {
+            return CheckedStatement::Yield(
+                expr: CheckedExpression::Match(
+                    expr: checked_condition,
+                    match_cases: [
+                        CheckedMatchCase::Expression(
+                            expression: CheckedExpression::Boolean(val: true, span)
+                            body: CheckedMatchBody::Expression(CheckedExpression::Block(block: checked_block, span, type_id: checked_block.yielded_type!))
+                            marker_span: span
+                        ),
+                        CheckedMatchCase::CatchAll(
+                            body: CheckedMatchBody::Block(checked_else_block)
+                            marker_span: span
+                        )
+                    ]
+                    span
+                    type_id: checked_block.yielded_type!
+                    all_variants_constant: false
+                ),
+                span
+            )
+        }
+
         return CheckedStatement::If(condition: checked_condition, then_block: checked_block, else_statement: checked_else, span)
     }
 


### PR DESCRIPTION
In cases where there is a yield statement guard is rewritten as a
yielded match with 2 cases rather than an if statement.