### PR TITLE
jakttest+samples+tests+editors: Remove `selfhost-only` test qualifier

### DIFF
--- a/editors/vscode/snippets/jakt.json
+++ b/editors/vscode/snippets/jakt.json
@@ -3,7 +3,7 @@
         "scope": "jakt",
         "prefix": "jt",
         "body": [
-            "/// Expect: selfhost-only",
+            "/// Expect:",
             "/// - output: \"$1\"",
             "",
             "$0"
@@ -14,7 +14,7 @@
         "scope": "jakt",
         "prefix": "jte",
         "body": [
-            "/// Expect: selfhost-only",
+            "/// Expect:",
             "/// - error: \"$1\"",
             "",
             "$0"

--- a/jakttest/README.md
+++ b/jakttest/README.md
@@ -60,16 +60,3 @@ There are currently three available tags:
   written to stdandard error.
 - `error`: Expects the test to be rejected by the Jakt compiler, where the given
   output must appear somewhere in its error output.
-
-## On adding selfhost-only tests
-
-Since CI runs both selfhost and rust-based tests, and because rust-based
-development is being discontinued, if you just add a test with the regular
-`Expect` format, it will probably get picked by the rust test driver, failing in
-the process. For this, add `selfhost-only` after `Expect:`:
-```jakt
-/// Expect: selfhost-only
-/// - ...
-```
-This will tell the rust test driver to skip the test, while Jakttest will run it
-normally.

--- a/samples/arrays/throws.jakt
+++ b/samples/arrays/throws.jakt
@@ -1,4 +1,4 @@
-/// Expect: selfhost-only
+/// Expect:
 /// - error: "Array initialization inside non-throwing scope\n"
 
 function a() -> [u8] => []

--- a/samples/closures/capture_by_reference.jakt
+++ b/samples/closures/capture_by_reference.jakt
@@ -1,4 +1,4 @@
-/// Expect: selfhost-only
+/// Expect:
 /// - output: "PASS\n"
 
 function test(cb: function() -> void) {

--- a/samples/closures/capture_by_value.jakt
+++ b/samples/closures/capture_by_value.jakt
@@ -1,4 +1,4 @@
-/// Expect: selfhost-only
+/// Expect:
 /// - output: "PASS\n"
 
 function test(cb: function() -> void) {

--- a/samples/closures/closure_with_parameter.jakt
+++ b/samples/closures/closure_with_parameter.jakt
@@ -1,4 +1,4 @@
-/// Expect: selfhost-only
+/// Expect:
 /// - output: "5\n"
 
 function find(anon arr: [i64], anon cb: function(a: i64) -> bool) -> i64? {

--- a/samples/closures/function_as_parameter.jakt
+++ b/samples/closures/function_as_parameter.jakt
@@ -1,4 +1,4 @@
-/// Expect: selfhost-only
+/// Expect:
 /// - output: "well, hello friends.\n"
 
 function hello(anon who: function() -> String) {

--- a/samples/closures/function_as_variable.jakt
+++ b/samples/closures/function_as_variable.jakt
@@ -1,4 +1,4 @@
-/// Expect: selfhost-only
+/// Expect:
 /// - output: "PASS\nPASS\n"
 
 function main() {

--- a/samples/closures/lambdas_can_throw.jakt
+++ b/samples/closures/lambdas_can_throw.jakt
@@ -1,4 +1,4 @@
-/// Expect: selfhost-only
+/// Expect:
 /// - output: "69\n"
 
 function test(anon cb: function() throws -> String) throws {

--- a/samples/closures/no_returning_functions.jakt
+++ b/samples/closures/no_returning_functions.jakt
@@ -1,4 +1,4 @@
-/// Expect: selfhost-only
+/// Expect:
 /// - error: "Returning a function is not currently supported\n"
 
 function test() -> function() -> void {

--- a/samples/compiletime_execution/basic.jakt
+++ b/samples/compiletime_execution/basic.jakt
@@ -1,4 +1,4 @@
-/// Expect: selfhost-only
+/// Expect:
 /// - output: "fibonacci(16) = 987\n"
 
 

--- a/samples/compiletime_execution/match.jakt
+++ b/samples/compiletime_execution/match.jakt
@@ -1,4 +1,4 @@
-/// Expect: selfhost-only
+/// Expect:
 /// - output: "32\n32\n42\n"
 
 enum SomeEnum {

--- a/samples/control_flow/never_return.jakt
+++ b/samples/control_flow/never_return.jakt
@@ -1,4 +1,4 @@
-/// Expect: selfhost-only
+/// Expect:
 /// - output: ""
 
 function test() -> String {

--- a/samples/control_flow/no_never_return.jakt
+++ b/samples/control_flow/no_never_return.jakt
@@ -1,4 +1,4 @@
-/// Expect: selfhost-only
+/// Expect:
 /// - error: "Control reaches end of never-returning function\n"
 
 function test() -> never {

--- a/samples/control_flow/statements_after_never_return.jakt
+++ b/samples/control_flow/statements_after_never_return.jakt
@@ -1,4 +1,4 @@
-/// Expect: selfhost-only
+/// Expect:
 /// - error: "Unreachable code\n"
 
 function main() {

--- a/samples/control_flow/try_expression.jakt
+++ b/samples/control_flow/try_expression.jakt
@@ -1,4 +1,4 @@
-/// Expect: selfhost-only
+/// Expect:
 /// - output: "123\nPASS\n"
 
 struct Foo {

--- a/samples/enums/is_variant_binding.jakt
+++ b/samples/enums/is_variant_binding.jakt
@@ -1,4 +1,4 @@
-/// Expect: selfhost-only
+/// Expect:
 /// - output: "5 Hello\n"
 
 enum Foo {

--- a/samples/enums/is_variant_binding_compound.jakt
+++ b/samples/enums/is_variant_binding_compound.jakt
@@ -1,4 +1,4 @@
-/// Expect: selfhost-only
+/// Expect:
 /// - output: "5\n"
 
 enum Foo {

--- a/samples/enums/is_variant_binding_compound_middle.jakt
+++ b/samples/enums/is_variant_binding_compound_middle.jakt
@@ -1,4 +1,4 @@
-/// Expect: selfhost-only
+/// Expect:
 /// - output: "PASS\n"
 
 enum Foo {

--- a/samples/enums/is_variant_binding_compound_multiple.jakt
+++ b/samples/enums/is_variant_binding_compound_multiple.jakt
@@ -1,4 +1,4 @@
-/// Expect: selfhost-only
+/// Expect:
 /// - output: "PASS\n"
 
 enum Foo {

--- a/samples/enums/is_variant_binding_compound_unmatched.jakt
+++ b/samples/enums/is_variant_binding_compound_unmatched.jakt
@@ -1,4 +1,4 @@
-/// Expect: selfhost-only
+/// Expect:
 /// - output: "did not match\n"
 
 enum Foo {

--- a/samples/enums/is_variant_binding_else.jakt
+++ b/samples/enums/is_variant_binding_else.jakt
@@ -1,4 +1,4 @@
-/// Expect: selfhost-only
+/// Expect:
 /// - output: "PASS\n"
 
 enum E {

--- a/samples/enums/is_variant_binding_else_complex.jakt
+++ b/samples/enums/is_variant_binding_else_complex.jakt
@@ -1,4 +1,4 @@
-/// Expect: selfhost-only
+/// Expect:
 /// - output: "PASS\n"
 
 enum E {

--- a/samples/enums/is_variant_binding_untyped_variant.jakt
+++ b/samples/enums/is_variant_binding_untyped_variant.jakt
@@ -1,4 +1,4 @@
-/// Expect: selfhost-only
+/// Expect:
 /// - output: "PASS\n"
 
 enum E {

--- a/samples/guard/is_guard.jakt
+++ b/samples/guard/is_guard.jakt
@@ -1,4 +1,4 @@
-/// Expect: selfhost-only
+/// Expect:
 /// - output: "hello there: 5\n"
 
 enum Foo {

--- a/samples/guard/is_guard_compound_matched.jakt
+++ b/samples/guard/is_guard_compound_matched.jakt
@@ -1,4 +1,4 @@
-/// Expect: selfhost-only
+/// Expect:
 /// - output: "hello there: 5\n"
 
 enum Foo {

--- a/samples/guard/is_guard_compound_unmatched.jakt
+++ b/samples/guard/is_guard_compound_unmatched.jakt
@@ -1,4 +1,4 @@
-/// Expect: selfhost-only
+/// Expect:
 /// - output: "not matched\n"
 
 enum Foo {

--- a/samples/guard/is_guard_no_exit.jakt
+++ b/samples/guard/is_guard_no_exit.jakt
@@ -1,4 +1,4 @@
-/// Expect: selfhost-only
+/// Expect:
 //  - error: "Else block of guard must either `return`, `break`, `continue`, or `throw`"
 
 enum Foo {

--- a/samples/guard/is_guard_no_leaks.jakt
+++ b/samples/guard/is_guard_no_leaks.jakt
@@ -1,4 +1,4 @@
-/// Expect: selfhost-only
+/// Expect:
 /// - error: "Variable 'x' not found"
 
 enum Foo {

--- a/samples/imports/assign_across_import/main.jakt
+++ b/samples/imports/assign_across_import/main.jakt
@@ -1,4 +1,4 @@
-/// Expect: selfhost-only
+/// Expect:
 /// - output: ""
 import helper { S }
 

--- a/samples/imports/import_extern_c.jakt
+++ b/samples/imports/import_extern_c.jakt
@@ -1,4 +1,4 @@
-/// Expect: selfhost-only
+/// Expect:
 /// - output: "PASS\n"
 
 import extern c "stdlib.h"  {

--- a/samples/imports/import_extern_cpp.jakt
+++ b/samples/imports/import_extern_cpp.jakt
@@ -1,4 +1,4 @@
-/// Expect: selfhost-only
+/// Expect:
 /// - output: "PASS\n"
 
 import extern "vector" {

--- a/samples/namespaces/extend_namespace.jakt
+++ b/samples/namespaces/extend_namespace.jakt
@@ -1,4 +1,4 @@
-/// Expect: selfhost-only
+/// Expect:
 /// - output: "PASS\n"
 
 namespace foo {

--- a/samples/optional/throw_while_none_coalescing.jakt
+++ b/samples/optional/throw_while_none_coalescing.jakt
@@ -1,4 +1,4 @@
-/// Expect: selfhost-only
+/// Expect:
 /// - output: "PASS\n"
 
 function troublemaker() throws -> i64 {

--- a/samples/tuples/destructuring_assignment.jakt
+++ b/samples/tuples/destructuring_assignment.jakt
@@ -1,4 +1,4 @@
-/// Expect: selfhost-only
+/// Expect:
 /// - output: "1 hello\n"
 
 function foo() -> (i64, String) {

--- a/tests/codegen/class_return_this.jakt
+++ b/tests/codegen/class_return_this.jakt
@@ -1,4 +1,4 @@
-/// Expect: selfhost-only
+/// Expect:
 /// - output: "PASS\n"
 
 class A {

--- a/tests/codegen/optional_chaining.jakt
+++ b/tests/codegen/optional_chaining.jakt
@@ -1,4 +1,4 @@
-/// Expect: selfhost-only
+/// Expect:
 /// - output: "PASS\nPASS\n1\nNone\n"
 
 struct Test {

--- a/tests/codegen/out_of_order_optional_type.jakt
+++ b/tests/codegen/out_of_order_optional_type.jakt
@@ -1,4 +1,4 @@
-/// Expect: selfhost-only
+/// Expect:
 /// - output: ""
 
 struct CheckedBlock {

--- a/tests/typechecker/auto_deref.jakt
+++ b/tests/typechecker/auto_deref.jakt
@@ -1,4 +1,4 @@
-/// Expect: selfhost-only
+/// Expect:
 /// - output: "arithmetic 586, boolean true, unary -70, match 1, access 139, index 0, brackets 0\n"
 
 function deref_arithmetic_binary(anon foo: &i32) -> i32 {


### PR DESCRIPTION
As the rust based compiler was removed there is no need for the `selfhost-only` test qualifier anymore.