### PR TITLE
parser: Fix possible out-of-bounds array access in ParsedExpr::equals() for ParsedExpr:: Array, Dictionary, Set and Tuple

### DIFF
--- a/selfhost/parser.jakt
+++ b/selfhost/parser.jakt
@@ -1108,7 +1108,8 @@ boxed enum ParsedExpression {
                         return false
                     }
                 }
-                if not lhs_values.size() == rhs_values.size() {
+
+                guard lhs_values.size() == rhs_values.size() else {
                     return false
                 }
 
@@ -1123,9 +1124,10 @@ boxed enum ParsedExpression {
         }
         JaktDictionary(values: lhs_values) => match rhs_expression {
             JaktDictionary(values: rhs_values) => {
-                if not lhs_values.size() == rhs_values.size() {
+                guard lhs_values.size() == rhs_values.size() else {
                     return false
                 }
+
                 for i in 0..lhs_values.size() {
                     if not (lhs_values[i].0.equals(rhs_values[i].0) and lhs_values[i].1.equals(rhs_values[i].1)) {
                         return false
@@ -1137,9 +1139,10 @@ boxed enum ParsedExpression {
         }
         Set(values: lhs_values) => match rhs_expression {
             Set(values: rhs_values) => {
-                if not lhs_values.size() == rhs_values.size() {
+                guard lhs_values.size() == rhs_values.size() else {
                     return false
                 }
+
                 for i in 0..lhs_values.size() {
                     if not lhs_values[i].equals(rhs_values[i]) {
                         return false
@@ -1151,9 +1154,10 @@ boxed enum ParsedExpression {
         }
         JaktTuple(values: lhs_values) => match rhs_expression {
             JaktTuple(values: rhs_values) => {
-                if not lhs_values.size() == rhs_values.size() {
+                guard lhs_values.size() == rhs_values.size() else {
                     return false
                 }
+
                 for i in 0..lhs_values.size() {
                     if not lhs_values[i].equals(rhs_values[i]) {
                         return false

--- a/tests/parser/if_else_branches_different_array_expr.jakt
+++ b/tests/parser/if_else_branches_different_array_expr.jakt
@@ -1,0 +1,13 @@
+/// Expect:
+/// - output: "success\n"
+
+function main() throws {
+    if true {
+        let x = [1, 2]
+    } else {
+        let x = [1]
+    }
+
+    // should parse without crashing the compiler
+    println("success")
+}

--- a/tests/parser/if_else_branches_different_dict_expr.jakt
+++ b/tests/parser/if_else_branches_different_dict_expr.jakt
@@ -1,0 +1,13 @@
+/// Expect:
+/// - output: "success\n"
+
+function main() throws {
+    if true {
+        let x = ["a": 1, "b": 2]
+    } else {
+        let x = ["a": 1]
+    }
+
+    // should parse without crashing the compiler
+    println("success")
+}

--- a/tests/parser/if_else_branches_different_set_expr.jakt
+++ b/tests/parser/if_else_branches_different_set_expr.jakt
@@ -1,0 +1,13 @@
+/// Expect:
+/// - output: "success\n"
+
+function main() throws {
+    if true {
+        let x = {1, 2}
+    } else {
+        let x = {1}
+    }
+
+    // should parse without crashing the compiler
+    println("success")
+}

--- a/tests/parser/if_else_branches_different_tuple_expr.jakt
+++ b/tests/parser/if_else_branches_different_tuple_expr.jakt
@@ -1,0 +1,13 @@
+/// Expect:
+/// - output: "success\n"
+
+function main() throws {
+    if true {
+        let x = (1, 2, 3)
+    } else {
+        let x = (1, 2)
+    }
+
+    // should parse without crashing the compiler
+    println("success")
+}


### PR DESCRIPTION
A typo / missing parenthesis when comparing the size of both arrays caused an out-of-bounds array access during element-wise comparison.