### PR TITLE
codegen+runtime: Support upcast and downcast with class pointers

### DIFF
--- a/runtime/lib.h
+++ b/runtime/lib.h
@@ -218,6 +218,21 @@ ALWAYS_INLINE constexpr OutputType infallible_integer_cast(InputType input)
     }
 }
 
+template<AK::SpecializationOf<AK::NonnullRefPtr> T, AK::SpecializationOf<AK::NonnullRefPtr> U>
+inline Optional<T> fallible_class_cast(U const& ptr)
+{
+    if (!is<typename T::ElementType>(*ptr))
+        return Optional<T> {};
+    return T(static_cast<typename T::ElementType const&>(*ptr));
+}
+
+template<AK::SpecializationOf<AK::NonnullRefPtr> T, AK::SpecializationOf<AK::NonnullRefPtr> U>
+inline T infallible_class_cast(U const& ptr)
+{
+    VERIFY(is<typename T::ElementType>(*ptr));
+    return T(static_cast<typename T::ElementType const&>(*ptr));
+}
+
 template<typename OutputType, typename InputType>
 ALWAYS_INLINE constexpr OutputType as_saturated(InputType input)
 {
@@ -305,7 +320,9 @@ namespace Jakt {
 using JaktInternal::abort;
 using JaktInternal::as_saturated;
 using JaktInternal::as_truncated;
+using JaktInternal::fallible_class_cast;
 using JaktInternal::fallible_integer_cast;
+using JaktInternal::infallible_class_cast;
 using JaktInternal::infallible_integer_cast;
 using JaktInternal::Range;
 using JaktInternal::unchecked_add;

--- a/selfhost/codegen.jakt
+++ b/selfhost/codegen.jakt
@@ -1669,17 +1669,21 @@ struct CodeGenerator {
                 }
                 TypeCast(cast) => {
                     mut final_type_id = cast.type_id();
+                    let type = .program.get_type(final_type_id)
                     let cast_type = match cast {
                         Fallible => {
-                            let ty = .program.get_type(cast.type_id())
-                            let type_id = match ty {
+                            let type_id = match type {
                                 GenericInstance(args) => args[0]
                                 else => {
                                     panic("Fallible type cast must have Optional result.")
                                 }
                             }
                             mut cast_type = "dynamic_cast"
-                            if .program.is_integer(type_id) {
+                            if .program.get_type(type_id) is Struct(struct_id)
+                                and .program.get_struct(struct_id).record_type is Class {
+                                    final_type_id = type_id
+                                cast_type = "fallible_class_cast"
+                            } else if .program.is_integer(type_id) {
                                 final_type_id = type_id
                                 cast_type = "fallible_integer_cast"
                             }
@@ -1688,7 +1692,9 @@ struct CodeGenerator {
                         }
                         Infallible => {
                             mut cast_type = "verify_cast"
-                            if .program.is_integer(type_id) {
+                            if type is Struct(struct_id) and .program.get_struct(struct_id).record_type is Class {
+                                cast_type = "infallible_class_cast"
+                            } else if .program.is_integer(type_id) {
                                 cast_type = "infallible_integer_cast"
                             }
                             yield cast_type

--- a/tests/codegen/class_casts.jakt
+++ b/tests/codegen/class_casts.jakt
@@ -1,0 +1,32 @@
+/// Expect:
+/// - output: "123\n"
+
+class Base {
+}
+
+class Derived: Base {
+    public x: i64
+}
+
+class OtherDerived: Base {
+}
+
+function main() {
+    let derived = Derived(x: 123)
+
+    // Infallible upcast
+    let base = derived as! Base
+
+    // Infallible downcast
+    println("{}", (base as! Derived).x)
+
+    // Fallible downcast (good)
+    if not (base as? Derived).has_value() {
+        println("Error 1")
+    }
+
+    // Fallible downcast (bad)
+    if (base as? OtherDerived).has_value() {
+        println("Error 2")
+    }
+}


### PR DESCRIPTION
This patch implemens `as!` and `as?` for class pointer values, both upwards and downwards in the class hierarchy.