### PR TITLE
typechecker: Allow omitting label on dereference of same-name variable

### DIFF
--- a/samples/functions/implicit_argument_label_on_dereference.jakt
+++ b/samples/functions/implicit_argument_label_on_dereference.jakt
@@ -1,0 +1,15 @@
+/// Expect:
+/// - output: "5\n"
+
+function bar(a: i64) -> i64 {
+    return a
+}
+
+function foo(a: &i64) -> i64 {
+    return bar(*a)
+}
+
+function main() {
+    let a = 5
+    println("{}", foo(&a))
+}

--- a/selfhost/typechecker.jakt
+++ b/selfhost/typechecker.jakt
@@ -5864,7 +5864,7 @@ struct Typechecker {
                 return false
             }
             UnaryOp(expr, op) => {
-                if op is Reference or op is MutableReference {
+                if op is Reference or op is MutableReference or op is Dereference {
                     if expr is Var(name, span) {
                         if name == param.variable.name {
                             return true


### PR DESCRIPTION
We already allowed you to omit the argument label when passing a
reference (immutable or mutable) to a variable with the same name as the
parameter. This patch extends that feature to also support dereferences.