### PR TITLE
String Interpolation

### DIFF
--- a/editors/vscode/syntaxes/jakt.tmLanguage.json
+++ b/editors/vscode/syntaxes/jakt.tmLanguage.json
@@ -937,6 +937,9 @@
             {
               "name": "constant.character.escape.jakt",
               "match": "\\\\."
+            },
+            {
+              "include": "#interpolation"
             }
           ]
         },
@@ -960,6 +963,41 @@
               "match": "\\\\."
             }
           ]
+        }
+      ]
+    },
+    "interpolation": {
+      "patterns": [
+        {
+          "name": "meta.block.interpolated.jakt",
+          "begin": "(\\$\\{)",
+          "beginCaptures": {
+            "1": {
+              "name": "punctuation.start.interpolation.jakt"
+            }
+          },
+          "end": "(\\})",
+          "endCaptures": {
+            "1": {
+              "name": "punctuation.end.interpolation.jakt"
+            }
+          },
+          "patterns": [
+            {
+              "include": "#expressions"
+            },
+            {
+              "include": "#formatspecifier"
+            }
+          ]
+        }
+      ]
+    },
+    "formatspecifier": {
+      "patterns": [
+        {
+          "match": "\\:[^\\}]+",
+          "name": "constant.character.format.jakt"
         }
       ]
     }

--- a/selfhost/codegen.jakt
+++ b/selfhost/codegen.jakt
@@ -1276,6 +1276,15 @@ struct CodeGenerator {
             let escaped_value = val.replace(replace: "\n", with: "\\n")
             yield "String(\"" + escaped_value + "\")"
         }
+        InterpolatedString(format_string, interpolated_expressions, span) => {
+            mut parameter_list = ""
+            for expression in interpolated_expressions.iterator() {
+                parameter_list += ","
+                parameter_list += .codegen_expression(expression)
+            }
+            let escaped_value = format_string.replace(replace: "\n", with: "\\n")
+            yield "TRY(String::formatted(\"" + escaped_value + "\"" + parameter_list + "))"
+        }
         ByteConstant(val) => "'" + val + "'"
         CharacterConstant(val) => "'" + val + "'"
         Var(var) => match var.name {

--- a/selfhost/interpreter.jakt
+++ b/selfhost/interpreter.jakt
@@ -4411,6 +4411,21 @@ class Interpreter {
             F64(x) => Value(impl: ValueImpl::F64(x), span: span)
         })
         QuotedString(val, span) => StatementResult::JustValue(Value(impl: ValueImpl::JaktString(interpret_escapes(val)), span: span))
+        InterpolatedString(format_string, interpolated_expressions, span) => {
+            mut format_args: [Value] = [Value(impl: ValueImpl::JaktString(format_string), span:span)]
+            for format_expression in interpolated_expressions.iterator() {
+                let expression_result = .execute_expression_without_cast(format_expression, scope)
+                guard expression_result is JustValue(value) else {
+                    .error(
+                        format("Unexpected expression result in string interpolation. Got: {}", expression_result),
+                        span: format_expression.span()
+                    )
+                    throw Error::from_errno(InterpretError::InvalidType as! i32);
+                }
+                format_args.push(value)
+            }
+            return .call_prelude_function("format", [], this_argument: None, arguments: format_args, call_span: span, type_bindings: [:])
+        }
         CharacterConstant(val, span) => StatementResult::JustValue(Value(impl: ValueImpl::CChar(val.byte_at(0) as! c_char), span: span))
         JaktArray(vals, repeat, span, type_id) => match repeat.has_value() {
             true => {

--- a/selfhost/lexer.jakt
+++ b/selfhost/lexer.jakt
@@ -23,6 +23,7 @@ enum Token {
     Identifier(name: String, span: Span)
     Semicolon(Span)
     Colon(Span)
+    DoubleQuote(span: Span)
     ColonColon(Span)
     LParen(Span)
     RParen(Span)
@@ -61,6 +62,7 @@ enum Token {
     Caret(Span)
     CaretEqual(Span)
     Dollar(Span)
+    DollarLCurly(span: Span)
     Tilde(Span)
     ForwardSlash(Span)
     ExclamationPoint(Span)
@@ -132,6 +134,7 @@ enum Token {
         QuotedString(quote, span) => span
         Number(number, span) => span
         Identifier(name, span) => span
+        DoubleQuote(span) => span
         Semicolon(span) => span
         Colon(span) => span
         ColonColon(span) => span
@@ -174,6 +177,7 @@ enum Token {
         Caret(span) => span
         CaretEqual(span) => span
         Dollar(span) => span
+        DollarLCurly(span) => span
         Tilde(span) => span
         ForwardSlash(span) => span
         ExclamationPoint(span) => span
@@ -374,8 +378,12 @@ struct Lexer {
     input: [u8]
     compiler: Compiler
 
+    string_nesting_level: u64
+    interpolation_nesting_level: u64
+    did_just_end_interpolated_block: bool
+
     function lex(compiler: Compiler) throws -> [Token] {
-        mut lexer = Lexer(index: 0, input: compiler.current_file_contents, compiler)
+        mut lexer = Lexer(index: 0, input: compiler.current_file_contents, compiler, string_nesting_level: 0, interpolation_nesting_level: 0, did_just_end_interpolated_block: false)
         mut tokens: [Token] = []
 
         for token in lexer {
@@ -427,6 +435,10 @@ struct Lexer {
             builder.append(.input[i])
         }
         return builder.to_string()
+    }
+
+    function unescaped_interpolation_start_next(this) -> bool {
+        return .peek() == b'$' and .peek_ahead(steps:1) == b'{' and .peek_ahead(steps:2) != b'{'
     }
 
     function lex_character_constant_or_name(mut this) throws -> Token {
@@ -787,11 +799,13 @@ struct Lexer {
         return suffix
     }
 
+    function lex_quoted_string(mut this, delimiter: u8, consume_first_token:bool, consume_final_quote: bool) throws -> Token {
 
-    function lex_quoted_string(mut this, delimiter: u8) throws -> Token {
+        let span_start = .index
+        if consume_first_token {
+            ++.index
+        }
         let start = .index
-
-        ++.index
 
         if .eof() {
             .error("unexpected eof", .span(start, end: start))
@@ -799,8 +813,9 @@ struct Lexer {
         }
 
         mut escaped = false
+        mut at_start_of_interpolated_block = delimiter == b'\"' and .unescaped_interpolation_start_next()
 
-        while not .eof() and (escaped or .peek() != delimiter) {
+        while not .eof() and (escaped or ((.peek() != delimiter) and (not at_start_of_interpolated_block))) {
             // Ignore a standalone carriage return
             if .peek() == b'\r' or .peek() == b'\n' {
                 ++.index
@@ -808,23 +823,34 @@ struct Lexer {
             }
 
             if not escaped and .peek() == b'\\' {
+                if .peek_ahead(steps: 1) == b'$' {
+                    ++.index
+                }
                 escaped = true
             } else {
                 escaped = false
             }
             ++.index
+            at_start_of_interpolated_block = delimiter == b'\"' and .unescaped_interpolation_start_next()
         }
 
-        let str = .substring(start: start + 1, length: .index)
+        if .eof() {
+            .error("unexpected eof", .span(start: .index, end: .index))
+            return Token::Garbage(.span(start: .index, end: .index))
+        }
 
-        .index++
-        let end = .index
+        let str = .substring(start: start, length: .index)
+
+        if consume_final_quote {
+            ++.index
+        }
+        let span_end = .index
 
         if delimiter == b'\'' {
-            return Token::SingleQuotedString(quote: str, span: .span(start, end))
+            return Token::SingleQuotedString(quote: str, span: .span(start: span_start, end: span_end))
         }
 
-        return Token::QuotedString(quote: str, span: .span(start, end))
+        return Token::QuotedString(quote: str, span: .span(start: span_start, end: span_end))
     }
 
     function lex_plus(mut this) -> Token {
@@ -984,7 +1010,49 @@ struct Lexer {
         }
     }
 
+
+    function lex_dollar(mut this) throws -> Token {
+        if .peek_ahead(steps: 1) == b'{' and .string_nesting_level > 0 {
+            .index += 2
+            ++.interpolation_nesting_level
+            return Token::DollarLCurly(span: .span(start: .index-2, end: .index))
+        }
+        return Token::Dollar(.span(start: .index, end: ++.index))
+    }
+
+    function lex_rcurly(mut this) -> Token {
+        let start = .index
+        if .interpolation_nesting_level > 0 {
+            --.interpolation_nesting_level
+            .did_just_end_interpolated_block = true
+        }
+        return Token::RCurly(.span(start, end: ++.index))
+    }
+
+    function lex_doublequote(mut this)throws -> Token {
+        let start = .index
+        if .string_nesting_level == .interpolation_nesting_level {
+            ++.string_nesting_level
+            return .lex_quoted_string(delimiter: b'\"', consume_first_token: true, consume_final_quote: false)
+        }
+
+        if .string_nesting_level == (.interpolation_nesting_level + 1) {
+            --.string_nesting_level
+            return Token::DoubleQuote(span: .span(start, end: ++.index))
+        }
+
+        let span = .span(start, end: ++.index)
+        .error("unmatched '}' in interpolated string", span)
+        return Token::Garbage(span)
+    }
+
     function next(mut this) throws -> Token? {
+
+        if .did_just_end_interpolated_block {
+            .did_just_end_interpolated_block = false
+            return .lex_quoted_string(delimiter: b'\"', consume_first_token: false, consume_final_quote: false)
+        }
+
         // Consume whitespace until a character is encountered or Eof is
         // reached. For Eof return a token.
         loop {
@@ -1015,7 +1083,7 @@ struct Lexer {
             b'[' => Token::LSquare(.span(start, end: ++.index))
             b']' => Token::RSquare(.span(start, end: ++.index))
             b'{' => Token::LCurly(.span(start, end: ++.index))
-            b'}' => Token::RCurly(.span(start, end: ++.index))
+            b'}' => .lex_rcurly()
             b'<' => .lex_less_than()
             b'>' => .lex_greater_than()
             b'.' => .lex_dot()
@@ -1033,11 +1101,11 @@ struct Lexer {
             b'%' => .lex_percent_sign()
             b'!' => .lex_exclamation_point()
             b'&' => .lex_ampersand()
-            b'$' => Token::Dollar(.span(start, end: ++.index))
+            b'$' => .lex_dollar()
             b'=' => .lex_equals()
             b'\n' => Token::Eol(.span(start, end: ++.index))
-            b'\'' => .lex_quoted_string(delimiter: b'\'')
-            b'\"' => .lex_quoted_string(delimiter: b'"')
+            b'\'' => .lex_quoted_string(delimiter: b'\'', consume_first_token: true, consume_final_quote: true)
+            b'\"' => .lex_doublequote()
             b'b' => .lex_character_constant_or_name()
             b'c' => .lex_character_constant_or_name()
             else => .lex_number_or_name()

--- a/selfhost/parser.jakt
+++ b/selfhost/parser.jakt
@@ -26,6 +26,10 @@ function merge_spans(anon start: Span, anon end: Span) throws -> Span {
     return Span(file_id: start.file_id, start: start.start, end: end.end)
 }
 
+function escape_curly_braces_for_format_string(anon string: String) throws -> String {
+    return string.replace(replace: "{", with: "{{").replace(replace: "}" with: "}}")
+}
+
 enum DefinitionLinkage {
     Internal
     External
@@ -711,7 +715,9 @@ enum ParsedCapture {
 boxed enum ParsedExpression {
     Boolean(val: bool, span: Span)
     NumericConstant(val: NumericConstant, span: Span)
+    FormatExpression(expr: ParsedExpression, format_specifier: String, span:Span)
     QuotedString(val: String, span: Span)
+    InterpolatedString(format_string: String, interpolated_expressions: [ParsedExpression], span: Span)
     SingleQuotedString(val: String, span: Span)
     SingleQuotedByteString(val: String, span: Span)
     Call(call: ParsedCall, span: Span)
@@ -742,7 +748,9 @@ boxed enum ParsedExpression {
     function span(this) => match this {
         Boolean(val, span) => span
         NumericConstant(val, span) => span
+        FormatExpression(span) => span
         QuotedString(val, span) => span
+        InterpolatedString(format_string, interpolated_expressions, span) => span
         SingleQuotedString(val, span) => span
         SingleQuotedByteString(val, span) => span
         Call(call, span) => span
@@ -827,8 +835,23 @@ boxed enum ParsedExpression {
             NumericConstant(val: rhs_val) => lhs_val.to_usize() == rhs_val.to_usize()
             else => false
         }
+        FormatExpression(expr: lhs_expr, format_specifier: lhs_fmt_specifier) => match rhs_expression {
+            FormatExpression(expr: rhs_expr, format_specifier: rhs_fmt_specifier) => lhs_expr.equals(rhs_expr) && lhs_fmt_specifier == rhs_fmt_specifier
+            else => false
+        }
         QuotedString(val: lhs_val) => match rhs_expression {
             QuotedString(val: rhs_val) => lhs_val == rhs_val
+            else => false
+        }
+        InterpolatedString(format_string: lhs_val, interpolated_expressions: lhs_exprs) => match rhs_expression {
+            InterpolatedString(format_string: rhs_val, interpolated_expressions: rhs_exprs ) => {
+                if not (lhs_val == rhs_val) { return false }
+                if not (lhs_exprs.size() == rhs_exprs.size()) { return false }
+                for expr_index in 0..lhs_exprs.size() {
+                    if not lhs_exprs[expr_index].equals(rhs_exprs[expr_index]) { return false }
+                }
+                return true
+            }
             else => false
         }
         SingleQuotedString(val: lhs_val) => match rhs_expression {
@@ -1380,7 +1403,7 @@ struct Parser {
 
         let import_path = match .current() {
             QuotedString(quote) => {
-                .index++
+                .index+=2
                 yield quote
             }
             else => {
@@ -2936,6 +2959,132 @@ struct Parser {
         return expr_stack[0]
     }
 
+    function parse_quoted_string(mut this) throws -> ParsedExpression {
+        let start_span = .current().span()
+        mut string_nesting_level:u64 = 0
+        mut interpolation_nesting_level:u64 = 0
+
+        mut string_contents = StringBuilder::create()
+        mut interpolated_expressions: [ParsedExpression] = []
+        mut just_exited_iterpolated_block = false
+        mut is_interpolated_string = false
+
+        while(not .eof()){
+            match .current() {
+                DoubleQuote(span) => {
+                    ++.index
+                    if string_nesting_level == 1 and interpolation_nesting_level == 0 {
+                        break
+                    } else if string_nesting_level <= 1 {
+                        .error(format("Unexpected token {}", .previous()), .previous().span())
+                        return ParsedExpression::Garbage(.previous().span())
+                    } else {
+                        --string_nesting_level
+                    }
+                }
+                QuotedString(quote, span) => {
+                    ++string_nesting_level
+                    ++.index
+                    mut escaped = quote
+                    if is_interpolated_string {
+                        escaped = escape_curly_braces_for_format_string(quote)
+                    }
+                    string_contents.append_string(escaped)
+                }
+                DollarLCurly => {
+                    if not is_interpolated_string {
+                        is_interpolated_string = true
+                        // this is the first interpolated block, so we need to retroactively
+                        // escape all braces we encountered so far
+                         mut format_string_so_far = escape_curly_braces_for_format_string(string_contents.to_string())
+                        string_contents.clear()
+                        string_contents.append_string(format_string_so_far)
+                    }
+
+                    let start_index = .index
+                    ++.index
+                    ++interpolation_nesting_level
+                    if .peek(steps: 0) is RCurly {
+                        .error("Empty expression in interpolated block", .current().span())
+                        return ParsedExpression::Garbage(.current().span())
+                    }
+                    let expression = .parse_expression(allow_assignments: false, allow_newlines: false)
+
+                    mut format_specifier = ""
+                    if .current() is Colon {
+                        format_specifier += ":"
+                        ++.index
+                        format_specifier += .parse_format_specifier()
+                    }
+                    string_contents.append(b'{')
+                    string_contents.append_string(format_specifier)
+                    string_contents.append(b'}')
+
+                    let span = .span(start: start_index, end: .current().span().end)
+                    let format_expression = ParsedExpression::FormatExpression(expr: expression, format_specifier: format_specifier, span)
+                    interpolated_expressions.push(format_expression)
+                }
+                RCurly => {
+                    ++.index
+                    --interpolation_nesting_level
+                    --string_nesting_level
+                    just_exited_iterpolated_block = true
+                }
+                else => {
+
+                    .error(format("Unexpected token {}", .current()), .current().span())
+                    return ParsedExpression::Garbage(.current().span())
+                }
+            }
+        }
+
+        let string = string_contents.to_string()
+        if not is_interpolated_string {
+            return ParsedExpression::QuotedString(val: string, span: .previous().span())
+        }
+
+        let span = merge_spans(start: start_span, end: .previous().span())
+        return ParsedExpression::InterpolatedString(format_string: string, interpolated_expressions, span)
+    }
+
+    function parse_format_specifier(mut this) throws -> String{
+        // A format specifier is everything that follows an interpolated
+        // expression to allow for simple format specifiers to be declared
+        // directly, we just take the verbatim spans of any tokens until the
+        // closing RCurly, however the lexer chokes on some expressions (e.g.
+        // ".2f") so we also allow to specify the  format in a QuotedString to
+        // be able to represent arbitrary specifiers.
+        // FIXME: Ideally we could either lex the format specifier as a seperate
+        // token which is imposible for now since we don't know when the
+        // expression ended while lexing or we would not throw errors in the
+        // lexer and just let it yield Garbage tokens we could actually use here
+        mut token_string = StringBuilder::create()
+        while not .current() is RCurly {
+            match .current() {
+                RCurly => { break }
+                QuotedString(quote) => {
+                    token_string.append_string(quote)
+                    if not .peek(steps: 1) is DoubleQuote {
+                        .error("Unexpected Token. Expected \", got: {}", .current().span())
+                    }
+                    .index += 2
+                    break
+                }
+                else => {
+                    // FIXME: there is currently no better way to convert tokens back to a string
+                    // and while lexing it is impossible to determine where the expression ends
+                    // and the format specifier starts
+                    let span = .current().span()
+                    for char_ in .compiler.current_file_contents[span.start..span.end].iterator() {
+                        token_string.append(char_)
+                    }
+                    ++.index
+                }
+            }
+        }
+        return token_string.to_string()
+    }
+
     function parse_operand_base(mut this) throws => match .current() {
         Dot(span) => {
             yield ParsedExpression::Var(name: "this", span)
@@ -2961,8 +3110,17 @@ struct Parser {
             }
         }
         QuotedString(quote, span) => {
+            yield .parse_quoted_string()
+        }
+        DoubleQuote(span) => {
+            ++.index
+            .error("Unexpected Quote", span)
+            yield ParsedExpression::Garbage(span)
+        }
+        DollarLCurly(span) => {
             .index++
-            yield ParsedExpression::QuotedString(val: quote, span)
+            .error("Unexpected String Interpolation", span)
+            yield ParsedExpression::Garbage(span)
         }
         SingleQuotedString(quote, span) => {
             .index++

--- a/selfhost/typechecker.jakt
+++ b/selfhost/typechecker.jakt
@@ -4176,15 +4176,32 @@ struct Typechecker {
                 UnknownUnsigned(val) => .infer_unsigned_int(val, span, type_hint: type_hint_unwrapped)
             }
         }
+        FormatExpression(expr, format_specifier, span) => {
+            //FIXME: parse the format specifier and typecheck the value expression
+            yield .typecheck_expression(expr, scope_id, safety_mode, type_hint: None)
+        }
         SingleQuotedString(val, span) => CheckedExpression::CharacterConstant(val, span)
         SingleQuotedByteString(val, span) => CheckedExpression::ByteConstant(val, span)
         QuotedString(val, span) => {
             if .dump_try_hints {
                 .dump_try_hint(span)
             }
-        
+
             .unify_with_type(found_type: builtin(BuiltinType::JaktString), expected_type: type_hint, rhs_span: span)
             yield CheckedExpression::QuotedString(val, span)
+        }
+        InterpolatedString(format_string, interpolated_expressions, span) => {
+            if .dump_try_hints {
+                .dump_try_hint(span)
+            }
+
+            .unify_with_type(found_type: builtin(BuiltinType::JaktString), expected_type: type_hint, rhs_span: span)
+
+            mut checked_format_expressions: [CheckedExpression] = []
+            for expression in interpolated_expressions.iterator() {
+                checked_format_expressions.push(.typecheck_expression(expression, scope_id, safety_mode, type_hint: None))
+            }
+            yield CheckedExpression::InterpolatedString(format_string, interpolated_expressions: checked_format_expressions, span)
         }
         Call(call, span) => {
             yield .typecheck_call(call, caller_scope_id: scope_id, span, this_expr: None, parent_id: None, safety_mode, type_hint, must_be_enum_constructor: false)

--- a/selfhost/types.jakt
+++ b/selfhost/types.jakt
@@ -955,6 +955,7 @@ boxed enum CheckedExpression {
     Boolean(val: bool, span: Span)
     NumericConstant(val: CheckedNumericConstant, span: Span, type_id: TypeId)
     QuotedString(val: String, span: Span)
+    InterpolatedString(format_string: String, interpolated_expressions: [CheckedExpression], span: Span)
     ByteConstant(val: String, span: Span)
     CharacterConstant(val: String, span: Span)
     UnaryOp(expr: CheckedExpression, op: CheckedUnaryOperator, span: Span, type_id: TypeId)
@@ -1013,6 +1014,7 @@ boxed enum CheckedExpression {
         Boolean(span) => span
         NumericConstant(span) => span
         QuotedString(span) => span
+        InterpolatedString(span) => span
         ByteConstant(span) => span
         CharacterConstant(span) => span
         UnaryOp(span) => span
@@ -1071,6 +1073,7 @@ boxed enum CheckedExpression {
         Boolean => builtin(BuiltinType::Bool)
         NumericConstant(type_id) => type_id
         QuotedString => builtin(BuiltinType::JaktString)
+        InterpolatedString => builtin(BuiltinType::JaktString)
         ByteConstant => builtin(BuiltinType::U8)
         CharacterConstant => builtin(BuiltinType::CChar)
         UnaryOp(type_id) => type_id

--- a/tests/parser/string_interpolation.jakt
+++ b/tests/parser/string_interpolation.jakt
@@ -1,0 +1,11 @@
+/// Expect:
+/// - output: "52\n42\n${13+29 :d}\n52\n5555555500000000\n"
+
+function main() {
+    let interpolate_this = 13
+    println(format("{:o}", 42))
+    println("${interpolate_this + 29:d}")
+    println("${{13+29 :d}}")
+    println("${interpolate_this + 29 :o}")
+    println("${0x55555555:hex-dump}")
+}

--- a/tests/parser/string_interpolation_empty_expression.jakt
+++ b/tests/parser/string_interpolation_empty_expression.jakt
@@ -1,0 +1,6 @@
+/// Expect:
+/// - error: "Empty expression in interpolated block"
+
+function main() {
+    println("${}")
+}

--- a/tests/parser/string_interpolation_unmatched_braces.jakt
+++ b/tests/parser/string_interpolation_unmatched_braces.jakt
@@ -1,0 +1,7 @@
+/// Expect:
+/// - error: "unexpected eof"
+
+function main() {
+    let test = 123
+    println("${test")
+}


### PR DESCRIPTION
Hello friends, 

I had some time this Sunday and decided to hack a bit on the self hosted jacket compiler to add a feature I was always thinking would really contribute to readability when watching videos of JT of Andreas: String Interpolation!

The current syntax uses curly braces without any prefix so you can write 
```
let interpolation = "there"
println("Hello {interpolation}")
```

The part between the braces is parsed as an expression so you can also do stuff like:
```
let part_of_the_answer = 13
println("The answer is {29 + part_of_the_answer}")
```

The expressions are also type checked. For the code generation I currently check if there are any expressions in the string that need to be interpolated and only then generate a call to `String::formatted`, otherwise the basic `String()` constructor is used. I'm sure there are many edge cases I have forgotten but I thought before I put much more time into this I ask the community for comments. I'm sure there are lots of improvements since this is my first time contributing to the project and also hacking on a compiler, so be gentle :^)

Some stuff I'm unsure about:
- How to handle *old style* format string when mixed with interpolated expressions? I think it would be best to check that only one style of formatting is used
- Currently during lexing a list of subtokens is parsed and attached to the Token. Would it be nicer to keep the "Token stream" flat and not embed the information? What would be the best factoring here?

Have a nice Sunday everyone and let me know what you think?  