### PR TITLE
Allow binding mutable reference to enum field in match case

### DIFF
--- a/selfhost/codegen.jakt
+++ b/selfhost/codegen.jakt
@@ -2196,7 +2196,13 @@ struct CodeGenerator {
                                 if not args.is_empty() {
                                     let arg = args[0]
                                     let var = .program.find_var_in_scope(scope_id, var: arg.binding)!
-                                    output += format("{} const& {} = __jakt_match_value.value;\n", .codegen_type(var.type_id), arg.binding)
+                                    output += .codegen_type(var.type_id)
+                                    if not var.is_mutable {
+                                        output += " const"
+                                    }
+                                    output += "& "
+                                    output += arg.binding
+                                    output += " = __jakt_match_value.value;\n"
                                 }
                             }
                             StructLike(name, fields) => {
@@ -2212,7 +2218,10 @@ struct CodeGenerator {
                                     for arg in args {
                                         let var = .program.find_var_in_scope(scope_id, var: arg.binding)!
                                         output += .codegen_type(var.type_id)
-                                        output += " const& "
+                                        if not var.is_mutable {
+                                            output += " const"
+                                        }
+                                        output += "& "
                                         output += arg.binding
                                         output += " = __jakt_match_value."
                                         output += arg.name.value_or(arg.binding)

--- a/selfhost/parser.jakt
+++ b/selfhost/parser.jakt
@@ -793,6 +793,8 @@ struct EnumVariantPatternArgument {
     name: String?
     binding: String
     span: Span
+    is_reference: bool
+    is_mutable: bool
 
     function equals(this, anon rhs_variant_pattern_argument: EnumVariantPatternArgument) -> bool {
         if .binding != rhs_variant_pattern_argument.binding {
@@ -801,6 +803,14 @@ struct EnumVariantPatternArgument {
 
         if .name.has_value() and rhs_variant_pattern_argument.name.has_value() {
             return .name! == rhs_variant_pattern_argument.name!
+        }
+
+        if .is_reference != rhs_variant_pattern_argument.is_reference {
+            return false
+        }
+
+        if .is_mutable != rhs_variant_pattern_argument.is_mutable {
+            return false
         }
 
         return not .name.has_value() and not rhs_variant_pattern_argument.name.has_value()
@@ -4617,9 +4627,20 @@ struct Parser {
             has_parens = true
             .index++
 
+            mut is_reference = false
+            mut is_mutable = false
+
             while not .eof() {
                 .skip_newlines()
                 match .current() {
+                    Ampersand => {
+                        is_reference = true
+                        .index++
+                    }
+                    Mut => {
+                        is_mutable = true
+                        .index++
+                    }
                     Identifier(name: arg_name) => {
                         if .peek(1) is Colon {
                             .index += 2
@@ -4629,18 +4650,25 @@ struct Parser {
                                 variant_arguments.push(EnumVariantPatternArgument(
                                     name: Some(arg_name)
                                     binding: arg_binding
-                                    span)
-                                )
+                                    span
+                                    is_reference
+                                    is_mutable
+                                ))
                             } else {
                                 .error("Expected binding after ‘:’", .current().span())
                             }
                         } else {
                             variant_arguments.push(EnumVariantPatternArgument(
-                                        name: None
-                                        binding: arg_name
-                                        span: .current().span()))
+                                name: None
+                                binding: arg_name
+                                span: .current().span()
+                                is_reference
+                                is_mutable
+                            ))
                             .index++
                         }
+                        is_reference = false
+                        is_mutable = false
                     }
                     Comma => {
                         .index++

--- a/selfhost/typechecker.jakt
+++ b/selfhost/typechecker.jakt
@@ -6394,7 +6394,7 @@ struct Typechecker {
                         let var_id = module.add_variable(CheckedVariable(
                             name: variant_argument.binding
                             type_id: variable_type_id
-                            is_mutable: false
+                            is_mutable: variant_argument.is_mutable
                             definition_span: span
                             type_span: None
                             visibility: CheckedVisibility::Public
@@ -6461,7 +6461,7 @@ struct Typechecker {
                         let var_id = module.add_variable(CheckedVariable(
                             name: arg.binding
                             type_id: substituted_type_id
-                            is_mutable: false
+                            is_mutable: arg.is_mutable
                             definition_span: matched_span
                             type_span: None
                             visibility: CheckedVisibility::Public

--- a/selfhost/typechecker.jakt
+++ b/selfhost/typechecker.jakt
@@ -6451,27 +6451,24 @@ struct Typechecker {
                         }
                     }
 
-                    match matched_field_variable.has_value() {
-                        true => {
-                            let substituted_type_id = .substitute_typevars_in_type(type_id: matched_field_variable!.type_id, generic_inferences: .generic_inferences)
-                            let matched_span = matched_field_variable!.definition_span
-                            if .dump_type_hints {
-                                .dump_type_hint(type_id: matched_field_variable!.type_id, span: arg.span)
-                            }
+                    if matched_field_variable.has_value() {
+                        let substituted_type_id = .substitute_typevars_in_type(type_id: matched_field_variable!.type_id, generic_inferences: .generic_inferences)
+                        let matched_span = matched_field_variable!.definition_span
+                        if .dump_type_hints {
+                            .dump_type_hint(type_id: matched_field_variable!.type_id, span: arg.span)
+                        }
 
-                            let var_id = module.add_variable(CheckedVariable(
-                                name: arg.binding
-                                type_id: substituted_type_id
-                                is_mutable: false
-                                definition_span: matched_span
-                                type_span: None
-                                visibility: CheckedVisibility::Public
-                            ))
-                            .add_var_to_scope(scope_id: new_scope_id, name: arg.binding, var_id, span: matched_span)
-                        }
-                        else => {
-                            .error(format("Match case argument '{}' does not exist in struct-like enum variant '{}'", arg_name, name), arg.span)
-                        }
+                        let var_id = module.add_variable(CheckedVariable(
+                            name: arg.binding
+                            type_id: substituted_type_id
+                            is_mutable: false
+                            definition_span: matched_span
+                            type_span: None
+                            visibility: CheckedVisibility::Public
+                        ))
+                        .add_var_to_scope(scope_id: new_scope_id, name: arg.binding, var_id, span: matched_span)
+                    } else {
+                        .error(format("Match case argument '{}' does not exist in struct-like enum variant '{}'", arg_name, name), arg.span)
                     }
                 }
             }


### PR DESCRIPTION
It's now possible to mutate enum fields by matching them:

```jakt    
match my_enum {
    MyVariant(&mut field) => {
    	field = new_value
   	}
}
```