### PR TITLE
VSCode: Use buffer.size not text.size as upper limit

### DIFF
--- a/editors/vscode/server/src/server.ts
+++ b/editors/vscode/server/src/server.ts
@@ -467,7 +467,7 @@ function convertPosition(position: Position, text: string): number {
     const buffer = new TextEncoder().encode(text);
 
     let i = 0;
-    while (i < text.length) {
+    while (i < buffer.length) {
         if (line == position.line && character == position.character) {
             return i;
         }


### PR DESCRIPTION
Using text.size will prematurely stop this calculation from working in files where the text.size is not the same as the buffer.size. Because we use the buffer and index into it, the buffer.size should be the guard.