### PR TITLE
typechecker: Make `while` block control flow resolving less definitive + use more info

### DIFF
--- a/selfhost/typechecker.jakt
+++ b/selfhost/typechecker.jakt
@@ -3666,12 +3666,10 @@ struct Typechecker {
         }
         Block(block) => block.control_flow
         // FIXME: While could use more information here.
-        While(block) => match block.control_flow {
-            AlwaysTransfersControl => BlockControlFlow::MayReturn
-            NeverReturns => BlockControlFlow::NeverReturns
-            AlwaysReturns => BlockControlFlow::AlwaysReturns
-            else => BlockControlFlow::MayReturn
-        }
+        // Note that 'while' blocks, similarly to 'if's with a missing 'else' branch, produce a partial result.
+        // But also: every 'break' and 'continue' inside of it, does not apply to the outer blocks,
+        // and without a need for that info, Partials can just get degraded to the MayReturn.
+        While(block) => BlockControlFlow::MayReturn
         Loop(block) => match block.control_flow {
             AlwaysTransfersControl(might_break) => match might_break {
                 false => BlockControlFlow::AlwaysTransfersControl(might_break)

--- a/selfhost/typechecker.jakt
+++ b/selfhost/typechecker.jakt
@@ -3665,11 +3665,21 @@ struct Typechecker {
             }
         }
         Block(block) => block.control_flow
-        // FIXME: While could use more information here.
-        // Note that 'while' blocks, similarly to 'if's with a missing 'else' branch, produce a partial result.
+        // Note that 'while' blocks, which conditions are not always true,
+        // similarly to 'if's with a missing 'else' branch, produce a partial result.
         // But also: every 'break' and 'continue' inside of it, does not apply to the outer blocks,
         // and without a need for that info, Partials can just get degraded to the MayReturn.
-        While(block) => BlockControlFlow::MayReturn
+        While(condition, block) => match condition {
+            Boolean(val) => match val {
+                true => match block.control_flow {
+                    AlwaysReturns => BlockControlFlow::AlwaysReturns
+                    NeverReturns => BlockControlFlow::NeverReturns
+                    else => BlockControlFlow::MayReturn
+                }
+                else => BlockControlFlow::MayReturn
+            }
+            else => BlockControlFlow::MayReturn
+        }
         Loop(block) => match block.control_flow {
             AlwaysTransfersControl(might_break) => match might_break {
                 false => BlockControlFlow::AlwaysTransfersControl(might_break)

--- a/tests/typechecker/control_flow_while_1.jakt
+++ b/tests/typechecker/control_flow_while_1.jakt
@@ -1,0 +1,14 @@
+/// Expect:
+/// - output: "PASS\n"
+
+function test(anon mut argument: i64) -> String {
+    while argument > 0 {
+        return "NOT PASSED" // This should be reachable (in case argument > 0)
+    }
+
+    return "PASS" // This should be reachable as well (in case argument <= 0)
+}
+
+function main() {
+    println("{}", test(-1))
+}

--- a/tests/typechecker/control_flow_while_2.jakt
+++ b/tests/typechecker/control_flow_while_2.jakt
@@ -1,0 +1,14 @@
+/// Expect:
+/// - output: "PASS\n"
+
+function test(anon mut argument: i64) -> String {
+    while argument > 0 {
+        abort() // This should be reachable (in case argument > 0)
+    }
+
+    return "PASS" // This should be reachable as well (in case argument <= 0)
+}
+
+function main() {
+    println("{}", test(-1))
+}

--- a/tests/typechecker/control_flow_while_3.jakt
+++ b/tests/typechecker/control_flow_while_3.jakt
@@ -1,0 +1,20 @@
+/// Expect:
+/// - error: "Unreachable code"
+
+function test(anon mut argument: i64) -> String {
+    loop {
+        while argument > 1 {
+            if (argument == 2) {
+                break // This should be reachable (in case argument == 2)
+            }
+        }
+
+        return "NOT PASSED" // This should be reachable (in case argument == 2 or argument <= 1)
+    }
+
+    return "NOT PASSED" // This should not be reachable
+}
+
+function main() {
+    println("{}", test(-1))
+}

--- a/tests/typechecker/control_flow_while_4.jakt
+++ b/tests/typechecker/control_flow_while_4.jakt
@@ -1,0 +1,14 @@
+/// Expect:
+/// - error: "Unreachable code"
+
+function test(anon mut argument: i64) -> String {
+    while true {
+        return "NOT PASSED"
+    }
+
+    return "NOT PASSED" // This should not be reachable
+}
+
+function main() {
+    println("{}", test(-1))
+}

--- a/tests/typechecker/control_flow_while_5.jakt
+++ b/tests/typechecker/control_flow_while_5.jakt
@@ -1,0 +1,14 @@
+/// Expect:
+/// - error: "Unreachable code"
+
+function test(anon mut argument: i64) -> String {
+    while true {
+        abort()
+    }
+
+    return "NOT PASSED" // This should not be reachable
+}
+
+function main() {
+    println("{}", test(-1))
+}


### PR DESCRIPTION
Previously, control flow of a `while` block was a little bit too definitive. Ex. in:
```cpp
while condition {
    return
}
println("Hello, condition might not be true!")
```
it would be resolved to `AlwaysReturns` and the `println()` would be marked as an "Unreachable code".
But `while` blocks act somewhat similarly to the `if` blocks that have no `else` statement. The **condition** might not be `true` so the result cannot be definitive, only partial.

`While` blocks, however, also consume all the `break`s and `continue`s, and without them, partial results can be downgraded to `MayReturn`s (like we already did before this patch).

This means that if the condition is not known to be always true, no matter what the inner control flow of the `while` block is, we will resolve it to `MayReturn`.

Tests 1 and 2 didn't work before, test 3 worked, but it prevents from leaking the `might_break` value from inner `while` loops to outer loops (which happened to me during some experiments for this PR, and nothing complained). Tests 4 and 5 did work before this PR, but it was only because we were definitive about the control flow result of the `while` blocks, not caring if the condition is always true or not.