### PR TITLE
vscode: Fix file:// URI for gotodef

### DIFF
--- a/editors/vscode/server/src/server.ts
+++ b/editors/vscode/server/src/server.ts
@@ -144,7 +144,7 @@ async function goToDefinition(
                 ? (await fs.promises.readFile(obj.file)).toString()
                 : document.getText() ?? ""
         );
-        const uri = obj.file ? "file:/" + obj.file : document.uri;
+        const uri = obj.file ? "file://" + obj.file : document.uri;
         // connection.console.log(uri);
 
         console.timeEnd("onDefinition");


### PR DESCRIPTION
Looks like we weren't quite prepending a whole `file://` URI, which caused goto-def to struggle to find the files when you would run goto-def.

This seems like a new-ish issues, I'm not sure if it's a regression in jakt or a difference in how vscode runs in recent versions.