### PR TITLE
selfhost: Add `is None` operator

### DIFF
--- a/samples/basics/is_none.jakt
+++ b/samples/basics/is_none.jakt
@@ -1,0 +1,14 @@
+/// Expect:
+/// - output: "hello there: 5\n"
+
+fn main() -> c_int {
+    let foo: i64? = Some(5)
+
+    if foo is None {
+        println("no foo")
+        return 1
+    }
+
+    println("hello there: {}", foo!)
+    return 0
+}

--- a/selfhost/codegen.jakt
+++ b/selfhost/codegen.jakt
@@ -2010,6 +2010,7 @@ struct CodeGenerator {
                     }
                     yield "is<" + is_type + ">("
                 }
+                IsNone => "!"
                 TypeCast(cast) => {
                     mut final_type_id = cast.type_id();
                     let type = .program.get_type(final_type_id)
@@ -2095,6 +2096,7 @@ struct CodeGenerator {
                     }
                     yield suffix
                 }
+                IsNone => ").has_value()"
                 RawAddress => "))"
                 else => ")"
             }

--- a/selfhost/typechecker.jakt
+++ b/selfhost/typechecker.jakt
@@ -4512,7 +4512,7 @@ struct Typechecker {
             Negate => {
                 return .typecheck_unary_negate(expr: checked_expr, span, type_id: expr_type_id)
             }
-            Is | IsEnumVariant => {
+            Is | IsEnumVariant | IsNone => {
                 return CheckedExpression::UnaryOp(expr: checked_expr, op: checked_op, span, type_id: builtin(BuiltinType::Bool))
             }
             Sizeof => {
@@ -6509,6 +6509,18 @@ struct Typechecker {
                             if not exists and type_id.equals(unknown_type_id()) {
                                 .error(format("Enum variant {} does not exist on {}", name, .type_name(expr_type_id)), span)
                             }
+                        } else if name == "None" {
+                            let optional_struct_id = .find_struct_in_prelude("Optional")
+                            let checked_expr_type = .get_type(checked_expr.type())
+
+                            if not checked_expr_type is GenericInstance(id: optional_struct_id) {
+                                .error(
+                                    "The left-hand side of an `is None` statement must be an optional type"
+                                    checked_expr.span()
+                                )
+                            }
+
+                            operator_is = CheckedUnaryOperator::IsNone
                         } else if type_id.equals(unknown_type_id()) {
                             .error(format("Unknown type or invalid type name: {}", name), span)
                         }

--- a/selfhost/typechecker.jakt
+++ b/selfhost/typechecker.jakt
@@ -6515,7 +6515,7 @@ struct Typechecker {
 
                             if not checked_expr_type is GenericInstance(id: optional_struct_id) {
                                 .error(
-                                    "The left-hand side of an `is None` statement must be an optional type"
+                                    "The left-hand side of an `is None` statement must have a None variant"
                                     checked_expr.span()
                                 )
                             }

--- a/selfhost/types.jakt
+++ b/selfhost/types.jakt
@@ -1396,6 +1396,7 @@ enum CheckedUnaryOperator {
     TypeCast(CheckedTypeCast)
     Is(TypeId)
     IsEnumVariant(enum_variant: CheckedEnumVariant, bindings: [CheckedEnumVariantBinding], type_id: TypeId)
+    IsNone
     Sizeof(TypeId)
 }
 

--- a/tests/typechecker/enum_is_none.jakt
+++ b/tests/typechecker/enum_is_none.jakt
@@ -1,0 +1,15 @@
+/// Expect:
+/// - output: "PASS\n"
+
+enum Foo {
+    Bar
+    None
+}
+
+fn main() {
+    let foo = Foo::None
+
+    if foo is None {
+        println("PASS")
+    }
+}

--- a/tests/typechecker/is_none_type_mismatch.jakt
+++ b/tests/typechecker/is_none_type_mismatch.jakt
@@ -1,0 +1,8 @@
+/// Expect:
+/// - error: "The left-hand side of an `is None` statement must be an optional type\n"
+
+fn main() {
+    if 64 is None {
+        println("FAIL")
+    }
+}

--- a/tests/typechecker/is_none_type_mismatch.jakt
+++ b/tests/typechecker/is_none_type_mismatch.jakt
@@ -1,5 +1,5 @@
 /// Expect:
-/// - error: "The left-hand side of an `is None` statement must be an optional type\n"
+/// - error: "The left-hand side of an `is None` statement must have a None variant\n"
 
 fn main() {
     if 64 is None {


### PR DESCRIPTION
First step towards being able to doing `is` checks on optionals as if they were enums.
