### PR TITLE
CMake: Remove fdiagnostics-color with clang-cl, and give stack size

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -76,6 +76,9 @@ target_include_directories(jakt_stage0
     $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}/runtime>
 )
 apply_output_rules(jakt_stage0)
+if (MSVC)
+    target_link_options(jakt_stage0 PRIVATE LINKER:/STACK:0x800000)
+endif()
 
 set(SELFHOST_SOURCES
   selfhost/build.jakt
@@ -148,6 +151,9 @@ target_include_directories(jakt_stage1
 )
 add_executable(Jakt::jakt_stage1 ALIAS jakt_stage1)
 apply_output_rules(jakt_stage1)
+if (MSVC)
+    target_link_options(jakt_stage1 PRIVATE LINKER:/STACK:0x800000)
+endif()
 
 if (FINAL_STAGE GREATER_EQUAL 2)
   add_jakt_executable(jakt_stage2
@@ -165,6 +171,9 @@ if (FINAL_STAGE GREATER_EQUAL 2)
   )
   add_executable(Jakt::jakt_stage2 ALIAS jakt_stage2)
   apply_output_rules(jakt_stage2)
+  if (MSVC)
+    target_link_options(jakt_stage2 PRIVATE LINKER:/STACK:0x800000)
+  endif()
 endif()
 
 # Link runtime into build directory(ies) for relative pathing usage

--- a/cmake/jakt-executable.cmake
+++ b/cmake/jakt-executable.cmake
@@ -25,7 +25,6 @@ function(add_jakt_compiler_flags target)
     -Wno-deprecated-declarations
     -Wno-unknown-warning-option
     -Wno-unused-command-line-argument
-    -fdiagnostics-color=always
     # Silence warning about `no_unique_address`;
     # It does not apply on windows, and clang-cl just warns about it.
     -Wno-unknown-attributes
@@ -34,7 +33,7 @@ function(add_jakt_compiler_flags target)
     # For clang-cl, which shows up to CMake as MSVC and accepts both kinds of arguments
     target_compile_options("${target}" PRIVATE /permissive- /utf-8 /EHsc-)
   else()
-    target_compile_options("${target}" PRIVATE -fno-exceptions)
+    target_compile_options("${target}" PRIVATE -fno-exceptions -fdiagnostics-color=always)
   endif()
   if (CYGWIN OR MSYS)
     target_compile_options("${target}" PRIVATE -Wa,-mbig-obj)


### PR DESCRIPTION
link.exe defaults to 1MiB of stack size. When using clang-cl, which defaults to linking with link.exe, provide an explicit stack size of 8MiB to better match with Unix platforms.

Fixes #1328