### PR TITLE
typechecker: Use function scope as parent for generic specialization

### DIFF
--- a/samples/modules/a.jakt
+++ b/samples/modules/a.jakt
@@ -10,3 +10,9 @@ function use_cool_things() {
 function call_function(anon a: function(anon x: i64) -> i64) -> i64 {
     return a(1)
 }
+
+function module_local_call() => 2
+
+function adder<T>(x: T) -> T {
+    return x + module_local_call()
+}

--- a/samples/modules/basic_modules.jakt
+++ b/samples/modules/basic_modules.jakt
@@ -1,7 +1,6 @@
 /// Expect:
 /// - output: "not_cool\n"
 
-
 import b
 
 function main() {

--- a/samples/modules/generic_module_scope.jakt
+++ b/samples/modules/generic_module_scope.jakt
@@ -1,0 +1,10 @@
+/// Expect:
+/// - output: "4\n"
+
+import a
+
+function main() {
+    let x = a::adder(x: 2)
+
+    println("{}", x)
+}

--- a/selfhost/typechecker.jakt
+++ b/selfhost/typechecker.jakt
@@ -1102,6 +1102,7 @@ struct Typechecker {
                 return_type_span: None
                 params: []
                 generics: FunctionGenerics(
+                    base_scope_id: method_scope_id
                     base_params: []
                     params: []
                     specializations: []
@@ -1251,6 +1252,7 @@ struct Typechecker {
                 return_type_span: None
                 params: []
                 generics: FunctionGenerics(
+                    base_scope_id: function_scope_id
                     base_params: []
                     params: []
                     specializations: []
@@ -1411,6 +1413,7 @@ struct Typechecker {
                 return_type_span: func.return_type_span
                 params: []
                 generics: FunctionGenerics(
+                    base_scope_id: method_scope_id
                     base_params: []
                     params: []
                     specializations: []
@@ -1740,6 +1743,7 @@ struct Typechecker {
                                 return_type_span: None
                                 params
                                 generics: FunctionGenerics(
+                                    base_scope_id: function_scope_id
                                     base_params: params
                                     params: []
                                     specializations: []
@@ -1793,6 +1797,7 @@ struct Typechecker {
                                 return_type_span: None
                                 params: [param]
                                 generics: FunctionGenerics(
+                                    base_scope_id: function_scope_id
                                     base_params: [param]
                                     params: []
                                     specializations: []
@@ -1833,6 +1838,7 @@ struct Typechecker {
                                 return_type_span: None
                                 params: []
                                 generics: FunctionGenerics(
+                                    base_scope_id: function_scope_id
                                     base_params: []
                                     params: []
                                     specializations: []
@@ -2057,6 +2063,7 @@ struct Typechecker {
         mut base_definition = false
         if not generics.has_value() {
             generics = FunctionGenerics(
+                base_scope_id: function_scope_id
                 base_params: []
                 params: []
                 specializations: []
@@ -2221,7 +2228,7 @@ struct Typechecker {
             return
         }
         mut parsed_function = checked_function.to_parsed_function()
-        let scope_id = .create_scope(parent_scope_id, can_throw: parsed_function.can_throw, debug_name: format("function-specialization({})", parsed_function.name))
+        let scope_id = .create_scope(parent_scope_id: checked_function.generics.base_scope_id, can_throw: parsed_function.can_throw, debug_name: format("function-specialization({})", parsed_function.name))
 
         if parsed_function.generic_parameters.size() != generic_arguments.size() {
             .error(
@@ -3106,6 +3113,7 @@ struct Typechecker {
                 return_type_span: return_type.span()
                 params: checked_params
                 generics: FunctionGenerics(
+                    base_scope_id: scope_id
                     base_params: checked_params
                     params: []
                     specializations: []

--- a/selfhost/types.jakt
+++ b/selfhost/types.jakt
@@ -634,6 +634,7 @@ class CheckedFunction {
 }
 
 class FunctionGenerics {
+    public base_scope_id: ScopeId
     public base_params: [CheckedParameter]
     public params: [FunctionGenericParameter]
     public specializations: [[TypeId]]


### PR DESCRIPTION
As specializing a generic function creates a new scope in the current module, a function from another module is no longer able to make local calls within that module.

This change instead uses the original function scope as the parent when creating a new scope for specialization, allowing it to make calls local to the module it is in.