### PR TITLE
Function overloading

### DIFF
--- a/bootstrap/stage0/Root Module.cpp
+++ b/bootstrap/stage0/Root Module.cpp
@@ -87,15 +87,15 @@ if (__jakt_enum_value == static_cast<size_t>(1ULL)) {
 return JaktInternal::ExplicitValue(input_file_length);
 }
 else if (__jakt_enum_value == static_cast<size_t>(2ULL)) {
-return JaktInternal::ExplicitValue(({ Optional<size_t> __jakt_var_700; {
+return JaktInternal::ExplicitValue(({ Optional<size_t> __jakt_var_707; {
 JaktInternal::Optional<u32> const end_input = ((((parts)[static_cast<i64>(1LL)])).to_uint());
 if ((!(((end_input).has_value())))){
 return (JaktInternal::OptionalNone());
 }
-__jakt_var_700 = (infallible_integer_cast<size_t>(((end_input.value())))); goto __jakt_label_645;
+__jakt_var_707 = (infallible_integer_cast<size_t>(((end_input.value())))); goto __jakt_label_651;
 
 }
-__jakt_label_645:; __jakt_var_700.release_value(); }));
+__jakt_label_651:; __jakt_var_707.release_value(); }));
 }
 else {
 {
@@ -202,15 +202,15 @@ bool const interpret_run = TRY((((args_parser).flag((TRY((Array<String>::create_
 bool const format = TRY((((args_parser).flag((TRY((Array<String>::create_with({String("-f"), String("--format")}))))))));
 bool const format_debug = TRY((((args_parser).flag((TRY((Array<String>::create_with({String("-fd"), String("--format-debug")}))))))));
 String const input_format_range = TRY((((args_parser).option((TRY((Array<String>::create_with({String("-fr"), String("--format-range")})))))))).value_or_lazy_evaluated([&] { return String(""); });
-size_t const max_concurrent = (infallible_integer_cast<size_t>((({ Optional<u32> __jakt_var_701;
-auto __jakt_var_702 = [&]() -> ErrorOr<u32> { return TRY((value_or_throw<u32>(((compiler_job_count).to_uint())))); }();
-if (__jakt_var_702.is_error()) {{
+size_t const max_concurrent = (infallible_integer_cast<size_t>((({ Optional<u32> __jakt_var_708;
+auto __jakt_var_709 = [&]() -> ErrorOr<u32> { return TRY((value_or_throw<u32>(((compiler_job_count).to_uint())))); }();
+if (__jakt_var_709.is_error()) {{
 warnln(String("error: invalid value for --jobs: {}"),compiler_job_count);
 return (static_cast<i64>(1LL));
 }
-} else {__jakt_var_701 = __jakt_var_702.release_value();
+} else {__jakt_var_708 = __jakt_var_709.release_value();
 }
-__jakt_var_701.release_value(); }))));
+__jakt_var_708.release_value(); }))));
 if (TRY((((args_parser).flag((TRY((Array<String>::create_with({String("--repl")}))))))))){
 repl::REPL repl = TRY((repl::REPL::REPL::create(TRY((path::Path::Path::from_parts((TRY((Array<String>::create_with({runtime_path, String("jaktlib")}))))))),target_triple)));
 TRY((((repl).run())));
@@ -475,16 +475,20 @@ if ((!(((((scope)->parent)).map([&](auto& _value) { return _value.equals(prelude
 continue;
 }
 {
-JaktInternal::DictionaryIterator<String,types::FunctionId> _magic = ((((scope)->functions)).iterator());
+JaktInternal::DictionaryIterator<String,JaktInternal::Array<types::FunctionId>> _magic = ((((scope)->functions)).iterator());
 for (;;){
-JaktInternal::Optional<JaktInternal::Tuple<String,types::FunctionId>> _magic_value = ((_magic).next());
+JaktInternal::Optional<JaktInternal::Tuple<String,JaktInternal::Array<types::FunctionId>>> _magic_value = ((_magic).next());
 if ((!(((_magic_value).has_value())))){
 break;
 }
-JaktInternal::Tuple<String,types::FunctionId> function_ = (_magic_value.value());
+JaktInternal::Tuple<String,JaktInternal::Array<types::FunctionId>> function_name__overload_set__ = (_magic_value.value());
 {
-if ((((function_).get<0>()) == String("main"))){
-(main_function_id = ((function_).get<1>()));
+JaktInternal::Tuple<String,JaktInternal::Array<types::FunctionId>> const jakt__function_name__overload_set__ = function_name__overload_set__;
+String const function_name = ((jakt__function_name__overload_set__).get<0>());
+JaktInternal::Array<types::FunctionId> const overload_set = ((jakt__function_name__overload_set__).get<1>());
+
+if ((function_name == String("main"))){
+(main_function_id = ((overload_set)[static_cast<i64>(0LL)]));
 break;
 }
 }
@@ -518,7 +522,7 @@ JaktInternal::Optional<types::CheckedParameter> const first_main_param = ((((((c
 JaktInternal::Array<types::Value> const arguments = JAKT_RESOLVE_EXPLICIT_VALUE_OR_CONTROL_FLOW_RETURN_ONLY(([&]() -> JaktInternal::ExplicitValueOrControlFlow<JaktInternal::Array<types::Value>,ErrorOr<int>>{
 auto __jakt_enum_value = (((first_main_param).has_value()));
 if (__jakt_enum_value == true) {
-return JaktInternal::ExplicitValue(({ Optional<JaktInternal::Array<types::Value>> __jakt_var_703; {
+return JaktInternal::ExplicitValue(({ Optional<JaktInternal::Array<types::Value>> __jakt_var_710; {
 JaktInternal::Array<types::Value> passed_arguments = (TRY((Array<types::Value>::create_with({types::Value(TRY((types::ValueImpl::template create<typename types::ValueImpl::JaktString>((file_name.value())))),call_span)}))));
 {
 JaktInternal::ArrayIterator<String> _magic = ((interpreted_main_arguments).iterator());
@@ -535,10 +539,10 @@ TRY((((passed_arguments).push(types::Value(TRY((types::ValueImpl::template creat
 }
 }
 
-__jakt_var_703 = (TRY((Array<types::Value>::create_with({types::Value(TRY((types::ValueImpl::template create<typename types::ValueImpl::JaktArray>(passed_arguments,(((((first_main_param.value())).variable)).type_id)))),call_span)})))); goto __jakt_label_646;
+__jakt_var_710 = (TRY((Array<types::Value>::create_with({types::Value(TRY((types::ValueImpl::template create<typename types::ValueImpl::JaktArray>(passed_arguments,(((((first_main_param.value())).variable)).type_id)))),call_span)})))); goto __jakt_label_652;
 
 }
-__jakt_label_646:; __jakt_var_703.release_value(); }));
+__jakt_label_652:; __jakt_var_710.release_value(); }));
 }
 else {
 return JaktInternal::ExplicitValue((TRY((Array<types::Value>::create_with({})))));
@@ -699,8 +703,8 @@ String const contents = ((contents_module_file_path_).get<0>());
 String const module_file_path = ((contents_module_file_path_).get<1>());
 
 path::Path const path = TRY((((binary_dir).join(file))));
-auto __jakt_var_705 = [&]() -> ErrorOr<void> { return TRY((write_to_file(contents,((path).to_string())))), ErrorOr<void>{}; }();
-if (__jakt_var_705.is_error()) {auto error = __jakt_var_705.release_error();
+auto __jakt_var_712 = [&]() -> ErrorOr<void> { return TRY((write_to_file(contents,((path).to_string())))), ErrorOr<void>{}; }();
+if (__jakt_var_712.is_error()) {auto error = __jakt_var_712.release_error();
 {
 warnln(String("Error: Could not write to file: {} ({})"),file,error);
 return (static_cast<i64>(1LL));
@@ -719,12 +723,12 @@ TRY((((depfile_builder).append('\n'))));
 }
 
 if (((generate_depfile).has_value())){
-auto __jakt_var_706 = [&]() -> ErrorOr<void> {{
+auto __jakt_var_713 = [&]() -> ErrorOr<void> {{
 TRY((write_to_file(TRY((((depfile_builder).to_string()))),(generate_depfile.value()))));
 }
 
 ;return {};}();
-if (__jakt_var_706.is_error()) {auto error = __jakt_var_706.release_error();{
+if (__jakt_var_713.is_error()) {auto error = __jakt_var_713.release_error();{
 warnln(String("Error: Could not write to file list ({})"),error);
 return (static_cast<i64>(1LL));
 }
@@ -755,18 +759,18 @@ TRY((((files).push(file_name))));
 }
 
 build::Builder builder = TRY((build::Builder::Builder::for_building(files,max_concurrent)));
-auto __jakt_var_708 = [&]() -> ErrorOr<void> { return TRY((((builder).build_all(binary_dir,(([cxx_compiler_path, runtime_path, extra_include_paths, optimize](String input_filename, String output_filename) -> ErrorOr<JaktInternal::Array<String>> {
+auto __jakt_var_715 = [&]() -> ErrorOr<void> { return TRY((((builder).build_all(binary_dir,(([cxx_compiler_path, runtime_path, extra_include_paths, optimize](String input_filename, String output_filename) -> ErrorOr<JaktInternal::Array<String>> {
 return (TRY((unknown_compiler::run_compiler(cxx_compiler_path,input_filename,output_filename,runtime_path,extra_include_paths,(TRY((Array<String>::create_with({})))),(TRY((Array<String>::create_with({})))),optimize,(TRY((Array<String>::create_with({String("-c")}))))))));
 }
 )))))), ErrorOr<void>{}; }();
-if (__jakt_var_708.is_error()) {{
+if (__jakt_var_715.is_error()) {{
 return (static_cast<i64>(1LL));
 }
 }
 ;
 if (((link_archive).has_value())){
-auto __jakt_var_710 = [&]() -> ErrorOr<void> { return TRY((((builder).link_into_archive(archiver_path.value_or_lazy_evaluated([&] { return String("ar"); }),(link_archive.value()))))), ErrorOr<void>{}; }();
-if (__jakt_var_710.is_error()) {{
+auto __jakt_var_717 = [&]() -> ErrorOr<void> { return TRY((((builder).link_into_archive(archiver_path.value_or_lazy_evaluated([&] { return String("ar"); }),(link_archive.value()))))), ErrorOr<void>{}; }();
+if (__jakt_var_717.is_error()) {{
 return (static_cast<i64>(1LL));
 }
 }
@@ -813,8 +817,8 @@ if ((false && (TRY((((TRY((path::Path::Path::from_string(cxx_compiler_path)))).b
 TRY((((extra_arguments).push(String("/link")))));
 TRY((((extra_arguments).push(String("/subsystem:console")))));
 }
-auto __jakt_var_712 = [&]() -> ErrorOr<void> { return TRY((((builder).link_into_executable(cxx_compiler_path,output_filename,extra_arguments)))), ErrorOr<void>{}; }();
-if (__jakt_var_712.is_error()) {{
+auto __jakt_var_719 = [&]() -> ErrorOr<void> { return TRY((((builder).link_into_executable(cxx_compiler_path,output_filename,extra_arguments)))), ErrorOr<void>{}; }();
+if (__jakt_var_719.is_error()) {{
 return (static_cast<i64>(1LL));
 }
 }

--- a/bootstrap/stage0/__unified_forward.h
+++ b/bootstrap/stage0/__unified_forward.h
@@ -21,18 +21,14 @@ struct Span;
 struct FileId;
 bool is_ascii_binary(u8 const c);
 
-bool is_ascii_alpha(u8 const c);
+String join(JaktInternal::Array<String> const strings, String const separator);
 
 template <typename T>
 ErrorOr<JaktInternal::Array<T>> add_arrays(JaktInternal::Array<T> const a, JaktInternal::Array<T> const b);
 
 bool is_whitespace(u8 const byte);
 
-template <typename T>
-T* null();
-
-template <typename T>
-ErrorOr<void> extend_array(JaktInternal::Array<T> target, JaktInternal::Array<T> const extend_with);
+bool is_ascii_alpha(u8 const c);
 
 ErrorOr<JaktInternal::Array<String>> prepend_to_each(JaktInternal::Array<String> const strings, String const prefix);
 
@@ -46,7 +42,8 @@ ErrorOr<String> interpret_escapes(String const s);
 
 ErrorOr<JaktInternal::Array<String>> append_to_each(JaktInternal::Array<String> const strings, String const suffix);
 
-String join(JaktInternal::Array<String> const strings, String const separator);
+template <typename T>
+T* null();
 
 bool is_ascii_octdigit(u8 const c);
 
@@ -839,6 +836,12 @@ namespace typechecker {
 struct AlreadyImplementedFor;
 struct Typechecker;
 struct TraitImplCheck;
+namespace FunctionMatchResult_Details {
+struct MatchSuccess;
+struct MatchError;
+}
+struct FunctionMatchResult;
+
 }
 namespace codegen {
 struct LineSpan;
@@ -994,6 +997,8 @@ ErrorOr<JaktInternal::Optional<ide::Usage>> find_span_in_expression(NonnullRefPt
 ErrorOr<JaktInternal::Optional<ide::Usage>> find_span_in_block(NonnullRefPtr<types::CheckedProgram> const program, types::CheckedBlock const block, utility::Span const span);
 
 ErrorOr<JaktInternal::Optional<ide::Usage>> find_span_in_program(NonnullRefPtr<types::CheckedProgram> const program, utility::Span const span);
+
+ErrorOr<JaktInternal::Array<String>> find_function_completions_in_scope(NonnullRefPtr<types::Scope> const scope, NonnullRefPtr<types::CheckedProgram> const program);
 
 ErrorOr<JaktInternal::Array<ide::JaktSymbol>> find_symbols_in_namespace(parser::ParsedNamespace const namespace_);
 

--- a/bootstrap/stage0/build.cpp
+++ b/bootstrap/stage0/build.cpp
@@ -208,15 +208,15 @@ JaktInternal::Tuple<size_t,unknown_process::Process> const jakt__index__process_
 size_t const index = ((jakt__index__process__).get<0>());
 unknown_process::Process const process = ((jakt__index__process__).get<1>());
 
-JaktInternal::Optional<unknown_process::ExitPollResult> const status = ({ Optional<JaktInternal::Optional<unknown_process::ExitPollResult>> __jakt_var_698;
-auto __jakt_var_699 = [&]() -> ErrorOr<JaktInternal::Optional<unknown_process::ExitPollResult>> { return TRY((unknown_process::poll_process_exit(((process))))); }();
-if (__jakt_var_699.is_error()) {{
+JaktInternal::Optional<unknown_process::ExitPollResult> const status = ({ Optional<JaktInternal::Optional<unknown_process::ExitPollResult>> __jakt_var_705;
+auto __jakt_var_706 = [&]() -> ErrorOr<JaktInternal::Optional<unknown_process::ExitPollResult>> { return TRY((unknown_process::poll_process_exit(((process))))); }();
+if (__jakt_var_706.is_error()) {{
 TRY((((pids_to_remove).set(index,finished_status))));
 continue;
 }
-} else {__jakt_var_698 = __jakt_var_699.release_value();
+} else {__jakt_var_705 = __jakt_var_706.release_value();
 }
-__jakt_var_698.release_value(); });
+__jakt_var_705.release_value(); });
 if (((status).has_value())){
 TRY((((pids_to_remove).set(index,(status.value())))));
 }

--- a/bootstrap/stage0/codegen.cpp
+++ b/bootstrap/stage0/codegen.cpp
@@ -377,12 +377,12 @@ auto&& __jakt_match_variant = *((((*this).program))->get_type(((expression)->typ
 switch(__jakt_match_variant.index()) {
 case 18: {
 auto&& __jakt_match_value = __jakt_match_variant.template get<typename types::Type::TypeVariable>();
-return JaktInternal::ExplicitValue(({ Optional<String> __jakt_var_383; {
+return JaktInternal::ExplicitValue(({ Optional<String> __jakt_var_390; {
 String const contents = TRY((((*this).codegen_expression(expression))));
-__jakt_var_383 = TRY((String::formatted(String("(*([]<typename V>(V const& value) {{ if constexpr (IsSpecializationOf<V, NonnullRefPtr>) return &*value; else return &value; }})({}))"),contents))); goto __jakt_label_356;
+__jakt_var_390 = TRY((String::formatted(String("(*([]<typename V>(V const& value) {{ if constexpr (IsSpecializationOf<V, NonnullRefPtr>) return &*value; else return &value; }})({}))"),contents))); goto __jakt_label_362;
 
 }
-__jakt_label_356:; __jakt_var_383.release_value(); }));
+__jakt_label_362:; __jakt_var_390.release_value(); }));
 };/*case end*/
 default: {
 return JaktInternal::ExplicitValue(TRY((((*this).codegen_expression(expression)))));
@@ -537,25 +537,34 @@ continue;
 }
 
 {
-JaktInternal::DictionaryIterator<String,types::FunctionId> _magic = ((((scope)->functions)).iterator());
+JaktInternal::DictionaryIterator<String,JaktInternal::Array<types::FunctionId>> _magic = ((((scope)->functions)).iterator());
 for (;;){
-JaktInternal::Optional<JaktInternal::Tuple<String,types::FunctionId>> _magic_value = ((_magic).next());
+JaktInternal::Optional<JaktInternal::Tuple<String,JaktInternal::Array<types::FunctionId>>> _magic_value = ((_magic).next());
 if ((!(((_magic_value).has_value())))){
 break;
 }
-JaktInternal::Tuple<String,types::FunctionId> ___function_id__ = (_magic_value.value());
+JaktInternal::Tuple<String,JaktInternal::Array<types::FunctionId>> ___overload_set__ = (_magic_value.value());
 {
-JaktInternal::Tuple<String,types::FunctionId> const jakt_____function_id__ = ___function_id__;
-String const _ = ((jakt_____function_id__).get<0>());
-types::FunctionId const function_id = ((jakt_____function_id__).get<1>());
+JaktInternal::Tuple<String,JaktInternal::Array<types::FunctionId>> const jakt_____overload_set__ = ___overload_set__;
+String const _ = ((jakt_____overload_set__).get<0>());
+JaktInternal::Array<types::FunctionId> const overload_set = ((jakt_____overload_set__).get<1>());
 
+{
+JaktInternal::ArrayIterator<types::FunctionId> _magic = ((overload_set).iterator());
+for (;;){
+JaktInternal::Optional<types::FunctionId> _magic_value = ((_magic).next());
+if ((!(((_magic_value).has_value())))){
+break;
+}
+types::FunctionId function_id = (_magic_value.value());
+{
 if ((!(((((function_id).module)).equals(((current_module)->id)))))){
 continue;
 }
 NonnullRefPtr<types::CheckedFunction> const function_ = ((((*this).program))->get_function(function_id));
 JaktInternal::Optional<NonnullRefPtr<types::CheckedFunction>> const previous_function = ((*this).current_function);
 (((*this).current_function) = function_);
-ScopeGuard __jakt_var_384([&] {
+ScopeGuard __jakt_var_391([&] {
 (((*this).current_function) = previous_function);
 });
 if (((((((function_)->linkage)).index() == 1 /* External */) || ((((function_)->type)).index() == 1 /* ImplicitConstructor */)) || ((((function_)->type)).index() == 2 /* ImplicitEnumConstructor */))){
@@ -565,6 +574,11 @@ if ((!(((((((function_)->generics))->params)).is_empty())))){
 (output += TRY((((*this).codegen_function(function_,false)))));
 (output += String("\n"));
 }
+}
+
+}
+}
+
 }
 
 }
@@ -599,25 +613,34 @@ return (output);
 }
 String output = String("");
 {
-JaktInternal::DictionaryIterator<String,types::FunctionId> _magic = ((((scope)->functions)).iterator());
+JaktInternal::DictionaryIterator<String,JaktInternal::Array<types::FunctionId>> _magic = ((((scope)->functions)).iterator());
 for (;;){
-JaktInternal::Optional<JaktInternal::Tuple<String,types::FunctionId>> _magic_value = ((_magic).next());
+JaktInternal::Optional<JaktInternal::Tuple<String,JaktInternal::Array<types::FunctionId>>> _magic_value = ((_magic).next());
 if ((!(((_magic_value).has_value())))){
 break;
 }
-JaktInternal::Tuple<String,types::FunctionId> ___function_id__ = (_magic_value.value());
+JaktInternal::Tuple<String,JaktInternal::Array<types::FunctionId>> ___overload_set__ = (_magic_value.value());
 {
-JaktInternal::Tuple<String,types::FunctionId> const jakt_____function_id__ = ___function_id__;
-String const _ = ((jakt_____function_id__).get<0>());
-types::FunctionId const function_id = ((jakt_____function_id__).get<1>());
+JaktInternal::Tuple<String,JaktInternal::Array<types::FunctionId>> const jakt_____overload_set__ = ___overload_set__;
+String const _ = ((jakt_____overload_set__).get<0>());
+JaktInternal::Array<types::FunctionId> const overload_set = ((jakt_____overload_set__).get<1>());
 
+{
+JaktInternal::ArrayIterator<types::FunctionId> _magic = ((overload_set).iterator());
+for (;;){
+JaktInternal::Optional<types::FunctionId> _magic_value = ((_magic).next());
+if ((!(((_magic_value).has_value())))){
+break;
+}
+types::FunctionId function_id = (_magic_value.value());
+{
 if ((!(((((function_id).module)).equals(((current_module)->id)))))){
 continue;
 }
 NonnullRefPtr<types::CheckedFunction> const function_ = ((((*this).program))->get_function(function_id));
 JaktInternal::Optional<NonnullRefPtr<types::CheckedFunction>> const previous_function = ((*this).current_function);
 (((*this).current_function) = function_);
-ScopeGuard __jakt_var_385([&] {
+ScopeGuard __jakt_var_392([&] {
 (((*this).current_function) = previous_function);
 });
 if (((((((function_)->linkage)).index() == 1 /* External */) || ((((function_)->type)).index() == 1 /* ImplicitConstructor */)) || ((((function_)->type)).index() == 2 /* ImplicitEnumConstructor */))){
@@ -627,6 +650,11 @@ if (((((((function_)->generics))->params)).is_empty())){
 (output += TRY((((*this).codegen_function(function_,false)))));
 (output += String("\n"));
 }
+}
+
+}
+}
+
 }
 
 }
@@ -658,22 +686,31 @@ continue;
 (output += TRY((((*this).codegen_debug_description_getter(struct_,false)))));
 NonnullRefPtr<types::Scope> const scope = TRY((((((*this).program))->get_scope(((struct_).scope_id)))));
 {
-JaktInternal::DictionaryIterator<String,types::FunctionId> _magic = ((((scope)->functions)).iterator());
+JaktInternal::DictionaryIterator<String,JaktInternal::Array<types::FunctionId>> _magic = ((((scope)->functions)).iterator());
 for (;;){
-JaktInternal::Optional<JaktInternal::Tuple<String,types::FunctionId>> _magic_value = ((_magic).next());
+JaktInternal::Optional<JaktInternal::Tuple<String,JaktInternal::Array<types::FunctionId>>> _magic_value = ((_magic).next());
 if ((!(((_magic_value).has_value())))){
 break;
 }
-JaktInternal::Tuple<String,types::FunctionId> ___function_id__ = (_magic_value.value());
+JaktInternal::Tuple<String,JaktInternal::Array<types::FunctionId>> ___overload_set__ = (_magic_value.value());
 {
-JaktInternal::Tuple<String,types::FunctionId> const jakt_____function_id__ = ___function_id__;
-String const _ = ((jakt_____function_id__).get<0>());
-types::FunctionId const function_id = ((jakt_____function_id__).get<1>());
+JaktInternal::Tuple<String,JaktInternal::Array<types::FunctionId>> const jakt_____overload_set__ = ___overload_set__;
+String const _ = ((jakt_____overload_set__).get<0>());
+JaktInternal::Array<types::FunctionId> const overload_set = ((jakt_____overload_set__).get<1>());
 
+{
+JaktInternal::ArrayIterator<types::FunctionId> _magic = ((overload_set).iterator());
+for (;;){
+JaktInternal::Optional<types::FunctionId> _magic_value = ((_magic).next());
+if ((!(((_magic_value).has_value())))){
+break;
+}
+types::FunctionId function_id = (_magic_value.value());
+{
 NonnullRefPtr<types::CheckedFunction> const function_ = ((((*this).program))->get_function(function_id));
 JaktInternal::Optional<NonnullRefPtr<types::CheckedFunction>> const previous_function = ((*this).current_function);
 (((*this).current_function) = function_);
-ScopeGuard __jakt_var_386([&] {
+ScopeGuard __jakt_var_393([&] {
 (((*this).current_function) = previous_function);
 });
 if (((((function_)->type)).index() == 1 /* ImplicitConstructor */)){
@@ -684,6 +721,11 @@ else if (((!(((((function_)->type)).index() == 2 /* ImplicitEnumConstructor */))
 (output += TRY((((*this).codegen_function_in_namespace(function_,((struct_).type_id),false)))));
 (output += String("\n"));
 }
+}
+
+}
+}
+
 }
 
 }
@@ -722,28 +764,42 @@ if (((((enum_).underlying_type_id)).equals(types::void_type_id()))){
 }
 NonnullRefPtr<types::Scope> const scope = TRY((((((*this).program))->get_scope(((enum_).scope_id)))));
 {
-JaktInternal::DictionaryIterator<String,types::FunctionId> _magic = ((((scope)->functions)).iterator());
+JaktInternal::DictionaryIterator<String,JaktInternal::Array<types::FunctionId>> _magic = ((((scope)->functions)).iterator());
 for (;;){
-JaktInternal::Optional<JaktInternal::Tuple<String,types::FunctionId>> _magic_value = ((_magic).next());
+JaktInternal::Optional<JaktInternal::Tuple<String,JaktInternal::Array<types::FunctionId>>> _magic_value = ((_magic).next());
 if ((!(((_magic_value).has_value())))){
 break;
 }
-JaktInternal::Tuple<String,types::FunctionId> ___function_id__ = (_magic_value.value());
+JaktInternal::Tuple<String,JaktInternal::Array<types::FunctionId>> ___overload_set__ = (_magic_value.value());
 {
-JaktInternal::Tuple<String,types::FunctionId> const jakt_____function_id__ = ___function_id__;
-String const _ = ((jakt_____function_id__).get<0>());
-types::FunctionId const function_id = ((jakt_____function_id__).get<1>());
+JaktInternal::Tuple<String,JaktInternal::Array<types::FunctionId>> const jakt_____overload_set__ = ___overload_set__;
+String const _ = ((jakt_____overload_set__).get<0>());
+JaktInternal::Array<types::FunctionId> const overload_set = ((jakt_____overload_set__).get<1>());
 
+{
+JaktInternal::ArrayIterator<types::FunctionId> _magic = ((overload_set).iterator());
+for (;;){
+JaktInternal::Optional<types::FunctionId> _magic_value = ((_magic).next());
+if ((!(((_magic_value).has_value())))){
+break;
+}
+types::FunctionId function_id = (_magic_value.value());
+{
 NonnullRefPtr<types::CheckedFunction> const function_ = ((((*this).program))->get_function(function_id));
 JaktInternal::Optional<NonnullRefPtr<types::CheckedFunction>> const previous_function = ((*this).current_function);
 (((*this).current_function) = function_);
-ScopeGuard __jakt_var_387([&] {
+ScopeGuard __jakt_var_394([&] {
 (((*this).current_function) = previous_function);
 });
 if (((!(((((function_)->type)).index() == 1 /* ImplicitConstructor */))) && ((!(((((function_)->type)).index() == 2 /* ImplicitEnumConstructor */))) && (!(((function_)->is_comptime)))))){
 (output += TRY((((*this).codegen_function_in_namespace(function_,((enum_).type_id),false)))));
 (output += String("\n"));
 }
+}
+
+}
+}
+
 }
 
 }
@@ -942,7 +998,7 @@ return JaktInternal::ExplicitValue((TRY((((*this).codegen_expression(expr)))) + 
 };/*case end*/
 case 1: {
 auto&& __jakt_match_value = __jakt_match_variant.template get<types::CheckedStatement::Defer>();NonnullRefPtr<types::CheckedStatement> const& statement = __jakt_match_value.statement;
-return JaktInternal::ExplicitValue(({ Optional<String> __jakt_var_388; {
+return JaktInternal::ExplicitValue(({ Optional<String> __jakt_var_395; {
 String output = String("");
 (output += String("ScopeGuard "));
 (output += TRY((((*this).fresh_var()))));
@@ -955,10 +1011,10 @@ bool const old_inside_defer = ((*this).inside_defer);
 (output += String("});"));
 (((*this).control_flow_state) = last_control_flow);
 (((*this).inside_defer) = old_inside_defer);
-__jakt_var_388 = output; goto __jakt_label_357;
+__jakt_var_395 = output; goto __jakt_label_363;
 
 }
-__jakt_label_357:; __jakt_var_388.release_value(); }));
+__jakt_label_363:; __jakt_var_395.release_value(); }));
 };/*case end*/
 case 8: {
 auto&& __jakt_match_value = __jakt_match_variant.template get<types::CheckedStatement::Return>();JaktInternal::Optional<NonnullRefPtr<types::CheckedExpression>> const& val = __jakt_match_value.val;
@@ -968,8 +1024,8 @@ if (__jakt_enum_value == true) {
 return JaktInternal::ExplicitValue(((String("return (") + TRY((((*this).codegen_expression((val.value())))))) + String(");")));
 }
 else {
-return JaktInternal::ExplicitValue(({ Optional<String> __jakt_var_389; {
-__jakt_var_389 = JAKT_RESOLVE_EXPLICIT_VALUE_OR_CONTROL_FLOW_RETURN_ONLY(([&]() -> JaktInternal::ExplicitValueOrControlFlow<String,ErrorOr<String>>{
+return JaktInternal::ExplicitValue(({ Optional<String> __jakt_var_396; {
+__jakt_var_396 = JAKT_RESOLVE_EXPLICIT_VALUE_OR_CONTROL_FLOW_RETURN_ONLY(([&]() -> JaktInternal::ExplicitValueOrControlFlow<String,ErrorOr<String>>{
 auto __jakt_enum_value = ((((((*this).current_function).value()))->can_throw));
 if (__jakt_enum_value == true) {
 return JaktInternal::ExplicitValue(String("return {};"));
@@ -978,17 +1034,17 @@ else {
 return JaktInternal::ExplicitValue(String("return;"));
 }
 }()))
-; goto __jakt_label_358;
+; goto __jakt_label_364;
 
 }
-__jakt_label_358:; __jakt_var_389.release_value(); }));
+__jakt_label_364:; __jakt_var_396.release_value(); }));
 }
 }()))
 );
 };/*case end*/
 case 6: {
 auto&& __jakt_match_value = __jakt_match_variant.template get<types::CheckedStatement::Loop>();types::CheckedBlock const& block = __jakt_match_value.block;
-return JaktInternal::ExplicitValue(({ Optional<String> __jakt_var_390; {
+return JaktInternal::ExplicitValue(({ Optional<String> __jakt_var_397; {
 String output = String("");
 if ((((((*this).debug_info)).statement_span_comments) && ((((statement)->span())).has_value()))){
 (output += TRY((String::formatted(String("\n#line {}\n"),TRY((((((*this).debug_info)).span_to_source_location((((statement)->span()).value())))))))));
@@ -1000,15 +1056,15 @@ codegen::ControlFlowState const last_control_flow = ((*this).control_flow_state)
 String const block_str = TRY((((*this).codegen_block(block))));
 (((*this).control_flow_state) = last_control_flow);
 (output += block_str);
-__jakt_var_390 = output; goto __jakt_label_359;
+__jakt_var_397 = output; goto __jakt_label_365;
 
 }
-__jakt_label_359:; __jakt_var_390.release_value(); }));
+__jakt_label_365:; __jakt_var_397.release_value(); }));
 };/*case end*/
 case 7: {
 auto&& __jakt_match_value = __jakt_match_variant.template get<types::CheckedStatement::While>();NonnullRefPtr<types::CheckedExpression> const& condition = __jakt_match_value.condition;
 types::CheckedBlock const& block = __jakt_match_value.block;
-return JaktInternal::ExplicitValue(({ Optional<String> __jakt_var_391; {
+return JaktInternal::ExplicitValue(({ Optional<String> __jakt_var_398; {
 String output = String("");
 if ((((((*this).debug_info)).statement_span_comments) && ((((statement)->span())).has_value()))){
 (output += TRY((String::formatted(String("\n#line {}\n"),TRY((((((*this).debug_info)).span_to_source_location((((statement)->span()).value())))))))));
@@ -1025,10 +1081,10 @@ String const code = TRY((((*this).codegen_block(block))));
 }
 
 (add_newline = false);
-__jakt_var_391 = output; goto __jakt_label_360;
+__jakt_var_398 = output; goto __jakt_label_366;
 
 }
-__jakt_label_360:; __jakt_var_391.release_value(); }));
+__jakt_label_366:; __jakt_var_398.release_value(); }));
 };/*case end*/
 case 5: {
 auto&& __jakt_match_value = __jakt_match_variant.template get<types::CheckedStatement::Block>();types::CheckedBlock const& block = __jakt_match_value.block;
@@ -1043,7 +1099,7 @@ utility::panic(String("Garbage statement in codegen"));
 case 2: {
 auto&& __jakt_match_value = __jakt_match_variant.template get<types::CheckedStatement::DestructuringAssignment>();JaktInternal::Array<NonnullRefPtr<types::CheckedStatement>> const& vars = __jakt_match_value.vars;
 NonnullRefPtr<types::CheckedStatement> const& var_decl = __jakt_match_value.var_decl;
-return JaktInternal::ExplicitValue(({ Optional<String> __jakt_var_392; {
+return JaktInternal::ExplicitValue(({ Optional<String> __jakt_var_399; {
 String output = String("");
 (output += TRY((((*this).codegen_statement(var_decl)))));
 {
@@ -1061,15 +1117,15 @@ NonnullRefPtr<types::CheckedStatement> v = (_magic_value.value());
 }
 }
 
-__jakt_var_392 = output; goto __jakt_label_361;
+__jakt_var_399 = output; goto __jakt_label_367;
 
 }
-__jakt_label_361:; __jakt_var_392.release_value(); }));
+__jakt_label_367:; __jakt_var_399.release_value(); }));
 };/*case end*/
 case 3: {
 auto&& __jakt_match_value = __jakt_match_variant.template get<types::CheckedStatement::VarDecl>();types::VarId const& var_id = __jakt_match_value.var_id;
 NonnullRefPtr<types::CheckedExpression> const& init = __jakt_match_value.init;
-return JaktInternal::ExplicitValue(({ Optional<String> __jakt_var_393; {
+return JaktInternal::ExplicitValue(({ Optional<String> __jakt_var_400; {
 types::CheckedVariable const var = ((((*this).program))->get_variable(var_id));
 String output = String("");
 NonnullRefPtr<types::Type> const var_type = ((((*this).program))->get_type(((var).type_id)));
@@ -1082,14 +1138,14 @@ if (((!(((var).is_mutable))) && (!((((var_type)->index() == 27 /* Reference */) 
 (output += String(" = "));
 (output += TRY((((*this).codegen_expression(init)))));
 (output += String(";"));
-__jakt_var_393 = output; goto __jakt_label_362;
+__jakt_var_400 = output; goto __jakt_label_368;
 
 }
-__jakt_label_362:; __jakt_var_393.release_value(); }));
+__jakt_label_368:; __jakt_var_400.release_value(); }));
 };/*case end*/
 case 13: {
 auto&& __jakt_match_value = __jakt_match_variant.template get<types::CheckedStatement::InlineCpp>();JaktInternal::Array<String> const& lines = __jakt_match_value.lines;
-return JaktInternal::ExplicitValue(({ Optional<String> __jakt_var_394; {
+return JaktInternal::ExplicitValue(({ Optional<String> __jakt_var_401; {
 String output = String("");
 {
 JaktInternal::ArrayIterator<String> _magic = ((lines).iterator());
@@ -1109,16 +1165,16 @@ String escaped_line = line;
 }
 }
 
-__jakt_var_394 = output; goto __jakt_label_363;
+__jakt_var_401 = output; goto __jakt_label_369;
 
 }
-__jakt_label_363:; __jakt_var_394.release_value(); }));
+__jakt_label_369:; __jakt_var_401.release_value(); }));
 };/*case end*/
 case 4: {
 auto&& __jakt_match_value = __jakt_match_variant.template get<types::CheckedStatement::If>();NonnullRefPtr<types::CheckedExpression> const& condition = __jakt_match_value.condition;
 types::CheckedBlock const& then_block = __jakt_match_value.then_block;
 JaktInternal::Optional<NonnullRefPtr<types::CheckedStatement>> const& else_statement = __jakt_match_value.else_statement;
-return JaktInternal::ExplicitValue(({ Optional<String> __jakt_var_395; {
+return JaktInternal::ExplicitValue(({ Optional<String> __jakt_var_402; {
 String output = String("");
 if ((((((*this).debug_info)).statement_span_comments) && ((((statement)->span())).has_value()))){
 (output += TRY((String::formatted(String("\n#line {}\n"),TRY((((((*this).debug_info)).span_to_source_location((((statement)->span()).value())))))))));
@@ -1138,15 +1194,15 @@ return JaktInternal::ExplicitValue(String(""));
 }()))
 );
 (add_newline = false);
-__jakt_var_395 = output; goto __jakt_label_364;
+__jakt_var_402 = output; goto __jakt_label_370;
 
 }
-__jakt_label_364:; __jakt_var_395.release_value(); }));
+__jakt_label_370:; __jakt_var_402.release_value(); }));
 };/*case end*/
 case 12: {
 auto&& __jakt_match_value = __jakt_match_variant.template get<types::CheckedStatement::Yield>();NonnullRefPtr<types::CheckedExpression> const& expr = __jakt_match_value.expr;
 utility::Span const& span = __jakt_match_value.span;
-return JaktInternal::ExplicitValue(({ Optional<String> __jakt_var_396; {
+return JaktInternal::ExplicitValue(({ Optional<String> __jakt_var_403; {
 String output = String("");
 if ((((((*this).entered_yieldable_blocks)).size()) == static_cast<size_t>(0ULL))){
 utility::panic(String("Must be in a block to yield"));
@@ -1161,10 +1217,10 @@ String const end_label = ((var_name_end_label_).get<1>());
 (output += String("; goto "));
 (output += end_label);
 (output += String(";\n"));
-__jakt_var_396 = output; goto __jakt_label_365;
+__jakt_var_403 = output; goto __jakt_label_371;
 
 }
-__jakt_label_365:; __jakt_var_396.release_value(); }));
+__jakt_label_371:; __jakt_var_403.release_value(); }));
 };/*case end*/
 default: VERIFY_NOT_REACHED();}/*switch end*/
 }()
@@ -1200,12 +1256,12 @@ NonnullRefPtr<types::CheckedExpression> const& expr = __jakt_match_value.expr;
 return JaktInternal::ExplicitValue((((name + String(" = ")) + TRY((((*this).codegen_expression(expr))))) + String(",\n")));
 };/*case end*/
 default: {
-return JaktInternal::ExplicitValue(({ Optional<String> __jakt_var_397; {
+return JaktInternal::ExplicitValue(({ Optional<String> __jakt_var_404; {
 utility::todo(TRY((String::formatted(String("codegen_enum can't generate variant: {}"),variant))));
-__jakt_var_397 = String(""); goto __jakt_label_366;
+__jakt_var_404 = String(""); goto __jakt_label_372;
 
 }
-__jakt_label_366:; __jakt_var_397.release_value(); }));
+__jakt_label_372:; __jakt_var_404.release_value(); }));
 };/*case end*/
 }/*switch end*/
 }()
@@ -1275,20 +1331,20 @@ auto&& __jakt_match_variant = variant;
 switch(__jakt_match_variant.index()) {
 case 0: {
 auto&& __jakt_match_value = __jakt_match_variant.template get<types::CheckedEnumVariant::Untyped>();String const& name = __jakt_match_value.name;
-return JaktInternal::ExplicitValue(({ Optional<JaktInternal::Array<JaktInternal::Tuple<String,String>>> __jakt_var_398; {
+return JaktInternal::ExplicitValue(({ Optional<JaktInternal::Array<JaktInternal::Tuple<String,String>>> __jakt_var_405; {
 if (is_generic){
 (output += ((String("template<") + template_args) + String(">\n")));
 }
 (output += ((String("struct ") + name) + String(" {\n")));
-__jakt_var_398 = common_fields; goto __jakt_label_367;
+__jakt_var_405 = common_fields; goto __jakt_label_373;
 
 }
-__jakt_label_367:; __jakt_var_398.release_value(); }));
+__jakt_label_373:; __jakt_var_405.release_value(); }));
 };/*case end*/
 case 3: {
 auto&& __jakt_match_value = __jakt_match_variant.template get<types::CheckedEnumVariant::StructLike>();String const& name = __jakt_match_value.name;
 JaktInternal::Array<types::VarId> const& own_fields = __jakt_match_value.fields;
-return JaktInternal::ExplicitValue(({ Optional<JaktInternal::Array<JaktInternal::Tuple<String,String>>> __jakt_var_399; {
+return JaktInternal::ExplicitValue(({ Optional<JaktInternal::Array<JaktInternal::Tuple<String,String>>> __jakt_var_406; {
 JaktInternal::Array<JaktInternal::Tuple<String,String>> fields = (TRY((Array<JaktInternal::Tuple<String,String>>::create_with({}))));
 {
 JaktInternal::ArrayIterator<types::VarId> _magic = ((own_fields).iterator());
@@ -1310,15 +1366,15 @@ if (is_generic){
 (output += ((String("template<") + template_args) + String(">\n")));
 }
 (output += ((String("struct ") + name) + String(" {\n")));
-__jakt_var_399 = fields; goto __jakt_label_368;
+__jakt_var_406 = fields; goto __jakt_label_374;
 
 }
-__jakt_label_368:; __jakt_var_399.release_value(); }));
+__jakt_label_374:; __jakt_var_406.release_value(); }));
 };/*case end*/
 case 1: {
 auto&& __jakt_match_value = __jakt_match_variant.template get<types::CheckedEnumVariant::Typed>();String const& name = __jakt_match_value.name;
 types::TypeId const& type_id = __jakt_match_value.type_id;
-return JaktInternal::ExplicitValue(({ Optional<JaktInternal::Array<JaktInternal::Tuple<String,String>>> __jakt_var_400; {
+return JaktInternal::ExplicitValue(({ Optional<JaktInternal::Array<JaktInternal::Tuple<String,String>>> __jakt_var_407; {
 JaktInternal::Array<JaktInternal::Tuple<String,String>> fields = (TRY((Array<JaktInternal::Tuple<String,String>>::create_with({}))));
 {
 JaktInternal::ArrayIterator<JaktInternal::Tuple<String,String>> _magic = ((common_fields).iterator());
@@ -1340,18 +1396,18 @@ if (is_generic){
 (output += ((String("template<") + template_args) + String(">\n")));
 }
 (output += ((String("struct ") + name) + String("{\n")));
-__jakt_var_400 = fields; goto __jakt_label_369;
+__jakt_var_407 = fields; goto __jakt_label_375;
 
 }
-__jakt_label_369:; __jakt_var_400.release_value(); }));
+__jakt_label_375:; __jakt_var_407.release_value(); }));
 };/*case end*/
 default: {
-return JaktInternal::ExplicitValue(({ Optional<JaktInternal::Array<JaktInternal::Tuple<String,String>>> __jakt_var_401; {
+return JaktInternal::ExplicitValue(({ Optional<JaktInternal::Array<JaktInternal::Tuple<String,String>>> __jakt_var_408; {
 utility::todo(TRY((String::formatted(String("codegen enum variant: {}"),variant))));
-__jakt_var_401 = (TRY((Array<JaktInternal::Tuple<String,String>>::create_with({})))); goto __jakt_label_370;
+__jakt_var_408 = (TRY((Array<JaktInternal::Tuple<String,String>>::create_with({})))); goto __jakt_label_376;
 
 }
-__jakt_label_370:; __jakt_var_401.release_value(); }));
+__jakt_label_376:; __jakt_var_408.release_value(); }));
 };/*case end*/
 }/*switch end*/
 }()
@@ -1525,18 +1581,31 @@ String const name = ((variant).name());
 
 NonnullRefPtr<types::Scope> const enum_scope = TRY((((((*this).program))->get_scope(((enum_).scope_id)))));
 {
-JaktInternal::DictionaryIterator<String,types::FunctionId> _magic = ((((enum_scope)->functions)).iterator());
+JaktInternal::DictionaryIterator<String,JaktInternal::Array<types::FunctionId>> _magic = ((((enum_scope)->functions)).iterator());
 for (;;){
-JaktInternal::Optional<JaktInternal::Tuple<String,types::FunctionId>> _magic_value = ((_magic).next());
+JaktInternal::Optional<JaktInternal::Tuple<String,JaktInternal::Array<types::FunctionId>>> _magic_value = ((_magic).next());
 if ((!(((_magic_value).has_value())))){
 break;
 }
-JaktInternal::Tuple<String,types::FunctionId> function_item = (_magic_value.value());
+JaktInternal::Tuple<String,JaktInternal::Array<types::FunctionId>> ___overload_set__ = (_magic_value.value());
 {
-NonnullRefPtr<types::CheckedFunction> const function_ = ((((*this).program))->get_function(((function_item).get<1>())));
+JaktInternal::Tuple<String,JaktInternal::Array<types::FunctionId>> const jakt_____overload_set__ = ___overload_set__;
+String const _ = ((jakt_____overload_set__).get<0>());
+JaktInternal::Array<types::FunctionId> const overload_set = ((jakt_____overload_set__).get<1>());
+
+{
+JaktInternal::ArrayIterator<types::FunctionId> _magic = ((overload_set).iterator());
+for (;;){
+JaktInternal::Optional<types::FunctionId> _magic_value = ((_magic).next());
+if ((!(((_magic_value).has_value())))){
+break;
+}
+types::FunctionId function_id = (_magic_value.value());
+{
+NonnullRefPtr<types::CheckedFunction> const function_ = ((((*this).program))->get_function(function_id));
 JaktInternal::Optional<NonnullRefPtr<types::CheckedFunction>> const previous_function_id = ((*this).current_function);
 (((*this).current_function) = static_cast<JaktInternal::Optional<NonnullRefPtr<types::CheckedFunction>>>(function_));
-ScopeGuard __jakt_var_402([&] {
+ScopeGuard __jakt_var_409([&] {
 (((*this).current_function) = previous_function_id);
 });
 if ((!(((((function_)->type)).index() == 2 /* ImplicitEnumConstructor */)))){
@@ -1548,6 +1617,11 @@ else {
 }
 
 }
+}
+
+}
+}
+
 }
 
 }
@@ -2020,7 +2094,7 @@ case 8: {
 auto&& __jakt_match_value = __jakt_match_variant.template get<types::CheckedExpression::Range>();JaktInternal::Optional<NonnullRefPtr<types::CheckedExpression>> const& from = __jakt_match_value.from;
 JaktInternal::Optional<NonnullRefPtr<types::CheckedExpression>> const& to = __jakt_match_value.to;
 types::TypeId const& type_id = __jakt_match_value.type_id;
-return JaktInternal::ExplicitValue(({ Optional<String> __jakt_var_403; {
+return JaktInternal::ExplicitValue(({ Optional<String> __jakt_var_410; {
 String output = String("");
 NonnullRefPtr<types::Type> const type = ((((*this).program))->get_type(type_id));
 types::TypeId const index_type = JAKT_RESOLVE_EXPLICIT_VALUE_OR_CONTROL_FLOW_RETURN_ONLY(([&]() -> JaktInternal::ExplicitValueOrControlFlow<types::TypeId, ErrorOr<String>>{
@@ -2063,10 +2137,10 @@ else {
 }
 
 (output += String(")})"));
-__jakt_var_403 = output; goto __jakt_label_371;
+__jakt_var_410 = output; goto __jakt_label_377;
 
 }
-__jakt_label_371:; __jakt_var_403.release_value(); }));
+__jakt_label_377:; __jakt_var_410.release_value(); }));
 };/*case end*/
 case 23: {
 auto&& __jakt_match_value = __jakt_match_variant.template get<types::CheckedExpression::OptionalNone>();return JaktInternal::ExplicitValue(String("JaktInternal::OptionalNone()"));
@@ -2083,12 +2157,12 @@ return JaktInternal::ExplicitValue(((String("(") + TRY((((*this).codegen_express
 };/*case end*/
 case 2: {
 auto&& __jakt_match_value = __jakt_match_variant.template get<types::CheckedExpression::QuotedString>();String const& val = __jakt_match_value.val;
-return JaktInternal::ExplicitValue(({ Optional<String> __jakt_var_404; {
+return JaktInternal::ExplicitValue(({ Optional<String> __jakt_var_411; {
 String const escaped_value = TRY((((val).replace(String("\n"),String("\\n")))));
-__jakt_var_404 = ((String("String(\"") + escaped_value) + String("\")")); goto __jakt_label_372;
+__jakt_var_411 = ((String("String(\"") + escaped_value) + String("\")")); goto __jakt_label_378;
 
 }
-__jakt_label_372:; __jakt_var_404.release_value(); }));
+__jakt_label_378:; __jakt_var_411.release_value(); }));
 };/*case end*/
 case 3: {
 auto&& __jakt_match_value = __jakt_match_variant.template get<types::CheckedExpression::ByteConstant>();String const& val = __jakt_match_value.val;
@@ -2140,7 +2214,7 @@ case 15: {
 auto&& __jakt_match_value = __jakt_match_variant.template get<types::CheckedExpression::IndexedStruct>();NonnullRefPtr<types::CheckedExpression> const& expr = __jakt_match_value.expr;
 String const& index = __jakt_match_value.index;
 bool const& is_optional = __jakt_match_value.is_optional;
-return JaktInternal::ExplicitValue(({ Optional<String> __jakt_var_405; {
+return JaktInternal::ExplicitValue(({ Optional<String> __jakt_var_412; {
 String output = String("");
 String const object = TRY((((*this).codegen_expression(expr))));
 (output += String("(("));
@@ -2204,16 +2278,16 @@ else {
 }
 
 (output += String(")"));
-__jakt_var_405 = output; goto __jakt_label_373;
+__jakt_var_412 = output; goto __jakt_label_379;
 
 }
-__jakt_label_373:; __jakt_var_405.release_value(); }));
+__jakt_label_379:; __jakt_var_412.release_value(); }));
 };/*case end*/
 case 16: {
 auto&& __jakt_match_value = __jakt_match_variant.template get<types::CheckedExpression::IndexedCommonEnumMember>();NonnullRefPtr<types::CheckedExpression> const& expr = __jakt_match_value.expr;
 String const& index = __jakt_match_value.index;
 bool const& is_optional = __jakt_match_value.is_optional;
-return JaktInternal::ExplicitValue(({ Optional<String> __jakt_var_406; {
+return JaktInternal::ExplicitValue(({ Optional<String> __jakt_var_413; {
 String output = String("");
 String const object = TRY((((*this).codegen_expression(expr))));
 (output += String("(("));
@@ -2291,10 +2365,10 @@ else {
 }
 
 (output += String(")"));
-__jakt_var_406 = output; goto __jakt_label_374;
+__jakt_var_413 = output; goto __jakt_label_380;
 
 }
-__jakt_label_374:; __jakt_var_406.release_value(); }));
+__jakt_label_380:; __jakt_var_413.release_value(); }));
 };/*case end*/
 case 26: {
 auto&& __jakt_match_value = __jakt_match_variant.template get<types::CheckedExpression::Block>();types::CheckedBlock const& block = __jakt_match_value.block;
@@ -2327,7 +2401,7 @@ case 5: {
 auto&& __jakt_match_value = __jakt_match_variant.template get<types::CheckedExpression::UnaryOp>();NonnullRefPtr<types::CheckedExpression> const& expr = __jakt_match_value.expr;
 types::CheckedUnaryOperator const& op = __jakt_match_value.op;
 types::TypeId const& type_id = __jakt_match_value.type_id;
-return JaktInternal::ExplicitValue(({ Optional<String> __jakt_var_407; {
+return JaktInternal::ExplicitValue(({ Optional<String> __jakt_var_414; {
 String output = String("(");
 (output += JAKT_RESOLVE_EXPLICIT_VALUE_OR_CONTROL_FLOW_RETURN_ONLY(([&]() -> JaktInternal::ExplicitValueOrControlFlow<String, ErrorOr<String>>{
 auto&& __jakt_match_variant = op;
@@ -2375,19 +2449,19 @@ return JaktInternal::ExplicitValue(String("~"));
 case 12: {
 auto&& __jakt_match_value = __jakt_match_variant.template get<typename types::CheckedUnaryOperator::Is>();
 types::TypeId const& type_id = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(({ Optional<String> __jakt_var_408; {
+return JaktInternal::ExplicitValue(({ Optional<String> __jakt_var_415; {
 String const is_type = JAKT_RESOLVE_EXPLICIT_VALUE_OR_CONTROL_FLOW_RETURN_ONLY(([&]() -> JaktInternal::ExplicitValueOrControlFlow<String, ErrorOr<String>>{
 auto&& __jakt_match_variant = *((((*this).program))->get_type(type_id));
 switch(__jakt_match_variant.index()) {
 case 23: {
 auto&& __jakt_match_value = __jakt_match_variant.template get<typename types::Type::Struct>();
 types::StructId const& id = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(({ Optional<String> __jakt_var_409; {
+return JaktInternal::ExplicitValue(({ Optional<String> __jakt_var_416; {
 NonnullRefPtr<types::Module> const type_module = ((((*this).program))->get_module(((id).module)));
-__jakt_var_409 = ((((((*this).program))->get_struct(id))).name); goto __jakt_label_377;
+__jakt_var_416 = ((((((*this).program))->get_struct(id))).name); goto __jakt_label_383;
 
 }
-__jakt_label_377:; __jakt_var_409.release_value(); }));
+__jakt_label_383:; __jakt_var_416.release_value(); }));
 };/*case end*/
 default: {
 return JaktInternal::ExplicitValue(TRY((((*this).codegen_type(type_id)))));
@@ -2395,22 +2469,22 @@ return JaktInternal::ExplicitValue(TRY((((*this).codegen_type(type_id)))));
 }/*switch end*/
 }()
 ));
-__jakt_var_408 = ((String("is<") + is_type) + String(">(")); goto __jakt_label_376;
+__jakt_var_415 = ((String("is<") + is_type) + String(">(")); goto __jakt_label_382;
 
 }
-__jakt_label_376:; __jakt_var_408.release_value(); }));
+__jakt_label_382:; __jakt_var_415.release_value(); }));
 };/*case end*/
 case 11: {
 auto&& __jakt_match_value = __jakt_match_variant.template get<typename types::CheckedUnaryOperator::TypeCast>();
 types::CheckedTypeCast const& cast = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(({ Optional<String> __jakt_var_410; {
+return JaktInternal::ExplicitValue(({ Optional<String> __jakt_var_417; {
 types::TypeId final_type_id = ((cast).type_id());
 String const cast_type = JAKT_RESOLVE_EXPLICIT_VALUE_OR_CONTROL_FLOW_RETURN_ONLY(([&]() -> JaktInternal::ExplicitValueOrControlFlow<String, ErrorOr<String>>{
 auto&& __jakt_match_variant = cast;
 switch(__jakt_match_variant.index()) {
 case 0: {
 auto&& __jakt_match_value = __jakt_match_variant.template get<typename types::CheckedTypeCast::Fallible>();
-return JaktInternal::ExplicitValue(({ Optional<String> __jakt_var_411; {
+return JaktInternal::ExplicitValue(({ Optional<String> __jakt_var_418; {
 NonnullRefPtr<types::Type> const ty = ((((*this).program))->get_type(((cast).type_id())));
 types::TypeId const type_id = JAKT_RESOLVE_EXPLICIT_VALUE_OR_CONTROL_FLOW_RETURN_ONLY(([&]() -> JaktInternal::ExplicitValueOrControlFlow<types::TypeId, ErrorOr<String>>{
 auto&& __jakt_match_variant = *ty;
@@ -2432,30 +2506,30 @@ if (((((*this).program))->is_integer(type_id))){
 (final_type_id = type_id);
 (cast_type = String("fallible_integer_cast"));
 }
-__jakt_var_411 = cast_type; goto __jakt_label_379;
+__jakt_var_418 = cast_type; goto __jakt_label_385;
 
 }
-__jakt_label_379:; __jakt_var_411.release_value(); }));
+__jakt_label_385:; __jakt_var_418.release_value(); }));
 };/*case end*/
 case 1: {
 auto&& __jakt_match_value = __jakt_match_variant.template get<typename types::CheckedTypeCast::Infallible>();
-return JaktInternal::ExplicitValue(({ Optional<String> __jakt_var_412; {
+return JaktInternal::ExplicitValue(({ Optional<String> __jakt_var_419; {
 String cast_type = String("verify_cast");
 if (((((*this).program))->is_integer(type_id))){
 (cast_type = String("infallible_integer_cast"));
 }
-__jakt_var_412 = cast_type; goto __jakt_label_380;
+__jakt_var_419 = cast_type; goto __jakt_label_386;
 
 }
-__jakt_label_380:; __jakt_var_412.release_value(); }));
+__jakt_label_386:; __jakt_var_419.release_value(); }));
 };/*case end*/
 default: VERIFY_NOT_REACHED();}/*switch end*/
 }()
 ));
-__jakt_var_410 = (((cast_type + String("<")) + TRY((((*this).codegen_type(final_type_id))))) + String(">(")); goto __jakt_label_378;
+__jakt_var_417 = (((cast_type + String("<")) + TRY((((*this).codegen_type(final_type_id))))) + String(">(")); goto __jakt_label_384;
 
 }
-__jakt_label_378:; __jakt_var_410.release_value(); }));
+__jakt_label_384:; __jakt_var_417.release_value(); }));
 };/*case end*/
 default: {
 return JaktInternal::ExplicitValue(String(""));
@@ -2488,7 +2562,7 @@ return JaktInternal::ExplicitValue(String("))"));
 case 13: {
 auto&& __jakt_match_value = __jakt_match_variant.template get<types::CheckedUnaryOperator::IsEnumVariant>();types::CheckedEnumVariant const& enum_variant = __jakt_match_value.enum_variant;
 types::TypeId const& enum_type_id = __jakt_match_value.type_id;
-return JaktInternal::ExplicitValue(({ Optional<String> __jakt_var_413; {
+return JaktInternal::ExplicitValue(({ Optional<String> __jakt_var_420; {
 String const name = ((enum_variant).name());
 String suffix = String(")");
 types::CheckedEnum const enum_ = ((((*this).program))->get_enum(JAKT_RESOLVE_EXPLICIT_VALUE_OR_CONTROL_FLOW_RETURN_ONLY(([&]() -> JaktInternal::ExplicitValueOrControlFlow<types::EnumId, ErrorOr<String>>{
@@ -2539,10 +2613,10 @@ break;
 }
 
 (suffix += TRY((String::formatted(String("index() == {} /* {} */"),variant_index,name))));
-__jakt_var_413 = suffix; goto __jakt_label_381;
+__jakt_var_420 = suffix; goto __jakt_label_387;
 
 }
-__jakt_label_381:; __jakt_var_413.release_value(); }));
+__jakt_label_387:; __jakt_var_420.release_value(); }));
 };/*case end*/
 case 6: {
 auto&& __jakt_match_value = __jakt_match_variant.template get<typename types::CheckedUnaryOperator::RawAddress>();
@@ -2555,10 +2629,10 @@ return JaktInternal::ExplicitValue(String(")"));
 }()
 )));
 (output += String(")"));
-__jakt_var_407 = output; goto __jakt_label_375;
+__jakt_var_414 = output; goto __jakt_label_381;
 
 }
-__jakt_label_375:; __jakt_var_407.release_value(); }));
+__jakt_label_381:; __jakt_var_414.release_value(); }));
 };/*case end*/
 case 6: {
 auto&& __jakt_match_value = __jakt_match_variant.template get<types::CheckedExpression::BinaryOp>();NonnullRefPtr<types::CheckedExpression> const& lhs = __jakt_match_value.lhs;
@@ -2570,7 +2644,7 @@ return JaktInternal::ExplicitValue(TRY((((*this).codegen_binary_expression(expre
 case 1: {
 auto&& __jakt_match_value = __jakt_match_variant.template get<types::CheckedExpression::NumericConstant>();types::CheckedNumericConstant const& val = __jakt_match_value.val;
 types::TypeId const& type_id = __jakt_match_value.type_id;
-return JaktInternal::ExplicitValue(({ Optional<String> __jakt_var_414; {
+return JaktInternal::ExplicitValue(({ Optional<String> __jakt_var_421; {
 String const suffix = JAKT_RESOLVE_EXPLICIT_VALUE_OR_CONTROL_FLOW_RETURN_ONLY(([&]() -> JaktInternal::ExplicitValueOrControlFlow<String, ErrorOr<String>>{
 auto&& __jakt_match_variant = val;
 switch(__jakt_match_variant.index()) {
@@ -2605,7 +2679,7 @@ return JaktInternal::ExplicitValue(TRY((((*this).codegen_type(type_id)))));
 }/*switch end*/
 }()
 ));
-__jakt_var_414 = JAKT_RESOLVE_EXPLICIT_VALUE_OR_CONTROL_FLOW_RETURN_ONLY(([&]() -> JaktInternal::ExplicitValueOrControlFlow<String, ErrorOr<String>>{
+__jakt_var_421 = JAKT_RESOLVE_EXPLICIT_VALUE_OR_CONTROL_FLOW_RETURN_ONLY(([&]() -> JaktInternal::ExplicitValueOrControlFlow<String, ErrorOr<String>>{
 auto&& __jakt_match_variant = val;
 switch(__jakt_match_variant.index()) {
 case 9: {
@@ -2665,15 +2739,15 @@ return JaktInternal::ExplicitValue(TRY((String::formatted(String("static_cast<{}
 };/*case end*/
 default: VERIFY_NOT_REACHED();}/*switch end*/
 }()
-)); goto __jakt_label_382;
+)); goto __jakt_label_388;
 
 }
-__jakt_label_382:; __jakt_var_414.release_value(); }));
+__jakt_label_388:; __jakt_var_421.release_value(); }));
 };/*case end*/
 case 21: {
 auto&& __jakt_match_value = __jakt_match_variant.template get<types::CheckedExpression::NamespacedVar>();JaktInternal::Array<types::CheckedNamespace> const& namespaces = __jakt_match_value.namespaces;
 types::CheckedVariable const& var = __jakt_match_value.var;
-return JaktInternal::ExplicitValue(({ Optional<String> __jakt_var_415; {
+return JaktInternal::ExplicitValue(({ Optional<String> __jakt_var_422; {
 String output = String("");
 {
 JaktInternal::ArrayIterator<types::CheckedNamespace> _magic = ((namespaces).iterator());
@@ -2690,10 +2764,10 @@ types::CheckedNamespace ns = (_magic_value.value());
 }
 }
 
-__jakt_var_415 = (output + ((var).name)); goto __jakt_label_383;
+__jakt_var_422 = (output + ((var).name)); goto __jakt_label_389;
 
 }
-__jakt_label_383:; __jakt_var_415.release_value(); }));
+__jakt_label_389:; __jakt_var_422.release_value(); }));
 };/*case end*/
 case 17: {
 auto&& __jakt_match_value = __jakt_match_variant.template get<types::CheckedExpression::Match>();NonnullRefPtr<types::CheckedExpression> const& expr = __jakt_match_value.expr;
@@ -2706,7 +2780,7 @@ case 18: {
 auto&& __jakt_match_value = __jakt_match_variant.template get<types::CheckedExpression::EnumVariantArg>();NonnullRefPtr<types::CheckedExpression> const& expr = __jakt_match_value.expr;
 types::CheckedEnumVariantBinding const& arg = __jakt_match_value.arg;
 types::CheckedEnumVariant const& enum_variant = __jakt_match_value.enum_variant;
-return JaktInternal::ExplicitValue(({ Optional<String> __jakt_var_416; {
+return JaktInternal::ExplicitValue(({ Optional<String> __jakt_var_423; {
 String const var_name = TRY((((*this).codegen_expression(expr))));
 String const enum_type = TRY((((*this).codegen_type_possibly_as_namespace(((expr)->type()),true))));
 String const variant_name = ((enum_variant).name());
@@ -2724,10 +2798,10 @@ return JaktInternal::ExplicitValue(String("."));
 }
 }()))
 ;
-__jakt_var_416 = TRY((String::formatted(String("({}{}get<{}::{}>()).{}"),var_name,cpp_deref_operator,enum_type,variant_name,arg_name))); goto __jakt_label_384;
+__jakt_var_423 = TRY((String::formatted(String("({}{}get<{}::{}>()).{}"),var_name,cpp_deref_operator,enum_type,variant_name,arg_name))); goto __jakt_label_390;
 
 }
-__jakt_label_384:; __jakt_var_416.release_value(); }));
+__jakt_label_390:; __jakt_var_423.release_value(); }));
 };/*case end*/
 case 9: {
 auto&& __jakt_match_value = __jakt_match_variant.template get<types::CheckedExpression::JaktArray>();JaktInternal::Array<NonnullRefPtr<types::CheckedExpression>> const& vals = __jakt_match_value.vals;
@@ -2735,7 +2809,7 @@ JaktInternal::Optional<NonnullRefPtr<types::CheckedExpression>> const& repeat = 
 utility::Span const& span = __jakt_match_value.span;
 types::TypeId const& type_id = __jakt_match_value.type_id;
 types::TypeId const& inner_type_id = __jakt_match_value.inner_type_id;
-return JaktInternal::ExplicitValue(({ Optional<String> __jakt_var_417; {
+return JaktInternal::ExplicitValue(({ Optional<String> __jakt_var_424; {
 String output = String("");
 if (((repeat).has_value())){
 NonnullRefPtr<types::CheckedExpression> const repeat_val = ((repeat).value());
@@ -2781,10 +2855,10 @@ else {
 (output += String("}))))"));
 }
 
-__jakt_var_417 = output; goto __jakt_label_385;
+__jakt_var_424 = output; goto __jakt_label_391;
 
 }
-__jakt_label_385:; __jakt_var_417.release_value(); }));
+__jakt_label_391:; __jakt_var_424.release_value(); }));
 };/*case end*/
 case 11: {
 auto&& __jakt_match_value = __jakt_match_variant.template get<types::CheckedExpression::JaktDictionary>();JaktInternal::Array<JaktInternal::Tuple<NonnullRefPtr<types::CheckedExpression>,NonnullRefPtr<types::CheckedExpression>>> const& vals = __jakt_match_value.vals;
@@ -2792,7 +2866,7 @@ utility::Span const& span = __jakt_match_value.span;
 types::TypeId const& type_id = __jakt_match_value.type_id;
 types::TypeId const& key_type_id = __jakt_match_value.key_type_id;
 types::TypeId const& value_type_id = __jakt_match_value.value_type_id;
-return JaktInternal::ExplicitValue(({ Optional<String> __jakt_var_418; {
+return JaktInternal::ExplicitValue(({ Optional<String> __jakt_var_425; {
 String output = TRY((String::formatted(String("({}((Dictionary<{}, {}>::create_with_entries({{"),TRY((((*this).current_error_handler()))),TRY((((*this).codegen_type(key_type_id)))),TRY((((*this).codegen_type(value_type_id)))))));
 bool first = true;
 {
@@ -2826,17 +2900,17 @@ else {
 }
 
 (output += String("}))))"));
-__jakt_var_418 = output; goto __jakt_label_386;
+__jakt_var_425 = output; goto __jakt_label_392;
 
 }
-__jakt_label_386:; __jakt_var_418.release_value(); }));
+__jakt_label_392:; __jakt_var_425.release_value(); }));
 };/*case end*/
 case 10: {
 auto&& __jakt_match_value = __jakt_match_variant.template get<types::CheckedExpression::JaktSet>();JaktInternal::Array<NonnullRefPtr<types::CheckedExpression>> const& vals = __jakt_match_value.vals;
 utility::Span const& span = __jakt_match_value.span;
 types::TypeId const& type_id = __jakt_match_value.type_id;
 types::TypeId const& inner_type_id = __jakt_match_value.inner_type_id;
-return JaktInternal::ExplicitValue(({ Optional<String> __jakt_var_419; {
+return JaktInternal::ExplicitValue(({ Optional<String> __jakt_var_426; {
 String output = String("");
 (output += TRY((String::formatted(String("({}((Set<{}>::create_with_values({{"),TRY((((*this).current_error_handler()))),TRY((((*this).codegen_type(inner_type_id))))))));
 bool first = true;
@@ -2863,16 +2937,16 @@ else {
 }
 
 (output += String("}))))"));
-__jakt_var_419 = output; goto __jakt_label_387;
+__jakt_var_426 = output; goto __jakt_label_393;
 
 }
-__jakt_label_387:; __jakt_var_419.release_value(); }));
+__jakt_label_393:; __jakt_var_426.release_value(); }));
 };/*case end*/
 case 7: {
 auto&& __jakt_match_value = __jakt_match_variant.template get<types::CheckedExpression::JaktTuple>();JaktInternal::Array<NonnullRefPtr<types::CheckedExpression>> const& vals = __jakt_match_value.vals;
 utility::Span const& span = __jakt_match_value.span;
 types::TypeId const& type_id = __jakt_match_value.type_id;
-return JaktInternal::ExplicitValue(({ Optional<String> __jakt_var_420; {
+return JaktInternal::ExplicitValue(({ Optional<String> __jakt_var_427; {
 String output = String("");
 (output += String("(Tuple{"));
 bool first = true;
@@ -2899,10 +2973,10 @@ else {
 }
 
 (output += String("})"));
-__jakt_var_420 = output; goto __jakt_label_388;
+__jakt_var_427 = output; goto __jakt_label_394;
 
 }
-__jakt_label_388:; __jakt_var_420.release_value(); }));
+__jakt_label_394:; __jakt_var_427.release_value(); }));
 };/*case end*/
 case 27: {
 auto&& __jakt_match_value = __jakt_match_variant.template get<types::CheckedExpression::Function>();JaktInternal::Array<types::CheckedCapture> const& captures = __jakt_match_value.captures;
@@ -2911,7 +2985,7 @@ bool const& can_throw = __jakt_match_value.can_throw;
 types::CheckedBlock const& block = __jakt_match_value.block;
 types::TypeId const& return_type_id = __jakt_match_value.return_type_id;
 JaktInternal::Optional<types::FunctionId> const& pseudo_function_id = __jakt_match_value.pseudo_function_id;
-return JaktInternal::ExplicitValue(({ Optional<String> __jakt_var_421; {
+return JaktInternal::ExplicitValue(({ Optional<String> __jakt_var_428; {
 JaktInternal::Array<String> generated_captures = (TRY((Array<String>::create_with({}))));
 {
 JaktInternal::ArrayIterator<types::CheckedCapture> _magic = ((captures).iterator());
@@ -2973,7 +3047,7 @@ if (((pseudo_function_id).has_value())){
 NonnullRefPtr<types::CheckedFunction> const function_ = ((((*this).program))->get_function((pseudo_function_id.value())));
 JaktInternal::Optional<NonnullRefPtr<types::CheckedFunction>> const previous_function = ((*this).current_function);
 (((*this).current_function) = function_);
-ScopeGuard __jakt_var_422([&] {
+ScopeGuard __jakt_var_429([&] {
 (((*this).current_function) = previous_function);
 });
 (block_output = TRY((((*this).codegen_block(block)))));
@@ -2982,17 +3056,17 @@ else {
 (block_output = TRY((((*this).codegen_block(block)))));
 }
 
-__jakt_var_421 = TRY((String::formatted(String("[{}]({}) -> {} {}"),utility::join(generated_captures,String(", ")),utility::join(generated_params,String(", ")),return_type,block_output))); goto __jakt_label_389;
+__jakt_var_428 = TRY((String::formatted(String("[{}]({}) -> {} {}"),utility::join(generated_captures,String(", ")),utility::join(generated_params,String(", ")),return_type,block_output))); goto __jakt_label_395;
 
 }
-__jakt_label_389:; __jakt_var_421.release_value(); }));
+__jakt_label_395:; __jakt_var_428.release_value(); }));
 };/*case end*/
 case 29: {
 auto&& __jakt_match_value = __jakt_match_variant.template get<types::CheckedExpression::TryBlock>();NonnullRefPtr<types::CheckedStatement> const& stmt = __jakt_match_value.stmt;
 String const& error_name = __jakt_match_value.error_name;
 types::CheckedBlock const& catch_block = __jakt_match_value.catch_block;
 utility::Span const& span = __jakt_match_value.span;
-return JaktInternal::ExplicitValue(({ Optional<String> __jakt_var_423; {
+return JaktInternal::ExplicitValue(({ Optional<String> __jakt_var_430; {
 String output = String("");
 String const try_var = TRY((((*this).fresh_var())));
 (output += String("auto "));
@@ -3018,10 +3092,10 @@ if ((!(((error_name).is_empty())))){
 (output += TRY((((*this).codegen_block(catch_block)))));
 (((*this).control_flow_state) = last_control_flow);
 (output += String("}"));
-__jakt_var_423 = output; goto __jakt_label_390;
+__jakt_var_430 = output; goto __jakt_label_396;
 
 }
-__jakt_label_390:; __jakt_var_423.release_value(); }));
+__jakt_label_396:; __jakt_var_430.release_value(); }));
 };/*case end*/
 case 28: {
 auto&& __jakt_match_value = __jakt_match_variant.template get<types::CheckedExpression::Try>();NonnullRefPtr<types::CheckedExpression> const& expr = __jakt_match_value.expr;
@@ -3030,7 +3104,7 @@ JaktInternal::Optional<String> const& catch_name = __jakt_match_value.catch_name
 utility::Span const& span = __jakt_match_value.span;
 types::TypeId const& type_id = __jakt_match_value.type_id;
 types::TypeId const& inner_type_id = __jakt_match_value.inner_type_id;
-return JaktInternal::ExplicitValue(({ Optional<String> __jakt_var_424; {
+return JaktInternal::ExplicitValue(({ Optional<String> __jakt_var_431; {
 String output = String("");
 String const fresh_var = TRY((((*this).fresh_var())));
 bool const is_void = ((inner_type_id).equals(types::void_type_id()));
@@ -3038,7 +3112,7 @@ String const try_var = TRY((((*this).fresh_var())));
 codegen::ControlFlowState const last_control_flow = ((*this).control_flow_state);
 (((((*this).control_flow_state)).passes_through_match) = false);
 (((((*this).control_flow_state)).passes_through_try) = true);
-ScopeGuard __jakt_var_425([&] {
+ScopeGuard __jakt_var_432([&] {
 {
 (((*this).control_flow_state) = last_control_flow);
 }
@@ -3107,20 +3181,22 @@ if (((catch_block).has_value())){
 }
 (output += String("; })"));
 }
-__jakt_var_424 = output; goto __jakt_label_391;
+__jakt_var_431 = output; goto __jakt_label_397;
 
 }
-__jakt_label_391:; __jakt_var_424.release_value(); }));
+__jakt_label_397:; __jakt_var_431.release_value(); }));
 };/*case end*/
-default: {
-return JaktInternal::ExplicitValue(({ Optional<String> __jakt_var_426; {
-utility::todo(TRY((String::formatted(String("codegen_expression else: {}"),expression))));
-__jakt_var_426 = String(""); goto __jakt_label_392;
+case 30: {
+auto&& __jakt_match_value = __jakt_match_variant.template get<typename types::CheckedExpression::Garbage>();
+utility::Span const& span = __jakt_match_value.value;
+return JaktInternal::ExplicitValue(({ Optional<String> __jakt_var_433; {
+utility::todo(TRY((String::formatted(String("codegen_expression of bad AST node in {} at {}..{}"),TRY((((((*this).compiler))->get_file_path(((span).file_id))))),((span).start),((span).end)))));
+__jakt_var_433 = String(""); goto __jakt_label_398;
 
 }
-__jakt_label_392:; __jakt_var_426.release_value(); }));
+__jakt_label_398:; __jakt_var_433.release_value(); }));
 };/*case end*/
-}/*switch end*/
+default: VERIFY_NOT_REACHED();}/*switch end*/
 }()
 )));
 }
@@ -3608,18 +3684,31 @@ types::CheckedVariable const variable = ((((*this).program))->get_variable(((fie
 
 NonnullRefPtr<types::Scope> const scope = TRY((((((*this).program))->get_scope(((struct_).scope_id)))));
 {
-JaktInternal::DictionaryIterator<String,types::FunctionId> _magic = ((((scope)->functions)).iterator());
+JaktInternal::DictionaryIterator<String,JaktInternal::Array<types::FunctionId>> _magic = ((((scope)->functions)).iterator());
 for (;;){
-JaktInternal::Optional<JaktInternal::Tuple<String,types::FunctionId>> _magic_value = ((_magic).next());
+JaktInternal::Optional<JaktInternal::Tuple<String,JaktInternal::Array<types::FunctionId>>> _magic_value = ((_magic).next());
 if ((!(((_magic_value).has_value())))){
 break;
 }
-JaktInternal::Tuple<String,types::FunctionId> fn = (_magic_value.value());
+JaktInternal::Tuple<String,JaktInternal::Array<types::FunctionId>> ___overload_set__ = (_magic_value.value());
 {
-NonnullRefPtr<types::CheckedFunction> const function_ = ((((*this).program))->get_function(((fn).get<1>())));
+JaktInternal::Tuple<String,JaktInternal::Array<types::FunctionId>> const jakt_____overload_set__ = ___overload_set__;
+String const _ = ((jakt_____overload_set__).get<0>());
+JaktInternal::Array<types::FunctionId> const overload_set = ((jakt_____overload_set__).get<1>());
+
+{
+JaktInternal::ArrayIterator<types::FunctionId> _magic = ((overload_set).iterator());
+for (;;){
+JaktInternal::Optional<types::FunctionId> _magic_value = ((_magic).next());
+if ((!(((_magic_value).has_value())))){
+break;
+}
+types::FunctionId function_id = (_magic_value.value());
+{
 JaktInternal::Optional<NonnullRefPtr<types::CheckedFunction>> const previous_function_id = ((*this).current_function);
+NonnullRefPtr<types::CheckedFunction> const function_ = ((((*this).program))->get_function(function_id));
 (((*this).current_function) = static_cast<JaktInternal::Optional<NonnullRefPtr<types::CheckedFunction>>>(function_));
-ScopeGuard __jakt_var_427([&] {
+ScopeGuard __jakt_var_434([&] {
 (((*this).current_function) = previous_function_id);
 });
 if (((((function_)->type)).index() == 1 /* ImplicitConstructor */)){
@@ -3640,6 +3729,11 @@ else {
 (output += TRY((((*this).codegen_function(function_,true)))));
 }
 
+}
+
+}
+
+}
 }
 
 }
@@ -4107,12 +4201,12 @@ auto&& __jakt_match_value = __jakt_match_variant.template get<typename parser::B
 return JaktInternal::ExplicitValue(String(" >> "));
 };/*case end*/
 default: {
-return JaktInternal::ExplicitValue(({ Optional<String> __jakt_var_428; {
+return JaktInternal::ExplicitValue(({ Optional<String> __jakt_var_435; {
 utility::todo(TRY((String::formatted(String("codegen_binary_expression {}"),op))));
-__jakt_var_428 = String(""); goto __jakt_label_393;
+__jakt_var_435 = String(""); goto __jakt_label_399;
 
 }
-__jakt_label_393:; __jakt_var_428.release_value(); }));
+__jakt_label_399:; __jakt_var_435.release_value(); }));
 };/*case end*/
 }/*switch end*/
 }()
@@ -4198,18 +4292,27 @@ types::ScopeId child = (_magic_value.value());
 }
 
 {
-JaktInternal::DictionaryIterator<String,types::FunctionId> _magic = ((((scope)->functions)).iterator());
+JaktInternal::DictionaryIterator<String,JaktInternal::Array<types::FunctionId>> _magic = ((((scope)->functions)).iterator());
 for (;;){
-JaktInternal::Optional<JaktInternal::Tuple<String,types::FunctionId>> _magic_value = ((_magic).next());
+JaktInternal::Optional<JaktInternal::Tuple<String,JaktInternal::Array<types::FunctionId>>> _magic_value = ((_magic).next());
 if ((!(((_magic_value).has_value())))){
 break;
 }
-JaktInternal::Tuple<String,types::FunctionId> ___function_id__ = (_magic_value.value());
+JaktInternal::Tuple<String,JaktInternal::Array<types::FunctionId>> ___overload_set__ = (_magic_value.value());
 {
-JaktInternal::Tuple<String,types::FunctionId> const jakt_____function_id__ = ___function_id__;
-String const _ = ((jakt_____function_id__).get<0>());
-types::FunctionId const function_id = ((jakt_____function_id__).get<1>());
+JaktInternal::Tuple<String,JaktInternal::Array<types::FunctionId>> const jakt_____overload_set__ = ___overload_set__;
+String const _ = ((jakt_____overload_set__).get<0>());
+JaktInternal::Array<types::FunctionId> const overload_set = ((jakt_____overload_set__).get<1>());
 
+{
+JaktInternal::ArrayIterator<types::FunctionId> _magic = ((overload_set).iterator());
+for (;;){
+JaktInternal::Optional<types::FunctionId> _magic_value = ((_magic).next());
+if ((!(((_magic_value).has_value())))){
+break;
+}
+types::FunctionId function_id = (_magic_value.value());
+{
 if ((!(((((function_id).module)).equals(((current_module)->id)))))){
 continue;
 }
@@ -4219,13 +4322,18 @@ continue;
 }
 JaktInternal::Optional<NonnullRefPtr<types::CheckedFunction>> const previous_function_id = ((*this).current_function);
 (((*this).current_function) = static_cast<JaktInternal::Optional<NonnullRefPtr<types::CheckedFunction>>>(function_));
-ScopeGuard __jakt_var_429([&] {
+ScopeGuard __jakt_var_436([&] {
 (((*this).current_function) = previous_function_id);
 });
 if (((!(((((function_)->type)).index() == 1 /* ImplicitConstructor */))) && (((function_)->name) != String("main")))){
 (output += TRY((((*this).codegen_function_predecl(function_,false)))));
 (output += String("\n"));
 }
+}
+
+}
+}
+
 }
 
 }
@@ -4437,7 +4545,7 @@ case 29: {
 auto&& __jakt_match_value = __jakt_match_variant.template get<types::Type::Function>();JaktInternal::Array<types::TypeId> const& params = __jakt_match_value.params;
 bool const& can_throw = __jakt_match_value.can_throw;
 types::TypeId const& return_type_id = __jakt_match_value.return_type_id;
-return JaktInternal::ExplicitValue(({ Optional<String> __jakt_var_430; {
+return JaktInternal::ExplicitValue(({ Optional<String> __jakt_var_437; {
 String output = String("Function<");
 if (can_throw){
 (output += String("ErrorOr<"));
@@ -4471,10 +4579,10 @@ else {
 }
 
 (output += String(")>"));
-__jakt_var_430 = output; goto __jakt_label_394;
+__jakt_var_437 = output; goto __jakt_label_400;
 
 }
-__jakt_label_394:; __jakt_var_430.release_value(); }));
+__jakt_label_400:; __jakt_var_437.release_value(); }));
 };/*case end*/
 case 21: {
 auto&& __jakt_match_value = __jakt_match_variant.template get<types::Type::GenericTraitInstance>();{
@@ -4482,11 +4590,11 @@ utility::panic(String("Generic trait instance in codegen"));
 }
 };/*case end*/
 default: {
-return JaktInternal::ExplicitValue(({ Optional<String> __jakt_var_431; {
-__jakt_var_431 = String("auto"); goto __jakt_label_395;
+return JaktInternal::ExplicitValue(({ Optional<String> __jakt_var_438; {
+__jakt_var_438 = String("auto"); goto __jakt_label_401;
 
 }
-__jakt_label_395:; __jakt_var_431.release_value(); }));
+__jakt_label_401:; __jakt_var_438.release_value(); }));
 };/*case end*/
 }/*switch end*/
 }()

--- a/bootstrap/stage0/error.cpp
+++ b/bootstrap/stage0/error.cpp
@@ -72,13 +72,34 @@ size_t const width = ((TRY((String::formatted(String("{}"),largest_line_number))
 while ((line_index < ((line_spans).size()))){
 if (((((span).start) >= ((((line_spans)[line_index])).get<0>())) && (((span).start) <= ((((line_spans)[line_index])).get<1>())))){
 size_t const column_index = (JaktInternal::checked_sub<size_t>(((span).start),((((line_spans)[line_index])).get<0>())));
-warnln(String("----- \u001b[33m{}:{}:{}\u001b[0m"),file_name,(JaktInternal::checked_add<size_t>(line_index,static_cast<size_t>(1ULL))),(JaktInternal::checked_add<size_t>(column_index,static_cast<size_t>(1ULL))));
+{
+JaktInternal::Range<size_t> _magic = (JaktInternal::Range<size_t>{static_cast<size_t>(static_cast<size_t>(0ULL)),static_cast<size_t>((JaktInternal::checked_add<size_t>(width,static_cast<size_t>(2ULL))))});
+for (;;){
+JaktInternal::Optional<size_t> _magic_value = ((_magic).next());
+if ((!(((_magic_value).has_value())))){
+break;
+}
+size_t x = (_magic_value.value());
+{
+warn(String("─"));
+}
+
+}
+}
+
+warnln(String("┬─ \u001b[33m{}:{}:{}\u001b[0m"),file_name,(JaktInternal::checked_add<size_t>(line_index,static_cast<size_t>(1ULL))),(JaktInternal::checked_add<size_t>(column_index,static_cast<size_t>(1ULL))));
 if ((line_index > static_cast<size_t>(0ULL))){
 TRY((error::print_source_line(severity,file_contents,((line_spans)[(JaktInternal::checked_sub<size_t>(line_index,static_cast<size_t>(1ULL)))]),span,line_index,largest_line_number)));
 }
+while (((line_index < ((line_spans).size())) && (((span).end) > ((((line_spans)[line_index])).get<0>())))){
 TRY((error::print_source_line(severity,file_contents,((line_spans)[line_index]),span,(JaktInternal::checked_add<size_t>(line_index,static_cast<size_t>(1ULL))),largest_line_number)));
+if ((((span).end) <= ((((line_spans)[line_index])).get<1>()))){
+break;
+}
+(++(line_index));
+}
 {
-JaktInternal::Range<size_t> _magic = (JaktInternal::Range<size_t>{static_cast<size_t>(static_cast<size_t>(0ULL)),static_cast<size_t>((JaktInternal::checked_add<size_t>((JaktInternal::checked_add<size_t>((JaktInternal::checked_sub<size_t>(((span).start),((((line_spans)[line_index])).get<0>()))),width)),static_cast<size_t>(4ULL))))});
+JaktInternal::Range<size_t> _magic = (JaktInternal::Range<size_t>{static_cast<size_t>(static_cast<size_t>(0ULL)),static_cast<size_t>((JaktInternal::checked_add<size_t>(width,static_cast<size_t>(2ULL))))});
 for (;;){
 JaktInternal::Optional<size_t> _magic_value = ((_magic).next());
 if ((!(((_magic_value).has_value())))){
@@ -92,14 +113,26 @@ warn(String(" "));
 }
 }
 
-warnln(String("\u001b[{}m^- {}\u001b[0m"),TRY((((severity).ansi_color_code()))),message);
-while (((line_index < ((line_spans).size())) && (((span).end) > ((((line_spans)[line_index])).get<0>())))){
-(++(line_index));
-if ((line_index >= ((line_spans).size()))){
+warn(String("│"));
+{
+JaktInternal::Range<size_t> _magic = (JaktInternal::Range<size_t>{static_cast<size_t>(static_cast<size_t>(0ULL)),static_cast<size_t>((JaktInternal::checked_sub<size_t>(((span).end),((((line_spans)[line_index])).get<0>()))))});
+for (;;){
+JaktInternal::Optional<size_t> _magic_value = ((_magic).next());
+if ((!(((_magic_value).has_value())))){
 break;
 }
+size_t x = (_magic_value.value());
+{
+warn(String(" "));
+}
+
+}
+}
+
+warnln(String("\u001b[{}m╰─ {}\u001b[0m"),TRY((((severity).ansi_color_code()))),message);
+(++(line_index));
+if ((line_index < ((line_spans).size()))){
 TRY((error::print_source_line(severity,file_contents,((line_spans)[line_index]),span,(JaktInternal::checked_add<size_t>(line_index,static_cast<size_t>(1ULL))),largest_line_number)));
-break;
 }
 }
 else {
@@ -107,7 +140,23 @@ else {
 }
 
 }
-warnln(String("\u001b[0m-----"));
+warn(String("\u001b[0m"));
+{
+JaktInternal::Range<size_t> _magic = (JaktInternal::Range<size_t>{static_cast<size_t>(static_cast<size_t>(0ULL)),static_cast<size_t>((JaktInternal::checked_add<size_t>(width,static_cast<size_t>(2ULL))))});
+for (;;){
+JaktInternal::Optional<size_t> _magic_value = ((_magic).next());
+if ((!(((_magic_value).has_value())))){
+break;
+}
+size_t x = (_magic_value.value());
+{
+warn(String("─"));
+}
+
+}
+}
+
+warnln(String("┴─"));
 }
 return {};
 }
@@ -133,7 +182,7 @@ warn(String(" "));
 }
 }
 
-warn(String(" | "));
+warn(String(" │ "));
 while ((index <= ((file_span).get<1>()))){
 u8 c = ' ';
 if ((index < ((file_span).get<1>()))){

--- a/bootstrap/stage0/formatter.cpp
+++ b/bootstrap/stage0/formatter.cpp
@@ -1515,7 +1515,7 @@ ErrorOr<formatter::Stage0> formatter::Stage0::create(NonnullRefPtr<compiler::Com
 {
 JaktInternal::Array<u8> const old_file_contents = ((compiler)->current_file_contents);
 (((compiler)->current_file_contents) = source);
-ScopeGuard __jakt_var_432([&] {
+ScopeGuard __jakt_var_439([&] {
 {
 (((compiler)->current_file_contents) = old_file_contents);
 }
@@ -1561,7 +1561,7 @@ else if (((((((*this).dedents_to_skip)).last()).value()) > static_cast<size_t>(0
 }
 }
 }
-ScopeGuard __jakt_var_433([&] {
+ScopeGuard __jakt_var_440([&] {
 {
 if ((indent_change > static_cast<i64>(0LL))){
 ({auto& _jakt_ref = ((*this).indent);_jakt_ref = JaktInternal::checked_add<size_t>(_jakt_ref, (infallible_integer_cast<size_t>((indent_change))));});
@@ -1604,168 +1604,168 @@ auto&& __jakt_match_variant = token;
 switch(__jakt_match_variant.index()) {
 case 71: {
 auto&& __jakt_match_value = __jakt_match_variant.template get<typename lexer::Token::Enum>();
-return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_434; {
+return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_441; {
 TRY((((*this).push_state( formatter::State { typename formatter::State::EntityDeclaration(formatter::Entity::from_token(((token))),(!(((token).index() == 85 /* Namespace */))),false,static_cast<size_t>(0ULL)) } ))));
 JaktInternal::Array<u8> trailing_trivia = (TRY((Array<u8>::create_with({}))));
 if ((((token).index() == 85 /* Namespace */) || (!(((((*this).peek(static_cast<i64>(0LL)))).index() == 29 /* LessThan */))))){
 TRY((((trailing_trivia).push(' '))));
 }
-__jakt_var_434 = formatter::FormattedToken(token,((*this).indent),trailing_trivia,(TRY((Array<u8>::create_with({}))))); goto __jakt_label_396;
+__jakt_var_441 = formatter::FormattedToken(token,((*this).indent),trailing_trivia,(TRY((Array<u8>::create_with({}))))); goto __jakt_label_402;
 
 }
-__jakt_label_396:; __jakt_var_434.release_value(); }));
+__jakt_label_402:; __jakt_var_441.release_value(); }));
 };/*case end*/
 case 66: {
 auto&& __jakt_match_value = __jakt_match_variant.template get<typename lexer::Token::Class>();
-return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_435; {
+return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_442; {
 TRY((((*this).push_state( formatter::State { typename formatter::State::EntityDeclaration(formatter::Entity::from_token(((token))),(!(((token).index() == 85 /* Namespace */))),false,static_cast<size_t>(0ULL)) } ))));
 JaktInternal::Array<u8> trailing_trivia = (TRY((Array<u8>::create_with({}))));
 if ((((token).index() == 85 /* Namespace */) || (!(((((*this).peek(static_cast<i64>(0LL)))).index() == 29 /* LessThan */))))){
 TRY((((trailing_trivia).push(' '))));
 }
-__jakt_var_435 = formatter::FormattedToken(token,((*this).indent),trailing_trivia,(TRY((Array<u8>::create_with({}))))); goto __jakt_label_397;
+__jakt_var_442 = formatter::FormattedToken(token,((*this).indent),trailing_trivia,(TRY((Array<u8>::create_with({}))))); goto __jakt_label_403;
 
 }
-__jakt_label_397:; __jakt_var_435.release_value(); }));
+__jakt_label_403:; __jakt_var_442.release_value(); }));
 };/*case end*/
 case 94: {
 auto&& __jakt_match_value = __jakt_match_variant.template get<typename lexer::Token::Struct>();
-return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_436; {
+return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_443; {
 TRY((((*this).push_state( formatter::State { typename formatter::State::EntityDeclaration(formatter::Entity::from_token(((token))),(!(((token).index() == 85 /* Namespace */))),false,static_cast<size_t>(0ULL)) } ))));
 JaktInternal::Array<u8> trailing_trivia = (TRY((Array<u8>::create_with({}))));
 if ((((token).index() == 85 /* Namespace */) || (!(((((*this).peek(static_cast<i64>(0LL)))).index() == 29 /* LessThan */))))){
 TRY((((trailing_trivia).push(' '))));
 }
-__jakt_var_436 = formatter::FormattedToken(token,((*this).indent),trailing_trivia,(TRY((Array<u8>::create_with({}))))); goto __jakt_label_398;
+__jakt_var_443 = formatter::FormattedToken(token,((*this).indent),trailing_trivia,(TRY((Array<u8>::create_with({}))))); goto __jakt_label_404;
 
 }
-__jakt_label_398:; __jakt_var_436.release_value(); }));
+__jakt_label_404:; __jakt_var_443.release_value(); }));
 };/*case end*/
 case 75: {
 auto&& __jakt_match_value = __jakt_match_variant.template get<typename lexer::Token::Function>();
-return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_437; {
+return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_444; {
 TRY((((*this).push_state( formatter::State { typename formatter::State::EntityDeclaration(formatter::Entity::from_token(((token))),(!(((token).index() == 85 /* Namespace */))),false,static_cast<size_t>(0ULL)) } ))));
 JaktInternal::Array<u8> trailing_trivia = (TRY((Array<u8>::create_with({}))));
 if ((((token).index() == 85 /* Namespace */) || (!(((((*this).peek(static_cast<i64>(0LL)))).index() == 29 /* LessThan */))))){
 TRY((((trailing_trivia).push(' '))));
 }
-__jakt_var_437 = formatter::FormattedToken(token,((*this).indent),trailing_trivia,(TRY((Array<u8>::create_with({}))))); goto __jakt_label_399;
+__jakt_var_444 = formatter::FormattedToken(token,((*this).indent),trailing_trivia,(TRY((Array<u8>::create_with({}))))); goto __jakt_label_405;
 
 }
-__jakt_label_399:; __jakt_var_437.release_value(); }));
+__jakt_label_405:; __jakt_var_444.release_value(); }));
 };/*case end*/
 case 76: {
 auto&& __jakt_match_value = __jakt_match_variant.template get<typename lexer::Token::Comptime>();
-return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_438; {
+return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_445; {
 TRY((((*this).push_state( formatter::State { typename formatter::State::EntityDeclaration(formatter::Entity::from_token(((token))),(!(((token).index() == 85 /* Namespace */))),false,static_cast<size_t>(0ULL)) } ))));
 JaktInternal::Array<u8> trailing_trivia = (TRY((Array<u8>::create_with({}))));
 if ((((token).index() == 85 /* Namespace */) || (!(((((*this).peek(static_cast<i64>(0LL)))).index() == 29 /* LessThan */))))){
 TRY((((trailing_trivia).push(' '))));
 }
-__jakt_var_438 = formatter::FormattedToken(token,((*this).indent),trailing_trivia,(TRY((Array<u8>::create_with({}))))); goto __jakt_label_400;
+__jakt_var_445 = formatter::FormattedToken(token,((*this).indent),trailing_trivia,(TRY((Array<u8>::create_with({}))))); goto __jakt_label_406;
 
 }
-__jakt_label_400:; __jakt_var_438.release_value(); }));
+__jakt_label_406:; __jakt_var_445.release_value(); }));
 };/*case end*/
 case 85: {
 auto&& __jakt_match_value = __jakt_match_variant.template get<typename lexer::Token::Namespace>();
-return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_439; {
+return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_446; {
 TRY((((*this).push_state( formatter::State { typename formatter::State::EntityDeclaration(formatter::Entity::from_token(((token))),(!(((token).index() == 85 /* Namespace */))),false,static_cast<size_t>(0ULL)) } ))));
 JaktInternal::Array<u8> trailing_trivia = (TRY((Array<u8>::create_with({}))));
 if ((((token).index() == 85 /* Namespace */) || (!(((((*this).peek(static_cast<i64>(0LL)))).index() == 29 /* LessThan */))))){
 TRY((((trailing_trivia).push(' '))));
 }
-__jakt_var_439 = formatter::FormattedToken(token,((*this).indent),trailing_trivia,(TRY((Array<u8>::create_with({}))))); goto __jakt_label_401;
+__jakt_var_446 = formatter::FormattedToken(token,((*this).indent),trailing_trivia,(TRY((Array<u8>::create_with({}))))); goto __jakt_label_407;
 
 }
-__jakt_label_401:; __jakt_var_439.release_value(); }));
+__jakt_label_407:; __jakt_var_446.release_value(); }));
 };/*case end*/
 case 12: {
 auto&& __jakt_match_value = __jakt_match_variant.template get<typename lexer::Token::LSquare>();
-return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_440; {
+return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_447; {
 TRY((((*this).replace_state( formatter::State { typename formatter::State::Toplevel(open_parens,open_curlies,(JaktInternal::checked_add<size_t>(open_squares,static_cast<size_t>(1ULL)))) } ))));
-__jakt_var_440 = formatter::FormattedToken(token,((*this).indent),(TRY((Array<u8>::create_with({})))),(TRY((Array<u8>::create_with({}))))); goto __jakt_label_402;
+__jakt_var_447 = formatter::FormattedToken(token,((*this).indent),(TRY((Array<u8>::create_with({})))),(TRY((Array<u8>::create_with({}))))); goto __jakt_label_408;
 
 }
-__jakt_label_402:; __jakt_var_440.release_value(); }));
+__jakt_label_408:; __jakt_var_447.release_value(); }));
 };/*case end*/
 case 13: {
 auto&& __jakt_match_value = __jakt_match_variant.template get<typename lexer::Token::RSquare>();
-return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_441; {
+return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_448; {
 if ((open_squares == static_cast<size_t>(0ULL))){
 ((*this).pop_state());
 ((((*this).index)--));
 return (TRY((((*this).next_impl(true)))));
 }
 TRY((((*this).replace_state( formatter::State { typename formatter::State::Toplevel(open_parens,open_curlies,(JaktInternal::checked_sub<size_t>(open_squares,static_cast<size_t>(1ULL)))) } ))));
-__jakt_var_441 = formatter::FormattedToken(token,((*this).indent),(TRY((Array<u8>::create_with({})))),(TRY((Array<u8>::create_with({}))))); goto __jakt_label_403;
+__jakt_var_448 = formatter::FormattedToken(token,((*this).indent),(TRY((Array<u8>::create_with({})))),(TRY((Array<u8>::create_with({}))))); goto __jakt_label_409;
 
 }
-__jakt_label_403:; __jakt_var_441.release_value(); }));
+__jakt_label_409:; __jakt_var_448.release_value(); }));
 };/*case end*/
 case 8: {
 auto&& __jakt_match_value = __jakt_match_variant.template get<typename lexer::Token::LParen>();
-return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_442; {
+return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_449; {
 TRY((((*this).replace_state( formatter::State { typename formatter::State::Toplevel((JaktInternal::checked_add<size_t>(open_parens,static_cast<size_t>(1ULL))),open_curlies,open_squares) } ))));
-__jakt_var_442 = formatter::FormattedToken(token,((*this).indent),(TRY((Array<u8>::create_with({})))),(TRY((Array<u8>::create_with({}))))); goto __jakt_label_404;
+__jakt_var_449 = formatter::FormattedToken(token,((*this).indent),(TRY((Array<u8>::create_with({})))),(TRY((Array<u8>::create_with({}))))); goto __jakt_label_410;
 
 }
-__jakt_label_404:; __jakt_var_442.release_value(); }));
+__jakt_label_410:; __jakt_var_449.release_value(); }));
 };/*case end*/
 case 9: {
 auto&& __jakt_match_value = __jakt_match_variant.template get<typename lexer::Token::RParen>();
-return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_443; {
+return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_450; {
 if ((open_parens == static_cast<size_t>(0ULL))){
 ((*this).pop_state());
 ((((*this).index)--));
 return (TRY((((*this).next_impl(true)))));
 }
 TRY((((*this).replace_state( formatter::State { typename formatter::State::Toplevel((JaktInternal::checked_sub<size_t>(open_parens,static_cast<size_t>(1ULL))),open_curlies,open_squares) } ))));
-__jakt_var_443 = formatter::FormattedToken(token,((*this).indent),(TRY((Array<u8>::create_with({})))),(TRY((Array<u8>::create_with({}))))); goto __jakt_label_405;
+__jakt_var_450 = formatter::FormattedToken(token,((*this).indent),(TRY((Array<u8>::create_with({})))),(TRY((Array<u8>::create_with({}))))); goto __jakt_label_411;
 
 }
-__jakt_label_405:; __jakt_var_443.release_value(); }));
+__jakt_label_411:; __jakt_var_450.release_value(); }));
 };/*case end*/
 case 10: {
 auto&& __jakt_match_value = __jakt_match_variant.template get<typename lexer::Token::LCurly>();
-return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_444; {
+return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_451; {
 TRY((((*this).replace_state( formatter::State { typename formatter::State::Toplevel(open_parens,(JaktInternal::checked_add<size_t>(open_curlies,static_cast<size_t>(1ULL))),open_squares) } ))));
-__jakt_var_444 = formatter::FormattedToken(token,((*this).indent),(TRY((Array<u8>::create_with({})))),(TRY((Array<u8>::create_with({' '}))))); goto __jakt_label_406;
+__jakt_var_451 = formatter::FormattedToken(token,((*this).indent),(TRY((Array<u8>::create_with({})))),(TRY((Array<u8>::create_with({' '}))))); goto __jakt_label_412;
 
 }
-__jakt_label_406:; __jakt_var_444.release_value(); }));
+__jakt_label_412:; __jakt_var_451.release_value(); }));
 };/*case end*/
 case 11: {
 auto&& __jakt_match_value = __jakt_match_variant.template get<typename lexer::Token::RCurly>();
-return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_445; {
+return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_452; {
 if ((open_curlies == static_cast<size_t>(0ULL))){
 ((*this).pop_state());
 ({auto& _jakt_ref = ((*this).index);_jakt_ref = JaktInternal::checked_sub<size_t>(_jakt_ref, static_cast<size_t>(1ULL));});
 return (TRY((((*this).next_impl(true)))));
 }
 TRY((((*this).replace_state( formatter::State { typename formatter::State::Toplevel(open_parens,(JaktInternal::checked_sub<size_t>(open_curlies,static_cast<size_t>(1ULL))),open_squares) } ))));
-__jakt_var_445 = formatter::FormattedToken(token,((*this).indent),(TRY((Array<u8>::create_with({})))),(TRY((Array<u8>::create_with({}))))); goto __jakt_label_407;
+__jakt_var_452 = formatter::FormattedToken(token,((*this).indent),(TRY((Array<u8>::create_with({})))),(TRY((Array<u8>::create_with({}))))); goto __jakt_label_413;
 
 }
-__jakt_label_407:; __jakt_var_445.release_value(); }));
+__jakt_label_413:; __jakt_var_452.release_value(); }));
 };/*case end*/
 case 6: {
 auto&& __jakt_match_value = __jakt_match_variant.template get<typename lexer::Token::Colon>();
-return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_446; {
+return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_453; {
 TRY((((*this).push_state( formatter::State { typename formatter::State::TypeContext(static_cast<size_t>(0ULL),static_cast<size_t>(0ULL),static_cast<size_t>(0ULL),static_cast<size_t>(0ULL),true) } ))));
-__jakt_var_446 = formatter::FormattedToken(token,((*this).indent),(TRY((Array<u8>::create_with({' '})))),(TRY((Array<u8>::create_with({}))))); goto __jakt_label_408;
+__jakt_var_453 = formatter::FormattedToken(token,((*this).indent),(TRY((Array<u8>::create_with({' '})))),(TRY((Array<u8>::create_with({}))))); goto __jakt_label_414;
 
 }
-__jakt_label_408:; __jakt_var_446.release_value(); }));
+__jakt_label_414:; __jakt_var_453.release_value(); }));
 };/*case end*/
 case 78: {
 auto&& __jakt_match_value = __jakt_match_variant.template get<typename lexer::Token::Import>();
-return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_447; {
+return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_454; {
 TRY((((*this).push_state( formatter::State { typename formatter::State::Import(((((*this).peek(static_cast<i64>(0LL)))).index() == 72 /* Extern */)) } ))));
-__jakt_var_447 = formatter::FormattedToken(token,((*this).indent),(TRY((Array<u8>::create_with({' '})))),(TRY((Array<u8>::create_with({}))))); goto __jakt_label_409;
+__jakt_var_454 = formatter::FormattedToken(token,((*this).indent),(TRY((Array<u8>::create_with({' '})))),(TRY((Array<u8>::create_with({}))))); goto __jakt_label_415;
 
 }
-__jakt_label_409:; __jakt_var_447.release_value(); }));
+__jakt_label_415:; __jakt_var_454.release_value(); }));
 };/*case end*/
 case 90: {
 auto&& __jakt_match_value = __jakt_match_variant.template get<typename lexer::Token::Public>();
@@ -1793,12 +1793,12 @@ return JaktInternal::ExplicitValue(formatter::FormattedToken(token,((*this).inde
 };/*case end*/
 case 93: {
 auto&& __jakt_match_value = __jakt_match_variant.template get<typename lexer::Token::Restricted>();
-return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_448; {
+return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_455; {
 TRY((((*this).push_state( formatter::State { typename formatter::State::RestrictionList() } ))));
-__jakt_var_448 = formatter::FormattedToken(token,((*this).indent),(TRY((Array<u8>::create_with({})))),(TRY((Array<u8>::create_with({}))))); goto __jakt_label_410;
+__jakt_var_455 = formatter::FormattedToken(token,((*this).indent),(TRY((Array<u8>::create_with({})))),(TRY((Array<u8>::create_with({}))))); goto __jakt_label_416;
 
 }
-__jakt_label_410:; __jakt_var_448.release_value(); }));
+__jakt_label_416:; __jakt_var_455.release_value(); }));
 };/*case end*/
 case 53: {
 auto&& __jakt_match_value = __jakt_match_variant.template get<typename lexer::Token::Comma>();
@@ -1825,18 +1825,18 @@ auto&& __jakt_match_value = __jakt_match_variant.template get<typename lexer::To
 return JaktInternal::ExplicitValue(formatter::FormattedToken(token,((*this).indent),(TRY((Array<u8>::create_with({' '})))),(TRY((Array<u8>::create_with({}))))));
 };/*case end*/
 case 4: {
-auto&& __jakt_match_value = __jakt_match_variant.template get<lexer::Token::Identifier>();return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_449; {
+auto&& __jakt_match_value = __jakt_match_variant.template get<lexer::Token::Identifier>();return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_456; {
 if (((!(is_extern)) && ((!(((((*this).peek(static_cast<i64>(0LL)))).index() == 10 /* LCurly */))) && (!(((((*this).peek(static_cast<i64>(0LL)))).index() == 62 /* As */)))))){
 ((*this).pop_state());
 }
-__jakt_var_449 = formatter::FormattedToken(token,((*this).indent),(TRY((Array<u8>::create_with({' '})))),(TRY((Array<u8>::create_with({}))))); goto __jakt_label_411;
+__jakt_var_456 = formatter::FormattedToken(token,((*this).indent),(TRY((Array<u8>::create_with({' '})))),(TRY((Array<u8>::create_with({}))))); goto __jakt_label_417;
 
 }
-__jakt_label_411:; __jakt_var_449.release_value(); }));
+__jakt_label_417:; __jakt_var_456.release_value(); }));
 };/*case end*/
 case 10: {
 auto&& __jakt_match_value = __jakt_match_variant.template get<typename lexer::Token::LCurly>();
-return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_450; {
+return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_457; {
 if (is_extern){
 TRY((((*this).push_state( formatter::State { typename formatter::State::Toplevel(static_cast<size_t>(0ULL),static_cast<size_t>(0ULL),static_cast<size_t>(0ULL)) } ))));
 }
@@ -1844,24 +1844,24 @@ else {
 TRY((((*this).push_state( formatter::State { typename formatter::State::ImportList(true) } ))));
 }
 
-__jakt_var_450 = formatter::FormattedToken(token,((*this).indent),(TRY((Array<u8>::create_with({})))),(TRY((Array<u8>::create_with({}))))); goto __jakt_label_412;
+__jakt_var_457 = formatter::FormattedToken(token,((*this).indent),(TRY((Array<u8>::create_with({})))),(TRY((Array<u8>::create_with({}))))); goto __jakt_label_418;
 
 }
-__jakt_label_412:; __jakt_var_450.release_value(); }));
+__jakt_label_418:; __jakt_var_457.release_value(); }));
 };/*case end*/
 case 11: {
 auto&& __jakt_match_value = __jakt_match_variant.template get<typename lexer::Token::RCurly>();
-return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_451; {
+return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_458; {
 ((*this).pop_state());
-__jakt_var_451 = formatter::FormattedToken(token,((*this).indent),(TRY((Array<u8>::create_with({})))),(TRY((Array<u8>::create_with({}))))); goto __jakt_label_413;
+__jakt_var_458 = formatter::FormattedToken(token,((*this).indent),(TRY((Array<u8>::create_with({})))),(TRY((Array<u8>::create_with({}))))); goto __jakt_label_419;
 
 }
-__jakt_label_413:; __jakt_var_451.release_value(); }));
+__jakt_label_419:; __jakt_var_458.release_value(); }));
 };/*case end*/
 case 53: {
 auto&& __jakt_match_value = __jakt_match_variant.template get<typename lexer::Token::Comma>();
-return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_452; {
-__jakt_var_452 = formatter::FormattedToken(token,((*this).indent),JAKT_RESOLVE_EXPLICIT_VALUE_OR_CONTROL_FLOW_RETURN_ONLY(([&]() -> JaktInternal::ExplicitValueOrControlFlow<JaktInternal::Array<u8>, ErrorOr<JaktInternal::Optional<formatter::FormattedToken>>>{
+return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_459; {
+__jakt_var_459 = formatter::FormattedToken(token,((*this).indent),JAKT_RESOLVE_EXPLICIT_VALUE_OR_CONTROL_FLOW_RETURN_ONLY(([&]() -> JaktInternal::ExplicitValueOrControlFlow<JaktInternal::Array<u8>, ErrorOr<JaktInternal::Optional<formatter::FormattedToken>>>{
 auto&& __jakt_match_variant = ((*this).peek(static_cast<i64>(0LL)));
 switch(__jakt_match_variant.index()) {
 case 56: {
@@ -1872,10 +1872,10 @@ return JaktInternal::ExplicitValue((TRY((Array<u8>::create_with({' '})))));
 };/*case end*/
 }/*switch end*/
 }()
-)),(TRY((Array<u8>::create_with({}))))); goto __jakt_label_414;
+)),(TRY((Array<u8>::create_with({}))))); goto __jakt_label_420;
 
 }
-__jakt_label_414:; __jakt_var_452.release_value(); }));
+__jakt_label_420:; __jakt_var_459.release_value(); }));
 };/*case end*/
 default: {
 return JaktInternal::ExplicitValue(formatter::FormattedToken(token,((*this).indent),(TRY((Array<u8>::create_with({' '})))),(TRY((Array<u8>::create_with({}))))));
@@ -1899,12 +1899,12 @@ return (TRY((((*this).next_impl(true)))));
 };/*case end*/
 case 53: {
 auto&& __jakt_match_value = __jakt_match_variant.template get<typename lexer::Token::Comma>();
-return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_453; {
+return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_460; {
 TRY((((*this).replace_state( formatter::State { typename formatter::State::ImportList(true) } ))));
-__jakt_var_453 = formatter::FormattedToken(token,((*this).indent),(TRY((Array<u8>::create_with({' '})))),(TRY((Array<u8>::create_with({}))))); goto __jakt_label_415;
+__jakt_var_460 = formatter::FormattedToken(token,((*this).indent),(TRY((Array<u8>::create_with({' '})))),(TRY((Array<u8>::create_with({}))))); goto __jakt_label_421;
 
 }
-__jakt_label_415:; __jakt_var_453.release_value(); }));
+__jakt_label_421:; __jakt_var_460.release_value(); }));
 };/*case end*/
 case 56: {
 auto&& __jakt_match_value = __jakt_match_variant.template get<lexer::Token::Eol>();{
@@ -1912,7 +1912,7 @@ return (TRY((((*this).next()))));
 }
 };/*case end*/
 default: {
-return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_454; {
+return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_461; {
 JaktInternal::Array<String> collection = (TRY((Array<String>::create_with({}))));
 String output = String("");
 utility::Span const span = ((token).span());
@@ -1997,10 +1997,10 @@ else {
 
 ((*this).pop_state());
 ((((*this).index)--));
-__jakt_var_454 = formatter::FormattedToken( lexer::Token { typename lexer::Token::Identifier(output,span) } ,((*this).indent),(TRY((Array<u8>::create_with({})))),(TRY((Array<u8>::create_with({}))))); goto __jakt_label_416;
+__jakt_var_461 = formatter::FormattedToken( lexer::Token { typename lexer::Token::Identifier(output,span) } ,((*this).indent),(TRY((Array<u8>::create_with({})))),(TRY((Array<u8>::create_with({}))))); goto __jakt_label_422;
 
 }
-__jakt_label_416:; __jakt_var_454.release_value(); }));
+__jakt_label_422:; __jakt_var_461.release_value(); }));
 };/*case end*/
 }/*switch end*/
 }()
@@ -2016,18 +2016,18 @@ auto&& __jakt_match_variant = token;
 switch(__jakt_match_variant.index()) {
 case 29: {
 auto&& __jakt_match_value = __jakt_match_variant.template get<typename lexer::Token::LessThan>();
-return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_455; {
+return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_462; {
 if (accept_generics){
 TRY((((*this).replace_state( formatter::State { typename formatter::State::EntityDeclaration(entity,accept_generics,true,(JaktInternal::checked_add<size_t>(generic_nesting,static_cast<size_t>(1ULL)))) } ))));
 }
-__jakt_var_455 = formatter::FormattedToken(token,((*this).indent),(TRY((Array<u8>::create_with({})))),(TRY((Array<u8>::create_with({}))))); goto __jakt_label_417;
+__jakt_var_462 = formatter::FormattedToken(token,((*this).indent),(TRY((Array<u8>::create_with({})))),(TRY((Array<u8>::create_with({}))))); goto __jakt_label_423;
 
 }
-__jakt_label_417:; __jakt_var_455.release_value(); }));
+__jakt_label_423:; __jakt_var_462.release_value(); }));
 };/*case end*/
 case 27: {
 auto&& __jakt_match_value = __jakt_match_variant.template get<typename lexer::Token::GreaterThan>();
-return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_456; {
+return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_463; {
 if (accept_generics){
 if ((generic_nesting > static_cast<size_t>(1ULL))){
 TRY((((*this).replace_state( formatter::State { typename formatter::State::EntityDeclaration(entity,accept_generics,has_generics,(JaktInternal::checked_sub<size_t>(generic_nesting,static_cast<size_t>(1ULL)))) } ))));
@@ -2037,20 +2037,20 @@ TRY((((*this).replace_state( formatter::State { typename formatter::State::Entit
 }
 
 }
-__jakt_var_456 = formatter::FormattedToken(token,((*this).indent),(TRY((Array<u8>::create_with({})))),(TRY((Array<u8>::create_with({}))))); goto __jakt_label_418;
+__jakt_var_463 = formatter::FormattedToken(token,((*this).indent),(TRY((Array<u8>::create_with({})))),(TRY((Array<u8>::create_with({}))))); goto __jakt_label_424;
 
 }
-__jakt_label_418:; __jakt_var_456.release_value(); }));
+__jakt_label_424:; __jakt_var_463.release_value(); }));
 };/*case end*/
 case 4: {
-auto&& __jakt_match_value = __jakt_match_variant.template get<lexer::Token::Identifier>();return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_457; {
+auto&& __jakt_match_value = __jakt_match_variant.template get<lexer::Token::Identifier>();return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_464; {
 if (((generic_nesting == static_cast<size_t>(0ULL)) && ((!(((((*this).peek(static_cast<i64>(0LL)))).index() == 29 /* LessThan */))) && (!(has_generics))))){
 TRY((((*this).replace_state( formatter::State { typename formatter::State::EntityDefinition(entity) } ))));
 }
-__jakt_var_457 = formatter::FormattedToken(token,((*this).indent),(TRY((Array<u8>::create_with({})))),(TRY((Array<u8>::create_with({}))))); goto __jakt_label_419;
+__jakt_var_464 = formatter::FormattedToken(token,((*this).indent),(TRY((Array<u8>::create_with({})))),(TRY((Array<u8>::create_with({}))))); goto __jakt_label_425;
 
 }
-__jakt_label_419:; __jakt_var_457.release_value(); }));
+__jakt_label_425:; __jakt_var_464.release_value(); }));
 };/*case end*/
 case 53: {
 auto&& __jakt_match_value = __jakt_match_variant.template get<typename lexer::Token::Comma>();
@@ -2058,20 +2058,20 @@ return JaktInternal::ExplicitValue(formatter::FormattedToken(token,((*this).inde
 };/*case end*/
 case 11: {
 auto&& __jakt_match_value = __jakt_match_variant.template get<typename lexer::Token::RCurly>();
-return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_458; {
+return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_465; {
 ((*this).pop_state());
-__jakt_var_458 = formatter::FormattedToken(token,((*this).indent),(TRY((Array<u8>::create_with({})))),(TRY((Array<u8>::create_with({}))))); goto __jakt_label_420;
+__jakt_var_465 = formatter::FormattedToken(token,((*this).indent),(TRY((Array<u8>::create_with({})))),(TRY((Array<u8>::create_with({}))))); goto __jakt_label_426;
 
 }
-__jakt_label_420:; __jakt_var_458.release_value(); }));
+__jakt_label_426:; __jakt_var_465.release_value(); }));
 };/*case end*/
 case 56: {
-auto&& __jakt_match_value = __jakt_match_variant.template get<lexer::Token::Eol>();return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_459; {
+auto&& __jakt_match_value = __jakt_match_variant.template get<lexer::Token::Eol>();return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_466; {
 ((*this).pop_state());
-__jakt_var_459 = formatter::FormattedToken(token,((*this).indent),(TRY((Array<u8>::create_with({})))),(TRY((Array<u8>::create_with({}))))); goto __jakt_label_421;
+__jakt_var_466 = formatter::FormattedToken(token,((*this).indent),(TRY((Array<u8>::create_with({})))),(TRY((Array<u8>::create_with({}))))); goto __jakt_label_427;
 
 }
-__jakt_label_421:; __jakt_var_459.release_value(); }));
+__jakt_label_427:; __jakt_var_466.release_value(); }));
 };/*case end*/
 case 90: {
 auto&& __jakt_match_value = __jakt_match_variant.template get<typename lexer::Token::Public>();
@@ -2091,12 +2091,12 @@ return JaktInternal::ExplicitValue(formatter::FormattedToken(token,((*this).inde
 };/*case end*/
 case 93: {
 auto&& __jakt_match_value = __jakt_match_variant.template get<typename lexer::Token::Restricted>();
-return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_460; {
+return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_467; {
 TRY((((*this).push_state( formatter::State { typename formatter::State::RestrictionList() } ))));
-__jakt_var_460 = formatter::FormattedToken(token,((*this).indent),(TRY((Array<u8>::create_with({})))),(TRY((Array<u8>::create_with({}))))); goto __jakt_label_422;
+__jakt_var_467 = formatter::FormattedToken(token,((*this).indent),(TRY((Array<u8>::create_with({})))),(TRY((Array<u8>::create_with({}))))); goto __jakt_label_428;
 
 }
-__jakt_label_422:; __jakt_var_460.release_value(); }));
+__jakt_label_428:; __jakt_var_467.release_value(); }));
 };/*case end*/
 default: {
 return JaktInternal::ExplicitValue(formatter::FormattedToken(token,((*this).indent),(TRY((Array<u8>::create_with({})))),(TRY((Array<u8>::create_with({}))))));
@@ -2117,9 +2117,9 @@ auto&& __jakt_match_variant = token;
 switch(__jakt_match_variant.index()) {
 case 11: {
 auto&& __jakt_match_value = __jakt_match_variant.template get<typename lexer::Token::RCurly>();
-return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_461; {
+return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_468; {
 ((*this).pop_state());
-__jakt_var_461 = formatter::FormattedToken(token,((*this).indent),(TRY((Array<u8>::create_with({})))),JAKT_RESOLVE_EXPLICIT_VALUE_OR_CONTROL_FLOW_RETURN_ONLY(([&]() -> JaktInternal::ExplicitValueOrControlFlow<JaktInternal::Array<u8>, ErrorOr<JaktInternal::Optional<formatter::FormattedToken>>>{
+__jakt_var_468 = formatter::FormattedToken(token,((*this).indent),(TRY((Array<u8>::create_with({})))),JAKT_RESOLVE_EXPLICIT_VALUE_OR_CONTROL_FLOW_RETURN_ONLY(([&]() -> JaktInternal::ExplicitValueOrControlFlow<JaktInternal::Array<u8>, ErrorOr<JaktInternal::Optional<formatter::FormattedToken>>>{
 auto&& __jakt_match_variant = ((*this).peek((-(static_cast<i64>(1LL)))));
 switch(__jakt_match_variant.index()) {
 case 56: {
@@ -2134,16 +2134,16 @@ return JaktInternal::ExplicitValue((TRY((Array<u8>::create_with({' '})))));
 };/*case end*/
 }/*switch end*/
 }()
-))); goto __jakt_label_423;
+))); goto __jakt_label_429;
 
 }
-__jakt_label_423:; __jakt_var_461.release_value(); }));
+__jakt_label_429:; __jakt_var_468.release_value(); }));
 };/*case end*/
 case 10: {
 auto&& __jakt_match_value = __jakt_match_variant.template get<typename lexer::Token::LCurly>();
-return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_462; {
+return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_469; {
 TRY((((*this).push_state( formatter::State { typename formatter::State::Toplevel(static_cast<size_t>(0ULL),static_cast<size_t>(0ULL),static_cast<size_t>(0ULL)) } ))));
-__jakt_var_462 = formatter::FormattedToken(token,((*this).indent),JAKT_RESOLVE_EXPLICIT_VALUE_OR_CONTROL_FLOW_RETURN_ONLY(([&]() -> JaktInternal::ExplicitValueOrControlFlow<JaktInternal::Array<u8>, ErrorOr<JaktInternal::Optional<formatter::FormattedToken>>>{
+__jakt_var_469 = formatter::FormattedToken(token,((*this).indent),JAKT_RESOLVE_EXPLICIT_VALUE_OR_CONTROL_FLOW_RETURN_ONLY(([&]() -> JaktInternal::ExplicitValueOrControlFlow<JaktInternal::Array<u8>, ErrorOr<JaktInternal::Optional<formatter::FormattedToken>>>{
 auto&& __jakt_match_variant = ((*this).peek(static_cast<i64>(0LL)));
 switch(__jakt_match_variant.index()) {
 case 56: {
@@ -2158,10 +2158,10 @@ return JaktInternal::ExplicitValue((TRY((Array<u8>::create_with({' '})))));
 };/*case end*/
 }/*switch end*/
 }()
-)),(TRY((Array<u8>::create_with({' '}))))); goto __jakt_label_424;
+)),(TRY((Array<u8>::create_with({' '}))))); goto __jakt_label_430;
 
 }
-__jakt_label_424:; __jakt_var_462.release_value(); }));
+__jakt_label_430:; __jakt_var_469.release_value(); }));
 };/*case end*/
 case 6: {
 auto&& __jakt_match_value = __jakt_match_variant.template get<typename lexer::Token::Colon>();
@@ -2188,9 +2188,9 @@ auto&& __jakt_match_variant = token;
 switch(__jakt_match_variant.index()) {
 case 11: {
 auto&& __jakt_match_value = __jakt_match_variant.template get<typename lexer::Token::RCurly>();
-return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_463; {
+return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_470; {
 ((*this).pop_state());
-__jakt_var_463 = formatter::FormattedToken(token,((*this).indent),(TRY((Array<u8>::create_with({})))),JAKT_RESOLVE_EXPLICIT_VALUE_OR_CONTROL_FLOW_RETURN_ONLY(([&]() -> JaktInternal::ExplicitValueOrControlFlow<JaktInternal::Array<u8>, ErrorOr<JaktInternal::Optional<formatter::FormattedToken>>>{
+__jakt_var_470 = formatter::FormattedToken(token,((*this).indent),(TRY((Array<u8>::create_with({})))),JAKT_RESOLVE_EXPLICIT_VALUE_OR_CONTROL_FLOW_RETURN_ONLY(([&]() -> JaktInternal::ExplicitValueOrControlFlow<JaktInternal::Array<u8>, ErrorOr<JaktInternal::Optional<formatter::FormattedToken>>>{
 auto&& __jakt_match_variant = ((*this).peek((-(static_cast<i64>(1LL)))));
 switch(__jakt_match_variant.index()) {
 case 56: {
@@ -2205,16 +2205,16 @@ return JaktInternal::ExplicitValue((TRY((Array<u8>::create_with({' '})))));
 };/*case end*/
 }/*switch end*/
 }()
-))); goto __jakt_label_425;
+))); goto __jakt_label_431;
 
 }
-__jakt_label_425:; __jakt_var_463.release_value(); }));
+__jakt_label_431:; __jakt_var_470.release_value(); }));
 };/*case end*/
 case 10: {
 auto&& __jakt_match_value = __jakt_match_variant.template get<typename lexer::Token::LCurly>();
-return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_464; {
+return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_471; {
 TRY((((*this).push_state( formatter::State { typename formatter::State::Toplevel(static_cast<size_t>(0ULL),static_cast<size_t>(0ULL),static_cast<size_t>(0ULL)) } ))));
-__jakt_var_464 = formatter::FormattedToken(token,((*this).indent),JAKT_RESOLVE_EXPLICIT_VALUE_OR_CONTROL_FLOW_RETURN_ONLY(([&]() -> JaktInternal::ExplicitValueOrControlFlow<JaktInternal::Array<u8>, ErrorOr<JaktInternal::Optional<formatter::FormattedToken>>>{
+__jakt_var_471 = formatter::FormattedToken(token,((*this).indent),JAKT_RESOLVE_EXPLICIT_VALUE_OR_CONTROL_FLOW_RETURN_ONLY(([&]() -> JaktInternal::ExplicitValueOrControlFlow<JaktInternal::Array<u8>, ErrorOr<JaktInternal::Optional<formatter::FormattedToken>>>{
 auto&& __jakt_match_variant = ((*this).peek(static_cast<i64>(0LL)));
 switch(__jakt_match_variant.index()) {
 case 56: {
@@ -2229,10 +2229,10 @@ return JaktInternal::ExplicitValue((TRY((Array<u8>::create_with({' '})))));
 };/*case end*/
 }/*switch end*/
 }()
-)),(TRY((Array<u8>::create_with({' '}))))); goto __jakt_label_426;
+)),(TRY((Array<u8>::create_with({' '}))))); goto __jakt_label_432;
 
 }
-__jakt_label_426:; __jakt_var_464.release_value(); }));
+__jakt_label_432:; __jakt_var_471.release_value(); }));
 };/*case end*/
 case 6: {
 auto&& __jakt_match_value = __jakt_match_variant.template get<typename lexer::Token::Colon>();
@@ -2259,9 +2259,9 @@ auto&& __jakt_match_variant = token;
 switch(__jakt_match_variant.index()) {
 case 11: {
 auto&& __jakt_match_value = __jakt_match_variant.template get<typename lexer::Token::RCurly>();
-return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_465; {
+return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_472; {
 ((*this).pop_state());
-__jakt_var_465 = formatter::FormattedToken(token,((*this).indent),(TRY((Array<u8>::create_with({})))),JAKT_RESOLVE_EXPLICIT_VALUE_OR_CONTROL_FLOW_RETURN_ONLY(([&]() -> JaktInternal::ExplicitValueOrControlFlow<JaktInternal::Array<u8>, ErrorOr<JaktInternal::Optional<formatter::FormattedToken>>>{
+__jakt_var_472 = formatter::FormattedToken(token,((*this).indent),(TRY((Array<u8>::create_with({})))),JAKT_RESOLVE_EXPLICIT_VALUE_OR_CONTROL_FLOW_RETURN_ONLY(([&]() -> JaktInternal::ExplicitValueOrControlFlow<JaktInternal::Array<u8>, ErrorOr<JaktInternal::Optional<formatter::FormattedToken>>>{
 auto&& __jakt_match_variant = ((*this).peek((-(static_cast<i64>(1LL)))));
 switch(__jakt_match_variant.index()) {
 case 56: {
@@ -2276,16 +2276,16 @@ return JaktInternal::ExplicitValue((TRY((Array<u8>::create_with({' '})))));
 };/*case end*/
 }/*switch end*/
 }()
-))); goto __jakt_label_427;
+))); goto __jakt_label_433;
 
 }
-__jakt_label_427:; __jakt_var_465.release_value(); }));
+__jakt_label_433:; __jakt_var_472.release_value(); }));
 };/*case end*/
 case 10: {
 auto&& __jakt_match_value = __jakt_match_variant.template get<typename lexer::Token::LCurly>();
-return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_466; {
+return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_473; {
 TRY((((*this).push_state( formatter::State { typename formatter::State::Toplevel(static_cast<size_t>(0ULL),static_cast<size_t>(0ULL),static_cast<size_t>(0ULL)) } ))));
-__jakt_var_466 = formatter::FormattedToken(token,((*this).indent),JAKT_RESOLVE_EXPLICIT_VALUE_OR_CONTROL_FLOW_RETURN_ONLY(([&]() -> JaktInternal::ExplicitValueOrControlFlow<JaktInternal::Array<u8>, ErrorOr<JaktInternal::Optional<formatter::FormattedToken>>>{
+__jakt_var_473 = formatter::FormattedToken(token,((*this).indent),JAKT_RESOLVE_EXPLICIT_VALUE_OR_CONTROL_FLOW_RETURN_ONLY(([&]() -> JaktInternal::ExplicitValueOrControlFlow<JaktInternal::Array<u8>, ErrorOr<JaktInternal::Optional<formatter::FormattedToken>>>{
 auto&& __jakt_match_variant = ((*this).peek(static_cast<i64>(0LL)));
 switch(__jakt_match_variant.index()) {
 case 56: {
@@ -2300,10 +2300,10 @@ return JaktInternal::ExplicitValue((TRY((Array<u8>::create_with({' '})))));
 };/*case end*/
 }/*switch end*/
 }()
-)),(TRY((Array<u8>::create_with({' '}))))); goto __jakt_label_428;
+)),(TRY((Array<u8>::create_with({' '}))))); goto __jakt_label_434;
 
 }
-__jakt_label_428:; __jakt_var_466.release_value(); }));
+__jakt_label_434:; __jakt_var_473.release_value(); }));
 };/*case end*/
 case 6: {
 auto&& __jakt_match_value = __jakt_match_variant.template get<typename lexer::Token::Colon>();
@@ -2331,7 +2331,7 @@ auto&& __jakt_match_variant = token;
 switch(__jakt_match_variant.index()) {
 case 58: {
 auto&& __jakt_match_value = __jakt_match_variant.template get<typename lexer::Token::FatArrow>();
-return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_467; {
+return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_474; {
 bool const next_is_eol = ((((*this).peek(static_cast<i64>(0LL)))).index() == 56 /* Eol */);
 TRY((((*this).replace_state( formatter::State { typename formatter::State::EntityDefinition( formatter::Entity { typename formatter::Entity::Function(true,next_is_eol) } ) } ))));
 if (next_is_eol){
@@ -2347,28 +2347,28 @@ if (next_is_eol){
 (eols_allowed = static_cast<size_t>(1ULL));
 }
 TRY((((*this).push_state( formatter::State { typename formatter::State::StatementContext(static_cast<size_t>(0ULL),static_cast<size_t>(0ULL),static_cast<size_t>(0ULL),static_cast<size_t>(0ULL),eols_allowed,false, formatter::ExpressionMode { typename formatter::ExpressionMode::BeforeExpressions() } ,static_cast<size_t>(0ULL)) } ))));
-__jakt_var_467 = formatter::FormattedToken(token,((*this).indent),(TRY((Array<u8>::create_with({' '})))),(TRY((Array<u8>::create_with({' '}))))); goto __jakt_label_429;
+__jakt_var_474 = formatter::FormattedToken(token,((*this).indent),(TRY((Array<u8>::create_with({' '})))),(TRY((Array<u8>::create_with({' '}))))); goto __jakt_label_435;
 
 }
-__jakt_label_429:; __jakt_var_467.release_value(); }));
+__jakt_label_435:; __jakt_var_474.release_value(); }));
 };/*case end*/
 case 59: {
 auto&& __jakt_match_value = __jakt_match_variant.template get<typename lexer::Token::Arrow>();
-return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_468; {
+return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_475; {
 TRY((((*this).push_state( formatter::State { typename formatter::State::TypeContext(static_cast<size_t>(0ULL),static_cast<size_t>(0ULL),static_cast<size_t>(0ULL),static_cast<size_t>(0ULL),false) } ))));
-__jakt_var_468 = formatter::FormattedToken(token,((*this).indent),(TRY((Array<u8>::create_with({' '})))),(TRY((Array<u8>::create_with({' '}))))); goto __jakt_label_430;
+__jakt_var_475 = formatter::FormattedToken(token,((*this).indent),(TRY((Array<u8>::create_with({' '})))),(TRY((Array<u8>::create_with({' '}))))); goto __jakt_label_436;
 
 }
-__jakt_label_430:; __jakt_var_468.release_value(); }));
+__jakt_label_436:; __jakt_var_475.release_value(); }));
 };/*case end*/
 case 8: {
 auto&& __jakt_match_value = __jakt_match_variant.template get<typename lexer::Token::LParen>();
-return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_469; {
+return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_476; {
 TRY((((*this).push_state( formatter::State { typename formatter::State::ParameterList(static_cast<size_t>(0ULL)) } ))));
-__jakt_var_469 = formatter::FormattedToken(token,((*this).indent),(TRY((Array<u8>::create_with({})))),(TRY((Array<u8>::create_with({}))))); goto __jakt_label_431;
+__jakt_var_476 = formatter::FormattedToken(token,((*this).indent),(TRY((Array<u8>::create_with({})))),(TRY((Array<u8>::create_with({}))))); goto __jakt_label_437;
 
 }
-__jakt_label_431:; __jakt_var_469.release_value(); }));
+__jakt_label_437:; __jakt_var_476.release_value(); }));
 };/*case end*/
 case 9: {
 auto&& __jakt_match_value = __jakt_match_variant.template get<typename lexer::Token::RParen>();
@@ -2388,24 +2388,24 @@ return JaktInternal::ExplicitValue((TRY((Array<u8>::create_with({})))));
 };/*case end*/
 case 10: {
 auto&& __jakt_match_value = __jakt_match_variant.template get<typename lexer::Token::LCurly>();
-return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_470; {
+return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_477; {
 TRY((((*this).push_state( formatter::State { typename formatter::State::StatementContext(static_cast<size_t>(0ULL),static_cast<size_t>(0ULL),static_cast<size_t>(0ULL),static_cast<size_t>(0ULL),JaktInternal::OptionalNone(),false, formatter::ExpressionMode { typename formatter::ExpressionMode::OutsideExpression() } ,static_cast<size_t>(0ULL)) } ))));
-__jakt_var_470 = formatter::FormattedToken(token,((*this).indent),(TRY((Array<u8>::create_with({})))),(TRY((Array<u8>::create_with({' '}))))); goto __jakt_label_432;
+__jakt_var_477 = formatter::FormattedToken(token,((*this).indent),(TRY((Array<u8>::create_with({})))),(TRY((Array<u8>::create_with({' '}))))); goto __jakt_label_438;
 
 }
-__jakt_label_432:; __jakt_var_470.release_value(); }));
+__jakt_label_438:; __jakt_var_477.release_value(); }));
 };/*case end*/
 case 11: {
 auto&& __jakt_match_value = __jakt_match_variant.template get<typename lexer::Token::RCurly>();
-return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_471; {
+return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_478; {
 ((*this).pop_state());
-__jakt_var_471 = formatter::FormattedToken(token,((*this).indent),(TRY((Array<u8>::create_with({})))),(TRY((Array<u8>::create_with({}))))); goto __jakt_label_433;
+__jakt_var_478 = formatter::FormattedToken(token,((*this).indent),(TRY((Array<u8>::create_with({})))),(TRY((Array<u8>::create_with({}))))); goto __jakt_label_439;
 
 }
-__jakt_label_433:; __jakt_var_471.release_value(); }));
+__jakt_label_439:; __jakt_var_478.release_value(); }));
 };/*case end*/
 case 56: {
-auto&& __jakt_match_value = __jakt_match_variant.template get<lexer::Token::Eol>();return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_472; {
+auto&& __jakt_match_value = __jakt_match_variant.template get<lexer::Token::Eol>();return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_479; {
 if ((!(arrow))){
 return (TRY((((*this).next()))));
 }
@@ -2421,10 +2421,10 @@ else if (((((((*this).dedents_to_skip)).last()).value()) > static_cast<size_t>(0
 ({auto& _jakt_ref = ((((*this).dedents_to_skip))[(JaktInternal::checked_sub<size_t>(((((*this).dedents_to_skip)).size()),static_cast<size_t>(1ULL)))]);_jakt_ref = JaktInternal::checked_sub<size_t>(_jakt_ref, static_cast<size_t>(1ULL));});
 }
 }
-__jakt_var_472 = formatter::FormattedToken(token,((*this).indent),(TRY((Array<u8>::create_with({})))),(TRY((Array<u8>::create_with({}))))); goto __jakt_label_434;
+__jakt_var_479 = formatter::FormattedToken(token,((*this).indent),(TRY((Array<u8>::create_with({})))),(TRY((Array<u8>::create_with({}))))); goto __jakt_label_440;
 
 }
-__jakt_label_434:; __jakt_var_472.release_value(); }));
+__jakt_label_440:; __jakt_var_479.release_value(); }));
 };/*case end*/
 default: {
 return JaktInternal::ExplicitValue(formatter::FormattedToken(token,((*this).indent),(TRY((Array<u8>::create_with({})))),(TRY((Array<u8>::create_with({}))))));
@@ -2451,170 +2451,91 @@ auto&& __jakt_match_variant = token;
 switch(__jakt_match_variant.index()) {
 case 81: {
 auto&& __jakt_match_value = __jakt_match_variant.template get<typename lexer::Token::Let>();
-return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_473; {
+return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_480; {
 TRY((((*this).replace_state( formatter::State { typename formatter::State::StatementContext(open_parens,open_curlies,open_squares,arrow_indents,allow_eol,inserted_comma, formatter::ExpressionMode { typename formatter::ExpressionMode::OutsideExpression() } ,dedents_on_open_curly) } ))));
 TRY((((*this).push_state( formatter::State { typename formatter::State::VariableDeclaration(static_cast<size_t>(0ULL)) } ))));
-__jakt_var_473 = formatter::FormattedToken(token,((*this).indent),(TRY((Array<u8>::create_with({' '})))),(TRY((Array<u8>::create_with({}))))); goto __jakt_label_435;
+__jakt_var_480 = formatter::FormattedToken(token,((*this).indent),(TRY((Array<u8>::create_with({' '})))),(TRY((Array<u8>::create_with({}))))); goto __jakt_label_441;
 
 }
-__jakt_label_435:; __jakt_var_473.release_value(); }));
+__jakt_label_441:; __jakt_var_480.release_value(); }));
 };/*case end*/
 case 84: {
 auto&& __jakt_match_value = __jakt_match_variant.template get<typename lexer::Token::Mut>();
-return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_474; {
+return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_481; {
 TRY((((*this).replace_state( formatter::State { typename formatter::State::StatementContext(open_parens,open_curlies,open_squares,arrow_indents,allow_eol,inserted_comma, formatter::ExpressionMode { typename formatter::ExpressionMode::AtExpressionStart() } ,dedents_on_open_curly) } ))));
 if (((expression_mode).index() == 0 /* OutsideExpression */)){
 TRY((((*this).push_state( formatter::State { typename formatter::State::VariableDeclaration(static_cast<size_t>(0ULL)) } ))));
 }
-__jakt_var_474 = formatter::FormattedToken(token,((*this).indent),(TRY((Array<u8>::create_with({' '})))),(TRY((Array<u8>::create_with({}))))); goto __jakt_label_436;
+__jakt_var_481 = formatter::FormattedToken(token,((*this).indent),(TRY((Array<u8>::create_with({' '})))),(TRY((Array<u8>::create_with({}))))); goto __jakt_label_442;
 
 }
-__jakt_label_436:; __jakt_var_474.release_value(); }));
+__jakt_label_442:; __jakt_var_481.release_value(); }));
 };/*case end*/
 case 83: {
 auto&& __jakt_match_value = __jakt_match_variant.template get<typename lexer::Token::Match>();
-return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_475; {
+return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_482; {
 size_t const added_indent = JAKT_RESOLVE_EXPLICIT_VALUE_OR_CONTROL_FLOW_RETURN_ONLY(([&]() -> JaktInternal::ExplicitValueOrControlFlow<size_t, ErrorOr<JaktInternal::Optional<formatter::FormattedToken>>>{
 auto&& __jakt_match_variant = token;
 switch(__jakt_match_variant.index()) {
 case 83: {
 auto&& __jakt_match_value = __jakt_match_variant.template get<typename lexer::Token::Match>();
-return JaktInternal::ExplicitValue(({ Optional<size_t> __jakt_var_476; {
-size_t indent = static_cast<size_t>(1ULL);
-if (((*this).line_has_indent())){
-(indent = static_cast<size_t>(0ULL));
-}
-__jakt_var_476 = indent; goto __jakt_label_438;
-
-}
-__jakt_label_438:; __jakt_var_476.release_value(); }));
-};/*case end*/
-case 74: {
-auto&& __jakt_match_value = __jakt_match_variant.template get<typename lexer::Token::For>();
-return JaktInternal::ExplicitValue(({ Optional<size_t> __jakt_var_477; {
-size_t indent = static_cast<size_t>(1ULL);
-if (((*this).line_has_indent())){
-(indent = static_cast<size_t>(0ULL));
-}
-__jakt_var_477 = indent; goto __jakt_label_439;
-
-}
-__jakt_label_439:; __jakt_var_477.release_value(); }));
-};/*case end*/
-case 103: {
-auto&& __jakt_match_value = __jakt_match_variant.template get<typename lexer::Token::While>();
-return JaktInternal::ExplicitValue(({ Optional<size_t> __jakt_var_478; {
-size_t indent = static_cast<size_t>(1ULL);
-if (((*this).line_has_indent())){
-(indent = static_cast<size_t>(0ULL));
-}
-__jakt_var_478 = indent; goto __jakt_label_440;
-
-}
-__jakt_label_440:; __jakt_var_478.release_value(); }));
-};/*case end*/
-case 77: {
-auto&& __jakt_match_value = __jakt_match_variant.template get<typename lexer::Token::If>();
-return JaktInternal::ExplicitValue(({ Optional<size_t> __jakt_var_479; {
-size_t indent = static_cast<size_t>(1ULL);
-if (((*this).line_has_indent())){
-(indent = static_cast<size_t>(0ULL));
-}
-__jakt_var_479 = indent; goto __jakt_label_441;
-
-}
-__jakt_label_441:; __jakt_var_479.release_value(); }));
-};/*case end*/
-case 105: {
-auto&& __jakt_match_value = __jakt_match_variant.template get<typename lexer::Token::Guard>();
-return JaktInternal::ExplicitValue(({ Optional<size_t> __jakt_var_480; {
-size_t indent = static_cast<size_t>(1ULL);
-if (((*this).line_has_indent())){
-(indent = static_cast<size_t>(0ULL));
-}
-__jakt_var_480 = indent; goto __jakt_label_442;
-
-}
-__jakt_label_442:; __jakt_var_480.release_value(); }));
-};/*case end*/
-default: {
-return JaktInternal::ExplicitValue(static_cast<size_t>(0ULL));
-};/*case end*/
-}/*switch end*/
-}()
-));
-TRY((((*this).replace_state( formatter::State { typename formatter::State::StatementContext(open_parens,open_curlies,open_squares,arrow_indents,allow_eol,inserted_comma, formatter::ExpressionMode { typename formatter::ExpressionMode::AtExpressionStart() } ,(JaktInternal::checked_add<size_t>(dedents_on_open_curly,added_indent))) } ))));
-({auto& _jakt_ref = indent_change;_jakt_ref = JaktInternal::checked_add<i64>(_jakt_ref, (infallible_integer_cast<i64>((added_indent))));});
-__jakt_var_475 = formatter::FormattedToken(token,((*this).indent),(TRY((Array<u8>::create_with({' '})))),(TRY((Array<u8>::create_with({}))))); goto __jakt_label_437;
-
-}
-__jakt_label_437:; __jakt_var_475.release_value(); }));
-};/*case end*/
-case 74: {
-auto&& __jakt_match_value = __jakt_match_variant.template get<typename lexer::Token::For>();
-return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_481; {
-size_t const added_indent = JAKT_RESOLVE_EXPLICIT_VALUE_OR_CONTROL_FLOW_RETURN_ONLY(([&]() -> JaktInternal::ExplicitValueOrControlFlow<size_t, ErrorOr<JaktInternal::Optional<formatter::FormattedToken>>>{
-auto&& __jakt_match_variant = token;
-switch(__jakt_match_variant.index()) {
-case 83: {
-auto&& __jakt_match_value = __jakt_match_variant.template get<typename lexer::Token::Match>();
-return JaktInternal::ExplicitValue(({ Optional<size_t> __jakt_var_482; {
-size_t indent = static_cast<size_t>(1ULL);
-if (((*this).line_has_indent())){
-(indent = static_cast<size_t>(0ULL));
-}
-__jakt_var_482 = indent; goto __jakt_label_444;
-
-}
-__jakt_label_444:; __jakt_var_482.release_value(); }));
-};/*case end*/
-case 74: {
-auto&& __jakt_match_value = __jakt_match_variant.template get<typename lexer::Token::For>();
 return JaktInternal::ExplicitValue(({ Optional<size_t> __jakt_var_483; {
 size_t indent = static_cast<size_t>(1ULL);
 if (((*this).line_has_indent())){
 (indent = static_cast<size_t>(0ULL));
 }
-__jakt_var_483 = indent; goto __jakt_label_445;
+__jakt_var_483 = indent; goto __jakt_label_444;
 
 }
-__jakt_label_445:; __jakt_var_483.release_value(); }));
+__jakt_label_444:; __jakt_var_483.release_value(); }));
 };/*case end*/
-case 103: {
-auto&& __jakt_match_value = __jakt_match_variant.template get<typename lexer::Token::While>();
+case 74: {
+auto&& __jakt_match_value = __jakt_match_variant.template get<typename lexer::Token::For>();
 return JaktInternal::ExplicitValue(({ Optional<size_t> __jakt_var_484; {
 size_t indent = static_cast<size_t>(1ULL);
 if (((*this).line_has_indent())){
 (indent = static_cast<size_t>(0ULL));
 }
-__jakt_var_484 = indent; goto __jakt_label_446;
+__jakt_var_484 = indent; goto __jakt_label_445;
 
 }
-__jakt_label_446:; __jakt_var_484.release_value(); }));
+__jakt_label_445:; __jakt_var_484.release_value(); }));
 };/*case end*/
-case 77: {
-auto&& __jakt_match_value = __jakt_match_variant.template get<typename lexer::Token::If>();
+case 103: {
+auto&& __jakt_match_value = __jakt_match_variant.template get<typename lexer::Token::While>();
 return JaktInternal::ExplicitValue(({ Optional<size_t> __jakt_var_485; {
 size_t indent = static_cast<size_t>(1ULL);
 if (((*this).line_has_indent())){
 (indent = static_cast<size_t>(0ULL));
 }
-__jakt_var_485 = indent; goto __jakt_label_447;
+__jakt_var_485 = indent; goto __jakt_label_446;
 
 }
-__jakt_label_447:; __jakt_var_485.release_value(); }));
+__jakt_label_446:; __jakt_var_485.release_value(); }));
 };/*case end*/
-case 105: {
-auto&& __jakt_match_value = __jakt_match_variant.template get<typename lexer::Token::Guard>();
+case 77: {
+auto&& __jakt_match_value = __jakt_match_variant.template get<typename lexer::Token::If>();
 return JaktInternal::ExplicitValue(({ Optional<size_t> __jakt_var_486; {
 size_t indent = static_cast<size_t>(1ULL);
 if (((*this).line_has_indent())){
 (indent = static_cast<size_t>(0ULL));
 }
-__jakt_var_486 = indent; goto __jakt_label_448;
+__jakt_var_486 = indent; goto __jakt_label_447;
 
 }
-__jakt_label_448:; __jakt_var_486.release_value(); }));
+__jakt_label_447:; __jakt_var_486.release_value(); }));
+};/*case end*/
+case 105: {
+auto&& __jakt_match_value = __jakt_match_variant.template get<typename lexer::Token::Guard>();
+return JaktInternal::ExplicitValue(({ Optional<size_t> __jakt_var_487; {
+size_t indent = static_cast<size_t>(1ULL);
+if (((*this).line_has_indent())){
+(indent = static_cast<size_t>(0ULL));
+}
+__jakt_var_487 = indent; goto __jakt_label_448;
+
+}
+__jakt_label_448:; __jakt_var_487.release_value(); }));
 };/*case end*/
 default: {
 return JaktInternal::ExplicitValue(static_cast<size_t>(0ULL));
@@ -2624,76 +2545,76 @@ return JaktInternal::ExplicitValue(static_cast<size_t>(0ULL));
 ));
 TRY((((*this).replace_state( formatter::State { typename formatter::State::StatementContext(open_parens,open_curlies,open_squares,arrow_indents,allow_eol,inserted_comma, formatter::ExpressionMode { typename formatter::ExpressionMode::AtExpressionStart() } ,(JaktInternal::checked_add<size_t>(dedents_on_open_curly,added_indent))) } ))));
 ({auto& _jakt_ref = indent_change;_jakt_ref = JaktInternal::checked_add<i64>(_jakt_ref, (infallible_integer_cast<i64>((added_indent))));});
-__jakt_var_481 = formatter::FormattedToken(token,((*this).indent),(TRY((Array<u8>::create_with({' '})))),(TRY((Array<u8>::create_with({}))))); goto __jakt_label_443;
+__jakt_var_482 = formatter::FormattedToken(token,((*this).indent),(TRY((Array<u8>::create_with({' '})))),(TRY((Array<u8>::create_with({}))))); goto __jakt_label_443;
 
 }
-__jakt_label_443:; __jakt_var_481.release_value(); }));
+__jakt_label_443:; __jakt_var_482.release_value(); }));
 };/*case end*/
-case 103: {
-auto&& __jakt_match_value = __jakt_match_variant.template get<typename lexer::Token::While>();
-return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_487; {
+case 74: {
+auto&& __jakt_match_value = __jakt_match_variant.template get<typename lexer::Token::For>();
+return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_488; {
 size_t const added_indent = JAKT_RESOLVE_EXPLICIT_VALUE_OR_CONTROL_FLOW_RETURN_ONLY(([&]() -> JaktInternal::ExplicitValueOrControlFlow<size_t, ErrorOr<JaktInternal::Optional<formatter::FormattedToken>>>{
 auto&& __jakt_match_variant = token;
 switch(__jakt_match_variant.index()) {
 case 83: {
 auto&& __jakt_match_value = __jakt_match_variant.template get<typename lexer::Token::Match>();
-return JaktInternal::ExplicitValue(({ Optional<size_t> __jakt_var_488; {
-size_t indent = static_cast<size_t>(1ULL);
-if (((*this).line_has_indent())){
-(indent = static_cast<size_t>(0ULL));
-}
-__jakt_var_488 = indent; goto __jakt_label_450;
-
-}
-__jakt_label_450:; __jakt_var_488.release_value(); }));
-};/*case end*/
-case 74: {
-auto&& __jakt_match_value = __jakt_match_variant.template get<typename lexer::Token::For>();
 return JaktInternal::ExplicitValue(({ Optional<size_t> __jakt_var_489; {
 size_t indent = static_cast<size_t>(1ULL);
 if (((*this).line_has_indent())){
 (indent = static_cast<size_t>(0ULL));
 }
-__jakt_var_489 = indent; goto __jakt_label_451;
+__jakt_var_489 = indent; goto __jakt_label_450;
 
 }
-__jakt_label_451:; __jakt_var_489.release_value(); }));
+__jakt_label_450:; __jakt_var_489.release_value(); }));
 };/*case end*/
-case 103: {
-auto&& __jakt_match_value = __jakt_match_variant.template get<typename lexer::Token::While>();
+case 74: {
+auto&& __jakt_match_value = __jakt_match_variant.template get<typename lexer::Token::For>();
 return JaktInternal::ExplicitValue(({ Optional<size_t> __jakt_var_490; {
 size_t indent = static_cast<size_t>(1ULL);
 if (((*this).line_has_indent())){
 (indent = static_cast<size_t>(0ULL));
 }
-__jakt_var_490 = indent; goto __jakt_label_452;
+__jakt_var_490 = indent; goto __jakt_label_451;
 
 }
-__jakt_label_452:; __jakt_var_490.release_value(); }));
+__jakt_label_451:; __jakt_var_490.release_value(); }));
 };/*case end*/
-case 77: {
-auto&& __jakt_match_value = __jakt_match_variant.template get<typename lexer::Token::If>();
+case 103: {
+auto&& __jakt_match_value = __jakt_match_variant.template get<typename lexer::Token::While>();
 return JaktInternal::ExplicitValue(({ Optional<size_t> __jakt_var_491; {
 size_t indent = static_cast<size_t>(1ULL);
 if (((*this).line_has_indent())){
 (indent = static_cast<size_t>(0ULL));
 }
-__jakt_var_491 = indent; goto __jakt_label_453;
+__jakt_var_491 = indent; goto __jakt_label_452;
 
 }
-__jakt_label_453:; __jakt_var_491.release_value(); }));
+__jakt_label_452:; __jakt_var_491.release_value(); }));
 };/*case end*/
-case 105: {
-auto&& __jakt_match_value = __jakt_match_variant.template get<typename lexer::Token::Guard>();
+case 77: {
+auto&& __jakt_match_value = __jakt_match_variant.template get<typename lexer::Token::If>();
 return JaktInternal::ExplicitValue(({ Optional<size_t> __jakt_var_492; {
 size_t indent = static_cast<size_t>(1ULL);
 if (((*this).line_has_indent())){
 (indent = static_cast<size_t>(0ULL));
 }
-__jakt_var_492 = indent; goto __jakt_label_454;
+__jakt_var_492 = indent; goto __jakt_label_453;
 
 }
-__jakt_label_454:; __jakt_var_492.release_value(); }));
+__jakt_label_453:; __jakt_var_492.release_value(); }));
+};/*case end*/
+case 105: {
+auto&& __jakt_match_value = __jakt_match_variant.template get<typename lexer::Token::Guard>();
+return JaktInternal::ExplicitValue(({ Optional<size_t> __jakt_var_493; {
+size_t indent = static_cast<size_t>(1ULL);
+if (((*this).line_has_indent())){
+(indent = static_cast<size_t>(0ULL));
+}
+__jakt_var_493 = indent; goto __jakt_label_454;
+
+}
+__jakt_label_454:; __jakt_var_493.release_value(); }));
 };/*case end*/
 default: {
 return JaktInternal::ExplicitValue(static_cast<size_t>(0ULL));
@@ -2703,76 +2624,76 @@ return JaktInternal::ExplicitValue(static_cast<size_t>(0ULL));
 ));
 TRY((((*this).replace_state( formatter::State { typename formatter::State::StatementContext(open_parens,open_curlies,open_squares,arrow_indents,allow_eol,inserted_comma, formatter::ExpressionMode { typename formatter::ExpressionMode::AtExpressionStart() } ,(JaktInternal::checked_add<size_t>(dedents_on_open_curly,added_indent))) } ))));
 ({auto& _jakt_ref = indent_change;_jakt_ref = JaktInternal::checked_add<i64>(_jakt_ref, (infallible_integer_cast<i64>((added_indent))));});
-__jakt_var_487 = formatter::FormattedToken(token,((*this).indent),(TRY((Array<u8>::create_with({' '})))),(TRY((Array<u8>::create_with({}))))); goto __jakt_label_449;
+__jakt_var_488 = formatter::FormattedToken(token,((*this).indent),(TRY((Array<u8>::create_with({' '})))),(TRY((Array<u8>::create_with({}))))); goto __jakt_label_449;
 
 }
-__jakt_label_449:; __jakt_var_487.release_value(); }));
+__jakt_label_449:; __jakt_var_488.release_value(); }));
 };/*case end*/
-case 77: {
-auto&& __jakt_match_value = __jakt_match_variant.template get<typename lexer::Token::If>();
-return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_493; {
+case 103: {
+auto&& __jakt_match_value = __jakt_match_variant.template get<typename lexer::Token::While>();
+return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_494; {
 size_t const added_indent = JAKT_RESOLVE_EXPLICIT_VALUE_OR_CONTROL_FLOW_RETURN_ONLY(([&]() -> JaktInternal::ExplicitValueOrControlFlow<size_t, ErrorOr<JaktInternal::Optional<formatter::FormattedToken>>>{
 auto&& __jakt_match_variant = token;
 switch(__jakt_match_variant.index()) {
 case 83: {
 auto&& __jakt_match_value = __jakt_match_variant.template get<typename lexer::Token::Match>();
-return JaktInternal::ExplicitValue(({ Optional<size_t> __jakt_var_494; {
-size_t indent = static_cast<size_t>(1ULL);
-if (((*this).line_has_indent())){
-(indent = static_cast<size_t>(0ULL));
-}
-__jakt_var_494 = indent; goto __jakt_label_456;
-
-}
-__jakt_label_456:; __jakt_var_494.release_value(); }));
-};/*case end*/
-case 74: {
-auto&& __jakt_match_value = __jakt_match_variant.template get<typename lexer::Token::For>();
 return JaktInternal::ExplicitValue(({ Optional<size_t> __jakt_var_495; {
 size_t indent = static_cast<size_t>(1ULL);
 if (((*this).line_has_indent())){
 (indent = static_cast<size_t>(0ULL));
 }
-__jakt_var_495 = indent; goto __jakt_label_457;
+__jakt_var_495 = indent; goto __jakt_label_456;
 
 }
-__jakt_label_457:; __jakt_var_495.release_value(); }));
+__jakt_label_456:; __jakt_var_495.release_value(); }));
 };/*case end*/
-case 103: {
-auto&& __jakt_match_value = __jakt_match_variant.template get<typename lexer::Token::While>();
+case 74: {
+auto&& __jakt_match_value = __jakt_match_variant.template get<typename lexer::Token::For>();
 return JaktInternal::ExplicitValue(({ Optional<size_t> __jakt_var_496; {
 size_t indent = static_cast<size_t>(1ULL);
 if (((*this).line_has_indent())){
 (indent = static_cast<size_t>(0ULL));
 }
-__jakt_var_496 = indent; goto __jakt_label_458;
+__jakt_var_496 = indent; goto __jakt_label_457;
 
 }
-__jakt_label_458:; __jakt_var_496.release_value(); }));
+__jakt_label_457:; __jakt_var_496.release_value(); }));
 };/*case end*/
-case 77: {
-auto&& __jakt_match_value = __jakt_match_variant.template get<typename lexer::Token::If>();
+case 103: {
+auto&& __jakt_match_value = __jakt_match_variant.template get<typename lexer::Token::While>();
 return JaktInternal::ExplicitValue(({ Optional<size_t> __jakt_var_497; {
 size_t indent = static_cast<size_t>(1ULL);
 if (((*this).line_has_indent())){
 (indent = static_cast<size_t>(0ULL));
 }
-__jakt_var_497 = indent; goto __jakt_label_459;
+__jakt_var_497 = indent; goto __jakt_label_458;
 
 }
-__jakt_label_459:; __jakt_var_497.release_value(); }));
+__jakt_label_458:; __jakt_var_497.release_value(); }));
 };/*case end*/
-case 105: {
-auto&& __jakt_match_value = __jakt_match_variant.template get<typename lexer::Token::Guard>();
+case 77: {
+auto&& __jakt_match_value = __jakt_match_variant.template get<typename lexer::Token::If>();
 return JaktInternal::ExplicitValue(({ Optional<size_t> __jakt_var_498; {
 size_t indent = static_cast<size_t>(1ULL);
 if (((*this).line_has_indent())){
 (indent = static_cast<size_t>(0ULL));
 }
-__jakt_var_498 = indent; goto __jakt_label_460;
+__jakt_var_498 = indent; goto __jakt_label_459;
 
 }
-__jakt_label_460:; __jakt_var_498.release_value(); }));
+__jakt_label_459:; __jakt_var_498.release_value(); }));
+};/*case end*/
+case 105: {
+auto&& __jakt_match_value = __jakt_match_variant.template get<typename lexer::Token::Guard>();
+return JaktInternal::ExplicitValue(({ Optional<size_t> __jakt_var_499; {
+size_t indent = static_cast<size_t>(1ULL);
+if (((*this).line_has_indent())){
+(indent = static_cast<size_t>(0ULL));
+}
+__jakt_var_499 = indent; goto __jakt_label_460;
+
+}
+__jakt_label_460:; __jakt_var_499.release_value(); }));
 };/*case end*/
 default: {
 return JaktInternal::ExplicitValue(static_cast<size_t>(0ULL));
@@ -2782,76 +2703,76 @@ return JaktInternal::ExplicitValue(static_cast<size_t>(0ULL));
 ));
 TRY((((*this).replace_state( formatter::State { typename formatter::State::StatementContext(open_parens,open_curlies,open_squares,arrow_indents,allow_eol,inserted_comma, formatter::ExpressionMode { typename formatter::ExpressionMode::AtExpressionStart() } ,(JaktInternal::checked_add<size_t>(dedents_on_open_curly,added_indent))) } ))));
 ({auto& _jakt_ref = indent_change;_jakt_ref = JaktInternal::checked_add<i64>(_jakt_ref, (infallible_integer_cast<i64>((added_indent))));});
-__jakt_var_493 = formatter::FormattedToken(token,((*this).indent),(TRY((Array<u8>::create_with({' '})))),(TRY((Array<u8>::create_with({}))))); goto __jakt_label_455;
+__jakt_var_494 = formatter::FormattedToken(token,((*this).indent),(TRY((Array<u8>::create_with({' '})))),(TRY((Array<u8>::create_with({}))))); goto __jakt_label_455;
 
 }
-__jakt_label_455:; __jakt_var_493.release_value(); }));
+__jakt_label_455:; __jakt_var_494.release_value(); }));
 };/*case end*/
-case 99: {
-auto&& __jakt_match_value = __jakt_match_variant.template get<typename lexer::Token::Try>();
-return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_499; {
+case 77: {
+auto&& __jakt_match_value = __jakt_match_variant.template get<typename lexer::Token::If>();
+return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_500; {
 size_t const added_indent = JAKT_RESOLVE_EXPLICIT_VALUE_OR_CONTROL_FLOW_RETURN_ONLY(([&]() -> JaktInternal::ExplicitValueOrControlFlow<size_t, ErrorOr<JaktInternal::Optional<formatter::FormattedToken>>>{
 auto&& __jakt_match_variant = token;
 switch(__jakt_match_variant.index()) {
 case 83: {
 auto&& __jakt_match_value = __jakt_match_variant.template get<typename lexer::Token::Match>();
-return JaktInternal::ExplicitValue(({ Optional<size_t> __jakt_var_500; {
-size_t indent = static_cast<size_t>(1ULL);
-if (((*this).line_has_indent())){
-(indent = static_cast<size_t>(0ULL));
-}
-__jakt_var_500 = indent; goto __jakt_label_462;
-
-}
-__jakt_label_462:; __jakt_var_500.release_value(); }));
-};/*case end*/
-case 74: {
-auto&& __jakt_match_value = __jakt_match_variant.template get<typename lexer::Token::For>();
 return JaktInternal::ExplicitValue(({ Optional<size_t> __jakt_var_501; {
 size_t indent = static_cast<size_t>(1ULL);
 if (((*this).line_has_indent())){
 (indent = static_cast<size_t>(0ULL));
 }
-__jakt_var_501 = indent; goto __jakt_label_463;
+__jakt_var_501 = indent; goto __jakt_label_462;
 
 }
-__jakt_label_463:; __jakt_var_501.release_value(); }));
+__jakt_label_462:; __jakt_var_501.release_value(); }));
 };/*case end*/
-case 103: {
-auto&& __jakt_match_value = __jakt_match_variant.template get<typename lexer::Token::While>();
+case 74: {
+auto&& __jakt_match_value = __jakt_match_variant.template get<typename lexer::Token::For>();
 return JaktInternal::ExplicitValue(({ Optional<size_t> __jakt_var_502; {
 size_t indent = static_cast<size_t>(1ULL);
 if (((*this).line_has_indent())){
 (indent = static_cast<size_t>(0ULL));
 }
-__jakt_var_502 = indent; goto __jakt_label_464;
+__jakt_var_502 = indent; goto __jakt_label_463;
 
 }
-__jakt_label_464:; __jakt_var_502.release_value(); }));
+__jakt_label_463:; __jakt_var_502.release_value(); }));
 };/*case end*/
-case 77: {
-auto&& __jakt_match_value = __jakt_match_variant.template get<typename lexer::Token::If>();
+case 103: {
+auto&& __jakt_match_value = __jakt_match_variant.template get<typename lexer::Token::While>();
 return JaktInternal::ExplicitValue(({ Optional<size_t> __jakt_var_503; {
 size_t indent = static_cast<size_t>(1ULL);
 if (((*this).line_has_indent())){
 (indent = static_cast<size_t>(0ULL));
 }
-__jakt_var_503 = indent; goto __jakt_label_465;
+__jakt_var_503 = indent; goto __jakt_label_464;
 
 }
-__jakt_label_465:; __jakt_var_503.release_value(); }));
+__jakt_label_464:; __jakt_var_503.release_value(); }));
 };/*case end*/
-case 105: {
-auto&& __jakt_match_value = __jakt_match_variant.template get<typename lexer::Token::Guard>();
+case 77: {
+auto&& __jakt_match_value = __jakt_match_variant.template get<typename lexer::Token::If>();
 return JaktInternal::ExplicitValue(({ Optional<size_t> __jakt_var_504; {
 size_t indent = static_cast<size_t>(1ULL);
 if (((*this).line_has_indent())){
 (indent = static_cast<size_t>(0ULL));
 }
-__jakt_var_504 = indent; goto __jakt_label_466;
+__jakt_var_504 = indent; goto __jakt_label_465;
 
 }
-__jakt_label_466:; __jakt_var_504.release_value(); }));
+__jakt_label_465:; __jakt_var_504.release_value(); }));
+};/*case end*/
+case 105: {
+auto&& __jakt_match_value = __jakt_match_variant.template get<typename lexer::Token::Guard>();
+return JaktInternal::ExplicitValue(({ Optional<size_t> __jakt_var_505; {
+size_t indent = static_cast<size_t>(1ULL);
+if (((*this).line_has_indent())){
+(indent = static_cast<size_t>(0ULL));
+}
+__jakt_var_505 = indent; goto __jakt_label_466;
+
+}
+__jakt_label_466:; __jakt_var_505.release_value(); }));
 };/*case end*/
 default: {
 return JaktInternal::ExplicitValue(static_cast<size_t>(0ULL));
@@ -2861,76 +2782,76 @@ return JaktInternal::ExplicitValue(static_cast<size_t>(0ULL));
 ));
 TRY((((*this).replace_state( formatter::State { typename formatter::State::StatementContext(open_parens,open_curlies,open_squares,arrow_indents,allow_eol,inserted_comma, formatter::ExpressionMode { typename formatter::ExpressionMode::AtExpressionStart() } ,(JaktInternal::checked_add<size_t>(dedents_on_open_curly,added_indent))) } ))));
 ({auto& _jakt_ref = indent_change;_jakt_ref = JaktInternal::checked_add<i64>(_jakt_ref, (infallible_integer_cast<i64>((added_indent))));});
-__jakt_var_499 = formatter::FormattedToken(token,((*this).indent),(TRY((Array<u8>::create_with({' '})))),(TRY((Array<u8>::create_with({}))))); goto __jakt_label_461;
+__jakt_var_500 = formatter::FormattedToken(token,((*this).indent),(TRY((Array<u8>::create_with({' '})))),(TRY((Array<u8>::create_with({}))))); goto __jakt_label_461;
 
 }
-__jakt_label_461:; __jakt_var_499.release_value(); }));
+__jakt_label_461:; __jakt_var_500.release_value(); }));
 };/*case end*/
-case 82: {
-auto&& __jakt_match_value = __jakt_match_variant.template get<typename lexer::Token::Loop>();
-return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_505; {
+case 99: {
+auto&& __jakt_match_value = __jakt_match_variant.template get<typename lexer::Token::Try>();
+return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_506; {
 size_t const added_indent = JAKT_RESOLVE_EXPLICIT_VALUE_OR_CONTROL_FLOW_RETURN_ONLY(([&]() -> JaktInternal::ExplicitValueOrControlFlow<size_t, ErrorOr<JaktInternal::Optional<formatter::FormattedToken>>>{
 auto&& __jakt_match_variant = token;
 switch(__jakt_match_variant.index()) {
 case 83: {
 auto&& __jakt_match_value = __jakt_match_variant.template get<typename lexer::Token::Match>();
-return JaktInternal::ExplicitValue(({ Optional<size_t> __jakt_var_506; {
-size_t indent = static_cast<size_t>(1ULL);
-if (((*this).line_has_indent())){
-(indent = static_cast<size_t>(0ULL));
-}
-__jakt_var_506 = indent; goto __jakt_label_468;
-
-}
-__jakt_label_468:; __jakt_var_506.release_value(); }));
-};/*case end*/
-case 74: {
-auto&& __jakt_match_value = __jakt_match_variant.template get<typename lexer::Token::For>();
 return JaktInternal::ExplicitValue(({ Optional<size_t> __jakt_var_507; {
 size_t indent = static_cast<size_t>(1ULL);
 if (((*this).line_has_indent())){
 (indent = static_cast<size_t>(0ULL));
 }
-__jakt_var_507 = indent; goto __jakt_label_469;
+__jakt_var_507 = indent; goto __jakt_label_468;
 
 }
-__jakt_label_469:; __jakt_var_507.release_value(); }));
+__jakt_label_468:; __jakt_var_507.release_value(); }));
 };/*case end*/
-case 103: {
-auto&& __jakt_match_value = __jakt_match_variant.template get<typename lexer::Token::While>();
+case 74: {
+auto&& __jakt_match_value = __jakt_match_variant.template get<typename lexer::Token::For>();
 return JaktInternal::ExplicitValue(({ Optional<size_t> __jakt_var_508; {
 size_t indent = static_cast<size_t>(1ULL);
 if (((*this).line_has_indent())){
 (indent = static_cast<size_t>(0ULL));
 }
-__jakt_var_508 = indent; goto __jakt_label_470;
+__jakt_var_508 = indent; goto __jakt_label_469;
 
 }
-__jakt_label_470:; __jakt_var_508.release_value(); }));
+__jakt_label_469:; __jakt_var_508.release_value(); }));
 };/*case end*/
-case 77: {
-auto&& __jakt_match_value = __jakt_match_variant.template get<typename lexer::Token::If>();
+case 103: {
+auto&& __jakt_match_value = __jakt_match_variant.template get<typename lexer::Token::While>();
 return JaktInternal::ExplicitValue(({ Optional<size_t> __jakt_var_509; {
 size_t indent = static_cast<size_t>(1ULL);
 if (((*this).line_has_indent())){
 (indent = static_cast<size_t>(0ULL));
 }
-__jakt_var_509 = indent; goto __jakt_label_471;
+__jakt_var_509 = indent; goto __jakt_label_470;
 
 }
-__jakt_label_471:; __jakt_var_509.release_value(); }));
+__jakt_label_470:; __jakt_var_509.release_value(); }));
 };/*case end*/
-case 105: {
-auto&& __jakt_match_value = __jakt_match_variant.template get<typename lexer::Token::Guard>();
+case 77: {
+auto&& __jakt_match_value = __jakt_match_variant.template get<typename lexer::Token::If>();
 return JaktInternal::ExplicitValue(({ Optional<size_t> __jakt_var_510; {
 size_t indent = static_cast<size_t>(1ULL);
 if (((*this).line_has_indent())){
 (indent = static_cast<size_t>(0ULL));
 }
-__jakt_var_510 = indent; goto __jakt_label_472;
+__jakt_var_510 = indent; goto __jakt_label_471;
 
 }
-__jakt_label_472:; __jakt_var_510.release_value(); }));
+__jakt_label_471:; __jakt_var_510.release_value(); }));
+};/*case end*/
+case 105: {
+auto&& __jakt_match_value = __jakt_match_variant.template get<typename lexer::Token::Guard>();
+return JaktInternal::ExplicitValue(({ Optional<size_t> __jakt_var_511; {
+size_t indent = static_cast<size_t>(1ULL);
+if (((*this).line_has_indent())){
+(indent = static_cast<size_t>(0ULL));
+}
+__jakt_var_511 = indent; goto __jakt_label_472;
+
+}
+__jakt_label_472:; __jakt_var_511.release_value(); }));
 };/*case end*/
 default: {
 return JaktInternal::ExplicitValue(static_cast<size_t>(0ULL));
@@ -2940,76 +2861,76 @@ return JaktInternal::ExplicitValue(static_cast<size_t>(0ULL));
 ));
 TRY((((*this).replace_state( formatter::State { typename formatter::State::StatementContext(open_parens,open_curlies,open_squares,arrow_indents,allow_eol,inserted_comma, formatter::ExpressionMode { typename formatter::ExpressionMode::AtExpressionStart() } ,(JaktInternal::checked_add<size_t>(dedents_on_open_curly,added_indent))) } ))));
 ({auto& _jakt_ref = indent_change;_jakt_ref = JaktInternal::checked_add<i64>(_jakt_ref, (infallible_integer_cast<i64>((added_indent))));});
-__jakt_var_505 = formatter::FormattedToken(token,((*this).indent),(TRY((Array<u8>::create_with({' '})))),(TRY((Array<u8>::create_with({}))))); goto __jakt_label_467;
+__jakt_var_506 = formatter::FormattedToken(token,((*this).indent),(TRY((Array<u8>::create_with({' '})))),(TRY((Array<u8>::create_with({}))))); goto __jakt_label_467;
 
 }
-__jakt_label_467:; __jakt_var_505.release_value(); }));
+__jakt_label_467:; __jakt_var_506.release_value(); }));
 };/*case end*/
-case 105: {
-auto&& __jakt_match_value = __jakt_match_variant.template get<typename lexer::Token::Guard>();
-return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_511; {
+case 82: {
+auto&& __jakt_match_value = __jakt_match_variant.template get<typename lexer::Token::Loop>();
+return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_512; {
 size_t const added_indent = JAKT_RESOLVE_EXPLICIT_VALUE_OR_CONTROL_FLOW_RETURN_ONLY(([&]() -> JaktInternal::ExplicitValueOrControlFlow<size_t, ErrorOr<JaktInternal::Optional<formatter::FormattedToken>>>{
 auto&& __jakt_match_variant = token;
 switch(__jakt_match_variant.index()) {
 case 83: {
 auto&& __jakt_match_value = __jakt_match_variant.template get<typename lexer::Token::Match>();
-return JaktInternal::ExplicitValue(({ Optional<size_t> __jakt_var_512; {
-size_t indent = static_cast<size_t>(1ULL);
-if (((*this).line_has_indent())){
-(indent = static_cast<size_t>(0ULL));
-}
-__jakt_var_512 = indent; goto __jakt_label_474;
-
-}
-__jakt_label_474:; __jakt_var_512.release_value(); }));
-};/*case end*/
-case 74: {
-auto&& __jakt_match_value = __jakt_match_variant.template get<typename lexer::Token::For>();
 return JaktInternal::ExplicitValue(({ Optional<size_t> __jakt_var_513; {
 size_t indent = static_cast<size_t>(1ULL);
 if (((*this).line_has_indent())){
 (indent = static_cast<size_t>(0ULL));
 }
-__jakt_var_513 = indent; goto __jakt_label_475;
+__jakt_var_513 = indent; goto __jakt_label_474;
 
 }
-__jakt_label_475:; __jakt_var_513.release_value(); }));
+__jakt_label_474:; __jakt_var_513.release_value(); }));
 };/*case end*/
-case 103: {
-auto&& __jakt_match_value = __jakt_match_variant.template get<typename lexer::Token::While>();
+case 74: {
+auto&& __jakt_match_value = __jakt_match_variant.template get<typename lexer::Token::For>();
 return JaktInternal::ExplicitValue(({ Optional<size_t> __jakt_var_514; {
 size_t indent = static_cast<size_t>(1ULL);
 if (((*this).line_has_indent())){
 (indent = static_cast<size_t>(0ULL));
 }
-__jakt_var_514 = indent; goto __jakt_label_476;
+__jakt_var_514 = indent; goto __jakt_label_475;
 
 }
-__jakt_label_476:; __jakt_var_514.release_value(); }));
+__jakt_label_475:; __jakt_var_514.release_value(); }));
 };/*case end*/
-case 77: {
-auto&& __jakt_match_value = __jakt_match_variant.template get<typename lexer::Token::If>();
+case 103: {
+auto&& __jakt_match_value = __jakt_match_variant.template get<typename lexer::Token::While>();
 return JaktInternal::ExplicitValue(({ Optional<size_t> __jakt_var_515; {
 size_t indent = static_cast<size_t>(1ULL);
 if (((*this).line_has_indent())){
 (indent = static_cast<size_t>(0ULL));
 }
-__jakt_var_515 = indent; goto __jakt_label_477;
+__jakt_var_515 = indent; goto __jakt_label_476;
 
 }
-__jakt_label_477:; __jakt_var_515.release_value(); }));
+__jakt_label_476:; __jakt_var_515.release_value(); }));
 };/*case end*/
-case 105: {
-auto&& __jakt_match_value = __jakt_match_variant.template get<typename lexer::Token::Guard>();
+case 77: {
+auto&& __jakt_match_value = __jakt_match_variant.template get<typename lexer::Token::If>();
 return JaktInternal::ExplicitValue(({ Optional<size_t> __jakt_var_516; {
 size_t indent = static_cast<size_t>(1ULL);
 if (((*this).line_has_indent())){
 (indent = static_cast<size_t>(0ULL));
 }
-__jakt_var_516 = indent; goto __jakt_label_478;
+__jakt_var_516 = indent; goto __jakt_label_477;
 
 }
-__jakt_label_478:; __jakt_var_516.release_value(); }));
+__jakt_label_477:; __jakt_var_516.release_value(); }));
+};/*case end*/
+case 105: {
+auto&& __jakt_match_value = __jakt_match_variant.template get<typename lexer::Token::Guard>();
+return JaktInternal::ExplicitValue(({ Optional<size_t> __jakt_var_517; {
+size_t indent = static_cast<size_t>(1ULL);
+if (((*this).line_has_indent())){
+(indent = static_cast<size_t>(0ULL));
+}
+__jakt_var_517 = indent; goto __jakt_label_478;
+
+}
+__jakt_label_478:; __jakt_var_517.release_value(); }));
 };/*case end*/
 default: {
 return JaktInternal::ExplicitValue(static_cast<size_t>(0ULL));
@@ -3019,76 +2940,76 @@ return JaktInternal::ExplicitValue(static_cast<size_t>(0ULL));
 ));
 TRY((((*this).replace_state( formatter::State { typename formatter::State::StatementContext(open_parens,open_curlies,open_squares,arrow_indents,allow_eol,inserted_comma, formatter::ExpressionMode { typename formatter::ExpressionMode::AtExpressionStart() } ,(JaktInternal::checked_add<size_t>(dedents_on_open_curly,added_indent))) } ))));
 ({auto& _jakt_ref = indent_change;_jakt_ref = JaktInternal::checked_add<i64>(_jakt_ref, (infallible_integer_cast<i64>((added_indent))));});
-__jakt_var_511 = formatter::FormattedToken(token,((*this).indent),(TRY((Array<u8>::create_with({' '})))),(TRY((Array<u8>::create_with({}))))); goto __jakt_label_473;
+__jakt_var_512 = formatter::FormattedToken(token,((*this).indent),(TRY((Array<u8>::create_with({' '})))),(TRY((Array<u8>::create_with({}))))); goto __jakt_label_473;
 
 }
-__jakt_label_473:; __jakt_var_511.release_value(); }));
+__jakt_label_473:; __jakt_var_512.release_value(); }));
 };/*case end*/
-case 69: {
-auto&& __jakt_match_value = __jakt_match_variant.template get<typename lexer::Token::Defer>();
-return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_517; {
+case 105: {
+auto&& __jakt_match_value = __jakt_match_variant.template get<typename lexer::Token::Guard>();
+return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_518; {
 size_t const added_indent = JAKT_RESOLVE_EXPLICIT_VALUE_OR_CONTROL_FLOW_RETURN_ONLY(([&]() -> JaktInternal::ExplicitValueOrControlFlow<size_t, ErrorOr<JaktInternal::Optional<formatter::FormattedToken>>>{
 auto&& __jakt_match_variant = token;
 switch(__jakt_match_variant.index()) {
 case 83: {
 auto&& __jakt_match_value = __jakt_match_variant.template get<typename lexer::Token::Match>();
-return JaktInternal::ExplicitValue(({ Optional<size_t> __jakt_var_518; {
-size_t indent = static_cast<size_t>(1ULL);
-if (((*this).line_has_indent())){
-(indent = static_cast<size_t>(0ULL));
-}
-__jakt_var_518 = indent; goto __jakt_label_480;
-
-}
-__jakt_label_480:; __jakt_var_518.release_value(); }));
-};/*case end*/
-case 74: {
-auto&& __jakt_match_value = __jakt_match_variant.template get<typename lexer::Token::For>();
 return JaktInternal::ExplicitValue(({ Optional<size_t> __jakt_var_519; {
 size_t indent = static_cast<size_t>(1ULL);
 if (((*this).line_has_indent())){
 (indent = static_cast<size_t>(0ULL));
 }
-__jakt_var_519 = indent; goto __jakt_label_481;
+__jakt_var_519 = indent; goto __jakt_label_480;
 
 }
-__jakt_label_481:; __jakt_var_519.release_value(); }));
+__jakt_label_480:; __jakt_var_519.release_value(); }));
 };/*case end*/
-case 103: {
-auto&& __jakt_match_value = __jakt_match_variant.template get<typename lexer::Token::While>();
+case 74: {
+auto&& __jakt_match_value = __jakt_match_variant.template get<typename lexer::Token::For>();
 return JaktInternal::ExplicitValue(({ Optional<size_t> __jakt_var_520; {
 size_t indent = static_cast<size_t>(1ULL);
 if (((*this).line_has_indent())){
 (indent = static_cast<size_t>(0ULL));
 }
-__jakt_var_520 = indent; goto __jakt_label_482;
+__jakt_var_520 = indent; goto __jakt_label_481;
 
 }
-__jakt_label_482:; __jakt_var_520.release_value(); }));
+__jakt_label_481:; __jakt_var_520.release_value(); }));
 };/*case end*/
-case 77: {
-auto&& __jakt_match_value = __jakt_match_variant.template get<typename lexer::Token::If>();
+case 103: {
+auto&& __jakt_match_value = __jakt_match_variant.template get<typename lexer::Token::While>();
 return JaktInternal::ExplicitValue(({ Optional<size_t> __jakt_var_521; {
 size_t indent = static_cast<size_t>(1ULL);
 if (((*this).line_has_indent())){
 (indent = static_cast<size_t>(0ULL));
 }
-__jakt_var_521 = indent; goto __jakt_label_483;
+__jakt_var_521 = indent; goto __jakt_label_482;
 
 }
-__jakt_label_483:; __jakt_var_521.release_value(); }));
+__jakt_label_482:; __jakt_var_521.release_value(); }));
 };/*case end*/
-case 105: {
-auto&& __jakt_match_value = __jakt_match_variant.template get<typename lexer::Token::Guard>();
+case 77: {
+auto&& __jakt_match_value = __jakt_match_variant.template get<typename lexer::Token::If>();
 return JaktInternal::ExplicitValue(({ Optional<size_t> __jakt_var_522; {
 size_t indent = static_cast<size_t>(1ULL);
 if (((*this).line_has_indent())){
 (indent = static_cast<size_t>(0ULL));
 }
-__jakt_var_522 = indent; goto __jakt_label_484;
+__jakt_var_522 = indent; goto __jakt_label_483;
 
 }
-__jakt_label_484:; __jakt_var_522.release_value(); }));
+__jakt_label_483:; __jakt_var_522.release_value(); }));
+};/*case end*/
+case 105: {
+auto&& __jakt_match_value = __jakt_match_variant.template get<typename lexer::Token::Guard>();
+return JaktInternal::ExplicitValue(({ Optional<size_t> __jakt_var_523; {
+size_t indent = static_cast<size_t>(1ULL);
+if (((*this).line_has_indent())){
+(indent = static_cast<size_t>(0ULL));
+}
+__jakt_var_523 = indent; goto __jakt_label_484;
+
+}
+__jakt_label_484:; __jakt_var_523.release_value(); }));
 };/*case end*/
 default: {
 return JaktInternal::ExplicitValue(static_cast<size_t>(0ULL));
@@ -3098,16 +3019,95 @@ return JaktInternal::ExplicitValue(static_cast<size_t>(0ULL));
 ));
 TRY((((*this).replace_state( formatter::State { typename formatter::State::StatementContext(open_parens,open_curlies,open_squares,arrow_indents,allow_eol,inserted_comma, formatter::ExpressionMode { typename formatter::ExpressionMode::AtExpressionStart() } ,(JaktInternal::checked_add<size_t>(dedents_on_open_curly,added_indent))) } ))));
 ({auto& _jakt_ref = indent_change;_jakt_ref = JaktInternal::checked_add<i64>(_jakt_ref, (infallible_integer_cast<i64>((added_indent))));});
-__jakt_var_517 = formatter::FormattedToken(token,((*this).indent),(TRY((Array<u8>::create_with({' '})))),(TRY((Array<u8>::create_with({}))))); goto __jakt_label_479;
+__jakt_var_518 = formatter::FormattedToken(token,((*this).indent),(TRY((Array<u8>::create_with({' '})))),(TRY((Array<u8>::create_with({}))))); goto __jakt_label_479;
 
 }
-__jakt_label_479:; __jakt_var_517.release_value(); }));
+__jakt_label_479:; __jakt_var_518.release_value(); }));
+};/*case end*/
+case 69: {
+auto&& __jakt_match_value = __jakt_match_variant.template get<typename lexer::Token::Defer>();
+return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_524; {
+size_t const added_indent = JAKT_RESOLVE_EXPLICIT_VALUE_OR_CONTROL_FLOW_RETURN_ONLY(([&]() -> JaktInternal::ExplicitValueOrControlFlow<size_t, ErrorOr<JaktInternal::Optional<formatter::FormattedToken>>>{
+auto&& __jakt_match_variant = token;
+switch(__jakt_match_variant.index()) {
+case 83: {
+auto&& __jakt_match_value = __jakt_match_variant.template get<typename lexer::Token::Match>();
+return JaktInternal::ExplicitValue(({ Optional<size_t> __jakt_var_525; {
+size_t indent = static_cast<size_t>(1ULL);
+if (((*this).line_has_indent())){
+(indent = static_cast<size_t>(0ULL));
+}
+__jakt_var_525 = indent; goto __jakt_label_486;
+
+}
+__jakt_label_486:; __jakt_var_525.release_value(); }));
+};/*case end*/
+case 74: {
+auto&& __jakt_match_value = __jakt_match_variant.template get<typename lexer::Token::For>();
+return JaktInternal::ExplicitValue(({ Optional<size_t> __jakt_var_526; {
+size_t indent = static_cast<size_t>(1ULL);
+if (((*this).line_has_indent())){
+(indent = static_cast<size_t>(0ULL));
+}
+__jakt_var_526 = indent; goto __jakt_label_487;
+
+}
+__jakt_label_487:; __jakt_var_526.release_value(); }));
+};/*case end*/
+case 103: {
+auto&& __jakt_match_value = __jakt_match_variant.template get<typename lexer::Token::While>();
+return JaktInternal::ExplicitValue(({ Optional<size_t> __jakt_var_527; {
+size_t indent = static_cast<size_t>(1ULL);
+if (((*this).line_has_indent())){
+(indent = static_cast<size_t>(0ULL));
+}
+__jakt_var_527 = indent; goto __jakt_label_488;
+
+}
+__jakt_label_488:; __jakt_var_527.release_value(); }));
+};/*case end*/
+case 77: {
+auto&& __jakt_match_value = __jakt_match_variant.template get<typename lexer::Token::If>();
+return JaktInternal::ExplicitValue(({ Optional<size_t> __jakt_var_528; {
+size_t indent = static_cast<size_t>(1ULL);
+if (((*this).line_has_indent())){
+(indent = static_cast<size_t>(0ULL));
+}
+__jakt_var_528 = indent; goto __jakt_label_489;
+
+}
+__jakt_label_489:; __jakt_var_528.release_value(); }));
+};/*case end*/
+case 105: {
+auto&& __jakt_match_value = __jakt_match_variant.template get<typename lexer::Token::Guard>();
+return JaktInternal::ExplicitValue(({ Optional<size_t> __jakt_var_529; {
+size_t indent = static_cast<size_t>(1ULL);
+if (((*this).line_has_indent())){
+(indent = static_cast<size_t>(0ULL));
+}
+__jakt_var_529 = indent; goto __jakt_label_490;
+
+}
+__jakt_label_490:; __jakt_var_529.release_value(); }));
+};/*case end*/
+default: {
+return JaktInternal::ExplicitValue(static_cast<size_t>(0ULL));
+};/*case end*/
+}/*switch end*/
+}()
+));
+TRY((((*this).replace_state( formatter::State { typename formatter::State::StatementContext(open_parens,open_curlies,open_squares,arrow_indents,allow_eol,inserted_comma, formatter::ExpressionMode { typename formatter::ExpressionMode::AtExpressionStart() } ,(JaktInternal::checked_add<size_t>(dedents_on_open_curly,added_indent))) } ))));
+({auto& _jakt_ref = indent_change;_jakt_ref = JaktInternal::checked_add<i64>(_jakt_ref, (infallible_integer_cast<i64>((added_indent))));});
+__jakt_var_524 = formatter::FormattedToken(token,((*this).indent),(TRY((Array<u8>::create_with({' '})))),(TRY((Array<u8>::create_with({}))))); goto __jakt_label_485;
+
+}
+__jakt_label_485:; __jakt_var_524.release_value(); }));
 };/*case end*/
 case 65: {
 auto&& __jakt_match_value = __jakt_match_variant.template get<typename lexer::Token::Catch>();
-return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_523; {
+return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_530; {
 TRY((((*this).replace_state( formatter::State { typename formatter::State::StatementContext(open_parens,open_curlies,open_squares,arrow_indents,allow_eol,inserted_comma, formatter::ExpressionMode { typename formatter::ExpressionMode::OutsideExpression() } ,dedents_on_open_curly) } ))));
-__jakt_var_523 = formatter::FormattedToken(token,((*this).indent),JAKT_RESOLVE_EXPLICIT_VALUE_OR_CONTROL_FLOW_RETURN_ONLY(([&]() -> JaktInternal::ExplicitValueOrControlFlow<JaktInternal::Array<u8>, ErrorOr<JaktInternal::Optional<formatter::FormattedToken>>>{
+__jakt_var_530 = formatter::FormattedToken(token,((*this).indent),JAKT_RESOLVE_EXPLICIT_VALUE_OR_CONTROL_FLOW_RETURN_ONLY(([&]() -> JaktInternal::ExplicitValueOrControlFlow<JaktInternal::Array<u8>, ErrorOr<JaktInternal::Optional<formatter::FormattedToken>>>{
 auto&& __jakt_match_variant = ((*this).peek(static_cast<i64>(0LL)));
 switch(__jakt_match_variant.index()) {
 case 56: {
@@ -3141,16 +3141,16 @@ return JaktInternal::ExplicitValue((TRY((Array<u8>::create_with({' '})))));
 };/*case end*/
 }/*switch end*/
 }()
-))); goto __jakt_label_485;
+))); goto __jakt_label_491;
 
 }
-__jakt_label_485:; __jakt_var_523.release_value(); }));
+__jakt_label_491:; __jakt_var_530.release_value(); }));
 };/*case end*/
 case 70: {
 auto&& __jakt_match_value = __jakt_match_variant.template get<typename lexer::Token::Else>();
-return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_524; {
+return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_531; {
 TRY((((*this).replace_state( formatter::State { typename formatter::State::StatementContext(open_parens,open_curlies,open_squares,arrow_indents,allow_eol,inserted_comma, formatter::ExpressionMode { typename formatter::ExpressionMode::OutsideExpression() } ,dedents_on_open_curly) } ))));
-__jakt_var_524 = formatter::FormattedToken(token,((*this).indent),JAKT_RESOLVE_EXPLICIT_VALUE_OR_CONTROL_FLOW_RETURN_ONLY(([&]() -> JaktInternal::ExplicitValueOrControlFlow<JaktInternal::Array<u8>, ErrorOr<JaktInternal::Optional<formatter::FormattedToken>>>{
+__jakt_var_531 = formatter::FormattedToken(token,((*this).indent),JAKT_RESOLVE_EXPLICIT_VALUE_OR_CONTROL_FLOW_RETURN_ONLY(([&]() -> JaktInternal::ExplicitValueOrControlFlow<JaktInternal::Array<u8>, ErrorOr<JaktInternal::Optional<formatter::FormattedToken>>>{
 auto&& __jakt_match_variant = ((*this).peek(static_cast<i64>(0LL)));
 switch(__jakt_match_variant.index()) {
 case 56: {
@@ -3184,13 +3184,13 @@ return JaktInternal::ExplicitValue((TRY((Array<u8>::create_with({' '})))));
 };/*case end*/
 }/*switch end*/
 }()
-))); goto __jakt_label_486;
+))); goto __jakt_label_492;
 
 }
-__jakt_label_486:; __jakt_var_524.release_value(); }));
+__jakt_label_492:; __jakt_var_531.release_value(); }));
 };/*case end*/
 case 56: {
-auto&& __jakt_match_value = __jakt_match_variant.template get<lexer::Token::Eol>();return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_525; {
+auto&& __jakt_match_value = __jakt_match_variant.template get<lexer::Token::Eol>();return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_532; {
 if ((((expression_mode).index() == 1 /* BeforeExpressions */) && ((((*this).peek(static_cast<i64>(0LL)))).index() == 56 /* Eol */))){
 return (TRY((((*this).next()))));
 }
@@ -3224,25 +3224,25 @@ else if (((((((*this).dedents_to_skip)).last()).value()) > static_cast<size_t>(0
 }
 
 TRY((((*this).replace_state( formatter::State { typename formatter::State::StatementContext(open_parens,open_curlies,open_squares,new_arrow_indents,new_allow_eol,inserted_comma,new_expression_mode,dedents_on_open_curly) } ))));
-__jakt_var_525 = formatter::FormattedToken(token,((*this).indent),(TRY((Array<u8>::create_with({})))),(TRY((Array<u8>::create_with({}))))); goto __jakt_label_487;
+__jakt_var_532 = formatter::FormattedToken(token,((*this).indent),(TRY((Array<u8>::create_with({})))),(TRY((Array<u8>::create_with({}))))); goto __jakt_label_493;
 
 }
-__jakt_label_487:; __jakt_var_525.release_value(); }));
+__jakt_label_493:; __jakt_var_532.release_value(); }));
 };/*case end*/
 case 75: {
 auto&& __jakt_match_value = __jakt_match_variant.template get<typename lexer::Token::Function>();
-return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_526; {
+return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_533; {
 TRY((((*this).push_state( formatter::State { typename formatter::State::FunctionTypeContext(false) } ))));
-__jakt_var_526 = formatter::FormattedToken(token,((*this).indent),(TRY((Array<u8>::create_with({})))),(TRY((Array<u8>::create_with({}))))); goto __jakt_label_488;
+__jakt_var_533 = formatter::FormattedToken(token,((*this).indent),(TRY((Array<u8>::create_with({})))),(TRY((Array<u8>::create_with({}))))); goto __jakt_label_494;
 
 }
-__jakt_label_488:; __jakt_var_526.release_value(); }));
+__jakt_label_494:; __jakt_var_533.release_value(); }));
 };/*case end*/
 case 53: {
 auto&& __jakt_match_value = __jakt_match_variant.template get<typename lexer::Token::Comma>();
-return JaktInternal::ExplicitValue(({ Optional<JaktInternal::Optional<formatter::FormattedToken>> __jakt_var_527; {
+return JaktInternal::ExplicitValue(({ Optional<JaktInternal::Optional<formatter::FormattedToken>> __jakt_var_534; {
 TRY((((*this).replace_state( formatter::State { typename formatter::State::StatementContext(open_parens,open_curlies,open_squares,arrow_indents,allow_eol,inserted_comma, formatter::ExpressionMode { typename formatter::ExpressionMode::AtExpressionStart() } ,dedents_on_open_curly) } ))));
-__jakt_var_527 = JAKT_RESOLVE_EXPLICIT_VALUE_OR_CONTROL_FLOW_RETURN_ONLY(([&]() -> JaktInternal::ExplicitValueOrControlFlow<JaktInternal::Optional<formatter::FormattedToken>, ErrorOr<JaktInternal::Optional<formatter::FormattedToken>>>{
+__jakt_var_534 = JAKT_RESOLVE_EXPLICIT_VALUE_OR_CONTROL_FLOW_RETURN_ONLY(([&]() -> JaktInternal::ExplicitValueOrControlFlow<JaktInternal::Optional<formatter::FormattedToken>, ErrorOr<JaktInternal::Optional<formatter::FormattedToken>>>{
 auto&& __jakt_match_variant = ((*this).peek(static_cast<i64>(0LL)));
 switch(__jakt_match_variant.index()) {
 case 56: {
@@ -3253,10 +3253,10 @@ return JaktInternal::ExplicitValue(formatter::FormattedToken(token,((*this).inde
 };/*case end*/
 }/*switch end*/
 }()
-)); goto __jakt_label_489;
+)); goto __jakt_label_495;
 
 }
-__jakt_label_489:; __jakt_var_527.release_value(); }));
+__jakt_label_495:; __jakt_var_534.release_value(); }));
 };/*case end*/
 case 92: {
 auto&& __jakt_match_value = __jakt_match_variant.template get<typename lexer::Token::Return>();
@@ -3265,28 +3265,28 @@ auto&& __jakt_match_variant = ((*this).peek(static_cast<i64>(0LL)));
 switch(__jakt_match_variant.index()) {
 case 5: {
 auto&& __jakt_match_value = __jakt_match_variant.template get<typename lexer::Token::Semicolon>();
-return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_528; {
+return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_535; {
 TRY((((*this).replace_state( formatter::State { typename formatter::State::StatementContext(open_parens,open_curlies,open_squares,arrow_indents,allow_eol,inserted_comma, formatter::ExpressionMode { typename formatter::ExpressionMode::OutsideExpression() } ,dedents_on_open_curly) } ))));
-__jakt_var_528 = formatter::FormattedToken(token,((*this).indent),(TRY((Array<u8>::create_with({})))),(TRY((Array<u8>::create_with({}))))); goto __jakt_label_490;
+__jakt_var_535 = formatter::FormattedToken(token,((*this).indent),(TRY((Array<u8>::create_with({})))),(TRY((Array<u8>::create_with({}))))); goto __jakt_label_496;
 
 }
-__jakt_label_490:; __jakt_var_528.release_value(); }));
+__jakt_label_496:; __jakt_var_535.release_value(); }));
 };/*case end*/
 case 56: {
-auto&& __jakt_match_value = __jakt_match_variant.template get<lexer::Token::Eol>();return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_529; {
+auto&& __jakt_match_value = __jakt_match_variant.template get<lexer::Token::Eol>();return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_536; {
 TRY((((*this).replace_state( formatter::State { typename formatter::State::StatementContext(open_parens,open_curlies,open_squares,arrow_indents,allow_eol,inserted_comma, formatter::ExpressionMode { typename formatter::ExpressionMode::OutsideExpression() } ,dedents_on_open_curly) } ))));
-__jakt_var_529 = formatter::FormattedToken(token,((*this).indent),(TRY((Array<u8>::create_with({})))),(TRY((Array<u8>::create_with({}))))); goto __jakt_label_491;
+__jakt_var_536 = formatter::FormattedToken(token,((*this).indent),(TRY((Array<u8>::create_with({})))),(TRY((Array<u8>::create_with({}))))); goto __jakt_label_497;
 
 }
-__jakt_label_491:; __jakt_var_529.release_value(); }));
+__jakt_label_497:; __jakt_var_536.release_value(); }));
 };/*case end*/
 default: {
-return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_530; {
+return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_537; {
 TRY((((*this).replace_state( formatter::State { typename formatter::State::StatementContext(open_parens,open_curlies,open_squares,arrow_indents,allow_eol,inserted_comma, formatter::ExpressionMode { typename formatter::ExpressionMode::AtExpressionStart() } ,dedents_on_open_curly) } ))));
-__jakt_var_530 = formatter::FormattedToken(token,((*this).indent),(TRY((Array<u8>::create_with({' '})))),(TRY((Array<u8>::create_with({}))))); goto __jakt_label_492;
+__jakt_var_537 = formatter::FormattedToken(token,((*this).indent),(TRY((Array<u8>::create_with({' '})))),(TRY((Array<u8>::create_with({}))))); goto __jakt_label_498;
 
 }
-__jakt_label_492:; __jakt_var_530.release_value(); }));
+__jakt_label_498:; __jakt_var_537.release_value(); }));
 };/*case end*/
 }/*switch end*/
 }()
@@ -3299,28 +3299,28 @@ auto&& __jakt_match_variant = ((*this).peek(static_cast<i64>(0LL)));
 switch(__jakt_match_variant.index()) {
 case 5: {
 auto&& __jakt_match_value = __jakt_match_variant.template get<typename lexer::Token::Semicolon>();
-return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_531; {
+return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_538; {
 TRY((((*this).replace_state( formatter::State { typename formatter::State::StatementContext(open_parens,open_curlies,open_squares,arrow_indents,allow_eol,inserted_comma, formatter::ExpressionMode { typename formatter::ExpressionMode::OutsideExpression() } ,dedents_on_open_curly) } ))));
-__jakt_var_531 = formatter::FormattedToken(token,((*this).indent),(TRY((Array<u8>::create_with({})))),(TRY((Array<u8>::create_with({}))))); goto __jakt_label_493;
+__jakt_var_538 = formatter::FormattedToken(token,((*this).indent),(TRY((Array<u8>::create_with({})))),(TRY((Array<u8>::create_with({}))))); goto __jakt_label_499;
 
 }
-__jakt_label_493:; __jakt_var_531.release_value(); }));
+__jakt_label_499:; __jakt_var_538.release_value(); }));
 };/*case end*/
 case 56: {
-auto&& __jakt_match_value = __jakt_match_variant.template get<lexer::Token::Eol>();return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_532; {
+auto&& __jakt_match_value = __jakt_match_variant.template get<lexer::Token::Eol>();return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_539; {
 TRY((((*this).replace_state( formatter::State { typename formatter::State::StatementContext(open_parens,open_curlies,open_squares,arrow_indents,allow_eol,inserted_comma, formatter::ExpressionMode { typename formatter::ExpressionMode::OutsideExpression() } ,dedents_on_open_curly) } ))));
-__jakt_var_532 = formatter::FormattedToken(token,((*this).indent),(TRY((Array<u8>::create_with({})))),(TRY((Array<u8>::create_with({}))))); goto __jakt_label_494;
+__jakt_var_539 = formatter::FormattedToken(token,((*this).indent),(TRY((Array<u8>::create_with({})))),(TRY((Array<u8>::create_with({}))))); goto __jakt_label_500;
 
 }
-__jakt_label_494:; __jakt_var_532.release_value(); }));
+__jakt_label_500:; __jakt_var_539.release_value(); }));
 };/*case end*/
 default: {
-return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_533; {
+return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_540; {
 TRY((((*this).replace_state( formatter::State { typename formatter::State::StatementContext(open_parens,open_curlies,open_squares,arrow_indents,allow_eol,inserted_comma, formatter::ExpressionMode { typename formatter::ExpressionMode::AtExpressionStart() } ,dedents_on_open_curly) } ))));
-__jakt_var_533 = formatter::FormattedToken(token,((*this).indent),(TRY((Array<u8>::create_with({' '})))),(TRY((Array<u8>::create_with({}))))); goto __jakt_label_495;
+__jakt_var_540 = formatter::FormattedToken(token,((*this).indent),(TRY((Array<u8>::create_with({' '})))),(TRY((Array<u8>::create_with({}))))); goto __jakt_label_501;
 
 }
-__jakt_label_495:; __jakt_var_533.release_value(); }));
+__jakt_label_501:; __jakt_var_540.release_value(); }));
 };/*case end*/
 }/*switch end*/
 }()
@@ -3333,28 +3333,28 @@ auto&& __jakt_match_variant = ((*this).peek(static_cast<i64>(0LL)));
 switch(__jakt_match_variant.index()) {
 case 5: {
 auto&& __jakt_match_value = __jakt_match_variant.template get<typename lexer::Token::Semicolon>();
-return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_534; {
+return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_541; {
 TRY((((*this).replace_state( formatter::State { typename formatter::State::StatementContext(open_parens,open_curlies,open_squares,arrow_indents,allow_eol,inserted_comma, formatter::ExpressionMode { typename formatter::ExpressionMode::OutsideExpression() } ,dedents_on_open_curly) } ))));
-__jakt_var_534 = formatter::FormattedToken(token,((*this).indent),(TRY((Array<u8>::create_with({})))),(TRY((Array<u8>::create_with({}))))); goto __jakt_label_496;
+__jakt_var_541 = formatter::FormattedToken(token,((*this).indent),(TRY((Array<u8>::create_with({})))),(TRY((Array<u8>::create_with({}))))); goto __jakt_label_502;
 
 }
-__jakt_label_496:; __jakt_var_534.release_value(); }));
+__jakt_label_502:; __jakt_var_541.release_value(); }));
 };/*case end*/
 case 56: {
-auto&& __jakt_match_value = __jakt_match_variant.template get<lexer::Token::Eol>();return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_535; {
+auto&& __jakt_match_value = __jakt_match_variant.template get<lexer::Token::Eol>();return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_542; {
 TRY((((*this).replace_state( formatter::State { typename formatter::State::StatementContext(open_parens,open_curlies,open_squares,arrow_indents,allow_eol,inserted_comma, formatter::ExpressionMode { typename formatter::ExpressionMode::OutsideExpression() } ,dedents_on_open_curly) } ))));
-__jakt_var_535 = formatter::FormattedToken(token,((*this).indent),(TRY((Array<u8>::create_with({})))),(TRY((Array<u8>::create_with({}))))); goto __jakt_label_497;
+__jakt_var_542 = formatter::FormattedToken(token,((*this).indent),(TRY((Array<u8>::create_with({})))),(TRY((Array<u8>::create_with({}))))); goto __jakt_label_503;
 
 }
-__jakt_label_497:; __jakt_var_535.release_value(); }));
+__jakt_label_503:; __jakt_var_542.release_value(); }));
 };/*case end*/
 default: {
-return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_536; {
+return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_543; {
 TRY((((*this).replace_state( formatter::State { typename formatter::State::StatementContext(open_parens,open_curlies,open_squares,arrow_indents,allow_eol,inserted_comma, formatter::ExpressionMode { typename formatter::ExpressionMode::AtExpressionStart() } ,dedents_on_open_curly) } ))));
-__jakt_var_536 = formatter::FormattedToken(token,((*this).indent),(TRY((Array<u8>::create_with({' '})))),(TRY((Array<u8>::create_with({}))))); goto __jakt_label_498;
+__jakt_var_543 = formatter::FormattedToken(token,((*this).indent),(TRY((Array<u8>::create_with({' '})))),(TRY((Array<u8>::create_with({}))))); goto __jakt_label_504;
 
 }
-__jakt_label_498:; __jakt_var_536.release_value(); }));
+__jakt_label_504:; __jakt_var_543.release_value(); }));
 };/*case end*/
 }/*switch end*/
 }()
@@ -3362,7 +3362,7 @@ __jakt_label_498:; __jakt_var_536.release_value(); }));
 };/*case end*/
 case 58: {
 auto&& __jakt_match_value = __jakt_match_variant.template get<typename lexer::Token::FatArrow>();
-return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_537; {
+return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_544; {
 bool const next_is_eol = ((((*this).peek(static_cast<i64>(0LL)))).index() == 56 /* Eol */);
 size_t new_arrow_indents = arrow_indents;
 if (next_is_eol){
@@ -3387,67 +3387,67 @@ return JaktInternal::ExplicitValue( formatter::ExpressionMode { typename formatt
 }/*switch end*/
 }()
 )),dedents_on_open_curly) } ))));
-__jakt_var_537 = formatter::FormattedToken(token,((*this).indent),(TRY((Array<u8>::create_with({' '})))),(TRY((Array<u8>::create_with({' '}))))); goto __jakt_label_499;
+__jakt_var_544 = formatter::FormattedToken(token,((*this).indent),(TRY((Array<u8>::create_with({' '})))),(TRY((Array<u8>::create_with({' '}))))); goto __jakt_label_505;
 
 }
-__jakt_label_499:; __jakt_var_537.release_value(); }));
+__jakt_label_505:; __jakt_var_544.release_value(); }));
 };/*case end*/
 case 12: {
 auto&& __jakt_match_value = __jakt_match_variant.template get<typename lexer::Token::LSquare>();
-return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_538; {
+return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_545; {
 TRY((((*this).replace_state( formatter::State { typename formatter::State::StatementContext(open_parens,open_curlies,(JaktInternal::checked_add<size_t>(open_squares,static_cast<size_t>(1ULL))),arrow_indents,allow_eol,inserted_comma, formatter::ExpressionMode { typename formatter::ExpressionMode::AtExpressionStart() } ,dedents_on_open_curly) } ))));
-__jakt_var_538 = formatter::FormattedToken(token,((*this).indent),(TRY((Array<u8>::create_with({})))),(TRY((Array<u8>::create_with({}))))); goto __jakt_label_500;
+__jakt_var_545 = formatter::FormattedToken(token,((*this).indent),(TRY((Array<u8>::create_with({})))),(TRY((Array<u8>::create_with({}))))); goto __jakt_label_506;
 
 }
-__jakt_label_500:; __jakt_var_538.release_value(); }));
+__jakt_label_506:; __jakt_var_545.release_value(); }));
 };/*case end*/
 case 13: {
 auto&& __jakt_match_value = __jakt_match_variant.template get<typename lexer::Token::RSquare>();
-return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_539; {
+return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_546; {
 if ((open_squares == static_cast<size_t>(0ULL))){
 ((*this).pop_state());
 ((((*this).index)--));
 return (TRY((((*this).next_impl(true)))));
 }
 TRY((((*this).replace_state( formatter::State { typename formatter::State::StatementContext(open_parens,open_curlies,(JaktInternal::checked_sub<size_t>(open_squares,static_cast<size_t>(1ULL))),arrow_indents,allow_eol,inserted_comma, formatter::ExpressionMode { typename formatter::ExpressionMode::AtExpressionStart() } ,dedents_on_open_curly) } ))));
-__jakt_var_539 = formatter::FormattedToken(token,((*this).indent),(TRY((Array<u8>::create_with({})))),(TRY((Array<u8>::create_with({}))))); goto __jakt_label_501;
+__jakt_var_546 = formatter::FormattedToken(token,((*this).indent),(TRY((Array<u8>::create_with({})))),(TRY((Array<u8>::create_with({}))))); goto __jakt_label_507;
 
 }
-__jakt_label_501:; __jakt_var_539.release_value(); }));
+__jakt_label_507:; __jakt_var_546.release_value(); }));
 };/*case end*/
 case 8: {
 auto&& __jakt_match_value = __jakt_match_variant.template get<typename lexer::Token::LParen>();
-return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_540; {
+return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_547; {
 TRY((((*this).replace_state( formatter::State { typename formatter::State::StatementContext((JaktInternal::checked_add<size_t>(open_parens,static_cast<size_t>(1ULL))),open_curlies,open_squares,arrow_indents,allow_eol,inserted_comma, formatter::ExpressionMode { typename formatter::ExpressionMode::AtExpressionStart() } ,dedents_on_open_curly) } ))));
-__jakt_var_540 = formatter::FormattedToken(token,((*this).indent),(TRY((Array<u8>::create_with({})))),(TRY((Array<u8>::create_with({}))))); goto __jakt_label_502;
+__jakt_var_547 = formatter::FormattedToken(token,((*this).indent),(TRY((Array<u8>::create_with({})))),(TRY((Array<u8>::create_with({}))))); goto __jakt_label_508;
 
 }
-__jakt_label_502:; __jakt_var_540.release_value(); }));
+__jakt_label_508:; __jakt_var_547.release_value(); }));
 };/*case end*/
 case 9: {
 auto&& __jakt_match_value = __jakt_match_variant.template get<typename lexer::Token::RParen>();
-return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_541; {
+return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_548; {
 if ((open_parens == static_cast<size_t>(0ULL))){
 ((*this).pop_state());
 ((((*this).index)--));
 return (TRY((((*this).next_impl(true)))));
 }
 TRY((((*this).replace_state( formatter::State { typename formatter::State::StatementContext((JaktInternal::checked_sub<size_t>(open_parens,static_cast<size_t>(1ULL))),open_curlies,open_squares,arrow_indents,allow_eol,inserted_comma, formatter::ExpressionMode { typename formatter::ExpressionMode::InExpression() } ,dedents_on_open_curly) } ))));
-__jakt_var_541 = formatter::FormattedToken(token,((*this).indent),(TRY((Array<u8>::create_with({})))),(TRY((Array<u8>::create_with({}))))); goto __jakt_label_503;
+__jakt_var_548 = formatter::FormattedToken(token,((*this).indent),(TRY((Array<u8>::create_with({})))),(TRY((Array<u8>::create_with({}))))); goto __jakt_label_509;
 
 }
-__jakt_label_503:; __jakt_var_541.release_value(); }));
+__jakt_label_509:; __jakt_var_548.release_value(); }));
 };/*case end*/
 case 10: {
 auto&& __jakt_match_value = __jakt_match_variant.template get<typename lexer::Token::LCurly>();
-return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_542; {
+return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_549; {
 size_t dedented = static_cast<size_t>(0ULL);
 if ((dedents_on_open_curly > static_cast<size_t>(0ULL))){
 ({auto& _jakt_ref = ((*this).indent);_jakt_ref = JaktInternal::checked_sub<size_t>(_jakt_ref, static_cast<size_t>(1ULL));});
 (dedented = static_cast<size_t>(1ULL));
 }
 TRY((((*this).replace_state( formatter::State { typename formatter::State::StatementContext(open_parens,(JaktInternal::checked_add<size_t>(open_curlies,static_cast<size_t>(1ULL))),open_squares,arrow_indents,allow_eol,inserted_comma, formatter::ExpressionMode { typename formatter::ExpressionMode::AtExpressionStart() } ,(JaktInternal::checked_sub<size_t>(dedents_on_open_curly,dedented))) } ))));
-__jakt_var_542 = formatter::FormattedToken(token,((*this).indent),JAKT_RESOLVE_EXPLICIT_VALUE_OR_CONTROL_FLOW_RETURN_ONLY(([&]() -> JaktInternal::ExplicitValueOrControlFlow<JaktInternal::Array<u8>, ErrorOr<JaktInternal::Optional<formatter::FormattedToken>>>{
+__jakt_var_549 = formatter::FormattedToken(token,((*this).indent),JAKT_RESOLVE_EXPLICIT_VALUE_OR_CONTROL_FLOW_RETURN_ONLY(([&]() -> JaktInternal::ExplicitValueOrControlFlow<JaktInternal::Array<u8>, ErrorOr<JaktInternal::Optional<formatter::FormattedToken>>>{
 auto&& __jakt_match_variant = expression_mode;
 switch(__jakt_match_variant.index()) {
 case 2: {
@@ -3514,21 +3514,21 @@ return JaktInternal::ExplicitValue((TRY((Array<u8>::create_with({' '})))));
 };/*case end*/
 }/*switch end*/
 }()
-))); goto __jakt_label_504;
+))); goto __jakt_label_510;
 
 }
-__jakt_label_504:; __jakt_var_542.release_value(); }));
+__jakt_label_510:; __jakt_var_549.release_value(); }));
 };/*case end*/
 case 11: {
 auto&& __jakt_match_value = __jakt_match_variant.template get<typename lexer::Token::RCurly>();
-return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_543; {
+return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_550; {
 if ((open_curlies == static_cast<size_t>(0ULL))){
 ((*this).pop_state());
 ({auto& _jakt_ref = ((*this).index);_jakt_ref = JaktInternal::checked_sub<size_t>(_jakt_ref, static_cast<size_t>(1ULL));});
 return (TRY((((*this).next_impl(true)))));
 }
 TRY((((*this).replace_state( formatter::State { typename formatter::State::StatementContext(open_parens,(JaktInternal::checked_sub<size_t>(open_curlies,static_cast<size_t>(1ULL))),open_squares,arrow_indents,allow_eol,inserted_comma, formatter::ExpressionMode { typename formatter::ExpressionMode::InExpression() } ,dedents_on_open_curly) } ))));
-__jakt_var_543 = formatter::FormattedToken(token,((*this).indent),(TRY((Array<u8>::create_with({})))),JAKT_RESOLVE_EXPLICIT_VALUE_OR_CONTROL_FLOW_RETURN_ONLY(([&]() -> JaktInternal::ExplicitValueOrControlFlow<JaktInternal::Array<u8>, ErrorOr<JaktInternal::Optional<formatter::FormattedToken>>>{
+__jakt_var_550 = formatter::FormattedToken(token,((*this).indent),(TRY((Array<u8>::create_with({})))),JAKT_RESOLVE_EXPLICIT_VALUE_OR_CONTROL_FLOW_RETURN_ONLY(([&]() -> JaktInternal::ExplicitValueOrControlFlow<JaktInternal::Array<u8>, ErrorOr<JaktInternal::Optional<formatter::FormattedToken>>>{
 auto&& __jakt_match_variant = ((*this).peek((-(static_cast<i64>(1LL)))));
 switch(__jakt_match_variant.index()) {
 case 56: {
@@ -3543,25 +3543,25 @@ return JaktInternal::ExplicitValue((TRY((Array<u8>::create_with({' '})))));
 };/*case end*/
 }/*switch end*/
 }()
-))); goto __jakt_label_505;
+))); goto __jakt_label_511;
 
 }
-__jakt_label_505:; __jakt_var_543.release_value(); }));
+__jakt_label_511:; __jakt_var_550.release_value(); }));
 };/*case end*/
 case 86: {
 auto&& __jakt_match_value = __jakt_match_variant.template get<typename lexer::Token::Not>();
-return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_544; {
+return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_551; {
 TRY((((*this).replace_state( formatter::State { typename formatter::State::StatementContext(open_parens,open_curlies,open_squares,arrow_indents,allow_eol,inserted_comma, formatter::ExpressionMode { typename formatter::ExpressionMode::AtExpressionStart() } ,dedents_on_open_curly) } ))));
-__jakt_var_544 = formatter::FormattedToken(token,((*this).indent),(TRY((Array<u8>::create_with({' '})))),(TRY((Array<u8>::create_with({}))))); goto __jakt_label_506;
+__jakt_var_551 = formatter::FormattedToken(token,((*this).indent),(TRY((Array<u8>::create_with({' '})))),(TRY((Array<u8>::create_with({}))))); goto __jakt_label_512;
 
 }
-__jakt_label_506:; __jakt_var_544.release_value(); }));
+__jakt_label_512:; __jakt_var_551.release_value(); }));
 };/*case end*/
 case 6: {
 auto&& __jakt_match_value = __jakt_match_variant.template get<typename lexer::Token::Colon>();
-return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_545; {
+return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_552; {
 TRY((((*this).replace_state( formatter::State { typename formatter::State::StatementContext(open_parens,open_curlies,open_squares,arrow_indents,allow_eol,inserted_comma, formatter::ExpressionMode { typename formatter::ExpressionMode::AtExpressionStart() } ,dedents_on_open_curly) } ))));
-__jakt_var_545 = formatter::FormattedToken(token,((*this).indent),JAKT_RESOLVE_EXPLICIT_VALUE_OR_CONTROL_FLOW_RETURN_ONLY(([&]() -> JaktInternal::ExplicitValueOrControlFlow<JaktInternal::Array<u8>, ErrorOr<JaktInternal::Optional<formatter::FormattedToken>>>{
+__jakt_var_552 = formatter::FormattedToken(token,((*this).indent),JAKT_RESOLVE_EXPLICIT_VALUE_OR_CONTROL_FLOW_RETURN_ONLY(([&]() -> JaktInternal::ExplicitValueOrControlFlow<JaktInternal::Array<u8>, ErrorOr<JaktInternal::Optional<formatter::FormattedToken>>>{
 auto&& __jakt_match_variant = ((*this).peek(static_cast<i64>(0LL)));
 switch(__jakt_match_variant.index()) {
 case 13: {
@@ -3573,14 +3573,14 @@ return JaktInternal::ExplicitValue((TRY((Array<u8>::create_with({' '})))));
 };/*case end*/
 }/*switch end*/
 }()
-)),(TRY((Array<u8>::create_with({}))))); goto __jakt_label_507;
+)),(TRY((Array<u8>::create_with({}))))); goto __jakt_label_513;
 
 }
-__jakt_label_507:; __jakt_var_545.release_value(); }));
+__jakt_label_513:; __jakt_var_552.release_value(); }));
 };/*case end*/
 case 16: {
 auto&& __jakt_match_value = __jakt_match_variant.template get<typename lexer::Token::Minus>();
-return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_546; {
+return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_553; {
 TRY((((*this).replace_state( formatter::State { typename formatter::State::StatementContext(open_parens,open_curlies,open_squares,arrow_indents,allow_eol,inserted_comma, formatter::ExpressionMode { typename formatter::ExpressionMode::AtExpressionStart() } ,dedents_on_open_curly) } ))));
 JaktInternal::Array<u8> const trivia = JAKT_RESOLVE_EXPLICIT_VALUE_OR_CONTROL_FLOW_RETURN_ONLY(([&]() -> JaktInternal::ExplicitValueOrControlFlow<JaktInternal::Array<u8>, ErrorOr<JaktInternal::Optional<formatter::FormattedToken>>>{
 auto&& __jakt_match_variant = expression_mode;
@@ -3595,14 +3595,14 @@ return JaktInternal::ExplicitValue((TRY((Array<u8>::create_with({})))));
 }/*switch end*/
 }()
 ));
-__jakt_var_546 = formatter::FormattedToken(token,((*this).indent),trivia,trivia); goto __jakt_label_508;
+__jakt_var_553 = formatter::FormattedToken(token,((*this).indent),trivia,trivia); goto __jakt_label_514;
 
 }
-__jakt_label_508:; __jakt_var_546.release_value(); }));
+__jakt_label_514:; __jakt_var_553.release_value(); }));
 };/*case end*/
 case 37: {
 auto&& __jakt_match_value = __jakt_match_variant.template get<typename lexer::Token::Asterisk>();
-return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_547; {
+return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_554; {
 TRY((((*this).replace_state( formatter::State { typename formatter::State::StatementContext(open_parens,open_curlies,open_squares,arrow_indents,allow_eol,inserted_comma, formatter::ExpressionMode { typename formatter::ExpressionMode::AtExpressionStart() } ,dedents_on_open_curly) } ))));
 JaktInternal::Array<u8> const trivia = JAKT_RESOLVE_EXPLICIT_VALUE_OR_CONTROL_FLOW_RETURN_ONLY(([&]() -> JaktInternal::ExplicitValueOrControlFlow<JaktInternal::Array<u8>, ErrorOr<JaktInternal::Optional<formatter::FormattedToken>>>{
 auto&& __jakt_match_variant = expression_mode;
@@ -3617,14 +3617,14 @@ return JaktInternal::ExplicitValue((TRY((Array<u8>::create_with({})))));
 }/*switch end*/
 }()
 ));
-__jakt_var_547 = formatter::FormattedToken(token,((*this).indent),trivia,trivia); goto __jakt_label_509;
+__jakt_var_554 = formatter::FormattedToken(token,((*this).indent),trivia,trivia); goto __jakt_label_515;
 
 }
-__jakt_label_509:; __jakt_var_547.release_value(); }));
+__jakt_label_515:; __jakt_var_554.release_value(); }));
 };/*case end*/
 case 38: {
 auto&& __jakt_match_value = __jakt_match_variant.template get<typename lexer::Token::Ampersand>();
-return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_548; {
+return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_555; {
 TRY((((*this).replace_state( formatter::State { typename formatter::State::StatementContext(open_parens,open_curlies,open_squares,arrow_indents,allow_eol,inserted_comma, formatter::ExpressionMode { typename formatter::ExpressionMode::AtExpressionStart() } ,dedents_on_open_curly) } ))));
 JaktInternal::Array<u8> const trivia = JAKT_RESOLVE_EXPLICIT_VALUE_OR_CONTROL_FLOW_RETURN_ONLY(([&]() -> JaktInternal::ExplicitValueOrControlFlow<JaktInternal::Array<u8>, ErrorOr<JaktInternal::Optional<formatter::FormattedToken>>>{
 auto&& __jakt_match_variant = expression_mode;
@@ -3639,298 +3639,298 @@ return JaktInternal::ExplicitValue((TRY((Array<u8>::create_with({})))));
 }/*switch end*/
 }()
 ));
-__jakt_var_548 = formatter::FormattedToken(token,((*this).indent),trivia,trivia); goto __jakt_label_510;
+__jakt_var_555 = formatter::FormattedToken(token,((*this).indent),trivia,trivia); goto __jakt_label_516;
 
 }
-__jakt_label_510:; __jakt_var_548.release_value(); }));
+__jakt_label_516:; __jakt_var_555.release_value(); }));
 };/*case end*/
 case 14: {
 auto&& __jakt_match_value = __jakt_match_variant.template get<typename lexer::Token::PercentSign>();
-return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_549; {
+return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_556; {
 TRY((((*this).replace_state( formatter::State { typename formatter::State::StatementContext(open_parens,open_curlies,open_squares,arrow_indents,allow_eol,inserted_comma, formatter::ExpressionMode { typename formatter::ExpressionMode::AtExpressionStart() } ,dedents_on_open_curly) } ))));
-__jakt_var_549 = formatter::FormattedToken(token,((*this).indent),(TRY((Array<u8>::create_with({' '})))),(TRY((Array<u8>::create_with({' '}))))); goto __jakt_label_511;
+__jakt_var_556 = formatter::FormattedToken(token,((*this).indent),(TRY((Array<u8>::create_with({' '})))),(TRY((Array<u8>::create_with({' '}))))); goto __jakt_label_517;
 
 }
-__jakt_label_511:; __jakt_var_549.release_value(); }));
+__jakt_label_517:; __jakt_var_556.release_value(); }));
 };/*case end*/
 case 15: {
 auto&& __jakt_match_value = __jakt_match_variant.template get<typename lexer::Token::Plus>();
-return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_550; {
+return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_557; {
 TRY((((*this).replace_state( formatter::State { typename formatter::State::StatementContext(open_parens,open_curlies,open_squares,arrow_indents,allow_eol,inserted_comma, formatter::ExpressionMode { typename formatter::ExpressionMode::AtExpressionStart() } ,dedents_on_open_curly) } ))));
-__jakt_var_550 = formatter::FormattedToken(token,((*this).indent),(TRY((Array<u8>::create_with({' '})))),(TRY((Array<u8>::create_with({' '}))))); goto __jakt_label_512;
+__jakt_var_557 = formatter::FormattedToken(token,((*this).indent),(TRY((Array<u8>::create_with({' '})))),(TRY((Array<u8>::create_with({' '}))))); goto __jakt_label_518;
 
 }
-__jakt_label_512:; __jakt_var_550.release_value(); }));
+__jakt_label_518:; __jakt_var_557.release_value(); }));
 };/*case end*/
 case 17: {
 auto&& __jakt_match_value = __jakt_match_variant.template get<typename lexer::Token::Equal>();
-return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_551; {
+return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_558; {
 TRY((((*this).replace_state( formatter::State { typename formatter::State::StatementContext(open_parens,open_curlies,open_squares,arrow_indents,allow_eol,inserted_comma, formatter::ExpressionMode { typename formatter::ExpressionMode::AtExpressionStart() } ,dedents_on_open_curly) } ))));
-__jakt_var_551 = formatter::FormattedToken(token,((*this).indent),(TRY((Array<u8>::create_with({' '})))),(TRY((Array<u8>::create_with({' '}))))); goto __jakt_label_513;
+__jakt_var_558 = formatter::FormattedToken(token,((*this).indent),(TRY((Array<u8>::create_with({' '})))),(TRY((Array<u8>::create_with({' '}))))); goto __jakt_label_519;
 
 }
-__jakt_label_513:; __jakt_var_551.release_value(); }));
+__jakt_label_519:; __jakt_var_558.release_value(); }));
 };/*case end*/
 case 41: {
 auto&& __jakt_match_value = __jakt_match_variant.template get<typename lexer::Token::Pipe>();
-return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_552; {
+return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_559; {
 TRY((((*this).replace_state( formatter::State { typename formatter::State::StatementContext(open_parens,open_curlies,open_squares,arrow_indents,allow_eol,inserted_comma, formatter::ExpressionMode { typename formatter::ExpressionMode::AtExpressionStart() } ,dedents_on_open_curly) } ))));
-__jakt_var_552 = formatter::FormattedToken(token,((*this).indent),(TRY((Array<u8>::create_with({' '})))),(TRY((Array<u8>::create_with({' '}))))); goto __jakt_label_514;
+__jakt_var_559 = formatter::FormattedToken(token,((*this).indent),(TRY((Array<u8>::create_with({' '})))),(TRY((Array<u8>::create_with({' '}))))); goto __jakt_label_520;
 
 }
-__jakt_label_514:; __jakt_var_552.release_value(); }));
+__jakt_label_520:; __jakt_var_559.release_value(); }));
 };/*case end*/
 case 18: {
 auto&& __jakt_match_value = __jakt_match_variant.template get<typename lexer::Token::PlusEqual>();
-return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_553; {
+return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_560; {
 TRY((((*this).replace_state( formatter::State { typename formatter::State::StatementContext(open_parens,open_curlies,open_squares,arrow_indents,allow_eol,inserted_comma, formatter::ExpressionMode { typename formatter::ExpressionMode::AtExpressionStart() } ,dedents_on_open_curly) } ))));
-__jakt_var_553 = formatter::FormattedToken(token,((*this).indent),(TRY((Array<u8>::create_with({' '})))),(TRY((Array<u8>::create_with({' '}))))); goto __jakt_label_515;
+__jakt_var_560 = formatter::FormattedToken(token,((*this).indent),(TRY((Array<u8>::create_with({' '})))),(TRY((Array<u8>::create_with({' '}))))); goto __jakt_label_521;
 
 }
-__jakt_label_515:; __jakt_var_553.release_value(); }));
+__jakt_label_521:; __jakt_var_560.release_value(); }));
 };/*case end*/
 case 20: {
 auto&& __jakt_match_value = __jakt_match_variant.template get<typename lexer::Token::MinusEqual>();
-return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_554; {
+return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_561; {
 TRY((((*this).replace_state( formatter::State { typename formatter::State::StatementContext(open_parens,open_curlies,open_squares,arrow_indents,allow_eol,inserted_comma, formatter::ExpressionMode { typename formatter::ExpressionMode::AtExpressionStart() } ,dedents_on_open_curly) } ))));
-__jakt_var_554 = formatter::FormattedToken(token,((*this).indent),(TRY((Array<u8>::create_with({' '})))),(TRY((Array<u8>::create_with({' '}))))); goto __jakt_label_516;
+__jakt_var_561 = formatter::FormattedToken(token,((*this).indent),(TRY((Array<u8>::create_with({' '})))),(TRY((Array<u8>::create_with({' '}))))); goto __jakt_label_522;
 
 }
-__jakt_label_516:; __jakt_var_554.release_value(); }));
+__jakt_label_522:; __jakt_var_561.release_value(); }));
 };/*case end*/
 case 22: {
 auto&& __jakt_match_value = __jakt_match_variant.template get<typename lexer::Token::AsteriskEqual>();
-return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_555; {
+return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_562; {
 TRY((((*this).replace_state( formatter::State { typename formatter::State::StatementContext(open_parens,open_curlies,open_squares,arrow_indents,allow_eol,inserted_comma, formatter::ExpressionMode { typename formatter::ExpressionMode::AtExpressionStart() } ,dedents_on_open_curly) } ))));
-__jakt_var_555 = formatter::FormattedToken(token,((*this).indent),(TRY((Array<u8>::create_with({' '})))),(TRY((Array<u8>::create_with({' '}))))); goto __jakt_label_517;
+__jakt_var_562 = formatter::FormattedToken(token,((*this).indent),(TRY((Array<u8>::create_with({' '})))),(TRY((Array<u8>::create_with({' '}))))); goto __jakt_label_523;
 
 }
-__jakt_label_517:; __jakt_var_555.release_value(); }));
+__jakt_label_523:; __jakt_var_562.release_value(); }));
 };/*case end*/
 case 23: {
 auto&& __jakt_match_value = __jakt_match_variant.template get<typename lexer::Token::ForwardSlashEqual>();
-return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_556; {
+return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_563; {
 TRY((((*this).replace_state( formatter::State { typename formatter::State::StatementContext(open_parens,open_curlies,open_squares,arrow_indents,allow_eol,inserted_comma, formatter::ExpressionMode { typename formatter::ExpressionMode::AtExpressionStart() } ,dedents_on_open_curly) } ))));
-__jakt_var_556 = formatter::FormattedToken(token,((*this).indent),(TRY((Array<u8>::create_with({' '})))),(TRY((Array<u8>::create_with({' '}))))); goto __jakt_label_518;
+__jakt_var_563 = formatter::FormattedToken(token,((*this).indent),(TRY((Array<u8>::create_with({' '})))),(TRY((Array<u8>::create_with({' '}))))); goto __jakt_label_524;
 
 }
-__jakt_label_518:; __jakt_var_556.release_value(); }));
+__jakt_label_524:; __jakt_var_563.release_value(); }));
 };/*case end*/
 case 24: {
 auto&& __jakt_match_value = __jakt_match_variant.template get<typename lexer::Token::PercentSignEqual>();
-return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_557; {
+return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_564; {
 TRY((((*this).replace_state( formatter::State { typename formatter::State::StatementContext(open_parens,open_curlies,open_squares,arrow_indents,allow_eol,inserted_comma, formatter::ExpressionMode { typename formatter::ExpressionMode::AtExpressionStart() } ,dedents_on_open_curly) } ))));
-__jakt_var_557 = formatter::FormattedToken(token,((*this).indent),(TRY((Array<u8>::create_with({' '})))),(TRY((Array<u8>::create_with({' '}))))); goto __jakt_label_519;
+__jakt_var_564 = formatter::FormattedToken(token,((*this).indent),(TRY((Array<u8>::create_with({' '})))),(TRY((Array<u8>::create_with({' '}))))); goto __jakt_label_525;
 
 }
-__jakt_label_519:; __jakt_var_557.release_value(); }));
+__jakt_label_525:; __jakt_var_564.release_value(); }));
 };/*case end*/
 case 25: {
 auto&& __jakt_match_value = __jakt_match_variant.template get<typename lexer::Token::NotEqual>();
-return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_558; {
+return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_565; {
 TRY((((*this).replace_state( formatter::State { typename formatter::State::StatementContext(open_parens,open_curlies,open_squares,arrow_indents,allow_eol,inserted_comma, formatter::ExpressionMode { typename formatter::ExpressionMode::AtExpressionStart() } ,dedents_on_open_curly) } ))));
-__jakt_var_558 = formatter::FormattedToken(token,((*this).indent),(TRY((Array<u8>::create_with({' '})))),(TRY((Array<u8>::create_with({' '}))))); goto __jakt_label_520;
+__jakt_var_565 = formatter::FormattedToken(token,((*this).indent),(TRY((Array<u8>::create_with({' '})))),(TRY((Array<u8>::create_with({' '}))))); goto __jakt_label_526;
 
 }
-__jakt_label_520:; __jakt_var_558.release_value(); }));
+__jakt_label_526:; __jakt_var_565.release_value(); }));
 };/*case end*/
 case 26: {
 auto&& __jakt_match_value = __jakt_match_variant.template get<typename lexer::Token::DoubleEqual>();
-return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_559; {
+return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_566; {
 TRY((((*this).replace_state( formatter::State { typename formatter::State::StatementContext(open_parens,open_curlies,open_squares,arrow_indents,allow_eol,inserted_comma, formatter::ExpressionMode { typename formatter::ExpressionMode::AtExpressionStart() } ,dedents_on_open_curly) } ))));
-__jakt_var_559 = formatter::FormattedToken(token,((*this).indent),(TRY((Array<u8>::create_with({' '})))),(TRY((Array<u8>::create_with({' '}))))); goto __jakt_label_521;
+__jakt_var_566 = formatter::FormattedToken(token,((*this).indent),(TRY((Array<u8>::create_with({' '})))),(TRY((Array<u8>::create_with({' '}))))); goto __jakt_label_527;
 
 }
-__jakt_label_521:; __jakt_var_559.release_value(); }));
+__jakt_label_527:; __jakt_var_566.release_value(); }));
 };/*case end*/
 case 27: {
 auto&& __jakt_match_value = __jakt_match_variant.template get<typename lexer::Token::GreaterThan>();
-return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_560; {
+return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_567; {
 TRY((((*this).replace_state( formatter::State { typename formatter::State::StatementContext(open_parens,open_curlies,open_squares,arrow_indents,allow_eol,inserted_comma, formatter::ExpressionMode { typename formatter::ExpressionMode::AtExpressionStart() } ,dedents_on_open_curly) } ))));
-__jakt_var_560 = formatter::FormattedToken(token,((*this).indent),(TRY((Array<u8>::create_with({' '})))),(TRY((Array<u8>::create_with({' '}))))); goto __jakt_label_522;
+__jakt_var_567 = formatter::FormattedToken(token,((*this).indent),(TRY((Array<u8>::create_with({' '})))),(TRY((Array<u8>::create_with({' '}))))); goto __jakt_label_528;
 
 }
-__jakt_label_522:; __jakt_var_560.release_value(); }));
+__jakt_label_528:; __jakt_var_567.release_value(); }));
 };/*case end*/
 case 28: {
 auto&& __jakt_match_value = __jakt_match_variant.template get<typename lexer::Token::GreaterThanOrEqual>();
-return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_561; {
+return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_568; {
 TRY((((*this).replace_state( formatter::State { typename formatter::State::StatementContext(open_parens,open_curlies,open_squares,arrow_indents,allow_eol,inserted_comma, formatter::ExpressionMode { typename formatter::ExpressionMode::AtExpressionStart() } ,dedents_on_open_curly) } ))));
-__jakt_var_561 = formatter::FormattedToken(token,((*this).indent),(TRY((Array<u8>::create_with({' '})))),(TRY((Array<u8>::create_with({' '}))))); goto __jakt_label_523;
+__jakt_var_568 = formatter::FormattedToken(token,((*this).indent),(TRY((Array<u8>::create_with({' '})))),(TRY((Array<u8>::create_with({' '}))))); goto __jakt_label_529;
 
 }
-__jakt_label_523:; __jakt_var_561.release_value(); }));
+__jakt_label_529:; __jakt_var_568.release_value(); }));
 };/*case end*/
 case 29: {
 auto&& __jakt_match_value = __jakt_match_variant.template get<typename lexer::Token::LessThan>();
-return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_562; {
+return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_569; {
 TRY((((*this).replace_state( formatter::State { typename formatter::State::StatementContext(open_parens,open_curlies,open_squares,arrow_indents,allow_eol,inserted_comma, formatter::ExpressionMode { typename formatter::ExpressionMode::AtExpressionStart() } ,dedents_on_open_curly) } ))));
-__jakt_var_562 = formatter::FormattedToken(token,((*this).indent),(TRY((Array<u8>::create_with({' '})))),(TRY((Array<u8>::create_with({' '}))))); goto __jakt_label_524;
+__jakt_var_569 = formatter::FormattedToken(token,((*this).indent),(TRY((Array<u8>::create_with({' '})))),(TRY((Array<u8>::create_with({' '}))))); goto __jakt_label_530;
 
 }
-__jakt_label_524:; __jakt_var_562.release_value(); }));
+__jakt_label_530:; __jakt_var_569.release_value(); }));
 };/*case end*/
 case 30: {
 auto&& __jakt_match_value = __jakt_match_variant.template get<typename lexer::Token::LessThanOrEqual>();
-return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_563; {
+return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_570; {
 TRY((((*this).replace_state( formatter::State { typename formatter::State::StatementContext(open_parens,open_curlies,open_squares,arrow_indents,allow_eol,inserted_comma, formatter::ExpressionMode { typename formatter::ExpressionMode::AtExpressionStart() } ,dedents_on_open_curly) } ))));
-__jakt_var_563 = formatter::FormattedToken(token,((*this).indent),(TRY((Array<u8>::create_with({' '})))),(TRY((Array<u8>::create_with({' '}))))); goto __jakt_label_525;
+__jakt_var_570 = formatter::FormattedToken(token,((*this).indent),(TRY((Array<u8>::create_with({' '})))),(TRY((Array<u8>::create_with({' '}))))); goto __jakt_label_531;
 
 }
-__jakt_label_525:; __jakt_var_563.release_value(); }));
+__jakt_label_531:; __jakt_var_570.release_value(); }));
 };/*case end*/
 case 31: {
 auto&& __jakt_match_value = __jakt_match_variant.template get<typename lexer::Token::LeftArithmeticShift>();
-return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_564; {
+return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_571; {
 TRY((((*this).replace_state( formatter::State { typename formatter::State::StatementContext(open_parens,open_curlies,open_squares,arrow_indents,allow_eol,inserted_comma, formatter::ExpressionMode { typename formatter::ExpressionMode::AtExpressionStart() } ,dedents_on_open_curly) } ))));
-__jakt_var_564 = formatter::FormattedToken(token,((*this).indent),(TRY((Array<u8>::create_with({' '})))),(TRY((Array<u8>::create_with({' '}))))); goto __jakt_label_526;
+__jakt_var_571 = formatter::FormattedToken(token,((*this).indent),(TRY((Array<u8>::create_with({' '})))),(TRY((Array<u8>::create_with({' '}))))); goto __jakt_label_532;
 
 }
-__jakt_label_526:; __jakt_var_564.release_value(); }));
+__jakt_label_532:; __jakt_var_571.release_value(); }));
 };/*case end*/
 case 32: {
 auto&& __jakt_match_value = __jakt_match_variant.template get<typename lexer::Token::LeftShift>();
-return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_565; {
+return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_572; {
 TRY((((*this).replace_state( formatter::State { typename formatter::State::StatementContext(open_parens,open_curlies,open_squares,arrow_indents,allow_eol,inserted_comma, formatter::ExpressionMode { typename formatter::ExpressionMode::AtExpressionStart() } ,dedents_on_open_curly) } ))));
-__jakt_var_565 = formatter::FormattedToken(token,((*this).indent),(TRY((Array<u8>::create_with({' '})))),(TRY((Array<u8>::create_with({' '}))))); goto __jakt_label_527;
+__jakt_var_572 = formatter::FormattedToken(token,((*this).indent),(TRY((Array<u8>::create_with({' '})))),(TRY((Array<u8>::create_with({' '}))))); goto __jakt_label_533;
 
 }
-__jakt_label_527:; __jakt_var_565.release_value(); }));
+__jakt_label_533:; __jakt_var_572.release_value(); }));
 };/*case end*/
 case 34: {
 auto&& __jakt_match_value = __jakt_match_variant.template get<typename lexer::Token::RightShift>();
-return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_566; {
+return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_573; {
 TRY((((*this).replace_state( formatter::State { typename formatter::State::StatementContext(open_parens,open_curlies,open_squares,arrow_indents,allow_eol,inserted_comma, formatter::ExpressionMode { typename formatter::ExpressionMode::AtExpressionStart() } ,dedents_on_open_curly) } ))));
-__jakt_var_566 = formatter::FormattedToken(token,((*this).indent),(TRY((Array<u8>::create_with({' '})))),(TRY((Array<u8>::create_with({' '}))))); goto __jakt_label_528;
+__jakt_var_573 = formatter::FormattedToken(token,((*this).indent),(TRY((Array<u8>::create_with({' '})))),(TRY((Array<u8>::create_with({' '}))))); goto __jakt_label_534;
 
 }
-__jakt_label_528:; __jakt_var_566.release_value(); }));
+__jakt_label_534:; __jakt_var_573.release_value(); }));
 };/*case end*/
 case 33: {
 auto&& __jakt_match_value = __jakt_match_variant.template get<typename lexer::Token::LeftShiftEqual>();
-return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_567; {
+return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_574; {
 TRY((((*this).replace_state( formatter::State { typename formatter::State::StatementContext(open_parens,open_curlies,open_squares,arrow_indents,allow_eol,inserted_comma, formatter::ExpressionMode { typename formatter::ExpressionMode::AtExpressionStart() } ,dedents_on_open_curly) } ))));
-__jakt_var_567 = formatter::FormattedToken(token,((*this).indent),(TRY((Array<u8>::create_with({' '})))),(TRY((Array<u8>::create_with({' '}))))); goto __jakt_label_529;
+__jakt_var_574 = formatter::FormattedToken(token,((*this).indent),(TRY((Array<u8>::create_with({' '})))),(TRY((Array<u8>::create_with({' '}))))); goto __jakt_label_535;
 
 }
-__jakt_label_529:; __jakt_var_567.release_value(); }));
+__jakt_label_535:; __jakt_var_574.release_value(); }));
 };/*case end*/
 case 35: {
 auto&& __jakt_match_value = __jakt_match_variant.template get<typename lexer::Token::RightArithmeticShift>();
-return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_568; {
+return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_575; {
 TRY((((*this).replace_state( formatter::State { typename formatter::State::StatementContext(open_parens,open_curlies,open_squares,arrow_indents,allow_eol,inserted_comma, formatter::ExpressionMode { typename formatter::ExpressionMode::AtExpressionStart() } ,dedents_on_open_curly) } ))));
-__jakt_var_568 = formatter::FormattedToken(token,((*this).indent),(TRY((Array<u8>::create_with({' '})))),(TRY((Array<u8>::create_with({' '}))))); goto __jakt_label_530;
+__jakt_var_575 = formatter::FormattedToken(token,((*this).indent),(TRY((Array<u8>::create_with({' '})))),(TRY((Array<u8>::create_with({' '}))))); goto __jakt_label_536;
 
 }
-__jakt_label_530:; __jakt_var_568.release_value(); }));
+__jakt_label_536:; __jakt_var_575.release_value(); }));
 };/*case end*/
 case 36: {
 auto&& __jakt_match_value = __jakt_match_variant.template get<typename lexer::Token::RightShiftEqual>();
-return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_569; {
+return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_576; {
 TRY((((*this).replace_state( formatter::State { typename formatter::State::StatementContext(open_parens,open_curlies,open_squares,arrow_indents,allow_eol,inserted_comma, formatter::ExpressionMode { typename formatter::ExpressionMode::AtExpressionStart() } ,dedents_on_open_curly) } ))));
-__jakt_var_569 = formatter::FormattedToken(token,((*this).indent),(TRY((Array<u8>::create_with({' '})))),(TRY((Array<u8>::create_with({' '}))))); goto __jakt_label_531;
+__jakt_var_576 = formatter::FormattedToken(token,((*this).indent),(TRY((Array<u8>::create_with({' '})))),(TRY((Array<u8>::create_with({' '}))))); goto __jakt_label_537;
 
 }
-__jakt_label_531:; __jakt_var_569.release_value(); }));
+__jakt_label_537:; __jakt_var_576.release_value(); }));
 };/*case end*/
 case 39: {
 auto&& __jakt_match_value = __jakt_match_variant.template get<typename lexer::Token::AmpersandEqual>();
-return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_570; {
+return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_577; {
 TRY((((*this).replace_state( formatter::State { typename formatter::State::StatementContext(open_parens,open_curlies,open_squares,arrow_indents,allow_eol,inserted_comma, formatter::ExpressionMode { typename formatter::ExpressionMode::AtExpressionStart() } ,dedents_on_open_curly) } ))));
-__jakt_var_570 = formatter::FormattedToken(token,((*this).indent),(TRY((Array<u8>::create_with({' '})))),(TRY((Array<u8>::create_with({' '}))))); goto __jakt_label_532;
+__jakt_var_577 = formatter::FormattedToken(token,((*this).indent),(TRY((Array<u8>::create_with({' '})))),(TRY((Array<u8>::create_with({' '}))))); goto __jakt_label_538;
 
 }
-__jakt_label_532:; __jakt_var_570.release_value(); }));
+__jakt_label_538:; __jakt_var_577.release_value(); }));
 };/*case end*/
 case 42: {
 auto&& __jakt_match_value = __jakt_match_variant.template get<typename lexer::Token::PipeEqual>();
-return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_571; {
+return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_578; {
 TRY((((*this).replace_state( formatter::State { typename formatter::State::StatementContext(open_parens,open_curlies,open_squares,arrow_indents,allow_eol,inserted_comma, formatter::ExpressionMode { typename formatter::ExpressionMode::AtExpressionStart() } ,dedents_on_open_curly) } ))));
-__jakt_var_571 = formatter::FormattedToken(token,((*this).indent),(TRY((Array<u8>::create_with({' '})))),(TRY((Array<u8>::create_with({' '}))))); goto __jakt_label_533;
+__jakt_var_578 = formatter::FormattedToken(token,((*this).indent),(TRY((Array<u8>::create_with({' '})))),(TRY((Array<u8>::create_with({' '}))))); goto __jakt_label_539;
 
 }
-__jakt_label_533:; __jakt_var_571.release_value(); }));
+__jakt_label_539:; __jakt_var_578.release_value(); }));
 };/*case end*/
 case 44: {
 auto&& __jakt_match_value = __jakt_match_variant.template get<typename lexer::Token::Caret>();
-return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_572; {
+return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_579; {
 TRY((((*this).replace_state( formatter::State { typename formatter::State::StatementContext(open_parens,open_curlies,open_squares,arrow_indents,allow_eol,inserted_comma, formatter::ExpressionMode { typename formatter::ExpressionMode::AtExpressionStart() } ,dedents_on_open_curly) } ))));
-__jakt_var_572 = formatter::FormattedToken(token,((*this).indent),(TRY((Array<u8>::create_with({' '})))),(TRY((Array<u8>::create_with({' '}))))); goto __jakt_label_534;
+__jakt_var_579 = formatter::FormattedToken(token,((*this).indent),(TRY((Array<u8>::create_with({' '})))),(TRY((Array<u8>::create_with({' '}))))); goto __jakt_label_540;
 
 }
-__jakt_label_534:; __jakt_var_572.release_value(); }));
+__jakt_label_540:; __jakt_var_579.release_value(); }));
 };/*case end*/
 case 45: {
 auto&& __jakt_match_value = __jakt_match_variant.template get<typename lexer::Token::CaretEqual>();
-return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_573; {
+return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_580; {
 TRY((((*this).replace_state( formatter::State { typename formatter::State::StatementContext(open_parens,open_curlies,open_squares,arrow_indents,allow_eol,inserted_comma, formatter::ExpressionMode { typename formatter::ExpressionMode::AtExpressionStart() } ,dedents_on_open_curly) } ))));
-__jakt_var_573 = formatter::FormattedToken(token,((*this).indent),(TRY((Array<u8>::create_with({' '})))),(TRY((Array<u8>::create_with({' '}))))); goto __jakt_label_535;
+__jakt_var_580 = formatter::FormattedToken(token,((*this).indent),(TRY((Array<u8>::create_with({' '})))),(TRY((Array<u8>::create_with({' '}))))); goto __jakt_label_541;
 
 }
-__jakt_label_535:; __jakt_var_573.release_value(); }));
+__jakt_label_541:; __jakt_var_580.release_value(); }));
 };/*case end*/
 case 48: {
 auto&& __jakt_match_value = __jakt_match_variant.template get<typename lexer::Token::ForwardSlash>();
-return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_574; {
+return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_581; {
 TRY((((*this).replace_state( formatter::State { typename formatter::State::StatementContext(open_parens,open_curlies,open_squares,arrow_indents,allow_eol,inserted_comma, formatter::ExpressionMode { typename formatter::ExpressionMode::AtExpressionStart() } ,dedents_on_open_curly) } ))));
-__jakt_var_574 = formatter::FormattedToken(token,((*this).indent),(TRY((Array<u8>::create_with({' '})))),(TRY((Array<u8>::create_with({' '}))))); goto __jakt_label_536;
+__jakt_var_581 = formatter::FormattedToken(token,((*this).indent),(TRY((Array<u8>::create_with({' '})))),(TRY((Array<u8>::create_with({' '}))))); goto __jakt_label_542;
 
 }
-__jakt_label_536:; __jakt_var_574.release_value(); }));
+__jakt_label_542:; __jakt_var_581.release_value(); }));
 };/*case end*/
 case 51: {
 auto&& __jakt_match_value = __jakt_match_variant.template get<typename lexer::Token::QuestionMarkQuestionMark>();
-return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_575; {
+return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_582; {
 TRY((((*this).replace_state( formatter::State { typename formatter::State::StatementContext(open_parens,open_curlies,open_squares,arrow_indents,allow_eol,inserted_comma, formatter::ExpressionMode { typename formatter::ExpressionMode::AtExpressionStart() } ,dedents_on_open_curly) } ))));
-__jakt_var_575 = formatter::FormattedToken(token,((*this).indent),(TRY((Array<u8>::create_with({' '})))),(TRY((Array<u8>::create_with({' '}))))); goto __jakt_label_537;
+__jakt_var_582 = formatter::FormattedToken(token,((*this).indent),(TRY((Array<u8>::create_with({' '})))),(TRY((Array<u8>::create_with({' '}))))); goto __jakt_label_543;
 
 }
-__jakt_label_537:; __jakt_var_575.release_value(); }));
+__jakt_label_543:; __jakt_var_582.release_value(); }));
 };/*case end*/
 case 52: {
 auto&& __jakt_match_value = __jakt_match_variant.template get<typename lexer::Token::QuestionMarkQuestionMarkEqual>();
-return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_576; {
+return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_583; {
 TRY((((*this).replace_state( formatter::State { typename formatter::State::StatementContext(open_parens,open_curlies,open_squares,arrow_indents,allow_eol,inserted_comma, formatter::ExpressionMode { typename formatter::ExpressionMode::AtExpressionStart() } ,dedents_on_open_curly) } ))));
-__jakt_var_576 = formatter::FormattedToken(token,((*this).indent),(TRY((Array<u8>::create_with({' '})))),(TRY((Array<u8>::create_with({' '}))))); goto __jakt_label_538;
+__jakt_var_583 = formatter::FormattedToken(token,((*this).indent),(TRY((Array<u8>::create_with({' '})))),(TRY((Array<u8>::create_with({' '}))))); goto __jakt_label_544;
 
 }
-__jakt_label_538:; __jakt_var_576.release_value(); }));
+__jakt_label_544:; __jakt_var_583.release_value(); }));
 };/*case end*/
 case 60: {
 auto&& __jakt_match_value = __jakt_match_variant.template get<typename lexer::Token::And>();
-return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_577; {
+return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_584; {
 TRY((((*this).replace_state( formatter::State { typename formatter::State::StatementContext(open_parens,open_curlies,open_squares,arrow_indents,allow_eol,inserted_comma, formatter::ExpressionMode { typename formatter::ExpressionMode::AtExpressionStart() } ,dedents_on_open_curly) } ))));
-__jakt_var_577 = formatter::FormattedToken(token,((*this).indent),(TRY((Array<u8>::create_with({' '})))),(TRY((Array<u8>::create_with({' '}))))); goto __jakt_label_539;
+__jakt_var_584 = formatter::FormattedToken(token,((*this).indent),(TRY((Array<u8>::create_with({' '})))),(TRY((Array<u8>::create_with({' '}))))); goto __jakt_label_545;
 
 }
-__jakt_label_539:; __jakt_var_577.release_value(); }));
+__jakt_label_545:; __jakt_var_584.release_value(); }));
 };/*case end*/
 case 79: {
 auto&& __jakt_match_value = __jakt_match_variant.template get<typename lexer::Token::In>();
-return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_578; {
+return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_585; {
 TRY((((*this).replace_state( formatter::State { typename formatter::State::StatementContext(open_parens,open_curlies,open_squares,arrow_indents,allow_eol,inserted_comma, formatter::ExpressionMode { typename formatter::ExpressionMode::AtExpressionStart() } ,dedents_on_open_curly) } ))));
-__jakt_var_578 = formatter::FormattedToken(token,((*this).indent),(TRY((Array<u8>::create_with({' '})))),(TRY((Array<u8>::create_with({' '}))))); goto __jakt_label_540;
+__jakt_var_585 = formatter::FormattedToken(token,((*this).indent),(TRY((Array<u8>::create_with({' '})))),(TRY((Array<u8>::create_with({' '}))))); goto __jakt_label_546;
 
 }
-__jakt_label_540:; __jakt_var_578.release_value(); }));
+__jakt_label_546:; __jakt_var_585.release_value(); }));
 };/*case end*/
 case 87: {
 auto&& __jakt_match_value = __jakt_match_variant.template get<typename lexer::Token::Or>();
-return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_579; {
+return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_586; {
 TRY((((*this).replace_state( formatter::State { typename formatter::State::StatementContext(open_parens,open_curlies,open_squares,arrow_indents,allow_eol,inserted_comma, formatter::ExpressionMode { typename formatter::ExpressionMode::AtExpressionStart() } ,dedents_on_open_curly) } ))));
-__jakt_var_579 = formatter::FormattedToken(token,((*this).indent),(TRY((Array<u8>::create_with({' '})))),(TRY((Array<u8>::create_with({' '}))))); goto __jakt_label_541;
+__jakt_var_586 = formatter::FormattedToken(token,((*this).indent),(TRY((Array<u8>::create_with({' '})))),(TRY((Array<u8>::create_with({' '}))))); goto __jakt_label_547;
 
 }
-__jakt_label_541:; __jakt_var_579.release_value(); }));
+__jakt_label_547:; __jakt_var_586.release_value(); }));
 };/*case end*/
 case 80: {
 auto&& __jakt_match_value = __jakt_match_variant.template get<typename lexer::Token::Is>();
-return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_580; {
+return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_587; {
 TRY((((*this).push_state( formatter::State { typename formatter::State::MatchPattern(static_cast<size_t>(0ULL),false) } ))));
-__jakt_var_580 = formatter::FormattedToken(token,((*this).indent),(TRY((Array<u8>::create_with({' '})))),(TRY((Array<u8>::create_with({' '}))))); goto __jakt_label_542;
+__jakt_var_587 = formatter::FormattedToken(token,((*this).indent),(TRY((Array<u8>::create_with({' '})))),(TRY((Array<u8>::create_with({' '}))))); goto __jakt_label_548;
 
 }
-__jakt_label_542:; __jakt_var_580.release_value(); }));
+__jakt_label_548:; __jakt_var_587.release_value(); }));
 };/*case end*/
 case 62: {
 auto&& __jakt_match_value = __jakt_match_variant.template get<typename lexer::Token::As>();
@@ -3959,11 +3959,11 @@ auto&& __jakt_match_variant = ((*this).peek((-(static_cast<i64>(1LL)))));
 switch(__jakt_match_variant.index()) {
 case 62: {
 auto&& __jakt_match_value = __jakt_match_variant.template get<typename lexer::Token::As>();
-return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_581; {
-__jakt_var_581 = formatter::FormattedToken(token,((*this).indent),(TRY((Array<u8>::create_with({' '})))),(TRY((Array<u8>::create_with({}))))); goto __jakt_label_543;
+return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_588; {
+__jakt_var_588 = formatter::FormattedToken(token,((*this).indent),(TRY((Array<u8>::create_with({' '})))),(TRY((Array<u8>::create_with({}))))); goto __jakt_label_549;
 
 }
-__jakt_label_543:; __jakt_var_581.release_value(); }));
+__jakt_label_549:; __jakt_var_588.release_value(); }));
 };/*case end*/
 default: {
 return JaktInternal::ExplicitValue(formatter::FormattedToken(token,((*this).indent),(TRY((Array<u8>::create_with({})))),(TRY((Array<u8>::create_with({}))))));
@@ -3979,11 +3979,11 @@ auto&& __jakt_match_variant = ((*this).peek((-(static_cast<i64>(1LL)))));
 switch(__jakt_match_variant.index()) {
 case 62: {
 auto&& __jakt_match_value = __jakt_match_variant.template get<typename lexer::Token::As>();
-return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_582; {
-__jakt_var_582 = formatter::FormattedToken(token,((*this).indent),(TRY((Array<u8>::create_with({' '})))),(TRY((Array<u8>::create_with({}))))); goto __jakt_label_544;
+return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_589; {
+__jakt_var_589 = formatter::FormattedToken(token,((*this).indent),(TRY((Array<u8>::create_with({' '})))),(TRY((Array<u8>::create_with({}))))); goto __jakt_label_550;
 
 }
-__jakt_label_544:; __jakt_var_582.release_value(); }));
+__jakt_label_550:; __jakt_var_589.release_value(); }));
 };/*case end*/
 default: {
 return JaktInternal::ExplicitValue(formatter::FormattedToken(token,((*this).indent),(TRY((Array<u8>::create_with({})))),(TRY((Array<u8>::create_with({}))))));
@@ -3993,7 +3993,7 @@ return JaktInternal::ExplicitValue(formatter::FormattedToken(token,((*this).inde
 )));
 };/*case end*/
 case 4: {
-auto&& __jakt_match_value = __jakt_match_variant.template get<lexer::Token::Identifier>();return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_583; {
+auto&& __jakt_match_value = __jakt_match_variant.template get<lexer::Token::Identifier>();return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_590; {
 if ((((((*this).peek((-(static_cast<i64>(1LL)))))).index() == 4 /* Identifier */) && (!(inserted_comma)))){
 ((((*this).index)--));
 TRY((((*this).replace_state( formatter::State { typename formatter::State::StatementContext(open_parens,open_curlies,open_squares,arrow_indents,allow_eol,true, formatter::ExpressionMode { typename formatter::ExpressionMode::InExpression() } ,dedents_on_open_curly) } ))));
@@ -4268,13 +4268,13 @@ return JaktInternal::ExplicitValue<void>();
 if (((open_angles == static_cast<i64>(0LL)) && ((((*this).peek(lookahead_index))).index() == 8 /* LParen */))){
 TRY((((*this).push_state( formatter::State { typename formatter::State::GenericCallTypeParams(static_cast<size_t>(0ULL)) } ))));
 }
-__jakt_var_583 = formatter::FormattedToken(token,((*this).indent),(TRY((Array<u8>::create_with({})))),(TRY((Array<u8>::create_with({}))))); goto __jakt_label_545;
+__jakt_var_590 = formatter::FormattedToken(token,((*this).indent),(TRY((Array<u8>::create_with({})))),(TRY((Array<u8>::create_with({}))))); goto __jakt_label_551;
 
 }
-__jakt_label_545:; __jakt_var_583.release_value(); }));
+__jakt_label_551:; __jakt_var_590.release_value(); }));
 };/*case end*/
 case 3: {
-auto&& __jakt_match_value = __jakt_match_variant.template get<lexer::Token::Number>();return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_584; {
+auto&& __jakt_match_value = __jakt_match_variant.template get<lexer::Token::Number>();return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_591; {
 if ((((((*this).peek((-(static_cast<i64>(1LL)))))).index() == 4 /* Identifier */) && (!(inserted_comma)))){
 ((((*this).index)--));
 TRY((((*this).replace_state( formatter::State { typename formatter::State::StatementContext(open_parens,open_curlies,open_squares,arrow_indents,allow_eol,true, formatter::ExpressionMode { typename formatter::ExpressionMode::InExpression() } ,dedents_on_open_curly) } ))));
@@ -4549,14 +4549,14 @@ return JaktInternal::ExplicitValue<void>();
 if (((open_angles == static_cast<i64>(0LL)) && ((((*this).peek(lookahead_index))).index() == 8 /* LParen */))){
 TRY((((*this).push_state( formatter::State { typename formatter::State::GenericCallTypeParams(static_cast<size_t>(0ULL)) } ))));
 }
-__jakt_var_584 = formatter::FormattedToken(token,((*this).indent),(TRY((Array<u8>::create_with({})))),(TRY((Array<u8>::create_with({}))))); goto __jakt_label_546;
+__jakt_var_591 = formatter::FormattedToken(token,((*this).indent),(TRY((Array<u8>::create_with({})))),(TRY((Array<u8>::create_with({}))))); goto __jakt_label_552;
 
 }
-__jakt_label_546:; __jakt_var_584.release_value(); }));
+__jakt_label_552:; __jakt_var_591.release_value(); }));
 };/*case end*/
 case 5: {
 auto&& __jakt_match_value = __jakt_match_variant.template get<typename lexer::Token::Semicolon>();
-return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_585; {
+return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_592; {
 if ((open_squares == static_cast<size_t>(0ULL))){
 return (JAKT_RESOLVE_EXPLICIT_VALUE_OR_CONTROL_FLOW_RETURN_ONLY(([&]() -> JaktInternal::ExplicitValueOrControlFlow<JaktInternal::Optional<formatter::FormattedToken>, ErrorOr<JaktInternal::Optional<formatter::FormattedToken>>>{
 auto&& __jakt_match_variant = ((*this).peek(static_cast<i64>(0LL)));
@@ -4571,27 +4571,27 @@ return JaktInternal::ExplicitValue(formatter::FormattedToken( lexer::Token { typ
 }()
 )));
 }
-__jakt_var_585 = formatter::FormattedToken(token,((*this).indent),(TRY((Array<u8>::create_with({' '})))),(TRY((Array<u8>::create_with({}))))); goto __jakt_label_547;
+__jakt_var_592 = formatter::FormattedToken(token,((*this).indent),(TRY((Array<u8>::create_with({' '})))),(TRY((Array<u8>::create_with({}))))); goto __jakt_label_553;
 
 }
-__jakt_label_547:; __jakt_var_585.release_value(); }));
+__jakt_label_553:; __jakt_var_592.release_value(); }));
 };/*case end*/
 case 91: {
 auto&& __jakt_match_value = __jakt_match_variant.template get<typename lexer::Token::Raw>();
-return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_586; {
+return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_593; {
 TRY((((*this).replace_state( formatter::State { typename formatter::State::StatementContext(open_parens,open_curlies,open_squares,arrow_indents,allow_eol,inserted_comma, formatter::ExpressionMode { typename formatter::ExpressionMode::AtExpressionStart() } ,dedents_on_open_curly) } ))));
-__jakt_var_586 = formatter::FormattedToken(token,((*this).indent),(TRY((Array<u8>::create_with({' '})))),(TRY((Array<u8>::create_with({}))))); goto __jakt_label_548;
+__jakt_var_593 = formatter::FormattedToken(token,((*this).indent),(TRY((Array<u8>::create_with({' '})))),(TRY((Array<u8>::create_with({}))))); goto __jakt_label_554;
 
 }
-__jakt_label_548:; __jakt_var_586.release_value(); }));
+__jakt_label_554:; __jakt_var_593.release_value(); }));
 };/*case end*/
 default: {
-return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_587; {
+return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_594; {
 TRY((((*this).replace_state( formatter::State { typename formatter::State::StatementContext(open_parens,open_curlies,open_squares,arrow_indents,allow_eol,inserted_comma, formatter::ExpressionMode { typename formatter::ExpressionMode::InExpression() } ,dedents_on_open_curly) } ))));
-__jakt_var_587 = formatter::FormattedToken(token,((*this).indent),(TRY((Array<u8>::create_with({})))),(TRY((Array<u8>::create_with({}))))); goto __jakt_label_549;
+__jakt_var_594 = formatter::FormattedToken(token,((*this).indent),(TRY((Array<u8>::create_with({})))),(TRY((Array<u8>::create_with({}))))); goto __jakt_label_555;
 
 }
-__jakt_label_549:; __jakt_var_587.release_value(); }));
+__jakt_label_555:; __jakt_var_594.release_value(); }));
 };/*case end*/
 }/*switch end*/
 }()
@@ -4604,16 +4604,16 @@ auto&& __jakt_match_variant = token;
 switch(__jakt_match_variant.index()) {
 case 29: {
 auto&& __jakt_match_value = __jakt_match_variant.template get<typename lexer::Token::LessThan>();
-return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_588; {
+return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_595; {
 TRY((((*this).push_state( formatter::State { typename formatter::State::TypeContext(static_cast<size_t>(0ULL),static_cast<size_t>(0ULL),static_cast<size_t>(0ULL),static_cast<size_t>(0ULL),false) } ))));
-__jakt_var_588 = formatter::FormattedToken(token,((*this).indent),(TRY((Array<u8>::create_with({})))),(TRY((Array<u8>::create_with({}))))); goto __jakt_label_550;
+__jakt_var_595 = formatter::FormattedToken(token,((*this).indent),(TRY((Array<u8>::create_with({})))),(TRY((Array<u8>::create_with({}))))); goto __jakt_label_556;
 
 }
-__jakt_label_550:; __jakt_var_588.release_value(); }));
+__jakt_label_556:; __jakt_var_595.release_value(); }));
 };/*case end*/
 case 27: {
 auto&& __jakt_match_value = __jakt_match_variant.template get<typename lexer::Token::GreaterThan>();
-return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_589; {
+return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_596; {
 if ((open_angles <= static_cast<size_t>(1ULL))){
 ((*this).pop_state());
 }
@@ -4621,19 +4621,19 @@ else {
 TRY((((*this).replace_state( formatter::State { typename formatter::State::GenericCallTypeParams((JaktInternal::checked_sub<size_t>(open_angles,static_cast<size_t>(1ULL)))) } ))));
 }
 
-__jakt_var_589 = formatter::FormattedToken(token,((*this).indent),(TRY((Array<u8>::create_with({})))),(TRY((Array<u8>::create_with({}))))); goto __jakt_label_551;
+__jakt_var_596 = formatter::FormattedToken(token,((*this).indent),(TRY((Array<u8>::create_with({})))),(TRY((Array<u8>::create_with({}))))); goto __jakt_label_557;
 
 }
-__jakt_label_551:; __jakt_var_589.release_value(); }));
+__jakt_label_557:; __jakt_var_596.release_value(); }));
 };/*case end*/
 case 53: {
 auto&& __jakt_match_value = __jakt_match_variant.template get<typename lexer::Token::Comma>();
-return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_590; {
+return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_597; {
 TRY((((*this).push_state( formatter::State { typename formatter::State::TypeContext(static_cast<size_t>(0ULL),static_cast<size_t>(0ULL),static_cast<size_t>(0ULL),static_cast<size_t>(0ULL),false) } ))));
-__jakt_var_590 = formatter::FormattedToken(token,((*this).indent),(TRY((Array<u8>::create_with({' '})))),(TRY((Array<u8>::create_with({}))))); goto __jakt_label_552;
+__jakt_var_597 = formatter::FormattedToken(token,((*this).indent),(TRY((Array<u8>::create_with({' '})))),(TRY((Array<u8>::create_with({}))))); goto __jakt_label_558;
 
 }
-__jakt_label_552:; __jakt_var_590.release_value(); }));
+__jakt_label_558:; __jakt_var_597.release_value(); }));
 };/*case end*/
 default: {
 return JaktInternal::ExplicitValue(formatter::FormattedToken(token,((*this).indent),(TRY((Array<u8>::create_with({})))),(TRY((Array<u8>::create_with({}))))));
@@ -4649,44 +4649,44 @@ auto&& __jakt_match_variant = token;
 switch(__jakt_match_variant.index()) {
 case 6: {
 auto&& __jakt_match_value = __jakt_match_variant.template get<typename lexer::Token::Colon>();
-return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_591; {
+return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_598; {
 TRY((((*this).push_state( formatter::State { typename formatter::State::TypeContext(static_cast<size_t>(0ULL),static_cast<size_t>(0ULL),static_cast<size_t>(0ULL),static_cast<size_t>(0ULL),false) } ))));
-__jakt_var_591 = formatter::FormattedToken(token,((*this).indent),(TRY((Array<u8>::create_with({' '})))),(TRY((Array<u8>::create_with({}))))); goto __jakt_label_553;
+__jakt_var_598 = formatter::FormattedToken(token,((*this).indent),(TRY((Array<u8>::create_with({' '})))),(TRY((Array<u8>::create_with({}))))); goto __jakt_label_559;
 
 }
-__jakt_label_553:; __jakt_var_591.release_value(); }));
+__jakt_label_559:; __jakt_var_598.release_value(); }));
 };/*case end*/
 case 8: {
 auto&& __jakt_match_value = __jakt_match_variant.template get<typename lexer::Token::LParen>();
-return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_592; {
+return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_599; {
 TRY((((*this).replace_state( formatter::State { typename formatter::State::VariableDeclaration((JaktInternal::checked_add<size_t>(open_parens,static_cast<size_t>(1ULL)))) } ))));
-__jakt_var_592 = formatter::FormattedToken(token,((*this).indent),(TRY((Array<u8>::create_with({})))),(TRY((Array<u8>::create_with({}))))); goto __jakt_label_554;
+__jakt_var_599 = formatter::FormattedToken(token,((*this).indent),(TRY((Array<u8>::create_with({})))),(TRY((Array<u8>::create_with({}))))); goto __jakt_label_560;
 
 }
-__jakt_label_554:; __jakt_var_592.release_value(); }));
+__jakt_label_560:; __jakt_var_599.release_value(); }));
 };/*case end*/
 case 9: {
 auto&& __jakt_match_value = __jakt_match_variant.template get<typename lexer::Token::RParen>();
-return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_593; {
+return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_600; {
 if ((open_parens == static_cast<size_t>(0ULL))){
 ((*this).pop_state());
 ((((*this).index)--));
 return (TRY((((*this).next_impl(true)))));
 }
 TRY((((*this).replace_state( formatter::State { typename formatter::State::VariableDeclaration((JaktInternal::checked_sub<size_t>(open_parens,static_cast<size_t>(1ULL)))) } ))));
-__jakt_var_593 = formatter::FormattedToken(token,((*this).indent),(TRY((Array<u8>::create_with({})))),(TRY((Array<u8>::create_with({}))))); goto __jakt_label_555;
+__jakt_var_600 = formatter::FormattedToken(token,((*this).indent),(TRY((Array<u8>::create_with({})))),(TRY((Array<u8>::create_with({}))))); goto __jakt_label_561;
 
 }
-__jakt_label_555:; __jakt_var_593.release_value(); }));
+__jakt_label_561:; __jakt_var_600.release_value(); }));
 };/*case end*/
 case 17: {
 auto&& __jakt_match_value = __jakt_match_variant.template get<typename lexer::Token::Equal>();
-return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_594; {
+return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_601; {
 ((*this).pop_state());
-__jakt_var_594 = formatter::FormattedToken(token,((*this).indent),(TRY((Array<u8>::create_with({' '})))),(TRY((Array<u8>::create_with({' '}))))); goto __jakt_label_556;
+__jakt_var_601 = formatter::FormattedToken(token,((*this).indent),(TRY((Array<u8>::create_with({' '})))),(TRY((Array<u8>::create_with({' '}))))); goto __jakt_label_562;
 
 }
-__jakt_label_556:; __jakt_var_594.release_value(); }));
+__jakt_label_562:; __jakt_var_601.release_value(); }));
 };/*case end*/
 case 53: {
 auto&& __jakt_match_value = __jakt_match_variant.template get<typename lexer::Token::Comma>();
@@ -4706,21 +4706,21 @@ auto&& __jakt_match_variant = token;
 switch(__jakt_match_variant.index()) {
 case 53: {
 auto&& __jakt_match_value = __jakt_match_variant.template get<typename lexer::Token::Comma>();
-return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_595; {
+return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_602; {
 TRY((((*this).push_state( formatter::State { typename formatter::State::TypeContext(static_cast<size_t>(0ULL),static_cast<size_t>(0ULL),static_cast<size_t>(0ULL),static_cast<size_t>(0ULL),false) } ))));
-__jakt_var_595 = formatter::FormattedToken(token,((*this).indent),(TRY((Array<u8>::create_with({' '})))),(TRY((Array<u8>::create_with({}))))); goto __jakt_label_557;
+__jakt_var_602 = formatter::FormattedToken(token,((*this).indent),(TRY((Array<u8>::create_with({' '})))),(TRY((Array<u8>::create_with({}))))); goto __jakt_label_563;
 
 }
-__jakt_label_557:; __jakt_var_595.release_value(); }));
+__jakt_label_563:; __jakt_var_602.release_value(); }));
 };/*case end*/
 case 9: {
 auto&& __jakt_match_value = __jakt_match_variant.template get<typename lexer::Token::RParen>();
-return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_596; {
+return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_603; {
 ((*this).pop_state());
-__jakt_var_596 = formatter::FormattedToken(token,((*this).indent),(TRY((Array<u8>::create_with({' '})))),(TRY((Array<u8>::create_with({}))))); goto __jakt_label_558;
+__jakt_var_603 = formatter::FormattedToken(token,((*this).indent),(TRY((Array<u8>::create_with({' '})))),(TRY((Array<u8>::create_with({}))))); goto __jakt_label_564;
 
 }
-__jakt_label_558:; __jakt_var_596.release_value(); }));
+__jakt_label_564:; __jakt_var_603.release_value(); }));
 };/*case end*/
 default: {
 return JaktInternal::ExplicitValue(formatter::FormattedToken(token,((*this).indent),(TRY((Array<u8>::create_with({})))),(TRY((Array<u8>::create_with({}))))));
@@ -4744,12 +4744,12 @@ return JaktInternal::ExplicitValue(formatter::FormattedToken(token,((*this).inde
 };/*case end*/
 case 6: {
 auto&& __jakt_match_value = __jakt_match_variant.template get<typename lexer::Token::Colon>();
-return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_597; {
+return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_604; {
 TRY((((*this).push_state( formatter::State { typename formatter::State::TypeContext(static_cast<size_t>(0ULL),static_cast<size_t>(0ULL),static_cast<size_t>(0ULL),static_cast<size_t>(0ULL),false) } ))));
-__jakt_var_597 = formatter::FormattedToken(token,((*this).indent),(TRY((Array<u8>::create_with({' '})))),(TRY((Array<u8>::create_with({}))))); goto __jakt_label_559;
+__jakt_var_604 = formatter::FormattedToken(token,((*this).indent),(TRY((Array<u8>::create_with({' '})))),(TRY((Array<u8>::create_with({}))))); goto __jakt_label_565;
 
 }
-__jakt_label_559:; __jakt_var_597.release_value(); }));
+__jakt_label_565:; __jakt_var_604.release_value(); }));
 };/*case end*/
 case 53: {
 auto&& __jakt_match_value = __jakt_match_variant.template get<typename lexer::Token::Comma>();
@@ -4757,35 +4757,35 @@ return JaktInternal::ExplicitValue(formatter::FormattedToken(token,((*this).inde
 };/*case end*/
 case 17: {
 auto&& __jakt_match_value = __jakt_match_variant.template get<typename lexer::Token::Equal>();
-return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_598; {
+return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_605; {
 TRY((((*this).push_state( formatter::State { typename formatter::State::StatementContext(static_cast<size_t>(0ULL),static_cast<size_t>(0ULL),static_cast<size_t>(0ULL),static_cast<size_t>(0ULL),static_cast<size_t>(0ULL),false, formatter::ExpressionMode { typename formatter::ExpressionMode::AtExpressionStart() } ,static_cast<size_t>(0ULL)) } ))));
-__jakt_var_598 = formatter::FormattedToken(token,((*this).indent),(TRY((Array<u8>::create_with({' '})))),(TRY((Array<u8>::create_with({' '}))))); goto __jakt_label_560;
+__jakt_var_605 = formatter::FormattedToken(token,((*this).indent),(TRY((Array<u8>::create_with({' '})))),(TRY((Array<u8>::create_with({' '}))))); goto __jakt_label_566;
 
 }
-__jakt_label_560:; __jakt_var_598.release_value(); }));
+__jakt_label_566:; __jakt_var_605.release_value(); }));
 };/*case end*/
 case 8: {
 auto&& __jakt_match_value = __jakt_match_variant.template get<typename lexer::Token::LParen>();
-return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_599; {
+return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_606; {
 TRY((((*this).replace_state( formatter::State { typename formatter::State::ParameterList((JaktInternal::checked_add<size_t>(open_parens,static_cast<size_t>(1ULL)))) } ))));
-__jakt_var_599 = formatter::FormattedToken(token,((*this).indent),(TRY((Array<u8>::create_with({})))),(TRY((Array<u8>::create_with({}))))); goto __jakt_label_561;
+__jakt_var_606 = formatter::FormattedToken(token,((*this).indent),(TRY((Array<u8>::create_with({})))),(TRY((Array<u8>::create_with({}))))); goto __jakt_label_567;
 
 }
-__jakt_label_561:; __jakt_var_599.release_value(); }));
+__jakt_label_567:; __jakt_var_606.release_value(); }));
 };/*case end*/
 case 9: {
 auto&& __jakt_match_value = __jakt_match_variant.template get<typename lexer::Token::RParen>();
-return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_600; {
+return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_607; {
 if ((open_parens == static_cast<size_t>(0ULL))){
 ((*this).pop_state());
 ((((*this).index)--));
 return (TRY((((*this).next_impl(true)))));
 }
 TRY((((*this).replace_state( formatter::State { typename formatter::State::ParameterList((JaktInternal::checked_sub<size_t>(open_parens,static_cast<size_t>(1ULL)))) } ))));
-__jakt_var_600 = formatter::FormattedToken(token,((*this).indent),(TRY((Array<u8>::create_with({})))),(TRY((Array<u8>::create_with({}))))); goto __jakt_label_562;
+__jakt_var_607 = formatter::FormattedToken(token,((*this).indent),(TRY((Array<u8>::create_with({})))),(TRY((Array<u8>::create_with({}))))); goto __jakt_label_568;
 
 }
-__jakt_label_562:; __jakt_var_600.release_value(); }));
+__jakt_label_568:; __jakt_var_607.release_value(); }));
 };/*case end*/
 default: {
 return JaktInternal::ExplicitValue(formatter::FormattedToken(token,((*this).indent),(TRY((Array<u8>::create_with({})))),(TRY((Array<u8>::create_with({}))))));
@@ -4805,42 +4805,42 @@ auto&& __jakt_match_variant = token;
 switch(__jakt_match_variant.index()) {
 case 29: {
 auto&& __jakt_match_value = __jakt_match_variant.template get<typename lexer::Token::LessThan>();
-return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_601; {
+return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_608; {
 TRY((((*this).replace_state( formatter::State { typename formatter::State::TypeContext(open_parens,open_curlies,open_squares,(JaktInternal::checked_add<size_t>(open_angles,static_cast<size_t>(1ULL))),seen_start) } ))));
-__jakt_var_601 = formatter::FormattedToken(token,((*this).indent),(TRY((Array<u8>::create_with({})))),(TRY((Array<u8>::create_with({}))))); goto __jakt_label_563;
+__jakt_var_608 = formatter::FormattedToken(token,((*this).indent),(TRY((Array<u8>::create_with({})))),(TRY((Array<u8>::create_with({}))))); goto __jakt_label_569;
 
 }
-__jakt_label_563:; __jakt_var_601.release_value(); }));
+__jakt_label_569:; __jakt_var_608.release_value(); }));
 };/*case end*/
 case 27: {
 auto&& __jakt_match_value = __jakt_match_variant.template get<typename lexer::Token::GreaterThan>();
-return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_602; {
+return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_609; {
 if ((open_angles == static_cast<size_t>(0ULL))){
 ((*this).pop_state());
 ((((*this).index)--));
 return (TRY((((*this).next_impl(true)))));
 }
 TRY((((*this).replace_state( formatter::State { typename formatter::State::TypeContext(open_parens,open_curlies,open_squares,(JaktInternal::checked_sub<size_t>(open_angles,static_cast<size_t>(1ULL))),seen_start) } ))));
-__jakt_var_602 = formatter::FormattedToken(token,((*this).indent),(TRY((Array<u8>::create_with({})))),(TRY((Array<u8>::create_with({}))))); goto __jakt_label_564;
+__jakt_var_609 = formatter::FormattedToken(token,((*this).indent),(TRY((Array<u8>::create_with({})))),(TRY((Array<u8>::create_with({}))))); goto __jakt_label_570;
 
 }
-__jakt_label_564:; __jakt_var_602.release_value(); }));
+__jakt_label_570:; __jakt_var_609.release_value(); }));
 };/*case end*/
 case 56: {
-auto&& __jakt_match_value = __jakt_match_variant.template get<lexer::Token::Eol>();return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_603; {
+auto&& __jakt_match_value = __jakt_match_variant.template get<lexer::Token::Eol>();return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_610; {
 if (((JaktInternal::checked_add<size_t>((JaktInternal::checked_add<size_t>((JaktInternal::checked_add<size_t>(open_parens,open_curlies)),open_squares)),open_angles)) == static_cast<size_t>(0ULL))){
 ((*this).pop_state());
 ((((*this).index)--));
 return (TRY((((*this).next_impl(true)))));
 }
-__jakt_var_603 = formatter::FormattedToken(token,((*this).indent),(TRY((Array<u8>::create_with({})))),(TRY((Array<u8>::create_with({}))))); goto __jakt_label_565;
+__jakt_var_610 = formatter::FormattedToken(token,((*this).indent),(TRY((Array<u8>::create_with({})))),(TRY((Array<u8>::create_with({}))))); goto __jakt_label_571;
 
 }
-__jakt_label_565:; __jakt_var_603.release_value(); }));
+__jakt_label_571:; __jakt_var_610.release_value(); }));
 };/*case end*/
 case 12: {
 auto&& __jakt_match_value = __jakt_match_variant.template get<typename lexer::Token::LSquare>();
-return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_604; {
+return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_611; {
 if (seen_start){
 ((((*this).index)--));
 ((*this).pop_state());
@@ -4848,28 +4848,28 @@ return (TRY((((*this).next_impl(true)))));
 }
 TRY((((*this).replace_state( formatter::State { typename formatter::State::TypeContext(open_parens,open_curlies,(JaktInternal::checked_add<size_t>(open_squares,static_cast<size_t>(1ULL))),open_angles,true) } ))));
 TRY((((*this).push_state( formatter::State { typename formatter::State::TypeContext(static_cast<size_t>(0ULL),static_cast<size_t>(0ULL),static_cast<size_t>(0ULL),static_cast<size_t>(0ULL),false) } ))));
-__jakt_var_604 = formatter::FormattedToken(token,((*this).indent),(TRY((Array<u8>::create_with({})))),(TRY((Array<u8>::create_with({}))))); goto __jakt_label_566;
+__jakt_var_611 = formatter::FormattedToken(token,((*this).indent),(TRY((Array<u8>::create_with({})))),(TRY((Array<u8>::create_with({}))))); goto __jakt_label_572;
 
 }
-__jakt_label_566:; __jakt_var_604.release_value(); }));
+__jakt_label_572:; __jakt_var_611.release_value(); }));
 };/*case end*/
 case 13: {
 auto&& __jakt_match_value = __jakt_match_variant.template get<typename lexer::Token::RSquare>();
-return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_605; {
+return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_612; {
 if ((open_squares == static_cast<size_t>(0ULL))){
 ((*this).pop_state());
 ((((*this).index)--));
 return (TRY((((*this).next_impl(true)))));
 }
 TRY((((*this).replace_state( formatter::State { typename formatter::State::TypeContext(open_parens,open_curlies,(JaktInternal::checked_sub<size_t>(open_squares,static_cast<size_t>(1ULL))),open_angles,seen_start) } ))));
-__jakt_var_605 = formatter::FormattedToken(token,((*this).indent),(TRY((Array<u8>::create_with({})))),(TRY((Array<u8>::create_with({}))))); goto __jakt_label_567;
+__jakt_var_612 = formatter::FormattedToken(token,((*this).indent),(TRY((Array<u8>::create_with({})))),(TRY((Array<u8>::create_with({}))))); goto __jakt_label_573;
 
 }
-__jakt_label_567:; __jakt_var_605.release_value(); }));
+__jakt_label_573:; __jakt_var_612.release_value(); }));
 };/*case end*/
 case 8: {
 auto&& __jakt_match_value = __jakt_match_variant.template get<typename lexer::Token::LParen>();
-return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_606; {
+return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_613; {
 if (seen_start){
 ((((*this).index)--));
 ((*this).pop_state());
@@ -4877,28 +4877,28 @@ return (TRY((((*this).next_impl(true)))));
 }
 TRY((((*this).replace_state( formatter::State { typename formatter::State::TypeContext((JaktInternal::checked_add<size_t>(open_parens,static_cast<size_t>(1ULL))),open_curlies,open_squares,open_angles,true) } ))));
 TRY((((*this).push_state( formatter::State { typename formatter::State::TypeContext(static_cast<size_t>(0ULL),static_cast<size_t>(0ULL),static_cast<size_t>(0ULL),static_cast<size_t>(0ULL),false) } ))));
-__jakt_var_606 = formatter::FormattedToken(token,((*this).indent),(TRY((Array<u8>::create_with({})))),(TRY((Array<u8>::create_with({}))))); goto __jakt_label_568;
+__jakt_var_613 = formatter::FormattedToken(token,((*this).indent),(TRY((Array<u8>::create_with({})))),(TRY((Array<u8>::create_with({}))))); goto __jakt_label_574;
 
 }
-__jakt_label_568:; __jakt_var_606.release_value(); }));
+__jakt_label_574:; __jakt_var_613.release_value(); }));
 };/*case end*/
 case 9: {
 auto&& __jakt_match_value = __jakt_match_variant.template get<typename lexer::Token::RParen>();
-return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_607; {
+return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_614; {
 if ((open_parens == static_cast<size_t>(0ULL))){
 ((*this).pop_state());
 ((((*this).index)--));
 return (TRY((((*this).next_impl(true)))));
 }
 TRY((((*this).replace_state( formatter::State { typename formatter::State::TypeContext((JaktInternal::checked_sub<size_t>(open_parens,static_cast<size_t>(1ULL))),open_curlies,open_squares,open_angles,seen_start) } ))));
-__jakt_var_607 = formatter::FormattedToken(token,((*this).indent),(TRY((Array<u8>::create_with({})))),(TRY((Array<u8>::create_with({}))))); goto __jakt_label_569;
+__jakt_var_614 = formatter::FormattedToken(token,((*this).indent),(TRY((Array<u8>::create_with({})))),(TRY((Array<u8>::create_with({}))))); goto __jakt_label_575;
 
 }
-__jakt_label_569:; __jakt_var_607.release_value(); }));
+__jakt_label_575:; __jakt_var_614.release_value(); }));
 };/*case end*/
 case 10: {
 auto&& __jakt_match_value = __jakt_match_variant.template get<typename lexer::Token::LCurly>();
-return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_608; {
+return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_615; {
 if (seen_start){
 ((((*this).index)--));
 ((*this).pop_state());
@@ -4906,91 +4906,91 @@ return (TRY((((*this).next_impl(true)))));
 }
 TRY((((*this).replace_state( formatter::State { typename formatter::State::TypeContext(open_parens,(JaktInternal::checked_add<size_t>(open_curlies,static_cast<size_t>(1ULL))),open_squares,open_angles,true) } ))));
 TRY((((*this).push_state( formatter::State { typename formatter::State::TypeContext(static_cast<size_t>(0ULL),static_cast<size_t>(0ULL),static_cast<size_t>(0ULL),static_cast<size_t>(0ULL),false) } ))));
-__jakt_var_608 = formatter::FormattedToken(token,((*this).indent),(TRY((Array<u8>::create_with({})))),(TRY((Array<u8>::create_with({}))))); goto __jakt_label_570;
+__jakt_var_615 = formatter::FormattedToken(token,((*this).indent),(TRY((Array<u8>::create_with({})))),(TRY((Array<u8>::create_with({}))))); goto __jakt_label_576;
 
 }
-__jakt_label_570:; __jakt_var_608.release_value(); }));
+__jakt_label_576:; __jakt_var_615.release_value(); }));
 };/*case end*/
 case 11: {
 auto&& __jakt_match_value = __jakt_match_variant.template get<typename lexer::Token::RCurly>();
-return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_609; {
+return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_616; {
 if ((open_curlies == static_cast<size_t>(0ULL))){
 ((*this).pop_state());
 ({auto& _jakt_ref = ((*this).index);_jakt_ref = JaktInternal::checked_sub<size_t>(_jakt_ref, static_cast<size_t>(1ULL));});
 return (TRY((((*this).next_impl(true)))));
 }
 TRY((((*this).replace_state( formatter::State { typename formatter::State::TypeContext(open_parens,(JaktInternal::checked_sub<size_t>(open_curlies,static_cast<size_t>(1ULL))),open_squares,open_angles,seen_start) } ))));
-__jakt_var_609 = formatter::FormattedToken(token,((*this).indent),(TRY((Array<u8>::create_with({})))),(TRY((Array<u8>::create_with({}))))); goto __jakt_label_571;
+__jakt_var_616 = formatter::FormattedToken(token,((*this).indent),(TRY((Array<u8>::create_with({})))),(TRY((Array<u8>::create_with({}))))); goto __jakt_label_577;
 
 }
-__jakt_label_571:; __jakt_var_609.release_value(); }));
+__jakt_label_577:; __jakt_var_616.release_value(); }));
 };/*case end*/
 case 91: {
 auto&& __jakt_match_value = __jakt_match_variant.template get<typename lexer::Token::Raw>();
-return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_610; {
+return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_617; {
 TRY((((*this).replace_state( formatter::State { typename formatter::State::TypeContext(open_parens,open_curlies,open_squares,open_angles,true) } ))));
-__jakt_var_610 = formatter::FormattedToken(token,((*this).indent),(TRY((Array<u8>::create_with({' '})))),(TRY((Array<u8>::create_with({}))))); goto __jakt_label_572;
+__jakt_var_617 = formatter::FormattedToken(token,((*this).indent),(TRY((Array<u8>::create_with({' '})))),(TRY((Array<u8>::create_with({}))))); goto __jakt_label_578;
 
 }
-__jakt_label_572:; __jakt_var_610.release_value(); }));
+__jakt_label_578:; __jakt_var_617.release_value(); }));
 };/*case end*/
 case 84: {
 auto&& __jakt_match_value = __jakt_match_variant.template get<typename lexer::Token::Mut>();
-return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_611; {
+return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_618; {
 TRY((((*this).replace_state( formatter::State { typename formatter::State::TypeContext(open_parens,open_curlies,open_squares,open_angles,true) } ))));
-__jakt_var_611 = formatter::FormattedToken(token,((*this).indent),(TRY((Array<u8>::create_with({' '})))),(TRY((Array<u8>::create_with({}))))); goto __jakt_label_573;
+__jakt_var_618 = formatter::FormattedToken(token,((*this).indent),(TRY((Array<u8>::create_with({' '})))),(TRY((Array<u8>::create_with({}))))); goto __jakt_label_579;
 
 }
-__jakt_label_573:; __jakt_var_611.release_value(); }));
+__jakt_label_579:; __jakt_var_618.release_value(); }));
 };/*case end*/
 case 38: {
 auto&& __jakt_match_value = __jakt_match_variant.template get<typename lexer::Token::Ampersand>();
-return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_612; {
+return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_619; {
 TRY((((*this).replace_state( formatter::State { typename formatter::State::TypeContext(open_parens,open_curlies,open_squares,open_angles,true) } ))));
-__jakt_var_612 = formatter::FormattedToken(token,((*this).indent),(TRY((Array<u8>::create_with({})))),(TRY((Array<u8>::create_with({}))))); goto __jakt_label_574;
+__jakt_var_619 = formatter::FormattedToken(token,((*this).indent),(TRY((Array<u8>::create_with({})))),(TRY((Array<u8>::create_with({}))))); goto __jakt_label_580;
 
 }
-__jakt_label_574:; __jakt_var_612.release_value(); }));
+__jakt_label_580:; __jakt_var_619.release_value(); }));
 };/*case end*/
 case 75: {
 auto&& __jakt_match_value = __jakt_match_variant.template get<typename lexer::Token::Function>();
-return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_613; {
+return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_620; {
 TRY((((*this).replace_state( formatter::State { typename formatter::State::TypeContext(open_parens,open_curlies,open_squares,open_angles,true) } ))));
 TRY((((*this).push_state( formatter::State { typename formatter::State::FunctionTypeContext(false) } ))));
-__jakt_var_613 = formatter::FormattedToken(token,((*this).indent),(TRY((Array<u8>::create_with({})))),(TRY((Array<u8>::create_with({}))))); goto __jakt_label_575;
+__jakt_var_620 = formatter::FormattedToken(token,((*this).indent),(TRY((Array<u8>::create_with({})))),(TRY((Array<u8>::create_with({}))))); goto __jakt_label_581;
 
 }
-__jakt_label_575:; __jakt_var_613.release_value(); }));
+__jakt_label_581:; __jakt_var_620.release_value(); }));
 };/*case end*/
 case 53: {
 auto&& __jakt_match_value = __jakt_match_variant.template get<typename lexer::Token::Comma>();
-return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_614; {
+return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_621; {
 if (((JaktInternal::checked_add<size_t>(open_angles,open_parens)) == static_cast<size_t>(0ULL))){
 ((((*this).index)--));
 ((*this).pop_state());
 return (TRY((((*this).next_impl(true)))));
 }
 TRY((((*this).push_state( formatter::State { typename formatter::State::TypeContext(static_cast<size_t>(0ULL),static_cast<size_t>(0ULL),static_cast<size_t>(0ULL),static_cast<size_t>(0ULL),false) } ))));
-__jakt_var_614 = formatter::FormattedToken(token,((*this).indent),(TRY((Array<u8>::create_with({' '})))),(TRY((Array<u8>::create_with({}))))); goto __jakt_label_576;
+__jakt_var_621 = formatter::FormattedToken(token,((*this).indent),(TRY((Array<u8>::create_with({' '})))),(TRY((Array<u8>::create_with({}))))); goto __jakt_label_582;
 
 }
-__jakt_label_576:; __jakt_var_614.release_value(); }));
+__jakt_label_582:; __jakt_var_621.release_value(); }));
 };/*case end*/
 case 4: {
-auto&& __jakt_match_value = __jakt_match_variant.template get<lexer::Token::Identifier>();return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_615; {
+auto&& __jakt_match_value = __jakt_match_variant.template get<lexer::Token::Identifier>();return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_622; {
 TRY((((*this).replace_state( formatter::State { typename formatter::State::TypeContext(open_parens,open_curlies,open_squares,open_angles,true) } ))));
-__jakt_var_615 = formatter::FormattedToken(token,((*this).indent),(TRY((Array<u8>::create_with({})))),(TRY((Array<u8>::create_with({}))))); goto __jakt_label_577;
+__jakt_var_622 = formatter::FormattedToken(token,((*this).indent),(TRY((Array<u8>::create_with({})))),(TRY((Array<u8>::create_with({}))))); goto __jakt_label_583;
 
 }
-__jakt_label_577:; __jakt_var_615.release_value(); }));
+__jakt_label_583:; __jakt_var_622.release_value(); }));
 };/*case end*/
 case 102: {
 auto&& __jakt_match_value = __jakt_match_variant.template get<typename lexer::Token::Weak>();
-return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_616; {
-__jakt_var_616 = formatter::FormattedToken(token,((*this).indent),(TRY((Array<u8>::create_with({' '})))),(TRY((Array<u8>::create_with({}))))); goto __jakt_label_578;
+return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_623; {
+__jakt_var_623 = formatter::FormattedToken(token,((*this).indent),(TRY((Array<u8>::create_with({' '})))),(TRY((Array<u8>::create_with({}))))); goto __jakt_label_584;
 
 }
-__jakt_label_578:; __jakt_var_616.release_value(); }));
+__jakt_label_584:; __jakt_var_623.release_value(); }));
 };/*case end*/
 case 17: {
 auto&& __jakt_match_value = __jakt_match_variant.template get<typename lexer::Token::Equal>();
@@ -5046,7 +5046,7 @@ return (TRY((((*this).next_impl(true)))));
 };/*case end*/
 case 59: {
 auto&& __jakt_match_value = __jakt_match_variant.template get<typename lexer::Token::Arrow>();
-return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_617; {
+return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_624; {
 if (seen_final_type){
 ((*this).pop_state());
 ((((*this).index)--));
@@ -5054,34 +5054,34 @@ return (TRY((((*this).next_impl(true)))));
 }
 TRY((((*this).replace_state( formatter::State { typename formatter::State::FunctionTypeContext(true) } ))));
 TRY((((*this).push_state( formatter::State { typename formatter::State::TypeContext(static_cast<size_t>(0ULL),static_cast<size_t>(0ULL),static_cast<size_t>(0ULL),static_cast<size_t>(0ULL),false) } ))));
-__jakt_var_617 = formatter::FormattedToken(token,((*this).indent),(TRY((Array<u8>::create_with({' '})))),(TRY((Array<u8>::create_with({' '}))))); goto __jakt_label_579;
+__jakt_var_624 = formatter::FormattedToken(token,((*this).indent),(TRY((Array<u8>::create_with({' '})))),(TRY((Array<u8>::create_with({' '}))))); goto __jakt_label_585;
 
 }
-__jakt_label_579:; __jakt_var_617.release_value(); }));
+__jakt_label_585:; __jakt_var_624.release_value(); }));
 };/*case end*/
 case 8: {
 auto&& __jakt_match_value = __jakt_match_variant.template get<typename lexer::Token::LParen>();
-return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_618; {
+return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_625; {
 if (seen_final_type){
 ((*this).pop_state());
 ((((*this).index)--));
 return (TRY((((*this).next_impl(true)))));
 }
 TRY((((*this).push_state( formatter::State { typename formatter::State::ParameterList(static_cast<size_t>(0ULL)) } ))));
-__jakt_var_618 = formatter::FormattedToken(token,((*this).indent),(TRY((Array<u8>::create_with({})))),(TRY((Array<u8>::create_with({}))))); goto __jakt_label_580;
+__jakt_var_625 = formatter::FormattedToken(token,((*this).indent),(TRY((Array<u8>::create_with({})))),(TRY((Array<u8>::create_with({}))))); goto __jakt_label_586;
 
 }
-__jakt_label_580:; __jakt_var_618.release_value(); }));
+__jakt_label_586:; __jakt_var_625.release_value(); }));
 };/*case end*/
 case 9: {
 auto&& __jakt_match_value = __jakt_match_variant.template get<typename lexer::Token::RParen>();
-return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_619; {
+return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_626; {
 if (seen_final_type){
 ((*this).pop_state());
 ((((*this).index)--));
 return (TRY((((*this).next_impl(true)))));
 }
-__jakt_var_619 = formatter::FormattedToken(token,((*this).indent),JAKT_RESOLVE_EXPLICIT_VALUE_OR_CONTROL_FLOW_RETURN_ONLY(([&]() -> JaktInternal::ExplicitValueOrControlFlow<JaktInternal::Array<u8>, ErrorOr<JaktInternal::Optional<formatter::FormattedToken>>>{
+__jakt_var_626 = formatter::FormattedToken(token,((*this).indent),JAKT_RESOLVE_EXPLICIT_VALUE_OR_CONTROL_FLOW_RETURN_ONLY(([&]() -> JaktInternal::ExplicitValueOrControlFlow<JaktInternal::Array<u8>, ErrorOr<JaktInternal::Optional<formatter::FormattedToken>>>{
 auto&& __jakt_match_variant = ((*this).peek(static_cast<i64>(0LL)));
 switch(__jakt_match_variant.index()) {
 case 97: {
@@ -5093,26 +5093,26 @@ return JaktInternal::ExplicitValue((TRY((Array<u8>::create_with({})))));
 };/*case end*/
 }/*switch end*/
 }()
-)),(TRY((Array<u8>::create_with({}))))); goto __jakt_label_581;
+)),(TRY((Array<u8>::create_with({}))))); goto __jakt_label_587;
 
 }
-__jakt_label_581:; __jakt_var_619.release_value(); }));
+__jakt_label_587:; __jakt_var_626.release_value(); }));
 };/*case end*/
 case 97: {
 auto&& __jakt_match_value = __jakt_match_variant.template get<typename lexer::Token::Throws>();
 return JaktInternal::ExplicitValue(formatter::FormattedToken(token,((*this).indent),(TRY((Array<u8>::create_with({})))),(TRY((Array<u8>::create_with({}))))));
 };/*case end*/
 default: {
-return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_620; {
+return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_627; {
 if (seen_final_type){
 ((*this).pop_state());
 ((((*this).index)--));
 return (TRY((((*this).next_impl(true)))));
 }
-__jakt_var_620 = formatter::FormattedToken(token,((*this).indent),(TRY((Array<u8>::create_with({})))),(TRY((Array<u8>::create_with({}))))); goto __jakt_label_582;
+__jakt_var_627 = formatter::FormattedToken(token,((*this).indent),(TRY((Array<u8>::create_with({})))),(TRY((Array<u8>::create_with({}))))); goto __jakt_label_588;
 
 }
-__jakt_label_582:; __jakt_var_620.release_value(); }));
+__jakt_label_588:; __jakt_var_627.release_value(); }));
 };/*case end*/
 }/*switch end*/
 }()
@@ -5126,55 +5126,55 @@ auto&& __jakt_match_variant = token;
 switch(__jakt_match_variant.index()) {
 case 8: {
 auto&& __jakt_match_value = __jakt_match_variant.template get<typename lexer::Token::LParen>();
-return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_621; {
+return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_628; {
 TRY((((*this).replace_state( formatter::State { typename formatter::State::MatchPattern((JaktInternal::checked_add<size_t>(open_parens,static_cast<size_t>(1ULL))),allow_multiple) } ))));
 TRY((((*this).push_state( formatter::State { typename formatter::State::StatementContext(static_cast<size_t>(0ULL),static_cast<size_t>(0ULL),static_cast<size_t>(0ULL),static_cast<size_t>(0ULL),static_cast<size_t>(0ULL),false, formatter::ExpressionMode { typename formatter::ExpressionMode::OutsideExpression() } ,static_cast<size_t>(0ULL)) } ))));
-__jakt_var_621 = formatter::FormattedToken(token,((*this).indent),(TRY((Array<u8>::create_with({})))),(TRY((Array<u8>::create_with({}))))); goto __jakt_label_583;
+__jakt_var_628 = formatter::FormattedToken(token,((*this).indent),(TRY((Array<u8>::create_with({})))),(TRY((Array<u8>::create_with({}))))); goto __jakt_label_589;
 
 }
-__jakt_label_583:; __jakt_var_621.release_value(); }));
+__jakt_label_589:; __jakt_var_628.release_value(); }));
 };/*case end*/
 case 9: {
 auto&& __jakt_match_value = __jakt_match_variant.template get<typename lexer::Token::RParen>();
-return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_622; {
+return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_629; {
 if ((open_parens == static_cast<size_t>(0ULL))){
 ((*this).pop_state());
 ({auto& _jakt_ref = ((*this).index);_jakt_ref = JaktInternal::checked_sub<size_t>(_jakt_ref, static_cast<size_t>(1ULL));});
 return (TRY((((*this).next_impl(true)))));
 }
 TRY((((*this).replace_state( formatter::State { typename formatter::State::MatchPattern((JaktInternal::checked_sub<size_t>(open_parens,static_cast<size_t>(1ULL))),allow_multiple) } ))));
-__jakt_var_622 = formatter::FormattedToken(token,((*this).indent),(TRY((Array<u8>::create_with({})))),(TRY((Array<u8>::create_with({}))))); goto __jakt_label_584;
+__jakt_var_629 = formatter::FormattedToken(token,((*this).indent),(TRY((Array<u8>::create_with({})))),(TRY((Array<u8>::create_with({}))))); goto __jakt_label_590;
 
 }
-__jakt_label_584:; __jakt_var_622.release_value(); }));
+__jakt_label_590:; __jakt_var_629.release_value(); }));
 };/*case end*/
 case 56: {
-auto&& __jakt_match_value = __jakt_match_variant.template get<lexer::Token::Eol>();return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_623; {
+auto&& __jakt_match_value = __jakt_match_variant.template get<lexer::Token::Eol>();return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_630; {
 if ((!(allow_multiple))){
 ((*this).pop_state());
 ({auto& _jakt_ref = ((*this).index);_jakt_ref = JaktInternal::checked_sub<size_t>(_jakt_ref, static_cast<size_t>(1ULL));});
 return (TRY((((*this).next_impl(true)))));
 }
-__jakt_var_623 = formatter::FormattedToken(token,((*this).indent),(TRY((Array<u8>::create_with({})))),(TRY((Array<u8>::create_with({}))))); goto __jakt_label_585;
+__jakt_var_630 = formatter::FormattedToken(token,((*this).indent),(TRY((Array<u8>::create_with({})))),(TRY((Array<u8>::create_with({}))))); goto __jakt_label_591;
 
 }
-__jakt_label_585:; __jakt_var_623.release_value(); }));
+__jakt_label_591:; __jakt_var_630.release_value(); }));
 };/*case end*/
 case 4: {
 auto&& __jakt_match_value = __jakt_match_variant.template get<lexer::Token::Identifier>();return JaktInternal::ExplicitValue(formatter::FormattedToken(token,((*this).indent),(TRY((Array<u8>::create_with({})))),(TRY((Array<u8>::create_with({}))))));
 };/*case end*/
 case 41: {
 auto&& __jakt_match_value = __jakt_match_variant.template get<typename lexer::Token::Pipe>();
-return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_624; {
+return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_631; {
 if ((!(allow_multiple))){
 ((*this).pop_state());
 ({auto& _jakt_ref = ((*this).index);_jakt_ref = JaktInternal::checked_sub<size_t>(_jakt_ref, static_cast<size_t>(1ULL));});
 return (TRY((((*this).next_impl(true)))));
 }
-__jakt_var_624 = formatter::FormattedToken(token,((*this).indent),(TRY((Array<u8>::create_with({' '})))),(TRY((Array<u8>::create_with({' '}))))); goto __jakt_label_586;
+__jakt_var_631 = formatter::FormattedToken(token,((*this).indent),(TRY((Array<u8>::create_with({' '})))),(TRY((Array<u8>::create_with({' '}))))); goto __jakt_label_592;
 
 }
-__jakt_label_586:; __jakt_var_624.release_value(); }));
+__jakt_label_592:; __jakt_var_631.release_value(); }));
 };/*case end*/
 default: {
 {

--- a/bootstrap/stage0/formatter.h
+++ b/bootstrap/stage0/formatter.h
@@ -300,21 +300,7 @@ template <typename T>
 ErrorOr<JaktInternal::Array<T>> concat(JaktInternal::Array<T> const xs,T const y) {
 {
 JaktInternal::Array<T> ys = (TRY((Array<T>::create_with({}))));
-{
-JaktInternal::ArrayIterator<T> _magic = ((xs).iterator());
-for (;;){
-JaktInternal::Optional<T> _magic_value = ((_magic).next());
-if ((!(((_magic_value).has_value())))){
-break;
-}
-T x = (_magic_value.value());
-{
-TRY((((ys).push(x))));
-}
-
-}
-}
-
+TRY((((ys).push_values(xs))));
 TRY((((ys).push(y))));
 return (ys);
 }

--- a/bootstrap/stage0/ide.cpp
+++ b/bootstrap/stage0/ide.cpp
@@ -10,7 +10,7 @@ auto&& __jakt_match_variant = ((record).record_type);
 switch(__jakt_match_variant.index()) {
 case 0: {
 auto&& __jakt_match_value = __jakt_match_variant.template get<parser::RecordType::Struct>();JaktInternal::Array<parser::ParsedField> const& fields = __jakt_match_value.fields;
-return JaktInternal::ExplicitValue(({ Optional<String> __jakt_var_647; {
+return JaktInternal::ExplicitValue(({ Optional<String> __jakt_var_654; {
 {
 JaktInternal::ArrayIterator<parser::ParsedField> _magic = ((fields).iterator());
 for (;;){
@@ -26,14 +26,14 @@ TRY((((children).push(ide::JaktSymbol(((((field).var_decl)).name),JaktInternal::
 }
 }
 
-__jakt_var_647 = String("struct"); goto __jakt_label_594;
+__jakt_var_654 = String("struct"); goto __jakt_label_600;
 
 }
-__jakt_label_594:; __jakt_var_647.release_value(); }));
+__jakt_label_600:; __jakt_var_654.release_value(); }));
 };/*case end*/
 case 1: {
 auto&& __jakt_match_value = __jakt_match_variant.template get<parser::RecordType::Class>();JaktInternal::Array<parser::ParsedField> const& fields = __jakt_match_value.fields;
-return JaktInternal::ExplicitValue(({ Optional<String> __jakt_var_648; {
+return JaktInternal::ExplicitValue(({ Optional<String> __jakt_var_655; {
 {
 JaktInternal::ArrayIterator<parser::ParsedField> _magic = ((fields).iterator());
 for (;;){
@@ -49,14 +49,14 @@ TRY((((children).push(ide::JaktSymbol(((((field).var_decl)).name),JaktInternal::
 }
 }
 
-__jakt_var_648 = String("class"); goto __jakt_label_595;
+__jakt_var_655 = String("class"); goto __jakt_label_601;
 
 }
-__jakt_label_595:; __jakt_var_648.release_value(); }));
+__jakt_label_601:; __jakt_var_655.release_value(); }));
 };/*case end*/
 case 2: {
 auto&& __jakt_match_value = __jakt_match_variant.template get<parser::RecordType::ValueEnum>();JaktInternal::Array<parser::ValueEnumVariant> const& variants = __jakt_match_value.variants;
-return JaktInternal::ExplicitValue(({ Optional<String> __jakt_var_649; {
+return JaktInternal::ExplicitValue(({ Optional<String> __jakt_var_656; {
 {
 JaktInternal::ArrayIterator<parser::ValueEnumVariant> _magic = ((variants).iterator());
 for (;;){
@@ -72,14 +72,14 @@ TRY((((children).push(ide::JaktSymbol(((variant).name),JaktInternal::OptionalNon
 }
 }
 
-__jakt_var_649 = String("enum"); goto __jakt_label_596;
+__jakt_var_656 = String("enum"); goto __jakt_label_602;
 
 }
-__jakt_label_596:; __jakt_var_649.release_value(); }));
+__jakt_label_602:; __jakt_var_656.release_value(); }));
 };/*case end*/
 case 3: {
 auto&& __jakt_match_value = __jakt_match_variant.template get<parser::RecordType::SumEnum>();JaktInternal::Array<parser::SumEnumVariant> const& variants = __jakt_match_value.variants;
-return JaktInternal::ExplicitValue(({ Optional<String> __jakt_var_650; {
+return JaktInternal::ExplicitValue(({ Optional<String> __jakt_var_657; {
 {
 JaktInternal::ArrayIterator<parser::SumEnumVariant> _magic = ((variants).iterator());
 for (;;){
@@ -115,10 +115,10 @@ TRY((((children).push(ide::JaktSymbol(((variant).name),JaktInternal::OptionalNon
 }
 }
 
-__jakt_var_650 = String("enum"); goto __jakt_label_597;
+__jakt_var_657 = String("enum"); goto __jakt_label_603;
 
 }
-__jakt_label_597:; __jakt_var_650.release_value(); }));
+__jakt_label_603:; __jakt_var_657.release_value(); }));
 };/*case end*/
 case 4: {
 auto&& __jakt_match_value = __jakt_match_variant.template get<typename parser::RecordType::Garbage>();
@@ -162,37 +162,37 @@ ide::Mutability const& mutability = __jakt_match_value.mutability;
 ide::VarType const& var_type = __jakt_match_value.var_type;
 ide::VarVisibility const& visibility = __jakt_match_value.visibility;
 JaktInternal::Optional<types::TypeId> const& struct_type_id = __jakt_match_value.struct_type_id;
-return JaktInternal::ExplicitValue(({ Optional<JaktInternal::Optional<String>> __jakt_var_651; {
+return JaktInternal::ExplicitValue(({ Optional<JaktInternal::Optional<String>> __jakt_var_658; {
 String const result = TRY((ide::get_var_signature(program,name,type_id,mutability,var_type,visibility,struct_type_id)));
-__jakt_var_651 = static_cast<JaktInternal::Optional<String>>(result); goto __jakt_label_598;
+__jakt_var_658 = static_cast<JaktInternal::Optional<String>>(result); goto __jakt_label_604;
 
 }
-__jakt_label_598:; __jakt_var_651.release_value(); }));
+__jakt_label_604:; __jakt_var_658.release_value(); }));
 };/*case end*/
 case 1: {
 auto&& __jakt_match_value = __jakt_match_variant.template get<typename ide::Usage::Call>();
 types::FunctionId const& function_id = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(({ Optional<JaktInternal::Optional<String>> __jakt_var_652; {
+return JaktInternal::ExplicitValue(({ Optional<JaktInternal::Optional<String>> __jakt_var_659; {
 String const result = TRY((ide::get_function_signature(program,function_id)));
-__jakt_var_652 = static_cast<JaktInternal::Optional<String>>(result); goto __jakt_label_599;
+__jakt_var_659 = static_cast<JaktInternal::Optional<String>>(result); goto __jakt_label_605;
 
 }
-__jakt_label_599:; __jakt_var_652.release_value(); }));
+__jakt_label_605:; __jakt_var_659.release_value(); }));
 };/*case end*/
 case 2: {
 auto&& __jakt_match_value = __jakt_match_variant.template get<typename ide::Usage::Typename>();
 types::TypeId const& type_id = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(({ Optional<JaktInternal::Optional<String>> __jakt_var_653; {
+return JaktInternal::ExplicitValue(({ Optional<JaktInternal::Optional<String>> __jakt_var_660; {
 String const result = TRY((ide::get_type_signature(program,type_id)));
-__jakt_var_653 = static_cast<JaktInternal::Optional<String>>(result); goto __jakt_label_600;
+__jakt_var_660 = static_cast<JaktInternal::Optional<String>>(result); goto __jakt_label_606;
 
 }
-__jakt_label_600:; __jakt_var_653.release_value(); }));
+__jakt_label_606:; __jakt_var_660.release_value(); }));
 };/*case end*/
 case 3: {
 auto&& __jakt_match_value = __jakt_match_variant.template get<typename ide::Usage::NameSet>();
 JaktInternal::Array<String> const& names = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(({ Optional<JaktInternal::Optional<String>> __jakt_var_654; {
+return JaktInternal::ExplicitValue(({ Optional<JaktInternal::Optional<String>> __jakt_var_661; {
 String output = String("");
 bool first = true;
 {
@@ -217,22 +217,22 @@ else {
 }
 }
 
-__jakt_var_654 = static_cast<JaktInternal::Optional<String>>(output); goto __jakt_label_601;
+__jakt_var_661 = static_cast<JaktInternal::Optional<String>>(output); goto __jakt_label_607;
 
 }
-__jakt_label_601:; __jakt_var_654.release_value(); }));
+__jakt_label_607:; __jakt_var_661.release_value(); }));
 };/*case end*/
 case 4: {
 auto&& __jakt_match_value = __jakt_match_variant.template get<ide::Usage::EnumVariant>();String const& name = __jakt_match_value.name;
 types::TypeId const& type_id = __jakt_match_value.type_id;
 JaktInternal::Array<JaktInternal::Tuple<JaktInternal::Optional<String>,types::TypeId>> const& variants = __jakt_match_value.variants;
 JaktInternal::Optional<types::NumberConstant> const& number_constant = __jakt_match_value.number_constant;
-return JaktInternal::ExplicitValue(({ Optional<JaktInternal::Optional<String>> __jakt_var_655; {
+return JaktInternal::ExplicitValue(({ Optional<JaktInternal::Optional<String>> __jakt_var_662; {
 String const result = TRY((ide::get_enum_variant_signature(program,name,type_id,variants,number_constant)));
-__jakt_var_655 = static_cast<JaktInternal::Optional<String>>(result); goto __jakt_label_602;
+__jakt_var_662 = static_cast<JaktInternal::Optional<String>>(result); goto __jakt_label_608;
 
 }
-__jakt_label_602:; __jakt_var_655.release_value(); }));
+__jakt_label_608:; __jakt_var_662.release_value(); }));
 };/*case end*/
 default: VERIFY_NOT_REACHED();}/*switch end*/
 }()
@@ -258,60 +258,7 @@ types::EnumId const& enum_id = __jakt_match_value.value;
 {
 types::CheckedEnum const enum_ = ((program)->get_enum(enum_id));
 NonnullRefPtr<types::Scope> const scope = TRY((((program)->get_scope(((enum_).scope_id)))));
-{
-JaktInternal::ArrayIterator<String> _magic = ((TRY((((((scope)->functions)).keys())))).iterator());
-for (;;){
-JaktInternal::Optional<String> _magic_value = ((_magic).next());
-if ((!(((_magic_value).has_value())))){
-break;
-}
-String function_name = (_magic_value.value());
-{
-types::FunctionId const function_id = (((((scope)->functions)).get(function_name)).value());
-NonnullRefPtr<types::CheckedFunction> const checked_function = ((program)->get_function(function_id));
-if (((((((checked_function)->params)).first())).has_value())){
-types::CheckedParameter const param = (((((checked_function)->params)).first()).value());
-if ((((((param).variable)).name) == String("this"))){
-String full_call = ((checked_function)->name);
-bool first = true;
-(full_call += String("("));
-JaktInternal::ArrayIterator<types::CheckedParameter> iter = ((((checked_function)->params)).iterator());
-JaktInternal::Optional<types::CheckedParameter> const dummy = ((iter).next());
-{
-JaktInternal::ArrayIterator<types::CheckedParameter> _magic = iter;
-for (;;){
-JaktInternal::Optional<types::CheckedParameter> _magic_value = ((_magic).next());
-if ((!(((_magic_value).has_value())))){
-break;
-}
-types::CheckedParameter param = (_magic_value.value());
-{
-if ((!(first))){
-(full_call += String(", "));
-}
-else {
-(first = false);
-}
-
-(full_call += ((((param).variable)).name));
-}
-
-}
-}
-
-(full_call += String(")"));
-TRY((((output).push(full_call))));
-}
-}
-else {
-TRY((((output).push(TRY((String::formatted(String("{}()"),((checked_function)->name))))))));
-}
-
-}
-
-}
-}
-
+TRY((((output).push_values(TRY((ide::find_function_completions_in_scope(scope,program)))))));
 }
 return JaktInternal::ExplicitValue<void>();
 };/*case end*/
@@ -337,60 +284,7 @@ TRY((((output).push(((field_var).name)))));
 }
 
 NonnullRefPtr<types::Scope> const scope = TRY((((program)->get_scope(((structure).scope_id)))));
-{
-JaktInternal::ArrayIterator<String> _magic = ((TRY((((((scope)->functions)).keys())))).iterator());
-for (;;){
-JaktInternal::Optional<String> _magic_value = ((_magic).next());
-if ((!(((_magic_value).has_value())))){
-break;
-}
-String function_name = (_magic_value.value());
-{
-types::FunctionId const function_id = (((((scope)->functions)).get(function_name)).value());
-NonnullRefPtr<types::CheckedFunction> const checked_function = ((program)->get_function(function_id));
-if (((((((checked_function)->params)).first())).has_value())){
-types::CheckedParameter const param = (((((checked_function)->params)).first()).value());
-if ((((((param).variable)).name) == String("this"))){
-String full_call = ((checked_function)->name);
-bool first = true;
-(full_call += String("("));
-JaktInternal::ArrayIterator<types::CheckedParameter> iter = ((((checked_function)->params)).iterator());
-JaktInternal::Optional<types::CheckedParameter> const dummy = ((iter).next());
-{
-JaktInternal::ArrayIterator<types::CheckedParameter> _magic = iter;
-for (;;){
-JaktInternal::Optional<types::CheckedParameter> _magic_value = ((_magic).next());
-if ((!(((_magic_value).has_value())))){
-break;
-}
-types::CheckedParameter param = (_magic_value.value());
-{
-if ((!(first))){
-(full_call += String(", "));
-}
-else {
-(first = false);
-}
-
-(full_call += ((((param).variable)).name));
-}
-
-}
-}
-
-(full_call += String(")"));
-TRY((((output).push(full_call))));
-}
-}
-else {
-TRY((((output).push(TRY((String::formatted(String("{}()"),((checked_function)->name))))))));
-}
-
-}
-
-}
-}
-
+TRY((((output).push_values(TRY((ide::find_function_completions_in_scope(scope,program)))))));
 }
 return JaktInternal::ExplicitValue<void>();
 };/*case end*/
@@ -415,60 +309,7 @@ TRY((((output).push(((field_var).name)))));
 }
 
 NonnullRefPtr<types::Scope> const scope = TRY((((program)->get_scope(((structure).scope_id)))));
-{
-JaktInternal::ArrayIterator<String> _magic = ((TRY((((((scope)->functions)).keys())))).iterator());
-for (;;){
-JaktInternal::Optional<String> _magic_value = ((_magic).next());
-if ((!(((_magic_value).has_value())))){
-break;
-}
-String function_name = (_magic_value.value());
-{
-types::FunctionId const function_id = (((((scope)->functions)).get(function_name)).value());
-NonnullRefPtr<types::CheckedFunction> const checked_function = ((program)->get_function(function_id));
-if (((((((checked_function)->params)).first())).has_value())){
-types::CheckedParameter const param = (((((checked_function)->params)).first()).value());
-if ((((((param).variable)).name) == String("this"))){
-String full_call = ((checked_function)->name);
-bool first = true;
-(full_call += String("("));
-JaktInternal::ArrayIterator<types::CheckedParameter> iter = ((((checked_function)->params)).iterator());
-JaktInternal::Optional<types::CheckedParameter> const dummy = ((iter).next());
-{
-JaktInternal::ArrayIterator<types::CheckedParameter> _magic = iter;
-for (;;){
-JaktInternal::Optional<types::CheckedParameter> _magic_value = ((_magic).next());
-if ((!(((_magic_value).has_value())))){
-break;
-}
-types::CheckedParameter param = (_magic_value.value());
-{
-if ((!(first))){
-(full_call += String(", "));
-}
-else {
-(first = false);
-}
-
-(full_call += ((((param).variable)).name));
-}
-
-}
-}
-
-(full_call += String(")"));
-TRY((((output).push(full_call))));
-}
-}
-else {
-TRY((((output).push(TRY((String::formatted(String("{}()"),((checked_function)->name))))))));
-}
-
-}
-
-}
-}
-
+TRY((((output).push_values(TRY((ide::find_function_completions_in_scope(scope,program)))))));
 }
 return JaktInternal::ExplicitValue<void>();
 };/*case end*/
@@ -598,19 +439,19 @@ auto&& __jakt_match_variant = variant;
 switch(__jakt_match_variant.index()) {
 case 2: {
 auto&& __jakt_match_value = __jakt_match_variant.template get<types::CheckedEnumVariant::WithValue>();NonnullRefPtr<types::CheckedExpression> const& expr = __jakt_match_value.expr;
-return JaktInternal::ExplicitValue(({ Optional<JaktInternal::Optional<types::NumberConstant>> __jakt_var_656; {
-__jakt_var_656 = ((expr)->to_number_constant(program)); goto __jakt_label_603;
+return JaktInternal::ExplicitValue(({ Optional<JaktInternal::Optional<types::NumberConstant>> __jakt_var_663; {
+__jakt_var_663 = ((expr)->to_number_constant(program)); goto __jakt_label_609;
 
 }
-__jakt_label_603:; __jakt_var_656.release_value(); }));
+__jakt_label_609:; __jakt_var_663.release_value(); }));
 };/*case end*/
 default: {
-return JaktInternal::ExplicitValue(({ Optional<JaktInternal::Optional<types::NumberConstant>> __jakt_var_657; {
+return JaktInternal::ExplicitValue(({ Optional<JaktInternal::Optional<types::NumberConstant>> __jakt_var_664; {
 JaktInternal::Optional<types::NumberConstant> const none = JaktInternal::OptionalNone();
-__jakt_var_657 = none; goto __jakt_label_604;
+__jakt_var_664 = none; goto __jakt_label_610;
 
 }
-__jakt_label_604:; __jakt_var_657.release_value(); }));
+__jakt_label_610:; __jakt_var_664.release_value(); }));
 };/*case end*/
 }/*switch end*/
 }()
@@ -747,7 +588,7 @@ return JaktInternal::ExplicitValue(((((program)->get_trait(trait_id)))->name));
 case 29: {
 auto&& __jakt_match_value = __jakt_match_variant.template get<types::Type::Function>();JaktInternal::Array<types::TypeId> const& params = __jakt_match_value.params;
 types::TypeId const& return_type_id = __jakt_match_value.return_type_id;
-return JaktInternal::ExplicitValue(({ Optional<String> __jakt_var_658; {
+return JaktInternal::ExplicitValue(({ Optional<String> __jakt_var_665; {
 JaktInternal::Array<String> param_names = (TRY((Array<String>::create_with({}))));
 {
 JaktInternal::ArrayIterator<types::TypeId> _magic = ((params).iterator());
@@ -765,10 +606,10 @@ TRY((((param_names).push(TRY((((program)->type_name(x))))))));
 }
 
 String const return_type = TRY((((program)->type_name(return_type_id))));
-__jakt_var_658 = TRY((String::formatted(String("function({}) -> {}"),utility::join(param_names,String(", ")),return_type))); goto __jakt_label_605;
+__jakt_var_665 = TRY((String::formatted(String("function({}) -> {}"),utility::join(param_names,String(", ")),return_type))); goto __jakt_label_611;
 
 }
-__jakt_label_605:; __jakt_var_658.release_value(); }));
+__jakt_label_611:; __jakt_var_665.release_value(); }));
 };/*case end*/
 case 25: {
 auto&& __jakt_match_value = __jakt_match_variant.template get<typename types::Type::RawPtr>();
@@ -778,9 +619,9 @@ return JaktInternal::ExplicitValue((String("raw ") + TRY((ide::get_type_signatur
 case 24: {
 auto&& __jakt_match_value = __jakt_match_variant.template get<typename types::Type::Enum>();
 types::EnumId const& id = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(({ Optional<String> __jakt_var_659; {
+return JaktInternal::ExplicitValue(({ Optional<String> __jakt_var_666; {
 types::CheckedEnum const enum_ = ((program)->get_enum(id));
-__jakt_var_659 = ((JAKT_RESOLVE_EXPLICIT_VALUE_OR_CONTROL_FLOW_RETURN_ONLY(([&]() -> JaktInternal::ExplicitValueOrControlFlow<String,ErrorOr<String>>{
+__jakt_var_666 = ((JAKT_RESOLVE_EXPLICIT_VALUE_OR_CONTROL_FLOW_RETURN_ONLY(([&]() -> JaktInternal::ExplicitValueOrControlFlow<String,ErrorOr<String>>{
 auto __jakt_enum_value = (((enum_).is_boxed));
 if (__jakt_enum_value == true) {
 return JaktInternal::ExplicitValue(String("boxed "));
@@ -789,17 +630,17 @@ else {
 return JaktInternal::ExplicitValue(String(""));
 }
 }()))
- + String("enum ")) + ((enum_).name)); goto __jakt_label_606;
+ + String("enum ")) + ((enum_).name)); goto __jakt_label_612;
 
 }
-__jakt_label_606:; __jakt_var_659.release_value(); }));
+__jakt_label_612:; __jakt_var_666.release_value(); }));
 };/*case end*/
 case 23: {
 auto&& __jakt_match_value = __jakt_match_variant.template get<typename types::Type::Struct>();
 types::StructId const& id = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(({ Optional<String> __jakt_var_660; {
+return JaktInternal::ExplicitValue(({ Optional<String> __jakt_var_667; {
 types::CheckedStruct const struct_ = ((program)->get_struct(id));
-__jakt_var_660 = (JAKT_RESOLVE_EXPLICIT_VALUE_OR_CONTROL_FLOW_RETURN_ONLY(([&]() -> JaktInternal::ExplicitValueOrControlFlow<String, ErrorOr<String>>{
+__jakt_var_667 = (JAKT_RESOLVE_EXPLICIT_VALUE_OR_CONTROL_FLOW_RETURN_ONLY(([&]() -> JaktInternal::ExplicitValueOrControlFlow<String, ErrorOr<String>>{
 auto&& __jakt_match_variant = ((struct_).record_type);
 switch(__jakt_match_variant.index()) {
 case 1: {
@@ -815,15 +656,15 @@ utility::panic(String("unreachable: should've been struct"));
 };/*case end*/
 }/*switch end*/
 }()
-)) + ((struct_).name)); goto __jakt_label_607;
+)) + ((struct_).name)); goto __jakt_label_613;
 
 }
-__jakt_label_607:; __jakt_var_660.release_value(); }));
+__jakt_label_613:; __jakt_var_667.release_value(); }));
 };/*case end*/
 case 22: {
 auto&& __jakt_match_value = __jakt_match_variant.template get<types::Type::GenericResolvedType>();types::StructId const& id = __jakt_match_value.id;
 JaktInternal::Array<types::TypeId> const& args = __jakt_match_value.args;
-return JaktInternal::ExplicitValue(({ Optional<String> __jakt_var_661; {
+return JaktInternal::ExplicitValue(({ Optional<String> __jakt_var_668; {
 types::CheckedStruct const record = ((program)->get_struct(id));
 String output = ((record).name);
 (output += String("<"));
@@ -846,15 +687,15 @@ size_t i = (_magic_value.value());
 }
 
 }
-__jakt_var_661 = (output + String(">")); goto __jakt_label_608;
+__jakt_var_668 = (output + String(">")); goto __jakt_label_614;
 
 }
-__jakt_label_608:; __jakt_var_661.release_value(); }));
+__jakt_label_614:; __jakt_var_668.release_value(); }));
 };/*case end*/
 case 20: {
 auto&& __jakt_match_value = __jakt_match_variant.template get<types::Type::GenericEnumInstance>();types::EnumId const& id = __jakt_match_value.id;
 JaktInternal::Array<types::TypeId> const& args = __jakt_match_value.args;
-return JaktInternal::ExplicitValue(({ Optional<String> __jakt_var_662; {
+return JaktInternal::ExplicitValue(({ Optional<String> __jakt_var_669; {
 types::CheckedEnum const enum_ = ((program)->get_enum(id));
 String output = String("");
 if (((enum_).is_boxed)){
@@ -882,15 +723,15 @@ size_t i = (_magic_value.value());
 }
 
 }
-__jakt_var_662 = (output + String(">")); goto __jakt_label_609;
+__jakt_var_669 = (output + String(">")); goto __jakt_label_615;
 
 }
-__jakt_label_609:; __jakt_var_662.release_value(); }));
+__jakt_label_615:; __jakt_var_669.release_value(); }));
 };/*case end*/
 case 21: {
 auto&& __jakt_match_value = __jakt_match_variant.template get<types::Type::GenericTraitInstance>();types::TraitId const& id = __jakt_match_value.id;
 JaktInternal::Array<types::TypeId> const& args = __jakt_match_value.args;
-return JaktInternal::ExplicitValue(({ Optional<String> __jakt_var_663; {
+return JaktInternal::ExplicitValue(({ Optional<String> __jakt_var_670; {
 NonnullRefPtr<types::CheckedTrait> const trait_ = ((program)->get_trait(id));
 String output = String("");
 (output += String("trait "));
@@ -915,15 +756,15 @@ size_t i = (_magic_value.value());
 }
 
 }
-__jakt_var_663 = (output + String(">")); goto __jakt_label_610;
+__jakt_var_670 = (output + String(">")); goto __jakt_label_616;
 
 }
-__jakt_label_610:; __jakt_var_663.release_value(); }));
+__jakt_label_616:; __jakt_var_670.release_value(); }));
 };/*case end*/
 case 19: {
 auto&& __jakt_match_value = __jakt_match_variant.template get<types::Type::GenericInstance>();types::StructId const& id = __jakt_match_value.id;
 JaktInternal::Array<types::TypeId> const& args = __jakt_match_value.args;
-return JaktInternal::ExplicitValue(({ Optional<String> __jakt_var_664; {
+return JaktInternal::ExplicitValue(({ Optional<String> __jakt_var_671; {
 if (((id).equals(array_struct_id))){
 if (((args).is_empty())){
 return (String("[]"));
@@ -1031,10 +872,10 @@ size_t i = (_magic_value.value());
 }
 
 }
-__jakt_var_664 = (output + String(">")); goto __jakt_label_611;
+__jakt_var_671 = (output + String(">")); goto __jakt_label_617;
 
 }
-__jakt_label_611:; __jakt_var_664.release_value(); }));
+__jakt_label_617:; __jakt_var_671.release_value(); }));
 };/*case end*/
 case 27: {
 auto&& __jakt_match_value = __jakt_match_variant.template get<typename types::Type::Reference>();
@@ -1073,19 +914,37 @@ return (static_cast<JaktInternal::Optional<ide::Usage>>( ide::Usage { typename i
 }
 
 {
-JaktInternal::DictionaryIterator<String,types::FunctionId> _magic = ((((scope)->functions)).iterator());
+JaktInternal::DictionaryIterator<String,JaktInternal::Array<types::FunctionId>> _magic = ((((scope)->functions)).iterator());
 for (;;){
-JaktInternal::Optional<JaktInternal::Tuple<String,types::FunctionId>> _magic_value = ((_magic).next());
+JaktInternal::Optional<JaktInternal::Tuple<String,JaktInternal::Array<types::FunctionId>>> _magic_value = ((_magic).next());
 if ((!(((_magic_value).has_value())))){
 break;
 }
-JaktInternal::Tuple<String,types::FunctionId> function_id = (_magic_value.value());
+JaktInternal::Tuple<String,JaktInternal::Array<types::FunctionId>> ___overload_set__ = (_magic_value.value());
 {
-NonnullRefPtr<types::CheckedFunction> const checked_function = ((program)->get_function(((function_id).get<1>())));
+JaktInternal::Tuple<String,JaktInternal::Array<types::FunctionId>> const jakt_____overload_set__ = ___overload_set__;
+String const _ = ((jakt_____overload_set__).get<0>());
+JaktInternal::Array<types::FunctionId> const overload_set = ((jakt_____overload_set__).get<1>());
+
+{
+JaktInternal::ArrayIterator<types::FunctionId> _magic = ((overload_set).iterator());
+for (;;){
+JaktInternal::Optional<types::FunctionId> _magic_value = ((_magic).next());
+if ((!(((_magic_value).has_value())))){
+break;
+}
+types::FunctionId function_id = (_magic_value.value());
+{
+NonnullRefPtr<types::CheckedFunction> const checked_function = ((program)->get_function(function_id));
 JaktInternal::Optional<ide::Usage> const usage = TRY((ide::find_span_in_function(program,checked_function,span)));
 if (((usage).has_value())){
 return ((usage.value()));
 }
+}
+
+}
+}
+
 }
 
 }
@@ -1217,21 +1076,21 @@ auto&& __jakt_match_variant = (result.value());
 switch(__jakt_match_variant.index()) {
 case 0: {
 auto&& __jakt_match_value = __jakt_match_variant.template get<ide::Usage::Variable>();types::TypeId const& type_id = __jakt_match_value.type_id;
-return JaktInternal::ExplicitValue(({ Optional<JaktInternal::Array<String>> __jakt_var_665; {
-__jakt_var_665 = TRY((ide::completions_for_type_id(program,type_id))); goto __jakt_label_612;
+return JaktInternal::ExplicitValue(({ Optional<JaktInternal::Array<String>> __jakt_var_672; {
+__jakt_var_672 = TRY((ide::completions_for_type_id(program,type_id))); goto __jakt_label_618;
 
 }
-__jakt_label_612:; __jakt_var_665.release_value(); }));
+__jakt_label_618:; __jakt_var_672.release_value(); }));
 };/*case end*/
 case 1: {
 auto&& __jakt_match_value = __jakt_match_variant.template get<typename ide::Usage::Call>();
 types::FunctionId const& function_id = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(({ Optional<JaktInternal::Array<String>> __jakt_var_666; {
+return JaktInternal::ExplicitValue(({ Optional<JaktInternal::Array<String>> __jakt_var_673; {
 types::TypeId const result_type_id = ((((program)->get_function(function_id)))->return_type_id);
-__jakt_var_666 = TRY((ide::completions_for_type_id(program,result_type_id))); goto __jakt_label_613;
+__jakt_var_673 = TRY((ide::completions_for_type_id(program,result_type_id))); goto __jakt_label_619;
 
 }
-__jakt_label_613:; __jakt_var_666.release_value(); }));
+__jakt_label_619:; __jakt_var_673.release_value(); }));
 };/*case end*/
 default: {
 return JaktInternal::ExplicitValue((TRY((Array<String>::create_with({})))));
@@ -1294,7 +1153,7 @@ auto&& __jakt_match_variant = var_type;
 switch(__jakt_match_variant.index()) {
 case 0: {
 auto&& __jakt_match_value = __jakt_match_variant.template get<typename ide::VarType::Variable>();
-return JaktInternal::ExplicitValue(({ Optional<String> __jakt_var_667; {
+return JaktInternal::ExplicitValue(({ Optional<String> __jakt_var_674; {
 String const mut_string = JAKT_RESOLVE_EXPLICIT_VALUE_OR_CONTROL_FLOW_RETURN_ONLY(([&]() -> JaktInternal::ExplicitValueOrControlFlow<String, ErrorOr<String>>{
 auto&& __jakt_match_variant = mutability;
 switch(__jakt_match_variant.index()) {
@@ -1313,10 +1172,10 @@ return JaktInternal::ExplicitValue(String(""));
 }()
 ));
 String const type_name = TRY((ide::get_type_signature(program,var_type_id)));
-__jakt_var_667 = TRY((String::formatted(String("{} {}: {}"),mut_string,name,type_name))); goto __jakt_label_614;
+__jakt_var_674 = TRY((String::formatted(String("{} {}: {}"),mut_string,name,type_name))); goto __jakt_label_620;
 
 }
-__jakt_label_614:; __jakt_var_667.release_value(); }));
+__jakt_label_620:; __jakt_var_674.release_value(); }));
 };/*case end*/
 case 1: {
 auto&& __jakt_match_value = __jakt_match_variant.template get<typename ide::VarType::Field>();
@@ -1365,7 +1224,7 @@ auto&& __jakt_match_variant = checked_enum_variant;
 switch(__jakt_match_variant.index()) {
 case 3: {
 auto&& __jakt_match_value = __jakt_match_variant.template get<types::CheckedEnumVariant::StructLike>();JaktInternal::Array<types::VarId> const& fields = __jakt_match_value.fields;
-return JaktInternal::ExplicitValue(({ Optional<JaktInternal::Array<JaktInternal::Tuple<JaktInternal::Optional<String>,types::TypeId>>> __jakt_var_668; {
+return JaktInternal::ExplicitValue(({ Optional<JaktInternal::Array<JaktInternal::Tuple<JaktInternal::Optional<String>,types::TypeId>>> __jakt_var_675; {
 JaktInternal::Array<JaktInternal::Tuple<JaktInternal::Optional<String>,types::TypeId>> output = (TRY((Array<JaktInternal::Tuple<JaktInternal::Optional<String>,types::TypeId>>::create_with({}))));
 {
 JaktInternal::ArrayIterator<types::VarId> _magic = ((fields).iterator());
@@ -1385,19 +1244,19 @@ TRY((((output).push(o))));
 }
 }
 
-__jakt_var_668 = output; goto __jakt_label_615;
+__jakt_var_675 = output; goto __jakt_label_621;
 
 }
-__jakt_label_615:; __jakt_var_668.release_value(); }));
+__jakt_label_621:; __jakt_var_675.release_value(); }));
 };/*case end*/
 case 1: {
 auto&& __jakt_match_value = __jakt_match_variant.template get<types::CheckedEnumVariant::Typed>();types::TypeId const& type_id = __jakt_match_value.type_id;
-return JaktInternal::ExplicitValue(({ Optional<JaktInternal::Array<JaktInternal::Tuple<JaktInternal::Optional<String>,types::TypeId>>> __jakt_var_669; {
+return JaktInternal::ExplicitValue(({ Optional<JaktInternal::Array<JaktInternal::Tuple<JaktInternal::Optional<String>,types::TypeId>>> __jakt_var_676; {
 JaktInternal::Optional<String> const string_none = JaktInternal::OptionalNone();
-__jakt_var_669 = (TRY((Array<JaktInternal::Tuple<JaktInternal::Optional<String>,types::TypeId>>::create_with({(Tuple{string_none, type_id})})))); goto __jakt_label_616;
+__jakt_var_676 = (TRY((Array<JaktInternal::Tuple<JaktInternal::Optional<String>,types::TypeId>>::create_with({(Tuple{string_none, type_id})})))); goto __jakt_label_622;
 
 }
-__jakt_label_616:; __jakt_var_669.release_value(); }));
+__jakt_label_622:; __jakt_var_676.release_value(); }));
 };/*case end*/
 default: {
 return JaktInternal::ExplicitValue((TRY((Array<JaktInternal::Tuple<JaktInternal::Optional<String>,types::TypeId>>::create_with({})))));
@@ -1418,29 +1277,29 @@ switch(__jakt_match_variant.index()) {
 case 0: {
 auto&& __jakt_match_value = __jakt_match_variant.template get<ide::Usage::Variable>();utility::Span const& span = __jakt_match_value.span;
 types::TypeId const& type_id = __jakt_match_value.type_id;
-return JaktInternal::ExplicitValue(({ Optional<utility::Span> __jakt_var_670; {
-__jakt_var_670 = TRY((ide::find_type_definition_for_type_id(program,type_id,span))); goto __jakt_label_617;
+return JaktInternal::ExplicitValue(({ Optional<utility::Span> __jakt_var_677; {
+__jakt_var_677 = TRY((ide::find_type_definition_for_type_id(program,type_id,span))); goto __jakt_label_623;
 
 }
-__jakt_label_617:; __jakt_var_670.release_value(); }));
+__jakt_label_623:; __jakt_var_677.release_value(); }));
 };/*case end*/
 case 1: {
 auto&& __jakt_match_value = __jakt_match_variant.template get<typename ide::Usage::Call>();
 types::FunctionId const& function_id = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(({ Optional<utility::Span> __jakt_var_671; {
-__jakt_var_671 = ((((program)->get_function(function_id)))->name_span); goto __jakt_label_618;
+return JaktInternal::ExplicitValue(({ Optional<utility::Span> __jakt_var_678; {
+__jakt_var_678 = ((((program)->get_function(function_id)))->name_span); goto __jakt_label_624;
 
 }
-__jakt_label_618:; __jakt_var_671.release_value(); }));
+__jakt_label_624:; __jakt_var_678.release_value(); }));
 };/*case end*/
 case 2: {
 auto&& __jakt_match_value = __jakt_match_variant.template get<typename ide::Usage::Typename>();
 types::TypeId const& type_id = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(({ Optional<utility::Span> __jakt_var_672; {
-__jakt_var_672 = TRY((ide::find_type_definition_for_type_id(program,type_id,span))); goto __jakt_label_619;
+return JaktInternal::ExplicitValue(({ Optional<utility::Span> __jakt_var_679; {
+__jakt_var_679 = TRY((ide::find_type_definition_for_type_id(program,type_id,span))); goto __jakt_label_625;
 
 }
-__jakt_label_619:; __jakt_var_672.release_value(); }));
+__jakt_label_625:; __jakt_var_679.release_value(); }));
 };/*case end*/
 case 3: {
 auto&& __jakt_match_value = __jakt_match_variant.template get<typename ide::Usage::NameSet>();
@@ -1471,20 +1330,20 @@ case 6: {
 auto&& __jakt_match_value = __jakt_match_variant.template get<types::CheckedExpression::BinaryOp>();NonnullRefPtr<types::CheckedExpression> const& lhs = __jakt_match_value.lhs;
 parser::BinaryOperator const& op = __jakt_match_value.op;
 NonnullRefPtr<types::CheckedExpression> const& rhs = __jakt_match_value.rhs;
-return JaktInternal::ExplicitValue(({ Optional<JaktInternal::Optional<ide::Usage>> __jakt_var_673; {
+return JaktInternal::ExplicitValue(({ Optional<JaktInternal::Optional<ide::Usage>> __jakt_var_680; {
 JaktInternal::Optional<ide::Usage> const found = TRY((ide::find_span_in_expression(program,lhs,span)));
 if (((found).has_value())){
 return (found);
 }
-__jakt_var_673 = TRY((ide::find_span_in_expression(program,rhs,span))); goto __jakt_label_620;
+__jakt_var_680 = TRY((ide::find_span_in_expression(program,rhs,span))); goto __jakt_label_626;
 
 }
-__jakt_label_620:; __jakt_var_673.release_value(); }));
+__jakt_label_626:; __jakt_var_680.release_value(); }));
 };/*case end*/
 case 9: {
 auto&& __jakt_match_value = __jakt_match_variant.template get<types::CheckedExpression::JaktArray>();JaktInternal::Array<NonnullRefPtr<types::CheckedExpression>> const& vals = __jakt_match_value.vals;
 JaktInternal::Optional<NonnullRefPtr<types::CheckedExpression>> const& repeat = __jakt_match_value.repeat;
-return JaktInternal::ExplicitValue(({ Optional<JaktInternal::Optional<ide::Usage>> __jakt_var_674; {
+return JaktInternal::ExplicitValue(({ Optional<JaktInternal::Optional<ide::Usage>> __jakt_var_681; {
 {
 JaktInternal::ArrayIterator<NonnullRefPtr<types::CheckedExpression>> _magic = ((vals).iterator());
 for (;;){
@@ -1506,10 +1365,10 @@ return (found);
 if (((repeat).has_value())){
 return (TRY((ide::find_span_in_expression(program,(repeat.value()),span))));
 }
-__jakt_var_674 = none; goto __jakt_label_621;
+__jakt_var_681 = none; goto __jakt_label_627;
 
 }
-__jakt_label_621:; __jakt_var_674.release_value(); }));
+__jakt_label_627:; __jakt_var_681.release_value(); }));
 };/*case end*/
 case 26: {
 auto&& __jakt_match_value = __jakt_match_variant.template get<types::CheckedExpression::Block>();types::CheckedBlock const& block = __jakt_match_value.block;
@@ -1518,7 +1377,7 @@ return JaktInternal::ExplicitValue(TRY((ide::find_span_in_block(program,block,sp
 case 19: {
 auto&& __jakt_match_value = __jakt_match_variant.template get<types::CheckedExpression::Call>();types::CheckedCall const& call = __jakt_match_value.call;
 utility::Span const& call_span = __jakt_match_value.span;
-return JaktInternal::ExplicitValue(({ Optional<JaktInternal::Optional<ide::Usage>> __jakt_var_675; {
+return JaktInternal::ExplicitValue(({ Optional<JaktInternal::Optional<ide::Usage>> __jakt_var_682; {
 {
 JaktInternal::ArrayIterator<JaktInternal::Tuple<String,NonnullRefPtr<types::CheckedExpression>>> _magic = ((((call).args)).iterator());
 for (;;){
@@ -1544,14 +1403,14 @@ return (found);
 if ((((((call).function_id)).has_value()) && ((call_span).contains(span)))){
 return (static_cast<JaktInternal::Optional<ide::Usage>>( ide::Usage { typename ide::Usage::Call((((call).function_id).value())) } ));
 }
-__jakt_var_675 = none; goto __jakt_label_622;
+__jakt_var_682 = none; goto __jakt_label_628;
 
 }
-__jakt_label_622:; __jakt_var_675.release_value(); }));
+__jakt_label_628:; __jakt_var_682.release_value(); }));
 };/*case end*/
 case 11: {
 auto&& __jakt_match_value = __jakt_match_variant.template get<types::CheckedExpression::JaktDictionary>();JaktInternal::Array<JaktInternal::Tuple<NonnullRefPtr<types::CheckedExpression>,NonnullRefPtr<types::CheckedExpression>>> const& vals = __jakt_match_value.vals;
-return JaktInternal::ExplicitValue(({ Optional<JaktInternal::Optional<ide::Usage>> __jakt_var_676; {
+return JaktInternal::ExplicitValue(({ Optional<JaktInternal::Optional<ide::Usage>> __jakt_var_683; {
 {
 JaktInternal::ArrayIterator<JaktInternal::Tuple<NonnullRefPtr<types::CheckedExpression>,NonnullRefPtr<types::CheckedExpression>>> _magic = ((vals).iterator());
 for (;;){
@@ -1578,15 +1437,15 @@ return (found);
 }
 }
 
-__jakt_var_676 = none; goto __jakt_label_623;
+__jakt_var_683 = none; goto __jakt_label_629;
 
 }
-__jakt_label_623:; __jakt_var_676.release_value(); }));
+__jakt_label_629:; __jakt_var_683.release_value(); }));
 };/*case end*/
 case 12: {
 auto&& __jakt_match_value = __jakt_match_variant.template get<types::CheckedExpression::IndexedExpression>();NonnullRefPtr<types::CheckedExpression> const& expr = __jakt_match_value.expr;
 NonnullRefPtr<types::CheckedExpression> const& index = __jakt_match_value.index;
-return JaktInternal::ExplicitValue(({ Optional<JaktInternal::Optional<ide::Usage>> __jakt_var_677; {
+return JaktInternal::ExplicitValue(({ Optional<JaktInternal::Optional<ide::Usage>> __jakt_var_684; {
 JaktInternal::Optional<ide::Usage> found = TRY((ide::find_span_in_expression(program,expr,span)));
 if (((found).has_value())){
 return (found);
@@ -1595,17 +1454,17 @@ return (found);
 if (((found).has_value())){
 return (found);
 }
-__jakt_var_677 = none; goto __jakt_label_624;
+__jakt_var_684 = none; goto __jakt_label_630;
 
 }
-__jakt_label_624:; __jakt_var_677.release_value(); }));
+__jakt_label_630:; __jakt_var_684.release_value(); }));
 };/*case end*/
 case 15: {
 auto&& __jakt_match_value = __jakt_match_variant.template get<types::CheckedExpression::IndexedStruct>();NonnullRefPtr<types::CheckedExpression> const& expr = __jakt_match_value.expr;
 String const& index = __jakt_match_value.index;
 utility::Span const& index_span = __jakt_match_value.span;
 types::TypeId const& known_type_id = __jakt_match_value.type_id;
-return JaktInternal::ExplicitValue(({ Optional<JaktInternal::Optional<ide::Usage>> __jakt_var_678; {
+return JaktInternal::ExplicitValue(({ Optional<JaktInternal::Optional<ide::Usage>> __jakt_var_685; {
 JaktInternal::Optional<ide::Usage> const found = TRY((ide::find_span_in_expression(program,expr,span)));
 if (((found).has_value())){
 return (found);
@@ -1655,30 +1514,30 @@ default: VERIFY_NOT_REACHED();}/*switch end*/
 
 }
 }
-__jakt_var_678 = none; goto __jakt_label_625;
+__jakt_var_685 = none; goto __jakt_label_631;
 
 }
-__jakt_label_625:; __jakt_var_678.release_value(); }));
+__jakt_label_631:; __jakt_var_685.release_value(); }));
 };/*case end*/
 case 13: {
 auto&& __jakt_match_value = __jakt_match_variant.template get<types::CheckedExpression::IndexedDictionary>();NonnullRefPtr<types::CheckedExpression> const& expr = __jakt_match_value.expr;
 NonnullRefPtr<types::CheckedExpression> const& index = __jakt_match_value.index;
-return JaktInternal::ExplicitValue(({ Optional<JaktInternal::Optional<ide::Usage>> __jakt_var_679; {
+return JaktInternal::ExplicitValue(({ Optional<JaktInternal::Optional<ide::Usage>> __jakt_var_686; {
 JaktInternal::Optional<ide::Usage> const found = TRY((ide::find_span_in_expression(program,expr,span)));
 if (((found).has_value())){
 return (found);
 }
-__jakt_var_679 = TRY((ide::find_span_in_expression(program,index,span))); goto __jakt_label_626;
+__jakt_var_686 = TRY((ide::find_span_in_expression(program,index,span))); goto __jakt_label_632;
 
 }
-__jakt_label_626:; __jakt_var_679.release_value(); }));
+__jakt_label_632:; __jakt_var_686.release_value(); }));
 };/*case end*/
 case 17: {
 auto&& __jakt_match_value = __jakt_match_variant.template get<types::CheckedExpression::Match>();NonnullRefPtr<types::CheckedExpression> const& expr = __jakt_match_value.expr;
 JaktInternal::Array<types::CheckedMatchCase> const& match_cases = __jakt_match_value.match_cases;
 utility::Span const& match_span = __jakt_match_value.span;
 types::TypeId const& type_id = __jakt_match_value.type_id;
-return JaktInternal::ExplicitValue(({ Optional<JaktInternal::Optional<ide::Usage>> __jakt_var_680; {
+return JaktInternal::ExplicitValue(({ Optional<JaktInternal::Optional<ide::Usage>> __jakt_var_687; {
 {
 JaktInternal::ArrayIterator<types::CheckedMatchCase> _magic = ((match_cases).iterator());
 for (;;){
@@ -1699,11 +1558,11 @@ size_t const& index = __jakt_match_value.index;
 types::ScopeId const& scope_id = __jakt_match_value.scope_id;
 types::CheckedMatchBody const& body = __jakt_match_value.body;
 utility::Span const& marker_span = __jakt_match_value.marker_span;
-return JaktInternal::ExplicitValue(({ Optional<JaktInternal::Optional<ide::Usage>> __jakt_var_681; {
+return JaktInternal::ExplicitValue(({ Optional<JaktInternal::Optional<ide::Usage>> __jakt_var_688; {
 if (((marker_span).contains(span))){
 return (static_cast<JaktInternal::Optional<ide::Usage>>(TRY((ide::get_enum_variant_usage_from_type_id_and_name(program,subject_type_id,name)))));
 }
-__jakt_var_681 = JAKT_RESOLVE_EXPLICIT_VALUE_OR_CONTROL_FLOW_AT_LOOP_NESTED_MATCH(([&]() -> JaktInternal::ExplicitValueOrControlFlow<JaktInternal::Optional<ide::Usage>, ErrorOr<JaktInternal::Optional<ide::Usage>>>{
+__jakt_var_688 = JAKT_RESOLVE_EXPLICIT_VALUE_OR_CONTROL_FLOW_AT_LOOP_NESTED_MATCH(([&]() -> JaktInternal::ExplicitValueOrControlFlow<JaktInternal::Optional<ide::Usage>, ErrorOr<JaktInternal::Optional<ide::Usage>>>{
 auto&& __jakt_match_variant = body;
 switch(__jakt_match_variant.index()) {
 case 1: {
@@ -1718,20 +1577,20 @@ return JaktInternal::ExplicitValue(TRY((ide::find_span_in_expression(program,exp
 };/*case end*/
 default: VERIFY_NOT_REACHED();}/*switch end*/
 }()
-)); goto __jakt_label_628;
+)); goto __jakt_label_634;
 
 }
-__jakt_label_628:; __jakt_var_681.release_value(); }));
+__jakt_label_634:; __jakt_var_688.release_value(); }));
 };/*case end*/
 case 1: {
 auto&& __jakt_match_value = __jakt_match_variant.template get<types::CheckedMatchCase::Expression>();NonnullRefPtr<types::CheckedExpression> const& expr = __jakt_match_value.expression;
 types::CheckedMatchBody const& body = __jakt_match_value.body;
-return JaktInternal::ExplicitValue(({ Optional<JaktInternal::Optional<ide::Usage>> __jakt_var_682; {
+return JaktInternal::ExplicitValue(({ Optional<JaktInternal::Optional<ide::Usage>> __jakt_var_689; {
 JaktInternal::Optional<ide::Usage> const found = TRY((ide::find_span_in_expression(program,expr,span)));
 if (((found).has_value())){
 return (found);
 }
-__jakt_var_682 = JAKT_RESOLVE_EXPLICIT_VALUE_OR_CONTROL_FLOW_AT_LOOP_NESTED_MATCH(([&]() -> JaktInternal::ExplicitValueOrControlFlow<JaktInternal::Optional<ide::Usage>, ErrorOr<JaktInternal::Optional<ide::Usage>>>{
+__jakt_var_689 = JAKT_RESOLVE_EXPLICIT_VALUE_OR_CONTROL_FLOW_AT_LOOP_NESTED_MATCH(([&]() -> JaktInternal::ExplicitValueOrControlFlow<JaktInternal::Optional<ide::Usage>, ErrorOr<JaktInternal::Optional<ide::Usage>>>{
 auto&& __jakt_match_variant = body;
 switch(__jakt_match_variant.index()) {
 case 1: {
@@ -1746,10 +1605,10 @@ return JaktInternal::ExplicitValue(TRY((ide::find_span_in_expression(program,exp
 };/*case end*/
 default: VERIFY_NOT_REACHED();}/*switch end*/
 }()
-)); goto __jakt_label_629;
+)); goto __jakt_label_635;
 
 }
-__jakt_label_629:; __jakt_var_682.release_value(); }));
+__jakt_label_635:; __jakt_var_689.release_value(); }));
 };/*case end*/
 case 2: {
 auto&& __jakt_match_value = __jakt_match_variant.template get<types::CheckedMatchCase::CatchAll>();types::CheckedMatchBody const& body = __jakt_match_value.body;
@@ -1757,14 +1616,14 @@ utility::Span const& marker_span = __jakt_match_value.marker_span;
 return JaktInternal::ExplicitValue(JAKT_RESOLVE_EXPLICIT_VALUE_OR_CONTROL_FLOW_AT_LOOP_NESTED_MATCH(([&]() -> JaktInternal::ExplicitValueOrControlFlow<JaktInternal::Optional<ide::Usage>,ErrorOr<JaktInternal::Optional<ide::Usage>>>{
 auto __jakt_enum_value = (((marker_span).contains(span)));
 if (__jakt_enum_value == true) {
-return JaktInternal::ExplicitValue(({ Optional<JaktInternal::Optional<ide::Usage>> __jakt_var_683; {
+return JaktInternal::ExplicitValue(({ Optional<JaktInternal::Optional<ide::Usage>> __jakt_var_690; {
 JaktInternal::Set<String> const all_cases = JAKT_RESOLVE_EXPLICIT_VALUE_OR_CONTROL_FLOW_AT_LOOP_NESTED_MATCH(([&]() -> JaktInternal::ExplicitValueOrControlFlow<JaktInternal::Set<String>, ErrorOr<JaktInternal::Optional<ide::Usage>>>{
 auto&& __jakt_match_variant = *((program)->get_type(type_id));
 switch(__jakt_match_variant.index()) {
 case 24: {
 auto&& __jakt_match_value = __jakt_match_variant.template get<typename types::Type::Enum>();
 types::EnumId const& enum_id = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(({ Optional<JaktInternal::Set<String>> __jakt_var_684; {
+return JaktInternal::ExplicitValue(({ Optional<JaktInternal::Set<String>> __jakt_var_691; {
 JaktInternal::Set<String> names = (TRY((Set<String>::create_with_values({}))));
 types::CheckedEnum const enum_ = ((program)->get_enum(enum_id));
 {
@@ -1782,14 +1641,14 @@ TRY((((names).add(((variant).name())))));
 }
 }
 
-__jakt_var_684 = names; goto __jakt_label_631;
+__jakt_var_691 = names; goto __jakt_label_637;
 
 }
-__jakt_label_631:; __jakt_var_684.release_value(); }));
+__jakt_label_637:; __jakt_var_691.release_value(); }));
 };/*case end*/
 case 20: {
 auto&& __jakt_match_value = __jakt_match_variant.template get<types::Type::GenericEnumInstance>();types::EnumId const& enum_id = __jakt_match_value.id;
-return JaktInternal::ExplicitValue(({ Optional<JaktInternal::Set<String>> __jakt_var_685; {
+return JaktInternal::ExplicitValue(({ Optional<JaktInternal::Set<String>> __jakt_var_692; {
 JaktInternal::Set<String> names = (TRY((Set<String>::create_with_values({}))));
 types::CheckedEnum const enum_ = ((program)->get_enum(enum_id));
 {
@@ -1807,17 +1666,17 @@ TRY((((names).add(((variant).name())))));
 }
 }
 
-__jakt_var_685 = names; goto __jakt_label_632;
+__jakt_var_692 = names; goto __jakt_label_638;
 
 }
-__jakt_label_632:; __jakt_var_685.release_value(); }));
+__jakt_label_638:; __jakt_var_692.release_value(); }));
 };/*case end*/
 default: {
-return JaktInternal::ExplicitValue(({ Optional<JaktInternal::Set<String>> __jakt_var_686; {
-__jakt_var_686 = (TRY((Set<String>::create_with_values({TRY((String::formatted(String("else ({})"),TRY((((program)->type_name(type_id)))))))})))); goto __jakt_label_633;
+return JaktInternal::ExplicitValue(({ Optional<JaktInternal::Set<String>> __jakt_var_693; {
+__jakt_var_693 = (TRY((Set<String>::create_with_values({TRY((String::formatted(String("else ({})"),TRY((((program)->type_name(type_id)))))))})))); goto __jakt_label_639;
 
 }
-__jakt_label_633:; __jakt_var_686.release_value(); }));
+__jakt_label_639:; __jakt_var_693.release_value(); }));
 };/*case end*/
 }/*switch end*/
 }()
@@ -1841,10 +1700,10 @@ String const name = (other_case.get<types::CheckedMatchCase::EnumVariant>()).nam
 }
 }
 
-__jakt_var_683 = JAKT_RESOLVE_EXPLICIT_VALUE_OR_CONTROL_FLOW_AT_LOOP_NESTED_MATCH(([&]() -> JaktInternal::ExplicitValueOrControlFlow<JaktInternal::Optional<ide::Usage>,ErrorOr<JaktInternal::Optional<ide::Usage>>>{
+__jakt_var_690 = JAKT_RESOLVE_EXPLICIT_VALUE_OR_CONTROL_FLOW_AT_LOOP_NESTED_MATCH(([&]() -> JaktInternal::ExplicitValueOrControlFlow<JaktInternal::Optional<ide::Usage>,ErrorOr<JaktInternal::Optional<ide::Usage>>>{
 auto __jakt_enum_value = (((remaining_cases).is_empty()));
 if (__jakt_enum_value == false) {
-return JaktInternal::ExplicitValue(({ Optional<JaktInternal::Optional<ide::Usage>> __jakt_var_687; {
+return JaktInternal::ExplicitValue(({ Optional<JaktInternal::Optional<ide::Usage>> __jakt_var_694; {
 JaktInternal::Array<String> cases_array = (TRY((Array<String>::create_with({}))));
 TRY((((cases_array).ensure_capacity(((remaining_cases).size())))));
 {
@@ -1862,19 +1721,19 @@ TRY((((cases_array).push(name))));
 }
 }
 
-__jakt_var_687 = static_cast<JaktInternal::Optional<ide::Usage>>( ide::Usage { typename ide::Usage::NameSet(cases_array) } ); goto __jakt_label_634;
+__jakt_var_694 = static_cast<JaktInternal::Optional<ide::Usage>>( ide::Usage { typename ide::Usage::NameSet(cases_array) } ); goto __jakt_label_640;
 
 }
-__jakt_label_634:; __jakt_var_687.release_value(); }));
+__jakt_label_640:; __jakt_var_694.release_value(); }));
 }
 else {
 return JaktInternal::ExplicitValue(JaktInternal::OptionalNone());
 }
 }()))
-; goto __jakt_label_630;
+; goto __jakt_label_636;
 
 }
-__jakt_label_630:; __jakt_var_683.release_value(); }));
+__jakt_label_636:; __jakt_var_690.release_value(); }));
 }
 else {
 return JaktInternal::ExplicitValue(JAKT_RESOLVE_EXPLICIT_VALUE_OR_CONTROL_FLOW_AT_LOOP_NESTED_MATCH(([&]() -> JaktInternal::ExplicitValueOrControlFlow<JaktInternal::Optional<ide::Usage>, ErrorOr<JaktInternal::Optional<ide::Usage>>>{
@@ -1908,10 +1767,10 @@ return (found);
 }
 }
 
-__jakt_var_680 = TRY((ide::find_span_in_expression(program,expr,span))); goto __jakt_label_627;
+__jakt_var_687 = TRY((ide::find_span_in_expression(program,expr,span))); goto __jakt_label_633;
 
 }
-__jakt_label_627:; __jakt_var_680.release_value(); }));
+__jakt_label_633:; __jakt_var_687.release_value(); }));
 };/*case end*/
 case 25: {
 auto&& __jakt_match_value = __jakt_match_variant.template get<types::CheckedExpression::ForcedUnwrap>();NonnullRefPtr<types::CheckedExpression> const& expr = __jakt_match_value.expr;
@@ -1984,7 +1843,7 @@ case 21: {
 auto&& __jakt_match_value = __jakt_match_variant.template get<types::CheckedExpression::NamespacedVar>();JaktInternal::Array<types::CheckedNamespace> const& namespaces = __jakt_match_value.namespaces;
 types::CheckedVariable const& var = __jakt_match_value.var;
 utility::Span const& var_span = __jakt_match_value.span;
-return JaktInternal::ExplicitValue(({ Optional<JaktInternal::Optional<ide::Usage>> __jakt_var_688; {
+return JaktInternal::ExplicitValue(({ Optional<JaktInternal::Optional<ide::Usage>> __jakt_var_695; {
 if ((((var_span).contains(span)) && (!(((namespaces).is_empty()))))){
 types::CheckedNamespace const last_ns = (((namespaces).last()).value());
 if (((((TRY((((program)->get_scope(((last_ns).scope))))))->namespace_name)).has_value())){
@@ -1995,34 +1854,34 @@ return (static_cast<JaktInternal::Optional<ide::Usage>>(TRY((ide::get_enum_varia
 }
 }
 }
-__jakt_var_688 = none; goto __jakt_label_635;
+__jakt_var_695 = none; goto __jakt_label_641;
 
 }
-__jakt_label_635:; __jakt_var_688.release_value(); }));
+__jakt_label_641:; __jakt_var_695.release_value(); }));
 };/*case end*/
 case 29: {
 auto&& __jakt_match_value = __jakt_match_variant.template get<types::CheckedExpression::TryBlock>();NonnullRefPtr<types::CheckedStatement> const& stmt = __jakt_match_value.stmt;
 String const& error_name = __jakt_match_value.error_name;
 types::CheckedBlock const& catch_block = __jakt_match_value.catch_block;
-return JaktInternal::ExplicitValue(({ Optional<JaktInternal::Optional<ide::Usage>> __jakt_var_689; {
+return JaktInternal::ExplicitValue(({ Optional<JaktInternal::Optional<ide::Usage>> __jakt_var_696; {
 JaktInternal::Optional<ide::Usage> const found = TRY((ide::find_span_in_statement(program,stmt,span)));
 if (((found).has_value())){
 return (found);
 }
-__jakt_var_689 = TRY((ide::find_span_in_block(program,catch_block,span))); goto __jakt_label_636;
+__jakt_var_696 = TRY((ide::find_span_in_block(program,catch_block,span))); goto __jakt_label_642;
 
 }
-__jakt_label_636:; __jakt_var_689.release_value(); }));
+__jakt_label_642:; __jakt_var_696.release_value(); }));
 };/*case end*/
 case 28: {
 auto&& __jakt_match_value = __jakt_match_variant.template get<types::CheckedExpression::Try>();NonnullRefPtr<types::CheckedExpression> const& expr = __jakt_match_value.expr;
 JaktInternal::Optional<types::CheckedBlock> const& catch_block = __jakt_match_value.catch_block;
-return JaktInternal::ExplicitValue(({ Optional<JaktInternal::Optional<ide::Usage>> __jakt_var_690; {
+return JaktInternal::ExplicitValue(({ Optional<JaktInternal::Optional<ide::Usage>> __jakt_var_697; {
 JaktInternal::Optional<ide::Usage> const found = TRY((ide::find_span_in_expression(program,expr,span)));
 if (((found).has_value())){
 return (found);
 }
-__jakt_var_690 = JAKT_RESOLVE_EXPLICIT_VALUE_OR_CONTROL_FLOW_RETURN_ONLY(([&]() -> JaktInternal::ExplicitValueOrControlFlow<JaktInternal::Optional<ide::Usage>,ErrorOr<JaktInternal::Optional<ide::Usage>>>{
+__jakt_var_697 = JAKT_RESOLVE_EXPLICIT_VALUE_OR_CONTROL_FLOW_RETURN_ONLY(([&]() -> JaktInternal::ExplicitValueOrControlFlow<JaktInternal::Optional<ide::Usage>,ErrorOr<JaktInternal::Optional<ide::Usage>>>{
 auto __jakt_enum_value = (((catch_block).has_value()));
 if (__jakt_enum_value == true) {
 return JaktInternal::ExplicitValue(TRY((ide::find_span_in_block(program,(catch_block.value()),span))));
@@ -2031,15 +1890,15 @@ else {
 return JaktInternal::ExplicitValue(none);
 }
 }()))
-; goto __jakt_label_637;
+; goto __jakt_label_643;
 
 }
-__jakt_label_637:; __jakt_var_690.release_value(); }));
+__jakt_label_643:; __jakt_var_697.release_value(); }));
 };/*case end*/
 case 8: {
 auto&& __jakt_match_value = __jakt_match_variant.template get<types::CheckedExpression::Range>();JaktInternal::Optional<NonnullRefPtr<types::CheckedExpression>> const& from = __jakt_match_value.from;
 JaktInternal::Optional<NonnullRefPtr<types::CheckedExpression>> const& to = __jakt_match_value.to;
-return JaktInternal::ExplicitValue(({ Optional<JaktInternal::Optional<ide::Usage>> __jakt_var_691; {
+return JaktInternal::ExplicitValue(({ Optional<JaktInternal::Optional<ide::Usage>> __jakt_var_698; {
 if (((from).has_value())){
 JaktInternal::Optional<ide::Usage> const found = TRY((ide::find_span_in_expression(program,(from.value()),span)));
 if (((found).has_value())){
@@ -2049,10 +1908,10 @@ return (found);
 if (((to).has_value())){
 return (TRY((ide::find_span_in_expression(program,(to.value()),span))));
 }
-__jakt_var_691 = none; goto __jakt_label_638;
+__jakt_var_698 = none; goto __jakt_label_644;
 
 }
-__jakt_label_638:; __jakt_var_691.release_value(); }));
+__jakt_label_644:; __jakt_var_698.release_value(); }));
 };/*case end*/
 default: {
 return JaktInternal::ExplicitValue(none);
@@ -2111,6 +1970,81 @@ return (JaktInternal::OptionalNone());
 }
 }
 
+ErrorOr<JaktInternal::Array<String>> find_function_completions_in_scope(NonnullRefPtr<types::Scope> const scope,NonnullRefPtr<types::CheckedProgram> const program) {
+{
+JaktInternal::Array<String> output = (TRY((Array<String>::create_with({}))));
+{
+JaktInternal::ArrayIterator<String> _magic = ((TRY((((((scope)->functions)).keys())))).iterator());
+for (;;){
+JaktInternal::Optional<String> _magic_value = ((_magic).next());
+if ((!(((_magic_value).has_value())))){
+break;
+}
+String function_name = (_magic_value.value());
+{
+JaktInternal::Array<types::FunctionId> const overload_set = (((((scope)->functions)).get(function_name)).value());
+{
+JaktInternal::ArrayIterator<types::FunctionId> _magic = ((overload_set).iterator());
+for (;;){
+JaktInternal::Optional<types::FunctionId> _magic_value = ((_magic).next());
+if ((!(((_magic_value).has_value())))){
+break;
+}
+types::FunctionId function_id = (_magic_value.value());
+{
+NonnullRefPtr<types::CheckedFunction> const checked_function = ((program)->get_function(function_id));
+if (((((((checked_function)->params)).first())).has_value())){
+types::CheckedParameter const param = (((((checked_function)->params)).first()).value());
+if ((((((param).variable)).name) == String("this"))){
+String full_call = ((checked_function)->name);
+bool first = true;
+(full_call += String("("));
+JaktInternal::ArrayIterator<types::CheckedParameter> iter = ((((checked_function)->params)).iterator());
+JaktInternal::Optional<types::CheckedParameter> const dummy = ((iter).next());
+{
+JaktInternal::ArrayIterator<types::CheckedParameter> _magic = iter;
+for (;;){
+JaktInternal::Optional<types::CheckedParameter> _magic_value = ((_magic).next());
+if ((!(((_magic_value).has_value())))){
+break;
+}
+types::CheckedParameter param = (_magic_value.value());
+{
+if ((!(first))){
+(full_call += String(", "));
+}
+else {
+(first = false);
+}
+
+(full_call += ((((param).variable)).name));
+}
+
+}
+}
+
+(full_call += String(")"));
+TRY((((output).push(full_call))));
+}
+}
+else {
+TRY((((output).push(TRY((String::formatted(String("{}()"),((checked_function)->name))))))));
+}
+
+}
+
+}
+}
+
+}
+
+}
+}
+
+return (output);
+}
+}
+
 ErrorOr<JaktInternal::Array<ide::JaktSymbol>> find_symbols_in_namespace(parser::ParsedNamespace const namespace_) {
 {
 JaktInternal::Array<ide::JaktSymbol> symbols = (TRY((Array<ide::JaktSymbol>::create_with({}))));
@@ -2153,21 +2087,7 @@ break;
 }
 parser::ParsedNamespace sub_namespace = (_magic_value.value());
 {
-{
-JaktInternal::ArrayIterator<ide::JaktSymbol> _magic = ((TRY((ide::find_symbols_in_namespace(sub_namespace)))).iterator());
-for (;;){
-JaktInternal::Optional<ide::JaktSymbol> _magic_value = ((_magic).next());
-if ((!(((_magic_value).has_value())))){
-break;
-}
-ide::JaktSymbol child_symbol = (_magic_value.value());
-{
-TRY((((symbols).push(child_symbol))));
-}
-
-}
-}
-
+TRY((((symbols).push_values(TRY((ide::find_symbols_in_namespace(sub_namespace)))))));
 }
 
 }
@@ -2319,7 +2239,7 @@ return JaktInternal::ExplicitValue(((((program)->get_trait(id)))->name_span));
 case 19: {
 auto&& __jakt_match_value = __jakt_match_variant.template get<types::Type::GenericInstance>();types::StructId const& struct_id = __jakt_match_value.id;
 JaktInternal::Array<types::TypeId> const& args = __jakt_match_value.args;
-return JaktInternal::ExplicitValue(({ Optional<utility::Span> __jakt_var_692; {
+return JaktInternal::ExplicitValue(({ Optional<utility::Span> __jakt_var_699; {
 utility::Span output = span;
 if ((((((((struct_id).equals(array_struct_id)) || ((struct_id).equals(optional_struct_id))) || ((struct_id).equals(range_struct_id))) || ((struct_id).equals(set_struct_id))) || ((struct_id).equals(tuple_struct_id))) || ((struct_id).equals(weak_ptr_struct_id)))){
 (output = TRY((ide::find_type_definition_for_type_id(program,((args)[static_cast<i64>(0LL)]),span))));
@@ -2331,10 +2251,10 @@ else {
 (output = ((((program)->get_struct(struct_id))).name_span));
 }
 
-__jakt_var_692 = output; goto __jakt_label_639;
+__jakt_var_699 = output; goto __jakt_label_645;
 
 }
-__jakt_label_639:; __jakt_var_692.release_value(); }));
+__jakt_label_645:; __jakt_var_699.release_value(); }));
 };/*case end*/
 case 23: {
 auto&& __jakt_match_value = __jakt_match_variant.template get<typename types::Type::Struct>();
@@ -2592,7 +2512,7 @@ case 4: {
 auto&& __jakt_match_value = __jakt_match_variant.template get<types::CheckedStatement::If>();NonnullRefPtr<types::CheckedExpression> const& condition = __jakt_match_value.condition;
 types::CheckedBlock const& then_block = __jakt_match_value.then_block;
 JaktInternal::Optional<NonnullRefPtr<types::CheckedStatement>> const& else_statement = __jakt_match_value.else_statement;
-return JaktInternal::ExplicitValue(({ Optional<JaktInternal::Optional<ide::Usage>> __jakt_var_693; {
+return JaktInternal::ExplicitValue(({ Optional<JaktInternal::Optional<ide::Usage>> __jakt_var_700; {
 JaktInternal::Optional<ide::Usage> found = TRY((ide::find_span_in_expression(program,condition,span)));
 if (((found).has_value())){
 return (found);
@@ -2604,18 +2524,18 @@ return (found);
 if (((else_statement).has_value())){
 return (TRY((ide::find_span_in_statement(program,(else_statement.value()),span))));
 }
-__jakt_var_693 = none; goto __jakt_label_640;
+__jakt_var_700 = none; goto __jakt_label_646;
 
 }
-__jakt_label_640:; __jakt_var_693.release_value(); }));
+__jakt_label_646:; __jakt_var_700.release_value(); }));
 };/*case end*/
 case 13: {
-auto&& __jakt_match_value = __jakt_match_variant.template get<types::CheckedStatement::InlineCpp>();return JaktInternal::ExplicitValue(({ Optional<JaktInternal::Optional<ide::Usage>> __jakt_var_694; {
+auto&& __jakt_match_value = __jakt_match_variant.template get<types::CheckedStatement::InlineCpp>();return JaktInternal::ExplicitValue(({ Optional<JaktInternal::Optional<ide::Usage>> __jakt_var_701; {
 JaktInternal::Optional<ide::Usage> const output = JaktInternal::OptionalNone();
-__jakt_var_694 = output; goto __jakt_label_641;
+__jakt_var_701 = output; goto __jakt_label_647;
 
 }
-__jakt_label_641:; __jakt_var_694.release_value(); }));
+__jakt_label_647:; __jakt_var_701.release_value(); }));
 };/*case end*/
 case 6: {
 auto&& __jakt_match_value = __jakt_match_variant.template get<types::CheckedStatement::Loop>();types::CheckedBlock const& block = __jakt_match_value.block;
@@ -2641,7 +2561,7 @@ return JaktInternal::ExplicitValue(TRY((ide::find_span_in_expression(program,exp
 case 3: {
 auto&& __jakt_match_value = __jakt_match_variant.template get<types::CheckedStatement::VarDecl>();types::VarId const& var_id = __jakt_match_value.var_id;
 NonnullRefPtr<types::CheckedExpression> const& init = __jakt_match_value.init;
-return JaktInternal::ExplicitValue(({ Optional<JaktInternal::Optional<ide::Usage>> __jakt_var_695; {
+return JaktInternal::ExplicitValue(({ Optional<JaktInternal::Optional<ide::Usage>> __jakt_var_702; {
 types::CheckedVariable const checked_var = ((program)->get_variable(var_id));
 JaktInternal::Optional<ide::Usage> const found = TRY((ide::find_span_in_expression(program,init,span)));
 if (((found).has_value())){
@@ -2666,28 +2586,28 @@ return JaktInternal::ExplicitValue( ide::Mutability { typename ide::Mutability::
 ;
 return (static_cast<JaktInternal::Optional<ide::Usage>>( ide::Usage { typename ide::Usage::Variable(((checked_var).definition_span),((checked_var).name),((checked_var).type_id),mutability, ide::VarType { typename ide::VarType::Variable() } , ide::VarVisibility { typename ide::VarVisibility::DoesNotApply() } ,JaktInternal::OptionalNone()) } ));
 }
-__jakt_var_695 = none; goto __jakt_label_642;
+__jakt_var_702 = none; goto __jakt_label_648;
 
 }
-__jakt_label_642:; __jakt_var_695.release_value(); }));
+__jakt_label_648:; __jakt_var_702.release_value(); }));
 };/*case end*/
 case 7: {
 auto&& __jakt_match_value = __jakt_match_variant.template get<types::CheckedStatement::While>();NonnullRefPtr<types::CheckedExpression> const& condition = __jakt_match_value.condition;
 types::CheckedBlock const& block = __jakt_match_value.block;
-return JaktInternal::ExplicitValue(({ Optional<JaktInternal::Optional<ide::Usage>> __jakt_var_696; {
+return JaktInternal::ExplicitValue(({ Optional<JaktInternal::Optional<ide::Usage>> __jakt_var_703; {
 JaktInternal::Optional<ide::Usage> const found = TRY((ide::find_span_in_expression(program,condition,span)));
 if (((found).has_value())){
 return (found);
 }
-__jakt_var_696 = TRY((ide::find_span_in_block(program,block,span))); goto __jakt_label_643;
+__jakt_var_703 = TRY((ide::find_span_in_block(program,block,span))); goto __jakt_label_649;
 
 }
-__jakt_label_643:; __jakt_var_696.release_value(); }));
+__jakt_label_649:; __jakt_var_703.release_value(); }));
 };/*case end*/
 case 2: {
 auto&& __jakt_match_value = __jakt_match_variant.template get<types::CheckedStatement::DestructuringAssignment>();JaktInternal::Array<NonnullRefPtr<types::CheckedStatement>> const& vars = __jakt_match_value.vars;
 NonnullRefPtr<types::CheckedStatement> const& var_decl = __jakt_match_value.var_decl;
-return JaktInternal::ExplicitValue(({ Optional<JaktInternal::Optional<ide::Usage>> __jakt_var_697; {
+return JaktInternal::ExplicitValue(({ Optional<JaktInternal::Optional<ide::Usage>> __jakt_var_704; {
 {
 JaktInternal::ArrayIterator<NonnullRefPtr<types::CheckedStatement>> _magic = ((vars).iterator());
 for (;;){
@@ -2706,10 +2626,10 @@ return (found);
 }
 }
 
-__jakt_var_697 = TRY((ide::find_span_in_statement(program,var_decl,span))); goto __jakt_label_644;
+__jakt_var_704 = TRY((ide::find_span_in_statement(program,var_decl,span))); goto __jakt_label_650;
 
 }
-__jakt_label_644:; __jakt_var_697.release_value(); }));
+__jakt_label_650:; __jakt_var_704.release_value(); }));
 };/*case end*/
 case 12: {
 auto&& __jakt_match_value = __jakt_match_variant.template get<types::CheckedStatement::Yield>();NonnullRefPtr<types::CheckedExpression> const& expr = __jakt_match_value.expr;

--- a/bootstrap/stage0/interpreter.cpp
+++ b/bootstrap/stage0/interpreter.cpp
@@ -480,21 +480,21 @@ return JaktInternal::ExplicitValue(TRY((types::CheckedExpression::template creat
 };/*case end*/
 case 23: {
 auto&& __jakt_match_value = __jakt_match_variant.template get<types::ValueImpl::OptionalSome>();types::Value const& value = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(({ Optional<NonnullRefPtr<types::CheckedExpression>> __jakt_var_113; {
+return JaktInternal::ExplicitValue(({ Optional<NonnullRefPtr<types::CheckedExpression>> __jakt_var_117; {
 NonnullRefPtr<types::CheckedExpression> const expr = TRY((interpreter::value_to_checked_expression(value,interpreter)));
 types::TypeId const inner_type_id = ((expr)->type());
 types::StructId const optional_struct_id = TRY((((((interpreter)->program))->find_struct_in_prelude(String("Optional")))));
 NonnullRefPtr<types::Type> const type = TRY((types::Type::template create<typename types::Type::GenericInstance>(optional_struct_id,(TRY((Array<types::TypeId>::create_with({inner_type_id})))))));
 types::TypeId const type_id = TRY((((interpreter)->find_or_add_type_id(type))));
-__jakt_var_113 = TRY((types::CheckedExpression::template create<typename types::CheckedExpression::OptionalSome>(expr,((this_value).span),type_id))); goto __jakt_label_111;
+__jakt_var_117 = TRY((types::CheckedExpression::template create<typename types::CheckedExpression::OptionalSome>(expr,((this_value).span),type_id))); goto __jakt_label_115;
 
 }
-__jakt_label_111:; __jakt_var_113.release_value(); }));
+__jakt_label_115:; __jakt_var_117.release_value(); }));
 };/*case end*/
 case 25: {
 auto&& __jakt_match_value = __jakt_match_variant.template get<types::ValueImpl::JaktTuple>();JaktInternal::Array<types::Value> const& fields = __jakt_match_value.fields;
 types::TypeId const& type_id = __jakt_match_value.type_id;
-return JaktInternal::ExplicitValue(({ Optional<NonnullRefPtr<types::CheckedExpression>> __jakt_var_114; {
+return JaktInternal::ExplicitValue(({ Optional<NonnullRefPtr<types::CheckedExpression>> __jakt_var_118; {
 JaktInternal::Array<NonnullRefPtr<types::CheckedExpression>> vals = (TRY((Array<NonnullRefPtr<types::CheckedExpression>>::create_with({}))));
 {
 JaktInternal::ArrayIterator<types::Value> _magic = ((fields).iterator());
@@ -511,16 +511,16 @@ TRY((((vals).push(TRY((interpreter::value_to_checked_expression(field,interprete
 }
 }
 
-__jakt_var_114 = TRY((types::CheckedExpression::template create<typename types::CheckedExpression::JaktTuple>(vals,((this_value).span),type_id))); goto __jakt_label_112;
+__jakt_var_118 = TRY((types::CheckedExpression::template create<typename types::CheckedExpression::JaktTuple>(vals,((this_value).span),type_id))); goto __jakt_label_116;
 
 }
-__jakt_label_112:; __jakt_var_114.release_value(); }));
+__jakt_label_116:; __jakt_var_118.release_value(); }));
 };/*case end*/
 case 16: {
 auto&& __jakt_match_value = __jakt_match_variant.template get<types::ValueImpl::Struct>();JaktInternal::Array<types::Value> const& fields = __jakt_match_value.fields;
 types::StructId const& struct_id = __jakt_match_value.struct_id;
 JaktInternal::Optional<types::FunctionId> const& constructor = __jakt_match_value.constructor;
-return JaktInternal::ExplicitValue(({ Optional<NonnullRefPtr<types::CheckedExpression>> __jakt_var_115; {
+return JaktInternal::ExplicitValue(({ Optional<NonnullRefPtr<types::CheckedExpression>> __jakt_var_119; {
 if ((!(((constructor).has_value())))){
 TRY((((interpreter)->error_with_hint(String("Cannot convert struct to expression without constructor"),((this_value).span),String("Given struct cannot be created from its contents in any known way"),((this_value).span)))));
 return Error::from_errno((infallible_integer_cast<i32>((InterpretError::InvalidType))));
@@ -588,16 +588,16 @@ TRY((((args).push((Tuple{label, arg})))));
 
 NonnullRefPtr<types::CheckedFunction> const callee = ((((interpreter)->program))->get_function((constructor.value())));
 types::CheckedCall const call = types::CheckedCall(namespace_,name,args,(TRY((Array<types::TypeId>::create_with({})))),constructor,((struct_).type_id),((callee)->can_throw));
-__jakt_var_115 = TRY((types::CheckedExpression::template create<typename types::CheckedExpression::Call>(call,((this_value).span),((struct_).type_id)))); goto __jakt_label_113;
+__jakt_var_119 = TRY((types::CheckedExpression::template create<typename types::CheckedExpression::Call>(call,((this_value).span),((struct_).type_id)))); goto __jakt_label_117;
 
 }
-__jakt_label_113:; __jakt_var_115.release_value(); }));
+__jakt_label_117:; __jakt_var_119.release_value(); }));
 };/*case end*/
 case 17: {
 auto&& __jakt_match_value = __jakt_match_variant.template get<types::ValueImpl::Class>();JaktInternal::Array<types::Value> const& fields = __jakt_match_value.fields;
 types::StructId const& struct_id = __jakt_match_value.struct_id;
 JaktInternal::Optional<types::FunctionId> const& constructor = __jakt_match_value.constructor;
-return JaktInternal::ExplicitValue(({ Optional<NonnullRefPtr<types::CheckedExpression>> __jakt_var_116; {
+return JaktInternal::ExplicitValue(({ Optional<NonnullRefPtr<types::CheckedExpression>> __jakt_var_120; {
 if ((!(((constructor).has_value())))){
 TRY((((interpreter)->error_with_hint(String("Cannot convert struct to expression without constructor"),((this_value).span),String("Given struct cannot be created from its contents in any known way"),((this_value).span)))));
 return Error::from_errno((infallible_integer_cast<i32>((InterpretError::InvalidType))));
@@ -665,16 +665,16 @@ TRY((((args).push((Tuple{label, arg})))));
 
 NonnullRefPtr<types::CheckedFunction> const callee = ((((interpreter)->program))->get_function((constructor.value())));
 types::CheckedCall const call = types::CheckedCall(namespace_,name,args,(TRY((Array<types::TypeId>::create_with({})))),constructor,((struct_).type_id),((callee)->can_throw));
-__jakt_var_116 = TRY((types::CheckedExpression::template create<typename types::CheckedExpression::Call>(call,((this_value).span),((struct_).type_id)))); goto __jakt_label_114;
+__jakt_var_120 = TRY((types::CheckedExpression::template create<typename types::CheckedExpression::Call>(call,((this_value).span),((struct_).type_id)))); goto __jakt_label_118;
 
 }
-__jakt_label_114:; __jakt_var_116.release_value(); }));
+__jakt_label_118:; __jakt_var_120.release_value(); }));
 };/*case end*/
 case 18: {
 auto&& __jakt_match_value = __jakt_match_variant.template get<types::ValueImpl::Enum>();JaktInternal::Array<types::Value> const& fields = __jakt_match_value.fields;
 types::EnumId const& enum_id = __jakt_match_value.enum_id;
 types::FunctionId const& constructor = __jakt_match_value.constructor;
-return JaktInternal::ExplicitValue(({ Optional<NonnullRefPtr<types::CheckedExpression>> __jakt_var_117; {
+return JaktInternal::ExplicitValue(({ Optional<NonnullRefPtr<types::CheckedExpression>> __jakt_var_121; {
 JaktInternal::Array<NonnullRefPtr<types::CheckedExpression>> materialised_fields = (TRY((Array<NonnullRefPtr<types::CheckedExpression>>::create_with({}))));
 {
 JaktInternal::ArrayIterator<types::Value> _magic = ((fields).iterator());
@@ -738,15 +738,15 @@ TRY((((args).push((Tuple{String(""), arg})))));
 
 NonnullRefPtr<types::CheckedFunction> const callee = ((((interpreter)->program))->get_function(constructor));
 types::CheckedCall const call = types::CheckedCall(namespace_,((callee)->name),args,(TRY((Array<types::TypeId>::create_with({})))),constructor,((enum_).type_id),((callee)->can_throw));
-__jakt_var_117 = TRY((types::CheckedExpression::template create<typename types::CheckedExpression::Call>(call,((this_value).span),((enum_).type_id)))); goto __jakt_label_115;
+__jakt_var_121 = TRY((types::CheckedExpression::template create<typename types::CheckedExpression::Call>(call,((this_value).span),((enum_).type_id)))); goto __jakt_label_119;
 
 }
-__jakt_label_115:; __jakt_var_117.release_value(); }));
+__jakt_label_119:; __jakt_var_121.release_value(); }));
 };/*case end*/
 case 19: {
 auto&& __jakt_match_value = __jakt_match_variant.template get<types::ValueImpl::JaktArray>();JaktInternal::Array<types::Value> const& values = __jakt_match_value.values;
 types::TypeId const& type_id = __jakt_match_value.type_id;
-return JaktInternal::ExplicitValue(({ Optional<NonnullRefPtr<types::CheckedExpression>> __jakt_var_118; {
+return JaktInternal::ExplicitValue(({ Optional<NonnullRefPtr<types::CheckedExpression>> __jakt_var_122; {
 JaktInternal::Array<NonnullRefPtr<types::CheckedExpression>> vals = (TRY((Array<NonnullRefPtr<types::CheckedExpression>>::create_with({}))));
 {
 JaktInternal::ArrayIterator<types::Value> _magic = ((values).iterator());
@@ -778,16 +778,16 @@ utility::panic(String("Expected generic instance of Array while materialising an
 }/*switch end*/
 }()
 ));
-__jakt_var_118 = TRY((types::CheckedExpression::template create<typename types::CheckedExpression::JaktArray>(vals,JaktInternal::OptionalNone(),((this_value).span),type_id,inner_type_id))); goto __jakt_label_116;
+__jakt_var_122 = TRY((types::CheckedExpression::template create<typename types::CheckedExpression::JaktArray>(vals,JaktInternal::OptionalNone(),((this_value).span),type_id,inner_type_id))); goto __jakt_label_120;
 
 }
-__jakt_label_116:; __jakt_var_118.release_value(); }));
+__jakt_label_120:; __jakt_var_122.release_value(); }));
 };/*case end*/
 case 20: {
 auto&& __jakt_match_value = __jakt_match_variant.template get<types::ValueImpl::JaktDictionary>();JaktInternal::Array<types::Value> const& keys = __jakt_match_value.keys;
 JaktInternal::Array<types::Value> const& values = __jakt_match_value.values;
 types::TypeId const& type_id = __jakt_match_value.type_id;
-return JaktInternal::ExplicitValue(({ Optional<NonnullRefPtr<types::CheckedExpression>> __jakt_var_119; {
+return JaktInternal::ExplicitValue(({ Optional<NonnullRefPtr<types::CheckedExpression>> __jakt_var_123; {
 JaktInternal::Array<JaktInternal::Tuple<NonnullRefPtr<types::CheckedExpression>,NonnullRefPtr<types::CheckedExpression>>> vals = (TRY((Array<JaktInternal::Tuple<NonnullRefPtr<types::CheckedExpression>,NonnullRefPtr<types::CheckedExpression>>>::create_with({}))));
 {
 JaktInternal::Range<size_t> _magic = (JaktInternal::Range<size_t>{static_cast<size_t>(static_cast<size_t>(0ULL)),static_cast<size_t>(((keys).size()))});
@@ -822,15 +822,15 @@ utility::panic(String("Expected generic instance of Dictionary while materialisi
 types::TypeId const key_type_id = ((key_type_id_value_type_id_).get<0>());
 types::TypeId const value_type_id = ((key_type_id_value_type_id_).get<1>());
 
-__jakt_var_119 = TRY((types::CheckedExpression::template create<typename types::CheckedExpression::JaktDictionary>(vals,((this_value).span),type_id,key_type_id,value_type_id))); goto __jakt_label_117;
+__jakt_var_123 = TRY((types::CheckedExpression::template create<typename types::CheckedExpression::JaktDictionary>(vals,((this_value).span),type_id,key_type_id,value_type_id))); goto __jakt_label_121;
 
 }
-__jakt_label_117:; __jakt_var_119.release_value(); }));
+__jakt_label_121:; __jakt_var_123.release_value(); }));
 };/*case end*/
 case 21: {
 auto&& __jakt_match_value = __jakt_match_variant.template get<types::ValueImpl::JaktSet>();JaktInternal::Array<types::Value> const& values = __jakt_match_value.values;
 types::TypeId const& type_id = __jakt_match_value.type_id;
-return JaktInternal::ExplicitValue(({ Optional<NonnullRefPtr<types::CheckedExpression>> __jakt_var_120; {
+return JaktInternal::ExplicitValue(({ Optional<NonnullRefPtr<types::CheckedExpression>> __jakt_var_124; {
 JaktInternal::Array<NonnullRefPtr<types::CheckedExpression>> vals = (TRY((Array<NonnullRefPtr<types::CheckedExpression>>::create_with({}))));
 {
 JaktInternal::Range<size_t> _magic = (JaktInternal::Range<size_t>{static_cast<size_t>(static_cast<size_t>(0ULL)),static_cast<size_t>(((values).size()))});
@@ -862,10 +862,10 @@ utility::panic(String("Expected generic instance of Set while materialising an a
 }/*switch end*/
 }()
 ));
-__jakt_var_120 = TRY((types::CheckedExpression::template create<typename types::CheckedExpression::JaktSet>(vals,((this_value).span),type_id,value_type_id))); goto __jakt_label_118;
+__jakt_var_124 = TRY((types::CheckedExpression::template create<typename types::CheckedExpression::JaktSet>(vals,((this_value).span),type_id,value_type_id))); goto __jakt_label_122;
 
 }
-__jakt_label_118:; __jakt_var_120.release_value(); }));
+__jakt_label_122:; __jakt_var_124.release_value(); }));
 };/*case end*/
 case 26: {
 auto&& __jakt_match_value = __jakt_match_variant.template get<types::ValueImpl::Function>();JaktInternal::Dictionary<String,types::Value> const& captures = __jakt_match_value.captures;
@@ -874,7 +874,7 @@ types::TypeId const& return_type_id = __jakt_match_value.return_type_id;
 types::TypeId const& type_id = __jakt_match_value.type_id;
 types::CheckedBlock const& block = __jakt_match_value.block;
 JaktInternal::Array<types::CheckedParameter> const& checked_params = __jakt_match_value.checked_params;
-return JaktInternal::ExplicitValue(({ Optional<NonnullRefPtr<types::CheckedExpression>> __jakt_var_121; {
+return JaktInternal::ExplicitValue(({ Optional<NonnullRefPtr<types::CheckedExpression>> __jakt_var_125; {
 NonnullRefPtr<types::Scope> const parent_scope = TRY((((((interpreter)->program))->get_scope(((block).scope_id)))));
 types::ScopeId const inherited_scope_id = TRY((((((interpreter)->program))->create_scope(((block).scope_id),((parent_scope)->can_throw),TRY((String::formatted(String("synthetic({})"),((parent_scope)->debug_name)))),((type_id).module)))));
 NonnullRefPtr<types::Scope> inherited_scope = TRY((((((interpreter)->program))->get_scope(inherited_scope_id))));
@@ -897,21 +897,7 @@ TRY((((((inherited_scope)->comptime_bindings)).set(((capture).get<0>()),((captur
 }
 }
 
-{
-JaktInternal::ArrayIterator<NonnullRefPtr<types::CheckedStatement>> _magic = ((((block).statements)).iterator());
-for (;;){
-JaktInternal::Optional<NonnullRefPtr<types::CheckedStatement>> _magic_value = ((_magic).next());
-if ((!(((_magic_value).has_value())))){
-break;
-}
-NonnullRefPtr<types::CheckedStatement> statement = (_magic_value.value());
-{
-TRY((((statements).push(statement))));
-}
-
-}
-}
-
+TRY((((statements).push_values(((block).statements)))));
 types::CheckedBlock const new_block = types::CheckedBlock(statements,inherited_scope_id,((block).control_flow),((block).yielded_type),((block).yielded_none));
 {
 JaktInternal::ArrayIterator<types::CheckedParameter> _magic = ((checked_params).iterator());
@@ -928,10 +914,10 @@ outln(String("Param: {}"),TRY((((((interpreter)->program))->type_name(((((param)
 }
 }
 
-__jakt_var_121 = TRY((types::CheckedExpression::template create<typename types::CheckedExpression::Function>((TRY((Array<types::CheckedCapture>::create_with({})))),checked_params,can_throw,return_type_id,new_block,((this_value).span),type_id,JaktInternal::OptionalNone()))); goto __jakt_label_119;
+__jakt_var_125 = TRY((types::CheckedExpression::template create<typename types::CheckedExpression::Function>((TRY((Array<types::CheckedCapture>::create_with({})))),checked_params,can_throw,return_type_id,new_block,((this_value).span),type_id,JaktInternal::OptionalNone()))); goto __jakt_label_123;
 
 }
-__jakt_label_119:; __jakt_var_121.release_value(); }));
+__jakt_label_123:; __jakt_var_125.release_value(); }));
 };/*case end*/
 default: {
 {
@@ -977,7 +963,7 @@ if ((((namespace_).size()) != static_cast<size_t>(1ULL))){
 return (JAKT_RESOLVE_EXPLICIT_VALUE_OR_CONTROL_FLOW_RETURN_ONLY(([&]() -> JaktInternal::ExplicitValueOrControlFlow<interpreter::StatementResult,ErrorOr<interpreter::StatementResult>>{
 auto __jakt_enum_value = (prelude_function);
 if (__jakt_enum_value == String("format")) {
-return JaktInternal::ExplicitValue(({ Optional<interpreter::StatementResult> __jakt_var_122; {
+return JaktInternal::ExplicitValue(({ Optional<interpreter::StatementResult> __jakt_var_126; {
 String const format_string = JAKT_RESOLVE_EXPLICIT_VALUE_OR_CONTROL_FLOW_RETURN_ONLY(([&]() -> JaktInternal::ExplicitValueOrControlFlow<String, ErrorOr<interpreter::StatementResult>>{
 auto&& __jakt_match_variant = *((((arguments)[static_cast<i64>(0LL)])).impl);
 switch(__jakt_match_variant.index()) {
@@ -995,7 +981,7 @@ return Error::from_errno((infallible_integer_cast<i32>((InterpretError::InvalidT
 }/*switch end*/
 }()
 ));
-__jakt_var_122 =  interpreter::StatementResult { typename interpreter::StatementResult::JustValue(types::Value(TRY((types::ValueImpl::template create<typename types::ValueImpl::JaktString>(JAKT_RESOLVE_EXPLICIT_VALUE_OR_CONTROL_FLOW_RETURN_ONLY(([&]() -> JaktInternal::ExplicitValueOrControlFlow<String,ErrorOr<interpreter::StatementResult>>{
+__jakt_var_126 =  interpreter::StatementResult { typename interpreter::StatementResult::JustValue(types::Value(TRY((types::ValueImpl::template create<typename types::ValueImpl::JaktString>(JAKT_RESOLVE_EXPLICIT_VALUE_OR_CONTROL_FLOW_RETURN_ONLY(([&]() -> JaktInternal::ExplicitValueOrControlFlow<String,ErrorOr<interpreter::StatementResult>>{
 auto __jakt_enum_value = (((arguments).size()));
 if (__jakt_enum_value == static_cast<size_t>(1ULL)) {
 return JaktInternal::ExplicitValue(TRY((String::formatted(format_string))));
@@ -1096,1566 +1082,1566 @@ return Error::from_errno((infallible_integer_cast<i32>((InterpretError::InvalidT
 }
 }
 }()))
-))),call_span)) } ; goto __jakt_label_120;
-
-}
-__jakt_label_120:; __jakt_var_122.release_value(); }));
-}
-else if (__jakt_enum_value == String("println")) {
-return JaktInternal::ExplicitValue(({ Optional<interpreter::StatementResult> __jakt_var_123; {
-String const format_string = JAKT_RESOLVE_EXPLICIT_VALUE_OR_CONTROL_FLOW_RETURN_ONLY(([&]() -> JaktInternal::ExplicitValueOrControlFlow<String, ErrorOr<interpreter::StatementResult>>{
-auto&& __jakt_match_variant = *((((arguments)[static_cast<i64>(0LL)])).impl);
-switch(__jakt_match_variant.index()) {
-case 13: {
-auto&& __jakt_match_value = __jakt_match_variant.template get<typename types::ValueImpl::JaktString>();
-String const& x = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(x);
-};/*case end*/
-default: {
-{
-TRY((((*this).error(TRY((String::formatted(String("println expects a string as its first argument, but got {}"),((((arguments)[static_cast<i64>(0LL)])).impl)))),call_span))));
-return Error::from_errno((infallible_integer_cast<i32>((InterpretError::InvalidType))));
-}
-};/*case end*/
-}/*switch end*/
-}()
-));
-JAKT_RESOLVE_EXPLICIT_VALUE_OR_CONTROL_FLOW_RETURN_ONLY(([&]() -> JaktInternal::ExplicitValueOrControlFlow<void,ErrorOr<interpreter::StatementResult>>{
-auto __jakt_enum_value = (((arguments).size()));
-if (__jakt_enum_value == static_cast<size_t>(1ULL)) {
-return (JAKT_RESOLVE_EXPLICIT_VALUE_OR_CONTROL_FLOW_RETURN_ONLY(([&]() -> JaktInternal::ExplicitValueOrControlFlow<void,ErrorOr<interpreter::StatementResult>>{
-auto __jakt_enum_value = (prelude_function);
-if (__jakt_enum_value == String("println")) {
-return (outln(format_string)), JaktInternal::ExplicitValue<void>();
-}
-else if (__jakt_enum_value == String("eprintln")) {
-return (warnln(format_string)), JaktInternal::ExplicitValue<void>();
-}
-else if (__jakt_enum_value == String("print")) {
-return (out(format_string)), JaktInternal::ExplicitValue<void>();
-}
-else {
-return (warn(format_string)), JaktInternal::ExplicitValue<void>();
-}
-return JaktInternal::ExplicitValue<void>();
-}()))
-), JaktInternal::ExplicitValue<void>();
-}
-else if (__jakt_enum_value == static_cast<size_t>(2ULL)) {
-return (JAKT_RESOLVE_EXPLICIT_VALUE_OR_CONTROL_FLOW_RETURN_ONLY(([&]() -> JaktInternal::ExplicitValueOrControlFlow<void, ErrorOr<interpreter::StatementResult>>{
-auto&& __jakt_match_variant = *((((arguments)[static_cast<i64>(1LL)])).impl);
-switch(__jakt_match_variant.index()) {
-case 1: {
-auto&& __jakt_match_value = __jakt_match_variant.template get<typename types::ValueImpl::Bool>();
-bool const& x = __jakt_match_value.value;
-return (JAKT_RESOLVE_EXPLICIT_VALUE_OR_CONTROL_FLOW_RETURN_ONLY(([&]() -> JaktInternal::ExplicitValueOrControlFlow<void,ErrorOr<interpreter::StatementResult>>{
-auto __jakt_enum_value = (prelude_function);
-if (__jakt_enum_value == String("println")) {
-return (outln(format_string,x)), JaktInternal::ExplicitValue<void>();
-}
-else if (__jakt_enum_value == String("eprintln")) {
-return (warnln(format_string,x)), JaktInternal::ExplicitValue<void>();
-}
-else if (__jakt_enum_value == String("print")) {
-return (out(format_string,x)), JaktInternal::ExplicitValue<void>();
-}
-else {
-return (warn(format_string,x)), JaktInternal::ExplicitValue<void>();
-}
-return JaktInternal::ExplicitValue<void>();
-}()))
-), JaktInternal::ExplicitValue<void>();
-};/*case end*/
-case 2: {
-auto&& __jakt_match_value = __jakt_match_variant.template get<typename types::ValueImpl::U8>();
-u8 const& x = __jakt_match_value.value;
-return (JAKT_RESOLVE_EXPLICIT_VALUE_OR_CONTROL_FLOW_RETURN_ONLY(([&]() -> JaktInternal::ExplicitValueOrControlFlow<void,ErrorOr<interpreter::StatementResult>>{
-auto __jakt_enum_value = (prelude_function);
-if (__jakt_enum_value == String("println")) {
-return (outln(format_string,x)), JaktInternal::ExplicitValue<void>();
-}
-else if (__jakt_enum_value == String("eprintln")) {
-return (warnln(format_string,x)), JaktInternal::ExplicitValue<void>();
-}
-else if (__jakt_enum_value == String("print")) {
-return (out(format_string,x)), JaktInternal::ExplicitValue<void>();
-}
-else {
-return (warn(format_string,x)), JaktInternal::ExplicitValue<void>();
-}
-return JaktInternal::ExplicitValue<void>();
-}()))
-), JaktInternal::ExplicitValue<void>();
-};/*case end*/
-case 3: {
-auto&& __jakt_match_value = __jakt_match_variant.template get<typename types::ValueImpl::U16>();
-u16 const& x = __jakt_match_value.value;
-return (JAKT_RESOLVE_EXPLICIT_VALUE_OR_CONTROL_FLOW_RETURN_ONLY(([&]() -> JaktInternal::ExplicitValueOrControlFlow<void,ErrorOr<interpreter::StatementResult>>{
-auto __jakt_enum_value = (prelude_function);
-if (__jakt_enum_value == String("println")) {
-return (outln(format_string,x)), JaktInternal::ExplicitValue<void>();
-}
-else if (__jakt_enum_value == String("eprintln")) {
-return (warnln(format_string,x)), JaktInternal::ExplicitValue<void>();
-}
-else if (__jakt_enum_value == String("print")) {
-return (out(format_string,x)), JaktInternal::ExplicitValue<void>();
-}
-else {
-return (warn(format_string,x)), JaktInternal::ExplicitValue<void>();
-}
-return JaktInternal::ExplicitValue<void>();
-}()))
-), JaktInternal::ExplicitValue<void>();
-};/*case end*/
-case 4: {
-auto&& __jakt_match_value = __jakt_match_variant.template get<typename types::ValueImpl::U32>();
-u32 const& x = __jakt_match_value.value;
-return (JAKT_RESOLVE_EXPLICIT_VALUE_OR_CONTROL_FLOW_RETURN_ONLY(([&]() -> JaktInternal::ExplicitValueOrControlFlow<void,ErrorOr<interpreter::StatementResult>>{
-auto __jakt_enum_value = (prelude_function);
-if (__jakt_enum_value == String("println")) {
-return (outln(format_string,x)), JaktInternal::ExplicitValue<void>();
-}
-else if (__jakt_enum_value == String("eprintln")) {
-return (warnln(format_string,x)), JaktInternal::ExplicitValue<void>();
-}
-else if (__jakt_enum_value == String("print")) {
-return (out(format_string,x)), JaktInternal::ExplicitValue<void>();
-}
-else {
-return (warn(format_string,x)), JaktInternal::ExplicitValue<void>();
-}
-return JaktInternal::ExplicitValue<void>();
-}()))
-), JaktInternal::ExplicitValue<void>();
-};/*case end*/
-case 5: {
-auto&& __jakt_match_value = __jakt_match_variant.template get<typename types::ValueImpl::U64>();
-u64 const& x = __jakt_match_value.value;
-return (JAKT_RESOLVE_EXPLICIT_VALUE_OR_CONTROL_FLOW_RETURN_ONLY(([&]() -> JaktInternal::ExplicitValueOrControlFlow<void,ErrorOr<interpreter::StatementResult>>{
-auto __jakt_enum_value = (prelude_function);
-if (__jakt_enum_value == String("println")) {
-return (outln(format_string,x)), JaktInternal::ExplicitValue<void>();
-}
-else if (__jakt_enum_value == String("eprintln")) {
-return (warnln(format_string,x)), JaktInternal::ExplicitValue<void>();
-}
-else if (__jakt_enum_value == String("print")) {
-return (out(format_string,x)), JaktInternal::ExplicitValue<void>();
-}
-else {
-return (warn(format_string,x)), JaktInternal::ExplicitValue<void>();
-}
-return JaktInternal::ExplicitValue<void>();
-}()))
-), JaktInternal::ExplicitValue<void>();
-};/*case end*/
-case 6: {
-auto&& __jakt_match_value = __jakt_match_variant.template get<typename types::ValueImpl::I8>();
-i8 const& x = __jakt_match_value.value;
-return (JAKT_RESOLVE_EXPLICIT_VALUE_OR_CONTROL_FLOW_RETURN_ONLY(([&]() -> JaktInternal::ExplicitValueOrControlFlow<void,ErrorOr<interpreter::StatementResult>>{
-auto __jakt_enum_value = (prelude_function);
-if (__jakt_enum_value == String("println")) {
-return (outln(format_string,x)), JaktInternal::ExplicitValue<void>();
-}
-else if (__jakt_enum_value == String("eprintln")) {
-return (warnln(format_string,x)), JaktInternal::ExplicitValue<void>();
-}
-else if (__jakt_enum_value == String("print")) {
-return (out(format_string,x)), JaktInternal::ExplicitValue<void>();
-}
-else {
-return (warn(format_string,x)), JaktInternal::ExplicitValue<void>();
-}
-return JaktInternal::ExplicitValue<void>();
-}()))
-), JaktInternal::ExplicitValue<void>();
-};/*case end*/
-case 7: {
-auto&& __jakt_match_value = __jakt_match_variant.template get<typename types::ValueImpl::I16>();
-i16 const& x = __jakt_match_value.value;
-return (JAKT_RESOLVE_EXPLICIT_VALUE_OR_CONTROL_FLOW_RETURN_ONLY(([&]() -> JaktInternal::ExplicitValueOrControlFlow<void,ErrorOr<interpreter::StatementResult>>{
-auto __jakt_enum_value = (prelude_function);
-if (__jakt_enum_value == String("println")) {
-return (outln(format_string,x)), JaktInternal::ExplicitValue<void>();
-}
-else if (__jakt_enum_value == String("eprintln")) {
-return (warnln(format_string,x)), JaktInternal::ExplicitValue<void>();
-}
-else if (__jakt_enum_value == String("print")) {
-return (out(format_string,x)), JaktInternal::ExplicitValue<void>();
-}
-else {
-return (warn(format_string,x)), JaktInternal::ExplicitValue<void>();
-}
-return JaktInternal::ExplicitValue<void>();
-}()))
-), JaktInternal::ExplicitValue<void>();
-};/*case end*/
-case 8: {
-auto&& __jakt_match_value = __jakt_match_variant.template get<typename types::ValueImpl::I32>();
-i32 const& x = __jakt_match_value.value;
-return (JAKT_RESOLVE_EXPLICIT_VALUE_OR_CONTROL_FLOW_RETURN_ONLY(([&]() -> JaktInternal::ExplicitValueOrControlFlow<void,ErrorOr<interpreter::StatementResult>>{
-auto __jakt_enum_value = (prelude_function);
-if (__jakt_enum_value == String("println")) {
-return (outln(format_string,x)), JaktInternal::ExplicitValue<void>();
-}
-else if (__jakt_enum_value == String("eprintln")) {
-return (warnln(format_string,x)), JaktInternal::ExplicitValue<void>();
-}
-else if (__jakt_enum_value == String("print")) {
-return (out(format_string,x)), JaktInternal::ExplicitValue<void>();
-}
-else {
-return (warn(format_string,x)), JaktInternal::ExplicitValue<void>();
-}
-return JaktInternal::ExplicitValue<void>();
-}()))
-), JaktInternal::ExplicitValue<void>();
-};/*case end*/
-case 9: {
-auto&& __jakt_match_value = __jakt_match_variant.template get<typename types::ValueImpl::I64>();
-i64 const& x = __jakt_match_value.value;
-return (JAKT_RESOLVE_EXPLICIT_VALUE_OR_CONTROL_FLOW_RETURN_ONLY(([&]() -> JaktInternal::ExplicitValueOrControlFlow<void,ErrorOr<interpreter::StatementResult>>{
-auto __jakt_enum_value = (prelude_function);
-if (__jakt_enum_value == String("println")) {
-return (outln(format_string,x)), JaktInternal::ExplicitValue<void>();
-}
-else if (__jakt_enum_value == String("eprintln")) {
-return (warnln(format_string,x)), JaktInternal::ExplicitValue<void>();
-}
-else if (__jakt_enum_value == String("print")) {
-return (out(format_string,x)), JaktInternal::ExplicitValue<void>();
-}
-else {
-return (warn(format_string,x)), JaktInternal::ExplicitValue<void>();
-}
-return JaktInternal::ExplicitValue<void>();
-}()))
-), JaktInternal::ExplicitValue<void>();
-};/*case end*/
-case 10: {
-auto&& __jakt_match_value = __jakt_match_variant.template get<typename types::ValueImpl::F32>();
-f32 const& x = __jakt_match_value.value;
-return (JAKT_RESOLVE_EXPLICIT_VALUE_OR_CONTROL_FLOW_RETURN_ONLY(([&]() -> JaktInternal::ExplicitValueOrControlFlow<void,ErrorOr<interpreter::StatementResult>>{
-auto __jakt_enum_value = (prelude_function);
-if (__jakt_enum_value == String("println")) {
-return (outln(format_string,x)), JaktInternal::ExplicitValue<void>();
-}
-else if (__jakt_enum_value == String("eprintln")) {
-return (warnln(format_string,x)), JaktInternal::ExplicitValue<void>();
-}
-else if (__jakt_enum_value == String("print")) {
-return (out(format_string,x)), JaktInternal::ExplicitValue<void>();
-}
-else {
-return (warn(format_string,x)), JaktInternal::ExplicitValue<void>();
-}
-return JaktInternal::ExplicitValue<void>();
-}()))
-), JaktInternal::ExplicitValue<void>();
-};/*case end*/
-case 11: {
-auto&& __jakt_match_value = __jakt_match_variant.template get<typename types::ValueImpl::F64>();
-f64 const& x = __jakt_match_value.value;
-return (JAKT_RESOLVE_EXPLICIT_VALUE_OR_CONTROL_FLOW_RETURN_ONLY(([&]() -> JaktInternal::ExplicitValueOrControlFlow<void,ErrorOr<interpreter::StatementResult>>{
-auto __jakt_enum_value = (prelude_function);
-if (__jakt_enum_value == String("println")) {
-return (outln(format_string,x)), JaktInternal::ExplicitValue<void>();
-}
-else if (__jakt_enum_value == String("eprintln")) {
-return (warnln(format_string,x)), JaktInternal::ExplicitValue<void>();
-}
-else if (__jakt_enum_value == String("print")) {
-return (out(format_string,x)), JaktInternal::ExplicitValue<void>();
-}
-else {
-return (warn(format_string,x)), JaktInternal::ExplicitValue<void>();
-}
-return JaktInternal::ExplicitValue<void>();
-}()))
-), JaktInternal::ExplicitValue<void>();
-};/*case end*/
-case 12: {
-auto&& __jakt_match_value = __jakt_match_variant.template get<typename types::ValueImpl::USize>();
-size_t const& x = __jakt_match_value.value;
-return (JAKT_RESOLVE_EXPLICIT_VALUE_OR_CONTROL_FLOW_RETURN_ONLY(([&]() -> JaktInternal::ExplicitValueOrControlFlow<void,ErrorOr<interpreter::StatementResult>>{
-auto __jakt_enum_value = (prelude_function);
-if (__jakt_enum_value == String("println")) {
-return (outln(format_string,x)), JaktInternal::ExplicitValue<void>();
-}
-else if (__jakt_enum_value == String("eprintln")) {
-return (warnln(format_string,x)), JaktInternal::ExplicitValue<void>();
-}
-else if (__jakt_enum_value == String("print")) {
-return (out(format_string,x)), JaktInternal::ExplicitValue<void>();
-}
-else {
-return (warn(format_string,x)), JaktInternal::ExplicitValue<void>();
-}
-return JaktInternal::ExplicitValue<void>();
-}()))
-), JaktInternal::ExplicitValue<void>();
-};/*case end*/
-case 13: {
-auto&& __jakt_match_value = __jakt_match_variant.template get<typename types::ValueImpl::JaktString>();
-String const& x = __jakt_match_value.value;
-return (JAKT_RESOLVE_EXPLICIT_VALUE_OR_CONTROL_FLOW_RETURN_ONLY(([&]() -> JaktInternal::ExplicitValueOrControlFlow<void,ErrorOr<interpreter::StatementResult>>{
-auto __jakt_enum_value = (prelude_function);
-if (__jakt_enum_value == String("println")) {
-return (outln(format_string,x)), JaktInternal::ExplicitValue<void>();
-}
-else if (__jakt_enum_value == String("eprintln")) {
-return (warnln(format_string,x)), JaktInternal::ExplicitValue<void>();
-}
-else if (__jakt_enum_value == String("print")) {
-return (out(format_string,x)), JaktInternal::ExplicitValue<void>();
-}
-else {
-return (warn(format_string,x)), JaktInternal::ExplicitValue<void>();
-}
-return JaktInternal::ExplicitValue<void>();
-}()))
-), JaktInternal::ExplicitValue<void>();
-};/*case end*/
-case 14: {
-auto&& __jakt_match_value = __jakt_match_variant.template get<typename types::ValueImpl::CChar>();
-char const& x = __jakt_match_value.value;
-return (JAKT_RESOLVE_EXPLICIT_VALUE_OR_CONTROL_FLOW_RETURN_ONLY(([&]() -> JaktInternal::ExplicitValueOrControlFlow<void,ErrorOr<interpreter::StatementResult>>{
-auto __jakt_enum_value = (prelude_function);
-if (__jakt_enum_value == String("println")) {
-return (outln(format_string,x)), JaktInternal::ExplicitValue<void>();
-}
-else if (__jakt_enum_value == String("eprintln")) {
-return (warnln(format_string,x)), JaktInternal::ExplicitValue<void>();
-}
-else if (__jakt_enum_value == String("print")) {
-return (out(format_string,x)), JaktInternal::ExplicitValue<void>();
-}
-else {
-return (warn(format_string,x)), JaktInternal::ExplicitValue<void>();
-}
-return JaktInternal::ExplicitValue<void>();
-}()))
-), JaktInternal::ExplicitValue<void>();
-};/*case end*/
-case 15: {
-auto&& __jakt_match_value = __jakt_match_variant.template get<typename types::ValueImpl::CInt>();
-int const& x = __jakt_match_value.value;
-return (JAKT_RESOLVE_EXPLICIT_VALUE_OR_CONTROL_FLOW_RETURN_ONLY(([&]() -> JaktInternal::ExplicitValueOrControlFlow<void,ErrorOr<interpreter::StatementResult>>{
-auto __jakt_enum_value = (prelude_function);
-if (__jakt_enum_value == String("println")) {
-return (outln(format_string,x)), JaktInternal::ExplicitValue<void>();
-}
-else if (__jakt_enum_value == String("eprintln")) {
-return (warnln(format_string,x)), JaktInternal::ExplicitValue<void>();
-}
-else if (__jakt_enum_value == String("print")) {
-return (out(format_string,x)), JaktInternal::ExplicitValue<void>();
-}
-else {
-return (warn(format_string,x)), JaktInternal::ExplicitValue<void>();
-}
-return JaktInternal::ExplicitValue<void>();
-}()))
-), JaktInternal::ExplicitValue<void>();
-};/*case end*/
-default: {
-{
-TRY((((*this).error(TRY((String::formatted(String("comptime format can only format primitves, got {}"),((((arguments)[static_cast<i64>(1LL)])).impl)))),call_span))));
-return Error::from_errno((infallible_integer_cast<i32>((InterpretError::InvalidType))));
-}
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
-}/*switch end*/
-}()
-))), JaktInternal::ExplicitValue<void>();
-}
-else {
-{
-TRY((((*this).error(TRY((String::formatted(String("comptime format accepts at most two arguments, but got {}"),((arguments).size())))),call_span))));
-return Error::from_errno((infallible_integer_cast<i32>((InterpretError::InvalidType))));
-}
-return JaktInternal::ExplicitValue<void>();
-}
-return JaktInternal::ExplicitValue<void>();
-}()))
-;
-__jakt_var_123 =  interpreter::StatementResult { typename interpreter::StatementResult::JustValue(types::Value(TRY((types::ValueImpl::template create<typename types::ValueImpl::Void>())),call_span)) } ; goto __jakt_label_121;
-
-}
-__jakt_label_121:; __jakt_var_123.release_value(); }));
-}
-else if (__jakt_enum_value == String("eprintln")) {
-return JaktInternal::ExplicitValue(({ Optional<interpreter::StatementResult> __jakt_var_124; {
-String const format_string = JAKT_RESOLVE_EXPLICIT_VALUE_OR_CONTROL_FLOW_RETURN_ONLY(([&]() -> JaktInternal::ExplicitValueOrControlFlow<String, ErrorOr<interpreter::StatementResult>>{
-auto&& __jakt_match_variant = *((((arguments)[static_cast<i64>(0LL)])).impl);
-switch(__jakt_match_variant.index()) {
-case 13: {
-auto&& __jakt_match_value = __jakt_match_variant.template get<typename types::ValueImpl::JaktString>();
-String const& x = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(x);
-};/*case end*/
-default: {
-{
-TRY((((*this).error(TRY((String::formatted(String("println expects a string as its first argument, but got {}"),((((arguments)[static_cast<i64>(0LL)])).impl)))),call_span))));
-return Error::from_errno((infallible_integer_cast<i32>((InterpretError::InvalidType))));
-}
-};/*case end*/
-}/*switch end*/
-}()
-));
-JAKT_RESOLVE_EXPLICIT_VALUE_OR_CONTROL_FLOW_RETURN_ONLY(([&]() -> JaktInternal::ExplicitValueOrControlFlow<void,ErrorOr<interpreter::StatementResult>>{
-auto __jakt_enum_value = (((arguments).size()));
-if (__jakt_enum_value == static_cast<size_t>(1ULL)) {
-return (JAKT_RESOLVE_EXPLICIT_VALUE_OR_CONTROL_FLOW_RETURN_ONLY(([&]() -> JaktInternal::ExplicitValueOrControlFlow<void,ErrorOr<interpreter::StatementResult>>{
-auto __jakt_enum_value = (prelude_function);
-if (__jakt_enum_value == String("println")) {
-return (outln(format_string)), JaktInternal::ExplicitValue<void>();
-}
-else if (__jakt_enum_value == String("eprintln")) {
-return (warnln(format_string)), JaktInternal::ExplicitValue<void>();
-}
-else if (__jakt_enum_value == String("print")) {
-return (out(format_string)), JaktInternal::ExplicitValue<void>();
-}
-else {
-return (warn(format_string)), JaktInternal::ExplicitValue<void>();
-}
-return JaktInternal::ExplicitValue<void>();
-}()))
-), JaktInternal::ExplicitValue<void>();
-}
-else if (__jakt_enum_value == static_cast<size_t>(2ULL)) {
-return (JAKT_RESOLVE_EXPLICIT_VALUE_OR_CONTROL_FLOW_RETURN_ONLY(([&]() -> JaktInternal::ExplicitValueOrControlFlow<void, ErrorOr<interpreter::StatementResult>>{
-auto&& __jakt_match_variant = *((((arguments)[static_cast<i64>(1LL)])).impl);
-switch(__jakt_match_variant.index()) {
-case 1: {
-auto&& __jakt_match_value = __jakt_match_variant.template get<typename types::ValueImpl::Bool>();
-bool const& x = __jakt_match_value.value;
-return (JAKT_RESOLVE_EXPLICIT_VALUE_OR_CONTROL_FLOW_RETURN_ONLY(([&]() -> JaktInternal::ExplicitValueOrControlFlow<void,ErrorOr<interpreter::StatementResult>>{
-auto __jakt_enum_value = (prelude_function);
-if (__jakt_enum_value == String("println")) {
-return (outln(format_string,x)), JaktInternal::ExplicitValue<void>();
-}
-else if (__jakt_enum_value == String("eprintln")) {
-return (warnln(format_string,x)), JaktInternal::ExplicitValue<void>();
-}
-else if (__jakt_enum_value == String("print")) {
-return (out(format_string,x)), JaktInternal::ExplicitValue<void>();
-}
-else {
-return (warn(format_string,x)), JaktInternal::ExplicitValue<void>();
-}
-return JaktInternal::ExplicitValue<void>();
-}()))
-), JaktInternal::ExplicitValue<void>();
-};/*case end*/
-case 2: {
-auto&& __jakt_match_value = __jakt_match_variant.template get<typename types::ValueImpl::U8>();
-u8 const& x = __jakt_match_value.value;
-return (JAKT_RESOLVE_EXPLICIT_VALUE_OR_CONTROL_FLOW_RETURN_ONLY(([&]() -> JaktInternal::ExplicitValueOrControlFlow<void,ErrorOr<interpreter::StatementResult>>{
-auto __jakt_enum_value = (prelude_function);
-if (__jakt_enum_value == String("println")) {
-return (outln(format_string,x)), JaktInternal::ExplicitValue<void>();
-}
-else if (__jakt_enum_value == String("eprintln")) {
-return (warnln(format_string,x)), JaktInternal::ExplicitValue<void>();
-}
-else if (__jakt_enum_value == String("print")) {
-return (out(format_string,x)), JaktInternal::ExplicitValue<void>();
-}
-else {
-return (warn(format_string,x)), JaktInternal::ExplicitValue<void>();
-}
-return JaktInternal::ExplicitValue<void>();
-}()))
-), JaktInternal::ExplicitValue<void>();
-};/*case end*/
-case 3: {
-auto&& __jakt_match_value = __jakt_match_variant.template get<typename types::ValueImpl::U16>();
-u16 const& x = __jakt_match_value.value;
-return (JAKT_RESOLVE_EXPLICIT_VALUE_OR_CONTROL_FLOW_RETURN_ONLY(([&]() -> JaktInternal::ExplicitValueOrControlFlow<void,ErrorOr<interpreter::StatementResult>>{
-auto __jakt_enum_value = (prelude_function);
-if (__jakt_enum_value == String("println")) {
-return (outln(format_string,x)), JaktInternal::ExplicitValue<void>();
-}
-else if (__jakt_enum_value == String("eprintln")) {
-return (warnln(format_string,x)), JaktInternal::ExplicitValue<void>();
-}
-else if (__jakt_enum_value == String("print")) {
-return (out(format_string,x)), JaktInternal::ExplicitValue<void>();
-}
-else {
-return (warn(format_string,x)), JaktInternal::ExplicitValue<void>();
-}
-return JaktInternal::ExplicitValue<void>();
-}()))
-), JaktInternal::ExplicitValue<void>();
-};/*case end*/
-case 4: {
-auto&& __jakt_match_value = __jakt_match_variant.template get<typename types::ValueImpl::U32>();
-u32 const& x = __jakt_match_value.value;
-return (JAKT_RESOLVE_EXPLICIT_VALUE_OR_CONTROL_FLOW_RETURN_ONLY(([&]() -> JaktInternal::ExplicitValueOrControlFlow<void,ErrorOr<interpreter::StatementResult>>{
-auto __jakt_enum_value = (prelude_function);
-if (__jakt_enum_value == String("println")) {
-return (outln(format_string,x)), JaktInternal::ExplicitValue<void>();
-}
-else if (__jakt_enum_value == String("eprintln")) {
-return (warnln(format_string,x)), JaktInternal::ExplicitValue<void>();
-}
-else if (__jakt_enum_value == String("print")) {
-return (out(format_string,x)), JaktInternal::ExplicitValue<void>();
-}
-else {
-return (warn(format_string,x)), JaktInternal::ExplicitValue<void>();
-}
-return JaktInternal::ExplicitValue<void>();
-}()))
-), JaktInternal::ExplicitValue<void>();
-};/*case end*/
-case 5: {
-auto&& __jakt_match_value = __jakt_match_variant.template get<typename types::ValueImpl::U64>();
-u64 const& x = __jakt_match_value.value;
-return (JAKT_RESOLVE_EXPLICIT_VALUE_OR_CONTROL_FLOW_RETURN_ONLY(([&]() -> JaktInternal::ExplicitValueOrControlFlow<void,ErrorOr<interpreter::StatementResult>>{
-auto __jakt_enum_value = (prelude_function);
-if (__jakt_enum_value == String("println")) {
-return (outln(format_string,x)), JaktInternal::ExplicitValue<void>();
-}
-else if (__jakt_enum_value == String("eprintln")) {
-return (warnln(format_string,x)), JaktInternal::ExplicitValue<void>();
-}
-else if (__jakt_enum_value == String("print")) {
-return (out(format_string,x)), JaktInternal::ExplicitValue<void>();
-}
-else {
-return (warn(format_string,x)), JaktInternal::ExplicitValue<void>();
-}
-return JaktInternal::ExplicitValue<void>();
-}()))
-), JaktInternal::ExplicitValue<void>();
-};/*case end*/
-case 6: {
-auto&& __jakt_match_value = __jakt_match_variant.template get<typename types::ValueImpl::I8>();
-i8 const& x = __jakt_match_value.value;
-return (JAKT_RESOLVE_EXPLICIT_VALUE_OR_CONTROL_FLOW_RETURN_ONLY(([&]() -> JaktInternal::ExplicitValueOrControlFlow<void,ErrorOr<interpreter::StatementResult>>{
-auto __jakt_enum_value = (prelude_function);
-if (__jakt_enum_value == String("println")) {
-return (outln(format_string,x)), JaktInternal::ExplicitValue<void>();
-}
-else if (__jakt_enum_value == String("eprintln")) {
-return (warnln(format_string,x)), JaktInternal::ExplicitValue<void>();
-}
-else if (__jakt_enum_value == String("print")) {
-return (out(format_string,x)), JaktInternal::ExplicitValue<void>();
-}
-else {
-return (warn(format_string,x)), JaktInternal::ExplicitValue<void>();
-}
-return JaktInternal::ExplicitValue<void>();
-}()))
-), JaktInternal::ExplicitValue<void>();
-};/*case end*/
-case 7: {
-auto&& __jakt_match_value = __jakt_match_variant.template get<typename types::ValueImpl::I16>();
-i16 const& x = __jakt_match_value.value;
-return (JAKT_RESOLVE_EXPLICIT_VALUE_OR_CONTROL_FLOW_RETURN_ONLY(([&]() -> JaktInternal::ExplicitValueOrControlFlow<void,ErrorOr<interpreter::StatementResult>>{
-auto __jakt_enum_value = (prelude_function);
-if (__jakt_enum_value == String("println")) {
-return (outln(format_string,x)), JaktInternal::ExplicitValue<void>();
-}
-else if (__jakt_enum_value == String("eprintln")) {
-return (warnln(format_string,x)), JaktInternal::ExplicitValue<void>();
-}
-else if (__jakt_enum_value == String("print")) {
-return (out(format_string,x)), JaktInternal::ExplicitValue<void>();
-}
-else {
-return (warn(format_string,x)), JaktInternal::ExplicitValue<void>();
-}
-return JaktInternal::ExplicitValue<void>();
-}()))
-), JaktInternal::ExplicitValue<void>();
-};/*case end*/
-case 8: {
-auto&& __jakt_match_value = __jakt_match_variant.template get<typename types::ValueImpl::I32>();
-i32 const& x = __jakt_match_value.value;
-return (JAKT_RESOLVE_EXPLICIT_VALUE_OR_CONTROL_FLOW_RETURN_ONLY(([&]() -> JaktInternal::ExplicitValueOrControlFlow<void,ErrorOr<interpreter::StatementResult>>{
-auto __jakt_enum_value = (prelude_function);
-if (__jakt_enum_value == String("println")) {
-return (outln(format_string,x)), JaktInternal::ExplicitValue<void>();
-}
-else if (__jakt_enum_value == String("eprintln")) {
-return (warnln(format_string,x)), JaktInternal::ExplicitValue<void>();
-}
-else if (__jakt_enum_value == String("print")) {
-return (out(format_string,x)), JaktInternal::ExplicitValue<void>();
-}
-else {
-return (warn(format_string,x)), JaktInternal::ExplicitValue<void>();
-}
-return JaktInternal::ExplicitValue<void>();
-}()))
-), JaktInternal::ExplicitValue<void>();
-};/*case end*/
-case 9: {
-auto&& __jakt_match_value = __jakt_match_variant.template get<typename types::ValueImpl::I64>();
-i64 const& x = __jakt_match_value.value;
-return (JAKT_RESOLVE_EXPLICIT_VALUE_OR_CONTROL_FLOW_RETURN_ONLY(([&]() -> JaktInternal::ExplicitValueOrControlFlow<void,ErrorOr<interpreter::StatementResult>>{
-auto __jakt_enum_value = (prelude_function);
-if (__jakt_enum_value == String("println")) {
-return (outln(format_string,x)), JaktInternal::ExplicitValue<void>();
-}
-else if (__jakt_enum_value == String("eprintln")) {
-return (warnln(format_string,x)), JaktInternal::ExplicitValue<void>();
-}
-else if (__jakt_enum_value == String("print")) {
-return (out(format_string,x)), JaktInternal::ExplicitValue<void>();
-}
-else {
-return (warn(format_string,x)), JaktInternal::ExplicitValue<void>();
-}
-return JaktInternal::ExplicitValue<void>();
-}()))
-), JaktInternal::ExplicitValue<void>();
-};/*case end*/
-case 10: {
-auto&& __jakt_match_value = __jakt_match_variant.template get<typename types::ValueImpl::F32>();
-f32 const& x = __jakt_match_value.value;
-return (JAKT_RESOLVE_EXPLICIT_VALUE_OR_CONTROL_FLOW_RETURN_ONLY(([&]() -> JaktInternal::ExplicitValueOrControlFlow<void,ErrorOr<interpreter::StatementResult>>{
-auto __jakt_enum_value = (prelude_function);
-if (__jakt_enum_value == String("println")) {
-return (outln(format_string,x)), JaktInternal::ExplicitValue<void>();
-}
-else if (__jakt_enum_value == String("eprintln")) {
-return (warnln(format_string,x)), JaktInternal::ExplicitValue<void>();
-}
-else if (__jakt_enum_value == String("print")) {
-return (out(format_string,x)), JaktInternal::ExplicitValue<void>();
-}
-else {
-return (warn(format_string,x)), JaktInternal::ExplicitValue<void>();
-}
-return JaktInternal::ExplicitValue<void>();
-}()))
-), JaktInternal::ExplicitValue<void>();
-};/*case end*/
-case 11: {
-auto&& __jakt_match_value = __jakt_match_variant.template get<typename types::ValueImpl::F64>();
-f64 const& x = __jakt_match_value.value;
-return (JAKT_RESOLVE_EXPLICIT_VALUE_OR_CONTROL_FLOW_RETURN_ONLY(([&]() -> JaktInternal::ExplicitValueOrControlFlow<void,ErrorOr<interpreter::StatementResult>>{
-auto __jakt_enum_value = (prelude_function);
-if (__jakt_enum_value == String("println")) {
-return (outln(format_string,x)), JaktInternal::ExplicitValue<void>();
-}
-else if (__jakt_enum_value == String("eprintln")) {
-return (warnln(format_string,x)), JaktInternal::ExplicitValue<void>();
-}
-else if (__jakt_enum_value == String("print")) {
-return (out(format_string,x)), JaktInternal::ExplicitValue<void>();
-}
-else {
-return (warn(format_string,x)), JaktInternal::ExplicitValue<void>();
-}
-return JaktInternal::ExplicitValue<void>();
-}()))
-), JaktInternal::ExplicitValue<void>();
-};/*case end*/
-case 12: {
-auto&& __jakt_match_value = __jakt_match_variant.template get<typename types::ValueImpl::USize>();
-size_t const& x = __jakt_match_value.value;
-return (JAKT_RESOLVE_EXPLICIT_VALUE_OR_CONTROL_FLOW_RETURN_ONLY(([&]() -> JaktInternal::ExplicitValueOrControlFlow<void,ErrorOr<interpreter::StatementResult>>{
-auto __jakt_enum_value = (prelude_function);
-if (__jakt_enum_value == String("println")) {
-return (outln(format_string,x)), JaktInternal::ExplicitValue<void>();
-}
-else if (__jakt_enum_value == String("eprintln")) {
-return (warnln(format_string,x)), JaktInternal::ExplicitValue<void>();
-}
-else if (__jakt_enum_value == String("print")) {
-return (out(format_string,x)), JaktInternal::ExplicitValue<void>();
-}
-else {
-return (warn(format_string,x)), JaktInternal::ExplicitValue<void>();
-}
-return JaktInternal::ExplicitValue<void>();
-}()))
-), JaktInternal::ExplicitValue<void>();
-};/*case end*/
-case 13: {
-auto&& __jakt_match_value = __jakt_match_variant.template get<typename types::ValueImpl::JaktString>();
-String const& x = __jakt_match_value.value;
-return (JAKT_RESOLVE_EXPLICIT_VALUE_OR_CONTROL_FLOW_RETURN_ONLY(([&]() -> JaktInternal::ExplicitValueOrControlFlow<void,ErrorOr<interpreter::StatementResult>>{
-auto __jakt_enum_value = (prelude_function);
-if (__jakt_enum_value == String("println")) {
-return (outln(format_string,x)), JaktInternal::ExplicitValue<void>();
-}
-else if (__jakt_enum_value == String("eprintln")) {
-return (warnln(format_string,x)), JaktInternal::ExplicitValue<void>();
-}
-else if (__jakt_enum_value == String("print")) {
-return (out(format_string,x)), JaktInternal::ExplicitValue<void>();
-}
-else {
-return (warn(format_string,x)), JaktInternal::ExplicitValue<void>();
-}
-return JaktInternal::ExplicitValue<void>();
-}()))
-), JaktInternal::ExplicitValue<void>();
-};/*case end*/
-case 14: {
-auto&& __jakt_match_value = __jakt_match_variant.template get<typename types::ValueImpl::CChar>();
-char const& x = __jakt_match_value.value;
-return (JAKT_RESOLVE_EXPLICIT_VALUE_OR_CONTROL_FLOW_RETURN_ONLY(([&]() -> JaktInternal::ExplicitValueOrControlFlow<void,ErrorOr<interpreter::StatementResult>>{
-auto __jakt_enum_value = (prelude_function);
-if (__jakt_enum_value == String("println")) {
-return (outln(format_string,x)), JaktInternal::ExplicitValue<void>();
-}
-else if (__jakt_enum_value == String("eprintln")) {
-return (warnln(format_string,x)), JaktInternal::ExplicitValue<void>();
-}
-else if (__jakt_enum_value == String("print")) {
-return (out(format_string,x)), JaktInternal::ExplicitValue<void>();
-}
-else {
-return (warn(format_string,x)), JaktInternal::ExplicitValue<void>();
-}
-return JaktInternal::ExplicitValue<void>();
-}()))
-), JaktInternal::ExplicitValue<void>();
-};/*case end*/
-case 15: {
-auto&& __jakt_match_value = __jakt_match_variant.template get<typename types::ValueImpl::CInt>();
-int const& x = __jakt_match_value.value;
-return (JAKT_RESOLVE_EXPLICIT_VALUE_OR_CONTROL_FLOW_RETURN_ONLY(([&]() -> JaktInternal::ExplicitValueOrControlFlow<void,ErrorOr<interpreter::StatementResult>>{
-auto __jakt_enum_value = (prelude_function);
-if (__jakt_enum_value == String("println")) {
-return (outln(format_string,x)), JaktInternal::ExplicitValue<void>();
-}
-else if (__jakt_enum_value == String("eprintln")) {
-return (warnln(format_string,x)), JaktInternal::ExplicitValue<void>();
-}
-else if (__jakt_enum_value == String("print")) {
-return (out(format_string,x)), JaktInternal::ExplicitValue<void>();
-}
-else {
-return (warn(format_string,x)), JaktInternal::ExplicitValue<void>();
-}
-return JaktInternal::ExplicitValue<void>();
-}()))
-), JaktInternal::ExplicitValue<void>();
-};/*case end*/
-default: {
-{
-TRY((((*this).error(TRY((String::formatted(String("comptime format can only format primitves, got {}"),((((arguments)[static_cast<i64>(1LL)])).impl)))),call_span))));
-return Error::from_errno((infallible_integer_cast<i32>((InterpretError::InvalidType))));
-}
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
-}/*switch end*/
-}()
-))), JaktInternal::ExplicitValue<void>();
-}
-else {
-{
-TRY((((*this).error(TRY((String::formatted(String("comptime format accepts at most two arguments, but got {}"),((arguments).size())))),call_span))));
-return Error::from_errno((infallible_integer_cast<i32>((InterpretError::InvalidType))));
-}
-return JaktInternal::ExplicitValue<void>();
-}
-return JaktInternal::ExplicitValue<void>();
-}()))
-;
-__jakt_var_124 =  interpreter::StatementResult { typename interpreter::StatementResult::JustValue(types::Value(TRY((types::ValueImpl::template create<typename types::ValueImpl::Void>())),call_span)) } ; goto __jakt_label_122;
-
-}
-__jakt_label_122:; __jakt_var_124.release_value(); }));
-}
-else if (__jakt_enum_value == String("print")) {
-return JaktInternal::ExplicitValue(({ Optional<interpreter::StatementResult> __jakt_var_125; {
-String const format_string = JAKT_RESOLVE_EXPLICIT_VALUE_OR_CONTROL_FLOW_RETURN_ONLY(([&]() -> JaktInternal::ExplicitValueOrControlFlow<String, ErrorOr<interpreter::StatementResult>>{
-auto&& __jakt_match_variant = *((((arguments)[static_cast<i64>(0LL)])).impl);
-switch(__jakt_match_variant.index()) {
-case 13: {
-auto&& __jakt_match_value = __jakt_match_variant.template get<typename types::ValueImpl::JaktString>();
-String const& x = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(x);
-};/*case end*/
-default: {
-{
-TRY((((*this).error(TRY((String::formatted(String("println expects a string as its first argument, but got {}"),((((arguments)[static_cast<i64>(0LL)])).impl)))),call_span))));
-return Error::from_errno((infallible_integer_cast<i32>((InterpretError::InvalidType))));
-}
-};/*case end*/
-}/*switch end*/
-}()
-));
-JAKT_RESOLVE_EXPLICIT_VALUE_OR_CONTROL_FLOW_RETURN_ONLY(([&]() -> JaktInternal::ExplicitValueOrControlFlow<void,ErrorOr<interpreter::StatementResult>>{
-auto __jakt_enum_value = (((arguments).size()));
-if (__jakt_enum_value == static_cast<size_t>(1ULL)) {
-return (JAKT_RESOLVE_EXPLICIT_VALUE_OR_CONTROL_FLOW_RETURN_ONLY(([&]() -> JaktInternal::ExplicitValueOrControlFlow<void,ErrorOr<interpreter::StatementResult>>{
-auto __jakt_enum_value = (prelude_function);
-if (__jakt_enum_value == String("println")) {
-return (outln(format_string)), JaktInternal::ExplicitValue<void>();
-}
-else if (__jakt_enum_value == String("eprintln")) {
-return (warnln(format_string)), JaktInternal::ExplicitValue<void>();
-}
-else if (__jakt_enum_value == String("print")) {
-return (out(format_string)), JaktInternal::ExplicitValue<void>();
-}
-else {
-return (warn(format_string)), JaktInternal::ExplicitValue<void>();
-}
-return JaktInternal::ExplicitValue<void>();
-}()))
-), JaktInternal::ExplicitValue<void>();
-}
-else if (__jakt_enum_value == static_cast<size_t>(2ULL)) {
-return (JAKT_RESOLVE_EXPLICIT_VALUE_OR_CONTROL_FLOW_RETURN_ONLY(([&]() -> JaktInternal::ExplicitValueOrControlFlow<void, ErrorOr<interpreter::StatementResult>>{
-auto&& __jakt_match_variant = *((((arguments)[static_cast<i64>(1LL)])).impl);
-switch(__jakt_match_variant.index()) {
-case 1: {
-auto&& __jakt_match_value = __jakt_match_variant.template get<typename types::ValueImpl::Bool>();
-bool const& x = __jakt_match_value.value;
-return (JAKT_RESOLVE_EXPLICIT_VALUE_OR_CONTROL_FLOW_RETURN_ONLY(([&]() -> JaktInternal::ExplicitValueOrControlFlow<void,ErrorOr<interpreter::StatementResult>>{
-auto __jakt_enum_value = (prelude_function);
-if (__jakt_enum_value == String("println")) {
-return (outln(format_string,x)), JaktInternal::ExplicitValue<void>();
-}
-else if (__jakt_enum_value == String("eprintln")) {
-return (warnln(format_string,x)), JaktInternal::ExplicitValue<void>();
-}
-else if (__jakt_enum_value == String("print")) {
-return (out(format_string,x)), JaktInternal::ExplicitValue<void>();
-}
-else {
-return (warn(format_string,x)), JaktInternal::ExplicitValue<void>();
-}
-return JaktInternal::ExplicitValue<void>();
-}()))
-), JaktInternal::ExplicitValue<void>();
-};/*case end*/
-case 2: {
-auto&& __jakt_match_value = __jakt_match_variant.template get<typename types::ValueImpl::U8>();
-u8 const& x = __jakt_match_value.value;
-return (JAKT_RESOLVE_EXPLICIT_VALUE_OR_CONTROL_FLOW_RETURN_ONLY(([&]() -> JaktInternal::ExplicitValueOrControlFlow<void,ErrorOr<interpreter::StatementResult>>{
-auto __jakt_enum_value = (prelude_function);
-if (__jakt_enum_value == String("println")) {
-return (outln(format_string,x)), JaktInternal::ExplicitValue<void>();
-}
-else if (__jakt_enum_value == String("eprintln")) {
-return (warnln(format_string,x)), JaktInternal::ExplicitValue<void>();
-}
-else if (__jakt_enum_value == String("print")) {
-return (out(format_string,x)), JaktInternal::ExplicitValue<void>();
-}
-else {
-return (warn(format_string,x)), JaktInternal::ExplicitValue<void>();
-}
-return JaktInternal::ExplicitValue<void>();
-}()))
-), JaktInternal::ExplicitValue<void>();
-};/*case end*/
-case 3: {
-auto&& __jakt_match_value = __jakt_match_variant.template get<typename types::ValueImpl::U16>();
-u16 const& x = __jakt_match_value.value;
-return (JAKT_RESOLVE_EXPLICIT_VALUE_OR_CONTROL_FLOW_RETURN_ONLY(([&]() -> JaktInternal::ExplicitValueOrControlFlow<void,ErrorOr<interpreter::StatementResult>>{
-auto __jakt_enum_value = (prelude_function);
-if (__jakt_enum_value == String("println")) {
-return (outln(format_string,x)), JaktInternal::ExplicitValue<void>();
-}
-else if (__jakt_enum_value == String("eprintln")) {
-return (warnln(format_string,x)), JaktInternal::ExplicitValue<void>();
-}
-else if (__jakt_enum_value == String("print")) {
-return (out(format_string,x)), JaktInternal::ExplicitValue<void>();
-}
-else {
-return (warn(format_string,x)), JaktInternal::ExplicitValue<void>();
-}
-return JaktInternal::ExplicitValue<void>();
-}()))
-), JaktInternal::ExplicitValue<void>();
-};/*case end*/
-case 4: {
-auto&& __jakt_match_value = __jakt_match_variant.template get<typename types::ValueImpl::U32>();
-u32 const& x = __jakt_match_value.value;
-return (JAKT_RESOLVE_EXPLICIT_VALUE_OR_CONTROL_FLOW_RETURN_ONLY(([&]() -> JaktInternal::ExplicitValueOrControlFlow<void,ErrorOr<interpreter::StatementResult>>{
-auto __jakt_enum_value = (prelude_function);
-if (__jakt_enum_value == String("println")) {
-return (outln(format_string,x)), JaktInternal::ExplicitValue<void>();
-}
-else if (__jakt_enum_value == String("eprintln")) {
-return (warnln(format_string,x)), JaktInternal::ExplicitValue<void>();
-}
-else if (__jakt_enum_value == String("print")) {
-return (out(format_string,x)), JaktInternal::ExplicitValue<void>();
-}
-else {
-return (warn(format_string,x)), JaktInternal::ExplicitValue<void>();
-}
-return JaktInternal::ExplicitValue<void>();
-}()))
-), JaktInternal::ExplicitValue<void>();
-};/*case end*/
-case 5: {
-auto&& __jakt_match_value = __jakt_match_variant.template get<typename types::ValueImpl::U64>();
-u64 const& x = __jakt_match_value.value;
-return (JAKT_RESOLVE_EXPLICIT_VALUE_OR_CONTROL_FLOW_RETURN_ONLY(([&]() -> JaktInternal::ExplicitValueOrControlFlow<void,ErrorOr<interpreter::StatementResult>>{
-auto __jakt_enum_value = (prelude_function);
-if (__jakt_enum_value == String("println")) {
-return (outln(format_string,x)), JaktInternal::ExplicitValue<void>();
-}
-else if (__jakt_enum_value == String("eprintln")) {
-return (warnln(format_string,x)), JaktInternal::ExplicitValue<void>();
-}
-else if (__jakt_enum_value == String("print")) {
-return (out(format_string,x)), JaktInternal::ExplicitValue<void>();
-}
-else {
-return (warn(format_string,x)), JaktInternal::ExplicitValue<void>();
-}
-return JaktInternal::ExplicitValue<void>();
-}()))
-), JaktInternal::ExplicitValue<void>();
-};/*case end*/
-case 6: {
-auto&& __jakt_match_value = __jakt_match_variant.template get<typename types::ValueImpl::I8>();
-i8 const& x = __jakt_match_value.value;
-return (JAKT_RESOLVE_EXPLICIT_VALUE_OR_CONTROL_FLOW_RETURN_ONLY(([&]() -> JaktInternal::ExplicitValueOrControlFlow<void,ErrorOr<interpreter::StatementResult>>{
-auto __jakt_enum_value = (prelude_function);
-if (__jakt_enum_value == String("println")) {
-return (outln(format_string,x)), JaktInternal::ExplicitValue<void>();
-}
-else if (__jakt_enum_value == String("eprintln")) {
-return (warnln(format_string,x)), JaktInternal::ExplicitValue<void>();
-}
-else if (__jakt_enum_value == String("print")) {
-return (out(format_string,x)), JaktInternal::ExplicitValue<void>();
-}
-else {
-return (warn(format_string,x)), JaktInternal::ExplicitValue<void>();
-}
-return JaktInternal::ExplicitValue<void>();
-}()))
-), JaktInternal::ExplicitValue<void>();
-};/*case end*/
-case 7: {
-auto&& __jakt_match_value = __jakt_match_variant.template get<typename types::ValueImpl::I16>();
-i16 const& x = __jakt_match_value.value;
-return (JAKT_RESOLVE_EXPLICIT_VALUE_OR_CONTROL_FLOW_RETURN_ONLY(([&]() -> JaktInternal::ExplicitValueOrControlFlow<void,ErrorOr<interpreter::StatementResult>>{
-auto __jakt_enum_value = (prelude_function);
-if (__jakt_enum_value == String("println")) {
-return (outln(format_string,x)), JaktInternal::ExplicitValue<void>();
-}
-else if (__jakt_enum_value == String("eprintln")) {
-return (warnln(format_string,x)), JaktInternal::ExplicitValue<void>();
-}
-else if (__jakt_enum_value == String("print")) {
-return (out(format_string,x)), JaktInternal::ExplicitValue<void>();
-}
-else {
-return (warn(format_string,x)), JaktInternal::ExplicitValue<void>();
-}
-return JaktInternal::ExplicitValue<void>();
-}()))
-), JaktInternal::ExplicitValue<void>();
-};/*case end*/
-case 8: {
-auto&& __jakt_match_value = __jakt_match_variant.template get<typename types::ValueImpl::I32>();
-i32 const& x = __jakt_match_value.value;
-return (JAKT_RESOLVE_EXPLICIT_VALUE_OR_CONTROL_FLOW_RETURN_ONLY(([&]() -> JaktInternal::ExplicitValueOrControlFlow<void,ErrorOr<interpreter::StatementResult>>{
-auto __jakt_enum_value = (prelude_function);
-if (__jakt_enum_value == String("println")) {
-return (outln(format_string,x)), JaktInternal::ExplicitValue<void>();
-}
-else if (__jakt_enum_value == String("eprintln")) {
-return (warnln(format_string,x)), JaktInternal::ExplicitValue<void>();
-}
-else if (__jakt_enum_value == String("print")) {
-return (out(format_string,x)), JaktInternal::ExplicitValue<void>();
-}
-else {
-return (warn(format_string,x)), JaktInternal::ExplicitValue<void>();
-}
-return JaktInternal::ExplicitValue<void>();
-}()))
-), JaktInternal::ExplicitValue<void>();
-};/*case end*/
-case 9: {
-auto&& __jakt_match_value = __jakt_match_variant.template get<typename types::ValueImpl::I64>();
-i64 const& x = __jakt_match_value.value;
-return (JAKT_RESOLVE_EXPLICIT_VALUE_OR_CONTROL_FLOW_RETURN_ONLY(([&]() -> JaktInternal::ExplicitValueOrControlFlow<void,ErrorOr<interpreter::StatementResult>>{
-auto __jakt_enum_value = (prelude_function);
-if (__jakt_enum_value == String("println")) {
-return (outln(format_string,x)), JaktInternal::ExplicitValue<void>();
-}
-else if (__jakt_enum_value == String("eprintln")) {
-return (warnln(format_string,x)), JaktInternal::ExplicitValue<void>();
-}
-else if (__jakt_enum_value == String("print")) {
-return (out(format_string,x)), JaktInternal::ExplicitValue<void>();
-}
-else {
-return (warn(format_string,x)), JaktInternal::ExplicitValue<void>();
-}
-return JaktInternal::ExplicitValue<void>();
-}()))
-), JaktInternal::ExplicitValue<void>();
-};/*case end*/
-case 10: {
-auto&& __jakt_match_value = __jakt_match_variant.template get<typename types::ValueImpl::F32>();
-f32 const& x = __jakt_match_value.value;
-return (JAKT_RESOLVE_EXPLICIT_VALUE_OR_CONTROL_FLOW_RETURN_ONLY(([&]() -> JaktInternal::ExplicitValueOrControlFlow<void,ErrorOr<interpreter::StatementResult>>{
-auto __jakt_enum_value = (prelude_function);
-if (__jakt_enum_value == String("println")) {
-return (outln(format_string,x)), JaktInternal::ExplicitValue<void>();
-}
-else if (__jakt_enum_value == String("eprintln")) {
-return (warnln(format_string,x)), JaktInternal::ExplicitValue<void>();
-}
-else if (__jakt_enum_value == String("print")) {
-return (out(format_string,x)), JaktInternal::ExplicitValue<void>();
-}
-else {
-return (warn(format_string,x)), JaktInternal::ExplicitValue<void>();
-}
-return JaktInternal::ExplicitValue<void>();
-}()))
-), JaktInternal::ExplicitValue<void>();
-};/*case end*/
-case 11: {
-auto&& __jakt_match_value = __jakt_match_variant.template get<typename types::ValueImpl::F64>();
-f64 const& x = __jakt_match_value.value;
-return (JAKT_RESOLVE_EXPLICIT_VALUE_OR_CONTROL_FLOW_RETURN_ONLY(([&]() -> JaktInternal::ExplicitValueOrControlFlow<void,ErrorOr<interpreter::StatementResult>>{
-auto __jakt_enum_value = (prelude_function);
-if (__jakt_enum_value == String("println")) {
-return (outln(format_string,x)), JaktInternal::ExplicitValue<void>();
-}
-else if (__jakt_enum_value == String("eprintln")) {
-return (warnln(format_string,x)), JaktInternal::ExplicitValue<void>();
-}
-else if (__jakt_enum_value == String("print")) {
-return (out(format_string,x)), JaktInternal::ExplicitValue<void>();
-}
-else {
-return (warn(format_string,x)), JaktInternal::ExplicitValue<void>();
-}
-return JaktInternal::ExplicitValue<void>();
-}()))
-), JaktInternal::ExplicitValue<void>();
-};/*case end*/
-case 12: {
-auto&& __jakt_match_value = __jakt_match_variant.template get<typename types::ValueImpl::USize>();
-size_t const& x = __jakt_match_value.value;
-return (JAKT_RESOLVE_EXPLICIT_VALUE_OR_CONTROL_FLOW_RETURN_ONLY(([&]() -> JaktInternal::ExplicitValueOrControlFlow<void,ErrorOr<interpreter::StatementResult>>{
-auto __jakt_enum_value = (prelude_function);
-if (__jakt_enum_value == String("println")) {
-return (outln(format_string,x)), JaktInternal::ExplicitValue<void>();
-}
-else if (__jakt_enum_value == String("eprintln")) {
-return (warnln(format_string,x)), JaktInternal::ExplicitValue<void>();
-}
-else if (__jakt_enum_value == String("print")) {
-return (out(format_string,x)), JaktInternal::ExplicitValue<void>();
-}
-else {
-return (warn(format_string,x)), JaktInternal::ExplicitValue<void>();
-}
-return JaktInternal::ExplicitValue<void>();
-}()))
-), JaktInternal::ExplicitValue<void>();
-};/*case end*/
-case 13: {
-auto&& __jakt_match_value = __jakt_match_variant.template get<typename types::ValueImpl::JaktString>();
-String const& x = __jakt_match_value.value;
-return (JAKT_RESOLVE_EXPLICIT_VALUE_OR_CONTROL_FLOW_RETURN_ONLY(([&]() -> JaktInternal::ExplicitValueOrControlFlow<void,ErrorOr<interpreter::StatementResult>>{
-auto __jakt_enum_value = (prelude_function);
-if (__jakt_enum_value == String("println")) {
-return (outln(format_string,x)), JaktInternal::ExplicitValue<void>();
-}
-else if (__jakt_enum_value == String("eprintln")) {
-return (warnln(format_string,x)), JaktInternal::ExplicitValue<void>();
-}
-else if (__jakt_enum_value == String("print")) {
-return (out(format_string,x)), JaktInternal::ExplicitValue<void>();
-}
-else {
-return (warn(format_string,x)), JaktInternal::ExplicitValue<void>();
-}
-return JaktInternal::ExplicitValue<void>();
-}()))
-), JaktInternal::ExplicitValue<void>();
-};/*case end*/
-case 14: {
-auto&& __jakt_match_value = __jakt_match_variant.template get<typename types::ValueImpl::CChar>();
-char const& x = __jakt_match_value.value;
-return (JAKT_RESOLVE_EXPLICIT_VALUE_OR_CONTROL_FLOW_RETURN_ONLY(([&]() -> JaktInternal::ExplicitValueOrControlFlow<void,ErrorOr<interpreter::StatementResult>>{
-auto __jakt_enum_value = (prelude_function);
-if (__jakt_enum_value == String("println")) {
-return (outln(format_string,x)), JaktInternal::ExplicitValue<void>();
-}
-else if (__jakt_enum_value == String("eprintln")) {
-return (warnln(format_string,x)), JaktInternal::ExplicitValue<void>();
-}
-else if (__jakt_enum_value == String("print")) {
-return (out(format_string,x)), JaktInternal::ExplicitValue<void>();
-}
-else {
-return (warn(format_string,x)), JaktInternal::ExplicitValue<void>();
-}
-return JaktInternal::ExplicitValue<void>();
-}()))
-), JaktInternal::ExplicitValue<void>();
-};/*case end*/
-case 15: {
-auto&& __jakt_match_value = __jakt_match_variant.template get<typename types::ValueImpl::CInt>();
-int const& x = __jakt_match_value.value;
-return (JAKT_RESOLVE_EXPLICIT_VALUE_OR_CONTROL_FLOW_RETURN_ONLY(([&]() -> JaktInternal::ExplicitValueOrControlFlow<void,ErrorOr<interpreter::StatementResult>>{
-auto __jakt_enum_value = (prelude_function);
-if (__jakt_enum_value == String("println")) {
-return (outln(format_string,x)), JaktInternal::ExplicitValue<void>();
-}
-else if (__jakt_enum_value == String("eprintln")) {
-return (warnln(format_string,x)), JaktInternal::ExplicitValue<void>();
-}
-else if (__jakt_enum_value == String("print")) {
-return (out(format_string,x)), JaktInternal::ExplicitValue<void>();
-}
-else {
-return (warn(format_string,x)), JaktInternal::ExplicitValue<void>();
-}
-return JaktInternal::ExplicitValue<void>();
-}()))
-), JaktInternal::ExplicitValue<void>();
-};/*case end*/
-default: {
-{
-TRY((((*this).error(TRY((String::formatted(String("comptime format can only format primitves, got {}"),((((arguments)[static_cast<i64>(1LL)])).impl)))),call_span))));
-return Error::from_errno((infallible_integer_cast<i32>((InterpretError::InvalidType))));
-}
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
-}/*switch end*/
-}()
-))), JaktInternal::ExplicitValue<void>();
-}
-else {
-{
-TRY((((*this).error(TRY((String::formatted(String("comptime format accepts at most two arguments, but got {}"),((arguments).size())))),call_span))));
-return Error::from_errno((infallible_integer_cast<i32>((InterpretError::InvalidType))));
-}
-return JaktInternal::ExplicitValue<void>();
-}
-return JaktInternal::ExplicitValue<void>();
-}()))
-;
-__jakt_var_125 =  interpreter::StatementResult { typename interpreter::StatementResult::JustValue(types::Value(TRY((types::ValueImpl::template create<typename types::ValueImpl::Void>())),call_span)) } ; goto __jakt_label_123;
-
-}
-__jakt_label_123:; __jakt_var_125.release_value(); }));
-}
-else if (__jakt_enum_value == String("eprint")) {
-return JaktInternal::ExplicitValue(({ Optional<interpreter::StatementResult> __jakt_var_126; {
-String const format_string = JAKT_RESOLVE_EXPLICIT_VALUE_OR_CONTROL_FLOW_RETURN_ONLY(([&]() -> JaktInternal::ExplicitValueOrControlFlow<String, ErrorOr<interpreter::StatementResult>>{
-auto&& __jakt_match_variant = *((((arguments)[static_cast<i64>(0LL)])).impl);
-switch(__jakt_match_variant.index()) {
-case 13: {
-auto&& __jakt_match_value = __jakt_match_variant.template get<typename types::ValueImpl::JaktString>();
-String const& x = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(x);
-};/*case end*/
-default: {
-{
-TRY((((*this).error(TRY((String::formatted(String("println expects a string as its first argument, but got {}"),((((arguments)[static_cast<i64>(0LL)])).impl)))),call_span))));
-return Error::from_errno((infallible_integer_cast<i32>((InterpretError::InvalidType))));
-}
-};/*case end*/
-}/*switch end*/
-}()
-));
-JAKT_RESOLVE_EXPLICIT_VALUE_OR_CONTROL_FLOW_RETURN_ONLY(([&]() -> JaktInternal::ExplicitValueOrControlFlow<void,ErrorOr<interpreter::StatementResult>>{
-auto __jakt_enum_value = (((arguments).size()));
-if (__jakt_enum_value == static_cast<size_t>(1ULL)) {
-return (JAKT_RESOLVE_EXPLICIT_VALUE_OR_CONTROL_FLOW_RETURN_ONLY(([&]() -> JaktInternal::ExplicitValueOrControlFlow<void,ErrorOr<interpreter::StatementResult>>{
-auto __jakt_enum_value = (prelude_function);
-if (__jakt_enum_value == String("println")) {
-return (outln(format_string)), JaktInternal::ExplicitValue<void>();
-}
-else if (__jakt_enum_value == String("eprintln")) {
-return (warnln(format_string)), JaktInternal::ExplicitValue<void>();
-}
-else if (__jakt_enum_value == String("print")) {
-return (out(format_string)), JaktInternal::ExplicitValue<void>();
-}
-else {
-return (warn(format_string)), JaktInternal::ExplicitValue<void>();
-}
-return JaktInternal::ExplicitValue<void>();
-}()))
-), JaktInternal::ExplicitValue<void>();
-}
-else if (__jakt_enum_value == static_cast<size_t>(2ULL)) {
-return (JAKT_RESOLVE_EXPLICIT_VALUE_OR_CONTROL_FLOW_RETURN_ONLY(([&]() -> JaktInternal::ExplicitValueOrControlFlow<void, ErrorOr<interpreter::StatementResult>>{
-auto&& __jakt_match_variant = *((((arguments)[static_cast<i64>(1LL)])).impl);
-switch(__jakt_match_variant.index()) {
-case 1: {
-auto&& __jakt_match_value = __jakt_match_variant.template get<typename types::ValueImpl::Bool>();
-bool const& x = __jakt_match_value.value;
-return (JAKT_RESOLVE_EXPLICIT_VALUE_OR_CONTROL_FLOW_RETURN_ONLY(([&]() -> JaktInternal::ExplicitValueOrControlFlow<void,ErrorOr<interpreter::StatementResult>>{
-auto __jakt_enum_value = (prelude_function);
-if (__jakt_enum_value == String("println")) {
-return (outln(format_string,x)), JaktInternal::ExplicitValue<void>();
-}
-else if (__jakt_enum_value == String("eprintln")) {
-return (warnln(format_string,x)), JaktInternal::ExplicitValue<void>();
-}
-else if (__jakt_enum_value == String("print")) {
-return (out(format_string,x)), JaktInternal::ExplicitValue<void>();
-}
-else {
-return (warn(format_string,x)), JaktInternal::ExplicitValue<void>();
-}
-return JaktInternal::ExplicitValue<void>();
-}()))
-), JaktInternal::ExplicitValue<void>();
-};/*case end*/
-case 2: {
-auto&& __jakt_match_value = __jakt_match_variant.template get<typename types::ValueImpl::U8>();
-u8 const& x = __jakt_match_value.value;
-return (JAKT_RESOLVE_EXPLICIT_VALUE_OR_CONTROL_FLOW_RETURN_ONLY(([&]() -> JaktInternal::ExplicitValueOrControlFlow<void,ErrorOr<interpreter::StatementResult>>{
-auto __jakt_enum_value = (prelude_function);
-if (__jakt_enum_value == String("println")) {
-return (outln(format_string,x)), JaktInternal::ExplicitValue<void>();
-}
-else if (__jakt_enum_value == String("eprintln")) {
-return (warnln(format_string,x)), JaktInternal::ExplicitValue<void>();
-}
-else if (__jakt_enum_value == String("print")) {
-return (out(format_string,x)), JaktInternal::ExplicitValue<void>();
-}
-else {
-return (warn(format_string,x)), JaktInternal::ExplicitValue<void>();
-}
-return JaktInternal::ExplicitValue<void>();
-}()))
-), JaktInternal::ExplicitValue<void>();
-};/*case end*/
-case 3: {
-auto&& __jakt_match_value = __jakt_match_variant.template get<typename types::ValueImpl::U16>();
-u16 const& x = __jakt_match_value.value;
-return (JAKT_RESOLVE_EXPLICIT_VALUE_OR_CONTROL_FLOW_RETURN_ONLY(([&]() -> JaktInternal::ExplicitValueOrControlFlow<void,ErrorOr<interpreter::StatementResult>>{
-auto __jakt_enum_value = (prelude_function);
-if (__jakt_enum_value == String("println")) {
-return (outln(format_string,x)), JaktInternal::ExplicitValue<void>();
-}
-else if (__jakt_enum_value == String("eprintln")) {
-return (warnln(format_string,x)), JaktInternal::ExplicitValue<void>();
-}
-else if (__jakt_enum_value == String("print")) {
-return (out(format_string,x)), JaktInternal::ExplicitValue<void>();
-}
-else {
-return (warn(format_string,x)), JaktInternal::ExplicitValue<void>();
-}
-return JaktInternal::ExplicitValue<void>();
-}()))
-), JaktInternal::ExplicitValue<void>();
-};/*case end*/
-case 4: {
-auto&& __jakt_match_value = __jakt_match_variant.template get<typename types::ValueImpl::U32>();
-u32 const& x = __jakt_match_value.value;
-return (JAKT_RESOLVE_EXPLICIT_VALUE_OR_CONTROL_FLOW_RETURN_ONLY(([&]() -> JaktInternal::ExplicitValueOrControlFlow<void,ErrorOr<interpreter::StatementResult>>{
-auto __jakt_enum_value = (prelude_function);
-if (__jakt_enum_value == String("println")) {
-return (outln(format_string,x)), JaktInternal::ExplicitValue<void>();
-}
-else if (__jakt_enum_value == String("eprintln")) {
-return (warnln(format_string,x)), JaktInternal::ExplicitValue<void>();
-}
-else if (__jakt_enum_value == String("print")) {
-return (out(format_string,x)), JaktInternal::ExplicitValue<void>();
-}
-else {
-return (warn(format_string,x)), JaktInternal::ExplicitValue<void>();
-}
-return JaktInternal::ExplicitValue<void>();
-}()))
-), JaktInternal::ExplicitValue<void>();
-};/*case end*/
-case 5: {
-auto&& __jakt_match_value = __jakt_match_variant.template get<typename types::ValueImpl::U64>();
-u64 const& x = __jakt_match_value.value;
-return (JAKT_RESOLVE_EXPLICIT_VALUE_OR_CONTROL_FLOW_RETURN_ONLY(([&]() -> JaktInternal::ExplicitValueOrControlFlow<void,ErrorOr<interpreter::StatementResult>>{
-auto __jakt_enum_value = (prelude_function);
-if (__jakt_enum_value == String("println")) {
-return (outln(format_string,x)), JaktInternal::ExplicitValue<void>();
-}
-else if (__jakt_enum_value == String("eprintln")) {
-return (warnln(format_string,x)), JaktInternal::ExplicitValue<void>();
-}
-else if (__jakt_enum_value == String("print")) {
-return (out(format_string,x)), JaktInternal::ExplicitValue<void>();
-}
-else {
-return (warn(format_string,x)), JaktInternal::ExplicitValue<void>();
-}
-return JaktInternal::ExplicitValue<void>();
-}()))
-), JaktInternal::ExplicitValue<void>();
-};/*case end*/
-case 6: {
-auto&& __jakt_match_value = __jakt_match_variant.template get<typename types::ValueImpl::I8>();
-i8 const& x = __jakt_match_value.value;
-return (JAKT_RESOLVE_EXPLICIT_VALUE_OR_CONTROL_FLOW_RETURN_ONLY(([&]() -> JaktInternal::ExplicitValueOrControlFlow<void,ErrorOr<interpreter::StatementResult>>{
-auto __jakt_enum_value = (prelude_function);
-if (__jakt_enum_value == String("println")) {
-return (outln(format_string,x)), JaktInternal::ExplicitValue<void>();
-}
-else if (__jakt_enum_value == String("eprintln")) {
-return (warnln(format_string,x)), JaktInternal::ExplicitValue<void>();
-}
-else if (__jakt_enum_value == String("print")) {
-return (out(format_string,x)), JaktInternal::ExplicitValue<void>();
-}
-else {
-return (warn(format_string,x)), JaktInternal::ExplicitValue<void>();
-}
-return JaktInternal::ExplicitValue<void>();
-}()))
-), JaktInternal::ExplicitValue<void>();
-};/*case end*/
-case 7: {
-auto&& __jakt_match_value = __jakt_match_variant.template get<typename types::ValueImpl::I16>();
-i16 const& x = __jakt_match_value.value;
-return (JAKT_RESOLVE_EXPLICIT_VALUE_OR_CONTROL_FLOW_RETURN_ONLY(([&]() -> JaktInternal::ExplicitValueOrControlFlow<void,ErrorOr<interpreter::StatementResult>>{
-auto __jakt_enum_value = (prelude_function);
-if (__jakt_enum_value == String("println")) {
-return (outln(format_string,x)), JaktInternal::ExplicitValue<void>();
-}
-else if (__jakt_enum_value == String("eprintln")) {
-return (warnln(format_string,x)), JaktInternal::ExplicitValue<void>();
-}
-else if (__jakt_enum_value == String("print")) {
-return (out(format_string,x)), JaktInternal::ExplicitValue<void>();
-}
-else {
-return (warn(format_string,x)), JaktInternal::ExplicitValue<void>();
-}
-return JaktInternal::ExplicitValue<void>();
-}()))
-), JaktInternal::ExplicitValue<void>();
-};/*case end*/
-case 8: {
-auto&& __jakt_match_value = __jakt_match_variant.template get<typename types::ValueImpl::I32>();
-i32 const& x = __jakt_match_value.value;
-return (JAKT_RESOLVE_EXPLICIT_VALUE_OR_CONTROL_FLOW_RETURN_ONLY(([&]() -> JaktInternal::ExplicitValueOrControlFlow<void,ErrorOr<interpreter::StatementResult>>{
-auto __jakt_enum_value = (prelude_function);
-if (__jakt_enum_value == String("println")) {
-return (outln(format_string,x)), JaktInternal::ExplicitValue<void>();
-}
-else if (__jakt_enum_value == String("eprintln")) {
-return (warnln(format_string,x)), JaktInternal::ExplicitValue<void>();
-}
-else if (__jakt_enum_value == String("print")) {
-return (out(format_string,x)), JaktInternal::ExplicitValue<void>();
-}
-else {
-return (warn(format_string,x)), JaktInternal::ExplicitValue<void>();
-}
-return JaktInternal::ExplicitValue<void>();
-}()))
-), JaktInternal::ExplicitValue<void>();
-};/*case end*/
-case 9: {
-auto&& __jakt_match_value = __jakt_match_variant.template get<typename types::ValueImpl::I64>();
-i64 const& x = __jakt_match_value.value;
-return (JAKT_RESOLVE_EXPLICIT_VALUE_OR_CONTROL_FLOW_RETURN_ONLY(([&]() -> JaktInternal::ExplicitValueOrControlFlow<void,ErrorOr<interpreter::StatementResult>>{
-auto __jakt_enum_value = (prelude_function);
-if (__jakt_enum_value == String("println")) {
-return (outln(format_string,x)), JaktInternal::ExplicitValue<void>();
-}
-else if (__jakt_enum_value == String("eprintln")) {
-return (warnln(format_string,x)), JaktInternal::ExplicitValue<void>();
-}
-else if (__jakt_enum_value == String("print")) {
-return (out(format_string,x)), JaktInternal::ExplicitValue<void>();
-}
-else {
-return (warn(format_string,x)), JaktInternal::ExplicitValue<void>();
-}
-return JaktInternal::ExplicitValue<void>();
-}()))
-), JaktInternal::ExplicitValue<void>();
-};/*case end*/
-case 10: {
-auto&& __jakt_match_value = __jakt_match_variant.template get<typename types::ValueImpl::F32>();
-f32 const& x = __jakt_match_value.value;
-return (JAKT_RESOLVE_EXPLICIT_VALUE_OR_CONTROL_FLOW_RETURN_ONLY(([&]() -> JaktInternal::ExplicitValueOrControlFlow<void,ErrorOr<interpreter::StatementResult>>{
-auto __jakt_enum_value = (prelude_function);
-if (__jakt_enum_value == String("println")) {
-return (outln(format_string,x)), JaktInternal::ExplicitValue<void>();
-}
-else if (__jakt_enum_value == String("eprintln")) {
-return (warnln(format_string,x)), JaktInternal::ExplicitValue<void>();
-}
-else if (__jakt_enum_value == String("print")) {
-return (out(format_string,x)), JaktInternal::ExplicitValue<void>();
-}
-else {
-return (warn(format_string,x)), JaktInternal::ExplicitValue<void>();
-}
-return JaktInternal::ExplicitValue<void>();
-}()))
-), JaktInternal::ExplicitValue<void>();
-};/*case end*/
-case 11: {
-auto&& __jakt_match_value = __jakt_match_variant.template get<typename types::ValueImpl::F64>();
-f64 const& x = __jakt_match_value.value;
-return (JAKT_RESOLVE_EXPLICIT_VALUE_OR_CONTROL_FLOW_RETURN_ONLY(([&]() -> JaktInternal::ExplicitValueOrControlFlow<void,ErrorOr<interpreter::StatementResult>>{
-auto __jakt_enum_value = (prelude_function);
-if (__jakt_enum_value == String("println")) {
-return (outln(format_string,x)), JaktInternal::ExplicitValue<void>();
-}
-else if (__jakt_enum_value == String("eprintln")) {
-return (warnln(format_string,x)), JaktInternal::ExplicitValue<void>();
-}
-else if (__jakt_enum_value == String("print")) {
-return (out(format_string,x)), JaktInternal::ExplicitValue<void>();
-}
-else {
-return (warn(format_string,x)), JaktInternal::ExplicitValue<void>();
-}
-return JaktInternal::ExplicitValue<void>();
-}()))
-), JaktInternal::ExplicitValue<void>();
-};/*case end*/
-case 12: {
-auto&& __jakt_match_value = __jakt_match_variant.template get<typename types::ValueImpl::USize>();
-size_t const& x = __jakt_match_value.value;
-return (JAKT_RESOLVE_EXPLICIT_VALUE_OR_CONTROL_FLOW_RETURN_ONLY(([&]() -> JaktInternal::ExplicitValueOrControlFlow<void,ErrorOr<interpreter::StatementResult>>{
-auto __jakt_enum_value = (prelude_function);
-if (__jakt_enum_value == String("println")) {
-return (outln(format_string,x)), JaktInternal::ExplicitValue<void>();
-}
-else if (__jakt_enum_value == String("eprintln")) {
-return (warnln(format_string,x)), JaktInternal::ExplicitValue<void>();
-}
-else if (__jakt_enum_value == String("print")) {
-return (out(format_string,x)), JaktInternal::ExplicitValue<void>();
-}
-else {
-return (warn(format_string,x)), JaktInternal::ExplicitValue<void>();
-}
-return JaktInternal::ExplicitValue<void>();
-}()))
-), JaktInternal::ExplicitValue<void>();
-};/*case end*/
-case 13: {
-auto&& __jakt_match_value = __jakt_match_variant.template get<typename types::ValueImpl::JaktString>();
-String const& x = __jakt_match_value.value;
-return (JAKT_RESOLVE_EXPLICIT_VALUE_OR_CONTROL_FLOW_RETURN_ONLY(([&]() -> JaktInternal::ExplicitValueOrControlFlow<void,ErrorOr<interpreter::StatementResult>>{
-auto __jakt_enum_value = (prelude_function);
-if (__jakt_enum_value == String("println")) {
-return (outln(format_string,x)), JaktInternal::ExplicitValue<void>();
-}
-else if (__jakt_enum_value == String("eprintln")) {
-return (warnln(format_string,x)), JaktInternal::ExplicitValue<void>();
-}
-else if (__jakt_enum_value == String("print")) {
-return (out(format_string,x)), JaktInternal::ExplicitValue<void>();
-}
-else {
-return (warn(format_string,x)), JaktInternal::ExplicitValue<void>();
-}
-return JaktInternal::ExplicitValue<void>();
-}()))
-), JaktInternal::ExplicitValue<void>();
-};/*case end*/
-case 14: {
-auto&& __jakt_match_value = __jakt_match_variant.template get<typename types::ValueImpl::CChar>();
-char const& x = __jakt_match_value.value;
-return (JAKT_RESOLVE_EXPLICIT_VALUE_OR_CONTROL_FLOW_RETURN_ONLY(([&]() -> JaktInternal::ExplicitValueOrControlFlow<void,ErrorOr<interpreter::StatementResult>>{
-auto __jakt_enum_value = (prelude_function);
-if (__jakt_enum_value == String("println")) {
-return (outln(format_string,x)), JaktInternal::ExplicitValue<void>();
-}
-else if (__jakt_enum_value == String("eprintln")) {
-return (warnln(format_string,x)), JaktInternal::ExplicitValue<void>();
-}
-else if (__jakt_enum_value == String("print")) {
-return (out(format_string,x)), JaktInternal::ExplicitValue<void>();
-}
-else {
-return (warn(format_string,x)), JaktInternal::ExplicitValue<void>();
-}
-return JaktInternal::ExplicitValue<void>();
-}()))
-), JaktInternal::ExplicitValue<void>();
-};/*case end*/
-case 15: {
-auto&& __jakt_match_value = __jakt_match_variant.template get<typename types::ValueImpl::CInt>();
-int const& x = __jakt_match_value.value;
-return (JAKT_RESOLVE_EXPLICIT_VALUE_OR_CONTROL_FLOW_RETURN_ONLY(([&]() -> JaktInternal::ExplicitValueOrControlFlow<void,ErrorOr<interpreter::StatementResult>>{
-auto __jakt_enum_value = (prelude_function);
-if (__jakt_enum_value == String("println")) {
-return (outln(format_string,x)), JaktInternal::ExplicitValue<void>();
-}
-else if (__jakt_enum_value == String("eprintln")) {
-return (warnln(format_string,x)), JaktInternal::ExplicitValue<void>();
-}
-else if (__jakt_enum_value == String("print")) {
-return (out(format_string,x)), JaktInternal::ExplicitValue<void>();
-}
-else {
-return (warn(format_string,x)), JaktInternal::ExplicitValue<void>();
-}
-return JaktInternal::ExplicitValue<void>();
-}()))
-), JaktInternal::ExplicitValue<void>();
-};/*case end*/
-default: {
-{
-TRY((((*this).error(TRY((String::formatted(String("comptime format can only format primitves, got {}"),((((arguments)[static_cast<i64>(1LL)])).impl)))),call_span))));
-return Error::from_errno((infallible_integer_cast<i32>((InterpretError::InvalidType))));
-}
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
-}/*switch end*/
-}()
-))), JaktInternal::ExplicitValue<void>();
-}
-else {
-{
-TRY((((*this).error(TRY((String::formatted(String("comptime format accepts at most two arguments, but got {}"),((arguments).size())))),call_span))));
-return Error::from_errno((infallible_integer_cast<i32>((InterpretError::InvalidType))));
-}
-return JaktInternal::ExplicitValue<void>();
-}
-return JaktInternal::ExplicitValue<void>();
-}()))
-;
-__jakt_var_126 =  interpreter::StatementResult { typename interpreter::StatementResult::JustValue(types::Value(TRY((types::ValueImpl::template create<typename types::ValueImpl::Void>())),call_span)) } ; goto __jakt_label_124;
+))),call_span)) } ; goto __jakt_label_124;
 
 }
 __jakt_label_124:; __jakt_var_126.release_value(); }));
 }
-else if (__jakt_enum_value == String("as_saturated")) {
+else if (__jakt_enum_value == String("println")) {
 return JaktInternal::ExplicitValue(({ Optional<interpreter::StatementResult> __jakt_var_127; {
-NonnullRefPtr<types::CheckedFunction> const function_ = ((((*this).program))->get_function((TRY((((((*this).program))->find_function_in_scope(((((*this).program))->prelude_scope_id()),String("as_saturated"))))).value())));
-JaktInternal::Optional<types::TypeId> const output_type_id = ((type_bindings).get(TRY((((((((((((function_)->generics))->params))[static_cast<i64>(0LL)])).type_id())).to_string())))));
-__jakt_var_127 =  interpreter::StatementResult { typename interpreter::StatementResult::JustValue(TRY((interpreter::cast_value_to_type(((arguments)[static_cast<i64>(0LL)]),(output_type_id.value()),*this,true)))) } ; goto __jakt_label_125;
+String const format_string = JAKT_RESOLVE_EXPLICIT_VALUE_OR_CONTROL_FLOW_RETURN_ONLY(([&]() -> JaktInternal::ExplicitValueOrControlFlow<String, ErrorOr<interpreter::StatementResult>>{
+auto&& __jakt_match_variant = *((((arguments)[static_cast<i64>(0LL)])).impl);
+switch(__jakt_match_variant.index()) {
+case 13: {
+auto&& __jakt_match_value = __jakt_match_variant.template get<typename types::ValueImpl::JaktString>();
+String const& x = __jakt_match_value.value;
+return JaktInternal::ExplicitValue(x);
+};/*case end*/
+default: {
+{
+TRY((((*this).error(TRY((String::formatted(String("println expects a string as its first argument, but got {}"),((((arguments)[static_cast<i64>(0LL)])).impl)))),call_span))));
+return Error::from_errno((infallible_integer_cast<i32>((InterpretError::InvalidType))));
+}
+};/*case end*/
+}/*switch end*/
+}()
+));
+JAKT_RESOLVE_EXPLICIT_VALUE_OR_CONTROL_FLOW_RETURN_ONLY(([&]() -> JaktInternal::ExplicitValueOrControlFlow<void,ErrorOr<interpreter::StatementResult>>{
+auto __jakt_enum_value = (((arguments).size()));
+if (__jakt_enum_value == static_cast<size_t>(1ULL)) {
+return (JAKT_RESOLVE_EXPLICIT_VALUE_OR_CONTROL_FLOW_RETURN_ONLY(([&]() -> JaktInternal::ExplicitValueOrControlFlow<void,ErrorOr<interpreter::StatementResult>>{
+auto __jakt_enum_value = (prelude_function);
+if (__jakt_enum_value == String("println")) {
+return (outln(format_string)), JaktInternal::ExplicitValue<void>();
+}
+else if (__jakt_enum_value == String("eprintln")) {
+return (warnln(format_string)), JaktInternal::ExplicitValue<void>();
+}
+else if (__jakt_enum_value == String("print")) {
+return (out(format_string)), JaktInternal::ExplicitValue<void>();
+}
+else {
+return (warn(format_string)), JaktInternal::ExplicitValue<void>();
+}
+return JaktInternal::ExplicitValue<void>();
+}()))
+), JaktInternal::ExplicitValue<void>();
+}
+else if (__jakt_enum_value == static_cast<size_t>(2ULL)) {
+return (JAKT_RESOLVE_EXPLICIT_VALUE_OR_CONTROL_FLOW_RETURN_ONLY(([&]() -> JaktInternal::ExplicitValueOrControlFlow<void, ErrorOr<interpreter::StatementResult>>{
+auto&& __jakt_match_variant = *((((arguments)[static_cast<i64>(1LL)])).impl);
+switch(__jakt_match_variant.index()) {
+case 1: {
+auto&& __jakt_match_value = __jakt_match_variant.template get<typename types::ValueImpl::Bool>();
+bool const& x = __jakt_match_value.value;
+return (JAKT_RESOLVE_EXPLICIT_VALUE_OR_CONTROL_FLOW_RETURN_ONLY(([&]() -> JaktInternal::ExplicitValueOrControlFlow<void,ErrorOr<interpreter::StatementResult>>{
+auto __jakt_enum_value = (prelude_function);
+if (__jakt_enum_value == String("println")) {
+return (outln(format_string,x)), JaktInternal::ExplicitValue<void>();
+}
+else if (__jakt_enum_value == String("eprintln")) {
+return (warnln(format_string,x)), JaktInternal::ExplicitValue<void>();
+}
+else if (__jakt_enum_value == String("print")) {
+return (out(format_string,x)), JaktInternal::ExplicitValue<void>();
+}
+else {
+return (warn(format_string,x)), JaktInternal::ExplicitValue<void>();
+}
+return JaktInternal::ExplicitValue<void>();
+}()))
+), JaktInternal::ExplicitValue<void>();
+};/*case end*/
+case 2: {
+auto&& __jakt_match_value = __jakt_match_variant.template get<typename types::ValueImpl::U8>();
+u8 const& x = __jakt_match_value.value;
+return (JAKT_RESOLVE_EXPLICIT_VALUE_OR_CONTROL_FLOW_RETURN_ONLY(([&]() -> JaktInternal::ExplicitValueOrControlFlow<void,ErrorOr<interpreter::StatementResult>>{
+auto __jakt_enum_value = (prelude_function);
+if (__jakt_enum_value == String("println")) {
+return (outln(format_string,x)), JaktInternal::ExplicitValue<void>();
+}
+else if (__jakt_enum_value == String("eprintln")) {
+return (warnln(format_string,x)), JaktInternal::ExplicitValue<void>();
+}
+else if (__jakt_enum_value == String("print")) {
+return (out(format_string,x)), JaktInternal::ExplicitValue<void>();
+}
+else {
+return (warn(format_string,x)), JaktInternal::ExplicitValue<void>();
+}
+return JaktInternal::ExplicitValue<void>();
+}()))
+), JaktInternal::ExplicitValue<void>();
+};/*case end*/
+case 3: {
+auto&& __jakt_match_value = __jakt_match_variant.template get<typename types::ValueImpl::U16>();
+u16 const& x = __jakt_match_value.value;
+return (JAKT_RESOLVE_EXPLICIT_VALUE_OR_CONTROL_FLOW_RETURN_ONLY(([&]() -> JaktInternal::ExplicitValueOrControlFlow<void,ErrorOr<interpreter::StatementResult>>{
+auto __jakt_enum_value = (prelude_function);
+if (__jakt_enum_value == String("println")) {
+return (outln(format_string,x)), JaktInternal::ExplicitValue<void>();
+}
+else if (__jakt_enum_value == String("eprintln")) {
+return (warnln(format_string,x)), JaktInternal::ExplicitValue<void>();
+}
+else if (__jakt_enum_value == String("print")) {
+return (out(format_string,x)), JaktInternal::ExplicitValue<void>();
+}
+else {
+return (warn(format_string,x)), JaktInternal::ExplicitValue<void>();
+}
+return JaktInternal::ExplicitValue<void>();
+}()))
+), JaktInternal::ExplicitValue<void>();
+};/*case end*/
+case 4: {
+auto&& __jakt_match_value = __jakt_match_variant.template get<typename types::ValueImpl::U32>();
+u32 const& x = __jakt_match_value.value;
+return (JAKT_RESOLVE_EXPLICIT_VALUE_OR_CONTROL_FLOW_RETURN_ONLY(([&]() -> JaktInternal::ExplicitValueOrControlFlow<void,ErrorOr<interpreter::StatementResult>>{
+auto __jakt_enum_value = (prelude_function);
+if (__jakt_enum_value == String("println")) {
+return (outln(format_string,x)), JaktInternal::ExplicitValue<void>();
+}
+else if (__jakt_enum_value == String("eprintln")) {
+return (warnln(format_string,x)), JaktInternal::ExplicitValue<void>();
+}
+else if (__jakt_enum_value == String("print")) {
+return (out(format_string,x)), JaktInternal::ExplicitValue<void>();
+}
+else {
+return (warn(format_string,x)), JaktInternal::ExplicitValue<void>();
+}
+return JaktInternal::ExplicitValue<void>();
+}()))
+), JaktInternal::ExplicitValue<void>();
+};/*case end*/
+case 5: {
+auto&& __jakt_match_value = __jakt_match_variant.template get<typename types::ValueImpl::U64>();
+u64 const& x = __jakt_match_value.value;
+return (JAKT_RESOLVE_EXPLICIT_VALUE_OR_CONTROL_FLOW_RETURN_ONLY(([&]() -> JaktInternal::ExplicitValueOrControlFlow<void,ErrorOr<interpreter::StatementResult>>{
+auto __jakt_enum_value = (prelude_function);
+if (__jakt_enum_value == String("println")) {
+return (outln(format_string,x)), JaktInternal::ExplicitValue<void>();
+}
+else if (__jakt_enum_value == String("eprintln")) {
+return (warnln(format_string,x)), JaktInternal::ExplicitValue<void>();
+}
+else if (__jakt_enum_value == String("print")) {
+return (out(format_string,x)), JaktInternal::ExplicitValue<void>();
+}
+else {
+return (warn(format_string,x)), JaktInternal::ExplicitValue<void>();
+}
+return JaktInternal::ExplicitValue<void>();
+}()))
+), JaktInternal::ExplicitValue<void>();
+};/*case end*/
+case 6: {
+auto&& __jakt_match_value = __jakt_match_variant.template get<typename types::ValueImpl::I8>();
+i8 const& x = __jakt_match_value.value;
+return (JAKT_RESOLVE_EXPLICIT_VALUE_OR_CONTROL_FLOW_RETURN_ONLY(([&]() -> JaktInternal::ExplicitValueOrControlFlow<void,ErrorOr<interpreter::StatementResult>>{
+auto __jakt_enum_value = (prelude_function);
+if (__jakt_enum_value == String("println")) {
+return (outln(format_string,x)), JaktInternal::ExplicitValue<void>();
+}
+else if (__jakt_enum_value == String("eprintln")) {
+return (warnln(format_string,x)), JaktInternal::ExplicitValue<void>();
+}
+else if (__jakt_enum_value == String("print")) {
+return (out(format_string,x)), JaktInternal::ExplicitValue<void>();
+}
+else {
+return (warn(format_string,x)), JaktInternal::ExplicitValue<void>();
+}
+return JaktInternal::ExplicitValue<void>();
+}()))
+), JaktInternal::ExplicitValue<void>();
+};/*case end*/
+case 7: {
+auto&& __jakt_match_value = __jakt_match_variant.template get<typename types::ValueImpl::I16>();
+i16 const& x = __jakt_match_value.value;
+return (JAKT_RESOLVE_EXPLICIT_VALUE_OR_CONTROL_FLOW_RETURN_ONLY(([&]() -> JaktInternal::ExplicitValueOrControlFlow<void,ErrorOr<interpreter::StatementResult>>{
+auto __jakt_enum_value = (prelude_function);
+if (__jakt_enum_value == String("println")) {
+return (outln(format_string,x)), JaktInternal::ExplicitValue<void>();
+}
+else if (__jakt_enum_value == String("eprintln")) {
+return (warnln(format_string,x)), JaktInternal::ExplicitValue<void>();
+}
+else if (__jakt_enum_value == String("print")) {
+return (out(format_string,x)), JaktInternal::ExplicitValue<void>();
+}
+else {
+return (warn(format_string,x)), JaktInternal::ExplicitValue<void>();
+}
+return JaktInternal::ExplicitValue<void>();
+}()))
+), JaktInternal::ExplicitValue<void>();
+};/*case end*/
+case 8: {
+auto&& __jakt_match_value = __jakt_match_variant.template get<typename types::ValueImpl::I32>();
+i32 const& x = __jakt_match_value.value;
+return (JAKT_RESOLVE_EXPLICIT_VALUE_OR_CONTROL_FLOW_RETURN_ONLY(([&]() -> JaktInternal::ExplicitValueOrControlFlow<void,ErrorOr<interpreter::StatementResult>>{
+auto __jakt_enum_value = (prelude_function);
+if (__jakt_enum_value == String("println")) {
+return (outln(format_string,x)), JaktInternal::ExplicitValue<void>();
+}
+else if (__jakt_enum_value == String("eprintln")) {
+return (warnln(format_string,x)), JaktInternal::ExplicitValue<void>();
+}
+else if (__jakt_enum_value == String("print")) {
+return (out(format_string,x)), JaktInternal::ExplicitValue<void>();
+}
+else {
+return (warn(format_string,x)), JaktInternal::ExplicitValue<void>();
+}
+return JaktInternal::ExplicitValue<void>();
+}()))
+), JaktInternal::ExplicitValue<void>();
+};/*case end*/
+case 9: {
+auto&& __jakt_match_value = __jakt_match_variant.template get<typename types::ValueImpl::I64>();
+i64 const& x = __jakt_match_value.value;
+return (JAKT_RESOLVE_EXPLICIT_VALUE_OR_CONTROL_FLOW_RETURN_ONLY(([&]() -> JaktInternal::ExplicitValueOrControlFlow<void,ErrorOr<interpreter::StatementResult>>{
+auto __jakt_enum_value = (prelude_function);
+if (__jakt_enum_value == String("println")) {
+return (outln(format_string,x)), JaktInternal::ExplicitValue<void>();
+}
+else if (__jakt_enum_value == String("eprintln")) {
+return (warnln(format_string,x)), JaktInternal::ExplicitValue<void>();
+}
+else if (__jakt_enum_value == String("print")) {
+return (out(format_string,x)), JaktInternal::ExplicitValue<void>();
+}
+else {
+return (warn(format_string,x)), JaktInternal::ExplicitValue<void>();
+}
+return JaktInternal::ExplicitValue<void>();
+}()))
+), JaktInternal::ExplicitValue<void>();
+};/*case end*/
+case 10: {
+auto&& __jakt_match_value = __jakt_match_variant.template get<typename types::ValueImpl::F32>();
+f32 const& x = __jakt_match_value.value;
+return (JAKT_RESOLVE_EXPLICIT_VALUE_OR_CONTROL_FLOW_RETURN_ONLY(([&]() -> JaktInternal::ExplicitValueOrControlFlow<void,ErrorOr<interpreter::StatementResult>>{
+auto __jakt_enum_value = (prelude_function);
+if (__jakt_enum_value == String("println")) {
+return (outln(format_string,x)), JaktInternal::ExplicitValue<void>();
+}
+else if (__jakt_enum_value == String("eprintln")) {
+return (warnln(format_string,x)), JaktInternal::ExplicitValue<void>();
+}
+else if (__jakt_enum_value == String("print")) {
+return (out(format_string,x)), JaktInternal::ExplicitValue<void>();
+}
+else {
+return (warn(format_string,x)), JaktInternal::ExplicitValue<void>();
+}
+return JaktInternal::ExplicitValue<void>();
+}()))
+), JaktInternal::ExplicitValue<void>();
+};/*case end*/
+case 11: {
+auto&& __jakt_match_value = __jakt_match_variant.template get<typename types::ValueImpl::F64>();
+f64 const& x = __jakt_match_value.value;
+return (JAKT_RESOLVE_EXPLICIT_VALUE_OR_CONTROL_FLOW_RETURN_ONLY(([&]() -> JaktInternal::ExplicitValueOrControlFlow<void,ErrorOr<interpreter::StatementResult>>{
+auto __jakt_enum_value = (prelude_function);
+if (__jakt_enum_value == String("println")) {
+return (outln(format_string,x)), JaktInternal::ExplicitValue<void>();
+}
+else if (__jakt_enum_value == String("eprintln")) {
+return (warnln(format_string,x)), JaktInternal::ExplicitValue<void>();
+}
+else if (__jakt_enum_value == String("print")) {
+return (out(format_string,x)), JaktInternal::ExplicitValue<void>();
+}
+else {
+return (warn(format_string,x)), JaktInternal::ExplicitValue<void>();
+}
+return JaktInternal::ExplicitValue<void>();
+}()))
+), JaktInternal::ExplicitValue<void>();
+};/*case end*/
+case 12: {
+auto&& __jakt_match_value = __jakt_match_variant.template get<typename types::ValueImpl::USize>();
+size_t const& x = __jakt_match_value.value;
+return (JAKT_RESOLVE_EXPLICIT_VALUE_OR_CONTROL_FLOW_RETURN_ONLY(([&]() -> JaktInternal::ExplicitValueOrControlFlow<void,ErrorOr<interpreter::StatementResult>>{
+auto __jakt_enum_value = (prelude_function);
+if (__jakt_enum_value == String("println")) {
+return (outln(format_string,x)), JaktInternal::ExplicitValue<void>();
+}
+else if (__jakt_enum_value == String("eprintln")) {
+return (warnln(format_string,x)), JaktInternal::ExplicitValue<void>();
+}
+else if (__jakt_enum_value == String("print")) {
+return (out(format_string,x)), JaktInternal::ExplicitValue<void>();
+}
+else {
+return (warn(format_string,x)), JaktInternal::ExplicitValue<void>();
+}
+return JaktInternal::ExplicitValue<void>();
+}()))
+), JaktInternal::ExplicitValue<void>();
+};/*case end*/
+case 13: {
+auto&& __jakt_match_value = __jakt_match_variant.template get<typename types::ValueImpl::JaktString>();
+String const& x = __jakt_match_value.value;
+return (JAKT_RESOLVE_EXPLICIT_VALUE_OR_CONTROL_FLOW_RETURN_ONLY(([&]() -> JaktInternal::ExplicitValueOrControlFlow<void,ErrorOr<interpreter::StatementResult>>{
+auto __jakt_enum_value = (prelude_function);
+if (__jakt_enum_value == String("println")) {
+return (outln(format_string,x)), JaktInternal::ExplicitValue<void>();
+}
+else if (__jakt_enum_value == String("eprintln")) {
+return (warnln(format_string,x)), JaktInternal::ExplicitValue<void>();
+}
+else if (__jakt_enum_value == String("print")) {
+return (out(format_string,x)), JaktInternal::ExplicitValue<void>();
+}
+else {
+return (warn(format_string,x)), JaktInternal::ExplicitValue<void>();
+}
+return JaktInternal::ExplicitValue<void>();
+}()))
+), JaktInternal::ExplicitValue<void>();
+};/*case end*/
+case 14: {
+auto&& __jakt_match_value = __jakt_match_variant.template get<typename types::ValueImpl::CChar>();
+char const& x = __jakt_match_value.value;
+return (JAKT_RESOLVE_EXPLICIT_VALUE_OR_CONTROL_FLOW_RETURN_ONLY(([&]() -> JaktInternal::ExplicitValueOrControlFlow<void,ErrorOr<interpreter::StatementResult>>{
+auto __jakt_enum_value = (prelude_function);
+if (__jakt_enum_value == String("println")) {
+return (outln(format_string,x)), JaktInternal::ExplicitValue<void>();
+}
+else if (__jakt_enum_value == String("eprintln")) {
+return (warnln(format_string,x)), JaktInternal::ExplicitValue<void>();
+}
+else if (__jakt_enum_value == String("print")) {
+return (out(format_string,x)), JaktInternal::ExplicitValue<void>();
+}
+else {
+return (warn(format_string,x)), JaktInternal::ExplicitValue<void>();
+}
+return JaktInternal::ExplicitValue<void>();
+}()))
+), JaktInternal::ExplicitValue<void>();
+};/*case end*/
+case 15: {
+auto&& __jakt_match_value = __jakt_match_variant.template get<typename types::ValueImpl::CInt>();
+int const& x = __jakt_match_value.value;
+return (JAKT_RESOLVE_EXPLICIT_VALUE_OR_CONTROL_FLOW_RETURN_ONLY(([&]() -> JaktInternal::ExplicitValueOrControlFlow<void,ErrorOr<interpreter::StatementResult>>{
+auto __jakt_enum_value = (prelude_function);
+if (__jakt_enum_value == String("println")) {
+return (outln(format_string,x)), JaktInternal::ExplicitValue<void>();
+}
+else if (__jakt_enum_value == String("eprintln")) {
+return (warnln(format_string,x)), JaktInternal::ExplicitValue<void>();
+}
+else if (__jakt_enum_value == String("print")) {
+return (out(format_string,x)), JaktInternal::ExplicitValue<void>();
+}
+else {
+return (warn(format_string,x)), JaktInternal::ExplicitValue<void>();
+}
+return JaktInternal::ExplicitValue<void>();
+}()))
+), JaktInternal::ExplicitValue<void>();
+};/*case end*/
+default: {
+{
+TRY((((*this).error(TRY((String::formatted(String("comptime format can only format primitves, got {}"),((((arguments)[static_cast<i64>(1LL)])).impl)))),call_span))));
+return Error::from_errno((infallible_integer_cast<i32>((InterpretError::InvalidType))));
+}
+return JaktInternal::ExplicitValue<void>();
+};/*case end*/
+}/*switch end*/
+}()
+))), JaktInternal::ExplicitValue<void>();
+}
+else {
+{
+TRY((((*this).error(TRY((String::formatted(String("comptime format accepts at most two arguments, but got {}"),((arguments).size())))),call_span))));
+return Error::from_errno((infallible_integer_cast<i32>((InterpretError::InvalidType))));
+}
+return JaktInternal::ExplicitValue<void>();
+}
+return JaktInternal::ExplicitValue<void>();
+}()))
+;
+__jakt_var_127 =  interpreter::StatementResult { typename interpreter::StatementResult::JustValue(types::Value(TRY((types::ValueImpl::template create<typename types::ValueImpl::Void>())),call_span)) } ; goto __jakt_label_125;
 
 }
 __jakt_label_125:; __jakt_var_127.release_value(); }));
 }
-else if (__jakt_enum_value == String("unchecked_mul")) {
+else if (__jakt_enum_value == String("eprintln")) {
 return JaktInternal::ExplicitValue(({ Optional<interpreter::StatementResult> __jakt_var_128; {
+String const format_string = JAKT_RESOLVE_EXPLICIT_VALUE_OR_CONTROL_FLOW_RETURN_ONLY(([&]() -> JaktInternal::ExplicitValueOrControlFlow<String, ErrorOr<interpreter::StatementResult>>{
+auto&& __jakt_match_variant = *((((arguments)[static_cast<i64>(0LL)])).impl);
+switch(__jakt_match_variant.index()) {
+case 13: {
+auto&& __jakt_match_value = __jakt_match_variant.template get<typename types::ValueImpl::JaktString>();
+String const& x = __jakt_match_value.value;
+return JaktInternal::ExplicitValue(x);
+};/*case end*/
+default: {
+{
+TRY((((*this).error(TRY((String::formatted(String("println expects a string as its first argument, but got {}"),((((arguments)[static_cast<i64>(0LL)])).impl)))),call_span))));
+return Error::from_errno((infallible_integer_cast<i32>((InterpretError::InvalidType))));
+}
+};/*case end*/
+}/*switch end*/
+}()
+));
+JAKT_RESOLVE_EXPLICIT_VALUE_OR_CONTROL_FLOW_RETURN_ONLY(([&]() -> JaktInternal::ExplicitValueOrControlFlow<void,ErrorOr<interpreter::StatementResult>>{
+auto __jakt_enum_value = (((arguments).size()));
+if (__jakt_enum_value == static_cast<size_t>(1ULL)) {
+return (JAKT_RESOLVE_EXPLICIT_VALUE_OR_CONTROL_FLOW_RETURN_ONLY(([&]() -> JaktInternal::ExplicitValueOrControlFlow<void,ErrorOr<interpreter::StatementResult>>{
+auto __jakt_enum_value = (prelude_function);
+if (__jakt_enum_value == String("println")) {
+return (outln(format_string)), JaktInternal::ExplicitValue<void>();
+}
+else if (__jakt_enum_value == String("eprintln")) {
+return (warnln(format_string)), JaktInternal::ExplicitValue<void>();
+}
+else if (__jakt_enum_value == String("print")) {
+return (out(format_string)), JaktInternal::ExplicitValue<void>();
+}
+else {
+return (warn(format_string)), JaktInternal::ExplicitValue<void>();
+}
+return JaktInternal::ExplicitValue<void>();
+}()))
+), JaktInternal::ExplicitValue<void>();
+}
+else if (__jakt_enum_value == static_cast<size_t>(2ULL)) {
+return (JAKT_RESOLVE_EXPLICIT_VALUE_OR_CONTROL_FLOW_RETURN_ONLY(([&]() -> JaktInternal::ExplicitValueOrControlFlow<void, ErrorOr<interpreter::StatementResult>>{
+auto&& __jakt_match_variant = *((((arguments)[static_cast<i64>(1LL)])).impl);
+switch(__jakt_match_variant.index()) {
+case 1: {
+auto&& __jakt_match_value = __jakt_match_variant.template get<typename types::ValueImpl::Bool>();
+bool const& x = __jakt_match_value.value;
+return (JAKT_RESOLVE_EXPLICIT_VALUE_OR_CONTROL_FLOW_RETURN_ONLY(([&]() -> JaktInternal::ExplicitValueOrControlFlow<void,ErrorOr<interpreter::StatementResult>>{
+auto __jakt_enum_value = (prelude_function);
+if (__jakt_enum_value == String("println")) {
+return (outln(format_string,x)), JaktInternal::ExplicitValue<void>();
+}
+else if (__jakt_enum_value == String("eprintln")) {
+return (warnln(format_string,x)), JaktInternal::ExplicitValue<void>();
+}
+else if (__jakt_enum_value == String("print")) {
+return (out(format_string,x)), JaktInternal::ExplicitValue<void>();
+}
+else {
+return (warn(format_string,x)), JaktInternal::ExplicitValue<void>();
+}
+return JaktInternal::ExplicitValue<void>();
+}()))
+), JaktInternal::ExplicitValue<void>();
+};/*case end*/
+case 2: {
+auto&& __jakt_match_value = __jakt_match_variant.template get<typename types::ValueImpl::U8>();
+u8 const& x = __jakt_match_value.value;
+return (JAKT_RESOLVE_EXPLICIT_VALUE_OR_CONTROL_FLOW_RETURN_ONLY(([&]() -> JaktInternal::ExplicitValueOrControlFlow<void,ErrorOr<interpreter::StatementResult>>{
+auto __jakt_enum_value = (prelude_function);
+if (__jakt_enum_value == String("println")) {
+return (outln(format_string,x)), JaktInternal::ExplicitValue<void>();
+}
+else if (__jakt_enum_value == String("eprintln")) {
+return (warnln(format_string,x)), JaktInternal::ExplicitValue<void>();
+}
+else if (__jakt_enum_value == String("print")) {
+return (out(format_string,x)), JaktInternal::ExplicitValue<void>();
+}
+else {
+return (warn(format_string,x)), JaktInternal::ExplicitValue<void>();
+}
+return JaktInternal::ExplicitValue<void>();
+}()))
+), JaktInternal::ExplicitValue<void>();
+};/*case end*/
+case 3: {
+auto&& __jakt_match_value = __jakt_match_variant.template get<typename types::ValueImpl::U16>();
+u16 const& x = __jakt_match_value.value;
+return (JAKT_RESOLVE_EXPLICIT_VALUE_OR_CONTROL_FLOW_RETURN_ONLY(([&]() -> JaktInternal::ExplicitValueOrControlFlow<void,ErrorOr<interpreter::StatementResult>>{
+auto __jakt_enum_value = (prelude_function);
+if (__jakt_enum_value == String("println")) {
+return (outln(format_string,x)), JaktInternal::ExplicitValue<void>();
+}
+else if (__jakt_enum_value == String("eprintln")) {
+return (warnln(format_string,x)), JaktInternal::ExplicitValue<void>();
+}
+else if (__jakt_enum_value == String("print")) {
+return (out(format_string,x)), JaktInternal::ExplicitValue<void>();
+}
+else {
+return (warn(format_string,x)), JaktInternal::ExplicitValue<void>();
+}
+return JaktInternal::ExplicitValue<void>();
+}()))
+), JaktInternal::ExplicitValue<void>();
+};/*case end*/
+case 4: {
+auto&& __jakt_match_value = __jakt_match_variant.template get<typename types::ValueImpl::U32>();
+u32 const& x = __jakt_match_value.value;
+return (JAKT_RESOLVE_EXPLICIT_VALUE_OR_CONTROL_FLOW_RETURN_ONLY(([&]() -> JaktInternal::ExplicitValueOrControlFlow<void,ErrorOr<interpreter::StatementResult>>{
+auto __jakt_enum_value = (prelude_function);
+if (__jakt_enum_value == String("println")) {
+return (outln(format_string,x)), JaktInternal::ExplicitValue<void>();
+}
+else if (__jakt_enum_value == String("eprintln")) {
+return (warnln(format_string,x)), JaktInternal::ExplicitValue<void>();
+}
+else if (__jakt_enum_value == String("print")) {
+return (out(format_string,x)), JaktInternal::ExplicitValue<void>();
+}
+else {
+return (warn(format_string,x)), JaktInternal::ExplicitValue<void>();
+}
+return JaktInternal::ExplicitValue<void>();
+}()))
+), JaktInternal::ExplicitValue<void>();
+};/*case end*/
+case 5: {
+auto&& __jakt_match_value = __jakt_match_variant.template get<typename types::ValueImpl::U64>();
+u64 const& x = __jakt_match_value.value;
+return (JAKT_RESOLVE_EXPLICIT_VALUE_OR_CONTROL_FLOW_RETURN_ONLY(([&]() -> JaktInternal::ExplicitValueOrControlFlow<void,ErrorOr<interpreter::StatementResult>>{
+auto __jakt_enum_value = (prelude_function);
+if (__jakt_enum_value == String("println")) {
+return (outln(format_string,x)), JaktInternal::ExplicitValue<void>();
+}
+else if (__jakt_enum_value == String("eprintln")) {
+return (warnln(format_string,x)), JaktInternal::ExplicitValue<void>();
+}
+else if (__jakt_enum_value == String("print")) {
+return (out(format_string,x)), JaktInternal::ExplicitValue<void>();
+}
+else {
+return (warn(format_string,x)), JaktInternal::ExplicitValue<void>();
+}
+return JaktInternal::ExplicitValue<void>();
+}()))
+), JaktInternal::ExplicitValue<void>();
+};/*case end*/
+case 6: {
+auto&& __jakt_match_value = __jakt_match_variant.template get<typename types::ValueImpl::I8>();
+i8 const& x = __jakt_match_value.value;
+return (JAKT_RESOLVE_EXPLICIT_VALUE_OR_CONTROL_FLOW_RETURN_ONLY(([&]() -> JaktInternal::ExplicitValueOrControlFlow<void,ErrorOr<interpreter::StatementResult>>{
+auto __jakt_enum_value = (prelude_function);
+if (__jakt_enum_value == String("println")) {
+return (outln(format_string,x)), JaktInternal::ExplicitValue<void>();
+}
+else if (__jakt_enum_value == String("eprintln")) {
+return (warnln(format_string,x)), JaktInternal::ExplicitValue<void>();
+}
+else if (__jakt_enum_value == String("print")) {
+return (out(format_string,x)), JaktInternal::ExplicitValue<void>();
+}
+else {
+return (warn(format_string,x)), JaktInternal::ExplicitValue<void>();
+}
+return JaktInternal::ExplicitValue<void>();
+}()))
+), JaktInternal::ExplicitValue<void>();
+};/*case end*/
+case 7: {
+auto&& __jakt_match_value = __jakt_match_variant.template get<typename types::ValueImpl::I16>();
+i16 const& x = __jakt_match_value.value;
+return (JAKT_RESOLVE_EXPLICIT_VALUE_OR_CONTROL_FLOW_RETURN_ONLY(([&]() -> JaktInternal::ExplicitValueOrControlFlow<void,ErrorOr<interpreter::StatementResult>>{
+auto __jakt_enum_value = (prelude_function);
+if (__jakt_enum_value == String("println")) {
+return (outln(format_string,x)), JaktInternal::ExplicitValue<void>();
+}
+else if (__jakt_enum_value == String("eprintln")) {
+return (warnln(format_string,x)), JaktInternal::ExplicitValue<void>();
+}
+else if (__jakt_enum_value == String("print")) {
+return (out(format_string,x)), JaktInternal::ExplicitValue<void>();
+}
+else {
+return (warn(format_string,x)), JaktInternal::ExplicitValue<void>();
+}
+return JaktInternal::ExplicitValue<void>();
+}()))
+), JaktInternal::ExplicitValue<void>();
+};/*case end*/
+case 8: {
+auto&& __jakt_match_value = __jakt_match_variant.template get<typename types::ValueImpl::I32>();
+i32 const& x = __jakt_match_value.value;
+return (JAKT_RESOLVE_EXPLICIT_VALUE_OR_CONTROL_FLOW_RETURN_ONLY(([&]() -> JaktInternal::ExplicitValueOrControlFlow<void,ErrorOr<interpreter::StatementResult>>{
+auto __jakt_enum_value = (prelude_function);
+if (__jakt_enum_value == String("println")) {
+return (outln(format_string,x)), JaktInternal::ExplicitValue<void>();
+}
+else if (__jakt_enum_value == String("eprintln")) {
+return (warnln(format_string,x)), JaktInternal::ExplicitValue<void>();
+}
+else if (__jakt_enum_value == String("print")) {
+return (out(format_string,x)), JaktInternal::ExplicitValue<void>();
+}
+else {
+return (warn(format_string,x)), JaktInternal::ExplicitValue<void>();
+}
+return JaktInternal::ExplicitValue<void>();
+}()))
+), JaktInternal::ExplicitValue<void>();
+};/*case end*/
+case 9: {
+auto&& __jakt_match_value = __jakt_match_variant.template get<typename types::ValueImpl::I64>();
+i64 const& x = __jakt_match_value.value;
+return (JAKT_RESOLVE_EXPLICIT_VALUE_OR_CONTROL_FLOW_RETURN_ONLY(([&]() -> JaktInternal::ExplicitValueOrControlFlow<void,ErrorOr<interpreter::StatementResult>>{
+auto __jakt_enum_value = (prelude_function);
+if (__jakt_enum_value == String("println")) {
+return (outln(format_string,x)), JaktInternal::ExplicitValue<void>();
+}
+else if (__jakt_enum_value == String("eprintln")) {
+return (warnln(format_string,x)), JaktInternal::ExplicitValue<void>();
+}
+else if (__jakt_enum_value == String("print")) {
+return (out(format_string,x)), JaktInternal::ExplicitValue<void>();
+}
+else {
+return (warn(format_string,x)), JaktInternal::ExplicitValue<void>();
+}
+return JaktInternal::ExplicitValue<void>();
+}()))
+), JaktInternal::ExplicitValue<void>();
+};/*case end*/
+case 10: {
+auto&& __jakt_match_value = __jakt_match_variant.template get<typename types::ValueImpl::F32>();
+f32 const& x = __jakt_match_value.value;
+return (JAKT_RESOLVE_EXPLICIT_VALUE_OR_CONTROL_FLOW_RETURN_ONLY(([&]() -> JaktInternal::ExplicitValueOrControlFlow<void,ErrorOr<interpreter::StatementResult>>{
+auto __jakt_enum_value = (prelude_function);
+if (__jakt_enum_value == String("println")) {
+return (outln(format_string,x)), JaktInternal::ExplicitValue<void>();
+}
+else if (__jakt_enum_value == String("eprintln")) {
+return (warnln(format_string,x)), JaktInternal::ExplicitValue<void>();
+}
+else if (__jakt_enum_value == String("print")) {
+return (out(format_string,x)), JaktInternal::ExplicitValue<void>();
+}
+else {
+return (warn(format_string,x)), JaktInternal::ExplicitValue<void>();
+}
+return JaktInternal::ExplicitValue<void>();
+}()))
+), JaktInternal::ExplicitValue<void>();
+};/*case end*/
+case 11: {
+auto&& __jakt_match_value = __jakt_match_variant.template get<typename types::ValueImpl::F64>();
+f64 const& x = __jakt_match_value.value;
+return (JAKT_RESOLVE_EXPLICIT_VALUE_OR_CONTROL_FLOW_RETURN_ONLY(([&]() -> JaktInternal::ExplicitValueOrControlFlow<void,ErrorOr<interpreter::StatementResult>>{
+auto __jakt_enum_value = (prelude_function);
+if (__jakt_enum_value == String("println")) {
+return (outln(format_string,x)), JaktInternal::ExplicitValue<void>();
+}
+else if (__jakt_enum_value == String("eprintln")) {
+return (warnln(format_string,x)), JaktInternal::ExplicitValue<void>();
+}
+else if (__jakt_enum_value == String("print")) {
+return (out(format_string,x)), JaktInternal::ExplicitValue<void>();
+}
+else {
+return (warn(format_string,x)), JaktInternal::ExplicitValue<void>();
+}
+return JaktInternal::ExplicitValue<void>();
+}()))
+), JaktInternal::ExplicitValue<void>();
+};/*case end*/
+case 12: {
+auto&& __jakt_match_value = __jakt_match_variant.template get<typename types::ValueImpl::USize>();
+size_t const& x = __jakt_match_value.value;
+return (JAKT_RESOLVE_EXPLICIT_VALUE_OR_CONTROL_FLOW_RETURN_ONLY(([&]() -> JaktInternal::ExplicitValueOrControlFlow<void,ErrorOr<interpreter::StatementResult>>{
+auto __jakt_enum_value = (prelude_function);
+if (__jakt_enum_value == String("println")) {
+return (outln(format_string,x)), JaktInternal::ExplicitValue<void>();
+}
+else if (__jakt_enum_value == String("eprintln")) {
+return (warnln(format_string,x)), JaktInternal::ExplicitValue<void>();
+}
+else if (__jakt_enum_value == String("print")) {
+return (out(format_string,x)), JaktInternal::ExplicitValue<void>();
+}
+else {
+return (warn(format_string,x)), JaktInternal::ExplicitValue<void>();
+}
+return JaktInternal::ExplicitValue<void>();
+}()))
+), JaktInternal::ExplicitValue<void>();
+};/*case end*/
+case 13: {
+auto&& __jakt_match_value = __jakt_match_variant.template get<typename types::ValueImpl::JaktString>();
+String const& x = __jakt_match_value.value;
+return (JAKT_RESOLVE_EXPLICIT_VALUE_OR_CONTROL_FLOW_RETURN_ONLY(([&]() -> JaktInternal::ExplicitValueOrControlFlow<void,ErrorOr<interpreter::StatementResult>>{
+auto __jakt_enum_value = (prelude_function);
+if (__jakt_enum_value == String("println")) {
+return (outln(format_string,x)), JaktInternal::ExplicitValue<void>();
+}
+else if (__jakt_enum_value == String("eprintln")) {
+return (warnln(format_string,x)), JaktInternal::ExplicitValue<void>();
+}
+else if (__jakt_enum_value == String("print")) {
+return (out(format_string,x)), JaktInternal::ExplicitValue<void>();
+}
+else {
+return (warn(format_string,x)), JaktInternal::ExplicitValue<void>();
+}
+return JaktInternal::ExplicitValue<void>();
+}()))
+), JaktInternal::ExplicitValue<void>();
+};/*case end*/
+case 14: {
+auto&& __jakt_match_value = __jakt_match_variant.template get<typename types::ValueImpl::CChar>();
+char const& x = __jakt_match_value.value;
+return (JAKT_RESOLVE_EXPLICIT_VALUE_OR_CONTROL_FLOW_RETURN_ONLY(([&]() -> JaktInternal::ExplicitValueOrControlFlow<void,ErrorOr<interpreter::StatementResult>>{
+auto __jakt_enum_value = (prelude_function);
+if (__jakt_enum_value == String("println")) {
+return (outln(format_string,x)), JaktInternal::ExplicitValue<void>();
+}
+else if (__jakt_enum_value == String("eprintln")) {
+return (warnln(format_string,x)), JaktInternal::ExplicitValue<void>();
+}
+else if (__jakt_enum_value == String("print")) {
+return (out(format_string,x)), JaktInternal::ExplicitValue<void>();
+}
+else {
+return (warn(format_string,x)), JaktInternal::ExplicitValue<void>();
+}
+return JaktInternal::ExplicitValue<void>();
+}()))
+), JaktInternal::ExplicitValue<void>();
+};/*case end*/
+case 15: {
+auto&& __jakt_match_value = __jakt_match_variant.template get<typename types::ValueImpl::CInt>();
+int const& x = __jakt_match_value.value;
+return (JAKT_RESOLVE_EXPLICIT_VALUE_OR_CONTROL_FLOW_RETURN_ONLY(([&]() -> JaktInternal::ExplicitValueOrControlFlow<void,ErrorOr<interpreter::StatementResult>>{
+auto __jakt_enum_value = (prelude_function);
+if (__jakt_enum_value == String("println")) {
+return (outln(format_string,x)), JaktInternal::ExplicitValue<void>();
+}
+else if (__jakt_enum_value == String("eprintln")) {
+return (warnln(format_string,x)), JaktInternal::ExplicitValue<void>();
+}
+else if (__jakt_enum_value == String("print")) {
+return (out(format_string,x)), JaktInternal::ExplicitValue<void>();
+}
+else {
+return (warn(format_string,x)), JaktInternal::ExplicitValue<void>();
+}
+return JaktInternal::ExplicitValue<void>();
+}()))
+), JaktInternal::ExplicitValue<void>();
+};/*case end*/
+default: {
+{
+TRY((((*this).error(TRY((String::formatted(String("comptime format can only format primitves, got {}"),((((arguments)[static_cast<i64>(1LL)])).impl)))),call_span))));
+return Error::from_errno((infallible_integer_cast<i32>((InterpretError::InvalidType))));
+}
+return JaktInternal::ExplicitValue<void>();
+};/*case end*/
+}/*switch end*/
+}()
+))), JaktInternal::ExplicitValue<void>();
+}
+else {
+{
+TRY((((*this).error(TRY((String::formatted(String("comptime format accepts at most two arguments, but got {}"),((arguments).size())))),call_span))));
+return Error::from_errno((infallible_integer_cast<i32>((InterpretError::InvalidType))));
+}
+return JaktInternal::ExplicitValue<void>();
+}
+return JaktInternal::ExplicitValue<void>();
+}()))
+;
+__jakt_var_128 =  interpreter::StatementResult { typename interpreter::StatementResult::JustValue(types::Value(TRY((types::ValueImpl::template create<typename types::ValueImpl::Void>())),call_span)) } ; goto __jakt_label_126;
+
+}
+__jakt_label_126:; __jakt_var_128.release_value(); }));
+}
+else if (__jakt_enum_value == String("print")) {
+return JaktInternal::ExplicitValue(({ Optional<interpreter::StatementResult> __jakt_var_129; {
+String const format_string = JAKT_RESOLVE_EXPLICIT_VALUE_OR_CONTROL_FLOW_RETURN_ONLY(([&]() -> JaktInternal::ExplicitValueOrControlFlow<String, ErrorOr<interpreter::StatementResult>>{
+auto&& __jakt_match_variant = *((((arguments)[static_cast<i64>(0LL)])).impl);
+switch(__jakt_match_variant.index()) {
+case 13: {
+auto&& __jakt_match_value = __jakt_match_variant.template get<typename types::ValueImpl::JaktString>();
+String const& x = __jakt_match_value.value;
+return JaktInternal::ExplicitValue(x);
+};/*case end*/
+default: {
+{
+TRY((((*this).error(TRY((String::formatted(String("println expects a string as its first argument, but got {}"),((((arguments)[static_cast<i64>(0LL)])).impl)))),call_span))));
+return Error::from_errno((infallible_integer_cast<i32>((InterpretError::InvalidType))));
+}
+};/*case end*/
+}/*switch end*/
+}()
+));
+JAKT_RESOLVE_EXPLICIT_VALUE_OR_CONTROL_FLOW_RETURN_ONLY(([&]() -> JaktInternal::ExplicitValueOrControlFlow<void,ErrorOr<interpreter::StatementResult>>{
+auto __jakt_enum_value = (((arguments).size()));
+if (__jakt_enum_value == static_cast<size_t>(1ULL)) {
+return (JAKT_RESOLVE_EXPLICIT_VALUE_OR_CONTROL_FLOW_RETURN_ONLY(([&]() -> JaktInternal::ExplicitValueOrControlFlow<void,ErrorOr<interpreter::StatementResult>>{
+auto __jakt_enum_value = (prelude_function);
+if (__jakt_enum_value == String("println")) {
+return (outln(format_string)), JaktInternal::ExplicitValue<void>();
+}
+else if (__jakt_enum_value == String("eprintln")) {
+return (warnln(format_string)), JaktInternal::ExplicitValue<void>();
+}
+else if (__jakt_enum_value == String("print")) {
+return (out(format_string)), JaktInternal::ExplicitValue<void>();
+}
+else {
+return (warn(format_string)), JaktInternal::ExplicitValue<void>();
+}
+return JaktInternal::ExplicitValue<void>();
+}()))
+), JaktInternal::ExplicitValue<void>();
+}
+else if (__jakt_enum_value == static_cast<size_t>(2ULL)) {
+return (JAKT_RESOLVE_EXPLICIT_VALUE_OR_CONTROL_FLOW_RETURN_ONLY(([&]() -> JaktInternal::ExplicitValueOrControlFlow<void, ErrorOr<interpreter::StatementResult>>{
+auto&& __jakt_match_variant = *((((arguments)[static_cast<i64>(1LL)])).impl);
+switch(__jakt_match_variant.index()) {
+case 1: {
+auto&& __jakt_match_value = __jakt_match_variant.template get<typename types::ValueImpl::Bool>();
+bool const& x = __jakt_match_value.value;
+return (JAKT_RESOLVE_EXPLICIT_VALUE_OR_CONTROL_FLOW_RETURN_ONLY(([&]() -> JaktInternal::ExplicitValueOrControlFlow<void,ErrorOr<interpreter::StatementResult>>{
+auto __jakt_enum_value = (prelude_function);
+if (__jakt_enum_value == String("println")) {
+return (outln(format_string,x)), JaktInternal::ExplicitValue<void>();
+}
+else if (__jakt_enum_value == String("eprintln")) {
+return (warnln(format_string,x)), JaktInternal::ExplicitValue<void>();
+}
+else if (__jakt_enum_value == String("print")) {
+return (out(format_string,x)), JaktInternal::ExplicitValue<void>();
+}
+else {
+return (warn(format_string,x)), JaktInternal::ExplicitValue<void>();
+}
+return JaktInternal::ExplicitValue<void>();
+}()))
+), JaktInternal::ExplicitValue<void>();
+};/*case end*/
+case 2: {
+auto&& __jakt_match_value = __jakt_match_variant.template get<typename types::ValueImpl::U8>();
+u8 const& x = __jakt_match_value.value;
+return (JAKT_RESOLVE_EXPLICIT_VALUE_OR_CONTROL_FLOW_RETURN_ONLY(([&]() -> JaktInternal::ExplicitValueOrControlFlow<void,ErrorOr<interpreter::StatementResult>>{
+auto __jakt_enum_value = (prelude_function);
+if (__jakt_enum_value == String("println")) {
+return (outln(format_string,x)), JaktInternal::ExplicitValue<void>();
+}
+else if (__jakt_enum_value == String("eprintln")) {
+return (warnln(format_string,x)), JaktInternal::ExplicitValue<void>();
+}
+else if (__jakt_enum_value == String("print")) {
+return (out(format_string,x)), JaktInternal::ExplicitValue<void>();
+}
+else {
+return (warn(format_string,x)), JaktInternal::ExplicitValue<void>();
+}
+return JaktInternal::ExplicitValue<void>();
+}()))
+), JaktInternal::ExplicitValue<void>();
+};/*case end*/
+case 3: {
+auto&& __jakt_match_value = __jakt_match_variant.template get<typename types::ValueImpl::U16>();
+u16 const& x = __jakt_match_value.value;
+return (JAKT_RESOLVE_EXPLICIT_VALUE_OR_CONTROL_FLOW_RETURN_ONLY(([&]() -> JaktInternal::ExplicitValueOrControlFlow<void,ErrorOr<interpreter::StatementResult>>{
+auto __jakt_enum_value = (prelude_function);
+if (__jakt_enum_value == String("println")) {
+return (outln(format_string,x)), JaktInternal::ExplicitValue<void>();
+}
+else if (__jakt_enum_value == String("eprintln")) {
+return (warnln(format_string,x)), JaktInternal::ExplicitValue<void>();
+}
+else if (__jakt_enum_value == String("print")) {
+return (out(format_string,x)), JaktInternal::ExplicitValue<void>();
+}
+else {
+return (warn(format_string,x)), JaktInternal::ExplicitValue<void>();
+}
+return JaktInternal::ExplicitValue<void>();
+}()))
+), JaktInternal::ExplicitValue<void>();
+};/*case end*/
+case 4: {
+auto&& __jakt_match_value = __jakt_match_variant.template get<typename types::ValueImpl::U32>();
+u32 const& x = __jakt_match_value.value;
+return (JAKT_RESOLVE_EXPLICIT_VALUE_OR_CONTROL_FLOW_RETURN_ONLY(([&]() -> JaktInternal::ExplicitValueOrControlFlow<void,ErrorOr<interpreter::StatementResult>>{
+auto __jakt_enum_value = (prelude_function);
+if (__jakt_enum_value == String("println")) {
+return (outln(format_string,x)), JaktInternal::ExplicitValue<void>();
+}
+else if (__jakt_enum_value == String("eprintln")) {
+return (warnln(format_string,x)), JaktInternal::ExplicitValue<void>();
+}
+else if (__jakt_enum_value == String("print")) {
+return (out(format_string,x)), JaktInternal::ExplicitValue<void>();
+}
+else {
+return (warn(format_string,x)), JaktInternal::ExplicitValue<void>();
+}
+return JaktInternal::ExplicitValue<void>();
+}()))
+), JaktInternal::ExplicitValue<void>();
+};/*case end*/
+case 5: {
+auto&& __jakt_match_value = __jakt_match_variant.template get<typename types::ValueImpl::U64>();
+u64 const& x = __jakt_match_value.value;
+return (JAKT_RESOLVE_EXPLICIT_VALUE_OR_CONTROL_FLOW_RETURN_ONLY(([&]() -> JaktInternal::ExplicitValueOrControlFlow<void,ErrorOr<interpreter::StatementResult>>{
+auto __jakt_enum_value = (prelude_function);
+if (__jakt_enum_value == String("println")) {
+return (outln(format_string,x)), JaktInternal::ExplicitValue<void>();
+}
+else if (__jakt_enum_value == String("eprintln")) {
+return (warnln(format_string,x)), JaktInternal::ExplicitValue<void>();
+}
+else if (__jakt_enum_value == String("print")) {
+return (out(format_string,x)), JaktInternal::ExplicitValue<void>();
+}
+else {
+return (warn(format_string,x)), JaktInternal::ExplicitValue<void>();
+}
+return JaktInternal::ExplicitValue<void>();
+}()))
+), JaktInternal::ExplicitValue<void>();
+};/*case end*/
+case 6: {
+auto&& __jakt_match_value = __jakt_match_variant.template get<typename types::ValueImpl::I8>();
+i8 const& x = __jakt_match_value.value;
+return (JAKT_RESOLVE_EXPLICIT_VALUE_OR_CONTROL_FLOW_RETURN_ONLY(([&]() -> JaktInternal::ExplicitValueOrControlFlow<void,ErrorOr<interpreter::StatementResult>>{
+auto __jakt_enum_value = (prelude_function);
+if (__jakt_enum_value == String("println")) {
+return (outln(format_string,x)), JaktInternal::ExplicitValue<void>();
+}
+else if (__jakt_enum_value == String("eprintln")) {
+return (warnln(format_string,x)), JaktInternal::ExplicitValue<void>();
+}
+else if (__jakt_enum_value == String("print")) {
+return (out(format_string,x)), JaktInternal::ExplicitValue<void>();
+}
+else {
+return (warn(format_string,x)), JaktInternal::ExplicitValue<void>();
+}
+return JaktInternal::ExplicitValue<void>();
+}()))
+), JaktInternal::ExplicitValue<void>();
+};/*case end*/
+case 7: {
+auto&& __jakt_match_value = __jakt_match_variant.template get<typename types::ValueImpl::I16>();
+i16 const& x = __jakt_match_value.value;
+return (JAKT_RESOLVE_EXPLICIT_VALUE_OR_CONTROL_FLOW_RETURN_ONLY(([&]() -> JaktInternal::ExplicitValueOrControlFlow<void,ErrorOr<interpreter::StatementResult>>{
+auto __jakt_enum_value = (prelude_function);
+if (__jakt_enum_value == String("println")) {
+return (outln(format_string,x)), JaktInternal::ExplicitValue<void>();
+}
+else if (__jakt_enum_value == String("eprintln")) {
+return (warnln(format_string,x)), JaktInternal::ExplicitValue<void>();
+}
+else if (__jakt_enum_value == String("print")) {
+return (out(format_string,x)), JaktInternal::ExplicitValue<void>();
+}
+else {
+return (warn(format_string,x)), JaktInternal::ExplicitValue<void>();
+}
+return JaktInternal::ExplicitValue<void>();
+}()))
+), JaktInternal::ExplicitValue<void>();
+};/*case end*/
+case 8: {
+auto&& __jakt_match_value = __jakt_match_variant.template get<typename types::ValueImpl::I32>();
+i32 const& x = __jakt_match_value.value;
+return (JAKT_RESOLVE_EXPLICIT_VALUE_OR_CONTROL_FLOW_RETURN_ONLY(([&]() -> JaktInternal::ExplicitValueOrControlFlow<void,ErrorOr<interpreter::StatementResult>>{
+auto __jakt_enum_value = (prelude_function);
+if (__jakt_enum_value == String("println")) {
+return (outln(format_string,x)), JaktInternal::ExplicitValue<void>();
+}
+else if (__jakt_enum_value == String("eprintln")) {
+return (warnln(format_string,x)), JaktInternal::ExplicitValue<void>();
+}
+else if (__jakt_enum_value == String("print")) {
+return (out(format_string,x)), JaktInternal::ExplicitValue<void>();
+}
+else {
+return (warn(format_string,x)), JaktInternal::ExplicitValue<void>();
+}
+return JaktInternal::ExplicitValue<void>();
+}()))
+), JaktInternal::ExplicitValue<void>();
+};/*case end*/
+case 9: {
+auto&& __jakt_match_value = __jakt_match_variant.template get<typename types::ValueImpl::I64>();
+i64 const& x = __jakt_match_value.value;
+return (JAKT_RESOLVE_EXPLICIT_VALUE_OR_CONTROL_FLOW_RETURN_ONLY(([&]() -> JaktInternal::ExplicitValueOrControlFlow<void,ErrorOr<interpreter::StatementResult>>{
+auto __jakt_enum_value = (prelude_function);
+if (__jakt_enum_value == String("println")) {
+return (outln(format_string,x)), JaktInternal::ExplicitValue<void>();
+}
+else if (__jakt_enum_value == String("eprintln")) {
+return (warnln(format_string,x)), JaktInternal::ExplicitValue<void>();
+}
+else if (__jakt_enum_value == String("print")) {
+return (out(format_string,x)), JaktInternal::ExplicitValue<void>();
+}
+else {
+return (warn(format_string,x)), JaktInternal::ExplicitValue<void>();
+}
+return JaktInternal::ExplicitValue<void>();
+}()))
+), JaktInternal::ExplicitValue<void>();
+};/*case end*/
+case 10: {
+auto&& __jakt_match_value = __jakt_match_variant.template get<typename types::ValueImpl::F32>();
+f32 const& x = __jakt_match_value.value;
+return (JAKT_RESOLVE_EXPLICIT_VALUE_OR_CONTROL_FLOW_RETURN_ONLY(([&]() -> JaktInternal::ExplicitValueOrControlFlow<void,ErrorOr<interpreter::StatementResult>>{
+auto __jakt_enum_value = (prelude_function);
+if (__jakt_enum_value == String("println")) {
+return (outln(format_string,x)), JaktInternal::ExplicitValue<void>();
+}
+else if (__jakt_enum_value == String("eprintln")) {
+return (warnln(format_string,x)), JaktInternal::ExplicitValue<void>();
+}
+else if (__jakt_enum_value == String("print")) {
+return (out(format_string,x)), JaktInternal::ExplicitValue<void>();
+}
+else {
+return (warn(format_string,x)), JaktInternal::ExplicitValue<void>();
+}
+return JaktInternal::ExplicitValue<void>();
+}()))
+), JaktInternal::ExplicitValue<void>();
+};/*case end*/
+case 11: {
+auto&& __jakt_match_value = __jakt_match_variant.template get<typename types::ValueImpl::F64>();
+f64 const& x = __jakt_match_value.value;
+return (JAKT_RESOLVE_EXPLICIT_VALUE_OR_CONTROL_FLOW_RETURN_ONLY(([&]() -> JaktInternal::ExplicitValueOrControlFlow<void,ErrorOr<interpreter::StatementResult>>{
+auto __jakt_enum_value = (prelude_function);
+if (__jakt_enum_value == String("println")) {
+return (outln(format_string,x)), JaktInternal::ExplicitValue<void>();
+}
+else if (__jakt_enum_value == String("eprintln")) {
+return (warnln(format_string,x)), JaktInternal::ExplicitValue<void>();
+}
+else if (__jakt_enum_value == String("print")) {
+return (out(format_string,x)), JaktInternal::ExplicitValue<void>();
+}
+else {
+return (warn(format_string,x)), JaktInternal::ExplicitValue<void>();
+}
+return JaktInternal::ExplicitValue<void>();
+}()))
+), JaktInternal::ExplicitValue<void>();
+};/*case end*/
+case 12: {
+auto&& __jakt_match_value = __jakt_match_variant.template get<typename types::ValueImpl::USize>();
+size_t const& x = __jakt_match_value.value;
+return (JAKT_RESOLVE_EXPLICIT_VALUE_OR_CONTROL_FLOW_RETURN_ONLY(([&]() -> JaktInternal::ExplicitValueOrControlFlow<void,ErrorOr<interpreter::StatementResult>>{
+auto __jakt_enum_value = (prelude_function);
+if (__jakt_enum_value == String("println")) {
+return (outln(format_string,x)), JaktInternal::ExplicitValue<void>();
+}
+else if (__jakt_enum_value == String("eprintln")) {
+return (warnln(format_string,x)), JaktInternal::ExplicitValue<void>();
+}
+else if (__jakt_enum_value == String("print")) {
+return (out(format_string,x)), JaktInternal::ExplicitValue<void>();
+}
+else {
+return (warn(format_string,x)), JaktInternal::ExplicitValue<void>();
+}
+return JaktInternal::ExplicitValue<void>();
+}()))
+), JaktInternal::ExplicitValue<void>();
+};/*case end*/
+case 13: {
+auto&& __jakt_match_value = __jakt_match_variant.template get<typename types::ValueImpl::JaktString>();
+String const& x = __jakt_match_value.value;
+return (JAKT_RESOLVE_EXPLICIT_VALUE_OR_CONTROL_FLOW_RETURN_ONLY(([&]() -> JaktInternal::ExplicitValueOrControlFlow<void,ErrorOr<interpreter::StatementResult>>{
+auto __jakt_enum_value = (prelude_function);
+if (__jakt_enum_value == String("println")) {
+return (outln(format_string,x)), JaktInternal::ExplicitValue<void>();
+}
+else if (__jakt_enum_value == String("eprintln")) {
+return (warnln(format_string,x)), JaktInternal::ExplicitValue<void>();
+}
+else if (__jakt_enum_value == String("print")) {
+return (out(format_string,x)), JaktInternal::ExplicitValue<void>();
+}
+else {
+return (warn(format_string,x)), JaktInternal::ExplicitValue<void>();
+}
+return JaktInternal::ExplicitValue<void>();
+}()))
+), JaktInternal::ExplicitValue<void>();
+};/*case end*/
+case 14: {
+auto&& __jakt_match_value = __jakt_match_variant.template get<typename types::ValueImpl::CChar>();
+char const& x = __jakt_match_value.value;
+return (JAKT_RESOLVE_EXPLICIT_VALUE_OR_CONTROL_FLOW_RETURN_ONLY(([&]() -> JaktInternal::ExplicitValueOrControlFlow<void,ErrorOr<interpreter::StatementResult>>{
+auto __jakt_enum_value = (prelude_function);
+if (__jakt_enum_value == String("println")) {
+return (outln(format_string,x)), JaktInternal::ExplicitValue<void>();
+}
+else if (__jakt_enum_value == String("eprintln")) {
+return (warnln(format_string,x)), JaktInternal::ExplicitValue<void>();
+}
+else if (__jakt_enum_value == String("print")) {
+return (out(format_string,x)), JaktInternal::ExplicitValue<void>();
+}
+else {
+return (warn(format_string,x)), JaktInternal::ExplicitValue<void>();
+}
+return JaktInternal::ExplicitValue<void>();
+}()))
+), JaktInternal::ExplicitValue<void>();
+};/*case end*/
+case 15: {
+auto&& __jakt_match_value = __jakt_match_variant.template get<typename types::ValueImpl::CInt>();
+int const& x = __jakt_match_value.value;
+return (JAKT_RESOLVE_EXPLICIT_VALUE_OR_CONTROL_FLOW_RETURN_ONLY(([&]() -> JaktInternal::ExplicitValueOrControlFlow<void,ErrorOr<interpreter::StatementResult>>{
+auto __jakt_enum_value = (prelude_function);
+if (__jakt_enum_value == String("println")) {
+return (outln(format_string,x)), JaktInternal::ExplicitValue<void>();
+}
+else if (__jakt_enum_value == String("eprintln")) {
+return (warnln(format_string,x)), JaktInternal::ExplicitValue<void>();
+}
+else if (__jakt_enum_value == String("print")) {
+return (out(format_string,x)), JaktInternal::ExplicitValue<void>();
+}
+else {
+return (warn(format_string,x)), JaktInternal::ExplicitValue<void>();
+}
+return JaktInternal::ExplicitValue<void>();
+}()))
+), JaktInternal::ExplicitValue<void>();
+};/*case end*/
+default: {
+{
+TRY((((*this).error(TRY((String::formatted(String("comptime format can only format primitves, got {}"),((((arguments)[static_cast<i64>(1LL)])).impl)))),call_span))));
+return Error::from_errno((infallible_integer_cast<i32>((InterpretError::InvalidType))));
+}
+return JaktInternal::ExplicitValue<void>();
+};/*case end*/
+}/*switch end*/
+}()
+))), JaktInternal::ExplicitValue<void>();
+}
+else {
+{
+TRY((((*this).error(TRY((String::formatted(String("comptime format accepts at most two arguments, but got {}"),((arguments).size())))),call_span))));
+return Error::from_errno((infallible_integer_cast<i32>((InterpretError::InvalidType))));
+}
+return JaktInternal::ExplicitValue<void>();
+}
+return JaktInternal::ExplicitValue<void>();
+}()))
+;
+__jakt_var_129 =  interpreter::StatementResult { typename interpreter::StatementResult::JustValue(types::Value(TRY((types::ValueImpl::template create<typename types::ValueImpl::Void>())),call_span)) } ; goto __jakt_label_127;
+
+}
+__jakt_label_127:; __jakt_var_129.release_value(); }));
+}
+else if (__jakt_enum_value == String("eprint")) {
+return JaktInternal::ExplicitValue(({ Optional<interpreter::StatementResult> __jakt_var_130; {
+String const format_string = JAKT_RESOLVE_EXPLICIT_VALUE_OR_CONTROL_FLOW_RETURN_ONLY(([&]() -> JaktInternal::ExplicitValueOrControlFlow<String, ErrorOr<interpreter::StatementResult>>{
+auto&& __jakt_match_variant = *((((arguments)[static_cast<i64>(0LL)])).impl);
+switch(__jakt_match_variant.index()) {
+case 13: {
+auto&& __jakt_match_value = __jakt_match_variant.template get<typename types::ValueImpl::JaktString>();
+String const& x = __jakt_match_value.value;
+return JaktInternal::ExplicitValue(x);
+};/*case end*/
+default: {
+{
+TRY((((*this).error(TRY((String::formatted(String("println expects a string as its first argument, but got {}"),((((arguments)[static_cast<i64>(0LL)])).impl)))),call_span))));
+return Error::from_errno((infallible_integer_cast<i32>((InterpretError::InvalidType))));
+}
+};/*case end*/
+}/*switch end*/
+}()
+));
+JAKT_RESOLVE_EXPLICIT_VALUE_OR_CONTROL_FLOW_RETURN_ONLY(([&]() -> JaktInternal::ExplicitValueOrControlFlow<void,ErrorOr<interpreter::StatementResult>>{
+auto __jakt_enum_value = (((arguments).size()));
+if (__jakt_enum_value == static_cast<size_t>(1ULL)) {
+return (JAKT_RESOLVE_EXPLICIT_VALUE_OR_CONTROL_FLOW_RETURN_ONLY(([&]() -> JaktInternal::ExplicitValueOrControlFlow<void,ErrorOr<interpreter::StatementResult>>{
+auto __jakt_enum_value = (prelude_function);
+if (__jakt_enum_value == String("println")) {
+return (outln(format_string)), JaktInternal::ExplicitValue<void>();
+}
+else if (__jakt_enum_value == String("eprintln")) {
+return (warnln(format_string)), JaktInternal::ExplicitValue<void>();
+}
+else if (__jakt_enum_value == String("print")) {
+return (out(format_string)), JaktInternal::ExplicitValue<void>();
+}
+else {
+return (warn(format_string)), JaktInternal::ExplicitValue<void>();
+}
+return JaktInternal::ExplicitValue<void>();
+}()))
+), JaktInternal::ExplicitValue<void>();
+}
+else if (__jakt_enum_value == static_cast<size_t>(2ULL)) {
+return (JAKT_RESOLVE_EXPLICIT_VALUE_OR_CONTROL_FLOW_RETURN_ONLY(([&]() -> JaktInternal::ExplicitValueOrControlFlow<void, ErrorOr<interpreter::StatementResult>>{
+auto&& __jakt_match_variant = *((((arguments)[static_cast<i64>(1LL)])).impl);
+switch(__jakt_match_variant.index()) {
+case 1: {
+auto&& __jakt_match_value = __jakt_match_variant.template get<typename types::ValueImpl::Bool>();
+bool const& x = __jakt_match_value.value;
+return (JAKT_RESOLVE_EXPLICIT_VALUE_OR_CONTROL_FLOW_RETURN_ONLY(([&]() -> JaktInternal::ExplicitValueOrControlFlow<void,ErrorOr<interpreter::StatementResult>>{
+auto __jakt_enum_value = (prelude_function);
+if (__jakt_enum_value == String("println")) {
+return (outln(format_string,x)), JaktInternal::ExplicitValue<void>();
+}
+else if (__jakt_enum_value == String("eprintln")) {
+return (warnln(format_string,x)), JaktInternal::ExplicitValue<void>();
+}
+else if (__jakt_enum_value == String("print")) {
+return (out(format_string,x)), JaktInternal::ExplicitValue<void>();
+}
+else {
+return (warn(format_string,x)), JaktInternal::ExplicitValue<void>();
+}
+return JaktInternal::ExplicitValue<void>();
+}()))
+), JaktInternal::ExplicitValue<void>();
+};/*case end*/
+case 2: {
+auto&& __jakt_match_value = __jakt_match_variant.template get<typename types::ValueImpl::U8>();
+u8 const& x = __jakt_match_value.value;
+return (JAKT_RESOLVE_EXPLICIT_VALUE_OR_CONTROL_FLOW_RETURN_ONLY(([&]() -> JaktInternal::ExplicitValueOrControlFlow<void,ErrorOr<interpreter::StatementResult>>{
+auto __jakt_enum_value = (prelude_function);
+if (__jakt_enum_value == String("println")) {
+return (outln(format_string,x)), JaktInternal::ExplicitValue<void>();
+}
+else if (__jakt_enum_value == String("eprintln")) {
+return (warnln(format_string,x)), JaktInternal::ExplicitValue<void>();
+}
+else if (__jakt_enum_value == String("print")) {
+return (out(format_string,x)), JaktInternal::ExplicitValue<void>();
+}
+else {
+return (warn(format_string,x)), JaktInternal::ExplicitValue<void>();
+}
+return JaktInternal::ExplicitValue<void>();
+}()))
+), JaktInternal::ExplicitValue<void>();
+};/*case end*/
+case 3: {
+auto&& __jakt_match_value = __jakt_match_variant.template get<typename types::ValueImpl::U16>();
+u16 const& x = __jakt_match_value.value;
+return (JAKT_RESOLVE_EXPLICIT_VALUE_OR_CONTROL_FLOW_RETURN_ONLY(([&]() -> JaktInternal::ExplicitValueOrControlFlow<void,ErrorOr<interpreter::StatementResult>>{
+auto __jakt_enum_value = (prelude_function);
+if (__jakt_enum_value == String("println")) {
+return (outln(format_string,x)), JaktInternal::ExplicitValue<void>();
+}
+else if (__jakt_enum_value == String("eprintln")) {
+return (warnln(format_string,x)), JaktInternal::ExplicitValue<void>();
+}
+else if (__jakt_enum_value == String("print")) {
+return (out(format_string,x)), JaktInternal::ExplicitValue<void>();
+}
+else {
+return (warn(format_string,x)), JaktInternal::ExplicitValue<void>();
+}
+return JaktInternal::ExplicitValue<void>();
+}()))
+), JaktInternal::ExplicitValue<void>();
+};/*case end*/
+case 4: {
+auto&& __jakt_match_value = __jakt_match_variant.template get<typename types::ValueImpl::U32>();
+u32 const& x = __jakt_match_value.value;
+return (JAKT_RESOLVE_EXPLICIT_VALUE_OR_CONTROL_FLOW_RETURN_ONLY(([&]() -> JaktInternal::ExplicitValueOrControlFlow<void,ErrorOr<interpreter::StatementResult>>{
+auto __jakt_enum_value = (prelude_function);
+if (__jakt_enum_value == String("println")) {
+return (outln(format_string,x)), JaktInternal::ExplicitValue<void>();
+}
+else if (__jakt_enum_value == String("eprintln")) {
+return (warnln(format_string,x)), JaktInternal::ExplicitValue<void>();
+}
+else if (__jakt_enum_value == String("print")) {
+return (out(format_string,x)), JaktInternal::ExplicitValue<void>();
+}
+else {
+return (warn(format_string,x)), JaktInternal::ExplicitValue<void>();
+}
+return JaktInternal::ExplicitValue<void>();
+}()))
+), JaktInternal::ExplicitValue<void>();
+};/*case end*/
+case 5: {
+auto&& __jakt_match_value = __jakt_match_variant.template get<typename types::ValueImpl::U64>();
+u64 const& x = __jakt_match_value.value;
+return (JAKT_RESOLVE_EXPLICIT_VALUE_OR_CONTROL_FLOW_RETURN_ONLY(([&]() -> JaktInternal::ExplicitValueOrControlFlow<void,ErrorOr<interpreter::StatementResult>>{
+auto __jakt_enum_value = (prelude_function);
+if (__jakt_enum_value == String("println")) {
+return (outln(format_string,x)), JaktInternal::ExplicitValue<void>();
+}
+else if (__jakt_enum_value == String("eprintln")) {
+return (warnln(format_string,x)), JaktInternal::ExplicitValue<void>();
+}
+else if (__jakt_enum_value == String("print")) {
+return (out(format_string,x)), JaktInternal::ExplicitValue<void>();
+}
+else {
+return (warn(format_string,x)), JaktInternal::ExplicitValue<void>();
+}
+return JaktInternal::ExplicitValue<void>();
+}()))
+), JaktInternal::ExplicitValue<void>();
+};/*case end*/
+case 6: {
+auto&& __jakt_match_value = __jakt_match_variant.template get<typename types::ValueImpl::I8>();
+i8 const& x = __jakt_match_value.value;
+return (JAKT_RESOLVE_EXPLICIT_VALUE_OR_CONTROL_FLOW_RETURN_ONLY(([&]() -> JaktInternal::ExplicitValueOrControlFlow<void,ErrorOr<interpreter::StatementResult>>{
+auto __jakt_enum_value = (prelude_function);
+if (__jakt_enum_value == String("println")) {
+return (outln(format_string,x)), JaktInternal::ExplicitValue<void>();
+}
+else if (__jakt_enum_value == String("eprintln")) {
+return (warnln(format_string,x)), JaktInternal::ExplicitValue<void>();
+}
+else if (__jakt_enum_value == String("print")) {
+return (out(format_string,x)), JaktInternal::ExplicitValue<void>();
+}
+else {
+return (warn(format_string,x)), JaktInternal::ExplicitValue<void>();
+}
+return JaktInternal::ExplicitValue<void>();
+}()))
+), JaktInternal::ExplicitValue<void>();
+};/*case end*/
+case 7: {
+auto&& __jakt_match_value = __jakt_match_variant.template get<typename types::ValueImpl::I16>();
+i16 const& x = __jakt_match_value.value;
+return (JAKT_RESOLVE_EXPLICIT_VALUE_OR_CONTROL_FLOW_RETURN_ONLY(([&]() -> JaktInternal::ExplicitValueOrControlFlow<void,ErrorOr<interpreter::StatementResult>>{
+auto __jakt_enum_value = (prelude_function);
+if (__jakt_enum_value == String("println")) {
+return (outln(format_string,x)), JaktInternal::ExplicitValue<void>();
+}
+else if (__jakt_enum_value == String("eprintln")) {
+return (warnln(format_string,x)), JaktInternal::ExplicitValue<void>();
+}
+else if (__jakt_enum_value == String("print")) {
+return (out(format_string,x)), JaktInternal::ExplicitValue<void>();
+}
+else {
+return (warn(format_string,x)), JaktInternal::ExplicitValue<void>();
+}
+return JaktInternal::ExplicitValue<void>();
+}()))
+), JaktInternal::ExplicitValue<void>();
+};/*case end*/
+case 8: {
+auto&& __jakt_match_value = __jakt_match_variant.template get<typename types::ValueImpl::I32>();
+i32 const& x = __jakt_match_value.value;
+return (JAKT_RESOLVE_EXPLICIT_VALUE_OR_CONTROL_FLOW_RETURN_ONLY(([&]() -> JaktInternal::ExplicitValueOrControlFlow<void,ErrorOr<interpreter::StatementResult>>{
+auto __jakt_enum_value = (prelude_function);
+if (__jakt_enum_value == String("println")) {
+return (outln(format_string,x)), JaktInternal::ExplicitValue<void>();
+}
+else if (__jakt_enum_value == String("eprintln")) {
+return (warnln(format_string,x)), JaktInternal::ExplicitValue<void>();
+}
+else if (__jakt_enum_value == String("print")) {
+return (out(format_string,x)), JaktInternal::ExplicitValue<void>();
+}
+else {
+return (warn(format_string,x)), JaktInternal::ExplicitValue<void>();
+}
+return JaktInternal::ExplicitValue<void>();
+}()))
+), JaktInternal::ExplicitValue<void>();
+};/*case end*/
+case 9: {
+auto&& __jakt_match_value = __jakt_match_variant.template get<typename types::ValueImpl::I64>();
+i64 const& x = __jakt_match_value.value;
+return (JAKT_RESOLVE_EXPLICIT_VALUE_OR_CONTROL_FLOW_RETURN_ONLY(([&]() -> JaktInternal::ExplicitValueOrControlFlow<void,ErrorOr<interpreter::StatementResult>>{
+auto __jakt_enum_value = (prelude_function);
+if (__jakt_enum_value == String("println")) {
+return (outln(format_string,x)), JaktInternal::ExplicitValue<void>();
+}
+else if (__jakt_enum_value == String("eprintln")) {
+return (warnln(format_string,x)), JaktInternal::ExplicitValue<void>();
+}
+else if (__jakt_enum_value == String("print")) {
+return (out(format_string,x)), JaktInternal::ExplicitValue<void>();
+}
+else {
+return (warn(format_string,x)), JaktInternal::ExplicitValue<void>();
+}
+return JaktInternal::ExplicitValue<void>();
+}()))
+), JaktInternal::ExplicitValue<void>();
+};/*case end*/
+case 10: {
+auto&& __jakt_match_value = __jakt_match_variant.template get<typename types::ValueImpl::F32>();
+f32 const& x = __jakt_match_value.value;
+return (JAKT_RESOLVE_EXPLICIT_VALUE_OR_CONTROL_FLOW_RETURN_ONLY(([&]() -> JaktInternal::ExplicitValueOrControlFlow<void,ErrorOr<interpreter::StatementResult>>{
+auto __jakt_enum_value = (prelude_function);
+if (__jakt_enum_value == String("println")) {
+return (outln(format_string,x)), JaktInternal::ExplicitValue<void>();
+}
+else if (__jakt_enum_value == String("eprintln")) {
+return (warnln(format_string,x)), JaktInternal::ExplicitValue<void>();
+}
+else if (__jakt_enum_value == String("print")) {
+return (out(format_string,x)), JaktInternal::ExplicitValue<void>();
+}
+else {
+return (warn(format_string,x)), JaktInternal::ExplicitValue<void>();
+}
+return JaktInternal::ExplicitValue<void>();
+}()))
+), JaktInternal::ExplicitValue<void>();
+};/*case end*/
+case 11: {
+auto&& __jakt_match_value = __jakt_match_variant.template get<typename types::ValueImpl::F64>();
+f64 const& x = __jakt_match_value.value;
+return (JAKT_RESOLVE_EXPLICIT_VALUE_OR_CONTROL_FLOW_RETURN_ONLY(([&]() -> JaktInternal::ExplicitValueOrControlFlow<void,ErrorOr<interpreter::StatementResult>>{
+auto __jakt_enum_value = (prelude_function);
+if (__jakt_enum_value == String("println")) {
+return (outln(format_string,x)), JaktInternal::ExplicitValue<void>();
+}
+else if (__jakt_enum_value == String("eprintln")) {
+return (warnln(format_string,x)), JaktInternal::ExplicitValue<void>();
+}
+else if (__jakt_enum_value == String("print")) {
+return (out(format_string,x)), JaktInternal::ExplicitValue<void>();
+}
+else {
+return (warn(format_string,x)), JaktInternal::ExplicitValue<void>();
+}
+return JaktInternal::ExplicitValue<void>();
+}()))
+), JaktInternal::ExplicitValue<void>();
+};/*case end*/
+case 12: {
+auto&& __jakt_match_value = __jakt_match_variant.template get<typename types::ValueImpl::USize>();
+size_t const& x = __jakt_match_value.value;
+return (JAKT_RESOLVE_EXPLICIT_VALUE_OR_CONTROL_FLOW_RETURN_ONLY(([&]() -> JaktInternal::ExplicitValueOrControlFlow<void,ErrorOr<interpreter::StatementResult>>{
+auto __jakt_enum_value = (prelude_function);
+if (__jakt_enum_value == String("println")) {
+return (outln(format_string,x)), JaktInternal::ExplicitValue<void>();
+}
+else if (__jakt_enum_value == String("eprintln")) {
+return (warnln(format_string,x)), JaktInternal::ExplicitValue<void>();
+}
+else if (__jakt_enum_value == String("print")) {
+return (out(format_string,x)), JaktInternal::ExplicitValue<void>();
+}
+else {
+return (warn(format_string,x)), JaktInternal::ExplicitValue<void>();
+}
+return JaktInternal::ExplicitValue<void>();
+}()))
+), JaktInternal::ExplicitValue<void>();
+};/*case end*/
+case 13: {
+auto&& __jakt_match_value = __jakt_match_variant.template get<typename types::ValueImpl::JaktString>();
+String const& x = __jakt_match_value.value;
+return (JAKT_RESOLVE_EXPLICIT_VALUE_OR_CONTROL_FLOW_RETURN_ONLY(([&]() -> JaktInternal::ExplicitValueOrControlFlow<void,ErrorOr<interpreter::StatementResult>>{
+auto __jakt_enum_value = (prelude_function);
+if (__jakt_enum_value == String("println")) {
+return (outln(format_string,x)), JaktInternal::ExplicitValue<void>();
+}
+else if (__jakt_enum_value == String("eprintln")) {
+return (warnln(format_string,x)), JaktInternal::ExplicitValue<void>();
+}
+else if (__jakt_enum_value == String("print")) {
+return (out(format_string,x)), JaktInternal::ExplicitValue<void>();
+}
+else {
+return (warn(format_string,x)), JaktInternal::ExplicitValue<void>();
+}
+return JaktInternal::ExplicitValue<void>();
+}()))
+), JaktInternal::ExplicitValue<void>();
+};/*case end*/
+case 14: {
+auto&& __jakt_match_value = __jakt_match_variant.template get<typename types::ValueImpl::CChar>();
+char const& x = __jakt_match_value.value;
+return (JAKT_RESOLVE_EXPLICIT_VALUE_OR_CONTROL_FLOW_RETURN_ONLY(([&]() -> JaktInternal::ExplicitValueOrControlFlow<void,ErrorOr<interpreter::StatementResult>>{
+auto __jakt_enum_value = (prelude_function);
+if (__jakt_enum_value == String("println")) {
+return (outln(format_string,x)), JaktInternal::ExplicitValue<void>();
+}
+else if (__jakt_enum_value == String("eprintln")) {
+return (warnln(format_string,x)), JaktInternal::ExplicitValue<void>();
+}
+else if (__jakt_enum_value == String("print")) {
+return (out(format_string,x)), JaktInternal::ExplicitValue<void>();
+}
+else {
+return (warn(format_string,x)), JaktInternal::ExplicitValue<void>();
+}
+return JaktInternal::ExplicitValue<void>();
+}()))
+), JaktInternal::ExplicitValue<void>();
+};/*case end*/
+case 15: {
+auto&& __jakt_match_value = __jakt_match_variant.template get<typename types::ValueImpl::CInt>();
+int const& x = __jakt_match_value.value;
+return (JAKT_RESOLVE_EXPLICIT_VALUE_OR_CONTROL_FLOW_RETURN_ONLY(([&]() -> JaktInternal::ExplicitValueOrControlFlow<void,ErrorOr<interpreter::StatementResult>>{
+auto __jakt_enum_value = (prelude_function);
+if (__jakt_enum_value == String("println")) {
+return (outln(format_string,x)), JaktInternal::ExplicitValue<void>();
+}
+else if (__jakt_enum_value == String("eprintln")) {
+return (warnln(format_string,x)), JaktInternal::ExplicitValue<void>();
+}
+else if (__jakt_enum_value == String("print")) {
+return (out(format_string,x)), JaktInternal::ExplicitValue<void>();
+}
+else {
+return (warn(format_string,x)), JaktInternal::ExplicitValue<void>();
+}
+return JaktInternal::ExplicitValue<void>();
+}()))
+), JaktInternal::ExplicitValue<void>();
+};/*case end*/
+default: {
+{
+TRY((((*this).error(TRY((String::formatted(String("comptime format can only format primitves, got {}"),((((arguments)[static_cast<i64>(1LL)])).impl)))),call_span))));
+return Error::from_errno((infallible_integer_cast<i32>((InterpretError::InvalidType))));
+}
+return JaktInternal::ExplicitValue<void>();
+};/*case end*/
+}/*switch end*/
+}()
+))), JaktInternal::ExplicitValue<void>();
+}
+else {
+{
+TRY((((*this).error(TRY((String::formatted(String("comptime format accepts at most two arguments, but got {}"),((arguments).size())))),call_span))));
+return Error::from_errno((infallible_integer_cast<i32>((InterpretError::InvalidType))));
+}
+return JaktInternal::ExplicitValue<void>();
+}
+return JaktInternal::ExplicitValue<void>();
+}()))
+;
+__jakt_var_130 =  interpreter::StatementResult { typename interpreter::StatementResult::JustValue(types::Value(TRY((types::ValueImpl::template create<typename types::ValueImpl::Void>())),call_span)) } ; goto __jakt_label_128;
+
+}
+__jakt_label_128:; __jakt_var_130.release_value(); }));
+}
+else if (__jakt_enum_value == String("as_saturated")) {
+return JaktInternal::ExplicitValue(({ Optional<interpreter::StatementResult> __jakt_var_131; {
+NonnullRefPtr<types::CheckedFunction> const function_ = ((((*this).program))->get_function((((TRY((((((*this).program))->find_functions_with_name_in_scope(((((*this).program))->prelude_scope_id()),String("as_saturated"))))).value()))[static_cast<i64>(0LL)])));
+JaktInternal::Optional<types::TypeId> const output_type_id = ((type_bindings).get(TRY((((((((((((function_)->generics))->params))[static_cast<i64>(0LL)])).type_id())).to_string())))));
+__jakt_var_131 =  interpreter::StatementResult { typename interpreter::StatementResult::JustValue(TRY((interpreter::cast_value_to_type(((arguments)[static_cast<i64>(0LL)]),(output_type_id.value()),*this,true)))) } ; goto __jakt_label_129;
+
+}
+__jakt_label_129:; __jakt_var_131.release_value(); }));
+}
+else if (__jakt_enum_value == String("unchecked_mul")) {
+return JaktInternal::ExplicitValue(({ Optional<interpreter::StatementResult> __jakt_var_132; {
 types::Value const lhs_value = ((arguments)[static_cast<i64>(0LL)]);
 types::Value const rhs_value = ((arguments)[static_cast<i64>(1LL)]);
 utility::Span const span = call_span;
-__jakt_var_128 =  interpreter::StatementResult { typename interpreter::StatementResult::JustValue(types::Value(JAKT_RESOLVE_EXPLICIT_VALUE_OR_CONTROL_FLOW_RETURN_ONLY(([&]() -> JaktInternal::ExplicitValueOrControlFlow<NonnullRefPtr<types::ValueImpl>, ErrorOr<interpreter::StatementResult>>{
+__jakt_var_132 =  interpreter::StatementResult { typename interpreter::StatementResult::JustValue(types::Value(JAKT_RESOLVE_EXPLICIT_VALUE_OR_CONTROL_FLOW_RETURN_ONLY(([&]() -> JaktInternal::ExplicitValueOrControlFlow<NonnullRefPtr<types::ValueImpl>, ErrorOr<interpreter::StatementResult>>{
 auto&& __jakt_match_variant = *((lhs_value).impl);
 switch(__jakt_match_variant.index()) {
 case 2: {
@@ -2897,17 +2883,17 @@ return Error::from_errno((infallible_integer_cast<i32>((InterpretError::InvalidT
 };/*case end*/
 }/*switch end*/
 }()
-)),span)) } ; goto __jakt_label_126;
+)),span)) } ; goto __jakt_label_130;
 
 }
-__jakt_label_126:; __jakt_var_128.release_value(); }));
+__jakt_label_130:; __jakt_var_132.release_value(); }));
 }
 else if (__jakt_enum_value == String("unchecked_add")) {
-return JaktInternal::ExplicitValue(({ Optional<interpreter::StatementResult> __jakt_var_129; {
+return JaktInternal::ExplicitValue(({ Optional<interpreter::StatementResult> __jakt_var_133; {
 types::Value const lhs_value = ((arguments)[static_cast<i64>(0LL)]);
 types::Value const rhs_value = ((arguments)[static_cast<i64>(1LL)]);
 utility::Span const span = call_span;
-__jakt_var_129 =  interpreter::StatementResult { typename interpreter::StatementResult::JustValue(types::Value(JAKT_RESOLVE_EXPLICIT_VALUE_OR_CONTROL_FLOW_RETURN_ONLY(([&]() -> JaktInternal::ExplicitValueOrControlFlow<NonnullRefPtr<types::ValueImpl>, ErrorOr<interpreter::StatementResult>>{
+__jakt_var_133 =  interpreter::StatementResult { typename interpreter::StatementResult::JustValue(types::Value(JAKT_RESOLVE_EXPLICIT_VALUE_OR_CONTROL_FLOW_RETURN_ONLY(([&]() -> JaktInternal::ExplicitValueOrControlFlow<NonnullRefPtr<types::ValueImpl>, ErrorOr<interpreter::StatementResult>>{
 auto&& __jakt_match_variant = *((lhs_value).impl);
 switch(__jakt_match_variant.index()) {
 case 2: {
@@ -3149,10 +3135,10 @@ return Error::from_errno((infallible_integer_cast<i32>((InterpretError::InvalidT
 };/*case end*/
 }/*switch end*/
 }()
-)),span)) } ; goto __jakt_label_127;
+)),span)) } ; goto __jakt_label_131;
 
 }
-__jakt_label_127:; __jakt_var_129.release_value(); }));
+__jakt_label_131:; __jakt_var_133.release_value(); }));
 }
 else if (__jakt_enum_value == String("___jakt_get_target_triple_string")) {
 return JaktInternal::ExplicitValue( interpreter::StatementResult { typename interpreter::StatementResult::JustValue(types::Value(TRY((types::ValueImpl::template create<typename types::ValueImpl::JaktString>(((((*this).compiler))->target_triple).value_or_lazy_evaluated([&] { return ___jakt_get_target_triple_string(); })))),call_span)) } );
@@ -3163,30 +3149,30 @@ abort();
 }
 }
 else if (__jakt_enum_value == String("Set")) {
-return JaktInternal::ExplicitValue(({ Optional<interpreter::StatementResult> __jakt_var_130; {
+return JaktInternal::ExplicitValue(({ Optional<interpreter::StatementResult> __jakt_var_134; {
 if ((((type_bindings).size()) != static_cast<size_t>(1ULL))){
 TRY((((*this).error(String("Set constructor expects one generic argument"),call_span))));
 return Error::from_errno((infallible_integer_cast<i32>((InterpretError::InvalidType))));
 }
 types::StructId const set_struct_id = TRY((((((*this).program))->find_struct_in_prelude(String("Set")))));
 types::TypeId const type_id = TRY((((*this).find_or_add_type_id(TRY((types::Type::template create<typename types::Type::GenericInstance>(set_struct_id,(TRY((Array<types::TypeId>::create_with({(((type_bindings).get(((TRY((((type_bindings).keys()))))[static_cast<i64>(0LL)]))).value())})))))))))));
-__jakt_var_130 =  interpreter::StatementResult { typename interpreter::StatementResult::JustValue(types::Value(TRY((types::ValueImpl::template create<typename types::ValueImpl::JaktSet>((TRY((Array<types::Value>::create_with({})))),type_id))),call_span)) } ; goto __jakt_label_128;
+__jakt_var_134 =  interpreter::StatementResult { typename interpreter::StatementResult::JustValue(types::Value(TRY((types::ValueImpl::template create<typename types::ValueImpl::JaktSet>((TRY((Array<types::Value>::create_with({})))),type_id))),call_span)) } ; goto __jakt_label_132;
 
 }
-__jakt_label_128:; __jakt_var_130.release_value(); }));
+__jakt_label_132:; __jakt_var_134.release_value(); }));
 }
 else if (__jakt_enum_value == String("Dictionary")) {
-return JaktInternal::ExplicitValue(({ Optional<interpreter::StatementResult> __jakt_var_131; {
+return JaktInternal::ExplicitValue(({ Optional<interpreter::StatementResult> __jakt_var_135; {
 if ((((type_bindings).size()) != static_cast<size_t>(2ULL))){
 TRY((((*this).error(String("Dictionary constructor expects two generic argumenst"),call_span))));
 return Error::from_errno((infallible_integer_cast<i32>((InterpretError::InvalidType))));
 }
 types::StructId const dictionary_struct_id = TRY((((((*this).program))->find_struct_in_prelude(String("Dictionary")))));
 types::TypeId const type_id = TRY((((*this).find_or_add_type_id(TRY((types::Type::template create<typename types::Type::GenericInstance>(dictionary_struct_id,(TRY((Array<types::TypeId>::create_with({(((type_bindings).get(((TRY((((type_bindings).keys()))))[static_cast<i64>(0LL)]))).value()), (((type_bindings).get(((TRY((((type_bindings).keys()))))[static_cast<i64>(1LL)]))).value())})))))))))));
-__jakt_var_131 =  interpreter::StatementResult { typename interpreter::StatementResult::JustValue(types::Value(TRY((types::ValueImpl::template create<typename types::ValueImpl::JaktDictionary>((TRY((Array<types::Value>::create_with({})))),(TRY((Array<types::Value>::create_with({})))),type_id))),call_span)) } ; goto __jakt_label_129;
+__jakt_var_135 =  interpreter::StatementResult { typename interpreter::StatementResult::JustValue(types::Value(TRY((types::ValueImpl::template create<typename types::ValueImpl::JaktDictionary>((TRY((Array<types::Value>::create_with({})))),(TRY((Array<types::Value>::create_with({})))),type_id))),call_span)) } ; goto __jakt_label_133;
 
 }
-__jakt_label_129:; __jakt_var_131.release_value(); }));
+__jakt_label_133:; __jakt_var_135.release_value(); }));
 }
 else {
 {
@@ -3203,16 +3189,16 @@ if (__jakt_enum_value == String("Error")) {
 return JaktInternal::ExplicitValue(JAKT_RESOLVE_EXPLICIT_VALUE_OR_CONTROL_FLOW_RETURN_ONLY(([&]() -> JaktInternal::ExplicitValueOrControlFlow<interpreter::StatementResult,ErrorOr<interpreter::StatementResult>>{
 auto __jakt_enum_value = (prelude_function);
 if (__jakt_enum_value == String("from_errno")) {
-return JaktInternal::ExplicitValue(({ Optional<interpreter::StatementResult> __jakt_var_132; {
+return JaktInternal::ExplicitValue(({ Optional<interpreter::StatementResult> __jakt_var_136; {
 types::Value const err = ((arguments)[static_cast<i64>(0LL)]);
 types::StructId const error_struct_id = TRY((((((*this).program))->find_struct_in_prelude(String("Error")))));
 types::CheckedStruct const error_struct = ((((*this).program))->get_struct(error_struct_id));
 NonnullRefPtr<types::Scope> const scope = TRY((((((*this).program))->get_scope(((error_struct).scope_id)))));
-JaktInternal::Optional<types::FunctionId> const constructor = ((((scope)->functions)).get(String("from_errno")));
-__jakt_var_132 =  interpreter::StatementResult { typename interpreter::StatementResult::JustValue(types::Value(TRY((types::ValueImpl::template create<typename types::ValueImpl::Struct>((TRY((Array<types::Value>::create_with({err})))),error_struct_id,(constructor.value())))),call_span)) } ; goto __jakt_label_130;
+JaktInternal::Optional<JaktInternal::Array<types::FunctionId>> const constructors = ((((scope)->functions)).get(String("from_errno")));
+__jakt_var_136 =  interpreter::StatementResult { typename interpreter::StatementResult::JustValue(types::Value(TRY((types::ValueImpl::template create<typename types::ValueImpl::Struct>((TRY((Array<types::Value>::create_with({err})))),error_struct_id,(((constructors.value()))[static_cast<i64>(0LL)])))),call_span)) } ; goto __jakt_label_134;
 
 }
-__jakt_label_130:; __jakt_var_132.release_value(); }));
+__jakt_label_134:; __jakt_var_136.release_value(); }));
 }
 else if (__jakt_enum_value == String("code")) {
 return JaktInternal::ExplicitValue(JAKT_RESOLVE_EXPLICIT_VALUE_OR_CONTROL_FLOW_RETURN_ONLY(([&]() -> JaktInternal::ExplicitValueOrControlFlow<interpreter::StatementResult, ErrorOr<interpreter::StatementResult>>{
@@ -3261,7 +3247,7 @@ else if (__jakt_enum_value == String("File")) {
 return JaktInternal::ExplicitValue(JAKT_RESOLVE_EXPLICIT_VALUE_OR_CONTROL_FLOW_RETURN_ONLY(([&]() -> JaktInternal::ExplicitValueOrControlFlow<interpreter::StatementResult,ErrorOr<interpreter::StatementResult>>{
 auto __jakt_enum_value = (prelude_function);
 if (__jakt_enum_value == String("open_for_reading")) {
-return JaktInternal::ExplicitValue(({ Optional<interpreter::StatementResult> __jakt_var_133; {
+return JaktInternal::ExplicitValue(({ Optional<interpreter::StatementResult> __jakt_var_137; {
 String const requested_path = JAKT_RESOLVE_EXPLICIT_VALUE_OR_CONTROL_FLOW_RETURN_ONLY(([&]() -> JaktInternal::ExplicitValueOrControlFlow<String, ErrorOr<interpreter::StatementResult>>{
 auto&& __jakt_match_variant = *((((arguments)[static_cast<i64>(0LL)])).impl);
 switch(__jakt_match_variant.index()) {
@@ -3288,14 +3274,14 @@ return Error::from_errno((infallible_integer_cast<i32>((InterpretError::InvalidT
 types::StructId const file_struct_id = TRY((((((*this).program))->find_struct_in_prelude(String("File")))));
 types::CheckedStruct const file_struct = ((((*this).program))->get_struct(file_struct_id));
 NonnullRefPtr<types::Scope> const scope = TRY((((((*this).program))->get_scope(((file_struct).scope_id)))));
-JaktInternal::Optional<types::FunctionId> const constructor = ((((scope)->functions)).get(String("open_for_reading")));
-__jakt_var_133 =  interpreter::StatementResult { typename interpreter::StatementResult::JustValue(types::Value(TRY((types::ValueImpl::template create<typename types::ValueImpl::Struct>((TRY((Array<types::Value>::create_with({path_value})))),file_struct_id,(constructor.value())))),call_span)) } ; goto __jakt_label_131;
+JaktInternal::Optional<JaktInternal::Array<types::FunctionId>> const constructors = ((((scope)->functions)).get(String("open_for_reading")));
+__jakt_var_137 =  interpreter::StatementResult { typename interpreter::StatementResult::JustValue(types::Value(TRY((types::ValueImpl::template create<typename types::ValueImpl::Struct>((TRY((Array<types::Value>::create_with({path_value})))),file_struct_id,(((constructors.value()))[static_cast<i64>(0LL)])))),call_span)) } ; goto __jakt_label_135;
 
 }
-__jakt_label_131:; __jakt_var_133.release_value(); }));
+__jakt_label_135:; __jakt_var_137.release_value(); }));
 }
 else if (__jakt_enum_value == String("open_for_writing")) {
-return JaktInternal::ExplicitValue(({ Optional<interpreter::StatementResult> __jakt_var_134; {
+return JaktInternal::ExplicitValue(({ Optional<interpreter::StatementResult> __jakt_var_138; {
 String const requested_path = JAKT_RESOLVE_EXPLICIT_VALUE_OR_CONTROL_FLOW_RETURN_ONLY(([&]() -> JaktInternal::ExplicitValueOrControlFlow<String, ErrorOr<interpreter::StatementResult>>{
 auto&& __jakt_match_variant = *((((arguments)[static_cast<i64>(0LL)])).impl);
 switch(__jakt_match_variant.index()) {
@@ -3322,14 +3308,14 @@ return Error::from_errno((infallible_integer_cast<i32>((InterpretError::InvalidT
 types::StructId const file_struct_id = TRY((((((*this).program))->find_struct_in_prelude(String("File")))));
 types::CheckedStruct const file_struct = ((((*this).program))->get_struct(file_struct_id));
 NonnullRefPtr<types::Scope> const scope = TRY((((((*this).program))->get_scope(((file_struct).scope_id)))));
-JaktInternal::Optional<types::FunctionId> const constructor = ((((scope)->functions)).get(String("open_for_writing")));
-__jakt_var_134 =  interpreter::StatementResult { typename interpreter::StatementResult::JustValue(types::Value(TRY((types::ValueImpl::template create<typename types::ValueImpl::Struct>((TRY((Array<types::Value>::create_with({path_value})))),file_struct_id,(constructor.value())))),call_span)) } ; goto __jakt_label_132;
+JaktInternal::Optional<JaktInternal::Array<types::FunctionId>> const constructor = ((((scope)->functions)).get(String("open_for_writing")));
+__jakt_var_138 =  interpreter::StatementResult { typename interpreter::StatementResult::JustValue(types::Value(TRY((types::ValueImpl::template create<typename types::ValueImpl::Struct>((TRY((Array<types::Value>::create_with({path_value})))),file_struct_id,(((constructor.value()))[static_cast<i64>(0LL)])))),call_span)) } ; goto __jakt_label_136;
 
 }
-__jakt_label_132:; __jakt_var_134.release_value(); }));
+__jakt_label_136:; __jakt_var_138.release_value(); }));
 }
 else if (__jakt_enum_value == String("read_all")) {
-return JaktInternal::ExplicitValue(({ Optional<interpreter::StatementResult> __jakt_var_135; {
+return JaktInternal::ExplicitValue(({ Optional<interpreter::StatementResult> __jakt_var_139; {
 String const path = JAKT_RESOLVE_EXPLICIT_VALUE_OR_CONTROL_FLOW_RETURN_ONLY(([&]() -> JaktInternal::ExplicitValueOrControlFlow<String, ErrorOr<interpreter::StatementResult>>{
 auto&& __jakt_match_variant = *(((this_argument.value())).impl);
 switch(__jakt_match_variant.index()) {
@@ -3364,7 +3350,7 @@ return Error::from_errno((infallible_integer_cast<i32>((InterpretError::InvalidT
 types::StructId const file_struct_id = TRY((((((*this).program))->find_struct_in_prelude(String("File")))));
 types::CheckedStruct const file_struct = ((((*this).program))->get_struct(file_struct_id));
 NonnullRefPtr<types::Scope> const scope = TRY((((((*this).program))->get_scope(((file_struct).scope_id)))));
-types::FunctionId const open_for_reading = (((((scope)->functions)).get(String("open_for_reading"))).value());
+types::FunctionId const open_for_reading = (((((((scope)->functions)).get(String("open_for_reading"))).value()))[static_cast<i64>(0LL)]);
 JAKT_RESOLVE_EXPLICIT_VALUE_OR_CONTROL_FLOW_RETURN_ONLY(([&]() -> JaktInternal::ExplicitValueOrControlFlow<void, ErrorOr<interpreter::StatementResult>>{
 auto&& __jakt_match_variant = *(((this_argument.value())).impl);
 switch(__jakt_match_variant.index()) {
@@ -3405,13 +3391,13 @@ TRY((((result_values).push(types::Value(TRY((types::ValueImpl::template create<t
 }
 
 types::StructId const array_struct_id = TRY((((((*this).program))->find_struct_in_prelude(String("Array")))));
-__jakt_var_135 =  interpreter::StatementResult { typename interpreter::StatementResult::JustValue(types::Value(TRY((types::ValueImpl::template create<typename types::ValueImpl::JaktArray>(result_values,TRY((((*this).find_or_add_type_id(TRY((types::Type::template create<typename types::Type::GenericInstance>(array_struct_id,(TRY((Array<types::TypeId>::create_with({types::builtin( types::BuiltinType { typename types::BuiltinType::U8() } )})))))))))))))),call_span)) } ; goto __jakt_label_133;
+__jakt_var_139 =  interpreter::StatementResult { typename interpreter::StatementResult::JustValue(types::Value(TRY((types::ValueImpl::template create<typename types::ValueImpl::JaktArray>(result_values,TRY((((*this).find_or_add_type_id(TRY((types::Type::template create<typename types::Type::GenericInstance>(array_struct_id,(TRY((Array<types::TypeId>::create_with({types::builtin( types::BuiltinType { typename types::BuiltinType::U8() } )})))))))))))))),call_span)) } ; goto __jakt_label_137;
 
 }
-__jakt_label_133:; __jakt_var_135.release_value(); }));
+__jakt_label_137:; __jakt_var_139.release_value(); }));
 }
 else if (__jakt_enum_value == String("read")) {
-return JaktInternal::ExplicitValue(({ Optional<interpreter::StatementResult> __jakt_var_136; {
+return JaktInternal::ExplicitValue(({ Optional<interpreter::StatementResult> __jakt_var_140; {
 String const path = JAKT_RESOLVE_EXPLICIT_VALUE_OR_CONTROL_FLOW_RETURN_ONLY(([&]() -> JaktInternal::ExplicitValueOrControlFlow<String, ErrorOr<interpreter::StatementResult>>{
 auto&& __jakt_match_variant = *(((this_argument.value())).impl);
 switch(__jakt_match_variant.index()) {
@@ -3446,7 +3432,7 @@ return Error::from_errno((infallible_integer_cast<i32>((InterpretError::InvalidT
 types::StructId const file_struct_id = TRY((((((*this).program))->find_struct_in_prelude(String("File")))));
 types::CheckedStruct const file_struct = ((((*this).program))->get_struct(file_struct_id));
 NonnullRefPtr<types::Scope> const scope = TRY((((((*this).program))->get_scope(((file_struct).scope_id)))));
-types::FunctionId const open_for_reading = (((((scope)->functions)).get(String("open_for_reading"))).value());
+types::FunctionId const open_for_reading = (((((((scope)->functions)).get(String("open_for_reading"))).value()))[static_cast<i64>(0LL)]);
 JAKT_RESOLVE_EXPLICIT_VALUE_OR_CONTROL_FLOW_RETURN_ONLY(([&]() -> JaktInternal::ExplicitValueOrControlFlow<void, ErrorOr<interpreter::StatementResult>>{
 auto&& __jakt_match_variant = *(((this_argument.value())).impl);
 switch(__jakt_match_variant.index()) {
@@ -3503,13 +3489,13 @@ size_t i = (_magic_value.value());
 }
 }
 
-__jakt_var_136 =  interpreter::StatementResult { typename interpreter::StatementResult::JustValue(types::Value(TRY((types::ValueImpl::template create<typename types::ValueImpl::USize>(bytes_read))),call_span)) } ; goto __jakt_label_134;
+__jakt_var_140 =  interpreter::StatementResult { typename interpreter::StatementResult::JustValue(types::Value(TRY((types::ValueImpl::template create<typename types::ValueImpl::USize>(bytes_read))),call_span)) } ; goto __jakt_label_138;
 
 }
-__jakt_label_134:; __jakt_var_136.release_value(); }));
+__jakt_label_138:; __jakt_var_140.release_value(); }));
 }
 else if (__jakt_enum_value == String("exists")) {
-return JaktInternal::ExplicitValue(({ Optional<interpreter::StatementResult> __jakt_var_137; {
+return JaktInternal::ExplicitValue(({ Optional<interpreter::StatementResult> __jakt_var_141; {
 String const requested_path = JAKT_RESOLVE_EXPLICIT_VALUE_OR_CONTROL_FLOW_RETURN_ONLY(([&]() -> JaktInternal::ExplicitValueOrControlFlow<String, ErrorOr<interpreter::StatementResult>>{
 auto&& __jakt_match_variant = *((((arguments)[static_cast<i64>(0LL)])).impl);
 switch(__jakt_match_variant.index()) {
@@ -3528,13 +3514,13 @@ return Error::from_errno((infallible_integer_cast<i32>((InterpretError::InvalidT
 }()
 ));
 path::Path const path = TRY((((TRY(((((TRY((((((((*this).program))->compiler))->get_file_path(((call_span).file_id))))).value())).parent())))).join(requested_path))));
-__jakt_var_137 =  interpreter::StatementResult { typename interpreter::StatementResult::JustValue(types::Value(TRY((types::ValueImpl::template create<typename types::ValueImpl::Bool>(((path).exists())))),call_span)) } ; goto __jakt_label_135;
+__jakt_var_141 =  interpreter::StatementResult { typename interpreter::StatementResult::JustValue(types::Value(TRY((types::ValueImpl::template create<typename types::ValueImpl::Bool>(((path).exists())))),call_span)) } ; goto __jakt_label_139;
 
 }
-__jakt_label_135:; __jakt_var_137.release_value(); }));
+__jakt_label_139:; __jakt_var_141.release_value(); }));
 }
 else if (__jakt_enum_value == String("write")) {
-return JaktInternal::ExplicitValue(({ Optional<interpreter::StatementResult> __jakt_var_138; {
+return JaktInternal::ExplicitValue(({ Optional<interpreter::StatementResult> __jakt_var_142; {
 String const path = JAKT_RESOLVE_EXPLICIT_VALUE_OR_CONTROL_FLOW_RETURN_ONLY(([&]() -> JaktInternal::ExplicitValueOrControlFlow<String, ErrorOr<interpreter::StatementResult>>{
 auto&& __jakt_match_variant = *(((this_argument.value())).impl);
 switch(__jakt_match_variant.index()) {
@@ -3569,7 +3555,7 @@ return Error::from_errno((infallible_integer_cast<i32>((InterpretError::InvalidT
 types::StructId const file_struct_id = TRY((((((*this).program))->find_struct_in_prelude(String("File")))));
 types::CheckedStruct const file_struct = ((((*this).program))->get_struct(file_struct_id));
 NonnullRefPtr<types::Scope> const scope = TRY((((((*this).program))->get_scope(((file_struct).scope_id)))));
-types::FunctionId const open_for_writing = (((((scope)->functions)).get(String("open_for_writing"))).value());
+types::FunctionId const open_for_writing = (((((((scope)->functions)).get(String("open_for_writing"))).value()))[static_cast<i64>(0LL)]);
 JAKT_RESOLVE_EXPLICIT_VALUE_OR_CONTROL_FLOW_RETURN_ONLY(([&]() -> JaktInternal::ExplicitValueOrControlFlow<void, ErrorOr<interpreter::StatementResult>>{
 auto&& __jakt_match_variant = *(((this_argument.value())).impl);
 switch(__jakt_match_variant.index()) {
@@ -3641,10 +3627,10 @@ utility::panic(String("expected byte"));
 }
 
 size_t const bytes_written = TRY((((file)->write(data))));
-__jakt_var_138 =  interpreter::StatementResult { typename interpreter::StatementResult::JustValue(types::Value(TRY((types::ValueImpl::template create<typename types::ValueImpl::USize>(bytes_written))),call_span)) } ; goto __jakt_label_136;
+__jakt_var_142 =  interpreter::StatementResult { typename interpreter::StatementResult::JustValue(types::Value(TRY((types::ValueImpl::template create<typename types::ValueImpl::USize>(bytes_written))),call_span)) } ; goto __jakt_label_140;
 
 }
-__jakt_label_136:; __jakt_var_138.release_value(); }));
+__jakt_label_140:; __jakt_var_142.release_value(); }));
 }
 else {
 {
@@ -3659,536 +3645,536 @@ else if (__jakt_enum_value == String("StringBuilder")) {
 return JaktInternal::ExplicitValue(JAKT_RESOLVE_EXPLICIT_VALUE_OR_CONTROL_FLOW_RETURN_ONLY(([&]() -> JaktInternal::ExplicitValueOrControlFlow<interpreter::StatementResult,ErrorOr<interpreter::StatementResult>>{
 auto __jakt_enum_value = (prelude_function);
 if (__jakt_enum_value == String("create")) {
-return JaktInternal::ExplicitValue(({ Optional<interpreter::StatementResult> __jakt_var_139; {
-types::StructId const string_builder_struct_id = TRY((((((*this).program))->find_struct_in_prelude(String("StringBuilder")))));
-__jakt_var_139 =  interpreter::StatementResult { typename interpreter::StatementResult::JustValue(types::Value(TRY((types::ValueImpl::template create<typename types::ValueImpl::Struct>((TRY((Array<types::Value>::create_with({types::Value(TRY((types::ValueImpl::template create<typename types::ValueImpl::JaktString>(String("")))),call_span)})))),string_builder_struct_id,JaktInternal::OptionalNone()))),call_span)) } ; goto __jakt_label_137;
-
-}
-__jakt_label_137:; __jakt_var_139.release_value(); }));
-}
-else if (__jakt_enum_value == String("append")) {
-return JaktInternal::ExplicitValue(({ Optional<interpreter::StatementResult> __jakt_var_140; {
-JaktInternal::Tuple<JaktInternal::Array<types::Value>,String> fields_current_string_ = JAKT_RESOLVE_EXPLICIT_VALUE_OR_CONTROL_FLOW_RETURN_ONLY(([&]() -> JaktInternal::ExplicitValueOrControlFlow<JaktInternal::Tuple<JaktInternal::Array<types::Value>,String>, ErrorOr<interpreter::StatementResult>>{
-auto&& __jakt_match_variant = *(((this_argument.value())).impl);
-switch(__jakt_match_variant.index()) {
-case 16: {
-auto&& __jakt_match_value = __jakt_match_variant.template get<types::ValueImpl::Struct>();JaktInternal::Array<types::Value> const& fields = __jakt_match_value.fields;
-return JaktInternal::ExplicitValue(JAKT_RESOLVE_EXPLICIT_VALUE_OR_CONTROL_FLOW_RETURN_ONLY(([&]() -> JaktInternal::ExplicitValueOrControlFlow<JaktInternal::Tuple<JaktInternal::Array<types::Value>,String>, ErrorOr<interpreter::StatementResult>>{
-auto&& __jakt_match_variant = *((((fields)[static_cast<i64>(0LL)])).impl);
-switch(__jakt_match_variant.index()) {
-case 13: {
-auto&& __jakt_match_value = __jakt_match_variant.template get<typename types::ValueImpl::JaktString>();
-String const& value = __jakt_match_value.value;
-return JaktInternal::ExplicitValue((Tuple{fields, value}));
-};/*case end*/
-default: {
-{
-utility::panic(String("Invalid use of prelude StringBuilder"));
-}
-};/*case end*/
-}/*switch end*/
-}()
-)));
-};/*case end*/
-default: {
-{
-TRY((((*this).error(TRY((String::formatted(String("Prelude function `StringBuilder::{}` expects a StringBuilder as its this argument"),prelude_function))),call_span))));
-return Error::from_errno((infallible_integer_cast<i32>((InterpretError::Unimplemented))));
-}
-};/*case end*/
-}/*switch end*/
-}()
-));
-JaktInternal::Array<types::Value> fields = ((fields_current_string_).get<0>());
-String current_string = ((fields_current_string_).get<1>());
-
-StringBuilder builder = TRY((StringBuilder::create()));
-TRY((((builder).append_string(current_string))));
-JAKT_RESOLVE_EXPLICIT_VALUE_OR_CONTROL_FLOW_RETURN_ONLY(([&]() -> JaktInternal::ExplicitValueOrControlFlow<void,ErrorOr<interpreter::StatementResult>>{
-auto __jakt_enum_value = (prelude_function);
-if (__jakt_enum_value == String("append")) {
-return (TRY((((builder).append(JAKT_RESOLVE_EXPLICIT_VALUE_OR_CONTROL_FLOW_RETURN_ONLY(([&]() -> JaktInternal::ExplicitValueOrControlFlow<u8, ErrorOr<interpreter::StatementResult>>{
-auto&& __jakt_match_variant = *((((arguments)[static_cast<i64>(0LL)])).impl);
-switch(__jakt_match_variant.index()) {
-case 2: {
-auto&& __jakt_match_value = __jakt_match_variant.template get<typename types::ValueImpl::U8>();
-u8 const& value = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(value);
-};/*case end*/
-default: {
-{
-TRY((((*this).error(TRY((String::formatted(String("Invalid use of StringBuilder::append({})"),((((arguments)[static_cast<i64>(0LL)])).impl)))),call_span))));
-return Error::from_errno((infallible_integer_cast<i32>((InterpretError::InvalidType))));
-}
-};/*case end*/
-}/*switch end*/
-}()
-))))))), JaktInternal::ExplicitValue<void>();
-}
-else if (__jakt_enum_value == String("append_string")) {
-return (TRY((((builder).append_string(JAKT_RESOLVE_EXPLICIT_VALUE_OR_CONTROL_FLOW_RETURN_ONLY(([&]() -> JaktInternal::ExplicitValueOrControlFlow<String, ErrorOr<interpreter::StatementResult>>{
-auto&& __jakt_match_variant = *((((arguments)[static_cast<i64>(0LL)])).impl);
-switch(__jakt_match_variant.index()) {
-case 13: {
-auto&& __jakt_match_value = __jakt_match_variant.template get<typename types::ValueImpl::JaktString>();
-String const& value = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(value);
-};/*case end*/
-default: {
-{
-TRY((((*this).error(String("Invalid use of StringBuilder::append_string()"),call_span))));
-return Error::from_errno((infallible_integer_cast<i32>((InterpretError::InvalidType))));
-}
-};/*case end*/
-}/*switch end*/
-}()
-))))))), JaktInternal::ExplicitValue<void>();
-}
-else if (__jakt_enum_value == String("append_escaped_for_json")) {
-return (TRY((((builder).append_escaped_for_json(JAKT_RESOLVE_EXPLICIT_VALUE_OR_CONTROL_FLOW_RETURN_ONLY(([&]() -> JaktInternal::ExplicitValueOrControlFlow<String, ErrorOr<interpreter::StatementResult>>{
-auto&& __jakt_match_variant = *((((arguments)[static_cast<i64>(0LL)])).impl);
-switch(__jakt_match_variant.index()) {
-case 13: {
-auto&& __jakt_match_value = __jakt_match_variant.template get<typename types::ValueImpl::JaktString>();
-String const& value = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(value);
-};/*case end*/
-default: {
-{
-TRY((((*this).error(String("Invalid use of StringBuilder::append_escaped_for_json()"),call_span))));
-return Error::from_errno((infallible_integer_cast<i32>((InterpretError::InvalidType))));
-}
-};/*case end*/
-}/*switch end*/
-}()
-))))))), JaktInternal::ExplicitValue<void>();
-}
-else if (__jakt_enum_value == String("append_code_point")) {
-return (TRY((((builder).append_code_point(JAKT_RESOLVE_EXPLICIT_VALUE_OR_CONTROL_FLOW_RETURN_ONLY(([&]() -> JaktInternal::ExplicitValueOrControlFlow<u32, ErrorOr<interpreter::StatementResult>>{
-auto&& __jakt_match_variant = *((((arguments)[static_cast<i64>(0LL)])).impl);
-switch(__jakt_match_variant.index()) {
-case 4: {
-auto&& __jakt_match_value = __jakt_match_variant.template get<typename types::ValueImpl::U32>();
-u32 const& value = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(value);
-};/*case end*/
-default: {
-{
-TRY((((*this).error(String("Invalid use of StringBuilder::append_code_point()"),call_span))));
-return Error::from_errno((infallible_integer_cast<i32>((InterpretError::InvalidType))));
-}
-};/*case end*/
-}/*switch end*/
-}()
-))))))), JaktInternal::ExplicitValue<void>();
-}
-else {
-{
-abort();
-}
-return JaktInternal::ExplicitValue<void>();
-}
-return JaktInternal::ExplicitValue<void>();
-}()))
-;
-(((fields)[static_cast<i64>(0LL)]) = types::Value(TRY((types::ValueImpl::template create<typename types::ValueImpl::JaktString>(TRY((((builder).to_string())))))),call_span));
-__jakt_var_140 =  interpreter::StatementResult { typename interpreter::StatementResult::JustValue(types::Value(TRY((types::ValueImpl::template create<typename types::ValueImpl::Void>())),call_span)) } ; goto __jakt_label_138;
-
-}
-__jakt_label_138:; __jakt_var_140.release_value(); }));
-}
-else if (__jakt_enum_value == String("append_string")) {
-return JaktInternal::ExplicitValue(({ Optional<interpreter::StatementResult> __jakt_var_141; {
-JaktInternal::Tuple<JaktInternal::Array<types::Value>,String> fields_current_string_ = JAKT_RESOLVE_EXPLICIT_VALUE_OR_CONTROL_FLOW_RETURN_ONLY(([&]() -> JaktInternal::ExplicitValueOrControlFlow<JaktInternal::Tuple<JaktInternal::Array<types::Value>,String>, ErrorOr<interpreter::StatementResult>>{
-auto&& __jakt_match_variant = *(((this_argument.value())).impl);
-switch(__jakt_match_variant.index()) {
-case 16: {
-auto&& __jakt_match_value = __jakt_match_variant.template get<types::ValueImpl::Struct>();JaktInternal::Array<types::Value> const& fields = __jakt_match_value.fields;
-return JaktInternal::ExplicitValue(JAKT_RESOLVE_EXPLICIT_VALUE_OR_CONTROL_FLOW_RETURN_ONLY(([&]() -> JaktInternal::ExplicitValueOrControlFlow<JaktInternal::Tuple<JaktInternal::Array<types::Value>,String>, ErrorOr<interpreter::StatementResult>>{
-auto&& __jakt_match_variant = *((((fields)[static_cast<i64>(0LL)])).impl);
-switch(__jakt_match_variant.index()) {
-case 13: {
-auto&& __jakt_match_value = __jakt_match_variant.template get<typename types::ValueImpl::JaktString>();
-String const& value = __jakt_match_value.value;
-return JaktInternal::ExplicitValue((Tuple{fields, value}));
-};/*case end*/
-default: {
-{
-utility::panic(String("Invalid use of prelude StringBuilder"));
-}
-};/*case end*/
-}/*switch end*/
-}()
-)));
-};/*case end*/
-default: {
-{
-TRY((((*this).error(TRY((String::formatted(String("Prelude function `StringBuilder::{}` expects a StringBuilder as its this argument"),prelude_function))),call_span))));
-return Error::from_errno((infallible_integer_cast<i32>((InterpretError::Unimplemented))));
-}
-};/*case end*/
-}/*switch end*/
-}()
-));
-JaktInternal::Array<types::Value> fields = ((fields_current_string_).get<0>());
-String current_string = ((fields_current_string_).get<1>());
-
-StringBuilder builder = TRY((StringBuilder::create()));
-TRY((((builder).append_string(current_string))));
-JAKT_RESOLVE_EXPLICIT_VALUE_OR_CONTROL_FLOW_RETURN_ONLY(([&]() -> JaktInternal::ExplicitValueOrControlFlow<void,ErrorOr<interpreter::StatementResult>>{
-auto __jakt_enum_value = (prelude_function);
-if (__jakt_enum_value == String("append")) {
-return (TRY((((builder).append(JAKT_RESOLVE_EXPLICIT_VALUE_OR_CONTROL_FLOW_RETURN_ONLY(([&]() -> JaktInternal::ExplicitValueOrControlFlow<u8, ErrorOr<interpreter::StatementResult>>{
-auto&& __jakt_match_variant = *((((arguments)[static_cast<i64>(0LL)])).impl);
-switch(__jakt_match_variant.index()) {
-case 2: {
-auto&& __jakt_match_value = __jakt_match_variant.template get<typename types::ValueImpl::U8>();
-u8 const& value = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(value);
-};/*case end*/
-default: {
-{
-TRY((((*this).error(TRY((String::formatted(String("Invalid use of StringBuilder::append({})"),((((arguments)[static_cast<i64>(0LL)])).impl)))),call_span))));
-return Error::from_errno((infallible_integer_cast<i32>((InterpretError::InvalidType))));
-}
-};/*case end*/
-}/*switch end*/
-}()
-))))))), JaktInternal::ExplicitValue<void>();
-}
-else if (__jakt_enum_value == String("append_string")) {
-return (TRY((((builder).append_string(JAKT_RESOLVE_EXPLICIT_VALUE_OR_CONTROL_FLOW_RETURN_ONLY(([&]() -> JaktInternal::ExplicitValueOrControlFlow<String, ErrorOr<interpreter::StatementResult>>{
-auto&& __jakt_match_variant = *((((arguments)[static_cast<i64>(0LL)])).impl);
-switch(__jakt_match_variant.index()) {
-case 13: {
-auto&& __jakt_match_value = __jakt_match_variant.template get<typename types::ValueImpl::JaktString>();
-String const& value = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(value);
-};/*case end*/
-default: {
-{
-TRY((((*this).error(String("Invalid use of StringBuilder::append_string()"),call_span))));
-return Error::from_errno((infallible_integer_cast<i32>((InterpretError::InvalidType))));
-}
-};/*case end*/
-}/*switch end*/
-}()
-))))))), JaktInternal::ExplicitValue<void>();
-}
-else if (__jakt_enum_value == String("append_escaped_for_json")) {
-return (TRY((((builder).append_escaped_for_json(JAKT_RESOLVE_EXPLICIT_VALUE_OR_CONTROL_FLOW_RETURN_ONLY(([&]() -> JaktInternal::ExplicitValueOrControlFlow<String, ErrorOr<interpreter::StatementResult>>{
-auto&& __jakt_match_variant = *((((arguments)[static_cast<i64>(0LL)])).impl);
-switch(__jakt_match_variant.index()) {
-case 13: {
-auto&& __jakt_match_value = __jakt_match_variant.template get<typename types::ValueImpl::JaktString>();
-String const& value = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(value);
-};/*case end*/
-default: {
-{
-TRY((((*this).error(String("Invalid use of StringBuilder::append_escaped_for_json()"),call_span))));
-return Error::from_errno((infallible_integer_cast<i32>((InterpretError::InvalidType))));
-}
-};/*case end*/
-}/*switch end*/
-}()
-))))))), JaktInternal::ExplicitValue<void>();
-}
-else if (__jakt_enum_value == String("append_code_point")) {
-return (TRY((((builder).append_code_point(JAKT_RESOLVE_EXPLICIT_VALUE_OR_CONTROL_FLOW_RETURN_ONLY(([&]() -> JaktInternal::ExplicitValueOrControlFlow<u32, ErrorOr<interpreter::StatementResult>>{
-auto&& __jakt_match_variant = *((((arguments)[static_cast<i64>(0LL)])).impl);
-switch(__jakt_match_variant.index()) {
-case 4: {
-auto&& __jakt_match_value = __jakt_match_variant.template get<typename types::ValueImpl::U32>();
-u32 const& value = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(value);
-};/*case end*/
-default: {
-{
-TRY((((*this).error(String("Invalid use of StringBuilder::append_code_point()"),call_span))));
-return Error::from_errno((infallible_integer_cast<i32>((InterpretError::InvalidType))));
-}
-};/*case end*/
-}/*switch end*/
-}()
-))))))), JaktInternal::ExplicitValue<void>();
-}
-else {
-{
-abort();
-}
-return JaktInternal::ExplicitValue<void>();
-}
-return JaktInternal::ExplicitValue<void>();
-}()))
-;
-(((fields)[static_cast<i64>(0LL)]) = types::Value(TRY((types::ValueImpl::template create<typename types::ValueImpl::JaktString>(TRY((((builder).to_string())))))),call_span));
-__jakt_var_141 =  interpreter::StatementResult { typename interpreter::StatementResult::JustValue(types::Value(TRY((types::ValueImpl::template create<typename types::ValueImpl::Void>())),call_span)) } ; goto __jakt_label_139;
-
-}
-__jakt_label_139:; __jakt_var_141.release_value(); }));
-}
-else if (__jakt_enum_value == String("append_code_point")) {
-return JaktInternal::ExplicitValue(({ Optional<interpreter::StatementResult> __jakt_var_142; {
-JaktInternal::Tuple<JaktInternal::Array<types::Value>,String> fields_current_string_ = JAKT_RESOLVE_EXPLICIT_VALUE_OR_CONTROL_FLOW_RETURN_ONLY(([&]() -> JaktInternal::ExplicitValueOrControlFlow<JaktInternal::Tuple<JaktInternal::Array<types::Value>,String>, ErrorOr<interpreter::StatementResult>>{
-auto&& __jakt_match_variant = *(((this_argument.value())).impl);
-switch(__jakt_match_variant.index()) {
-case 16: {
-auto&& __jakt_match_value = __jakt_match_variant.template get<types::ValueImpl::Struct>();JaktInternal::Array<types::Value> const& fields = __jakt_match_value.fields;
-return JaktInternal::ExplicitValue(JAKT_RESOLVE_EXPLICIT_VALUE_OR_CONTROL_FLOW_RETURN_ONLY(([&]() -> JaktInternal::ExplicitValueOrControlFlow<JaktInternal::Tuple<JaktInternal::Array<types::Value>,String>, ErrorOr<interpreter::StatementResult>>{
-auto&& __jakt_match_variant = *((((fields)[static_cast<i64>(0LL)])).impl);
-switch(__jakt_match_variant.index()) {
-case 13: {
-auto&& __jakt_match_value = __jakt_match_variant.template get<typename types::ValueImpl::JaktString>();
-String const& value = __jakt_match_value.value;
-return JaktInternal::ExplicitValue((Tuple{fields, value}));
-};/*case end*/
-default: {
-{
-utility::panic(String("Invalid use of prelude StringBuilder"));
-}
-};/*case end*/
-}/*switch end*/
-}()
-)));
-};/*case end*/
-default: {
-{
-TRY((((*this).error(TRY((String::formatted(String("Prelude function `StringBuilder::{}` expects a StringBuilder as its this argument"),prelude_function))),call_span))));
-return Error::from_errno((infallible_integer_cast<i32>((InterpretError::Unimplemented))));
-}
-};/*case end*/
-}/*switch end*/
-}()
-));
-JaktInternal::Array<types::Value> fields = ((fields_current_string_).get<0>());
-String current_string = ((fields_current_string_).get<1>());
-
-StringBuilder builder = TRY((StringBuilder::create()));
-TRY((((builder).append_string(current_string))));
-JAKT_RESOLVE_EXPLICIT_VALUE_OR_CONTROL_FLOW_RETURN_ONLY(([&]() -> JaktInternal::ExplicitValueOrControlFlow<void,ErrorOr<interpreter::StatementResult>>{
-auto __jakt_enum_value = (prelude_function);
-if (__jakt_enum_value == String("append")) {
-return (TRY((((builder).append(JAKT_RESOLVE_EXPLICIT_VALUE_OR_CONTROL_FLOW_RETURN_ONLY(([&]() -> JaktInternal::ExplicitValueOrControlFlow<u8, ErrorOr<interpreter::StatementResult>>{
-auto&& __jakt_match_variant = *((((arguments)[static_cast<i64>(0LL)])).impl);
-switch(__jakt_match_variant.index()) {
-case 2: {
-auto&& __jakt_match_value = __jakt_match_variant.template get<typename types::ValueImpl::U8>();
-u8 const& value = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(value);
-};/*case end*/
-default: {
-{
-TRY((((*this).error(TRY((String::formatted(String("Invalid use of StringBuilder::append({})"),((((arguments)[static_cast<i64>(0LL)])).impl)))),call_span))));
-return Error::from_errno((infallible_integer_cast<i32>((InterpretError::InvalidType))));
-}
-};/*case end*/
-}/*switch end*/
-}()
-))))))), JaktInternal::ExplicitValue<void>();
-}
-else if (__jakt_enum_value == String("append_string")) {
-return (TRY((((builder).append_string(JAKT_RESOLVE_EXPLICIT_VALUE_OR_CONTROL_FLOW_RETURN_ONLY(([&]() -> JaktInternal::ExplicitValueOrControlFlow<String, ErrorOr<interpreter::StatementResult>>{
-auto&& __jakt_match_variant = *((((arguments)[static_cast<i64>(0LL)])).impl);
-switch(__jakt_match_variant.index()) {
-case 13: {
-auto&& __jakt_match_value = __jakt_match_variant.template get<typename types::ValueImpl::JaktString>();
-String const& value = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(value);
-};/*case end*/
-default: {
-{
-TRY((((*this).error(String("Invalid use of StringBuilder::append_string()"),call_span))));
-return Error::from_errno((infallible_integer_cast<i32>((InterpretError::InvalidType))));
-}
-};/*case end*/
-}/*switch end*/
-}()
-))))))), JaktInternal::ExplicitValue<void>();
-}
-else if (__jakt_enum_value == String("append_escaped_for_json")) {
-return (TRY((((builder).append_escaped_for_json(JAKT_RESOLVE_EXPLICIT_VALUE_OR_CONTROL_FLOW_RETURN_ONLY(([&]() -> JaktInternal::ExplicitValueOrControlFlow<String, ErrorOr<interpreter::StatementResult>>{
-auto&& __jakt_match_variant = *((((arguments)[static_cast<i64>(0LL)])).impl);
-switch(__jakt_match_variant.index()) {
-case 13: {
-auto&& __jakt_match_value = __jakt_match_variant.template get<typename types::ValueImpl::JaktString>();
-String const& value = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(value);
-};/*case end*/
-default: {
-{
-TRY((((*this).error(String("Invalid use of StringBuilder::append_escaped_for_json()"),call_span))));
-return Error::from_errno((infallible_integer_cast<i32>((InterpretError::InvalidType))));
-}
-};/*case end*/
-}/*switch end*/
-}()
-))))))), JaktInternal::ExplicitValue<void>();
-}
-else if (__jakt_enum_value == String("append_code_point")) {
-return (TRY((((builder).append_code_point(JAKT_RESOLVE_EXPLICIT_VALUE_OR_CONTROL_FLOW_RETURN_ONLY(([&]() -> JaktInternal::ExplicitValueOrControlFlow<u32, ErrorOr<interpreter::StatementResult>>{
-auto&& __jakt_match_variant = *((((arguments)[static_cast<i64>(0LL)])).impl);
-switch(__jakt_match_variant.index()) {
-case 4: {
-auto&& __jakt_match_value = __jakt_match_variant.template get<typename types::ValueImpl::U32>();
-u32 const& value = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(value);
-};/*case end*/
-default: {
-{
-TRY((((*this).error(String("Invalid use of StringBuilder::append_code_point()"),call_span))));
-return Error::from_errno((infallible_integer_cast<i32>((InterpretError::InvalidType))));
-}
-};/*case end*/
-}/*switch end*/
-}()
-))))))), JaktInternal::ExplicitValue<void>();
-}
-else {
-{
-abort();
-}
-return JaktInternal::ExplicitValue<void>();
-}
-return JaktInternal::ExplicitValue<void>();
-}()))
-;
-(((fields)[static_cast<i64>(0LL)]) = types::Value(TRY((types::ValueImpl::template create<typename types::ValueImpl::JaktString>(TRY((((builder).to_string())))))),call_span));
-__jakt_var_142 =  interpreter::StatementResult { typename interpreter::StatementResult::JustValue(types::Value(TRY((types::ValueImpl::template create<typename types::ValueImpl::Void>())),call_span)) } ; goto __jakt_label_140;
-
-}
-__jakt_label_140:; __jakt_var_142.release_value(); }));
-}
-else if (__jakt_enum_value == String("append_escaped_for_json")) {
 return JaktInternal::ExplicitValue(({ Optional<interpreter::StatementResult> __jakt_var_143; {
-JaktInternal::Tuple<JaktInternal::Array<types::Value>,String> fields_current_string_ = JAKT_RESOLVE_EXPLICIT_VALUE_OR_CONTROL_FLOW_RETURN_ONLY(([&]() -> JaktInternal::ExplicitValueOrControlFlow<JaktInternal::Tuple<JaktInternal::Array<types::Value>,String>, ErrorOr<interpreter::StatementResult>>{
-auto&& __jakt_match_variant = *(((this_argument.value())).impl);
-switch(__jakt_match_variant.index()) {
-case 16: {
-auto&& __jakt_match_value = __jakt_match_variant.template get<types::ValueImpl::Struct>();JaktInternal::Array<types::Value> const& fields = __jakt_match_value.fields;
-return JaktInternal::ExplicitValue(JAKT_RESOLVE_EXPLICIT_VALUE_OR_CONTROL_FLOW_RETURN_ONLY(([&]() -> JaktInternal::ExplicitValueOrControlFlow<JaktInternal::Tuple<JaktInternal::Array<types::Value>,String>, ErrorOr<interpreter::StatementResult>>{
-auto&& __jakt_match_variant = *((((fields)[static_cast<i64>(0LL)])).impl);
-switch(__jakt_match_variant.index()) {
-case 13: {
-auto&& __jakt_match_value = __jakt_match_variant.template get<typename types::ValueImpl::JaktString>();
-String const& value = __jakt_match_value.value;
-return JaktInternal::ExplicitValue((Tuple{fields, value}));
-};/*case end*/
-default: {
-{
-utility::panic(String("Invalid use of prelude StringBuilder"));
-}
-};/*case end*/
-}/*switch end*/
-}()
-)));
-};/*case end*/
-default: {
-{
-TRY((((*this).error(TRY((String::formatted(String("Prelude function `StringBuilder::{}` expects a StringBuilder as its this argument"),prelude_function))),call_span))));
-return Error::from_errno((infallible_integer_cast<i32>((InterpretError::Unimplemented))));
-}
-};/*case end*/
-}/*switch end*/
-}()
-));
-JaktInternal::Array<types::Value> fields = ((fields_current_string_).get<0>());
-String current_string = ((fields_current_string_).get<1>());
-
-StringBuilder builder = TRY((StringBuilder::create()));
-TRY((((builder).append_string(current_string))));
-JAKT_RESOLVE_EXPLICIT_VALUE_OR_CONTROL_FLOW_RETURN_ONLY(([&]() -> JaktInternal::ExplicitValueOrControlFlow<void,ErrorOr<interpreter::StatementResult>>{
-auto __jakt_enum_value = (prelude_function);
-if (__jakt_enum_value == String("append")) {
-return (TRY((((builder).append(JAKT_RESOLVE_EXPLICIT_VALUE_OR_CONTROL_FLOW_RETURN_ONLY(([&]() -> JaktInternal::ExplicitValueOrControlFlow<u8, ErrorOr<interpreter::StatementResult>>{
-auto&& __jakt_match_variant = *((((arguments)[static_cast<i64>(0LL)])).impl);
-switch(__jakt_match_variant.index()) {
-case 2: {
-auto&& __jakt_match_value = __jakt_match_variant.template get<typename types::ValueImpl::U8>();
-u8 const& value = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(value);
-};/*case end*/
-default: {
-{
-TRY((((*this).error(TRY((String::formatted(String("Invalid use of StringBuilder::append({})"),((((arguments)[static_cast<i64>(0LL)])).impl)))),call_span))));
-return Error::from_errno((infallible_integer_cast<i32>((InterpretError::InvalidType))));
-}
-};/*case end*/
-}/*switch end*/
-}()
-))))))), JaktInternal::ExplicitValue<void>();
-}
-else if (__jakt_enum_value == String("append_string")) {
-return (TRY((((builder).append_string(JAKT_RESOLVE_EXPLICIT_VALUE_OR_CONTROL_FLOW_RETURN_ONLY(([&]() -> JaktInternal::ExplicitValueOrControlFlow<String, ErrorOr<interpreter::StatementResult>>{
-auto&& __jakt_match_variant = *((((arguments)[static_cast<i64>(0LL)])).impl);
-switch(__jakt_match_variant.index()) {
-case 13: {
-auto&& __jakt_match_value = __jakt_match_variant.template get<typename types::ValueImpl::JaktString>();
-String const& value = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(value);
-};/*case end*/
-default: {
-{
-TRY((((*this).error(String("Invalid use of StringBuilder::append_string()"),call_span))));
-return Error::from_errno((infallible_integer_cast<i32>((InterpretError::InvalidType))));
-}
-};/*case end*/
-}/*switch end*/
-}()
-))))))), JaktInternal::ExplicitValue<void>();
-}
-else if (__jakt_enum_value == String("append_escaped_for_json")) {
-return (TRY((((builder).append_escaped_for_json(JAKT_RESOLVE_EXPLICIT_VALUE_OR_CONTROL_FLOW_RETURN_ONLY(([&]() -> JaktInternal::ExplicitValueOrControlFlow<String, ErrorOr<interpreter::StatementResult>>{
-auto&& __jakt_match_variant = *((((arguments)[static_cast<i64>(0LL)])).impl);
-switch(__jakt_match_variant.index()) {
-case 13: {
-auto&& __jakt_match_value = __jakt_match_variant.template get<typename types::ValueImpl::JaktString>();
-String const& value = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(value);
-};/*case end*/
-default: {
-{
-TRY((((*this).error(String("Invalid use of StringBuilder::append_escaped_for_json()"),call_span))));
-return Error::from_errno((infallible_integer_cast<i32>((InterpretError::InvalidType))));
-}
-};/*case end*/
-}/*switch end*/
-}()
-))))))), JaktInternal::ExplicitValue<void>();
-}
-else if (__jakt_enum_value == String("append_code_point")) {
-return (TRY((((builder).append_code_point(JAKT_RESOLVE_EXPLICIT_VALUE_OR_CONTROL_FLOW_RETURN_ONLY(([&]() -> JaktInternal::ExplicitValueOrControlFlow<u32, ErrorOr<interpreter::StatementResult>>{
-auto&& __jakt_match_variant = *((((arguments)[static_cast<i64>(0LL)])).impl);
-switch(__jakt_match_variant.index()) {
-case 4: {
-auto&& __jakt_match_value = __jakt_match_variant.template get<typename types::ValueImpl::U32>();
-u32 const& value = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(value);
-};/*case end*/
-default: {
-{
-TRY((((*this).error(String("Invalid use of StringBuilder::append_code_point()"),call_span))));
-return Error::from_errno((infallible_integer_cast<i32>((InterpretError::InvalidType))));
-}
-};/*case end*/
-}/*switch end*/
-}()
-))))))), JaktInternal::ExplicitValue<void>();
-}
-else {
-{
-abort();
-}
-return JaktInternal::ExplicitValue<void>();
-}
-return JaktInternal::ExplicitValue<void>();
-}()))
-;
-(((fields)[static_cast<i64>(0LL)]) = types::Value(TRY((types::ValueImpl::template create<typename types::ValueImpl::JaktString>(TRY((((builder).to_string())))))),call_span));
-__jakt_var_143 =  interpreter::StatementResult { typename interpreter::StatementResult::JustValue(types::Value(TRY((types::ValueImpl::template create<typename types::ValueImpl::Void>())),call_span)) } ; goto __jakt_label_141;
+types::StructId const string_builder_struct_id = TRY((((((*this).program))->find_struct_in_prelude(String("StringBuilder")))));
+__jakt_var_143 =  interpreter::StatementResult { typename interpreter::StatementResult::JustValue(types::Value(TRY((types::ValueImpl::template create<typename types::ValueImpl::Struct>((TRY((Array<types::Value>::create_with({types::Value(TRY((types::ValueImpl::template create<typename types::ValueImpl::JaktString>(String("")))),call_span)})))),string_builder_struct_id,JaktInternal::OptionalNone()))),call_span)) } ; goto __jakt_label_141;
 
 }
 __jakt_label_141:; __jakt_var_143.release_value(); }));
+}
+else if (__jakt_enum_value == String("append")) {
+return JaktInternal::ExplicitValue(({ Optional<interpreter::StatementResult> __jakt_var_144; {
+JaktInternal::Tuple<JaktInternal::Array<types::Value>,String> fields_current_string_ = JAKT_RESOLVE_EXPLICIT_VALUE_OR_CONTROL_FLOW_RETURN_ONLY(([&]() -> JaktInternal::ExplicitValueOrControlFlow<JaktInternal::Tuple<JaktInternal::Array<types::Value>,String>, ErrorOr<interpreter::StatementResult>>{
+auto&& __jakt_match_variant = *(((this_argument.value())).impl);
+switch(__jakt_match_variant.index()) {
+case 16: {
+auto&& __jakt_match_value = __jakt_match_variant.template get<types::ValueImpl::Struct>();JaktInternal::Array<types::Value> const& fields = __jakt_match_value.fields;
+return JaktInternal::ExplicitValue(JAKT_RESOLVE_EXPLICIT_VALUE_OR_CONTROL_FLOW_RETURN_ONLY(([&]() -> JaktInternal::ExplicitValueOrControlFlow<JaktInternal::Tuple<JaktInternal::Array<types::Value>,String>, ErrorOr<interpreter::StatementResult>>{
+auto&& __jakt_match_variant = *((((fields)[static_cast<i64>(0LL)])).impl);
+switch(__jakt_match_variant.index()) {
+case 13: {
+auto&& __jakt_match_value = __jakt_match_variant.template get<typename types::ValueImpl::JaktString>();
+String const& value = __jakt_match_value.value;
+return JaktInternal::ExplicitValue((Tuple{fields, value}));
+};/*case end*/
+default: {
+{
+utility::panic(String("Invalid use of prelude StringBuilder"));
+}
+};/*case end*/
+}/*switch end*/
+}()
+)));
+};/*case end*/
+default: {
+{
+TRY((((*this).error(TRY((String::formatted(String("Prelude function `StringBuilder::{}` expects a StringBuilder as its this argument"),prelude_function))),call_span))));
+return Error::from_errno((infallible_integer_cast<i32>((InterpretError::Unimplemented))));
+}
+};/*case end*/
+}/*switch end*/
+}()
+));
+JaktInternal::Array<types::Value> fields = ((fields_current_string_).get<0>());
+String current_string = ((fields_current_string_).get<1>());
+
+StringBuilder builder = TRY((StringBuilder::create()));
+TRY((((builder).append_string(current_string))));
+JAKT_RESOLVE_EXPLICIT_VALUE_OR_CONTROL_FLOW_RETURN_ONLY(([&]() -> JaktInternal::ExplicitValueOrControlFlow<void,ErrorOr<interpreter::StatementResult>>{
+auto __jakt_enum_value = (prelude_function);
+if (__jakt_enum_value == String("append")) {
+return (TRY((((builder).append(JAKT_RESOLVE_EXPLICIT_VALUE_OR_CONTROL_FLOW_RETURN_ONLY(([&]() -> JaktInternal::ExplicitValueOrControlFlow<u8, ErrorOr<interpreter::StatementResult>>{
+auto&& __jakt_match_variant = *((((arguments)[static_cast<i64>(0LL)])).impl);
+switch(__jakt_match_variant.index()) {
+case 2: {
+auto&& __jakt_match_value = __jakt_match_variant.template get<typename types::ValueImpl::U8>();
+u8 const& value = __jakt_match_value.value;
+return JaktInternal::ExplicitValue(value);
+};/*case end*/
+default: {
+{
+TRY((((*this).error(TRY((String::formatted(String("Invalid use of StringBuilder::append({})"),((((arguments)[static_cast<i64>(0LL)])).impl)))),call_span))));
+return Error::from_errno((infallible_integer_cast<i32>((InterpretError::InvalidType))));
+}
+};/*case end*/
+}/*switch end*/
+}()
+))))))), JaktInternal::ExplicitValue<void>();
+}
+else if (__jakt_enum_value == String("append_string")) {
+return (TRY((((builder).append_string(JAKT_RESOLVE_EXPLICIT_VALUE_OR_CONTROL_FLOW_RETURN_ONLY(([&]() -> JaktInternal::ExplicitValueOrControlFlow<String, ErrorOr<interpreter::StatementResult>>{
+auto&& __jakt_match_variant = *((((arguments)[static_cast<i64>(0LL)])).impl);
+switch(__jakt_match_variant.index()) {
+case 13: {
+auto&& __jakt_match_value = __jakt_match_variant.template get<typename types::ValueImpl::JaktString>();
+String const& value = __jakt_match_value.value;
+return JaktInternal::ExplicitValue(value);
+};/*case end*/
+default: {
+{
+TRY((((*this).error(String("Invalid use of StringBuilder::append_string()"),call_span))));
+return Error::from_errno((infallible_integer_cast<i32>((InterpretError::InvalidType))));
+}
+};/*case end*/
+}/*switch end*/
+}()
+))))))), JaktInternal::ExplicitValue<void>();
+}
+else if (__jakt_enum_value == String("append_escaped_for_json")) {
+return (TRY((((builder).append_escaped_for_json(JAKT_RESOLVE_EXPLICIT_VALUE_OR_CONTROL_FLOW_RETURN_ONLY(([&]() -> JaktInternal::ExplicitValueOrControlFlow<String, ErrorOr<interpreter::StatementResult>>{
+auto&& __jakt_match_variant = *((((arguments)[static_cast<i64>(0LL)])).impl);
+switch(__jakt_match_variant.index()) {
+case 13: {
+auto&& __jakt_match_value = __jakt_match_variant.template get<typename types::ValueImpl::JaktString>();
+String const& value = __jakt_match_value.value;
+return JaktInternal::ExplicitValue(value);
+};/*case end*/
+default: {
+{
+TRY((((*this).error(String("Invalid use of StringBuilder::append_escaped_for_json()"),call_span))));
+return Error::from_errno((infallible_integer_cast<i32>((InterpretError::InvalidType))));
+}
+};/*case end*/
+}/*switch end*/
+}()
+))))))), JaktInternal::ExplicitValue<void>();
+}
+else if (__jakt_enum_value == String("append_code_point")) {
+return (TRY((((builder).append_code_point(JAKT_RESOLVE_EXPLICIT_VALUE_OR_CONTROL_FLOW_RETURN_ONLY(([&]() -> JaktInternal::ExplicitValueOrControlFlow<u32, ErrorOr<interpreter::StatementResult>>{
+auto&& __jakt_match_variant = *((((arguments)[static_cast<i64>(0LL)])).impl);
+switch(__jakt_match_variant.index()) {
+case 4: {
+auto&& __jakt_match_value = __jakt_match_variant.template get<typename types::ValueImpl::U32>();
+u32 const& value = __jakt_match_value.value;
+return JaktInternal::ExplicitValue(value);
+};/*case end*/
+default: {
+{
+TRY((((*this).error(String("Invalid use of StringBuilder::append_code_point()"),call_span))));
+return Error::from_errno((infallible_integer_cast<i32>((InterpretError::InvalidType))));
+}
+};/*case end*/
+}/*switch end*/
+}()
+))))))), JaktInternal::ExplicitValue<void>();
+}
+else {
+{
+abort();
+}
+return JaktInternal::ExplicitValue<void>();
+}
+return JaktInternal::ExplicitValue<void>();
+}()))
+;
+(((fields)[static_cast<i64>(0LL)]) = types::Value(TRY((types::ValueImpl::template create<typename types::ValueImpl::JaktString>(TRY((((builder).to_string())))))),call_span));
+__jakt_var_144 =  interpreter::StatementResult { typename interpreter::StatementResult::JustValue(types::Value(TRY((types::ValueImpl::template create<typename types::ValueImpl::Void>())),call_span)) } ; goto __jakt_label_142;
+
+}
+__jakt_label_142:; __jakt_var_144.release_value(); }));
+}
+else if (__jakt_enum_value == String("append_string")) {
+return JaktInternal::ExplicitValue(({ Optional<interpreter::StatementResult> __jakt_var_145; {
+JaktInternal::Tuple<JaktInternal::Array<types::Value>,String> fields_current_string_ = JAKT_RESOLVE_EXPLICIT_VALUE_OR_CONTROL_FLOW_RETURN_ONLY(([&]() -> JaktInternal::ExplicitValueOrControlFlow<JaktInternal::Tuple<JaktInternal::Array<types::Value>,String>, ErrorOr<interpreter::StatementResult>>{
+auto&& __jakt_match_variant = *(((this_argument.value())).impl);
+switch(__jakt_match_variant.index()) {
+case 16: {
+auto&& __jakt_match_value = __jakt_match_variant.template get<types::ValueImpl::Struct>();JaktInternal::Array<types::Value> const& fields = __jakt_match_value.fields;
+return JaktInternal::ExplicitValue(JAKT_RESOLVE_EXPLICIT_VALUE_OR_CONTROL_FLOW_RETURN_ONLY(([&]() -> JaktInternal::ExplicitValueOrControlFlow<JaktInternal::Tuple<JaktInternal::Array<types::Value>,String>, ErrorOr<interpreter::StatementResult>>{
+auto&& __jakt_match_variant = *((((fields)[static_cast<i64>(0LL)])).impl);
+switch(__jakt_match_variant.index()) {
+case 13: {
+auto&& __jakt_match_value = __jakt_match_variant.template get<typename types::ValueImpl::JaktString>();
+String const& value = __jakt_match_value.value;
+return JaktInternal::ExplicitValue((Tuple{fields, value}));
+};/*case end*/
+default: {
+{
+utility::panic(String("Invalid use of prelude StringBuilder"));
+}
+};/*case end*/
+}/*switch end*/
+}()
+)));
+};/*case end*/
+default: {
+{
+TRY((((*this).error(TRY((String::formatted(String("Prelude function `StringBuilder::{}` expects a StringBuilder as its this argument"),prelude_function))),call_span))));
+return Error::from_errno((infallible_integer_cast<i32>((InterpretError::Unimplemented))));
+}
+};/*case end*/
+}/*switch end*/
+}()
+));
+JaktInternal::Array<types::Value> fields = ((fields_current_string_).get<0>());
+String current_string = ((fields_current_string_).get<1>());
+
+StringBuilder builder = TRY((StringBuilder::create()));
+TRY((((builder).append_string(current_string))));
+JAKT_RESOLVE_EXPLICIT_VALUE_OR_CONTROL_FLOW_RETURN_ONLY(([&]() -> JaktInternal::ExplicitValueOrControlFlow<void,ErrorOr<interpreter::StatementResult>>{
+auto __jakt_enum_value = (prelude_function);
+if (__jakt_enum_value == String("append")) {
+return (TRY((((builder).append(JAKT_RESOLVE_EXPLICIT_VALUE_OR_CONTROL_FLOW_RETURN_ONLY(([&]() -> JaktInternal::ExplicitValueOrControlFlow<u8, ErrorOr<interpreter::StatementResult>>{
+auto&& __jakt_match_variant = *((((arguments)[static_cast<i64>(0LL)])).impl);
+switch(__jakt_match_variant.index()) {
+case 2: {
+auto&& __jakt_match_value = __jakt_match_variant.template get<typename types::ValueImpl::U8>();
+u8 const& value = __jakt_match_value.value;
+return JaktInternal::ExplicitValue(value);
+};/*case end*/
+default: {
+{
+TRY((((*this).error(TRY((String::formatted(String("Invalid use of StringBuilder::append({})"),((((arguments)[static_cast<i64>(0LL)])).impl)))),call_span))));
+return Error::from_errno((infallible_integer_cast<i32>((InterpretError::InvalidType))));
+}
+};/*case end*/
+}/*switch end*/
+}()
+))))))), JaktInternal::ExplicitValue<void>();
+}
+else if (__jakt_enum_value == String("append_string")) {
+return (TRY((((builder).append_string(JAKT_RESOLVE_EXPLICIT_VALUE_OR_CONTROL_FLOW_RETURN_ONLY(([&]() -> JaktInternal::ExplicitValueOrControlFlow<String, ErrorOr<interpreter::StatementResult>>{
+auto&& __jakt_match_variant = *((((arguments)[static_cast<i64>(0LL)])).impl);
+switch(__jakt_match_variant.index()) {
+case 13: {
+auto&& __jakt_match_value = __jakt_match_variant.template get<typename types::ValueImpl::JaktString>();
+String const& value = __jakt_match_value.value;
+return JaktInternal::ExplicitValue(value);
+};/*case end*/
+default: {
+{
+TRY((((*this).error(String("Invalid use of StringBuilder::append_string()"),call_span))));
+return Error::from_errno((infallible_integer_cast<i32>((InterpretError::InvalidType))));
+}
+};/*case end*/
+}/*switch end*/
+}()
+))))))), JaktInternal::ExplicitValue<void>();
+}
+else if (__jakt_enum_value == String("append_escaped_for_json")) {
+return (TRY((((builder).append_escaped_for_json(JAKT_RESOLVE_EXPLICIT_VALUE_OR_CONTROL_FLOW_RETURN_ONLY(([&]() -> JaktInternal::ExplicitValueOrControlFlow<String, ErrorOr<interpreter::StatementResult>>{
+auto&& __jakt_match_variant = *((((arguments)[static_cast<i64>(0LL)])).impl);
+switch(__jakt_match_variant.index()) {
+case 13: {
+auto&& __jakt_match_value = __jakt_match_variant.template get<typename types::ValueImpl::JaktString>();
+String const& value = __jakt_match_value.value;
+return JaktInternal::ExplicitValue(value);
+};/*case end*/
+default: {
+{
+TRY((((*this).error(String("Invalid use of StringBuilder::append_escaped_for_json()"),call_span))));
+return Error::from_errno((infallible_integer_cast<i32>((InterpretError::InvalidType))));
+}
+};/*case end*/
+}/*switch end*/
+}()
+))))))), JaktInternal::ExplicitValue<void>();
+}
+else if (__jakt_enum_value == String("append_code_point")) {
+return (TRY((((builder).append_code_point(JAKT_RESOLVE_EXPLICIT_VALUE_OR_CONTROL_FLOW_RETURN_ONLY(([&]() -> JaktInternal::ExplicitValueOrControlFlow<u32, ErrorOr<interpreter::StatementResult>>{
+auto&& __jakt_match_variant = *((((arguments)[static_cast<i64>(0LL)])).impl);
+switch(__jakt_match_variant.index()) {
+case 4: {
+auto&& __jakt_match_value = __jakt_match_variant.template get<typename types::ValueImpl::U32>();
+u32 const& value = __jakt_match_value.value;
+return JaktInternal::ExplicitValue(value);
+};/*case end*/
+default: {
+{
+TRY((((*this).error(String("Invalid use of StringBuilder::append_code_point()"),call_span))));
+return Error::from_errno((infallible_integer_cast<i32>((InterpretError::InvalidType))));
+}
+};/*case end*/
+}/*switch end*/
+}()
+))))))), JaktInternal::ExplicitValue<void>();
+}
+else {
+{
+abort();
+}
+return JaktInternal::ExplicitValue<void>();
+}
+return JaktInternal::ExplicitValue<void>();
+}()))
+;
+(((fields)[static_cast<i64>(0LL)]) = types::Value(TRY((types::ValueImpl::template create<typename types::ValueImpl::JaktString>(TRY((((builder).to_string())))))),call_span));
+__jakt_var_145 =  interpreter::StatementResult { typename interpreter::StatementResult::JustValue(types::Value(TRY((types::ValueImpl::template create<typename types::ValueImpl::Void>())),call_span)) } ; goto __jakt_label_143;
+
+}
+__jakt_label_143:; __jakt_var_145.release_value(); }));
+}
+else if (__jakt_enum_value == String("append_code_point")) {
+return JaktInternal::ExplicitValue(({ Optional<interpreter::StatementResult> __jakt_var_146; {
+JaktInternal::Tuple<JaktInternal::Array<types::Value>,String> fields_current_string_ = JAKT_RESOLVE_EXPLICIT_VALUE_OR_CONTROL_FLOW_RETURN_ONLY(([&]() -> JaktInternal::ExplicitValueOrControlFlow<JaktInternal::Tuple<JaktInternal::Array<types::Value>,String>, ErrorOr<interpreter::StatementResult>>{
+auto&& __jakt_match_variant = *(((this_argument.value())).impl);
+switch(__jakt_match_variant.index()) {
+case 16: {
+auto&& __jakt_match_value = __jakt_match_variant.template get<types::ValueImpl::Struct>();JaktInternal::Array<types::Value> const& fields = __jakt_match_value.fields;
+return JaktInternal::ExplicitValue(JAKT_RESOLVE_EXPLICIT_VALUE_OR_CONTROL_FLOW_RETURN_ONLY(([&]() -> JaktInternal::ExplicitValueOrControlFlow<JaktInternal::Tuple<JaktInternal::Array<types::Value>,String>, ErrorOr<interpreter::StatementResult>>{
+auto&& __jakt_match_variant = *((((fields)[static_cast<i64>(0LL)])).impl);
+switch(__jakt_match_variant.index()) {
+case 13: {
+auto&& __jakt_match_value = __jakt_match_variant.template get<typename types::ValueImpl::JaktString>();
+String const& value = __jakt_match_value.value;
+return JaktInternal::ExplicitValue((Tuple{fields, value}));
+};/*case end*/
+default: {
+{
+utility::panic(String("Invalid use of prelude StringBuilder"));
+}
+};/*case end*/
+}/*switch end*/
+}()
+)));
+};/*case end*/
+default: {
+{
+TRY((((*this).error(TRY((String::formatted(String("Prelude function `StringBuilder::{}` expects a StringBuilder as its this argument"),prelude_function))),call_span))));
+return Error::from_errno((infallible_integer_cast<i32>((InterpretError::Unimplemented))));
+}
+};/*case end*/
+}/*switch end*/
+}()
+));
+JaktInternal::Array<types::Value> fields = ((fields_current_string_).get<0>());
+String current_string = ((fields_current_string_).get<1>());
+
+StringBuilder builder = TRY((StringBuilder::create()));
+TRY((((builder).append_string(current_string))));
+JAKT_RESOLVE_EXPLICIT_VALUE_OR_CONTROL_FLOW_RETURN_ONLY(([&]() -> JaktInternal::ExplicitValueOrControlFlow<void,ErrorOr<interpreter::StatementResult>>{
+auto __jakt_enum_value = (prelude_function);
+if (__jakt_enum_value == String("append")) {
+return (TRY((((builder).append(JAKT_RESOLVE_EXPLICIT_VALUE_OR_CONTROL_FLOW_RETURN_ONLY(([&]() -> JaktInternal::ExplicitValueOrControlFlow<u8, ErrorOr<interpreter::StatementResult>>{
+auto&& __jakt_match_variant = *((((arguments)[static_cast<i64>(0LL)])).impl);
+switch(__jakt_match_variant.index()) {
+case 2: {
+auto&& __jakt_match_value = __jakt_match_variant.template get<typename types::ValueImpl::U8>();
+u8 const& value = __jakt_match_value.value;
+return JaktInternal::ExplicitValue(value);
+};/*case end*/
+default: {
+{
+TRY((((*this).error(TRY((String::formatted(String("Invalid use of StringBuilder::append({})"),((((arguments)[static_cast<i64>(0LL)])).impl)))),call_span))));
+return Error::from_errno((infallible_integer_cast<i32>((InterpretError::InvalidType))));
+}
+};/*case end*/
+}/*switch end*/
+}()
+))))))), JaktInternal::ExplicitValue<void>();
+}
+else if (__jakt_enum_value == String("append_string")) {
+return (TRY((((builder).append_string(JAKT_RESOLVE_EXPLICIT_VALUE_OR_CONTROL_FLOW_RETURN_ONLY(([&]() -> JaktInternal::ExplicitValueOrControlFlow<String, ErrorOr<interpreter::StatementResult>>{
+auto&& __jakt_match_variant = *((((arguments)[static_cast<i64>(0LL)])).impl);
+switch(__jakt_match_variant.index()) {
+case 13: {
+auto&& __jakt_match_value = __jakt_match_variant.template get<typename types::ValueImpl::JaktString>();
+String const& value = __jakt_match_value.value;
+return JaktInternal::ExplicitValue(value);
+};/*case end*/
+default: {
+{
+TRY((((*this).error(String("Invalid use of StringBuilder::append_string()"),call_span))));
+return Error::from_errno((infallible_integer_cast<i32>((InterpretError::InvalidType))));
+}
+};/*case end*/
+}/*switch end*/
+}()
+))))))), JaktInternal::ExplicitValue<void>();
+}
+else if (__jakt_enum_value == String("append_escaped_for_json")) {
+return (TRY((((builder).append_escaped_for_json(JAKT_RESOLVE_EXPLICIT_VALUE_OR_CONTROL_FLOW_RETURN_ONLY(([&]() -> JaktInternal::ExplicitValueOrControlFlow<String, ErrorOr<interpreter::StatementResult>>{
+auto&& __jakt_match_variant = *((((arguments)[static_cast<i64>(0LL)])).impl);
+switch(__jakt_match_variant.index()) {
+case 13: {
+auto&& __jakt_match_value = __jakt_match_variant.template get<typename types::ValueImpl::JaktString>();
+String const& value = __jakt_match_value.value;
+return JaktInternal::ExplicitValue(value);
+};/*case end*/
+default: {
+{
+TRY((((*this).error(String("Invalid use of StringBuilder::append_escaped_for_json()"),call_span))));
+return Error::from_errno((infallible_integer_cast<i32>((InterpretError::InvalidType))));
+}
+};/*case end*/
+}/*switch end*/
+}()
+))))))), JaktInternal::ExplicitValue<void>();
+}
+else if (__jakt_enum_value == String("append_code_point")) {
+return (TRY((((builder).append_code_point(JAKT_RESOLVE_EXPLICIT_VALUE_OR_CONTROL_FLOW_RETURN_ONLY(([&]() -> JaktInternal::ExplicitValueOrControlFlow<u32, ErrorOr<interpreter::StatementResult>>{
+auto&& __jakt_match_variant = *((((arguments)[static_cast<i64>(0LL)])).impl);
+switch(__jakt_match_variant.index()) {
+case 4: {
+auto&& __jakt_match_value = __jakt_match_variant.template get<typename types::ValueImpl::U32>();
+u32 const& value = __jakt_match_value.value;
+return JaktInternal::ExplicitValue(value);
+};/*case end*/
+default: {
+{
+TRY((((*this).error(String("Invalid use of StringBuilder::append_code_point()"),call_span))));
+return Error::from_errno((infallible_integer_cast<i32>((InterpretError::InvalidType))));
+}
+};/*case end*/
+}/*switch end*/
+}()
+))))))), JaktInternal::ExplicitValue<void>();
+}
+else {
+{
+abort();
+}
+return JaktInternal::ExplicitValue<void>();
+}
+return JaktInternal::ExplicitValue<void>();
+}()))
+;
+(((fields)[static_cast<i64>(0LL)]) = types::Value(TRY((types::ValueImpl::template create<typename types::ValueImpl::JaktString>(TRY((((builder).to_string())))))),call_span));
+__jakt_var_146 =  interpreter::StatementResult { typename interpreter::StatementResult::JustValue(types::Value(TRY((types::ValueImpl::template create<typename types::ValueImpl::Void>())),call_span)) } ; goto __jakt_label_144;
+
+}
+__jakt_label_144:; __jakt_var_146.release_value(); }));
+}
+else if (__jakt_enum_value == String("append_escaped_for_json")) {
+return JaktInternal::ExplicitValue(({ Optional<interpreter::StatementResult> __jakt_var_147; {
+JaktInternal::Tuple<JaktInternal::Array<types::Value>,String> fields_current_string_ = JAKT_RESOLVE_EXPLICIT_VALUE_OR_CONTROL_FLOW_RETURN_ONLY(([&]() -> JaktInternal::ExplicitValueOrControlFlow<JaktInternal::Tuple<JaktInternal::Array<types::Value>,String>, ErrorOr<interpreter::StatementResult>>{
+auto&& __jakt_match_variant = *(((this_argument.value())).impl);
+switch(__jakt_match_variant.index()) {
+case 16: {
+auto&& __jakt_match_value = __jakt_match_variant.template get<types::ValueImpl::Struct>();JaktInternal::Array<types::Value> const& fields = __jakt_match_value.fields;
+return JaktInternal::ExplicitValue(JAKT_RESOLVE_EXPLICIT_VALUE_OR_CONTROL_FLOW_RETURN_ONLY(([&]() -> JaktInternal::ExplicitValueOrControlFlow<JaktInternal::Tuple<JaktInternal::Array<types::Value>,String>, ErrorOr<interpreter::StatementResult>>{
+auto&& __jakt_match_variant = *((((fields)[static_cast<i64>(0LL)])).impl);
+switch(__jakt_match_variant.index()) {
+case 13: {
+auto&& __jakt_match_value = __jakt_match_variant.template get<typename types::ValueImpl::JaktString>();
+String const& value = __jakt_match_value.value;
+return JaktInternal::ExplicitValue((Tuple{fields, value}));
+};/*case end*/
+default: {
+{
+utility::panic(String("Invalid use of prelude StringBuilder"));
+}
+};/*case end*/
+}/*switch end*/
+}()
+)));
+};/*case end*/
+default: {
+{
+TRY((((*this).error(TRY((String::formatted(String("Prelude function `StringBuilder::{}` expects a StringBuilder as its this argument"),prelude_function))),call_span))));
+return Error::from_errno((infallible_integer_cast<i32>((InterpretError::Unimplemented))));
+}
+};/*case end*/
+}/*switch end*/
+}()
+));
+JaktInternal::Array<types::Value> fields = ((fields_current_string_).get<0>());
+String current_string = ((fields_current_string_).get<1>());
+
+StringBuilder builder = TRY((StringBuilder::create()));
+TRY((((builder).append_string(current_string))));
+JAKT_RESOLVE_EXPLICIT_VALUE_OR_CONTROL_FLOW_RETURN_ONLY(([&]() -> JaktInternal::ExplicitValueOrControlFlow<void,ErrorOr<interpreter::StatementResult>>{
+auto __jakt_enum_value = (prelude_function);
+if (__jakt_enum_value == String("append")) {
+return (TRY((((builder).append(JAKT_RESOLVE_EXPLICIT_VALUE_OR_CONTROL_FLOW_RETURN_ONLY(([&]() -> JaktInternal::ExplicitValueOrControlFlow<u8, ErrorOr<interpreter::StatementResult>>{
+auto&& __jakt_match_variant = *((((arguments)[static_cast<i64>(0LL)])).impl);
+switch(__jakt_match_variant.index()) {
+case 2: {
+auto&& __jakt_match_value = __jakt_match_variant.template get<typename types::ValueImpl::U8>();
+u8 const& value = __jakt_match_value.value;
+return JaktInternal::ExplicitValue(value);
+};/*case end*/
+default: {
+{
+TRY((((*this).error(TRY((String::formatted(String("Invalid use of StringBuilder::append({})"),((((arguments)[static_cast<i64>(0LL)])).impl)))),call_span))));
+return Error::from_errno((infallible_integer_cast<i32>((InterpretError::InvalidType))));
+}
+};/*case end*/
+}/*switch end*/
+}()
+))))))), JaktInternal::ExplicitValue<void>();
+}
+else if (__jakt_enum_value == String("append_string")) {
+return (TRY((((builder).append_string(JAKT_RESOLVE_EXPLICIT_VALUE_OR_CONTROL_FLOW_RETURN_ONLY(([&]() -> JaktInternal::ExplicitValueOrControlFlow<String, ErrorOr<interpreter::StatementResult>>{
+auto&& __jakt_match_variant = *((((arguments)[static_cast<i64>(0LL)])).impl);
+switch(__jakt_match_variant.index()) {
+case 13: {
+auto&& __jakt_match_value = __jakt_match_variant.template get<typename types::ValueImpl::JaktString>();
+String const& value = __jakt_match_value.value;
+return JaktInternal::ExplicitValue(value);
+};/*case end*/
+default: {
+{
+TRY((((*this).error(String("Invalid use of StringBuilder::append_string()"),call_span))));
+return Error::from_errno((infallible_integer_cast<i32>((InterpretError::InvalidType))));
+}
+};/*case end*/
+}/*switch end*/
+}()
+))))))), JaktInternal::ExplicitValue<void>();
+}
+else if (__jakt_enum_value == String("append_escaped_for_json")) {
+return (TRY((((builder).append_escaped_for_json(JAKT_RESOLVE_EXPLICIT_VALUE_OR_CONTROL_FLOW_RETURN_ONLY(([&]() -> JaktInternal::ExplicitValueOrControlFlow<String, ErrorOr<interpreter::StatementResult>>{
+auto&& __jakt_match_variant = *((((arguments)[static_cast<i64>(0LL)])).impl);
+switch(__jakt_match_variant.index()) {
+case 13: {
+auto&& __jakt_match_value = __jakt_match_variant.template get<typename types::ValueImpl::JaktString>();
+String const& value = __jakt_match_value.value;
+return JaktInternal::ExplicitValue(value);
+};/*case end*/
+default: {
+{
+TRY((((*this).error(String("Invalid use of StringBuilder::append_escaped_for_json()"),call_span))));
+return Error::from_errno((infallible_integer_cast<i32>((InterpretError::InvalidType))));
+}
+};/*case end*/
+}/*switch end*/
+}()
+))))))), JaktInternal::ExplicitValue<void>();
+}
+else if (__jakt_enum_value == String("append_code_point")) {
+return (TRY((((builder).append_code_point(JAKT_RESOLVE_EXPLICIT_VALUE_OR_CONTROL_FLOW_RETURN_ONLY(([&]() -> JaktInternal::ExplicitValueOrControlFlow<u32, ErrorOr<interpreter::StatementResult>>{
+auto&& __jakt_match_variant = *((((arguments)[static_cast<i64>(0LL)])).impl);
+switch(__jakt_match_variant.index()) {
+case 4: {
+auto&& __jakt_match_value = __jakt_match_variant.template get<typename types::ValueImpl::U32>();
+u32 const& value = __jakt_match_value.value;
+return JaktInternal::ExplicitValue(value);
+};/*case end*/
+default: {
+{
+TRY((((*this).error(String("Invalid use of StringBuilder::append_code_point()"),call_span))));
+return Error::from_errno((infallible_integer_cast<i32>((InterpretError::InvalidType))));
+}
+};/*case end*/
+}/*switch end*/
+}()
+))))))), JaktInternal::ExplicitValue<void>();
+}
+else {
+{
+abort();
+}
+return JaktInternal::ExplicitValue<void>();
+}
+return JaktInternal::ExplicitValue<void>();
+}()))
+;
+(((fields)[static_cast<i64>(0LL)]) = types::Value(TRY((types::ValueImpl::template create<typename types::ValueImpl::JaktString>(TRY((((builder).to_string())))))),call_span));
+__jakt_var_147 =  interpreter::StatementResult { typename interpreter::StatementResult::JustValue(types::Value(TRY((types::ValueImpl::template create<typename types::ValueImpl::Void>())),call_span)) } ; goto __jakt_label_145;
+
+}
+__jakt_label_145:; __jakt_var_147.release_value(); }));
 }
 else if (__jakt_enum_value == String("to_string")) {
 return JaktInternal::ExplicitValue(JAKT_RESOLVE_EXPLICIT_VALUE_OR_CONTROL_FLOW_RETURN_ONLY(([&]() -> JaktInternal::ExplicitValueOrControlFlow<interpreter::StatementResult, ErrorOr<interpreter::StatementResult>>{
@@ -4280,13 +4266,13 @@ auto&& __jakt_match_variant = *(((this_argument.value())).impl);
 switch(__jakt_match_variant.index()) {
 case 16: {
 auto&& __jakt_match_value = __jakt_match_variant.template get<types::ValueImpl::Struct>();JaktInternal::Array<types::Value> const& fields = __jakt_match_value.fields;
-return JaktInternal::ExplicitValue(({ Optional<interpreter::StatementResult> __jakt_var_144; {
+return JaktInternal::ExplicitValue(({ Optional<interpreter::StatementResult> __jakt_var_148; {
 JaktInternal::Array<types::Value> mutable_fields = fields;
 (((((mutable_fields)[static_cast<i64>(0LL)])).impl) = TRY((types::ValueImpl::template create<typename types::ValueImpl::JaktString>(String("")))));
-__jakt_var_144 =  interpreter::StatementResult { typename interpreter::StatementResult::JustValue(types::Value(TRY((types::ValueImpl::template create<typename types::ValueImpl::Void>())),call_span)) } ; goto __jakt_label_142;
+__jakt_var_148 =  interpreter::StatementResult { typename interpreter::StatementResult::JustValue(types::Value(TRY((types::ValueImpl::template create<typename types::ValueImpl::Void>())),call_span)) } ; goto __jakt_label_146;
 
 }
-__jakt_label_142:; __jakt_var_144.release_value(); }));
+__jakt_label_146:; __jakt_var_148.release_value(); }));
 };/*case end*/
 default: {
 {
@@ -4317,7 +4303,7 @@ switch(__jakt_match_variant.index()) {
 case 20: {
 auto&& __jakt_match_value = __jakt_match_variant.template get<types::ValueImpl::JaktDictionary>();JaktInternal::Array<types::Value> const& keys = __jakt_match_value.keys;
 JaktInternal::Array<types::Value> const& values = __jakt_match_value.values;
-return JaktInternal::ExplicitValue(({ Optional<interpreter::StatementResult> __jakt_var_145; {
+return JaktInternal::ExplicitValue(({ Optional<interpreter::StatementResult> __jakt_var_149; {
 JaktInternal::Optional<size_t> found_index = JaktInternal::OptionalNone();
 {
 JaktInternal::Range<size_t> _magic = (JaktInternal::Range<size_t>{static_cast<size_t>(static_cast<size_t>(0ULL)),static_cast<size_t>(((keys).size()))});
@@ -4337,7 +4323,7 @@ break;
 }
 }
 
-__jakt_var_145 =  interpreter::StatementResult { typename interpreter::StatementResult::JustValue(JAKT_RESOLVE_EXPLICIT_VALUE_OR_CONTROL_FLOW_RETURN_ONLY(([&]() -> JaktInternal::ExplicitValueOrControlFlow<types::Value,ErrorOr<interpreter::StatementResult>>{
+__jakt_var_149 =  interpreter::StatementResult { typename interpreter::StatementResult::JustValue(JAKT_RESOLVE_EXPLICIT_VALUE_OR_CONTROL_FLOW_RETURN_ONLY(([&]() -> JaktInternal::ExplicitValueOrControlFlow<types::Value,ErrorOr<interpreter::StatementResult>>{
 auto __jakt_enum_value = (((found_index).has_value()));
 if (__jakt_enum_value == true) {
 return JaktInternal::ExplicitValue(types::Value(TRY((types::ValueImpl::template create<typename types::ValueImpl::OptionalSome>(((values)[(found_index.value())])))),call_span));
@@ -4346,10 +4332,10 @@ else {
 return JaktInternal::ExplicitValue(types::Value(TRY((types::ValueImpl::template create<typename types::ValueImpl::OptionalNone>())),call_span));
 }
 }()))
-) } ; goto __jakt_label_143;
+) } ; goto __jakt_label_147;
 
 }
-__jakt_label_143:; __jakt_var_145.release_value(); }));
+__jakt_label_147:; __jakt_var_149.release_value(); }));
 };/*case end*/
 default: {
 {
@@ -4367,7 +4353,7 @@ switch(__jakt_match_variant.index()) {
 case 20: {
 auto&& __jakt_match_value = __jakt_match_variant.template get<types::ValueImpl::JaktDictionary>();JaktInternal::Array<types::Value> const& keys = __jakt_match_value.keys;
 JaktInternal::Array<types::Value> const& values = __jakt_match_value.values;
-return JaktInternal::ExplicitValue(({ Optional<interpreter::StatementResult> __jakt_var_146; {
+return JaktInternal::ExplicitValue(({ Optional<interpreter::StatementResult> __jakt_var_150; {
 JaktInternal::Optional<size_t> found_index = JaktInternal::OptionalNone();
 {
 JaktInternal::Range<size_t> _magic = (JaktInternal::Range<size_t>{static_cast<size_t>(static_cast<size_t>(0ULL)),static_cast<size_t>(((keys).size()))});
@@ -4397,10 +4383,10 @@ TRY((((mutable_keys).push(((arguments)[static_cast<i64>(0LL)])))));
 TRY((((mutable_values).push(((arguments)[static_cast<i64>(1LL)])))));
 }
 
-__jakt_var_146 =  interpreter::StatementResult { typename interpreter::StatementResult::JustValue(types::Value(TRY((types::ValueImpl::template create<typename types::ValueImpl::Void>())),call_span)) } ; goto __jakt_label_144;
+__jakt_var_150 =  interpreter::StatementResult { typename interpreter::StatementResult::JustValue(types::Value(TRY((types::ValueImpl::template create<typename types::ValueImpl::Void>())),call_span)) } ; goto __jakt_label_148;
 
 }
-__jakt_label_144:; __jakt_var_146.release_value(); }));
+__jakt_label_148:; __jakt_var_150.release_value(); }));
 };/*case end*/
 default: {
 {
@@ -4435,7 +4421,7 @@ auto&& __jakt_match_variant = *(((this_argument.value())).impl);
 switch(__jakt_match_variant.index()) {
 case 20: {
 auto&& __jakt_match_value = __jakt_match_variant.template get<types::ValueImpl::JaktDictionary>();JaktInternal::Array<types::Value> const& keys = __jakt_match_value.keys;
-return JaktInternal::ExplicitValue(({ Optional<interpreter::StatementResult> __jakt_var_147; {
+return JaktInternal::ExplicitValue(({ Optional<interpreter::StatementResult> __jakt_var_151; {
 bool found = false;
 {
 JaktInternal::Range<size_t> _magic = (JaktInternal::Range<size_t>{static_cast<size_t>(static_cast<size_t>(0ULL)),static_cast<size_t>(((keys).size()))});
@@ -4455,10 +4441,10 @@ break;
 }
 }
 
-__jakt_var_147 =  interpreter::StatementResult { typename interpreter::StatementResult::JustValue(types::Value(TRY((types::ValueImpl::template create<typename types::ValueImpl::Bool>(found))),call_span)) } ; goto __jakt_label_145;
+__jakt_var_151 =  interpreter::StatementResult { typename interpreter::StatementResult::JustValue(types::Value(TRY((types::ValueImpl::template create<typename types::ValueImpl::Bool>(found))),call_span)) } ; goto __jakt_label_149;
 
 }
-__jakt_label_145:; __jakt_var_147.release_value(); }));
+__jakt_label_149:; __jakt_var_151.release_value(); }));
 };/*case end*/
 default: {
 {
@@ -4476,7 +4462,7 @@ switch(__jakt_match_variant.index()) {
 case 20: {
 auto&& __jakt_match_value = __jakt_match_variant.template get<types::ValueImpl::JaktDictionary>();JaktInternal::Array<types::Value> const& keys = __jakt_match_value.keys;
 JaktInternal::Array<types::Value> const& values = __jakt_match_value.values;
-return JaktInternal::ExplicitValue(({ Optional<interpreter::StatementResult> __jakt_var_148; {
+return JaktInternal::ExplicitValue(({ Optional<interpreter::StatementResult> __jakt_var_152; {
 JaktInternal::Optional<size_t> found_index = JaktInternal::OptionalNone();
 {
 JaktInternal::Range<size_t> _magic = (JaktInternal::Range<size_t>{static_cast<size_t>(static_cast<size_t>(0ULL)),static_cast<size_t>(((keys).size()))});
@@ -4539,10 +4525,10 @@ TRY((((mutable_values).push(((values_without)[i])))));
 }
 
 }
-__jakt_var_148 =  interpreter::StatementResult { typename interpreter::StatementResult::JustValue(types::Value(TRY((types::ValueImpl::template create<typename types::ValueImpl::Bool>(((found_index).has_value())))),call_span)) } ; goto __jakt_label_146;
+__jakt_var_152 =  interpreter::StatementResult { typename interpreter::StatementResult::JustValue(types::Value(TRY((types::ValueImpl::template create<typename types::ValueImpl::Bool>(((found_index).has_value())))),call_span)) } ; goto __jakt_label_150;
 
 }
-__jakt_label_146:; __jakt_var_148.release_value(); }));
+__jakt_label_150:; __jakt_var_152.release_value(); }));
 };/*case end*/
 default: {
 {
@@ -4566,15 +4552,15 @@ switch(__jakt_match_variant.index()) {
 case 12: {
 auto&& __jakt_match_value = __jakt_match_variant.template get<typename types::ValueImpl::USize>();
 size_t const& capacity = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(({ Optional<interpreter::StatementResult> __jakt_var_149; {
+return JaktInternal::ExplicitValue(({ Optional<interpreter::StatementResult> __jakt_var_153; {
 JaktInternal::Array<types::Value> mutable_keys = keys;
 JaktInternal::Array<types::Value> mutable_values = values;
 TRY((((mutable_keys).ensure_capacity(capacity))));
 TRY((((mutable_values).ensure_capacity(capacity))));
-__jakt_var_149 =  interpreter::StatementResult { typename interpreter::StatementResult::JustValue(types::Value(TRY((types::ValueImpl::template create<typename types::ValueImpl::Void>())),call_span)) } ; goto __jakt_label_147;
+__jakt_var_153 =  interpreter::StatementResult { typename interpreter::StatementResult::JustValue(types::Value(TRY((types::ValueImpl::template create<typename types::ValueImpl::Void>())),call_span)) } ; goto __jakt_label_151;
 
 }
-__jakt_label_147:; __jakt_var_149.release_value(); }));
+__jakt_label_151:; __jakt_var_153.release_value(); }));
 };/*case end*/
 default: {
 {
@@ -4619,15 +4605,15 @@ switch(__jakt_match_variant.index()) {
 case 20: {
 auto&& __jakt_match_value = __jakt_match_variant.template get<types::ValueImpl::JaktDictionary>();JaktInternal::Array<types::Value> const& keys = __jakt_match_value.keys;
 JaktInternal::Array<types::Value> const& values = __jakt_match_value.values;
-return JaktInternal::ExplicitValue(({ Optional<interpreter::StatementResult> __jakt_var_150; {
+return JaktInternal::ExplicitValue(({ Optional<interpreter::StatementResult> __jakt_var_154; {
 JaktInternal::Array<types::Value> mutable_keys = keys;
 JaktInternal::Array<types::Value> mutable_values = values;
 ((mutable_keys).shrink(static_cast<size_t>(0ULL)));
 ((mutable_values).shrink(static_cast<size_t>(0ULL)));
-__jakt_var_150 =  interpreter::StatementResult { typename interpreter::StatementResult::JustValue(types::Value(TRY((types::ValueImpl::template create<typename types::ValueImpl::Void>())),call_span)) } ; goto __jakt_label_148;
+__jakt_var_154 =  interpreter::StatementResult { typename interpreter::StatementResult::JustValue(types::Value(TRY((types::ValueImpl::template create<typename types::ValueImpl::Void>())),call_span)) } ; goto __jakt_label_152;
 
 }
-__jakt_label_148:; __jakt_var_150.release_value(); }));
+__jakt_label_152:; __jakt_var_154.release_value(); }));
 };/*case end*/
 default: {
 {
@@ -4662,7 +4648,7 @@ switch(__jakt_match_variant.index()) {
 case 20: {
 auto&& __jakt_match_value = __jakt_match_variant.template get<types::ValueImpl::JaktDictionary>();JaktInternal::Array<types::Value> const& keys = __jakt_match_value.keys;
 types::TypeId const& type_id = __jakt_match_value.type_id;
-return JaktInternal::ExplicitValue(({ Optional<interpreter::StatementResult> __jakt_var_151; {
+return JaktInternal::ExplicitValue(({ Optional<interpreter::StatementResult> __jakt_var_155; {
 JaktInternal::Array<types::TypeId> const generics = JAKT_RESOLVE_EXPLICIT_VALUE_OR_CONTROL_FLOW_RETURN_ONLY(([&]() -> JaktInternal::ExplicitValueOrControlFlow<JaktInternal::Array<types::TypeId>, ErrorOr<interpreter::StatementResult>>{
 auto&& __jakt_match_variant = *((((*this).program))->get_type(type_id));
 switch(__jakt_match_variant.index()) {
@@ -4678,16 +4664,16 @@ utility::panic(String("expected generic instance"));
 }/*switch end*/
 }()
 ));
-__jakt_var_151 = JAKT_RESOLVE_EXPLICIT_VALUE_OR_CONTROL_FLOW_RETURN_ONLY(([&]() -> JaktInternal::ExplicitValueOrControlFlow<interpreter::StatementResult,ErrorOr<interpreter::StatementResult>>{
+__jakt_var_155 = JAKT_RESOLVE_EXPLICIT_VALUE_OR_CONTROL_FLOW_RETURN_ONLY(([&]() -> JaktInternal::ExplicitValueOrControlFlow<interpreter::StatementResult,ErrorOr<interpreter::StatementResult>>{
 auto __jakt_enum_value = ((((generics).size()) == static_cast<size_t>(2ULL)));
 if (__jakt_enum_value == true) {
-return JaktInternal::ExplicitValue(({ Optional<interpreter::StatementResult> __jakt_var_152; {
+return JaktInternal::ExplicitValue(({ Optional<interpreter::StatementResult> __jakt_var_156; {
 types::StructId const array_struct_id = TRY((((((*this).program))->find_struct_in_prelude(String("Array")))));
 types::TypeId const type_id = TRY((((*this).find_or_add_type_id(TRY((types::Type::template create<typename types::Type::GenericInstance>(array_struct_id,(TRY((Array<types::TypeId>::create_with({((generics)[static_cast<i64>(0LL)])})))))))))));
-__jakt_var_152 =  interpreter::StatementResult { typename interpreter::StatementResult::JustValue(types::Value(TRY((types::ValueImpl::template create<typename types::ValueImpl::JaktArray>(keys,type_id))),call_span)) } ; goto __jakt_label_150;
+__jakt_var_156 =  interpreter::StatementResult { typename interpreter::StatementResult::JustValue(types::Value(TRY((types::ValueImpl::template create<typename types::ValueImpl::JaktArray>(keys,type_id))),call_span)) } ; goto __jakt_label_154;
 
 }
-__jakt_label_150:; __jakt_var_152.release_value(); }));
+__jakt_label_154:; __jakt_var_156.release_value(); }));
 }
 else {
 {
@@ -4695,10 +4681,10 @@ utility::panic(String("dictionary should have 2 generic args. one for keys, one 
 }
 }
 }()))
-; goto __jakt_label_149;
+; goto __jakt_label_153;
 
 }
-__jakt_label_149:; __jakt_var_151.release_value(); }));
+__jakt_label_153:; __jakt_var_155.release_value(); }));
 };/*case end*/
 default: {
 {
@@ -4714,12 +4700,12 @@ return JaktInternal::ExplicitValue(JAKT_RESOLVE_EXPLICIT_VALUE_OR_CONTROL_FLOW_R
 auto&& __jakt_match_variant = *(((this_argument.value())).impl);
 switch(__jakt_match_variant.index()) {
 case 20: {
-auto&& __jakt_match_value = __jakt_match_variant.template get<types::ValueImpl::JaktDictionary>();return JaktInternal::ExplicitValue(({ Optional<interpreter::StatementResult> __jakt_var_153; {
+auto&& __jakt_match_value = __jakt_match_variant.template get<types::ValueImpl::JaktDictionary>();return JaktInternal::ExplicitValue(({ Optional<interpreter::StatementResult> __jakt_var_157; {
 types::StructId const struct_id = TRY((((((*this).program))->find_struct_in_prelude(String("DictionaryIterator")))));
-__jakt_var_153 =  interpreter::StatementResult { typename interpreter::StatementResult::JustValue(types::Value(TRY((types::ValueImpl::template create<typename types::ValueImpl::Struct>((TRY((Array<types::Value>::create_with({(this_argument.value()), types::Value(TRY((types::ValueImpl::template create<typename types::ValueImpl::USize>(static_cast<size_t>(0ULL)))),call_span)})))),struct_id,JaktInternal::OptionalNone()))),call_span)) } ; goto __jakt_label_151;
+__jakt_var_157 =  interpreter::StatementResult { typename interpreter::StatementResult::JustValue(types::Value(TRY((types::ValueImpl::template create<typename types::ValueImpl::Struct>((TRY((Array<types::Value>::create_with({(this_argument.value()), types::Value(TRY((types::ValueImpl::template create<typename types::ValueImpl::USize>(static_cast<size_t>(0ULL)))),call_span)})))),struct_id,JaktInternal::OptionalNone()))),call_span)) } ; goto __jakt_label_155;
 
 }
-__jakt_label_151:; __jakt_var_153.release_value(); }));
+__jakt_label_155:; __jakt_var_157.release_value(); }));
 };/*case end*/
 default: {
 {
@@ -4747,12 +4733,12 @@ return JaktInternal::ExplicitValue(JAKT_RESOLVE_EXPLICIT_VALUE_OR_CONTROL_FLOW_R
 auto&& __jakt_match_variant = *(((this_argument.value())).impl);
 switch(__jakt_match_variant.index()) {
 case 19: {
-auto&& __jakt_match_value = __jakt_match_variant.template get<types::ValueImpl::JaktArray>();return JaktInternal::ExplicitValue(({ Optional<interpreter::StatementResult> __jakt_var_154; {
+auto&& __jakt_match_value = __jakt_match_variant.template get<types::ValueImpl::JaktArray>();return JaktInternal::ExplicitValue(({ Optional<interpreter::StatementResult> __jakt_var_158; {
 types::StructId const struct_id = TRY((((((*this).program))->find_struct_in_prelude(String("ArrayIterator")))));
-__jakt_var_154 =  interpreter::StatementResult { typename interpreter::StatementResult::JustValue(types::Value(TRY((types::ValueImpl::template create<typename types::ValueImpl::Struct>((TRY((Array<types::Value>::create_with({(this_argument.value()), types::Value(TRY((types::ValueImpl::template create<typename types::ValueImpl::USize>(static_cast<size_t>(0ULL)))),call_span)})))),struct_id,JaktInternal::OptionalNone()))),call_span)) } ; goto __jakt_label_152;
+__jakt_var_158 =  interpreter::StatementResult { typename interpreter::StatementResult::JustValue(types::Value(TRY((types::ValueImpl::template create<typename types::ValueImpl::Struct>((TRY((Array<types::Value>::create_with({(this_argument.value()), types::Value(TRY((types::ValueImpl::template create<typename types::ValueImpl::USize>(static_cast<size_t>(0ULL)))),call_span)})))),struct_id,JaktInternal::OptionalNone()))),call_span)) } ; goto __jakt_label_156;
 
 }
-__jakt_label_152:; __jakt_var_154.release_value(); }));
+__jakt_label_156:; __jakt_var_158.release_value(); }));
 };/*case end*/
 default: {
 {
@@ -4769,11 +4755,11 @@ auto&& __jakt_match_variant = *(((this_argument.value())).impl);
 switch(__jakt_match_variant.index()) {
 case 19: {
 auto&& __jakt_match_value = __jakt_match_variant.template get<types::ValueImpl::JaktArray>();JaktInternal::Array<types::Value> const& values = __jakt_match_value.values;
-return JaktInternal::ExplicitValue(({ Optional<interpreter::StatementResult> __jakt_var_155; {
-__jakt_var_155 =  interpreter::StatementResult { typename interpreter::StatementResult::JustValue(types::Value(TRY((types::ValueImpl::template create<typename types::ValueImpl::USize>(((values).size())))),call_span)) } ; goto __jakt_label_153;
+return JaktInternal::ExplicitValue(({ Optional<interpreter::StatementResult> __jakt_var_159; {
+__jakt_var_159 =  interpreter::StatementResult { typename interpreter::StatementResult::JustValue(types::Value(TRY((types::ValueImpl::template create<typename types::ValueImpl::USize>(((values).size())))),call_span)) } ; goto __jakt_label_157;
 
 }
-__jakt_label_153:; __jakt_var_155.release_value(); }));
+__jakt_label_157:; __jakt_var_159.release_value(); }));
 };/*case end*/
 default: {
 {
@@ -4790,17 +4776,69 @@ auto&& __jakt_match_variant = *(((this_argument.value())).impl);
 switch(__jakt_match_variant.index()) {
 case 19: {
 auto&& __jakt_match_value = __jakt_match_variant.template get<types::ValueImpl::JaktArray>();JaktInternal::Array<types::Value> const& values = __jakt_match_value.values;
-return JaktInternal::ExplicitValue(({ Optional<interpreter::StatementResult> __jakt_var_156; {
+return JaktInternal::ExplicitValue(({ Optional<interpreter::StatementResult> __jakt_var_160; {
 JaktInternal::Array<types::Value> mutable_values = values;
 TRY((((mutable_values).push(((arguments)[static_cast<i64>(0LL)])))));
-__jakt_var_156 =  interpreter::StatementResult { typename interpreter::StatementResult::JustValue(types::Value(TRY((types::ValueImpl::template create<typename types::ValueImpl::Void>())),call_span)) } ; goto __jakt_label_154;
+__jakt_var_160 =  interpreter::StatementResult { typename interpreter::StatementResult::JustValue(types::Value(TRY((types::ValueImpl::template create<typename types::ValueImpl::Void>())),call_span)) } ; goto __jakt_label_158;
 
 }
-__jakt_label_154:; __jakt_var_156.release_value(); }));
+__jakt_label_158:; __jakt_var_160.release_value(); }));
 };/*case end*/
 default: {
 {
 utility::panic(String("Invalid use of Array::push()"));
+}
+};/*case end*/
+}/*switch end*/
+}()
+)));
+}
+else if (__jakt_enum_value == String("push_values")) {
+return JaktInternal::ExplicitValue(JAKT_RESOLVE_EXPLICIT_VALUE_OR_CONTROL_FLOW_RETURN_ONLY(([&]() -> JaktInternal::ExplicitValueOrControlFlow<interpreter::StatementResult, ErrorOr<interpreter::StatementResult>>{
+auto&& __jakt_match_variant = *(((this_argument.value())).impl);
+switch(__jakt_match_variant.index()) {
+case 19: {
+auto&& __jakt_match_value = __jakt_match_variant.template get<types::ValueImpl::JaktArray>();JaktInternal::Array<types::Value> const& values = __jakt_match_value.values;
+return JaktInternal::ExplicitValue(({ Optional<interpreter::StatementResult> __jakt_var_161; {
+JaktInternal::Array<types::Value> mutable_values = values;
+JAKT_RESOLVE_EXPLICIT_VALUE_OR_CONTROL_FLOW_RETURN_ONLY(([&]() -> JaktInternal::ExplicitValueOrControlFlow<void, ErrorOr<interpreter::StatementResult>>{
+auto&& __jakt_match_variant = *((((arguments)[static_cast<i64>(0LL)])).impl);
+switch(__jakt_match_variant.index()) {
+case 19: {
+auto&& __jakt_match_value = __jakt_match_variant.template get<types::ValueImpl::JaktArray>();JaktInternal::Array<types::Value> const& values = __jakt_match_value.values;
+{
+{
+JaktInternal::ArrayIterator<types::Value> _magic = ((values).iterator());
+for (;;){
+JaktInternal::Optional<types::Value> _magic_value = ((_magic).next());
+if ((!(((_magic_value).has_value())))){
+break;
+}
+types::Value value = (_magic_value.value());
+{
+TRY((((mutable_values).push(value))));
+}
+
+}
+}
+
+}
+return JaktInternal::ExplicitValue<void>();
+};/*case end*/
+default: {
+return (TRY((((*this).error(String("Only argument to push_values needs to be another Array"),call_span))))), JaktInternal::ExplicitValue<void>();
+};/*case end*/
+}/*switch end*/
+}()
+));
+__jakt_var_161 =  interpreter::StatementResult { typename interpreter::StatementResult::JustValue(types::Value(TRY((types::ValueImpl::template create<typename types::ValueImpl::Void>())),call_span)) } ; goto __jakt_label_159;
+
+}
+__jakt_label_159:; __jakt_var_161.release_value(); }));
+};/*case end*/
+default: {
+{
+utility::panic(String("Invalid use of Array::push_values()"));
 }
 };/*case end*/
 }/*switch end*/
@@ -4813,10 +4851,10 @@ auto&& __jakt_match_variant = *(((this_argument.value())).impl);
 switch(__jakt_match_variant.index()) {
 case 19: {
 auto&& __jakt_match_value = __jakt_match_variant.template get<types::ValueImpl::JaktArray>();JaktInternal::Array<types::Value> const& values = __jakt_match_value.values;
-return JaktInternal::ExplicitValue(({ Optional<interpreter::StatementResult> __jakt_var_157; {
+return JaktInternal::ExplicitValue(({ Optional<interpreter::StatementResult> __jakt_var_162; {
 JaktInternal::Array<types::Value> mutable_values = values;
 JaktInternal::Optional<types::Value> const value = ((mutable_values).pop());
-__jakt_var_157 = JAKT_RESOLVE_EXPLICIT_VALUE_OR_CONTROL_FLOW_RETURN_ONLY(([&]() -> JaktInternal::ExplicitValueOrControlFlow<interpreter::StatementResult,ErrorOr<interpreter::StatementResult>>{
+__jakt_var_162 = JAKT_RESOLVE_EXPLICIT_VALUE_OR_CONTROL_FLOW_RETURN_ONLY(([&]() -> JaktInternal::ExplicitValueOrControlFlow<interpreter::StatementResult,ErrorOr<interpreter::StatementResult>>{
 auto __jakt_enum_value = (((value).has_value()));
 if (__jakt_enum_value == true) {
 return JaktInternal::ExplicitValue( interpreter::StatementResult { typename interpreter::StatementResult::JustValue((value.value())) } );
@@ -4825,10 +4863,10 @@ else {
 return JaktInternal::ExplicitValue( interpreter::StatementResult { typename interpreter::StatementResult::JustValue(types::Value(TRY((types::ValueImpl::template create<typename types::ValueImpl::OptionalNone>())),call_span)) } );
 }
 }()))
-; goto __jakt_label_155;
+; goto __jakt_label_160;
 
 }
-__jakt_label_155:; __jakt_var_157.release_value(); }));
+__jakt_label_160:; __jakt_var_162.release_value(); }));
 };/*case end*/
 default: {
 {
@@ -4845,10 +4883,10 @@ auto&& __jakt_match_variant = *(((this_argument.value())).impl);
 switch(__jakt_match_variant.index()) {
 case 19: {
 auto&& __jakt_match_value = __jakt_match_variant.template get<types::ValueImpl::JaktArray>();JaktInternal::Array<types::Value> const& values = __jakt_match_value.values;
-return JaktInternal::ExplicitValue(({ Optional<interpreter::StatementResult> __jakt_var_158; {
+return JaktInternal::ExplicitValue(({ Optional<interpreter::StatementResult> __jakt_var_163; {
 JaktInternal::Array<types::Value> mutable_values = values;
 JaktInternal::Optional<types::Value> const value = ((mutable_values).first());
-__jakt_var_158 = JAKT_RESOLVE_EXPLICIT_VALUE_OR_CONTROL_FLOW_RETURN_ONLY(([&]() -> JaktInternal::ExplicitValueOrControlFlow<interpreter::StatementResult,ErrorOr<interpreter::StatementResult>>{
+__jakt_var_163 = JAKT_RESOLVE_EXPLICIT_VALUE_OR_CONTROL_FLOW_RETURN_ONLY(([&]() -> JaktInternal::ExplicitValueOrControlFlow<interpreter::StatementResult,ErrorOr<interpreter::StatementResult>>{
 auto __jakt_enum_value = (((value).has_value()));
 if (__jakt_enum_value == true) {
 return JaktInternal::ExplicitValue( interpreter::StatementResult { typename interpreter::StatementResult::JustValue((value.value())) } );
@@ -4857,10 +4895,10 @@ else {
 return JaktInternal::ExplicitValue( interpreter::StatementResult { typename interpreter::StatementResult::JustValue(types::Value(TRY((types::ValueImpl::template create<typename types::ValueImpl::OptionalNone>())),call_span)) } );
 }
 }()))
-; goto __jakt_label_156;
+; goto __jakt_label_161;
 
 }
-__jakt_label_156:; __jakt_var_158.release_value(); }));
+__jakt_label_161:; __jakt_var_163.release_value(); }));
 };/*case end*/
 default: {
 {
@@ -4877,10 +4915,10 @@ auto&& __jakt_match_variant = *(((this_argument.value())).impl);
 switch(__jakt_match_variant.index()) {
 case 19: {
 auto&& __jakt_match_value = __jakt_match_variant.template get<types::ValueImpl::JaktArray>();JaktInternal::Array<types::Value> const& values = __jakt_match_value.values;
-return JaktInternal::ExplicitValue(({ Optional<interpreter::StatementResult> __jakt_var_159; {
+return JaktInternal::ExplicitValue(({ Optional<interpreter::StatementResult> __jakt_var_164; {
 JaktInternal::Array<types::Value> mutable_values = values;
 JaktInternal::Optional<types::Value> const value = ((mutable_values).last());
-__jakt_var_159 = JAKT_RESOLVE_EXPLICIT_VALUE_OR_CONTROL_FLOW_RETURN_ONLY(([&]() -> JaktInternal::ExplicitValueOrControlFlow<interpreter::StatementResult,ErrorOr<interpreter::StatementResult>>{
+__jakt_var_164 = JAKT_RESOLVE_EXPLICIT_VALUE_OR_CONTROL_FLOW_RETURN_ONLY(([&]() -> JaktInternal::ExplicitValueOrControlFlow<interpreter::StatementResult,ErrorOr<interpreter::StatementResult>>{
 auto __jakt_enum_value = (((value).has_value()));
 if (__jakt_enum_value == true) {
 return JaktInternal::ExplicitValue( interpreter::StatementResult { typename interpreter::StatementResult::JustValue((value.value())) } );
@@ -4889,10 +4927,10 @@ else {
 return JaktInternal::ExplicitValue( interpreter::StatementResult { typename interpreter::StatementResult::JustValue(types::Value(TRY((types::ValueImpl::template create<typename types::ValueImpl::OptionalNone>())),call_span)) } );
 }
 }()))
-; goto __jakt_label_157;
+; goto __jakt_label_162;
 
 }
-__jakt_label_157:; __jakt_var_159.release_value(); }));
+__jakt_label_162:; __jakt_var_164.release_value(); }));
 };/*case end*/
 default: {
 {
@@ -4909,7 +4947,7 @@ auto&& __jakt_match_variant = *(((this_argument.value())).impl);
 switch(__jakt_match_variant.index()) {
 case 19: {
 auto&& __jakt_match_value = __jakt_match_variant.template get<types::ValueImpl::JaktArray>();JaktInternal::Array<types::Value> const& values = __jakt_match_value.values;
-return JaktInternal::ExplicitValue(({ Optional<interpreter::StatementResult> __jakt_var_160; {
+return JaktInternal::ExplicitValue(({ Optional<interpreter::StatementResult> __jakt_var_165; {
 bool found = false;
 {
 JaktInternal::ArrayIterator<types::Value> _magic = ((values).iterator());
@@ -4929,14 +4967,14 @@ break;
 }
 }
 
-__jakt_var_160 =  interpreter::StatementResult { typename interpreter::StatementResult::JustValue(types::Value(TRY((types::ValueImpl::template create<typename types::ValueImpl::Bool>(found))),call_span)) } ; goto __jakt_label_158;
+__jakt_var_165 =  interpreter::StatementResult { typename interpreter::StatementResult::JustValue(types::Value(TRY((types::ValueImpl::template create<typename types::ValueImpl::Bool>(found))),call_span)) } ; goto __jakt_label_163;
 
 }
-__jakt_label_158:; __jakt_var_160.release_value(); }));
+__jakt_label_163:; __jakt_var_165.release_value(); }));
 };/*case end*/
 default: {
 {
-utility::panic(String("Invalid use of Array::push()"));
+utility::panic(String("Invalid use of Array::contains()"));
 }
 };/*case end*/
 }/*switch end*/
@@ -4966,11 +5004,11 @@ auto&& __jakt_match_variant = *(((this_argument.value())).impl);
 switch(__jakt_match_variant.index()) {
 case 19: {
 auto&& __jakt_match_value = __jakt_match_variant.template get<types::ValueImpl::JaktArray>();JaktInternal::Array<types::Value> const& values = __jakt_match_value.values;
-return JaktInternal::ExplicitValue(({ Optional<interpreter::StatementResult> __jakt_var_161; {
-__jakt_var_161 =  interpreter::StatementResult { typename interpreter::StatementResult::JustValue(types::Value(TRY((types::ValueImpl::template create<typename types::ValueImpl::USize>(((values).capacity())))),call_span)) } ; goto __jakt_label_159;
+return JaktInternal::ExplicitValue(({ Optional<interpreter::StatementResult> __jakt_var_166; {
+__jakt_var_166 =  interpreter::StatementResult { typename interpreter::StatementResult::JustValue(types::Value(TRY((types::ValueImpl::template create<typename types::ValueImpl::USize>(((values).capacity())))),call_span)) } ; goto __jakt_label_164;
 
 }
-__jakt_label_159:; __jakt_var_161.release_value(); }));
+__jakt_label_164:; __jakt_var_166.release_value(); }));
 };/*case end*/
 default: {
 {
@@ -4993,13 +5031,13 @@ switch(__jakt_match_variant.index()) {
 case 12: {
 auto&& __jakt_match_value = __jakt_match_variant.template get<typename types::ValueImpl::USize>();
 size_t const& capacity = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(({ Optional<interpreter::StatementResult> __jakt_var_162; {
+return JaktInternal::ExplicitValue(({ Optional<interpreter::StatementResult> __jakt_var_167; {
 JaktInternal::Array<types::Value> mutable_values = values;
 TRY((((mutable_values).ensure_capacity(capacity))));
-__jakt_var_162 =  interpreter::StatementResult { typename interpreter::StatementResult::JustValue(types::Value(TRY((types::ValueImpl::template create<typename types::ValueImpl::Void>())),call_span)) } ; goto __jakt_label_160;
+__jakt_var_167 =  interpreter::StatementResult { typename interpreter::StatementResult::JustValue(types::Value(TRY((types::ValueImpl::template create<typename types::ValueImpl::Void>())),call_span)) } ; goto __jakt_label_165;
 
 }
-__jakt_label_160:; __jakt_var_162.release_value(); }));
+__jakt_label_165:; __jakt_var_167.release_value(); }));
 };/*case end*/
 default: {
 {
@@ -5032,13 +5070,13 @@ switch(__jakt_match_variant.index()) {
 case 12: {
 auto&& __jakt_match_value = __jakt_match_variant.template get<typename types::ValueImpl::USize>();
 size_t const& capacity = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(({ Optional<interpreter::StatementResult> __jakt_var_163; {
+return JaktInternal::ExplicitValue(({ Optional<interpreter::StatementResult> __jakt_var_168; {
 JaktInternal::Array<types::Value> mutable_values = values;
 TRY((((mutable_values).add_capacity(capacity))));
-__jakt_var_163 =  interpreter::StatementResult { typename interpreter::StatementResult::JustValue(types::Value(TRY((types::ValueImpl::template create<typename types::ValueImpl::Void>())),call_span)) } ; goto __jakt_label_161;
+__jakt_var_168 =  interpreter::StatementResult { typename interpreter::StatementResult::JustValue(types::Value(TRY((types::ValueImpl::template create<typename types::ValueImpl::Void>())),call_span)) } ; goto __jakt_label_166;
 
 }
-__jakt_label_161:; __jakt_var_163.release_value(); }));
+__jakt_label_166:; __jakt_var_168.release_value(); }));
 };/*case end*/
 default: {
 {
@@ -5071,13 +5109,13 @@ switch(__jakt_match_variant.index()) {
 case 12: {
 auto&& __jakt_match_value = __jakt_match_variant.template get<typename types::ValueImpl::USize>();
 size_t const& size = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(({ Optional<interpreter::StatementResult> __jakt_var_164; {
+return JaktInternal::ExplicitValue(({ Optional<interpreter::StatementResult> __jakt_var_169; {
 JaktInternal::Array<types::Value> mutable_values = values;
 ((mutable_values).shrink(size));
-__jakt_var_164 =  interpreter::StatementResult { typename interpreter::StatementResult::JustValue(types::Value(TRY((types::ValueImpl::template create<typename types::ValueImpl::Void>())),call_span)) } ; goto __jakt_label_162;
+__jakt_var_169 =  interpreter::StatementResult { typename interpreter::StatementResult::JustValue(types::Value(TRY((types::ValueImpl::template create<typename types::ValueImpl::Void>())),call_span)) } ; goto __jakt_label_167;
 
 }
-__jakt_label_162:; __jakt_var_164.release_value(); }));
+__jakt_label_167:; __jakt_var_169.release_value(); }));
 };/*case end*/
 default: {
 {
@@ -5116,7 +5154,7 @@ auto&& __jakt_match_variant = *(((this_argument.value())).impl);
 switch(__jakt_match_variant.index()) {
 case 16: {
 auto&& __jakt_match_value = __jakt_match_variant.template get<types::ValueImpl::Struct>();JaktInternal::Array<types::Value> const& fields = __jakt_match_value.fields;
-return JaktInternal::ExplicitValue(({ Optional<interpreter::StatementResult> __jakt_var_165; {
+return JaktInternal::ExplicitValue(({ Optional<interpreter::StatementResult> __jakt_var_170; {
 size_t const index = JAKT_RESOLVE_EXPLICIT_VALUE_OR_CONTROL_FLOW_RETURN_ONLY(([&]() -> JaktInternal::ExplicitValueOrControlFlow<size_t, ErrorOr<interpreter::StatementResult>>{
 auto&& __jakt_match_variant = *((((fields)[static_cast<i64>(1LL)])).impl);
 switch(__jakt_match_variant.index()) {
@@ -5134,7 +5172,7 @@ utility::panic(String("Invalid ArrayIterator index configuration"));
 }()
 ));
 JaktInternal::Array<types::Value> mutable_fields = fields;
-__jakt_var_165 =  interpreter::StatementResult { typename interpreter::StatementResult::JustValue(JAKT_RESOLVE_EXPLICIT_VALUE_OR_CONTROL_FLOW_RETURN_ONLY(([&]() -> JaktInternal::ExplicitValueOrControlFlow<types::Value, ErrorOr<interpreter::StatementResult>>{
+__jakt_var_170 =  interpreter::StatementResult { typename interpreter::StatementResult::JustValue(JAKT_RESOLVE_EXPLICIT_VALUE_OR_CONTROL_FLOW_RETURN_ONLY(([&]() -> JaktInternal::ExplicitValueOrControlFlow<types::Value, ErrorOr<interpreter::StatementResult>>{
 auto&& __jakt_match_variant = *((((fields)[static_cast<i64>(0LL)])).impl);
 switch(__jakt_match_variant.index()) {
 case 19: {
@@ -5142,12 +5180,12 @@ auto&& __jakt_match_value = __jakt_match_variant.template get<types::ValueImpl::
 return JaktInternal::ExplicitValue(JAKT_RESOLVE_EXPLICIT_VALUE_OR_CONTROL_FLOW_RETURN_ONLY(([&]() -> JaktInternal::ExplicitValueOrControlFlow<types::Value,ErrorOr<interpreter::StatementResult>>{
 auto __jakt_enum_value = ((((values).size()) > index));
 if (__jakt_enum_value == true) {
-return JaktInternal::ExplicitValue(({ Optional<types::Value> __jakt_var_166; {
+return JaktInternal::ExplicitValue(({ Optional<types::Value> __jakt_var_171; {
 (((mutable_fields)[static_cast<i64>(1LL)]) = types::Value(TRY((types::ValueImpl::template create<typename types::ValueImpl::USize>((JaktInternal::checked_add<size_t>(index,static_cast<size_t>(1ULL)))))),call_span));
-__jakt_var_166 = types::Value(TRY((types::ValueImpl::template create<typename types::ValueImpl::OptionalSome>(((values)[index])))),call_span); goto __jakt_label_164;
+__jakt_var_171 = types::Value(TRY((types::ValueImpl::template create<typename types::ValueImpl::OptionalSome>(((values)[index])))),call_span); goto __jakt_label_169;
 
 }
-__jakt_label_164:; __jakt_var_166.release_value(); }));
+__jakt_label_169:; __jakt_var_171.release_value(); }));
 }
 else {
 return JaktInternal::ExplicitValue(types::Value(TRY((types::ValueImpl::template create<typename types::ValueImpl::OptionalNone>())),call_span));
@@ -5162,10 +5200,10 @@ utility::panic(String("Invalid ArrayIterator configuration"));
 };/*case end*/
 }/*switch end*/
 }()
-))) } ; goto __jakt_label_163;
+))) } ; goto __jakt_label_168;
 
 }
-__jakt_label_163:; __jakt_var_165.release_value(); }));
+__jakt_label_168:; __jakt_var_170.release_value(); }));
 };/*case end*/
 default: {
 {
@@ -5189,7 +5227,7 @@ else if (__jakt_enum_value == String("Range")) {
 return JaktInternal::ExplicitValue(JAKT_RESOLVE_EXPLICIT_VALUE_OR_CONTROL_FLOW_RETURN_ONLY(([&]() -> JaktInternal::ExplicitValueOrControlFlow<interpreter::StatementResult,ErrorOr<interpreter::StatementResult>>{
 auto __jakt_enum_value = (prelude_function);
 if (__jakt_enum_value == String("next")) {
-return JaktInternal::ExplicitValue(({ Optional<interpreter::StatementResult> __jakt_var_167; {
+return JaktInternal::ExplicitValue(({ Optional<interpreter::StatementResult> __jakt_var_172; {
 JaktInternal::Array<types::Value> fields = JAKT_RESOLVE_EXPLICIT_VALUE_OR_CONTROL_FLOW_RETURN_ONLY(([&]() -> JaktInternal::ExplicitValueOrControlFlow<JaktInternal::Array<types::Value>, ErrorOr<interpreter::StatementResult>>{
 auto&& __jakt_match_variant = *(((this_argument.value())).impl);
 switch(__jakt_match_variant.index()) {
@@ -5327,10 +5365,10 @@ else {
 (((fields)[static_cast<i64>(0LL)]) = types::Value(TRY((types::ValueImpl::template create<typename types::ValueImpl::U64>((JaktInternal::checked_add<u64>(start,static_cast<u64>(1ULL)))))),call_span));
 }
 
-__jakt_var_167 =  interpreter::StatementResult { typename interpreter::StatementResult::JustValue(types::Value(TRY((types::ValueImpl::template create<typename types::ValueImpl::OptionalSome>(types::Value(TRY((types::ValueImpl::template create<typename types::ValueImpl::U64>(start))),call_span)))),call_span)) } ; goto __jakt_label_165;
+__jakt_var_172 =  interpreter::StatementResult { typename interpreter::StatementResult::JustValue(types::Value(TRY((types::ValueImpl::template create<typename types::ValueImpl::OptionalSome>(types::Value(TRY((types::ValueImpl::template create<typename types::ValueImpl::U64>(start))),call_span)))),call_span)) } ; goto __jakt_label_170;
 
 }
-__jakt_label_165:; __jakt_var_167.release_value(); }));
+__jakt_label_170:; __jakt_var_172.release_value(); }));
 }
 else if (__jakt_enum_value == String("inclusive")) {
 return JaktInternal::ExplicitValue(JAKT_RESOLVE_EXPLICIT_VALUE_OR_CONTROL_FLOW_RETURN_ONLY(([&]() -> JaktInternal::ExplicitValueOrControlFlow<interpreter::StatementResult, ErrorOr<interpreter::StatementResult>>{
@@ -5340,7 +5378,7 @@ case 16: {
 auto&& __jakt_match_value = __jakt_match_variant.template get<types::ValueImpl::Struct>();JaktInternal::Array<types::Value> const& fields = __jakt_match_value.fields;
 types::StructId const& struct_id = __jakt_match_value.struct_id;
 JaktInternal::Optional<types::FunctionId> const& constructor = __jakt_match_value.constructor;
-return JaktInternal::ExplicitValue(({ Optional<interpreter::StatementResult> __jakt_var_168; {
+return JaktInternal::ExplicitValue(({ Optional<interpreter::StatementResult> __jakt_var_173; {
 JaktInternal::Array<types::Value> mutable_fields = fields;
 u64 const end = JAKT_RESOLVE_EXPLICIT_VALUE_OR_CONTROL_FLOW_RETURN_ONLY(([&]() -> JaktInternal::ExplicitValueOrControlFlow<u64, ErrorOr<interpreter::StatementResult>>{
 auto&& __jakt_match_variant = *((((fields)[static_cast<i64>(1LL)])).impl);
@@ -5399,10 +5437,10 @@ utility::panic(String("Invalid type for comptime range"));
 }()
 ));
 (((((mutable_fields)[static_cast<i64>(1LL)])).impl) = TRY((types::ValueImpl::template create<typename types::ValueImpl::U64>((JaktInternal::checked_add<u64>(end,static_cast<u64>(1ULL)))))));
-__jakt_var_168 =  interpreter::StatementResult { typename interpreter::StatementResult::JustValue(types::Value(TRY((types::ValueImpl::template create<typename types::ValueImpl::Struct>(fields,struct_id,constructor))),(((this_argument.value())).span))) } ; goto __jakt_label_166;
+__jakt_var_173 =  interpreter::StatementResult { typename interpreter::StatementResult::JustValue(types::Value(TRY((types::ValueImpl::template create<typename types::ValueImpl::Struct>(fields,struct_id,constructor))),(((this_argument.value())).span))) } ; goto __jakt_label_171;
 
 }
-__jakt_label_166:; __jakt_var_168.release_value(); }));
+__jakt_label_171:; __jakt_var_173.release_value(); }));
 };/*case end*/
 default: {
 {
@@ -5514,72 +5552,6 @@ switch(__jakt_match_variant.index()) {
 case 12: {
 auto&& __jakt_match_value = __jakt_match_variant.template get<typename types::ValueImpl::USize>();
 size_t const& length = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(({ Optional<interpreter::StatementResult> __jakt_var_169; {
-String const result = TRY((((value).substring((infallible_integer_cast<size_t>((start))),(infallible_integer_cast<size_t>((length)))))));
-__jakt_var_169 =  interpreter::StatementResult { typename interpreter::StatementResult::JustValue(types::Value(TRY((types::ValueImpl::template create<typename types::ValueImpl::JaktString>(result))),call_span)) } ; goto __jakt_label_167;
-
-}
-__jakt_label_167:; __jakt_var_169.release_value(); }));
-};/*case end*/
-case 5: {
-auto&& __jakt_match_value = __jakt_match_variant.template get<typename types::ValueImpl::U64>();
-u64 const& length = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(({ Optional<interpreter::StatementResult> __jakt_var_170; {
-String const result = TRY((((value).substring((infallible_integer_cast<size_t>((start))),(infallible_integer_cast<size_t>((length)))))));
-__jakt_var_170 =  interpreter::StatementResult { typename interpreter::StatementResult::JustValue(types::Value(TRY((types::ValueImpl::template create<typename types::ValueImpl::JaktString>(result))),call_span)) } ; goto __jakt_label_168;
-
-}
-__jakt_label_168:; __jakt_var_170.release_value(); }));
-};/*case end*/
-case 4: {
-auto&& __jakt_match_value = __jakt_match_variant.template get<typename types::ValueImpl::U32>();
-u32 const& length = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(({ Optional<interpreter::StatementResult> __jakt_var_171; {
-String const result = TRY((((value).substring((infallible_integer_cast<size_t>((start))),(infallible_integer_cast<size_t>((length)))))));
-__jakt_var_171 =  interpreter::StatementResult { typename interpreter::StatementResult::JustValue(types::Value(TRY((types::ValueImpl::template create<typename types::ValueImpl::JaktString>(result))),call_span)) } ; goto __jakt_label_169;
-
-}
-__jakt_label_169:; __jakt_var_171.release_value(); }));
-};/*case end*/
-case 3: {
-auto&& __jakt_match_value = __jakt_match_variant.template get<typename types::ValueImpl::U16>();
-u16 const& length = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(({ Optional<interpreter::StatementResult> __jakt_var_172; {
-String const result = TRY((((value).substring((infallible_integer_cast<size_t>((start))),(infallible_integer_cast<size_t>((length)))))));
-__jakt_var_172 =  interpreter::StatementResult { typename interpreter::StatementResult::JustValue(types::Value(TRY((types::ValueImpl::template create<typename types::ValueImpl::JaktString>(result))),call_span)) } ; goto __jakt_label_170;
-
-}
-__jakt_label_170:; __jakt_var_172.release_value(); }));
-};/*case end*/
-case 2: {
-auto&& __jakt_match_value = __jakt_match_variant.template get<typename types::ValueImpl::U8>();
-u8 const& length = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(({ Optional<interpreter::StatementResult> __jakt_var_173; {
-String const result = TRY((((value).substring((infallible_integer_cast<size_t>((start))),(infallible_integer_cast<size_t>((length)))))));
-__jakt_var_173 =  interpreter::StatementResult { typename interpreter::StatementResult::JustValue(types::Value(TRY((types::ValueImpl::template create<typename types::ValueImpl::JaktString>(result))),call_span)) } ; goto __jakt_label_171;
-
-}
-__jakt_label_171:; __jakt_var_173.release_value(); }));
-};/*case end*/
-default: {
-{
-TRY((((*this).error(String("String::substring must be called with unsigned arguments"),((((arguments)[static_cast<i64>(1LL)])).span)))));
-return Error::from_errno((infallible_integer_cast<i32>((InterpretError::InvalidType))));
-}
-};/*case end*/
-}/*switch end*/
-}()
-)));
-};/*case end*/
-case 5: {
-auto&& __jakt_match_value = __jakt_match_variant.template get<typename types::ValueImpl::U64>();
-u64 const& start = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(JAKT_RESOLVE_EXPLICIT_VALUE_OR_CONTROL_FLOW_RETURN_ONLY(([&]() -> JaktInternal::ExplicitValueOrControlFlow<interpreter::StatementResult, ErrorOr<interpreter::StatementResult>>{
-auto&& __jakt_match_variant = *((((arguments)[static_cast<i64>(1LL)])).impl);
-switch(__jakt_match_variant.index()) {
-case 12: {
-auto&& __jakt_match_value = __jakt_match_variant.template get<typename types::ValueImpl::USize>();
-size_t const& length = __jakt_match_value.value;
 return JaktInternal::ExplicitValue(({ Optional<interpreter::StatementResult> __jakt_var_174; {
 String const result = TRY((((value).substring((infallible_integer_cast<size_t>((start))),(infallible_integer_cast<size_t>((length)))))));
 __jakt_var_174 =  interpreter::StatementResult { typename interpreter::StatementResult::JustValue(types::Value(TRY((types::ValueImpl::template create<typename types::ValueImpl::JaktString>(result))),call_span)) } ; goto __jakt_label_172;
@@ -5637,9 +5609,9 @@ return Error::from_errno((infallible_integer_cast<i32>((InterpretError::InvalidT
 }()
 )));
 };/*case end*/
-case 4: {
-auto&& __jakt_match_value = __jakt_match_variant.template get<typename types::ValueImpl::U32>();
-u32 const& start = __jakt_match_value.value;
+case 5: {
+auto&& __jakt_match_value = __jakt_match_variant.template get<typename types::ValueImpl::U64>();
+u64 const& start = __jakt_match_value.value;
 return JaktInternal::ExplicitValue(JAKT_RESOLVE_EXPLICIT_VALUE_OR_CONTROL_FLOW_RETURN_ONLY(([&]() -> JaktInternal::ExplicitValueOrControlFlow<interpreter::StatementResult, ErrorOr<interpreter::StatementResult>>{
 auto&& __jakt_match_variant = *((((arguments)[static_cast<i64>(1LL)])).impl);
 switch(__jakt_match_variant.index()) {
@@ -5703,9 +5675,9 @@ return Error::from_errno((infallible_integer_cast<i32>((InterpretError::InvalidT
 }()
 )));
 };/*case end*/
-case 3: {
-auto&& __jakt_match_value = __jakt_match_variant.template get<typename types::ValueImpl::U16>();
-u16 const& start = __jakt_match_value.value;
+case 4: {
+auto&& __jakt_match_value = __jakt_match_variant.template get<typename types::ValueImpl::U32>();
+u32 const& start = __jakt_match_value.value;
 return JaktInternal::ExplicitValue(JAKT_RESOLVE_EXPLICIT_VALUE_OR_CONTROL_FLOW_RETURN_ONLY(([&]() -> JaktInternal::ExplicitValueOrControlFlow<interpreter::StatementResult, ErrorOr<interpreter::StatementResult>>{
 auto&& __jakt_match_variant = *((((arguments)[static_cast<i64>(1LL)])).impl);
 switch(__jakt_match_variant.index()) {
@@ -5769,9 +5741,9 @@ return Error::from_errno((infallible_integer_cast<i32>((InterpretError::InvalidT
 }()
 )));
 };/*case end*/
-case 2: {
-auto&& __jakt_match_value = __jakt_match_variant.template get<typename types::ValueImpl::U8>();
-u8 const& start = __jakt_match_value.value;
+case 3: {
+auto&& __jakt_match_value = __jakt_match_variant.template get<typename types::ValueImpl::U16>();
+u16 const& start = __jakt_match_value.value;
 return JaktInternal::ExplicitValue(JAKT_RESOLVE_EXPLICIT_VALUE_OR_CONTROL_FLOW_RETURN_ONLY(([&]() -> JaktInternal::ExplicitValueOrControlFlow<interpreter::StatementResult, ErrorOr<interpreter::StatementResult>>{
 auto&& __jakt_match_variant = *((((arguments)[static_cast<i64>(1LL)])).impl);
 switch(__jakt_match_variant.index()) {
@@ -5824,6 +5796,72 @@ __jakt_var_193 =  interpreter::StatementResult { typename interpreter::Statement
 
 }
 __jakt_label_191:; __jakt_var_193.release_value(); }));
+};/*case end*/
+default: {
+{
+TRY((((*this).error(String("String::substring must be called with unsigned arguments"),((((arguments)[static_cast<i64>(1LL)])).span)))));
+return Error::from_errno((infallible_integer_cast<i32>((InterpretError::InvalidType))));
+}
+};/*case end*/
+}/*switch end*/
+}()
+)));
+};/*case end*/
+case 2: {
+auto&& __jakt_match_value = __jakt_match_variant.template get<typename types::ValueImpl::U8>();
+u8 const& start = __jakt_match_value.value;
+return JaktInternal::ExplicitValue(JAKT_RESOLVE_EXPLICIT_VALUE_OR_CONTROL_FLOW_RETURN_ONLY(([&]() -> JaktInternal::ExplicitValueOrControlFlow<interpreter::StatementResult, ErrorOr<interpreter::StatementResult>>{
+auto&& __jakt_match_variant = *((((arguments)[static_cast<i64>(1LL)])).impl);
+switch(__jakt_match_variant.index()) {
+case 12: {
+auto&& __jakt_match_value = __jakt_match_variant.template get<typename types::ValueImpl::USize>();
+size_t const& length = __jakt_match_value.value;
+return JaktInternal::ExplicitValue(({ Optional<interpreter::StatementResult> __jakt_var_194; {
+String const result = TRY((((value).substring((infallible_integer_cast<size_t>((start))),(infallible_integer_cast<size_t>((length)))))));
+__jakt_var_194 =  interpreter::StatementResult { typename interpreter::StatementResult::JustValue(types::Value(TRY((types::ValueImpl::template create<typename types::ValueImpl::JaktString>(result))),call_span)) } ; goto __jakt_label_192;
+
+}
+__jakt_label_192:; __jakt_var_194.release_value(); }));
+};/*case end*/
+case 5: {
+auto&& __jakt_match_value = __jakt_match_variant.template get<typename types::ValueImpl::U64>();
+u64 const& length = __jakt_match_value.value;
+return JaktInternal::ExplicitValue(({ Optional<interpreter::StatementResult> __jakt_var_195; {
+String const result = TRY((((value).substring((infallible_integer_cast<size_t>((start))),(infallible_integer_cast<size_t>((length)))))));
+__jakt_var_195 =  interpreter::StatementResult { typename interpreter::StatementResult::JustValue(types::Value(TRY((types::ValueImpl::template create<typename types::ValueImpl::JaktString>(result))),call_span)) } ; goto __jakt_label_193;
+
+}
+__jakt_label_193:; __jakt_var_195.release_value(); }));
+};/*case end*/
+case 4: {
+auto&& __jakt_match_value = __jakt_match_variant.template get<typename types::ValueImpl::U32>();
+u32 const& length = __jakt_match_value.value;
+return JaktInternal::ExplicitValue(({ Optional<interpreter::StatementResult> __jakt_var_196; {
+String const result = TRY((((value).substring((infallible_integer_cast<size_t>((start))),(infallible_integer_cast<size_t>((length)))))));
+__jakt_var_196 =  interpreter::StatementResult { typename interpreter::StatementResult::JustValue(types::Value(TRY((types::ValueImpl::template create<typename types::ValueImpl::JaktString>(result))),call_span)) } ; goto __jakt_label_194;
+
+}
+__jakt_label_194:; __jakt_var_196.release_value(); }));
+};/*case end*/
+case 3: {
+auto&& __jakt_match_value = __jakt_match_variant.template get<typename types::ValueImpl::U16>();
+u16 const& length = __jakt_match_value.value;
+return JaktInternal::ExplicitValue(({ Optional<interpreter::StatementResult> __jakt_var_197; {
+String const result = TRY((((value).substring((infallible_integer_cast<size_t>((start))),(infallible_integer_cast<size_t>((length)))))));
+__jakt_var_197 =  interpreter::StatementResult { typename interpreter::StatementResult::JustValue(types::Value(TRY((types::ValueImpl::template create<typename types::ValueImpl::JaktString>(result))),call_span)) } ; goto __jakt_label_195;
+
+}
+__jakt_label_195:; __jakt_var_197.release_value(); }));
+};/*case end*/
+case 2: {
+auto&& __jakt_match_value = __jakt_match_variant.template get<typename types::ValueImpl::U8>();
+u8 const& length = __jakt_match_value.value;
+return JaktInternal::ExplicitValue(({ Optional<interpreter::StatementResult> __jakt_var_198; {
+String const result = TRY((((value).substring((infallible_integer_cast<size_t>((start))),(infallible_integer_cast<size_t>((length)))))));
+__jakt_var_198 =  interpreter::StatementResult { typename interpreter::StatementResult::JustValue(types::Value(TRY((types::ValueImpl::template create<typename types::ValueImpl::JaktString>(result))),call_span)) } ; goto __jakt_label_196;
+
+}
+__jakt_label_196:; __jakt_var_198.release_value(); }));
 };/*case end*/
 default: {
 {
@@ -5924,9 +5962,9 @@ switch(__jakt_match_variant.index()) {
 case 13: {
 auto&& __jakt_match_value = __jakt_match_variant.template get<typename types::ValueImpl::JaktString>();
 String const& value = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(({ Optional<interpreter::StatementResult> __jakt_var_194; {
+return JaktInternal::ExplicitValue(({ Optional<interpreter::StatementResult> __jakt_var_199; {
 JaktInternal::Optional<u32> const result = ((value).to_uint());
-__jakt_var_194 =  interpreter::StatementResult { typename interpreter::StatementResult::JustValue(types::Value(JAKT_RESOLVE_EXPLICIT_VALUE_OR_CONTROL_FLOW_RETURN_ONLY(([&]() -> JaktInternal::ExplicitValueOrControlFlow<NonnullRefPtr<types::ValueImpl>,ErrorOr<interpreter::StatementResult>>{
+__jakt_var_199 =  interpreter::StatementResult { typename interpreter::StatementResult::JustValue(types::Value(JAKT_RESOLVE_EXPLICIT_VALUE_OR_CONTROL_FLOW_RETURN_ONLY(([&]() -> JaktInternal::ExplicitValueOrControlFlow<NonnullRefPtr<types::ValueImpl>,ErrorOr<interpreter::StatementResult>>{
 auto __jakt_enum_value = (((result).has_value()));
 if (__jakt_enum_value == true) {
 return JaktInternal::ExplicitValue(TRY((types::ValueImpl::template create<typename types::ValueImpl::OptionalSome>(types::Value(TRY((types::ValueImpl::template create<typename types::ValueImpl::U32>((result.value())))),call_span)))));
@@ -5935,10 +5973,10 @@ else {
 return JaktInternal::ExplicitValue(TRY((types::ValueImpl::template create<typename types::ValueImpl::OptionalNone>())));
 }
 }()))
-,call_span)) } ; goto __jakt_label_192;
+,call_span)) } ; goto __jakt_label_197;
 
 }
-__jakt_label_192:; __jakt_var_194.release_value(); }));
+__jakt_label_197:; __jakt_var_199.release_value(); }));
 };/*case end*/
 default: {
 {
@@ -5956,9 +5994,9 @@ switch(__jakt_match_variant.index()) {
 case 13: {
 auto&& __jakt_match_value = __jakt_match_variant.template get<typename types::ValueImpl::JaktString>();
 String const& value = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(({ Optional<interpreter::StatementResult> __jakt_var_195; {
+return JaktInternal::ExplicitValue(({ Optional<interpreter::StatementResult> __jakt_var_200; {
 JaktInternal::Optional<i32> const result = ((value).to_int());
-__jakt_var_195 =  interpreter::StatementResult { typename interpreter::StatementResult::JustValue(types::Value(JAKT_RESOLVE_EXPLICIT_VALUE_OR_CONTROL_FLOW_RETURN_ONLY(([&]() -> JaktInternal::ExplicitValueOrControlFlow<NonnullRefPtr<types::ValueImpl>,ErrorOr<interpreter::StatementResult>>{
+__jakt_var_200 =  interpreter::StatementResult { typename interpreter::StatementResult::JustValue(types::Value(JAKT_RESOLVE_EXPLICIT_VALUE_OR_CONTROL_FLOW_RETURN_ONLY(([&]() -> JaktInternal::ExplicitValueOrControlFlow<NonnullRefPtr<types::ValueImpl>,ErrorOr<interpreter::StatementResult>>{
 auto __jakt_enum_value = (((result).has_value()));
 if (__jakt_enum_value == true) {
 return JaktInternal::ExplicitValue(TRY((types::ValueImpl::template create<typename types::ValueImpl::OptionalSome>(types::Value(TRY((types::ValueImpl::template create<typename types::ValueImpl::I32>((result.value())))),call_span)))));
@@ -5967,10 +6005,10 @@ else {
 return JaktInternal::ExplicitValue(TRY((types::ValueImpl::template create<typename types::ValueImpl::OptionalNone>())));
 }
 }()))
-,call_span)) } ; goto __jakt_label_193;
+,call_span)) } ; goto __jakt_label_198;
 
 }
-__jakt_label_193:; __jakt_var_195.release_value(); }));
+__jakt_label_198:; __jakt_var_200.release_value(); }));
 };/*case end*/
 default: {
 {
@@ -6150,7 +6188,7 @@ switch(__jakt_match_variant.index()) {
 case 14: {
 auto&& __jakt_match_value = __jakt_match_variant.template get<typename types::ValueImpl::CChar>();
 char const& c = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(({ Optional<interpreter::StatementResult> __jakt_var_196; {
+return JaktInternal::ExplicitValue(({ Optional<interpreter::StatementResult> __jakt_var_201; {
 JaktInternal::Array<String> const values = TRY((((value).split(c))));
 JaktInternal::Array<types::Value> result = (TRY((Array<types::Value>::create_with({}))));
 {
@@ -6169,10 +6207,10 @@ TRY((((result).push(types::Value(TRY((types::ValueImpl::template create<typename
 }
 
 types::StructId const array_struct_id = TRY((((((*this).program))->find_struct_in_prelude(String("Array")))));
-__jakt_var_196 =  interpreter::StatementResult { typename interpreter::StatementResult::JustValue(types::Value(TRY((types::ValueImpl::template create<typename types::ValueImpl::JaktArray>(result,TRY((((*this).find_or_add_type_id(TRY((types::Type::template create<typename types::Type::GenericInstance>(array_struct_id,(TRY((Array<types::TypeId>::create_with({types::builtin( types::BuiltinType { typename types::BuiltinType::JaktString() } )})))))))))))))),call_span)) } ; goto __jakt_label_194;
+__jakt_var_201 =  interpreter::StatementResult { typename interpreter::StatementResult::JustValue(types::Value(TRY((types::ValueImpl::template create<typename types::ValueImpl::JaktArray>(result,TRY((((*this).find_or_add_type_id(TRY((types::Type::template create<typename types::Type::GenericInstance>(array_struct_id,(TRY((Array<types::TypeId>::create_with({types::builtin( types::BuiltinType { typename types::BuiltinType::JaktString() } )})))))))))))))),call_span)) } ; goto __jakt_label_199;
 
 }
-__jakt_label_194:; __jakt_var_196.release_value(); }));
+__jakt_label_199:; __jakt_var_201.release_value(); }));
 };/*case end*/
 default: {
 {
@@ -6262,7 +6300,7 @@ utility::panic(String("Invalid String"));
 )));
 }
 else if (__jakt_enum_value == String("repeated")) {
-return JaktInternal::ExplicitValue(({ Optional<interpreter::StatementResult> __jakt_var_197; {
+return JaktInternal::ExplicitValue(({ Optional<interpreter::StatementResult> __jakt_var_202; {
 if ((((arguments).size()) != static_cast<size_t>(2ULL))){
 TRY((((*this).error(String("String::repeated must be called with a c_char and a usize"),call_span))));
 return Error::from_errno((infallible_integer_cast<i32>((InterpretError::InvalidType))));
@@ -6303,10 +6341,10 @@ return Error::from_errno((infallible_integer_cast<i32>((InterpretError::InvalidT
 char const character = ((character_count_).get<0>());
 size_t const count = ((character_count_).get<1>());
 
-__jakt_var_197 =  interpreter::StatementResult { typename interpreter::StatementResult::JustValue(types::Value(TRY((types::ValueImpl::template create<typename types::ValueImpl::JaktString>(TRY((String::repeated(character,count)))))),call_span)) } ; goto __jakt_label_195;
+__jakt_var_202 =  interpreter::StatementResult { typename interpreter::StatementResult::JustValue(types::Value(TRY((types::ValueImpl::template create<typename types::ValueImpl::JaktString>(TRY((String::repeated(character,count)))))),call_span)) } ; goto __jakt_label_200;
 
 }
-__jakt_label_195:; __jakt_var_197.release_value(); }));
+__jakt_label_200:; __jakt_var_202.release_value(); }));
 }
 else {
 {
@@ -6343,7 +6381,7 @@ auto&& __jakt_match_variant = *(((this_argument.value())).impl);
 switch(__jakt_match_variant.index()) {
 case 21: {
 auto&& __jakt_match_value = __jakt_match_variant.template get<types::ValueImpl::JaktSet>();JaktInternal::Array<types::Value> const& values = __jakt_match_value.values;
-return JaktInternal::ExplicitValue(({ Optional<interpreter::StatementResult> __jakt_var_198; {
+return JaktInternal::ExplicitValue(({ Optional<interpreter::StatementResult> __jakt_var_203; {
 bool found = false;
 {
 JaktInternal::Range<size_t> _magic = (JaktInternal::Range<size_t>{static_cast<size_t>(static_cast<size_t>(0ULL)),static_cast<size_t>(((values).size()))});
@@ -6363,10 +6401,10 @@ break;
 }
 }
 
-__jakt_var_198 =  interpreter::StatementResult { typename interpreter::StatementResult::JustValue(types::Value(TRY((types::ValueImpl::template create<typename types::ValueImpl::Bool>(found))),call_span)) } ; goto __jakt_label_196;
+__jakt_var_203 =  interpreter::StatementResult { typename interpreter::StatementResult::JustValue(types::Value(TRY((types::ValueImpl::template create<typename types::ValueImpl::Bool>(found))),call_span)) } ; goto __jakt_label_201;
 
 }
-__jakt_label_196:; __jakt_var_198.release_value(); }));
+__jakt_label_201:; __jakt_var_203.release_value(); }));
 };/*case end*/
 default: {
 {
@@ -6383,13 +6421,13 @@ auto&& __jakt_match_variant = *(((this_argument.value())).impl);
 switch(__jakt_match_variant.index()) {
 case 21: {
 auto&& __jakt_match_value = __jakt_match_variant.template get<types::ValueImpl::JaktSet>();JaktInternal::Array<types::Value> const& values = __jakt_match_value.values;
-return JaktInternal::ExplicitValue(({ Optional<interpreter::StatementResult> __jakt_var_199; {
+return JaktInternal::ExplicitValue(({ Optional<interpreter::StatementResult> __jakt_var_204; {
 JaktInternal::Array<types::Value> mutable_values = values;
 TRY((((mutable_values).push(((arguments)[static_cast<i64>(0LL)])))));
-__jakt_var_199 =  interpreter::StatementResult { typename interpreter::StatementResult::JustValue(types::Value(TRY((types::ValueImpl::template create<typename types::ValueImpl::Void>())),call_span)) } ; goto __jakt_label_197;
+__jakt_var_204 =  interpreter::StatementResult { typename interpreter::StatementResult::JustValue(types::Value(TRY((types::ValueImpl::template create<typename types::ValueImpl::Void>())),call_span)) } ; goto __jakt_label_202;
 
 }
-__jakt_label_197:; __jakt_var_199.release_value(); }));
+__jakt_label_202:; __jakt_var_204.release_value(); }));
 };/*case end*/
 default: {
 {
@@ -6406,7 +6444,7 @@ auto&& __jakt_match_variant = *(((this_argument.value())).impl);
 switch(__jakt_match_variant.index()) {
 case 21: {
 auto&& __jakt_match_value = __jakt_match_variant.template get<types::ValueImpl::JaktSet>();JaktInternal::Array<types::Value> const& values = __jakt_match_value.values;
-return JaktInternal::ExplicitValue(({ Optional<interpreter::StatementResult> __jakt_var_200; {
+return JaktInternal::ExplicitValue(({ Optional<interpreter::StatementResult> __jakt_var_205; {
 bool found = false;
 JaktInternal::Array<types::Value> values_without = (TRY((Array<types::Value>::create_with({}))));
 {
@@ -6445,10 +6483,10 @@ TRY((((mutable_values).push(((values_without)[i])))));
 }
 }
 
-__jakt_var_200 =  interpreter::StatementResult { typename interpreter::StatementResult::JustValue(types::Value(TRY((types::ValueImpl::template create<typename types::ValueImpl::Bool>(found))),call_span)) } ; goto __jakt_label_198;
+__jakt_var_205 =  interpreter::StatementResult { typename interpreter::StatementResult::JustValue(types::Value(TRY((types::ValueImpl::template create<typename types::ValueImpl::Bool>(found))),call_span)) } ; goto __jakt_label_203;
 
 }
-__jakt_label_198:; __jakt_var_200.release_value(); }));
+__jakt_label_203:; __jakt_var_205.release_value(); }));
 };/*case end*/
 default: {
 {
@@ -6465,13 +6503,13 @@ auto&& __jakt_match_variant = *(((this_argument.value())).impl);
 switch(__jakt_match_variant.index()) {
 case 21: {
 auto&& __jakt_match_value = __jakt_match_variant.template get<types::ValueImpl::JaktSet>();JaktInternal::Array<types::Value> const& values = __jakt_match_value.values;
-return JaktInternal::ExplicitValue(({ Optional<interpreter::StatementResult> __jakt_var_201; {
+return JaktInternal::ExplicitValue(({ Optional<interpreter::StatementResult> __jakt_var_206; {
 JaktInternal::Array<types::Value> mutable_values = values;
 ((mutable_values).shrink(static_cast<size_t>(0ULL)));
-__jakt_var_201 =  interpreter::StatementResult { typename interpreter::StatementResult::JustValue(types::Value(TRY((types::ValueImpl::template create<typename types::ValueImpl::Void>())),call_span)) } ; goto __jakt_label_199;
+__jakt_var_206 =  interpreter::StatementResult { typename interpreter::StatementResult::JustValue(types::Value(TRY((types::ValueImpl::template create<typename types::ValueImpl::Void>())),call_span)) } ; goto __jakt_label_204;
 
 }
-__jakt_label_199:; __jakt_var_201.release_value(); }));
+__jakt_label_204:; __jakt_var_206.release_value(); }));
 };/*case end*/
 default: {
 {
@@ -6528,13 +6566,13 @@ switch(__jakt_match_variant.index()) {
 case 12: {
 auto&& __jakt_match_value = __jakt_match_variant.template get<typename types::ValueImpl::USize>();
 size_t const& capacity = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(({ Optional<interpreter::StatementResult> __jakt_var_202; {
+return JaktInternal::ExplicitValue(({ Optional<interpreter::StatementResult> __jakt_var_207; {
 JaktInternal::Array<types::Value> mutable_values = values;
 TRY((((mutable_values).ensure_capacity(capacity))));
-__jakt_var_202 =  interpreter::StatementResult { typename interpreter::StatementResult::JustValue(types::Value(TRY((types::ValueImpl::template create<typename types::ValueImpl::Void>())),call_span)) } ; goto __jakt_label_200;
+__jakt_var_207 =  interpreter::StatementResult { typename interpreter::StatementResult::JustValue(types::Value(TRY((types::ValueImpl::template create<typename types::ValueImpl::Void>())),call_span)) } ; goto __jakt_label_205;
 
 }
-__jakt_label_200:; __jakt_var_202.release_value(); }));
+__jakt_label_205:; __jakt_var_207.release_value(); }));
 };/*case end*/
 default: {
 {
@@ -6560,12 +6598,12 @@ return JaktInternal::ExplicitValue(JAKT_RESOLVE_EXPLICIT_VALUE_OR_CONTROL_FLOW_R
 auto&& __jakt_match_variant = *(((this_argument.value())).impl);
 switch(__jakt_match_variant.index()) {
 case 21: {
-auto&& __jakt_match_value = __jakt_match_variant.template get<types::ValueImpl::JaktSet>();return JaktInternal::ExplicitValue(({ Optional<interpreter::StatementResult> __jakt_var_203; {
+auto&& __jakt_match_value = __jakt_match_variant.template get<types::ValueImpl::JaktSet>();return JaktInternal::ExplicitValue(({ Optional<interpreter::StatementResult> __jakt_var_208; {
 types::StructId const struct_id = TRY((((((*this).program))->find_struct_in_prelude(String("SetIterator")))));
-__jakt_var_203 =  interpreter::StatementResult { typename interpreter::StatementResult::JustValue(types::Value(TRY((types::ValueImpl::template create<typename types::ValueImpl::Struct>((TRY((Array<types::Value>::create_with({(this_argument.value()), types::Value(TRY((types::ValueImpl::template create<typename types::ValueImpl::USize>(static_cast<size_t>(0ULL)))),call_span)})))),struct_id,JaktInternal::OptionalNone()))),call_span)) } ; goto __jakt_label_201;
+__jakt_var_208 =  interpreter::StatementResult { typename interpreter::StatementResult::JustValue(types::Value(TRY((types::ValueImpl::template create<typename types::ValueImpl::Struct>((TRY((Array<types::Value>::create_with({(this_argument.value()), types::Value(TRY((types::ValueImpl::template create<typename types::ValueImpl::USize>(static_cast<size_t>(0ULL)))),call_span)})))),struct_id,JaktInternal::OptionalNone()))),call_span)) } ; goto __jakt_label_206;
 
 }
-__jakt_label_201:; __jakt_var_203.release_value(); }));
+__jakt_label_206:; __jakt_var_208.release_value(); }));
 };/*case end*/
 default: {
 {
@@ -6594,7 +6632,7 @@ auto&& __jakt_match_variant = *(((this_argument.value())).impl);
 switch(__jakt_match_variant.index()) {
 case 16: {
 auto&& __jakt_match_value = __jakt_match_variant.template get<types::ValueImpl::Struct>();JaktInternal::Array<types::Value> const& fields = __jakt_match_value.fields;
-return JaktInternal::ExplicitValue(({ Optional<interpreter::StatementResult> __jakt_var_204; {
+return JaktInternal::ExplicitValue(({ Optional<interpreter::StatementResult> __jakt_var_209; {
 size_t const index = JAKT_RESOLVE_EXPLICIT_VALUE_OR_CONTROL_FLOW_RETURN_ONLY(([&]() -> JaktInternal::ExplicitValueOrControlFlow<size_t, ErrorOr<interpreter::StatementResult>>{
 auto&& __jakt_match_variant = *((((fields)[static_cast<i64>(1LL)])).impl);
 switch(__jakt_match_variant.index()) {
@@ -6612,7 +6650,7 @@ utility::panic(String("Invalid SetIterator index configuration"));
 }()
 ));
 JaktInternal::Array<types::Value> mutable_fields = fields;
-__jakt_var_204 =  interpreter::StatementResult { typename interpreter::StatementResult::JustValue(JAKT_RESOLVE_EXPLICIT_VALUE_OR_CONTROL_FLOW_RETURN_ONLY(([&]() -> JaktInternal::ExplicitValueOrControlFlow<types::Value, ErrorOr<interpreter::StatementResult>>{
+__jakt_var_209 =  interpreter::StatementResult { typename interpreter::StatementResult::JustValue(JAKT_RESOLVE_EXPLICIT_VALUE_OR_CONTROL_FLOW_RETURN_ONLY(([&]() -> JaktInternal::ExplicitValueOrControlFlow<types::Value, ErrorOr<interpreter::StatementResult>>{
 auto&& __jakt_match_variant = *((((fields)[static_cast<i64>(0LL)])).impl);
 switch(__jakt_match_variant.index()) {
 case 21: {
@@ -6620,12 +6658,12 @@ auto&& __jakt_match_value = __jakt_match_variant.template get<types::ValueImpl::
 return JaktInternal::ExplicitValue(JAKT_RESOLVE_EXPLICIT_VALUE_OR_CONTROL_FLOW_RETURN_ONLY(([&]() -> JaktInternal::ExplicitValueOrControlFlow<types::Value,ErrorOr<interpreter::StatementResult>>{
 auto __jakt_enum_value = ((((values).size()) > index));
 if (__jakt_enum_value == true) {
-return JaktInternal::ExplicitValue(({ Optional<types::Value> __jakt_var_205; {
+return JaktInternal::ExplicitValue(({ Optional<types::Value> __jakt_var_210; {
 (((mutable_fields)[static_cast<i64>(1LL)]) = types::Value(TRY((types::ValueImpl::template create<typename types::ValueImpl::USize>((JaktInternal::checked_add<size_t>(index,static_cast<size_t>(1ULL)))))),call_span));
-__jakt_var_205 = types::Value(TRY((types::ValueImpl::template create<typename types::ValueImpl::OptionalSome>(((values)[index])))),call_span); goto __jakt_label_203;
+__jakt_var_210 = types::Value(TRY((types::ValueImpl::template create<typename types::ValueImpl::OptionalSome>(((values)[index])))),call_span); goto __jakt_label_208;
 
 }
-__jakt_label_203:; __jakt_var_205.release_value(); }));
+__jakt_label_208:; __jakt_var_210.release_value(); }));
 }
 else {
 return JaktInternal::ExplicitValue(types::Value(TRY((types::ValueImpl::template create<typename types::ValueImpl::OptionalNone>())),call_span));
@@ -6640,10 +6678,10 @@ utility::panic(String("Invalid SetIterator configuration"));
 };/*case end*/
 }/*switch end*/
 }()
-))) } ; goto __jakt_label_202;
+))) } ; goto __jakt_label_207;
 
 }
-__jakt_label_202:; __jakt_var_204.release_value(); }));
+__jakt_label_207:; __jakt_var_209.release_value(); }));
 };/*case end*/
 default: {
 {
@@ -6672,7 +6710,7 @@ auto&& __jakt_match_variant = *(((this_argument.value())).impl);
 switch(__jakt_match_variant.index()) {
 case 16: {
 auto&& __jakt_match_value = __jakt_match_variant.template get<types::ValueImpl::Struct>();JaktInternal::Array<types::Value> const& fields = __jakt_match_value.fields;
-return JaktInternal::ExplicitValue(({ Optional<interpreter::StatementResult> __jakt_var_206; {
+return JaktInternal::ExplicitValue(({ Optional<interpreter::StatementResult> __jakt_var_211; {
 size_t const index = JAKT_RESOLVE_EXPLICIT_VALUE_OR_CONTROL_FLOW_RETURN_ONLY(([&]() -> JaktInternal::ExplicitValueOrControlFlow<size_t, ErrorOr<interpreter::StatementResult>>{
 auto&& __jakt_match_variant = *((((fields)[static_cast<i64>(1LL)])).impl);
 switch(__jakt_match_variant.index()) {
@@ -6690,7 +6728,7 @@ utility::panic(String("Invalid DictionaryIterator index configuration"));
 }()
 ));
 JaktInternal::Array<types::Value> mutable_fields = fields;
-__jakt_var_206 =  interpreter::StatementResult { typename interpreter::StatementResult::JustValue(JAKT_RESOLVE_EXPLICIT_VALUE_OR_CONTROL_FLOW_RETURN_ONLY(([&]() -> JaktInternal::ExplicitValueOrControlFlow<types::Value, ErrorOr<interpreter::StatementResult>>{
+__jakt_var_211 =  interpreter::StatementResult { typename interpreter::StatementResult::JustValue(JAKT_RESOLVE_EXPLICIT_VALUE_OR_CONTROL_FLOW_RETURN_ONLY(([&]() -> JaktInternal::ExplicitValueOrControlFlow<types::Value, ErrorOr<interpreter::StatementResult>>{
 auto&& __jakt_match_variant = *((((fields)[static_cast<i64>(0LL)])).impl);
 switch(__jakt_match_variant.index()) {
 case 20: {
@@ -6700,7 +6738,7 @@ types::TypeId const& type_id = __jakt_match_value.type_id;
 return JaktInternal::ExplicitValue(JAKT_RESOLVE_EXPLICIT_VALUE_OR_CONTROL_FLOW_RETURN_ONLY(([&]() -> JaktInternal::ExplicitValueOrControlFlow<types::Value,ErrorOr<interpreter::StatementResult>>{
 auto __jakt_enum_value = (((((keys).size()) > index) && (((values).size()) > index)));
 if (__jakt_enum_value == true) {
-return JaktInternal::ExplicitValue(({ Optional<types::Value> __jakt_var_207; {
+return JaktInternal::ExplicitValue(({ Optional<types::Value> __jakt_var_212; {
 (((mutable_fields)[static_cast<i64>(1LL)]) = types::Value(TRY((types::ValueImpl::template create<typename types::ValueImpl::USize>((JaktInternal::checked_add<size_t>(index,static_cast<size_t>(1ULL)))))),call_span));
 JaktInternal::Array<types::TypeId> const generics = JAKT_RESOLVE_EXPLICIT_VALUE_OR_CONTROL_FLOW_RETURN_ONLY(([&]() -> JaktInternal::ExplicitValueOrControlFlow<JaktInternal::Array<types::TypeId>, ErrorOr<interpreter::StatementResult>>{
 auto&& __jakt_match_variant = *((((*this).program))->get_type(type_id));
@@ -6719,10 +6757,10 @@ utility::panic(String("expected generic instance"));
 ));
 types::StructId const tuple_struct_id = TRY((((((*this).program))->find_struct_in_prelude(String("Tuple")))));
 types::TypeId const tuple_type_id = TRY((((*this).find_or_add_type_id(TRY((types::Type::template create<typename types::Type::GenericInstance>(tuple_struct_id,generics)))))));
-__jakt_var_207 = types::Value(TRY((types::ValueImpl::template create<typename types::ValueImpl::OptionalSome>(types::Value(TRY((types::ValueImpl::template create<typename types::ValueImpl::JaktTuple>((TRY((Array<types::Value>::create_with({((keys)[index]), ((values)[index])})))),tuple_type_id))),call_span)))),call_span); goto __jakt_label_205;
+__jakt_var_212 = types::Value(TRY((types::ValueImpl::template create<typename types::ValueImpl::OptionalSome>(types::Value(TRY((types::ValueImpl::template create<typename types::ValueImpl::JaktTuple>((TRY((Array<types::Value>::create_with({((keys)[index]), ((values)[index])})))),tuple_type_id))),call_span)))),call_span); goto __jakt_label_210;
 
 }
-__jakt_label_205:; __jakt_var_207.release_value(); }));
+__jakt_label_210:; __jakt_var_212.release_value(); }));
 }
 else {
 return JaktInternal::ExplicitValue(types::Value(TRY((types::ValueImpl::template create<typename types::ValueImpl::OptionalNone>())),call_span));
@@ -6737,10 +6775,10 @@ utility::panic(String("Invalid DictionaryIterator configuration"));
 };/*case end*/
 }/*switch end*/
 }()
-))) } ; goto __jakt_label_204;
+))) } ; goto __jakt_label_209;
 
 }
-__jakt_label_204:; __jakt_var_206.release_value(); }));
+__jakt_label_209:; __jakt_var_211.release_value(); }));
 };/*case end*/
 default: {
 {
@@ -11335,7 +11373,7 @@ auto&& __jakt_match_value = __jakt_match_variant.template get<types::CheckedExpr
 parser::BinaryOperator const& op = __jakt_match_value.op;
 NonnullRefPtr<types::CheckedExpression> const& rhs = __jakt_match_value.rhs;
 utility::Span const& span = __jakt_match_value.span;
-return JaktInternal::ExplicitValue(({ Optional<interpreter::StatementResult> __jakt_var_208; {
+return JaktInternal::ExplicitValue(({ Optional<interpreter::StatementResult> __jakt_var_213; {
 types::Value const lhs_value = JAKT_RESOLVE_EXPLICIT_VALUE_OR_CONTROL_FLOW_RETURN_ONLY(([&]() -> JaktInternal::ExplicitValueOrControlFlow<types::Value, ErrorOr<interpreter::StatementResult>>{
 auto&& __jakt_match_variant = TRY((((*this).execute_expression(lhs,scope))));
 switch(__jakt_match_variant.index()) {
@@ -11658,7 +11696,7 @@ return Error::from_errno((infallible_integer_cast<i32>((InterpretError::InvalidT
 ))) } );
 };/*case end*/
 default: {
-return JaktInternal::ExplicitValue(({ Optional<interpreter::StatementResult> __jakt_var_209; {
+return JaktInternal::ExplicitValue(({ Optional<interpreter::StatementResult> __jakt_var_214; {
 types::Value const rhs_value = TRY((((JAKT_RESOLVE_EXPLICIT_VALUE_OR_CONTROL_FLOW_RETURN_ONLY(([&]() -> JaktInternal::ExplicitValueOrControlFlow<types::Value, ErrorOr<interpreter::StatementResult>>{
 auto&& __jakt_match_variant = TRY((((*this).execute_expression(rhs,scope))));
 switch(__jakt_match_variant.index()) {
@@ -11703,10 +11741,10 @@ utility::panic(String("Invalid control flow"));
 default: VERIFY_NOT_REACHED();}/*switch end*/
 }()
 ))).cast(lhs_value,span))));
-__jakt_var_209 = TRY((((*this).execute_binary_operator(lhs_value,rhs_value,op,span,scope)))); goto __jakt_label_207;
+__jakt_var_214 = TRY((((*this).execute_binary_operator(lhs_value,rhs_value,op,span,scope)))); goto __jakt_label_212;
 
 }
-__jakt_label_207:; __jakt_var_209.release_value(); }));
+__jakt_label_212:; __jakt_var_214.release_value(); }));
 };/*case end*/
 }/*switch end*/
 }()
@@ -11821,16 +11859,16 @@ return JaktInternal::ExplicitValue<void>();
 }/*switch end*/
 }()
 ));
-__jakt_var_208 = value; goto __jakt_label_206;
+__jakt_var_213 = value; goto __jakt_label_211;
 
 }
-__jakt_label_206:; __jakt_var_208.release_value(); }));
+__jakt_label_211:; __jakt_var_213.release_value(); }));
 };/*case end*/
 case 5: {
 auto&& __jakt_match_value = __jakt_match_variant.template get<types::CheckedExpression::UnaryOp>();NonnullRefPtr<types::CheckedExpression> const& expr = __jakt_match_value.expr;
 types::CheckedUnaryOperator const& op = __jakt_match_value.op;
 utility::Span const& span = __jakt_match_value.span;
-return JaktInternal::ExplicitValue(({ Optional<interpreter::StatementResult> __jakt_var_210; {
+return JaktInternal::ExplicitValue(({ Optional<interpreter::StatementResult> __jakt_var_215; {
 types::Value const value = JAKT_RESOLVE_EXPLICIT_VALUE_OR_CONTROL_FLOW_RETURN_ONLY(([&]() -> JaktInternal::ExplicitValueOrControlFlow<types::Value, ErrorOr<interpreter::StatementResult>>{
 auto&& __jakt_match_variant = TRY((((*this).execute_expression(expr,scope))));
 switch(__jakt_match_variant.index()) {
@@ -11875,7 +11913,7 @@ utility::panic(String("Invalid control flow"));
 default: VERIFY_NOT_REACHED();}/*switch end*/
 }()
 ));
-__jakt_var_210 = JAKT_RESOLVE_EXPLICIT_VALUE_OR_CONTROL_FLOW_RETURN_ONLY(([&]() -> JaktInternal::ExplicitValueOrControlFlow<interpreter::StatementResult, ErrorOr<interpreter::StatementResult>>{
+__jakt_var_215 = JAKT_RESOLVE_EXPLICIT_VALUE_OR_CONTROL_FLOW_RETURN_ONLY(([&]() -> JaktInternal::ExplicitValueOrControlFlow<interpreter::StatementResult, ErrorOr<interpreter::StatementResult>>{
 auto&& __jakt_match_variant = op;
 switch(__jakt_match_variant.index()) {
 case 9: {
@@ -11906,112 +11944,112 @@ switch(__jakt_match_variant.index()) {
 case 2: {
 auto&& __jakt_match_value = __jakt_match_variant.template get<typename types::ValueImpl::U8>();
 u8 const& x = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(({ Optional<types::Value> __jakt_var_211; {
-TRY((((*this).update_binding(expr,scope,types::Value(TRY((types::ValueImpl::template create<typename types::ValueImpl::U8>((JaktInternal::checked_add<u8>(x,static_cast<u8>(1)))))),span),span))));
-__jakt_var_211 = value; goto __jakt_label_209;
-
-}
-__jakt_label_209:; __jakt_var_211.release_value(); }));
-};/*case end*/
-case 6: {
-auto&& __jakt_match_value = __jakt_match_variant.template get<typename types::ValueImpl::I8>();
-i8 const& x = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(({ Optional<types::Value> __jakt_var_212; {
-TRY((((*this).update_binding(expr,scope,types::Value(TRY((types::ValueImpl::template create<typename types::ValueImpl::I8>((JaktInternal::checked_add<i8>(x,static_cast<i8>(1)))))),span),span))));
-__jakt_var_212 = value; goto __jakt_label_210;
-
-}
-__jakt_label_210:; __jakt_var_212.release_value(); }));
-};/*case end*/
-case 3: {
-auto&& __jakt_match_value = __jakt_match_variant.template get<typename types::ValueImpl::U16>();
-u16 const& x = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(({ Optional<types::Value> __jakt_var_213; {
-TRY((((*this).update_binding(expr,scope,types::Value(TRY((types::ValueImpl::template create<typename types::ValueImpl::U16>((JaktInternal::checked_add<u16>(x,static_cast<u16>(1)))))),span),span))));
-__jakt_var_213 = value; goto __jakt_label_211;
-
-}
-__jakt_label_211:; __jakt_var_213.release_value(); }));
-};/*case end*/
-case 7: {
-auto&& __jakt_match_value = __jakt_match_variant.template get<typename types::ValueImpl::I16>();
-i16 const& x = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(({ Optional<types::Value> __jakt_var_214; {
-TRY((((*this).update_binding(expr,scope,types::Value(TRY((types::ValueImpl::template create<typename types::ValueImpl::I16>((JaktInternal::checked_add<i16>(x,static_cast<i16>(1)))))),span),span))));
-__jakt_var_214 = value; goto __jakt_label_212;
-
-}
-__jakt_label_212:; __jakt_var_214.release_value(); }));
-};/*case end*/
-case 4: {
-auto&& __jakt_match_value = __jakt_match_variant.template get<typename types::ValueImpl::U32>();
-u32 const& x = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(({ Optional<types::Value> __jakt_var_215; {
-TRY((((*this).update_binding(expr,scope,types::Value(TRY((types::ValueImpl::template create<typename types::ValueImpl::U32>((JaktInternal::checked_add<u32>(x,static_cast<u32>(1)))))),span),span))));
-__jakt_var_215 = value; goto __jakt_label_213;
-
-}
-__jakt_label_213:; __jakt_var_215.release_value(); }));
-};/*case end*/
-case 8: {
-auto&& __jakt_match_value = __jakt_match_variant.template get<typename types::ValueImpl::I32>();
-i32 const& x = __jakt_match_value.value;
 return JaktInternal::ExplicitValue(({ Optional<types::Value> __jakt_var_216; {
-TRY((((*this).update_binding(expr,scope,types::Value(TRY((types::ValueImpl::template create<typename types::ValueImpl::I32>((JaktInternal::checked_add<i32>(x,static_cast<i32>(1)))))),span),span))));
+TRY((((*this).update_binding(expr,scope,types::Value(TRY((types::ValueImpl::template create<typename types::ValueImpl::U8>((JaktInternal::checked_add<u8>(x,static_cast<u8>(1)))))),span),span))));
 __jakt_var_216 = value; goto __jakt_label_214;
 
 }
 __jakt_label_214:; __jakt_var_216.release_value(); }));
 };/*case end*/
-case 5: {
-auto&& __jakt_match_value = __jakt_match_variant.template get<typename types::ValueImpl::U64>();
-u64 const& x = __jakt_match_value.value;
+case 6: {
+auto&& __jakt_match_value = __jakt_match_variant.template get<typename types::ValueImpl::I8>();
+i8 const& x = __jakt_match_value.value;
 return JaktInternal::ExplicitValue(({ Optional<types::Value> __jakt_var_217; {
-TRY((((*this).update_binding(expr,scope,types::Value(TRY((types::ValueImpl::template create<typename types::ValueImpl::U64>((JaktInternal::checked_add<u64>(x,static_cast<u64>(1ULL)))))),span),span))));
+TRY((((*this).update_binding(expr,scope,types::Value(TRY((types::ValueImpl::template create<typename types::ValueImpl::I8>((JaktInternal::checked_add<i8>(x,static_cast<i8>(1)))))),span),span))));
 __jakt_var_217 = value; goto __jakt_label_215;
 
 }
 __jakt_label_215:; __jakt_var_217.release_value(); }));
 };/*case end*/
-case 9: {
-auto&& __jakt_match_value = __jakt_match_variant.template get<typename types::ValueImpl::I64>();
-i64 const& x = __jakt_match_value.value;
+case 3: {
+auto&& __jakt_match_value = __jakt_match_variant.template get<typename types::ValueImpl::U16>();
+u16 const& x = __jakt_match_value.value;
 return JaktInternal::ExplicitValue(({ Optional<types::Value> __jakt_var_218; {
-TRY((((*this).update_binding(expr,scope,types::Value(TRY((types::ValueImpl::template create<typename types::ValueImpl::I64>((JaktInternal::checked_add<i64>(x,static_cast<i64>(1LL)))))),span),span))));
+TRY((((*this).update_binding(expr,scope,types::Value(TRY((types::ValueImpl::template create<typename types::ValueImpl::U16>((JaktInternal::checked_add<u16>(x,static_cast<u16>(1)))))),span),span))));
 __jakt_var_218 = value; goto __jakt_label_216;
 
 }
 __jakt_label_216:; __jakt_var_218.release_value(); }));
 };/*case end*/
-case 14: {
-auto&& __jakt_match_value = __jakt_match_variant.template get<typename types::ValueImpl::CChar>();
-char const& x = __jakt_match_value.value;
+case 7: {
+auto&& __jakt_match_value = __jakt_match_variant.template get<typename types::ValueImpl::I16>();
+i16 const& x = __jakt_match_value.value;
 return JaktInternal::ExplicitValue(({ Optional<types::Value> __jakt_var_219; {
-TRY((((*this).update_binding(expr,scope,types::Value(TRY((types::ValueImpl::template create<typename types::ValueImpl::CChar>((JaktInternal::checked_add<char>(x,static_cast<char>(1)))))),span),span))));
+TRY((((*this).update_binding(expr,scope,types::Value(TRY((types::ValueImpl::template create<typename types::ValueImpl::I16>((JaktInternal::checked_add<i16>(x,static_cast<i16>(1)))))),span),span))));
 __jakt_var_219 = value; goto __jakt_label_217;
 
 }
 __jakt_label_217:; __jakt_var_219.release_value(); }));
 };/*case end*/
-case 15: {
-auto&& __jakt_match_value = __jakt_match_variant.template get<typename types::ValueImpl::CInt>();
-int const& x = __jakt_match_value.value;
+case 4: {
+auto&& __jakt_match_value = __jakt_match_variant.template get<typename types::ValueImpl::U32>();
+u32 const& x = __jakt_match_value.value;
 return JaktInternal::ExplicitValue(({ Optional<types::Value> __jakt_var_220; {
-TRY((((*this).update_binding(expr,scope,types::Value(TRY((types::ValueImpl::template create<typename types::ValueImpl::CInt>((JaktInternal::checked_add<int>(x,static_cast<size_t>(1ULL)))))),span),span))));
+TRY((((*this).update_binding(expr,scope,types::Value(TRY((types::ValueImpl::template create<typename types::ValueImpl::U32>((JaktInternal::checked_add<u32>(x,static_cast<u32>(1)))))),span),span))));
 __jakt_var_220 = value; goto __jakt_label_218;
 
 }
 __jakt_label_218:; __jakt_var_220.release_value(); }));
 };/*case end*/
-case 12: {
-auto&& __jakt_match_value = __jakt_match_variant.template get<typename types::ValueImpl::USize>();
-size_t const& x = __jakt_match_value.value;
+case 8: {
+auto&& __jakt_match_value = __jakt_match_variant.template get<typename types::ValueImpl::I32>();
+i32 const& x = __jakt_match_value.value;
 return JaktInternal::ExplicitValue(({ Optional<types::Value> __jakt_var_221; {
-TRY((((*this).update_binding(expr,scope,types::Value(TRY((types::ValueImpl::template create<typename types::ValueImpl::USize>((JaktInternal::checked_add<size_t>(x,static_cast<size_t>(1ULL)))))),span),span))));
+TRY((((*this).update_binding(expr,scope,types::Value(TRY((types::ValueImpl::template create<typename types::ValueImpl::I32>((JaktInternal::checked_add<i32>(x,static_cast<i32>(1)))))),span),span))));
 __jakt_var_221 = value; goto __jakt_label_219;
 
 }
 __jakt_label_219:; __jakt_var_221.release_value(); }));
+};/*case end*/
+case 5: {
+auto&& __jakt_match_value = __jakt_match_variant.template get<typename types::ValueImpl::U64>();
+u64 const& x = __jakt_match_value.value;
+return JaktInternal::ExplicitValue(({ Optional<types::Value> __jakt_var_222; {
+TRY((((*this).update_binding(expr,scope,types::Value(TRY((types::ValueImpl::template create<typename types::ValueImpl::U64>((JaktInternal::checked_add<u64>(x,static_cast<u64>(1ULL)))))),span),span))));
+__jakt_var_222 = value; goto __jakt_label_220;
+
+}
+__jakt_label_220:; __jakt_var_222.release_value(); }));
+};/*case end*/
+case 9: {
+auto&& __jakt_match_value = __jakt_match_variant.template get<typename types::ValueImpl::I64>();
+i64 const& x = __jakt_match_value.value;
+return JaktInternal::ExplicitValue(({ Optional<types::Value> __jakt_var_223; {
+TRY((((*this).update_binding(expr,scope,types::Value(TRY((types::ValueImpl::template create<typename types::ValueImpl::I64>((JaktInternal::checked_add<i64>(x,static_cast<i64>(1LL)))))),span),span))));
+__jakt_var_223 = value; goto __jakt_label_221;
+
+}
+__jakt_label_221:; __jakt_var_223.release_value(); }));
+};/*case end*/
+case 14: {
+auto&& __jakt_match_value = __jakt_match_variant.template get<typename types::ValueImpl::CChar>();
+char const& x = __jakt_match_value.value;
+return JaktInternal::ExplicitValue(({ Optional<types::Value> __jakt_var_224; {
+TRY((((*this).update_binding(expr,scope,types::Value(TRY((types::ValueImpl::template create<typename types::ValueImpl::CChar>((JaktInternal::checked_add<char>(x,static_cast<char>(1)))))),span),span))));
+__jakt_var_224 = value; goto __jakt_label_222;
+
+}
+__jakt_label_222:; __jakt_var_224.release_value(); }));
+};/*case end*/
+case 15: {
+auto&& __jakt_match_value = __jakt_match_variant.template get<typename types::ValueImpl::CInt>();
+int const& x = __jakt_match_value.value;
+return JaktInternal::ExplicitValue(({ Optional<types::Value> __jakt_var_225; {
+TRY((((*this).update_binding(expr,scope,types::Value(TRY((types::ValueImpl::template create<typename types::ValueImpl::CInt>((JaktInternal::checked_add<int>(x,static_cast<size_t>(1ULL)))))),span),span))));
+__jakt_var_225 = value; goto __jakt_label_223;
+
+}
+__jakt_label_223:; __jakt_var_225.release_value(); }));
+};/*case end*/
+case 12: {
+auto&& __jakt_match_value = __jakt_match_variant.template get<typename types::ValueImpl::USize>();
+size_t const& x = __jakt_match_value.value;
+return JaktInternal::ExplicitValue(({ Optional<types::Value> __jakt_var_226; {
+TRY((((*this).update_binding(expr,scope,types::Value(TRY((types::ValueImpl::template create<typename types::ValueImpl::USize>((JaktInternal::checked_add<size_t>(x,static_cast<size_t>(1ULL)))))),span),span))));
+__jakt_var_226 = value; goto __jakt_label_224;
+
+}
+__jakt_label_224:; __jakt_var_226.release_value(); }));
 };/*case end*/
 default: {
 {
@@ -12031,123 +12069,123 @@ switch(__jakt_match_variant.index()) {
 case 2: {
 auto&& __jakt_match_value = __jakt_match_variant.template get<typename types::ValueImpl::U8>();
 u8 const& x = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(({ Optional<types::Value> __jakt_var_222; {
-types::Value const value = types::Value(TRY((types::ValueImpl::template create<typename types::ValueImpl::U8>((JaktInternal::checked_add<u8>(x,static_cast<u8>(1)))))),span);
-TRY((((*this).update_binding(expr,scope,value,span))));
-__jakt_var_222 = value; goto __jakt_label_220;
-
-}
-__jakt_label_220:; __jakt_var_222.release_value(); }));
-};/*case end*/
-case 6: {
-auto&& __jakt_match_value = __jakt_match_variant.template get<typename types::ValueImpl::I8>();
-i8 const& x = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(({ Optional<types::Value> __jakt_var_223; {
-types::Value const value = types::Value(TRY((types::ValueImpl::template create<typename types::ValueImpl::I8>((JaktInternal::checked_add<i8>(x,static_cast<i8>(1)))))),span);
-TRY((((*this).update_binding(expr,scope,value,span))));
-__jakt_var_223 = value; goto __jakt_label_221;
-
-}
-__jakt_label_221:; __jakt_var_223.release_value(); }));
-};/*case end*/
-case 3: {
-auto&& __jakt_match_value = __jakt_match_variant.template get<typename types::ValueImpl::U16>();
-u16 const& x = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(({ Optional<types::Value> __jakt_var_224; {
-types::Value const value = types::Value(TRY((types::ValueImpl::template create<typename types::ValueImpl::U16>((JaktInternal::checked_add<u16>(x,static_cast<u16>(1)))))),span);
-TRY((((*this).update_binding(expr,scope,value,span))));
-__jakt_var_224 = value; goto __jakt_label_222;
-
-}
-__jakt_label_222:; __jakt_var_224.release_value(); }));
-};/*case end*/
-case 7: {
-auto&& __jakt_match_value = __jakt_match_variant.template get<typename types::ValueImpl::I16>();
-i16 const& x = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(({ Optional<types::Value> __jakt_var_225; {
-types::Value const value = types::Value(TRY((types::ValueImpl::template create<typename types::ValueImpl::I16>((JaktInternal::checked_add<i16>(x,static_cast<i16>(1)))))),span);
-TRY((((*this).update_binding(expr,scope,value,span))));
-__jakt_var_225 = value; goto __jakt_label_223;
-
-}
-__jakt_label_223:; __jakt_var_225.release_value(); }));
-};/*case end*/
-case 4: {
-auto&& __jakt_match_value = __jakt_match_variant.template get<typename types::ValueImpl::U32>();
-u32 const& x = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(({ Optional<types::Value> __jakt_var_226; {
-types::Value const value = types::Value(TRY((types::ValueImpl::template create<typename types::ValueImpl::U32>((JaktInternal::checked_add<u32>(x,static_cast<u32>(1)))))),span);
-TRY((((*this).update_binding(expr,scope,value,span))));
-__jakt_var_226 = value; goto __jakt_label_224;
-
-}
-__jakt_label_224:; __jakt_var_226.release_value(); }));
-};/*case end*/
-case 8: {
-auto&& __jakt_match_value = __jakt_match_variant.template get<typename types::ValueImpl::I32>();
-i32 const& x = __jakt_match_value.value;
 return JaktInternal::ExplicitValue(({ Optional<types::Value> __jakt_var_227; {
-types::Value const value = types::Value(TRY((types::ValueImpl::template create<typename types::ValueImpl::I32>((JaktInternal::checked_add<i32>(x,static_cast<i32>(1)))))),span);
+types::Value const value = types::Value(TRY((types::ValueImpl::template create<typename types::ValueImpl::U8>((JaktInternal::checked_add<u8>(x,static_cast<u8>(1)))))),span);
 TRY((((*this).update_binding(expr,scope,value,span))));
 __jakt_var_227 = value; goto __jakt_label_225;
 
 }
 __jakt_label_225:; __jakt_var_227.release_value(); }));
 };/*case end*/
-case 5: {
-auto&& __jakt_match_value = __jakt_match_variant.template get<typename types::ValueImpl::U64>();
-u64 const& x = __jakt_match_value.value;
+case 6: {
+auto&& __jakt_match_value = __jakt_match_variant.template get<typename types::ValueImpl::I8>();
+i8 const& x = __jakt_match_value.value;
 return JaktInternal::ExplicitValue(({ Optional<types::Value> __jakt_var_228; {
-types::Value const value = types::Value(TRY((types::ValueImpl::template create<typename types::ValueImpl::U64>((JaktInternal::checked_add<u64>(x,static_cast<u64>(1ULL)))))),span);
+types::Value const value = types::Value(TRY((types::ValueImpl::template create<typename types::ValueImpl::I8>((JaktInternal::checked_add<i8>(x,static_cast<i8>(1)))))),span);
 TRY((((*this).update_binding(expr,scope,value,span))));
 __jakt_var_228 = value; goto __jakt_label_226;
 
 }
 __jakt_label_226:; __jakt_var_228.release_value(); }));
 };/*case end*/
-case 9: {
-auto&& __jakt_match_value = __jakt_match_variant.template get<typename types::ValueImpl::I64>();
-i64 const& x = __jakt_match_value.value;
+case 3: {
+auto&& __jakt_match_value = __jakt_match_variant.template get<typename types::ValueImpl::U16>();
+u16 const& x = __jakt_match_value.value;
 return JaktInternal::ExplicitValue(({ Optional<types::Value> __jakt_var_229; {
-types::Value const value = types::Value(TRY((types::ValueImpl::template create<typename types::ValueImpl::I64>((JaktInternal::checked_add<i64>(x,static_cast<i64>(1LL)))))),span);
+types::Value const value = types::Value(TRY((types::ValueImpl::template create<typename types::ValueImpl::U16>((JaktInternal::checked_add<u16>(x,static_cast<u16>(1)))))),span);
 TRY((((*this).update_binding(expr,scope,value,span))));
 __jakt_var_229 = value; goto __jakt_label_227;
 
 }
 __jakt_label_227:; __jakt_var_229.release_value(); }));
 };/*case end*/
-case 14: {
-auto&& __jakt_match_value = __jakt_match_variant.template get<typename types::ValueImpl::CChar>();
-char const& x = __jakt_match_value.value;
+case 7: {
+auto&& __jakt_match_value = __jakt_match_variant.template get<typename types::ValueImpl::I16>();
+i16 const& x = __jakt_match_value.value;
 return JaktInternal::ExplicitValue(({ Optional<types::Value> __jakt_var_230; {
-types::Value const value = types::Value(TRY((types::ValueImpl::template create<typename types::ValueImpl::CChar>((JaktInternal::checked_add<char>(x,static_cast<char>(1)))))),span);
+types::Value const value = types::Value(TRY((types::ValueImpl::template create<typename types::ValueImpl::I16>((JaktInternal::checked_add<i16>(x,static_cast<i16>(1)))))),span);
 TRY((((*this).update_binding(expr,scope,value,span))));
 __jakt_var_230 = value; goto __jakt_label_228;
 
 }
 __jakt_label_228:; __jakt_var_230.release_value(); }));
 };/*case end*/
-case 15: {
-auto&& __jakt_match_value = __jakt_match_variant.template get<typename types::ValueImpl::CInt>();
-int const& x = __jakt_match_value.value;
+case 4: {
+auto&& __jakt_match_value = __jakt_match_variant.template get<typename types::ValueImpl::U32>();
+u32 const& x = __jakt_match_value.value;
 return JaktInternal::ExplicitValue(({ Optional<types::Value> __jakt_var_231; {
-types::Value const value = types::Value(TRY((types::ValueImpl::template create<typename types::ValueImpl::CInt>((JaktInternal::checked_add<int>(x,static_cast<size_t>(1ULL)))))),span);
+types::Value const value = types::Value(TRY((types::ValueImpl::template create<typename types::ValueImpl::U32>((JaktInternal::checked_add<u32>(x,static_cast<u32>(1)))))),span);
 TRY((((*this).update_binding(expr,scope,value,span))));
 __jakt_var_231 = value; goto __jakt_label_229;
 
 }
 __jakt_label_229:; __jakt_var_231.release_value(); }));
 };/*case end*/
-case 12: {
-auto&& __jakt_match_value = __jakt_match_variant.template get<typename types::ValueImpl::USize>();
-size_t const& x = __jakt_match_value.value;
+case 8: {
+auto&& __jakt_match_value = __jakt_match_variant.template get<typename types::ValueImpl::I32>();
+i32 const& x = __jakt_match_value.value;
 return JaktInternal::ExplicitValue(({ Optional<types::Value> __jakt_var_232; {
-types::Value const value = types::Value(TRY((types::ValueImpl::template create<typename types::ValueImpl::USize>((JaktInternal::checked_add<size_t>(x,static_cast<size_t>(1ULL)))))),span);
+types::Value const value = types::Value(TRY((types::ValueImpl::template create<typename types::ValueImpl::I32>((JaktInternal::checked_add<i32>(x,static_cast<i32>(1)))))),span);
 TRY((((*this).update_binding(expr,scope,value,span))));
 __jakt_var_232 = value; goto __jakt_label_230;
 
 }
 __jakt_label_230:; __jakt_var_232.release_value(); }));
+};/*case end*/
+case 5: {
+auto&& __jakt_match_value = __jakt_match_variant.template get<typename types::ValueImpl::U64>();
+u64 const& x = __jakt_match_value.value;
+return JaktInternal::ExplicitValue(({ Optional<types::Value> __jakt_var_233; {
+types::Value const value = types::Value(TRY((types::ValueImpl::template create<typename types::ValueImpl::U64>((JaktInternal::checked_add<u64>(x,static_cast<u64>(1ULL)))))),span);
+TRY((((*this).update_binding(expr,scope,value,span))));
+__jakt_var_233 = value; goto __jakt_label_231;
+
+}
+__jakt_label_231:; __jakt_var_233.release_value(); }));
+};/*case end*/
+case 9: {
+auto&& __jakt_match_value = __jakt_match_variant.template get<typename types::ValueImpl::I64>();
+i64 const& x = __jakt_match_value.value;
+return JaktInternal::ExplicitValue(({ Optional<types::Value> __jakt_var_234; {
+types::Value const value = types::Value(TRY((types::ValueImpl::template create<typename types::ValueImpl::I64>((JaktInternal::checked_add<i64>(x,static_cast<i64>(1LL)))))),span);
+TRY((((*this).update_binding(expr,scope,value,span))));
+__jakt_var_234 = value; goto __jakt_label_232;
+
+}
+__jakt_label_232:; __jakt_var_234.release_value(); }));
+};/*case end*/
+case 14: {
+auto&& __jakt_match_value = __jakt_match_variant.template get<typename types::ValueImpl::CChar>();
+char const& x = __jakt_match_value.value;
+return JaktInternal::ExplicitValue(({ Optional<types::Value> __jakt_var_235; {
+types::Value const value = types::Value(TRY((types::ValueImpl::template create<typename types::ValueImpl::CChar>((JaktInternal::checked_add<char>(x,static_cast<char>(1)))))),span);
+TRY((((*this).update_binding(expr,scope,value,span))));
+__jakt_var_235 = value; goto __jakt_label_233;
+
+}
+__jakt_label_233:; __jakt_var_235.release_value(); }));
+};/*case end*/
+case 15: {
+auto&& __jakt_match_value = __jakt_match_variant.template get<typename types::ValueImpl::CInt>();
+int const& x = __jakt_match_value.value;
+return JaktInternal::ExplicitValue(({ Optional<types::Value> __jakt_var_236; {
+types::Value const value = types::Value(TRY((types::ValueImpl::template create<typename types::ValueImpl::CInt>((JaktInternal::checked_add<int>(x,static_cast<size_t>(1ULL)))))),span);
+TRY((((*this).update_binding(expr,scope,value,span))));
+__jakt_var_236 = value; goto __jakt_label_234;
+
+}
+__jakt_label_234:; __jakt_var_236.release_value(); }));
+};/*case end*/
+case 12: {
+auto&& __jakt_match_value = __jakt_match_variant.template get<typename types::ValueImpl::USize>();
+size_t const& x = __jakt_match_value.value;
+return JaktInternal::ExplicitValue(({ Optional<types::Value> __jakt_var_237; {
+types::Value const value = types::Value(TRY((types::ValueImpl::template create<typename types::ValueImpl::USize>((JaktInternal::checked_add<size_t>(x,static_cast<size_t>(1ULL)))))),span);
+TRY((((*this).update_binding(expr,scope,value,span))));
+__jakt_var_237 = value; goto __jakt_label_235;
+
+}
+__jakt_label_235:; __jakt_var_237.release_value(); }));
 };/*case end*/
 default: {
 {
@@ -12167,112 +12205,112 @@ switch(__jakt_match_variant.index()) {
 case 2: {
 auto&& __jakt_match_value = __jakt_match_variant.template get<typename types::ValueImpl::U8>();
 u8 const& x = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(({ Optional<types::Value> __jakt_var_233; {
-TRY((((*this).update_binding(expr,scope,types::Value(TRY((types::ValueImpl::template create<typename types::ValueImpl::U8>((JaktInternal::checked_sub<u8>(x,static_cast<u8>(1)))))),span),span))));
-__jakt_var_233 = value; goto __jakt_label_231;
-
-}
-__jakt_label_231:; __jakt_var_233.release_value(); }));
-};/*case end*/
-case 6: {
-auto&& __jakt_match_value = __jakt_match_variant.template get<typename types::ValueImpl::I8>();
-i8 const& x = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(({ Optional<types::Value> __jakt_var_234; {
-TRY((((*this).update_binding(expr,scope,types::Value(TRY((types::ValueImpl::template create<typename types::ValueImpl::I8>((JaktInternal::checked_sub<i8>(x,static_cast<i8>(1)))))),span),span))));
-__jakt_var_234 = value; goto __jakt_label_232;
-
-}
-__jakt_label_232:; __jakt_var_234.release_value(); }));
-};/*case end*/
-case 3: {
-auto&& __jakt_match_value = __jakt_match_variant.template get<typename types::ValueImpl::U16>();
-u16 const& x = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(({ Optional<types::Value> __jakt_var_235; {
-TRY((((*this).update_binding(expr,scope,types::Value(TRY((types::ValueImpl::template create<typename types::ValueImpl::U16>((JaktInternal::checked_sub<u16>(x,static_cast<u16>(1)))))),span),span))));
-__jakt_var_235 = value; goto __jakt_label_233;
-
-}
-__jakt_label_233:; __jakt_var_235.release_value(); }));
-};/*case end*/
-case 7: {
-auto&& __jakt_match_value = __jakt_match_variant.template get<typename types::ValueImpl::I16>();
-i16 const& x = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(({ Optional<types::Value> __jakt_var_236; {
-TRY((((*this).update_binding(expr,scope,types::Value(TRY((types::ValueImpl::template create<typename types::ValueImpl::I16>((JaktInternal::checked_sub<i16>(x,static_cast<i16>(1)))))),span),span))));
-__jakt_var_236 = value; goto __jakt_label_234;
-
-}
-__jakt_label_234:; __jakt_var_236.release_value(); }));
-};/*case end*/
-case 4: {
-auto&& __jakt_match_value = __jakt_match_variant.template get<typename types::ValueImpl::U32>();
-u32 const& x = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(({ Optional<types::Value> __jakt_var_237; {
-TRY((((*this).update_binding(expr,scope,types::Value(TRY((types::ValueImpl::template create<typename types::ValueImpl::U32>((JaktInternal::checked_sub<u32>(x,static_cast<u32>(1)))))),span),span))));
-__jakt_var_237 = value; goto __jakt_label_235;
-
-}
-__jakt_label_235:; __jakt_var_237.release_value(); }));
-};/*case end*/
-case 8: {
-auto&& __jakt_match_value = __jakt_match_variant.template get<typename types::ValueImpl::I32>();
-i32 const& x = __jakt_match_value.value;
 return JaktInternal::ExplicitValue(({ Optional<types::Value> __jakt_var_238; {
-TRY((((*this).update_binding(expr,scope,types::Value(TRY((types::ValueImpl::template create<typename types::ValueImpl::I32>((JaktInternal::checked_sub<i32>(x,static_cast<i32>(1)))))),span),span))));
+TRY((((*this).update_binding(expr,scope,types::Value(TRY((types::ValueImpl::template create<typename types::ValueImpl::U8>((JaktInternal::checked_sub<u8>(x,static_cast<u8>(1)))))),span),span))));
 __jakt_var_238 = value; goto __jakt_label_236;
 
 }
 __jakt_label_236:; __jakt_var_238.release_value(); }));
 };/*case end*/
-case 5: {
-auto&& __jakt_match_value = __jakt_match_variant.template get<typename types::ValueImpl::U64>();
-u64 const& x = __jakt_match_value.value;
+case 6: {
+auto&& __jakt_match_value = __jakt_match_variant.template get<typename types::ValueImpl::I8>();
+i8 const& x = __jakt_match_value.value;
 return JaktInternal::ExplicitValue(({ Optional<types::Value> __jakt_var_239; {
-TRY((((*this).update_binding(expr,scope,types::Value(TRY((types::ValueImpl::template create<typename types::ValueImpl::U64>((JaktInternal::checked_sub<u64>(x,static_cast<u64>(1ULL)))))),span),span))));
+TRY((((*this).update_binding(expr,scope,types::Value(TRY((types::ValueImpl::template create<typename types::ValueImpl::I8>((JaktInternal::checked_sub<i8>(x,static_cast<i8>(1)))))),span),span))));
 __jakt_var_239 = value; goto __jakt_label_237;
 
 }
 __jakt_label_237:; __jakt_var_239.release_value(); }));
 };/*case end*/
-case 9: {
-auto&& __jakt_match_value = __jakt_match_variant.template get<typename types::ValueImpl::I64>();
-i64 const& x = __jakt_match_value.value;
+case 3: {
+auto&& __jakt_match_value = __jakt_match_variant.template get<typename types::ValueImpl::U16>();
+u16 const& x = __jakt_match_value.value;
 return JaktInternal::ExplicitValue(({ Optional<types::Value> __jakt_var_240; {
-TRY((((*this).update_binding(expr,scope,types::Value(TRY((types::ValueImpl::template create<typename types::ValueImpl::I64>((JaktInternal::checked_sub<i64>(x,static_cast<i64>(1LL)))))),span),span))));
+TRY((((*this).update_binding(expr,scope,types::Value(TRY((types::ValueImpl::template create<typename types::ValueImpl::U16>((JaktInternal::checked_sub<u16>(x,static_cast<u16>(1)))))),span),span))));
 __jakt_var_240 = value; goto __jakt_label_238;
 
 }
 __jakt_label_238:; __jakt_var_240.release_value(); }));
 };/*case end*/
-case 14: {
-auto&& __jakt_match_value = __jakt_match_variant.template get<typename types::ValueImpl::CChar>();
-char const& x = __jakt_match_value.value;
+case 7: {
+auto&& __jakt_match_value = __jakt_match_variant.template get<typename types::ValueImpl::I16>();
+i16 const& x = __jakt_match_value.value;
 return JaktInternal::ExplicitValue(({ Optional<types::Value> __jakt_var_241; {
-TRY((((*this).update_binding(expr,scope,types::Value(TRY((types::ValueImpl::template create<typename types::ValueImpl::CChar>((JaktInternal::checked_sub<char>(x,static_cast<char>(1)))))),span),span))));
+TRY((((*this).update_binding(expr,scope,types::Value(TRY((types::ValueImpl::template create<typename types::ValueImpl::I16>((JaktInternal::checked_sub<i16>(x,static_cast<i16>(1)))))),span),span))));
 __jakt_var_241 = value; goto __jakt_label_239;
 
 }
 __jakt_label_239:; __jakt_var_241.release_value(); }));
 };/*case end*/
-case 15: {
-auto&& __jakt_match_value = __jakt_match_variant.template get<typename types::ValueImpl::CInt>();
-int const& x = __jakt_match_value.value;
+case 4: {
+auto&& __jakt_match_value = __jakt_match_variant.template get<typename types::ValueImpl::U32>();
+u32 const& x = __jakt_match_value.value;
 return JaktInternal::ExplicitValue(({ Optional<types::Value> __jakt_var_242; {
-TRY((((*this).update_binding(expr,scope,types::Value(TRY((types::ValueImpl::template create<typename types::ValueImpl::CInt>((JaktInternal::checked_sub<int>(x,static_cast<size_t>(1ULL)))))),span),span))));
+TRY((((*this).update_binding(expr,scope,types::Value(TRY((types::ValueImpl::template create<typename types::ValueImpl::U32>((JaktInternal::checked_sub<u32>(x,static_cast<u32>(1)))))),span),span))));
 __jakt_var_242 = value; goto __jakt_label_240;
 
 }
 __jakt_label_240:; __jakt_var_242.release_value(); }));
 };/*case end*/
-case 12: {
-auto&& __jakt_match_value = __jakt_match_variant.template get<typename types::ValueImpl::USize>();
-size_t const& x = __jakt_match_value.value;
+case 8: {
+auto&& __jakt_match_value = __jakt_match_variant.template get<typename types::ValueImpl::I32>();
+i32 const& x = __jakt_match_value.value;
 return JaktInternal::ExplicitValue(({ Optional<types::Value> __jakt_var_243; {
-TRY((((*this).update_binding(expr,scope,types::Value(TRY((types::ValueImpl::template create<typename types::ValueImpl::USize>((JaktInternal::checked_sub<size_t>(x,static_cast<size_t>(1ULL)))))),span),span))));
+TRY((((*this).update_binding(expr,scope,types::Value(TRY((types::ValueImpl::template create<typename types::ValueImpl::I32>((JaktInternal::checked_sub<i32>(x,static_cast<i32>(1)))))),span),span))));
 __jakt_var_243 = value; goto __jakt_label_241;
 
 }
 __jakt_label_241:; __jakt_var_243.release_value(); }));
+};/*case end*/
+case 5: {
+auto&& __jakt_match_value = __jakt_match_variant.template get<typename types::ValueImpl::U64>();
+u64 const& x = __jakt_match_value.value;
+return JaktInternal::ExplicitValue(({ Optional<types::Value> __jakt_var_244; {
+TRY((((*this).update_binding(expr,scope,types::Value(TRY((types::ValueImpl::template create<typename types::ValueImpl::U64>((JaktInternal::checked_sub<u64>(x,static_cast<u64>(1ULL)))))),span),span))));
+__jakt_var_244 = value; goto __jakt_label_242;
+
+}
+__jakt_label_242:; __jakt_var_244.release_value(); }));
+};/*case end*/
+case 9: {
+auto&& __jakt_match_value = __jakt_match_variant.template get<typename types::ValueImpl::I64>();
+i64 const& x = __jakt_match_value.value;
+return JaktInternal::ExplicitValue(({ Optional<types::Value> __jakt_var_245; {
+TRY((((*this).update_binding(expr,scope,types::Value(TRY((types::ValueImpl::template create<typename types::ValueImpl::I64>((JaktInternal::checked_sub<i64>(x,static_cast<i64>(1LL)))))),span),span))));
+__jakt_var_245 = value; goto __jakt_label_243;
+
+}
+__jakt_label_243:; __jakt_var_245.release_value(); }));
+};/*case end*/
+case 14: {
+auto&& __jakt_match_value = __jakt_match_variant.template get<typename types::ValueImpl::CChar>();
+char const& x = __jakt_match_value.value;
+return JaktInternal::ExplicitValue(({ Optional<types::Value> __jakt_var_246; {
+TRY((((*this).update_binding(expr,scope,types::Value(TRY((types::ValueImpl::template create<typename types::ValueImpl::CChar>((JaktInternal::checked_sub<char>(x,static_cast<char>(1)))))),span),span))));
+__jakt_var_246 = value; goto __jakt_label_244;
+
+}
+__jakt_label_244:; __jakt_var_246.release_value(); }));
+};/*case end*/
+case 15: {
+auto&& __jakt_match_value = __jakt_match_variant.template get<typename types::ValueImpl::CInt>();
+int const& x = __jakt_match_value.value;
+return JaktInternal::ExplicitValue(({ Optional<types::Value> __jakt_var_247; {
+TRY((((*this).update_binding(expr,scope,types::Value(TRY((types::ValueImpl::template create<typename types::ValueImpl::CInt>((JaktInternal::checked_sub<int>(x,static_cast<size_t>(1ULL)))))),span),span))));
+__jakt_var_247 = value; goto __jakt_label_245;
+
+}
+__jakt_label_245:; __jakt_var_247.release_value(); }));
+};/*case end*/
+case 12: {
+auto&& __jakt_match_value = __jakt_match_variant.template get<typename types::ValueImpl::USize>();
+size_t const& x = __jakt_match_value.value;
+return JaktInternal::ExplicitValue(({ Optional<types::Value> __jakt_var_248; {
+TRY((((*this).update_binding(expr,scope,types::Value(TRY((types::ValueImpl::template create<typename types::ValueImpl::USize>((JaktInternal::checked_sub<size_t>(x,static_cast<size_t>(1ULL)))))),span),span))));
+__jakt_var_248 = value; goto __jakt_label_246;
+
+}
+__jakt_label_246:; __jakt_var_248.release_value(); }));
 };/*case end*/
 default: {
 {
@@ -12292,123 +12330,123 @@ switch(__jakt_match_variant.index()) {
 case 2: {
 auto&& __jakt_match_value = __jakt_match_variant.template get<typename types::ValueImpl::U8>();
 u8 const& x = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(({ Optional<types::Value> __jakt_var_244; {
-types::Value const value = types::Value(TRY((types::ValueImpl::template create<typename types::ValueImpl::U8>((JaktInternal::checked_sub<u8>(x,static_cast<u8>(1)))))),span);
-TRY((((*this).update_binding(expr,scope,value,span))));
-__jakt_var_244 = value; goto __jakt_label_242;
-
-}
-__jakt_label_242:; __jakt_var_244.release_value(); }));
-};/*case end*/
-case 6: {
-auto&& __jakt_match_value = __jakt_match_variant.template get<typename types::ValueImpl::I8>();
-i8 const& x = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(({ Optional<types::Value> __jakt_var_245; {
-types::Value const value = types::Value(TRY((types::ValueImpl::template create<typename types::ValueImpl::I8>((JaktInternal::checked_sub<i8>(x,static_cast<i8>(1)))))),span);
-TRY((((*this).update_binding(expr,scope,value,span))));
-__jakt_var_245 = value; goto __jakt_label_243;
-
-}
-__jakt_label_243:; __jakt_var_245.release_value(); }));
-};/*case end*/
-case 3: {
-auto&& __jakt_match_value = __jakt_match_variant.template get<typename types::ValueImpl::U16>();
-u16 const& x = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(({ Optional<types::Value> __jakt_var_246; {
-types::Value const value = types::Value(TRY((types::ValueImpl::template create<typename types::ValueImpl::U16>((JaktInternal::checked_sub<u16>(x,static_cast<u16>(1)))))),span);
-TRY((((*this).update_binding(expr,scope,value,span))));
-__jakt_var_246 = value; goto __jakt_label_244;
-
-}
-__jakt_label_244:; __jakt_var_246.release_value(); }));
-};/*case end*/
-case 7: {
-auto&& __jakt_match_value = __jakt_match_variant.template get<typename types::ValueImpl::I16>();
-i16 const& x = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(({ Optional<types::Value> __jakt_var_247; {
-types::Value const value = types::Value(TRY((types::ValueImpl::template create<typename types::ValueImpl::I16>((JaktInternal::checked_sub<i16>(x,static_cast<i16>(1)))))),span);
-TRY((((*this).update_binding(expr,scope,value,span))));
-__jakt_var_247 = value; goto __jakt_label_245;
-
-}
-__jakt_label_245:; __jakt_var_247.release_value(); }));
-};/*case end*/
-case 4: {
-auto&& __jakt_match_value = __jakt_match_variant.template get<typename types::ValueImpl::U32>();
-u32 const& x = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(({ Optional<types::Value> __jakt_var_248; {
-types::Value const value = types::Value(TRY((types::ValueImpl::template create<typename types::ValueImpl::U32>((JaktInternal::checked_sub<u32>(x,static_cast<u32>(1)))))),span);
-TRY((((*this).update_binding(expr,scope,value,span))));
-__jakt_var_248 = value; goto __jakt_label_246;
-
-}
-__jakt_label_246:; __jakt_var_248.release_value(); }));
-};/*case end*/
-case 8: {
-auto&& __jakt_match_value = __jakt_match_variant.template get<typename types::ValueImpl::I32>();
-i32 const& x = __jakt_match_value.value;
 return JaktInternal::ExplicitValue(({ Optional<types::Value> __jakt_var_249; {
-types::Value const value = types::Value(TRY((types::ValueImpl::template create<typename types::ValueImpl::I32>((JaktInternal::checked_sub<i32>(x,static_cast<i32>(1)))))),span);
+types::Value const value = types::Value(TRY((types::ValueImpl::template create<typename types::ValueImpl::U8>((JaktInternal::checked_sub<u8>(x,static_cast<u8>(1)))))),span);
 TRY((((*this).update_binding(expr,scope,value,span))));
 __jakt_var_249 = value; goto __jakt_label_247;
 
 }
 __jakt_label_247:; __jakt_var_249.release_value(); }));
 };/*case end*/
-case 5: {
-auto&& __jakt_match_value = __jakt_match_variant.template get<typename types::ValueImpl::U64>();
-u64 const& x = __jakt_match_value.value;
+case 6: {
+auto&& __jakt_match_value = __jakt_match_variant.template get<typename types::ValueImpl::I8>();
+i8 const& x = __jakt_match_value.value;
 return JaktInternal::ExplicitValue(({ Optional<types::Value> __jakt_var_250; {
-types::Value const value = types::Value(TRY((types::ValueImpl::template create<typename types::ValueImpl::U64>((JaktInternal::checked_sub<u64>(x,static_cast<u64>(1ULL)))))),span);
+types::Value const value = types::Value(TRY((types::ValueImpl::template create<typename types::ValueImpl::I8>((JaktInternal::checked_sub<i8>(x,static_cast<i8>(1)))))),span);
 TRY((((*this).update_binding(expr,scope,value,span))));
 __jakt_var_250 = value; goto __jakt_label_248;
 
 }
 __jakt_label_248:; __jakt_var_250.release_value(); }));
 };/*case end*/
-case 9: {
-auto&& __jakt_match_value = __jakt_match_variant.template get<typename types::ValueImpl::I64>();
-i64 const& x = __jakt_match_value.value;
+case 3: {
+auto&& __jakt_match_value = __jakt_match_variant.template get<typename types::ValueImpl::U16>();
+u16 const& x = __jakt_match_value.value;
 return JaktInternal::ExplicitValue(({ Optional<types::Value> __jakt_var_251; {
-types::Value const value = types::Value(TRY((types::ValueImpl::template create<typename types::ValueImpl::I64>((JaktInternal::checked_sub<i64>(x,static_cast<i64>(1LL)))))),span);
+types::Value const value = types::Value(TRY((types::ValueImpl::template create<typename types::ValueImpl::U16>((JaktInternal::checked_sub<u16>(x,static_cast<u16>(1)))))),span);
 TRY((((*this).update_binding(expr,scope,value,span))));
 __jakt_var_251 = value; goto __jakt_label_249;
 
 }
 __jakt_label_249:; __jakt_var_251.release_value(); }));
 };/*case end*/
-case 14: {
-auto&& __jakt_match_value = __jakt_match_variant.template get<typename types::ValueImpl::CChar>();
-char const& x = __jakt_match_value.value;
+case 7: {
+auto&& __jakt_match_value = __jakt_match_variant.template get<typename types::ValueImpl::I16>();
+i16 const& x = __jakt_match_value.value;
 return JaktInternal::ExplicitValue(({ Optional<types::Value> __jakt_var_252; {
-types::Value const value = types::Value(TRY((types::ValueImpl::template create<typename types::ValueImpl::CChar>((JaktInternal::checked_sub<char>(x,static_cast<char>(1)))))),span);
+types::Value const value = types::Value(TRY((types::ValueImpl::template create<typename types::ValueImpl::I16>((JaktInternal::checked_sub<i16>(x,static_cast<i16>(1)))))),span);
 TRY((((*this).update_binding(expr,scope,value,span))));
 __jakt_var_252 = value; goto __jakt_label_250;
 
 }
 __jakt_label_250:; __jakt_var_252.release_value(); }));
 };/*case end*/
-case 15: {
-auto&& __jakt_match_value = __jakt_match_variant.template get<typename types::ValueImpl::CInt>();
-int const& x = __jakt_match_value.value;
+case 4: {
+auto&& __jakt_match_value = __jakt_match_variant.template get<typename types::ValueImpl::U32>();
+u32 const& x = __jakt_match_value.value;
 return JaktInternal::ExplicitValue(({ Optional<types::Value> __jakt_var_253; {
-types::Value const value = types::Value(TRY((types::ValueImpl::template create<typename types::ValueImpl::CInt>((JaktInternal::checked_sub<int>(x,static_cast<size_t>(1ULL)))))),span);
+types::Value const value = types::Value(TRY((types::ValueImpl::template create<typename types::ValueImpl::U32>((JaktInternal::checked_sub<u32>(x,static_cast<u32>(1)))))),span);
 TRY((((*this).update_binding(expr,scope,value,span))));
 __jakt_var_253 = value; goto __jakt_label_251;
 
 }
 __jakt_label_251:; __jakt_var_253.release_value(); }));
 };/*case end*/
-case 12: {
-auto&& __jakt_match_value = __jakt_match_variant.template get<typename types::ValueImpl::USize>();
-size_t const& x = __jakt_match_value.value;
+case 8: {
+auto&& __jakt_match_value = __jakt_match_variant.template get<typename types::ValueImpl::I32>();
+i32 const& x = __jakt_match_value.value;
 return JaktInternal::ExplicitValue(({ Optional<types::Value> __jakt_var_254; {
-types::Value const value = types::Value(TRY((types::ValueImpl::template create<typename types::ValueImpl::USize>((JaktInternal::checked_sub<size_t>(x,static_cast<size_t>(1ULL)))))),span);
+types::Value const value = types::Value(TRY((types::ValueImpl::template create<typename types::ValueImpl::I32>((JaktInternal::checked_sub<i32>(x,static_cast<i32>(1)))))),span);
 TRY((((*this).update_binding(expr,scope,value,span))));
 __jakt_var_254 = value; goto __jakt_label_252;
 
 }
 __jakt_label_252:; __jakt_var_254.release_value(); }));
+};/*case end*/
+case 5: {
+auto&& __jakt_match_value = __jakt_match_variant.template get<typename types::ValueImpl::U64>();
+u64 const& x = __jakt_match_value.value;
+return JaktInternal::ExplicitValue(({ Optional<types::Value> __jakt_var_255; {
+types::Value const value = types::Value(TRY((types::ValueImpl::template create<typename types::ValueImpl::U64>((JaktInternal::checked_sub<u64>(x,static_cast<u64>(1ULL)))))),span);
+TRY((((*this).update_binding(expr,scope,value,span))));
+__jakt_var_255 = value; goto __jakt_label_253;
+
+}
+__jakt_label_253:; __jakt_var_255.release_value(); }));
+};/*case end*/
+case 9: {
+auto&& __jakt_match_value = __jakt_match_variant.template get<typename types::ValueImpl::I64>();
+i64 const& x = __jakt_match_value.value;
+return JaktInternal::ExplicitValue(({ Optional<types::Value> __jakt_var_256; {
+types::Value const value = types::Value(TRY((types::ValueImpl::template create<typename types::ValueImpl::I64>((JaktInternal::checked_sub<i64>(x,static_cast<i64>(1LL)))))),span);
+TRY((((*this).update_binding(expr,scope,value,span))));
+__jakt_var_256 = value; goto __jakt_label_254;
+
+}
+__jakt_label_254:; __jakt_var_256.release_value(); }));
+};/*case end*/
+case 14: {
+auto&& __jakt_match_value = __jakt_match_variant.template get<typename types::ValueImpl::CChar>();
+char const& x = __jakt_match_value.value;
+return JaktInternal::ExplicitValue(({ Optional<types::Value> __jakt_var_257; {
+types::Value const value = types::Value(TRY((types::ValueImpl::template create<typename types::ValueImpl::CChar>((JaktInternal::checked_sub<char>(x,static_cast<char>(1)))))),span);
+TRY((((*this).update_binding(expr,scope,value,span))));
+__jakt_var_257 = value; goto __jakt_label_255;
+
+}
+__jakt_label_255:; __jakt_var_257.release_value(); }));
+};/*case end*/
+case 15: {
+auto&& __jakt_match_value = __jakt_match_variant.template get<typename types::ValueImpl::CInt>();
+int const& x = __jakt_match_value.value;
+return JaktInternal::ExplicitValue(({ Optional<types::Value> __jakt_var_258; {
+types::Value const value = types::Value(TRY((types::ValueImpl::template create<typename types::ValueImpl::CInt>((JaktInternal::checked_sub<int>(x,static_cast<size_t>(1ULL)))))),span);
+TRY((((*this).update_binding(expr,scope,value,span))));
+__jakt_var_258 = value; goto __jakt_label_256;
+
+}
+__jakt_label_256:; __jakt_var_258.release_value(); }));
+};/*case end*/
+case 12: {
+auto&& __jakt_match_value = __jakt_match_variant.template get<typename types::ValueImpl::USize>();
+size_t const& x = __jakt_match_value.value;
+return JaktInternal::ExplicitValue(({ Optional<types::Value> __jakt_var_259; {
+types::Value const value = types::Value(TRY((types::ValueImpl::template create<typename types::ValueImpl::USize>((JaktInternal::checked_sub<size_t>(x,static_cast<size_t>(1ULL)))))),span);
+TRY((((*this).update_binding(expr,scope,value,span))));
+__jakt_var_259 = value; goto __jakt_label_257;
+
+}
+__jakt_label_257:; __jakt_var_259.release_value(); }));
 };/*case end*/
 default: {
 {
@@ -12434,11 +12472,11 @@ return JaktInternal::ExplicitValue( interpreter::StatementResult { typename inte
 case 0: {
 auto&& __jakt_match_value = __jakt_match_variant.template get<typename types::CheckedTypeCast::Fallible>();
 types::TypeId const& type_id = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(({ Optional<interpreter::StatementResult> __jakt_var_255; {
-__jakt_var_255 =  interpreter::StatementResult { typename interpreter::StatementResult::JustValue(types::Value(TRY((types::ValueImpl::template create<typename types::ValueImpl::OptionalSome>(TRY((interpreter::cast_value_to_type(value,type_id,*this,false)))))),span)) } ; goto __jakt_label_253;
+return JaktInternal::ExplicitValue(({ Optional<interpreter::StatementResult> __jakt_var_260; {
+__jakt_var_260 =  interpreter::StatementResult { typename interpreter::StatementResult::JustValue(types::Value(TRY((types::ValueImpl::template create<typename types::ValueImpl::OptionalSome>(TRY((interpreter::cast_value_to_type(value,type_id,*this,false)))))),span)) } ; goto __jakt_label_258;
 
 }
-__jakt_label_253:; __jakt_var_255.release_value(); }));
+__jakt_label_258:; __jakt_var_260.release_value(); }));
 };/*case end*/
 default: VERIFY_NOT_REACHED();}/*switch end*/
 }()
@@ -12453,15 +12491,15 @@ switch(__jakt_match_variant.index()) {
 case 18: {
 auto&& __jakt_match_value = __jakt_match_variant.template get<types::ValueImpl::Enum>();JaktInternal::Array<types::Value> const& fields = __jakt_match_value.fields;
 types::FunctionId const& constructor = __jakt_match_value.constructor;
-return JaktInternal::ExplicitValue(({ Optional<interpreter::StatementResult> __jakt_var_256; {
+return JaktInternal::ExplicitValue(({ Optional<interpreter::StatementResult> __jakt_var_261; {
 String const constructor_name = ((((((*this).program))->get_function(constructor)))->name);
 if ((((enum_variant).name()) != constructor_name)){
 return ( interpreter::StatementResult { typename interpreter::StatementResult::JustValue(types::Value(TRY((types::ValueImpl::template create<typename types::ValueImpl::Bool>(false))),span)) } );
 }
-__jakt_var_256 =  interpreter::StatementResult { typename interpreter::StatementResult::JustValue(types::Value(TRY((types::ValueImpl::template create<typename types::ValueImpl::Bool>(true))),span)) } ; goto __jakt_label_254;
+__jakt_var_261 =  interpreter::StatementResult { typename interpreter::StatementResult::JustValue(types::Value(TRY((types::ValueImpl::template create<typename types::ValueImpl::Bool>(true))),span)) } ; goto __jakt_label_259;
 
 }
-__jakt_label_254:; __jakt_var_256.release_value(); }));
+__jakt_label_259:; __jakt_var_261.release_value(); }));
 };/*case end*/
 default: {
 {
@@ -12481,16 +12519,16 @@ return Error::from_errno((infallible_integer_cast<i32>((InterpretError::Unimplem
 };/*case end*/
 }/*switch end*/
 }()
-)); goto __jakt_label_208;
+)); goto __jakt_label_213;
 
 }
-__jakt_label_208:; __jakt_var_210.release_value(); }));
+__jakt_label_213:; __jakt_var_215.release_value(); }));
 };/*case end*/
 case 8: {
 auto&& __jakt_match_value = __jakt_match_variant.template get<types::CheckedExpression::Range>();JaktInternal::Optional<NonnullRefPtr<types::CheckedExpression>> const& from = __jakt_match_value.from;
 JaktInternal::Optional<NonnullRefPtr<types::CheckedExpression>> const& to = __jakt_match_value.to;
 utility::Span const& span = __jakt_match_value.span;
-return JaktInternal::ExplicitValue(({ Optional<interpreter::StatementResult> __jakt_var_257; {
+return JaktInternal::ExplicitValue(({ Optional<interpreter::StatementResult> __jakt_var_262; {
 types::Value const start = JAKT_RESOLVE_EXPLICIT_VALUE_OR_CONTROL_FLOW_RETURN_ONLY(([&]() -> JaktInternal::ExplicitValueOrControlFlow<types::Value,ErrorOr<interpreter::StatementResult>>{
 auto __jakt_enum_value = (((from).has_value()));
 if (__jakt_enum_value == true) {
@@ -12604,16 +12642,16 @@ return Error::from_errno((infallible_integer_cast<i32>((InterpretError::Unimplem
 }()))
 ;
 types::StructId const range_struct_id = TRY((((((*this).program))->find_struct_in_prelude(String("Range")))));
-types::FunctionId const range_constructor = (TRY((((((*this).program))->find_function_in_scope(((((((*this).program))->get_struct(range_struct_id))).scope_id),String("Range"))))).value());
-__jakt_var_257 =  interpreter::StatementResult { typename interpreter::StatementResult::JustValue(types::Value(TRY((types::ValueImpl::template create<typename types::ValueImpl::Struct>((TRY((Array<types::Value>::create_with({start, end})))),range_struct_id,range_constructor))),span)) } ; goto __jakt_label_255;
+JaktInternal::Array<types::FunctionId> const range_constructors = (TRY((((((*this).program))->find_functions_with_name_in_scope(((((((*this).program))->get_struct(range_struct_id))).scope_id),String("Range"))))).value());
+__jakt_var_262 =  interpreter::StatementResult { typename interpreter::StatementResult::JustValue(types::Value(TRY((types::ValueImpl::template create<typename types::ValueImpl::Struct>((TRY((Array<types::Value>::create_with({start, end})))),range_struct_id,((range_constructors)[static_cast<i64>(0LL)])))),span)) } ; goto __jakt_label_260;
 
 }
-__jakt_label_255:; __jakt_var_257.release_value(); }));
+__jakt_label_260:; __jakt_var_262.release_value(); }));
 };/*case end*/
 case 19: {
 auto&& __jakt_match_value = __jakt_match_variant.template get<types::CheckedExpression::Call>();types::CheckedCall const& call = __jakt_match_value.call;
 utility::Span const& span = __jakt_match_value.span;
-return JaktInternal::ExplicitValue(({ Optional<interpreter::StatementResult> __jakt_var_258; {
+return JaktInternal::ExplicitValue(({ Optional<interpreter::StatementResult> __jakt_var_263; {
 if ((!(((((call).function_id)).has_value())))){
 JaktInternal::Array<types::Value> arguments = (TRY((Array<types::Value>::create_with({}))));
 {
@@ -12759,7 +12797,7 @@ TRY((((type_bindings).set(TRY((((((param).type_id())).to_string()))),((((call).t
 }
 
 JaktInternal::Dictionary<String,types::Value> const empty_bindings = (TRY((Dictionary<String, types::Value>::create_with_entries({}))));
-__jakt_var_258 = JAKT_RESOLVE_EXPLICIT_VALUE_OR_CONTROL_FLOW_RETURN_ONLY(([&]() -> JaktInternal::ExplicitValueOrControlFlow<interpreter::StatementResult, ErrorOr<interpreter::StatementResult>>{
+__jakt_var_263 = JAKT_RESOLVE_EXPLICIT_VALUE_OR_CONTROL_FLOW_RETURN_ONLY(([&]() -> JaktInternal::ExplicitValueOrControlFlow<interpreter::StatementResult, ErrorOr<interpreter::StatementResult>>{
 auto&& __jakt_match_variant = TRY((((*this).execute((((call).function_id).value()),static_cast<JaktInternal::Optional<JaktInternal::Array<types::ResolvedNamespace>>>(((call).namespace_)),this_argument,arguments,span,TRY((interpreter::InterpreterScope::InterpreterScope::create((TRY((Dictionary<String, types::Value>::create_with_entries({})))),JaktInternal::OptionalNone(),type_bindings)))))));
 switch(__jakt_match_variant.index()) {
 case 0: {
@@ -12774,16 +12812,16 @@ return JaktInternal::ExplicitValue( interpreter::StatementResult { typename inte
 };/*case end*/
 default: VERIFY_NOT_REACHED();}/*switch end*/
 }()
-)); goto __jakt_label_256;
+)); goto __jakt_label_261;
 
 }
-__jakt_label_256:; __jakt_var_258.release_value(); }));
+__jakt_label_261:; __jakt_var_263.release_value(); }));
 };/*case end*/
 case 20: {
 auto&& __jakt_match_value = __jakt_match_variant.template get<types::CheckedExpression::MethodCall>();NonnullRefPtr<types::CheckedExpression> const& expr = __jakt_match_value.expr;
 types::CheckedCall const& call = __jakt_match_value.call;
 utility::Span const& span = __jakt_match_value.span;
-return JaktInternal::ExplicitValue(({ Optional<interpreter::StatementResult> __jakt_var_259; {
+return JaktInternal::ExplicitValue(({ Optional<interpreter::StatementResult> __jakt_var_264; {
 types::Value const this_argument = JAKT_RESOLVE_EXPLICIT_VALUE_OR_CONTROL_FLOW_RETURN_ONLY(([&]() -> JaktInternal::ExplicitValueOrControlFlow<types::Value, ErrorOr<interpreter::StatementResult>>{
 auto&& __jakt_match_variant = TRY((((*this).execute_expression(expr,scope))));
 switch(__jakt_match_variant.index()) {
@@ -13072,7 +13110,7 @@ default: VERIFY_NOT_REACHED();}/*switch end*/
 }
 }
 
-__jakt_var_259 = JAKT_RESOLVE_EXPLICIT_VALUE_OR_CONTROL_FLOW_RETURN_ONLY(([&]() -> JaktInternal::ExplicitValueOrControlFlow<interpreter::StatementResult, ErrorOr<interpreter::StatementResult>>{
+__jakt_var_264 = JAKT_RESOLVE_EXPLICIT_VALUE_OR_CONTROL_FLOW_RETURN_ONLY(([&]() -> JaktInternal::ExplicitValueOrControlFlow<interpreter::StatementResult, ErrorOr<interpreter::StatementResult>>{
 auto&& __jakt_match_variant = TRY((((*this).execute((((call).function_id).value()),static_cast<JaktInternal::Optional<JaktInternal::Array<types::ResolvedNamespace>>>(((call).namespace_)),this_argument,arguments,span,JaktInternal::OptionalNone()))));
 switch(__jakt_match_variant.index()) {
 case 0: {
@@ -13087,10 +13125,10 @@ return JaktInternal::ExplicitValue( interpreter::StatementResult { typename inte
 };/*case end*/
 default: VERIFY_NOT_REACHED();}/*switch end*/
 }()
-)); goto __jakt_label_257;
+)); goto __jakt_label_262;
 
 }
-__jakt_label_257:; __jakt_var_259.release_value(); }));
+__jakt_label_262:; __jakt_var_264.release_value(); }));
 };/*case end*/
 case 23: {
 auto&& __jakt_match_value = __jakt_match_variant.template get<types::CheckedExpression::OptionalNone>();utility::Span const& span = __jakt_match_value.span;
@@ -13110,7 +13148,7 @@ return (result);
 };/*case end*/
 case 25: {
 auto&& __jakt_match_value = __jakt_match_variant.template get<types::CheckedExpression::ForcedUnwrap>();NonnullRefPtr<types::CheckedExpression> const& expr = __jakt_match_value.expr;
-return JaktInternal::ExplicitValue(({ Optional<interpreter::StatementResult> __jakt_var_260; {
+return JaktInternal::ExplicitValue(({ Optional<interpreter::StatementResult> __jakt_var_265; {
 types::Value const value = JAKT_RESOLVE_EXPLICIT_VALUE_OR_CONTROL_FLOW_RETURN_ONLY(([&]() -> JaktInternal::ExplicitValueOrControlFlow<types::Value, ErrorOr<interpreter::StatementResult>>{
 auto&& __jakt_match_variant = TRY((((*this).execute_expression(expr,scope))));
 switch(__jakt_match_variant.index()) {
@@ -13159,7 +13197,7 @@ if (((((value).impl))->index() == 24 /* OptionalNone */)){
 TRY((((*this).error(String("Attempted to unwrap an optional value that was None"),((value).span)))));
 return Error::from_errno((infallible_integer_cast<i32>((InterpretError::InvalidType))));
 }
-__jakt_var_260 = JAKT_RESOLVE_EXPLICIT_VALUE_OR_CONTROL_FLOW_RETURN_ONLY(([&]() -> JaktInternal::ExplicitValueOrControlFlow<interpreter::StatementResult, ErrorOr<interpreter::StatementResult>>{
+__jakt_var_265 = JAKT_RESOLVE_EXPLICIT_VALUE_OR_CONTROL_FLOW_RETURN_ONLY(([&]() -> JaktInternal::ExplicitValueOrControlFlow<interpreter::StatementResult, ErrorOr<interpreter::StatementResult>>{
 auto&& __jakt_match_variant = *((value).impl);
 switch(__jakt_match_variant.index()) {
 case 23: {
@@ -13174,10 +13212,10 @@ return Error::from_errno((infallible_integer_cast<i32>((InterpretError::InvalidT
 };/*case end*/
 }/*switch end*/
 }()
-)); goto __jakt_label_258;
+)); goto __jakt_label_263;
 
 }
-__jakt_label_258:; __jakt_var_260.release_value(); }));
+__jakt_label_263:; __jakt_var_265.release_value(); }));
 };/*case end*/
 case 26: {
 auto&& __jakt_match_value = __jakt_match_variant.template get<types::CheckedExpression::Block>();types::CheckedBlock const& block = __jakt_match_value.block;
@@ -13197,7 +13235,7 @@ case 12: {
 auto&& __jakt_match_value = __jakt_match_variant.template get<types::CheckedExpression::IndexedExpression>();NonnullRefPtr<types::CheckedExpression> const& expr = __jakt_match_value.expr;
 NonnullRefPtr<types::CheckedExpression> const& index_expr = __jakt_match_value.index;
 utility::Span const& span = __jakt_match_value.span;
-return JaktInternal::ExplicitValue(({ Optional<interpreter::StatementResult> __jakt_var_261; {
+return JaktInternal::ExplicitValue(({ Optional<interpreter::StatementResult> __jakt_var_266; {
 types::Value const value = JAKT_RESOLVE_EXPLICIT_VALUE_OR_CONTROL_FLOW_RETURN_ONLY(([&]() -> JaktInternal::ExplicitValueOrControlFlow<types::Value, ErrorOr<interpreter::StatementResult>>{
 auto&& __jakt_match_variant = TRY((((*this).execute_expression(expr,scope))));
 switch(__jakt_match_variant.index()) {
@@ -13286,12 +13324,12 @@ utility::panic(String("Invalid control flow"));
 default: VERIFY_NOT_REACHED();}/*switch end*/
 }()
 ));
-__jakt_var_261 = JAKT_RESOLVE_EXPLICIT_VALUE_OR_CONTROL_FLOW_RETURN_ONLY(([&]() -> JaktInternal::ExplicitValueOrControlFlow<interpreter::StatementResult, ErrorOr<interpreter::StatementResult>>{
+__jakt_var_266 = JAKT_RESOLVE_EXPLICIT_VALUE_OR_CONTROL_FLOW_RETURN_ONLY(([&]() -> JaktInternal::ExplicitValueOrControlFlow<interpreter::StatementResult, ErrorOr<interpreter::StatementResult>>{
 auto&& __jakt_match_variant = *((value).impl);
 switch(__jakt_match_variant.index()) {
 case 19: {
 auto&& __jakt_match_value = __jakt_match_variant.template get<types::ValueImpl::JaktArray>();JaktInternal::Array<types::Value> const& values = __jakt_match_value.values;
-return JaktInternal::ExplicitValue(({ Optional<interpreter::StatementResult> __jakt_var_262; {
+return JaktInternal::ExplicitValue(({ Optional<interpreter::StatementResult> __jakt_var_267; {
 u64 const numeric_index = JAKT_RESOLVE_EXPLICIT_VALUE_OR_CONTROL_FLOW_RETURN_ONLY(([&]() -> JaktInternal::ExplicitValueOrControlFlow<u64, ErrorOr<interpreter::StatementResult>>{
 auto&& __jakt_match_variant = *((index).impl);
 switch(__jakt_match_variant.index()) {
@@ -13352,10 +13390,10 @@ if ((numeric_index >= (infallible_integer_cast<u64>((((values).size())))))){
 TRY((((*this).error(TRY((String::formatted(String("Index {} out of bounds (max={})"),numeric_index,((values).size())))),span))));
 return Error::from_errno((infallible_integer_cast<i32>((InterpretError::InvalidType))));
 }
-__jakt_var_262 =  interpreter::StatementResult { typename interpreter::StatementResult::JustValue(((values)[numeric_index])) } ; goto __jakt_label_260;
+__jakt_var_267 =  interpreter::StatementResult { typename interpreter::StatementResult::JustValue(((values)[numeric_index])) } ; goto __jakt_label_265;
 
 }
-__jakt_label_260:; __jakt_var_262.release_value(); }));
+__jakt_label_265:; __jakt_var_267.release_value(); }));
 };/*case end*/
 default: {
 {
@@ -13365,10 +13403,10 @@ return Error::from_errno((infallible_integer_cast<i32>((InterpretError::InvalidT
 };/*case end*/
 }/*switch end*/
 }()
-)); goto __jakt_label_259;
+)); goto __jakt_label_264;
 
 }
-__jakt_label_259:; __jakt_var_261.release_value(); }));
+__jakt_label_264:; __jakt_var_266.release_value(); }));
 };/*case end*/
 case 0: {
 auto&& __jakt_match_value = __jakt_match_variant.template get<types::CheckedExpression::Boolean>();bool const& val = __jakt_match_value.val;
@@ -13378,7 +13416,7 @@ return JaktInternal::ExplicitValue( interpreter::StatementResult { typename inte
 case 15: {
 auto&& __jakt_match_value = __jakt_match_variant.template get<types::CheckedExpression::IndexedStruct>();NonnullRefPtr<types::CheckedExpression> const& expr = __jakt_match_value.expr;
 String const& index = __jakt_match_value.index;
-return JaktInternal::ExplicitValue(({ Optional<interpreter::StatementResult> __jakt_var_263; {
+return JaktInternal::ExplicitValue(({ Optional<interpreter::StatementResult> __jakt_var_268; {
 types::Value const value = JAKT_RESOLVE_EXPLICIT_VALUE_OR_CONTROL_FLOW_RETURN_ONLY(([&]() -> JaktInternal::ExplicitValueOrControlFlow<types::Value, ErrorOr<interpreter::StatementResult>>{
 auto&& __jakt_match_variant = TRY((((*this).execute_expression(expr,scope))));
 switch(__jakt_match_variant.index()) {
@@ -13423,13 +13461,13 @@ utility::panic(String("Invalid control flow"));
 default: VERIFY_NOT_REACHED();}/*switch end*/
 }()
 ));
-__jakt_var_263 = JAKT_RESOLVE_EXPLICIT_VALUE_OR_CONTROL_FLOW_RETURN_ONLY(([&]() -> JaktInternal::ExplicitValueOrControlFlow<interpreter::StatementResult, ErrorOr<interpreter::StatementResult>>{
+__jakt_var_268 = JAKT_RESOLVE_EXPLICIT_VALUE_OR_CONTROL_FLOW_RETURN_ONLY(([&]() -> JaktInternal::ExplicitValueOrControlFlow<interpreter::StatementResult, ErrorOr<interpreter::StatementResult>>{
 auto&& __jakt_match_variant = *((value).impl);
 switch(__jakt_match_variant.index()) {
 case 16: {
 auto&& __jakt_match_value = __jakt_match_variant.template get<types::ValueImpl::Struct>();JaktInternal::Array<types::Value> const& fields = __jakt_match_value.fields;
 types::StructId const& struct_id = __jakt_match_value.struct_id;
-return JaktInternal::ExplicitValue(({ Optional<interpreter::StatementResult> __jakt_var_264; {
+return JaktInternal::ExplicitValue(({ Optional<interpreter::StatementResult> __jakt_var_269; {
 types::CheckedStruct const struct_ = ((((*this).program))->get_struct(struct_id));
 i64 idx = static_cast<i64>(0LL);
 JaktInternal::Optional<i64> found_index = JaktInternal::OptionalNone();
@@ -13456,15 +13494,15 @@ if ((!(((found_index).has_value())))){
 TRY((((*this).error(String("Attempted to access a field that does not exist"),((value).span)))));
 return Error::from_errno((infallible_integer_cast<i32>((InterpretError::InvalidType))));
 }
-__jakt_var_264 =  interpreter::StatementResult { typename interpreter::StatementResult::JustValue(((fields)[(found_index.value())])) } ; goto __jakt_label_262;
+__jakt_var_269 =  interpreter::StatementResult { typename interpreter::StatementResult::JustValue(((fields)[(found_index.value())])) } ; goto __jakt_label_267;
 
 }
-__jakt_label_262:; __jakt_var_264.release_value(); }));
+__jakt_label_267:; __jakt_var_269.release_value(); }));
 };/*case end*/
 case 17: {
 auto&& __jakt_match_value = __jakt_match_variant.template get<types::ValueImpl::Class>();JaktInternal::Array<types::Value> const& fields = __jakt_match_value.fields;
 types::StructId const& struct_id = __jakt_match_value.struct_id;
-return JaktInternal::ExplicitValue(({ Optional<interpreter::StatementResult> __jakt_var_265; {
+return JaktInternal::ExplicitValue(({ Optional<interpreter::StatementResult> __jakt_var_270; {
 types::CheckedStruct const struct_ = ((((*this).program))->get_struct(struct_id));
 i64 idx = static_cast<i64>(0LL);
 JaktInternal::Optional<i64> found_index = JaktInternal::OptionalNone();
@@ -13491,10 +13529,10 @@ if ((!(((found_index).has_value())))){
 TRY((((*this).error(String("Attempted to access a field that does not exist"),((value).span)))));
 return Error::from_errno((infallible_integer_cast<i32>((InterpretError::InvalidType))));
 }
-__jakt_var_265 =  interpreter::StatementResult { typename interpreter::StatementResult::JustValue(((fields)[(found_index.value())])) } ; goto __jakt_label_263;
+__jakt_var_270 =  interpreter::StatementResult { typename interpreter::StatementResult::JustValue(((fields)[(found_index.value())])) } ; goto __jakt_label_268;
 
 }
-__jakt_label_263:; __jakt_var_265.release_value(); }));
+__jakt_label_268:; __jakt_var_270.release_value(); }));
 };/*case end*/
 default: {
 {
@@ -13504,15 +13542,15 @@ return Error::from_errno((infallible_integer_cast<i32>((InterpretError::InvalidT
 };/*case end*/
 }/*switch end*/
 }()
-)); goto __jakt_label_261;
+)); goto __jakt_label_266;
 
 }
-__jakt_label_261:; __jakt_var_263.release_value(); }));
+__jakt_label_266:; __jakt_var_268.release_value(); }));
 };/*case end*/
 case 16: {
 auto&& __jakt_match_value = __jakt_match_variant.template get<types::CheckedExpression::IndexedCommonEnumMember>();NonnullRefPtr<types::CheckedExpression> const& expr = __jakt_match_value.expr;
 String const& index = __jakt_match_value.index;
-return JaktInternal::ExplicitValue(({ Optional<interpreter::StatementResult> __jakt_var_266; {
+return JaktInternal::ExplicitValue(({ Optional<interpreter::StatementResult> __jakt_var_271; {
 types::Value const value = JAKT_RESOLVE_EXPLICIT_VALUE_OR_CONTROL_FLOW_RETURN_ONLY(([&]() -> JaktInternal::ExplicitValueOrControlFlow<types::Value, ErrorOr<interpreter::StatementResult>>{
 auto&& __jakt_match_variant = TRY((((*this).execute_expression(expr,scope))));
 switch(__jakt_match_variant.index()) {
@@ -13557,13 +13595,13 @@ utility::panic(String("Invalid control flow"));
 default: VERIFY_NOT_REACHED();}/*switch end*/
 }()
 ));
-__jakt_var_266 = JAKT_RESOLVE_EXPLICIT_VALUE_OR_CONTROL_FLOW_RETURN_ONLY(([&]() -> JaktInternal::ExplicitValueOrControlFlow<interpreter::StatementResult, ErrorOr<interpreter::StatementResult>>{
+__jakt_var_271 = JAKT_RESOLVE_EXPLICIT_VALUE_OR_CONTROL_FLOW_RETURN_ONLY(([&]() -> JaktInternal::ExplicitValueOrControlFlow<interpreter::StatementResult, ErrorOr<interpreter::StatementResult>>{
 auto&& __jakt_match_variant = *((value).impl);
 switch(__jakt_match_variant.index()) {
 case 18: {
 auto&& __jakt_match_value = __jakt_match_variant.template get<types::ValueImpl::Enum>();JaktInternal::Array<types::Value> const& fields = __jakt_match_value.fields;
 types::EnumId const& enum_id = __jakt_match_value.enum_id;
-return JaktInternal::ExplicitValue(({ Optional<interpreter::StatementResult> __jakt_var_267; {
+return JaktInternal::ExplicitValue(({ Optional<interpreter::StatementResult> __jakt_var_272; {
 types::CheckedEnum const enum_ = ((((*this).program))->get_enum(enum_id));
 i64 idx = static_cast<i64>(0LL);
 JaktInternal::Optional<i64> found_index = JaktInternal::OptionalNone();
@@ -13590,10 +13628,10 @@ if ((!(((found_index).has_value())))){
 TRY((((*this).error(String("Attempted to access a field that does not exist"),((value).span)))));
 return Error::from_errno((infallible_integer_cast<i32>((InterpretError::InvalidType))));
 }
-__jakt_var_267 =  interpreter::StatementResult { typename interpreter::StatementResult::JustValue(((fields)[(found_index.value())])) } ; goto __jakt_label_265;
+__jakt_var_272 =  interpreter::StatementResult { typename interpreter::StatementResult::JustValue(((fields)[(found_index.value())])) } ; goto __jakt_label_270;
 
 }
-__jakt_label_265:; __jakt_var_267.release_value(); }));
+__jakt_label_270:; __jakt_var_272.release_value(); }));
 };/*case end*/
 default: {
 {
@@ -13603,16 +13641,16 @@ return Error::from_errno((infallible_integer_cast<i32>((InterpretError::InvalidT
 };/*case end*/
 }/*switch end*/
 }()
-)); goto __jakt_label_264;
+)); goto __jakt_label_269;
 
 }
-__jakt_label_264:; __jakt_var_266.release_value(); }));
+__jakt_label_269:; __jakt_var_271.release_value(); }));
 };/*case end*/
 case 11: {
 auto&& __jakt_match_value = __jakt_match_variant.template get<types::CheckedExpression::JaktDictionary>();JaktInternal::Array<JaktInternal::Tuple<NonnullRefPtr<types::CheckedExpression>,NonnullRefPtr<types::CheckedExpression>>> const& vals = __jakt_match_value.vals;
 utility::Span const& span = __jakt_match_value.span;
 types::TypeId const& type_id = __jakt_match_value.type_id;
-return JaktInternal::ExplicitValue(({ Optional<interpreter::StatementResult> __jakt_var_268; {
+return JaktInternal::ExplicitValue(({ Optional<interpreter::StatementResult> __jakt_var_273; {
 JaktInternal::Array<types::Value> keys = (TRY((Array<types::Value>::create_with({}))));
 JaktInternal::Array<types::Value> values = (TRY((Array<types::Value>::create_with({}))));
 {
@@ -13723,10 +13761,10 @@ TRY((((values).push(val))));
 }
 }
 
-__jakt_var_268 =  interpreter::StatementResult { typename interpreter::StatementResult::JustValue(types::Value(TRY((types::ValueImpl::template create<typename types::ValueImpl::JaktDictionary>(keys,values,type_id))),span)) } ; goto __jakt_label_266;
+__jakt_var_273 =  interpreter::StatementResult { typename interpreter::StatementResult::JustValue(types::Value(TRY((types::ValueImpl::template create<typename types::ValueImpl::JaktDictionary>(keys,values,type_id))),span)) } ; goto __jakt_label_271;
 
 }
-__jakt_label_266:; __jakt_var_268.release_value(); }));
+__jakt_label_271:; __jakt_var_273.release_value(); }));
 };/*case end*/
 case 1: {
 auto&& __jakt_match_value = __jakt_match_variant.template get<types::CheckedExpression::NumericConstant>();types::CheckedNumericConstant const& val = __jakt_match_value.val;
@@ -13811,7 +13849,7 @@ types::TypeId const& type_id = __jakt_match_value.type_id;
 return JaktInternal::ExplicitValue(JAKT_RESOLVE_EXPLICIT_VALUE_OR_CONTROL_FLOW_RETURN_ONLY(([&]() -> JaktInternal::ExplicitValueOrControlFlow<interpreter::StatementResult,ErrorOr<interpreter::StatementResult>>{
 auto __jakt_enum_value = (((repeat).has_value()));
 if (__jakt_enum_value == true) {
-return JaktInternal::ExplicitValue(({ Optional<interpreter::StatementResult> __jakt_var_269; {
+return JaktInternal::ExplicitValue(({ Optional<interpreter::StatementResult> __jakt_var_274; {
 size_t const count = JAKT_RESOLVE_EXPLICIT_VALUE_OR_CONTROL_FLOW_RETURN_ONLY(([&]() -> JaktInternal::ExplicitValueOrControlFlow<size_t, ErrorOr<interpreter::StatementResult>>{
 auto&& __jakt_match_variant = TRY((((*this).execute_expression((repeat.value()),scope))));
 switch(__jakt_match_variant.index()) {
@@ -13955,13 +13993,13 @@ utility::panic(String("Invalid control flow"));
 default: VERIFY_NOT_REACHED();}/*switch end*/
 }()
 ));
-__jakt_var_269 =  interpreter::StatementResult { typename interpreter::StatementResult::JustValue(types::Value(TRY((types::ValueImpl::template create<typename types::ValueImpl::JaktArray>((TRY((Array<types::Value>::filled(count, value_to_repeat)))),TRY((((((*this).program))->substitute_typevars_in_type(type_id,TRY((((scope)->type_map_for_substitution()))),((type_id).module)))))))),span)) } ; goto __jakt_label_267;
+__jakt_var_274 =  interpreter::StatementResult { typename interpreter::StatementResult::JustValue(types::Value(TRY((types::ValueImpl::template create<typename types::ValueImpl::JaktArray>((TRY((Array<types::Value>::filled(count, value_to_repeat)))),TRY((((((*this).program))->substitute_typevars_in_type(type_id,TRY((((scope)->type_map_for_substitution()))),((type_id).module)))))))),span)) } ; goto __jakt_label_272;
 
 }
-__jakt_label_267:; __jakt_var_269.release_value(); }));
+__jakt_label_272:; __jakt_var_274.release_value(); }));
 }
 else {
-return JaktInternal::ExplicitValue(({ Optional<interpreter::StatementResult> __jakt_var_270; {
+return JaktInternal::ExplicitValue(({ Optional<interpreter::StatementResult> __jakt_var_275; {
 JaktInternal::Array<types::Value> values = (TRY((Array<types::Value>::create_with({}))));
 {
 JaktInternal::ArrayIterator<NonnullRefPtr<types::CheckedExpression>> _magic = ((vals).iterator());
@@ -14022,10 +14060,10 @@ TRY((((values).push(val))));
 }
 }
 
-__jakt_var_270 =  interpreter::StatementResult { typename interpreter::StatementResult::JustValue(types::Value(TRY((types::ValueImpl::template create<typename types::ValueImpl::JaktArray>(values,TRY((((((*this).program))->substitute_typevars_in_type(type_id,TRY((((scope)->type_map_for_substitution()))),((type_id).module)))))))),span)) } ; goto __jakt_label_268;
+__jakt_var_275 =  interpreter::StatementResult { typename interpreter::StatementResult::JustValue(types::Value(TRY((types::ValueImpl::template create<typename types::ValueImpl::JaktArray>(values,TRY((((((*this).program))->substitute_typevars_in_type(type_id,TRY((((scope)->type_map_for_substitution()))),((type_id).module)))))))),span)) } ; goto __jakt_label_273;
 
 }
-__jakt_label_268:; __jakt_var_270.release_value(); }));
+__jakt_label_273:; __jakt_var_275.release_value(); }));
 }
 }()))
 );
@@ -14033,7 +14071,7 @@ __jakt_label_268:; __jakt_var_270.release_value(); }));
 case 14: {
 auto&& __jakt_match_value = __jakt_match_variant.template get<types::CheckedExpression::IndexedTuple>();NonnullRefPtr<types::CheckedExpression> const& expr = __jakt_match_value.expr;
 size_t const& index = __jakt_match_value.index;
-return JaktInternal::ExplicitValue(({ Optional<interpreter::StatementResult> __jakt_var_271; {
+return JaktInternal::ExplicitValue(({ Optional<interpreter::StatementResult> __jakt_var_276; {
 types::Value const value = JAKT_RESOLVE_EXPLICIT_VALUE_OR_CONTROL_FLOW_RETURN_ONLY(([&]() -> JaktInternal::ExplicitValueOrControlFlow<types::Value, ErrorOr<interpreter::StatementResult>>{
 auto&& __jakt_match_variant = TRY((((*this).execute_expression(expr,scope))));
 switch(__jakt_match_variant.index()) {
@@ -14077,15 +14115,15 @@ utility::panic(String("Invalid control flow"));
 default: VERIFY_NOT_REACHED();}/*switch end*/
 }()
 ));
-__jakt_var_271 = JAKT_RESOLVE_EXPLICIT_VALUE_OR_CONTROL_FLOW_RETURN_ONLY(([&]() -> JaktInternal::ExplicitValueOrControlFlow<interpreter::StatementResult,ErrorOr<interpreter::StatementResult>>{
+__jakt_var_276 = JAKT_RESOLVE_EXPLICIT_VALUE_OR_CONTROL_FLOW_RETURN_ONLY(([&]() -> JaktInternal::ExplicitValueOrControlFlow<interpreter::StatementResult,ErrorOr<interpreter::StatementResult>>{
 auto __jakt_enum_value = (((((value).impl))->index() == 25 /* JaktTuple */));
 if (__jakt_enum_value == true) {
-return JaktInternal::ExplicitValue(({ Optional<interpreter::StatementResult> __jakt_var_272; {
+return JaktInternal::ExplicitValue(({ Optional<interpreter::StatementResult> __jakt_var_277; {
 JaktInternal::Array<types::Value> const fields = (((value).impl)->get<types::ValueImpl::JaktTuple>()).fields;
-__jakt_var_272 =  interpreter::StatementResult { typename interpreter::StatementResult::JustValue(((fields)[index])) } ; goto __jakt_label_270;
+__jakt_var_277 =  interpreter::StatementResult { typename interpreter::StatementResult::JustValue(((fields)[index])) } ; goto __jakt_label_275;
 
 }
-__jakt_label_270:; __jakt_var_272.release_value(); }));
+__jakt_label_275:; __jakt_var_277.release_value(); }));
 }
 else {
 {
@@ -14093,17 +14131,17 @@ utility::panic(String("expected tuple"));
 }
 }
 }()))
-; goto __jakt_label_269;
+; goto __jakt_label_274;
 
 }
-__jakt_label_269:; __jakt_var_271.release_value(); }));
+__jakt_label_274:; __jakt_var_276.release_value(); }));
 };/*case end*/
 case 17: {
 auto&& __jakt_match_value = __jakt_match_variant.template get<types::CheckedExpression::Match>();NonnullRefPtr<types::CheckedExpression> const& expr = __jakt_match_value.expr;
 JaktInternal::Array<types::CheckedMatchCase> const& match_cases = __jakt_match_value.match_cases;
 bool const& all_variants_constant = __jakt_match_value.all_variants_constant;
 utility::Span const& span = __jakt_match_value.span;
-return JaktInternal::ExplicitValue(({ Optional<interpreter::StatementResult> __jakt_var_273; {
+return JaktInternal::ExplicitValue(({ Optional<interpreter::StatementResult> __jakt_var_278; {
 types::Value const value = JAKT_RESOLVE_EXPLICIT_VALUE_OR_CONTROL_FLOW_RETURN_ONLY(([&]() -> JaktInternal::ExplicitValueOrControlFlow<types::Value, ErrorOr<interpreter::StatementResult>>{
 auto&& __jakt_match_variant = TRY((((*this).execute_expression(expr,scope))));
 switch(__jakt_match_variant.index()) {
@@ -14147,14 +14185,14 @@ utility::panic(String("Invalid control flow"));
 default: VERIFY_NOT_REACHED();}/*switch end*/
 }()
 ));
-__jakt_var_273 = JAKT_RESOLVE_EXPLICIT_VALUE_OR_CONTROL_FLOW_RETURN_ONLY(([&]() -> JaktInternal::ExplicitValueOrControlFlow<interpreter::StatementResult, ErrorOr<interpreter::StatementResult>>{
+__jakt_var_278 = JAKT_RESOLVE_EXPLICIT_VALUE_OR_CONTROL_FLOW_RETURN_ONLY(([&]() -> JaktInternal::ExplicitValueOrControlFlow<interpreter::StatementResult, ErrorOr<interpreter::StatementResult>>{
 auto&& __jakt_match_variant = *((value).impl);
 switch(__jakt_match_variant.index()) {
 case 18: {
 auto&& __jakt_match_value = __jakt_match_variant.template get<types::ValueImpl::Enum>();JaktInternal::Array<types::Value> const& fields = __jakt_match_value.fields;
 types::EnumId const& enum_id = __jakt_match_value.enum_id;
 types::FunctionId const& constructor = __jakt_match_value.constructor;
-return JaktInternal::ExplicitValue(({ Optional<interpreter::StatementResult> __jakt_var_274; {
+return JaktInternal::ExplicitValue(({ Optional<interpreter::StatementResult> __jakt_var_279; {
 String const constructor_name = ((((((*this).program))->get_function(constructor)))->name);
 JaktInternal::Optional<types::CheckedMatchBody> catch_all_case = JaktInternal::OptionalNone();
 JaktInternal::Optional<types::CheckedMatchBody> found_body = JaktInternal::OptionalNone();
@@ -14221,7 +14259,7 @@ default: VERIFY_NOT_REACHED();}/*switch end*/
 JaktInternal::Array<parser::EnumVariantPatternArgument> const empty_args = (TRY((Array<parser::EnumVariantPatternArgument>::create_with({}))));
 (found_args = found_args.value_or_lazy_evaluated([&] { return empty_args; }));
 NonnullRefPtr<interpreter::InterpreterScope> new_scope = TRY((interpreter::InterpreterScope::InterpreterScope::create((TRY((Dictionary<String, types::Value>::create_with_entries({})))),scope,(TRY((Dictionary<String, types::TypeId>::create_with_entries({})))))));
-ScopeGuard __jakt_var_275([&] {
+ScopeGuard __jakt_var_280([&] {
 MUST((((new_scope)->perform_defers(*this,(span.value())))));
 });
 if ((((found_variant_index).has_value()) && (!((((found_args.value())).is_empty()))))){
@@ -14291,15 +14329,15 @@ default: VERIFY_NOT_REACHED();}/*switch end*/
 }()
 ));
 }
-__jakt_var_274 = JAKT_RESOLVE_EXPLICIT_VALUE_OR_CONTROL_FLOW_RETURN_ONLY(([&]() -> JaktInternal::ExplicitValueOrControlFlow<interpreter::StatementResult, ErrorOr<interpreter::StatementResult>>{
+__jakt_var_279 = JAKT_RESOLVE_EXPLICIT_VALUE_OR_CONTROL_FLOW_RETURN_ONLY(([&]() -> JaktInternal::ExplicitValueOrControlFlow<interpreter::StatementResult, ErrorOr<interpreter::StatementResult>>{
 auto&& __jakt_match_variant = (found_body.value());
 switch(__jakt_match_variant.index()) {
 case 0: {
 auto&& __jakt_match_value = __jakt_match_variant.template get<typename types::CheckedMatchBody::Expression>();
 NonnullRefPtr<types::CheckedExpression> const& expr = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(({ Optional<interpreter::StatementResult> __jakt_var_276; {
+return JaktInternal::ExplicitValue(({ Optional<interpreter::StatementResult> __jakt_var_281; {
 interpreter::StatementResult const result = TRY((((*this).execute_expression(expr,new_scope))));
-__jakt_var_276 = JAKT_RESOLVE_EXPLICIT_VALUE_OR_CONTROL_FLOW_RETURN_ONLY(([&]() -> JaktInternal::ExplicitValueOrControlFlow<interpreter::StatementResult, ErrorOr<interpreter::StatementResult>>{
+__jakt_var_281 = JAKT_RESOLVE_EXPLICIT_VALUE_OR_CONTROL_FLOW_RETURN_ONLY(([&]() -> JaktInternal::ExplicitValueOrControlFlow<interpreter::StatementResult, ErrorOr<interpreter::StatementResult>>{
 auto&& __jakt_match_variant = result;
 switch(__jakt_match_variant.index()) {
 case 2: {
@@ -14329,17 +14367,17 @@ return JaktInternal::ExplicitValue(result);
 };/*case end*/
 default: VERIFY_NOT_REACHED();}/*switch end*/
 }()
-)); goto __jakt_label_273;
+)); goto __jakt_label_278;
 
 }
-__jakt_label_273:; __jakt_var_276.release_value(); }));
+__jakt_label_278:; __jakt_var_281.release_value(); }));
 };/*case end*/
 case 1: {
 auto&& __jakt_match_value = __jakt_match_variant.template get<typename types::CheckedMatchBody::Block>();
 types::CheckedBlock const& block = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(({ Optional<interpreter::StatementResult> __jakt_var_277; {
+return JaktInternal::ExplicitValue(({ Optional<interpreter::StatementResult> __jakt_var_282; {
 interpreter::StatementResult const result = TRY((((*this).execute_block(block,new_scope,(span.value())))));
-__jakt_var_277 = JAKT_RESOLVE_EXPLICIT_VALUE_OR_CONTROL_FLOW_RETURN_ONLY(([&]() -> JaktInternal::ExplicitValueOrControlFlow<interpreter::StatementResult, ErrorOr<interpreter::StatementResult>>{
+__jakt_var_282 = JAKT_RESOLVE_EXPLICIT_VALUE_OR_CONTROL_FLOW_RETURN_ONLY(([&]() -> JaktInternal::ExplicitValueOrControlFlow<interpreter::StatementResult, ErrorOr<interpreter::StatementResult>>{
 auto&& __jakt_match_variant = result;
 switch(__jakt_match_variant.index()) {
 case 2: {
@@ -14369,20 +14407,20 @@ return JaktInternal::ExplicitValue(result);
 };/*case end*/
 default: VERIFY_NOT_REACHED();}/*switch end*/
 }()
-)); goto __jakt_label_274;
+)); goto __jakt_label_279;
 
 }
-__jakt_label_274:; __jakt_var_277.release_value(); }));
+__jakt_label_279:; __jakt_var_282.release_value(); }));
 };/*case end*/
 default: VERIFY_NOT_REACHED();}/*switch end*/
 }()
-)); goto __jakt_label_272;
+)); goto __jakt_label_277;
 
 }
-__jakt_label_272:; __jakt_var_274.release_value(); }));
+__jakt_label_277:; __jakt_var_279.release_value(); }));
 };/*case end*/
 default: {
-return JaktInternal::ExplicitValue(({ Optional<interpreter::StatementResult> __jakt_var_278; {
+return JaktInternal::ExplicitValue(({ Optional<interpreter::StatementResult> __jakt_var_283; {
 JaktInternal::Optional<types::CheckedMatchBody> catch_all_case = JaktInternal::OptionalNone();
 JaktInternal::Optional<types::CheckedMatchBody> found_body = JaktInternal::OptionalNone();
 JaktInternal::Optional<utility::Span> span = JaktInternal::OptionalNone();
@@ -14482,18 +14520,18 @@ default: VERIFY_NOT_REACHED();}/*switch end*/
 
 (found_body = found_body.value_or_lazy_evaluated([&] { return (catch_all_case.value()); }));
 NonnullRefPtr<interpreter::InterpreterScope> new_scope = TRY((interpreter::InterpreterScope::InterpreterScope::create((TRY((Dictionary<String, types::Value>::create_with_entries({})))),scope,(TRY((Dictionary<String, types::TypeId>::create_with_entries({})))))));
-ScopeGuard __jakt_var_279([&] {
+ScopeGuard __jakt_var_284([&] {
 MUST((((new_scope)->perform_defers(*this,(span.value())))));
 });
-__jakt_var_278 = JAKT_RESOLVE_EXPLICIT_VALUE_OR_CONTROL_FLOW_RETURN_ONLY(([&]() -> JaktInternal::ExplicitValueOrControlFlow<interpreter::StatementResult, ErrorOr<interpreter::StatementResult>>{
+__jakt_var_283 = JAKT_RESOLVE_EXPLICIT_VALUE_OR_CONTROL_FLOW_RETURN_ONLY(([&]() -> JaktInternal::ExplicitValueOrControlFlow<interpreter::StatementResult, ErrorOr<interpreter::StatementResult>>{
 auto&& __jakt_match_variant = (found_body.value());
 switch(__jakt_match_variant.index()) {
 case 0: {
 auto&& __jakt_match_value = __jakt_match_variant.template get<typename types::CheckedMatchBody::Expression>();
 NonnullRefPtr<types::CheckedExpression> const& expr = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(({ Optional<interpreter::StatementResult> __jakt_var_280; {
+return JaktInternal::ExplicitValue(({ Optional<interpreter::StatementResult> __jakt_var_285; {
 interpreter::StatementResult const result = TRY((((*this).execute_expression(expr,new_scope))));
-__jakt_var_280 = JAKT_RESOLVE_EXPLICIT_VALUE_OR_CONTROL_FLOW_RETURN_ONLY(([&]() -> JaktInternal::ExplicitValueOrControlFlow<interpreter::StatementResult, ErrorOr<interpreter::StatementResult>>{
+__jakt_var_285 = JAKT_RESOLVE_EXPLICIT_VALUE_OR_CONTROL_FLOW_RETURN_ONLY(([&]() -> JaktInternal::ExplicitValueOrControlFlow<interpreter::StatementResult, ErrorOr<interpreter::StatementResult>>{
 auto&& __jakt_match_variant = result;
 switch(__jakt_match_variant.index()) {
 case 2: {
@@ -14523,17 +14561,17 @@ return JaktInternal::ExplicitValue(result);
 };/*case end*/
 default: VERIFY_NOT_REACHED();}/*switch end*/
 }()
-)); goto __jakt_label_276;
+)); goto __jakt_label_281;
 
 }
-__jakt_label_276:; __jakt_var_280.release_value(); }));
+__jakt_label_281:; __jakt_var_285.release_value(); }));
 };/*case end*/
 case 1: {
 auto&& __jakt_match_value = __jakt_match_variant.template get<typename types::CheckedMatchBody::Block>();
 types::CheckedBlock const& block = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(({ Optional<interpreter::StatementResult> __jakt_var_281; {
+return JaktInternal::ExplicitValue(({ Optional<interpreter::StatementResult> __jakt_var_286; {
 interpreter::StatementResult const result = TRY((((*this).execute_block(block,new_scope,(span.value())))));
-__jakt_var_281 = JAKT_RESOLVE_EXPLICIT_VALUE_OR_CONTROL_FLOW_RETURN_ONLY(([&]() -> JaktInternal::ExplicitValueOrControlFlow<interpreter::StatementResult, ErrorOr<interpreter::StatementResult>>{
+__jakt_var_286 = JAKT_RESOLVE_EXPLICIT_VALUE_OR_CONTROL_FLOW_RETURN_ONLY(([&]() -> JaktInternal::ExplicitValueOrControlFlow<interpreter::StatementResult, ErrorOr<interpreter::StatementResult>>{
 auto&& __jakt_match_variant = result;
 switch(__jakt_match_variant.index()) {
 case 2: {
@@ -14563,31 +14601,31 @@ return JaktInternal::ExplicitValue(result);
 };/*case end*/
 default: VERIFY_NOT_REACHED();}/*switch end*/
 }()
-)); goto __jakt_label_277;
+)); goto __jakt_label_282;
 
 }
-__jakt_label_277:; __jakt_var_281.release_value(); }));
+__jakt_label_282:; __jakt_var_286.release_value(); }));
 };/*case end*/
 default: VERIFY_NOT_REACHED();}/*switch end*/
 }()
-)); goto __jakt_label_275;
+)); goto __jakt_label_280;
 
 }
-__jakt_label_275:; __jakt_var_278.release_value(); }));
+__jakt_label_280:; __jakt_var_283.release_value(); }));
 };/*case end*/
 }/*switch end*/
 }()
-)); goto __jakt_label_271;
+)); goto __jakt_label_276;
 
 }
-__jakt_label_271:; __jakt_var_273.release_value(); }));
+__jakt_label_276:; __jakt_var_278.release_value(); }));
 };/*case end*/
 case 18: {
 auto&& __jakt_match_value = __jakt_match_variant.template get<types::CheckedExpression::EnumVariantArg>();NonnullRefPtr<types::CheckedExpression> const& expr = __jakt_match_value.expr;
 types::CheckedEnumVariantBinding const& arg = __jakt_match_value.arg;
 types::CheckedEnumVariant const& enum_variant = __jakt_match_value.enum_variant;
 utility::Span const& span = __jakt_match_value.span;
-return JaktInternal::ExplicitValue(({ Optional<interpreter::StatementResult> __jakt_var_282; {
+return JaktInternal::ExplicitValue(({ Optional<interpreter::StatementResult> __jakt_var_287; {
 types::Value const value = JAKT_RESOLVE_EXPLICIT_VALUE_OR_CONTROL_FLOW_RETURN_ONLY(([&]() -> JaktInternal::ExplicitValueOrControlFlow<types::Value, ErrorOr<interpreter::StatementResult>>{
 auto&& __jakt_match_variant = TRY((((*this).execute_expression(expr,scope))));
 switch(__jakt_match_variant.index()) {
@@ -14631,14 +14669,14 @@ utility::panic(String("Invalid control flow"));
 default: VERIFY_NOT_REACHED();}/*switch end*/
 }()
 ));
-__jakt_var_282 = JAKT_RESOLVE_EXPLICIT_VALUE_OR_CONTROL_FLOW_RETURN_ONLY(([&]() -> JaktInternal::ExplicitValueOrControlFlow<interpreter::StatementResult, ErrorOr<interpreter::StatementResult>>{
+__jakt_var_287 = JAKT_RESOLVE_EXPLICIT_VALUE_OR_CONTROL_FLOW_RETURN_ONLY(([&]() -> JaktInternal::ExplicitValueOrControlFlow<interpreter::StatementResult, ErrorOr<interpreter::StatementResult>>{
 auto&& __jakt_match_variant = *((value).impl);
 switch(__jakt_match_variant.index()) {
 case 18: {
 auto&& __jakt_match_value = __jakt_match_variant.template get<types::ValueImpl::Enum>();JaktInternal::Array<types::Value> const& fields = __jakt_match_value.fields;
 types::EnumId const& enum_id = __jakt_match_value.enum_id;
 types::FunctionId const& constructor = __jakt_match_value.constructor;
-return JaktInternal::ExplicitValue(({ Optional<interpreter::StatementResult> __jakt_var_283; {
+return JaktInternal::ExplicitValue(({ Optional<interpreter::StatementResult> __jakt_var_288; {
 JaktInternal::Optional<types::CheckedEnumVariant> found_variant = JaktInternal::OptionalNone();
 {
 JaktInternal::ArrayIterator<types::CheckedEnumVariant> _magic = ((((((((*this).program))->get_enum(enum_id))).variants)).iterator());
@@ -14658,7 +14696,7 @@ break;
 }
 }
 
-__jakt_var_283 = JAKT_RESOLVE_EXPLICIT_VALUE_OR_CONTROL_FLOW_RETURN_ONLY(([&]() -> JaktInternal::ExplicitValueOrControlFlow<interpreter::StatementResult, ErrorOr<interpreter::StatementResult>>{
+__jakt_var_288 = JAKT_RESOLVE_EXPLICIT_VALUE_OR_CONTROL_FLOW_RETURN_ONLY(([&]() -> JaktInternal::ExplicitValueOrControlFlow<interpreter::StatementResult, ErrorOr<interpreter::StatementResult>>{
 auto&& __jakt_match_variant = (found_variant.value());
 switch(__jakt_match_variant.index()) {
 case 1: {
@@ -14666,7 +14704,7 @@ auto&& __jakt_match_value = __jakt_match_variant.template get<types::CheckedEnum
 };/*case end*/
 case 3: {
 auto&& __jakt_match_value = __jakt_match_variant.template get<types::CheckedEnumVariant::StructLike>();JaktInternal::Array<types::VarId> const& variant_fields = __jakt_match_value.fields;
-return JaktInternal::ExplicitValue(({ Optional<interpreter::StatementResult> __jakt_var_284; {
+return JaktInternal::ExplicitValue(({ Optional<interpreter::StatementResult> __jakt_var_289; {
 i64 i = static_cast<i64>(0LL);
 {
 JaktInternal::ArrayIterator<types::VarId> _magic = ((variant_fields).iterator());
@@ -14688,20 +14726,20 @@ break;
 }
 }
 
-__jakt_var_284 =  interpreter::StatementResult { typename interpreter::StatementResult::JustValue(((fields)[i])) } ; goto __jakt_label_280;
+__jakt_var_289 =  interpreter::StatementResult { typename interpreter::StatementResult::JustValue(((fields)[i])) } ; goto __jakt_label_285;
 
 }
-__jakt_label_280:; __jakt_var_284.release_value(); }));
+__jakt_label_285:; __jakt_var_289.release_value(); }));
 };/*case end*/
 default: {
 return JaktInternal::ExplicitValue( interpreter::StatementResult { typename interpreter::StatementResult::JustValue(types::Value(TRY((types::ValueImpl::template create<typename types::ValueImpl::Void>())),span)) } );
 };/*case end*/
 }/*switch end*/
 }()
-)); goto __jakt_label_279;
+)); goto __jakt_label_284;
 
 }
-__jakt_label_279:; __jakt_var_283.release_value(); }));
+__jakt_label_284:; __jakt_var_288.release_value(); }));
 };/*case end*/
 default: {
 {
@@ -14711,16 +14749,16 @@ return Error::from_errno((infallible_integer_cast<i32>((InterpretError::InvalidT
 };/*case end*/
 }/*switch end*/
 }()
-)); goto __jakt_label_278;
+)); goto __jakt_label_283;
 
 }
-__jakt_label_278:; __jakt_var_282.release_value(); }));
+__jakt_label_283:; __jakt_var_287.release_value(); }));
 };/*case end*/
 case 7: {
 auto&& __jakt_match_value = __jakt_match_variant.template get<types::CheckedExpression::JaktTuple>();JaktInternal::Array<NonnullRefPtr<types::CheckedExpression>> const& vals = __jakt_match_value.vals;
 utility::Span const& span = __jakt_match_value.span;
 types::TypeId const& type_id = __jakt_match_value.type_id;
-return JaktInternal::ExplicitValue(({ Optional<interpreter::StatementResult> __jakt_var_285; {
+return JaktInternal::ExplicitValue(({ Optional<interpreter::StatementResult> __jakt_var_290; {
 JaktInternal::Array<types::Value> fields = (TRY((Array<types::Value>::create_with({}))));
 {
 JaktInternal::ArrayIterator<NonnullRefPtr<types::CheckedExpression>> _magic = ((vals).iterator());
@@ -14780,16 +14818,16 @@ TRY((((fields).push(value))));
 }
 }
 
-__jakt_var_285 =  interpreter::StatementResult { typename interpreter::StatementResult::JustValue(types::Value(TRY((types::ValueImpl::template create<typename types::ValueImpl::JaktTuple>(fields,type_id))),span)) } ; goto __jakt_label_281;
+__jakt_var_290 =  interpreter::StatementResult { typename interpreter::StatementResult::JustValue(types::Value(TRY((types::ValueImpl::template create<typename types::ValueImpl::JaktTuple>(fields,type_id))),span)) } ; goto __jakt_label_286;
 
 }
-__jakt_label_281:; __jakt_var_285.release_value(); }));
+__jakt_label_286:; __jakt_var_290.release_value(); }));
 };/*case end*/
 case 10: {
 auto&& __jakt_match_value = __jakt_match_variant.template get<types::CheckedExpression::JaktSet>();JaktInternal::Array<NonnullRefPtr<types::CheckedExpression>> const& vals = __jakt_match_value.vals;
 utility::Span const& span = __jakt_match_value.span;
 types::TypeId const& type_id = __jakt_match_value.type_id;
-return JaktInternal::ExplicitValue(({ Optional<interpreter::StatementResult> __jakt_var_286; {
+return JaktInternal::ExplicitValue(({ Optional<interpreter::StatementResult> __jakt_var_291; {
 JaktInternal::Array<types::Value> values = (TRY((Array<types::Value>::create_with({}))));
 {
 JaktInternal::ArrayIterator<NonnullRefPtr<types::CheckedExpression>> _magic = ((vals).iterator());
@@ -14850,10 +14888,10 @@ TRY((((values).push(val))));
 }
 }
 
-__jakt_var_286 =  interpreter::StatementResult { typename interpreter::StatementResult::JustValue(types::Value(TRY((types::ValueImpl::template create<typename types::ValueImpl::JaktSet>(values,type_id))),span)) } ; goto __jakt_label_282;
+__jakt_var_291 =  interpreter::StatementResult { typename interpreter::StatementResult::JustValue(types::Value(TRY((types::ValueImpl::template create<typename types::ValueImpl::JaktSet>(values,type_id))),span)) } ; goto __jakt_label_287;
 
 }
-__jakt_label_282:; __jakt_var_286.release_value(); }));
+__jakt_label_287:; __jakt_var_291.release_value(); }));
 };/*case end*/
 case 27: {
 auto&& __jakt_match_value = __jakt_match_variant.template get<types::CheckedExpression::Function>();JaktInternal::Array<types::CheckedCapture> const& captures = __jakt_match_value.captures;
@@ -14863,7 +14901,7 @@ types::TypeId const& type_id = __jakt_match_value.type_id;
 types::CheckedBlock const& block = __jakt_match_value.block;
 utility::Span const& span = __jakt_match_value.span;
 bool const& can_throw = __jakt_match_value.can_throw;
-return JaktInternal::ExplicitValue(({ Optional<interpreter::StatementResult> __jakt_var_287; {
+return JaktInternal::ExplicitValue(({ Optional<interpreter::StatementResult> __jakt_var_292; {
 JaktInternal::Dictionary<String,types::Value> resolved_captures = (TRY((Dictionary<String, types::Value>::create_with_entries({}))));
 {
 JaktInternal::ArrayIterator<types::CheckedCapture> _magic = ((captures).iterator());
@@ -14908,17 +14946,17 @@ TRY((((checked_params).push(types::CheckedParameter(((param).requires_label),typ
 }
 }
 
-__jakt_var_287 =  interpreter::StatementResult { typename interpreter::StatementResult::JustValue(types::Value(TRY((types::ValueImpl::template create<typename types::ValueImpl::Function>(resolved_captures,resolved_params,TRY((((((*this).program))->substitute_typevars_in_type(return_type_id,type_map,((return_type_id).module))))),TRY((((((*this).program))->substitute_typevars_in_type(type_id,type_map,((type_id).module))))),block,can_throw,checked_params))),span)) } ; goto __jakt_label_283;
+__jakt_var_292 =  interpreter::StatementResult { typename interpreter::StatementResult::JustValue(types::Value(TRY((types::ValueImpl::template create<typename types::ValueImpl::Function>(resolved_captures,resolved_params,TRY((((((*this).program))->substitute_typevars_in_type(return_type_id,type_map,((return_type_id).module))))),TRY((((((*this).program))->substitute_typevars_in_type(type_id,type_map,((type_id).module))))),block,can_throw,checked_params))),span)) } ; goto __jakt_label_288;
 
 }
-__jakt_label_283:; __jakt_var_287.release_value(); }));
+__jakt_label_288:; __jakt_var_292.release_value(); }));
 };/*case end*/
 case 29: {
 auto&& __jakt_match_value = __jakt_match_variant.template get<types::CheckedExpression::TryBlock>();NonnullRefPtr<types::CheckedStatement> const& stmt = __jakt_match_value.stmt;
 types::CheckedBlock const& catch_block = __jakt_match_value.catch_block;
 String const& error_name = __jakt_match_value.error_name;
 utility::Span const& span = __jakt_match_value.span;
-return JaktInternal::ExplicitValue(({ Optional<interpreter::StatementResult> __jakt_var_288; {
+return JaktInternal::ExplicitValue(({ Optional<interpreter::StatementResult> __jakt_var_293; {
 JAKT_RESOLVE_EXPLICIT_VALUE_OR_CONTROL_FLOW_RETURN_ONLY(([&]() -> JaktInternal::ExplicitValueOrControlFlow<void, ErrorOr<interpreter::StatementResult>>{
 auto&& __jakt_match_variant = TRY((((*this).execute_statement(stmt,scope,span))));
 switch(__jakt_match_variant.index()) {
@@ -14933,7 +14971,7 @@ auto&& __jakt_match_value = __jakt_match_variant.template get<typename interpret
 types::Value const& value = __jakt_match_value.value;
 {
 NonnullRefPtr<interpreter::InterpreterScope> catch_scope = TRY((interpreter::InterpreterScope::InterpreterScope::create((TRY((Dictionary<String, types::Value>::create_with_entries({})))),scope,(TRY((Dictionary<String, types::TypeId>::create_with_entries({})))))));
-ScopeGuard __jakt_var_289([&] {
+ScopeGuard __jakt_var_294([&] {
 MUST((((catch_scope)->perform_defers(*this,span))));
 });
 TRY((((((catch_scope)->bindings)).set(error_name,value))));
@@ -15012,10 +15050,10 @@ return JaktInternal::ExplicitValue<void>();
 default: VERIFY_NOT_REACHED();}/*switch end*/
 }()
 ));
-__jakt_var_288 =  interpreter::StatementResult { typename interpreter::StatementResult::JustValue(types::Value(TRY((types::ValueImpl::template create<typename types::ValueImpl::Void>())),span)) } ; goto __jakt_label_284;
+__jakt_var_293 =  interpreter::StatementResult { typename interpreter::StatementResult::JustValue(types::Value(TRY((types::ValueImpl::template create<typename types::ValueImpl::Void>())),span)) } ; goto __jakt_label_289;
 
 }
-__jakt_label_284:; __jakt_var_288.release_value(); }));
+__jakt_label_289:; __jakt_var_293.release_value(); }));
 };/*case end*/
 default: {
 {
@@ -15374,7 +15412,7 @@ auto&& __jakt_match_value = __jakt_match_variant.template get<types::CheckedStat
 utility::Span const& span = __jakt_match_value.span;
 {
 NonnullRefPtr<interpreter::InterpreterScope> new_scope = TRY((interpreter::InterpreterScope::InterpreterScope::create((TRY((Dictionary<String, types::Value>::create_with_entries({})))),scope,(TRY((Dictionary<String, types::TypeId>::create_with_entries({})))))));
-ScopeGuard __jakt_var_290([&] {
+ScopeGuard __jakt_var_295([&] {
 MUST((((new_scope)->perform_defers(*this,span))));
 });
 return (TRY((((*this).execute_block(block,new_scope,span)))));
@@ -15750,7 +15788,7 @@ NonnullRefPtr<types::CheckedFunction> const function_to_run = ((((*this).program
 TRY((((*this).enter_span(call_span))));
 JaktInternal::Optional<types::FunctionId> const old_function_id = ((*this).current_function_id);
 (((*this).current_function_id) = function_to_run_id);
-ScopeGuard __jakt_var_291([&] {
+ScopeGuard __jakt_var_296([&] {
 {
 (((*this).current_function_id) = old_function_id);
 ((*this).leave_span());
@@ -15963,7 +16001,7 @@ case 0: {
 auto&& __jakt_match_value = __jakt_match_variant.template get<typename parser::FunctionType::Normal>();
 {
 NonnullRefPtr<interpreter::InterpreterScope> scope = TRY((interpreter::InterpreterScope::InterpreterScope::create((TRY((Dictionary<String, types::Value>::create_with_entries({})))),invocation_scope,(TRY((Dictionary<String, types::TypeId>::create_with_entries({})))))));
-ScopeGuard __jakt_var_292([&] {
+ScopeGuard __jakt_var_297([&] {
 {
 MUST((((scope)->perform_defers(*this,call_span))));
 }
@@ -16182,7 +16220,7 @@ break;
 NonnullRefPtr<types::CheckedStatement> statement = (_magic_value.value());
 {
 TRY((((*this).enter_span(((statement)->span()).value_or_lazy_evaluated([&] { return call_span; })))));
-ScopeGuard __jakt_var_293([&] {
+ScopeGuard __jakt_var_298([&] {
 ((*this).leave_span());
 });
 JAKT_RESOLVE_EXPLICIT_VALUE_OR_CONTROL_FLOW_AT_LOOP(([&]() -> JaktInternal::ExplicitValueOrControlFlow<void, ErrorOr<interpreter::StatementResult>>{

--- a/bootstrap/stage0/parser.cpp
+++ b/bootstrap/stage0/parser.cpp
@@ -207,6 +207,41 @@ TRY(JaktInternal::PrettyPrint::output_indentation(builder));TRY(builder.append("
 TRY(builder.append(")"));return builder.to_string(); }
 parser::ParsedFunction::ParsedFunction(String a_name, utility::Span a_name_span, parser::Visibility a_visibility, JaktInternal::Array<parser::ParsedParameter> a_params, JaktInternal::Array<parser::ParsedGenericParameter> a_generic_parameters, parser::ParsedBlock a_block, NonnullRefPtr<parser::ParsedType> a_return_type, utility::Span a_return_type_span, bool a_can_throw, parser::FunctionType a_type, parser::FunctionLinkage a_linkage, bool a_must_instantiate, bool a_is_comptime, bool a_is_fat_arrow) :name(a_name), name_span(a_name_span), visibility(a_visibility), params(a_params), generic_parameters(a_generic_parameters), block(a_block), return_type(a_return_type), return_type_span(a_return_type_span), can_throw(a_can_throw), type(a_type), linkage(a_linkage), must_instantiate(a_must_instantiate), is_comptime(a_is_comptime), is_fat_arrow(a_is_fat_arrow){}
 
+bool parser::ParsedFunction::equals(parser::ParsedFunction const other) const {
+{
+if (((((((*this).name) != ((other).name)) || (((*this).can_throw) != ((other).can_throw))) || (((*this).is_comptime) != ((other).is_comptime))) || (((*this).is_fat_arrow) != ((other).is_fat_arrow)))){
+return (false);
+}
+if ((!(((((*this).block)).equals(((other).block)))))){
+return (false);
+}
+if ((((((*this).params)).size()) != ((((other).params)).size()))){
+return (false);
+}
+{
+JaktInternal::Range<size_t> _magic = (JaktInternal::Range<size_t>{static_cast<size_t>(static_cast<size_t>(0ULL)),static_cast<size_t>(((((*this).params)).size()))});
+for (;;){
+JaktInternal::Optional<size_t> _magic_value = ((_magic).next());
+if ((!(((_magic_value).has_value())))){
+break;
+}
+size_t param_index = (_magic_value.value());
+{
+if ((!(((((((*this).params))[param_index])).equals(((((other).params))[param_index])))))){
+return (false);
+}
+}
+
+}
+}
+
+if ((((((*this).generic_parameters)).size()) != ((((other).generic_parameters)).size()))){
+return (false);
+}
+return (true);
+}
+}
+
 ErrorOr<String> parser::ParsedExternImport::debug_description() const { auto builder = MUST(StringBuilder::create());TRY(builder.append("ParsedExternImport("));{
 JaktInternal::PrettyPrint::ScopedLevelIncrease increase_indent {};
 TRY(JaktInternal::PrettyPrint::output_indentation(builder));TRY(builder.append("is_c: "));TRY(builder.appendff("{}, ", is_c));
@@ -2197,7 +2232,7 @@ return JaktInternal::ExplicitValue<void>();
 };/*case end*/
 default: {
 {
-(to = TRY((((*this).parse_expression(false,false)))));
+(to = TRY((((*this).parse_operand()))));
 }
 return JaktInternal::ExplicitValue<void>();
 };/*case end*/
@@ -4055,21 +4090,7 @@ NonnullRefPtr<parser::ParsedStatement> const var_decl = TRY((parser::ParsedState
 NonnullRefPtr<parser::ParsedStatement> const destructured_vars_stmt = TRY((parser::ParsedStatement::template create<typename parser::ParsedStatement::DestructuringAssignment>(destructured_var_decls,var_decl,TRY((parser::merge_spans(start_span,((((*this).previous())).span())))))));
 JaktInternal::Array<NonnullRefPtr<parser::ParsedStatement>> block_stmts = (TRY((Array<NonnullRefPtr<parser::ParsedStatement>>::create_with({}))));
 TRY((((block_stmts).push(destructured_vars_stmt))));
-{
-JaktInternal::ArrayIterator<NonnullRefPtr<parser::ParsedStatement>> _magic = ((((block).stmts)).iterator());
-for (;;){
-JaktInternal::Optional<NonnullRefPtr<parser::ParsedStatement>> _magic_value = ((_magic).next());
-if ((!(((_magic_value).has_value())))){
-break;
-}
-NonnullRefPtr<parser::ParsedStatement> stmt = (_magic_value.value());
-{
-TRY((((block_stmts).push(stmt))));
-}
-
-}
-}
-
+TRY((((block_stmts).push_values(((block).stmts)))));
 (((block).stmts) = block_stmts);
 }
 return (TRY((parser::ParsedStatement::template create<typename parser::ParsedStatement::For>(iterator_name,name_span,range,block,TRY((parser::merge_spans(start_span,((((*this).previous())).span()))))))));
@@ -6001,21 +6022,7 @@ if (__jakt_enum_value == String("before_include")) {
 ((((*this).index)++));
 JaktInternal::Optional<JaktInternal::Array<parser::IncludeAction>> const actions = TRY((((*this).parse_include_action())));
 if (((actions).has_value())){
-{
-JaktInternal::ArrayIterator<parser::IncludeAction> _magic = (((actions.value())).iterator());
-for (;;){
-JaktInternal::Optional<parser::IncludeAction> _magic_value = ((_magic).next());
-if ((!(((_magic_value).has_value())))){
-break;
-}
-parser::IncludeAction action = (_magic_value.value());
-{
-TRY((((((parsed_import).before_include)).push(action))));
-}
-
-}
-}
-
+TRY((((((parsed_import).before_include)).push_values((actions.value())))));
 }
 }
 return JaktInternal::ExplicitValue<void>();
@@ -6025,21 +6032,7 @@ else if (__jakt_enum_value == String("after_include")) {
 ((((*this).index)++));
 JaktInternal::Optional<JaktInternal::Array<parser::IncludeAction>> const actions = TRY((((*this).parse_include_action())));
 if (((actions).has_value())){
-{
-JaktInternal::ArrayIterator<parser::IncludeAction> _magic = (((actions.value())).iterator());
-for (;;){
-JaktInternal::Optional<parser::IncludeAction> _magic_value = ((_magic).next());
-if ((!(((_magic_value).has_value())))){
-break;
-}
-parser::IncludeAction action = (_magic_value.value());
-{
-TRY((((((parsed_import).after_include)).push(action))));
-}
-
-}
-}
-
+TRY((((((parsed_import).after_include)).push_values((actions.value())))));
 }
 }
 return JaktInternal::ExplicitValue<void>();
@@ -6721,6 +6714,14 @@ case 4: {
 auto&& __jakt_match_value = __jakt_match_variant.template get<lexer::Token::Identifier>();String const& name = __jakt_match_value.name;
 {
 TRY((((captures).push( parser::ParsedCapture { typename parser::ParsedCapture::ByValue(name,((((*this).current())).span())) } ))));
+((((*this).index)++));
+}
+return JaktInternal::ExplicitValue<void>();
+};/*case end*/
+case 95: {
+auto&& __jakt_match_value = __jakt_match_variant.template get<typename lexer::Token::This>();
+{
+TRY((((captures).push( parser::ParsedCapture { typename parser::ParsedCapture::ByValue(String("this"),((((*this).current())).span())) } ))));
 ((((*this).index)++));
 }
 return JaktInternal::ExplicitValue<void>();
@@ -7445,7 +7446,7 @@ return JaktInternal::ExplicitValue<void>();
 };/*case end*/
 default: {
 {
-(to = TRY((((*this).parse_expression(false,false)))));
+(to = TRY((((*this).parse_operand()))));
 (span_end = (((to.value()))->span()));
 }
 return JaktInternal::ExplicitValue<void>();
@@ -7909,36 +7910,8 @@ parser::ParsedExternImport extern_import = (_magic_value.value());
 {
 if (TRY((((extern_import).is_equivalent_to(import_))))){
 TRY((((((extern_import).assigned_namespace)).merge_with(((import_).assigned_namespace)))));
-{
-JaktInternal::ArrayIterator<parser::IncludeAction> _magic = ((((import_).before_include)).iterator());
-for (;;){
-JaktInternal::Optional<parser::IncludeAction> _magic_value = ((_magic).next());
-if ((!(((_magic_value).has_value())))){
-break;
-}
-parser::IncludeAction action = (_magic_value.value());
-{
-TRY((((((extern_import).before_include)).push(action))));
-}
-
-}
-}
-
-{
-JaktInternal::ArrayIterator<parser::IncludeAction> _magic = ((((import_).after_include)).iterator());
-for (;;){
-JaktInternal::Optional<parser::IncludeAction> _magic_value = ((_magic).next());
-if ((!(((_magic_value).has_value())))){
-break;
-}
-parser::IncludeAction action = (_magic_value.value());
-{
-TRY((((((extern_import).after_include)).push(action))));
-}
-
-}
-}
-
+TRY((((((extern_import).before_include)).push_values(((import_).before_include)))));
+TRY((((((extern_import).after_include)).push_values(((import_).after_include)))));
 return {};
 }
 }
@@ -7953,8 +7926,8 @@ return {};
 
 ErrorOr<void> parser::ParsedNamespace::merge_with(parser::ParsedNamespace const namespace_) {
 {
-TRY((utility::extend_array<parser::ParsedFunction>(((*this).functions),((namespace_).functions))));
-TRY((utility::extend_array<parser::ParsedRecord>(((*this).records),((namespace_).records))));
+TRY((((((*this).functions)).push_values(((namespace_).functions)))));
+TRY((((((*this).records)).push_values(((namespace_).records)))));
 TRY((((((*this).module_imports)).add_capacity(((((namespace_).module_imports)).size())))));
 {
 JaktInternal::ArrayIterator<parser::ParsedModuleImport> _magic = ((((namespace_).module_imports)).iterator());
@@ -11486,43 +11459,344 @@ return (JAKT_RESOLVE_EXPLICIT_VALUE_OR_CONTROL_FLOW_RETURN_ONLY(([&]() -> JaktIn
 auto&& __jakt_match_variant = *this;
 switch(__jakt_match_variant.index()) {
 case 0: {
-auto&& __jakt_match_value = __jakt_match_variant.template get<parser::ParsedType::Name>();return JaktInternal::ExplicitValue(((rhs_parsed_type)->index() == 0 /* Name */));
+auto&& __jakt_match_value = __jakt_match_variant.template get<parser::ParsedType::Name>();String const& lhs_name = __jakt_match_value.name;
+return JaktInternal::ExplicitValue(JAKT_RESOLVE_EXPLICIT_VALUE_OR_CONTROL_FLOW_RETURN_ONLY(([&]() -> JaktInternal::ExplicitValueOrControlFlow<bool, bool>{
+auto&& __jakt_match_variant = *rhs_parsed_type;
+switch(__jakt_match_variant.index()) {
+case 0: {
+auto&& __jakt_match_value = __jakt_match_variant.template get<parser::ParsedType::Name>();String const& rhs_name = __jakt_match_value.name;
+return JaktInternal::ExplicitValue((lhs_name == rhs_name));
+};/*case end*/
+default: {
+return JaktInternal::ExplicitValue(false);
+};/*case end*/
+}/*switch end*/
+}()
+)));
 };/*case end*/
 case 1: {
-auto&& __jakt_match_value = __jakt_match_variant.template get<parser::ParsedType::NamespacedName>();return JaktInternal::ExplicitValue(((rhs_parsed_type)->index() == 1 /* NamespacedName */));
+auto&& __jakt_match_value = __jakt_match_variant.template get<parser::ParsedType::NamespacedName>();String const& lhs_name = __jakt_match_value.name;
+JaktInternal::Array<String> const& lhs_namespaces = __jakt_match_value.namespaces;
+JaktInternal::Array<NonnullRefPtr<parser::ParsedType>> const& lhs_params = __jakt_match_value.params;
+return JaktInternal::ExplicitValue(JAKT_RESOLVE_EXPLICIT_VALUE_OR_CONTROL_FLOW_RETURN_ONLY(([&]() -> JaktInternal::ExplicitValueOrControlFlow<bool, bool>{
+auto&& __jakt_match_variant = *rhs_parsed_type;
+switch(__jakt_match_variant.index()) {
+case 1: {
+auto&& __jakt_match_value = __jakt_match_variant.template get<parser::ParsedType::NamespacedName>();String const& rhs_name = __jakt_match_value.name;
+JaktInternal::Array<String> const& rhs_namespaces = __jakt_match_value.namespaces;
+JaktInternal::Array<NonnullRefPtr<parser::ParsedType>> const& rhs_params = __jakt_match_value.params;
+{
+if ((lhs_name != rhs_name)){
+return (false);
+}
+if ((((lhs_namespaces).size()) != ((rhs_namespaces).size()))){
+return (false);
+}
+{
+JaktInternal::Range<size_t> _magic = (JaktInternal::Range<size_t>{static_cast<size_t>(static_cast<size_t>(0ULL)),static_cast<size_t>(((lhs_namespaces).size()))});
+for (;;){
+JaktInternal::Optional<size_t> _magic_value = ((_magic).next());
+if ((!(((_magic_value).has_value())))){
+break;
+}
+size_t namespace_index = (_magic_value.value());
+{
+if ((((lhs_namespaces)[namespace_index]) != ((rhs_namespaces)[namespace_index]))){
+return (false);
+}
+}
+
+}
+}
+
+if ((((lhs_params).size()) != ((rhs_params).size()))){
+return (false);
+}
+{
+JaktInternal::Range<size_t> _magic = (JaktInternal::Range<size_t>{static_cast<size_t>(static_cast<size_t>(0ULL)),static_cast<size_t>(((lhs_params).size()))});
+for (;;){
+JaktInternal::Optional<size_t> _magic_value = ((_magic).next());
+if ((!(((_magic_value).has_value())))){
+break;
+}
+size_t param_index = (_magic_value.value());
+{
+if ((!(((((lhs_params)[param_index]))->equals(((rhs_params)[param_index])))))){
+return (false);
+}
+}
+
+}
+}
+
+return (true);
+}
+};/*case end*/
+default: {
+return JaktInternal::ExplicitValue(false);
+};/*case end*/
+}/*switch end*/
+}()
+)));
 };/*case end*/
 case 2: {
-auto&& __jakt_match_value = __jakt_match_variant.template get<parser::ParsedType::GenericType>();return JaktInternal::ExplicitValue(((rhs_parsed_type)->index() == 2 /* GenericType */));
+auto&& __jakt_match_value = __jakt_match_variant.template get<parser::ParsedType::GenericType>();String const& lhs_name = __jakt_match_value.name;
+JaktInternal::Array<NonnullRefPtr<parser::ParsedType>> const& lhs_generic_parameters = __jakt_match_value.generic_parameters;
+return JaktInternal::ExplicitValue(JAKT_RESOLVE_EXPLICIT_VALUE_OR_CONTROL_FLOW_RETURN_ONLY(([&]() -> JaktInternal::ExplicitValueOrControlFlow<bool, bool>{
+auto&& __jakt_match_variant = *rhs_parsed_type;
+switch(__jakt_match_variant.index()) {
+case 2: {
+auto&& __jakt_match_value = __jakt_match_variant.template get<parser::ParsedType::GenericType>();String const& rhs_name = __jakt_match_value.name;
+JaktInternal::Array<NonnullRefPtr<parser::ParsedType>> const& rhs_generic_parameters = __jakt_match_value.generic_parameters;
+{
+if ((lhs_name != rhs_name)){
+return (false);
+}
+if ((((lhs_generic_parameters).size()) != ((rhs_generic_parameters).size()))){
+return (false);
+}
+{
+JaktInternal::Range<size_t> _magic = (JaktInternal::Range<size_t>{static_cast<size_t>(static_cast<size_t>(0ULL)),static_cast<size_t>(((lhs_generic_parameters).size()))});
+for (;;){
+JaktInternal::Optional<size_t> _magic_value = ((_magic).next());
+if ((!(((_magic_value).has_value())))){
+break;
+}
+size_t param_index = (_magic_value.value());
+{
+if ((!(((((lhs_generic_parameters)[param_index]))->equals(((rhs_generic_parameters)[param_index])))))){
+return (false);
+}
+}
+
+}
+}
+
+return (true);
+}
+};/*case end*/
+default: {
+return JaktInternal::ExplicitValue(false);
+};/*case end*/
+}/*switch end*/
+}()
+)));
 };/*case end*/
 case 3: {
-auto&& __jakt_match_value = __jakt_match_variant.template get<parser::ParsedType::JaktArray>();return JaktInternal::ExplicitValue(((rhs_parsed_type)->index() == 3 /* JaktArray */));
+auto&& __jakt_match_value = __jakt_match_variant.template get<parser::ParsedType::JaktArray>();NonnullRefPtr<parser::ParsedType> const& lhs_inner = __jakt_match_value.inner;
+return JaktInternal::ExplicitValue(JAKT_RESOLVE_EXPLICIT_VALUE_OR_CONTROL_FLOW_RETURN_ONLY(([&]() -> JaktInternal::ExplicitValueOrControlFlow<bool, bool>{
+auto&& __jakt_match_variant = *rhs_parsed_type;
+switch(__jakt_match_variant.index()) {
+case 3: {
+auto&& __jakt_match_value = __jakt_match_variant.template get<parser::ParsedType::JaktArray>();NonnullRefPtr<parser::ParsedType> const& rhs_inner = __jakt_match_value.inner;
+return JaktInternal::ExplicitValue(((lhs_inner)->equals(rhs_inner)));
+};/*case end*/
+default: {
+return JaktInternal::ExplicitValue(false);
+};/*case end*/
+}/*switch end*/
+}()
+)));
 };/*case end*/
 case 4: {
-auto&& __jakt_match_value = __jakt_match_variant.template get<parser::ParsedType::Dictionary>();return JaktInternal::ExplicitValue(((rhs_parsed_type)->index() == 4 /* Dictionary */));
+auto&& __jakt_match_value = __jakt_match_variant.template get<parser::ParsedType::Dictionary>();NonnullRefPtr<parser::ParsedType> const& lhs_key = __jakt_match_value.key;
+NonnullRefPtr<parser::ParsedType> const& lhs_value = __jakt_match_value.value;
+return JaktInternal::ExplicitValue(JAKT_RESOLVE_EXPLICIT_VALUE_OR_CONTROL_FLOW_RETURN_ONLY(([&]() -> JaktInternal::ExplicitValueOrControlFlow<bool, bool>{
+auto&& __jakt_match_variant = *rhs_parsed_type;
+switch(__jakt_match_variant.index()) {
+case 4: {
+auto&& __jakt_match_value = __jakt_match_variant.template get<parser::ParsedType::Dictionary>();NonnullRefPtr<parser::ParsedType> const& rhs_key = __jakt_match_value.key;
+NonnullRefPtr<parser::ParsedType> const& rhs_value = __jakt_match_value.value;
+return JaktInternal::ExplicitValue((((lhs_key)->equals(rhs_key)) && ((lhs_value)->equals(rhs_value))));
+};/*case end*/
+default: {
+return JaktInternal::ExplicitValue(false);
+};/*case end*/
+}/*switch end*/
+}()
+)));
 };/*case end*/
 case 5: {
-auto&& __jakt_match_value = __jakt_match_variant.template get<parser::ParsedType::JaktTuple>();return JaktInternal::ExplicitValue(((rhs_parsed_type)->index() == 5 /* JaktTuple */));
+auto&& __jakt_match_value = __jakt_match_variant.template get<parser::ParsedType::JaktTuple>();JaktInternal::Array<NonnullRefPtr<parser::ParsedType>> const& lhs_types = __jakt_match_value.types;
+return JaktInternal::ExplicitValue(JAKT_RESOLVE_EXPLICIT_VALUE_OR_CONTROL_FLOW_RETURN_ONLY(([&]() -> JaktInternal::ExplicitValueOrControlFlow<bool, bool>{
+auto&& __jakt_match_variant = *rhs_parsed_type;
+switch(__jakt_match_variant.index()) {
+case 5: {
+auto&& __jakt_match_value = __jakt_match_variant.template get<parser::ParsedType::JaktTuple>();JaktInternal::Array<NonnullRefPtr<parser::ParsedType>> const& rhs_types = __jakt_match_value.types;
+{
+if ((((lhs_types).size()) != ((rhs_types).size()))){
+return (false);
+}
+{
+JaktInternal::Range<size_t> _magic = (JaktInternal::Range<size_t>{static_cast<size_t>(static_cast<size_t>(0ULL)),static_cast<size_t>(((lhs_types).size()))});
+for (;;){
+JaktInternal::Optional<size_t> _magic_value = ((_magic).next());
+if ((!(((_magic_value).has_value())))){
+break;
+}
+size_t type_index = (_magic_value.value());
+{
+if ((!(((((lhs_types)[type_index]))->equals(((rhs_types)[type_index])))))){
+return (false);
+}
+}
+
+}
+}
+
+return (true);
+}
+};/*case end*/
+default: {
+return JaktInternal::ExplicitValue(false);
+};/*case end*/
+}/*switch end*/
+}()
+)));
 };/*case end*/
 case 6: {
-auto&& __jakt_match_value = __jakt_match_variant.template get<parser::ParsedType::Set>();return JaktInternal::ExplicitValue(((rhs_parsed_type)->index() == 6 /* Set */));
+auto&& __jakt_match_value = __jakt_match_variant.template get<parser::ParsedType::Set>();NonnullRefPtr<parser::ParsedType> const& lhs_inner = __jakt_match_value.inner;
+return JaktInternal::ExplicitValue(JAKT_RESOLVE_EXPLICIT_VALUE_OR_CONTROL_FLOW_RETURN_ONLY(([&]() -> JaktInternal::ExplicitValueOrControlFlow<bool, bool>{
+auto&& __jakt_match_variant = *rhs_parsed_type;
+switch(__jakt_match_variant.index()) {
+case 6: {
+auto&& __jakt_match_value = __jakt_match_variant.template get<parser::ParsedType::Set>();NonnullRefPtr<parser::ParsedType> const& rhs_inner = __jakt_match_value.inner;
+return JaktInternal::ExplicitValue(((lhs_inner)->equals(rhs_inner)));
+};/*case end*/
+default: {
+return JaktInternal::ExplicitValue(false);
+};/*case end*/
+}/*switch end*/
+}()
+)));
 };/*case end*/
 case 7: {
-auto&& __jakt_match_value = __jakt_match_variant.template get<parser::ParsedType::Optional>();return JaktInternal::ExplicitValue(((rhs_parsed_type)->index() == 7 /* Optional */));
+auto&& __jakt_match_value = __jakt_match_variant.template get<parser::ParsedType::Optional>();NonnullRefPtr<parser::ParsedType> const& lhs_inner = __jakt_match_value.inner;
+return JaktInternal::ExplicitValue(JAKT_RESOLVE_EXPLICIT_VALUE_OR_CONTROL_FLOW_RETURN_ONLY(([&]() -> JaktInternal::ExplicitValueOrControlFlow<bool, bool>{
+auto&& __jakt_match_variant = *rhs_parsed_type;
+switch(__jakt_match_variant.index()) {
+case 7: {
+auto&& __jakt_match_value = __jakt_match_variant.template get<parser::ParsedType::Optional>();NonnullRefPtr<parser::ParsedType> const& rhs_inner = __jakt_match_value.inner;
+return JaktInternal::ExplicitValue(((lhs_inner)->equals(rhs_inner)));
+};/*case end*/
+default: {
+return JaktInternal::ExplicitValue(false);
+};/*case end*/
+}/*switch end*/
+}()
+)));
 };/*case end*/
 case 8: {
-auto&& __jakt_match_value = __jakt_match_variant.template get<parser::ParsedType::Reference>();return JaktInternal::ExplicitValue(((rhs_parsed_type)->index() == 8 /* Reference */));
+auto&& __jakt_match_value = __jakt_match_variant.template get<parser::ParsedType::Reference>();NonnullRefPtr<parser::ParsedType> const& lhs_inner = __jakt_match_value.inner;
+return JaktInternal::ExplicitValue(JAKT_RESOLVE_EXPLICIT_VALUE_OR_CONTROL_FLOW_RETURN_ONLY(([&]() -> JaktInternal::ExplicitValueOrControlFlow<bool, bool>{
+auto&& __jakt_match_variant = *rhs_parsed_type;
+switch(__jakt_match_variant.index()) {
+case 8: {
+auto&& __jakt_match_value = __jakt_match_variant.template get<parser::ParsedType::Reference>();NonnullRefPtr<parser::ParsedType> const& rhs_inner = __jakt_match_value.inner;
+return JaktInternal::ExplicitValue(((lhs_inner)->equals(rhs_inner)));
+};/*case end*/
+default: {
+return JaktInternal::ExplicitValue(false);
+};/*case end*/
+}/*switch end*/
+}()
+)));
 };/*case end*/
 case 9: {
-auto&& __jakt_match_value = __jakt_match_variant.template get<parser::ParsedType::MutableReference>();return JaktInternal::ExplicitValue(((rhs_parsed_type)->index() == 9 /* MutableReference */));
+auto&& __jakt_match_value = __jakt_match_variant.template get<parser::ParsedType::MutableReference>();NonnullRefPtr<parser::ParsedType> const& lhs_inner = __jakt_match_value.inner;
+return JaktInternal::ExplicitValue(JAKT_RESOLVE_EXPLICIT_VALUE_OR_CONTROL_FLOW_RETURN_ONLY(([&]() -> JaktInternal::ExplicitValueOrControlFlow<bool, bool>{
+auto&& __jakt_match_variant = *rhs_parsed_type;
+switch(__jakt_match_variant.index()) {
+case 9: {
+auto&& __jakt_match_value = __jakt_match_variant.template get<parser::ParsedType::MutableReference>();NonnullRefPtr<parser::ParsedType> const& rhs_inner = __jakt_match_value.inner;
+return JaktInternal::ExplicitValue(((lhs_inner)->equals(rhs_inner)));
+};/*case end*/
+default: {
+return JaktInternal::ExplicitValue(false);
+};/*case end*/
+}/*switch end*/
+}()
+)));
 };/*case end*/
 case 10: {
-auto&& __jakt_match_value = __jakt_match_variant.template get<parser::ParsedType::RawPtr>();return JaktInternal::ExplicitValue(((rhs_parsed_type)->index() == 10 /* RawPtr */));
+auto&& __jakt_match_value = __jakt_match_variant.template get<parser::ParsedType::RawPtr>();NonnullRefPtr<parser::ParsedType> const& lhs_inner = __jakt_match_value.inner;
+return JaktInternal::ExplicitValue(JAKT_RESOLVE_EXPLICIT_VALUE_OR_CONTROL_FLOW_RETURN_ONLY(([&]() -> JaktInternal::ExplicitValueOrControlFlow<bool, bool>{
+auto&& __jakt_match_variant = *rhs_parsed_type;
+switch(__jakt_match_variant.index()) {
+case 10: {
+auto&& __jakt_match_value = __jakt_match_variant.template get<parser::ParsedType::RawPtr>();NonnullRefPtr<parser::ParsedType> const& rhs_inner = __jakt_match_value.inner;
+return JaktInternal::ExplicitValue(((lhs_inner)->equals(rhs_inner)));
+};/*case end*/
+default: {
+return JaktInternal::ExplicitValue(false);
+};/*case end*/
+}/*switch end*/
+}()
+)));
 };/*case end*/
 case 11: {
-auto&& __jakt_match_value = __jakt_match_variant.template get<parser::ParsedType::WeakPtr>();return JaktInternal::ExplicitValue(((rhs_parsed_type)->index() == 11 /* WeakPtr */));
+auto&& __jakt_match_value = __jakt_match_variant.template get<parser::ParsedType::WeakPtr>();NonnullRefPtr<parser::ParsedType> const& lhs_inner = __jakt_match_value.inner;
+return JaktInternal::ExplicitValue(JAKT_RESOLVE_EXPLICIT_VALUE_OR_CONTROL_FLOW_RETURN_ONLY(([&]() -> JaktInternal::ExplicitValueOrControlFlow<bool, bool>{
+auto&& __jakt_match_variant = *rhs_parsed_type;
+switch(__jakt_match_variant.index()) {
+case 11: {
+auto&& __jakt_match_value = __jakt_match_variant.template get<parser::ParsedType::WeakPtr>();NonnullRefPtr<parser::ParsedType> const& rhs_inner = __jakt_match_value.inner;
+return JaktInternal::ExplicitValue(((lhs_inner)->equals(rhs_inner)));
+};/*case end*/
+default: {
+return JaktInternal::ExplicitValue(false);
+};/*case end*/
+}/*switch end*/
+}()
+)));
 };/*case end*/
 case 12: {
-auto&& __jakt_match_value = __jakt_match_variant.template get<parser::ParsedType::Function>();return JaktInternal::ExplicitValue(((rhs_parsed_type)->index() == 12 /* Function */));
+auto&& __jakt_match_value = __jakt_match_variant.template get<parser::ParsedType::Function>();JaktInternal::Array<parser::ParsedParameter> const& lhs_params = __jakt_match_value.params;
+bool const& lhs_can_throw = __jakt_match_value.can_throw;
+NonnullRefPtr<parser::ParsedType> const& lhs_return_type = __jakt_match_value.return_type;
+return JaktInternal::ExplicitValue(JAKT_RESOLVE_EXPLICIT_VALUE_OR_CONTROL_FLOW_RETURN_ONLY(([&]() -> JaktInternal::ExplicitValueOrControlFlow<bool, bool>{
+auto&& __jakt_match_variant = *rhs_parsed_type;
+switch(__jakt_match_variant.index()) {
+case 12: {
+auto&& __jakt_match_value = __jakt_match_variant.template get<parser::ParsedType::Function>();JaktInternal::Array<parser::ParsedParameter> const& rhs_params = __jakt_match_value.params;
+bool const& rhs_can_throw = __jakt_match_value.can_throw;
+NonnullRefPtr<parser::ParsedType> const& rhs_return_type = __jakt_match_value.return_type;
+{
+if ((lhs_can_throw != rhs_can_throw)){
+return (false);
+}
+if ((!(((lhs_return_type)->equals(rhs_return_type))))){
+return (false);
+}
+if ((((lhs_params).size()) != ((rhs_params).size()))){
+return (false);
+}
+{
+JaktInternal::Range<size_t> _magic = (JaktInternal::Range<size_t>{static_cast<size_t>(static_cast<size_t>(0ULL)),static_cast<size_t>(((lhs_params).size()))});
+for (;;){
+JaktInternal::Optional<size_t> _magic_value = ((_magic).next());
+if ((!(((_magic_value).has_value())))){
+break;
+}
+size_t param_index = (_magic_value.value());
+{
+if ((!(((((lhs_params)[param_index])).equals(((rhs_params)[param_index])))))){
+return (false);
+}
+}
+
+}
+}
+
+return (true);
+}
+};/*case end*/
+default: {
+return JaktInternal::ExplicitValue(false);
+};/*case end*/
+}/*switch end*/
+}()
+)));
 };/*case end*/
 case 13: {
 auto&& __jakt_match_value = __jakt_match_variant.template get<typename parser::ParsedType::Empty>();

--- a/bootstrap/stage0/parser.h
+++ b/bootstrap/stage0/parser.h
@@ -175,6 +175,7 @@ struct ParsedFunction {
   public:
 String name;utility::Span name_span;parser::Visibility visibility;JaktInternal::Array<parser::ParsedParameter> params;JaktInternal::Array<parser::ParsedGenericParameter> generic_parameters;parser::ParsedBlock block;NonnullRefPtr<parser::ParsedType> return_type;utility::Span return_type_span;bool can_throw;parser::FunctionType type;parser::FunctionLinkage linkage;bool must_instantiate;bool is_comptime;bool is_fat_arrow;ParsedFunction(String a_name, utility::Span a_name_span, parser::Visibility a_visibility, JaktInternal::Array<parser::ParsedParameter> a_params, JaktInternal::Array<parser::ParsedGenericParameter> a_generic_parameters, parser::ParsedBlock a_block, NonnullRefPtr<parser::ParsedType> a_return_type, utility::Span a_return_type_span, bool a_can_throw, parser::FunctionType a_type, parser::FunctionLinkage a_linkage, bool a_must_instantiate, bool a_is_comptime, bool a_is_fat_arrow);
 
+bool equals(parser::ParsedFunction const other) const;
 ErrorOr<String> debug_description() const;
 };struct ParsedField {
   public:

--- a/bootstrap/stage0/repl.cpp
+++ b/bootstrap/stage0/repl.cpp
@@ -151,7 +151,7 @@ return JaktInternal::ExplicitValue(repl::serialize_unary_operation(op,TRY((repl:
 };/*case end*/
 case 7: {
 auto&& __jakt_match_value = __jakt_match_variant.template get<types::CheckedExpression::JaktTuple>();JaktInternal::Array<NonnullRefPtr<types::CheckedExpression>> const& vals = __jakt_match_value.vals;
-return JaktInternal::ExplicitValue(({ Optional<String> __jakt_var_625; {
+return JaktInternal::ExplicitValue(({ Optional<String> __jakt_var_632; {
 StringBuilder builder = TRY((StringBuilder::create()));
 TRY((((builder).append_string(String("(")))));
 {
@@ -173,15 +173,15 @@ TRY((((builder).append_string(TRY((repl::serialize_ast_node(((vals)[i]))))))));
 }
 
 TRY((((builder).append_string(String(")")))));
-__jakt_var_625 = TRY((((builder).to_string()))); goto __jakt_label_587;
+__jakt_var_632 = TRY((((builder).to_string()))); goto __jakt_label_593;
 
 }
-__jakt_label_587:; __jakt_var_625.release_value(); }));
+__jakt_label_593:; __jakt_var_632.release_value(); }));
 };/*case end*/
 case 8: {
 auto&& __jakt_match_value = __jakt_match_variant.template get<types::CheckedExpression::Range>();JaktInternal::Optional<NonnullRefPtr<types::CheckedExpression>> const& from = __jakt_match_value.from;
 JaktInternal::Optional<NonnullRefPtr<types::CheckedExpression>> const& to = __jakt_match_value.to;
-return JaktInternal::ExplicitValue(({ Optional<String> __jakt_var_626; {
+return JaktInternal::ExplicitValue(({ Optional<String> __jakt_var_633; {
 String from_output = String("");
 if (((from).has_value())){
 (from_output = TRY((repl::serialize_ast_node((from.value())))));
@@ -190,14 +190,14 @@ String to_output = String("");
 if (((to).has_value())){
 (to_output = TRY((repl::serialize_ast_node((to.value())))));
 }
-__jakt_var_626 = TRY((String::formatted(String("{}..{}"),from_output,to_output))); goto __jakt_label_588;
+__jakt_var_633 = TRY((String::formatted(String("{}..{}"),from_output,to_output))); goto __jakt_label_594;
 
 }
-__jakt_label_588:; __jakt_var_626.release_value(); }));
+__jakt_label_594:; __jakt_var_633.release_value(); }));
 };/*case end*/
 case 9: {
 auto&& __jakt_match_value = __jakt_match_variant.template get<types::CheckedExpression::JaktArray>();JaktInternal::Array<NonnullRefPtr<types::CheckedExpression>> const& vals = __jakt_match_value.vals;
-return JaktInternal::ExplicitValue(({ Optional<String> __jakt_var_627; {
+return JaktInternal::ExplicitValue(({ Optional<String> __jakt_var_634; {
 StringBuilder builder = TRY((StringBuilder::create()));
 TRY((((builder).append_string(String("[")))));
 {
@@ -219,14 +219,14 @@ TRY((((builder).append_string(TRY((repl::serialize_ast_node(((vals)[i]))))))));
 }
 
 TRY((((builder).append_string(String("]")))));
-__jakt_var_627 = TRY((((builder).to_string()))); goto __jakt_label_589;
+__jakt_var_634 = TRY((((builder).to_string()))); goto __jakt_label_595;
 
 }
-__jakt_label_589:; __jakt_var_627.release_value(); }));
+__jakt_label_595:; __jakt_var_634.release_value(); }));
 };/*case end*/
 case 10: {
 auto&& __jakt_match_value = __jakt_match_variant.template get<types::CheckedExpression::JaktSet>();JaktInternal::Array<NonnullRefPtr<types::CheckedExpression>> const& vals = __jakt_match_value.vals;
-return JaktInternal::ExplicitValue(({ Optional<String> __jakt_var_628; {
+return JaktInternal::ExplicitValue(({ Optional<String> __jakt_var_635; {
 StringBuilder builder = TRY((StringBuilder::create()));
 TRY((((builder).append_string(String("{")))));
 {
@@ -248,14 +248,14 @@ TRY((((builder).append_string(TRY((repl::serialize_ast_node(((vals)[i]))))))));
 }
 
 TRY((((builder).append_string(String("}")))));
-__jakt_var_628 = TRY((((builder).to_string()))); goto __jakt_label_590;
+__jakt_var_635 = TRY((((builder).to_string()))); goto __jakt_label_596;
 
 }
-__jakt_label_590:; __jakt_var_628.release_value(); }));
+__jakt_label_596:; __jakt_var_635.release_value(); }));
 };/*case end*/
 case 11: {
 auto&& __jakt_match_value = __jakt_match_variant.template get<types::CheckedExpression::JaktDictionary>();JaktInternal::Array<JaktInternal::Tuple<NonnullRefPtr<types::CheckedExpression>,NonnullRefPtr<types::CheckedExpression>>> const& vals = __jakt_match_value.vals;
-return JaktInternal::ExplicitValue(({ Optional<String> __jakt_var_629; {
+return JaktInternal::ExplicitValue(({ Optional<String> __jakt_var_636; {
 StringBuilder builder = TRY((StringBuilder::create()));
 TRY((((builder).append_string(String("[")))));
 {
@@ -280,10 +280,10 @@ TRY((((builder).append_string(TRY((repl::serialize_ast_node(((val).get<1>())))))
 }
 
 TRY((((builder).append_string(String("]")))));
-__jakt_var_629 = TRY((((builder).to_string()))); goto __jakt_label_591;
+__jakt_var_636 = TRY((((builder).to_string()))); goto __jakt_label_597;
 
 }
-__jakt_label_591:; __jakt_var_629.release_value(); }));
+__jakt_label_597:; __jakt_var_636.release_value(); }));
 };/*case end*/
 case 12: {
 auto&& __jakt_match_value = __jakt_match_variant.template get<types::CheckedExpression::IndexedExpression>();NonnullRefPtr<types::CheckedExpression> const& expr = __jakt_match_value.expr;
@@ -308,7 +308,7 @@ return JaktInternal::ExplicitValue(TRY((String::formatted(String("{}.{}"),TRY((r
 case 21: {
 auto&& __jakt_match_value = __jakt_match_variant.template get<types::CheckedExpression::NamespacedVar>();JaktInternal::Array<types::CheckedNamespace> const& namespaces = __jakt_match_value.namespaces;
 types::CheckedVariable const& var = __jakt_match_value.var;
-return JaktInternal::ExplicitValue(({ Optional<String> __jakt_var_630; {
+return JaktInternal::ExplicitValue(({ Optional<String> __jakt_var_637; {
 StringBuilder builder = TRY((StringBuilder::create()));
 {
 JaktInternal::ArrayIterator<types::CheckedNamespace> _magic = ((namespaces).iterator());
@@ -327,10 +327,10 @@ TRY((((builder).append_string(String("::")))));
 }
 
 TRY((((builder).append_string(((var).name)))));
-__jakt_var_630 = TRY((((builder).to_string()))); goto __jakt_label_592;
+__jakt_var_637 = TRY((((builder).to_string()))); goto __jakt_label_598;
 
 }
-__jakt_label_592:; __jakt_var_630.release_value(); }));
+__jakt_label_598:; __jakt_var_637.release_value(); }));
 };/*case end*/
 case 22: {
 auto&& __jakt_match_value = __jakt_match_variant.template get<types::CheckedExpression::Var>();types::CheckedVariable const& var = __jakt_match_value.var;
@@ -349,7 +349,7 @@ return JaktInternal::ExplicitValue(TRY((String::formatted(String("{}!"),TRY((rep
 };/*case end*/
 case 19: {
 auto&& __jakt_match_value = __jakt_match_variant.template get<types::CheckedExpression::Call>();types::CheckedCall const& call = __jakt_match_value.call;
-return JaktInternal::ExplicitValue(({ Optional<String> __jakt_var_631; {
+return JaktInternal::ExplicitValue(({ Optional<String> __jakt_var_638; {
 StringBuilder builder = TRY((StringBuilder::create()));
 {
 JaktInternal::ArrayIterator<types::ResolvedNamespace> _magic = ((((call).namespace_)).iterator());
@@ -393,10 +393,10 @@ TRY((((builder).append_string(TRY((repl::serialize_ast_node(((arg).get<1>())))))
 }
 
 TRY((((builder).append_string(String(")")))));
-__jakt_var_631 = TRY((((builder).to_string()))); goto __jakt_label_593;
+__jakt_var_638 = TRY((((builder).to_string()))); goto __jakt_label_599;
 
 }
-__jakt_label_593:; __jakt_var_631.release_value(); }));
+__jakt_label_599:; __jakt_var_638.release_value(); }));
 };/*case end*/
 case 30: {
 auto&& __jakt_match_value = __jakt_match_variant.template get<typename types::CheckedExpression::Garbage>();
@@ -490,7 +490,7 @@ return (repl::REPL(compiler,typechecker,root_scope_id,root_interpreter_scope,fil
 ErrorOr<void> repl::REPL::run() {
 {
 repl::Editor editor = TRY((repl::Editor::Editor::create(String("> "))));
-ScopeGuard __jakt_var_632([&] {
+ScopeGuard __jakt_var_639([&] {
 ((editor).destroy());
 });
 for (;;){
@@ -499,15 +499,15 @@ TRY((((((*this).compiler))->print_errors())));
 JaktInternal::Array<error::JaktError> const arr = (TRY((Array<error::JaktError>::create_with({}))));
 (((((*this).compiler))->errors) = arr);
 }
-repl::LineResult const line_result = ({ Optional<repl::LineResult> __jakt_var_633;
-auto __jakt_var_634 = [&]() -> ErrorOr<repl::LineResult> { return TRY((((editor).get_line()))); }();
-if (__jakt_var_634.is_error()) {auto error = __jakt_var_634.release_error();
+repl::LineResult const line_result = ({ Optional<repl::LineResult> __jakt_var_640;
+auto __jakt_var_641 = [&]() -> ErrorOr<repl::LineResult> { return TRY((((editor).get_line()))); }();
+if (__jakt_var_641.is_error()) {auto error = __jakt_var_641.release_error();
 {
 return {};
 }
-} else {__jakt_var_633 = __jakt_var_634.release_value();
+} else {__jakt_var_640 = __jakt_var_641.release_value();
 }
-__jakt_var_633.release_value(); });
+__jakt_var_640.release_value(); });
 if (((line_result).index() == 0 /* Line */)){
 String const line = (line_result.get<repl::LineResult::Line>()).value;
 if ((line == String(".exit\n"))){
@@ -522,34 +522,34 @@ TRY((((bytes_).push(((line).byte_at(pos))))));
 }
 (((((*this).compiler))->current_file) = ((*this).file_id));
 (((((*this).compiler))->current_file_contents) = bytes_);
-JaktInternal::Array<lexer::Token> const tokens = ({ Optional<JaktInternal::Array<lexer::Token>> __jakt_var_635;
-auto __jakt_var_636 = [&]() -> ErrorOr<JaktInternal::Array<lexer::Token>> { return TRY((lexer::Lexer::Lexer::lex(((*this).compiler)))); }();
-if (__jakt_var_636.is_error()) {{
+JaktInternal::Array<lexer::Token> const tokens = ({ Optional<JaktInternal::Array<lexer::Token>> __jakt_var_642;
+auto __jakt_var_643 = [&]() -> ErrorOr<JaktInternal::Array<lexer::Token>> { return TRY((lexer::Lexer::Lexer::lex(((*this).compiler)))); }();
+if (__jakt_var_643.is_error()) {{
 continue;
 }
-} else {__jakt_var_635 = __jakt_var_636.release_value();
+} else {__jakt_var_642 = __jakt_var_643.release_value();
 }
-__jakt_var_635.release_value(); });
+__jakt_var_642.release_value(); });
 if (((tokens).is_empty())){
 continue;
 }
 parser::Parser parser = parser::Parser(static_cast<size_t>(0ULL),tokens,((*this).compiler));
 lexer::Token const first_token = (((tokens).first()).value());
 if (((((((((((first_token).index() == 75 /* Function */) || ((first_token).index() == 76 /* Comptime */)) || ((first_token).index() == 94 /* Struct */)) || ((first_token).index() == 66 /* Class */)) || ((first_token).index() == 71 /* Enum */)) || ((first_token).index() == 63 /* Boxed */)) || ((first_token).index() == 85 /* Namespace */)) || ((first_token).index() == 78 /* Import */)) || ((first_token).index() == 108 /* Trait */))){
-parser::ParsedNamespace const parsed_namespace = ({ Optional<parser::ParsedNamespace> __jakt_var_637;
-auto __jakt_var_638 = [&]() -> ErrorOr<parser::ParsedNamespace> { return TRY((((parser).parse_namespace()))); }();
-if (__jakt_var_638.is_error()) {{
+parser::ParsedNamespace const parsed_namespace = ({ Optional<parser::ParsedNamespace> __jakt_var_644;
+auto __jakt_var_645 = [&]() -> ErrorOr<parser::ParsedNamespace> { return TRY((((parser).parse_namespace()))); }();
+if (__jakt_var_645.is_error()) {{
 TRY((((*this).handle_possible_error())));
 continue;
 }
-} else {__jakt_var_637 = __jakt_var_638.release_value();
+} else {__jakt_var_644 = __jakt_var_645.release_value();
 }
-__jakt_var_637.release_value(); });
+__jakt_var_644.release_value(); });
 if (TRY((((*this).handle_possible_error())))){
 continue;
 }
-auto __jakt_var_640 = [&]() -> ErrorOr<void> { return TRY((((((*this).typechecker)).typecheck_module(parsed_namespace,((*this).root_scope_id))))), ErrorOr<void>{}; }();
-if (__jakt_var_640.is_error()) {{
+auto __jakt_var_647 = [&]() -> ErrorOr<void> { return TRY((((((*this).typechecker)).typecheck_module(parsed_namespace,((*this).root_scope_id))))), ErrorOr<void>{}; }();
+if (__jakt_var_647.is_error()) {{
 TRY((((*this).handle_possible_error())));
 continue;
 }
@@ -558,40 +558,40 @@ continue;
 TRY((((*this).handle_possible_error())));
 continue;
 }
-NonnullRefPtr<parser::ParsedStatement> const parsed_statement = ({ Optional<NonnullRefPtr<parser::ParsedStatement>> __jakt_var_641;
-auto __jakt_var_642 = [&]() -> ErrorOr<NonnullRefPtr<parser::ParsedStatement>> { return TRY((((parser).parse_statement(true)))); }();
-if (__jakt_var_642.is_error()) {{
+NonnullRefPtr<parser::ParsedStatement> const parsed_statement = ({ Optional<NonnullRefPtr<parser::ParsedStatement>> __jakt_var_648;
+auto __jakt_var_649 = [&]() -> ErrorOr<NonnullRefPtr<parser::ParsedStatement>> { return TRY((((parser).parse_statement(true)))); }();
+if (__jakt_var_649.is_error()) {{
 TRY((((*this).handle_possible_error())));
 continue;
 }
-} else {__jakt_var_641 = __jakt_var_642.release_value();
+} else {__jakt_var_648 = __jakt_var_649.release_value();
 }
-__jakt_var_641.release_value(); });
+__jakt_var_648.release_value(); });
 if (TRY((((*this).handle_possible_error())))){
 continue;
 }
-NonnullRefPtr<types::CheckedStatement> const checked_statement = ({ Optional<NonnullRefPtr<types::CheckedStatement>> __jakt_var_643;
-auto __jakt_var_644 = [&]() -> ErrorOr<NonnullRefPtr<types::CheckedStatement>> { return TRY((((((*this).typechecker)).typecheck_statement(parsed_statement,((*this).root_scope_id), types::SafetyMode { typename types::SafetyMode::Safe() } ,JaktInternal::OptionalNone())))); }();
-if (__jakt_var_644.is_error()) {{
+NonnullRefPtr<types::CheckedStatement> const checked_statement = ({ Optional<NonnullRefPtr<types::CheckedStatement>> __jakt_var_650;
+auto __jakt_var_651 = [&]() -> ErrorOr<NonnullRefPtr<types::CheckedStatement>> { return TRY((((((*this).typechecker)).typecheck_statement(parsed_statement,((*this).root_scope_id), types::SafetyMode { typename types::SafetyMode::Safe() } ,JaktInternal::OptionalNone())))); }();
+if (__jakt_var_651.is_error()) {{
 TRY((((*this).handle_possible_error())));
 continue;
 }
-} else {__jakt_var_643 = __jakt_var_644.release_value();
+} else {__jakt_var_650 = __jakt_var_651.release_value();
 }
-__jakt_var_643.release_value(); });
+__jakt_var_650.release_value(); });
 if (TRY((((*this).handle_possible_error())))){
 continue;
 }
 NonnullRefPtr<interpreter::Interpreter> interpreter = TRY((interpreter::Interpreter::Interpreter::create(((*this).compiler),((((*this).typechecker)).program),(TRY((Array<utility::Span>::create_with({})))))));
-interpreter::StatementResult const result = ({ Optional<interpreter::StatementResult> __jakt_var_645;
-auto __jakt_var_646 = [&]() -> ErrorOr<interpreter::StatementResult> { return TRY((((interpreter)->execute_statement(checked_statement,((*this).root_interpreter_scope),utility::Span(((*this).file_id),static_cast<size_t>(0ULL),((line).length())))))); }();
-if (__jakt_var_646.is_error()) {{
+interpreter::StatementResult const result = ({ Optional<interpreter::StatementResult> __jakt_var_652;
+auto __jakt_var_653 = [&]() -> ErrorOr<interpreter::StatementResult> { return TRY((((interpreter)->execute_statement(checked_statement,((*this).root_interpreter_scope),utility::Span(((*this).file_id),static_cast<size_t>(0ULL),((line).length())))))); }();
+if (__jakt_var_653.is_error()) {{
 TRY((((*this).handle_possible_error())));
 continue;
 }
-} else {__jakt_var_645 = __jakt_var_646.release_value();
+} else {__jakt_var_652 = __jakt_var_653.release_value();
 }
-__jakt_var_645.release_value(); });
+__jakt_var_652.release_value(); });
 if (TRY((((*this).handle_possible_error())))){
 continue;
 }

--- a/bootstrap/stage0/repl.h
+++ b/bootstrap/stage0/repl.h
@@ -11,15 +11,7 @@
 #include "jakt__libc__io.h"
 namespace Jakt {
 namespace repl {
-struct Editor {
-  public:
-FILE* standard_input_file;char* line_pointer;String prompt;static ErrorOr<repl::Editor> create(String const prompt);
-void destroy();
-Editor(FILE* a_standard_input_file, char* a_line_pointer, String a_prompt);
-
-ErrorOr<repl::LineResult> get_line();
-ErrorOr<String> debug_description() const;
-};struct REPL {
+struct REPL {
   public:
 NonnullRefPtr<compiler::Compiler> compiler;typechecker::Typechecker typechecker;types::ScopeId root_scope_id;NonnullRefPtr<interpreter::InterpreterScope> root_interpreter_scope;utility::FileId file_id;static ErrorOr<repl::REPL> create(path::Path const runtime_path, JaktInternal::Optional<String> const target_triple);
 ErrorOr<void> run();
@@ -44,14 +36,22 @@ using Variant<LineResult_Details::Line, LineResult_Details::Eof>::Variant;
     using Eof = LineResult_Details::Eof;
 ErrorOr<String> debug_description() const;
 };
-}
-template<>struct Formatter<repl::Editor> : Formatter<StringView>{
-ErrorOr<void> format(FormatBuilder& builder, repl::Editor const& value) {
-JaktInternal::PrettyPrint::ScopedEnable pretty_print_enable { m_alternative_form };ErrorOr<void> format_error = Formatter<StringView>::format(builder, MUST(value.debug_description()));return format_error; }};
+struct Editor {
+  public:
+FILE* standard_input_file;char* line_pointer;String prompt;static ErrorOr<repl::Editor> create(String const prompt);
+void destroy();
+Editor(FILE* a_standard_input_file, char* a_line_pointer, String a_prompt);
+
+ErrorOr<repl::LineResult> get_line();
+ErrorOr<String> debug_description() const;
+};}
 template<>struct Formatter<repl::REPL> : Formatter<StringView>{
 ErrorOr<void> format(FormatBuilder& builder, repl::REPL const& value) {
 JaktInternal::PrettyPrint::ScopedEnable pretty_print_enable { m_alternative_form };ErrorOr<void> format_error = Formatter<StringView>::format(builder, MUST(value.debug_description()));return format_error; }};
 template<>struct Formatter<repl::LineResult> : Formatter<StringView>{
 ErrorOr<void> format(FormatBuilder& builder, repl::LineResult const& value) {
+JaktInternal::PrettyPrint::ScopedEnable pretty_print_enable { m_alternative_form };ErrorOr<void> format_error = Formatter<StringView>::format(builder, MUST(value.debug_description()));return format_error; }};
+template<>struct Formatter<repl::Editor> : Formatter<StringView>{
+ErrorOr<void> format(FormatBuilder& builder, repl::Editor const& value) {
 JaktInternal::PrettyPrint::ScopedEnable pretty_print_enable { m_alternative_form };ErrorOr<void> format_error = Formatter<StringView>::format(builder, MUST(value.debug_description()));return format_error; }};
 } // namespace Jakt

--- a/bootstrap/stage0/runtime/Builtins/Array.h
+++ b/bootstrap/stage0/runtime/Builtins/Array.h
@@ -240,6 +240,15 @@ public:
         return {};
     }
 
+    ErrorOr<void> push_values(Array<T> const& values)
+    {
+        TRY(m_storage->ensure_capacity(capacity() + values.size()));
+        for (size_t i = 0; i < values.size(); ++i) {
+            TRY(push(values.at(i)));
+        }
+        return {};
+    }
+
     T const& at(size_t index) const
     {
         return m_storage->at(index);

--- a/bootstrap/stage0/runtime/lib.h
+++ b/bootstrap/stage0/runtime/lib.h
@@ -249,9 +249,9 @@ inline String ___jakt_get_target_triple_string()
     return String(__JAKT_BUILD_TARGET);
 #else
 // Pure guesswork.
-#   if defined(_WIN32)
+#   if defined(_WIN64)
     return String("x86_64-pc-windows-msvc");
-#   elif defined(_WIN64)
+#   elif defined(_WIN32)
     return String("i686-pc-windows-msvc");
 #   elif defined(__linux__)
     return String("x86_64-pc-linux-gnu");

--- a/bootstrap/stage0/runtime/prelude.jakt
+++ b/bootstrap/stage0/runtime/prelude.jakt
@@ -19,6 +19,7 @@ extern struct Array<T> {
     function resize(mut this, anon size: usize) throws
     function shrink(mut this, anon size: usize) -> void
     function push(mut this, anon value: T) throws
+    function push_values(mut this, anon other: &Array<T>) throws
     function pop(mut this) -> T?
     function iterator(this) -> ArrayIterator<T>
     function first(this) -> T?

--- a/bootstrap/stage0/typechecker.cpp
+++ b/bootstrap/stage0/typechecker.cpp
@@ -40,7 +40,7 @@ switch(__jakt_match_variant.index()) {
 case 1: {
 auto&& __jakt_match_value = __jakt_match_variant.template get<typename parser::ParsedMatchBody::Block>();
 parser::ParsedBlock const& block = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(({ Optional<types::CheckedMatchBody> __jakt_var_294; {
+return JaktInternal::ExplicitValue(({ Optional<types::CheckedMatchBody> __jakt_var_299; {
 types::CheckedBlock const checked_block = TRY((((*this).typecheck_block(block,scope_id,safety_mode,final_result_type))));
 if ((((((checked_block).control_flow)).may_return()) || ((((checked_block).yielded_type)).has_value()))){
 types::TypeId const block_type_id = ((checked_block).yielded_type).value_or_lazy_evaluated([&] { return types::void_type_id(); });
@@ -61,15 +61,15 @@ else {
 (final_body =  types::CheckedMatchBody { typename types::CheckedMatchBody::Block(checked_block) } );
 }
 
-__jakt_var_294 = (final_body.value()); goto __jakt_label_285;
+__jakt_var_299 = (final_body.value()); goto __jakt_label_290;
 
 }
-__jakt_label_285:; __jakt_var_294.release_value(); }));
+__jakt_label_290:; __jakt_var_299.release_value(); }));
 };/*case end*/
 case 0: {
 auto&& __jakt_match_value = __jakt_match_variant.template get<typename parser::ParsedMatchBody::Expression>();
 NonnullRefPtr<parser::ParsedExpression> const& expr = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(({ Optional<types::CheckedMatchBody> __jakt_var_295; {
+return JaktInternal::ExplicitValue(({ Optional<types::CheckedMatchBody> __jakt_var_300; {
 NonnullRefPtr<types::CheckedExpression> const checked_expression = TRY((((*this).typecheck_expression(expr,scope_id,safety_mode,result_type))));
 if (((result_type).has_value())){
 TRY((((*this).check_types_for_compat((result_type.value()),((checked_expression)->type()),generic_inferences,span))));
@@ -78,10 +78,10 @@ else {
 (result_type = ((checked_expression)->type()));
 }
 
-__jakt_var_295 =  types::CheckedMatchBody { typename types::CheckedMatchBody::Expression(checked_expression) } ; goto __jakt_label_286;
+__jakt_var_300 =  types::CheckedMatchBody { typename types::CheckedMatchBody::Expression(checked_expression) } ; goto __jakt_label_291;
 
 }
-__jakt_label_286:; __jakt_var_295.release_value(); }));
+__jakt_label_291:; __jakt_var_300.release_value(); }));
 };/*case end*/
 default: VERIFY_NOT_REACHED();}/*switch end*/
 }()
@@ -337,14 +337,14 @@ JaktInternal::Tuple<String,types::FunctionId> const jakt__name__function_id__ = 
 String const name = ((jakt__name__function_id__).get<0>());
 types::FunctionId const function_id = ((jakt__name__function_id__).get<1>());
 
-if (((TRY((((*this).find_function_in_scope(((struct_).scope_id),name))))).has_value())){
+if (((TRY((((*this).find_functions_with_name_in_scope(((struct_).scope_id),name))))).has_value())){
 continue;
 }
 NonnullRefPtr<types::CheckedFunction> const function_ = ((*this).get_function(function_id));
 if (((((((function_)->block)).statements)).is_empty())){
 continue;
 }
-TRY((((*this).add_function_to_scope(((struct_).scope_id),name,function_id,((trait_name).name_span)))));
+TRY((((*this).add_function_to_scope(((struct_).scope_id),name,(TRY((Array<types::FunctionId>::create_with({function_id})))),((trait_name).name_span)))));
 }
 
 }
@@ -412,14 +412,14 @@ JaktInternal::Tuple<String,types::FunctionId> const jakt__name__function_id__ = 
 String const name = ((jakt__name__function_id__).get<0>());
 types::FunctionId const function_id = ((jakt__name__function_id__).get<1>());
 
-if (((TRY((((*this).find_function_in_scope(((struct_).scope_id),name))))).has_value())){
+if (((TRY((((*this).find_functions_with_name_in_scope(((struct_).scope_id),name))))).has_value())){
 continue;
 }
 NonnullRefPtr<types::CheckedFunction> const function_ = ((*this).get_function(function_id));
 if (((((((function_)->block)).statements)).is_empty())){
 continue;
 }
-TRY((((*this).add_function_to_scope(((struct_).scope_id),name,function_id,((trait_name).name_span)))));
+TRY((((*this).add_function_to_scope(((struct_).scope_id),name,(TRY((Array<types::FunctionId>::create_with({function_id})))),((trait_name).name_span)))));
 }
 
 }
@@ -488,14 +488,14 @@ JaktInternal::Tuple<String,types::FunctionId> const jakt__name__function_id__ = 
 String const name = ((jakt__name__function_id__).get<0>());
 types::FunctionId const function_id = ((jakt__name__function_id__).get<1>());
 
-if (((TRY((((*this).find_function_in_scope(((enum_).scope_id),name))))).has_value())){
+if (((TRY((((*this).find_functions_with_name_in_scope(((enum_).scope_id),name))))).has_value())){
 continue;
 }
 NonnullRefPtr<types::CheckedFunction> const function_ = ((*this).get_function(function_id));
 if (((((((function_)->block)).statements)).is_empty())){
 continue;
 }
-TRY((((*this).add_function_to_scope(((enum_).scope_id),name,function_id,((trait_name).name_span)))));
+TRY((((*this).add_function_to_scope(((enum_).scope_id),name,(TRY((Array<types::FunctionId>::create_with({function_id})))),((trait_name).name_span)))));
 }
 
 }
@@ -563,14 +563,14 @@ JaktInternal::Tuple<String,types::FunctionId> const jakt__name__function_id__ = 
 String const name = ((jakt__name__function_id__).get<0>());
 types::FunctionId const function_id = ((jakt__name__function_id__).get<1>());
 
-if (((TRY((((*this).find_function_in_scope(((enum_).scope_id),name))))).has_value())){
+if (((TRY((((*this).find_functions_with_name_in_scope(((enum_).scope_id),name))))).has_value())){
 continue;
 }
 NonnullRefPtr<types::CheckedFunction> const function_ = ((*this).get_function(function_id));
 if (((((((function_)->block)).statements)).is_empty())){
 continue;
 }
-TRY((((*this).add_function_to_scope(((enum_).scope_id),name,function_id,((trait_name).name_span)))));
+TRY((((*this).add_function_to_scope(((enum_).scope_id),name,(TRY((Array<types::FunctionId>::create_with({function_id})))),((trait_name).name_span)))));
 }
 
 }
@@ -706,11 +706,12 @@ types::TypeId return_type = types::builtin( types::BuiltinType { typename types:
 JaktInternal::Array<types::TypeId> generic_arguments = (TRY((Array<types::TypeId>::create_with({}))));
 bool callee_throws = false;
 JaktInternal::Array<types::ResolvedNamespace> resolved_namespaces = (TRY((Array<types::ResolvedNamespace>::create_with({}))));
+JaktInternal::Array<types::FunctionId> resolved_function_id_candidates = (TRY((Array<types::FunctionId>::create_with({}))));
 JaktInternal::Optional<types::FunctionId> resolved_function_id = JaktInternal::OptionalNone();
 JaktInternal::Optional<types::TypeId> maybe_this_type_id = JaktInternal::OptionalNone();
 JaktInternal::Optional<types::FunctionId> generic_checked_function_to_instantiate = JaktInternal::OptionalNone();
 JaktInternal::Dictionary<String,String> const old_generic_inferences = TRY((((((*this).generic_inferences)).perform_checkpoint(false))));
-ScopeGuard __jakt_var_296([&] {
+ScopeGuard __jakt_var_301([&] {
 {
 ((((*this).generic_inferences)).restore(old_generic_inferences));
 }
@@ -740,12 +741,15 @@ switch(__jakt_match_variant.index()) {
 case 0: {
 auto&& __jakt_match_value = __jakt_match_variant.template get<typename types::StructOrEnumId::Struct>();
 types::StructId const& id = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(({ Optional<types::ScopeId> __jakt_var_297; {
+return JaktInternal::ExplicitValue(({ Optional<types::ScopeId> __jakt_var_302; {
 types::CheckedStruct struct_ = ((*this).get_struct(id));
 types::ScopeId scope_id = ((struct_).scope_id);
-while ((!(((resolved_function_id).has_value())))){
-(resolved_function_id = TRY((((*this).resolve_call(call,resolved_namespaces,span,scope_id,must_be_enum_constructor,true)))));
-if (((resolved_function_id).has_value())){
+while (((resolved_function_id_candidates).is_empty())){
+bool const old_ignore_errors = ((*this).ignore_errors);
+(((*this).ignore_errors) = true);
+(resolved_function_id_candidates = TRY((((*this).resolve_call(call,resolved_namespaces,span,scope_id,must_be_enum_constructor)))));
+(((*this).ignore_errors) = old_ignore_errors);
+if ((!(((resolved_function_id_candidates).is_empty())))){
 break;
 }
 if (((((struct_).super_struct_id)).has_value())){
@@ -759,28 +763,28 @@ break;
 }
 
 }
-__jakt_var_297 = scope_id; goto __jakt_label_287;
+__jakt_var_302 = scope_id; goto __jakt_label_292;
 
 }
-__jakt_label_287:; __jakt_var_297.release_value(); }));
+__jakt_label_292:; __jakt_var_302.release_value(); }));
 };/*case end*/
 case 1: {
 auto&& __jakt_match_value = __jakt_match_variant.template get<typename types::StructOrEnumId::Enum>();
 types::EnumId const& id = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(({ Optional<types::ScopeId> __jakt_var_298; {
+return JaktInternal::ExplicitValue(({ Optional<types::ScopeId> __jakt_var_303; {
 types::ScopeId const scope_id = ((((*this).get_enum(id))).scope_id);
-(resolved_function_id = TRY((((*this).resolve_call(call,resolved_namespaces,span,scope_id,must_be_enum_constructor,false)))));
-__jakt_var_298 = scope_id; goto __jakt_label_288;
+(resolved_function_id_candidates = TRY((((*this).resolve_call(call,resolved_namespaces,span,scope_id,must_be_enum_constructor)))));
+__jakt_var_303 = scope_id; goto __jakt_label_293;
 
 }
-__jakt_label_288:; __jakt_var_298.release_value(); }));
+__jakt_label_293:; __jakt_var_303.release_value(); }));
 };/*case end*/
 default: VERIFY_NOT_REACHED();}/*switch end*/
 }()
 )));
 }
 else {
-return JaktInternal::ExplicitValue(({ Optional<types::ScopeId> __jakt_var_299; {
+return JaktInternal::ExplicitValue(({ Optional<types::ScopeId> __jakt_var_304; {
 JAKT_RESOLVE_EXPLICIT_VALUE_OR_CONTROL_FLOW_RETURN_ONLY(([&]() -> JaktInternal::ExplicitValueOrControlFlow<void,ErrorOr<NonnullRefPtr<types::CheckedExpression>>>{
 auto __jakt_enum_value = (((call).name));
 if (__jakt_enum_value == String("print")) {
@@ -810,17 +814,17 @@ return JaktInternal::ExplicitValue<void>();
 }
 else {
 {
-(resolved_function_id = TRY((((*this).resolve_call(call,resolved_namespaces,span,caller_scope_id,must_be_enum_constructor,false)))));
+(resolved_function_id_candidates = TRY((((*this).resolve_call(call,resolved_namespaces,span,caller_scope_id,must_be_enum_constructor)))));
 }
 return JaktInternal::ExplicitValue<void>();
 }
 return JaktInternal::ExplicitValue<void>();
 }()))
 ;
-__jakt_var_299 = caller_scope_id; goto __jakt_label_289;
+__jakt_var_304 = caller_scope_id; goto __jakt_label_294;
 
 }
-__jakt_label_289:; __jakt_var_299.release_value(); }));
+__jakt_label_294:; __jakt_var_304.release_value(); }));
 }
 }()))
 ;
@@ -953,7 +957,101 @@ return JaktInternal::ExplicitValue<void>();
 }
 else {
 {
+i64 max_found_specificity = (-(static_cast<i64>(1LL)));
+JaktInternal::Array<error::JaktError> errors_while_trying_to_find_matching_function = (TRY((Array<error::JaktError>::create_with({}))));
+JaktInternal::Dictionary<String,String> generic_inferences_for_best_match = (TRY((Dictionary<String, String>::create_with_entries({}))));
+{
+JaktInternal::ArrayIterator<types::FunctionId> _magic = ((resolved_function_id_candidates).iterator());
+for (;;){
+JaktInternal::Optional<types::FunctionId> _magic_value = ((_magic).next());
+if ((!(((_magic_value).has_value())))){
+break;
+}
+types::FunctionId candidate = (_magic_value.value());
+{
+JAKT_RESOLVE_EXPLICIT_VALUE_OR_CONTROL_FLOW_AT_LOOP(([&]() -> JaktInternal::ExplicitValueOrControlFlow<void, ErrorOr<NonnullRefPtr<types::CheckedExpression>>>{
+auto&& __jakt_match_variant = TRY((((*this).match_function_and_resolve_args(call,caller_scope_id,candidate,safety_mode,span,this_expr))));
+switch(__jakt_match_variant.index()) {
+case 0: {
+auto&& __jakt_match_value = __jakt_match_variant.template get<typechecker::FunctionMatchResult::MatchSuccess>();JaktInternal::Array<NonnullRefPtr<types::CheckedExpression>> const& resolved_args = __jakt_match_value.args;
+JaktInternal::Optional<types::TypeId> const& resolved_this_type_id = __jakt_match_value.maybe_this_type_id;
+JaktInternal::Dictionary<String,String> const& used_generic_inferences = __jakt_match_value.used_generic_inferences;
+i64 const& specificity = __jakt_match_value.specificity;
+{
+if ((specificity > max_found_specificity)){
+(resolved_function_id = candidate);
+(maybe_this_type_id = resolved_this_type_id);
+(max_found_specificity = specificity);
+(generic_inferences_for_best_match = used_generic_inferences);
+(args = (TRY((Array<JaktInternal::Tuple<String,NonnullRefPtr<types::CheckedExpression>>>::create_with({})))));
+{
+JaktInternal::ArrayIterator<NonnullRefPtr<types::CheckedExpression>> _magic = ((resolved_args).iterator());
+for (;;){
+JaktInternal::Optional<NonnullRefPtr<types::CheckedExpression>> _magic_value = ((_magic).next());
+if ((!(((_magic_value).has_value())))){
+break;
+}
+NonnullRefPtr<types::CheckedExpression> resolved_arg = (_magic_value.value());
+{
+TRY((((args).push((Tuple{((call).name), resolved_arg})))));
+}
+
+}
+}
+
+}
+}
+return JaktInternal::ExplicitValue<void>();
+};/*case end*/
+case 1: {
+auto&& __jakt_match_value = __jakt_match_variant.template get<typechecker::FunctionMatchResult::MatchError>();JaktInternal::Array<error::JaktError> const& errors = __jakt_match_value.errors;
+{
+{
+JaktInternal::ArrayIterator<error::JaktError> _magic = ((errors).iterator());
+for (;;){
+JaktInternal::Optional<error::JaktError> _magic_value = ((_magic).next());
+if ((!(((_magic_value).has_value())))){
+break;
+}
+error::JaktError error = (_magic_value.value());
+{
+TRY((((errors_while_trying_to_find_matching_function).push(error))));
+}
+
+}
+}
+
+return JaktInternal::LoopContinue{};
+}
+return JaktInternal::ExplicitValue<void>();
+};/*case end*/
+default: VERIFY_NOT_REACHED();}/*switch end*/
+}()
+));
+}
+
+}
+}
+
 if ((!(((resolved_function_id).has_value())))){
+if ((!(((resolved_function_id_candidates).is_empty())))){
+TRY((((*this).error(String("No function with matching signature found."),span))));
+{
+JaktInternal::ArrayIterator<error::JaktError> _magic = ((errors_while_trying_to_find_matching_function).iterator());
+for (;;){
+JaktInternal::Optional<error::JaktError> _magic_value = ((_magic).next());
+if ((!(((_magic_value).has_value())))){
+break;
+}
+error::JaktError match_error = (_magic_value.value());
+{
+TRY((((((((*this).compiler))->errors)).push(match_error))));
+}
+
+}
+}
+
+}
 JaktInternal::Array<types::TypeId> checked_type_args = (TRY((Array<types::TypeId>::create_with({}))));
 {
 JaktInternal::ArrayIterator<NonnullRefPtr<parser::ParsedType>> _magic = ((((call).type_args)).iterator());
@@ -986,115 +1084,13 @@ TRY((((args).push((Tuple{((call).name), checked_arg})))));
 }
 }
 
-return (TRY((types::CheckedExpression::template create<typename types::CheckedExpression::Call>(types::CheckedCall(resolved_namespaces,((call).name),args,checked_type_args,resolved_function_id,return_type,callee_throws),span,return_type))));
+return (TRY((types::CheckedExpression::template create<typename types::CheckedExpression::Call>(types::CheckedCall(resolved_namespaces,((call).name),args,checked_type_args,JaktInternal::OptionalNone(),return_type,callee_throws),span,return_type))));
 }
-types::FunctionId const function_id = (resolved_function_id.value());
-NonnullRefPtr<types::CheckedFunction> const callee = ((*this).get_function(function_id));
-if (((callee)->is_instantiated)){
-TRY((((((*this).generic_inferences)).perform_checkpoint(true))));
-}
+((((*this).generic_inferences)).restore(generic_inferences_for_best_match));
+NonnullRefPtr<types::CheckedFunction> const callee = ((*this).get_function((resolved_function_id.value())));
 (callee_throws = ((callee)->can_throw));
 (return_type = ((callee)->return_type_id));
 types::ScopeId const scope_containing_callee = (((TRY((((*this).get_scope(((callee)->function_scope_id))))))->parent).value());
-if (((((callee)->type)).index() == 1 /* ImplicitConstructor */)){
-types::CheckedStruct const struct_ = ((*this).get_struct((((callee)->struct_id).value())));
-TRY((((*this).check_implicit_constructor_argument_access(caller_scope_id,call,struct_))));
-}
-else {
-TRY((((*this).check_method_access(caller_scope_id,scope_containing_callee,callee,span))));
-}
-
-size_t type_arg_index = static_cast<size_t>(0ULL);
-{
-JaktInternal::ArrayIterator<NonnullRefPtr<parser::ParsedType>> _magic = ((((call).type_args)).iterator());
-for (;;){
-JaktInternal::Optional<NonnullRefPtr<parser::ParsedType>> _magic_value = ((_magic).next());
-if ((!(((_magic_value).has_value())))){
-break;
-}
-NonnullRefPtr<parser::ParsedType> parsed_type = (_magic_value.value());
-{
-types::TypeId const checked_type = TRY((((*this).typecheck_typename(parsed_type,caller_scope_id,JaktInternal::OptionalNone()))));
-if ((((((((callee)->generics))->params)).size()) <= type_arg_index)){
-TRY((((*this).error(String("Trying to access generic parameter out of bounds"),((parsed_type)->span())))));
-continue;
-}
-types::TypeId const typevar_type_id = ((((((((callee)->generics))->params))[type_arg_index])).type_id());
-if ((!(((typevar_type_id).equals(checked_type))))){
-TRY((((((*this).generic_inferences)).set(TRY((((typevar_type_id).to_string()))),TRY((((checked_type).to_string())))))));
-}
-({auto& _jakt_ref = type_arg_index;_jakt_ref = JaktInternal::checked_add<size_t>(_jakt_ref, static_cast<size_t>(1ULL));});
-}
-
-}
-}
-
-size_t arg_offset = static_cast<size_t>(0ULL);
-if (((this_expr).has_value())){
-types::TypeId const type_id = (((this_expr.value()))->type());
-(maybe_this_type_id = type_id);
-NonnullRefPtr<types::Type> const param_type = ((*this).get_type(type_id));
-if (((param_type)->index() == 19 /* GenericInstance */)){
-types::StructId const id = (param_type->get<types::Type::GenericInstance>()).id;
-JaktInternal::Array<types::TypeId> const args = (param_type->get<types::Type::GenericInstance>()).args;
-types::CheckedStruct const structure = ((*this).get_struct(id));
-{
-JaktInternal::Range<size_t> _magic = (JaktInternal::Range<size_t>{static_cast<size_t>(static_cast<size_t>(0ULL)),static_cast<size_t>(((((structure).generic_parameters)).size()))});
-for (;;){
-JaktInternal::Optional<size_t> _magic_value = ((_magic).next());
-if ((!(((_magic_value).has_value())))){
-break;
-}
-size_t i = (_magic_value.value());
-{
-if (((((((((structure).generic_parameters))[i])).type_id)).equals(((args)[i])))){
-continue;
-}
-TRY((((((*this).generic_inferences)).set(TRY((((((((((structure).generic_parameters))[i])).type_id)).to_string()))),TRY((((((args)[i])).to_string())))))));
-}
-
-}
-}
-
-}
-if (((callee)->is_static())){
-TRY((((*this).error(String("Cannot call static method on an instance of an object"),span))));
-}
-else {
-(arg_offset = static_cast<size_t>(1ULL));
-}
-
-if ((((callee)->is_mutating()) && (!((((this_expr.value()))->is_mutable(((*this).program))))))){
-TRY((((*this).error(String("Cannot call mutating method on an immutable object instance"),span))));
-}
-}
-else if ((!(((callee)->is_static())))){
-TRY((((*this).error_with_hint(String("Cannot call an instance method statically"),span,String("Add a dot before the method name to call an instance method"),span))));
-}
-JaktInternal::Array<JaktInternal::Tuple<String,utility::Span,NonnullRefPtr<types::CheckedExpression>>> resolved_args = TRY((((*this).resolve_default_params(((((callee)->generics))->base_params),((call).args),caller_scope_id,safety_mode,arg_offset,span))));
-if ((((((((callee)->generics))->base_params)).size()) == (JaktInternal::checked_add<size_t>(((resolved_args).size()),arg_offset)))){
-{
-JaktInternal::Range<size_t> _magic = (JaktInternal::Range<size_t>{static_cast<size_t>(static_cast<size_t>(0ULL)),static_cast<size_t>((JaktInternal::checked_sub<size_t>(((((((callee)->generics))->base_params)).size()),arg_offset)))});
-for (;;){
-JaktInternal::Optional<size_t> _magic_value = ((_magic).next());
-if ((!(((_magic_value).has_value())))){
-break;
-}
-size_t i = (_magic_value.value());
-{
-JaktInternal::Tuple<String,utility::Span,NonnullRefPtr<types::CheckedExpression>> const name_span_checked_arg_ = ((resolved_args)[i]);
-String const name = ((name_span_checked_arg_).get<0>());
-utility::Span const span = ((name_span_checked_arg_).get<1>());
-NonnullRefPtr<types::CheckedExpression> const checked_arg = ((name_span_checked_arg_).get<2>());
-
-TRY((((*this).check_types_for_compat(((((((((((callee)->generics))->base_params))[(JaktInternal::checked_add<size_t>(i,arg_offset))])).variable)).type_id),((checked_arg)->type()),((((*this).generic_inferences))),((checked_arg)->span())))));
-TRY((((args).push((Tuple{((call).name), checked_arg})))));
-}
-
-}
-}
-
-}
 if ((((type_hint).has_value()) && (!(((((type_hint).value())).equals(types::unknown_type_id())))))){
 bool const old_ignore_errors = ((*this).ignore_errors);
 (((*this).ignore_errors) = true);
@@ -1135,7 +1131,7 @@ TRY((((*this).error(String("Not all generic parameters have known types"),span))
 }
 
 if (((!(((callee)->is_instantiated))) || ((!(((((callee)->linkage)).index() == 1 /* External */))) && (!(((((callee)->generics))->is_specialized_for_types(generic_arguments))))))){
-(generic_checked_function_to_instantiate = static_cast<JaktInternal::Optional<types::FunctionId>>(function_id));
+(generic_checked_function_to_instantiate = static_cast<JaktInternal::Optional<types::FunctionId>>((resolved_function_id.value())));
 }
 else if (((callee)->is_instantiated)){
 if ((((type_hint).has_value()) && (!(((((type_hint).value())).equals(types::unknown_type_id())))))){
@@ -1172,7 +1168,7 @@ JaktInternal::Array<types::Value> call_args = (TRY((Array<types::Value>::create_
 JaktInternal::Optional<types::Value> this_argument = JaktInternal::OptionalNone();
 NonnullRefPtr<interpreter::InterpreterScope> eval_scope = TRY((interpreter::InterpreterScope::InterpreterScope::from_runtime_scope(caller_scope_id,((*this).program),JaktInternal::OptionalNone())));
 {
-JaktInternal::DictionaryIterator<String,String> _magic = ((((*this).generic_inferences)).iterator());
+JaktInternal::DictionaryIterator<String,String> _magic = ((((((*this).generic_inferences)).iterator())).iterator());
 for (;;){
 JaktInternal::Optional<JaktInternal::Tuple<String,String>> _magic_value = ((_magic).next());
 if ((!(((_magic_value).has_value())))){
@@ -1191,7 +1187,7 @@ TRY((((((eval_scope)->type_bindings)).set(key,TRY((types::TypeId::TypeId::from_s
 }
 
 if (((this_expr).has_value())){
-auto __jakt_var_300 = [&]() -> ErrorOr<void> {{
+auto __jakt_var_305 = [&]() -> ErrorOr<void> {{
 interpreter::StatementResult const evaluated_this = TRY((((interpreter)->execute_expression((this_expr.value()),eval_scope))));
 if (((evaluated_this).index() == 5 /* JustValue */)){
 types::Value const value = (evaluated_this.get<interpreter::StatementResult::JustValue>()).value;
@@ -1208,7 +1204,7 @@ TRY((((*this).error(String("Invalid this expression"),(((this_expr.value()))->sp
 }
 
 ;return {};}();
-if (__jakt_var_300.is_error()) {{
+if (__jakt_var_305.is_error()) {{
 TRY((((*this).error(String("Error executing this expression"),(((this_expr.value()))->span())))));
 }
 };
@@ -1222,15 +1218,15 @@ break;
 }
 JaktInternal::Tuple<String,NonnullRefPtr<types::CheckedExpression>> argument = (_magic_value.value());
 {
-interpreter::StatementResult const value = ({ Optional<interpreter::StatementResult> __jakt_var_301;
-auto __jakt_var_302 = [&]() -> ErrorOr<interpreter::StatementResult> { return TRY((((interpreter)->execute_expression(((argument).get<1>()),eval_scope)))); }();
-if (__jakt_var_302.is_error()) {{
+interpreter::StatementResult const value = ({ Optional<interpreter::StatementResult> __jakt_var_306;
+auto __jakt_var_307 = [&]() -> ErrorOr<interpreter::StatementResult> { return TRY((((interpreter)->execute_expression(((argument).get<1>()),eval_scope)))); }();
+if (__jakt_var_307.is_error()) {{
 TRY((((*this).error(String("Error in argument"),span))));
 continue;
 }
-} else {__jakt_var_301 = __jakt_var_302.release_value();
+} else {__jakt_var_306 = __jakt_var_307.release_value();
 }
-__jakt_var_301.release_value(); });
+__jakt_var_306.release_value(); });
 if (((value).index() == 1 /* Throw */)){
 TRY((((*this).error(TRY((String::formatted(String("Compiletime call failed: {}"),value))),((((argument).get<1>()))->span())))));
 break;
@@ -1281,12 +1277,12 @@ TRY((((type_bindings).set(TRY((((((param).type_id())).to_string()))),((((functio
 
 JaktInternal::Optional<interpreter::ExecutionResult> result = JaktInternal::OptionalNone();
 NonnullRefPtr<interpreter::InterpreterScope> invocation_scope = TRY((interpreter::InterpreterScope::InterpreterScope::create((TRY((Dictionary<String, types::Value>::create_with_entries({})))),JaktInternal::OptionalNone(),type_bindings)));
-auto __jakt_var_303 = [&]() -> ErrorOr<void> {{
+auto __jakt_var_308 = [&]() -> ErrorOr<void> {{
 (result = TRY((((interpreter)->execute((resolved_function_id.value()),resolved_namespaces,this_argument,call_args,span,invocation_scope)))));
 }
 
 ;return {};}();
-if (__jakt_var_303.is_error()) {auto error = __jakt_var_303.release_error();{
+if (__jakt_var_308.is_error()) {auto error = __jakt_var_308.release_error();{
 TRY((((*this).error(TRY((String::formatted(String("Compiletime call failed: {}"),error))),span))));
 return (checked_call);
 }
@@ -1302,12 +1298,12 @@ return JaktInternal::ExplicitValue(TRY((interpreter::value_to_checked_expression
 case 1: {
 auto&& __jakt_match_value = __jakt_match_variant.template get<typename interpreter::ExecutionResult::Throw>();
 types::Value const& x = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(({ Optional<NonnullRefPtr<types::CheckedExpression>> __jakt_var_304; {
+return JaktInternal::ExplicitValue(({ Optional<NonnullRefPtr<types::CheckedExpression>> __jakt_var_309; {
 TRY((((*this).error(TRY((String::formatted(String("Compiletime call failed: {}"),x))),span))));
-__jakt_var_304 = checked_call; goto __jakt_label_290;
+__jakt_var_309 = checked_call; goto __jakt_label_295;
 
 }
-__jakt_label_290:; __jakt_var_304.release_value(); }));
+__jakt_label_295:; __jakt_var_309.release_value(); }));
 };/*case end*/
 default: VERIFY_NOT_REACHED();}/*switch end*/
 }()
@@ -1403,23 +1399,10 @@ return (TRY((types::CheckedStatement::template create<typename types::CheckedSta
 ErrorOr<bool> typechecker::Typechecker::add_comptime_binding_to_scope(types::ScopeId const scope_id,String const name,types::Value const value,utility::Span const span) {
 {
 NonnullRefPtr<types::Scope> scope = TRY((((*this).get_scope(scope_id))));
-{
-JaktInternal::DictionaryIterator<String,types::Value> _magic = ((((scope)->comptime_bindings)).iterator());
-for (;;){
-JaktInternal::Optional<JaktInternal::Tuple<String,types::Value>> _magic_value = ((_magic).next());
-if ((!(((_magic_value).has_value())))){
-break;
+JaktInternal::Optional<types::Value> const existing_binding = ((((scope)->comptime_bindings)).get(name));
+if (((existing_binding).has_value())){
+TRY((((*this).error_with_hint(TRY((String::formatted(String("Redefinition of comptime variable ‘{}’"),name))),span,String("previous definition here"),(((existing_binding.value())).span)))));
 }
-JaktInternal::Tuple<String,types::Value> existing = (_magic_value.value());
-{
-if ((name == ((existing).get<0>()))){
-TRY((((*this).error_with_hint(TRY((String::formatted(String("Redefinition of comptime variable ‘{}’"),name))),span,String("previous definition here"),((((existing).get<1>())).span)))));
-}
-}
-
-}
-}
-
 TRY((((((scope)->comptime_bindings)).set(name,value))));
 return (true);
 }
@@ -1457,19 +1440,19 @@ JaktInternal::Array<types::TypeId> const& args = __jakt_match_value.args;
 return JaktInternal::ExplicitValue(TRY((((((typechecker))).implements_trait(mapped_b,id,args)))));
 };/*case end*/
 default: {
-return JaktInternal::ExplicitValue(({ Optional<bool> __jakt_var_305; {
+return JaktInternal::ExplicitValue(({ Optional<bool> __jakt_var_310; {
 bool const old_ignore_errors = ((((typechecker))).ignore_errors);
 (((((typechecker))).ignore_errors) = true);
-ScopeGuard __jakt_var_306([&] {
+ScopeGuard __jakt_var_311([&] {
 {
 (((((typechecker))).ignore_errors) = old_ignore_errors);
 }
 
 });
-__jakt_var_305 = TRY((((((typechecker))).check_types_for_compat(mapped_a,mapped_b,((((((typechecker))).generic_inferences))),utility::Span(utility::FileId(static_cast<size_t>(0ULL)),static_cast<size_t>(0ULL),static_cast<size_t>(0ULL)))))); goto __jakt_label_291;
+__jakt_var_310 = TRY((((((typechecker))).check_types_for_compat(mapped_a,mapped_b,((((((typechecker))).generic_inferences))),utility::Span(utility::FileId(static_cast<size_t>(0ULL)),static_cast<size_t>(0ULL),static_cast<size_t>(0ULL)))))); goto __jakt_label_296;
 
 }
-__jakt_label_291:; __jakt_var_305.release_value(); }));
+__jakt_label_296:; __jakt_var_310.release_value(); }));
 };/*case end*/
 }/*switch end*/
 }()
@@ -1945,28 +1928,28 @@ auto&& __jakt_match_variant = *parsed_type;
 switch(__jakt_match_variant.index()) {
 case 8: {
 auto&& __jakt_match_value = __jakt_match_variant.template get<parser::ParsedType::Reference>();NonnullRefPtr<parser::ParsedType> const& inner = __jakt_match_value.inner;
-return JaktInternal::ExplicitValue(({ Optional<types::TypeId> __jakt_var_307; {
+return JaktInternal::ExplicitValue(({ Optional<types::TypeId> __jakt_var_312; {
 types::TypeId const inner_type_id = TRY((((*this).typecheck_typename(inner,scope_id,name))));
-__jakt_var_307 = TRY((((*this).find_or_add_type_id(TRY((types::Type::template create<typename types::Type::Reference>(inner_type_id))))))); goto __jakt_label_292;
+__jakt_var_312 = TRY((((*this).find_or_add_type_id(TRY((types::Type::template create<typename types::Type::Reference>(inner_type_id))))))); goto __jakt_label_297;
 
 }
-__jakt_label_292:; __jakt_var_307.release_value(); }));
+__jakt_label_297:; __jakt_var_312.release_value(); }));
 };/*case end*/
 case 9: {
 auto&& __jakt_match_value = __jakt_match_variant.template get<parser::ParsedType::MutableReference>();NonnullRefPtr<parser::ParsedType> const& inner = __jakt_match_value.inner;
-return JaktInternal::ExplicitValue(({ Optional<types::TypeId> __jakt_var_308; {
+return JaktInternal::ExplicitValue(({ Optional<types::TypeId> __jakt_var_313; {
 types::TypeId const inner_type_id = TRY((((*this).typecheck_typename(inner,scope_id,name))));
-__jakt_var_308 = TRY((((*this).find_or_add_type_id(TRY((types::Type::template create<typename types::Type::MutableReference>(inner_type_id))))))); goto __jakt_label_293;
+__jakt_var_313 = TRY((((*this).find_or_add_type_id(TRY((types::Type::template create<typename types::Type::MutableReference>(inner_type_id))))))); goto __jakt_label_298;
 
 }
-__jakt_label_293:; __jakt_var_308.release_value(); }));
+__jakt_label_298:; __jakt_var_313.release_value(); }));
 };/*case end*/
 case 1: {
 auto&& __jakt_match_value = __jakt_match_variant.template get<parser::ParsedType::NamespacedName>();String const& name = __jakt_match_value.name;
 JaktInternal::Array<String> const& namespaces = __jakt_match_value.namespaces;
 JaktInternal::Array<NonnullRefPtr<parser::ParsedType>> const& params = __jakt_match_value.params;
 utility::Span const& span = __jakt_match_value.span;
-return JaktInternal::ExplicitValue(({ Optional<types::TypeId> __jakt_var_309; {
+return JaktInternal::ExplicitValue(({ Optional<types::TypeId> __jakt_var_314; {
 types::ScopeId current_namespace_scope_id = scope_id;
 {
 JaktInternal::ArrayIterator<String> _magic = ((namespaces).iterator());
@@ -2017,22 +2000,22 @@ else {
 (type_id = TRY((((*this).typecheck_generic_resolved_type(name,generic_args,current_namespace_scope_id,span)))));
 }
 
-__jakt_var_309 = (type_id.value()); goto __jakt_label_294;
+__jakt_var_314 = (type_id.value()); goto __jakt_label_299;
 
 }
-__jakt_label_294:; __jakt_var_309.release_value(); }));
+__jakt_label_299:; __jakt_var_314.release_value(); }));
 };/*case end*/
 case 0: {
 auto&& __jakt_match_value = __jakt_match_variant.template get<parser::ParsedType::Name>();String const& name = __jakt_match_value.name;
 utility::Span const& span = __jakt_match_value.span;
-return JaktInternal::ExplicitValue(({ Optional<types::TypeId> __jakt_var_310; {
+return JaktInternal::ExplicitValue(({ Optional<types::TypeId> __jakt_var_315; {
 JaktInternal::Optional<JaktInternal::Tuple<types::TypeId,types::ScopeId>> const maybe_type_and_scope = TRY((((*this).find_type_scope(scope_id,name))));
 if (((maybe_type_and_scope).has_value())){
 if ((!((((((maybe_type_and_scope.value())).get<1>())).equals(((*this).prelude_scope_id())))))){
 return ((((maybe_type_and_scope.value())).get<0>()));
 }
 }
-__jakt_var_310 = JAKT_RESOLVE_EXPLICIT_VALUE_OR_CONTROL_FLOW_RETURN_ONLY(([&]() -> JaktInternal::ExplicitValueOrControlFlow<types::TypeId,ErrorOr<types::TypeId>>{
+__jakt_var_315 = JAKT_RESOLVE_EXPLICIT_VALUE_OR_CONTROL_FLOW_RETURN_ONLY(([&]() -> JaktInternal::ExplicitValueOrControlFlow<types::TypeId,ErrorOr<types::TypeId>>{
 auto __jakt_enum_value = (name);
 if (__jakt_enum_value == String("i8")) {
 return JaktInternal::ExplicitValue(types::builtin( types::BuiltinType { typename types::BuiltinType::I8() } ));
@@ -2086,34 +2069,34 @@ else if (__jakt_enum_value == String("never")) {
 return JaktInternal::ExplicitValue(types::builtin( types::BuiltinType { typename types::BuiltinType::Never() } ));
 }
 else {
-return JaktInternal::ExplicitValue(({ Optional<types::TypeId> __jakt_var_311; {
+return JaktInternal::ExplicitValue(({ Optional<types::TypeId> __jakt_var_316; {
 if (((maybe_type_and_scope).has_value())){
 return ((((maybe_type_and_scope.value())).get<0>()));
 }
 TRY((((*this).error(TRY((String::formatted(String("Unknown type ‘{}’"),name))),span))));
-__jakt_var_311 = types::unknown_type_id(); goto __jakt_label_296;
+__jakt_var_316 = types::unknown_type_id(); goto __jakt_label_301;
 
 }
-__jakt_label_296:; __jakt_var_311.release_value(); }));
+__jakt_label_301:; __jakt_var_316.release_value(); }));
 }
 }()))
-; goto __jakt_label_295;
+; goto __jakt_label_300;
 
 }
-__jakt_label_295:; __jakt_var_310.release_value(); }));
+__jakt_label_300:; __jakt_var_315.release_value(); }));
 };/*case end*/
 case 13: {
 auto&& __jakt_match_value = __jakt_match_variant.template get<typename parser::ParsedType::Empty>();
-return JaktInternal::ExplicitValue(({ Optional<types::TypeId> __jakt_var_312; {
-__jakt_var_312 = types::unknown_type_id(); goto __jakt_label_297;
+return JaktInternal::ExplicitValue(({ Optional<types::TypeId> __jakt_var_317; {
+__jakt_var_317 = types::unknown_type_id(); goto __jakt_label_302;
 
 }
-__jakt_label_297:; __jakt_var_312.release_value(); }));
+__jakt_label_302:; __jakt_var_317.release_value(); }));
 };/*case end*/
 case 5: {
 auto&& __jakt_match_value = __jakt_match_variant.template get<parser::ParsedType::JaktTuple>();JaktInternal::Array<NonnullRefPtr<parser::ParsedType>> const& types = __jakt_match_value.types;
 utility::Span const& span = __jakt_match_value.span;
-return JaktInternal::ExplicitValue(({ Optional<types::TypeId> __jakt_var_313; {
+return JaktInternal::ExplicitValue(({ Optional<types::TypeId> __jakt_var_318; {
 JaktInternal::Array<types::TypeId> checked_types = (TRY((Array<types::TypeId>::create_with({}))));
 {
 JaktInternal::ArrayIterator<NonnullRefPtr<parser::ParsedType>> _magic = ((types).iterator());
@@ -2131,83 +2114,83 @@ TRY((((checked_types).push(TRY((((*this).typecheck_typename(parsed_type,scope_id
 }
 
 types::StructId const tuple_struct_id = TRY((((*this).find_struct_in_prelude(String("Tuple")))));
-__jakt_var_313 = TRY((((*this).find_or_add_type_id(TRY((types::Type::template create<typename types::Type::GenericInstance>(tuple_struct_id,checked_types))))))); goto __jakt_label_298;
+__jakt_var_318 = TRY((((*this).find_or_add_type_id(TRY((types::Type::template create<typename types::Type::GenericInstance>(tuple_struct_id,checked_types))))))); goto __jakt_label_303;
 
 }
-__jakt_label_298:; __jakt_var_313.release_value(); }));
+__jakt_label_303:; __jakt_var_318.release_value(); }));
 };/*case end*/
 case 3: {
 auto&& __jakt_match_value = __jakt_match_variant.template get<parser::ParsedType::JaktArray>();NonnullRefPtr<parser::ParsedType> const& inner = __jakt_match_value.inner;
 utility::Span const& span = __jakt_match_value.span;
-return JaktInternal::ExplicitValue(({ Optional<types::TypeId> __jakt_var_314; {
+return JaktInternal::ExplicitValue(({ Optional<types::TypeId> __jakt_var_319; {
 types::TypeId const inner_type_id = TRY((((*this).typecheck_typename(inner,scope_id,name))));
 types::StructId const array_struct_id = TRY((((*this).find_struct_in_prelude(String("Array")))));
-__jakt_var_314 = TRY((((*this).find_or_add_type_id(TRY((types::Type::template create<typename types::Type::GenericInstance>(array_struct_id,(TRY((Array<types::TypeId>::create_with({inner_type_id}))))))))))); goto __jakt_label_299;
+__jakt_var_319 = TRY((((*this).find_or_add_type_id(TRY((types::Type::template create<typename types::Type::GenericInstance>(array_struct_id,(TRY((Array<types::TypeId>::create_with({inner_type_id}))))))))))); goto __jakt_label_304;
 
 }
-__jakt_label_299:; __jakt_var_314.release_value(); }));
+__jakt_label_304:; __jakt_var_319.release_value(); }));
 };/*case end*/
 case 4: {
 auto&& __jakt_match_value = __jakt_match_variant.template get<parser::ParsedType::Dictionary>();NonnullRefPtr<parser::ParsedType> const& key = __jakt_match_value.key;
 NonnullRefPtr<parser::ParsedType> const& value = __jakt_match_value.value;
 utility::Span const& span = __jakt_match_value.span;
-return JaktInternal::ExplicitValue(({ Optional<types::TypeId> __jakt_var_315; {
+return JaktInternal::ExplicitValue(({ Optional<types::TypeId> __jakt_var_320; {
 types::TypeId const key_type_id = TRY((((*this).typecheck_typename(key,scope_id,name))));
 types::TypeId const value_type_id = TRY((((*this).typecheck_typename(value,scope_id,name))));
 types::StructId const dict_struct_id = TRY((((*this).find_struct_in_prelude(String("Dictionary")))));
-__jakt_var_315 = TRY((((*this).find_or_add_type_id(TRY((types::Type::template create<typename types::Type::GenericInstance>(dict_struct_id,(TRY((Array<types::TypeId>::create_with({key_type_id, value_type_id}))))))))))); goto __jakt_label_300;
+__jakt_var_320 = TRY((((*this).find_or_add_type_id(TRY((types::Type::template create<typename types::Type::GenericInstance>(dict_struct_id,(TRY((Array<types::TypeId>::create_with({key_type_id, value_type_id}))))))))))); goto __jakt_label_305;
 
 }
-__jakt_label_300:; __jakt_var_315.release_value(); }));
+__jakt_label_305:; __jakt_var_320.release_value(); }));
 };/*case end*/
 case 6: {
 auto&& __jakt_match_value = __jakt_match_variant.template get<parser::ParsedType::Set>();NonnullRefPtr<parser::ParsedType> const& inner = __jakt_match_value.inner;
 utility::Span const& span = __jakt_match_value.span;
-return JaktInternal::ExplicitValue(({ Optional<types::TypeId> __jakt_var_316; {
+return JaktInternal::ExplicitValue(({ Optional<types::TypeId> __jakt_var_321; {
 types::TypeId const inner_type_id = TRY((((*this).typecheck_typename(inner,scope_id,name))));
 types::StructId const set_struct_id = TRY((((*this).find_struct_in_prelude(String("Set")))));
-__jakt_var_316 = TRY((((*this).find_or_add_type_id(TRY((types::Type::template create<typename types::Type::GenericInstance>(set_struct_id,(TRY((Array<types::TypeId>::create_with({inner_type_id}))))))))))); goto __jakt_label_301;
+__jakt_var_321 = TRY((((*this).find_or_add_type_id(TRY((types::Type::template create<typename types::Type::GenericInstance>(set_struct_id,(TRY((Array<types::TypeId>::create_with({inner_type_id}))))))))))); goto __jakt_label_306;
 
 }
-__jakt_label_301:; __jakt_var_316.release_value(); }));
+__jakt_label_306:; __jakt_var_321.release_value(); }));
 };/*case end*/
 case 7: {
 auto&& __jakt_match_value = __jakt_match_variant.template get<parser::ParsedType::Optional>();NonnullRefPtr<parser::ParsedType> const& inner = __jakt_match_value.inner;
 utility::Span const& span = __jakt_match_value.span;
-return JaktInternal::ExplicitValue(({ Optional<types::TypeId> __jakt_var_317; {
+return JaktInternal::ExplicitValue(({ Optional<types::TypeId> __jakt_var_322; {
 types::TypeId const inner_type_id = TRY((((*this).typecheck_typename(inner,scope_id,name))));
 types::StructId const optional_struct_id = TRY((((*this).find_struct_in_prelude(String("Optional")))));
-__jakt_var_317 = TRY((((*this).find_or_add_type_id(TRY((types::Type::template create<typename types::Type::GenericInstance>(optional_struct_id,(TRY((Array<types::TypeId>::create_with({inner_type_id}))))))))))); goto __jakt_label_302;
+__jakt_var_322 = TRY((((*this).find_or_add_type_id(TRY((types::Type::template create<typename types::Type::GenericInstance>(optional_struct_id,(TRY((Array<types::TypeId>::create_with({inner_type_id}))))))))))); goto __jakt_label_307;
 
 }
-__jakt_label_302:; __jakt_var_317.release_value(); }));
+__jakt_label_307:; __jakt_var_322.release_value(); }));
 };/*case end*/
 case 11: {
 auto&& __jakt_match_value = __jakt_match_variant.template get<parser::ParsedType::WeakPtr>();NonnullRefPtr<parser::ParsedType> const& inner = __jakt_match_value.inner;
 utility::Span const& span = __jakt_match_value.span;
-return JaktInternal::ExplicitValue(({ Optional<types::TypeId> __jakt_var_318; {
+return JaktInternal::ExplicitValue(({ Optional<types::TypeId> __jakt_var_323; {
 types::TypeId const inner_type_id = TRY((((*this).typecheck_typename(inner,scope_id,name))));
 types::StructId const weakptr_struct_id = TRY((((*this).find_struct_in_prelude(String("WeakPtr")))));
-__jakt_var_318 = TRY((((*this).find_or_add_type_id(TRY((types::Type::template create<typename types::Type::GenericInstance>(weakptr_struct_id,(TRY((Array<types::TypeId>::create_with({inner_type_id}))))))))))); goto __jakt_label_303;
+__jakt_var_323 = TRY((((*this).find_or_add_type_id(TRY((types::Type::template create<typename types::Type::GenericInstance>(weakptr_struct_id,(TRY((Array<types::TypeId>::create_with({inner_type_id}))))))))))); goto __jakt_label_308;
 
 }
-__jakt_label_303:; __jakt_var_318.release_value(); }));
+__jakt_label_308:; __jakt_var_323.release_value(); }));
 };/*case end*/
 case 10: {
 auto&& __jakt_match_value = __jakt_match_variant.template get<parser::ParsedType::RawPtr>();NonnullRefPtr<parser::ParsedType> const& inner = __jakt_match_value.inner;
 utility::Span const& span = __jakt_match_value.span;
-return JaktInternal::ExplicitValue(({ Optional<types::TypeId> __jakt_var_319; {
+return JaktInternal::ExplicitValue(({ Optional<types::TypeId> __jakt_var_324; {
 types::TypeId const inner_type_id = TRY((((*this).typecheck_typename(inner,scope_id,name))));
-__jakt_var_319 = TRY((((*this).find_or_add_type_id(TRY((types::Type::template create<typename types::Type::RawPtr>(inner_type_id))))))); goto __jakt_label_304;
+__jakt_var_324 = TRY((((*this).find_or_add_type_id(TRY((types::Type::template create<typename types::Type::RawPtr>(inner_type_id))))))); goto __jakt_label_309;
 
 }
-__jakt_label_304:; __jakt_var_319.release_value(); }));
+__jakt_label_309:; __jakt_var_324.release_value(); }));
 };/*case end*/
 case 2: {
 auto&& __jakt_match_value = __jakt_match_variant.template get<parser::ParsedType::GenericType>();String const& name = __jakt_match_value.name;
 JaktInternal::Array<NonnullRefPtr<parser::ParsedType>> const& generic_parameters = __jakt_match_value.generic_parameters;
 utility::Span const& span = __jakt_match_value.span;
-return JaktInternal::ExplicitValue(({ Optional<types::TypeId> __jakt_var_320; {
+return JaktInternal::ExplicitValue(({ Optional<types::TypeId> __jakt_var_325; {
 JaktInternal::Array<types::TypeId> checked_inner_types = (TRY((Array<types::TypeId>::create_with({}))));
 {
 JaktInternal::ArrayIterator<NonnullRefPtr<parser::ParsedType>> _magic = ((generic_parameters).iterator());
@@ -2225,34 +2208,34 @@ TRY((((checked_inner_types).push(inner_type_id))));
 }
 }
 
-__jakt_var_320 = TRY((((*this).typecheck_generic_resolved_type(name,checked_inner_types,scope_id,span)))); goto __jakt_label_305;
+__jakt_var_325 = TRY((((*this).typecheck_generic_resolved_type(name,checked_inner_types,scope_id,span)))); goto __jakt_label_310;
 
 }
-__jakt_label_305:; __jakt_var_320.release_value(); }));
+__jakt_label_310:; __jakt_var_325.release_value(); }));
 };/*case end*/
 case 12: {
 auto&& __jakt_match_value = __jakt_match_variant.template get<parser::ParsedType::Function>();JaktInternal::Array<parser::ParsedParameter> const& params = __jakt_match_value.params;
 bool const& can_throw = __jakt_match_value.can_throw;
 NonnullRefPtr<parser::ParsedType> const& return_type = __jakt_match_value.return_type;
 utility::Span const& span = __jakt_match_value.span;
-return JaktInternal::ExplicitValue(({ Optional<types::TypeId> __jakt_var_321; {
+return JaktInternal::ExplicitValue(({ Optional<types::TypeId> __jakt_var_326; {
 String const function_name = JAKT_RESOLVE_EXPLICIT_VALUE_OR_CONTROL_FLOW_RETURN_ONLY(([&]() -> JaktInternal::ExplicitValueOrControlFlow<String,ErrorOr<types::TypeId>>{
 auto __jakt_enum_value = (((name).has_value()));
 if (__jakt_enum_value == true) {
 return JaktInternal::ExplicitValue((name.value()));
 }
 else {
-return JaktInternal::ExplicitValue(({ Optional<String> __jakt_var_322;
-auto __jakt_var_323 = [&]() -> ErrorOr<String> { return TRY((String::formatted(String("lambda{}"),((((*this).lambda_count)++))))); }();
-if (!__jakt_var_323.is_error()) __jakt_var_322 = __jakt_var_323.release_value();
-__jakt_var_322; }).value_or_lazy_evaluated([&] { return String(""); }));
+return JaktInternal::ExplicitValue(({ Optional<String> __jakt_var_327;
+auto __jakt_var_328 = [&]() -> ErrorOr<String> { return TRY((String::formatted(String("lambda{}"),((((*this).lambda_count)++))))); }();
+if (!__jakt_var_328.is_error()) __jakt_var_327 = __jakt_var_328.release_value();
+__jakt_var_327; }).value_or_lazy_evaluated([&] { return String(""); }));
 }
 }()))
 ;
 JaktInternal::Array<types::CheckedParameter> checked_params = (TRY((Array<types::CheckedParameter>::create_with({}))));
 bool first = true;
 JaktInternal::Dictionary<String,String> const old_generic_inferences = TRY((((((*this).generic_inferences)).perform_checkpoint(false))));
-ScopeGuard __jakt_var_324([&] {
+ScopeGuard __jakt_var_329([&] {
 {
 ((((*this).generic_inferences)).restore(old_generic_inferences));
 }
@@ -2293,10 +2276,10 @@ TRY((((param_type_ids).push(((((param).variable)).type_id)))));
 }
 }
 
-__jakt_var_321 = TRY((((*this).find_or_add_type_id(TRY((types::Type::template create<typename types::Type::Function>(param_type_ids,can_throw,((checked_function)->return_type_id),function_id))))))); goto __jakt_label_306;
+__jakt_var_326 = TRY((((*this).find_or_add_type_id(TRY((types::Type::template create<typename types::Type::Function>(param_type_ids,can_throw,((checked_function)->return_type_id),function_id))))))); goto __jakt_label_311;
 
 }
-__jakt_label_306:; __jakt_var_321.release_value(); }));
+__jakt_label_311:; __jakt_var_326.release_value(); }));
 };/*case end*/
 default: VERIFY_NOT_REACHED();}/*switch end*/
 }()
@@ -2459,7 +2442,12 @@ TRY((((checked_function)->add_param(types::CheckedParameter(((param).requires_la
 else {
 types::TypeId const param_type = TRY((((*this).typecheck_typename(((((param).variable)).parsed_type),method_scope_id,((((param).variable)).name)))));
 types::CheckedVariable const checked_variable = types::CheckedVariable(((((param).variable)).name),param_type,((((param).variable)).is_mutable),((((param).variable)).span),((((((param).variable)).parsed_type))->span()), types::CheckedVisibility { typename types::CheckedVisibility::Public() } );
-TRY((((checked_function)->add_param(types::CheckedParameter(((param).requires_label),checked_variable,JaktInternal::OptionalNone())))));
+JaktInternal::Optional<NonnullRefPtr<types::CheckedExpression>> default_value = JaktInternal::OptionalNone();
+if (((((param).default_argument)).has_value())){
+types::TypeId const param_type = TRY((((*this).typecheck_typename(((((param).variable)).parsed_type),method_scope_id,((((param).variable)).name)))));
+(default_value = TRY((((*this).typecheck_expression((((param).default_argument).value()),scope_id, types::SafetyMode { typename types::SafetyMode::Safe() } ,param_type)))));
+}
+TRY((((checked_function)->add_param(types::CheckedParameter(((param).requires_label),checked_variable,default_value)))));
 }
 
 }
@@ -2467,7 +2455,7 @@ TRY((((checked_function)->add_param(types::CheckedParameter(((param).requires_la
 }
 }
 
-TRY((((*this).add_function_to_scope(enum_scope_id,((func).name),function_id,((parsed_record).name_span)))));
+TRY((((*this).add_function_to_scope(enum_scope_id,((func).name),(TRY((Array<types::FunctionId>::create_with({function_id})))),((parsed_record).name_span)))));
 types::TypeId const function_return_type_id = TRY((((*this).typecheck_typename(((func).return_type),method_scope_id,JaktInternal::OptionalNone()))));
 (((checked_function)->return_type_id) = function_return_type_id);
 }
@@ -2477,6 +2465,12 @@ types::TypeId const function_return_type_id = TRY((((*this).typecheck_typename((
 
 }
 return {};
+}
+
+ErrorOr<types::ScopeId> typechecker::Typechecker::create_scope(JaktInternal::Optional<types::ScopeId> const parent_scope_id,bool const can_throw,String const debug_name) {
+{
+return (TRY((((((*this).program))->create_scope(parent_scope_id,can_throw,debug_name,((*this).current_module_id))))));
+}
 }
 
 ErrorOr<JaktInternal::Optional<types::CheckedEnumVariant>> typechecker::Typechecker::get_enum_variant(types::CheckedEnum const enum_,String const variant_name) {
@@ -2505,12 +2499,6 @@ return (JaktInternal::OptionalNone());
 types::ScopeId typechecker::Typechecker::root_scope_id() const {
 {
 return (types::ScopeId(types::ModuleId(static_cast<size_t>(1ULL)),static_cast<size_t>(0ULL)));
-}
-}
-
-ErrorOr<JaktInternal::Optional<types::FunctionId>> typechecker::Typechecker::find_function_in_scope(types::ScopeId const parent_scope_id,String const function_name) const {
-{
-return (TRY((((((*this).program))->find_function_in_scope(parent_scope_id,function_name)))));
 }
 }
 
@@ -2549,21 +2537,104 @@ TRY((((*this).typecheck_function(parsed_function,((checked_trait)->scope_id)))))
 return {};
 }
 
-ErrorOr<NonnullRefPtr<types::CheckedStatement>> typechecker::Typechecker::typecheck_defer(NonnullRefPtr<parser::ParsedStatement> const statement,types::ScopeId const scope_id,types::SafetyMode const safety_mode,utility::Span const span) {
+ErrorOr<NonnullRefPtr<types::CheckedStatement>> typechecker::Typechecker::typecheck_var_decl(parser::ParsedVarDecl const var,NonnullRefPtr<parser::ParsedExpression> const init,types::ScopeId const scope_id,types::SafetyMode const safety_mode,utility::Span const span) {
 {
-bool const was_inside_defer = ((*this).inside_defer);
-(((*this).inside_defer) = true);
-ScopeGuard __jakt_var_325([&] {
-(((*this).inside_defer) = was_inside_defer);
-});
-NonnullRefPtr<types::CheckedStatement> const checked_statement = TRY((((*this).typecheck_statement(statement,scope_id,safety_mode,JaktInternal::OptionalNone()))));
-if (((checked_statement)->index() == 5 /* Block */)){
-types::CheckedBlock const block = (checked_statement->get<types::CheckedStatement::Block>()).block;
-if (((((block).yielded_type)).has_value())){
-TRY((((*this).error(String("‘yield’ inside ‘defer’ is meaningless"),span))));
+types::TypeId lhs_type_id = TRY((((*this).typecheck_typename(((var).parsed_type),scope_id,((var).name)))));
+NonnullRefPtr<types::CheckedExpression> checked_expr = TRY((((*this).typecheck_expression(init,scope_id,safety_mode,lhs_type_id))));
+types::TypeId const rhs_type_id = ((checked_expr)->type());
+if (((rhs_type_id).equals(types::void_type_id()))){
+TRY((((*this).error(String("Cannot assign `void` to a variable"),((checked_expr)->span())))));
+}
+if ((((lhs_type_id).equals(types::unknown_type_id())) && (!(((rhs_type_id).equals(types::unknown_type_id())))))){
+(lhs_type_id = rhs_type_id);
+}
+types::StructId const weak_ptr_struct_id = TRY((((*this).find_struct_in_prelude(String("WeakPtr")))));
+types::StructId const optional_struct_id = TRY((((*this).find_struct_in_prelude(String("Optional")))));
+NonnullRefPtr<types::Type> const lhs_type = ((*this).get_type(lhs_type_id));
+TRY((((*this).check_that_type_doesnt_contain_reference(lhs_type_id,span))));
+if (((checked_expr)->index() == 23 /* OptionalNone */)){
+utility::Span const span = (checked_expr->get<types::CheckedExpression::OptionalNone>()).span;
+types::TypeId const type_id = (checked_expr->get<types::CheckedExpression::OptionalNone>()).type_id;
+if (((lhs_type)->index() == 19 /* GenericInstance */)){
+types::StructId const id = (lhs_type->get<types::Type::GenericInstance>()).id;
+JaktInternal::Array<types::TypeId> const args = (lhs_type->get<types::Type::GenericInstance>()).args;
+if ((!((((id).equals(optional_struct_id)) || ((id).equals(weak_ptr_struct_id)))))){
+TRY((((*this).error(String("Cannot assign None to a non-optional type"),span))));
 }
 }
-return (TRY((types::CheckedStatement::template create<typename types::CheckedStatement::Defer>(checked_statement,span))));
+else {
+TRY((((*this).error(String("Cannot assign None to a non-optional type"),span))));
+}
+
+}
+if (((lhs_type)->index() == 19 /* GenericInstance */)){
+types::StructId const id = (lhs_type->get<types::Type::GenericInstance>()).id;
+JaktInternal::Array<types::TypeId> const args = (lhs_type->get<types::Type::GenericInstance>()).args;
+if (((id).equals(weak_ptr_struct_id))){
+if ((!(((var).is_mutable)))){
+TRY((((*this).error(String("Weak reference must be mutable"),((var).span)))));
+}
+if (((!(((lhs_type_id).equals(rhs_type_id)))) && ((!(((((args)[static_cast<i64>(0LL)])).equals(rhs_type_id)))) && (!(((rhs_type_id).equals(types::unknown_type_id()))))))){
+TRY((((*this).error(TRY((String::formatted(String("Type mismatch: expected ‘{}’, but got ‘{}’"),TRY((((*this).type_name(lhs_type_id)))),TRY((((*this).type_name(rhs_type_id))))))),((checked_expr)->span())))));
+}
+}
+else if (((id).equals(optional_struct_id))){
+if (((!(((lhs_type_id).equals(rhs_type_id)))) && ((!(((((args)[static_cast<i64>(0LL)])).equals(rhs_type_id)))) && (!(((rhs_type_id).equals(types::unknown_type_id()))))))){
+TRY((((*this).error(TRY((String::formatted(String("Type mismatch: expected ‘{}’, but got ‘{}’"),TRY((((*this).type_name(lhs_type_id)))),TRY((((*this).type_name(rhs_type_id))))))),((checked_expr)->span())))));
+}
+}
+else {
+if (((!(((lhs_type_id).equals(rhs_type_id)))) && (!(((rhs_type_id).equals(types::unknown_type_id())))))){
+TRY((((*this).error(TRY((String::formatted(String("Type mismatch: expected ‘{}’, but got ‘{}’"),TRY((((*this).type_name(lhs_type_id)))),TRY((((*this).type_name(rhs_type_id))))))),((checked_expr)->span())))));
+}
+}
+
+}
+else if (((lhs_type)->is_builtin())){
+JaktInternal::Optional<types::NumberConstant> const number_constant = ((checked_expr)->to_number_constant(((*this).program)));
+bool is_rhs_zero = false;
+if (((number_constant).has_value())){
+(is_rhs_zero = JAKT_RESOLVE_EXPLICIT_VALUE_OR_CONTROL_FLOW_RETURN_ONLY(([&]() -> JaktInternal::ExplicitValueOrControlFlow<bool, ErrorOr<NonnullRefPtr<types::CheckedStatement>>>{
+auto&& __jakt_match_variant = (number_constant.value());
+switch(__jakt_match_variant.index()) {
+case 0: {
+auto&& __jakt_match_value = __jakt_match_variant.template get<typename types::NumberConstant::Signed>();
+i64 const& value = __jakt_match_value.value;
+return JaktInternal::ExplicitValue((value == static_cast<i64>(0LL)));
+};/*case end*/
+case 1: {
+auto&& __jakt_match_value = __jakt_match_variant.template get<typename types::NumberConstant::Unsigned>();
+u64 const& value = __jakt_match_value.value;
+return JaktInternal::ExplicitValue((value == static_cast<u64>(0ULL)));
+};/*case end*/
+case 2: {
+auto&& __jakt_match_value = __jakt_match_variant.template get<typename types::NumberConstant::Floating>();
+f64 const& value = __jakt_match_value.value;
+return JaktInternal::ExplicitValue((value == static_cast<f64>(0)));
+};/*case end*/
+default: VERIFY_NOT_REACHED();}/*switch end*/
+}()
+)));
+}
+if (((!((((*this).is_numeric(lhs_type_id)) && is_rhs_zero))) && (((*this).is_integer(lhs_type_id)) ^ ((*this).is_integer(rhs_type_id))))){
+TRY((((*this).error(TRY((String::formatted(String("Type mismatch: expected ‘{}’, but got ‘{}’"),TRY((((*this).type_name(lhs_type_id)))),TRY((((*this).type_name(rhs_type_id))))))),((checked_expr)->span())))));
+return (TRY((types::CheckedStatement::template create<typename types::CheckedStatement::Garbage>(span))));
+}
+}
+else {
+if (((!(((lhs_type_id).equals(rhs_type_id)))) && (!(((rhs_type_id).equals(types::unknown_type_id())))))){
+TRY((((*this).error(TRY((String::formatted(String("Type mismatch: expected ‘{}’, but got ‘{}’"),TRY((((*this).type_name(lhs_type_id)))),TRY((((*this).type_name(rhs_type_id))))))),((checked_expr)->span())))));
+}
+}
+
+types::CheckedVariable const checked_var = types::CheckedVariable(((var).name),lhs_type_id,((var).is_mutable),((var).span),JaktInternal::OptionalNone(), types::CheckedVisibility { typename types::CheckedVisibility::Public() } );
+if ((((*this).dump_type_hints) && ((((var).inlay_span)).has_value()))){
+TRY((((*this).dump_type_hint(lhs_type_id,(((var).inlay_span).value())))));
+}
+NonnullRefPtr<types::Module> module = ((*this).current_module());
+types::VarId const var_id = TRY((((module)->add_variable(checked_var))));
+TRY((((*this).add_var_to_scope(scope_id,((var).name),var_id,((checked_var).definition_span)))));
+return (TRY((types::CheckedStatement::template create<typename types::CheckedStatement::VarDecl>(var_id,checked_expr,span))));
 }
 }
 
@@ -2858,9 +2929,7 @@ break;
 }
 parser::ParsedFunction fun = (_magic_value.value());
 {
-(((*this).current_function_id) = TRY((((*this).find_function_in_scope(scope_id,((fun).name))))));
 TRY((((*this).typecheck_function(fun,scope_id))));
-(((*this).current_function_id) = JaktInternal::OptionalNone());
 }
 
 }
@@ -3018,7 +3087,7 @@ switch(__jakt_match_variant.index()) {
 case 23: {
 auto&& __jakt_match_value = __jakt_match_variant.template get<typename types::Type::Struct>();
 types::StructId const& struct_id = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(({ Optional<JaktInternal::Array<JaktInternal::Array<types::TypeId>>> __jakt_var_326; {
+return JaktInternal::ExplicitValue(({ Optional<JaktInternal::Array<JaktInternal::Array<types::TypeId>>> __jakt_var_330; {
 types::CheckedStruct const struct_ = ((*this).get_struct(struct_id));
 JaktInternal::Array<JaktInternal::Array<types::TypeId>> implementations = (TRY((Array<JaktInternal::Array<types::TypeId>>::create_with({}))));
 {
@@ -3042,14 +3111,14 @@ TRY((((implementations).push(((trait_descriptor).get<1>())))));
 }
 }
 
-__jakt_var_326 = implementations; goto __jakt_label_307;
+__jakt_var_330 = implementations; goto __jakt_label_312;
 
 }
-__jakt_label_307:; __jakt_var_326.release_value(); }));
+__jakt_label_312:; __jakt_var_330.release_value(); }));
 };/*case end*/
 case 19: {
 auto&& __jakt_match_value = __jakt_match_variant.template get<types::Type::GenericInstance>();types::StructId const& struct_id = __jakt_match_value.id;
-return JaktInternal::ExplicitValue(({ Optional<JaktInternal::Array<JaktInternal::Array<types::TypeId>>> __jakt_var_327; {
+return JaktInternal::ExplicitValue(({ Optional<JaktInternal::Array<JaktInternal::Array<types::TypeId>>> __jakt_var_331; {
 types::CheckedStruct const struct_ = ((*this).get_struct(struct_id));
 JaktInternal::Array<JaktInternal::Array<types::TypeId>> implementations = (TRY((Array<JaktInternal::Array<types::TypeId>>::create_with({}))));
 {
@@ -3073,15 +3142,15 @@ TRY((((implementations).push(((trait_descriptor).get<1>())))));
 }
 }
 
-__jakt_var_327 = implementations; goto __jakt_label_308;
+__jakt_var_331 = implementations; goto __jakt_label_313;
 
 }
-__jakt_label_308:; __jakt_var_327.release_value(); }));
+__jakt_label_313:; __jakt_var_331.release_value(); }));
 };/*case end*/
 case 24: {
 auto&& __jakt_match_value = __jakt_match_variant.template get<typename types::Type::Enum>();
 types::EnumId const& enum_id = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(({ Optional<JaktInternal::Array<JaktInternal::Array<types::TypeId>>> __jakt_var_328; {
+return JaktInternal::ExplicitValue(({ Optional<JaktInternal::Array<JaktInternal::Array<types::TypeId>>> __jakt_var_332; {
 types::CheckedEnum const enum_ = ((*this).get_enum(enum_id));
 JaktInternal::Array<JaktInternal::Array<types::TypeId>> implementations = (TRY((Array<JaktInternal::Array<types::TypeId>>::create_with({}))));
 {
@@ -3105,14 +3174,14 @@ TRY((((implementations).push(((trait_descriptor).get<1>())))));
 }
 }
 
-__jakt_var_328 = implementations; goto __jakt_label_309;
+__jakt_var_332 = implementations; goto __jakt_label_314;
 
 }
-__jakt_label_309:; __jakt_var_328.release_value(); }));
+__jakt_label_314:; __jakt_var_332.release_value(); }));
 };/*case end*/
 case 20: {
 auto&& __jakt_match_value = __jakt_match_variant.template get<types::Type::GenericEnumInstance>();types::EnumId const& enum_id = __jakt_match_value.id;
-return JaktInternal::ExplicitValue(({ Optional<JaktInternal::Array<JaktInternal::Array<types::TypeId>>> __jakt_var_329; {
+return JaktInternal::ExplicitValue(({ Optional<JaktInternal::Array<JaktInternal::Array<types::TypeId>>> __jakt_var_333; {
 types::CheckedEnum const enum_ = ((*this).get_enum(enum_id));
 JaktInternal::Array<JaktInternal::Array<types::TypeId>> implementations = (TRY((Array<JaktInternal::Array<types::TypeId>>::create_with({}))));
 {
@@ -3136,34 +3205,34 @@ TRY((((implementations).push(((trait_descriptor).get<1>())))));
 }
 }
 
-__jakt_var_329 = implementations; goto __jakt_label_310;
+__jakt_var_333 = implementations; goto __jakt_label_315;
 
 }
-__jakt_label_310:; __jakt_var_329.release_value(); }));
+__jakt_label_315:; __jakt_var_333.release_value(); }));
 };/*case end*/
 case 26: {
 auto&& __jakt_match_value = __jakt_match_variant.template get<typename types::Type::Trait>();
 types::TraitId const& id = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(({ Optional<JaktInternal::Array<JaktInternal::Array<types::TypeId>>> __jakt_var_330; {
+return JaktInternal::ExplicitValue(({ Optional<JaktInternal::Array<JaktInternal::Array<types::TypeId>>> __jakt_var_334; {
 if (((id).equals(trait_id))){
 return ((TRY((Array<JaktInternal::Array<types::TypeId>>::create_with({(TRY((Array<types::TypeId>::create_with({}))))})))));
 }
-__jakt_var_330 = (TRY((Array<JaktInternal::Array<types::TypeId>>::create_with({})))); goto __jakt_label_311;
+__jakt_var_334 = (TRY((Array<JaktInternal::Array<types::TypeId>>::create_with({})))); goto __jakt_label_316;
 
 }
-__jakt_label_311:; __jakt_var_330.release_value(); }));
+__jakt_label_316:; __jakt_var_334.release_value(); }));
 };/*case end*/
 case 21: {
 auto&& __jakt_match_value = __jakt_match_variant.template get<types::Type::GenericTraitInstance>();types::TraitId const& id = __jakt_match_value.id;
 JaktInternal::Array<types::TypeId> const& args = __jakt_match_value.args;
-return JaktInternal::ExplicitValue(({ Optional<JaktInternal::Array<JaktInternal::Array<types::TypeId>>> __jakt_var_331; {
+return JaktInternal::ExplicitValue(({ Optional<JaktInternal::Array<JaktInternal::Array<types::TypeId>>> __jakt_var_335; {
 if ((!(((id).equals(trait_id))))){
 return ((TRY((Array<JaktInternal::Array<types::TypeId>>::create_with({})))));
 }
-__jakt_var_331 = (TRY((Array<JaktInternal::Array<types::TypeId>>::create_with({args})))); goto __jakt_label_312;
+__jakt_var_335 = (TRY((Array<JaktInternal::Array<types::TypeId>>::create_with({args})))); goto __jakt_label_317;
 
 }
-__jakt_label_312:; __jakt_var_331.release_value(); }));
+__jakt_label_317:; __jakt_var_335.release_value(); }));
 };/*case end*/
 default: {
 return JaktInternal::ExplicitValue((TRY((Array<JaktInternal::Array<types::TypeId>>::create_with({})))));
@@ -3205,59 +3274,59 @@ return JaktInternal::ExplicitValue(static_cast<JaktInternal::Optional<JaktIntern
 };/*case end*/
 case 1: {
 auto&& __jakt_match_value = __jakt_match_variant.template get<parser::ImportName::Comptime>();NonnullRefPtr<parser::ParsedExpression> const& expression = __jakt_match_value.expression;
-return JaktInternal::ExplicitValue(({ Optional<JaktInternal::Optional<JaktInternal::Array<JaktInternal::Tuple<String,utility::Span>>>> __jakt_var_332; {
+return JaktInternal::ExplicitValue(({ Optional<JaktInternal::Optional<JaktInternal::Array<JaktInternal::Tuple<String,utility::Span>>>> __jakt_var_336; {
 NonnullRefPtr<interpreter::Interpreter> interpreter = TRY((interpreter::Interpreter::Interpreter::create(((*this).compiler),((*this).program),(TRY((Array<utility::Span>::create_with({})))))));
 NonnullRefPtr<interpreter::InterpreterScope> eval_scope = TRY((interpreter::InterpreterScope::InterpreterScope::from_runtime_scope(scope_id,((*this).program),JaktInternal::OptionalNone())));
 types::ScopeId const exec_scope = TRY((((*this).create_scope(scope_id,true,String("comptime-import")))));
 interpreter::StatementResult const result = TRY((((interpreter)->execute_expression(TRY((((*this).typecheck_expression(expression,exec_scope, types::SafetyMode { typename types::SafetyMode::Safe() } ,JaktInternal::OptionalNone())))),eval_scope))));
-__jakt_var_332 = JAKT_RESOLVE_EXPLICIT_VALUE_OR_CONTROL_FLOW_RETURN_ONLY(([&]() -> JaktInternal::ExplicitValueOrControlFlow<JaktInternal::Optional<JaktInternal::Array<JaktInternal::Tuple<String,utility::Span>>>, ErrorOr<void>>{
+__jakt_var_336 = JAKT_RESOLVE_EXPLICIT_VALUE_OR_CONTROL_FLOW_RETURN_ONLY(([&]() -> JaktInternal::ExplicitValueOrControlFlow<JaktInternal::Optional<JaktInternal::Array<JaktInternal::Tuple<String,utility::Span>>>, ErrorOr<void>>{
 auto&& __jakt_match_variant = result;
 switch(__jakt_match_variant.index()) {
 case 0: {
 auto&& __jakt_match_value = __jakt_match_variant.template get<typename interpreter::StatementResult::Return>();
-return JaktInternal::ExplicitValue(({ Optional<JaktInternal::Array<JaktInternal::Tuple<String,utility::Span>>> __jakt_var_333; {
+return JaktInternal::ExplicitValue(({ Optional<JaktInternal::Array<JaktInternal::Tuple<String,utility::Span>>> __jakt_var_337; {
 TRY((((*this).error_with_hint(String("module name must evalute to a string literal or an array of strings"),((expression)->span()),String("this expression evaluates to an invalid value"),((expression)->span())))));
-__jakt_var_333 = JaktInternal::OptionalNone(); goto __jakt_label_314;
+__jakt_var_337 = JaktInternal::OptionalNone(); goto __jakt_label_319;
 
 }
-__jakt_label_314:; __jakt_var_333; }));
+__jakt_label_319:; __jakt_var_337; }));
 };/*case end*/
 case 2: {
 auto&& __jakt_match_value = __jakt_match_variant.template get<typename interpreter::StatementResult::Yield>();
-return JaktInternal::ExplicitValue(({ Optional<JaktInternal::Array<JaktInternal::Tuple<String,utility::Span>>> __jakt_var_334; {
+return JaktInternal::ExplicitValue(({ Optional<JaktInternal::Array<JaktInternal::Tuple<String,utility::Span>>> __jakt_var_338; {
 TRY((((*this).error_with_hint(String("module name must evalute to a string literal or an array of strings"),((expression)->span()),String("this expression evaluates to an invalid value"),((expression)->span())))));
-__jakt_var_334 = JaktInternal::OptionalNone(); goto __jakt_label_315;
+__jakt_var_338 = JaktInternal::OptionalNone(); goto __jakt_label_320;
 
 }
-__jakt_label_315:; __jakt_var_334; }));
+__jakt_label_320:; __jakt_var_338; }));
 };/*case end*/
 case 3: {
 auto&& __jakt_match_value = __jakt_match_variant.template get<typename interpreter::StatementResult::Continue>();
-return JaktInternal::ExplicitValue(({ Optional<JaktInternal::Array<JaktInternal::Tuple<String,utility::Span>>> __jakt_var_335; {
+return JaktInternal::ExplicitValue(({ Optional<JaktInternal::Array<JaktInternal::Tuple<String,utility::Span>>> __jakt_var_339; {
 TRY((((*this).error_with_hint(String("module name must evalute to a string literal or an array of strings"),((expression)->span()),String("this expression evaluates to an invalid value"),((expression)->span())))));
-__jakt_var_335 = JaktInternal::OptionalNone(); goto __jakt_label_316;
+__jakt_var_339 = JaktInternal::OptionalNone(); goto __jakt_label_321;
 
 }
-__jakt_label_316:; __jakt_var_335; }));
+__jakt_label_321:; __jakt_var_339; }));
 };/*case end*/
 case 4: {
 auto&& __jakt_match_value = __jakt_match_variant.template get<typename interpreter::StatementResult::Break>();
-return JaktInternal::ExplicitValue(({ Optional<JaktInternal::Array<JaktInternal::Tuple<String,utility::Span>>> __jakt_var_336; {
+return JaktInternal::ExplicitValue(({ Optional<JaktInternal::Array<JaktInternal::Tuple<String,utility::Span>>> __jakt_var_340; {
 TRY((((*this).error_with_hint(String("module name must evalute to a string literal or an array of strings"),((expression)->span()),String("this expression evaluates to an invalid value"),((expression)->span())))));
-__jakt_var_336 = JaktInternal::OptionalNone(); goto __jakt_label_317;
+__jakt_var_340 = JaktInternal::OptionalNone(); goto __jakt_label_322;
 
 }
-__jakt_label_317:; __jakt_var_336; }));
+__jakt_label_322:; __jakt_var_340; }));
 };/*case end*/
 case 1: {
 auto&& __jakt_match_value = __jakt_match_variant.template get<typename interpreter::StatementResult::Throw>();
 types::Value const& error = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(({ Optional<JaktInternal::Array<JaktInternal::Tuple<String,utility::Span>>> __jakt_var_337; {
+return JaktInternal::ExplicitValue(({ Optional<JaktInternal::Array<JaktInternal::Tuple<String,utility::Span>>> __jakt_var_341; {
 TRY((((*this).error_with_hint(String("module name must evalute to a string literal or an array of strings"),((expression)->span()),TRY((String::formatted(String("this expression threw an error: {}"),error))),((expression)->span())))));
-__jakt_var_337 = JaktInternal::OptionalNone(); goto __jakt_label_318;
+__jakt_var_341 = JaktInternal::OptionalNone(); goto __jakt_label_323;
 
 }
-__jakt_label_318:; __jakt_var_337; }));
+__jakt_label_323:; __jakt_var_341; }));
 };/*case end*/
 case 5: {
 auto&& __jakt_match_value = __jakt_match_variant.template get<typename interpreter::StatementResult::JustValue>();
@@ -3272,7 +3341,7 @@ return JaktInternal::ExplicitValue(static_cast<JaktInternal::Optional<JaktIntern
 };/*case end*/
 case 19: {
 auto&& __jakt_match_value = __jakt_match_variant.template get<types::ValueImpl::JaktArray>();JaktInternal::Array<types::Value> const& values = __jakt_match_value.values;
-return JaktInternal::ExplicitValue(({ Optional<JaktInternal::Optional<JaktInternal::Array<JaktInternal::Tuple<String,utility::Span>>>> __jakt_var_338; {
+return JaktInternal::ExplicitValue(({ Optional<JaktInternal::Optional<JaktInternal::Array<JaktInternal::Tuple<String,utility::Span>>>> __jakt_var_342; {
 if (((values).is_empty())){
 TRY((((*this).error_with_hint(String("module name must evalute to a string literal or an array of strings"),((expression)->span()),String("this expression evaluates to an empty array"),((expression)->span())))));
 }
@@ -3308,18 +3377,18 @@ return JaktInternal::ExplicitValue<void>();
 }
 }
 
-__jakt_var_338 = static_cast<JaktInternal::Optional<JaktInternal::Array<JaktInternal::Tuple<String,utility::Span>>>>(result); goto __jakt_label_319;
+__jakt_var_342 = static_cast<JaktInternal::Optional<JaktInternal::Array<JaktInternal::Tuple<String,utility::Span>>>>(result); goto __jakt_label_324;
 
 }
-__jakt_label_319:; __jakt_var_338.release_value(); }));
+__jakt_label_324:; __jakt_var_342.release_value(); }));
 };/*case end*/
 default: {
-return JaktInternal::ExplicitValue(({ Optional<JaktInternal::Array<JaktInternal::Tuple<String,utility::Span>>> __jakt_var_339; {
+return JaktInternal::ExplicitValue(({ Optional<JaktInternal::Array<JaktInternal::Tuple<String,utility::Span>>> __jakt_var_343; {
 TRY((((*this).error_with_hint(String("module name must evalute to a string literal"),((expression)->span()),String("this expression evaluates to a non-string value"),((expression)->span())))));
-__jakt_var_339 = JaktInternal::OptionalNone(); goto __jakt_label_320;
+__jakt_var_343 = JaktInternal::OptionalNone(); goto __jakt_label_325;
 
 }
-__jakt_label_320:; __jakt_var_339; }));
+__jakt_label_325:; __jakt_var_343; }));
 };/*case end*/
 }/*switch end*/
 }()
@@ -3327,10 +3396,10 @@ __jakt_label_320:; __jakt_var_339; }));
 };/*case end*/
 default: VERIFY_NOT_REACHED();}/*switch end*/
 }()
-)); goto __jakt_label_313;
+)); goto __jakt_label_318;
 
 }
-__jakt_label_313:; __jakt_var_332.release_value(); }));
+__jakt_label_318:; __jakt_var_336.release_value(); }));
 };/*case end*/
 default: VERIFY_NOT_REACHED();}/*switch end*/
 }()
@@ -3489,19 +3558,19 @@ TRY((((*this).add_struct_to_scope(scope_id,name,struct_id,((((import_).module_na
 }
 
 {
-JaktInternal::DictionaryIterator<String,types::FunctionId> _magic = ((((import_scope)->functions)).iterator());
+JaktInternal::DictionaryIterator<String,JaktInternal::Array<types::FunctionId>> _magic = ((((import_scope)->functions)).iterator());
 for (;;){
-JaktInternal::Optional<JaktInternal::Tuple<String,types::FunctionId>> _magic_value = ((_magic).next());
+JaktInternal::Optional<JaktInternal::Tuple<String,JaktInternal::Array<types::FunctionId>>> _magic_value = ((_magic).next());
 if ((!(((_magic_value).has_value())))){
 break;
 }
-JaktInternal::Tuple<String,types::FunctionId> name__function_id__ = (_magic_value.value());
+JaktInternal::Tuple<String,JaktInternal::Array<types::FunctionId>> name__overload_set__ = (_magic_value.value());
 {
-JaktInternal::Tuple<String,types::FunctionId> const jakt__name__function_id__ = name__function_id__;
-String const name = ((jakt__name__function_id__).get<0>());
-types::FunctionId const function_id = ((jakt__name__function_id__).get<1>());
+JaktInternal::Tuple<String,JaktInternal::Array<types::FunctionId>> const jakt__name__overload_set__ = name__overload_set__;
+String const name = ((jakt__name__overload_set__).get<0>());
+JaktInternal::Array<types::FunctionId> const overload_set = ((jakt__name__overload_set__).get<1>());
 
-TRY((((*this).add_function_to_scope(scope_id,name,function_id,((((import_).module_name)).span())))));
+TRY((((*this).add_function_to_scope(scope_id,name,overload_set,((((import_).module_name)).span())))));
 }
 
 }
@@ -3578,10 +3647,10 @@ break;
 parser::ImportName imported_name = (_magic_value.value());
 {
 bool found = false;
-JaktInternal::Optional<types::FunctionId> const maybe_function_id = TRY((((*this).find_function_in_scope(import_scope_id,((imported_name).literal_name())))));
-if (((maybe_function_id).has_value())){
+JaktInternal::Optional<JaktInternal::Array<types::FunctionId>> const maybe_overload_set = TRY((((*this).find_functions_with_name_in_scope(import_scope_id,((imported_name).literal_name())))));
+if (((maybe_overload_set).has_value())){
 (found = true);
-TRY((((*this).add_function_to_scope(scope_id,((imported_name).literal_name()),(maybe_function_id.value()),((imported_name).span())))));
+TRY((((*this).add_function_to_scope(scope_id,((imported_name).literal_name()),(maybe_overload_set.value()),((imported_name).span())))));
 }
 JaktInternal::Optional<types::EnumId> const maybe_enum_id = TRY((((((*this).program))->find_enum_in_scope(import_scope_id,((imported_name).literal_name())))));
 if (((maybe_enum_id).has_value())){
@@ -3804,7 +3873,7 @@ case 21: {
 auto&& __jakt_match_value = __jakt_match_variant.template get<typename parser::BinaryOperator::Assign>();
 {
 if ((!(((checked_lhs)->is_mutable(((*this).program)))))){
-TRY((((*this).error(String("Assignment to immutable variable"),span))));
+TRY((((*this).error(String("Assignment to immutable variable"),((checked_lhs)->span())))));
 return (lhs_type_id);
 }
 if (((checked_rhs)->index() == 23 /* OptionalNone */)){
@@ -3866,7 +3935,7 @@ if ((!(((result).has_value())))){
 TRY((((*this).error(TRY((String::formatted(String("Assignment between incompatible types (‘{}’ and ‘{}’)"),TRY((((*this).type_name(lhs_type_id)))),TRY((((*this).type_name(rhs_type_id))))))),span))));
 }
 if ((!(((checked_lhs)->is_mutable(((*this).program)))))){
-TRY((((*this).error(String("Assignment to immutable variable"),span))));
+TRY((((*this).error(String("Assignment to immutable variable"),((checked_lhs)->span())))));
 }
 }
 return JaktInternal::ExplicitValue<void>();
@@ -3893,7 +3962,7 @@ if ((!(((result).has_value())))){
 TRY((((*this).error(TRY((String::formatted(String("Assignment between incompatible types (‘{}’ and ‘{}’)"),TRY((((*this).type_name(lhs_type_id)))),TRY((((*this).type_name(rhs_type_id))))))),span))));
 }
 if ((!(((checked_lhs)->is_mutable(((*this).program)))))){
-TRY((((*this).error(String("Assignment to immutable variable"),span))));
+TRY((((*this).error(String("Assignment to immutable variable"),((checked_lhs)->span())))));
 }
 }
 return JaktInternal::ExplicitValue<void>();
@@ -3920,7 +3989,7 @@ if ((!(((result).has_value())))){
 TRY((((*this).error(TRY((String::formatted(String("Assignment between incompatible types (‘{}’ and ‘{}’)"),TRY((((*this).type_name(lhs_type_id)))),TRY((((*this).type_name(rhs_type_id))))))),span))));
 }
 if ((!(((checked_lhs)->is_mutable(((*this).program)))))){
-TRY((((*this).error(String("Assignment to immutable variable"),span))));
+TRY((((*this).error(String("Assignment to immutable variable"),((checked_lhs)->span())))));
 }
 }
 return JaktInternal::ExplicitValue<void>();
@@ -3947,7 +4016,7 @@ if ((!(((result).has_value())))){
 TRY((((*this).error(TRY((String::formatted(String("Assignment between incompatible types (‘{}’ and ‘{}’)"),TRY((((*this).type_name(lhs_type_id)))),TRY((((*this).type_name(rhs_type_id))))))),span))));
 }
 if ((!(((checked_lhs)->is_mutable(((*this).program)))))){
-TRY((((*this).error(String("Assignment to immutable variable"),span))));
+TRY((((*this).error(String("Assignment to immutable variable"),((checked_lhs)->span())))));
 }
 }
 return JaktInternal::ExplicitValue<void>();
@@ -3974,7 +4043,7 @@ if ((!(((result).has_value())))){
 TRY((((*this).error(TRY((String::formatted(String("Assignment between incompatible types (‘{}’ and ‘{}’)"),TRY((((*this).type_name(lhs_type_id)))),TRY((((*this).type_name(rhs_type_id))))))),span))));
 }
 if ((!(((checked_lhs)->is_mutable(((*this).program)))))){
-TRY((((*this).error(String("Assignment to immutable variable"),span))));
+TRY((((*this).error(String("Assignment to immutable variable"),((checked_lhs)->span())))));
 }
 }
 return JaktInternal::ExplicitValue<void>();
@@ -4001,7 +4070,7 @@ if ((!(((result).has_value())))){
 TRY((((*this).error(TRY((String::formatted(String("Assignment between incompatible types (‘{}’ and ‘{}’)"),TRY((((*this).type_name(lhs_type_id)))),TRY((((*this).type_name(rhs_type_id))))))),span))));
 }
 if ((!(((checked_lhs)->is_mutable(((*this).program)))))){
-TRY((((*this).error(String("Assignment to immutable variable"),span))));
+TRY((((*this).error(String("Assignment to immutable variable"),((checked_lhs)->span())))));
 }
 }
 return JaktInternal::ExplicitValue<void>();
@@ -4028,7 +4097,7 @@ if ((!(((result).has_value())))){
 TRY((((*this).error(TRY((String::formatted(String("Assignment between incompatible types (‘{}’ and ‘{}’)"),TRY((((*this).type_name(lhs_type_id)))),TRY((((*this).type_name(rhs_type_id))))))),span))));
 }
 if ((!(((checked_lhs)->is_mutable(((*this).program)))))){
-TRY((((*this).error(String("Assignment to immutable variable"),span))));
+TRY((((*this).error(String("Assignment to immutable variable"),((checked_lhs)->span())))));
 }
 }
 return JaktInternal::ExplicitValue<void>();
@@ -4055,7 +4124,7 @@ if ((!(((result).has_value())))){
 TRY((((*this).error(TRY((String::formatted(String("Assignment between incompatible types (‘{}’ and ‘{}’)"),TRY((((*this).type_name(lhs_type_id)))),TRY((((*this).type_name(rhs_type_id))))))),span))));
 }
 if ((!(((checked_lhs)->is_mutable(((*this).program)))))){
-TRY((((*this).error(String("Assignment to immutable variable"),span))));
+TRY((((*this).error(String("Assignment to immutable variable"),((checked_lhs)->span())))));
 }
 }
 return JaktInternal::ExplicitValue<void>();
@@ -4082,7 +4151,7 @@ if ((!(((result).has_value())))){
 TRY((((*this).error(TRY((String::formatted(String("Assignment between incompatible types (‘{}’ and ‘{}’)"),TRY((((*this).type_name(lhs_type_id)))),TRY((((*this).type_name(rhs_type_id))))))),span))));
 }
 if ((!(((checked_lhs)->is_mutable(((*this).program)))))){
-TRY((((*this).error(String("Assignment to immutable variable"),span))));
+TRY((((*this).error(String("Assignment to immutable variable"),((checked_lhs)->span())))));
 }
 }
 return JaktInternal::ExplicitValue<void>();
@@ -4109,7 +4178,7 @@ if ((!(((result).has_value())))){
 TRY((((*this).error(TRY((String::formatted(String("Assignment between incompatible types (‘{}’ and ‘{}’)"),TRY((((*this).type_name(lhs_type_id)))),TRY((((*this).type_name(rhs_type_id))))))),span))));
 }
 if ((!(((checked_lhs)->is_mutable(((*this).program)))))){
-TRY((((*this).error(String("Assignment to immutable variable"),span))));
+TRY((((*this).error(String("Assignment to immutable variable"),((checked_lhs)->span())))));
 }
 }
 return JaktInternal::ExplicitValue<void>();
@@ -4184,6 +4253,67 @@ return (type_id);
 ErrorOr<JaktInternal::Optional<types::StructId>> typechecker::Typechecker::find_struct_in_scope(types::ScopeId const scope_id,String const name) const {
 {
 return (TRY((((((*this).program))->find_struct_in_scope(scope_id,name)))));
+}
+}
+
+ErrorOr<bool> typechecker::Typechecker::implements_trait(types::TypeId const type_id,types::TraitId const trait_id,JaktInternal::Optional<JaktInternal::Array<types::TypeId>> const generic_arguments) {
+{
+Function<ErrorOr<bool>(JaktInternal::Array<JaktInternal::Array<types::TypeId>>, types::TraitId, JaktInternal::Array<types::TypeId>, typechecker::Typechecker&)> const has_matching_trait = [](JaktInternal::Array<JaktInternal::Array<types::TypeId>> trait_implementations, types::TraitId trait_id, JaktInternal::Array<types::TypeId> passed_generic_arguments, typechecker::Typechecker& typechecker) -> ErrorOr<bool> {
+bool const old_ignore_errors = ((((typechecker))).ignore_errors);
+(((((typechecker))).ignore_errors) = true);
+ScopeGuard __jakt_var_344([&] {
+{
+(((((typechecker))).ignore_errors) = old_ignore_errors);
+}
+
+});
+bool found = false;
+{
+JaktInternal::ArrayIterator<JaktInternal::Array<types::TypeId>> _magic = ((trait_implementations).iterator());
+for (;;){
+JaktInternal::Optional<JaktInternal::Array<types::TypeId>> _magic_value = ((_magic).next());
+if ((!(((_magic_value).has_value())))){
+break;
+}
+JaktInternal::Array<types::TypeId> implemented_generic_arguments = (_magic_value.value());
+{
+if ((((implemented_generic_arguments).size()) != ((passed_generic_arguments).size()))){
+continue;
+}
+bool ok = false;
+{
+JaktInternal::Range<size_t> _magic = (JaktInternal::Range<size_t>{static_cast<size_t>(static_cast<size_t>(0ULL)),static_cast<size_t>(((implemented_generic_arguments).size()))});
+for (;;){
+JaktInternal::Optional<size_t> _magic_value = ((_magic).next());
+if ((!(((_magic_value).has_value())))){
+break;
+}
+size_t i = (_magic_value.value());
+{
+(ok = TRY((((((typechecker))).check_types_for_compat(((implemented_generic_arguments)[i]),((passed_generic_arguments)[i]),((((((typechecker))).generic_inferences))),utility::Span(utility::FileId(static_cast<size_t>(0ULL)),static_cast<size_t>(0ULL),static_cast<size_t>(0ULL)))))));
+if ((!(ok))){
+break;
+}
+}
+
+}
+}
+
+if ((!(ok))){
+continue;
+}
+(found = true);
+break;
+}
+
+}
+}
+
+return (found);
+}
+;
+JaktInternal::Array<types::TypeId> const empty = (TRY((Array<types::TypeId>::create_with({}))));
+return (TRY((has_matching_trait(TRY((((*this).find_all_implementations_of_trait(type_id,trait_id)))),trait_id,generic_arguments.value_or_lazy_evaluated([&] { return empty; }),((*this))))));
 }
 }
 
@@ -4349,12 +4479,12 @@ ErrorOr<void> typechecker::Typechecker::typecheck_function(parser::ParsedFunctio
 if (((!(((((parsed_function).generic_parameters)).is_empty()))) && (!(((parsed_function).must_instantiate))))){
 return {};
 }
-JaktInternal::Optional<types::FunctionId> const function_id = TRY((((*this).find_function_in_scope(parent_scope_id,((parsed_function).name)))));
-if ((!(((function_id).has_value())))){
-TRY((((((*this).compiler))->panic(String("Internal error: missing previously defined function")))));
-}
+JaktInternal::Optional<JaktInternal::Array<types::FunctionId>> const func_ids = TRY((((*this).find_functions_with_name_in_scope(parent_scope_id,((parsed_function).name)))));
+JaktInternal::Optional<types::FunctionId> const function_id = TRY((((*this).find_function_matching_signature_in_scope(parent_scope_id,parsed_function))));
+if (((function_id).has_value())){
+(((*this).current_function_id) = (function_id.value()));
 if ((((parsed_function).name) == String("main"))){
-TRY((((*this).typecheck_jakt_main(parsed_function))));
+TRY((((*this).typecheck_jakt_main(parsed_function,parent_scope_id))));
 }
 NonnullRefPtr<types::CheckedFunction> checked_function = ((*this).get_function((function_id.value())));
 types::ScopeId const function_scope_id = ((checked_function)->function_scope_id);
@@ -4414,6 +4544,12 @@ TRY((((*this).error(String("Control reaches end of non-void function"),((parsed_
 }
 (((checked_function)->block) = block);
 (((checked_function)->return_type_id) = return_type_id);
+(((*this).current_function_id) = JaktInternal::OptionalNone());
+}
+else {
+TRY((((((*this).compiler))->panic(TRY((String::formatted(String("Previously defined function {} not found in scope {}"),((parsed_function).name),parent_scope_id)))))));
+}
+
 }
 return {};
 }
@@ -4534,12 +4670,12 @@ if (__jakt_enum_value == true) {
 return JaktInternal::ExplicitValue(((((*this).get_function((((*this).current_function_id).value()))))->function_scope_id));
 }
 else {
-return JaktInternal::ExplicitValue(({ Optional<types::ScopeId> __jakt_var_340; {
+return JaktInternal::ExplicitValue(({ Optional<types::ScopeId> __jakt_var_345; {
 if ((!(((((*this).current_struct_type_id)).has_value())))){
 TRY((((*this).error(TRY((String::formatted(String("Can't access {0} ‘{1}’ from this global scope, because ‘{1}’ restricts access to it"),accessee_kind,name))),span))));
 return (false);
 }
-__jakt_var_340 = JAKT_RESOLVE_EXPLICIT_VALUE_OR_CONTROL_FLOW_RETURN_ONLY(([&]() -> JaktInternal::ExplicitValueOrControlFlow<types::ScopeId, ErrorOr<bool>>{
+__jakt_var_345 = JAKT_RESOLVE_EXPLICIT_VALUE_OR_CONTROL_FLOW_RETURN_ONLY(([&]() -> JaktInternal::ExplicitValueOrControlFlow<types::ScopeId, ErrorOr<bool>>{
 auto&& __jakt_match_variant = *((*this).get_type((((*this).current_struct_type_id).value())));
 switch(__jakt_match_variant.index()) {
 case 23: {
@@ -4554,10 +4690,10 @@ utility::panic(TRY((String::formatted(String("Internal error: current_struct_typ
 };/*case end*/
 }/*switch end*/
 }()
-)); goto __jakt_label_321;
+)); goto __jakt_label_326;
 
 }
-__jakt_label_321:; __jakt_var_340.release_value(); }));
+__jakt_label_326:; __jakt_var_345.release_value(); }));
 }
 }()))
 ;
@@ -4639,29 +4775,50 @@ return (reverse_chain);
 }
 }
 
-ErrorOr<bool> typechecker::Typechecker::add_function_to_scope(types::ScopeId const parent_scope_id,String const name,types::FunctionId const function_id,utility::Span const span) {
+ErrorOr<bool> typechecker::Typechecker::add_function_to_scope(types::ScopeId const parent_scope_id,String const name,JaktInternal::Array<types::FunctionId> const overload_set,utility::Span const span) {
 {
 NonnullRefPtr<types::Scope> scope = TRY((((*this).get_scope(parent_scope_id))));
+if (((((scope)->functions)).contains(name))){
+JaktInternal::Array<types::FunctionId> const existing_function_binding = ((((scope)->functions))[name]);
 {
-JaktInternal::DictionaryIterator<String,types::FunctionId> _magic = ((((scope)->functions)).iterator());
+JaktInternal::ArrayIterator<types::FunctionId> _magic = ((overload_set).iterator());
 for (;;){
-JaktInternal::Optional<JaktInternal::Tuple<String,types::FunctionId>> _magic_value = ((_magic).next());
+JaktInternal::Optional<types::FunctionId> _magic_value = ((_magic).next());
 if ((!(((_magic_value).has_value())))){
 break;
 }
-JaktInternal::Tuple<String,types::FunctionId> existing_function = (_magic_value.value());
+types::FunctionId function_id = (_magic_value.value());
 {
-if ((name == ((existing_function).get<0>()))){
-NonnullRefPtr<types::CheckedFunction> const function_ = ((*this).get_function(((existing_function).get<1>())));
-TRY((((*this).error_with_hint(TRY((String::formatted(String("Redefinition of function ‘{}’"),name))),span,String("previous definition here"),((function_)->name_span)))));
-return (false);
+NonnullRefPtr<types::CheckedFunction> const function_to_add = ((*this).get_function(function_id));
+{
+JaktInternal::ArrayIterator<types::FunctionId> _magic = ((existing_function_binding).iterator());
+for (;;){
+JaktInternal::Optional<types::FunctionId> _magic_value = ((_magic).next());
+if ((!(((_magic_value).has_value())))){
+break;
+}
+types::FunctionId existing_function_id = (_magic_value.value());
+{
+NonnullRefPtr<types::CheckedFunction> const existing_function = ((*this).get_function(existing_function_id));
+if (TRY((((function_to_add)->signature_matches(existing_function))))){
+TRY((((*this).error_with_hint(TRY((String::formatted(String("Redefinition of function ‘{}’."),((function_to_add)->name)))),(((((function_to_add)->parsed_function).value())).name_span),String("Previous definition is here"),(((((existing_function)->parsed_function).value())).name_span)))));
 }
 }
 
 }
 }
 
-TRY((((((scope)->functions)).set(name,function_id))));
+TRY((((((((scope)->functions))[name])).push(function_id))));
+}
+
+}
+}
+
+}
+else {
+TRY((((((scope)->functions)).set(name,overload_set))));
+}
+
 return (true);
 }
 }
@@ -4795,6 +4952,150 @@ TRY((((((structure).fields)).push(types::CheckedField(variable_id,default_value)
 return {};
 }
 
+ErrorOr<typechecker::FunctionMatchResult> typechecker::Typechecker::match_function_and_resolve_args(parser::ParsedCall const call,types::ScopeId const caller_scope_id,types::FunctionId const candidate,types::SafetyMode const safety_mode,utility::Span const span,JaktInternal::Optional<NonnullRefPtr<types::CheckedExpression>> const this_expr) {
+{
+JaktInternal::Array<NonnullRefPtr<types::CheckedExpression>> args = (TRY((Array<NonnullRefPtr<types::CheckedExpression>>::create_with({}))));
+JaktInternal::Optional<types::TypeId> maybe_this_type_id = JaktInternal::OptionalNone();
+JaktInternal::Array<error::JaktError> argument_errors = (TRY((Array<error::JaktError>::create_with({}))));
+size_t const num_old_compiler_errors = ((((((*this).compiler))->errors)).size());
+NonnullRefPtr<types::CheckedFunction> const callee_candidate = ((*this).get_function(candidate));
+types::ScopeId const scope_containing_callee = (((TRY((((*this).get_scope(((callee_candidate)->function_scope_id))))))->parent).value());
+JaktInternal::Dictionary<String,String> const generic_inference_checkpoint = TRY((((((*this).generic_inferences)).perform_checkpoint(false))));
+if (((callee_candidate)->is_instantiated)){
+TRY((((((*this).generic_inferences)).perform_checkpoint(true))));
+}
+ScopeGuard __jakt_var_346([&] {
+{
+((((*this).generic_inferences)).restore(generic_inference_checkpoint));
+}
+
+});
+if (((((callee_candidate)->type)).index() == 1 /* ImplicitConstructor */)){
+types::CheckedStruct const struct_ = ((*this).get_struct((((callee_candidate)->struct_id).value())));
+TRY((((*this).check_implicit_constructor_argument_access(caller_scope_id,call,struct_))));
+}
+else {
+TRY((((*this).check_method_access(caller_scope_id,scope_containing_callee,callee_candidate,span))));
+}
+
+size_t type_arg_index = static_cast<size_t>(0ULL);
+{
+JaktInternal::ArrayIterator<NonnullRefPtr<parser::ParsedType>> _magic = ((((call).type_args)).iterator());
+for (;;){
+JaktInternal::Optional<NonnullRefPtr<parser::ParsedType>> _magic_value = ((_magic).next());
+if ((!(((_magic_value).has_value())))){
+break;
+}
+NonnullRefPtr<parser::ParsedType> parsed_type = (_magic_value.value());
+{
+types::TypeId const checked_type = TRY((((*this).typecheck_typename(parsed_type,caller_scope_id,JaktInternal::OptionalNone()))));
+if ((((((((callee_candidate)->generics))->params)).size()) <= type_arg_index)){
+TRY((((*this).error(String("Trying to access generic parameter out of bounds"),((parsed_type)->span())))));
+continue;
+}
+types::TypeId const typevar_type_id = ((((((((callee_candidate)->generics))->params))[type_arg_index])).type_id());
+if ((!(((typevar_type_id).equals(checked_type))))){
+TRY((((((*this).generic_inferences)).set(TRY((((typevar_type_id).to_string()))),TRY((((checked_type).to_string())))))));
+}
+({auto& _jakt_ref = type_arg_index;_jakt_ref = JaktInternal::checked_add<size_t>(_jakt_ref, static_cast<size_t>(1ULL));});
+}
+
+}
+}
+
+size_t arg_offset = static_cast<size_t>(0ULL);
+if (((this_expr).has_value())){
+types::TypeId const type_id = (((this_expr.value()))->type());
+(maybe_this_type_id = type_id);
+NonnullRefPtr<types::Type> const param_type = ((*this).get_type(type_id));
+if (((param_type)->index() == 19 /* GenericInstance */)){
+types::StructId const id = (param_type->get<types::Type::GenericInstance>()).id;
+JaktInternal::Array<types::TypeId> const args = (param_type->get<types::Type::GenericInstance>()).args;
+types::CheckedStruct const structure = ((*this).get_struct(id));
+{
+JaktInternal::Range<size_t> _magic = (JaktInternal::Range<size_t>{static_cast<size_t>(static_cast<size_t>(0ULL)),static_cast<size_t>(((((structure).generic_parameters)).size()))});
+for (;;){
+JaktInternal::Optional<size_t> _magic_value = ((_magic).next());
+if ((!(((_magic_value).has_value())))){
+break;
+}
+size_t i = (_magic_value.value());
+{
+if (((((((((structure).generic_parameters))[i])).type_id)).equals(((args)[i])))){
+continue;
+}
+TRY((((((*this).generic_inferences)).set(TRY((((((((((structure).generic_parameters))[i])).type_id)).to_string()))),TRY((((((args)[i])).to_string())))))));
+}
+
+}
+}
+
+}
+if (((callee_candidate)->is_static())){
+TRY((((*this).error(String("Cannot call static method on an instance of an object"),span))));
+}
+else {
+(arg_offset = static_cast<size_t>(1ULL));
+}
+
+if ((((callee_candidate)->is_mutating()) && (!((((this_expr.value()))->is_mutable(((*this).program))))))){
+TRY((((*this).error(String("Cannot call mutating method on an immutable object instance"),span))));
+}
+}
+else if ((!(((callee_candidate)->is_static())))){
+TRY((((*this).error_with_hint(String("Cannot call an instance method statically"),span,String("Add a dot before the method name to call an instance method"),span))));
+}
+i64 total_function_specificity = static_cast<i64>(0LL);
+JaktInternal::Array<JaktInternal::Tuple<String,utility::Span,NonnullRefPtr<types::CheckedExpression>>> const resolved_args = TRY((((*this).resolve_default_params(((((callee_candidate)->generics))->base_params),((call).args),caller_scope_id,safety_mode,arg_offset,span))));
+if ((((((((callee_candidate)->generics))->base_params)).size()) == (JaktInternal::checked_add<size_t>(((resolved_args).size()),arg_offset)))){
+{
+JaktInternal::Range<size_t> _magic = (JaktInternal::Range<size_t>{static_cast<size_t>(static_cast<size_t>(0ULL)),static_cast<size_t>((JaktInternal::checked_sub<size_t>(((((((callee_candidate)->generics))->base_params)).size()),arg_offset)))});
+for (;;){
+JaktInternal::Optional<size_t> _magic_value = ((_magic).next());
+if ((!(((_magic_value).has_value())))){
+break;
+}
+size_t i = (_magic_value.value());
+{
+JaktInternal::Tuple<String,utility::Span,NonnullRefPtr<types::CheckedExpression>> const name_span_checked_arg_ = ((resolved_args)[i]);
+String const name = ((name_span_checked_arg_).get<0>());
+utility::Span const span = ((name_span_checked_arg_).get<1>());
+NonnullRefPtr<types::CheckedExpression> const checked_arg = ((name_span_checked_arg_).get<2>());
+
+NonnullRefPtr<types::Type> const type_to = ((*this).get_type(((((((((((callee_candidate)->generics))->base_params))[(JaktInternal::checked_add<size_t>(i,arg_offset))])).variable)).type_id)));
+({auto& _jakt_ref = total_function_specificity;_jakt_ref = JaktInternal::checked_add<i64>(_jakt_ref, ((type_to)->specificity(((*this).program),(static_cast<i64>(1LL) << static_cast<i64>(31LL)))));});
+TRY((((*this).check_types_for_compat(((((((((((callee_candidate)->generics))->base_params))[(JaktInternal::checked_add<size_t>(i,arg_offset))])).variable)).type_id),((checked_arg)->type()),((((*this).generic_inferences))),((checked_arg)->span())))));
+TRY((((args).push(checked_arg))));
+}
+
+}
+}
+
+}
+size_t const num_match_errors = (JaktInternal::checked_sub<size_t>(((((((*this).compiler))->errors)).size()),num_old_compiler_errors));
+if ((num_match_errors > static_cast<size_t>(0ULL))){
+{
+JaktInternal::Range<size_t> _magic = (JaktInternal::Range<size_t>{static_cast<size_t>(static_cast<size_t>(0ULL)),static_cast<size_t>(num_match_errors)});
+for (;;){
+JaktInternal::Optional<size_t> _magic_value = ((_magic).next());
+if ((!(((_magic_value).has_value())))){
+break;
+}
+size_t error_index = (_magic_value.value());
+{
+TRY((((argument_errors).push((((((((*this).compiler))->errors)).pop()).value())))));
+}
+
+}
+}
+
+return ( typechecker::FunctionMatchResult { typename typechecker::FunctionMatchResult::MatchError(argument_errors) } );
+}
+JaktInternal::Dictionary<String,String> const used_inferences = TRY((((((*this).generic_inferences)).perform_checkpoint(false))));
+return ( typechecker::FunctionMatchResult { typename typechecker::FunctionMatchResult::MatchSuccess(args,maybe_this_type_id,used_inferences,total_function_specificity) } );
+}
+}
+
 ErrorOr<NonnullRefPtr<types::CheckedExpression>> typechecker::Typechecker::typecheck_expression(NonnullRefPtr<parser::ParsedExpression> const expr,types::ScopeId const scope_id,types::SafetyMode const safety_mode,JaktInternal::Optional<types::TypeId> const type_hint) {
 {
 return (JAKT_RESOLVE_EXPLICIT_VALUE_OR_CONTROL_FLOW_RETURN_ONLY(([&]() -> JaktInternal::ExplicitValueOrControlFlow<NonnullRefPtr<types::CheckedExpression>, ErrorOr<NonnullRefPtr<types::CheckedExpression>>>{
@@ -4810,12 +5111,17 @@ return JaktInternal::ExplicitValue(TRY((((*this).typecheck_indexed_struct(expr,f
 case 0: {
 auto&& __jakt_match_value = __jakt_match_variant.template get<parser::ParsedExpression::Boolean>();bool const& val = __jakt_match_value.val;
 utility::Span const& span = __jakt_match_value.span;
-return JaktInternal::ExplicitValue(TRY((types::CheckedExpression::template create<typename types::CheckedExpression::Boolean>(val,span))));
+return JaktInternal::ExplicitValue(({ Optional<NonnullRefPtr<types::CheckedExpression>> __jakt_var_347; {
+TRY((((*this).unify_with_type(types::builtin( types::BuiltinType { typename types::BuiltinType::Bool() } ),type_hint,span))));
+__jakt_var_347 = TRY((types::CheckedExpression::template create<typename types::CheckedExpression::Boolean>(val,span))); goto __jakt_label_327;
+
+}
+__jakt_label_327:; __jakt_var_347.release_value(); }));
 };/*case end*/
 case 1: {
 auto&& __jakt_match_value = __jakt_match_variant.template get<parser::ParsedExpression::NumericConstant>();parser::NumericConstant const& val = __jakt_match_value.val;
 utility::Span const& span = __jakt_match_value.span;
-return JaktInternal::ExplicitValue(({ Optional<NonnullRefPtr<types::CheckedExpression>> __jakt_var_341; {
+return JaktInternal::ExplicitValue(({ Optional<NonnullRefPtr<types::CheckedExpression>> __jakt_var_348; {
 JaktInternal::Optional<types::TypeId> type_hint_unwrapped = type_hint;
 if ((((type_hint).has_value()) && ((((*this).get_type((type_hint.value()))))->index() == 19 /* GenericInstance */))){
 types::StructId const id = (((*this).get_type((type_hint.value())))->get<types::Type::GenericInstance>()).id;
@@ -4825,7 +5131,7 @@ if (((id).equals(optional_struct_id))){
 (type_hint_unwrapped = ((args)[static_cast<i64>(0LL)]));
 }
 }
-__jakt_var_341 = JAKT_RESOLVE_EXPLICIT_VALUE_OR_CONTROL_FLOW_RETURN_ONLY(([&]() -> JaktInternal::ExplicitValueOrControlFlow<NonnullRefPtr<types::CheckedExpression>, ErrorOr<NonnullRefPtr<types::CheckedExpression>>>{
+__jakt_var_348 = JAKT_RESOLVE_EXPLICIT_VALUE_OR_CONTROL_FLOW_RETURN_ONLY(([&]() -> JaktInternal::ExplicitValueOrControlFlow<NonnullRefPtr<types::CheckedExpression>, ErrorOr<NonnullRefPtr<types::CheckedExpression>>>{
 auto&& __jakt_match_variant = val;
 switch(__jakt_match_variant.index()) {
 case 0: {
@@ -4895,10 +5201,10 @@ return JaktInternal::ExplicitValue(TRY((((*this).infer_unsigned_int(val,span,typ
 };/*case end*/
 default: VERIFY_NOT_REACHED();}/*switch end*/
 }()
-)); goto __jakt_label_322;
+)); goto __jakt_label_328;
 
 }
-__jakt_label_322:; __jakt_var_341.release_value(); }));
+__jakt_label_328:; __jakt_var_348.release_value(); }));
 };/*case end*/
 case 3: {
 auto&& __jakt_match_value = __jakt_match_variant.template get<parser::ParsedExpression::SingleQuotedString>();String const& val = __jakt_match_value.val;
@@ -4913,31 +5219,31 @@ return JaktInternal::ExplicitValue(TRY((types::CheckedExpression::template creat
 case 2: {
 auto&& __jakt_match_value = __jakt_match_variant.template get<parser::ParsedExpression::QuotedString>();String const& val = __jakt_match_value.val;
 utility::Span const& span = __jakt_match_value.span;
-return JaktInternal::ExplicitValue(({ Optional<NonnullRefPtr<types::CheckedExpression>> __jakt_var_342; {
+return JaktInternal::ExplicitValue(({ Optional<NonnullRefPtr<types::CheckedExpression>> __jakt_var_349; {
 if (((*this).dump_try_hints)){
 TRY((((*this).dump_try_hint(span))));
 }
 TRY((((*this).unify_with_type(types::builtin( types::BuiltinType { typename types::BuiltinType::JaktString() } ),type_hint,span))));
-__jakt_var_342 = TRY((types::CheckedExpression::template create<typename types::CheckedExpression::QuotedString>(val,span))); goto __jakt_label_323;
+__jakt_var_349 = TRY((types::CheckedExpression::template create<typename types::CheckedExpression::QuotedString>(val,span))); goto __jakt_label_329;
 
 }
-__jakt_label_323:; __jakt_var_342.release_value(); }));
+__jakt_label_329:; __jakt_var_349.release_value(); }));
 };/*case end*/
 case 5: {
 auto&& __jakt_match_value = __jakt_match_variant.template get<parser::ParsedExpression::Call>();parser::ParsedCall const& call = __jakt_match_value.call;
 utility::Span const& span = __jakt_match_value.span;
-return JaktInternal::ExplicitValue(({ Optional<NonnullRefPtr<types::CheckedExpression>> __jakt_var_343; {
-__jakt_var_343 = TRY((((*this).typecheck_call(call,scope_id,span,JaktInternal::OptionalNone(),JaktInternal::OptionalNone(),safety_mode,type_hint,false)))); goto __jakt_label_324;
+return JaktInternal::ExplicitValue(({ Optional<NonnullRefPtr<types::CheckedExpression>> __jakt_var_350; {
+__jakt_var_350 = TRY((((*this).typecheck_call(call,scope_id,span,JaktInternal::OptionalNone(),JaktInternal::OptionalNone(),safety_mode,type_hint,false)))); goto __jakt_label_330;
 
 }
-__jakt_label_324:; __jakt_var_343.release_value(); }));
+__jakt_label_330:; __jakt_var_350.release_value(); }));
 };/*case end*/
 case 6: {
 auto&& __jakt_match_value = __jakt_match_variant.template get<parser::ParsedExpression::MethodCall>();NonnullRefPtr<parser::ParsedExpression> const& expr = __jakt_match_value.expr;
 parser::ParsedCall const& call = __jakt_match_value.call;
 utility::Span const& span = __jakt_match_value.span;
 bool const& is_optional = __jakt_match_value.is_optional;
-return JaktInternal::ExplicitValue(({ Optional<NonnullRefPtr<types::CheckedExpression>> __jakt_var_344; {
+return JaktInternal::ExplicitValue(({ Optional<NonnullRefPtr<types::CheckedExpression>> __jakt_var_351; {
 NonnullRefPtr<types::CheckedExpression> const checked_expr = TRY((((*this).typecheck_expression_and_dereference_if_needed(expr,scope_id,safety_mode,JaktInternal::OptionalNone(),span))));
 types::TypeId const checked_expr_type_id = ((checked_expr)->type());
 bool found_optional = false;
@@ -4961,11 +5267,11 @@ return JaktInternal::ExplicitValue(static_cast<JaktInternal::Optional<types::Str
 case 19: {
 auto&& __jakt_match_value = __jakt_match_variant.template get<types::Type::GenericInstance>();types::StructId const& id = __jakt_match_value.id;
 JaktInternal::Array<types::TypeId> const& args = __jakt_match_value.args;
-return JaktInternal::ExplicitValue(({ Optional<JaktInternal::Optional<types::StructOrEnumId>> __jakt_var_345; {
-__jakt_var_345 = JAKT_RESOLVE_EXPLICIT_VALUE_OR_CONTROL_FLOW_RETURN_ONLY(([&]() -> JaktInternal::ExplicitValueOrControlFlow<JaktInternal::Optional<types::StructOrEnumId>,ErrorOr<NonnullRefPtr<types::CheckedExpression>>>{
+return JaktInternal::ExplicitValue(({ Optional<JaktInternal::Optional<types::StructOrEnumId>> __jakt_var_352; {
+__jakt_var_352 = JAKT_RESOLVE_EXPLICIT_VALUE_OR_CONTROL_FLOW_RETURN_ONLY(([&]() -> JaktInternal::ExplicitValueOrControlFlow<JaktInternal::Optional<types::StructOrEnumId>,ErrorOr<NonnullRefPtr<types::CheckedExpression>>>{
 auto __jakt_enum_value = (is_optional);
 if (__jakt_enum_value == true) {
-return JaktInternal::ExplicitValue(({ Optional<JaktInternal::Optional<types::StructOrEnumId>> __jakt_var_346; {
+return JaktInternal::ExplicitValue(({ Optional<JaktInternal::Optional<types::StructOrEnumId>> __jakt_var_353; {
 types::StructId const optional_struct_id = TRY((((*this).find_struct_in_prelude(String("Optional")))));
 JaktInternal::Optional<types::StructOrEnumId> struct_id = JaktInternal::OptionalNone();
 if ((!(((id).equals(optional_struct_id))))){
@@ -4995,45 +5301,45 @@ auto&& __jakt_match_value = __jakt_match_variant.template get<types::Type::Gener
 return JaktInternal::ExplicitValue( types::StructOrEnumId { typename types::StructOrEnumId::Enum(id) } );
 };/*case end*/
 default: {
-return JaktInternal::ExplicitValue(({ Optional<types::StructOrEnumId> __jakt_var_347; {
+return JaktInternal::ExplicitValue(({ Optional<types::StructOrEnumId> __jakt_var_354; {
 TRY((((*this).error(String("Can't use non-struct type as an optional type in optional chained call"),span))));
 (found_optional = false);
-__jakt_var_347 =  types::StructOrEnumId { typename types::StructOrEnumId::Struct(optional_struct_id) } ; goto __jakt_label_328;
+__jakt_var_354 =  types::StructOrEnumId { typename types::StructOrEnumId::Struct(optional_struct_id) } ; goto __jakt_label_334;
 
 }
-__jakt_label_328:; __jakt_var_347.release_value(); }));
+__jakt_label_334:; __jakt_var_354.release_value(); }));
 };/*case end*/
 }/*switch end*/
 }()
 )));
 }
 
-__jakt_var_346 = static_cast<JaktInternal::Optional<types::StructOrEnumId>>(struct_id.value_or_lazy_evaluated([&] { return  types::StructOrEnumId { typename types::StructOrEnumId::Struct(optional_struct_id) } ; })); goto __jakt_label_327;
+__jakt_var_353 = static_cast<JaktInternal::Optional<types::StructOrEnumId>>(struct_id.value_or_lazy_evaluated([&] { return  types::StructOrEnumId { typename types::StructOrEnumId::Struct(optional_struct_id) } ; })); goto __jakt_label_333;
 
 }
-__jakt_label_327:; __jakt_var_346.release_value(); }));
+__jakt_label_333:; __jakt_var_353.release_value(); }));
 }
 else {
 return JaktInternal::ExplicitValue(static_cast<JaktInternal::Optional<types::StructOrEnumId>>( types::StructOrEnumId { typename types::StructOrEnumId::Struct(id) } ));
 }
 }()))
-; goto __jakt_label_326;
+; goto __jakt_label_332;
 
 }
-__jakt_label_326:; __jakt_var_345.release_value(); }));
+__jakt_label_332:; __jakt_var_352.release_value(); }));
 };/*case end*/
 case 20: {
 auto&& __jakt_match_value = __jakt_match_variant.template get<types::Type::GenericEnumInstance>();types::EnumId const& id = __jakt_match_value.id;
 return JaktInternal::ExplicitValue(static_cast<JaktInternal::Optional<types::StructOrEnumId>>( types::StructOrEnumId { typename types::StructOrEnumId::Enum(id) } ));
 };/*case end*/
 default: {
-return JaktInternal::ExplicitValue(({ Optional<JaktInternal::Optional<types::StructOrEnumId>> __jakt_var_348; {
+return JaktInternal::ExplicitValue(({ Optional<JaktInternal::Optional<types::StructOrEnumId>> __jakt_var_355; {
 TRY((((*this).error(TRY((String::formatted(String("no methods available on value (type: {})"),TRY((((*this).type_name(checked_expr_type_id))))))),((checked_expr)->span())))));
 JaktInternal::Optional<types::StructOrEnumId> const none = JaktInternal::OptionalNone();
-__jakt_var_348 = none; goto __jakt_label_329;
+__jakt_var_355 = none; goto __jakt_label_335;
 
 }
-__jakt_label_329:; __jakt_var_348.release_value(); }));
+__jakt_label_335:; __jakt_var_355.release_value(); }));
 };/*case end*/
 }/*switch end*/
 }()
@@ -5043,21 +5349,21 @@ TRY((((*this).error(TRY((String::formatted(String("Optional chain mismatch: expe
 }
 NonnullRefPtr<types::CheckedExpression> const checked_call_expr = TRY((((*this).typecheck_call(call,scope_id,span,checked_expr,parent_id,safety_mode,type_hint,false))));
 types::TypeId const type_id = ((checked_call_expr)->type());
-__jakt_var_344 = JAKT_RESOLVE_EXPLICIT_VALUE_OR_CONTROL_FLOW_RETURN_ONLY(([&]() -> JaktInternal::ExplicitValueOrControlFlow<NonnullRefPtr<types::CheckedExpression>, ErrorOr<NonnullRefPtr<types::CheckedExpression>>>{
+__jakt_var_351 = JAKT_RESOLVE_EXPLICIT_VALUE_OR_CONTROL_FLOW_RETURN_ONLY(([&]() -> JaktInternal::ExplicitValueOrControlFlow<NonnullRefPtr<types::CheckedExpression>, ErrorOr<NonnullRefPtr<types::CheckedExpression>>>{
 auto&& __jakt_match_variant = *checked_call_expr;
 switch(__jakt_match_variant.index()) {
 case 19: {
 auto&& __jakt_match_value = __jakt_match_variant.template get<types::CheckedExpression::Call>();types::CheckedCall const& call = __jakt_match_value.call;
-return JaktInternal::ExplicitValue(({ Optional<NonnullRefPtr<types::CheckedExpression>> __jakt_var_349; {
+return JaktInternal::ExplicitValue(({ Optional<NonnullRefPtr<types::CheckedExpression>> __jakt_var_356; {
 types::TypeId result_type = ((call).return_type);
 if (is_optional){
 types::StructId const optional_struct_id = TRY((((*this).find_struct_in_prelude(String("Optional")))));
 (result_type = TRY((((*this).find_or_add_type_id(TRY((types::Type::template create<typename types::Type::GenericInstance>(optional_struct_id,(TRY((Array<types::TypeId>::create_with({result_type}))))))))))));
 }
-__jakt_var_349 = TRY((types::CheckedExpression::template create<typename types::CheckedExpression::MethodCall>(checked_expr,call,span,is_optional,result_type))); goto __jakt_label_330;
+__jakt_var_356 = TRY((types::CheckedExpression::template create<typename types::CheckedExpression::MethodCall>(checked_expr,call,span,is_optional,result_type))); goto __jakt_label_336;
 
 }
-__jakt_label_330:; __jakt_var_349.release_value(); }));
+__jakt_label_336:; __jakt_var_356.release_value(); }));
 };/*case end*/
 default: {
 {
@@ -5066,16 +5372,16 @@ TRY((((((*this).compiler))->panic(String("typecheck_call should return `CheckedE
 };/*case end*/
 }/*switch end*/
 }()
-)); goto __jakt_label_325;
+)); goto __jakt_label_331;
 
 }
-__jakt_label_325:; __jakt_var_344.release_value(); }));
+__jakt_label_331:; __jakt_var_351.release_value(); }));
 };/*case end*/
 case 20: {
 auto&& __jakt_match_value = __jakt_match_variant.template get<parser::ParsedExpression::Range>();JaktInternal::Optional<NonnullRefPtr<parser::ParsedExpression>> const& from = __jakt_match_value.from;
 JaktInternal::Optional<NonnullRefPtr<parser::ParsedExpression>> const& to = __jakt_match_value.to;
 utility::Span const& span = __jakt_match_value.span;
-return JaktInternal::ExplicitValue(({ Optional<NonnullRefPtr<types::CheckedExpression>> __jakt_var_350; {
+return JaktInternal::ExplicitValue(({ Optional<NonnullRefPtr<types::CheckedExpression>> __jakt_var_357; {
 JaktInternal::Optional<NonnullRefPtr<types::CheckedExpression>> checked_from = JaktInternal::OptionalNone();
 JaktInternal::Optional<types::TypeId> from_type = JaktInternal::OptionalNone();
 utility::Span from_span = span;
@@ -5113,16 +5419,16 @@ else if (((to).has_value())){
 types::StructId const range_struct_id = TRY((((*this).find_struct_in_prelude(String("Range")))));
 NonnullRefPtr<types::Type> const range_type = TRY((types::Type::template create<typename types::Type::GenericInstance>(range_struct_id,(TRY((Array<types::TypeId>::create_with({((values_type_id).value_or(types::builtin( types::BuiltinType { typename types::BuiltinType::I64() } )))})))))));
 types::TypeId const type_id = TRY((((*this).find_or_add_type_id(range_type))));
-__jakt_var_350 = TRY((types::CheckedExpression::template create<typename types::CheckedExpression::Range>(checked_from,checked_to,span,type_id))); goto __jakt_label_331;
+__jakt_var_357 = TRY((types::CheckedExpression::template create<typename types::CheckedExpression::Range>(checked_from,checked_to,span,type_id))); goto __jakt_label_337;
 
 }
-__jakt_label_331:; __jakt_var_350.release_value(); }));
+__jakt_label_337:; __jakt_var_357.release_value(); }));
 };/*case end*/
 case 11: {
 auto&& __jakt_match_value = __jakt_match_variant.template get<parser::ParsedExpression::UnaryOp>();NonnullRefPtr<parser::ParsedExpression> const& expr = __jakt_match_value.expr;
 parser::UnaryOperator const& op = __jakt_match_value.op;
 utility::Span const& span = __jakt_match_value.span;
-return JaktInternal::ExplicitValue(({ Optional<NonnullRefPtr<types::CheckedExpression>> __jakt_var_351; {
+return JaktInternal::ExplicitValue(({ Optional<NonnullRefPtr<types::CheckedExpression>> __jakt_var_358; {
 NonnullRefPtr<types::CheckedExpression> const checked_expr = JAKT_RESOLVE_EXPLICIT_VALUE_OR_CONTROL_FLOW_RETURN_ONLY(([&]() -> JaktInternal::ExplicitValueOrControlFlow<NonnullRefPtr<types::CheckedExpression>, ErrorOr<NonnullRefPtr<types::CheckedExpression>>>{
 auto&& __jakt_match_variant = op;
 switch(__jakt_match_variant.index()) {
@@ -5186,21 +5492,21 @@ return JaktInternal::ExplicitValue( types::CheckedUnaryOperator { typename types
 case 11: {
 auto&& __jakt_match_value = __jakt_match_variant.template get<typename parser::UnaryOperator::TypeCast>();
 parser::TypeCast const& cast = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(({ Optional<types::CheckedUnaryOperator> __jakt_var_352; {
+return JaktInternal::ExplicitValue(({ Optional<types::CheckedUnaryOperator> __jakt_var_359; {
 types::TypeId const type_id = TRY((((*this).typecheck_typename(((cast).parsed_type()),scope_id,JaktInternal::OptionalNone()))));
 types::CheckedTypeCast const checked_cast = JAKT_RESOLVE_EXPLICIT_VALUE_OR_CONTROL_FLOW_RETURN_ONLY(([&]() -> JaktInternal::ExplicitValueOrControlFlow<types::CheckedTypeCast, ErrorOr<NonnullRefPtr<types::CheckedExpression>>>{
 auto&& __jakt_match_variant = cast;
 switch(__jakt_match_variant.index()) {
 case 0: {
 auto&& __jakt_match_value = __jakt_match_variant.template get<typename parser::TypeCast::Fallible>();
-return JaktInternal::ExplicitValue(({ Optional<types::CheckedTypeCast> __jakt_var_353; {
+return JaktInternal::ExplicitValue(({ Optional<types::CheckedTypeCast> __jakt_var_360; {
 types::StructId const optional_struct_id = TRY((((*this).find_struct_in_prelude(String("Optional")))));
 NonnullRefPtr<types::Type> const optional_type = TRY((types::Type::template create<typename types::Type::GenericInstance>(optional_struct_id,(TRY((Array<types::TypeId>::create_with({type_id})))))));
 types::TypeId const optional_type_id = TRY((((*this).find_or_add_type_id(optional_type))));
-__jakt_var_353 =  types::CheckedTypeCast { typename types::CheckedTypeCast::Fallible(optional_type_id) } ; goto __jakt_label_334;
+__jakt_var_360 =  types::CheckedTypeCast { typename types::CheckedTypeCast::Fallible(optional_type_id) } ; goto __jakt_label_340;
 
 }
-__jakt_label_334:; __jakt_var_353.release_value(); }));
+__jakt_label_340:; __jakt_var_360.release_value(); }));
 };/*case end*/
 case 1: {
 auto&& __jakt_match_value = __jakt_match_variant.template get<typename parser::TypeCast::Infallible>();
@@ -5209,15 +5515,15 @@ return JaktInternal::ExplicitValue( types::CheckedTypeCast { typename types::Che
 default: VERIFY_NOT_REACHED();}/*switch end*/
 }()
 ));
-__jakt_var_352 =  types::CheckedUnaryOperator { typename types::CheckedUnaryOperator::TypeCast(checked_cast) } ; goto __jakt_label_333;
+__jakt_var_359 =  types::CheckedUnaryOperator { typename types::CheckedUnaryOperator::TypeCast(checked_cast) } ; goto __jakt_label_339;
 
 }
-__jakt_label_333:; __jakt_var_352.release_value(); }));
+__jakt_label_339:; __jakt_var_359.release_value(); }));
 };/*case end*/
 case 12: {
 auto&& __jakt_match_value = __jakt_match_variant.template get<typename parser::UnaryOperator::Is>();
 NonnullRefPtr<parser::ParsedType> const& unchecked_type = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(({ Optional<types::CheckedUnaryOperator> __jakt_var_354; {
+return JaktInternal::ExplicitValue(({ Optional<types::CheckedUnaryOperator> __jakt_var_361; {
 bool const old_ignore_errors = ((*this).ignore_errors);
 (((*this).ignore_errors) = true);
 types::TypeId const type_id = TRY((((*this).typecheck_typename(unchecked_type,scope_id,JaktInternal::OptionalNone()))));
@@ -5281,10 +5587,10 @@ else {
 TRY((((*this).error(String("The right-hand side of an `is` operator must be a type name or enum variant"),span))));
 }
 
-__jakt_var_354 = operator_is; goto __jakt_label_335;
+__jakt_var_361 = operator_is; goto __jakt_label_341;
 
 }
-__jakt_label_335:; __jakt_var_354.release_value(); }));
+__jakt_label_341:; __jakt_var_361.release_value(); }));
 };/*case end*/
 case 13: {
 auto&& __jakt_match_value = __jakt_match_variant.template get<parser::UnaryOperator::IsEnumVariant>();NonnullRefPtr<parser::ParsedType> const& inner = __jakt_match_value.inner;
@@ -5294,17 +5600,17 @@ return JaktInternal::ExplicitValue(TRY((((*this).typecheck_is_enum_variant(check
 default: VERIFY_NOT_REACHED();}/*switch end*/
 }()
 ));
-__jakt_var_351 = TRY((((*this).typecheck_unary_operation(checked_expr,checked_op,span,scope_id,safety_mode)))); goto __jakt_label_332;
+__jakt_var_358 = TRY((((*this).typecheck_unary_operation(checked_expr,checked_op,span,scope_id,safety_mode)))); goto __jakt_label_338;
 
 }
-__jakt_label_332:; __jakt_var_351.release_value(); }));
+__jakt_label_338:; __jakt_var_358.release_value(); }));
 };/*case end*/
 case 12: {
 auto&& __jakt_match_value = __jakt_match_variant.template get<parser::ParsedExpression::BinaryOp>();NonnullRefPtr<parser::ParsedExpression> const& lhs = __jakt_match_value.lhs;
 parser::BinaryOperator const& op = __jakt_match_value.op;
 NonnullRefPtr<parser::ParsedExpression> const& rhs = __jakt_match_value.rhs;
 utility::Span const& span = __jakt_match_value.span;
-return JaktInternal::ExplicitValue(({ Optional<NonnullRefPtr<types::CheckedExpression>> __jakt_var_355; {
+return JaktInternal::ExplicitValue(({ Optional<NonnullRefPtr<types::CheckedExpression>> __jakt_var_362; {
 JaktInternal::Optional<NonnullRefPtr<types::CheckedExpression>> checked_lhs = JaktInternal::OptionalNone();
 JaktInternal::Optional<NonnullRefPtr<types::CheckedExpression>> checked_rhs = JaktInternal::OptionalNone();
 if ((((lhs)->index() == 1 /* NumericConstant */) || ((lhs)->index() == 1 /* NumericConstant */))){
@@ -5319,15 +5625,15 @@ types::TypeId const hint = (((checked_lhs.value()))->type());
 }
 
 types::TypeId const output_type = TRY((((*this).typecheck_binary_operation((checked_lhs.value()),op,(checked_rhs.value()),scope_id,span))));
-__jakt_var_355 = TRY((types::CheckedExpression::template create<typename types::CheckedExpression::BinaryOp>((checked_lhs.value()),op,(checked_rhs.value()),span,output_type))); goto __jakt_label_336;
+__jakt_var_362 = TRY((types::CheckedExpression::template create<typename types::CheckedExpression::BinaryOp>((checked_lhs.value()),op,(checked_rhs.value()),span,output_type))); goto __jakt_label_342;
 
 }
-__jakt_label_336:; __jakt_var_355.release_value(); }));
+__jakt_label_342:; __jakt_var_362.release_value(); }));
 };/*case end*/
 case 15: {
 auto&& __jakt_match_value = __jakt_match_variant.template get<typename parser::ParsedExpression::OptionalNone>();
 utility::Span const& span = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(({ Optional<NonnullRefPtr<types::CheckedExpression>> __jakt_var_356; {
+return JaktInternal::ExplicitValue(({ Optional<NonnullRefPtr<types::CheckedExpression>> __jakt_var_363; {
 JaktInternal::Optional<types::TypeId> type_hint_unwrapped = type_hint;
 if ((((type_hint).has_value()) && ((((*this).get_type((type_hint.value()))))->index() == 19 /* GenericInstance */))){
 types::StructId const id = (((*this).get_type((type_hint.value())))->get<types::Type::GenericInstance>()).id;
@@ -5337,24 +5643,24 @@ if (((id).equals(optional_struct_id))){
 (type_hint_unwrapped = ((args)[static_cast<i64>(0LL)]));
 }
 }
-__jakt_var_356 = TRY((types::CheckedExpression::template create<typename types::CheckedExpression::OptionalNone>(span,type_hint_unwrapped.value_or_lazy_evaluated([&] { return types::unknown_type_id(); })))); goto __jakt_label_337;
+__jakt_var_363 = TRY((types::CheckedExpression::template create<typename types::CheckedExpression::OptionalNone>(span,type_hint_unwrapped.value_or_lazy_evaluated([&] { return types::unknown_type_id(); })))); goto __jakt_label_343;
 
 }
-__jakt_label_337:; __jakt_var_356.release_value(); }));
+__jakt_label_343:; __jakt_var_363.release_value(); }));
 };/*case end*/
 case 14: {
 auto&& __jakt_match_value = __jakt_match_variant.template get<parser::ParsedExpression::OptionalSome>();NonnullRefPtr<parser::ParsedExpression> const& expr = __jakt_match_value.expr;
 utility::Span const& span = __jakt_match_value.span;
-return JaktInternal::ExplicitValue(({ Optional<NonnullRefPtr<types::CheckedExpression>> __jakt_var_357; {
+return JaktInternal::ExplicitValue(({ Optional<NonnullRefPtr<types::CheckedExpression>> __jakt_var_364; {
 NonnullRefPtr<types::CheckedExpression> const checked_expr = TRY((((*this).typecheck_expression(expr,scope_id,safety_mode,JaktInternal::OptionalNone()))));
 types::TypeId const type_id = ((checked_expr)->type());
 types::StructId const optional_struct_id = TRY((((*this).find_struct_in_prelude(String("Optional")))));
 NonnullRefPtr<types::Type> const optional_type = TRY((types::Type::template create<typename types::Type::GenericInstance>(optional_struct_id,(TRY((Array<types::TypeId>::create_with({type_id})))))));
 types::TypeId const optional_type_id = TRY((((*this).find_or_add_type_id(optional_type))));
-__jakt_var_357 = TRY((types::CheckedExpression::template create<typename types::CheckedExpression::OptionalSome>(checked_expr,span,optional_type_id))); goto __jakt_label_338;
+__jakt_var_364 = TRY((types::CheckedExpression::template create<typename types::CheckedExpression::OptionalSome>(checked_expr,span,optional_type_id))); goto __jakt_label_344;
 
 }
-__jakt_label_338:; __jakt_var_357.release_value(); }));
+__jakt_label_344:; __jakt_var_364.release_value(); }));
 };/*case end*/
 case 9: {
 auto&& __jakt_match_value = __jakt_match_variant.template get<parser::ParsedExpression::Var>();String const& name = __jakt_match_value.name;
@@ -5367,12 +5673,12 @@ if (__jakt_enum_value == true) {
 return JaktInternal::ExplicitValue(TRY((types::CheckedExpression::template create<typename types::CheckedExpression::Var>((var.value()),span))));
 }
 else {
-return JaktInternal::ExplicitValue(({ Optional<NonnullRefPtr<types::CheckedExpression>> __jakt_var_358; {
+return JaktInternal::ExplicitValue(({ Optional<NonnullRefPtr<types::CheckedExpression>> __jakt_var_365; {
 TRY((((*this).error(TRY((String::formatted(String("Variable '{}' not found"),name))),span))));
-__jakt_var_358 = TRY((types::CheckedExpression::template create<typename types::CheckedExpression::Var>(types::CheckedVariable(name,((type_hint).value_or(types::unknown_type_id())),false,span,JaktInternal::OptionalNone(), types::CheckedVisibility { typename types::CheckedVisibility::Public() } ),span))); goto __jakt_label_339;
+__jakt_var_365 = TRY((types::CheckedExpression::template create<typename types::CheckedExpression::Var>(types::CheckedVariable(name,((type_hint).value_or(types::unknown_type_id())),false,span,JaktInternal::OptionalNone(), types::CheckedVisibility { typename types::CheckedVisibility::Public() } ),span))); goto __jakt_label_345;
 
 }
-__jakt_label_339:; __jakt_var_358.release_value(); }));
+__jakt_label_345:; __jakt_var_365.release_value(); }));
 }
 }()))
 );
@@ -5381,7 +5687,7 @@ __jakt_label_339:; __jakt_var_358.release_value(); }));
 case 21: {
 auto&& __jakt_match_value = __jakt_match_variant.template get<parser::ParsedExpression::ForcedUnwrap>();NonnullRefPtr<parser::ParsedExpression> const& expr = __jakt_match_value.expr;
 utility::Span const& span = __jakt_match_value.span;
-return JaktInternal::ExplicitValue(({ Optional<NonnullRefPtr<types::CheckedExpression>> __jakt_var_359; {
+return JaktInternal::ExplicitValue(({ Optional<NonnullRefPtr<types::CheckedExpression>> __jakt_var_366; {
 NonnullRefPtr<types::CheckedExpression> const checked_expr = TRY((((*this).typecheck_expression_and_dereference_if_needed(expr,scope_id,safety_mode,JaktInternal::OptionalNone(),span))));
 NonnullRefPtr<types::Type> const type = ((*this).get_type(((checked_expr)->type())));
 types::StructId const optional_struct_id = TRY((((*this).find_struct_in_prelude(String("Optional")))));
@@ -5392,7 +5698,7 @@ switch(__jakt_match_variant.index()) {
 case 19: {
 auto&& __jakt_match_value = __jakt_match_variant.template get<types::Type::GenericInstance>();types::StructId const& id = __jakt_match_value.id;
 JaktInternal::Array<types::TypeId> const& args = __jakt_match_value.args;
-return JaktInternal::ExplicitValue(({ Optional<types::TypeId> __jakt_var_360; {
+return JaktInternal::ExplicitValue(({ Optional<types::TypeId> __jakt_var_367; {
 types::TypeId inner_type_id = types::unknown_type_id();
 if ((((id).equals(optional_struct_id)) || ((id).equals(weakptr_struct_id)))){
 (inner_type_id = ((args)[static_cast<i64>(0LL)]));
@@ -5401,26 +5707,26 @@ else {
 TRY((((*this).error(String("Forced unwrap only works on Optional"),span))));
 }
 
-__jakt_var_360 = inner_type_id; goto __jakt_label_341;
+__jakt_var_367 = inner_type_id; goto __jakt_label_347;
 
 }
-__jakt_label_341:; __jakt_var_360.release_value(); }));
+__jakt_label_347:; __jakt_var_367.release_value(); }));
 };/*case end*/
 default: {
-return JaktInternal::ExplicitValue(({ Optional<types::TypeId> __jakt_var_361; {
+return JaktInternal::ExplicitValue(({ Optional<types::TypeId> __jakt_var_368; {
 TRY((((*this).error(String("Forced unwrap only works on Optional"),span))));
-__jakt_var_361 = types::unknown_type_id(); goto __jakt_label_342;
+__jakt_var_368 = types::unknown_type_id(); goto __jakt_label_348;
 
 }
-__jakt_label_342:; __jakt_var_361.release_value(); }));
+__jakt_label_348:; __jakt_var_368.release_value(); }));
 };/*case end*/
 }/*switch end*/
 }()
 ));
-__jakt_var_359 = TRY((types::CheckedExpression::template create<typename types::CheckedExpression::ForcedUnwrap>(checked_expr,span,type_id))); goto __jakt_label_340;
+__jakt_var_366 = TRY((types::CheckedExpression::template create<typename types::CheckedExpression::ForcedUnwrap>(checked_expr,span,type_id))); goto __jakt_label_346;
 
 }
-__jakt_label_340:; __jakt_var_359.release_value(); }));
+__jakt_label_346:; __jakt_var_366.release_value(); }));
 };/*case end*/
 case 16: {
 auto&& __jakt_match_value = __jakt_match_variant.template get<parser::ParsedExpression::JaktArray>();JaktInternal::Array<NonnullRefPtr<parser::ParsedExpression>> const& values = __jakt_match_value.values;
@@ -5431,7 +5737,7 @@ return JaktInternal::ExplicitValue(TRY((((*this).typecheck_array(scope_id,values
 case 19: {
 auto&& __jakt_match_value = __jakt_match_variant.template get<parser::ParsedExpression::JaktTuple>();JaktInternal::Array<NonnullRefPtr<parser::ParsedExpression>> const& values = __jakt_match_value.values;
 utility::Span const& span = __jakt_match_value.span;
-return JaktInternal::ExplicitValue(({ Optional<NonnullRefPtr<types::CheckedExpression>> __jakt_var_362; {
+return JaktInternal::ExplicitValue(({ Optional<NonnullRefPtr<types::CheckedExpression>> __jakt_var_369; {
 types::TypeId const VOID_TYPE_ID = types::builtin( types::BuiltinType { typename types::BuiltinType::Void() } );
 JaktInternal::Array<NonnullRefPtr<types::CheckedExpression>> checked_values = (TRY((Array<NonnullRefPtr<types::CheckedExpression>>::create_with({}))));
 JaktInternal::Array<types::TypeId> checked_types = (TRY((Array<types::TypeId>::create_with({}))));
@@ -5461,25 +5767,25 @@ types::TypeId const type_id = TRY((((*this).find_or_add_type_id(TRY((types::Type
 if (((type_hint).has_value())){
 TRY((((*this).check_types_for_compat((type_hint.value()),type_id,((((*this).generic_inferences))),span))));
 }
-__jakt_var_362 = TRY((types::CheckedExpression::template create<typename types::CheckedExpression::JaktTuple>(checked_values,span,type_id))); goto __jakt_label_343;
+__jakt_var_369 = TRY((types::CheckedExpression::template create<typename types::CheckedExpression::JaktTuple>(checked_values,span,type_id))); goto __jakt_label_349;
 
 }
-__jakt_label_343:; __jakt_var_362.release_value(); }));
+__jakt_label_349:; __jakt_var_369.release_value(); }));
 };/*case end*/
 case 10: {
 auto&& __jakt_match_value = __jakt_match_variant.template get<parser::ParsedExpression::IndexedExpression>();NonnullRefPtr<parser::ParsedExpression> const& base = __jakt_match_value.base;
 NonnullRefPtr<parser::ParsedExpression> const& index = __jakt_match_value.index;
 utility::Span const& span = __jakt_match_value.span;
-return JaktInternal::ExplicitValue(({ Optional<NonnullRefPtr<types::CheckedExpression>> __jakt_var_363; {
+return JaktInternal::ExplicitValue(({ Optional<NonnullRefPtr<types::CheckedExpression>> __jakt_var_370; {
 NonnullRefPtr<types::CheckedExpression> const checked_base = TRY((((*this).typecheck_expression_and_dereference_if_needed(base,scope_id,safety_mode,JaktInternal::OptionalNone(),span))));
 NonnullRefPtr<types::CheckedExpression> const checked_index = TRY((((*this).typecheck_expression_and_dereference_if_needed(index,scope_id,safety_mode,JaktInternal::OptionalNone(),span))));
-__jakt_var_363 = JAKT_RESOLVE_EXPLICIT_VALUE_OR_CONTROL_FLOW_RETURN_ONLY(([&]() -> JaktInternal::ExplicitValueOrControlFlow<NonnullRefPtr<types::CheckedExpression>, ErrorOr<NonnullRefPtr<types::CheckedExpression>>>{
+__jakt_var_370 = JAKT_RESOLVE_EXPLICIT_VALUE_OR_CONTROL_FLOW_RETURN_ONLY(([&]() -> JaktInternal::ExplicitValueOrControlFlow<NonnullRefPtr<types::CheckedExpression>, ErrorOr<NonnullRefPtr<types::CheckedExpression>>>{
 auto&& __jakt_match_variant = *((*this).get_type(((checked_base)->type())));
 switch(__jakt_match_variant.index()) {
 case 19: {
 auto&& __jakt_match_value = __jakt_match_variant.template get<types::Type::GenericInstance>();types::StructId const& id = __jakt_match_value.id;
 JaktInternal::Array<types::TypeId> const& args = __jakt_match_value.args;
-return JaktInternal::ExplicitValue(({ Optional<NonnullRefPtr<types::CheckedExpression>> __jakt_var_364; {
+return JaktInternal::ExplicitValue(({ Optional<NonnullRefPtr<types::CheckedExpression>> __jakt_var_371; {
 types::StructId const array_struct_id = TRY((((*this).find_struct_in_prelude(String("Array")))));
 types::StructId const array_slice_struct_id = TRY((((*this).find_struct_in_prelude(String("ArraySlice")))));
 types::StructId const dictionary_struct_id = TRY((((*this).find_struct_in_prelude(String("Dictionary")))));
@@ -5490,12 +5796,12 @@ types::TypeId const type_id = JAKT_RESOLVE_EXPLICIT_VALUE_OR_CONTROL_FLOW_RETURN
 auto&& __jakt_match_variant = *checked_index;
 switch(__jakt_match_variant.index()) {
 case 8: {
-auto&& __jakt_match_value = __jakt_match_variant.template get<types::CheckedExpression::Range>();return JaktInternal::ExplicitValue(({ Optional<types::TypeId> __jakt_var_365; {
+auto&& __jakt_match_value = __jakt_match_variant.template get<types::CheckedExpression::Range>();return JaktInternal::ExplicitValue(({ Optional<types::TypeId> __jakt_var_372; {
 types::StructId const array_slice_struct_id = TRY((((*this).find_struct_in_prelude(String("ArraySlice")))));
-__jakt_var_365 = TRY((((*this).find_or_add_type_id(TRY((types::Type::template create<typename types::Type::GenericInstance>(array_slice_struct_id,args))))))); goto __jakt_label_346;
+__jakt_var_372 = TRY((((*this).find_or_add_type_id(TRY((types::Type::template create<typename types::Type::GenericInstance>(array_slice_struct_id,args))))))); goto __jakt_label_352;
 
 }
-__jakt_label_346:; __jakt_var_365.release_value(); }));
+__jakt_label_352:; __jakt_var_372.release_value(); }));
 };/*case end*/
 default: {
 return JaktInternal::ExplicitValue(((args)[static_cast<i64>(0LL)]));
@@ -5513,32 +5819,32 @@ TRY((((*this).error(String("Index must be an integer or a range"),span))));
 else if (((id).equals(dictionary_struct_id))){
 (result = TRY((types::CheckedExpression::template create<typename types::CheckedExpression::IndexedDictionary>(checked_base,checked_index,span,((args)[static_cast<i64>(1LL)])))));
 }
-__jakt_var_364 = result; goto __jakt_label_345;
+__jakt_var_371 = result; goto __jakt_label_351;
 
 }
-__jakt_label_345:; __jakt_var_364.release_value(); }));
+__jakt_label_351:; __jakt_var_371.release_value(); }));
 };/*case end*/
 default: {
-return JaktInternal::ExplicitValue(({ Optional<NonnullRefPtr<types::CheckedExpression>> __jakt_var_366; {
+return JaktInternal::ExplicitValue(({ Optional<NonnullRefPtr<types::CheckedExpression>> __jakt_var_373; {
 TRY((((*this).error(String("Index used on value that cannot be indexed"),span))));
-__jakt_var_366 = TRY((types::CheckedExpression::template create<typename types::CheckedExpression::Garbage>(span))); goto __jakt_label_347;
+__jakt_var_373 = TRY((types::CheckedExpression::template create<typename types::CheckedExpression::Garbage>(span))); goto __jakt_label_353;
 
 }
-__jakt_label_347:; __jakt_var_366.release_value(); }));
+__jakt_label_353:; __jakt_var_373.release_value(); }));
 };/*case end*/
 }/*switch end*/
 }()
-)); goto __jakt_label_344;
+)); goto __jakt_label_350;
 
 }
-__jakt_label_344:; __jakt_var_363.release_value(); }));
+__jakt_label_350:; __jakt_var_370.release_value(); }));
 };/*case end*/
 case 7: {
 auto&& __jakt_match_value = __jakt_match_variant.template get<parser::ParsedExpression::IndexedTuple>();NonnullRefPtr<parser::ParsedExpression> const& expr = __jakt_match_value.expr;
 size_t const& index = __jakt_match_value.index;
 bool const& is_optional = __jakt_match_value.is_optional;
 utility::Span const& span = __jakt_match_value.span;
-return JaktInternal::ExplicitValue(({ Optional<NonnullRefPtr<types::CheckedExpression>> __jakt_var_367; {
+return JaktInternal::ExplicitValue(({ Optional<NonnullRefPtr<types::CheckedExpression>> __jakt_var_374; {
 NonnullRefPtr<types::CheckedExpression> const checked_expr = TRY((((*this).typecheck_expression_and_dereference_if_needed(expr,scope_id,safety_mode,JaktInternal::OptionalNone(),span))));
 types::StructId const tuple_struct_id = TRY((((*this).find_struct_in_prelude(String("Tuple")))));
 types::StructId const optional_struct_id = TRY((((*this).find_struct_in_prelude(String("Optional")))));
@@ -5586,10 +5892,10 @@ else {
 TRY((((*this).error(String("Tuple index used on non-tuple value"),span))));
 }
 
-__jakt_var_367 = TRY((types::CheckedExpression::template create<typename types::CheckedExpression::IndexedTuple>(checked_expr,index,span,is_optional,expr_type_id))); goto __jakt_label_348;
+__jakt_var_374 = TRY((types::CheckedExpression::template create<typename types::CheckedExpression::IndexedTuple>(checked_expr,index,span,is_optional,expr_type_id))); goto __jakt_label_354;
 
 }
-__jakt_label_348:; __jakt_var_367.release_value(); }));
+__jakt_label_354:; __jakt_var_374.release_value(); }));
 };/*case end*/
 case 28: {
 auto&& __jakt_match_value = __jakt_match_variant.template get<typename parser::ParsedExpression::Garbage>();
@@ -5613,7 +5919,7 @@ auto&& __jakt_match_value = __jakt_match_variant.template get<parser::ParsedExpr
 parser::EnumVariantPatternArgument const& arg = __jakt_match_value.arg;
 NonnullRefPtr<parser::ParsedType> const& enum_variant = __jakt_match_value.enum_variant;
 utility::Span const& span = __jakt_match_value.span;
-return JaktInternal::ExplicitValue(({ Optional<NonnullRefPtr<types::CheckedExpression>> __jakt_var_368; {
+return JaktInternal::ExplicitValue(({ Optional<NonnullRefPtr<types::CheckedExpression>> __jakt_var_375; {
 NonnullRefPtr<types::CheckedExpression> const checked_expr = TRY((((*this).typecheck_expression_and_dereference_if_needed(inner_expr,scope_id,safety_mode,JaktInternal::OptionalNone(),span))));
 types::CheckedEnumVariantBinding checked_binding = types::CheckedEnumVariantBinding(String(""),String(""),types::unknown_type_id(),span);
 JaktInternal::Optional<types::CheckedEnumVariant> checked_enum_variant = JaktInternal::OptionalNone();
@@ -5706,10 +6012,10 @@ NonnullRefPtr<types::CheckedExpression> output = TRY((types::CheckedExpression::
 if (((checked_enum_variant).has_value())){
 (output = TRY((types::CheckedExpression::template create<typename types::CheckedExpression::EnumVariantArg>(checked_expr,checked_binding,(checked_enum_variant.value()),span))));
 }
-__jakt_var_368 = output; goto __jakt_label_349;
+__jakt_var_375 = output; goto __jakt_label_355;
 
 }
-__jakt_label_349:; __jakt_var_368.release_value(); }));
+__jakt_label_355:; __jakt_var_375.release_value(); }));
 };/*case end*/
 case 17: {
 auto&& __jakt_match_value = __jakt_match_variant.template get<parser::ParsedExpression::JaktDictionary>();JaktInternal::Array<JaktInternal::Tuple<NonnullRefPtr<parser::ParsedExpression>,NonnullRefPtr<parser::ParsedExpression>>> const& values = __jakt_match_value.values;
@@ -5842,13 +6148,21 @@ return (module_id);
 }
 }
 
-ErrorOr<NonnullRefPtr<types::CheckedStatement>> typechecker::Typechecker::typecheck_block_statement(parser::ParsedBlock const parsed_block,types::ScopeId const scope_id,types::SafetyMode const safety_mode,utility::Span const span) {
+ErrorOr<NonnullRefPtr<types::CheckedStatement>> typechecker::Typechecker::typecheck_defer(NonnullRefPtr<parser::ParsedStatement> const statement,types::ScopeId const scope_id,types::SafetyMode const safety_mode,utility::Span const span) {
 {
-types::CheckedBlock const checked_block = TRY((((*this).typecheck_block(parsed_block,scope_id,safety_mode,JaktInternal::OptionalNone()))));
-if (((((checked_block).yielded_type)).has_value())){
-TRY((((*this).error(String("A block used as a statement cannot yield values, as the value cannot be observed in any way"),(((parsed_block).find_yield_span()).value())))));
+bool const was_inside_defer = ((*this).inside_defer);
+(((*this).inside_defer) = true);
+ScopeGuard __jakt_var_376([&] {
+(((*this).inside_defer) = was_inside_defer);
+});
+NonnullRefPtr<types::CheckedStatement> const checked_statement = TRY((((*this).typecheck_statement(statement,scope_id,safety_mode,JaktInternal::OptionalNone()))));
+if (((checked_statement)->index() == 5 /* Block */)){
+types::CheckedBlock const block = (checked_statement->get<types::CheckedStatement::Block>()).block;
+if (((((block).yielded_type)).has_value())){
+TRY((((*this).error(String("‘yield’ inside ‘defer’ is meaningless"),span))));
 }
-return (TRY((types::CheckedStatement::template create<typename types::CheckedStatement::Block>(checked_block,span))));
+}
+return (TRY((types::CheckedStatement::template create<typename types::CheckedStatement::Defer>(checked_statement,span))));
 }
 }
 
@@ -5959,21 +6273,7 @@ if (((acc).has_value())){
 TRY((((outer_if_stmts).push(TRY((parser::ParsedStatement::template create<typename parser::ParsedStatement::If>(inner_condition,(then_block.value()),else_statement,span)))))));
 }
 else {
-{
-JaktInternal::ArrayIterator<NonnullRefPtr<parser::ParsedStatement>> _magic = (((((then_block.value())).stmts)).iterator());
-for (;;){
-JaktInternal::Optional<NonnullRefPtr<parser::ParsedStatement>> _magic_value = ((_magic).next());
-if ((!(((_magic_value).has_value())))){
-break;
-}
-NonnullRefPtr<parser::ParsedStatement> stmt = (_magic_value.value());
-{
-TRY((((outer_if_stmts).push(stmt))));
-}
-
-}
-}
-
+TRY((((outer_if_stmts).push_values((((then_block.value())).stmts)))));
 }
 
 }
@@ -6121,24 +6421,11 @@ return (TRY((types::CheckedExpression::template create<typename types::CheckedEx
 ErrorOr<bool> typechecker::Typechecker::add_var_to_scope(types::ScopeId const scope_id,String const name,types::VarId const var_id,utility::Span const span) {
 {
 NonnullRefPtr<types::Scope> scope = TRY((((*this).get_scope(scope_id))));
-{
-JaktInternal::DictionaryIterator<String,types::VarId> _magic = ((((scope)->vars)).iterator());
-for (;;){
-JaktInternal::Optional<JaktInternal::Tuple<String,types::VarId>> _magic_value = ((_magic).next());
-if ((!(((_magic_value).has_value())))){
-break;
-}
-JaktInternal::Tuple<String,types::VarId> existing_var = (_magic_value.value());
-{
-if ((name == ((existing_var).get<0>()))){
-types::CheckedVariable const variable_ = ((*this).get_variable(((existing_var).get<1>())));
+JaktInternal::Optional<types::VarId> const existing_var = ((((scope)->vars)).get(name));
+if (((existing_var).has_value())){
+types::CheckedVariable const variable_ = ((*this).get_variable((existing_var.value())));
 TRY((((*this).error_with_hint(TRY((String::formatted(String("Redefinition of variable ‘{}’"),name))),span,String("previous definition here"),((variable_).definition_span)))));
 }
-}
-
-}
-}
-
 TRY((((((scope)->vars)).set(name,var_id))));
 return (true);
 }
@@ -6531,23 +6818,11 @@ return (true);
 }
 }
 
-ErrorOr<JaktInternal::Optional<types::CheckedVariable>> typechecker::Typechecker::find_var_in_scope(types::ScopeId const scope_id,String const var) const {
-{
-return (TRY((((((*this).program))->find_var_in_scope(scope_id,var)))));
-}
-}
-
-types::CheckedStruct typechecker::Typechecker::get_struct(types::StructId const id) const {
-{
-return (((((*this).program))->get_struct(id)));
-}
-}
-
 ErrorOr<NonnullRefPtr<types::CheckedExpression>> typechecker::Typechecker::typecheck_lambda(JaktInternal::Array<parser::ParsedCapture> const captures,JaktInternal::Array<parser::ParsedParameter> const params,bool const can_throw,bool const is_fat_arrow,NonnullRefPtr<parser::ParsedType> const return_type,parser::ParsedBlock const block,utility::Span const span,types::ScopeId const scope_id,types::SafetyMode const safety_mode) {
 {
 NonnullRefPtr<parser::ParsedType> const synthetic_type = TRY((parser::ParsedType::template create<typename parser::ParsedType::Function>(params,can_throw,return_type,span)));
 JaktInternal::Dictionary<String,String> const old_generic_inferences = TRY((((((*this).generic_inferences)).perform_checkpoint(false))));
-ScopeGuard __jakt_var_369([&] {
+ScopeGuard __jakt_var_377([&] {
 {
 ((((*this).generic_inferences)).restore(old_generic_inferences));
 }
@@ -6640,7 +6915,7 @@ TRY((((*this).add_var_to_scope(lambda_scope_id,((((checked_param).variable)).nam
 
 JaktInternal::Optional<types::FunctionId> const previous_function_id = ((*this).current_function_id);
 (((*this).current_function_id) = pseudo_function_id);
-ScopeGuard __jakt_var_370([&] {
+ScopeGuard __jakt_var_378([&] {
 {
 (((*this).current_function_id) = previous_function_id);
 }
@@ -6681,6 +6956,12 @@ TRY((((((*this).compiler))->panic(String("Expected the just-checked function to 
 }
 }
 return (TRY((types::CheckedExpression::template create<typename types::CheckedExpression::Function>(checked_captures,checked_params,can_throw,return_type_id,checked_block,span,type_id,pseudo_function_id))));
+}
+}
+
+types::CheckedStruct typechecker::Typechecker::get_struct(types::StructId const id) const {
+{
+return (((((*this).program))->get_struct(id)));
 }
 }
 
@@ -6756,10 +7037,10 @@ ErrorOr<void> typechecker::Typechecker::include_prelude() {
 {
 String const module_name = String("__prelude__");
 path::Path const file_name = TRY((path::Path::Path::from_string(module_name)));
-JaktInternal::Array<u8> const file_contents = (TRY((Array<u8>::create_with({static_cast<u8>(101), static_cast<u8>(120), static_cast<u8>(116), static_cast<u8>(101), static_cast<u8>(114), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(115), static_cast<u8>(116), static_cast<u8>(114), static_cast<u8>(117), static_cast<u8>(99), static_cast<u8>(116), static_cast<u8>(32), static_cast<u8>(79), static_cast<u8>(112), static_cast<u8>(116), static_cast<u8>(105), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(97), static_cast<u8>(108), static_cast<u8>(60), static_cast<u8>(84), static_cast<u8>(62), static_cast<u8>(32), static_cast<u8>(123), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(102), static_cast<u8>(117), static_cast<u8>(110), static_cast<u8>(99), static_cast<u8>(116), static_cast<u8>(105), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(104), static_cast<u8>(97), static_cast<u8>(115), static_cast<u8>(95), static_cast<u8>(118), static_cast<u8>(97), static_cast<u8>(108), static_cast<u8>(117), static_cast<u8>(101), static_cast<u8>(40), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(105), static_cast<u8>(115), static_cast<u8>(41), static_cast<u8>(32), static_cast<u8>(45), static_cast<u8>(62), static_cast<u8>(32), static_cast<u8>(98), static_cast<u8>(111), static_cast<u8>(111), static_cast<u8>(108), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(102), static_cast<u8>(117), static_cast<u8>(110), static_cast<u8>(99), static_cast<u8>(116), static_cast<u8>(105), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(118), static_cast<u8>(97), static_cast<u8>(108), static_cast<u8>(117), static_cast<u8>(101), static_cast<u8>(40), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(105), static_cast<u8>(115), static_cast<u8>(41), static_cast<u8>(32), static_cast<u8>(45), static_cast<u8>(62), static_cast<u8>(32), static_cast<u8>(84), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(102), static_cast<u8>(117), static_cast<u8>(110), static_cast<u8>(99), static_cast<u8>(116), static_cast<u8>(105), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(118), static_cast<u8>(97), static_cast<u8>(108), static_cast<u8>(117), static_cast<u8>(101), static_cast<u8>(95), static_cast<u8>(111), static_cast<u8>(114), static_cast<u8>(40), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(105), static_cast<u8>(115), static_cast<u8>(44), static_cast<u8>(32), static_cast<u8>(97), static_cast<u8>(110), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(120), static_cast<u8>(58), static_cast<u8>(32), static_cast<u8>(84), static_cast<u8>(41), static_cast<u8>(32), static_cast<u8>(45), static_cast<u8>(62), static_cast<u8>(32), static_cast<u8>(84), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(102), static_cast<u8>(117), static_cast<u8>(110), static_cast<u8>(99), static_cast<u8>(116), static_cast<u8>(105), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(79), static_cast<u8>(112), static_cast<u8>(116), static_cast<u8>(105), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(97), static_cast<u8>(108), static_cast<u8>(60), static_cast<u8>(83), static_cast<u8>(62), static_cast<u8>(40), static_cast<u8>(97), static_cast<u8>(110), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(120), static_cast<u8>(58), static_cast<u8>(32), static_cast<u8>(83), static_cast<u8>(41), static_cast<u8>(32), static_cast<u8>(45), static_cast<u8>(62), static_cast<u8>(32), static_cast<u8>(79), static_cast<u8>(112), static_cast<u8>(116), static_cast<u8>(105), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(97), static_cast<u8>(108), static_cast<u8>(60), static_cast<u8>(83), static_cast<u8>(62), static_cast<u8>(10), static_cast<u8>(125), static_cast<u8>(10), static_cast<u8>(10), static_cast<u8>(101), static_cast<u8>(120), static_cast<u8>(116), static_cast<u8>(101), static_cast<u8>(114), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(115), static_cast<u8>(116), static_cast<u8>(114), static_cast<u8>(117), static_cast<u8>(99), static_cast<u8>(116), static_cast<u8>(32), static_cast<u8>(65), static_cast<u8>(114), static_cast<u8>(114), static_cast<u8>(97), static_cast<u8>(121), static_cast<u8>(73), static_cast<u8>(116), static_cast<u8>(101), static_cast<u8>(114), static_cast<u8>(97), static_cast<u8>(116), static_cast<u8>(111), static_cast<u8>(114), static_cast<u8>(60), static_cast<u8>(84), static_cast<u8>(62), static_cast<u8>(32), static_cast<u8>(123), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(102), static_cast<u8>(117), static_cast<u8>(110), static_cast<u8>(99), static_cast<u8>(116), static_cast<u8>(105), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(110), static_cast<u8>(101), static_cast<u8>(120), static_cast<u8>(116), static_cast<u8>(40), static_cast<u8>(109), static_cast<u8>(117), static_cast<u8>(116), static_cast<u8>(32), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(105), static_cast<u8>(115), static_cast<u8>(41), static_cast<u8>(32), static_cast<u8>(45), static_cast<u8>(62), static_cast<u8>(32), static_cast<u8>(84), static_cast<u8>(63), static_cast<u8>(10), static_cast<u8>(125), static_cast<u8>(10), static_cast<u8>(10), static_cast<u8>(101), static_cast<u8>(120), static_cast<u8>(116), static_cast<u8>(101), static_cast<u8>(114), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(115), static_cast<u8>(116), static_cast<u8>(114), static_cast<u8>(117), static_cast<u8>(99), static_cast<u8>(116), static_cast<u8>(32), static_cast<u8>(65), static_cast<u8>(114), static_cast<u8>(114), static_cast<u8>(97), static_cast<u8>(121), static_cast<u8>(60), static_cast<u8>(84), static_cast<u8>(62), static_cast<u8>(32), static_cast<u8>(123), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(102), static_cast<u8>(117), static_cast<u8>(110), static_cast<u8>(99), static_cast<u8>(116), static_cast<u8>(105), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(105), static_cast<u8>(115), static_cast<u8>(95), static_cast<u8>(101), static_cast<u8>(109), static_cast<u8>(112), static_cast<u8>(116), static_cast<u8>(121), static_cast<u8>(40), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(105), static_cast<u8>(115), static_cast<u8>(41), static_cast<u8>(32), static_cast<u8>(45), static_cast<u8>(62), static_cast<u8>(32), static_cast<u8>(98), static_cast<u8>(111), static_cast<u8>(111), static_cast<u8>(108), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(102), static_cast<u8>(117), static_cast<u8>(110), static_cast<u8>(99), static_cast<u8>(116), static_cast<u8>(105), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(99), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(116), static_cast<u8>(97), static_cast<u8>(105), static_cast<u8>(110), static_cast<u8>(115), static_cast<u8>(40), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(105), static_cast<u8>(115), static_cast<u8>(44), static_cast<u8>(32), static_cast<u8>(97), static_cast<u8>(110), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(118), static_cast<u8>(97), static_cast<u8>(108), static_cast<u8>(117), static_cast<u8>(101), static_cast<u8>(58), static_cast<u8>(32), static_cast<u8>(84), static_cast<u8>(41), static_cast<u8>(32), static_cast<u8>(45), static_cast<u8>(62), static_cast<u8>(32), static_cast<u8>(98), static_cast<u8>(111), static_cast<u8>(111), static_cast<u8>(108), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(102), static_cast<u8>(117), static_cast<u8>(110), static_cast<u8>(99), static_cast<u8>(116), static_cast<u8>(105), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(115), static_cast<u8>(105), static_cast<u8>(122), static_cast<u8>(101), static_cast<u8>(40), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(105), static_cast<u8>(115), static_cast<u8>(41), static_cast<u8>(32), static_cast<u8>(45), static_cast<u8>(62), static_cast<u8>(32), static_cast<u8>(117), static_cast<u8>(115), static_cast<u8>(105), static_cast<u8>(122), static_cast<u8>(101), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(102), static_cast<u8>(117), static_cast<u8>(110), static_cast<u8>(99), static_cast<u8>(116), static_cast<u8>(105), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(99), static_cast<u8>(97), static_cast<u8>(112), static_cast<u8>(97), static_cast<u8>(99), static_cast<u8>(105), static_cast<u8>(116), static_cast<u8>(121), static_cast<u8>(40), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(105), static_cast<u8>(115), static_cast<u8>(41), static_cast<u8>(32), static_cast<u8>(45), static_cast<u8>(62), static_cast<u8>(32), static_cast<u8>(117), static_cast<u8>(115), static_cast<u8>(105), static_cast<u8>(122), static_cast<u8>(101), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(102), static_cast<u8>(117), static_cast<u8>(110), static_cast<u8>(99), static_cast<u8>(116), static_cast<u8>(105), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(101), static_cast<u8>(110), static_cast<u8>(115), static_cast<u8>(117), static_cast<u8>(114), static_cast<u8>(101), static_cast<u8>(95), static_cast<u8>(99), static_cast<u8>(97), static_cast<u8>(112), static_cast<u8>(97), static_cast<u8>(99), static_cast<u8>(105), static_cast<u8>(116), static_cast<u8>(121), static_cast<u8>(40), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(105), static_cast<u8>(115), static_cast<u8>(44), static_cast<u8>(32), static_cast<u8>(97), static_cast<u8>(110), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(99), static_cast<u8>(97), static_cast<u8>(112), static_cast<u8>(97), static_cast<u8>(99), static_cast<u8>(105), static_cast<u8>(116), static_cast<u8>(121), static_cast<u8>(58), static_cast<u8>(32), static_cast<u8>(117), static_cast<u8>(115), static_cast<u8>(105), static_cast<u8>(122), static_cast<u8>(101), static_cast<u8>(41), static_cast<u8>(32), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(114), static_cast<u8>(111), static_cast<u8>(119), static_cast<u8>(115), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(102), static_cast<u8>(117), static_cast<u8>(110), static_cast<u8>(99), static_cast<u8>(116), static_cast<u8>(105), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(97), static_cast<u8>(100), static_cast<u8>(100), static_cast<u8>(95), static_cast<u8>(99), static_cast<u8>(97), static_cast<u8>(112), static_cast<u8>(97), static_cast<u8>(99), static_cast<u8>(105), static_cast<u8>(116), static_cast<u8>(121), static_cast<u8>(40), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(105), static_cast<u8>(115), static_cast<u8>(44), static_cast<u8>(32), static_cast<u8>(97), static_cast<u8>(110), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(99), static_cast<u8>(97), static_cast<u8>(112), static_cast<u8>(97), static_cast<u8>(99), static_cast<u8>(105), static_cast<u8>(116), static_cast<u8>(121), static_cast<u8>(58), static_cast<u8>(32), static_cast<u8>(117), static_cast<u8>(115), static_cast<u8>(105), static_cast<u8>(122), static_cast<u8>(101), static_cast<u8>(41), static_cast<u8>(32), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(114), static_cast<u8>(111), static_cast<u8>(119), static_cast<u8>(115), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(102), static_cast<u8>(117), static_cast<u8>(110), static_cast<u8>(99), static_cast<u8>(116), static_cast<u8>(105), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(114), static_cast<u8>(101), static_cast<u8>(115), static_cast<u8>(105), static_cast<u8>(122), static_cast<u8>(101), static_cast<u8>(40), static_cast<u8>(109), static_cast<u8>(117), static_cast<u8>(116), static_cast<u8>(32), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(105), static_cast<u8>(115), static_cast<u8>(44), static_cast<u8>(32), static_cast<u8>(97), static_cast<u8>(110), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(115), static_cast<u8>(105), static_cast<u8>(122), static_cast<u8>(101), static_cast<u8>(58), static_cast<u8>(32), static_cast<u8>(117), static_cast<u8>(115), static_cast<u8>(105), static_cast<u8>(122), static_cast<u8>(101), static_cast<u8>(41), static_cast<u8>(32), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(114), static_cast<u8>(111), static_cast<u8>(119), static_cast<u8>(115), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(102), static_cast<u8>(117), static_cast<u8>(110), static_cast<u8>(99), static_cast<u8>(116), static_cast<u8>(105), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(115), static_cast<u8>(104), static_cast<u8>(114), static_cast<u8>(105), static_cast<u8>(110), static_cast<u8>(107), static_cast<u8>(40), static_cast<u8>(109), static_cast<u8>(117), static_cast<u8>(116), static_cast<u8>(32), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(105), static_cast<u8>(115), static_cast<u8>(44), static_cast<u8>(32), static_cast<u8>(97), static_cast<u8>(110), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(115), static_cast<u8>(105), static_cast<u8>(122), static_cast<u8>(101), static_cast<u8>(58), static_cast<u8>(32), static_cast<u8>(117), static_cast<u8>(115), static_cast<u8>(105), static_cast<u8>(122), static_cast<u8>(101), static_cast<u8>(41), static_cast<u8>(32), static_cast<u8>(45), static_cast<u8>(62), static_cast<u8>(32), static_cast<u8>(118), static_cast<u8>(111), static_cast<u8>(105), static_cast<u8>(100), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(102), static_cast<u8>(117), static_cast<u8>(110), static_cast<u8>(99), static_cast<u8>(116), static_cast<u8>(105), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(112), static_cast<u8>(117), static_cast<u8>(115), static_cast<u8>(104), static_cast<u8>(40), static_cast<u8>(109), static_cast<u8>(117), static_cast<u8>(116), static_cast<u8>(32), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(105), static_cast<u8>(115), static_cast<u8>(44), static_cast<u8>(32), static_cast<u8>(97), static_cast<u8>(110), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(118), static_cast<u8>(97), static_cast<u8>(108), static_cast<u8>(117), static_cast<u8>(101), static_cast<u8>(58), static_cast<u8>(32), static_cast<u8>(84), static_cast<u8>(41), static_cast<u8>(32), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(114), static_cast<u8>(111), static_cast<u8>(119), static_cast<u8>(115), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(102), static_cast<u8>(117), static_cast<u8>(110), static_cast<u8>(99), static_cast<u8>(116), static_cast<u8>(105), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(112), static_cast<u8>(111), static_cast<u8>(112), static_cast<u8>(40), static_cast<u8>(109), static_cast<u8>(117), static_cast<u8>(116), static_cast<u8>(32), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(105), static_cast<u8>(115), static_cast<u8>(41), static_cast<u8>(32), static_cast<u8>(45), static_cast<u8>(62), static_cast<u8>(32), static_cast<u8>(84), static_cast<u8>(63), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(102), static_cast<u8>(117), static_cast<u8>(110), static_cast<u8>(99), static_cast<u8>(116), static_cast<u8>(105), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(105), static_cast<u8>(116), static_cast<u8>(101), static_cast<u8>(114), static_cast<u8>(97), static_cast<u8>(116), static_cast<u8>(111), static_cast<u8>(114), static_cast<u8>(40), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(105), static_cast<u8>(115), static_cast<u8>(41), static_cast<u8>(32), static_cast<u8>(45), static_cast<u8>(62), static_cast<u8>(32), static_cast<u8>(65), static_cast<u8>(114), static_cast<u8>(114), static_cast<u8>(97), static_cast<u8>(121), static_cast<u8>(73), static_cast<u8>(116), static_cast<u8>(101), static_cast<u8>(114), static_cast<u8>(97), static_cast<u8>(116), static_cast<u8>(111), static_cast<u8>(114), static_cast<u8>(60), static_cast<u8>(84), static_cast<u8>(62), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(102), static_cast<u8>(117), static_cast<u8>(110), static_cast<u8>(99), static_cast<u8>(116), static_cast<u8>(105), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(102), static_cast<u8>(105), static_cast<u8>(114), static_cast<u8>(115), static_cast<u8>(116), static_cast<u8>(40), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(105), static_cast<u8>(115), static_cast<u8>(41), static_cast<u8>(32), static_cast<u8>(45), static_cast<u8>(62), static_cast<u8>(32), static_cast<u8>(84), static_cast<u8>(63), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(102), static_cast<u8>(117), static_cast<u8>(110), static_cast<u8>(99), static_cast<u8>(116), static_cast<u8>(105), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(108), static_cast<u8>(97), static_cast<u8>(115), static_cast<u8>(116), static_cast<u8>(40), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(105), static_cast<u8>(115), static_cast<u8>(41), static_cast<u8>(32), static_cast<u8>(45), static_cast<u8>(62), static_cast<u8>(32), static_cast<u8>(84), static_cast<u8>(63), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(102), static_cast<u8>(117), static_cast<u8>(110), static_cast<u8>(99), static_cast<u8>(116), static_cast<u8>(105), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(105), static_cast<u8>(110), static_cast<u8>(115), static_cast<u8>(101), static_cast<u8>(114), static_cast<u8>(116), static_cast<u8>(40), static_cast<u8>(109), static_cast<u8>(117), static_cast<u8>(116), static_cast<u8>(32), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(105), static_cast<u8>(115), static_cast<u8>(44), static_cast<u8>(32), static_cast<u8>(98), static_cast<u8>(101), static_cast<u8>(102), static_cast<u8>(111), static_cast<u8>(114), static_cast<u8>(101), static_cast<u8>(95), static_cast<u8>(105), static_cast<u8>(110), static_cast<u8>(100), static_cast<u8>(101), static_cast<u8>(120), static_cast<u8>(58), static_cast<u8>(32), static_cast<u8>(117), static_cast<u8>(115), static_cast<u8>(105), static_cast<u8>(122), static_cast<u8>(101), static_cast<u8>(44), static_cast<u8>(32), static_cast<u8>(118), static_cast<u8>(97), static_cast<u8>(108), static_cast<u8>(117), static_cast<u8>(101), static_cast<u8>(58), static_cast<u8>(32), static_cast<u8>(84), static_cast<u8>(41), static_cast<u8>(32), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(114), static_cast<u8>(111), static_cast<u8>(119), static_cast<u8>(115), static_cast<u8>(10), static_cast<u8>(125), static_cast<u8>(10), static_cast<u8>(10), static_cast<u8>(101), static_cast<u8>(120), static_cast<u8>(116), static_cast<u8>(101), static_cast<u8>(114), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(115), static_cast<u8>(116), static_cast<u8>(114), static_cast<u8>(117), static_cast<u8>(99), static_cast<u8>(116), static_cast<u8>(32), static_cast<u8>(65), static_cast<u8>(114), static_cast<u8>(114), static_cast<u8>(97), static_cast<u8>(121), static_cast<u8>(83), static_cast<u8>(108), static_cast<u8>(105), static_cast<u8>(99), static_cast<u8>(101), static_cast<u8>(60), static_cast<u8>(84), static_cast<u8>(62), static_cast<u8>(32), static_cast<u8>(123), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(102), static_cast<u8>(117), static_cast<u8>(110), static_cast<u8>(99), static_cast<u8>(116), static_cast<u8>(105), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(105), static_cast<u8>(115), static_cast<u8>(95), static_cast<u8>(101), static_cast<u8>(109), static_cast<u8>(112), static_cast<u8>(116), static_cast<u8>(121), static_cast<u8>(40), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(105), static_cast<u8>(115), static_cast<u8>(41), static_cast<u8>(32), static_cast<u8>(45), static_cast<u8>(62), static_cast<u8>(32), static_cast<u8>(98), static_cast<u8>(111), static_cast<u8>(111), static_cast<u8>(108), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(102), static_cast<u8>(117), static_cast<u8>(110), static_cast<u8>(99), static_cast<u8>(116), static_cast<u8>(105), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(99), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(116), static_cast<u8>(97), static_cast<u8>(105), static_cast<u8>(110), static_cast<u8>(115), static_cast<u8>(40), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(105), static_cast<u8>(115), static_cast<u8>(44), static_cast<u8>(32), static_cast<u8>(97), static_cast<u8>(110), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(118), static_cast<u8>(97), static_cast<u8>(108), static_cast<u8>(117), static_cast<u8>(101), static_cast<u8>(58), static_cast<u8>(32), static_cast<u8>(84), static_cast<u8>(41), static_cast<u8>(32), static_cast<u8>(45), static_cast<u8>(62), static_cast<u8>(32), static_cast<u8>(98), static_cast<u8>(111), static_cast<u8>(111), static_cast<u8>(108), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(102), static_cast<u8>(117), static_cast<u8>(110), static_cast<u8>(99), static_cast<u8>(116), static_cast<u8>(105), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(115), static_cast<u8>(105), static_cast<u8>(122), static_cast<u8>(101), static_cast<u8>(40), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(105), static_cast<u8>(115), static_cast<u8>(41), static_cast<u8>(32), static_cast<u8>(45), static_cast<u8>(62), static_cast<u8>(32), static_cast<u8>(117), static_cast<u8>(115), static_cast<u8>(105), static_cast<u8>(122), static_cast<u8>(101), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(102), static_cast<u8>(117), static_cast<u8>(110), static_cast<u8>(99), static_cast<u8>(116), static_cast<u8>(105), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(105), static_cast<u8>(116), static_cast<u8>(101), static_cast<u8>(114), static_cast<u8>(97), static_cast<u8>(116), static_cast<u8>(111), static_cast<u8>(114), static_cast<u8>(40), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(105), static_cast<u8>(115), static_cast<u8>(41), static_cast<u8>(32), static_cast<u8>(45), static_cast<u8>(62), static_cast<u8>(32), static_cast<u8>(65), static_cast<u8>(114), static_cast<u8>(114), static_cast<u8>(97), static_cast<u8>(121), static_cast<u8>(73), static_cast<u8>(116), static_cast<u8>(101), static_cast<u8>(114), static_cast<u8>(97), static_cast<u8>(116), static_cast<u8>(111), static_cast<u8>(114), static_cast<u8>(60), static_cast<u8>(84), static_cast<u8>(62), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(102), static_cast<u8>(117), static_cast<u8>(110), static_cast<u8>(99), static_cast<u8>(116), static_cast<u8>(105), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(116), static_cast<u8>(111), static_cast<u8>(95), static_cast<u8>(97), static_cast<u8>(114), static_cast<u8>(114), static_cast<u8>(97), static_cast<u8>(121), static_cast<u8>(40), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(105), static_cast<u8>(115), static_cast<u8>(41), static_cast<u8>(32), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(114), static_cast<u8>(111), static_cast<u8>(119), static_cast<u8>(115), static_cast<u8>(32), static_cast<u8>(45), static_cast<u8>(62), static_cast<u8>(32), static_cast<u8>(65), static_cast<u8>(114), static_cast<u8>(114), static_cast<u8>(97), static_cast<u8>(121), static_cast<u8>(60), static_cast<u8>(84), static_cast<u8>(62), static_cast<u8>(32), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(102), static_cast<u8>(117), static_cast<u8>(110), static_cast<u8>(99), static_cast<u8>(116), static_cast<u8>(105), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(102), static_cast<u8>(105), static_cast<u8>(114), static_cast<u8>(115), static_cast<u8>(116), static_cast<u8>(40), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(105), static_cast<u8>(115), static_cast<u8>(41), static_cast<u8>(32), static_cast<u8>(45), static_cast<u8>(62), static_cast<u8>(32), static_cast<u8>(84), static_cast<u8>(63), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(102), static_cast<u8>(117), static_cast<u8>(110), static_cast<u8>(99), static_cast<u8>(116), static_cast<u8>(105), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(108), static_cast<u8>(97), static_cast<u8>(115), static_cast<u8>(116), static_cast<u8>(40), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(105), static_cast<u8>(115), static_cast<u8>(41), static_cast<u8>(32), static_cast<u8>(45), static_cast<u8>(62), static_cast<u8>(32), static_cast<u8>(84), static_cast<u8>(63), static_cast<u8>(10), static_cast<u8>(125), static_cast<u8>(10), static_cast<u8>(10), static_cast<u8>(101), static_cast<u8>(120), static_cast<u8>(116), static_cast<u8>(101), static_cast<u8>(114), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(115), static_cast<u8>(116), static_cast<u8>(114), static_cast<u8>(117), static_cast<u8>(99), static_cast<u8>(116), static_cast<u8>(32), static_cast<u8>(83), static_cast<u8>(116), static_cast<u8>(114), static_cast<u8>(105), static_cast<u8>(110), static_cast<u8>(103), static_cast<u8>(32), static_cast<u8>(123), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(102), static_cast<u8>(117), static_cast<u8>(110), static_cast<u8>(99), static_cast<u8>(116), static_cast<u8>(105), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(110), static_cast<u8>(117), static_cast<u8>(109), static_cast<u8>(98), static_cast<u8>(101), static_cast<u8>(114), static_cast<u8>(40), static_cast<u8>(97), static_cast<u8>(110), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(110), static_cast<u8>(117), static_cast<u8>(109), static_cast<u8>(98), static_cast<u8>(101), static_cast<u8>(114), static_cast<u8>(58), static_cast<u8>(32), static_cast<u8>(105), static_cast<u8>(54), static_cast<u8>(52), static_cast<u8>(41), static_cast<u8>(32), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(114), static_cast<u8>(111), static_cast<u8>(119), static_cast<u8>(115), static_cast<u8>(32), static_cast<u8>(45), static_cast<u8>(62), static_cast<u8>(32), static_cast<u8>(83), static_cast<u8>(116), static_cast<u8>(114), static_cast<u8>(105), static_cast<u8>(110), static_cast<u8>(103), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(102), static_cast<u8>(117), static_cast<u8>(110), static_cast<u8>(99), static_cast<u8>(116), static_cast<u8>(105), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(115), static_cast<u8>(112), static_cast<u8>(108), static_cast<u8>(105), static_cast<u8>(116), static_cast<u8>(40), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(105), static_cast<u8>(115), static_cast<u8>(44), static_cast<u8>(32), static_cast<u8>(97), static_cast<u8>(110), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(99), static_cast<u8>(58), static_cast<u8>(32), static_cast<u8>(99), static_cast<u8>(95), static_cast<u8>(99), static_cast<u8>(104), static_cast<u8>(97), static_cast<u8>(114), static_cast<u8>(41), static_cast<u8>(32), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(114), static_cast<u8>(111), static_cast<u8>(119), static_cast<u8>(115), static_cast<u8>(32), static_cast<u8>(45), static_cast<u8>(62), static_cast<u8>(32), static_cast<u8>(91), static_cast<u8>(83), static_cast<u8>(116), static_cast<u8>(114), static_cast<u8>(105), static_cast<u8>(110), static_cast<u8>(103), static_cast<u8>(93), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(102), static_cast<u8>(117), static_cast<u8>(110), static_cast<u8>(99), static_cast<u8>(116), static_cast<u8>(105), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(99), static_cast<u8>(95), static_cast<u8>(115), static_cast<u8>(116), static_cast<u8>(114), static_cast<u8>(105), static_cast<u8>(110), static_cast<u8>(103), static_cast<u8>(40), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(105), static_cast<u8>(115), static_cast<u8>(41), static_cast<u8>(32), static_cast<u8>(45), static_cast<u8>(62), static_cast<u8>(32), static_cast<u8>(114), static_cast<u8>(97), static_cast<u8>(119), static_cast<u8>(32), static_cast<u8>(99), static_cast<u8>(95), static_cast<u8>(99), static_cast<u8>(104), static_cast<u8>(97), static_cast<u8>(114), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(102), static_cast<u8>(117), static_cast<u8>(110), static_cast<u8>(99), static_cast<u8>(116), static_cast<u8>(105), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(116), static_cast<u8>(111), static_cast<u8>(95), static_cast<u8>(105), static_cast<u8>(110), static_cast<u8>(116), static_cast<u8>(40), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(105), static_cast<u8>(115), static_cast<u8>(41), static_cast<u8>(32), static_cast<u8>(45), static_cast<u8>(62), static_cast<u8>(32), static_cast<u8>(105), static_cast<u8>(51), static_cast<u8>(50), static_cast<u8>(63), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(102), static_cast<u8>(117), static_cast<u8>(110), static_cast<u8>(99), static_cast<u8>(116), static_cast<u8>(105), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(116), static_cast<u8>(111), static_cast<u8>(95), static_cast<u8>(117), static_cast<u8>(105), static_cast<u8>(110), static_cast<u8>(116), static_cast<u8>(40), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(105), static_cast<u8>(115), static_cast<u8>(41), static_cast<u8>(32), static_cast<u8>(45), static_cast<u8>(62), static_cast<u8>(32), static_cast<u8>(117), static_cast<u8>(51), static_cast<u8>(50), static_cast<u8>(63), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(102), static_cast<u8>(117), static_cast<u8>(110), static_cast<u8>(99), static_cast<u8>(116), static_cast<u8>(105), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(105), static_cast<u8>(115), static_cast<u8>(95), static_cast<u8>(119), static_cast<u8>(104), static_cast<u8>(105), static_cast<u8>(116), static_cast<u8>(101), static_cast<u8>(115), static_cast<u8>(112), static_cast<u8>(97), static_cast<u8>(99), static_cast<u8>(101), static_cast<u8>(40), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(105), static_cast<u8>(115), static_cast<u8>(41), static_cast<u8>(32), static_cast<u8>(45), static_cast<u8>(62), static_cast<u8>(32), static_cast<u8>(98), static_cast<u8>(111), static_cast<u8>(111), static_cast<u8>(108), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(102), static_cast<u8>(117), static_cast<u8>(110), static_cast<u8>(99), static_cast<u8>(116), static_cast<u8>(105), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(104), static_cast<u8>(97), static_cast<u8>(115), static_cast<u8>(104), static_cast<u8>(40), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(105), static_cast<u8>(115), static_cast<u8>(41), static_cast<u8>(32), static_cast<u8>(45), static_cast<u8>(62), static_cast<u8>(32), static_cast<u8>(117), static_cast<u8>(51), static_cast<u8>(50), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(102), static_cast<u8>(117), static_cast<u8>(110), static_cast<u8>(99), static_cast<u8>(116), static_cast<u8>(105), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(115), static_cast<u8>(117), static_cast<u8>(98), static_cast<u8>(115), static_cast<u8>(116), static_cast<u8>(114), static_cast<u8>(105), static_cast<u8>(110), static_cast<u8>(103), static_cast<u8>(40), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(105), static_cast<u8>(115), static_cast<u8>(44), static_cast<u8>(32), static_cast<u8>(115), static_cast<u8>(116), static_cast<u8>(97), static_cast<u8>(114), static_cast<u8>(116), static_cast<u8>(58), static_cast<u8>(32), static_cast<u8>(117), static_cast<u8>(115), static_cast<u8>(105), static_cast<u8>(122), static_cast<u8>(101), static_cast<u8>(44), static_cast<u8>(32), static_cast<u8>(108), static_cast<u8>(101), static_cast<u8>(110), static_cast<u8>(103), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(58), static_cast<u8>(32), static_cast<u8>(117), static_cast<u8>(115), static_cast<u8>(105), static_cast<u8>(122), static_cast<u8>(101), static_cast<u8>(41), static_cast<u8>(32), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(114), static_cast<u8>(111), static_cast<u8>(119), static_cast<u8>(115), static_cast<u8>(32), static_cast<u8>(45), static_cast<u8>(62), static_cast<u8>(32), static_cast<u8>(83), static_cast<u8>(116), static_cast<u8>(114), static_cast<u8>(105), static_cast<u8>(110), static_cast<u8>(103), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(102), static_cast<u8>(117), static_cast<u8>(110), static_cast<u8>(99), static_cast<u8>(116), static_cast<u8>(105), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(114), static_cast<u8>(101), static_cast<u8>(112), static_cast<u8>(101), static_cast<u8>(97), static_cast<u8>(116), static_cast<u8>(101), static_cast<u8>(100), static_cast<u8>(40), static_cast<u8>(99), static_cast<u8>(104), static_cast<u8>(97), static_cast<u8>(114), static_cast<u8>(97), static_cast<u8>(99), static_cast<u8>(116), static_cast<u8>(101), static_cast<u8>(114), static_cast<u8>(58), static_cast<u8>(32), static_cast<u8>(99), static_cast<u8>(95), static_cast<u8>(99), static_cast<u8>(104), static_cast<u8>(97), static_cast<u8>(114), static_cast<u8>(44), static_cast<u8>(32), static_cast<u8>(99), static_cast<u8>(111), static_cast<u8>(117), static_cast<u8>(110), static_cast<u8>(116), static_cast<u8>(58), static_cast<u8>(32), static_cast<u8>(117), static_cast<u8>(115), static_cast<u8>(105), static_cast<u8>(122), static_cast<u8>(101), static_cast<u8>(41), static_cast<u8>(32), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(114), static_cast<u8>(111), static_cast<u8>(119), static_cast<u8>(115), static_cast<u8>(32), static_cast<u8>(45), static_cast<u8>(62), static_cast<u8>(32), static_cast<u8>(83), static_cast<u8>(116), static_cast<u8>(114), static_cast<u8>(105), static_cast<u8>(110), static_cast<u8>(103), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(102), static_cast<u8>(117), static_cast<u8>(110), static_cast<u8>(99), static_cast<u8>(116), static_cast<u8>(105), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(105), static_cast<u8>(115), static_cast<u8>(95), static_cast<u8>(101), static_cast<u8>(109), static_cast<u8>(112), static_cast<u8>(116), static_cast<u8>(121), static_cast<u8>(40), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(105), static_cast<u8>(115), static_cast<u8>(41), static_cast<u8>(32), static_cast<u8>(45), static_cast<u8>(62), static_cast<u8>(32), static_cast<u8>(98), static_cast<u8>(111), static_cast<u8>(111), static_cast<u8>(108), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(102), static_cast<u8>(117), static_cast<u8>(110), static_cast<u8>(99), static_cast<u8>(116), static_cast<u8>(105), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(108), static_cast<u8>(101), static_cast<u8>(110), static_cast<u8>(103), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(40), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(105), static_cast<u8>(115), static_cast<u8>(41), static_cast<u8>(32), static_cast<u8>(45), static_cast<u8>(62), static_cast<u8>(32), static_cast<u8>(117), static_cast<u8>(115), static_cast<u8>(105), static_cast<u8>(122), static_cast<u8>(101), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(102), static_cast<u8>(117), static_cast<u8>(110), static_cast<u8>(99), static_cast<u8>(116), static_cast<u8>(105), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(98), static_cast<u8>(121), static_cast<u8>(116), static_cast<u8>(101), static_cast<u8>(95), static_cast<u8>(97), static_cast<u8>(116), static_cast<u8>(40), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(105), static_cast<u8>(115), static_cast<u8>(44), static_cast<u8>(32), static_cast<u8>(97), static_cast<u8>(110), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(105), static_cast<u8>(110), static_cast<u8>(100), static_cast<u8>(101), static_cast<u8>(120), static_cast<u8>(58), static_cast<u8>(32), static_cast<u8>(117), static_cast<u8>(115), static_cast<u8>(105), static_cast<u8>(122), static_cast<u8>(101), static_cast<u8>(41), static_cast<u8>(32), static_cast<u8>(45), static_cast<u8>(62), static_cast<u8>(32), static_cast<u8>(117), static_cast<u8>(56), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(102), static_cast<u8>(117), static_cast<u8>(110), static_cast<u8>(99), static_cast<u8>(116), static_cast<u8>(105), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(99), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(116), static_cast<u8>(97), static_cast<u8>(105), static_cast<u8>(110), static_cast<u8>(115), static_cast<u8>(40), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(105), static_cast<u8>(115), static_cast<u8>(44), static_cast<u8>(32), static_cast<u8>(97), static_cast<u8>(110), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(110), static_cast<u8>(101), static_cast<u8>(101), static_cast<u8>(100), static_cast<u8>(108), static_cast<u8>(101), static_cast<u8>(58), static_cast<u8>(32), static_cast<u8>(83), static_cast<u8>(116), static_cast<u8>(114), static_cast<u8>(105), static_cast<u8>(110), static_cast<u8>(103), static_cast<u8>(41), static_cast<u8>(32), static_cast<u8>(45), static_cast<u8>(62), static_cast<u8>(32), static_cast<u8>(98), static_cast<u8>(111), static_cast<u8>(111), static_cast<u8>(108), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(102), static_cast<u8>(117), static_cast<u8>(110), static_cast<u8>(99), static_cast<u8>(116), static_cast<u8>(105), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(114), static_cast<u8>(101), static_cast<u8>(112), static_cast<u8>(108), static_cast<u8>(97), static_cast<u8>(99), static_cast<u8>(101), static_cast<u8>(40), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(105), static_cast<u8>(115), static_cast<u8>(44), static_cast<u8>(32), static_cast<u8>(114), static_cast<u8>(101), static_cast<u8>(112), static_cast<u8>(108), static_cast<u8>(97), static_cast<u8>(99), static_cast<u8>(101), static_cast<u8>(58), static_cast<u8>(32), static_cast<u8>(83), static_cast<u8>(116), static_cast<u8>(114), static_cast<u8>(105), static_cast<u8>(110), static_cast<u8>(103), static_cast<u8>(44), static_cast<u8>(32), static_cast<u8>(119), static_cast<u8>(105), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(58), static_cast<u8>(32), static_cast<u8>(83), static_cast<u8>(116), static_cast<u8>(114), static_cast<u8>(105), static_cast<u8>(110), static_cast<u8>(103), static_cast<u8>(41), static_cast<u8>(32), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(114), static_cast<u8>(111), static_cast<u8>(119), static_cast<u8>(115), static_cast<u8>(32), static_cast<u8>(45), static_cast<u8>(62), static_cast<u8>(32), static_cast<u8>(83), static_cast<u8>(116), static_cast<u8>(114), static_cast<u8>(105), static_cast<u8>(110), static_cast<u8>(103), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(102), static_cast<u8>(117), static_cast<u8>(110), static_cast<u8>(99), static_cast<u8>(116), static_cast<u8>(105), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(115), static_cast<u8>(116), static_cast<u8>(97), static_cast<u8>(114), static_cast<u8>(116), static_cast<u8>(115), static_cast<u8>(95), static_cast<u8>(119), static_cast<u8>(105), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(40), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(105), static_cast<u8>(115), static_cast<u8>(44), static_cast<u8>(32), static_cast<u8>(97), static_cast<u8>(110), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(110), static_cast<u8>(101), static_cast<u8>(101), static_cast<u8>(100), static_cast<u8>(108), static_cast<u8>(101), static_cast<u8>(58), static_cast<u8>(32), static_cast<u8>(83), static_cast<u8>(116), static_cast<u8>(114), static_cast<u8>(105), static_cast<u8>(110), static_cast<u8>(103), static_cast<u8>(41), static_cast<u8>(32), static_cast<u8>(45), static_cast<u8>(62), static_cast<u8>(32), static_cast<u8>(98), static_cast<u8>(111), static_cast<u8>(111), static_cast<u8>(108), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(102), static_cast<u8>(117), static_cast<u8>(110), static_cast<u8>(99), static_cast<u8>(116), static_cast<u8>(105), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(101), static_cast<u8>(110), static_cast<u8>(100), static_cast<u8>(115), static_cast<u8>(95), static_cast<u8>(119), static_cast<u8>(105), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(40), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(105), static_cast<u8>(115), static_cast<u8>(44), static_cast<u8>(32), static_cast<u8>(97), static_cast<u8>(110), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(110), static_cast<u8>(101), static_cast<u8>(101), static_cast<u8>(100), static_cast<u8>(108), static_cast<u8>(101), static_cast<u8>(58), static_cast<u8>(32), static_cast<u8>(83), static_cast<u8>(116), static_cast<u8>(114), static_cast<u8>(105), static_cast<u8>(110), static_cast<u8>(103), static_cast<u8>(41), static_cast<u8>(32), static_cast<u8>(45), static_cast<u8>(62), static_cast<u8>(32), static_cast<u8>(98), static_cast<u8>(111), static_cast<u8>(111), static_cast<u8>(108), static_cast<u8>(10), static_cast<u8>(125), static_cast<u8>(10), static_cast<u8>(10), static_cast<u8>(101), static_cast<u8>(120), static_cast<u8>(116), static_cast<u8>(101), static_cast<u8>(114), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(115), static_cast<u8>(116), static_cast<u8>(114), static_cast<u8>(117), static_cast<u8>(99), static_cast<u8>(116), static_cast<u8>(32), static_cast<u8>(83), static_cast<u8>(116), static_cast<u8>(114), static_cast<u8>(105), static_cast<u8>(110), static_cast<u8>(103), static_cast<u8>(66), static_cast<u8>(117), static_cast<u8>(105), static_cast<u8>(108), static_cast<u8>(100), static_cast<u8>(101), static_cast<u8>(114), static_cast<u8>(32), static_cast<u8>(123), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(102), static_cast<u8>(117), static_cast<u8>(110), static_cast<u8>(99), static_cast<u8>(116), static_cast<u8>(105), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(97), static_cast<u8>(112), static_cast<u8>(112), static_cast<u8>(101), static_cast<u8>(110), static_cast<u8>(100), static_cast<u8>(40), static_cast<u8>(109), static_cast<u8>(117), static_cast<u8>(116), static_cast<u8>(32), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(105), static_cast<u8>(115), static_cast<u8>(44), static_cast<u8>(32), static_cast<u8>(97), static_cast<u8>(110), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(98), static_cast<u8>(58), static_cast<u8>(32), static_cast<u8>(117), static_cast<u8>(56), static_cast<u8>(41), static_cast<u8>(32), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(114), static_cast<u8>(111), static_cast<u8>(119), static_cast<u8>(115), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(102), static_cast<u8>(117), static_cast<u8>(110), static_cast<u8>(99), static_cast<u8>(116), static_cast<u8>(105), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(97), static_cast<u8>(112), static_cast<u8>(112), static_cast<u8>(101), static_cast<u8>(110), static_cast<u8>(100), static_cast<u8>(95), static_cast<u8>(115), static_cast<u8>(116), static_cast<u8>(114), static_cast<u8>(105), static_cast<u8>(110), static_cast<u8>(103), static_cast<u8>(40), static_cast<u8>(109), static_cast<u8>(117), static_cast<u8>(116), static_cast<u8>(32), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(105), static_cast<u8>(115), static_cast<u8>(44), static_cast<u8>(32), static_cast<u8>(97), static_cast<u8>(110), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(115), static_cast<u8>(58), static_cast<u8>(32), static_cast<u8>(83), static_cast<u8>(116), static_cast<u8>(114), static_cast<u8>(105), static_cast<u8>(110), static_cast<u8>(103), static_cast<u8>(41), static_cast<u8>(32), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(114), static_cast<u8>(111), static_cast<u8>(119), static_cast<u8>(115), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(102), static_cast<u8>(117), static_cast<u8>(110), static_cast<u8>(99), static_cast<u8>(116), static_cast<u8>(105), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(97), static_cast<u8>(112), static_cast<u8>(112), static_cast<u8>(101), static_cast<u8>(110), static_cast<u8>(100), static_cast<u8>(95), static_cast<u8>(99), static_cast<u8>(95), static_cast<u8>(115), static_cast<u8>(116), static_cast<u8>(114), static_cast<u8>(105), static_cast<u8>(110), static_cast<u8>(103), static_cast<u8>(40), static_cast<u8>(109), static_cast<u8>(117), static_cast<u8>(116), static_cast<u8>(32), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(105), static_cast<u8>(115), static_cast<u8>(44), static_cast<u8>(32), static_cast<u8>(97), static_cast<u8>(110), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(115), static_cast<u8>(58), static_cast<u8>(32), static_cast<u8>(114), static_cast<u8>(97), static_cast<u8>(119), static_cast<u8>(32), static_cast<u8>(99), static_cast<u8>(95), static_cast<u8>(99), static_cast<u8>(104), static_cast<u8>(97), static_cast<u8>(114), static_cast<u8>(41), static_cast<u8>(32), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(114), static_cast<u8>(111), static_cast<u8>(119), static_cast<u8>(115), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(102), static_cast<u8>(117), static_cast<u8>(110), static_cast<u8>(99), static_cast<u8>(116), static_cast<u8>(105), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(97), static_cast<u8>(112), static_cast<u8>(112), static_cast<u8>(101), static_cast<u8>(110), static_cast<u8>(100), static_cast<u8>(95), static_cast<u8>(99), static_cast<u8>(111), static_cast<u8>(100), static_cast<u8>(101), static_cast<u8>(95), static_cast<u8>(112), static_cast<u8>(111), static_cast<u8>(105), static_cast<u8>(110), static_cast<u8>(116), static_cast<u8>(40), static_cast<u8>(109), static_cast<u8>(117), static_cast<u8>(116), static_cast<u8>(32), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(105), static_cast<u8>(115), static_cast<u8>(44), static_cast<u8>(32), static_cast<u8>(97), static_cast<u8>(110), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(99), static_cast<u8>(111), static_cast<u8>(100), static_cast<u8>(101), static_cast<u8>(95), static_cast<u8>(112), static_cast<u8>(111), static_cast<u8>(105), static_cast<u8>(110), static_cast<u8>(116), static_cast<u8>(58), static_cast<u8>(32), static_cast<u8>(117), static_cast<u8>(51), static_cast<u8>(50), static_cast<u8>(41), static_cast<u8>(32), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(114), static_cast<u8>(111), static_cast<u8>(119), static_cast<u8>(115), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(102), static_cast<u8>(117), static_cast<u8>(110), static_cast<u8>(99), static_cast<u8>(116), static_cast<u8>(105), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(97), static_cast<u8>(112), static_cast<u8>(112), static_cast<u8>(101), static_cast<u8>(110), static_cast<u8>(100), static_cast<u8>(95), static_cast<u8>(101), static_cast<u8>(115), static_cast<u8>(99), static_cast<u8>(97), static_cast<u8>(112), static_cast<u8>(101), static_cast<u8>(100), static_cast<u8>(95), static_cast<u8>(102), static_cast<u8>(111), static_cast<u8>(114), static_cast<u8>(95), static_cast<u8>(106), static_cast<u8>(115), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(40), static_cast<u8>(109), static_cast<u8>(117), static_cast<u8>(116), static_cast<u8>(32), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(105), static_cast<u8>(115), static_cast<u8>(44), static_cast<u8>(32), static_cast<u8>(97), static_cast<u8>(110), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(115), static_cast<u8>(58), static_cast<u8>(32), static_cast<u8>(83), static_cast<u8>(116), static_cast<u8>(114), static_cast<u8>(105), static_cast<u8>(110), static_cast<u8>(103), static_cast<u8>(41), static_cast<u8>(32), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(114), static_cast<u8>(111), static_cast<u8>(119), static_cast<u8>(115), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(102), static_cast<u8>(117), static_cast<u8>(110), static_cast<u8>(99), static_cast<u8>(116), static_cast<u8>(105), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(116), static_cast<u8>(111), static_cast<u8>(95), static_cast<u8>(115), static_cast<u8>(116), static_cast<u8>(114), static_cast<u8>(105), static_cast<u8>(110), static_cast<u8>(103), static_cast<u8>(40), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(105), static_cast<u8>(115), static_cast<u8>(41), static_cast<u8>(32), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(114), static_cast<u8>(111), static_cast<u8>(119), static_cast<u8>(115), static_cast<u8>(32), static_cast<u8>(45), static_cast<u8>(62), static_cast<u8>(32), static_cast<u8>(83), static_cast<u8>(116), static_cast<u8>(114), static_cast<u8>(105), static_cast<u8>(110), static_cast<u8>(103), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(102), static_cast<u8>(117), static_cast<u8>(110), static_cast<u8>(99), static_cast<u8>(116), static_cast<u8>(105), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(105), static_cast<u8>(115), static_cast<u8>(95), static_cast<u8>(101), static_cast<u8>(109), static_cast<u8>(112), static_cast<u8>(116), static_cast<u8>(121), static_cast<u8>(40), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(105), static_cast<u8>(115), static_cast<u8>(41), static_cast<u8>(32), static_cast<u8>(45), static_cast<u8>(62), static_cast<u8>(32), static_cast<u8>(98), static_cast<u8>(111), static_cast<u8>(111), static_cast<u8>(108), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(102), static_cast<u8>(117), static_cast<u8>(110), static_cast<u8>(99), static_cast<u8>(116), static_cast<u8>(105), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(108), static_cast<u8>(101), static_cast<u8>(110), static_cast<u8>(103), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(40), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(105), static_cast<u8>(115), static_cast<u8>(41), static_cast<u8>(32), static_cast<u8>(45), static_cast<u8>(62), static_cast<u8>(32), static_cast<u8>(117), static_cast<u8>(115), static_cast<u8>(105), static_cast<u8>(122), static_cast<u8>(101), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(102), static_cast<u8>(117), static_cast<u8>(110), static_cast<u8>(99), static_cast<u8>(116), static_cast<u8>(105), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(99), static_cast<u8>(108), static_cast<u8>(101), static_cast<u8>(97), static_cast<u8>(114), static_cast<u8>(40), static_cast<u8>(109), static_cast<u8>(117), static_cast<u8>(116), static_cast<u8>(32), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(105), static_cast<u8>(115), static_cast<u8>(41), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(102), static_cast<u8>(117), static_cast<u8>(110), static_cast<u8>(99), static_cast<u8>(116), static_cast<u8>(105), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(99), static_cast<u8>(114), static_cast<u8>(101), static_cast<u8>(97), static_cast<u8>(116), static_cast<u8>(101), static_cast<u8>(40), static_cast<u8>(41), static_cast<u8>(32), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(114), static_cast<u8>(111), static_cast<u8>(119), static_cast<u8>(115), static_cast<u8>(32), static_cast<u8>(45), static_cast<u8>(62), static_cast<u8>(32), static_cast<u8>(83), static_cast<u8>(116), static_cast<u8>(114), static_cast<u8>(105), static_cast<u8>(110), static_cast<u8>(103), static_cast<u8>(66), static_cast<u8>(117), static_cast<u8>(105), static_cast<u8>(108), static_cast<u8>(100), static_cast<u8>(101), static_cast<u8>(114), static_cast<u8>(10), static_cast<u8>(125), static_cast<u8>(10), static_cast<u8>(10), static_cast<u8>(101), static_cast<u8>(120), static_cast<u8>(116), static_cast<u8>(101), static_cast<u8>(114), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(115), static_cast<u8>(116), static_cast<u8>(114), static_cast<u8>(117), static_cast<u8>(99), static_cast<u8>(116), static_cast<u8>(32), static_cast<u8>(87), static_cast<u8>(101), static_cast<u8>(97), static_cast<u8>(107), static_cast<u8>(80), static_cast<u8>(116), static_cast<u8>(114), static_cast<u8>(60), static_cast<u8>(84), static_cast<u8>(62), static_cast<u8>(32), static_cast<u8>(123), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(102), static_cast<u8>(117), static_cast<u8>(110), static_cast<u8>(99), static_cast<u8>(116), static_cast<u8>(105), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(104), static_cast<u8>(97), static_cast<u8>(115), static_cast<u8>(95), static_cast<u8>(118), static_cast<u8>(97), static_cast<u8>(108), static_cast<u8>(117), static_cast<u8>(101), static_cast<u8>(40), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(105), static_cast<u8>(115), static_cast<u8>(41), static_cast<u8>(32), static_cast<u8>(45), static_cast<u8>(62), static_cast<u8>(32), static_cast<u8>(98), static_cast<u8>(111), static_cast<u8>(111), static_cast<u8>(108), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(102), static_cast<u8>(117), static_cast<u8>(110), static_cast<u8>(99), static_cast<u8>(116), static_cast<u8>(105), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(99), static_cast<u8>(108), static_cast<u8>(101), static_cast<u8>(97), static_cast<u8>(114), static_cast<u8>(40), static_cast<u8>(109), static_cast<u8>(117), static_cast<u8>(116), static_cast<u8>(32), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(105), static_cast<u8>(115), static_cast<u8>(41), static_cast<u8>(10), static_cast<u8>(125), static_cast<u8>(10), static_cast<u8>(10), static_cast<u8>(101), static_cast<u8>(120), static_cast<u8>(116), static_cast<u8>(101), static_cast<u8>(114), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(115), static_cast<u8>(116), static_cast<u8>(114), static_cast<u8>(117), static_cast<u8>(99), static_cast<u8>(116), static_cast<u8>(32), static_cast<u8>(84), static_cast<u8>(117), static_cast<u8>(112), static_cast<u8>(108), static_cast<u8>(101), static_cast<u8>(32), static_cast<u8>(123), static_cast<u8>(125), static_cast<u8>(10), static_cast<u8>(10), static_cast<u8>(101), static_cast<u8>(120), static_cast<u8>(116), static_cast<u8>(101), static_cast<u8>(114), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(115), static_cast<u8>(116), static_cast<u8>(114), static_cast<u8>(117), static_cast<u8>(99), static_cast<u8>(116), static_cast<u8>(32), static_cast<u8>(68), static_cast<u8>(105), static_cast<u8>(99), static_cast<u8>(116), static_cast<u8>(105), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(97), static_cast<u8>(114), static_cast<u8>(121), static_cast<u8>(73), static_cast<u8>(116), static_cast<u8>(101), static_cast<u8>(114), static_cast<u8>(97), static_cast<u8>(116), static_cast<u8>(111), static_cast<u8>(114), static_cast<u8>(60), static_cast<u8>(75), static_cast<u8>(44), static_cast<u8>(32), static_cast<u8>(86), static_cast<u8>(62), static_cast<u8>(32), static_cast<u8>(123), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(102), static_cast<u8>(117), static_cast<u8>(110), static_cast<u8>(99), static_cast<u8>(116), static_cast<u8>(105), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(110), static_cast<u8>(101), static_cast<u8>(120), static_cast<u8>(116), static_cast<u8>(40), static_cast<u8>(109), static_cast<u8>(117), static_cast<u8>(116), static_cast<u8>(32), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(105), static_cast<u8>(115), static_cast<u8>(41), static_cast<u8>(32), static_cast<u8>(45), static_cast<u8>(62), static_cast<u8>(32), static_cast<u8>(40), static_cast<u8>(75), static_cast<u8>(44), static_cast<u8>(32), static_cast<u8>(86), static_cast<u8>(41), static_cast<u8>(63), static_cast<u8>(10), static_cast<u8>(125), static_cast<u8>(10), static_cast<u8>(10), static_cast<u8>(101), static_cast<u8>(120), static_cast<u8>(116), static_cast<u8>(101), static_cast<u8>(114), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(115), static_cast<u8>(116), static_cast<u8>(114), static_cast<u8>(117), static_cast<u8>(99), static_cast<u8>(116), static_cast<u8>(32), static_cast<u8>(68), static_cast<u8>(105), static_cast<u8>(99), static_cast<u8>(116), static_cast<u8>(105), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(97), static_cast<u8>(114), static_cast<u8>(121), static_cast<u8>(60), static_cast<u8>(75), static_cast<u8>(44), static_cast<u8>(32), static_cast<u8>(86), static_cast<u8>(62), static_cast<u8>(32), static_cast<u8>(123), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(102), static_cast<u8>(117), static_cast<u8>(110), static_cast<u8>(99), static_cast<u8>(116), static_cast<u8>(105), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(105), static_cast<u8>(115), static_cast<u8>(95), static_cast<u8>(101), static_cast<u8>(109), static_cast<u8>(112), static_cast<u8>(116), static_cast<u8>(121), static_cast<u8>(40), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(105), static_cast<u8>(115), static_cast<u8>(41), static_cast<u8>(32), static_cast<u8>(45), static_cast<u8>(62), static_cast<u8>(32), static_cast<u8>(98), static_cast<u8>(111), static_cast<u8>(111), static_cast<u8>(108), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(102), static_cast<u8>(117), static_cast<u8>(110), static_cast<u8>(99), static_cast<u8>(116), static_cast<u8>(105), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(103), static_cast<u8>(101), static_cast<u8>(116), static_cast<u8>(40), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(105), static_cast<u8>(115), static_cast<u8>(44), static_cast<u8>(32), static_cast<u8>(97), static_cast<u8>(110), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(107), static_cast<u8>(101), static_cast<u8>(121), static_cast<u8>(58), static_cast<u8>(32), static_cast<u8>(75), static_cast<u8>(41), static_cast<u8>(32), static_cast<u8>(45), static_cast<u8>(62), static_cast<u8>(32), static_cast<u8>(86), static_cast<u8>(63), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(102), static_cast<u8>(117), static_cast<u8>(110), static_cast<u8>(99), static_cast<u8>(116), static_cast<u8>(105), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(99), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(116), static_cast<u8>(97), static_cast<u8>(105), static_cast<u8>(110), static_cast<u8>(115), static_cast<u8>(40), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(105), static_cast<u8>(115), static_cast<u8>(44), static_cast<u8>(32), static_cast<u8>(97), static_cast<u8>(110), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(107), static_cast<u8>(101), static_cast<u8>(121), static_cast<u8>(58), static_cast<u8>(32), static_cast<u8>(75), static_cast<u8>(41), static_cast<u8>(32), static_cast<u8>(45), static_cast<u8>(62), static_cast<u8>(32), static_cast<u8>(98), static_cast<u8>(111), static_cast<u8>(111), static_cast<u8>(108), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(102), static_cast<u8>(117), static_cast<u8>(110), static_cast<u8>(99), static_cast<u8>(116), static_cast<u8>(105), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(115), static_cast<u8>(101), static_cast<u8>(116), static_cast<u8>(40), static_cast<u8>(109), static_cast<u8>(117), static_cast<u8>(116), static_cast<u8>(32), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(105), static_cast<u8>(115), static_cast<u8>(44), static_cast<u8>(32), static_cast<u8>(97), static_cast<u8>(110), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(107), static_cast<u8>(101), static_cast<u8>(121), static_cast<u8>(58), static_cast<u8>(32), static_cast<u8>(75), static_cast<u8>(44), static_cast<u8>(32), static_cast<u8>(97), static_cast<u8>(110), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(118), static_cast<u8>(97), static_cast<u8>(108), static_cast<u8>(117), static_cast<u8>(101), static_cast<u8>(58), static_cast<u8>(32), static_cast<u8>(86), static_cast<u8>(41), static_cast<u8>(32), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(114), static_cast<u8>(111), static_cast<u8>(119), static_cast<u8>(115), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(102), static_cast<u8>(117), static_cast<u8>(110), static_cast<u8>(99), static_cast<u8>(116), static_cast<u8>(105), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(114), static_cast<u8>(101), static_cast<u8>(109), static_cast<u8>(111), static_cast<u8>(118), static_cast<u8>(101), static_cast<u8>(40), static_cast<u8>(109), static_cast<u8>(117), static_cast<u8>(116), static_cast<u8>(32), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(105), static_cast<u8>(115), static_cast<u8>(44), static_cast<u8>(32), static_cast<u8>(97), static_cast<u8>(110), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(107), static_cast<u8>(101), static_cast<u8>(121), static_cast<u8>(58), static_cast<u8>(32), static_cast<u8>(75), static_cast<u8>(41), static_cast<u8>(32), static_cast<u8>(45), static_cast<u8>(62), static_cast<u8>(32), static_cast<u8>(98), static_cast<u8>(111), static_cast<u8>(111), static_cast<u8>(108), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(102), static_cast<u8>(117), static_cast<u8>(110), static_cast<u8>(99), static_cast<u8>(116), static_cast<u8>(105), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(101), static_cast<u8>(110), static_cast<u8>(115), static_cast<u8>(117), static_cast<u8>(114), static_cast<u8>(101), static_cast<u8>(95), static_cast<u8>(99), static_cast<u8>(97), static_cast<u8>(112), static_cast<u8>(97), static_cast<u8>(99), static_cast<u8>(105), static_cast<u8>(116), static_cast<u8>(121), static_cast<u8>(40), static_cast<u8>(109), static_cast<u8>(117), static_cast<u8>(116), static_cast<u8>(32), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(105), static_cast<u8>(115), static_cast<u8>(44), static_cast<u8>(32), static_cast<u8>(97), static_cast<u8>(110), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(99), static_cast<u8>(97), static_cast<u8>(112), static_cast<u8>(97), static_cast<u8>(99), static_cast<u8>(105), static_cast<u8>(116), static_cast<u8>(121), static_cast<u8>(58), static_cast<u8>(32), static_cast<u8>(117), static_cast<u8>(115), static_cast<u8>(105), static_cast<u8>(122), static_cast<u8>(101), static_cast<u8>(41), static_cast<u8>(32), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(114), static_cast<u8>(111), static_cast<u8>(119), static_cast<u8>(115), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(102), static_cast<u8>(117), static_cast<u8>(110), static_cast<u8>(99), static_cast<u8>(116), static_cast<u8>(105), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(99), static_cast<u8>(108), static_cast<u8>(101), static_cast<u8>(97), static_cast<u8>(114), static_cast<u8>(40), static_cast<u8>(109), static_cast<u8>(117), static_cast<u8>(116), static_cast<u8>(32), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(105), static_cast<u8>(115), static_cast<u8>(41), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(102), static_cast<u8>(117), static_cast<u8>(110), static_cast<u8>(99), static_cast<u8>(116), static_cast<u8>(105), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(115), static_cast<u8>(105), static_cast<u8>(122), static_cast<u8>(101), static_cast<u8>(40), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(105), static_cast<u8>(115), static_cast<u8>(41), static_cast<u8>(32), static_cast<u8>(45), static_cast<u8>(62), static_cast<u8>(32), static_cast<u8>(117), static_cast<u8>(115), static_cast<u8>(105), static_cast<u8>(122), static_cast<u8>(101), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(102), static_cast<u8>(117), static_cast<u8>(110), static_cast<u8>(99), static_cast<u8>(116), static_cast<u8>(105), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(99), static_cast<u8>(97), static_cast<u8>(112), static_cast<u8>(97), static_cast<u8>(99), static_cast<u8>(105), static_cast<u8>(116), static_cast<u8>(121), static_cast<u8>(40), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(105), static_cast<u8>(115), static_cast<u8>(41), static_cast<u8>(32), static_cast<u8>(45), static_cast<u8>(62), static_cast<u8>(32), static_cast<u8>(117), static_cast<u8>(115), static_cast<u8>(105), static_cast<u8>(122), static_cast<u8>(101), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(102), static_cast<u8>(117), static_cast<u8>(110), static_cast<u8>(99), static_cast<u8>(116), static_cast<u8>(105), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(107), static_cast<u8>(101), static_cast<u8>(121), static_cast<u8>(115), static_cast<u8>(40), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(105), static_cast<u8>(115), static_cast<u8>(41), static_cast<u8>(32), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(114), static_cast<u8>(111), static_cast<u8>(119), static_cast<u8>(115), static_cast<u8>(32), static_cast<u8>(45), static_cast<u8>(62), static_cast<u8>(32), static_cast<u8>(91), static_cast<u8>(75), static_cast<u8>(93), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(102), static_cast<u8>(117), static_cast<u8>(110), static_cast<u8>(99), static_cast<u8>(116), static_cast<u8>(105), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(104), static_cast<u8>(97), static_cast<u8>(115), static_cast<u8>(104), static_cast<u8>(40), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(105), static_cast<u8>(115), static_cast<u8>(41), static_cast<u8>(32), static_cast<u8>(45), static_cast<u8>(62), static_cast<u8>(32), static_cast<u8>(117), static_cast<u8>(51), static_cast<u8>(50), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(102), static_cast<u8>(117), static_cast<u8>(110), static_cast<u8>(99), static_cast<u8>(116), static_cast<u8>(105), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(68), static_cast<u8>(105), static_cast<u8>(99), static_cast<u8>(116), static_cast<u8>(105), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(97), static_cast<u8>(114), static_cast<u8>(121), static_cast<u8>(60), static_cast<u8>(65), static_cast<u8>(44), static_cast<u8>(32), static_cast<u8>(66), static_cast<u8>(62), static_cast<u8>(40), static_cast<u8>(41), static_cast<u8>(32), static_cast<u8>(45), static_cast<u8>(62), static_cast<u8>(32), static_cast<u8>(68), static_cast<u8>(105), static_cast<u8>(99), static_cast<u8>(116), static_cast<u8>(105), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(97), static_cast<u8>(114), static_cast<u8>(121), static_cast<u8>(60), static_cast<u8>(65), static_cast<u8>(44), static_cast<u8>(32), static_cast<u8>(66), static_cast<u8>(62), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(102), static_cast<u8>(117), static_cast<u8>(110), static_cast<u8>(99), static_cast<u8>(116), static_cast<u8>(105), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(105), static_cast<u8>(116), static_cast<u8>(101), static_cast<u8>(114), static_cast<u8>(97), static_cast<u8>(116), static_cast<u8>(111), static_cast<u8>(114), static_cast<u8>(40), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(105), static_cast<u8>(115), static_cast<u8>(41), static_cast<u8>(32), static_cast<u8>(45), static_cast<u8>(62), static_cast<u8>(32), static_cast<u8>(68), static_cast<u8>(105), static_cast<u8>(99), static_cast<u8>(116), static_cast<u8>(105), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(97), static_cast<u8>(114), static_cast<u8>(121), static_cast<u8>(73), static_cast<u8>(116), static_cast<u8>(101), static_cast<u8>(114), static_cast<u8>(97), static_cast<u8>(116), static_cast<u8>(111), static_cast<u8>(114), static_cast<u8>(60), static_cast<u8>(75), static_cast<u8>(44), static_cast<u8>(32), static_cast<u8>(86), static_cast<u8>(62), static_cast<u8>(10), static_cast<u8>(125), static_cast<u8>(10), static_cast<u8>(10), static_cast<u8>(101), static_cast<u8>(120), static_cast<u8>(116), static_cast<u8>(101), static_cast<u8>(114), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(115), static_cast<u8>(116), static_cast<u8>(114), static_cast<u8>(117), static_cast<u8>(99), static_cast<u8>(116), static_cast<u8>(32), static_cast<u8>(83), static_cast<u8>(101), static_cast<u8>(116), static_cast<u8>(73), static_cast<u8>(116), static_cast<u8>(101), static_cast<u8>(114), static_cast<u8>(97), static_cast<u8>(116), static_cast<u8>(111), static_cast<u8>(114), static_cast<u8>(60), static_cast<u8>(84), static_cast<u8>(62), static_cast<u8>(32), static_cast<u8>(123), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(102), static_cast<u8>(117), static_cast<u8>(110), static_cast<u8>(99), static_cast<u8>(116), static_cast<u8>(105), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(110), static_cast<u8>(101), static_cast<u8>(120), static_cast<u8>(116), static_cast<u8>(40), static_cast<u8>(109), static_cast<u8>(117), static_cast<u8>(116), static_cast<u8>(32), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(105), static_cast<u8>(115), static_cast<u8>(41), static_cast<u8>(32), static_cast<u8>(45), static_cast<u8>(62), static_cast<u8>(32), static_cast<u8>(84), static_cast<u8>(63), static_cast<u8>(10), static_cast<u8>(125), static_cast<u8>(10), static_cast<u8>(10), static_cast<u8>(101), static_cast<u8>(120), static_cast<u8>(116), static_cast<u8>(101), static_cast<u8>(114), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(115), static_cast<u8>(116), static_cast<u8>(114), static_cast<u8>(117), static_cast<u8>(99), static_cast<u8>(116), static_cast<u8>(32), static_cast<u8>(83), static_cast<u8>(101), static_cast<u8>(116), static_cast<u8>(60), static_cast<u8>(86), static_cast<u8>(62), static_cast<u8>(32), static_cast<u8>(123), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(102), static_cast<u8>(117), static_cast<u8>(110), static_cast<u8>(99), static_cast<u8>(116), static_cast<u8>(105), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(105), static_cast<u8>(115), static_cast<u8>(95), static_cast<u8>(101), static_cast<u8>(109), static_cast<u8>(112), static_cast<u8>(116), static_cast<u8>(121), static_cast<u8>(40), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(105), static_cast<u8>(115), static_cast<u8>(41), static_cast<u8>(32), static_cast<u8>(45), static_cast<u8>(62), static_cast<u8>(32), static_cast<u8>(98), static_cast<u8>(111), static_cast<u8>(111), static_cast<u8>(108), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(102), static_cast<u8>(117), static_cast<u8>(110), static_cast<u8>(99), static_cast<u8>(116), static_cast<u8>(105), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(99), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(116), static_cast<u8>(97), static_cast<u8>(105), static_cast<u8>(110), static_cast<u8>(115), static_cast<u8>(40), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(105), static_cast<u8>(115), static_cast<u8>(44), static_cast<u8>(32), static_cast<u8>(97), static_cast<u8>(110), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(118), static_cast<u8>(97), static_cast<u8>(108), static_cast<u8>(117), static_cast<u8>(101), static_cast<u8>(58), static_cast<u8>(32), static_cast<u8>(86), static_cast<u8>(41), static_cast<u8>(32), static_cast<u8>(45), static_cast<u8>(62), static_cast<u8>(32), static_cast<u8>(98), static_cast<u8>(111), static_cast<u8>(111), static_cast<u8>(108), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(102), static_cast<u8>(117), static_cast<u8>(110), static_cast<u8>(99), static_cast<u8>(116), static_cast<u8>(105), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(97), static_cast<u8>(100), static_cast<u8>(100), static_cast<u8>(40), static_cast<u8>(109), static_cast<u8>(117), static_cast<u8>(116), static_cast<u8>(32), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(105), static_cast<u8>(115), static_cast<u8>(44), static_cast<u8>(32), static_cast<u8>(97), static_cast<u8>(110), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(118), static_cast<u8>(97), static_cast<u8>(108), static_cast<u8>(117), static_cast<u8>(101), static_cast<u8>(58), static_cast<u8>(32), static_cast<u8>(86), static_cast<u8>(41), static_cast<u8>(32), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(114), static_cast<u8>(111), static_cast<u8>(119), static_cast<u8>(115), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(102), static_cast<u8>(117), static_cast<u8>(110), static_cast<u8>(99), static_cast<u8>(116), static_cast<u8>(105), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(114), static_cast<u8>(101), static_cast<u8>(109), static_cast<u8>(111), static_cast<u8>(118), static_cast<u8>(101), static_cast<u8>(40), static_cast<u8>(109), static_cast<u8>(117), static_cast<u8>(116), static_cast<u8>(32), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(105), static_cast<u8>(115), static_cast<u8>(44), static_cast<u8>(32), static_cast<u8>(97), static_cast<u8>(110), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(118), static_cast<u8>(97), static_cast<u8>(108), static_cast<u8>(117), static_cast<u8>(101), static_cast<u8>(58), static_cast<u8>(32), static_cast<u8>(86), static_cast<u8>(41), static_cast<u8>(32), static_cast<u8>(45), static_cast<u8>(62), static_cast<u8>(32), static_cast<u8>(98), static_cast<u8>(111), static_cast<u8>(111), static_cast<u8>(108), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(102), static_cast<u8>(117), static_cast<u8>(110), static_cast<u8>(99), static_cast<u8>(116), static_cast<u8>(105), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(101), static_cast<u8>(110), static_cast<u8>(115), static_cast<u8>(117), static_cast<u8>(114), static_cast<u8>(101), static_cast<u8>(95), static_cast<u8>(99), static_cast<u8>(97), static_cast<u8>(112), static_cast<u8>(97), static_cast<u8>(99), static_cast<u8>(105), static_cast<u8>(116), static_cast<u8>(121), static_cast<u8>(40), static_cast<u8>(109), static_cast<u8>(117), static_cast<u8>(116), static_cast<u8>(32), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(105), static_cast<u8>(115), static_cast<u8>(44), static_cast<u8>(32), static_cast<u8>(97), static_cast<u8>(110), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(99), static_cast<u8>(97), static_cast<u8>(112), static_cast<u8>(97), static_cast<u8>(99), static_cast<u8>(105), static_cast<u8>(116), static_cast<u8>(121), static_cast<u8>(58), static_cast<u8>(32), static_cast<u8>(117), static_cast<u8>(115), static_cast<u8>(105), static_cast<u8>(122), static_cast<u8>(101), static_cast<u8>(41), static_cast<u8>(32), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(114), static_cast<u8>(111), static_cast<u8>(119), static_cast<u8>(115), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(102), static_cast<u8>(117), static_cast<u8>(110), static_cast<u8>(99), static_cast<u8>(116), static_cast<u8>(105), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(99), static_cast<u8>(108), static_cast<u8>(101), static_cast<u8>(97), static_cast<u8>(114), static_cast<u8>(40), static_cast<u8>(109), static_cast<u8>(117), static_cast<u8>(116), static_cast<u8>(32), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(105), static_cast<u8>(115), static_cast<u8>(41), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(102), static_cast<u8>(117), static_cast<u8>(110), static_cast<u8>(99), static_cast<u8>(116), static_cast<u8>(105), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(115), static_cast<u8>(105), static_cast<u8>(122), static_cast<u8>(101), static_cast<u8>(40), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(105), static_cast<u8>(115), static_cast<u8>(41), static_cast<u8>(32), static_cast<u8>(45), static_cast<u8>(62), static_cast<u8>(32), static_cast<u8>(117), static_cast<u8>(115), static_cast<u8>(105), static_cast<u8>(122), static_cast<u8>(101), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(102), static_cast<u8>(117), static_cast<u8>(110), static_cast<u8>(99), static_cast<u8>(116), static_cast<u8>(105), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(99), static_cast<u8>(97), static_cast<u8>(112), static_cast<u8>(97), static_cast<u8>(99), static_cast<u8>(105), static_cast<u8>(116), static_cast<u8>(121), static_cast<u8>(40), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(105), static_cast<u8>(115), static_cast<u8>(41), static_cast<u8>(32), static_cast<u8>(45), static_cast<u8>(62), static_cast<u8>(32), static_cast<u8>(117), static_cast<u8>(115), static_cast<u8>(105), static_cast<u8>(122), static_cast<u8>(101), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(102), static_cast<u8>(117), static_cast<u8>(110), static_cast<u8>(99), static_cast<u8>(116), static_cast<u8>(105), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(104), static_cast<u8>(97), static_cast<u8>(115), static_cast<u8>(104), static_cast<u8>(40), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(105), static_cast<u8>(115), static_cast<u8>(41), static_cast<u8>(32), static_cast<u8>(45), static_cast<u8>(62), static_cast<u8>(32), static_cast<u8>(117), static_cast<u8>(51), static_cast<u8>(50), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(102), static_cast<u8>(117), static_cast<u8>(110), static_cast<u8>(99), static_cast<u8>(116), static_cast<u8>(105), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(83), static_cast<u8>(101), static_cast<u8>(116), static_cast<u8>(60), static_cast<u8>(65), static_cast<u8>(62), static_cast<u8>(40), static_cast<u8>(41), static_cast<u8>(32), static_cast<u8>(45), static_cast<u8>(62), static_cast<u8>(32), static_cast<u8>(83), static_cast<u8>(101), static_cast<u8>(116), static_cast<u8>(60), static_cast<u8>(65), static_cast<u8>(62), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(102), static_cast<u8>(117), static_cast<u8>(110), static_cast<u8>(99), static_cast<u8>(116), static_cast<u8>(105), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(105), static_cast<u8>(116), static_cast<u8>(101), static_cast<u8>(114), static_cast<u8>(97), static_cast<u8>(116), static_cast<u8>(111), static_cast<u8>(114), static_cast<u8>(40), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(105), static_cast<u8>(115), static_cast<u8>(41), static_cast<u8>(32), static_cast<u8>(45), static_cast<u8>(62), static_cast<u8>(32), static_cast<u8>(83), static_cast<u8>(101), static_cast<u8>(116), static_cast<u8>(73), static_cast<u8>(116), static_cast<u8>(101), static_cast<u8>(114), static_cast<u8>(97), static_cast<u8>(116), static_cast<u8>(111), static_cast<u8>(114), static_cast<u8>(60), static_cast<u8>(86), static_cast<u8>(62), static_cast<u8>(10), static_cast<u8>(125), static_cast<u8>(10), static_cast<u8>(10), static_cast<u8>(101), static_cast<u8>(120), static_cast<u8>(116), static_cast<u8>(101), static_cast<u8>(114), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(115), static_cast<u8>(116), static_cast<u8>(114), static_cast<u8>(117), static_cast<u8>(99), static_cast<u8>(116), static_cast<u8>(32), static_cast<u8>(82), static_cast<u8>(97), static_cast<u8>(110), static_cast<u8>(103), static_cast<u8>(101), static_cast<u8>(60), static_cast<u8>(84), static_cast<u8>(62), static_cast<u8>(32), static_cast<u8>(123), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(102), static_cast<u8>(117), static_cast<u8>(110), static_cast<u8>(99), static_cast<u8>(116), static_cast<u8>(105), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(82), static_cast<u8>(97), static_cast<u8>(110), static_cast<u8>(103), static_cast<u8>(101), static_cast<u8>(60), static_cast<u8>(85), static_cast<u8>(62), static_cast<u8>(40), static_cast<u8>(97), static_cast<u8>(110), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(115), static_cast<u8>(116), static_cast<u8>(97), static_cast<u8>(114), static_cast<u8>(116), static_cast<u8>(58), static_cast<u8>(32), static_cast<u8>(85), static_cast<u8>(44), static_cast<u8>(32), static_cast<u8>(97), static_cast<u8>(110), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(101), static_cast<u8>(110), static_cast<u8>(100), static_cast<u8>(58), static_cast<u8>(32), static_cast<u8>(85), static_cast<u8>(41), static_cast<u8>(32), static_cast<u8>(45), static_cast<u8>(62), static_cast<u8>(32), static_cast<u8>(82), static_cast<u8>(97), static_cast<u8>(110), static_cast<u8>(103), static_cast<u8>(101), static_cast<u8>(60), static_cast<u8>(85), static_cast<u8>(62), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(102), static_cast<u8>(117), static_cast<u8>(110), static_cast<u8>(99), static_cast<u8>(116), static_cast<u8>(105), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(110), static_cast<u8>(101), static_cast<u8>(120), static_cast<u8>(116), static_cast<u8>(40), static_cast<u8>(109), static_cast<u8>(117), static_cast<u8>(116), static_cast<u8>(32), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(105), static_cast<u8>(115), static_cast<u8>(41), static_cast<u8>(32), static_cast<u8>(45), static_cast<u8>(62), static_cast<u8>(32), static_cast<u8>(84), static_cast<u8>(63), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(102), static_cast<u8>(117), static_cast<u8>(110), static_cast<u8>(99), static_cast<u8>(116), static_cast<u8>(105), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(105), static_cast<u8>(110), static_cast<u8>(99), static_cast<u8>(108), static_cast<u8>(117), static_cast<u8>(115), static_cast<u8>(105), static_cast<u8>(118), static_cast<u8>(101), static_cast<u8>(40), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(105), static_cast<u8>(115), static_cast<u8>(41), static_cast<u8>(32), static_cast<u8>(45), static_cast<u8>(62), static_cast<u8>(32), static_cast<u8>(82), static_cast<u8>(97), static_cast<u8>(110), static_cast<u8>(103), static_cast<u8>(101), static_cast<u8>(60), static_cast<u8>(84), static_cast<u8>(62), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(102), static_cast<u8>(117), static_cast<u8>(110), static_cast<u8>(99), static_cast<u8>(116), static_cast<u8>(105), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(101), static_cast<u8>(120), static_cast<u8>(99), static_cast<u8>(108), static_cast<u8>(117), static_cast<u8>(115), static_cast<u8>(105), static_cast<u8>(118), static_cast<u8>(101), static_cast<u8>(40), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(105), static_cast<u8>(115), static_cast<u8>(41), static_cast<u8>(32), static_cast<u8>(45), static_cast<u8>(62), static_cast<u8>(32), static_cast<u8>(82), static_cast<u8>(97), static_cast<u8>(110), static_cast<u8>(103), static_cast<u8>(101), static_cast<u8>(60), static_cast<u8>(84), static_cast<u8>(62), static_cast<u8>(10), static_cast<u8>(125), static_cast<u8>(10), static_cast<u8>(10), static_cast<u8>(101), static_cast<u8>(120), static_cast<u8>(116), static_cast<u8>(101), static_cast<u8>(114), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(115), static_cast<u8>(116), static_cast<u8>(114), static_cast<u8>(117), static_cast<u8>(99), static_cast<u8>(116), static_cast<u8>(32), static_cast<u8>(69), static_cast<u8>(114), static_cast<u8>(114), static_cast<u8>(111), static_cast<u8>(114), static_cast<u8>(32), static_cast<u8>(123), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(102), static_cast<u8>(117), static_cast<u8>(110), static_cast<u8>(99), static_cast<u8>(116), static_cast<u8>(105), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(99), static_cast<u8>(111), static_cast<u8>(100), static_cast<u8>(101), static_cast<u8>(40), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(105), static_cast<u8>(115), static_cast<u8>(41), static_cast<u8>(32), static_cast<u8>(45), static_cast<u8>(62), static_cast<u8>(32), static_cast<u8>(105), static_cast<u8>(51), static_cast<u8>(50), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(102), static_cast<u8>(117), static_cast<u8>(110), static_cast<u8>(99), static_cast<u8>(116), static_cast<u8>(105), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(102), static_cast<u8>(114), static_cast<u8>(111), static_cast<u8>(109), static_cast<u8>(95), static_cast<u8>(101), static_cast<u8>(114), static_cast<u8>(114), static_cast<u8>(110), static_cast<u8>(111), static_cast<u8>(40), static_cast<u8>(97), static_cast<u8>(110), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(101), static_cast<u8>(114), static_cast<u8>(114), static_cast<u8>(110), static_cast<u8>(111), static_cast<u8>(58), static_cast<u8>(32), static_cast<u8>(105), static_cast<u8>(51), static_cast<u8>(50), static_cast<u8>(41), static_cast<u8>(32), static_cast<u8>(45), static_cast<u8>(62), static_cast<u8>(32), static_cast<u8>(69), static_cast<u8>(114), static_cast<u8>(114), static_cast<u8>(111), static_cast<u8>(114), static_cast<u8>(10), static_cast<u8>(125), static_cast<u8>(10), static_cast<u8>(10), static_cast<u8>(101), static_cast<u8>(120), static_cast<u8>(116), static_cast<u8>(101), static_cast<u8>(114), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(99), static_cast<u8>(108), static_cast<u8>(97), static_cast<u8>(115), static_cast<u8>(115), static_cast<u8>(32), static_cast<u8>(70), static_cast<u8>(105), static_cast<u8>(108), static_cast<u8>(101), static_cast<u8>(32), static_cast<u8>(123), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(112), static_cast<u8>(117), static_cast<u8>(98), static_cast<u8>(108), static_cast<u8>(105), static_cast<u8>(99), static_cast<u8>(32), static_cast<u8>(102), static_cast<u8>(117), static_cast<u8>(110), static_cast<u8>(99), static_cast<u8>(116), static_cast<u8>(105), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(111), static_cast<u8>(112), static_cast<u8>(101), static_cast<u8>(110), static_cast<u8>(95), static_cast<u8>(102), static_cast<u8>(111), static_cast<u8>(114), static_cast<u8>(95), static_cast<u8>(114), static_cast<u8>(101), static_cast<u8>(97), static_cast<u8>(100), static_cast<u8>(105), static_cast<u8>(110), static_cast<u8>(103), static_cast<u8>(40), static_cast<u8>(97), static_cast<u8>(110), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(112), static_cast<u8>(97), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(58), static_cast<u8>(32), static_cast<u8>(83), static_cast<u8>(116), static_cast<u8>(114), static_cast<u8>(105), static_cast<u8>(110), static_cast<u8>(103), static_cast<u8>(41), static_cast<u8>(32), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(114), static_cast<u8>(111), static_cast<u8>(119), static_cast<u8>(115), static_cast<u8>(32), static_cast<u8>(45), static_cast<u8>(62), static_cast<u8>(32), static_cast<u8>(70), static_cast<u8>(105), static_cast<u8>(108), static_cast<u8>(101), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(112), static_cast<u8>(117), static_cast<u8>(98), static_cast<u8>(108), static_cast<u8>(105), static_cast<u8>(99), static_cast<u8>(32), static_cast<u8>(102), static_cast<u8>(117), static_cast<u8>(110), static_cast<u8>(99), static_cast<u8>(116), static_cast<u8>(105), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(111), static_cast<u8>(112), static_cast<u8>(101), static_cast<u8>(110), static_cast<u8>(95), static_cast<u8>(102), static_cast<u8>(111), static_cast<u8>(114), static_cast<u8>(95), static_cast<u8>(119), static_cast<u8>(114), static_cast<u8>(105), static_cast<u8>(116), static_cast<u8>(105), static_cast<u8>(110), static_cast<u8>(103), static_cast<u8>(40), static_cast<u8>(97), static_cast<u8>(110), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(112), static_cast<u8>(97), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(58), static_cast<u8>(32), static_cast<u8>(83), static_cast<u8>(116), static_cast<u8>(114), static_cast<u8>(105), static_cast<u8>(110), static_cast<u8>(103), static_cast<u8>(41), static_cast<u8>(32), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(114), static_cast<u8>(111), static_cast<u8>(119), static_cast<u8>(115), static_cast<u8>(32), static_cast<u8>(45), static_cast<u8>(62), static_cast<u8>(32), static_cast<u8>(70), static_cast<u8>(105), static_cast<u8>(108), static_cast<u8>(101), static_cast<u8>(10), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(112), static_cast<u8>(117), static_cast<u8>(98), static_cast<u8>(108), static_cast<u8>(105), static_cast<u8>(99), static_cast<u8>(32), static_cast<u8>(102), static_cast<u8>(117), static_cast<u8>(110), static_cast<u8>(99), static_cast<u8>(116), static_cast<u8>(105), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(114), static_cast<u8>(101), static_cast<u8>(97), static_cast<u8>(100), static_cast<u8>(40), static_cast<u8>(109), static_cast<u8>(117), static_cast<u8>(116), static_cast<u8>(32), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(105), static_cast<u8>(115), static_cast<u8>(44), static_cast<u8>(32), static_cast<u8>(97), static_cast<u8>(110), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(98), static_cast<u8>(117), static_cast<u8>(102), static_cast<u8>(102), static_cast<u8>(101), static_cast<u8>(114), static_cast<u8>(58), static_cast<u8>(32), static_cast<u8>(91), static_cast<u8>(117), static_cast<u8>(56), static_cast<u8>(93), static_cast<u8>(41), static_cast<u8>(32), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(114), static_cast<u8>(111), static_cast<u8>(119), static_cast<u8>(115), static_cast<u8>(32), static_cast<u8>(45), static_cast<u8>(62), static_cast<u8>(32), static_cast<u8>(117), static_cast<u8>(115), static_cast<u8>(105), static_cast<u8>(122), static_cast<u8>(101), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(112), static_cast<u8>(117), static_cast<u8>(98), static_cast<u8>(108), static_cast<u8>(105), static_cast<u8>(99), static_cast<u8>(32), static_cast<u8>(102), static_cast<u8>(117), static_cast<u8>(110), static_cast<u8>(99), static_cast<u8>(116), static_cast<u8>(105), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(119), static_cast<u8>(114), static_cast<u8>(105), static_cast<u8>(116), static_cast<u8>(101), static_cast<u8>(40), static_cast<u8>(109), static_cast<u8>(117), static_cast<u8>(116), static_cast<u8>(32), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(105), static_cast<u8>(115), static_cast<u8>(44), static_cast<u8>(32), static_cast<u8>(97), static_cast<u8>(110), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(100), static_cast<u8>(97), static_cast<u8>(116), static_cast<u8>(97), static_cast<u8>(58), static_cast<u8>(32), static_cast<u8>(91), static_cast<u8>(117), static_cast<u8>(56), static_cast<u8>(93), static_cast<u8>(41), static_cast<u8>(32), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(114), static_cast<u8>(111), static_cast<u8>(119), static_cast<u8>(115), static_cast<u8>(32), static_cast<u8>(45), static_cast<u8>(62), static_cast<u8>(32), static_cast<u8>(117), static_cast<u8>(115), static_cast<u8>(105), static_cast<u8>(122), static_cast<u8>(101), static_cast<u8>(10), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(112), static_cast<u8>(117), static_cast<u8>(98), static_cast<u8>(108), static_cast<u8>(105), static_cast<u8>(99), static_cast<u8>(32), static_cast<u8>(102), static_cast<u8>(117), static_cast<u8>(110), static_cast<u8>(99), static_cast<u8>(116), static_cast<u8>(105), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(114), static_cast<u8>(101), static_cast<u8>(97), static_cast<u8>(100), static_cast<u8>(95), static_cast<u8>(97), static_cast<u8>(108), static_cast<u8>(108), static_cast<u8>(40), static_cast<u8>(109), static_cast<u8>(117), static_cast<u8>(116), static_cast<u8>(32), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(105), static_cast<u8>(115), static_cast<u8>(41), static_cast<u8>(32), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(114), static_cast<u8>(111), static_cast<u8>(119), static_cast<u8>(115), static_cast<u8>(32), static_cast<u8>(45), static_cast<u8>(62), static_cast<u8>(32), static_cast<u8>(91), static_cast<u8>(117), static_cast<u8>(56), static_cast<u8>(93), static_cast<u8>(10), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(112), static_cast<u8>(117), static_cast<u8>(98), static_cast<u8>(108), static_cast<u8>(105), static_cast<u8>(99), static_cast<u8>(32), static_cast<u8>(102), static_cast<u8>(117), static_cast<u8>(110), static_cast<u8>(99), static_cast<u8>(116), static_cast<u8>(105), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(101), static_cast<u8>(120), static_cast<u8>(105), static_cast<u8>(115), static_cast<u8>(116), static_cast<u8>(115), static_cast<u8>(40), static_cast<u8>(97), static_cast<u8>(110), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(112), static_cast<u8>(97), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(58), static_cast<u8>(32), static_cast<u8>(83), static_cast<u8>(116), static_cast<u8>(114), static_cast<u8>(105), static_cast<u8>(110), static_cast<u8>(103), static_cast<u8>(41), static_cast<u8>(32), static_cast<u8>(45), static_cast<u8>(62), static_cast<u8>(32), static_cast<u8>(98), static_cast<u8>(111), static_cast<u8>(111), static_cast<u8>(108), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(112), static_cast<u8>(117), static_cast<u8>(98), static_cast<u8>(108), static_cast<u8>(105), static_cast<u8>(99), static_cast<u8>(32), static_cast<u8>(102), static_cast<u8>(117), static_cast<u8>(110), static_cast<u8>(99), static_cast<u8>(116), static_cast<u8>(105), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(99), static_cast<u8>(117), static_cast<u8>(114), static_cast<u8>(114), static_cast<u8>(101), static_cast<u8>(110), static_cast<u8>(116), static_cast<u8>(95), static_cast<u8>(101), static_cast<u8>(120), static_cast<u8>(101), static_cast<u8>(99), static_cast<u8>(117), static_cast<u8>(116), static_cast<u8>(97), static_cast<u8>(98), static_cast<u8>(108), static_cast<u8>(101), static_cast<u8>(95), static_cast<u8>(112), static_cast<u8>(97), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(40), static_cast<u8>(41), static_cast<u8>(32), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(114), static_cast<u8>(111), static_cast<u8>(119), static_cast<u8>(115), static_cast<u8>(32), static_cast<u8>(45), static_cast<u8>(62), static_cast<u8>(32), static_cast<u8>(83), static_cast<u8>(116), static_cast<u8>(114), static_cast<u8>(105), static_cast<u8>(110), static_cast<u8>(103), static_cast<u8>(10), static_cast<u8>(125), static_cast<u8>(10), static_cast<u8>(10), static_cast<u8>(101), static_cast<u8>(120), static_cast<u8>(116), static_cast<u8>(101), static_cast<u8>(114), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(102), static_cast<u8>(117), static_cast<u8>(110), static_cast<u8>(99), static_cast<u8>(116), static_cast<u8>(105), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(95), static_cast<u8>(95), static_cast<u8>(95), static_cast<u8>(106), static_cast<u8>(97), static_cast<u8>(107), static_cast<u8>(116), static_cast<u8>(95), static_cast<u8>(103), static_cast<u8>(101), static_cast<u8>(116), static_cast<u8>(95), static_cast<u8>(116), static_cast<u8>(97), static_cast<u8>(114), static_cast<u8>(103), static_cast<u8>(101), static_cast<u8>(116), static_cast<u8>(95), static_cast<u8>(116), static_cast<u8>(114), static_cast<u8>(105), static_cast<u8>(112), static_cast<u8>(108), static_cast<u8>(101), static_cast<u8>(95), static_cast<u8>(115), static_cast<u8>(116), static_cast<u8>(114), static_cast<u8>(105), static_cast<u8>(110), static_cast<u8>(103), static_cast<u8>(40), static_cast<u8>(41), static_cast<u8>(32), static_cast<u8>(45), static_cast<u8>(62), static_cast<u8>(32), static_cast<u8>(83), static_cast<u8>(116), static_cast<u8>(114), static_cast<u8>(105), static_cast<u8>(110), static_cast<u8>(103), static_cast<u8>(10), static_cast<u8>(10), static_cast<u8>(101), static_cast<u8>(120), static_cast<u8>(116), static_cast<u8>(101), static_cast<u8>(114), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(102), static_cast<u8>(117), static_cast<u8>(110), static_cast<u8>(99), static_cast<u8>(116), static_cast<u8>(105), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(97), static_cast<u8>(98), static_cast<u8>(111), static_cast<u8>(114), static_cast<u8>(116), static_cast<u8>(40), static_cast<u8>(41), static_cast<u8>(32), static_cast<u8>(45), static_cast<u8>(62), static_cast<u8>(32), static_cast<u8>(110), static_cast<u8>(101), static_cast<u8>(118), static_cast<u8>(101), static_cast<u8>(114), static_cast<u8>(10), static_cast<u8>(101), static_cast<u8>(120), static_cast<u8>(116), static_cast<u8>(101), static_cast<u8>(114), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(102), static_cast<u8>(117), static_cast<u8>(110), static_cast<u8>(99), static_cast<u8>(116), static_cast<u8>(105), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(97), static_cast<u8>(115), static_cast<u8>(95), static_cast<u8>(115), static_cast<u8>(97), static_cast<u8>(116), static_cast<u8>(117), static_cast<u8>(114), static_cast<u8>(97), static_cast<u8>(116), static_cast<u8>(101), static_cast<u8>(100), static_cast<u8>(60), static_cast<u8>(85), static_cast<u8>(44), static_cast<u8>(32), static_cast<u8>(84), static_cast<u8>(62), static_cast<u8>(40), static_cast<u8>(97), static_cast<u8>(110), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(105), static_cast<u8>(110), static_cast<u8>(112), static_cast<u8>(117), static_cast<u8>(116), static_cast<u8>(58), static_cast<u8>(32), static_cast<u8>(84), static_cast<u8>(41), static_cast<u8>(32), static_cast<u8>(45), static_cast<u8>(62), static_cast<u8>(32), static_cast<u8>(85), static_cast<u8>(10), static_cast<u8>(101), static_cast<u8>(120), static_cast<u8>(116), static_cast<u8>(101), static_cast<u8>(114), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(102), static_cast<u8>(117), static_cast<u8>(110), static_cast<u8>(99), static_cast<u8>(116), static_cast<u8>(105), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(97), static_cast<u8>(115), static_cast<u8>(95), static_cast<u8>(116), static_cast<u8>(114), static_cast<u8>(117), static_cast<u8>(110), static_cast<u8>(99), static_cast<u8>(97), static_cast<u8>(116), static_cast<u8>(101), static_cast<u8>(100), static_cast<u8>(60), static_cast<u8>(85), static_cast<u8>(44), static_cast<u8>(32), static_cast<u8>(84), static_cast<u8>(62), static_cast<u8>(40), static_cast<u8>(97), static_cast<u8>(110), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(105), static_cast<u8>(110), static_cast<u8>(112), static_cast<u8>(117), static_cast<u8>(116), static_cast<u8>(58), static_cast<u8>(32), static_cast<u8>(84), static_cast<u8>(41), static_cast<u8>(32), static_cast<u8>(45), static_cast<u8>(62), static_cast<u8>(32), static_cast<u8>(85), static_cast<u8>(10), static_cast<u8>(101), static_cast<u8>(120), static_cast<u8>(116), static_cast<u8>(101), static_cast<u8>(114), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(102), static_cast<u8>(117), static_cast<u8>(110), static_cast<u8>(99), static_cast<u8>(116), static_cast<u8>(105), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(117), static_cast<u8>(110), static_cast<u8>(99), static_cast<u8>(104), static_cast<u8>(101), static_cast<u8>(99), static_cast<u8>(107), static_cast<u8>(101), static_cast<u8>(100), static_cast<u8>(95), static_cast<u8>(97), static_cast<u8>(100), static_cast<u8>(100), static_cast<u8>(60), static_cast<u8>(84), static_cast<u8>(62), static_cast<u8>(40), static_cast<u8>(97), static_cast<u8>(110), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(97), static_cast<u8>(58), static_cast<u8>(32), static_cast<u8>(84), static_cast<u8>(44), static_cast<u8>(32), static_cast<u8>(97), static_cast<u8>(110), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(98), static_cast<u8>(58), static_cast<u8>(32), static_cast<u8>(84), static_cast<u8>(41), static_cast<u8>(32), static_cast<u8>(45), static_cast<u8>(62), static_cast<u8>(32), static_cast<u8>(84), static_cast<u8>(10), static_cast<u8>(101), static_cast<u8>(120), static_cast<u8>(116), static_cast<u8>(101), static_cast<u8>(114), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(102), static_cast<u8>(117), static_cast<u8>(110), static_cast<u8>(99), static_cast<u8>(116), static_cast<u8>(105), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(117), static_cast<u8>(110), static_cast<u8>(99), static_cast<u8>(104), static_cast<u8>(101), static_cast<u8>(99), static_cast<u8>(107), static_cast<u8>(101), static_cast<u8>(100), static_cast<u8>(95), static_cast<u8>(109), static_cast<u8>(117), static_cast<u8>(108), static_cast<u8>(60), static_cast<u8>(84), static_cast<u8>(62), static_cast<u8>(40), static_cast<u8>(97), static_cast<u8>(110), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(97), static_cast<u8>(58), static_cast<u8>(32), static_cast<u8>(84), static_cast<u8>(44), static_cast<u8>(32), static_cast<u8>(97), static_cast<u8>(110), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(98), static_cast<u8>(58), static_cast<u8>(32), static_cast<u8>(84), static_cast<u8>(41), static_cast<u8>(32), static_cast<u8>(45), static_cast<u8>(62), static_cast<u8>(32), static_cast<u8>(84), static_cast<u8>(10)}))));
+JaktInternal::Array<u8> const file_contents = (TRY((Array<u8>::create_with({static_cast<u8>(101), static_cast<u8>(120), static_cast<u8>(116), static_cast<u8>(101), static_cast<u8>(114), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(115), static_cast<u8>(116), static_cast<u8>(114), static_cast<u8>(117), static_cast<u8>(99), static_cast<u8>(116), static_cast<u8>(32), static_cast<u8>(79), static_cast<u8>(112), static_cast<u8>(116), static_cast<u8>(105), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(97), static_cast<u8>(108), static_cast<u8>(60), static_cast<u8>(84), static_cast<u8>(62), static_cast<u8>(32), static_cast<u8>(123), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(102), static_cast<u8>(117), static_cast<u8>(110), static_cast<u8>(99), static_cast<u8>(116), static_cast<u8>(105), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(104), static_cast<u8>(97), static_cast<u8>(115), static_cast<u8>(95), static_cast<u8>(118), static_cast<u8>(97), static_cast<u8>(108), static_cast<u8>(117), static_cast<u8>(101), static_cast<u8>(40), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(105), static_cast<u8>(115), static_cast<u8>(41), static_cast<u8>(32), static_cast<u8>(45), static_cast<u8>(62), static_cast<u8>(32), static_cast<u8>(98), static_cast<u8>(111), static_cast<u8>(111), static_cast<u8>(108), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(102), static_cast<u8>(117), static_cast<u8>(110), static_cast<u8>(99), static_cast<u8>(116), static_cast<u8>(105), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(118), static_cast<u8>(97), static_cast<u8>(108), static_cast<u8>(117), static_cast<u8>(101), static_cast<u8>(40), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(105), static_cast<u8>(115), static_cast<u8>(41), static_cast<u8>(32), static_cast<u8>(45), static_cast<u8>(62), static_cast<u8>(32), static_cast<u8>(84), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(102), static_cast<u8>(117), static_cast<u8>(110), static_cast<u8>(99), static_cast<u8>(116), static_cast<u8>(105), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(118), static_cast<u8>(97), static_cast<u8>(108), static_cast<u8>(117), static_cast<u8>(101), static_cast<u8>(95), static_cast<u8>(111), static_cast<u8>(114), static_cast<u8>(40), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(105), static_cast<u8>(115), static_cast<u8>(44), static_cast<u8>(32), static_cast<u8>(97), static_cast<u8>(110), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(120), static_cast<u8>(58), static_cast<u8>(32), static_cast<u8>(84), static_cast<u8>(41), static_cast<u8>(32), static_cast<u8>(45), static_cast<u8>(62), static_cast<u8>(32), static_cast<u8>(84), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(102), static_cast<u8>(117), static_cast<u8>(110), static_cast<u8>(99), static_cast<u8>(116), static_cast<u8>(105), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(79), static_cast<u8>(112), static_cast<u8>(116), static_cast<u8>(105), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(97), static_cast<u8>(108), static_cast<u8>(60), static_cast<u8>(83), static_cast<u8>(62), static_cast<u8>(40), static_cast<u8>(97), static_cast<u8>(110), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(120), static_cast<u8>(58), static_cast<u8>(32), static_cast<u8>(83), static_cast<u8>(41), static_cast<u8>(32), static_cast<u8>(45), static_cast<u8>(62), static_cast<u8>(32), static_cast<u8>(79), static_cast<u8>(112), static_cast<u8>(116), static_cast<u8>(105), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(97), static_cast<u8>(108), static_cast<u8>(60), static_cast<u8>(83), static_cast<u8>(62), static_cast<u8>(10), static_cast<u8>(125), static_cast<u8>(10), static_cast<u8>(10), static_cast<u8>(101), static_cast<u8>(120), static_cast<u8>(116), static_cast<u8>(101), static_cast<u8>(114), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(115), static_cast<u8>(116), static_cast<u8>(114), static_cast<u8>(117), static_cast<u8>(99), static_cast<u8>(116), static_cast<u8>(32), static_cast<u8>(65), static_cast<u8>(114), static_cast<u8>(114), static_cast<u8>(97), static_cast<u8>(121), static_cast<u8>(73), static_cast<u8>(116), static_cast<u8>(101), static_cast<u8>(114), static_cast<u8>(97), static_cast<u8>(116), static_cast<u8>(111), static_cast<u8>(114), static_cast<u8>(60), static_cast<u8>(84), static_cast<u8>(62), static_cast<u8>(32), static_cast<u8>(123), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(102), static_cast<u8>(117), static_cast<u8>(110), static_cast<u8>(99), static_cast<u8>(116), static_cast<u8>(105), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(110), static_cast<u8>(101), static_cast<u8>(120), static_cast<u8>(116), static_cast<u8>(40), static_cast<u8>(109), static_cast<u8>(117), static_cast<u8>(116), static_cast<u8>(32), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(105), static_cast<u8>(115), static_cast<u8>(41), static_cast<u8>(32), static_cast<u8>(45), static_cast<u8>(62), static_cast<u8>(32), static_cast<u8>(84), static_cast<u8>(63), static_cast<u8>(10), static_cast<u8>(125), static_cast<u8>(10), static_cast<u8>(10), static_cast<u8>(101), static_cast<u8>(120), static_cast<u8>(116), static_cast<u8>(101), static_cast<u8>(114), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(115), static_cast<u8>(116), static_cast<u8>(114), static_cast<u8>(117), static_cast<u8>(99), static_cast<u8>(116), static_cast<u8>(32), static_cast<u8>(65), static_cast<u8>(114), static_cast<u8>(114), static_cast<u8>(97), static_cast<u8>(121), static_cast<u8>(60), static_cast<u8>(84), static_cast<u8>(62), static_cast<u8>(32), static_cast<u8>(123), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(102), static_cast<u8>(117), static_cast<u8>(110), static_cast<u8>(99), static_cast<u8>(116), static_cast<u8>(105), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(105), static_cast<u8>(115), static_cast<u8>(95), static_cast<u8>(101), static_cast<u8>(109), static_cast<u8>(112), static_cast<u8>(116), static_cast<u8>(121), static_cast<u8>(40), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(105), static_cast<u8>(115), static_cast<u8>(41), static_cast<u8>(32), static_cast<u8>(45), static_cast<u8>(62), static_cast<u8>(32), static_cast<u8>(98), static_cast<u8>(111), static_cast<u8>(111), static_cast<u8>(108), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(102), static_cast<u8>(117), static_cast<u8>(110), static_cast<u8>(99), static_cast<u8>(116), static_cast<u8>(105), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(99), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(116), static_cast<u8>(97), static_cast<u8>(105), static_cast<u8>(110), static_cast<u8>(115), static_cast<u8>(40), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(105), static_cast<u8>(115), static_cast<u8>(44), static_cast<u8>(32), static_cast<u8>(97), static_cast<u8>(110), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(118), static_cast<u8>(97), static_cast<u8>(108), static_cast<u8>(117), static_cast<u8>(101), static_cast<u8>(58), static_cast<u8>(32), static_cast<u8>(84), static_cast<u8>(41), static_cast<u8>(32), static_cast<u8>(45), static_cast<u8>(62), static_cast<u8>(32), static_cast<u8>(98), static_cast<u8>(111), static_cast<u8>(111), static_cast<u8>(108), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(102), static_cast<u8>(117), static_cast<u8>(110), static_cast<u8>(99), static_cast<u8>(116), static_cast<u8>(105), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(115), static_cast<u8>(105), static_cast<u8>(122), static_cast<u8>(101), static_cast<u8>(40), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(105), static_cast<u8>(115), static_cast<u8>(41), static_cast<u8>(32), static_cast<u8>(45), static_cast<u8>(62), static_cast<u8>(32), static_cast<u8>(117), static_cast<u8>(115), static_cast<u8>(105), static_cast<u8>(122), static_cast<u8>(101), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(102), static_cast<u8>(117), static_cast<u8>(110), static_cast<u8>(99), static_cast<u8>(116), static_cast<u8>(105), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(99), static_cast<u8>(97), static_cast<u8>(112), static_cast<u8>(97), static_cast<u8>(99), static_cast<u8>(105), static_cast<u8>(116), static_cast<u8>(121), static_cast<u8>(40), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(105), static_cast<u8>(115), static_cast<u8>(41), static_cast<u8>(32), static_cast<u8>(45), static_cast<u8>(62), static_cast<u8>(32), static_cast<u8>(117), static_cast<u8>(115), static_cast<u8>(105), static_cast<u8>(122), static_cast<u8>(101), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(102), static_cast<u8>(117), static_cast<u8>(110), static_cast<u8>(99), static_cast<u8>(116), static_cast<u8>(105), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(101), static_cast<u8>(110), static_cast<u8>(115), static_cast<u8>(117), static_cast<u8>(114), static_cast<u8>(101), static_cast<u8>(95), static_cast<u8>(99), static_cast<u8>(97), static_cast<u8>(112), static_cast<u8>(97), static_cast<u8>(99), static_cast<u8>(105), static_cast<u8>(116), static_cast<u8>(121), static_cast<u8>(40), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(105), static_cast<u8>(115), static_cast<u8>(44), static_cast<u8>(32), static_cast<u8>(97), static_cast<u8>(110), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(99), static_cast<u8>(97), static_cast<u8>(112), static_cast<u8>(97), static_cast<u8>(99), static_cast<u8>(105), static_cast<u8>(116), static_cast<u8>(121), static_cast<u8>(58), static_cast<u8>(32), static_cast<u8>(117), static_cast<u8>(115), static_cast<u8>(105), static_cast<u8>(122), static_cast<u8>(101), static_cast<u8>(41), static_cast<u8>(32), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(114), static_cast<u8>(111), static_cast<u8>(119), static_cast<u8>(115), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(102), static_cast<u8>(117), static_cast<u8>(110), static_cast<u8>(99), static_cast<u8>(116), static_cast<u8>(105), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(97), static_cast<u8>(100), static_cast<u8>(100), static_cast<u8>(95), static_cast<u8>(99), static_cast<u8>(97), static_cast<u8>(112), static_cast<u8>(97), static_cast<u8>(99), static_cast<u8>(105), static_cast<u8>(116), static_cast<u8>(121), static_cast<u8>(40), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(105), static_cast<u8>(115), static_cast<u8>(44), static_cast<u8>(32), static_cast<u8>(97), static_cast<u8>(110), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(99), static_cast<u8>(97), static_cast<u8>(112), static_cast<u8>(97), static_cast<u8>(99), static_cast<u8>(105), static_cast<u8>(116), static_cast<u8>(121), static_cast<u8>(58), static_cast<u8>(32), static_cast<u8>(117), static_cast<u8>(115), static_cast<u8>(105), static_cast<u8>(122), static_cast<u8>(101), static_cast<u8>(41), static_cast<u8>(32), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(114), static_cast<u8>(111), static_cast<u8>(119), static_cast<u8>(115), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(102), static_cast<u8>(117), static_cast<u8>(110), static_cast<u8>(99), static_cast<u8>(116), static_cast<u8>(105), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(114), static_cast<u8>(101), static_cast<u8>(115), static_cast<u8>(105), static_cast<u8>(122), static_cast<u8>(101), static_cast<u8>(40), static_cast<u8>(109), static_cast<u8>(117), static_cast<u8>(116), static_cast<u8>(32), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(105), static_cast<u8>(115), static_cast<u8>(44), static_cast<u8>(32), static_cast<u8>(97), static_cast<u8>(110), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(115), static_cast<u8>(105), static_cast<u8>(122), static_cast<u8>(101), static_cast<u8>(58), static_cast<u8>(32), static_cast<u8>(117), static_cast<u8>(115), static_cast<u8>(105), static_cast<u8>(122), static_cast<u8>(101), static_cast<u8>(41), static_cast<u8>(32), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(114), static_cast<u8>(111), static_cast<u8>(119), static_cast<u8>(115), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(102), static_cast<u8>(117), static_cast<u8>(110), static_cast<u8>(99), static_cast<u8>(116), static_cast<u8>(105), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(115), static_cast<u8>(104), static_cast<u8>(114), static_cast<u8>(105), static_cast<u8>(110), static_cast<u8>(107), static_cast<u8>(40), static_cast<u8>(109), static_cast<u8>(117), static_cast<u8>(116), static_cast<u8>(32), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(105), static_cast<u8>(115), static_cast<u8>(44), static_cast<u8>(32), static_cast<u8>(97), static_cast<u8>(110), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(115), static_cast<u8>(105), static_cast<u8>(122), static_cast<u8>(101), static_cast<u8>(58), static_cast<u8>(32), static_cast<u8>(117), static_cast<u8>(115), static_cast<u8>(105), static_cast<u8>(122), static_cast<u8>(101), static_cast<u8>(41), static_cast<u8>(32), static_cast<u8>(45), static_cast<u8>(62), static_cast<u8>(32), static_cast<u8>(118), static_cast<u8>(111), static_cast<u8>(105), static_cast<u8>(100), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(102), static_cast<u8>(117), static_cast<u8>(110), static_cast<u8>(99), static_cast<u8>(116), static_cast<u8>(105), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(112), static_cast<u8>(117), static_cast<u8>(115), static_cast<u8>(104), static_cast<u8>(40), static_cast<u8>(109), static_cast<u8>(117), static_cast<u8>(116), static_cast<u8>(32), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(105), static_cast<u8>(115), static_cast<u8>(44), static_cast<u8>(32), static_cast<u8>(97), static_cast<u8>(110), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(118), static_cast<u8>(97), static_cast<u8>(108), static_cast<u8>(117), static_cast<u8>(101), static_cast<u8>(58), static_cast<u8>(32), static_cast<u8>(84), static_cast<u8>(41), static_cast<u8>(32), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(114), static_cast<u8>(111), static_cast<u8>(119), static_cast<u8>(115), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(102), static_cast<u8>(117), static_cast<u8>(110), static_cast<u8>(99), static_cast<u8>(116), static_cast<u8>(105), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(112), static_cast<u8>(117), static_cast<u8>(115), static_cast<u8>(104), static_cast<u8>(95), static_cast<u8>(118), static_cast<u8>(97), static_cast<u8>(108), static_cast<u8>(117), static_cast<u8>(101), static_cast<u8>(115), static_cast<u8>(40), static_cast<u8>(109), static_cast<u8>(117), static_cast<u8>(116), static_cast<u8>(32), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(105), static_cast<u8>(115), static_cast<u8>(44), static_cast<u8>(32), static_cast<u8>(97), static_cast<u8>(110), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(111), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(101), static_cast<u8>(114), static_cast<u8>(58), static_cast<u8>(32), static_cast<u8>(38), static_cast<u8>(65), static_cast<u8>(114), static_cast<u8>(114), static_cast<u8>(97), static_cast<u8>(121), static_cast<u8>(60), static_cast<u8>(84), static_cast<u8>(62), static_cast<u8>(41), static_cast<u8>(32), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(114), static_cast<u8>(111), static_cast<u8>(119), static_cast<u8>(115), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(102), static_cast<u8>(117), static_cast<u8>(110), static_cast<u8>(99), static_cast<u8>(116), static_cast<u8>(105), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(112), static_cast<u8>(111), static_cast<u8>(112), static_cast<u8>(40), static_cast<u8>(109), static_cast<u8>(117), static_cast<u8>(116), static_cast<u8>(32), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(105), static_cast<u8>(115), static_cast<u8>(41), static_cast<u8>(32), static_cast<u8>(45), static_cast<u8>(62), static_cast<u8>(32), static_cast<u8>(84), static_cast<u8>(63), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(102), static_cast<u8>(117), static_cast<u8>(110), static_cast<u8>(99), static_cast<u8>(116), static_cast<u8>(105), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(105), static_cast<u8>(116), static_cast<u8>(101), static_cast<u8>(114), static_cast<u8>(97), static_cast<u8>(116), static_cast<u8>(111), static_cast<u8>(114), static_cast<u8>(40), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(105), static_cast<u8>(115), static_cast<u8>(41), static_cast<u8>(32), static_cast<u8>(45), static_cast<u8>(62), static_cast<u8>(32), static_cast<u8>(65), static_cast<u8>(114), static_cast<u8>(114), static_cast<u8>(97), static_cast<u8>(121), static_cast<u8>(73), static_cast<u8>(116), static_cast<u8>(101), static_cast<u8>(114), static_cast<u8>(97), static_cast<u8>(116), static_cast<u8>(111), static_cast<u8>(114), static_cast<u8>(60), static_cast<u8>(84), static_cast<u8>(62), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(102), static_cast<u8>(117), static_cast<u8>(110), static_cast<u8>(99), static_cast<u8>(116), static_cast<u8>(105), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(102), static_cast<u8>(105), static_cast<u8>(114), static_cast<u8>(115), static_cast<u8>(116), static_cast<u8>(40), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(105), static_cast<u8>(115), static_cast<u8>(41), static_cast<u8>(32), static_cast<u8>(45), static_cast<u8>(62), static_cast<u8>(32), static_cast<u8>(84), static_cast<u8>(63), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(102), static_cast<u8>(117), static_cast<u8>(110), static_cast<u8>(99), static_cast<u8>(116), static_cast<u8>(105), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(108), static_cast<u8>(97), static_cast<u8>(115), static_cast<u8>(116), static_cast<u8>(40), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(105), static_cast<u8>(115), static_cast<u8>(41), static_cast<u8>(32), static_cast<u8>(45), static_cast<u8>(62), static_cast<u8>(32), static_cast<u8>(84), static_cast<u8>(63), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(102), static_cast<u8>(117), static_cast<u8>(110), static_cast<u8>(99), static_cast<u8>(116), static_cast<u8>(105), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(105), static_cast<u8>(110), static_cast<u8>(115), static_cast<u8>(101), static_cast<u8>(114), static_cast<u8>(116), static_cast<u8>(40), static_cast<u8>(109), static_cast<u8>(117), static_cast<u8>(116), static_cast<u8>(32), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(105), static_cast<u8>(115), static_cast<u8>(44), static_cast<u8>(32), static_cast<u8>(98), static_cast<u8>(101), static_cast<u8>(102), static_cast<u8>(111), static_cast<u8>(114), static_cast<u8>(101), static_cast<u8>(95), static_cast<u8>(105), static_cast<u8>(110), static_cast<u8>(100), static_cast<u8>(101), static_cast<u8>(120), static_cast<u8>(58), static_cast<u8>(32), static_cast<u8>(117), static_cast<u8>(115), static_cast<u8>(105), static_cast<u8>(122), static_cast<u8>(101), static_cast<u8>(44), static_cast<u8>(32), static_cast<u8>(118), static_cast<u8>(97), static_cast<u8>(108), static_cast<u8>(117), static_cast<u8>(101), static_cast<u8>(58), static_cast<u8>(32), static_cast<u8>(84), static_cast<u8>(41), static_cast<u8>(32), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(114), static_cast<u8>(111), static_cast<u8>(119), static_cast<u8>(115), static_cast<u8>(10), static_cast<u8>(125), static_cast<u8>(10), static_cast<u8>(10), static_cast<u8>(101), static_cast<u8>(120), static_cast<u8>(116), static_cast<u8>(101), static_cast<u8>(114), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(115), static_cast<u8>(116), static_cast<u8>(114), static_cast<u8>(117), static_cast<u8>(99), static_cast<u8>(116), static_cast<u8>(32), static_cast<u8>(65), static_cast<u8>(114), static_cast<u8>(114), static_cast<u8>(97), static_cast<u8>(121), static_cast<u8>(83), static_cast<u8>(108), static_cast<u8>(105), static_cast<u8>(99), static_cast<u8>(101), static_cast<u8>(60), static_cast<u8>(84), static_cast<u8>(62), static_cast<u8>(32), static_cast<u8>(123), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(102), static_cast<u8>(117), static_cast<u8>(110), static_cast<u8>(99), static_cast<u8>(116), static_cast<u8>(105), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(105), static_cast<u8>(115), static_cast<u8>(95), static_cast<u8>(101), static_cast<u8>(109), static_cast<u8>(112), static_cast<u8>(116), static_cast<u8>(121), static_cast<u8>(40), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(105), static_cast<u8>(115), static_cast<u8>(41), static_cast<u8>(32), static_cast<u8>(45), static_cast<u8>(62), static_cast<u8>(32), static_cast<u8>(98), static_cast<u8>(111), static_cast<u8>(111), static_cast<u8>(108), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(102), static_cast<u8>(117), static_cast<u8>(110), static_cast<u8>(99), static_cast<u8>(116), static_cast<u8>(105), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(99), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(116), static_cast<u8>(97), static_cast<u8>(105), static_cast<u8>(110), static_cast<u8>(115), static_cast<u8>(40), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(105), static_cast<u8>(115), static_cast<u8>(44), static_cast<u8>(32), static_cast<u8>(97), static_cast<u8>(110), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(118), static_cast<u8>(97), static_cast<u8>(108), static_cast<u8>(117), static_cast<u8>(101), static_cast<u8>(58), static_cast<u8>(32), static_cast<u8>(84), static_cast<u8>(41), static_cast<u8>(32), static_cast<u8>(45), static_cast<u8>(62), static_cast<u8>(32), static_cast<u8>(98), static_cast<u8>(111), static_cast<u8>(111), static_cast<u8>(108), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(102), static_cast<u8>(117), static_cast<u8>(110), static_cast<u8>(99), static_cast<u8>(116), static_cast<u8>(105), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(115), static_cast<u8>(105), static_cast<u8>(122), static_cast<u8>(101), static_cast<u8>(40), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(105), static_cast<u8>(115), static_cast<u8>(41), static_cast<u8>(32), static_cast<u8>(45), static_cast<u8>(62), static_cast<u8>(32), static_cast<u8>(117), static_cast<u8>(115), static_cast<u8>(105), static_cast<u8>(122), static_cast<u8>(101), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(102), static_cast<u8>(117), static_cast<u8>(110), static_cast<u8>(99), static_cast<u8>(116), static_cast<u8>(105), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(105), static_cast<u8>(116), static_cast<u8>(101), static_cast<u8>(114), static_cast<u8>(97), static_cast<u8>(116), static_cast<u8>(111), static_cast<u8>(114), static_cast<u8>(40), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(105), static_cast<u8>(115), static_cast<u8>(41), static_cast<u8>(32), static_cast<u8>(45), static_cast<u8>(62), static_cast<u8>(32), static_cast<u8>(65), static_cast<u8>(114), static_cast<u8>(114), static_cast<u8>(97), static_cast<u8>(121), static_cast<u8>(73), static_cast<u8>(116), static_cast<u8>(101), static_cast<u8>(114), static_cast<u8>(97), static_cast<u8>(116), static_cast<u8>(111), static_cast<u8>(114), static_cast<u8>(60), static_cast<u8>(84), static_cast<u8>(62), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(102), static_cast<u8>(117), static_cast<u8>(110), static_cast<u8>(99), static_cast<u8>(116), static_cast<u8>(105), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(116), static_cast<u8>(111), static_cast<u8>(95), static_cast<u8>(97), static_cast<u8>(114), static_cast<u8>(114), static_cast<u8>(97), static_cast<u8>(121), static_cast<u8>(40), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(105), static_cast<u8>(115), static_cast<u8>(41), static_cast<u8>(32), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(114), static_cast<u8>(111), static_cast<u8>(119), static_cast<u8>(115), static_cast<u8>(32), static_cast<u8>(45), static_cast<u8>(62), static_cast<u8>(32), static_cast<u8>(65), static_cast<u8>(114), static_cast<u8>(114), static_cast<u8>(97), static_cast<u8>(121), static_cast<u8>(60), static_cast<u8>(84), static_cast<u8>(62), static_cast<u8>(32), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(102), static_cast<u8>(117), static_cast<u8>(110), static_cast<u8>(99), static_cast<u8>(116), static_cast<u8>(105), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(102), static_cast<u8>(105), static_cast<u8>(114), static_cast<u8>(115), static_cast<u8>(116), static_cast<u8>(40), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(105), static_cast<u8>(115), static_cast<u8>(41), static_cast<u8>(32), static_cast<u8>(45), static_cast<u8>(62), static_cast<u8>(32), static_cast<u8>(84), static_cast<u8>(63), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(102), static_cast<u8>(117), static_cast<u8>(110), static_cast<u8>(99), static_cast<u8>(116), static_cast<u8>(105), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(108), static_cast<u8>(97), static_cast<u8>(115), static_cast<u8>(116), static_cast<u8>(40), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(105), static_cast<u8>(115), static_cast<u8>(41), static_cast<u8>(32), static_cast<u8>(45), static_cast<u8>(62), static_cast<u8>(32), static_cast<u8>(84), static_cast<u8>(63), static_cast<u8>(10), static_cast<u8>(125), static_cast<u8>(10), static_cast<u8>(10), static_cast<u8>(101), static_cast<u8>(120), static_cast<u8>(116), static_cast<u8>(101), static_cast<u8>(114), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(115), static_cast<u8>(116), static_cast<u8>(114), static_cast<u8>(117), static_cast<u8>(99), static_cast<u8>(116), static_cast<u8>(32), static_cast<u8>(83), static_cast<u8>(116), static_cast<u8>(114), static_cast<u8>(105), static_cast<u8>(110), static_cast<u8>(103), static_cast<u8>(32), static_cast<u8>(123), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(102), static_cast<u8>(117), static_cast<u8>(110), static_cast<u8>(99), static_cast<u8>(116), static_cast<u8>(105), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(110), static_cast<u8>(117), static_cast<u8>(109), static_cast<u8>(98), static_cast<u8>(101), static_cast<u8>(114), static_cast<u8>(40), static_cast<u8>(97), static_cast<u8>(110), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(110), static_cast<u8>(117), static_cast<u8>(109), static_cast<u8>(98), static_cast<u8>(101), static_cast<u8>(114), static_cast<u8>(58), static_cast<u8>(32), static_cast<u8>(105), static_cast<u8>(54), static_cast<u8>(52), static_cast<u8>(41), static_cast<u8>(32), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(114), static_cast<u8>(111), static_cast<u8>(119), static_cast<u8>(115), static_cast<u8>(32), static_cast<u8>(45), static_cast<u8>(62), static_cast<u8>(32), static_cast<u8>(83), static_cast<u8>(116), static_cast<u8>(114), static_cast<u8>(105), static_cast<u8>(110), static_cast<u8>(103), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(102), static_cast<u8>(117), static_cast<u8>(110), static_cast<u8>(99), static_cast<u8>(116), static_cast<u8>(105), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(115), static_cast<u8>(112), static_cast<u8>(108), static_cast<u8>(105), static_cast<u8>(116), static_cast<u8>(40), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(105), static_cast<u8>(115), static_cast<u8>(44), static_cast<u8>(32), static_cast<u8>(97), static_cast<u8>(110), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(99), static_cast<u8>(58), static_cast<u8>(32), static_cast<u8>(99), static_cast<u8>(95), static_cast<u8>(99), static_cast<u8>(104), static_cast<u8>(97), static_cast<u8>(114), static_cast<u8>(41), static_cast<u8>(32), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(114), static_cast<u8>(111), static_cast<u8>(119), static_cast<u8>(115), static_cast<u8>(32), static_cast<u8>(45), static_cast<u8>(62), static_cast<u8>(32), static_cast<u8>(91), static_cast<u8>(83), static_cast<u8>(116), static_cast<u8>(114), static_cast<u8>(105), static_cast<u8>(110), static_cast<u8>(103), static_cast<u8>(93), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(102), static_cast<u8>(117), static_cast<u8>(110), static_cast<u8>(99), static_cast<u8>(116), static_cast<u8>(105), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(99), static_cast<u8>(95), static_cast<u8>(115), static_cast<u8>(116), static_cast<u8>(114), static_cast<u8>(105), static_cast<u8>(110), static_cast<u8>(103), static_cast<u8>(40), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(105), static_cast<u8>(115), static_cast<u8>(41), static_cast<u8>(32), static_cast<u8>(45), static_cast<u8>(62), static_cast<u8>(32), static_cast<u8>(114), static_cast<u8>(97), static_cast<u8>(119), static_cast<u8>(32), static_cast<u8>(99), static_cast<u8>(95), static_cast<u8>(99), static_cast<u8>(104), static_cast<u8>(97), static_cast<u8>(114), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(102), static_cast<u8>(117), static_cast<u8>(110), static_cast<u8>(99), static_cast<u8>(116), static_cast<u8>(105), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(116), static_cast<u8>(111), static_cast<u8>(95), static_cast<u8>(105), static_cast<u8>(110), static_cast<u8>(116), static_cast<u8>(40), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(105), static_cast<u8>(115), static_cast<u8>(41), static_cast<u8>(32), static_cast<u8>(45), static_cast<u8>(62), static_cast<u8>(32), static_cast<u8>(105), static_cast<u8>(51), static_cast<u8>(50), static_cast<u8>(63), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(102), static_cast<u8>(117), static_cast<u8>(110), static_cast<u8>(99), static_cast<u8>(116), static_cast<u8>(105), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(116), static_cast<u8>(111), static_cast<u8>(95), static_cast<u8>(117), static_cast<u8>(105), static_cast<u8>(110), static_cast<u8>(116), static_cast<u8>(40), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(105), static_cast<u8>(115), static_cast<u8>(41), static_cast<u8>(32), static_cast<u8>(45), static_cast<u8>(62), static_cast<u8>(32), static_cast<u8>(117), static_cast<u8>(51), static_cast<u8>(50), static_cast<u8>(63), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(102), static_cast<u8>(117), static_cast<u8>(110), static_cast<u8>(99), static_cast<u8>(116), static_cast<u8>(105), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(105), static_cast<u8>(115), static_cast<u8>(95), static_cast<u8>(119), static_cast<u8>(104), static_cast<u8>(105), static_cast<u8>(116), static_cast<u8>(101), static_cast<u8>(115), static_cast<u8>(112), static_cast<u8>(97), static_cast<u8>(99), static_cast<u8>(101), static_cast<u8>(40), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(105), static_cast<u8>(115), static_cast<u8>(41), static_cast<u8>(32), static_cast<u8>(45), static_cast<u8>(62), static_cast<u8>(32), static_cast<u8>(98), static_cast<u8>(111), static_cast<u8>(111), static_cast<u8>(108), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(102), static_cast<u8>(117), static_cast<u8>(110), static_cast<u8>(99), static_cast<u8>(116), static_cast<u8>(105), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(104), static_cast<u8>(97), static_cast<u8>(115), static_cast<u8>(104), static_cast<u8>(40), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(105), static_cast<u8>(115), static_cast<u8>(41), static_cast<u8>(32), static_cast<u8>(45), static_cast<u8>(62), static_cast<u8>(32), static_cast<u8>(117), static_cast<u8>(51), static_cast<u8>(50), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(102), static_cast<u8>(117), static_cast<u8>(110), static_cast<u8>(99), static_cast<u8>(116), static_cast<u8>(105), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(115), static_cast<u8>(117), static_cast<u8>(98), static_cast<u8>(115), static_cast<u8>(116), static_cast<u8>(114), static_cast<u8>(105), static_cast<u8>(110), static_cast<u8>(103), static_cast<u8>(40), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(105), static_cast<u8>(115), static_cast<u8>(44), static_cast<u8>(32), static_cast<u8>(115), static_cast<u8>(116), static_cast<u8>(97), static_cast<u8>(114), static_cast<u8>(116), static_cast<u8>(58), static_cast<u8>(32), static_cast<u8>(117), static_cast<u8>(115), static_cast<u8>(105), static_cast<u8>(122), static_cast<u8>(101), static_cast<u8>(44), static_cast<u8>(32), static_cast<u8>(108), static_cast<u8>(101), static_cast<u8>(110), static_cast<u8>(103), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(58), static_cast<u8>(32), static_cast<u8>(117), static_cast<u8>(115), static_cast<u8>(105), static_cast<u8>(122), static_cast<u8>(101), static_cast<u8>(41), static_cast<u8>(32), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(114), static_cast<u8>(111), static_cast<u8>(119), static_cast<u8>(115), static_cast<u8>(32), static_cast<u8>(45), static_cast<u8>(62), static_cast<u8>(32), static_cast<u8>(83), static_cast<u8>(116), static_cast<u8>(114), static_cast<u8>(105), static_cast<u8>(110), static_cast<u8>(103), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(102), static_cast<u8>(117), static_cast<u8>(110), static_cast<u8>(99), static_cast<u8>(116), static_cast<u8>(105), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(114), static_cast<u8>(101), static_cast<u8>(112), static_cast<u8>(101), static_cast<u8>(97), static_cast<u8>(116), static_cast<u8>(101), static_cast<u8>(100), static_cast<u8>(40), static_cast<u8>(99), static_cast<u8>(104), static_cast<u8>(97), static_cast<u8>(114), static_cast<u8>(97), static_cast<u8>(99), static_cast<u8>(116), static_cast<u8>(101), static_cast<u8>(114), static_cast<u8>(58), static_cast<u8>(32), static_cast<u8>(99), static_cast<u8>(95), static_cast<u8>(99), static_cast<u8>(104), static_cast<u8>(97), static_cast<u8>(114), static_cast<u8>(44), static_cast<u8>(32), static_cast<u8>(99), static_cast<u8>(111), static_cast<u8>(117), static_cast<u8>(110), static_cast<u8>(116), static_cast<u8>(58), static_cast<u8>(32), static_cast<u8>(117), static_cast<u8>(115), static_cast<u8>(105), static_cast<u8>(122), static_cast<u8>(101), static_cast<u8>(41), static_cast<u8>(32), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(114), static_cast<u8>(111), static_cast<u8>(119), static_cast<u8>(115), static_cast<u8>(32), static_cast<u8>(45), static_cast<u8>(62), static_cast<u8>(32), static_cast<u8>(83), static_cast<u8>(116), static_cast<u8>(114), static_cast<u8>(105), static_cast<u8>(110), static_cast<u8>(103), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(102), static_cast<u8>(117), static_cast<u8>(110), static_cast<u8>(99), static_cast<u8>(116), static_cast<u8>(105), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(105), static_cast<u8>(115), static_cast<u8>(95), static_cast<u8>(101), static_cast<u8>(109), static_cast<u8>(112), static_cast<u8>(116), static_cast<u8>(121), static_cast<u8>(40), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(105), static_cast<u8>(115), static_cast<u8>(41), static_cast<u8>(32), static_cast<u8>(45), static_cast<u8>(62), static_cast<u8>(32), static_cast<u8>(98), static_cast<u8>(111), static_cast<u8>(111), static_cast<u8>(108), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(102), static_cast<u8>(117), static_cast<u8>(110), static_cast<u8>(99), static_cast<u8>(116), static_cast<u8>(105), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(108), static_cast<u8>(101), static_cast<u8>(110), static_cast<u8>(103), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(40), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(105), static_cast<u8>(115), static_cast<u8>(41), static_cast<u8>(32), static_cast<u8>(45), static_cast<u8>(62), static_cast<u8>(32), static_cast<u8>(117), static_cast<u8>(115), static_cast<u8>(105), static_cast<u8>(122), static_cast<u8>(101), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(102), static_cast<u8>(117), static_cast<u8>(110), static_cast<u8>(99), static_cast<u8>(116), static_cast<u8>(105), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(98), static_cast<u8>(121), static_cast<u8>(116), static_cast<u8>(101), static_cast<u8>(95), static_cast<u8>(97), static_cast<u8>(116), static_cast<u8>(40), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(105), static_cast<u8>(115), static_cast<u8>(44), static_cast<u8>(32), static_cast<u8>(97), static_cast<u8>(110), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(105), static_cast<u8>(110), static_cast<u8>(100), static_cast<u8>(101), static_cast<u8>(120), static_cast<u8>(58), static_cast<u8>(32), static_cast<u8>(117), static_cast<u8>(115), static_cast<u8>(105), static_cast<u8>(122), static_cast<u8>(101), static_cast<u8>(41), static_cast<u8>(32), static_cast<u8>(45), static_cast<u8>(62), static_cast<u8>(32), static_cast<u8>(117), static_cast<u8>(56), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(102), static_cast<u8>(117), static_cast<u8>(110), static_cast<u8>(99), static_cast<u8>(116), static_cast<u8>(105), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(99), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(116), static_cast<u8>(97), static_cast<u8>(105), static_cast<u8>(110), static_cast<u8>(115), static_cast<u8>(40), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(105), static_cast<u8>(115), static_cast<u8>(44), static_cast<u8>(32), static_cast<u8>(97), static_cast<u8>(110), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(110), static_cast<u8>(101), static_cast<u8>(101), static_cast<u8>(100), static_cast<u8>(108), static_cast<u8>(101), static_cast<u8>(58), static_cast<u8>(32), static_cast<u8>(83), static_cast<u8>(116), static_cast<u8>(114), static_cast<u8>(105), static_cast<u8>(110), static_cast<u8>(103), static_cast<u8>(41), static_cast<u8>(32), static_cast<u8>(45), static_cast<u8>(62), static_cast<u8>(32), static_cast<u8>(98), static_cast<u8>(111), static_cast<u8>(111), static_cast<u8>(108), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(102), static_cast<u8>(117), static_cast<u8>(110), static_cast<u8>(99), static_cast<u8>(116), static_cast<u8>(105), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(114), static_cast<u8>(101), static_cast<u8>(112), static_cast<u8>(108), static_cast<u8>(97), static_cast<u8>(99), static_cast<u8>(101), static_cast<u8>(40), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(105), static_cast<u8>(115), static_cast<u8>(44), static_cast<u8>(32), static_cast<u8>(114), static_cast<u8>(101), static_cast<u8>(112), static_cast<u8>(108), static_cast<u8>(97), static_cast<u8>(99), static_cast<u8>(101), static_cast<u8>(58), static_cast<u8>(32), static_cast<u8>(83), static_cast<u8>(116), static_cast<u8>(114), static_cast<u8>(105), static_cast<u8>(110), static_cast<u8>(103), static_cast<u8>(44), static_cast<u8>(32), static_cast<u8>(119), static_cast<u8>(105), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(58), static_cast<u8>(32), static_cast<u8>(83), static_cast<u8>(116), static_cast<u8>(114), static_cast<u8>(105), static_cast<u8>(110), static_cast<u8>(103), static_cast<u8>(41), static_cast<u8>(32), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(114), static_cast<u8>(111), static_cast<u8>(119), static_cast<u8>(115), static_cast<u8>(32), static_cast<u8>(45), static_cast<u8>(62), static_cast<u8>(32), static_cast<u8>(83), static_cast<u8>(116), static_cast<u8>(114), static_cast<u8>(105), static_cast<u8>(110), static_cast<u8>(103), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(102), static_cast<u8>(117), static_cast<u8>(110), static_cast<u8>(99), static_cast<u8>(116), static_cast<u8>(105), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(115), static_cast<u8>(116), static_cast<u8>(97), static_cast<u8>(114), static_cast<u8>(116), static_cast<u8>(115), static_cast<u8>(95), static_cast<u8>(119), static_cast<u8>(105), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(40), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(105), static_cast<u8>(115), static_cast<u8>(44), static_cast<u8>(32), static_cast<u8>(97), static_cast<u8>(110), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(110), static_cast<u8>(101), static_cast<u8>(101), static_cast<u8>(100), static_cast<u8>(108), static_cast<u8>(101), static_cast<u8>(58), static_cast<u8>(32), static_cast<u8>(83), static_cast<u8>(116), static_cast<u8>(114), static_cast<u8>(105), static_cast<u8>(110), static_cast<u8>(103), static_cast<u8>(41), static_cast<u8>(32), static_cast<u8>(45), static_cast<u8>(62), static_cast<u8>(32), static_cast<u8>(98), static_cast<u8>(111), static_cast<u8>(111), static_cast<u8>(108), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(102), static_cast<u8>(117), static_cast<u8>(110), static_cast<u8>(99), static_cast<u8>(116), static_cast<u8>(105), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(101), static_cast<u8>(110), static_cast<u8>(100), static_cast<u8>(115), static_cast<u8>(95), static_cast<u8>(119), static_cast<u8>(105), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(40), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(105), static_cast<u8>(115), static_cast<u8>(44), static_cast<u8>(32), static_cast<u8>(97), static_cast<u8>(110), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(110), static_cast<u8>(101), static_cast<u8>(101), static_cast<u8>(100), static_cast<u8>(108), static_cast<u8>(101), static_cast<u8>(58), static_cast<u8>(32), static_cast<u8>(83), static_cast<u8>(116), static_cast<u8>(114), static_cast<u8>(105), static_cast<u8>(110), static_cast<u8>(103), static_cast<u8>(41), static_cast<u8>(32), static_cast<u8>(45), static_cast<u8>(62), static_cast<u8>(32), static_cast<u8>(98), static_cast<u8>(111), static_cast<u8>(111), static_cast<u8>(108), static_cast<u8>(10), static_cast<u8>(125), static_cast<u8>(10), static_cast<u8>(10), static_cast<u8>(101), static_cast<u8>(120), static_cast<u8>(116), static_cast<u8>(101), static_cast<u8>(114), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(115), static_cast<u8>(116), static_cast<u8>(114), static_cast<u8>(117), static_cast<u8>(99), static_cast<u8>(116), static_cast<u8>(32), static_cast<u8>(83), static_cast<u8>(116), static_cast<u8>(114), static_cast<u8>(105), static_cast<u8>(110), static_cast<u8>(103), static_cast<u8>(66), static_cast<u8>(117), static_cast<u8>(105), static_cast<u8>(108), static_cast<u8>(100), static_cast<u8>(101), static_cast<u8>(114), static_cast<u8>(32), static_cast<u8>(123), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(102), static_cast<u8>(117), static_cast<u8>(110), static_cast<u8>(99), static_cast<u8>(116), static_cast<u8>(105), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(97), static_cast<u8>(112), static_cast<u8>(112), static_cast<u8>(101), static_cast<u8>(110), static_cast<u8>(100), static_cast<u8>(40), static_cast<u8>(109), static_cast<u8>(117), static_cast<u8>(116), static_cast<u8>(32), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(105), static_cast<u8>(115), static_cast<u8>(44), static_cast<u8>(32), static_cast<u8>(97), static_cast<u8>(110), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(98), static_cast<u8>(58), static_cast<u8>(32), static_cast<u8>(117), static_cast<u8>(56), static_cast<u8>(41), static_cast<u8>(32), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(114), static_cast<u8>(111), static_cast<u8>(119), static_cast<u8>(115), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(102), static_cast<u8>(117), static_cast<u8>(110), static_cast<u8>(99), static_cast<u8>(116), static_cast<u8>(105), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(97), static_cast<u8>(112), static_cast<u8>(112), static_cast<u8>(101), static_cast<u8>(110), static_cast<u8>(100), static_cast<u8>(95), static_cast<u8>(115), static_cast<u8>(116), static_cast<u8>(114), static_cast<u8>(105), static_cast<u8>(110), static_cast<u8>(103), static_cast<u8>(40), static_cast<u8>(109), static_cast<u8>(117), static_cast<u8>(116), static_cast<u8>(32), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(105), static_cast<u8>(115), static_cast<u8>(44), static_cast<u8>(32), static_cast<u8>(97), static_cast<u8>(110), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(115), static_cast<u8>(58), static_cast<u8>(32), static_cast<u8>(83), static_cast<u8>(116), static_cast<u8>(114), static_cast<u8>(105), static_cast<u8>(110), static_cast<u8>(103), static_cast<u8>(41), static_cast<u8>(32), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(114), static_cast<u8>(111), static_cast<u8>(119), static_cast<u8>(115), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(102), static_cast<u8>(117), static_cast<u8>(110), static_cast<u8>(99), static_cast<u8>(116), static_cast<u8>(105), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(97), static_cast<u8>(112), static_cast<u8>(112), static_cast<u8>(101), static_cast<u8>(110), static_cast<u8>(100), static_cast<u8>(95), static_cast<u8>(99), static_cast<u8>(95), static_cast<u8>(115), static_cast<u8>(116), static_cast<u8>(114), static_cast<u8>(105), static_cast<u8>(110), static_cast<u8>(103), static_cast<u8>(40), static_cast<u8>(109), static_cast<u8>(117), static_cast<u8>(116), static_cast<u8>(32), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(105), static_cast<u8>(115), static_cast<u8>(44), static_cast<u8>(32), static_cast<u8>(97), static_cast<u8>(110), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(115), static_cast<u8>(58), static_cast<u8>(32), static_cast<u8>(114), static_cast<u8>(97), static_cast<u8>(119), static_cast<u8>(32), static_cast<u8>(99), static_cast<u8>(95), static_cast<u8>(99), static_cast<u8>(104), static_cast<u8>(97), static_cast<u8>(114), static_cast<u8>(41), static_cast<u8>(32), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(114), static_cast<u8>(111), static_cast<u8>(119), static_cast<u8>(115), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(102), static_cast<u8>(117), static_cast<u8>(110), static_cast<u8>(99), static_cast<u8>(116), static_cast<u8>(105), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(97), static_cast<u8>(112), static_cast<u8>(112), static_cast<u8>(101), static_cast<u8>(110), static_cast<u8>(100), static_cast<u8>(95), static_cast<u8>(99), static_cast<u8>(111), static_cast<u8>(100), static_cast<u8>(101), static_cast<u8>(95), static_cast<u8>(112), static_cast<u8>(111), static_cast<u8>(105), static_cast<u8>(110), static_cast<u8>(116), static_cast<u8>(40), static_cast<u8>(109), static_cast<u8>(117), static_cast<u8>(116), static_cast<u8>(32), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(105), static_cast<u8>(115), static_cast<u8>(44), static_cast<u8>(32), static_cast<u8>(97), static_cast<u8>(110), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(99), static_cast<u8>(111), static_cast<u8>(100), static_cast<u8>(101), static_cast<u8>(95), static_cast<u8>(112), static_cast<u8>(111), static_cast<u8>(105), static_cast<u8>(110), static_cast<u8>(116), static_cast<u8>(58), static_cast<u8>(32), static_cast<u8>(117), static_cast<u8>(51), static_cast<u8>(50), static_cast<u8>(41), static_cast<u8>(32), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(114), static_cast<u8>(111), static_cast<u8>(119), static_cast<u8>(115), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(102), static_cast<u8>(117), static_cast<u8>(110), static_cast<u8>(99), static_cast<u8>(116), static_cast<u8>(105), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(97), static_cast<u8>(112), static_cast<u8>(112), static_cast<u8>(101), static_cast<u8>(110), static_cast<u8>(100), static_cast<u8>(95), static_cast<u8>(101), static_cast<u8>(115), static_cast<u8>(99), static_cast<u8>(97), static_cast<u8>(112), static_cast<u8>(101), static_cast<u8>(100), static_cast<u8>(95), static_cast<u8>(102), static_cast<u8>(111), static_cast<u8>(114), static_cast<u8>(95), static_cast<u8>(106), static_cast<u8>(115), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(40), static_cast<u8>(109), static_cast<u8>(117), static_cast<u8>(116), static_cast<u8>(32), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(105), static_cast<u8>(115), static_cast<u8>(44), static_cast<u8>(32), static_cast<u8>(97), static_cast<u8>(110), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(115), static_cast<u8>(58), static_cast<u8>(32), static_cast<u8>(83), static_cast<u8>(116), static_cast<u8>(114), static_cast<u8>(105), static_cast<u8>(110), static_cast<u8>(103), static_cast<u8>(41), static_cast<u8>(32), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(114), static_cast<u8>(111), static_cast<u8>(119), static_cast<u8>(115), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(102), static_cast<u8>(117), static_cast<u8>(110), static_cast<u8>(99), static_cast<u8>(116), static_cast<u8>(105), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(116), static_cast<u8>(111), static_cast<u8>(95), static_cast<u8>(115), static_cast<u8>(116), static_cast<u8>(114), static_cast<u8>(105), static_cast<u8>(110), static_cast<u8>(103), static_cast<u8>(40), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(105), static_cast<u8>(115), static_cast<u8>(41), static_cast<u8>(32), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(114), static_cast<u8>(111), static_cast<u8>(119), static_cast<u8>(115), static_cast<u8>(32), static_cast<u8>(45), static_cast<u8>(62), static_cast<u8>(32), static_cast<u8>(83), static_cast<u8>(116), static_cast<u8>(114), static_cast<u8>(105), static_cast<u8>(110), static_cast<u8>(103), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(102), static_cast<u8>(117), static_cast<u8>(110), static_cast<u8>(99), static_cast<u8>(116), static_cast<u8>(105), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(105), static_cast<u8>(115), static_cast<u8>(95), static_cast<u8>(101), static_cast<u8>(109), static_cast<u8>(112), static_cast<u8>(116), static_cast<u8>(121), static_cast<u8>(40), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(105), static_cast<u8>(115), static_cast<u8>(41), static_cast<u8>(32), static_cast<u8>(45), static_cast<u8>(62), static_cast<u8>(32), static_cast<u8>(98), static_cast<u8>(111), static_cast<u8>(111), static_cast<u8>(108), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(102), static_cast<u8>(117), static_cast<u8>(110), static_cast<u8>(99), static_cast<u8>(116), static_cast<u8>(105), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(108), static_cast<u8>(101), static_cast<u8>(110), static_cast<u8>(103), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(40), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(105), static_cast<u8>(115), static_cast<u8>(41), static_cast<u8>(32), static_cast<u8>(45), static_cast<u8>(62), static_cast<u8>(32), static_cast<u8>(117), static_cast<u8>(115), static_cast<u8>(105), static_cast<u8>(122), static_cast<u8>(101), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(102), static_cast<u8>(117), static_cast<u8>(110), static_cast<u8>(99), static_cast<u8>(116), static_cast<u8>(105), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(99), static_cast<u8>(108), static_cast<u8>(101), static_cast<u8>(97), static_cast<u8>(114), static_cast<u8>(40), static_cast<u8>(109), static_cast<u8>(117), static_cast<u8>(116), static_cast<u8>(32), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(105), static_cast<u8>(115), static_cast<u8>(41), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(102), static_cast<u8>(117), static_cast<u8>(110), static_cast<u8>(99), static_cast<u8>(116), static_cast<u8>(105), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(99), static_cast<u8>(114), static_cast<u8>(101), static_cast<u8>(97), static_cast<u8>(116), static_cast<u8>(101), static_cast<u8>(40), static_cast<u8>(41), static_cast<u8>(32), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(114), static_cast<u8>(111), static_cast<u8>(119), static_cast<u8>(115), static_cast<u8>(32), static_cast<u8>(45), static_cast<u8>(62), static_cast<u8>(32), static_cast<u8>(83), static_cast<u8>(116), static_cast<u8>(114), static_cast<u8>(105), static_cast<u8>(110), static_cast<u8>(103), static_cast<u8>(66), static_cast<u8>(117), static_cast<u8>(105), static_cast<u8>(108), static_cast<u8>(100), static_cast<u8>(101), static_cast<u8>(114), static_cast<u8>(10), static_cast<u8>(125), static_cast<u8>(10), static_cast<u8>(10), static_cast<u8>(101), static_cast<u8>(120), static_cast<u8>(116), static_cast<u8>(101), static_cast<u8>(114), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(115), static_cast<u8>(116), static_cast<u8>(114), static_cast<u8>(117), static_cast<u8>(99), static_cast<u8>(116), static_cast<u8>(32), static_cast<u8>(87), static_cast<u8>(101), static_cast<u8>(97), static_cast<u8>(107), static_cast<u8>(80), static_cast<u8>(116), static_cast<u8>(114), static_cast<u8>(60), static_cast<u8>(84), static_cast<u8>(62), static_cast<u8>(32), static_cast<u8>(123), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(102), static_cast<u8>(117), static_cast<u8>(110), static_cast<u8>(99), static_cast<u8>(116), static_cast<u8>(105), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(104), static_cast<u8>(97), static_cast<u8>(115), static_cast<u8>(95), static_cast<u8>(118), static_cast<u8>(97), static_cast<u8>(108), static_cast<u8>(117), static_cast<u8>(101), static_cast<u8>(40), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(105), static_cast<u8>(115), static_cast<u8>(41), static_cast<u8>(32), static_cast<u8>(45), static_cast<u8>(62), static_cast<u8>(32), static_cast<u8>(98), static_cast<u8>(111), static_cast<u8>(111), static_cast<u8>(108), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(102), static_cast<u8>(117), static_cast<u8>(110), static_cast<u8>(99), static_cast<u8>(116), static_cast<u8>(105), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(99), static_cast<u8>(108), static_cast<u8>(101), static_cast<u8>(97), static_cast<u8>(114), static_cast<u8>(40), static_cast<u8>(109), static_cast<u8>(117), static_cast<u8>(116), static_cast<u8>(32), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(105), static_cast<u8>(115), static_cast<u8>(41), static_cast<u8>(10), static_cast<u8>(125), static_cast<u8>(10), static_cast<u8>(10), static_cast<u8>(101), static_cast<u8>(120), static_cast<u8>(116), static_cast<u8>(101), static_cast<u8>(114), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(115), static_cast<u8>(116), static_cast<u8>(114), static_cast<u8>(117), static_cast<u8>(99), static_cast<u8>(116), static_cast<u8>(32), static_cast<u8>(84), static_cast<u8>(117), static_cast<u8>(112), static_cast<u8>(108), static_cast<u8>(101), static_cast<u8>(32), static_cast<u8>(123), static_cast<u8>(125), static_cast<u8>(10), static_cast<u8>(10), static_cast<u8>(101), static_cast<u8>(120), static_cast<u8>(116), static_cast<u8>(101), static_cast<u8>(114), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(115), static_cast<u8>(116), static_cast<u8>(114), static_cast<u8>(117), static_cast<u8>(99), static_cast<u8>(116), static_cast<u8>(32), static_cast<u8>(68), static_cast<u8>(105), static_cast<u8>(99), static_cast<u8>(116), static_cast<u8>(105), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(97), static_cast<u8>(114), static_cast<u8>(121), static_cast<u8>(73), static_cast<u8>(116), static_cast<u8>(101), static_cast<u8>(114), static_cast<u8>(97), static_cast<u8>(116), static_cast<u8>(111), static_cast<u8>(114), static_cast<u8>(60), static_cast<u8>(75), static_cast<u8>(44), static_cast<u8>(32), static_cast<u8>(86), static_cast<u8>(62), static_cast<u8>(32), static_cast<u8>(123), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(102), static_cast<u8>(117), static_cast<u8>(110), static_cast<u8>(99), static_cast<u8>(116), static_cast<u8>(105), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(110), static_cast<u8>(101), static_cast<u8>(120), static_cast<u8>(116), static_cast<u8>(40), static_cast<u8>(109), static_cast<u8>(117), static_cast<u8>(116), static_cast<u8>(32), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(105), static_cast<u8>(115), static_cast<u8>(41), static_cast<u8>(32), static_cast<u8>(45), static_cast<u8>(62), static_cast<u8>(32), static_cast<u8>(40), static_cast<u8>(75), static_cast<u8>(44), static_cast<u8>(32), static_cast<u8>(86), static_cast<u8>(41), static_cast<u8>(63), static_cast<u8>(10), static_cast<u8>(125), static_cast<u8>(10), static_cast<u8>(10), static_cast<u8>(101), static_cast<u8>(120), static_cast<u8>(116), static_cast<u8>(101), static_cast<u8>(114), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(115), static_cast<u8>(116), static_cast<u8>(114), static_cast<u8>(117), static_cast<u8>(99), static_cast<u8>(116), static_cast<u8>(32), static_cast<u8>(68), static_cast<u8>(105), static_cast<u8>(99), static_cast<u8>(116), static_cast<u8>(105), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(97), static_cast<u8>(114), static_cast<u8>(121), static_cast<u8>(60), static_cast<u8>(75), static_cast<u8>(44), static_cast<u8>(32), static_cast<u8>(86), static_cast<u8>(62), static_cast<u8>(32), static_cast<u8>(123), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(102), static_cast<u8>(117), static_cast<u8>(110), static_cast<u8>(99), static_cast<u8>(116), static_cast<u8>(105), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(105), static_cast<u8>(115), static_cast<u8>(95), static_cast<u8>(101), static_cast<u8>(109), static_cast<u8>(112), static_cast<u8>(116), static_cast<u8>(121), static_cast<u8>(40), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(105), static_cast<u8>(115), static_cast<u8>(41), static_cast<u8>(32), static_cast<u8>(45), static_cast<u8>(62), static_cast<u8>(32), static_cast<u8>(98), static_cast<u8>(111), static_cast<u8>(111), static_cast<u8>(108), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(102), static_cast<u8>(117), static_cast<u8>(110), static_cast<u8>(99), static_cast<u8>(116), static_cast<u8>(105), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(103), static_cast<u8>(101), static_cast<u8>(116), static_cast<u8>(40), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(105), static_cast<u8>(115), static_cast<u8>(44), static_cast<u8>(32), static_cast<u8>(97), static_cast<u8>(110), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(107), static_cast<u8>(101), static_cast<u8>(121), static_cast<u8>(58), static_cast<u8>(32), static_cast<u8>(75), static_cast<u8>(41), static_cast<u8>(32), static_cast<u8>(45), static_cast<u8>(62), static_cast<u8>(32), static_cast<u8>(86), static_cast<u8>(63), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(102), static_cast<u8>(117), static_cast<u8>(110), static_cast<u8>(99), static_cast<u8>(116), static_cast<u8>(105), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(99), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(116), static_cast<u8>(97), static_cast<u8>(105), static_cast<u8>(110), static_cast<u8>(115), static_cast<u8>(40), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(105), static_cast<u8>(115), static_cast<u8>(44), static_cast<u8>(32), static_cast<u8>(97), static_cast<u8>(110), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(107), static_cast<u8>(101), static_cast<u8>(121), static_cast<u8>(58), static_cast<u8>(32), static_cast<u8>(75), static_cast<u8>(41), static_cast<u8>(32), static_cast<u8>(45), static_cast<u8>(62), static_cast<u8>(32), static_cast<u8>(98), static_cast<u8>(111), static_cast<u8>(111), static_cast<u8>(108), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(102), static_cast<u8>(117), static_cast<u8>(110), static_cast<u8>(99), static_cast<u8>(116), static_cast<u8>(105), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(115), static_cast<u8>(101), static_cast<u8>(116), static_cast<u8>(40), static_cast<u8>(109), static_cast<u8>(117), static_cast<u8>(116), static_cast<u8>(32), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(105), static_cast<u8>(115), static_cast<u8>(44), static_cast<u8>(32), static_cast<u8>(97), static_cast<u8>(110), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(107), static_cast<u8>(101), static_cast<u8>(121), static_cast<u8>(58), static_cast<u8>(32), static_cast<u8>(75), static_cast<u8>(44), static_cast<u8>(32), static_cast<u8>(97), static_cast<u8>(110), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(118), static_cast<u8>(97), static_cast<u8>(108), static_cast<u8>(117), static_cast<u8>(101), static_cast<u8>(58), static_cast<u8>(32), static_cast<u8>(86), static_cast<u8>(41), static_cast<u8>(32), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(114), static_cast<u8>(111), static_cast<u8>(119), static_cast<u8>(115), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(102), static_cast<u8>(117), static_cast<u8>(110), static_cast<u8>(99), static_cast<u8>(116), static_cast<u8>(105), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(114), static_cast<u8>(101), static_cast<u8>(109), static_cast<u8>(111), static_cast<u8>(118), static_cast<u8>(101), static_cast<u8>(40), static_cast<u8>(109), static_cast<u8>(117), static_cast<u8>(116), static_cast<u8>(32), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(105), static_cast<u8>(115), static_cast<u8>(44), static_cast<u8>(32), static_cast<u8>(97), static_cast<u8>(110), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(107), static_cast<u8>(101), static_cast<u8>(121), static_cast<u8>(58), static_cast<u8>(32), static_cast<u8>(75), static_cast<u8>(41), static_cast<u8>(32), static_cast<u8>(45), static_cast<u8>(62), static_cast<u8>(32), static_cast<u8>(98), static_cast<u8>(111), static_cast<u8>(111), static_cast<u8>(108), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(102), static_cast<u8>(117), static_cast<u8>(110), static_cast<u8>(99), static_cast<u8>(116), static_cast<u8>(105), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(101), static_cast<u8>(110), static_cast<u8>(115), static_cast<u8>(117), static_cast<u8>(114), static_cast<u8>(101), static_cast<u8>(95), static_cast<u8>(99), static_cast<u8>(97), static_cast<u8>(112), static_cast<u8>(97), static_cast<u8>(99), static_cast<u8>(105), static_cast<u8>(116), static_cast<u8>(121), static_cast<u8>(40), static_cast<u8>(109), static_cast<u8>(117), static_cast<u8>(116), static_cast<u8>(32), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(105), static_cast<u8>(115), static_cast<u8>(44), static_cast<u8>(32), static_cast<u8>(97), static_cast<u8>(110), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(99), static_cast<u8>(97), static_cast<u8>(112), static_cast<u8>(97), static_cast<u8>(99), static_cast<u8>(105), static_cast<u8>(116), static_cast<u8>(121), static_cast<u8>(58), static_cast<u8>(32), static_cast<u8>(117), static_cast<u8>(115), static_cast<u8>(105), static_cast<u8>(122), static_cast<u8>(101), static_cast<u8>(41), static_cast<u8>(32), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(114), static_cast<u8>(111), static_cast<u8>(119), static_cast<u8>(115), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(102), static_cast<u8>(117), static_cast<u8>(110), static_cast<u8>(99), static_cast<u8>(116), static_cast<u8>(105), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(99), static_cast<u8>(108), static_cast<u8>(101), static_cast<u8>(97), static_cast<u8>(114), static_cast<u8>(40), static_cast<u8>(109), static_cast<u8>(117), static_cast<u8>(116), static_cast<u8>(32), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(105), static_cast<u8>(115), static_cast<u8>(41), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(102), static_cast<u8>(117), static_cast<u8>(110), static_cast<u8>(99), static_cast<u8>(116), static_cast<u8>(105), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(115), static_cast<u8>(105), static_cast<u8>(122), static_cast<u8>(101), static_cast<u8>(40), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(105), static_cast<u8>(115), static_cast<u8>(41), static_cast<u8>(32), static_cast<u8>(45), static_cast<u8>(62), static_cast<u8>(32), static_cast<u8>(117), static_cast<u8>(115), static_cast<u8>(105), static_cast<u8>(122), static_cast<u8>(101), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(102), static_cast<u8>(117), static_cast<u8>(110), static_cast<u8>(99), static_cast<u8>(116), static_cast<u8>(105), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(99), static_cast<u8>(97), static_cast<u8>(112), static_cast<u8>(97), static_cast<u8>(99), static_cast<u8>(105), static_cast<u8>(116), static_cast<u8>(121), static_cast<u8>(40), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(105), static_cast<u8>(115), static_cast<u8>(41), static_cast<u8>(32), static_cast<u8>(45), static_cast<u8>(62), static_cast<u8>(32), static_cast<u8>(117), static_cast<u8>(115), static_cast<u8>(105), static_cast<u8>(122), static_cast<u8>(101), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(102), static_cast<u8>(117), static_cast<u8>(110), static_cast<u8>(99), static_cast<u8>(116), static_cast<u8>(105), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(107), static_cast<u8>(101), static_cast<u8>(121), static_cast<u8>(115), static_cast<u8>(40), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(105), static_cast<u8>(115), static_cast<u8>(41), static_cast<u8>(32), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(114), static_cast<u8>(111), static_cast<u8>(119), static_cast<u8>(115), static_cast<u8>(32), static_cast<u8>(45), static_cast<u8>(62), static_cast<u8>(32), static_cast<u8>(91), static_cast<u8>(75), static_cast<u8>(93), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(102), static_cast<u8>(117), static_cast<u8>(110), static_cast<u8>(99), static_cast<u8>(116), static_cast<u8>(105), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(104), static_cast<u8>(97), static_cast<u8>(115), static_cast<u8>(104), static_cast<u8>(40), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(105), static_cast<u8>(115), static_cast<u8>(41), static_cast<u8>(32), static_cast<u8>(45), static_cast<u8>(62), static_cast<u8>(32), static_cast<u8>(117), static_cast<u8>(51), static_cast<u8>(50), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(102), static_cast<u8>(117), static_cast<u8>(110), static_cast<u8>(99), static_cast<u8>(116), static_cast<u8>(105), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(68), static_cast<u8>(105), static_cast<u8>(99), static_cast<u8>(116), static_cast<u8>(105), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(97), static_cast<u8>(114), static_cast<u8>(121), static_cast<u8>(60), static_cast<u8>(65), static_cast<u8>(44), static_cast<u8>(32), static_cast<u8>(66), static_cast<u8>(62), static_cast<u8>(40), static_cast<u8>(41), static_cast<u8>(32), static_cast<u8>(45), static_cast<u8>(62), static_cast<u8>(32), static_cast<u8>(68), static_cast<u8>(105), static_cast<u8>(99), static_cast<u8>(116), static_cast<u8>(105), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(97), static_cast<u8>(114), static_cast<u8>(121), static_cast<u8>(60), static_cast<u8>(65), static_cast<u8>(44), static_cast<u8>(32), static_cast<u8>(66), static_cast<u8>(62), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(102), static_cast<u8>(117), static_cast<u8>(110), static_cast<u8>(99), static_cast<u8>(116), static_cast<u8>(105), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(105), static_cast<u8>(116), static_cast<u8>(101), static_cast<u8>(114), static_cast<u8>(97), static_cast<u8>(116), static_cast<u8>(111), static_cast<u8>(114), static_cast<u8>(40), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(105), static_cast<u8>(115), static_cast<u8>(41), static_cast<u8>(32), static_cast<u8>(45), static_cast<u8>(62), static_cast<u8>(32), static_cast<u8>(68), static_cast<u8>(105), static_cast<u8>(99), static_cast<u8>(116), static_cast<u8>(105), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(97), static_cast<u8>(114), static_cast<u8>(121), static_cast<u8>(73), static_cast<u8>(116), static_cast<u8>(101), static_cast<u8>(114), static_cast<u8>(97), static_cast<u8>(116), static_cast<u8>(111), static_cast<u8>(114), static_cast<u8>(60), static_cast<u8>(75), static_cast<u8>(44), static_cast<u8>(32), static_cast<u8>(86), static_cast<u8>(62), static_cast<u8>(10), static_cast<u8>(125), static_cast<u8>(10), static_cast<u8>(10), static_cast<u8>(101), static_cast<u8>(120), static_cast<u8>(116), static_cast<u8>(101), static_cast<u8>(114), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(115), static_cast<u8>(116), static_cast<u8>(114), static_cast<u8>(117), static_cast<u8>(99), static_cast<u8>(116), static_cast<u8>(32), static_cast<u8>(83), static_cast<u8>(101), static_cast<u8>(116), static_cast<u8>(73), static_cast<u8>(116), static_cast<u8>(101), static_cast<u8>(114), static_cast<u8>(97), static_cast<u8>(116), static_cast<u8>(111), static_cast<u8>(114), static_cast<u8>(60), static_cast<u8>(84), static_cast<u8>(62), static_cast<u8>(32), static_cast<u8>(123), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(102), static_cast<u8>(117), static_cast<u8>(110), static_cast<u8>(99), static_cast<u8>(116), static_cast<u8>(105), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(110), static_cast<u8>(101), static_cast<u8>(120), static_cast<u8>(116), static_cast<u8>(40), static_cast<u8>(109), static_cast<u8>(117), static_cast<u8>(116), static_cast<u8>(32), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(105), static_cast<u8>(115), static_cast<u8>(41), static_cast<u8>(32), static_cast<u8>(45), static_cast<u8>(62), static_cast<u8>(32), static_cast<u8>(84), static_cast<u8>(63), static_cast<u8>(10), static_cast<u8>(125), static_cast<u8>(10), static_cast<u8>(10), static_cast<u8>(101), static_cast<u8>(120), static_cast<u8>(116), static_cast<u8>(101), static_cast<u8>(114), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(115), static_cast<u8>(116), static_cast<u8>(114), static_cast<u8>(117), static_cast<u8>(99), static_cast<u8>(116), static_cast<u8>(32), static_cast<u8>(83), static_cast<u8>(101), static_cast<u8>(116), static_cast<u8>(60), static_cast<u8>(86), static_cast<u8>(62), static_cast<u8>(32), static_cast<u8>(123), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(102), static_cast<u8>(117), static_cast<u8>(110), static_cast<u8>(99), static_cast<u8>(116), static_cast<u8>(105), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(105), static_cast<u8>(115), static_cast<u8>(95), static_cast<u8>(101), static_cast<u8>(109), static_cast<u8>(112), static_cast<u8>(116), static_cast<u8>(121), static_cast<u8>(40), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(105), static_cast<u8>(115), static_cast<u8>(41), static_cast<u8>(32), static_cast<u8>(45), static_cast<u8>(62), static_cast<u8>(32), static_cast<u8>(98), static_cast<u8>(111), static_cast<u8>(111), static_cast<u8>(108), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(102), static_cast<u8>(117), static_cast<u8>(110), static_cast<u8>(99), static_cast<u8>(116), static_cast<u8>(105), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(99), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(116), static_cast<u8>(97), static_cast<u8>(105), static_cast<u8>(110), static_cast<u8>(115), static_cast<u8>(40), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(105), static_cast<u8>(115), static_cast<u8>(44), static_cast<u8>(32), static_cast<u8>(97), static_cast<u8>(110), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(118), static_cast<u8>(97), static_cast<u8>(108), static_cast<u8>(117), static_cast<u8>(101), static_cast<u8>(58), static_cast<u8>(32), static_cast<u8>(86), static_cast<u8>(41), static_cast<u8>(32), static_cast<u8>(45), static_cast<u8>(62), static_cast<u8>(32), static_cast<u8>(98), static_cast<u8>(111), static_cast<u8>(111), static_cast<u8>(108), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(102), static_cast<u8>(117), static_cast<u8>(110), static_cast<u8>(99), static_cast<u8>(116), static_cast<u8>(105), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(97), static_cast<u8>(100), static_cast<u8>(100), static_cast<u8>(40), static_cast<u8>(109), static_cast<u8>(117), static_cast<u8>(116), static_cast<u8>(32), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(105), static_cast<u8>(115), static_cast<u8>(44), static_cast<u8>(32), static_cast<u8>(97), static_cast<u8>(110), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(118), static_cast<u8>(97), static_cast<u8>(108), static_cast<u8>(117), static_cast<u8>(101), static_cast<u8>(58), static_cast<u8>(32), static_cast<u8>(86), static_cast<u8>(41), static_cast<u8>(32), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(114), static_cast<u8>(111), static_cast<u8>(119), static_cast<u8>(115), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(102), static_cast<u8>(117), static_cast<u8>(110), static_cast<u8>(99), static_cast<u8>(116), static_cast<u8>(105), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(114), static_cast<u8>(101), static_cast<u8>(109), static_cast<u8>(111), static_cast<u8>(118), static_cast<u8>(101), static_cast<u8>(40), static_cast<u8>(109), static_cast<u8>(117), static_cast<u8>(116), static_cast<u8>(32), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(105), static_cast<u8>(115), static_cast<u8>(44), static_cast<u8>(32), static_cast<u8>(97), static_cast<u8>(110), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(118), static_cast<u8>(97), static_cast<u8>(108), static_cast<u8>(117), static_cast<u8>(101), static_cast<u8>(58), static_cast<u8>(32), static_cast<u8>(86), static_cast<u8>(41), static_cast<u8>(32), static_cast<u8>(45), static_cast<u8>(62), static_cast<u8>(32), static_cast<u8>(98), static_cast<u8>(111), static_cast<u8>(111), static_cast<u8>(108), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(102), static_cast<u8>(117), static_cast<u8>(110), static_cast<u8>(99), static_cast<u8>(116), static_cast<u8>(105), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(101), static_cast<u8>(110), static_cast<u8>(115), static_cast<u8>(117), static_cast<u8>(114), static_cast<u8>(101), static_cast<u8>(95), static_cast<u8>(99), static_cast<u8>(97), static_cast<u8>(112), static_cast<u8>(97), static_cast<u8>(99), static_cast<u8>(105), static_cast<u8>(116), static_cast<u8>(121), static_cast<u8>(40), static_cast<u8>(109), static_cast<u8>(117), static_cast<u8>(116), static_cast<u8>(32), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(105), static_cast<u8>(115), static_cast<u8>(44), static_cast<u8>(32), static_cast<u8>(97), static_cast<u8>(110), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(99), static_cast<u8>(97), static_cast<u8>(112), static_cast<u8>(97), static_cast<u8>(99), static_cast<u8>(105), static_cast<u8>(116), static_cast<u8>(121), static_cast<u8>(58), static_cast<u8>(32), static_cast<u8>(117), static_cast<u8>(115), static_cast<u8>(105), static_cast<u8>(122), static_cast<u8>(101), static_cast<u8>(41), static_cast<u8>(32), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(114), static_cast<u8>(111), static_cast<u8>(119), static_cast<u8>(115), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(102), static_cast<u8>(117), static_cast<u8>(110), static_cast<u8>(99), static_cast<u8>(116), static_cast<u8>(105), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(99), static_cast<u8>(108), static_cast<u8>(101), static_cast<u8>(97), static_cast<u8>(114), static_cast<u8>(40), static_cast<u8>(109), static_cast<u8>(117), static_cast<u8>(116), static_cast<u8>(32), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(105), static_cast<u8>(115), static_cast<u8>(41), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(102), static_cast<u8>(117), static_cast<u8>(110), static_cast<u8>(99), static_cast<u8>(116), static_cast<u8>(105), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(115), static_cast<u8>(105), static_cast<u8>(122), static_cast<u8>(101), static_cast<u8>(40), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(105), static_cast<u8>(115), static_cast<u8>(41), static_cast<u8>(32), static_cast<u8>(45), static_cast<u8>(62), static_cast<u8>(32), static_cast<u8>(117), static_cast<u8>(115), static_cast<u8>(105), static_cast<u8>(122), static_cast<u8>(101), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(102), static_cast<u8>(117), static_cast<u8>(110), static_cast<u8>(99), static_cast<u8>(116), static_cast<u8>(105), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(99), static_cast<u8>(97), static_cast<u8>(112), static_cast<u8>(97), static_cast<u8>(99), static_cast<u8>(105), static_cast<u8>(116), static_cast<u8>(121), static_cast<u8>(40), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(105), static_cast<u8>(115), static_cast<u8>(41), static_cast<u8>(32), static_cast<u8>(45), static_cast<u8>(62), static_cast<u8>(32), static_cast<u8>(117), static_cast<u8>(115), static_cast<u8>(105), static_cast<u8>(122), static_cast<u8>(101), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(102), static_cast<u8>(117), static_cast<u8>(110), static_cast<u8>(99), static_cast<u8>(116), static_cast<u8>(105), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(104), static_cast<u8>(97), static_cast<u8>(115), static_cast<u8>(104), static_cast<u8>(40), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(105), static_cast<u8>(115), static_cast<u8>(41), static_cast<u8>(32), static_cast<u8>(45), static_cast<u8>(62), static_cast<u8>(32), static_cast<u8>(117), static_cast<u8>(51), static_cast<u8>(50), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(102), static_cast<u8>(117), static_cast<u8>(110), static_cast<u8>(99), static_cast<u8>(116), static_cast<u8>(105), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(83), static_cast<u8>(101), static_cast<u8>(116), static_cast<u8>(60), static_cast<u8>(65), static_cast<u8>(62), static_cast<u8>(40), static_cast<u8>(41), static_cast<u8>(32), static_cast<u8>(45), static_cast<u8>(62), static_cast<u8>(32), static_cast<u8>(83), static_cast<u8>(101), static_cast<u8>(116), static_cast<u8>(60), static_cast<u8>(65), static_cast<u8>(62), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(102), static_cast<u8>(117), static_cast<u8>(110), static_cast<u8>(99), static_cast<u8>(116), static_cast<u8>(105), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(105), static_cast<u8>(116), static_cast<u8>(101), static_cast<u8>(114), static_cast<u8>(97), static_cast<u8>(116), static_cast<u8>(111), static_cast<u8>(114), static_cast<u8>(40), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(105), static_cast<u8>(115), static_cast<u8>(41), static_cast<u8>(32), static_cast<u8>(45), static_cast<u8>(62), static_cast<u8>(32), static_cast<u8>(83), static_cast<u8>(101), static_cast<u8>(116), static_cast<u8>(73), static_cast<u8>(116), static_cast<u8>(101), static_cast<u8>(114), static_cast<u8>(97), static_cast<u8>(116), static_cast<u8>(111), static_cast<u8>(114), static_cast<u8>(60), static_cast<u8>(86), static_cast<u8>(62), static_cast<u8>(10), static_cast<u8>(125), static_cast<u8>(10), static_cast<u8>(10), static_cast<u8>(101), static_cast<u8>(120), static_cast<u8>(116), static_cast<u8>(101), static_cast<u8>(114), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(115), static_cast<u8>(116), static_cast<u8>(114), static_cast<u8>(117), static_cast<u8>(99), static_cast<u8>(116), static_cast<u8>(32), static_cast<u8>(82), static_cast<u8>(97), static_cast<u8>(110), static_cast<u8>(103), static_cast<u8>(101), static_cast<u8>(60), static_cast<u8>(84), static_cast<u8>(62), static_cast<u8>(32), static_cast<u8>(123), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(102), static_cast<u8>(117), static_cast<u8>(110), static_cast<u8>(99), static_cast<u8>(116), static_cast<u8>(105), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(82), static_cast<u8>(97), static_cast<u8>(110), static_cast<u8>(103), static_cast<u8>(101), static_cast<u8>(60), static_cast<u8>(85), static_cast<u8>(62), static_cast<u8>(40), static_cast<u8>(97), static_cast<u8>(110), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(115), static_cast<u8>(116), static_cast<u8>(97), static_cast<u8>(114), static_cast<u8>(116), static_cast<u8>(58), static_cast<u8>(32), static_cast<u8>(85), static_cast<u8>(44), static_cast<u8>(32), static_cast<u8>(97), static_cast<u8>(110), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(101), static_cast<u8>(110), static_cast<u8>(100), static_cast<u8>(58), static_cast<u8>(32), static_cast<u8>(85), static_cast<u8>(41), static_cast<u8>(32), static_cast<u8>(45), static_cast<u8>(62), static_cast<u8>(32), static_cast<u8>(82), static_cast<u8>(97), static_cast<u8>(110), static_cast<u8>(103), static_cast<u8>(101), static_cast<u8>(60), static_cast<u8>(85), static_cast<u8>(62), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(102), static_cast<u8>(117), static_cast<u8>(110), static_cast<u8>(99), static_cast<u8>(116), static_cast<u8>(105), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(110), static_cast<u8>(101), static_cast<u8>(120), static_cast<u8>(116), static_cast<u8>(40), static_cast<u8>(109), static_cast<u8>(117), static_cast<u8>(116), static_cast<u8>(32), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(105), static_cast<u8>(115), static_cast<u8>(41), static_cast<u8>(32), static_cast<u8>(45), static_cast<u8>(62), static_cast<u8>(32), static_cast<u8>(84), static_cast<u8>(63), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(102), static_cast<u8>(117), static_cast<u8>(110), static_cast<u8>(99), static_cast<u8>(116), static_cast<u8>(105), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(105), static_cast<u8>(110), static_cast<u8>(99), static_cast<u8>(108), static_cast<u8>(117), static_cast<u8>(115), static_cast<u8>(105), static_cast<u8>(118), static_cast<u8>(101), static_cast<u8>(40), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(105), static_cast<u8>(115), static_cast<u8>(41), static_cast<u8>(32), static_cast<u8>(45), static_cast<u8>(62), static_cast<u8>(32), static_cast<u8>(82), static_cast<u8>(97), static_cast<u8>(110), static_cast<u8>(103), static_cast<u8>(101), static_cast<u8>(60), static_cast<u8>(84), static_cast<u8>(62), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(102), static_cast<u8>(117), static_cast<u8>(110), static_cast<u8>(99), static_cast<u8>(116), static_cast<u8>(105), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(101), static_cast<u8>(120), static_cast<u8>(99), static_cast<u8>(108), static_cast<u8>(117), static_cast<u8>(115), static_cast<u8>(105), static_cast<u8>(118), static_cast<u8>(101), static_cast<u8>(40), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(105), static_cast<u8>(115), static_cast<u8>(41), static_cast<u8>(32), static_cast<u8>(45), static_cast<u8>(62), static_cast<u8>(32), static_cast<u8>(82), static_cast<u8>(97), static_cast<u8>(110), static_cast<u8>(103), static_cast<u8>(101), static_cast<u8>(60), static_cast<u8>(84), static_cast<u8>(62), static_cast<u8>(10), static_cast<u8>(125), static_cast<u8>(10), static_cast<u8>(10), static_cast<u8>(101), static_cast<u8>(120), static_cast<u8>(116), static_cast<u8>(101), static_cast<u8>(114), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(115), static_cast<u8>(116), static_cast<u8>(114), static_cast<u8>(117), static_cast<u8>(99), static_cast<u8>(116), static_cast<u8>(32), static_cast<u8>(69), static_cast<u8>(114), static_cast<u8>(114), static_cast<u8>(111), static_cast<u8>(114), static_cast<u8>(32), static_cast<u8>(123), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(102), static_cast<u8>(117), static_cast<u8>(110), static_cast<u8>(99), static_cast<u8>(116), static_cast<u8>(105), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(99), static_cast<u8>(111), static_cast<u8>(100), static_cast<u8>(101), static_cast<u8>(40), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(105), static_cast<u8>(115), static_cast<u8>(41), static_cast<u8>(32), static_cast<u8>(45), static_cast<u8>(62), static_cast<u8>(32), static_cast<u8>(105), static_cast<u8>(51), static_cast<u8>(50), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(102), static_cast<u8>(117), static_cast<u8>(110), static_cast<u8>(99), static_cast<u8>(116), static_cast<u8>(105), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(102), static_cast<u8>(114), static_cast<u8>(111), static_cast<u8>(109), static_cast<u8>(95), static_cast<u8>(101), static_cast<u8>(114), static_cast<u8>(114), static_cast<u8>(110), static_cast<u8>(111), static_cast<u8>(40), static_cast<u8>(97), static_cast<u8>(110), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(101), static_cast<u8>(114), static_cast<u8>(114), static_cast<u8>(110), static_cast<u8>(111), static_cast<u8>(58), static_cast<u8>(32), static_cast<u8>(105), static_cast<u8>(51), static_cast<u8>(50), static_cast<u8>(41), static_cast<u8>(32), static_cast<u8>(45), static_cast<u8>(62), static_cast<u8>(32), static_cast<u8>(69), static_cast<u8>(114), static_cast<u8>(114), static_cast<u8>(111), static_cast<u8>(114), static_cast<u8>(10), static_cast<u8>(125), static_cast<u8>(10), static_cast<u8>(10), static_cast<u8>(101), static_cast<u8>(120), static_cast<u8>(116), static_cast<u8>(101), static_cast<u8>(114), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(99), static_cast<u8>(108), static_cast<u8>(97), static_cast<u8>(115), static_cast<u8>(115), static_cast<u8>(32), static_cast<u8>(70), static_cast<u8>(105), static_cast<u8>(108), static_cast<u8>(101), static_cast<u8>(32), static_cast<u8>(123), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(112), static_cast<u8>(117), static_cast<u8>(98), static_cast<u8>(108), static_cast<u8>(105), static_cast<u8>(99), static_cast<u8>(32), static_cast<u8>(102), static_cast<u8>(117), static_cast<u8>(110), static_cast<u8>(99), static_cast<u8>(116), static_cast<u8>(105), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(111), static_cast<u8>(112), static_cast<u8>(101), static_cast<u8>(110), static_cast<u8>(95), static_cast<u8>(102), static_cast<u8>(111), static_cast<u8>(114), static_cast<u8>(95), static_cast<u8>(114), static_cast<u8>(101), static_cast<u8>(97), static_cast<u8>(100), static_cast<u8>(105), static_cast<u8>(110), static_cast<u8>(103), static_cast<u8>(40), static_cast<u8>(97), static_cast<u8>(110), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(112), static_cast<u8>(97), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(58), static_cast<u8>(32), static_cast<u8>(83), static_cast<u8>(116), static_cast<u8>(114), static_cast<u8>(105), static_cast<u8>(110), static_cast<u8>(103), static_cast<u8>(41), static_cast<u8>(32), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(114), static_cast<u8>(111), static_cast<u8>(119), static_cast<u8>(115), static_cast<u8>(32), static_cast<u8>(45), static_cast<u8>(62), static_cast<u8>(32), static_cast<u8>(70), static_cast<u8>(105), static_cast<u8>(108), static_cast<u8>(101), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(112), static_cast<u8>(117), static_cast<u8>(98), static_cast<u8>(108), static_cast<u8>(105), static_cast<u8>(99), static_cast<u8>(32), static_cast<u8>(102), static_cast<u8>(117), static_cast<u8>(110), static_cast<u8>(99), static_cast<u8>(116), static_cast<u8>(105), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(111), static_cast<u8>(112), static_cast<u8>(101), static_cast<u8>(110), static_cast<u8>(95), static_cast<u8>(102), static_cast<u8>(111), static_cast<u8>(114), static_cast<u8>(95), static_cast<u8>(119), static_cast<u8>(114), static_cast<u8>(105), static_cast<u8>(116), static_cast<u8>(105), static_cast<u8>(110), static_cast<u8>(103), static_cast<u8>(40), static_cast<u8>(97), static_cast<u8>(110), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(112), static_cast<u8>(97), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(58), static_cast<u8>(32), static_cast<u8>(83), static_cast<u8>(116), static_cast<u8>(114), static_cast<u8>(105), static_cast<u8>(110), static_cast<u8>(103), static_cast<u8>(41), static_cast<u8>(32), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(114), static_cast<u8>(111), static_cast<u8>(119), static_cast<u8>(115), static_cast<u8>(32), static_cast<u8>(45), static_cast<u8>(62), static_cast<u8>(32), static_cast<u8>(70), static_cast<u8>(105), static_cast<u8>(108), static_cast<u8>(101), static_cast<u8>(10), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(112), static_cast<u8>(117), static_cast<u8>(98), static_cast<u8>(108), static_cast<u8>(105), static_cast<u8>(99), static_cast<u8>(32), static_cast<u8>(102), static_cast<u8>(117), static_cast<u8>(110), static_cast<u8>(99), static_cast<u8>(116), static_cast<u8>(105), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(114), static_cast<u8>(101), static_cast<u8>(97), static_cast<u8>(100), static_cast<u8>(40), static_cast<u8>(109), static_cast<u8>(117), static_cast<u8>(116), static_cast<u8>(32), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(105), static_cast<u8>(115), static_cast<u8>(44), static_cast<u8>(32), static_cast<u8>(97), static_cast<u8>(110), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(98), static_cast<u8>(117), static_cast<u8>(102), static_cast<u8>(102), static_cast<u8>(101), static_cast<u8>(114), static_cast<u8>(58), static_cast<u8>(32), static_cast<u8>(91), static_cast<u8>(117), static_cast<u8>(56), static_cast<u8>(93), static_cast<u8>(41), static_cast<u8>(32), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(114), static_cast<u8>(111), static_cast<u8>(119), static_cast<u8>(115), static_cast<u8>(32), static_cast<u8>(45), static_cast<u8>(62), static_cast<u8>(32), static_cast<u8>(117), static_cast<u8>(115), static_cast<u8>(105), static_cast<u8>(122), static_cast<u8>(101), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(112), static_cast<u8>(117), static_cast<u8>(98), static_cast<u8>(108), static_cast<u8>(105), static_cast<u8>(99), static_cast<u8>(32), static_cast<u8>(102), static_cast<u8>(117), static_cast<u8>(110), static_cast<u8>(99), static_cast<u8>(116), static_cast<u8>(105), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(119), static_cast<u8>(114), static_cast<u8>(105), static_cast<u8>(116), static_cast<u8>(101), static_cast<u8>(40), static_cast<u8>(109), static_cast<u8>(117), static_cast<u8>(116), static_cast<u8>(32), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(105), static_cast<u8>(115), static_cast<u8>(44), static_cast<u8>(32), static_cast<u8>(97), static_cast<u8>(110), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(100), static_cast<u8>(97), static_cast<u8>(116), static_cast<u8>(97), static_cast<u8>(58), static_cast<u8>(32), static_cast<u8>(91), static_cast<u8>(117), static_cast<u8>(56), static_cast<u8>(93), static_cast<u8>(41), static_cast<u8>(32), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(114), static_cast<u8>(111), static_cast<u8>(119), static_cast<u8>(115), static_cast<u8>(32), static_cast<u8>(45), static_cast<u8>(62), static_cast<u8>(32), static_cast<u8>(117), static_cast<u8>(115), static_cast<u8>(105), static_cast<u8>(122), static_cast<u8>(101), static_cast<u8>(10), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(112), static_cast<u8>(117), static_cast<u8>(98), static_cast<u8>(108), static_cast<u8>(105), static_cast<u8>(99), static_cast<u8>(32), static_cast<u8>(102), static_cast<u8>(117), static_cast<u8>(110), static_cast<u8>(99), static_cast<u8>(116), static_cast<u8>(105), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(114), static_cast<u8>(101), static_cast<u8>(97), static_cast<u8>(100), static_cast<u8>(95), static_cast<u8>(97), static_cast<u8>(108), static_cast<u8>(108), static_cast<u8>(40), static_cast<u8>(109), static_cast<u8>(117), static_cast<u8>(116), static_cast<u8>(32), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(105), static_cast<u8>(115), static_cast<u8>(41), static_cast<u8>(32), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(114), static_cast<u8>(111), static_cast<u8>(119), static_cast<u8>(115), static_cast<u8>(32), static_cast<u8>(45), static_cast<u8>(62), static_cast<u8>(32), static_cast<u8>(91), static_cast<u8>(117), static_cast<u8>(56), static_cast<u8>(93), static_cast<u8>(10), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(112), static_cast<u8>(117), static_cast<u8>(98), static_cast<u8>(108), static_cast<u8>(105), static_cast<u8>(99), static_cast<u8>(32), static_cast<u8>(102), static_cast<u8>(117), static_cast<u8>(110), static_cast<u8>(99), static_cast<u8>(116), static_cast<u8>(105), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(101), static_cast<u8>(120), static_cast<u8>(105), static_cast<u8>(115), static_cast<u8>(116), static_cast<u8>(115), static_cast<u8>(40), static_cast<u8>(97), static_cast<u8>(110), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(112), static_cast<u8>(97), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(58), static_cast<u8>(32), static_cast<u8>(83), static_cast<u8>(116), static_cast<u8>(114), static_cast<u8>(105), static_cast<u8>(110), static_cast<u8>(103), static_cast<u8>(41), static_cast<u8>(32), static_cast<u8>(45), static_cast<u8>(62), static_cast<u8>(32), static_cast<u8>(98), static_cast<u8>(111), static_cast<u8>(111), static_cast<u8>(108), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(112), static_cast<u8>(117), static_cast<u8>(98), static_cast<u8>(108), static_cast<u8>(105), static_cast<u8>(99), static_cast<u8>(32), static_cast<u8>(102), static_cast<u8>(117), static_cast<u8>(110), static_cast<u8>(99), static_cast<u8>(116), static_cast<u8>(105), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(99), static_cast<u8>(117), static_cast<u8>(114), static_cast<u8>(114), static_cast<u8>(101), static_cast<u8>(110), static_cast<u8>(116), static_cast<u8>(95), static_cast<u8>(101), static_cast<u8>(120), static_cast<u8>(101), static_cast<u8>(99), static_cast<u8>(117), static_cast<u8>(116), static_cast<u8>(97), static_cast<u8>(98), static_cast<u8>(108), static_cast<u8>(101), static_cast<u8>(95), static_cast<u8>(112), static_cast<u8>(97), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(40), static_cast<u8>(41), static_cast<u8>(32), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(114), static_cast<u8>(111), static_cast<u8>(119), static_cast<u8>(115), static_cast<u8>(32), static_cast<u8>(45), static_cast<u8>(62), static_cast<u8>(32), static_cast<u8>(83), static_cast<u8>(116), static_cast<u8>(114), static_cast<u8>(105), static_cast<u8>(110), static_cast<u8>(103), static_cast<u8>(10), static_cast<u8>(125), static_cast<u8>(10), static_cast<u8>(10), static_cast<u8>(101), static_cast<u8>(120), static_cast<u8>(116), static_cast<u8>(101), static_cast<u8>(114), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(102), static_cast<u8>(117), static_cast<u8>(110), static_cast<u8>(99), static_cast<u8>(116), static_cast<u8>(105), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(95), static_cast<u8>(95), static_cast<u8>(95), static_cast<u8>(106), static_cast<u8>(97), static_cast<u8>(107), static_cast<u8>(116), static_cast<u8>(95), static_cast<u8>(103), static_cast<u8>(101), static_cast<u8>(116), static_cast<u8>(95), static_cast<u8>(116), static_cast<u8>(97), static_cast<u8>(114), static_cast<u8>(103), static_cast<u8>(101), static_cast<u8>(116), static_cast<u8>(95), static_cast<u8>(116), static_cast<u8>(114), static_cast<u8>(105), static_cast<u8>(112), static_cast<u8>(108), static_cast<u8>(101), static_cast<u8>(95), static_cast<u8>(115), static_cast<u8>(116), static_cast<u8>(114), static_cast<u8>(105), static_cast<u8>(110), static_cast<u8>(103), static_cast<u8>(40), static_cast<u8>(41), static_cast<u8>(32), static_cast<u8>(45), static_cast<u8>(62), static_cast<u8>(32), static_cast<u8>(83), static_cast<u8>(116), static_cast<u8>(114), static_cast<u8>(105), static_cast<u8>(110), static_cast<u8>(103), static_cast<u8>(10), static_cast<u8>(10), static_cast<u8>(101), static_cast<u8>(120), static_cast<u8>(116), static_cast<u8>(101), static_cast<u8>(114), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(102), static_cast<u8>(117), static_cast<u8>(110), static_cast<u8>(99), static_cast<u8>(116), static_cast<u8>(105), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(97), static_cast<u8>(98), static_cast<u8>(111), static_cast<u8>(114), static_cast<u8>(116), static_cast<u8>(40), static_cast<u8>(41), static_cast<u8>(32), static_cast<u8>(45), static_cast<u8>(62), static_cast<u8>(32), static_cast<u8>(110), static_cast<u8>(101), static_cast<u8>(118), static_cast<u8>(101), static_cast<u8>(114), static_cast<u8>(10), static_cast<u8>(101), static_cast<u8>(120), static_cast<u8>(116), static_cast<u8>(101), static_cast<u8>(114), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(102), static_cast<u8>(117), static_cast<u8>(110), static_cast<u8>(99), static_cast<u8>(116), static_cast<u8>(105), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(97), static_cast<u8>(115), static_cast<u8>(95), static_cast<u8>(115), static_cast<u8>(97), static_cast<u8>(116), static_cast<u8>(117), static_cast<u8>(114), static_cast<u8>(97), static_cast<u8>(116), static_cast<u8>(101), static_cast<u8>(100), static_cast<u8>(60), static_cast<u8>(85), static_cast<u8>(44), static_cast<u8>(32), static_cast<u8>(84), static_cast<u8>(62), static_cast<u8>(40), static_cast<u8>(97), static_cast<u8>(110), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(105), static_cast<u8>(110), static_cast<u8>(112), static_cast<u8>(117), static_cast<u8>(116), static_cast<u8>(58), static_cast<u8>(32), static_cast<u8>(84), static_cast<u8>(41), static_cast<u8>(32), static_cast<u8>(45), static_cast<u8>(62), static_cast<u8>(32), static_cast<u8>(85), static_cast<u8>(10), static_cast<u8>(101), static_cast<u8>(120), static_cast<u8>(116), static_cast<u8>(101), static_cast<u8>(114), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(102), static_cast<u8>(117), static_cast<u8>(110), static_cast<u8>(99), static_cast<u8>(116), static_cast<u8>(105), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(97), static_cast<u8>(115), static_cast<u8>(95), static_cast<u8>(116), static_cast<u8>(114), static_cast<u8>(117), static_cast<u8>(110), static_cast<u8>(99), static_cast<u8>(97), static_cast<u8>(116), static_cast<u8>(101), static_cast<u8>(100), static_cast<u8>(60), static_cast<u8>(85), static_cast<u8>(44), static_cast<u8>(32), static_cast<u8>(84), static_cast<u8>(62), static_cast<u8>(40), static_cast<u8>(97), static_cast<u8>(110), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(105), static_cast<u8>(110), static_cast<u8>(112), static_cast<u8>(117), static_cast<u8>(116), static_cast<u8>(58), static_cast<u8>(32), static_cast<u8>(84), static_cast<u8>(41), static_cast<u8>(32), static_cast<u8>(45), static_cast<u8>(62), static_cast<u8>(32), static_cast<u8>(85), static_cast<u8>(10), static_cast<u8>(101), static_cast<u8>(120), static_cast<u8>(116), static_cast<u8>(101), static_cast<u8>(114), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(102), static_cast<u8>(117), static_cast<u8>(110), static_cast<u8>(99), static_cast<u8>(116), static_cast<u8>(105), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(117), static_cast<u8>(110), static_cast<u8>(99), static_cast<u8>(104), static_cast<u8>(101), static_cast<u8>(99), static_cast<u8>(107), static_cast<u8>(101), static_cast<u8>(100), static_cast<u8>(95), static_cast<u8>(97), static_cast<u8>(100), static_cast<u8>(100), static_cast<u8>(60), static_cast<u8>(84), static_cast<u8>(62), static_cast<u8>(40), static_cast<u8>(97), static_cast<u8>(110), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(97), static_cast<u8>(58), static_cast<u8>(32), static_cast<u8>(84), static_cast<u8>(44), static_cast<u8>(32), static_cast<u8>(97), static_cast<u8>(110), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(98), static_cast<u8>(58), static_cast<u8>(32), static_cast<u8>(84), static_cast<u8>(41), static_cast<u8>(32), static_cast<u8>(45), static_cast<u8>(62), static_cast<u8>(32), static_cast<u8>(84), static_cast<u8>(10), static_cast<u8>(101), static_cast<u8>(120), static_cast<u8>(116), static_cast<u8>(101), static_cast<u8>(114), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(102), static_cast<u8>(117), static_cast<u8>(110), static_cast<u8>(99), static_cast<u8>(116), static_cast<u8>(105), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(117), static_cast<u8>(110), static_cast<u8>(99), static_cast<u8>(104), static_cast<u8>(101), static_cast<u8>(99), static_cast<u8>(107), static_cast<u8>(101), static_cast<u8>(100), static_cast<u8>(95), static_cast<u8>(109), static_cast<u8>(117), static_cast<u8>(108), static_cast<u8>(60), static_cast<u8>(84), static_cast<u8>(62), static_cast<u8>(40), static_cast<u8>(97), static_cast<u8>(110), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(97), static_cast<u8>(58), static_cast<u8>(32), static_cast<u8>(84), static_cast<u8>(44), static_cast<u8>(32), static_cast<u8>(97), static_cast<u8>(110), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(98), static_cast<u8>(58), static_cast<u8>(32), static_cast<u8>(84), static_cast<u8>(41), static_cast<u8>(32), static_cast<u8>(45), static_cast<u8>(62), static_cast<u8>(32), static_cast<u8>(84), static_cast<u8>(10)}))));
 JaktInternal::Optional<utility::FileId> const old_file_id = ((((*this).compiler))->current_file);
 JaktInternal::Array<u8> const old_file_contents = ((((*this).compiler))->current_file_contents);
-ScopeGuard __jakt_var_371([&] {
+ScopeGuard __jakt_var_379([&] {
 {
 (((((*this).compiler))->current_file) = old_file_id);
 (((((*this).compiler))->current_file_contents) = old_file_contents);
@@ -6881,7 +7162,7 @@ TRY((((*this).check_type_argument_requirements(((generic_arguments)[i]),((((((((
 
 utility::Span const span = ((parsed_function).name_span);
 {
-JaktInternal::DictionaryIterator<String,String> _magic = ((generic_substitutions).iterator());
+JaktInternal::DictionaryIterator<String,String> _magic = ((((generic_substitutions).iterator())).iterator());
 for (;;){
 JaktInternal::Optional<JaktInternal::Tuple<String,String>> _magic_value = ((_magic).next());
 if ((!(((_magic_value).has_value())))){
@@ -6915,7 +7196,7 @@ JaktInternal::Tuple<JaktInternal::Optional<utility::FileId>,JaktInternal::Array<
 if ((!(((((*this).compiler))->set_current_file(file_id))))){
 return (JaktInternal::OptionalNone());
 }
-ScopeGuard __jakt_var_372([&] {
+ScopeGuard __jakt_var_380([&] {
 ((((*this).compiler))->restore_file_state(old_file_state));
 });
 JaktInternal::Array<lexer::Token> const tokens = TRY((lexer::Lexer::Lexer::lex(((*this).compiler))));
@@ -7266,7 +7547,7 @@ return (((((*this).program))->get_function(id)));
 ErrorOr<void> typechecker::Typechecker::typecheck_struct_predecl(parser::ParsedRecord const parsed_record,types::StructId const struct_id,types::ScopeId const scope_id) {
 {
 JaktInternal::Dictionary<String,String> const old_generic_inferences = TRY((((((*this).generic_inferences)).perform_checkpoint(true))));
-ScopeGuard __jakt_var_373([&] {
+ScopeGuard __jakt_var_381([&] {
 {
 ((((*this).generic_inferences)).restore(old_generic_inferences));
 }
@@ -7371,57 +7652,6 @@ TRY((((*this).add_type_to_scope(struct_scope_id,((gen_parameter).name),parameter
 }
 }
 
-if (((((parsed_record).implements_list)).has_value())){
-TRY((((*this).fill_trait_implementation_list((((parsed_record).implements_list).value()),((((((((module)->structures))[((struct_id).id)])).trait_implementations))),struct_scope_id,JaktInternal::OptionalNone()))));
-{
-JaktInternal::ArrayIterator<parser::ParsedNameWithGenericParameters> _magic = (((((parsed_record).implements_list).value())).iterator());
-for (;;){
-JaktInternal::Optional<parser::ParsedNameWithGenericParameters> _magic_value = ((_magic).next());
-if ((!(((_magic_value).has_value())))){
-break;
-}
-parser::ParsedNameWithGenericParameters implements_entry = (_magic_value.value());
-{
-JaktInternal::Optional<types::TraitId> const trait_id = TRY((((*this).find_trait_in_scope(scope_id,((implements_entry).name)))));
-if (((trait_id).has_value())){
-NonnullRefPtr<types::CheckedTrait> const trait_ = ((((((((((*this).program))->modules))[(((((trait_id.value())).module)).id)]))->traits))[(((trait_id.value())).id)]);
-{
-JaktInternal::DictionaryIterator<String,types::FunctionId> _magic = ((((trait_)->methods)).iterator());
-for (;;){
-JaktInternal::Optional<JaktInternal::Tuple<String,types::FunctionId>> _magic_value = ((_magic).next());
-if ((!(((_magic_value).has_value())))){
-break;
-}
-JaktInternal::Tuple<String,types::FunctionId> name__function_id__ = (_magic_value.value());
-{
-JaktInternal::Tuple<String,types::FunctionId> const jakt__name__function_id__ = name__function_id__;
-String const name = ((jakt__name__function_id__).get<0>());
-types::FunctionId const function_id = ((jakt__name__function_id__).get<1>());
-
-if (((TRY((((*this).find_function_in_scope(struct_scope_id,name))))).has_value())){
-continue;
-}
-NonnullRefPtr<types::CheckedFunction> const function_ = ((((((((((*this).program))->modules))[((((function_id).module)).id)]))->functions))[((function_id).id)]);
-if (((((((function_)->block)).statements)).is_empty())){
-continue;
-}
-TRY((((*this).add_function_to_scope(struct_scope_id,name,function_id,((implements_entry).name_span)))));
-}
-
-}
-}
-
-}
-else {
-continue;
-}
-
-}
-
-}
-}
-
-}
 bool const is_extern = ((((parsed_record).definition_linkage)).index() == 1 /* External */);
 {
 JaktInternal::ArrayIterator<parser::ParsedMethod> _magic = ((((parsed_record).methods)).iterator());
@@ -7503,7 +7733,7 @@ TRY((((*this).error(String("Functions cannot be both virtual and static"),((chec
 if ((((checked_function)->is_override) && ((checked_function)->is_static()))){
 TRY((((*this).error(String("Functions cannot be both override and static"),((checked_function)->name_span)))));
 }
-TRY((((*this).add_function_to_scope(struct_scope_id,((func).name),function_id,((parsed_record).name_span)))));
+TRY((((*this).add_function_to_scope(struct_scope_id,((func).name),(TRY((Array<types::FunctionId>::create_with({function_id})))),((parsed_record).name_span)))));
 types::TypeId const function_return_type_id = TRY((((*this).typecheck_typename(((func).return_type),method_scope_id,JaktInternal::OptionalNone()))));
 (((checked_function)->return_type_id) = function_return_type_id);
 (((((module)->functions))[((function_id).id)]) = checked_function);
@@ -7513,6 +7743,57 @@ types::TypeId const function_return_type_id = TRY((((*this).typecheck_typename((
 }
 }
 
+if (((((parsed_record).implements_list)).has_value())){
+TRY((((*this).fill_trait_implementation_list((((parsed_record).implements_list).value()),((((((((module)->structures))[((struct_id).id)])).trait_implementations))),struct_scope_id,JaktInternal::OptionalNone()))));
+{
+JaktInternal::ArrayIterator<parser::ParsedNameWithGenericParameters> _magic = (((((parsed_record).implements_list).value())).iterator());
+for (;;){
+JaktInternal::Optional<parser::ParsedNameWithGenericParameters> _magic_value = ((_magic).next());
+if ((!(((_magic_value).has_value())))){
+break;
+}
+parser::ParsedNameWithGenericParameters implements_entry = (_magic_value.value());
+{
+JaktInternal::Optional<types::TraitId> const trait_id = TRY((((*this).find_trait_in_scope(scope_id,((implements_entry).name)))));
+if (((trait_id).has_value())){
+NonnullRefPtr<types::CheckedTrait> const trait_ = ((((((((((*this).program))->modules))[(((((trait_id.value())).module)).id)]))->traits))[(((trait_id.value())).id)]);
+{
+JaktInternal::DictionaryIterator<String,types::FunctionId> _magic = ((((trait_)->methods)).iterator());
+for (;;){
+JaktInternal::Optional<JaktInternal::Tuple<String,types::FunctionId>> _magic_value = ((_magic).next());
+if ((!(((_magic_value).has_value())))){
+break;
+}
+JaktInternal::Tuple<String,types::FunctionId> name__function_id__ = (_magic_value.value());
+{
+JaktInternal::Tuple<String,types::FunctionId> const jakt__name__function_id__ = name__function_id__;
+String const name = ((jakt__name__function_id__).get<0>());
+types::FunctionId const function_id = ((jakt__name__function_id__).get<1>());
+
+if (((TRY((((*this).find_functions_with_name_in_scope(struct_scope_id,name))))).has_value())){
+continue;
+}
+NonnullRefPtr<types::CheckedFunction> const function_ = ((((((((((*this).program))->modules))[((((function_id).module)).id)]))->functions))[((function_id).id)]);
+if (((((((function_)->block)).statements)).is_empty())){
+continue;
+}
+TRY((((*this).add_function_to_scope(struct_scope_id,name,(TRY((Array<types::FunctionId>::create_with({function_id})))),((implements_entry).name_span)))));
+}
+
+}
+}
+
+}
+else {
+continue;
+}
+
+}
+
+}
+}
+
+}
 (((((((module)->structures))[((struct_id).id)])).generic_parameters) = generic_parameters);
 (((*this).current_struct_type_id) = JaktInternal::OptionalNone());
 }
@@ -7713,7 +7994,7 @@ return (JaktInternal::OptionalNone());
 }
 types::ScopeId const structure_scope_id = scope_id;
 parser::DefinitionLinkage const structure_linkage = definition_linkage;
-JaktInternal::Optional<types::FunctionId> const method_id = TRY((((*this).find_function_in_scope(structure_scope_id,((func).name)))));
+JaktInternal::Optional<types::FunctionId> const method_id = TRY((((*this).find_function_matching_signature_in_scope(structure_scope_id,func))));
 if ((!(((method_id).has_value())))){
 TRY((((((*this).compiler))->panic(String("we just pushed the checked function, but it's not present")))));
 }
@@ -7737,7 +8018,7 @@ TRY((((*this).add_var_to_scope(function_scope_id,((variable).name),var_id,((vari
 }
 }
 
-(((*this).current_function_id) = method_id);
+(((*this).current_function_id) = (method_id.value()));
 types::TypeId const VOID_TYPE_ID = types::builtin( types::BuiltinType { typename types::BuiltinType::Void() } );
 types::CheckedBlock const block = TRY((((*this).typecheck_block(((func).block),function_scope_id, types::SafetyMode { typename types::SafetyMode::Safe() } ,JaktInternal::OptionalNone()))));
 types::TypeId const function_return_type_id = TRY((((*this).typecheck_typename(((func).return_type),function_scope_id,JaktInternal::OptionalNone()))));
@@ -7947,9 +8228,8 @@ return (TRY((types::CheckedExpression::template create<typename types::CheckedEx
 }
 }
 
-ErrorOr<JaktInternal::Optional<types::FunctionId>> typechecker::Typechecker::resolve_call(parser::ParsedCall const call,JaktInternal::Array<types::ResolvedNamespace> namespaces,utility::Span const span,types::ScopeId const scope_id,bool const must_be_enum_constructor,bool const ignore_errors) {
+ErrorOr<JaktInternal::Array<types::FunctionId>> typechecker::Typechecker::resolve_call(parser::ParsedCall const call,JaktInternal::Array<types::ResolvedNamespace> namespaces,utility::Span const span,types::ScopeId const scope_id,bool const must_be_enum_constructor) {
 {
-JaktInternal::Optional<types::FunctionId> callee = JaktInternal::OptionalNone();
 types::ScopeId current_scope_id = scope_id;
 {
 JaktInternal::Range<size_t> _magic = (JaktInternal::Range<size_t>{static_cast<size_t>(static_cast<size_t>(0ULL)),static_cast<size_t>(((((call).namespace_)).size()))});
@@ -7993,7 +8273,7 @@ TRY((((*this).error(TRY((String::formatted(String("Not a namespace, enum, class,
 
 JaktInternal::Optional<types::CheckedVariable> const maybe_var = TRY((((*this).find_var_in_scope(current_scope_id,((call).name)))));
 if (((maybe_var).has_value())){
-types::TypeId const inner_type = JAKT_RESOLVE_EXPLICIT_VALUE_OR_CONTROL_FLOW_RETURN_ONLY(([&]() -> JaktInternal::ExplicitValueOrControlFlow<types::TypeId, ErrorOr<JaktInternal::Optional<types::FunctionId>>>{
+types::TypeId const inner_type = JAKT_RESOLVE_EXPLICIT_VALUE_OR_CONTROL_FLOW_RETURN_ONLY(([&]() -> JaktInternal::ExplicitValueOrControlFlow<types::TypeId, ErrorOr<JaktInternal::Array<types::FunctionId>>>{
 auto&& __jakt_match_variant = *((*this).get_type((((maybe_var.value())).type_id)));
 switch(__jakt_match_variant.index()) {
 case 27: {
@@ -8014,34 +8294,30 @@ return JaktInternal::ExplicitValue((((maybe_var.value())).type_id));
 ));
 if (((((*this).get_type(inner_type)))->index() == 29 /* Function */)){
 types::FunctionId const pseudo_function_id = (((*this).get_type(inner_type))->get<types::Type::Function>()).pseudo_function_id;
-return (pseudo_function_id);
+return ((TRY((Array<types::FunctionId>::create_with({pseudo_function_id})))));
 }
 }
-JaktInternal::Optional<types::FunctionId> const maybe_function_id = TRY((((*this).find_function_in_scope(current_scope_id,((call).name)))));
-if (((maybe_function_id).has_value())){
-types::FunctionId const function_id = (maybe_function_id.value());
-if (((!(must_be_enum_constructor)) || ((((((*this).get_function(function_id)))->type)).index() == 2 /* ImplicitEnumConstructor */))){
-return (function_id);
+JaktInternal::Optional<JaktInternal::Array<types::FunctionId>> const maybe_overload_set = TRY((((*this).find_functions_with_name_in_scope(current_scope_id,((call).name)))));
+if (((maybe_overload_set).has_value())){
+if (((!(must_be_enum_constructor)) || ((((((*this).get_function((((maybe_overload_set.value()))[static_cast<i64>(0LL)]))))->type)).index() == 2 /* ImplicitEnumConstructor */))){
+return ((maybe_overload_set.value()));
 }
 }
 if (must_be_enum_constructor){
 TRY((((*this).error(TRY((String::formatted(String("No such enum constructor ‘{}’"),((call).name)))),span))));
-return (callee);
+return ((TRY((Array<types::FunctionId>::create_with({})))));
 }
 JaktInternal::Optional<types::StructId> const maybe_struct_id = TRY((((*this).find_struct_in_scope(current_scope_id,((call).name)))));
 if (((maybe_struct_id).has_value())){
 types::StructId const struct_id = (maybe_struct_id.value());
 types::CheckedStruct const structure = ((*this).get_struct(struct_id));
-JaktInternal::Optional<types::FunctionId> const maybe_function_id = TRY((((*this).find_function_in_scope(((structure).scope_id),((call).name)))));
+JaktInternal::Optional<JaktInternal::Array<types::FunctionId>> const maybe_function_id = TRY((((*this).find_functions_with_name_in_scope(((structure).scope_id),((call).name)))));
 if (((maybe_function_id).has_value())){
 return ((maybe_function_id.value()));
 }
-return (callee);
 }
-if ((!(ignore_errors))){
 TRY((((*this).error(TRY((String::formatted(String("Call to unknown function: ‘{}’"),((call).name)))),span))));
-}
-return (JaktInternal::OptionalNone());
+return ((TRY((Array<types::FunctionId>::create_with({})))));
 }
 }
 
@@ -8216,6 +8492,16 @@ return {};
 return {};
 }
 
+ErrorOr<NonnullRefPtr<types::CheckedStatement>> typechecker::Typechecker::typecheck_block_statement(parser::ParsedBlock const parsed_block,types::ScopeId const scope_id,types::SafetyMode const safety_mode,utility::Span const span) {
+{
+types::CheckedBlock const checked_block = TRY((((*this).typecheck_block(parsed_block,scope_id,safety_mode,JaktInternal::OptionalNone()))));
+if (((((checked_block).yielded_type)).has_value())){
+TRY((((*this).error(String("A block used as a statement cannot yield values, as the value cannot be observed in any way"),(((parsed_block).find_yield_span()).value())))));
+}
+return (TRY((types::CheckedStatement::template create<typename types::CheckedStatement::Block>(checked_block,span))));
+}
+}
+
 ErrorOr<NonnullRefPtr<types::CheckedStatement>> typechecker::Typechecker::typecheck_if(NonnullRefPtr<parser::ParsedExpression> const condition,parser::ParsedBlock const then_block,JaktInternal::Optional<NonnullRefPtr<parser::ParsedStatement>> const else_statement,types::ScopeId const scope_id,types::SafetyMode const safety_mode,utility::Span const span) {
 {
 JaktInternal::Tuple<NonnullRefPtr<parser::ParsedExpression>,JaktInternal::Optional<parser::ParsedBlock>,JaktInternal::Optional<NonnullRefPtr<parser::ParsedStatement>>> const new_condition_new_then_block_new_else_statement_ = TRY((((*this).expand_context_for_bindings(condition,JaktInternal::OptionalNone(),then_block,else_statement,span))));
@@ -8334,7 +8620,7 @@ return JaktInternal::ExplicitValue( types::CheckedVisibility { typename types::C
 case 2: {
 auto&& __jakt_match_value = __jakt_match_variant.template get<parser::Visibility::Restricted>();JaktInternal::Array<parser::VisibilityRestriction> const& whitelist = __jakt_match_value.whitelist;
 utility::Span const& span = __jakt_match_value.span;
-return JaktInternal::ExplicitValue(({ Optional<types::CheckedVisibility> __jakt_var_374; {
+return JaktInternal::ExplicitValue(({ Optional<types::CheckedVisibility> __jakt_var_382; {
 JaktInternal::Array<NonnullRefPtr<types::MaybeResolvedScope>> restricted_scopes = (TRY((Array<NonnullRefPtr<types::MaybeResolvedScope>>::create_with({}))));
 {
 JaktInternal::ArrayIterator<parser::VisibilityRestriction> _magic = ((whitelist).iterator());
@@ -8368,10 +8654,10 @@ TRY((((restricted_scopes).push(TRY((((unresolved)->try_resolve(((*this).program)
 }
 }
 
-__jakt_var_374 =  types::CheckedVisibility { typename types::CheckedVisibility::Restricted(restricted_scopes,span) } ; goto __jakt_label_350;
+__jakt_var_382 =  types::CheckedVisibility { typename types::CheckedVisibility::Restricted(restricted_scopes,span) } ; goto __jakt_label_356;
 
 }
-__jakt_label_350:; __jakt_var_374.release_value(); }));
+__jakt_label_356:; __jakt_var_382.release_value(); }));
 };/*case end*/
 default: VERIFY_NOT_REACHED();}/*switch end*/
 }()
@@ -8453,9 +8739,31 @@ return (true);
 }
 }
 
-ErrorOr<types::ScopeId> typechecker::Typechecker::create_scope(JaktInternal::Optional<types::ScopeId> const parent_scope_id,bool const can_throw,String const debug_name) {
+ErrorOr<JaktInternal::Optional<types::FunctionId>> typechecker::Typechecker::find_function_matching_signature_in_scope(types::ScopeId const parent_scope_id,parser::ParsedFunction const prototype) const {
 {
-return (TRY((((((*this).program))->create_scope(parent_scope_id,can_throw,debug_name,((*this).current_module_id))))));
+String const function_name = ((prototype).name);
+JaktInternal::Optional<JaktInternal::Array<types::FunctionId>> const candidate_ids = TRY((((((*this).program))->find_functions_with_name_in_scope(parent_scope_id,function_name))));
+if (((candidate_ids).has_value())){
+{
+JaktInternal::ArrayIterator<types::FunctionId> _magic = (((candidate_ids.value())).iterator());
+for (;;){
+JaktInternal::Optional<types::FunctionId> _magic_value = ((_magic).next());
+if ((!(((_magic_value).has_value())))){
+break;
+}
+types::FunctionId candidate_id = (_magic_value.value());
+{
+NonnullRefPtr<types::CheckedFunction> const candidate = ((*this).get_function(candidate_id));
+if ((((((candidate)->parsed_function)).has_value()) && (((((candidate)->parsed_function).value())).equals(prototype)))){
+return (candidate_id);
+}
+}
+
+}
+}
+
+}
+return (JaktInternal::OptionalNone());
 }
 }
 
@@ -9001,7 +9309,7 @@ return JaktInternal::ExplicitValue(TRY((((*this).resolve_type_var(function_retur
 (((checked_function)->block) = block);
 (((checked_function)->return_type_id) = return_type_id);
 }
-TRY((((*this).add_function_to_scope(parent_scope_id,((parsed_function).name),function_id,((parsed_function).name_span)))));
+TRY((((*this).add_function_to_scope(parent_scope_id,((parsed_function).name),(TRY((Array<types::FunctionId>::create_with({function_id})))),((parsed_function).name_span)))));
 }
 return {};
 }
@@ -9285,7 +9593,14 @@ size_t i = (_magic_value.value());
 types::CheckedParameter const param = ((params)[i]);
 JaktInternal::Optional<NonnullRefPtr<types::CheckedExpression>> maybe_checked_expr = JaktInternal::OptionalNone();
 if ((!(((param).requires_label)))){
-if ((((args).size()) > consumed_arg)){
+if ((((args).size()) <= consumed_arg)){
+if ((!(((((param).default_value)).has_value())))){
+TRY((((*this).error(TRY((String::formatted(String("Missing argument for function parameter {}"),((((param).variable)).name)))),span))));
+continue;
+}
+(maybe_checked_expr = ((param).default_value));
+}
+else {
 JaktInternal::Tuple<String,utility::Span,NonnullRefPtr<parser::ParsedExpression>> const name_span_expr_ = ((args)[consumed_arg]);
 String const name = ((name_span_expr_).get<0>());
 utility::Span const span = ((name_span_expr_).get<1>());
@@ -9293,10 +9608,6 @@ NonnullRefPtr<parser::ParsedExpression> const expr = ((name_span_expr_).get<2>()
 
 (maybe_checked_expr = TRY((((*this).typecheck_expression(expr,scope_id,safety_mode,((((param).variable)).type_id))))));
 ((consumed_arg++));
-}
-else {
-TRY((((*this).error(TRY((String::formatted(String("Missing argument for function parameter {}"),((((param).variable)).name)))),span))));
-continue;
 }
 
 }
@@ -9461,37 +9772,37 @@ types::ScopeId const record_scope_id = JAKT_RESOLVE_EXPLICIT_VALUE_OR_CONTROL_FL
 auto&& __jakt_match_variant = ((record).record_type);
 switch(__jakt_match_variant.index()) {
 case 0: {
-auto&& __jakt_match_value = __jakt_match_variant.template get<parser::RecordType::Struct>();return JaktInternal::ExplicitValue(({ Optional<types::ScopeId> __jakt_var_375; {
+auto&& __jakt_match_value = __jakt_match_variant.template get<parser::RecordType::Struct>();return JaktInternal::ExplicitValue(({ Optional<types::ScopeId> __jakt_var_383; {
 JaktInternal::Optional<types::StructId> const struct_id = TRY((((*this).find_struct_in_scope(scope_id,((record).name)))));
 if ((!(((struct_id).has_value())))){
 return JaktInternal::LoopContinue{};
 }
-__jakt_var_375 = ((((*this).get_struct((struct_id.value())))).scope_id); goto __jakt_label_351;
+__jakt_var_383 = ((((*this).get_struct((struct_id.value())))).scope_id); goto __jakt_label_357;
 
 }
-__jakt_label_351:; __jakt_var_375.release_value(); }));
+__jakt_label_357:; __jakt_var_383.release_value(); }));
 };/*case end*/
 case 1: {
-auto&& __jakt_match_value = __jakt_match_variant.template get<parser::RecordType::Class>();return JaktInternal::ExplicitValue(({ Optional<types::ScopeId> __jakt_var_376; {
+auto&& __jakt_match_value = __jakt_match_variant.template get<parser::RecordType::Class>();return JaktInternal::ExplicitValue(({ Optional<types::ScopeId> __jakt_var_384; {
 JaktInternal::Optional<types::StructId> const struct_id = TRY((((*this).find_struct_in_scope(scope_id,((record).name)))));
 if ((!(((struct_id).has_value())))){
 return JaktInternal::LoopContinue{};
 }
-__jakt_var_376 = ((((*this).get_struct((struct_id.value())))).scope_id); goto __jakt_label_352;
+__jakt_var_384 = ((((*this).get_struct((struct_id.value())))).scope_id); goto __jakt_label_358;
 
 }
-__jakt_label_352:; __jakt_var_376.release_value(); }));
+__jakt_label_358:; __jakt_var_384.release_value(); }));
 };/*case end*/
 default: {
-return JaktInternal::ExplicitValue(({ Optional<types::ScopeId> __jakt_var_377; {
+return JaktInternal::ExplicitValue(({ Optional<types::ScopeId> __jakt_var_385; {
 JaktInternal::Optional<types::EnumId> const enum_id = TRY((((((*this).program))->find_enum_in_scope(scope_id,((record).name)))));
 if ((!(((enum_id).has_value())))){
 return JaktInternal::LoopContinue{};
 }
-__jakt_var_377 = ((((*this).get_enum((enum_id.value())))).scope_id); goto __jakt_label_353;
+__jakt_var_385 = ((((*this).get_enum((enum_id.value())))).scope_id); goto __jakt_label_359;
 
 }
-__jakt_label_353:; __jakt_var_377.release_value(); }));
+__jakt_label_359:; __jakt_var_385.release_value(); }));
 };/*case end*/
 }/*switch end*/
 }()
@@ -9506,7 +9817,7 @@ break;
 parser::ParsedMethod method = (_magic_value.value());
 {
 if (((!(((((record).generic_parameters)).is_empty()))) || (!(((((((method).parsed_function)).generic_parameters)).is_empty()))))){
-NonnullRefPtr<types::CheckedFunction> func = ((*this).get_function((TRY((((*this).find_function_in_scope(record_scope_id,((((method).parsed_function)).name))))).value())));
+NonnullRefPtr<types::CheckedFunction> func = ((*this).get_function((TRY((((*this).find_function_matching_signature_in_scope(record_scope_id,((method).parsed_function))))).value())));
 types::ScopeId const method_scope_id = ((func)->function_scope_id);
 types::ScopeId const check_scope = TRY((((*this).create_scope(method_scope_id,((func)->can_throw),TRY((String::formatted(String("method-checking({}::{})"),((record).name),((func)->name))))))));
 {
@@ -9613,7 +9924,7 @@ TRY((((seen_names).add(((variant).name)))));
 NonnullRefPtr<types::CheckedExpression> const expr = JAKT_RESOLVE_EXPLICIT_VALUE_OR_CONTROL_FLOW_AT_LOOP(([&]() -> JaktInternal::ExplicitValueOrControlFlow<NonnullRefPtr<types::CheckedExpression>,ErrorOr<void>>{
 auto __jakt_enum_value = (((((variant).value)).has_value()));
 if (__jakt_enum_value == true) {
-return JaktInternal::ExplicitValue(({ Optional<NonnullRefPtr<types::CheckedExpression>> __jakt_var_378; {
+return JaktInternal::ExplicitValue(({ Optional<NonnullRefPtr<types::CheckedExpression>> __jakt_var_386; {
 NonnullRefPtr<types::CheckedExpression> const value_expression = TRY((((*this).cast_to_underlying((((variant).value).value()),parent_scope_id,underlying_type))));
 JaktInternal::Optional<types::NumberConstant> const number_constant = ((value_expression)->to_number_constant(((*this).program)));
 JAKT_RESOLVE_EXPLICIT_VALUE_OR_CONTROL_FLOW_AT_LOOP_NESTED_MATCH(([&]() -> JaktInternal::ExplicitValueOrControlFlow<void,ErrorOr<void>>{
@@ -9636,12 +9947,12 @@ return JaktInternal::ExplicitValue((JaktInternal::checked_add<u64>(val,static_ca
 case 2: {
 auto&& __jakt_match_value = __jakt_match_variant.template get<typename types::NumberConstant::Floating>();
 f64 const& val = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(({ Optional<u64> __jakt_var_379; {
+return JaktInternal::ExplicitValue(({ Optional<u64> __jakt_var_387; {
 utility::todo(String("Implement floats"));
-__jakt_var_379 = static_cast<u64>(0ULL); goto __jakt_label_355;
+__jakt_var_387 = static_cast<u64>(0ULL); goto __jakt_label_361;
 
 }
-__jakt_label_355:; __jakt_var_379.release_value(); }));
+__jakt_label_361:; __jakt_var_387.release_value(); }));
 };/*case end*/
 default: VERIFY_NOT_REACHED();}/*switch end*/
 }()
@@ -9658,10 +9969,10 @@ return JaktInternal::ExplicitValue<void>();
 return JaktInternal::ExplicitValue<void>();
 }()))
 ;
-__jakt_var_378 = value_expression; goto __jakt_label_354;
+__jakt_var_386 = value_expression; goto __jakt_label_360;
 
 }
-__jakt_label_354:; __jakt_var_378.release_value(); }));
+__jakt_label_360:; __jakt_var_386.release_value(); }));
 }
 else {
 return JaktInternal::ExplicitValue(TRY((((*this).cast_to_underlying(TRY((parser::ParsedExpression::template create<typename parser::ParsedExpression::NumericConstant>( parser::NumericConstant { typename parser::NumericConstant::U64(((next_constant_value++))) } ,((variant).span)))),parent_scope_id,underlying_type)))));
@@ -9780,14 +10091,14 @@ TRY((((fields).push(var_id))));
 }
 
 TRY((((((enum_).variants)).push( types::CheckedEnumVariant { typename types::CheckedEnumVariant::StructLike(enum_id,((variant).name),fields,((variant).span)) } ))));
-JaktInternal::Optional<types::FunctionId> const maybe_enum_variant_constructor = TRY((((*this).find_function_in_scope(((enum_).scope_id),((variant).name)))));
+JaktInternal::Optional<JaktInternal::Array<types::FunctionId>> const maybe_enum_variant_constructor = TRY((((*this).find_functions_with_name_in_scope(((enum_).scope_id),((variant).name)))));
 if ((!(((maybe_enum_variant_constructor).has_value())))){
 bool const can_function_throw = is_boxed;
 types::ScopeId const function_scope_id = TRY((((*this).create_scope(parent_scope_id,can_function_throw,TRY((String::formatted(String("enum-variant-constructor({}::{})"),((enum_).name),((variant).name))))))));
 types::ScopeId const block_scope_id = TRY((((*this).create_scope(function_scope_id,can_function_throw,TRY((String::formatted(String("enum-variant-constructor-block({}::{})"),((enum_).name),((variant).name))))))));
 NonnullRefPtr<types::CheckedFunction> const checked_function = TRY((types::CheckedFunction::create(((variant).name),((variant).span), types::CheckedVisibility { typename types::CheckedVisibility::Public() } ,TRY((((*this).find_or_add_type_id(TRY((types::Type::template create<typename types::Type::Enum>(enum_id))))))),JaktInternal::OptionalNone(),params,TRY((types::FunctionGenerics::create(function_scope_id,params,(TRY((Array<types::FunctionGenericParameter>::create_with({})))),(TRY((Array<JaktInternal::Array<types::TypeId>>::create_with({}))))))),types::CheckedBlock((TRY((Array<NonnullRefPtr<types::CheckedStatement>>::create_with({})))),block_scope_id, types::BlockControlFlow { typename types::BlockControlFlow::MayReturn() } ,types::TypeId::TypeId::none(),false),can_function_throw, parser::FunctionType { typename parser::FunctionType::ImplicitEnumConstructor() } , parser::FunctionLinkage { typename parser::FunctionLinkage::Internal() } ,function_scope_id,JaktInternal::OptionalNone(),true,JaktInternal::OptionalNone(),false,false,false)));
 types::FunctionId const function_id = TRY((((module)->add_function(checked_function))));
-TRY((((*this).add_function_to_scope(((enum_).scope_id),((variant).name),function_id,((variant).span)))));
+TRY((((*this).add_function_to_scope(((enum_).scope_id),((variant).name),(TRY((Array<types::FunctionId>::create_with({function_id})))),((variant).span)))));
 }
 }
 else if (is_typed){
@@ -9810,7 +10121,7 @@ TRY((((params).push(param))));
 parser::ParsedVarDecl const param = (((((variant).params).value()))[static_cast<i64>(0LL)]);
 types::TypeId const type_id = TRY((((*this).typecheck_typename(((param).parsed_type),((enum_).scope_id),((param).name)))));
 TRY((((((enum_).variants)).push( types::CheckedEnumVariant { typename types::CheckedEnumVariant::Typed(enum_id,((variant).name),type_id,((variant).span)) } ))));
-JaktInternal::Optional<types::FunctionId> const maybe_enum_variant_constructor = TRY((((*this).find_function_in_scope(((enum_).scope_id),((variant).name)))));
+JaktInternal::Optional<JaktInternal::Array<types::FunctionId>> const maybe_enum_variant_constructor = TRY((((*this).find_functions_with_name_in_scope(((enum_).scope_id),((variant).name)))));
 if ((!(((maybe_enum_variant_constructor).has_value())))){
 bool const can_function_throw = is_boxed;
 types::ScopeId const function_scope_id = TRY((((*this).create_scope(parent_scope_id,can_function_throw,TRY((String::formatted(String("enum-variant-constructor({}::{})"),((enum_).name),((variant).name))))))));
@@ -9819,7 +10130,7 @@ types::CheckedVariable const variable = types::CheckedVariable(String("value"),t
 TRY((((params).push(types::CheckedParameter(false,variable,JaktInternal::OptionalNone())))));
 NonnullRefPtr<types::CheckedFunction> const checked_function = TRY((types::CheckedFunction::create(((variant).name),((variant).span), types::CheckedVisibility { typename types::CheckedVisibility::Public() } ,TRY((((*this).find_or_add_type_id(TRY((types::Type::template create<typename types::Type::Enum>(enum_id))))))),JaktInternal::OptionalNone(),params,TRY((types::FunctionGenerics::create(function_scope_id,params,(TRY((Array<types::FunctionGenericParameter>::create_with({})))),(TRY((Array<JaktInternal::Array<types::TypeId>>::create_with({}))))))),types::CheckedBlock((TRY((Array<NonnullRefPtr<types::CheckedStatement>>::create_with({})))),block_scope_id, types::BlockControlFlow { typename types::BlockControlFlow::AlwaysReturns() } ,types::TypeId::TypeId::none(),false),can_function_throw, parser::FunctionType { typename parser::FunctionType::ImplicitEnumConstructor() } , parser::FunctionLinkage { typename parser::FunctionLinkage::Internal() } ,function_scope_id,JaktInternal::OptionalNone(),true,JaktInternal::OptionalNone(),false,false,false)));
 types::FunctionId const function_id = TRY((((module)->add_function(checked_function))));
-TRY((((*this).add_function_to_scope(((enum_).scope_id),((variant).name),function_id,((variant).span)))));
+TRY((((*this).add_function_to_scope(((enum_).scope_id),((variant).name),(TRY((Array<types::FunctionId>::create_with({function_id})))),((variant).span)))));
 }
 }
 else {
@@ -9840,14 +10151,14 @@ TRY((((params).push(param))));
 }
 
 TRY((((((enum_).variants)).push( types::CheckedEnumVariant { typename types::CheckedEnumVariant::Untyped(enum_id,((variant).name),((variant).span)) } ))));
-JaktInternal::Optional<types::FunctionId> const maybe_enum_variant_constructor = TRY((((*this).find_function_in_scope(((enum_).scope_id),((variant).name)))));
+JaktInternal::Optional<JaktInternal::Array<types::FunctionId>> const maybe_enum_variant_constructor = TRY((((*this).find_functions_with_name_in_scope(((enum_).scope_id),((variant).name)))));
 if ((!(((maybe_enum_variant_constructor).has_value())))){
 bool const can_function_throw = is_boxed;
 types::ScopeId const function_scope_id = TRY((((*this).create_scope(parent_scope_id,can_function_throw,TRY((String::formatted(String("enum-variant-constructor({}::{})"),((enum_).name),((variant).name))))))));
 types::ScopeId const block_scope_id = TRY((((*this).create_scope(function_scope_id,can_function_throw,TRY((String::formatted(String("enum-variant-constructor-block({}::{})"),((enum_).name),((variant).name))))))));
 NonnullRefPtr<types::CheckedFunction> const checked_function = TRY((types::CheckedFunction::create(((variant).name),((variant).span), types::CheckedVisibility { typename types::CheckedVisibility::Public() } ,TRY((((*this).find_or_add_type_id(TRY((types::Type::template create<typename types::Type::Enum>(enum_id))))))),JaktInternal::OptionalNone(),params,TRY((types::FunctionGenerics::create(function_scope_id,params,(TRY((Array<types::FunctionGenericParameter>::create_with({})))),(TRY((Array<JaktInternal::Array<types::TypeId>>::create_with({}))))))),types::CheckedBlock((TRY((Array<NonnullRefPtr<types::CheckedStatement>>::create_with({})))),block_scope_id, types::BlockControlFlow { typename types::BlockControlFlow::AlwaysReturns() } ,types::TypeId::TypeId::none(),false),can_function_throw, parser::FunctionType { typename parser::FunctionType::ImplicitEnumConstructor() } , parser::FunctionLinkage { typename parser::FunctionLinkage::Internal() } ,function_scope_id,JaktInternal::OptionalNone(),true,JaktInternal::OptionalNone(),false,false,false)));
 types::FunctionId const function_id = TRY((((module)->add_function(checked_function))));
-TRY((((*this).add_function_to_scope(((enum_).scope_id),((variant).name),function_id,((variant).span)))));
+TRY((((*this).add_function_to_scope(((enum_).scope_id),((variant).name),(TRY((Array<types::FunctionId>::create_with({function_id})))),((variant).span)))));
 }
 }
 
@@ -9876,11 +10187,25 @@ ErrorOr<void> typechecker::Typechecker::typecheck_struct_constructor(parser::Par
 types::TypeId const struct_type_id = TRY((((*this).find_or_add_type_id(TRY((types::Type::template create<typename types::Type::Struct>(struct_id)))))));
 (((*this).current_struct_type_id) = struct_type_id);
 types::CheckedStruct const struct_ = ((*this).get_struct(struct_id));
-JaktInternal::Optional<types::FunctionId> const constructor_id = TRY((((*this).find_function_in_scope(((struct_).scope_id),((parsed_record).name)))));
-if (((constructor_id).has_value())){
+JaktInternal::Optional<JaktInternal::Array<types::FunctionId>> const constructor_ids = TRY((((*this).find_functions_with_name_in_scope(((struct_).scope_id),((parsed_record).name)))));
+if (((constructor_ids).has_value())){
 if ((((((parsed_record).record_type)).index() == 1 /* Class */) && ((((parsed_record).definition_linkage)).index() == 1 /* External */))){
-NonnullRefPtr<types::CheckedFunction> func = ((*this).get_function((constructor_id.value())));
+{
+JaktInternal::ArrayIterator<types::FunctionId> _magic = (((constructor_ids.value())).iterator());
+for (;;){
+JaktInternal::Optional<types::FunctionId> _magic_value = ((_magic).next());
+if ((!(((_magic_value).has_value())))){
+break;
+}
+types::FunctionId constructor_id = (_magic_value.value());
+{
+NonnullRefPtr<types::CheckedFunction> func = ((*this).get_function(constructor_id));
 (((func)->linkage) =  parser::FunctionLinkage { typename parser::FunctionLinkage::External() } );
+}
+
+}
+}
+
 }
 }
 else if ((!(((((parsed_record).definition_linkage)).index() == 1 /* External */)))){
@@ -9922,111 +10247,42 @@ TRY((((func)->add_param(types::CheckedParameter(true,variable,((field).default_v
 }
 }
 
-TRY((((*this).add_function_to_scope(((struct_).scope_id),((parsed_record).name),function_id,((parsed_record).name_span)))));
+TRY((((*this).add_function_to_scope(((struct_).scope_id),((parsed_record).name),(TRY((Array<types::FunctionId>::create_with({function_id})))),((parsed_record).name_span)))));
 }
 (((*this).current_struct_type_id) = JaktInternal::OptionalNone());
 }
 return {};
 }
 
-ErrorOr<NonnullRefPtr<types::CheckedStatement>> typechecker::Typechecker::typecheck_var_decl(parser::ParsedVarDecl const var,NonnullRefPtr<parser::ParsedExpression> const init,types::ScopeId const scope_id,types::SafetyMode const safety_mode,utility::Span const span) {
+ErrorOr<types::CheckedParameter> typechecker::Typechecker::typecheck_parameter(parser::ParsedParameter const parameter,types::ScopeId const scope_id,bool const first,JaktInternal::Optional<types::TypeId> const this_arg_type_id,JaktInternal::Optional<types::ScopeId> const check_scope) {
 {
-types::TypeId lhs_type_id = TRY((((*this).typecheck_typename(((var).parsed_type),scope_id,((var).name)))));
-NonnullRefPtr<types::CheckedExpression> checked_expr = TRY((((*this).typecheck_expression(init,scope_id,safety_mode,lhs_type_id))));
-types::TypeId const rhs_type_id = ((checked_expr)->type());
-if (((rhs_type_id).equals(types::void_type_id()))){
-TRY((((*this).error(String("Cannot assign `void` to a variable"),((checked_expr)->span())))));
-}
-if ((((lhs_type_id).equals(types::unknown_type_id())) && (!(((rhs_type_id).equals(types::unknown_type_id())))))){
-(lhs_type_id = rhs_type_id);
-}
-types::StructId const weak_ptr_struct_id = TRY((((*this).find_struct_in_prelude(String("WeakPtr")))));
-types::StructId const optional_struct_id = TRY((((*this).find_struct_in_prelude(String("Optional")))));
-NonnullRefPtr<types::Type> const lhs_type = ((*this).get_type(lhs_type_id));
-TRY((((*this).check_that_type_doesnt_contain_reference(lhs_type_id,span))));
-if (((checked_expr)->index() == 23 /* OptionalNone */)){
-utility::Span const span = (checked_expr->get<types::CheckedExpression::OptionalNone>()).span;
-types::TypeId const type_id = (checked_expr->get<types::CheckedExpression::OptionalNone>()).type_id;
-if (((lhs_type)->index() == 19 /* GenericInstance */)){
-types::StructId const id = (lhs_type->get<types::Type::GenericInstance>()).id;
-JaktInternal::Array<types::TypeId> const args = (lhs_type->get<types::Type::GenericInstance>()).args;
-if ((!((((id).equals(optional_struct_id)) || ((id).equals(weak_ptr_struct_id)))))){
-TRY((((*this).error(String("Cannot assign None to a non-optional type"),span))));
+types::TypeId type_id = TRY((((*this).typecheck_typename(((((parameter).variable)).parsed_type),scope_id,((((parameter).variable)).name)))));
+if ((first && (((((parameter).variable)).name) == String("this")))){
+if (((this_arg_type_id).has_value())){
+(type_id = (this_arg_type_id.value()));
 }
 }
-else {
-TRY((((*this).error(String("Cannot assign None to a non-optional type"),span))));
+types::CheckedVariable const variable = types::CheckedVariable(((((parameter).variable)).name),type_id,((((parameter).variable)).is_mutable),((((parameter).variable)).span),JaktInternal::OptionalNone(), types::CheckedVisibility { typename types::CheckedVisibility::Public() } );
+JaktInternal::Optional<NonnullRefPtr<types::CheckedExpression>> checked_default_value = JaktInternal::OptionalNone();
+if (((((parameter).default_argument)).has_value())){
+NonnullRefPtr<types::CheckedExpression> checked_default_value_expr = TRY((((*this).typecheck_expression((((parameter).default_argument).value()),scope_id, types::SafetyMode { typename types::SafetyMode::Safe() } ,type_id))));
+if (((checked_default_value_expr)->index() == 23 /* OptionalNone */)){
+utility::Span const expr_span = (checked_default_value_expr->get<types::CheckedExpression::OptionalNone>()).span;
+(checked_default_value_expr = TRY((types::CheckedExpression::template create<typename types::CheckedExpression::OptionalNone>(expr_span,type_id))));
 }
-
-}
-if (((lhs_type)->index() == 19 /* GenericInstance */)){
-types::StructId const id = (lhs_type->get<types::Type::GenericInstance>()).id;
-JaktInternal::Array<types::TypeId> const args = (lhs_type->get<types::Type::GenericInstance>()).args;
-if (((id).equals(weak_ptr_struct_id))){
-if ((!(((var).is_mutable)))){
-TRY((((*this).error(String("Weak reference must be mutable"),((var).span)))));
-}
-if (((!(((lhs_type_id).equals(rhs_type_id)))) && ((!(((((args)[static_cast<i64>(0LL)])).equals(rhs_type_id)))) && (!(((rhs_type_id).equals(types::unknown_type_id()))))))){
-TRY((((*this).error(TRY((String::formatted(String("Type mismatch: expected ‘{}’, but got ‘{}’"),TRY((((*this).type_name(lhs_type_id)))),TRY((((*this).type_name(rhs_type_id))))))),((checked_expr)->span())))));
+types::TypeId const default_value_type_id = ((checked_default_value_expr)->type());
+(checked_default_value = checked_default_value_expr);
+if ((!(TRY((((*this).check_types_for_compat(type_id,default_value_type_id,((((*this).generic_inferences))),((checked_default_value_expr)->span())))))))){
+(checked_default_value = JaktInternal::OptionalNone());
 }
 }
-else if (((id).equals(optional_struct_id))){
-if (((!(((lhs_type_id).equals(rhs_type_id)))) && ((!(((((args)[static_cast<i64>(0LL)])).equals(rhs_type_id)))) && (!(((rhs_type_id).equals(types::unknown_type_id()))))))){
-TRY((((*this).error(TRY((String::formatted(String("Type mismatch: expected ‘{}’, but got ‘{}’"),TRY((((*this).type_name(lhs_type_id)))),TRY((((*this).type_name(rhs_type_id))))))),((checked_expr)->span())))));
-}
-}
-else {
-if (((!(((lhs_type_id).equals(rhs_type_id)))) && (!(((rhs_type_id).equals(types::unknown_type_id())))))){
-TRY((((*this).error(TRY((String::formatted(String("Type mismatch: expected ‘{}’, but got ‘{}’"),TRY((((*this).type_name(lhs_type_id)))),TRY((((*this).type_name(rhs_type_id))))))),((checked_expr)->span())))));
-}
-}
-
-}
-else if (((lhs_type)->is_builtin())){
-JaktInternal::Optional<types::NumberConstant> const number_constant = ((checked_expr)->to_number_constant(((*this).program)));
-bool is_rhs_zero = false;
-if (((number_constant).has_value())){
-(is_rhs_zero = JAKT_RESOLVE_EXPLICIT_VALUE_OR_CONTROL_FLOW_RETURN_ONLY(([&]() -> JaktInternal::ExplicitValueOrControlFlow<bool, ErrorOr<NonnullRefPtr<types::CheckedStatement>>>{
-auto&& __jakt_match_variant = (number_constant.value());
-switch(__jakt_match_variant.index()) {
-case 0: {
-auto&& __jakt_match_value = __jakt_match_variant.template get<typename types::NumberConstant::Signed>();
-i64 const& value = __jakt_match_value.value;
-return JaktInternal::ExplicitValue((value == static_cast<i64>(0LL)));
-};/*case end*/
-case 1: {
-auto&& __jakt_match_value = __jakt_match_variant.template get<typename types::NumberConstant::Unsigned>();
-u64 const& value = __jakt_match_value.value;
-return JaktInternal::ExplicitValue((value == static_cast<u64>(0ULL)));
-};/*case end*/
-case 2: {
-auto&& __jakt_match_value = __jakt_match_variant.template get<typename types::NumberConstant::Floating>();
-f64 const& value = __jakt_match_value.value;
-return JaktInternal::ExplicitValue((value == static_cast<f64>(0)));
-};/*case end*/
-default: VERIFY_NOT_REACHED();}/*switch end*/
-}()
-)));
-}
-if (((!((((*this).is_numeric(lhs_type_id)) && is_rhs_zero))) && (((*this).is_integer(lhs_type_id)) ^ ((*this).is_integer(rhs_type_id))))){
-TRY((((*this).error(TRY((String::formatted(String("Type mismatch: expected ‘{}’, but got ‘{}’"),TRY((((*this).type_name(lhs_type_id)))),TRY((((*this).type_name(rhs_type_id))))))),((checked_expr)->span())))));
-return (TRY((types::CheckedStatement::template create<typename types::CheckedStatement::Garbage>(span))));
-}
-}
-else {
-if (((!(((lhs_type_id).equals(rhs_type_id)))) && (!(((rhs_type_id).equals(types::unknown_type_id())))))){
-TRY((((*this).error(TRY((String::formatted(String("Type mismatch: expected ‘{}’, but got ‘{}’"),TRY((((*this).type_name(lhs_type_id)))),TRY((((*this).type_name(rhs_type_id))))))),((checked_expr)->span())))));
-}
-}
-
-types::CheckedVariable const checked_var = types::CheckedVariable(((var).name),lhs_type_id,((var).is_mutable),((var).span),JaktInternal::OptionalNone(), types::CheckedVisibility { typename types::CheckedVisibility::Public() } );
-if ((((*this).dump_type_hints) && ((((var).inlay_span)).has_value()))){
-TRY((((*this).dump_type_hint(lhs_type_id,(((var).inlay_span).value())))));
-}
+types::CheckedParameter const checked_parameter = types::CheckedParameter(((parameter).requires_label),variable,checked_default_value);
+if (((check_scope).has_value())){
 NonnullRefPtr<types::Module> module = ((*this).current_module());
-types::VarId const var_id = TRY((((module)->add_variable(checked_var))));
-TRY((((*this).add_var_to_scope(scope_id,((var).name),var_id,((checked_var).definition_span)))));
-return (TRY((types::CheckedStatement::template create<typename types::CheckedStatement::VarDecl>(var_id,checked_expr,span))));
+types::VarId const var_id = TRY((((module)->add_variable(variable))));
+TRY((((*this).add_var_to_scope((check_scope.value()),((((parameter).variable)).name),var_id,((((parameter).variable)).span)))));
+}
+return (checked_parameter);
 }
 }
 
@@ -10162,96 +10418,15 @@ TRY((((*this).typecheck_method(((method).parsed_function), types::StructOrEnumId
 return {};
 }
 
-ErrorOr<bool> typechecker::Typechecker::implements_trait(types::TypeId const type_id,types::TraitId const trait_id,JaktInternal::Optional<JaktInternal::Array<types::TypeId>> const generic_arguments) {
+ErrorOr<JaktInternal::Optional<JaktInternal::Array<types::FunctionId>>> typechecker::Typechecker::find_functions_with_name_in_scope(types::ScopeId const parent_scope_id,String const function_name) const {
 {
-Function<ErrorOr<bool>(JaktInternal::Array<JaktInternal::Array<types::TypeId>>, types::TraitId, JaktInternal::Array<types::TypeId>, typechecker::Typechecker&)> const has_matching_trait = [](JaktInternal::Array<JaktInternal::Array<types::TypeId>> trait_implementations, types::TraitId trait_id, JaktInternal::Array<types::TypeId> passed_generic_arguments, typechecker::Typechecker& typechecker) -> ErrorOr<bool> {
-bool const old_ignore_errors = ((((typechecker))).ignore_errors);
-(((((typechecker))).ignore_errors) = true);
-ScopeGuard __jakt_var_380([&] {
-{
-(((((typechecker))).ignore_errors) = old_ignore_errors);
-}
-
-});
-bool found = false;
-{
-JaktInternal::ArrayIterator<JaktInternal::Array<types::TypeId>> _magic = ((trait_implementations).iterator());
-for (;;){
-JaktInternal::Optional<JaktInternal::Array<types::TypeId>> _magic_value = ((_magic).next());
-if ((!(((_magic_value).has_value())))){
-break;
-}
-JaktInternal::Array<types::TypeId> implemented_generic_arguments = (_magic_value.value());
-{
-if ((((implemented_generic_arguments).size()) != ((passed_generic_arguments).size()))){
-continue;
-}
-bool ok = false;
-{
-JaktInternal::Range<size_t> _magic = (JaktInternal::Range<size_t>{static_cast<size_t>(static_cast<size_t>(0ULL)),static_cast<size_t>(((implemented_generic_arguments).size()))});
-for (;;){
-JaktInternal::Optional<size_t> _magic_value = ((_magic).next());
-if ((!(((_magic_value).has_value())))){
-break;
-}
-size_t i = (_magic_value.value());
-{
-(ok = TRY((((((typechecker))).check_types_for_compat(((implemented_generic_arguments)[i]),((passed_generic_arguments)[i]),((((((typechecker))).generic_inferences))),utility::Span(utility::FileId(static_cast<size_t>(0ULL)),static_cast<size_t>(0ULL),static_cast<size_t>(0ULL)))))));
-if ((!(ok))){
-break;
+return (TRY((((((*this).program))->find_functions_with_name_in_scope(parent_scope_id,function_name)))));
 }
 }
 
-}
-}
-
-if ((!(ok))){
-continue;
-}
-(found = true);
-break;
-}
-
-}
-}
-
-return (found);
-}
-;
-JaktInternal::Array<types::TypeId> const empty = (TRY((Array<types::TypeId>::create_with({}))));
-return (TRY((has_matching_trait(TRY((((*this).find_all_implementations_of_trait(type_id,trait_id)))),trait_id,generic_arguments.value_or_lazy_evaluated([&] { return empty; }),((*this))))));
-}
-}
-
-ErrorOr<types::CheckedParameter> typechecker::Typechecker::typecheck_parameter(parser::ParsedParameter const parameter,types::ScopeId const scope_id,bool const first,JaktInternal::Optional<types::TypeId> const this_arg_type_id,JaktInternal::Optional<types::ScopeId> const check_scope) {
+ErrorOr<JaktInternal::Optional<types::CheckedVariable>> typechecker::Typechecker::find_var_in_scope(types::ScopeId const scope_id,String const var) const {
 {
-types::TypeId type_id = TRY((((*this).typecheck_typename(((((parameter).variable)).parsed_type),scope_id,((((parameter).variable)).name)))));
-if ((first && (((((parameter).variable)).name) == String("this")))){
-if (((this_arg_type_id).has_value())){
-(type_id = (this_arg_type_id.value()));
-}
-}
-types::CheckedVariable const variable = types::CheckedVariable(((((parameter).variable)).name),type_id,((((parameter).variable)).is_mutable),((((parameter).variable)).span),JaktInternal::OptionalNone(), types::CheckedVisibility { typename types::CheckedVisibility::Public() } );
-JaktInternal::Optional<NonnullRefPtr<types::CheckedExpression>> checked_default_value = JaktInternal::OptionalNone();
-if (((((parameter).default_argument)).has_value())){
-NonnullRefPtr<types::CheckedExpression> checked_default_value_expr = TRY((((*this).typecheck_expression((((parameter).default_argument).value()),scope_id, types::SafetyMode { typename types::SafetyMode::Safe() } ,type_id))));
-if (((checked_default_value_expr)->index() == 23 /* OptionalNone */)){
-utility::Span const expr_span = (checked_default_value_expr->get<types::CheckedExpression::OptionalNone>()).span;
-(checked_default_value_expr = TRY((types::CheckedExpression::template create<typename types::CheckedExpression::OptionalNone>(expr_span,type_id))));
-}
-types::TypeId const default_value_type_id = ((checked_default_value_expr)->type());
-(checked_default_value = checked_default_value_expr);
-if ((!(TRY((((*this).check_types_for_compat(type_id,default_value_type_id,((((*this).generic_inferences))),((checked_default_value_expr)->span())))))))){
-(checked_default_value = JaktInternal::OptionalNone());
-}
-}
-types::CheckedParameter const checked_parameter = types::CheckedParameter(((parameter).requires_label),variable,checked_default_value);
-if (((check_scope).has_value())){
-NonnullRefPtr<types::Module> module = ((*this).current_module());
-types::VarId const var_id = TRY((((module)->add_variable(variable))));
-TRY((((*this).add_var_to_scope((check_scope.value()),((((parameter).variable)).name),var_id,((((parameter).variable)).span)))));
-}
-return (checked_parameter);
+return (TRY((((((*this).program))->find_var_in_scope(scope_id,var)))));
 }
 }
 
@@ -10259,24 +10434,48 @@ ErrorOr<void> typechecker::Typechecker::typecheck_struct(parser::ParsedRecord co
 {
 types::TypeId const struct_type_id = TRY((((*this).find_or_add_type_id(TRY((types::Type::template create<typename types::Type::Struct>(struct_id)))))));
 (((*this).current_struct_type_id) = struct_type_id);
-JaktInternal::Dictionary<String,NonnullRefPtr<types::CheckedFunction>> all_virtuals = (TRY((Dictionary<String, NonnullRefPtr<types::CheckedFunction>>::create_with_entries({}))));
+JaktInternal::Dictionary<String,JaktInternal::Array<NonnullRefPtr<types::CheckedFunction>>> all_virtuals = (TRY((Dictionary<String, JaktInternal::Array<NonnullRefPtr<types::CheckedFunction>>>::create_with_entries({}))));
 JaktInternal::Optional<types::StructId> super_struct_id = ((((*this).get_struct(struct_id))).super_struct_id);
 while (((super_struct_id).has_value())){
 types::CheckedStruct const super_struct = ((*this).get_struct((super_struct_id.value())));
 NonnullRefPtr<types::Scope> const scope = TRY((((*this).get_scope(((super_struct).scope_id)))));
 {
-JaktInternal::DictionaryIterator<String,types::FunctionId> _magic = ((((scope)->functions)).iterator());
+JaktInternal::DictionaryIterator<String,JaktInternal::Array<types::FunctionId>> _magic = ((((scope)->functions)).iterator());
 for (;;){
-JaktInternal::Optional<JaktInternal::Tuple<String,types::FunctionId>> _magic_value = ((_magic).next());
+JaktInternal::Optional<JaktInternal::Tuple<String,JaktInternal::Array<types::FunctionId>>> _magic_value = ((_magic).next());
 if ((!(((_magic_value).has_value())))){
 break;
 }
-JaktInternal::Tuple<String,types::FunctionId> function_tuple = (_magic_value.value());
+JaktInternal::Tuple<String,JaktInternal::Array<types::FunctionId>> ___overload_set__ = (_magic_value.value());
 {
-NonnullRefPtr<types::CheckedFunction> const function_ = ((*this).get_function(((function_tuple).get<1>())));
-if (((function_)->is_virtual)){
-TRY(all_virtuals.set(((function_)->name), function_));
+JaktInternal::Tuple<String,JaktInternal::Array<types::FunctionId>> const jakt_____overload_set__ = ___overload_set__;
+String const _ = ((jakt_____overload_set__).get<0>());
+JaktInternal::Array<types::FunctionId> const overload_set = ((jakt_____overload_set__).get<1>());
+
+{
+JaktInternal::ArrayIterator<types::FunctionId> _magic = ((overload_set).iterator());
+for (;;){
+JaktInternal::Optional<types::FunctionId> _magic_value = ((_magic).next());
+if ((!(((_magic_value).has_value())))){
+break;
 }
+types::FunctionId function_id = (_magic_value.value());
+{
+NonnullRefPtr<types::CheckedFunction> const function_ = ((*this).get_function(function_id));
+if (((function_)->is_virtual)){
+if ((!(((all_virtuals).contains(((function_)->name)))))){
+TRY(all_virtuals.set(((function_)->name), (TRY((Array<NonnullRefPtr<types::CheckedFunction>>::create_with({function_}))))));
+}
+else {
+TRY((((((all_virtuals)[((function_)->name)])).push(function_))));
+}
+
+}
+}
+
+}
+}
+
 }
 
 }
@@ -10334,7 +10533,7 @@ TRY((((*this).typecheck_method(((method).parsed_function), types::StructOrEnumId
 
 {
 JaktInternal::Dictionary<String,String> const old_generic_inferences = TRY((((((*this).generic_inferences)).perform_checkpoint(true))));
-ScopeGuard __jakt_var_381([&] {
+ScopeGuard __jakt_var_388([&] {
 {
 ((((*this).generic_inferences)).restore(old_generic_inferences));
 }
@@ -10372,19 +10571,33 @@ TRY((((*this).specialize_trait(trait_id,generic_params))));
 
 NonnullRefPtr<types::Scope> const scope = TRY((((*this).get_scope(((((*this).get_struct(struct_id))).scope_id)))));
 {
-JaktInternal::DictionaryIterator<String,types::FunctionId> _magic = ((((scope)->functions)).iterator());
+JaktInternal::DictionaryIterator<String,JaktInternal::Array<types::FunctionId>> _magic = ((((scope)->functions)).iterator());
 for (;;){
-JaktInternal::Optional<JaktInternal::Tuple<String,types::FunctionId>> _magic_value = ((_magic).next());
+JaktInternal::Optional<JaktInternal::Tuple<String,JaktInternal::Array<types::FunctionId>>> _magic_value = ((_magic).next());
 if ((!(((_magic_value).has_value())))){
 break;
 }
-JaktInternal::Tuple<String,types::FunctionId> name__function_id__ = (_magic_value.value());
+JaktInternal::Tuple<String,JaktInternal::Array<types::FunctionId>> name__overload_set__ = (_magic_value.value());
 {
-JaktInternal::Tuple<String,types::FunctionId> const jakt__name__function_id__ = name__function_id__;
-String const name = ((jakt__name__function_id__).get<0>());
-types::FunctionId const function_id = ((jakt__name__function_id__).get<1>());
+JaktInternal::Tuple<String,JaktInternal::Array<types::FunctionId>> const jakt__name__overload_set__ = name__overload_set__;
+String const name = ((jakt__name__overload_set__).get<0>());
+JaktInternal::Array<types::FunctionId> const overload_set = ((jakt__name__overload_set__).get<1>());
 
+{
+JaktInternal::ArrayIterator<types::FunctionId> _magic = ((overload_set).iterator());
+for (;;){
+JaktInternal::Optional<types::FunctionId> _magic_value = ((_magic).next());
+if ((!(((_magic_value).has_value())))){
+break;
+}
+types::FunctionId function_id = (_magic_value.value());
+{
 TRY((((checks).register_method(name,function_id,((*this))))));
+}
+
+}
+}
+
 }
 
 }
@@ -10419,7 +10632,7 @@ types::TypeId const subject_type_id = ((checked_expr)->type());
 NonnullRefPtr<types::Type> const type_to_match_on = ((*this).get_type(subject_type_id));
 JaktInternal::Array<types::CheckedMatchCase> checked_cases = (TRY((Array<types::CheckedMatchCase>::create_with({}))));
 JaktInternal::Dictionary<String,String> const old_generic_inferences = TRY((((((*this).generic_inferences)).perform_checkpoint(false))));
-ScopeGuard __jakt_var_382([&] {
+ScopeGuard __jakt_var_389([&] {
 {
 ((((*this).generic_inferences)).restore(old_generic_inferences));
 }
@@ -11073,9 +11286,13 @@ return JaktInternal::ExplicitValue(((other_branch).partial()));
 }
 }
 
-ErrorOr<void> typechecker::Typechecker::typecheck_jakt_main(parser::ParsedFunction const parsed_function) {
+ErrorOr<void> typechecker::Typechecker::typecheck_jakt_main(parser::ParsedFunction const parsed_function,types::ScopeId const parent_scope_id) {
 {
 String const param_type_error = String("Main function must take a single array of strings as its parameter");
+JaktInternal::Optional<JaktInternal::Array<types::FunctionId>> const func_ids = TRY((((*this).find_functions_with_name_in_scope(parent_scope_id,String("main")))));
+if (((((func_ids.value())).size()) > static_cast<size_t>(1ULL))){
+TRY((((*this).error(String("Function 'main' declared multiple times."),((parsed_function).name_span)))));
+}
 if ((((((parsed_function).params)).size()) > static_cast<size_t>(1ULL))){
 TRY((((*this).error(param_type_error,((parsed_function).name_span)))));
 }
@@ -11539,5 +11756,41 @@ TRY((((((typechecker))).error_with_hint(TRY((String::formatted(String("Missing i
 return {};
 }
 
+ErrorOr<String> typechecker::FunctionMatchResult::debug_description() const {
+auto builder = TRY(StringBuilder::create());
+switch (this->index()) {case 0 /* MatchSuccess */: {
+[[maybe_unused]] auto const& that = this->template get<FunctionMatchResult::MatchSuccess>();
+TRY(builder.append("FunctionMatchResult::MatchSuccess"));
+TRY(builder.append("("));
+{
+JaktInternal::PrettyPrint::ScopedLevelIncrease increase_indent {};
+TRY(JaktInternal::PrettyPrint::output_indentation(builder));
+TRY(builder.appendff("args: {}", that.args));
+TRY(builder.append(", "));
+TRY(JaktInternal::PrettyPrint::output_indentation(builder));
+TRY(builder.appendff("maybe_this_type_id: {}", that.maybe_this_type_id));
+TRY(builder.append(", "));
+TRY(JaktInternal::PrettyPrint::output_indentation(builder));
+TRY(builder.appendff("used_generic_inferences: {}", that.used_generic_inferences));
+TRY(builder.append(", "));
+TRY(JaktInternal::PrettyPrint::output_indentation(builder));
+TRY(builder.appendff("specificity: {}", that.specificity));
+}
+TRY(builder.append(")"));
+break;}
+case 1 /* MatchError */: {
+[[maybe_unused]] auto const& that = this->template get<FunctionMatchResult::MatchError>();
+TRY(builder.append("FunctionMatchResult::MatchError"));
+TRY(builder.append("("));
+{
+JaktInternal::PrettyPrint::ScopedLevelIncrease increase_indent {};
+TRY(JaktInternal::PrettyPrint::output_indentation(builder));
+TRY(builder.appendff("errors: {}", that.errors));
+}
+TRY(builder.append(")"));
+break;}
+}
+return builder.to_string();
+}
 }
 } // namespace Jakt

--- a/bootstrap/stage0/utility.cpp
+++ b/bootstrap/stage0/utility.cpp
@@ -7,15 +7,42 @@ return (((c == '0') || (c == '1')));
 }
 }
 
-bool is_ascii_alpha(u8 const c) {
+String join(JaktInternal::Array<String> const strings,String const separator) {
 {
-return ((((c >= 'a') && (c <= 'z')) || ((c >= 'A') && (c <= 'Z'))));
+String output = String("");
+size_t i = static_cast<size_t>(0ULL);
+{
+JaktInternal::ArrayIterator<String> _magic = ((strings).iterator());
+for (;;){
+JaktInternal::Optional<String> _magic_value = ((_magic).next());
+if ((!(((_magic_value).has_value())))){
+break;
+}
+String s = (_magic_value.value());
+{
+(output += s);
+if ((i < (JaktInternal::checked_sub<size_t>(((strings).size()),static_cast<size_t>(1ULL))))){
+(output += separator);
+}
+((i++));
+}
+
+}
+}
+
+return (output);
 }
 }
 
 bool is_whitespace(u8 const byte) {
 {
 return ((((byte == ' ') || (byte == '\t')) || (byte == '\r')));
+}
+}
+
+bool is_ascii_alpha(u8 const c) {
+{
+return ((((c >= 'a') && (c <= 'z')) || ((c >= 'A') && (c <= 'Z'))));
 }
 }
 
@@ -152,33 +179,6 @@ break;
 String str = (_magic_value.value());
 {
 TRY((((output).push((str + suffix)))));
-}
-
-}
-}
-
-return (output);
-}
-}
-
-String join(JaktInternal::Array<String> const strings,String const separator) {
-{
-String output = String("");
-size_t i = static_cast<size_t>(0ULL);
-{
-JaktInternal::ArrayIterator<String> _magic = ((strings).iterator());
-for (;;){
-JaktInternal::Optional<String> _magic_value = ((_magic).next());
-if ((!(((_magic_value).has_value())))){
-break;
-}
-String s = (_magic_value.value());
-{
-(output += s);
-if ((i < (JaktInternal::checked_sub<size_t>(((strings).size()),static_cast<size_t>(1ULL))))){
-(output += separator);
-}
-((i++));
 }
 
 }

--- a/bootstrap/stage0/utility.h
+++ b/bootstrap/stage0/utility.h
@@ -65,29 +65,6 @@ abort();
 }
 
 template <typename T>
-ErrorOr<void> extend_array(JaktInternal::Array<T> target,JaktInternal::Array<T> const extend_with) {
-{
-TRY((((target).add_capacity(((extend_with).size())))));
-{
-JaktInternal::ArrayIterator<T> _magic = ((extend_with).iterator());
-for (;;){
-JaktInternal::Optional<T> _magic_value = ((_magic).next());
-if ((!(((_magic_value).has_value())))){
-break;
-}
-T v = (_magic_value.value());
-{
-TRY((((target).push(v))));
-}
-
-}
-}
-
-}
-return {};
-}
-
-template <typename T>
 T* allocate(size_t const count) {
 {
 {

--- a/runtime/Builtins/Array.h
+++ b/runtime/Builtins/Array.h
@@ -240,6 +240,15 @@ public:
         return {};
     }
 
+    ErrorOr<void> push_values(Array<T> const& values)
+    {
+        TRY(m_storage->ensure_capacity(capacity() + values.size()));
+        for (size_t i = 0; i < values.size(); ++i) {
+            TRY(push(values.at(i)));
+        }
+        return {};
+    }
+
     T const& at(size_t index) const
     {
         return m_storage->at(index);

--- a/runtime/prelude.jakt
+++ b/runtime/prelude.jakt
@@ -19,6 +19,7 @@ extern struct Array<T> {
     function resize(mut this, anon size: usize) throws
     function shrink(mut this, anon size: usize) -> void
     function push(mut this, anon value: T) throws
+    function push_values(mut this, anon other: &Array<T>) throws
     function pop(mut this) -> T?
     function iterator(this) -> ArrayIterator<T>
     function first(this) -> T?

--- a/samples/arrays/push_values.jakt
+++ b/samples/arrays/push_values.jakt
@@ -1,0 +1,11 @@
+/// Expect:
+/// - output: "x: [1, 2, 3, 5]\ny: [5]\n"
+
+function main() {
+    mut x = [1, 2, 3]
+    mut y = [5]
+
+    x.push_values(y)
+    println("x: {}", x)
+    println("y: {}", y)
+}

--- a/samples/classes/overload_methods.jakt
+++ b/samples/classes/overload_methods.jakt
@@ -1,0 +1,26 @@
+/// Expect:
+/// - output: "144\n168\n"
+
+class Rect {
+    private width: i64
+    private height: i64
+
+    public function construct(width: i64, height: i64) throws -> Rect {
+        return Rect(width, height)
+    }
+
+    public function construct(square_with_sides: i64) throws -> Rect {
+        return Rect(width: square_with_sides, height: square_with_sides)
+    }
+
+    public function area(this) -> i64 {
+        return this.width * this.height
+    }
+}
+
+function main() {
+    let square = Rect::construct(square_with_sides: 12)
+    let rect = Rect::construct(width: 12, height: 14)
+    println("{}", square.area())
+    println("{}", rect.area())
+}

--- a/samples/functions/default_arguments_enum.jakt
+++ b/samples/functions/default_arguments_enum.jakt
@@ -1,0 +1,13 @@
+/// Expect:
+/// - output: "42\n"
+
+enum S {
+    X
+    function my_func(this, anon def: i64 = 42) {
+        println("{}", def)
+    }
+}
+
+function main() {
+    S::X.my_func()
+}

--- a/samples/functions/overloading.jakt
+++ b/samples/functions/overloading.jakt
@@ -1,0 +1,15 @@
+/// Expect:
+/// - output: "[\"Array\"]\n\"String\"\n64i64\n"
+
+function to_string(anon x: i64) throws -> String {
+    return format("{}i64", x)
+}
+function to_string(anon x: String) throws => format("\"{}\"", x)
+function to_string<T>(anon z: T) throws => format("{}", z)
+
+
+function main() {
+    println(to_string(["Array"]))
+    println(to_string("String"))
+    println(to_string(64i64))
+}

--- a/selfhost/codegen.jakt
+++ b/selfhost/codegen.jakt
@@ -614,24 +614,26 @@ struct CodeGenerator {
                 output += "\n"
             }
 
-            for (_, function_id) in scope.functions {
-                if not function_id.module.equals(current_module.id) {
-                    continue
-                }
+            for (_, overload_set) in scope.functions {
+                for function_id in overload_set {
+                    if not function_id.module.equals(current_module.id) {
+                        continue
+                    }
 
-                let function_ = .program.get_function(function_id)
+                    let function_ = .program.get_function(function_id)
 
-                let previous_function = .current_function
-                .current_function = function_
-                defer .current_function = previous_function
+                    let previous_function = .current_function
+                    .current_function = function_
+                    defer .current_function = previous_function
 
-                if function_.linkage is External or function_.type is ImplicitConstructor or function_.type is ImplicitEnumConstructor {
-                    continue
-                }
+                    if function_.linkage is External or function_.type is ImplicitConstructor or function_.type is ImplicitEnumConstructor {
+                        continue
+                    }
 
-                if not function_.generics.params.is_empty() {
-                    output += .codegen_function(function_)
-                    output += "\n"
+                    if not function_.generics.params.is_empty() {
+                        output += .codegen_function(function_)
+                        output += "\n"
+                    }
                 }
             }
 
@@ -654,24 +656,26 @@ struct CodeGenerator {
         }
 
         mut output = ""
-        for (_, function_id) in scope.functions {
-            if not function_id.module.equals(current_module.id) {
-                continue
-            }
+        for (_, overload_set) in scope.functions {
+            for function_id in overload_set {
+                if not function_id.module.equals(current_module.id) {
+                    continue
+                }
 
-            let function_ = .program.get_function(function_id)
+                let function_ = .program.get_function(function_id)
 
-            let previous_function = .current_function
-            .current_function = function_
-            defer .current_function = previous_function
+                let previous_function = .current_function
+                .current_function = function_
+                defer .current_function = previous_function
 
-            if function_.linkage is External or function_.type is ImplicitConstructor or function_.type is ImplicitEnumConstructor {
-                continue
-            }
+                if function_.linkage is External or function_.type is ImplicitConstructor or function_.type is ImplicitEnumConstructor {
+                    continue
+                }
 
-            if function_.generics.params.is_empty() {
-                output += .codegen_function(function_)
-                output += "\n"
+                if function_.generics.params.is_empty() {
+                    output += .codegen_function(function_)
+                    output += "\n"
+                }
             }
         }
 
@@ -692,18 +696,20 @@ struct CodeGenerator {
             output += .codegen_debug_description_getter(struct_)
 
             let scope = .program.get_scope(struct_.scope_id)
-            for (_, function_id) in scope.functions {
-                let function_ = .program.get_function(function_id)
-                let previous_function = .current_function
-                .current_function = function_
-                defer .current_function = previous_function
+            for (_, overload_set) in scope.functions {
+                for function_id in overload_set {
+                    let function_ = .program.get_function(function_id)
+                    let previous_function = .current_function
+                    .current_function = function_
+                    defer .current_function = previous_function
 
-                if function_.type is ImplicitConstructor {
-                    output += .codegen_constructor(function_)
-                    output += "\n"
-                } else if not function_.type is ImplicitEnumConstructor and not function_.is_comptime and function_.generics.params.is_empty() {
-                    output += .codegen_function_in_namespace(function_, containing_struct: struct_.type_id)
-                    output += "\n"
+                    if function_.type is ImplicitConstructor {
+                        output += .codegen_constructor(function_)
+                        output += "\n"
+                    } else if not function_.type is ImplicitEnumConstructor and not function_.is_comptime and function_.generics.params.is_empty() {
+                        output += .codegen_function_in_namespace(function_, containing_struct: struct_.type_id)
+                        output += "\n"
+                    }
                 }
             }
         }
@@ -727,14 +733,17 @@ struct CodeGenerator {
             }
 
             let scope = .program.get_scope(enum_.scope_id)
-            for (_, function_id) in scope.functions {
-                let function_ = .program.get_function(function_id)
-                let previous_function = .current_function
-                .current_function = function_
-                defer .current_function = previous_function
-                if not function_.type is ImplicitConstructor and not function_.type is ImplicitEnumConstructor and not function_.is_comptime {
-                    output += .codegen_function_in_namespace(function_, containing_struct: enum_.type_id)
-                    output += "\n"
+            for (_, overload_set) in scope.functions {
+                for function_id in overload_set {
+                    let function_ = .program.get_function(function_id)
+                    let previous_function = .current_function
+                    .current_function = function_
+                    defer .current_function = previous_function
+
+                    if not function_.type is ImplicitConstructor and not function_.type is ImplicitEnumConstructor and not function_.is_comptime {
+                        output += .codegen_function_in_namespace(function_, containing_struct: enum_.type_id)
+                        output += "\n"
+                    }
                 }
             }
         }
@@ -789,22 +798,24 @@ struct CodeGenerator {
             output += .codegen_namespace_predecl(scope: .program.get_scope(child), current_module)
         }
 
-        for (_, function_id) in scope.functions {
-            if not function_id.module.equals(current_module.id) {
-                continue
-            }
-            let function_ = .program.get_function(function_id)
-            if function_.type is ImplicitEnumConstructor {
-                continue
-            }
+        for (_, overload_set) in scope.functions {
+            for function_id in overload_set {
+                if not function_id.module.equals(current_module.id) {
+                    continue
+                }
+                let function_ = .program.get_function(function_id)
+                if function_.type is ImplicitEnumConstructor {
+                    continue
+                }
 
-            let previous_function_id = .current_function
-            .current_function = Some(function_)
-            defer .current_function = previous_function_id
+                let previous_function_id = .current_function
+                .current_function = Some(function_)
+                defer .current_function = previous_function_id
 
-            if not function_.type is ImplicitConstructor and function_.name != "main" {
-                output += .codegen_function_predecl(function_)
-                output += "\n"
+                if not function_.type is ImplicitConstructor and function_.name != "main" {
+                    output += .codegen_function_predecl(function_)
+                    output += "\n"
+                }
             }
         }
 
@@ -905,10 +916,10 @@ struct CodeGenerator {
             output += param.variable.name
         }
         output += ")"
-        
+
         if not function_.is_static() and not function_.is_mutating() {
             output += " const"
-        } 
+        }
         if function_.is_override {
             output += " override"
         }
@@ -1019,26 +1030,27 @@ struct CodeGenerator {
         }
 
         let scope = .program.get_scope(struct_.scope_id)
-        for fn in scope.functions {
+        for (_, overload_set) in scope.functions {
+            for function_id in overload_set {
+                let previous_function_id = .current_function
 
-            let function_ = .program.get_function(fn.1)
+                let function_ = .program.get_function(function_id)
+                .current_function = Some(function_)
+                defer .current_function = previous_function_id
 
-            let previous_function_id = .current_function
-            .current_function = Some(function_)
-            defer .current_function = previous_function_id
-
-            if function_.type is ImplicitConstructor {
-                if struct_.generic_parameters.is_empty() {
-                    output += .codegen_constructor_predecl(function_)
+                if function_.type is ImplicitConstructor {
+                    if struct_.generic_parameters.is_empty() {
+                        output += .codegen_constructor_predecl(function_)
+                    } else {
+                        output += .codegen_constructor(function_, is_inline: true)
+                    }
+                    output += "\n"
                 } else {
-                    output += .codegen_constructor(function_, is_inline: true)
-                }
-                output += "\n"
-            } else {
-                if struct_.generic_parameters.is_empty() and function_.generics.params.is_empty() {
-                    output += .codegen_function_predecl(function_, as_method: true)
-                } else {
-                    output += .codegen_function(function_, as_method: true)
+                    if struct_.generic_parameters.is_empty() and function_.generics.params.is_empty() {
+                        output += .codegen_function_predecl(function_, as_method: true)
+                    } else {
+                        output += .codegen_function(function_, as_method: true)
+                    }
                 }
             }
         }
@@ -1265,18 +1277,20 @@ struct CodeGenerator {
         }
 
         let enum_scope = .program.get_scope(enum_.scope_id)
-        for function_item in enum_scope.functions {
-            let function_ = .program.get_function(function_item.1)
+        for (_, overload_set) in enum_scope.functions {
+            for function_id in overload_set {
+                let function_ = .program.get_function(function_id)
 
-            let previous_function_id = .current_function
-            .current_function = Some(function_)
-            defer .current_function = previous_function_id
+                let previous_function_id = .current_function
+                .current_function = Some(function_)
+                defer .current_function = previous_function_id
 
-            if not function_.type is ImplicitEnumConstructor {
-                if enum_.generic_parameters.is_empty() and function_.generics.params.is_empty() {
-                    output += .codegen_function_predecl(function_, as_method: true)
-                } else {
-                    output += .codegen_function(function_, as_method: true)
+                if not function_.type is ImplicitEnumConstructor {
+                    if enum_.generic_parameters.is_empty() and function_.generics.params.is_empty() {
+                        output += .codegen_function_predecl(function_, as_method: true)
+                    } else {
+                        output += .codegen_function(function_, as_method: true)
+                    }
                 }
             }
         }
@@ -1938,7 +1952,7 @@ struct CodeGenerator {
                 } else {
                     output += .codegen_block(block: catch_block!)
                 }
-                
+
                 if not is_void {
                     output += "} else {"
                     output += fresh_var
@@ -2102,7 +2116,7 @@ struct CodeGenerator {
                             output += " >= "
                             output += .codegen_expression(from!)
                         }
-                        
+
                         if to.has_value() {
                             if from.has_value() {
                                 output += "&& __jakt_enum_value "
@@ -2639,11 +2653,11 @@ struct CodeGenerator {
                         let type = .program.get_type(type_id)
 
                         if not (
-                            type_module.is_root or 
-                            type_module.is_prelude() or 
-                            function_.linkage is External or 
+                            type_module.is_root or
+                            type_module.is_prelude() or
+                            function_.linkage is External or
                             function_.type is Expression or
-                            function_.type is Closure or 
+                            function_.type is Closure or
                             (not call.namespace_.is_empty() and call.namespace_[0].name == type_module.name)
                         ) {
                             output += type_module.name
@@ -2704,11 +2718,11 @@ struct CodeGenerator {
                                 let enum_type_module = .program.get_module(enum_id.module)
                                 if enum_.is_boxed {
                                     if not (
-                                        type_module.is_root or 
-                                        type_module.is_prelude() or 
-                                        function_.linkage is External or 
+                                        type_module.is_root or
+                                        type_module.is_prelude() or
+                                        function_.linkage is External or
                                         function_.type is Expression or
-                                        function_.type is Closure or 
+                                        function_.type is Closure or
                                         (not call.namespace_.is_empty() and call.namespace_[0].name == type_module.name)
                                     ) {
                                         output += type_module.name
@@ -2738,11 +2752,11 @@ struct CodeGenerator {
                         }
                     } else {
                         if not (
-                            type_module.is_root or 
-                            type_module.is_prelude() or 
-                            function_.linkage is External or 
+                            type_module.is_root or
+                            type_module.is_prelude() or
+                            function_.linkage is External or
                             function_.type is Expression or
-                            function_.type is Closure or 
+                            function_.type is Closure or
                             (not call.namespace_.is_empty() and call.namespace_[0].name == type_module.name)
                         ) {
                             output += type_module.name

--- a/selfhost/formatter.jakt
+++ b/selfhost/formatter.jakt
@@ -3,9 +3,7 @@ import lexer { Lexer, Token }
 
 function concat<T>(anon xs: [T], anon y: T) throws -> [T] {
     mut ys: [T] = []
-    for x in xs {
-        ys.push(x)
-    }
+    ys.push_values(xs)
     ys.push(y)
     return ys
 }
@@ -108,7 +106,7 @@ struct FormattedToken {
 
     function debug_text(this) throws -> String => match .token {
         Identifier(name) => format("Identifier: {}", name)
-        Eol(comment) => format("Eol: {}", comment ?? ""), 
+        Eol(comment) => format("Eol: {}", comment ?? ""),
         Eof => "Eof"
         else => .token_text()
     }
@@ -633,7 +631,7 @@ struct Stage0 {
                 }
                 RCurly => {
                     .pop_state()
-                    
+
                     yield FormattedToken(
                         token
                         indent: .indent
@@ -1145,7 +1143,7 @@ struct Stage0 {
                     mut new_expression_mode = ExpressionMode::OutsideExpression
                     if expression_mode is BeforeExpressions {
                         new_expression_mode = ExpressionMode::BeforeExpressions
-                    } else {    
+                    } else {
                         if allow_eol.has_value() and allow_eol! > 0 {
                             new_allow_eol = allow_eol! - 1
                         }
@@ -1273,7 +1271,7 @@ struct Stage0 {
                         .dedents_to_skip[.dedents_to_skip.size() - 1] += 1
                         new_arrow_indents++
                     }
-                    
+
                     .replace_state(State::StatementContext(
                         open_parens
                         open_curlies
@@ -1720,7 +1718,7 @@ struct Stage0 {
                             )
                         }
                     }
-                    
+
                     yield FormattedToken(
                         token
                         indent: .indent
@@ -2301,7 +2299,7 @@ struct Stage0 {
                        indent: .indent
                        trailing_trivia: [b' ']
                        preceding_trivia: []
-                   ) 
+                   )
                 }
                 Equal | Arrow | FatArrow => {
                     .pop_state()
@@ -2868,7 +2866,7 @@ struct Formatter implements(ThrowingIterable<[FormattedToken]>) {
                         and not .breakable_points_in_current_line.is_empty()
                         and .breakable_points_in_current_line[most_desirable_breaking_point_index].point() < .current_line.size()
                         and not Formatter::should_ignore_state(current_state) {
-                        
+
                         let breakable_point = .breakable_points_in_current_line[most_desirable_breaking_point_index]
                         if not .replace_commas_in_enclosure.is_empty() {
                             .replace_commas_in_enclosure[.replace_commas_in_enclosure.size() - 1] = newline

--- a/selfhost/ide.jakt
+++ b/selfhost/ide.jakt
@@ -360,31 +360,34 @@ function completions_for_type_id(program: CheckedProgram, type_id: TypeId) throw
 
 function find_function_completions_in_scope(anon scope: Scope, program: CheckedProgram) throws -> [String] {
     mut output: [String] = []
-    for function_name in scope.functions.keys() {
-        let function_id = scope.functions.get(function_name)!
-        let checked_function = program.get_function(function_id)
+    for function_name in scope.functions.keys().iterator() {
+        let overload_set = scope.functions.get(function_name)!
 
-        if checked_function.params.first().has_value() {
-            let param = checked_function.params.first()!
-            if param.variable.name == "this" {
-                mut full_call = checked_function.name
-                mut first = true
-                full_call += "("
-                mut iter = checked_function.params.iterator()
-                let dummy = iter.next()
-                for param in iter {
-                    if not first {
-                        full_call += ", "
-                    } else {
-                        first = false
+        for function_id in overload_set {
+            let checked_function = program.get_function(function_id)
+
+            if checked_function.params.first().has_value() {
+                let param = checked_function.params.first()!
+                if param.variable.name == "this" {
+                    mut full_call = checked_function.name
+                    mut first = true
+                    full_call += "("
+                    mut iter = checked_function.params.iterator()
+                    let dummy = iter.next()
+                    for param in iter {
+                        if not first {
+                            full_call += ", "
+                        } else {
+                            first = false
+                        }
+                        full_call += param.variable.name
                     }
-                    full_call += param.variable.name
+                    full_call += ")"
+                    output.push(full_call)
                 }
-                full_call += ")"
-                output.push(full_call)
+            } else {
+                output.push(format("{}()", checked_function.name))
             }
-        } else {
-            output.push(format("{}()", checked_function.name))
         }
     }
     return output
@@ -428,11 +431,13 @@ function find_span_in_scope(program: CheckedProgram, scope: Scope, span: Span) t
         }
     }
 
-    for function_id in scope.functions {
-        let checked_function = program.get_function(function_id.1)
-        let usage = find_span_in_function(program, checked_function, span)
-        if usage.has_value() {
-            return usage!
+    for (_, overload_set) in scope.functions {
+        for function_id in overload_set {
+            let checked_function = program.get_function(function_id)
+            let usage = find_span_in_function(program, checked_function, span)
+            if usage.has_value() {
+                return usage!
+            }
         }
     }
 

--- a/selfhost/ide.jakt
+++ b/selfhost/ide.jakt
@@ -87,9 +87,7 @@ function find_symbols_in_namespace(anon namespace_: ParsedNamespace) throws -> [
     }
 
     for sub_namespace in namespace_.namespaces {
-        for child_symbol in find_symbols_in_namespace(sub_namespace) {
-            symbols.push(child_symbol)
-        }
+        symbols.push_values(find_symbols_in_namespace(sub_namespace))
     }
 
     if not namespace_.name_span.has_value() {
@@ -321,9 +319,7 @@ function completions_for_type_id(program: CheckedProgram, type_id: TypeId) throw
         Enum(enum_id) => {
             let enum_ = program.get_enum(enum_id)
             let scope = program.get_scope(enum_.scope_id)
-            for completion in find_function_completions_in_scope(scope, program) {
-                output.push(completion)
-            }
+            output.push_values(find_function_completions_in_scope(scope, program))
         }
         Struct(struct_id) => {
             let structure = program.get_struct(struct_id)
@@ -334,9 +330,7 @@ function completions_for_type_id(program: CheckedProgram, type_id: TypeId) throw
             }
 
             let scope = program.get_scope(structure.scope_id)
-            for completion in find_function_completions_in_scope(scope, program) {
-                output.push(completion)
-            }
+            output.push_values(find_function_completions_in_scope(scope, program))
         }
         GenericInstance(id: struct_id) => {
             let structure = program.get_struct(struct_id)
@@ -347,10 +341,7 @@ function completions_for_type_id(program: CheckedProgram, type_id: TypeId) throw
             }
 
             let scope = program.get_scope(structure.scope_id)
-            //FIXME: replace once a Array.push_values or Array.extends is available
-            for completion in find_function_completions_in_scope(scope, program) {
-                output.push(completion)
-            }
+            output.push_values(find_function_completions_in_scope(scope, program))
         }
         else => {}
     }

--- a/selfhost/ide.jakt
+++ b/selfhost/ide.jakt
@@ -321,33 +321,8 @@ function completions_for_type_id(program: CheckedProgram, type_id: TypeId) throw
         Enum(enum_id) => {
             let enum_ = program.get_enum(enum_id)
             let scope = program.get_scope(enum_.scope_id)
-            for function_name in scope.functions.keys() {
-                let function_id = scope.functions.get(function_name)!
-
-                let checked_function = program.get_function(function_id)
-
-                if checked_function.params.first().has_value() {
-                    let param = checked_function.params.first()!
-                    if param.variable.name == "this" {
-                        mut full_call = checked_function.name
-                        mut first = true
-                        full_call += "("
-                        mut iter = checked_function.params.iterator()
-                        let dummy = iter.next()
-                        for param in iter {
-                            if not first {
-                                full_call += ", "
-                            } else {
-                                first = false
-                            }
-                            full_call += param.variable.name
-                        }
-                        full_call += ")"
-                        output.push(full_call)
-                    }
-                } else {
-                    output.push(format("{}()", checked_function.name))
-                }
+            for completion in find_function_completions_in_scope(scope, program) {
+                output.push(completion)
             }
         }
         Struct(struct_id) => {
@@ -359,38 +334,11 @@ function completions_for_type_id(program: CheckedProgram, type_id: TypeId) throw
             }
 
             let scope = program.get_scope(structure.scope_id)
-
-            for function_name in scope.functions.keys() {
-                let function_id = scope.functions.get(function_name)!
-
-                let checked_function = program.get_function(function_id)
-
-                if checked_function.params.first().has_value() {
-                    let param = checked_function.params.first()!
-                    if param.variable.name == "this" {
-                        mut full_call = checked_function.name
-                        mut first = true
-                        full_call += "("
-                        mut iter = checked_function.params.iterator()
-                        let dummy = iter.next()
-                        for param in iter {
-                            if not first {
-                                full_call += ", "
-                            } else {
-                                first = false
-                            }
-                            full_call += param.variable.name
-                        }
-                        full_call += ")"
-                        output.push(full_call)
-                    }
-                } else {
-                    output.push(format("{}()", checked_function.name))
-                }
+            for completion in find_function_completions_in_scope(scope, program) {
+                output.push(completion)
             }
         }
         GenericInstance(id: struct_id) => {
-            // FIXME: this is a copy of the above
             let structure = program.get_struct(struct_id)
 
             for field in structure.fields {
@@ -399,39 +347,46 @@ function completions_for_type_id(program: CheckedProgram, type_id: TypeId) throw
             }
 
             let scope = program.get_scope(structure.scope_id)
-
-            for function_name in scope.functions.keys() {
-                let function_id = scope.functions.get(function_name)!
-
-                let checked_function = program.get_function(function_id)
-
-                if checked_function.params.first().has_value() {
-                    let param = checked_function.params.first()!
-                    if param.variable.name == "this" {
-                        mut full_call = checked_function.name
-                        mut first = true
-                        full_call += "("
-                        mut iter = checked_function.params.iterator()
-                        let dummy = iter.next()
-                        for param in iter {
-                            if not first {
-                                full_call += ", "
-                            } else {
-                                first = false
-                            }
-                            full_call += param.variable.name
-                        }
-                        full_call += ")"
-                        output.push(full_call)
-                    }
-                } else {
-                    output.push(format("{}()", checked_function.name))
-                }
+            //FIXME: replace once a Array.push_values or Array.extends is available
+            for completion in find_function_completions_in_scope(scope, program) {
+                output.push(completion)
             }
         }
         else => {}
     }
 
+    return output
+}
+
+function find_function_completions_in_scope(anon scope: Scope, program: CheckedProgram) throws -> [String] {
+    mut output: [String] = []
+    for function_name in scope.functions.keys() {
+        let function_id = scope.functions.get(function_name)!
+        let checked_function = program.get_function(function_id)
+
+        if checked_function.params.first().has_value() {
+            let param = checked_function.params.first()!
+            if param.variable.name == "this" {
+                mut full_call = checked_function.name
+                mut first = true
+                full_call += "("
+                mut iter = checked_function.params.iterator()
+                let dummy = iter.next()
+                for param in iter {
+                    if not first {
+                        full_call += ", "
+                    } else {
+                        first = false
+                    }
+                    full_call += param.variable.name
+                }
+                full_call += ")"
+                output.push(full_call)
+            }
+        } else {
+            output.push(format("{}()", checked_function.name))
+        }
+    }
     return output
 }
 
@@ -673,7 +628,7 @@ function find_span_in_statement(program: CheckedProgram, statement: CheckedState
     }
 }
 
-function find_span_in_expression(program: CheckedProgram, expr: CheckedExpression, span: Span) throws -> Usage? { 
+function find_span_in_expression(program: CheckedProgram, expr: CheckedExpression, span: Span) throws -> Usage? {
     let none: Usage? = None
 
     return match expr {
@@ -934,7 +889,7 @@ function find_span_in_expression(program: CheckedProgram, expr: CheckedExpressio
             }
             if to.has_value() {
                 return find_span_in_expression(program, expr: to!, span)
-            } 
+            }
             yield none
         }
         else => none

--- a/selfhost/interpreter.jakt
+++ b/selfhost/interpreter.jakt
@@ -701,9 +701,9 @@ class Interpreter {
                     )
                 }
                 "as_saturated" => {
-                    let function_ = .program.get_function(.program.find_function_in_scope(
+                    let function_ = .program.get_function(.program.find_functions_with_name_in_scope(
                         parent_scope_id: .program.prelude_scope_id()
-                        function_name: "as_saturated")!)
+                        function_name: "as_saturated")![0])
 
                     let output_type_id = type_bindings.get(function_.generics.params[0].type_id().to_string())
                     yield StatementResult::JustValue(
@@ -949,7 +949,7 @@ class Interpreter {
                     let error_struct_id = .program.find_struct_in_prelude("Error")
                     let error_struct = .program.get_struct(error_struct_id)
                     let scope = .program.get_scope(error_struct.scope_id)
-                    let constructor = scope.functions.get("from_errno")
+                    let constructors = scope.functions.get("from_errno")
                     yield StatementResult::JustValue(
                         Value(
                             impl: ValueImpl::Struct(
@@ -957,7 +957,7 @@ class Interpreter {
                                     err
                                 ],
                                 struct_id: error_struct_id
-                                constructor: constructor!
+                                constructor: constructors![0]
                             )
                             span: call_span
                         )
@@ -1018,7 +1018,7 @@ class Interpreter {
                     let file_struct_id = .program.find_struct_in_prelude("File")
                     let file_struct = .program.get_struct(file_struct_id)
                     let scope = .program.get_scope(file_struct.scope_id)
-                    let constructor = scope.functions.get("open_for_reading")
+                    let constructors = scope.functions.get("open_for_reading")
                     yield StatementResult::JustValue(
                         Value(
                             impl: ValueImpl::Struct(
@@ -1026,7 +1026,7 @@ class Interpreter {
                                     path_value
                                 ],
                                 struct_id: file_struct_id
-                                constructor: constructor!
+                                constructor: constructors![0]
                             )
                             span: call_span
                         )
@@ -1067,7 +1067,7 @@ class Interpreter {
                                     path_value
                                 ],
                                 struct_id: file_struct_id
-                                constructor: constructor!
+                                constructor: constructor![0]
                             )
                             span: call_span
                         )
@@ -1092,7 +1092,7 @@ class Interpreter {
                     let file_struct_id = .program.find_struct_in_prelude("File")
                     let file_struct = .program.get_struct(file_struct_id)
                     let scope = .program.get_scope(file_struct.scope_id)
-                    let open_for_reading = scope.functions.get("open_for_reading")!
+                    let open_for_reading = scope.functions.get("open_for_reading")![0]
                     match this_argument!.impl {
                         Struct(constructor) => {
                             if not constructor.has_value() or not constructor!.equals(open_for_reading) {
@@ -1147,7 +1147,7 @@ class Interpreter {
                     let file_struct_id = .program.find_struct_in_prelude("File")
                     let file_struct = .program.get_struct(file_struct_id)
                     let scope = .program.get_scope(file_struct.scope_id)
-                    let open_for_reading = scope.functions.get("open_for_reading")!
+                    let open_for_reading = scope.functions.get("open_for_reading")![0]
                     match this_argument!.impl {
                         Struct(constructor) => {
                             if not constructor.has_value() or not constructor!.equals(open_for_reading) {
@@ -1228,7 +1228,7 @@ class Interpreter {
                     let file_struct_id = .program.find_struct_in_prelude("File")
                     let file_struct = .program.get_struct(file_struct_id)
                     let scope = .program.get_scope(file_struct.scope_id)
-                    let open_for_writing = scope.functions.get("open_for_writing")!
+                    let open_for_writing = scope.functions.get("open_for_writing")![0]
                     match this_argument!.impl {
                         Struct(constructor) => {
                             if not constructor.has_value() or not constructor!.equals(open_for_writing) {
@@ -5170,7 +5170,7 @@ class Interpreter {
             }
 
             let range_struct_id = .program.find_struct_in_prelude("Range")
-            let range_constructor = .program.find_function_in_scope(
+            let range_constructors = .program.find_functions_with_name_in_scope(
                 parent_scope_id: .program.get_struct(range_struct_id).scope_id,
                 function_name: "Range")!
 
@@ -5178,7 +5178,7 @@ class Interpreter {
                 impl: ValueImpl::Struct(
                     fields: [start, end]
                     struct_id: range_struct_id
-                    constructor: range_constructor
+                    constructor: range_constructors[0]
                 )
                 span
             ))

--- a/selfhost/interpreter.jakt
+++ b/selfhost/interpreter.jakt
@@ -555,7 +555,8 @@ class Interpreter {
     public function enter_span(mut this, anon span: Span) throws {
         .spans.push(span)
     }
-    
+
+
     public function leave_span(mut this) {
         // FIXME: It's awkward that we need a temporary to avoid the C++ nodiscard warning
         let dummy = .spans.pop()
@@ -1107,7 +1108,7 @@ class Interpreter {
                             panic("expected struct as this argument")
                         }
                     }
-                    
+
                     mut file = File::open_for_reading(path)
                     mut result_values: [Value] = []
                     for byte in file.read_all() {
@@ -1702,6 +1703,25 @@ class Interpreter {
                     }
                     else => {
                         panic("Invalid use of Array::push()")
+                    }
+                }
+                "push_values" => match this_argument!.impl {
+                    JaktArray(values) => {
+                        mut mutable_values = values
+                        match arguments[0].impl {
+                            JaktArray(values) => {
+                                for value in values {
+                                    mutable_values.push(value)
+                                }
+                            }
+                            else => .error("Only argument to push_values needs to be another Array", call_span)
+                        }
+                        yield StatementResult::JustValue(
+                            Value(impl: ValueImpl::Void, span: call_span)
+                        )
+                    }
+                    else => {
+                        panic("Invalid use of Array::push_values()")
                     }
                 }
                 "pop" => match this_argument!.impl {
@@ -2517,7 +2537,7 @@ class Interpreter {
         if function_to_run.linkage is External {
             // If this is a prelude function, run it manually
             let function_scope = .program.get_scope(function_to_run.function_scope_id)
-            
+
             if not .get_prelude_function(function_to_run.function_scope_id) {
                 .error(
                     format("Cannot call external function '{}'", function_to_run.name)
@@ -2645,7 +2665,7 @@ class Interpreter {
                 defer {
                     scope.perform_defers(interpreter: this, span: call_span)
                 }
-                
+
                 for i in 0..function_to_run.params.size() {
                     if this_offset != 0 and i == 0 {
                         continue
@@ -2695,7 +2715,7 @@ class Interpreter {
                         return ExecutionResult::Return(Value(
                             impl
                             span: call_span
-                        )) 
+                        ))
                     }
                     else => {
                         .error(
@@ -2720,7 +2740,7 @@ class Interpreter {
                         return ExecutionResult::Return(Value(
                             impl
                             span: call_span
-                        )) 
+                        ))
                     }
                     else => {
                         .error(
@@ -4658,7 +4678,7 @@ class Interpreter {
         }
     }
 
-    public function execute_expression(mut this, anon expr: CheckedExpression, anon mut scope: InterpreterScope) throws -> StatementResult => match .current_function_id.has_value() { 
+    public function execute_expression(mut this, anon expr: CheckedExpression, anon mut scope: InterpreterScope) throws -> StatementResult => match .current_function_id.has_value() {
         false => .execute_expression_without_cast(expr, scope)
         else => match .execute_expression_without_cast(expr, scope) {
             Return(value) => StatementResult::Return(cast_value_to_type(value, .program.get_function(.current_function_id!).return_type_id, interpreter: this))

--- a/selfhost/interpreter.jakt
+++ b/selfhost/interpreter.jakt
@@ -358,9 +358,7 @@ function value_to_checked_expression(anon this_value: Value, anon mut interprete
         }
 
         // Then append all the statements in the block
-        for statement in block.statements {
-            statements.push(statement)
-        }
+        statements.push_values(block.statements)
 
         let new_block = CheckedBlock(
             statements

--- a/selfhost/interpreter.jakt
+++ b/selfhost/interpreter.jakt
@@ -1760,7 +1760,7 @@ class Interpreter {
                         )
                     }
                     else => {
-                        panic("Invalid use of Array::push()")
+                        panic("Invalid use of Array::contains()")
                     }
                 }
                 "is_empty" => match this_argument!.impl {

--- a/selfhost/main.jakt
+++ b/selfhost/main.jakt
@@ -416,9 +416,9 @@ function main(args: [String]) {
                     continue
                 }
 
-                for function_ in scope.functions {
-                    if function_.0 == "main" {
-                        main_function_id = function_.1
+                for (function_name, overload_set) in scope.functions {
+                    if function_name == "main" {
+                        main_function_id = overload_set[0]
                         break
                     }
                 }

--- a/selfhost/parser.jakt
+++ b/selfhost/parser.jakt
@@ -9,7 +9,7 @@
 
 import error { JaktError, print_error}
 import lexer { Token, LiteralPrefix, LiteralSuffix }
-import utility { panic, todo, FileId, Span, extend_array, join }
+import utility { panic, todo, FileId, Span, join }
 import compiler { Compiler }
 
 enum NumericConstant {
@@ -253,13 +253,8 @@ struct ParsedNamespace {
         for extern_import in .extern_imports {
             if extern_import.is_equivalent_to(import_) {
                 extern_import.assigned_namespace.merge_with(import_.assigned_namespace)
-                for action in import_.before_include {
-                    extern_import.before_include.push(action)
-                }
-                for action in import_.after_include {
-                    extern_import.after_include.push(action)
-                }
-
+                extern_import.before_include.push_values(import_.before_include)
+                extern_import.after_include.push_values(import_.after_include)
                 return
             }
         }
@@ -277,8 +272,8 @@ struct ParsedNamespace {
     }
 
     function merge_with(mut this, anon namespace_: ParsedNamespace) throws {
-        extend_array(target: .functions, extend_with: namespace_.functions)
-        extend_array(target: .records, extend_with: namespace_.records)
+        .functions.push_values(namespace_.functions)
+        .records.push_values(namespace_.records)
 
         .module_imports.add_capacity(namespace_.module_imports.size())
         for import_ in namespace_.module_imports {
@@ -1191,7 +1186,7 @@ boxed enum ParsedExpression {
         }
         Function(captures: lhs_captures, params: lhs_params, can_throw: lhs_can_throw, return_type: lhs_return_type) => match rhs_expression {
             Function(captures: rhs_captures, params: rhs_params, can_throw: rhs_can_throw, return_type: rhs_return_type) => {
-                guard lhs_return_type.equals(rhs_return_type) and 
+                guard lhs_return_type.equals(rhs_return_type) and
                     lhs_can_throw == rhs_can_throw and
                     lhs_captures.size() == rhs_captures.size() and
                     lhs_params.size() == rhs_params.size() else {
@@ -1252,8 +1247,8 @@ struct ParsedVariable {
     span: Span
 
     function equals(this, anon rhs_parsed_varible: ParsedVariable) -> bool {
-        return .name == rhs_parsed_varible.name and 
-        .parsed_type.equals(rhs_parsed_varible.parsed_type) and 
+        return .name == rhs_parsed_varible.name and
+        .parsed_type.equals(rhs_parsed_varible.parsed_type) and
         .is_mutable ==  rhs_parsed_varible.is_mutable
     }
 }
@@ -1824,18 +1819,14 @@ struct Parser {
                         .index++
                         let actions = .parse_include_action()
                         if actions.has_value() {
-                            for action in actions! {
-                                parsed_import.before_include.push(action)
-                            }
+                            parsed_import.before_include.push_values(actions!)
                         }
                     }
                     "after_include" => {
                         .index++
                         let actions = .parse_include_action()
                         if actions.has_value() {
-                            for action in actions! {
-                                parsed_import.after_include.push(action)
-                            }
+                            parsed_import.after_include.push_values(actions!)
                         }
                     }
                     else => {
@@ -2756,7 +2747,7 @@ struct Parser {
                     let var_decl = .parse_variable_declaration(is_mutable: current_param_is_mutable)
 
                     mut default_argument: ParsedExpression? = None
-                    
+
                     if .current() is Equal {
                         .index++
                         default_argument = .parse_expression(allow_assignments: false, allow_newlines: true)
@@ -3099,7 +3090,7 @@ struct Parser {
                 }
             }
         }
-        
+
         return []
     }
 
@@ -3227,7 +3218,7 @@ struct Parser {
 
         if .current() is LCurly {
             .index++
-        } else { 
+        } else {
             .error("Expected '{'", start)
         }
 
@@ -3425,7 +3416,7 @@ struct Parser {
 
         mut iterator_name = ""
         mut destructured_var_decls: [ParsedVarDecl] = []
-        
+
         match .current() {
             Identifier(name) => {
                 iterator_name = name
@@ -3472,9 +3463,7 @@ struct Parser {
             let destructured_vars_stmt = ParsedStatement::DestructuringAssignment(vars: destructured_var_decls, var_decl, span: merge_spans(start_span, .previous().span()))
             mut block_stmts: [ParsedStatement] = []
             block_stmts.push(destructured_vars_stmt)
-            for stmt in block.stmts {
-                block_stmts.push(stmt)
-            }
+            block_stmts.push_values(block.stmts)
             block.stmts = block_stmts
         }
 
@@ -3698,7 +3687,7 @@ struct Parser {
         LParen(span) => {
             let start_span = .current().span()
             .index++
-            
+
             mut expr = .parse_expression(allow_assignments: false, allow_newlines: false)
 
             .skip_newlines()
@@ -3845,7 +3834,7 @@ struct Parser {
                             let digit: u64 = as_saturated(byte - b'0')
                             total = total * 2 + digit
                         }
-                    }                    
+                    }
                 }
                 None => {}
             }
@@ -3902,7 +3891,7 @@ struct Parser {
 
         if floating and suffix is None {
             suffix = LiteralSuffix::F64
-        } 
+        }
 
         // Sanity check for float numbers with an integer suffix
         let is_float_suffix = match suffix {
@@ -4030,7 +4019,7 @@ struct Parser {
             return []
         }
         .index++
-        
+
         while not .eof() {
             match .current() {
                 RSquare => {
@@ -4151,7 +4140,7 @@ struct Parser {
                 to = .parse_operand()
             }
         }
-        
+
         return ParsedExpression::Range(from: None, to, span: merge_spans(start, .current().span()))
     }
 
@@ -4192,7 +4181,7 @@ struct Parser {
 
         return ParsedExpression::Set(values: output, span: merge_spans(start, .tokens[end].span()))
     }
-    
+
     function parse_operand(mut this) throws -> ParsedExpression {
         .skip_newlines()
         let start = .current().span()

--- a/selfhost/parser.jakt
+++ b/selfhost/parser.jakt
@@ -1276,19 +1276,127 @@ boxed enum ParsedType {
     }
 
     function equals(this, anon rhs_parsed_type: ParsedType) -> bool => match this {
-        Name => rhs_parsed_type is Name
-        NamespacedName => rhs_parsed_type is NamespacedName
-        GenericType => rhs_parsed_type is GenericType
-        JaktArray => rhs_parsed_type is JaktArray
-        Dictionary => rhs_parsed_type is Dictionary
-        JaktTuple => rhs_parsed_type is JaktTuple
-        Set => rhs_parsed_type is Set
-        Optional => rhs_parsed_type is Optional
-        Reference => rhs_parsed_type is Reference
-        MutableReference => rhs_parsed_type is MutableReference
-        RawPtr => rhs_parsed_type is RawPtr
-        WeakPtr => rhs_parsed_type is WeakPtr
-        Function => rhs_parsed_type is Function
+        Name(name: lhs_name) => match rhs_parsed_type {
+            Name(name: rhs_name) => lhs_name == rhs_name
+            else => false
+        }
+        NamespacedName(name: lhs_name, namespaces: lhs_namespaces, params: lhs_params) => match rhs_parsed_type {
+            NamespacedName(name: rhs_name, namespaces: rhs_namespaces, params: rhs_params) => {
+                if lhs_name != rhs_name {
+                    return false
+                }
+
+                if lhs_namespaces.size() != rhs_namespaces.size() {
+                    return false
+                }
+                for namespace_index in 0..lhs_namespaces.size() {
+                    if lhs_namespaces[namespace_index] != rhs_namespaces[namespace_index] {
+                        return false
+                    }
+                }
+
+                if lhs_params.size() != rhs_params.size() {
+                    return false
+                }
+                for param_index in 0..lhs_params.size() {
+                    if not lhs_params[param_index].equals(rhs_params[param_index]) {
+                        return false
+                    }
+                }
+
+                return true
+            }
+            else => false
+        }
+        GenericType(name: lhs_name, generic_parameters: lhs_generic_parameters) => match rhs_parsed_type {
+            GenericType(name: rhs_name, generic_parameters: rhs_generic_parameters) => {
+                if lhs_name != rhs_name {
+                    return false
+                }
+
+                if lhs_generic_parameters.size() != rhs_generic_parameters.size() {
+                    return false
+                }
+                for param_index in 0..lhs_generic_parameters.size() {
+                    if not lhs_generic_parameters[param_index].equals(rhs_generic_parameters[param_index]) {
+                        return false
+                    }
+                }
+
+                return true
+            }
+            else => false
+        }
+        JaktArray(inner: lhs_inner) => match rhs_parsed_type {
+            JaktArray(inner: rhs_inner) => lhs_inner.equals(rhs_inner)
+            else => false
+        }
+        Dictionary(key: lhs_key, value: lhs_value) => match rhs_parsed_type {
+            Dictionary(key: rhs_key, value: rhs_value) => lhs_key.equals(rhs_key) and lhs_value.equals(rhs_value)
+            else => false
+        }
+        JaktTuple(types: lhs_types) => match rhs_parsed_type {
+            JaktTuple(types: rhs_types) => {
+                if lhs_types.size() != rhs_types.size() {
+                    return false
+                }
+                for type_index in 0..lhs_types.size() {
+                    if not lhs_types[type_index].equals(rhs_types[type_index]) {
+                        return false
+                    }
+                }
+
+                return true
+            }
+            else => false
+        }
+        Set(inner: lhs_inner) => match rhs_parsed_type {
+            Set(inner: rhs_inner) => lhs_inner.equals(rhs_inner)
+            else => false
+        }
+        Optional(inner: lhs_inner) => match rhs_parsed_type {
+            Optional(inner: rhs_inner) => lhs_inner.equals(rhs_inner)
+            else => false
+        }
+        Reference(inner: lhs_inner) => match rhs_parsed_type {
+            Reference(inner: rhs_inner) => lhs_inner.equals(rhs_inner)
+            else => false
+        }
+        MutableReference(inner: lhs_inner) => match rhs_parsed_type {
+            MutableReference(inner: rhs_inner) => lhs_inner.equals(rhs_inner)
+            else => false
+        }
+        RawPtr(inner: lhs_inner) => match rhs_parsed_type {
+            RawPtr(inner: rhs_inner) => lhs_inner.equals(rhs_inner)
+            else => false
+        }
+        WeakPtr(inner: lhs_inner) => match rhs_parsed_type {
+            WeakPtr(inner: rhs_inner) => lhs_inner.equals(rhs_inner)
+            else => false
+        }
+        Function(params: lhs_params, can_throw: lhs_can_throw, return_type: lhs_return_type) => match rhs_parsed_type {
+            Function(params: rhs_params, can_throw: rhs_can_throw, return_type: rhs_return_type) => {
+                if lhs_can_throw != rhs_can_throw {
+                    return false
+                }
+
+                if not lhs_return_type.equals(rhs_return_type) {
+                    return false
+                }
+
+                if lhs_params.size() != rhs_params.size() {
+                    return false
+                }
+                for param_index in 0..lhs_params.size() {
+                    if not lhs_params[param_index].equals(rhs_params[param_index]) {
+                        return false
+                    }
+                }
+
+                return true
+            }
+            else => false
+        }
         Empty => rhs_parsed_type is Empty
     }
 }

--- a/selfhost/parser.jakt
+++ b/selfhost/parser.jakt
@@ -358,6 +358,34 @@ struct ParsedFunction {
     must_instantiate: bool
     is_comptime: bool
     is_fat_arrow: bool
+
+    function equals(this, anon other: ParsedFunction) -> bool {
+        if this.name != other.name or
+        this.can_throw != other.can_throw or
+        this.is_comptime != other.is_comptime or
+        this.is_fat_arrow != other.is_fat_arrow {
+            return false
+        }
+
+        if not this.block.equals(other.block) {
+            return false
+        }
+
+        if this.params.size() != other.params.size() {
+            return false
+        }
+        for param_index in 0..this.params.size() {
+            if not this.params[param_index].equals(other.params[param_index])  {
+                return false
+            }
+        }
+
+        if this.generic_parameters.size() != other.generic_parameters.size() {
+            return false
+        }
+
+        return true
+    }
 }
 
 struct ParsedParameter {

--- a/selfhost/posix_compiler.jakt
+++ b/selfhost/posix_compiler.jakt
@@ -22,10 +22,7 @@ function run_compiler(
         extra_flags.push("-Wno-implicit-fallthrough")
         extra_flags.push("-Wno-unused-command-line-argument")
     }
-
-    for extra_flag in extra_compiler_flags {
-        extra_flags.push(extra_flag)
-    }
+    extra_flags.push_values(extra_compiler_flags)
 
     mut compile_args = [
         cxx_compiler_path
@@ -45,9 +42,7 @@ function run_compiler(
     }
 
     if not extra_flags.is_empty() {
-        for flag in extra_flags {
-            compile_args.push(flag)
-        }
+        compile_args.push_values(extra_flags)
     }
 
     compile_args.push("-I")

--- a/selfhost/typechecker.jakt
+++ b/selfhost/typechecker.jakt
@@ -560,11 +560,10 @@ struct Typechecker {
 
     function add_var_to_scope(mut this, scope_id: ScopeId, name: String, var_id: VarId, span: Span) throws -> bool {
         mut scope = .get_scope(scope_id)
-        for existing_var in scope.vars {
-            if name == existing_var.0 {
-                let variable_ = .get_variable(existing_var.1)
-                .error_with_hint(message: format("Redefinition of variable ‘{}’", name), span, hint: "previous definition here", hint_span: variable_.definition_span)
-            }
+        let existing_var = scope.vars.get(name)
+        if existing_var.has_value() {
+            let variable_ = .get_variable(existing_var!)
+            .error_with_hint(message: format("Redefinition of variable ‘{}’", name), span, hint: "previous definition here", hint_span: variable_.definition_span)
         }
         scope.vars.set(key: name, value: var_id)
         return true
@@ -572,14 +571,13 @@ struct Typechecker {
 
     function add_comptime_binding_to_scope(mut this, scope_id: ScopeId, name: String, value: Value, span: Span) throws -> bool {
         mut scope = .get_scope(scope_id)
-        for existing in scope.comptime_bindings {
-            if name == existing.0 {
-                .error_with_hint(
-                    message: format("Redefinition of comptime variable ‘{}’", name)
-                    span
-                    hint: "previous definition here"
-                    hint_span: existing.1.span)
-            }
+        let existing_binding = scope.comptime_bindings.get(name)
+        if existing_binding.has_value() {
+            .error_with_hint(
+                message: format("Redefinition of comptime variable ‘{}’", name)
+                span
+                hint: "previous definition here"
+                hint_span: existing_binding!.span)
         }
         scope.comptime_bindings.set(key: name, value)
         return true

--- a/selfhost/typechecker.jakt
+++ b/selfhost/typechecker.jakt
@@ -31,6 +31,11 @@ import path { Path }
 import compiler { Compiler }
 import interpreter { Interpreter, InterpreterScope, ExecutionResult, value_to_checked_expression }
 
+enum FunctionMatchResult {
+    MatchSuccess(args: [CheckedExpression], maybe_this_type_id: TypeId?, used_generic_inferences: [String:String], specificity: i64)
+    MatchError(errors: [JaktError])
+}
+
 struct Typechecker {
     compiler: Compiler
     program: CheckedProgram
@@ -537,12 +542,12 @@ struct Typechecker {
                 for existing_function_id in existing_function_binding {
                     let existing_function = .get_function(existing_function_id)
                     if function_to_add.signature_matches(existing_function) {
-                        .error_with_hint(
-                            format("Redefinition of function ‘{}’.", function_to_add.name)
-                            function_to_add.parsed_function!.name_span
-                            "Previous definition is here"
-                            existing_function.parsed_function!.name_span
-                        )
+                    .error_with_hint(
+                        format("Redefinition of function ‘{}’.", function_to_add.name)
+                        function_to_add.parsed_function!.name_span
+                        "Previous definition is here"
+                        existing_function.parsed_function!.name_span
+                    )
                     }
                 }
                 scope.functions[name].push(function_id)
@@ -582,6 +587,20 @@ struct Typechecker {
 
     function find_functions_with_name_in_scope(this, parent_scope_id: ScopeId, function_name: String) throws -> [FunctionId]? {
         return .program.find_functions_with_name_in_scope(parent_scope_id, function_name)
+    }
+
+    function find_function_matching_signature_in_scope(this, parent_scope_id: ScopeId, prototype: ParsedFunction) throws -> FunctionId? {
+        let function_name  = prototype.name
+        let candidate_ids = .program.find_functions_with_name_in_scope(parent_scope_id, function_name)
+        if candidate_ids.has_value() {
+            for candidate_id in candidate_ids!.iterator() {
+                let candidate = .get_function(candidate_id)
+                if candidate.parsed_function.has_value() and candidate.parsed_function!.equals(prototype) {
+                    return candidate_id
+                }
+            }
+        }
+        return None
     }
 
     function find_struct_in_scope(this, scope_id: ScopeId, name: String) throws -> StructId? =>
@@ -2230,9 +2249,7 @@ struct Typechecker {
         }
 
         for fun in parsed_namespace.functions.iterator() {
-            .current_function_id = .find_functions_with_name_in_scope(parent_scope_id: scope_id, function_name: fun.name)![0]
             .typecheck_function(parsed_function: fun, parent_scope_id: scope_id)
-            .current_function_id = None
         }
 
         for implementation in parsed_namespace.external_trait_implementations {
@@ -3103,8 +3120,14 @@ struct Typechecker {
         checked_function.function_scope_id = scope_id
     }
 
-    function typecheck_jakt_main(mut this, parsed_function: ParsedFunction) throws {
+    function typecheck_jakt_main(mut this, parsed_function: ParsedFunction, parent_scope_id: ScopeId) throws {
         let param_type_error = "Main function must take a single array of strings as its parameter"
+
+        let func_ids = .find_functions_with_name_in_scope(parent_scope_id, function_name: "main")
+        if func_ids!.size() > 1 {
+            .error("Function 'main' declared multiple times.", parsed_function.name_span)
+        }
+
         if parsed_function.params.size() > 1 {
             .error(param_type_error, parsed_function.name_span)
         }
@@ -3148,13 +3171,22 @@ struct Typechecker {
     }
 
     function typecheck_function(mut this, parsed_function: ParsedFunction, parent_scope_id: ScopeId) throws {
+
         if not parsed_function.generic_parameters.is_empty() and not parsed_function.must_instantiate {
             return
         }
 
-        let function_id = .find_functions_with_name_in_scope(parent_scope_id, function_name: parsed_function.name)![0]
+        let func_ids = .find_functions_with_name_in_scope(parent_scope_id, function_name: parsed_function.name)
+        let function_id = .find_function_matching_signature_in_scope(parent_scope_id, prototype: parsed_function)
+
+        guard function_id.has_value() else {
+            .compiler.panic(format("Previously defined function {} not found in scope {}", parsed_function.name, parent_scope_id))
+        }
+
+        .current_function_id = function_id!
+
         if parsed_function.name == "main" {
-            .typecheck_jakt_main(parsed_function)
+            .typecheck_jakt_main(parsed_function, parent_scope_id)
         }
 
         mut checked_function = .get_function(function_id!)
@@ -3236,6 +3268,7 @@ struct Typechecker {
 
         checked_function.block = block
         checked_function.return_type_id = return_type_id
+        .current_function_id = None
     }
 
     function statement_control_flow(this, anon statement: CheckedStatement) -> BlockControlFlow => match statement {
@@ -5452,7 +5485,6 @@ struct Typechecker {
         IndexedStruct(expr, field_name, span, is_optional) => .typecheck_indexed_struct(expr, field_name, scope_id, is_optional, safety_mode, span)
         Boolean(val, span) => {
             .unify_with_type(found_type: builtin(BuiltinType::Bool), expected_type: type_hint, rhs_span: span)
-
             yield CheckedExpression::Boolean(val, span)
         }
         NumericConstant(val, span) => {
@@ -7039,34 +7071,134 @@ struct Typechecker {
             }
         }
 
-        if not ignore_errors {
-            .error(format("Call to unknown function: ‘{}’", call.name), span)
-        }
-
+        .error(format("Call to unknown function: ‘{}’", call.name), span)
         return []
     }
 
-    function typecheck_call(
-        mut this
-        call: ParsedCall
-        caller_scope_id: ScopeId
-        span: Span
-        this_expr: CheckedExpression?
-        parent_id: StructOrEnumId?
-        safety_mode: SafetyMode
-        mut type_hint: TypeId?
-        must_be_enum_constructor: bool
-    ) throws -> CheckedExpression {
+    function match_function_and_resolve_args(mut this, call: ParsedCall, caller_scope_id: ScopeId, candidate: FunctionId, safety_mode: SafetyMode, span: Span, this_expr: CheckedExpression?) throws -> FunctionMatchResult {
+        mut args: [CheckedExpression] = []
+        mut maybe_this_type_id: TypeId? = None
+        mut argument_errors: [JaktError] = []
+        let num_old_compiler_errors = .compiler.errors.size()
+
+        let callee_candidate = .get_function(candidate)
+        let scope_containing_callee = .get_scope(callee_candidate.function_scope_id).parent!
+        let generic_inference_checkpoint = .generic_inferences.perform_checkpoint(reset: false)
+
+        if callee_candidate.is_instantiated {
+            .generic_inferences.perform_checkpoint(reset: true)
+        }
+
+        defer {
+            .generic_inferences.restore(generic_inference_checkpoint)
+        }
+
+        if callee_candidate.type is ImplicitConstructor {
+            let struct_ = .get_struct(callee_candidate.struct_id!)
+            .check_implicit_constructor_argument_access(caller_scope_id, call, struct_)
+        } else {
+            .check_method_access(accessor: caller_scope_id, accessee: scope_containing_callee, method: callee_candidate, span)
+        }
+
+        // If the user gave us explicit type arguments, let's use them in our substitutions
+        mut type_arg_index = 0uz
+        for parsed_type in call.type_args {
+            let checked_type = .typecheck_typename(parsed_type, scope_id: caller_scope_id, name: None)
+            if callee_candidate.generics.params.size() <= type_arg_index {
+                .error("Trying to access generic parameter out of bounds", parsed_type.span())
+                continue
+            }
+
+            // Find the associated type variable for this parameter, we'll use it in substitution
+            let typevar_type_id = callee_candidate.generics.params[type_arg_index].type_id()
+
+            if not typevar_type_id.equals(checked_type) {
+                .generic_inferences.set(typevar_type_id.to_string(), checked_type.to_string())
+            }
+
+            type_arg_index += 1
+        }
+
+        // This will be 0 for functions or 1 for instance methods, because of the `this` ptr
+        mut arg_offset = 0uz
+
+        // If this is a method, let's also add the types we know from our `this` pointer.
+        if this_expr.has_value() {
+            let type_id = this_expr!.type()
+            maybe_this_type_id = type_id
+            let param_type = .get_type(type_id)
+
+            if param_type is GenericInstance(id, args) {
+                let structure = .get_struct(id)
+                for i in 0..structure.generic_parameters.size() {
+                    if structure.generic_parameters[i].type_id.equals(args[i]) {
+                        continue
+                    }
+
+                    .generic_inferences.set(
+                        structure.generic_parameters[i].type_id.to_string()
+                        args[i].to_string()
+                    )
+                }
+            }
+
+            if callee_candidate.is_static() {
+                .error("Cannot call static method on an instance of an object", span)
+            } else {
+                arg_offset = 1uz
+            }
+
+            if callee_candidate.is_mutating() and not this_expr!.is_mutable(program: .program) {
+                .error("Cannot call mutating method on an immutable object instance", span)
+            }
+        } else if not callee_candidate.is_static() {
+            .error_with_hint(
+                "Cannot call an instance method statically"
+                span
+                "Add a dot before the method name to call an instance method"
+                span
+            )
+        }
+
+        mut total_function_specificity = 0
+        let resolved_args: [(String, Span, CheckedExpression)] = .resolve_default_params(params: callee_candidate.generics.base_params, args: call.args, scope_id: caller_scope_id, safety_mode, arg_offset, span)
+        if callee_candidate.generics.base_params.size() == resolved_args.size() + arg_offset {
+            for i in 0..(callee_candidate.generics.base_params.size() - arg_offset) {
+                let (name, span, checked_arg) = resolved_args[i]
+                let type_to = .get_type(callee_candidate.generics.base_params[i+arg_offset].variable.type_id)
+                total_function_specificity += type_to.specificity(program: .program)
+                .check_types_for_compat(
+                    lhs_type_id: callee_candidate.generics.base_params[i+arg_offset].variable.type_id
+                    rhs_type_id: checked_arg.type()
+                    generic_inferences: &mut .generic_inferences
+                    span: checked_arg.span()
+                )
+                args.push(checked_arg)
+            }
+        }
+        let num_match_errors = .compiler.errors.size() - num_old_compiler_errors
+        if num_match_errors > 0 {
+            for error_index in 0uz..num_match_errors {
+                argument_errors.push(.compiler.errors.pop()!)
+            }
+            return FunctionMatchResult::MatchError(errors: argument_errors)
+        }
+        let used_inferences = .generic_inferences.perform_checkpoint(reset: false)
+        return FunctionMatchResult::MatchSuccess(args, maybe_this_type_id, used_generic_inferences: used_inferences, specificity: total_function_specificity)
+    }
+
+    function typecheck_call(mut this, call: ParsedCall, caller_scope_id: ScopeId, span: Span, this_expr: CheckedExpression?, parent_id: StructOrEnumId?, safety_mode: SafetyMode, mut type_hint: TypeId?, must_be_enum_constructor: bool) throws -> CheckedExpression {
         mut args: [(String, CheckedExpression)] = []
         mut return_type = builtin(BuiltinType::Void)
         mut generic_arguments: [TypeId] = []
         mut callee_throws = false
         mut resolved_namespaces: [ResolvedNamespace] = []
+        mut resolved_function_id_candidates: [FunctionId] = []
         mut resolved_function_id: FunctionId? = None
         mut maybe_this_type_id: TypeId? = None
         mut generic_checked_function_to_instantiate: FunctionId? = None
-
         let old_generic_inferences = .generic_inferences.perform_checkpoint(reset: false)
+
         defer {
             .generic_inferences.restore(old_generic_inferences)
         }
@@ -7080,9 +7212,13 @@ struct Typechecker {
                 Struct(id) => {
                     mut struct_ = .get_struct(id)
                     mut scope_id = struct_.scope_id
-                    while not resolved_function_id.has_value() {
-                        resolved_function_id = .resolve_call(call, namespaces: resolved_namespaces, span, scope_id, must_be_enum_constructor, ignore_errors: true).first()
-                        if resolved_function_id.has_value() {
+                    while resolved_function_id_candidates.is_empty() {
+                        let old_ignore_errors = .ignore_errors
+                        .ignore_errors = true
+                        resolved_function_id_candidates = .resolve_call(call, namespaces: resolved_namespaces, span, scope_id, must_be_enum_constructor)
+                        .ignore_errors = old_ignore_errors
+
+                        if not resolved_function_id_candidates.is_empty() {
                             break
                         }
                         if struct_.super_struct_id.has_value() {
@@ -7098,7 +7234,7 @@ struct Typechecker {
                 }
                 Enum(id) => {
                     let scope_id = .get_enum(id).scope_id
-                    resolved_function_id = .resolve_call(call, namespaces: resolved_namespaces, span, scope_id, must_be_enum_constructor, ignore_errors: false).first()
+                    resolved_function_id_candidates = .resolve_call(call, namespaces: resolved_namespaces, span, scope_id, must_be_enum_constructor)
                     yield scope_id
                 }
             }
@@ -7106,7 +7242,7 @@ struct Typechecker {
                 match call.name {
                     "print" | "println" | "eprintln" | "eprint" | "format" => {}
                     else => {
-                        resolved_function_id = .resolve_call(call, namespaces: resolved_namespaces, span, scope_id: caller_scope_id, must_be_enum_constructor, ignore_errors: false).first()
+                        resolved_function_id_candidates = .resolve_call(call, namespaces: resolved_namespaces, span, scope_id: caller_scope_id, must_be_enum_constructor)
                     }
                 }
                 yield caller_scope_id
@@ -7127,7 +7263,42 @@ struct Typechecker {
                 }
             }
             else => {
-                if not resolved_function_id.has_value() {
+                mut max_found_specificity = -1i64
+                mut errors_while_trying_to_find_matching_function: [JaktError] = []
+                mut generic_inferences_for_best_match: [String:String] = [:]
+                // find the best match i.e. the most specific implementation that matches the signature
+                for candidate in resolved_function_id_candidates.iterator() {
+                    match .match_function_and_resolve_args(call, caller_scope_id, candidate, safety_mode, span, this_expr) {
+                        MatchSuccess(args: resolved_args, maybe_this_type_id: resolved_this_type_id, used_generic_inferences, specificity) => {
+                            if specificity > max_found_specificity {
+                                resolved_function_id = candidate
+                                maybe_this_type_id = resolved_this_type_id
+                                max_found_specificity = specificity
+                                generic_inferences_for_best_match = used_generic_inferences
+
+                                args = []
+                                for resolved_arg in resolved_args.iterator() {
+                                    args.push((call.name, resolved_arg))
+                                }
+                            }
+                        }
+                        MatchError(errors) => {
+                            for error in errors.iterator() {
+                                errors_while_trying_to_find_matching_function.push(error)
+                            }
+                            continue
+                        }
+                    }
+                }
+
+                if not resolved_function_id.has_value(){
+                    if not resolved_function_id_candidates.is_empty() {
+                        .error("No function with matching signature found.", span)
+                        for match_error in errors_while_trying_to_find_matching_function.iterator() {
+                            .compiler.errors.push(match_error)
+                        }
+                    }
+
                     mut checked_type_args: [TypeId] = []
                     for type_arg in call.type_args {
                         checked_type_args.push(.typecheck_typename(parsed_type: type_arg, scope_id: caller_scope_id, name: None))
@@ -7135,7 +7306,6 @@ struct Typechecker {
 
                     for arg in call.args {
                         let checked_arg = .typecheck_expression(expr: arg.2, scope_id: caller_scope_id, safety_mode, type_hint: None)
-
                         args.push((call.name, checked_arg))
                     }
 
@@ -7145,7 +7315,7 @@ struct Typechecker {
                             name: call.name,
                             args,
                             type_args: checked_type_args,
-                            function_id: resolved_function_id,
+                            function_id: None,
                             return_type,
                             callee_throws
                         ),
@@ -7154,101 +7324,12 @@ struct Typechecker {
                     )
                 }
 
-                let function_id = resolved_function_id!
-                let callee = .get_function(function_id)
-
-                if callee.is_instantiated {
-                    .generic_inferences.perform_checkpoint(reset: true)
-                }
-
+                .generic_inferences.restore(generic_inferences_for_best_match)
+                let callee = .get_function(resolved_function_id!)
                 callee_throws = callee.can_throw
                 return_type = callee.return_type_id
+
                 let scope_containing_callee = .get_scope(callee.function_scope_id).parent!
-
-                if callee.type is ImplicitConstructor {
-                    let struct_ = .get_struct(callee.struct_id!)
-                    .check_implicit_constructor_argument_access(caller_scope_id, call, struct_)
-                } else {
-                    .check_method_access(accessor: caller_scope_id, accessee: scope_containing_callee, method: callee, span)
-                }
-
-                // If the user gave us explicit type arguments, let's use them in our substitutions
-                mut type_arg_index = 0uz
-                for parsed_type in call.type_args {
-                    let checked_type = .typecheck_typename(parsed_type, scope_id: caller_scope_id, name: None)
-                    if callee.generics.params.size() <= type_arg_index {
-                        .error("Trying to access generic parameter out of bounds", parsed_type.span())
-                        continue
-                    }
-
-                    // Find the associated type variable for this parameter, we'll use it in substitution
-                    let typevar_type_id = callee.generics.params[type_arg_index].type_id()
-
-                    if not typevar_type_id.equals(checked_type) {
-                        .generic_inferences.set(typevar_type_id.to_string(), checked_type.to_string())
-                    }
-
-                    type_arg_index += 1
-                }
-
-
-                // This will be 0 for functions or 1 for instance methods, because of the `this` ptr
-                mut arg_offset = 0uz
-
-                // If this is a method, let's also add the types we know from our `this` pointer.
-                if this_expr.has_value() {
-                    let type_id = this_expr!.type()
-                    maybe_this_type_id = type_id
-                    let param_type = .get_type(type_id)
-
-                    if param_type is GenericInstance(id, args) {
-                        let structure = .get_struct(id)
-                        for i in 0..structure.generic_parameters.size() {
-                            if structure.generic_parameters[i].type_id.equals(args[i]) {
-                                continue
-                            }
-
-                            .generic_inferences.set(
-                                structure.generic_parameters[i].type_id.to_string()
-                                args[i].to_string()
-                            )
-                        }
-                    }
-
-                    if callee.is_static() {
-                        .error("Cannot call static method on an instance of an object", span)
-                    } else {
-                        arg_offset = 1uz
-                    }
-
-                    if callee.is_mutating() and not this_expr!.is_mutable(program: .program) {
-                        .error("Cannot call mutating method on an immutable object instance", span)
-                    }
-                } else if not callee.is_static() {
-                    .error_with_hint(
-                        "Cannot call an instance method statically"
-                        span
-                        "Add a dot before the method name to call an instance method"
-                        span
-                    )
-                }
-
-                mut resolved_args: [(String, Span, CheckedExpression)] = .resolve_default_params(params: callee.generics.base_params, args: call.args, scope_id: caller_scope_id, safety_mode, arg_offset, span)
-
-                if callee.generics.base_params.size() == resolved_args.size() + arg_offset {
-                    for i in 0..(callee.generics.base_params.size() - arg_offset) {
-                        let (name, span, checked_arg) = resolved_args[i]
-
-                        .check_types_for_compat(
-                            lhs_type_id: callee.generics.base_params[i+arg_offset].variable.type_id
-                            rhs_type_id: checked_arg.type()
-                            generic_inferences: &mut .generic_inferences
-                            span: checked_arg.span()
-                        )
-
-                        args.push((call.name, checked_arg))
-                    }
-                }
 
                 // We've now seen all the arguments and should be able to substitute the return type, if it's contains a
                 // type variable. For the moment, we'll just checked to see if it's a type variable.
@@ -7294,7 +7375,7 @@ struct Typechecker {
                 }
 
                 if not callee.is_instantiated or (not callee.linkage is External and not callee.generics.is_specialized_for_types(types: generic_arguments)) {
-                    generic_checked_function_to_instantiate = Some(function_id)
+                    generic_checked_function_to_instantiate = Some(resolved_function_id!)
                 } else if callee.is_instantiated {
                     if type_hint.has_value() and not type_hint.value().equals(unknown_type_id()) {
                         .check_types_for_compat(

--- a/selfhost/typechecker.jakt
+++ b/selfhost/typechecker.jakt
@@ -4686,9 +4686,7 @@ struct Typechecker {
                                 inner_condition = acc!
                                 outer_if_stmts.push(ParsedStatement::If(condition: inner_condition, then_block: then_block!, else_statement, span))
                             } else {
-                                for stmt in then_block!.stmts {
-                                    outer_if_stmts.push(stmt)
-                                }
+                                outer_if_stmts.push_values(then_block!.stmts)
                             }
                         }
 

--- a/selfhost/typechecker.jakt
+++ b/selfhost/typechecker.jakt
@@ -526,16 +526,30 @@ struct Typechecker {
         return true
     }
 
-    function add_function_to_scope(mut this, parent_scope_id: ScopeId, name: String, function_id: FunctionId, span: Span) throws -> bool {
+    function add_function_to_scope(mut this, parent_scope_id: ScopeId, name: String, overload_set: [FunctionId], span: Span) throws -> bool {
         mut scope = .get_scope(id: parent_scope_id)
-        for existing_function in scope.functions {
-            if name == existing_function.0 {
-                let function_ = .get_function(existing_function.1)
-                .error_with_hint(message: format("Redefinition of function ‘{}’", name), span, hint: "previous definition here", hint_span: function_.name_span)
-                return false
+
+        if scope.functions.contains(name) {
+            let existing_function_binding = scope.functions[name]
+
+            for function_id in overload_set {
+                let function_to_add = .get_function(function_id)
+                for existing_function_id in existing_function_binding {
+                    let existing_function = .get_function(existing_function_id)
+                    if function_to_add.signature_matches(existing_function) {
+                        .error_with_hint(
+                            format("Redefinition of function ‘{}’.", function_to_add.name)
+                            function_to_add.parsed_function!.name_span
+                            "Previous definition is here"
+                            existing_function.parsed_function!.name_span
+                        )
+                    }
+                }
+                scope.functions[name].push(function_id)
             }
+        }else {
+            scope.functions.set(key: name, value: overload_set)
         }
-        scope.functions.set(key: name, value: function_id)
         return true
     }
 
@@ -566,8 +580,8 @@ struct Typechecker {
         return true
     }
 
-    function find_function_in_scope(this, parent_scope_id: ScopeId, function_name: String) throws -> FunctionId? {
-        return .program.find_function_in_scope(parent_scope_id, function_name)
+    function find_functions_with_name_in_scope(this, parent_scope_id: ScopeId, function_name: String) throws -> [FunctionId]? {
+        return .program.find_functions_with_name_in_scope(parent_scope_id, function_name)
     }
 
     function find_struct_in_scope(this, scope_id: ScopeId, name: String) throws -> StructId? =>
@@ -864,11 +878,11 @@ struct Typechecker {
                     span: import_.module_name.span()
                 )
             }
-            for (name, function_id) in import_scope.functions {
+            for (name, overload_set) in import_scope.functions {
                 .add_function_to_scope(
                     parent_scope_id: scope_id
                     name
-                    function_id
+                    overload_set
                     span: import_.module_name.span()
                 )
             }
@@ -901,17 +915,17 @@ struct Typechecker {
             for imported_name in names {
                 mut found = false
                 // if it is a function, add function to scope
-                let maybe_function_id = .find_function_in_scope(
+                let maybe_overload_set = .find_functions_with_name_in_scope(
                     parent_scope_id: import_scope_id
                     function_name: imported_name.literal_name()
                 )
-                if maybe_function_id.has_value() {
+                if maybe_overload_set.has_value() {
                     found = true
                     // NOTE: what should we do if this returns false? error is already created in the function itself and rust compiler goes on
                     .add_function_to_scope(
                         parent_scope_id: scope_id
                         name: imported_name.literal_name()
-                        function_id: maybe_function_id!
+                        overload_set: maybe_overload_set!
                         span: imported_name.span()
                     )
                 }
@@ -1098,7 +1112,7 @@ struct Typechecker {
             for method in record.methods {
                 if not record.generic_parameters.is_empty() or not method.parsed_function.generic_parameters.is_empty() {
                     mut func = .get_function(
-                        .find_function_in_scope(parent_scope_id: record_scope_id, function_name: method.parsed_function.name)!
+                        .find_function_matching_signature_in_scope(parent_scope_id: record_scope_id, prototype: method.parsed_function)!
                     )
                     let method_scope_id = func.function_scope_id
 
@@ -1255,7 +1269,7 @@ struct Typechecker {
 
                         let trait_ = .get_trait(trait_id!)
                         for (name, function_id) in trait_.methods {
-                            if .find_function_in_scope(parent_scope_id: struct_.scope_id, function_name: name).has_value() {
+                            if .find_functions_with_name_in_scope(parent_scope_id: struct_.scope_id, function_name: name).has_value() {
                                 continue
                             }
 
@@ -1267,7 +1281,7 @@ struct Typechecker {
                             .add_function_to_scope(
                                 parent_scope_id: struct_.scope_id
                                 name: name
-                                function_id: function_id
+                                overload_set: [function_id]
                                 span: trait_name.name_span
                             )
                         }
@@ -1301,7 +1315,7 @@ struct Typechecker {
 
                         let trait_ = .get_trait(trait_id!)
                         for (name, function_id) in trait_.methods {
-                            if .find_function_in_scope(parent_scope_id: enum_.scope_id, function_name: name).has_value() {
+                            if .find_functions_with_name_in_scope(parent_scope_id: enum_.scope_id, function_name: name).has_value() {
                                 continue
                             }
 
@@ -1313,7 +1327,7 @@ struct Typechecker {
                             .add_function_to_scope(
                                 parent_scope_id: enum_.scope_id
                                 name: name
-                                function_id: function_id
+                                overload_set: [function_id]
                                 span: trait_name.name_span
                             )
                         }
@@ -1714,7 +1728,7 @@ struct Typechecker {
             .add_function_to_scope(
                 parent_scope_id: enum_scope_id
                 name: func.name
-                function_id
+                overload_set: [function_id]
                 span: parsed_record.name_span
             )
 
@@ -1750,15 +1764,17 @@ struct Typechecker {
 
         let struct_ = .get_struct(struct_id)
 
-        let constructor_id = .find_function_in_scope(parent_scope_id: struct_.scope_id, function_name: parsed_record.name)
-        if constructor_id.has_value() {
+        let constructor_ids = .find_functions_with_name_in_scope(parent_scope_id: struct_.scope_id, function_name: parsed_record.name)
+        if constructor_ids.has_value() {
             if parsed_record.record_type is Class and parsed_record.definition_linkage is External {
                 // XXX: The parser always sets the linkage type of an extern class'
                 //      constructor to External, but we actually want to call the
                 //      class' ::create function, just like we do with a
                 //      ImplicitConstructor class.
-                mut func = .get_function(constructor_id!)
-                func.linkage = FunctionLinkage::External
+                for constructor_id in constructor_ids!.iterator() {
+                    mut func = .get_function(constructor_id)
+                    func.linkage = FunctionLinkage::External
+                }
             }
         } else if not parsed_record.definition_linkage is External {
             // No constructor found, so let's make one
@@ -1821,7 +1837,7 @@ struct Typechecker {
             .add_function_to_scope(
                 parent_scope_id: struct_.scope_id
                 name: parsed_record.name
-                function_id: function_id
+                overload_set: [function_id]
                 span: parsed_record.name_span
             )
         }
@@ -1913,7 +1929,7 @@ struct Typechecker {
                 true => {
                     let super_type_id = .typecheck_typename(parsed_type: super_parsed_type!, scope_id, name: None)
                     let super_type = .get_type(super_type_id)
-                    
+
                     if super_type is Struct(struct_id) {
                         super_struct_id = struct_id
                     } else {
@@ -1926,7 +1942,7 @@ struct Typechecker {
                 true => {
                     let super_type_id = .typecheck_typename(parsed_type: super_parsed_type!, scope_id, name: None)
                     let super_type = .get_type(super_type_id)
-                    
+
                     if super_type is Struct(struct_id) {
                         super_struct_id = struct_id
                     } else {
@@ -2111,7 +2127,7 @@ struct Typechecker {
             .add_function_to_scope(
                 parent_scope_id: struct_scope_id
                 name: func.name
-                function_id: function_id
+                overload_set: [function_id]
                 span: parsed_record.name_span
             )
 
@@ -2134,7 +2150,7 @@ struct Typechecker {
                 guard trait_id.has_value() else { continue }
                 let trait_ = .program.modules[trait_id!.module.id].traits[trait_id!.id]
                 for (name, function_id) in trait_.methods {
-                    if .find_function_in_scope(parent_scope_id: struct_scope_id, function_name: name).has_value() {
+                    if .find_functions_with_name_in_scope(parent_scope_id: struct_scope_id, function_name: name).has_value() {
                         continue
                     }
 
@@ -2147,7 +2163,7 @@ struct Typechecker {
                     .add_function_to_scope(
                         parent_scope_id: struct_scope_id
                         name: name
-                        function_id: function_id
+                        overload_set: [function_id]
                         span: implements_entry.name_span
                     )
                 }
@@ -2213,8 +2229,8 @@ struct Typechecker {
             }
         }
 
-        for fun in parsed_namespace.functions {
-            .current_function_id = .find_function_in_scope(parent_scope_id: scope_id, function_name: fun.name)
+        for fun in parsed_namespace.functions.iterator() {
+            .current_function_id = .find_functions_with_name_in_scope(parent_scope_id: scope_id, function_name: fun.name)![0]
             .typecheck_function(parsed_function: fun, parent_scope_id: scope_id)
             .current_function_id = None
         }
@@ -2383,7 +2399,7 @@ struct Typechecker {
                             fields.push(var_id)
                         }
                         enum_.variants.push(CheckedEnumVariant::StructLike(enum_id, name: variant.name, fields, span: variant.span))
-                        let maybe_enum_variant_constructor = .find_function_in_scope(parent_scope_id: enum_.scope_id, function_name: variant.name)
+                        let maybe_enum_variant_constructor = .find_functions_with_name_in_scope(parent_scope_id: enum_.scope_id, function_name: variant.name)
                         if not maybe_enum_variant_constructor.has_value() {
                             let can_function_throw = is_boxed
                             let function_scope_id = .create_scope(parent_scope_id, can_throw: can_function_throw, debug_name: format("enum-variant-constructor({}::{})", enum_.name, variant.name))
@@ -2420,7 +2436,12 @@ struct Typechecker {
                                 is_override: false
                             )
                             let function_id = module.add_function(checked_function)
-                            .add_function_to_scope(parent_scope_id: enum_.scope_id, name: variant.name, function_id, span: variant.span)
+                            .add_function_to_scope(
+                                parent_scope_id: enum_.scope_id,
+                                name: variant.name,
+                                overload_set: [function_id],
+                                span: variant.span
+                            )
                         }
                     } else if is_typed {
                         mut params: [CheckedParameter] = []
@@ -2432,7 +2453,7 @@ struct Typechecker {
                         let type_id = .typecheck_typename(parsed_type: param.parsed_type, scope_id: enum_.scope_id, name: param.name)
                         enum_.variants.push(CheckedEnumVariant::Typed(enum_id, name: variant.name, type_id, span: variant.span))
 
-                        let maybe_enum_variant_constructor = .find_function_in_scope(parent_scope_id: enum_.scope_id, function_name: variant.name)
+                        let maybe_enum_variant_constructor = .find_functions_with_name_in_scope(parent_scope_id: enum_.scope_id, function_name: variant.name)
                         if not maybe_enum_variant_constructor.has_value() {
                             let can_function_throw = is_boxed
                             let function_scope_id = .create_scope(parent_scope_id, can_throw: can_function_throw, debug_name: format("enum-variant-constructor({}::{})", enum_.name, variant.name))
@@ -2479,7 +2500,12 @@ struct Typechecker {
                                 is_override: false
                             )
                             let function_id = module.add_function(checked_function)
-                            .add_function_to_scope(parent_scope_id: enum_.scope_id, name: variant.name, function_id, span: variant.span)
+                            .add_function_to_scope(
+                                parent_scope_id: enum_.scope_id,
+                                name: variant.name,
+                                overload_set: [function_id],
+                                span: variant.span
+                            )
                         }
                     } else {
                         mut params: [CheckedParameter] = []
@@ -2488,7 +2514,7 @@ struct Typechecker {
                         }
 
                         enum_.variants.push(CheckedEnumVariant::Untyped(enum_id, name: variant.name, span: variant.span))
-                        let maybe_enum_variant_constructor = .find_function_in_scope(parent_scope_id: enum_.scope_id, function_name: variant.name)
+                        let maybe_enum_variant_constructor = .find_functions_with_name_in_scope(parent_scope_id: enum_.scope_id, function_name: variant.name)
                         if not maybe_enum_variant_constructor.has_value() {
                             let can_function_throw = is_boxed
                             let function_scope_id = .create_scope(parent_scope_id, can_throw: can_function_throw, debug_name: format("enum-variant-constructor({}::{})", enum_.name, variant.name))
@@ -2525,7 +2551,12 @@ struct Typechecker {
                                 is_override: false
                             )
                             let function_id = module.add_function(checked_function)
-                            .add_function_to_scope(parent_scope_id: enum_.scope_id, name: variant.name, function_id, span: variant.span)
+                            .add_function_to_scope(
+                                parent_scope_id: enum_.scope_id,
+                                name: variant.name,
+                                overload_set: [function_id],
+                                span: variant.span
+                            )
                         }
                     }
                 }
@@ -2553,15 +2584,21 @@ struct Typechecker {
 
         .current_struct_type_id = struct_type_id
 
-        mut all_virtuals: [String: CheckedFunction] = [:]
+        mut all_virtuals: [String: [CheckedFunction]] = [:]
         mut super_struct_id = .get_struct(struct_id).super_struct_id
         while super_struct_id.has_value() {
             let super_struct = .get_struct(super_struct_id!)
             let scope = .get_scope(super_struct.scope_id)
-            for function_tuple in scope.functions {
-                let function_ = .get_function(function_tuple.1)
-                if function_.is_virtual {
-                    all_virtuals[function_.name] = function_
+            for (_, overload_set) in scope.functions {
+                for function_id in overload_set {
+                    let function_ = .get_function(function_id)
+                    if function_.is_virtual {
+                        if not all_virtuals.contains(function_.name) {
+                            all_virtuals[function_.name] = [function_]
+                        }else {
+                            all_virtuals[function_.name].push(function_)
+                        }
+                    }
                 }
             }
             super_struct_id = super_struct.super_struct_id
@@ -2622,12 +2659,14 @@ struct Typechecker {
             }
 
             let scope = .get_scope(.get_struct(struct_id).scope_id)
-            for (name, function_id) in scope.functions {
-                checks.register_method(
-                    method_name: name,
-                    method_id: function_id,
-                    typechecker: &mut this
-                )
+            for (name, overload_set) in scope.functions {
+                for function_id in overload_set {
+                    checks.register_method(
+                        method_name: name,
+                        method_id: function_id,
+                        typechecker: &mut this
+                    )
+                }
             }
         }
 
@@ -2663,11 +2702,10 @@ struct Typechecker {
         let structure_scope_id = scope_id
         let structure_linkage = definition_linkage
 
-        let method_id = .find_function_in_scope(parent_scope_id: structure_scope_id, function_name: func.name)
+        let method_id = .find_function_matching_signature_in_scope(parent_scope_id: structure_scope_id, prototype: func)
         if not method_id.has_value() {
             .compiler.panic("we just pushed the checked function, but it's not present")
         }
-
         mut checked_function = .get_function(method_id!)
         let function_scope_id = checked_function.function_scope_id
 
@@ -2680,7 +2718,7 @@ struct Typechecker {
 
         // Set current function index before a block type check so that
         // method return type is checked against its implementation
-        .current_function_id = method_id
+        .current_function_id = method_id!
 
         let VOID_TYPE_ID = builtin(BuiltinType::Void)
 
@@ -2737,11 +2775,11 @@ struct Typechecker {
         if parameter.default_argument.has_value() {
             //FIXME: Get the real safety mode from somewhere, right now it assumes it is safe
             mut checked_default_value_expr = .typecheck_expression(parameter.default_argument!, scope_id, safety_mode: SafetyMode::Safe, type_hint: type_id)
-            
+
             if checked_default_value_expr is OptionalNone(span: expr_span) {
                 checked_default_value_expr = CheckedExpression::OptionalNone(span: expr_span, type_id)
             }
-            
+
             let default_value_type_id = checked_default_value_expr.type()
             checked_default_value = checked_default_value_expr
             if not .check_types_for_compat(
@@ -2944,7 +2982,12 @@ struct Typechecker {
             checked_function.return_type_id = return_type_id
         }
 
-        .add_function_to_scope(parent_scope_id, name: parsed_function.name, function_id, span: parsed_function.name_span)
+        .add_function_to_scope(
+            parent_scope_id,
+            name: parsed_function.name,
+            overload_set: [function_id],
+            span: parsed_function.name_span
+        )
     }
 
     function check_that_type_doesnt_contain_reference(mut this, type_id: TypeId, span: Span) throws {
@@ -3000,7 +3043,7 @@ struct Typechecker {
             let implemented_trait: (TraitId, [TypeId])? = implemented_traits.get(trait_name)
             if not implemented_trait.has_value() or not implemented_trait!.0.equals(constraint) {
                 .error_with_hint(
-                    format("Cannot use ‘{}’ here as it doesn't implement the trait ‘{}’", 
+                    format("Cannot use ‘{}’ here as it doesn't implement the trait ‘{}’",
                             .type_name(generic_argument), trait_name)
                     arg_span,
                     "Consider implementing the required trait for this type",
@@ -3030,7 +3073,7 @@ struct Typechecker {
                 parsed_function.name_span
             )
         }
-        
+
         for i in 0..parsed_function.generic_parameters.size() {
             mut arg_span = call_span
             if type_args.size() > i {
@@ -3109,11 +3152,7 @@ struct Typechecker {
             return
         }
 
-        // FIXME: Optional.expect("...") would be nicer here.
-        let function_id = .find_function_in_scope(parent_scope_id, function_name: parsed_function.name)
-        if not function_id.has_value() {
-            .compiler.panic("Internal error: missing previously defined function")
-        }
+        let function_id = .find_functions_with_name_in_scope(parent_scope_id, function_name: parsed_function.name)![0]
         if parsed_function.name == "main" {
             .typecheck_jakt_main(parsed_function)
         }
@@ -3601,7 +3640,7 @@ struct Typechecker {
                         if .is_subclass_of(ancestor_type_id: lhs_type_id, child_type_id: rhs_type_id) {
                             return true
                         }
-                        
+
                         if not rhs_type_id.equals(lhs_type_id) {
                             .error(
                                 format("Type mismatch: expected ‘{}’, but got ‘{}’", .type_name(lhs_type_id), .type_name(rhs_type_id))
@@ -4624,7 +4663,7 @@ struct Typechecker {
 
                         let new_then_block = ParsedBlock(stmts: outer_if_stmts)
                         return .expand_context_for_bindings(condition: unary_op_single_condition, acc: None, then_block: new_then_block, else_statement, span)
-                        
+
                     }
                     else => {}
                 }
@@ -4715,7 +4754,7 @@ struct Typechecker {
         let lhs_type = .get_type(lhs_type_id)
 
         .check_that_type_doesnt_contain_reference(type_id: lhs_type_id, span)
-        
+
         if checked_expr is OptionalNone(span, type_id) {
             if lhs_type is GenericInstance(id, args) {
                 if not (id.equals(optional_struct_id) or id.equals(weak_ptr_struct_id)) {
@@ -5447,7 +5486,7 @@ struct Typechecker {
             if .dump_try_hints {
                 .dump_try_hint(span)
             }
-        
+
             .unify_with_type(found_type: builtin(BuiltinType::JaktString), expected_type: type_hint, rhs_span: span)
             yield CheckedExpression::QuotedString(val, span)
         }
@@ -5975,7 +6014,7 @@ struct Typechecker {
                 .compiler.panic("Expected the just-checked function to be of a function type")
             }
         }
-        
+
         let lambda_scope_id = .create_scope(parent_scope_id: scope_id, can_throw, debug_name: "lambda")
         mut checked_captures: [CheckedCapture] = []
         for capture in captures {
@@ -6015,9 +6054,9 @@ struct Typechecker {
             if not is_fat_arrow and return_type is Empty {
                 return_type_id = void_type_id()
                 return_type_updated = true
-            } else if is_fat_arrow and 
+            } else if is_fat_arrow and
                 not checked_block.statements.is_empty() and
-                checked_block.statements.last()! is Return(val) and 
+                checked_block.statements.last()! is Return(val) and
                 val.has_value() {
                 return_type_id = .resolve_type_var(type_var_type_id: val!.type(), scope_id: lambda_scope_id)
                 return_type_updated = true
@@ -6933,8 +6972,7 @@ struct Typechecker {
         )
     }
 
-    function resolve_call(mut this, call: ParsedCall, mut namespaces: [ResolvedNamespace], span: Span, scope_id: ScopeId, must_be_enum_constructor: bool, ignore_errors: bool) throws -> FunctionId? {
-        mut callee: FunctionId? = None
+    function resolve_call(mut this, call: ParsedCall, mut namespaces: [ResolvedNamespace], span: Span, scope_id: ScopeId, must_be_enum_constructor: bool) throws -> [FunctionId] {
         mut current_scope_id = scope_id
 
         for namespace_index in 0..call.namespace_.size() {
@@ -6973,22 +7011,21 @@ struct Typechecker {
             }
 
             if .get_type(inner_type) is Function(pseudo_function_id) {
-                return pseudo_function_id
+                return [pseudo_function_id]
             }
         }
 
         // 2. Look for a function with this name.
-        let maybe_function_id = .find_function_in_scope(parent_scope_id: current_scope_id, function_name: call.name)
-        if maybe_function_id.has_value() {
-            let function_id = maybe_function_id!
-            if not must_be_enum_constructor or .get_function(function_id).type is ImplicitEnumConstructor {
-                return function_id
+        let maybe_overload_set = .find_functions_with_name_in_scope(parent_scope_id: current_scope_id, function_name: call.name)
+        if maybe_overload_set.has_value() {
+            if not must_be_enum_constructor or .get_function(maybe_overload_set![0]).type is ImplicitEnumConstructor {
+                return maybe_overload_set!
             }
         }
 
         if must_be_enum_constructor {
             .error(format("No such enum constructor ‘{}’", call.name), span)
-            return callee
+            return []
         }
 
         // 3. Look for a struct, class or enum constructor with this name.
@@ -6996,18 +7033,17 @@ struct Typechecker {
         if maybe_struct_id.has_value() {
             let struct_id = maybe_struct_id!
             let structure = .get_struct(struct_id)
-            let maybe_function_id = .find_function_in_scope(parent_scope_id: structure.scope_id, function_name: call.name)
+            let maybe_function_id = .find_functions_with_name_in_scope(parent_scope_id: structure.scope_id, function_name: call.name)
             if maybe_function_id.has_value() {
                 return maybe_function_id!
             }
-            return callee
         }
 
         if not ignore_errors {
             .error(format("Call to unknown function: ‘{}’", call.name), span)
         }
 
-        return None
+        return []
     }
 
     function typecheck_call(
@@ -7045,7 +7081,7 @@ struct Typechecker {
                     mut struct_ = .get_struct(id)
                     mut scope_id = struct_.scope_id
                     while not resolved_function_id.has_value() {
-                        resolved_function_id = .resolve_call(call, namespaces: resolved_namespaces, span, scope_id, must_be_enum_constructor, ignore_errors: true)
+                        resolved_function_id = .resolve_call(call, namespaces: resolved_namespaces, span, scope_id, must_be_enum_constructor, ignore_errors: true).first()
                         if resolved_function_id.has_value() {
                             break
                         }
@@ -7062,7 +7098,7 @@ struct Typechecker {
                 }
                 Enum(id) => {
                     let scope_id = .get_enum(id).scope_id
-                    resolved_function_id = .resolve_call(call, namespaces: resolved_namespaces, span, scope_id, must_be_enum_constructor, ignore_errors: false)
+                    resolved_function_id = .resolve_call(call, namespaces: resolved_namespaces, span, scope_id, must_be_enum_constructor, ignore_errors: false).first()
                     yield scope_id
                 }
             }
@@ -7070,7 +7106,7 @@ struct Typechecker {
                 match call.name {
                     "print" | "println" | "eprintln" | "eprint" | "format" => {}
                     else => {
-                        resolved_function_id = .resolve_call(call, namespaces: resolved_namespaces, span, scope_id: caller_scope_id, must_be_enum_constructor, ignore_errors: false)
+                        resolved_function_id = .resolve_call(call, namespaces: resolved_namespaces, span, scope_id: caller_scope_id, must_be_enum_constructor, ignore_errors: false).first()
                     }
                 }
                 yield caller_scope_id
@@ -7154,6 +7190,7 @@ struct Typechecker {
 
                     type_arg_index += 1
                 }
+
 
                 // This will be 0 for functions or 1 for instance methods, because of the `this` ptr
                 mut arg_offset = 0uz

--- a/selfhost/typechecker.jakt
+++ b/selfhost/typechecker.jakt
@@ -1697,10 +1697,16 @@ struct Typechecker {
                         visibility: CheckedVisibility::Public
                     )
 
+                    mut default_value: CheckedExpression? = None
+                    if param.default_argument.has_value() {
+                        let param_type = .typecheck_typename(parsed_type: param.variable.parsed_type, scope_id: method_scope_id, name: param.variable.name)
+                        default_value = .typecheck_expression(param.default_argument!, scope_id, safety_mode: SafetyMode::Safe, type_hint: param_type)
+                    }
+
                     checked_function.add_param(CheckedParameter(
                         requires_label: param.requires_label
                         variable: checked_variable
-                        default_value: None
+                        default_value
                     ))
                 }
             }
@@ -7451,27 +7457,31 @@ struct Typechecker {
             let param = params[i]
             mut maybe_checked_expr: CheckedExpression? = None
             if not param.requires_label {
-                guard args.size() > consumed_arg else {
-                    .error(format("Missing argument for function parameter {}", param.variable.name), span)
-                    continue
+                if args.size() <= consumed_arg {
+                    if not param.default_value.has_value() {
+                        .error(format("Missing argument for function parameter {}", param.variable.name), span)
+                        continue
+                    }
+                    maybe_checked_expr = param.default_value
+                } else {
+                    let (name, span, expr) = args[consumed_arg]
+                    maybe_checked_expr = .typecheck_expression(expr, scope_id, safety_mode, type_hint: param.variable.type_id)
+                    consumed_arg++
                 }
 
-                let (name, span, expr) = args[consumed_arg]
-                maybe_checked_expr = .typecheck_expression(expr, scope_id, safety_mode, type_hint: param.variable.type_id)
-                consumed_arg++
             } else {
                 maybe_checked_expr = param.default_value
 
                 if args.size() > consumed_arg {
                     let (name, span, expr) = args[consumed_arg]
-                    
+
                     if .validate_argument_label(param, label: name, span, expr, default_value: maybe_checked_expr) {
                         maybe_checked_expr = .typecheck_expression(expr, scope_id, safety_mode, type_hint: param.variable.type_id)
                         consumed_arg++
                     }
                 }
             }
-            
+
             if maybe_checked_expr.has_value() {
                 mut checked_arg = maybe_checked_expr!
                 resolved_args.push((param.variable.name, span, checked_arg))

--- a/selfhost/types.jakt
+++ b/selfhost/types.jakt
@@ -232,6 +232,43 @@ boxed enum Type {
     MutableReference(TypeId)
     Function(params: [TypeId], can_throw: bool, return_type_id: TypeId, pseudo_function_id: FunctionId)
 
+    function specificity(this, program: CheckedProgram, base_specificity: i64 = 1<<31) => match this {
+        TypeVariable => 0
+        GenericInstance(args) => {
+            mut specificity = base_specificity / 2
+            for subtype_id in args.iterator() {
+                let subtype = program.get_type(subtype_id)
+                specificity += subtype.specificity(program, base_specificity: base_specificity/4)
+            }
+            yield specificity
+        }
+        GenericEnumInstance(args) => {
+            mut specificity = base_specificity / 2
+            for subtype_id in args.iterator() {
+                let subtype = program.get_type(subtype_id)
+                specificity += subtype.specificity(program, base_specificity: base_specificity/4)
+            }
+            yield specificity
+        }
+        GenericResolvedType(args) => {
+            mut specificity = base_specificity / 2
+            for subtype_id in args.iterator() {
+                let subtype = program.get_type(subtype_id)
+                specificity += subtype.specificity(program, base_specificity: base_specificity/4)
+            }
+            yield specificity
+        }
+        Function(params) => {
+            mut specificity = base_specificity / 2
+            for subtype_id in params.iterator() {
+                let subtype = program.get_type(subtype_id)
+                specificity += subtype.specificity(program, base_specificity: base_specificity/4)
+            }
+            yield specificity
+        }
+        else => base_specificity
+    }
+
     function constructor_name(this) => match this {
         Void => "Void"
         Bool => "Bool"

--- a/selfhost/types.jakt
+++ b/selfhost/types.jakt
@@ -638,6 +638,50 @@ class CheckedFunction {
     public is_virtual: bool
     public is_override: bool
 
+    public function signature_matches(this, anon other: CheckedFunction) throws -> bool {
+        if this.name != other.name or
+        this.can_throw != other.can_throw or
+        this.is_comptime != other.is_comptime {
+            return false
+        }
+
+        if this.params.size() != other.params.size() {
+            return false
+        }
+
+        if this.generics.params.size() != other.generics.params.size() {
+            return false
+        }
+
+        mut lhs_generic_type_ids: {String} = {}
+        mut rhs_generic_type_ids: {String} = {}
+        for param in this.generics.params.iterator() {
+            let type_id: TypeId = param.type_id()
+            lhs_generic_type_ids.add(type_id.to_string())
+        }
+        for param in other.generics.params.iterator() {
+            let type_id: TypeId = param.type_id()
+            rhs_generic_type_ids.add(type_id.to_string())
+        }
+
+        for param_index in 0..this.params.size() {
+            let lhs_param = this.params[param_index]
+            let rhs_param = other.params[param_index]
+
+            let lhs_param_id = lhs_param.variable.type_id.to_string()
+            let rhs_param_id = rhs_param.variable.type_id.to_string()
+
+            if not lhs_param.variable.type_id.equals(rhs_param.variable.type_id)
+                and not (lhs_generic_type_ids.contains(lhs_param_id) and rhs_generic_type_ids.contains(rhs_param_id))
+            {
+                return false
+            }
+        }
+
+
+        return true
+    }
+
     public function is_static(this) -> bool {
         if .params.size() < 1 {
             return true

--- a/selfhost/types.jakt
+++ b/selfhost/types.jakt
@@ -518,7 +518,7 @@ class Scope {
     public vars: [String: VarId]
     public comptime_bindings: [String: Value]
     public structs: [String: StructId]
-    public functions: [String: FunctionId]
+    public functions: [String: [FunctionId]]
     public enums: [String: EnumId]
     public types: [String: TypeId]
     public traits: [String: TraitId]
@@ -633,9 +633,9 @@ boxed enum MaybeResolvedScope {
                     }
 
                     if not scope_id.has_value() {
-                        let id = program.find_function_in_scope(parent_scope_id: scope, function_name: relative_name)
-                        if id.has_value() {
-                            scope_id = program.get_function(id!).function_scope_id
+                        let ids = program.find_functions_with_name_in_scope(parent_scope_id: scope, function_name: relative_name)
+                        if ids.has_value() {
+                            scope_id = program.get_function(ids![0]).function_scope_id
                         }
                     }
                     if (scope_id.has_value()) {
@@ -1619,7 +1619,7 @@ class CheckedProgram {
         return None
     }
 
-    public function find_function_in_scope(this, parent_scope_id: ScopeId, function_name: String) throws -> FunctionId? {
+    public function find_functions_with_name_in_scope(this, parent_scope_id: ScopeId, function_name: String) throws -> [FunctionId]? {
         mut visited: [ScopeId] = []
         mut queue: [ScopeId] = [parent_scope_id]
         mut scope_id = Some(parent_scope_id)

--- a/selfhost/utility.jakt
+++ b/selfhost/utility.jakt
@@ -78,13 +78,6 @@ struct FileId {
     }
 }
 
-function extend_array<T>(mut target: [T], extend_with: [T]) throws {
-    target.add_capacity(extend_with.size())
-    for v in extend_with {
-        target.push(v)
-    }
-}
-
 function escape_for_quotes(anon s: String) throws -> String {
     mut builder = StringBuilder::create()
     for i in 0..s.length() {

--- a/selfhost/windows_compiler.jakt
+++ b/selfhost/windows_compiler.jakt
@@ -19,9 +19,7 @@ function run_compiler(
         throw Error::from_errno(38)
     }
 
-    for extra_flag in extra_compiler_flags {
-        extra_flags.push(extra_flag)
-    }
+    extra_flags.push_values(extra_compiler_flags)
 
     mut compile_args = [
         cxx_compiler_path
@@ -44,9 +42,7 @@ function run_compiler(
     }
 
     if not extra_flags.is_empty() {
-        for flag in extra_flags {
-            compile_args.push(flag)
-        }
+        compile_args.push_values(extra_flags)
     }
 
     compile_args.push("-I")

--- a/tests/typechecker/class_private_field_default.jakt
+++ b/tests/typechecker/class_private_field_default.jakt
@@ -2,12 +2,16 @@
 /// - error: "Can't access field ‘muda_amount’, because it is marked private\n"
 
 class GoodEncapsulation {
+    public function create() throws {
+        return GoodEncapsulation(muda_amount: 20, ora_amount: 9001)
+    }
+
     muda_amount: u32
     public ora_amount: u32
 }
 
 function main() {
-    let encapsulated = GoodEncapsulation(muda_amount: 20, ora_amount: 9001)
+    let encapsulated = GoodEncapsulation::create()
     // This is okay!
     encapsulated.ora_amount
     encapsulated.muda_amount

--- a/tests/typechecker/function_overload_can_not_overload_main.jakt
+++ b/tests/typechecker/function_overload_can_not_overload_main.jakt
@@ -1,0 +1,10 @@
+/// Expect:
+/// - error: "Function 'main' declared multiple times."
+
+function main() {
+    return 0
+}
+
+function main(args: [String]) {
+    return ""
+}

--- a/tests/typechecker/function_overload_imported_function.jakt
+++ b/tests/typechecker/function_overload_imported_function.jakt
@@ -1,0 +1,14 @@
+/// Expect:
+/// - output: "333\n123\n"
+import function_block_return { foo }
+
+function foo(x: i64) -> i64 {
+    return x
+}
+
+function main() {
+    // call the imported function
+    println("{}", foo())
+    // call the overload
+    println("{}", foo(x: 123))
+}

--- a/tests/typechecker/function_overload_needs_different_parameters.jakt
+++ b/tests/typechecker/function_overload_needs_different_parameters.jakt
@@ -1,0 +1,10 @@
+/// Expect:
+/// - error: "Redefinition of function ‘foo’."
+
+function foo(x: String) -> i64 {
+    return 0
+}
+
+function foo(x: String) -> String {
+    return ""
+}

--- a/tests/typechecker/function_overloading_allows_different_return_types.jakt
+++ b/tests/typechecker/function_overloading_allows_different_return_types.jakt
@@ -1,0 +1,20 @@
+/// Expect:
+/// - output: "PASS\n"
+
+function identity(anon x: i64) throws => x
+function identity(anon x: String) => x
+function identity<T>(anon x: T) => x
+
+
+function main() {
+    mut pass = true
+    pass |= 64 == identity(64)
+    pass |= "String" == identity("String")
+    for x in identity(["Array"]).iterator() {
+        pass |= x == "Array"
+    }
+
+    if pass {
+        println("PASS")
+    }
+}

--- a/tests/typechecker/function_overloading_calls_most_specific_generic_signature.jakt
+++ b/tests/typechecker/function_overloading_calls_most_specific_generic_signature.jakt
@@ -1,0 +1,23 @@
+/// Expect:
+/// - output: "PASS\n"
+
+function to_representation(anon x: String) throws => format("\"{}\"", x)
+function to_representation(anon x: i8) throws => format("{}i8", x)
+
+function to_representation<K, V>(anon x: [K:V]) throws => "Somedict[K:V]"
+function to_representation<K>(anon x: [K:String]) throws => "Somedict[K:String]"
+function to_representation(anon x: [String:String]) throws => "Somedict[String:String]"
+function to_representation<T>(anon x: T) => "unimplemented"
+
+function main() {
+    mut pass = true
+    pass |= to_representation(42) == "42i8"
+    pass |= to_representation("Hello") == "\"Hello\""
+    pass |= to_representation(["": 0]) == "Somedict[K:V]"
+    pass |= to_representation(["": ""]) == "Somedict[String:String]"
+    pass |= to_representation([""]) == "unimplemented"
+
+    if pass {
+        println("PASS")
+    }
+}

--- a/tests/typechecker/method_overload_performs_name_hiding.jakt
+++ b/tests/typechecker/method_overload_performs_name_hiding.jakt
@@ -1,0 +1,15 @@
+/// Expect:
+/// - error: "No function with matching signature found."
+
+class A {
+    public function foo(this) => 0
+}
+
+class B : A {
+    public function foo(this, x: String) => 0
+}
+
+function main() {
+    let b = B()
+    b.foo()
+}

--- a/tests/typechecker/struct_private_field.jakt
+++ b/tests/typechecker/struct_private_field.jakt
@@ -2,10 +2,14 @@
 /// - error: "Can't access field ‘age’, because it is marked private\n"
 
 struct WeirdEncapsulation {
+    function create(age: i32) {
+        return WeirdEncapsulation(age)
+    }
+
     private age: i32
 }
 
 function main() {
-    let useless = WeirdEncapsulation(age: 2)
+    let useless = WeirdEncapsulation::create(age: 2)
     useless.age
 }

--- a/tests/typechecker/struct_private_field_ctr.jakt
+++ b/tests/typechecker/struct_private_field_ctr.jakt
@@ -1,0 +1,10 @@
+/// Expect:
+/// - error: "Can't access field 'age' when calling implicit constructor of 'WeirdEncapsulation' because it is marked private\n"
+
+struct WeirdEncapsulation {
+    private age: i32
+}
+
+function main() {
+    WeirdEncapsulation(age: 2)
+}


### PR DESCRIPTION
This adds support for function overloading, so you can do stuff like: 

```
function to_string(anon x: i64) throws -> String {
    return format("{}i64", x)
}
function to_string(anon x: String) throws => x
function to_string<T>(anon z: T) throws => format("{}", z)


function main() {
    println(to_string(["Array"]))
    println(to_string("String"))
    println(to_string(64i64))
}
```

The type checker chooses the call to use based on the sum of specificities of all its arguments where an argument has a specificity based on its type:
- Any "direct" Type (primitives, structs, enums, classes) have 1 "unit" of specificity.
- A Type variable has a specificity of 0.
- Generic types and functions have their specificity calculated recusively based on the arguments / parameters so that a fully defined generic (i.e. <String, i64> compared to <K, V>) has a specificity slightly below 1 unit, so a primitive is always most specific.


Or, to match some wording from [cppreference](https://en.cppreference.com/w/cpp/language/overload_resolution):

For each pair of viable function F1 and F2 F1 is determined to be a better function than F2
1) if F1 is a non-template function while F2 is a template specialization
2) or, if not that, F1 and F2 are both template specializations and F1 is more specialized 
3) or, if not that, F1 and F2 are non-template functions with the same parameter-type-lists, and F1 is more constrained than F2

:)