### PR TITLE
codegen: Generic classes/structs fixes

### DIFF
--- a/samples/generics/generic_class_method.jakt
+++ b/samples/generics/generic_class_method.jakt
@@ -1,0 +1,11 @@
+/// Expect:
+/// - output: "PASS\n"
+
+class A<T> {
+    public function test(this, anon x: T) => x
+}
+
+function main() {
+    let instance: A<String> = A()
+    println("{}", instance.test("PASS"))
+}

--- a/samples/generics/generic_struct_method.jakt
+++ b/samples/generics/generic_struct_method.jakt
@@ -1,0 +1,11 @@
+/// Expect:
+/// - output: "PASS\n"
+
+struct A<T> {
+    public function test(this, anon x: T) => x
+}
+
+function main() {
+    let instance: A<String> = A()
+    println("{}", instance.test("PASS"))
+}

--- a/selfhost/codegen.jakt
+++ b/selfhost/codegen.jakt
@@ -2323,6 +2323,17 @@ struct CodeGenerator {
                                     output += ">::create"
                                 } else {
                                     output += call.name
+                                    output += "<"
+                                    mut first = true
+                                    for arg in args.iterator() {
+                                        if not first {
+                                            output += ", "
+                                        } else {
+                                            first = false
+                                        }
+                                        output += .codegen_type(arg)
+                                    }
+                                    output += ">"
                                 }
                             }
                             else => {

--- a/selfhost/codegen.jakt
+++ b/selfhost/codegen.jakt
@@ -1299,15 +1299,7 @@ struct CodeGenerator {
                 RawPtr => {
                     output += "->"
                 }
-                Struct(struct_id) => {
-                    let structure = .program.get_struct(struct_id)
-                    if structure.record_type is Class and object != "*this" {
-                        output += "->"
-                    } else {
-                        output += "."
-                    }
-                }
-                GenericInstance(id) => {
+                Struct(id) | GenericInstance(id) => {
                     let structure = .program.get_struct(id)
                     if structure.record_type is Class and object != "*this" {
                         output += "->"

--- a/selfhost/codegen.jakt
+++ b/selfhost/codegen.jakt
@@ -2201,7 +2201,7 @@ struct CodeGenerator {
             RawPtr => {
                 output += "->"
             }
-            Struct(id) => {
+            Struct(id) | GenericInstance(id) => {
                 let struct_ = .program.get_struct(id)
                 if struct_.record_type is Class and object != "*this" {
                     output += "->"


### PR DESCRIPTION
1) I've realized that the fix that I introduced in https://github.com/SerenityOS/jakt/commit/6d369fad0241b5bb284e0ae475bb3706196f3b4c can be simplified

2) Fix dereference operator for methods in generic classes (similar to the fix in https://github.com/SerenityOS/jakt/commit/6d369fad0241b5bb284e0ae475bb3706196f3b4c but already simplified like above)

3) Previously, if the generic struct had no data members, ex. like this one:
```cpp
struct A<T> {
    public function test(this, anon x: T) => x
}
```
And we wanted to create an instance of it, ex. like so:
```cpp
let name: A<String> = A()
```

In CPP it would look like this:
```cpp
const A<String> name = A();
```

And unfortunately CPP would complain.

This PR changes the CPP codegen to:

```cpp
const A<String> name = A<String>();
```