### PR TITLE
all: Add class-based polymorphism and method overrides

### DIFF
--- a/selfhost/codegen.jakt
+++ b/selfhost/codegen.jakt
@@ -858,12 +858,8 @@ struct CodeGenerator {
                     class_name_with_generics += ">"
                 }
 
-                if struct_.super_type_id.has_value() {
-                    let super_struct_type = .program.get_type(struct_.super_type_id!)
-                    guard super_struct_type is Struct(struct_id) else {
-                        panic("internal error: expected super struct during codegen of class/struct")
-                    }
-                    let super_struct = .program.get_struct(struct_id)
+                if struct_.super_struct_id.has_value() {
+                    let super_struct = .program.get_struct(struct_.super_struct_id!)
                     output += format("class {}: public {} {{\n", struct_.name, super_struct.name)
                 } else {
                     output += format("class {} : public RefCounted<{}>, public Weakable<{}> {{\n", struct_.name, class_name_with_generics, class_name_with_generics)

--- a/selfhost/codegen.jakt
+++ b/selfhost/codegen.jakt
@@ -742,6 +742,10 @@ struct CodeGenerator {
         if function_.name == "main" {
             output += "ErrorOr<int>"
         } else {
+            if function_.is_virtual {
+                output += "virtual "
+            }
+
             if function_.is_static() and not function_.linkage is External {
                 output += "static "
             }
@@ -779,12 +783,15 @@ struct CodeGenerator {
             output += param.variable.name
         }
         output += ")"
-
+        
         if not function_.is_static() and not function_.is_mutating() {
-            output += " const;"
-        } else {
-            output += ";"
+            output += " const"
+        } 
+        if function_.is_override {
+            output += " override"
         }
+
+        output += ";"
 
         output += "\n"
 

--- a/selfhost/lexer.jakt
+++ b/selfhost/lexer.jakt
@@ -104,6 +104,7 @@ enum Token {
     Namespace(Span)
     Not(Span)
     Or(Span)
+    Override(Span)
     Private(Span)
     Public(Span)
     Raw(Span)
@@ -116,6 +117,7 @@ enum Token {
     True(Span)
     Try(Span)
     Unsafe(Span)
+    Virtual(Span)
     Weak(Span)
     While(Span)
     Yield(Span)
@@ -211,6 +213,7 @@ enum Token {
         Namespace(span) => span
         Not(span) => span
         Or(span) => span
+        Override(span) => span
         Private(span) => span
         Public(span) => span
         Raw(span) => span
@@ -224,6 +227,7 @@ enum Token {
         Try(span) => span
         Unsafe(span) => span
         Weak(span) => span
+        Virtual(span) => span
         While(span) => span
         Yield(span) => span
         Guard(span) => span
@@ -259,6 +263,7 @@ enum Token {
         "namespace" => Token::Namespace(span)
         "not" => Token::Not(span)
         "or" => Token::Or(span)
+        "override" => Token::Override(span)
         "private" => Token::Private(span)
         "public" => Token::Public(span)
         "raw" => Token::Raw(span)
@@ -271,6 +276,7 @@ enum Token {
         "true" => Token::True(span)
         "try" => Token::Try(span)
         "unsafe" => Token::Unsafe(span)
+        "virtual" => Token::Virtual(span)
         "weak" => Token::Weak(span)
         "while" => Token::While(span)
         "yield" => Token::Yield(span)

--- a/selfhost/parser.jakt
+++ b/selfhost/parser.jakt
@@ -1066,6 +1066,8 @@ struct ParsedMethod {
     // FIXME: It would be nice to extend the ParsedVarDecl struct instead.
     parsed_function: ParsedFunction
     visibility: Visibility
+    is_virtual: bool
+    is_override: bool
 }
 
 struct ParsedVariable {
@@ -1541,7 +1543,7 @@ struct Parser {
                     last_visibility = None
                     last_visibility_span = None
 
-                    let parsed_method = .parse_method(function_linkage, visibility, is_comptime)
+                    let parsed_method = .parse_method(function_linkage, visibility, is_virtual: false, is_override: false, is_comptime)
 
                     methods.push(parsed_method)
                 }
@@ -1674,7 +1676,7 @@ struct Parser {
                     last_visibility = None
                     last_visibility_span = None
 
-                    let parsed_method = .parse_method(function_linkage, visibility, is_comptime)
+                    let parsed_method = .parse_method(function_linkage, visibility, is_virtual: false, is_override: false, is_comptime)
 
                     methods.push(parsed_method)
                 }
@@ -1789,6 +1791,8 @@ struct Parser {
         // This gets reset after each loop. If someone doesn't consume it, we error out.
         mut last_visibility: Visibility? = None
         mut last_visibility_span: Span? = None
+        mut last_virtual = false
+        mut last_override = false
 
         // Have we already found an error?
         mut error = false;
@@ -1836,6 +1840,12 @@ struct Parser {
                     last_visibility = None
                     last_visibility_span = None
 
+                    if last_virtual or last_override {
+                        .error("Fields cannot be ‘virtual’ or ‘override’", .current().span())
+                    }
+                    last_virtual = false
+                    last_override = false
+
                     let field = .parse_field(visibility)
 
                     fields.push(field)
@@ -1857,9 +1867,22 @@ struct Parser {
                     last_visibility = None
                     last_visibility_span = None
 
-                    let parsed_method = .parse_method(function_linkage, visibility, is_comptime: .current() is Comptime)
+                    let is_virtual = last_virtual
+                    let is_override = last_override
+                    last_virtual = false
+                    last_override = false
+
+                    let parsed_method = .parse_method(function_linkage, visibility, is_virtual, is_override, is_comptime: .current() is Comptime)
 
                     methods.push(parsed_method)
+                }
+                Virtual => {
+                    last_virtual = true
+                    .index++
+                }
+                Override => {
+                    last_override = true
+                    .index++
                 }
                 else => {
                     // TODO: Find a better way of only reporting the first error.
@@ -2200,7 +2223,7 @@ struct Parser {
         )
     }
 
-    function parse_method(mut this, anon linkage: FunctionLinkage, anon visibility: Visibility, is_comptime: bool) throws -> ParsedMethod {
+    function parse_method(mut this, anon linkage: FunctionLinkage, anon visibility: Visibility, is_virtual: bool, is_override: bool, is_comptime: bool) throws -> ParsedMethod {
         mut parsed_function = .parse_function(linkage, visibility, is_comptime)
 
         if linkage is External {
@@ -2208,8 +2231,10 @@ struct Parser {
         }
 
         return ParsedMethod(
-            parsed_function,
-            visibility,
+            parsed_function
+            visibility
+            is_virtual
+            is_override
         )
     }
 

--- a/selfhost/typechecker.jakt
+++ b/selfhost/typechecker.jakt
@@ -13,7 +13,8 @@ import parser { Parser, BinaryOperator, DefinitionLinkage, DefinitionType, Unary
                 ParsedExpression, ParsedFunction, ParsedNamespace, ParsedModuleImport,
                 ParsedExternImport, ParsedType, ParsedStatement, ParsedVarDecl, RecordType,
                 ParsedRecord, ParsedField, TypeCast, EnumVariantPatternArgument,
-                ParsedMatchBody, ParsedMatchCase, Visibility, ParsedParameter, ParsedCapture }
+                ParsedMatchBody, ParsedMatchCase, Visibility, ParsedParameter, ParsedCapture,
+                ParsedMethod }
 import types {
     BlockControlFlow, BuiltinType, CheckedBlock, CheckedCall, CheckedCapture, CheckedEnum, CheckedEnumVariant,
     CheckedEnumVariantBinding, CheckedExpression, CheckedFunction, CheckedMatchBody, CheckedMatchCase,
@@ -931,6 +932,8 @@ struct Typechecker {
                 parsed_function: func
                 is_comptime: func.is_comptime
                 is_closure: false
+                is_virtual: false
+                is_override: false
             )
 
             let function_id = module.add_function(checked_function)
@@ -1053,6 +1056,8 @@ struct Typechecker {
                 parsed_function: None
                 is_comptime: false
                 is_closure: false
+                is_virtual: false
+                is_override: false
             )
 
             // Internal constructor
@@ -1206,6 +1211,8 @@ struct Typechecker {
                 parsed_function: method.parsed_function
                 is_comptime: method.parsed_function.is_comptime
                 is_closure: false
+                is_virtual: method.is_virtual
+                is_override: method.is_override
             )
 
             let function_id = module.add_function(checked_function)
@@ -1521,6 +1528,8 @@ struct Typechecker {
                                 parsed_function: None
                                 is_comptime: false
                                 is_closure: false
+                                is_virtual: false
+                                is_override: false
                             )
                             let function_id = module.add_function(checked_function)
                             .add_function_to_scope(parent_scope_id: enum_.scope_id, name: variant.name, function_id, span: variant.span)
@@ -1566,6 +1575,8 @@ struct Typechecker {
                                 parsed_function: None
                                 is_comptime: false
                                 is_closure: false
+                                is_virtual: false
+                                is_override: false
                             )
                             let function_id = module.add_function(checked_function)
                             .add_function_to_scope(parent_scope_id: enum_.scope_id, name: variant.name, function_id, span: variant.span)
@@ -1600,6 +1611,8 @@ struct Typechecker {
                                 parsed_function: None
                                 is_comptime: false
                                 is_closure: false
+                                is_virtual: false
+                                is_override: false
                             )
                             let function_id = module.add_function(checked_function)
                             .add_function_to_scope(parent_scope_id: enum_.scope_id, name: variant.name, function_id, span: variant.span)
@@ -1630,7 +1643,26 @@ struct Typechecker {
 
         .current_struct_type_id = struct_type_id
 
+        mut all_virtuals: [String: CheckedFunction] = [:]
+        mut super_struct_id = .get_struct(struct_id).super_struct_id
+        while super_struct_id.has_value() {
+            let super_struct = .get_struct(super_struct_id!)
+            let scope = .get_scope(super_struct.scope_id)
+            for function_tuple in scope.functions.iterator() {
+                let function_ = .get_function(function_tuple.1)
+                if function_.is_virtual {
+                    all_virtuals[function_.name] = function_
+                }
+            }
+            super_struct_id = super_struct.super_struct_id
+        }
+
         for method in record.methods.iterator() {
+            if method.is_override {
+                if not all_virtuals.contains(method.parsed_function.name) {
+                    .error("Missing virtual for override", method.parsed_function.name_span)
+                }
+            }
             .typecheck_method(func: method.parsed_function, parent_id: StructOrEnumId::Struct(struct_id))
         }
 
@@ -1806,6 +1838,8 @@ struct Typechecker {
             parsed_function
             is_comptime: parsed_function.is_comptime
             is_closure: false
+            is_virtual: false
+            is_override: false
         )
         // FIXME: We can't return a `mut Foo` from a function right now, but assigning anything to a `mut` variable makes it mutable.
         //        AKA, working around one bug with another bug. :^)
@@ -2812,6 +2846,8 @@ struct Typechecker {
                     parsed_function: None
                     is_comptime: false
                     is_closure: false
+                    is_virtual: false
+                    is_override: false
                 )
                 mut module = .current_module()
                 let function_id = module.add_function(checked_function)

--- a/selfhost/typechecker.jakt
+++ b/selfhost/typechecker.jakt
@@ -388,7 +388,6 @@ struct Typechecker {
         if maybe_scope_id.has_value() {
             let existing_struct_id = maybe_scope_id!
             let definition_span = .get_struct(existing_struct_id).name_span
-
             .error_with_hint(
                 format("redefinition of struct/class {}", name)
                 span
@@ -1113,23 +1112,31 @@ struct Typechecker {
             Internal => false
         }
 
-        mut super_type_id: TypeId? = None
+        mut super_struct_id: StructId? = None
 
         match parsed_record.record_type {
-            Class(super_type) => match super_type.has_value() {
+            Class(super_type: super_parsed_type) => match super_parsed_type.has_value() {
                 true => {
-                    super_type_id = .typecheck_typename(parsed_type: super_type!, scope_id, name: None)
-                    if not .is_class(super_type_id!) {
-                        .error("Class can only inherit from another class", super_type!.span())
+                    let super_type_id = .typecheck_typename(parsed_type: super_parsed_type!, scope_id, name: None)
+                    let super_type = .get_type(super_type_id)
+                    
+                    if super_type is Struct(struct_id) {
+                        super_struct_id = struct_id
+                    } else {
+                        .error("Class can only inherit from another class", super_parsed_type!.span())
                     }
                 }
                 else => {}
             }
-            Struct(super_type) => match super_type.has_value() {
+            Struct(super_type: super_parsed_type) => match super_parsed_type.has_value() {
                 true => {
-                    super_type_id = .typecheck_typename(parsed_type: super_type!, scope_id, name: None)
-                    if not .is_struct(super_type_id!) {
-                        .error("Struct can only inherit from another struct", super_type!.span())
+                    let super_type_id = .typecheck_typename(parsed_type: super_parsed_type!, scope_id, name: None)
+                    let super_type = .get_type(super_type_id)
+                    
+                    if super_type is Struct(struct_id) {
+                        super_struct_id = struct_id
+                    } else {
+                        .error("Struct can only inherit from another struct", super_parsed_type!.span())
                     }
                 }
                 else => {}
@@ -1149,7 +1156,7 @@ struct Typechecker {
             definition_linkage: parsed_record.definition_linkage
             record_type: parsed_record.record_type
             type_id: struct_type_id
-            super_type_id
+            super_struct_id
         )
 
         mut generic_parameters: [TypeId] = module.structures[struct_id.id].generic_parameters
@@ -1350,7 +1357,7 @@ struct Typechecker {
             definition_linkage: parsed_record.definition_linkage
             record_type: parsed_record.record_type
             type_id: struct_type_id
-            super_type_id: None
+            super_struct_id: None
         ))
     }
 
@@ -2450,6 +2457,11 @@ struct Typechecker {
                         }
                     }
                     else => {
+                        let rhs_type = .get_type(rhs_type_id)
+                        if .is_subclass_of(ancestor_type_id: lhs_type_id, child_type_id: rhs_type_id) {
+                            return true
+                        }
+                        
                         if not rhs_type_id.equals(lhs_type_id) {
                             .error(
                                 format("Type mismatch: expected ‘{}’, but got ‘{}’", .type_name(lhs_type_id), .type_name(rhs_type_id))
@@ -2510,6 +2522,32 @@ struct Typechecker {
         }
 
         return true
+    }
+
+    function is_subclass_of(this, ancestor_type_id: TypeId, child_type_id: TypeId) -> bool {
+        let ancestor_type = .get_type(ancestor_type_id)
+        let child_type = .get_type(child_type_id)
+
+        guard ancestor_type is Struct(ancestor_struct_id) else { return false }
+        guard child_type is Struct(child_struct_id) else { return false }
+
+        mut ancestor_struct = .get_struct(ancestor_struct_id)
+
+        mut current_struct_id = child_struct_id
+
+        loop {
+            let current_struct = .get_struct(current_struct_id)
+            if current_struct.super_struct_id.has_value() {
+                if ancestor_struct_id.equals(current_struct.super_struct_id!) {
+                    return true
+                }
+                current_struct_id = current_struct.super_struct_id!
+            } else {
+                return false
+            }
+        }
+
+        return false
     }
 
     function substitute_typevars_in_type(mut this, type_id: TypeId , generic_inferences: [String: String]) throws -> TypeId => .program.substitute_typevars_in_type(type_id, generic_inferences, module_id: .current_module_id)
@@ -5565,12 +5603,9 @@ struct Typechecker {
                         if resolved_function_id.has_value() {
                             break
                         }
-                        if struct_.super_type_id.has_value() {
-                            let parent_type_id = struct_.super_type_id!
-                            guard .get_type(parent_type_id) is Struct(struct_id) else {
-                                panic("internal error: could not find parent struct/class for struct/class")
-                            }
-                            struct_ = .get_struct(struct_id)
+                        if struct_.super_struct_id.has_value() {
+                            let parent_struct_id = struct_.super_struct_id!
+                            struct_ = .get_struct(parent_struct_id)
                             scope_id = struct_.scope_id
                         } else {
                             .error(format("Could not find `{}`", call.name), span)

--- a/selfhost/typechecker.jakt
+++ b/selfhost/typechecker.jakt
@@ -1301,6 +1301,13 @@ struct Typechecker {
                 }
             }
 
+            if checked_function.is_virtual and checked_function.is_static() {
+                .error("Functions cannot be both virtual and static", checked_function.name_span)
+            }
+            if checked_function.is_override and checked_function.is_static() {
+                .error("Functions cannot be both override and static", checked_function.name_span)
+            }
+
             .add_function_to_scope(
                 parent_scope_id: struct_scope_id
                 name: func.name

--- a/selfhost/types.jakt
+++ b/selfhost/types.jakt
@@ -678,7 +678,7 @@ struct CheckedStruct {
     definition_linkage: DefinitionLinkage
     record_type: RecordType
     type_id: TypeId
-    super_type_id: TypeId?
+    super_struct_id: StructId?
 }
 
 struct CheckedEnum {

--- a/selfhost/types.jakt
+++ b/selfhost/types.jakt
@@ -479,6 +479,8 @@ class CheckedFunction {
     public parsed_function: ParsedFunction?
     public is_comptime: bool
     public is_closure: bool
+    public is_virtual: bool
+    public is_override: bool
 
     public function is_static(this) -> bool {
         if .params.size() < 1 {
@@ -1689,6 +1691,8 @@ class CheckedProgram {
                     parsed_function: previous_function.parsed_function
                     is_comptime: previous_function.is_comptime
                     is_closure: previous_function.is_closure
+                    is_virtual: previous_function.is_virtual
+                    is_override: previous_function.is_override
                 )
 
                 let new_function_id = .modules[module_id.id].add_function(checked_function: new_function)

--- a/tests/typechecker/polymorphism.jakt
+++ b/tests/typechecker/polymorphism.jakt
@@ -1,0 +1,23 @@
+/// Expect:
+/// - output: "greeting from the child\n"
+class Parent {
+    public virtual function greet(this) {
+        println("greeting from the parent")
+    }
+}
+
+class Child: Parent {
+    public override function greet(this) {
+        println("greeting from the child")
+    }
+}
+
+function use_parent(anon parent: Parent) {
+    parent.greet()
+}
+
+function main() {
+    let child = Child()
+
+    use_parent(child)
+}

--- a/tests/typechecker/polymorphism_override_needs_virtual.jakt
+++ b/tests/typechecker/polymorphism_override_needs_virtual.jakt
@@ -1,0 +1,24 @@
+/// Expect:
+/// - error: "Missing virtual for override\n"
+
+class Parent {
+    public function greet(this) {
+        println("greeting from the parent")
+    }
+}
+
+class Child: Parent {
+    public override function greet(this) {
+        println("greeting from the child")
+    }
+}
+
+function use_parent(anon parent: Parent) {
+    parent.greet()
+}
+
+function main() {
+    let child = Child()
+
+    use_parent(child)
+}


### PR DESCRIPTION
This adds two related features to our class support: class-based polymorphism and method overrides.

Method overrides require there to be a method in the parent class hierarchy that has a corresponding virtual method.

Example:
```
class Parent {
    public virtual function greet(this) {
        println("greeting from the parent")
    }
}

class Child: Parent {
    public override function greet(this) {
        println("greeting from the child")
    }
}

function use_parent(anon parent: Parent) {
    parent.greet()
}

function main() {
    let child = Child()

    use_parent(child)
}
```