### PR TITLE
lexer+formatter: Store raw number value along with NumericConstant

### DIFF
--- a/selfhost/formatter.jakt
+++ b/selfhost/formatter.jakt
@@ -1386,6 +1386,7 @@ struct Stage0 {
                 | RightArithmeticShift
                 | RightShiftEqual
                 | AmpersandEqual
+                | Ampersand
                 | PipeEqual
                 | Caret
                 | CaretEqual

--- a/selfhost/formatter.jakt
+++ b/selfhost/formatter.jakt
@@ -108,20 +108,7 @@ struct FormattedToken {
         SingleQuotedString(quote) => format("'{}'", quote)
         SingleQuotedByteString(quote) => format("b'{}'", quote)
         QuotedString(quote) => format("\"{}\"", quote)
-        Number(number) => match number {
-            I8(number) => format("{}i8", number)
-            I16(number) => format("{}i16", number)
-            I32(number) => format("{}i32", number)
-            I64(number) => format("{}i64", number)
-            U8(number) => format("{}u8", number)
-            U16(number) => format("{}u16", number)
-            U32(number) => format("{}u32", number)
-            U64(number) => format("{}u64", number)
-            USize(number) => format("{}uz", number)
-            F32(number) => format("{}f32", number)
-            F64(number) => format("{}f64", number)
-            UnknownUnsigned(number) | UnknownSigned(number) => format("{}", number)
-        }
+        Number(raw_number) => raw_number
         Identifier(name) => name
         Semicolon => ";"
         Colon => ":"

--- a/selfhost/lexer.jakt
+++ b/selfhost/lexer.jakt
@@ -19,7 +19,7 @@ enum Token {
     SingleQuotedString(quote: String, span: Span)
     SingleQuotedByteString(quote: String, span: Span)
     QuotedString(quote: String, span: Span)
-    Number(number: NumericConstant, span: Span)
+    Number(number: NumericConstant, raw_number: String, span: Span)
     Identifier(name: String, span: Span)
     Semicolon(Span)
     Colon(Span)
@@ -332,10 +332,10 @@ enum NumericConstant {
     }
 }
 
-function make_float_token(number: f64, suffix: LiteralSuffix, span: Span) throws -> Token => match suffix {
+function make_float_token(number: f64, suffix: LiteralSuffix, raw_number: String, span: Span) throws -> Token => match suffix {
     // FIXME: consider unifying with make_integer_token() to a single function
-    LiteralSuffix::F32 => Token::Number(number: NumericConstant::F32(f64_to_f32(number)), span)
-    LiteralSuffix::F64 => Token::Number(number: NumericConstant::F64(number), span)
+    LiteralSuffix::F32 => Token::Number(number: NumericConstant::F32(f64_to_f32(number)), raw_number, span)
+    LiteralSuffix::F64 => Token::Number(number: NumericConstant::F64(number), raw_number, span)
 
     else => Token::Garbage(span)
 }
@@ -517,11 +517,15 @@ struct Lexer {
     function lex_number(mut this) throws -> Token {
         let start = .index
         mut total = 0u64
+        mut raw_number = StringBuilder::create()
 
         if .peek() == b'0' {
             match .peek_ahead(1) {
                 // Hexadecimal number
                 b'x' => {
+                    raw_number.append(b'0')
+                    raw_number.append(b'x')
+                    
                     .index += 2
                     while(is_ascii_hexdigit(.peek())) {
                         mut offset: u8 = 0
@@ -530,11 +534,13 @@ struct Lexer {
                         } else if (.peek() >= b'A' and .peek() <= b'Z') {
                             offset = 7
                         }
+                        raw_number.append(.input[.index])
                         let value = .input[.index] - offset
                         ++.index
                         let digit: u64 = as_saturated(value - b'0')
                         total = total * 16 + digit
                         if .peek() == b'_' {
+                            raw_number.append(b'_')
                             ++.index
                         }
                     }
@@ -549,19 +555,29 @@ struct Lexer {
                         return Token::Garbage(span)
                     }
 
-                    let suffix = .consume_numeric_literal_suffix() ?? LiteralSuffix::None
+                    mut suffix = LiteralSuffix::None
+                    let (consumed_suffix, raw_suffix) = .consume_numeric_literal_suffix()
+                    if not consumed_suffix is None {
+                        suffix = consumed_suffix
+                    }
+                    raw_number.append_string(raw_suffix.to_string())
 
-                    return .make_integer_token(number: total, suffix, span: .span(start, end))
+                    return .make_integer_token(number: total, suffix, raw_number: raw_number.to_string(), span: .span(start, end))
                 }
                 // Octal Number
                 b'o' => {
+                    raw_number.append(b'0')
+                    raw_number.append(b'o')
+
                     .index += 2
                     while(is_ascii_octdigit(.peek())) {
                         let value = .input[.index]
+                        raw_number.append(value)
                         ++.index
                         let digit: u64 = as_saturated(value - b'0')
                         total = total * 8 + digit
                         if .peek() == b'_' {
+                            raw_number.append(b'_')
                             ++.index
                         }
                     }
@@ -576,7 +592,12 @@ struct Lexer {
                         return Token::Garbage(span)
                     }
 
-                    let suffix = .consume_numeric_literal_suffix() ?? LiteralSuffix::None
+                    mut suffix = LiteralSuffix::None
+                    let (consumed_suffix, raw_suffix) = .consume_numeric_literal_suffix()
+                    if not consumed_suffix is None {
+                        suffix = consumed_suffix
+                    }
+                    raw_number.append_string(raw_suffix.to_string())
 
                     if is_ascii_alphanumeric(.peek()) {
                         .error(
@@ -586,17 +607,22 @@ struct Lexer {
                         return Token::Garbage(span)
                     }
 
-                    return .make_integer_token(number: total, suffix, span)
+                    return .make_integer_token(number: total, suffix, raw_number: raw_number.to_string(), span)
                 }
                 // Binary Number
                 b'b' => {
+                    raw_number.append(b'0')
+                    raw_number.append(b'b')
+
                     .index += 2
                     while(.peek() == b'0' or .peek() == b'1') {
                         let value = .input[.index]
+                        raw_number.append(value)
                         ++.index
                         let digit: u64 = as_saturated(value - b'0')
                         total = total * 2 + digit
                         if .peek() == b'_' {
+                            raw_number.append(b'_')
                             ++.index
                         }
                     }
@@ -611,7 +637,12 @@ struct Lexer {
                         return Token::Garbage(span)
                     }
 
-                    let suffix = .consume_numeric_literal_suffix() ?? LiteralSuffix::None
+                    mut suffix = LiteralSuffix::None
+                    let (consumed_suffix, raw_suffix) = .consume_numeric_literal_suffix()
+                    if not consumed_suffix is None {
+                        suffix = consumed_suffix
+                    }
+                    raw_number.append_string(raw_suffix.to_string())
 
                     if is_ascii_alphanumeric(.peek()) {
                         .error(
@@ -622,7 +653,7 @@ struct Lexer {
                         return Token::Garbage(span)
                     }
 
-                    return .make_integer_token(number: total, suffix, span)
+                    return .make_integer_token(number: total, suffix, raw_number: raw_number.to_string(), span)
                 }
                 else => {}
             }
@@ -635,13 +666,13 @@ struct Lexer {
         mut fraction_denominator: u64 = 1
 
         while not .eof() {
-
             let value = .input[.index]
 
             if value == b'.' {
                 if not is_ascii_digit(.peek_ahead(1)) or floating {
                     break
                 }
+                raw_number.append(b'.')
                 floating = true
                 .index++
                 continue
@@ -649,8 +680,9 @@ struct Lexer {
                 break
             }
 
-            ++.index
+            raw_number.append(value)
 
+            ++.index
             let digit: u64 = as_saturated(value - b'0')
             if not floating {
                 // NOTE: We use unchecked arithmetic here to see if the number is too large
@@ -664,7 +696,10 @@ struct Lexer {
                 fraction_nominator = fraction_nominator * 10u64 + digit
                 fraction_denominator *= 10u64
             }
+
             if .peek() == b'_' {
+                raw_number.append(b'_')
+
                 if is_ascii_digit(.peek_ahead(1)) {
                     ++.index
                 } else {
@@ -694,7 +729,13 @@ struct Lexer {
             true => LiteralSuffix::F64
             else => LiteralSuffix::None
         }
-        let suffix = .consume_numeric_literal_suffix() ?? default_suffix
+
+        mut suffix = default_suffix
+        let (consumed_suffix, raw_suffix) = .consume_numeric_literal_suffix()
+        if not consumed_suffix is None {
+            suffix = consumed_suffix
+        }
+        raw_number.append_string(raw_suffix.to_string())
 
         if is_ascii_alphanumeric(.peek()) {
             .error(
@@ -718,74 +759,103 @@ struct Lexer {
         return match suffix {
             LiteralSuffix::F32 | LiteralSuffix::F64 => {
                 let number: f64 = u64_to_float<f64>(total) + u64_to_float<f64>(fraction_nominator)/u64_to_float<f64>(fraction_denominator)
-                yield make_float_token(number, suffix, span: .span(start, end))
+                yield make_float_token(number, suffix, raw_number: raw_number.to_string(), span: .span(start, end))
             }
-            else => .make_integer_token(number: total, suffix, span: .span(start, end))
+            else => .make_integer_token(number: total, suffix, raw_number: raw_number.to_string(), span: .span(start, end))
         }
     }
 
+    function consume_numeric_literal_suffix(mut this) throws -> (LiteralSuffix, StringBuilder) {
+        mut raw_suffix = StringBuilder::create()
 
-    function consume_numeric_literal_suffix(mut this) -> LiteralSuffix? {
         match .peek() {
             b'u' | b'i' | b'f' => {}
             else => {
-                return None
+                // FIXME: Ideally could return LiteralSuffix::None directly in the tuple instead of creating a varible
+                let suffix = LiteralSuffix::None
+                return (suffix, raw_suffix)
             }
         }
 
         if .peek() == b'u' and .peek_ahead(1) == b'z' {
+            raw_suffix.append(b'u')
+            raw_suffix.append(b'z')
             .index += 2
-            return LiteralSuffix::UZ
+
+            let suffix = LiteralSuffix::UZ
+            return (suffix, raw_suffix)
         }
 
         mut local_index = 1uz
         mut width = 0i64
 
+        mut raw_digits = StringBuilder::create()
         while is_ascii_digit(.peek_ahead(local_index)) {
             // Make sure we don't overflow the width
             if local_index > 3 {
-                return None
+                let suffix = LiteralSuffix::None
+                return (suffix, raw_suffix)
             }
 
             let value = .input[.index + local_index]
+            raw_digits.append(value)
             ++local_index
             let digit: i64 = as_saturated(value - b'0')
             width = width * 10 + digit
         }
 
         let suffix = match .peek() {
-            b'u' => match width {
-                8 => LiteralSuffix::U8
-                16 => LiteralSuffix::U16
-                32 => LiteralSuffix::U32
-                64 => LiteralSuffix::U64
-                else => {
-                    return None
+            b'u' => {
+                raw_suffix.append(b'u')
+
+                yield match width {
+                    8 => LiteralSuffix::U8
+                    16 => LiteralSuffix::U16
+                    32 => LiteralSuffix::U32
+                    64 => LiteralSuffix::U64
+                    else => {
+                        let suffix = LiteralSuffix::None
+                        return (suffix, raw_suffix)
+                    }
                 }
             }
-            b'i' => match width {
-                8 => LiteralSuffix::I8
-                16 => LiteralSuffix::I16
-                32 => LiteralSuffix::I32
-                64 => LiteralSuffix::I64
-                else => {
-                    return None
+            b'i' => {
+                raw_suffix.append(b'i')
+
+                yield match width {
+                    8 => LiteralSuffix::I8
+                    16 => LiteralSuffix::I16
+                    32 => LiteralSuffix::I32
+                    64 => LiteralSuffix::I64
+                    else => {
+                        let suffix = LiteralSuffix::None
+                        return (suffix, raw_suffix)
+                    }
                 }
             }
-            b'f' => match width {
-                32 => LiteralSuffix::F32
-                64 => LiteralSuffix::F64
-                else => {
-                    return None
+            b'f' => {
+                raw_suffix.append(b'f')
+
+                yield match width {
+                    32 => LiteralSuffix::F32
+                    64 => LiteralSuffix::F64
+                    else => {
+                        let suffix = LiteralSuffix::None
+                        return (suffix, raw_suffix)
+                    }
                 }
             }
             else => {
-                return None
+                let suffix = LiteralSuffix::None
+                return (suffix, raw_suffix)
             }
         }
 
+        raw_suffix.append_string(raw_digits.to_string())
+
         .index += local_index
-        return suffix
+
+        return (suffix, raw_suffix)
     }
 
 
@@ -1077,87 +1147,87 @@ struct Lexer {
         return ch == b' ' or ch == b'\t' or ch == b'\r' or ch == b'\f' or ch == b'\v'
     }    
 
-    function make_integer_token(mut this, number: u64, suffix: LiteralSuffix, span: Span) throws -> Token {
+    function make_integer_token(mut this, number: u64, suffix: LiteralSuffix, raw_number: String, span: Span) throws -> Token {
         // FIXME: consider unifying with make_float_token() to a single function
         match suffix {
             None => {
                 let n = number as? i64
                 if n.has_value() {
-                    return Token::Number(number: NumericConstant::UnknownSigned(n!), span)
+                    return Token::Number(number: NumericConstant::UnknownSigned(n!), raw_number, span)
                 }
-                return Token::Number(number: NumericConstant::UnknownUnsigned(number), span)
+                return Token::Number(number: NumericConstant::UnknownUnsigned(number), raw_number, span)
             }
             U8 => {
                 let n = number as? u8
                 if not n.has_value() {
                     .error(format("Number {} cannot fit in integer type {}", number, suffix), span)
-                    return Token::Number(number: NumericConstant::U64(number), span)
+                    return Token::Number(number: NumericConstant::U64(number), raw_number, span)
                 }
-                return Token::Number(number: NumericConstant::U8(n!), span)
+                return Token::Number(number: NumericConstant::U8(n!), raw_number, span)
             }
             U16 => {
                 let n = number as? u16
                 if not n.has_value() {
                     .error(format("Number {} cannot fit in integer type {}", number, suffix), span)
-                    return Token::Number(number: NumericConstant::U64(number), span)
+                    return Token::Number(number: NumericConstant::U64(number), raw_number, span)
                 }
-                return Token::Number(number: NumericConstant::U16(n!), span)
+                return Token::Number(number: NumericConstant::U16(n!), raw_number, span)
             }
             U32 => {
                 let n = number as? u32
                 if not n.has_value() {
                     .error(format("Number {} cannot fit in integer type {}", number, suffix), span)
-                    return Token::Number(number: NumericConstant::U64(number), span)
+                    return Token::Number(number: NumericConstant::U64(number), raw_number, span)
                 }
-                return Token::Number(number: NumericConstant::U32(n!), span)
+                return Token::Number(number: NumericConstant::U32(n!), raw_number, span)
             }
             U64 => {
                 let n = number as? u64
                 if not n.has_value() {
                     .error(format("Number {} cannot fit in integer type {}", number, suffix), span)
-                    return Token::Number(number: NumericConstant::U64(number), span)
+                    return Token::Number(number: NumericConstant::U64(number), raw_number, span)
                 }
-                return Token::Number(number: NumericConstant::U64(n!), span)
+                return Token::Number(number: NumericConstant::U64(n!), raw_number, span)
             }
             UZ => {
                 let n = number as? usize
                 if not n.has_value() {
                     .error(format("Number {} cannot fit in integer type {}", number, suffix), span)
-                    return Token::Number(number: NumericConstant::U64(number), span)
+                    return Token::Number(number: NumericConstant::U64(number), raw_number, span)
                 }
-                return Token::Number(number: NumericConstant::USize(n! as! u64), span)
+                return Token::Number(number: NumericConstant::USize(n! as! u64), raw_number, span)
             }
             I8 => {
                 let n = number as? i8
                 if not n.has_value() {
                     .error(format("Number {} cannot fit in integer type {}", number, suffix), span)
-                    return Token::Number(number: NumericConstant::U64(number), span)
+                    return Token::Number(number: NumericConstant::U64(number), raw_number, span)
                 }
-                return Token::Number(number: NumericConstant::I8(n!), span)
+                return Token::Number(number: NumericConstant::I8(n!), raw_number, span)
             }
             I16 => {
                 let n = number as? i16
                 if not n.has_value() {
                     .error(format("Number {} cannot fit in integer type {}", number, suffix), span)
-                    return Token::Number(number: NumericConstant::U64(number), span)
+                    return Token::Number(number: NumericConstant::U64(number), raw_number, span)
                 }
-                return Token::Number(number: NumericConstant::I16(n!), span)
+                return Token::Number(number: NumericConstant::I16(n!), raw_number, span)
             }
             I32 => {
                 let n = number as? i32
                 if not n.has_value() {
                     .error(format("Number {} cannot fit in integer type {}", number, suffix), span)
-                    return Token::Number(number: NumericConstant::U64(number), span)
+                    return Token::Number(number: NumericConstant::U64(number), raw_number, span)
                 }
-                return Token::Number(number: NumericConstant::I32(n!), span)
+                return Token::Number(number: NumericConstant::I32(n!), raw_number, span)
             }
             I64 => {
                 let n = number as? i64
                 if not n.has_value() {
                     .error(format("Number {} cannot fit in integer type {}", number, suffix), span)
-                    return Token::Number(number: NumericConstant::U64(number), span)
+                    return Token::Number(number: NumericConstant::U64(number), raw_number, span)
                 }
-                return Token::Number(number: NumericConstant::I64(n!), span)
+                return Token::Number(number: NumericConstant::I64(n!), raw_number, span)
             }
             else => {}
         }


### PR DESCRIPTION
This allows the formatter to use the raw number value in the source
rather than the parsed `NumericConstant` when formatting.

Also fixed bitwise-and spacing.