### PR TITLE
typechecker: Add better error for calling an instance method statically

### DIFF
--- a/selfhost/typechecker.jakt
+++ b/selfhost/typechecker.jakt
@@ -5972,6 +5972,13 @@ struct Typechecker {
                     if callee.is_mutating() and not this_expr!.is_mutable(program: .program) {
                         .error("Cannot call mutating method on an immutable object instance", span)
                     }
+                } else if not callee.is_static() {
+                    .error_with_hint(
+                        "Cannot call an instance method statically"
+                        span
+                        "Add a dot before the method name to call an instance method"
+                        span
+                    )
                 }
 
                 mut resolved_args: [(String, Span, CheckedExpression)] = .resolve_default_params(params: callee.generics.base_params, args: call.args, scope_id: caller_scope_id, safety_mode, arg_offset, span)

--- a/tests/typechecker/call_instance_method_statically.jakt
+++ b/tests/typechecker/call_instance_method_statically.jakt
@@ -1,0 +1,16 @@
+/// Expect:
+/// - error: "Cannot call an instance method statically\n"
+
+class Foo {
+    public function a(mut this) {
+        let c = b()
+    }
+
+    public function b(mut this) -> i64 => 2
+}
+
+function main() {
+    mut foo = Foo()
+
+    foo.a()
+}


### PR DESCRIPTION
Previously this would just get the "Wrong number of arguments" error because an instance method has the `this` argument.