### PR TITLE
typechecker: Unwrap type_hints from an Optional in some places

### DIFF
--- a/selfhost/typechecker.jakt
+++ b/selfhost/typechecker.jakt
@@ -6774,10 +6774,9 @@ struct Typechecker {
         mut inferred_type_span: Span? = None
 
         mut inner_hint: TypeId? = None
-        if type_hint.has_value() {
-            if .get_type(type_hint!) is GenericInstance(id, args) and id.equals(array_struct_id) {
-                inner_hint = Some(args[0])
-            }
+        let type_hint_ids: [TypeId]? = .get_type_ids_from_type_hint_if_struct_ids_match(type_hint, expected_struct_id: array_struct_id)
+        if type_hint_ids.has_value() {
+            inner_hint = type_hint_ids![0]
         }
 
         mut vals: [CheckedExpression] = []

--- a/selfhost/typechecker.jakt
+++ b/selfhost/typechecker.jakt
@@ -642,6 +642,18 @@ struct Typechecker {
         return type
     }
 
+    function get_type_ids_from_type_hint_if_struct_ids_match(this, type_hint: TypeId?, expected_struct_id: StructId) throws -> [TypeId]? {
+        if not type_hint.has_value() {
+            return None
+        }
+
+        if .unwrap_type_from_optional_if_needed(type: .get_type(type_hint!)) is GenericInstance(id, args) and id.equals(expected_struct_id) {
+            return args
+        }
+
+        return None
+    }
+
     function typecheck_module(mut this, parsed_namespace: ParsedNamespace, scope_id: ScopeId) throws {
         .typecheck_namespace_imports(parsed_namespace, scope_id)
         .typecheck_namespace_predecl(parsed_namespace, scope_id)

--- a/selfhost/typechecker.jakt
+++ b/selfhost/typechecker.jakt
@@ -6836,8 +6836,11 @@ struct Typechecker {
 
         let set_struct_id = .find_struct_in_prelude("Set")
 
-        // TODO: type hints
         mut inner_hint: TypeId? = None
+        let type_hint_ids: [TypeId]? = .get_type_ids_from_type_hint_if_struct_ids_match(type_hint, expected_struct_id: set_struct_id)
+        if type_hint_ids.has_value() {
+            inner_hint = type_hint_ids![0]
+        }
 
         for value in values {
             let checked_value = .typecheck_expression(expr: value, scope_id, safety_mode, type_hint: inner_hint)
@@ -6868,16 +6871,12 @@ struct Typechecker {
             output.push(checked_value)
         }
 
-        if inner_type_id.equals(unknown_type_id()) and type_hint.has_value() and not type_hint!.equals(unknown_type_id()) {
-            if .get_type(type_hint!) is GenericInstance(id, args) and id.equals(set_struct_id) {
-                inner_type_id = args[0]
-            } else {
-                panic("expected Set struct")
-            }
-        }
-
         if inner_type_id.equals(unknown_type_id()) {
-            .error("Cannot infer generic type for Set<T>", span)
+            if inner_hint.has_value() {
+                inner_type_id = inner_hint!
+            } else {
+                .error("Cannot infer generic type for Set<T>", span)
+            }
         }
 
         let type_id = .find_or_add_type_id(Type::GenericInstance(

--- a/selfhost/typechecker.jakt
+++ b/selfhost/typechecker.jakt
@@ -632,6 +632,16 @@ struct Typechecker {
     function find_struct_in_scope(this, scope_id: ScopeId, name: String) throws -> StructId? =>
         .program.find_struct_in_scope(scope_id, name)
 
+    function unwrap_type_from_optional_if_needed(this, type: Type) throws -> Type {
+        let optional_struct_id = .find_struct_in_prelude("Optional")
+
+        if type is GenericInstance(id, args) and id.equals(optional_struct_id) {
+            return .get_type(args[0])
+        }
+
+        return type
+    }
+
     function typecheck_module(mut this, parsed_namespace: ParsedNamespace, scope_id: ScopeId) throws {
         .typecheck_namespace_imports(parsed_namespace, scope_id)
         .typecheck_namespace_predecl(parsed_namespace, scope_id)

--- a/selfhost/typechecker.jakt
+++ b/selfhost/typechecker.jakt
@@ -7555,11 +7555,10 @@ struct Typechecker {
 
         mut key_hint: TypeId? = None
         mut value_hint: TypeId? = None
-        if type_hint.has_value()
-            and .get_type(type_hint!) is GenericInstance(id, args)
-            and id.equals(dictionary_struct_id) {
-            key_hint = args[0]
-            value_hint = args[1]
+        let type_hint_ids: [TypeId]? = .get_type_ids_from_type_hint_if_struct_ids_match(type_hint, expected_struct_id: dictionary_struct_id)
+        if type_hint_ids.has_value() {
+            key_hint = type_hint_ids![0]
+            value_hint = type_hint_ids![1]
         }
 
         for (key, value) in values {

--- a/tests/typechecker/optional_array_assign_empty.jakt
+++ b/tests/typechecker/optional_array_assign_empty.jakt
@@ -1,0 +1,8 @@
+/// Expect:
+/// - output: "42\n"
+
+function main() {
+    mut arr: [i64]? = []
+    arr!.push(42)
+    println("{}", arr!.first())
+}

--- a/tests/typechecker/optional_dictionary_assign_empty.jakt
+++ b/tests/typechecker/optional_dictionary_assign_empty.jakt
@@ -1,0 +1,8 @@
+/// Expect:
+/// - output: "420\n"
+
+function main() {
+    mut dict: [i64:i64]? = [:]
+    dict!.set(42, 420)
+    println("{}", dict!.get(42))
+}

--- a/tests/typechecker/optional_set_assign_empty.jakt
+++ b/tests/typechecker/optional_set_assign_empty.jakt
@@ -1,0 +1,8 @@
+/// Expect:
+/// - output: "true\n"
+
+function main() {
+    mut set: {i64}? = {}
+    set!.add(42)
+    println("{}", set!.contains(42))
+}


### PR DESCRIPTION
We were not unwrapping type hints from an Optional which caused programs like these:
```cpp
function main() {
    mut arr: [i64]? = []
}
```
to fail (the array that we are assigning is empty and thus, there is nothing from which we can infer the type of the value other than a type hint).

When inferring a type of rhs from a type hint, we first check if struct ids of a type hint and rhs are the same (in this case we are checking if type hint and rhs are both arrays). This would previously fail because type hint is an array wrapped in an Optional, so we end up comparing Optional's struct id with an Array's struct id.