### PR TITLE
parser+typechecker: Update lambda return type inference

### DIFF
--- a/samples/closures/lambdas_can_throw.jakt
+++ b/samples/closures/lambdas_can_throw.jakt
@@ -6,8 +6,7 @@ function test(anon cb: function() throws -> String) throws {
 }
 
 function main() {
-    test(function() throws {
+    test(function() throws -> String {
         return format("{}", 69)
     })
 }
-

--- a/selfhost/parser.jakt
+++ b/selfhost/parser.jakt
@@ -724,7 +724,7 @@ boxed enum ParsedExpression {
     Match(expr: ParsedExpression, cases: [ParsedMatchCase], span: Span, marker_span: Span)
     EnumVariantArg(expr: ParsedExpression, arg: EnumVariantPatternArgument, enum_variant: ParsedType, span: Span)
     NamespacedVar(name: String, namespace_: [String], span: Span)
-    Function(captures: [ParsedCapture], params: [ParsedParameter], can_throw: bool, return_type: ParsedType, block: ParsedBlock, span: Span)
+    Function(captures: [ParsedCapture], params: [ParsedParameter], can_throw: bool, is_fat_arrow: bool, return_type: ParsedType, block: ParsedBlock, span: Span)
     Try(expr: ParsedExpression, catch_block: ParsedBlock?, catch_name: String?, span: Span)
     TryBlock(stmt: ParsedStatement, error_name: String, error_span: Span, catch_block: ParsedBlock, span: Span)
     Garbage(Span)
@@ -987,10 +987,10 @@ boxed enum ParsedExpression {
             TryBlock(stmt: rhs_stmt, error_name: rhs_error_name, catch_block: rhs_catch_block) => lhs_stmt.equals(rhs_stmt) and (lhs_error_name == rhs_error_name) and lhs_catch_block.equals(rhs_catch_block)
             else => false
         }
-        Function(captures: lhs_captures, params: lhs_params, can_throw: lsh_can_throw, return_type: lhs_return_type) => match rhs_expression {
-            Function(captures: rhs_captures, params: rhs_params, can_throw: rsh_can_throw, return_type: rhs_return_type) => {
+        Function(captures: lhs_captures, params: lhs_params, can_throw: lhs_can_throw, return_type: lhs_return_type) => match rhs_expression {
+            Function(captures: rhs_captures, params: rhs_params, can_throw: rhs_can_throw, return_type: rhs_return_type) => {
                 guard lhs_return_type.equals(rhs_return_type) and 
-                    lsh_can_throw == rsh_can_throw and
+                    lhs_can_throw == rhs_can_throw and
                     lhs_captures.size() == rhs_captures.size() and
                     lhs_params.size() == rhs_params.size() else {
                     return false
@@ -3142,8 +3142,10 @@ struct Parser {
             else => ParsedType::Empty
         }
 
+        mut is_fat_arrow = false
         let block = match .current() {
             FatArrow => {
+                is_fat_arrow = true
                 .index++
                 let expr = .parse_expression(allow_assignments: true, allow_newlines: false)
                 let span = expr.span()
@@ -3152,7 +3154,7 @@ struct Parser {
             else => .parse_block()
         }
 
-        return ParsedExpression::Function(captures, params, can_throw, return_type, block, span: merge_spans(start, .current().span()))
+        return ParsedExpression::Function(captures, params, can_throw, is_fat_arrow, return_type, block, span: merge_spans(start, .current().span()))
     }
 
     function parse_asterisk(mut this) throws -> ParsedExpression {

--- a/selfhost/typechecker.jakt
+++ b/selfhost/typechecker.jakt
@@ -1996,7 +1996,6 @@ struct Typechecker {
 
         // Check return type
         mut function_return_type_id = .typecheck_typename(parsed_type: parsed_function.return_type, scope_id: checked_function_scope_id, name: None)
-
         if not parsed_function.is_fat_arrow and parsed_function.return_type is Empty {
             function_return_type_id = void_type_id()
         }
@@ -4694,7 +4693,7 @@ struct Typechecker {
         }
         JaktDictionary(values, span) => .typecheck_dictionary(values, span, scope_id, safety_mode, type_hint)
         Set(values, span) => .typecheck_set(values, span, scope_id, safety_mode, type_hint)
-        Function(captures, params, can_throw, return_type, block, span) => .typecheck_lambda(captures, params, can_throw, return_type, block, span, scope_id, safety_mode)
+        Function(captures, params, can_throw, is_fat_arrow, return_type, block, span) => .typecheck_lambda(captures, params, can_throw, is_fat_arrow, return_type, block, span, scope_id, safety_mode)
         Try(expr, catch_block, catch_name, span) => .typecheck_try(expr, catch_block, catch_name, scope_id, safety_mode, span, type_hint)
         TryBlock(stmt, catch_block, error_name, error_span, span) => .typecheck_try_block(stmt, error_name, error_span, catch_block, scope_id, safety_mode, span)
         Operator => {
@@ -4775,7 +4774,7 @@ struct Typechecker {
         return None
     }
 
-    function typecheck_lambda(mut this, captures: [ParsedCapture], params: [ParsedParameter], can_throw: bool, return_type: ParsedType, block: ParsedBlock, span: Span, scope_id: ScopeId, safety_mode: SafetyMode) throws -> CheckedExpression {
+    function typecheck_lambda(mut this, captures: [ParsedCapture], params: [ParsedParameter], can_throw: bool, is_fat_arrow: bool, return_type: ParsedType, block: ParsedBlock, span: Span, scope_id: ScopeId, safety_mode: SafetyMode) throws -> CheckedExpression {
         let synthetic_type = ParsedType::Function(
             params
             can_throw
@@ -4830,13 +4829,20 @@ struct Typechecker {
 
         let checked_block = .typecheck_block(parsed_block: block, parent_scope_id: lambda_scope_id, safety_mode)
 
-        if return_type_id.equals(unknown_type_id())
-            and not checked_block.statements.is_empty() {
-
-            if checked_block.statements.last()! is Return(val)
-                and val.has_value() {
-
+        if return_type_id.equals(unknown_type_id()) {
+            mut return_type_updated = false
+            if not is_fat_arrow and return_type is Empty {
+                return_type_id = void_type_id()
+                return_type_updated = true
+            } else if is_fat_arrow and 
+                not checked_block.statements.is_empty() and
+                checked_block.statements.last()! is Return(val) and 
+                val.has_value() {
                 return_type_id = .resolve_type_var(type_var_type_id: val!.type(), scope_id: lambda_scope_id)
+                return_type_updated = true
+            }
+
+            if return_type_updated {
                 type_id = match .get_type(type_id) {
                     Function(params, can_throw, pseudo_function_id) => .find_or_add_type_id(Type::Function(
                         params
@@ -4859,7 +4865,8 @@ struct Typechecker {
             block: checked_block
             span
             type_id
-            pseudo_function_id)
+            pseudo_function_id
+        )
     }
 
     function typecheck_namespaced_var_or_simple_enum_constructor_call(mut this, name: String, namespace_: [String], scope_id: ScopeId, safety_mode: SafetyMode, type_hint: TypeId?, span: Span) throws -> CheckedExpression {

--- a/tests/typechecker/lambda_no_return_type.jakt
+++ b/tests/typechecker/lambda_no_return_type.jakt
@@ -1,0 +1,10 @@
+/// Expect:
+/// - output: "OK\n"
+
+function main() {
+    let a = function() {
+        println("OK")
+    }
+
+    a()
+}


### PR DESCRIPTION
This updates lambdas to match the rules now for other types of functions
- Only infer type if it is an arrow function.
- For non arrow functions without a return type specified the return type becomes void instead of unknown.