### PR TITLE
typechecker+codegen: Fix issues with generic match

### DIFF
--- a/samples/match/match_generic_codegen.jakt
+++ b/samples/match/match_generic_codegen.jakt
@@ -1,5 +1,5 @@
 /// Expect:
-/// - output: "1\n2\n3\n2\n2\n4\n2\n"
+/// - output: "1\n2\n3\n2\n2\n4\n2\n2\n2\n4\n2\n"
 
 function generic_value_match<T>(anon x: T) -> i64 {
     return match x {
@@ -30,6 +30,16 @@ enum Y {
     C
 }
 
+function generic_val_infer<T>(anon x: T) -> i64 {
+    let val = match x {
+        A(y) => y
+        B => 2
+        C => 3
+    }
+
+    return val
+}
+
 function main() {
     println("{}", generic_value_match(3));
     println("{}", generic_value_match(2));
@@ -40,4 +50,10 @@ function main() {
 
     println("{}", generic_enum_match(Y::A(4)))
     println("{}", generic_enum_match(Y::B))
+
+    println("{}", generic_val_infer(X::A(2)))
+    println("{}", generic_val_infer(X::B))
+
+    println("{}", generic_val_infer(Y::A(4)))
+    println("{}", generic_val_infer(Y::B))
 }

--- a/samples/match/match_generic_codegen.jakt
+++ b/samples/match/match_generic_codegen.jakt
@@ -1,0 +1,43 @@
+/// Expect:
+/// - output: "1\n2\n3\n2\n2\n4\n2\n"
+
+function generic_value_match<T>(anon x: T) -> i64 {
+    return match x {
+        (3) => 1
+        (2) => 2
+        (1) => 3
+        else => 0
+    }
+}
+
+function generic_enum_match<T>(anon x: T) -> i64 {
+    return match x {
+        A(y) => y
+        B => 2
+        C => 3
+    }
+}
+
+enum X {
+    A(i64)
+    B
+    C
+}
+
+enum Y {
+    A(i64)
+    B
+    C
+}
+
+function main() {
+    println("{}", generic_value_match(3));
+    println("{}", generic_value_match(2));
+    println("{}", generic_value_match(1));
+
+    println("{}", generic_enum_match(X::A(2)))
+    println("{}", generic_enum_match(X::B))
+
+    println("{}", generic_enum_match(Y::A(4)))
+    println("{}", generic_enum_match(Y::B))
+}

--- a/selfhost/codegen.jakt
+++ b/selfhost/codegen.jakt
@@ -2047,24 +2047,6 @@ struct CodeGenerator {
         for case_ in cases {
             match case_ {
                 EnumVariant(name, args, subject_type_id, scope_id, body) => {
-                    let enum_ = .program.get_enum(match .program.get_type(subject_type_id) {
-                        Enum(enum_id) => enum_id
-                        GenericEnumInstance(id) => id
-                        else => {
-                            panic(format("Unexpected type in IsEnumVariant: {}", .program.get_type(subject_type_id)))
-                        }
-                    })
-                    // FIXME: This should be a call to find(), but we do not yet provide the needed operator== for that
-                    mut variant_index = 0;
-                    for variant in enum_.variants {
-                        if variant.name() == name{
-                            break
-                        }
-                        variant_index++
-                    }
-
-                    output += format("if (__jakt_enum_value.index() == {} /* {} */) {{\n", variant_index, name)
-
                     mut variant_type_name = ""
                     let qualifier = .codegen_type_possibly_as_namespace(type_id: subject_type_id, as_namespace: true)
                     if not qualifier.is_empty() {
@@ -2073,6 +2055,31 @@ struct CodeGenerator {
                         variant_type_name += ">::"
                     }
                     variant_type_name += name
+
+                    let enum_id: EnumId? = match .program.get_type(subject_type_id) {
+                        Enum(enum_id) => enum_id
+                        GenericEnumInstance(id) => id
+                        else => None
+                    }
+
+                    if enum_id.has_value() {
+                        let enum_ = .program.get_enum(enum_id!)
+
+                        // FIXME: This should be a call to find(), but we do not yet provide the needed operator== for that
+                        mut variant_index = 0;
+                        for variant in enum_.variants {
+                            if variant.name() == name {
+                                break
+                            }
+                            variant_index++
+                        }
+
+                        output += format("if (__jakt_enum_value.index() == {} /* {} */) {{\n", variant_index, name)
+                    } else {
+                        output += "if (__jakt_enum_value.template has<"
+                        output += variant_type_name
+                        output += ">()) {\n"
+                    }
 
                     output += "auto& __jakt_match_value = __jakt_enum_value.template get<"
                     output += variant_type_name

--- a/selfhost/codegen.jakt
+++ b/selfhost/codegen.jakt
@@ -2283,7 +2283,7 @@ struct CodeGenerator {
                 }
             }
             Expression(expr) => {
-                if expr.type().equals(void_type_id()) or (expr.type().equals(unknown_type_id()) and not expr is OptionalNone) {
+                if expr.type().equals(void_type_id()) or (expr.type().equals(unknown_type_id()) and return_type_id.equals(unknown_type_id()) and not expr is OptionalNone) {
                     output += "return ("
                     output += .codegen_expression(expr)
                     output += "), JaktInternal::ExplicitValue<void>();\n"

--- a/selfhost/typechecker.jakt
+++ b/selfhost/typechecker.jakt
@@ -6860,7 +6860,7 @@ struct Typechecker {
                     let block_type_id = checked_block.yielded_type ?? void_type_id()
                     let yield_span = block.find_yield_span() ?? span
 
-                    if result_type.has_value() {
+                    if result_type.has_value() and not result_type!.equals(unknown_type_id()) {
                         .check_types_for_compat(
                             lhs_type_id: result_type!
                             rhs_type_id: block_type_id
@@ -6887,7 +6887,7 @@ struct Typechecker {
             }
             Expression(expr) => {
                 let checked_expression = .typecheck_expression(expr, scope_id, safety_mode, type_hint: result_type)
-                if result_type.has_value() {
+                if result_type.has_value() and not result_type!.equals(unknown_type_id()) {
                     .check_types_for_compat(
                         lhs_type_id: result_type!
                         rhs_type_id: checked_expression.type()

--- a/selfhost/typechecker.jakt
+++ b/selfhost/typechecker.jakt
@@ -2979,6 +2979,8 @@ struct Typechecker {
         .check_that_type_doesnt_contain_reference(type_id: function_return_type_id, span: parsed_function.return_type_span)
 
         if not parsed_function.generic_parameters.is_empty() {
+            let previous_function_id = .current_function_id
+            .current_function_id = function_id
             let old_ignore_errors = .ignore_errors
             .ignore_errors = true
             let block = .typecheck_block(
@@ -2987,6 +2989,7 @@ struct Typechecker {
                 safety_mode: SafetyMode::Safe
             )
             .ignore_errors = old_ignore_errors
+            .current_function_id = previous_function_id
 
             let return_type_id = match function_return_type_id.equals(unknown_type_id()) {
                 true => .infer_function_return_type(block)


### PR DESCRIPTION
Removal of `Variant::has` meant that generic matches would no longer work as codegen required a concrete enum id.

This adds back `Variant::has` in the case that we don't have an enum_id to use to find the variant index.

A similar version of this test was originally removed as being overly-permissive (https://github.com/SerenityOS/jakt/commit/8f0576b598debd0ff9b4a055b1a484cf7e966a8a). Depending on the desired behavior we can add some more checks in typechecker to be more restrictive, as it stands it was just failing in c++.