### PR TITLE
parser: Initial support for capturing `this`

### DIFF
--- a/samples/closures/capture_this.jakt
+++ b/samples/closures/capture_this.jakt
@@ -1,0 +1,22 @@
+/// Expect:
+/// - output: "0\n1\n"
+
+struct Foo {
+    bar: i64
+
+    function baz(mut this) {
+        let lambda = function[this]() {
+            println("{}", this.bar)
+            this.bar++
+        }
+
+        lambda()
+    }
+}
+
+function main() {
+    mut foo = Foo(bar: 0)
+
+    foo.baz()
+    foo.baz()
+}

--- a/selfhost/parser.jakt
+++ b/selfhost/parser.jakt
@@ -3928,6 +3928,11 @@ struct Parser {
                     captures.push(ParsedCapture::ByValue(name, span: .current().span()))
                     .index++
                 }
+                This => {
+                    // NOTE: We capture `this` "by value" here, but `this` is actually a raw reference
+                    captures.push(ParsedCapture::ByValue(name: "this", span: .current().span()))
+                    .index++
+                }
                 Comma | Eol => {
                     .index++
                 }


### PR DESCRIPTION
This patch allows us to capture the `this` raw reference in a closure, such as in:

```
struct Foo {
    message: String

    function bar(this) {
        let baz = function[this]() => println(this.message)

        baz()
    }
}

function main() {
    let foo = Foo(message: "WHF")

    foo.bar() // prints "WHF"
}
```

Previously we had pass in the enclosing type as a reference parameter to achieve this.

For now, we do a by-reference (in C++ terms) capture of the current object, but since we currently do not allow storing or returning closures, this should be safe.