### PR TITLE
Allow newlines after "namespace" keyword + minor FIXME

### DIFF
--- a/selfhost/parser.jakt
+++ b/selfhost/parser.jakt
@@ -1652,6 +1652,7 @@ struct Parser {
                         }
                         else => None
                     }
+                    .skip_newlines()
                     if .current() is LCurly {
                         .index++
                     } else {

--- a/selfhost/parser.jakt
+++ b/selfhost/parser.jakt
@@ -107,10 +107,8 @@ enum ImportName {
     }
 
     function literal_name(this) -> String {
-        // FIXME: this has to be reassigned here to be used as an enum is binding
-        let that = this
-        guard that is Literal(name) else {
-            panic("cannot get literal name of non-literal import name")
+        guard this is Literal(name) else {
+            panic("Cannot get literal name of non-literal import name")
         }
 
         return name

--- a/tests/parser/namespace_allow_newline_after_keyword.jakt
+++ b/tests/parser/namespace_allow_newline_after_keyword.jakt
@@ -1,0 +1,10 @@
+/// Expect:
+/// - output: "PASS\n"
+namespace Test
+{
+    function foo() => "PASS" 
+}
+
+function main() {
+    println("{}", Test::foo())
+}


### PR DESCRIPTION
This PR removes an amazing 1 FIXME

Allowing newlines after a `namespace foo`, but before a `{`, is the same behavior that we have for `if` and `match` statements, `function`s etc.