### PR TITLE
typechecker+types: Make `match` control flow resolving (more) correct

### DIFF
--- a/selfhost/typechecker.jakt
+++ b/selfhost/typechecker.jakt
@@ -3619,56 +3619,7 @@ struct Typechecker {
                 }
             }
             // Note that a missing 'else' branch produces a partial result.
-            else => match then_block.control_flow {
-                NeverReturns => .maybe_statement_control_flow(else_statement, then_block.control_flow)
-                AlwaysReturns => match .maybe_statement_control_flow(else_statement, then_block.control_flow) {
-                    NeverReturns | AlwaysReturns => BlockControlFlow::AlwaysReturns
-                    MayReturn => BlockControlFlow::MayReturn
-                    AlwaysTransfersControl(might_break) => BlockControlFlow::AlwaysTransfersControl(might_break)
-                    PartialNeverReturns(might_break) => BlockControlFlow::PartialNeverReturns(might_break)
-                    PartialAlwaysReturns(might_break) => BlockControlFlow::PartialAlwaysReturns(might_break)
-                    PartialAlwaysTransfersControl(might_break) => BlockControlFlow::PartialAlwaysTransfersControl(might_break)
-                }
-                MayReturn => match .maybe_statement_control_flow(else_statement, then_block.control_flow) {
-                    MayReturn | NeverReturns | AlwaysReturns => BlockControlFlow::MayReturn
-                    AlwaysTransfersControl(might_break) => BlockControlFlow::PartialAlwaysTransfersControl(might_break)
-                    PartialNeverReturns(might_break) => BlockControlFlow::PartialNeverReturns(might_break)
-                    PartialAlwaysReturns(might_break) => BlockControlFlow::PartialAlwaysReturns(might_break)
-                    PartialAlwaysTransfersControl(might_break) => BlockControlFlow::PartialAlwaysTransfersControl(might_break)
-                }
-                PartialNeverReturns(might_break: then_might_break) => match .maybe_statement_control_flow(else_statement, then_block.control_flow) {
-                    NeverReturns | AlwaysReturns => BlockControlFlow::PartialNeverReturns(might_break: then_might_break)
-                    MayReturn => BlockControlFlow::PartialNeverReturns(might_break: then_might_break)
-                    AlwaysTransfersControl(might_break) => BlockControlFlow::PartialAlwaysTransfersControl(might_break: might_break or then_might_break)
-                    PartialNeverReturns(might_break) => BlockControlFlow::PartialNeverReturns(might_break: might_break or then_might_break)
-                    PartialAlwaysReturns(might_break) => BlockControlFlow::PartialAlwaysReturns(might_break: might_break or then_might_break)
-                    PartialAlwaysTransfersControl(might_break) => BlockControlFlow::PartialAlwaysTransfersControl(might_break: might_break or then_might_break)
-                }
-                PartialAlwaysReturns(might_break: then_might_break) => match .maybe_statement_control_flow(else_statement, then_block.control_flow) {
-                    NeverReturns | AlwaysReturns => BlockControlFlow::PartialAlwaysReturns(might_break: then_might_break)
-                    MayReturn => BlockControlFlow::PartialAlwaysReturns(might_break: then_might_break)
-                    AlwaysTransfersControl(might_break) => BlockControlFlow::PartialAlwaysTransfersControl(might_break: might_break or then_might_break)
-                    PartialNeverReturns(might_break) => BlockControlFlow::PartialAlwaysReturns(might_break: might_break or then_might_break)
-                    PartialAlwaysReturns(might_break) => BlockControlFlow::PartialAlwaysReturns(might_break: might_break or then_might_break)
-                    PartialAlwaysTransfersControl(might_break) => BlockControlFlow::PartialAlwaysTransfersControl(might_break: might_break or then_might_break)
-                }
-                PartialAlwaysTransfersControl(might_break: then_might_break) => match .maybe_statement_control_flow(else_statement, then_block.control_flow) {
-                    NeverReturns | AlwaysReturns => BlockControlFlow::PartialAlwaysTransfersControl(might_break: then_might_break)
-                    MayReturn => BlockControlFlow::PartialAlwaysTransfersControl(might_break: then_might_break)
-                    AlwaysTransfersControl(might_break) => BlockControlFlow::PartialAlwaysTransfersControl(might_break: might_break or then_might_break)
-                    PartialNeverReturns(might_break) => BlockControlFlow::PartialAlwaysTransfersControl(might_break: might_break or then_might_break)
-                    PartialAlwaysReturns(might_break) => BlockControlFlow::PartialAlwaysTransfersControl(might_break: might_break or then_might_break)
-                    PartialAlwaysTransfersControl(might_break) => BlockControlFlow::PartialAlwaysTransfersControl(might_break: might_break or then_might_break)
-                }
-                AlwaysTransfersControl(might_break: then_might_break) => match .maybe_statement_control_flow(else_statement, then_block.control_flow) {
-                    NeverReturns | AlwaysReturns => BlockControlFlow::AlwaysTransfersControl(might_break: then_might_break)
-                    MayReturn => BlockControlFlow::PartialAlwaysTransfersControl(might_break: then_might_break)
-                    AlwaysTransfersControl(might_break) => BlockControlFlow::AlwaysTransfersControl(might_break: might_break or then_might_break)
-                    PartialNeverReturns(might_break) => BlockControlFlow::PartialNeverReturns(might_break: might_break or then_might_break)
-                    PartialAlwaysReturns(might_break) => BlockControlFlow::PartialAlwaysReturns(might_break: might_break or then_might_break)
-                    PartialAlwaysTransfersControl(might_break) => BlockControlFlow::PartialAlwaysTransfersControl(might_break: might_break or then_might_break)
-                }
-            }
+            else => then_block.control_flow.branch_unify_with(.maybe_statement_control_flow(else_statement, then_block.control_flow))
         }
         Block(block) => block.control_flow
         // Note that 'while' blocks, which conditions are not always true,

--- a/selfhost/types.jakt
+++ b/selfhost/types.jakt
@@ -1466,9 +1466,9 @@ boxed enum CheckedExpression {
                     }
                 }
                 if control_flow.has_value() {
-                    control_flow = control_flow!.unify_with(case_control_flow.definitive())
+                    control_flow = control_flow!.branch_unify_with(case_control_flow)
                 } else {
-                    control_flow = case_control_flow.definitive()
+                    control_flow = case_control_flow
                 }
             }
             yield control_flow ?? BlockControlFlow::MayReturn

--- a/selfhost/types.jakt
+++ b/selfhost/types.jakt
@@ -997,6 +997,58 @@ enum BlockControlFlow {
         }
     }
 
+    public function branch_unify_with(this, anon second: BlockControlFlow) => match this {
+        NeverReturns => second
+        AlwaysReturns => match second {
+            NeverReturns | AlwaysReturns => BlockControlFlow::AlwaysReturns
+            MayReturn => BlockControlFlow::MayReturn
+            AlwaysTransfersControl(might_break) => BlockControlFlow::AlwaysTransfersControl(might_break)
+            PartialNeverReturns(might_break) => BlockControlFlow::PartialNeverReturns(might_break)
+            PartialAlwaysReturns(might_break) => BlockControlFlow::PartialAlwaysReturns(might_break)
+            PartialAlwaysTransfersControl(might_break) => BlockControlFlow::PartialAlwaysTransfersControl(might_break)
+        }
+        MayReturn => match second {
+            NeverReturns | AlwaysReturns => BlockControlFlow::MayReturn
+            MayReturn => BlockControlFlow::MayReturn
+            AlwaysTransfersControl(might_break) => BlockControlFlow::PartialAlwaysTransfersControl(might_break)
+            PartialNeverReturns(might_break) => BlockControlFlow::PartialNeverReturns(might_break)
+            PartialAlwaysReturns(might_break) => BlockControlFlow::PartialAlwaysReturns(might_break)
+            PartialAlwaysTransfersControl(might_break) => BlockControlFlow::PartialAlwaysTransfersControl(might_break)
+        }
+        PartialNeverReturns(might_break: this_might_break) => match second {
+            NeverReturns | AlwaysReturns => BlockControlFlow::PartialNeverReturns(might_break: this_might_break)
+            MayReturn => BlockControlFlow::PartialNeverReturns(might_break: this_might_break)
+            AlwaysTransfersControl(might_break) => BlockControlFlow::PartialAlwaysTransfersControl(might_break: might_break or this_might_break)
+            PartialNeverReturns(might_break) => BlockControlFlow::PartialNeverReturns(might_break: might_break or this_might_break)
+            PartialAlwaysReturns(might_break) => BlockControlFlow::PartialAlwaysReturns(might_break: might_break or this_might_break)
+            PartialAlwaysTransfersControl(might_break) => BlockControlFlow::PartialAlwaysTransfersControl(might_break: might_break or this_might_break)
+        }
+        PartialAlwaysReturns(might_break: this_might_break) => match second {
+            NeverReturns | AlwaysReturns => BlockControlFlow::PartialAlwaysReturns(might_break: this_might_break)
+            MayReturn => BlockControlFlow::PartialAlwaysReturns(might_break: this_might_break)
+            AlwaysTransfersControl(might_break) => BlockControlFlow::PartialAlwaysTransfersControl(might_break: might_break or this_might_break)
+            PartialNeverReturns(might_break) => BlockControlFlow::PartialAlwaysReturns(might_break: might_break or this_might_break)
+            PartialAlwaysReturns(might_break) => BlockControlFlow::PartialAlwaysReturns(might_break: might_break or this_might_break)
+            PartialAlwaysTransfersControl(might_break) => BlockControlFlow::PartialAlwaysTransfersControl(might_break: might_break or this_might_break)
+        }
+        PartialAlwaysTransfersControl(might_break: this_might_break) => match second {
+            NeverReturns | AlwaysReturns => BlockControlFlow::PartialAlwaysTransfersControl(might_break: this_might_break)
+            MayReturn => BlockControlFlow::PartialAlwaysTransfersControl(might_break: this_might_break)
+            AlwaysTransfersControl(might_break) => BlockControlFlow::PartialAlwaysTransfersControl(might_break: might_break or this_might_break)
+            PartialNeverReturns(might_break) => BlockControlFlow::PartialAlwaysTransfersControl(might_break: might_break or this_might_break)
+            PartialAlwaysReturns(might_break) => BlockControlFlow::PartialAlwaysTransfersControl(might_break: might_break or this_might_break)
+            PartialAlwaysTransfersControl(might_break) => BlockControlFlow::PartialAlwaysTransfersControl(might_break: might_break or this_might_break)
+        }
+        AlwaysTransfersControl(might_break: this_might_break) => match second {
+            NeverReturns | AlwaysReturns => BlockControlFlow::AlwaysTransfersControl(might_break: this_might_break)
+            MayReturn => BlockControlFlow::PartialAlwaysTransfersControl(might_break: this_might_break)
+            AlwaysTransfersControl(might_break) => BlockControlFlow::AlwaysTransfersControl(might_break: might_break or this_might_break)
+            PartialNeverReturns(might_break) => BlockControlFlow::PartialNeverReturns(might_break: might_break or this_might_break)
+            PartialAlwaysReturns(might_break) => BlockControlFlow::PartialAlwaysReturns(might_break: might_break or this_might_break)
+            PartialAlwaysTransfersControl(might_break) => BlockControlFlow::PartialAlwaysTransfersControl(might_break: might_break or this_might_break)
+        }
+    }
+
     function updated(this, anon second: BlockControlFlow) => match this {
         NeverReturns => BlockControlFlow::NeverReturns
         AlwaysReturns => BlockControlFlow::AlwaysReturns

--- a/tests/typechecker/control_flow_match_1.jakt
+++ b/tests/typechecker/control_flow_match_1.jakt
@@ -1,0 +1,23 @@
+/// Expect:
+/// - output: "PASS\n"
+
+function test(first: i64, second: i64) -> String {
+    match first {
+        1 => {
+            // Partially never return
+            if second == 2 {
+                abort()
+            }
+        }
+        else => {
+            // Always return
+            return "NOT PASSED"
+        }
+    }
+
+    return "PASS" // This should be reachable (in case first == 1 and second != 2)
+}
+
+function main() {
+    println("{}", test(first: 1, second: 0))
+}

--- a/tests/typechecker/control_flow_match_10.jakt
+++ b/tests/typechecker/control_flow_match_10.jakt
@@ -1,0 +1,27 @@
+/// Expect:
+/// - output: "PASS\n"
+
+function test(first: i64, second: i64, third: i64) -> String {
+    loop {
+        match first {
+            1 => {
+                // Partially transfer control (can break)
+                if second == 2 {
+                    break
+                }
+            }
+            else => {
+                // Partially never return (can't break)
+                if third == 3 {
+                    abort()
+                }
+            }
+        }
+    }
+
+    return "PASS" // This should be reachable (in case first == 1 and second == 2)
+}
+
+function main() {
+    println("{}", test(first: 1, second: 2, third: 0))
+}

--- a/tests/typechecker/control_flow_match_10_continue_case.jakt
+++ b/tests/typechecker/control_flow_match_10_continue_case.jakt
@@ -1,0 +1,27 @@
+/// Expect:
+/// - error: "Unreachable code"
+
+function test(first: i64, second: i64, third: i64) -> String {
+    loop {
+        match first {
+            1 => {
+                // Partially transfer control (can't break)
+                if second == 2 {
+                    continue
+                }
+            }
+            else => {
+                // Partially never return (can't break)
+                if third == 3 {
+                    abort()
+                }
+            }
+        }
+    }
+
+    return "NOT PASSED" // This should not be reachable
+}
+
+function main() {
+    println("{}", test(first: 0, second: 0, third: 3)) // This test should error, so let's pass values that won't make the loop spin indefinitely
+}

--- a/tests/typechecker/control_flow_match_11.jakt
+++ b/tests/typechecker/control_flow_match_11.jakt
@@ -1,0 +1,27 @@
+/// Expect:
+/// - output: "PASS\n"
+
+function test(first: i64, second: i64, third: i64) -> String {
+    loop {
+        match first {
+            1 => {
+                // Partially transfer control (can break)
+                if second == 2 {
+                    break
+                }
+            }
+            else => {
+                // Partially always return (can't break)
+                if third == 3 {
+                    return "NOT PASSED"
+                }
+            }
+        }
+    }
+
+    return "PASS" // This should be reachable (in case first == 1 and second == 2)
+}
+
+function main() {
+    println("{}", test(first: 1, second: 2, third: 0))
+}

--- a/tests/typechecker/control_flow_match_11_continue_case.jakt
+++ b/tests/typechecker/control_flow_match_11_continue_case.jakt
@@ -1,0 +1,27 @@
+/// Expect:
+/// - error: "Unreachable code"
+
+function test(first: i64, second: i64, third: i64) -> String {
+    loop {
+        match first {
+            1 => {
+                // Partially transfer control (can't break)
+                if second == 2 {
+                    continue
+                }
+            }
+            else => {
+                // Partially always return (can't break)
+                if third == 3 {
+                    return "NOT PASSED"
+                }
+            }
+        }
+    }
+
+    return "NOT PASSED" // This should not be reachable
+}
+
+function main() {
+    println("{}", test(first: 0, second: 0, third: 3)) // This test should error, so let's pass values that won't make the loop spin indefinitely
+}

--- a/tests/typechecker/control_flow_match_12.jakt
+++ b/tests/typechecker/control_flow_match_12.jakt
@@ -1,0 +1,27 @@
+/// Expect:
+/// - output: "PASS\n"
+
+function test(first: i64, second: i64, third: i64) -> String {
+    loop {
+        match first {
+            1 => {
+                // Partially transfer control (can break)
+                if second == 2 {
+                    break
+                }
+            }
+            else => {
+                // Partially transfer control (can't break)
+                if third == 3 {
+                    continue
+                }
+            }
+        }
+    }
+
+    return "PASS" // This should be reachable (in case first == 1 and second == 2)
+}
+
+function main() {
+    println("{}", test(first: 1, second: 2, third: 0))
+}

--- a/tests/typechecker/control_flow_match_12_continue_case.jakt
+++ b/tests/typechecker/control_flow_match_12_continue_case.jakt
@@ -1,0 +1,27 @@
+/// Expect:
+/// - error: "Unreachable code"
+
+function test(first: i64, second: i64, third: i64) -> String {
+    loop {
+        match first {
+            1 => {
+                // Partially transfer control (can't break)
+                if second == 2 {
+                    continue
+                }
+            }
+            else => {
+                // Partially transfer control (can't break)
+                if third == 3 {
+                    continue
+                }
+            }
+        }
+    }
+
+    return "NOT PASSED" // This should not be reachable
+}
+
+function main() {
+    println("{}", test(first: 0, second: 0, third: 0))
+}

--- a/tests/typechecker/control_flow_match_13.jakt
+++ b/tests/typechecker/control_flow_match_13.jakt
@@ -1,0 +1,23 @@
+/// Expect:
+/// - output: "PASS\n"
+
+function test(first: i64) -> String {
+    loop {
+        match first {
+            1 => {
+                // Always transfer control (can break)
+                break
+            }
+            else => {
+                // Always return
+                return "NOT PASSED"
+            }
+        }
+    }
+
+    return "PASS" // This should be reachable (in case first == 1)
+}
+
+function main() {
+    println("{}", test(first: 1))
+}

--- a/tests/typechecker/control_flow_match_13_continue_case.jakt
+++ b/tests/typechecker/control_flow_match_13_continue_case.jakt
@@ -1,0 +1,23 @@
+/// Expect:
+/// - error: "Unreachable code"
+
+function test(first: i64) -> String {
+    loop {
+        match first {
+            1 => {
+                // Always transfer control (can't break)
+                continue
+            }
+            else => {
+                // Always return
+                return "NOT PASSED"
+            }
+        }
+    }
+
+    return "NOT PASSED" // This should not be reachable
+}
+
+function main() {
+    println("{}", test(first: 0)) // This test should error, so let's pass values that won't make the loop spin indefinitely
+}

--- a/tests/typechecker/control_flow_match_14.jakt
+++ b/tests/typechecker/control_flow_match_14.jakt
@@ -1,0 +1,23 @@
+/// Expect:
+/// - output: "PASS\n"
+
+function test(first: i64) -> String {
+    loop {
+        match first {
+            1 => {
+                // Always transfer control (can break)
+                break
+            }
+            else => {
+                // Never return
+                abort()
+            }
+        }
+    }
+
+    return "PASS" // This should be reachable (in case first == 1)
+}
+
+function main() {
+    println("{}", test(first: 1))
+}

--- a/tests/typechecker/control_flow_match_14_continue_case.jakt
+++ b/tests/typechecker/control_flow_match_14_continue_case.jakt
@@ -1,0 +1,23 @@
+/// Expect:
+/// - error: "Unreachable code"
+
+function test(first: i64) -> String {
+    loop {
+        match first {
+            1 => {
+                // Always transfer control (can't break)
+                continue
+            }
+            else => {
+                // Never return
+                abort()
+            }
+        }
+    }
+
+    return "NOT PASSED" // This should not be reachable
+}
+
+function main() {
+    println("{}", test(first: 0)) // This test should error, so let's pass values that won't make the loop spin indefinitely
+}

--- a/tests/typechecker/control_flow_match_15.jakt
+++ b/tests/typechecker/control_flow_match_15.jakt
@@ -1,0 +1,23 @@
+/// Expect:
+/// - output: "PASS\n"
+
+function test(first: i64) -> String {
+    loop {
+        match first {
+            1 => {
+                // Always transfer control (can break)
+                break
+            }
+            else => {
+                // Always transfer control (can't break)
+                continue
+            }
+        }
+    }
+
+    return "PASS" // This should be reachable (in case first == 1)
+}
+
+function main() {
+    println("{}", test(first: 1))
+}

--- a/tests/typechecker/control_flow_match_15_continue_case.jakt
+++ b/tests/typechecker/control_flow_match_15_continue_case.jakt
@@ -1,0 +1,23 @@
+/// Expect:
+/// - error: "Unreachable code"
+
+function test(first: i64) -> String {
+    loop {
+        match first {
+            1 => {
+                // Always transfer control (can't break)
+                continue
+            }
+            else => {
+                // Always transfer control (can't break)
+                continue
+            }
+        }
+    }
+
+    return "NOT PASSED" // This should not be reachable
+}
+
+function main() {
+    println("{}", test(first: 1))
+}

--- a/tests/typechecker/control_flow_match_16.jakt
+++ b/tests/typechecker/control_flow_match_16.jakt
@@ -1,0 +1,25 @@
+/// Expect:
+/// - output: "PASS\n"
+
+function test(first: i64, second: i64) -> String {
+    loop {
+        match first {
+            1 => {
+                // Always transfer control (can break)
+                break
+            }
+            else => {
+                // Partially never return (can't break)
+                if second == 2 {
+                    abort()
+                }
+            }
+        }
+    }
+
+    return "PASS" // This should be reachable (in case first == 1)
+}
+
+function main() {
+    println("{}", test(first: 1, second: 0))
+}

--- a/tests/typechecker/control_flow_match_16_continue_case.jakt
+++ b/tests/typechecker/control_flow_match_16_continue_case.jakt
@@ -1,0 +1,25 @@
+/// Expect:
+/// - error: "Unreachable code"
+
+function test(first: i64, second: i64) -> String {
+    loop {
+        match first {
+            1 => {
+                // Always transfer control (can't break)
+                continue
+            }
+            else => {
+                // Partially never return (can't break)
+                if second == 2 {
+                    abort()
+                }
+            }
+        }
+    }
+
+    return "NOT PASSED" // This should not be reachable
+}
+
+function main() {
+    println("{}", test(first: 0, second: 2)) // This test should error, so let's pass values that won't make the loop spin indefinitely
+}

--- a/tests/typechecker/control_flow_match_17.jakt
+++ b/tests/typechecker/control_flow_match_17.jakt
@@ -1,0 +1,25 @@
+/// Expect:
+/// - output: "PASS\n"
+
+function test(first: i64, second: i64) -> String {
+    loop {
+        match first {
+            1 => {
+                // Always transfer control (can break)
+                break
+            }
+            else => {
+                // Partially always return (can't break)
+                if second == 2 {
+                    return "NOT PASSED"
+                }
+            }
+        }
+    }
+
+    return "PASS" // This should be reachable (in case first == 1)
+}
+
+function main() {
+    println("{}", test(first: 1, second: 0))
+}

--- a/tests/typechecker/control_flow_match_17_continue_case.jakt
+++ b/tests/typechecker/control_flow_match_17_continue_case.jakt
@@ -1,0 +1,25 @@
+/// Expect:
+/// - error: "Unreachable code"
+
+function test(first: i64, second: i64) -> String {
+    loop {
+        match first {
+            1 => {
+                // Always transfer control (can't break)
+                continue
+            }
+            else => {
+                // Partially always return (can't break)
+                if second == 2 {
+                    return "NOT PASSED"
+                }
+            }
+        }
+    }
+
+    return "NOT PASSED" // This should not be reachable
+}
+
+function main() {
+    println("{}", test(first: 0, second: 2)) // This test should error, so let's pass values that won't make the loop spin indefinitely
+}

--- a/tests/typechecker/control_flow_match_18.jakt
+++ b/tests/typechecker/control_flow_match_18.jakt
@@ -1,0 +1,25 @@
+/// Expect:
+/// - output: "PASS\n"
+
+function test(first: i64, second: i64) -> String {
+    loop {
+        match first {
+            1 => {
+                // Always transfer control (can break)
+                break
+            }
+            else => {
+                // Partially transfer control (can't break)
+                if second == 2 {
+                    continue
+                }
+            }
+        }
+    }
+
+    return "PASS" // This should be reachable (in case first == 1)
+}
+
+function main() {
+    println("{}", test(first: 1, second: 0))
+}

--- a/tests/typechecker/control_flow_match_18_continue_case.jakt
+++ b/tests/typechecker/control_flow_match_18_continue_case.jakt
@@ -1,0 +1,25 @@
+/// Expect:
+/// - error: "Unreachable code"
+
+function test(first: i64, second: i64) -> String {
+    loop {
+        match first {
+            1 => {
+                // Always transfer control (can't break)
+                continue
+            }
+            else => {
+                // Partially transfer control (can't break)
+                if second == 2 {
+                    continue
+                }
+            }
+        }
+    }
+
+    return "NOT PASSED" // This should not be reachable
+}
+
+function main() {
+    println("{}", test(first: 0, second: 0))
+}

--- a/tests/typechecker/control_flow_match_19.jakt
+++ b/tests/typechecker/control_flow_match_19.jakt
@@ -1,0 +1,23 @@
+/// Expect:
+/// - output: "PASS\n"
+
+function test(first: i64) -> String {
+    loop {
+        match first {
+            1 => {
+                break // Always transfer control (can break)
+            }
+            else => {
+                // Doing other stuff
+            }
+        }
+
+        return "NOT PASSED" // This should be reachable (in case first != 1)
+    }
+
+    return "PASS" // This should be reachable (in case first == 1)
+}
+
+function main() {
+    println("{}", test(first: 1))
+}

--- a/tests/typechecker/control_flow_match_19_continue_case.jakt
+++ b/tests/typechecker/control_flow_match_19_continue_case.jakt
@@ -1,0 +1,23 @@
+/// Expect:
+/// - error: "Unreachable code"
+
+function test(first: i64) -> String {
+    loop {
+        match first {
+            1 => {
+                continue // Always transfer control (can't break)
+            }
+            else => {
+                // Doing other stuff
+            }
+        }
+
+        return "NOT PASSED" // This should be reachable (in case first != 1)
+    }
+
+    return "NOT PASSED" // This should not be reachable
+}
+
+function main() {
+    println("{}", test(first: 0)) // This test should error, so let's pass values that won't make the loop spin indefinitely
+}

--- a/tests/typechecker/control_flow_match_2.jakt
+++ b/tests/typechecker/control_flow_match_2.jakt
@@ -1,0 +1,23 @@
+/// Expect:
+/// - output: "PASS\n"
+
+function test(first: i64, second: i64) -> String {
+    match first {
+        1 => {
+            // Partially never return
+            if second == 2 {
+                abort()
+            }
+        }
+        else => {
+            // Never return
+            abort()
+        }
+    }
+
+    return "PASS" // This should be reachable (in case first == 1 and second != 2)
+}
+
+function main() {
+    println("{}", test(first: 1, second: 0))
+}

--- a/tests/typechecker/control_flow_match_20.jakt
+++ b/tests/typechecker/control_flow_match_20.jakt
@@ -1,0 +1,28 @@
+/// Expect:
+/// - output: "PASS\n"
+
+function test(first: i64, second: i64) -> String {
+    loop {
+        match first {
+            1 => {
+                // Partial transfer control (can break)
+                if second == 2 {
+                    break
+                } else {
+                    // Doing other stuff
+                }
+            }
+            else => {
+                // Doing other stuff
+            }
+        }
+
+        return "NOT PASSED" // This should be reachable (in case first != 1 or (first == 1 and second != 2))
+    }
+
+    return "PASS" // This should be reachable (in case first == 1 and second == 2)
+}
+
+function main() {
+    println("{}", test(first: 1, second: 2))
+}

--- a/tests/typechecker/control_flow_match_20_continue_case.jakt
+++ b/tests/typechecker/control_flow_match_20_continue_case.jakt
@@ -1,0 +1,28 @@
+/// Expect:
+/// - error: "Unreachable code"
+
+function test(first: i64, second: i64) -> String {
+    loop {
+        match first {
+            1 => {
+                // Partial transfer control (can't break)
+                if second == 2 {
+                    continue
+                } else {
+                    // Doing other stuff
+                }
+            }
+            else => {
+                // Doing other stuff
+            }
+        }
+
+        return "NOT PASSED" // This should be reachable (in case first != 1 or (first == 1 and second != 2))
+    }
+
+    return "NOT PASSED" // This should not be reachable
+}
+
+function main() {
+    println("{}", test(first: 0, second: 0)) // This test should error, so let's pass values that won't make the loop spin indefinitely
+}

--- a/tests/typechecker/control_flow_match_21.jakt
+++ b/tests/typechecker/control_flow_match_21.jakt
@@ -1,0 +1,23 @@
+/// Expect:
+/// - output: "PASS\n"
+
+function test(first: i64) -> String {
+    loop {
+        match first {
+            1 => {
+                // Doing other stuff
+            }
+            else => {
+                break // Always transfer control (can break)
+            }
+        }
+
+        return "NOT PASSED" // This should be reachable (in case first == 1)
+    }
+
+    return "PASS" // This should be reachable (in case first != 1)
+}
+
+function main() {
+    println("{}", test(first: 0))
+}

--- a/tests/typechecker/control_flow_match_21_continue_case.jakt
+++ b/tests/typechecker/control_flow_match_21_continue_case.jakt
@@ -1,0 +1,23 @@
+/// Expect:
+/// - error: "Unreachable code"
+
+function test(first: i64) -> String {
+    loop {
+        match first {
+            1 => {
+                // Doing other stuff
+            }
+            else => {
+                continue // Always transfer control (can't break)
+            }
+        }
+
+        return "NOT PASSED" // This should be reachable (in case first == 1)
+    }
+
+    return "NOT PASSED" // This should not be reachable
+}
+
+function main() {
+    println("{}", test(first: 1)) // This test should error, so let's pass values that won't make the loop spin indefinitely
+}

--- a/tests/typechecker/control_flow_match_22.jakt
+++ b/tests/typechecker/control_flow_match_22.jakt
@@ -1,0 +1,28 @@
+/// Expect:
+/// - output: "PASS\n"
+
+function test(first: i64, second: i64) -> String {
+    loop {
+        match first {
+            1 => {
+                // Doing other stuff
+            }
+            else => {
+                // Partial transfer control (can break)
+                if second == 2 {
+                    break
+                } else {
+                    // Doing other stuff
+                }
+            }
+        }
+
+        return "NOT PASSED" // This should be reachable (in case first == 1 or (first != 1 and second != 2))
+    }
+
+    return "PASS" // This should be reachable (in case first != 1 and second == 2)
+}
+
+function main() {
+    println("{}", test(first: 0, second: 2))
+}

--- a/tests/typechecker/control_flow_match_22_continue_case.jakt
+++ b/tests/typechecker/control_flow_match_22_continue_case.jakt
@@ -1,0 +1,28 @@
+/// Expect:
+/// - error: "Unreachable code"
+
+function test(first: i64, second: i64) -> String {
+    loop {
+        match first {
+            1 => {
+                // Doing other stuff
+            }
+            else => {
+                // Partial transfer control (can't break)
+                if second == 2 {
+                    continue
+                } else {
+                    // Doing other stuff
+                }
+            }
+        }
+
+        return "NOT PASSED" // This should be reachable (in case first == 1 or (first != 1 and second != 2))
+    }
+
+    return "NOT PASSED" // This should not be reachable
+}
+
+function main() {
+    println("{}", test(first: 1, second: 0)) // This test should error, so let's pass values that won't make the loop spin indefinitely
+}

--- a/tests/typechecker/control_flow_match_3.jakt
+++ b/tests/typechecker/control_flow_match_3.jakt
@@ -1,0 +1,27 @@
+/// Expect:
+/// - output: "PASS\n"
+
+function test(first: i64, second: i64) -> String {
+    loop {
+        match first {
+            1 => {
+                // Partially never return
+                if second == 2 {
+                    abort()
+                }
+            }
+            else => {
+                // Always transfer control (can break)
+                break
+            }
+        }
+
+        break // This should be reachable (in case first == 1 and second != 2)
+    }
+
+    return "PASS" // This should be reachable (in case first != 1 or (first == 1 and second != 2))
+}
+
+function main() {
+    println("{}", test(first: 1, second: 0))
+}

--- a/tests/typechecker/control_flow_match_4.jakt
+++ b/tests/typechecker/control_flow_match_4.jakt
@@ -1,0 +1,23 @@
+/// Expect:
+/// - output: "PASS\n"
+
+function test(first: i64, second: i64) -> String {
+    match first {
+        1 => {
+            // Partially always return
+            if second == 2 {
+                return "NOT PASSED"
+            }
+        }
+        else => {
+            // Always return
+            return "NOT PASSED"
+        }
+    }
+
+    return "PASS" // This should be reachable (in case first == 1 and second != 2)
+}
+
+function main() {
+    println("{}", test(first: 1, second: 0))
+}

--- a/tests/typechecker/control_flow_match_5.jakt
+++ b/tests/typechecker/control_flow_match_5.jakt
@@ -1,0 +1,23 @@
+/// Expect:
+/// - output: "PASS\n"
+
+function test(first: i64, second: i64) -> String {
+    match first {
+        1 => {
+            // Partially always return
+            if second == 2 {
+                return "NOT PASSED"
+            }
+        }
+        else => {
+            // Never return
+            abort()
+        }
+    }
+
+    return "PASS" // This should be reachable (in case first == 1 and second != 2)
+}
+
+function main() {
+    println("{}", test(first: 1, second: 0))
+}

--- a/tests/typechecker/control_flow_match_6.jakt
+++ b/tests/typechecker/control_flow_match_6.jakt
@@ -1,0 +1,27 @@
+/// Expect:
+/// - output: "PASS\n"
+
+function test(first: i64, second: i64) -> String {
+    loop {
+        match first {
+            1 => {
+                // Partially always return
+                if second == 2 {
+                    return "NOT PASSED"
+                }
+            }
+            else => {
+                // Always transfer control (can break)
+                break
+            }
+        }
+
+        break // This should be reachable (in case first == 1 and second != 2)
+    }
+
+    return "PASS" // This should be reachable (in case first != 1 or (first == 1 and second != 2))
+}
+
+function main() {
+    println("{}", test(first: 1, second: 0))
+}

--- a/tests/typechecker/control_flow_match_7.jakt
+++ b/tests/typechecker/control_flow_match_7.jakt
@@ -1,0 +1,33 @@
+/// Expect:
+/// - output: "PASS\n"
+
+function test(first: i64, second: i64, third: i64) -> String {
+    loop {
+        match first {
+            1 => {
+                // Partially transfer control (can break)
+                if second == 2 {
+
+                    // Partially transfer control (can break)
+                    if third == 3 {
+                        break
+                    }
+
+                    continue
+                }
+            }
+            else => {
+                // Always return
+                return "NOT PASSED"
+            }
+        }
+
+        let x = 1 // This should be reachable (in case first == 1 and second != 2)
+    }
+
+    return "PASS" // This should be reachable
+}
+
+function main() {
+    println("{}", test(first: 1, second: 2, third: 3))
+}

--- a/tests/typechecker/control_flow_match_7_continue_case.jakt
+++ b/tests/typechecker/control_flow_match_7_continue_case.jakt
@@ -1,0 +1,31 @@
+/// Expect:
+/// - error: "Unreachable code"
+
+function test(first: i64, second: i64, third: i64) -> String {
+    loop {
+        match first {
+            1 => {
+                // Partially transfer control (can't break)
+                if second == 2 {
+
+                    // Partially transfer control (can't break)
+                    if third == 3 {
+                        continue
+                    }
+
+                    continue
+                }
+            }
+            else => {
+                // Always return
+                return "NOT PASSED"
+            }
+        }
+    }
+
+    return "NOT PASSED" // This should not be reachable
+}
+
+function main() {
+    println("{}", test(first: 0, second: 0, third: 0)) // This test should error, so let's pass values that won't make the loop spin indefinitely
+}

--- a/tests/typechecker/control_flow_match_8.jakt
+++ b/tests/typechecker/control_flow_match_8.jakt
@@ -1,0 +1,33 @@
+/// Expect:
+/// - output: "PASS\n"
+
+function test(first: i64, second: i64, third: i64) -> String {
+    loop {
+        match first {
+            1 => {
+                // Partially transfer control (can break)
+                if second == 2 {
+
+                    // Partially transfer control (can break)
+                    if third == 3 {
+                        break
+                    }
+
+                    continue
+                }
+            }
+            else => {
+                // Never return
+                abort()
+            }
+        }
+
+        let x = 1 // This should be reachable (in case first == 1 and second != 2)
+    }
+
+    return "PASS" // This should be reachable (in case first == 1 and second == 2 and third == 3)
+}
+
+function main() {
+    println("{}", test(first: 1, second: 2, third: 3))
+}

--- a/tests/typechecker/control_flow_match_8_continue_case.jakt
+++ b/tests/typechecker/control_flow_match_8_continue_case.jakt
@@ -1,0 +1,33 @@
+/// Expect:
+/// - error: "Unreachable code"
+
+function test(first: i64, second: i64, third: i64) -> String {
+    loop {
+        match first {
+            1 => {
+                // Partially transfer control (can't break)
+                if second == 2 {
+
+                    // Partially transfer control (can't break)
+                    if third == 3 {
+                        continue
+                    }
+
+                    continue
+                }
+            }
+            else => {
+                // Never return
+                abort()
+            }
+        }
+
+        let x = 1 // This should be reachable (in case first == 1 and second != 2)
+    }
+
+    return "NOT PASSED" // This should not be reachable
+}
+
+function main() {
+    println("{}", test(first: 0, second: 0, third: 0)) // This test should error, so let's pass values that won't make the loop spin indefinitely
+}

--- a/tests/typechecker/control_flow_match_9.jakt
+++ b/tests/typechecker/control_flow_match_9.jakt
@@ -1,0 +1,25 @@
+/// Expect:
+/// - output: "PASS\n"
+
+function test(first: i64, second: i64) -> String {
+    loop {
+        match first {
+            1 => {
+                // Partially transfer control (can break)
+                if second == 2 {
+                    break
+                }
+            }
+            else => {
+                // Always transfer control (can't break)
+                continue
+            }
+        }
+    }
+
+    return "PASS" // This should be reachable (in case first == 1 and second == 2)
+}
+
+function main() {
+    println("{}", test(first: 1, second: 2))
+}

--- a/tests/typechecker/control_flow_match_9_continue_case.jakt
+++ b/tests/typechecker/control_flow_match_9_continue_case.jakt
@@ -1,0 +1,25 @@
+/// Expect:
+/// - error: "Unreachable code"
+
+function test(first: i64, second: i64) -> String {
+    loop {
+        match first {
+            1 => {
+                // Partially transfer control (can't break)
+                if second == 2 {
+                    continue
+                }
+            }
+            else => {
+                // Always transfer control (can't break)
+                continue
+            }
+        }
+    }
+
+    return "NOT PASSED" // This should not be reachable
+}
+
+function main() {
+    println("{}", test(first: 0, second: 0))
+}


### PR DESCRIPTION
Move out an already battle-tested `if` control flow resolution to a helper in BlockControlFlow, in types.jakt, and use it for `match` control flow resolution as well.

All existing tests for `if` control flow were converted to `match` and added in this PR.
Of which previously not passing were:
- control_flow_match_3.jakt
- control_flow_match_6.jakt
- control_flow_match_7_continue_case.jakt
- control_flow_match_8_continue_case.jakt
- control_flow_match_9.jakt
- control_flow_match_10_continue_case.jakt
- control_flow_match_11_continue_case.jakt
- control_flow_match_12_continue_case.jakt  (would make the program and jakttest loop endlessly)
- control_flow_match_19.jakt
- control_flow_match_20.jakt
- control_flow_match_21.jakt
- control_flow_match_22.jakt