### PR TITLE
parser+typechecker: Put type hints of for statements at the expected location

### DIFF
--- a/selfhost/parser.jakt
+++ b/selfhost/parser.jakt
@@ -520,7 +520,7 @@ boxed enum ParsedStatement {
     Block(block: ParsedBlock, span: Span)
     Loop(block: ParsedBlock, span: Span)
     While(condition: ParsedExpression, block: ParsedBlock, span: Span)
-    For(iterator_name: String, name_span: Span, range: ParsedExpression, block: ParsedBlock, span: Span)
+    For(iterator_name: String, name_span: Span, is_destructuring: bool, range: ParsedExpression, block: ParsedBlock, span: Span)
     Break(Span)
     Continue(Span)
     Return(expr: ParsedExpression?, span: Span)
@@ -4107,9 +4107,11 @@ struct Parser {
         let range = .parse_expression(allow_assignments: false, allow_newlines: false)
         .can_have_trailing_closure = previous_can_have_trailing_closure
 
+        mut is_destructuring = false
         mut block = .parse_block();
 
         if destructured_var_decls.size() > 0 {
+            is_destructuring = true
             mut tuple_var_name = "jakt__"
             tuple_var_name += iterator_name
             mut tuple_var_decl = ParsedVarDecl(
@@ -4128,7 +4130,7 @@ struct Parser {
             block.stmts = block_stmts
         }
 
-        return ParsedStatement::For(iterator_name, name_span, range, block, span: merge_spans(start_span, .previous().span()))
+        return ParsedStatement::For(iterator_name, name_span, is_destructuring, range, block, span: merge_spans(start_span, .previous().span()))
     }
 
     fn parse_if_statement(mut this) throws -> ParsedStatement {

--- a/selfhost/parser.jakt
+++ b/selfhost/parser.jakt
@@ -1354,6 +1354,11 @@ struct ParsedVarDecl {
     }
 }
 
+struct ParsedVarDeclTuple {
+    var_decls: [ParsedVarDecl]
+    span: Span
+}
+
 struct ParsedField {
     // FIXME: It would be nice to extend the ParsedVarDecl struct instead.
     var_decl: ParsedVarDecl
@@ -3703,8 +3708,10 @@ struct Parser {
         }
     }
 
-    fn parse_destructuring_assignment(mut this, is_mutable: bool) throws -> [ParsedVarDecl] {
+    fn parse_destructuring_assignment(mut this, is_mutable: bool) throws -> ParsedVarDeclTuple {
+        let start = .current().span()
         .index++
+
         mut var_declarations: [ParsedVarDecl] = []
 
         loop {
@@ -3717,16 +3724,20 @@ struct Parser {
                 }
                 RParen => {
                     .index++
-                    return var_declarations
+                    break
                 }
                 else => {
                     .error("Expected close of destructuring assignment block", .current().span())
-                    return []
+                    var_declarations = []
+                    break
                 }
             }
         }
 
-        return []
+        return ParsedVarDeclTuple(
+            var_decls: var_declarations,
+            span: merge_spans(start, .previous().span())
+        )
     }
 
     fn parse_variable_declaration(mut this, is_mutable: bool) throws -> ParsedVarDecl {
@@ -3954,7 +3965,7 @@ struct Parser {
                 )
 
                 if .current() is LParen {
-                    vars = .parse_destructuring_assignment(is_mutable)
+                    vars = .parse_destructuring_assignment(is_mutable).var_decls
                     for var in vars {
                         tuple_var_name += var.name
                         tuple_var_name += "_"
@@ -4060,18 +4071,22 @@ struct Parser {
         mut iterator_name = ""
         mut destructured_var_decls: [ParsedVarDecl] = []
 
+        mut name_span = .current().span()
+
         match .current() {
             Identifier(name) => {
                 iterator_name = name
                 .index++
             }
             LParen => {
-                destructured_var_decls = .parse_destructuring_assignment(is_mutable: false)
+                let destructured_assignment = .parse_destructuring_assignment(is_mutable: false)
+                destructured_var_decls = destructured_assignment.var_decls
                 mut tuple_var_name = ""
                 for var in destructured_var_decls {
                     tuple_var_name += var.name
                     tuple_var_name += "__"
                 }
+                name_span = destructured_assignment.span
                 iterator_name = tuple_var_name
             }
             else => {
@@ -4080,7 +4095,6 @@ struct Parser {
             }
         }
 
-        let name_span = .current().span()
         if .current() is In {
             .index++
         } else {

--- a/selfhost/typechecker.jakt
+++ b/selfhost/typechecker.jakt
@@ -4696,7 +4696,7 @@ struct Typechecker {
         DestructuringAssignment(vars, var_decl, span) => .typecheck_destructuring_assignment(vars, var_decl, scope_id, safety_mode, span)
         If(condition, then_block, else_statement, span) => .typecheck_if(condition, then_block, else_statement, scope_id, safety_mode, span)
         Garbage(span) => CheckedStatement::Garbage(span)
-        For(iterator_name, name_span, range, block, span) => .typecheck_for(iterator_name,  name_span, range, block, scope_id, safety_mode, span)
+        For(iterator_name, name_span, is_destructuring, range, block, span) => .typecheck_for(iterator_name, name_span, is_destructuring, range, block, scope_id, safety_mode, span)
         Guard(expr, else_block, remaining_code, span) => .typecheck_guard(expr, else_block, remaining_code, scope_id, safety_mode, span)
     }
 
@@ -4764,6 +4764,7 @@ struct Typechecker {
         mut this
         iterator_name: String
         name_span: Span
+        is_destructuring: bool
         range: ParsedExpression
         block: ParsedBlock
         scope_id: ScopeId
@@ -4952,7 +4953,12 @@ struct Typechecker {
                                     // FIXME: loop variable mutability should be independent
                                     // of iterable mutability
                                     is_mutable: true,
-                                    inlay_span: name_span,
+                                    inlay_span: match is_destructuring {
+                                        // No need for a type hint on the tuple as a whole when destructuring,
+                                        // as each of its constituents already gets one.
+                                        true => None
+                                        else => name_span
+                                    },
                                     span: name_span
                                 ),
                                 init: ParsedExpression::ForcedUnwrap(


### PR DESCRIPTION
* Place the type hint of the iteration variable right next to the variable declaration, instead of after `in`.
* Don't show type hints for tuples when destructuring, as each of the constituent already gets a type hint. (Like regular destructuring assignments.)

Before:
![image](https://user-images.githubusercontent.com/204831/218870714-781ca55a-ff65-45aa-bfad-db33364dd6af.png)
![image](https://user-images.githubusercontent.com/204831/218870904-b2efda90-6491-46c6-b975-2efd583f6c0f.png)
![image](https://user-images.githubusercontent.com/204831/218871043-4aae64df-a81c-4b9b-b683-625a91ac6c91.png)

After:
![image](https://user-images.githubusercontent.com/204831/218871990-8dad63d2-ff59-4c49-bdf9-f73892d353b8.png)
![image](https://user-images.githubusercontent.com/204831/218872158-47f42778-5a2a-4668-adbe-bf10c6e2ff65.png)
![image](https://user-images.githubusercontent.com/204831/218872108-63891da3-90c6-412c-9a06-d56dd7c6df0d.png)
