### PR TITLE
typechecker: Allow subclass to be assigned to type of it's base class (v2)

### DIFF
--- a/samples/classes/assign_derived_to_base.jakt
+++ b/samples/classes/assign_derived_to_base.jakt
@@ -1,0 +1,17 @@
+/// Expect:
+/// - output: "PASS\n"
+
+class Base {
+    public fn test(this) {
+        println("PASS")
+    }
+}
+
+class Derived: Base {}
+
+fn main() {
+    let derived = Derived()
+    mut base: Base = Base()
+    base = derived
+    base.test()
+}

--- a/selfhost/typechecker.jakt
+++ b/selfhost/typechecker.jakt
@@ -4062,7 +4062,6 @@ struct Typechecker {
                         }
                     }
                     else => {
-                        let rhs_type = .get_type(rhs_type_id)
                         if .is_subclass_of(ancestor_type_id: lhs_type_id, child_type_id: rhs_type_id) {
                             return true
                         }

--- a/selfhost/typechecker.jakt
+++ b/selfhost/typechecker.jakt
@@ -4007,7 +4007,7 @@ struct Typechecker {
                 }
             }
             Struct(lhs_struct_id) => {
-                if lhs_type_id.equals(rhs_type_id) {
+                if lhs_type_id.equals(rhs_type_id) or .is_subclass_of(ancestor_type_id: rhs_type_id, child_type_id: lhs_type_id) {
                     return true
                 }
 
@@ -5449,11 +5449,13 @@ struct Typechecker {
 
         if lhs_type is GenericInstance(id, args) {
             if id.equals(weak_ptr_struct_id) {
-                if not lhs_type_id.equals(rhs_type_id) and not args[0].equals(rhs_type_id) and not rhs_type_id.equals(unknown_type_id()) {
+                if not lhs_type_id.equals(rhs_type_id) and not args[0].equals(rhs_type_id) and not rhs_type_id.equals(unknown_type_id())
+                   and not .is_subclass_of(ancestor_type_id: args[0], child_type_id: rhs_type_id) {
                     .error(format("Type mismatch: expected ‘{}’, but got ‘{}’", .type_name(lhs_type_id), .type_name(rhs_type_id)), checked_expr.span())
                 }
             } else if id.equals(optional_struct_id) {
-                if not lhs_type_id.equals(rhs_type_id) and not args[0].equals(rhs_type_id) and not rhs_type_id.equals(unknown_type_id()) {
+                if not lhs_type_id.equals(rhs_type_id) and not args[0].equals(rhs_type_id) and not rhs_type_id.equals(unknown_type_id())
+                   and not .is_subclass_of(ancestor_type_id: args[0], child_type_id: rhs_type_id) {
                     .error(format("Type mismatch: expected ‘{}’, but got ‘{}’", .type_name(lhs_type_id), .type_name(rhs_type_id)), checked_expr.span())
                 }
             } else {
@@ -5478,7 +5480,8 @@ struct Typechecker {
                 return CheckedStatement::Garbage(span)
             }
         } else {
-            if not lhs_type_id.equals(rhs_type_id) and not rhs_type_id.equals(unknown_type_id()) {
+            if not lhs_type_id.equals(rhs_type_id) and not rhs_type_id.equals(unknown_type_id())
+               and not .is_subclass_of(ancestor_type_id: lhs_type_id, child_type_id: rhs_type_id) {
                 .error(format("Type mismatch: expected ‘{}’, but got ‘{}’", .type_name(lhs_type_id), .type_name(rhs_type_id)), checked_expr.span())
             }
         }

--- a/tests/typechecker/assign_derived_to_base_on_declaration.jakt
+++ b/tests/typechecker/assign_derived_to_base_on_declaration.jakt
@@ -1,0 +1,16 @@
+/// Expect:
+/// - output: "PASS\n"
+
+class Base {
+    public fn test(this) {
+        println("PASS")
+    }
+}
+
+class Derived: Base {}
+
+fn main() {
+    let derived = Derived()
+    let base: Base = derived
+    base.test()
+}

--- a/tests/typechecker/assign_derived_to_optional_base_on_declaration.jakt
+++ b/tests/typechecker/assign_derived_to_optional_base_on_declaration.jakt
@@ -1,0 +1,17 @@
+/// Expect:
+/// - output: "PASS\n"
+
+class Base {
+    public fn test(this) {
+        println("PASS")
+    }
+}
+
+class Derived: Base {}
+
+fn main() {
+    let derived = Derived()
+    let base: Base? = derived
+
+    base!.test()
+}

--- a/tests/typechecker/assign_derived_to_weak_base_ptr_on_declaration.jakt
+++ b/tests/typechecker/assign_derived_to_weak_base_ptr_on_declaration.jakt
@@ -1,0 +1,17 @@
+/// Expect:
+/// - output: "PASS\n"
+
+class Base {
+    public fn test(this) {
+        println("PASS")
+    }
+}
+
+class Derived: Base {}
+
+fn main() {
+    let derived = Derived()
+    mut base: weak Base = derived
+
+    base!.test()
+}


### PR DESCRIPTION
Partially based on #1350. Resolves #1341 + assigning Derived to Optional\<Base\> and assigning Derived to Base weak ptr.