### PR TITLE
typechecker: Teach match about true & false being exhaustive

### DIFF
--- a/runtime/jaktlib/platform/windows_compiler.jakt
+++ b/runtime/jaktlib/platform/windows_compiler.jakt
@@ -28,7 +28,7 @@ fn run_compiler(
         "/permissive-"
         "/utf-8"
         "-Wa,-mbig-obj"
-        match optimize { true => "/MT", else => "/MTd" }
+        match optimize { true => "/MT", false => "/MTd" }
         "-Wno-unknown-warning-option"
         "-Wno-trigraphs"
         "-Wno-parentheses-equality"

--- a/selfhost/codegen.jakt
+++ b/selfhost/codegen.jakt
@@ -671,14 +671,14 @@ struct CodeGenerator {
 
             output += match function.can_throw {
                 true => format("ErrorOr<{}>", .codegen_type(function.return_type_id))
-                else => .codegen_type(function.return_type_id)
+                false => .codegen_type(function.return_type_id)
             }
 
             output += " "
 
             let qualifier = match containing_struct.has_value() {
                 true => .codegen_type_possibly_as_namespace(type_id: containing_struct!, as_namespace: true)
-                else => ""
+                false => ""
             }
             if not qualifier.is_empty() {
                 output += qualifier
@@ -1213,7 +1213,7 @@ struct CodeGenerator {
             let naked_return_type = .codegen_type(function.return_type_id)
             let return_type = match function.can_throw {
                 true => format("ErrorOr<{}>", naked_return_type)
-                else => naked_return_type
+                false => naked_return_type
             }
             output += return_type
         }
@@ -1877,7 +1877,7 @@ struct CodeGenerator {
             let escaped_value = original_string.replace(replace: "\n", with: "\\n")
             yield match val.type_id.equals(builtin(BuiltinType::JaktString)) {
                 true => "Jakt::DeprecatedString(\"" + escaped_value + "\"sv)"
-                else => {
+                false => {
                     let error_handler = match val.may_throw { true => "TRY", else => "" }
                     yield format("{}({}::from_string_literal(\"{}\"sv))", error_handler, .codegen_type(val.type_id), escaped_value)
                 }
@@ -1894,7 +1894,7 @@ struct CodeGenerator {
         IndexedDictionary(expr, index) => "((" + .codegen_expression(expr) + ")[" + .codegen_expression(index) + "])"
         IndexedTuple(expr, index, is_optional) => match is_optional {
             true => format("(({}).map([](auto& _value) {{ return _value.template get<{}>(); }}))", .codegen_expression(expr), index)
-            else => format("(({}).template get<{}>())", .codegen_expression(expr), index)
+            false => format("(({}).template get<{}>())", .codegen_expression(expr), index)
         }
         IndexedStruct(expr, index, is_optional) => {
             mut output = ""
@@ -2269,7 +2269,7 @@ struct CodeGenerator {
             }
             let return_type = match can_throw {
                 true => format("ErrorOr<{}>", .codegen_type(return_type_id))
-                else => .codegen_type(return_type_id)
+                false => .codegen_type(return_type_id)
             }
 
             mut block_output = ""
@@ -3350,11 +3350,11 @@ struct CodeGenerator {
             Throw(expr) => "return " + .codegen_expression(expr) + ";"
             Continue => match .control_flow_state.passes_through_match {
                 true => "return JaktInternal::LoopContinue{};"
-                else => "continue;"
+                false => "continue;"
             }
             Break => match .control_flow_state.passes_through_match {
                 true => "return JaktInternal::LoopBreak{};"
-                else => "break;"
+                false => "break;"
             }
             Expression(expr) => .codegen_expression(expr) + ";"
             Defer(statement) => {
@@ -3377,10 +3377,10 @@ struct CodeGenerator {
             }
             Return(val) => match val.has_value() {
                 true => "return (" + .codegen_expression(val!) + ");"
-                else => {
+                false => {
                     yield match .current_function!.can_throw {
                         true => "return {};"
-                        else => "return;"
+                        false => "return;"
                     }
                 }
             }
@@ -3470,7 +3470,7 @@ struct CodeGenerator {
 
                 output += match else_statement.has_value() {
                     true => "else " + .codegen_statement(statement: else_statement!)
-                    else => ""
+                    false => ""
                 }
 
                 add_newline = false
@@ -3670,7 +3670,7 @@ struct CodeGenerator {
         mut output = ""
         mut current_scope_id = match skip_current {
             true => .program.get_scope(scope_id).parent
-            else => scope_id
+            false => scope_id
         }
 
         mut first = true
@@ -3981,7 +3981,7 @@ struct CodeGenerator {
 
             let qualified_namespace = match is_inline {
                 true => ""
-                else => qualified_name + "::"
+                false => qualified_name + "::"
             }
             output += format("ErrorOr<NonnullRefPtr<{}>> {}__jakt_create", class_name_with_generics, qualified_namespace)
             output += "("
@@ -4098,7 +4098,7 @@ struct CodeGenerator {
             if not function.type is Destructor {
                 output += match function.can_throw {
                     true => format("ErrorOr<{}>", .codegen_type(function.return_type_id))
-                    else => .codegen_type(function.return_type_id)
+                    false => .codegen_type(function.return_type_id)
                 }
             }
         }
@@ -4110,7 +4110,7 @@ struct CodeGenerator {
         } else {
             let qualifier = match containing_struct.has_value() {
                 true => .codegen_type_possibly_as_namespace(type_id: containing_struct!, as_namespace: true)
-                else => ""
+                false => ""
             }
             if not qualifier.is_empty() {
                 output += qualifier

--- a/selfhost/formatter.jakt
+++ b/selfhost/formatter.jakt
@@ -12,7 +12,7 @@ fn init<T>(anon xs: [T]) throws -> [T] => xs[..(xs.size() - 1)].to_array()
 
 fn collapse<T>(anon x: Optional<T>?) -> T? => match x.has_value() {
     true => x!
-    else => None
+    false => None
 }
 
 enum Entity {

--- a/selfhost/ide.jakt
+++ b/selfhost/ide.jakt
@@ -590,7 +590,7 @@ fn find_span_in_statement(program: CheckedProgram, statement: CheckedStatement, 
             if checked_var.definition_span.contains(span) {
                 let mutability = match checked_var.is_mutable {
                     true => Mutability::Mutable
-                    else => Mutability::Immutable
+                    false => Mutability::Immutable
                 }
 
                 return Some(Usage::Variable(
@@ -790,7 +790,7 @@ fn find_span_in_expression(program: CheckedProgram, expr: CheckedExpression, spa
                                     }
                                     yield Some(Usage::NameSet(cases_array))
                                 }
-                                else => None
+                                true => None
                             }
                         }
                         else => match body {
@@ -874,7 +874,7 @@ fn find_span_in_expression(program: CheckedProgram, expr: CheckedExpression, spa
             }
             yield match catch_block.has_value() {
                 true => find_span_in_block(program, block: catch_block!, span),
-                else => none
+                false => none
             }
         }
         Range(from, to) => {
@@ -919,7 +919,7 @@ fn get_function_signature(program: CheckedProgram, function_id: FunctionId) thro
 
             let separator = match is_first_param {
                 true => ""
-                else => ", "
+                false => ", "
             }
 
             generic_parameters += format("{}{}", separator, generic_type)
@@ -935,12 +935,12 @@ fn get_function_signature(program: CheckedProgram, function_id: FunctionId) thro
     for param in checked_function.params {
         let anon_value = match param.requires_label {
             true => ""
-            else => "anon "
+            false => "anon "
         }
 
         let is_mutable = match param.variable.is_mutable {
             true => "mut "
-            else => ""
+            false => ""
         }
 
         mut variable_type = program.type_name(type_id: param.variable.type_id)
@@ -952,7 +952,7 @@ fn get_function_signature(program: CheckedProgram, function_id: FunctionId) thro
 
         let separator = match is_first_param {
             true => ""
-            else => ", "
+            false => ", "
         }
 
         parameters += format("{}{}{}{}{}", separator, anon_value, is_mutable, param.variable.name, variable_type)
@@ -961,7 +961,7 @@ fn get_function_signature(program: CheckedProgram, function_id: FunctionId) thro
 
     let throws_str = match checked_function.can_throw {
         true => " throws"
-        else => ""
+        false => ""
     }
 
     mut returns = program.type_name(type_id: checked_function.return_type_id)

--- a/selfhost/interpreter.jakt
+++ b/selfhost/interpreter.jakt
@@ -574,7 +574,7 @@ fn cast_value_to_type(anon this_value: Value, anon type_id: TypeId, interpreter:
             USize(value) => Value(impl: ValueImpl::U8(value as! u8), span: this_value.span)
             else => match is_optional {
                 true => Value(impl: ValueImpl::OptionalSome(value: this_value), span: this_value.span),
-                else => this_value
+                false => this_value
             }
         }
         U16 => match this_value.impl {
@@ -584,7 +584,7 @@ fn cast_value_to_type(anon this_value: Value, anon type_id: TypeId, interpreter:
             USize(value) => Value(impl: ValueImpl::U16(value as! u16), span: this_value.span)
             else => match is_optional {
                 true => Value(impl: ValueImpl::OptionalSome(value: this_value), span: this_value.span),
-                else => this_value
+                false => this_value
             }
         }
         U32 => match this_value.impl {
@@ -594,7 +594,7 @@ fn cast_value_to_type(anon this_value: Value, anon type_id: TypeId, interpreter:
             USize(value) => Value(impl: ValueImpl::U32(value as! u32), span: this_value.span)
             else => match is_optional {
                 true => Value(impl: ValueImpl::OptionalSome(value: this_value), span: this_value.span),
-                else => this_value
+                false => this_value
             }
         }
         U64 => match this_value.impl {
@@ -604,7 +604,7 @@ fn cast_value_to_type(anon this_value: Value, anon type_id: TypeId, interpreter:
             USize(value) => Value(impl: ValueImpl::U64(value as! u64), span: this_value.span)
             else => match is_optional {
                 true => Value(impl: ValueImpl::OptionalSome(value: this_value), span: this_value.span),
-                else => this_value
+                false => this_value
             }
         }
         I8 => match this_value.impl {
@@ -613,7 +613,7 @@ fn cast_value_to_type(anon this_value: Value, anon type_id: TypeId, interpreter:
             I64(value) => Value(impl: ValueImpl::I8(value as! i8), span: this_value.span)
             else => match is_optional {
                 true => Value(impl: ValueImpl::OptionalSome(value: this_value), span: this_value.span),
-                else => this_value
+                false => this_value
             }
         }
         I16 => match this_value.impl {
@@ -622,7 +622,7 @@ fn cast_value_to_type(anon this_value: Value, anon type_id: TypeId, interpreter:
             I64(value) => Value(impl: ValueImpl::I16(value as! i16), span: this_value.span)
             else => match is_optional {
                 true => Value(impl: ValueImpl::OptionalSome(value: this_value), span: this_value.span),
-                else => this_value
+                false => this_value
             }
         }
         I32 => match this_value.impl {
@@ -631,7 +631,7 @@ fn cast_value_to_type(anon this_value: Value, anon type_id: TypeId, interpreter:
             I64(value) => Value(impl: ValueImpl::I32(value as! i32), span: this_value.span)
             else => match is_optional {
                 true => Value(impl: ValueImpl::OptionalSome(value: this_value), span: this_value.span),
-                else => this_value
+                false => this_value
             }
         }
         I64 => match this_value.impl {
@@ -640,14 +640,14 @@ fn cast_value_to_type(anon this_value: Value, anon type_id: TypeId, interpreter:
             I32(value) => Value(impl: ValueImpl::I64(value as! i64), span: this_value.span)
             else => match is_optional {
                 true => Value(impl: ValueImpl::OptionalSome(value: this_value), span: this_value.span),
-                else => this_value
+                false => this_value
             }
         }
         Usize => match this_value.impl {
             U64(value) => Value(impl: ValueImpl::USize(value as! usize), span: this_value.span)
             else => match is_optional {
                 true => Value(impl: ValueImpl::OptionalSome(value: this_value), span: this_value.span),
-                else => this_value
+                false => this_value
             }
         }
         else => match is_optional {
@@ -1278,7 +1278,7 @@ class Interpreter {
         }
         Return(val, span) => match val.has_value() {
             true => CheckedStatement::Return(val: .perform_final_interpretation_expr_pass(expr: val!, scope), span)
-            else => statement
+            false => statement
         }
         Break | Continue | InlineCpp | Garbage => statement
         Throw(expr, span) => CheckedStatement::Throw(expr: .perform_final_interpretation_expr_pass(expr, scope), span)
@@ -2611,7 +2611,7 @@ class Interpreter {
                         let value = mutable_values.pop()
                         yield match value.has_value() {
                             true => StatementResult::JustValue(value!)
-                            else => StatementResult::JustValue(Value(impl: ValueImpl::OptionalNone, span: call_span))
+                            false => StatementResult::JustValue(Value(impl: ValueImpl::OptionalNone, span: call_span))
                         }
                     }
                     else => {
@@ -2624,7 +2624,7 @@ class Interpreter {
                         let value = mutable_values.first()
                         yield match value.has_value() {
                             true => StatementResult::JustValue(value!)
-                            else => StatementResult::JustValue(Value(impl: ValueImpl::OptionalNone, span: call_span))
+                            false => StatementResult::JustValue(Value(impl: ValueImpl::OptionalNone, span: call_span))
                         }
                     }
                     else => {
@@ -2637,7 +2637,7 @@ class Interpreter {
                         let value = mutable_values.last()
                         yield match value.has_value() {
                             true => StatementResult::JustValue(value!)
-                            else => StatementResult::JustValue(Value(impl: ValueImpl::OptionalNone, span: call_span))
+                            false => StatementResult::JustValue(Value(impl: ValueImpl::OptionalNone, span: call_span))
                         }
                     }
                     else => {
@@ -2966,7 +2966,7 @@ class Interpreter {
                         yield StatementResult::JustValue(Value(
                             impl: match result.has_value() {
                                 true => ValueImpl::OptionalSome(value: Value(impl: ValueImpl::I32(result!), span: call_span))
-                                else => ValueImpl::OptionalNone()
+                                false => ValueImpl::OptionalNone()
                             }
                             span: call_span
                         ))
@@ -3350,7 +3350,7 @@ class Interpreter {
                                         span: call_span
                                     )
                                 }
-                                else => Value(impl: ValueImpl::OptionalNone, span: call_span)
+                                false => Value(impl: ValueImpl::OptionalNone, span: call_span)
                             }
                             else => {
                                 panic("Invalid DictionaryIterator configuration")
@@ -3775,7 +3775,7 @@ class Interpreter {
 
                 let block = match cond {
                     true => Some(then_block)
-                    else => match else_statement.has_value() {
+                    false => match else_statement.has_value() {
                         true => Some(CheckedBlock(
                             statements: [else_statement!]
                             scope_id: then_block.scope_id
@@ -3783,7 +3783,7 @@ class Interpreter {
                             yielded_type: None
                             yielded_none: false
                         ))
-                        else => None
+                        false => None
                     }
                 }
 
@@ -6067,7 +6067,7 @@ class Interpreter {
                         panic("Invalid control flow")
                     }
                 }
-                else => {
+                false => {
                     .error("Partial ranges are not implemented", span)
                     throw Error::from_errno(InterpretError::Unimplemented as! i32)
                 }
@@ -6091,7 +6091,7 @@ class Interpreter {
                         panic("Invalid control flow")
                     }
                 }
-                else => {
+                false => {
                     .error("Partial ranges are not implemented", span)
                     throw Error::from_errno(InterpretError::Unimplemented as! i32)
                 }
@@ -6605,7 +6605,7 @@ class Interpreter {
         })
         QuotedString(val, span) => match val.type_id.equals(builtin(BuiltinType::JaktString)) {
             true => StatementResult::JustValue(Value(impl: ValueImpl::JaktString(interpret_escapes(val.to_string())), span: span))
-            else => {
+            false => {
                 let function_id = match .program.get_type(val.type_id) {
                     Struct(struct_id) | GenericInstance(id: struct_id) => {
                         let scope = .program.get_scope(.program.get_struct(struct_id).scope_id)

--- a/selfhost/main.jakt
+++ b/selfhost/main.jakt
@@ -414,7 +414,7 @@ fn main(args: [String]) -> c_int {
                     span: call_span
                 )]
             }
-            else => []
+            false => []
         }
 
         let main_result = interpreter.execute(

--- a/selfhost/typechecker.jakt
+++ b/selfhost/typechecker.jakt
@@ -916,7 +916,7 @@ struct Typechecker {
                 let maybe_file_name = .compiler.search_for_path(name_and_span.0)
                 let file_name = match maybe_file_name.has_value() {
                     true => maybe_file_name!
-                    else => .get_root_path().parent().join(name_and_span.0).replace_extension("jakt")
+                    false => .get_root_path().parent().join(name_and_span.0).replace_extension("jakt")
                 }
                 if File::exists(file_name.to_string()) {
                     module_name_and_span = name_and_span
@@ -946,7 +946,7 @@ struct Typechecker {
             let maybe_file_name = .compiler.search_for_path(module_name)
             let file_name = match maybe_file_name.has_value() {
                 true => maybe_file_name!
-                else => .get_root_path().parent().join(module_name).replace_extension("jakt")
+                false => .get_root_path().parent().join(module_name).replace_extension("jakt")
             }
 
             let file_id = .compiler.get_file_id_or_register(file_name)
@@ -1313,7 +1313,7 @@ struct Typechecker {
         mut scope = .get_scope(scope_id)
         let alias_scope_id = match scope.alias_scope.has_value() {
             true => scope.alias_scope!
-            else => {
+            false => {
                 let new_scope_id = .create_scope(
                     parent_scope_id: scope_id
                     can_throw: false
@@ -2302,7 +2302,7 @@ struct Typechecker {
                         .error("Class can only inherit from another class", super_parsed_type!.span())
                     }
                 }
-                else => {}
+                false => {}
             }
             Struct(super_type: super_parsed_type) => match super_parsed_type.has_value() {
                 true => {
@@ -2315,7 +2315,7 @@ struct Typechecker {
                         .error("Struct can only inherit from another struct", super_parsed_type!.span())
                     }
                 }
-                else => {}
+                false => {}
             }
             else => {
                 panic("Expected Struct or Class in typecheck_struct_predecl")
@@ -2578,7 +2578,7 @@ struct Typechecker {
                                 }
                                 yield value_expression
                             }
-                            else => .cast_to_underlying(
+                            false => .cast_to_underlying(
                                 expr: ParsedExpression::NumericConstant(val: NumericConstant::U64(next_constant_value++), span: variant.span)
                                 scope_id: parent_scope_id
                                 parsed_type: underlying_type
@@ -3337,7 +3337,7 @@ struct Typechecker {
 
             let return_type_id = match function_return_type_id.equals(unknown_type_id()) {
                 true => .infer_function_return_type(block)
-                else => .resolve_type_var(type_var_type_id: function_return_type_id, scope_id: parent_scope_id)
+                false => .resolve_type_var(type_var_type_id: function_return_type_id, scope_id: parent_scope_id)
             }
 
             checked_function.block = block
@@ -3647,9 +3647,9 @@ struct Typechecker {
         If(condition, then_block, else_statement) => match condition {
             Boolean(val) => match val {
                 true => then_block.control_flow
-                else => match else_statement.has_value() {
+                false => match else_statement.has_value() {
                     true => .statement_control_flow(else_statement!)
-                    else => BlockControlFlow::MayReturn
+                    false => BlockControlFlow::MayReturn
                 }
             }
             // Note that a missing 'else' branch produces a partial result.
@@ -3674,7 +3674,7 @@ struct Typechecker {
         Loop(block) => match block.control_flow {
             AlwaysTransfersControl(might_break) => match might_break {
                 false => BlockControlFlow::AlwaysTransfersControl(might_break)
-                else => BlockControlFlow::MayReturn
+                true => BlockControlFlow::MayReturn
             }
             NeverReturns => BlockControlFlow::NeverReturns
             AlwaysReturns => BlockControlFlow::AlwaysReturns
@@ -3682,7 +3682,7 @@ struct Typechecker {
             else => match block.control_flow.may_break() {
                 true => BlockControlFlow::MayReturn
                 // Loop will always continue, so upgrade partial results to full ones
-                else => match block.control_flow {
+                false => match block.control_flow {
                     PartialAlwaysReturns => BlockControlFlow::AlwaysReturns
                     PartialNeverReturns => BlockControlFlow::NeverReturns
                     PartialAlwaysTransfersControl(might_break) => BlockControlFlow::AlwaysTransfersControl(might_break)
@@ -3696,7 +3696,7 @@ struct Typechecker {
 
     fn maybe_statement_control_flow(this, anon statement: CheckedStatement?, anon other_branch: BlockControlFlow) -> BlockControlFlow => match statement.has_value() {
         true => .statement_control_flow(statement!)
-        else => other_branch.partial()
+        false => other_branch.partial()
     }
 
     // FIXME: Use [TypeId: TypeID] without TypeId.to_string()/TypeId::from_string() workaround
@@ -3834,7 +3834,7 @@ struct Typechecker {
 
                     let rhs_throw = match rhs_can_throw {
                         true => "Yes"
-                        else => "No"
+                        false => "No"
                     }
 
                     .error(
@@ -5043,7 +5043,7 @@ struct Typechecker {
                                         // No need for a type hint on the tuple as a whole when destructuring,
                                         // as each of its constituents already gets one.
                                         true => None
-                                        else => name_span
+                                        false => name_span
                                     },
                                     span: name_span
                                 ),
@@ -6385,7 +6385,7 @@ struct Typechecker {
 
                             yield Some(struct_id ?? StructLikeId::Struct(optional_struct_id))
                         }
-                        else => Some(StructLikeId::Struct(generic_arguments: args, id))
+                        false => Some(StructLikeId::Struct(generic_arguments: args, id))
                     }
                 }
                 GenericEnumInstance(id, args) => Some(StructLikeId::Enum(generic_arguments: args, id))
@@ -8671,7 +8671,7 @@ struct Typechecker {
                 }
                 yield function.external_name
             }
-            else => None
+            false => None
         }
 
         if resolved_function_id.has_value() {

--- a/selfhost/typechecker.jakt
+++ b/selfhost/typechecker.jakt
@@ -7751,6 +7751,11 @@ struct Typechecker {
                 .error("Can't match on 'void' type", checked_expr.span())
             }
             else => {
+                let is_boolean_match = type_to_match_on is Bool
+                mut seen_true = false
+                mut seen_false = false
+                mut catch_all_span: Span? = None
+
                 mut is_enum_match = false
                 mut is_value_match = false
                 mut seen_catch_all = false
@@ -7818,6 +7823,8 @@ struct Typechecker {
                                     .error("Match else case is only allowed as the last case", case_.marker_span)
                                 }
 
+                                catch_all_span = case_.marker_span
+
                                 if seen_catch_all {
                                     .error("Multiple catch-all cases in match are not allowed", case_.marker_span)
                                 } else {
@@ -7883,6 +7890,14 @@ struct Typechecker {
                                 )
                                 let checked_expression = .typecheck_expression_and_dereference_if_needed(new_condition, scope_id, safety_mode, type_hint: Some(subject_type_id), span)
 
+                                if is_boolean_match and checked_expression is Boolean(val) {
+                                    if val {
+                                        seen_true = true
+                                    } else {
+                                        seen_false = true
+                                    }
+                                }
+
                                 if not checked_expression.to_number_constant(program: .program).has_value() {
                                     all_variants_constant = false
                                 }
@@ -7943,11 +7958,15 @@ struct Typechecker {
                     current_case_index++
                 }
 
-                if is_value_match and not seen_catch_all {
+                if is_value_match and not (seen_catch_all or (is_boolean_match and seen_true and seen_false)) {
                     .error(
-                        "match expression is not exhaustive, a value match must contain an irrefutable 'else' pattern"
+                        "Match expression is not exhaustive, a value match must contain an irrefutable 'else' pattern"
                         span
                     )
+                }
+
+                if is_value_match and seen_catch_all and is_boolean_match and seen_true and seen_false {
+                    .error("All cases are covered, but an irrefutable pattern is also present", catch_all_span!)
                 }
             }
         }

--- a/selfhost/types.jakt
+++ b/selfhost/types.jakt
@@ -1588,7 +1588,7 @@ boxed enum CheckedExpression {
         }
         MethodCall(type_id) | Call(type_id) => match type_id.equals(never_type_id()) {
             true => BlockControlFlow::NeverReturns
-            else => BlockControlFlow::MayReturn
+            false => BlockControlFlow::MayReturn
         }
         TryBlock(stmt, catch_block) => {
             guard stmt is Block(block) else {

--- a/tests/parser/match_bare_literals.jakt
+++ b/tests/parser/match_bare_literals.jakt
@@ -5,7 +5,6 @@ fn main() {
     println("{}", match true {
         true => 1
         false => 0
-        else => 2
     })
 
     println("{}", match 5 {

--- a/tests/typechecker/match_non_exhaustive_value.jakt
+++ b/tests/typechecker/match_non_exhaustive_value.jakt
@@ -1,5 +1,5 @@
 /// Expect:
-/// - error: "match expression is not exhaustive, a value match must contain an irrefutable 'else' pattern"
+/// - error: "Match expression is not exhaustive, a value match must contain an irrefutable 'else' pattern"
 
 fn main() {
     match 123 {

--- a/tests/typechecker/match_true_false_else.jakt
+++ b/tests/typechecker/match_true_false_else.jakt
@@ -1,0 +1,11 @@
+/// Expect:
+/// - error: "All cases are covered, but an irrefutable pattern is also present"
+
+fn main() {
+    let var = true
+    match var {
+        true => { println("FAIL") }
+        false => { println("FAIL") }
+        else => { println("FAIL") }
+    }
+}

--- a/tests/typechecker/match_true_false_exhaustive.jakt
+++ b/tests/typechecker/match_true_false_exhaustive.jakt
@@ -1,0 +1,10 @@
+/// Expect:
+/// - output: "PASS\n"
+
+fn main() {
+    let var = true
+    match var {
+        true => { println("PASS") }
+        false => { println("FAIL") }
+    }
+}


### PR DESCRIPTION
Also:
- change, well, most but probably not all occurrences of the `true => else =>` pattern (or much less frequently -
`false => else =>`) to the `true => false =>` pattern,
- fix one test that was affected by this (which had a `true => false => else =>` pattern, `else` obviously not reachable),
- fix one error not starting with an uppercase.

Funny business like this is still possible though:

```rust
fn main() {
    let x = false
    let y = false
    match x {
        true => { }
        false => { }
        (y == y) => { }
    }
}
```