### PR TITLE
formatter: Fix space around minus

### DIFF
--- a/selfhost/formatter.jakt
+++ b/selfhost/formatter.jakt
@@ -1419,7 +1419,7 @@ struct Stage0 {
                         preceding_trivia: []
                     )
                 }
-                Identifier => {
+                Identifier | Number => {
                     if .peek(offset: -1) is Identifier and not inserted_comma {
                         // Insert a fake comma
                         .index--


### PR DESCRIPTION
This fixes the issue where `1-3+2` was formatted to `1-3 + 2` instead of `1 - 3 + 2`