### PR TITLE
codegen: Wrap enum variant call in enum type

### DIFF
--- a/selfhost/codegen.jakt
+++ b/selfhost/codegen.jakt
@@ -2293,6 +2293,7 @@ struct CodeGenerator {
                 output += ")"
             }
             else => {
+                mut close_enum_type_wrapper = false
                 if call.function_id.has_value() {
                     let function_id = call.function_id!
                     let function_ = .program.get_function(function_id)
@@ -2383,10 +2384,14 @@ struct CodeGenerator {
                                     output += .codegen_type_possibly_as_namespace(type_id: call.return_type, as_namespace: true)
                                     output += "::" + call.name + ">"
                                 } else {
+                                    output += " " + .codegen_type(call.return_type)
+                                    output += " { "
                                     output += "typename "
                                     output += .codegen_type(call.return_type)
                                     output += "::"
                                     output += call.name
+
+                                    close_enum_type_wrapper = true
                                 }
                             }
                             GenericEnumInstance(id) => {
@@ -2432,6 +2437,10 @@ struct CodeGenerator {
                 }
 
                 output += format("({})", join(arguments, separator: ","))
+
+                if close_enum_type_wrapper {
+                    output += " } "
+                }
             }
         }
 

--- a/tests/codegen/tuple_enum_variant.jakt
+++ b/tests/codegen/tuple_enum_variant.jakt
@@ -1,0 +1,13 @@
+/// Expect:
+/// - output: "(Foo::A, 1)\n"
+
+enum Foo {
+    A
+    B
+}
+
+function main() {
+    let tuple = (Foo::A, 1)
+
+    println("{}", tuple)
+}


### PR DESCRIPTION
Previously instantiating a Tuple with an enum variant as a variant would give a c++ error for no viable constructor.

This is because for example:
`let tuple = (Foo::A, 1)`
would codegen to
`Tuple{ typename Foo::A(), static_cast<i64>(1LL)}`

Which would be a constructor of Tuple(Foo, long) with an argument of a Tuple<Foo::A, long>
With the compiler not knowing how to convert a Tuple(A, long) into a Tuple(Variant<A, B>, long)

It now will codegen to:
`Tuple{ Foo { typename Foo::A() } , static_cast<i64>(1LL)}`

Thanks to Andrew Kaster for explaining the c++ issue and working out the fix.