### PR TITLE
Don't infer return type in function/method blocks

### DIFF
--- a/jakttest/jakttest.jakt
+++ b/jakttest/jakttest.jakt
@@ -81,7 +81,7 @@ function has_jakt_extension(name: String) throws -> bool {
 
 // Traverse directory in a DFS manner ta find files with the .jakt extension
 // and store results into the given array
-function get_jakt_files_under(directory: String, results: &mut [String]) throws -> [String] {
+function get_jakt_files_under(directory: String, results: &mut [String]) throws {
     mut path_stack: [String] = [directory]
 
     while not path_stack.is_empty() {
@@ -101,8 +101,6 @@ function get_jakt_files_under(directory: String, results: &mut [String]) throws 
             }
         }
     }
-
-    return results
 }
 
 import extern "process.h" {

--- a/samples/compiletime_execution/bitwise.jakt
+++ b/samples/compiletime_execution/bitwise.jakt
@@ -1,9 +1,7 @@
 /// Expect:
 /// - output: "PASS\n"
 
-comptime bitwise() {
-    return ((0x123 ^ 0x456) << 12) | (0x789 & 0xabc)
-}
+comptime bitwise() => ((0x123 ^ 0x456) << 12) | (0x789 & 0xabc)
 
 function main() {
     if bitwise() == 0x575288 {

--- a/samples/enums/methods.jakt
+++ b/samples/enums/methods.jakt
@@ -16,7 +16,7 @@ enum Foo {
         }
     }
 
-    function name(this) throws {
+    function name(this) throws -> String? {
         return this.name_impl()
     }
 }

--- a/samples/optional/mutable_unwrap.jakt
+++ b/samples/optional/mutable_unwrap.jakt
@@ -8,7 +8,7 @@ class Foo {
         this.x = value
     }
 
-    public function get(this) {
+    public function get(this) -> i64 {
         return this.x
     }
 }

--- a/selfhost/parser.jakt
+++ b/selfhost/parser.jakt
@@ -84,7 +84,7 @@ struct ParsedExternImport {
 
     function get_name(this) -> String => .assigned_namespace.name!
 
-    function is_equivalent_to(this, anon other: ParsedExternImport) throws {
+    function is_equivalent_to(this, anon other: ParsedExternImport) throws -> bool {
         return .is_c and other.is_c and .get_path() == other.get_path() and .get_name() == other.get_name()
     }
 }

--- a/selfhost/typechecker.jakt
+++ b/selfhost/typechecker.jakt
@@ -1729,18 +1729,31 @@ struct Typechecker {
         .current_function_id = method_id
 
         let VOID_TYPE_ID = builtin(BuiltinType::Void)
+        mut function_return_type_id = .typecheck_typename(
+            parsed_type: func.return_type,
+            scope_id: function_scope_id,
+            name: None
+        )
 
-        let block = .typecheck_block(parsed_block: func.block, parent_scope_id: function_scope_id, safety_mode: SafetyMode::Safe)
-        let function_return_type_id = .typecheck_typename(parsed_type: func.return_type, scope_id: function_scope_id, name: None)
+        if not func.is_fat_arrow and func.return_type is Empty {
+             function_return_type_id = VOID_TYPE_ID
+        }
+
+        checked_function.return_type_id = function_return_type_id
+
+        let block = .typecheck_block(
+            parsed_block: func.block,
+            parent_scope_id: function_scope_id,
+            safety_mode: SafetyMode::Safe
+        )
 
         mut return_type_id = function_return_type_id
         if function_return_type_id.equals(unknown_type_id()) and not block.statements.is_empty() {
-            // If the return type is unknown, and the function starts with a return statement,
+            // If the return type is unknown and function is a fat arrow function,
             // we infer the return type from its expression.
-            if block.statements[0] is Return(val) and val.has_value() {
-                return_type_id = val!.type()
-            } else {
-                return_type_id = VOID_TYPE_ID
+            // The only statement in fat arrow function block.statements is a Return statement.
+            if func.is_fat_arrow {
+                return_type_id = .infer_function_return_type(block)
             }
         } else if function_return_type_id.equals(unknown_type_id()) {
             return_type_id = VOID_TYPE_ID
@@ -1929,9 +1942,16 @@ struct Typechecker {
             )
             .ignore_errors = old_ignore_errors
 
-            let return_type_id = match function_return_type_id.equals(unknown_type_id()) {
-                true => .infer_function_return_type(block)
-                else => .resolve_type_var(type_var_type_id: function_return_type_id, scope_id: parent_scope_id)
+            mut return_type_id = function_return_type_id
+            if function_return_type_id.equals(unknown_type_id()) {
+                // If the return type is unknown and function is a fat arrow function,
+                // we infer the return type from its expression.
+                // The only statement in fat arrow function block.statements is a Return statement.
+                if parsed_function.is_fat_arrow {
+                    return_type_id = .infer_function_return_type(block)
+                }
+            } else {
+                return_type_id = .resolve_type_var(type_var_type_id: function_return_type_id, scope_id: parent_scope_id)
             }
 
             checked_function.block = block
@@ -2107,14 +2127,15 @@ struct Typechecker {
             name: None
         )
 
-        // Infer return type if necessary
-        // If the return type is unknown, and the function starts with a return statement,
-        // we infer the return type from its expression.
-        let UNKNOWN_TYPE_ID = unknown_type_id()
         let VOID_TYPE_ID = void_type_id()
         mut return_type_id = VOID_TYPE_ID
-        if function_return_type_id.equals(UNKNOWN_TYPE_ID) {
-            return_type_id = .infer_function_return_type(block)
+        if function_return_type_id.equals(unknown_type_id()) {
+            // If the return type is unknown and function is a fat arrow function,
+            // we infer the return type from its expression.
+            // The only statement in fat arrow function block.statements is a Return statement.
+            if parsed_function.is_fat_arrow {
+                return_type_id = .infer_function_return_type(block)
+            }
         } else {
             return_type_id = .resolve_type_var(
                 type_var_type_id: function_return_type_id,
@@ -3759,7 +3780,30 @@ struct Typechecker {
         if .inside_defer {
             .error("‘return’ is not allowed inside ‘defer’", span)
         }
+
+        mut type_hint: TypeId? = None
+        if .current_function_id.has_value() {
+            type_hint = Some(.get_function(.current_function_id!).return_type_id)
+        }
+
         if not expr.has_value() {
+            // Return expression is empty, so we try to return void
+
+            if type_hint.has_value() and not type_hint!.equals(void_type_id()){
+                // We didn't expect to return void
+                .error(
+                    format("Type mismatch: expected ‘{}’, but got ‘{}’",
+                    .type_name(type_hint!),
+                    .type_name(void_type_id())
+                    ),
+                span)
+            }
+
+            if (.current_function_id.has_value() and .get_function(.current_function_id!).name == "main") {
+                // We can't return void in the `main` function
+                .error("Main function must return c_int", span)
+            }
+
             return CheckedStatement::Return(val: None, span)
         }
 
@@ -3767,12 +3811,28 @@ struct Typechecker {
             .error("Returning a function is not currently supported", span)
         }
 
-        mut type_hint: TypeId? = None
-        if .current_function_id.has_value() {
-            type_hint = Some(.get_function(.current_function_id!).return_type_id)
+        let checked_expr = .typecheck_expression(expr!, scope_id, safety_mode, type_hint)
+
+        if .current_function_id.has_value() and .get_function(.current_function_id!).name == "main" {
+            // Even without a type_hint, "main" function has a c_int return type, we can only return an integer
+            if not .is_integer(checked_expr.type()) {
+                .error("Main function must return c_int", checked_expr.span())
+            }
         }
 
-        let checked_expr = .typecheck_expression(expr!, scope_id, safety_mode, type_hint)
+        if not type_hint.has_value()
+        or .get_type(checked_expr.type()) is TypeVariable {
+            return CheckedStatement::Return(val: checked_expr, span)
+        }
+
+
+        // Check if what we are returning is compatible with what we expected to return
+        .check_types_for_compat(
+            lhs_type_id: type_hint!,
+            rhs_type_id: checked_expr.type(),
+            generic_inferences: &mut .generic_inferences,
+            span)
+
         return CheckedStatement::Return(val: checked_expr, span)
     }
 

--- a/tests/typechecker/auto_deref.jakt
+++ b/tests/typechecker/auto_deref.jakt
@@ -47,8 +47,8 @@ function deref_match(anon foo: &i32) -> i32 {
 }
 
 struct Foo {
-    function const_method(this) => 69
-    function mutable_method(mut this) => 69 + 1
+    function const_method(this) => 69i32
+    function mutable_method(mut this) => 69i32 + 1i32
 }
 
 function deref_access(anon foo: &mut Foo) -> i32 {

--- a/tests/typechecker/function_block_wrong_return_type.jakt
+++ b/tests/typechecker/function_block_wrong_return_type.jakt
@@ -1,0 +1,11 @@
+/// Expect:
+/// - error: "Type mismatch: expected ‘void’, but got ‘String’"
+
+function foo() {
+    let y: String = "5123"
+    return y
+}
+
+function main() {
+    let x = foo()
+}

--- a/tests/typechecker/function_block_wrong_return_type2.jakt
+++ b/tests/typechecker/function_block_wrong_return_type2.jakt
@@ -1,0 +1,10 @@
+/// Expect:
+/// - error: "Type mismatch: expected ‘void’, but got ‘String’"
+
+function foo() {
+    return "5123"
+}
+
+function main() {
+    let x = foo()
+}

--- a/tests/typechecker/function_block_wrong_return_type_void.jakt
+++ b/tests/typechecker/function_block_wrong_return_type_void.jakt
@@ -1,0 +1,14 @@
+/// Expect:
+/// - error: "Type mismatch: expected ‘i64’, but got ‘void’"
+
+function foo(anon x: i64) -> i64 {
+    if x == 6 {
+        return 4
+    } else {
+        return
+    }
+}
+
+function main() {
+    let x = foo(7)
+}

--- a/tests/typechecker/generic_function_block_wrong_return_type.jakt
+++ b/tests/typechecker/generic_function_block_wrong_return_type.jakt
@@ -1,0 +1,11 @@
+/// Expect:
+/// - error: "Type mismatch: expected ‘i32’, but got ‘String’"
+
+function foo<T>() -> T {
+    let y: String = "5123"
+    return y
+}
+
+function main() {
+    let x = foo<i32>()
+}

--- a/tests/typechecker/generic_function_block_wrong_return_type2.jakt
+++ b/tests/typechecker/generic_function_block_wrong_return_type2.jakt
@@ -1,10 +1,10 @@
 /// Expect:
-/// - output: "4\n"
+/// - error: "Type mismatch: expected ‘i64?’, but got ‘usize’"
 
 function find<T>(anon arr: [T], anon cb: function(a: T) -> bool) -> T? {
     for i in 0..arr.size() {
         if cb(a: arr[i]) {
-            return i as! i64
+            return i
         }
     }
     return None

--- a/tests/typechecker/main_function_wrong_return_type.jakt
+++ b/tests/typechecker/main_function_wrong_return_type.jakt
@@ -1,0 +1,11 @@
+/// Expect:
+/// - error: "Main function must return c_int"
+
+enum Foo {
+    A
+}
+
+function main() {
+    let x = Foo::A()
+    return x
+}

--- a/tests/typechecker/main_function_wrong_return_type_void.jakt
+++ b/tests/typechecker/main_function_wrong_return_type_void.jakt
@@ -1,0 +1,6 @@
+/// Expect:
+/// - error: "Main function must return c_int"
+
+function main() {
+    return
+}

--- a/tests/typechecker/method_wrong_return_type.jakt
+++ b/tests/typechecker/method_wrong_return_type.jakt
@@ -1,0 +1,13 @@
+/// Expect:
+/// - error: "Type mismatch: expected ‘void’, but got ‘C’"
+
+class C {
+    public function give_c() {
+        let foo = true
+        return C()
+    }
+}
+
+function main() {
+    println("{}", C::give_c())
+}

--- a/tests/typechecker/method_wrong_return_type_void.jakt
+++ b/tests/typechecker/method_wrong_return_type_void.jakt
@@ -1,0 +1,13 @@
+/// Expect:
+/// - error: "Type mismatch: expected ‘i32’, but got ‘void’"
+
+class C {
+    public function give_c() -> i32 {
+        let foo = true
+        return
+    }
+}
+
+function main() {
+    println("{}", C::give_c())
+}


### PR DESCRIPTION
A spiritual ancestor of #748 and #215. Fixes #151 in case incompatible return types are actually reachable (which seemed to be the issue, given the title). #1133 follow-up.

Resolves #1092 and resolves #1093 because we no longer infer the return type for function blocks. Fixes #483.

Not sure about the generic stuff, please check :^)

I don't know how to put a commit description without commit linter complaining, so I'll just paste it here:
> This refers to functions as well as methods that are not fat-arrow.
> Parser and a couple of tests needed to be updated in some cases, to specify the return type.
> When the return type is not specified for not-fat-arrow functions, it is set to void.