### PR TITLE
runtime: Make it possible to compare two array slices

### DIFF
--- a/runtime/Builtins/DynamicArray.h
+++ b/runtime/Builtins/DynamicArray.h
@@ -475,6 +475,26 @@ public:
         return at(size() - 1);
     }
 
+    operator Span<T const>() const
+    {
+        return { unsafe_data(), size() };
+    }
+
+    T* unsafe_data()
+    {
+        return m_storage->unsafe_data() + m_offset;
+    }
+
+    T const* unsafe_data() const
+    {
+        return m_storage->unsafe_data() + m_offset;
+    }
+
+    bool operator==(ArraySlice const& other) const
+    {
+        return static_cast<Span<T const>>(*this) == static_cast<Span<T const>>(other);
+    }
+
 private:
     RefPtr<DynamicArrayStorage<T>> m_storage;
     size_t m_offset { 0 };

--- a/tests/runtime/array_slice_equality.jakt
+++ b/tests/runtime/array_slice_equality.jakt
@@ -1,0 +1,10 @@
+/// Expect:
+/// - output: "true\nfalse\ntrue\n"
+
+fn main() {
+    let array1 = [1, 2, 3]
+    let array2 = [4, 5, 6, 1, 2, 3]
+    println("{}", array1[0..0] == array2[0..0]) // true
+    println("{}", array1[..] == array2[..]) // false
+    println("{}", array1[..] == array2[3..]) // true
+}


### PR DESCRIPTION
Code generation already assumed that slices have `operator==()`, which they didn't. :^)