### PR TITLE
typechecker: Hide type hints for explicitly typed enum fields

### DIFF
--- a/selfhost/typechecker.jakt
+++ b/selfhost/typechecker.jakt
@@ -1079,6 +1079,10 @@ struct Typechecker {
                     )
                 }
 
+                if .dump_type_hints and var_decl.parsed_type is Empty {
+                    .dump_type_hint(type_id, span: var_decl.span)
+                }
+
                 mut module = .current_module()
                 let variable_id = module.add_variable(checked_var)
                 checked_fields.push(CheckedField(variable_id, default_value))
@@ -1687,10 +1691,6 @@ struct Typechecker {
                 variable,
                 default_value: field.default_value))
 
-            if .dump_type_hints {
-                .dump_type_hint(type_id: variable.type_id, span: variable.definition_span)
-            }
-
             common_seen_fields.add(variable.name)
             common_fields.push(field.variable_id)
         }
@@ -1790,7 +1790,7 @@ struct Typechecker {
                             )
                             params.push(CheckedParameter(requires_label: true, variable: checked_var, default_value: None))
 
-                            if .dump_type_hints {
+                            if .dump_type_hints and param.parsed_type is Empty {
                                 .dump_type_hint(type_id, span: param.span)
                             }
 


### PR DESCRIPTION
This pull request disables dumping of type hints for enum fields that have an explicit type, removing hints that duplicate type information.

Before

![image](https://user-images.githubusercontent.com/42888162/197071395-5c537973-5382-498a-9127-a8b33a5c502c.png)

After

![image](https://user-images.githubusercontent.com/42888162/197071499-1f494c87-b2c6-4490-aac3-8a5feb234313.png)

Note that this depends on #1234
