### PR TITLE
typecheker+codegen: Add basic support for ranges in match cases

### DIFF
--- a/samples/match/match_ranges.jakt
+++ b/samples/match/match_ranges.jakt
@@ -1,0 +1,14 @@
+/// Expect:
+/// - output: "bar\n"
+
+function main() {
+    let x = 42
+
+    let y = match x {
+        0..30 => "foo"
+        30..100 => "bar"
+        else => "baz"
+    }
+
+    println("{}", y)
+}

--- a/selfhost/codegen.jakt
+++ b/selfhost/codegen.jakt
@@ -1805,8 +1805,24 @@ struct CodeGenerator {
                     if not first {
                         output += "else "
                     }
-                    output += "if (__jakt_enum_value == "
-                    output += .codegen_expression(expression)
+                    if expression is Range(from, to) {
+                        output += "if (__jakt_enum_value"
+                        if from.has_value() {
+                            output += " >= "
+                            output += .codegen_expression(from!)
+                        }
+                        
+                        if to.has_value() {
+                            if from.has_value() {
+                                output += "&& __jakt_enum_value "
+                            }
+                            output += "< "
+                            output += .codegen_expression(to!)
+                        }
+                    } else {
+                        output += "if (__jakt_enum_value == "
+                        output += .codegen_expression(expression)
+                    }
                     output += ") {\n"
                     output += .codegen_match_body(body, return_type_id)
                     output += "}\n"

--- a/selfhost/typechecker.jakt
+++ b/selfhost/typechecker.jakt
@@ -5238,11 +5238,28 @@ struct Typechecker {
                                     all_variants_constant = false
                                 }
 
+                                mut expression_type = checked_expression.type()
+
+                                if checked_expression is Range(from, to) {
+                                    guard from.has_value() or to.has_value() else {
+                                        .error(
+                                            "There has to be at least a 'from', or a 'to' in a range expression"
+                                            expr.span()
+                                        )
+                                        continue
+                                    }
+                                    if from.has_value() {
+                                        expression_type = from!.type()
+                                    } else if to.has_value() {
+                                        expression_type = to!.type()
+                                    }
+                                }
+
                                 // FIXME: In the future, we should really make this a "does it satisfy some trait" check.
                                 //        For now, we just check that the types are equal.
                                 mut generic_inferences: [String:String] = [:]
                                 .check_types_for_compat(
-                                    lhs_type_id: checked_expression.type()
+                                    lhs_type_id: expression_type
                                     rhs_type_id: subject_type_id
                                     &mut generic_inferences // FIXME: use correct generic inferences
                                     span: case_.marker_span


### PR DESCRIPTION
```
function main() {
    let x = 42

    let y = match x {
        0..30 => "foo"
        30..100 => "bar"
        else => "baz"
    }

    println("{}", y)
}
```