### PR TITLE
typechecker+tests: Enforce override keyword on function that is virtual

### DIFF
--- a/selfhost/codegen.jakt
+++ b/selfhost/codegen.jakt
@@ -457,6 +457,13 @@ struct CodeGenerator {
             }
         }
 
+        mut super_struct_id = struct_.super_struct_id
+        while super_struct_id.has_value() {
+            let super_struct = .program.get_struct(super_struct_id!)
+            dependencies.push(super_struct.type_id.to_string())
+            super_struct_id = super_struct.super_struct_id
+        }
+
         dependencies.push(struct_.type_id.to_string())
         // The struct's fields are also dependencies.
         for field in struct_.fields.iterator() {

--- a/selfhost/typechecker.jakt
+++ b/selfhost/typechecker.jakt
@@ -1669,6 +1669,8 @@ struct Typechecker {
                 if not all_virtuals.contains(method.parsed_function.name) {
                     .error("Missing virtual for override", method.parsed_function.name_span)
                 }
+            } else if all_virtuals.contains(method.parsed_function.name) {
+                .error("Missing override keyword on function that is virtual", method.parsed_function.name_span)
             }
             .typecheck_method(func: method.parsed_function, parent_id: StructOrEnumId::Struct(struct_id))
         }

--- a/tests/typechecker/polymorphism_missing_override.jakt
+++ b/tests/typechecker/polymorphism_missing_override.jakt
@@ -1,0 +1,24 @@
+/// Expect:
+/// - error: "Missing override keyword on function that is virtual\n"
+
+class Parent {
+    public virtual function greet(this) {
+        println("greeting from the parent")
+    }
+}
+
+class Child: Parent {
+    public function greet(this) {
+        println("greeting from the child")
+    }
+}
+
+function use_parent(anon parent: Parent) {
+    parent.greet()
+}
+
+function main() {
+    let child = Child()
+
+    use_parent(child)
+}


### PR DESCRIPTION
C++ allows to omit the override keyword, however in Jakt we can do better
and actually enforce it :^)

Previously this would just compile, but resulted in unexpected behaviour where it was still calling the method on the child.

Also adds a commit that makes sure that the parent class is added to the codegen dependency graph, because C++ requires that.