### PR TITLE
main+editors/vscode: Implement a range formatter

### DIFF
--- a/samples/modules/callback_modules.jakt
+++ b/samples/modules/callback_modules.jakt
@@ -1,3 +1,6 @@
+/// Expect:
+/// - output: "2\n"
+
 import a
 
 function main() {

--- a/selfhost/main.jakt
+++ b/selfhost/main.jakt
@@ -66,6 +66,49 @@ function indent(anon level: usize) throws -> String {
     return output
 }
 
+struct FormatRange {
+    start: usize
+    end: usize
+}
+function parse_format_range(anon range: String, anon input_file_length: usize) throws -> FormatRange? {
+    // range: <start-offset>:<end-offset>
+    // {start,end}-offset: usize
+
+    let parts = range.split(':')
+    if parts.is_empty() {
+        return FormatRange(
+            start: 0
+            end: input_file_length
+        )
+    }
+
+    let start_input = parts[0].to_uint()
+    if not start_input.has_value() {
+        return None
+    }
+
+    let start = start_input! as! usize
+    let end = match parts.size() {
+        1 => input_file_length
+        2 => {
+            let end_input = parts[1].to_uint()
+            if not end_input.has_value() {
+                return None
+            }
+
+            yield end_input! as! usize
+        }
+        else => {
+            return None
+        }
+    }
+
+    return FormatRange(
+        start
+        end
+    )
+}
+
 function main(args: [String]) {
     if args.size() <= 1 {
         eprintln("{}", usage())
@@ -117,6 +160,7 @@ function main(args: [String]) {
     let interpret_run = args_parser.flag(["-r", "--run"])
 
     let format = args_parser.flag(["-f", "--format"])
+    let input_format_range = args_parser.option(["-fr", "--format-range"]) ?? ""
 
     if args_parser.flag(["--repl"]) {
         mut repl = REPL::create()
@@ -142,7 +186,11 @@ function main(args: [String]) {
         }
 
         if not interpret_run {
-            eprintln("you can only pass one source file")
+            eprintln(
+                "Extra unknown argument '{}', you can only pass one source file (was '{}')"
+                arg
+                file_name
+            )
             eprintln("{}", usage())
             return 1
         }
@@ -196,10 +244,23 @@ function main(args: [String]) {
         }
     }
 
+    let format_range = parse_format_range(
+        range: input_format_range
+        input_file_length: compiler.current_file_contents.size()
+    )
+    if not format_range.has_value() {
+        eprintln("invalid format range '{}', expected <start>(:<end>?)", input_format_range)
+        return 1
+    }
+
     if format {
         mut on_new_line = true
         for formatted_line in Formatter::for_tokens(tokens) {
             for formatted_token in formatted_line.iterator() {
+                if not formatted_token.token.span().is_in_offset_range(start: format_range!.start, end: format_range!.end) {
+                    continue
+                }
+
                 for byte in formatted_token.preceding_trivia.iterator() {
                     print("{:c}", byte)
                 }

--- a/selfhost/parser.jakt
+++ b/selfhost/parser.jakt
@@ -733,7 +733,7 @@ boxed enum ParsedExpression {
     JaktTuple(values: [ParsedExpression], span: Span)
     Range(from: ParsedExpression?, to: ParsedExpression?, span: Span)
     ForcedUnwrap(expr: ParsedExpression, span: Span)
-    Match(expr: ParsedExpression, cases: [ParsedMatchCase], span: Span)
+    Match(expr: ParsedExpression, cases: [ParsedMatchCase], span: Span, marker_span: Span)
     EnumVariantArg(expr: ParsedExpression, arg: EnumVariantPatternArgument, enum_variant: ParsedType, span: Span)
     NamespacedVar(name: String, namespace_: [String], span: Span)
     Function(captures: [ParsedCapture], params: [ParsedParameter], can_throw: bool, return_type: ParsedType, block: ParsedBlock, span: Span)
@@ -3557,7 +3557,12 @@ struct Parser {
         let expr = .parse_expression(allow_assignments: false, allow_newlines: true)
         let cases = .parse_match_cases()
 
-        return ParsedExpression::Match(expr, cases, span: merge_spans(start, .previous().span()))
+        return ParsedExpression::Match(
+            expr
+            cases
+            span: merge_spans(start, .previous().span())
+            marker_span: start
+        )
     }
 
     function parse_match_cases(mut this) throws -> [ParsedMatchCase] {

--- a/selfhost/typechecker.jakt
+++ b/selfhost/typechecker.jakt
@@ -4610,7 +4610,7 @@ struct Typechecker {
         }
         Garbage(span) => CheckedExpression::Garbage(span)
         NamespacedVar(name, namespace_, span) => .typecheck_namespaced_var_or_simple_enum_constructor_call(name, namespace_, scope_id, safety_mode, type_hint, span)
-        Match(expr, cases, span) => .typecheck_match(expr, cases, span, scope_id, safety_mode, type_hint)
+        Match(expr, cases, marker_span) => .typecheck_match(expr, cases, span: marker_span, scope_id, safety_mode, type_hint)
         EnumVariantArg(expr: inner_expr, arg, enum_variant, span) => {
             let checked_expr = .typecheck_expression_and_dereference_if_needed(inner_expr, scope_id, safety_mode, type_hint: None, span)
             mut checked_binding = CheckedEnumVariantBinding(name: "", binding: "", type_id: unknown_type_id(), span)

--- a/selfhost/utility.jakt
+++ b/selfhost/utility.jakt
@@ -52,6 +52,8 @@ struct Span {
     function contains(this, span: Span) -> bool {
         return .file_id.equals(span.file_id) and span.start >= .start and span.end <= .end
     }
+
+    function is_in_offset_range(this, start: usize, end: usize) => start <= .start and end >= .end
 }
 
 struct FileId {


### PR DESCRIPTION
This allows us to 'format modified lines' instead of formatting the entire document.

Also contains a `match` error nicety, I got tired of having the screen light up