### PR TITLE
Unsafe functions

### DIFF
--- a/selfhost/parser.jakt
+++ b/selfhost/parser.jakt
@@ -1786,13 +1786,30 @@ struct Parser {
                 Extern => {
                     .index++
                     match .current() {
+                        Unsafe => {
+                            .index++
+                            if .current() is Fn {
+                                mut parsed_function = .parse_function(
+                                    FunctionLinkage::External
+                                    Visibility::Public
+                                    is_comptime: false
+                                    is_destructor: false
+                                    is_unsafe: true
+                                )
+                                .apply_attributes(&mut parsed_function, &active_attributes)
+                                active_attributes = []
+                                parsed_namespace.functions.push(parsed_function)
+                            } else {
+                                .error("Expected 'fn' after 'unsafe'", .current().span())
+                            }
+                        }
                         Fn => {
                             mut parsed_function = .parse_function(
                                 FunctionLinkage::External
                                 Visibility::Public
                                 is_comptime: false
                                 is_destructor: false
-                                is_unsafe: false // FIXME: Parse extern unsafe functions.
+                                is_unsafe: false
                             )
                             .apply_attributes(&mut parsed_function, &active_attributes)
                             active_attributes = []

--- a/selfhost/parser.jakt
+++ b/selfhost/parser.jakt
@@ -371,6 +371,7 @@ struct ParsedFunction {
     must_instantiate: bool
     is_comptime: bool
     is_fat_arrow: bool
+    is_unsafe: bool
 
     external_name: String? = None
     deprecated_message: String? = None // if not None, the function is deprecated
@@ -1716,12 +1717,30 @@ struct Parser {
                         .index += 1
                     }
                 }
+                Unsafe => {
+                    .index++
+                    if .current() is Fn {
+                        mut parsed_function = .parse_function(
+                            FunctionLinkage::Internal
+                            Visibility::Public
+                            is_comptime: .current() is Comptime
+                            is_destructor: false
+                            is_unsafe: true
+                        )
+                        .apply_attributes(&mut parsed_function, &active_attributes)
+                        active_attributes = []
+                        parsed_namespace.functions.push(parsed_function)
+                    } else {
+                        .error("Expected 'fn' after 'unsafe'", .current().span())
+                    }
+                }
                 Fn | Comptime => {
                     mut parsed_function = .parse_function(
                         FunctionLinkage::Internal
                         Visibility::Public
                         is_comptime: .current() is Comptime
                         is_destructor: false
+                        is_unsafe: false
                     )
                     .apply_attributes(&mut parsed_function, &active_attributes)
                     active_attributes = []
@@ -1773,6 +1792,7 @@ struct Parser {
                                 Visibility::Public
                                 is_comptime: false
                                 is_destructor: false
+                                is_unsafe: false // FIXME: Parse extern unsafe functions.
                             )
                             .apply_attributes(&mut parsed_function, &active_attributes)
                             active_attributes = []
@@ -2249,6 +2269,7 @@ struct Parser {
                         Visibility::Public
                         is_comptime: false
                         is_destructor: false
+                        is_unsafe: false // FIXME: Parse unsafe trait methods(?)
                         allow_missing_body: true
                     )
                     if method.block.stmts.is_empty() {
@@ -2720,6 +2741,7 @@ struct Parser {
                         is_override: false
                         is_comptime
                         is_destructor: false
+                        is_unsafe: false // FIXME: Parse unsafe methods.
                     )
 
                     methods.push(parsed_method)
@@ -2873,7 +2895,15 @@ struct Parser {
                     last_visibility = None
                     last_visibility_span = None
 
-                    let parsed_method = .parse_method(function_linkage, visibility, is_virtual: false, is_override: false, is_comptime, is_destructor: false)
+                    let parsed_method = .parse_method(
+                        function_linkage
+                        visibility
+                        is_virtual: false
+                        is_override: false
+                        is_comptime
+                        is_destructor: false
+                        is_unsafe: false // FIXME: Parse unsafe methods.
+                    )
 
                     methods.push(parsed_method)
                 }
@@ -3100,7 +3130,15 @@ struct Parser {
                     last_virtual = false
                     last_override = false
 
-                    mut parsed_method = .parse_method(function_linkage, visibility, is_virtual, is_override, is_comptime, is_destructor)
+                    mut parsed_method = .parse_method(
+                        function_linkage
+                        visibility
+                        is_virtual
+                        is_override
+                        is_comptime
+                        is_destructor
+                        is_unsafe: false // FIXME: Parse unsafe methods.
+                    )
                     .apply_attributes(&mut parsed_method, &active_attributes)
                     active_attributes = []
 
@@ -3384,6 +3422,7 @@ struct Parser {
         anon visibility: Visibility
         is_comptime: bool
         is_destructor: bool
+        is_unsafe: bool
         allow_missing_body: bool = false
     ) throws -> ParsedFunction {
         mut parsed_function = ParsedFunction(
@@ -3401,6 +3440,7 @@ struct Parser {
             must_instantiate: false,
             is_comptime
             is_fat_arrow: false
+            is_unsafe
         )
 
         if is_destructor {
@@ -3523,8 +3563,8 @@ struct Parser {
         )
     }
 
-    fn parse_method(mut this, anon linkage: FunctionLinkage, anon visibility: Visibility, is_virtual: bool, is_override: bool, is_comptime: bool, is_destructor: bool) throws -> ParsedMethod {
-        mut parsed_function = .parse_function(linkage, visibility, is_comptime, is_destructor)
+    fn parse_method(mut this, anon linkage: FunctionLinkage, anon visibility: Visibility, is_virtual: bool, is_override: bool, is_comptime: bool, is_destructor: bool, is_unsafe: bool) throws -> ParsedMethod {
+        mut parsed_function = .parse_function(linkage, visibility, is_comptime, is_destructor, is_unsafe)
 
         if linkage is External {
             parsed_function.must_instantiate = true

--- a/selfhost/typechecker.jakt
+++ b/selfhost/typechecker.jakt
@@ -1985,6 +1985,7 @@ struct Typechecker {
                 is_comptime: func.is_comptime
                 is_virtual: false
                 is_override: false
+                is_unsafe: func.is_unsafe
             )
 
             let function_id = module.add_function(checked_function)
@@ -2158,6 +2159,7 @@ struct Typechecker {
                 is_comptime: false
                 is_virtual: false
                 is_override: false
+                is_unsafe: false
                 external_name: parsed_record.external_name
             )
 
@@ -2684,6 +2686,7 @@ struct Typechecker {
                                 is_comptime: false
                                 is_virtual: false
                                 is_override: false
+                                is_unsafe: false
                             )
                             let function_id = module.add_function(checked_function)
                             .add_function_to_scope(
@@ -2748,6 +2751,7 @@ struct Typechecker {
                                 is_comptime: false
                                 is_virtual: false
                                 is_override: false
+                                is_unsafe: false
                             )
                             let function_id = module.add_function(checked_function)
                             .add_function_to_scope(
@@ -2799,6 +2803,7 @@ struct Typechecker {
                                 is_comptime: false
                                 is_virtual: false
                                 is_override: false
+                                is_unsafe: false
                             )
                             let function_id = module.add_function(checked_function)
                             .add_function_to_scope(
@@ -3184,6 +3189,7 @@ struct Typechecker {
             is_comptime: parsed_function.is_comptime
             is_virtual: false
             is_override: false
+            is_unsafe: parsed_function.is_unsafe
             external_name: parsed_function.external_name
             deprecated_message: parsed_function.deprecated_message
         )
@@ -4433,6 +4439,7 @@ struct Typechecker {
                 is_comptime: false
                 is_virtual: false
                 is_override: false
+                is_unsafe: false
             )
             mut module = .current_module()
             let function_id = module.add_function(checked_function)
@@ -8431,6 +8438,10 @@ struct Typechecker {
                 let callee = .get_function(resolved_function_id!)
                 callee_throws = callee.can_throw
                 return_type = callee.return_type_id
+
+                if callee.is_unsafe and safety_mode is Safe {
+                    .error("Cannot call unsafe function in safe context", span)
+                }
 
                 // We've now seen all the arguments and should be able to substitute the return type, if it's contains a
                 // type variable. For the moment, we'll just checked to see if it's a type variable.

--- a/selfhost/types.jakt
+++ b/selfhost/types.jakt
@@ -746,6 +746,7 @@ class CheckedFunction {
     public is_comptime: bool
     public is_virtual: bool
     public is_override: bool
+    public is_unsafe: bool
     public specialization_index: usize? = None
 
     public owner_scope: ScopeId? = None
@@ -784,6 +785,7 @@ class CheckedFunction {
         is_comptime: .is_comptime
         is_virtual: .is_virtual
         is_override: .is_override
+        is_unsafe: .is_unsafe
         specialization_index: .specialization_index
         owner_scope: .owner_scope
         external_name: .external_name
@@ -2363,6 +2365,7 @@ class CheckedProgram {
                     is_comptime: previous_function.is_comptime
                     is_virtual: previous_function.is_virtual
                     is_override: previous_function.is_override
+                    is_unsafe: previous_function.is_unsafe
                 )
 
                 let new_function_id = .modules[module_id.id].add_function(checked_function: new_function)

--- a/tests/typechecker/unsafe_extern_function_call_bad.jakt
+++ b/tests/typechecker/unsafe_extern_function_call_bad.jakt
@@ -1,0 +1,17 @@
+/// Expect:
+/// - error: "Cannot call unsafe function in safe context"
+
+import extern c "string.h" {
+    extern unsafe fn memcpy(destination: raw i64, source: raw i64, byte_count: usize)
+}
+
+fn main() {
+    mut x = 123
+    mut y = 456
+    memcpy(
+        destination: &raw x
+        source: &raw y
+        byte_count: sizeof i64
+    )
+    println("x: {}, y: {}", x, y)
+}

--- a/tests/typechecker/unsafe_extern_function_call_good.jakt
+++ b/tests/typechecker/unsafe_extern_function_call_good.jakt
@@ -1,0 +1,19 @@
+/// Expect:
+/// - output: "x: 456, y: 456\n"
+
+import extern c "string.h" {
+    extern unsafe fn memcpy(destination: raw i64, source: raw i64, byte_count: usize)
+}
+
+fn main() {
+    mut x = 123
+    mut y = 456
+    unsafe {
+        memcpy(
+            destination: &raw x
+            source: &raw y
+            byte_count: sizeof i64
+        )
+    }
+    println("x: {}, y: {}", x, y)
+}

--- a/tests/typechecker/unsafe_function_call_bad.jakt
+++ b/tests/typechecker/unsafe_function_call_bad.jakt
@@ -1,0 +1,10 @@
+/// Expect:
+/// - error: "Cannot call unsafe function in safe context"
+
+unsafe fn hello() {
+    println("I am unsafe")
+}
+
+fn main() {
+    hello()
+}

--- a/tests/typechecker/unsafe_function_call_good.jakt
+++ b/tests/typechecker/unsafe_function_call_good.jakt
@@ -1,0 +1,12 @@
+/// Expect:
+/// - output: "I am unsafe\n"
+
+unsafe fn hello() {
+    println("I am unsafe")
+}
+
+fn main() {
+    unsafe {
+        hello()
+    }
+}


### PR DESCRIPTION
This PR adds support for marking functions `unsafe`.

Unsafe functions cannot be called in a safe context, you must enter an `unsafe {}` block first.

This first cut supports free functions and extern functions. Methods, etc, are left for our future selves :^)