### PR TITLE
Add implicit return for lambdas returning void, which can throw

### DIFF
--- a/selfhost/codegen.jakt
+++ b/selfhost/codegen.jakt
@@ -1890,9 +1890,9 @@ struct CodeGenerator {
                 .current_function = function_
                 defer .current_function = previous_function
 
-                block_output = .codegen_block(block)
+                block_output = .codegen_lambda_block(can_throw, block, return_type_id)
             } else {
-                block_output = .codegen_block(block)
+                block_output = .codegen_lambda_block(can_throw, block, return_type_id)
             }
 
             yield format("[{}]({}) -> {} {}", join(generated_captures, separator: ", "), join(generated_params, separator: ", "), return_type, block_output)
@@ -3706,6 +3706,19 @@ struct CodeGenerator {
 
         output += "}\n"
 
+        return output
+    }
+
+    function codegen_lambda_block(mut this, can_throw: bool, block: CheckedBlock, return_type_id: TypeId) throws -> String {
+        mut output = "{\n"
+
+        output += .codegen_block(block)
+
+        if can_throw and return_type_id.equals(builtin(BuiltinType::Void)) {
+            output += "return {};\n"
+        }
+
+        output += "}\n"
         return output
     }
 }

--- a/tests/codegen/lambda_throw_and_return_void_implicit_return.jakt
+++ b/tests/codegen/lambda_throw_and_return_void_implicit_return.jakt
@@ -1,0 +1,11 @@
+/// Expect:
+/// - output: "PASS\n"
+
+function main() {
+    let lambda = function[]() throws -> void {
+        //  Implicit return
+    }
+
+    lambda()
+    println("PASS")
+}


### PR DESCRIPTION
Resolves https://github.com/SerenityOS/jakt/issues/1280.
Now we always add a `return {};` for all lambdas that can throw and return `void`, similarly to how we do it for regular functions.