### PR TITLE
typechecker: Disallow argument label overriding

### DIFF
--- a/selfhost/codegen.jakt
+++ b/selfhost/codegen.jakt
@@ -309,8 +309,8 @@ struct CodeGenerator {
                 let scope = generator.program.get_scope(scope_id)
 
                 if as_forward {
-                    for child_scope in scope.children {
-                        let scope = generator.program.get_scope(scope_id: child_scope)
+                    for child_scope_id in scope.children {
+                        let scope = generator.program.get_scope(child_scope_id)
                         if scope.import_path_if_extern.has_value() {
                             let has_name = scope.namespace_name.has_value()
                             if has_name {
@@ -2087,7 +2087,7 @@ struct CodeGenerator {
         output += format(
             "(([&]() -> JaktInternal::ExplicitValueOrControlFlow<{},{}>"
             .codegen_type(return_type_id)
-            .codegen_function_return_type(function_: .current_function!)
+            .codegen_function_return_type(function: .current_function!)
         ) + "{\n"
 
         if is_generic_enum {
@@ -2224,7 +2224,7 @@ struct CodeGenerator {
             output += "(([&]() -> JaktInternal::ExplicitValueOrControlFlow<"
             output += .codegen_type(type_id)
             output += ", "
-            output += .codegen_function_return_type(function_: .current_function!)
+            output += .codegen_function_return_type(function: .current_function!)
             output += ">{\n"
             output += "auto&& __jakt_match_variant = "
             if needs_deref {
@@ -2366,7 +2366,7 @@ struct CodeGenerator {
         return output
     }
 
-    fn codegen_function_return_type(mut this, anon function: CheckedFunction) throws -> String {
+    fn codegen_function_return_type(mut this, function: CheckedFunction) throws -> String {
         if function.is_static() and function.name_for_codegen() == "main" {
             return "ErrorOr<int>"
         }

--- a/selfhost/formatter.jakt
+++ b/selfhost/formatter.jakt
@@ -1632,7 +1632,7 @@ struct Stage0 {
                             dedents_on_open_curly
                         ))
                         return FormattedToken(
-                            token: Token::Comma(span: token.span())
+                            token: Token::Comma(token.span())
                             indent: .indent
                             trailing_trivia: [b' ']
                             preceding_trivia: []

--- a/selfhost/ide.jakt
+++ b/selfhost/ide.jakt
@@ -520,7 +520,7 @@ fn find_span_in_struct(program: CheckedProgram, checked_struct: CheckedStruct, s
 fn find_span_in_function(program: CheckedProgram, checked_function: CheckedFunction, span: Span) throws -> Usage? {
     if checked_function.return_type_span.has_value() {
         if checked_function.return_type_span!.contains(span) {
-            return Some(Usage::Typename(type_id: checked_function.return_type_id))
+            return Some(Usage::Typename(checked_function.return_type_id))
         }
     }
 

--- a/selfhost/parser.jakt
+++ b/selfhost/parser.jakt
@@ -4031,7 +4031,7 @@ struct Parser {
     fn parse_if_statement(mut this) throws -> ParsedStatement {
         if not .current() is If {
             .error("Expected ‘if’ statement", .current().span())
-            return ParsedStatement::Garbage(span: .current().span())
+            return ParsedStatement::Garbage(.current().span())
         }
 
         let start_span = .current().span()

--- a/selfhost/repl.jakt
+++ b/selfhost/repl.jakt
@@ -23,7 +23,7 @@ struct Editor {
     prompt: String
 
     fn create(prompt: String) throws -> Editor {
-        mut std_in = fopen(pathname: "/dev/stdin".c_string(), mode: "r".c_string())
+        mut std_in = fopen(str: "/dev/stdin".c_string(), mode: "r".c_string())
         if std_in == null<FILE>() {
             eprintln("Could not open /dev/stdin for reading")
             throw Error::from_errno(42)
@@ -58,7 +58,7 @@ struct Editor {
     }
 
     fn destroy(mut this) {
-        fclose(stream: .standard_input_file)
+        fclose(file: .standard_input_file)
         unsafe {
             cpp {
                 "free(line_pointer);"

--- a/selfhost/typechecker.jakt
+++ b/selfhost/typechecker.jakt
@@ -4272,11 +4272,11 @@ struct Typechecker {
     fn typecheck_typename(mut this, parsed_type: ParsedType, scope_id: ScopeId, name: String?) throws -> TypeId => match parsed_type {
         Reference(inner) => {
             let inner_type_id = .typecheck_typename(parsed_type: inner, scope_id, name)
-            yield .find_or_add_type_id(Type::Reference(id: inner_type_id))
+            yield .find_or_add_type_id(Type::Reference(inner_type_id))
         }
         MutableReference(inner) => {
             let inner_type_id = .typecheck_typename(parsed_type: inner, scope_id, name)
-            yield .find_or_add_type_id(Type::MutableReference(id: inner_type_id))
+            yield .find_or_add_type_id(Type::MutableReference(inner_type_id))
         }
         NamespacedName(name, namespaces, params, span) => {
             mut current_namespace_scope_id = scope_id
@@ -4398,7 +4398,7 @@ struct Typechecker {
         RawPtr(inner, span) => {
             let inner_type_id = .typecheck_typename(parsed_type: inner, scope_id, name)
 
-            yield .find_or_add_type_id(Type::RawPtr(id: inner_type_id))
+            yield .find_or_add_type_id(Type::RawPtr(inner_type_id))
         }
         GenericType(name, generic_parameters, span) => {
             mut checked_inner_types: [TypeId] = []
@@ -4806,7 +4806,7 @@ struct Typechecker {
         }
 
         // Ensure that we don't use any bindings we shouldn't have access to
-        let checked_else_block = .typecheck_block(block: else_block, parent_scope_id: scope_id, safety_mode)
+        let checked_else_block = .typecheck_block(else_block, parent_scope_id: scope_id, safety_mode)
 
         if not seen_scope_exit and checked_else_block.control_flow.may_return() {
             .error("Else block of guard must either `return`, `break`, `continue`, or `throw`", span) // FIXME: better span?
@@ -5294,7 +5294,7 @@ struct Typechecker {
             visibility: CheckedVisibility::Public
         )
         mut module = .current_module()
-        let error_id = module.add_variable(name: error_decl)
+        let error_id = module.add_variable(error_decl)
 
         let catch_scope_id = .create_scope(parent_scope_id: scope_id, can_throw: true, debug_name: "catch")
         .add_var_to_scope(scope_id: catch_scope_id, name: error_name, var_id: error_id, span: error_span)
@@ -5332,7 +5332,7 @@ struct Typechecker {
                     visibility: CheckedVisibility::Public
                 )
                 mut module = .current_module()
-                let error_id = module.add_variable(name: error_decl)
+                let error_id = module.add_variable(error_decl)
                 .add_var_to_scope(scope_id: catch_scope_id, name: catch_name!, var_id: error_id, span)
             }
 
@@ -7594,7 +7594,7 @@ struct Typechecker {
                         message: format("Type '{}' does not match type '{}' of previous keys in dictionary", current_key_type_name, key_type_name)
                         span: key.span()
                         hint: format("Dictionary was inferred to store keys of type '{}' here", key_type_name)
-                        span: key_type_span!
+                        hint_span: key_type_span!
                     )
                 }
                 if not value_type_id.equals(current_value_type_id) {
@@ -7604,7 +7604,7 @@ struct Typechecker {
                         message: format("Type '{}' does not match type '{}' of previous values in dictionary", current_value_type_name, value_type_name)
                         span: value.span()
                         hint: format("Dictionary was inferred to store values of type '{}' here", value_type_name)
-                        span: value_type_span!
+                        hint_span: value_type_span!
                     )
                 }
             }
@@ -8279,7 +8279,7 @@ struct Typechecker {
             mut invocation_scope = InterpreterScope::create(type_bindings)
             try {
                 result = interpreter.execute(
-                    function_to_run: resolved_function_id!
+                    function_to_run_id: resolved_function_id!
                     namespace_: resolved_namespaces
                     this_argument: this_argument
                     arguments: call_args
@@ -8357,6 +8357,12 @@ struct Typechecker {
                     maybe_checked_expr = param.default_value
                 } else {
                     let (name, span, expr) = args[consumed_arg]
+
+                    // The label is not required, but if it is present regardless, it has to match the parameter name
+                    if not name.is_empty() and name != param.variable.name {
+                        .error(format("Wrong parameter name in argument label (got '{}', expected '{}')", name, param.variable.name), span)
+                    }
+
                     maybe_checked_expr = .typecheck_expression(expr, scope_id, safety_mode, type_hint: param.variable.type_id)
                     consumed_arg++
                 }

--- a/tests/typechecker/wrong_parameter_name_in_anon_argument_label.jakt
+++ b/tests/typechecker/wrong_parameter_name_in_anon_argument_label.jakt
@@ -1,0 +1,9 @@
+/// Expect:
+/// - error: "Wrong parameter name in argument label (got 'bad', expected 'good')\n"
+
+fn test(anon good: i64) {}
+
+fn main() {
+    let variable = 2
+    test(bad: variable)
+}


### PR DESCRIPTION
We were using this behavior, consciously or not, in a couple of places.