### PR TITLE
Error in typechecker when generic else in a match has bindings

### DIFF
--- a/selfhost/codegen.jakt
+++ b/selfhost/codegen.jakt
@@ -2125,7 +2125,7 @@ struct CodeGenerator {
                 }
                 CatchAll(has_arguments, body, marker_span) => {
                     if has_arguments {
-                        panic("Bindings aren't allowed in generic else")
+                        panic("Bindings should not be present in a generic else")
                     }
 
                     // TODO: Use default statement if all values are constant

--- a/selfhost/typechecker.jakt
+++ b/selfhost/typechecker.jakt
@@ -7289,8 +7289,13 @@ struct Typechecker {
                                     seen_catch_all = true
                                 }
 
-                                // FIXME: bindings shouldn't be allowed for generic else but we can't just put an error here as the generic version
-                                // is typechecked with ignore errors
+                                if variant_arguments.size() != 0 {
+                                    let old_ignore_errors = .ignore_errors
+                                    .ignore_errors = false
+                                    .error("Bindings aren't allowed in a generic else", case_.marker_span)
+                                    .ignore_errors = old_ignore_errors
+                                }
+
                                 let new_scope_id = .create_scope(parent_scope_id: scope_id, can_throw: .get_scope(scope_id).can_throw, debug_name: "catch-all")
                                 mut defaults: [CheckedStatement] = []
                                 for (_, default_) in pattern.defaults {

--- a/tests/typechecker/match_enum_else_binding_generic.jakt
+++ b/tests/typechecker/match_enum_else_binding_generic.jakt
@@ -1,5 +1,5 @@
 /// Expect:
-/// - error: "Bindings aren't allowed in generic else"
+/// - error: "Bindings aren't allowed in a generic else"
 
 enum Foo {
     A(x: i64)


### PR DESCRIPTION
Previously the responsibility for an error (or alternatively a panic) when a generic else in a match had bindings was on codegen. It wasn't done in typechecker because `ignore_errors` is set to `true` when typechecking such expression.
But we know that this situation is not allowed in any case, so we can set `ignore_errors` to `false` and emit an error.

Removes 1 FIXME :^) and gives a better span for such an error.