### PR TITLE
codegen: Fix codegen for optional chaining with classes

### DIFF
--- a/selfhost/codegen.jakt
+++ b/selfhost/codegen.jakt
@@ -1535,7 +1535,8 @@ struct CodeGenerator {
             output += object
             output += ")"
 
-            match .program.get_type(expr.type()) {
+            let expression_type = .program.get_type(expr.type())
+            match expression_type {
                 RawPtr => {
                     output += "->"
                 }
@@ -1552,7 +1553,19 @@ struct CodeGenerator {
                 }
             }
             if is_optional {
-                output += "map([](auto& _value) { return _value."
+                output += "map([](auto& _value) { return _value"
+                mut access_operator = "."
+                if expression_type is GenericInstance(args) and args.size() > 0 {
+                    match .program.get_type(args[0]) {
+                        Struct(id) | GenericInstance(id) => {
+                            if .program.get_struct(id).record_type is Class {
+                                access_operator = "->"
+                            }
+                        }
+                        else => {}
+                    }
+                }
+                output += access_operator
                 output += index
                 output += "; })"
             } else {
@@ -2553,7 +2566,8 @@ struct CodeGenerator {
         output += object
         output += ")"
 
-        match .program.get_type(expr.type()) {
+        let expression_type = .program.get_type(expr.type())
+        match expression_type {
             RawPtr => {
                 output += "->"
             }
@@ -2579,7 +2593,19 @@ struct CodeGenerator {
         }
 
         if is_optional {
-            output += "map([&](auto& _value) { return _value."
+            output += "map([&](auto& _value) { return _value"
+            mut access_operator = "."
+            if expression_type is GenericInstance(args) and args.size() > 0 {
+                match .program.get_type(args[0]) {
+                    Struct(id) | GenericInstance(id) => {
+                        if .program.get_struct(id).record_type is Class {
+                            access_operator = "->"
+                        }
+                    }
+                    else => {}
+                }
+            }
+            output += access_operator
         }
 
         let generic_parameters = call.type_args

--- a/tests/codegen/optional_chaining_class.jakt
+++ b/tests/codegen/optional_chaining_class.jakt
@@ -1,0 +1,31 @@
+/// Expect:
+/// - output: "PASS\n123\nPASS\nNone\n"
+
+class Test {
+    public x: i32
+
+    public function y(this) throws => this
+    public function throwing_y(this) throws -> String {
+        throw Error::from_errno(69)
+    }
+}
+
+function main() {
+    mut test: Test? = Test(x: 123)
+    try {
+        println("{}", test?.y()?.throwing_y() ?? "FAIL")
+    } catch err {
+        println("PASS")
+    }
+
+    println("{}", test?.x)
+
+    test = None
+    try {
+        println("{}", test?.y()?.throwing_y() ?? "PASS")
+    } catch err {
+        println("FAIL")
+    }
+
+    println("{}", test?.x)
+}


### PR DESCRIPTION
The operator for accessing members of classes is `->`, since they are of type NonnullRefPtr. But when mapping an optional for chaining, the operator generated was the default `.`.

My code seems a bit weird. Any pointers on how to make it look better are appreciated.