### PR TITLE
typechecker: Prohibit returning None if non-optional is expected

### DIFF
--- a/selfhost/typechecker.jakt
+++ b/selfhost/typechecker.jakt
@@ -5699,6 +5699,16 @@ struct Typechecker {
         let checked_expr = .typecheck_expression_and_dereference_if_needed(new_condition, scope_id, safety_mode, type_hint, span)
 
         if type_hint.has_value() {
+            if checked_expr is OptionalNone(span) {
+                if .get_type(type_hint!) is GenericInstance(id, args) {
+                    if not id.equals(.find_struct_in_prelude("Optional")) and not id.equals(.find_struct_in_prelude("WeakPtr")) {
+                        .error("Cannot assign None to a non-optional type", span)
+                    }
+                } else {
+                    .error("Cannot assign None to a non-optional type", span)
+                }
+            }
+
             .unify_with_type(found_type: checked_expr.type(), expected_type: type_hint!, span)
         }
 

--- a/tests/typechecker/return_none_should_return_non_optional.jakt
+++ b/tests/typechecker/return_none_should_return_non_optional.jakt
@@ -1,0 +1,12 @@
+/// Expect:
+/// - error: "Cannot assign None to a non-optional type"
+
+class A { }
+
+fn test() -> A {
+    return None
+}
+
+fn main() {
+    let a = test()
+}


### PR DESCRIPTION
Resolves #1390. This is looking kinda meh, but we do that in this way in a couple of places already