### PR TITLE
CMake: Make sure that we link against -pthread when required

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,6 +13,8 @@ if(CCACHE_PROGRAM)
     set(CMAKE_CXX_COMPILER_LAUNCHER "${CCACHE_PROGRAM}" CACHE FILEPATH "Path to a compiler launcher program, e.g. ccache")
 endif()
 
+find_package(Threads REQUIRED)
+
 include(GNUInstallDirs)
 
 set(NO_SYMLINKS_DEFAULT OFF)
@@ -63,6 +65,7 @@ list(FILTER JAKT_STAGE0_ALL_SOURCES EXCLUDE REGEX ".*AK/Time\.cpp$")
 add_executable(jakt_stage0 "${JAKT_STAGE0_ALL_SOURCES}")
 add_executable(Jakt::jakt_stage0 ALIAS jakt_stage0)
 add_jakt_compiler_flags(jakt_stage0)
+target_link_libraries(jakt_stage0 PRIVATE Threads::Threads)
 target_include_directories(jakt_stage0
   PRIVATE
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/bootstrap/stage0/runtime>

--- a/cmake/install-config.cmake.in
+++ b/cmake/install-config.cmake.in
@@ -1,3 +1,5 @@
+find_package(Threads REQUIRED)
+
 include("${CMAKE_CURRENT_LIST_DIR}/JaktTargets.cmake")
 include("${CMAKE_CURRENT_LIST_DIR}/jakt-executable.cmake")
 

--- a/cmake/jakt-executable.cmake
+++ b/cmake/jakt-executable.cmake
@@ -20,6 +20,7 @@ function(add_jakt_compiler_flags target)
     -Wno-parentheses-equality
     -Wno-unqualified-std-cast-call
     -Wno-user-defined-literals
+    -Wno-literal-suffix
     -Wno-return-type
     -Wno-deprecated-declarations
     -Wno-unknown-warning-option

--- a/runtime/CMakeLists.txt
+++ b/runtime/CMakeLists.txt
@@ -81,6 +81,7 @@ target_include_directories(jakt_runtime
 
 add_library(Jakt::jakt_runtime ALIAS jakt_runtime)
 apply_output_rules(jakt_runtime)
+target_link_libraries(jakt_runtime PRIVATE Threads::Threads)
 
 add_library(jakt_main STATIC Main.cpp)
 add_jakt_compiler_flags(jakt_main)

--- a/runtime/CMakeLists.txt
+++ b/runtime/CMakeLists.txt
@@ -94,3 +94,5 @@ target_include_directories(jakt_main
 
 add_library(Jakt::jakt_main ALIAS jakt_main)
 apply_output_rules(jakt_main)
+
+set_target_properties(jakt_runtime jakt_main PROPERTIES POSITION_INDEPENDENT_CODE ON)


### PR DESCRIPTION
The Compiler Explorer misc-builder doesn't add -pthread automatically.

We might have to revisit this when adding actual threading support to
jakt.