### PR TITLE
rules: Adapt rules from official discord for repo

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,18 @@
+The purpose of this repo is to facilitate productive development of the Jakt programming language, a part of the SerenityOS project. Any behavior that runs counter to that goal will not be tolerated.
+
+## Some basic rules:
+
+1. Do the best you can, both in code and in communication. Expect others to do the same.
+2. Politics, religion and sex are not appropriate topics here. Discuss them elsewhere.
+3. Any discussion unrelated to the Jakt/SerenityOS project belongs elsewhere.
+4. Try your best to keep a positive attitude, and try to not drag others down if/when you're having a bad day.
+5. Don't complain about things you are not actively engaged in improving. This includes low-effort whining like "$THING is trash". Don't shit on other projects, companies, or communities. 
+6. If you need help building Jakt, use the discord #jakt channel.
+8. Talk is cheap. Don't waste other people's time by talking about your great ideas if you don't also spend time implementing your ideas. We have no need for "idea guys"
+9. Don't ask other people to look things up for you. If a question can be answered by consulting the code, the git history, the issue tracker, or a search engine, look it up yourself.
+10. Avoid when-posting. "When will Jakt get this feature?", "When will you do X?", etc. If you want to see something happen, you make it happen.
+11. Refrain from excitement-posting on issues/pull requests. We are all excited about Jakt, but please don't add unnecessary noise. Users who repeatedly misuse this will be restricted.
+12. If a bug is discussed, please make sure there's a separate GitHub issue for it.
+13. No soliciting of any kind.
+14. Be judicious when using the @user ("ping") feature. The purpose of pinging somebody is to request their attention. Please don't use @user when simply referring to a user in conversation.
+15. Don't send general technical questions as direct messages to strangers and don't send friend requests to people you don't have a prior relationship with. If you have questions, asking in public makes it far more likely that someone can answer it. Furthermore, if multiple people have the same question, it's more efficient to answer it once where everyone can learn from it.


### PR DESCRIPTION
An adaptation of the Serenity CoC/rules from discord for the repo. These are already enforced, but we don't specify them on GitHub only discord, so this helps to make them more visible.