### PR TITLE
ci: Use clang-15 to build on CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,10 +27,10 @@ jobs:
       fail-fast: true
       matrix:
         platform: [ubuntu-22.04]
-        cxx_compiler: [clang++-14]
+        cxx_compiler: [clang++-15]
         include:
           - platform: macos-latest
-            cxx_compiler: "$(brew --prefix llvm@14)/bin/clang++"
+            cxx_compiler: "$(brew --prefix llvm@15)/bin/clang++"
 
     runs-on: ${{ matrix.platform }}
 
@@ -43,9 +43,19 @@ jobs:
           version: 1.10.0
           dest: ${{ github.workspace }}/ninja_bin
 
+      - name: Install Linux dependencies
+        if: ${{ matrix.platform == 'ubuntu-22.04' }}
+        run: |
+          . /etc/lsb-release
+          wget -O /usr/share/keyrings/llvm-snapshot.gpg.key https://apt.llvm.org/llvm-snapshot.gpg.key
+          sudo echo "deb [signed-by=/usr/share/keyrings/llvm-snapshot.gpg.key] http://apt.llvm.org/${DISTRIB_CODENAME}/ llvm-toolchain-${DISTRIB_CODENAME} main" | sudo tee -a /etc/apt/sources.list.d/llvm.list
+          sudo echo "deb [signed-by=/usr/share/keyrings/llvm-snapshot.gpg.key] http://apt.llvm.org/${DISTRIB_CODENAME}/ llvm-toolchain-${DISTRIB_CODENAME}-15 main" | sudo tee -a /etc/apt/sources.list.d/llvm.list
+          sudo apt-get update
+          sudo apt-get install -y clang-15
+
       - name: Install macOS dependencies
         if: ${{ matrix.platform == 'macos-latest' }}
-        run: brew install coreutils
+        run: brew install coreutils llvm@15
 
       - name: Build Jakt Stage 1
         run: |

--- a/selfhost/main.jakt
+++ b/selfhost/main.jakt
@@ -188,6 +188,11 @@ function main(args: [String]) {
     let runtime_library_path = args_parser.option(["-RLP", "--runtime-library-path"]) ?? default_runtime_library_path.to_string()
     mut compiler_job_count = args_parser.option(["-J", "--jobs"]) ?? "2"
 
+    // FIXME: Remove this when parallel runs on windows work correctly.
+    if is_windows() {
+        compiler_job_count = "1"
+    }
+
     let clang_format_path = args_parser.option(["-F", "--clang-format-path"]) ?? "clang-format"
     let runtime_path = args_parser.option(["-R", "--runtime-path"]) ?? default_runtime_path.to_string()
     let binary_dir = Path::from_string(args_parser.option(["-B", "--binary-dir"]) ?? "build")
@@ -232,11 +237,6 @@ function main(args: [String]) {
         let project = Project(name: project_name!)
         project.populate()
         return 0
-    }
-
-    // FIXME: Remove this when parallel runs on windows work correctly.
-    if is_windows() {
-        compiler_job_count = "1"
     }
 
     mut file_name: String? = None


### PR DESCRIPTION
Following the serenity CI update, switch to using clang-15.