### PR TITLE
typechecker: Remove redundant errors that come from bad lookups

### DIFF
--- a/jakttest/jakttest.jakt
+++ b/jakttest/jakttest.jakt
@@ -183,14 +183,41 @@ function compare_error(bytes: [u8], expected: String) throws -> bool {
     let builder_output = builder.to_string()
     let stripped_expected = strip_line_breaks(expected)
 
-    // println("builder output: {}", builder_output)
-    // println("stripped_expected: {}", stripped_expected)
-
     if not builder_output.contains(stripped_expected) {
         // TODO: return more information about expected/parsed
         return false
     }
     return true
+}
+
+function compare_error_exact(bytes: [u8], expected: String, expected_result: ExpectedResult) throws -> TestFailedReason? {
+    mut builder = StringBuilder::create()
+
+    for b in bytes.iterator() {
+        if b == 0xd {
+            // skip
+        } else if b == 0xa {
+            builder.append(b'\\')
+            builder.append(b'n')
+        } else {
+            builder.append(b)
+        }
+    }
+
+    let builder_output = builder.to_string()
+    let stripped_expected = strip_line_breaks(expected)
+
+    guard builder_output.contains(stripped_expected) else {
+        return TestFailedReason::CompilerErrorUnmatched(had: bytes_to_string(bytes), expected: expected_result)
+    }
+
+    // 7 is the length of "Error: "
+    let stripped_error_line_len = 7 + stripped_expected.length()
+    let stripped_rest = builder_output.substring(start: stripped_error_line_len, length: builder_output.length() - stripped_error_line_len)
+    guard not stripped_rest.contains("Error: ") else {
+        return TestFailedReason::CompilerErrorNotUnique(had: bytes_to_string(bytes), unique_error: expected)
+    }
+    return None
 }
 
 function strip_line_breaks(anon input: String) throws -> String {
@@ -369,7 +396,7 @@ enum TestStage {
 
 enum ResultKind {
     Okay
-    CompileError
+    CompileError(is_exact: bool)
     RuntimeError
 
     function to_stage(this) => match this {
@@ -397,6 +424,7 @@ struct TestsRunResult {
 
 enum TestFailedReason {
     CompilerErrorUnmatched(had: String, expected: ExpectedResult)
+    CompilerErrorNotUnique(had: String, unique_error: String)
     StderrUnmatched(had: String, expected: ExpectedResult)
     StdoutUnmatched(had: String, expected: ExpectedResult)
     ExpectedError(had: String, expected: ExpectedResult)
@@ -440,16 +468,30 @@ struct TestScheduler {
             return TestExitedResult::Failed(file: test.file_name)
         }
 
+
+
         let stage = maybe_stage!
+
 
         // check the test results
         let (result_output, error_output) = test_outputs(directory: .directories[test.directory_index], stage)
 
         let expected = test.result.output
 
+        let expected_stage = test.result.kind.to_stage()
+
+        mut failed_reason: TestFailedReason? = None
+
         let passed_test = match test.result.kind {
             Okay => compare_test(bytes: result_output, expected)
-            RuntimeError | CompileError => compare_error(bytes: error_output, expected)
+            RuntimeError => compare_error(bytes: error_output, expected)
+            CompileError(is_exact) => match is_exact {
+                false => compare_error(bytes: error_output, expected)
+                else => {
+                    failed_reason = compare_error_exact(bytes: error_output, expected, expected_result: test.result)
+                    yield not failed_reason.has_value()
+                }
+            }
         }
 
         if not passed_test {
@@ -457,6 +499,7 @@ struct TestScheduler {
             let expected_stage = test.result.kind.to_stage()
 
             if not stage.equals(expected_stage) {
+                eprintln("expected stage doesn't match exited stage")
                 if .failed_reasons.has_value() {
                     if stage.to_order() < expected_stage.to_order() {
                         .failed_reasons![test.file_name] = TestFailedReason::ErroredAtEarlierStage(
@@ -464,7 +507,7 @@ struct TestScheduler {
                             expected: test.result
                             failed_stage: stage.to_string()
                         )
-                    } else if stage is TestRun and result_output.size() > 0 {
+                    } else if stage is TestRun and not result_output.is_empty() {
                         .failed_reasons![test.file_name] = TestFailedReason::ExpectedError(
                             had: bytes_to_string(result_output)
                             expected: test.result
@@ -480,19 +523,23 @@ struct TestScheduler {
 
                 return TestExitedResult::Failed(file: test.file_name)
             } else if .failed_reasons.has_value() {
-                .failed_reasons![test.file_name] = match test.result.kind {
-                    Okay => TestFailedReason::StdoutUnmatched(
-                                had: bytes_to_string(result_output)
-                                expected: test.result
-                            )
-                    RuntimeError => TestFailedReason::StderrUnmatched(
-                                had: bytes_to_string(error_output)
-                                expected: test.result
-                            )
-                    CompileError => TestFailedReason::CompilerErrorUnmatched(
-                                had: bytes_to_string(error_output)
-                                expected: test.result
-                            )
+                if failed_reason.has_value() {
+                    .failed_reasons![test.file_name] = failed_reason!
+                } else {
+                    .failed_reasons![test.file_name] = match test.result.kind {
+                        Okay => TestFailedReason::StdoutUnmatched(
+                                    had: bytes_to_string(result_output)
+                                    expected: test.result
+                                )
+                        RuntimeError => TestFailedReason::StderrUnmatched(
+                                    had: bytes_to_string(error_output)
+                                    expected: test.result
+                                )
+                        CompileError => TestFailedReason::CompilerErrorUnmatched(
+                                    had: bytes_to_string(error_output)
+                                    expected: test.result
+                                )
+                    }
                 }
             }
 
@@ -665,8 +712,8 @@ function main(args: [String]) {
                                 file_name
                                 directory_index: 0))
             }
-            CompileErrorTest(output) => {
-                tests.push(Test(result: ExpectedResult(kind: ResultKind::CompileError, output)
+            CompileErrorTest(output, is_exact) => {
+                tests.push(Test(result: ExpectedResult(kind: ResultKind::CompileError(is_exact), output)
                                 file_name
                                 directory_index: 0))
             }
@@ -737,6 +784,10 @@ function main(args: [String]) {
             match reasons[file] {
                 CompilerErrorUnmatched(had, expected) => {
                     output += format("Could not find error \"{}\" in error output:\n", expected)
+                    output += had
+                }
+                CompilerErrorNotUnique(had, unique_error) => {
+                    output += format("Error \"{}\" was not unique:\n", unique_error)
                     output += had
                 }
                 StdoutUnmatched(had, expected) => {

--- a/jakttest/parser.jakt
+++ b/jakttest/parser.jakt
@@ -7,7 +7,7 @@ import utility { panic, todo, Span }
 
 enum ParsedTest {
     SuccessTest(String),
-    CompileErrorTest(String),
+    CompileErrorTest(output: String, is_exact: bool),
     RuntimeErrorTest(String),
     SkipTest
     NoExpectOrSkip
@@ -89,9 +89,17 @@ struct Parser {
             if .lex_literal("selfhost-only") {
                 .skip_whitespace()
             }
+
+            let is_exact_error = .lex_literal("exact-error")
+
+            while not .is_eof() and .current() != b'\n' and is_whitespace(.current()) {
+                .index++
+            }
+
             if .is_eof() or .current() != b'\n' {
                 continue
             }
+
             .index++
             if not .lex_literal("///") {
                 continue
@@ -109,6 +117,10 @@ struct Parser {
             let runtime_error = .lex_literal("stderr")
             if is_error and not (compile_error or runtime_error) {
                 continue
+            }
+            if is_exact_error and not compile_error {
+                // malformed: only compiler errors can be toggled to be exactly one.
+                return ParsedTest::SkipTest
             }
             .skip_whitespace()
             if .is_eof() or .current() != b':' {
@@ -133,7 +145,7 @@ struct Parser {
             if is_error and runtime_error {
                 return ParsedTest::RuntimeErrorTest(output)
             } else if is_error and compile_error {
-                return ParsedTest::CompileErrorTest(output)
+                return ParsedTest::CompileErrorTest(output, is_exact: is_exact_error)
             } else {
                 return ParsedTest::SuccessTest(output)
             }

--- a/selfhost/typechecker.jakt
+++ b/selfhost/typechecker.jakt
@@ -2303,6 +2303,10 @@ struct Typechecker {
         let lhs_type = .get_type(lhs_type_id)
         let rhs_type = .get_type(rhs_type_id)
 
+        if lhs_type is Unknown or rhs_type is Unknown {
+            return true
+        }
+
         let lhs_type_id_string = lhs_type_id.to_string()
         let rhs_type_id_string = rhs_type_id.to_string()
 
@@ -3372,7 +3376,11 @@ struct Typechecker {
         //     1- Must respond to .next(); the mutability of the iterator is inferred from .next()'s signature
         //     2- The result of .next() must be an Optional.
 
+        // Ignore errors here to avoid duplicated errors
+        let old_ignore_errors = .ignore_errors
+        .ignore_errors = true
         let iterable_expr = .typecheck_expression(range, scope_id, safety_mode, type_hint: None)
+        .ignore_errors = old_ignore_errors
         mut iterable_should_be_mutable = false
 
         let iterable_type = .program.get_type(iterable_expr.type())
@@ -3936,6 +3944,8 @@ struct Typechecker {
 
                         .error(format("unknown member of struct: {}.{}", structure.name, field), span)
                     }
+                    // do not error if the type is unknown
+                    Unknown => {}
                     else => .error(format("Member field access on value of non-struct type ‘{}’", .type_name(checked_expr_type_id)), span)
                 }
             }
@@ -3962,6 +3972,7 @@ struct Typechecker {
 
                 .error(format("unknown member of struct: {}.{}", structure.name, field), span)
             }
+            Unknown => {}
             else => .error(format("Member field access on value of non-struct type ‘{}’", .type_name(checked_expr_type_id)), span)
         }
 
@@ -4317,6 +4328,8 @@ struct Typechecker {
                     }
                 }
                 GenericEnumInstance(id) => Some(StructOrEnumId::Enum(id))
+                // do not output an error if the type is unknown
+                Unknown => None
                 else => {
                     .error(message: format("no methods available on value (type: {})", .type_name(type_id: checked_expr_type_id)), span: checked_expr.span())
                     let none: StructOrEnumId? = None
@@ -4329,24 +4342,55 @@ struct Typechecker {
                 .error(message: format("Optional chain mismatch: expected optional chain, found {}", .type_name(type_id: checked_expr_type_id)), span: checked_expr.span())
             }
 
-            let checked_call_expr = .typecheck_call(call, caller_scope_id: scope_id, span, this_expr: checked_expr, parent_id, safety_mode, type_hint, must_be_enum_constructor: false)
-            let type_id = checked_call_expr.type()
-            yield match checked_call_expr {
-                Call(call) => {
-                    mut result_type = call.return_type
-                    if is_optional {
-                        let optional_struct_id = .find_struct_in_prelude("Optional")
-                        result_type = .find_or_add_type_id(Type::GenericInstance(id: optional_struct_id, args: [result_type]))
+            yield match parent_id.has_value() {
+                true => {
+                    let checked_call_expr = .typecheck_call(call, caller_scope_id: scope_id, span, this_expr: checked_expr, parent_id, safety_mode, type_hint, must_be_enum_constructor: false)
+                    let type_id = checked_call_expr.type()
+                    yield match checked_call_expr {
+                        Call(call) => {
+                            mut result_type = call.return_type
+                            if is_optional {
+                                let optional_struct_id = .find_struct_in_prelude("Optional")
+                                result_type = .find_or_add_type_id(Type::GenericInstance(id: optional_struct_id, args: [result_type]))
+                            }
+                            yield CheckedExpression::MethodCall(
+                                expr: checked_expr
+                                call
+                                span
+                                is_optional
+                                type_id: result_type)
+                        }
+                        else => {
+                            .compiler.panic("typecheck_call should return `CheckedExpression::Call()`")
+                        }
                     }
-                    yield CheckedExpression::MethodCall(
-                        expr: checked_expr
-                        call
-                        span
-                        is_optional
-                        type_id: result_type)
                 }
                 else => {
-                    .compiler.panic("typecheck_call should return `CheckedExpression::Call()`")
+                    // run the typechecker through the arguments without
+                    // expecting anything
+                    mut args: [(String, CheckedExpression)] = []
+                    args.ensure_capacity(call.args.size())
+                    for triple in call.args.iterator() {
+                        let (name, span, arg) = triple
+                        args.push((name, .typecheck_expression(
+                                    arg
+                                    scope_id
+                                    safety_mode
+                                    type_hint: None)))
+                    }
+                    yield CheckedExpression::MethodCall(
+                    expr: checked_expr
+                    call: CheckedCall(
+                        namespace_: []
+                        name: call.name
+                        args
+                        type_args: []
+                        function_id: None
+                        return_type: unknown_type_id()
+                        callee_throws: false)
+                    span
+                    is_optional
+                    type_id: unknown_type_id())
                 }
             }
         }
@@ -5811,7 +5855,7 @@ struct Typechecker {
                     for arg in call.args.iterator() {
                         let checked_arg = .typecheck_expression(expr: arg.2, scope_id: caller_scope_id, safety_mode, type_hint: None)
 
-                        args.push((call.name, checked_arg))
+                        args.push((arg.0, checked_arg))
                     }
 
                     return CheckedExpression::Call(
@@ -5821,11 +5865,11 @@ struct Typechecker {
                             args,
                             type_args: checked_type_args,
                             function_id: resolved_function_id,
-                            return_type,
+                            return_type: unknown_type_id(),
                             callee_throws
                         ),
                         span,
-                        type_id: return_type
+                        type_id: unknown_type_id()
                     )
                 }
 

--- a/selfhost/typechecker.jakt
+++ b/selfhost/typechecker.jakt
@@ -3317,7 +3317,8 @@ struct Typechecker {
 
         let (new_condition, new_then_block, new_else_statement) = .expand_context_for_bindings(condition: expr, acc: None, then_block: remaining_code, else_statement: ParsedStatement::Block(block: else_block, span), span)
         let checked_condition = .typecheck_expression_and_dereference_if_needed(new_condition, scope_id, safety_mode, type_hint: None, span)
-        if not checked_condition.type().equals(builtin(BuiltinType::Bool)) {
+        if not checked_condition.type().equals(builtin(BuiltinType::Bool)) and
+            not checked_condition.type().equals(unknown_type_id()) {
             .error("Condition must be a boolean expression", new_condition.span())
         }
 
@@ -3406,6 +3407,9 @@ struct Typechecker {
                     }
                 }
             }
+            // accept unknown type since we don't know what the expression could
+            // have been.
+            Unknown => {}
             else => {
                 .error("Iterator must have a .next() method", name_span)
             }
@@ -3571,7 +3575,8 @@ struct Typechecker {
     function typecheck_if(mut this, condition: ParsedExpression, then_block: ParsedBlock, else_statement: ParsedStatement?, scope_id: ScopeId, safety_mode: SafetyMode, span: Span) throws -> CheckedStatement {
         let (new_condition, new_then_block, new_else_statement) = .expand_context_for_bindings(condition, acc: None, then_block, else_statement, span)
         let checked_condition = .typecheck_expression_and_dereference_if_needed(new_condition, scope_id, safety_mode, type_hint: None, span)
-        if not checked_condition.type().equals(builtin(BuiltinType::Bool)) {
+        if not checked_condition.type().equals(builtin(BuiltinType::Bool)) and
+            not checked_condition.type().equals(unknown_type_id()) {
             .error("Condition must be a boolean expression", new_condition.span())
         }
 
@@ -3716,7 +3721,8 @@ struct Typechecker {
 
     function typecheck_while(mut this, condition: ParsedExpression, block: ParsedBlock, scope_id: ScopeId, safety_mode: SafetyMode, span: Span) throws -> CheckedStatement {
         let checked_condition = .typecheck_expression_and_dereference_if_needed(condition, scope_id, safety_mode, type_hint: None, span)
-        if not checked_condition.type().equals(builtin(BuiltinType::Bool)) {
+        if not checked_condition.type().equals(builtin(BuiltinType::Bool)) and
+            not checked_condition.type().equals(unknown_type_id()) {
             .error("Condition must be a boolean expression", condition.span())
         }
 
@@ -3972,6 +3978,7 @@ struct Typechecker {
 
                 .error(format("unknown member of struct: {}.{}", structure.name, field), span)
             }
+            // do not error if the type is unknown
             Unknown => {}
             else => .error(format("Member field access on value of non-struct type ‘{}’", .type_name(checked_expr_type_id)), span)
         }
@@ -4589,6 +4596,8 @@ struct Typechecker {
                     }
                     yield inner_type_id
                 }
+                // forward unknown type id without registering an error
+                Unknown => unknown_type_id()
                 else => {
                     .error("Forced unwrap only works on Optional", span)
                     yield unknown_type_id()

--- a/tests/typechecker/no_error_on_propagated_unknown.jakt
+++ b/tests/typechecker/no_error_on_propagated_unknown.jakt
@@ -1,0 +1,20 @@
+/// Expect: exact-error
+/// - error: "Call to unknown function: ‘should_return_s_but_is_unknown’"
+
+struct S {
+    val: i32
+    function bar() {}
+}
+
+function get_s(a: i32) => should_return_s_but_is_unknown()
+
+function main() {
+    // s has type 'unknown'
+    let s = get_s(a: 2)
+    print("s value is {}", s.val) // <- should not error here saying that 'val' is not a property of 'unknown'!
+    s.bar() // <- should not error here saying that 'bar' is not a known method!
+
+    // s2 has type 'S', and we're going to assign it 'unknown'
+    mut s2 = S(val: 3i32)
+    s2 = get_s(a: 5) // <- should not error here saying 'incompatible types' or 'assignment between incompatible types'
+}

--- a/tests/typechecker/no_error_on_propagated_unknown_for.jakt
+++ b/tests/typechecker/no_error_on_propagated_unknown_for.jakt
@@ -1,0 +1,11 @@
+/// Expect: exact-error
+/// - error: "Could not find ‘iterator’"
+struct S {}
+
+function main() {
+    let s = S()
+
+    // S has no 'iterator' method on purpose. Only this error should be shown
+    for value in s.iterator() {
+    }
+}


### PR DESCRIPTION
Removes errors of the kind "no methods available on type", "assignment between
incompatible types", "attempt to access member on a non-struct type" etc. that propagate when some lookup yields "unknown" as the type of the expression. This avoids cluttering the error output and thus gives a clearer message to the user: "I got stuck at this point because I don't know what you're doing".

Failed lookups on functions now return a dummy expression that has "unknown" as the return type instead of "void". Failed lookups on method calls because of an unknown expression type id run the arguments through the typechecker but otherwise accept the call name and make it have "unknown" as a result.

Since the test proves that those redundant errors *don't* exist by requiring only one error to exist (the one lookup error that would've chained the redundant ones), I've modified Jakttest so it can check for this condition as well, under a `exact-error` flag after the `Expect: `.
