### PR TITLE
parser+test: Fix precedence of ranges

### DIFF
--- a/selfhost/codegen.jakt
+++ b/selfhost/codegen.jakt
@@ -1967,8 +1967,8 @@ struct CodeGenerator {
 
             yield output
         }
-        else => {
-            todo(format("codegen_expression else: {}", expression))
+        Garbage(span) => {
+            todo(format("codegen_expression of bad AST node in {} at {}..{}", this.compiler.get_file_path(span.file_id), span.start, span.end))
             yield ""
         }
     }

--- a/selfhost/formatter.jakt
+++ b/selfhost/formatter.jakt
@@ -10,7 +10,7 @@ function concat<T>(anon xs: [T], anon y: T) throws -> [T] {
     return ys
 }
 
-function init<T>(anon xs: [T]) throws -> [T] => xs[..xs.size() - 1].to_array()
+function init<T>(anon xs: [T]) throws -> [T] => xs[..(xs.size() - 1)].to_array()
 
 function collapse<T>(anon x: Optional<T>?) -> T? => match x.has_value() {
     true => x!

--- a/selfhost/parser.jakt
+++ b/selfhost/parser.jakt
@@ -4012,7 +4012,7 @@ struct Parser {
         match .current() {
             RSquare | Eol | Comma | RParen => {}
             else => {
-                to = .parse_expression(allow_assignments: false, allow_newlines: false)
+                to = .parse_operand()
             }
         }
         
@@ -4077,7 +4077,7 @@ struct Parser {
                     match .current() {
                         RSquare | Eol | Comma | RParen => {}
                         else => {
-                            to = .parse_expression(allow_assignments: false, allow_newlines: false)
+                            to = .parse_operand()
                             span_end = to!.span()
                         }
                     }

--- a/selfhost/typechecker.jakt
+++ b/selfhost/typechecker.jakt
@@ -7193,7 +7193,7 @@ struct Typechecker {
                 mut resolved_args: [(String, Span, CheckedExpression)] = .resolve_default_params(params: callee.generics.base_params, args: call.args, scope_id: caller_scope_id, safety_mode, arg_offset, span)
 
                 if callee.generics.base_params.size() == resolved_args.size() + arg_offset {
-                    for i in 0..callee.generics.base_params.size()-arg_offset {
+                    for i in 0..(callee.generics.base_params.size() - arg_offset) {
                         let (name, span, checked_arg) = resolved_args[i]
 
                         .check_types_for_compat(

--- a/tests/parser/range_patterns.jakt
+++ b/tests/parser/range_patterns.jakt
@@ -1,0 +1,21 @@
+/// Expect:
+/// - output: "success\nsuccess\nsuccess\n"
+
+function main() {
+  let abc = 123;
+
+  match abc {
+    100..200 | 300..400 => println("success")
+    else => println("failure")
+  }
+
+  match abc {
+    1..10 | 100..400 => println("success")
+    else => println("failure")
+  }
+
+  match abc {
+    1..10 | 200..400 => println("failure")
+    else => println("success")
+  }
+}


### PR DESCRIPTION
This changes the parsing rules for ranges, which lets them have a more correct precedence when used in more situations. The common one this will fix is when a range is used in a match separated by `|` to say "one of these ranges match".

Example:
```
match abc {
    100..200 | 300..400 => println("success")
    else => println("failure")
}
```