### PR TITLE
repl: Avoid showing an error when entering an empty line

### DIFF
--- a/selfhost/repl.jakt
+++ b/selfhost/repl.jakt
@@ -316,6 +316,10 @@ struct REPL {
                 break
             }
 
+            if line == "\n" {
+              continue
+            }
+
             if line == ".exit\n" {
                 break
             }


### PR DESCRIPTION
Currently the repl shows a parser error "Unsupported expression" when the user enters an empty line. This commit adds a check for the empty line and skips the loop to avoid the error.