### PR TITLE
prelude+tests: Add string.contains support

### DIFF
--- a/runtime/prelude.jakt
+++ b/runtime/prelude.jakt
@@ -68,6 +68,7 @@ extern struct String {
     fn replace(this, replace: String, with: String) -> String
     fn starts_with(this, anon needle: String) -> bool
     fn ends_with(this, anon needle: String) -> bool
+    fn contains(this, anon needle: StringView) -> bool
 }
 
 [[name=DeprecatedStringBuilder]]

--- a/samples/strings/contains.jakt
+++ b/samples/strings/contains.jakt
@@ -1,0 +1,9 @@
+/// Expect:
+/// - output: "false\ntrue\n"
+
+fn main() {
+    let x = "Well, hello friends"
+
+    println("{}", x.contains("goodbye"))
+    println("{}", x.contains("hello"))
+}


### PR DESCRIPTION
Pulled in the string.contains method from the C++ side. Added a few tests to ensure it was working.