### PR TITLE
Formatter: Don't die on `import foo()`

### DIFF
--- a/selfhost/build.jakt
+++ b/selfhost/build.jakt
@@ -1,6 +1,6 @@
 import os { platform_process }
 import path { Path }
-import platform_process () {
+import platform_process() {
     Process
     ExitPollResult
     start_background_process

--- a/selfhost/formatter.jakt
+++ b/selfhost/formatter.jakt
@@ -602,6 +602,24 @@ struct Stage0 {
                     preceding_trivia: []
                 )
                 Identifier => {
+                    if not is_extern and .peek() is LParen {
+                        .push_state(State::StatementContext(
+                            open_parens: 0
+                            open_curlies: 0
+                            open_squares: 0
+                            arrow_indents: 0
+                            allow_eol: None
+                            inserted_comma: false
+                            expression_mode: ExpressionMode::AtExpressionStart
+                            dedents_on_open_curly: 0
+                        ))
+                        return FormattedToken(
+                            token
+                            indent: .indent
+                            trailing_trivia: []
+                            preceding_trivia: []
+                        )
+                    }
                     if not is_extern and not .peek() is LCurly and not .peek() is As {
                         .pop_state()
                     }


### PR DESCRIPTION
Makes this
```
import foo( bar, baz) { }
```

do this
```
import foo(bar, baz) { }
```

instead of this
```
import foo (bar, baz) { }
```