### PR TITLE
parser: Allow trailing closure arguments to occur after the call's ()

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ Some of the features that encourage more readable programs:
 - [x] None coalescing for optionals (`foo ?? bar` yields `foo` if `foo` has a value, otherwise `bar`)
 - [x] `defer` statements.
 - [x] Pointers are always dereferenced with `.` (never `->`)
-- [ ] Trailing closure parameters can be passed outside the call parentheses.
+- [x] Trailing closure parameters can be passed outside the call parentheses.
 - [ ] Error propagation with `ErrorOr<T>` return type and dedicated `try` / `must` keywords.
 
 ## Function calls

--- a/samples/closures/trailing_closure_parameter.jakt
+++ b/samples/closures/trailing_closure_parameter.jakt
@@ -1,0 +1,15 @@
+/// Expect:
+/// - output: "Before\nWell, hello friends!\nAfter\n"
+
+function wrapped(anon action: &function() -> void) {
+    println("Before")
+    action()
+    println("After")
+}
+
+function main() {
+    let message = "Well, hello friends!"
+    wrapped() {
+        println(message)
+    }
+}

--- a/selfhost/codegen.jakt
+++ b/selfhost/codegen.jakt
@@ -1871,6 +1871,7 @@ struct CodeGenerator {
                 generated_captures.push(match capture {
                     ByValue => capture.name()
                     ByReference | ByMutableReference => format("&{}", capture.name())
+                    AllByReference => "&"
                 })
             }
             mut generated_params: [String] = []

--- a/selfhost/parser.jakt
+++ b/selfhost/parser.jakt
@@ -995,17 +995,20 @@ enum ParsedCapture {
     ByValue(name: String, span: Span)
     ByReference(name: String, span: Span)
     ByMutableReference(name: String, span: Span)
+    AllByReference(span: Span)
 
     function name(this) => match this {
         ByValue(name) => name
         ByReference(name) => name
         ByMutableReference(name) => name
+        AllByReference() => ""
     }
 
     function span(this) => match this {
         ByValue(span) => span
         ByReference(span) => span
         ByMutableReference(span) => span
+        AllByReference(span) => span
     }
 }
 

--- a/selfhost/parser.jakt
+++ b/selfhost/parser.jakt
@@ -1586,6 +1586,7 @@ struct Parser {
     index: usize
     tokens: [Token]
     compiler: Compiler
+    can_have_trailing_closure: bool = true
 
     function parse(compiler: Compiler, tokens: [Token]) throws -> ParsedNamespace {
         mut parser = Parser(index: 0, tokens, compiler)
@@ -2441,10 +2442,13 @@ struct Parser {
         parsed_import.module_name = match .current() {
             Identifier(name, span) => match .peek(1) {
                 LParen => {
+                    let previous_can_have_trailing_closure = .can_have_trailing_closure
+                    .can_have_trailing_closure = false
                     let expression = ParsedExpression::Call(
                         call: .parse_call()!
                         span
                     )
+                    .can_have_trailing_closure = previous_can_have_trailing_closure
                     .index--
                     yield ImportName::Comptime(expression)
                 }
@@ -3791,7 +3795,12 @@ struct Parser {
             }
             While => {
                 .index++
+
+                let previous_can_have_trailing_closure = .can_have_trailing_closure
+                .can_have_trailing_closure = false
                 let condition = .parse_expression(allow_assignments: false, allow_newlines: true)
+                .can_have_trailing_closure = previous_can_have_trailing_closure
+
                 let block = .parse_block()
                 yield ParsedStatement::While(condition, block, span: merge_spans(start, .previous().span()))
             }
@@ -3873,7 +3882,10 @@ struct Parser {
     function parse_guard_statement(mut this) throws -> ParsedStatement {
         let span = .current().span()
         .index++
+        let previous_can_have_trailing_closure = .can_have_trailing_closure
+        .can_have_trailing_closure = false
         let expr = .parse_expression(allow_assignments: false, allow_newlines: true)
+        .can_have_trailing_closure = previous_can_have_trailing_closure
         if .current() is Else {
             .index++
         } else {
@@ -3957,7 +3969,11 @@ struct Parser {
             return ParsedStatement::Garbage(merge_spans(start_span, .current().span()))
         }
 
+        let previous_can_have_trailing_closure = .can_have_trailing_closure
+        .can_have_trailing_closure = false
         let range = .parse_expression(allow_assignments: false, allow_newlines: false)
+        .can_have_trailing_closure = previous_can_have_trailing_closure
+
         mut block = .parse_block();
 
         if destructured_var_decls.size() > 0 {
@@ -3991,7 +4007,11 @@ struct Parser {
         let start_span = .current().span()
         .index++
 
+        let previous_can_have_trailing_closure = .can_have_trailing_closure
+        .can_have_trailing_closure = false
         let condition = .parse_expression(allow_assignments: false, allow_newlines: true)
+        .can_have_trailing_closure = previous_can_have_trailing_closure
+
         let then_block = .parse_block()
 
         mut else_statement: ParsedStatement? = None
@@ -5000,7 +5020,10 @@ struct Parser {
         mut start = .current().span()
         .index++
 
+        let previous_can_have_trailing_closure = .can_have_trailing_closure
+        .can_have_trailing_closure = false
         let expr = .parse_expression(allow_assignments: false, allow_newlines: true)
+        .can_have_trailing_closure = previous_can_have_trailing_closure
         let cases = .parse_match_cases()
 
 
@@ -5369,6 +5392,18 @@ struct Parser {
                     call.args.push((label, label_span, expr))
                 }
             }
+        }
+
+        // Look for a possible trailing closure. For now, this has to be a block with no parameters, which captures everything by reference.
+        // FIXME: Support explicit captures, and maybe parameters.
+        if .can_have_trailing_closure and .current() is LCurly {
+            let start = .current().span()
+            let block = .parse_block()
+            let span = merge_spans(start, .current().span())
+            let captures = [ParsedCapture::AllByReference(span: .empty_span())]
+            let trailing_closure = ParsedExpression::Function(captures, params: [], can_throw: false, is_fat_arrow: false, return_type: ParsedType::Empty, block, span)
+            let reference_to_closure = ParsedExpression::UnaryOp(expr: trailing_closure, op: UnaryOperator::Reference, span)
+            call.args.push(("", .empty_span(), reference_to_closure))
         }
 
         return call

--- a/selfhost/typechecker.jakt
+++ b/selfhost/typechecker.jakt
@@ -6591,11 +6591,16 @@ struct Typechecker {
         let lambda_scope_id = .create_scope(parent_scope_id: scope_id, can_throw, debug_name: "lambda")
         mut checked_captures: [CheckedCapture] = []
         for capture in captures {
-            if .find_var_in_scope(scope_id, var: capture.name()).has_value() {
+            if capture is AllByReference(span) {
+                checked_captures.push(CheckedCapture::AllByReference(span))
+            } else if .find_var_in_scope(scope_id, var: capture.name()).has_value() {
                 checked_captures.push(match capture {
                     ByValue(name, span) => CheckedCapture::ByValue(name, span)
                     ByReference(name, span) => CheckedCapture::ByReference(name, span)
                     ByMutableReference(name, span) => CheckedCapture::ByMutableReference(name, span)
+                    AllByReference(span) => {
+                        .compiler.panic("AllByReference capture should not be looked up by name")
+                    }
                 })
             } else {
                 .error(format("Variable '{}' not found", capture.name()), span)

--- a/selfhost/types.jakt
+++ b/selfhost/types.jakt
@@ -900,17 +900,20 @@ enum CheckedCapture {
     ByValue(name: String, span: Span)
     ByReference(name: String, span: Span)
     ByMutableReference(name: String, span: Span)
+    AllByReference(span: Span)
 
     function name(this) => match this {
         ByValue(name) => name
         ByReference(name) => name
         ByMutableReference(name) => name
+        AllByReference() => ""
     }
 
     function span(this) => match this {
         ByValue(span) => span
         ByReference(span) => span
         ByMutableReference(span) => span
+        AllByReference(span) => span
     }
 }
 

--- a/tests/parser/trailing_closure_not_allowed_in_for.jakt
+++ b/tests/parser/trailing_closure_not_allowed_in_for.jakt
@@ -1,0 +1,13 @@
+/// Expect:
+/// - error: "No function with matching signature found.\n"
+
+function wrapped(anon action: &function() -> void) -> bool {
+    println("Before")
+    action()
+    println("After")
+    return true
+}
+
+function main() {
+    for thing in wrapped() {} {}
+}

--- a/tests/parser/trailing_closure_not_allowed_in_guard.jakt
+++ b/tests/parser/trailing_closure_not_allowed_in_guard.jakt
@@ -1,0 +1,15 @@
+/// Expect:
+/// - error: "Expected `else` keyword\n"
+
+function wrapped(anon action: &function() -> void) -> bool {
+    println("Before")
+    action()
+    println("After")
+    return true
+}
+
+function main() {
+    guard wrapped() {} else {
+        return
+    }
+}

--- a/tests/parser/trailing_closure_not_allowed_in_if.jakt
+++ b/tests/parser/trailing_closure_not_allowed_in_if.jakt
@@ -1,0 +1,13 @@
+/// Expect:
+/// - error: "No function with matching signature found.\n"
+
+function wrapped(anon action: &function() -> void) -> bool {
+    println("Before")
+    action()
+    println("After")
+    return true
+}
+
+function main() {
+    if wrapped() {} {}
+}

--- a/tests/parser/trailing_closure_not_allowed_in_match.jakt
+++ b/tests/parser/trailing_closure_not_allowed_in_match.jakt
@@ -1,0 +1,16 @@
+/// Expect:
+/// - error: "Unsupported expression\n"
+
+function wrapped(anon action: &function() -> void) -> i32 {
+    println("Before")
+    action()
+    println("After")
+    return 42
+}
+
+function main() {
+    match wrapped() {} {
+    42 => {}
+    else => {}
+    }
+}


### PR DESCRIPTION
See `samples/closures/trailing_closure_parameter.jakt` for an example.

As shown by the tests, these are not parsed in the expressions of if/for/guard/match, since that leads to ambiguous syntax and also just looks bad.

This is a very limited first pass. A single block is parsed, and treated as a closure. This means that closure parameters, captures, and the return type (including the throwingness) cannot be defined. Ideally the return type would be inferred based on the closure's contents and the called function's parameter type.