### PR TITLE
parser+typechecker: Add support for struct field default values

### DIFF
--- a/samples/structs/field_default_values.jakt
+++ b/samples/structs/field_default_values.jakt
@@ -1,0 +1,29 @@
+/// Expect:
+/// - output: "Jane\n100\nJane\n100\nJane\n100\n"
+
+struct Person1 {
+    name: String = "Jane"
+    age: i64
+}
+
+struct Person2 {
+    name: String
+    age: i64 = 100
+}
+
+struct Person3 {
+    name: String = "Jane"
+    age: i64 = 100
+}
+
+function main() {
+    let p1 = Person1(age: 100)
+    println("{}", p1.name)
+    println("{}", p1.age)
+    let p2 = Person2(name: "Jane")
+    println("{}", p2.name)
+    println("{}", p2.age)
+    let p3 = Person3()
+    println("{}", p3.name)
+    println("{}", p3.age)
+}

--- a/samples/structs/field_default_values.jakt
+++ b/samples/structs/field_default_values.jakt
@@ -2,28 +2,34 @@
 /// - output: "Jane\n100\nJane\n100\nJane\n100\n"
 
 struct Person1 {
-    name: String = "Jane"
+    private name: String = "Jane"
     age: i64
+    function getName(this) => .name
+    function getAge(this) => .age
 }
 
 struct Person2 {
     name: String
-    age: i64 = 100
+    private age: i64 = 100
+    function getName(this) => .name
+    function getAge(this) => .age
 }
 
 struct Person3 {
-    name: String = "Jane"
-    age: i64 = 100
+    private name: String = "Jane"
+    private age: i64 = 100
+    function getName(this) => .name
+    function getAge(this) => .age
 }
 
 function main() {
     let p1 = Person1(age: 100)
-    println("{}", p1.name)
-    println("{}", p1.age)
+    println("{}", p1.getName())
+    println("{}", p1.getAge())
     let p2 = Person2(name: "Jane")
-    println("{}", p2.name)
-    println("{}", p2.age)
+    println("{}", p2.getName())
+    println("{}", p2.getAge())
     let p3 = Person3()
-    println("{}", p3.name)
-    println("{}", p3.age)
+    println("{}", p3.getName())
+    println("{}", p3.getAge())
 }

--- a/selfhost/codegen.jakt
+++ b/selfhost/codegen.jakt
@@ -533,7 +533,7 @@ struct CodeGenerator {
         dependencies.push(struct_.type_id.to_string())
         // The struct's fields are also dependencies.
         for field in struct_.fields.iterator() {
-            let type_id = .program.get_variable(field).type_id
+            let type_id = .program.get_variable(field.variable_id).type_id
             let inner_dependencies = .extract_dependencies_from(type_id, dependency_graph, top_level: false)
             for dependency in inner_dependencies.iterator() {
                 dependencies.push(dependency)
@@ -1014,11 +1014,11 @@ struct CodeGenerator {
             else => {}
         }
 
-        for field_id in struct_.fields.iterator() {
-            let field = .program.get_variable(field_id)
-            output += .codegen_type(field.type_id)
+        for field in struct_.fields.iterator() {
+            let variable = .program.get_variable(field.variable_id)
+            output += .codegen_type(variable.type_id)
             output += " "
-            output += field.name
+            output += variable.name
             output += ";"
         }
 
@@ -1290,7 +1290,7 @@ struct CodeGenerator {
 
         mut i = 0uz
         for field in struct_.fields.iterator() {
-            let field_var = .program.get_variable(field)
+            let field_var = .program.get_variable(field.variable_id)
             output += "TRY(JaktInternal::PrettyPrint::output_indentation(builder));"
             output += format("TRY(builder.append(\"{}: \"));", field_var.name)
             output += "TRY(builder.appendff(\""

--- a/selfhost/ide.jakt
+++ b/selfhost/ide.jakt
@@ -352,7 +352,7 @@ function completions_for_type_id(program: CheckedProgram, type_id: TypeId) throw
             let structure = program.get_struct(struct_id)
 
             for field in structure.fields.iterator() {
-                let field_var = program.get_variable(field)
+                let field_var = program.get_variable(field.variable_id)
                 output.push(field_var.name)
             }
 
@@ -392,7 +392,7 @@ function completions_for_type_id(program: CheckedProgram, type_id: TypeId) throw
             let structure = program.get_struct(struct_id)
 
             for field in structure.fields.iterator() {
-                let field_var = program.get_variable(field)
+                let field_var = program.get_variable(field.variable_id)
                 output.push(field_var.name)
             }
 
@@ -551,7 +551,7 @@ function find_span_in_struct(program: CheckedProgram, checked_struct: CheckedStr
     let scope = program.get_scope(checked_struct.scope_id)
 
     for field in checked_struct.fields.iterator() {
-        let variable = program.get_variable(field)
+        let variable = program.get_variable(field.variable_id)
 
         if variable.definition_span.contains(span) {
             return Some(Usage::Typename(variable.type_id))
@@ -745,7 +745,7 @@ function find_span_in_expression(program: CheckedProgram, expr: CheckedExpressio
 
                 if program.get_type(type_id) is Struct(struct_id) {
                     for field in program.get_struct(struct_id).fields.iterator() {
-                        let var = program.get_variable(field)
+                        let var = program.get_variable(field.variable_id)
                         if index != var.name {
                             continue
                         }
@@ -1393,7 +1393,7 @@ function get_constructor_signature(program: CheckedProgram, function_id: Functio
                     output += ", "
                 }
 
-                let variable = program.get_variable(field)
+                let variable = program.get_variable(field.variable_id)
                 if variable.is_mutable {
                     output += "mut "
                 }

--- a/selfhost/interpreter.jakt
+++ b/selfhost/interpreter.jakt
@@ -188,7 +188,7 @@ function value_to_checked_expression(anon this_value: Value, anon mut interprete
         mut args: [(String, CheckedExpression)] = []
         for i in 0..materialised_fields.size() {
             let arg = materialised_fields[i]
-            let label = interpreter.program.get_variable(struct_.fields[i]).name
+            let label = interpreter.program.get_variable(struct_.fields[i].variable_id).name
             args.push((label, arg))
         }
 
@@ -3664,7 +3664,7 @@ class Interpreter {
                 let field_decls = .program.get_struct(struct_id).fields
                 mut field_index = 0uz
                 for i in 0..field_decls.size() {
-                    if .program.get_variable(field_decls[i]).name == index {
+                    if .program.get_variable(field_decls[i].variable_id).name == index {
                         field_index = i
                         break
                     }
@@ -4443,8 +4443,8 @@ class Interpreter {
                     let struct_ = .program.get_struct(struct_id)
                     mut idx = 0
                     mut found_index: i64? = None
-                    for field_id in struct_.fields.iterator() {
-                        if .program.get_variable(field_id).name == index {
+                    for field in struct_.fields.iterator() {
+                        if .program.get_variable(field.variable_id).name == index {
                             found_index = idx
                             break
                         }

--- a/selfhost/parser.jakt
+++ b/selfhost/parser.jakt
@@ -819,7 +819,7 @@ boxed enum ParsedExpression {
     Call(call: ParsedCall, span: Span)
     MethodCall(expr: ParsedExpression, call: ParsedCall, is_optional: bool, span: Span)
     IndexedTuple(expr: ParsedExpression, index: usize, is_optional: bool, span: Span)
-    IndexedStruct(expr: ParsedExpression, field: String, is_optional: bool, span: Span)
+    IndexedStruct(expr: ParsedExpression, field_name: String, is_optional: bool, span: Span)
     Var(name: String, span: Span)
     IndexedExpression(base: ParsedExpression, index: ParsedExpression, span: Span)
     UnaryOp(expr: ParsedExpression, op: UnaryOperator, span: Span)
@@ -925,8 +925,8 @@ boxed enum ParsedExpression {
             IndexedTuple(expr: rhs_expr, index: rhs_index, is_optional: rhs_optional) => lhs_optional == rhs_optional and lhs_expr.equals(rhs_expr) and lhs_index == rhs_index
             else => false
         }
-        IndexedStruct(expr: lhs_expr, field: lhs_field, is_optional: lhs_optional) => match rhs_expression {
-            IndexedStruct(expr: rhs_expr, field: rhs_field, is_optional: rhs_optional) => lhs_optional == rhs_optional and lhs_expr.equals(rhs_expr) and lhs_field == rhs_field
+        IndexedStruct(expr: lhs_expr, field_name: lhs_field, is_optional: lhs_optional) => match rhs_expression {
+            IndexedStruct(expr: rhs_expr, field_name: rhs_field, is_optional: rhs_optional) => lhs_optional == rhs_optional and lhs_expr.equals(rhs_expr) and lhs_field == rhs_field
             else => false
         }
         Var(name: lhs_name) => match rhs_expression {
@@ -1144,6 +1144,7 @@ struct ParsedField {
     // FIXME: It would be nice to extend the ParsedVarDecl struct instead.
     var_decl: ParsedVarDecl
     visibility: Visibility
+    default_value: ParsedExpression?
 }
 
 struct ParsedMethod {
@@ -2453,9 +2454,17 @@ struct Parser {
             .error("Field missing type", parsed_variable_declaration.span)
         }
 
+        mut default_value: ParsedExpression? = None
+
+        if .peek(0) is Equal {
+            .index++
+            default_value = .parse_expression(allow_assignments: false, allow_newlines: false)
+        }
+
         return ParsedField(
             var_decl: parsed_variable_declaration,
             visibility,
+            default_value
         )
     }
 
@@ -3873,7 +3882,7 @@ struct Parser {
                                 }
                                 else => ParsedExpression::IndexedStruct(
                                     expr: result
-                                    field: name
+                                    field_name: name
                                     is_optional
                                     span: merge_spans(start, end: .current().span()))
                             }

--- a/selfhost/typechecker.jakt
+++ b/selfhost/typechecker.jakt
@@ -17,7 +17,7 @@ import parser { Parser, BinaryOperator, DefinitionLinkage, UnaryOperator,
                 ParsedMethod }
 import types {
     BlockControlFlow, BuiltinType, CheckedBlock, CheckedCall, CheckedCapture, CheckedEnum, CheckedEnumVariant,
-    CheckedEnumVariantBinding, CheckedExpression, CheckedFunction, FunctionGenerics, CheckedMatchBody, CheckedMatchCase,
+    CheckedEnumVariantBinding, CheckedExpression, CheckedFunction, CheckedField, FunctionGenerics, CheckedMatchBody, CheckedMatchCase,
     CheckedNamespace, CheckedNumericConstant, CheckedParameter, CheckedProgram, CheckedStatement, CheckedStruct,
     CheckedTypeCast, CheckedUnaryOperator, CheckedVariable, CheckedVisibility, EnumId, FieldRecord, FunctionGenericParameter,
     FunctionId, LoadedModule, Module, ModuleId, NumberConstant, ResolvedNamespace, SafetyMode, Scope, ScopeId, StructId,
@@ -125,10 +125,10 @@ struct Typechecker {
         }
 
         for current_struct_id in chain.iterator() {
-            for field_id in .get_struct(current_struct_id).fields.iterator() {
-                let field = .get_variable(field_id)
-                if field.name == name {
-                    return FieldRecord(struct_id: current_struct_id, field_id)
+            for field in .get_struct(current_struct_id).fields.iterator() {
+                let variable = .get_variable(field.variable_id)
+                if variable.name == name {
+                    return FieldRecord(struct_id: current_struct_id, field_id: field.variable_id)
                 }
             }
         }
@@ -585,7 +585,7 @@ struct Typechecker {
             .check_that_type_doesnt_contain_reference(type_id: checked_member_type, span: parsed_var_decl.parsed_type.span())
 
             mut module = .current_module()
-            let var_id = module.add_variable(checked_variable: CheckedVariable(
+            let variable_id = module.add_variable(checked_variable: CheckedVariable(
                 name: parsed_var_decl.name
                 type_id: checked_member_type
                 is_mutable: parsed_var_decl.is_mutable
@@ -593,7 +593,16 @@ struct Typechecker {
                 type_span: None
                 visibility: .typecheck_visibility(visibility: unchecked_member.visibility, scope_id: checked_struct_scope_id)
             ))
-            structure.fields.push(var_id)
+            mut default_value: CheckedExpression? = None
+            if unchecked_member.default_value.has_value() {
+                default_value = .typecheck_expression(
+                    unchecked_member.default_value!,
+                    scope_id: checked_struct_scope_id,
+                    safety_mode: SafetyMode::Safe,
+                    type_hint: None
+                )
+            }
+            structure.fields.push(CheckedField(variable_id, default_value))
         }
     }
 
@@ -1271,16 +1280,16 @@ struct Typechecker {
 
             mut func = module.functions.last()!
             for field_struct_id in inheritance_chain.iterator() {
-                for field_id in .get_struct(field_struct_id).fields.iterator() {
-                    let field = .get_variable(field_id)
-                    if field.visibility is Private {
+                for field in .get_struct(field_struct_id).fields.iterator() {
+                    let variable = .get_variable(field.variable_id)
+                    if variable.visibility is Private {
                         checked_constructor.visibility = CheckedVisibility::Private
                     }
 
                     func.add_param(CheckedParameter(
                         requires_label: true
-                        variable: field
-                        default_value: None
+                        variable: variable
+                        default_value: field.default_value
                     ))
                 }
             }
@@ -4042,7 +4051,7 @@ struct Typechecker {
         return checked_expr
     }
 
-    function typecheck_indexed_struct(mut this, expr: ParsedExpression, field: String, scope_id: ScopeId, is_optional: bool, safety_mode: SafetyMode, span: Span) throws -> CheckedExpression {
+    function typecheck_indexed_struct(mut this, expr: ParsedExpression, field_name: String, scope_id: ScopeId, is_optional: bool, safety_mode: SafetyMode, span: Span) throws -> CheckedExpression {
         let checked_expr = .typecheck_expression_and_dereference_if_needed(expr, scope_id, safety_mode, type_hint: None, span)
         let checked_expr_type_id = checked_expr.type()
         let checked_expr_type = .get_type(checked_expr_type_id)
@@ -4056,7 +4065,7 @@ struct Typechecker {
                         .error("Optional chaining is only allowed on optional types", span)
                         return CheckedExpression::IndexedStruct(
                             expr: checked_expr
-                            index: field
+                            index: field_name
                             span
                             is_optional
                             type_id: unknown_type_id())
@@ -4068,10 +4077,10 @@ struct Typechecker {
                 match .get_type(type_id) {
                     GenericInstance(id: struct_id) | Struct(struct_id) => {
                         let structure = .get_struct(struct_id)
-                        for member_id in structure.fields.iterator() {
-                            let member = .get_variable(member_id)
+                        for field in structure.fields.iterator() {
+                            let member = .get_variable(field.variable_id)
 
-                            if member.name == field {
+                            if member.name == field_name {
                                 mut resolved_type_id = .resolve_type_var(type_var_type_id: member.type_id, scope_id)
                                 if is_optional {
                                     resolved_type_id = .find_or_add_type_id(Type::GenericInstance(id: optional_struct_id, args: [resolved_type_id]))
@@ -4080,14 +4089,14 @@ struct Typechecker {
                                 .check_member_access(accessor: scope_id, accessee: structure.scope_id, member, span)
                                 return CheckedExpression::IndexedStruct(
                                     expr: checked_expr
-                                    index: field
+                                    index: field_name
                                     span
                                     is_optional
                                     type_id: resolved_type_id)
                             }
                         }
 
-                        .error(format("unknown member of struct: {}.{}", structure.name, field), span)
+                        .error(format("unknown member of struct: {}.{}", structure.name, field_name), span)
                     }
                     else => .error(format("Member field access on value of non-struct type ‘{}’", .type_name(checked_expr_type_id)), span)
                 }
@@ -4099,7 +4108,7 @@ struct Typechecker {
 
                 let structure = .get_struct(struct_id)
 
-                let field_record = .lookup_struct_field(struct_id, name: field)
+                let field_record = .lookup_struct_field(struct_id, name: field_name)
                 if field_record.has_value() {
                     let member = .get_variable(field_record!.field_id)
                     let resolved_type_id = .resolve_type_var(type_var_type_id: member.type_id, scope_id)
@@ -4107,13 +4116,13 @@ struct Typechecker {
                     .check_member_access(accessor: scope_id, accessee: .get_struct(field_record!.struct_id).scope_id, member, span)
                     return CheckedExpression::IndexedStruct(
                         expr: checked_expr
-                        index: field
+                        index: field_name
                         span
                         is_optional
                         type_id: resolved_type_id)
                 }
 
-                .error(format("unknown member of struct: {}.{}", structure.name, field), span)
+                .error(format("unknown member of struct: {}.{}", structure.name, field_name), span)
             }
             else => .error(format("Member field access on value of non-struct type ‘{}’", .type_name(checked_expr_type_id)), span)
         }
@@ -4121,7 +4130,7 @@ struct Typechecker {
         // FIXME: Unify with type
         return CheckedExpression::IndexedStruct(
             expr: checked_expr
-            index: field
+            index: field_name
             span
             is_optional
             type_id: unknown_type_id())
@@ -4418,7 +4427,7 @@ struct Typechecker {
     }
 
     function typecheck_expression(mut this, anon expr: ParsedExpression, scope_id: ScopeId, safety_mode: SafetyMode, type_hint: TypeId?) throws -> CheckedExpression => match expr {
-        IndexedStruct(expr, field, span, is_optional) => .typecheck_indexed_struct(expr, field, scope_id, is_optional, safety_mode, span)
+        IndexedStruct(expr, field_name, span, is_optional) => .typecheck_indexed_struct(expr, field_name, scope_id, is_optional, safety_mode, span)
         Boolean(val, span) => CheckedExpression::Boolean(val, span)
         NumericConstant(val, span) => {
             mut type_hint_unwrapped = type_hint

--- a/selfhost/typechecker.jakt
+++ b/selfhost/typechecker.jakt
@@ -1117,6 +1117,7 @@ struct Typechecker {
                 type: func.type
                 linkage: func.linkage
                 function_scope_id: method_scope_id
+                struct_id: None
                 is_instantiated: not is_generic or is_extern
                 parsed_function: func
                 is_comptime: func.is_comptime
@@ -1265,6 +1266,7 @@ struct Typechecker {
                 type: FunctionType::ImplicitConstructor
                 linkage: FunctionLinkage::Internal
                 function_scope_id
+                struct_id
                 is_instantiated: true
                 parsed_function: None
                 is_comptime: false
@@ -1282,10 +1284,6 @@ struct Typechecker {
             for field_struct_id in inheritance_chain.iterator() {
                 for field in .get_struct(field_struct_id).fields.iterator() {
                     let variable = .get_variable(field.variable_id)
-                    if variable.visibility is Private {
-                        checked_constructor.visibility = CheckedVisibility::Private
-                    }
-
                     func.add_param(CheckedParameter(
                         requires_label: true
                         variable: variable
@@ -1428,6 +1426,7 @@ struct Typechecker {
                 type: func.type
                 linkage: func.linkage
                 function_scope_id: method_scope_id
+                struct_id: None
                 is_instantiated: not is_generic or is_extern
                 parsed_function: method.parsed_function
                 is_comptime: method.parsed_function.is_comptime
@@ -1756,6 +1755,7 @@ struct Typechecker {
                                 type: FunctionType::ImplicitEnumConstructor
                                 linkage: FunctionLinkage::Internal
                                 function_scope_id
+                                struct_id: None
                                 is_instantiated: true
                                 parsed_function: None
                                 is_comptime: false
@@ -1808,6 +1808,7 @@ struct Typechecker {
                                 type: FunctionType::ImplicitEnumConstructor
                                 linkage: FunctionLinkage::Internal
                                 function_scope_id
+                                struct_id: None
                                 is_instantiated: true
                                 parsed_function: None
                                 is_comptime: false
@@ -1847,6 +1848,7 @@ struct Typechecker {
                                 type: FunctionType::ImplicitEnumConstructor
                                 linkage: FunctionLinkage::Internal
                                 function_scope_id
+                                struct_id: None
                                 is_instantiated: true
                                 parsed_function: None
                                 is_comptime: false
@@ -2085,6 +2087,7 @@ struct Typechecker {
             type: FunctionType::Normal
             linkage: parsed_function.linkage
             function_scope_id
+            struct_id: None
             is_instantiated: not is_generic or not base_definition
             parsed_function
             is_comptime: parsed_function.is_comptime
@@ -3132,6 +3135,7 @@ struct Typechecker {
                     type: FunctionType::Expression
                     linkage: FunctionLinkage::Internal
                     function_scope_id: scope_id
+                    struct_id: None
                     is_instantiated: true
                     parsed_function: None
                     is_comptime: false
@@ -6100,7 +6104,12 @@ struct Typechecker {
                 return_type = callee.return_type_id
                 let scope_containing_callee = .get_scope(callee.function_scope_id).parent!
 
-                .check_method_access(accessor: caller_scope_id, accessee: scope_containing_callee, method: callee, span)
+                if callee.type is ImplicitConstructor {
+                    let struct_ = .get_struct(callee.struct_id!)
+                    .check_implicit_constructor_argument_access(caller_scope_id, call, struct_)
+                } else {
+                    .check_method_access(accessor: caller_scope_id, accessee: scope_containing_callee, method: callee, span)
+                }
 
                 // If the user gave us explicit type arguments, let's use them in our substitutions
                 mut type_arg_index = 0uz
@@ -6387,6 +6396,20 @@ struct Typechecker {
         }
 
         return checked_call
+    }
+
+    function check_implicit_constructor_argument_access(mut this, caller_scope_id: ScopeId, call: ParsedCall, struct_: CheckedStruct)  throws {
+        if not .scope_can_access(accessor:caller_scope_id, accessee:struct_.scope_id) {
+            for arg in call.args.iterator() {
+                for field in struct_.fields.iterator() {
+                    let variable = .get_variable(field.variable_id)
+                    if (variable.name == arg.0 and variable.visibility is Private) {
+                        .error(format("Can't access field '{}' when calling implicit constructor of '{}' because it is marked private", variable.name, struct_.name), arg.1)
+                        return
+                    }
+                }
+            }
+        }
     }
 
     function resolve_default_params(mut this, params: [CheckedParameter], args: [(String, Span, ParsedExpression)], scope_id: ScopeId, safety_mode: SafetyMode, arg_offset: usize, span: Span) throws -> [(String, Span, CheckedExpression)] {

--- a/selfhost/types.jakt
+++ b/selfhost/types.jakt
@@ -586,6 +586,7 @@ class CheckedFunction {
     public type: FunctionType
     public linkage: FunctionLinkage
     public function_scope_id: ScopeId
+    public struct_id: StructId?
     public is_instantiated: bool
     public parsed_function: ParsedFunction?
     public is_comptime: bool
@@ -1789,6 +1790,7 @@ class CheckedProgram {
                     type: previous_function.type
                     linkage: previous_function.linkage
                     function_scope_id: previous_function.function_scope_id
+                    struct_id: previous_function.struct_id
                     is_instantiated: previous_function.is_instantiated
                     parsed_function: previous_function.parsed_function
                     is_comptime: previous_function.is_comptime

--- a/selfhost/types.jakt
+++ b/selfhost/types.jakt
@@ -840,11 +840,16 @@ struct FieldRecord {
     field_id: VarId
 }
 
+struct CheckedField {
+    variable_id: VarId
+    default_value: CheckedExpression?
+}
+
 struct CheckedStruct {
     name: String
     name_span: Span
     generic_parameters: [TypeId]
-    fields: [VarId]
+    fields: [CheckedField]
     scope_id: ScopeId
     definition_linkage: DefinitionLinkage
     record_type: RecordType

--- a/tests/typechecker/class_private_field_ctr.jakt
+++ b/tests/typechecker/class_private_field_ctr.jakt
@@ -1,5 +1,5 @@
 /// Expect:
-/// - error: "Can't access constructor ‘GoodEncapsulation’, because it is marked private\n"
+/// - error: "Can't access field 'muda_amount' when calling implicit constructor of 'GoodEncapsulation' because it is marked private\n"
 
 class GoodEncapsulation {
     muda_amount: u32


### PR DESCRIPTION
Fields with default values can be ommitted from the implicit constructor call and are treated as default arguments. Additionally the constructor is no longer automatically marked private in the presence of private fields, instead each constructor call is checked and rejected only if it actually sets any private fields.