### PR TITLE
jakttest: Don't spin while polling child processes

### DIFF
--- a/jakttest/jakttest.jakt
+++ b/jakttest/jakttest.jakt
@@ -660,8 +660,24 @@ struct TestScheduler {
             unsafe { cpp { "fflush(stderr);" }}
         }
 
-        while not scheduler.running_tests.is_empty() {
-            scheduler.poll_running_tests()
+	// NOTE: wait for SIGCHLD on non win32, same as in `wait_for_free_dictionary`.
+        unsafe {
+            cpp { "#ifndef _WIN32" }
+            cpp { "sigset_t set;" }
+            cpp { "int signal;"   }
+            cpp { "sigemptyset(&set);" }
+            cpp { "sigaddset(&set, SIGCHLD);" }
+            cpp { "#endif" }
+
+            while not scheduler.running_tests.is_empty() {
+                unsafe {
+                    cpp { "#ifndef _WIN32" }
+                    cpp { "if (sigwait(&set, &signal) > 0)" }
+                    cpp { "    return Error::from_errno(errno);" }
+                    cpp { "#endif" }
+                }
+                scheduler.poll_running_tests()
+            }
         }
         eprint("\r\x1b[2K")
         unsafe { cpp { "fflush(stderr);" }}


### PR DESCRIPTION
This patch adds a `sigwait` call before each `poll_running_tests` while the last tests run in the scheduler so that we don't spin calling `waitpid` in a loop.

Fixes https://github.com/SerenityOS/jakt/issues/1228.