### PR TITLE
misc: Add jakt.nix

### DIFF
--- a/jakt.nix
+++ b/jakt.nix
@@ -1,0 +1,12 @@
+{ pkgs ? import <nixpkgs> { } }:
+pkgs.mkShell
+{
+  name = "jakt";
+
+  nativeBuildInputs = with pkgs; [
+    pkgconfig
+    cmake
+    ninja
+    clang_14
+  ];
+}


### PR DESCRIPTION
This brings jakt more inline with other Serenity projects by providing a nix-shell build-dependencies setup :^)