### PR TITLE
typechecker: Don't infer return type for function blocks

### DIFF
--- a/samples/functions/fat_arrow.jakt
+++ b/samples/functions/fat_arrow.jakt
@@ -1,10 +1,12 @@
 /// Expect:
-/// - output: "Well, hello friends.\n5\n"
+/// - output: "Well, hello friends.\n5\nGoodbye friends.\n"
 
 function greet() => println("Well, hello friends.")
 function num() -> i64 => 5
+function str() => "Hello friends."
 
 function main() {
     greet()
     println("{}", num())
+    println("{}", str().replace(replace: "Hello", with: "Goodbye"))
 }

--- a/samples/generics/passing_arrays.jakt
+++ b/samples/generics/passing_arrays.jakt
@@ -1,7 +1,7 @@
 /// Expect:
 /// - output: "1\n"
 
-function dump<T>(anon v: [T]) { return v[0] }
+function dump<T>(anon v: [T]) => v[0]
 
 function main() {
     println("{}", dump([1, 2, 3]))

--- a/selfhost/parser.jakt
+++ b/selfhost/parser.jakt
@@ -208,6 +208,7 @@ struct ParsedFunction {
     linkage: FunctionLinkage
     must_instantiate: bool
     is_comptime: bool
+    is_fat_arrow: bool
 }
 
 struct ParsedParameter {
@@ -2149,6 +2150,7 @@ struct Parser {
             linkage,
             must_instantiate: false,
             is_comptime
+            is_fat_arrow: false
         )
 
         .index++
@@ -2195,6 +2197,7 @@ struct Parser {
 
         if .current() is FatArrow {
             parsed_function.block = .parse_fat_arrow()
+            parsed_function.is_fat_arrow = true
         } else {
             parsed_function.block = .parse_block()
         }

--- a/selfhost/typechecker.jakt
+++ b/selfhost/typechecker.jakt
@@ -1899,7 +1899,12 @@ struct Typechecker {
         }
 
         // Check return type
-        let function_return_type_id = .typecheck_typename(parsed_type: parsed_function.return_type, scope_id: checked_function_scope_id, name: None)
+        mut function_return_type_id = .typecheck_typename(parsed_type: parsed_function.return_type, scope_id: checked_function_scope_id, name: None)
+
+        if not parsed_function.is_fat_arrow and parsed_function.return_type is Empty {
+            function_return_type_id = void_type_id()
+        }
+
         checked_function.return_type_id = function_return_type_id
 
         .check_that_type_doesnt_contain_reference(type_id: function_return_type_id, span: parsed_function.return_type_span)
@@ -1915,19 +1920,7 @@ struct Typechecker {
             .ignore_errors = old_ignore_errors
 
             let return_type_id = match function_return_type_id.equals(unknown_type_id()) {
-                true => {
-                    let statement = block.statements.last()
-                    yield match statement.has_value() {
-                        true => match statement! {
-                            Return(val) => match val.has_value() {
-                                true => val!.type()
-                                else => void_type_id()
-                            }
-                            else => void_type_id()
-                        }
-                        else => unknown_type_id()
-                    }
-                }
+                true => .infer_function_return_type(block)
                 else => .resolve_type_var(type_var_type_id: function_return_type_id, scope_id: parent_scope_id)
             }
 
@@ -2073,6 +2066,11 @@ struct Typechecker {
             scope_id: function_scope_id
             name: None
         )
+
+        if not parsed_function.is_fat_arrow and parsed_function.return_type is Empty and parsed_function.name != "main" {
+            function_return_type_id = void_type_id()
+        }
+
         checked_function.return_type_id = function_return_type_id
 
         if function_return_type_id.equals(never_type_id()) {
@@ -2081,7 +2079,6 @@ struct Typechecker {
             scope.can_throw = true
         }
 
-        // TODO: Typecheck function block
         let block = .typecheck_block(
             parsed_function.block
             parent_scope_id: function_scope_id

--- a/tests/typechecker/generic_late_type_check.jakt
+++ b/tests/typechecker/generic_late_type_check.jakt
@@ -7,9 +7,7 @@ function foo<T>(anon x: T, anon y: T) -> T {
 }
 
 // Make sure type inference kinda works
-function bar<T>(anon x: T) {
-    return x + 1
-}
+function bar<T>(anon x: T) => x + 1
 
 // Make sure we can access struct members
 struct Test {


### PR DESCRIPTION
Not specifying a return type for a function block results in that block
returning void. We will still infer the return type for fat arrow
functions.