### PR TITLE
typechecker+codegen+tests: Accept never as a branch result

### DIFF
--- a/selfhost/codegen.jakt
+++ b/selfhost/codegen.jakt
@@ -1976,6 +1976,7 @@ struct CodeGenerator {
     function codegen_match_body(mut this, body: CheckedMatchBody, return_type_id: TypeId) throws -> String {
         mut output = ""
 
+
         match body {
             Block(block) => {
                 output += .codegen_block(block)
@@ -1989,6 +1990,11 @@ struct CodeGenerator {
                     output += "return ("
                     output += .codegen_expression(expr)
                     output += "), JaktInternal::ExplicitValue<void>();\n"
+                } else if expr.type().equals(never_type_id()) {
+                    output += "("
+                    output += .codegen_expression(expr)
+                    output += ");\n"
+                    output += "VERIFY_NOT_REACHED();\n"
                 } else {
                     output += "return JaktInternal::ExplicitValue("
                     output += .codegen_expression(expr)
@@ -2476,25 +2482,36 @@ struct CodeGenerator {
     function codegen_block(mut this, block: CheckedBlock) throws -> String {
         mut output = ""
 
+        mut yields_never = false
+
         if block.yielded_type.has_value() {
             let yielded_type = block.yielded_type!
-            let type_output = .codegen_type(yielded_type)
             let fresh_var = .fresh_var()
             let fresh_label = .fresh_label()
 
-            .entered_yieldable_blocks.push((fresh_var, fresh_label))
 
-            output += "({ Optional<"
-            output += type_output
-            output += "> "
-            output += fresh_var
-            output += "; "
+            if not yielded_type.equals(unknown_type_id()) {
+                .entered_yieldable_blocks.push((fresh_var, fresh_label))
+
+                let type_output = .codegen_type(yielded_type)
+                output += "({ Optional<"
+                output += type_output
+                output += "> "
+                output += fresh_var
+                output += "; "
+            } else {
+                yields_never = true
+            }
         }
 
         output += "{\n"
 
         for statement in block.statements.iterator() {
             output += .codegen_statement(statement)
+        }
+
+        if yields_never {
+            output += "VERIFY_NOT_REACHED();\n"
         }
 
         output += "}\n"

--- a/selfhost/typechecker.jakt
+++ b/selfhost/typechecker.jakt
@@ -2252,12 +2252,17 @@ struct Typechecker {
         let lhs_type = .get_type(lhs_type_id)
         let rhs_type = .get_type(rhs_type_id)
 
+        if lhs_type is Never or rhs_type is Never {
+            return true
+        }
+
         let lhs_type_id_string = lhs_type_id.to_string()
         let rhs_type_id_string = rhs_type_id.to_string()
 
         let optional_struct_id = .find_struct_in_prelude("Optional")
         let weakptr_struct_id = .find_struct_in_prelude("WeakPtr")
         let array_struct_id = .find_struct_in_prelude("Array")
+
 
         match lhs_type {
             TypeVariable => {
@@ -3068,6 +3073,12 @@ struct Typechecker {
         return CheckedExpression::UnaryOp(expr: CheckedExpression::NumericConstant(val: new_constant, span, type_id), op: CheckedUnaryOperator::Negate, span, type_id: flipped_sign_type)
     }
 
+    function check_never_returning_assignment(mut this, rhs_type_id: TypeId, span: Span) throws {
+        if rhs_type_id.equals(never_type_id()) {
+            .error("Cannot assign expression that never returns", span)
+        }
+    }
+
     function typecheck_binary_operation(mut this, checked_lhs: CheckedExpression, op: BinaryOperator, checked_rhs: CheckedExpression, scope_id: ScopeId, span: Span) throws -> TypeId {
         let lhs_type_id = checked_lhs.type()
         let rhs_type_id = checked_rhs.type()
@@ -3173,6 +3184,8 @@ struct Typechecker {
                     }
                 }
 
+                .check_never_returning_assignment(rhs_type_id, span)
+
                 let result = .unify(lhs: rhs_type_id, lhs_span: rhs_span, rhs: lhs_type_id, rhs_span: lhs_span)
                 if not result.has_value() {
                     .error(format("Assignment between incompatible types (`{}` and `{}`)", .type_name(lhs_type_id), .type_name(rhs_type_id)), span)
@@ -3189,6 +3202,7 @@ struct Typechecker {
                     and lhs_struct_id.equals(rhs_struct_id) {
                     return lhs_type_id
                 }
+                .check_never_returning_assignment(rhs_type_id, span)
                 let result = .unify(lhs: rhs_type_id, lhs_span: rhs_span, rhs: lhs_type_id, rhs_span: lhs_span)
                 if not result.has_value() {
                     .error(format(

--- a/tests/typechecker/bad_assignment_of_never.jakt
+++ b/tests/typechecker/bad_assignment_of_never.jakt
@@ -1,0 +1,7 @@
+/// Expect:
+/// - error: "Cannot assign expression that never returns"
+
+function main() {
+    mut value = 1u64
+    value = abort()
+}

--- a/tests/typechecker/never_branch_compatible.jakt
+++ b/tests/typechecker/never_branch_compatible.jakt
@@ -1,0 +1,23 @@
+/// Expect:
+/// - output: "OK\n"
+
+function unreachable(anon message: String) -> never {
+    eprintln("unreachable code: {}", message)
+    abort()
+}
+
+enum Foo {
+    Bar
+    Baz
+}
+
+function main() {
+    let foo = Foo::Bar
+
+    // String and never branches are compatible
+    let message = match foo {
+        Bar => "OK"
+        Baz => unreachable("foo can't be baz")
+    }
+    println("{}", message)
+}


### PR DESCRIPTION
This affects matches specially but another test is added to make sure
that assigning never is still reported as an error since it doesn't make
sense to store something you're not getting.

EDIT: cc @alimpfard
