### PR TITLE
Simplify error display + some fixes (including a fixed panic)

### DIFF
--- a/selfhost/error.jakt
+++ b/selfhost/error.jakt
@@ -73,7 +73,7 @@ function display_message_with_span(anon severity: MessageSeverity, file_name: St
     mut line_index = 0uz
     mut largest_line_number = 0uz
     while line_index < line_spans.size() {
-        if span.start >= line_spans[line_index].0 and span.start <= line_spans[line_index].1 {
+        if span.end >= line_spans[line_index].0 and span.end <= line_spans[line_index].1 {
             largest_line_number = line_index + 2 // 1 (row number) + 1 (extra source line)
         }
         ++line_index

--- a/selfhost/error.jakt
+++ b/selfhost/error.jakt
@@ -70,8 +70,7 @@ function display_message_with_span(anon severity: MessageSeverity, file_name: St
     let file_contents = contents!
     let line_spans = gather_line_spans(file_contents)
 
-    mut line_index = 1uz
-
+    mut line_index = 0uz
     mut largest_line_number = 0uz
     while line_index < line_spans.size() {
         if span.start >= line_spans[line_index].0 and span.start <= line_spans[line_index].1 {
@@ -82,7 +81,7 @@ function display_message_with_span(anon severity: MessageSeverity, file_name: St
     
     let width = format("{}", largest_line_number).length()
 
-    line_index = 1uz
+    line_index = 0uz
     while line_index < line_spans.size() {
         if span.start >= line_spans[line_index].0 and span.start <= line_spans[line_index].1 {
             let column_index = span.start - line_spans[line_index].0

--- a/selfhost/error.jakt
+++ b/selfhost/error.jakt
@@ -71,67 +71,70 @@ function display_message_with_span(anon severity: MessageSeverity, file_name: St
     let line_spans = gather_line_spans(file_contents)
 
     mut line_index = 0uz
+    mut error_start_index = 0uz
     mut largest_line_number = 0uz
+    // Determine largest (human readable) line number and the index of the first error line
     while line_index < line_spans.size() {
+        if span.start >= line_spans[line_index].0 and span.start <= line_spans[line_index].1 {
+            error_start_index = line_index
+        }
+
         if span.end >= line_spans[line_index].0 and span.end <= line_spans[line_index].1 {
             largest_line_number = line_index + 2 // 1 (row number) + 1 (extra source line)
         }
+
         ++line_index
     }
     
     let width = format("{}", largest_line_number).length()
 
-    line_index = 0uz
-    while line_index < line_spans.size() {
-        if span.start >= line_spans[line_index].0 and span.start <= line_spans[line_index].1 {
-            let column_index = span.start - line_spans[line_index].0
+    // Start printing the error and additional info, including source line numbers surrounded with a nice border
 
-            for x in 0..(width + 2) {
-                eprint("─")
-            }
+    line_index = error_start_index
+    let column_index = span.start - line_spans[line_index].0
 
-            eprintln("┬─ \u001b[33m{}:{}:{}\u001b[0m", file_name, line_index + 1, column_index + 1)
-
-            if line_index > 0 {
-                print_source_line(severity, file_contents, file_span: line_spans[line_index - 1], error_span: span, line_number: line_index, largest_line_number)
-            }
-
-            // Print the lines that include the error
-
-            while line_index < line_spans.size() and span.end > line_spans[line_index].0 {
-                print_source_line(severity, file_contents, file_span: line_spans[line_index], error_span: span, line_number: line_index + 1, largest_line_number)
-                if span.end <= line_spans[line_index].1 {
-                    break
-                }
-                ++line_index
-            }
-
-            // Print the error label
-            for x in 0..(width + 2) {
-                eprint(" ")
-            }
-            eprint("│")
-            for x in 0..(span.end - line_spans[line_index].0) {
-                eprint(" ")
-            }
-            eprintln("\u001b[{}m╰─ {}\u001b[0m", severity.ansi_color_code(), message)
-
-            ++line_index
-
-            // Print one last line for context
-            if line_index < line_spans.size() {
-                print_source_line(severity, file_contents, file_span: line_spans[line_index], error_span: span, line_number: line_index + 1, largest_line_number)
-            }
-        } else {
-            ++line_index
-        }
-
+    // Print top of the border, file name, line number and column of the error
+    for x in 0..(width + 2) {
+        eprint("─")
     }
+    eprintln("┬─ \u001b[33m{}:{}:{}\u001b[0m", file_name, line_index + 1, column_index + 1)
+
+    // Print one line before the error for the context
+    if line_index > 0 {
+        print_source_line(severity, file_contents, file_span: line_spans[line_index - 1], error_span: span, line_number: line_index, largest_line_number)
+    }
+
+    // Print the lines that include the error
+    while line_index < line_spans.size() and span.end > line_spans[line_index].0 {
+        print_source_line(severity, file_contents, file_span: line_spans[line_index], error_span: span, line_number: line_index + 1, largest_line_number)
+        if span.end <= line_spans[line_index].1 {
+            break
+        }
+        ++line_index
+    }
+
+    // Print the error label
+    for x in 0..(width + 2) {
+        eprint(" ")
+    }
+    eprint("│")
+    for x in 0..(span.end - line_spans[line_index].0) {
+        eprint(" ")
+    }
+    eprintln("\u001b[{}m╰─ {}\u001b[0m", severity.ansi_color_code(), message)
+
+    ++line_index
+
+    // Print one line after the error for context
+    if line_index < line_spans.size() {
+        print_source_line(severity, file_contents, file_span: line_spans[line_index], error_span: span, line_number: line_index + 1, largest_line_number)
+    }
+
+    // Print bottom of the border
     eprint("\u001b[0m")
     for x in 0..(width + 2) {
         eprint("─")
     }
-
     eprintln("┴─")
 }
 

--- a/selfhost/error.jakt
+++ b/selfhost/error.jakt
@@ -181,7 +181,7 @@ function gather_line_spans(file_contents: [u8]) throws -> [(usize, usize)] {
         }
         idx += 1
     }
-    if start < idx {
+    if start <= idx {
         output.push((start, idx))
     }
 

--- a/selfhost/parser.jakt
+++ b/selfhost/parser.jakt
@@ -3713,7 +3713,7 @@ struct Parser {
             Return => {
                 .index++
                 yield match .current() {
-                    Eol | Eof | RCurly => ParsedStatement::Return(expr: None, span: .current().span())
+                    Eol | Eof | RCurly => ParsedStatement::Return(expr: None, span: start)
                     else => ParsedStatement::Return(expr: .parse_expression(allow_assignments: false, allow_newlines: false), span: merge_spans(start, .previous().span()))
                 }
             }

--- a/tests/typechecker/dont_choke_on_multiline_error_spans.jakt
+++ b/tests/typechecker/dont_choke_on_multiline_error_spans.jakt
@@ -1,0 +1,15 @@
+/// Expect:
+/// - error: "Variable 'y' not found"
+
+// This actually just checks if the error displaying is not choking on multiline error spans that
+// happen to be on lines with a changing number of digits (lines 8 to 10 in this case)
+function foo(anon x: i64) -> i64 {
+    if x > 5 {
+        return struct {
+
+        }
+    } else {
+        return y
+    }
+}
+function main() { }


### PR DESCRIPTION
I've been hunting a weird panic that I've stumbled upon. Turned out it was a logic error in the display_message_with_span in error.jakt. While being there I've also fixed some other issues.

- 0081da911eec952ee0468c794d1ebaa9a3969294 we didn't properly print the span of the errors that occurred in first line of the source code

test.jakt:
```cpp
function main() { return y }
```
Previously:
```
greenclover@CloverLaptop:~/jakt$ ./build/bin/jakt ./own/test.jakt 
Error: Variable 'y' not found
───┴─
```
Now:
```
greenclover@CloverLaptop:~/jakt$ ./build/bin/jakt ./own/test.jakt 
Error: Variable 'y' not found
───┬─ ./own/test.jakt:1:26
 1 │ function main() { return y } 
   │                          ╰─ Variable 'y' not found
───┴─
```

- 865cb956ab2ad51bf2615d953eb0fb4e8f7bc16c we were not gathering a span of the last line of the file, if the line was empty. Seems like a bug and if not fixed, it would cause issues in the next commit

- f6e20b44929eb7dbd650449150a89be0510ae05f we were calculating the largest line number that we will display based on the ***start*** of the error span. The span could be several lines long tho, and we will display all of them, so the largest line number could be off. If it was off by enough line numbers, that the actual largest line number had more digits than we had expected, it later led on to the panic in the unsigned integers subtraction

- 229d5d16a784358c4aa478148b07d2c1716510d6 by calculating index of the first error line, we can later omit a `while` loop and an `if` inside it, which removes two levels of indentation. I've also added some comments

- b3f28c3a39f8529a679b795657c4de2202f766f9 previously, we gave return statements that return void (so they end with an `eof`, `eol` or `}`) a span that consists of the next token (`eof`, `eol`, `}`) instead of the span of the `return` keyword like we do if we return a non-void value (in this case we also include a span of the returned expression, but when returning void, there is no expression). This causes some oddities when displaying an error message of the error that happened in this statement

test.jakt:
```cpp
function foo(anon x: i64) -> i64 {
    return 
}
function main() { }
```

Previously:
```
greenclover@CloverLaptop:~/jakt$ ./build/bin/jakt ./own/test.jakt 
Error: ’return’ with no value in function ’foo’ returning ’i64’
───┬─ ./own/test.jakt:2:12
 1 │ function foo(anon x: i64) -> i64 { 
 2 │     return  
   │╰─ ’return’ with no value in function ’foo’ returning ’i64’
 4 │ function main() { } 
───┴─
```

Now:
```
greenclover@CloverLaptop:~/jakt$ ./build/bin/jakt ./own/test.jakt 
Error: ’return’ with no value in function ’foo’ returning ’i64’
───┬─ ./own/test.jakt:2:5
 1 │ function foo(anon x: i64) -> i64 { 
 2 │     return  
   │          ╰─ ’return’ with no value in function ’foo’ returning ’i64’
 3 │ } 
───┴─
```