### PR TITLE
editors/vscode: Add syntax highlighting for references in arguments

### DIFF
--- a/editors/vscode/syntaxes/jakt.tmLanguage.json
+++ b/editors/vscode/syntaxes/jakt.tmLanguage.json
@@ -531,13 +531,19 @@
         },
         {
           "name": "meta.argument.jakt",
-          "begin": "\\b((?:\\w|_)(?:\\w|_|[0-9])*)\\s*(:)",
+          "begin": "\\b((?:\\w|_)(?:\\w|_|[0-9])*)\\s*(:)\\s*(&)?\\s*(\\bmut\\b)?",
           "beginCaptures": {
             "1": {
               "name": "variable.parameter.jakt"
             },
             "2": {
               "name": "punctuation.colon.jakt"
+            },
+            "3": {
+              "name": "keyword.reference.jakt"
+            },
+            "4": {
+              "name": "storage.modifier.mut.argument.jakt"
             }
           },
           "end": "$|(,)|(?:(?=\\)))",
@@ -562,13 +568,19 @@
       "patterns": [
         {
           "name": "meta.parameter.jakt",
-          "begin": "\\b((?:\\w|_)(?:\\w|_|[0-9])*)\\s*(:)(?!\\:)",
+          "begin": "\\b((?:\\w|_)(?:\\w|_|[0-9])*)\\s*(:)(?!\\:)\\s*(&)?\\s*(\\bmut\\b)?",
           "beginCaptures": {
             "1": {
               "name": "variable.parameter.name.jakt"
             },
             "2": {
               "name": "punctuation.colon.jakt"
+            },
+            "3": {
+              "name": "keyword.reference.jakt"
+            },
+            "4": {
+              "name": "storage.modifier.mut.argument.jakt"
             }
           },
           "end": "$|(,)|(?=\\))",
@@ -582,6 +594,18 @@
               "include": "$self"
             }
           ]
+        },
+        {
+          "match": "\\b(mut)\\b",
+          "captures": {
+            "1": {
+              "name": "storage.modifier.mut.argument.jakt"
+            }
+          }
+        },
+        {
+          "name": "keyword.reference.jakt",
+          "match": "&"
         },
         {
           "name": "punctuation.comma.jakt",


### PR DESCRIPTION
This also fixes the corruption of syntax highlighting in the rest of the file, when something like
`function_call(&mut argument)` occurred.

Before:
![obraz](https://user-images.githubusercontent.com/36564831/186651895-66ff93cd-6058-401e-8ba0-3f5143d0f104.png)

After:
![obraz](https://user-images.githubusercontent.com/36564831/186652649-83e5f058-2f0f-4155-aac4-f234ff081710.png)
