### PR TITLE
typechecker: Deduplicate and improve some errors

### DIFF
--- a/selfhost/typechecker.jakt
+++ b/selfhost/typechecker.jakt
@@ -7253,6 +7253,8 @@ struct Typechecker {
                 if call.name == "format" {
                     return_type = builtin(BuiltinType::JaktString)
                     callee_throws = true
+                } else {
+                    return_type = void_type_id()
                 }
             }
             else => {

--- a/selfhost/typechecker.jakt
+++ b/selfhost/typechecker.jakt
@@ -7029,6 +7029,7 @@ struct Typechecker {
             }
 
             .error(format("Not a namespace, enum, class, or struct: ‘{}’", join(call.namespace_, separator: "::")), span)
+            return []
         }
 
         // 1. Look for a variable in the current scope with this name.

--- a/selfhost/typechecker.jakt
+++ b/selfhost/typechecker.jakt
@@ -7186,7 +7186,7 @@ struct Typechecker {
 
     function typecheck_call(mut this, call: ParsedCall, caller_scope_id: ScopeId, span: Span, this_expr: CheckedExpression?, parent_id: StructOrEnumId?, safety_mode: SafetyMode, mut type_hint: TypeId?, must_be_enum_constructor: bool) throws -> CheckedExpression {
         mut args: [(String, CheckedExpression)] = []
-        mut return_type = builtin(BuiltinType::Void)
+        mut return_type = builtin(BuiltinType::Unknown)
         mut generic_arguments: [TypeId] = []
         mut callee_throws = false
         mut resolved_namespaces: [ResolvedNamespace] = []

--- a/selfhost/typechecker.jakt
+++ b/selfhost/typechecker.jakt
@@ -1035,7 +1035,7 @@ struct Typechecker {
             }
 
             if not f.block.stmts.is_empty() {
-                .error("imported extern function is not allowed to have a body"
+                .error("Imported extern function is not allowed to have a body"
                         f.name_span)
             }
         }
@@ -3398,7 +3398,7 @@ struct Typechecker {
                     if lhs_enum_id.equals(rhs_enum_id) {
                         let lhs_enum = .get_enum(lhs_enum_id)
                         guard lhs_args.size() == rhs_args.size() else {
-                            .error(format("mismatched number of generic parameters for {}", lhs_enum.name), span)
+                            .error(format("Mismatched number of generic parameters for {}", lhs_enum.name), span)
                             return false
                         }
 
@@ -3513,7 +3513,7 @@ struct Typechecker {
                         let rhs_args = args
                         let lhs_struct = .get_struct(lhs_struct_id)
                         guard lhs_args.size() == rhs_args.size() else {
-                            .error(format("mismatched number of generic parameters for {}", lhs_struct.name), span)
+                            .error(format("Mismatched number of generic parameters for {}", lhs_struct.name), span)
                             return false
                         }
 
@@ -3567,7 +3567,7 @@ struct Typechecker {
                         if enum_id.equals(id) {
                             let lhs_enum = .get_enum(enum_id)
                             if args.size() != lhs_enum.generic_parameters.size() {
-                                .error(format("mismatched number of generic parameters for {}", lhs_enum.name), span)
+                                .error(format("Mismatched number of generic parameters for {}", lhs_enum.name), span)
                                 return false
                             }
 
@@ -3629,7 +3629,7 @@ struct Typechecker {
 
                         let lhs_struct = .get_struct(lhs_struct_id)
                         if args.size() != lhs_struct.generic_parameters.size() {
-                            .error(format("mismatched number of generic parameters for {}", lhs_struct.name), span)
+                            .error(format("Mismatched number of generic parameters for {}", lhs_struct.name), span)
                             return false
                         }
 
@@ -4057,7 +4057,7 @@ struct Typechecker {
             return .find_or_add_type_id(Type::GenericTraitInstance(id: trait_id!, args: checked_inner_types))
         }
 
-        .error(format("could not find {}", name), span)
+        .error(format("Could not find {}", name), span)
         return unknown_type_id()
     }
 
@@ -4240,11 +4240,11 @@ struct Typechecker {
             }
             LogicalAnd | LogicalOr => {
                 if not lhs_type_id.equals(builtin(BuiltinType::Bool)) {
-                    .error("left side of logical binary operation is not a boolean", lhs_span)
+                    .error("Left side of logical binary operation is not a boolean", lhs_span)
                 }
 
                 if not rhs_type_id.equals(builtin(BuiltinType::Bool)) {
-                    .error("right side of logical binary operation is not a boolean", rhs_span)
+                    .error("Right side of logical binary operation is not a boolean", rhs_span)
                 }
 
                 type_id = builtin(BuiltinType::Bool)
@@ -4414,7 +4414,7 @@ struct Typechecker {
     ) throws -> CheckedStatement {
         let maybe_span = block.find_yield_span()
         if maybe_span.has_value() {
-            .error("a 'for' loop block is not allowed to yield values", maybe_span!)
+            .error("A 'for' loop block is not allowed to yield values", maybe_span!)
         }
 
         // Translate `for x in expr { body }` to
@@ -4950,7 +4950,7 @@ struct Typechecker {
 
         let error_type_id = .find_type_in_prelude("Error")
         if not checked_expr.type().equals(error_type_id) {
-            .error("throw expression does not produce an error", expr.span())
+            .error("Throw expression does not produce an error", expr.span())
         }
 
         let scope = .get_scope(scope_id)
@@ -5102,7 +5102,7 @@ struct Typechecker {
                             }
                         }
 
-                        .error(format("unknown member of struct: {}.{}", structure.name, field_name), span)
+                        .error(format("Unknown member of struct: {}.{}", structure.name, field_name), span)
                     }
                     GenericEnumInstance(id: enum_id) | Enum(enum_id) => {
                         let enum_ = .get_enum(enum_id)
@@ -5125,7 +5125,7 @@ struct Typechecker {
                             }
                         }
 
-                        .error(format("unknown common member of enum: {}.{}", enum_.name, field_name), span)
+                        .error(format("Unknown common member of enum: {}.{}", enum_.name, field_name), span)
                     }
                     else => .error(format("Member field access on value of non-struct type ‘{}’", .type_name(checked_expr_type_id)), span)
                 }
@@ -5177,7 +5177,7 @@ struct Typechecker {
                     }
                 }
 
-                .error(format("unknown common member of enum: {}.{}", enum_.name, field_name), span)
+                .error(format("Unknown common member of enum: {}.{}", enum_.name, field_name), span)
             }
             else => .error(format("Member field access on value of non-struct type ‘{}’", .type_name(checked_expr_type_id)), span)
         }

--- a/selfhost/typechecker.jakt
+++ b/selfhost/typechecker.jakt
@@ -3246,6 +3246,10 @@ struct Typechecker {
         mut return_type_id = VOID_TYPE_ID
         if function_return_type_id.equals(UNKNOWN_TYPE_ID) {
             return_type_id = .infer_function_return_type(block)
+            if return_type_id.equals(UNKNOWN_TYPE_ID) {
+                // Functions are void by default if type cannot be inferred.
+                return_type_id = VOID_TYPE_ID
+            }
         } else {
             return_type_id = .resolve_type_var(
                 type_var_type_id: function_return_type_id,
@@ -7286,7 +7290,7 @@ struct Typechecker {
                     }
                 }
 
-                if not resolved_function_id.has_value(){
+                if not resolved_function_id.has_value() {
                     if not resolved_function_id_candidates.is_empty() {
                         .error("No function with matching signature found.", span)
                         for match_error in errors_while_trying_to_find_matching_function.iterator() {
@@ -7323,6 +7327,10 @@ struct Typechecker {
                 let callee = .get_function(resolved_function_id!)
                 callee_throws = callee.can_throw
                 return_type = callee.return_type_id
+
+                if return_type.equals(unknown_type_id()) {
+                    return_type = void_type_id()
+                }
 
                 let scope_containing_callee = .get_scope(callee.function_scope_id).parent!
 

--- a/tests/typechecker/field_access_on_enum.jakt
+++ b/tests/typechecker/field_access_on_enum.jakt
@@ -1,5 +1,5 @@
 /// Expect:
-/// - error: "unknown common member of enum: E.x"
+/// - error: "Unknown common member of enum: E.x"
 
 enum E {
     A

--- a/tests/typechecker/throw_no_error.jakt
+++ b/tests/typechecker/throw_no_error.jakt
@@ -1,5 +1,5 @@
 /// Expect:
-/// - error: "throw expression does not produce an error"
+/// - error: "Throw expression does not produce an error"
 
 function foo() throws -> u32 {
     throw 1


### PR DESCRIPTION
- typechecker: Make (e)print(ln) functions' return type void
- typechecker: Make functions' return type void if it cannot be inferred
- typechecker: Make functions' return type unknown if call is invalid
- typechecker: Add a missing return after "not a namespace" error
- typechecker: Make all error messages start uppercase
