### PR TITLE
editors/vscode: Convert file URLs to paths with "fileURLToPath()"

### DIFF
--- a/editors/vscode/server/src/server.ts
+++ b/editors/vscode/server/src/server.ts
@@ -50,6 +50,7 @@ import path = require("path");
 
 import util = require("node:util");
 import { TextEncoder } from "node:util";
+import { fileURLToPath } from "node:url";
 
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 const exec = util.promisify(require("node:child_process").exec);
@@ -57,10 +58,10 @@ const exec = util.promisify(require("node:child_process").exec);
 const tmpFile = tmp.fileSync();
 
 function includeFlagForPath(file_path: string): string {
-    const protocol_end = file_path.indexOf("://");
-    if (protocol_end == -1) return " -I " + file_path;
-    // Not protocol.length + 3, include the last '/'
-    return " -I " + path.dirname(file_path.slice(protocol_end + 2));
+    if (file_path.startsWith("file://")) {
+        return " -I " + path.dirname(fileURLToPath(file_path));   
+    }
+    return " -I " + file_path;
 }
 
 connection.onInitialize((params: InitializeParams) => {


### PR DESCRIPTION
This ensures that include paths are properly resolved on all platforms. The previous technique did not work on Windows.