### PR TITLE
runtime: Pin version of serenity before RefPtr const-correctness changes

### DIFF
--- a/runtime/CMakeLists.txt
+++ b/runtime/CMakeLists.txt
@@ -2,8 +2,8 @@ include(FetchContent)
 
 FetchContent_Declare(Serenity
     GIT_REPOSITORY https://github.com/serenityos/serenity.git
-    GIT_TAG origin/master
-    GIT_SHALLOW TRUE
+    GIT_TAG 33e87d16271bc09ae63456e890af556b65a2f1cd # FIXME: Issue 1385, revert and restore shallow clone
+    GIT_SHALLOW FALSE
     SOURCE_DIR serenity
     EXCLUDE_FROM_ALL
 )


### PR DESCRIPTION
https://github.com/SerenityOS/serenity/pull/17557 has conflicts with how we do codegen of class types. For one, const-ness is not a property of the type, but the binding. We need to figure out a way to pass this information to codegen_struct_type so that it can generate const-correct code.

Ref #1385. The true fix will need some elbow grease.