### PR TITLE
typechecker: Emit Jakt error instead of C++ one, when trying to yield out of functions

### DIFF
--- a/selfhost/parser.jakt
+++ b/selfhost/parser.jakt
@@ -260,6 +260,15 @@ struct ParsedBlock {
         return None
     }
 
+    function find_yield_keyword_span(this) -> Span? {
+        for stmt in .stmts.iterator() {
+            if stmt is Yield(expr) {
+                return stmt.span()
+            }
+        }
+        return None
+    }
+
     function span(this, parser: Parser) throws -> Span? {
         mut start: usize? = None
         mut end: usize = 0

--- a/selfhost/typechecker.jakt
+++ b/selfhost/typechecker.jakt
@@ -2095,6 +2095,11 @@ struct Typechecker {
             safety_mode: SafetyMode::Safe
         )
 
+        if block.yielded_type.has_value() {
+            .error_with_hint("Functions are not allowed to yield values", parsed_function.block.find_yield_span()!,
+                            "You might want to return instead", parsed_function.block.find_yield_keyword_span()!)
+        }
+
         // Typecheck return type a second time to resolve generics
         function_return_type_id = .typecheck_typename(
             parsed_type: parsed_function.return_type

--- a/tests/typechecker/block_yield_function.jakt
+++ b/tests/typechecker/block_yield_function.jakt
@@ -1,0 +1,6 @@
+/// Expect:
+/// - error: "Functions are not allowed to yield values"
+
+function main() {
+    yield 1
+}


### PR DESCRIPTION
This follows the behavior of yielding out of defers, if blocks, statement blocks, etc. Resolves #461.