### PR TITLE
jakttest: Move blocking on any exiting child to `poll_process_exit`

### DIFF
--- a/jakttest/jakttest.jakt
+++ b/jakttest/jakttest.jakt
@@ -555,7 +555,20 @@ struct TestScheduler {
         return (result_output, error_output)
     }
 
+
     fn poll_running_tests(mut this) throws {
+        unsafe {
+            cpp { "#ifndef _WIN32" }
+            cpp { "sigset_t set;" }
+            cpp { "int signal;" }
+            cpp { "sigemptyset(&set);" }
+            cpp { "sigaddset(&set, SIGCHLD);" }
+            cpp { "int const sigwait_errno = sigwait(&set, &signal);" }
+            cpp { "if (sigwait_errno != 0)" }
+            cpp { "    return Error::from_errno(sigwait_errno);" }
+            cpp { "#endif" }
+        }
+        // Blocking on any exiting child is handled within the poll_process_exit method
         mut exited = process::poll_process_exit(pid: -1i32)
         while exited.has_value() {
             match .on_test_exited(pid: exited!.pid(), exit_code: exited!.exit_code()) {
@@ -572,32 +585,8 @@ struct TestScheduler {
     }
 
     fn wait_for_free_directory(mut this) throws -> usize {
-        // NOTE: `unsafe` creates its own scope (because variables *can* be
-        // created inside an unsafe block) but in turn the C++ generated is not
-        // inline, it's inside a block. Since we're using `set` to initialize it
-        // once, we can't separate initialization to a separate `unsafe` block.
-        // Maybe `unsafe inline` blocks that have the same scope as its parent
-        // scope could be a solution to this?
-        unsafe {
-            cpp { "#ifndef _WIN32" }
-            cpp { "sigset_t set;" }
-            cpp { "int signal;"   }
-            cpp { "sigemptyset(&set);" }
-            cpp { "sigaddset(&set, SIGCHLD);" }
-            cpp { "#endif" }
-
-            while .free_directories.is_empty() {
-                // wait for sigchld
-                unsafe {
-                    // Blocking on any exiting child is handled within the poll_process_exit method  on win32
-                    cpp { "#ifndef _WIN32" }
-                    cpp { "if (sigwait(&set, &signal) > 0)" }
-                    cpp { "    return Error::from_errno(errno);" }
-                    cpp { "#endif" }
-                }
-                // check if any test has exited
-                .poll_running_tests()
-            }
+        while .free_directories.is_empty() {
+            .poll_running_tests()
         }
         return .free_directories.pop()!
     }

--- a/jakttest/process.cpp
+++ b/jakttest/process.cpp
@@ -5,10 +5,10 @@
 // SPDX-License-Identifier: BSD-2-Clause
 #include "process.h"
 
-#include <Jakt/DeprecatedString.h>
 #include <AK/Assertions.h>
 #include <AK/HashMap.h>
 #include <AK/RefPtr.h>
+#include <Jakt/DeprecatedString.h>
 #include <time.h>
 #ifndef _WIN32
 #include <signal.h>
@@ -110,6 +110,8 @@ ErrorOr<Optional<ExitPollResult>> poll_process_exit(i32 pid)
         }
         return Error::from_errno(errno);
     }
+
+
     // not exited.
     if (result == 0) {
         return JaktInternal::OptionalNone {};
@@ -190,6 +192,7 @@ static ErrorOr<Optional<DWORD>> get_process_status(PROCESS_INFORMATION process)
     return Optional<DWORD> { exit_code };
 }
 
+
 static ErrorOr<Optional<ExitPollResult>> poll_any_process(DWORD timeout = 0)
 {
     if (s_process_handles.is_empty())
@@ -241,7 +244,7 @@ ErrorOr<Optional<ExitPollResult>> poll_process_exit(i32 pid)
 
     DWORD ret = WaitForSingleObject(process_handle.hProcess, 0);
     if (ret == WAIT_FAILED)
-         return Error::from_errno(last_error_to_errno(GetLastError()));
+        return Error::from_errno(last_error_to_errno(GetLastError()));
     if (ret == WAIT_TIMEOUT)
         return Optional<ExitPollResult> {};
 


### PR DESCRIPTION
Makes `sigwait` common to `poll_running_tests`, making the last waiting loop also suspend instead of polling its children.

Fixes #1228, since there's no more spinning and spamming `wait4`.