### PR TITLE
cmake: Clean up include and runtime paths to un-break external projects

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -53,8 +53,11 @@ add_executable(jakt_stage0 "${JAKT_STAGE0_SOURCES}")
 add_executable(Jakt::jakt_stage0 ALIAS jakt_stage0)
 add_jakt_compiler_flags(jakt_stage0)
 target_include_directories(jakt_stage0
-  PUBLIC
+  PRIVATE
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/bootstrap/stage0/runtime>
+  INTERFACE
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/bootstrap/stage0/runtime>
+  PUBLIC
     $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}/runtime>
 )
 target_link_libraries(jakt_stage0 PRIVATE Jakt::jakt_runtime Jakt::jakt_main)
@@ -121,9 +124,12 @@ add_jakt_executable(jakt_stage1
   RUNTIME_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/runtime"
 )
 
-target_include_directories(jakt_stage1 PUBLIC
-  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/runtime>
-  $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}/runtime>)
+target_include_directories(jakt_stage1
+  INTERFACE
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/runtime>
+  PUBLIC
+    $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}/runtime>
+)
 add_executable(Jakt::jakt_stage1 ALIAS jakt_stage1)
 apply_output_rules(jakt_stage1)
 
@@ -135,9 +141,11 @@ if (FINAL_STAGE GREATER_EQUAL 2)
     STDLIB_SOURCES ${SELFHOST_STDLIB_SOURCES}
     RUNTIME_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/runtime"
   )
-  target_include_directories(jakt_stage2 PUBLIC
-    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/runtime>
-    $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}/runtime>
+  target_include_directories(jakt_stage2
+    INTERFACE
+      $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/runtime>
+    PUBLIC
+      $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}/runtime>
   )
   add_executable(Jakt::jakt_stage2 ALIAS jakt_stage2)
   apply_output_rules(jakt_stage2)
@@ -187,10 +195,6 @@ if (JAKT_BUILD_TESTING)
      jakttest/fs.cpp
      jakttest/os.cpp
      jakttest/process.cpp
-  )
-  target_include_directories(jakttest PRIVATE
-    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/jakttest>
-    $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}/jakttest>
   )
   apply_output_rules(jakttest)
 endif()

--- a/runtime/CMakeLists.txt
+++ b/runtime/CMakeLists.txt
@@ -12,9 +12,11 @@ set(RUNTIME_SOURCES
 
 add_library(jakt_runtime STATIC ${RUNTIME_SOURCES})
 add_jakt_compiler_flags(jakt_runtime)
-target_include_directories(jakt_runtime PUBLIC
-    "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>"
-    "$<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}/runtime>"
+target_include_directories(jakt_runtime
+  PRIVATE
+   "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>"
+  PUBLIC
+   "$<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}/runtime>"
 )
 
 add_library(Jakt::jakt_runtime ALIAS jakt_runtime)
@@ -22,8 +24,10 @@ apply_output_rules(jakt_runtime)
 
 add_library(jakt_main STATIC Main.cpp)
 add_jakt_compiler_flags(jakt_main)
-target_include_directories(jakt_main PUBLIC
+target_include_directories(jakt_main
+  PRIVATE
     "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>"
+  PUBLIC
     "$<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}/runtime>"
 )
 


### PR DESCRIPTION
Ensure that the runtime path is properly passed to external jakt executables based on the RUNTIME_DIRECTORY propery rather than hardcoding to CMAKE_CURRENT_LIST_DIR/runtime, which is only correct when the add_jakt_executable is run from the top level directory in jakt/.

Clean up some other cmake variables to ensure that we are explicit about what include paths are required to build a jakt compiler, what paths are required by cpp files created by that jakt compiler, and which paths are passed in from the user.