### PR TITLE
Typecheck_function/method clean up and fixes to achieve parity

### DIFF
--- a/samples/arrays/slice_of_slice.jakt
+++ b/samples/arrays/slice_of_slice.jakt
@@ -1,7 +1,7 @@
 /// Expect:
 /// - output: "21\n"
 
-function slices(anon s: ArraySlice<i64>, mut total: i64) {
+function slices(anon s: ArraySlice<i64>, mut total: i64) -> i64 {
     total += s[0]
 
     if s.size() > 1 {

--- a/samples/enums/methods.jakt
+++ b/samples/enums/methods.jakt
@@ -16,9 +16,7 @@ enum Foo {
         }
     }
 
-    function name(this) throws {
-        return this.name_impl()
-    }
+    function name(this) throws => this.name_impl()
 }
 
 function main() {

--- a/samples/optional/mutable_unwrap.jakt
+++ b/samples/optional/mutable_unwrap.jakt
@@ -8,9 +8,7 @@ class Foo {
         this.x = value
     }
 
-    public function get(this) {
-        return this.x
-    }
+    public function get(this) => this.x
 }
 
 function main() {

--- a/selfhost/parser.jakt
+++ b/selfhost/parser.jakt
@@ -217,7 +217,7 @@ struct ParsedExternImport {
 
     function get_name(this) -> String => .assigned_namespace.name!
 
-    function is_equivalent_to(this, anon other: ParsedExternImport) throws {
+    function is_equivalent_to(this, anon other: ParsedExternImport) throws -> bool {
         return .is_c and other.is_c and .get_path() == other.get_path() and .get_name() == other.get_name()
     }
 }

--- a/selfhost/typechecker.jakt
+++ b/selfhost/typechecker.jakt
@@ -2937,10 +2937,15 @@ struct Typechecker {
         // method return type is checked against its implementation
         .current_function_id = method_id!
 
-        let VOID_TYPE_ID = builtin(BuiltinType::Void)
-
         let block = .typecheck_block(parsed_block: func.block, parent_scope_id: function_scope_id, safety_mode: SafetyMode::Safe)
-        let function_return_type_id = .typecheck_typename(parsed_type: func.return_type, scope_id: function_scope_id, name: None)
+        mut function_return_type_id = .typecheck_typename(parsed_type: func.return_type, scope_id: function_scope_id, name: None)
+
+        let VOID_TYPE_ID = void_type_id()
+
+        // If return type is not specified, default return type of non fat arrow functions is void
+        if not func.is_fat_arrow and func.return_type is Empty {
+            function_return_type_id = VOID_TYPE_ID
+        }
 
         mut return_type_id = function_return_type_id
         if function_return_type_id.equals(unknown_type_id()) and not block.statements.is_empty() {
@@ -3431,6 +3436,7 @@ struct Typechecker {
             name: None
         )
 
+        // If return type is not specified, default return type of non fat arrow functions is void
         if not parsed_function.is_fat_arrow and parsed_function.return_type is Empty and parsed_function.name != "main" {
             function_return_type_id = void_type_id()
         }

--- a/selfhost/typechecker.jakt
+++ b/selfhost/typechecker.jakt
@@ -2954,6 +2954,11 @@ struct Typechecker {
 
         let block = .typecheck_block(parsed_block: func.block, parent_scope_id: function_scope_id, safety_mode: SafetyMode::Safe)
 
+        if block.yielded_type.has_value() {
+            .error_with_hint("Functions are not allowed to yield values", func.block.find_yield_span()!,
+                            "You might want to return instead", func.block.find_yield_keyword_span()!)
+        }
+
         // Infer return type if necessary
         // If the return type is unknown we infer the return type from its expression.
         let return_type_id = match function_return_type_id.equals(unknown_type_id()) {

--- a/selfhost/typechecker.jakt
+++ b/selfhost/typechecker.jakt
@@ -3412,7 +3412,6 @@ struct Typechecker {
             return
         }
 
-        let func_ids = .find_functions_with_name_in_scope(parent_scope_id, function_name: parsed_function.name)
         let function_id = .find_function_matching_signature_in_scope(parent_scope_id, prototype: parsed_function)
 
         guard function_id.has_value() else {
@@ -3447,8 +3446,6 @@ struct Typechecker {
             function_return_type_id = void_type_id()
         }
 
-        checked_function.return_type_id = function_return_type_id
-
         if function_return_type_id.equals(never_type_id()) {
             // Allow noreturn functions to call throwing functions, they'll just be forced to crash.
             mut scope = .get_scope(function_scope_id)
@@ -3473,9 +3470,7 @@ struct Typechecker {
             else => .resolve_type_var(type_var_type_id: function_return_type_id, scope_id: function_scope_id)
         }
 
-        let external_linkage = function_linkage is External
-
-        if not external_linkage and not return_type_id.equals(void_type_id()) and not block.control_flow.always_transfers_control() {
+        if not function_linkage is External and not return_type_id.equals(void_type_id()) and not block.control_flow.always_transfers_control() {
             // FIXME: Use better span
             if return_type_id.equals(never_type_id()) and not block.control_flow.never_returns() {
                 .error("Control reaches end of never-returning function", parsed_function.name_span)

--- a/selfhost/typechecker.jakt
+++ b/selfhost/typechecker.jakt
@@ -3455,23 +3455,15 @@ struct Typechecker {
         }
 
         // Infer return type if necessary
-        // If the return type is unknown, and the function starts with a return statement,
-        // we infer the return type from its expression.
-        let UNKNOWN_TYPE_ID = unknown_type_id()
-        let VOID_TYPE_ID = void_type_id()
-        mut return_type_id = VOID_TYPE_ID
-        if function_return_type_id.equals(UNKNOWN_TYPE_ID) {
-            return_type_id = .infer_function_return_type(block)
-        } else {
-            return_type_id = .resolve_type_var(
-                type_var_type_id: function_return_type_id,
-                scope_id: function_scope_id
-            )
+        // If the return type is unknown we infer the return type from its expression.
+        let return_type_id = match function_return_type_id.equals(unknown_type_id()) {
+            true => .infer_function_return_type(block)
+            else => .resolve_type_var(type_var_type_id: function_return_type_id, scope_id: function_scope_id)
         }
 
         let external_linkage = function_linkage is External
 
-        if not external_linkage and not return_type_id.equals(VOID_TYPE_ID) and not block.control_flow.always_transfers_control() {
+        if not external_linkage and not return_type_id.equals(void_type_id()) and not block.control_flow.always_transfers_control() {
             // FIXME: Use better span
             if return_type_id.equals(never_type_id()) and not block.control_flow.never_returns() {
                 .error("Control reaches end of never-returning function", parsed_function.name_span)

--- a/selfhost/typechecker.jakt
+++ b/selfhost/typechecker.jakt
@@ -2937,7 +2937,6 @@ struct Typechecker {
         // method return type is checked against its implementation
         .current_function_id = method_id!
 
-        let block = .typecheck_block(parsed_block: func.block, parent_scope_id: function_scope_id, safety_mode: SafetyMode::Safe)
         mut function_return_type_id = .typecheck_typename(parsed_type: func.return_type, scope_id: function_scope_id, name: None)
 
         let VOID_TYPE_ID = void_type_id()
@@ -2946,6 +2945,14 @@ struct Typechecker {
         if not func.is_fat_arrow and func.return_type is Empty {
             function_return_type_id = VOID_TYPE_ID
         }
+
+        if function_return_type_id.equals(never_type_id()) {
+            // Allow noreturn functions to call throwing functions, they'll just be forced to crash.
+            mut scope = .get_scope(function_scope_id)
+            scope.can_throw = true
+        }
+
+        let block = .typecheck_block(parsed_block: func.block, parent_scope_id: function_scope_id, safety_mode: SafetyMode::Safe)
 
         // Infer return type if necessary
         // If the return type is unknown we infer the return type from its expression.

--- a/selfhost/typechecker.jakt
+++ b/selfhost/typechecker.jakt
@@ -3418,12 +3418,9 @@ struct Typechecker {
         let function_scope_id = checked_function.function_scope_id
         let function_linkage = checked_function.linkage
 
-        mut param_vars: [CheckedVariable] = []
         mut module = .current_module()
         for param in checked_function.params {
             let variable = param.variable
-            param_vars.push(variable)
-
             let var_id = module.add_variable(variable)
             .add_var_to_scope(scope_id: function_scope_id, name: variable.name, var_id, span: variable.definition_span)
         }

--- a/selfhost/typechecker.jakt
+++ b/selfhost/typechecker.jakt
@@ -2890,26 +2890,26 @@ struct Typechecker {
 
     function typecheck_method(mut this, func: ParsedFunction, parent_id: StructLikeId) throws -> FunctionId? {
         mut parent_generic_parameters: [CheckedGenericParameter] = []
-        mut scope_id = .prelude_scope_id()
-        mut definition_linkage = DefinitionLinkage::Internal
+        mut parent_scope_id = .prelude_scope_id()
+        mut parent_definition_linkage = DefinitionLinkage::Internal
 
         match parent_id {
             Struct(struct_id) => {
                 mut structure = .get_struct(struct_id)
+                parent_scope_id = structure.scope_id
+                parent_definition_linkage = structure.definition_linkage
                 parent_generic_parameters = structure.generic_parameters
-                scope_id = structure.scope_id
-                definition_linkage = structure.definition_linkage
             }
             Enum(enum_id) => {
                 let enum_ = .get_enum(enum_id)
-                definition_linkage = enum_.definition_linkage
-                scope_id = enum_.scope_id
+                parent_scope_id = enum_.scope_id
+                parent_definition_linkage = enum_.definition_linkage
                 parent_generic_parameters = enum_.generic_parameters
             }
             Trait(trait_id) => {
                 let trait_ = .get_trait(trait_id)
-                definition_linkage = DefinitionLinkage::Internal
-                scope_id = trait_.scope_id
+                parent_scope_id = trait_.scope_id
+                parent_definition_linkage = DefinitionLinkage::Internal
                 parent_generic_parameters = trait_.generic_parameters
             }
         }
@@ -2918,10 +2918,7 @@ struct Typechecker {
             return None
         }
 
-        let structure_scope_id = scope_id
-        let structure_linkage = definition_linkage
-
-        let method_id = .find_function_matching_signature_in_scope(parent_scope_id: structure_scope_id, prototype: func)
+        let method_id = .find_function_matching_signature_in_scope(parent_scope_id, prototype: func)
         if not method_id.has_value() {
             .compiler.panic("we just pushed the checked function, but it's not present")
         }
@@ -2957,7 +2954,7 @@ struct Typechecker {
             return_type_id = VOID_TYPE_ID
         }
 
-        if not structure_linkage is External and not return_type_id.equals(VOID_TYPE_ID) and not block.control_flow.always_transfers_control() {
+        if not parent_definition_linkage is External and not return_type_id.equals(VOID_TYPE_ID) and not block.control_flow.always_transfers_control() {
             // FIXME: Use better span
             if return_type_id.equals(never_type_id()) and not block.control_flow.never_returns() {
                 .error("Control reaches end of never-returning function", func.name_span)

--- a/selfhost/typechecker.jakt
+++ b/selfhost/typechecker.jakt
@@ -2919,9 +2919,10 @@ struct Typechecker {
         }
 
         let method_id = .find_function_matching_signature_in_scope(parent_scope_id, prototype: func)
-        if not method_id.has_value() {
-            .compiler.panic("we just pushed the checked function, but it's not present")
+        guard method_id.has_value() else {
+            .compiler.panic(format("Previously defined function {} not found in scope {}", func.name, parent_scope_id))
         }
+
         mut checked_function = .get_function(method_id!)
         let function_scope_id = checked_function.function_scope_id
 

--- a/selfhost/typechecker.jakt
+++ b/selfhost/typechecker.jakt
@@ -3425,7 +3425,6 @@ struct Typechecker {
             .add_var_to_scope(scope_id: function_scope_id, name: variable.name, var_id, span: variable.definition_span)
         }
 
-        // Resolve concrete types
         mut function_return_type_id = .typecheck_typename(
             parsed_type: parsed_function.return_type
             scope_id: function_scope_id
@@ -3454,13 +3453,6 @@ struct Typechecker {
             .error_with_hint("Functions are not allowed to yield values", parsed_function.block.find_yield_span()!,
                             "You might want to return instead", parsed_function.block.find_yield_keyword_span()!)
         }
-
-        // Typecheck return type a second time to resolve generics
-        function_return_type_id = .typecheck_typename(
-            parsed_type: parsed_function.return_type
-            scope_id: function_scope_id
-            name: None
-        )
 
         // Infer return type if necessary
         // If the return type is unknown, and the function starts with a return statement,

--- a/selfhost/typechecker.jakt
+++ b/selfhost/typechecker.jakt
@@ -2947,17 +2947,11 @@ struct Typechecker {
             function_return_type_id = VOID_TYPE_ID
         }
 
-        mut return_type_id = function_return_type_id
-        if function_return_type_id.equals(unknown_type_id()) and not block.statements.is_empty() {
-            // If the return type is unknown, and the function starts with a return statement,
-            // we infer the return type from its expression.
-            if block.statements[0] is Return(val) and val.has_value() {
-                return_type_id = val!.type()
-            } else {
-                return_type_id = VOID_TYPE_ID
-            }
-        } else if function_return_type_id.equals(unknown_type_id()) {
-            return_type_id = VOID_TYPE_ID
+        // Infer return type if necessary
+        // If the return type is unknown we infer the return type from its expression.
+        let return_type_id = match function_return_type_id.equals(unknown_type_id()) {
+            true => .infer_function_return_type(block)
+            else => .resolve_type_var(type_var_type_id: function_return_type_id, scope_id: function_scope_id)
         }
 
         if not parent_definition_linkage is External and not return_type_id.equals(VOID_TYPE_ID) and not block.control_flow.always_transfers_control() {

--- a/tests/typechecker/class_private_field_default.jakt
+++ b/tests/typechecker/class_private_field_default.jakt
@@ -2,9 +2,7 @@
 /// - error: "Can't access field ‘muda_amount’, because it is marked private\n"
 
 class GoodEncapsulation {
-    public function create() throws {
-        return GoodEncapsulation(muda_amount: 20, ora_amount: 9001)
-    }
+    public function create() throws => GoodEncapsulation(muda_amount: 20, ora_amount: 9001)
 
     muda_amount: u32
     public ora_amount: u32

--- a/tests/typechecker/restrict_to_scopes_accepted.jakt
+++ b/tests/typechecker/restrict_to_scopes_accepted.jakt
@@ -6,22 +6,16 @@ struct Foo {
 }
 
 struct A {
-    function b(anon foo: Foo) { return foo.x }
+    function b(anon foo: Foo) => foo.x
 }
 
 namespace Bar {
-    function bar(anon foo: Foo) {
-        return foo.x
-    }
+    function bar(anon foo: Foo) => foo.x
 
-    function bar2(anon foo: Foo) {
-        return foo.x
-    }
+    function bar2(anon foo: Foo) => foo.x
 }
 
-function baz(anon foo: Foo) {
-    return foo.x
-}
+function baz(anon foo: Foo) => foo.x
 
 function main() {
     let foo = Foo(x: 42)

--- a/tests/typechecker/struct_private_field.jakt
+++ b/tests/typechecker/struct_private_field.jakt
@@ -2,9 +2,7 @@
 /// - error: "Can't access field ‘age’, because it is marked private\n"
 
 struct WeirdEncapsulation {
-    function create(age: i32) {
-        return WeirdEncapsulation(age)
-    }
+    function create(age: i32) => WeirdEncapsulation(age)
 
     private age: i32
 }

--- a/tests/typechecker/yield_out_of_method_not_allowed.jakt
+++ b/tests/typechecker/yield_out_of_method_not_allowed.jakt
@@ -1,0 +1,12 @@
+/// Expect:
+/// - error: "Functions are not allowed to yield values"
+
+class Foo {
+    public function test() -> String {
+        yield "Foo"
+    }
+}
+
+function main() {
+
+}


### PR DESCRIPTION
I've decided to clean up `typecheck_method` and `typecheck_function` a little bit. I've tried to keep commits as atomic as possible to help the reviewer/s while also trying not to spam with them too much...
This PR does several things:
- 64c4070c678f3cb1bdfe841610f5efd08c334c97 removing the second `function_return_type_id = .typecheck_typename()` in `typecheck_function`.
I think this does not achieve anything (at least the removal of this does not break any tests) other than overwriting the previous value of the return type, which for function blocks with no specified type, would default to void at this point in code (as was the intention in bea32fbf16dee90f4038a42fd2552e2da0630ff7). In other words, this overwrite prevents us from defaulting to void for function blocks with no specified return type. After this commit we actually do that

- 50720a859626d5f5e2137c478a6c3b9bee821b88 we now default to void type for method blocks with no specified return type (this matches the (fixed above) behavior for function blocks)

- 1bb36bc4e662022d820f14d6d407aab8b7078acb, in c2486884f74ce8197df6bbac09f42501264343dc we started allowing to call throwing functions in noreturn functions. This commit allows us to do that in noreturn methods as well

- 9d3efa78a5ecc205e0302c486574e4699f83b369 emit error when trying to yield out of methods. In ecb581cfab538dea33a1a5694745856ae6183fca I've added an error when trying to yield out of function, but I forgot to do that for methods

- 6a8384fc3087e5d82c12d94462321770f92a0c53, 3faf88a01bf37b1c74f0b7233217ad4a6cc4d943, 2b657ae5ff068a4542a75122069bce46804a3181, a722114286eb33b2536b0a62d37bf8021e989709, 66e6ff8e5f39df65cf46c0f2366d6cc14b43fc4d, 4f15309836a8bc7ff8420711e6df6dc79a66e359, some general clean up, removing variables which are not used anywhere, unnecessary assignments, renaming etc.