### PR TITLE
editors/vim: Switch 'function' to 'fn'

### DIFF
--- a/editors/vim/syntax/jakt.vim
+++ b/editors/vim/syntax/jakt.vim
@@ -28,7 +28,7 @@ let s:jakt_syntax_keywords = {
     \ , 'jaktBoolean' :["true"
     \ ,                 "false"
     \ ,                ]
-    \ , 'jaktKeyword' :["function"
+    \ , 'jaktKeyword' :["fn"
     \ ,                 "extern"
     \ ,                 "import"
     \ ,                 "comptime"


### PR DESCRIPTION
A simple change as I noticed function didn't work and it's fn now :^)