### PR TITLE
codegen+tests: Use proper dereference operator for generic classes

### DIFF
--- a/samples/generics/generic_class.jakt
+++ b/samples/generics/generic_class.jakt
@@ -1,0 +1,12 @@
+/// Expect:
+/// - output: "100\n"
+
+class Foo<T> {
+    public x: T
+}
+
+function main() {
+    let f = Foo(x: 100);
+
+    println("{}", f.x);
+}

--- a/selfhost/codegen.jakt
+++ b/selfhost/codegen.jakt
@@ -1307,6 +1307,14 @@ struct CodeGenerator {
                         output += "."
                     }
                 }
+                GenericInstance(id) => {
+                    let structure = .program.get_struct(id)
+                    if structure.record_type is Class and object != "*this" {
+                        output += "->"
+                    } else {
+                        output += "."
+                    }
+                }
                 else => {
                     output += "."
                 }


### PR DESCRIPTION
Fixes the updated test case of #428 and adds a test for it (similar to generic_struct test).