### PR TITLE
typechecker: Unwrap return in throwing fatarrow functions

### DIFF
--- a/selfhost/typechecker.jakt
+++ b/selfhost/typechecker.jakt
@@ -3626,7 +3626,7 @@ struct Typechecker {
             scope.can_throw = true
         }
 
-        let block = .typecheck_block(
+        mut block = .typecheck_block(
             parsed_function.block
             parent_scope_id: function_scope_id
             safety_mode: SafetyMode::Safe
@@ -3642,6 +3642,21 @@ struct Typechecker {
         let return_type_id = match function_return_type_id.equals(unknown_type_id()) {
             true => .infer_function_return_type(block)
             else => .resolve_type_var(type_var_type_id: function_return_type_id, scope_id: function_scope_id)
+        }
+
+        // Unwrap return in throwing fat arrow function that returns void
+        // void can't automatically be cast to ErrorOr<void> which crashes c++ compilation
+        if parsed_function.is_fat_arrow and parsed_function.can_throw and return_type_id.equals(void_type_id()) {
+            let statement = block.statements[0]
+            match statement {
+                Return(val, span) => {
+                    let stmt = CheckedStatement::Expression(expr: val!, span: span!)
+                    block.statements = [stmt]
+                }
+                else => {
+                    panic("No return in fat arrow function")
+                }
+            }
         }
 
         if not function_linkage is External and not return_type_id.equals(void_type_id()) and not block.control_flow.always_transfers_control() {

--- a/selfhost/typechecker.jakt
+++ b/selfhost/typechecker.jakt
@@ -3111,7 +3111,7 @@ struct Typechecker {
             scope.can_throw = true
         }
 
-        let block = .typecheck_block(parsed_block: func.block, parent_scope_id: function_scope_id, safety_mode: SafetyMode::Safe)
+        mut block = .typecheck_block(parsed_block: func.block, parent_scope_id: function_scope_id, safety_mode: SafetyMode::Safe)
 
         if block.yielded_type.has_value() {
             .error_with_hint("Functions are not allowed to yield values", func.block.find_yield_span()!,
@@ -3123,6 +3123,21 @@ struct Typechecker {
         let return_type_id = match function_return_type_id.equals(unknown_type_id()) {
             true => .infer_function_return_type(block)
             else => .resolve_type_var(type_var_type_id: function_return_type_id, scope_id: function_scope_id)
+        }
+
+        // Unwrap return in throwing fat arrow function that returns void
+        // void can't automatically be cast to ErrorOr<void> which crashes c++ compilation
+        if func.is_fat_arrow and func.can_throw and return_type_id.equals(void_type_id()) {
+            let statement = block.statements[0]
+            match statement {
+                Return(val, span) => {
+                    let stmt = CheckedStatement::Expression(expr: val!, span: span!)
+                    block.statements = [stmt]
+                }
+                else => {
+                    panic("No return in fat arrow function")
+                }
+            }
         }
 
         if not parent_definition_linkage is External and not return_type_id.equals(VOID_TYPE_ID) and not block.control_flow.always_transfers_control() {

--- a/tests/typechecker/return_void_in_throwing_fatarrow_function.jakt
+++ b/tests/typechecker/return_void_in_throwing_fatarrow_function.jakt
@@ -1,0 +1,11 @@
+/// Expect:
+/// - output: "OK\n"
+
+function f() {
+    println("OK")
+}
+function g() throws => f()
+
+function main() {
+    f()
+}

--- a/tests/typechecker/return_void_in_throwing_fatarrow_method.jakt
+++ b/tests/typechecker/return_void_in_throwing_fatarrow_method.jakt
@@ -1,0 +1,14 @@
+/// Expect:
+/// - output: "OK\n"
+
+class Test {
+    function f() {
+        println("OK")
+    }
+
+    public function g() throws => f()
+}
+
+function main() {
+    Test::g()
+}


### PR DESCRIPTION
Expressions in fatarrow functions are always appended by a Return, which causes Problems in the specific case where a throwing fatarrow function calls a non-throwing, void-returning function.
In this case we can unwrap the return as it is already handeled in codegen.

Fixes #1305