### PR TITLE
all: Make optimized builds use unchecked math

### DIFF
--- a/selfhost/codegen.jakt
+++ b/selfhost/codegen.jakt
@@ -2093,10 +2093,18 @@ struct CodeGenerator {
             // Integer arithmetic is checked by default.
             match op {
                 Add | Subtract | Multiply | Divide | Modulo => {
-                    return "(" + .codegen_checked_binary_op(lhs, rhs, op, type_id) + ")"
+                    if .compiler.optimize {
+                        return "(" + .codegen_unchecked_binary_op(lhs, rhs, op, type_id) + ")"
+                    } else {
+                        return "(" + .codegen_checked_binary_op(lhs, rhs, op, type_id) + ")"
+                    }
                 }
                 AddAssign | SubtractAssign | MultiplyAssign | DivideAssign | ModuloAssign => {
-                    return "(" + .codegen_checked_binary_op_assignment(lhs, rhs, op, type_id) + ")"
+                    if .compiler.optimize {
+                        return "(" + .codegen_unchecked_binary_op_assignment(lhs, rhs, op, type_id) + ")"
+                    } else {
+                        return "(" + .codegen_checked_binary_op_assignment(lhs, rhs, op, type_id) + ")"
+                    }
                 }
                 else => { }
             }
@@ -2147,6 +2155,26 @@ struct CodeGenerator {
         return output
     }
 
+    function codegen_unchecked_binary_op(mut this, lhs: CheckedExpression, rhs: CheckedExpression, op: BinaryOperator, type_id: TypeId) throws -> String {
+        mut output = "static_cast<"
+        output += .codegen_type(type_id)
+        output += ">("
+        output += .codegen_expression(lhs)
+        output += match op {
+            Add => " + "
+            Subtract => " - "
+            Multiply => " * "
+            Divide => " / "
+            Modulo => " % "
+            else => {
+                panic(format("Checked binary operation codegen is not supported for BinaryOperator::{}", op))
+            }
+        }
+        output += .codegen_expression(rhs)
+        output += ")"
+        return output
+    }
+
     function codegen_checked_binary_op(mut this, lhs: CheckedExpression, rhs: CheckedExpression, op: BinaryOperator, type_id: TypeId) throws -> String {
         mut output = ""
         output += "JaktInternal::"
@@ -2170,6 +2198,32 @@ struct CodeGenerator {
         output += .codegen_expression(rhs)
         output += ")"
 
+        return output
+    }
+
+    function codegen_unchecked_binary_op_assignment(mut this, lhs: CheckedExpression, rhs: CheckedExpression, op: BinaryOperator, type_id: TypeId) throws -> String {
+        mut output = ""
+
+        output += "{"
+        output += "auto& _jakt_ref = "
+        output += .codegen_expression(lhs)
+        output += ";"
+        output += "_jakt_ref = static_cast<"
+        output += .codegen_type(type_id)
+        output += ">(_jakt_ref "
+        output += match op {
+            AddAssign => " + "
+            SubtractAssign => " - "
+            MultiplyAssign => " * "
+            DivideAssign => " / "
+            ModuloAssign => " % "
+            else => {
+                panic(format("Checked binary operation assignment codegen is not supported for BinaryOperator::{}", op))
+            }
+        }
+        output += .codegen_expression(rhs)
+        output += ");"
+        output += "}"
         return output
     }
 

--- a/selfhost/compiler.jakt
+++ b/selfhost/compiler.jakt
@@ -16,6 +16,7 @@ class Compiler {
     public json_errors: bool
     public dump_type_hints: bool
     public dump_try_hints: bool
+    public optimize: bool
 
     public function panic(this, anon message: String) throws -> never {
         .print_errors()

--- a/selfhost/main.jakt
+++ b/selfhost/main.jakt
@@ -226,6 +226,7 @@ function main(args: [String]) {
         json_errors
         dump_type_hints
         dump_try_hints
+        optimize
     )
 
     compiler.load_prelude()

--- a/selfhost/repl.jakt
+++ b/selfhost/repl.jakt
@@ -252,6 +252,7 @@ struct REPL {
             json_errors: false
             dump_type_hints: false
             dump_try_hints: false
+            optimize: false
         )
 
         compiler.load_prelude()


### PR DESCRIPTION
Because the cost of checked math is so high, let's use unchecked math specifically during optimized release builds. This matches languages like Rust, but just in general is probably what many devs might expect as the cost of doing checked math is quite high (in my tests it's something like 3x slower.