### PR TITLE
parser: Don't incorrectly error when value enum has eof after ending `}`

### DIFF
--- a/selfhost/parser.jakt
+++ b/selfhost/parser.jakt
@@ -2675,7 +2675,6 @@ struct Parser {
                     }
                 }
                 RCurly => {
-                    .index++
                     break
                 }
                 Comma | Eol => {
@@ -2731,10 +2730,12 @@ struct Parser {
             }
         }
 
-        if .eof() {
+        if not .current() is RCurly {
             .error("Invalid enum definition, expected `}`", .current().span())
             return (variants, methods)
         }
+
+        .index++
 
         if variants.is_empty() {
             .error("Empty enums are not allowed", partial_enum.name_span)

--- a/tests/parser/value_enum_eof_after_right_curly.jakt
+++ b/tests/parser/value_enum_eof_after_right_curly.jakt
@@ -1,0 +1,11 @@
+/// Expect:
+/// - output: "42\n"
+
+fn main() {
+    let x = Test::A
+    println("{}", x as! i64)
+}
+
+enum Test : i64 {
+    A = 42
+}


### PR DESCRIPTION
By applying the same logic as in the normal enums.

Spotted in https://youtu.be/IRT5wGTH4iY?t=282