### PR TITLE
typechecker: Properly track control flow when dealing with an "if... else" block

### DIFF
--- a/selfhost/typechecker.jakt
+++ b/selfhost/typechecker.jakt
@@ -3638,7 +3638,15 @@ struct Typechecker {
                     PartialAlwaysReturns(might_break) => BlockControlFlow::PartialAlwaysReturns(might_break: might_break or then_might_break)
                     PartialAlwaysTransfersControl(might_break) => BlockControlFlow::PartialAlwaysTransfersControl(might_break: might_break or then_might_break)
                 }
-                PartialAlwaysReturns | PartialAlwaysTransfersControl | AlwaysTransfersControl => .maybe_statement_control_flow(else_statement, then_block.control_flow)
+                PartialAlwaysReturns(might_break: then_might_break) => match .maybe_statement_control_flow(else_statement, then_block.control_flow) {
+                    NeverReturns | AlwaysReturns => BlockControlFlow::PartialAlwaysReturns(might_break: then_might_break)
+                    MayReturn => BlockControlFlow::MayReturn
+                    AlwaysTransfersControl(might_break) => BlockControlFlow::PartialAlwaysTransfersControl(might_break: might_break or then_might_break)
+                    PartialNeverReturns(might_break) => BlockControlFlow::PartialAlwaysReturns(might_break: might_break or then_might_break)
+                    PartialAlwaysReturns(might_break) => BlockControlFlow::PartialAlwaysReturns(might_break: might_break or then_might_break)
+                    PartialAlwaysTransfersControl(might_break) => BlockControlFlow::PartialAlwaysTransfersControl(might_break: might_break or then_might_break)
+                }
+                PartialAlwaysTransfersControl | AlwaysTransfersControl => .maybe_statement_control_flow(else_statement, then_block.control_flow)
             }
         }
         Block(block) => block.control_flow

--- a/selfhost/typechecker.jakt
+++ b/selfhost/typechecker.jakt
@@ -3654,7 +3654,14 @@ struct Typechecker {
                     PartialAlwaysReturns(might_break) => BlockControlFlow::PartialAlwaysTransfersControl(might_break: might_break or then_might_break)
                     PartialAlwaysTransfersControl(might_break) => BlockControlFlow::PartialAlwaysTransfersControl(might_break: might_break or then_might_break)
                 }
-                AlwaysTransfersControl => .maybe_statement_control_flow(else_statement, then_block.control_flow)
+                AlwaysTransfersControl(might_break: then_might_break) => match .maybe_statement_control_flow(else_statement, then_block.control_flow) {
+                    NeverReturns | AlwaysReturns => BlockControlFlow::AlwaysTransfersControl(might_break: then_might_break)
+                    MayReturn => BlockControlFlow::MayReturn
+                    AlwaysTransfersControl(might_break) => BlockControlFlow::AlwaysTransfersControl(might_break: might_break or then_might_break)
+                    PartialNeverReturns(might_break) => BlockControlFlow::PartialNeverReturns(might_break: might_break or then_might_break)
+                    PartialAlwaysReturns(might_break) => BlockControlFlow::PartialAlwaysReturns(might_break: might_break or then_might_break)
+                    PartialAlwaysTransfersControl(might_break) => BlockControlFlow::PartialAlwaysTransfersControl(might_break: might_break or then_might_break)
+                }
             }
         }
         Block(block) => block.control_flow

--- a/selfhost/typechecker.jakt
+++ b/selfhost/typechecker.jakt
@@ -3646,7 +3646,15 @@ struct Typechecker {
                     PartialAlwaysReturns(might_break) => BlockControlFlow::PartialAlwaysReturns(might_break: might_break or then_might_break)
                     PartialAlwaysTransfersControl(might_break) => BlockControlFlow::PartialAlwaysTransfersControl(might_break: might_break or then_might_break)
                 }
-                PartialAlwaysTransfersControl | AlwaysTransfersControl => .maybe_statement_control_flow(else_statement, then_block.control_flow)
+                PartialAlwaysTransfersControl(might_break: then_might_break) => match .maybe_statement_control_flow(else_statement, then_block.control_flow) {
+                    NeverReturns | AlwaysReturns => BlockControlFlow::PartialAlwaysTransfersControl(might_break: then_might_break)
+                    MayReturn => BlockControlFlow::MayReturn
+                    AlwaysTransfersControl(might_break) => BlockControlFlow::PartialAlwaysTransfersControl(might_break: might_break or then_might_break)
+                    PartialNeverReturns(might_break) => BlockControlFlow::PartialAlwaysTransfersControl(might_break: might_break or then_might_break)
+                    PartialAlwaysReturns(might_break) => BlockControlFlow::PartialAlwaysTransfersControl(might_break: might_break or then_might_break)
+                    PartialAlwaysTransfersControl(might_break) => BlockControlFlow::PartialAlwaysTransfersControl(might_break: might_break or then_might_break)
+                }
+                AlwaysTransfersControl => .maybe_statement_control_flow(else_statement, then_block.control_flow)
             }
         }
         Block(block) => block.control_flow

--- a/selfhost/typechecker.jakt
+++ b/selfhost/typechecker.jakt
@@ -3630,7 +3630,15 @@ struct Typechecker {
                     PartialAlwaysTransfersControl(might_break) => BlockControlFlow::PartialAlwaysTransfersControl(might_break)
                 }
                 MayReturn => BlockControlFlow::MayReturn
-                PartialNeverReturns | PartialAlwaysReturns | PartialAlwaysTransfersControl | AlwaysTransfersControl => .maybe_statement_control_flow(else_statement, then_block.control_flow)
+                PartialNeverReturns(might_break: then_might_break) => match .maybe_statement_control_flow(else_statement, then_block.control_flow) {
+                    NeverReturns | AlwaysReturns => BlockControlFlow::PartialNeverReturns(might_break: then_might_break)
+                    MayReturn => BlockControlFlow::MayReturn
+                    AlwaysTransfersControl(might_break) => BlockControlFlow::PartialAlwaysTransfersControl(might_break: might_break or then_might_break)
+                    PartialNeverReturns(might_break) => BlockControlFlow::PartialNeverReturns(might_break: might_break or then_might_break)
+                    PartialAlwaysReturns(might_break) => BlockControlFlow::PartialAlwaysReturns(might_break: might_break or then_might_break)
+                    PartialAlwaysTransfersControl(might_break) => BlockControlFlow::PartialAlwaysTransfersControl(might_break: might_break or then_might_break)
+                }
+                PartialAlwaysReturns | PartialAlwaysTransfersControl | AlwaysTransfersControl => .maybe_statement_control_flow(else_statement, then_block.control_flow)
             }
         }
         Block(block) => block.control_flow

--- a/tests/typechecker/control_flow_1.jakt
+++ b/tests/typechecker/control_flow_1.jakt
@@ -1,0 +1,24 @@
+/// Expect:
+/// - output: "PASS\n"
+
+function test() -> i64 {
+    let x = 2
+
+    if x == 2 {
+        // Partially never return
+        if x == 3 {
+            abort()
+        }
+    } else {
+        // Always return
+        return 1
+    }
+
+    // This should be reachable
+    println("PASS")
+    return 1
+}
+
+function main() {
+    test()
+}

--- a/tests/typechecker/control_flow_10.jakt
+++ b/tests/typechecker/control_flow_10.jakt
@@ -1,0 +1,28 @@
+/// Expect:
+/// - output: "PASS\n"
+
+function test() -> i64 {
+    let x = 2
+
+    loop {
+        if x == 2 {
+            // Partially transfer control (can break)
+            if x == 2 {
+                break
+            }
+        } else {
+            // Partially never return (can't break)
+            if x == 3 {
+                abort()
+            }
+        }
+    }
+
+    // This should be reachable
+    println("PASS")
+    return 1
+}
+
+function main() {
+    test()
+}

--- a/tests/typechecker/control_flow_10_continue_case.jakt
+++ b/tests/typechecker/control_flow_10_continue_case.jakt
@@ -1,0 +1,28 @@
+/// Expect:
+/// - error: "Unreachable code"
+
+function test() -> i64 {
+    let x = 2
+
+    loop {
+        if x == 2 {
+            // Partially transfer control (can't break)
+            if x == 2 {
+                continue
+            }
+        } else {
+            // Partially never return (can't break)
+            if x == 3 {
+                abort()
+            }
+        }
+    }
+
+    // This should not be reachable
+    println("NOT PASSED")
+    return 1
+}
+
+function main() {
+    test()
+}

--- a/tests/typechecker/control_flow_11.jakt
+++ b/tests/typechecker/control_flow_11.jakt
@@ -1,0 +1,28 @@
+/// Expect:
+/// - output: "PASS\n"
+
+function test() -> i64 {
+    let x = 2
+
+    loop {
+        if x == 2 {
+            // Partially transfer control (can break)
+            if x == 2 {
+                break
+            }
+        } else {
+            // Partially always return (can't break)
+            if x == 3 {
+                return 1
+            }
+        }
+    }
+
+    // This should be reachable
+    println("PASS")
+    return 1
+}
+
+function main() {
+    test()
+}

--- a/tests/typechecker/control_flow_11_continue_case.jakt
+++ b/tests/typechecker/control_flow_11_continue_case.jakt
@@ -1,0 +1,28 @@
+/// Expect:
+/// - error: "Unreachable code"
+
+function test() -> i64 {
+    let x = 2
+
+    loop {
+        if x == 2 {
+            // Partially transfer control (can't break)
+            if x == 2 {
+                continue
+            }
+        } else {
+            // Partially always return (can't break)
+            if x == 3 {
+                return 1
+            }
+        }
+    }
+
+    // This should not be reachable
+    println("NOT PASSED")
+    return 1
+}
+
+function main() {
+    test()
+}

--- a/tests/typechecker/control_flow_12.jakt
+++ b/tests/typechecker/control_flow_12.jakt
@@ -1,0 +1,28 @@
+/// Expect:
+/// - output: "PASS\n"
+
+function test() -> i64 {
+    let x = 2
+
+    loop {
+        if x == 2 {
+            // Partially transfer control (can break)
+            if x == 2 {
+                break
+            }
+        } else {
+            // Partially always transfer control (can't break)
+            if x == 3 {
+                continue
+            }
+        }
+    }
+
+    // This should be reachable
+    println("PASS")
+    return 1
+}
+
+function main() {
+    test()
+}

--- a/tests/typechecker/control_flow_12_continue_case.jakt
+++ b/tests/typechecker/control_flow_12_continue_case.jakt
@@ -1,0 +1,28 @@
+/// Expect:
+/// - error: "Unreachable code"
+
+function test() -> i64 {
+    let x = 2
+
+    loop {
+        if x == 2 {
+            // Partially transfer control (can't break)
+            if x == 2 {
+                continue
+            }
+        } else {
+            // Partially always transfer control (can't break)
+            if x == 3 {
+                continue
+            }
+        }
+    }
+
+    // This should not be reachable
+    println("NOT PASSED")
+    return 1
+}
+
+function main() {
+    test()
+}

--- a/tests/typechecker/control_flow_13.jakt
+++ b/tests/typechecker/control_flow_13.jakt
@@ -1,0 +1,24 @@
+/// Expect:
+/// - output: "PASS\n"
+
+function test() -> i64 {
+    let x = 2
+
+    loop {
+        if x == 2 {
+            // Always transfer control (can break)
+            break
+        } else {
+            // Always return
+            return 1
+        }
+    }
+
+    // This should be reachable
+    println("PASS")
+    return 1
+}
+
+function main() {
+    test()
+}

--- a/tests/typechecker/control_flow_13_continue_case.jakt
+++ b/tests/typechecker/control_flow_13_continue_case.jakt
@@ -1,0 +1,24 @@
+/// Expect:
+/// - error: "Unreachable code"
+
+function test() -> i64 {
+    let x = 1
+
+    loop {
+        if x == 2 {
+            // Always transfer control (can't break)
+            continue
+        } else {
+            // Always return
+            return 1
+        }
+    }
+
+    // This should not be reachable
+    println("NOT PASSED")
+    return 1
+}
+
+function main() {
+    test()
+}

--- a/tests/typechecker/control_flow_14.jakt
+++ b/tests/typechecker/control_flow_14.jakt
@@ -1,0 +1,24 @@
+/// Expect:
+/// - output: "PASS\n"
+
+function test() -> i64 {
+    let x = 2
+
+    loop {
+        if x == 2 {
+            // Always transfer control (can break)
+            break
+        } else {
+            // Never return
+            abort()
+        }
+    }
+
+    // This should be reachable
+    println("PASS")
+    return 1
+}
+
+function main() {
+    test()
+}

--- a/tests/typechecker/control_flow_14_continue_case.jakt
+++ b/tests/typechecker/control_flow_14_continue_case.jakt
@@ -1,0 +1,24 @@
+/// Expect:
+/// - error: "Unreachable code"
+
+function test() -> i64 {
+    let x = 1
+
+    loop {
+        if x == 2 {
+            // Always transfer control (can't break)
+            continue
+        } else {
+            // Never return
+            abort()
+        }
+    }
+
+    // This should not be reachable
+    println("NOT PASSED")
+    return 1
+}
+
+function main() {
+    test()
+}

--- a/tests/typechecker/control_flow_15.jakt
+++ b/tests/typechecker/control_flow_15.jakt
@@ -1,0 +1,24 @@
+/// Expect:
+/// - output: "PASS\n"
+
+function test() -> i64 {
+    let x = 2
+
+    loop {
+        if x == 2 {
+            // Always transfer control (can break)
+            break
+        } else {
+            // Always transfer control (can't break)
+            continue
+        }
+    }
+
+    // This should be reachable
+    println("PASS")
+    return 1
+}
+
+function main() {
+    test()
+}

--- a/tests/typechecker/control_flow_15_continue_case.jakt
+++ b/tests/typechecker/control_flow_15_continue_case.jakt
@@ -1,0 +1,24 @@
+/// Expect:
+/// - error: "Unreachable code"
+
+function test() -> i64 {
+    let x = 2
+
+    loop {
+        if x == 2 {
+            // Always transfer control (can't break)
+            continue
+        } else {
+            // Always transfer control (can't break)
+            continue
+        }
+    }
+
+    // This should not be reachable
+    println("NOT PASSED")
+    return 1
+}
+
+function main() {
+    test()
+}

--- a/tests/typechecker/control_flow_16.jakt
+++ b/tests/typechecker/control_flow_16.jakt
@@ -1,0 +1,26 @@
+/// Expect:
+/// - output: "PASS\n"
+
+function test() -> i64 {
+    let x = 2
+
+    loop {
+        if x == 2 {
+            // Always transfer control (can break)
+            break
+        } else {
+            // Partially never return (can't break)
+            if x == 3 {
+                abort()
+            }
+        }
+    }
+
+    // This should be reachable
+    println("PASS")
+    return 1
+}
+
+function main() {
+    test()
+}

--- a/tests/typechecker/control_flow_16_continue_case.jakt
+++ b/tests/typechecker/control_flow_16_continue_case.jakt
@@ -1,0 +1,26 @@
+/// Expect:
+/// - error: "Unreachable code"
+
+function test() -> i64 {
+    let x = 2
+
+    loop {
+        if x == 2 {
+            // Always transfer control (can't break)
+            continue
+        } else {
+            // Partially never return (can't break)
+            if x == 3 {
+                abort()
+            }
+        }
+    }
+
+    // This should not be reachable
+    println("NOT PASSED")
+    return 1
+}
+
+function main() {
+    test()
+}

--- a/tests/typechecker/control_flow_17.jakt
+++ b/tests/typechecker/control_flow_17.jakt
@@ -1,0 +1,26 @@
+/// Expect:
+/// - output: "PASS\n"
+
+function test() -> i64 {
+    let x = 2
+
+    loop {
+        if x == 2 {
+            // Always transfer control (can break)
+            break
+        } else {
+            // Partially always return (can't break)
+            if x == 3 {
+                return 1
+            }
+        }
+    }
+
+    // This should be reachable
+    println("PASS")
+    return 1
+}
+
+function main() {
+    test()
+}

--- a/tests/typechecker/control_flow_17_continue_case.jakt
+++ b/tests/typechecker/control_flow_17_continue_case.jakt
@@ -1,0 +1,26 @@
+/// Expect:
+/// - error: "Unreachable code"
+
+function test() -> i64 {
+    let x = 2
+
+    loop {
+        if x == 2 {
+            // Always transfer control (can't break)
+            continue
+        } else {
+            // Partially always return (can't break)
+            if x == 3 {
+                return 1
+            }
+        }
+    }
+
+    // This should not be reachable
+    println("NOT PASSED")
+    return 1
+}
+
+function main() {
+    test()
+}

--- a/tests/typechecker/control_flow_18.jakt
+++ b/tests/typechecker/control_flow_18.jakt
@@ -1,0 +1,26 @@
+/// Expect:
+/// - output: "PASS\n"
+
+function test() -> i64 {
+    let x = 2
+
+    loop {
+        if x == 2 {
+            // Always transfer control (can break)
+            break
+        } else {
+            // Partially transfer control (can't break)
+            if x == 3 {
+                continue
+            }
+        }
+    }
+
+    // This should be reachable
+    println("PASS")
+    return 1
+}
+
+function main() {
+    test()
+}

--- a/tests/typechecker/control_flow_18_continue_case.jakt
+++ b/tests/typechecker/control_flow_18_continue_case.jakt
@@ -1,0 +1,26 @@
+/// Expect:
+/// - error: "Unreachable code"
+
+function test() -> i64 {
+    let x = 2
+
+    loop {
+        if x == 2 {
+            // Always transfer control (can't break)
+            continue
+        } else {
+            // Partially transfer control (can't break)
+            if x == 3 {
+                continue
+            }
+        }
+    }
+
+    // This should not be reachable
+    println("NOT PASSED")
+    return 1
+}
+
+function main() {
+    test()
+}

--- a/tests/typechecker/control_flow_2.jakt
+++ b/tests/typechecker/control_flow_2.jakt
@@ -1,0 +1,24 @@
+/// Expect:
+/// - output: "PASS\n"
+
+function test() -> i64 {
+    let x = 2
+
+    if x == 2 {
+        // Partially never return
+        if x == 3 {
+            abort()
+        }
+    } else {
+        // Never return
+        abort()
+    }
+
+    // This should be reachable
+    println("PASS")
+    return 1
+}
+
+function main() {
+    test()
+}

--- a/tests/typechecker/control_flow_3.jakt
+++ b/tests/typechecker/control_flow_3.jakt
@@ -1,0 +1,27 @@
+/// Expect:
+/// - output: "PASS\n"
+
+function test() -> i64 {
+    let x = 4
+
+    loop {
+        if x == 2 {
+            // Partially never return
+            if x == 3 {
+                abort()
+            }
+        } else {
+            break
+        }
+
+        // This should be reachable
+        break
+    }
+
+    println("PASS")
+    return 1
+}
+
+function main() {
+    test()
+}

--- a/tests/typechecker/control_flow_4.jakt
+++ b/tests/typechecker/control_flow_4.jakt
@@ -1,0 +1,24 @@
+/// Expect:
+/// - output: "PASS\n"
+
+function test() -> i64 {
+    let x = 2
+
+    if x == 2 {
+        // Partially always return
+        if x == 3 {
+            return 1
+        }
+    } else {
+        // Always return
+        return 1
+    }
+
+    // This should be reachable
+    println("PASS")
+    return 1
+}
+
+function main() {
+    test()
+}

--- a/tests/typechecker/control_flow_5.jakt
+++ b/tests/typechecker/control_flow_5.jakt
@@ -1,0 +1,24 @@
+/// Expect:
+/// - output: "PASS\n"
+
+function test() -> i64 {
+    let x = 2
+
+    if x == 2 {
+        // Partially always return
+        if x == 3 {
+            return 1
+        }
+    } else {
+        // Never return
+        abort()
+    }
+
+    // This should be reachable
+    println("PASS")
+    return 1
+}
+
+function main() {
+    test()
+}

--- a/tests/typechecker/control_flow_6.jakt
+++ b/tests/typechecker/control_flow_6.jakt
@@ -1,0 +1,27 @@
+/// Expect:
+/// - output: "PASS\n"
+
+function test() -> i64 {
+    let x = 4
+
+    loop {
+        if x == 2 {
+            // Partially always return
+            if x == 3 {
+                return 1
+            }
+        } else {
+            break
+        }
+
+        // This should be reachable
+        break
+    }
+
+    println("PASS")
+    return 1
+}
+
+function main() {
+    test()
+}

--- a/tests/typechecker/control_flow_7.jakt
+++ b/tests/typechecker/control_flow_7.jakt
@@ -1,0 +1,33 @@
+/// Expect:
+/// - output: "PASS\n"
+
+function test() -> i64 {
+    let x = 2
+
+    loop {
+        if x == 2 {
+
+            // Partially always transfer control
+            if x == 2 {
+
+                // Partially transfer control (can break)
+                if x == 2 {
+                    break
+                }
+
+                continue
+            }
+        } else {
+            // Always return
+            return 1
+        }
+    }
+
+    // This should be reachable
+    println("PASS")
+    return 1
+}
+
+function main() {
+    test()
+}

--- a/tests/typechecker/control_flow_7_continue_case.jakt
+++ b/tests/typechecker/control_flow_7_continue_case.jakt
@@ -1,0 +1,33 @@
+/// Expect:
+/// - error: "Unreachable code"
+
+function test() -> i64 {
+    let x = 2
+
+    loop {
+        if x == 2 {
+
+            // Partially always transfer control
+            if x == 2 {
+
+                // Partially transfer control (can't break)
+                if x == 2 {
+                    continue
+                }
+
+                continue
+            }
+        } else {
+            // Always return
+            return 1
+        }
+    }
+
+    // This should not be reachable
+    println("NOT PASSED")
+    return 1
+}
+
+function main() {
+    test()
+}

--- a/tests/typechecker/control_flow_8.jakt
+++ b/tests/typechecker/control_flow_8.jakt
@@ -1,0 +1,33 @@
+/// Expect:
+/// - output: "PASS\n"
+
+function test() -> i64 {
+    let x = 2
+
+    loop {
+        if x == 2 {
+
+            // Partially always transfer control
+            if x == 2 {
+
+                // Partially transfer control (can break)
+                if x == 2 {
+                    break
+                }
+
+                continue
+            }
+        } else {
+            // Never return
+            abort()
+        }
+    }
+
+    // This should be reachable
+    println("PASS")
+    return 1
+}
+
+function main() {
+    test()
+}

--- a/tests/typechecker/control_flow_8_continue_case.jakt
+++ b/tests/typechecker/control_flow_8_continue_case.jakt
@@ -1,0 +1,33 @@
+/// Expect:
+/// - error: "Unreachable code"
+
+function test() -> i64 {
+    let x = 2
+
+    loop {
+        if x == 2 {
+
+            // Partially always transfer control
+            if x == 2 {
+
+                // Partially transfer control (can't break)
+                if x == 2 {
+                    continue
+                }
+
+                continue
+            }
+        } else {
+            // Never return
+            abort()
+        }
+    }
+
+    // This should not be reachable
+    println("NOT PASSED")
+    return 1
+}
+
+function main() {
+    test()
+}

--- a/tests/typechecker/control_flow_9.jakt
+++ b/tests/typechecker/control_flow_9.jakt
@@ -1,0 +1,26 @@
+/// Expect:
+/// - output: "PASS\n"
+
+function test() -> i64 {
+    let x = 2
+
+    loop {
+        if x == 2 {
+            // Partially transfer control (can break)
+            if x == 2 {
+                break
+            }
+        } else {
+            // Always transfer control (can't break)
+            continue
+        }
+    }
+
+    // This should be reachable
+    println("PASS")
+    return 1
+}
+
+function main() {
+    test()
+}

--- a/tests/typechecker/control_flow_9_continue_case.jakt
+++ b/tests/typechecker/control_flow_9_continue_case.jakt
@@ -1,0 +1,26 @@
+/// Expect:
+/// - error: "Unreachable code"
+
+function test() -> i64 {
+    let x = 2
+
+    loop {
+        if x == 2 {
+            // Partially transfer control (can't break)
+            if x == 2 {
+                continue
+            }
+        } else {
+            // Always transfer control (can't break)
+            continue
+        }
+    }
+
+    // This should not be reachable
+    println("NOT PASSED")
+    return 1
+}
+
+function main() {
+    test()
+}


### PR DESCRIPTION
Previously, when control flow of an `if` block was determined to be one of:
`PartiallyNeverReturns`, `PartialAlwaysReturns`, `PartialAlwaysTransfersControl`, `AlwaysTransfersControl`,
and an `else` block was present, we were basically completely ignoring the control flow of an `if` block and going with what the `else` block control flow was telling us.

Every test with the name which doesn't contain "continue_case" was not working before this PR. "continue_case" tests were working, but I still added them so they won't break in the future.
There is a test added for every case added to the match in typechecker, other than when `if` block has control_flow of either `PartialAlwaysReturns` or `PartialNeverReturns`, and the `else` block has any of the `Partial...` control_flows. I couldn't really find tests for these cases, because when there is a `break` or `continue` inside of them, `unity_with()` will promote them to `PartialAlwaysTransfersControl`. And if there is no `break` or `continue` inside of them, then they don't really matter all that much (if the `else` block also is one of the Partials) as far as I'm aware 🤷.

Fixes #1152. Not sure if a specific test with a `guard` is needed, since `guard`s are expanded to `if`s anyway.

Plan for the future:
- Move the whole `if... else` control flow resolving to its own function in the `types.jakt` and potentially use it for the `match` (the control flow for `match`es is currently also not properly tracked)