### PR TITLE
typechecker: Unify bool literal with type hint

### DIFF
--- a/selfhost/typechecker.jakt
+++ b/selfhost/typechecker.jakt
@@ -5405,7 +5405,11 @@ struct Typechecker {
 
     function typecheck_expression(mut this, anon expr: ParsedExpression, scope_id: ScopeId, safety_mode: SafetyMode, type_hint: TypeId?) throws -> CheckedExpression => match expr {
         IndexedStruct(expr, field_name, span, is_optional) => .typecheck_indexed_struct(expr, field_name, scope_id, is_optional, safety_mode, span)
-        Boolean(val, span) => CheckedExpression::Boolean(val, span)
+        Boolean(val, span) => {
+            .unify_with_type(found_type: builtin(BuiltinType::Bool), expected_type: type_hint, rhs_span: span)
+
+            yield CheckedExpression::Boolean(val, span)
+        }
         NumericConstant(val, span) => {
             mut type_hint_unwrapped = type_hint
             if type_hint.has_value() and .get_type(type_hint!) is GenericInstance(id, args) {

--- a/tests/typechecker/assign_bool_literal_to_string.jakt
+++ b/tests/typechecker/assign_bool_literal_to_string.jakt
@@ -1,0 +1,6 @@
+/// Expect:
+/// - error: "Type mismatch: expected ‘String’, but got ‘bool’"
+
+function foo() {
+    let bar: String = false
+}

--- a/tests/typechecker/return_bool_literal_in_function_returning_string.jakt
+++ b/tests/typechecker/return_bool_literal_in_function_returning_string.jakt
@@ -1,0 +1,12 @@
+/// Expect:
+/// - error: "Type mismatch: expected ‘void’, but got ‘bool’\n"
+
+function foo() -> void {
+    return true
+}
+
+function bar() -> void {
+    guard true else {
+        return true
+    }
+}

--- a/tests/typechecker/return_bool_literal_in_function_returning_void.jakt
+++ b/tests/typechecker/return_bool_literal_in_function_returning_void.jakt
@@ -1,0 +1,6 @@
+/// Expect:
+/// - error: "Type mismatch: expected ‘String’, but got ‘bool’\n"
+
+function baz() -> String {
+    return false
+}


### PR DESCRIPTION
Previously, boolean literals just ignored type hints. We also add some tests for this behavior.

Fixes #1254.