### PR TITLE
all: Allow destructuring into existing variables/ from nested Tuples

### DIFF
--- a/samples/compiletime_execution/dict.jakt
+++ b/samples/compiletime_execution/dict.jakt
@@ -38,11 +38,23 @@ comptime keys() throws -> bool {
 comptime iterator() throws -> bool {
     mut dict = ["m":'m',"n":'n',"o":'o']
     mut output = ""
+
     for (key, val) in dict {
         output += format("{}=>", key) + format("{}\n", key)
     }
     return output == "m=>m\nn=>n\no=>o\n"
 }
+comptime iterator_existing_vars() throws -> bool {
+    mut key = ""
+    mut val = ""
+    mut dict = ["m":'m',"n":'n',"o":'o']
+    mut output = ""
+    for (key, val) in dict.iterator() {
+        output += format("{}=>", key) + format("{}\n", val)
+    }
+    return output == "m=>m\nn=>n\no=>o\n"
+}
+
 comptime dictionary_constructor() => Dictionary<String, c_char>().is_empty()
 
 function main() {
@@ -55,6 +67,7 @@ function main() {
     success &= size()
     success &= keys()
     success &= iterator()
+    success &= iterator_existing_vars()
     success &= dictionary_constructor()
 
     if success {

--- a/samples/tuples/destructuring_assignment.jakt
+++ b/samples/tuples/destructuring_assignment.jakt
@@ -1,11 +1,42 @@
 /// Expect:
-/// - output: "1 hello\n"
+/// - output: "1 hello\n1 hello\n2, 3, 4\nTest(a: 1, b: 2, c: 3)\n"
 
 function foo() -> (i64, String) {
     return (1, "hello")
 }
 
+struct Test {
+    a: i64
+    b: i64
+    c: i64
+}
+
 function main() {
     let (x1, x2) = foo()
+
     println("{} {}", x1, x2)
+
+    mut bar = 0
+    mut baz = ""
+
+    (bar, baz) = foo()
+
+    println("{} {}", bar, baz)
+
+    let tuple = (1, 2, 3)
+
+    mut (a, b, c) = tuple
+    a++
+    b++
+    c++
+
+    println("{}, {}, {}", a, b, c)
+
+    let nested_tuple = (1, (2, 3))
+
+    mut test = Test(a: 5, b: 6, c: 7)
+
+    (test.a, (test.b, test.c)) = nested_tuple
+
+    println("{}", test)
 }

--- a/samples/tuples/destructuring_assignment.jakt
+++ b/samples/tuples/destructuring_assignment.jakt
@@ -1,5 +1,5 @@
 /// Expect:
-/// - output: "1 hello\n1 hello\n2, 3, 4\nTest(a: 1, b: 2, c: 3)\n"
+/// - output: "1 hello\n1 hello\n2, 3, 4\n1, 2, 3\n"
 
 function foo() -> (i64, String) {
     return (1, "hello")
@@ -14,14 +14,16 @@ struct Test {
 function main() {
     let (x1, x2) = foo()
 
-    println("{} {}", x1, x2)
+    print("{} ", x1)
+    println("{}", x2)
 
     mut bar = 0
     mut baz = ""
 
     (bar, baz) = foo()
 
-    println("{} {}", bar, baz)
+    print("{} ", bar)
+    println("{}", baz)
 
     let tuple = (1, 2, 3)
 
@@ -30,7 +32,9 @@ function main() {
     b++
     c++
 
-    println("{}, {}, {}", a, b, c)
+    print("{}, ", a)
+    print("{}, ", b)
+    println("{}", c)
 
     let nested_tuple = (1, (2, 3))
 
@@ -38,5 +42,7 @@ function main() {
 
     (test.a, (test.b, test.c)) = nested_tuple
 
-    println("{}", test)
+    print("{}, ", test.a)
+    print("{}, ", test.b)
+    println("{}", test.c)
 }

--- a/samples/tuples/destructuring_assignment_for.jakt
+++ b/samples/tuples/destructuring_assignment_for.jakt
@@ -1,10 +1,16 @@
 /// Expect:
-/// - output: "1, Hello\n2, World\n"
+/// - output: "1, Hello\n2, World\n1, Hello-3\n2, World-4\n"
 
 function main() {
     mut list = [(1, "Hello"), (2, "World")]
 
     for (idx, word) in list {
         println("{}, {}" idx, word)
+    }
+
+    mut nested_list = [(1, ("Hello", 3)), (2, ("World", 4))]
+
+    for (idx, (word, count)) in nested_list.iterator() {
+        println("{}, {}-{}" idx, word, count)
     }
 }

--- a/samples/tuples/destructuring_assignment_for.jakt
+++ b/samples/tuples/destructuring_assignment_for.jakt
@@ -5,12 +5,15 @@ function main() {
     mut list = [(1, "Hello"), (2, "World")]
 
     for (idx, word) in list {
-        println("{}, {}" idx, word)
+        print("{}, ", idx)
+        println("{}", word)
     }
 
     mut nested_list = [(1, ("Hello", 3)), (2, ("World", 4))]
 
     for (idx, (word, count)) in nested_list.iterator() {
-        println("{}, {}-{}" idx, word, count)
+        print("{}, ", idx)
+        print("{}-" word)
+        println("{}", count)
     }
 }

--- a/selfhost/codegen.jakt
+++ b/selfhost/codegen.jakt
@@ -2979,7 +2979,21 @@ struct CodeGenerator {
             }
             DestructuringAssignment(vars, var_decl) => {
                 mut output = ""
-                output += .codegen_statement(statement: var_decl)
+                if var_decl.has_value() {
+                    output += .codegen_statement(statement: var_decl!)
+                }
+
+                for v in vars.iterator() {
+                    output += .codegen_expression(expression: v)
+                    output += ";"
+                }
+                yield output
+            }
+            DestructuringDeclarationAssignment(vars, var_decl) => {
+                mut output = ""
+                if var_decl.has_value() {
+                    output += .codegen_statement(statement: var_decl!)
+                }
 
                 for v in vars {
                     output += .codegen_statement(statement: v)

--- a/selfhost/ide.jakt
+++ b/selfhost/ide.jakt
@@ -610,14 +610,23 @@ function find_span_in_statement(program: CheckedProgram, statement: CheckedState
             }
             yield find_span_in_block(program, block, span)
         }
-        DestructuringAssignment(vars, var_decl) => {
+        DestructuringAssignment(vars) => {
+            for var in vars {
+                let found = find_span_in_expression(program, expr: var, span)
+                if found.has_value() {
+                    return found
+                }
+            }
+            yield none
+        }
+        DestructuringDeclarationAssignment(vars) => {
             for var in vars {
                 let found = find_span_in_statement(program, statement: var, span)
                 if found.has_value() {
                     return found
                 }
             }
-            yield find_span_in_statement(program, statement: var_decl, span)
+            yield none
         }
         Yield(expr) => find_span_in_expression(program, expr, span)
         Break | Continue | Garbage => none

--- a/selfhost/interpreter.jakt
+++ b/selfhost/interpreter.jakt
@@ -2767,33 +2767,83 @@ class Interpreter {
             Defer(statement) => {
                 scope.defer_statement(statement)
             }
-            DestructuringAssignment(vars, var_decl) => {
-                guard var_decl! is VarDecl(var_id, init) else {
-                    panic("expected vardecl")
-                }
-                match .execute_expression(init, scope) {
-                    Return(value) => {
-                        return StatementResult::Return(value)
-                    }
-                    Throw(value) => {
-                        return StatementResult::Throw(value)
-                    }
-                    JustValue(var_value) => {
-                        scope.bindings[.program.get_variable(id: var_id).name] = var_value
-                    }
-                    Continue => {
-                        return StatementResult::Continue
-                    }
-                    Break => {
-                        return StatementResult::Break
-                    }
-                    Yield => {
-                        panic("Invalid control flow")
+            DestructuringAssignment(vars, var_decl, span) => {
+                if var_decl.has_value() and var_decl! is VarDecl(var_id, init) {
+                    match .execute_expression(init, scope) {
+                        Return(value) => {
+                            return StatementResult::Return(value)
+                        }
+                        Throw(value) => {
+                            return StatementResult::Throw(value)
+                        }
+                        JustValue(var_value) => {
+                            scope.bindings[.program.get_variable(id: var_id).name] = var_value
+                        }
+                        Continue => {
+                            return StatementResult::Continue
+                        }
+                        Break => {
+                            return StatementResult::Break
+                        }
+                        Yield => {
+                            panic("Invalid control flow")
+                        }
                     }
                 }
 
                 for var in vars {
-                    guard var is Var(var_id, init) else {
+                    guard var is BinaryOp(lhs, op) and op is Assign else {
+                        panic("Expecting assignment expression for DestructuringAssignment")
+                    }
+
+                    match .execute_expression(var, scope) {
+                        Return(value) => {
+                            return StatementResult::Return(value)
+                        }
+                        Throw(value) => {
+                            return StatementResult::Throw(value)
+                        }
+                        JustValue(var_value) => {
+                            .update_binding(lhs, scope, var_value, span)
+                        }
+                        Continue => {
+                            return StatementResult::Continue
+                        }
+                        Break => {
+                            return StatementResult::Break
+                        }
+                        Yield => {
+                            panic("Invalid control flow")
+                        }
+                    }
+                }
+            }
+            DestructuringDeclarationAssignment(vars, var_decl) => {
+                if var_decl.has_value() and var_decl! is VarDecl(var_id, init) {
+                    match .execute_expression(init, scope) {
+                        Return(value) => {
+                            return StatementResult::Return(value)
+                        }
+                        Throw(value) => {
+                            return StatementResult::Throw(value)
+                        }
+                        JustValue(var_value) => {
+                            scope.bindings[.program.get_variable(id: var_id).name] = var_value
+                        }
+                        Continue => {
+                            return StatementResult::Continue
+                        }
+                        Break => {
+                            return StatementResult::Break
+                        }
+                        Yield => {
+                            panic("Invalid control flow")
+                        }
+                    }
+                }
+
+                for var in vars {
+                    guard var is VarDecl(var_id, init) else {
                         panic("expected vardecl")
                     }
                     match .execute_expression(init, scope) {
@@ -2818,7 +2868,6 @@ class Interpreter {
                     }
                 }
             }
-            DestructuringDeclarationAssignment(span) => .error("destructuring declaration assignment not implemented", span)
             VarDecl(var_id, init, span) => {
                 match .execute_expression(init, scope) {
                     Return(value) => {

--- a/selfhost/interpreter.jakt
+++ b/selfhost/interpreter.jakt
@@ -2768,7 +2768,7 @@ class Interpreter {
                 scope.defer_statement(statement)
             }
             DestructuringAssignment(vars, var_decl) => {
-                guard var_decl is VarDecl(var_id, init) else {
+                guard var_decl! is VarDecl(var_id, init) else {
                     panic("expected vardecl")
                 }
                 match .execute_expression(init, scope) {
@@ -2793,7 +2793,7 @@ class Interpreter {
                 }
 
                 for var in vars {
-                    guard var is VarDecl(var_id, init) else {
+                    guard var is Var(var_id, init) else {
                         panic("expected vardecl")
                     }
                     match .execute_expression(init, scope) {
@@ -2818,6 +2818,7 @@ class Interpreter {
                     }
                 }
             }
+            DestructuringDeclarationAssignment(span) => .error("destructuring declaration assignment not implemented", span)
             VarDecl(var_id, init, span) => {
                 match .execute_expression(init, scope) {
                     Return(value) => {

--- a/selfhost/parser.jakt
+++ b/selfhost/parser.jakt
@@ -327,6 +327,12 @@ struct ParsedRecord {
     record_type: RecordType
 }
 
+enum DestructuringDeclarationType {
+    Immutable
+    Mutable
+    Assign
+}
+
 enum FunctionType {
     Normal
     ImplicitConstructor
@@ -492,7 +498,7 @@ boxed enum ParsedStatement {
     Expression(expr: ParsedExpression, span: Span)
     Defer(statement: ParsedStatement, span: Span)
     UnsafeBlock(block: ParsedBlock, span: Span)
-    DestructuringAssignment(vars: [ParsedVarDecl], var_decl: ParsedStatement, span: Span)
+    DestructuringAssignment(destructure: ParsedExpression, expr: ParsedExpression, declaration_type: DestructuringDeclarationType, span: Span)
     VarDecl(var: ParsedVarDecl, init: ParsedExpression, span: Span)
     If(condition: ParsedExpression, then_block: ParsedBlock, else_statement: ParsedStatement?, span: Span)
     Block(block: ParsedBlock, span: Span)
@@ -525,18 +531,13 @@ boxed enum ParsedStatement {
             VarDecl(var: rhs_var, init: rhs_init) => lhs_var.equals(rhs_var) and lhs_init.equals(rhs_init)
             else => false
         }
-        DestructuringAssignment(vars: lhs_vars, var_decl: lhs_var_decl) => match rhs_statement {
-            DestructuringAssignment(vars: rhs_vars, var_decl: rhs_var_decl) => {
-                if lhs_vars.size() != rhs_vars.size() {
+        DestructuringAssignment(destructure: lhs_destructure, expr: lhs_expr) => match rhs_statement {
+            DestructuringAssignment(destructure: rhs_destructure, expr: rhs_expr) => {
+                if not lhs_destructure.equals(rhs_destructure) {
                     return false
                 }
-                for i in 0..lhs_vars.size() {
-                    if not lhs_vars[i].equals(rhs_vars[i]) {
-                        return false
-                    }
-                }
 
-                if not lhs_var_decl.equals(rhs_var_decl) {
+                if not lhs_expr.equals(rhs_expr) {
                     return false
                 }
 
@@ -926,6 +927,7 @@ boxed enum ParsedExpression {
     JaktDictionary(values: [(ParsedExpression, ParsedExpression)], span: Span)
     Set(values: [ParsedExpression], span: Span)
     JaktTuple(values: [ParsedExpression], span: Span)
+    Destructure(values: [ParsedExpression], span: Span)
     Range(from: ParsedExpression?, to: ParsedExpression?, span: Span)
     ForcedUnwrap(expr: ParsedExpression, span: Span)
     Match(expr: ParsedExpression, cases: [ParsedMatchCase], span: Span, marker_span: Span)
@@ -1106,6 +1108,20 @@ boxed enum ParsedExpression {
         }
         JaktTuple(values: lhs_values) => match rhs_expression {
             JaktTuple(values: rhs_values) => {
+                if not lhs_values.size() == rhs_values.size() {
+                    return false
+                }
+                for i in 0..lhs_values.size() {
+                    if not lhs_values[i].equals(rhs_values[i]) {
+                        return false
+                    }
+                }
+                yield true
+            }
+            else => false
+        }
+        Destructure(values: lhs_values) => match rhs_expression {
+            Destructure(values: rhs_values) => {
                 if not lhs_values.size() == rhs_values.size() {
                     return false
                 }
@@ -1452,11 +1468,12 @@ enum Visibility {
 
 struct Parser {
     index: usize
+    iterator_count: u64
     tokens: [Token]
     compiler: Compiler
 
     function parse(compiler: Compiler, tokens: [Token]) throws -> ParsedNamespace {
-        mut parser = Parser(index: 0, tokens, compiler)
+        mut parser = Parser(index: 0, iterator_count: 0, tokens, compiler)
         return parser.parse_namespace()
     }
 
@@ -3314,25 +3331,16 @@ struct Parser {
 
                 mut vars: [ParsedVarDecl] = []
                 mut is_destructuring_assingment = false
-                mut tuple_var_name = ""
-                mut tuple_var_decl = ParsedVarDecl(
-                    name: "",
-                    parsed_type: ParsedType::Empty,
-                    is_mutable: is_mutable,
-                    inlay_span: None,
-                    span: .current().span(),
-                )
 
+                mut destructure: ParsedExpression? = None
+                mut var_decl: ParsedVarDecl? = None
+                
                 if .current() is LParen {
-                    vars = .parse_destructuring_assignment(is_mutable)
-                    for var in vars {
-                        tuple_var_name += var.name
-                        tuple_var_name += "_"
-                    }
-                    tuple_var_decl.name = tuple_var_name
+                    destructure = .parse_operand_base()
+
                     is_destructuring_assingment = true
                 } else {
-                    tuple_var_decl = .parse_variable_declaration(is_mutable)
+                    var_decl = .parse_variable_declaration(is_mutable)
                 }
 
                 let init = match .current() {
@@ -3346,13 +3354,24 @@ struct Parser {
                     }
                 }
 
-                mut return_statement = ParsedStatement::VarDecl(var: tuple_var_decl, init, span: merge_spans(start, .previous().span()))
-
+                mut return_statement: ParsedStatement? = None
                 if is_destructuring_assingment {
-                    let old_return_statement = return_statement
-                    return_statement = ParsedStatement::DestructuringAssignment(vars, var_decl: old_return_statement, span: merge_spans(start, .previous().span()))
+                    if destructure.has_value() and destructure! is Destructure {
+                        let declaration_type = match is_mutable {
+                            true => DestructuringDeclarationType::Mutable
+                            else => DestructuringDeclarationType::Immutable
+                        }
+
+                        return_statement = ParsedStatement::DestructuringAssignment(destructure: destructure!, expr: init, declaration_type, span: merge_spans(start, .previous().span()))
+                    } else {
+                        .error("Invalid destructure", merge_spans(start, .previous().span()))
+                        return_statement = ParsedStatement::Garbage(merge_spans(start, .previous().span()))
+                    }                    
+                } else {
+                    return_statement = ParsedStatement::VarDecl(var: var_decl!, init, span: merge_spans(start, .previous().span()))
                 }
-                yield return_statement
+
+                yield return_statement!
             }
             If => .parse_if_statement()
             For => .parse_for_statement()
@@ -3363,7 +3382,16 @@ struct Parser {
             Guard => .parse_guard_statement()
             else => {
                 let expr = .parse_expression(allow_assignments: true, allow_newlines: false)
-                yield ParsedStatement::Expression(expr, span: merge_spans(start, .previous().span()))
+
+                mut statement: ParsedStatement? = None
+                // FIXME: This is probably not the ideal spot to rewrite an assingment into a Destructure as a DestructuringAssignment but I can't find a better one currently
+                if expr is BinaryOp(lhs, op, rhs) and op is Assign and lhs is Destructure {
+                    statement = ParsedStatement::DestructuringAssignment(destructure: lhs, expr: rhs, declaration_type: DestructuringDeclarationType::Assign, span: merge_spans(start, .previous().span()))
+                } else {
+                    statement = ParsedStatement::Expression(expr, span: merge_spans(start, .previous().span()))
+                }
+
+                yield statement!
             }
         }
     }
@@ -3424,8 +3452,9 @@ struct Parser {
         let start_span = .current().span()
         .index++
 
+        mut destructure: ParsedExpression? = None
+        mut is_destructuring_assingment = false
         mut iterator_name = ""
-        mut destructured_var_decls: [ParsedVarDecl] = []
 
         match .current() {
             Identifier(name) => {
@@ -3433,13 +3462,8 @@ struct Parser {
                 .index++
             }
             LParen => {
-                destructured_var_decls = .parse_destructuring_assignment(is_mutable: false)
-                mut tuple_var_name = ""
-                for var in destructured_var_decls {
-                    tuple_var_name += var.name
-                    tuple_var_name += "__"
-                }
-                iterator_name = tuple_var_name
+                destructure = .parse_operand_base()
+                is_destructuring_assingment = true
             }
             else => {
                 .error("Expected iterator name or destructuring pattern", .current().span())
@@ -3458,23 +3482,28 @@ struct Parser {
         let range = .parse_expression(allow_assignments: false, allow_newlines: false)
         mut block = .parse_block();
 
-        if destructured_var_decls.size() > 0 {
-            mut tuple_var_name = "jakt__"
-            tuple_var_name += iterator_name
-            mut tuple_var_decl = ParsedVarDecl(
-                name: tuple_var_name,
-                parsed_type: ParsedType::Empty,
-                is_mutable: false,
-                inlay_span: None,
-                span: .current().span(),
-            )
-            let init = ParsedExpression::Var(name: iterator_name, span: merge_spans(start_span, .previous().span()))
-            let var_decl = ParsedStatement::VarDecl(var: tuple_var_decl, init, span: merge_spans(start_span, .previous().span()))
-            let destructured_vars_stmt = ParsedStatement::DestructuringAssignment(vars: destructured_var_decls, var_decl, span: merge_spans(start_span, .previous().span()))
-            mut block_stmts: [ParsedStatement] = []
-            block_stmts.push(destructured_vars_stmt)
-            block_stmts.push_values(block.stmts)
-            block.stmts = block_stmts
+        if is_destructuring_assingment {
+            if destructure.has_value() and destructure! is Destructure(values) {
+                iterator_name = format("iterator{}", .iterator_count++)
+                let init = ParsedExpression::Var(name: iterator_name, span: merge_spans(start_span, .previous().span()))
+
+                let destructured_vars_stmt = ParsedStatement::DestructuringAssignment(
+                    destructure: destructure!
+                    expr: init
+                    declaration_type: DestructuringDeclarationType::Immutable
+                    span: merge_spans(start_span, .previous().span())
+                )
+                
+                mut block_stmts: [ParsedStatement] = []
+                block_stmts.push(destructured_vars_stmt)
+                for stmt in block.stmts.iterator() {
+                    block_stmts.push(stmt)
+                }
+
+                block.stmts = block_stmts
+            } else {
+                .error("Invalid destructure", merge_spans(start_span, .previous().span()))
+            }
         }
 
         return ParsedStatement::For(iterator_name, name_span, range, block, span: merge_spans(start_span, .previous().span()))
@@ -3707,37 +3736,8 @@ struct Parser {
                     .index++
                 }
                 Comma => {
-                    // We have a tuple
-                    .index++
-
-                    mut tuple_exprs: [ParsedExpression] = [expr]
-                    mut end_span = start_span
-
-                    while not .eof() {
-                        match .current() {
-                            Eol | Comma => {
-                                .index++
-                            }
-                            RParen => {
-                                .index++
-                                break
-                            }
-                            else => {
-                                let expr = .parse_expression(allow_assignments: false, allow_newlines: false)
-                                end_span = expr.span()
-                                tuple_exprs.push(expr)
-                            }
-                        }
-                    }
-
-                    if .eof() {
-                        .error("Expected ')'", .current().span());
-                    }
-
-                    expr = ParsedExpression::JaktTuple(
-                        values: tuple_exprs,
-                        span: merge_spans(start_span, end_span)
-                    )
+                    // We have a tuple or destructure
+                    expr = .parse_tuple_or_destructure(expr, start_span)
                 }
                 else => {
                     .error("Expected ')'", .current().span())
@@ -4021,6 +4021,66 @@ struct Parser {
         LiteralSuffix::F32 => NumericConstant::F32(f64_to_f32(number))
         LiteralSuffix::F64 => NumericConstant::F64(number)
         else => None
+    }
+
+    function update_tuple_to_destructure(mut this, mut expr: ParsedExpression) throws -> ParsedExpression
+    {
+        if expr is JaktTuple(values, span) {
+            mut new_values: [ParsedExpression] = []
+            for i in ..values.size() {
+                if values[i] is JaktTuple {
+                    new_values.push(.update_tuple_to_destructure(expr: values[i]))
+                } else {
+                    new_values.push(values[i])
+                }
+            }
+
+            expr = ParsedExpression::Destructure(
+                values: new_values
+                span
+            )
+        }
+
+        return expr
+    }
+
+    function parse_tuple_or_destructure(mut this, expr: ParsedExpression, start_span: Span) throws -> ParsedExpression {
+        .index++
+
+        mut tuple_exprs: [ParsedExpression] = [expr]
+        mut end_span = start_span
+
+        while not .eof() {
+            match .current() {
+                Eol | Comma => {
+                    .index++
+                }
+                RParen => {
+                    .index++
+                    break
+                }
+                else => {
+                    let expr = .parse_expression(allow_assignments: false, allow_newlines: false)
+                    end_span = expr.span()
+                    tuple_exprs.push(expr)
+                }
+            }
+        }
+
+        if .eof() {
+            .error("Expected ')'", .current().span());
+        }
+
+        mut expr = ParsedExpression::JaktTuple(
+            values: tuple_exprs,
+            span: merge_spans(start_span, end_span)
+        )
+
+        if .current() is Equal or .current() is In {
+            expr = .update_tuple_to_destructure(expr)
+        }
+
+        return expr
     }
 
     function parse_captures(mut this) throws -> [ParsedCapture] {

--- a/selfhost/repl.jakt
+++ b/selfhost/repl.jakt
@@ -250,6 +250,7 @@ struct REPL {
             dump_type_hints: compiler.dump_type_hints
             dump_try_hints: compiler.dump_try_hints
             lambda_count: 0
+            destructure_count: 0
             generic_inferences: GenericInferences(values: [:])
         )
 
@@ -331,7 +332,7 @@ struct REPL {
                 continue
             }
 
-            mut parser = Parser(index: 0, tokens, compiler: .compiler)
+            mut parser = Parser(index: 0, iterator_count: 0, tokens, compiler: .compiler)
 
             let first_token = tokens.first()!
             if first_token is Function

--- a/selfhost/typechecker.jakt
+++ b/selfhost/typechecker.jakt
@@ -5860,50 +5860,7 @@ struct Typechecker {
                 }
             }
         }
-        IndexedTuple(expr, index, is_optional, span) => {
-            let checked_expr = .typecheck_expression_and_dereference_if_needed(expr, scope_id, safety_mode, type_hint: None, span)
-
-            let tuple_struct_id = .find_struct_in_prelude("Tuple")
-            let optional_struct_id = .find_struct_in_prelude("Optional")
-            mut expr_type_id = unknown_type_id()
-
-            if .get_type(checked_expr.type()) is GenericInstance(id, args) {
-                if id.equals(tuple_struct_id) {
-                    if is_optional {
-                        .error("Optional chaining is not allowed on a non-optional tuple type", span)
-                    }
-                    if (index >= args.size()){
-                        .error("Tuple index past the end of the tuple", span)
-                    } else {
-                        expr_type_id = args[index]
-                    }
-                } else if is_optional and id.equals(optional_struct_id) {
-                    let inner_type_id = args[0]
-                    if .get_type(inner_type_id) is GenericInstance(id, args) {
-                        if id.equals(tuple_struct_id) {
-                            if (index >= args.size()){
-                                .error("Optional-chained tuple index past the end of the tuple", span)
-                            } else {
-                                expr_type_id = .find_or_add_type_id(Type::GenericInstance(id: optional_struct_id, args: [args[index]]))
-                            }
-                        }
-                    } else {
-                        .error("Optional-chained tuple index used on non-tuple value", span)
-                    }
-                }
-            } else if is_optional {
-                .error("Optional-chained tuple index used on non-tuple value", span)
-            } else {
-                .error("Tuple index used on non-tuple value", span)
-            }
-
-            yield CheckedExpression::IndexedTuple(
-                expr: checked_expr
-                index: index
-                span
-                is_optional
-                type_id: expr_type_id)
-        }
+        IndexedTuple(expr, index, is_optional, span) => .typecheck_indexed_tuple(expr, index, scope_id, is_optional, safety_mode, span)
         Garbage(span) => CheckedExpression::Garbage(span)
         NamespacedVar(name, namespace_, span) => .typecheck_namespaced_var_or_simple_enum_constructor_call(name, namespace_, scope_id, safety_mode, type_hint, span)
         Match(expr, cases, marker_span) => .typecheck_match(expr, cases, span: marker_span, scope_id, safety_mode, type_hint)

--- a/selfhost/typechecker.jakt
+++ b/selfhost/typechecker.jakt
@@ -4734,19 +4734,28 @@ struct Typechecker {
         mut tuple_variable: CheckedVariable? = None
         mut checked_var_decl: CheckedStatement? = None
 
-        let var_decl = ParsedVarDecl(
-            name: format("destructure{}", .destructure_count++),
-            parsed_type: ParsedType::Empty,
-            is_mutable: false,
-            inlay_span: None,
-            span
-        )
-
-        checked_var_decl = .typecheck_var_decl(var: var_decl, init: expr, scope_id, safety_mode, span)
-        if checked_var_decl! is VarDecl(var_id) {
-            tuple_variable = .program.get_variable(var_id)
+        if checked_expr is Var(var) {
+            let maybe_var = .find_var_in_scope(scope_id, var: var.name)
+            if maybe_var.has_value() {
+                tuple_variable = maybe_var!
+            } else {
+                .error(format("Variable `{}` not found", var.name), span)
+            }
         } else {
-            .error("Invalid var declaration", span)
+            let var_decl = ParsedVarDecl(
+                name: format("destructure{}", .destructure_count++),
+                parsed_type: ParsedType::Empty,
+                is_mutable: false,
+                inlay_span: None,
+                span
+            )
+
+            checked_var_decl = .typecheck_var_decl(var: var_decl, init: expr, scope_id, safety_mode, span)
+            if checked_var_decl! is VarDecl(var_id) {
+                tuple_variable = .program.get_variable(var_id)
+            } else {
+                .compiler.panic(format("Internal destructure variable `{}` not found", var_decl.name))
+            }
         }
 
         return (checked_expr, tuple_variable, checked_var_decl)

--- a/selfhost/typechecker.jakt
+++ b/selfhost/typechecker.jakt
@@ -13,8 +13,9 @@ import parser {
     NumericConstant, ParsedBlock, ParsedCall, ParsedCapture, ParsedExpression, ParsedExternImport, ParsedField
     ParsedFunction, ParsedMatchBody, ParsedMatchCase, ParsedMethod, ParsedModuleImport, ParsedName
     ParsedNameWithGenericParameters, ParsedNamespace, ParsedParameter, ParsedRecord, ParsedStatement, ParsedTrait
-    ParsedType, ParsedVarDecl, Parser, RecordType, TypeCast, UnaryOperator, Visibility
+    ParsedType, ParsedVarDecl, Parser, RecordType, TypeCast, UnaryOperator, Visibility, DestructuringDeclarationType
 }
+
 import types {
     BlockControlFlow, BuiltinType, CheckedBlock, CheckedCall, CheckedCapture, CheckedEnum, CheckedEnumVariant
     CheckedEnumVariantBinding, CheckedExpression, CheckedField, CheckedFunction, CheckedGenericParameter
@@ -48,6 +49,7 @@ struct Typechecker {
     dump_type_hints: bool
     dump_try_hints: bool
     lambda_count: u64
+    destructure_count: u64
     generic_inferences: GenericInferences
 
     function type_name(this, anon type_id: TypeId) throws => .program.type_name(type_id)
@@ -84,6 +86,7 @@ struct Typechecker {
             dump_type_hints: compiler.dump_type_hints
             dump_try_hints: compiler.dump_try_hints
             lambda_count: 0
+            destructure_count: 0
             generic_inferences: GenericInferences(values: [:])
         )
 
@@ -4333,7 +4336,7 @@ struct Typechecker {
         Continue(span) => CheckedStatement::Continue(span)
         Break(span) => CheckedStatement::Break(span)
         VarDecl(var, init, span) => .typecheck_var_decl(var, init, scope_id, safety_mode, span)
-        DestructuringAssignment(vars, var_decl, span) => .typecheck_destructuring_assignment(vars, var_decl, scope_id, safety_mode, span)
+        DestructuringAssignment(destructure, expr, declaration_type, span) => .typecheck_destructuring_assignment(destructure, expr, declaration_type, scope_id, safety_mode, span)
         If(condition, then_block, else_statement, span) => .typecheck_if(condition, then_block, else_statement, scope_id, safety_mode, span)
         Garbage(span) => CheckedStatement::Garbage(span)
         For(iterator_name, name_span, range, block, span) => .typecheck_for(iterator_name,  name_span, range, block, scope_id, safety_mode, span)
@@ -4726,42 +4729,170 @@ struct Typechecker {
         return CheckedStatement::If(condition: checked_condition, then_block: checked_block, else_statement: checked_else, span)
     }
 
-    function typecheck_destructuring_assignment(mut this, vars: [ParsedVarDecl], var_decl: ParsedStatement, scope_id: ScopeId, safety_mode: SafetyMode, span: Span) throws -> CheckedStatement {
-        mut var_decls: [CheckedStatement] = []
-        let checked_tuple_var_decl = .typecheck_statement(statement: var_decl, scope_id, safety_mode)
-        mut expr_type_id: TypeId = unknown_type_id()
-        mut tuple_var_id = VarId(module: ModuleId(id: 0), id: 0)
-        if checked_tuple_var_decl is VarDecl(var_id, init) {
-            expr_type_id = init.type()
-            tuple_var_id = var_id
+    function typecheck_destructured_tuple(mut this, expr: ParsedExpression, scope_id: ScopeId, safety_mode: SafetyMode, span: Span) throws -> (CheckedExpression, CheckedVariable?, CheckedStatement?) {
+        mut checked_expr = .typecheck_expression(expr, scope_id, safety_mode, type_hint: None)
+        mut tuple_variable: CheckedVariable? = None
+        mut checked_var_decl: CheckedStatement? = None
+
+        let var_decl = ParsedVarDecl(
+            name: format("destructure{}", .destructure_count++),
+            parsed_type: ParsedType::Empty,
+            is_mutable: false,
+            inlay_span: None,
+            span
+        )
+
+        checked_var_decl = .typecheck_var_decl(var: var_decl, init: expr, scope_id, safety_mode, span)
+        if checked_var_decl! is VarDecl(var_id) {
+            tuple_variable = .program.get_variable(var_id)
         } else {
-            .error("Destructuting assignment should be a variable declaration", span)
+            .error("Invalid var declaration", span)
         }
 
-        mut inner_types: [TypeId] = []
-        let tuple_type = .get_type(expr_type_id)
-        if tuple_type is GenericInstance(args) {
-            inner_types = args
-        } else {
-            .error("Tuple Type should be Generic Instance", span)
+        return (checked_expr, tuple_variable, checked_var_decl)
+    }
+
+    function typecheck_destructuring_assignment(mut this, destructure: ParsedExpression, expr: ParsedExpression, declaration_type: DestructuringDeclarationType, scope_id: ScopeId, safety_mode: SafetyMode, span: Span) throws -> CheckedStatement {
+        mut var_assignments: [CheckedExpression] = []
+        mut var_declarations: [CheckedStatement] = []
+
+        guard destructure is Destructure(values) else {
+            .error("Missing Destructure", span)
+
+            return CheckedStatement::DestructuringDeclarationAssignment(vars: var_declarations, var_decl: None, span)
         }
-        let tuple_variable = .program.get_variable(tuple_var_id)
-        if vars.size() == inner_types.size() {
+
+        let (checked_expr, tuple_variable, checked_var_decl) = .typecheck_destructured_tuple(expr, scope_id, safety_mode, span)
+        
+        if tuple_variable.has_value() {
+            mut inner_types: [TypeId] = []
+            let tuple_type = .get_type(checked_expr.type())
+            if tuple_type is GenericInstance(args) {
+                inner_types = args
+            } else {
+                .error("Tuple being destructured should be Generic Instance", span)
+            }
+
+            let tuple_expression = ParsedExpression::Var(name: tuple_variable!.name, span)
+
+            if declaration_type is Assign {
+                var_assignments = .collect_destructuring_assignments(var_assignments, tuple_expression, checked_expr, vars: values, var_types: inner_types, scope_id, safety_mode, span)
+            } else {
+                let is_mutable = match declaration_type {
+                    DestructuringDeclarationType::Mutable => true
+                    else => false
+                }
+
+                var_declarations = .collect_destructuring_declarations(var_declarations, tuple_expression, checked_expr, vars: values, var_types: inner_types, is_mutable, scope_id, safety_mode, span)
+            }
+        }
+
+        if declaration_type is Assign {
+            return CheckedStatement::DestructuringAssignment(vars: var_assignments, var_decl: checked_var_decl, span)
+        }
+
+        return CheckedStatement::DestructuringDeclarationAssignment(vars: var_declarations, var_decl: checked_var_decl, span)
+    }
+
+    function collect_destructuring_assignments(mut this, mut var_assignments: [CheckedExpression], tuple_expression: ParsedExpression, checked_expr: CheckedExpression, vars: [ParsedExpression], var_types: [TypeId], scope_id: ScopeId, safety_mode: SafetyMode, span: Span) throws -> [CheckedExpression] {
+        if vars.size() == var_types.size() {
             for i in 0..vars.size() {
-                mut new_var = vars[i]
-                new_var.parsed_type = ParsedType::Name(name: .type_name(inner_types[i]), span)
-                let init = ParsedExpression::IndexedTuple(
-                    expr: ParsedExpression::Var(name: tuple_variable.name, span)
-                    index: i
-                    is_optional: false
-                    span)
-                var_decls.push(.typecheck_var_decl(var: vars[i], init, scope_id, safety_mode, span))
+                match vars[i] {
+                    Var(span: var_span) | IndexedStruct(span: var_span) => {
+                        let expr = ParsedExpression::BinaryOp(
+                            lhs: vars[i]
+                            op: BinaryOperator::Assign
+                            rhs: ParsedExpression::IndexedTuple(
+                                expr: tuple_expression
+                                index: i
+                                is_optional: false
+                                span: var_span
+                            )
+                            span: var_span
+                        )
+
+                        var_assignments.push(.typecheck_expression(expr, scope_id, safety_mode, type_hint: checked_expr.type()))
+                    }
+                    Destructure(values: inner_vars, span: tuple_span) => {
+                        let inner_tuple_expression = ParsedExpression::IndexedTuple(
+                            expr: tuple_expression
+                            index: i
+                            is_optional: false
+                            span: tuple_span
+                        )
+
+                        mut inner_types: [TypeId] = []
+                        let tuple_type = .get_type(var_types[i])
+                        if .get_type(var_types[i]) is GenericInstance(args) {
+                            inner_types = args
+                        } else {
+                            .error("Tuple being destructured should be Generic Instance", span)
+                        }
+
+                        var_assignments = .collect_destructuring_assignments(var_assignments, tuple_expression: inner_tuple_expression, checked_expr, vars: inner_vars, var_types: inner_types, scope_id, safety_mode, span: tuple_span)
+                    }
+                    else => {
+                        .error(format("Unable to destructure into type: {}", .type_name(var_types[i])), span)
+                    }
+                }
             }
         } else {
-            .error("Tuple inner types sould have same size as tuple members", span)
+            .error("Destructure inner types sould have same size as tuple being destructured", span)
         }
 
-        return CheckedStatement::DestructuringAssignment(vars: var_decls, var_decl: checked_tuple_var_decl, span)
+        return var_assignments
+    }
+
+    function collect_destructuring_declarations(mut this, mut var_declarations: [CheckedStatement], tuple_expression: ParsedExpression, checked_expr: CheckedExpression, vars: [ParsedExpression], var_types: [TypeId], is_mutable: bool, scope_id: ScopeId, safety_mode: SafetyMode, span: Span) throws -> [CheckedStatement] {
+        if vars.size() == var_types.size() {
+            for i in 0..vars.size() {
+                match vars[i] {
+                    Var(name, span: var_span) => {
+                        let parsed_var_decl = ParsedVarDecl(
+                            name: name,
+                            parsed_type: ParsedType::Empty,
+                            is_mutable,
+                            inlay_span: None,
+                            span: var_span
+                        )
+
+                        let init = ParsedExpression::IndexedTuple(
+                            expr: tuple_expression
+                            index: i
+                            is_optional: false
+                            span: var_span
+                        )
+
+                        var_declarations.push(.typecheck_var_decl(var: parsed_var_decl, init, scope_id, safety_mode, span))
+                    }
+                    Destructure(values: inner_vars, span: tuple_span) => {
+                        let inner_tuple_expression = ParsedExpression::IndexedTuple(
+                            expr: tuple_expression
+                            index: i
+                            is_optional: false
+                            span: tuple_span
+                        )
+
+                        mut inner_types: [TypeId] = []
+                        let tuple_type = .get_type(var_types[i])
+                        if .get_type(var_types[i]) is GenericInstance(args) {
+                            inner_types = args
+                        } else {
+                            .error("Tuple being destructured should be Generic Instance", span)
+                        }
+
+                        var_declarations = .collect_destructuring_declarations(var_declarations, tuple_expression: inner_tuple_expression, checked_expr, vars: inner_vars, var_types: inner_types, is_mutable, scope_id, safety_mode, span: tuple_span)
+                    }
+                    else => {
+                        .error(format("Unable to destructure into type: {}", .type_name(var_types[i])), span)
+                    }
+                }           
+            }
+        } else {
+            .error("Destructure inner types sould have same size as tuple being destructured", span)
+        }
+
+        return var_declarations
     }
 
     function typecheck_var_decl(mut this, var: ParsedVarDecl, init: ParsedExpression, scope_id: ScopeId, safety_mode: SafetyMode, span: Span) throws -> CheckedStatement {
@@ -5901,6 +6032,9 @@ struct Typechecker {
         Function(captures, params, can_throw, is_fat_arrow, return_type, block, span) => .typecheck_lambda(captures, params, can_throw, is_fat_arrow, return_type, block, span, scope_id, safety_mode)
         Try(expr, catch_block, catch_name, span) => .typecheck_try(expr, catch_block, catch_name, scope_id, safety_mode, span, type_hint)
         TryBlock(stmt, catch_block, error_name, error_span, span) => .typecheck_try_block(stmt, error_name, error_span, catch_block, scope_id, safety_mode, span)
+        Destructure => {
+            .compiler.panic("Destructure expression not typechecked individually")
+        }
         Operator => {
             .compiler.panic("idk how to handle this thing")
         }

--- a/selfhost/types.jakt
+++ b/selfhost/types.jakt
@@ -1068,7 +1068,8 @@ struct CheckedEnumVariantBinding {
 boxed enum CheckedStatement {
     Expression(expr: CheckedExpression, span: Span)
     Defer(statement: CheckedStatement, span: Span)
-    DestructuringAssignment(vars: [CheckedStatement], var_decl: CheckedStatement, span: Span)
+    DestructuringAssignment(vars: [CheckedExpression], var_decl: CheckedStatement?, span: Span)
+    DestructuringDeclarationAssignment(vars: [CheckedStatement], var_decl: CheckedStatement?, span: Span)
     VarDecl(var_id: VarId, init: CheckedExpression, span: Span)
     If(condition: CheckedExpression, then_block: CheckedBlock, else_statement: CheckedStatement?, span: Span)
     Block(block: CheckedBlock, span: Span)

--- a/tests/typechecker/destructure_immutable_variable.jakt
+++ b/tests/typechecker/destructure_immutable_variable.jakt
@@ -1,0 +1,9 @@
+/// Expect:
+/// - error: "Assignment to immutable variable"
+
+function main() {
+    mut foo = 0
+    let bar = 0
+
+    (foo, bar) = (1, 2)
+}

--- a/tests/typechecker/destructure_missing_variable.jakt
+++ b/tests/typechecker/destructure_missing_variable.jakt
@@ -1,0 +1,8 @@
+/// Expect:
+/// - error: "Variable 'bar' not found"
+
+function main() {
+    mut foo = 0
+
+    (foo, bar) = (1, 2)
+}

--- a/tests/typechecker/destructure_private.jakt
+++ b/tests/typechecker/destructure_private.jakt
@@ -1,0 +1,19 @@
+/// Expect:
+/// - error: "Can't access field ‘x’, because it is marked private"
+
+class TestClass {
+    x: i64
+    y: i64
+
+    public function make(x: i64, y: i64) throws -> TestClass {
+        return TestClass(x, y)
+    }
+}
+
+function main() {
+    let tuple = (8, 9)
+
+    let test_class = TestClass::make(x: 6, y: 7)
+
+    (test_class.x, test_class.y) = tuple
+}

--- a/tests/typechecker/invalid_nested_destructure.jakt
+++ b/tests/typechecker/invalid_nested_destructure.jakt
@@ -1,0 +1,8 @@
+/// Expect:
+/// - error: "Destructure inner types sould have same size as tuple being destructured"
+
+function main() {
+    let a = (1, (1, 2, 3))
+
+    let (b, (c, d)) = a
+}


### PR DESCRIPTION
If destructure is not preceded by `let`/`mut` existing variables will be
destructured into rather than new variables be declared.

Allow destructuring recursively for nested Tuples.

Introduced `ParsedExpression::Destructure` to be used for the 
destructure pattern to allow easier pattern matching destructures on 
enums in a future PR. Currently it takes the same form as 
`ParsedExpression::JaktTuple`.

Updated naming scheme for the Tuple being destructured to work like
anonymous lambdas to avoid naming ambiguity when the same variables are 
destructured into multiple times.