### PR TITLE
all: Change fancy quotes to backticks

### DIFF
--- a/bootstrap/stage0/jakt.cpp
+++ b/bootstrap/stage0/jakt.cpp
@@ -8740,7 +8740,7 @@ return JaktInternal::ExplicitValue(({ Optional<NonnullRefPtr<parser::ParsedState
 ((((*this).index)++));
 const NonnullRefPtr<parser::ParsedExpression> expr = TRY((((*this).parse_expression(false,false))));
 if ((!(inside_block))){
-TRY((((*this).error(String("‘yield’ can only be used inside a block"),TRY((parser::merge_spans(start,((expr)->span()))))))));
+TRY((((*this).error(String("`yield` can only be used inside a block"),TRY((parser::merge_spans(start,((expr)->span()))))))));
 }
 __jakt_var_15 = TRY((parser::ParsedStatement::template create<typename parser::ParsedStatement::Yield>(expr,TRY((parser::merge_spans(start,((((*this).previous())).span()))))))); goto __jakt_label_13;
 
@@ -9169,7 +9169,7 @@ if (((((*this).current())).index() == 69 /* Enum */)){
 ((((*this).index)++));
 }
 else {
-TRY((((*this).error(String("Expected ‘enum’ keyword"),((((*this).current())).span())))));
+TRY((((*this).error(String("Expected `enum` keyword"),((((*this).current())).span())))));
 return (parsed_enum);
 }
 
@@ -10357,7 +10357,7 @@ if (((((*this).current())).index() == 77 /* In */)){
 ((((*this).index)++));
 }
 else {
-TRY((((*this).error(String("Expected ‘in’"),((((*this).current())).span())))));
+TRY((((*this).error(String("Expected `in`"),((((*this).current())).span())))));
 return (TRY((parser::ParsedStatement::template create<typename parser::ParsedStatement::Garbage>(TRY((parser::merge_spans(start_span,((((*this).current())).span()))))))));
 }
 
@@ -10451,15 +10451,15 @@ case 59: {
 auto&& __jakt_match_value = __jakt_match_variant.template get<typename lexer::Token::Anon>();
 {
 if ((parameter_complete && (!(error)))){
-TRY((((*this).error(String("‘anon’ must appear at start of parameter declaration, not the end"),((((*this).current())).span())))));
+TRY((((*this).error(String("`anon` must appear at start of parameter declaration, not the end"),((((*this).current())).span())))));
 (error = true);
 }
 if ((current_param_is_mutable && (!(error)))){
-TRY((((*this).error(String("‘anon’ must appear before ‘mut’"),((((*this).current())).span())))));
+TRY((((*this).error(String("`anon` must appear before `mut`"),((((*this).current())).span())))));
 (error = true);
 }
 if (((!(current_param_requires_label)) && (!(error)))){
-TRY((((*this).error(String("‘anon’ cannot appear multiple times in one parameter declaration"),((((*this).current())).span())))));
+TRY((((*this).error(String("`anon` cannot appear multiple times in one parameter declaration"),((((*this).current())).span())))));
 (error = true);
 }
 ((((*this).index)++));
@@ -10471,11 +10471,11 @@ case 82: {
 auto&& __jakt_match_value = __jakt_match_variant.template get<typename lexer::Token::Mut>();
 {
 if ((parameter_complete && (!(error)))){
-TRY((((*this).error(String("‘mut’ must appear at start of parameter declaration, not the end"),((((*this).current())).span())))));
+TRY((((*this).error(String("`mut` must appear at start of parameter declaration, not the end"),((((*this).current())).span())))));
 (error = true);
 }
 if ((current_param_is_mutable && (!(error)))){
-TRY((((*this).error(String("‘mut’ cannot appear multiple times in one parameter declaration"),((((*this).current())).span())))));
+TRY((((*this).error(String("`mut` cannot appear multiple times in one parameter declaration"),((((*this).current())).span())))));
 (error = true);
 }
 ((((*this).index)++));
@@ -10641,7 +10641,7 @@ ErrorOr<JaktInternal::Array<parser::ParsedMatchCase>> parser::Parser::parse_matc
 JaktInternal::Array<parser::ParsedMatchCase> cases = (TRY((Array<parser::ParsedMatchCase>::create_with({}))));
 ((*this).skip_newlines());
 if ((!(((((*this).current())).index() == 10 /* LCurly */)))){
-TRY((((*this).error(String("Expected ‘{’"),((((*this).current())).span())))));
+TRY((((*this).error(String("Expected `{`"),((((*this).current())).span())))));
 return (cases);
 }
 ((((*this).index)++));
@@ -10655,7 +10655,7 @@ if (((((*this).current())).index() == 56 /* FatArrow */)){
 ((((*this).index)++));
 }
 else {
-TRY((((*this).error(String("Expected ‘=>’"),((((*this).current())).span())))));
+TRY((((*this).error(String("Expected `=>`"),((((*this).current())).span())))));
 }
 
 ((*this).skip_newlines());
@@ -10697,7 +10697,7 @@ if ((((((*this).current())).index() == 54 /* Eol */) || ((((*this).current())).i
 }
 ((*this).skip_newlines());
 if ((!(((((*this).current())).index() == 11 /* RCurly */)))){
-TRY((((*this).error(String("Expected ‘}’"),((((*this).current())).span())))));
+TRY((((*this).error(String("Expected `}`"),((((*this).current())).span())))));
 }
 ((((*this).index)++));
 return (cases);
@@ -10756,7 +10756,7 @@ ErrorOr<NonnullRefPtr<parser::ParsedExpression>> parser::Parser::parse_array_or_
 bool is_dictionary = false;
 const utility::Span start = ((((*this).current())).span());
 if ((!(((((*this).current())).index() == 12 /* LSquare */)))){
-TRY((((*this).error(String("Expected ‘[’"),((((*this).current())).span())))));
+TRY((((*this).error(String("Expected `[`"),((((*this).current())).span())))));
 return (TRY((parser::ParsedExpression::template create<typename parser::ParsedExpression::Garbage>(((((*this).current())).span())))));
 }
 ((((*this).index)++));
@@ -10814,7 +10814,7 @@ if (((((*this).current())).index() == 13 /* RSquare */)){
 return JaktInternal::LoopBreak{};
 }
 else {
-TRY((((*this).error(String("Expected ‘]’"),((((*this).current())).span())))));
+TRY((((*this).error(String("Expected `]`"),((((*this).current())).span())))));
 }
 
 }
@@ -10856,7 +10856,7 @@ return JaktInternal::ExplicitValue<void>();
 }
 const size_t end = (JaktInternal::checked_sub<size_t>(((*this).index),static_cast<size_t>(1ULL)));
 if (((end >= ((((*this).tokens)).size())) || (!(((((((*this).tokens))[end])).index() == 13 /* RSquare */))))){
-TRY((((*this).error(String("Expected ‘]’ to close the array"),((((((*this).tokens))[end])).span())))));
+TRY((((*this).error(String("Expected `]` to close the array"),((((((*this).tokens))[end])).span())))));
 }
 if (is_dictionary){
 return (TRY((parser::ParsedExpression::template create<typename parser::ParsedExpression::JaktDictionary>(dict_output,TRY((parser::merge_spans(start,((((((*this).tokens))[end])).span()))))))));
@@ -10976,7 +10976,7 @@ __jakt_label_51:; __jakt_var_53.release_value(); }));
 };/*case end*/
 default: {
 return JaktInternal::ExplicitValue(({ Optional<parser::ParsedMatchPattern> __jakt_var_54; {
-TRY((((*this).error(String("Expected pattern or ‘else’"),((((*this).current())).span())))));
+TRY((((*this).error(String("Expected pattern or `else`"),((((*this).current())).span())))));
 __jakt_var_54 = typename parser::ParsedMatchPattern::CatchAll(); goto __jakt_label_52;
 
 }
@@ -11046,7 +11046,7 @@ if (((((*this).current())).index() == 10 /* LCurly */)){
 ((((*this).index)++));
 }
 else {
-TRY((((*this).error(String("Expected ‘{’"),((((*this).current())).span())))));
+TRY((((*this).error(String("Expected `{`"),((((*this).current())).span())))));
 }
 
 JaktInternal::Array<parser::ParsedField> fields = (TRY((Array<parser::ParsedField>::create_with({}))));
@@ -11129,7 +11129,7 @@ const parser::Visibility visibility = last_visibility.value_or_lazy_evaluated([&
 (last_visibility = JaktInternal::OptionalNone());
 (last_visibility_span = JaktInternal::OptionalNone());
 if ((last_virtual || last_override)){
-TRY((((*this).error(String("Fields cannot be ‘virtual’ or ‘override’"),((((*this).current())).span())))));
+TRY((((*this).error(String("Fields cannot be `virtual` or `override`"),((((*this).current())).span())))));
 }
 (last_virtual = false);
 (last_override = false);
@@ -11235,10 +11235,10 @@ return JaktInternal::ExplicitValue<void>();
 ));
 }
 if (is_class){
-TRY((((*this).error(String("Incomplete class body, expected ‘}’"),((((*this).current())).span())))));
+TRY((((*this).error(String("Incomplete class body, expected `}`"),((((*this).current())).span())))));
 }
 else {
-TRY((((*this).error(String("Incomplete struct body, expected ‘}’"),((((*this).current())).span())))));
+TRY((((*this).error(String("Incomplete struct body, expected `}`"),((((*this).current())).span())))));
 }
 
 return ((Tuple{fields, methods}));
@@ -11335,7 +11335,7 @@ const utility::Span span = ((((*this).current())).span());
 TRY((((variant_arguments).push(parser::EnumVariantPatternArgument(static_cast<JaktInternal::Optional<String>>(arg_name),arg_binding,span)))));
 }
 else {
-TRY((((*this).error(String("Expected binding after ‘:’"),((((*this).current())).span())))));
+TRY((((*this).error(String("Expected binding after `:`"),((((*this).current())).span())))));
 }
 
 }
@@ -11382,7 +11382,7 @@ ErrorOr<NonnullRefPtr<parser::ParsedExpression>> parser::Parser::parse_set_liter
 {
 const utility::Span start = ((((*this).current())).span());
 if ((!(((((*this).current())).index() == 10 /* LCurly */)))){
-TRY((((*this).error(String("Expected ‘{’"),((((*this).current())).span())))));
+TRY((((*this).error(String("Expected `{`"),((((*this).current())).span())))));
 return (TRY((parser::ParsedExpression::template create<typename parser::ParsedExpression::Garbage>(((((*this).current())).span())))));
 }
 ((((*this).index)++));
@@ -11428,7 +11428,7 @@ return JaktInternal::ExplicitValue<void>();
 }
 const size_t end = (JaktInternal::checked_sub<size_t>(((*this).index),static_cast<size_t>(1ULL)));
 if (((end >= ((((*this).tokens)).size())) || (!(((((((*this).tokens))[end])).index() == 11 /* RCurly */))))){
-TRY((((*this).error(String("Expected ‘}’ to close the set"),((((((*this).tokens))[end])).span())))));
+TRY((((*this).error(String("Expected `}` to close the set"),((((((*this).tokens))[end])).span())))));
 }
 return (TRY((parser::ParsedExpression::template create<typename parser::ParsedExpression::Set>(output,TRY((parser::merge_spans(start,((((((*this).tokens))[end])).span()))))))));
 }
@@ -11529,7 +11529,7 @@ if (((((*this).current())).index() == 10 /* LCurly */)){
 ((((*this).index)++));
 }
 else {
-TRY((((*this).error(String("Expected ‘{’"),((((*this).current())).span())))));
+TRY((((*this).error(String("Expected `{`"),((((*this).current())).span())))));
 }
 
 parser::ParsedNamespace namespace_ = TRY((((*this).parse_namespace())));
@@ -11912,7 +11912,7 @@ break;
 }
 TRY((((types).push(type))));
 }
-TRY((((*this).error(String("Expected ‘)’"),((((*this).current())).span())))));
+TRY((((*this).error(String("Expected `)`"),((((*this).current())).span())))));
 return (TRY((parser::ParsedType::template create<typename parser::ParsedType::Empty>())));
 }
 }
@@ -12095,7 +12095,7 @@ return {};
 ErrorOr<NonnullRefPtr<parser::ParsedStatement>> parser::Parser::parse_if_statement() {
 {
 if ((!(((((*this).current())).index() == 75 /* If */)))){
-TRY((((*this).error(String("Expected ‘if’ statement"),((((*this).current())).span())))));
+TRY((((*this).error(String("Expected `if` statement"),((((*this).current())).span())))));
 return (TRY((parser::ParsedStatement::template create<typename parser::ParsedStatement::Garbage>(((((*this).current())).span())))));
 }
 const utility::Span start_span = ((((*this).current())).span());
@@ -12130,7 +12130,7 @@ return JaktInternal::ExplicitValue<void>();
 };/*case end*/
 default: {
 {
-TRY((((*this).error(String("‘else’ missing ‘if’ or block"),((((*this).previous())).span())))));
+TRY((((*this).error(String("`else` missing `if` or block"),((((*this).previous())).span())))));
 }
 return JaktInternal::ExplicitValue<void>();
 };/*case end*/
@@ -12342,7 +12342,7 @@ if (((((*this).current())).index() == 8 /* LParen */)){
 ((((*this).index)++));
 }
 else {
-TRY((((*this).error(String("Expected ‘(’"),((((*this).current())).span())))));
+TRY((((*this).error(String("Expected `(`"),((((*this).current())).span())))));
 }
 
 JaktInternal::Array<NonnullRefPtr<parser::ParsedType>> whitelist = (TRY((Array<NonnullRefPtr<parser::ParsedType>>::create_with({}))));
@@ -12397,7 +12397,7 @@ if (((((*this).current())).index() == 9 /* RParen */)){
 ((((*this).index)++));
 }
 else {
-TRY((((*this).error(String("Expected ‘)’"),((((*this).current())).span())))));
+TRY((((*this).error(String("Expected `)`"),((((*this).current())).span())))));
 }
 
 return (typename parser::Visibility::Restricted(whitelist,restricted_span));
@@ -12469,7 +12469,7 @@ const String name = (((*this).current()).get<lexer::Token::Identifier>()).name;
 }
 }
 else {
-TRY((((*this).error(String("Expected ‘catch’"),((((*this).current())).span())))));
+TRY((((*this).error(String("Expected `catch`"),((((*this).current())).span())))));
 }
 
 const parser::ParsedBlock catch_block = TRY((((*this).parse_block())));
@@ -12666,7 +12666,7 @@ const bool is_optional = ((((*this).current())).index() == 48 /* QuestionMark */
 if (is_optional){
 ((((*this).index)++));
 if ((!(((((*this).current())).index() == 52 /* Dot */)))){
-TRY((((*this).error(String("Expected ‘.’ after ‘?’ for optional chaining access"),((((*this).current())).span())))));
+TRY((((*this).error(String("Expected `.` after `?` for optional chaining access"),((((*this).current())).span())))));
 }
 }
 ((((*this).index)++));
@@ -12733,7 +12733,7 @@ const bool is_optional = ((((*this).current())).index() == 48 /* QuestionMark */
 if (is_optional){
 ((((*this).index)++));
 if ((!(((((*this).current())).index() == 52 /* Dot */)))){
-TRY((((*this).error(String("Expected ‘.’ after ‘?’ for optional chaining access"),((((*this).current())).span())))));
+TRY((((*this).error(String("Expected `.` after `?` for optional chaining access"),((((*this).current())).span())))));
 }
 }
 ((((*this).index)++));
@@ -38053,7 +38053,7 @@ break;
 JaktInternal::Tuple<String,types::Value> existing = (_magic_value.value());
 {
 if ((name == ((existing).get<0>()))){
-TRY((((*this).error_with_hint(TRY((String::formatted(String("Redefinition of comptime variable ‘{}’"),name))),span,String("previous definition here"),((((existing).get<1>())).span)))));
+TRY((((*this).error_with_hint(TRY((String::formatted(String("Redefinition of comptime variable `{}`"),name))),span,String("previous definition here"),((((existing).get<1>())).span)))));
 }
 }
 
@@ -38088,7 +38088,7 @@ else if (((enum_in_scope).has_value())){
 (next_scope = ((((*this).get_enum((enum_in_scope.value())))).scope_id));
 }
 else {
-TRY((((*this).error(TRY((String::formatted(String("Namespace ‘{}’ not found"),ns))),span))));
+TRY((((*this).error(TRY((String::formatted(String("Namespace `{}` not found"),ns))),span))));
 }
 
 TRY((((scopes).push(next_scope))));
@@ -38421,7 +38421,7 @@ else {
 if (((maybe_type_and_scope).has_value())){
 return ((((maybe_type_and_scope.value())).get<0>()));
 }
-TRY((((*this).error(TRY((String::formatted(String("Unknown type ‘{}’"),name))),span))));
+TRY((((*this).error(TRY((String::formatted(String("Unknown type `{}`"),name))),span))));
 return (types::unknown_type_id());
 }
 }
@@ -38795,7 +38795,7 @@ ErrorOr<NonnullRefPtr<types::CheckedStatement>> typechecker::Typechecker::typech
 {
 const types::CheckedBlock checked_block = TRY((((*this).typecheck_block(parsed_block,scope_id,safety_mode,JaktInternal::OptionalNone()))));
 if (((((checked_block).yielded_type)).has_value())){
-TRY((((*this).error(String("A ‘loop’ block is not allowed to yield values"),(((parsed_block).find_yield_span()).value())))));
+TRY((((*this).error(String("A `loop` block is not allowed to yield values"),(((parsed_block).find_yield_span()).value())))));
 }
 return (TRY((types::CheckedStatement::template create<typename types::CheckedStatement::Loop>(checked_block,span))));
 }
@@ -38812,7 +38812,7 @@ const NonnullRefPtr<types::CheckedStatement> checked_statement = TRY((((*this).t
 if (((checked_statement)->index() == 5 /* Block */)){
 const types::CheckedBlock block = (checked_statement->get<types::CheckedStatement::Block>()).block;
 if (((((block).yielded_type)).has_value())){
-TRY((((*this).error(String("‘yield’ inside ‘defer’ is meaningless"),span))));
+TRY((((*this).error(String("`yield` inside `defer` is meaningless"),span))));
 }
 }
 return (TRY((types::CheckedStatement::template create<typename types::CheckedStatement::Defer>(checked_statement,span))));
@@ -39088,15 +39088,15 @@ return (inner_type_id);
 }
 }
 else {
-TRY((((*this).error_with_hint(TRY((String::formatted(String("None coalescing (??) with incompatible types (‘{}’ and ‘{}’)"),TRY((((*this).type_name(lhs_type_id)))),TRY((((*this).type_name(rhs_type_id))))))),span,String("Left side of ?? must be an Optional but isn't"),lhs_span))));
+TRY((((*this).error_with_hint(TRY((String::formatted(String("None coalescing (??) with incompatible types (`{}` and `{}`)"),TRY((((*this).type_name(lhs_type_id)))),TRY((((*this).type_name(rhs_type_id))))))),span,String("Left side of ?? must be an Optional but isn't"),lhs_span))));
 }
 
 }
 else {
-TRY((((*this).error_with_hint(TRY((String::formatted(String("None coalescing (??) with incompatible types (‘{}’ and ‘{}’)"),TRY((((*this).type_name(lhs_type_id)))),TRY((((*this).type_name(rhs_type_id))))))),span,String("Left side of ?? must be an Optional but isn't"),lhs_span))));
+TRY((((*this).error_with_hint(TRY((String::formatted(String("None coalescing (??) with incompatible types (`{}` and `{}`)"),TRY((((*this).type_name(lhs_type_id)))),TRY((((*this).type_name(rhs_type_id))))))),span,String("Left side of ?? must be an Optional but isn't"),lhs_span))));
 }
 
-TRY((((*this).error(TRY((String::formatted(String("None coalescing (??) with incompatible types (‘{}’ and ‘{}’)"),TRY((((*this).type_name(lhs_type_id)))),TRY((((*this).type_name(rhs_type_id))))))),span))));
+TRY((((*this).error(TRY((String::formatted(String("None coalescing (??) with incompatible types (`{}` and `{}`)"),TRY((((*this).type_name(lhs_type_id)))),TRY((((*this).type_name(rhs_type_id))))))),span))));
 return (lhs_type_id);
 }
 return JaktInternal::ExplicitValue<void>();
@@ -39132,15 +39132,15 @@ return (inner_type_id);
 }
 }
 else {
-TRY((((*this).error_with_hint(TRY((String::formatted(String("None coalescing (??) with incompatible types (‘{}’ and ‘{}’)"),TRY((((*this).type_name(lhs_type_id)))),TRY((((*this).type_name(rhs_type_id))))))),span,String("Left side of ?? must be an Optional but isn't"),lhs_span))));
+TRY((((*this).error_with_hint(TRY((String::formatted(String("None coalescing (??) with incompatible types (`{}` and `{}`)"),TRY((((*this).type_name(lhs_type_id)))),TRY((((*this).type_name(rhs_type_id))))))),span,String("Left side of ?? must be an Optional but isn't"),lhs_span))));
 }
 
 }
 else {
-TRY((((*this).error_with_hint(TRY((String::formatted(String("None coalescing (??) with incompatible types (‘{}’ and ‘{}’)"),TRY((((*this).type_name(lhs_type_id)))),TRY((((*this).type_name(rhs_type_id))))))),span,String("Left side of ?? must be an Optional but isn't"),lhs_span))));
+TRY((((*this).error_with_hint(TRY((String::formatted(String("None coalescing (??) with incompatible types (`{}` and `{}`)"),TRY((((*this).type_name(lhs_type_id)))),TRY((((*this).type_name(rhs_type_id))))))),span,String("Left side of ?? must be an Optional but isn't"),lhs_span))));
 }
 
-TRY((((*this).error(TRY((String::formatted(String("None coalescing (??) with incompatible types (‘{}’ and ‘{}’)"),TRY((((*this).type_name(lhs_type_id)))),TRY((((*this).type_name(rhs_type_id))))))),span))));
+TRY((((*this).error(TRY((String::formatted(String("None coalescing (??) with incompatible types (`{}` and `{}`)"),TRY((((*this).type_name(lhs_type_id)))),TRY((((*this).type_name(rhs_type_id))))))),span))));
 return (lhs_type_id);
 }
 return JaktInternal::ExplicitValue<void>();
@@ -39269,7 +39269,7 @@ return (lhs_type_id);
 }
 const JaktInternal::Optional<types::TypeId> result = TRY((((*this).unify(rhs_type_id,rhs_span,lhs_type_id,lhs_span))));
 if ((!(((result).has_value())))){
-TRY((((*this).error(TRY((String::formatted(String("Assignment between incompatible types (‘{}’ and ‘{}’)"),TRY((((*this).type_name(lhs_type_id)))),TRY((((*this).type_name(rhs_type_id))))))),span))));
+TRY((((*this).error(TRY((String::formatted(String("Assignment between incompatible types (`{}` and `{}`)"),TRY((((*this).type_name(lhs_type_id)))),TRY((((*this).type_name(rhs_type_id))))))),span))));
 }
 return (((result).value_or(lhs_type_id)));
 }
@@ -39294,7 +39294,7 @@ return (lhs_type_id);
 }
 const JaktInternal::Optional<types::TypeId> result = TRY((((*this).unify(rhs_type_id,rhs_span,lhs_type_id,lhs_span))));
 if ((!(((result).has_value())))){
-TRY((((*this).error(TRY((String::formatted(String("Assignment between incompatible types (‘{}’ and ‘{}’)"),TRY((((*this).type_name(lhs_type_id)))),TRY((((*this).type_name(rhs_type_id))))))),span))));
+TRY((((*this).error(TRY((String::formatted(String("Assignment between incompatible types (`{}` and `{}`)"),TRY((((*this).type_name(lhs_type_id)))),TRY((((*this).type_name(rhs_type_id))))))),span))));
 }
 if ((!(((checked_lhs)->is_mutable(((*this).program)))))){
 TRY((((*this).error(String("Assignment to immutable variable"),span))));
@@ -39321,7 +39321,7 @@ return (lhs_type_id);
 }
 const JaktInternal::Optional<types::TypeId> result = TRY((((*this).unify(rhs_type_id,rhs_span,lhs_type_id,lhs_span))));
 if ((!(((result).has_value())))){
-TRY((((*this).error(TRY((String::formatted(String("Assignment between incompatible types (‘{}’ and ‘{}’)"),TRY((((*this).type_name(lhs_type_id)))),TRY((((*this).type_name(rhs_type_id))))))),span))));
+TRY((((*this).error(TRY((String::formatted(String("Assignment between incompatible types (`{}` and `{}`)"),TRY((((*this).type_name(lhs_type_id)))),TRY((((*this).type_name(rhs_type_id))))))),span))));
 }
 if ((!(((checked_lhs)->is_mutable(((*this).program)))))){
 TRY((((*this).error(String("Assignment to immutable variable"),span))));
@@ -39348,7 +39348,7 @@ return (lhs_type_id);
 }
 const JaktInternal::Optional<types::TypeId> result = TRY((((*this).unify(rhs_type_id,rhs_span,lhs_type_id,lhs_span))));
 if ((!(((result).has_value())))){
-TRY((((*this).error(TRY((String::formatted(String("Assignment between incompatible types (‘{}’ and ‘{}’)"),TRY((((*this).type_name(lhs_type_id)))),TRY((((*this).type_name(rhs_type_id))))))),span))));
+TRY((((*this).error(TRY((String::formatted(String("Assignment between incompatible types (`{}` and `{}`)"),TRY((((*this).type_name(lhs_type_id)))),TRY((((*this).type_name(rhs_type_id))))))),span))));
 }
 if ((!(((checked_lhs)->is_mutable(((*this).program)))))){
 TRY((((*this).error(String("Assignment to immutable variable"),span))));
@@ -39375,7 +39375,7 @@ return (lhs_type_id);
 }
 const JaktInternal::Optional<types::TypeId> result = TRY((((*this).unify(rhs_type_id,rhs_span,lhs_type_id,lhs_span))));
 if ((!(((result).has_value())))){
-TRY((((*this).error(TRY((String::formatted(String("Assignment between incompatible types (‘{}’ and ‘{}’)"),TRY((((*this).type_name(lhs_type_id)))),TRY((((*this).type_name(rhs_type_id))))))),span))));
+TRY((((*this).error(TRY((String::formatted(String("Assignment between incompatible types (`{}` and `{}`)"),TRY((((*this).type_name(lhs_type_id)))),TRY((((*this).type_name(rhs_type_id))))))),span))));
 }
 if ((!(((checked_lhs)->is_mutable(((*this).program)))))){
 TRY((((*this).error(String("Assignment to immutable variable"),span))));
@@ -39402,7 +39402,7 @@ return (lhs_type_id);
 }
 const JaktInternal::Optional<types::TypeId> result = TRY((((*this).unify(rhs_type_id,rhs_span,lhs_type_id,lhs_span))));
 if ((!(((result).has_value())))){
-TRY((((*this).error(TRY((String::formatted(String("Assignment between incompatible types (‘{}’ and ‘{}’)"),TRY((((*this).type_name(lhs_type_id)))),TRY((((*this).type_name(rhs_type_id))))))),span))));
+TRY((((*this).error(TRY((String::formatted(String("Assignment between incompatible types (`{}` and `{}`)"),TRY((((*this).type_name(lhs_type_id)))),TRY((((*this).type_name(rhs_type_id))))))),span))));
 }
 if ((!(((checked_lhs)->is_mutable(((*this).program)))))){
 TRY((((*this).error(String("Assignment to immutable variable"),span))));
@@ -39429,7 +39429,7 @@ return (lhs_type_id);
 }
 const JaktInternal::Optional<types::TypeId> result = TRY((((*this).unify(rhs_type_id,rhs_span,lhs_type_id,lhs_span))));
 if ((!(((result).has_value())))){
-TRY((((*this).error(TRY((String::formatted(String("Assignment between incompatible types (‘{}’ and ‘{}’)"),TRY((((*this).type_name(lhs_type_id)))),TRY((((*this).type_name(rhs_type_id))))))),span))));
+TRY((((*this).error(TRY((String::formatted(String("Assignment between incompatible types (`{}` and `{}`)"),TRY((((*this).type_name(lhs_type_id)))),TRY((((*this).type_name(rhs_type_id))))))),span))));
 }
 if ((!(((checked_lhs)->is_mutable(((*this).program)))))){
 TRY((((*this).error(String("Assignment to immutable variable"),span))));
@@ -39456,7 +39456,7 @@ return (lhs_type_id);
 }
 const JaktInternal::Optional<types::TypeId> result = TRY((((*this).unify(rhs_type_id,rhs_span,lhs_type_id,lhs_span))));
 if ((!(((result).has_value())))){
-TRY((((*this).error(TRY((String::formatted(String("Assignment between incompatible types (‘{}’ and ‘{}’)"),TRY((((*this).type_name(lhs_type_id)))),TRY((((*this).type_name(rhs_type_id))))))),span))));
+TRY((((*this).error(TRY((String::formatted(String("Assignment between incompatible types (`{}` and `{}`)"),TRY((((*this).type_name(lhs_type_id)))),TRY((((*this).type_name(rhs_type_id))))))),span))));
 }
 if ((!(((checked_lhs)->is_mutable(((*this).program)))))){
 TRY((((*this).error(String("Assignment to immutable variable"),span))));
@@ -39483,7 +39483,7 @@ return (lhs_type_id);
 }
 const JaktInternal::Optional<types::TypeId> result = TRY((((*this).unify(rhs_type_id,rhs_span,lhs_type_id,lhs_span))));
 if ((!(((result).has_value())))){
-TRY((((*this).error(TRY((String::formatted(String("Assignment between incompatible types (‘{}’ and ‘{}’)"),TRY((((*this).type_name(lhs_type_id)))),TRY((((*this).type_name(rhs_type_id))))))),span))));
+TRY((((*this).error(TRY((String::formatted(String("Assignment between incompatible types (`{}` and `{}`)"),TRY((((*this).type_name(lhs_type_id)))),TRY((((*this).type_name(rhs_type_id))))))),span))));
 }
 if ((!(((checked_lhs)->is_mutable(((*this).program)))))){
 TRY((((*this).error(String("Assignment to immutable variable"),span))));
@@ -39510,7 +39510,7 @@ return (lhs_type_id);
 }
 const JaktInternal::Optional<types::TypeId> result = TRY((((*this).unify(rhs_type_id,rhs_span,lhs_type_id,lhs_span))));
 if ((!(((result).has_value())))){
-TRY((((*this).error(TRY((String::formatted(String("Assignment between incompatible types (‘{}’ and ‘{}’)"),TRY((((*this).type_name(lhs_type_id)))),TRY((((*this).type_name(rhs_type_id))))))),span))));
+TRY((((*this).error(TRY((String::formatted(String("Assignment between incompatible types (`{}` and `{}`)"),TRY((((*this).type_name(lhs_type_id)))),TRY((((*this).type_name(rhs_type_id))))))),span))));
 }
 if ((!(((checked_lhs)->is_mutable(((*this).program)))))){
 TRY((((*this).error(String("Assignment to immutable variable"),span))));
@@ -39537,7 +39537,7 @@ return (lhs_type_id);
 }
 const JaktInternal::Optional<types::TypeId> result = TRY((((*this).unify(rhs_type_id,rhs_span,lhs_type_id,lhs_span))));
 if ((!(((result).has_value())))){
-TRY((((*this).error(TRY((String::formatted(String("Assignment between incompatible types (‘{}’ and ‘{}’)"),TRY((((*this).type_name(lhs_type_id)))),TRY((((*this).type_name(rhs_type_id))))))),span))));
+TRY((((*this).error(TRY((String::formatted(String("Assignment between incompatible types (`{}` and `{}`)"),TRY((((*this).type_name(lhs_type_id)))),TRY((((*this).type_name(rhs_type_id))))))),span))));
 }
 if ((!(((checked_lhs)->is_mutable(((*this).program)))))){
 TRY((((*this).error(String("Assignment to immutable variable"),span))));
@@ -39550,7 +39550,7 @@ auto&& __jakt_match_value = __jakt_match_variant.template get<typename parser::B
 {
 const JaktInternal::Optional<types::TypeId> result = TRY((((*this).unify(rhs_type_id,rhs_span,lhs_type_id,lhs_span))));
 if ((!(((result).has_value())))){
-TRY((((*this).error(TRY((String::formatted(String("Binary arithmetic operation between incompatible types (‘{}’ and ‘{}’)"),TRY((((*this).type_name(lhs_type_id)))),TRY((((*this).type_name(rhs_type_id))))))),span))));
+TRY((((*this).error(TRY((String::formatted(String("Binary arithmetic operation between incompatible types (`{}` and `{}`)"),TRY((((*this).type_name(lhs_type_id)))),TRY((((*this).type_name(rhs_type_id))))))),span))));
 }
 (type_id = lhs_type_id);
 }
@@ -39561,7 +39561,7 @@ auto&& __jakt_match_value = __jakt_match_variant.template get<typename parser::B
 {
 const JaktInternal::Optional<types::TypeId> result = TRY((((*this).unify(rhs_type_id,rhs_span,lhs_type_id,lhs_span))));
 if ((!(((result).has_value())))){
-TRY((((*this).error(TRY((String::formatted(String("Binary arithmetic operation between incompatible types (‘{}’ and ‘{}’)"),TRY((((*this).type_name(lhs_type_id)))),TRY((((*this).type_name(rhs_type_id))))))),span))));
+TRY((((*this).error(TRY((String::formatted(String("Binary arithmetic operation between incompatible types (`{}` and `{}`)"),TRY((((*this).type_name(lhs_type_id)))),TRY((((*this).type_name(rhs_type_id))))))),span))));
 }
 (type_id = lhs_type_id);
 }
@@ -39572,7 +39572,7 @@ auto&& __jakt_match_value = __jakt_match_variant.template get<typename parser::B
 {
 const JaktInternal::Optional<types::TypeId> result = TRY((((*this).unify(rhs_type_id,rhs_span,lhs_type_id,lhs_span))));
 if ((!(((result).has_value())))){
-TRY((((*this).error(TRY((String::formatted(String("Binary arithmetic operation between incompatible types (‘{}’ and ‘{}’)"),TRY((((*this).type_name(lhs_type_id)))),TRY((((*this).type_name(rhs_type_id))))))),span))));
+TRY((((*this).error(TRY((String::formatted(String("Binary arithmetic operation between incompatible types (`{}` and `{}`)"),TRY((((*this).type_name(lhs_type_id)))),TRY((((*this).type_name(rhs_type_id))))))),span))));
 }
 (type_id = lhs_type_id);
 }
@@ -39583,7 +39583,7 @@ auto&& __jakt_match_value = __jakt_match_variant.template get<typename parser::B
 {
 const JaktInternal::Optional<types::TypeId> result = TRY((((*this).unify(rhs_type_id,rhs_span,lhs_type_id,lhs_span))));
 if ((!(((result).has_value())))){
-TRY((((*this).error(TRY((String::formatted(String("Binary arithmetic operation between incompatible types (‘{}’ and ‘{}’)"),TRY((((*this).type_name(lhs_type_id)))),TRY((((*this).type_name(rhs_type_id))))))),span))));
+TRY((((*this).error(TRY((String::formatted(String("Binary arithmetic operation between incompatible types (`{}` and `{}`)"),TRY((((*this).type_name(lhs_type_id)))),TRY((((*this).type_name(rhs_type_id))))))),span))));
 }
 (type_id = lhs_type_id);
 }
@@ -39594,7 +39594,7 @@ auto&& __jakt_match_value = __jakt_match_variant.template get<typename parser::B
 {
 const JaktInternal::Optional<types::TypeId> result = TRY((((*this).unify(rhs_type_id,rhs_span,lhs_type_id,lhs_span))));
 if ((!(((result).has_value())))){
-TRY((((*this).error(TRY((String::formatted(String("Binary arithmetic operation between incompatible types (‘{}’ and ‘{}’)"),TRY((((*this).type_name(lhs_type_id)))),TRY((((*this).type_name(rhs_type_id))))))),span))));
+TRY((((*this).error(TRY((String::formatted(String("Binary arithmetic operation between incompatible types (`{}` and `{}`)"),TRY((((*this).type_name(lhs_type_id)))),TRY((((*this).type_name(rhs_type_id))))))),span))));
 }
 (type_id = lhs_type_id);
 }
@@ -39628,10 +39628,10 @@ auto&& __jakt_match_value = __jakt_match_variant.template get<typename parser::V
 {
 if ((!(TRY((((*this).scope_can_access(accessor,accessee))))))){
 if ((!(((((method)->type)).index() == 0 /* Normal */)))){
-TRY((((*this).error_with_hint(TRY((String::formatted(String("Can't access constructor ‘{}’, because it is marked private"),((method)->name)))),span,String("Private constructors are created if any fields are private"),span))));
+TRY((((*this).error_with_hint(TRY((String::formatted(String("Can't access constructor `{}`, because it is marked private"),((method)->name)))),span,String("Private constructors are created if any fields are private"),span))));
 }
 else {
-TRY((((*this).error(TRY((String::formatted(String("Can't access method ‘{}’, because it is marked private"),((method)->name)))),span))));
+TRY((((*this).error(TRY((String::formatted(String("Can't access method `{}`, because it is marked private"),((method)->name)))),span))));
 }
 
 }
@@ -39893,7 +39893,7 @@ return (TRY((types::CheckedStatement::template create<typename types::CheckedSta
 ErrorOr<void> typechecker::Typechecker::check_restricted_access(const types::ScopeId accessor,const String accessee_kind,const types::ScopeId accessee,const String name,const JaktInternal::Array<NonnullRefPtr<parser::ParsedType>> whitelist,const utility::Span span) {
 {
 if ((!(((((*this).current_struct_type_id)).has_value())))){
-TRY((((*this).error(TRY((String::formatted(String("Can't access {} ‘{}’ from scope ‘{}’, because ‘{}’ is not in the restricted whitelist"),accessee_kind,name,((TRY((((*this).get_scope(accessor)))))->namespace_name),((TRY((((*this).get_scope(accessor)))))->namespace_name)))),span))));
+TRY((((*this).error(TRY((String::formatted(String("Can't access {} `{}` from scope `{}`, because `{}` is not in the restricted whitelist"),accessee_kind,name,((TRY((((*this).get_scope(accessor)))))->namespace_name),((TRY((((*this).get_scope(accessor)))))->namespace_name)))),span))));
 return {};
 }
 const types::TypeId own_type_id = (((*this).current_struct_type_id).value());
@@ -39921,11 +39921,11 @@ break;
 }
 
 if ((!(was_whitelisted))){
-TRY((((*this).error(TRY((String::formatted(String("Can't access {} ‘{}’ from ‘{}’, because ‘{}’ is not in the restricted whitelist"),accessee_kind,name,((((*this).get_struct(id))).name),((((*this).get_struct(id))).name)))),span))));
+TRY((((*this).error(TRY((String::formatted(String("Can't access {} `{}` from `{}`, because `{}` is not in the restricted whitelist"),accessee_kind,name,((((*this).get_struct(id))).name),((((*this).get_struct(id))).name)))),span))));
 }
 }
 else {
-TRY((((*this).error(TRY((String::formatted(String("Can't access {} ‘{}’ from scope ‘{}’, because it is not in the restricted whitelist"),accessee_kind,name,((TRY((((*this).get_scope(accessor)))))->namespace_name)))),span))));
+TRY((((*this).error(TRY((String::formatted(String("Can't access {} `{}` from scope `{}`, because it is not in the restricted whitelist"),accessee_kind,name,((TRY((((*this).get_scope(accessor)))))->namespace_name)))),span))));
 }
 
 }
@@ -39995,7 +39995,7 @@ JaktInternal::Tuple<String,types::FunctionId> existing_function = (_magic_value.
 {
 if ((name == ((existing_function).get<0>()))){
 const NonnullRefPtr<types::CheckedFunction> function_ = ((*this).get_function(((existing_function).get<1>())));
-TRY((((*this).error_with_hint(TRY((String::formatted(String("Redefinition of function ‘{}’"),name))),span,String("previous definition here"),((function_)->name_span)))));
+TRY((((*this).error_with_hint(TRY((String::formatted(String("Redefinition of function `{}`"),name))),span,String("previous definition here"),((function_)->name_span)))));
 return (false);
 }
 }
@@ -40016,7 +40016,7 @@ TRY((((*this).error(String("Condition must be a boolean expression"),((condition
 }
 const types::CheckedBlock checked_block = TRY((((*this).typecheck_block(block,scope_id,safety_mode,JaktInternal::OptionalNone()))));
 if (((((checked_block).yielded_type)).has_value())){
-TRY((((*this).error(String("A ‘while’ block is not allowed to yield values"),(((block).find_yield_span()).value())))));
+TRY((((*this).error(String("A `while` block is not allowed to yield values"),(((block).find_yield_span()).value())))));
 }
 return (TRY((types::CheckedStatement::template create<typename types::CheckedStatement::While>(checked_condition,checked_block,span))));
 }
@@ -40303,7 +40303,7 @@ return JaktInternal::ExplicitValue(({ Optional<JaktInternal::Optional<types::Str
 const types::StructId optional_struct_id = TRY((((*this).find_struct_in_prelude(String("Optional")))));
 JaktInternal::Optional<types::StructOrEnumId> struct_id = JaktInternal::OptionalNone();
 if ((!(((id).equals(optional_struct_id))))){
-TRY((((*this).error(TRY((String::formatted(String("Can't use ‘{}’ as an optional type in optional chained call"),((((*this).get_struct(id))).name)))),span))));
+TRY((((*this).error(TRY((String::formatted(String("Can't use `{}` as an optional type in optional chained call"),((((*this).get_struct(id))).name)))),span))));
 }
 else {
 (found_optional = true);
@@ -41386,7 +41386,7 @@ JaktInternal::Tuple<String,types::VarId> existing_var = (_magic_value.value());
 {
 if ((name == ((existing_var).get<0>()))){
 const types::CheckedVariable variable_ = ((*this).get_variable(((existing_var).get<1>())));
-TRY((((*this).error_with_hint(TRY((String::formatted(String("Redefinition of variable ‘{}’"),name))),span,String("previous definition here"),((variable_).definition_span)))));
+TRY((((*this).error_with_hint(TRY((String::formatted(String("Redefinition of variable `{}`"),name))),span,String("previous definition here"),((variable_).definition_span)))));
 }
 }
 
@@ -41429,7 +41429,7 @@ if (((((*this).get_type(seen_type_id)))->index() == 18 /* TypeVariable */)){
 return (TRY((((*this).check_types_for_compat(seen_type_id,lhs_type_id,generic_inferences,span)))));
 }
 if ((((seen_type_id_string).value()) != rhs_type_id_string)){
-TRY((((*this).error(TRY((String::formatted(String("Type mismatch: expected ‘{}’, but got ‘{}’"),TRY((((*this).type_name(seen_type_id)))),TRY((((*this).type_name(rhs_type_id))))))),span))));
+TRY((((*this).error(TRY((String::formatted(String("Type mismatch: expected `{}`, but got `{}`"),TRY((((*this).type_name(seen_type_id)))),TRY((((*this).type_name(rhs_type_id))))))),span))));
 return (false);
 }
 }
@@ -41467,7 +41467,7 @@ return (false);
 }
 else {
 if ((!(((rhs_type_id).equals(lhs_type_id))))){
-TRY((((*this).error(TRY((String::formatted(String("Type mismatch: expected ‘{}’, but got ‘{}’"),TRY((((*this).type_name(lhs_type_id)))),TRY((((*this).type_name(rhs_type_id))))))),span))));
+TRY((((*this).error(TRY((String::formatted(String("Type mismatch: expected `{}`, but got `{}`"),TRY((((*this).type_name(lhs_type_id)))),TRY((((*this).type_name(rhs_type_id))))))),span))));
 return (false);
 }
 }
@@ -41505,14 +41505,14 @@ return JaktInternal::ExplicitValue(String("No"));
 }
 }()))
 ;
-TRY((((*this).error(TRY((String::formatted(String("Function can throw mismatch: expected ‘{}’, but got ‘{}’"),lhs_throw,rhs_throw))),span))));
+TRY((((*this).error(TRY((String::formatted(String("Function can throw mismatch: expected `{}`, but got `{}`"),lhs_throw,rhs_throw))),span))));
 }
 if ((!((((lhs_params).size()) == ((rhs_params).size()))))){
-TRY((((*this).error(TRY((String::formatted(String("Function parameter count mismatch: expected ‘{}’, but got ‘{}’"),((lhs_params).size()),((rhs_params).size())))),span))));
+TRY((((*this).error(TRY((String::formatted(String("Function parameter count mismatch: expected `{}`, but got `{}`"),((lhs_params).size()),((rhs_params).size())))),span))));
 return (false);
 }
 if ((!(TRY((((*this).check_types_for_compat(lhs_return_type_id,rhs_return_type_id,generic_inferences,span))))))){
-TRY((((*this).error_with_hint(TRY((String::formatted(String("Function type mismatch: expected ‘{}’, but got ‘{}’"),TRY((((*this).type_name(lhs_type_id)))),TRY((((*this).type_name(rhs_type_id))))))),span,TRY((String::formatted(String("The return types differ: expected ‘{}’, but got ‘{}’"),TRY((((*this).type_name(lhs_return_type_id)))),TRY((((*this).type_name(rhs_return_type_id))))))),span))));
+TRY((((*this).error_with_hint(TRY((String::formatted(String("Function type mismatch: expected `{}`, but got `{}`"),TRY((((*this).type_name(lhs_type_id)))),TRY((((*this).type_name(rhs_type_id))))))),span,TRY((String::formatted(String("The return types differ: expected `{}`, but got `{}`"),TRY((((*this).type_name(lhs_return_type_id)))),TRY((((*this).type_name(rhs_return_type_id))))))),span))));
 return (false);
 }
 {
@@ -41525,7 +41525,7 @@ break;
 size_t i = (_magic_value.value());
 {
 if ((!(TRY((((*this).check_types_for_compat(((lhs_params)[i]),((rhs_params)[i]),generic_inferences,span))))))){
-TRY((((*this).error_with_hint(TRY((String::formatted(String("Function type mismatch: expected ‘{}’, but got ‘{}’"),TRY((((*this).type_name(lhs_type_id)))),TRY((((*this).type_name(rhs_type_id))))))),span,TRY((String::formatted(String("The parameter types differ at argument {}: expected ‘{}’, but got ‘{}’"),(JaktInternal::checked_add<size_t>(i,static_cast<size_t>(1ULL))),TRY((((*this).type_name(((lhs_params)[i]))))),TRY((((*this).type_name(((rhs_params)[i])))))))),span))));
+TRY((((*this).error_with_hint(TRY((String::formatted(String("Function type mismatch: expected `{}`, but got `{}`"),TRY((((*this).type_name(lhs_type_id)))),TRY((((*this).type_name(rhs_type_id))))))),span,TRY((String::formatted(String("The parameter types differ at argument {}: expected `{}`, but got `{}`"),(JaktInternal::checked_add<size_t>(i,static_cast<size_t>(1ULL))),TRY((((*this).type_name(((lhs_params)[i]))))),TRY((((*this).type_name(((rhs_params)[i])))))))),span))));
 return (false);
 }
 }
@@ -41535,7 +41535,7 @@ return (false);
 
 }
 else {
-TRY((((*this).error(TRY((String::formatted(String("Type mismatch: expected ‘{}’, but got ‘{}’"),TRY((((*this).type_name(lhs_type_id)))),TRY((((*this).type_name(rhs_type_id))))))),span))));
+TRY((((*this).error(TRY((String::formatted(String("Type mismatch: expected `{}`, but got `{}`"),TRY((((*this).type_name(lhs_type_id)))),TRY((((*this).type_name(rhs_type_id))))))),span))));
 return (false);
 }
 
@@ -41584,14 +41584,14 @@ return (true);
 }
 }
 else {
-TRY((((*this).error(TRY((String::formatted(String("Type mismatch: expected ‘{}’, but got ‘{}’"),TRY((((*this).type_name(lhs_type_id)))),TRY((((*this).type_name(rhs_type_id))))))),span))));
+TRY((((*this).error(TRY((String::formatted(String("Type mismatch: expected `{}`, but got `{}`"),TRY((((*this).type_name(lhs_type_id)))),TRY((((*this).type_name(rhs_type_id))))))),span))));
 return (false);
 }
 
 }
 else {
 if ((!(((rhs_type_id).equals(lhs_type_id))))){
-TRY((((*this).error(TRY((String::formatted(String("Type mismatch: expected ‘{}’, but got ‘{}’"),TRY((((*this).type_name(lhs_type_id)))),TRY((((*this).type_name(rhs_type_id))))))),span))));
+TRY((((*this).error(TRY((String::formatted(String("Type mismatch: expected `{}`, but got `{}`"),TRY((((*this).type_name(lhs_type_id)))),TRY((((*this).type_name(rhs_type_id))))))),span))));
 return (false);
 }
 }
@@ -41636,7 +41636,7 @@ auto&& __jakt_match_value = __jakt_match_variant.template get<typename types::Ty
 const JaktInternal::Optional<String> seen_type_id_string = ((((generic_inferences))).get(rhs_type_id_string));
 if (((seen_type_id_string).has_value())){
 if ((((seen_type_id_string).value()) != lhs_type_id_string)){
-TRY((((*this).error(TRY((String::formatted(String("Type mismatch: expected ‘{}’, but got ‘{}’"),TRY((((*this).type_name(lhs_type_id)))),TRY((((*this).type_name(TRY((types::TypeId::from_string(((seen_type_id_string).value()))))))))))),span))));
+TRY((((*this).error(TRY((String::formatted(String("Type mismatch: expected `{}`, but got `{}`"),TRY((((*this).type_name(lhs_type_id)))),TRY((((*this).type_name(TRY((types::TypeId::from_string(((seen_type_id_string).value()))))))))))),span))));
 return (false);
 }
 }
@@ -41650,7 +41650,7 @@ return JaktInternal::ExplicitValue<void>();
 default: {
 {
 if ((!(((rhs_type_id).equals(lhs_type_id))))){
-TRY((((*this).error(TRY((String::formatted(String("Type mismatch: expected ‘{}’, but got ‘{}’"),TRY((((*this).type_name(lhs_type_id)))),TRY((((*this).type_name(rhs_type_id))))))),span))));
+TRY((((*this).error(TRY((String::formatted(String("Type mismatch: expected `{}`, but got `{}`"),TRY((((*this).type_name(lhs_type_id)))),TRY((((*this).type_name(rhs_type_id))))))),span))));
 return (false);
 }
 }
@@ -41677,7 +41677,7 @@ auto&& __jakt_match_value = __jakt_match_variant.template get<types::Type::Gener
 JaktInternal::Array<types::TypeId> const& args = __jakt_match_value.args;
 {
 if ((!(((lhs_struct_id).equals(id))))){
-TRY((((*this).error(TRY((String::formatted(String("Type mismatch: expected ‘{}’, but got ‘{}’"),TRY((((*this).type_name(lhs_type_id)))),TRY((((*this).type_name(rhs_type_id))))))),span))));
+TRY((((*this).error(TRY((String::formatted(String("Type mismatch: expected `{}`, but got `{}`"),TRY((((*this).type_name(lhs_type_id)))),TRY((((*this).type_name(rhs_type_id))))))),span))));
 return (false);
 }
 const types::CheckedStruct lhs_struct = ((*this).get_struct(lhs_struct_id));
@@ -41701,7 +41701,7 @@ auto&& __jakt_match_value = __jakt_match_variant.template get<typename types::Ty
 const JaktInternal::Optional<String> seen_type_id_string = ((((generic_inferences))).get(rhs_type_id_string));
 if (((seen_type_id_string).has_value())){
 if ((((seen_type_id_string).value()) != lhs_type_id_string)){
-TRY((((*this).error(TRY((String::formatted(String("Type mismatch: expected ‘{}’, but got ‘{}’"),TRY((((*this).type_name(TRY((types::TypeId::from_string(((seen_type_id_string).value())))))))),TRY((((*this).type_name(rhs_type_id))))))),span))));
+TRY((((*this).error(TRY((String::formatted(String("Type mismatch: expected `{}`, but got `{}`"),TRY((((*this).type_name(TRY((types::TypeId::from_string(((seen_type_id_string).value())))))))),TRY((((*this).type_name(rhs_type_id))))))),span))));
 return (false);
 }
 }
@@ -41719,7 +41719,7 @@ if (((*this).is_subclass_of(lhs_type_id,rhs_type_id))){
 return (true);
 }
 if ((!(((rhs_type_id).equals(lhs_type_id))))){
-TRY((((*this).error(TRY((String::formatted(String("Type mismatch: expected ‘{}’, but got ‘{}’"),TRY((((*this).type_name(lhs_type_id)))),TRY((((*this).type_name(rhs_type_id))))))),span))));
+TRY((((*this).error(TRY((String::formatted(String("Type mismatch: expected `{}`, but got `{}`"),TRY((((*this).type_name(lhs_type_id)))),TRY((((*this).type_name(rhs_type_id))))))),span))));
 return (false);
 }
 }
@@ -41746,7 +41746,7 @@ return (false);
 }
 else {
 if ((!(((rhs_type_id).equals(lhs_type_id))))){
-TRY((((*this).error(TRY((String::formatted(String("Type mismatch: expected ‘{}’, but got ‘{}’"),TRY((((*this).type_name(lhs_type_id)))),TRY((((*this).type_name(rhs_type_id))))))),span))));
+TRY((((*this).error(TRY((String::formatted(String("Type mismatch: expected `{}`, but got `{}`"),TRY((((*this).type_name(lhs_type_id)))),TRY((((*this).type_name(rhs_type_id))))))),span))));
 return (false);
 }
 }
@@ -41770,7 +41770,7 @@ return JaktInternal::ExplicitValue<void>();
 default: {
 {
 if ((((((generic_inferences))).map(rhs_type_id_string)) != ((((generic_inferences))).map(lhs_type_id_string)))){
-TRY((((*this).error(TRY((String::formatted(String("Type mismatch: expected ‘{}’, but got ‘{}’"),TRY((((*this).type_name(lhs_type_id)))),TRY((((*this).type_name(rhs_type_id))))))),span))));
+TRY((((*this).error(TRY((String::formatted(String("Type mismatch: expected `{}`, but got `{}`"),TRY((((*this).type_name(lhs_type_id)))),TRY((((*this).type_name(rhs_type_id))))))),span))));
 return (false);
 }
 }
@@ -41990,7 +41990,7 @@ TRY((((*this).add_var_to_scope(catch_scope_id,(catch_name.value()),error_id,span
 const types::CheckedBlock block = TRY((((*this).typecheck_block((catch_block.value()),catch_scope_id,safety_mode,JaktInternal::OptionalNone()))));
 if ((((((block).control_flow)).always_transfers_control()) || ((((block).yielded_type)).has_value()))){
 if ((!(((((block).yielded_type).value_or_lazy_evaluated([&] { return expression_type_id; })).equals(expression_type_id))))){
-TRY((((*this).error_with_hint(TRY((String::formatted(String("Expected a value of type ‘{}’, but got ‘{}’"),TRY((((*this).type_name(expression_type_id)))),TRY((((*this).type_name((((block).yielded_type).value())))))))),span,TRY((String::formatted(String("Expression 'catch' block must either yield the same type as the expression it is catching, or yield nothing")))),span))));
+TRY((((*this).error_with_hint(TRY((String::formatted(String("Expected a value of type `{}`, but got `{}`"),TRY((((*this).type_name(expression_type_id)))),TRY((((*this).type_name((((block).yielded_type).value())))))))),span,TRY((String::formatted(String("Expression 'catch' block must either yield the same type as the expression it is catching, or yield nothing")))),span))));
 }
 else {
 (type_id = ((block).yielded_type).value_or_lazy_evaluated([&] { return expression_type_id; }));
@@ -42006,7 +42006,7 @@ return (TRY((types::CheckedExpression::template create<typename types::CheckedEx
 ErrorOr<NonnullRefPtr<types::CheckedStatement>> typechecker::Typechecker::typecheck_return(const JaktInternal::Optional<NonnullRefPtr<parser::ParsedExpression>> expr,const utility::Span span,const types::ScopeId scope_id,const types::SafetyMode safety_mode) {
 {
 if (((*this).inside_defer)){
-TRY((((*this).error(String("‘return’ is not allowed inside ‘defer’"),span))));
+TRY((((*this).error(String("`return` is not allowed inside `defer`"),span))));
 }
 if ((!(((expr).has_value())))){
 return (TRY((types::CheckedStatement::template create<typename types::CheckedStatement::Return>(JaktInternal::OptionalNone(),span))));
@@ -42044,7 +42044,7 @@ return JaktInternal::ExplicitValue(false);
 }()
 ));
 if (contains_reference){
-TRY((((*this).error(TRY((String::formatted(String("Reference type ‘{}’ not usable in this context"),TRY((((*this).type_name(type_id))))))),span))));
+TRY((((*this).error(TRY((String::formatted(String("Reference type `{}` not usable in this context"),TRY((((*this).type_name(type_id))))))),span))));
 }
 }
 return {};
@@ -42956,7 +42956,7 @@ case 1: {
 auto&& __jakt_match_value = __jakt_match_variant.template get<typename parser::Visibility::Private>();
 {
 if ((!(TRY((((*this).scope_can_access(accessor,accessee))))))){
-TRY((((*this).error(TRY((String::formatted(String("Can't access field ‘{}’, because it is marked private"),((member).name)))),span))));
+TRY((((*this).error(TRY((String::formatted(String("Can't access field `{}`, because it is marked private"),((member).name)))),span))));
 }
 }
 return JaktInternal::ExplicitValue<void>();
@@ -43225,7 +43225,7 @@ if ((raw_number <= max_signed)){
 }
 const types::NumberConstant negated_number_constant = typename types::NumberConstant::Signed((infallible_integer_cast<i64>((negated_number))));
 if (((raw_number > (JaktInternal::checked_add<size_t>(max_signed,static_cast<size_t>(1ULL)))) || (!(((negated_number_constant).can_fit_number(flipped_sign_type,((*this).program))))))){
-TRY((((*this).error(TRY((String::formatted(String("Negative literal -{} too small for type ‘{}’"),raw_number,TRY((((*this).type_name(flipped_sign_type))))))),span))));
+TRY((((*this).error(TRY((String::formatted(String("Negative literal -{} too small for type `{}`"),raw_number,TRY((((*this).type_name(flipped_sign_type))))))),span))));
 return (TRY((types::CheckedExpression::template create<typename types::CheckedExpression::UnaryOp>(expr,typename types::CheckedUnaryOperator::Negate(),span,type_id))));
 }
 const types::CheckedNumericConstant new_constant = JAKT_RESOLVE_EXPLICIT_VALUE_OR_CONTROL_FLOW_RETURN_ONLY(([&]() -> JaktInternal::ExplicitValueOrControlFlow<types::CheckedNumericConstant, ErrorOr<NonnullRefPtr<types::CheckedExpression>>>{
@@ -43297,7 +43297,7 @@ const types::CheckedEnum enum_ = ((*this).get_enum((maybe_enum_scope.value())));
 (current_scope_id = ((enum_).scope_id));
 continue;
 }
-TRY((((*this).error(TRY((String::formatted(String("Not a namespace, enum, class, or struct: ‘{}’"),utility::join(((call).namespace_),String("::"))))),span))));
+TRY((((*this).error(TRY((String::formatted(String("Not a namespace, enum, class, or struct: `{}`"),utility::join(((call).namespace_),String("::"))))),span))));
 }
 
 }
@@ -43337,7 +43337,7 @@ return (function_id);
 }
 }
 if (must_be_enum_constructor){
-TRY((((*this).error(TRY((String::formatted(String("No such enum constructor ‘{}’"),((call).name)))),span))));
+TRY((((*this).error(TRY((String::formatted(String("No such enum constructor `{}`"),((call).name)))),span))));
 return (callee);
 }
 const JaktInternal::Optional<types::StructId> maybe_struct_id = TRY((((*this).find_struct_in_scope(current_scope_id,((call).name)))));
@@ -43351,7 +43351,7 @@ return ((maybe_function_id.value()));
 return (callee);
 }
 if ((!(ignore_errors))){
-TRY((((*this).error(TRY((String::formatted(String("Call to unknown function: ‘{}’"),((call).name)))),span))));
+TRY((((*this).error(TRY((String::formatted(String("Call to unknown function: `{}`"),((call).name)))),span))));
 }
 return (JaktInternal::OptionalNone());
 }
@@ -43605,7 +43605,7 @@ ErrorOr<bool> typechecker::Typechecker::add_type_to_scope(const types::ScopeId s
 NonnullRefPtr<types::Scope> scope = TRY((((*this).get_scope(scope_id))));
 const JaktInternal::Optional<types::TypeId> found_type_id = ((((scope)->types)).get(type_name));
 if ((((found_type_id).has_value()) && (!((((found_type_id.value())).equals(type_id)))))){
-TRY((((*this).error(TRY((String::formatted(String("Redefinition of type ‘{}’"),type_name))),span))));
+TRY((((*this).error(TRY((String::formatted(String("Redefinition of type `{}`"),type_name))),span))));
 return (false);
 }
 TRY((((((scope)->types)).set(type_name,type_id))));
@@ -43653,7 +43653,7 @@ if ((name == ((((param).variable)).name))){
 return (true);
 }
 if ((!(((default_value).has_value())))){
-TRY((((*this).error(TRY((String::formatted(String("Wrong parameter name in argument label (got ‘{}’, expected ‘{}’)"),name,((((param).variable)).name)))),span))));
+TRY((((*this).error(TRY((String::formatted(String("Wrong parameter name in argument label (got `{}`, expected `{}`)"),name,((((param).variable)).name)))),span))));
 }
 return (false);
 }
@@ -43884,7 +43884,7 @@ TRY((((*this).error(TRY((String::formatted(String("unknown member of struct: {}.
 return JaktInternal::ExplicitValue<void>();
 };/*case end*/
 default: {
-return (TRY((((*this).error(TRY((String::formatted(String("Member field access on value of non-struct type ‘{}’"),TRY((((*this).type_name(checked_expr_type_id))))))),span))))), JaktInternal::ExplicitValue<void>();
+return (TRY((((*this).error(TRY((String::formatted(String("Member field access on value of non-struct type `{}`"),TRY((((*this).type_name(checked_expr_type_id))))))),span))))), JaktInternal::ExplicitValue<void>();
 };/*case end*/
 }/*switch end*/
 }()
@@ -43925,7 +43925,7 @@ TRY((((*this).error(TRY((String::formatted(String("unknown member of struct: {}.
 return JaktInternal::ExplicitValue<void>();
 };/*case end*/
 default: {
-return (TRY((((*this).error(TRY((String::formatted(String("Member field access on value of non-struct type ‘{}’"),TRY((((*this).type_name(checked_expr_type_id))))))),span))))), JaktInternal::ExplicitValue<void>();
+return (TRY((((*this).error(TRY((String::formatted(String("Member field access on value of non-struct type `{}`"),TRY((((*this).type_name(checked_expr_type_id))))))),span))))), JaktInternal::ExplicitValue<void>();
 };/*case end*/
 }/*switch end*/
 }()
@@ -44709,17 +44709,17 @@ if ((!(((var).is_mutable)))){
 TRY((((*this).error(String("Weak reference must be mutable"),((var).span)))));
 }
 if (((!(((lhs_type_id).equals(rhs_type_id)))) && ((!(((((args)[static_cast<i64>(0LL)])).equals(rhs_type_id)))) && (!(((rhs_type_id).equals(types::unknown_type_id()))))))){
-TRY((((*this).error(TRY((String::formatted(String("Type mismatch: expected ‘{}’, but got ‘{}’"),TRY((((*this).type_name(lhs_type_id)))),TRY((((*this).type_name(rhs_type_id))))))),((checked_expr)->span())))));
+TRY((((*this).error(TRY((String::formatted(String("Type mismatch: expected `{}`, but got `{}`"),TRY((((*this).type_name(lhs_type_id)))),TRY((((*this).type_name(rhs_type_id))))))),((checked_expr)->span())))));
 }
 }
 else if (((id).equals(optional_struct_id))){
 if (((!(((lhs_type_id).equals(rhs_type_id)))) && ((!(((((args)[static_cast<i64>(0LL)])).equals(rhs_type_id)))) && (!(((rhs_type_id).equals(types::unknown_type_id()))))))){
-TRY((((*this).error(TRY((String::formatted(String("Type mismatch: expected ‘{}’, but got ‘{}’"),TRY((((*this).type_name(lhs_type_id)))),TRY((((*this).type_name(rhs_type_id))))))),((checked_expr)->span())))));
+TRY((((*this).error(TRY((String::formatted(String("Type mismatch: expected `{}`, but got `{}`"),TRY((((*this).type_name(lhs_type_id)))),TRY((((*this).type_name(rhs_type_id))))))),((checked_expr)->span())))));
 }
 }
 else {
 if (((!(((lhs_type_id).equals(rhs_type_id)))) && (!(((rhs_type_id).equals(types::unknown_type_id())))))){
-TRY((((*this).error(TRY((String::formatted(String("Type mismatch: expected ‘{}’, but got ‘{}’"),TRY((((*this).type_name(lhs_type_id)))),TRY((((*this).type_name(rhs_type_id))))))),((checked_expr)->span())))));
+TRY((((*this).error(TRY((String::formatted(String("Type mismatch: expected `{}`, but got `{}`"),TRY((((*this).type_name(lhs_type_id)))),TRY((((*this).type_name(rhs_type_id))))))),((checked_expr)->span())))));
 }
 }
 
@@ -44751,13 +44751,13 @@ default: VERIFY_NOT_REACHED();}/*switch end*/
 )));
 }
 if (((!((((*this).is_numeric(lhs_type_id)) && is_rhs_zero))) && (((*this).is_integer(lhs_type_id)) ^ ((*this).is_integer(rhs_type_id))))){
-TRY((((*this).error(TRY((String::formatted(String("Type mismatch: expected ‘{}’, but got ‘{}’"),TRY((((*this).type_name(lhs_type_id)))),TRY((((*this).type_name(rhs_type_id))))))),((checked_expr)->span())))));
+TRY((((*this).error(TRY((String::formatted(String("Type mismatch: expected `{}`, but got `{}`"),TRY((((*this).type_name(lhs_type_id)))),TRY((((*this).type_name(rhs_type_id))))))),((checked_expr)->span())))));
 return (TRY((types::CheckedStatement::template create<typename types::CheckedStatement::Garbage>(span))));
 }
 }
 else {
 if (((!(((lhs_type_id).equals(rhs_type_id)))) && (!(((rhs_type_id).equals(types::unknown_type_id())))))){
-TRY((((*this).error(TRY((String::formatted(String("Type mismatch: expected ‘{}’, but got ‘{}’"),TRY((((*this).type_name(lhs_type_id)))),TRY((((*this).type_name(rhs_type_id))))))),((checked_expr)->span())))));
+TRY((((*this).error(TRY((String::formatted(String("Type mismatch: expected `{}`, but got `{}`"),TRY((((*this).type_name(lhs_type_id)))),TRY((((*this).type_name(rhs_type_id))))))),((checked_expr)->span())))));
 }
 }
 
@@ -44777,7 +44777,7 @@ ErrorOr<JaktInternal::Optional<JaktInternal::Array<types::CheckedEnumVariantBind
 if (((variant).index() == 1 /* Typed */)){
 const types::TypeId type_id = (variant.get<types::CheckedEnumVariant::Typed>()).type_id;
 if ((((bindings).size()) != static_cast<size_t>(1ULL))){
-TRY((((*this).error(TRY((String::formatted(String("Enum variant ‘{}’ must have exactly one argument"),((variant).name())))),span))));
+TRY((((*this).error(TRY((String::formatted(String("Enum variant `{}` must have exactly one argument"),((variant).name())))),span))));
 return (JaktInternal::OptionalNone());
 }
 return ((TRY((Array<types::CheckedEnumVariantBinding>::create_with({types::CheckedEnumVariantBinding(JaktInternal::OptionalNone(),((((bindings)[static_cast<i64>(0LL)])).binding),type_id,span)})))));
@@ -45145,7 +45145,7 @@ utility::Span const& span = __jakt_match_value.span;
 TRY((((covered_variants).add(name))));
 if ((!(((variant_arguments).is_empty())))){
 if ((((variant_arguments).size()) != static_cast<size_t>(1ULL))){
-TRY((((*this).error(TRY((String::formatted(String("Match case ‘{}’ must have exactly one argument"),name))),span))));
+TRY((((*this).error(TRY((String::formatted(String("Match case `{}` must have exactly one argument"),name))),span))));
 }
 else {
 const parser::EnumVariantPatternArgument variant_argument = ((variant_arguments)[static_cast<i64>(0LL)]);
@@ -45506,7 +45506,7 @@ utility::Span const& span = __jakt_match_value.span;
 TRY((((covered_variants).add(name))));
 if ((!(((variant_arguments).is_empty())))){
 if ((((variant_arguments).size()) != static_cast<size_t>(1ULL))){
-TRY((((*this).error(TRY((String::formatted(String("Match case ‘{}’ must have exactly one argument"),name))),span))));
+TRY((((*this).error(TRY((String::formatted(String("Match case `{}` must have exactly one argument"),name))),span))));
 }
 else {
 const parser::EnumVariantPatternArgument variant_argument = ((variant_arguments)[static_cast<i64>(0LL)]);

--- a/documentation/coding-style.md
+++ b/documentation/coding-style.md
@@ -141,15 +141,15 @@ Try to keep error messages short and clear, while still providing enough informa
 
 Capitalize the start of the first word of each error message that is displayed to the user. Do not end the message with a period.
 
-Type names and code excerpts should be wrapped in ‘ `'LEFT SINGLE QUOTATION MARK' (U+2018)` and ’ `'RIGHT SINGLE QUOTATION MARK' (U+2019)`.
+Type names and code excerpts should be wrapped in backticks.
 
 If there is a category for the error, follow it with a colon and space, and begin the rest of the message with a lowercase letter. For internal errors, the category is "Internal error".
 
 ##### Right:
 
 ```
-"Type mismatch: expected ‘String’, but got ‘i64’"
-"Binary arithmetic operation between incompatible types (‘String’ and ‘i64’)"
+"Type mismatch: expected `String`, but got `i64`"
+"Binary arithmetic operation between incompatible types (`String` and `i64`)"
 "Internal error: expression stack empty"
 ```
 

--- a/samples/arrays/empty_infer_call_bad.jakt
+++ b/samples/arrays/empty_infer_call_bad.jakt
@@ -1,5 +1,5 @@
 /// Expect:
-/// - error: "Type mismatch: expected ‘f64’, but got ‘String’\n"
+/// - error: "Type mismatch: expected `f64`, but got `String`\n"
 
 function test(arr: [f64]) {
     println("OK")

--- a/samples/classes/restricted_method_inaccessible.jakt
+++ b/samples/classes/restricted_method_inaccessible.jakt
@@ -1,5 +1,5 @@
 /// Expect:
-/// - error: "Can't access function ‘get_secret’ from ‘C’, because ‘C’ is not in the restricted whitelist\n"
+/// - error: "Can't access function `get_secret` from `C`, because `C` is not in the restricted whitelist\n"
 
 class Limited {
     restricted(A) function get_secret() => "Shhhh! Don't tell anyone!"

--- a/samples/control_flow/defer_return_error.jakt
+++ b/samples/control_flow/defer_return_error.jakt
@@ -1,5 +1,5 @@
 /// Expect:
-/// - error: "‘return’ is not allowed inside ‘defer’\n"
+/// - error: "`return` is not allowed inside `defer`\n"
 
 function foo() {
     defer {

--- a/samples/enums/methods_access_violation.jakt
+++ b/samples/enums/methods_access_violation.jakt
@@ -1,5 +1,5 @@
 /// Expect:
-/// - error: "Can't access method ‘test’, because it is marked private\n"
+/// - error: "Can't access method `test`, because it is marked private\n"
 
 enum Foo {
     Bar

--- a/samples/functions/call_with_bad_args.jakt
+++ b/samples/functions/call_with_bad_args.jakt
@@ -1,5 +1,5 @@
 /// Expect:
-/// - error: "Type mismatch: expected ‘String’, but got ‘i64’\n"
+/// - error: "Type mismatch: expected `String`, but got `i64`\n"
 
 function greet(msg: String, msg2: String) {
     println("{}", msg)

--- a/samples/functions/default_arguments_bad_type.jakt
+++ b/samples/functions/default_arguments_bad_type.jakt
@@ -1,5 +1,5 @@
 /// Expect:
-/// - error: "Type mismatch: expected ‘String’, but got ‘i64’\n"
+/// - error: "Type mismatch: expected `String`, but got `i64`\n"
 
 function say(text: String = 3) {
     println("{}", text)

--- a/samples/generics/generic_struct_mismatch.jakt
+++ b/samples/generics/generic_struct_mismatch.jakt
@@ -1,5 +1,5 @@
 /// Expect:
-/// - error: "Type mismatch: expected ‘Foo<i64>’, but got ‘Bar<i64>’\n"
+/// - error: "Type mismatch: expected `Foo<i64>`, but got `Bar<i64>`\n"
 
 struct Foo<T> {
     x: T

--- a/samples/math/incompatible_literal.jakt
+++ b/samples/math/incompatible_literal.jakt
@@ -1,5 +1,5 @@
 /// Expect:
-/// - error: "Binary arithmetic operation between incompatible types (‘u8’ and ‘u16’)\n"
+/// - error: "Binary arithmetic operation between incompatible types (`u8` and `u16`)\n"
 
 function main() {
     let x: u8 = 12;

--- a/samples/math/too_small_literal.jakt
+++ b/samples/math/too_small_literal.jakt
@@ -1,5 +1,5 @@
 /// Expect:
-/// - error: "Negative literal -9223372036854775809 too small for type ‘i64’"
+/// - error: "Negative literal -9223372036854775809 too small for type `i64`"
 
 function main() {
     let too_small_i64 = -9_223_372_036_854_775_809;

--- a/samples/namespaces/bogus_namespace1.jakt
+++ b/samples/namespaces/bogus_namespace1.jakt
@@ -1,5 +1,5 @@
 /// Expect:
-/// - error: "Not a namespace, enum, class, or struct: ‘NS::Foo’\n"
+/// - error: "Not a namespace, enum, class, or struct: `NS::Foo`\n"
 
 namespace NS {
     function foo() {}

--- a/samples/namespaces/bogus_namespace2.jakt
+++ b/samples/namespaces/bogus_namespace2.jakt
@@ -1,5 +1,5 @@
 /// Expect:
-/// - error: "Not a namespace, enum, class, or struct: ‘NS’\n"
+/// - error: "Not a namespace, enum, class, or struct: `NS`\n"
 
 function main() {
     NS::foo()

--- a/samples/references/no_reference_locals.jakt
+++ b/samples/references/no_reference_locals.jakt
@@ -1,5 +1,5 @@
 /// Expect:
-/// - error: "Reference type ‘&i64’ not usable in this context"
+/// - error: "Reference type `&i64` not usable in this context"
 
 function main() {
     let i = 0

--- a/samples/references/no_reference_return_type.jakt
+++ b/samples/references/no_reference_return_type.jakt
@@ -1,5 +1,5 @@
 /// Expect:
-/// - error: "Reference type ‘&i64’ not usable in this context"
+/// - error: "Reference type `&i64` not usable in this context"
 
 function foo() -> &i64 {
     let x = 1

--- a/samples/references/no_reference_struct_fields.jakt
+++ b/samples/references/no_reference_struct_fields.jakt
@@ -1,5 +1,5 @@
 /// Expect:
-/// - error: "Reference type ‘&i64’ not usable in this context"
+/// - error: "Reference type `&i64` not usable in this context"
 
 struct Foo {
     x: &i64

--- a/samples/variables/var_redefinition.jakt
+++ b/samples/variables/var_redefinition.jakt
@@ -1,5 +1,5 @@
 /// Expect:
-/// - error: "Redefinition of variable ‘x’\n"
+/// - error: "Redefinition of variable `x`\n"
 
 function main() {
     let x = 10

--- a/selfhost/parser.jakt
+++ b/selfhost/parser.jakt
@@ -1273,7 +1273,7 @@ struct Parser {
                     if .current() is LCurly {
                         .index++
                     } else {
-                        .error("Expected ‘{’", .current().span())
+                        .error("Expected `{`", .current().span())
                     }
                     mut namespace_ = .parse_namespace()
                     if .current() is RCurly {
@@ -1722,7 +1722,7 @@ struct Parser {
         if .current() is Enum {
             .index++
         } else {
-            .error("Expected ‘enum’ keyword", .current().span())
+            .error("Expected `enum` keyword", .current().span())
             return parsed_enum
         }
 
@@ -1792,7 +1792,7 @@ struct Parser {
         if .current() is LCurly {
             .index++
         } else {
-            .error("Expected ‘{’", .current().span())
+            .error("Expected `{`", .current().span())
         }
 
         mut fields: [ParsedField] = []
@@ -1851,7 +1851,7 @@ struct Parser {
                     last_visibility_span = None
 
                     if last_virtual or last_override {
-                        .error("Fields cannot be ‘virtual’ or ‘override’", .current().span())
+                        .error("Fields cannot be `virtual` or `override`", .current().span())
                     }
                     last_virtual = false
                     last_override = false
@@ -1906,9 +1906,9 @@ struct Parser {
             }
         }
         if is_class {
-            .error("Incomplete class body, expected ‘}’", .current().span())
+            .error("Incomplete class body, expected `}`", .current().span())
         } else {
-            .error("Incomplete struct body, expected ‘}’", .current().span())
+            .error("Incomplete struct body, expected `}`", .current().span())
         }
         return (fields, methods)
     }
@@ -2066,15 +2066,15 @@ struct Parser {
                 }
                 Anon => {
                     if parameter_complete and not error  {
-                        .error("‘anon’ must appear at start of parameter declaration, not the end", .current().span())
+                        .error("`anon` must appear at start of parameter declaration, not the end", .current().span())
                         error = true
                     }
                     if current_param_is_mutable and not error  {
-                        .error("‘anon’ must appear before ‘mut’", .current().span())
+                        .error("`anon` must appear before `mut`", .current().span())
                         error = true
                     }
                     if not current_param_requires_label and not error  {
-                        .error("‘anon’ cannot appear multiple times in one parameter declaration", .current().span())
+                        .error("`anon` cannot appear multiple times in one parameter declaration", .current().span())
                         error = true
                     }
                     .index++
@@ -2082,11 +2082,11 @@ struct Parser {
                 }
                 Mut => {
                     if parameter_complete and not error  {
-                        .error("‘mut’ must appear at start of parameter declaration, not the end", .current().span())
+                        .error("`mut` must appear at start of parameter declaration, not the end", .current().span())
                         error = true
                     }
                     if current_param_is_mutable and not error  {
-                        .error("‘mut’ cannot appear multiple times in one parameter declaration", .current().span())
+                        .error("`mut` cannot appear multiple times in one parameter declaration", .current().span())
                         error = true
                     }
                     .index++
@@ -2546,7 +2546,7 @@ struct Parser {
             }
             types.push(type)
         }
-        .error("Expected ‘)’", .current().span())
+        .error("Expected `)`", .current().span())
         return ParsedType::Empty
     }
 
@@ -2632,7 +2632,7 @@ struct Parser {
                 .index++
                 let expr = .parse_expression(allow_assignments: false, allow_newlines: false)
                 if not inside_block {
-                    .error("‘yield’ can only be used inside a block", span: merge_spans(start, end: expr.span()))
+                    .error("`yield` can only be used inside a block", span: merge_spans(start, end: expr.span()))
                 }
                 yield ParsedStatement::Yield(expr, span: merge_spans(start, .previous().span()))
             }
@@ -2748,7 +2748,7 @@ struct Parser {
                 .index++
             }
         } else {
-            .error("Expected ‘catch’", .current().span())
+            .error("Expected `catch`", .current().span())
         }
 
         let catch_block = .parse_block()
@@ -2786,7 +2786,7 @@ struct Parser {
         if .current() is In {
             .index++
         } else {
-            .error("Expected ‘in’", .current().span())
+            .error("Expected `in`", .current().span())
             return ParsedStatement::Garbage(merge_spans(start_span, .current().span()))
         }
 
@@ -2819,7 +2819,7 @@ struct Parser {
 
     function parse_if_statement(mut this) throws -> ParsedStatement {
         if not .current() is If {
-            .error("Expected ‘if’ statement", .current().span())
+            .error("Expected `if` statement", .current().span())
             return ParsedStatement::Garbage(span: .current().span())
         }
 
@@ -2849,7 +2849,7 @@ struct Parser {
                     else_statement = ParsedStatement::Block(block, span: merge_spans(start_span, .previous().span()))
                 }
                 else => {
-                    .error("‘else’ missing ‘if’ or block", .previous().span())
+                    .error("`else` missing `if` or block", .previous().span())
                 }
             }
         }
@@ -3256,7 +3256,7 @@ struct Parser {
         let start = .current().span()
 
         if not .current() is LCurly {
-            .error("Expected ‘{’", .current().span())
+            .error("Expected `{`", .current().span())
             return ParsedExpression::Garbage(.current().span())
         }
         .index++
@@ -3284,7 +3284,7 @@ struct Parser {
 
         let end = .index - 1
         if end >= .tokens.size() or not .tokens[end] is RCurly {
-            .error("Expected ‘}’ to close the set", .tokens[end].span())
+            .error("Expected `}` to close the set", .tokens[end].span())
         }
 
         return ParsedExpression::Set(values: output, span: merge_spans(start, .tokens[end].span()))
@@ -3381,7 +3381,7 @@ struct Parser {
                     if is_optional {
                         .index++
                         if not .current() is Dot {
-                            .error("Expected ‘.’ after ‘?’ for optional chaining access", .current().span())
+                            .error("Expected `.` after `?` for optional chaining access", .current().span())
                         }
                     }
 
@@ -3571,7 +3571,7 @@ struct Parser {
         .skip_newlines()
 
         if not .current() is LCurly {
-            .error("Expected ‘{’", .current().span())
+            .error("Expected `{`", .current().span())
             return cases
         }
 
@@ -3588,7 +3588,7 @@ struct Parser {
             if .current() is FatArrow {
                 .index++
             } else {
-                .error("Expected ‘=>’", .current().span())
+                .error("Expected `=>`", .current().span())
             }
 
             .skip_newlines()
@@ -3617,7 +3617,7 @@ struct Parser {
         .skip_newlines()
 
         if not .current() is RCurly {
-            .error("Expected ‘}’", .current().span())
+            .error("Expected `}`", .current().span())
         }
 
         .index++
@@ -3687,7 +3687,7 @@ struct Parser {
         }
 
         else => {
-            .error("Expected pattern or ‘else’", .current().span())
+            .error("Expected pattern or `else`", .current().span())
             yield ParsedMatchPattern::CatchAll
         }
     }
@@ -3714,7 +3714,7 @@ struct Parser {
                                     span)
                                 )
                             } else {
-                                .error("Expected binding after ‘:’", .current().span())
+                                .error("Expected binding after `:`", .current().span())
                             }
                         } else {
                             variant_arguments.push(EnumVariantPatternArgument(
@@ -3875,7 +3875,7 @@ struct Parser {
         if .current() is LParen {
             .index++
         } else {
-            .error("Expected ‘(’", .current().span())
+            .error("Expected `(`", .current().span())
         }
 
         mut whitelist: [ParsedType] = []
@@ -3916,7 +3916,7 @@ struct Parser {
         if .current() is RParen {
             .index++
         } else {
-            .error("Expected ‘)’", .current().span())
+            .error("Expected `)`", .current().span())
         }
 
         return Visibility::Restricted(whitelist, span: restricted_span)
@@ -3927,7 +3927,7 @@ struct Parser {
         let start = .current().span()
 
         if not .current() is LSquare {
-            .error("Expected ‘[’", .current().span());
+            .error("Expected `[`", .current().span());
             return ParsedExpression::Garbage(.current().span())
         }
         .index++
@@ -3962,7 +3962,7 @@ struct Parser {
                             is_dictionary = true
                             break
                         } else {
-                            .error("Expected ‘]’", .current().span())
+                            .error("Expected `]`", .current().span())
                         }
                     } else {
                         .error("Missing key in dictionary literal", .current().span())
@@ -3997,7 +3997,7 @@ struct Parser {
 
         let end = .index - 1
         if end >= .tokens.size() or not .tokens[end] is RSquare {
-            .error("Expected ‘]’ to close the array", .tokens[end].span())
+            .error("Expected `]` to close the array", .tokens[end].span())
         }
 
         if is_dictionary {

--- a/selfhost/typechecker.jakt
+++ b/selfhost/typechecker.jakt
@@ -426,7 +426,7 @@ struct Typechecker {
         if found_type_id.has_value() and not found_type_id!.equals(type_id) {
             // FIXME: Show hint of the original definition, once we store the name span.
             .error(
-                format("Redefinition of type ‘{}’", type_name)
+                format("Redefinition of type `{}`", type_name)
                 span
             )
             return false
@@ -440,7 +440,7 @@ struct Typechecker {
         for existing_function in scope.functions.iterator() {
             if name == existing_function.0 {
                 let function_ = .get_function(existing_function.1)
-                .error_with_hint(message: format("Redefinition of function ‘{}’", name), span, hint: "previous definition here", hint_span: function_.name_span)
+                .error_with_hint(message: format("Redefinition of function `{}`", name), span, hint: "previous definition here", hint_span: function_.name_span)
                 return false
             }
         }
@@ -453,7 +453,7 @@ struct Typechecker {
         for existing_var in scope.vars.iterator() {
             if name == existing_var.0 {
                 let variable_ = .get_variable(existing_var.1)
-                .error_with_hint(message: format("Redefinition of variable ‘{}’", name), span, hint: "previous definition here", hint_span: variable_.definition_span)
+                .error_with_hint(message: format("Redefinition of variable `{}`", name), span, hint: "previous definition here", hint_span: variable_.definition_span)
             }
         }
         scope.vars.set(key: name, value: var_id)
@@ -465,7 +465,7 @@ struct Typechecker {
         for existing in scope.comptime_bindings.iterator() {
             if name == existing.0 {
                 .error_with_hint(
-                    message: format("Redefinition of comptime variable ‘{}’", name)
+                    message: format("Redefinition of comptime variable `{}`", name)
                     span
                     hint: "previous definition here"
                     hint_span: existing.1.span)
@@ -1988,7 +1988,7 @@ struct Typechecker {
         if contains_reference {
             .error(
                 format(
-                    "Reference type ‘{}’ not usable in this context"
+                    "Reference type `{}` not usable in this context"
                     .type_name(type_id)
                 )
                 span
@@ -2277,7 +2277,7 @@ struct Typechecker {
                     if seen_type_id_string.value() != rhs_type_id_string {
                         .error(
                             format(
-                                "Type mismatch: expected ‘{}’, but got ‘{}’"
+                                "Type mismatch: expected `{}`, but got `{}`"
                                 .type_name(seen_type_id)
                                 .type_name(rhs_type_id)
                             )
@@ -2315,7 +2315,7 @@ struct Typechecker {
                 } else {
                     if not rhs_type_id.equals(lhs_type_id) {
                         .error(
-                            format("Type mismatch: expected ‘{}’, but got ‘{}’", .type_name(lhs_type_id), .type_name(rhs_type_id))
+                            format("Type mismatch: expected `{}`, but got `{}`", .type_name(lhs_type_id), .type_name(rhs_type_id))
                             span
                         )
                         return false
@@ -2325,7 +2325,7 @@ struct Typechecker {
             Function(params: lhs_params, can_throw: lhs_can_throw, return_type_id: lhs_return_type_id) => {
                 guard rhs_type is Function(params: rhs_params, can_throw: rhs_can_throw, return_type_id: rhs_return_type_id) else {
                     .error(
-                        format("Type mismatch: expected ‘{}’, but got ‘{}’", .type_name(lhs_type_id), .type_name(rhs_type_id))
+                        format("Type mismatch: expected `{}`, but got `{}`", .type_name(lhs_type_id), .type_name(rhs_type_id))
                         span
                     )
                     return false
@@ -2343,14 +2343,14 @@ struct Typechecker {
                     }
 
                     .error(
-                        format("Function can throw mismatch: expected ‘{}’, but got ‘{}’", lhs_throw, rhs_throw)
+                        format("Function can throw mismatch: expected `{}`, but got `{}`", lhs_throw, rhs_throw)
                         span
                     )
                 }
 
                 if not (lhs_params.size() == rhs_params.size()) {
                     .error(
-                        format("Function parameter count mismatch: expected ‘{}’, but got ‘{}’", lhs_params.size(), rhs_params.size())
+                        format("Function parameter count mismatch: expected `{}`, but got `{}`", lhs_params.size(), rhs_params.size())
                         span
                     )
                     return false
@@ -2363,9 +2363,9 @@ struct Typechecker {
                     span
                 ) {
                     .error_with_hint(
-                        format("Function type mismatch: expected ‘{}’, but got ‘{}’", .type_name(lhs_type_id), .type_name(rhs_type_id))
+                        format("Function type mismatch: expected `{}`, but got `{}`", .type_name(lhs_type_id), .type_name(rhs_type_id))
                         span
-                        format("The return types differ: expected ‘{}’, but got ‘{}’", .type_name(lhs_return_type_id), .type_name(rhs_return_type_id))
+                        format("The return types differ: expected `{}`, but got `{}`", .type_name(lhs_return_type_id), .type_name(rhs_return_type_id))
                         hint_span: span
                     )
                     return false
@@ -2379,9 +2379,9 @@ struct Typechecker {
                         span
                     ) {
                         .error_with_hint(
-                            format("Function type mismatch: expected ‘{}’, but got ‘{}’", .type_name(lhs_type_id), .type_name(rhs_type_id))
+                            format("Function type mismatch: expected `{}`, but got `{}`", .type_name(lhs_type_id), .type_name(rhs_type_id))
                             span
-                            format("The parameter types differ at argument {}: expected ‘{}’, but got ‘{}’", (i + 1), .type_name(lhs_params[i]), .type_name(rhs_params[i]))
+                            format("The parameter types differ at argument {}: expected `{}`, but got `{}`", (i + 1), .type_name(lhs_params[i]), .type_name(rhs_params[i]))
                             hint_span: span
                         )
                         return false
@@ -2433,7 +2433,7 @@ struct Typechecker {
                         }
                     } else {
                         .error(
-                            format("Type mismatch: expected ‘{}’, but got ‘{}’", .type_name(lhs_type_id), .type_name(rhs_type_id))
+                            format("Type mismatch: expected `{}`, but got `{}`", .type_name(lhs_type_id), .type_name(rhs_type_id))
                             span
                         )
                         return false
@@ -2441,7 +2441,7 @@ struct Typechecker {
                 } else {
                     if not rhs_type_id.equals(lhs_type_id) {
                         .error(
-                            format("Type mismatch: expected ‘{}’, but got ‘{}’", .type_name(lhs_type_id), .type_name(rhs_type_id))
+                            format("Type mismatch: expected `{}`, but got `{}`", .type_name(lhs_type_id), .type_name(rhs_type_id))
                             span
                         )
                         return false
@@ -2483,7 +2483,7 @@ struct Typechecker {
                             if seen_type_id_string.value() != lhs_type_id_string {
                                 .error(
                                     format(
-                                        "Type mismatch: expected ‘{}’, but got ‘{}’"
+                                        "Type mismatch: expected `{}`, but got `{}`"
                                         .type_name(lhs_type_id)
                                         .type_name(TypeId::from_string(seen_type_id_string.value()))
                                     )
@@ -2498,7 +2498,7 @@ struct Typechecker {
                     else => {
                         if not rhs_type_id.equals(lhs_type_id) {
                             .error(
-                                format("Type mismatch: expected ‘{}’, but got ‘{}’", .type_name(lhs_type_id), .type_name(rhs_type_id))
+                                format("Type mismatch: expected `{}`, but got `{}`", .type_name(lhs_type_id), .type_name(rhs_type_id))
                                 span
                             )
                             return false
@@ -2514,7 +2514,7 @@ struct Typechecker {
                 match rhs_type {
                     GenericInstance(id, args) => {
                         if not lhs_struct_id.equals(id) {
-                            .error(format("Type mismatch: expected ‘{}’, but got ‘{}’", .type_name(lhs_type_id), .type_name(rhs_type_id)), span)
+                            .error(format("Type mismatch: expected `{}`, but got `{}`", .type_name(lhs_type_id), .type_name(rhs_type_id)), span)
                             return false
                         }
 
@@ -2549,7 +2549,7 @@ struct Typechecker {
                             if seen_type_id_string.value() != lhs_type_id_string {
                                 .error(
                                     format(
-                                        "Type mismatch: expected ‘{}’, but got ‘{}’"
+                                        "Type mismatch: expected `{}`, but got `{}`"
                                         .type_name(TypeId::from_string(seen_type_id_string.value()))
                                         .type_name(rhs_type_id)
                                     )
@@ -2569,7 +2569,7 @@ struct Typechecker {
                         
                         if not rhs_type_id.equals(lhs_type_id) {
                             .error(
-                                format("Type mismatch: expected ‘{}’, but got ‘{}’", .type_name(lhs_type_id), .type_name(rhs_type_id))
+                                format("Type mismatch: expected `{}`, but got `{}`", .type_name(lhs_type_id), .type_name(rhs_type_id))
                                 span
                             )
                             return false
@@ -2595,7 +2595,7 @@ struct Typechecker {
                 } else {
                     if not rhs_type_id.equals(lhs_type_id) {
                         .error(
-                            format("Type mismatch: expected ‘{}’, but got ‘{}’", .type_name(lhs_type_id), .type_name(rhs_type_id))
+                            format("Type mismatch: expected `{}`, but got `{}`", .type_name(lhs_type_id), .type_name(rhs_type_id))
                             span
                         )
                         return false
@@ -2618,7 +2618,7 @@ struct Typechecker {
             else => {
                 if generic_inferences.map(rhs_type_id_string) != generic_inferences.map(lhs_type_id_string) {
                     .error(
-                        format("Type mismatch: expected ‘{}’, but got ‘{}’", .type_name(lhs_type_id), .type_name(rhs_type_id))
+                        format("Type mismatch: expected `{}`, but got `{}`", .type_name(lhs_type_id), .type_name(rhs_type_id))
                         span
                     )
                     return false
@@ -2797,7 +2797,7 @@ struct Typechecker {
                             return maybe_type_and_scope!.0
                         }
 
-                        .error(format("Unknown type ‘{}’", name), span)
+                        .error(format("Unknown type `{}`", name), span)
                         return unknown_type_id()
                     }
                 }
@@ -3046,7 +3046,7 @@ struct Typechecker {
         if raw_number > (max_signed + 1) or not negated_number_constant.can_fit_number(type_id: flipped_sign_type, program: .program) {
             .error(
                 format(
-                    "Negative literal -{} too small for type ‘{}’"
+                    "Negative literal -{} too small for type `{}`"
                     raw_number
                     .type_name(flipped_sign_type)
                 )
@@ -3112,7 +3112,7 @@ struct Typechecker {
                     }
                 } else {
                     .error_with_hint(format(
-                        "None coalescing (??) with incompatible types (‘{}’ and ‘{}’)",
+                        "None coalescing (??) with incompatible types (`{}` and `{}`)",
                         .type_name(lhs_type_id),
                         .type_name(rhs_type_id),
                     ), span,
@@ -3121,7 +3121,7 @@ struct Typechecker {
                 }
 
                 .error(format(
-                    "None coalescing (??) with incompatible types (‘{}’ and ‘{}’)",
+                    "None coalescing (??) with incompatible types (`{}` and `{}`)",
                     .type_name(lhs_type_id),
                     .type_name(rhs_type_id),
                 ), span)
@@ -3175,7 +3175,7 @@ struct Typechecker {
 
                 let result = .unify(lhs: rhs_type_id, lhs_span: rhs_span, rhs: lhs_type_id, rhs_span: lhs_span)
                 if not result.has_value() {
-                    .error(format("Assignment between incompatible types (‘{}’ and ‘{}’)", .type_name(lhs_type_id), .type_name(rhs_type_id)), span)
+                    .error(format("Assignment between incompatible types (`{}` and `{}`)", .type_name(lhs_type_id), .type_name(rhs_type_id)), span)
                 }
                 return result.value_or(lhs_type_id)
             }
@@ -3192,7 +3192,7 @@ struct Typechecker {
                 let result = .unify(lhs: rhs_type_id, lhs_span: rhs_span, rhs: lhs_type_id, rhs_span: lhs_span)
                 if not result.has_value() {
                     .error(format(
-                        "Assignment between incompatible types (‘{}’ and ‘{}’)",
+                        "Assignment between incompatible types (`{}` and `{}`)",
                         .type_name(lhs_type_id),
                         .type_name(rhs_type_id),
                     ), span)
@@ -3205,7 +3205,7 @@ struct Typechecker {
                 let result = .unify(lhs: rhs_type_id, lhs_span: rhs_span, rhs: lhs_type_id, rhs_span: lhs_span)
                 if not result.has_value() {
                     .error(format(
-                        "Binary arithmetic operation between incompatible types (‘{}’ and ‘{}’)",
+                        "Binary arithmetic operation between incompatible types (`{}` and `{}`)",
                         .type_name(lhs_type_id),
                         .type_name(rhs_type_id),
                     ),
@@ -3602,15 +3602,15 @@ struct Typechecker {
                     .error("Weak reference must be mutable", var.span)
                 }
                 if not lhs_type_id.equals(rhs_type_id) and not args[0].equals(rhs_type_id) and not rhs_type_id.equals(unknown_type_id()) {
-                    .error(format("Type mismatch: expected ‘{}’, but got ‘{}’", .type_name(lhs_type_id), .type_name(rhs_type_id)), checked_expr.span())
+                    .error(format("Type mismatch: expected `{}`, but got `{}`", .type_name(lhs_type_id), .type_name(rhs_type_id)), checked_expr.span())
                 }
             } else if id.equals(optional_struct_id) {
                 if not lhs_type_id.equals(rhs_type_id) and not args[0].equals(rhs_type_id) and not rhs_type_id.equals(unknown_type_id()) {
-                    .error(format("Type mismatch: expected ‘{}’, but got ‘{}’", .type_name(lhs_type_id), .type_name(rhs_type_id)), checked_expr.span())
+                    .error(format("Type mismatch: expected `{}`, but got `{}`", .type_name(lhs_type_id), .type_name(rhs_type_id)), checked_expr.span())
                 }
             } else {
                 if not lhs_type_id.equals(rhs_type_id) and not rhs_type_id.equals(unknown_type_id()) {
-                    .error(format("Type mismatch: expected ‘{}’, but got ‘{}’", .type_name(lhs_type_id), .type_name(rhs_type_id)), checked_expr.span())
+                    .error(format("Type mismatch: expected `{}`, but got `{}`", .type_name(lhs_type_id), .type_name(rhs_type_id)), checked_expr.span())
                 }
             }
         } else if lhs_type.is_builtin() {
@@ -3626,12 +3626,12 @@ struct Typechecker {
             }
 
             if not (.is_numeric(lhs_type_id) and is_rhs_zero) and (.is_integer(lhs_type_id) ^ .is_integer(rhs_type_id)) {
-                .error(format("Type mismatch: expected ‘{}’, but got ‘{}’", .type_name(lhs_type_id), .type_name(rhs_type_id)), checked_expr.span())
+                .error(format("Type mismatch: expected `{}`, but got `{}`", .type_name(lhs_type_id), .type_name(rhs_type_id)), checked_expr.span())
                 return CheckedStatement::Garbage(span)
             }
         } else {
             if not lhs_type_id.equals(rhs_type_id) and not rhs_type_id.equals(unknown_type_id()) {
-                .error(format("Type mismatch: expected ‘{}’, but got ‘{}’", .type_name(lhs_type_id), .type_name(rhs_type_id)), checked_expr.span())
+                .error(format("Type mismatch: expected `{}`, but got `{}`", .type_name(lhs_type_id), .type_name(rhs_type_id)), checked_expr.span())
             }
         }
 
@@ -3663,7 +3663,7 @@ struct Typechecker {
 
         let checked_block = .typecheck_block(block, parent_scope_id: scope_id, safety_mode)
         if checked_block.yielded_type.has_value() {
-            .error("A ‘while’ block is not allowed to yield values", block.find_yield_span()!)
+            .error("A `while` block is not allowed to yield values", block.find_yield_span()!)
         }
 
         return CheckedStatement::While(condition: checked_condition, block: checked_block, span)
@@ -3724,7 +3724,7 @@ struct Typechecker {
             if block.control_flow.always_transfers_control() or block.yielded_type.has_value() {
                 if not (block.yielded_type ?? expression_type_id).equals(expression_type_id) {
                     .error_with_hint(
-                        message: format("Expected a value of type ‘{}’, but got ‘{}’", .type_name(expression_type_id), .type_name(block.yielded_type!)),
+                        message: format("Expected a value of type `{}`, but got `{}`", .type_name(expression_type_id), .type_name(block.yielded_type!)),
                         span
                         hint: format("Expression 'catch' block must either yield the same type as the expression it is catching, or yield nothing"),
                         hint_span: span
@@ -3758,7 +3758,7 @@ struct Typechecker {
     function typecheck_loop(mut this, parsed_block: ParsedBlock, scope_id: ScopeId, safety_mode: SafetyMode, span: Span) throws -> CheckedStatement {
         let checked_block = .typecheck_block(parsed_block, parent_scope_id: scope_id, safety_mode)
         if checked_block.yielded_type.has_value() {
-            .error("A ‘loop’ block is not allowed to yield values", parsed_block.find_yield_span()!)
+            .error("A `loop` block is not allowed to yield values", parsed_block.find_yield_span()!)
         }
         return CheckedStatement::Loop(block: checked_block, span)
     }
@@ -3769,7 +3769,7 @@ struct Typechecker {
         defer .inside_defer = was_inside_defer
         let checked_statement = .typecheck_statement(statement, scope_id, safety_mode)
         if checked_statement is Block(block) and block.yielded_type.has_value() {
-            .error("‘yield’ inside ‘defer’ is meaningless", span)
+            .error("`yield` inside `defer` is meaningless", span)
         }
         return CheckedStatement::Defer(statement: checked_statement, span)
     }
@@ -3802,7 +3802,7 @@ struct Typechecker {
 
     function typecheck_return(mut this, expr: ParsedExpression?, span: Span, scope_id: ScopeId, safety_mode: SafetyMode) throws -> CheckedStatement {
         if .inside_defer {
-            .error("‘return’ is not allowed inside ‘defer’", span)
+            .error("`return` is not allowed inside `defer`", span)
         }
         if not expr.has_value() {
             return CheckedStatement::Return(val: None, span)
@@ -3885,7 +3885,7 @@ struct Typechecker {
 
                         .error(format("unknown member of struct: {}.{}", structure.name, field), span)
                     }
-                    else => .error(format("Member field access on value of non-struct type ‘{}’", .type_name(checked_expr_type_id)), span)
+                    else => .error(format("Member field access on value of non-struct type `{}`", .type_name(checked_expr_type_id)), span)
                 }
             }
             Type::Struct(struct_id) => {
@@ -3912,7 +3912,7 @@ struct Typechecker {
 
                 .error(format("unknown member of struct: {}.{}", structure.name, field), span)
             }
-            else => .error(format("Member field access on value of non-struct type ‘{}’", .type_name(checked_expr_type_id)), span)
+            else => .error(format("Member field access on value of non-struct type `{}`", .type_name(checked_expr_type_id)), span)
         }
 
         // FIXME: Unify with type
@@ -3973,7 +3973,7 @@ struct Typechecker {
         match member.visibility {
             Private => {
                 if not .scope_can_access(accessor, accessee) {
-                    .error(format("Can't access field ‘{}’, because it is marked private", member.name), span)
+                    .error(format("Can't access field `{}`, because it is marked private", member.name), span)
                 }
             }
             Restricted(whitelist, span) => {
@@ -3988,13 +3988,13 @@ struct Typechecker {
             Private => {
                 if not .scope_can_access(accessor, accessee) {
                     if not method.type is Normal {
-                        .error_with_hint(format("Can't access constructor ‘{}’, because it is marked private", method.name)
+                        .error_with_hint(format("Can't access constructor `{}`, because it is marked private", method.name)
                             span
                             hint: "Private constructors are created if any fields are private"
                             span
                         )
                     } else {
-                        .error(format("Can't access method ‘{}’, because it is marked private", method.name), span)
+                        .error(format("Can't access method `{}`, because it is marked private", method.name), span)
                     }
                 }
             }
@@ -4007,7 +4007,7 @@ struct Typechecker {
 
     function check_restricted_access(mut this, accessor: ScopeId, accessee_kind: String, accessee: ScopeId, name: String, whitelist: [ParsedType], span: Span) throws {
         if not .current_struct_type_id.has_value() {
-            .error(format("Can't access {} ‘{}’ from scope ‘{}’, because ‘{}’ is not in the restricted whitelist", accessee_kind, name, .get_scope(accessor).namespace_name, .get_scope(accessor).namespace_name), span)
+            .error(format("Can't access {} `{}` from scope `{}`, because `{}` is not in the restricted whitelist", accessee_kind, name, .get_scope(accessor).namespace_name, .get_scope(accessor).namespace_name), span)
             return
         }
         let own_type_id = .current_struct_type_id!
@@ -4024,10 +4024,10 @@ struct Typechecker {
                 }
             }
             if not was_whitelisted {
-                .error(format("Can't access {} ‘{}’ from ‘{}’, because ‘{}’ is not in the restricted whitelist", accessee_kind, name, .get_struct(id).name, .get_struct(id).name), span)
+                .error(format("Can't access {} `{}` from `{}`, because `{}` is not in the restricted whitelist", accessee_kind, name, .get_struct(id).name, .get_struct(id).name), span)
             }
         } else {
-            .error(format("Can't access {} ‘{}’ from scope ‘{}’, because it is not in the restricted whitelist", accessee_kind, name, .get_scope(accessor).namespace_name), span)
+            .error(format("Can't access {} `{}` from scope `{}`, because it is not in the restricted whitelist", accessee_kind, name, .get_scope(accessor).namespace_name), span)
         }
     }
 
@@ -4249,7 +4249,7 @@ struct Typechecker {
                             let optional_struct_id = .find_struct_in_prelude("Optional")
                             mut struct_id: StructOrEnumId? = None
                             if not id.equals(optional_struct_id) {
-                                .error(format("Can't use ‘{}’ as an optional type in optional chained call", .get_struct(id).name), span)
+                                .error(format("Can't use `{}` as an optional type in optional chained call", .get_struct(id).name), span)
                             } else {
                                 found_optional = true
                                 struct_id = match .get_type(args[0]) {
@@ -4696,7 +4696,7 @@ struct Typechecker {
     function typecheck_enum_variant_bindings(mut this, variant: CheckedEnumVariant, bindings: [EnumVariantPatternArgument], span: Span) throws -> [CheckedEnumVariantBinding]? {
         if variant is Typed(type_id) {
             if bindings.size() != 1 {
-                .error(format("Enum variant ‘{}’ must have exactly one argument", variant.name()), span)
+                .error(format("Enum variant `{}` must have exactly one argument", variant.name()), span)
                 return None
             }
             return [CheckedEnumVariantBinding(name: None, binding: bindings[0].binding, type_id, span)]
@@ -4825,7 +4825,7 @@ struct Typechecker {
             } else if enum_in_scope.has_value() {
                 next_scope = .get_enum(enum_in_scope!).scope_id
             } else {
-                .error(format("Namespace ‘{}’ not found", ns), span)
+                .error(format("Namespace `{}` not found", ns), span)
             }
             scopes.push(next_scope)
         }
@@ -5133,7 +5133,7 @@ struct Typechecker {
                                         covered_variants.add(name)
                                         if not variant_arguments.is_empty() {
                                             if variant_arguments.size() != 1 {
-                                                .error(format("Match case ‘{}’ must have exactly one argument", name), span)
+                                                .error(format("Match case `{}` must have exactly one argument", name), span)
                                             } else {
                                                 let variant_argument = variant_arguments[0]
                                                 let variable_type_id = .substitute_typevars_in_type(
@@ -5644,7 +5644,7 @@ struct Typechecker {
                 continue
             }
 
-            .error(format("Not a namespace, enum, class, or struct: ‘{}’", join(call.namespace_, separator: "::")), span)
+            .error(format("Not a namespace, enum, class, or struct: `{}`", join(call.namespace_, separator: "::")), span)
         }
 
         // 1. Look for a variable in the current scope with this name.
@@ -5670,7 +5670,7 @@ struct Typechecker {
         }
 
         if must_be_enum_constructor {
-            .error(format("No such enum constructor ‘{}’", call.name), span)
+            .error(format("No such enum constructor `{}`", call.name), span)
             return callee
         }
 
@@ -5687,7 +5687,7 @@ struct Typechecker {
         }
 
         if not ignore_errors {
-            .error(format("Call to unknown function: ‘{}’", call.name), span)
+            .error(format("Call to unknown function: `{}`", call.name), span)
         }
 
         return None
@@ -6179,7 +6179,7 @@ struct Typechecker {
                             return true
                         }
                         if not default_value.has_value() {
-                            .error(format("Wrong parameter name in argument label (got ‘{}’, expected ‘{}’)", name, param.variable.name), span)
+                            .error(format("Wrong parameter name in argument label (got `{}`, expected `{}`)", name, param.variable.name), span)
                         }
                         return false
                     }

--- a/tests/parser/boxed_followed_by_eof.crash.jakt
+++ b/tests/parser/boxed_followed_by_eof.crash.jakt
@@ -1,4 +1,4 @@
 /// Expect:
-/// - error: "Expected ‘enum’ keyword"
+/// - error: "Expected `enum` keyword"
 
 boxed

--- a/tests/parser/incomplete_struct.jakt
+++ b/tests/parser/incomplete_struct.jakt
@@ -1,4 +1,4 @@
 /// Expect:
-/// - error: "Incomplete struct body, expected ‘}’\n"
+/// - error: "Incomplete struct body, expected `}`\n"
 
 struct Incomplete {

--- a/tests/parser/missing_return_type_arrow.jakt
+++ b/tests/parser/missing_return_type_arrow.jakt
@@ -1,5 +1,5 @@
 /// Expect:
-/// - error: "Expected ‘throws’, ‘->’, ‘=>’ or ‘{’"
+/// - error: "Expected `throws`, `->`, `=>` or `{`"
 function foo() i64 {
     return 5
 }

--- a/tests/parser/missing_return_type_arrow_after_throws.jakt
+++ b/tests/parser/missing_return_type_arrow_after_throws.jakt
@@ -1,5 +1,5 @@
 /// Expect:
-/// - error: "Expected ‘->’, ‘=>’ or ‘{’"
+/// - error: "Expected `->`, `=>` or `{`"
 function foo() throws i64 {
     return 5
 }

--- a/tests/parser/no_return_in_defer.jakt
+++ b/tests/parser/no_return_in_defer.jakt
@@ -1,5 +1,5 @@
 /// Expect:
-/// - error: "‘return’ is not allowed inside ‘defer’"
+/// - error: "`return` is not allowed inside `defer`"
 
 function main() {
     defer {

--- a/tests/parser/unclosed_square_bracket_in_enum_value.jakt
+++ b/tests/parser/unclosed_square_bracket_in_enum_value.jakt
@@ -1,4 +1,4 @@
 /// Expect:
-/// - error: "Expected ‘]’ to close the array\n"
+/// - error: "Expected `]` to close the array\n"
 
 enum foo : i32 { b=[ }

--- a/tests/parser/yield_not_used_in_block_from_defer.jakt
+++ b/tests/parser/yield_not_used_in_block_from_defer.jakt
@@ -1,5 +1,5 @@
 /// Expect:
-/// - error: "‘yield’ can only be used inside a block"
+/// - error: "`yield` can only be used inside a block"
 
 function main() {
     defer yield 1

--- a/tests/typechecker/assign_incompatible_to_optional.jakt
+++ b/tests/typechecker/assign_incompatible_to_optional.jakt
@@ -1,5 +1,5 @@
 /// Expect:
-/// - error: "Assignment between incompatible types (‘Foo?’ and ‘i64’)\n"
+/// - error: "Assignment between incompatible types (`Foo?` and `i64`)\n"
 
 class Foo {
 }

--- a/tests/typechecker/assign_integer_to_weak.jakt
+++ b/tests/typechecker/assign_integer_to_weak.jakt
@@ -1,5 +1,5 @@
 /// Expect:
-/// - error: "Assignment between incompatible types (‘weak Foo?’ and ‘i64’)\n"
+/// - error: "Assignment between incompatible types (`weak Foo?` and `i64`)\n"
 
 class Foo {
 }

--- a/tests/typechecker/block_yield_type_mismatch.jakt
+++ b/tests/typechecker/block_yield_type_mismatch.jakt
@@ -1,5 +1,5 @@
 /// Expect:
-/// - error: "Type mismatch: expected ‘String’, but got ‘i64’"
+/// - error: "Type mismatch: expected `String`, but got `i64`"
 
 function main() {
     match 123 {

--- a/tests/typechecker/class_private_default.jakt
+++ b/tests/typechecker/class_private_default.jakt
@@ -1,5 +1,5 @@
 /// Expect:
-/// - error: "Can't access method ‘cant_touch’, because it is marked private\n"
+/// - error: "Can't access method `cant_touch`, because it is marked private\n"
 
 class GoodEncapsulation {
     function cant_touch(this) {}

--- a/tests/typechecker/class_private_field_ctr.jakt
+++ b/tests/typechecker/class_private_field_ctr.jakt
@@ -1,5 +1,5 @@
 /// Expect:
-/// - error: "Can't access constructor ‘GoodEncapsulation’, because it is marked private\n"
+/// - error: "Can't access constructor `GoodEncapsulation`, because it is marked private\n"
 
 class GoodEncapsulation {
     muda_amount: u32

--- a/tests/typechecker/class_private_field_default.jakt
+++ b/tests/typechecker/class_private_field_default.jakt
@@ -1,5 +1,5 @@
 /// Expect:
-/// - error: "Can't access field ‘muda_amount’, because it is marked private\n"
+/// - error: "Can't access field `muda_amount`, because it is marked private\n"
 
 class GoodEncapsulation {
     muda_amount: u32

--- a/tests/typechecker/class_private_static.jakt
+++ b/tests/typechecker/class_private_static.jakt
@@ -1,5 +1,5 @@
 /// Expect:
-/// - error: "Can't access method ‘private_static_function’, because it is marked private\n"
+/// - error: "Can't access method `private_static_function`, because it is marked private\n"
 
 class Foo {
     function private_static_function() {}

--- a/tests/typechecker/constructor_with_different_generic_instance.jakt
+++ b/tests/typechecker/constructor_with_different_generic_instance.jakt
@@ -1,5 +1,5 @@
 /// Expect:
-/// - error: "Type mismatch: expected ‘B’, but got ‘[unknown]’"
+/// - error: "Type mismatch: expected `B`, but got `[unknown]`"
 
 class B {
 }

--- a/tests/typechecker/field_access_on_enum.jakt
+++ b/tests/typechecker/field_access_on_enum.jakt
@@ -1,5 +1,5 @@
 /// Expect:
-/// - error: "Member field access on value of non-struct type ‘E’"
+/// - error: "Member field access on value of non-struct type `E`"
 
 enum E {
     A

--- a/tests/typechecker/function_return_type_with_fat_arrow.jakt
+++ b/tests/typechecker/function_return_type_with_fat_arrow.jakt
@@ -1,5 +1,5 @@
 /// Expect:
-/// - error: "Type mismatch: expected ‘i32’, but got ‘String’\n"
+/// - error: "Type mismatch: expected `i32`, but got `String`\n"
 
 class S {
     public function get_value() -> i32 => "Hello"

--- a/tests/typechecker/generic_function_with_function_can_throw.jakt
+++ b/tests/typechecker/generic_function_with_function_can_throw.jakt
@@ -1,5 +1,5 @@
 /// Expect:
-/// - error: "Function can throw mismatch: expected ‘Yes’, but got ‘No’"
+/// - error: "Function can throw mismatch: expected `Yes`, but got `No`"
 
 function find<T>(anon arr: [T], anon cb: function(a: T, b: T) throws -> bool) -> T? {
     for i in 0..arr.size() {

--- a/tests/typechecker/generic_function_with_function_param_wrong_param_count.jakt
+++ b/tests/typechecker/generic_function_with_function_param_wrong_param_count.jakt
@@ -1,5 +1,5 @@
 /// Expect:
-/// - error: "Function parameter count mismatch: expected ‘2’, but got ‘3’"
+/// - error: "Function parameter count mismatch: expected `2`, but got `3`"
 
 function find<T>(anon arr: [T], anon cb: function(a: T, b: T) -> bool) -> T? {
     for i in 0..arr.size() {

--- a/tests/typechecker/generic_function_with_function_param_wrong_return_type.jakt
+++ b/tests/typechecker/generic_function_with_function_param_wrong_return_type.jakt
@@ -1,5 +1,5 @@
 /// Expect:
-/// - error: "The return types differ: expected ‘bool’, but got ‘i32’"
+/// - error: "The return types differ: expected `bool`, but got `i32`"
 
 function find<T>(anon arr: [T], anon cb: function(a: T, b: T) -> bool) -> T? {
     for i in 0..arr.size() {

--- a/tests/typechecker/generic_function_with_function_param_wrong_type.jakt
+++ b/tests/typechecker/generic_function_with_function_param_wrong_type.jakt
@@ -1,5 +1,5 @@
 /// Expect:
-/// - error: "Function type mismatch: expected ‘function(T, T) -> bool’, but got ‘function(i64, i32) -> bool"
+/// - error: "Function type mismatch: expected `function(T, T) -> bool`, but got `function(i64, i32) -> bool"
 
 function find<T>(anon arr: [T], anon cb: function(a: T, b: T) -> bool) -> T? {
     for i in 0..arr.size() {

--- a/tests/typechecker/generic_late_type_check_bad.jakt
+++ b/tests/typechecker/generic_late_type_check_bad.jakt
@@ -1,5 +1,5 @@
 /// Expect:
-/// - error: "Binary arithmetic operation between incompatible types (‘String’ and ‘i64’)\n"
+/// - error: "Binary arithmetic operation between incompatible types (`String` and `i64`)\n"
 
 struct Foo<T> {
     a: T

--- a/tests/typechecker/none_coalescing_type_check.jakt
+++ b/tests/typechecker/none_coalescing_type_check.jakt
@@ -1,5 +1,5 @@
 /// Expect:
-/// - error: "None coalescing (??) with incompatible types (‘i64?’ and ‘String’)\n"
+/// - error: "None coalescing (??) with incompatible types (`i64?` and `String`)\n"
 
 function main() {
     let my_optional: i64? = 5

--- a/tests/typechecker/return_value_type_mismatch.jakt
+++ b/tests/typechecker/return_value_type_mismatch.jakt
@@ -1,5 +1,5 @@
 /// Expect:
-/// - error: "Type mismatch: expected ‘u64’, but got ‘String’\n"
+/// - error: "Type mismatch: expected `u64`, but got `String`\n"
 
 function foo() -> u64 {
     return "Foo"

--- a/tests/typechecker/simple_enum_constructor_in_unknown_namespace.jakt
+++ b/tests/typechecker/simple_enum_constructor_in_unknown_namespace.jakt
@@ -1,5 +1,5 @@
 /// Expect:
-/// - error: "Namespace ‘Foo’ not found"
+/// - error: "Namespace `Foo` not found"
 function boog() {
     Foo::Bar
 }

--- a/tests/typechecker/struct_private.jakt
+++ b/tests/typechecker/struct_private.jakt
@@ -1,5 +1,5 @@
 /// Expect:
-/// - error: "Can't access method ‘parts’, because it is marked private\n"
+/// - error: "Can't access method `parts`, because it is marked private\n"
 
 struct WeirdEncapsulation {
     private function parts(this) {}

--- a/tests/typechecker/struct_private_field.jakt
+++ b/tests/typechecker/struct_private_field.jakt
@@ -1,5 +1,5 @@
 /// Expect:
-/// - error: "Can't access field ‘age’, because it is marked private\n"
+/// - error: "Can't access field `age`, because it is marked private\n"
 
 struct WeirdEncapsulation {
     private age: i32

--- a/tests/typechecker/vardecl_type_mismatch.jakt
+++ b/tests/typechecker/vardecl_type_mismatch.jakt
@@ -1,5 +1,5 @@
 /// Expect:
-/// - error: "Type mismatch: expected ‘String’, but got ‘u64’\n"
+/// - error: "Type mismatch: expected `String`, but got `u64`\n"
 
 function main() {
     let foo: u64 = 0

--- a/tests/typechecker/vardecl_type_mismatch_literal.jakt
+++ b/tests/typechecker/vardecl_type_mismatch_literal.jakt
@@ -1,5 +1,5 @@
 /// Expect:
-/// - error: "Type mismatch: expected ‘String’, but got ‘i64’\n"
+/// - error: "Type mismatch: expected `String`, but got `i64`\n"
 
 function main() {
     let a: String = 0


### PR DESCRIPTION
This replaces the fancy quotes we currently use with backticks. Unfortunately, the fancy quotes aren't compatible with US English Windows, which makes the experience there look pretty rough (see #1173 for details)

![image](https://user-images.githubusercontent.com/547158/189494212-4413cd0d-6074-48c0-b54a-e2675e1c1c44.png)

This PR moves us to using backticks instead, which (hopefully) are more universally supported

fixes #1173 