### PR TITLE
editors/vscode: Clarify installation instructions for vscode extention

### DIFF
--- a/editors/vscode/README.md
+++ b/editors/vscode/README.md
@@ -41,7 +41,7 @@ npx vsce package
 
 Then install vscode by switching to the Extensions section on the left, then the `...` at the top middle and choose "Install from VSIX..." and choose the package you just created.
 
-In the settings for jakt under Preferences: Open Settings (UI) from the command palate (cmd/ctrl + shift + p), set the Jakt Compiler: Executable Path to your configured ``$JAKT_INSTALL/bin/jakt``. The $JAKT_INSTALL variable must be manually expanded to an absolute path for the path in the settings field.
+In the settings for jakt under Preferences: Open Settings (UI) from the command palate (cmd/ctrl + shift + p), set the Jakt Compiler: Executable Path to your configured ``/path/to/bin/jakt``. This must be an absolute path, you cannot use $JAKT_INSTALL here.
 
 Alternatively, modify the ``.vscode/settings.json`` file to have an entry similar to the following:
 


### PR DESCRIPTION
Make it explicit that you must use an absolute path to the jakt binary in the vscode configuration pane.