### PR TITLE
all: Revert quote style in more places

### DIFF
--- a/samples/pointers/bad_pointer_deref.jakt
+++ b/samples/pointers/bad_pointer_deref.jakt
@@ -1,5 +1,5 @@
 /// Expect:
-/// - error: "Dereference of a non-pointer type `i64`"
+/// - error: "Dereference of a non-pointer type ‘i64’"
 
 function main() {
     let x = 4

--- a/selfhost/parser.jakt
+++ b/selfhost/parser.jakt
@@ -1637,7 +1637,7 @@ struct Parser {
                                 .index++
                             }
                             else => {
-                                .error(format("Incomplete enum variant defintion, expected `,` or `)`; got `{}`", .current()), .current().span())
+                                .error(format("Incomplete enum variant defintion, expected `,` or `)`; got ‘{}’", .current()), .current().span())
                                 break;
                             }
                         }

--- a/selfhost/typechecker.jakt
+++ b/selfhost/typechecker.jakt
@@ -249,7 +249,7 @@ struct Typechecker {
             println("{:#}", parsed_namespace)
         }
 
-        .compiler.dbg_println(format("before typechecking parsed prelude, modules `{}`", .program.modules))
+        .compiler.dbg_println(format("before typechecking parsed prelude, modules ‘{}’", .program.modules))
         .typecheck_module(
             parsed_namespace
             scope_id: prelude_scope_id
@@ -3008,7 +3008,7 @@ struct Typechecker {
                         return CheckedExpression::UnaryOp(expr: checked_expr, op: checked_op, span, type_id)
                     }
                     else => {
-                        .error(format("Dereference of a non-pointer type `{}`", .type_name(expr_type_id)), span)
+                        .error(format("Dereference of a non-pointer type ‘{}’", .type_name(expr_type_id)), span)
                     }
                 }
             }
@@ -5715,7 +5715,7 @@ struct Typechecker {
                             struct_ = .get_struct(parent_struct_id)
                             scope_id = struct_.scope_id
                         } else {
-                            .error(format("Could not find `{}`", call.name), span)
+                            .error(format("Could not find ‘{}’", call.name), span)
                             break
                         }
                     }

--- a/selfhost/types.jakt
+++ b/selfhost/types.jakt
@@ -127,13 +127,13 @@ struct TypeId {
     function from_string(anon type_id_string: String) throws -> TypeId {
         let parts = type_id_string.split('_')
         if not (parts.size() == 2) {
-            panic(format("Failed to convert string `{}` to a TypeId: Wrong number of parts. (Wanted 2, got {})", type_id_string, parts.size()))
+            panic(format("Failed to convert string ‘{}’ to a TypeId: Wrong number of parts. (Wanted 2, got {})", type_id_string, parts.size()))
         }
 
         let module_id = parts[0].to_uint()
         let type_id = parts[1].to_uint()
         if not module_id.has_value() or not type_id.has_value() {
-            panic(format("Failed to convert string `{}` to a TypeId. (module_id = {} ({}), type_id = {} ({}))", type_id_string, module_id, parts[0], type_id, parts[1]))
+            panic(format("Failed to convert string ‘{}’ to a TypeId. (module_id = {} ({}), type_id = {} ({}))", type_id_string, module_id, parts[0], type_id, parts[1]))
         }
 
         return TypeId(module: ModuleId(id: module_id.value() as! usize), id: type_id.value() as! usize)


### PR DESCRIPTION
Ran the (vim) command:
```
:s/`{}`/‘{}’/gc
```
on all selfhost files, now every quote should be back to its original style.
