### PR TITLE
repl: Add multiline input support

### DIFF
--- a/selfhost/repl.jakt
+++ b/selfhost/repl.jakt
@@ -31,12 +31,54 @@ struct Editor {
             throw Error::from_errno(42)
         }
 
-        let editor = Editor(
+        return Editor(
             standard_input_file: std_in
             line_pointer: allocate<c_char>(count: 4096)
             prompt
         )
-        return editor
+    }
+
+    fn check_parens(anon input: String) -> bool {
+        mut unmatched_parens   = 0
+        mut unmatched_brackets = 0
+        mut unmatched_curlies  = 0
+
+        mut pos: usize = 0
+
+        while pos < input.length() {
+            match input.byte_at(pos) {
+                b'(' => { unmatched_parens += 1   }
+                b')' => { unmatched_parens -= 1   }
+                b'[' => { unmatched_brackets += 1 }
+                b']' => { unmatched_brackets -= 1 }
+                b'{' => { unmatched_curlies += 1  }
+                b'}' => { unmatched_curlies -= 1  }
+                else => {}
+            }
+
+            pos += 1
+        }
+
+        return unmatched_parens == 0 and unmatched_brackets == 0 and unmatched_curlies == 0
+    }
+
+    fn read_next_statement(mut this) throws -> LineResult {
+        mut builder = StringBuilder::create()
+        mut prompt  = .prompt
+
+        loop {
+            match .get_line(prompt) {
+                LineResult::Line(line) => { builder.append_string(line) }
+                LineResult::Eof        => { return LineResult::Eof      }
+            }
+
+            prompt = ".."
+
+            let result = builder.to_string()
+            if check_parens(result) {
+                return LineResult::Line(result)
+            }
+        }
     }
 
     fn get_line(mut this, prompt: String? = None) throws -> LineResult {
@@ -332,7 +374,7 @@ struct REPL {
         loop {
             .handle_possible_error()
 
-            let line_result = try editor.get_line() catch error {
+            let line_result = try editor.read_next_statement() catch error {
                 return
             }
 

--- a/selfhost/repl.jakt
+++ b/selfhost/repl.jakt
@@ -3,7 +3,7 @@ import typechecker {
     InterpreterScope, LoadedModule, ModuleId, SafetyMode, ScopeId, TypeId, Typechecker, builtin
 }
 import compiler { Compiler, FileId }
-import lexer { Lexer }
+import lexer { Lexer, Token }
 import parser { Parser }
 import utility { Span, allocate, null }
 import error { JaktError }
@@ -23,8 +23,9 @@ struct Editor {
     prompt: String
     multiline_input_start_indicator: String = "{-"
     multiline_input_end_indicator: String = "-}"
+    compiler: Compiler
 
-    fn create(prompt: String) throws -> Editor {
+    fn create(compiler: Compiler, prompt: String) throws -> Editor {
         mut std_in = fopen(str: "/dev/stdin".c_string(), mode: "r".c_string())
         if std_in == null<FILE>() {
             eprintln("Could not open /dev/stdin for reading")
@@ -34,26 +35,40 @@ struct Editor {
         return Editor(
             standard_input_file: std_in
             line_pointer: allocate<c_char>(count: 4096)
-            prompt
+            prompt,
+            compiler
         )
     }
 
-    fn check_parens(anon input: String) -> bool {
+    fn check_parens(mut this, anon input: String) throws -> bool {
+        mut pos: usize   = 0
+        mut buffer: [u8] = []
+        buffer.ensure_capacity(input.length())
+
+        while pos < input.length() {
+            buffer.push(input.byte_at(pos))
+            ++pos
+        }
+
+        .compiler.current_file_contents = buffer
+
+        let tokens = Lexer::lex(compiler: .compiler)
+
         mut unmatched_parens   = 0
         mut unmatched_brackets = 0
         mut unmatched_curlies  = 0
 
-        mut pos: usize = 0
+        pos = 0
 
-        while pos < input.length() {
-            match input.byte_at(pos) {
-                b'(' => { unmatched_parens += 1   }
-                b')' => { unmatched_parens -= 1   }
-                b'[' => { unmatched_brackets += 1 }
-                b']' => { unmatched_brackets -= 1 }
-                b'{' => { unmatched_curlies += 1  }
-                b'}' => { unmatched_curlies -= 1  }
-                else => {}
+        while pos < tokens.size() {
+            match tokens[pos] {
+                LParen  => { unmatched_parens   += 1 }
+                RParen  => { unmatched_parens   -= 1 }
+                LSquare => { unmatched_brackets += 1 }
+                RSquare => { unmatched_brackets -= 1 }
+                LCurly  => { unmatched_curlies  += 1 }
+                RCurly  => { unmatched_curlies  -= 1 }
+                else    => {}
             }
 
             pos += 1
@@ -75,7 +90,7 @@ struct Editor {
             prompt = ".."
 
             let result = builder.to_string()
-            if check_parens(result) {
+            if .check_parens(result) {
                 return LineResult::Line(result)
             }
         }
@@ -368,7 +383,7 @@ struct REPL {
     }
 
     fn run(mut this) throws {
-        mut editor = Editor::create(prompt: "> ")
+        mut editor = Editor::create(compiler: .compiler, prompt: "> ")
         defer editor.destroy()
 
         loop {

--- a/selfhost/repl.jakt
+++ b/selfhost/repl.jakt
@@ -21,6 +21,8 @@ struct Editor {
     standard_input_file: raw FILE
     line_pointer: raw c_char
     prompt: String
+    multiline_input_start_indicator: String = "{-"
+    multiline_input_end_indicator: String = "-}"
 
     fn create(prompt: String) throws -> Editor {
         mut std_in = fopen(str: "/dev/stdin".c_string(), mode: "r".c_string())
@@ -37,10 +39,11 @@ struct Editor {
         return editor
     }
 
-    fn get_line(mut this) throws -> LineResult {
-        eprint("{}", .prompt)
+    fn get_line(mut this, prompt: String? = None) throws -> LineResult {
+        eprint("{}", prompt ?? .prompt)
 
         mut builder = StringBuilder::create()
+
         unsafe {
             let c_string = fgets(
                 s: .line_pointer
@@ -52,6 +55,32 @@ struct Editor {
             }
 
             builder.append_c_string(c_string)
+        }
+
+        let line = builder.to_string()
+
+        if line == format("{}\n", .multiline_input_start_indicator) {
+          return .read_lines_until_separator(.multiline_input_end_indicator)
+        }
+
+        return LineResult::Line(line)
+    }
+
+    fn read_lines_until_separator(mut this, anon sep: String) throws -> LineResult {
+        mut builder = StringBuilder::create()
+
+        loop {
+            match .get_line(prompt: ".. ") {
+                LineResult::Line(line) => {
+                    if line == format("{}\n", sep) {
+                      break
+                    }
+                    builder.append_string(line)
+                }
+                LineResult::Eof => {
+                    return LineResult::Eof
+                }
+            }
         }
 
         return LineResult::Line(builder.to_string())
@@ -277,7 +306,6 @@ struct REPL {
 
         let PRELUDE_SCOPE_ID: ScopeId = typechecker.prelude_scope_id()
         let root_scope_id = typechecker.create_scope(parent_scope_id: PRELUDE_SCOPE_ID, can_throw: true,  debug_name: "root")
-
         let root_interpreter_scope = InterpreterScope::create()
 
         return REPL(
@@ -302,11 +330,7 @@ struct REPL {
         defer editor.destroy()
 
         loop {
-            if not .compiler.errors.is_empty() {
-                .compiler.print_errors()
-                let arr: [JaktError] = []
-                .compiler.errors = arr
-            }
+            .handle_possible_error()
 
             let line_result = try editor.get_line() catch error {
                 return


### PR DESCRIPTION
Now multiple lines can be entered at the repl using a pair of delimitters. For now they are "{-" to start and "-}" to end but they can be changed in the future.

Example:

```
> {-
.. struct Person {
..     name: String
.. }
.. -}
> let p = Person(name: "John")
```