### PR TITLE
parser: Fix comparison of match cases to be order independent & also compare case bodies

### DIFF
--- a/selfhost/parser.jakt
+++ b/selfhost/parser.jakt
@@ -875,28 +875,28 @@ enum ParsedMatchPattern {
         return true
     }
 
-    function equals(this, anon rhs_parsed_match_pattern: ParsedMatchPattern) -> bool => .defaults_equal(rhs_parsed_match_pattern.defaults) and match this {
-        EnumVariant(variant_names: lhs_variant_names, variant_arguments: lhs_variant_arguments) => match rhs_parsed_match_pattern {
-            EnumVariant(variant_names: rhs_variant_names, variant_arguments: rhs_variant_arguments) => {
-                guard lhs_variant_names.size() == rhs_variant_names.size() and lhs_variant_arguments.size() == rhs_variant_arguments.size() else {
+    function is_equal_pattern(this, anon rhs_parsed_match_pattern: ParsedMatchPattern) -> bool => match this {
+        EnumVariant(variant_names: lhs_variant_names) => {
+            guard rhs_parsed_match_pattern is EnumVariant(variant_names: rhs_variant_names) else {
+                return false
+            }
+
+            // compare name & namespaces in reverse order
+            // -> when one is a subset of the other they are treated equal
+            mut namespace_count = lhs_variant_names.size();
+            if rhs_variant_names.size() < namespace_count {
+                namespace_count = rhs_variant_names.size()
+            }
+
+            for i in 0..namespace_count {
+                let lhs_name = lhs_variant_names[lhs_variant_names.size() - i - 1].0
+                let rhs_name = rhs_variant_names[rhs_variant_names.size() - i - 1].0
+                guard lhs_name == rhs_name else {
                     return false
                 }
-
-                for i in ..lhs_variant_names.size() {
-                    if lhs_variant_names[i].0 != rhs_variant_names[i].0 {
-                        return false
-                    }
-                }
-
-                for i in ..lhs_variant_arguments.size() {
-                    if not lhs_variant_arguments[i].equals(rhs_variant_arguments[i]) {
-                        return false
-                    }
-                }
-
-                return true
             }
-            else => false
+
+            return true
         }
         Expression(lhs_parsed_expression) => match rhs_parsed_match_pattern {
             Expression(rhs_parsed_expression) => lhs_parsed_expression.equals(rhs_parsed_expression)
@@ -905,12 +905,54 @@ enum ParsedMatchPattern {
         CatchAll => rhs_parsed_match_pattern is CatchAll
         Invalid => rhs_parsed_match_pattern is Invalid
     }
+
+    function equals(this, anon rhs_parsed_match_pattern: ParsedMatchPattern) -> bool {
+        guard .is_equal_pattern(rhs_parsed_match_pattern) else {
+            return false
+        }
+
+        guard .defaults_equal(rhs_parsed_match_pattern.defaults) else {
+            return false
+        }
+
+        if this is EnumVariant(variant_arguments: lhs_variant_arguments) {
+            guard rhs_parsed_match_pattern is EnumVariant(variant_arguments: rhs_variant_arguments) else {
+                return false
+            }
+
+            guard lhs_variant_arguments.size() == rhs_variant_arguments.size() else {
+                return false
+            }
+
+            for i in ..lhs_variant_arguments.size() {
+                if not lhs_variant_arguments[i].equals(rhs_variant_arguments[i]) {
+                    return false
+                }
+            }
+        }
+
+        return true
+    }
 }
 
 struct ParsedMatchCase {
     patterns: [ParsedMatchPattern]
     marker_span: Span
     body: ParsedMatchBody
+
+    function has_equal_pattern(this, anon rhs_match_case: ParsedMatchCase) -> bool {
+        guard .patterns.size() == rhs_match_case.patterns.size() else {
+            return false
+        }
+
+        for i in ..(.patterns.size()) {
+            if not .patterns[i].is_equal_pattern(rhs_match_case.patterns[i]) {
+                return false
+            }
+        }
+
+        return true
+    }
 
     function equals(this, anon rhs_match_case: ParsedMatchCase) -> bool {
         guard .patterns.size() == rhs_match_case.patterns.size() else {

--- a/selfhost/parser.jakt
+++ b/selfhost/parser.jakt
@@ -4980,6 +4980,20 @@ struct Parser {
         let expr = .parse_expression(allow_assignments: false, allow_newlines: true)
         let cases = .parse_match_cases()
 
+
+        if cases.size() > 1 {
+            for i in ..(cases.size() - 1) {
+                for k in (i + 1)..cases.size() {
+                    if cases[i].has_equal_pattern(cases[k]) {
+                        .error_with_hint(
+                            "Duplicated match pattern", cases[k].marker_span,
+                            "Original pattern here", cases[i].marker_span
+                        )
+                    }
+                }
+            }
+        }
+
         return ParsedExpression::Match(
             expr
             cases

--- a/selfhost/parser.jakt
+++ b/selfhost/parser.jakt
@@ -1251,9 +1251,17 @@ boxed enum ParsedExpression {
                     return false
                 }
 
-                // FIXME: cases should probably be sorted before being compared
                 for i in ..lhs_cases.size() {
-                    if not lhs_cases[i].equals(rhs_cases[i]) {
+                    mut current_case_has_match = false
+
+                    for k in ..rhs_cases.size() {
+                        if lhs_cases[i].equals(rhs_cases[k]) {
+                            current_case_has_match = true
+                            break
+                        }
+                    }
+
+                    guard current_case_has_match else {
                         return false
                     }
                 }

--- a/selfhost/parser.jakt
+++ b/selfhost/parser.jakt
@@ -965,13 +965,30 @@ struct ParsedMatchCase {
             }
         }
 
-        return true
+        return .body.equals(rhs_match_case.body)
     }
 }
 
 enum ParsedMatchBody {
     Expression(ParsedExpression)
     Block(ParsedBlock)
+
+    function equals(this, anon rhs_match_body: ParsedMatchBody) -> bool => match this {
+        Expression(lhs_expr) => {
+            guard rhs_match_body is Expression(rhs_expr) else {
+                return false
+            }
+
+            yield lhs_expr.equals(rhs_expr)
+        }
+        Block(lhs_block) => {
+            guard rhs_match_body is Block(rhs_block) else {
+                return false
+            }
+
+            yield lhs_block.equals(rhs_block)
+        }
+    }
 }
 
 enum ParsedCapture {

--- a/tests/parser/match_duplicate_pattern_enum.jakt
+++ b/tests/parser/match_duplicate_pattern_enum.jakt
@@ -1,0 +1,15 @@
+/// Expect:
+/// - error: "Duplicated match pattern\n"
+
+enum Foo {
+    A
+    B
+}
+
+function main() {
+    match Foo::A {
+        A => println("1")
+        A => println("2")
+        else => println("...")
+    }
+}

--- a/tests/parser/match_duplicate_pattern_enum_with_namespaces.jakt
+++ b/tests/parser/match_duplicate_pattern_enum_with_namespaces.jakt
@@ -1,0 +1,15 @@
+/// Expect:
+/// - error: "Duplicated match pattern\n"
+
+enum Foo {
+    A
+    B
+}
+
+function main() {
+    match Foo::A {
+        Foo::A => println("1")
+        A => println("2")
+        else => println("...")
+    }
+}

--- a/tests/parser/match_duplicate_pattern_enum_with_variables.jakt
+++ b/tests/parser/match_duplicate_pattern_enum_with_variables.jakt
@@ -1,0 +1,15 @@
+/// Expect:
+/// - error: "Duplicated match pattern\n"
+
+enum Foo {
+    A(x: i64)
+    B
+}
+
+function main() {
+    match Foo::A(x: 1) {
+        A(x) => println("1")
+        A => println("2")
+        else => println("...")
+    }
+}

--- a/tests/parser/match_duplicate_pattern_int.jakt
+++ b/tests/parser/match_duplicate_pattern_int.jakt
@@ -1,0 +1,10 @@
+/// Expect:
+/// - error: "Duplicated match pattern\n"
+
+function main() {
+    match 1 {
+        1 => println("1")
+        1 => println("2")
+        else => println("...")
+    }
+}

--- a/tests/parser/match_equals_different_case_body.jakt
+++ b/tests/parser/match_equals_different_case_body.jakt
@@ -1,0 +1,14 @@
+/// Expect:
+/// - output: "hello\n"
+
+function main() {
+    if true {
+        match 1 {
+            else => println("hello")
+        }
+    } else {
+        match 1 {
+            else => println("world")
+        }
+    }
+}

--- a/tests/parser/match_equals_same_case_body.jakt
+++ b/tests/parser/match_equals_same_case_body.jakt
@@ -1,0 +1,14 @@
+/// Expect:
+/// - error: "if and else have identical blocks\n"
+
+function main() {
+    if true {
+        match 1 {
+            else => println("hello")
+        }
+    } else {
+        match 1 {
+            else => println("hello")
+        }
+    }
+}

--- a/tests/parser/match_equals_same_compare_unordered.jakt
+++ b/tests/parser/match_equals_same_compare_unordered.jakt
@@ -1,0 +1,18 @@
+/// Expect:
+/// - error: "if and else have identical blocks\n"
+
+function main() {
+    if true {
+        match 1 {
+            1 => println("1")
+            2 | 3 => println("2 or 3")
+            else => println("...")
+        }
+    } else {
+        match 1 {
+            2 | 3 => println("2 or 3")
+            1 => println("1")
+            else => println("...")
+        }
+    }
+}


### PR DESCRIPTION
- patterns, that are enum variants now get treated as equal when one is a subset of the other
  -> `Foo::A` is the same as `A`, but not the same as `Bar::A`
- match cases no longer get detected as equal, when they have different bodies
- match cases now get detected as equal, even when they are in different order
- duplicate patterns in a single match expression are now an error