### PR TITLE
typechecker+parser: Allow restricted() to refer to functions as well

### DIFF
--- a/samples/classes/restricted_method_inaccessible.jakt
+++ b/samples/classes/restricted_method_inaccessible.jakt
@@ -1,5 +1,5 @@
 /// Expect:
-/// - error: "Can't access function ‘get_secret’ from ‘C’, because ‘C’ is not in the restricted whitelist\n"
+/// - error: "Cannot access function ‘get_secret’ from this scope\n"
 
 class Limited {
     restricted(A) function get_secret() => "Shhhh! Don't tell anyone!"

--- a/selfhost/interpreter.jakt
+++ b/selfhost/interpreter.jakt
@@ -1,7 +1,7 @@
 import types {
     BlockControlFlow, BuiltinType, CheckedBlock, CheckedCall, CheckedExpression, CheckedEnum,
     CheckedMatchBody, CheckedNumericConstant, CheckedProgram, CheckedStatement, EnumId,
-    BinaryOperator, CheckedEnumVariant, CheckedVariable, Visibility, CheckedParameter,
+    BinaryOperator, CheckedEnumVariant, CheckedVariable, CheckedVisibility, CheckedParameter,
     EnumVariantPatternArgument, FunctionId, ModuleId, ResolvedNamespace, ScopeId, Span, StructId,
     GenericInferences, Scope, Type, TypeId, VarId, Value, ValueImpl, builtin, unknown_type_id,
 }
@@ -325,7 +325,7 @@ function value_to_checked_expression(anon this_value: Value, anon mut interprete
                 is_mutable: false
                 definition_span: this_value.span
                 type_span: None
-                visibility: Visibility::Public
+                visibility: CheckedVisibility::Public
             ))
             statements.push(CheckedStatement::VarDecl(
                 var_id

--- a/selfhost/parser.jakt
+++ b/selfhost/parser.jakt
@@ -1123,10 +1123,15 @@ enum FunctionLinkage {
     External
 }
 
+struct VisibilityRestriction {
+    namespace_: [String]
+    name: String
+}
+
 enum Visibility {
     Public
     Private
-    Restricted(whitelist: [ParsedType], span: Span)
+    Restricted(whitelist: [VisibilityRestriction], span: Span)
 }
 
 struct Parser {
@@ -3820,16 +3825,17 @@ struct Parser {
 
     function parse_restricted_visibility_modifier(mut this) throws -> Visibility {
         mut restricted_span = .current().span()
-        
+
         .index++
 
         if .current() is LParen {
             .index++
         } else {
             .error("Expected ‘(’", .current().span())
+            return Visibility::Restricted(whitelist: [], span: restricted_span)
         }
 
-        mut whitelist: [ParsedType] = []
+        mut whitelist: [VisibilityRestriction] = []
         mut expect_comma = false
 
         while .index < .tokens.size() {
@@ -3851,8 +3857,27 @@ struct Parser {
                     }
 
                     .skip_newlines()
-                    let parsed_type = .parse_typename()
-                    whitelist.push(parsed_type)
+                    // Either a plain name, or a namespaced name
+                    mut names: [String] = []
+                    loop {
+                        guard .current() is Identifier(name) else {
+                            break
+                        }
+
+                        names.push(name)
+                        .index++
+                        if .current() is ColonColon {
+                            .index++
+                        } else {
+                            break
+                        }
+                    }
+                    if names.is_empty() {
+                        .error("Expected identifier", .current().span())
+                    } else {
+                        let name = names.pop()!
+                        whitelist.push(VisibilityRestriction(namespace_: names, name))
+                    }
                     expect_comma = true
                 }
             }
@@ -3861,7 +3886,10 @@ struct Parser {
         restricted_span.end = .current().span().end
 
         if whitelist.is_empty() {
-            .error("Type list cannot be empty", restricted_span)
+            .error_with_hint(
+                "Restriction list cannot be empty", restricted_span
+                "Did you mean to use ‘private’ instead of ‘restricted’?", restricted_span
+            )
         }
 
         if .current() is RParen {

--- a/selfhost/typechecker.jakt
+++ b/selfhost/typechecker.jakt
@@ -8,20 +8,20 @@
 
 import error { JaktError, print_error }
 import lexer { Lexer, NumericConstant }
-import parser { Parser, BinaryOperator, DefinitionLinkage, DefinitionType, UnaryOperator,
-                FunctionLinkage, FunctionType, ParsedBlock, ParsedCall,
-                ParsedExpression, ParsedFunction, ParsedNamespace, ParsedModuleImport,
-                ParsedExternImport, ParsedType, ParsedStatement, ParsedVarDecl, RecordType,
-                ParsedRecord, ParsedField, TypeCast, EnumVariantPatternArgument,
-                ParsedMatchBody, ParsedMatchCase, Visibility, ParsedParameter, ParsedCapture,
-                ParsedMethod }
+import parser {
+    BinaryOperator, DefinitionLinkage, EnumVariantPatternArgument, FunctionLinkage, FunctionType, ParsedBlock
+    ParsedCall, ParsedCapture, ParsedExpression, ParsedExternImport, ParsedField, ParsedFunction, ParsedMatchBody
+    ParsedMatchCase, ParsedMethod, ParsedModuleImport, ParsedNamespace, ParsedParameter, ParsedRecord
+    ParsedStatement, ParsedType, ParsedVarDecl, Parser, RecordType, TypeCast, UnaryOperator, Visibility
+    VisibilityRestriction
+}
 import types {
     BlockControlFlow, BuiltinType, CheckedBlock, CheckedCall, CheckedCapture, CheckedEnum, CheckedEnumVariant,
     CheckedEnumVariantBinding, CheckedExpression, CheckedFunction, FunctionGenerics, CheckedMatchBody, CheckedMatchCase,
     CheckedNamespace, CheckedNumericConstant, CheckedParameter, CheckedProgram, CheckedStatement, CheckedStruct,
-    CheckedTypeCast, CheckedUnaryOperator, CheckedVariable, EnumId, FieldRecord, FunctionGenericParameter, FunctionId,
-    LoadedModule, Module, ModuleId, NumberConstant, ResolvedNamespace, SafetyMode, Scope, ScopeId, StructId,
-    GenericInferences, StructOrEnumId, Type, TypeId, VarId, Value,
+    CheckedTypeCast, CheckedUnaryOperator, CheckedVariable, CheckedVisibility, EnumId, FieldRecord, FunctionGenericParameter,
+    FunctionId, LoadedModule, Module, ModuleId, NumberConstant, ResolvedNamespace, SafetyMode, Scope, ScopeId, StructId,
+    GenericInferences, StructOrEnumId, Type, TypeId, VarId, Value, MaybeResolvedScope,
     builtin, never_type_id, unknown_type_id, void_type_id,
 }
 import types
@@ -517,6 +517,31 @@ struct Typechecker {
         .typecheck_namespace_declarations(parsed_namespace, scope_id)
     }
 
+    function typecheck_visibility(mut this, visibility: Visibility, scope_id: ScopeId) throws -> CheckedVisibility {
+        return match visibility {
+            Private => CheckedVisibility::Private
+            Public => CheckedVisibility::Public
+            Restricted(whitelist, span) => {
+                mut restricted_scopes: [MaybeResolvedScope] = []
+                for entry in whitelist.iterator() {
+                    mut parent_scope = MaybeResolvedScope::Resolved(scope_id)
+                    for ns in entry.namespace_.iterator() {
+                        parent_scope = MaybeResolvedScope::Unresolved(parent_scope, relative_name: ns)
+                    }
+
+                    mut unresolved = MaybeResolvedScope::Unresolved(
+                        parent_scope
+                        relative_name: entry.name
+                    )
+
+                    restricted_scopes.push(unresolved.try_resolve(program: .program))
+                }
+
+                yield CheckedVisibility::Restricted(scopes: restricted_scopes, span)
+            }
+        }
+    }
+
     function typecheck_namespace_fields(mut this, parsed_namespace: ParsedNamespace, scope_id: ScopeId) throws {
         let children = .get_scope(id: scope_id).children
         for i in 0..parsed_namespace.namespaces.size() {
@@ -564,7 +589,7 @@ struct Typechecker {
                 is_mutable: parsed_var_decl.is_mutable
                 definition_span: parsed_var_decl.span
                 type_span: None
-                visibility: unchecked_member.visibility
+                visibility: .typecheck_visibility(visibility: unchecked_member.visibility, scope_id: checked_struct_scope_id)
             ))
             structure.fields.push(var_id)
         }
@@ -778,7 +803,7 @@ struct Typechecker {
             let child_namespace_scope_id = children[i]
             .typecheck_namespace_function_predecl(parsed_namespace: child_namespace, scope_id: child_namespace_scope_id)
         }
-        
+
         for fun in parsed_namespace.functions.iterator() {
             .typecheck_function_predecl(parsed_function: fun, parent_scope_id: scope_id, this_arg_type_id: None)
         }
@@ -938,7 +963,7 @@ struct Typechecker {
             mut checked_function = CheckedFunction(
                 name: func.name
                 name_span: func.name_span
-                visibility: method.visibility
+                visibility: .typecheck_visibility(visibility: method.visibility, scope_id: enum_scope_id)
                 return_type_id: unknown_type_id()
                 return_type_span: None
                 params: []
@@ -999,7 +1024,7 @@ struct Typechecker {
                         is_mutable: param.variable.is_mutable
                         definition_span: param.variable.span
                         type_span: None
-                        visibility: Visibility::Public
+                        visibility: CheckedVisibility::Public
                     )
 
                     checked_function.add_param(CheckedParameter(
@@ -1016,7 +1041,7 @@ struct Typechecker {
                         is_mutable: param.variable.is_mutable
                         definition_span: param.variable.span
                         type_span: param.variable.parsed_type.span()
-                        visibility: Visibility::Public
+                        visibility: CheckedVisibility::Public
                     )
 
                     checked_function.add_param(CheckedParameter(
@@ -1086,7 +1111,7 @@ struct Typechecker {
             mut checked_constructor = CheckedFunction(
                 name: parsed_record.name
                 name_span: parsed_record.name_span
-                visibility: Visibility::Public
+                visibility: CheckedVisibility::Public
                 return_type_id: struct_type_id
                 return_type_span: None
                 params: []
@@ -1124,7 +1149,7 @@ struct Typechecker {
                 for field_id in .get_struct(field_struct_id).fields.iterator() {
                     let field = .get_variable(field_id)
                     if field.visibility is Private {
-                        checked_constructor.visibility = Visibility::Private
+                        checked_constructor.visibility = CheckedVisibility::Private
                     }
 
                     func.add_param(CheckedParameter(
@@ -1170,7 +1195,7 @@ struct Typechecker {
         let struct_type_id = .find_or_add_type_id(type: Type::Struct(struct_id))
         .current_struct_type_id = struct_type_id
 
-        let struct_scope_id = .create_scope(parent_scope_id: scope_id, can_throw: false, debug_name: format("struct({})", parsed_record.name))
+        let struct_scope_id = .current_module().structures[struct_id.id].scope_id
 
         .add_struct_to_scope(scope_id, name: parsed_record.name, struct_id, span: parsed_record.name_span)
 
@@ -1249,7 +1274,7 @@ struct Typechecker {
             mut checked_function = CheckedFunction(
                 name: func.name
                 name_span: func.name_span
-                visibility: method.visibility
+                visibility: .typecheck_visibility(visibility: method.visibility, scope_id: struct_scope_id)
                 return_type_id: unknown_type_id()
                 return_type_span: func.return_type_span
                 params: []
@@ -1304,7 +1329,7 @@ struct Typechecker {
                         is_mutable: param.variable.is_mutable
                         definition_span: param.variable.span
                         type_span: None
-                        visibility: Visibility::Public
+                        visibility: CheckedVisibility::Public
                     )
 
                     checked_function.add_param(CheckedParameter(
@@ -1326,7 +1351,7 @@ struct Typechecker {
                         is_mutable: param.variable.is_mutable
                         definition_span: param.variable.span
                         type_span: param.variable.parsed_type.span()
-                        visibility: Visibility::Public
+                        visibility: CheckedVisibility::Public
                     )
 
                     mut checked_default_value: CheckedExpression? = None
@@ -1421,13 +1446,15 @@ struct Typechecker {
         let struct_type_id = TypeId(module: module_id, id: .current_module().types.size() - 1)
         .add_type_to_scope(scope_id, type_name: parsed_record.name, type_id: struct_type_id, span: parsed_record.name_span)
 
+        let struct_scope_id = .create_scope(parent_scope_id: scope_id, can_throw: false, debug_name: format("struct({})", parsed_record.name))
+
         // Add a placeholder entry, this will be replaced later.
         module.structures.push(CheckedStruct(
             name: parsed_record.name
             name_span: parsed_record.name_span
             generic_parameters: []
             fields: []
-            scope_id: .prelude_scope_id()
+            scope_id: struct_scope_id
             definition_linkage: parsed_record.definition_linkage
             record_type: parsed_record.record_type
             type_id: struct_type_id
@@ -1521,7 +1548,7 @@ struct Typechecker {
                             is_mutable: false
                             definition_span: variant.span
                             type_span: None
-                            visibility: Visibility::Public
+                            visibility: CheckedVisibility::Public
                         ))
                         .add_var_to_scope(scope_id: enum_.scope_id, name: variant.name, var_id, span: variant.span)
                     }
@@ -1554,7 +1581,7 @@ struct Typechecker {
                                 is_mutable: param.is_mutable
                                 definition_span: param.span
                                 type_span: None
-                                visibility: Visibility::Public
+                                visibility: CheckedVisibility::Public
                             )
                             params.push(CheckedParameter(requires_label: true, variable: checked_var, default_value: None))
 
@@ -1575,7 +1602,7 @@ struct Typechecker {
                             let checked_function = CheckedFunction(
                                 name: variant.name
                                 name_span: variant.span
-                                visibility: Visibility::Public
+                                visibility: CheckedVisibility::Public
                                 return_type_id: .find_or_add_type_id(Type::Enum(enum_id))
                                 return_type_span: None
                                 params
@@ -1620,14 +1647,14 @@ struct Typechecker {
                                 is_mutable: false
                                 definition_span: param.span
                                 type_span: None
-                                visibility: Visibility::Public
+                                visibility: CheckedVisibility::Public
                             )
                             let param = CheckedParameter(requires_label: false, variable, default_value: None)
 
                             let checked_function = CheckedFunction(
                                 name: variant.name
                                 name_span: variant.span
-                                visibility: Visibility::Public
+                                visibility: CheckedVisibility::Public
                                 return_type_id: .find_or_add_type_id(Type::Enum(enum_id))
                                 return_type_span: None
                                 params: [param]
@@ -1666,7 +1693,7 @@ struct Typechecker {
                             let checked_function = CheckedFunction(
                                 name: variant.name
                                 name_span: variant.span
-                                visibility: Visibility::Public
+                                visibility: CheckedVisibility::Public
                                 return_type_id: .find_or_add_type_id(Type::Enum(enum_id))
                                 return_type_span: None
                                 params: []
@@ -1841,7 +1868,7 @@ struct Typechecker {
             is_mutable: parameter.variable.is_mutable
             definition_span: parameter.variable.span
             type_span: None
-            visibility: Visibility::Public
+            visibility: CheckedVisibility::Public
         )
 
         mut checked_default_value: CheckedExpression? = None
@@ -1908,7 +1935,7 @@ struct Typechecker {
         mut checked_function = CheckedFunction(
             name: parsed_function.name
             name_span: parsed_function.name_span
-            visibility: parsed_function.visibility
+            visibility: .typecheck_visibility(visibility: parsed_function.visibility, scope_id: parent_scope_id)
             return_type_id: unknown_type_id()
             return_type_span: parsed_function.return_type_span
             params: []
@@ -2064,7 +2091,7 @@ struct Typechecker {
             .error(
                 format("Generic function {} expects {} generic arguments, but {} were given",
                     parsed_function.name, parsed_function.generic_parameters.size(), generic_arguments.size()
-                ) 
+                )
                 parsed_function.name_span
             )
         }
@@ -2951,7 +2978,7 @@ struct Typechecker {
                 let checked_function = CheckedFunction(
                     name: function_name
                     name_span: span
-                    visibility: Visibility::Public
+                    visibility: CheckedVisibility::Public
                     return_type_id: .typecheck_typename(parsed_type: return_type, scope_id, name: None)
                     return_type_span: return_type.span()
                     params: checked_params
@@ -3693,7 +3720,7 @@ struct Typechecker {
             is_mutable: var.is_mutable
             definition_span: var.span
             type_span: None
-            visibility: Visibility::Public
+            visibility: CheckedVisibility::Public
         )
 
         if .dump_type_hints and var.inlay_span.has_value() {
@@ -3731,7 +3758,7 @@ struct Typechecker {
             is_mutable: false
             definition_span: error_span
             type_span: None
-            visibility: Visibility::Public
+            visibility: CheckedVisibility::Public
         )
         mut module = .current_module()
         let error_id = module.add_variable(name: error_decl)
@@ -3765,7 +3792,7 @@ struct Typechecker {
                     is_mutable: false
                     definition_span: span
                     type_span: None
-                    visibility: Visibility::Public
+                    visibility: CheckedVisibility::Public
                 )
                 mut module = .current_module()
                 let error_id = module.add_variable(name: error_decl)
@@ -4027,8 +4054,8 @@ struct Typechecker {
                     .error(format("Can't access field ‘{}’, because it is marked private", member.name), span)
                 }
             }
-            Restricted(whitelist, span) => {
-                .check_restricted_access(accessor, accessee_kind: "field", accessee, name: member.name, whitelist, span)
+            Restricted(scopes) => {
+                .check_restricted_access(accessor, accessee_kind: "field", accessee, name: member.name, whitelist: scopes, span)
             }
             else => {}
         }
@@ -4049,35 +4076,58 @@ struct Typechecker {
                     }
                 }
             }
-            Restricted(whitelist, span) => {
-                .check_restricted_access(accessor, accessee_kind: "function", accessee, name: method.name, whitelist, span)
+            Restricted(scopes) => {
+                .check_restricted_access(accessor, accessee_kind: "function", accessee, name: method.name, whitelist: scopes, span)
             }
             else => {}
         }
     }
 
-    function check_restricted_access(mut this, accessor: ScopeId, accessee_kind: String, accessee: ScopeId, name: String, whitelist: [ParsedType], span: Span) throws {
-        if not .current_struct_type_id.has_value() {
-            .error(format("Can't access {} ‘{}’ from scope ‘{}’, because ‘{}’ is not in the restricted whitelist", accessee_kind, name, .get_scope(accessor).namespace_name, .get_scope(accessor).namespace_name), span)
-            return
-        }
-        let own_type_id = .current_struct_type_id!
-        let type = .get_type(own_type_id)
-        if type is Struct(id) {
-            mut was_whitelisted = false
-            for whitelisted_type in whitelist.iterator() {
-                let type_id = .typecheck_typename(parsed_type: whitelisted_type, scope_id: accessee, name: None)
-                // FIXME: Handle typecheck failure
-                if type_id.equals(own_type_id) {
-                    return
+    function check_restricted_access(mut this, accessor: ScopeId, accessee_kind: String, accessee: ScopeId, name: String, whitelist: [MaybeResolvedScope], span: Span) throws -> bool {
+        let most_specific_active_scope_id = match .current_function_id.has_value() {
+            true => .get_function(.current_function_id!).function_scope_id
+            else => {
+                if not .current_struct_type_id.has_value() {
+                    .error(
+                        format(
+                            "Can't access {0} ‘{1}’ from this global scope, because ‘{1}’ restricts access to it"
+                            accessee_kind
+                            name
+                        )
+                        span
+                    )
+                    return false
+                }
+                yield match .get_type(.current_struct_type_id!) {
+                    Struct(id) => .get_struct(id).scope_id
+                    else => {
+                        panic(format("Internal error: current_struct_type_id is not a struct", span))
+                    }
                 }
             }
-            if not was_whitelisted {
-                .error(format("Can't access {} ‘{}’ from ‘{}’, because ‘{}’ is not in the restricted whitelist", accessee_kind, name, .get_struct(id).name, .get_struct(id).name), span)
-            }
-        } else {
-            .error(format("Can't access {} ‘{}’ from scope ‘{}’, because it is not in the restricted whitelist", accessee_kind, name, .get_scope(accessor).namespace_name), span)
         }
+
+        for scope in whitelist.iterator() {
+            let resolved_scope = scope.try_resolve(program: .program)
+            guard resolved_scope is Resolved(scope_id) else {
+                continue
+            }
+
+            if .scope_can_access(accessor: most_specific_active_scope_id, accessee: scope_id) {
+                return true
+            }
+        }
+
+        let scope = .get_scope(most_specific_active_scope_id)
+        .error(
+            format(
+                "Cannot access {} ‘{}’ from this scope"
+                accessee_kind
+                name
+            )
+            span
+        )
+        return false
     }
 
     function infer_signed_int(mut this, val: i64, span: Span, type_hint: TypeId?) throws -> CheckedExpression {
@@ -4523,7 +4573,7 @@ struct Typechecker {
                             is_mutable: false,
                             definition_span: span,
                             type_span: None
-                            visibility: Visibility::Public),
+                            visibility: CheckedVisibility::Public),
                         span
                     )
                 }
@@ -4918,7 +4968,7 @@ struct Typechecker {
                 is_mutable: false,
                 definition_span: span
                 type_span: None
-                visibility: Visibility::Public
+                visibility: CheckedVisibility::Public
             ),
             span
         )
@@ -5129,7 +5179,7 @@ struct Typechecker {
                             is_mutable: false
                             definition_span: span
                             type_span: None
-                            visibility: Visibility::Public
+                            visibility: CheckedVisibility::Public
                         ))
                         .add_var_to_scope(scope_id: new_scope_id, name: variant_argument.binding, var_id, span)
                     }
@@ -5197,7 +5247,7 @@ struct Typechecker {
                                 is_mutable: false
                                 definition_span: matched_span
                                 type_span: None
-                                visibility: Visibility::Public
+                                visibility: CheckedVisibility::Public
                             ))
                             .add_var_to_scope(scope_id: new_scope_id, name: arg.binding, var_id, span: matched_span)
                         }

--- a/selfhost/types.jakt
+++ b/selfhost/types.jakt
@@ -3,7 +3,7 @@ import parser { Parser, BinaryOperator, DefinitionLinkage, DefinitionType, Unary
                 ParsedExpression, ParsedFunction, ParsedNamespace, ParsedModuleImport,
                 ParsedExternImport, ParsedType, ParsedStatement, ParsedVarDecl, RecordType,
                 ParsedRecord, ParsedField, TypeCast, EnumVariantPatternArgument,
-                ParsedMatchBody, ParsedMatchCase, Visibility, ParsedParameter, ParsedCapture }
+                ParsedMatchBody, ParsedMatchCase, ParsedParameter, ParsedCapture }
 import utility { panic, todo, join, FileId, Span }
 import compiler { Compiler }
 
@@ -511,10 +511,69 @@ struct CheckedNamespace {
     scope: ScopeId
 }
 
+boxed enum MaybeResolvedScope {
+    Resolved(ScopeId)
+    Unresolved(
+        parent_scope: MaybeResolvedScope
+        relative_name: String
+    )
+
+    function try_resolve(this, program: CheckedProgram) throws -> MaybeResolvedScope {
+        return match this {
+            Resolved(id) => MaybeResolvedScope::Resolved(id)
+            Unresolved(parent_scope, relative_name) => {
+                mut parent = parent_scope.try_resolve(program)
+                if parent is Resolved(parent_scope_id) {
+                    let scope = parent_scope_id
+                    mut scope_id: ScopeId? = None
+                    if not scope_id.has_value() {
+                        let struct_ = program.find_struct_in_scope(scope_id: scope, name: relative_name)
+                        if struct_.has_value() {
+                            scope_id = program.get_struct(struct_!).scope_id
+                        }
+                    }
+
+                    if not scope_id.has_value() {
+                        let enum_ = program.find_enum_in_scope(scope_id: scope, name: relative_name)
+                        if enum_.has_value() {
+                            scope_id = program.get_enum(enum_!).scope_id
+                        }
+                    }
+
+                    if not scope_id.has_value() {
+                        let ns = program.find_namespace_in_scope(scope_id: scope, name: relative_name)
+                        if ns.has_value() {
+                            scope_id = ns!.0
+                        }
+                    }
+
+                    if not scope_id.has_value() {
+                        let id = program.find_function_in_scope(parent_scope_id: scope, function_name: relative_name)
+                        if id.has_value() {
+                            scope_id = program.get_function(id!).function_scope_id
+                        }
+                    }
+                    if (scope_id.has_value()) {
+                        return MaybeResolvedScope::Resolved(scope_id!)
+                    }
+                }
+
+                yield MaybeResolvedScope::Unresolved(parent_scope: parent, relative_name)
+            }
+        }
+    }
+}
+
+enum CheckedVisibility {
+    Public
+    Private
+    Restricted(scopes: [MaybeResolvedScope], span: Span)
+}
+
 class CheckedFunction {
     public name: String
     public name_span: Span
-    public visibility: Visibility
+    public visibility: CheckedVisibility
     public return_type_id: TypeId
     public return_type_span: Span?
     public params: [CheckedParameter]
@@ -641,7 +700,7 @@ struct CheckedVariable {
     is_mutable: bool
     definition_span: Span
     type_span: Span?
-    visibility: Visibility
+    visibility: CheckedVisibility
 }
 
 struct CheckedVarDecl {

--- a/tests/typechecker/restrict_to_scopes.jakt
+++ b/tests/typechecker/restrict_to_scopes.jakt
@@ -1,0 +1,25 @@
+/// Expect:
+/// - error: "Cannot access field ‘x’ from this scope\n"
+
+struct Foo {
+    restricted(A::b, baz, Bar) x: i32
+}
+
+struct A {
+    function b(anon foo: Foo) { return foo.x }
+    function c(anon foo: Foo) { return foo.x }
+}
+
+namespace Bar {
+    function bar(anon foo: Foo) {
+        return foo.x
+    }
+
+    function bar2(anon foo: Foo) {
+        return foo.x
+    }
+}
+
+function baz(anon foo: Foo) {
+    return foo.x
+}

--- a/tests/typechecker/restrict_to_scopes_accepted.jakt
+++ b/tests/typechecker/restrict_to_scopes_accepted.jakt
@@ -1,0 +1,34 @@
+/// Expect:
+/// - output: "OK\n"
+
+struct Foo {
+    restricted(A::b, baz, Bar, main) x: i32
+}
+
+struct A {
+    function b(anon foo: Foo) { return foo.x }
+}
+
+namespace Bar {
+    function bar(anon foo: Foo) {
+        return foo.x
+    }
+
+    function bar2(anon foo: Foo) {
+        return foo.x
+    }
+}
+
+function baz(anon foo: Foo) {
+    return foo.x
+}
+
+function main() {
+    let foo = Foo(x: 42)
+    A::b(foo)
+    Bar::bar(foo)
+    Bar::bar2(foo)
+    baz(foo)
+
+    println("OK")
+}


### PR DESCRIPTION
This makes it possible to restrict access only to a single helper function in any scope that can be named, or grant access to an entire namespace/struct/class, etc.

e.g.

```
struct Foo {
    restricted(A::b, baz, Bar) x: i32
}

struct A {
    function b(anon foo: Foo) { return foo.x }
    function c(anon foo: Foo) { return foo.x }
}

namespace Bar {
    function bar(anon foo: Foo) {
        return foo.x
    }

    function bar2(anon foo: Foo) {
        return foo.x
    }
}

function baz(anon foo: Foo) {
    return foo.x
}
```
->
```
Error: Cannot access field ‘x’ from this scope
----- restr.jakt:7:40
 6 |     function b(anon foo: Foo) { return foo.x }
 7 |     function c(anon foo: Foo) { return foo.x }
                                             ^- Cannot access field ‘x’ from this scope
 8 | }
-----
```