### PR TITLE
vscode: Fix Windows IDE paths for includes

### DIFF
--- a/editors/vscode/server/src/server.ts
+++ b/editors/vscode/server/src/server.ts
@@ -59,6 +59,7 @@ const tmpFile = tmp.fileSync();
 
 function includeFlagForPath(file_path: string): string {
     if (file_path.startsWith("file://")) {
+        file_path = decodeURI(file_path);
         return " -I " + path.dirname(fileURLToPath(file_path));
     }
     return " -I " + file_path;


### PR DESCRIPTION
This adds a URI decode which is required on my Windows machine for the IDE support to work. Otherwise, we'd try to convert an encoded URI and fail to find any imported files from the file you're editing.