### PR TITLE
formatter: Replace semicolons with newlines when appropriate

### DIFF
--- a/selfhost/formatter.jakt
+++ b/selfhost/formatter.jakt
@@ -1564,6 +1564,26 @@ struct Stage0 {
                         preceding_trivia: []
                     )
                 }
+                Semicolon => {
+                    if open_squares == 0 {
+                        return match .peek() {
+                            Eol => .next()
+                            else => FormattedToken(
+                                token: Token::Eol(comment: None, span: token.span())
+                                indent: .indent
+                                trailing_trivia: []
+                                preceding_trivia: []
+                            )
+                        }
+                    }
+                    
+                    yield FormattedToken(
+                        token
+                        indent: .indent
+                        trailing_trivia: [b' ']
+                        preceding_trivia: []
+                    )
+                }
                 else => FormattedToken(
                     token
                     indent: .indent


### PR DESCRIPTION
If we are in array initialization, semicolon is a valid syntax to specify the size of the array. Otherwise, it is superfluous and should be replaced with newline.

before:
```
function main() {
    println("hello friends;"); println("goodbye friends"); // what about comments
    let arr = [0;69]
    unsafe {
        cpp {
            "int wat;"
        }
    }
}
```
after:
```
function main() {
    println("hello friends;")
    println("goodbye friends") // what about comments
    let arr = [0; 69]
    unsafe {
        cpp {
            "int wat;"
        }
    }
}
```