### PR TITLE
typechecker: Report errors in more unreachable cases

### DIFF
--- a/samples/apps/json.jakt
+++ b/samples/apps/json.jakt
@@ -167,8 +167,6 @@ class JsonParser {
 
     function parse_failure(this, error_message: String) throws -> JsonValue {
         throw Error::from_errno(9001)
-        // FIXME: The compiler should notice that we can't get here and allow omitting the return.
-        return JsonValue::Null
     }
 
     function parse_array(mut this) throws -> JsonValue {
@@ -266,7 +264,6 @@ class JsonParser {
             else => {
                 // FIXME: "Unexpected number"
                 throw Error::from_errno(9017)
-                return 1.0
             }
         }
     }

--- a/samples/control_flow/for_throw.jakt
+++ b/samples/control_flow/for_throw.jakt
@@ -4,7 +4,6 @@
 struct Iter {
     function next(this) throws -> i64? {
         throw Error::from_errno(1i32)
-        return None
     }
 }
 

--- a/samples/control_flow/return_nothing.jakt
+++ b/samples/control_flow/return_nothing.jakt
@@ -6,10 +6,8 @@ function foo() {
         println("PASS")
         return
     }
-    println("FAIL")
 }
 
 function main() {
     foo()
-    
 }

--- a/samples/enums/methods.jakt
+++ b/samples/enums/methods.jakt
@@ -14,8 +14,6 @@ enum Foo {
                 return format("anon:{}", id)
             }
         }
-
-        return None
     }
 
     function name(this) throws {

--- a/samples/enums/recursive_enums.jakt
+++ b/samples/enums/recursive_enums.jakt
@@ -23,8 +23,6 @@ function eval(anon ast: AST) -> i64 {
             }
         }
     }
-
-    return 0
 }
 
 function main() {

--- a/selfhost/codegen.jakt
+++ b/selfhost/codegen.jakt
@@ -2970,7 +2970,6 @@ struct CodeGenerator {
 
             return output
         }
-        return ""
     }
 
     function codegen_function_in_namespace(mut this, function_: CheckedFunction, containing_struct: TypeId?) throws -> String {

--- a/selfhost/ide.jakt
+++ b/selfhost/ide.jakt
@@ -324,7 +324,6 @@ function find_span_in_program(program: CheckedProgram, span: Span) throws -> Usa
 
         return find_span_in_scope(program, scope, span)
     }
-
     return None
 }
 
@@ -1217,7 +1216,7 @@ function get_enum_variant_usage_from_type_id_and_name(program: CheckedProgram, t
         }
         panic("unreachable: should have found variant")
     }
-    panic("unreachable: should have found enum")
+    panic("unreachable: should have found variant")
 }
 
 function enum_variant_fields(program: CheckedProgram, checked_enum_variant: CheckedEnumVariant) throws -> [(String?, TypeId)] {

--- a/selfhost/parser.jakt
+++ b/selfhost/parser.jakt
@@ -3403,8 +3403,6 @@ struct Parser {
                 }
                 else => {
                     break
-                    // FIXME: This is unreachable.
-                    yield result
                 }
             }
         }
@@ -3460,8 +3458,6 @@ struct Parser {
                 span: merge_spans(start, .current().span())
             )
         }
-        // FIXME: This is not reachable, so a return should not be required.
-        return ParsedExpression::Garbage(.current().span())
     }
 
     function parse_operator(mut this, allow_assignments: bool) throws -> ParsedExpression {

--- a/selfhost/typechecker.jakt
+++ b/selfhost/typechecker.jakt
@@ -2096,7 +2096,10 @@ struct Typechecker {
             else => BlockControlFlow::MayReturn
         }
         Loop(block) => match block.control_flow {
-            AlwaysTransfersControl(might_break) => BlockControlFlow::AlwaysTransfersControl(might_break)
+            AlwaysTransfersControl(might_break) => match might_break {
+                false => BlockControlFlow::AlwaysTransfersControl(might_break)
+                else => BlockControlFlow::MayReturn
+            }
             NeverReturns => BlockControlFlow::NeverReturns
             AlwaysReturns => BlockControlFlow::AlwaysReturns
             MayReturn => BlockControlFlow::MayReturn
@@ -2595,7 +2598,7 @@ struct Typechecker {
         // FIXME: Use [TypeId: TypeID] without TypeId.to_string()/TypeId::from_string() workaround
         mut generic_inferences: [String: String] = [:]
         for parsed_statement in parsed_block.stmts.iterator() {
-            if checked_block.control_flow.never_returns() {
+            if not checked_block.control_flow.is_reachable() {
                 .error("Unreachable code", parsed_statement.span())
             }
 
@@ -2605,7 +2608,6 @@ struct Typechecker {
                 safety_mode
                 type_hint: yield_type_hint
             )
-
             checked_block.control_flow = checked_block.control_flow.updated(.statement_control_flow(checked_statement))
 
             let yield_span: Span? = match parsed_statement {
@@ -2861,9 +2863,6 @@ struct Typechecker {
                 return .find_or_add_type_id(Type::Function(params: param_type_ids, can_throw, return_type_id))
             }
         }
-
-        // FIXME: This is unreachable but the generated C++ causes a warning.
-        .compiler.panic("should be unreachable")
     }
 
     function typecheck_generic_resolved_type(mut this, name: String, checked_inner_types: [TypeId], scope_id: ScopeId, span: Span) throws -> TypeId {

--- a/selfhost/types.jakt
+++ b/selfhost/types.jakt
@@ -325,7 +325,6 @@ boxed enum Type {
                     return false
                 }
             }
-            return false
         }
     }
 
@@ -577,11 +576,12 @@ enum BlockControlFlow {
         AlwaysTransfersControl(might_break: lhs) => match second {
             NeverReturns | AlwaysReturns => BlockControlFlow::AlwaysTransfersControl(might_break: lhs)
             AlwaysTransfersControl(might_break) => BlockControlFlow::AlwaysTransfersControl(might_break: lhs or might_break)
-            MayReturn => BlockControlFlow::MayReturn
+            MayReturn => BlockControlFlow::AlwaysTransfersControl(might_break: lhs)
             else => BlockControlFlow::AlwaysTransfersControl(might_break: lhs)
         }
         MayReturn => match second {
             else => BlockControlFlow::MayReturn
+            AlwaysTransfersControl(might_break) => BlockControlFlow::AlwaysTransfersControl(might_break)
             PartialAlwaysReturns(might_break) => BlockControlFlow::PartialAlwaysReturns(might_break)
             PartialAlwaysTransfersControl(might_break) => BlockControlFlow::PartialAlwaysTransfersControl(might_break)
             PartialNeverReturns(might_break) => BlockControlFlow::PartialNeverReturns(might_break)
@@ -592,7 +592,7 @@ enum BlockControlFlow {
             AlwaysReturns => BlockControlFlow::AlwaysReturns
             NeverReturns => BlockControlFlow::AlwaysTransfersControl(might_break: lhs)
             AlwaysTransfersControl(might_break) => BlockControlFlow::AlwaysTransfersControl(might_break: lhs or might_break)
-            MayReturn => BlockControlFlow::PartialAlwaysReturns(might_break: lhs)
+            MayReturn => BlockControlFlow::MayReturn
         }
         PartialAlwaysTransfersControl(might_break: lhs) => match second {
             PartialAlwaysTransfersControl(might_break) | PartialAlwaysReturns(might_break) | PartialNeverReturns(might_break) => BlockControlFlow::PartialAlwaysTransfersControl(might_break: lhs or might_break)
@@ -626,6 +626,14 @@ enum BlockControlFlow {
         PartialAlwaysTransfersControl(might_break) => BlockControlFlow::PartialAlwaysTransfersControl(might_break)
         PartialAlwaysReturns(might_break) => BlockControlFlow::PartialAlwaysReturns(might_break)
         PartialNeverReturns(might_break) => BlockControlFlow::PartialNeverReturns(might_break)
+    }
+
+    function definitive(this) => match this {
+        NeverReturns => BlockControlFlow::NeverReturns
+        AlwaysReturns => BlockControlFlow::AlwaysReturns
+        AlwaysTransfersControl(might_break) => BlockControlFlow::AlwaysTransfersControl(might_break)
+        MayReturn => BlockControlFlow::MayReturn
+        else => BlockControlFlow::MayReturn
     }
 
     function always_transfers_control(this) => match this {
@@ -1047,9 +1055,9 @@ boxed enum CheckedExpression {
                     }
                 }
                 if control_flow.has_value() {
-                    control_flow = control_flow!.unify_with(case_control_flow)
+                    control_flow = control_flow!.unify_with(case_control_flow.definitive())
                 } else {
-                    control_flow = case_control_flow
+                    control_flow = case_control_flow.definitive()
                 }
             }
             yield control_flow ?? BlockControlFlow::MayReturn

--- a/tests/codegen/control_flow_inside_match.jakt
+++ b/tests/codegen/control_flow_inside_match.jakt
@@ -14,7 +14,6 @@ function test_continue() -> i64 {
             }
         }
     }
-    return -1 // TODO: control flow analysis sholud know that we never get here.
 }
 
 function test_break() -> i64 {

--- a/tests/codegen/control_flow_inside_nested_match_block.jakt
+++ b/tests/codegen/control_flow_inside_nested_match_block.jakt
@@ -16,8 +16,6 @@ function test_continue() -> bool {
             }
             else => {}
         }
-        println("test_continue: must be unreachable")
-        return false
     }
     return true
 }
@@ -34,8 +32,6 @@ function test_break() -> bool {
             }
             else => {}
         }
-        println("test_break: must be unreachable")
-        return false
     }
     return true
 }
@@ -48,5 +44,4 @@ function main() {
     } else {
         println("Something happened. Check above log and codegen code.")
     }
-
 }

--- a/tests/typechecker/function_for_return.jakt
+++ b/tests/typechecker/function_for_return.jakt
@@ -5,6 +5,7 @@ function foo() -> i32 {
     for i in 1..10 {
         return 187
     }
+    return 0
 }
 
 function main() {

--- a/tests/typechecker/unreachable_code_after_return.jakt
+++ b/tests/typechecker/unreachable_code_after_return.jakt
@@ -1,0 +1,12 @@
+/// Expect:
+/// - error: "Unreachable code\n"
+
+function foo() -> bool {
+    return true
+    return false
+}
+
+function main() {
+    foo()
+}
+


### PR DESCRIPTION
We used to only check for reachability after "never return" statements.
Now, we check after every statement that can divert control flow.

fixes #151 