### PR TITLE
editors: Switch 'function' to 'fn' in Emacs and Nano

### DIFF
--- a/editors/emacs/jakt-mode.el
+++ b/editors/emacs/jakt-mode.el
@@ -43,7 +43,7 @@
              (jakt-repeat '("while" "for" "loop"))
              (jakt-execution '("return" "break" "continue" "throw" "yield"))
              (jakt-boolean '("true" "false"))
-             (jakt-keyword '("function" "extern" "comptime"))
+             (jakt-keyword '("fn" "extern" "comptime"))
              (jakt-exception '("throws"))
              (jakt-macro '("defer" "unsafe" "throw" "try" "catch" "cpp")) 
              (jakt-var-decls '("mut" "let" "anon" "raw"))

--- a/editors/nano/jakt.nanorc
+++ b/editors/nano/jakt.nanorc
@@ -3,11 +3,11 @@
 syntax jakt "\.jakt$"
 comment "//"
 # Function definitions
-color magenta "function [a-z_0-9]+"
+color magenta "fn [a-z_0-9]+"
 color magenta "comptime [a-z_0-9]+"
 
 # Reserved words
-color yellow "\<(and|anon|boxed|break|catch|class|continue|cpp|defer|else|enum|extern|false|for|function|comptime|if|import|in|is|let|loop|match|mut|namespace|not|or|private|public|raw|return|restricted|struct|this|throw|throws|true|try|unsafe|weak|while|yield|guard)\>"
+color yellow "\<(and|anon|boxed|break|catch|class|continue|cpp|defer|else|enum|extern|false|for|fn|comptime|if|import|in|is|let|loop|match|mut|namespace|not|or|private|public|raw|return|restricted|struct|this|throw|throws|true|try|unsafe|weak|while|yield|guard)\>"
 
 # Constants
 color magenta "[A-Z][A-Z_0-9]+"


### PR DESCRIPTION
I should have done this in 1 commit