### PR TITLE
editors/vscode: Add syntax highlighting for "virtual", "override" and floating point numbers

### DIFF
--- a/editors/vscode/syntaxes/jakt.tmLanguage.json
+++ b/editors/vscode/syntaxes/jakt.tmLanguage.json
@@ -875,6 +875,24 @@
           }
         },
         {
+          "name": "constant.numeric.float.jakt",
+          "match": "\\b(?<!\\$|\\.)[0-9](?:[0-9]|_)*((?:[f](?:32|64)))\\b(?!\\$)",
+          "captures": {
+            "1": {
+              "name": "storage.type.numeric.jakt"
+            }
+          }
+        },
+        {
+          "name": "constant.numeric.float.jakt",
+          "match": "\\b(?<!\\$|\\.)[0-9](?:[0-9]|_)*(?:\\.)(?:[0-9]|_)*((?:[f](?:32|64)))?\\b(?!\\$)",
+          "captures": {
+            "1": {
+              "name": "storage.type.numeric.jakt"
+            }
+          }
+        },
+        {
           "name": "constant.numeric.jakt",
           "match": "\\b(?<!\\$)[0-9][0-9_]*(n|(?:[ui](?:8|16|32|64))|usize)?\\b(?!\\$)",
           "captures": {

--- a/editors/vscode/syntaxes/jakt.tmLanguage.json
+++ b/editors/vscode/syntaxes/jakt.tmLanguage.json
@@ -398,7 +398,7 @@
       "patterns": [
         {
           "name": "meta.function.declaration.jakt",
-          "match": "(?:\\b(public|private)\\s+)?(\\bextern\\s+)?(\\b(?:function|comptime))\\s+((?:\\w|_)(?:\\w|_|[0-9])*)",
+          "match": "(?:\\b(public|private)\\s+)?(\\bextern\\s+)?(?:(\\boverride\\b)\\s+|(\\bvirtual\\b)\\s+)?(\\b(?:function|comptime))\\s+((?:\\w|_)(?:\\w|_|[0-9])*)",
           "captures": {
             "1": {
               "name": "storage.modifier.visibility.jakt"
@@ -407,13 +407,16 @@
               "name": "storage.modifier.linkage.jakt"
             },
             "3": {
-              "name": "keyword.function.jakt"
+              "name": "storage.modifier.specifier.override.jakt"
             },
             "4": {
-              "name": "entity.name.function"
+              "name": "storage.modifier.specifier.virtual.jakt"
             },
             "5": {
-              "name": "punctuation.begin.bracket"
+              "name": "keyword.function.jakt"
+            },
+            "6": {
+              "name": "entity.name.function"
             }
           }
         },


### PR DESCRIPTION
Before:
![obraz](https://user-images.githubusercontent.com/36564831/187895939-e8049a5a-6de2-41d1-81fb-a375dabe0fc1.png)
After:
![obraz](https://user-images.githubusercontent.com/36564831/187898219-8e72efbd-9af9-4645-b20f-ae4263492a44.png)

Before:
![obraz](https://user-images.githubusercontent.com/36564831/187895985-f7c347e9-daa4-4098-8159-a0fc219a23dd.png)
After:
![obraz](https://user-images.githubusercontent.com/36564831/187896005-6e3a7df4-532c-443d-8305-2a45d2af43de.png)

Technical details:
One "constant.numeric.float.jakt" is for numbers that do not have a `.` inside them, but have explicitly specified the type to be `f32` or `f64`. The other "constant.numeric.float.jakt" is for numbers that have a `.` inside them (and may or may not specified the type).