### PR TITLE
runtime: Return the correct types from Dictionary::get() / random other fixes

### DIFF
--- a/runtime/Jakt/Forward.h
+++ b/runtime/Jakt/Forward.h
@@ -45,11 +45,11 @@ class HashTable;
 template<typename T, typename TraitsForT = Traits<T>>
 using OrderedHashTable = HashTable<T, TraitsForT, true>;
 
-template<typename K, typename V, typename KeyTraits = Traits<K>, bool IsOrdered = false>
+template<typename K, typename V, typename KeyTraits = Traits<K>, typename ValueTraits = Traits<V>, bool IsOrdered = false>
 class HashMap;
 
-template<typename K, typename V, typename KeyTraits = Traits<K>>
-using OrderedHashMap = HashMap<K, V, KeyTraits, true>;
+template<typename K, typename V, typename KeyTraits = Traits<K>, typename ValueTraits = Traits<V>>
+using OrderedHashMap = HashMap<K, V, KeyTraits, ValueTraits, true>;
 
 template<typename>
 class Function;

--- a/runtime/Jakt/HashMap.h
+++ b/runtime/Jakt/HashMap.h
@@ -12,7 +12,7 @@
 
 namespace Jakt {
 
-template<typename K, typename V, typename KeyTraits, bool IsOrdered>
+template<typename K, typename V, typename KeyTraits, typename ValueTraits, bool IsOrdered>
 class HashMap {
 private:
     struct Entry {
@@ -122,7 +122,7 @@ public:
 
     ErrorOr<void> ensure_capacity(size_t capacity) { return m_table.try_ensure_capacity(capacity); }
 
-    Optional<typename Traits<V>::ConstPeekType> get(const K& key) const requires(!IsPointer<typename Traits<V>::PeekType>)
+    Optional<typename ValueTraits::ConstPeekType> get(const K& key) const requires(!IsPointer<typename ValueTraits::PeekType>)
     {
         auto it = find(key);
         if (it == end())
@@ -130,7 +130,7 @@ public:
         return (*it).value;
     }
 
-    Optional<typename Traits<V>::ConstPeekType> get(const K& key) const requires(IsPointer<typename Traits<V>::PeekType>)
+    Optional<typename ValueTraits::ConstPeekType> get(const K& key) const requires(IsPointer<typename ValueTraits::PeekType>)
     {
         auto it = find(key);
         if (it == end())
@@ -138,17 +138,7 @@ public:
         return (*it).value;
     }
 
-    Optional<typename Traits<V>::PeekType> get(const K& key) requires(!IsConst<typename Traits<V>::PeekType>)
-    {
-        auto it = find(key);
-        if (it == end())
-            return {};
-        return (*it).value;
-    }
-
-    template<HashCompatible<K> Key>
-    requires(IsSame<KeyTraits, Traits<K>>) Optional<typename Traits<V>::PeekType> get(Key const& key)
-    const requires(!IsPointer<typename Traits<V>::PeekType>)
+    Optional<typename ValueTraits::PeekType> get(const K& key) requires(!IsConst<typename ValueTraits::PeekType>)
     {
         auto it = find(key);
         if (it == end())
@@ -157,8 +147,8 @@ public:
     }
 
     template<HashCompatible<K> Key>
-    requires(IsSame<KeyTraits, Traits<K>>) Optional<typename Traits<V>::ConstPeekType> get(Key const& key)
-    const requires(IsPointer<typename Traits<V>::PeekType>)
+    requires(IsSame<KeyTraits, Traits<K>>) Optional<typename ValueTraits::PeekType> get(Key const& key)
+    const requires(!IsPointer<typename ValueTraits::PeekType>)
     {
         auto it = find(key);
         if (it == end())
@@ -167,8 +157,18 @@ public:
     }
 
     template<HashCompatible<K> Key>
-    requires(IsSame<KeyTraits, Traits<K>>) Optional<typename Traits<V>::PeekType> get(Key const& key)
-    requires(!IsConst<typename Traits<V>::PeekType>)
+    requires(IsSame<KeyTraits, Traits<K>>) Optional<typename ValueTraits::ConstPeekType> get(Key const& key)
+    const requires(IsPointer<typename ValueTraits::PeekType>)
+    {
+        auto it = find(key);
+        if (it == end())
+            return {};
+        return (*it).value;
+    }
+
+    template<HashCompatible<K> Key>
+    requires(IsSame<KeyTraits, Traits<K>>) Optional<typename ValueTraits::PeekType> get(Key const& key)
+    requires(!IsConst<typename ValueTraits::PeekType>)
     {
         auto it = find(key);
         if (it == end())

--- a/samples/arrays/push_values.jakt
+++ b/samples/arrays/push_values.jakt
@@ -5,7 +5,7 @@ function main() {
     mut x = [1, 2, 3]
     mut y = [5]
 
-    x.push_values(y)
+    x.push_values(&y)
     println("x: {}", x)
     println("y: {}", y)
 }

--- a/samples/attributes/deprecated.jakt
+++ b/samples/attributes/deprecated.jakt
@@ -1,0 +1,13 @@
+/// Expect:
+/// - error: "Call to deprecated function: Use println() instead"
+
+struct Bar {
+    [[deprecated("Use println() instead")]] function foo(this) {
+        println("Well hello friends!")
+    }
+}
+
+function main() {
+    let bar = Bar()
+    bar.foo()
+}

--- a/samples/attributes/external_name.jakt
+++ b/samples/attributes/external_name.jakt
@@ -1,0 +1,13 @@
+/// Expect:
+/// - output: "Well hello friends!\n"
+
+[[name=Foo]] struct Bar {
+    [[name=bar]] function foo(this) {
+        println("Well hello friends!")
+    }
+}
+
+function main() {
+    let bar = Bar()
+    unsafe { cpp { "bar.bar();" } }
+}

--- a/samples/dictionaries/with_class.jakt
+++ b/samples/dictionaries/with_class.jakt
@@ -1,0 +1,14 @@
+/// Expect:
+/// - output: "foo\nfoo\n"
+
+class Foo {
+    public x: String
+}
+
+function main() {
+    let foo = Foo(x: "foo")
+    let dict = ["a": foo]
+    println("{}", dict["a"].x)
+    println("{}", dict.get("a")!.x)
+}
+

--- a/selfhost/codegen.jakt
+++ b/selfhost/codegen.jakt
@@ -812,7 +812,7 @@ struct CodeGenerator {
                 .current_function = Some(function_)
                 defer .current_function = previous_function_id
 
-                if not function_.type is ImplicitConstructor and function_.name != "main" {
+                if not function_.type is ImplicitConstructor and function_.name_for_codegen() != "main" {
                     output += .codegen_function_predecl(function_)
                     output += "\n"
                 }
@@ -872,7 +872,7 @@ struct CodeGenerator {
             output += "[[noreturn]] "
         }
 
-        if function_.name == "main" {
+        if function_.name_for_codegen() == "main" {
             output += "ErrorOr<int>"
         } else {
             if as_method and function_.is_static() {
@@ -892,7 +892,7 @@ struct CodeGenerator {
         }
 
         output += " "
-        output += function_.name
+        output += function_.name_for_codegen()
         output += "("
 
         mut first = true
@@ -958,7 +958,7 @@ struct CodeGenerator {
             else => ""
         }
 
-        output += struct_.name
+        output += struct_.name_for_codegen()
         output += ";"
 
         return output
@@ -983,7 +983,7 @@ struct CodeGenerator {
         match struct_.record_type {
             Class => {
                 mut class_name_with_generics = ""
-                class_name_with_generics += struct_.name
+                class_name_with_generics += struct_.name_for_codegen()
                 mut first = true
                 for generic_parameter in struct_.generic_parameters {
                     if not first {
@@ -1000,15 +1000,15 @@ struct CodeGenerator {
 
                 if struct_.super_struct_id.has_value() {
                     let super_struct = .program.get_struct(struct_.super_struct_id!)
-                    output += format("class {}: public {} {{\n", struct_.name, super_struct.name)
+                    output += format("class {}: public {} {{\n", struct_.name_for_codegen(), super_struct.name_for_codegen())
                 } else {
-                    output += format("class {} : public RefCounted<{}>, public Weakable<{}> {{\n", struct_.name, class_name_with_generics, class_name_with_generics)
+                    output += format("class {} : public RefCounted<{}>, public Weakable<{}> {{\n", struct_.name_for_codegen(), class_name_with_generics, class_name_with_generics)
                 }
                 output += "  public:\n"
-                output += format("virtual ~{}() = default;\n", struct_.name)
+                output += format("virtual ~{}() = default;\n", struct_.name_for_codegen())
             }
             Struct => {
-                output += format("struct {}", struct_.name)
+                output += format("struct {}", struct_.name_for_codegen())
                 output += " {\n"
                 output += "  public:\n"
             }
@@ -1063,7 +1063,7 @@ struct CodeGenerator {
 
         output += "};"
 
-        .deferred_output += .codegen_ak_formatter(name: struct_.name, generic_parameter_names)
+        .deferred_output += .codegen_ak_formatter(name: struct_.name_for_codegen(), generic_parameter_names)
 
         return output
     }
@@ -1327,7 +1327,7 @@ struct CodeGenerator {
         }
         output += "debug_description() const { "
         output += "auto builder = MUST(StringBuilder::create());"
-        output += format("TRY(builder.append(\"{}(\"));", struct_.name)
+        output += format("TRY(builder.append(\"{}(\"));", struct_.name_for_codegen())
         output += "{\n"
         output += "JaktInternal::PrettyPrint::ScopedLevelIncrease increase_indent {};\n"
 
@@ -1639,7 +1639,7 @@ struct CodeGenerator {
                     let is_type = match .program.get_type(type_id) {
                         Struct(id) => {
                             let type_module = .program.get_module(id.module)
-                            yield .program.get_struct(id).name
+                            yield .program.get_struct(id).name_for_codegen()
                         }
                         else => .codegen_type(type_id)
                     }
@@ -2331,7 +2331,7 @@ struct CodeGenerator {
     }
 
     function codegen_function_return_type(mut this, anon function_: CheckedFunction) throws -> String {
-        if function_.is_static() and function_.name == "main" {
+        if function_.is_static() and function_.name_for_codegen() == "main" {
             return "ErrorOr<int>"
         }
         let type_name = .codegen_type(function_.return_type_id)
@@ -2355,7 +2355,7 @@ struct CodeGenerator {
             }
 
             output += .codegen_expression(lhs)
-            if rhs_type is GenericInstance(id) and .program.get_struct(id).name == "Optional" {
+            if rhs_type is GenericInstance(id) and .program.get_struct(id).name_for_codegen() == "Optional" {
                 if rhs_can_throw {
                     output += ".try_value_or_lazy_evaluated_optional";
                 } else {
@@ -2640,7 +2640,7 @@ struct CodeGenerator {
             output += "template "
         }
 
-        output += call.name
+        output += call.name_for_codegen()
 
         if not generic_parameters.is_empty() {
             mut types: [String] = []
@@ -2731,18 +2731,18 @@ struct CodeGenerator {
                             Struct(struct_id) => {
                                 let struct_ = .program.get_struct(struct_id)
                                 if struct_.record_type is Class {
-                                    output += call.name
+                                    output += call.name_for_codegen()
                                     output += "::"
                                     output += "create"
                                 } else {
-                                    output += call.name
+                                    output += call.name_for_codegen()
                                 }
                             }
                             GenericInstance(id, args) => {
                                 let struct_ = .program.get_struct(id)
                                 if struct_.record_type is Class {
                                     output += .codegen_namespace_qualifier(scope_id: struct_.scope_id)
-                                    output += struct_.name
+                                    output += struct_.name_for_codegen()
                                     output += "<"
                                     mut first = true
                                     for arg in args {
@@ -2755,7 +2755,7 @@ struct CodeGenerator {
                                     }
                                     output += ">::create"
                                 } else {
-                                    output += call.name
+                                    output += call.name_for_codegen()
                                     output += "<"
                                     mut first = true
                                     for arg in args {
@@ -2793,14 +2793,14 @@ struct CodeGenerator {
                                     output += .codegen_namespace_path(call)
                                     output += "template create<typename "
                                     output += .codegen_type_possibly_as_namespace(type_id: call.return_type, as_namespace: true)
-                                    output += "::" + call.name + ">"
+                                    output += "::" + call.name_for_codegen() + ">"
                                 } else {
                                     output += " " + .codegen_type(call.return_type)
                                     output += " { "
                                     output += "typename "
                                     output += .codegen_type(call.return_type)
                                     output += "::"
-                                    output += call.name
+                                    output += call.name_for_codegen()
 
                                     close_enum_type_wrapper = true
                                 }
@@ -2834,15 +2834,15 @@ struct CodeGenerator {
                            function_.linkage is Internal {
 
                             let struct_ = .program.get_struct(function_.struct_id!)
-                            output += struct_.name
+                            output += struct_.name_for_codegen()
                             output += "::"
                         }
 
-                        output += call.name
+                        output += call.name_for_codegen()
                     }
                 } else {
                     output += .codegen_namespace_path(call)
-                    output += call.name
+                    output += call.name_for_codegen()
                 }
 
                 let generic_parameters = call.type_args
@@ -2887,7 +2887,7 @@ struct CodeGenerator {
                 break
             }
 
-            output += namespace_.name
+            output += namespace_.external_name ?? namespace_.name
             if namespace_.generic_parameters.has_value() {
                 output += "<"
                 mut i: usize = 0
@@ -3198,7 +3198,7 @@ struct CodeGenerator {
             let inner_struct_id = inner_weak_ptr_struct_id.value()
             let struct_ = .program.get_struct(inner_struct_id)
             output += .codegen_namespace_qualifier(scope_id: struct_.scope_id)
-            output += struct_.name
+            output += struct_.name_for_codegen()
 
             output += ">"
         } else {
@@ -3210,7 +3210,7 @@ struct CodeGenerator {
             }
             output += namespace_
             output += .codegen_namespace_qualifier(scope_id: struct_.scope_id)
-            output += struct_.name
+            output += struct_.name_for_codegen()
             output += "<"
             mut first = true
             for type_id in args {
@@ -3306,7 +3306,7 @@ struct CodeGenerator {
                 output += "::"
             }
             output += .codegen_namespace_qualifier(scope_id: checked_struct.scope_id)
-            output += checked_struct.name
+            output += checked_struct.name_for_codegen()
             output += ">"
         } else {
             if not (type_module.is_root or type_module.id.equals(ModuleId(id: 0))  or checked_struct.definition_linkage is External) {
@@ -3314,7 +3314,7 @@ struct CodeGenerator {
                 output += "::"
             }
             output += .codegen_namespace_qualifier(scope_id: checked_struct.scope_id)
-            output += checked_struct.name
+            output += checked_struct.name_for_codegen()
         }
 
         return output
@@ -3368,7 +3368,7 @@ struct CodeGenerator {
 
             output += "protected:\n"
 
-            output += format("explicit {}(", function_.name)
+            output += format("explicit {}(", function_.name_for_codegen())
             mut first = true
             for param in function_.params {
                 if not first {
@@ -3385,7 +3385,7 @@ struct CodeGenerator {
             output += ");\n"
 
             mut class_name_with_generics = ""
-            class_name_with_generics += structure.name
+            class_name_with_generics += structure.name_for_codegen()
 
             first = true
             for generic_parameter in structure.generic_parameters {
@@ -3424,7 +3424,7 @@ struct CodeGenerator {
         }
 
         mut output = ""
-        output += function_.name
+        output += function_.name_for_codegen()
         output += "("
 
         mut first = true
@@ -3473,10 +3473,10 @@ struct CodeGenerator {
 
         if structure.record_type is Class {
             if is_inline {
-                output += function_.name
+                output += function_.name_for_codegen()
                 output += "("
             } else {
-                output += format("{}::{}(", qualified_name, function_.name)
+                output += format("{}::{}(", qualified_name, function_.name_for_codegen())
             }
 
             mut first = true
@@ -3502,7 +3502,7 @@ struct CodeGenerator {
                 let parent_constructor_parameter_count = function_.params.size() - structure.fields.size()
                 if parent_constructor_parameter_count > 0 {
                     mut parent_initializer = ""
-                    parent_initializer += .program.get_struct(structure.super_struct_id!).name
+                    parent_initializer += .program.get_struct(structure.super_struct_id!).name_for_codegen()
                     parent_initializer += "("
 
                     mut strings: [String] = []
@@ -3525,7 +3525,7 @@ struct CodeGenerator {
             output += "{}\n"
 
             mut class_name_with_generics = ""
-            class_name_with_generics += structure.name
+            class_name_with_generics += structure.name_for_codegen()
 
             first = true
             for generic_parameter in structure.generic_parameters {
@@ -3590,7 +3590,7 @@ struct CodeGenerator {
             output += qualified_name
             output += "::"
         }
-        output += function_.name
+        output += function_.name_for_codegen()
         output += "("
 
         mut first = true
@@ -3642,7 +3642,7 @@ struct CodeGenerator {
 
         output += .codegen_function_generic_parameters(function_)
 
-        let is_main = function_.name == "main" and not containing_struct.has_value()
+        let is_main = function_.name_for_codegen() == "main" and not containing_struct.has_value()
 
         if function_.return_type_id.equals(never_type_id()) {
             output += "[[noreturn]] "
@@ -3672,7 +3672,7 @@ struct CodeGenerator {
                 output += qualifier
                 output += "::"
             }
-            output += function_.name
+            output += function_.name_for_codegen()
         }
 
         output += "("

--- a/selfhost/formatter.jakt
+++ b/selfhost/formatter.jakt
@@ -3,7 +3,7 @@ import lexer { Lexer, Token }
 
 function concat<T>(anon xs: [T], anon y: T) throws -> [T] {
     mut ys: [T] = []
-    ys.push_values(xs)
+    ys.push_values(&xs)
     ys.push(y)
     return ys
 }

--- a/selfhost/ide.jakt
+++ b/selfhost/ide.jakt
@@ -87,7 +87,7 @@ function find_symbols_in_namespace(anon namespace_: ParsedNamespace) throws -> [
     }
 
     for sub_namespace in namespace_.namespaces {
-        symbols.push_values(find_symbols_in_namespace(sub_namespace))
+        symbols.push_values(&find_symbols_in_namespace(sub_namespace))
     }
 
     if not namespace_.name_span.has_value() {
@@ -320,7 +320,7 @@ function completions_for_type_id(program: CheckedProgram, type_id: TypeId) throw
         Enum(enum_id) => {
             let enum_ = program.get_enum(enum_id)
             let scope = program.get_scope(enum_.scope_id)
-            output.push_values(find_function_completions_in_scope(scope, program))
+            output.push_values(&find_function_completions_in_scope(scope, program))
         }
         Struct(struct_id) => {
             let structure = program.get_struct(struct_id)
@@ -331,7 +331,7 @@ function completions_for_type_id(program: CheckedProgram, type_id: TypeId) throw
             }
 
             let scope = program.get_scope(structure.scope_id)
-            output.push_values(find_function_completions_in_scope(scope, program))
+            output.push_values(&find_function_completions_in_scope(scope, program))
         }
         GenericInstance(id: struct_id) => {
             let structure = program.get_struct(struct_id)
@@ -342,7 +342,7 @@ function completions_for_type_id(program: CheckedProgram, type_id: TypeId) throw
             }
 
             let scope = program.get_scope(structure.scope_id)
-            output.push_values(find_function_completions_in_scope(scope, program))
+            output.push_values(&find_function_completions_in_scope(scope, program))
         }
         else => {}
     }

--- a/selfhost/interpreter.jakt
+++ b/selfhost/interpreter.jakt
@@ -219,6 +219,7 @@ function value_to_checked_expression(anon this_value: Value, anon mut interprete
             function_id: constructor
             return_type: struct_.type_id
             callee_throws: callee.can_throw
+            external_name: None
         )
 
         yield CheckedExpression::Call(
@@ -270,6 +271,7 @@ function value_to_checked_expression(anon this_value: Value, anon mut interprete
             function_id: constructor
             return_type: enum_.type_id
             callee_throws: callee.can_throw
+            external_name: None
         )
 
         yield CheckedExpression::Call(

--- a/selfhost/interpreter.jakt
+++ b/selfhost/interpreter.jakt
@@ -374,7 +374,7 @@ function value_to_checked_expression(anon this_value: Value, anon mut interprete
         }
 
         // Then append all the statements in the block
-        statements.push_values(block.statements)
+        statements.push_values(&block.statements)
 
         let new_block = CheckedBlock(
             statements

--- a/selfhost/parser.jakt
+++ b/selfhost/parser.jakt
@@ -253,8 +253,8 @@ struct ParsedNamespace {
         for extern_import in .extern_imports {
             if extern_import.is_equivalent_to(import_) {
                 extern_import.assigned_namespace.merge_with(import_.assigned_namespace)
-                extern_import.before_include.push_values(import_.before_include)
-                extern_import.after_include.push_values(import_.after_include)
+                extern_import.before_include.push_values(&import_.before_include)
+                extern_import.after_include.push_values(&import_.after_include)
                 return
             }
         }
@@ -272,8 +272,8 @@ struct ParsedNamespace {
     }
 
     function merge_with(mut this, anon namespace_: ParsedNamespace) throws {
-        .functions.push_values(namespace_.functions)
-        .records.push_values(namespace_.records)
+        .functions.push_values(&namespace_.functions)
+        .records.push_values(&namespace_.records)
 
         .module_imports.add_capacity(namespace_.module_imports.size())
         for import_ in namespace_.module_imports {
@@ -1857,14 +1857,14 @@ struct Parser {
                         .index++
                         let actions = .parse_include_action()
                         if actions.has_value() {
-                            parsed_import.before_include.push_values(actions!)
+                            parsed_import.before_include.push_values(&actions!)
                         }
                     }
                     "after_include" => {
                         .index++
                         let actions = .parse_include_action()
                         if actions.has_value() {
-                            parsed_import.after_include.push_values(actions!)
+                            parsed_import.after_include.push_values(&actions!)
                         }
                     }
                     else => {
@@ -3501,7 +3501,7 @@ struct Parser {
             let destructured_vars_stmt = ParsedStatement::DestructuringAssignment(vars: destructured_var_decls, var_decl, span: merge_spans(start_span, .previous().span()))
             mut block_stmts: [ParsedStatement] = []
             block_stmts.push(destructured_vars_stmt)
-            block_stmts.push_values(block.stmts)
+            block_stmts.push_values(&block.stmts)
             block.stmts = block_stmts
         }
 

--- a/selfhost/parser.jakt
+++ b/selfhost/parser.jakt
@@ -325,6 +325,8 @@ struct ParsedRecord {
     implements_list: [ParsedNameWithGenericParameters]?
     methods: [ParsedMethod]
     record_type: RecordType
+
+    external_name: String? = None
 }
 
 enum FunctionType {
@@ -353,6 +355,9 @@ struct ParsedFunction {
     must_instantiate: bool
     is_comptime: bool
     is_fat_arrow: bool
+
+    external_name: String? = None
+    deprecated_message: String? = None // if not None, the function is deprecated
 
     function equals(this, anon other: ParsedFunction) -> bool {
         if this.name != other.name or
@@ -1478,6 +1483,19 @@ enum Visibility {
     Restricted(whitelist: [VisibilityRestriction], span: Span)
 }
 
+struct ParsedAttributeArgument {
+    name: String
+    span: Span
+    assigned_value: String?
+}
+
+struct ParsedAttribute {
+    name: String
+    span: Span
+    assigned_value: String?
+    arguments: [ParsedAttributeArgument]
+}
+
 struct Parser {
     index: usize
     tokens: [Token]
@@ -1544,35 +1562,67 @@ struct Parser {
             generating_import_extern_after_include: []
         )
 
+        mut active_attributes: [ParsedAttribute] = []
+
         while not .eof() {
             match .current() {
                 Trait => {
+                    if not active_attributes.is_empty() {
+                        .error("Cannot apply attributes to trait declarations", active_attributes[0].span)
+                        active_attributes = []
+                    }
                     .index++
                     parsed_namespace.traits.push(.parse_trait())
                 }
                 Identifier(name) => match name {
                     "type" => {
+                        if not active_attributes.is_empty() {
+                            .error("Cannot apply attributes to external trait declarations", active_attributes[0].span)
+                            active_attributes = []
+                        }
                         .index++
                         parsed_namespace.external_trait_implementations.push(.parse_external_trait_implementation())
                     }
                     else => {
+                        active_attributes = []
                         .error("Unexpected token (expected keyword)", .current().span())
                         break
                     }
                 }
                 Import => {
+                    if not active_attributes.is_empty() {
+                        .error("Cannot apply attributes to imports", active_attributes[0].span)
+                        active_attributes = []
+                    }
                     .index++
                     .parse_import(parent: &mut parsed_namespace)
                 }
+                LSquare => {
+                    if .peek(1) is LSquare {
+                        .index += 2
+                        .parse_attribute_list(&mut active_attributes)
+                    } else {
+                        .error("Unexpected token (expected ‘[[’)", .current().span())
+                        .index += 1
+                    }
+                }
                 Function | Comptime => {
-                    let parsed_function = .parse_function(FunctionLinkage::Internal, Visibility::Public, is_comptime: .current() is Comptime)
+                    mut parsed_function = .parse_function(FunctionLinkage::Internal, Visibility::Public, is_comptime: .current() is Comptime)
+                    .apply_attributes(&mut parsed_function, &active_attributes)
+                    active_attributes = []
                     parsed_namespace.functions.push(parsed_function)
                 }
                 Struct | Class | Enum | Boxed => {
-                    let parsed_record = .parse_record(DefinitionLinkage::Internal)
+                    mut parsed_record = .parse_record(DefinitionLinkage::Internal)
+                    .apply_attributes(&mut parsed_record, &active_attributes)
+                    active_attributes = []
                     parsed_namespace.records.push(parsed_record)
                 }
                 Namespace => {
+                    if not active_attributes.is_empty() {
+                        .error("Cannot apply attributes to namespaces", active_attributes[0].span)
+                        active_attributes = []
+                    }
                     .index++
                     let name: (String, Span)? = match .current() {
                         Identifier(name, span) => {
@@ -1602,18 +1652,25 @@ struct Parser {
                     .index++
                     match .current() {
                         Function => {
-                            let parsed_function = .parse_function(FunctionLinkage::External, Visibility::Public, is_comptime: false)
+                            mut parsed_function = .parse_function(FunctionLinkage::External, Visibility::Public, is_comptime: false)
+                            .apply_attributes(&mut parsed_function, &active_attributes)
+                            active_attributes = []
                             parsed_namespace.functions.push(parsed_function)
                         }
                         Struct => {
-                            let parsed_struct = .parse_struct(DefinitionLinkage::External)
+                            mut parsed_struct = .parse_struct(DefinitionLinkage::External)
+                            .apply_attributes(&mut parsed_struct, &active_attributes)
+                            active_attributes = []
                             parsed_namespace.records.push(parsed_struct)
                         }
                         Class => {
-                            let parsed_class = .parse_class(DefinitionLinkage::External)
+                            mut parsed_class = .parse_class(DefinitionLinkage::External)
+                            .apply_attributes(&mut parsed_class, &active_attributes)
+                            active_attributes = []
                             parsed_namespace.records.push(parsed_class)
                         }
                         else => {
+                            active_attributes = []
                             .error("Unexpected keyword", .current().span())
                         }
                     }
@@ -1633,6 +1690,202 @@ struct Parser {
         }
 
         return parsed_namespace
+    }
+
+    function apply_attributes(mut this, anon parsed_function: &mut ParsedFunction, active_attributes: &[ParsedAttribute]) throws {
+        for attribute in *active_attributes {
+            match attribute.name {
+                "name" => {
+                    guard attribute.assigned_value.has_value() else {
+                        .error(
+                            format("The attribute '{}' requires a value", attribute.name)
+                            attribute.span
+                        )
+                        continue
+                    }
+
+                    if parsed_function.external_name.has_value() {
+                        .error(
+                            format("The attribute '{}' cannot be applied more than once", attribute.name)
+                            attribute.span
+                        )
+                        continue
+                    }
+
+                    parsed_function.external_name = attribute.assigned_value
+                }
+                "deprecated" => {
+                    if parsed_function.deprecated_message.has_value() {
+                        .error(
+                            format("The attribute '{}' cannot be applied more than once", attribute.name)
+                            attribute.span
+                        )
+                        continue
+                    }
+
+                    let message = attribute.arguments.first()?.name ?? format("The function '{}' is marked as deprecated", parsed_function.name)
+                    parsed_function.deprecated_message = message
+                }
+                else => {
+                    .error(
+                        format("The attribute '{}' does not apply to functions", attribute.name)
+                        attribute.span
+                    )
+                }
+            }
+        }
+    }
+
+    function apply_attributes(mut this, anon parsed_method: &mut ParsedMethod, active_attributes: &[ParsedAttribute]) throws {
+        .apply_attributes(parsed_function: &mut parsed_method.parsed_function, active_attributes)
+    }
+
+    function apply_attributes(mut this, anon parsed_record: &mut ParsedRecord, active_attributes: &[ParsedAttribute]) throws {
+        for attribute in *active_attributes {
+            match attribute.name {
+                "name" => {
+                    guard attribute.assigned_value.has_value() else {
+                        .error(
+                            format("The attribute '{}' requires a value", attribute.name)
+                            attribute.span
+                        )
+                        continue
+                    }
+
+                    if parsed_record.external_name.has_value() {
+                        .error(
+                            format("The attribute '{}' cannot be applied more than once", attribute.name)
+                            attribute.span
+                        )
+                        continue
+                    }
+
+                    parsed_record.external_name = attribute.assigned_value
+                }
+                else => {
+                    .error(
+                        format("The attribute '{}' does not apply to records", attribute.name)
+                        attribute.span
+                    )
+                }
+            }
+        }
+    }
+
+    function parse_attribute_list(mut this, active_attributes: &mut [ParsedAttribute]) throws {
+        while not .eof() and not .current() is RSquare and not .peek(1) is RSquare {
+            let attribute = .parse_attribute()
+            if attribute.has_value() {
+                active_attributes.push(attribute!)
+            }
+        }
+        if .current() is RSquare and .peek(1) is RSquare {
+            .index += 2
+        } else {
+            .error("Expected ‘]]’", .current().span())
+        }
+    }
+
+    function parse_attribute(mut this) throws -> ParsedAttribute? {
+        // Ident ('(' ((Ident|String) (':' (Ident|String))? ','?)* ')')? ('=' (Ident|String))?
+        let span = .current().span()
+        let name = match .current() {
+            Identifier(name) => {
+                .index++
+                yield name
+            }
+            else => {
+                .error("Expected identifier", .current().span())
+                return None
+            }
+        }
+
+        mut arguments: [ParsedAttributeArgument] = []
+        if .current() is LParen {
+            .index++
+            while not .eof() and not .current() is RParen {
+                let span = .current().span()
+
+                let argument_name = match .current() {
+                    Identifier(name) => {
+                        .index++
+                        yield name
+                    }
+                    QuotedString(quote) => {
+                        .index++
+                        yield quote
+                    }
+                    else => {
+                        .error("Expected identifier or string literal", .current().span())
+                        return None
+                    }
+                }
+
+                mut argument_value: String? = None
+                if .current() is Colon {
+                    .index++
+                    argument_value = match .current() {
+                        Identifier(name) => {
+                            .index++
+                            yield name
+                        }
+                        QuotedString(quote) => {
+                            .index++
+                            yield quote
+                        }
+                        else => {
+                            .error("Expected identifier or string literal", .current().span())
+                            return None
+                        }
+                    }
+                }
+
+                arguments.push(ParsedAttributeArgument(
+                    name: argument_name
+                    span
+                    assigned_value: argument_value
+                ))
+
+                if .current() is Comma {
+                    .index++
+                } else if not .current() is RParen {
+                    .error("Expected ‘,’ or ‘)’", .current().span())
+                    break
+                }
+            }
+
+            if .current() is RParen {
+                .index++
+            } else {
+                .error("Expected ‘)’", .current().span())
+            }
+        }
+
+        mut assigned_value: String? = None
+        if .current() is Equal {
+            .index++
+            assigned_value = match .current() {
+                Identifier(name) => {
+                    .index++
+                    yield Some(name)
+                }
+                QuotedString(quote) => {
+                    .index++
+                    yield Some(quote)
+                }
+                else => {
+                    .error("Expected identifier or string literal", .current().span())
+                    yield None
+                }
+            }
+        }
+
+        return ParsedAttribute(
+            name
+            span
+            assigned_value
+            arguments
+        )
     }
 
     function parse_external_trait_implementation(mut this) throws -> ParsedExternalTraitImplementation {
@@ -2469,12 +2722,18 @@ struct Parser {
         // Have we already found an error?
         mut error = false;
 
+        // Attributes being parsed for the next entity
+        mut active_attributes: [ParsedAttribute] = []
+
         while not .eof() {
             let token = .current()
             match token {
                 RCurly => {
                     if last_visibility.has_value() {
                         .error("Expected function or parameter after visibility modifier", token.span())
+                    }
+                    if not active_attributes.is_empty() {
+                        .error("Expected function after attribute", token.span())
                     }
                     .index++
                     return (fields, methods)
@@ -2506,7 +2765,20 @@ struct Parser {
                     last_visibility = .parse_restricted_visibility_modifier()
                     last_visibility_span = span
                 }
+                LSquare => {
+                    if .peek(1) is LSquare {
+                        .index += 2
+                        .parse_attribute_list(&mut active_attributes)
+                    } else {
+                        .error("Unexpected token (expected ‘[[’)", .current().span())
+                        .index += 1
+                    }
+                }
                 Identifier => {
+                    if not active_attributes.is_empty() {
+                        .error("Attributes cannot be applied to fields", .current().span())
+                        active_attributes = []
+                    }
                     // Parse a field
                     let visibility = last_visibility ?? default_visibility
                     last_visibility = None
@@ -2544,7 +2816,9 @@ struct Parser {
                     last_virtual = false
                     last_override = false
 
-                    let parsed_method = .parse_method(function_linkage, visibility, is_virtual, is_override, is_comptime: .current() is Comptime)
+                    mut parsed_method = .parse_method(function_linkage, visibility, is_virtual, is_override, is_comptime: .current() is Comptime)
+                    .apply_attributes(&mut parsed_method, &active_attributes)
+                    active_attributes = []
 
                     methods.push(parsed_method)
                 }
@@ -2557,6 +2831,8 @@ struct Parser {
                     .index++
                 }
                 else => {
+                    active_attributes = []
+
                     // TODO: Find a better way of only reporting the first error.
                     //       Also, should we report every error when running as the "language server"?
                     if not error {

--- a/selfhost/posix_compiler.jakt
+++ b/selfhost/posix_compiler.jakt
@@ -22,7 +22,7 @@ function run_compiler(
         extra_flags.push("-Wno-implicit-fallthrough")
         extra_flags.push("-Wno-unused-command-line-argument")
     }
-    extra_flags.push_values(extra_compiler_flags)
+    extra_flags.push_values(&extra_compiler_flags)
 
     mut compile_args = [
         cxx_compiler_path
@@ -42,7 +42,7 @@ function run_compiler(
     }
 
     if not extra_flags.is_empty() {
-        compile_args.push_values(extra_flags)
+        compile_args.push_values(&extra_flags)
     }
 
     compile_args.push("-I")

--- a/selfhost/typechecker.jakt
+++ b/selfhost/typechecker.jakt
@@ -1991,6 +1991,7 @@ struct Typechecker {
                 is_comptime: false
                 is_virtual: false
                 is_override: false
+                external_name: parsed_record.external_name
             )
 
             // Internal constructor
@@ -2164,6 +2165,7 @@ struct Typechecker {
             record_type: parsed_record.record_type
             type_id: struct_type_id
             super_struct_id
+            external_name: parsed_record.external_name
         )
 
         mut generic_parameters: [CheckedGenericParameter] = module.structures[struct_id.id].generic_parameters
@@ -2229,6 +2231,8 @@ struct Typechecker {
                 is_comptime: method.parsed_function.is_comptime
                 is_virtual: method.is_virtual
                 is_override: method.is_override
+                external_name: func.external_name
+                deprecated_message: func.deprecated_message
             )
 
             let function_id = module.add_function(checked_function)
@@ -2381,6 +2385,7 @@ struct Typechecker {
         .add_type_to_scope(scope_id, type_name: parsed_record.name, type_id: struct_type_id, span: parsed_record.name_span)
 
         let struct_scope_id = .create_scope(parent_scope_id: scope_id, can_throw: false, debug_name: format("struct({})", parsed_record.name))
+        .get_scope(struct_scope_id).external_name = parsed_record.external_name
 
         // Add a placeholder entry, this will be replaced later.
         module.structures.push(CheckedStruct(
@@ -2394,6 +2399,7 @@ struct Typechecker {
             record_type: parsed_record.record_type
             type_id: struct_type_id
             super_struct_id: None
+            external_name: parsed_record.external_name
         ))
     }
 
@@ -3094,6 +3100,8 @@ struct Typechecker {
             is_comptime: parsed_function.is_comptime
             is_virtual: false
             is_override: false
+            external_name: parsed_function.external_name
+            deprecated_message: parsed_function.deprecated_message
         )
 
         // FIXME: We can't return a `mut Foo` from a function right now, but assigning anything to a `mut` variable makes it mutable.
@@ -6717,6 +6725,7 @@ struct Typechecker {
                 function_id: None
                 return_type: unknown_type_id()
                 callee_throws: false
+                external_name: None
             )
             span
             is_optional
@@ -7445,12 +7454,15 @@ struct Typechecker {
                 if is_import {
                     namespaces[namespace_index].name = .program.modules[scope_id.module_id.id].name
                 }
+                namespaces[namespace_index].external_name = .get_scope(scope_id).external_name
+
                 current_scope_id = scope_id
                 continue
             }
             let maybe_struct_scope = .find_struct_in_scope(scope_id: current_scope_id, name: scope_name)
             if maybe_struct_scope.has_value() {
                 let structure = .get_struct(maybe_struct_scope!)
+                namespaces[namespace_index].external_name = structure.external_name
                 current_scope_id = structure.scope_id
                 continue
             }
@@ -7649,7 +7661,7 @@ struct Typechecker {
         }
 
         for name in call.namespace_ {
-            resolved_namespaces.push(ResolvedNamespace(name, generic_parameters: None))
+            resolved_namespaces.push(ResolvedNamespace(name, external_name: None, generic_parameters: None))
         }
 
         let callee_scope_id = match parent_id.has_value() {
@@ -7768,6 +7780,7 @@ struct Typechecker {
                             function_id: None,
                             return_type,
                             callee_throws
+                            external_name: None
                         ),
                         span,
                         type_id: return_type
@@ -7869,6 +7882,20 @@ struct Typechecker {
             .dump_try_hint(span)
         }
 
+        let external_name = match resolved_function_id.has_value() {
+            true => {
+                let function_ = .get_function(resolved_function_id!)
+                if function_.deprecated_message.has_value() {
+                    .error(
+                        format("Call to deprecated function: {}", function_.deprecated_message!)
+                        span
+                    )
+                }
+                yield function_.external_name
+            }
+            else => None
+        }
+
         let function_call = CheckedCall(
             namespace_: resolved_namespaces
             name: call.name
@@ -7877,6 +7904,7 @@ struct Typechecker {
             function_id: resolved_function_id
             return_type
             callee_throws
+            external_name
         )
         let checked_call = CheckedExpression::Call(
             call: function_call

--- a/selfhost/typechecker.jakt
+++ b/selfhost/typechecker.jakt
@@ -22,7 +22,7 @@ import types {
     CheckedStatement, CheckedStringLiteral, CheckedStruct, CheckedTrait, CheckedTypeCast, CheckedUnaryOperator
     CheckedVariable, CheckedVisibility, EnumId, FieldRecord, FunctionGenericParameter, FunctionGenerics, FunctionId
     GenericInferences, LoadedModule, MaybeResolvedScope, Module, ModuleId, NumberConstant, ResolvedNamespace
-    SafetyMode, Scope, ScopeId, StringLiteral, StructId, StructOrEnumId, TraitId, Type, TypeId, Value, VarId
+    SafetyMode, Scope, ScopeId, StringLiteral, StructId, StructLikeId, TraitId, Type, TypeId, Value, VarId
     builtin, never_type_id, unknown_type_id, void_type_id
 }
 import types
@@ -55,8 +55,15 @@ struct Typechecker {
     dump_try_hints: bool
     lambda_count: u64
     generic_inferences: GenericInferences
+    self_type_id: TypeId? = None
 
-    function type_name(this, anon type_id: TypeId) throws => .program.type_name(type_id)
+    function type_name(this, anon type_id: TypeId) throws -> String {
+        mut id = type_id
+        if .program.get_type(id) is Self and .self_type_id.has_value() {
+            id = .self_type_id!
+        }
+        return .program.type_name(id)
+    }
 
     function dump_type_hint(this, type_id: TypeId, span: Span) throws {
         println("{{\"type\":\"hint\",\"file_id\":{},\"position\":{},\"typename\":\"{}\"}}"
@@ -707,6 +714,10 @@ struct Typechecker {
         let struct_type_id = .find_or_add_type_id(Type::Struct(struct_id))
         .current_struct_type_id = struct_type_id
 
+        let old_self_type_id = .self_type_id
+        .self_type_id = struct_type_id
+        defer .self_type_id = old_self_type_id
+
         let parsed_fields = match record.record_type {
             Struct(fields) => fields
             Class(fields) => fields
@@ -766,6 +777,10 @@ struct Typechecker {
         defer {
             .current_struct_type_id = previous_struct_type_id
         }
+
+        let old_self_type_id = .self_type_id
+        .self_type_id = struct_type_id
+        defer .self_type_id = old_self_type_id
 
         let parsed_fields = match parsed_record.record_type {
             Struct(fields) => fields
@@ -1349,6 +1364,15 @@ struct Typechecker {
         // 6. Resolve external trait implementations
         for implementation in parsed_namespace.external_trait_implementations {
             let for_type = .typecheck_typename(parsed_type: implementation.for_type, scope_id, name: None)
+
+            let old_self_type_id = .self_type_id
+
+            .self_type_id = for_type
+
+            defer {
+                .self_type_id = old_self_type_id
+            }
+
             match .get_type(for_type) {
                 Struct(struct_id) | GenericInstance(id: struct_id) => {
                     mut struct_ = .get_struct(struct_id)
@@ -1387,10 +1411,19 @@ struct Typechecker {
                                 continue
                             }
 
+                            mut replaced_function = function_.copy()
+                            let inferences = .generic_inferences
+                            replaced_function.map_types(&function[inferences](anon type_id: TypeId) throws -> TypeId {
+                                return inferences.map(type_id)
+                            })
+
+                            mut module = .current_module()
+                            let new_function_id = module.add_function(checked_function: replaced_function)
+
                             .add_function_to_scope(
                                 parent_scope_id: struct_.scope_id
                                 name: name
-                                overload_set: [function_id]
+                                overload_set: [new_function_id]
                                 span: trait_name.name_span
                             )
                         }
@@ -1433,10 +1466,19 @@ struct Typechecker {
                                 continue
                             }
 
+                            mut replaced_function = function_.copy()
+                            let inferences = .generic_inferences
+                            replaced_function.map_types(&function[inferences](anon type_id: TypeId) throws -> TypeId {
+                                return inferences.map(type_id)
+                            })
+
+                            mut module = .current_module()
+                            let new_function_id = module.add_function(checked_function: replaced_function)
+
                             .add_function_to_scope(
                                 parent_scope_id: enum_.scope_id
                                 name: name
-                                overload_set: [function_id]
+                                overload_set: [new_function_id]
                                 span: trait_name.name_span
                             )
                         }
@@ -1476,6 +1518,11 @@ struct Typechecker {
         let trait_type_id = .find_or_add_type_id(Type::Trait(trait_id))
 
         .program.modules[.current_module_id.id].traits.push(checked_trait)
+
+
+        let old_self_type_id = .self_type_id
+        .self_type_id = trait_type_id
+        defer .self_type_id = old_self_type_id
 
         // register the trait
         mut scope = .get_scope(scope_id)
@@ -1568,6 +1615,10 @@ struct Typechecker {
     function typecheck_trait(mut this, parsed_trait: ParsedTrait, trait_id: TraitId, scope_id: ScopeId) throws {
         let checked_trait = .program.modules[trait_id.module.id].traits[trait_id.id]
 
+        let old_self_type_id = .self_type_id
+        .self_type_id = .find_or_add_type_id(Type::Trait(trait_id))
+        defer .self_type_id = old_self_type_id
+
         for parsed_function in parsed_trait.methods {
             if parsed_function.block.stmts.is_empty() {
                 continue
@@ -1590,6 +1641,10 @@ struct Typechecker {
 
         let enum_type_id = TypeId(module: module_id, id: .current_module().types.size() - 1)
         .add_type_to_scope(scope_id, type_name: parsed_record.name, type_id: enum_type_id, span: parsed_record.name_span)
+
+        let old_self_type_id = .self_type_id
+        .self_type_id = enum_type_id
+        defer .self_type_id = old_self_type_id
 
         let is_boxed = match parsed_record.record_type {
             SumEnum(is_boxed) => is_boxed
@@ -1614,6 +1669,10 @@ struct Typechecker {
 
     function typecheck_enum_predecl(mut this, parsed_record: ParsedRecord, enum_id: EnumId, scope_id: ScopeId) throws {
         let enum_type_id = .find_or_add_type_id(type: Type::Enum(enum_id))
+
+        let old_self_type_id = .self_type_id
+        .self_type_id = enum_type_id
+        defer .self_type_id = old_self_type_id
 
         let enum_scope_id = .create_scope(parent_scope_id: scope_id, can_throw: false, debug_name: format("enum({})", parsed_record.name))
 
@@ -1877,6 +1936,10 @@ struct Typechecker {
         let struct_type_id = .find_or_add_type_id(type: Type::Struct(struct_id))
         .current_struct_type_id = struct_type_id
 
+        let old_self_type_id = .self_type_id
+        .self_type_id = struct_type_id
+        defer .self_type_id = old_self_type_id
+
         let struct_ = .get_struct(struct_id)
 
         let constructor_ids = .find_functions_with_name_in_scope(parent_scope_id: struct_.scope_id, function_name: parsed_record.name)
@@ -2021,6 +2084,11 @@ struct Typechecker {
             return
         }
 
+        let old_self_type_id = .self_type_id
+        .self_type_id = .find_or_add_type_id(Type::GenericTraitInstance(id: trait_id, args: generic_parameters))
+        defer .self_type_id = old_self_type_id
+
+
         for i in 0..trait_.generic_parameters.size() {
             let parameter = trait_.generic_parameters[i]
             let type = generic_parameters[i]
@@ -2041,6 +2109,10 @@ struct Typechecker {
 
         let struct_type_id = .find_or_add_type_id(type: Type::Struct(struct_id))
         .current_struct_type_id = struct_type_id
+
+        let old_self_type_id = .self_type_id
+        .self_type_id = struct_type_id
+        defer .self_type_id = old_self_type_id
 
         let struct_scope_id = .current_module().structures[struct_id.id].scope_id
 
@@ -2366,7 +2438,7 @@ struct Typechecker {
                         if (method.parsed_function.params.first()?.variable?.name ?? "") == "this" {
                             .typecheck_method(
                                 func: method.parsed_function
-                                parent_id: StructOrEnumId::Struct(struct_id)
+                                parent_id: StructLikeId::Struct(struct_id)
                             )
                         } else {
                             .typecheck_function(
@@ -2382,7 +2454,7 @@ struct Typechecker {
                         if (method.parsed_function.params.first()?.variable?.name ?? "") == "this" {
                             .typecheck_method(
                                 func: method.parsed_function
-                                parent_id: StructOrEnumId::Enum(enum_id)
+                                parent_id: StructLikeId::Enum(enum_id)
                             )
                         } else {
                             .typecheck_function(
@@ -2402,6 +2474,10 @@ struct Typechecker {
         mut seen_names: {String} = {}
 
         mut enum_ = .get_enum(enum_id)
+
+        let old_self_type_id = .self_type_id
+        .self_type_id = enum_.type_id
+        defer .self_type_id = old_self_type_id
 
         mut common_seen_fields: {String} = {}
         mut common_fields: [VarId] = []
@@ -2688,10 +2764,14 @@ struct Typechecker {
     }
 
     function typecheck_enum(mut this, record: ParsedRecord, enum_id: EnumId, parent_scope_id: ScopeId) throws {
+        let old_self_type_id = .self_type_id
+        .self_type_id = .get_enum(enum_id).type_id
+        defer .self_type_id = old_self_type_id
+
         for method in record.methods {
             .typecheck_method(
                 func: method.parsed_function
-                parent_id: StructOrEnumId::Enum(enum_id)
+                parent_id: StructLikeId::Enum(enum_id)
             )
         }
     }
@@ -2705,6 +2785,10 @@ struct Typechecker {
         let struct_type_id = .find_or_add_type_id(Type::Struct(struct_id))
 
         .current_struct_type_id = struct_type_id
+
+        let old_self_type_id = .self_type_id
+        .self_type_id = struct_type_id
+        defer .self_type_id = old_self_type_id
 
         mut all_virtuals: [String: [CheckedFunction]] = [:]
         mut super_struct_id = .get_struct(struct_id).super_struct_id
@@ -2749,7 +2833,7 @@ struct Typechecker {
             } else if all_virtuals.contains(method.parsed_function.name) {
                 .error("Missing override keyword on function that is virtual", method.parsed_function.name_span)
             }
-            .typecheck_method(func: method.parsed_function, parent_id: StructOrEnumId::Struct(struct_id))
+            .typecheck_method(func: method.parsed_function, parent_id: StructLikeId::Struct(struct_id))
         }
 
 
@@ -2798,7 +2882,7 @@ struct Typechecker {
         .current_struct_type_id = None
     }
 
-    function typecheck_method(mut this, func: ParsedFunction, parent_id: StructOrEnumId) throws -> FunctionId? {
+    function typecheck_method(mut this, func: ParsedFunction, parent_id: StructLikeId) throws -> FunctionId? {
         mut parent_generic_parameters: [CheckedGenericParameter] = []
         mut scope_id = .prelude_scope_id()
         mut definition_linkage = DefinitionLinkage::Internal
@@ -2815,6 +2899,12 @@ struct Typechecker {
                 definition_linkage = enum_.definition_linkage
                 scope_id = enum_.scope_id
                 parent_generic_parameters = enum_.generic_parameters
+            }
+            Trait(trait_id) => {
+                let trait_ = .get_trait(trait_id)
+                definition_linkage = DefinitionLinkage::Internal
+                scope_id = trait_.scope_id
+                parent_generic_parameters = trait_.generic_parameters
             }
         }
 
@@ -3175,7 +3265,16 @@ struct Typechecker {
         }
     }
 
-    function typecheck_and_specialize_generic_function(mut this, function_id: FunctionId, generic_arguments: [TypeId], parent_scope_id: ScopeId, this_type_id: TypeId?, generic_substitutions: GenericInferences, type_args: [ParsedType], call_span: Span) throws {
+    function typecheck_and_specialize_generic_function(
+        mut this
+        function_id: FunctionId
+        generic_arguments: [TypeId]
+        parent_scope_id: ScopeId
+        this_type_id: TypeId?
+        generic_substitutions: GenericInferences
+        type_args: [ParsedType]
+        call_span: Span
+    ) throws {
         mut checked_function = .get_function(function_id)
         checked_function.generics.specializations.push(generic_arguments)
 
@@ -3186,7 +3285,11 @@ struct Typechecker {
             return
         }
         mut parsed_function = checked_function.to_parsed_function()
-        let scope_id = .create_scope(parent_scope_id: checked_function.generics.base_scope_id, can_throw: parsed_function.can_throw, debug_name: format("function-specialization({})", parsed_function.name))
+        let scope_id = .create_scope(
+            parent_scope_id: checked_function.generics.base_scope_id
+            can_throw: parsed_function.can_throw
+            debug_name: format("function-specialization({})", parsed_function.name)
+        )
 
         if parsed_function.generic_parameters.size() != generic_arguments.size() {
             .error(
@@ -3469,6 +3572,36 @@ struct Typechecker {
 
         let lhs_type = .get_type(lhs_type_id)
         let rhs_type = .get_type(rhs_type_id)
+
+        if lhs_type is Self {
+            guard not .self_type_id.has_value() else {
+                return .check_types_for_compat(
+                    lhs_type_id: .self_type_id!
+                    rhs_type_id
+                    generic_inferences
+                    span
+                )
+            }
+            .error(
+                "Invalid use of the 'Self' type"
+                span
+            )
+        }
+
+        if rhs_type is Self {
+            guard not .self_type_id.has_value() else {
+                return .check_types_for_compat(
+                    lhs_type_id
+                    rhs_type_id: .self_type_id!
+                    generic_inferences
+                    span
+                )
+            }
+            .error(
+                "Invalid use of the 'Self' type"
+                span
+            )
+        }
 
         let lhs_type_id_string = lhs_type_id.to_string()
         let rhs_type_id_string = rhs_type_id.to_string()
@@ -5636,6 +5769,15 @@ struct Typechecker {
         else => type_id
     }
 
+    function final_type_resolution_form(this, anon type_id: TypeId, anon scope_id: ScopeId) throws -> TypeId {
+        let mapped_type_id = .resolve_type_var(type_var_type_id: type_id, scope_id)
+        if .get_type(mapped_type_id) is Self and .self_type_id.has_value() {
+            return .self_type_id!
+        }
+
+        return mapped_type_id
+    }
+
     function typecheck_expression(
         mut this
         anon expr: ParsedExpression
@@ -5735,39 +5877,47 @@ struct Typechecker {
             let checked_expr_type_id = checked_expr.type()
             mut found_optional = false
 
-            let parent_id = match .get_type(checked_expr_type_id) {
-                Struct(id) => Some(StructOrEnumId::Struct(id))
-                Enum(id) => Some(StructOrEnumId::Enum(id))
-                JaktString => Some(StructOrEnumId::Struct(.find_struct_in_prelude("String")))
+            let parent_id = match .get_type(.final_type_resolution_form(checked_expr_type_id, scope_id)) {
+                Struct(id) => Some(StructLikeId::Struct(id))
+                Enum(id) => Some(StructLikeId::Enum(id))
+                JaktString => Some(StructLikeId::Struct(.find_struct_in_prelude("String")))
                 GenericInstance(id, args) => {
                     yield match is_optional {
                         true => {
                             let optional_struct_id = .find_struct_in_prelude("Optional")
-                            mut struct_id: StructOrEnumId? = None
+                            mut struct_id: StructLikeId? = None
                             if not id.equals(optional_struct_id) {
                                 .error(format("Can't use ‘{}’ as an optional type in optional chained call", .get_struct(id).name), span)
                             } else {
                                 found_optional = true
                                 struct_id = match .get_type(args[0]) {
-                                    Struct(struct_id) | GenericInstance(id: struct_id) => StructOrEnumId::Struct(struct_id)
-                                    Enum(id) | GenericEnumInstance(id) => StructOrEnumId::Enum(id)
+                                    Struct(struct_id) | GenericInstance(id: struct_id) => StructLikeId::Struct(struct_id)
+                                    Enum(id) | GenericEnumInstance(id) => StructLikeId::Enum(id)
                                     else => {
                                         .error("Can't use non-struct type as an optional type in optional chained call", span)
                                         found_optional = false
-                                        yield StructOrEnumId::Struct(optional_struct_id)
+                                        yield StructLikeId::Struct(optional_struct_id)
                                     }
                                 }
                             }
 
-                            yield Some(struct_id ?? StructOrEnumId::Struct(optional_struct_id))
+                            yield Some(struct_id ?? StructLikeId::Struct(optional_struct_id))
                         }
-                        else => Some(StructOrEnumId::Struct(id))
+                        else => Some(StructLikeId::Struct(id))
                     }
                 }
-                GenericEnumInstance(id) => Some(StructOrEnumId::Enum(id))
+                GenericEnumInstance(id) => Some(StructLikeId::Enum(id))
+                Trait(id) | GenericTraitInstance(id) => Some(StructLikeId::Trait(id))
                 else => {
-                    .error(message: format("no methods available on value (type: {})", .type_name(type_id: checked_expr_type_id)), span: checked_expr.span())
-                    let none: StructOrEnumId? = None
+                    .error(
+                        message: format(
+                            "no methods available on value (type: {} {})"
+                            .get_type(checked_expr_type_id).constructor_name()
+                            .type_name(type_id: checked_expr_type_id)
+                        )
+                        span: checked_expr.span()
+                    )
+                    let none: StructLikeId? = None
 
                     yield none
                 }
@@ -6219,7 +6369,18 @@ struct Typechecker {
         return None
     }
 
-    function typecheck_lambda(mut this, captures: [ParsedCapture], params: [ParsedParameter], can_throw: bool, is_fat_arrow: bool, return_type: ParsedType, block: ParsedBlock, span: Span, scope_id: ScopeId, safety_mode: SafetyMode) throws -> CheckedExpression {
+    function typecheck_lambda(
+        mut this
+        captures: [ParsedCapture]
+        params: [ParsedParameter]
+        can_throw: bool
+        is_fat_arrow: bool
+        return_type: ParsedType
+        block: ParsedBlock
+        span: Span
+        scope_id: ScopeId
+        safety_mode: SafetyMode
+    ) throws -> CheckedExpression {
         let synthetic_type = ParsedType::Function(
             params
             can_throw
@@ -7344,7 +7505,15 @@ struct Typechecker {
         return []
     }
 
-    function match_function_and_resolve_args(mut this, call: ParsedCall, caller_scope_id: ScopeId, candidate: FunctionId, safety_mode: SafetyMode, span: Span, this_expr: CheckedExpression?) throws -> FunctionMatchResult {
+    function match_function_and_resolve_args(
+        mut this
+        call: ParsedCall
+        caller_scope_id: ScopeId
+        candidate: FunctionId
+        safety_mode: SafetyMode
+        span: Span
+        this_expr: CheckedExpression?
+    ) throws -> FunctionMatchResult {
         mut args: [CheckedExpression] = []
         mut maybe_this_type_id: TypeId? = None
         mut argument_errors: [JaktError] = []
@@ -7430,7 +7599,14 @@ struct Typechecker {
         }
 
         mut total_function_specificity = 0
-        let resolved_args: [(String, Span, CheckedExpression)] = .resolve_default_params(params: callee_candidate.generics.base_params, args: call.args, scope_id: caller_scope_id, safety_mode, arg_offset, span)
+        let resolved_args: [(String, Span, CheckedExpression)] = .resolve_default_params(
+            params: callee_candidate.generics.base_params
+            args: call.args
+            scope_id: caller_scope_id
+            safety_mode
+            arg_offset
+            span
+        )
         if callee_candidate.generics.base_params.size() == resolved_args.size() + arg_offset {
             for i in 0..(callee_candidate.generics.base_params.size() - arg_offset) {
                 let (name, span, checked_arg) = resolved_args[i]
@@ -7456,7 +7632,7 @@ struct Typechecker {
         return FunctionMatchResult::MatchSuccess(args, maybe_this_type_id, used_generic_inferences: used_inferences, specificity: total_function_specificity)
     }
 
-    function typecheck_call(mut this, call: ParsedCall, caller_scope_id: ScopeId, span: Span, this_expr: CheckedExpression?, parent_id: StructOrEnumId?, safety_mode: SafetyMode, mut type_hint: TypeId?, must_be_enum_constructor: bool) throws -> CheckedExpression {
+    function typecheck_call(mut this, call: ParsedCall, caller_scope_id: ScopeId, span: Span, this_expr: CheckedExpression?, parent_id: StructLikeId?, safety_mode: SafetyMode, mut type_hint: TypeId?, must_be_enum_constructor: bool) throws -> CheckedExpression {
         mut args: [(String, CheckedExpression)] = []
         mut return_type = builtin(BuiltinType::Void)
         mut generic_arguments: [TypeId] = []
@@ -7503,6 +7679,11 @@ struct Typechecker {
                 }
                 Enum(id) => {
                     let scope_id = .get_enum(id).scope_id
+                    resolved_function_id_candidates = .resolve_call(call, namespaces: resolved_namespaces, span, scope_id, must_be_enum_constructor)
+                    yield scope_id
+                }
+                Trait(id) => {
+                    let scope_id = .get_trait(id).scope_id
                     resolved_function_id_candidates = .resolve_call(call, namespaces: resolved_namespaces, span, scope_id, must_be_enum_constructor)
                     yield scope_id
                 }
@@ -7560,7 +7741,7 @@ struct Typechecker {
                     }
                 }
 
-                if not resolved_function_id.has_value(){
+                if not resolved_function_id.has_value() {
                     if not resolved_function_id_candidates.is_empty() {
                         .error("No function with matching signature found.", span)
                         for match_error in errors_while_trying_to_find_matching_function.iterator() {
@@ -7823,7 +8004,15 @@ struct Typechecker {
         }
     }
 
-    function resolve_default_params(mut this, params: [CheckedParameter], args: [(String, Span, ParsedExpression)], scope_id: ScopeId, safety_mode: SafetyMode, arg_offset: usize, span: Span) throws -> [(String, Span, CheckedExpression)] {
+    function resolve_default_params(
+        mut this
+        params: [CheckedParameter]
+        args: [(String, Span, ParsedExpression)]
+        scope_id: ScopeId
+        safety_mode: SafetyMode
+        arg_offset: usize
+        span: Span
+    ) throws -> [(String, Span, CheckedExpression)] {
         mut params_with_default_value = 0uz
 
         for param in params {

--- a/selfhost/typechecker.jakt
+++ b/selfhost/typechecker.jakt
@@ -3210,10 +3210,12 @@ struct Typechecker {
             if type_args.size() > i {
                 arg_span = type_args[i].span()
             }
-            .check_type_argument_requirements(
-                generic_argument: generic_arguments[i],
-                constraints: checked_function.generics.params[i].checked_parameter.constraints,
-                arg_span)
+            if generic_arguments.size() > i {
+                .check_type_argument_requirements(
+                    generic_argument: generic_arguments[i],
+                    constraints: checked_function.generics.params[i].checked_parameter.constraints,
+                    arg_span)
+            }
         }
 
         let span = parsed_function.name_span
@@ -3834,6 +3836,31 @@ struct Typechecker {
                         // FIXME: maybe emit secondary error?
                         return false
                     }
+                } else {
+                    .error(
+                        format("Type mismatch: expected ‘{}’, but got ‘{}’", .type_name(lhs_type_id), .type_name(rhs_type_id))
+                        span
+                    )
+                    return false
+                }
+            }
+            MutableReference(lhs_inner_type_id) => {
+                if rhs_type is MutableReference(rhs_inner_type_id) {
+                    if not .check_types_for_compat(
+                        lhs_type_id: lhs_inner_type_id
+                        rhs_type_id: rhs_inner_type_id
+                        generic_inferences
+                        span
+                    ) {
+                        // FIXME: maybe emit secondary error?
+                        return false
+                    }
+                } else {
+                    .error(
+                        format("Type mismatch: expected ‘{}’, but got ‘{}’", .type_name(lhs_type_id), .type_name(rhs_type_id))
+                        span
+                    )
+                    return false
                 }
             }
             else => {
@@ -4762,7 +4789,7 @@ struct Typechecker {
                                 inner_condition = acc!
                                 outer_if_stmts.push(ParsedStatement::If(condition: inner_condition, then_block: then_block!, else_statement, span))
                             } else {
-                                outer_if_stmts.push_values(then_block!.stmts)
+                                outer_if_stmts.push_values(&then_block!.stmts)
                             }
                         }
 

--- a/selfhost/types.jakt
+++ b/selfhost/types.jakt
@@ -115,9 +115,10 @@ struct EnumId {
     }
 }
 
-enum StructOrEnumId {
+enum StructLikeId {
     Struct(StructId)
     Enum(EnumId)
+    Trait(TraitId)
 }
 
 struct TypeId {
@@ -696,6 +697,36 @@ class CheckedFunction {
     public is_virtual: bool
     public is_override: bool
 
+    public function map_types(mut this, anon map: &function(anon type_id: TypeId) throws -> TypeId) throws {
+        .return_type_id = map(.return_type_id)
+        mut changed_params: [CheckedParameter] = []
+        for param in .params {
+            changed_params.push(param.map_types(map))
+        }
+        .params = changed_params
+    }
+
+    public function copy(this) throws -> CheckedFunction => CheckedFunction(
+        name: .name
+        name_span: .name_span
+        visibility: .visibility
+        return_type_id: .return_type_id
+        return_type_span: .return_type_span
+        params: .params
+        generics: .generics
+        block: .block
+        can_throw: .can_throw
+        type: .type
+        linkage: .linkage
+        function_scope_id: .function_scope_id
+        struct_id: .struct_id
+        is_instantiated: .is_instantiated
+        parsed_function: .parsed_function
+        is_comptime: .is_comptime
+        is_virtual: .is_virtual
+        is_override: .is_override
+    )
+
     public function signature_matches(this, anon other: CheckedFunction) throws -> bool {
         if this.name != other.name or
         this.can_throw != other.can_throw or
@@ -816,6 +847,14 @@ struct CheckedParameter {
     requires_label: bool
     variable: CheckedVariable
     default_value: CheckedExpression?
+
+    public function map_types(this, anon map: &function(anon type_id: TypeId) throws -> TypeId) throws -> CheckedParameter {
+        return CheckedParameter(
+            requires_label: .requires_label
+            variable: .variable.map_types(map)
+            default_value: .default_value
+        )
+    }
 }
 
 enum CheckedCapture {
@@ -864,6 +903,17 @@ struct CheckedVariable {
     definition_span: Span
     type_span: Span?
     visibility: CheckedVisibility
+
+    public function map_types(this, anon map: &function(anon type_id: TypeId) throws -> TypeId) throws -> CheckedVariable {
+        return CheckedVariable(
+            name: .name
+            type_id: map(.type_id)
+            is_mutable: .is_mutable
+            definition_span: .definition_span
+            type_span: .type_span
+            visibility: .visibility
+        )
+    }
 }
 
 struct CheckedVarDecl {

--- a/selfhost/types.jakt
+++ b/selfhost/types.jakt
@@ -537,6 +537,8 @@ boxed enum Type {
 
 class Scope {
     public namespace_name: String?
+    public external_name: String?
+
     public vars: [String: VarId]
     public comptime_bindings: [String: Value]
     public structs: [String: StructId]
@@ -696,6 +698,11 @@ class CheckedFunction {
     public is_comptime: bool
     public is_virtual: bool
     public is_override: bool
+
+    public external_name: String? = None
+    public deprecated_message: String? = None
+
+    public function name_for_codegen(this) -> String => .external_name ?? .name
 
     public function map_types(mut this, anon map: &function(anon type_id: TypeId) throws -> TypeId) throws {
         .return_type_id = map(.return_type_id)
@@ -1067,6 +1074,10 @@ struct CheckedStruct {
     record_type: RecordType
     type_id: TypeId
     super_struct_id: StructId?
+
+    external_name: String? = None
+
+    function name_for_codegen(this) -> String => .external_name ?? .name
 }
 
 struct CheckedEnum {
@@ -1410,6 +1421,7 @@ boxed enum CheckedExpression {
 
 struct ResolvedNamespace {
     name: String
+    external_name: String? = None
     generic_parameters: [TypeId]?
 }
 
@@ -1421,6 +1433,10 @@ struct CheckedCall {
     function_id: FunctionId?
     return_type: TypeId
     callee_throws: bool
+
+    external_name: String?
+
+    function name_for_codegen(this) -> String => .external_name ?? .name
 }
 
 function unknown_type_id() -> TypeId => builtin(BuiltinType::Unknown)
@@ -1455,6 +1471,7 @@ class CheckedProgram {
 
         let scope = Scope(
             namespace_name: none_string
+            external_name: none_string
             vars: [:]
             comptime_bindings: [:]
             structs: [:]

--- a/selfhost/windows_compiler.jakt
+++ b/selfhost/windows_compiler.jakt
@@ -19,7 +19,7 @@ function run_compiler(
         throw Error::from_errno(38)
     }
 
-    extra_flags.push_values(extra_compiler_flags)
+    extra_flags.push_values(&extra_compiler_flags)
 
     mut compile_args = [
         cxx_compiler_path
@@ -42,7 +42,7 @@ function run_compiler(
     }
 
     if not extra_flags.is_empty() {
-        compile_args.push_values(extra_flags)
+        compile_args.push_values(&extra_flags)
     }
 
     compile_args.push("-I")


### PR DESCRIPTION
A friendly class type cannot be used in dictionaries otherwise.

This issue stems from the fact that HashMap<T, U> hands U out as `Traits<U>::PeekType` (and not U itself), so we can't go back to the original U object from that if they're not the same type.
