### PR TITLE
typechecker: Allow calling a function passed by reference

### DIFF
--- a/samples/pointers/bad_pointer_deref.jakt
+++ b/samples/pointers/bad_pointer_deref.jakt
@@ -1,5 +1,5 @@
 /// Expect:
-/// - error: "Dereference of a non-pointer value"
+/// - error: "Dereference of a non-pointer type `i64`"
 
 function main() {
     let x = 4

--- a/selfhost/typechecker.jakt
+++ b/selfhost/typechecker.jakt
@@ -2178,7 +2178,7 @@ struct Typechecker {
                 }
             }
             GenericEnumInstance(id: lhs_enum_id, args: lhs_args) => {
-                if .get_type(rhs_type_id) is GenericEnumInstance(id: rhs_enum_id, args: rhs_args) {
+                if rhs_type is GenericEnumInstance(id: rhs_enum_id, args: rhs_args) {
                     if lhs_enum_id.equals(rhs_enum_id) {
                         let lhs_enum = .get_enum(lhs_enum_id)
                         guard lhs_args.size() == rhs_args.size() else {
@@ -2340,7 +2340,7 @@ struct Typechecker {
                 if lhs_type_id.equals(rhs_type_id) {
                     return true
                 }
-                let rhs_type = .get_type(rhs_type_id)
+
                 match rhs_type {
                     GenericEnumInstance(id, args) => {
                         if enum_id.equals(id) {
@@ -2398,7 +2398,7 @@ struct Typechecker {
                 if lhs_type_id.equals(rhs_type_id) {
                     return true
                 }
-                let rhs_type = .get_type(rhs_type_id)
+
                 match rhs_type {
                     GenericInstance(id, args) => {
                         if not lhs_struct_id.equals(id) {
@@ -2465,7 +2465,7 @@ struct Typechecker {
                     return true
                 }
 
-                if .get_type(rhs_type_id) is RawPtr(rhs_rawptr_type_id) {
+                if rhs_type is RawPtr(rhs_rawptr_type_id) {
                     if not .check_types_for_compat(
                         lhs_type_id: lhs_rawptr_type_id
                         rhs_type_id: rhs_rawptr_type_id
@@ -2481,6 +2481,19 @@ struct Typechecker {
                             format("Type mismatch: expected ‘{}’, but got ‘{}’", .type_name(lhs_type_id), .type_name(rhs_type_id))
                             span
                         )
+                        return false
+                    }
+                }
+            }
+            Reference(lhs_inner_type_id) => {
+                if rhs_type is Reference(rhs_inner_type_id) {
+                    if not .check_types_for_compat(
+                        lhs_type_id: lhs_inner_type_id
+                        rhs_type_id: rhs_inner_type_id
+                        generic_inferences
+                        span
+                    ) {
+                        // FIXME: maybe emit secondary error?
                         return false
                     }
                 }

--- a/selfhost/typechecker.jakt
+++ b/selfhost/typechecker.jakt
@@ -1815,7 +1815,6 @@ struct Typechecker {
 
         // Check generic parameters
         for generic_parameter in parsed_function.generic_parameters.iterator() {
-
             current_module.types.push(Type::TypeVariable(generic_parameter.name))
 
             let type_var_type_id = TypeId(
@@ -2848,7 +2847,7 @@ struct Typechecker {
                         return CheckedExpression::UnaryOp(expr: checked_expr, op: checked_op, span, type_id)
                     }
                     else => {
-                        .error("Dereference of a non-pointer value", span)
+                        .error(format("Dereference of a non-pointer type `{}`", .type_name(expr_type_id)), span)
                     }
                 }
             }
@@ -5469,8 +5468,15 @@ struct Typechecker {
 
         // 1. Look for a variable in the current scope with this name.
         let maybe_var = .find_var_in_scope(scope_id: current_scope_id, var: call.name)
-        if maybe_var.has_value() and .get_type(maybe_var!.type_id) is Function(pseudo_function_id) {
-            return pseudo_function_id
+        if maybe_var.has_value()  {
+            let inner_type = match .get_type(maybe_var!.type_id) {
+                Reference(type_id) | MutableReference(type_id) => type_id
+                else => maybe_var!.type_id
+            }
+
+            if .get_type(inner_type) is Function(pseudo_function_id) {
+                return pseudo_function_id
+            }
         }
 
         // 2. Look for a function with this name.

--- a/tests/typechecker/function_pass_by_reference.jakt
+++ b/tests/typechecker/function_pass_by_reference.jakt
@@ -1,0 +1,16 @@
+/// Expect:
+/// - output: "2\n"
+
+function add(i: i64, adder: &function(anon i: i64) -> i64) -> i64  {
+    return adder(i)
+}
+
+function main() {
+    let adder = function(anon i: i64) -> i64 {
+        return i + 1
+    }
+
+    let a = add(i: 1, &adder)
+
+    println("{}", a)
+}

--- a/tests/typechecker/generic_function_pass_by_reference.jakt
+++ b/tests/typechecker/generic_function_pass_by_reference.jakt
@@ -1,0 +1,16 @@
+/// Expect:
+/// - output: "3\n"
+
+function add<T>(i: T, adder: &function(anon i: T) -> T) -> T  {
+    return adder(i)
+}
+
+function main() {
+    let adder = function(anon i: i32) -> i32 {
+        return i + 2
+    }
+
+    let a = add(i: 1i32, &adder)
+
+    println("{}", a)
+}


### PR DESCRIPTION
Previously when resolving a call we didn't check to see if we needed to
dereference a variable in scope before checking if it is a function.

This also adds checking for references in `check_types_for_compat`