### PR TITLE
runtime: Make slicing an array slice with a non-zero offset work

### DIFF
--- a/runtime/Builtins/DynamicArray.h
+++ b/runtime/Builtins/DynamicArray.h
@@ -446,7 +446,7 @@ public:
 
     ArraySlice<T> slice_range(size_t from, size_t to) const
     {
-        return slice(from + m_offset, to - from + m_offset);
+        return slice(from + m_offset, to - from);
     }
 
     ArraySlice<T> slice(size_t offset, size_t size) const;

--- a/tests/runtime/array_slice_of_slice.jakt
+++ b/tests/runtime/array_slice_of_slice.jakt
@@ -1,0 +1,6 @@
+/// Expect:
+/// - output: "4\n"
+
+fn main() {
+    println("{}", [1u8; 100][50..][0..4].size())
+}


### PR DESCRIPTION
We were incorrectly adding the slice offset to the size of the subslice, which made them too large if the offset was non-zero.