### PR TITLE
all: Move `NumericConstant` parsing to the parser

### DIFF
--- a/selfhost/formatter.jakt
+++ b/selfhost/formatter.jakt
@@ -108,20 +108,7 @@ struct FormattedToken {
         SingleQuotedString(quote) => format("'{}'", quote)
         SingleQuotedByteString(quote) => format("b'{}'", quote)
         QuotedString(quote) => format("\"{}\"", quote)
-        Number(number) => match number {
-            I8(number) => format("{}i8", number)
-            I16(number) => format("{}i16", number)
-            I32(number) => format("{}i32", number)
-            I64(number) => format("{}i64", number)
-            U8(number) => format("{}u8", number)
-            U16(number) => format("{}u16", number)
-            U32(number) => format("{}u32", number)
-            U64(number) => format("{}u64", number)
-            USize(number) => format("{}uz", number)
-            F32(number) => format("{}f32", number)
-            F64(number) => format("{}f64", number)
-            UnknownUnsigned(number) | UnknownSigned(number) => format("{}", number)
-        }
+        Number(prefix, number, suffix) => format("{}{}{}", prefix.to_string(), number, suffix.to_string())
         Identifier(name) => name
         Semicolon => ";"
         Colon => ":"

--- a/selfhost/lexer.jakt
+++ b/selfhost/lexer.jakt
@@ -5,21 +5,14 @@
 // SPDX-License-Identifier: BSD-2-Clause
 
 import error { JaktError }
-import utility { Span }
+import utility { Span, is_ascii_digit, is_ascii_alpha, is_ascii_alphanumeric, is_ascii_hexdigit, is_ascii_octdigit, is_ascii_binary, is_whitespace }
 import compiler { Compiler }
-
-// FIXME: These should not need explicit "-> bool" return types.
-function is_ascii_alpha(anon c: u8) -> bool => (c >= b'a' and c <= b'z') or (c >= b'A' and c <= b'Z')
-function is_ascii_digit(anon c: u8) -> bool => (c >= b'0' and c <= b'9')
-function is_ascii_hexdigit(anon c: u8) -> bool => (c >= b'0' and c <= b'9') or (c >= b'a' and c <= b'f') or (c >= b'A' and c <= b'F')
-function is_ascii_octdigit(anon c: u8) -> bool => (c >= b'0' and c <= b'7')
-function is_ascii_alphanumeric(anon c: u8) -> bool => is_ascii_alpha(c) or is_ascii_digit(c)
 
 enum Token {
     SingleQuotedString(quote: String, span: Span)
     SingleQuotedByteString(quote: String, span: Span)
     QuotedString(quote: String, span: Span)
-    Number(number: NumericConstant, span: Span)
+    Number(prefix: LiteralPrefix, number: String, suffix: LiteralSuffix, span: Span)
     Identifier(name: String, span: Span)
     Semicolon(Span)
     Colon(Span)
@@ -181,6 +174,20 @@ enum Token {
     }
 }
 
+enum LiteralPrefix {
+    None
+    Hexadecimal
+    Octal
+    Binary
+
+    function to_string(this) => match this {
+        None => ""
+        Hexadecimal => "0x"
+        Octal => "0o"
+        Binary => "0b"
+    }
+}
+
 enum LiteralSuffix {
     None
     UZ
@@ -194,76 +201,22 @@ enum LiteralSuffix {
     I64
     F32
     F64
-}
 
-enum NumericConstant {
-    I8(i8)
-    I16(i16)
-    I32(i32)
-    I64(i64)
-    U8(u8)
-    U16(u16)
-    U32(u32)
-    U64(u64)
-    USize(u64)
-    F32(f32)
-    F64(f64)
-    UnknownSigned(i64)
-    UnknownUnsigned(u64)
-
-    public function to_usize(this) => match this {
-        I8(num) => num as! usize
-        I16(num) => num as! usize
-        I32(num) => num as! usize
-        I64(num) => num as! usize
-        U8(num) => num as! usize
-        U16(num) => num as! usize
-        U32(num) => num as! usize
-        U64(num) => num as! usize
-        USize(num) => num as! usize
-        UnknownSigned(num) => num as! usize
-        UnknownUnsigned(num) => num as! usize
-        // FIXME: handle floats properly - if the function is used at all?
-        else =>  0 as! usize
+    function to_string(this) => match this {
+        None => ""
+        UZ => "uz"
+        U8 => "u8"
+        U16 => "u16"
+        U32 => "u32"
+        U64 => "u64"
+        I8 => "i8"
+        I16 => "i16"
+        I32 => "i32"
+        I64 => "i64"
+        F32 => "f32"
+        F64 => "f64"
     }
 }
-
-function make_float_token(number: f64, suffix: LiteralSuffix, span: Span) throws -> Token => match suffix {
-    // FIXME: consider unifying with make_integer_token() to a single function
-    LiteralSuffix::F32 => Token::Number(number: NumericConstant::F32(f64_to_f32(number)), span)
-    LiteralSuffix::F64 => Token::Number(number: NumericConstant::F64(number), span)
-
-    else => Token::Garbage(span)
-}
-
-// A simple function to convert integers to floats. T is intended
-// to be either f32 or f64.
-// FIXME: Remove when a more general conversion is in place
-function u64_to_float<T>(anon number: u64) -> T {
-    mut float_value: T = 0
-
-    unsafe {
-        cpp {
-            "float_value = number;"
-        }
-    }
-
-    return float_value
-}
-
-// FIXME: Remove when a more general conversion is in place
-function f64_to_f32(anon number: f64) -> f32 {
-    mut f32_value: f32 = 0
-
-    unsafe {
-        cpp {
-            "f32_value = (f32)number;"
-        }
-    }
-
-    return f32_value
-}
-
 
 struct Lexer {
     index: usize
@@ -410,222 +363,79 @@ struct Lexer {
         return Token::Garbage(.span(start, end))
     }
 
+    function valid_digit(mut this, prefix: LiteralPrefix, digit: u8, decimal_allowed: bool = true) -> bool => match prefix {
+        Hexadecimal => is_ascii_hexdigit(digit)
+        Octal => is_ascii_octdigit(digit)
+        Binary => is_ascii_binary(digit)
+        else => is_ascii_digit(digit) or (decimal_allowed and digit == b'.')
+    }
+
     function lex_number(mut this) throws -> Token {
         let start = .index
-        mut total = 0u64
+
+        mut floating: bool = false
+        mut prefix = LiteralPrefix::None
+        mut number = StringBuilder::create()
 
         if .peek() == b'0' {
             match .peek_ahead(1) {
-                // Hexadecimal number
                 b'x' => {
+                    prefix = LiteralPrefix::Hexadecimal
                     .index += 2
-                    while(is_ascii_hexdigit(.peek())) {
-                        mut offset: u8 = 0
-                        if (.peek() >= b'a' and .peek() <= b'z') {
-                            offset = 39
-                        } else if (.peek() >= b'A' and .peek() <= b'Z') {
-                            offset = 7
-                        }
-                        let value = .input[.index] - offset
-                        ++.index
-                        let digit: u64 = as_saturated(value - b'0')
-                        total = total * 16 + digit
-                        if .peek() == b'_' {
-                            ++.index
-                        }
-                    }
-                    let end = .index
-                    let span = .span(start, end)
-
-                    if .peek_behind(1) == b'_' {
-                        .error(
-                            "Hexadecimal number literal cannot end with underscore"
-                            span
-                        )
-                        return Token::Garbage(span)
-                    }
-
-                    let suffix = .consume_numeric_literal_suffix() ?? LiteralSuffix::None
-
-                    return .make_integer_token(number: total, suffix, span: .span(start, end))
                 }
-                // Octal Number
                 b'o' => {
+                    prefix = LiteralPrefix::Octal
                     .index += 2
-                    while(is_ascii_octdigit(.peek())) {
-                        let value = .input[.index]
-                        ++.index
-                        let digit: u64 = as_saturated(value - b'0')
-                        total = total * 8 + digit
-                        if .peek() == b'_' {
-                            ++.index
-                        }
-                    }
-                    let end = .index
-                    let span = .span(start, end)
-
-                    if .peek_behind(1) == b'_' {
-                        .error(
-                            "Octal number literal cannot end with underscore"
-                            span
-                        )
-                        return Token::Garbage(span)
-                    }
-
-                    let suffix = .consume_numeric_literal_suffix() ?? LiteralSuffix::None
-
-                    if is_ascii_alphanumeric(.peek()) {
-                        .error(
-                            "Could not parse octal number"
-                            span
-                        )
-                        return Token::Garbage(span)
-                    }
-
-                    return .make_integer_token(number: total, suffix, span)
                 }
-                // Binary Number
                 b'b' => {
+                    prefix = LiteralPrefix::Binary
                     .index += 2
-                    while(.peek() == b'0' or .peek() == b'1') {
-                        let value = .input[.index]
-                        ++.index
-                        let digit: u64 = as_saturated(value - b'0')
-                        total = total * 2 + digit
-                        if .peek() == b'_' {
-                            ++.index
-                        }
-                    }
-                    let end = .index
-                    let span = .span(start, end)
-
-                    if .peek_behind(1) == b'_' {
-                        .error(
-                            "Binary number literal cannot end with underscore"
-                            span
-                        )
-                        return Token::Garbage(span)
-                    }
-
-                    let suffix = .consume_numeric_literal_suffix() ?? LiteralSuffix::None
-
-                    if is_ascii_alphanumeric(.peek()) {
-                        .error(
-                            "Could not parse binary number"
-                            span
-                        )
-
-                        return Token::Garbage(span)
-                    }
-
-                    return .make_integer_token(number: total, suffix, span)
-                }
-                else => {}
+                } else => {}
             }
         }
 
-        mut number_too_large = false
-        mut floating: bool = false
-
-        mut fraction_nominator: u64 = 0
-        mut fraction_denominator: u64 = 1
-
         while not .eof() {
-
             let value = .input[.index]
 
-            if value == b'.' {
-                if not is_ascii_digit(.peek_ahead(1)) or floating {
-                    break
-                }
-                floating = true
-                .index++
-                continue
-            } else if not is_ascii_digit(value) {
+            if not .valid_digit(prefix, digit: value) {
                 break
             }
 
-            ++.index
-
-            let digit: u64 = as_saturated(value - b'0')
-            if not floating {
-                // NOTE: We use unchecked arithmetic here to see if the number is too large
-                //       for our u64 storage type.
-                let old_total = total
-                total = unchecked_add(unchecked_mul(total, 10u64), digit)
-                if total < old_total {
-                    number_too_large = true
+            if value == b'.' {
+                if floating or not .valid_digit(prefix, digit: .peek_ahead(1), decimal_allowed: false) {
+                    break
                 }
-            } else {
-                fraction_nominator = fraction_nominator * 10u64 + digit
-                fraction_denominator *= 10u64
+
+                number.append(b'.')
+                floating = true
+                .index++
+                continue
             }
+
+            number.append(value)
+
+            ++.index
             if .peek() == b'_' {
-                if is_ascii_digit(.peek_ahead(1)) {
+                number.append(b'_')
+
+                if .valid_digit(prefix, digit: .peek_ahead(1)) {
                     ++.index
                 } else {
                     break
                 }
-            }            
-        }
-
-        // FIXME: Change match to if statements or similar when available
-        let end = .index
-        let span = .span(start, end)
-
-        if number_too_large {
-            .error(format("Integer literal too large"), span)
-            return Token::Garbage(span)
-        }
-
-        if .peek() == b'_' {
-            .error(
-                "Number literal cannot end with underscore"
-                span
-            )
-            return Token::Garbage(span)
-        }
-
-        let default_suffix = match floating {
-            true => LiteralSuffix::F64
-            else => LiteralSuffix::None
-        }
-        let suffix = .consume_numeric_literal_suffix() ?? default_suffix
-
-        if is_ascii_alphanumeric(.peek()) {
-            .error(
-                "Could not parse number"
-                span
-            )
-
-            return Token::Garbage(span)
-        }
-
-        // Sanity check for float numbers with an integer suffix
-        let is_float_suffix = match suffix {
-            LiteralSuffix::F32 | LiteralSuffix::F64 => true
-            else => false
-        }
-        if floating and not is_float_suffix {
-            // FIXME: Provide better error handling
-            return Token::Garbage(.span(start, end: .index))
-        }
-
-        return match suffix {
-            LiteralSuffix::F32 | LiteralSuffix::F64 => {
-                let number: f64 = u64_to_float<f64>(total) + u64_to_float<f64>(fraction_nominator)/u64_to_float<f64>(fraction_denominator)
-                yield make_float_token(number, suffix, span: .span(start, end))
             }
-            else => .make_integer_token(number: total, suffix, span: .span(start, end))
         }
+
+        let suffix = .consume_numeric_literal_suffix()
+
+        return Token::Number(prefix, number: number.to_string(), suffix, span: .span(start, end: .index))
     }
 
-
-    function consume_numeric_literal_suffix(mut this) -> LiteralSuffix? {
+    function consume_numeric_literal_suffix(mut this) throws -> LiteralSuffix {
         match .peek() {
             b'u' | b'i' | b'f' => {}
             else => {
-                return None
+                return LiteralSuffix::None
             }
         }
 
@@ -640,7 +450,7 @@ struct Lexer {
         while is_ascii_digit(.peek_ahead(local_index)) {
             // Make sure we don't overflow the width
             if local_index > 3 {
-                return None
+                return LiteralSuffix::None
             }
 
             let value = .input[.index + local_index]
@@ -655,35 +465,29 @@ struct Lexer {
                 16 => LiteralSuffix::U16
                 32 => LiteralSuffix::U32
                 64 => LiteralSuffix::U64
-                else => {
-                    return None
-                }
+                else => LiteralSuffix::None
             }
             b'i' => match width {
                 8 => LiteralSuffix::I8
                 16 => LiteralSuffix::I16
                 32 => LiteralSuffix::I32
                 64 => LiteralSuffix::I64
-                else => {
-                    return None
-                }
+                else => LiteralSuffix::None
             }
             b'f' => match width {
                 32 => LiteralSuffix::F32
                 64 => LiteralSuffix::F64
-                else => {
-                    return None
-                }
+                else => LiteralSuffix::None
             }
-            else => {
-                return None
-            }
+            else => LiteralSuffix::None
         }
 
-        .index += local_index
+        if not suffix is None {
+            .index += local_index
+        }
+
         return suffix
     }
-
 
     function lex_quoted_string(mut this, delimiter: u8) throws -> Token {
         let start = .index
@@ -925,7 +729,7 @@ struct Lexer {
                 return None
             }
             let ch = .peek()
-            if .is_whitespace(ch) {
+            if is_whitespace(ch) {
                 .index++
             } else {
                 break
@@ -967,96 +771,5 @@ struct Lexer {
             b'c' => .lex_character_constant_or_name()
             else => .lex_number_or_name()
         }
-    }
-
-    function is_whitespace(this, anon ch: u8) -> bool {
-        return ch == b' ' or ch == b'\t' or ch == b'\r' or ch == b'\f' or ch == b'\v'
-    }    
-
-    function make_integer_token(mut this, number: u64, suffix: LiteralSuffix, span: Span) throws -> Token {
-        // FIXME: consider unifying with make_float_token() to a single function
-        match suffix {
-            None => {
-                let n = number as? i64
-                if n.has_value() {
-                    return Token::Number(number: NumericConstant::UnknownSigned(n!), span)
-                }
-                return Token::Number(number: NumericConstant::UnknownUnsigned(number), span)
-            }
-            U8 => {
-                let n = number as? u8
-                if not n.has_value() {
-                    .error(format("Number {} cannot fit in integer type {}", number, suffix), span)
-                    return Token::Number(number: NumericConstant::U64(number), span)
-                }
-                return Token::Number(number: NumericConstant::U8(n!), span)
-            }
-            U16 => {
-                let n = number as? u16
-                if not n.has_value() {
-                    .error(format("Number {} cannot fit in integer type {}", number, suffix), span)
-                    return Token::Number(number: NumericConstant::U64(number), span)
-                }
-                return Token::Number(number: NumericConstant::U16(n!), span)
-            }
-            U32 => {
-                let n = number as? u32
-                if not n.has_value() {
-                    .error(format("Number {} cannot fit in integer type {}", number, suffix), span)
-                    return Token::Number(number: NumericConstant::U64(number), span)
-                }
-                return Token::Number(number: NumericConstant::U32(n!), span)
-            }
-            U64 => {
-                let n = number as? u64
-                if not n.has_value() {
-                    .error(format("Number {} cannot fit in integer type {}", number, suffix), span)
-                    return Token::Number(number: NumericConstant::U64(number), span)
-                }
-                return Token::Number(number: NumericConstant::U64(n!), span)
-            }
-            UZ => {
-                let n = number as? usize
-                if not n.has_value() {
-                    .error(format("Number {} cannot fit in integer type {}", number, suffix), span)
-                    return Token::Number(number: NumericConstant::U64(number), span)
-                }
-                return Token::Number(number: NumericConstant::USize(n! as! u64), span)
-            }
-            I8 => {
-                let n = number as? i8
-                if not n.has_value() {
-                    .error(format("Number {} cannot fit in integer type {}", number, suffix), span)
-                    return Token::Number(number: NumericConstant::U64(number), span)
-                }
-                return Token::Number(number: NumericConstant::I8(n!), span)
-            }
-            I16 => {
-                let n = number as? i16
-                if not n.has_value() {
-                    .error(format("Number {} cannot fit in integer type {}", number, suffix), span)
-                    return Token::Number(number: NumericConstant::U64(number), span)
-                }
-                return Token::Number(number: NumericConstant::I16(n!), span)
-            }
-            I32 => {
-                let n = number as? i32
-                if not n.has_value() {
-                    .error(format("Number {} cannot fit in integer type {}", number, suffix), span)
-                    return Token::Number(number: NumericConstant::U64(number), span)
-                }
-                return Token::Number(number: NumericConstant::I32(n!), span)
-            }
-            I64 => {
-                let n = number as? i64
-                if not n.has_value() {
-                    .error(format("Number {} cannot fit in integer type {}", number, suffix), span)
-                    return Token::Number(number: NumericConstant::U64(number), span)
-                }
-                return Token::Number(number: NumericConstant::I64(n!), span)
-            }
-            else => {}
-        }
-        return Token::Garbage(span)
     }
 }

--- a/selfhost/parser.jakt
+++ b/selfhost/parser.jakt
@@ -8,9 +8,69 @@
 
 
 import error { JaktError, print_error}
-import lexer { Token, NumericConstant }
+import lexer { Token, LiteralPrefix, LiteralSuffix }
 import utility { panic, todo, FileId, Span, extend_array, join }
 import compiler { Compiler }
+
+enum NumericConstant {
+    I8(i8)
+    I16(i16)
+    I32(i32)
+    I64(i64)
+    U8(u8)
+    U16(u16)
+    U32(u32)
+    U64(u64)
+    USize(u64)
+    F32(f32)
+    F64(f64)
+    UnknownSigned(i64)
+    UnknownUnsigned(u64)
+
+    public function to_usize(this) => match this {
+        I8(num) => num as! usize
+        I16(num) => num as! usize
+        I32(num) => num as! usize
+        I64(num) => num as! usize
+        U8(num) => num as! usize
+        U16(num) => num as! usize
+        U32(num) => num as! usize
+        U64(num) => num as! usize
+        USize(num) => num as! usize
+        UnknownSigned(num) => num as! usize
+        UnknownUnsigned(num) => num as! usize
+        // FIXME: handle floats properly - if the function is used at all?
+        else =>  0 as! usize
+    }
+}
+
+// A simple function to convert integers to floats. T is intended
+// to be either f32 or f64.
+// FIXME: Remove when a more general conversion is in place
+function u64_to_float<T>(anon number: u64) -> T {
+    mut float_value: T = 0
+
+    unsafe {
+        cpp {
+            "float_value = number;"
+        }
+    }
+
+    return float_value
+}
+
+// FIXME: Remove when a more general conversion is in place
+function f64_to_f32(anon number: f64) -> f32 {
+    mut f32_value: f32 = 0
+
+    unsafe {
+        cpp {
+            "f32_value = (f32)number;"
+        }
+    }
+
+    return f32_value
+}
 
 function merge_spans(anon start: Span, anon end: Span) throws -> Span {
     if end.file_id.id == 0 and end.start == 0 and end.end == 0 {
@@ -204,7 +264,6 @@ struct ParsedNamespace {
         }
     }
 }
-
 
 struct ValueEnumVariant {
     name: String
@@ -3139,10 +3198,7 @@ struct Parser {
             .index++
             yield ParsedExpression::SingleQuotedByteString(val: quote, span)
         }
-        Number(number, span) => {
-            .index++
-            yield ParsedExpression::NumericConstant(val: number, span)
-        }
+        Number(prefix, number, suffix, span) => .parse_number(prefix, number, suffix, span)
         True(span) => {
             .index++
             yield ParsedExpression::Boolean(val: true, span)
@@ -3290,6 +3346,241 @@ struct Parser {
             .error("Unsupported expression", span)
             yield ParsedExpression::Garbage(span)
         }
+    }
+
+    function parse_number(mut this, prefix: LiteralPrefix, number: String, mut suffix: LiteralSuffix, span: Span) throws -> ParsedExpression {
+        .index++
+        mut total = 0u64
+
+        if not prefix is None {
+            match prefix {
+                Hexadecimal => {
+                    if number.length() == 0 {
+                        .error(format("Could not parse hexadecimal number due to no digits"), span)
+                        return ParsedExpression::Garbage(span)
+                    }
+
+                    for i in ..number.length() {
+                        let byte = number.byte_at(i)
+
+                        if byte != b'_' {
+                            mut offset: u8 = 0
+                            if (byte >= b'a' and byte <= b'z') {
+                                offset = 39
+                            } else if (byte >= b'A' and byte <= b'Z') {
+                                offset = 7
+                            }
+                            let value = byte - offset
+                            let digit: u64 = as_saturated(value - b'0')
+                            total = total * 16 + digit
+                        }
+                    }
+                }
+                Octal => {
+                    if number.length() == 0 {
+                        .error(format("Could not parse octal number due to no digits"), span)
+                        return ParsedExpression::Garbage(span)
+                    }
+
+                    for i in ..number.length() {
+                        let byte = number.byte_at(i)
+
+                        if byte != b'_' {
+                            let digit: u64 = as_saturated(byte - b'0')
+                            total = total * 8 + digit
+                        }
+                    }
+                }
+                Binary => {
+                    if number.length() == 0 {
+                        .error(format("Could not parse binary number due to no digits"), span)
+                        return ParsedExpression::Garbage(span)
+                    }
+
+                    for i in ..number.length() {
+                        let byte = number.byte_at(i)
+
+                        if byte != b'_' {
+                            let digit: u64 = as_saturated(byte - b'0')
+                            total = total * 2 + digit
+                        }
+                    }                    
+                }
+                None => {}
+            }
+
+            let constant_value = .make_integer_numeric_constant(number: total, suffix, span)
+            if constant_value.has_value() {
+                return ParsedExpression::NumericConstant(val: constant_value!, span)
+            }
+
+            return ParsedExpression::Garbage(span)
+        }
+
+        mut number_too_large = false
+        mut floating = false
+
+        mut fraction_nominator: u64 = 0
+        mut fraction_denominator: u64 = 1
+
+        if number.length() == 0 {
+            .error(format("Could not parse number due to no digits"), span)
+            return ParsedExpression::Garbage(span)
+        }
+
+        for i in ..number.length() {
+            let byte = number.byte_at(i)
+
+            if byte != b'_' {
+                if byte == b'.' {
+                    floating = true
+                    continue
+                }
+
+                let digit: u64 = as_saturated(byte - b'0')
+
+                if floating {
+                    fraction_nominator = fraction_nominator * 10u64 + digit
+                    fraction_denominator *= 10u64
+                } else {
+                    // NOTE: We use unchecked arithmetic here to see if the number is too large
+                    //       for our u64 storage type.
+                    let old_total = total
+                    total = unchecked_add(unchecked_mul(total, 10u64), digit)
+                    if total < old_total {
+                        number_too_large = true
+                    }
+                }
+            }
+        }
+
+        if number_too_large {
+            .error(format("Integer literal too large"), span)
+            return ParsedExpression::Garbage(span)
+        }
+
+        if floating and suffix is None {
+            suffix = LiteralSuffix::F64
+        } 
+
+        // Sanity check for float numbers with an integer suffix
+        let is_float_suffix = match suffix {
+            LiteralSuffix::F32 | LiteralSuffix::F64 => true
+            else => false
+        }
+        if floating and not is_float_suffix {
+            // FIXME: Provide better error handling
+            return ParsedExpression::Garbage(span)
+        }
+
+        let constant_value = match suffix {
+            LiteralSuffix::F32 | LiteralSuffix::F64 => {
+                let number: f64 = u64_to_float<f64>(total) + u64_to_float<f64>(fraction_nominator)/u64_to_float<f64>(fraction_denominator)
+                yield .make_float_numeric_constant(number, suffix, span)
+            }
+            else => .make_integer_numeric_constant(number: total, suffix, span)
+        }
+
+        if constant_value.has_value() {
+            return ParsedExpression::NumericConstant(val: constant_value!, span)
+        }
+
+        return ParsedExpression::Garbage(span)
+    }
+
+    function make_integer_numeric_constant(mut this, number: u64, suffix: LiteralSuffix, span: Span) throws -> NumericConstant? {
+        // FIXME: consider unifying with make_float_numeric_constant() to a single function
+        match suffix {
+            None => {
+                let n = number as? i64
+                if n.has_value() {
+                    return NumericConstant::UnknownSigned(n!)
+                }
+                return NumericConstant::UnknownUnsigned(number)
+            }
+            U8 => {
+                let n = number as? u8
+                if not n.has_value() {
+                    .error(format("Number {} cannot fit in integer type {}", number, suffix), span)
+                    return NumericConstant::U64(number)
+                }
+                return NumericConstant::U8(n!)
+            }
+            U16 => {
+                let n = number as? u16
+                if not n.has_value() {
+                    .error(format("Number {} cannot fit in integer type {}", number, suffix), span)
+                    return NumericConstant::U64(number)
+                }
+                return NumericConstant::U16(n!)
+            }
+            U32 => {
+                let n = number as? u32
+                if not n.has_value() {
+                    .error(format("Number {} cannot fit in integer type {}", number, suffix), span)
+                    return NumericConstant::U64(number)
+                }
+                return NumericConstant::U32(n!)
+            }
+            U64 => {
+                let n = number as? u64
+                if not n.has_value() {
+                    .error(format("Number {} cannot fit in integer type {}", number, suffix), span)
+                    return NumericConstant::U64(number)
+                }
+                return NumericConstant::U64(n!)
+            }
+            UZ => {
+                let n = number as? usize
+                if not n.has_value() {
+                    .error(format("Number {} cannot fit in integer type {}", number, suffix), span)
+                    return NumericConstant::U64(number)
+                }
+                return NumericConstant::USize(n! as! u64)
+            }
+            I8 => {
+                let n = number as? i8
+                if not n.has_value() {
+                    .error(format("Number {} cannot fit in integer type {}", number, suffix), span)
+                    return NumericConstant::U64(number)
+                }
+                return NumericConstant::I8(n!)
+            }
+            I16 => {
+                let n = number as? i16
+                if not n.has_value() {
+                    .error(format("Number {} cannot fit in integer type {}", number, suffix), span)
+                    return NumericConstant::U64(number)
+                }
+                return NumericConstant::I16(n!)
+            }
+            I32 => {
+                let n = number as? i32
+                if not n.has_value() {
+                    .error(format("Number {} cannot fit in integer type {}", number, suffix), span)
+                    return NumericConstant::U64(number)
+                }
+                return NumericConstant::I32(n!)
+            }
+            I64 => {
+                let n = number as? i64
+                if not n.has_value() {
+                    .error(format("Number {} cannot fit in integer type {}", number, suffix), span)
+                    return NumericConstant::U64(number)
+                }
+                return NumericConstant::I64(n!)
+            }
+            else => {}
+        }
+
+        return None
+    }
+
+    function make_float_numeric_constant(mut this, number: f64, suffix: LiteralSuffix, span: Span) throws -> NumericConstant? => match suffix {
+        // FIXME: consider unifying with make_integer_numeric_constant() to a single function
+        LiteralSuffix::F32 => NumericConstant::F32(f64_to_f32(number))
+        LiteralSuffix::F64 => NumericConstant::F64(number)
+        else => None
     }
 
     function parse_captures(mut this) throws -> [ParsedCapture] {
@@ -3551,10 +3842,15 @@ struct Parser {
 
                     .index++
                     yield match .current() {
-                        Number(number) => {
+                        Number(prefix, number, suffix, span) => {
+                            let numeric_constant = .parse_number(prefix, number, suffix, span)
+                            guard numeric_constant is NumericConstant(val) else {
+                                .error("Invalid Numeric Constant", span)
+                                return expr
+                            }
+
                             // Indexing into a tuple
-                            .index++
-                            let num = number.to_usize()
+                            let num = val.to_usize()
                             yield ParsedExpression::IndexedTuple(
                                 expr: result
                                 index: num

--- a/selfhost/typechecker.jakt
+++ b/selfhost/typechecker.jakt
@@ -7,9 +7,9 @@
 // SPDX-License-Identifier: BSD-2-Clause
 
 import error { JaktError, print_error }
-import lexer { Lexer, NumericConstant }
+import lexer { Lexer }
 import parser { Parser, BinaryOperator, DefinitionLinkage, UnaryOperator,
-                FunctionLinkage, FunctionType, ParsedBlock, ParsedCall,
+                FunctionLinkage, FunctionType, NumericConstant, ParsedBlock, ParsedCall,
                 ParsedExpression, ParsedFunction, ParsedNamespace, ParsedModuleImport,
                 ParsedExternImport, ParsedType, ParsedStatement, ParsedVarDecl, RecordType,
                 ParsedRecord, ParsedField, TypeCast, EnumVariantPatternArgument,
@@ -861,7 +861,6 @@ struct Typechecker {
                 .error("imported extern function is not allowed to have a body"
                         f.name_span)
             }
-
         }
 
         for record in import_.assigned_namespace.records.iterator() {

--- a/selfhost/utility.jakt
+++ b/selfhost/utility.jakt
@@ -244,3 +244,12 @@ function allocate<T>(count: usize) -> raw T {
 
     abort()
 }
+
+function is_ascii_alpha(anon c: u8) => (c >= b'a' and c <= b'z') or (c >= b'A' and c <= b'Z')
+function is_ascii_digit(anon c: u8) => (c >= b'0' and c <= b'9')
+function is_ascii_hexdigit(anon c: u8) => (c >= b'0' and c <= b'9') or (c >= b'a' and c <= b'f') or (c >= b'A' and c <= b'F')
+function is_ascii_octdigit(anon c: u8) => (c >= b'0' and c <= b'7')
+function is_ascii_binary(anon c: u8) => (c == b'0' or c == b'1')
+function is_ascii_alphanumeric(anon c: u8) -> bool => is_ascii_alpha(c) or is_ascii_digit(c)
+
+function is_whitespace(anon byte: u8) => byte == b' ' or byte == b'\t' or byte == b'\r'

--- a/tests/parser/invalid_digits_in_binary_number.jakt
+++ b/tests/parser/invalid_digits_in_binary_number.jakt
@@ -1,5 +1,9 @@
 /// Expect:
-/// - error: "Could not parse binary number"
+/// - error: "Could not parse binary number due to no digits"
 
 // Binary number must not contain any digits other than 0 or 1
-0b13
+function main() {
+    let binary = 0b8
+
+    println("{}", binary)
+}

--- a/tests/parser/invalid_digits_in_octal_number.jakt
+++ b/tests/parser/invalid_digits_in_octal_number.jakt
@@ -1,5 +1,9 @@
 /// Expect:
-/// - error: "Could not parse octal number"
+/// - error: "Could not parse octal number due to no digits"
 
 // Octal number must not contain any digits other than 0-7
-0o78
+function main() {
+    let octal = 0o8
+
+    println("{}", octal)
+}


### PR DESCRIPTION
This changes the lexer to output a `Number` token with: `prefix: LiteralPrefix, number: String, suffix: LiteralSuffix` instead of
`number: NumericConstant`

The parser then parses this token into a `NumericConstant`

The primary motivation for this is so that the Number token carries the information required to reconstruct the source for formatting. It also makes for a better separation of concerns though as this was parsing that the lexer was doing.

This also changes the lexing slightly in that for example for an octal: `0o78` would end up as `Garbage` due to the 8 being an invalid digit. It would now lex as `0o7` and then a number `8`

`0o8` would lex as `0o` and `8`, with `0o` giving an error in the parser as having no digits.