### PR TITLE
codegen: Add FunctionId for lambdas for correct match codegen

### DIFF
--- a/selfhost/codegen.jakt
+++ b/selfhost/codegen.jakt
@@ -1566,7 +1566,7 @@ struct CodeGenerator {
 
             yield output
         }
-        Function(captures, params, can_throw, block, return_type_id) => {
+        Function(captures, params, can_throw, block, return_type_id, pseudo_function_id) => {
             mut generated_captures: [String] = []
             for capture in captures.iterator() {
                 generated_captures.push(match capture {
@@ -1582,7 +1582,21 @@ struct CodeGenerator {
                 true => format("ErrorOr<{}>", .codegen_type(return_type_id))
                 else => .codegen_type(return_type_id)
             }
-            yield format("[{}]({}) -> {} {}", join(generated_captures, separator: ", "), join(generated_params, separator: ", "), return_type, .codegen_block(block))
+
+            mut block_output = ""
+            if pseudo_function_id.has_value() {
+                let function_ = .program.get_function(pseudo_function_id!)
+
+                let previous_function = .current_function
+                .current_function = function_
+                defer .current_function = previous_function
+
+                block_output = .codegen_block(block)
+            } else {
+                block_output = .codegen_block(block)
+            }
+
+            yield format("[{}]({}) -> {} {}", join(generated_captures, separator: ", "), join(generated_params, separator: ", "), return_type, block_output)
         }
         TryBlock(stmt, error_name, catch_block, span) => {
             mut output = ""

--- a/selfhost/interpreter.jakt
+++ b/selfhost/interpreter.jakt
@@ -361,6 +361,7 @@ function value_to_checked_expression(anon this_value: Value, anon mut interprete
             block: new_block
             span: this_value.span
             type_id
+            pseudo_function_id: None
         )
     }
     else => {

--- a/selfhost/typechecker.jakt
+++ b/selfhost/typechecker.jakt
@@ -4809,7 +4809,8 @@ struct Typechecker {
             return_type_id
             block: checked_block
             span
-            type_id)
+            type_id
+            pseudo_function_id)
     }
 
     function typecheck_namespaced_var_or_simple_enum_constructor_call(mut this, name: String, namespace_: [String], scope_id: ScopeId, safety_mode: SafetyMode, type_hint: TypeId?, span: Span) throws -> CheckedExpression {

--- a/selfhost/types.jakt
+++ b/selfhost/types.jakt
@@ -1022,7 +1022,7 @@ boxed enum CheckedExpression {
     OptionalSome(expr: CheckedExpression, span: Span, type_id: TypeId)
     ForcedUnwrap(expr: CheckedExpression, span: Span, type_id: TypeId)
     Block(block: CheckedBlock, span: Span, type_id: TypeId)
-    Function(captures: [CheckedCapture], params: [CheckedParameter], can_throw: bool, return_type_id: TypeId, block: CheckedBlock, span: Span, type_id: TypeId)
+    Function(captures: [CheckedCapture], params: [CheckedParameter], can_throw: bool, return_type_id: TypeId, block: CheckedBlock, span: Span, type_id: TypeId, pseudo_function_id: FunctionId?)
     Try(expr: CheckedExpression, catch_block: CheckedBlock?, catch_name: String?, span: Span, type_id: TypeId, inner_type_id: TypeId)
     TryBlock(stmt: CheckedStatement, catch_block: CheckedBlock, error_name: String, error_span: Span, span: Span, type_id: TypeId)
     Garbage(Span)

--- a/tests/typechecker/match_in_lambda.jakt
+++ b/tests/typechecker/match_in_lambda.jakt
@@ -1,0 +1,26 @@
+/// Expect:
+/// - output: "OK\n"
+
+enum Test {
+    A(message: String)
+    B(message: String)
+}
+
+function pass(item: Test, check: &function(anon item: Test) -> String) -> String {
+    return check(item)
+}
+
+function main() {
+    let test = Test::A(message: "OK")
+
+    let ret = pass(item: test, check: &function(anon item: Test) -> String {
+        let message_a: String = match item {
+            A(message) => message
+            B(message) => message
+        }
+
+        return message_a
+    })
+
+    println("{}", ret)
+}


### PR DESCRIPTION
Match codegen requires the current function to get the return type for the control flow part of `ExplicitValueOrControlFlow`. For a lambda we weren't updating the current function so would get the wrong return type.