### PR TITLE
main+editors/vscode: Make go-to-definition actions work on Windows

### DIFF
--- a/editors/vscode/README.md
+++ b/editors/vscode/README.md
@@ -29,8 +29,7 @@ In the editors/vscode directory:
 
 To create the package
 ```
-> npm install vsce -g
-> vsce package
+> npx vsce package
 ```
 
 Then install vscode by switching to the Extensions section on the left, then the `...` at the top middle and choose "Install from VSIX..." and choose the package you just created.

--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -114,7 +114,8 @@
 		"esbuild": "^0.14.42",
 		"eslint": "^8.13.0",
 		"mocha": "^9.2.1",
-		"typescript": "^4.7.2"
+		"typescript": "^4.7.2",
+		"vsce": "^2.11.0"
 	},
 	"dependencies": {
 		"@types/vscode": "^1.67.0",

--- a/selfhost/main.jakt
+++ b/selfhost/main.jakt
@@ -9,7 +9,7 @@
 import compiler { Compiler, FileId }
 import codegen { CodeGenerator }
 import error { JaktError, print_error }
-import utility { FilePath, ArgsParser, Span }
+import utility { FilePath, ArgsParser, Span, escape_for_quotes }
 import lexer { Lexer }
 import parser { Parser }
 import interpreter { Interpreter, InterpreterScope, value_to_checked_expression }
@@ -289,7 +289,7 @@ function main(args: [String]) {
         } else {
             let file_path = compiler.get_file_path(result.file_id)
             
-            println("{{\"start\": {}, \"end\": {}, \"file\": \"{}\"}}", result.start, result.end, file_path!.path);
+            println("{{\"start\": {}, \"end\": {}, \"file\": \"{}\"}}", result.start, result.end, escape_for_quotes(file_path!.path));
         }
         return 0
     }
@@ -303,7 +303,7 @@ function main(args: [String]) {
         } else {
             let file_path = compiler.get_file_path(result.file_id)
 
-            println("{{\"start\": {}, \"end\": {}, \"file\": \"{}\"}}", result.start, result.end, file_path!.path);
+            println("{{\"start\": {}, \"end\": {}, \"file\": \"{}\"}}", result.start, result.end, escape_for_quotes(file_path!.path));
         }
         return 0
     }


### PR DESCRIPTION
Make the go-to-definition actions work by escaping file paths before inserting them into JSON documents, as they contain backslashes on Windows. This also technically fixes paths on Linux, as they can contain pretty much any character expect for slashes and null.

There are other strings that are inserted into JSON documents, but they should not contain slashes or double-quotes, as they are type names and function prototypes.

Not really related, but this PR also updates the VS Code extension build instructions in order to avoid installing the vsce package globally.