### PR TITLE
vscode: Switch vscode highlighter to use 'fn'

### DIFF
--- a/editors/vscode/package-lock.json
+++ b/editors/vscode/package-lock.json
@@ -30,371 +30,6 @@
 				"vscode": "^1.67.0"
 			}
 		},
-		"client": {
-			"name": "lsp-sample-client",
-			"version": "0.0.1",
-			"license": "MIT",
-			"dependencies": {
-				"vscode-languageclient": "^8.0.1"
-			},
-			"devDependencies": {
-				"@types/vscode": "^1.63.0",
-				"@vscode/test-electron": "^2.1.2"
-			},
-			"engines": {
-				"vscode": "^1.63.0"
-			}
-		},
-		"client/node_modules/@tootallnate/once": {
-			"version": "1.1.2",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">= 6"
-			}
-		},
-		"client/node_modules/@vscode/test-electron": {
-			"version": "2.1.2",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"http-proxy-agent": "^4.0.1",
-				"https-proxy-agent": "^5.0.0",
-				"rimraf": "^3.0.2",
-				"unzipper": "^0.10.11"
-			},
-			"engines": {
-				"node": ">=8.9.3"
-			}
-		},
-		"client/node_modules/@vscode/test-electron/node_modules/agent-base": {
-			"version": "6.0.2",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"debug": "4"
-			},
-			"engines": {
-				"node": ">= 6.0.0"
-			}
-		},
-		"client/node_modules/@vscode/test-electron/node_modules/debug": {
-			"version": "4.3.2",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"ms": "2.1.2"
-			},
-			"engines": {
-				"node": ">=6.0"
-			},
-			"peerDependenciesMeta": {
-				"supports-color": {
-					"optional": true
-				}
-			}
-		},
-		"client/node_modules/@vscode/test-electron/node_modules/http-proxy-agent": {
-			"version": "4.0.1",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@tootallnate/once": "1",
-				"agent-base": "6",
-				"debug": "4"
-			},
-			"engines": {
-				"node": ">= 6"
-			}
-		},
-		"client/node_modules/@vscode/test-electron/node_modules/https-proxy-agent": {
-			"version": "5.0.0",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"agent-base": "6",
-				"debug": "4"
-			},
-			"engines": {
-				"node": ">= 6"
-			}
-		},
-		"client/node_modules/@vscode/test-electron/node_modules/ms": {
-			"version": "2.1.2",
-			"dev": true,
-			"license": "MIT"
-		},
-		"client/node_modules/@vscode/test-electron/node_modules/rimraf": {
-			"version": "3.0.2",
-			"dev": true,
-			"license": "ISC",
-			"dependencies": {
-				"glob": "^7.1.3"
-			},
-			"bin": {
-				"rimraf": "bin.js"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/isaacs"
-			}
-		},
-		"client/node_modules/balanced-match": {
-			"version": "1.0.0",
-			"dev": true,
-			"license": "MIT"
-		},
-		"client/node_modules/big-integer": {
-			"version": "1.6.48",
-			"dev": true,
-			"license": "Unlicense",
-			"engines": {
-				"node": ">=0.6"
-			}
-		},
-		"client/node_modules/binary": {
-			"version": "0.3.0",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"buffers": "~0.1.1",
-				"chainsaw": "~0.1.0"
-			}
-		},
-		"client/node_modules/bluebird": {
-			"version": "3.4.7",
-			"dev": true,
-			"license": "MIT"
-		},
-		"client/node_modules/brace-expansion": {
-			"version": "1.1.11",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"balanced-match": "^1.0.0",
-				"concat-map": "0.0.1"
-			}
-		},
-		"client/node_modules/buffer-indexof-polyfill": {
-			"version": "1.0.2",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=0.10"
-			}
-		},
-		"client/node_modules/buffers": {
-			"version": "0.1.1",
-			"dev": true,
-			"engines": {
-				"node": ">=0.2.0"
-			}
-		},
-		"client/node_modules/chainsaw": {
-			"version": "0.1.0",
-			"dev": true,
-			"license": "MIT/X11",
-			"dependencies": {
-				"traverse": ">=0.3.0 <0.4"
-			}
-		},
-		"client/node_modules/concat-map": {
-			"version": "0.0.1",
-			"dev": true,
-			"license": "MIT"
-		},
-		"client/node_modules/core-util-is": {
-			"version": "1.0.2",
-			"dev": true,
-			"license": "MIT"
-		},
-		"client/node_modules/duplexer2": {
-			"version": "0.1.4",
-			"dev": true,
-			"license": "BSD-3-Clause",
-			"dependencies": {
-				"readable-stream": "^2.0.2"
-			}
-		},
-		"client/node_modules/fs.realpath": {
-			"version": "1.0.0",
-			"dev": true,
-			"license": "ISC"
-		},
-		"client/node_modules/fstream": {
-			"version": "1.0.12",
-			"dev": true,
-			"license": "ISC",
-			"dependencies": {
-				"graceful-fs": "^4.1.2",
-				"inherits": "~2.0.0",
-				"mkdirp": ">=0.5 0",
-				"rimraf": "2"
-			},
-			"engines": {
-				"node": ">=0.6"
-			}
-		},
-		"client/node_modules/glob": {
-			"version": "7.1.6",
-			"dev": true,
-			"license": "ISC",
-			"dependencies": {
-				"fs.realpath": "^1.0.0",
-				"inflight": "^1.0.4",
-				"inherits": "2",
-				"minimatch": "^3.0.4",
-				"once": "^1.3.0",
-				"path-is-absolute": "^1.0.0"
-			},
-			"engines": {
-				"node": "*"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/isaacs"
-			}
-		},
-		"client/node_modules/graceful-fs": {
-			"version": "4.2.6",
-			"dev": true,
-			"license": "ISC"
-		},
-		"client/node_modules/inflight": {
-			"version": "1.0.6",
-			"dev": true,
-			"license": "ISC",
-			"dependencies": {
-				"once": "^1.3.0",
-				"wrappy": "1"
-			}
-		},
-		"client/node_modules/inherits": {
-			"version": "2.0.4",
-			"dev": true,
-			"license": "ISC"
-		},
-		"client/node_modules/isarray": {
-			"version": "1.0.0",
-			"dev": true,
-			"license": "MIT"
-		},
-		"client/node_modules/listenercount": {
-			"version": "1.0.1",
-			"dev": true,
-			"license": "ISC"
-		},
-		"client/node_modules/minimatch": {
-			"version": "3.0.4",
-			"dev": true,
-			"license": "ISC",
-			"dependencies": {
-				"brace-expansion": "^1.1.7"
-			},
-			"engines": {
-				"node": "*"
-			}
-		},
-		"client/node_modules/mkdirp": {
-			"version": "0.5.5",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"minimist": "^1.2.5"
-			},
-			"bin": {
-				"mkdirp": "bin/cmd.js"
-			}
-		},
-		"client/node_modules/once": {
-			"version": "1.4.0",
-			"dev": true,
-			"license": "ISC",
-			"dependencies": {
-				"wrappy": "1"
-			}
-		},
-		"client/node_modules/path-is-absolute": {
-			"version": "1.0.1",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=0.10.0"
-			}
-		},
-		"client/node_modules/process-nextick-args": {
-			"version": "2.0.1",
-			"dev": true,
-			"license": "MIT"
-		},
-		"client/node_modules/readable-stream": {
-			"version": "2.3.7",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"core-util-is": "~1.0.0",
-				"inherits": "~2.0.3",
-				"isarray": "~1.0.0",
-				"process-nextick-args": "~2.0.0",
-				"safe-buffer": "~5.1.1",
-				"string_decoder": "~1.1.1",
-				"util-deprecate": "~1.0.1"
-			}
-		},
-		"client/node_modules/rimraf": {
-			"version": "2.7.1",
-			"dev": true,
-			"license": "ISC",
-			"dependencies": {
-				"glob": "^7.1.3"
-			},
-			"bin": {
-				"rimraf": "bin.js"
-			}
-		},
-		"client/node_modules/safe-buffer": {
-			"version": "5.1.2",
-			"dev": true,
-			"license": "MIT"
-		},
-		"client/node_modules/setimmediate": {
-			"version": "1.0.5",
-			"dev": true,
-			"license": "MIT"
-		},
-		"client/node_modules/string_decoder": {
-			"version": "1.1.1",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"safe-buffer": "~5.1.0"
-			}
-		},
-		"client/node_modules/traverse": {
-			"version": "0.3.9",
-			"dev": true,
-			"license": "MIT/X11"
-		},
-		"client/node_modules/unzipper": {
-			"version": "0.10.11",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"big-integer": "^1.6.17",
-				"binary": "~0.3.0",
-				"bluebird": "~3.4.1",
-				"buffer-indexof-polyfill": "~1.0.0",
-				"duplexer2": "~0.1.4",
-				"fstream": "^1.0.12",
-				"graceful-fs": "^4.2.2",
-				"listenercount": "~1.0.1",
-				"readable-stream": "~2.3.6",
-				"setimmediate": "~1.0.4"
-			}
-		},
-		"client/node_modules/wrappy": {
-			"version": "1.0.2",
-			"dev": true,
-			"license": "ISC"
-		},
 		"node_modules/@eslint/eslintrc": {
 			"version": "1.3.0",
 			"dev": true,
@@ -1969,8 +1604,18 @@
 			"license": "ISC"
 		},
 		"node_modules/jakt-lsp-server": {
-			"resolved": "server",
-			"link": true
+			"version": "1.0.0",
+			"resolved": "file:server",
+			"license": "MIT",
+			"dependencies": {
+				"@types/vscode": "^1.67.0",
+				"tmp": "^0.2.1",
+				"vscode-languageserver": "^8.0.1",
+				"vscode-languageserver-textdocument": "^1.0.4"
+			},
+			"engines": {
+				"node": "*"
+			}
 		},
 		"node_modules/js-yaml": {
 			"version": "4.1.0",
@@ -2079,8 +1724,15 @@
 			}
 		},
 		"node_modules/lsp-sample-client": {
-			"resolved": "client",
-			"link": true
+			"version": "0.0.1",
+			"resolved": "file:client",
+			"license": "MIT",
+			"dependencies": {
+				"vscode-languageclient": "^8.0.1"
+			},
+			"engines": {
+				"vscode": "^1.63.0"
+			}
 		},
 		"node_modules/markdown-it": {
 			"version": "12.3.2",
@@ -3250,6 +2902,11 @@
 				"vscode-languageserver-types": "3.17.1"
 			}
 		},
+		"node_modules/vscode-languageserver-textdocument": {
+			"version": "1.0.8",
+			"resolved": "https://registry.npmjs.org/vscode-languageserver-textdocument/-/vscode-languageserver-textdocument-1.0.8.tgz",
+			"integrity": "sha512-1bonkGqQs5/fxGT5UchTgjGVnfysL0O8v1AYMBjqTbWQTFn721zaPGDYFkOKtfDgFiSgXM3KwaG3FMGfW4Ed9Q=="
+		},
 		"node_modules/vscode-languageserver-types": {
 			"version": "3.17.1",
 			"resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.17.1.tgz",
@@ -3404,32 +3061,6 @@
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
-		},
-		"server": {
-			"name": "jakt-lsp-server",
-			"version": "1.0.0",
-			"license": "MIT",
-			"dependencies": {
-				"@types/vscode": "^1.67.0",
-				"tmp": "^0.2.1",
-				"vscode-languageserver": "^8.0.1",
-				"vscode-languageserver-textdocument": "^1.0.4"
-			},
-			"devDependencies": {
-				"@types/tmp": "^0.2.3"
-			},
-			"engines": {
-				"node": "*"
-			}
-		},
-		"server/node_modules/@types/tmp": {
-			"version": "0.2.3",
-			"dev": true,
-			"license": "MIT"
-		},
-		"server/node_modules/vscode-languageserver-textdocument": {
-			"version": "1.0.4",
-			"license": "MIT"
 		}
 	},
 	"dependencies": {
@@ -4416,22 +4047,12 @@
 			"dev": true
 		},
 		"jakt-lsp-server": {
-			"version": "file:server",
+			"version": "1.0.0",
 			"requires": {
-				"@types/tmp": "^0.2.3",
 				"@types/vscode": "^1.67.0",
 				"tmp": "^0.2.1",
 				"vscode-languageserver": "^8.0.1",
 				"vscode-languageserver-textdocument": "^1.0.4"
-			},
-			"dependencies": {
-				"@types/tmp": {
-					"version": "0.2.3",
-					"dev": true
-				},
-				"vscode-languageserver-textdocument": {
-					"version": "1.0.4"
-				}
 			}
 		},
 		"js-yaml": {
@@ -4508,267 +4129,9 @@
 			}
 		},
 		"lsp-sample-client": {
-			"version": "file:client",
+			"version": "0.0.1",
 			"requires": {
-				"@types/vscode": "^1.63.0",
-				"@vscode/test-electron": "^2.1.2",
 				"vscode-languageclient": "^8.0.1"
-			},
-			"dependencies": {
-				"@tootallnate/once": {
-					"version": "1.1.2",
-					"dev": true
-				},
-				"@vscode/test-electron": {
-					"version": "2.1.2",
-					"dev": true,
-					"requires": {
-						"http-proxy-agent": "^4.0.1",
-						"https-proxy-agent": "^5.0.0",
-						"rimraf": "^3.0.2",
-						"unzipper": "^0.10.11"
-					},
-					"dependencies": {
-						"agent-base": {
-							"version": "6.0.2",
-							"dev": true,
-							"requires": {
-								"debug": "4"
-							}
-						},
-						"debug": {
-							"version": "4.3.2",
-							"dev": true,
-							"requires": {
-								"ms": "2.1.2"
-							}
-						},
-						"http-proxy-agent": {
-							"version": "4.0.1",
-							"dev": true,
-							"requires": {
-								"@tootallnate/once": "1",
-								"agent-base": "6",
-								"debug": "4"
-							}
-						},
-						"https-proxy-agent": {
-							"version": "5.0.0",
-							"dev": true,
-							"requires": {
-								"agent-base": "6",
-								"debug": "4"
-							}
-						},
-						"ms": {
-							"version": "2.1.2",
-							"dev": true
-						},
-						"rimraf": {
-							"version": "3.0.2",
-							"dev": true,
-							"requires": {
-								"glob": "^7.1.3"
-							}
-						}
-					}
-				},
-				"balanced-match": {
-					"version": "1.0.0",
-					"dev": true
-				},
-				"big-integer": {
-					"version": "1.6.48",
-					"dev": true
-				},
-				"binary": {
-					"version": "0.3.0",
-					"dev": true,
-					"requires": {
-						"buffers": "~0.1.1",
-						"chainsaw": "~0.1.0"
-					}
-				},
-				"bluebird": {
-					"version": "3.4.7",
-					"dev": true
-				},
-				"brace-expansion": {
-					"version": "1.1.11",
-					"dev": true,
-					"requires": {
-						"balanced-match": "^1.0.0",
-						"concat-map": "0.0.1"
-					}
-				},
-				"buffer-indexof-polyfill": {
-					"version": "1.0.2",
-					"dev": true
-				},
-				"buffers": {
-					"version": "0.1.1",
-					"dev": true
-				},
-				"chainsaw": {
-					"version": "0.1.0",
-					"dev": true,
-					"requires": {
-						"traverse": ">=0.3.0 <0.4"
-					}
-				},
-				"concat-map": {
-					"version": "0.0.1",
-					"dev": true
-				},
-				"core-util-is": {
-					"version": "1.0.2",
-					"dev": true
-				},
-				"duplexer2": {
-					"version": "0.1.4",
-					"dev": true,
-					"requires": {
-						"readable-stream": "^2.0.2"
-					}
-				},
-				"fs.realpath": {
-					"version": "1.0.0",
-					"dev": true
-				},
-				"fstream": {
-					"version": "1.0.12",
-					"dev": true,
-					"requires": {
-						"graceful-fs": "^4.1.2",
-						"inherits": "~2.0.0",
-						"mkdirp": ">=0.5 0",
-						"rimraf": "2"
-					}
-				},
-				"glob": {
-					"version": "7.1.6",
-					"dev": true,
-					"requires": {
-						"fs.realpath": "^1.0.0",
-						"inflight": "^1.0.4",
-						"inherits": "2",
-						"minimatch": "^3.0.4",
-						"once": "^1.3.0",
-						"path-is-absolute": "^1.0.0"
-					}
-				},
-				"graceful-fs": {
-					"version": "4.2.6",
-					"dev": true
-				},
-				"inflight": {
-					"version": "1.0.6",
-					"dev": true,
-					"requires": {
-						"once": "^1.3.0",
-						"wrappy": "1"
-					}
-				},
-				"inherits": {
-					"version": "2.0.4",
-					"dev": true
-				},
-				"isarray": {
-					"version": "1.0.0",
-					"dev": true
-				},
-				"listenercount": {
-					"version": "1.0.1",
-					"dev": true
-				},
-				"minimatch": {
-					"version": "3.0.4",
-					"dev": true,
-					"requires": {
-						"brace-expansion": "^1.1.7"
-					}
-				},
-				"mkdirp": {
-					"version": "0.5.5",
-					"dev": true,
-					"requires": {
-						"minimist": "^1.2.5"
-					}
-				},
-				"once": {
-					"version": "1.4.0",
-					"dev": true,
-					"requires": {
-						"wrappy": "1"
-					}
-				},
-				"path-is-absolute": {
-					"version": "1.0.1",
-					"dev": true
-				},
-				"process-nextick-args": {
-					"version": "2.0.1",
-					"dev": true
-				},
-				"readable-stream": {
-					"version": "2.3.7",
-					"dev": true,
-					"requires": {
-						"core-util-is": "~1.0.0",
-						"inherits": "~2.0.3",
-						"isarray": "~1.0.0",
-						"process-nextick-args": "~2.0.0",
-						"safe-buffer": "~5.1.1",
-						"string_decoder": "~1.1.1",
-						"util-deprecate": "~1.0.1"
-					}
-				},
-				"rimraf": {
-					"version": "2.7.1",
-					"dev": true,
-					"requires": {
-						"glob": "^7.1.3"
-					}
-				},
-				"safe-buffer": {
-					"version": "5.1.2",
-					"dev": true
-				},
-				"setimmediate": {
-					"version": "1.0.5",
-					"dev": true
-				},
-				"string_decoder": {
-					"version": "1.1.1",
-					"dev": true,
-					"requires": {
-						"safe-buffer": "~5.1.0"
-					}
-				},
-				"traverse": {
-					"version": "0.3.9",
-					"dev": true
-				},
-				"unzipper": {
-					"version": "0.10.11",
-					"dev": true,
-					"requires": {
-						"big-integer": "^1.6.17",
-						"binary": "~0.3.0",
-						"bluebird": "~3.4.1",
-						"buffer-indexof-polyfill": "~1.0.0",
-						"duplexer2": "~0.1.4",
-						"fstream": "^1.0.12",
-						"graceful-fs": "^4.2.2",
-						"listenercount": "~1.0.1",
-						"readable-stream": "~2.3.6",
-						"setimmediate": "~1.0.4"
-					}
-				},
-				"wrappy": {
-					"version": "1.0.2",
-					"dev": true
-				}
 			}
 		},
 		"markdown-it": {
@@ -5551,6 +4914,11 @@
 				"vscode-jsonrpc": "8.0.1",
 				"vscode-languageserver-types": "3.17.1"
 			}
+		},
+		"vscode-languageserver-textdocument": {
+			"version": "1.0.8",
+			"resolved": "https://registry.npmjs.org/vscode-languageserver-textdocument/-/vscode-languageserver-textdocument-1.0.8.tgz",
+			"integrity": "sha512-1bonkGqQs5/fxGT5UchTgjGVnfysL0O8v1AYMBjqTbWQTFn721zaPGDYFkOKtfDgFiSgXM3KwaG3FMGfW4Ed9Q=="
 		},
 		"vscode-languageserver-types": {
 			"version": "3.17.1",

--- a/editors/vscode/syntaxes/jakt.tmLanguage.json
+++ b/editors/vscode/syntaxes/jakt.tmLanguage.json
@@ -6,7 +6,7 @@
   ],
   "patterns": [
     {
-      "include": "#function"
+      "include": "#fn"
     },
     {
       "include": "#namespace"
@@ -502,10 +502,10 @@
         }
       ]
     },
-    "function": {
+    "fn": {
       "patterns": [
         {
-          "name": "meta.function.declaration.jakt",
+          "name": "meta.fn.declaration.jakt",
           "match": "(?:\\b(public|private)\\s+)?(\\bextern\\s+)?(?:(\\boverride\\b)\\s+|(\\bvirtual\\b)\\s+)?(\\b(?:fn|comptime))\\s+((?:\\w|_)(?:\\w|_|[0-9])*)",
           "captures": {
             "1": {
@@ -521,15 +521,15 @@
               "name": "storage.modifier.specifier.virtual.jakt"
             },
             "5": {
-              "name": "keyword.function.jakt"
+              "name": "keyword.fn.jakt"
             },
             "6": {
-              "name": "entity.name.function"
+              "name": "entity.name.fn"
             }
           }
         },
         {
-          "name": "meta.function.argument-list.jakt",
+          "name": "meta.fn.argument-list.jakt",
           "begin": "(?<=(?:fn|comptime).*?)(\\()",
           "beginCaptures": {
             "1": {
@@ -549,7 +549,7 @@
           ]
         },
         {
-          "name": "meta.function.return-type.jakt",
+          "name": "meta.fn.return-type.jakt",
           "begin": "(?<=\\)\\s*)(throws)?\\s*(\\-\\>)",
           "beginCaptures": {
             "1": {
@@ -575,7 +575,7 @@
           ]
         },
         {
-          "name": "meta.function.return-throws.jakt",
+          "name": "meta.fn.return-throws.jakt",
           "begin": "(?<=\\)\\s*)(throws)",
           "beginCaptures": {
             "1": {
@@ -590,7 +590,7 @@
           ]
         },
         {
-          "name": "meta.function.return-shorthand.jakt",
+          "name": "meta.fn.return-shorthand.jakt",
           "begin": "(?<=(?:fn|comptime).*?)(\\=\\>)",
           "beginCaptures": {
             "1": {
@@ -605,7 +605,7 @@
           ]
         },
         {
-          "name": "meta.function.body.jakt",
+          "name": "meta.fn.body.jakt",
           "begin": "(?<=(?:fn|comptime).*?)(\\{)",
           "beginCaptures": {
             "1": {
@@ -625,7 +625,7 @@
           ]
         },
         {
-          "name": "meta.function.generic-arguments.jakt",
+          "name": "meta.fn.generic-arguments.jakt",
           "begin": "(?<=(?:fn|comptime)\\s+(\\w)*?)(<)",
           "beginCaptures": {
             "1": {
@@ -877,7 +877,7 @@
       "begin": "\\b((?:\\w|_)(?:\\w|_|[0-9])*)\\s*(\\()",
       "beginCaptures": {
         "1": {
-          "name": "entity.name.function.call.jakt"
+          "name": "entity.name.fn.call.jakt"
         },
         "2": {
           "name": "punctuation.begin.bracket.jakt"


### PR DESCRIPTION
Does a `function`->`fn` update on the vscode highlighter.

Also updates the lock file with a fresh set of dependency versions.