### PR TITLE
codegen: Qualify the typenames in `is` expressions

### DIFF
--- a/selfhost/codegen.jakt
+++ b/selfhost/codegen.jakt
@@ -1660,8 +1660,8 @@ struct CodeGenerator {
                 Is(type_id) => {
                     let is_type = match .program.get_type(type_id) {
                         Struct(id) => {
-                            let type_module = .program.get_module(id.module)
-                            yield .program.get_struct(id).name_for_codegen()
+                            let struct_ = .program.get_struct(id)
+                            yield .codegen_namespace_qualifier(scope_id: struct_.scope_id) + struct_.name_for_codegen()
                         }
                         else => .codegen_type(type_id)
                     }

--- a/tests/typechecker/is_operator_on_imported_class.jakt
+++ b/tests/typechecker/is_operator_on_imported_class.jakt
@@ -1,0 +1,11 @@
+/// Expect:
+/// - output: "OK\n"
+
+import simple_base_and_derived
+
+fn main() {
+    let a = Derived()
+    if a is Derived {
+        println("OK")
+    }
+}

--- a/tests/typechecker/simple_base_and_derived.jakt
+++ b/tests/typechecker/simple_base_and_derived.jakt
@@ -1,0 +1,4 @@
+/// Expect: Skip
+
+class Base {}
+class Derived: Base {}


### PR DESCRIPTION
This makes the `is` operator work on imported class names.