### PR TITLE
typechecker: Prevent imports with `::` being imported multiple times

### DIFF
--- a/samples/modules/c.jakt
+++ b/samples/modules/c.jakt
@@ -1,0 +1,7 @@
+/// Expect: Skip
+
+import jakt::arguments { ArgsParser }
+
+function test_common_import(mut args: ArgsParser) throws -> bool {
+    return args.flag(["-h", "--help"])
+}

--- a/samples/modules/common_import.jakt
+++ b/samples/modules/common_import.jakt
@@ -1,0 +1,13 @@
+/// Expect:
+/// - output: "PASS\n"
+
+import jakt::arguments { ArgsParser }
+import c { test_common_import }
+
+function main() {
+    mut args_parser = ArgsParser::from_args(["-h"])
+
+    if test_common_import(args: args_parser) {
+        println("PASS")
+    }
+}

--- a/selfhost/typechecker.jakt
+++ b/selfhost/typechecker.jakt
@@ -814,8 +814,10 @@ struct Typechecker {
 
         let (module_name, module_span) = module_name_and_span!
 
+        let sanitized_module_name = module_name.replace(replace: ":", with: "_")
+
         mut imported_module_id = ModuleId(id: 0)
-        mut maybe_loaded_module = .program.get_loaded_module(module_name)
+        mut maybe_loaded_module = .program.get_loaded_module(sanitized_module_name)
         if not maybe_loaded_module.has_value() {
             let maybe_file_name = .compiler.search_for_path(module_name)
             let file_name = match maybe_file_name.has_value() {
@@ -836,8 +838,6 @@ struct Typechecker {
             }
 
             let original_current_module_id = .current_module_id
-
-            let sanitized_module_name = module_name.replace(replace: ":", with: "_")
             imported_module_id = .create_module(name: sanitized_module_name, is_root: false, path: file_name.to_string())
             .program.set_loaded_module(
                 module_name: sanitized_module_name


### PR DESCRIPTION
Previously `::` was converted to `__` when setting the imported name but not when checking if the import existed, so the module would be imported again each time that it was seen.