### PR TITLE
editors/vscode: Document the correct build directory path for cmake

### DIFF
--- a/editors/vscode/README.md
+++ b/editors/vscode/README.md
@@ -18,7 +18,7 @@ export JAKT_INSTALL=$PWD/install
 
 In the root jakt directory:
 ```
-> cmake -GNinja -DCMAKE_CXX_COMPILER=clang++-14 -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=$JAKT_INSTALL
+> cmake --build build -GNinja -DCMAKE_CXX_COMPILER=clang++-14 -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=$JAKT_INSTALL
 > cmake --build build -- install
 ```
 


### PR DESCRIPTION
Previously the documentation would have cmake write build files into the project root.