### PR TITLE
types: Make try-catch use the same control flow resolution as if-else

### DIFF
--- a/selfhost/types.jakt
+++ b/selfhost/types.jakt
@@ -1579,6 +1579,13 @@ boxed enum CheckedExpression {
             true => BlockControlFlow::NeverReturns
             else => BlockControlFlow::MayReturn
         }
+        TryBlock(stmt, catch_block) => {
+            guard stmt is Block(block) else {
+                panic("Try block doesn't have a block")
+            }
+
+            yield block.control_flow.branch_unify_with(catch_block.control_flow)
+        }
         else => BlockControlFlow::MayReturn
     }
 }

--- a/tests/typechecker/control_flow_try_catch.jakt
+++ b/tests/typechecker/control_flow_try_catch.jakt
@@ -1,0 +1,16 @@
+/// Expect:
+/// - error: "Unreachable code"
+
+fn test() -> i64 {
+    try {
+        return 1
+    } catch err {
+        abort()
+    }
+
+    println("Unreachable")
+}
+
+fn main() {
+    test()
+}


### PR DESCRIPTION
In theory fixes #1365 (and probably many more situations), unfortunately we can't currently `return` from `try` blocks.