### PR TITLE
typechecker: Error on array/tuple literals when another type is expected

### DIFF
--- a/selfhost/typechecker.jakt
+++ b/selfhost/typechecker.jakt
@@ -2652,6 +2652,11 @@ struct Typechecker {
                         if (array_value_type_id.equals(unknown_type_id())) {
                             return true
                         }
+                        .error(
+                            format("Type mismatch: expected ‘{}’, but got ‘{}’", .type_name(lhs_type_id), .type_name(rhs_type_id))
+                            span
+                        )
+                        return false
                     } else {
                         .error(
                             format("Type mismatch: expected ‘{}’, but got ‘{}’", .type_name(lhs_type_id), .type_name(rhs_type_id))
@@ -4765,6 +4770,15 @@ struct Typechecker {
             let type_id = .find_or_add_type_id(Type::GenericInstance(id: tuple_struct_id, args: checked_types))
 
             // FIXME: Unify type
+
+            if type_hint.has_value() {
+                .check_types_for_compat(
+                    lhs_type_id: type_hint!
+                    rhs_type_id: type_id
+                    generic_inferences: &mut .generic_inferences
+                    span
+                )
+            }
 
             yield CheckedExpression::JaktTuple(vals: checked_values, span, type_id)
         }

--- a/selfhost/typechecker.jakt
+++ b/selfhost/typechecker.jakt
@@ -5197,6 +5197,16 @@ struct Typechecker {
         }
 
         let type_id = .find_or_add_type_id(Type::GenericInstance(id: array_struct_id, args: [inner_type_id]))
+
+        if type_hint.has_value() {
+            .check_types_for_compat(
+                lhs_type_id: type_hint!
+                rhs_type_id: type_id
+                generic_inferences: &mut .generic_inferences
+                span
+            )
+        }
+
         return CheckedExpression::JaktArray(vals, repeat, span, type_id, inner_type_id)
     }
 

--- a/tests/typechecker/return_array_literal_in_function_returning_tuple.jakt
+++ b/tests/typechecker/return_array_literal_in_function_returning_tuple.jakt
@@ -1,0 +1,5 @@
+/// Expect:
+/// - error: "Type mismatch: expected ‘(f64, f64)’, but got ‘[unknown]’"
+function foo() throws -> (f64, f64) {
+    return []
+}

--- a/tests/typechecker/return_tuple_literal_in_function_returning_array.jakt
+++ b/tests/typechecker/return_tuple_literal_in_function_returning_array.jakt
@@ -1,0 +1,5 @@
+/// Expect:
+/// - error: "Type mismatch: expected ‘[i32]’, but got ‘(i64, i64)’"
+function foo() throws -> [i32] {
+    return (1, 2)
+}


### PR DESCRIPTION
We should catch attempts to return an array or tuple literal when it's incompatible with the context return type.