### PR TITLE
parser: Continue parsing typename after invalid cast syntax

### DIFF
--- a/selfhost/parser.jakt
+++ b/selfhost/parser.jakt
@@ -3349,8 +3349,8 @@ struct Parser {
                             yield TypeCast::Fallible(.parse_typename())
                         }
                         else => {
-                            .error("Invalid cast syntax", cast_span)
-                            yield TypeCast::Fallible(ParsedType::Empty)
+                            .error_with_hint("Invalid cast syntax", cast_span, "Use `as!` for an infallible cast, or `as?` for a fallible cast", .previous().span())
+                            yield TypeCast::Fallible(.parse_typename())
                         }
                     }
                     let span = merge_spans(start, merge_spans(cast_span, .current().span()))

--- a/tests/parser/invalid_cast_syntax.jakt
+++ b/tests/parser/invalid_cast_syntax.jakt
@@ -1,0 +1,9 @@
+/// Expect:
+/// - error: "Invalid cast syntax"
+
+function main() {
+    let arr = [0]
+    for i in 1..(arr.size() as u8) { 
+        println("hello world")
+    }
+}


### PR DESCRIPTION
Previously, we would assume an empty type after `as`, which led to us
rejecting everything after the as. Now, we error with a hint about the
incorrect syntax, and continue parsing a typename.

fixes #385 
<img width="854" alt="image" src="https://user-images.githubusercontent.com/3748720/187954236-921c1b23-7713-4960-a0ad-8c547fb48693.png">
