### PR TITLE
CMake: Enable all warnings, then manually disable those we trigger

### DIFF
--- a/cmake/jakt-executable.cmake
+++ b/cmake/jakt-executable.cmake
@@ -9,6 +9,9 @@ STRING(TOLOWER ${JAKT_TARGET_IN} JAKT_TARGET)
 
 function(add_jakt_compiler_flags target)
   target_compile_options("${target}" PRIVATE
+    -Wall
+    -Wextra
+    -Werror
     -Wno-unused-local-typedefs
     -Wno-unused-function
     -Wno-unused-variable
@@ -25,6 +28,8 @@ function(add_jakt_compiler_flags target)
     -Wno-deprecated-declarations
     -Wno-unknown-warning-option
     -Wno-unused-command-line-argument
+    -Wno-unused-lambda-capture
+    -Wno-reorder-ctor
     # Silence warning about `no_unique_address`;
     # It does not apply on windows, and clang-cl just warns about it.
     -Wno-unknown-attributes


### PR DESCRIPTION
When building Serenity with ENABLE_JAKT, it builds Jakt using this cmake file, BUT it already has the `-Wall -Wextra -Werror` options set. This was causing it to fail to compile Jakt: Some warnings were not enabled by default, so building Jakt directly would work, but they are enabled by these extra options, so would fail as part of building Serenity.

By defining the options here, we make sure that we can't accidentally break the Serenity build without also breaking the Jakt build itself.

Of course, ideally we would also generate code that doesn't set off warnings, but that's trickier.