### PR TITLE
selfhost/parser: Report error if Function is not followed by Identifier

### DIFF
--- a/selfhost/codegen.jakt
+++ b/selfhost/codegen.jakt
@@ -721,6 +721,10 @@ struct CodeGenerator {
             return ""
         }
 
+        if function_.is_comptime {
+            return ""
+        }
+
         // FIXME: for now, just exit early if we're a constructor
         if function_.type is ImplicitConstructor {
             return ""

--- a/selfhost/parser.jakt
+++ b/selfhost/parser.jakt
@@ -2168,6 +2168,7 @@ struct Parser {
         }
 
         guard .current() is Identifier(name) else {
+            .error("Incomplete function definition", .current().span())
             return parsed_function
         }
         parsed_function.name = name

--- a/tests/parser/invalid_function_decl.jakt
+++ b/tests/parser/invalid_function_decl.jakt
@@ -1,0 +1,5 @@
+/// Expect:
+/// - error: "Incomplete function definition"
+
+comptime function foo() {}
+


### PR DESCRIPTION
Or if Comptime is not followed by Identifier. This fixes invalid code
like ``comptime function foo() {}``or``function function foo() {}``
from creating a nameless function.

Also, stop generating function declarations for comptime functions. We don't need em.