### PR TITLE
selfhost+tests: Fix a crash when trying to typecheck generic call

### DIFF
--- a/selfhost/typechecker.jakt
+++ b/selfhost/typechecker.jakt
@@ -3197,6 +3197,14 @@ struct Typechecker {
             )
         }
 
+        // NOTE: In the case where the calling function has type errors, we may not have sufficient information to
+        //       check this generic call. If that's the case, we bail out here and let the previous errors bubble
+        //       out to the user.
+        guard parsed_function.generic_parameters.size() <= generic_arguments.size()
+            and parsed_function.generic_parameters.size() <= checked_function.generics.params.size() else {
+            return
+        }
+
         for i in 0..parsed_function.generic_parameters.size() {
             mut arg_span = call_span
             if type_args.size() > i {

--- a/tests/typechecker/dont_crash_on_bogus_generic_call.jakt
+++ b/tests/typechecker/dont_crash_on_bogus_generic_call.jakt
@@ -1,0 +1,18 @@
+/// Expect:
+/// - error: "Unknown type ‘T’"
+
+struct Foo<T> {
+    value: T
+}
+
+function inner<T>(value: T) -> Foo<T> {
+    return Foo(value)
+}
+
+function outer(value: T) -> Foo<T> {
+    return inner(value)
+}
+
+function main() {
+    let foo = outer(value: 3)
+}


### PR DESCRIPTION
...in the presence of previous type errors that made the call impossible to specialize.

When this happens, we will already have queued up errors about the type errors, so we just bail out of the generic typecheck and let said errors bubble to the user.