### PR TITLE
everywhere: Add support for common enum fields 

### DIFF
--- a/samples/enums/common_members.jakt
+++ b/samples/enums/common_members.jakt
@@ -1,0 +1,30 @@
+/// Expect:
+/// - output: "You gave me a mild mustard that's not on sale, and expires tomorrow lol\n"
+
+enum Sauce {
+    expiry_date: String
+    on_sale: bool = false
+
+    Mustard(mild: bool)
+    Ketchup(spicy: bool)
+    Mayo(String)
+}
+
+function gib_sauce() throws -> Sauce {
+    return Sauce::Mustard(expiry_date: "tomorrow lol", mild: true)
+}
+
+function main() {
+    let sauce = gib_sauce()
+    let name = match sauce {
+        Mustard(mild) => format("{} mustard", match mild { true => "mild", else => "regular" })
+        Ketchup(spicy) => format("{} ketchup", match spicy { true => "spicy", else => "regular" })
+        Mayo(name) => format("{} mayo", name)
+    }
+    println(
+        "You gave me a {} that's {}on sale, and expires {}"
+        name
+        match sauce.on_sale { true => "", else => "not " }
+        sauce.expiry_date
+    )
+}

--- a/selfhost/codegen.jakt
+++ b/selfhost/codegen.jakt
@@ -11,7 +11,7 @@ import typechecker {
     CheckedFunction, CheckedProgram, CheckedStatement, CheckedStruct,
     Module, ModuleId, Scope, ScopeId, StructId, EnumId, Type, TypeId,
     CheckedEnum, unknown_type_id, CheckedMatchCase, FunctionId, CheckedMatchBody, void_type_id, never_type_id, builtin,
-    CheckedVariable }
+    CheckedVariable, VarId }
 import utility { panic, todo, join, prepend_to_each, Span }
 import compiler { Compiler }
 
@@ -1130,56 +1130,77 @@ struct CodeGenerator {
             }
         }
         mut template_args = join(prepend_to_each(generic_parameter_names, prefix: "typename "), separator: ", ")
+
+        mut common_fields: [(String, String)] = []
+        for field in enum_.fields.iterator() {
+            let variable = .program.get_variable(field.variable_id)
+            common_fields.push((variable.name, .codegen_type(variable.type_id)))
+        }
+
         output += "namespace " + enum_.name + "_Details {\n"
         for variant in enum_.variants.iterator() {
-            match variant {
+            let fields = match variant {
                 Untyped(name) => {
                     if is_generic {
                         output += "template<" + template_args + ">\n"
                     }
-                    output += "struct " + name + " {};\n"
+                    output += "struct " + name + " {\n"
+                    yield common_fields
                 }
-                StructLike(name, fields) => {
+                StructLike(name, fields: own_fields) => {
+                    mut fields: [(String, String)] = []
+                    for field in own_fields.iterator() {
+                        let variable = .program.get_variable(field)
+                        fields.push((variable.name, .codegen_type(variable.type_id)))
+                    }
+
                     if is_generic {
                         output += "template<" + template_args + ">\n"
                     }
                     output += "struct " + name + " {\n"
-                    for field in fields.iterator() {
-                        let var = .program.get_variable(field)
-                        output += format("{} {};\n", .codegen_type(var.type_id), var.name)
-                    }
-                    output += "template<"
-                    mut generic_typenames: [String] = []
-                    mut generic_argument_types: [String] = []
-                    mut initializers: [String] = []
-                    for i in 0..fields.size() {
-                        generic_typenames.push(format("typename _MemberT{}", i))
-                        generic_argument_types.push(format("_MemberT{}&& member_{}", i, i))
-
-                        mut initializer = .program.get_variable(fields[i]).name + "{ forward<_MemberT"
-                        initializer += format("{}>(member_{}", i, i) + ")}"
-                        initializers.push(initializer)
-                    }
-                    output += join(generic_typenames, separator: ", ")
-                    output += ">\n"
-                    output += name + "(" + join(generic_argument_types, separator: ", ") + "):\n"
-                    output += join(initializers, separator: ",\n") + "\n{}\n"
-                    output +="};\n"
+                    yield fields
                 }
                 Typed(name, type_id) => {
+                    mut fields: [(String, String)] = []
+                    for field in common_fields.iterator() {
+                        fields.push(field)
+                    }
+                    fields.push(("value", .codegen_type(type_id)))
+
                     if is_generic {
                         output += "template<" + template_args + ">\n"
                     }
                     output += "struct " + name + "{\n"
-                    output += .codegen_type(type_id) + " value;\n"
-                    output += "template<typename... Args>\n"
-                    output += name + "(Args&&... args): value { forward<Args>(args)... } {}\n"
-                    output += "};\n"
+                    yield fields
                 }
                 else => {
                     todo(format("codegen enum variant: {}", variant))
+                    yield []
                 }
             }
+
+            for (name, type) in fields.iterator() {
+                output += format("{} {};\n", type, name)
+            }
+            if not fields.is_empty() {
+                output += "template<"
+                mut generic_typenames: [String] = []
+                mut generic_argument_types: [String] = []
+                mut initializers: [String] = []
+                for i in 0..fields.size() {
+                    generic_typenames.push(format("typename _MemberT{}", i))
+                    generic_argument_types.push(format("_MemberT{}&& member_{}", i, i))
+
+                    mut initializer = fields[i].0 + "{ forward<_MemberT"
+                    initializer += format("{}>(member_{}", i, i) + ")}"
+                    initializers.push(initializer)
+                }
+                output += join(generic_typenames, separator: ", ")
+                output += ">\n"
+                output += variant.name() + "(" + join(generic_argument_types, separator: ", ") + "):\n"
+                output += join(initializers, separator: ",\n") + "\n{}\n"
+            }
+            output +="};\n"
         }
         output += "}\n"
 
@@ -1233,6 +1254,18 @@ struct CodeGenerator {
             output += "ErrorOr<String> debug_description() const;\n"
         } else {
             output += .codegen_enum_debug_description_getter(enum_, is_inline: true)
+        }
+
+        for (field_name, type) in common_fields.iterator() {
+            output += format("{} const& {}() const {{ switch(this->index()) {{", type, field_name)
+            for i in 0..enum_.variants.size() {
+                let variant = enum_.variants[i]
+                let name = variant.name()
+                output += format("case {} /* {} */: ", i, name)
+                output += format("return this->template get<{}::{}>().{};\n", enum_.name, name, field_name)
+            }
+            output += "default: VERIFY_NOT_REACHED();\n"
+            output += "}\n}\n"
         }
 
         let enum_scope = .program.get_scope(enum_.scope_id)
@@ -1503,6 +1536,39 @@ struct CodeGenerator {
                 output += "; })"
             } else {
                 output += index
+            }
+            output += ")"
+            yield output
+        }
+        IndexedCommonEnumMember(expr, index, is_optional) => {
+            mut output = ""
+            let object = .codegen_expression(expression: expr)
+            output += "(("
+            output += object
+            output += ")"
+
+            match .program.get_type(expr.type()) {
+                RawPtr => {
+                    output += "->"
+                }
+                Enum(id) | GenericEnumInstance(id) => {
+                    let structure = .program.get_enum(id)
+                    if structure.record_type is SumEnum(is_boxed) and is_boxed and object != "*this" {
+                        output += "->"
+                    } else {
+                        output += "."
+                    }
+                }
+                else => {
+                    output += "."
+                }
+            }
+            if is_optional {
+                output += "map([](auto& _value) { return _value."
+                output += index
+                output += "(); })"
+            } else {
+                output += index + "()"
             }
             output += ")"
             yield output

--- a/selfhost/interpreter.jakt
+++ b/selfhost/interpreter.jakt
@@ -4623,6 +4623,31 @@ class Interpreter {
 
                 fields[field_index] = value
             }
+            IndexedCommonEnumMember(expr, index) => {
+                // FIXME: This should not be evaluated twice.
+                mut (fields, enum_id) = match .execute_expression(expr, scope) {
+                    JustValue(value) => match value.impl {
+                        Enum(fields, enum_id) => (fields, enum_id)
+                        else => {
+                            panic("Invalid left-hand side in assignment")
+                        }
+                    }
+                    else => {
+                        panic("Should not be happening here")
+                    }
+                }
+
+                let field_decls = .program.get_enum(enum_id).fields
+                mut field_index = 0uz
+                for i in 0..field_decls.size() {
+                    if .program.get_variable(field_decls[i].variable_id).name == index {
+                        field_index = i
+                        break
+                    }
+                }
+
+                fields[field_index] = value
+            }
             else => {
                 .error(
                     format("Invalid left-hand side of assignment {}", binding),
@@ -5519,6 +5544,50 @@ class Interpreter {
                     mut idx = 0
                     mut found_index: i64? = None
                     for field in struct_.fields.iterator() {
+                        if .program.get_variable(field.variable_id).name == index {
+                            found_index = idx
+                            break
+                        }
+                        idx += 1
+                    }
+                    if not found_index.has_value() {
+                        .error("Attempted to access a field that does not exist", value.span)
+                        throw Error::from_errno(InterpretError::InvalidType as! i32)
+                    }
+
+                    yield StatementResult::JustValue(fields[found_index!])
+                }
+                else => {
+                    .error("Attempted to access a field on a non-struct/enum type", value.span)
+                    throw Error::from_errno(InterpretError::InvalidType as! i32)
+                }
+            }
+        }
+        IndexedCommonEnumMember(expr, index) => {
+            let value = match .execute_expression(expr, scope) {
+                Return(value) => {
+                    return StatementResult::Return(value)
+                }
+                Throw(value) => {
+                    return StatementResult::Throw(value)
+                }
+                JustValue(value) => value
+                Continue => {
+                    return StatementResult::Continue
+                }
+                Break => {
+                    return StatementResult::Break
+                }
+                Yield(expr) => {
+                    panic("Invalid control flow")
+                }
+            }
+            yield match value.impl {
+                Enum(fields, enum_id) => {
+                    let enum_ = .program.get_enum(enum_id)
+                    mut idx = 0
+                    mut found_index: i64? = None
+                    for field in enum_.fields.iterator() {
                         if .program.get_variable(field.variable_id).name == index {
                             found_index = idx
                             break

--- a/selfhost/parser.jakt
+++ b/selfhost/parser.jakt
@@ -278,7 +278,7 @@ enum RecordType {
     Struct(fields: [ParsedField], super_type: ParsedType?)
     Class(fields: [ParsedField], super_type: ParsedType?)
     ValueEnum(underlying_type: ParsedType, variants: [ValueEnumVariant])
-    SumEnum(is_boxed: bool, variants: [SumEnumVariant])
+    SumEnum(is_boxed: bool, fields: [ParsedField], variants: [SumEnumVariant])
     Garbage
 
     public function record_type_name(this) => match this {
@@ -1799,9 +1799,11 @@ struct Parser {
         return (variants, methods)
     }
 
-    function parse_sum_enum_body(mut this, partial_enum: ParsedRecord, definition_linkage: DefinitionLinkage, is_boxed: bool) throws -> ([SumEnumVariant], [ParsedMethod]) {
+    function parse_sum_enum_body(mut this, partial_enum: ParsedRecord, definition_linkage: DefinitionLinkage, is_boxed: bool) throws -> ([SumEnumVariant], [ParsedField], [ParsedMethod]) {
         mut methods: [ParsedMethod] = []
         mut variants: [SumEnumVariant] = []
+        mut fields: [ParsedField] = []
+        mut seen_a_variant = false
 
         if .current() is LCurly {
             .index++
@@ -1812,8 +1814,8 @@ struct Parser {
         .skip_newlines()
 
         if .eof() {
-            .error("Incomplete enum definition, expected variant name", .previous().span())
-            return (variants, methods)
+            .error("Incomplete enum definition, expected variant or field name", .previous().span())
+            return (variants, fields, methods)
         }
 
         mut last_visibility: Visibility? = None
@@ -1821,11 +1823,27 @@ struct Parser {
         while not .eof() {
             match .current() {
                 Identifier(name, span) => {
-                    if not .peek(1) is LParen {
+                    if .peek(1) is Colon {
+                        let field = .parse_field(visibility: last_visibility ?? Visibility::Public)
+                        if seen_a_variant {
+                            .error_with_hint(
+                                "Common enum fields must be declared before variants", span,
+                                "Previous variant is here", variants.last()!.span
+                            )
+                        } else {
+                            fields.push(field)
+                        }
+                        continue
+                    }
+
+                    seen_a_variant = true
+
+                    if not (.peek(1) is LParen) {
                         .index++
                         variants.push(SumEnumVariant(name, span, params: None))
                         continue
                     }
+
                     .index += 2
 
                     mut var_decls: [ParsedVarDecl] = []
@@ -1923,14 +1941,14 @@ struct Parser {
 
         if not .current() is RCurly {
             .error("Invalid enum definition, expected `}`", .current().span())
-            return (variants, methods)
+            return (variants, fields, methods)
         }
         .index++
 
         if variants.is_empty() {
             .error("Empty enums are not allowed", partial_enum.name_span)
         }
-        return (variants, methods)
+        return (variants, fields, methods)
     }
 
     function parse_enum(mut this, anon definition_linkage: DefinitionLinkage, is_boxed: bool) throws -> ParsedRecord {
@@ -2000,10 +2018,11 @@ struct Parser {
                 variants
             )
         } else {
-            let (variants, methods) = .parse_sum_enum_body(partial_enum: parsed_enum, definition_linkage, is_boxed)
+            let (variants, fields, methods) = .parse_sum_enum_body(partial_enum: parsed_enum, definition_linkage, is_boxed)
             parsed_enum.methods = methods
             parsed_enum.record_type = RecordType::SumEnum(
                 is_boxed: is_boxed,
+                fields,
                 variants
             )
         }

--- a/selfhost/typechecker.jakt
+++ b/selfhost/typechecker.jakt
@@ -1023,6 +1023,7 @@ struct Typechecker {
             name_span: parsed_record.name_span
             generic_parameters: []
             variants: []
+            fields: []
             scope_id: .prelude_scope_id()
             definition_linkage: parsed_record.definition_linkage
             record_type: parsed_record.record_type
@@ -1048,12 +1049,49 @@ struct Typechecker {
             SumEnum(is_boxed) => is_boxed
             else => false
         }
+
+        mut checked_fields: [CheckedField] = []
+        mut seen_fields: {String} = {}
+        if parsed_record.record_type is SumEnum(fields) {
+            for field in fields.iterator() {
+                let var_decl = field.var_decl
+                if seen_fields.contains(var_decl.name) {
+                    .error(format("Field '{}' is defined more than once", var_decl.name), var_decl.span)
+                    continue
+                }
+                seen_fields.add(var_decl.name)
+                let type_id = .typecheck_typename(parsed_type: var_decl.parsed_type, scope_id: enum_scope_id, name: var_decl.name)
+                let checked_var = CheckedVariable(
+                    name: var_decl.name
+                    type_id
+                    is_mutable: var_decl.is_mutable
+                    definition_span: var_decl.span
+                    type_span: var_decl.parsed_type.span()
+                    visibility: .typecheck_visibility(visibility: field.visibility, scope_id: enum_scope_id)
+                )
+                mut default_value: CheckedExpression? = None
+                if field.default_value.has_value() {
+                    default_value = .typecheck_expression(
+                        expr: field.default_value!
+                        scope_id: enum_scope_id
+                        safety_mode: SafetyMode::Safe
+                        type_hint: type_id
+                    )
+                }
+
+                mut module = .current_module()
+                let variable_id = module.add_variable(checked_var)
+                checked_fields.push(CheckedField(variable_id, default_value))
+            }
+        }
+
         mut module = .current_module()
         module.enums[enum_id.id] = CheckedEnum(
             name: parsed_record.name
             name_span: parsed_record.name_span
             generic_parameters: []
             variants: []
+            fields: checked_fields
             scope_id: enum_scope_id
             definition_linkage: parsed_record.definition_linkage
             record_type: parsed_record.record_type
@@ -1639,6 +1677,24 @@ struct Typechecker {
 
         mut enum_ = .get_enum(enum_id)
 
+        mut common_seen_fields: {String} = {}
+        mut common_fields: [VarId] = []
+        mut common_params: [CheckedParameter] = []
+        for field in enum_.fields.iterator() {
+            let variable = .get_variable(field.variable_id)
+            common_params.push(CheckedParameter(
+                requires_label: true,
+                variable,
+                default_value: field.default_value))
+
+            if .dump_type_hints {
+                .dump_type_hint(type_id: variable.type_id, span: variable.definition_span)
+            }
+
+            common_seen_fields.add(variable.name)
+            common_fields.push(field.variable_id)
+        }
+
         match record.record_type {
             ValueEnum(underlying_type, variants) => {
                 let underlying_type_id = .typecheck_typename(parsed_type: underlying_type, scope_id: parent_scope_id, name: None)
@@ -1700,10 +1756,23 @@ struct Typechecker {
                     seen_names.add(variant.name)
                     let is_structlike = variant.params.has_value() and variant.params!.size() > 0 and variant.params![0].name != ""
                     let is_typed = variant.params.has_value() and variant.params!.size() == 1 and variant.params![0].name == ""
+
                     if is_structlike {
                         mut seen_fields: {String} = {}
-                        mut fields: [VarId] = []
+                        for name in common_seen_fields.iterator() {
+                            seen_fields.add(name)
+                        }
+
                         mut params: [CheckedParameter] = []
+                        for param in common_params.iterator() {
+                            params.push(param)
+                        }
+
+                        mut fields: [VarId] = []
+                        for field in common_fields.iterator() {
+                            fields.push(field)
+                        }
+
                         for param in variant.params!.iterator() {
                             if seen_fields.contains(param.name) {
                                 .error(format("Enum variant '{}' has a member named '{}' more than once", variant.name, param.name), param.span)
@@ -1770,6 +1839,11 @@ struct Typechecker {
                             .add_function_to_scope(parent_scope_id: enum_.scope_id, name: variant.name, function_id, span: variant.span)
                         }
                     } else if is_typed {
+                        mut params: [CheckedParameter] = []
+                        for param in common_params.iterator() {
+                            params.push(param)
+                        }
+
                         let param = variant.params![0]
                         let type_id = .typecheck_typename(parsed_type: param.parsed_type, scope_id: enum_.scope_id, name: param.name)
                         enum_.variants.push(CheckedEnumVariant::Typed(enum_id, name: variant.name, type_id, span: variant.span))
@@ -1787,7 +1861,7 @@ struct Typechecker {
                                 type_span: None
                                 visibility: CheckedVisibility::Public
                             )
-                            let param = CheckedParameter(requires_label: false, variable, default_value: None)
+                            params.push(CheckedParameter(requires_label: false, variable, default_value: None))
 
                             let checked_function = CheckedFunction(
                                 name: variant.name
@@ -1795,10 +1869,10 @@ struct Typechecker {
                                 visibility: CheckedVisibility::Public
                                 return_type_id: .find_or_add_type_id(Type::Enum(enum_id))
                                 return_type_span: None
-                                params: [param]
+                                params
                                 generics: FunctionGenerics(
                                     base_scope_id: function_scope_id
-                                    base_params: [param]
+                                    base_params: params
                                     params: []
                                     specializations: []
                                 )
@@ -1824,6 +1898,11 @@ struct Typechecker {
                             .add_function_to_scope(parent_scope_id: enum_.scope_id, name: variant.name, function_id, span: variant.span)
                         }
                     } else {
+                        mut params: [CheckedParameter] = []
+                        for param in common_params.iterator() {
+                            params.push(param)
+                        }
+
                         enum_.variants.push(CheckedEnumVariant::Untyped(enum_id, name: variant.name, span: variant.span))
                         let maybe_enum_variant_constructor = .find_function_in_scope(parent_scope_id: enum_.scope_id, function_name: variant.name)
                         if not maybe_enum_variant_constructor.has_value() {
@@ -1836,10 +1915,10 @@ struct Typechecker {
                                 visibility: CheckedVisibility::Public
                                 return_type_id: .find_or_add_type_id(Type::Enum(enum_id))
                                 return_type_span: None
-                                params: []
+                                params
                                 generics: FunctionGenerics(
                                     base_scope_id: function_scope_id
-                                    base_params: []
+                                    base_params: params
                                     params: []
                                     specializations: []
                                 )
@@ -4110,6 +4189,29 @@ struct Typechecker {
 
                         .error(format("unknown member of struct: {}.{}", structure.name, field_name), span)
                     }
+                    GenericEnumInstance(id: enum_id) | Enum(enum_id) => {
+                        let enum_ = .get_enum(enum_id)
+                        for field in enum_.fields.iterator() {
+                            let member = .get_variable(field.variable_id)
+
+                            if member.name == field_name {
+                                mut resolved_type_id = .resolve_type_var(type_var_type_id: member.type_id, scope_id)
+                                if is_optional {
+                                    resolved_type_id = .find_or_add_type_id(Type::GenericInstance(id: optional_struct_id, args: [resolved_type_id]))
+                                }
+                                // FIXME: Unify with type
+                                .check_member_access(accessor: scope_id, accessee: enum_.scope_id, member, span)
+                                return CheckedExpression::IndexedCommonEnumMember(
+                                    expr: checked_expr
+                                    index: field_name
+                                    span
+                                    is_optional
+                                    type_id: resolved_type_id)
+                            }
+                        }
+
+                        .error(format("unknown common member of enum: {}.{}", enum_.name, field_name), span)
+                    }
                     else => .error(format("Member field access on value of non-struct type ‘{}’", .type_name(checked_expr_type_id)), span)
                 }
             }
@@ -4135,6 +4237,33 @@ struct Typechecker {
                 }
 
                 .error(format("unknown member of struct: {}.{}", structure.name, field_name), span)
+            }
+            Type::GenericEnumInstance(id: enum_id) | Type::Enum(enum_id) => {
+                if is_optional {
+                    .error("Optional chaining is not allowed on non-optional types", span)
+                }
+
+                let enum_ = .get_enum(enum_id)
+                for field in enum_.fields.iterator() {
+                    let member = .get_variable(field.variable_id)
+
+                    if member.name == field_name {
+                        mut resolved_type_id = .resolve_type_var(type_var_type_id: member.type_id, scope_id)
+                        if is_optional {
+                            resolved_type_id = .find_or_add_type_id(Type::GenericInstance(id: optional_struct_id, args: [resolved_type_id]))
+                        }
+                        // FIXME: Unify with type
+                        .check_member_access(accessor: scope_id, accessee: enum_.scope_id, member, span)
+                        return CheckedExpression::IndexedCommonEnumMember(
+                            expr: checked_expr
+                            index: field_name
+                            span
+                            is_optional
+                            type_id: resolved_type_id)
+                    }
+                }
+
+                .error(format("unknown common member of enum: {}.{}", enum_.name, field_name), span)
             }
             else => .error(format("Member field access on value of non-struct type ‘{}’", .type_name(checked_expr_type_id)), span)
         }

--- a/selfhost/types.jakt
+++ b/selfhost/types.jakt
@@ -864,6 +864,7 @@ struct CheckedEnum {
     name_span: Span
     generic_parameters: [TypeId]
     variants: [CheckedEnumVariant]
+    fields: [CheckedField]
     scope_id: ScopeId
     definition_linkage: DefinitionLinkage
     record_type: RecordType
@@ -1066,6 +1067,7 @@ boxed enum CheckedExpression {
     IndexedDictionary(expr: CheckedExpression, index: CheckedExpression, span: Span, type_id: TypeId)
     IndexedTuple(expr: CheckedExpression, index: usize, span: Span, is_optional: bool, type_id: TypeId)
     IndexedStruct(expr: CheckedExpression, index: String, span: Span, is_optional: bool, type_id: TypeId)
+    IndexedCommonEnumMember(expr: CheckedExpression, index: String, span: Span, is_optional: bool, type_id: TypeId)
     Match(expr: CheckedExpression, match_cases: [CheckedMatchCase], span: Span, type_id: TypeId, all_variants_constant: bool)
     EnumVariantArg(expr: CheckedExpression, arg: CheckedEnumVariantBinding, enum_variant: CheckedEnumVariant, span: Span)
     Call(call: CheckedCall, span: Span, type_id: TypeId)

--- a/tests/parser/unclosed_brace_in_enum.jakt
+++ b/tests/parser/unclosed_brace_in_enum.jakt
@@ -1,4 +1,4 @@
 /// Expect:
-/// - error: "Incomplete enum definition, expected variant name\n"
+/// - error: "Incomplete enum definition, expected variant or field name\n"
 
 enum foo {

--- a/tests/parser/unclosed_brace_in_ref_enum.jakt
+++ b/tests/parser/unclosed_brace_in_ref_enum.jakt
@@ -1,4 +1,4 @@
 /// Expect:
-/// - error: "Incomplete enum definition, expected variant name\n"
+/// - error: "Incomplete enum definition, expected variant or field name\n"
 boxed enum bar {
 

--- a/tests/typechecker/field_access_on_enum.jakt
+++ b/tests/typechecker/field_access_on_enum.jakt
@@ -1,5 +1,5 @@
 /// Expect:
-/// - error: "Member field access on value of non-struct type ‘E’"
+/// - error: "unknown common member of enum: E.x"
 
 enum E {
     A


### PR DESCRIPTION
In cases where all enum variants share a member, the member can now be
hoisted into the enum body, and can be directly accessed via the normal
dot notation.