### PR TITLE
typechecker: Don't allow using logical Not on non-boolean types

### DIFF
--- a/selfhost/typechecker.jakt
+++ b/selfhost/typechecker.jakt
@@ -4500,7 +4500,18 @@ struct Typechecker {
                     .error("Increment/decrement of non-numeric value", span)
                 }
             }
-            LogicalNot | BitwiseNot => {
+            LogicalNot => {
+                if not .check_types_for_compat(
+                    lhs_type_id: builtin(BuiltinType::Bool)
+                    rhs_type_id: checked_expr.type()
+                    generic_inferences: &mut .generic_inferences
+                    span) {
+                    .error("Cannot use a logical Not on a value of non-boolean type", span)
+                }
+
+                return CheckedExpression::UnaryOp(expr: checked_expr, op: checked_op, span, type_id: expr_type_id)
+            }
+            BitwiseNot => {
                 return CheckedExpression::UnaryOp(expr: checked_expr, op: checked_op, span, type_id: expr_type_id)
             }
             TypeCast(cast) => {

--- a/tests/typechecker/logical_not_cannot_use_on_non_boolean_type.jakt
+++ b/tests/typechecker/logical_not_cannot_use_on_non_boolean_type.jakt
@@ -1,0 +1,21 @@
+/// Expect:
+/// - error: "Cannot use a logical Not on a value of non-boolean type"
+
+class Foo {
+    public my_size: usize
+
+    public function size(this) -> usize {
+        return .my_size
+    }
+}
+
+function main() {
+    let a = Foo(my_size: 2uz)
+    let b = Foo(my_size: 3uz)
+
+    if not a.size() == b.size() {
+        println("NOT PASSED")
+    }
+
+    println("NOT PASSED")
+}


### PR DESCRIPTION
Fixes #1312