### PR TITLE
typechecker: Argument label validation fixes

### DIFF
--- a/selfhost/codegen.jakt
+++ b/selfhost/codegen.jakt
@@ -547,7 +547,7 @@ struct CodeGenerator {
                 .postorder_traversal(
                     encoded_type_id: entry.0
                     visited: seen_types
-                    dependency_graph: encoded_dependency_graph
+                    encoded_dependency_graph
                     output: traversal
                 )
                 for type_id in traversal {

--- a/selfhost/compiler.jakt
+++ b/selfhost/compiler.jakt
@@ -49,7 +49,7 @@ class Compiler {
                                 file_contents = file.read_all()
                             } catch error {}
                         }
-                        print_error(file_name, contents: file_contents, error)
+                        print_error(file_name, file_contents, error)
                     }
                 }
             }

--- a/selfhost/parser.jakt
+++ b/selfhost/parser.jakt
@@ -2058,7 +2058,7 @@ struct Parser {
                 Identifier(name, span) => {
                     alias.alias_name = ParsedName(
                         name
-                        name_span: span
+                        span
                     )
                     .index++
                 }

--- a/selfhost/typechecker.jakt
+++ b/selfhost/typechecker.jakt
@@ -2634,7 +2634,7 @@ struct Typechecker {
         }
     }
 
-    fn typecheck_enum_constructor(mut this, record: ParsedRecord, enum_id: EnumId, parent_scope_id: ScopeId) throws {
+    fn typecheck_enum_constructor(mut this, parsed_record: ParsedRecord, enum_id: EnumId, parent_scope_id: ScopeId) throws {
         mut next_constant_value = 0u64
         mut seen_names: {String} = {}
 
@@ -2658,7 +2658,7 @@ struct Typechecker {
             common_fields.push(field.variable_id)
         }
 
-        match record.record_type {
+        match parsed_record.record_type {
             ValueEnum(underlying_type, variants) => {
                 let underlying_type_id = .typecheck_typename(parsed_type: underlying_type, scope_id: parent_scope_id, name: None)
                 mut module = .current_module()
@@ -3191,7 +3191,7 @@ struct Typechecker {
             .add_var_to_scope(
                 scope_id: check_scope!,
                 name: parameter.variable.name,
-                variable: var_id,
+                var_id,
                 span: parameter.variable.span,
             )
         }
@@ -5967,7 +5967,7 @@ struct Typechecker {
     ) throws -> CheckedExpression => match expr {
         IndexedStruct(expr, field_name, span, is_optional) => .typecheck_indexed_struct(expr, field_name, scope_id, is_optional, safety_mode, span)
         Boolean(val, span) => {
-            .unify_with_type(found_type: builtin(BuiltinType::Bool), expected_type: type_hint, rhs_span: span)
+            .unify_with_type(found_type: builtin(BuiltinType::Bool), expected_type: type_hint, span)
             yield CheckedExpression::Boolean(val, span)
         }
         NumericConstant(val, span) => {
@@ -6709,7 +6709,7 @@ struct Typechecker {
         }
         mut checked_namespaces: [CheckedNamespace] = []
         while i < min_length {
-            checked_namespaces.push(CheckedNamespace(name: namespace_[i], scope_id: scope))
+            checked_namespaces.push(CheckedNamespace(name: namespace_[i], scope))
             i++
         }
 
@@ -8416,37 +8416,19 @@ struct Typechecker {
     }
 
     fn validate_argument_label(mut this, param: CheckedParameter, label: String, span: Span, expr: ParsedExpression, default_value: CheckedExpression?) throws -> bool {
-        if label == param.variable.name {
+        let name = .get_argument_name(arg: (label, span, expr))
+        if name == param.variable.name {
             return true
         }
-        match expr {
-            Var(name, span) => {
-                if name == param.variable.name {
-                    return true
-                }
-                if not default_value.has_value() {
-                    .error(format("Wrong parameter name in argument label (got '{}', expected '{}')", name, param.variable.name), span)
-                }
-                return false
-            }
-            UnaryOp(expr, op) => {
-                if op is Reference or op is MutableReference or op is Dereference {
-                    if expr is Var(name, span) {
-                        if name == param.variable.name {
-                            return true
-                        }
-                        if not default_value.has_value() {
-                            .error(format("Wrong parameter name in argument label (got ‘{}’, expected ‘{}’)", name, param.variable.name), span)
-                        }
-                        return false
-                    }
-                }
-            }
-            else => {}
-        }
+
         if not default_value.has_value() {
-            .error(format("Wrong parameter name in argument label (got '{}', expected '{}')", label, param.variable.name), span)
+            if label.is_empty() {
+                .error(format("Missing argument label (expected '{}:')", param.variable.name), expr.span())
+            } else {
+                .error(format("Wrong parameter name in argument label (got '{}', expected '{}')", label, param.variable.name), span)
+            }
         }
+
         return false
     }
 

--- a/selfhost/typechecker.jakt
+++ b/selfhost/typechecker.jakt
@@ -8313,7 +8313,9 @@ struct Typechecker {
             for arg in call.args {
                 for field in struct_.fields {
                     let variable = .get_variable(field.variable_id)
-                    if (variable.name == arg.0 and variable.visibility is Private) {
+
+                    let name = .get_argument_name(arg)
+                    if (variable.name == name and variable.visibility is Private) {
                         .error(format("Can't access field '{}' when calling implicit constructor of '{}' because it is marked private", variable.name, struct_.name), arg.1)
                         return
                     }

--- a/selfhost/typechecker.jakt
+++ b/selfhost/typechecker.jakt
@@ -8450,6 +8450,28 @@ struct Typechecker {
         return false
     }
 
+    fn get_argument_name(this, arg: (String, Span, ParsedExpression)) -> String {
+        if not arg.0.is_empty() {
+            return arg.0
+        }
+
+        match arg.2 {
+            Var(name) => {
+                return name
+            }
+            UnaryOp(expr, op) => {
+                if op is Reference or op is MutableReference or op is Dereference {
+                    if expr is Var(name) {
+                        return name
+                    }
+                }
+            }
+            else => {}
+        }
+
+        return ""
+    }
+
     fn find_all_implementations_of_trait(mut this, type_id: TypeId, trait_id: TraitId) throws -> [[TypeId]] {
         return match .get_type(type_id) {
             Struct(struct_id) | GenericInstance(id: struct_id) => {

--- a/tests/typechecker/class_private_field_ctr_no_label.jakt
+++ b/tests/typechecker/class_private_field_ctr_no_label.jakt
@@ -1,0 +1,12 @@
+/// Expect:
+/// - error: "Can't access field 'private_field' when calling implicit constructor of 'Foo' because it is marked private\n"
+
+class Foo {
+    private_field: i64
+    public public_field: i64
+}
+
+fn main() {
+    let private_field = 1
+    let object = Foo(private_field, public_field: 42)
+}

--- a/tests/typechecker/no_argument_label_when_required.jakt
+++ b/tests/typechecker/no_argument_label_when_required.jakt
@@ -1,5 +1,5 @@
 /// Expect:
-/// - error: "Wrong parameter name in argument label"
+/// - error: "Missing argument label (expected 'a:')"
 
 fn foo(a: bool, b: bool) {
 }

--- a/tests/typechecker/wrong_parameter_name_in_arg_label.jakt
+++ b/tests/typechecker/wrong_parameter_name_in_arg_label.jakt
@@ -1,0 +1,9 @@
+/// Expect:
+/// - error: "Wrong parameter name in argument label (got 'bad', expected 'good')\n"
+
+fn test(good: i64) {}
+
+fn main() {
+    let variable = 2
+    test(bad: variable)
+}

--- a/tests/typechecker/wrong_parameter_name_in_arg_label_with_matching_name.jakt
+++ b/tests/typechecker/wrong_parameter_name_in_arg_label_with_matching_name.jakt
@@ -1,0 +1,9 @@
+/// Expect:
+/// - error: "Wrong parameter name in argument label (got 'bad', expected 'good')\n"
+
+fn test(good: i64) {}
+
+fn main() {
+    let good = 2
+    test(bad: good)
+}


### PR DESCRIPTION
1. Don't allow overriding the argument label when the label is **required**, but argument name matches the parameter name (as opposed to the fix in 5c0b593 which only fixed situations where the label was explicitly **not required** (it somehow went under my radar)). This is done by using the `get_argument_name()` in `validate_argument_label()`, which returns the label first, if it exists, so if it exists, we later only compare the label with the parameter name during validation

2. When the argument label doesn't match the parameter name and argument name is retrievable, but it also doesn't match the parameter name - don't highlight the **argument name** when printing an error, highlight the **wrong label**. This is a side effect of using `get_argument_name()` in `validate_argument_label()` as described in the commit message

Previously:
```
Error: Wrong parameter name in argument label (got 'variable', expected 'good')
───┬─ ./tests/typechecker/wrong_parameter_name_in_argument_label.jakt:8:15
 7 │     let variable = 2 
 8 │     test(bad: variable) 
   │                      ╰─ Wrong parameter name in argument label (got 'variable', expected 'good')
 9 │ } 
───┴─
```

Now:
```
Error: Wrong parameter name in argument label (got 'bad', expected 'good')
───┬─ ./tests/typechecker/wrong_parameter_name_in_argument_label.jakt:8:10
 7 │     let variable = 2 
 8 │     test(bad: variable) 
   │            ╰─ Wrong parameter name in argument label (got 'bad', expected 'good')
 9 │ } 
───┴─
```
Note the `got 'bad'` instead of `got 'variable'`

---
Previously:
```
Error: Wrong parameter name in argument label (got '', expected 'good')
───┬─ ./tests/typechecker/wrong_parameter_name_in_arg_label.jakt:8:10
 7 │     let variable = 2 
 8 │     test(variable) 
   │                 ╰─ Wrong parameter name in argument label (got 'variable', expected 'good')
 9 │ } 
```
Now:
```
Error: Wrong parameter name in argument label (got '', expected 'good')
───┬─ ./tests/typechecker/wrong_parameter_name_in_arg_label.jakt:8:10
 7 │     let variable = 2 
 8 │     test(variable) 
   │                 ╰─ Wrong parameter name in argument label (got '', expected 'good')
 9 │ } 
```
Note the `got ''` instead of `got 'variable'`

3. While validating the argument visibility in class/struct implicit constructor, take into account that the argument might not have a label if the argument name matches the parameter name (by using the `get_argument_name()` added in the first commit). Resolves #1326