### PR TITLE
typechecker: Add FunctionGenerics class to store specializations

### DIFF
--- a/selfhost/codegen.jakt
+++ b/selfhost/codegen.jakt
@@ -695,10 +695,10 @@ struct CodeGenerator {
     function codegen_function_generic_parameters(mut this, function_: CheckedFunction) throws -> String {
         mut output = ""
 
-        if not function_.generic_params.is_empty() {
+        if not function_.generics.params.is_empty() {
             output += "template <"
             mut first = true
-            for generic_parameter in function_.generic_params.iterator() {
+            for generic_parameter in function_.generics.params.iterator() {
                 if first {
                     first = false
                 } else {
@@ -720,7 +720,7 @@ struct CodeGenerator {
     function codegen_function_predecl(mut this, function_: CheckedFunction) throws -> String {
         mut output = ""
 
-        if not function_.generic_params.is_empty() and function_.linkage is External {
+        if not function_.generics.params.is_empty() and function_.linkage is External {
             return ""
         }
 
@@ -3033,7 +3033,7 @@ struct CodeGenerator {
 
     function codegen_function_in_namespace(mut this, function_: CheckedFunction, containing_struct: TypeId?) throws -> String {
         // Extern generics need to be in the header anyways, so we can't codegen for them.
-        if not function_.generic_params.is_empty() {
+        if not function_.generics.params.is_empty() {
             if function_.linkage is External {
                 return ""
             }

--- a/selfhost/ide.jakt
+++ b/selfhost/ide.jakt
@@ -823,10 +823,10 @@ function get_function_signature(program: CheckedProgram, function_id: FunctionId
 
     mut generic_parameters = ""
     mut is_first_param = true
-    if not checked_function.generic_params.is_empty() {
+    if not checked_function.generics.params.is_empty() {
         generic_parameters += "<"
 
-        for parameter in checked_function.generic_params.iterator() {
+        for parameter in checked_function.generics.params.iterator() {
             let generic_type = match parameter {
                 InferenceGuide(type_id) => {
                     yield program.type_name(type_id)

--- a/selfhost/interpreter.jakt
+++ b/selfhost/interpreter.jakt
@@ -682,7 +682,7 @@ class Interpreter {
                         parent_scope_id: .program.prelude_scope_id()
                         function_name: "as_saturated")!)
 
-                    let output_type_id = type_bindings.get(function_.generic_params[0].type_id().to_string())
+                    let output_type_id = type_bindings.get(function_.generics.params[0].type_id().to_string())
                     yield StatementResult::JustValue(
                         cast_value_to_type(arguments[0], output_type_id!, interpreter: this, saturating: true)
                     )
@@ -4035,8 +4035,8 @@ class Interpreter {
             }
 
             mut type_bindings: [String:TypeId] = [:]
-            for i in 0..function_to_run.generic_params.size() {
-                let param = function_to_run.generic_params[i]
+            for i in 0..function_to_run.generics.params.size() {
+                let param = function_to_run.generics.params[i]
 
                 type_bindings.set(
                     param.type_id().to_string()

--- a/selfhost/typechecker.jakt
+++ b/selfhost/typechecker.jakt
@@ -17,7 +17,7 @@ import parser { Parser, BinaryOperator, DefinitionLinkage, DefinitionType, Unary
                 ParsedMethod }
 import types {
     BlockControlFlow, BuiltinType, CheckedBlock, CheckedCall, CheckedCapture, CheckedEnum, CheckedEnumVariant,
-    CheckedEnumVariantBinding, CheckedExpression, CheckedFunction, CheckedMatchBody, CheckedMatchCase,
+    CheckedEnumVariantBinding, CheckedExpression, CheckedFunction, FunctionGenerics, CheckedMatchBody, CheckedMatchCase,
     CheckedNamespace, CheckedNumericConstant, CheckedParameter, CheckedProgram, CheckedStatement, CheckedStruct,
     CheckedTypeCast, CheckedUnaryOperator, CheckedVariable, EnumId, FunctionGenericParameter, FunctionId,
     LoadedModule, Module, ModuleId, NumberConstant, ResolvedNamespace, SafetyMode, Scope, ScopeId, StructId,
@@ -854,8 +854,6 @@ struct Typechecker {
 
         .add_enum_to_scope(scope_id, name: parsed_record.name, enum_id, span: parsed_record.name_span)
 
-        let is_extern = parsed_record.definition_linkage is External
-
         let underlying_type_id = match parsed_record.record_type {
             ValueEnum(underlying_type) => .typecheck_typename(parsed_type: underlying_type, scope_id, name: None)
             else => builtin(BuiltinType::Void)
@@ -895,6 +893,7 @@ struct Typechecker {
             .add_type_to_scope(scope_id: enum_scope_id, type_name: gen_parameter.name, type_id: parameter_type_id, span: gen_parameter.span)
         }
 
+        let is_extern = parsed_record.definition_linkage is External
         for method in parsed_record.methods.iterator() {
             let func = method.parsed_function
             let method_scope_id = .create_scope(
@@ -907,6 +906,7 @@ struct Typechecker {
                 can_throw: func.can_throw
                 debug_name: format("method-block({}::{})", parsed_record.name, func.name)
             )
+
             let is_generic = not parsed_record.generic_parameters.is_empty() or not func.generic_parameters.is_empty()
 
             mut checked_function = CheckedFunction(
@@ -916,7 +916,11 @@ struct Typechecker {
                 return_type_id: unknown_type_id()
                 return_type_span: None
                 params: []
-                generic_params: []
+                generics: FunctionGenerics(
+                    base_params: []
+                    params: []
+                    specializations: []
+                )
                 block: CheckedBlock(
                     statements: []
                     scope_id: block_scope_id
@@ -960,7 +964,7 @@ struct Typechecker {
                 }
             }
 
-            checked_function.generic_params = generic_parameters
+            checked_function.generics.params = generic_parameters
 
             for param in func.params.iterator() {
                 if param.variable.name == "this" {
@@ -973,7 +977,7 @@ struct Typechecker {
                         visibility: Visibility::Public
                     )
 
-                    checked_function.params.push(CheckedParameter(
+                    checked_function.add_param(CheckedParameter(
                         requires_label: param.requires_label
                         variable: checked_variable
                         default_value: None
@@ -990,7 +994,7 @@ struct Typechecker {
                         visibility: Visibility::Public
                     )
 
-                    checked_function.params.push(CheckedParameter(
+                    checked_function.add_param(CheckedParameter(
                         requires_label: param.requires_label
                         variable: checked_variable
                         default_value: None
@@ -1040,7 +1044,11 @@ struct Typechecker {
                 return_type_id: struct_type_id
                 return_type_span: None
                 params: []
-                generic_params: []
+                generics: FunctionGenerics(
+                    base_params: []
+                    params: []
+                    specializations: []
+                )
                 block: CheckedBlock(
                     statements: []
                     scope_id: block_scope_id
@@ -1070,8 +1078,8 @@ struct Typechecker {
                 if field.visibility is Private {
                     checked_constructor.visibility = Visibility::Private
                 }
-                
-                func.params.push(CheckedParameter(
+
+                func.add_param(CheckedParameter(
                     requires_label: true
                     variable: field
                     default_value: None
@@ -1116,11 +1124,6 @@ struct Typechecker {
         let struct_scope_id = .create_scope(parent_scope_id: scope_id, can_throw: false, debug_name: format("struct({})", parsed_record.name))
 
         .add_struct_to_scope(scope_id, name: parsed_record.name, struct_id, span: parsed_record.name_span)
-
-        let is_extern = match parsed_record.definition_linkage {
-            External => true
-            Internal => false
-        }
 
         mut super_struct_id: StructId? = None
 
@@ -1185,6 +1188,7 @@ struct Typechecker {
             .add_type_to_scope(scope_id: struct_scope_id, type_name: gen_parameter.name, type_id: parameter_type_id, span: gen_parameter.span)
         }
 
+        let is_extern = parsed_record.definition_linkage is External
         for method in parsed_record.methods.iterator() {
             let func = method.parsed_function
 
@@ -1200,7 +1204,11 @@ struct Typechecker {
                 return_type_id: unknown_type_id()
                 return_type_span: func.return_type_span
                 params: []
-                generic_params: []
+                generics: FunctionGenerics(
+                    base_params: []
+                    params: []
+                    specializations: []
+                )
                 block: CheckedBlock(
                     statements: []
                     scope_id: block_scope_id
@@ -1236,7 +1244,7 @@ struct Typechecker {
                     id: .current_module().types.size() - 1
                 )
 
-                checked_function.generic_params.push(FunctionGenericParameter::Parameter(type_var_type_id))
+                checked_function.generics.params.push(FunctionGenericParameter::Parameter(type_var_type_id))
                 .add_type_to_scope(scope_id: method_scope_id, type_name: gen_parameter.name, type_id: type_var_type_id, span: gen_parameter.span)
             }
 
@@ -1251,7 +1259,7 @@ struct Typechecker {
                         visibility: Visibility::Public
                     )
 
-                    checked_function.params.push(CheckedParameter(
+                    checked_function.add_param(CheckedParameter(
                         requires_label: param.requires_label
                         variable: checked_variable
                         default_value: None
@@ -1292,7 +1300,7 @@ struct Typechecker {
                         )
                     }
 
-                    checked_function.params.push(CheckedParameter(
+                    checked_function.add_param(CheckedParameter(
                         requires_label: param.requires_label
                         variable: checked_variable
                         default_value: checked_default_value
@@ -1517,13 +1525,17 @@ struct Typechecker {
                             let function_scope_id = .create_scope(parent_scope_id, can_throw: can_function_throw, debug_name: format("enum-variant-constructor({}::{})", enum_.name, variant.name))
                             let block_scope_id = .create_scope(parent_scope_id: function_scope_id, can_throw: can_function_throw, debug_name: format("enum-variant-constructor-block({}::{})", enum_.name, variant.name))
                             let checked_function = CheckedFunction(
-                                name: variant.name,
-                                name_span: variant.span,
-                                visibility: Visibility::Public,
-                                return_type_id: .find_or_add_type_id(Type::Enum(enum_id)),
+                                name: variant.name
+                                name_span: variant.span
+                                visibility: Visibility::Public
+                                return_type_id: .find_or_add_type_id(Type::Enum(enum_id))
                                 return_type_span: None
-                                params,
-                                generic_params: [],
+                                params
+                                generics: FunctionGenerics(
+                                    base_params: params
+                                    params: []
+                                    specializations: []
+                                )
                                 block: CheckedBlock(
                                     statements: []
                                     scope_id: block_scope_id
@@ -1531,9 +1543,9 @@ struct Typechecker {
                                     yielded_type: TypeId::none()
                                     yielded_none: false
                                 ),
-                                can_throw: can_function_throw,
-                                type: FunctionType::ImplicitEnumConstructor,
-                                linkage: FunctionLinkage::Internal,
+                                can_throw: can_function_throw
+                                type: FunctionType::ImplicitEnumConstructor
+                                linkage: FunctionLinkage::Internal
                                 function_scope_id
                                 is_instantiated: true
                                 parsed_function: None
@@ -1563,24 +1575,30 @@ struct Typechecker {
                                 type_span: None
                                 visibility: Visibility::Public
                             )
+                            let param = CheckedParameter(requires_label: false, variable, default_value: None)
+
                             let checked_function = CheckedFunction(
-                                name: variant.name,
-                                name_span: variant.span,
-                                visibility: Visibility::Public,
-                                return_type_id: .find_or_add_type_id(Type::Enum(enum_id)),
-                                return_type_span: None,
-                                params: [CheckedParameter(requires_label: false, variable, default_value: None)],
-                                generic_params: [],
+                                name: variant.name
+                                name_span: variant.span
+                                visibility: Visibility::Public
+                                return_type_id: .find_or_add_type_id(Type::Enum(enum_id))
+                                return_type_span: None
+                                params: [param]
+                                generics: FunctionGenerics(
+                                    base_params: [param]
+                                    params: []
+                                    specializations: []
+                                )
                                 block: CheckedBlock(
                                     statements: [],
-                                    scope_id: block_scope_id,
-                                    control_flow: BlockControlFlow::AlwaysReturns,
+                                    scope_id: block_scope_id
+                                    control_flow: BlockControlFlow::AlwaysReturns
                                     yielded_type: TypeId::none()
                                     yielded_none: false
                                 ),
-                                can_throw: can_function_throw,
-                                type: FunctionType::ImplicitEnumConstructor,
-                                linkage: FunctionLinkage::Internal,
+                                can_throw: can_function_throw
+                                type: FunctionType::ImplicitEnumConstructor
+                                linkage: FunctionLinkage::Internal
                                 function_scope_id
                                 is_instantiated: true
                                 parsed_function: None
@@ -1600,13 +1618,17 @@ struct Typechecker {
                             let function_scope_id = .create_scope(parent_scope_id, can_throw: can_function_throw, debug_name: format("enum-variant-constructor({}::{})", enum_.name, variant.name))
                             let block_scope_id = .create_scope(parent_scope_id: function_scope_id, can_throw: can_function_throw, debug_name: format("enum-variant-constructor-block({}::{})", enum_.name, variant.name))
                             let checked_function = CheckedFunction(
-                                name: variant.name,
-                                name_span: variant.span,
-                                visibility: Visibility::Public,
-                                return_type_id: .find_or_add_type_id(Type::Enum(enum_id)),
-                                return_type_span: None,
-                                params: [],
-                                generic_params: [],
+                                name: variant.name
+                                name_span: variant.span
+                                visibility: Visibility::Public
+                                return_type_id: .find_or_add_type_id(Type::Enum(enum_id))
+                                return_type_span: None
+                                params: []
+                                generics: FunctionGenerics(
+                                    base_params: []
+                                    params: []
+                                    specializations: []
+                                )
                                 block: CheckedBlock(
                                     statements: []
                                     scope_id: block_scope_id
@@ -1614,9 +1636,9 @@ struct Typechecker {
                                     yielded_type: TypeId::none()
                                     yielded_none: false
                                 ),
-                                can_throw: can_function_throw,
-                                type: FunctionType::ImplicitEnumConstructor,
-                                linkage: FunctionLinkage::Internal,
+                                can_throw: can_function_throw
+                                type: FunctionType::ImplicitEnumConstructor
+                                linkage: FunctionLinkage::Internal
                                 function_scope_id
                                 is_instantiated: true
                                 parsed_function: None
@@ -1812,23 +1834,29 @@ struct Typechecker {
                 span: parameter.variable.span,
             )
         }
+
         return checked_parameter
     }
 
-    function typecheck_function_predecl(mut this, parsed_function: ParsedFunction, parent_scope_id: ScopeId, this_arg_type_id: TypeId?) throws {
+    function typecheck_function_predecl(mut this, parsed_function: ParsedFunction, parent_scope_id: ScopeId, this_arg_type_id: TypeId?, mut generics: FunctionGenerics? = None) throws {
         let function_scope_id = .create_scope(parent_scope_id, can_throw: parsed_function.can_throw, debug_name: format("function({})", parsed_function.name))
         let scope_debug_name = format("function-block({})", parsed_function.name)
         let block_scope_id = .create_scope(parent_scope_id: function_scope_id, can_throw: parsed_function.can_throw, debug_name: scope_debug_name)
         let module_id = .current_module_id.id
 
-        let is_generic_function = not parsed_function.generic_parameters.is_empty()
-        let is_generic = match this_arg_type_id.has_value() {
-            true => match .get_type(this_arg_type_id!) {
-                GenericInstance => true
-                else => is_generic_function
-            }
-            else => is_generic_function
+        mut base_definition = false
+        if not generics.has_value() {
+            generics = FunctionGenerics(
+                base_params: []
+                params: []
+                specializations: []
+            )
+
+            base_definition = true
         }
+
+        let is_generic_function = not parsed_function.generic_parameters.is_empty()
+        let is_generic = is_generic_function or (this_arg_type_id.has_value() and .get_type(this_arg_type_id!) is GenericInstance)
 
         mut checked_function = CheckedFunction(
             name: parsed_function.name
@@ -1837,7 +1865,7 @@ struct Typechecker {
             return_type_id: unknown_type_id()
             return_type_span: parsed_function.return_type_span
             params: []
-            generic_params: []
+            generics: generics!
             block: CheckedBlock(
                 statements: []
                 scope_id: block_scope_id
@@ -1849,13 +1877,14 @@ struct Typechecker {
             type: FunctionType::Normal
             linkage: parsed_function.linkage
             function_scope_id
-            is_instantiated: not is_generic
+            is_instantiated: not is_generic or not base_definition
             parsed_function
             is_comptime: parsed_function.is_comptime
             is_closure: false
             is_virtual: false
             is_override: false
         )
+
         // FIXME: We can't return a `mut Foo` from a function right now, but assigning anything to a `mut` variable makes it mutable.
         //        AKA, working around one bug with another bug. :^)
         mut current_module = .current_module()
@@ -1870,14 +1899,19 @@ struct Typechecker {
         }
 
         // Check generic parameters
+        mut i = 0
         for generic_parameter in parsed_function.generic_parameters.iterator() {
-            current_module.types.push(Type::TypeVariable(generic_parameter.name))
-
-            let type_var_type_id = TypeId(
+            mut type_var_type_id = TypeId(
                 module: current_module.id
-                id: current_module.types.size() - 1
+                id: current_module.types.size()
             )
-            checked_function.generic_params.push(FunctionGenericParameter::Parameter(type_var_type_id))
+
+            if base_definition {
+                current_module.types.push(Type::TypeVariable(generic_parameter.name))
+                checked_function.generics.params.push(FunctionGenericParameter::Parameter(type_var_type_id))
+            } else if checked_function.generics.params[i] is Parameter(var_type_id) {
+                type_var_type_id = var_type_id
+            }
 
             if not parsed_function.must_instantiate or external_linkage {
                 .add_type_to_scope(
@@ -1896,13 +1930,21 @@ struct Typechecker {
                     span: generic_parameter.span
                 )
             }
+
+            i++
         }
 
         // Check parameters
         mut first = true
         mut module = .current_module()
         for parameter in parsed_function.params.iterator() {
-            checked_function.params.push(.typecheck_parameter(parameter, scope_id: checked_function_scope_id, first, this_arg_type_id, check_scope))
+            let checked_param = .typecheck_parameter(parameter, scope_id: checked_function_scope_id, first, this_arg_type_id, check_scope)
+
+            checked_function.params.push(checked_param)
+            if base_definition {
+                checked_function.generics.base_params.push(checked_param)
+            }
+
             first = false
         }
 
@@ -1968,6 +2010,8 @@ struct Typechecker {
 
     function typecheck_and_specialize_generic_function(mut this, function_id: FunctionId, generic_arguments: [TypeId], parent_scope_id: ScopeId, this_type_id: TypeId?, generic_substitutions: GenericInferences) throws {
         mut checked_function = .get_function(function_id)
+        checked_function.generics.specializations.push(generic_arguments)
+
         mut module = .current_module()
 
         let function_id = module.next_function_id()
@@ -1980,7 +2024,8 @@ struct Typechecker {
         if parsed_function.generic_parameters.size() != generic_arguments.size() {
             .error(
                 format("Generic function {} expects {} generic arguments, but {} were given",
-                    parsed_function.name, parsed_function.generic_parameters.size(), generic_arguments.size()),
+                    parsed_function.name, parsed_function.generic_parameters.size(), generic_arguments.size()
+                ) 
                 parsed_function.name_span
             )
         }
@@ -1993,13 +2038,13 @@ struct Typechecker {
         }
 
         parsed_function.must_instantiate = true
+        checked_function.is_instantiated = true
 
         .current_function_id = Some(function_id)
-        .typecheck_function_predecl(parsed_function, parent_scope_id: scope_id, this_arg_type_id: this_type_id)
+        .typecheck_function_predecl(parsed_function, parent_scope_id: scope_id, this_arg_type_id: this_type_id, generics: checked_function.generics)
         .typecheck_function(parsed_function, parent_scope_id: scope_id)
         .current_function_id = None
 
-        checked_function.is_instantiated = true
         checked_function.function_scope_id = scope_id
     }
 
@@ -2860,7 +2905,11 @@ struct Typechecker {
                     return_type_id: .typecheck_typename(parsed_type: return_type, scope_id, name: None)
                     return_type_span: return_type.span()
                     params: checked_params
-                    generic_params: []
+                    generics: FunctionGenerics(
+                        base_params: checked_params
+                        params: []
+                        specializations: []
+                    )
                     block: CheckedBlock(
                         statements: []
                         scope_id
@@ -2872,7 +2921,7 @@ struct Typechecker {
                     type: FunctionType::Normal
                     linkage: FunctionLinkage::Internal
                     function_scope_id: scope_id
-                    is_instantiated: false
+                    is_instantiated: true
                     parsed_function: None
                     is_comptime: false
                     is_closure: false
@@ -5655,7 +5704,7 @@ struct Typechecker {
         return None
     }
 
-    function typecheck_call(mut this, call: ParsedCall, caller_scope_id: ScopeId, span: Span, this_expr: CheckedExpression?, parent_id: StructOrEnumId?, safety_mode: SafetyMode, type_hint: TypeId?, must_be_enum_constructor: bool) throws -> CheckedExpression {
+    function typecheck_call(mut this, call: ParsedCall, caller_scope_id: ScopeId, span: Span, this_expr: CheckedExpression?, parent_id: StructOrEnumId?, safety_mode: SafetyMode, mut type_hint: TypeId?, must_be_enum_constructor: bool) throws -> CheckedExpression {
         mut args: [(String, CheckedExpression)] = []
         mut return_type = builtin(BuiltinType::Void)
         mut generic_arguments: [TypeId] = []
@@ -5752,8 +5801,14 @@ struct Typechecker {
                         type_id: return_type
                     )
                 }
+
                 let function_id = resolved_function_id!
                 let callee = .get_function(function_id)
+
+                if callee.is_instantiated {
+                    .generic_inferences.perform_checkpoint(reset: true)
+                }
+
                 callee_throws = callee.can_throw
                 return_type = callee.return_type_id
                 let scope_containing_callee = .get_scope(callee.function_scope_id).parent!
@@ -5764,13 +5819,13 @@ struct Typechecker {
                 mut type_arg_index = 0uz
                 for parsed_type in call.type_args.iterator() {
                     let checked_type = .typecheck_typename(parsed_type, scope_id: caller_scope_id, name: None)
-                    if callee.generic_params.size() <= type_arg_index {
+                    if callee.generics.params.size() <= type_arg_index {
                         .error("Trying to access generic parameter out of bounds", parsed_type.span())
                         continue
                     }
 
                     // Find the associated type variable for this parameter, we'll use it in substitution
-                    let typevar_type_id = match callee.generic_params[type_arg_index] {
+                    let typevar_type_id = match callee.generics.params[type_arg_index] {
                         InferenceGuide(id)
                         | Parameter(id) => id
                     }
@@ -5816,17 +5871,14 @@ struct Typechecker {
                     }
                 }
 
-                if not callee.is_instantiated {
-                    generic_checked_function_to_instantiate = Some(function_id)
-                }
+                mut resolved_args: [(String, Span, CheckedExpression)] = .resolve_default_params(params: callee.generics.base_params, args: call.args, scope_id: caller_scope_id, safety_mode, arg_offset, span)
 
-                mut resolved_args: [(String, Span, CheckedExpression)] = .resolve_default_params(params: callee.params, args: call.args, scope_id: caller_scope_id, safety_mode, arg_offset, span)
-
-                if callee.params.size() == resolved_args.size() + arg_offset {
-                    for i in 0..callee.params.size()-arg_offset {
+                if callee.generics.base_params.size() == resolved_args.size() + arg_offset {
+                    for i in 0..callee.generics.base_params.size()-arg_offset {
                         let (name, span, checked_arg) = resolved_args[i]
+
                         .check_types_for_compat(
-                            lhs_type_id: callee.params[i+arg_offset].variable.type_id
+                            lhs_type_id: callee.generics.base_params[i+arg_offset].variable.type_id
                             rhs_type_id: checked_arg.type()
                             generic_inferences: &mut .generic_inferences
                             span: checked_arg.span()
@@ -5853,15 +5905,22 @@ struct Typechecker {
                 return_type = .substitute_typevars_in_type(type_id: return_type, generic_inferences: .generic_inferences)
 
                 if type_hint.has_value() and not type_hint.value().equals(unknown_type_id()) {
+                    let old_ignore_errors = .ignore_errors
+                    if callee.is_instantiated {
+                        // If this is a possible respecialization of a generic function that is the child of a specialized version of that function
+                        // allow an error here, if it is not a respecialization we will recheck
+                        .ignore_errors = true
+                    }
                     .check_types_for_compat(
                         lhs_type_id: type_hint!
                         rhs_type_id: return_type
                         generic_inferences: &mut .generic_inferences
                         span
                     )
+                    .ignore_errors = old_ignore_errors
                 }
 
-                for generic_typevar in callee.generic_params.iterator() {
+                for generic_typevar in callee.generics.params.iterator() {
                     if generic_typevar is Parameter(id) {
                         let substitution = .generic_inferences.get(id.to_string())
                         if substitution.has_value() {
@@ -5869,6 +5928,19 @@ struct Typechecker {
                         } else {
                             .error("Not all generic parameters have known types", span)
                         }
+                    }
+                }
+
+                if not callee.is_instantiated or (not callee.linkage is External and not callee.generics.is_specialized_for_types(types: generic_arguments)) {
+                    generic_checked_function_to_instantiate = Some(function_id)
+                } else if callee.is_instantiated {
+                    if type_hint.has_value() and not type_hint.value().equals(unknown_type_id()) {
+                        .check_types_for_compat(
+                            lhs_type_id: type_hint!
+                            rhs_type_id: return_type
+                            generic_inferences: &mut .generic_inferences
+                            span
+                        )
                     }
                 }
             }
@@ -5885,7 +5957,6 @@ struct Typechecker {
 
         if generic_checked_function_to_instantiate.has_value() {
             // Clear the generic parameters and typecheck in the fully specialized scope.
-
             if maybe_this_type_id.has_value() {
                 maybe_this_type_id = .substitute_typevars_in_type(type_id: maybe_this_type_id!, generic_inferences: .generic_inferences)
             }
@@ -5984,8 +6055,8 @@ struct Typechecker {
 
 
             mut type_bindings: [String:TypeId] = [:]
-            for i in 0uz..resolved_function.generic_params.size() {
-                let param = resolved_function.generic_params[i]
+            for i in 0uz..resolved_function.generics.params.size() {
+                let param = resolved_function.generics.params[i]
 
                 type_bindings.set(
                     param.type_id().to_string()

--- a/selfhost/types.jakt
+++ b/selfhost/types.jakt
@@ -520,7 +520,7 @@ class CheckedFunction {
     public return_type_id: TypeId
     public return_type_span: Span?
     public params: [CheckedParameter]
-    public generic_params: [FunctionGenericParameter]
+    public generics: FunctionGenerics
     public block: CheckedBlock
     public can_throw: bool
     public type: FunctionType
@@ -551,11 +551,56 @@ class CheckedFunction {
         return first_param_variable.name == "this" and first_param_variable.is_mutable
     }
 
+    public function add_param(mut this, anon checked_param: CheckedParameter) throws {
+        .params.push(checked_param)
+        .generics.base_params.push(checked_param)
+    }
+
+    public function set_params(mut this, anon checked_params: [CheckedParameter]) throws {
+        .params = checked_params
+        .generics.base_params = checked_params
+    }
+
+    public function is_specialized_for_types(this, types: [TypeId]) -> bool {
+        return .generics.is_specialized_for_types(types)
+    }
+
     public function to_parsed_function(this) -> ParsedFunction {
         if not .parsed_function.has_value() {
             panic("to_parsed_function() called on a synthetic function")
         }
         return .parsed_function!
+    }
+}
+
+class FunctionGenerics {
+    public base_params: [CheckedParameter]
+    public params: [FunctionGenericParameter]
+    public specializations: [[TypeId]]
+
+    public function is_specialized_for_types(this, types: [TypeId]) -> bool {
+        if types.size() == 0 {
+            return true
+        }
+
+        for specialization in .specializations.iterator() {
+            mut matched = true
+
+            if types.size() == specialization.size() {
+                for i in ..types.size() {
+                    if not types[i].equals(specialization[i]) {
+                        matched = false
+                        break
+                    }
+                }
+            }
+
+            if matched {
+                return true
+            }
+        }
+
+        return false
     }
 }
 
@@ -1732,7 +1777,7 @@ class CheckedProgram {
                     return_type_id: return_type_substitute
                     return_type_span: previous_function.return_type_span
                     params: replacement_params
-                    generic_params: previous_function.generic_params
+                    generics: previous_function.generics
                     block: previous_function.block
                     can_throw
                     type: previous_function.type

--- a/tests/typechecker/generic_recursive_function.jakt
+++ b/tests/typechecker/generic_recursive_function.jakt
@@ -1,0 +1,18 @@
+/// Expect:
+/// - output: "103\ng\n"
+
+function recurse<T>(anon i: T) -> T {
+    if i > 100 {
+        return i
+    }
+
+    return recurse(i+3)
+}
+
+function main() {
+    let a = recurse(1)
+    let b = recurse('a')
+
+    println("{}", a)
+    println("{}", b)
+}

--- a/tests/typechecker/generic_recursive_function_with_respecialization.jakt
+++ b/tests/typechecker/generic_recursive_function_with_respecialization.jakt
@@ -1,0 +1,18 @@
+/// Expect:
+/// - output: "101\ne\n"
+
+function recurse<T>(anon i: T) -> T {
+    if i > 100 {
+        return i
+    }
+
+    return recurse((i + 1) as! i32)
+}
+
+function main() {
+    let a = recurse(1)
+    let b = recurse('a')
+
+    println("{}", a)
+    println("{}", b)
+}


### PR DESCRIPTION
This avoids the issue where currently infinite recursion will occur in
typechecking as typecheck_and_specialize_generic_function will be
recursively called.