### PR TITLE
all: Add support for basic class inheritance

### DIFF
--- a/samples/classes/inheritance.jakt
+++ b/samples/classes/inheritance.jakt
@@ -1,0 +1,16 @@
+/// Expect:
+/// - output: "I am the parent\n"
+
+class Parent {
+    public function greet(this) {
+        println("I am the parent")
+    }
+}
+
+class Child: Parent {
+}
+
+function main() {
+    let child = Child()
+    child.greet()
+}

--- a/selfhost/codegen.jakt
+++ b/selfhost/codegen.jakt
@@ -858,7 +858,16 @@ struct CodeGenerator {
                     class_name_with_generics += ">"
                 }
 
-                output += format("class {} : public RefCounted<{}>, public Weakable<{}> {{\n", struct_.name, class_name_with_generics, class_name_with_generics)
+                if struct_.super_type_id.has_value() {
+                    let super_struct_type = .program.get_type(struct_.super_type_id!)
+                    guard super_struct_type is Struct(struct_id) else {
+                        panic("internal error: expected super struct during codegen of class/struct")
+                    }
+                    let super_struct = .program.get_struct(struct_id)
+                    output += format("class {}: public {} {{\n", struct_.name, super_struct.name)
+                } else {
+                    output += format("class {} : public RefCounted<{}>, public Weakable<{}> {{\n", struct_.name, class_name_with_generics, class_name_with_generics)
+                }
                 output += "  public:\n"
                 output += format("virtual ~{}() = default;\n", struct_.name)
             }
@@ -2861,7 +2870,7 @@ struct CodeGenerator {
         if structure.record_type is Class {
             mut output = ""
 
-            output += "private:\n"
+            output += "protected:\n"
 
             output += format("explicit {}(", function_.name)
             mut first = true

--- a/selfhost/parser.jakt
+++ b/selfhost/parser.jakt
@@ -164,8 +164,8 @@ struct SumEnumVariant {
     params: [ParsedVarDecl]?
 }
 enum RecordType {
-    Struct(fields: [ParsedField])
-    Class(fields: [ParsedField], super_class: ParsedType?)
+    Struct(fields: [ParsedField], super_type: ParsedType?)
+    Class(fields: [ParsedField], super_type: ParsedType?)
     ValueEnum(underlying_type: ParsedType, variants: [ValueEnumVariant])
     SumEnum(is_boxed: bool, variants: [SumEnumVariant])
     Garbage
@@ -1927,7 +1927,8 @@ struct Parser {
         let fields_methods = .parse_struct_class_body(definition_linkage, default_visibility: Visibility::Public, is_class: false)
 
         parsed_struct.methods = fields_methods.1
-        parsed_struct.record_type = RecordType::Struct(fields: fields_methods.0)
+        let super_type: ParsedType? = None
+        parsed_struct.record_type = RecordType::Struct(fields: fields_methods.0, super_type)
 
         return parsed_struct
     }
@@ -1941,7 +1942,7 @@ struct Parser {
             methods: [],
             record_type: RecordType::Garbage
         )
-        mut super_class: ParsedType? = None
+        mut super_type: ParsedType? = None
         if .current() is Class {
             .index++
         } else {
@@ -1979,7 +1980,7 @@ struct Parser {
         // Super class
         if .current() is Colon {
             .index++
-            super_class = .parse_typename()
+            super_type = .parse_typename()
         }
 
         .skip_newlines()
@@ -1992,7 +1993,7 @@ struct Parser {
         let fields_methods = .parse_struct_class_body(definition_linkage, default_visibility: Visibility::Private, is_class: true)
 
         parsed_class.methods = fields_methods.1
-        parsed_class.record_type = RecordType::Class(fields: fields_methods.0, super_class)
+        parsed_class.record_type = RecordType::Class(fields: fields_methods.0, super_type)
 
         return parsed_class
     }

--- a/selfhost/typechecker.jakt
+++ b/selfhost/typechecker.jakt
@@ -1086,6 +1086,20 @@ struct Typechecker {
         .current_struct_type_id = None
     }
 
+    function is_class(this, anon type_id: TypeId) -> bool {
+        guard .get_type(type_id) is Struct(struct_id) else {
+            return false
+        }
+        return .get_struct(struct_id).record_type is Class
+    }
+
+    function is_struct(this, anon type_id: TypeId) -> bool {
+        guard .get_type(type_id) is Struct(struct_id) else {
+            return false
+        }
+        return .get_struct(struct_id).record_type is Struct
+    }
+
     function typecheck_struct_predecl(mut this, parsed_record: ParsedRecord, struct_id: StructId, scope_id: ScopeId) throws {
         let struct_type_id = .find_or_add_type_id(type: Type::Struct(struct_id))
         .current_struct_type_id = struct_type_id
@@ -1099,6 +1113,32 @@ struct Typechecker {
             Internal => false
         }
 
+        mut super_type_id: TypeId? = None
+
+        match parsed_record.record_type {
+            Class(super_type) => match super_type.has_value() {
+                true => {
+                    super_type_id = .typecheck_typename(parsed_type: super_type!, scope_id, name: None)
+                    if not .is_class(super_type_id!) {
+                        .error("Class can only inherit from another class", super_type!.span())
+                    }
+                }
+                else => {}
+            }
+            Struct(super_type) => match super_type.has_value() {
+                true => {
+                    super_type_id = .typecheck_typename(parsed_type: super_type!, scope_id, name: None)
+                    if not .is_struct(super_type_id!) {
+                        .error("Struct can only inherit from another struct", super_type!.span())
+                    }
+                }
+                else => {}
+            }
+            else => {
+                panic("Expected Struct or Class in typecheck_struct_predecl")
+            }
+        }
+
         mut module = .current_module()
         module.structures[struct_id.id] = CheckedStruct(
             name: parsed_record.name
@@ -1109,6 +1149,7 @@ struct Typechecker {
             definition_linkage: parsed_record.definition_linkage
             record_type: parsed_record.record_type
             type_id: struct_type_id
+            super_type_id
         )
 
         mut generic_parameters: [TypeId] = module.structures[struct_id.id].generic_parameters
@@ -1309,6 +1350,7 @@ struct Typechecker {
             definition_linkage: parsed_record.definition_linkage
             record_type: parsed_record.record_type
             type_id: struct_type_id
+            super_type_id: None
         ))
     }
 
@@ -5376,7 +5418,7 @@ struct Typechecker {
         )
     }
 
-    function resolve_call(mut this, call: ParsedCall, mut namespaces: [ResolvedNamespace], span: Span, scope_id: ScopeId, must_be_enum_constructor: bool) throws -> FunctionId? {
+    function resolve_call(mut this, call: ParsedCall, mut namespaces: [ResolvedNamespace], span: Span, scope_id: ScopeId, must_be_enum_constructor: bool, ignore_errors: bool) throws -> FunctionId? {
         mut callee: FunctionId? = None
         mut current_scope_id = scope_id
 
@@ -5440,7 +5482,9 @@ struct Typechecker {
             return callee
         }
 
-        .error(format("Call to unknown function: ‘{}’", call.name), span)
+        if not ignore_errors {
+            .error(format("Call to unknown function: ‘{}’", call.name), span)
+        }
 
         return None
     }
@@ -5462,10 +5506,43 @@ struct Typechecker {
 
         let callee_scope_id = match parent_id.has_value() {
             true => match parent_id! {
-                Struct(id) => .get_struct(id).scope_id
-                Enum(id) => .get_enum(id).scope_id
+                Struct(id) => {
+                    mut struct_ = .get_struct(id)
+                    mut scope_id = struct_.scope_id
+                    while not resolved_function_id.has_value() {
+                        resolved_function_id = .resolve_call(call, namespaces: resolved_namespaces, span, scope_id, must_be_enum_constructor, ignore_errors: true)
+                        if resolved_function_id.has_value() {
+                            break
+                        }
+                        if struct_.super_type_id.has_value() {
+                            let parent_type_id = struct_.super_type_id!
+                            guard .get_type(parent_type_id) is Struct(struct_id) else {
+                                panic("internal error: could not find parent struct/class for struct/class")
+                            }
+                            struct_ = .get_struct(struct_id)
+                            scope_id = struct_.scope_id
+                        } else {
+                            .error(format("Could not find `{}`", call.name), span)
+                            break
+                        }
+                    }
+                    yield scope_id
+                }
+                Enum(id) => {
+                    let scope_id = .get_enum(id).scope_id
+                    resolved_function_id = .resolve_call(call, namespaces: resolved_namespaces, span, scope_id, must_be_enum_constructor, ignore_errors: false)
+                    yield scope_id
+                }
             }
-            else => caller_scope_id
+            else => {
+                match call.name {
+                    "print" | "println" | "eprintln" | "eprint" | "format" => {}
+                    else => {
+                        resolved_function_id = .resolve_call(call, namespaces: resolved_namespaces, span, scope_id: caller_scope_id, must_be_enum_constructor, ignore_errors: false)
+                    }
+                }
+                yield caller_scope_id
+            }
         }
 
         match call.name {
@@ -5482,7 +5559,6 @@ struct Typechecker {
                 }
             }
             else => {
-                resolved_function_id = .resolve_call(call, namespaces: resolved_namespaces, span, scope_id: callee_scope_id, must_be_enum_constructor)
                 if not resolved_function_id.has_value() {
                     mut checked_type_args: [TypeId] = []
                     for type_arg in call.type_args.iterator() {

--- a/selfhost/types.jakt
+++ b/selfhost/types.jakt
@@ -678,6 +678,7 @@ struct CheckedStruct {
     definition_linkage: DefinitionLinkage
     record_type: RecordType
     type_id: TypeId
+    super_type_id: TypeId?
 }
 
 struct CheckedEnum {


### PR DESCRIPTION
co-authored with @awesomekling

This adds simple form of class-based inheritance to get us started. For this first PR, the focus is on adding an inheritance hierarchy and calling methods in your parent class.

eg)
```
class Parent {
    public function greet(this) {
        println("I am the parent")
    }
}

class Child: Parent {
}

function main() {
    let child = Child()
    child.greet()
}
```