### PR TITLE
formatter: Fix space after comma in enum

### DIFF
--- a/selfhost/formatter.jakt
+++ b/selfhost/formatter.jakt
@@ -538,6 +538,12 @@ struct Stage0 {
                         preceding_trivia: []
                     )
                 }
+                Comma => FormattedToken(
+                    token
+                    indent: .indent
+                    trailing_trivia: [b' ']
+                    preceding_trivia: []
+                )
                 else => FormattedToken(
                     token
                     indent: .indent


### PR DESCRIPTION
This fixes the formatter, which previously would output:

`Bar(x: i64,y: i64)`

Now outputs:

`Bar(x: i64, y: i64)`