### PR TITLE
typechecker: Control flow, don't lose information about `break`s

### DIFF
--- a/selfhost/typechecker.jakt
+++ b/selfhost/typechecker.jakt
@@ -3632,7 +3632,7 @@ struct Typechecker {
                 MayReturn => BlockControlFlow::MayReturn
                 PartialNeverReturns(might_break: then_might_break) => match .maybe_statement_control_flow(else_statement, then_block.control_flow) {
                     NeverReturns | AlwaysReturns => BlockControlFlow::PartialNeverReturns(might_break: then_might_break)
-                    MayReturn => BlockControlFlow::MayReturn
+                    MayReturn => BlockControlFlow::PartialNeverReturns(might_break: then_might_break)
                     AlwaysTransfersControl(might_break) => BlockControlFlow::PartialAlwaysTransfersControl(might_break: might_break or then_might_break)
                     PartialNeverReturns(might_break) => BlockControlFlow::PartialNeverReturns(might_break: might_break or then_might_break)
                     PartialAlwaysReturns(might_break) => BlockControlFlow::PartialAlwaysReturns(might_break: might_break or then_might_break)
@@ -3640,7 +3640,7 @@ struct Typechecker {
                 }
                 PartialAlwaysReturns(might_break: then_might_break) => match .maybe_statement_control_flow(else_statement, then_block.control_flow) {
                     NeverReturns | AlwaysReturns => BlockControlFlow::PartialAlwaysReturns(might_break: then_might_break)
-                    MayReturn => BlockControlFlow::MayReturn
+                    MayReturn => BlockControlFlow::PartialAlwaysReturns(might_break: then_might_break)
                     AlwaysTransfersControl(might_break) => BlockControlFlow::PartialAlwaysTransfersControl(might_break: might_break or then_might_break)
                     PartialNeverReturns(might_break) => BlockControlFlow::PartialAlwaysReturns(might_break: might_break or then_might_break)
                     PartialAlwaysReturns(might_break) => BlockControlFlow::PartialAlwaysReturns(might_break: might_break or then_might_break)
@@ -3648,7 +3648,7 @@ struct Typechecker {
                 }
                 PartialAlwaysTransfersControl(might_break: then_might_break) => match .maybe_statement_control_flow(else_statement, then_block.control_flow) {
                     NeverReturns | AlwaysReturns => BlockControlFlow::PartialAlwaysTransfersControl(might_break: then_might_break)
-                    MayReturn => BlockControlFlow::MayReturn
+                    MayReturn => BlockControlFlow::PartialAlwaysTransfersControl(might_break: then_might_break)
                     AlwaysTransfersControl(might_break) => BlockControlFlow::PartialAlwaysTransfersControl(might_break: might_break or then_might_break)
                     PartialNeverReturns(might_break) => BlockControlFlow::PartialAlwaysTransfersControl(might_break: might_break or then_might_break)
                     PartialAlwaysReturns(might_break) => BlockControlFlow::PartialAlwaysTransfersControl(might_break: might_break or then_might_break)
@@ -3656,7 +3656,7 @@ struct Typechecker {
                 }
                 AlwaysTransfersControl(might_break: then_might_break) => match .maybe_statement_control_flow(else_statement, then_block.control_flow) {
                     NeverReturns | AlwaysReturns => BlockControlFlow::AlwaysTransfersControl(might_break: then_might_break)
-                    MayReturn => BlockControlFlow::MayReturn
+                    MayReturn => BlockControlFlow::PartialAlwaysTransfersControl(might_break: then_might_break)
                     AlwaysTransfersControl(might_break) => BlockControlFlow::AlwaysTransfersControl(might_break: might_break or then_might_break)
                     PartialNeverReturns(might_break) => BlockControlFlow::PartialNeverReturns(might_break: might_break or then_might_break)
                     PartialAlwaysReturns(might_break) => BlockControlFlow::PartialAlwaysReturns(might_break: might_break or then_might_break)

--- a/selfhost/typechecker.jakt
+++ b/selfhost/typechecker.jakt
@@ -3629,7 +3629,13 @@ struct Typechecker {
                     PartialAlwaysReturns(might_break) => BlockControlFlow::PartialAlwaysReturns(might_break)
                     PartialAlwaysTransfersControl(might_break) => BlockControlFlow::PartialAlwaysTransfersControl(might_break)
                 }
-                MayReturn => BlockControlFlow::MayReturn
+                MayReturn => match .maybe_statement_control_flow(else_statement, then_block.control_flow) {
+                    MayReturn | NeverReturns | AlwaysReturns => BlockControlFlow::MayReturn
+                    AlwaysTransfersControl(might_break) => BlockControlFlow::PartialAlwaysTransfersControl(might_break)
+                    PartialNeverReturns(might_break) => BlockControlFlow::PartialNeverReturns(might_break)
+                    PartialAlwaysReturns(might_break) => BlockControlFlow::PartialAlwaysReturns(might_break)
+                    PartialAlwaysTransfersControl(might_break) => BlockControlFlow::PartialAlwaysTransfersControl(might_break)
+                }
                 PartialNeverReturns(might_break: then_might_break) => match .maybe_statement_control_flow(else_statement, then_block.control_flow) {
                     NeverReturns | AlwaysReturns => BlockControlFlow::PartialNeverReturns(might_break: then_might_break)
                     MayReturn => BlockControlFlow::PartialNeverReturns(might_break: then_might_break)

--- a/tests/typechecker/control_flow_19.jakt
+++ b/tests/typechecker/control_flow_19.jakt
@@ -1,0 +1,20 @@
+/// Expect:
+/// - output: "PASS\n"
+
+function test(first: i64) -> String {
+    loop {
+        if first == 1 {
+            break // Always transfer control (can break)
+        } else {
+            // Doing other stuff
+        }
+
+        return "NOT PASSED" // This should be reachable (in case first != 1)
+    }
+
+    return "PASS" // This should be reachable (in case first == 1)
+}
+
+function main() {
+    println("{}", test(first: 1))
+}

--- a/tests/typechecker/control_flow_19_continue_case.jakt
+++ b/tests/typechecker/control_flow_19_continue_case.jakt
@@ -1,0 +1,20 @@
+/// Expect:
+/// - error: "Unreachable code"
+
+function test(first: i64) -> String {
+    loop {
+        if first == 1 {
+            continue // Always transfer control (can't break)
+        } else {
+            // Doing other stuff
+        }
+
+        return "NOT PASSED" // This should be reachable (in case first != 1)
+    }
+
+    return "NOT PASSED" // This should not be reachable
+}
+
+function main() {
+    println("{}", test(first: 0))
+}

--- a/tests/typechecker/control_flow_20.jakt
+++ b/tests/typechecker/control_flow_20.jakt
@@ -1,0 +1,25 @@
+/// Expect:
+/// - output: "PASS\n"
+
+function test(first: i64, second: i64) -> String {
+    loop {
+        if first == 1 {
+            // Partial transfer control (can break)
+            if second == 2 {
+                break
+            } else {
+                // Doing other stuff
+            }
+        } else {
+            // Doing other stuff
+        }
+
+        return "NOT PASSED" // This should be reachable (in case first != 1 or (first == 1 and second != 2))
+    }
+
+    return "PASS" // This should be reachable (in case first == 1 and second == 2)
+}
+
+function main() {
+    println("{}", test(first: 1, second: 2))
+}

--- a/tests/typechecker/control_flow_20_continue_case.jakt
+++ b/tests/typechecker/control_flow_20_continue_case.jakt
@@ -1,0 +1,25 @@
+/// Expect:
+/// - error: "Unreachable code"
+
+function test(first: i64, second: i64) -> String {
+    loop {
+        if first == 1 {
+            // Partial transfer control (can't break)
+            if second == 2 {
+                continue
+            } else {
+                // Doing other stuff
+            }
+        } else {
+            // Doing other stuff
+        }
+
+        return "NOT PASSED" // This should be reachable (in case first != 1 or (first == 1 and second != 2))
+    }
+
+    return "NOT PASSED" // This should not be reachable
+}
+
+function main() {
+    println("{}", test(first: 0, second: 0))
+}

--- a/tests/typechecker/control_flow_21.jakt
+++ b/tests/typechecker/control_flow_21.jakt
@@ -1,0 +1,20 @@
+/// Expect:
+/// - output: "PASS\n"
+
+function test(first: i64) -> String {
+    loop {
+        if first == 1 {
+            // Doing other stuff
+        } else {
+            break // Always transfer control (can break)
+        }
+
+        return "NOT PASSED" // This should be reachable (in case first == 1)
+    }
+
+    return "PASS" // This should be reachable (in case first != 1)
+}
+
+function main() {
+    println("{}", test(first: 0))
+}

--- a/tests/typechecker/control_flow_21_continue_case.jakt
+++ b/tests/typechecker/control_flow_21_continue_case.jakt
@@ -1,0 +1,20 @@
+/// Expect:
+/// - error: "Unreachable code"
+
+function test(first: i64) -> String {
+    loop {
+        if first == 1 {
+            // Doing other stuff
+        } else {
+            continue // Always transfer control (can't break)
+        }
+
+        return "NOT PASSED" // This should be reachable (in case first == 1)
+    }
+
+    return "NOT PASSED" // This should not be reachable
+}
+
+function main() {
+    println("{}", test(first: 1))
+}

--- a/tests/typechecker/control_flow_22.jakt
+++ b/tests/typechecker/control_flow_22.jakt
@@ -1,0 +1,25 @@
+/// Expect:
+/// - output: "PASS\n"
+
+function test(first: i64, second: i64) -> String {
+    loop {
+        if first == 1 {
+            // Doing other stuff
+        } else {
+            // Partial transfer control (can break)
+            if second == 2 {
+                break
+            } else {
+                // Doing other stuff
+            }
+        }
+
+        return "NOT PASSED" // This should be reachable (in case first == 1 or (first != 1 and second != 2))
+    }
+
+    return "PASS" // This should be reachable (in case first != 1 and second == 2)
+}
+
+function main() {
+    println("{}", test(first: 0, second: 2))
+}

--- a/tests/typechecker/control_flow_22_continue_case.jakt
+++ b/tests/typechecker/control_flow_22_continue_case.jakt
@@ -1,0 +1,25 @@
+/// Expect:
+/// - error: "Unreachable code"
+
+function test(first: i64, second: i64) -> String {
+    loop {
+        if first == 1 {
+            // Doing other stuff
+        } else {
+            // Partial transfer control (can't break)
+            if second == 2 {
+                continue
+            } else {
+                // Doing other stuff
+            }
+        }
+
+        return "NOT PASSED" // This should be reachable (in case first == 1 or (first != 1 and second != 2))
+    }
+
+    return "NOT PASSED" // This should not be reachable
+}
+
+function main() {
+    println("{}", test(first: 1, second: 0))
+}


### PR DESCRIPTION
Very similar to #1306.

When resolving an `if... else` statement, whenever an `if` block was resolved to `MayReturn` we were losing information about the potential `break`s in the `else` block. And the other way around as well, whenever an `else` block was resolved to `MayReturn`, we were losing information about `break`s in the `if` block.

Tests not added for `PartialAlwaysReturns` and `PartialNeverReturns` because of the same reason as in the mentioned PR. I've still changed the behavior for these to the more correct one, in case `unify_with()` changes its behavior.