### PR TITLE
all: Remove most uses of .iterator()

### DIFF
--- a/bootstrap/stage0/runtime/jaktlib/arguments.jakt
+++ b/bootstrap/stage0/runtime/jaktlib/arguments.jakt
@@ -10,7 +10,7 @@ struct ArgsParser {
 
     function flag(mut this, anon names: [String]) throws -> bool {
         for i in 0...args.size() {
-            for name in names.iterator() {
+            for name in names {
                 if .args[i] == name {
                     .removed_indices.push(i)
                     return true
@@ -23,7 +23,7 @@ struct ArgsParser {
 
     function option(mut this, anon names: [String]) throws -> String? {
         for i in 1...args.size() {
-            for name in names.iterator() {
+            for name in names {
                 if .args[i] == name {
                     if .args.size() <= i+1 {
                         eprintln("The option '{}' requires a value, but none was supplied", name)
@@ -49,7 +49,7 @@ struct ArgsParser {
     {
         mut result: [String] = []
         for i in 1...args.size() {
-            for name in names.iterator() {
+            for name in names {
                 if .args[i] == name {
                     if .args.size() <= i + 1 {
                         eprintln("The option '{}' requires a value, but none was supplied", name)
@@ -73,7 +73,7 @@ struct ArgsParser {
     function from_args(anon args: [String]) throws -> ArgsParser {
         mut parser = ArgsParser(args, removed_indices: [], definitely_positional_args: [])
         mut i = 0uz
-        for arg in parser.args.iterator() {
+        for arg in parser.args {
             if arg == "--" {
                 parser.definitely_positional_args = parser.args[(i+1)..parser.args.size()].to_array()
                 parser.args = parser.args[0..i].to_array()
@@ -94,7 +94,7 @@ struct ArgsParser {
             }
         }
 
-        for arg in .definitely_positional_args.iterator() {
+        for arg in .definitely_positional_args {
             remaining.push(arg)
         }
 

--- a/jakttest/jakttest.jakt
+++ b/jakttest/jakttest.jakt
@@ -151,7 +151,7 @@ function print_usage()  {
 function compare_test(bytes: [u8], expected: String) throws -> bool {
     // first, build up the content to compare to
     mut builder = StringBuilder::create()
-    for b in bytes.iterator() {
+    for b in bytes {
         builder.append(b)
     }
 
@@ -170,7 +170,7 @@ function compare_error(bytes: [u8], expected: String) throws -> bool {
     // first, build up the content to compare to
     mut builder = StringBuilder::create()
 
-    for b in bytes.iterator() {
+    for b in bytes {
         if b == 0xd {
             // skip
         } else if b == 0xa {
@@ -681,7 +681,7 @@ function main(args: [String]) {
     }
 
     if not parsed_options.errors.is_empty() {
-        for error in parsed_options.errors.iterator() {
+        for error in parsed_options.errors {
             eprintln("Error: {}", error)
         }
         print_usage()
@@ -695,7 +695,7 @@ function main(args: [String]) {
     tests.ensure_capacity(parsed_options.files.size())
 
     // parse all files to collect the actual work we have to do
-    for file_name in parsed_options.files.iterator() {
+    for file_name in parsed_options.files {
         mut file = File::open_for_reading(file_name)
         let contents = file.read_all()
         let result = Parser::parse(input: contents)
@@ -748,7 +748,7 @@ function main(args: [String]) {
     )
 
     // delete directories
-    for dir in directories.iterator() {
+    for dir in directories {
         for file in fs::list_directory(path: dir) {
             if file == "." or file == ".." {
                 continue
@@ -771,7 +771,7 @@ function main(args: [String]) {
         eprintln("Showing why tests failed:")
         let reasons = run_result.failed_reasons!
         mut is_first = true
-        for file in reasons.keys().iterator() {
+        for file in reasons.keys() {
             if not is_first {
                 eprintln("----------------------------------------")
             } else {
@@ -835,7 +835,7 @@ function main(args: [String]) {
                 }
             }
 
-            for line in output.split('\n').iterator() {
+            for line in output.split('\n') {
                 eprintln("\x1b[m\x1b[1m|\x1b[m\t{}", line)
             }
         }
@@ -843,7 +843,7 @@ function main(args: [String]) {
         if not bad_formatted_tests.is_empty() {
             eprintln("==============================")
             eprintln("These tests failed to parse because they didn't have an expectation or skip message:")
-            for file in bad_formatted_tests.iterator() {
+            for file in bad_formatted_tests {
                 eprintln("\x1b[1m|\x1b[m\t{}", file)
             }
         }
@@ -858,7 +858,7 @@ function main(args: [String]) {
 function bytes_to_string(anon bytes: [u8]) throws -> String {
     mut builder = StringBuilder::create()
 
-    for byte in bytes.iterator() {
+    for byte in bytes {
         builder.append(byte)
     }
 

--- a/runtime/jaktlib/arguments.jakt
+++ b/runtime/jaktlib/arguments.jakt
@@ -10,7 +10,7 @@ struct ArgsParser {
 
     function flag(mut this, anon names: [String]) throws -> bool {
         for i in 0...args.size() {
-            for name in names.iterator() {
+            for name in names {
                 if .args[i] == name {
                     .removed_indices.push(i)
                     return true
@@ -23,7 +23,7 @@ struct ArgsParser {
 
     function option(mut this, anon names: [String]) throws -> String? {
         for i in 1...args.size() {
-            for name in names.iterator() {
+            for name in names {
                 if .args[i] == name {
                     if .args.size() <= i+1 {
                         eprintln("The option '{}' requires a value, but none was supplied", name)
@@ -49,7 +49,7 @@ struct ArgsParser {
     {
         mut result: [String] = []
         for i in 1...args.size() {
-            for name in names.iterator() {
+            for name in names {
                 if .args[i] == name {
                     if .args.size() <= i + 1 {
                         eprintln("The option '{}' requires a value, but none was supplied", name)
@@ -73,7 +73,7 @@ struct ArgsParser {
     function from_args(anon args: [String]) throws -> ArgsParser {
         mut parser = ArgsParser(args, removed_indices: [], definitely_positional_args: [])
         mut i = 0uz
-        for arg in parser.args.iterator() {
+        for arg in parser.args {
             if arg == "--" {
                 parser.definitely_positional_args = parser.args[(i+1)..parser.args.size()].to_array()
                 parser.args = parser.args[0..i].to_array()
@@ -94,7 +94,7 @@ struct ArgsParser {
             }
         }
 
-        for arg in .definitely_positional_args.iterator() {
+        for arg in .definitely_positional_args {
             remaining.push(arg)
         }
 

--- a/samples/apps/read_all.jakt
+++ b/samples/apps/read_all.jakt
@@ -4,7 +4,7 @@
 function parse_to_string(file_path: String) throws -> String {
     mut file = File::open_for_reading(file_path)
     mut builder = StringBuilder::create()
-    for b in file.read_all().iterator() {
+    for b in file.read_all() {
         builder.append(b)
     }
     return builder.to_string()

--- a/samples/arrays/array_iterator.jakt
+++ b/samples/arrays/array_iterator.jakt
@@ -3,7 +3,7 @@
 
 function main() {
     let words = ["foo", "bar", "baz"]
-    for word in words.iterator() {
+    for word in words {
         println("{}", word)
     }
 }

--- a/samples/arrays/slice.jakt
+++ b/samples/arrays/slice.jakt
@@ -10,7 +10,7 @@ function main() {
     
     println("slice size: {}", slice.size())
 
-    for y in slice.iterator() {
+    for y in slice {
         println("{}", y)
     }
 

--- a/samples/compiletime_execution/dict.jakt
+++ b/samples/compiletime_execution/dict.jakt
@@ -38,7 +38,7 @@ comptime keys() throws -> bool {
 comptime iterator() throws -> bool {
     mut dict = ["m":'m',"n":'n',"o":'o']
     mut output = ""
-    for (key, val) in dict.iterator() {
+    for (key, val) in dict {
         output += format("{}=>", key) + format("{}\n", key)
     }
     return output == "m=>m\nn=>n\no=>o\n"

--- a/samples/compiletime_execution/set.jakt
+++ b/samples/compiletime_execution/set.jakt
@@ -29,7 +29,7 @@ comptime capacity() throws -> bool {
 comptime set_iterator() throws -> bool {
     let set = {4u8, 5u8, 6u8, 7u8}
     mut output = ""
-    for val in set.iterator() {
+    for val in set {
         output += format("{}", val)
     }
     return output == "4567"

--- a/samples/dictionaries/iterator.jakt
+++ b/samples/dictionaries/iterator.jakt
@@ -3,7 +3,7 @@
 
 function main() {
     let dictionary = ["well": 1, "hello": 2, "friends": 3]
-    for item in dictionary.iterator() {
+    for item in dictionary {
         println("{}: {}", item.0, item.1)
     }
 }

--- a/samples/sets/iterator.jakt
+++ b/samples/sets/iterator.jakt
@@ -3,7 +3,7 @@
 
 function main() {
     let set = {1, 2, 3, 4}
-    for value in set.iterator() {
+    for value in set {
         println("{}", value)
     }
 }

--- a/samples/tuples/destructuring_assignment_for.jakt
+++ b/samples/tuples/destructuring_assignment_for.jakt
@@ -4,7 +4,7 @@
 function main() {
     mut list = [(1, "Hello"), (2, "World")]
 
-    for (idx, word) in list.iterator() {
+    for (idx, word) in list {
         println("{}, {}" idx, word)
     }
 }

--- a/selfhost/build.jakt
+++ b/selfhost/build.jakt
@@ -52,7 +52,7 @@ struct ParallelExecutionPool {
             pids_to_remove.set(finished_pid!, finished_status)
         }
 
-        for (index, process) in .pids.iterator() {
+        for (index, process) in .pids {
             // Swallow errors here, we'll get ECHLD for at least the one above
             let status = try poll_process_exit(&process) catch {
                 pids_to_remove.set(index, finished_status)
@@ -63,7 +63,7 @@ struct ParallelExecutionPool {
             }
         }
 
-        for (index, status) in pids_to_remove.iterator() {
+        for (index, status) in pids_to_remove {
             .pids.remove(index)
             .completed.set(index, status)
         }
@@ -76,7 +76,7 @@ struct ParallelExecutionPool {
     }
 
     function kill_all(mut this) throws -> void {
-        for (_, process) in .pids.iterator() {
+        for (_, process) in .pids {
             forcefully_kill_process(&process)
         }
     }
@@ -101,8 +101,8 @@ struct Builder {
         compiler_invocation: &function(input_filename: String, output_filename: String) throws -> [String]
     ) throws -> void {
         mut ids: {usize} = {}
-        for file_name in .files_to_compile.iterator() {
-            for (id, exit_result) in .pool.completed.iterator() {
+        for file_name in .files_to_compile {
+            for (id, exit_result) in .pool.completed {
                 if exit_result.exit_code != 0 {
                     eprintln("Error: Compilation failed")
                     .pool.kill_all()
@@ -127,7 +127,7 @@ struct Builder {
 
         .pool.wait_for_all_jobs_to_complete()
 
-        for (id, exit_result) in .pool.completed.iterator() {
+        for (id, exit_result) in .pool.completed {
             if exit_result.exit_code != 0 {
                 eprintln("Error: Compilation failed")
                 throw Error::from_errno(1)
@@ -143,7 +143,7 @@ struct Builder {
             "cr"
             archive_filename
         ]
-        for file in .linked_files.iterator() {
+        for file in .linked_files {
             args.push(file)
         }
 
@@ -167,10 +167,10 @@ struct Builder {
             "-o"
             output_filename
         ]
-        for file in .linked_files.iterator() {
+        for file in .linked_files {
             args.push(file)
         }
-        for arg in extra_arguments.iterator() {
+        for arg in extra_arguments {
             args.push(arg)
         }
 

--- a/selfhost/codegen.jakt
+++ b/selfhost/codegen.jakt
@@ -123,7 +123,7 @@ struct CodegenDebugInfo {
     }
 
     function gather_line_spans(mut this) throws {
-        for file in .compiler.file_ids.iterator() {
+        for file in .compiler.file_ids {
 
             if file.0 == "__prelude__" {
                 continue
@@ -184,8 +184,8 @@ struct CodeGenerator {
     function topologically_sort_modules(this) throws -> [ModuleId] {
         mut in_degrees: [usize:i64] = [:]
 
-        for module in .program.modules.iterator() {
-            for imported_module in module.imports.iterator() {
+        for module in .program.modules {
+            for imported_module in module.imports {
                 let existing = in_degrees.get(imported_module.id) ?? 0
                 in_degrees.set(imported_module.id, existing + 1)
             }
@@ -196,7 +196,7 @@ struct CodeGenerator {
         }
 
         mut stack: [ModuleId] = []
-        for module in .program.modules.iterator() {
+        for module in .program.modules {
             if in_degrees[module.id.id] == 0 {
                 stack.push(module.id)
             }
@@ -206,7 +206,7 @@ struct CodeGenerator {
         while not stack.is_empty() {
             let id = stack.pop()!
             sorted_modules.push(id)
-            for imported_module in .program.modules[id.id].imports.iterator() {
+            for imported_module in .program.modules[id.id].imports {
                 let module_in_degrees = in_degrees[imported_module.id]
                 in_degrees.set(imported_module.id, module_in_degrees - 1)
                 if module_in_degrees == 1 {
@@ -289,7 +289,7 @@ struct CodeGenerator {
         )
 
 
-        for as_forward in [true, false].iterator() {
+        for as_forward in [true, false] {
             for idx in sorted_modules.size()..0 {
                 // Module forward declarations header (if as_forward), or module implementation (if not as_forward)
                 let i = sorted_modules[idx - 1].id
@@ -315,14 +315,14 @@ struct CodeGenerator {
                 let scope = generator.program.get_scope(scope_id)
 
                 if as_forward {
-                    for child_scope in scope.children.iterator() {
+                    for child_scope in scope.children {
                         let scope = generator.program.get_scope(scope_id: child_scope)
                         if scope.import_path_if_extern.has_value() {
                             let has_name = scope.namespace_name.has_value()
                             if has_name {
                                 output += format("namespace {} {{\n", scope.namespace_name!)
                             }
-                            for action in scope.before_extern_include.iterator() {
+                            for action in scope.before_extern_include {
                                 match action {
                                     Define(name, value) => {
                                         output += format("#ifdef {}\n", name)
@@ -338,7 +338,7 @@ struct CodeGenerator {
                                 }
                             }
                             output += format("#include <{}>\n", scope.import_path_if_extern!)
-                            for action in scope.after_extern_include.iterator() {
+                            for action in scope.after_extern_include {
                                 match action {
                                     Define(name, value) => {
                                         output += format("#ifdef {}\n", name)
@@ -358,7 +358,7 @@ struct CodeGenerator {
                             }
                         }
                     }
-                    for id in module.imports.iterator() {
+                    for id in module.imports {
                         let module = generator.program.modules[id.id]
                         output += format("#include \"{}.h\"\n", module.name)
                     }
@@ -406,7 +406,7 @@ struct CodeGenerator {
         }
         visited.add(type_id.to_string())
         if encoded_dependency_graph.contains(encoded_type_id) {
-            for dependency in encoded_dependency_graph.get(encoded_type_id)!.iterator() {
+            for dependency in encoded_dependency_graph.get(encoded_type_id)! {
                 .postorder_traversal(encoded_type_id: dependency, visited, encoded_dependency_graph, output)
             }
         }
@@ -416,7 +416,7 @@ struct CodeGenerator {
     function produce_codegen_dependency_graph(this, scope: Scope) throws -> [String : [String]] {
         mut dependency_graph: [String : [String]] = [:]
 
-        for type_ in scope.types.iterator() {
+        for type_ in scope.types {
             dependency_graph.set(type_.1.to_string(), .extract_dependencies_from(type_id: type_.1, dependency_graph, top_level: true))
         }
 
@@ -427,7 +427,7 @@ struct CodeGenerator {
         mut dependencies: [String] = []
 
         if dependency_graph.contains(type_id.to_string()) {
-            for dependency in dependency_graph.get(type_id.to_string())!.iterator() {
+            for dependency in dependency_graph.get(type_id.to_string())! {
                 dependencies.push(dependency)
             }
             return dependencies
@@ -442,7 +442,7 @@ struct CodeGenerator {
             else => []
         }
 
-        for dependency in inner_dependencies.iterator() {
+        for dependency in inner_dependencies {
             dependencies.push(dependency)
         }
 
@@ -466,23 +466,23 @@ struct CodeGenerator {
         dependencies.push(enum_.type_id.to_string())
         if not enum_.underlying_type_id.equals(unknown_type_id()) {
             let inner_dependencies = .extract_dependencies_from(type_id: enum_.underlying_type_id, dependency_graph, top_level: false)
-            for dependency in inner_dependencies.iterator() {
+            for dependency in inner_dependencies {
                 dependencies.push(dependency)
             }
         }
-        for variant in enum_.variants.iterator() {
+        for variant in enum_.variants {
             match variant {
                 Typed(type_id) => {
                     let inner_dependencies = .extract_dependencies_from(type_id, dependency_graph, top_level: false)
-                    for dependency in inner_dependencies.iterator() {
+                    for dependency in inner_dependencies {
                         dependencies.push(dependency)
                     }
                 }
                 StructLike(fields) => {
-                    for field in fields.iterator() {
+                    for field in fields {
                         let type_id = .program.get_variable(field).type_id
                         let inner_dependencies = .extract_dependencies_from(type_id, dependency_graph, top_level: false)
-                        for dependency in inner_dependencies.iterator() {
+                        for dependency in inner_dependencies {
                             dependencies.push(dependency)
                         }
                     }
@@ -511,13 +511,13 @@ struct CodeGenerator {
         }
 
         if not args.is_empty() {
-            for inner_type in args.iterator() {
+            for inner_type in args {
                 let inner_dependencies = match .program.get_type(inner_type) {
                     Enum | Struct => .extract_dependencies_from(type_id: inner_type, dependency_graph, top_level: false)
                     else => []
                 }
 
-                for dependency in inner_dependencies.iterator() {
+                for dependency in inner_dependencies {
                     dependencies.push(dependency)
                 }
             }
@@ -532,10 +532,10 @@ struct CodeGenerator {
 
         dependencies.push(struct_.type_id.to_string())
         // The struct's fields are also dependencies.
-        for field in struct_.fields.iterator() {
+        for field in struct_.fields {
             let type_id = .program.get_variable(field.variable_id).type_id
             let inner_dependencies = .extract_dependencies_from(type_id, dependency_graph, top_level: false)
-            for dependency in inner_dependencies.iterator() {
+            for dependency in inner_dependencies {
                 dependencies.push(dependency)
             }
         }
@@ -551,10 +551,10 @@ struct CodeGenerator {
         if as_forward {
             mut output = ""
             let encoded_dependency_graph = .produce_codegen_dependency_graph(scope)
-            for entry in encoded_dependency_graph.iterator() {
+            for entry in encoded_dependency_graph {
                 let traversal: [TypeId] = []
                 .postorder_traversal(encoded_type_id: entry.0, visited: seen_types, dependency_graph: encoded_dependency_graph, output: traversal)
-                for type_id in traversal.iterator() {
+                for type_id in traversal {
                     let type_ = .program.get_type(type_id)
                     match type_ {
                         Enum(enum_id) => {
@@ -590,7 +590,7 @@ struct CodeGenerator {
                 }
             }
 
-            for (_, struct_id) in scope.structs.iterator() {
+            for (_, struct_id) in scope.structs {
                 if not struct_id.module.equals(current_module.id) {
                     continue
                 }
@@ -602,7 +602,7 @@ struct CodeGenerator {
                 output += "\n"
             }
 
-            for (_, enum_id) in scope.enums.iterator() {
+            for (_, enum_id) in scope.enums {
                 if not enum_id.module.equals(current_module.id) {
                     continue
                 }
@@ -614,7 +614,7 @@ struct CodeGenerator {
                 output += "\n"
             }
 
-            for (_, function_id) in scope.functions.iterator() {
+            for (_, function_id) in scope.functions {
                 if not function_id.module.equals(current_module.id) {
                     continue
                 }
@@ -635,7 +635,7 @@ struct CodeGenerator {
                 }
             }
 
-            for child_scope_id in scope.children.iterator() {
+            for child_scope_id in scope.children {
                 let child_scope = .program.get_scope(child_scope_id)
                 if child_scope.namespace_name.has_value() {
                     let name = child_scope.namespace_name!
@@ -654,7 +654,7 @@ struct CodeGenerator {
         }
 
         mut output = ""
-        for (_, function_id) in scope.functions.iterator() {
+        for (_, function_id) in scope.functions {
             if not function_id.module.equals(current_module.id) {
                 continue
             }
@@ -675,7 +675,7 @@ struct CodeGenerator {
             }
         }
 
-        for (_, struct_id) in scope.structs.iterator() {
+        for (_, struct_id) in scope.structs {
             if not struct_id.module.equals(current_module.id) {
                 continue
             }
@@ -692,7 +692,7 @@ struct CodeGenerator {
             output += .codegen_debug_description_getter(struct_)
 
             let scope = .program.get_scope(struct_.scope_id)
-            for (_, function_id) in scope.functions.iterator() {
+            for (_, function_id) in scope.functions {
                 let function_ = .program.get_function(function_id)
                 let previous_function = .current_function
                 .current_function = function_
@@ -708,7 +708,7 @@ struct CodeGenerator {
             }
         }
 
-        for (_, enum_id) in scope.enums.iterator() {
+        for (_, enum_id) in scope.enums {
             if not enum_id.module.equals(current_module.id) {
                 continue
             }
@@ -727,7 +727,7 @@ struct CodeGenerator {
             }
 
             let scope = .program.get_scope(enum_.scope_id)
-            for (_, function_id) in scope.functions.iterator() {
+            for (_, function_id) in scope.functions {
                 let function_ = .program.get_function(function_id)
                 let previous_function = .current_function
                 .current_function = function_
@@ -739,7 +739,7 @@ struct CodeGenerator {
             }
         }
 
-        for child_scope_id in scope.children.iterator() {
+        for child_scope_id in scope.children {
             let child_scope = .program.get_scope(child_scope_id)
             if child_scope.namespace_name.has_value() {
                 let name = child_scope.namespace_name!
@@ -767,7 +767,7 @@ struct CodeGenerator {
             output += scope.namespace_name!
             output += " {\n"
         }
-        for (_, struct_id) in scope.structs.iterator() {
+        for (_, struct_id) in scope.structs {
             if not struct_id.module.equals(current_module.id) {
                 continue
             }
@@ -776,7 +776,7 @@ struct CodeGenerator {
             output += "\n"
         }
 
-        for (_, enum_id) in scope.enums.iterator() {
+        for (_, enum_id) in scope.enums {
             if not enum_id.module.equals(current_module.id) {
                 continue
             }
@@ -785,11 +785,11 @@ struct CodeGenerator {
             output += "\n"
         }
 
-        for child in scope.children.iterator() {
+        for child in scope.children {
             output += .codegen_namespace_predecl(scope: .program.get_scope(child), current_module)
         }
 
-        for (_, function_id) in scope.functions.iterator() {
+        for (_, function_id) in scope.functions {
             if not function_id.module.equals(current_module.id) {
                 continue
             }
@@ -820,7 +820,7 @@ struct CodeGenerator {
         if not function_.generics.params.is_empty() {
             output += "template <"
             mut first = true
-            for generic_parameter in function_.generics.params.iterator() {
+            for generic_parameter in function_.generics.params {
                 if first {
                     first = false
                 } else {
@@ -885,7 +885,7 @@ struct CodeGenerator {
         output += "("
 
         mut first = true
-        for param in function_.params.iterator() {
+        for param in function_.params {
             if first and param.variable.name == "this" {
                 continue
             }
@@ -929,7 +929,7 @@ struct CodeGenerator {
         if not struct_.generic_parameters.is_empty() {
             output += "template <"
             mut first = true
-            for generic_parameter in struct_.generic_parameters.iterator() {
+            for generic_parameter in struct_.generic_parameters {
                 if first {
                     first = false
                 } else {
@@ -962,7 +962,7 @@ struct CodeGenerator {
 
         mut generic_parameter_names: [String] = []
         if not struct_.generic_parameters.is_empty() {
-            for generic_parameter in struct_.generic_parameters.iterator() {
+            for generic_parameter in struct_.generic_parameters {
                 generic_parameter_names.push(.codegen_type(generic_parameter.type_id))
             }
 
@@ -974,7 +974,7 @@ struct CodeGenerator {
                 mut class_name_with_generics = ""
                 class_name_with_generics += struct_.name
                 mut first = true
-                for generic_parameter in struct_.generic_parameters.iterator() {
+                for generic_parameter in struct_.generic_parameters {
                     if not first {
                         class_name_with_generics += ", "
                     } else {
@@ -1010,7 +1010,7 @@ struct CodeGenerator {
             else => {}
         }
 
-        for field in struct_.fields.iterator() {
+        for field in struct_.fields {
             let variable = .program.get_variable(field.variable_id)
             output += .codegen_type(variable.type_id)
             output += " "
@@ -1019,7 +1019,7 @@ struct CodeGenerator {
         }
 
         let scope = .program.get_scope(struct_.scope_id)
-        for fn in scope.functions.iterator() {
+        for fn in scope.functions {
 
             let function_ = .program.get_function(fn.1)
 
@@ -1069,7 +1069,7 @@ struct CodeGenerator {
 
         let is_generic = not enum_.generic_parameters.is_empty()
         mut template_args_array: [String] = []
-        for generic_parameter in enum_.generic_parameters.iterator() {
+        for generic_parameter in enum_.generic_parameters {
             if .program.get_type(generic_parameter.type_id) is TypeVariable(name) {
                 template_args_array.push("typename " + name)
             }
@@ -1077,7 +1077,7 @@ struct CodeGenerator {
         mut template_args = join(template_args_array, separator: ", ")
 
         output += format("namespace {}_Details", enum_.name) + " {\n"
-        for variant in enum_.variants.iterator() {
+        for variant in enum_.variants {
             match variant {
                 Untyped(name) | StructLike(name) | Typed(name) => {
                     if is_generic {
@@ -1103,7 +1103,7 @@ struct CodeGenerator {
         if not enum_.underlying_type_id.equals(void_type_id()) {
             if .program.is_integer(enum_.underlying_type_id) {
                 output += "enum class " + enum_.name + ": " + .codegen_type(enum_.underlying_type_id) + " {\n"
-                for variant in enum_.variants.iterator() {
+                for variant in enum_.variants {
                     output += match variant {
                         WithValue(name, expr) => name + " = " + .codegen_expression(expr) + ",\n"
                         else => {
@@ -1120,7 +1120,7 @@ struct CodeGenerator {
 
         let is_generic = not enum_.generic_parameters.is_empty()
         mut generic_parameter_names: [String] = []
-        for generic_parameter in enum_.generic_parameters.iterator() {
+        for generic_parameter in enum_.generic_parameters {
             if .program.get_type(generic_parameter.type_id) is TypeVariable(name) {
                 generic_parameter_names.push(name)
             }
@@ -1128,13 +1128,13 @@ struct CodeGenerator {
         mut template_args = join(prepend_to_each(generic_parameter_names, prefix: "typename "), separator: ", ")
 
         mut common_fields: [(String, String)] = []
-        for field in enum_.fields.iterator() {
+        for field in enum_.fields {
             let variable = .program.get_variable(field.variable_id)
             common_fields.push((variable.name, .codegen_type(variable.type_id)))
         }
 
         output += "namespace " + enum_.name + "_Details {\n"
-        for variant in enum_.variants.iterator() {
+        for variant in enum_.variants {
             let fields = match variant {
                 Untyped(name) => {
                     if is_generic {
@@ -1145,7 +1145,7 @@ struct CodeGenerator {
                 }
                 StructLike(name, fields: own_fields) => {
                     mut fields: [(String, String)] = []
-                    for field in own_fields.iterator() {
+                    for field in own_fields {
                         let variable = .program.get_variable(field)
                         fields.push((variable.name, .codegen_type(variable.type_id)))
                     }
@@ -1158,7 +1158,7 @@ struct CodeGenerator {
                 }
                 Typed(name, type_id) => {
                     mut fields: [(String, String)] = []
-                    for field in common_fields.iterator() {
+                    for field in common_fields {
                         fields.push(field)
                     }
                     fields.push(("value", .codegen_type(type_id)))
@@ -1175,7 +1175,7 @@ struct CodeGenerator {
                 }
             }
 
-            for (name, type) in fields.iterator() {
+            for (name, type) in fields {
                 output += format("{} {};\n", type, name)
             }
             if not fields.is_empty() {
@@ -1205,7 +1205,7 @@ struct CodeGenerator {
         }
         mut variant_names: [String] = []
         mut variant_arguments_array: [String] = []
-        for variant in enum_.variants.iterator() {
+        for variant in enum_.variants {
             mut argument = enum_.name + "_Details::" + variant.name()
             if is_generic {
                 argument += format("<{}>", join(generic_parameter_names, separator: ", "))
@@ -1226,7 +1226,7 @@ struct CodeGenerator {
         output += " {\n"
         output += "using Variant<" + variant_args + ">::Variant;\n"
 
-        for name in variant_names.iterator() {
+        for name in variant_names {
             output += "    using " +  name + " = " + enum_.name + "_Details::" + name
             if is_generic {
                 output += "<"
@@ -1252,7 +1252,7 @@ struct CodeGenerator {
             output += .codegen_enum_debug_description_getter(enum_, is_inline: true)
         }
 
-        for (field_name, type) in common_fields.iterator() {
+        for (field_name, type) in common_fields {
             output += format("{} const& {}() const {{ switch(this->index()) {{", type, field_name)
             for i in 0..enum_.variants.size() {
                 let variant = enum_.variants[i]
@@ -1265,7 +1265,7 @@ struct CodeGenerator {
         }
 
         let enum_scope = .program.get_scope(enum_.scope_id)
-        for function_item in enum_scope.functions.iterator() {
+        for function_item in enum_scope.functions {
             let function_ = .program.get_function(function_item.1)
 
             let previous_function_id = .current_function
@@ -1294,7 +1294,7 @@ struct CodeGenerator {
         if not is_inline and not struct_.generic_parameters.is_empty() {
             output += "template <"
             mut first = true
-            for param in struct_.generic_parameters.iterator() {
+            for param in struct_.generic_parameters {
                 if first {
                     first = false
                 } else {
@@ -1318,7 +1318,7 @@ struct CodeGenerator {
         output += "JaktInternal::PrettyPrint::ScopedLevelIncrease increase_indent {};\n"
 
         mut i = 0uz
-        for field in struct_.fields.iterator() {
+        for field in struct_.fields {
             let field_var = .program.get_variable(field.variable_id)
             output += "TRY(JaktInternal::PrettyPrint::output_indentation(builder));"
             output += format("TRY(builder.append(\"{}: \"));", field_var.name)
@@ -1357,7 +1357,7 @@ struct CodeGenerator {
         if not is_inline and not enum_.generic_parameters.is_empty() {
             output += "template <"
             mut first = true
-            for param in enum_.generic_parameters.iterator() {
+            for param in enum_.generic_parameters {
                 if first {
                     first = false
                 } else {
@@ -1390,7 +1390,7 @@ struct CodeGenerator {
                     output += "{\n";
                     output += "JaktInternal::PrettyPrint::ScopedLevelIncrease increase_indent {};\n"
                     mut i = 0uz
-                    for field in fields.iterator() {
+                    for field in fields {
                         output += "TRY(JaktInternal::PrettyPrint::output_indentation(builder));\n"
                         let var = .program.get_variable(field)
                         if .program.is_string(var.type_id){
@@ -1431,7 +1431,7 @@ struct CodeGenerator {
         let generic_type_args = join(generic_parameter_names, separator: ", ")
 
         mut qualified_name = ""
-        for namespace_ in .namespace_stack.iterator() {
+        for namespace_ in .namespace_stack {
             qualified_name += format("{}::", namespace_)
         }
 
@@ -1667,7 +1667,7 @@ struct CodeGenerator {
                     }
                     // FIXME: This should be a call to find(), but we do not yet provide the needed operator== for that
                     mut variant_index = 0;
-                    for variant in enum_.variants.iterator() {
+                    for variant in enum_.variants {
                         if variant.name() == name{
                             break
                         }
@@ -1712,7 +1712,7 @@ struct CodeGenerator {
         }
         NamespacedVar(namespaces, var) => {
             mut output = ""
-            for ns in namespaces.iterator() {
+            for ns in namespaces {
                 output += ns.name + "::"
             }
             yield output + var.name
@@ -1752,7 +1752,7 @@ struct CodeGenerator {
                 output += .codegen_type(inner_type_id)
                 output += ">::create_with({"
                 mut first = true
-                for val in vals.iterator() {
+                for val in vals {
                     if not first {
                         output += ", "
                     } else {
@@ -1773,7 +1773,7 @@ struct CodeGenerator {
                 .codegen_type(value_type_id))
 
             mut first = true
-            for (key, value) in vals.iterator() {
+            for (key, value) in vals {
                 if not first {
                     output += ", "
                 } else {
@@ -1795,7 +1795,7 @@ struct CodeGenerator {
             mut output = ""
             output += format("({}((Set<{}>::create_with_values({{", .current_error_handler(), .codegen_type(inner_type_id))
             mut first = true
-            for value in vals.iterator() {
+            for value in vals {
                 if not first {
                     output += ", "
                 } else {
@@ -1810,7 +1810,7 @@ struct CodeGenerator {
             mut output = ""
             output += "(Tuple{"
             mut first = true
-            for val in vals.iterator() {
+            for val in vals {
                 if not first {
                     output += ", "
                 } else {
@@ -1825,14 +1825,14 @@ struct CodeGenerator {
         }
         Function(captures, params, can_throw, block, return_type_id, pseudo_function_id) => {
             mut generated_captures: [String] = []
-            for capture in captures.iterator() {
+            for capture in captures {
                 generated_captures.push(match capture {
                     ByValue => capture.name()
                     ByReference | ByMutableReference => format("&{}", capture.name())
                 })
             }
             mut generated_params: [String] = []
-            for param in params.iterator() {
+            for param in params {
                 generated_params.push(format("{} {}", .codegen_type(param.variable.type_id), param.variable.name))
             }
             let return_type = match can_throw {
@@ -2003,7 +2003,7 @@ struct CodeGenerator {
         mut output = ""
 
         mut is_generic_enum: bool = false
-        for case_ in cases.iterator() {
+        for case_ in cases {
             if case_ is EnumVariant {
                 is_generic_enum = true
                 break
@@ -2030,7 +2030,7 @@ struct CodeGenerator {
 
         mut has_default = false
         mut first = true
-        for case_ in cases.iterator() {
+        for case_ in cases {
             match case_ {
                 EnumVariant(name, args, subject_type_id, scope_id, body) => {
                     let enum_ = .program.get_enum(match .program.get_type(subject_type_id) {
@@ -2042,7 +2042,7 @@ struct CodeGenerator {
                     })
                     // FIXME: This should be a call to find(), but we do not yet provide the needed operator== for that
                     mut variant_index = 0;
-                    for variant in enum_.variants.iterator() {
+                    for variant in enum_.variants {
                         if variant.name() == name{
                             break
                         }
@@ -2064,7 +2064,7 @@ struct CodeGenerator {
                     output += variant_type_name
                     output += ">();\n"
 
-                    for arg in args.iterator() {
+                    for arg in args {
                         output += "auto& "
                         output += arg.binding
                         output += " = __jakt_match_value."
@@ -2153,7 +2153,7 @@ struct CodeGenerator {
             output += "switch(__jakt_match_variant.index()) {\n"
 
             mut has_default = false
-            for match_case in match_cases.iterator() {
+            for match_case in match_cases {
                 match match_case {
                     EnumVariant(name, args, subject_type_id, index, scope_id, body) => {
                         let enum_type = .program.get_type(subject_type_id)
@@ -2195,7 +2195,7 @@ struct CodeGenerator {
                                     name)
 
                                 if not args.is_empty() {
-                                    for arg in args.iterator() {
+                                    for arg in args {
                                         let var = .program.find_var_in_scope(scope_id, var: arg.binding)!
                                         output += .codegen_type(var.type_id)
                                         output += " const& "
@@ -2568,7 +2568,7 @@ struct CodeGenerator {
 
         if not generic_parameters.is_empty() {
             mut types: [String] = []
-            for gen_param in generic_parameters.iterator() {
+            for gen_param in generic_parameters {
                 types.push(.codegen_type_possibly_as_namespace(type_id: gen_param, as_namespace: false))
             }
             output += format("<{}>", join(types, separator: ", "))
@@ -2577,7 +2577,7 @@ struct CodeGenerator {
         output += "("
 
         mut first = true
-        for (_, expr) in call.args.iterator() {
+        for (_, expr) in call.args {
             if first {
                 first = false
             } else {
@@ -2669,7 +2669,7 @@ struct CodeGenerator {
                                     output += struct_.name
                                     output += "<"
                                     mut first = true
-                                    for arg in args.iterator() {
+                                    for arg in args {
                                         if not first {
                                             output += ", "
                                         } else {
@@ -2682,7 +2682,7 @@ struct CodeGenerator {
                                     output += call.name
                                     output += "<"
                                     mut first = true
-                                    for arg in args.iterator() {
+                                    for arg in args {
                                         if not first {
                                             output += ", "
                                         } else {
@@ -2773,14 +2773,14 @@ struct CodeGenerator {
 
                 if not generic_parameters.is_empty() {
                     mut types: [String] = []
-                    for gen_param in generic_parameters.iterator() {
+                    for gen_param in generic_parameters {
                         types.push(.codegen_type_possibly_as_namespace(type_id: gen_param, as_namespace: false))
                     }
                     output += format("<{}>", join(types, separator: ", "))
                 }
 
                 mut arguments: [String] = []
-                for arg in call.args.iterator() {
+                for arg in call.args {
                     arguments.push(.codegen_expression(arg.1))
                 }
 
@@ -2804,7 +2804,7 @@ struct CodeGenerator {
 
         mut index: usize = 0
 
-        for namespace_ in call.namespace_.iterator() {
+        for namespace_ in call.namespace_ {
             // hack warning: this is to get around C++'s limitation that a constructor
             // can't be called like other static methods
             if index == call.namespace_.size() - 1 and namespace_.name == call.name {
@@ -2815,7 +2815,7 @@ struct CodeGenerator {
             if namespace_.generic_parameters.has_value() {
                 output += "<"
                 mut i: usize = 0
-                for param in namespace_.generic_parameters!.iterator() {
+                for param in namespace_.generic_parameters! {
                     output += .codegen_type(param)
                     if i != namespace_.generic_parameters!.size() - 1 {
                         output += ","
@@ -2851,7 +2851,7 @@ struct CodeGenerator {
 
         output += "{\n"
 
-        for statement in block.statements.iterator() {
+        for statement in block.statements {
             output += .codegen_statement(statement)
         }
 
@@ -2958,7 +2958,7 @@ struct CodeGenerator {
                 mut output = ""
                 output += .codegen_statement(statement: var_decl)
 
-                for v in vars.iterator() {
+                for v in vars {
                     output += .codegen_statement(statement: v)
                 }
                 yield output
@@ -2981,7 +2981,7 @@ struct CodeGenerator {
             }
             InlineCpp(lines) => {
                 mut output = ""
-                for line in lines.iterator() {
+                for line in lines {
                     mut escaped_line = line
                     escaped_line = escaped_line.replace(replace: "\\\"", with: "\"")
                     escaped_line = escaped_line.replace(replace: "\\\\", with: "\\")
@@ -3079,7 +3079,7 @@ struct CodeGenerator {
             }
             output += "("
             mut first = true
-            for param in params.iterator() {
+            for param in params {
                 if first {
                     first = false
                 } else {
@@ -3137,7 +3137,7 @@ struct CodeGenerator {
             output += struct_.name
             output += "<"
             mut first = true
-            for type_id in args.iterator() {
+            for type_id in args {
                 if not first {
                     output += ","
                 } else {
@@ -3179,7 +3179,7 @@ struct CodeGenerator {
         }
         output += "<"
         mut first = true
-        for type_id in args.iterator() {
+        for type_id in args {
             if not first {
                 output += ", "
             } else {
@@ -3294,7 +3294,7 @@ struct CodeGenerator {
 
             output += format("explicit {}(", function_.name)
             mut first = true
-            for param in function_.params.iterator() {
+            for param in function_.params {
                 if not first {
                     output += ", "
                 } else {
@@ -3312,7 +3312,7 @@ struct CodeGenerator {
             class_name_with_generics += structure.name
 
             first = true
-            for generic_parameter in structure.generic_parameters.iterator() {
+            for generic_parameter in structure.generic_parameters {
                 if not first {
                     class_name_with_generics += ", "
                 } else {
@@ -3331,7 +3331,7 @@ struct CodeGenerator {
             output += "("
 
             first = true
-            for param in function_.params.iterator() {
+            for param in function_.params {
                 if not first {
                     output += ", "
                 } else {
@@ -3352,7 +3352,7 @@ struct CodeGenerator {
         output += "("
 
         mut first = true
-        for param in function_.params.iterator() {
+        for param in function_.params {
             if not first {
                 output += ", "
             } else {
@@ -3383,7 +3383,7 @@ struct CodeGenerator {
         if not is_inline and not structure.generic_parameters.is_empty() {
             output += "template <"
             mut first = true
-            for param in structure.generic_parameters.iterator() {
+            for param in structure.generic_parameters {
                 if first {
                     first = false
                 } else {
@@ -3404,7 +3404,7 @@ struct CodeGenerator {
             }
 
             mut first = true
-            for param in function_.params.iterator() {
+            for param in function_.params {
                 if not first {
                     output += ", "
                 } else {
@@ -3430,7 +3430,7 @@ struct CodeGenerator {
                     parent_initializer += "("
 
                     mut strings: [String] = []
-                    for param in function_.params[0..parent_constructor_parameter_count].iterator() {
+                    for param in function_.params[0..parent_constructor_parameter_count] {
                         strings.push("move(a_" + param.variable.name + ")")
                     }
                     parent_initializer += join(strings, separator: ", ")
@@ -3452,7 +3452,7 @@ struct CodeGenerator {
             class_name_with_generics += structure.name
 
             first = true
-            for generic_parameter in structure.generic_parameters.iterator() {
+            for generic_parameter in structure.generic_parameters {
                 if not first {
                     class_name_with_generics += ", "
                 } else {
@@ -3478,7 +3478,7 @@ struct CodeGenerator {
             output += "("
 
             first = true
-            for param in function_.params.iterator() {
+            for param in function_.params {
                 if not first {
                     output += ", "
                 } else {
@@ -3493,7 +3493,7 @@ struct CodeGenerator {
             output += format(") {{ auto o = {}(adopt_nonnull_ref_or_enomem(new (nothrow) {} (", .current_error_handler(), class_name_with_generics)
 
             first = true
-            for param in function_.params.iterator() {
+            for param in function_.params {
                 if not first {
                     output += ", "
                 } else {
@@ -3518,7 +3518,7 @@ struct CodeGenerator {
         output += "("
 
         mut first = true
-        for param in function_.params.iterator() {
+        for param in function_.params {
             if not first {
                 output += ", "
             } else {
@@ -3536,7 +3536,7 @@ struct CodeGenerator {
         }
 
         first = true
-        for param in function_.params.iterator() {
+        for param in function_.params {
             if not first {
                 output += ", "
             } else {
@@ -3606,7 +3606,7 @@ struct CodeGenerator {
         }
 
         mut first = true
-        for param in function_.params.iterator() {
+        for param in function_.params {
             let variable = param.variable
             if variable.name == "this" {
                 continue

--- a/selfhost/compiler.jakt
+++ b/selfhost/compiler.jakt
@@ -30,12 +30,12 @@ class Compiler {
         // FIXME: This method of enumerating errors might be a problem for really huge code bases.
         //        So at some point we might want to use better data structures here.
         mut idx = 0uz
-        for file in .files.iterator() {
+        for file in .files {
             mut file_contents: [u8]? = None
             let file_name = file.to_string()
 
             // Only display the errors that belong to this file
-            for error in .errors.iterator() {
+            for error in .errors {
                 let span = error.span()
 
                 if span.file_id.id == idx {
@@ -154,7 +154,7 @@ class Compiler {
         // Note: Checking this after the replacement!
         let standard_module_name = "jakt"
 
-        for include_path in .include_paths.iterator() {
+        for include_path in .include_paths {
             let candidate_path = Path::from_parts([include_path, module_name + ".jakt"])
             if candidate_path.exists() {
                 return candidate_path
@@ -168,7 +168,7 @@ class Compiler {
                 return candidate_path
             }
         }
-        for include_path in .include_paths.iterator() {
+        for include_path in .include_paths {
             let candidate_path = Path::from_parts([include_path, module_name + ".jakt"])
             if candidate_path.exists() {
                 return candidate_path

--- a/selfhost/formatter.jakt
+++ b/selfhost/formatter.jakt
@@ -3,7 +3,7 @@ import lexer { Lexer, Token }
 
 function concat<T>(anon xs: [T], anon y: T) throws -> [T] {
     mut ys: [T] = []
-    for x in xs.iterator() {
+    for x in xs {
         ys.push(x)
     }
     ys.push(y)
@@ -411,7 +411,7 @@ struct Stage0 {
                 FormattedToken(token, indent: 0, trailing_trivia: [], preceding_trivia: []).debug_text(),
                 .indent
             )
-            for state in .states.iterator() {
+            for state in .states {
                 eprintln("- State: {}", state)
             }
             eprintln()
@@ -693,7 +693,7 @@ struct Stage0 {
                     mut overflow = false
                     mut current_len = 0uz
                     let indent_amount = 4uz
-                    for item in collection.iterator() {
+                    for item in collection {
                         if (current_len + item.length() + 2) > (120 - indent_amount) {
                             overflow = true
                             output += "\n"
@@ -2673,7 +2673,7 @@ struct Formatter implements(ThrowingIterable<[FormattedToken]>) {
             .in_condition_expr_indented = false
             .logical_break_indent = None
             mut result: [FormattedToken] = []
-            for state in line.iterator() {
+            for state in line {
                 result.push(state.token)
             }
 
@@ -2999,7 +2999,7 @@ struct Formatter implements(ThrowingIterable<[FormattedToken]>) {
         .fixup_closing_enclosures(&mut line)
 
         mut result: [FormattedToken] = []
-        for state in line.iterator() {
+        for state in line {
             result.push(state.token)
         }
 

--- a/selfhost/ide.jakt
+++ b/selfhost/ide.jakt
@@ -67,7 +67,7 @@ struct JaktSymbol {
         json_builder.append_string(format("\"selection_range\": {{\"start\": {}, \"end\": {}}},", this.selection_range.start, this.selection_range.end))
         mut child_symbols : [String] = []
         child_symbols.ensure_capacity(this.children.size())
-        for child in this.children.iterator() {
+        for child in this.children {
             child_symbols.push(child.to_json())
         }
         json_builder.append_string(format("\"children\": [{}]", join(child_symbols, separator: ",")))
@@ -78,16 +78,16 @@ struct JaktSymbol {
 
 function find_symbols_in_namespace(anon namespace_: ParsedNamespace) throws -> [JaktSymbol] {
     mut symbols: [JaktSymbol] = []
-    for record in namespace_.records.iterator() {
+    for record in namespace_.records {
         symbols.push(record_to_symbol(record))
     }
 
-    for function_ in namespace_.functions.iterator() {
+    for function_ in namespace_.functions {
         symbols.push(function_to_symbol(function_, kind: "function"))
     }
 
-    for sub_namespace in namespace_.namespaces.iterator() {
-        for child_symbol in find_symbols_in_namespace(sub_namespace).iterator() {
+    for sub_namespace in namespace_.namespaces {
+        for child_symbol in find_symbols_in_namespace(sub_namespace) {
             symbols.push(child_symbol)
         }
     }
@@ -98,7 +98,7 @@ function find_symbols_in_namespace(anon namespace_: ParsedNamespace) throws -> [
     }
 
     mut namespace_span = namespace_.name_span!
-    for child in symbols.iterator() {
+    for child in symbols {
         namespace_span = merge_spans(namespace_.name_span!, child.range)
     }
     return [JaktSymbol(
@@ -117,28 +117,28 @@ function record_to_symbol(anon record: ParsedRecord) throws -> JaktSymbol {
 
     let record_kind = match record.record_type {
         Struct(fields) => {
-            for field in fields.iterator() {
+            for field in fields {
                 children.push(JaktSymbol(name: field.var_decl.name, detail: None, kind: "field", range: field.var_decl.span, selection_range: field.var_decl.span, children: []))
             }
             yield "struct"
         }
         Class(fields) => {
-            for field in fields.iterator() {
+            for field in fields {
                 children.push(JaktSymbol(name: field.var_decl.name, detail: None, kind: "field", range: field.var_decl.span, selection_range: field.var_decl.span, children: []))
             }
             yield "class"
         }
         ValueEnum(variants) => {
-            for variant in variants.iterator() {
+            for variant in variants {
                 children.push(JaktSymbol(name: variant.name, detail: None, kind: "enum-member", range: variant.span, selection_range: variant.span, children: []))
             }
             yield "enum"
         }
         SumEnum(variants) => {
-            for variant in variants.iterator() {
+            for variant in variants {
                 mut variant_children: [JaktSymbol] = []
                 if variant.params.has_value() {
-                    for param in variant.params!.iterator() {
+                    for param in variant.params! {
                         if param.name != "" {
                             variant_children.push(JaktSymbol(name: param.name, detail: None, kind: "field", range: param.span, selection_range: param.span, children: []))
                         }
@@ -150,7 +150,7 @@ function record_to_symbol(anon record: ParsedRecord) throws -> JaktSymbol {
         }
         Garbage => "garbage"
     }
-    for method in record.methods.iterator() {
+    for method in record.methods {
         let function_symbol = function_to_symbol(method.parsed_function, kind: "method")
         children.push(function_symbol)
         record_span = merge_spans(record_span, function_symbol.range)
@@ -169,7 +169,7 @@ function record_to_symbol(anon record: ParsedRecord) throws -> JaktSymbol {
 function function_to_symbol(anon function_: ParsedFunction, kind: String) throws -> JaktSymbol {
     mut function_span = function_.name_span
 
-    for stmt in function_.block.stmts.iterator() {
+    for stmt in function_.block.stmts {
         function_span = merge_spans(function_span, stmt.span())
     }
 
@@ -293,7 +293,7 @@ function find_typename_in_program(program: CheckedProgram, span: Span) throws ->
             NameSet(names) => {
                 mut output = ""
                 mut first = true
-                for name in names.iterator() {
+                for name in names {
                     if not first {
                         output += " | "
                     } else {
@@ -321,7 +321,7 @@ function completions_for_type_id(program: CheckedProgram, type_id: TypeId) throw
         Enum(enum_id) => {
             let enum_ = program.get_enum(enum_id)
             let scope = program.get_scope(enum_.scope_id)
-            for function_name in scope.functions.keys().iterator() {
+            for function_name in scope.functions.keys() {
                 let function_id = scope.functions.get(function_name)!
 
                 let checked_function = program.get_function(function_id)
@@ -353,14 +353,14 @@ function completions_for_type_id(program: CheckedProgram, type_id: TypeId) throw
         Struct(struct_id) => {
             let structure = program.get_struct(struct_id)
 
-            for field in structure.fields.iterator() {
+            for field in structure.fields {
                 let field_var = program.get_variable(field.variable_id)
                 output.push(field_var.name)
             }
 
             let scope = program.get_scope(structure.scope_id)
 
-            for function_name in scope.functions.keys().iterator() {
+            for function_name in scope.functions.keys() {
                 let function_id = scope.functions.get(function_name)!
 
                 let checked_function = program.get_function(function_id)
@@ -393,14 +393,14 @@ function completions_for_type_id(program: CheckedProgram, type_id: TypeId) throw
             // FIXME: this is a copy of the above
             let structure = program.get_struct(struct_id)
 
-            for field in structure.fields.iterator() {
+            for field in structure.fields {
                 let field_var = program.get_variable(field.variable_id)
                 output.push(field_var.name)
             }
 
             let scope = program.get_scope(structure.scope_id)
 
-            for function_name in scope.functions.keys().iterator() {
+            for function_name in scope.functions.keys() {
                 let function_id = scope.functions.get(function_name)!
 
                 let checked_function = program.get_function(function_id)
@@ -466,14 +466,14 @@ function find_span_in_program(program: CheckedProgram, span: Span) throws -> Usa
 }
 
 function find_span_in_scope(program: CheckedProgram, scope: Scope, span: Span) throws -> Usage? {
-    for scope_var in scope.vars.iterator() {
+    for scope_var in scope.vars {
         let var = program.get_variable(scope_var.1)
         if var.definition_span.contains(span) {
             return Some(Usage::Typename(var.type_id))
         }
     }
 
-    for function_id in scope.functions.iterator() {
+    for function_id in scope.functions {
         let checked_function = program.get_function(function_id.1)
         let usage = find_span_in_function(program, checked_function, span)
         if usage.has_value() {
@@ -481,7 +481,7 @@ function find_span_in_scope(program: CheckedProgram, scope: Scope, span: Span) t
         }
     }
 
-    for struct_id in scope.structs.iterator() {
+    for struct_id in scope.structs {
         let checked_struct = program.get_struct(struct_id.1)
         let usage = find_span_in_struct(program, checked_struct, span)
         if usage.has_value() {
@@ -489,7 +489,7 @@ function find_span_in_scope(program: CheckedProgram, scope: Scope, span: Span) t
         }
     }
 
-    for enum_id in scope.enums.iterator() {
+    for enum_id in scope.enums {
         let checked_enum = program.get_enum(enum_id.1)
         let usage = find_span_in_enum(program, checked_enum, span)
         if usage.has_value() {
@@ -497,7 +497,7 @@ function find_span_in_scope(program: CheckedProgram, scope: Scope, span: Span) t
         }
     }
 
-    for child in scope.children.iterator() {
+    for child in scope.children {
         let scope = program.get_scope(child)
 
         let usage = find_span_in_scope(program, scope, span)
@@ -512,10 +512,10 @@ function find_span_in_scope(program: CheckedProgram, scope: Scope, span: Span) t
 function find_span_in_enum(program: CheckedProgram, checked_enum: CheckedEnum, span: Span) throws -> Usage? {
     let scope = program.get_scope(checked_enum.scope_id)
 
-    for variant in checked_enum.variants.iterator() {
+    for variant in checked_enum.variants {
         match variant {
             StructLike(name, fields, span: variant_span) => {
-                for field in fields.iterator() {
+                for field in fields {
                     let var = program.get_variable(field)
 
                     if var.definition_span.contains(span) {
@@ -552,7 +552,7 @@ function find_span_in_enum(program: CheckedProgram, checked_enum: CheckedEnum, s
 function find_span_in_struct(program: CheckedProgram, checked_struct: CheckedStruct, span: Span) throws -> Usage? {
     let scope = program.get_scope(checked_struct.scope_id)
 
-    for field in checked_struct.fields.iterator() {
+    for field in checked_struct.fields {
         let variable = program.get_variable(field.variable_id)
 
         if variable.definition_span.contains(span) {
@@ -572,7 +572,7 @@ function find_span_in_function(program: CheckedProgram, checked_function: Checke
         }
     }
 
-    for param in checked_function.params.iterator() {
+    for param in checked_function.params {
         if param.variable.definition_span.contains(span) {
             return Some(Usage::Typename(param.variable.type_id))
         }
@@ -582,7 +582,7 @@ function find_span_in_function(program: CheckedProgram, checked_function: Checke
 }
 
 function find_span_in_block(program: CheckedProgram, block: CheckedBlock, span: Span) throws -> Usage? {
-    for statement in block.statements.iterator() {
+    for statement in block.statements {
         let found = find_span_in_statement(program, statement, span)
         if found.has_value() {
             return found
@@ -660,7 +660,7 @@ function find_span_in_statement(program: CheckedProgram, statement: CheckedState
             yield find_span_in_block(program, block, span)
         }
         DestructuringAssignment(vars, var_decl) => {
-            for var in vars.iterator() {
+            for var in vars {
                 let found = find_span_in_statement(program, statement: var, span)
                 if found.has_value() {
                     return found
@@ -685,7 +685,7 @@ function find_span_in_expression(program: CheckedProgram, expr: CheckedExpressio
             yield find_span_in_expression(program, expr: rhs, span)
         }
         JaktArray(vals, repeat) => {
-            for val in vals.iterator() {
+            for val in vals {
                 let found = find_span_in_expression(program, expr: val, span)
                 if found.has_value() {
                     return found
@@ -698,7 +698,7 @@ function find_span_in_expression(program: CheckedProgram, expr: CheckedExpressio
         }
         Block(block) => find_span_in_block(program, block, span)
         Call(call, span: call_span) => {
-            for (_, expr) in call.args.iterator() {
+            for (_, expr) in call.args {
                 let found = find_span_in_expression(program, expr, span)
                 if found.has_value() {
                     return found
@@ -710,7 +710,7 @@ function find_span_in_expression(program: CheckedProgram, expr: CheckedExpressio
             yield none
         }
         JaktDictionary(vals) => {
-            for (key, value) in vals.iterator() {
+            for (key, value) in vals {
                 mut found = find_span_in_expression(program, expr: key, span)
                 if found.has_value() {
                     return found
@@ -746,7 +746,7 @@ function find_span_in_expression(program: CheckedProgram, expr: CheckedExpressio
                 }
 
                 if program.get_type(type_id) is Struct(struct_id) {
-                    for field in program.get_struct(struct_id).fields.iterator() {
+                    for field in program.get_struct(struct_id).fields {
                         let var = program.get_variable(field.variable_id)
                         if index != var.name {
                             continue
@@ -777,7 +777,7 @@ function find_span_in_expression(program: CheckedProgram, expr: CheckedExpressio
             yield find_span_in_expression(program, expr: index, span)
         }
         Match(expr, match_cases, span: match_span, type_id) => {
-            for match_case in match_cases.iterator() {
+            for match_case in match_cases {
                 let found = match match_case {
                     EnumVariant(name, args, subject_type_id, index, scope_id, body, marker_span) => {
                         if marker_span.contains(span) {
@@ -811,7 +811,7 @@ function find_span_in_expression(program: CheckedProgram, expr: CheckedExpressio
                                     // can't be duplicate, but I'll leave previous implementation from Rust based
                                     mut names: {String} = {}
                                     let enum_ = program.get_enum(enum_id)
-                                    for variant in enum_.variants.iterator() {
+                                    for variant in enum_.variants {
                                         names.add(variant.name())
                                     }
                                     yield names
@@ -823,7 +823,7 @@ function find_span_in_expression(program: CheckedProgram, expr: CheckedExpressio
 
                             mut remaining_cases = all_cases
 
-                            for other_case in match_cases.iterator() {
+                            for other_case in match_cases {
                                 if other_case is EnumVariant(name) {
                                     remaining_cases.remove(name)
                                 }
@@ -833,7 +833,7 @@ function find_span_in_expression(program: CheckedProgram, expr: CheckedExpressio
                                 false => {
                                     mut cases_array: [String] = []
                                     cases_array.ensure_capacity(remaining_cases.size())
-                                    for name in remaining_cases.iterator() {
+                                    for name in remaining_cases {
                                         cases_array.push(name)
                                     }
                                     yield Some(Usage::NameSet(cases_array))
@@ -862,7 +862,7 @@ function find_span_in_expression(program: CheckedProgram, expr: CheckedExpressio
             if found.has_value() {
                 return found
             }
-            for (_, expr) in call.args.iterator() {
+            for (_, expr) in call.args {
                 found = find_span_in_expression(program, expr, span)
                 if found.has_value() {
                     return found
@@ -961,7 +961,7 @@ function get_function_signature(program: CheckedProgram, function_id: FunctionId
     if not checked_function.generics.params.is_empty() {
         generic_parameters += "<"
 
-        for parameter in checked_function.generics.params.iterator() {
+        for parameter in checked_function.generics.params {
 
             let generic_type = program.type_name(parameter.type_id())
 
@@ -980,7 +980,7 @@ function get_function_signature(program: CheckedProgram, function_id: FunctionId
     mut parameters = ""
     is_first_param = true
 
-    for param in checked_function.params.iterator() {
+    for param in checked_function.params {
         let anon_value = match param.requires_label {
             true => ""
             else => "anon "
@@ -1089,7 +1089,7 @@ function get_type_signature(program: CheckedProgram, type_id: TypeId) throws -> 
         Trait(trait_id) => program.get_trait(trait_id).name
         Function(params, return_type_id) => {
             mut param_names: [String] = []
-            for x in params.iterator() {
+            for x in params {
                 param_names.push(program.type_name(x))
             }
 
@@ -1249,7 +1249,7 @@ function get_enum_variant_signature(program: CheckedProgram, name: String, type_
     if not variants.is_empty() {
         output += "("
         mut first = true
-        for (variant_name, variant_type_id) in variants.iterator() {
+        for (variant_name, variant_type_id) in variants {
             if first {
                 first = false
             } else {
@@ -1284,9 +1284,9 @@ function get_enum_variant_signature(program: CheckedProgram, name: String, type_
 
 function get_enum_variant_signature_from_type_id_and_name(program: CheckedProgram, type_id: TypeId, name: String) throws -> String {
     let mod = program.modules[type_id.module.id]
-    for enum_ in mod.enums.iterator() {
+    for enum_ in mod.enums {
         if enum_.type_id.equals(type_id) {
-            for variant in enum_.variants.iterator() {
+            for variant in enum_.variants {
                 match variant {
                     Untyped(name: v_name) => {
                         if v_name == name {
@@ -1341,12 +1341,12 @@ function get_enum_variant_signature_from_type_id_and_name(program: CheckedProgra
 }
 
 function get_enum_variant_usage_from_type_id_and_name(program: CheckedProgram, type_id: TypeId, name: String) throws -> Usage {
-    for enum_ in program.get_module(type_id.module).enums.iterator() {
+    for enum_ in program.get_module(type_id.module).enums {
         if not enum_.type_id.equals(type_id) {
             continue
         }
 
-        for variant in enum_.variants.iterator() {
+        for variant in enum_.variants {
             if variant.name() == name {
                 let variants = enum_variant_fields(program, checked_enum_variant: variant)
                 let number_constant = match variant {
@@ -1371,7 +1371,7 @@ function enum_variant_fields(program: CheckedProgram, checked_enum_variant: Chec
     return match checked_enum_variant {
         StructLike(fields) => {
             mut output: [(String?, TypeId)] = []
-            for field in fields.iterator() {
+            for field in fields {
                 let variable = program.get_variable(field)
                 let var_name = Some(variable.name)
                 let o = (var_name, variable.type_id)
@@ -1391,14 +1391,14 @@ function get_constructor_signature(program: CheckedProgram, function_id: Functio
     let checked_function = program.get_function(function_id)
     let type_id = checked_function.return_type_id
     let mod = program.modules[type_id.module.id]
-    for struct_ in mod.structures.iterator() {
+    for struct_ in mod.structures {
         if struct_.type_id.equals(type_id) {
             mut output = get_type_signature(program, type_id)
 
             output += "("
 
             mut first = true
-            for field in struct_.fields.iterator() {
+            for field in struct_.fields {
                 if first {
                     first = false
                 } else {

--- a/selfhost/interpreter.jakt
+++ b/selfhost/interpreter.jakt
@@ -151,7 +151,7 @@ function value_to_checked_expression(anon this_value: Value, anon mut interprete
     }
     JaktTuple(fields, type_id) => {
         mut vals: [CheckedExpression] = []
-        for field in fields.iterator() {
+        for field in fields {
             vals.push(value_to_checked_expression(field, interpreter))
         }
         yield CheckedExpression::JaktTuple(vals, span: this_value.span, type_id)
@@ -166,7 +166,7 @@ function value_to_checked_expression(anon this_value: Value, anon mut interprete
         }
 
         mut materialised_fields: [CheckedExpression] = []
-        for field in fields.iterator() {
+        for field in fields {
             materialised_fields.push(value_to_checked_expression(field, interpreter))
         }
 
@@ -213,7 +213,7 @@ function value_to_checked_expression(anon this_value: Value, anon mut interprete
     }
     Enum(fields, enum_id, constructor) => {
         mut materialised_fields: [CheckedExpression] = []
-        for field in fields.iterator() {
+        for field in fields {
             materialised_fields.push(value_to_checked_expression(field, interpreter))
         }
 
@@ -264,7 +264,7 @@ function value_to_checked_expression(anon this_value: Value, anon mut interprete
     }
     JaktArray(values, type_id) => {
         mut vals: [CheckedExpression] = []
-        for value in values.iterator() {
+        for value in values {
             vals.push(value_to_checked_expression(value, interpreter))
         }
 
@@ -338,7 +338,7 @@ function value_to_checked_expression(anon this_value: Value, anon mut interprete
 
         mut inherited_scope = interpreter.program.get_scope(inherited_scope_id)
         mut statements: [CheckedStatement] = []
-        for capture in captures.iterator() {
+        for capture in captures {
             let value = value_to_checked_expression(capture.1, interpreter)
             let var_id = interpreter.program.get_module(id: type_id.module).add_variable(CheckedVariable(
                 name: capture.0
@@ -358,7 +358,7 @@ function value_to_checked_expression(anon this_value: Value, anon mut interprete
         }
 
         // Then append all the statements in the block
-        for statement in block.statements.iterator() {
+        for statement in block.statements {
             statements.push(statement)
         }
 
@@ -370,7 +370,7 @@ function value_to_checked_expression(anon this_value: Value, anon mut interprete
             yielded_none: block.yielded_none
         )
 
-        for param in checked_params.iterator() {
+        for param in checked_params {
             println("Param: {}", interpreter.program.type_name(param.variable.type_id))
         }
 
@@ -417,7 +417,7 @@ class InterpreterScope {
         mut current_id: ScopeId? = scope_id
         while current_id.has_value() {
             let scope = program.get_scope(current_id!)
-            for pair in scope.comptime_bindings.iterator() {
+            for pair in scope.comptime_bindings {
                 if bindings.contains(pair.0) {
                     continue
                 }
@@ -493,7 +493,7 @@ class InterpreterScope {
             .parent!.type_map_for_substitution_helper(map)
         }
 
-        for pair in .type_bindings.iterator() {
+        for pair in .type_bindings {
             map.set(pair.0, pair.1.to_string())
         }
     }
@@ -581,7 +581,7 @@ class Interpreter {
 
     public function find_or_add_type_id(mut this, anon type: Type) throws -> TypeId {
 
-        for module in .program.modules.iterator() {
+        for module in .program.modules {
             for id in 0..module.types.size() {
                 if module.types[id].equals(type) {
                     return TypeId(module: module.id, id)
@@ -1110,7 +1110,7 @@ class Interpreter {
                     
                     mut file = File::open_for_reading(path)
                     mut result_values: [Value] = []
-                    for byte in file.read_all().iterator() {
+                    for byte in file.read_all() {
                         result_values.push(Value(
                             impl: ValueImpl::U8(byte)
                             span: call_span
@@ -1255,7 +1255,7 @@ class Interpreter {
                         }
                     }
                     mut data: [u8] = []
-                    for val in data_values.iterator() {
+                    for val in data_values {
                         data.push(match val.impl {
                             U8(x) => x
                             else => {panic("expected byte")}
@@ -1746,7 +1746,7 @@ class Interpreter {
                 "contains" => match this_argument!.impl {
                     JaktArray(values) => {
                         mut found = false
-                        for value in values.iterator() {
+                        for value in values {
                             if value.impl.equals(arguments[0].impl) {
                                 found = true
                                 break
@@ -2132,7 +2132,7 @@ class Interpreter {
                         CChar(c) => {
                             let values = value.split(c)
                             mut result: [Value] = []
-                            for value in values.iterator() {
+                            for value in values {
                                 result.push(Value(impl: ValueImpl::JaktString(value), span: call_span))
                             }
                             let array_struct_id = .program.find_struct_in_prelude("Array")
@@ -2774,7 +2774,7 @@ class Interpreter {
                     }
                 }
 
-                for var in vars.iterator() {
+                for var in vars {
                     guard var is VarDecl(var_id, init) else {
                         panic("expected vardecl")
                     }
@@ -3013,7 +3013,7 @@ class Interpreter {
     }
 
     public function execute_block(mut this, block: CheckedBlock, mut scope: InterpreterScope, call_span: Span) throws -> StatementResult {
-        for statement in block.statements.iterator() {
+        for statement in block.statements {
             .enter_span(statement.span() ?? call_span)
             defer .leave_span()
             match .execute_statement(statement, scope, call_span) {
@@ -5186,7 +5186,7 @@ class Interpreter {
         Call(call, span) => {
             if not call.function_id.has_value() {
                 mut arguments: [Value] = []
-                for arg in call.args.iterator() {
+                for arg in call.args {
                     arguments.push(match .execute_expression(arg.1, scope) {
                         Return(value) => {
                             return StatementResult::Return(value)
@@ -5227,7 +5227,7 @@ class Interpreter {
             }
             mut this_argument: Value? = None
             mut arguments: [Value] = []
-            for arg in call.args.iterator() {
+            for arg in call.args {
                 arguments.push(match .execute_expression(arg.1, scope) {
                     Return(value) => {
                         return StatementResult::Return(value)
@@ -5349,7 +5349,7 @@ class Interpreter {
 
             if not call.function_id.has_value() {
                 mut arguments: [Value] = []
-                for arg in call.args.iterator() {
+                for arg in call.args {
                     arguments.push(match .execute_expression(arg.1, scope) {
                         Return(value) => {
                             return StatementResult::Return(value)
@@ -5382,7 +5382,7 @@ class Interpreter {
 
             let function_to_run = .program.get_function(id: call.function_id!)
             mut arguments: [Value] = []
-            for arg in call.args.iterator() {
+            for arg in call.args {
                 arguments.push(match .execute_expression(arg.1, scope) {
                     Return(value) => {
                         return StatementResult::Return(value)
@@ -5543,7 +5543,7 @@ class Interpreter {
                     let struct_ = .program.get_struct(struct_id)
                     mut idx = 0
                     mut found_index: i64? = None
-                    for field in struct_.fields.iterator() {
+                    for field in struct_.fields {
                         if .program.get_variable(field.variable_id).name == index {
                             found_index = idx
                             break
@@ -5587,7 +5587,7 @@ class Interpreter {
                     let enum_ = .program.get_enum(enum_id)
                     mut idx = 0
                     mut found_index: i64? = None
-                    for field in enum_.fields.iterator() {
+                    for field in enum_.fields {
                         if .program.get_variable(field.variable_id).name == index {
                             found_index = idx
                             break
@@ -5610,7 +5610,7 @@ class Interpreter {
         JaktDictionary(vals, span, type_id) => {
             mut keys: [Value] = []
             mut values: [Value] = []
-            for (k, v) in vals.iterator() {
+            for (k, v) in vals {
                 let key = match .execute_expression(k, scope) {
                     Return(value) => {
                         return StatementResult::Return(value)
@@ -5733,7 +5733,7 @@ class Interpreter {
             }
             else => {
                 mut values: [Value] = []
-                for value in vals.iterator() {
+                for value in vals {
                     let val = match .execute_expression(value, scope) {
                         Return(value) => {
                             return StatementResult::Return(value)
@@ -5820,7 +5820,7 @@ class Interpreter {
                     mut found_variant_index: usize? = None
                     mut span: Span? = None
 
-                    for match_case in match_cases.iterator() {
+                    for match_case in match_cases {
                         match match_case {
                             EnumVariant(name, args, index, body, marker_span) => {
                                 if name != constructor_name {
@@ -5866,9 +5866,9 @@ class Interpreter {
                             }
                             StructLike(fields: variant_fields) => {
                                 mut i = 0
-                                for var_id in variant_fields.iterator() {
+                                for var_id in variant_fields {
                                     let field = .program.get_variable(var_id)
-                                    for arg in found_args!.iterator() {
+                                    for arg in found_args! {
                                         let matched_name = arg.name ?? arg.binding
                                         if matched_name == field.name {
                                             new_scope.bindings.set(
@@ -5906,7 +5906,7 @@ class Interpreter {
                     mut found_body: CheckedMatchBody? = None
                     mut span: Span? = None
 
-                    for match_case in match_cases.iterator() {
+                    for match_case in match_cases {
                         match match_case {
                             Expression(body, expression, marker_span) => {
                                 let value_to_match_against = match .execute_expression(expression, scope) {
@@ -5993,7 +5993,7 @@ class Interpreter {
             yield match value.impl {
                 Enum(fields,  enum_id, constructor) => {
                     mut found_variant: CheckedEnumVariant? = None
-                    for variant in .program.get_enum(enum_id).variants.iterator() {
+                    for variant in .program.get_enum(enum_id).variants {
                         if variant.name() == enum_variant.name() {
                             found_variant = variant
                             break
@@ -6004,7 +6004,7 @@ class Interpreter {
                         Typed => StatementResult::JustValue(fields[0])
                         StructLike(fields: variant_fields) => {
                             mut i = 0
-                            for var_id in variant_fields.iterator() {
+                            for var_id in variant_fields {
                                 let field = .program.get_variable(var_id)
                                 let matched_name = arg.name ?? arg.binding
                                 if matched_name == field.name {
@@ -6027,7 +6027,7 @@ class Interpreter {
         }
         JaktTuple(vals, span, type_id) => {
             mut fields: [Value] = []
-            for val in vals.iterator() {
+            for val in vals {
                 let value = match .execute_expression(val, scope) {
                     JustValue(value) => value
                     Return(value) => {
@@ -6052,7 +6052,7 @@ class Interpreter {
         }
         JaktSet(vals, span, type_id) => {
             mut values: [Value] = []
-            for v in vals.iterator() {
+            for v in vals {
                 let val = match .execute_expression(v, scope) {
                     Return(value) => {
                         return StatementResult::Return(value)
@@ -6086,7 +6086,7 @@ class Interpreter {
         Function(captures, params, return_type_id, type_id, block, span, can_throw) => {
             // First, resolve the captures
             mut resolved_captures: [String:Value] = [:]
-            for capture in captures.iterator() {
+            for capture in captures {
                 let name = capture.name()
                 guard capture is ByValue else {
                     .error(
@@ -6102,7 +6102,7 @@ class Interpreter {
             let type_map = scope.type_map_for_substitution()
             mut resolved_params: [String:(TypeId, CheckedExpression?)] = [:]
             mut checked_params: [CheckedParameter] = []
-            for param in params.iterator() {
+            for param in params {
                 let param_type_id = .program.substitute_typevars_in_type(
                     type_id: param.variable.type_id
                     generic_inferences: type_map

--- a/selfhost/lexer.jakt
+++ b/selfhost/lexer.jakt
@@ -717,7 +717,7 @@ struct Lexer implements(ThrowingIterable<Token>) {
         let contents = .comment_contents!
         .comment_contents = None
         mut builder = StringBuilder::create()
-        for c in contents.iterator() {
+        for c in contents {
             builder.append(c)
         }
 

--- a/selfhost/main.jakt
+++ b/selfhost/main.jakt
@@ -233,7 +233,7 @@ function main(args: [String]) {
     mut first_arg = true
     mut interpreted_main_arguments: [String] = []
 
-    for arg in positional_arguments.iterator() {
+    for arg in positional_arguments {
         if first_arg {
             first_arg = false
             continue
@@ -305,7 +305,7 @@ function main(args: [String]) {
     let tokens = Lexer::lex(compiler)
 
     if lexer_debug {
-        for token in tokens.iterator() {
+        for token in tokens {
             println("token: {}", token)
         }
     }
@@ -322,12 +322,12 @@ function main(args: [String]) {
     if format or format_debug {
         mut on_new_line = true
         for formatted_line in Formatter::for_tokens(tokens, debug: format_debug) {
-            for formatted_token in formatted_line.iterator() {
+            for formatted_token in formatted_line {
                 if not formatted_token.token.span().is_in_offset_range(start: format_range!.start, end: format_range!.end) {
                     continue
                 }
 
-                for byte in formatted_token.preceding_trivia.iterator() {
+                for byte in formatted_token.preceding_trivia {
                     print("{:c}", byte)
                 }
 
@@ -366,7 +366,7 @@ function main(args: [String]) {
                     }
                 }
 
-                for byte in formatted_token.trailing_trivia.iterator() {
+                for byte in formatted_token.trailing_trivia {
                     print("{:c}", byte)
                 }
 
@@ -388,7 +388,7 @@ function main(args: [String]) {
         let symbols = ide::find_symbols_in_namespace(parsed_namespace)
 
         mut symbol_representations: [String] = []
-        for symbol in symbols.iterator() {
+        for symbol in symbols {
             symbol_representations.push(symbol.to_json())
         }
         println("[{}]", join(symbol_representations, separator: ","))
@@ -410,13 +410,13 @@ function main(args: [String]) {
         // Find the main function
         let prelude_scope_id = ScopeId(module_id: ModuleId(id: 0), id: 0)
         mut main_function_id: FunctionId? = None
-        for module in checked_program.modules.iterator() {
-            for scope in module.scopes.iterator() {
+        for module in checked_program.modules {
+            for scope in module.scopes {
                 if not (scope.parent?.equals(prelude_scope_id) ?? false) {
                     continue
                 }
 
-                for function_ in scope.functions.iterator() {
+                for function_ in scope.functions {
                     if function_.0 == "main" {
                         main_function_id = function_.1
                         break
@@ -443,7 +443,7 @@ function main(args: [String]) {
         let arguments = match first_main_param.has_value() {
             true => {
                 mut passed_arguments: [Value] = [Value(impl: ValueImpl::JaktString(file_name!), span: call_span)]
-                for argument in interpreted_main_arguments.iterator() {
+                for argument in interpreted_main_arguments {
                     passed_arguments.push(Value(impl: ValueImpl::JaktString(argument), span: call_span))
                 }
                 yield [Value(
@@ -528,7 +528,7 @@ function main(args: [String]) {
 
         print("{{\"completions\": [");
         mut first = true
-        for completion in result.iterator() {
+        for completion in result {
             if not first {
                 print(", ")
             } else {
@@ -562,7 +562,7 @@ function main(args: [String]) {
         make_directory(path: binary_dir.to_string())
     }
 
-    for (file, contents_and_path) in codegen_result.iterator() {
+    for (file, contents_and_path) in codegen_result {
         let (contents, module_file_path) = contents_and_path
 
         let path = binary_dir.join(file)
@@ -598,7 +598,7 @@ function main(args: [String]) {
 
     if build_executable or run_executable {
         mut files: [String] = []
-        for (file_name, _) in codegen_result.iterator() {
+        for (file_name, _) in codegen_result {
             if file_name.ends_with(".h") {
                 continue
             }
@@ -648,12 +648,12 @@ function main(args: [String]) {
             extra_arguments.push(runtime_lib_path.join(library_name("main")).to_string())
             extra_arguments.push(runtime_lib_path.join(library_name("runtime")).to_string())
 
-            for path in extra_lib_paths.iterator() {
+            for path in extra_lib_paths {
                 extra_arguments.push("-L")
                 extra_arguments.push(path)
             }
 
-            for lib in extra_link_libs.iterator() {
+            for lib in extra_link_libs {
                 extra_arguments.push("-l")
                 extra_arguments.push(lib)
             }

--- a/selfhost/parser.jakt
+++ b/selfhost/parser.jakt
@@ -172,7 +172,7 @@ struct ParsedModuleImport {
         mut everything = false
         match .import_list {
             List(names) => {
-                for name in names.iterator() {
+                for name in names {
                     name_set.add(name.literal_name())
                 }
             }
@@ -184,7 +184,7 @@ struct ParsedModuleImport {
         if not everything {
             match list {
                 List(names) => {
-                    for name in names.iterator() {
+                    for name in names {
                         if not name_set.contains(name.literal_name()) {
                             .import_list.add(name)
                         }
@@ -240,7 +240,7 @@ struct ParsedNamespace {
         .name == other.name and .import_path_if_extern == other.import_path_if_extern
 
     function add_module_import(mut this, anon import_: ParsedModuleImport) throws {
-        for module_import in .module_imports.iterator() {
+        for module_import in .module_imports {
             if module_import.is_equivalent_to(import_) {
                 module_import.merge_import_list(import_.import_list)
                 return
@@ -250,13 +250,13 @@ struct ParsedNamespace {
     }
 
     function add_extern_import(mut this, anon import_: ParsedExternImport) throws {
-        for extern_import in .extern_imports.iterator() {
+        for extern_import in .extern_imports {
             if extern_import.is_equivalent_to(import_) {
                 extern_import.assigned_namespace.merge_with(import_.assigned_namespace)
-                for action in import_.before_include.iterator() {
+                for action in import_.before_include {
                     extern_import.before_include.push(action)
                 }
-                for action in import_.after_include.iterator() {
+                for action in import_.after_include {
                     extern_import.after_include.push(action)
                 }
 
@@ -267,7 +267,7 @@ struct ParsedNamespace {
     }
 
     function add_child_namespace(mut this, anon namespace_: ParsedNamespace) throws {
-        for child_namespace in .namespaces.iterator() {
+        for child_namespace in .namespaces {
             if child_namespace.is_equivalent_to(namespace_) {
                 child_namespace.merge_with(namespace_)
                 return
@@ -281,16 +281,16 @@ struct ParsedNamespace {
         extend_array(target: .records, extend_with: namespace_.records)
 
         .module_imports.add_capacity(namespace_.module_imports.size())
-        for import_ in namespace_.module_imports.iterator() {
+        for import_ in namespace_.module_imports {
             .add_module_import(import_)
         }
 
         .extern_imports.add_capacity(namespace_.extern_imports.size())
-        for import_ in namespace_.extern_imports.iterator() {
+        for import_ in namespace_.extern_imports {
             .add_extern_import(import_)
         }
 
-        for child_namespace in namespace_.namespaces.iterator() {
+        for child_namespace in namespace_.namespaces {
             .add_child_namespace(child_namespace)
         }
     }
@@ -428,7 +428,7 @@ struct ParsedBlock {
     }
 
     function find_yield_span(this) -> Span? {
-        for stmt in .stmts.iterator() {
+        for stmt in .stmts {
             if stmt is Yield(expr) {
                 return expr.span()
             }
@@ -437,7 +437,7 @@ struct ParsedBlock {
     }
 
     function find_yield_keyword_span(this) -> Span? {
-        for stmt in .stmts.iterator() {
+        for stmt in .stmts {
             if stmt is Yield(expr) {
                 return stmt.span()
             }
@@ -449,7 +449,7 @@ struct ParsedBlock {
         mut start: usize? = None
         mut end: usize = 0
 
-        for stmt in .stmts.iterator() {
+        for stmt in .stmts {
             let stmt_span = stmt.span()
             if not start.has_value() {
                 start = stmt_span.start
@@ -1688,7 +1688,7 @@ struct Parser {
                         .index++
                         let actions = .parse_include_action()
                         if actions.has_value() {
-                            for action in actions!.iterator() {
+                            for action in actions! {
                                 parsed_import.before_include.push(action)
                             }
                         }
@@ -1697,7 +1697,7 @@ struct Parser {
                         .index++
                         let actions = .parse_include_action()
                         if actions.has_value() {
-                            for action in actions!.iterator() {
+                            for action in actions! {
                                 parsed_import.after_include.push(action)
                             }
                         }
@@ -3188,7 +3188,7 @@ struct Parser {
 
                 if .current() is LParen {
                     vars = .parse_destructuring_assignment(is_mutable)
-                    for var in vars.iterator() {
+                    for var in vars {
                         tuple_var_name += var.name
                         tuple_var_name += "_"
                     }
@@ -3298,7 +3298,7 @@ struct Parser {
             LParen => {
                 destructured_var_decls = .parse_destructuring_assignment(is_mutable: false)
                 mut tuple_var_name = ""
-                for var in destructured_var_decls.iterator() {
+                for var in destructured_var_decls {
                     tuple_var_name += var.name
                     tuple_var_name += "__"
                 }
@@ -3336,7 +3336,7 @@ struct Parser {
             let destructured_vars_stmt = ParsedStatement::DestructuringAssignment(vars: destructured_var_decls, var_decl, span: merge_spans(start_span, .previous().span()))
             mut block_stmts: [ParsedStatement] = []
             block_stmts.push(destructured_vars_stmt)
-            for stmt in block.stmts.iterator() {
+            for stmt in block.stmts {
                 block_stmts.push(stmt)
             }
             block.stmts = block_stmts
@@ -4378,7 +4378,7 @@ struct Parser {
                 else => ParsedMatchBody::Expression(.parse_expression(allow_assignments: false, allow_newlines: true))
             }
 
-            for pattern in patterns.iterator() {
+            for pattern in patterns {
                 cases.push(ParsedMatchCase(patterns: [pattern], marker_span, body))
             }
 

--- a/selfhost/path.jakt
+++ b/selfhost/path.jakt
@@ -14,7 +14,7 @@ struct Path {
 
     function from_parts(anon parts: [String]) throws -> Path {
         mut path = Path(path: ".")
-        for part in parts.iterator() {
+        for part in parts {
             path = path.join(part)
         }
         return path

--- a/selfhost/posix_compiler.jakt
+++ b/selfhost/posix_compiler.jakt
@@ -23,7 +23,7 @@ function run_compiler(
         extra_flags.push("-Wno-unused-command-line-argument")
     }
 
-    for extra_flag in extra_compiler_flags.iterator() {
+    for extra_flag in extra_compiler_flags {
         extra_flags.push(extra_flag)
     }
 
@@ -45,7 +45,7 @@ function run_compiler(
     }
 
     if not extra_flags.is_empty() {
-        for flag in extra_flags.iterator() {
+        for flag in extra_flags {
             compile_args.push(flag)
         }
     }
@@ -59,21 +59,21 @@ function run_compiler(
     compile_args.push(cpp_filename)
     if not extra_include_paths.is_empty() {
         compile_args.add_capacity(extra_include_paths.size() * 2)
-        for path in extra_include_paths.iterator() {
+        for path in extra_include_paths {
             compile_args.push("-I")
             compile_args.push(path)
         }
     }
     if not extra_lib_paths.is_empty() {
         compile_args.add_capacity(extra_lib_paths.size() * 2)
-        for path in extra_lib_paths.iterator() {
+        for path in extra_lib_paths {
             compile_args.push("-L")
             compile_args.push(path)
         }
     }
     if not extra_link_libs.is_empty() {
         compile_args.add_capacity(extra_link_libs.size())
-        for path in extra_link_libs.iterator() {
+        for path in extra_link_libs {
             compile_args.push("-l" + path)
         }
     }

--- a/selfhost/posix_process.jakt
+++ b/selfhost/posix_process.jakt
@@ -45,7 +45,7 @@ function start_background_process(anon args: [String]) throws -> Process {
     }
 
     mut i = 0
-    for arg in args.iterator() {
+    for arg in args {
         unsafe {
             cpp {
                 "call_args[i++] = const_cast<char*>(arg.c_string());"

--- a/selfhost/repl.jakt
+++ b/selfhost/repl.jakt
@@ -168,7 +168,7 @@ function serialize_ast_node(anon node: CheckedExpression) throws -> String => ma
     | IndexedStruct(expr, index) => format("{}.{}", serialize_ast_node(expr), index)
     NamespacedVar(namespaces, var) => {
         mut builder = StringBuilder::create()
-        for namespace_ in namespaces.iterator() {
+        for namespace_ in namespaces {
             builder.append_string(namespace_.name)
             builder.append_string("::")
         }
@@ -182,7 +182,7 @@ function serialize_ast_node(anon node: CheckedExpression) throws -> String => ma
     Call(call) => {
         mut builder = StringBuilder::create()
 
-        for namespace_ in call.namespace_.iterator() {
+        for namespace_ in call.namespace_ {
             builder.append_string(namespace_.name)
             builder.append_string("::")
         }

--- a/selfhost/typechecker.jakt
+++ b/selfhost/typechecker.jakt
@@ -139,8 +139,8 @@ struct Typechecker {
             current = parent
         }
 
-        for current_struct_id in chain.iterator() {
-            for field in .get_struct(current_struct_id).fields.iterator() {
+        for current_struct_id in chain {
+            for field in .get_struct(current_struct_id).fields {
                 let variable = .get_variable(field.variable_id)
                 if variable.name == name {
                     return FieldRecord(struct_id: current_struct_id, field_id: field.variable_id)
@@ -286,7 +286,7 @@ struct Typechecker {
         let tokens = Lexer::lex(compiler: .compiler)
 
         if .compiler.dump_lexer {
-            for token in tokens.iterator() {
+            for token in tokens {
                 println("token: {}", token)
             }
         }
@@ -315,7 +315,7 @@ struct Typechecker {
         let tokens = Lexer::lex(compiler: .compiler)
 
         if .compiler.dump_lexer {
-            for token in tokens.iterator() {
+            for token in tokens {
                 println("token: {}", token)
             }
         }
@@ -375,7 +375,7 @@ struct Typechecker {
             if maybe_type.has_value() {
                 return maybe_type
             }
-            for child_id in scope.children.iterator() {
+            for child_id in scope.children {
                 let child_scope = .get_scope(id: child_id)
                 if not child_scope.namespace_name.has_value() {
                     let maybe_type = child_scope.types.get(name)
@@ -404,7 +404,7 @@ struct Typechecker {
             if maybe_trait.has_value() {
                 return maybe_trait
             }
-            for child_id in scope.children.iterator() {
+            for child_id in scope.children {
                 let child_scope = .get_scope(id: child_id)
                 if not child_scope.namespace_name.has_value() {
                     let maybe_trait = child_scope.traits.get(name)
@@ -433,7 +433,7 @@ struct Typechecker {
             if maybe_type.has_value() {
                 return (maybe_type!, current)
             }
-            for child_id in scope.children.iterator() {
+            for child_id in scope.children {
                 let child_scope = .get_scope(id: child_id)
                 if not child_scope.namespace_name.has_value() {
                     let maybe_type = child_scope.types.get(name)
@@ -528,7 +528,7 @@ struct Typechecker {
 
     function add_function_to_scope(mut this, parent_scope_id: ScopeId, name: String, function_id: FunctionId, span: Span) throws -> bool {
         mut scope = .get_scope(id: parent_scope_id)
-        for existing_function in scope.functions.iterator() {
+        for existing_function in scope.functions {
             if name == existing_function.0 {
                 let function_ = .get_function(existing_function.1)
                 .error_with_hint(message: format("Redefinition of function ‘{}’", name), span, hint: "previous definition here", hint_span: function_.name_span)
@@ -541,7 +541,7 @@ struct Typechecker {
 
     function add_var_to_scope(mut this, scope_id: ScopeId, name: String, var_id: VarId, span: Span) throws -> bool {
         mut scope = .get_scope(scope_id)
-        for existing_var in scope.vars.iterator() {
+        for existing_var in scope.vars {
             if name == existing_var.0 {
                 let variable_ = .get_variable(existing_var.1)
                 .error_with_hint(message: format("Redefinition of variable ‘{}’", name), span, hint: "previous definition here", hint_span: variable_.definition_span)
@@ -553,7 +553,7 @@ struct Typechecker {
 
     function add_comptime_binding_to_scope(mut this, scope_id: ScopeId, name: String, value: Value, span: Span) throws -> bool {
         mut scope = .get_scope(scope_id)
-        for existing in scope.comptime_bindings.iterator() {
+        for existing in scope.comptime_bindings {
             if name == existing.0 {
                 .error_with_hint(
                     message: format("Redefinition of comptime variable ‘{}’", name)
@@ -588,9 +588,9 @@ struct Typechecker {
             Public => CheckedVisibility::Public
             Restricted(whitelist, span) => {
                 mut restricted_scopes: [MaybeResolvedScope] = []
-                for entry in whitelist.iterator() {
+                for entry in whitelist {
                     mut parent_scope = MaybeResolvedScope::Resolved(scope_id)
-                    for ns in entry.namespace_.iterator() {
+                    for ns in entry.namespace_ {
                         parent_scope = MaybeResolvedScope::Unresolved(parent_scope, relative_name: ns)
                     }
 
@@ -615,7 +615,7 @@ struct Typechecker {
             .typecheck_namespace_fields(parsed_namespace: child_namespace,
                 scope_id: child_namespace_scope_id)
         }
-        for record in parsed_namespace.records.iterator() {
+        for record in parsed_namespace.records {
             if record.record_type is Struct or record.record_type is Class {
                 let struct_id = .find_struct_in_scope(scope_id, name: record.name)
                 if not struct_id.has_value() {
@@ -641,7 +641,7 @@ struct Typechecker {
             }
         }
 
-        for unchecked_member in parsed_fields.iterator() {
+        for unchecked_member in parsed_fields {
             let parsed_var_decl = unchecked_member.var_decl
             let checked_member_type = .typecheck_typename(parsed_type: parsed_var_decl.parsed_type, scope_id: checked_struct_scope_id, name: parsed_var_decl.name)
 
@@ -720,7 +720,7 @@ struct Typechecker {
                             }
 
                             mut result: [(String, Span)] = []
-                            for value in values.iterator() {
+                            for value in values {
                                 match value.impl {
                                     JaktString(string) => result.push((string, value.span))
                                     else => {
@@ -753,7 +753,7 @@ struct Typechecker {
 
         mut module_name_and_span: (String, Span)? = None
         mut names: [String] = []
-        for name_and_span in module_names_and_spans!.iterator() {
+        for name_and_span in module_names_and_spans! {
             names.push(name_and_span.0)
 
             mut maybe_loaded_module = .program.get_loaded_module(name_and_span.0)
@@ -840,7 +840,7 @@ struct Typechecker {
                 value: imported_module_id) // FIXME: Add span and should this be alias span if there is an alias?
         } else if import_.import_list is All {
             let import_scope = .get_scope(ScopeId(module_id: imported_module_id, id: 0))
-            for (name, var_id) in import_scope.vars.iterator() {
+            for (name, var_id) in import_scope.vars {
                 .add_var_to_scope(
                     scope_id
                     name
@@ -848,7 +848,7 @@ struct Typechecker {
                     span: import_.module_name.span()
                 )
             }
-            for (name, value) in import_scope.comptime_bindings.iterator() {
+            for (name, value) in import_scope.comptime_bindings {
                 .add_comptime_binding_to_scope(
                     scope_id
                     name
@@ -856,7 +856,7 @@ struct Typechecker {
                     span: import_.module_name.span()
                 )
             }
-            for (name, struct_id) in import_scope.structs.iterator() {
+            for (name, struct_id) in import_scope.structs {
                 .add_struct_to_scope(
                     scope_id
                     name
@@ -864,7 +864,7 @@ struct Typechecker {
                     span: import_.module_name.span()
                 )
             }
-            for (name, function_id) in import_scope.functions.iterator() {
+            for (name, function_id) in import_scope.functions {
                 .add_function_to_scope(
                     parent_scope_id: scope_id
                     name
@@ -872,7 +872,7 @@ struct Typechecker {
                     span: import_.module_name.span()
                 )
             }
-            for (name, enum_id) in import_scope.enums.iterator() {
+            for (name, enum_id) in import_scope.enums {
                 .add_enum_to_scope(
                     scope_id
                     name
@@ -880,7 +880,7 @@ struct Typechecker {
                     span: import_.module_name.span()
                 )
             }
-            for (name, type_id) in import_scope.types.iterator() {
+            for (name, type_id) in import_scope.types {
                 .add_type_to_scope(
                     scope_id
                     type_name: name
@@ -888,7 +888,7 @@ struct Typechecker {
                     span: import_.module_name.span()
                 )
             }
-            for (name, trait_id) in import_scope.traits.iterator() {
+            for (name, trait_id) in import_scope.traits {
                 .add_trait_to_scope(
                     scope_id
                     trait_name: name
@@ -898,7 +898,7 @@ struct Typechecker {
             }
         } else if import_.import_list is List(names) {
             let import_scope_id = ScopeId(module_id: imported_module_id, id: 0)
-            for imported_name in names.iterator() {
+            for imported_name in names {
                 mut found = false
                 // if it is a function, add function to scope
                 let maybe_function_id = .find_function_in_scope(
@@ -990,7 +990,7 @@ struct Typechecker {
     }
 
     function typecheck_extern_import(mut this, anon import_: ParsedExternImport, scope_id: ScopeId) throws {
-        for f in import_.assigned_namespace.functions.iterator() {
+        for f in import_.assigned_namespace.functions {
             if not f.linkage is External {
                 .error("Expected all functions in an `import extern` to be be external", f.name_span)
             }
@@ -1009,7 +1009,7 @@ struct Typechecker {
             }
         }
 
-        for record in import_.assigned_namespace.records.iterator() {
+        for record in import_.assigned_namespace.records {
             if not record.definition_linkage is External {
                 .error("Expected all records in an `import extern` to be external"
                         record.name_span)
@@ -1027,11 +1027,11 @@ struct Typechecker {
     }
 
     function typecheck_namespace_imports(mut this, parsed_namespace: ParsedNamespace, scope_id: ScopeId) throws {
-        for module_import in parsed_namespace.module_imports.iterator() {
+        for module_import in parsed_namespace.module_imports {
             .typecheck_module_import(module_import, scope_id)
         }
 
-        for extern_import in parsed_namespace.extern_imports.iterator() {
+        for extern_import in parsed_namespace.extern_imports {
             .typecheck_extern_import(extern_import, scope_id)
         }
     }
@@ -1043,7 +1043,7 @@ struct Typechecker {
             let child_namespace_scope_id = children[i]
             .typecheck_namespace_constructors(parsed_namespace: child_namespace, scope_id: child_namespace_scope_id)
         }
-        for record in parsed_namespace.records.iterator() {
+        for record in parsed_namespace.records {
             match record.record_type {
                 Struct | Class => {
                     let struct_id = .find_struct_in_scope(scope_id, name: record.name)
@@ -1072,13 +1072,13 @@ struct Typechecker {
             .typecheck_namespace_function_predecl(parsed_namespace: child_namespace, scope_id: child_namespace_scope_id)
         }
 
-        for fun in parsed_namespace.functions.iterator() {
+        for fun in parsed_namespace.functions {
             .typecheck_function_predecl(parsed_function: fun, parent_scope_id: scope_id, this_arg_type_id: None)
         }
 
         mut module = .current_module()
 
-        for record in parsed_namespace.records.iterator() {
+        for record in parsed_namespace.records {
             let record_scope_id = match record.record_type {
                 Struct | Class => {
                     let struct_id = .find_struct_in_scope(scope_id, name: record.name)
@@ -1095,7 +1095,7 @@ struct Typechecker {
                     yield .get_enum(enum_id!).scope_id
                 }
             }
-            for method in record.methods.iterator() {
+            for method in record.methods {
                 if not record.generic_parameters.is_empty() or not method.parsed_function.generic_parameters.is_empty() {
                     mut func = .get_function(
                         .find_function_in_scope(parent_scope_id: record_scope_id, function_name: method.parsed_function.name)!
@@ -1108,7 +1108,7 @@ struct Typechecker {
                         debug_name: format("method-checking({}::{})", record.name, func.name)
                     )
 
-                    for param in func.params.iterator() {
+                    for param in func.params {
                         .add_var_to_scope(
                             scope_id: check_scope
                             name: param.variable.name
@@ -1153,7 +1153,7 @@ struct Typechecker {
         // 1. Initialize structs
         mut struct_index: usize = 0
         mut enum_index: usize = 0
-        for parsed_record in parsed_namespace.records.iterator() {
+        for parsed_record in parsed_namespace.records {
             match parsed_record.record_type {
                 Struct | Class => { .typecheck_struct_predecl_initial(parsed_record, struct_index: struct_index++, module_struct_len, scope_id) }
                 SumEnum | ValueEnum => { .typecheck_enum_predecl_initial(parsed_record, enum_index: enum_index++, module_enum_len, scope_id) }
@@ -1164,7 +1164,7 @@ struct Typechecker {
         }
 
         // 2. Typecheck subnamespaces
-        for namespace_ in parsed_namespace.namespaces.iterator() {
+        for namespace_ in parsed_namespace.namespaces {
             // Find all predeclarations in namespaces that are children of this namespace
             mut debug_name = "namespace("
             if namespace_.name.has_value() {
@@ -1189,12 +1189,12 @@ struct Typechecker {
         }
 
         // 3. Register traits
-        for parsed_trait in parsed_namespace.traits.iterator() {
+        for parsed_trait in parsed_namespace.traits {
             .typecheck_trait_predecl(parsed_trait, scope_id)
         }
 
         // 4. Resolve default trait implementations
-        for parsed_trait in parsed_namespace.traits.iterator() {
+        for parsed_trait in parsed_namespace.traits {
             let trait_id = .find_trait_in_scope(scope_id, name: parsed_trait.name)
             guard trait_id.has_value() else {
                 .compiler.panic("can't find trait that has been previous added")
@@ -1205,7 +1205,7 @@ struct Typechecker {
         // 5. Typecheck struct predeclaration
         struct_index = 0
         enum_index = 0
-        for parsed_record in parsed_namespace.records.iterator() {
+        for parsed_record in parsed_namespace.records {
             let struct_id = StructId(module: .current_module_id, id: struct_index + module_struct_len)
             match parsed_record.record_type {
                 Struct | Class => {
@@ -1224,12 +1224,12 @@ struct Typechecker {
         }
 
         // 6. Resolve external trait implementations
-        for implementation in parsed_namespace.external_trait_implementations.iterator() {
+        for implementation in parsed_namespace.external_trait_implementations {
             let for_type = .typecheck_typename(parsed_type: implementation.for_type, scope_id, name: None)
             match .get_type(for_type) {
                 Struct(struct_id) | GenericInstance(id: struct_id) => {
                     mut struct_ = .get_struct(struct_id)
-                    for method in implementation.methods.iterator() {
+                    for method in implementation.methods {
                         mut this_arg_type_id: TypeId? = None
                         if (method.parsed_function.params.first()?.variable?.name ?? "") == "this" {
                             this_arg_type_id = for_type
@@ -1249,12 +1249,12 @@ struct Typechecker {
                         trait_name_scope_id_override: scope_id
                     )
 
-                    for trait_name in implementation.traits.iterator() {
+                    for trait_name in implementation.traits {
                         let trait_id = .find_trait_in_scope(scope_id, name: trait_name.name)
                         guard trait_id.has_value() else { continue }
 
                         let trait_ = .get_trait(trait_id!)
-                        for (name, function_id) in trait_.methods.iterator() {
+                        for (name, function_id) in trait_.methods {
                             if .find_function_in_scope(parent_scope_id: struct_.scope_id, function_name: name).has_value() {
                                 continue
                             }
@@ -1275,7 +1275,7 @@ struct Typechecker {
                 }
                 Enum(enum_id) | GenericEnumInstance(id: enum_id) => {
                     mut enum_ = .get_enum(enum_id)
-                    for method in implementation.methods.iterator() {
+                    for method in implementation.methods {
                         mut this_arg_type_id: TypeId? = None
                         if (method.parsed_function.params.first()?.variable?.name ?? "") == "this" {
                             this_arg_type_id = for_type
@@ -1295,12 +1295,12 @@ struct Typechecker {
                         trait_name_scope_id_override: scope_id
                     )
 
-                    for trait_name in implementation.traits.iterator() {
+                    for trait_name in implementation.traits {
                         let trait_id = .find_trait_in_scope(scope_id, name: trait_name.name)
                         guard trait_id.has_value() else { continue }
 
                         let trait_ = .get_trait(trait_id!)
-                        for (name, function_id) in trait_.methods.iterator() {
+                        for (name, function_id) in trait_.methods {
                             if .find_function_in_scope(parent_scope_id: enum_.scope_id, function_name: name).has_value() {
                                 continue
                             }
@@ -1366,7 +1366,7 @@ struct Typechecker {
         mut generic_parameters: [CheckedGenericParameter] = module.traits[trait_id.id].generic_parameters
         generic_parameters.ensure_capacity(parsed_trait.generic_parameters.size())
 
-        for gen_parameter in parsed_trait.generic_parameters.iterator() {
+        for gen_parameter in parsed_trait.generic_parameters {
             module.types.push(Type::TypeVariable(gen_parameter.name))
 
             let parameter_type_id = TypeId(
@@ -1410,7 +1410,7 @@ struct Typechecker {
         ))
         let struct_type_id = .find_or_add_type_id(Type::Struct(synthetic_struct_id))
 
-        for parsed_function in parsed_trait.methods.iterator() {
+        for parsed_function in parsed_trait.methods {
             let method_scope_id = .create_scope(
                 parent_scope_id: trait_scope_id
                 can_throw: parsed_function.can_throw
@@ -1439,7 +1439,7 @@ struct Typechecker {
     function typecheck_trait(mut this, parsed_trait: ParsedTrait, trait_id: TraitId, scope_id: ScopeId) throws {
         let checked_trait = .program.modules[trait_id.module.id].traits[trait_id.id]
 
-        for parsed_function in parsed_trait.methods.iterator() {
+        for parsed_function in parsed_trait.methods {
             if parsed_function.block.stmts.is_empty() {
                 continue
             }
@@ -1503,7 +1503,7 @@ struct Typechecker {
         mut checked_fields: [CheckedField] = []
         mut seen_fields: {String} = {}
         if parsed_record.record_type is SumEnum(fields) {
-            for field in fields.iterator() {
+            for field in fields {
                 let var_decl = field.var_decl
                 if seen_fields.contains(var_decl.name) {
                     .error(format("Field '{}' is defined more than once", var_decl.name), var_decl.span)
@@ -1558,7 +1558,7 @@ struct Typechecker {
         mut generic_parameters: [CheckedGenericParameter] = module.enums[enum_id.id].generic_parameters
         generic_parameters.ensure_capacity(parsed_record.generic_parameters.size())
 
-        for gen_parameter in parsed_record.generic_parameters.iterator() {
+        for gen_parameter in parsed_record.generic_parameters {
             module.types.push(Type::TypeVariable(gen_parameter.name))
 
             let parameter_type_id = TypeId(
@@ -1589,7 +1589,7 @@ struct Typechecker {
         }
 
         let is_extern = parsed_record.definition_linkage is External
-        for method in parsed_record.methods.iterator() {
+        for method in parsed_record.methods {
             let func = method.parsed_function
             let method_scope_id = .create_scope(
                 parent_scope_id: enum_scope_id
@@ -1639,7 +1639,7 @@ struct Typechecker {
             let function_id = module.add_function(checked_function)
             mut generic_parameters: [FunctionGenericParameter] = []
 
-            for generic_parameter in func.generic_parameters.iterator() {
+            for generic_parameter in func.generic_parameters {
                 module.types.push(Type::TypeVariable(generic_parameter.name))
                 let type_var_type_id = TypeId(
                     module: .current_module_id
@@ -1669,7 +1669,7 @@ struct Typechecker {
 
             checked_function.generics.params = generic_parameters
 
-            for param in func.params.iterator() {
+            for param in func.params {
                 if param.variable.name == "this" {
                     let checked_variable = CheckedVariable(
                         name: param.variable.name
@@ -1800,8 +1800,8 @@ struct Typechecker {
             let inheritance_chain = .struct_inheritance_chain(struct_id)
 
             mut func = module.functions.last()!
-            for field_struct_id in inheritance_chain.iterator() {
-                for field in .get_struct(field_struct_id).fields.iterator() {
+            for field_struct_id in inheritance_chain {
+                for field in .get_struct(field_struct_id).fields {
                     let variable = .get_variable(field.variable_id)
                     func.add_param(CheckedParameter(
                         requires_label: true
@@ -1846,7 +1846,7 @@ struct Typechecker {
     ) throws {
         let trait_name_scope_id = trait_name_scope_id_override ?? scope_id
         // register the traits that this record is supposed to implement.
-        for trait_name in parsed_impl_list.iterator() {
+        for trait_name in parsed_impl_list {
             // look for the trait.
             let maybe_type_id = .find_type_in_scope(scope_id: trait_name_scope_id, name: trait_name.name)
             guard maybe_type_id.has_value() else {
@@ -1860,7 +1860,7 @@ struct Typechecker {
             }
 
             mut generic_arguments: [TypeId] = []
-            for argument in trait_name.generic_parameters.iterator() {
+            for argument in trait_name.generic_parameters {
                 let argument_type_id = .typecheck_typename(parsed_type: argument, scope_id, name: None)
                 generic_arguments.push(argument_type_id)
             }
@@ -1951,7 +1951,7 @@ struct Typechecker {
         mut generic_parameters: [CheckedGenericParameter] = module.structures[struct_id.id].generic_parameters
         generic_parameters.ensure_capacity(parsed_record.generic_parameters.size())
 
-        for gen_parameter in parsed_record.generic_parameters.iterator() {
+        for gen_parameter in parsed_record.generic_parameters {
             module.types.push(Type::TypeVariable(gen_parameter.name))
 
             let parameter_type_id = TypeId(
@@ -1979,11 +1979,11 @@ struct Typechecker {
                 scope_id: struct_scope_id
             )
 
-            for implements_entry in parsed_record.implements_list!.iterator() {
+            for implements_entry in parsed_record.implements_list! {
                 let trait_id = .find_trait_in_scope(scope_id, name: implements_entry.name)
                 guard trait_id.has_value() else { continue }
                 let trait_ = .program.modules[trait_id!.module.id].traits[trait_id!.id]
-                for (name, function_id) in trait_.methods.iterator() {
+                for (name, function_id) in trait_.methods {
                     if .find_function_in_scope(parent_scope_id: struct_scope_id, function_name: name).has_value() {
                         continue
                     }
@@ -2005,7 +2005,7 @@ struct Typechecker {
         }
 
         let is_extern = parsed_record.definition_linkage is External
-        for method in parsed_record.methods.iterator() {
+        for method in parsed_record.methods {
             let func = method.parsed_function
 
             let method_scope_id = .create_scope(parent_scope_id: struct_scope_id, can_throw: func.can_throw, debug_name: format("method({}::{})", parsed_record.name, func.name))
@@ -2050,7 +2050,7 @@ struct Typechecker {
             .current_function_id = function_id
 
 
-            for gen_parameter in func.generic_parameters.iterator() {
+            for gen_parameter in func.generic_parameters {
                 module.types.push(Type::TypeVariable(gen_parameter.name))
                 let type_var_type_id = TypeId(
                     module: .current_module_id
@@ -2070,7 +2070,7 @@ struct Typechecker {
                 .add_type_to_scope(scope_id: method_scope_id, type_name: gen_parameter.name, type_id: type_var_type_id, span: gen_parameter.span)
             }
 
-            for param in func.params.iterator() {
+            for param in func.params {
                 if param.variable.name == "this" {
                     let checked_variable = CheckedVariable(
                         name: param.variable.name
@@ -2187,7 +2187,7 @@ struct Typechecker {
             .typecheck_namespace_declarations(parsed_namespace: child_namespace, scope_id: child_namespace_scope_id)
         }
 
-        for record in parsed_namespace.records.iterator() {
+        for record in parsed_namespace.records {
             match record.record_type {
                 Struct | Class => {
                     let struct_id = .find_struct_in_scope(scope_id, name: record.name)
@@ -2207,18 +2207,18 @@ struct Typechecker {
             }
         }
 
-        for fun in parsed_namespace.functions.iterator() {
+        for fun in parsed_namespace.functions {
             .current_function_id = .find_function_in_scope(parent_scope_id: scope_id, function_name: fun.name)
             .typecheck_function(parsed_function: fun, parent_scope_id: scope_id)
             .current_function_id = None
         }
 
-        for implementation in parsed_namespace.external_trait_implementations.iterator() {
+        for implementation in parsed_namespace.external_trait_implementations {
             let for_type = .typecheck_typename(parsed_type: implementation.for_type, scope_id, name: None)
             match .get_type(for_type) {
                 Struct(struct_id) | GenericInstance(id: struct_id) => {
                     mut struct_ = .get_struct(struct_id)
-                    for method in implementation.methods.iterator() {
+                    for method in implementation.methods {
                         if (method.parsed_function.params.first()?.variable?.name ?? "") == "this" {
                             .typecheck_method(
                                 func: method.parsed_function
@@ -2234,7 +2234,7 @@ struct Typechecker {
                 }
                 Enum(enum_id) | GenericEnumInstance(id: enum_id) => {
                     mut enum_ = .get_enum(enum_id)
-                    for method in implementation.methods.iterator() {
+                    for method in implementation.methods {
                         if (method.parsed_function.params.first()?.variable?.name ?? "") == "this" {
                             .typecheck_method(
                                 func: method.parsed_function
@@ -2262,7 +2262,7 @@ struct Typechecker {
         mut common_seen_fields: {String} = {}
         mut common_fields: [VarId] = []
         mut common_params: [CheckedParameter] = []
-        for field in enum_.fields.iterator() {
+        for field in enum_.fields {
             let variable = .get_variable(field.variable_id)
             common_params.push(CheckedParameter(
                 requires_label: true,
@@ -2277,7 +2277,7 @@ struct Typechecker {
             ValueEnum(underlying_type, variants) => {
                 let underlying_type_id = .typecheck_typename(parsed_type: underlying_type, scope_id: parent_scope_id, name: None)
                 mut module = .current_module()
-                for variant in variants.iterator() {
+                for variant in variants {
                     if seen_names.contains(variant.name) {
                         .error(format("Enum variant '{}' is defined more than once", variant.name), variant.span)
                     } else {
@@ -2326,7 +2326,7 @@ struct Typechecker {
             }
             SumEnum(is_boxed, variants) => {
                 mut module = .current_module()
-                for variant in variants.iterator() {
+                for variant in variants {
                     if seen_names.contains(variant.name) {
                         .error(format("Enum variant '{}' is defined more than once", variant.name), variant.span)
                         continue
@@ -2337,21 +2337,21 @@ struct Typechecker {
 
                     if is_structlike {
                         mut seen_fields: {String} = {}
-                        for name in common_seen_fields.iterator() {
+                        for name in common_seen_fields {
                             seen_fields.add(name)
                         }
 
                         mut params: [CheckedParameter] = []
-                        for param in common_params.iterator() {
+                        for param in common_params {
                             params.push(param)
                         }
 
                         mut fields: [VarId] = []
-                        for field in common_fields.iterator() {
+                        for field in common_fields {
                             fields.push(field)
                         }
 
-                        for param in variant.params!.iterator() {
+                        for param in variant.params! {
                             if seen_fields.contains(param.name) {
                                 .error(format("Enum variant '{}' has a member named '{}' more than once", variant.name, param.name), param.span)
                                 continue
@@ -2418,7 +2418,7 @@ struct Typechecker {
                         }
                     } else if is_typed {
                         mut params: [CheckedParameter] = []
-                        for param in common_params.iterator() {
+                        for param in common_params {
                             params.push(param)
                         }
 
@@ -2477,7 +2477,7 @@ struct Typechecker {
                         }
                     } else {
                         mut params: [CheckedParameter] = []
-                        for param in common_params.iterator() {
+                        for param in common_params {
                             params.push(param)
                         }
 
@@ -2529,7 +2529,7 @@ struct Typechecker {
     }
 
     function typecheck_enum(mut this, record: ParsedRecord, enum_id: EnumId, parent_scope_id: ScopeId) throws {
-        for method in record.methods.iterator() {
+        for method in record.methods {
             .typecheck_method(
                 func: method.parsed_function
                 parent_id: StructOrEnumId::Enum(enum_id)
@@ -2552,7 +2552,7 @@ struct Typechecker {
         while super_struct_id.has_value() {
             let super_struct = .get_struct(super_struct_id!)
             let scope = .get_scope(super_struct.scope_id)
-            for function_tuple in scope.functions.iterator() {
+            for function_tuple in scope.functions {
                 let function_ = .get_function(function_tuple.1)
                 if function_.is_virtual {
                     all_virtuals[function_.name] = function_
@@ -2567,7 +2567,7 @@ struct Typechecker {
             let trait_implementations = .get_struct(struct_id).trait_implementations
             checks.ensure_capacity(trait_implementations.size())
 
-            for (trait_name, trait_id_and_generic_params) in trait_implementations.iterator() {
+            for (trait_name, trait_id_and_generic_params) in trait_implementations {
                 checks.register_trait(
                     trait_id: trait_id_and_generic_params.0
                     trait_name
@@ -2576,7 +2576,7 @@ struct Typechecker {
             }
         }
 
-        for method in record.methods.iterator() {
+        for method in record.methods {
             if method.is_override {
                 if not all_virtuals.contains(method.parsed_function.name) {
                     .error("Missing virtual for override", method.parsed_function.name_span)
@@ -2597,7 +2597,7 @@ struct Typechecker {
             let trait_implementations = .get_struct(struct_id).trait_implementations
             checks.ensure_capacity(trait_implementations.size())
 
-            for (trait_name, trait_id_and_generic_params) in trait_implementations.iterator() {
+            for (trait_name, trait_id_and_generic_params) in trait_implementations {
                 let (trait_id, generic_params) = trait_id_and_generic_params
                 let trait_ = .get_trait(trait_id)
                 if trait_.generic_parameters.size() != generic_params.size() {
@@ -2616,7 +2616,7 @@ struct Typechecker {
             }
 
             let scope = .get_scope(.get_struct(struct_id).scope_id)
-            for (name, function_id) in scope.functions.iterator() {
+            for (name, function_id) in scope.functions {
                 checks.register_method(
                     method_name: name,
                     method_id: function_id,
@@ -2666,7 +2666,7 @@ struct Typechecker {
         let function_scope_id = checked_function.function_scope_id
 
         mut module = .current_module()
-        for param in checked_function.params.iterator() {
+        for param in checked_function.params {
             let variable = param.variable
             let var_id = module.add_variable(variable)
             .add_var_to_scope(scope_id: function_scope_id, name: variable.name, var_id, span: variable.definition_span)
@@ -2775,7 +2775,7 @@ struct Typechecker {
         scope_id: ScopeId
     ) throws {
         trait_requirements.ensure_capacity(names.size())
-        for name in names.iterator() {
+        for name in names {
             let type_id = .find_type_in_scope(scope_id, name: name.name)
             guard type_id.has_value() else {
                 .error(format("Couldn't find trait ‘{}’", name.name), name.name_span)
@@ -2854,7 +2854,7 @@ struct Typechecker {
 
         // Check generic parameters
         mut i = 0
-        for generic_parameter in parsed_function.generic_parameters.iterator() {
+        for generic_parameter in parsed_function.generic_parameters {
             mut type_var_type_id = TypeId(
                 module: current_module.id
                 id: current_module.types.size()
@@ -2898,7 +2898,7 @@ struct Typechecker {
         // Check parameters
         mut first = true
         mut module = .current_module()
-        for parameter in parsed_function.params.iterator() {
+        for parameter in parsed_function.params {
             let checked_param = .typecheck_parameter(parameter, scope_id: checked_function_scope_id, first, this_arg_type_id, check_scope)
 
             checked_function.params.push(checked_param)
@@ -2989,7 +2989,7 @@ struct Typechecker {
             }
         }
 
-        for constraint in constraints.iterator() {
+        for constraint in constraints {
             let trait_name = .program.get_trait(constraint).name
             let implemented_trait: (TraitId, [TypeId])? = implemented_traits.get(trait_name)
             if not implemented_trait.has_value() or not implemented_trait!.0.equals(constraint) {
@@ -3118,7 +3118,7 @@ struct Typechecker {
 
         mut param_vars: [CheckedVariable] = []
         mut module = .current_module()
-        for param in checked_function.params.iterator() {
+        for param in checked_function.params {
             let variable = param.variable
             param_vars.push(variable)
 
@@ -3696,7 +3696,7 @@ struct Typechecker {
             yielded_type: TypeId::none()
             yielded_none: false
         )
-        for parsed_statement in parsed_block.stmts.iterator() {
+        for parsed_statement in parsed_block.stmts {
             if not checked_block.control_flow.is_reachable() {
                 .error("Unreachable code", parsed_statement.span())
             }
@@ -3765,7 +3765,7 @@ struct Typechecker {
         NamespacedName(name, namespaces, params, span) => {
             mut current_namespace_scope_id = scope_id
 
-            for ns in namespaces.iterator() {
+            for ns in namespaces {
                 let result = .find_namespace_in_scope(scope_id: current_namespace_scope_id, name: ns)
 
                 if result.has_value() {
@@ -3778,7 +3778,7 @@ struct Typechecker {
 
             mut generic_args: [TypeId] = []
 
-            for param in params.iterator() {
+            for param in params {
                 let checked_arg = .typecheck_typename(parsed_type: param, scope_id, name)
 
                 generic_args.push(checked_arg)
@@ -3836,7 +3836,7 @@ struct Typechecker {
         }
         JaktTuple(types, span) => {
             mut checked_types: [TypeId] = []
-            for parsed_type in types.iterator() {
+            for parsed_type in types {
                 checked_types.push(.typecheck_typename(parsed_type, scope_id, name))
             }
             let tuple_struct_id = .find_struct_in_prelude("Tuple")
@@ -3887,7 +3887,7 @@ struct Typechecker {
         GenericType(name, generic_parameters, span) => {
             mut checked_inner_types: [TypeId] = []
 
-            for inner_type in generic_parameters.iterator() {
+            for inner_type in generic_parameters {
                 let inner_type_id = .typecheck_typename(parsed_type: inner_type, scope_id, name)
                 checked_inner_types.push(inner_type_id)
             }
@@ -3908,7 +3908,7 @@ struct Typechecker {
                 .generic_inferences.restore(old_generic_inferences)
             }
 
-            for param in params.iterator() {
+            for param in params {
                 checked_params.push(.typecheck_parameter(parameter: param, scope_id, first, this_arg_type_id: None, check_scope: None))
                 first = false
             }
@@ -3948,7 +3948,7 @@ struct Typechecker {
             let function_id = module.add_function(checked_function)
 
             mut param_type_ids: [TypeId] = []
-            for param in checked_function.params.iterator() {
+            for param in checked_function.params {
                 param_type_ids.push(param.variable.type_id)
             }
 
@@ -4266,7 +4266,7 @@ struct Typechecker {
 
     function typecheck_guard(mut this, expr: ParsedExpression, else_block: ParsedBlock, remaining_code: ParsedBlock, scope_id: ScopeId, safety_mode: SafetyMode, span: Span) throws -> CheckedStatement {
         mut seen_scope_exit = false
-        for statement in else_block.stmts.iterator() {
+        for statement in else_block.stmts {
             match statement {
                 Break | Continue | Return | Throw => {
                     seen_scope_exit = true
@@ -4395,7 +4395,7 @@ struct Typechecker {
             } else if implemented_into_iterator_trait_id.size() != 1 {
                 mut type_names = ""
                 mut first = true
-                for args in implemented_into_iterator_trait_id.iterator() {
+                for args in implemented_into_iterator_trait_id {
                     if first {
                         first = false
                     } else {
@@ -4426,7 +4426,7 @@ struct Typechecker {
             if implemented_iterable_trait_args.size() != 1 {
                 mut type_names = ""
                 mut first = true
-                for args in implemented_iterable_trait_args.iterator() {
+                for args in implemented_iterable_trait_args {
                     if first {
                         first = false
                     } else {
@@ -4593,7 +4593,7 @@ struct Typechecker {
                     IsEnumVariant(inner, bindings) => {
                         let unary_op_single_condition = ParsedExpression::UnaryOp(expr, op: UnaryOperator::Is(inner), span)
                         mut outer_if_stmts: [ParsedStatement] = []
-                        for binding in bindings.iterator() {
+                        for binding in bindings {
                             let var = ParsedVarDecl(
                                 name: binding.binding
                                 parsed_type: ParsedType::Empty
@@ -4610,7 +4610,7 @@ struct Typechecker {
                                 inner_condition = acc!
                                 outer_if_stmts.push(ParsedStatement::If(condition: inner_condition, then_block: then_block!, else_statement, span))
                             } else {
-                                for stmt in then_block!.stmts.iterator() {
+                                for stmt in then_block!.stmts {
                                     outer_if_stmts.push(stmt)
                                 }
                             }
@@ -4916,7 +4916,7 @@ struct Typechecker {
         }
 
         mut strings: [String] = []
-        for statement in block.stmts.iterator() {
+        for statement in block.stmts {
             if statement is Expression(expr)
                 and expr is QuotedString(val, span) {
                 strings.push(val)
@@ -5005,7 +5005,7 @@ struct Typechecker {
                 match .get_type(type_id) {
                     GenericInstance(id: struct_id) | Struct(struct_id) => {
                         let structure = .get_struct(struct_id)
-                        for field in structure.fields.iterator() {
+                        for field in structure.fields {
                             let member = .get_variable(field.variable_id)
 
                             if member.name == field_name {
@@ -5028,7 +5028,7 @@ struct Typechecker {
                     }
                     GenericEnumInstance(id: enum_id) | Enum(enum_id) => {
                         let enum_ = .get_enum(enum_id)
-                        for field in enum_.fields.iterator() {
+                        for field in enum_.fields {
                             let member = .get_variable(field.variable_id)
 
                             if member.name == field_name {
@@ -5080,7 +5080,7 @@ struct Typechecker {
                 }
 
                 let enum_ = .get_enum(enum_id)
-                for field in enum_.fields.iterator() {
+                for field in enum_.fields {
                     let member = .get_variable(field.variable_id)
 
                     if member.name == field_name {
@@ -5218,7 +5218,7 @@ struct Typechecker {
             }
         }
 
-        for scope in whitelist.iterator() {
+        for scope in whitelist {
             let resolved_scope = scope.try_resolve(program: .program)
             guard resolved_scope is Resolved(scope_id) else {
                 continue
@@ -5606,7 +5606,7 @@ struct Typechecker {
                         if .get_type(expr_type_id) is Enum(enum_id) {
                             let enum_ = .get_enum(enum_id)
                             mut exists = false
-                            for variant in enum_.variants.iterator() {
+                            for variant in enum_.variants {
                                 exists = match variant {
                                     StructLike(name: var_name) | Typed(name: var_name) | Untyped(name: var_name) => var_name == name
                                     else => false
@@ -5721,7 +5721,7 @@ struct Typechecker {
             mut checked_values: [CheckedExpression] = []
             mut checked_types: [TypeId] = []
 
-            for value in values.iterator() {
+            for value in values {
                 let checked_value= .typecheck_expression(value, scope_id, safety_mode, type_hint: None)
                 let type_id = checked_value.type()
                 if type_id.equals(VOID_TYPE_ID) {
@@ -5904,7 +5904,7 @@ struct Typechecker {
     }
 
     function get_enum_variant(mut this, enum_: CheckedEnum, variant_name: String) throws -> CheckedEnumVariant? {
-        for variant in enum_.variants.iterator() {
+        for variant in enum_.variants {
             if variant.name() == variant_name {
                 return variant
             }
@@ -5926,11 +5926,11 @@ struct Typechecker {
         }
         mut checked_vars: [CheckedVariable] = []
         mut checked_enum_variant_bindings: [CheckedEnumVariantBinding] = []
-        for field in fields.iterator() {
+        for field in fields {
             checked_vars.push(.get_variable(field))
         }
-        for binding in bindings.iterator() {
-            for var in checked_vars.iterator() {
+        for binding in bindings {
+            for var in checked_vars {
                 let binding_name = binding.name ?? binding.binding
                 let type_id = var.type_id
                 if binding_name == var.name {
@@ -5968,7 +5968,7 @@ struct Typechecker {
         
         let lambda_scope_id = .create_scope(parent_scope_id: scope_id, can_throw, debug_name: "lambda")
         mut checked_captures: [CheckedCapture] = []
-        for capture in captures.iterator() {
+        for capture in captures {
             if .find_var_in_scope(scope_id, var: capture.name()).has_value() {
                 checked_captures.push(match capture {
                     ByValue(name, span) => CheckedCapture::ByValue(name, span)
@@ -5983,7 +5983,7 @@ struct Typechecker {
         mut module = .current_module()
         mut checked_params: [CheckedParameter] = []
         mut first = true
-        for param in params.iterator() {
+        for param in params {
             let checked_param = .typecheck_parameter(parameter: param, scope_id, first, this_arg_type_id: None, check_scope: None)
             checked_params.push(checked_param)
             let var_id = module.add_variable(checked_param.variable)
@@ -6042,7 +6042,7 @@ struct Typechecker {
 
     function typecheck_namespaced_var_or_simple_enum_constructor_call(mut this, name: String, namespace_: [String], scope_id: ScopeId, safety_mode: SafetyMode, type_hint: TypeId?, span: Span) throws -> CheckedExpression {
         mut scopes = [scope_id]
-        for ns in namespace_.iterator() {
+        for ns in namespace_ {
             let scope = scopes[scopes.size() - 1]
             let ns_in_scope = .find_namespace_in_scope(scope_id: scope, name: ns)
             let enum_in_scope = .program.find_enum_in_scope(scope_id: scope, name: ns)
@@ -6146,7 +6146,7 @@ struct Typechecker {
         }
 
         mut vals: [CheckedExpression] = []
-        for value in values.iterator() {
+        for value in values {
             let checked_expr = .typecheck_expression(value, scope_id, safety_mode, type_hint: inner_hint)
             let current_value_type_id = checked_expr.type()
             if current_value_type_id.equals(void_type_id()) {
@@ -6205,7 +6205,7 @@ struct Typechecker {
         // TODO: type hints
         mut inner_hint: TypeId? = None
 
-        for value in values.iterator() {
+        for value in values {
             let checked_value = .typecheck_expression(expr: value, scope_id, safety_mode, type_hint: inner_hint)
             let current_value_type_id = checked_value.type()
             if inner_type_id.equals(unknown_type_id()) {
@@ -6257,7 +6257,7 @@ struct Typechecker {
     function typecheck_generic_arguments_method_call(mut this, checked_expr: CheckedExpression, call: ParsedCall, scope_id: ScopeId, span: Span, is_optional: bool, safety_mode: SafetyMode) throws -> CheckedExpression {
         mut checked_args: [(String, CheckedExpression)] = []
         checked_args.ensure_capacity(call.args.size())
-        for (name, _, expr) in call.args.iterator() {
+        for (name, _, expr) in call.args {
             let checked_arg_expr = .typecheck_expression(
                 expr
                 scope_id
@@ -6268,7 +6268,7 @@ struct Typechecker {
         }
 
         mut checked_type_args: [TypeId] = []
-        for type_arg in call.type_args.iterator() {
+        for type_arg in call.type_args {
             checked_type_args.push(.typecheck_typename(parsed_type: type_arg, scope_id, name: None))
         }
 
@@ -6330,15 +6330,15 @@ struct Typechecker {
                 covered_name = name
 
                 mut field_variables: [CheckedVariable] = []
-                for var_id in fields.iterator() {
+                for var_id in fields {
                     field_variables.push(.program.get_variable(var_id))
                 }
                 mut seen_names: {String} = {}
-                for arg in variant_arguments.iterator() {
+                for arg in variant_arguments {
                     if not arg.name.has_value() {
                         mut found_field_name = false
                         mut field_names: [String] = []
-                        for var in field_variables.iterator() {
+                        for var in field_variables {
                             field_names.push(var.name)
                             if var.name == arg.binding {
                                 found_field_name = true
@@ -6346,7 +6346,7 @@ struct Typechecker {
                         }
                         if not found_field_name {
                             mut unused_field_names: [String] = []
-                            for field_name in field_names.iterator() {
+                            for field_name in field_names {
                                 if seen_names.contains(field_name) {
                                     continue
                                 }
@@ -6368,7 +6368,7 @@ struct Typechecker {
                     }
                     seen_names.add(arg_name)
                     mut matched_field_variable: CheckedVariable? = None
-                    for var in field_variables.iterator() {
+                    for var in field_variables {
                         if var.name == arg_name {
                             matched_field_variable = var
                         }
@@ -6462,8 +6462,8 @@ struct Typechecker {
 
                 let case_count = cases.size()
                 mut current_case_index = 0uz
-                for case_ in cases.iterator() {
-                    for pattern in case_.patterns.iterator() {
+                for case_ in cases {
+                    for pattern in case_.patterns {
                         match pattern {
                             EnumVariant(variant_names, variant_arguments, arguments_span) => {
                                 mut variant_names_ = variant_names
@@ -6488,7 +6488,7 @@ struct Typechecker {
                                 mut i = 0uz
                                 mut matched_variant: CheckedEnumVariant? = None
                                 mut variant_index: usize? = None
-                                for v in enum_.variants.iterator() {
+                                for v in enum_.variants {
                                     if v.name() == variant_names_[1].0 {
                                         matched_variant = v
                                         variant_index = i
@@ -6534,7 +6534,7 @@ struct Typechecker {
 
                                 if variant_arguments.size() > 0 {
                                     mut variant_index = 0uz
-                                    for variant in enum_.variants.iterator() {
+                                    for variant in enum_.variants {
                                         if not covered_variants.contains(variant.name()) {
                                             expanded_catch_all = true
 
@@ -6591,11 +6591,11 @@ struct Typechecker {
                 mut enum_variant_names: [String] = []
                 mut missing_variants: [String] = []
 
-                for variant in enum_.variants.iterator() {
+                for variant in enum_.variants {
                     enum_variant_names.push(variant.name())
                 }
 
-                for variant in enum_variant_names.iterator() {
+                for variant in enum_variant_names {
                     if not covered_variants.contains(variant) {
                         missing_variants.push(variant)
                     }
@@ -6621,8 +6621,8 @@ struct Typechecker {
 
                 let case_count = cases.size()
                 mut current_case_index = 0uz
-                for case_ in cases.iterator() {
-                    for pattern in case_.patterns.iterator() {
+                for case_ in cases {
+                    for pattern in case_.patterns {
                         match pattern {
                             EnumVariant(variant_names, variant_arguments, arguments_span) => {
                                 if is_value_match {
@@ -6847,7 +6847,7 @@ struct Typechecker {
             value_hint = args[1]
         }
 
-        for (key, value) in values.iterator() {
+        for (key, value) in values {
             let checked_key = .typecheck_expression(key, scope_id, safety_mode, type_hint: key_hint)
             let current_key_type_id = checked_key.type()
 
@@ -7025,7 +7025,7 @@ struct Typechecker {
             .generic_inferences.restore(old_generic_inferences)
         }
 
-        for name in call.namespace_.iterator() {
+        for name in call.namespace_ {
             resolved_namespaces.push(ResolvedNamespace(name, generic_parameters: None))
         }
 
@@ -7069,7 +7069,7 @@ struct Typechecker {
 
         match call.name {
             "print" | "println" | "eprintln" | "eprint" | "format" => {
-                for arg in call.args.iterator() {
+                for arg in call.args {
                     let checked_arg = .typecheck_expression(expr: arg.2, scope_id: caller_scope_id, safety_mode, type_hint: None)
 
                     args.push((call.name, checked_arg))
@@ -7083,11 +7083,11 @@ struct Typechecker {
             else => {
                 if not resolved_function_id.has_value() {
                     mut checked_type_args: [TypeId] = []
-                    for type_arg in call.type_args.iterator() {
+                    for type_arg in call.type_args {
                         checked_type_args.push(.typecheck_typename(parsed_type: type_arg, scope_id: caller_scope_id, name: None))
                     }
 
-                    for arg in call.args.iterator() {
+                    for arg in call.args {
                         let checked_arg = .typecheck_expression(expr: arg.2, scope_id: caller_scope_id, safety_mode, type_hint: None)
 
                         args.push((call.name, checked_arg))
@@ -7128,7 +7128,7 @@ struct Typechecker {
 
                 // If the user gave us explicit type arguments, let's use them in our substitutions
                 mut type_arg_index = 0uz
-                for parsed_type in call.type_args.iterator() {
+                for parsed_type in call.type_args {
                     let checked_type = .typecheck_typename(parsed_type, scope_id: caller_scope_id, name: None)
                     if callee.generics.params.size() <= type_arg_index {
                         .error("Trying to access generic parameter out of bounds", parsed_type.span())
@@ -7235,7 +7235,7 @@ struct Typechecker {
                     .ignore_errors = old_ignore_errors
                 }
 
-                for generic_typevar in callee.generics.params.iterator() {
+                for generic_typevar in callee.generics.params {
                     if generic_typevar.kind is Parameter {
                         let substitution = .generic_inferences.get(generic_typevar.type_id().to_string())
                         if substitution.has_value() {
@@ -7343,7 +7343,7 @@ struct Typechecker {
                 }
             }
 
-            for argument in args.iterator() {
+            for argument in args {
                 let value = try interpreter.execute_expression(
                     expr: argument.1,
                     scope: eval_scope
@@ -7414,8 +7414,8 @@ struct Typechecker {
 
     function check_implicit_constructor_argument_access(mut this, caller_scope_id: ScopeId, call: ParsedCall, struct_: CheckedStruct)  throws {
         if not .scope_can_access(accessor:caller_scope_id, accessee:struct_.scope_id) {
-            for arg in call.args.iterator() {
-                for field in struct_.fields.iterator() {
+            for arg in call.args {
+                for field in struct_.fields {
                     let variable = .get_variable(field.variable_id)
                     if (variable.name == arg.0 and variable.visibility is Private) {
                         .error(format("Can't access field '{}' when calling implicit constructor of '{}' because it is marked private", variable.name, struct_.name), arg.1)
@@ -7429,7 +7429,7 @@ struct Typechecker {
     function resolve_default_params(mut this, params: [CheckedParameter], args: [(String, Span, ParsedExpression)], scope_id: ScopeId, safety_mode: SafetyMode, arg_offset: usize, span: Span) throws -> [(String, Span, CheckedExpression)] {
         mut params_with_default_value = 0uz
 
-        for param in params.iterator() {
+        for param in params {
             if param.default_value.has_value() {
                 params_with_default_value++
             }
@@ -7540,7 +7540,7 @@ struct Typechecker {
             Struct(struct_id) | GenericInstance(id: struct_id) => {
                 let struct_ = .get_struct(struct_id)
                 mut implementations: [[TypeId]] = []
-                for (_, trait_descriptor) in struct_.trait_implementations.iterator() {
+                for (_, trait_descriptor) in struct_.trait_implementations {
                     if trait_descriptor.0.equals(trait_id) {
                         implementations.push(trait_descriptor.1)
                     }
@@ -7550,7 +7550,7 @@ struct Typechecker {
             Enum(enum_id) | GenericEnumInstance(id: enum_id) => {
                 let enum_ = .get_enum(enum_id)
                 mut implementations: [[TypeId]] = []
-                for (_, trait_descriptor) in enum_.trait_implementations.iterator() {
+                for (_, trait_descriptor) in enum_.trait_implementations {
                     if trait_descriptor.0.equals(trait_id) {
                         implementations.push(trait_descriptor.1)
                     }
@@ -7587,7 +7587,7 @@ struct Typechecker {
             }
 
             mut found = false
-            for implemented_generic_arguments in trait_implementations.iterator() {
+            for implemented_generic_arguments in trait_implementations {
                 if implemented_generic_arguments.size() != passed_generic_arguments.size() {
                     continue
                 }
@@ -7730,7 +7730,7 @@ struct TraitImplCheck {
         missing_methods.ensure_capacity(trait_methods.size())
 
 
-        for (method_name, method_id) in trait_methods.iterator() {
+        for (method_name, method_id) in trait_methods {
             missing_methods.set(method_name, method_id)
         }
 
@@ -7738,10 +7738,10 @@ struct TraitImplCheck {
     }
 
     function throw_errors(mut this, record_decl_span: Span, typechecker: &mut Typechecker) throws {
-        for (trait_name, missing_methods) in .missing_methods.iterator() {
+        for (trait_name, missing_methods) in .missing_methods {
             let unmatched_signatures = .unmatched_signatures[trait_name]
             let private_matching_methods = .private_matching_methods[trait_name]
-            for (method_name, trait_method_id) in missing_methods.iterator() {
+            for (method_name, trait_method_id) in missing_methods {
                 let already_implemented_for = .already_implemented_for.get(method_name)
                 let unmatched_signature = unmatched_signatures.get(method_name)
                 let private_matching_method = private_matching_methods.get(method_name)
@@ -7797,7 +7797,7 @@ struct TraitImplCheck {
         let method = typechecker.get_function(method_id)
 
         // search for a matching method
-        for (trait_name, methods) in .missing_methods.iterator() {
+        for (trait_name, methods) in .missing_methods {
             let trait_method_id = methods.get(method_name)
 
             guard trait_method_id.has_value() else {

--- a/selfhost/types.jakt
+++ b/selfhost/types.jakt
@@ -38,14 +38,14 @@ struct GenericInferences {
         return final_mapped_result ?? type
     }
 
-    function iterator(this) => .values.iterator()
+    function iterator(this) => .values
 
     function perform_checkpoint(mut this, reset: bool = true) throws -> [String:String] {
         let result = .values
         .values = [:]
 
         if not reset {
-            for (key, value) in result.iterator() {
+            for (key, value) in result {
                 .values[key] = value
             }
         }
@@ -689,7 +689,7 @@ class FunctionGenerics {
             return true
         }
 
-        for specialization in .specializations.iterator() {
+        for specialization in .specializations {
             mut matched = true
 
             if types.size() == specialization.size() {
@@ -1214,7 +1214,7 @@ boxed enum CheckedExpression {
     function control_flow(this) -> BlockControlFlow => match this {
         Match(expr, match_cases, span, type_id, all_variants_constant) => {
             mut control_flow: BlockControlFlow? = None
-            for case_ in match_cases.iterator() {
+            for case_ in match_cases {
                 let case_control_flow = match case_ {
                     EnumVariant(body) | Expression(body) | CatchAll(body) => match body {
                         Block(block) => block.control_flow
@@ -1376,7 +1376,7 @@ class CheckedProgram {
             if maybe_enum.has_value() {
                 return maybe_enum
             }
-            for child_id in scope.children.iterator() {
+            for child_id in scope.children {
                 let child_scope = .get_scope(id: child_id)
                 if not child_scope.namespace_name.has_value() {
                     let maybe_enum = child_scope.enums.get(name)
@@ -1405,7 +1405,7 @@ class CheckedProgram {
             if maybe_trait.has_value() {
                 return maybe_trait
             }
-            for child_id in scope.children.iterator() {
+            for child_id in scope.children {
                 let child_scope = .get_scope(id: child_id)
                 if not child_scope.namespace_name.has_value() {
                     let maybe_trait = child_scope.traits.get(name)
@@ -1461,7 +1461,7 @@ class CheckedProgram {
             if maybe_scope.has_value() {
                 return maybe_scope
             }
-            for child_id in scope.children.iterator() {
+            for child_id in scope.children {
                 let child_scope = .get_scope(id: child_id)
                 if not child_scope.namespace_name.has_value() {
                     let maybe_scope = child_scope.structs.get(name)
@@ -1492,7 +1492,7 @@ class CheckedProgram {
         loop {
             let scope = .get_scope(current)
 
-            for child in scope.children.iterator() {
+            for child in scope.children {
                 let child_scope = .get_scope(child)
                 if child_scope.namespace_name.has_value() {
                     if name == child_scope.namespace_name.value() {
@@ -1501,10 +1501,10 @@ class CheckedProgram {
                 }
             }
 
-            for child_id in scope.children.iterator() {
+            for child_id in scope.children {
                 let child_scope = .get_scope(id: child_id)
                 if not child_scope.namespace_name.has_value() {
-                    for scope in .get_scope(child_id).children.iterator() {
+                    for scope in .get_scope(child_id).children {
                         let descendant_scope = .get_scope(scope)
                         if descendant_scope.namespace_name.has_value() {
                             if name == descendant_scope.namespace_name.value() {
@@ -1546,7 +1546,7 @@ class CheckedProgram {
             let scope_id = queue.pop()!
             {
                 mut was_visited = false
-                for visited_id in visited.iterator() {
+                for visited_id in visited {
                     if visited_id.equals(scope_id) {
                         was_visited = true
                         break
@@ -1563,7 +1563,7 @@ class CheckedProgram {
                 return maybe_function
             }
             // search inside inline namespaces
-            for child_scope_id in scope.children.iterator() {
+            for child_scope_id in scope.children {
                 let scope = .get_scope(id: child_scope_id)
                 if not scope.namespace_name.has_value() {
                     queue.push(child_scope_id)
@@ -1638,7 +1638,7 @@ class CheckedProgram {
             Trait(id) => .get_trait(id).name
             Function(params, return_type_id) => {
                 mut param_names: [String] = []
-                for x in params.iterator() {
+                for x in params {
                     param_names.push(.type_name(x))
                 }
 
@@ -1653,7 +1653,7 @@ class CheckedProgram {
 
                 output += "<"
                 mut first = true
-                for arg in args.iterator() {
+                for arg in args {
                     if not first {
                         output += ", "
                     } else {
@@ -1672,7 +1672,7 @@ class CheckedProgram {
 
                 output += "<"
                 mut first = true
-                for arg in args.iterator() {
+                for arg in args {
                     if not first {
                         output += ", "
                     } else {
@@ -1711,7 +1711,7 @@ class CheckedProgram {
                 } else if id.equals(tuple_struct_id) {
                     output = "("
                     mut first = true
-                    for arg in args.iterator() {
+                    for arg in args {
                         if not first {
                             output += ", "
                         } else {
@@ -1727,7 +1727,7 @@ class CheckedProgram {
                     output = structure.name
                     output += "<"
                     mut first = true
-                    for arg in args.iterator() {
+                    for arg in args {
                         if not first {
                             output += ", "
                         } else {
@@ -1744,7 +1744,7 @@ class CheckedProgram {
                 mut output = .get_struct(id).name
                 mut first = true
                 output += "<"
-                for arg in args.iterator() {
+                for arg in args {
                     if not first {
                         output += ", "
                     } else {
@@ -1764,7 +1764,7 @@ class CheckedProgram {
     }
 
     public function find_or_add_type_id(mut this, anon type: Type, module_id: ModuleId) throws -> TypeId {
-        for module in .modules.iterator() {
+        for module in .modules {
             for id in 0..module.types.size() {
                 if module.types[id].equals(type) {
                     return TypeId(module: module.id, id)
@@ -1807,7 +1807,7 @@ class CheckedProgram {
             GenericTraitInstance(id, args) => {
                 mut new_args: [TypeId] = []
                 new_args.ensure_capacity(args.size())
-                for arg in args.iterator() {
+                for arg in args {
                     new_args.push(.substitute_typevars_in_type(type_id: arg, generic_inferences, module_id))
                 }
 
@@ -1816,7 +1816,7 @@ class CheckedProgram {
             GenericInstance(id, args) => {
                 mut new_args:[TypeId] = []
                 new_args.ensure_capacity(args.size())
-                for arg in args.iterator() {
+                for arg in args {
                     new_args.push(.substitute_typevars_in_type(type_id: arg, generic_inferences, module_id))
                 }
 
@@ -1825,7 +1825,7 @@ class CheckedProgram {
             GenericEnumInstance(id, args) => {
                 mut new_args:[TypeId] = []
                 new_args.ensure_capacity(args.size())
-                for arg in args.iterator() {
+                for arg in args {
                     new_args.push(.substitute_typevars_in_type(type_id: arg, generic_inferences, module_id))
                 }
                 return .find_or_add_type_id(Type::GenericEnumInstance(id, args: new_args), module_id)
@@ -1835,7 +1835,7 @@ class CheckedProgram {
                 if not struct_.generic_parameters.is_empty() {
                     mut new_args:[TypeId] = []
                     new_args.ensure_capacity(struct_.generic_parameters.size())
-                    for arg in struct_.generic_parameters.iterator() {
+                    for arg in struct_.generic_parameters {
                         new_args.push(.substitute_typevars_in_type(type_id: arg.type_id, generic_inferences, module_id))
                     }
                     return .find_or_add_type_id(Type::GenericInstance(id: struct_id, args: new_args), module_id)
@@ -1846,7 +1846,7 @@ class CheckedProgram {
                 if not enum_.generic_parameters.is_empty() {
                     mut new_args:[TypeId] = []
                     new_args.ensure_capacity(enum_.generic_parameters.size())
-                    for arg in enum_.generic_parameters.iterator() {
+                    for arg in enum_.generic_parameters {
                         new_args.push(.substitute_typevars_in_type(type_id: arg.type_id, generic_inferences, module_id))
                     }
                     return .find_or_add_type_id(Type::GenericEnumInstance(id: enum_id, args: new_args), module_id)
@@ -1874,7 +1874,7 @@ class CheckedProgram {
                 mut new_params:[TypeId] = []
                 new_params.ensure_capacity(params.size())
                 mut is_different = false
-                for param in params.iterator() {
+                for param in params {
                     let new_param = .substitute_typevars_in_type(type_id: param, generic_inferences, module_id)
                     is_different = is_different or not new_param.equals(param)
                     new_params.push(new_param)
@@ -1988,7 +1988,7 @@ boxed enum ValueImpl {
         CInt(x) => ValueImpl::CInt(x)
         Struct(fields, struct_id, constructor) => {
             mut fields_copy: [Value] = [];
-            for field in fields.iterator() {
+            for field in fields {
                 fields_copy.push(field.copy());
             }
             yield ValueImpl::Struct(fields: fields_copy, struct_id, constructor)
@@ -1996,32 +1996,32 @@ boxed enum ValueImpl {
         Class(fields, struct_id, constructor) => ValueImpl::Class(fields, struct_id, constructor)
         Enum(fields, enum_id, constructor) => {
             mut fields_copy: [Value] = [];
-            for field in fields.iterator() {
+            for field in fields {
                 fields_copy.push(field.copy());
             }
             yield ValueImpl::Enum(fields: fields_copy, enum_id, constructor)
         }
         JaktArray(values, type_id) => {
             mut values_copy: [Value] = [];
-            for value in values.iterator() {
+            for value in values {
                 values_copy.push(value.copy());
             }
             yield ValueImpl::JaktArray(values: values_copy, type_id)
         }
         JaktDictionary(keys, values, type_id) => {
             mut values_copy: [Value] = []
-            for value in values.iterator() {
+            for value in values {
                 values_copy.push(value.copy())
             }
             mut keys_copy: [Value] = []
-            for key in keys.iterator() {
+            for key in keys {
                 keys_copy.push(key.copy())
             }
             yield ValueImpl::JaktDictionary(keys: keys_copy, values: values_copy, type_id)
         }
         JaktSet(values, type_id) => {
             mut values_copy: [Value] = []
-            for value in values.iterator() {
+            for value in values {
                 values_copy.push(value.copy())
             }
             yield ValueImpl::JaktSet(values: values_copy, type_id)
@@ -2031,7 +2031,7 @@ boxed enum ValueImpl {
         OptionalNone => ValueImpl::OptionalNone
         JaktTuple(fields, type_id) => {
             mut values_copy: [Value] = [];
-            for value in fields.iterator() {
+            for value in fields {
                 values_copy.push(value.copy());
             }
             yield ValueImpl::JaktTuple(fields: values_copy, type_id)

--- a/selfhost/utility.jakt
+++ b/selfhost/utility.jakt
@@ -16,11 +16,11 @@ function todo(anon message: String) {
 function add_arrays<T>(anon a: [T], anon b: [T]) throws -> [T] {
     mut result: [T] = []
 
-    for x in a.iterator() {
+    for x in a {
         result.push(x)
     }
 
-    for x in b.iterator() {
+    for x in b {
         result.push(x)
     }
 
@@ -31,7 +31,7 @@ function join(anon strings: [String], separator: String) -> String {
     mut output = ""
 
     mut i = 0uz
-    for s in strings.iterator() {
+    for s in strings {
         output += s
         if i < strings.size() - 1 {
             output += separator
@@ -44,7 +44,7 @@ function join(anon strings: [String], separator: String) -> String {
 
 function prepend_to_each(anon strings: [String], prefix: String) throws -> [String] {
     mut output: [String] = []
-    for str in strings.iterator() {
+    for str in strings {
         output.push(prefix + str)
     }
     return output
@@ -52,7 +52,7 @@ function prepend_to_each(anon strings: [String], prefix: String) throws -> [Stri
 
 function append_to_each(anon strings: [String], suffix: String) throws -> [String] {
     mut output: [String] = []
-    for str in strings.iterator() {
+    for str in strings {
         output.push(str + suffix)
     }
     return output
@@ -80,7 +80,7 @@ struct FileId {
 
 function extend_array<T>(mut target: [T], extend_with: [T]) throws {
     target.add_capacity(extend_with.size())
-    for v in extend_with.iterator() {
+    for v in extend_with {
         target.push(v)
     }
 }

--- a/selfhost/windows_compiler.jakt
+++ b/selfhost/windows_compiler.jakt
@@ -19,7 +19,7 @@ function run_compiler(
         throw Error::from_errno(38)
     }
 
-    for extra_flag in extra_compiler_flags.iterator() {
+    for extra_flag in extra_compiler_flags {
         extra_flags.push(extra_flag)
     }
 
@@ -44,7 +44,7 @@ function run_compiler(
     }
 
     if not extra_flags.is_empty() {
-        for flag in extra_flags.iterator() {
+        for flag in extra_flags {
             compile_args.push(flag)
         }
     }
@@ -58,21 +58,21 @@ function run_compiler(
     compile_args.push(cpp_filename)
     if not extra_include_paths.is_empty() {
         compile_args.add_capacity(extra_include_paths.size() * 2)
-        for path in extra_include_paths.iterator() {
+        for path in extra_include_paths {
             compile_args.push("-I")
             compile_args.push(path)
         }
     }
     if not extra_lib_paths.is_empty() {
         compile_args.add_capacity(extra_lib_paths.size() * 2)
-        for path in extra_lib_paths.iterator() {
+        for path in extra_lib_paths {
             compile_args.push("-L")
             compile_args.push(path)
         }
     }
     if not extra_link_libs.is_empty() {
         compile_args.add_capacity(extra_link_libs.size())
-        for path in extra_link_libs.iterator() {
+        for path in extra_link_libs {
             compile_args.push("-l" + path)
         }
     }

--- a/selfhost/windows_process.jakt
+++ b/selfhost/windows_process.jakt
@@ -106,7 +106,7 @@ function join_arguments(args: [String]) throws -> String {
     // All this because there's no way to pass arguments to CreateProcess separately.
     mut joined_builder = StringBuilder::create()
     mut first = true
-    for arg in args.iterator() {
+    for arg in args {
         if first {
             first = false
         } else {

--- a/tests/codegen/array_slice_range_end_omited.jakt
+++ b/tests/codegen/array_slice_range_end_omited.jakt
@@ -2,7 +2,7 @@
 /// - output: "two\nthree\n"
 
 function main() {
-    for c in ["one", "two", "three"][1..].iterator() {
+    for c in ["one", "two", "three"][1..] {
         println("{}", c)
     }
 }


### PR DESCRIPTION
This removes most uses of `.iterator()`. There are still a couple places where we explicitly want an iterator and one case I wasn't quite sure how to implement IntoIterator for, but it's definitely noticeably cleaner now.