### PR TITLE
typechecker+runtime: Perf improvements and some hash salt in your dicts & sets

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -87,6 +87,7 @@ set(SELFHOST_SOURCES
   selfhost/error.jakt
   selfhost/formatter.jakt
   selfhost/ide.jakt
+  selfhost/ids.jakt
   selfhost/interpreter.jakt
   selfhost/lexer.jakt
   selfhost/parser.jakt

--- a/bootstrap/stage0/__prelude___specializations.cpp
+++ b/bootstrap/stage0/__prelude___specializations.cpp
@@ -27,6 +27,7 @@
 #include "jakt__platform.h"
 #include "jakt__arguments.h"
 #include "jakt__prelude__prelude.h"
+#include "jakt__prelude__hash.h"
 #include "jakt__prelude__operators.h"
 #include "jakt__prelude__string.h"
 #include "jakt__prelude__iteration.h"

--- a/bootstrap/stage0/__unified_forward.h
+++ b/bootstrap/stage0/__unified_forward.h
@@ -12,6 +12,8 @@ namespace jakt__prelude__string {
 namespace jakt__prelude__operators {
 enum class Ordering: u8;
 }
+namespace jakt__prelude__hash {
+}
 namespace jakt__prelude__prelude {
 }
 namespace jakt__arguments {

--- a/bootstrap/stage0/build_specializations.cpp
+++ b/bootstrap/stage0/build_specializations.cpp
@@ -28,6 +28,7 @@
 #include "jakt__platform.h"
 #include "jakt__arguments.h"
 #include "jakt__prelude__prelude.h"
+#include "jakt__prelude__hash.h"
 #include "jakt__prelude__operators.h"
 #include "jakt__prelude__string.h"
 #include "jakt__prelude__iteration.h"

--- a/bootstrap/stage0/codegen.h
+++ b/bootstrap/stage0/codegen.h
@@ -7,11 +7,9 @@
 #include "compiler.h"
 namespace Jakt {
 namespace codegen {
-struct CodegenDebugInfo {
+struct LineSpan {
   public:
-NonnullRefPtr<compiler::Compiler> compiler;JaktInternal::Dictionary<size_t,JaktInternal::DynamicArray<codegen::LineSpan>> line_spans;bool statement_span_comments;ErrorOr<void> gather_line_spans();
-ErrorOr<DeprecatedString> span_to_source_location(utility::Span const span);
-CodegenDebugInfo(NonnullRefPtr<compiler::Compiler> a_compiler, JaktInternal::Dictionary<size_t,JaktInternal::DynamicArray<codegen::LineSpan>> a_line_spans, bool a_statement_span_comments);
+size_t start;size_t end;LineSpan(size_t a_start, size_t a_end);
 
 ErrorOr<DeprecatedString> debug_description() const;
 };namespace AllowedControlExits_Details {
@@ -39,6 +37,13 @@ static codegen::ControlFlowState no_control_flow();
 bool is_match_nested() const;
 codegen::ControlFlowState enter_match() const;
 ControlFlowState(codegen::AllowedControlExits a_allowed_exits, bool a_passes_through_match, bool a_passes_through_try, size_t a_match_nest_level);
+
+ErrorOr<DeprecatedString> debug_description() const;
+};struct CodegenDebugInfo {
+  public:
+NonnullRefPtr<compiler::Compiler> compiler;JaktInternal::Dictionary<size_t,JaktInternal::DynamicArray<codegen::LineSpan>> line_spans;bool statement_span_comments;ErrorOr<void> gather_line_spans();
+ErrorOr<DeprecatedString> span_to_source_location(utility::Span const span);
+CodegenDebugInfo(NonnullRefPtr<compiler::Compiler> a_compiler, JaktInternal::Dictionary<size_t,JaktInternal::DynamicArray<codegen::LineSpan>> a_line_spans, bool a_statement_span_comments);
 
 ErrorOr<DeprecatedString> debug_description() const;
 };struct CodeGenerator {
@@ -101,15 +106,10 @@ ErrorOr<DeprecatedString> codegen_constructor(NonnullRefPtr<types::CheckedFuncti
 ErrorOr<DeprecatedString> codegen_type_possibly_as_namespace(types::TypeId const type_id, bool const as_namespace) const;
 ErrorOr<DeprecatedString> codegen_struct_predecl(types::CheckedStruct const struct_);
 ErrorOr<DeprecatedString> debug_description() const;
-};struct LineSpan {
-  public:
-size_t start;size_t end;LineSpan(size_t a_start, size_t a_end);
-
-ErrorOr<DeprecatedString> debug_description() const;
 };}
 } // namespace Jakt
-template<>struct Jakt::Formatter<Jakt::codegen::CodegenDebugInfo> : Jakt::Formatter<Jakt::StringView>{
-Jakt::ErrorOr<void> format(Jakt::FormatBuilder& builder, Jakt::codegen::CodegenDebugInfo const& value) {
+template<>struct Jakt::Formatter<Jakt::codegen::LineSpan> : Jakt::Formatter<Jakt::StringView>{
+Jakt::ErrorOr<void> format(Jakt::FormatBuilder& builder, Jakt::codegen::LineSpan const& value) {
 JaktInternal::PrettyPrint::ScopedEnable pretty_print_enable { m_alternative_form };Jakt::ErrorOr<void> format_error = Jakt::Formatter<Jakt::StringView>::format(builder, MUST(value.debug_description()));return format_error;}
 };
 namespace Jakt {
@@ -126,14 +126,14 @@ JaktInternal::PrettyPrint::ScopedEnable pretty_print_enable { m_alternative_form
 };
 namespace Jakt {
 } // namespace Jakt
-template<>struct Jakt::Formatter<Jakt::codegen::CodeGenerator> : Jakt::Formatter<Jakt::StringView>{
-Jakt::ErrorOr<void> format(Jakt::FormatBuilder& builder, Jakt::codegen::CodeGenerator const& value) {
+template<>struct Jakt::Formatter<Jakt::codegen::CodegenDebugInfo> : Jakt::Formatter<Jakt::StringView>{
+Jakt::ErrorOr<void> format(Jakt::FormatBuilder& builder, Jakt::codegen::CodegenDebugInfo const& value) {
 JaktInternal::PrettyPrint::ScopedEnable pretty_print_enable { m_alternative_form };Jakt::ErrorOr<void> format_error = Jakt::Formatter<Jakt::StringView>::format(builder, MUST(value.debug_description()));return format_error;}
 };
 namespace Jakt {
 } // namespace Jakt
-template<>struct Jakt::Formatter<Jakt::codegen::LineSpan> : Jakt::Formatter<Jakt::StringView>{
-Jakt::ErrorOr<void> format(Jakt::FormatBuilder& builder, Jakt::codegen::LineSpan const& value) {
+template<>struct Jakt::Formatter<Jakt::codegen::CodeGenerator> : Jakt::Formatter<Jakt::StringView>{
+Jakt::ErrorOr<void> format(Jakt::FormatBuilder& builder, Jakt::codegen::CodeGenerator const& value) {
 JaktInternal::PrettyPrint::ScopedEnable pretty_print_enable { m_alternative_form };Jakt::ErrorOr<void> format_error = Jakt::Formatter<Jakt::StringView>::format(builder, MUST(value.debug_description()));return format_error;}
 };
 namespace Jakt {

--- a/bootstrap/stage0/codegen_specializations.cpp
+++ b/bootstrap/stage0/codegen_specializations.cpp
@@ -28,6 +28,7 @@
 #include "jakt__platform.h"
 #include "jakt__arguments.h"
 #include "jakt__prelude__prelude.h"
+#include "jakt__prelude__hash.h"
 #include "jakt__prelude__operators.h"
 #include "jakt__prelude__string.h"
 #include "jakt__prelude__iteration.h"

--- a/bootstrap/stage0/compiler_specializations.cpp
+++ b/bootstrap/stage0/compiler_specializations.cpp
@@ -28,6 +28,7 @@
 #include "jakt__platform.h"
 #include "jakt__arguments.h"
 #include "jakt__prelude__prelude.h"
+#include "jakt__prelude__hash.h"
 #include "jakt__prelude__operators.h"
 #include "jakt__prelude__string.h"
 #include "jakt__prelude__iteration.h"

--- a/bootstrap/stage0/error.h
+++ b/bootstrap/stage0/error.h
@@ -3,6 +3,20 @@
 #include "utility.h"
 namespace Jakt {
 namespace error {
+namespace MessageSeverity_Details {
+struct Hint {
+};
+struct Error {
+};
+}
+struct MessageSeverity : public Variant<MessageSeverity_Details::Hint, MessageSeverity_Details::Error> {
+using Variant<MessageSeverity_Details::Hint, MessageSeverity_Details::Error>::Variant;
+    using Hint = MessageSeverity_Details::Hint;
+    using Error = MessageSeverity_Details::Error;
+ErrorOr<DeprecatedString> debug_description() const;
+ErrorOr<DeprecatedString> ansi_color_code() const;
+ErrorOr<DeprecatedString> name() const;
+};
 namespace JaktError_Details {
 struct Message {
 DeprecatedString message;
@@ -34,30 +48,16 @@ using Variant<JaktError_Details::Message, JaktError_Details::MessageWithHint>::V
 ErrorOr<DeprecatedString> debug_description() const;
 utility::Span span() const;
 };
-namespace MessageSeverity_Details {
-struct Hint {
-};
-struct Error {
-};
-}
-struct MessageSeverity : public Variant<MessageSeverity_Details::Hint, MessageSeverity_Details::Error> {
-using Variant<MessageSeverity_Details::Hint, MessageSeverity_Details::Error>::Variant;
-    using Hint = MessageSeverity_Details::Hint;
-    using Error = MessageSeverity_Details::Error;
-ErrorOr<DeprecatedString> debug_description() const;
-ErrorOr<DeprecatedString> ansi_color_code() const;
-ErrorOr<DeprecatedString> name() const;
-};
 }
 } // namespace Jakt
-template<>struct Jakt::Formatter<Jakt::error::JaktError> : Jakt::Formatter<Jakt::StringView>{
-Jakt::ErrorOr<void> format(Jakt::FormatBuilder& builder, Jakt::error::JaktError const& value) {
+template<>struct Jakt::Formatter<Jakt::error::MessageSeverity> : Jakt::Formatter<Jakt::StringView>{
+Jakt::ErrorOr<void> format(Jakt::FormatBuilder& builder, Jakt::error::MessageSeverity const& value) {
 JaktInternal::PrettyPrint::ScopedEnable pretty_print_enable { m_alternative_form };Jakt::ErrorOr<void> format_error = Jakt::Formatter<Jakt::StringView>::format(builder, MUST(value.debug_description()));return format_error;}
 };
 namespace Jakt {
 } // namespace Jakt
-template<>struct Jakt::Formatter<Jakt::error::MessageSeverity> : Jakt::Formatter<Jakt::StringView>{
-Jakt::ErrorOr<void> format(Jakt::FormatBuilder& builder, Jakt::error::MessageSeverity const& value) {
+template<>struct Jakt::Formatter<Jakt::error::JaktError> : Jakt::Formatter<Jakt::StringView>{
+Jakt::ErrorOr<void> format(Jakt::FormatBuilder& builder, Jakt::error::JaktError const& value) {
 JaktInternal::PrettyPrint::ScopedEnable pretty_print_enable { m_alternative_form };Jakt::ErrorOr<void> format_error = Jakt::Formatter<Jakt::StringView>::format(builder, MUST(value.debug_description()));return format_error;}
 };
 namespace Jakt {

--- a/bootstrap/stage0/error_specializations.cpp
+++ b/bootstrap/stage0/error_specializations.cpp
@@ -28,6 +28,7 @@
 #include "jakt__platform.h"
 #include "jakt__arguments.h"
 #include "jakt__prelude__prelude.h"
+#include "jakt__prelude__hash.h"
 #include "jakt__prelude__operators.h"
 #include "jakt__prelude__string.h"
 #include "jakt__prelude__iteration.h"

--- a/bootstrap/stage0/formatter.h
+++ b/bootstrap/stage0/formatter.h
@@ -4,14 +4,109 @@
 #include "lexer.h"
 namespace Jakt {
 namespace formatter {
-struct FormattedToken {
-  public:
-lexer::Token token;size_t indent;JaktInternal::DynamicArray<u8> trailing_trivia;JaktInternal::DynamicArray<u8> preceding_trivia;FormattedToken(lexer::Token a_token, size_t a_indent, JaktInternal::DynamicArray<u8> a_trailing_trivia, JaktInternal::DynamicArray<u8> a_preceding_trivia);
-
-ErrorOr<DeprecatedString> token_text() const;
-ErrorOr<DeprecatedString> debug_text() const;
+namespace BreakablePoint_Details {
+struct Paren {
+size_t point;
+size_t length;
+template<typename _MemberT0, typename _MemberT1>
+Paren(_MemberT0&& member_0, _MemberT1&& member_1):
+point{ forward<_MemberT0>(member_0)},
+length{ forward<_MemberT1>(member_1)}
+{}
+};
+struct Curly {
+size_t point;
+size_t length;
+template<typename _MemberT0, typename _MemberT1>
+Curly(_MemberT0&& member_0, _MemberT1&& member_1):
+point{ forward<_MemberT0>(member_0)},
+length{ forward<_MemberT1>(member_1)}
+{}
+};
+struct Square {
+size_t point;
+size_t length;
+template<typename _MemberT0, typename _MemberT1>
+Square(_MemberT0&& member_0, _MemberT1&& member_1):
+point{ forward<_MemberT0>(member_0)},
+length{ forward<_MemberT1>(member_1)}
+{}
+};
+struct Logical {
+size_t point;
+size_t length;
+template<typename _MemberT0, typename _MemberT1>
+Logical(_MemberT0&& member_0, _MemberT1&& member_1):
+point{ forward<_MemberT0>(member_0)},
+length{ forward<_MemberT1>(member_1)}
+{}
+};
+}
+struct BreakablePoint : public Variant<BreakablePoint_Details::Paren, BreakablePoint_Details::Curly, BreakablePoint_Details::Square, BreakablePoint_Details::Logical> {
+using Variant<BreakablePoint_Details::Paren, BreakablePoint_Details::Curly, BreakablePoint_Details::Square, BreakablePoint_Details::Logical>::Variant;
+    using Paren = BreakablePoint_Details::Paren;
+    using Curly = BreakablePoint_Details::Curly;
+    using Square = BreakablePoint_Details::Square;
+    using Logical = BreakablePoint_Details::Logical;
 ErrorOr<DeprecatedString> debug_description() const;
-};namespace Entity_Details {
+size_t length() const;
+size_t point() const;
+};
+struct Stage0 {
+  public:
+JaktInternal::DynamicArray<lexer::Token> tokens;size_t index;JaktInternal::DynamicArray<formatter::State> states;size_t indent;bool already_seen_enclosure_in_current_line;JaktInternal::DynamicArray<size_t> dedents_to_skip;bool debug;ErrorOr<JaktInternal::Optional<formatter::FormattedToken>> next_in_implements_context(lexer::Token const token);
+ErrorOr<JaktInternal::Optional<formatter::FormattedToken>> next();
+ErrorOr<void> push_state(formatter::State const state);
+ErrorOr<JaktInternal::Optional<formatter::FormattedToken>> next_in_import_context(bool const is_extern, lexer::Token const token);
+ErrorOr<JaktInternal::Optional<formatter::FormattedToken>> next_in_toplevel_context(size_t const open_parens, size_t const open_curlies, size_t const open_squares, bool const is_extern, lexer::Token const token);
+ErrorOr<JaktInternal::Optional<formatter::FormattedToken>> next_in_entity_declaration_context(formatter::Entity const entity, bool const accept_generics, bool const has_generics, size_t const generic_nesting, bool const is_extern, lexer::Token const token);
+lexer::Token consume();
+bool line_has_indent() const;
+static ErrorOr<JaktInternal::DynamicArray<u8>> to_array(DeprecatedString const x);
+static ErrorOr<formatter::Stage0> create(NonnullRefPtr<compiler::Compiler> compiler, JaktInternal::DynamicArray<u8> const source, bool const debug);
+ErrorOr<JaktInternal::Optional<formatter::FormattedToken>> next_in_parameter_list_context(size_t const open_parens, lexer::Token const token);
+ErrorOr<JaktInternal::Optional<formatter::FormattedToken>> next_in_capture_list_context(lexer::Token const token);
+ErrorOr<JaktInternal::Optional<formatter::FormattedToken>> next_impl(bool const reconsume);
+ErrorOr<JaktInternal::Optional<formatter::FormattedToken>> next_in_statement_context(size_t const open_parens, size_t const open_curlies, size_t const open_squares, size_t const arrow_indents, JaktInternal::Optional<size_t> const allow_eol, bool const inserted_comma, formatter::ExpressionMode const expression_mode, size_t const dedents_on_open_curly, i64& indent_change, lexer::Token const token);
+ErrorOr<JaktInternal::Optional<formatter::FormattedToken>> next_in_generic_call_type_params_context(size_t const open_angles, lexer::Token const token);
+ErrorOr<JaktInternal::Optional<formatter::FormattedToken>> next_in_restriction_list_context(lexer::Token const token);
+ErrorOr<formatter::FormattedToken> formatted_token(lexer::Token const token) const;
+ErrorOr<formatter::FormattedToken> formatted_token(lexer::Token const token, JaktInternal::DynamicArray<u8> const trailing_trivia, JaktInternal::DynamicArray<u8> const preceding_trivia) const;
+ErrorOr<JaktInternal::Optional<formatter::FormattedToken>> formatted_peek();
+ErrorOr<JaktInternal::Optional<formatter::FormattedToken>> next_in_type_context(size_t const open_parens, size_t const open_curlies, size_t const open_squares, size_t const open_angles, bool const seen_start, lexer::Token const token);
+Stage0(JaktInternal::DynamicArray<lexer::Token> a_tokens, size_t a_index, JaktInternal::DynamicArray<formatter::State> a_states, size_t a_indent, bool a_already_seen_enclosure_in_current_line, JaktInternal::DynamicArray<size_t> a_dedents_to_skip, bool a_debug);
+
+formatter::State state() const;
+ErrorOr<JaktInternal::Optional<formatter::FormattedToken>> next_in_entity_definition_context(formatter::Entity const entity, bool const is_extern, i64& indent_change, lexer::Token const token);
+ErrorOr<JaktInternal::Optional<formatter::FormattedToken>> next_in_extern_context(lexer::Token const token);
+ErrorOr<JaktInternal::Optional<formatter::FormattedToken>> next_in_function_type_context(bool const seen_final_type, lexer::Token const token);
+void pop_state();
+lexer::Token peek(i64 const offset) const;
+ErrorOr<JaktInternal::Optional<formatter::FormattedToken>> next_in_match_pattern_context(size_t const open_parens, bool const allow_multiple, lexer::Token const token);
+ErrorOr<JaktInternal::Optional<formatter::FormattedToken>> next_in_import_list_context(bool const emitted_comma, lexer::Token const token);
+ErrorOr<void> replace_state(formatter::State const state);
+ErrorOr<JaktInternal::Optional<formatter::FormattedToken>> next_in_variable_declaration_context(size_t const open_parens, lexer::Token const token);
+static ErrorOr<formatter::Stage0> for_tokens(JaktInternal::DynamicArray<lexer::Token> const tokens, bool const debug);
+ErrorOr<DeprecatedString> debug_description() const;
+};namespace ExpressionMode_Details {
+struct OutsideExpression {
+};
+struct BeforeExpressions {
+};
+struct AtExpressionStart {
+};
+struct InExpression {
+};
+}
+struct ExpressionMode : public Variant<ExpressionMode_Details::OutsideExpression, ExpressionMode_Details::BeforeExpressions, ExpressionMode_Details::AtExpressionStart, ExpressionMode_Details::InExpression> {
+using Variant<ExpressionMode_Details::OutsideExpression, ExpressionMode_Details::BeforeExpressions, ExpressionMode_Details::AtExpressionStart, ExpressionMode_Details::InExpression>::Variant;
+    using OutsideExpression = ExpressionMode_Details::OutsideExpression;
+    using BeforeExpressions = ExpressionMode_Details::BeforeExpressions;
+    using AtExpressionStart = ExpressionMode_Details::AtExpressionStart;
+    using InExpression = ExpressionMode_Details::InExpression;
+ErrorOr<DeprecatedString> debug_description() const;
+};
+namespace Entity_Details {
 struct Struct {
 };
 struct Enum {
@@ -36,24 +131,6 @@ using Variant<Entity_Details::Struct, Entity_Details::Enum, Entity_Details::Name
     using Function = Entity_Details::Function;
 ErrorOr<DeprecatedString> debug_description() const;
 static formatter::Entity from_token(lexer::Token const& token);
-};
-namespace ExpressionMode_Details {
-struct OutsideExpression {
-};
-struct BeforeExpressions {
-};
-struct AtExpressionStart {
-};
-struct InExpression {
-};
-}
-struct ExpressionMode : public Variant<ExpressionMode_Details::OutsideExpression, ExpressionMode_Details::BeforeExpressions, ExpressionMode_Details::AtExpressionStart, ExpressionMode_Details::InExpression> {
-using Variant<ExpressionMode_Details::OutsideExpression, ExpressionMode_Details::BeforeExpressions, ExpressionMode_Details::AtExpressionStart, ExpressionMode_Details::InExpression>::Variant;
-    using OutsideExpression = ExpressionMode_Details::OutsideExpression;
-    using BeforeExpressions = ExpressionMode_Details::BeforeExpressions;
-    using AtExpressionStart = ExpressionMode_Details::AtExpressionStart;
-    using InExpression = ExpressionMode_Details::InExpression;
-ErrorOr<DeprecatedString> debug_description() const;
 };
 namespace State_Details {
 struct Toplevel {
@@ -210,46 +287,17 @@ using Variant<State_Details::Toplevel, State_Details::Extern, State_Details::Imp
 ErrorOr<DeprecatedString> debug_description() const;
 ErrorOr<DeprecatedString> name() const;
 };
-struct ReflowState {
+struct FormattedToken {
+  public:
+lexer::Token token;size_t indent;JaktInternal::DynamicArray<u8> trailing_trivia;JaktInternal::DynamicArray<u8> preceding_trivia;FormattedToken(lexer::Token a_token, size_t a_indent, JaktInternal::DynamicArray<u8> a_trailing_trivia, JaktInternal::DynamicArray<u8> a_preceding_trivia);
+
+ErrorOr<DeprecatedString> token_text() const;
+ErrorOr<DeprecatedString> debug_text() const;
+ErrorOr<DeprecatedString> debug_description() const;
+};struct ReflowState {
   public:
 formatter::FormattedToken token;formatter::State state;size_t enclosures_to_ignore;ReflowState(formatter::FormattedToken a_token, formatter::State a_state, size_t a_enclosures_to_ignore);
 
-ErrorOr<DeprecatedString> debug_description() const;
-};struct Stage0 {
-  public:
-JaktInternal::DynamicArray<lexer::Token> tokens;size_t index;JaktInternal::DynamicArray<formatter::State> states;size_t indent;bool already_seen_enclosure_in_current_line;JaktInternal::DynamicArray<size_t> dedents_to_skip;bool debug;ErrorOr<JaktInternal::Optional<formatter::FormattedToken>> next_in_implements_context(lexer::Token const token);
-ErrorOr<JaktInternal::Optional<formatter::FormattedToken>> next();
-ErrorOr<void> push_state(formatter::State const state);
-ErrorOr<JaktInternal::Optional<formatter::FormattedToken>> next_in_import_context(bool const is_extern, lexer::Token const token);
-ErrorOr<JaktInternal::Optional<formatter::FormattedToken>> next_in_toplevel_context(size_t const open_parens, size_t const open_curlies, size_t const open_squares, bool const is_extern, lexer::Token const token);
-ErrorOr<JaktInternal::Optional<formatter::FormattedToken>> next_in_entity_declaration_context(formatter::Entity const entity, bool const accept_generics, bool const has_generics, size_t const generic_nesting, bool const is_extern, lexer::Token const token);
-lexer::Token consume();
-bool line_has_indent() const;
-static ErrorOr<JaktInternal::DynamicArray<u8>> to_array(DeprecatedString const x);
-static ErrorOr<formatter::Stage0> create(NonnullRefPtr<compiler::Compiler> compiler, JaktInternal::DynamicArray<u8> const source, bool const debug);
-ErrorOr<JaktInternal::Optional<formatter::FormattedToken>> next_in_parameter_list_context(size_t const open_parens, lexer::Token const token);
-ErrorOr<JaktInternal::Optional<formatter::FormattedToken>> next_in_capture_list_context(lexer::Token const token);
-ErrorOr<JaktInternal::Optional<formatter::FormattedToken>> next_impl(bool const reconsume);
-ErrorOr<JaktInternal::Optional<formatter::FormattedToken>> next_in_statement_context(size_t const open_parens, size_t const open_curlies, size_t const open_squares, size_t const arrow_indents, JaktInternal::Optional<size_t> const allow_eol, bool const inserted_comma, formatter::ExpressionMode const expression_mode, size_t const dedents_on_open_curly, i64& indent_change, lexer::Token const token);
-ErrorOr<JaktInternal::Optional<formatter::FormattedToken>> next_in_generic_call_type_params_context(size_t const open_angles, lexer::Token const token);
-ErrorOr<JaktInternal::Optional<formatter::FormattedToken>> next_in_restriction_list_context(lexer::Token const token);
-ErrorOr<formatter::FormattedToken> formatted_token(lexer::Token const token) const;
-ErrorOr<formatter::FormattedToken> formatted_token(lexer::Token const token, JaktInternal::DynamicArray<u8> const trailing_trivia, JaktInternal::DynamicArray<u8> const preceding_trivia) const;
-ErrorOr<JaktInternal::Optional<formatter::FormattedToken>> formatted_peek();
-ErrorOr<JaktInternal::Optional<formatter::FormattedToken>> next_in_type_context(size_t const open_parens, size_t const open_curlies, size_t const open_squares, size_t const open_angles, bool const seen_start, lexer::Token const token);
-Stage0(JaktInternal::DynamicArray<lexer::Token> a_tokens, size_t a_index, JaktInternal::DynamicArray<formatter::State> a_states, size_t a_indent, bool a_already_seen_enclosure_in_current_line, JaktInternal::DynamicArray<size_t> a_dedents_to_skip, bool a_debug);
-
-formatter::State state() const;
-ErrorOr<JaktInternal::Optional<formatter::FormattedToken>> next_in_entity_definition_context(formatter::Entity const entity, bool const is_extern, i64& indent_change, lexer::Token const token);
-ErrorOr<JaktInternal::Optional<formatter::FormattedToken>> next_in_extern_context(lexer::Token const token);
-ErrorOr<JaktInternal::Optional<formatter::FormattedToken>> next_in_function_type_context(bool const seen_final_type, lexer::Token const token);
-void pop_state();
-lexer::Token peek(i64 const offset) const;
-ErrorOr<JaktInternal::Optional<formatter::FormattedToken>> next_in_match_pattern_context(size_t const open_parens, bool const allow_multiple, lexer::Token const token);
-ErrorOr<JaktInternal::Optional<formatter::FormattedToken>> next_in_import_list_context(bool const emitted_comma, lexer::Token const token);
-ErrorOr<void> replace_state(formatter::State const state);
-ErrorOr<JaktInternal::Optional<formatter::FormattedToken>> next_in_variable_declaration_context(size_t const open_parens, lexer::Token const token);
-static ErrorOr<formatter::Stage0> for_tokens(JaktInternal::DynamicArray<lexer::Token> const tokens, bool const debug);
 ErrorOr<DeprecatedString> debug_description() const;
 };struct Formatter {
   public:
@@ -265,55 +313,7 @@ ErrorOr<size_t> token_length(formatter::FormattedToken const token) const;
 ErrorOr<void> fixup_closing_enclosures(JaktInternal::DynamicArray<formatter::ReflowState>& line) const;
 size_t pick_breaking_point_index() const;
 ErrorOr<DeprecatedString> debug_description() const;
-};namespace BreakablePoint_Details {
-struct Paren {
-size_t point;
-size_t length;
-template<typename _MemberT0, typename _MemberT1>
-Paren(_MemberT0&& member_0, _MemberT1&& member_1):
-point{ forward<_MemberT0>(member_0)},
-length{ forward<_MemberT1>(member_1)}
-{}
-};
-struct Curly {
-size_t point;
-size_t length;
-template<typename _MemberT0, typename _MemberT1>
-Curly(_MemberT0&& member_0, _MemberT1&& member_1):
-point{ forward<_MemberT0>(member_0)},
-length{ forward<_MemberT1>(member_1)}
-{}
-};
-struct Square {
-size_t point;
-size_t length;
-template<typename _MemberT0, typename _MemberT1>
-Square(_MemberT0&& member_0, _MemberT1&& member_1):
-point{ forward<_MemberT0>(member_0)},
-length{ forward<_MemberT1>(member_1)}
-{}
-};
-struct Logical {
-size_t point;
-size_t length;
-template<typename _MemberT0, typename _MemberT1>
-Logical(_MemberT0&& member_0, _MemberT1&& member_1):
-point{ forward<_MemberT0>(member_0)},
-length{ forward<_MemberT1>(member_1)}
-{}
-};
-}
-struct BreakablePoint : public Variant<BreakablePoint_Details::Paren, BreakablePoint_Details::Curly, BreakablePoint_Details::Square, BreakablePoint_Details::Logical> {
-using Variant<BreakablePoint_Details::Paren, BreakablePoint_Details::Curly, BreakablePoint_Details::Square, BreakablePoint_Details::Logical>::Variant;
-    using Paren = BreakablePoint_Details::Paren;
-    using Curly = BreakablePoint_Details::Curly;
-    using Square = BreakablePoint_Details::Square;
-    using Logical = BreakablePoint_Details::Logical;
-ErrorOr<DeprecatedString> debug_description() const;
-size_t length() const;
-size_t point() const;
-};
-template <typename T>
+};template <typename T>
 ErrorOr<JaktInternal::DynamicArray<T>> concat(JaktInternal::DynamicArray<T> const xs, T const y);
 template <typename T>
 JaktInternal::Optional<T> collapse(JaktInternal::Optional<JaktInternal::Optional<T>> const x);
@@ -321,32 +321,8 @@ template <typename T>
 ErrorOr<JaktInternal::DynamicArray<T>> init(JaktInternal::DynamicArray<T> const xs);
 }
 } // namespace Jakt
-template<>struct Jakt::Formatter<Jakt::formatter::FormattedToken> : Jakt::Formatter<Jakt::StringView>{
-Jakt::ErrorOr<void> format(Jakt::FormatBuilder& builder, Jakt::formatter::FormattedToken const& value) {
-JaktInternal::PrettyPrint::ScopedEnable pretty_print_enable { m_alternative_form };Jakt::ErrorOr<void> format_error = Jakt::Formatter<Jakt::StringView>::format(builder, MUST(value.debug_description()));return format_error;}
-};
-namespace Jakt {
-} // namespace Jakt
-template<>struct Jakt::Formatter<Jakt::formatter::Entity> : Jakt::Formatter<Jakt::StringView>{
-Jakt::ErrorOr<void> format(Jakt::FormatBuilder& builder, Jakt::formatter::Entity const& value) {
-JaktInternal::PrettyPrint::ScopedEnable pretty_print_enable { m_alternative_form };Jakt::ErrorOr<void> format_error = Jakt::Formatter<Jakt::StringView>::format(builder, MUST(value.debug_description()));return format_error;}
-};
-namespace Jakt {
-} // namespace Jakt
-template<>struct Jakt::Formatter<Jakt::formatter::ExpressionMode> : Jakt::Formatter<Jakt::StringView>{
-Jakt::ErrorOr<void> format(Jakt::FormatBuilder& builder, Jakt::formatter::ExpressionMode const& value) {
-JaktInternal::PrettyPrint::ScopedEnable pretty_print_enable { m_alternative_form };Jakt::ErrorOr<void> format_error = Jakt::Formatter<Jakt::StringView>::format(builder, MUST(value.debug_description()));return format_error;}
-};
-namespace Jakt {
-} // namespace Jakt
-template<>struct Jakt::Formatter<Jakt::formatter::State> : Jakt::Formatter<Jakt::StringView>{
-Jakt::ErrorOr<void> format(Jakt::FormatBuilder& builder, Jakt::formatter::State const& value) {
-JaktInternal::PrettyPrint::ScopedEnable pretty_print_enable { m_alternative_form };Jakt::ErrorOr<void> format_error = Jakt::Formatter<Jakt::StringView>::format(builder, MUST(value.debug_description()));return format_error;}
-};
-namespace Jakt {
-} // namespace Jakt
-template<>struct Jakt::Formatter<Jakt::formatter::ReflowState> : Jakt::Formatter<Jakt::StringView>{
-Jakt::ErrorOr<void> format(Jakt::FormatBuilder& builder, Jakt::formatter::ReflowState const& value) {
+template<>struct Jakt::Formatter<Jakt::formatter::BreakablePoint> : Jakt::Formatter<Jakt::StringView>{
+Jakt::ErrorOr<void> format(Jakt::FormatBuilder& builder, Jakt::formatter::BreakablePoint const& value) {
 JaktInternal::PrettyPrint::ScopedEnable pretty_print_enable { m_alternative_form };Jakt::ErrorOr<void> format_error = Jakt::Formatter<Jakt::StringView>::format(builder, MUST(value.debug_description()));return format_error;}
 };
 namespace Jakt {
@@ -357,14 +333,38 @@ JaktInternal::PrettyPrint::ScopedEnable pretty_print_enable { m_alternative_form
 };
 namespace Jakt {
 } // namespace Jakt
-template<>struct Jakt::Formatter<Jakt::formatter::Formatter> : Jakt::Formatter<Jakt::StringView>{
-Jakt::ErrorOr<void> format(Jakt::FormatBuilder& builder, Jakt::formatter::Formatter const& value) {
+template<>struct Jakt::Formatter<Jakt::formatter::ExpressionMode> : Jakt::Formatter<Jakt::StringView>{
+Jakt::ErrorOr<void> format(Jakt::FormatBuilder& builder, Jakt::formatter::ExpressionMode const& value) {
 JaktInternal::PrettyPrint::ScopedEnable pretty_print_enable { m_alternative_form };Jakt::ErrorOr<void> format_error = Jakt::Formatter<Jakt::StringView>::format(builder, MUST(value.debug_description()));return format_error;}
 };
 namespace Jakt {
 } // namespace Jakt
-template<>struct Jakt::Formatter<Jakt::formatter::BreakablePoint> : Jakt::Formatter<Jakt::StringView>{
-Jakt::ErrorOr<void> format(Jakt::FormatBuilder& builder, Jakt::formatter::BreakablePoint const& value) {
+template<>struct Jakt::Formatter<Jakt::formatter::Entity> : Jakt::Formatter<Jakt::StringView>{
+Jakt::ErrorOr<void> format(Jakt::FormatBuilder& builder, Jakt::formatter::Entity const& value) {
+JaktInternal::PrettyPrint::ScopedEnable pretty_print_enable { m_alternative_form };Jakt::ErrorOr<void> format_error = Jakt::Formatter<Jakt::StringView>::format(builder, MUST(value.debug_description()));return format_error;}
+};
+namespace Jakt {
+} // namespace Jakt
+template<>struct Jakt::Formatter<Jakt::formatter::State> : Jakt::Formatter<Jakt::StringView>{
+Jakt::ErrorOr<void> format(Jakt::FormatBuilder& builder, Jakt::formatter::State const& value) {
+JaktInternal::PrettyPrint::ScopedEnable pretty_print_enable { m_alternative_form };Jakt::ErrorOr<void> format_error = Jakt::Formatter<Jakt::StringView>::format(builder, MUST(value.debug_description()));return format_error;}
+};
+namespace Jakt {
+} // namespace Jakt
+template<>struct Jakt::Formatter<Jakt::formatter::FormattedToken> : Jakt::Formatter<Jakt::StringView>{
+Jakt::ErrorOr<void> format(Jakt::FormatBuilder& builder, Jakt::formatter::FormattedToken const& value) {
+JaktInternal::PrettyPrint::ScopedEnable pretty_print_enable { m_alternative_form };Jakt::ErrorOr<void> format_error = Jakt::Formatter<Jakt::StringView>::format(builder, MUST(value.debug_description()));return format_error;}
+};
+namespace Jakt {
+} // namespace Jakt
+template<>struct Jakt::Formatter<Jakt::formatter::ReflowState> : Jakt::Formatter<Jakt::StringView>{
+Jakt::ErrorOr<void> format(Jakt::FormatBuilder& builder, Jakt::formatter::ReflowState const& value) {
+JaktInternal::PrettyPrint::ScopedEnable pretty_print_enable { m_alternative_form };Jakt::ErrorOr<void> format_error = Jakt::Formatter<Jakt::StringView>::format(builder, MUST(value.debug_description()));return format_error;}
+};
+namespace Jakt {
+} // namespace Jakt
+template<>struct Jakt::Formatter<Jakt::formatter::Formatter> : Jakt::Formatter<Jakt::StringView>{
+Jakt::ErrorOr<void> format(Jakt::FormatBuilder& builder, Jakt::formatter::Formatter const& value) {
 JaktInternal::PrettyPrint::ScopedEnable pretty_print_enable { m_alternative_form };Jakt::ErrorOr<void> format_error = Jakt::Formatter<Jakt::StringView>::format(builder, MUST(value.debug_description()));return format_error;}
 };
 namespace Jakt {

--- a/bootstrap/stage0/formatter_specializations.cpp
+++ b/bootstrap/stage0/formatter_specializations.cpp
@@ -28,6 +28,7 @@
 #include "jakt__platform.h"
 #include "jakt__arguments.h"
 #include "jakt__prelude__prelude.h"
+#include "jakt__prelude__hash.h"
 #include "jakt__prelude__operators.h"
 #include "jakt__prelude__string.h"
 #include "jakt__prelude__iteration.h"

--- a/bootstrap/stage0/ide_specializations.cpp
+++ b/bootstrap/stage0/ide_specializations.cpp
@@ -28,6 +28,7 @@
 #include "jakt__platform.h"
 #include "jakt__arguments.h"
 #include "jakt__prelude__prelude.h"
+#include "jakt__prelude__hash.h"
 #include "jakt__prelude__operators.h"
 #include "jakt__prelude__string.h"
 #include "jakt__prelude__iteration.h"

--- a/bootstrap/stage0/interpreter_specializations.cpp
+++ b/bootstrap/stage0/interpreter_specializations.cpp
@@ -28,6 +28,7 @@
 #include "jakt__platform.h"
 #include "jakt__arguments.h"
 #include "jakt__prelude__prelude.h"
+#include "jakt__prelude__hash.h"
 #include "jakt__prelude__operators.h"
 #include "jakt__prelude__string.h"
 #include "jakt__prelude__iteration.h"

--- a/bootstrap/stage0/jakt__arguments_specializations.cpp
+++ b/bootstrap/stage0/jakt__arguments_specializations.cpp
@@ -28,6 +28,7 @@
 #include "jakt__platform.h"
 #include "jakt__arguments.h"
 #include "jakt__prelude__prelude.h"
+#include "jakt__prelude__hash.h"
 #include "jakt__prelude__operators.h"
 #include "jakt__prelude__string.h"
 #include "jakt__prelude__iteration.h"

--- a/bootstrap/stage0/jakt__libc__io_specializations.cpp
+++ b/bootstrap/stage0/jakt__libc__io_specializations.cpp
@@ -28,6 +28,7 @@
 #include "jakt__platform.h"
 #include "jakt__arguments.h"
 #include "jakt__prelude__prelude.h"
+#include "jakt__prelude__hash.h"
 #include "jakt__prelude__operators.h"
 #include "jakt__prelude__string.h"
 #include "jakt__prelude__iteration.h"

--- a/bootstrap/stage0/jakt__path_specializations.cpp
+++ b/bootstrap/stage0/jakt__path_specializations.cpp
@@ -28,6 +28,7 @@
 #include "jakt__platform.h"
 #include "jakt__arguments.h"
 #include "jakt__prelude__prelude.h"
+#include "jakt__prelude__hash.h"
 #include "jakt__prelude__operators.h"
 #include "jakt__prelude__string.h"
 #include "jakt__prelude__iteration.h"

--- a/bootstrap/stage0/jakt__platform__unknown_fs_specializations.cpp
+++ b/bootstrap/stage0/jakt__platform__unknown_fs_specializations.cpp
@@ -28,6 +28,7 @@
 #include "jakt__platform.h"
 #include "jakt__arguments.h"
 #include "jakt__prelude__prelude.h"
+#include "jakt__prelude__hash.h"
 #include "jakt__prelude__operators.h"
 #include "jakt__prelude__string.h"
 #include "jakt__prelude__iteration.h"

--- a/bootstrap/stage0/jakt__platform__unknown_path_specializations.cpp
+++ b/bootstrap/stage0/jakt__platform__unknown_path_specializations.cpp
@@ -28,6 +28,7 @@
 #include "jakt__platform.h"
 #include "jakt__arguments.h"
 #include "jakt__prelude__prelude.h"
+#include "jakt__prelude__hash.h"
 #include "jakt__prelude__operators.h"
 #include "jakt__prelude__string.h"
 #include "jakt__prelude__iteration.h"

--- a/bootstrap/stage0/jakt__platform__unknown_process_specializations.cpp
+++ b/bootstrap/stage0/jakt__platform__unknown_process_specializations.cpp
@@ -28,6 +28,7 @@
 #include "jakt__platform.h"
 #include "jakt__arguments.h"
 #include "jakt__prelude__prelude.h"
+#include "jakt__prelude__hash.h"
 #include "jakt__prelude__operators.h"
 #include "jakt__prelude__string.h"
 #include "jakt__prelude__iteration.h"

--- a/bootstrap/stage0/jakt__platform_specializations.cpp
+++ b/bootstrap/stage0/jakt__platform_specializations.cpp
@@ -28,6 +28,7 @@
 #include "jakt__platform.h"
 #include "jakt__arguments.h"
 #include "jakt__prelude__prelude.h"
+#include "jakt__prelude__hash.h"
 #include "jakt__prelude__operators.h"
 #include "jakt__prelude__string.h"
 #include "jakt__prelude__iteration.h"

--- a/bootstrap/stage0/jakt__prelude__configuration_specializations.cpp
+++ b/bootstrap/stage0/jakt__prelude__configuration_specializations.cpp
@@ -28,6 +28,7 @@
 #include "jakt__platform.h"
 #include "jakt__arguments.h"
 #include "jakt__prelude__prelude.h"
+#include "jakt__prelude__hash.h"
 #include "jakt__prelude__operators.h"
 #include "jakt__prelude__string.h"
 #include "jakt__prelude__iteration.h"

--- a/bootstrap/stage0/jakt__prelude__hash.cpp
+++ b/bootstrap/stage0/jakt__prelude__hash.cpp
@@ -1,0 +1,5 @@
+#include "jakt__prelude__hash.h"
+namespace Jakt {
+namespace jakt__prelude__hash {
+}
+} // namespace Jakt

--- a/bootstrap/stage0/jakt__prelude__hash.h
+++ b/bootstrap/stage0/jakt__prelude__hash.h
@@ -1,0 +1,7 @@
+#pragma once
+#include "__unified_forward.h"
+#include <Jakt/Forward.h>
+namespace Jakt {
+namespace jakt__prelude__hash {
+}
+} // namespace Jakt

--- a/bootstrap/stage0/jakt__prelude__hash_specializations.cpp
+++ b/bootstrap/stage0/jakt__prelude__hash_specializations.cpp
@@ -1,4 +1,4 @@
-#include "jakt__file_iterator.h"
+#include "jakt__prelude__hash.h"
 #include "main.h"
 #include "platform__unknown_compiler.h"
 #include "repl.h"
@@ -33,6 +33,6 @@
 #include "jakt__prelude__string.h"
 #include "jakt__prelude__iteration.h"
 namespace Jakt {
-namespace jakt__file_iterator {
+namespace jakt__prelude__hash {
 }
 } // namespace Jakt

--- a/bootstrap/stage0/jakt__prelude__iteration_specializations.cpp
+++ b/bootstrap/stage0/jakt__prelude__iteration_specializations.cpp
@@ -28,6 +28,7 @@
 #include "jakt__platform.h"
 #include "jakt__arguments.h"
 #include "jakt__prelude__prelude.h"
+#include "jakt__prelude__hash.h"
 #include "jakt__prelude__operators.h"
 #include "jakt__prelude__string.h"
 #include "jakt__prelude__iteration.h"

--- a/bootstrap/stage0/jakt__prelude__operators_specializations.cpp
+++ b/bootstrap/stage0/jakt__prelude__operators_specializations.cpp
@@ -28,6 +28,7 @@
 #include "jakt__platform.h"
 #include "jakt__arguments.h"
 #include "jakt__prelude__prelude.h"
+#include "jakt__prelude__hash.h"
 #include "jakt__prelude__operators.h"
 #include "jakt__prelude__string.h"
 #include "jakt__prelude__iteration.h"

--- a/bootstrap/stage0/jakt__prelude__prelude.h
+++ b/bootstrap/stage0/jakt__prelude__prelude.h
@@ -3,6 +3,7 @@
 #include "jakt__prelude__iteration.h"
 #include "jakt__prelude__string.h"
 #include "jakt__prelude__operators.h"
+#include "jakt__prelude__hash.h"
 namespace Jakt {
 namespace jakt__prelude__prelude {
 }

--- a/bootstrap/stage0/jakt__prelude__prelude_specializations.cpp
+++ b/bootstrap/stage0/jakt__prelude__prelude_specializations.cpp
@@ -28,6 +28,7 @@
 #include "jakt__platform.h"
 #include "jakt__arguments.h"
 #include "jakt__prelude__prelude.h"
+#include "jakt__prelude__hash.h"
 #include "jakt__prelude__operators.h"
 #include "jakt__prelude__string.h"
 #include "jakt__prelude__iteration.h"

--- a/bootstrap/stage0/jakt__prelude__string_specializations.cpp
+++ b/bootstrap/stage0/jakt__prelude__string_specializations.cpp
@@ -28,6 +28,7 @@
 #include "jakt__platform.h"
 #include "jakt__arguments.h"
 #include "jakt__prelude__prelude.h"
+#include "jakt__prelude__hash.h"
 #include "jakt__prelude__operators.h"
 #include "jakt__prelude__string.h"
 #include "jakt__prelude__iteration.h"

--- a/bootstrap/stage0/lexer.h
+++ b/bootstrap/stage0/lexer.h
@@ -5,7 +5,43 @@
 #include "compiler.h"
 namespace Jakt {
 namespace lexer {
-namespace LiteralPrefix_Details {
+struct Lexer {
+  public:
+size_t index;JaktInternal::DynamicArray<u8> input;NonnullRefPtr<compiler::Compiler> compiler;JaktInternal::Optional<JaktInternal::DynamicArray<u8>> comment_contents;ErrorOr<JaktInternal::Optional<DeprecatedString>> consume_comment_contents();
+ErrorOr<lexer::Token> lex_quoted_string(u8 const delimiter);
+ErrorOr<JaktInternal::Optional<lexer::Token>> next();
+ErrorOr<lexer::Token> lex_character_constant_or_name();
+lexer::Token lex_dot();
+lexer::Token lex_question_mark();
+ErrorOr<lexer::Token> lex_forward_slash();
+u8 peek_behind(size_t const steps) const;
+u8 peek_ahead(size_t const steps) const;
+lexer::Token lex_asterisk();
+lexer::Token lex_minus();
+u8 peek() const;
+lexer::Token lex_percent_sign();
+ErrorOr<lexer::Token> lex_number_or_name();
+lexer::Token lex_less_than();
+bool eof() const;
+Lexer(size_t a_index, JaktInternal::DynamicArray<u8> a_input, NonnullRefPtr<compiler::Compiler> a_compiler, JaktInternal::Optional<JaktInternal::DynamicArray<u8>> a_comment_contents);
+
+lexer::Token lex_ampersand();
+utility::Span span(size_t const start, size_t const end) const;
+lexer::Token lex_plus();
+lexer::Token lex_exclamation_point();
+ErrorOr<lexer::LiteralSuffix> consume_numeric_literal_suffix();
+lexer::Token lex_colon();
+bool valid_digit(lexer::LiteralPrefix const prefix, u8 const digit, bool const decimal_allowed);
+ErrorOr<void> error(DeprecatedString const message, utility::Span const span);
+lexer::Token lex_equals();
+ErrorOr<DeprecatedString> substring(size_t const start, size_t const length) const;
+lexer::Token lex_greater_than();
+lexer::Token lex_pipe();
+lexer::Token lex_caret();
+ErrorOr<lexer::Token> lex_number();
+static ErrorOr<JaktInternal::DynamicArray<lexer::Token>> lex(NonnullRefPtr<compiler::Compiler> const compiler);
+ErrorOr<DeprecatedString> debug_description() const;
+};namespace LiteralPrefix_Details {
 struct None {
 };
 struct Hexadecimal {
@@ -989,43 +1025,13 @@ ErrorOr<DeprecatedString> debug_description() const;
 static ErrorOr<lexer::Token> from_keyword_or_identifier(DeprecatedString const string, utility::Span const span);
 utility::Span span() const;
 };
-struct Lexer {
-  public:
-size_t index;JaktInternal::DynamicArray<u8> input;NonnullRefPtr<compiler::Compiler> compiler;JaktInternal::Optional<JaktInternal::DynamicArray<u8>> comment_contents;ErrorOr<JaktInternal::Optional<DeprecatedString>> consume_comment_contents();
-ErrorOr<lexer::Token> lex_quoted_string(u8 const delimiter);
-ErrorOr<JaktInternal::Optional<lexer::Token>> next();
-ErrorOr<lexer::Token> lex_character_constant_or_name();
-lexer::Token lex_dot();
-lexer::Token lex_question_mark();
-ErrorOr<lexer::Token> lex_forward_slash();
-u8 peek_behind(size_t const steps) const;
-u8 peek_ahead(size_t const steps) const;
-lexer::Token lex_asterisk();
-lexer::Token lex_minus();
-u8 peek() const;
-lexer::Token lex_percent_sign();
-ErrorOr<lexer::Token> lex_number_or_name();
-lexer::Token lex_less_than();
-bool eof() const;
-Lexer(size_t a_index, JaktInternal::DynamicArray<u8> a_input, NonnullRefPtr<compiler::Compiler> a_compiler, JaktInternal::Optional<JaktInternal::DynamicArray<u8>> a_comment_contents);
-
-lexer::Token lex_ampersand();
-utility::Span span(size_t const start, size_t const end) const;
-lexer::Token lex_plus();
-lexer::Token lex_exclamation_point();
-ErrorOr<lexer::LiteralSuffix> consume_numeric_literal_suffix();
-lexer::Token lex_colon();
-bool valid_digit(lexer::LiteralPrefix const prefix, u8 const digit, bool const decimal_allowed);
-ErrorOr<void> error(DeprecatedString const message, utility::Span const span);
-lexer::Token lex_equals();
-ErrorOr<DeprecatedString> substring(size_t const start, size_t const length) const;
-lexer::Token lex_greater_than();
-lexer::Token lex_pipe();
-lexer::Token lex_caret();
-ErrorOr<lexer::Token> lex_number();
-static ErrorOr<JaktInternal::DynamicArray<lexer::Token>> lex(NonnullRefPtr<compiler::Compiler> const compiler);
-ErrorOr<DeprecatedString> debug_description() const;
-};}
+}
+} // namespace Jakt
+template<>struct Jakt::Formatter<Jakt::lexer::Lexer> : Jakt::Formatter<Jakt::StringView>{
+Jakt::ErrorOr<void> format(Jakt::FormatBuilder& builder, Jakt::lexer::Lexer const& value) {
+JaktInternal::PrettyPrint::ScopedEnable pretty_print_enable { m_alternative_form };Jakt::ErrorOr<void> format_error = Jakt::Formatter<Jakt::StringView>::format(builder, MUST(value.debug_description()));return format_error;}
+};
+namespace Jakt {
 } // namespace Jakt
 template<>struct Jakt::Formatter<Jakt::lexer::LiteralPrefix> : Jakt::Formatter<Jakt::StringView>{
 Jakt::ErrorOr<void> format(Jakt::FormatBuilder& builder, Jakt::lexer::LiteralPrefix const& value) {
@@ -1041,12 +1047,6 @@ namespace Jakt {
 } // namespace Jakt
 template<>struct Jakt::Formatter<Jakt::lexer::Token> : Jakt::Formatter<Jakt::StringView>{
 Jakt::ErrorOr<void> format(Jakt::FormatBuilder& builder, Jakt::lexer::Token const& value) {
-JaktInternal::PrettyPrint::ScopedEnable pretty_print_enable { m_alternative_form };Jakt::ErrorOr<void> format_error = Jakt::Formatter<Jakt::StringView>::format(builder, MUST(value.debug_description()));return format_error;}
-};
-namespace Jakt {
-} // namespace Jakt
-template<>struct Jakt::Formatter<Jakt::lexer::Lexer> : Jakt::Formatter<Jakt::StringView>{
-Jakt::ErrorOr<void> format(Jakt::FormatBuilder& builder, Jakt::lexer::Lexer const& value) {
 JaktInternal::PrettyPrint::ScopedEnable pretty_print_enable { m_alternative_form };Jakt::ErrorOr<void> format_error = Jakt::Formatter<Jakt::StringView>::format(builder, MUST(value.debug_description()));return format_error;}
 };
 namespace Jakt {

--- a/bootstrap/stage0/lexer_specializations.cpp
+++ b/bootstrap/stage0/lexer_specializations.cpp
@@ -28,6 +28,7 @@
 #include "jakt__platform.h"
 #include "jakt__arguments.h"
 #include "jakt__prelude__prelude.h"
+#include "jakt__prelude__hash.h"
 #include "jakt__prelude__operators.h"
 #include "jakt__prelude__string.h"
 #include "jakt__prelude__iteration.h"

--- a/bootstrap/stage0/main_specializations.cpp
+++ b/bootstrap/stage0/main_specializations.cpp
@@ -28,6 +28,7 @@
 #include "jakt__platform.h"
 #include "jakt__arguments.h"
 #include "jakt__prelude__prelude.h"
+#include "jakt__prelude__hash.h"
 #include "jakt__prelude__operators.h"
 #include "jakt__prelude__string.h"
 #include "jakt__prelude__iteration.h"

--- a/bootstrap/stage0/parser.h
+++ b/bootstrap/stage0/parser.h
@@ -6,77 +6,105 @@
 #include "compiler.h"
 namespace Jakt {
 namespace parser {
-namespace ParsedCapture_Details {
-struct ByValue {
-DeprecatedString name;
-utility::Span span;
-template<typename _MemberT0, typename _MemberT1>
-ByValue(_MemberT0&& member_0, _MemberT1&& member_1):
-name{ forward<_MemberT0>(member_0)},
-span{ forward<_MemberT1>(member_1)}
+namespace ParsedTraitRequirements_Details {
+struct Nothing {
+};
+struct Methods{
+JaktInternal::DynamicArray<parser::ParsedFunction> value;
+template<typename _MemberT0>
+Methods(_MemberT0&& member_0):
+value{ forward<_MemberT0>(member_0)}
 {}
 };
-struct ByReference {
-DeprecatedString name;
-utility::Span span;
-template<typename _MemberT0, typename _MemberT1>
-ByReference(_MemberT0&& member_0, _MemberT1&& member_1):
-name{ forward<_MemberT0>(member_0)},
-span{ forward<_MemberT1>(member_1)}
-{}
-};
-struct ByMutableReference {
-DeprecatedString name;
-utility::Span span;
-template<typename _MemberT0, typename _MemberT1>
-ByMutableReference(_MemberT0&& member_0, _MemberT1&& member_1):
-name{ forward<_MemberT0>(member_0)},
-span{ forward<_MemberT1>(member_1)}
-{}
-};
-struct ByComptimeDependency {
-DeprecatedString name;
-utility::Span span;
-template<typename _MemberT0, typename _MemberT1>
-ByComptimeDependency(_MemberT0&& member_0, _MemberT1&& member_1):
-name{ forward<_MemberT0>(member_0)},
-span{ forward<_MemberT1>(member_1)}
-{}
-};
-struct AllByReference {
-DeprecatedString name;
-utility::Span span;
-template<typename _MemberT0, typename _MemberT1>
-AllByReference(_MemberT0&& member_0, _MemberT1&& member_1):
-name{ forward<_MemberT0>(member_0)},
-span{ forward<_MemberT1>(member_1)}
+struct ComptimeExpression{
+NonnullRefPtr<typename parser::ParsedExpression> value;
+template<typename _MemberT0>
+ComptimeExpression(_MemberT0&& member_0):
+value{ forward<_MemberT0>(member_0)}
 {}
 };
 }
-struct ParsedCapture : public Variant<ParsedCapture_Details::ByValue, ParsedCapture_Details::ByReference, ParsedCapture_Details::ByMutableReference, ParsedCapture_Details::ByComptimeDependency, ParsedCapture_Details::AllByReference> {
-using Variant<ParsedCapture_Details::ByValue, ParsedCapture_Details::ByReference, ParsedCapture_Details::ByMutableReference, ParsedCapture_Details::ByComptimeDependency, ParsedCapture_Details::AllByReference>::Variant;
-    using ByValue = ParsedCapture_Details::ByValue;
-    using ByReference = ParsedCapture_Details::ByReference;
-    using ByMutableReference = ParsedCapture_Details::ByMutableReference;
-    using ByComptimeDependency = ParsedCapture_Details::ByComptimeDependency;
-    using AllByReference = ParsedCapture_Details::AllByReference;
+struct ParsedTraitRequirements : public Variant<ParsedTraitRequirements_Details::Nothing, ParsedTraitRequirements_Details::Methods, ParsedTraitRequirements_Details::ComptimeExpression> {
+using Variant<ParsedTraitRequirements_Details::Nothing, ParsedTraitRequirements_Details::Methods, ParsedTraitRequirements_Details::ComptimeExpression>::Variant;
+    using Nothing = ParsedTraitRequirements_Details::Nothing;
+    using Methods = ParsedTraitRequirements_Details::Methods;
+    using ComptimeExpression = ParsedTraitRequirements_Details::ComptimeExpression;
 ErrorOr<DeprecatedString> debug_description() const;
-DeprecatedString const& name() const { switch(this->index()) {case 0 /* ByValue */: return this->template get<ParsedCapture::ByValue>().name;
-case 1 /* ByReference */: return this->template get<ParsedCapture::ByReference>().name;
-case 2 /* ByMutableReference */: return this->template get<ParsedCapture::ByMutableReference>().name;
-case 3 /* ByComptimeDependency */: return this->template get<ParsedCapture::ByComptimeDependency>().name;
-case 4 /* AllByReference */: return this->template get<ParsedCapture::AllByReference>().name;
-default: VERIFY_NOT_REACHED();
+};
+struct ParsedTrait {
+  public:
+DeprecatedString name;utility::Span name_span;JaktInternal::DynamicArray<parser::ParsedGenericParameter> generic_parameters;parser::ParsedTraitRequirements requirements;ParsedTrait(DeprecatedString a_name, utility::Span a_name_span, JaktInternal::DynamicArray<parser::ParsedGenericParameter> a_generic_parameters, parser::ParsedTraitRequirements a_requirements);
+
+ErrorOr<DeprecatedString> debug_description() const;
+};namespace Visibility_Details {
+struct Public {
+};
+struct Private {
+};
+struct Restricted {
+JaktInternal::DynamicArray<parser::VisibilityRestriction> whitelist;
+utility::Span span;
+template<typename _MemberT0, typename _MemberT1>
+Restricted(_MemberT0&& member_0, _MemberT1&& member_1):
+whitelist{ forward<_MemberT0>(member_0)},
+span{ forward<_MemberT1>(member_1)}
+{}
+};
 }
+struct Visibility : public Variant<Visibility_Details::Public, Visibility_Details::Private, Visibility_Details::Restricted> {
+using Variant<Visibility_Details::Public, Visibility_Details::Private, Visibility_Details::Restricted>::Variant;
+    using Public = Visibility_Details::Public;
+    using Private = Visibility_Details::Private;
+    using Restricted = Visibility_Details::Restricted;
+ErrorOr<DeprecatedString> debug_description() const;
+};
+struct ParsedBlock {
+  public:
+JaktInternal::DynamicArray<NonnullRefPtr<typename parser::ParsedStatement>> stmts;ParsedBlock(JaktInternal::DynamicArray<NonnullRefPtr<typename parser::ParsedStatement>> a_stmts);
+
+JaktInternal::Optional<utility::Span> find_yield_span() const;
+bool equals(parser::ParsedBlock const rhs_block) const;
+ErrorOr<JaktInternal::Optional<utility::Span>> span(parser::Parser const parser) const;
+JaktInternal::Optional<utility::Span> find_yield_keyword_span() const;
+ErrorOr<DeprecatedString> debug_description() const;
+};namespace FunctionType_Details {
+struct Normal {
+};
+struct Destructor {
+};
+struct ImplicitConstructor {
+};
+struct ImplicitEnumConstructor {
+};
+struct ExternalClassConstructor {
+};
+struct Expression {
+};
+struct Closure {
+};
 }
-utility::Span const& span() const { switch(this->index()) {case 0 /* ByValue */: return this->template get<ParsedCapture::ByValue>().span;
-case 1 /* ByReference */: return this->template get<ParsedCapture::ByReference>().span;
-case 2 /* ByMutableReference */: return this->template get<ParsedCapture::ByMutableReference>().span;
-case 3 /* ByComptimeDependency */: return this->template get<ParsedCapture::ByComptimeDependency>().span;
-case 4 /* AllByReference */: return this->template get<ParsedCapture::AllByReference>().span;
-default: VERIFY_NOT_REACHED();
+struct FunctionType : public Variant<FunctionType_Details::Normal, FunctionType_Details::Destructor, FunctionType_Details::ImplicitConstructor, FunctionType_Details::ImplicitEnumConstructor, FunctionType_Details::ExternalClassConstructor, FunctionType_Details::Expression, FunctionType_Details::Closure> {
+using Variant<FunctionType_Details::Normal, FunctionType_Details::Destructor, FunctionType_Details::ImplicitConstructor, FunctionType_Details::ImplicitEnumConstructor, FunctionType_Details::ExternalClassConstructor, FunctionType_Details::Expression, FunctionType_Details::Closure>::Variant;
+    using Normal = FunctionType_Details::Normal;
+    using Destructor = FunctionType_Details::Destructor;
+    using ImplicitConstructor = FunctionType_Details::ImplicitConstructor;
+    using ImplicitEnumConstructor = FunctionType_Details::ImplicitEnumConstructor;
+    using ExternalClassConstructor = FunctionType_Details::ExternalClassConstructor;
+    using Expression = FunctionType_Details::Expression;
+    using Closure = FunctionType_Details::Closure;
+ErrorOr<DeprecatedString> debug_description() const;
+};
+namespace FunctionLinkage_Details {
+struct Internal {
+};
+struct External {
+};
 }
-}
+struct FunctionLinkage : public Variant<FunctionLinkage_Details::Internal, FunctionLinkage_Details::External> {
+using Variant<FunctionLinkage_Details::Internal, FunctionLinkage_Details::External>::Variant;
+    using Internal = FunctionLinkage_Details::Internal;
+    using External = FunctionLinkage_Details::External;
+ErrorOr<DeprecatedString> debug_description() const;
 };
 namespace ExternalName_Details {
 struct Plain{
@@ -102,7 +130,152 @@ ErrorOr<DeprecatedString> debug_description() const;
 ErrorOr<DeprecatedString> as_name_for_use() const;
 ErrorOr<DeprecatedString> as_name_for_definition() const;
 };
-struct ParsedName {
+struct ParsedFunction {
+  public:
+size_t id;DeprecatedString name;utility::Span name_span;parser::Visibility visibility;JaktInternal::DynamicArray<parser::ParsedParameter> params;JaktInternal::DynamicArray<parser::ParsedGenericParameter> generic_parameters;parser::ParsedBlock block;NonnullRefPtr<typename parser::ParsedType> return_type;utility::Span return_type_span;bool can_throw;parser::FunctionType type;parser::FunctionLinkage linkage;bool must_instantiate;bool is_comptime;bool is_fat_arrow;bool is_unsafe;JaktInternal::Optional<parser::ExternalName> external_name;JaktInternal::Optional<DeprecatedString> deprecated_message;JaktInternal::Optional<JaktInternal::DynamicArray<JaktInternal::Tuple<size_t,parser::ArgumentStoreLevel>>> stores_arguments;JaktInternal::Optional<bool> force_inline;ParsedFunction(size_t a_id, DeprecatedString a_name, utility::Span a_name_span, parser::Visibility a_visibility, JaktInternal::DynamicArray<parser::ParsedParameter> a_params, JaktInternal::DynamicArray<parser::ParsedGenericParameter> a_generic_parameters, parser::ParsedBlock a_block, NonnullRefPtr<typename parser::ParsedType> a_return_type, utility::Span a_return_type_span, bool a_can_throw, parser::FunctionType a_type, parser::FunctionLinkage a_linkage, bool a_must_instantiate, bool a_is_comptime, bool a_is_fat_arrow, bool a_is_unsafe, JaktInternal::Optional<parser::ExternalName> a_external_name, JaktInternal::Optional<DeprecatedString> a_deprecated_message, JaktInternal::Optional<JaktInternal::DynamicArray<JaktInternal::Tuple<size_t,parser::ArgumentStoreLevel>>> a_stores_arguments, JaktInternal::Optional<bool> a_force_inline);
+
+bool equals(parser::ParsedFunction const other, bool const ignore_block) const;
+ErrorOr<DeprecatedString> debug_description() const;
+};struct ParsedMethod {
+  public:
+parser::ParsedFunction parsed_function;parser::Visibility visibility;bool is_virtual;bool is_override;ParsedMethod(parser::ParsedFunction a_parsed_function, parser::Visibility a_visibility, bool a_is_virtual, bool a_is_override);
+
+ErrorOr<DeprecatedString> debug_description() const;
+};struct SumEnumVariant {
+  public:
+DeprecatedString name;utility::Span span;JaktInternal::Optional<JaktInternal::DynamicArray<parser::ParsedVarDecl>> params;JaktInternal::Optional<JaktInternal::DynamicArray<JaktInternal::Optional<NonnullRefPtr<typename parser::ParsedExpression>>>> default_values;SumEnumVariant(DeprecatedString a_name, utility::Span a_span, JaktInternal::Optional<JaktInternal::DynamicArray<parser::ParsedVarDecl>> a_params, JaktInternal::Optional<JaktInternal::DynamicArray<JaktInternal::Optional<NonnullRefPtr<typename parser::ParsedExpression>>>> a_default_values);
+
+ErrorOr<DeprecatedString> debug_description() const;
+};struct ParsedCall {
+  public:
+JaktInternal::DynamicArray<DeprecatedString> namespace_;DeprecatedString name;JaktInternal::DynamicArray<JaktInternal::Tuple<DeprecatedString,utility::Span,NonnullRefPtr<typename parser::ParsedExpression>>> args;JaktInternal::DynamicArray<NonnullRefPtr<typename parser::ParsedType>> type_args;ParsedCall(JaktInternal::DynamicArray<DeprecatedString> a_namespace_, DeprecatedString a_name, JaktInternal::DynamicArray<JaktInternal::Tuple<DeprecatedString,utility::Span,NonnullRefPtr<typename parser::ParsedExpression>>> a_args, JaktInternal::DynamicArray<NonnullRefPtr<typename parser::ParsedType>> a_type_args);
+
+bool equals(parser::ParsedCall const rhs_parsed_call) const;
+ErrorOr<DeprecatedString> debug_description() const;
+};namespace NumericConstant_Details {
+struct I8{
+i8 value;
+template<typename _MemberT0>
+I8(_MemberT0&& member_0):
+value{ forward<_MemberT0>(member_0)}
+{}
+};
+struct I16{
+i16 value;
+template<typename _MemberT0>
+I16(_MemberT0&& member_0):
+value{ forward<_MemberT0>(member_0)}
+{}
+};
+struct I32{
+i32 value;
+template<typename _MemberT0>
+I32(_MemberT0&& member_0):
+value{ forward<_MemberT0>(member_0)}
+{}
+};
+struct I64{
+i64 value;
+template<typename _MemberT0>
+I64(_MemberT0&& member_0):
+value{ forward<_MemberT0>(member_0)}
+{}
+};
+struct U8{
+u8 value;
+template<typename _MemberT0>
+U8(_MemberT0&& member_0):
+value{ forward<_MemberT0>(member_0)}
+{}
+};
+struct U16{
+u16 value;
+template<typename _MemberT0>
+U16(_MemberT0&& member_0):
+value{ forward<_MemberT0>(member_0)}
+{}
+};
+struct U32{
+u32 value;
+template<typename _MemberT0>
+U32(_MemberT0&& member_0):
+value{ forward<_MemberT0>(member_0)}
+{}
+};
+struct U64{
+u64 value;
+template<typename _MemberT0>
+U64(_MemberT0&& member_0):
+value{ forward<_MemberT0>(member_0)}
+{}
+};
+struct USize{
+u64 value;
+template<typename _MemberT0>
+USize(_MemberT0&& member_0):
+value{ forward<_MemberT0>(member_0)}
+{}
+};
+struct F32{
+f32 value;
+template<typename _MemberT0>
+F32(_MemberT0&& member_0):
+value{ forward<_MemberT0>(member_0)}
+{}
+};
+struct F64{
+f64 value;
+template<typename _MemberT0>
+F64(_MemberT0&& member_0):
+value{ forward<_MemberT0>(member_0)}
+{}
+};
+struct UnknownSigned{
+i64 value;
+template<typename _MemberT0>
+UnknownSigned(_MemberT0&& member_0):
+value{ forward<_MemberT0>(member_0)}
+{}
+};
+struct UnknownUnsigned{
+u64 value;
+template<typename _MemberT0>
+UnknownUnsigned(_MemberT0&& member_0):
+value{ forward<_MemberT0>(member_0)}
+{}
+};
+}
+struct NumericConstant : public Variant<NumericConstant_Details::I8, NumericConstant_Details::I16, NumericConstant_Details::I32, NumericConstant_Details::I64, NumericConstant_Details::U8, NumericConstant_Details::U16, NumericConstant_Details::U32, NumericConstant_Details::U64, NumericConstant_Details::USize, NumericConstant_Details::F32, NumericConstant_Details::F64, NumericConstant_Details::UnknownSigned, NumericConstant_Details::UnknownUnsigned> {
+using Variant<NumericConstant_Details::I8, NumericConstant_Details::I16, NumericConstant_Details::I32, NumericConstant_Details::I64, NumericConstant_Details::U8, NumericConstant_Details::U16, NumericConstant_Details::U32, NumericConstant_Details::U64, NumericConstant_Details::USize, NumericConstant_Details::F32, NumericConstant_Details::F64, NumericConstant_Details::UnknownSigned, NumericConstant_Details::UnknownUnsigned>::Variant;
+    using I8 = NumericConstant_Details::I8;
+    using I16 = NumericConstant_Details::I16;
+    using I32 = NumericConstant_Details::I32;
+    using I64 = NumericConstant_Details::I64;
+    using U8 = NumericConstant_Details::U8;
+    using U16 = NumericConstant_Details::U16;
+    using U32 = NumericConstant_Details::U32;
+    using U64 = NumericConstant_Details::U64;
+    using USize = NumericConstant_Details::USize;
+    using F32 = NumericConstant_Details::F32;
+    using F64 = NumericConstant_Details::F64;
+    using UnknownSigned = NumericConstant_Details::UnknownSigned;
+    using UnknownUnsigned = NumericConstant_Details::UnknownUnsigned;
+ErrorOr<DeprecatedString> debug_description() const;
+size_t to_usize() const;
+};
+struct ParsedVariable {
+  public:
+DeprecatedString name;NonnullRefPtr<typename parser::ParsedType> parsed_type;bool is_mutable;utility::Span span;ParsedVariable(DeprecatedString a_name, NonnullRefPtr<typename parser::ParsedType> a_parsed_type, bool a_is_mutable, utility::Span a_span);
+
+bool equals(parser::ParsedVariable const rhs_parsed_varible) const;
+ErrorOr<DeprecatedString> debug_description() const;
+};struct ParsedParameter {
+  public:
+bool requires_label;parser::ParsedVariable variable;JaktInternal::Optional<NonnullRefPtr<typename parser::ParsedExpression>> default_argument;utility::Span span;ParsedParameter(bool a_requires_label, parser::ParsedVariable a_variable, JaktInternal::Optional<NonnullRefPtr<typename parser::ParsedExpression>> a_default_argument, utility::Span a_span);
+
+bool equals(parser::ParsedParameter const rhs_param) const;
+ErrorOr<DeprecatedString> debug_description() const;
+};struct ParsedName {
   public:
 DeprecatedString name;utility::Span span;ParsedName(DeprecatedString a_name, utility::Span a_span);
 
@@ -112,7 +285,648 @@ ErrorOr<DeprecatedString> debug_description() const;
 JaktInternal::Optional<parser::ParsedName> alias_name;JaktInternal::DynamicArray<parser::ParsedNameWithGenericParameters> target;ParsedAlias(JaktInternal::Optional<parser::ParsedName> a_alias_name, JaktInternal::DynamicArray<parser::ParsedNameWithGenericParameters> a_target);
 
 ErrorOr<DeprecatedString> debug_description() const;
-};namespace ParsedType_Details {
+};struct ValueEnumVariant {
+  public:
+DeprecatedString name;utility::Span span;JaktInternal::Optional<NonnullRefPtr<typename parser::ParsedExpression>> value;ValueEnumVariant(DeprecatedString a_name, utility::Span a_span, JaktInternal::Optional<NonnullRefPtr<typename parser::ParsedExpression>> a_value);
+
+ErrorOr<DeprecatedString> debug_description() const;
+};namespace ParsedMatchBody_Details {
+struct Expression{
+NonnullRefPtr<typename parser::ParsedExpression> value;
+template<typename _MemberT0>
+Expression(_MemberT0&& member_0):
+value{ forward<_MemberT0>(member_0)}
+{}
+};
+struct Block{
+parser::ParsedBlock value;
+template<typename _MemberT0>
+Block(_MemberT0&& member_0):
+value{ forward<_MemberT0>(member_0)}
+{}
+};
+}
+struct ParsedMatchBody : public Variant<ParsedMatchBody_Details::Expression, ParsedMatchBody_Details::Block> {
+using Variant<ParsedMatchBody_Details::Expression, ParsedMatchBody_Details::Block>::Variant;
+    using Expression = ParsedMatchBody_Details::Expression;
+    using Block = ParsedMatchBody_Details::Block;
+ErrorOr<DeprecatedString> debug_description() const;
+bool equals(parser::ParsedMatchBody const rhs_match_body) const;
+};
+struct ParsedMatchCase {
+  public:
+JaktInternal::DynamicArray<parser::ParsedMatchPattern> patterns;utility::Span marker_span;parser::ParsedMatchBody body;bool has_equal_pattern(parser::ParsedMatchCase const rhs_match_case) const;
+bool equals(parser::ParsedMatchCase const rhs_match_case) const;
+ParsedMatchCase(JaktInternal::DynamicArray<parser::ParsedMatchPattern> a_patterns, utility::Span a_marker_span, parser::ParsedMatchBody a_body);
+
+ErrorOr<DeprecatedString> debug_description() const;
+};struct ParsedAttributeArgument {
+  public:
+DeprecatedString name;utility::Span span;JaktInternal::Optional<DeprecatedString> assigned_value;ParsedAttributeArgument(DeprecatedString a_name, utility::Span a_span, JaktInternal::Optional<DeprecatedString> a_assigned_value);
+
+ErrorOr<DeprecatedString> debug_description() const;
+};struct ParsedVarDecl {
+  public:
+DeprecatedString name;NonnullRefPtr<typename parser::ParsedType> parsed_type;bool is_mutable;JaktInternal::Optional<utility::Span> inlay_span;utility::Span span;JaktInternal::Optional<parser::ExternalName> external_name;bool equals(parser::ParsedVarDecl const rhs_var_decl) const;
+ParsedVarDecl(DeprecatedString a_name, NonnullRefPtr<typename parser::ParsedType> a_parsed_type, bool a_is_mutable, JaktInternal::Optional<utility::Span> a_inlay_span, utility::Span a_span, JaktInternal::Optional<parser::ExternalName> a_external_name);
+
+ErrorOr<DeprecatedString> debug_description() const;
+};struct ParsedPatternDefault {
+  public:
+parser::ParsedVarDecl variable;NonnullRefPtr<typename parser::ParsedExpression> value;ParsedPatternDefault(parser::ParsedVarDecl a_variable, NonnullRefPtr<typename parser::ParsedExpression> a_value);
+
+ErrorOr<DeprecatedString> debug_description() const;
+};namespace TypeCast_Details {
+struct Fallible{
+NonnullRefPtr<typename parser::ParsedType> value;
+template<typename _MemberT0>
+Fallible(_MemberT0&& member_0):
+value{ forward<_MemberT0>(member_0)}
+{}
+};
+struct Infallible{
+NonnullRefPtr<typename parser::ParsedType> value;
+template<typename _MemberT0>
+Infallible(_MemberT0&& member_0):
+value{ forward<_MemberT0>(member_0)}
+{}
+};
+}
+struct TypeCast : public Variant<TypeCast_Details::Fallible, TypeCast_Details::Infallible> {
+using Variant<TypeCast_Details::Fallible, TypeCast_Details::Infallible>::Variant;
+    using Fallible = TypeCast_Details::Fallible;
+    using Infallible = TypeCast_Details::Infallible;
+ErrorOr<DeprecatedString> debug_description() const;
+NonnullRefPtr<typename parser::ParsedType> parsed_type() const;
+};
+struct Parser {
+  public:
+size_t index;JaktInternal::DynamicArray<lexer::Token> tokens;NonnullRefPtr<compiler::Compiler> compiler;bool can_have_trailing_closure;size_t next_function_id;ErrorOr<NonnullRefPtr<typename parser::ParsedExpression>> parse_operand_base();
+utility::Span span(size_t const start, size_t const end) const;
+ErrorOr<JaktInternal::Optional<parser::NumericConstant>> make_integer_numeric_constant(u64 const number, lexer::LiteralSuffix const suffix, utility::Span const span);
+ErrorOr<NonnullRefPtr<typename parser::ParsedType>> parse_type_shorthand();
+ErrorOr<NonnullRefPtr<typename parser::ParsedExpression>> parse_lambda();
+ErrorOr<NonnullRefPtr<typename parser::ParsedType>> parse_type_longhand();
+ErrorOr<parser::ParsedAlias> parse_using();
+ErrorOr<JaktInternal::DynamicArray<parser::ParsedParameter>> parse_function_parameters();
+ErrorOr<JaktInternal::DynamicArray<parser::ParsedMatchCase>> parse_match_cases();
+ErrorOr<JaktInternal::Optional<parser::ParsedAttribute>> parse_attribute();
+ErrorOr<parser::ParsedMethod> parse_method(parser::FunctionLinkage const linkage, parser::Visibility const visibility, bool const is_virtual, bool const is_override, bool const is_comptime, bool const is_destructor, bool const is_unsafe);
+ErrorOr<parser::ParsedNamespace> parse_namespace(bool const process_only_one_entity);
+ErrorOr<JaktInternal::Tuple<JaktInternal::DynamicArray<parser::ParsedGenericParameter>,parser::ParsedNamespace>> parse_forall();
+ErrorOr<parser::ParsedVarDecl> parse_variable_declaration(bool const is_mutable);
+ErrorOr<NonnullRefPtr<typename parser::ParsedType>> parse_type_shorthand_set();
+ErrorOr<NonnullRefPtr<typename parser::ParsedStatement>> parse_if_statement();
+ErrorOr<JaktInternal::Optional<parser::ParsedCall>> parse_call();
+ErrorOr<void> inject_token(lexer::Token const token);
+ErrorOr<parser::ParsedRecord> parse_class(parser::DefinitionLinkage const definition_linkage);
+ErrorOr<parser::ParsedExternalTraitImplementation> parse_external_trait_implementation();
+ErrorOr<parser::ParsedMatchPattern> parse_match_pattern();
+ErrorOr<parser::ParsedFunction> parse_function(parser::FunctionLinkage const linkage, parser::Visibility const visibility, bool const is_comptime, bool const is_destructor, bool const is_unsafe, bool const allow_missing_body);
+ErrorOr<parser::ParsedExternImport> parse_extern_import(parser::ParsedNamespace& parent);
+ErrorOr<NonnullRefPtr<typename parser::ParsedType>> parse_typename();
+ErrorOr<JaktInternal::Tuple<JaktInternal::DynamicArray<parser::ParsedField>,JaktInternal::DynamicArray<parser::ParsedMethod>>> parse_struct_class_body(parser::DefinitionLinkage const definition_linkage, parser::Visibility const default_visibility, bool const is_class);
+ErrorOr<NonnullRefPtr<typename parser::ParsedExpression>> parse_unsafe_expr();
+static ErrorOr<parser::ParsedNamespace> parse(NonnullRefPtr<compiler::Compiler> const compiler, JaktInternal::DynamicArray<lexer::Token> const tokens);
+ErrorOr<JaktInternal::Optional<parser::NumericConstant>> make_float_numeric_constant(f64 const number, lexer::LiteralSuffix const suffix, utility::Span const span);
+ErrorOr<NonnullRefPtr<typename parser::ParsedExpression>> parse_range();
+ErrorOr<parser::ParsedBlock> parse_fat_arrow();
+void skip_newlines();
+ErrorOr<JaktInternal::Tuple<JaktInternal::DynamicArray<parser::ValueEnumVariant>,JaktInternal::DynamicArray<parser::ParsedMethod>>> parse_value_enum_body(parser::ParsedRecord const partial_enum, parser::DefinitionLinkage const definition_linkage);
+lexer::Token previous() const;
+ErrorOr<JaktInternal::DynamicArray<NonnullRefPtr<typename parser::ParsedType>>> parse_type_parameter_list();
+ErrorOr<JaktInternal::DynamicArray<parser::EnumVariantPatternArgument>> parse_variant_arguments();
+ErrorOr<NonnullRefPtr<typename parser::ParsedStatement>> parse_guard_statement();
+bool eof() const;
+ErrorOr<NonnullRefPtr<typename parser::ParsedExpression>> parse_asterisk();
+ErrorOr<NonnullRefPtr<typename parser::ParsedExpression>> parse_match_expression();
+ErrorOr<void> apply_attributes(parser::ParsedField& field, JaktInternal::DynamicArray<parser::ParsedAttribute> const& active_attributes);
+ErrorOr<void> apply_attributes(parser::ParsedFunction& parsed_function, JaktInternal::DynamicArray<parser::ParsedAttribute> const& active_attributes);
+ErrorOr<void> apply_attributes(parser::ParsedMethod& parsed_method, JaktInternal::DynamicArray<parser::ParsedAttribute> const& active_attributes);
+ErrorOr<void> apply_attributes(parser::ParsedRecord& parsed_record, JaktInternal::DynamicArray<parser::ParsedAttribute> const& active_attributes);
+lexer::Token current() const;
+ErrorOr<parser::ParsedRecord> parse_enum(parser::DefinitionLinkage const definition_linkage, bool const is_boxed);
+ErrorOr<parser::ParsedBlock> parse_block();
+utility::Span empty_span() const;
+ErrorOr<NonnullRefPtr<typename parser::ParsedExpression>> parse_postfix_colon_colon(utility::Span const start, NonnullRefPtr<typename parser::ParsedExpression> const expr);
+ErrorOr<void> error(DeprecatedString const message, utility::Span const span);
+ErrorOr<parser::ParsedTrait> parse_trait();
+ErrorOr<parser::Visibility> parse_restricted_visibility_modifier();
+ErrorOr<parser::ParsedVarDeclTuple> parse_destructuring_assignment(bool const is_mutable);
+ErrorOr<NonnullRefPtr<typename parser::ParsedExpression>> parse_operand_postfix_operator(utility::Span const start, NonnullRefPtr<typename parser::ParsedExpression> const expr);
+ErrorOr<NonnullRefPtr<typename parser::ParsedExpression>> parse_set_literal();
+ErrorOr<void> parse_attribute_list(JaktInternal::DynamicArray<parser::ParsedAttribute>& active_attributes);
+Parser(size_t a_index, JaktInternal::DynamicArray<lexer::Token> a_tokens, NonnullRefPtr<compiler::Compiler> a_compiler, bool a_can_have_trailing_closure, size_t a_next_function_id);
+
+ErrorOr<NonnullRefPtr<typename parser::ParsedExpression>> parse_expression(bool const allow_assignments, bool const allow_newlines);
+ErrorOr<NonnullRefPtr<typename parser::ParsedExpression>> parse_operator(bool const allow_assignments);
+ErrorOr<NonnullRefPtr<typename parser::ParsedStatement>> parse_for_statement();
+ErrorOr<NonnullRefPtr<typename parser::ParsedExpression>> parse_operand();
+ErrorOr<JaktInternal::Tuple<JaktInternal::DynamicArray<parser::SumEnumVariant>,JaktInternal::DynamicArray<parser::ParsedField>,JaktInternal::DynamicArray<parser::ParsedMethod>>> parse_sum_enum_body(parser::ParsedRecord const partial_enum, parser::DefinitionLinkage const definition_linkage, bool const is_boxed);
+ErrorOr<JaktInternal::DynamicArray<parser::ParsedCapture>> parse_captures();
+ErrorOr<NonnullRefPtr<typename parser::ParsedExpression>> parse_number(lexer::LiteralPrefix const prefix, DeprecatedString const number, lexer::LiteralSuffix suffix, utility::Span const span);
+ErrorOr<parser::ParsedModuleImport> parse_module_import();
+ErrorOr<parser::ParsedRecord> parse_record(parser::DefinitionLinkage const definition_linkage);
+lexer::Token peek(size_t const steps) const;
+ErrorOr<void> error_with_hint(DeprecatedString const message, utility::Span const span, DeprecatedString const hint, utility::Span const hint_span);
+ErrorOr<NonnullRefPtr<typename parser::ParsedType>> parse_type_shorthand_array_or_dictionary();
+ErrorOr<NonnullRefPtr<typename parser::ParsedType>> parse_type_shorthand_tuple();
+bool eol() const;
+ErrorOr<NonnullRefPtr<typename parser::ParsedExpression>> parse_array_or_dictionary_literal();
+ErrorOr<JaktInternal::DynamicArray<parser::ParsedMatchPattern>> parse_match_patterns();
+ErrorOr<void> parse_import(parser::ParsedNamespace& parent);
+ErrorOr<NonnullRefPtr<typename parser::ParsedStatement>> parse_statement(bool const inside_block);
+ErrorOr<parser::ParsedField> parse_field(parser::Visibility const visibility);
+ErrorOr<DeprecatedString> parse_argument_label();
+ErrorOr<NonnullRefPtr<typename parser::ParsedExpression>> parse_ampersand();
+ErrorOr<JaktInternal::Optional<JaktInternal::DynamicArray<parser::IncludeAction>>> parse_include_action();
+ErrorOr<NonnullRefPtr<typename parser::ParsedExpression>> parse_try_block();
+ErrorOr<JaktInternal::DynamicArray<parser::ParsedGenericParameter>> parse_generic_parameters();
+ErrorOr<parser::ParsedRecord> parse_struct(parser::DefinitionLinkage const definition_linkage);
+ErrorOr<JaktInternal::Optional<JaktInternal::DynamicArray<parser::ParsedNameWithGenericParameters>>> parse_trait_list();
+ErrorOr<DeprecatedString> debug_description() const;
+};struct ParsedGenericParameter {
+  public:
+DeprecatedString name;utility::Span span;JaktInternal::Optional<JaktInternal::DynamicArray<parser::ParsedNameWithGenericParameters>> requires_list;ParsedGenericParameter(DeprecatedString a_name, utility::Span a_span, JaktInternal::Optional<JaktInternal::DynamicArray<parser::ParsedNameWithGenericParameters>> a_requires_list);
+
+ErrorOr<DeprecatedString> debug_description() const;
+};struct ParsedField {
+  public:
+parser::ParsedVarDecl var_decl;parser::Visibility visibility;JaktInternal::Optional<NonnullRefPtr<typename parser::ParsedExpression>> default_value;ParsedField(parser::ParsedVarDecl a_var_decl, parser::Visibility a_visibility, JaktInternal::Optional<NonnullRefPtr<typename parser::ParsedExpression>> a_default_value);
+
+ErrorOr<DeprecatedString> debug_description() const;
+};namespace UnaryOperator_Details {
+struct PreIncrement {
+};
+struct PostIncrement {
+};
+struct PreDecrement {
+};
+struct PostDecrement {
+};
+struct Negate {
+};
+struct Dereference {
+};
+struct RawAddress {
+};
+struct Reference {
+};
+struct MutableReference {
+};
+struct LogicalNot {
+};
+struct BitwiseNot {
+};
+struct TypeCast{
+parser::TypeCast value;
+template<typename _MemberT0>
+TypeCast(_MemberT0&& member_0):
+value{ forward<_MemberT0>(member_0)}
+{}
+};
+struct Is{
+NonnullRefPtr<typename parser::ParsedType> value;
+template<typename _MemberT0>
+Is(_MemberT0&& member_0):
+value{ forward<_MemberT0>(member_0)}
+{}
+};
+struct IsEnumVariant {
+NonnullRefPtr<typename parser::ParsedType> inner;
+JaktInternal::DynamicArray<parser::EnumVariantPatternArgument> bindings;
+template<typename _MemberT0, typename _MemberT1>
+IsEnumVariant(_MemberT0&& member_0, _MemberT1&& member_1):
+inner{ forward<_MemberT0>(member_0)},
+bindings{ forward<_MemberT1>(member_1)}
+{}
+};
+struct Sizeof{
+NonnullRefPtr<typename parser::ParsedType> value;
+template<typename _MemberT0>
+Sizeof(_MemberT0&& member_0):
+value{ forward<_MemberT0>(member_0)}
+{}
+};
+}
+struct UnaryOperator : public Variant<UnaryOperator_Details::PreIncrement, UnaryOperator_Details::PostIncrement, UnaryOperator_Details::PreDecrement, UnaryOperator_Details::PostDecrement, UnaryOperator_Details::Negate, UnaryOperator_Details::Dereference, UnaryOperator_Details::RawAddress, UnaryOperator_Details::Reference, UnaryOperator_Details::MutableReference, UnaryOperator_Details::LogicalNot, UnaryOperator_Details::BitwiseNot, UnaryOperator_Details::TypeCast, UnaryOperator_Details::Is, UnaryOperator_Details::IsEnumVariant, UnaryOperator_Details::Sizeof> {
+using Variant<UnaryOperator_Details::PreIncrement, UnaryOperator_Details::PostIncrement, UnaryOperator_Details::PreDecrement, UnaryOperator_Details::PostDecrement, UnaryOperator_Details::Negate, UnaryOperator_Details::Dereference, UnaryOperator_Details::RawAddress, UnaryOperator_Details::Reference, UnaryOperator_Details::MutableReference, UnaryOperator_Details::LogicalNot, UnaryOperator_Details::BitwiseNot, UnaryOperator_Details::TypeCast, UnaryOperator_Details::Is, UnaryOperator_Details::IsEnumVariant, UnaryOperator_Details::Sizeof>::Variant;
+    using PreIncrement = UnaryOperator_Details::PreIncrement;
+    using PostIncrement = UnaryOperator_Details::PostIncrement;
+    using PreDecrement = UnaryOperator_Details::PreDecrement;
+    using PostDecrement = UnaryOperator_Details::PostDecrement;
+    using Negate = UnaryOperator_Details::Negate;
+    using Dereference = UnaryOperator_Details::Dereference;
+    using RawAddress = UnaryOperator_Details::RawAddress;
+    using Reference = UnaryOperator_Details::Reference;
+    using MutableReference = UnaryOperator_Details::MutableReference;
+    using LogicalNot = UnaryOperator_Details::LogicalNot;
+    using BitwiseNot = UnaryOperator_Details::BitwiseNot;
+    using TypeCast = UnaryOperator_Details::TypeCast;
+    using Is = UnaryOperator_Details::Is;
+    using IsEnumVariant = UnaryOperator_Details::IsEnumVariant;
+    using Sizeof = UnaryOperator_Details::Sizeof;
+ErrorOr<DeprecatedString> debug_description() const;
+bool equals(parser::UnaryOperator const rhs_op) const;
+};
+namespace BinaryOperator_Details {
+struct Add {
+};
+struct Subtract {
+};
+struct Multiply {
+};
+struct Divide {
+};
+struct Modulo {
+};
+struct LessThan {
+};
+struct LessThanOrEqual {
+};
+struct GreaterThan {
+};
+struct GreaterThanOrEqual {
+};
+struct Equal {
+};
+struct NotEqual {
+};
+struct BitwiseAnd {
+};
+struct BitwiseXor {
+};
+struct BitwiseOr {
+};
+struct BitwiseLeftShift {
+};
+struct BitwiseRightShift {
+};
+struct ArithmeticLeftShift {
+};
+struct ArithmeticRightShift {
+};
+struct LogicalAnd {
+};
+struct LogicalOr {
+};
+struct NoneCoalescing {
+};
+struct Assign {
+};
+struct BitwiseAndAssign {
+};
+struct BitwiseOrAssign {
+};
+struct BitwiseXorAssign {
+};
+struct BitwiseLeftShiftAssign {
+};
+struct BitwiseRightShiftAssign {
+};
+struct AddAssign {
+};
+struct SubtractAssign {
+};
+struct MultiplyAssign {
+};
+struct ModuloAssign {
+};
+struct DivideAssign {
+};
+struct NoneCoalescingAssign {
+};
+struct Garbage {
+};
+}
+struct BinaryOperator : public Variant<BinaryOperator_Details::Add, BinaryOperator_Details::Subtract, BinaryOperator_Details::Multiply, BinaryOperator_Details::Divide, BinaryOperator_Details::Modulo, BinaryOperator_Details::LessThan, BinaryOperator_Details::LessThanOrEqual, BinaryOperator_Details::GreaterThan, BinaryOperator_Details::GreaterThanOrEqual, BinaryOperator_Details::Equal, BinaryOperator_Details::NotEqual, BinaryOperator_Details::BitwiseAnd, BinaryOperator_Details::BitwiseXor, BinaryOperator_Details::BitwiseOr, BinaryOperator_Details::BitwiseLeftShift, BinaryOperator_Details::BitwiseRightShift, BinaryOperator_Details::ArithmeticLeftShift, BinaryOperator_Details::ArithmeticRightShift, BinaryOperator_Details::LogicalAnd, BinaryOperator_Details::LogicalOr, BinaryOperator_Details::NoneCoalescing, BinaryOperator_Details::Assign, BinaryOperator_Details::BitwiseAndAssign, BinaryOperator_Details::BitwiseOrAssign, BinaryOperator_Details::BitwiseXorAssign, BinaryOperator_Details::BitwiseLeftShiftAssign, BinaryOperator_Details::BitwiseRightShiftAssign, BinaryOperator_Details::AddAssign, BinaryOperator_Details::SubtractAssign, BinaryOperator_Details::MultiplyAssign, BinaryOperator_Details::ModuloAssign, BinaryOperator_Details::DivideAssign, BinaryOperator_Details::NoneCoalescingAssign, BinaryOperator_Details::Garbage> {
+using Variant<BinaryOperator_Details::Add, BinaryOperator_Details::Subtract, BinaryOperator_Details::Multiply, BinaryOperator_Details::Divide, BinaryOperator_Details::Modulo, BinaryOperator_Details::LessThan, BinaryOperator_Details::LessThanOrEqual, BinaryOperator_Details::GreaterThan, BinaryOperator_Details::GreaterThanOrEqual, BinaryOperator_Details::Equal, BinaryOperator_Details::NotEqual, BinaryOperator_Details::BitwiseAnd, BinaryOperator_Details::BitwiseXor, BinaryOperator_Details::BitwiseOr, BinaryOperator_Details::BitwiseLeftShift, BinaryOperator_Details::BitwiseRightShift, BinaryOperator_Details::ArithmeticLeftShift, BinaryOperator_Details::ArithmeticRightShift, BinaryOperator_Details::LogicalAnd, BinaryOperator_Details::LogicalOr, BinaryOperator_Details::NoneCoalescing, BinaryOperator_Details::Assign, BinaryOperator_Details::BitwiseAndAssign, BinaryOperator_Details::BitwiseOrAssign, BinaryOperator_Details::BitwiseXorAssign, BinaryOperator_Details::BitwiseLeftShiftAssign, BinaryOperator_Details::BitwiseRightShiftAssign, BinaryOperator_Details::AddAssign, BinaryOperator_Details::SubtractAssign, BinaryOperator_Details::MultiplyAssign, BinaryOperator_Details::ModuloAssign, BinaryOperator_Details::DivideAssign, BinaryOperator_Details::NoneCoalescingAssign, BinaryOperator_Details::Garbage>::Variant;
+    using Add = BinaryOperator_Details::Add;
+    using Subtract = BinaryOperator_Details::Subtract;
+    using Multiply = BinaryOperator_Details::Multiply;
+    using Divide = BinaryOperator_Details::Divide;
+    using Modulo = BinaryOperator_Details::Modulo;
+    using LessThan = BinaryOperator_Details::LessThan;
+    using LessThanOrEqual = BinaryOperator_Details::LessThanOrEqual;
+    using GreaterThan = BinaryOperator_Details::GreaterThan;
+    using GreaterThanOrEqual = BinaryOperator_Details::GreaterThanOrEqual;
+    using Equal = BinaryOperator_Details::Equal;
+    using NotEqual = BinaryOperator_Details::NotEqual;
+    using BitwiseAnd = BinaryOperator_Details::BitwiseAnd;
+    using BitwiseXor = BinaryOperator_Details::BitwiseXor;
+    using BitwiseOr = BinaryOperator_Details::BitwiseOr;
+    using BitwiseLeftShift = BinaryOperator_Details::BitwiseLeftShift;
+    using BitwiseRightShift = BinaryOperator_Details::BitwiseRightShift;
+    using ArithmeticLeftShift = BinaryOperator_Details::ArithmeticLeftShift;
+    using ArithmeticRightShift = BinaryOperator_Details::ArithmeticRightShift;
+    using LogicalAnd = BinaryOperator_Details::LogicalAnd;
+    using LogicalOr = BinaryOperator_Details::LogicalOr;
+    using NoneCoalescing = BinaryOperator_Details::NoneCoalescing;
+    using Assign = BinaryOperator_Details::Assign;
+    using BitwiseAndAssign = BinaryOperator_Details::BitwiseAndAssign;
+    using BitwiseOrAssign = BinaryOperator_Details::BitwiseOrAssign;
+    using BitwiseXorAssign = BinaryOperator_Details::BitwiseXorAssign;
+    using BitwiseLeftShiftAssign = BinaryOperator_Details::BitwiseLeftShiftAssign;
+    using BitwiseRightShiftAssign = BinaryOperator_Details::BitwiseRightShiftAssign;
+    using AddAssign = BinaryOperator_Details::AddAssign;
+    using SubtractAssign = BinaryOperator_Details::SubtractAssign;
+    using MultiplyAssign = BinaryOperator_Details::MultiplyAssign;
+    using ModuloAssign = BinaryOperator_Details::ModuloAssign;
+    using DivideAssign = BinaryOperator_Details::DivideAssign;
+    using NoneCoalescingAssign = BinaryOperator_Details::NoneCoalescingAssign;
+    using Garbage = BinaryOperator_Details::Garbage;
+ErrorOr<DeprecatedString> debug_description() const;
+bool equals(parser::BinaryOperator const rhs_op) const;
+bool is_assignment() const;
+};
+namespace ParsedStatement_Details {
+struct Expression {
+NonnullRefPtr<typename parser::ParsedExpression> expr;
+utility::Span span;
+template<typename _MemberT0, typename _MemberT1>
+Expression(_MemberT0&& member_0, _MemberT1&& member_1):
+expr{ forward<_MemberT0>(member_0)},
+span{ forward<_MemberT1>(member_1)}
+{}
+};
+struct Defer {
+NonnullRefPtr<typename parser::ParsedStatement> statement;
+utility::Span span;
+template<typename _MemberT0, typename _MemberT1>
+Defer(_MemberT0&& member_0, _MemberT1&& member_1):
+statement{ forward<_MemberT0>(member_0)},
+span{ forward<_MemberT1>(member_1)}
+{}
+};
+struct UnsafeBlock {
+parser::ParsedBlock block;
+utility::Span span;
+template<typename _MemberT0, typename _MemberT1>
+UnsafeBlock(_MemberT0&& member_0, _MemberT1&& member_1):
+block{ forward<_MemberT0>(member_0)},
+span{ forward<_MemberT1>(member_1)}
+{}
+};
+struct DestructuringAssignment {
+JaktInternal::DynamicArray<parser::ParsedVarDecl> vars;
+NonnullRefPtr<typename parser::ParsedStatement> var_decl;
+utility::Span span;
+template<typename _MemberT0, typename _MemberT1, typename _MemberT2>
+DestructuringAssignment(_MemberT0&& member_0, _MemberT1&& member_1, _MemberT2&& member_2):
+vars{ forward<_MemberT0>(member_0)},
+var_decl{ forward<_MemberT1>(member_1)},
+span{ forward<_MemberT2>(member_2)}
+{}
+};
+struct VarDecl {
+parser::ParsedVarDecl var;
+NonnullRefPtr<typename parser::ParsedExpression> init;
+utility::Span span;
+template<typename _MemberT0, typename _MemberT1, typename _MemberT2>
+VarDecl(_MemberT0&& member_0, _MemberT1&& member_1, _MemberT2&& member_2):
+var{ forward<_MemberT0>(member_0)},
+init{ forward<_MemberT1>(member_1)},
+span{ forward<_MemberT2>(member_2)}
+{}
+};
+struct If {
+NonnullRefPtr<typename parser::ParsedExpression> condition;
+parser::ParsedBlock then_block;
+JaktInternal::Optional<NonnullRefPtr<typename parser::ParsedStatement>> else_statement;
+utility::Span span;
+template<typename _MemberT0, typename _MemberT1, typename _MemberT2, typename _MemberT3>
+If(_MemberT0&& member_0, _MemberT1&& member_1, _MemberT2&& member_2, _MemberT3&& member_3):
+condition{ forward<_MemberT0>(member_0)},
+then_block{ forward<_MemberT1>(member_1)},
+else_statement{ forward<_MemberT2>(member_2)},
+span{ forward<_MemberT3>(member_3)}
+{}
+};
+struct Block {
+parser::ParsedBlock block;
+utility::Span span;
+template<typename _MemberT0, typename _MemberT1>
+Block(_MemberT0&& member_0, _MemberT1&& member_1):
+block{ forward<_MemberT0>(member_0)},
+span{ forward<_MemberT1>(member_1)}
+{}
+};
+struct Loop {
+parser::ParsedBlock block;
+utility::Span span;
+template<typename _MemberT0, typename _MemberT1>
+Loop(_MemberT0&& member_0, _MemberT1&& member_1):
+block{ forward<_MemberT0>(member_0)},
+span{ forward<_MemberT1>(member_1)}
+{}
+};
+struct While {
+NonnullRefPtr<typename parser::ParsedExpression> condition;
+parser::ParsedBlock block;
+utility::Span span;
+template<typename _MemberT0, typename _MemberT1, typename _MemberT2>
+While(_MemberT0&& member_0, _MemberT1&& member_1, _MemberT2&& member_2):
+condition{ forward<_MemberT0>(member_0)},
+block{ forward<_MemberT1>(member_1)},
+span{ forward<_MemberT2>(member_2)}
+{}
+};
+struct For {
+DeprecatedString iterator_name;
+utility::Span name_span;
+bool is_destructuring;
+NonnullRefPtr<typename parser::ParsedExpression> range;
+parser::ParsedBlock block;
+utility::Span span;
+template<typename _MemberT0, typename _MemberT1, typename _MemberT2, typename _MemberT3, typename _MemberT4, typename _MemberT5>
+For(_MemberT0&& member_0, _MemberT1&& member_1, _MemberT2&& member_2, _MemberT3&& member_3, _MemberT4&& member_4, _MemberT5&& member_5):
+iterator_name{ forward<_MemberT0>(member_0)},
+name_span{ forward<_MemberT1>(member_1)},
+is_destructuring{ forward<_MemberT2>(member_2)},
+range{ forward<_MemberT3>(member_3)},
+block{ forward<_MemberT4>(member_4)},
+span{ forward<_MemberT5>(member_5)}
+{}
+};
+struct Break{
+utility::Span value;
+template<typename _MemberT0>
+Break(_MemberT0&& member_0):
+value{ forward<_MemberT0>(member_0)}
+{}
+};
+struct Continue{
+utility::Span value;
+template<typename _MemberT0>
+Continue(_MemberT0&& member_0):
+value{ forward<_MemberT0>(member_0)}
+{}
+};
+struct Return {
+JaktInternal::Optional<NonnullRefPtr<typename parser::ParsedExpression>> expr;
+utility::Span span;
+template<typename _MemberT0, typename _MemberT1>
+Return(_MemberT0&& member_0, _MemberT1&& member_1):
+expr{ forward<_MemberT0>(member_0)},
+span{ forward<_MemberT1>(member_1)}
+{}
+};
+struct Throw {
+NonnullRefPtr<typename parser::ParsedExpression> expr;
+utility::Span span;
+template<typename _MemberT0, typename _MemberT1>
+Throw(_MemberT0&& member_0, _MemberT1&& member_1):
+expr{ forward<_MemberT0>(member_0)},
+span{ forward<_MemberT1>(member_1)}
+{}
+};
+struct Yield {
+NonnullRefPtr<typename parser::ParsedExpression> expr;
+utility::Span span;
+template<typename _MemberT0, typename _MemberT1>
+Yield(_MemberT0&& member_0, _MemberT1&& member_1):
+expr{ forward<_MemberT0>(member_0)},
+span{ forward<_MemberT1>(member_1)}
+{}
+};
+struct InlineCpp {
+parser::ParsedBlock block;
+utility::Span span;
+template<typename _MemberT0, typename _MemberT1>
+InlineCpp(_MemberT0&& member_0, _MemberT1&& member_1):
+block{ forward<_MemberT0>(member_0)},
+span{ forward<_MemberT1>(member_1)}
+{}
+};
+struct Guard {
+NonnullRefPtr<typename parser::ParsedExpression> expr;
+parser::ParsedBlock else_block;
+parser::ParsedBlock remaining_code;
+utility::Span span;
+template<typename _MemberT0, typename _MemberT1, typename _MemberT2, typename _MemberT3>
+Guard(_MemberT0&& member_0, _MemberT1&& member_1, _MemberT2&& member_2, _MemberT3&& member_3):
+expr{ forward<_MemberT0>(member_0)},
+else_block{ forward<_MemberT1>(member_1)},
+remaining_code{ forward<_MemberT2>(member_2)},
+span{ forward<_MemberT3>(member_3)}
+{}
+};
+struct Garbage{
+utility::Span value;
+template<typename _MemberT0>
+Garbage(_MemberT0&& member_0):
+value{ forward<_MemberT0>(member_0)}
+{}
+};
+}
+struct ParsedStatement : public Variant<ParsedStatement_Details::Expression, ParsedStatement_Details::Defer, ParsedStatement_Details::UnsafeBlock, ParsedStatement_Details::DestructuringAssignment, ParsedStatement_Details::VarDecl, ParsedStatement_Details::If, ParsedStatement_Details::Block, ParsedStatement_Details::Loop, ParsedStatement_Details::While, ParsedStatement_Details::For, ParsedStatement_Details::Break, ParsedStatement_Details::Continue, ParsedStatement_Details::Return, ParsedStatement_Details::Throw, ParsedStatement_Details::Yield, ParsedStatement_Details::InlineCpp, ParsedStatement_Details::Guard, ParsedStatement_Details::Garbage>, public RefCounted<ParsedStatement> {
+using Variant<ParsedStatement_Details::Expression, ParsedStatement_Details::Defer, ParsedStatement_Details::UnsafeBlock, ParsedStatement_Details::DestructuringAssignment, ParsedStatement_Details::VarDecl, ParsedStatement_Details::If, ParsedStatement_Details::Block, ParsedStatement_Details::Loop, ParsedStatement_Details::While, ParsedStatement_Details::For, ParsedStatement_Details::Break, ParsedStatement_Details::Continue, ParsedStatement_Details::Return, ParsedStatement_Details::Throw, ParsedStatement_Details::Yield, ParsedStatement_Details::InlineCpp, ParsedStatement_Details::Guard, ParsedStatement_Details::Garbage>::Variant;
+    using Expression = ParsedStatement_Details::Expression;
+    using Defer = ParsedStatement_Details::Defer;
+    using UnsafeBlock = ParsedStatement_Details::UnsafeBlock;
+    using DestructuringAssignment = ParsedStatement_Details::DestructuringAssignment;
+    using VarDecl = ParsedStatement_Details::VarDecl;
+    using If = ParsedStatement_Details::If;
+    using Block = ParsedStatement_Details::Block;
+    using Loop = ParsedStatement_Details::Loop;
+    using While = ParsedStatement_Details::While;
+    using For = ParsedStatement_Details::For;
+    using Break = ParsedStatement_Details::Break;
+    using Continue = ParsedStatement_Details::Continue;
+    using Return = ParsedStatement_Details::Return;
+    using Throw = ParsedStatement_Details::Throw;
+    using Yield = ParsedStatement_Details::Yield;
+    using InlineCpp = ParsedStatement_Details::InlineCpp;
+    using Guard = ParsedStatement_Details::Guard;
+    using Garbage = ParsedStatement_Details::Garbage;
+template<typename V, typename... Args> static auto __jakt_create(Args&&... args) {
+return adopt_nonnull_ref_or_enomem(new (nothrow) ParsedStatement(V(forward<Args>(args)...)));
+}
+ErrorOr<DeprecatedString> debug_description() const;
+bool equals(NonnullRefPtr<typename parser::ParsedStatement> const rhs_statement) const;
+utility::Span span() const;
+};
+namespace ArgumentStoreLevel_Details {
+struct InObject {
+size_t argument_index;
+template<typename _MemberT0>
+InObject(_MemberT0&& member_0):
+argument_index{ forward<_MemberT0>(member_0)}
+{}
+};
+struct InStaticStorage {
+};
+}
+struct ArgumentStoreLevel : public Variant<ArgumentStoreLevel_Details::InObject, ArgumentStoreLevel_Details::InStaticStorage> {
+using Variant<ArgumentStoreLevel_Details::InObject, ArgumentStoreLevel_Details::InStaticStorage>::Variant;
+    using InObject = ArgumentStoreLevel_Details::InObject;
+    using InStaticStorage = ArgumentStoreLevel_Details::InStaticStorage;
+ErrorOr<DeprecatedString> debug_description() const;
+};
+struct ParsedNamespace {
+  public:
+JaktInternal::Optional<DeprecatedString> name;JaktInternal::Optional<utility::Span> name_span;JaktInternal::DynamicArray<parser::ParsedFunction> functions;JaktInternal::DynamicArray<parser::ParsedRecord> records;JaktInternal::DynamicArray<parser::ParsedTrait> traits;JaktInternal::DynamicArray<parser::ParsedExternalTraitImplementation> external_trait_implementations;JaktInternal::DynamicArray<parser::ParsedNamespace> namespaces;JaktInternal::DynamicArray<parser::ParsedAlias> aliases;JaktInternal::DynamicArray<parser::ParsedModuleImport> module_imports;JaktInternal::DynamicArray<parser::ParsedExternImport> extern_imports;JaktInternal::Optional<DeprecatedString> import_path_if_extern;JaktInternal::DynamicArray<parser::IncludeAction> generating_import_extern_before_include;JaktInternal::DynamicArray<parser::IncludeAction> generating_import_extern_after_include;JaktInternal::DynamicArray<JaktInternal::Tuple<JaktInternal::DynamicArray<parser::ParsedGenericParameter>,parser::ParsedNamespace>> forall_chunks;ErrorOr<void> add_child_namespace(parser::ParsedNamespace const namespace_);
+ParsedNamespace(JaktInternal::Optional<DeprecatedString> a_name, JaktInternal::Optional<utility::Span> a_name_span, JaktInternal::DynamicArray<parser::ParsedFunction> a_functions, JaktInternal::DynamicArray<parser::ParsedRecord> a_records, JaktInternal::DynamicArray<parser::ParsedTrait> a_traits, JaktInternal::DynamicArray<parser::ParsedExternalTraitImplementation> a_external_trait_implementations, JaktInternal::DynamicArray<parser::ParsedNamespace> a_namespaces, JaktInternal::DynamicArray<parser::ParsedAlias> a_aliases, JaktInternal::DynamicArray<parser::ParsedModuleImport> a_module_imports, JaktInternal::DynamicArray<parser::ParsedExternImport> a_extern_imports, JaktInternal::Optional<DeprecatedString> a_import_path_if_extern, JaktInternal::DynamicArray<parser::IncludeAction> a_generating_import_extern_before_include, JaktInternal::DynamicArray<parser::IncludeAction> a_generating_import_extern_after_include, JaktInternal::DynamicArray<JaktInternal::Tuple<JaktInternal::DynamicArray<parser::ParsedGenericParameter>,parser::ParsedNamespace>> a_forall_chunks);
+
+bool is_equivalent_to(parser::ParsedNamespace const other) const;
+ErrorOr<void> add_extern_import(parser::ParsedExternImport const import_);
+ErrorOr<void> add_alias(parser::ParsedAlias const alias);
+ErrorOr<void> merge_with(parser::ParsedNamespace const namespace_);
+ErrorOr<void> add_module_import(parser::ParsedModuleImport const import_);
+ErrorOr<DeprecatedString> debug_description() const;
+};namespace RecordType_Details {
+struct Struct {
+JaktInternal::DynamicArray<parser::ParsedField> fields;
+JaktInternal::Optional<NonnullRefPtr<typename parser::ParsedType>> super_type;
+template<typename _MemberT0, typename _MemberT1>
+Struct(_MemberT0&& member_0, _MemberT1&& member_1):
+fields{ forward<_MemberT0>(member_0)},
+super_type{ forward<_MemberT1>(member_1)}
+{}
+};
+struct Class {
+JaktInternal::DynamicArray<parser::ParsedField> fields;
+JaktInternal::Optional<NonnullRefPtr<typename parser::ParsedType>> super_type;
+template<typename _MemberT0, typename _MemberT1>
+Class(_MemberT0&& member_0, _MemberT1&& member_1):
+fields{ forward<_MemberT0>(member_0)},
+super_type{ forward<_MemberT1>(member_1)}
+{}
+};
+struct ValueEnum {
+NonnullRefPtr<typename parser::ParsedType> underlying_type;
+JaktInternal::DynamicArray<parser::ValueEnumVariant> variants;
+template<typename _MemberT0, typename _MemberT1>
+ValueEnum(_MemberT0&& member_0, _MemberT1&& member_1):
+underlying_type{ forward<_MemberT0>(member_0)},
+variants{ forward<_MemberT1>(member_1)}
+{}
+};
+struct SumEnum {
+bool is_boxed;
+JaktInternal::DynamicArray<parser::ParsedField> fields;
+JaktInternal::DynamicArray<parser::SumEnumVariant> variants;
+template<typename _MemberT0, typename _MemberT1, typename _MemberT2>
+SumEnum(_MemberT0&& member_0, _MemberT1&& member_1, _MemberT2&& member_2):
+is_boxed{ forward<_MemberT0>(member_0)},
+fields{ forward<_MemberT1>(member_1)},
+variants{ forward<_MemberT2>(member_2)}
+{}
+};
+struct Garbage {
+};
+}
+struct RecordType : public Variant<RecordType_Details::Struct, RecordType_Details::Class, RecordType_Details::ValueEnum, RecordType_Details::SumEnum, RecordType_Details::Garbage> {
+using Variant<RecordType_Details::Struct, RecordType_Details::Class, RecordType_Details::ValueEnum, RecordType_Details::SumEnum, RecordType_Details::Garbage>::Variant;
+    using Struct = RecordType_Details::Struct;
+    using Class = RecordType_Details::Class;
+    using ValueEnum = RecordType_Details::ValueEnum;
+    using SumEnum = RecordType_Details::SumEnum;
+    using Garbage = RecordType_Details::Garbage;
+ErrorOr<DeprecatedString> debug_description() const;
+ErrorOr<DeprecatedString> record_type_name() const;
+};
+namespace ParsedType_Details {
 struct Name {
 DeprecatedString name;
 utility::Span span;
@@ -268,276 +1082,114 @@ ErrorOr<DeprecatedString> debug_description() const;
 bool equals(NonnullRefPtr<typename parser::ParsedType> const rhs_parsed_type) const;
 utility::Span span() const;
 };
-struct ParsedAttributeArgument {
-  public:
-DeprecatedString name;utility::Span span;JaktInternal::Optional<DeprecatedString> assigned_value;ParsedAttributeArgument(DeprecatedString a_name, utility::Span a_span, JaktInternal::Optional<DeprecatedString> a_assigned_value);
-
-ErrorOr<DeprecatedString> debug_description() const;
-};namespace FunctionLinkage_Details {
-struct Internal {
-};
-struct External {
-};
-}
-struct FunctionLinkage : public Variant<FunctionLinkage_Details::Internal, FunctionLinkage_Details::External> {
-using Variant<FunctionLinkage_Details::Internal, FunctionLinkage_Details::External>::Variant;
-    using Internal = FunctionLinkage_Details::Internal;
-    using External = FunctionLinkage_Details::External;
-ErrorOr<DeprecatedString> debug_description() const;
-};
-namespace NumericConstant_Details {
-struct I8{
-i8 value;
-template<typename _MemberT0>
-I8(_MemberT0&& member_0):
-value{ forward<_MemberT0>(member_0)}
-{}
-};
-struct I16{
-i16 value;
-template<typename _MemberT0>
-I16(_MemberT0&& member_0):
-value{ forward<_MemberT0>(member_0)}
-{}
-};
-struct I32{
-i32 value;
-template<typename _MemberT0>
-I32(_MemberT0&& member_0):
-value{ forward<_MemberT0>(member_0)}
-{}
-};
-struct I64{
-i64 value;
-template<typename _MemberT0>
-I64(_MemberT0&& member_0):
-value{ forward<_MemberT0>(member_0)}
-{}
-};
-struct U8{
-u8 value;
-template<typename _MemberT0>
-U8(_MemberT0&& member_0):
-value{ forward<_MemberT0>(member_0)}
-{}
-};
-struct U16{
-u16 value;
-template<typename _MemberT0>
-U16(_MemberT0&& member_0):
-value{ forward<_MemberT0>(member_0)}
-{}
-};
-struct U32{
-u32 value;
-template<typename _MemberT0>
-U32(_MemberT0&& member_0):
-value{ forward<_MemberT0>(member_0)}
-{}
-};
-struct U64{
-u64 value;
-template<typename _MemberT0>
-U64(_MemberT0&& member_0):
-value{ forward<_MemberT0>(member_0)}
-{}
-};
-struct USize{
-u64 value;
-template<typename _MemberT0>
-USize(_MemberT0&& member_0):
-value{ forward<_MemberT0>(member_0)}
-{}
-};
-struct F32{
-f32 value;
-template<typename _MemberT0>
-F32(_MemberT0&& member_0):
-value{ forward<_MemberT0>(member_0)}
-{}
-};
-struct F64{
-f64 value;
-template<typename _MemberT0>
-F64(_MemberT0&& member_0):
-value{ forward<_MemberT0>(member_0)}
-{}
-};
-struct UnknownSigned{
-i64 value;
-template<typename _MemberT0>
-UnknownSigned(_MemberT0&& member_0):
-value{ forward<_MemberT0>(member_0)}
-{}
-};
-struct UnknownUnsigned{
-u64 value;
-template<typename _MemberT0>
-UnknownUnsigned(_MemberT0&& member_0):
-value{ forward<_MemberT0>(member_0)}
-{}
-};
-}
-struct NumericConstant : public Variant<NumericConstant_Details::I8, NumericConstant_Details::I16, NumericConstant_Details::I32, NumericConstant_Details::I64, NumericConstant_Details::U8, NumericConstant_Details::U16, NumericConstant_Details::U32, NumericConstant_Details::U64, NumericConstant_Details::USize, NumericConstant_Details::F32, NumericConstant_Details::F64, NumericConstant_Details::UnknownSigned, NumericConstant_Details::UnknownUnsigned> {
-using Variant<NumericConstant_Details::I8, NumericConstant_Details::I16, NumericConstant_Details::I32, NumericConstant_Details::I64, NumericConstant_Details::U8, NumericConstant_Details::U16, NumericConstant_Details::U32, NumericConstant_Details::U64, NumericConstant_Details::USize, NumericConstant_Details::F32, NumericConstant_Details::F64, NumericConstant_Details::UnknownSigned, NumericConstant_Details::UnknownUnsigned>::Variant;
-    using I8 = NumericConstant_Details::I8;
-    using I16 = NumericConstant_Details::I16;
-    using I32 = NumericConstant_Details::I32;
-    using I64 = NumericConstant_Details::I64;
-    using U8 = NumericConstant_Details::U8;
-    using U16 = NumericConstant_Details::U16;
-    using U32 = NumericConstant_Details::U32;
-    using U64 = NumericConstant_Details::U64;
-    using USize = NumericConstant_Details::USize;
-    using F32 = NumericConstant_Details::F32;
-    using F64 = NumericConstant_Details::F64;
-    using UnknownSigned = NumericConstant_Details::UnknownSigned;
-    using UnknownUnsigned = NumericConstant_Details::UnknownUnsigned;
-ErrorOr<DeprecatedString> debug_description() const;
-size_t to_usize() const;
-};
-struct ParsedVarDeclTuple {
-  public:
-JaktInternal::DynamicArray<parser::ParsedVarDecl> var_decls;utility::Span span;ParsedVarDeclTuple(JaktInternal::DynamicArray<parser::ParsedVarDecl> a_var_decls, utility::Span a_span);
-
-ErrorOr<DeprecatedString> debug_description() const;
-};struct EnumVariantPatternArgument {
-  public:
-JaktInternal::Optional<DeprecatedString> name;JaktInternal::Optional<utility::Span> name_span;DeprecatedString binding;utility::Span span;bool is_reference;bool is_mutable;utility::Span name_in_enum_span() const;
-DeprecatedString name_in_enum() const;
-EnumVariantPatternArgument(JaktInternal::Optional<DeprecatedString> a_name, JaktInternal::Optional<utility::Span> a_name_span, DeprecatedString a_binding, utility::Span a_span, bool a_is_reference, bool a_is_mutable);
-
-bool equals(parser::EnumVariantPatternArgument const rhs_variant_pattern_argument) const;
-ErrorOr<DeprecatedString> debug_description() const;
-};struct ParsedVarDecl {
-  public:
-DeprecatedString name;NonnullRefPtr<typename parser::ParsedType> parsed_type;bool is_mutable;JaktInternal::Optional<utility::Span> inlay_span;utility::Span span;JaktInternal::Optional<parser::ExternalName> external_name;bool equals(parser::ParsedVarDecl const rhs_var_decl) const;
-ParsedVarDecl(DeprecatedString a_name, NonnullRefPtr<typename parser::ParsedType> a_parsed_type, bool a_is_mutable, JaktInternal::Optional<utility::Span> a_inlay_span, utility::Span a_span, JaktInternal::Optional<parser::ExternalName> a_external_name);
-
-ErrorOr<DeprecatedString> debug_description() const;
-};namespace Visibility_Details {
-struct Public {
-};
-struct Private {
-};
-struct Restricted {
-JaktInternal::DynamicArray<parser::VisibilityRestriction> whitelist;
+namespace ParsedCapture_Details {
+struct ByValue {
+DeprecatedString name;
 utility::Span span;
 template<typename _MemberT0, typename _MemberT1>
-Restricted(_MemberT0&& member_0, _MemberT1&& member_1):
-whitelist{ forward<_MemberT0>(member_0)},
+ByValue(_MemberT0&& member_0, _MemberT1&& member_1):
+name{ forward<_MemberT0>(member_0)},
+span{ forward<_MemberT1>(member_1)}
+{}
+};
+struct ByReference {
+DeprecatedString name;
+utility::Span span;
+template<typename _MemberT0, typename _MemberT1>
+ByReference(_MemberT0&& member_0, _MemberT1&& member_1):
+name{ forward<_MemberT0>(member_0)},
+span{ forward<_MemberT1>(member_1)}
+{}
+};
+struct ByMutableReference {
+DeprecatedString name;
+utility::Span span;
+template<typename _MemberT0, typename _MemberT1>
+ByMutableReference(_MemberT0&& member_0, _MemberT1&& member_1):
+name{ forward<_MemberT0>(member_0)},
+span{ forward<_MemberT1>(member_1)}
+{}
+};
+struct ByComptimeDependency {
+DeprecatedString name;
+utility::Span span;
+template<typename _MemberT0, typename _MemberT1>
+ByComptimeDependency(_MemberT0&& member_0, _MemberT1&& member_1):
+name{ forward<_MemberT0>(member_0)},
+span{ forward<_MemberT1>(member_1)}
+{}
+};
+struct AllByReference {
+DeprecatedString name;
+utility::Span span;
+template<typename _MemberT0, typename _MemberT1>
+AllByReference(_MemberT0&& member_0, _MemberT1&& member_1):
+name{ forward<_MemberT0>(member_0)},
 span{ forward<_MemberT1>(member_1)}
 {}
 };
 }
-struct Visibility : public Variant<Visibility_Details::Public, Visibility_Details::Private, Visibility_Details::Restricted> {
-using Variant<Visibility_Details::Public, Visibility_Details::Private, Visibility_Details::Restricted>::Variant;
-    using Public = Visibility_Details::Public;
-    using Private = Visibility_Details::Private;
-    using Restricted = Visibility_Details::Restricted;
+struct ParsedCapture : public Variant<ParsedCapture_Details::ByValue, ParsedCapture_Details::ByReference, ParsedCapture_Details::ByMutableReference, ParsedCapture_Details::ByComptimeDependency, ParsedCapture_Details::AllByReference> {
+using Variant<ParsedCapture_Details::ByValue, ParsedCapture_Details::ByReference, ParsedCapture_Details::ByMutableReference, ParsedCapture_Details::ByComptimeDependency, ParsedCapture_Details::AllByReference>::Variant;
+    using ByValue = ParsedCapture_Details::ByValue;
+    using ByReference = ParsedCapture_Details::ByReference;
+    using ByMutableReference = ParsedCapture_Details::ByMutableReference;
+    using ByComptimeDependency = ParsedCapture_Details::ByComptimeDependency;
+    using AllByReference = ParsedCapture_Details::AllByReference;
 ErrorOr<DeprecatedString> debug_description() const;
+DeprecatedString const& name() const { switch(this->index()) {case 0 /* ByValue */: return this->template get<ParsedCapture::ByValue>().name;
+case 1 /* ByReference */: return this->template get<ParsedCapture::ByReference>().name;
+case 2 /* ByMutableReference */: return this->template get<ParsedCapture::ByMutableReference>().name;
+case 3 /* ByComptimeDependency */: return this->template get<ParsedCapture::ByComptimeDependency>().name;
+case 4 /* AllByReference */: return this->template get<ParsedCapture::AllByReference>().name;
+default: VERIFY_NOT_REACHED();
+}
+}
+utility::Span const& span() const { switch(this->index()) {case 0 /* ByValue */: return this->template get<ParsedCapture::ByValue>().span;
+case 1 /* ByReference */: return this->template get<ParsedCapture::ByReference>().span;
+case 2 /* ByMutableReference */: return this->template get<ParsedCapture::ByMutableReference>().span;
+case 3 /* ByComptimeDependency */: return this->template get<ParsedCapture::ByComptimeDependency>().span;
+case 4 /* AllByReference */: return this->template get<ParsedCapture::AllByReference>().span;
+default: VERIFY_NOT_REACHED();
+}
+}
 };
-struct ParsedField {
+struct ParsedNameWithGenericParameters {
   public:
-parser::ParsedVarDecl var_decl;parser::Visibility visibility;JaktInternal::Optional<NonnullRefPtr<typename parser::ParsedExpression>> default_value;ParsedField(parser::ParsedVarDecl a_var_decl, parser::Visibility a_visibility, JaktInternal::Optional<NonnullRefPtr<typename parser::ParsedExpression>> a_default_value);
+DeprecatedString name;utility::Span name_span;JaktInternal::DynamicArray<NonnullRefPtr<typename parser::ParsedType>> generic_parameters;ParsedNameWithGenericParameters(DeprecatedString a_name, utility::Span a_name_span, JaktInternal::DynamicArray<NonnullRefPtr<typename parser::ParsedType>> a_generic_parameters);
 
 ErrorOr<DeprecatedString> debug_description() const;
-};namespace TypeCast_Details {
-struct Fallible{
-NonnullRefPtr<typename parser::ParsedType> value;
-template<typename _MemberT0>
-Fallible(_MemberT0&& member_0):
-value{ forward<_MemberT0>(member_0)}
-{}
-};
-struct Infallible{
-NonnullRefPtr<typename parser::ParsedType> value;
-template<typename _MemberT0>
-Infallible(_MemberT0&& member_0):
-value{ forward<_MemberT0>(member_0)}
-{}
-};
-}
-struct TypeCast : public Variant<TypeCast_Details::Fallible, TypeCast_Details::Infallible> {
-using Variant<TypeCast_Details::Fallible, TypeCast_Details::Infallible>::Variant;
-    using Fallible = TypeCast_Details::Fallible;
-    using Infallible = TypeCast_Details::Infallible;
+};struct ParsedExternalTraitImplementation {
+  public:
+NonnullRefPtr<typename parser::ParsedType> for_type;JaktInternal::DynamicArray<parser::ParsedNameWithGenericParameters> traits;JaktInternal::DynamicArray<parser::ParsedMethod> methods;ParsedExternalTraitImplementation(NonnullRefPtr<typename parser::ParsedType> a_for_type, JaktInternal::DynamicArray<parser::ParsedNameWithGenericParameters> a_traits, JaktInternal::DynamicArray<parser::ParsedMethod> a_methods);
+
 ErrorOr<DeprecatedString> debug_description() const;
-NonnullRefPtr<typename parser::ParsedType> parsed_type() const;
-};
-namespace UnaryOperator_Details {
-struct PreIncrement {
-};
-struct PostIncrement {
-};
-struct PreDecrement {
-};
-struct PostDecrement {
-};
-struct Negate {
-};
-struct Dereference {
-};
-struct RawAddress {
-};
-struct Reference {
-};
-struct MutableReference {
-};
-struct LogicalNot {
-};
-struct BitwiseNot {
-};
-struct TypeCast{
-parser::TypeCast value;
-template<typename _MemberT0>
-TypeCast(_MemberT0&& member_0):
-value{ forward<_MemberT0>(member_0)}
-{}
-};
-struct Is{
-NonnullRefPtr<typename parser::ParsedType> value;
-template<typename _MemberT0>
-Is(_MemberT0&& member_0):
-value{ forward<_MemberT0>(member_0)}
-{}
-};
-struct IsEnumVariant {
-NonnullRefPtr<typename parser::ParsedType> inner;
-JaktInternal::DynamicArray<parser::EnumVariantPatternArgument> bindings;
+};namespace ImportName_Details {
+struct Literal {
+DeprecatedString name;
+utility::Span span;
 template<typename _MemberT0, typename _MemberT1>
-IsEnumVariant(_MemberT0&& member_0, _MemberT1&& member_1):
-inner{ forward<_MemberT0>(member_0)},
-bindings{ forward<_MemberT1>(member_1)}
+Literal(_MemberT0&& member_0, _MemberT1&& member_1):
+name{ forward<_MemberT0>(member_0)},
+span{ forward<_MemberT1>(member_1)}
 {}
 };
-struct Sizeof{
-NonnullRefPtr<typename parser::ParsedType> value;
+struct Comptime {
+NonnullRefPtr<typename parser::ParsedExpression> expression;
 template<typename _MemberT0>
-Sizeof(_MemberT0&& member_0):
-value{ forward<_MemberT0>(member_0)}
+Comptime(_MemberT0&& member_0):
+expression{ forward<_MemberT0>(member_0)}
 {}
 };
 }
-struct UnaryOperator : public Variant<UnaryOperator_Details::PreIncrement, UnaryOperator_Details::PostIncrement, UnaryOperator_Details::PreDecrement, UnaryOperator_Details::PostDecrement, UnaryOperator_Details::Negate, UnaryOperator_Details::Dereference, UnaryOperator_Details::RawAddress, UnaryOperator_Details::Reference, UnaryOperator_Details::MutableReference, UnaryOperator_Details::LogicalNot, UnaryOperator_Details::BitwiseNot, UnaryOperator_Details::TypeCast, UnaryOperator_Details::Is, UnaryOperator_Details::IsEnumVariant, UnaryOperator_Details::Sizeof> {
-using Variant<UnaryOperator_Details::PreIncrement, UnaryOperator_Details::PostIncrement, UnaryOperator_Details::PreDecrement, UnaryOperator_Details::PostDecrement, UnaryOperator_Details::Negate, UnaryOperator_Details::Dereference, UnaryOperator_Details::RawAddress, UnaryOperator_Details::Reference, UnaryOperator_Details::MutableReference, UnaryOperator_Details::LogicalNot, UnaryOperator_Details::BitwiseNot, UnaryOperator_Details::TypeCast, UnaryOperator_Details::Is, UnaryOperator_Details::IsEnumVariant, UnaryOperator_Details::Sizeof>::Variant;
-    using PreIncrement = UnaryOperator_Details::PreIncrement;
-    using PostIncrement = UnaryOperator_Details::PostIncrement;
-    using PreDecrement = UnaryOperator_Details::PreDecrement;
-    using PostDecrement = UnaryOperator_Details::PostDecrement;
-    using Negate = UnaryOperator_Details::Negate;
-    using Dereference = UnaryOperator_Details::Dereference;
-    using RawAddress = UnaryOperator_Details::RawAddress;
-    using Reference = UnaryOperator_Details::Reference;
-    using MutableReference = UnaryOperator_Details::MutableReference;
-    using LogicalNot = UnaryOperator_Details::LogicalNot;
-    using BitwiseNot = UnaryOperator_Details::BitwiseNot;
-    using TypeCast = UnaryOperator_Details::TypeCast;
-    using Is = UnaryOperator_Details::Is;
-    using IsEnumVariant = UnaryOperator_Details::IsEnumVariant;
-    using Sizeof = UnaryOperator_Details::Sizeof;
+struct ImportName : public Variant<ImportName_Details::Literal, ImportName_Details::Comptime> {
+using Variant<ImportName_Details::Literal, ImportName_Details::Comptime>::Variant;
+    using Literal = ImportName_Details::Literal;
+    using Comptime = ImportName_Details::Comptime;
 ErrorOr<DeprecatedString> debug_description() const;
-bool equals(parser::UnaryOperator const rhs_op) const;
+ErrorOr<DeprecatedString> literal_name() const;
+bool equals(parser::ImportName const other) const;
+utility::Span span() const;
 };
 namespace ImportList_Details {
 struct List{
@@ -558,144 +1210,52 @@ ErrorOr<DeprecatedString> debug_description() const;
 ErrorOr<void> add(parser::ImportName const name);
 bool is_empty() const;
 };
-struct ParsedNameWithGenericParameters {
+struct ParsedModuleImport {
   public:
-DeprecatedString name;utility::Span name_span;JaktInternal::DynamicArray<NonnullRefPtr<typename parser::ParsedType>> generic_parameters;ParsedNameWithGenericParameters(DeprecatedString a_name, utility::Span a_name_span, JaktInternal::DynamicArray<NonnullRefPtr<typename parser::ParsedType>> a_generic_parameters);
+parser::ImportName module_name;JaktInternal::Optional<parser::ImportName> alias_name;parser::ImportList import_list;bool has_same_alias_than(parser::ParsedModuleImport const other) const;
+ParsedModuleImport(parser::ImportName a_module_name, JaktInternal::Optional<parser::ImportName> a_alias_name, parser::ImportList a_import_list);
 
+bool has_same_import_semantics(parser::ParsedModuleImport const other) const;
+ErrorOr<void> merge_import_list(parser::ImportList const list);
+bool is_equivalent_to(parser::ParsedModuleImport const other) const;
 ErrorOr<DeprecatedString> debug_description() const;
-};namespace RecordType_Details {
-struct Struct {
-JaktInternal::DynamicArray<parser::ParsedField> fields;
-JaktInternal::Optional<NonnullRefPtr<typename parser::ParsedType>> super_type;
-template<typename _MemberT0, typename _MemberT1>
-Struct(_MemberT0&& member_0, _MemberT1&& member_1):
-fields{ forward<_MemberT0>(member_0)},
-super_type{ forward<_MemberT1>(member_1)}
-{}
-};
-struct Class {
-JaktInternal::DynamicArray<parser::ParsedField> fields;
-JaktInternal::Optional<NonnullRefPtr<typename parser::ParsedType>> super_type;
-template<typename _MemberT0, typename _MemberT1>
-Class(_MemberT0&& member_0, _MemberT1&& member_1):
-fields{ forward<_MemberT0>(member_0)},
-super_type{ forward<_MemberT1>(member_1)}
-{}
-};
-struct ValueEnum {
-NonnullRefPtr<typename parser::ParsedType> underlying_type;
-JaktInternal::DynamicArray<parser::ValueEnumVariant> variants;
-template<typename _MemberT0, typename _MemberT1>
-ValueEnum(_MemberT0&& member_0, _MemberT1&& member_1):
-underlying_type{ forward<_MemberT0>(member_0)},
-variants{ forward<_MemberT1>(member_1)}
-{}
-};
-struct SumEnum {
-bool is_boxed;
-JaktInternal::DynamicArray<parser::ParsedField> fields;
-JaktInternal::DynamicArray<parser::SumEnumVariant> variants;
+};struct ParsedExternImport {
+  public:
+bool is_c;parser::ParsedNamespace assigned_namespace;JaktInternal::DynamicArray<parser::IncludeAction> before_include;JaktInternal::DynamicArray<parser::IncludeAction> after_include;ErrorOr<bool> is_equivalent_to(parser::ParsedExternImport const other) const;
+ParsedExternImport(bool a_is_c, parser::ParsedNamespace a_assigned_namespace, JaktInternal::DynamicArray<parser::IncludeAction> a_before_include, JaktInternal::DynamicArray<parser::IncludeAction> a_after_include);
+
+DeprecatedString get_path() const;
+DeprecatedString get_name() const;
+ErrorOr<DeprecatedString> debug_description() const;
+};namespace IncludeAction_Details {
+struct Define {
+DeprecatedString name;
+utility::Span span;
+DeprecatedString value;
 template<typename _MemberT0, typename _MemberT1, typename _MemberT2>
-SumEnum(_MemberT0&& member_0, _MemberT1&& member_1, _MemberT2&& member_2):
-is_boxed{ forward<_MemberT0>(member_0)},
-fields{ forward<_MemberT1>(member_1)},
-variants{ forward<_MemberT2>(member_2)}
+Define(_MemberT0&& member_0, _MemberT1&& member_1, _MemberT2&& member_2):
+name{ forward<_MemberT0>(member_0)},
+span{ forward<_MemberT1>(member_1)},
+value{ forward<_MemberT2>(member_2)}
 {}
 };
-struct Garbage {
-};
-}
-struct RecordType : public Variant<RecordType_Details::Struct, RecordType_Details::Class, RecordType_Details::ValueEnum, RecordType_Details::SumEnum, RecordType_Details::Garbage> {
-using Variant<RecordType_Details::Struct, RecordType_Details::Class, RecordType_Details::ValueEnum, RecordType_Details::SumEnum, RecordType_Details::Garbage>::Variant;
-    using Struct = RecordType_Details::Struct;
-    using Class = RecordType_Details::Class;
-    using ValueEnum = RecordType_Details::ValueEnum;
-    using SumEnum = RecordType_Details::SumEnum;
-    using Garbage = RecordType_Details::Garbage;
-ErrorOr<DeprecatedString> debug_description() const;
-ErrorOr<DeprecatedString> record_type_name() const;
-};
-struct ParsedNamespace {
-  public:
-JaktInternal::Optional<DeprecatedString> name;JaktInternal::Optional<utility::Span> name_span;JaktInternal::DynamicArray<parser::ParsedFunction> functions;JaktInternal::DynamicArray<parser::ParsedRecord> records;JaktInternal::DynamicArray<parser::ParsedTrait> traits;JaktInternal::DynamicArray<parser::ParsedExternalTraitImplementation> external_trait_implementations;JaktInternal::DynamicArray<parser::ParsedNamespace> namespaces;JaktInternal::DynamicArray<parser::ParsedAlias> aliases;JaktInternal::DynamicArray<parser::ParsedModuleImport> module_imports;JaktInternal::DynamicArray<parser::ParsedExternImport> extern_imports;JaktInternal::Optional<DeprecatedString> import_path_if_extern;JaktInternal::DynamicArray<parser::IncludeAction> generating_import_extern_before_include;JaktInternal::DynamicArray<parser::IncludeAction> generating_import_extern_after_include;JaktInternal::DynamicArray<JaktInternal::Tuple<JaktInternal::DynamicArray<parser::ParsedGenericParameter>,parser::ParsedNamespace>> forall_chunks;ErrorOr<void> add_child_namespace(parser::ParsedNamespace const namespace_);
-ParsedNamespace(JaktInternal::Optional<DeprecatedString> a_name, JaktInternal::Optional<utility::Span> a_name_span, JaktInternal::DynamicArray<parser::ParsedFunction> a_functions, JaktInternal::DynamicArray<parser::ParsedRecord> a_records, JaktInternal::DynamicArray<parser::ParsedTrait> a_traits, JaktInternal::DynamicArray<parser::ParsedExternalTraitImplementation> a_external_trait_implementations, JaktInternal::DynamicArray<parser::ParsedNamespace> a_namespaces, JaktInternal::DynamicArray<parser::ParsedAlias> a_aliases, JaktInternal::DynamicArray<parser::ParsedModuleImport> a_module_imports, JaktInternal::DynamicArray<parser::ParsedExternImport> a_extern_imports, JaktInternal::Optional<DeprecatedString> a_import_path_if_extern, JaktInternal::DynamicArray<parser::IncludeAction> a_generating_import_extern_before_include, JaktInternal::DynamicArray<parser::IncludeAction> a_generating_import_extern_after_include, JaktInternal::DynamicArray<JaktInternal::Tuple<JaktInternal::DynamicArray<parser::ParsedGenericParameter>,parser::ParsedNamespace>> a_forall_chunks);
-
-bool is_equivalent_to(parser::ParsedNamespace const other) const;
-ErrorOr<void> add_extern_import(parser::ParsedExternImport const import_);
-ErrorOr<void> add_alias(parser::ParsedAlias const alias);
-ErrorOr<void> merge_with(parser::ParsedNamespace const namespace_);
-ErrorOr<void> add_module_import(parser::ParsedModuleImport const import_);
-ErrorOr<DeprecatedString> debug_description() const;
-};struct SumEnumVariant {
-  public:
-DeprecatedString name;utility::Span span;JaktInternal::Optional<JaktInternal::DynamicArray<parser::ParsedVarDecl>> params;JaktInternal::Optional<JaktInternal::DynamicArray<JaktInternal::Optional<NonnullRefPtr<typename parser::ParsedExpression>>>> default_values;SumEnumVariant(DeprecatedString a_name, utility::Span a_span, JaktInternal::Optional<JaktInternal::DynamicArray<parser::ParsedVarDecl>> a_params, JaktInternal::Optional<JaktInternal::DynamicArray<JaktInternal::Optional<NonnullRefPtr<typename parser::ParsedExpression>>>> a_default_values);
-
-ErrorOr<DeprecatedString> debug_description() const;
-};namespace ArgumentStoreLevel_Details {
-struct InObject {
-size_t argument_index;
-template<typename _MemberT0>
-InObject(_MemberT0&& member_0):
-argument_index{ forward<_MemberT0>(member_0)}
+struct Undefine {
+DeprecatedString name;
+utility::Span span;
+template<typename _MemberT0, typename _MemberT1>
+Undefine(_MemberT0&& member_0, _MemberT1&& member_1):
+name{ forward<_MemberT0>(member_0)},
+span{ forward<_MemberT1>(member_1)}
 {}
 };
-struct InStaticStorage {
-};
 }
-struct ArgumentStoreLevel : public Variant<ArgumentStoreLevel_Details::InObject, ArgumentStoreLevel_Details::InStaticStorage> {
-using Variant<ArgumentStoreLevel_Details::InObject, ArgumentStoreLevel_Details::InStaticStorage>::Variant;
-    using InObject = ArgumentStoreLevel_Details::InObject;
-    using InStaticStorage = ArgumentStoreLevel_Details::InStaticStorage;
+struct IncludeAction : public Variant<IncludeAction_Details::Define, IncludeAction_Details::Undefine> {
+using Variant<IncludeAction_Details::Define, IncludeAction_Details::Undefine>::Variant;
+    using Define = IncludeAction_Details::Define;
+    using Undefine = IncludeAction_Details::Undefine;
 ErrorOr<DeprecatedString> debug_description() const;
 };
-struct ParsedBlock {
-  public:
-JaktInternal::DynamicArray<NonnullRefPtr<typename parser::ParsedStatement>> stmts;ParsedBlock(JaktInternal::DynamicArray<NonnullRefPtr<typename parser::ParsedStatement>> a_stmts);
-
-JaktInternal::Optional<utility::Span> find_yield_span() const;
-bool equals(parser::ParsedBlock const rhs_block) const;
-ErrorOr<JaktInternal::Optional<utility::Span>> span(parser::Parser const parser) const;
-JaktInternal::Optional<utility::Span> find_yield_keyword_span() const;
-ErrorOr<DeprecatedString> debug_description() const;
-};namespace FunctionType_Details {
-struct Normal {
-};
-struct Destructor {
-};
-struct ImplicitConstructor {
-};
-struct ImplicitEnumConstructor {
-};
-struct ExternalClassConstructor {
-};
-struct Expression {
-};
-struct Closure {
-};
-}
-struct FunctionType : public Variant<FunctionType_Details::Normal, FunctionType_Details::Destructor, FunctionType_Details::ImplicitConstructor, FunctionType_Details::ImplicitEnumConstructor, FunctionType_Details::ExternalClassConstructor, FunctionType_Details::Expression, FunctionType_Details::Closure> {
-using Variant<FunctionType_Details::Normal, FunctionType_Details::Destructor, FunctionType_Details::ImplicitConstructor, FunctionType_Details::ImplicitEnumConstructor, FunctionType_Details::ExternalClassConstructor, FunctionType_Details::Expression, FunctionType_Details::Closure>::Variant;
-    using Normal = FunctionType_Details::Normal;
-    using Destructor = FunctionType_Details::Destructor;
-    using ImplicitConstructor = FunctionType_Details::ImplicitConstructor;
-    using ImplicitEnumConstructor = FunctionType_Details::ImplicitEnumConstructor;
-    using ExternalClassConstructor = FunctionType_Details::ExternalClassConstructor;
-    using Expression = FunctionType_Details::Expression;
-    using Closure = FunctionType_Details::Closure;
-ErrorOr<DeprecatedString> debug_description() const;
-};
-struct ParsedFunction {
-  public:
-size_t id;DeprecatedString name;utility::Span name_span;parser::Visibility visibility;JaktInternal::DynamicArray<parser::ParsedParameter> params;JaktInternal::DynamicArray<parser::ParsedGenericParameter> generic_parameters;parser::ParsedBlock block;NonnullRefPtr<typename parser::ParsedType> return_type;utility::Span return_type_span;bool can_throw;parser::FunctionType type;parser::FunctionLinkage linkage;bool must_instantiate;bool is_comptime;bool is_fat_arrow;bool is_unsafe;JaktInternal::Optional<parser::ExternalName> external_name;JaktInternal::Optional<DeprecatedString> deprecated_message;JaktInternal::Optional<JaktInternal::DynamicArray<JaktInternal::Tuple<size_t,parser::ArgumentStoreLevel>>> stores_arguments;JaktInternal::Optional<bool> force_inline;ParsedFunction(size_t a_id, DeprecatedString a_name, utility::Span a_name_span, parser::Visibility a_visibility, JaktInternal::DynamicArray<parser::ParsedParameter> a_params, JaktInternal::DynamicArray<parser::ParsedGenericParameter> a_generic_parameters, parser::ParsedBlock a_block, NonnullRefPtr<typename parser::ParsedType> a_return_type, utility::Span a_return_type_span, bool a_can_throw, parser::FunctionType a_type, parser::FunctionLinkage a_linkage, bool a_must_instantiate, bool a_is_comptime, bool a_is_fat_arrow, bool a_is_unsafe, JaktInternal::Optional<parser::ExternalName> a_external_name, JaktInternal::Optional<DeprecatedString> a_deprecated_message, JaktInternal::Optional<JaktInternal::DynamicArray<JaktInternal::Tuple<size_t,parser::ArgumentStoreLevel>>> a_stores_arguments, JaktInternal::Optional<bool> a_force_inline);
-
-bool equals(parser::ParsedFunction const other, bool const ignore_block) const;
-ErrorOr<DeprecatedString> debug_description() const;
-};struct ParsedMethod {
-  public:
-parser::ParsedFunction parsed_function;parser::Visibility visibility;bool is_virtual;bool is_override;ParsedMethod(parser::ParsedFunction a_parsed_function, parser::Visibility a_visibility, bool a_is_virtual, bool a_is_override);
-
-ErrorOr<DeprecatedString> debug_description() const;
-};namespace DefinitionLinkage_Details {
+namespace DefinitionLinkage_Details {
 struct Internal {
 };
 struct External {
@@ -772,123 +1332,30 @@ bool equals(parser::ParsedMatchPattern const rhs_parsed_match_pattern) const;
 bool is_equal_pattern(parser::ParsedMatchPattern const rhs_parsed_match_pattern) const;
 bool defaults_equal(JaktInternal::Dictionary<DeprecatedString,parser::ParsedPatternDefault> const defaults) const;
 };
-struct ParsedCall {
+struct ParsedVarDeclTuple {
   public:
-JaktInternal::DynamicArray<DeprecatedString> namespace_;DeprecatedString name;JaktInternal::DynamicArray<JaktInternal::Tuple<DeprecatedString,utility::Span,NonnullRefPtr<typename parser::ParsedExpression>>> args;JaktInternal::DynamicArray<NonnullRefPtr<typename parser::ParsedType>> type_args;ParsedCall(JaktInternal::DynamicArray<DeprecatedString> a_namespace_, DeprecatedString a_name, JaktInternal::DynamicArray<JaktInternal::Tuple<DeprecatedString,utility::Span,NonnullRefPtr<typename parser::ParsedExpression>>> a_args, JaktInternal::DynamicArray<NonnullRefPtr<typename parser::ParsedType>> a_type_args);
+JaktInternal::DynamicArray<parser::ParsedVarDecl> var_decls;utility::Span span;ParsedVarDeclTuple(JaktInternal::DynamicArray<parser::ParsedVarDecl> a_var_decls, utility::Span a_span);
 
-bool equals(parser::ParsedCall const rhs_parsed_call) const;
 ErrorOr<DeprecatedString> debug_description() const;
-};namespace BinaryOperator_Details {
-struct Add {
-};
-struct Subtract {
-};
-struct Multiply {
-};
-struct Divide {
-};
-struct Modulo {
-};
-struct LessThan {
-};
-struct LessThanOrEqual {
-};
-struct GreaterThan {
-};
-struct GreaterThanOrEqual {
-};
-struct Equal {
-};
-struct NotEqual {
-};
-struct BitwiseAnd {
-};
-struct BitwiseXor {
-};
-struct BitwiseOr {
-};
-struct BitwiseLeftShift {
-};
-struct BitwiseRightShift {
-};
-struct ArithmeticLeftShift {
-};
-struct ArithmeticRightShift {
-};
-struct LogicalAnd {
-};
-struct LogicalOr {
-};
-struct NoneCoalescing {
-};
-struct Assign {
-};
-struct BitwiseAndAssign {
-};
-struct BitwiseOrAssign {
-};
-struct BitwiseXorAssign {
-};
-struct BitwiseLeftShiftAssign {
-};
-struct BitwiseRightShiftAssign {
-};
-struct AddAssign {
-};
-struct SubtractAssign {
-};
-struct MultiplyAssign {
-};
-struct ModuloAssign {
-};
-struct DivideAssign {
-};
-struct NoneCoalescingAssign {
-};
-struct Garbage {
-};
-}
-struct BinaryOperator : public Variant<BinaryOperator_Details::Add, BinaryOperator_Details::Subtract, BinaryOperator_Details::Multiply, BinaryOperator_Details::Divide, BinaryOperator_Details::Modulo, BinaryOperator_Details::LessThan, BinaryOperator_Details::LessThanOrEqual, BinaryOperator_Details::GreaterThan, BinaryOperator_Details::GreaterThanOrEqual, BinaryOperator_Details::Equal, BinaryOperator_Details::NotEqual, BinaryOperator_Details::BitwiseAnd, BinaryOperator_Details::BitwiseXor, BinaryOperator_Details::BitwiseOr, BinaryOperator_Details::BitwiseLeftShift, BinaryOperator_Details::BitwiseRightShift, BinaryOperator_Details::ArithmeticLeftShift, BinaryOperator_Details::ArithmeticRightShift, BinaryOperator_Details::LogicalAnd, BinaryOperator_Details::LogicalOr, BinaryOperator_Details::NoneCoalescing, BinaryOperator_Details::Assign, BinaryOperator_Details::BitwiseAndAssign, BinaryOperator_Details::BitwiseOrAssign, BinaryOperator_Details::BitwiseXorAssign, BinaryOperator_Details::BitwiseLeftShiftAssign, BinaryOperator_Details::BitwiseRightShiftAssign, BinaryOperator_Details::AddAssign, BinaryOperator_Details::SubtractAssign, BinaryOperator_Details::MultiplyAssign, BinaryOperator_Details::ModuloAssign, BinaryOperator_Details::DivideAssign, BinaryOperator_Details::NoneCoalescingAssign, BinaryOperator_Details::Garbage> {
-using Variant<BinaryOperator_Details::Add, BinaryOperator_Details::Subtract, BinaryOperator_Details::Multiply, BinaryOperator_Details::Divide, BinaryOperator_Details::Modulo, BinaryOperator_Details::LessThan, BinaryOperator_Details::LessThanOrEqual, BinaryOperator_Details::GreaterThan, BinaryOperator_Details::GreaterThanOrEqual, BinaryOperator_Details::Equal, BinaryOperator_Details::NotEqual, BinaryOperator_Details::BitwiseAnd, BinaryOperator_Details::BitwiseXor, BinaryOperator_Details::BitwiseOr, BinaryOperator_Details::BitwiseLeftShift, BinaryOperator_Details::BitwiseRightShift, BinaryOperator_Details::ArithmeticLeftShift, BinaryOperator_Details::ArithmeticRightShift, BinaryOperator_Details::LogicalAnd, BinaryOperator_Details::LogicalOr, BinaryOperator_Details::NoneCoalescing, BinaryOperator_Details::Assign, BinaryOperator_Details::BitwiseAndAssign, BinaryOperator_Details::BitwiseOrAssign, BinaryOperator_Details::BitwiseXorAssign, BinaryOperator_Details::BitwiseLeftShiftAssign, BinaryOperator_Details::BitwiseRightShiftAssign, BinaryOperator_Details::AddAssign, BinaryOperator_Details::SubtractAssign, BinaryOperator_Details::MultiplyAssign, BinaryOperator_Details::ModuloAssign, BinaryOperator_Details::DivideAssign, BinaryOperator_Details::NoneCoalescingAssign, BinaryOperator_Details::Garbage>::Variant;
-    using Add = BinaryOperator_Details::Add;
-    using Subtract = BinaryOperator_Details::Subtract;
-    using Multiply = BinaryOperator_Details::Multiply;
-    using Divide = BinaryOperator_Details::Divide;
-    using Modulo = BinaryOperator_Details::Modulo;
-    using LessThan = BinaryOperator_Details::LessThan;
-    using LessThanOrEqual = BinaryOperator_Details::LessThanOrEqual;
-    using GreaterThan = BinaryOperator_Details::GreaterThan;
-    using GreaterThanOrEqual = BinaryOperator_Details::GreaterThanOrEqual;
-    using Equal = BinaryOperator_Details::Equal;
-    using NotEqual = BinaryOperator_Details::NotEqual;
-    using BitwiseAnd = BinaryOperator_Details::BitwiseAnd;
-    using BitwiseXor = BinaryOperator_Details::BitwiseXor;
-    using BitwiseOr = BinaryOperator_Details::BitwiseOr;
-    using BitwiseLeftShift = BinaryOperator_Details::BitwiseLeftShift;
-    using BitwiseRightShift = BinaryOperator_Details::BitwiseRightShift;
-    using ArithmeticLeftShift = BinaryOperator_Details::ArithmeticLeftShift;
-    using ArithmeticRightShift = BinaryOperator_Details::ArithmeticRightShift;
-    using LogicalAnd = BinaryOperator_Details::LogicalAnd;
-    using LogicalOr = BinaryOperator_Details::LogicalOr;
-    using NoneCoalescing = BinaryOperator_Details::NoneCoalescing;
-    using Assign = BinaryOperator_Details::Assign;
-    using BitwiseAndAssign = BinaryOperator_Details::BitwiseAndAssign;
-    using BitwiseOrAssign = BinaryOperator_Details::BitwiseOrAssign;
-    using BitwiseXorAssign = BinaryOperator_Details::BitwiseXorAssign;
-    using BitwiseLeftShiftAssign = BinaryOperator_Details::BitwiseLeftShiftAssign;
-    using BitwiseRightShiftAssign = BinaryOperator_Details::BitwiseRightShiftAssign;
-    using AddAssign = BinaryOperator_Details::AddAssign;
-    using SubtractAssign = BinaryOperator_Details::SubtractAssign;
-    using MultiplyAssign = BinaryOperator_Details::MultiplyAssign;
-    using ModuloAssign = BinaryOperator_Details::ModuloAssign;
-    using DivideAssign = BinaryOperator_Details::DivideAssign;
-    using NoneCoalescingAssign = BinaryOperator_Details::NoneCoalescingAssign;
-    using Garbage = BinaryOperator_Details::Garbage;
+};struct VisibilityRestriction {
+  public:
+JaktInternal::DynamicArray<DeprecatedString> namespace_;DeprecatedString name;VisibilityRestriction(JaktInternal::DynamicArray<DeprecatedString> a_namespace_, DeprecatedString a_name);
+
 ErrorOr<DeprecatedString> debug_description() const;
-bool equals(parser::BinaryOperator const rhs_op) const;
-bool is_assignment() const;
-};
-namespace ParsedExpression_Details {
+};struct ParsedAttribute {
+  public:
+DeprecatedString name;utility::Span span;JaktInternal::Optional<DeprecatedString> assigned_value;JaktInternal::DynamicArray<parser::ParsedAttributeArgument> arguments;ParsedAttribute(DeprecatedString a_name, utility::Span a_span, JaktInternal::Optional<DeprecatedString> a_assigned_value, JaktInternal::DynamicArray<parser::ParsedAttributeArgument> a_arguments);
+
+ErrorOr<DeprecatedString> debug_description() const;
+};struct EnumVariantPatternArgument {
+  public:
+JaktInternal::Optional<DeprecatedString> name;JaktInternal::Optional<utility::Span> name_span;DeprecatedString binding;utility::Span span;bool is_reference;bool is_mutable;utility::Span name_in_enum_span() const;
+DeprecatedString name_in_enum() const;
+EnumVariantPatternArgument(JaktInternal::Optional<DeprecatedString> a_name, JaktInternal::Optional<utility::Span> a_name_span, DeprecatedString a_binding, utility::Span a_span, bool a_is_reference, bool a_is_mutable);
+
+bool equals(parser::EnumVariantPatternArgument const rhs_variant_pattern_argument) const;
+ErrorOr<DeprecatedString> debug_description() const;
+};namespace ParsedExpression_Details {
 struct Boolean {
 bool val;
 utility::Span span;
@@ -1266,599 +1733,24 @@ bool equals(NonnullRefPtr<typename parser::ParsedExpression> const rhs_expressio
 utility::Span span() const;
 i64 precedence() const;
 };
-namespace ImportName_Details {
-struct Literal {
-DeprecatedString name;
-utility::Span span;
-template<typename _MemberT0, typename _MemberT1>
-Literal(_MemberT0&& member_0, _MemberT1&& member_1):
-name{ forward<_MemberT0>(member_0)},
-span{ forward<_MemberT1>(member_1)}
-{}
-};
-struct Comptime {
-NonnullRefPtr<typename parser::ParsedExpression> expression;
-template<typename _MemberT0>
-Comptime(_MemberT0&& member_0):
-expression{ forward<_MemberT0>(member_0)}
-{}
-};
-}
-struct ImportName : public Variant<ImportName_Details::Literal, ImportName_Details::Comptime> {
-using Variant<ImportName_Details::Literal, ImportName_Details::Comptime>::Variant;
-    using Literal = ImportName_Details::Literal;
-    using Comptime = ImportName_Details::Comptime;
-ErrorOr<DeprecatedString> debug_description() const;
-ErrorOr<DeprecatedString> literal_name() const;
-bool equals(parser::ImportName const other) const;
-utility::Span span() const;
-};
-struct ParsedVariable {
-  public:
-DeprecatedString name;NonnullRefPtr<typename parser::ParsedType> parsed_type;bool is_mutable;utility::Span span;ParsedVariable(DeprecatedString a_name, NonnullRefPtr<typename parser::ParsedType> a_parsed_type, bool a_is_mutable, utility::Span a_span);
-
-bool equals(parser::ParsedVariable const rhs_parsed_varible) const;
-ErrorOr<DeprecatedString> debug_description() const;
-};struct VisibilityRestriction {
-  public:
-JaktInternal::DynamicArray<DeprecatedString> namespace_;DeprecatedString name;VisibilityRestriction(JaktInternal::DynamicArray<DeprecatedString> a_namespace_, DeprecatedString a_name);
-
-ErrorOr<DeprecatedString> debug_description() const;
-};struct ParsedModuleImport {
-  public:
-parser::ImportName module_name;JaktInternal::Optional<parser::ImportName> alias_name;parser::ImportList import_list;bool has_same_alias_than(parser::ParsedModuleImport const other) const;
-ParsedModuleImport(parser::ImportName a_module_name, JaktInternal::Optional<parser::ImportName> a_alias_name, parser::ImportList a_import_list);
-
-bool has_same_import_semantics(parser::ParsedModuleImport const other) const;
-ErrorOr<void> merge_import_list(parser::ImportList const list);
-bool is_equivalent_to(parser::ParsedModuleImport const other) const;
-ErrorOr<DeprecatedString> debug_description() const;
-};struct ParsedAttribute {
-  public:
-DeprecatedString name;utility::Span span;JaktInternal::Optional<DeprecatedString> assigned_value;JaktInternal::DynamicArray<parser::ParsedAttributeArgument> arguments;ParsedAttribute(DeprecatedString a_name, utility::Span a_span, JaktInternal::Optional<DeprecatedString> a_assigned_value, JaktInternal::DynamicArray<parser::ParsedAttributeArgument> a_arguments);
-
-ErrorOr<DeprecatedString> debug_description() const;
-};struct ParsedExternalTraitImplementation {
-  public:
-NonnullRefPtr<typename parser::ParsedType> for_type;JaktInternal::DynamicArray<parser::ParsedNameWithGenericParameters> traits;JaktInternal::DynamicArray<parser::ParsedMethod> methods;ParsedExternalTraitImplementation(NonnullRefPtr<typename parser::ParsedType> a_for_type, JaktInternal::DynamicArray<parser::ParsedNameWithGenericParameters> a_traits, JaktInternal::DynamicArray<parser::ParsedMethod> a_methods);
-
-ErrorOr<DeprecatedString> debug_description() const;
-};namespace ParsedMatchBody_Details {
-struct Expression{
-NonnullRefPtr<typename parser::ParsedExpression> value;
-template<typename _MemberT0>
-Expression(_MemberT0&& member_0):
-value{ forward<_MemberT0>(member_0)}
-{}
-};
-struct Block{
-parser::ParsedBlock value;
-template<typename _MemberT0>
-Block(_MemberT0&& member_0):
-value{ forward<_MemberT0>(member_0)}
-{}
-};
-}
-struct ParsedMatchBody : public Variant<ParsedMatchBody_Details::Expression, ParsedMatchBody_Details::Block> {
-using Variant<ParsedMatchBody_Details::Expression, ParsedMatchBody_Details::Block>::Variant;
-    using Expression = ParsedMatchBody_Details::Expression;
-    using Block = ParsedMatchBody_Details::Block;
-ErrorOr<DeprecatedString> debug_description() const;
-bool equals(parser::ParsedMatchBody const rhs_match_body) const;
-};
-struct ParsedMatchCase {
-  public:
-JaktInternal::DynamicArray<parser::ParsedMatchPattern> patterns;utility::Span marker_span;parser::ParsedMatchBody body;bool has_equal_pattern(parser::ParsedMatchCase const rhs_match_case) const;
-bool equals(parser::ParsedMatchCase const rhs_match_case) const;
-ParsedMatchCase(JaktInternal::DynamicArray<parser::ParsedMatchPattern> a_patterns, utility::Span a_marker_span, parser::ParsedMatchBody a_body);
-
-ErrorOr<DeprecatedString> debug_description() const;
-};namespace IncludeAction_Details {
-struct Define {
-DeprecatedString name;
-utility::Span span;
-DeprecatedString value;
-template<typename _MemberT0, typename _MemberT1, typename _MemberT2>
-Define(_MemberT0&& member_0, _MemberT1&& member_1, _MemberT2&& member_2):
-name{ forward<_MemberT0>(member_0)},
-span{ forward<_MemberT1>(member_1)},
-value{ forward<_MemberT2>(member_2)}
-{}
-};
-struct Undefine {
-DeprecatedString name;
-utility::Span span;
-template<typename _MemberT0, typename _MemberT1>
-Undefine(_MemberT0&& member_0, _MemberT1&& member_1):
-name{ forward<_MemberT0>(member_0)},
-span{ forward<_MemberT1>(member_1)}
-{}
-};
-}
-struct IncludeAction : public Variant<IncludeAction_Details::Define, IncludeAction_Details::Undefine> {
-using Variant<IncludeAction_Details::Define, IncludeAction_Details::Undefine>::Variant;
-    using Define = IncludeAction_Details::Define;
-    using Undefine = IncludeAction_Details::Undefine;
-ErrorOr<DeprecatedString> debug_description() const;
-};
-struct Parser {
-  public:
-size_t index;JaktInternal::DynamicArray<lexer::Token> tokens;NonnullRefPtr<compiler::Compiler> compiler;bool can_have_trailing_closure;size_t next_function_id;ErrorOr<NonnullRefPtr<typename parser::ParsedExpression>> parse_operand_base();
-utility::Span span(size_t const start, size_t const end) const;
-ErrorOr<JaktInternal::Optional<parser::NumericConstant>> make_integer_numeric_constant(u64 const number, lexer::LiteralSuffix const suffix, utility::Span const span);
-ErrorOr<NonnullRefPtr<typename parser::ParsedType>> parse_type_shorthand();
-ErrorOr<NonnullRefPtr<typename parser::ParsedExpression>> parse_lambda();
-ErrorOr<NonnullRefPtr<typename parser::ParsedType>> parse_type_longhand();
-ErrorOr<parser::ParsedAlias> parse_using();
-ErrorOr<JaktInternal::DynamicArray<parser::ParsedParameter>> parse_function_parameters();
-ErrorOr<JaktInternal::DynamicArray<parser::ParsedMatchCase>> parse_match_cases();
-ErrorOr<JaktInternal::Optional<parser::ParsedAttribute>> parse_attribute();
-ErrorOr<parser::ParsedMethod> parse_method(parser::FunctionLinkage const linkage, parser::Visibility const visibility, bool const is_virtual, bool const is_override, bool const is_comptime, bool const is_destructor, bool const is_unsafe);
-ErrorOr<parser::ParsedNamespace> parse_namespace(bool const process_only_one_entity);
-ErrorOr<JaktInternal::Tuple<JaktInternal::DynamicArray<parser::ParsedGenericParameter>,parser::ParsedNamespace>> parse_forall();
-ErrorOr<parser::ParsedVarDecl> parse_variable_declaration(bool const is_mutable);
-ErrorOr<NonnullRefPtr<typename parser::ParsedType>> parse_type_shorthand_set();
-ErrorOr<NonnullRefPtr<typename parser::ParsedStatement>> parse_if_statement();
-ErrorOr<JaktInternal::Optional<parser::ParsedCall>> parse_call();
-ErrorOr<void> inject_token(lexer::Token const token);
-ErrorOr<parser::ParsedRecord> parse_class(parser::DefinitionLinkage const definition_linkage);
-ErrorOr<parser::ParsedExternalTraitImplementation> parse_external_trait_implementation();
-ErrorOr<parser::ParsedMatchPattern> parse_match_pattern();
-ErrorOr<parser::ParsedFunction> parse_function(parser::FunctionLinkage const linkage, parser::Visibility const visibility, bool const is_comptime, bool const is_destructor, bool const is_unsafe, bool const allow_missing_body);
-ErrorOr<parser::ParsedExternImport> parse_extern_import(parser::ParsedNamespace& parent);
-ErrorOr<NonnullRefPtr<typename parser::ParsedType>> parse_typename();
-ErrorOr<JaktInternal::Tuple<JaktInternal::DynamicArray<parser::ParsedField>,JaktInternal::DynamicArray<parser::ParsedMethod>>> parse_struct_class_body(parser::DefinitionLinkage const definition_linkage, parser::Visibility const default_visibility, bool const is_class);
-ErrorOr<NonnullRefPtr<typename parser::ParsedExpression>> parse_unsafe_expr();
-static ErrorOr<parser::ParsedNamespace> parse(NonnullRefPtr<compiler::Compiler> const compiler, JaktInternal::DynamicArray<lexer::Token> const tokens);
-ErrorOr<JaktInternal::Optional<parser::NumericConstant>> make_float_numeric_constant(f64 const number, lexer::LiteralSuffix const suffix, utility::Span const span);
-ErrorOr<NonnullRefPtr<typename parser::ParsedExpression>> parse_range();
-ErrorOr<parser::ParsedBlock> parse_fat_arrow();
-void skip_newlines();
-ErrorOr<JaktInternal::Tuple<JaktInternal::DynamicArray<parser::ValueEnumVariant>,JaktInternal::DynamicArray<parser::ParsedMethod>>> parse_value_enum_body(parser::ParsedRecord const partial_enum, parser::DefinitionLinkage const definition_linkage);
-lexer::Token previous() const;
-ErrorOr<JaktInternal::DynamicArray<NonnullRefPtr<typename parser::ParsedType>>> parse_type_parameter_list();
-ErrorOr<JaktInternal::DynamicArray<parser::EnumVariantPatternArgument>> parse_variant_arguments();
-ErrorOr<NonnullRefPtr<typename parser::ParsedStatement>> parse_guard_statement();
-bool eof() const;
-ErrorOr<NonnullRefPtr<typename parser::ParsedExpression>> parse_asterisk();
-ErrorOr<NonnullRefPtr<typename parser::ParsedExpression>> parse_match_expression();
-ErrorOr<void> apply_attributes(parser::ParsedField& field, JaktInternal::DynamicArray<parser::ParsedAttribute> const& active_attributes);
-ErrorOr<void> apply_attributes(parser::ParsedFunction& parsed_function, JaktInternal::DynamicArray<parser::ParsedAttribute> const& active_attributes);
-ErrorOr<void> apply_attributes(parser::ParsedMethod& parsed_method, JaktInternal::DynamicArray<parser::ParsedAttribute> const& active_attributes);
-ErrorOr<void> apply_attributes(parser::ParsedRecord& parsed_record, JaktInternal::DynamicArray<parser::ParsedAttribute> const& active_attributes);
-lexer::Token current() const;
-ErrorOr<parser::ParsedRecord> parse_enum(parser::DefinitionLinkage const definition_linkage, bool const is_boxed);
-ErrorOr<parser::ParsedBlock> parse_block();
-utility::Span empty_span() const;
-ErrorOr<NonnullRefPtr<typename parser::ParsedExpression>> parse_postfix_colon_colon(utility::Span const start, NonnullRefPtr<typename parser::ParsedExpression> const expr);
-ErrorOr<void> error(DeprecatedString const message, utility::Span const span);
-ErrorOr<parser::ParsedTrait> parse_trait();
-ErrorOr<parser::Visibility> parse_restricted_visibility_modifier();
-ErrorOr<parser::ParsedVarDeclTuple> parse_destructuring_assignment(bool const is_mutable);
-ErrorOr<NonnullRefPtr<typename parser::ParsedExpression>> parse_operand_postfix_operator(utility::Span const start, NonnullRefPtr<typename parser::ParsedExpression> const expr);
-ErrorOr<NonnullRefPtr<typename parser::ParsedExpression>> parse_set_literal();
-ErrorOr<void> parse_attribute_list(JaktInternal::DynamicArray<parser::ParsedAttribute>& active_attributes);
-Parser(size_t a_index, JaktInternal::DynamicArray<lexer::Token> a_tokens, NonnullRefPtr<compiler::Compiler> a_compiler, bool a_can_have_trailing_closure, size_t a_next_function_id);
-
-ErrorOr<NonnullRefPtr<typename parser::ParsedExpression>> parse_expression(bool const allow_assignments, bool const allow_newlines);
-ErrorOr<NonnullRefPtr<typename parser::ParsedExpression>> parse_operator(bool const allow_assignments);
-ErrorOr<NonnullRefPtr<typename parser::ParsedStatement>> parse_for_statement();
-ErrorOr<NonnullRefPtr<typename parser::ParsedExpression>> parse_operand();
-ErrorOr<JaktInternal::Tuple<JaktInternal::DynamicArray<parser::SumEnumVariant>,JaktInternal::DynamicArray<parser::ParsedField>,JaktInternal::DynamicArray<parser::ParsedMethod>>> parse_sum_enum_body(parser::ParsedRecord const partial_enum, parser::DefinitionLinkage const definition_linkage, bool const is_boxed);
-ErrorOr<JaktInternal::DynamicArray<parser::ParsedCapture>> parse_captures();
-ErrorOr<NonnullRefPtr<typename parser::ParsedExpression>> parse_number(lexer::LiteralPrefix const prefix, DeprecatedString const number, lexer::LiteralSuffix suffix, utility::Span const span);
-ErrorOr<parser::ParsedModuleImport> parse_module_import();
-ErrorOr<parser::ParsedRecord> parse_record(parser::DefinitionLinkage const definition_linkage);
-lexer::Token peek(size_t const steps) const;
-ErrorOr<void> error_with_hint(DeprecatedString const message, utility::Span const span, DeprecatedString const hint, utility::Span const hint_span);
-ErrorOr<NonnullRefPtr<typename parser::ParsedType>> parse_type_shorthand_array_or_dictionary();
-ErrorOr<NonnullRefPtr<typename parser::ParsedType>> parse_type_shorthand_tuple();
-bool eol() const;
-ErrorOr<NonnullRefPtr<typename parser::ParsedExpression>> parse_array_or_dictionary_literal();
-ErrorOr<JaktInternal::DynamicArray<parser::ParsedMatchPattern>> parse_match_patterns();
-ErrorOr<void> parse_import(parser::ParsedNamespace& parent);
-ErrorOr<NonnullRefPtr<typename parser::ParsedStatement>> parse_statement(bool const inside_block);
-ErrorOr<parser::ParsedField> parse_field(parser::Visibility const visibility);
-ErrorOr<DeprecatedString> parse_argument_label();
-ErrorOr<NonnullRefPtr<typename parser::ParsedExpression>> parse_ampersand();
-ErrorOr<JaktInternal::Optional<JaktInternal::DynamicArray<parser::IncludeAction>>> parse_include_action();
-ErrorOr<NonnullRefPtr<typename parser::ParsedExpression>> parse_try_block();
-ErrorOr<JaktInternal::DynamicArray<parser::ParsedGenericParameter>> parse_generic_parameters();
-ErrorOr<parser::ParsedRecord> parse_struct(parser::DefinitionLinkage const definition_linkage);
-ErrorOr<JaktInternal::Optional<JaktInternal::DynamicArray<parser::ParsedNameWithGenericParameters>>> parse_trait_list();
-ErrorOr<DeprecatedString> debug_description() const;
-};struct ParsedParameter {
-  public:
-bool requires_label;parser::ParsedVariable variable;JaktInternal::Optional<NonnullRefPtr<typename parser::ParsedExpression>> default_argument;utility::Span span;ParsedParameter(bool a_requires_label, parser::ParsedVariable a_variable, JaktInternal::Optional<NonnullRefPtr<typename parser::ParsedExpression>> a_default_argument, utility::Span a_span);
-
-bool equals(parser::ParsedParameter const rhs_param) const;
-ErrorOr<DeprecatedString> debug_description() const;
-};struct ParsedPatternDefault {
-  public:
-parser::ParsedVarDecl variable;NonnullRefPtr<typename parser::ParsedExpression> value;ParsedPatternDefault(parser::ParsedVarDecl a_variable, NonnullRefPtr<typename parser::ParsedExpression> a_value);
-
-ErrorOr<DeprecatedString> debug_description() const;
-};namespace ParsedTraitRequirements_Details {
-struct Nothing {
-};
-struct Methods{
-JaktInternal::DynamicArray<parser::ParsedFunction> value;
-template<typename _MemberT0>
-Methods(_MemberT0&& member_0):
-value{ forward<_MemberT0>(member_0)}
-{}
-};
-struct ComptimeExpression{
-NonnullRefPtr<typename parser::ParsedExpression> value;
-template<typename _MemberT0>
-ComptimeExpression(_MemberT0&& member_0):
-value{ forward<_MemberT0>(member_0)}
-{}
-};
-}
-struct ParsedTraitRequirements : public Variant<ParsedTraitRequirements_Details::Nothing, ParsedTraitRequirements_Details::Methods, ParsedTraitRequirements_Details::ComptimeExpression> {
-using Variant<ParsedTraitRequirements_Details::Nothing, ParsedTraitRequirements_Details::Methods, ParsedTraitRequirements_Details::ComptimeExpression>::Variant;
-    using Nothing = ParsedTraitRequirements_Details::Nothing;
-    using Methods = ParsedTraitRequirements_Details::Methods;
-    using ComptimeExpression = ParsedTraitRequirements_Details::ComptimeExpression;
-ErrorOr<DeprecatedString> debug_description() const;
-};
-struct ParsedTrait {
-  public:
-DeprecatedString name;utility::Span name_span;JaktInternal::DynamicArray<parser::ParsedGenericParameter> generic_parameters;parser::ParsedTraitRequirements requirements;ParsedTrait(DeprecatedString a_name, utility::Span a_name_span, JaktInternal::DynamicArray<parser::ParsedGenericParameter> a_generic_parameters, parser::ParsedTraitRequirements a_requirements);
-
-ErrorOr<DeprecatedString> debug_description() const;
-};struct ValueEnumVariant {
-  public:
-DeprecatedString name;utility::Span span;JaktInternal::Optional<NonnullRefPtr<typename parser::ParsedExpression>> value;ValueEnumVariant(DeprecatedString a_name, utility::Span a_span, JaktInternal::Optional<NonnullRefPtr<typename parser::ParsedExpression>> a_value);
-
-ErrorOr<DeprecatedString> debug_description() const;
-};struct ParsedGenericParameter {
-  public:
-DeprecatedString name;utility::Span span;JaktInternal::Optional<JaktInternal::DynamicArray<parser::ParsedNameWithGenericParameters>> requires_list;ParsedGenericParameter(DeprecatedString a_name, utility::Span a_span, JaktInternal::Optional<JaktInternal::DynamicArray<parser::ParsedNameWithGenericParameters>> a_requires_list);
-
-ErrorOr<DeprecatedString> debug_description() const;
-};namespace ParsedStatement_Details {
-struct Expression {
-NonnullRefPtr<typename parser::ParsedExpression> expr;
-utility::Span span;
-template<typename _MemberT0, typename _MemberT1>
-Expression(_MemberT0&& member_0, _MemberT1&& member_1):
-expr{ forward<_MemberT0>(member_0)},
-span{ forward<_MemberT1>(member_1)}
-{}
-};
-struct Defer {
-NonnullRefPtr<typename parser::ParsedStatement> statement;
-utility::Span span;
-template<typename _MemberT0, typename _MemberT1>
-Defer(_MemberT0&& member_0, _MemberT1&& member_1):
-statement{ forward<_MemberT0>(member_0)},
-span{ forward<_MemberT1>(member_1)}
-{}
-};
-struct UnsafeBlock {
-parser::ParsedBlock block;
-utility::Span span;
-template<typename _MemberT0, typename _MemberT1>
-UnsafeBlock(_MemberT0&& member_0, _MemberT1&& member_1):
-block{ forward<_MemberT0>(member_0)},
-span{ forward<_MemberT1>(member_1)}
-{}
-};
-struct DestructuringAssignment {
-JaktInternal::DynamicArray<parser::ParsedVarDecl> vars;
-NonnullRefPtr<typename parser::ParsedStatement> var_decl;
-utility::Span span;
-template<typename _MemberT0, typename _MemberT1, typename _MemberT2>
-DestructuringAssignment(_MemberT0&& member_0, _MemberT1&& member_1, _MemberT2&& member_2):
-vars{ forward<_MemberT0>(member_0)},
-var_decl{ forward<_MemberT1>(member_1)},
-span{ forward<_MemberT2>(member_2)}
-{}
-};
-struct VarDecl {
-parser::ParsedVarDecl var;
-NonnullRefPtr<typename parser::ParsedExpression> init;
-utility::Span span;
-template<typename _MemberT0, typename _MemberT1, typename _MemberT2>
-VarDecl(_MemberT0&& member_0, _MemberT1&& member_1, _MemberT2&& member_2):
-var{ forward<_MemberT0>(member_0)},
-init{ forward<_MemberT1>(member_1)},
-span{ forward<_MemberT2>(member_2)}
-{}
-};
-struct If {
-NonnullRefPtr<typename parser::ParsedExpression> condition;
-parser::ParsedBlock then_block;
-JaktInternal::Optional<NonnullRefPtr<typename parser::ParsedStatement>> else_statement;
-utility::Span span;
-template<typename _MemberT0, typename _MemberT1, typename _MemberT2, typename _MemberT3>
-If(_MemberT0&& member_0, _MemberT1&& member_1, _MemberT2&& member_2, _MemberT3&& member_3):
-condition{ forward<_MemberT0>(member_0)},
-then_block{ forward<_MemberT1>(member_1)},
-else_statement{ forward<_MemberT2>(member_2)},
-span{ forward<_MemberT3>(member_3)}
-{}
-};
-struct Block {
-parser::ParsedBlock block;
-utility::Span span;
-template<typename _MemberT0, typename _MemberT1>
-Block(_MemberT0&& member_0, _MemberT1&& member_1):
-block{ forward<_MemberT0>(member_0)},
-span{ forward<_MemberT1>(member_1)}
-{}
-};
-struct Loop {
-parser::ParsedBlock block;
-utility::Span span;
-template<typename _MemberT0, typename _MemberT1>
-Loop(_MemberT0&& member_0, _MemberT1&& member_1):
-block{ forward<_MemberT0>(member_0)},
-span{ forward<_MemberT1>(member_1)}
-{}
-};
-struct While {
-NonnullRefPtr<typename parser::ParsedExpression> condition;
-parser::ParsedBlock block;
-utility::Span span;
-template<typename _MemberT0, typename _MemberT1, typename _MemberT2>
-While(_MemberT0&& member_0, _MemberT1&& member_1, _MemberT2&& member_2):
-condition{ forward<_MemberT0>(member_0)},
-block{ forward<_MemberT1>(member_1)},
-span{ forward<_MemberT2>(member_2)}
-{}
-};
-struct For {
-DeprecatedString iterator_name;
-utility::Span name_span;
-bool is_destructuring;
-NonnullRefPtr<typename parser::ParsedExpression> range;
-parser::ParsedBlock block;
-utility::Span span;
-template<typename _MemberT0, typename _MemberT1, typename _MemberT2, typename _MemberT3, typename _MemberT4, typename _MemberT5>
-For(_MemberT0&& member_0, _MemberT1&& member_1, _MemberT2&& member_2, _MemberT3&& member_3, _MemberT4&& member_4, _MemberT5&& member_5):
-iterator_name{ forward<_MemberT0>(member_0)},
-name_span{ forward<_MemberT1>(member_1)},
-is_destructuring{ forward<_MemberT2>(member_2)},
-range{ forward<_MemberT3>(member_3)},
-block{ forward<_MemberT4>(member_4)},
-span{ forward<_MemberT5>(member_5)}
-{}
-};
-struct Break{
-utility::Span value;
-template<typename _MemberT0>
-Break(_MemberT0&& member_0):
-value{ forward<_MemberT0>(member_0)}
-{}
-};
-struct Continue{
-utility::Span value;
-template<typename _MemberT0>
-Continue(_MemberT0&& member_0):
-value{ forward<_MemberT0>(member_0)}
-{}
-};
-struct Return {
-JaktInternal::Optional<NonnullRefPtr<typename parser::ParsedExpression>> expr;
-utility::Span span;
-template<typename _MemberT0, typename _MemberT1>
-Return(_MemberT0&& member_0, _MemberT1&& member_1):
-expr{ forward<_MemberT0>(member_0)},
-span{ forward<_MemberT1>(member_1)}
-{}
-};
-struct Throw {
-NonnullRefPtr<typename parser::ParsedExpression> expr;
-utility::Span span;
-template<typename _MemberT0, typename _MemberT1>
-Throw(_MemberT0&& member_0, _MemberT1&& member_1):
-expr{ forward<_MemberT0>(member_0)},
-span{ forward<_MemberT1>(member_1)}
-{}
-};
-struct Yield {
-NonnullRefPtr<typename parser::ParsedExpression> expr;
-utility::Span span;
-template<typename _MemberT0, typename _MemberT1>
-Yield(_MemberT0&& member_0, _MemberT1&& member_1):
-expr{ forward<_MemberT0>(member_0)},
-span{ forward<_MemberT1>(member_1)}
-{}
-};
-struct InlineCpp {
-parser::ParsedBlock block;
-utility::Span span;
-template<typename _MemberT0, typename _MemberT1>
-InlineCpp(_MemberT0&& member_0, _MemberT1&& member_1):
-block{ forward<_MemberT0>(member_0)},
-span{ forward<_MemberT1>(member_1)}
-{}
-};
-struct Guard {
-NonnullRefPtr<typename parser::ParsedExpression> expr;
-parser::ParsedBlock else_block;
-parser::ParsedBlock remaining_code;
-utility::Span span;
-template<typename _MemberT0, typename _MemberT1, typename _MemberT2, typename _MemberT3>
-Guard(_MemberT0&& member_0, _MemberT1&& member_1, _MemberT2&& member_2, _MemberT3&& member_3):
-expr{ forward<_MemberT0>(member_0)},
-else_block{ forward<_MemberT1>(member_1)},
-remaining_code{ forward<_MemberT2>(member_2)},
-span{ forward<_MemberT3>(member_3)}
-{}
-};
-struct Garbage{
-utility::Span value;
-template<typename _MemberT0>
-Garbage(_MemberT0&& member_0):
-value{ forward<_MemberT0>(member_0)}
-{}
-};
-}
-struct ParsedStatement : public Variant<ParsedStatement_Details::Expression, ParsedStatement_Details::Defer, ParsedStatement_Details::UnsafeBlock, ParsedStatement_Details::DestructuringAssignment, ParsedStatement_Details::VarDecl, ParsedStatement_Details::If, ParsedStatement_Details::Block, ParsedStatement_Details::Loop, ParsedStatement_Details::While, ParsedStatement_Details::For, ParsedStatement_Details::Break, ParsedStatement_Details::Continue, ParsedStatement_Details::Return, ParsedStatement_Details::Throw, ParsedStatement_Details::Yield, ParsedStatement_Details::InlineCpp, ParsedStatement_Details::Guard, ParsedStatement_Details::Garbage>, public RefCounted<ParsedStatement> {
-using Variant<ParsedStatement_Details::Expression, ParsedStatement_Details::Defer, ParsedStatement_Details::UnsafeBlock, ParsedStatement_Details::DestructuringAssignment, ParsedStatement_Details::VarDecl, ParsedStatement_Details::If, ParsedStatement_Details::Block, ParsedStatement_Details::Loop, ParsedStatement_Details::While, ParsedStatement_Details::For, ParsedStatement_Details::Break, ParsedStatement_Details::Continue, ParsedStatement_Details::Return, ParsedStatement_Details::Throw, ParsedStatement_Details::Yield, ParsedStatement_Details::InlineCpp, ParsedStatement_Details::Guard, ParsedStatement_Details::Garbage>::Variant;
-    using Expression = ParsedStatement_Details::Expression;
-    using Defer = ParsedStatement_Details::Defer;
-    using UnsafeBlock = ParsedStatement_Details::UnsafeBlock;
-    using DestructuringAssignment = ParsedStatement_Details::DestructuringAssignment;
-    using VarDecl = ParsedStatement_Details::VarDecl;
-    using If = ParsedStatement_Details::If;
-    using Block = ParsedStatement_Details::Block;
-    using Loop = ParsedStatement_Details::Loop;
-    using While = ParsedStatement_Details::While;
-    using For = ParsedStatement_Details::For;
-    using Break = ParsedStatement_Details::Break;
-    using Continue = ParsedStatement_Details::Continue;
-    using Return = ParsedStatement_Details::Return;
-    using Throw = ParsedStatement_Details::Throw;
-    using Yield = ParsedStatement_Details::Yield;
-    using InlineCpp = ParsedStatement_Details::InlineCpp;
-    using Guard = ParsedStatement_Details::Guard;
-    using Garbage = ParsedStatement_Details::Garbage;
-template<typename V, typename... Args> static auto __jakt_create(Args&&... args) {
-return adopt_nonnull_ref_or_enomem(new (nothrow) ParsedStatement(V(forward<Args>(args)...)));
-}
-ErrorOr<DeprecatedString> debug_description() const;
-bool equals(NonnullRefPtr<typename parser::ParsedStatement> const rhs_statement) const;
-utility::Span span() const;
-};
-struct ParsedExternImport {
-  public:
-bool is_c;parser::ParsedNamespace assigned_namespace;JaktInternal::DynamicArray<parser::IncludeAction> before_include;JaktInternal::DynamicArray<parser::IncludeAction> after_include;ErrorOr<bool> is_equivalent_to(parser::ParsedExternImport const other) const;
-ParsedExternImport(bool a_is_c, parser::ParsedNamespace a_assigned_namespace, JaktInternal::DynamicArray<parser::IncludeAction> a_before_include, JaktInternal::DynamicArray<parser::IncludeAction> a_after_include);
-
-DeprecatedString get_path() const;
-DeprecatedString get_name() const;
-ErrorOr<DeprecatedString> debug_description() const;
-};template <typename T>
+template <typename T>
 T u64_to_float(u64 const number);
 }
 } // namespace Jakt
-template<>struct Jakt::Formatter<Jakt::parser::ParsedCapture> : Jakt::Formatter<Jakt::StringView>{
-Jakt::ErrorOr<void> format(Jakt::FormatBuilder& builder, Jakt::parser::ParsedCapture const& value) {
+template<>struct Jakt::Formatter<Jakt::parser::ParsedTraitRequirements> : Jakt::Formatter<Jakt::StringView>{
+Jakt::ErrorOr<void> format(Jakt::FormatBuilder& builder, Jakt::parser::ParsedTraitRequirements const& value) {
 JaktInternal::PrettyPrint::ScopedEnable pretty_print_enable { m_alternative_form };Jakt::ErrorOr<void> format_error = Jakt::Formatter<Jakt::StringView>::format(builder, MUST(value.debug_description()));return format_error;}
 };
 namespace Jakt {
 } // namespace Jakt
-template<>struct Jakt::Formatter<Jakt::parser::ExternalName> : Jakt::Formatter<Jakt::StringView>{
-Jakt::ErrorOr<void> format(Jakt::FormatBuilder& builder, Jakt::parser::ExternalName const& value) {
-JaktInternal::PrettyPrint::ScopedEnable pretty_print_enable { m_alternative_form };Jakt::ErrorOr<void> format_error = Jakt::Formatter<Jakt::StringView>::format(builder, MUST(value.debug_description()));return format_error;}
-};
-namespace Jakt {
-} // namespace Jakt
-template<>struct Jakt::Formatter<Jakt::parser::ParsedName> : Jakt::Formatter<Jakt::StringView>{
-Jakt::ErrorOr<void> format(Jakt::FormatBuilder& builder, Jakt::parser::ParsedName const& value) {
-JaktInternal::PrettyPrint::ScopedEnable pretty_print_enable { m_alternative_form };Jakt::ErrorOr<void> format_error = Jakt::Formatter<Jakt::StringView>::format(builder, MUST(value.debug_description()));return format_error;}
-};
-namespace Jakt {
-} // namespace Jakt
-template<>struct Jakt::Formatter<Jakt::parser::ParsedAlias> : Jakt::Formatter<Jakt::StringView>{
-Jakt::ErrorOr<void> format(Jakt::FormatBuilder& builder, Jakt::parser::ParsedAlias const& value) {
-JaktInternal::PrettyPrint::ScopedEnable pretty_print_enable { m_alternative_form };Jakt::ErrorOr<void> format_error = Jakt::Formatter<Jakt::StringView>::format(builder, MUST(value.debug_description()));return format_error;}
-};
-namespace Jakt {
-} // namespace Jakt
-template<>struct Jakt::Formatter<Jakt::parser::ParsedType> : Jakt::Formatter<Jakt::StringView>{
-Jakt::ErrorOr<void> format(Jakt::FormatBuilder& builder, Jakt::parser::ParsedType const& value) {
-JaktInternal::PrettyPrint::ScopedEnable pretty_print_enable { m_alternative_form };Jakt::ErrorOr<void> format_error = Jakt::Formatter<Jakt::StringView>::format(builder, MUST(value.debug_description()));return format_error;}
-};
-namespace Jakt {
-} // namespace Jakt
-template<>struct Jakt::Formatter<Jakt::parser::ParsedAttributeArgument> : Jakt::Formatter<Jakt::StringView>{
-Jakt::ErrorOr<void> format(Jakt::FormatBuilder& builder, Jakt::parser::ParsedAttributeArgument const& value) {
-JaktInternal::PrettyPrint::ScopedEnable pretty_print_enable { m_alternative_form };Jakt::ErrorOr<void> format_error = Jakt::Formatter<Jakt::StringView>::format(builder, MUST(value.debug_description()));return format_error;}
-};
-namespace Jakt {
-} // namespace Jakt
-template<>struct Jakt::Formatter<Jakt::parser::FunctionLinkage> : Jakt::Formatter<Jakt::StringView>{
-Jakt::ErrorOr<void> format(Jakt::FormatBuilder& builder, Jakt::parser::FunctionLinkage const& value) {
-JaktInternal::PrettyPrint::ScopedEnable pretty_print_enable { m_alternative_form };Jakt::ErrorOr<void> format_error = Jakt::Formatter<Jakt::StringView>::format(builder, MUST(value.debug_description()));return format_error;}
-};
-namespace Jakt {
-} // namespace Jakt
-template<>struct Jakt::Formatter<Jakt::parser::NumericConstant> : Jakt::Formatter<Jakt::StringView>{
-Jakt::ErrorOr<void> format(Jakt::FormatBuilder& builder, Jakt::parser::NumericConstant const& value) {
-JaktInternal::PrettyPrint::ScopedEnable pretty_print_enable { m_alternative_form };Jakt::ErrorOr<void> format_error = Jakt::Formatter<Jakt::StringView>::format(builder, MUST(value.debug_description()));return format_error;}
-};
-namespace Jakt {
-} // namespace Jakt
-template<>struct Jakt::Formatter<Jakt::parser::ParsedVarDeclTuple> : Jakt::Formatter<Jakt::StringView>{
-Jakt::ErrorOr<void> format(Jakt::FormatBuilder& builder, Jakt::parser::ParsedVarDeclTuple const& value) {
-JaktInternal::PrettyPrint::ScopedEnable pretty_print_enable { m_alternative_form };Jakt::ErrorOr<void> format_error = Jakt::Formatter<Jakt::StringView>::format(builder, MUST(value.debug_description()));return format_error;}
-};
-namespace Jakt {
-} // namespace Jakt
-template<>struct Jakt::Formatter<Jakt::parser::EnumVariantPatternArgument> : Jakt::Formatter<Jakt::StringView>{
-Jakt::ErrorOr<void> format(Jakt::FormatBuilder& builder, Jakt::parser::EnumVariantPatternArgument const& value) {
-JaktInternal::PrettyPrint::ScopedEnable pretty_print_enable { m_alternative_form };Jakt::ErrorOr<void> format_error = Jakt::Formatter<Jakt::StringView>::format(builder, MUST(value.debug_description()));return format_error;}
-};
-namespace Jakt {
-} // namespace Jakt
-template<>struct Jakt::Formatter<Jakt::parser::ParsedVarDecl> : Jakt::Formatter<Jakt::StringView>{
-Jakt::ErrorOr<void> format(Jakt::FormatBuilder& builder, Jakt::parser::ParsedVarDecl const& value) {
+template<>struct Jakt::Formatter<Jakt::parser::ParsedTrait> : Jakt::Formatter<Jakt::StringView>{
+Jakt::ErrorOr<void> format(Jakt::FormatBuilder& builder, Jakt::parser::ParsedTrait const& value) {
 JaktInternal::PrettyPrint::ScopedEnable pretty_print_enable { m_alternative_form };Jakt::ErrorOr<void> format_error = Jakt::Formatter<Jakt::StringView>::format(builder, MUST(value.debug_description()));return format_error;}
 };
 namespace Jakt {
 } // namespace Jakt
 template<>struct Jakt::Formatter<Jakt::parser::Visibility> : Jakt::Formatter<Jakt::StringView>{
 Jakt::ErrorOr<void> format(Jakt::FormatBuilder& builder, Jakt::parser::Visibility const& value) {
-JaktInternal::PrettyPrint::ScopedEnable pretty_print_enable { m_alternative_form };Jakt::ErrorOr<void> format_error = Jakt::Formatter<Jakt::StringView>::format(builder, MUST(value.debug_description()));return format_error;}
-};
-namespace Jakt {
-} // namespace Jakt
-template<>struct Jakt::Formatter<Jakt::parser::ParsedField> : Jakt::Formatter<Jakt::StringView>{
-Jakt::ErrorOr<void> format(Jakt::FormatBuilder& builder, Jakt::parser::ParsedField const& value) {
-JaktInternal::PrettyPrint::ScopedEnable pretty_print_enable { m_alternative_form };Jakt::ErrorOr<void> format_error = Jakt::Formatter<Jakt::StringView>::format(builder, MUST(value.debug_description()));return format_error;}
-};
-namespace Jakt {
-} // namespace Jakt
-template<>struct Jakt::Formatter<Jakt::parser::TypeCast> : Jakt::Formatter<Jakt::StringView>{
-Jakt::ErrorOr<void> format(Jakt::FormatBuilder& builder, Jakt::parser::TypeCast const& value) {
-JaktInternal::PrettyPrint::ScopedEnable pretty_print_enable { m_alternative_form };Jakt::ErrorOr<void> format_error = Jakt::Formatter<Jakt::StringView>::format(builder, MUST(value.debug_description()));return format_error;}
-};
-namespace Jakt {
-} // namespace Jakt
-template<>struct Jakt::Formatter<Jakt::parser::UnaryOperator> : Jakt::Formatter<Jakt::StringView>{
-Jakt::ErrorOr<void> format(Jakt::FormatBuilder& builder, Jakt::parser::UnaryOperator const& value) {
-JaktInternal::PrettyPrint::ScopedEnable pretty_print_enable { m_alternative_form };Jakt::ErrorOr<void> format_error = Jakt::Formatter<Jakt::StringView>::format(builder, MUST(value.debug_description()));return format_error;}
-};
-namespace Jakt {
-} // namespace Jakt
-template<>struct Jakt::Formatter<Jakt::parser::ImportList> : Jakt::Formatter<Jakt::StringView>{
-Jakt::ErrorOr<void> format(Jakt::FormatBuilder& builder, Jakt::parser::ImportList const& value) {
-JaktInternal::PrettyPrint::ScopedEnable pretty_print_enable { m_alternative_form };Jakt::ErrorOr<void> format_error = Jakt::Formatter<Jakt::StringView>::format(builder, MUST(value.debug_description()));return format_error;}
-};
-namespace Jakt {
-} // namespace Jakt
-template<>struct Jakt::Formatter<Jakt::parser::ParsedNameWithGenericParameters> : Jakt::Formatter<Jakt::StringView>{
-Jakt::ErrorOr<void> format(Jakt::FormatBuilder& builder, Jakt::parser::ParsedNameWithGenericParameters const& value) {
-JaktInternal::PrettyPrint::ScopedEnable pretty_print_enable { m_alternative_form };Jakt::ErrorOr<void> format_error = Jakt::Formatter<Jakt::StringView>::format(builder, MUST(value.debug_description()));return format_error;}
-};
-namespace Jakt {
-} // namespace Jakt
-template<>struct Jakt::Formatter<Jakt::parser::RecordType> : Jakt::Formatter<Jakt::StringView>{
-Jakt::ErrorOr<void> format(Jakt::FormatBuilder& builder, Jakt::parser::RecordType const& value) {
-JaktInternal::PrettyPrint::ScopedEnable pretty_print_enable { m_alternative_form };Jakt::ErrorOr<void> format_error = Jakt::Formatter<Jakt::StringView>::format(builder, MUST(value.debug_description()));return format_error;}
-};
-namespace Jakt {
-} // namespace Jakt
-template<>struct Jakt::Formatter<Jakt::parser::ParsedNamespace> : Jakt::Formatter<Jakt::StringView>{
-Jakt::ErrorOr<void> format(Jakt::FormatBuilder& builder, Jakt::parser::ParsedNamespace const& value) {
-JaktInternal::PrettyPrint::ScopedEnable pretty_print_enable { m_alternative_form };Jakt::ErrorOr<void> format_error = Jakt::Formatter<Jakt::StringView>::format(builder, MUST(value.debug_description()));return format_error;}
-};
-namespace Jakt {
-} // namespace Jakt
-template<>struct Jakt::Formatter<Jakt::parser::SumEnumVariant> : Jakt::Formatter<Jakt::StringView>{
-Jakt::ErrorOr<void> format(Jakt::FormatBuilder& builder, Jakt::parser::SumEnumVariant const& value) {
-JaktInternal::PrettyPrint::ScopedEnable pretty_print_enable { m_alternative_form };Jakt::ErrorOr<void> format_error = Jakt::Formatter<Jakt::StringView>::format(builder, MUST(value.debug_description()));return format_error;}
-};
-namespace Jakt {
-} // namespace Jakt
-template<>struct Jakt::Formatter<Jakt::parser::ArgumentStoreLevel> : Jakt::Formatter<Jakt::StringView>{
-Jakt::ErrorOr<void> format(Jakt::FormatBuilder& builder, Jakt::parser::ArgumentStoreLevel const& value) {
 JaktInternal::PrettyPrint::ScopedEnable pretty_print_enable { m_alternative_form };Jakt::ErrorOr<void> format_error = Jakt::Formatter<Jakt::StringView>::format(builder, MUST(value.debug_description()));return format_error;}
 };
 namespace Jakt {
@@ -1875,6 +1767,18 @@ JaktInternal::PrettyPrint::ScopedEnable pretty_print_enable { m_alternative_form
 };
 namespace Jakt {
 } // namespace Jakt
+template<>struct Jakt::Formatter<Jakt::parser::FunctionLinkage> : Jakt::Formatter<Jakt::StringView>{
+Jakt::ErrorOr<void> format(Jakt::FormatBuilder& builder, Jakt::parser::FunctionLinkage const& value) {
+JaktInternal::PrettyPrint::ScopedEnable pretty_print_enable { m_alternative_form };Jakt::ErrorOr<void> format_error = Jakt::Formatter<Jakt::StringView>::format(builder, MUST(value.debug_description()));return format_error;}
+};
+namespace Jakt {
+} // namespace Jakt
+template<>struct Jakt::Formatter<Jakt::parser::ExternalName> : Jakt::Formatter<Jakt::StringView>{
+Jakt::ErrorOr<void> format(Jakt::FormatBuilder& builder, Jakt::parser::ExternalName const& value) {
+JaktInternal::PrettyPrint::ScopedEnable pretty_print_enable { m_alternative_form };Jakt::ErrorOr<void> format_error = Jakt::Formatter<Jakt::StringView>::format(builder, MUST(value.debug_description()));return format_error;}
+};
+namespace Jakt {
+} // namespace Jakt
 template<>struct Jakt::Formatter<Jakt::parser::ParsedFunction> : Jakt::Formatter<Jakt::StringView>{
 Jakt::ErrorOr<void> format(Jakt::FormatBuilder& builder, Jakt::parser::ParsedFunction const& value) {
 JaktInternal::PrettyPrint::ScopedEnable pretty_print_enable { m_alternative_form };Jakt::ErrorOr<void> format_error = Jakt::Formatter<Jakt::StringView>::format(builder, MUST(value.debug_description()));return format_error;}
@@ -1883,6 +1787,198 @@ namespace Jakt {
 } // namespace Jakt
 template<>struct Jakt::Formatter<Jakt::parser::ParsedMethod> : Jakt::Formatter<Jakt::StringView>{
 Jakt::ErrorOr<void> format(Jakt::FormatBuilder& builder, Jakt::parser::ParsedMethod const& value) {
+JaktInternal::PrettyPrint::ScopedEnable pretty_print_enable { m_alternative_form };Jakt::ErrorOr<void> format_error = Jakt::Formatter<Jakt::StringView>::format(builder, MUST(value.debug_description()));return format_error;}
+};
+namespace Jakt {
+} // namespace Jakt
+template<>struct Jakt::Formatter<Jakt::parser::SumEnumVariant> : Jakt::Formatter<Jakt::StringView>{
+Jakt::ErrorOr<void> format(Jakt::FormatBuilder& builder, Jakt::parser::SumEnumVariant const& value) {
+JaktInternal::PrettyPrint::ScopedEnable pretty_print_enable { m_alternative_form };Jakt::ErrorOr<void> format_error = Jakt::Formatter<Jakt::StringView>::format(builder, MUST(value.debug_description()));return format_error;}
+};
+namespace Jakt {
+} // namespace Jakt
+template<>struct Jakt::Formatter<Jakt::parser::ParsedCall> : Jakt::Formatter<Jakt::StringView>{
+Jakt::ErrorOr<void> format(Jakt::FormatBuilder& builder, Jakt::parser::ParsedCall const& value) {
+JaktInternal::PrettyPrint::ScopedEnable pretty_print_enable { m_alternative_form };Jakt::ErrorOr<void> format_error = Jakt::Formatter<Jakt::StringView>::format(builder, MUST(value.debug_description()));return format_error;}
+};
+namespace Jakt {
+} // namespace Jakt
+template<>struct Jakt::Formatter<Jakt::parser::NumericConstant> : Jakt::Formatter<Jakt::StringView>{
+Jakt::ErrorOr<void> format(Jakt::FormatBuilder& builder, Jakt::parser::NumericConstant const& value) {
+JaktInternal::PrettyPrint::ScopedEnable pretty_print_enable { m_alternative_form };Jakt::ErrorOr<void> format_error = Jakt::Formatter<Jakt::StringView>::format(builder, MUST(value.debug_description()));return format_error;}
+};
+namespace Jakt {
+} // namespace Jakt
+template<>struct Jakt::Formatter<Jakt::parser::ParsedVariable> : Jakt::Formatter<Jakt::StringView>{
+Jakt::ErrorOr<void> format(Jakt::FormatBuilder& builder, Jakt::parser::ParsedVariable const& value) {
+JaktInternal::PrettyPrint::ScopedEnable pretty_print_enable { m_alternative_form };Jakt::ErrorOr<void> format_error = Jakt::Formatter<Jakt::StringView>::format(builder, MUST(value.debug_description()));return format_error;}
+};
+namespace Jakt {
+} // namespace Jakt
+template<>struct Jakt::Formatter<Jakt::parser::ParsedParameter> : Jakt::Formatter<Jakt::StringView>{
+Jakt::ErrorOr<void> format(Jakt::FormatBuilder& builder, Jakt::parser::ParsedParameter const& value) {
+JaktInternal::PrettyPrint::ScopedEnable pretty_print_enable { m_alternative_form };Jakt::ErrorOr<void> format_error = Jakt::Formatter<Jakt::StringView>::format(builder, MUST(value.debug_description()));return format_error;}
+};
+namespace Jakt {
+} // namespace Jakt
+template<>struct Jakt::Formatter<Jakt::parser::ParsedName> : Jakt::Formatter<Jakt::StringView>{
+Jakt::ErrorOr<void> format(Jakt::FormatBuilder& builder, Jakt::parser::ParsedName const& value) {
+JaktInternal::PrettyPrint::ScopedEnable pretty_print_enable { m_alternative_form };Jakt::ErrorOr<void> format_error = Jakt::Formatter<Jakt::StringView>::format(builder, MUST(value.debug_description()));return format_error;}
+};
+namespace Jakt {
+} // namespace Jakt
+template<>struct Jakt::Formatter<Jakt::parser::ParsedAlias> : Jakt::Formatter<Jakt::StringView>{
+Jakt::ErrorOr<void> format(Jakt::FormatBuilder& builder, Jakt::parser::ParsedAlias const& value) {
+JaktInternal::PrettyPrint::ScopedEnable pretty_print_enable { m_alternative_form };Jakt::ErrorOr<void> format_error = Jakt::Formatter<Jakt::StringView>::format(builder, MUST(value.debug_description()));return format_error;}
+};
+namespace Jakt {
+} // namespace Jakt
+template<>struct Jakt::Formatter<Jakt::parser::ValueEnumVariant> : Jakt::Formatter<Jakt::StringView>{
+Jakt::ErrorOr<void> format(Jakt::FormatBuilder& builder, Jakt::parser::ValueEnumVariant const& value) {
+JaktInternal::PrettyPrint::ScopedEnable pretty_print_enable { m_alternative_form };Jakt::ErrorOr<void> format_error = Jakt::Formatter<Jakt::StringView>::format(builder, MUST(value.debug_description()));return format_error;}
+};
+namespace Jakt {
+} // namespace Jakt
+template<>struct Jakt::Formatter<Jakt::parser::ParsedMatchBody> : Jakt::Formatter<Jakt::StringView>{
+Jakt::ErrorOr<void> format(Jakt::FormatBuilder& builder, Jakt::parser::ParsedMatchBody const& value) {
+JaktInternal::PrettyPrint::ScopedEnable pretty_print_enable { m_alternative_form };Jakt::ErrorOr<void> format_error = Jakt::Formatter<Jakt::StringView>::format(builder, MUST(value.debug_description()));return format_error;}
+};
+namespace Jakt {
+} // namespace Jakt
+template<>struct Jakt::Formatter<Jakt::parser::ParsedMatchCase> : Jakt::Formatter<Jakt::StringView>{
+Jakt::ErrorOr<void> format(Jakt::FormatBuilder& builder, Jakt::parser::ParsedMatchCase const& value) {
+JaktInternal::PrettyPrint::ScopedEnable pretty_print_enable { m_alternative_form };Jakt::ErrorOr<void> format_error = Jakt::Formatter<Jakt::StringView>::format(builder, MUST(value.debug_description()));return format_error;}
+};
+namespace Jakt {
+} // namespace Jakt
+template<>struct Jakt::Formatter<Jakt::parser::ParsedAttributeArgument> : Jakt::Formatter<Jakt::StringView>{
+Jakt::ErrorOr<void> format(Jakt::FormatBuilder& builder, Jakt::parser::ParsedAttributeArgument const& value) {
+JaktInternal::PrettyPrint::ScopedEnable pretty_print_enable { m_alternative_form };Jakt::ErrorOr<void> format_error = Jakt::Formatter<Jakt::StringView>::format(builder, MUST(value.debug_description()));return format_error;}
+};
+namespace Jakt {
+} // namespace Jakt
+template<>struct Jakt::Formatter<Jakt::parser::ParsedVarDecl> : Jakt::Formatter<Jakt::StringView>{
+Jakt::ErrorOr<void> format(Jakt::FormatBuilder& builder, Jakt::parser::ParsedVarDecl const& value) {
+JaktInternal::PrettyPrint::ScopedEnable pretty_print_enable { m_alternative_form };Jakt::ErrorOr<void> format_error = Jakt::Formatter<Jakt::StringView>::format(builder, MUST(value.debug_description()));return format_error;}
+};
+namespace Jakt {
+} // namespace Jakt
+template<>struct Jakt::Formatter<Jakt::parser::ParsedPatternDefault> : Jakt::Formatter<Jakt::StringView>{
+Jakt::ErrorOr<void> format(Jakt::FormatBuilder& builder, Jakt::parser::ParsedPatternDefault const& value) {
+JaktInternal::PrettyPrint::ScopedEnable pretty_print_enable { m_alternative_form };Jakt::ErrorOr<void> format_error = Jakt::Formatter<Jakt::StringView>::format(builder, MUST(value.debug_description()));return format_error;}
+};
+namespace Jakt {
+} // namespace Jakt
+template<>struct Jakt::Formatter<Jakt::parser::TypeCast> : Jakt::Formatter<Jakt::StringView>{
+Jakt::ErrorOr<void> format(Jakt::FormatBuilder& builder, Jakt::parser::TypeCast const& value) {
+JaktInternal::PrettyPrint::ScopedEnable pretty_print_enable { m_alternative_form };Jakt::ErrorOr<void> format_error = Jakt::Formatter<Jakt::StringView>::format(builder, MUST(value.debug_description()));return format_error;}
+};
+namespace Jakt {
+} // namespace Jakt
+template<>struct Jakt::Formatter<Jakt::parser::Parser> : Jakt::Formatter<Jakt::StringView>{
+Jakt::ErrorOr<void> format(Jakt::FormatBuilder& builder, Jakt::parser::Parser const& value) {
+JaktInternal::PrettyPrint::ScopedEnable pretty_print_enable { m_alternative_form };Jakt::ErrorOr<void> format_error = Jakt::Formatter<Jakt::StringView>::format(builder, MUST(value.debug_description()));return format_error;}
+};
+namespace Jakt {
+} // namespace Jakt
+template<>struct Jakt::Formatter<Jakt::parser::ParsedGenericParameter> : Jakt::Formatter<Jakt::StringView>{
+Jakt::ErrorOr<void> format(Jakt::FormatBuilder& builder, Jakt::parser::ParsedGenericParameter const& value) {
+JaktInternal::PrettyPrint::ScopedEnable pretty_print_enable { m_alternative_form };Jakt::ErrorOr<void> format_error = Jakt::Formatter<Jakt::StringView>::format(builder, MUST(value.debug_description()));return format_error;}
+};
+namespace Jakt {
+} // namespace Jakt
+template<>struct Jakt::Formatter<Jakt::parser::ParsedField> : Jakt::Formatter<Jakt::StringView>{
+Jakt::ErrorOr<void> format(Jakt::FormatBuilder& builder, Jakt::parser::ParsedField const& value) {
+JaktInternal::PrettyPrint::ScopedEnable pretty_print_enable { m_alternative_form };Jakt::ErrorOr<void> format_error = Jakt::Formatter<Jakt::StringView>::format(builder, MUST(value.debug_description()));return format_error;}
+};
+namespace Jakt {
+} // namespace Jakt
+template<>struct Jakt::Formatter<Jakt::parser::UnaryOperator> : Jakt::Formatter<Jakt::StringView>{
+Jakt::ErrorOr<void> format(Jakt::FormatBuilder& builder, Jakt::parser::UnaryOperator const& value) {
+JaktInternal::PrettyPrint::ScopedEnable pretty_print_enable { m_alternative_form };Jakt::ErrorOr<void> format_error = Jakt::Formatter<Jakt::StringView>::format(builder, MUST(value.debug_description()));return format_error;}
+};
+namespace Jakt {
+} // namespace Jakt
+template<>struct Jakt::Formatter<Jakt::parser::BinaryOperator> : Jakt::Formatter<Jakt::StringView>{
+Jakt::ErrorOr<void> format(Jakt::FormatBuilder& builder, Jakt::parser::BinaryOperator const& value) {
+JaktInternal::PrettyPrint::ScopedEnable pretty_print_enable { m_alternative_form };Jakt::ErrorOr<void> format_error = Jakt::Formatter<Jakt::StringView>::format(builder, MUST(value.debug_description()));return format_error;}
+};
+namespace Jakt {
+} // namespace Jakt
+template<>struct Jakt::Formatter<Jakt::parser::ParsedStatement> : Jakt::Formatter<Jakt::StringView>{
+Jakt::ErrorOr<void> format(Jakt::FormatBuilder& builder, Jakt::parser::ParsedStatement const& value) {
+JaktInternal::PrettyPrint::ScopedEnable pretty_print_enable { m_alternative_form };Jakt::ErrorOr<void> format_error = Jakt::Formatter<Jakt::StringView>::format(builder, MUST(value.debug_description()));return format_error;}
+};
+namespace Jakt {
+} // namespace Jakt
+template<>struct Jakt::Formatter<Jakt::parser::ArgumentStoreLevel> : Jakt::Formatter<Jakt::StringView>{
+Jakt::ErrorOr<void> format(Jakt::FormatBuilder& builder, Jakt::parser::ArgumentStoreLevel const& value) {
+JaktInternal::PrettyPrint::ScopedEnable pretty_print_enable { m_alternative_form };Jakt::ErrorOr<void> format_error = Jakt::Formatter<Jakt::StringView>::format(builder, MUST(value.debug_description()));return format_error;}
+};
+namespace Jakt {
+} // namespace Jakt
+template<>struct Jakt::Formatter<Jakt::parser::ParsedNamespace> : Jakt::Formatter<Jakt::StringView>{
+Jakt::ErrorOr<void> format(Jakt::FormatBuilder& builder, Jakt::parser::ParsedNamespace const& value) {
+JaktInternal::PrettyPrint::ScopedEnable pretty_print_enable { m_alternative_form };Jakt::ErrorOr<void> format_error = Jakt::Formatter<Jakt::StringView>::format(builder, MUST(value.debug_description()));return format_error;}
+};
+namespace Jakt {
+} // namespace Jakt
+template<>struct Jakt::Formatter<Jakt::parser::RecordType> : Jakt::Formatter<Jakt::StringView>{
+Jakt::ErrorOr<void> format(Jakt::FormatBuilder& builder, Jakt::parser::RecordType const& value) {
+JaktInternal::PrettyPrint::ScopedEnable pretty_print_enable { m_alternative_form };Jakt::ErrorOr<void> format_error = Jakt::Formatter<Jakt::StringView>::format(builder, MUST(value.debug_description()));return format_error;}
+};
+namespace Jakt {
+} // namespace Jakt
+template<>struct Jakt::Formatter<Jakt::parser::ParsedType> : Jakt::Formatter<Jakt::StringView>{
+Jakt::ErrorOr<void> format(Jakt::FormatBuilder& builder, Jakt::parser::ParsedType const& value) {
+JaktInternal::PrettyPrint::ScopedEnable pretty_print_enable { m_alternative_form };Jakt::ErrorOr<void> format_error = Jakt::Formatter<Jakt::StringView>::format(builder, MUST(value.debug_description()));return format_error;}
+};
+namespace Jakt {
+} // namespace Jakt
+template<>struct Jakt::Formatter<Jakt::parser::ParsedCapture> : Jakt::Formatter<Jakt::StringView>{
+Jakt::ErrorOr<void> format(Jakt::FormatBuilder& builder, Jakt::parser::ParsedCapture const& value) {
+JaktInternal::PrettyPrint::ScopedEnable pretty_print_enable { m_alternative_form };Jakt::ErrorOr<void> format_error = Jakt::Formatter<Jakt::StringView>::format(builder, MUST(value.debug_description()));return format_error;}
+};
+namespace Jakt {
+} // namespace Jakt
+template<>struct Jakt::Formatter<Jakt::parser::ParsedNameWithGenericParameters> : Jakt::Formatter<Jakt::StringView>{
+Jakt::ErrorOr<void> format(Jakt::FormatBuilder& builder, Jakt::parser::ParsedNameWithGenericParameters const& value) {
+JaktInternal::PrettyPrint::ScopedEnable pretty_print_enable { m_alternative_form };Jakt::ErrorOr<void> format_error = Jakt::Formatter<Jakt::StringView>::format(builder, MUST(value.debug_description()));return format_error;}
+};
+namespace Jakt {
+} // namespace Jakt
+template<>struct Jakt::Formatter<Jakt::parser::ParsedExternalTraitImplementation> : Jakt::Formatter<Jakt::StringView>{
+Jakt::ErrorOr<void> format(Jakt::FormatBuilder& builder, Jakt::parser::ParsedExternalTraitImplementation const& value) {
+JaktInternal::PrettyPrint::ScopedEnable pretty_print_enable { m_alternative_form };Jakt::ErrorOr<void> format_error = Jakt::Formatter<Jakt::StringView>::format(builder, MUST(value.debug_description()));return format_error;}
+};
+namespace Jakt {
+} // namespace Jakt
+template<>struct Jakt::Formatter<Jakt::parser::ImportName> : Jakt::Formatter<Jakt::StringView>{
+Jakt::ErrorOr<void> format(Jakt::FormatBuilder& builder, Jakt::parser::ImportName const& value) {
+JaktInternal::PrettyPrint::ScopedEnable pretty_print_enable { m_alternative_form };Jakt::ErrorOr<void> format_error = Jakt::Formatter<Jakt::StringView>::format(builder, MUST(value.debug_description()));return format_error;}
+};
+namespace Jakt {
+} // namespace Jakt
+template<>struct Jakt::Formatter<Jakt::parser::ImportList> : Jakt::Formatter<Jakt::StringView>{
+Jakt::ErrorOr<void> format(Jakt::FormatBuilder& builder, Jakt::parser::ImportList const& value) {
+JaktInternal::PrettyPrint::ScopedEnable pretty_print_enable { m_alternative_form };Jakt::ErrorOr<void> format_error = Jakt::Formatter<Jakt::StringView>::format(builder, MUST(value.debug_description()));return format_error;}
+};
+namespace Jakt {
+} // namespace Jakt
+template<>struct Jakt::Formatter<Jakt::parser::ParsedModuleImport> : Jakt::Formatter<Jakt::StringView>{
+Jakt::ErrorOr<void> format(Jakt::FormatBuilder& builder, Jakt::parser::ParsedModuleImport const& value) {
+JaktInternal::PrettyPrint::ScopedEnable pretty_print_enable { m_alternative_form };Jakt::ErrorOr<void> format_error = Jakt::Formatter<Jakt::StringView>::format(builder, MUST(value.debug_description()));return format_error;}
+};
+namespace Jakt {
+} // namespace Jakt
+template<>struct Jakt::Formatter<Jakt::parser::ParsedExternImport> : Jakt::Formatter<Jakt::StringView>{
+Jakt::ErrorOr<void> format(Jakt::FormatBuilder& builder, Jakt::parser::ParsedExternImport const& value) {
+JaktInternal::PrettyPrint::ScopedEnable pretty_print_enable { m_alternative_form };Jakt::ErrorOr<void> format_error = Jakt::Formatter<Jakt::StringView>::format(builder, MUST(value.debug_description()));return format_error;}
+};
+namespace Jakt {
+} // namespace Jakt
+template<>struct Jakt::Formatter<Jakt::parser::IncludeAction> : Jakt::Formatter<Jakt::StringView>{
+Jakt::ErrorOr<void> format(Jakt::FormatBuilder& builder, Jakt::parser::IncludeAction const& value) {
 JaktInternal::PrettyPrint::ScopedEnable pretty_print_enable { m_alternative_form };Jakt::ErrorOr<void> format_error = Jakt::Formatter<Jakt::StringView>::format(builder, MUST(value.debug_description()));return format_error;}
 };
 namespace Jakt {
@@ -1905,32 +2001,8 @@ JaktInternal::PrettyPrint::ScopedEnable pretty_print_enable { m_alternative_form
 };
 namespace Jakt {
 } // namespace Jakt
-template<>struct Jakt::Formatter<Jakt::parser::ParsedCall> : Jakt::Formatter<Jakt::StringView>{
-Jakt::ErrorOr<void> format(Jakt::FormatBuilder& builder, Jakt::parser::ParsedCall const& value) {
-JaktInternal::PrettyPrint::ScopedEnable pretty_print_enable { m_alternative_form };Jakt::ErrorOr<void> format_error = Jakt::Formatter<Jakt::StringView>::format(builder, MUST(value.debug_description()));return format_error;}
-};
-namespace Jakt {
-} // namespace Jakt
-template<>struct Jakt::Formatter<Jakt::parser::BinaryOperator> : Jakt::Formatter<Jakt::StringView>{
-Jakt::ErrorOr<void> format(Jakt::FormatBuilder& builder, Jakt::parser::BinaryOperator const& value) {
-JaktInternal::PrettyPrint::ScopedEnable pretty_print_enable { m_alternative_form };Jakt::ErrorOr<void> format_error = Jakt::Formatter<Jakt::StringView>::format(builder, MUST(value.debug_description()));return format_error;}
-};
-namespace Jakt {
-} // namespace Jakt
-template<>struct Jakt::Formatter<Jakt::parser::ParsedExpression> : Jakt::Formatter<Jakt::StringView>{
-Jakt::ErrorOr<void> format(Jakt::FormatBuilder& builder, Jakt::parser::ParsedExpression const& value) {
-JaktInternal::PrettyPrint::ScopedEnable pretty_print_enable { m_alternative_form };Jakt::ErrorOr<void> format_error = Jakt::Formatter<Jakt::StringView>::format(builder, MUST(value.debug_description()));return format_error;}
-};
-namespace Jakt {
-} // namespace Jakt
-template<>struct Jakt::Formatter<Jakt::parser::ImportName> : Jakt::Formatter<Jakt::StringView>{
-Jakt::ErrorOr<void> format(Jakt::FormatBuilder& builder, Jakt::parser::ImportName const& value) {
-JaktInternal::PrettyPrint::ScopedEnable pretty_print_enable { m_alternative_form };Jakt::ErrorOr<void> format_error = Jakt::Formatter<Jakt::StringView>::format(builder, MUST(value.debug_description()));return format_error;}
-};
-namespace Jakt {
-} // namespace Jakt
-template<>struct Jakt::Formatter<Jakt::parser::ParsedVariable> : Jakt::Formatter<Jakt::StringView>{
-Jakt::ErrorOr<void> format(Jakt::FormatBuilder& builder, Jakt::parser::ParsedVariable const& value) {
+template<>struct Jakt::Formatter<Jakt::parser::ParsedVarDeclTuple> : Jakt::Formatter<Jakt::StringView>{
+Jakt::ErrorOr<void> format(Jakt::FormatBuilder& builder, Jakt::parser::ParsedVarDeclTuple const& value) {
 JaktInternal::PrettyPrint::ScopedEnable pretty_print_enable { m_alternative_form };Jakt::ErrorOr<void> format_error = Jakt::Formatter<Jakt::StringView>::format(builder, MUST(value.debug_description()));return format_error;}
 };
 namespace Jakt {
@@ -1941,92 +2013,20 @@ JaktInternal::PrettyPrint::ScopedEnable pretty_print_enable { m_alternative_form
 };
 namespace Jakt {
 } // namespace Jakt
-template<>struct Jakt::Formatter<Jakt::parser::ParsedModuleImport> : Jakt::Formatter<Jakt::StringView>{
-Jakt::ErrorOr<void> format(Jakt::FormatBuilder& builder, Jakt::parser::ParsedModuleImport const& value) {
-JaktInternal::PrettyPrint::ScopedEnable pretty_print_enable { m_alternative_form };Jakt::ErrorOr<void> format_error = Jakt::Formatter<Jakt::StringView>::format(builder, MUST(value.debug_description()));return format_error;}
-};
-namespace Jakt {
-} // namespace Jakt
 template<>struct Jakt::Formatter<Jakt::parser::ParsedAttribute> : Jakt::Formatter<Jakt::StringView>{
 Jakt::ErrorOr<void> format(Jakt::FormatBuilder& builder, Jakt::parser::ParsedAttribute const& value) {
 JaktInternal::PrettyPrint::ScopedEnable pretty_print_enable { m_alternative_form };Jakt::ErrorOr<void> format_error = Jakt::Formatter<Jakt::StringView>::format(builder, MUST(value.debug_description()));return format_error;}
 };
 namespace Jakt {
 } // namespace Jakt
-template<>struct Jakt::Formatter<Jakt::parser::ParsedExternalTraitImplementation> : Jakt::Formatter<Jakt::StringView>{
-Jakt::ErrorOr<void> format(Jakt::FormatBuilder& builder, Jakt::parser::ParsedExternalTraitImplementation const& value) {
+template<>struct Jakt::Formatter<Jakt::parser::EnumVariantPatternArgument> : Jakt::Formatter<Jakt::StringView>{
+Jakt::ErrorOr<void> format(Jakt::FormatBuilder& builder, Jakt::parser::EnumVariantPatternArgument const& value) {
 JaktInternal::PrettyPrint::ScopedEnable pretty_print_enable { m_alternative_form };Jakt::ErrorOr<void> format_error = Jakt::Formatter<Jakt::StringView>::format(builder, MUST(value.debug_description()));return format_error;}
 };
 namespace Jakt {
 } // namespace Jakt
-template<>struct Jakt::Formatter<Jakt::parser::ParsedMatchBody> : Jakt::Formatter<Jakt::StringView>{
-Jakt::ErrorOr<void> format(Jakt::FormatBuilder& builder, Jakt::parser::ParsedMatchBody const& value) {
-JaktInternal::PrettyPrint::ScopedEnable pretty_print_enable { m_alternative_form };Jakt::ErrorOr<void> format_error = Jakt::Formatter<Jakt::StringView>::format(builder, MUST(value.debug_description()));return format_error;}
-};
-namespace Jakt {
-} // namespace Jakt
-template<>struct Jakt::Formatter<Jakt::parser::ParsedMatchCase> : Jakt::Formatter<Jakt::StringView>{
-Jakt::ErrorOr<void> format(Jakt::FormatBuilder& builder, Jakt::parser::ParsedMatchCase const& value) {
-JaktInternal::PrettyPrint::ScopedEnable pretty_print_enable { m_alternative_form };Jakt::ErrorOr<void> format_error = Jakt::Formatter<Jakt::StringView>::format(builder, MUST(value.debug_description()));return format_error;}
-};
-namespace Jakt {
-} // namespace Jakt
-template<>struct Jakt::Formatter<Jakt::parser::IncludeAction> : Jakt::Formatter<Jakt::StringView>{
-Jakt::ErrorOr<void> format(Jakt::FormatBuilder& builder, Jakt::parser::IncludeAction const& value) {
-JaktInternal::PrettyPrint::ScopedEnable pretty_print_enable { m_alternative_form };Jakt::ErrorOr<void> format_error = Jakt::Formatter<Jakt::StringView>::format(builder, MUST(value.debug_description()));return format_error;}
-};
-namespace Jakt {
-} // namespace Jakt
-template<>struct Jakt::Formatter<Jakt::parser::Parser> : Jakt::Formatter<Jakt::StringView>{
-Jakt::ErrorOr<void> format(Jakt::FormatBuilder& builder, Jakt::parser::Parser const& value) {
-JaktInternal::PrettyPrint::ScopedEnable pretty_print_enable { m_alternative_form };Jakt::ErrorOr<void> format_error = Jakt::Formatter<Jakt::StringView>::format(builder, MUST(value.debug_description()));return format_error;}
-};
-namespace Jakt {
-} // namespace Jakt
-template<>struct Jakt::Formatter<Jakt::parser::ParsedParameter> : Jakt::Formatter<Jakt::StringView>{
-Jakt::ErrorOr<void> format(Jakt::FormatBuilder& builder, Jakt::parser::ParsedParameter const& value) {
-JaktInternal::PrettyPrint::ScopedEnable pretty_print_enable { m_alternative_form };Jakt::ErrorOr<void> format_error = Jakt::Formatter<Jakt::StringView>::format(builder, MUST(value.debug_description()));return format_error;}
-};
-namespace Jakt {
-} // namespace Jakt
-template<>struct Jakt::Formatter<Jakt::parser::ParsedPatternDefault> : Jakt::Formatter<Jakt::StringView>{
-Jakt::ErrorOr<void> format(Jakt::FormatBuilder& builder, Jakt::parser::ParsedPatternDefault const& value) {
-JaktInternal::PrettyPrint::ScopedEnable pretty_print_enable { m_alternative_form };Jakt::ErrorOr<void> format_error = Jakt::Formatter<Jakt::StringView>::format(builder, MUST(value.debug_description()));return format_error;}
-};
-namespace Jakt {
-} // namespace Jakt
-template<>struct Jakt::Formatter<Jakt::parser::ParsedTraitRequirements> : Jakt::Formatter<Jakt::StringView>{
-Jakt::ErrorOr<void> format(Jakt::FormatBuilder& builder, Jakt::parser::ParsedTraitRequirements const& value) {
-JaktInternal::PrettyPrint::ScopedEnable pretty_print_enable { m_alternative_form };Jakt::ErrorOr<void> format_error = Jakt::Formatter<Jakt::StringView>::format(builder, MUST(value.debug_description()));return format_error;}
-};
-namespace Jakt {
-} // namespace Jakt
-template<>struct Jakt::Formatter<Jakt::parser::ParsedTrait> : Jakt::Formatter<Jakt::StringView>{
-Jakt::ErrorOr<void> format(Jakt::FormatBuilder& builder, Jakt::parser::ParsedTrait const& value) {
-JaktInternal::PrettyPrint::ScopedEnable pretty_print_enable { m_alternative_form };Jakt::ErrorOr<void> format_error = Jakt::Formatter<Jakt::StringView>::format(builder, MUST(value.debug_description()));return format_error;}
-};
-namespace Jakt {
-} // namespace Jakt
-template<>struct Jakt::Formatter<Jakt::parser::ValueEnumVariant> : Jakt::Formatter<Jakt::StringView>{
-Jakt::ErrorOr<void> format(Jakt::FormatBuilder& builder, Jakt::parser::ValueEnumVariant const& value) {
-JaktInternal::PrettyPrint::ScopedEnable pretty_print_enable { m_alternative_form };Jakt::ErrorOr<void> format_error = Jakt::Formatter<Jakt::StringView>::format(builder, MUST(value.debug_description()));return format_error;}
-};
-namespace Jakt {
-} // namespace Jakt
-template<>struct Jakt::Formatter<Jakt::parser::ParsedGenericParameter> : Jakt::Formatter<Jakt::StringView>{
-Jakt::ErrorOr<void> format(Jakt::FormatBuilder& builder, Jakt::parser::ParsedGenericParameter const& value) {
-JaktInternal::PrettyPrint::ScopedEnable pretty_print_enable { m_alternative_form };Jakt::ErrorOr<void> format_error = Jakt::Formatter<Jakt::StringView>::format(builder, MUST(value.debug_description()));return format_error;}
-};
-namespace Jakt {
-} // namespace Jakt
-template<>struct Jakt::Formatter<Jakt::parser::ParsedStatement> : Jakt::Formatter<Jakt::StringView>{
-Jakt::ErrorOr<void> format(Jakt::FormatBuilder& builder, Jakt::parser::ParsedStatement const& value) {
-JaktInternal::PrettyPrint::ScopedEnable pretty_print_enable { m_alternative_form };Jakt::ErrorOr<void> format_error = Jakt::Formatter<Jakt::StringView>::format(builder, MUST(value.debug_description()));return format_error;}
-};
-namespace Jakt {
-} // namespace Jakt
-template<>struct Jakt::Formatter<Jakt::parser::ParsedExternImport> : Jakt::Formatter<Jakt::StringView>{
-Jakt::ErrorOr<void> format(Jakt::FormatBuilder& builder, Jakt::parser::ParsedExternImport const& value) {
+template<>struct Jakt::Formatter<Jakt::parser::ParsedExpression> : Jakt::Formatter<Jakt::StringView>{
+Jakt::ErrorOr<void> format(Jakt::FormatBuilder& builder, Jakt::parser::ParsedExpression const& value) {
 JaktInternal::PrettyPrint::ScopedEnable pretty_print_enable { m_alternative_form };Jakt::ErrorOr<void> format_error = Jakt::Formatter<Jakt::StringView>::format(builder, MUST(value.debug_description()));return format_error;}
 };
 namespace Jakt {

--- a/bootstrap/stage0/parser_specializations.cpp
+++ b/bootstrap/stage0/parser_specializations.cpp
@@ -28,6 +28,7 @@
 #include "jakt__platform.h"
 #include "jakt__arguments.h"
 #include "jakt__prelude__prelude.h"
+#include "jakt__prelude__hash.h"
 #include "jakt__prelude__operators.h"
 #include "jakt__prelude__string.h"
 #include "jakt__prelude__iteration.h"

--- a/bootstrap/stage0/platform__unknown_compiler_specializations.cpp
+++ b/bootstrap/stage0/platform__unknown_compiler_specializations.cpp
@@ -28,6 +28,7 @@
 #include "jakt__platform.h"
 #include "jakt__arguments.h"
 #include "jakt__prelude__prelude.h"
+#include "jakt__prelude__hash.h"
 #include "jakt__prelude__operators.h"
 #include "jakt__prelude__string.h"
 #include "jakt__prelude__iteration.h"

--- a/bootstrap/stage0/platform_specializations.cpp
+++ b/bootstrap/stage0/platform_specializations.cpp
@@ -28,6 +28,7 @@
 #include "jakt__platform.h"
 #include "jakt__arguments.h"
 #include "jakt__prelude__prelude.h"
+#include "jakt__prelude__hash.h"
 #include "jakt__prelude__operators.h"
 #include "jakt__prelude__string.h"
 #include "jakt__prelude__iteration.h"

--- a/bootstrap/stage0/project_specializations.cpp
+++ b/bootstrap/stage0/project_specializations.cpp
@@ -28,6 +28,7 @@
 #include "jakt__platform.h"
 #include "jakt__arguments.h"
 #include "jakt__prelude__prelude.h"
+#include "jakt__prelude__hash.h"
 #include "jakt__prelude__operators.h"
 #include "jakt__prelude__string.h"
 #include "jakt__prelude__iteration.h"

--- a/bootstrap/stage0/repl_backend__common.h
+++ b/bootstrap/stage0/repl_backend__common.h
@@ -2,23 +2,6 @@
 #include "__unified_forward.h"
 namespace Jakt {
 namespace repl_backend__common {
-namespace LineResult_Details {
-struct Line{
-DeprecatedString value;
-template<typename _MemberT0>
-Line(_MemberT0&& member_0):
-value{ forward<_MemberT0>(member_0)}
-{}
-};
-struct Eof {
-};
-}
-struct LineResult : public Variant<LineResult_Details::Line, LineResult_Details::Eof> {
-using Variant<LineResult_Details::Line, LineResult_Details::Eof>::Variant;
-    using Line = LineResult_Details::Line;
-    using Eof = LineResult_Details::Eof;
-ErrorOr<DeprecatedString> debug_description() const;
-};
 namespace XTermColor_Details {
 struct Default {
 };
@@ -86,13 +69,24 @@ struct Style {
 JaktInternal::Optional<repl_backend__common::Color> foreground;JaktInternal::Optional<repl_backend__common::Color> background;Style(JaktInternal::Optional<repl_backend__common::Color> a_foreground, JaktInternal::Optional<repl_backend__common::Color> a_background);
 
 ErrorOr<DeprecatedString> debug_description() const;
-};}
-} // namespace Jakt
-template<>struct Jakt::Formatter<Jakt::repl_backend__common::LineResult> : Jakt::Formatter<Jakt::StringView>{
-Jakt::ErrorOr<void> format(Jakt::FormatBuilder& builder, Jakt::repl_backend__common::LineResult const& value) {
-JaktInternal::PrettyPrint::ScopedEnable pretty_print_enable { m_alternative_form };Jakt::ErrorOr<void> format_error = Jakt::Formatter<Jakt::StringView>::format(builder, MUST(value.debug_description()));return format_error;}
+};namespace LineResult_Details {
+struct Line{
+DeprecatedString value;
+template<typename _MemberT0>
+Line(_MemberT0&& member_0):
+value{ forward<_MemberT0>(member_0)}
+{}
 };
-namespace Jakt {
+struct Eof {
+};
+}
+struct LineResult : public Variant<LineResult_Details::Line, LineResult_Details::Eof> {
+using Variant<LineResult_Details::Line, LineResult_Details::Eof>::Variant;
+    using Line = LineResult_Details::Line;
+    using Eof = LineResult_Details::Eof;
+ErrorOr<DeprecatedString> debug_description() const;
+};
+}
 } // namespace Jakt
 template<>struct Jakt::Formatter<Jakt::repl_backend__common::XTermColor> : Jakt::Formatter<Jakt::StringView>{
 Jakt::ErrorOr<void> format(Jakt::FormatBuilder& builder, Jakt::repl_backend__common::XTermColor const& value) {
@@ -108,6 +102,12 @@ namespace Jakt {
 } // namespace Jakt
 template<>struct Jakt::Formatter<Jakt::repl_backend__common::Style> : Jakt::Formatter<Jakt::StringView>{
 Jakt::ErrorOr<void> format(Jakt::FormatBuilder& builder, Jakt::repl_backend__common::Style const& value) {
+JaktInternal::PrettyPrint::ScopedEnable pretty_print_enable { m_alternative_form };Jakt::ErrorOr<void> format_error = Jakt::Formatter<Jakt::StringView>::format(builder, MUST(value.debug_description()));return format_error;}
+};
+namespace Jakt {
+} // namespace Jakt
+template<>struct Jakt::Formatter<Jakt::repl_backend__common::LineResult> : Jakt::Formatter<Jakt::StringView>{
+Jakt::ErrorOr<void> format(Jakt::FormatBuilder& builder, Jakt::repl_backend__common::LineResult const& value) {
 JaktInternal::PrettyPrint::ScopedEnable pretty_print_enable { m_alternative_form };Jakt::ErrorOr<void> format_error = Jakt::Formatter<Jakt::StringView>::format(builder, MUST(value.debug_description()));return format_error;}
 };
 namespace Jakt {

--- a/bootstrap/stage0/repl_backend__common_specializations.cpp
+++ b/bootstrap/stage0/repl_backend__common_specializations.cpp
@@ -28,6 +28,7 @@
 #include "jakt__platform.h"
 #include "jakt__arguments.h"
 #include "jakt__prelude__prelude.h"
+#include "jakt__prelude__hash.h"
 #include "jakt__prelude__operators.h"
 #include "jakt__prelude__string.h"
 #include "jakt__prelude__iteration.h"

--- a/bootstrap/stage0/repl_backend__default_specializations.cpp
+++ b/bootstrap/stage0/repl_backend__default_specializations.cpp
@@ -28,6 +28,7 @@
 #include "jakt__platform.h"
 #include "jakt__arguments.h"
 #include "jakt__prelude__prelude.h"
+#include "jakt__prelude__hash.h"
 #include "jakt__prelude__operators.h"
 #include "jakt__prelude__string.h"
 #include "jakt__prelude__iteration.h"

--- a/bootstrap/stage0/repl_specializations.cpp
+++ b/bootstrap/stage0/repl_specializations.cpp
@@ -28,6 +28,7 @@
 #include "jakt__platform.h"
 #include "jakt__arguments.h"
 #include "jakt__prelude__prelude.h"
+#include "jakt__prelude__hash.h"
 #include "jakt__prelude__operators.h"
 #include "jakt__prelude__string.h"
 #include "jakt__prelude__iteration.h"

--- a/bootstrap/stage0/runtime/Builtins/Dictionary.h
+++ b/bootstrap/stage0/runtime/Builtins/Dictionary.h
@@ -23,9 +23,27 @@ struct DirectlyPeekableTraits : public Traits<T> {
     using ConstPeekType = T const&;
 };
 
+template<typename T>
+struct JaktHashableKeyTraits : public Traits<T> {
+    static constexpr bool equals(T const& a, T const& b) {
+        if constexpr (requires { { a.equals(b) } -> SameAs<bool>; })
+            return a.equals(b);
+        else
+            return a == b;
+    }
+
+    static constexpr unsigned hash(T value)
+    {
+        if constexpr (requires { { value.hash() } -> SameAs<u32>; })
+            return value.hash();
+        else
+            return Traits<T>::hash(value);
+    }
+};
+
 template<typename K, typename V>
 struct DictionaryStorage : public RefCounted<DictionaryStorage<K, V>> {
-    HashMap<K, V, Traits<K>, DirectlyPeekableTraits<V>> map;
+    HashMap<K, V, JaktHashableKeyTraits<K>, DirectlyPeekableTraits<V>> map;
 };
 
 template<typename K, typename V>

--- a/bootstrap/stage0/runtime/Jakt/Forward.h
+++ b/bootstrap/stage0/runtime/Jakt/Forward.h
@@ -6,7 +6,7 @@
 
 #pragma once
 
-#include <Jakt/Types.h>
+#include <Jakt/AKIntegration.h>
 
 
 namespace JaktInternal {
@@ -17,78 +17,5 @@ class DynamicArray;
 namespace Jakt {
 
 using JaktInternal::DynamicArray;
-
-class Bitmap;
-class Error;
-class GenericLexer;
-class String;
-class StringBuilder;
-class StringImpl;
-class StringView;
-class Time;
-class Utf8CodePointIterator;
-class Utf8View;
-
-template<typename T>
-class Span;
-
-template<typename T, size_t Size>
-struct Array;
-
-template<typename Container, typename ValueType>
-class SimpleIterator;
-
-using ReadonlyBytes = Span<const u8>;
-using Bytes = Span<u8>;
-
-template<typename T, Jakt::MemoryOrder DefaultMemoryOrder>
-class Atomic;
-
-template<typename T>
-struct Traits;
-
-template<typename T, typename TraitsForT = Traits<T>, bool IsOrdered = false>
-class HashTable;
-
-template<typename T, typename TraitsForT = Traits<T>>
-using OrderedHashTable = HashTable<T, TraitsForT, true>;
-
-template<typename K, typename V, typename KeyTraits = Traits<K>, typename ValueTraits = Traits<V>, bool IsOrdered = false>
-class HashMap;
-
-template<typename K, typename V, typename KeyTraits = Traits<K>, typename ValueTraits = Traits<V>>
-using OrderedHashMap = HashMap<K, V, KeyTraits, ValueTraits, true>;
-
-template<typename>
-class Function;
-
-template<typename Out, typename... In>
-class Function<Out(In...)>;
-
-template<typename T>
-class NonnullRefPtr;
-
-template<typename T>
-class Optional;
-
-#ifdef KERNEL
-template<typename T>
-struct RefPtrTraits;
-
-template<typename T, typename PtrTraits = RefPtrTraits<T>>
-class RefPtr;
-#else
-template<typename T>
-class RefPtr;
-#endif
-
-template<typename T>
-class WeakPtr;
-
-template<typename T, typename ErrorType = Error>
-class [[nodiscard]] ErrorOr;
-
-template<typename T, typename = void>
-struct Formatter;
 
 }

--- a/bootstrap/stage0/runtime/jaktlib/prelude/hash.jakt
+++ b/bootstrap/stage0/runtime/jaktlib/prelude/hash.jakt
@@ -1,0 +1,41 @@
+trait DefaultHashable = match reflect Self {
+    U8 | U16 | U32 | U64
+    | I8 | I16 | I32 | I64
+    | Usize | CChar | CInt
+    | F32 | F64 | Bool
+    | JaktString => true
+    else => false
+}
+
+import extern "Jakt/Forward.h" {
+    namespace AK {
+        struct Traits<T> {
+            extern fn Traits<U>() -> Traits<U>
+            extern fn hash(this, anon x: T) -> u32
+        }
+    }
+
+    extern fn pair_int_hash(anon a: u32, anon b: u32) -> u32
+}
+
+trait Hashable {
+    fn hash(this) -> u32
+
+    [[inline(always)]]
+    fn pair_hash_with<T requires(Hashable)>(this, anon other: &T) -> u32 {
+        return pair_int_hash(.hash(), other.hash())
+    }
+}
+
+forall<T requires(DefaultHashable)>
+type T implements(Hashable) {
+    [[inline(always)]]
+    fn hash(this) -> u32 => AK::Traits<T>().hash(this)
+}
+
+type String implements(Hashable) {}
+
+type StringView implements(Hashable) {
+    [[inline(always)]]
+    fn hash(this) -> u32 => AK::Traits<StringView>().hash(this)
+}

--- a/bootstrap/stage0/runtime/jaktlib/prelude/prelude.jakt
+++ b/bootstrap/stage0/runtime/jaktlib/prelude/prelude.jakt
@@ -1,3 +1,4 @@
 import jakt::prelude::iteration { IntoIterator, IntoThrowingIterator, Iterable, ThrowingIterable }
 import jakt::prelude::string { FromStringLiteral, ThrowingFromStringLiteral }
 import jakt::prelude::operators { * }
+import jakt::prelude::hash { * }

--- a/bootstrap/stage0/typechecker.cpp
+++ b/bootstrap/stage0/typechecker.cpp
@@ -339,6 +339,19 @@ TRY((((((module)->structures)).push(types::CheckedStruct(((parsed_record).name),
 return {};
 }
 
+ErrorOr<void> typechecker::Typechecker::ensure_type_implements_trait(types::TypeId const type_id,DeprecatedString const trait_name,JaktInternal::Optional<JaktInternal::DynamicArray<types::TypeId>> const filter_for_generics,types::ScopeId const scope_id,utility::Span const span) {
+{
+if (((((*this).get_type(type_id)))->index() == 18 /* TypeVariable */)){
+return {};
+}
+JaktInternal::Optional<typechecker::TraitImplementationDescriptor> const implementation = TRY((((*this).find_any_singular_trait_implementation(type_id,(TRY((DynamicArray<DeprecatedString>::create_with({trait_name})))),scope_id,span,filter_for_generics))));
+if ((!(((implementation).has_value())))){
+TRY((((*this).error(TRY((__jakt_format((StringView::from_string_literal("Type ‘{}’ does not implement trait ‘{}’"sv)),TRY((((*this).type_name(type_id,false)))),trait_name))),span))));
+}
+}
+return {};
+}
+
 ErrorOr<JaktInternal::Tuple<types::CheckedMatchBody,JaktInternal::Optional<types::TypeId>>> typechecker::Typechecker::typecheck_match_body(parser::ParsedMatchBody const body,types::ScopeId const scope_id,types::SafetyMode const safety_mode,types::GenericInferences& generic_inferences,JaktInternal::Optional<types::TypeId> const final_result_type,utility::Span const span) {
 {
 JaktInternal::Optional<types::TypeId> result_type = final_result_type;
@@ -731,6 +744,10 @@ else {
 TRY((((*this).error(TRY(DeprecatedString::from_utf8("Cannot infer generic type for Set<T>"sv)),span))));
 }
 
+}
+if ((!(((inner_type_id).equals(types::unknown_type_id()))))){
+TRY((((*this).ensure_type_implements_trait(inner_type_id,TRY(DeprecatedString::from_utf8("Hashable"sv)),JaktInternal::OptionalNone(),scope_id,span))));
+TRY((((*this).ensure_type_implements_trait(inner_type_id,TRY(DeprecatedString::from_utf8("Equal"sv)),(TRY((DynamicArray<types::TypeId>::create_with({inner_type_id})))),scope_id,span))));
 }
 types::TypeId const type_id = TRY((((*this).find_or_add_type_id(TRY((types::Type::template __jakt_create<typename types::Type::GenericInstance>(set_struct_id,(TRY((DynamicArray<types::TypeId>::create_with({inner_type_id})))))))))));
 return TRY((types::CheckedExpression::template __jakt_create<typename types::CheckedExpression::JaktSet>(output,span,type_id,inner_type_id)));
@@ -4418,6 +4435,10 @@ else {
 TRY((((*this).error(TRY(DeprecatedString::from_utf8("Cannot infer key type for Dictionary<K, V>"sv)),span))));
 }
 
+}
+if ((!(((key_type_id).equals(types::unknown_type_id()))))){
+TRY((((*this).ensure_type_implements_trait(key_type_id,TRY(DeprecatedString::from_utf8("Hashable"sv)),JaktInternal::OptionalNone(),scope_id,span))));
+TRY((((*this).ensure_type_implements_trait(key_type_id,TRY(DeprecatedString::from_utf8("Equal"sv)),(TRY((DynamicArray<types::TypeId>::create_with({key_type_id})))),scope_id,span))));
 }
 if (((value_type_id).equals(types::unknown_type_id()))){
 if (((value_hint).has_value())){
@@ -20347,6 +20368,8 @@ return JaktInternal::ExplicitValue(({ Optional<types::TypeId> __jakt_var_569; {
 types::TypeId const key_type_id = TRY((((*this).typecheck_typename(key,scope_id,name))));
 types::TypeId const value_type_id = TRY((((*this).typecheck_typename(value,scope_id,name))));
 types::StructId const dict_struct_id = TRY((((*this).find_struct_in_prelude(TRY(DeprecatedString::from_utf8("Dictionary"sv))))));
+TRY((((*this).ensure_type_implements_trait(key_type_id,TRY(DeprecatedString::from_utf8("Hashable"sv)),JaktInternal::OptionalNone(),scope_id,span))));
+TRY((((*this).ensure_type_implements_trait(key_type_id,TRY(DeprecatedString::from_utf8("Equal"sv)),(TRY((DynamicArray<types::TypeId>::create_with({key_type_id})))),scope_id,span))));
 __jakt_var_569 = TRY((((*this).find_or_add_type_id(TRY((types::Type::template __jakt_create<typename types::Type::GenericInstance>(dict_struct_id,(TRY((DynamicArray<types::TypeId>::create_with({key_type_id, value_type_id}))))))))))); goto __jakt_label_484;
 
 }
@@ -20358,6 +20381,8 @@ utility::Span const& span = __jakt_match_value.span;
 return JaktInternal::ExplicitValue(({ Optional<types::TypeId> __jakt_var_570; {
 types::TypeId const inner_type_id = TRY((((*this).typecheck_typename(inner,scope_id,name))));
 types::StructId const set_struct_id = TRY((((*this).find_struct_in_prelude(TRY(DeprecatedString::from_utf8("Set"sv))))));
+TRY((((*this).ensure_type_implements_trait(inner_type_id,TRY(DeprecatedString::from_utf8("Hashable"sv)),JaktInternal::OptionalNone(),scope_id,span))));
+TRY((((*this).ensure_type_implements_trait(inner_type_id,TRY(DeprecatedString::from_utf8("Equal"sv)),(TRY((DynamicArray<types::TypeId>::create_with({inner_type_id})))),scope_id,span))));
 __jakt_var_570 = TRY((((*this).find_or_add_type_id(TRY((types::Type::template __jakt_create<typename types::Type::GenericInstance>(set_struct_id,(TRY((DynamicArray<types::TypeId>::create_with({inner_type_id}))))))))))); goto __jakt_label_485;
 
 }

--- a/bootstrap/stage0/typechecker.h
+++ b/bootstrap/stage0/typechecker.h
@@ -11,20 +11,56 @@
 #include "interpreter.h"
 namespace Jakt {
 namespace typechecker {
+struct TraitImplCheck {
+  public:
+JaktInternal::Dictionary<DeprecatedString,JaktInternal::Dictionary<DeprecatedString,types::FunctionId>> missing_methods;JaktInternal::Dictionary<DeprecatedString,JaktInternal::Dictionary<DeprecatedString,utility::Span>> unmatched_signatures;JaktInternal::Dictionary<DeprecatedString,JaktInternal::Dictionary<DeprecatedString,utility::Span>> private_matching_methods;JaktInternal::Dictionary<DeprecatedString,typechecker::AlreadyImplementedFor> already_implemented_for;ErrorOr<void> throw_errors(utility::Span const record_decl_span, typechecker::Typechecker& typechecker);
+ErrorOr<void> ensure_capacity(size_t const count);
+ErrorOr<void> register_method(types::TypeId const self_type_id, DeprecatedString const method_name, types::FunctionId const method_id, typechecker::Typechecker& typechecker);
+static ErrorOr<typechecker::TraitImplCheck> make();
+TraitImplCheck(JaktInternal::Dictionary<DeprecatedString,JaktInternal::Dictionary<DeprecatedString,types::FunctionId>> a_missing_methods, JaktInternal::Dictionary<DeprecatedString,JaktInternal::Dictionary<DeprecatedString,utility::Span>> a_unmatched_signatures, JaktInternal::Dictionary<DeprecatedString,JaktInternal::Dictionary<DeprecatedString,utility::Span>> a_private_matching_methods, JaktInternal::Dictionary<DeprecatedString,typechecker::AlreadyImplementedFor> a_already_implemented_for);
+
+ErrorOr<void> register_trait(types::TypeId const trait_type_id, DeprecatedString const trait_name, types::CheckedTraitRequirements const requirements);
+ErrorOr<DeprecatedString> debug_description() const;
+};namespace NumericOrStringValue_Details {
+struct StringValue{
+DeprecatedString value;
+template<typename _MemberT0>
+StringValue(_MemberT0&& member_0):
+value{ forward<_MemberT0>(member_0)}
+{}
+};
+struct SignedNumericValue{
+i64 value;
+template<typename _MemberT0>
+SignedNumericValue(_MemberT0&& member_0):
+value{ forward<_MemberT0>(member_0)}
+{}
+};
+struct UnsignedNumericValue{
+u64 value;
+template<typename _MemberT0>
+UnsignedNumericValue(_MemberT0&& member_0):
+value{ forward<_MemberT0>(member_0)}
+{}
+};
+}
+struct NumericOrStringValue : public Variant<NumericOrStringValue_Details::StringValue, NumericOrStringValue_Details::SignedNumericValue, NumericOrStringValue_Details::UnsignedNumericValue> {
+using Variant<NumericOrStringValue_Details::StringValue, NumericOrStringValue_Details::SignedNumericValue, NumericOrStringValue_Details::UnsignedNumericValue>::Variant;
+    using StringValue = NumericOrStringValue_Details::StringValue;
+    using SignedNumericValue = NumericOrStringValue_Details::SignedNumericValue;
+    using UnsignedNumericValue = NumericOrStringValue_Details::UnsignedNumericValue;
+ErrorOr<DeprecatedString> debug_description() const;
+};
 struct ImportRestrictions {
   public:
 bool functions;bool structs;bool enums;bool types;bool traits;bool namespaces;ImportRestrictions(bool a_functions, bool a_structs, bool a_enums, bool a_types, bool a_traits, bool a_namespaces);
 
 static typechecker::ImportRestrictions all();
 ErrorOr<DeprecatedString> debug_description() const;
-};struct AlreadyImplementedFor {
-  public:
-DeprecatedString trait_name;utility::Span encounter_span;AlreadyImplementedFor(DeprecatedString a_trait_name, utility::Span a_encounter_span);
-
-ErrorOr<DeprecatedString> debug_description() const;
 };struct Typechecker {
   public:
 NonnullRefPtr<compiler::Compiler> compiler;NonnullRefPtr<types::CheckedProgram> program;types::ModuleId current_module_id;JaktInternal::Optional<types::TypeId> current_struct_type_id;JaktInternal::Optional<types::FunctionId> current_function_id;bool inside_defer;size_t checkidx;bool ignore_errors;bool dump_type_hints;bool dump_try_hints;u64 lambda_count;types::GenericInferences generic_inferences;JaktInternal::Optional<types::TypeId> self_type_id;DeprecatedString root_module_name;bool in_comptime_function_call;bool had_an_error;ErrorOr<void> typecheck_struct_predecl_initial(parser::ParsedRecord const parsed_record, size_t const struct_index, size_t const module_struct_len, types::ScopeId const scope_id);
+ErrorOr<void> ensure_type_implements_trait(types::TypeId const type_id, DeprecatedString const trait_name, JaktInternal::Optional<JaktInternal::DynamicArray<types::TypeId>> const filter_for_generics, types::ScopeId const scope_id, utility::Span const span);
 ErrorOr<JaktInternal::Tuple<types::CheckedMatchBody,JaktInternal::Optional<types::TypeId>>> typecheck_match_body(parser::ParsedMatchBody const body, types::ScopeId const scope_id, types::SafetyMode const safety_mode, types::GenericInferences& generic_inferences, JaktInternal::Optional<types::TypeId> const final_result_type, utility::Span const span);
 ErrorOr<DeprecatedString> type_name(types::TypeId const type_id, bool const debug_mode) const;
 ErrorOr<types::ScopeId> create_scope(JaktInternal::Optional<types::ScopeId> const parent_scope_id, bool const can_throw, DeprecatedString const debug_name, bool const for_block);
@@ -208,6 +244,16 @@ ErrorOr<NonnullRefPtr<typename types::CheckedExpression>> typecheck_try(NonnullR
 types::TypeId infer_function_return_type(types::CheckedBlock const block) const;
 ErrorOr<bool> scope_lifetime_subsumes(JaktInternal::Optional<types::ScopeId> const larger, JaktInternal::Optional<types::ScopeId> const smaller) const;
 ErrorOr<DeprecatedString> debug_description() const;
+};struct AlreadyImplementedFor {
+  public:
+DeprecatedString trait_name;utility::Span encounter_span;AlreadyImplementedFor(DeprecatedString a_trait_name, utility::Span a_encounter_span);
+
+ErrorOr<DeprecatedString> debug_description() const;
+};struct TraitImplementationDescriptor {
+  public:
+types::TraitId trait_id;DeprecatedString trait_name;JaktInternal::DynamicArray<types::TypeId> implemented_type_args;TraitImplementationDescriptor(types::TraitId a_trait_id, DeprecatedString a_trait_name, JaktInternal::DynamicArray<types::TypeId> a_implemented_type_args);
+
+ErrorOr<DeprecatedString> debug_description() const;
 };template <typename K, typename V>struct InternalDictionaryProduct {
   public:
 JaktInternal::Dictionary<K,JaktInternal::DynamicArray<V>> dict;JaktInternal::Dictionary<K,V> current;JaktInternal::Dictionary<K,size_t> current_index;bool done;ErrorOr<JaktInternal::Optional<JaktInternal::Dictionary<K,V>>> next() {
@@ -281,51 +327,6 @@ TRY(JaktInternal::PrettyPrint::output_indentation(builder));TRY(builder.appendff
 TRY(JaktInternal::PrettyPrint::output_indentation(builder));TRY(builder.appendff("done: {}", done));
 }
 TRY(builder.append(")"sv));return builder.to_string(); }
-};namespace NumericOrStringValue_Details {
-struct StringValue{
-DeprecatedString value;
-template<typename _MemberT0>
-StringValue(_MemberT0&& member_0):
-value{ forward<_MemberT0>(member_0)}
-{}
-};
-struct SignedNumericValue{
-i64 value;
-template<typename _MemberT0>
-SignedNumericValue(_MemberT0&& member_0):
-value{ forward<_MemberT0>(member_0)}
-{}
-};
-struct UnsignedNumericValue{
-u64 value;
-template<typename _MemberT0>
-UnsignedNumericValue(_MemberT0&& member_0):
-value{ forward<_MemberT0>(member_0)}
-{}
-};
-}
-struct NumericOrStringValue : public Variant<NumericOrStringValue_Details::StringValue, NumericOrStringValue_Details::SignedNumericValue, NumericOrStringValue_Details::UnsignedNumericValue> {
-using Variant<NumericOrStringValue_Details::StringValue, NumericOrStringValue_Details::SignedNumericValue, NumericOrStringValue_Details::UnsignedNumericValue>::Variant;
-    using StringValue = NumericOrStringValue_Details::StringValue;
-    using SignedNumericValue = NumericOrStringValue_Details::SignedNumericValue;
-    using UnsignedNumericValue = NumericOrStringValue_Details::UnsignedNumericValue;
-ErrorOr<DeprecatedString> debug_description() const;
-};
-struct TraitImplementationDescriptor {
-  public:
-types::TraitId trait_id;DeprecatedString trait_name;JaktInternal::DynamicArray<types::TypeId> implemented_type_args;TraitImplementationDescriptor(types::TraitId a_trait_id, DeprecatedString a_trait_name, JaktInternal::DynamicArray<types::TypeId> a_implemented_type_args);
-
-ErrorOr<DeprecatedString> debug_description() const;
-};struct TraitImplCheck {
-  public:
-JaktInternal::Dictionary<DeprecatedString,JaktInternal::Dictionary<DeprecatedString,types::FunctionId>> missing_methods;JaktInternal::Dictionary<DeprecatedString,JaktInternal::Dictionary<DeprecatedString,utility::Span>> unmatched_signatures;JaktInternal::Dictionary<DeprecatedString,JaktInternal::Dictionary<DeprecatedString,utility::Span>> private_matching_methods;JaktInternal::Dictionary<DeprecatedString,typechecker::AlreadyImplementedFor> already_implemented_for;ErrorOr<void> throw_errors(utility::Span const record_decl_span, typechecker::Typechecker& typechecker);
-ErrorOr<void> ensure_capacity(size_t const count);
-ErrorOr<void> register_method(types::TypeId const self_type_id, DeprecatedString const method_name, types::FunctionId const method_id, typechecker::Typechecker& typechecker);
-static ErrorOr<typechecker::TraitImplCheck> make();
-TraitImplCheck(JaktInternal::Dictionary<DeprecatedString,JaktInternal::Dictionary<DeprecatedString,types::FunctionId>> a_missing_methods, JaktInternal::Dictionary<DeprecatedString,JaktInternal::Dictionary<DeprecatedString,utility::Span>> a_unmatched_signatures, JaktInternal::Dictionary<DeprecatedString,JaktInternal::Dictionary<DeprecatedString,utility::Span>> a_private_matching_methods, JaktInternal::Dictionary<DeprecatedString,typechecker::AlreadyImplementedFor> a_already_implemented_for);
-
-ErrorOr<void> register_trait(types::TypeId const trait_type_id, DeprecatedString const trait_name, types::CheckedTraitRequirements const requirements);
-ErrorOr<DeprecatedString> debug_description() const;
 };namespace FunctionMatchResult_Details {
 struct MatchSuccess {
 JaktInternal::DynamicArray<NonnullRefPtr<typename types::CheckedExpression>> args;
@@ -358,28 +359,8 @@ template <typename R,typename S>
 ErrorOr<typechecker::InternalDictionaryProduct<R,S>> create_internal_dictionary_product(JaktInternal::Dictionary<R,JaktInternal::DynamicArray<S>> const dict);
 }
 } // namespace Jakt
-template<>struct Jakt::Formatter<Jakt::typechecker::ImportRestrictions> : Jakt::Formatter<Jakt::StringView>{
-Jakt::ErrorOr<void> format(Jakt::FormatBuilder& builder, Jakt::typechecker::ImportRestrictions const& value) {
-JaktInternal::PrettyPrint::ScopedEnable pretty_print_enable { m_alternative_form };Jakt::ErrorOr<void> format_error = Jakt::Formatter<Jakt::StringView>::format(builder, MUST(value.debug_description()));return format_error;}
-};
-namespace Jakt {
-} // namespace Jakt
-template<>struct Jakt::Formatter<Jakt::typechecker::AlreadyImplementedFor> : Jakt::Formatter<Jakt::StringView>{
-Jakt::ErrorOr<void> format(Jakt::FormatBuilder& builder, Jakt::typechecker::AlreadyImplementedFor const& value) {
-JaktInternal::PrettyPrint::ScopedEnable pretty_print_enable { m_alternative_form };Jakt::ErrorOr<void> format_error = Jakt::Formatter<Jakt::StringView>::format(builder, MUST(value.debug_description()));return format_error;}
-};
-namespace Jakt {
-} // namespace Jakt
-template<>struct Jakt::Formatter<Jakt::typechecker::Typechecker> : Jakt::Formatter<Jakt::StringView>{
-Jakt::ErrorOr<void> format(Jakt::FormatBuilder& builder, Jakt::typechecker::Typechecker const& value) {
-JaktInternal::PrettyPrint::ScopedEnable pretty_print_enable { m_alternative_form };Jakt::ErrorOr<void> format_error = Jakt::Formatter<Jakt::StringView>::format(builder, MUST(value.debug_description()));return format_error;}
-};
-namespace Jakt {
-} // namespace Jakt
-template<typename K, typename V>struct Jakt::Formatter<Jakt::typechecker::InternalDictionaryProduct<K, V>
-> : Jakt::Formatter<Jakt::StringView>{
-Jakt::ErrorOr<void> format(Jakt::FormatBuilder& builder, Jakt::typechecker::InternalDictionaryProduct<K, V>
- const& value) {
+template<>struct Jakt::Formatter<Jakt::typechecker::TraitImplCheck> : Jakt::Formatter<Jakt::StringView>{
+Jakt::ErrorOr<void> format(Jakt::FormatBuilder& builder, Jakt::typechecker::TraitImplCheck const& value) {
 JaktInternal::PrettyPrint::ScopedEnable pretty_print_enable { m_alternative_form };Jakt::ErrorOr<void> format_error = Jakt::Formatter<Jakt::StringView>::format(builder, MUST(value.debug_description()));return format_error;}
 };
 namespace Jakt {
@@ -390,14 +371,34 @@ JaktInternal::PrettyPrint::ScopedEnable pretty_print_enable { m_alternative_form
 };
 namespace Jakt {
 } // namespace Jakt
+template<>struct Jakt::Formatter<Jakt::typechecker::ImportRestrictions> : Jakt::Formatter<Jakt::StringView>{
+Jakt::ErrorOr<void> format(Jakt::FormatBuilder& builder, Jakt::typechecker::ImportRestrictions const& value) {
+JaktInternal::PrettyPrint::ScopedEnable pretty_print_enable { m_alternative_form };Jakt::ErrorOr<void> format_error = Jakt::Formatter<Jakt::StringView>::format(builder, MUST(value.debug_description()));return format_error;}
+};
+namespace Jakt {
+} // namespace Jakt
+template<>struct Jakt::Formatter<Jakt::typechecker::Typechecker> : Jakt::Formatter<Jakt::StringView>{
+Jakt::ErrorOr<void> format(Jakt::FormatBuilder& builder, Jakt::typechecker::Typechecker const& value) {
+JaktInternal::PrettyPrint::ScopedEnable pretty_print_enable { m_alternative_form };Jakt::ErrorOr<void> format_error = Jakt::Formatter<Jakt::StringView>::format(builder, MUST(value.debug_description()));return format_error;}
+};
+namespace Jakt {
+} // namespace Jakt
+template<>struct Jakt::Formatter<Jakt::typechecker::AlreadyImplementedFor> : Jakt::Formatter<Jakt::StringView>{
+Jakt::ErrorOr<void> format(Jakt::FormatBuilder& builder, Jakt::typechecker::AlreadyImplementedFor const& value) {
+JaktInternal::PrettyPrint::ScopedEnable pretty_print_enable { m_alternative_form };Jakt::ErrorOr<void> format_error = Jakt::Formatter<Jakt::StringView>::format(builder, MUST(value.debug_description()));return format_error;}
+};
+namespace Jakt {
+} // namespace Jakt
 template<>struct Jakt::Formatter<Jakt::typechecker::TraitImplementationDescriptor> : Jakt::Formatter<Jakt::StringView>{
 Jakt::ErrorOr<void> format(Jakt::FormatBuilder& builder, Jakt::typechecker::TraitImplementationDescriptor const& value) {
 JaktInternal::PrettyPrint::ScopedEnable pretty_print_enable { m_alternative_form };Jakt::ErrorOr<void> format_error = Jakt::Formatter<Jakt::StringView>::format(builder, MUST(value.debug_description()));return format_error;}
 };
 namespace Jakt {
 } // namespace Jakt
-template<>struct Jakt::Formatter<Jakt::typechecker::TraitImplCheck> : Jakt::Formatter<Jakt::StringView>{
-Jakt::ErrorOr<void> format(Jakt::FormatBuilder& builder, Jakt::typechecker::TraitImplCheck const& value) {
+template<typename K, typename V>struct Jakt::Formatter<Jakt::typechecker::InternalDictionaryProduct<K, V>
+> : Jakt::Formatter<Jakt::StringView>{
+Jakt::ErrorOr<void> format(Jakt::FormatBuilder& builder, Jakt::typechecker::InternalDictionaryProduct<K, V>
+ const& value) {
 JaktInternal::PrettyPrint::ScopedEnable pretty_print_enable { m_alternative_form };Jakt::ErrorOr<void> format_error = Jakt::Formatter<Jakt::StringView>::format(builder, MUST(value.debug_description()));return format_error;}
 };
 namespace Jakt {

--- a/bootstrap/stage0/typechecker_specializations.cpp
+++ b/bootstrap/stage0/typechecker_specializations.cpp
@@ -28,6 +28,7 @@
 #include "jakt__platform.h"
 #include "jakt__arguments.h"
 #include "jakt__prelude__prelude.h"
+#include "jakt__prelude__hash.h"
 #include "jakt__prelude__operators.h"
 #include "jakt__prelude__string.h"
 #include "jakt__prelude__iteration.h"

--- a/bootstrap/stage0/types.h
+++ b/bootstrap/stage0/types.h
@@ -5,10 +5,88 @@
 #include "compiler.h"
 namespace Jakt {
 namespace types {
-struct ModuleId {
+namespace CheckedTraitRequirements_Details {
+struct Nothing {
+};
+struct Methods{
+JaktInternal::Dictionary<DeprecatedString,types::FunctionId> value;
+template<typename _MemberT0>
+Methods(_MemberT0&& member_0):
+value{ forward<_MemberT0>(member_0)}
+{}
+};
+struct ComptimeExpression{
+NonnullRefPtr<typename types::CheckedExpression> value;
+template<typename _MemberT0>
+ComptimeExpression(_MemberT0&& member_0):
+value{ forward<_MemberT0>(member_0)}
+{}
+};
+}
+struct CheckedTraitRequirements : public Variant<CheckedTraitRequirements_Details::Nothing, CheckedTraitRequirements_Details::Methods, CheckedTraitRequirements_Details::ComptimeExpression> {
+using Variant<CheckedTraitRequirements_Details::Nothing, CheckedTraitRequirements_Details::Methods, CheckedTraitRequirements_Details::ComptimeExpression>::Variant;
+    using Nothing = CheckedTraitRequirements_Details::Nothing;
+    using Methods = CheckedTraitRequirements_Details::Methods;
+    using ComptimeExpression = CheckedTraitRequirements_Details::ComptimeExpression;
+ErrorOr<DeprecatedString> debug_description() const;
+};
+struct Value {
+  public:
+NonnullRefPtr<typename types::ValueImpl> impl;utility::Span span;ErrorOr<types::Value> copy() const;
+ErrorOr<DeprecatedString> type_name() const;
+Value(NonnullRefPtr<typename types::ValueImpl> a_impl, utility::Span a_span);
+
+ErrorOr<types::Value> cast(types::Value const expected, utility::Span const span) const;
+ErrorOr<DeprecatedString> debug_description() const;
+};struct ModuleId {
   public:
 size_t id;bool equals(types::ModuleId const rhs) const;
 ModuleId(size_t a_id);
+
+ErrorOr<DeprecatedString> debug_description() const;
+};struct LoadedModule {
+  public:
+types::ModuleId module_id;utility::FileId file_id;LoadedModule(types::ModuleId a_module_id, utility::FileId a_file_id);
+
+ErrorOr<DeprecatedString> debug_description() const;
+};struct StructId {
+  public:
+types::ModuleId module;size_t id;StructId(types::ModuleId a_module, size_t a_id);
+
+bool equals(types::StructId const rhs) const;
+ErrorOr<DeprecatedString> debug_description() const;
+};struct EnumId {
+  public:
+types::ModuleId module;size_t id;bool equals(types::EnumId const rhs) const;
+EnumId(types::ModuleId a_module, size_t a_id);
+
+ErrorOr<DeprecatedString> debug_description() const;
+};namespace StructOrEnumId_Details {
+struct Struct{
+types::StructId value;
+template<typename _MemberT0>
+Struct(_MemberT0&& member_0):
+value{ forward<_MemberT0>(member_0)}
+{}
+};
+struct Enum{
+types::EnumId value;
+template<typename _MemberT0>
+Enum(_MemberT0&& member_0):
+value{ forward<_MemberT0>(member_0)}
+{}
+};
+}
+struct StructOrEnumId : public Variant<StructOrEnumId_Details::Struct, StructOrEnumId_Details::Enum> {
+using Variant<StructOrEnumId_Details::Struct, StructOrEnumId_Details::Enum>::Variant;
+    using Struct = StructOrEnumId_Details::Struct;
+    using Enum = StructOrEnumId_Details::Enum;
+ErrorOr<DeprecatedString> debug_description() const;
+};
+struct TraitId {
+  public:
+types::ModuleId module;size_t id;bool equals(types::TraitId const other) const;
+TraitId(types::ModuleId a_module, size_t a_id);
 
 ErrorOr<DeprecatedString> debug_description() const;
 };struct TypeId {
@@ -20,328 +98,238 @@ TypeId(types::ModuleId a_module, size_t a_id);
 bool equals(types::TypeId const rhs) const;
 static ErrorOr<types::TypeId> from_string(DeprecatedString const type_id_string);
 ErrorOr<DeprecatedString> debug_description() const;
-};namespace CheckedTypeCast_Details {
-struct Fallible{
-types::TypeId value;
-template<typename _MemberT0>
-Fallible(_MemberT0&& member_0):
-value{ forward<_MemberT0>(member_0)}
-{}
-};
-struct Infallible{
-types::TypeId value;
-template<typename _MemberT0>
-Infallible(_MemberT0&& member_0):
-value{ forward<_MemberT0>(member_0)}
-{}
-};
-}
-struct CheckedTypeCast : public Variant<CheckedTypeCast_Details::Fallible, CheckedTypeCast_Details::Infallible> {
-using Variant<CheckedTypeCast_Details::Fallible, CheckedTypeCast_Details::Infallible>::Variant;
-    using Fallible = CheckedTypeCast_Details::Fallible;
-    using Infallible = CheckedTypeCast_Details::Infallible;
-ErrorOr<DeprecatedString> debug_description() const;
-types::TypeId type_id() const;
-};
-struct EnumId {
+};struct FunctionId {
   public:
-types::ModuleId module;size_t id;bool equals(types::EnumId const rhs) const;
-EnumId(types::ModuleId a_module, size_t a_id);
+types::ModuleId module;size_t id;FunctionId(types::ModuleId a_module, size_t a_id);
 
+bool equals(types::FunctionId const rhs) const;
 ErrorOr<DeprecatedString> debug_description() const;
-};namespace CheckedEnumVariant_Details {
-struct Untyped {
-types::EnumId enum_id;
+};namespace Type_Details {
+struct Void {
+};
+struct Bool {
+};
+struct U8 {
+};
+struct U16 {
+};
+struct U32 {
+};
+struct U64 {
+};
+struct I8 {
+};
+struct I16 {
+};
+struct I32 {
+};
+struct I64 {
+};
+struct F32 {
+};
+struct F64 {
+};
+struct Usize {
+};
+struct JaktString {
+};
+struct CChar {
+};
+struct CInt {
+};
+struct Unknown {
+};
+struct Never {
+};
+struct TypeVariable {
 DeprecatedString name;
-utility::Span span;
-template<typename _MemberT0, typename _MemberT1, typename _MemberT2>
-Untyped(_MemberT0&& member_0, _MemberT1&& member_1, _MemberT2&& member_2):
-enum_id{ forward<_MemberT0>(member_0)},
-name{ forward<_MemberT1>(member_1)},
-span{ forward<_MemberT2>(member_2)}
+JaktInternal::DynamicArray<types::TypeId> trait_implementations;
+template<typename _MemberT0, typename _MemberT1>
+TypeVariable(_MemberT0&& member_0, _MemberT1&& member_1):
+name{ forward<_MemberT0>(member_0)},
+trait_implementations{ forward<_MemberT1>(member_1)}
 {}
 };
-struct Typed {
-types::EnumId enum_id;
-DeprecatedString name;
-types::TypeId type_id;
-utility::Span span;
+struct GenericInstance {
+types::StructId id;
+JaktInternal::DynamicArray<types::TypeId> args;
+template<typename _MemberT0, typename _MemberT1>
+GenericInstance(_MemberT0&& member_0, _MemberT1&& member_1):
+id{ forward<_MemberT0>(member_0)},
+args{ forward<_MemberT1>(member_1)}
+{}
+};
+struct GenericEnumInstance {
+types::EnumId id;
+JaktInternal::DynamicArray<types::TypeId> args;
+template<typename _MemberT0, typename _MemberT1>
+GenericEnumInstance(_MemberT0&& member_0, _MemberT1&& member_1):
+id{ forward<_MemberT0>(member_0)},
+args{ forward<_MemberT1>(member_1)}
+{}
+};
+struct GenericTraitInstance {
+types::TraitId id;
+JaktInternal::DynamicArray<types::TypeId> args;
+template<typename _MemberT0, typename _MemberT1>
+GenericTraitInstance(_MemberT0&& member_0, _MemberT1&& member_1):
+id{ forward<_MemberT0>(member_0)},
+args{ forward<_MemberT1>(member_1)}
+{}
+};
+struct GenericResolvedType {
+types::StructId id;
+JaktInternal::DynamicArray<types::TypeId> args;
+template<typename _MemberT0, typename _MemberT1>
+GenericResolvedType(_MemberT0&& member_0, _MemberT1&& member_1):
+id{ forward<_MemberT0>(member_0)},
+args{ forward<_MemberT1>(member_1)}
+{}
+};
+struct Struct{
+types::StructId value;
+template<typename _MemberT0>
+Struct(_MemberT0&& member_0):
+value{ forward<_MemberT0>(member_0)}
+{}
+};
+struct Enum{
+types::EnumId value;
+template<typename _MemberT0>
+Enum(_MemberT0&& member_0):
+value{ forward<_MemberT0>(member_0)}
+{}
+};
+struct RawPtr{
+types::TypeId value;
+template<typename _MemberT0>
+RawPtr(_MemberT0&& member_0):
+value{ forward<_MemberT0>(member_0)}
+{}
+};
+struct Trait{
+types::TraitId value;
+template<typename _MemberT0>
+Trait(_MemberT0&& member_0):
+value{ forward<_MemberT0>(member_0)}
+{}
+};
+struct Reference{
+types::TypeId value;
+template<typename _MemberT0>
+Reference(_MemberT0&& member_0):
+value{ forward<_MemberT0>(member_0)}
+{}
+};
+struct MutableReference{
+types::TypeId value;
+template<typename _MemberT0>
+MutableReference(_MemberT0&& member_0):
+value{ forward<_MemberT0>(member_0)}
+{}
+};
+struct Function {
+JaktInternal::DynamicArray<types::TypeId> params;
+bool can_throw;
+types::TypeId return_type_id;
+types::FunctionId pseudo_function_id;
 template<typename _MemberT0, typename _MemberT1, typename _MemberT2, typename _MemberT3>
-Typed(_MemberT0&& member_0, _MemberT1&& member_1, _MemberT2&& member_2, _MemberT3&& member_3):
-enum_id{ forward<_MemberT0>(member_0)},
-name{ forward<_MemberT1>(member_1)},
-type_id{ forward<_MemberT2>(member_2)},
-span{ forward<_MemberT3>(member_3)}
+Function(_MemberT0&& member_0, _MemberT1&& member_1, _MemberT2&& member_2, _MemberT3&& member_3):
+params{ forward<_MemberT0>(member_0)},
+can_throw{ forward<_MemberT1>(member_1)},
+return_type_id{ forward<_MemberT2>(member_2)},
+pseudo_function_id{ forward<_MemberT3>(member_3)}
 {}
 };
-struct WithValue {
-types::EnumId enum_id;
-DeprecatedString name;
-NonnullRefPtr<typename types::CheckedExpression> expr;
-utility::Span span;
-template<typename _MemberT0, typename _MemberT1, typename _MemberT2, typename _MemberT3>
-WithValue(_MemberT0&& member_0, _MemberT1&& member_1, _MemberT2&& member_2, _MemberT3&& member_3):
-enum_id{ forward<_MemberT0>(member_0)},
-name{ forward<_MemberT1>(member_1)},
-expr{ forward<_MemberT2>(member_2)},
-span{ forward<_MemberT3>(member_3)}
-{}
-};
-struct StructLike {
-types::EnumId enum_id;
-DeprecatedString name;
-JaktInternal::DynamicArray<types::VarId> fields;
-utility::Span span;
-template<typename _MemberT0, typename _MemberT1, typename _MemberT2, typename _MemberT3>
-StructLike(_MemberT0&& member_0, _MemberT1&& member_1, _MemberT2&& member_2, _MemberT3&& member_3):
-enum_id{ forward<_MemberT0>(member_0)},
-name{ forward<_MemberT1>(member_1)},
-fields{ forward<_MemberT2>(member_2)},
-span{ forward<_MemberT3>(member_3)}
-{}
+struct Self {
 };
 }
-struct CheckedEnumVariant : public Variant<CheckedEnumVariant_Details::Untyped, CheckedEnumVariant_Details::Typed, CheckedEnumVariant_Details::WithValue, CheckedEnumVariant_Details::StructLike> {
-using Variant<CheckedEnumVariant_Details::Untyped, CheckedEnumVariant_Details::Typed, CheckedEnumVariant_Details::WithValue, CheckedEnumVariant_Details::StructLike>::Variant;
-    using Untyped = CheckedEnumVariant_Details::Untyped;
-    using Typed = CheckedEnumVariant_Details::Typed;
-    using WithValue = CheckedEnumVariant_Details::WithValue;
-    using StructLike = CheckedEnumVariant_Details::StructLike;
-ErrorOr<DeprecatedString> debug_description() const;
-types::EnumId enum_id() const;
-DeprecatedString name() const;
-bool equals(types::CheckedEnumVariant const other) const;
-utility::Span span() const;
-};
-namespace CheckedUnaryOperator_Details {
-struct PreIncrement {
-};
-struct PostIncrement {
-};
-struct PreDecrement {
-};
-struct PostDecrement {
-};
-struct Negate {
-};
-struct Dereference {
-};
-struct RawAddress {
-};
-struct Reference {
-};
-struct MutableReference {
-};
-struct LogicalNot {
-};
-struct BitwiseNot {
-};
-struct TypeCast{
-types::CheckedTypeCast value;
-template<typename _MemberT0>
-TypeCast(_MemberT0&& member_0):
-value{ forward<_MemberT0>(member_0)}
-{}
-};
-struct Is{
-types::TypeId value;
-template<typename _MemberT0>
-Is(_MemberT0&& member_0):
-value{ forward<_MemberT0>(member_0)}
-{}
-};
-struct IsEnumVariant {
-types::CheckedEnumVariant enum_variant;
-JaktInternal::DynamicArray<types::CheckedEnumVariantBinding> bindings;
-types::TypeId type_id;
-template<typename _MemberT0, typename _MemberT1, typename _MemberT2>
-IsEnumVariant(_MemberT0&& member_0, _MemberT1&& member_1, _MemberT2&& member_2):
-enum_variant{ forward<_MemberT0>(member_0)},
-bindings{ forward<_MemberT1>(member_1)},
-type_id{ forward<_MemberT2>(member_2)}
-{}
-};
-struct IsSome {
-};
-struct IsNone {
-};
-struct Sizeof{
-types::TypeId value;
-template<typename _MemberT0>
-Sizeof(_MemberT0&& member_0):
-value{ forward<_MemberT0>(member_0)}
-{}
-};
+struct Type : public Variant<Type_Details::Void, Type_Details::Bool, Type_Details::U8, Type_Details::U16, Type_Details::U32, Type_Details::U64, Type_Details::I8, Type_Details::I16, Type_Details::I32, Type_Details::I64, Type_Details::F32, Type_Details::F64, Type_Details::Usize, Type_Details::JaktString, Type_Details::CChar, Type_Details::CInt, Type_Details::Unknown, Type_Details::Never, Type_Details::TypeVariable, Type_Details::GenericInstance, Type_Details::GenericEnumInstance, Type_Details::GenericTraitInstance, Type_Details::GenericResolvedType, Type_Details::Struct, Type_Details::Enum, Type_Details::RawPtr, Type_Details::Trait, Type_Details::Reference, Type_Details::MutableReference, Type_Details::Function, Type_Details::Self>, public RefCounted<Type> {
+using Variant<Type_Details::Void, Type_Details::Bool, Type_Details::U8, Type_Details::U16, Type_Details::U32, Type_Details::U64, Type_Details::I8, Type_Details::I16, Type_Details::I32, Type_Details::I64, Type_Details::F32, Type_Details::F64, Type_Details::Usize, Type_Details::JaktString, Type_Details::CChar, Type_Details::CInt, Type_Details::Unknown, Type_Details::Never, Type_Details::TypeVariable, Type_Details::GenericInstance, Type_Details::GenericEnumInstance, Type_Details::GenericTraitInstance, Type_Details::GenericResolvedType, Type_Details::Struct, Type_Details::Enum, Type_Details::RawPtr, Type_Details::Trait, Type_Details::Reference, Type_Details::MutableReference, Type_Details::Function, Type_Details::Self>::Variant;
+    using Void = Type_Details::Void;
+    using Bool = Type_Details::Bool;
+    using U8 = Type_Details::U8;
+    using U16 = Type_Details::U16;
+    using U32 = Type_Details::U32;
+    using U64 = Type_Details::U64;
+    using I8 = Type_Details::I8;
+    using I16 = Type_Details::I16;
+    using I32 = Type_Details::I32;
+    using I64 = Type_Details::I64;
+    using F32 = Type_Details::F32;
+    using F64 = Type_Details::F64;
+    using Usize = Type_Details::Usize;
+    using JaktString = Type_Details::JaktString;
+    using CChar = Type_Details::CChar;
+    using CInt = Type_Details::CInt;
+    using Unknown = Type_Details::Unknown;
+    using Never = Type_Details::Never;
+    using TypeVariable = Type_Details::TypeVariable;
+    using GenericInstance = Type_Details::GenericInstance;
+    using GenericEnumInstance = Type_Details::GenericEnumInstance;
+    using GenericTraitInstance = Type_Details::GenericTraitInstance;
+    using GenericResolvedType = Type_Details::GenericResolvedType;
+    using Struct = Type_Details::Struct;
+    using Enum = Type_Details::Enum;
+    using RawPtr = Type_Details::RawPtr;
+    using Trait = Type_Details::Trait;
+    using Reference = Type_Details::Reference;
+    using MutableReference = Type_Details::MutableReference;
+    using Function = Type_Details::Function;
+    using Self = Type_Details::Self;
+template<typename V, typename... Args> static auto __jakt_create(Args&&... args) {
+return adopt_nonnull_ref_or_enomem(new (nothrow) Type(V(forward<Args>(args)...)));
 }
-struct CheckedUnaryOperator : public Variant<CheckedUnaryOperator_Details::PreIncrement, CheckedUnaryOperator_Details::PostIncrement, CheckedUnaryOperator_Details::PreDecrement, CheckedUnaryOperator_Details::PostDecrement, CheckedUnaryOperator_Details::Negate, CheckedUnaryOperator_Details::Dereference, CheckedUnaryOperator_Details::RawAddress, CheckedUnaryOperator_Details::Reference, CheckedUnaryOperator_Details::MutableReference, CheckedUnaryOperator_Details::LogicalNot, CheckedUnaryOperator_Details::BitwiseNot, CheckedUnaryOperator_Details::TypeCast, CheckedUnaryOperator_Details::Is, CheckedUnaryOperator_Details::IsEnumVariant, CheckedUnaryOperator_Details::IsSome, CheckedUnaryOperator_Details::IsNone, CheckedUnaryOperator_Details::Sizeof> {
-using Variant<CheckedUnaryOperator_Details::PreIncrement, CheckedUnaryOperator_Details::PostIncrement, CheckedUnaryOperator_Details::PreDecrement, CheckedUnaryOperator_Details::PostDecrement, CheckedUnaryOperator_Details::Negate, CheckedUnaryOperator_Details::Dereference, CheckedUnaryOperator_Details::RawAddress, CheckedUnaryOperator_Details::Reference, CheckedUnaryOperator_Details::MutableReference, CheckedUnaryOperator_Details::LogicalNot, CheckedUnaryOperator_Details::BitwiseNot, CheckedUnaryOperator_Details::TypeCast, CheckedUnaryOperator_Details::Is, CheckedUnaryOperator_Details::IsEnumVariant, CheckedUnaryOperator_Details::IsSome, CheckedUnaryOperator_Details::IsNone, CheckedUnaryOperator_Details::Sizeof>::Variant;
-    using PreIncrement = CheckedUnaryOperator_Details::PreIncrement;
-    using PostIncrement = CheckedUnaryOperator_Details::PostIncrement;
-    using PreDecrement = CheckedUnaryOperator_Details::PreDecrement;
-    using PostDecrement = CheckedUnaryOperator_Details::PostDecrement;
-    using Negate = CheckedUnaryOperator_Details::Negate;
-    using Dereference = CheckedUnaryOperator_Details::Dereference;
-    using RawAddress = CheckedUnaryOperator_Details::RawAddress;
-    using Reference = CheckedUnaryOperator_Details::Reference;
-    using MutableReference = CheckedUnaryOperator_Details::MutableReference;
-    using LogicalNot = CheckedUnaryOperator_Details::LogicalNot;
-    using BitwiseNot = CheckedUnaryOperator_Details::BitwiseNot;
-    using TypeCast = CheckedUnaryOperator_Details::TypeCast;
-    using Is = CheckedUnaryOperator_Details::Is;
-    using IsEnumVariant = CheckedUnaryOperator_Details::IsEnumVariant;
-    using IsSome = CheckedUnaryOperator_Details::IsSome;
-    using IsNone = CheckedUnaryOperator_Details::IsNone;
-    using Sizeof = CheckedUnaryOperator_Details::Sizeof;
 ErrorOr<DeprecatedString> debug_description() const;
+u64 max() const;
+bool equals(NonnullRefPtr<typename types::Type> const rhs) const;
+ErrorOr<DeprecatedString> constructor_name() const;
+bool is_concrete() const;
+i64 get_bits() const;
+i64 specificity(NonnullRefPtr<types::CheckedProgram> const program, i64 const base_specificity) const;
+types::BuiltinType as_builtin_type() const;
+bool is_builtin() const;
+i64 min() const;
+ErrorOr<types::TypeId> flip_signedness() const;
+bool is_boxed(NonnullRefPtr<types::CheckedProgram> const program) const;
+bool is_signed() const;
 };
-namespace NumericOrStringValue_Details {
-struct StringValue{
-DeprecatedString value;
-template<typename _MemberT0>
-StringValue(_MemberT0&& member_0):
-value{ forward<_MemberT0>(member_0)}
-{}
-};
-struct SignedNumericValue{
-i64 value;
-template<typename _MemberT0>
-SignedNumericValue(_MemberT0&& member_0):
-value{ forward<_MemberT0>(member_0)}
-{}
-};
-struct UnsignedNumericValue{
-u64 value;
-template<typename _MemberT0>
-UnsignedNumericValue(_MemberT0&& member_0):
-value{ forward<_MemberT0>(member_0)}
-{}
-};
-}
-struct NumericOrStringValue : public Variant<NumericOrStringValue_Details::StringValue, NumericOrStringValue_Details::SignedNumericValue, NumericOrStringValue_Details::UnsignedNumericValue> {
-using Variant<NumericOrStringValue_Details::StringValue, NumericOrStringValue_Details::SignedNumericValue, NumericOrStringValue_Details::UnsignedNumericValue>::Variant;
-    using StringValue = NumericOrStringValue_Details::StringValue;
-    using SignedNumericValue = NumericOrStringValue_Details::SignedNumericValue;
-    using UnsignedNumericValue = NumericOrStringValue_Details::UnsignedNumericValue;
-ErrorOr<DeprecatedString> debug_description() const;
-};
-struct TraitId {
+struct CheckedCall {
   public:
-types::ModuleId module;size_t id;bool equals(types::TraitId const other) const;
-TraitId(types::ModuleId a_module, size_t a_id);
-
-ErrorOr<DeprecatedString> debug_description() const;
-};class TypecheckFunctions : public RefCounted<TypecheckFunctions>, public Weakable<TypecheckFunctions> {
-  public:
-virtual ~TypecheckFunctions() = default;
-Function<ErrorOr<types::CheckedBlock>(parser::ParsedBlock, types::ScopeId, types::SafetyMode, JaktInternal::Optional<types::TypeId>)> block;Function<ErrorOr<types::FunctionId>(NonnullRefPtr<types::CheckedFunction>)> register_function;protected:
-explicit TypecheckFunctions(Function<ErrorOr<types::CheckedBlock>(parser::ParsedBlock, types::ScopeId, types::SafetyMode, JaktInternal::Optional<types::TypeId>)> a_block, Function<ErrorOr<types::FunctionId>(NonnullRefPtr<types::CheckedFunction>)> a_register_function);
-public:
-static ErrorOr<NonnullRefPtr<TypecheckFunctions>> __jakt_create(Function<ErrorOr<types::CheckedBlock>(parser::ParsedBlock, types::ScopeId, types::SafetyMode, JaktInternal::Optional<types::TypeId>)> block, Function<ErrorOr<types::FunctionId>(NonnullRefPtr<types::CheckedFunction>)> register_function);
-
-ErrorOr<DeprecatedString> debug_description() const;
-};struct CheckedEnumVariantBinding {
-  public:
-JaktInternal::Optional<DeprecatedString> name;DeprecatedString binding;types::TypeId type_id;utility::Span span;CheckedEnumVariantBinding(JaktInternal::Optional<DeprecatedString> a_name, DeprecatedString a_binding, types::TypeId a_type_id, utility::Span a_span);
-
-ErrorOr<DeprecatedString> debug_description() const;
-};namespace StringLiteral_Details {
-struct Static{
-DeprecatedString value;
-template<typename _MemberT0>
-Static(_MemberT0&& member_0):
-value{ forward<_MemberT0>(member_0)}
-{}
-};
-}
-struct StringLiteral : public Variant<StringLiteral_Details::Static> {
-using Variant<StringLiteral_Details::Static>::Variant;
-    using Static = StringLiteral_Details::Static;
-ErrorOr<DeprecatedString> debug_description() const;
-DeprecatedString to_string() const;
-};
-struct ResolvedNamespace {
-  public:
-DeprecatedString name;JaktInternal::Optional<parser::ExternalName> external_name;JaktInternal::Optional<JaktInternal::DynamicArray<types::TypeId>> generic_parameters;ResolvedNamespace(DeprecatedString a_name, JaktInternal::Optional<parser::ExternalName> a_external_name, JaktInternal::Optional<JaktInternal::DynamicArray<types::TypeId>> a_generic_parameters);
+JaktInternal::DynamicArray<types::ResolvedNamespace> namespace_;DeprecatedString name;JaktInternal::DynamicArray<JaktInternal::Tuple<DeprecatedString,NonnullRefPtr<typename types::CheckedExpression>>> args;JaktInternal::DynamicArray<types::TypeId> type_args;JaktInternal::Optional<types::FunctionId> function_id;types::TypeId return_type;bool callee_throws;JaktInternal::Optional<parser::ExternalName> external_name;JaktInternal::Optional<bool> force_inline;CheckedCall(JaktInternal::DynamicArray<types::ResolvedNamespace> a_namespace_, DeprecatedString a_name, JaktInternal::DynamicArray<JaktInternal::Tuple<DeprecatedString,NonnullRefPtr<typename types::CheckedExpression>>> a_args, JaktInternal::DynamicArray<types::TypeId> a_type_args, JaktInternal::Optional<types::FunctionId> a_function_id, types::TypeId a_return_type, bool a_callee_throws, JaktInternal::Optional<parser::ExternalName> a_external_name, JaktInternal::Optional<bool> a_force_inline);
 
 parser::ExternalName name_for_codegen() const;
 ErrorOr<DeprecatedString> debug_description() const;
-};class CheckedProgram : public RefCounted<CheckedProgram>, public Weakable<CheckedProgram> {
+};struct OperatorTraitImplementation {
   public:
-virtual ~CheckedProgram() = default;
-NonnullRefPtr<compiler::Compiler> compiler;JaktInternal::DynamicArray<NonnullRefPtr<types::Module>> modules;JaktInternal::Dictionary<DeprecatedString,types::LoadedModule> loaded_modules;ErrorOr<types::TypeId> substitute_typevars_in_type(types::TypeId const type_id, types::GenericInferences const generic_inferences, types::ModuleId const module_id);
-types::ModuleId prelude_module_id() const;
-ErrorOr<types::StructId> find_struct_in_prelude(DeprecatedString const name) const;
-ErrorOr<NonnullRefPtr<types::Scope>> get_scope(types::ScopeId const id) const;
-bool is_floating(types::TypeId const type_id) const;
-ErrorOr<JaktInternal::Optional<types::StructId>> find_struct_in_scope(types::ScopeId const scope_id, DeprecatedString const name) const;
-ErrorOr<void> set_loaded_module(DeprecatedString const module_name, types::LoadedModule const loaded_module);
-bool is_integer(types::TypeId const type_id) const;
-ErrorOr<types::ScopeId> find_type_scope_id(types::TypeId const type_id);
-ErrorOr<types::ScopeId> create_scope(JaktInternal::Optional<types::ScopeId> const parent_scope_id, bool const can_throw, DeprecatedString const debug_name, types::ModuleId const module_id, bool const for_block);
-NonnullRefPtr<types::Module> get_module(types::ModuleId const id) const;
-ErrorOr<DeprecatedString> type_name(types::TypeId const type_id, bool const debug_mode) const;
-ErrorOr<JaktInternal::Optional<bool>> for_each_scope_accessible_unqualified_from_scope_impl(types::ScopeId const scope_id, Function<ErrorOr<typename utility::IterationDecision<bool>>(types::ScopeId, JaktInternal::Optional<DeprecatedString>, bool)> const& callback) const;
-ErrorOr<bool> is_scope_directly_accessible_from(types::ScopeId const check_scope_id, types::ScopeId const scope_id) const;
-ErrorOr<bool> is_string(types::TypeId const type_id) const;
-types::ScopeId prelude_scope_id() const;
-NonnullRefPtr<types::CheckedTrait> get_trait(types::TraitId const id) const;
-NonnullRefPtr<types::CheckedVariable> get_variable(types::VarId const id) const;
-protected:
-explicit CheckedProgram(NonnullRefPtr<compiler::Compiler> a_compiler, JaktInternal::DynamicArray<NonnullRefPtr<types::Module>> a_modules, JaktInternal::Dictionary<DeprecatedString,types::LoadedModule> a_loaded_modules);
-public:
-static ErrorOr<NonnullRefPtr<CheckedProgram>> __jakt_create(NonnullRefPtr<compiler::Compiler> compiler, JaktInternal::DynamicArray<NonnullRefPtr<types::Module>> modules, JaktInternal::Dictionary<DeprecatedString,types::LoadedModule> loaded_modules);
+types::TraitId trait_id;JaktInternal::DynamicArray<types::TypeId> trait_generic_arguments;types::CheckedCall call_expression;OperatorTraitImplementation(types::TraitId a_trait_id, JaktInternal::DynamicArray<types::TypeId> a_trait_generic_arguments, types::CheckedCall a_call_expression);
 
-NonnullRefPtr<types::CheckedFunction> get_function(types::FunctionId const id) const;
-ErrorOr<types::StructId> builtin_implementation_struct(types::BuiltinType const builtin, types::ModuleId const for_module);
-ErrorOr<types::TypeId> substitute_typevars_in_type_helper(types::TypeId const type_id, types::GenericInferences const generic_inferences, types::ModuleId const module_id);
-ErrorOr<JaktInternal::Optional<types::Value>> find_comptime_binding_in_scope(types::ScopeId const scope_id, DeprecatedString const name) const;
-i64 get_bits(types::TypeId const type_id) const;
-NonnullRefPtr<typename types::Type> get_type(types::TypeId const id) const;
-ErrorOr<types::TypeId> find_or_add_type_id(NonnullRefPtr<typename types::Type> const type, types::ModuleId const module_id);
-ErrorOr<JaktInternal::Optional<JaktInternal::Tuple<types::ScopeId,bool>>> find_namespace_in_scope(types::ScopeId const scope_id, DeprecatedString const name, bool const treat_aliases_as_imports) const;
-ErrorOr<JaktInternal::Optional<types::TraitId>> find_trait_in_scope(types::ScopeId const scope_id, DeprecatedString const name) const;
-types::CheckedEnum get_enum(types::EnumId const id) const;
-ErrorOr<JaktInternal::Optional<JaktInternal::DynamicArray<types::FunctionId>>> find_functions_with_name_in_scope(types::ScopeId const parent_scope_id, DeprecatedString const function_name) const;
-ErrorOr<JaktInternal::Optional<NonnullRefPtr<types::CheckedVariable>>> find_var_in_scope(types::ScopeId const scope_id, DeprecatedString const var) const;
-ErrorOr<JaktInternal::Optional<types::FunctionId>> find_function_in_scope(types::ScopeId const parent_scope_id, DeprecatedString const function_name) const;
-types::CheckedStruct get_struct(types::StructId const id) const;
-ErrorOr<JaktInternal::Optional<types::StructId>> check_and_extract_weak_ptr(types::StructId const struct_id, JaktInternal::DynamicArray<types::TypeId> const args) const;
-ErrorOr<JaktInternal::Optional<types::EnumId>> find_enum_in_scope(types::ScopeId const scope_id, DeprecatedString const name) const;
-JaktInternal::Optional<types::LoadedModule> get_loaded_module(DeprecatedString const module_name) const;
-ErrorOr<JaktInternal::Optional<JaktInternal::Tuple<JaktInternal::DynamicArray<types::FunctionId>,types::ScopeId>>> find_scoped_functions_with_name_in_scope(types::ScopeId const parent_scope_id, DeprecatedString const function_name) const;
-bool is_signed(types::TypeId const type_id) const;
-bool is_numeric(types::TypeId const type_id) const;
-template <typename T>
-ErrorOr<JaktInternal::Optional<T>> for_each_scope_accessible_unqualified_from_scope(types::ScopeId const scope_id, Function<ErrorOr<typename utility::IterationDecision<T>>(types::ScopeId, JaktInternal::Optional<DeprecatedString>, bool)> const& callback) const;
-ErrorOr<types::StructOrEnumId> find_reflected_primitive(DeprecatedString const primitive) const;
 ErrorOr<DeprecatedString> debug_description() const;
-};namespace CheckedVisibility_Details {
-struct Public {
-};
-struct Private {
-};
-struct Restricted {
-JaktInternal::DynamicArray<NonnullRefPtr<typename types::MaybeResolvedScope>> scopes;
-utility::Span span;
-template<typename _MemberT0, typename _MemberT1>
-Restricted(_MemberT0&& member_0, _MemberT1&& member_1):
-scopes{ forward<_MemberT0>(member_0)},
-span{ forward<_MemberT1>(member_1)}
-{}
-};
-}
-struct CheckedVisibility : public Variant<CheckedVisibility_Details::Public, CheckedVisibility_Details::Private, CheckedVisibility_Details::Restricted> {
-using Variant<CheckedVisibility_Details::Public, CheckedVisibility_Details::Private, CheckedVisibility_Details::Restricted>::Variant;
-    using Public = CheckedVisibility_Details::Public;
-    using Private = CheckedVisibility_Details::Private;
-    using Restricted = CheckedVisibility_Details::Restricted;
-ErrorOr<DeprecatedString> debug_description() const;
-};
-struct ScopeId {
+};struct ScopeId {
   public:
 types::ModuleId module_id;size_t id;ErrorOr<DeprecatedString> to_string() const;
 bool equals(types::ScopeId const other) const;
 ScopeId(types::ModuleId a_module_id, size_t a_id);
+
+ErrorOr<DeprecatedString> debug_description() const;
+};struct CheckedEnum {
+  public:
+DeprecatedString name;utility::Span name_span;JaktInternal::DynamicArray<types::CheckedGenericParameter> generic_parameters;JaktInternal::DynamicArray<types::CheckedEnumVariant> variants;JaktInternal::DynamicArray<types::CheckedField> fields;types::ScopeId scope_id;parser::DefinitionLinkage definition_linkage;JaktInternal::Dictionary<DeprecatedString,JaktInternal::DynamicArray<JaktInternal::Tuple<types::TraitId,JaktInternal::DynamicArray<types::TypeId>>>> trait_implementations;parser::RecordType record_type;types::TypeId underlying_type_id;types::TypeId type_id;bool is_boxed;CheckedEnum(DeprecatedString a_name, utility::Span a_name_span, JaktInternal::DynamicArray<types::CheckedGenericParameter> a_generic_parameters, JaktInternal::DynamicArray<types::CheckedEnumVariant> a_variants, JaktInternal::DynamicArray<types::CheckedField> a_fields, types::ScopeId a_scope_id, parser::DefinitionLinkage a_definition_linkage, JaktInternal::Dictionary<DeprecatedString,JaktInternal::DynamicArray<JaktInternal::Tuple<types::TraitId,JaktInternal::DynamicArray<types::TypeId>>>> a_trait_implementations, parser::RecordType a_record_type, types::TypeId a_underlying_type_id, types::TypeId a_type_id, bool a_is_boxed);
+
+ErrorOr<DeprecatedString> debug_description() const;
+};struct CheckedVarDecl {
+  public:
+DeprecatedString name;bool is_mutable;utility::Span span;types::TypeId type_id;CheckedVarDecl(DeprecatedString a_name, bool a_is_mutable, utility::Span a_span, types::TypeId a_type_id);
+
+ErrorOr<DeprecatedString> debug_description() const;
+};struct VarId {
+  public:
+types::ModuleId module;size_t id;VarId(types::ModuleId a_module, size_t a_id);
+
+ErrorOr<DeprecatedString> debug_description() const;
+};struct FieldRecord {
+  public:
+types::StructId struct_id;types::VarId field_id;FieldRecord(types::StructId a_struct_id, types::VarId a_field_id);
 
 ErrorOr<DeprecatedString> debug_description() const;
 };namespace BlockControlFlow_Details {
@@ -405,80 +393,6 @@ bool never_returns() const;
 struct CheckedBlock {
   public:
 JaktInternal::DynamicArray<NonnullRefPtr<typename types::CheckedStatement>> statements;types::ScopeId scope_id;types::BlockControlFlow control_flow;JaktInternal::Optional<types::TypeId> yielded_type;bool yielded_none;CheckedBlock(JaktInternal::DynamicArray<NonnullRefPtr<typename types::CheckedStatement>> a_statements, types::ScopeId a_scope_id, types::BlockControlFlow a_control_flow, JaktInternal::Optional<types::TypeId> a_yielded_type, bool a_yielded_none);
-
-ErrorOr<DeprecatedString> debug_description() const;
-};struct StructId {
-  public:
-types::ModuleId module;size_t id;StructId(types::ModuleId a_module, size_t a_id);
-
-bool equals(types::StructId const rhs) const;
-ErrorOr<DeprecatedString> debug_description() const;
-};class CheckedFunction : public RefCounted<CheckedFunction>, public Weakable<CheckedFunction> {
-  public:
-virtual ~CheckedFunction() = default;
-DeprecatedString name;utility::Span name_span;types::CheckedVisibility visibility;types::TypeId return_type_id;JaktInternal::Optional<utility::Span> return_type_span;JaktInternal::DynamicArray<types::CheckedParameter> params;NonnullRefPtr<types::FunctionGenerics> generics;types::CheckedBlock block;bool can_throw;parser::FunctionType type;parser::FunctionLinkage linkage;types::ScopeId function_scope_id;JaktInternal::Optional<types::StructId> struct_id;bool is_instantiated;JaktInternal::Optional<parser::ParsedFunction> parsed_function;bool is_comptime;bool is_virtual;bool is_override;bool is_unsafe;JaktInternal::Optional<size_t> specialization_index;JaktInternal::Optional<types::ScopeId> owner_scope;bool is_fully_checked;JaktInternal::Optional<parser::ExternalName> external_name;JaktInternal::Optional<DeprecatedString> deprecated_message;JaktInternal::Optional<JaktInternal::DynamicArray<JaktInternal::Tuple<size_t,parser::ArgumentStoreLevel>>> stores_arguments;JaktInternal::Optional<bool> force_inline;ErrorOr<void> map_types(Function<ErrorOr<types::TypeId>(types::TypeId)> const& map);
-ErrorOr<bool> is_static() const;
-ErrorOr<bool> is_mutating() const;
-protected:
-explicit CheckedFunction(DeprecatedString a_name, utility::Span a_name_span, types::CheckedVisibility a_visibility, types::TypeId a_return_type_id, JaktInternal::Optional<utility::Span> a_return_type_span, JaktInternal::DynamicArray<types::CheckedParameter> a_params, NonnullRefPtr<types::FunctionGenerics> a_generics, types::CheckedBlock a_block, bool a_can_throw, parser::FunctionType a_type, parser::FunctionLinkage a_linkage, types::ScopeId a_function_scope_id, JaktInternal::Optional<types::StructId> a_struct_id, bool a_is_instantiated, JaktInternal::Optional<parser::ParsedFunction> a_parsed_function, bool a_is_comptime, bool a_is_virtual, bool a_is_override, bool a_is_unsafe, JaktInternal::Optional<size_t> a_specialization_index, JaktInternal::Optional<types::ScopeId> a_owner_scope, bool a_is_fully_checked, JaktInternal::Optional<parser::ExternalName> a_external_name, JaktInternal::Optional<DeprecatedString> a_deprecated_message, JaktInternal::Optional<JaktInternal::DynamicArray<JaktInternal::Tuple<size_t,parser::ArgumentStoreLevel>>> a_stores_arguments, JaktInternal::Optional<bool> a_force_inline);
-public:
-static ErrorOr<NonnullRefPtr<CheckedFunction>> __jakt_create(DeprecatedString name, utility::Span name_span, types::CheckedVisibility visibility, types::TypeId return_type_id, JaktInternal::Optional<utility::Span> return_type_span, JaktInternal::DynamicArray<types::CheckedParameter> params, NonnullRefPtr<types::FunctionGenerics> generics, types::CheckedBlock block, bool can_throw, parser::FunctionType type, parser::FunctionLinkage linkage, types::ScopeId function_scope_id, JaktInternal::Optional<types::StructId> struct_id, bool is_instantiated, JaktInternal::Optional<parser::ParsedFunction> parsed_function, bool is_comptime, bool is_virtual, bool is_override, bool is_unsafe, JaktInternal::Optional<size_t> specialization_index, JaktInternal::Optional<types::ScopeId> owner_scope, bool is_fully_checked, JaktInternal::Optional<parser::ExternalName> external_name, JaktInternal::Optional<DeprecatedString> deprecated_message, JaktInternal::Optional<JaktInternal::DynamicArray<JaktInternal::Tuple<size_t,parser::ArgumentStoreLevel>>> stores_arguments, JaktInternal::Optional<bool> force_inline);
-
-ErrorOr<parser::ParsedFunction> to_parsed_function() const;
-bool is_specialized_for_types(JaktInternal::DynamicArray<types::TypeId> const types) const;
-ErrorOr<NonnullRefPtr<types::CheckedFunction>> copy() const;
-ErrorOr<bool> signature_matches(NonnullRefPtr<types::CheckedFunction> const other, bool const ignore_this) const;
-parser::ExternalName name_for_codegen() const;
-ErrorOr<void> add_param(types::CheckedParameter const checked_param);
-ErrorOr<void> set_params(JaktInternal::DynamicArray<types::CheckedParameter> const checked_params);
-ErrorOr<DeprecatedString> debug_description() const;
-};namespace StructLikeId_Details {
-struct Struct{
-JaktInternal::Optional<JaktInternal::DynamicArray<types::TypeId>> generic_arguments;
-types::StructId value;
-template<typename _MemberT0, typename _MemberT1>
-Struct(_MemberT0&& member_0, _MemberT1&& member_1):
-generic_arguments{ forward<_MemberT0>(member_0)},
-value{ forward<_MemberT1>(member_1)}
-{}
-};
-struct Enum{
-JaktInternal::Optional<JaktInternal::DynamicArray<types::TypeId>> generic_arguments;
-types::EnumId value;
-template<typename _MemberT0, typename _MemberT1>
-Enum(_MemberT0&& member_0, _MemberT1&& member_1):
-generic_arguments{ forward<_MemberT0>(member_0)},
-value{ forward<_MemberT1>(member_1)}
-{}
-};
-struct Trait{
-JaktInternal::Optional<JaktInternal::DynamicArray<types::TypeId>> generic_arguments;
-types::TraitId value;
-template<typename _MemberT0, typename _MemberT1>
-Trait(_MemberT0&& member_0, _MemberT1&& member_1):
-generic_arguments{ forward<_MemberT0>(member_0)},
-value{ forward<_MemberT1>(member_1)}
-{}
-};
-}
-struct StructLikeId : public Variant<StructLikeId_Details::Struct, StructLikeId_Details::Enum, StructLikeId_Details::Trait> {
-using Variant<StructLikeId_Details::Struct, StructLikeId_Details::Enum, StructLikeId_Details::Trait>::Variant;
-    using Struct = StructLikeId_Details::Struct;
-    using Enum = StructLikeId_Details::Enum;
-    using Trait = StructLikeId_Details::Trait;
-ErrorOr<DeprecatedString> debug_description() const;
-JaktInternal::Optional<JaktInternal::DynamicArray<types::TypeId>> const& generic_arguments() const { switch(this->index()) {case 0 /* Struct */: return this->template get<StructLikeId::Struct>().generic_arguments;
-case 1 /* Enum */: return this->template get<StructLikeId::Enum>().generic_arguments;
-case 2 /* Trait */: return this->template get<StructLikeId::Trait>().generic_arguments;
-default: VERIFY_NOT_REACHED();
-}
-}
-ErrorOr<JaktInternal::DynamicArray<types::TypeId>> generic_parameters(NonnullRefPtr<types::CheckedProgram> const& program) const;
-ErrorOr<types::ScopeId> scope_id(NonnullRefPtr<types::CheckedProgram> const& program) const;
-};
-struct ResolvedForallChunk {
-  public:
-JaktInternal::Dictionary<DeprecatedString,JaktInternal::DynamicArray<JaktInternal::Tuple<utility::Span,types::TypeId>>> parameters;parser::ParsedNamespace parsed_namespace;JaktInternal::DynamicArray<types::ScopeId> generated_scopes;ResolvedForallChunk(JaktInternal::Dictionary<DeprecatedString,JaktInternal::DynamicArray<JaktInternal::Tuple<utility::Span,types::TypeId>>> a_parameters, parser::ParsedNamespace a_parsed_namespace, JaktInternal::DynamicArray<types::ScopeId> a_generated_scopes);
 
 ErrorOr<DeprecatedString> debug_description() const;
 };namespace CheckedMatchBody_Details {
@@ -565,19 +479,656 @@ default: VERIFY_NOT_REACHED();
 }
 }
 };
-struct FunctionId {
-  public:
-types::ModuleId module;size_t id;FunctionId(types::ModuleId a_module, size_t a_id);
-
-bool equals(types::FunctionId const rhs) const;
+namespace CheckedNumericConstant_Details {
+struct I8{
+i8 value;
+template<typename _MemberT0>
+I8(_MemberT0&& member_0):
+value{ forward<_MemberT0>(member_0)}
+{}
+};
+struct I16{
+i16 value;
+template<typename _MemberT0>
+I16(_MemberT0&& member_0):
+value{ forward<_MemberT0>(member_0)}
+{}
+};
+struct I32{
+i32 value;
+template<typename _MemberT0>
+I32(_MemberT0&& member_0):
+value{ forward<_MemberT0>(member_0)}
+{}
+};
+struct I64{
+i64 value;
+template<typename _MemberT0>
+I64(_MemberT0&& member_0):
+value{ forward<_MemberT0>(member_0)}
+{}
+};
+struct U8{
+u8 value;
+template<typename _MemberT0>
+U8(_MemberT0&& member_0):
+value{ forward<_MemberT0>(member_0)}
+{}
+};
+struct U16{
+u16 value;
+template<typename _MemberT0>
+U16(_MemberT0&& member_0):
+value{ forward<_MemberT0>(member_0)}
+{}
+};
+struct U32{
+u32 value;
+template<typename _MemberT0>
+U32(_MemberT0&& member_0):
+value{ forward<_MemberT0>(member_0)}
+{}
+};
+struct U64{
+u64 value;
+template<typename _MemberT0>
+U64(_MemberT0&& member_0):
+value{ forward<_MemberT0>(member_0)}
+{}
+};
+struct USize{
+u64 value;
+template<typename _MemberT0>
+USize(_MemberT0&& member_0):
+value{ forward<_MemberT0>(member_0)}
+{}
+};
+struct F32{
+f32 value;
+template<typename _MemberT0>
+F32(_MemberT0&& member_0):
+value{ forward<_MemberT0>(member_0)}
+{}
+};
+struct F64{
+f64 value;
+template<typename _MemberT0>
+F64(_MemberT0&& member_0):
+value{ forward<_MemberT0>(member_0)}
+{}
+};
+}
+struct CheckedNumericConstant : public Variant<CheckedNumericConstant_Details::I8, CheckedNumericConstant_Details::I16, CheckedNumericConstant_Details::I32, CheckedNumericConstant_Details::I64, CheckedNumericConstant_Details::U8, CheckedNumericConstant_Details::U16, CheckedNumericConstant_Details::U32, CheckedNumericConstant_Details::U64, CheckedNumericConstant_Details::USize, CheckedNumericConstant_Details::F32, CheckedNumericConstant_Details::F64> {
+using Variant<CheckedNumericConstant_Details::I8, CheckedNumericConstant_Details::I16, CheckedNumericConstant_Details::I32, CheckedNumericConstant_Details::I64, CheckedNumericConstant_Details::U8, CheckedNumericConstant_Details::U16, CheckedNumericConstant_Details::U32, CheckedNumericConstant_Details::U64, CheckedNumericConstant_Details::USize, CheckedNumericConstant_Details::F32, CheckedNumericConstant_Details::F64>::Variant;
+    using I8 = CheckedNumericConstant_Details::I8;
+    using I16 = CheckedNumericConstant_Details::I16;
+    using I32 = CheckedNumericConstant_Details::I32;
+    using I64 = CheckedNumericConstant_Details::I64;
+    using U8 = CheckedNumericConstant_Details::U8;
+    using U16 = CheckedNumericConstant_Details::U16;
+    using U32 = CheckedNumericConstant_Details::U32;
+    using U64 = CheckedNumericConstant_Details::U64;
+    using USize = CheckedNumericConstant_Details::USize;
+    using F32 = CheckedNumericConstant_Details::F32;
+    using F64 = CheckedNumericConstant_Details::F64;
 ErrorOr<DeprecatedString> debug_description() const;
-};struct Value {
+JaktInternal::Optional<types::NumberConstant> number_constant() const;
+};
+namespace CheckedVisibility_Details {
+struct Public {
+};
+struct Private {
+};
+struct Restricted {
+JaktInternal::DynamicArray<NonnullRefPtr<typename types::MaybeResolvedScope>> scopes;
+utility::Span span;
+template<typename _MemberT0, typename _MemberT1>
+Restricted(_MemberT0&& member_0, _MemberT1&& member_1):
+scopes{ forward<_MemberT0>(member_0)},
+span{ forward<_MemberT1>(member_1)}
+{}
+};
+}
+struct CheckedVisibility : public Variant<CheckedVisibility_Details::Public, CheckedVisibility_Details::Private, CheckedVisibility_Details::Restricted> {
+using Variant<CheckedVisibility_Details::Public, CheckedVisibility_Details::Private, CheckedVisibility_Details::Restricted>::Variant;
+    using Public = CheckedVisibility_Details::Public;
+    using Private = CheckedVisibility_Details::Private;
+    using Restricted = CheckedVisibility_Details::Restricted;
+ErrorOr<DeprecatedString> debug_description() const;
+};
+namespace NumberConstant_Details {
+struct Signed{
+i64 value;
+template<typename _MemberT0>
+Signed(_MemberT0&& member_0):
+value{ forward<_MemberT0>(member_0)}
+{}
+};
+struct Unsigned{
+u64 value;
+template<typename _MemberT0>
+Unsigned(_MemberT0&& member_0):
+value{ forward<_MemberT0>(member_0)}
+{}
+};
+struct Floating{
+f64 value;
+template<typename _MemberT0>
+Floating(_MemberT0&& member_0):
+value{ forward<_MemberT0>(member_0)}
+{}
+};
+}
+struct NumberConstant : public Variant<NumberConstant_Details::Signed, NumberConstant_Details::Unsigned, NumberConstant_Details::Floating> {
+using Variant<NumberConstant_Details::Signed, NumberConstant_Details::Unsigned, NumberConstant_Details::Floating>::Variant;
+    using Signed = NumberConstant_Details::Signed;
+    using Unsigned = NumberConstant_Details::Unsigned;
+    using Floating = NumberConstant_Details::Floating;
+ErrorOr<DeprecatedString> debug_description() const;
+ErrorOr<bool> can_fit_number(types::TypeId const type_id, NonnullRefPtr<types::CheckedProgram> const program) const;
+ErrorOr<size_t> to_usize() const;
+};
+struct ResolvedForallChunk {
   public:
-NonnullRefPtr<typename types::ValueImpl> impl;utility::Span span;ErrorOr<types::Value> copy() const;
-ErrorOr<DeprecatedString> type_name() const;
-Value(NonnullRefPtr<typename types::ValueImpl> a_impl, utility::Span a_span);
+JaktInternal::Dictionary<DeprecatedString,JaktInternal::DynamicArray<JaktInternal::Tuple<utility::Span,types::TypeId>>> parameters;parser::ParsedNamespace parsed_namespace;JaktInternal::DynamicArray<types::ScopeId> generated_scopes;ResolvedForallChunk(JaktInternal::Dictionary<DeprecatedString,JaktInternal::DynamicArray<JaktInternal::Tuple<utility::Span,types::TypeId>>> a_parameters, parser::ParsedNamespace a_parsed_namespace, JaktInternal::DynamicArray<types::ScopeId> a_generated_scopes);
 
-ErrorOr<types::Value> cast(types::Value const expected, utility::Span const span) const;
+ErrorOr<DeprecatedString> debug_description() const;
+};namespace CheckedCapture_Details {
+struct ByValue {
+DeprecatedString name;
+utility::Span span;
+template<typename _MemberT0, typename _MemberT1>
+ByValue(_MemberT0&& member_0, _MemberT1&& member_1):
+name{ forward<_MemberT0>(member_0)},
+span{ forward<_MemberT1>(member_1)}
+{}
+};
+struct ByReference {
+DeprecatedString name;
+utility::Span span;
+template<typename _MemberT0, typename _MemberT1>
+ByReference(_MemberT0&& member_0, _MemberT1&& member_1):
+name{ forward<_MemberT0>(member_0)},
+span{ forward<_MemberT1>(member_1)}
+{}
+};
+struct ByMutableReference {
+DeprecatedString name;
+utility::Span span;
+template<typename _MemberT0, typename _MemberT1>
+ByMutableReference(_MemberT0&& member_0, _MemberT1&& member_1):
+name{ forward<_MemberT0>(member_0)},
+span{ forward<_MemberT1>(member_1)}
+{}
+};
+struct ByComptimeDependency {
+DeprecatedString name;
+utility::Span span;
+template<typename _MemberT0, typename _MemberT1>
+ByComptimeDependency(_MemberT0&& member_0, _MemberT1&& member_1):
+name{ forward<_MemberT0>(member_0)},
+span{ forward<_MemberT1>(member_1)}
+{}
+};
+struct AllByReference {
+DeprecatedString name;
+utility::Span span;
+template<typename _MemberT0, typename _MemberT1>
+AllByReference(_MemberT0&& member_0, _MemberT1&& member_1):
+name{ forward<_MemberT0>(member_0)},
+span{ forward<_MemberT1>(member_1)}
+{}
+};
+}
+struct CheckedCapture : public Variant<CheckedCapture_Details::ByValue, CheckedCapture_Details::ByReference, CheckedCapture_Details::ByMutableReference, CheckedCapture_Details::ByComptimeDependency, CheckedCapture_Details::AllByReference> {
+using Variant<CheckedCapture_Details::ByValue, CheckedCapture_Details::ByReference, CheckedCapture_Details::ByMutableReference, CheckedCapture_Details::ByComptimeDependency, CheckedCapture_Details::AllByReference>::Variant;
+    using ByValue = CheckedCapture_Details::ByValue;
+    using ByReference = CheckedCapture_Details::ByReference;
+    using ByMutableReference = CheckedCapture_Details::ByMutableReference;
+    using ByComptimeDependency = CheckedCapture_Details::ByComptimeDependency;
+    using AllByReference = CheckedCapture_Details::AllByReference;
+ErrorOr<DeprecatedString> debug_description() const;
+DeprecatedString const& name() const { switch(this->index()) {case 0 /* ByValue */: return this->template get<CheckedCapture::ByValue>().name;
+case 1 /* ByReference */: return this->template get<CheckedCapture::ByReference>().name;
+case 2 /* ByMutableReference */: return this->template get<CheckedCapture::ByMutableReference>().name;
+case 3 /* ByComptimeDependency */: return this->template get<CheckedCapture::ByComptimeDependency>().name;
+case 4 /* AllByReference */: return this->template get<CheckedCapture::AllByReference>().name;
+default: VERIFY_NOT_REACHED();
+}
+}
+utility::Span const& span() const { switch(this->index()) {case 0 /* ByValue */: return this->template get<CheckedCapture::ByValue>().span;
+case 1 /* ByReference */: return this->template get<CheckedCapture::ByReference>().span;
+case 2 /* ByMutableReference */: return this->template get<CheckedCapture::ByMutableReference>().span;
+case 3 /* ByComptimeDependency */: return this->template get<CheckedCapture::ByComptimeDependency>().span;
+case 4 /* AllByReference */: return this->template get<CheckedCapture::AllByReference>().span;
+default: VERIFY_NOT_REACHED();
+}
+}
+};
+struct CheckedParameter {
+  public:
+bool requires_label;NonnullRefPtr<types::CheckedVariable> variable;JaktInternal::Optional<NonnullRefPtr<typename types::CheckedExpression>> default_value;ErrorOr<types::CheckedParameter> map_types(Function<ErrorOr<types::TypeId>(types::TypeId)> const& map) const;
+CheckedParameter(bool a_requires_label, NonnullRefPtr<types::CheckedVariable> a_variable, JaktInternal::Optional<NonnullRefPtr<typename types::CheckedExpression>> a_default_value);
+
+ErrorOr<DeprecatedString> debug_description() const;
+};namespace StringLiteral_Details {
+struct Static{
+DeprecatedString value;
+template<typename _MemberT0>
+Static(_MemberT0&& member_0):
+value{ forward<_MemberT0>(member_0)}
+{}
+};
+}
+struct StringLiteral : public Variant<StringLiteral_Details::Static> {
+using Variant<StringLiteral_Details::Static>::Variant;
+    using Static = StringLiteral_Details::Static;
+ErrorOr<DeprecatedString> debug_description() const;
+DeprecatedString to_string() const;
+};
+struct CheckedStringLiteral {
+  public:
+types::StringLiteral value;types::TypeId type_id;bool may_throw;DeprecatedString to_string() const;
+CheckedStringLiteral(types::StringLiteral a_value, types::TypeId a_type_id, bool a_may_throw);
+
+ErrorOr<DeprecatedString> debug_description() const;
+};struct CheckedStruct {
+  public:
+DeprecatedString name;utility::Span name_span;JaktInternal::DynamicArray<types::CheckedGenericParameter> generic_parameters;JaktInternal::DynamicArray<types::CheckedField> fields;types::ScopeId scope_id;parser::DefinitionLinkage definition_linkage;JaktInternal::Dictionary<DeprecatedString,JaktInternal::DynamicArray<JaktInternal::Tuple<types::TraitId,JaktInternal::DynamicArray<types::TypeId>>>> trait_implementations;parser::RecordType record_type;types::TypeId type_id;JaktInternal::Optional<types::StructId> super_struct_id;JaktInternal::Optional<parser::ExternalName> external_name;JaktInternal::Optional<types::TypeId> implements_type;CheckedStruct(DeprecatedString a_name, utility::Span a_name_span, JaktInternal::DynamicArray<types::CheckedGenericParameter> a_generic_parameters, JaktInternal::DynamicArray<types::CheckedField> a_fields, types::ScopeId a_scope_id, parser::DefinitionLinkage a_definition_linkage, JaktInternal::Dictionary<DeprecatedString,JaktInternal::DynamicArray<JaktInternal::Tuple<types::TraitId,JaktInternal::DynamicArray<types::TypeId>>>> a_trait_implementations, parser::RecordType a_record_type, types::TypeId a_type_id, JaktInternal::Optional<types::StructId> a_super_struct_id, JaktInternal::Optional<parser::ExternalName> a_external_name, JaktInternal::Optional<types::TypeId> a_implements_type);
+
+parser::ExternalName name_for_codegen() const;
+ErrorOr<DeprecatedString> debug_description() const;
+};namespace BuiltinType_Details {
+struct Void {
+};
+struct Bool {
+};
+struct U8 {
+};
+struct U16 {
+};
+struct U32 {
+};
+struct U64 {
+};
+struct I8 {
+};
+struct I16 {
+};
+struct I32 {
+};
+struct I64 {
+};
+struct F32 {
+};
+struct F64 {
+};
+struct Usize {
+};
+struct JaktString {
+};
+struct CChar {
+};
+struct CInt {
+};
+struct Unknown {
+};
+struct Never {
+};
+}
+struct BuiltinType : public Variant<BuiltinType_Details::Void, BuiltinType_Details::Bool, BuiltinType_Details::U8, BuiltinType_Details::U16, BuiltinType_Details::U32, BuiltinType_Details::U64, BuiltinType_Details::I8, BuiltinType_Details::I16, BuiltinType_Details::I32, BuiltinType_Details::I64, BuiltinType_Details::F32, BuiltinType_Details::F64, BuiltinType_Details::Usize, BuiltinType_Details::JaktString, BuiltinType_Details::CChar, BuiltinType_Details::CInt, BuiltinType_Details::Unknown, BuiltinType_Details::Never> {
+using Variant<BuiltinType_Details::Void, BuiltinType_Details::Bool, BuiltinType_Details::U8, BuiltinType_Details::U16, BuiltinType_Details::U32, BuiltinType_Details::U64, BuiltinType_Details::I8, BuiltinType_Details::I16, BuiltinType_Details::I32, BuiltinType_Details::I64, BuiltinType_Details::F32, BuiltinType_Details::F64, BuiltinType_Details::Usize, BuiltinType_Details::JaktString, BuiltinType_Details::CChar, BuiltinType_Details::CInt, BuiltinType_Details::Unknown, BuiltinType_Details::Never>::Variant;
+    using Void = BuiltinType_Details::Void;
+    using Bool = BuiltinType_Details::Bool;
+    using U8 = BuiltinType_Details::U8;
+    using U16 = BuiltinType_Details::U16;
+    using U32 = BuiltinType_Details::U32;
+    using U64 = BuiltinType_Details::U64;
+    using I8 = BuiltinType_Details::I8;
+    using I16 = BuiltinType_Details::I16;
+    using I32 = BuiltinType_Details::I32;
+    using I64 = BuiltinType_Details::I64;
+    using F32 = BuiltinType_Details::F32;
+    using F64 = BuiltinType_Details::F64;
+    using Usize = BuiltinType_Details::Usize;
+    using JaktString = BuiltinType_Details::JaktString;
+    using CChar = BuiltinType_Details::CChar;
+    using CInt = BuiltinType_Details::CInt;
+    using Unknown = BuiltinType_Details::Unknown;
+    using Never = BuiltinType_Details::Never;
+ErrorOr<DeprecatedString> debug_description() const;
+ErrorOr<DeprecatedString> constructor_name() const;
+size_t id() const;
+};
+struct CheckedNamespace {
+  public:
+DeprecatedString name;types::ScopeId scope;CheckedNamespace(DeprecatedString a_name, types::ScopeId a_scope);
+
+ErrorOr<DeprecatedString> debug_description() const;
+};struct GenericInferences {
+  public:
+JaktInternal::Dictionary<DeprecatedString,DeprecatedString> values;ErrorOr<void> set_all(JaktInternal::DynamicArray<types::CheckedGenericParameter> const keys, JaktInternal::DynamicArray<types::TypeId> const values);
+DeprecatedString map_name(DeprecatedString const type) const;
+ErrorOr<void> set_from(JaktInternal::Dictionary<DeprecatedString,DeprecatedString> const checkpoint);
+ErrorOr<JaktInternal::Optional<types::TypeId>> find_and_map(DeprecatedString const name, NonnullRefPtr<types::CheckedProgram> const& program) const;
+GenericInferences(JaktInternal::Dictionary<DeprecatedString,DeprecatedString> a_values);
+
+void restore(JaktInternal::Dictionary<DeprecatedString,DeprecatedString> const checkpoint);
+ErrorOr<void> debug_description(NonnullRefPtr<types::CheckedProgram> const& program) const;
+ErrorOr<types::TypeId> map(types::TypeId const type_id) const;
+ErrorOr<JaktInternal::Dictionary<DeprecatedString,DeprecatedString>> perform_checkpoint(bool const reset);
+JaktInternal::Optional<DeprecatedString> get(DeprecatedString const key) const;
+JaktInternal::Dictionary<DeprecatedString,DeprecatedString> iterator() const;
+ErrorOr<void> set(DeprecatedString const key, DeprecatedString const value);
+ErrorOr<DeprecatedString> debug_description() const;
+};class CheckedProgram : public RefCounted<CheckedProgram>, public Weakable<CheckedProgram> {
+  public:
+virtual ~CheckedProgram() = default;
+NonnullRefPtr<compiler::Compiler> compiler;JaktInternal::DynamicArray<NonnullRefPtr<types::Module>> modules;JaktInternal::Dictionary<DeprecatedString,types::LoadedModule> loaded_modules;ErrorOr<types::TypeId> substitute_typevars_in_type(types::TypeId const type_id, types::GenericInferences const generic_inferences, types::ModuleId const module_id);
+types::ModuleId prelude_module_id() const;
+ErrorOr<types::StructId> find_struct_in_prelude(DeprecatedString const name) const;
+ErrorOr<NonnullRefPtr<types::Scope>> get_scope(types::ScopeId const id) const;
+bool is_floating(types::TypeId const type_id) const;
+ErrorOr<JaktInternal::Optional<types::StructId>> find_struct_in_scope(types::ScopeId const scope_id, DeprecatedString const name) const;
+ErrorOr<void> set_loaded_module(DeprecatedString const module_name, types::LoadedModule const loaded_module);
+bool is_integer(types::TypeId const type_id) const;
+ErrorOr<types::ScopeId> find_type_scope_id(types::TypeId const type_id);
+ErrorOr<types::ScopeId> create_scope(JaktInternal::Optional<types::ScopeId> const parent_scope_id, bool const can_throw, DeprecatedString const debug_name, types::ModuleId const module_id, bool const for_block);
+NonnullRefPtr<types::Module> get_module(types::ModuleId const id) const;
+ErrorOr<DeprecatedString> type_name(types::TypeId const type_id, bool const debug_mode) const;
+ErrorOr<JaktInternal::Optional<bool>> for_each_scope_accessible_unqualified_from_scope_impl(types::ScopeId const scope_id, Function<ErrorOr<typename utility::IterationDecision<bool>>(types::ScopeId, JaktInternal::Optional<DeprecatedString>, bool)> const& callback) const;
+ErrorOr<bool> is_scope_directly_accessible_from(types::ScopeId const check_scope_id, types::ScopeId const scope_id) const;
+ErrorOr<bool> is_string(types::TypeId const type_id) const;
+types::ScopeId prelude_scope_id() const;
+NonnullRefPtr<types::CheckedTrait> get_trait(types::TraitId const id) const;
+NonnullRefPtr<types::CheckedVariable> get_variable(types::VarId const id) const;
+protected:
+explicit CheckedProgram(NonnullRefPtr<compiler::Compiler> a_compiler, JaktInternal::DynamicArray<NonnullRefPtr<types::Module>> a_modules, JaktInternal::Dictionary<DeprecatedString,types::LoadedModule> a_loaded_modules);
+public:
+static ErrorOr<NonnullRefPtr<CheckedProgram>> __jakt_create(NonnullRefPtr<compiler::Compiler> compiler, JaktInternal::DynamicArray<NonnullRefPtr<types::Module>> modules, JaktInternal::Dictionary<DeprecatedString,types::LoadedModule> loaded_modules);
+
+NonnullRefPtr<types::CheckedFunction> get_function(types::FunctionId const id) const;
+ErrorOr<types::StructId> builtin_implementation_struct(types::BuiltinType const builtin, types::ModuleId const for_module);
+ErrorOr<types::TypeId> substitute_typevars_in_type_helper(types::TypeId const type_id, types::GenericInferences const generic_inferences, types::ModuleId const module_id);
+ErrorOr<JaktInternal::Optional<types::Value>> find_comptime_binding_in_scope(types::ScopeId const scope_id, DeprecatedString const name) const;
+i64 get_bits(types::TypeId const type_id) const;
+NonnullRefPtr<typename types::Type> get_type(types::TypeId const id) const;
+ErrorOr<types::TypeId> find_or_add_type_id(NonnullRefPtr<typename types::Type> const type, types::ModuleId const module_id);
+ErrorOr<JaktInternal::Optional<JaktInternal::Tuple<types::ScopeId,bool>>> find_namespace_in_scope(types::ScopeId const scope_id, DeprecatedString const name, bool const treat_aliases_as_imports) const;
+ErrorOr<JaktInternal::Optional<types::TraitId>> find_trait_in_scope(types::ScopeId const scope_id, DeprecatedString const name) const;
+types::CheckedEnum get_enum(types::EnumId const id) const;
+ErrorOr<JaktInternal::Optional<JaktInternal::DynamicArray<types::FunctionId>>> find_functions_with_name_in_scope(types::ScopeId const parent_scope_id, DeprecatedString const function_name) const;
+ErrorOr<JaktInternal::Optional<NonnullRefPtr<types::CheckedVariable>>> find_var_in_scope(types::ScopeId const scope_id, DeprecatedString const var) const;
+ErrorOr<JaktInternal::Optional<types::FunctionId>> find_function_in_scope(types::ScopeId const parent_scope_id, DeprecatedString const function_name) const;
+types::CheckedStruct get_struct(types::StructId const id) const;
+ErrorOr<JaktInternal::Optional<types::StructId>> check_and_extract_weak_ptr(types::StructId const struct_id, JaktInternal::DynamicArray<types::TypeId> const args) const;
+ErrorOr<JaktInternal::Optional<types::EnumId>> find_enum_in_scope(types::ScopeId const scope_id, DeprecatedString const name) const;
+JaktInternal::Optional<types::LoadedModule> get_loaded_module(DeprecatedString const module_name) const;
+ErrorOr<JaktInternal::Optional<JaktInternal::Tuple<JaktInternal::DynamicArray<types::FunctionId>,types::ScopeId>>> find_scoped_functions_with_name_in_scope(types::ScopeId const parent_scope_id, DeprecatedString const function_name) const;
+bool is_signed(types::TypeId const type_id) const;
+bool is_numeric(types::TypeId const type_id) const;
+template <typename T>
+ErrorOr<JaktInternal::Optional<T>> for_each_scope_accessible_unqualified_from_scope(types::ScopeId const scope_id, Function<ErrorOr<typename utility::IterationDecision<T>>(types::ScopeId, JaktInternal::Optional<DeprecatedString>, bool)> const& callback) const;
+ErrorOr<types::StructOrEnumId> find_reflected_primitive(DeprecatedString const primitive) const;
+ErrorOr<DeprecatedString> debug_description() const;
+};namespace CheckedStatement_Details {
+struct Expression {
+NonnullRefPtr<typename types::CheckedExpression> expr;
+utility::Span span;
+template<typename _MemberT0, typename _MemberT1>
+Expression(_MemberT0&& member_0, _MemberT1&& member_1):
+expr{ forward<_MemberT0>(member_0)},
+span{ forward<_MemberT1>(member_1)}
+{}
+};
+struct Defer {
+NonnullRefPtr<typename types::CheckedStatement> statement;
+utility::Span span;
+template<typename _MemberT0, typename _MemberT1>
+Defer(_MemberT0&& member_0, _MemberT1&& member_1):
+statement{ forward<_MemberT0>(member_0)},
+span{ forward<_MemberT1>(member_1)}
+{}
+};
+struct DestructuringAssignment {
+JaktInternal::DynamicArray<NonnullRefPtr<typename types::CheckedStatement>> vars;
+NonnullRefPtr<typename types::CheckedStatement> var_decl;
+utility::Span span;
+template<typename _MemberT0, typename _MemberT1, typename _MemberT2>
+DestructuringAssignment(_MemberT0&& member_0, _MemberT1&& member_1, _MemberT2&& member_2):
+vars{ forward<_MemberT0>(member_0)},
+var_decl{ forward<_MemberT1>(member_1)},
+span{ forward<_MemberT2>(member_2)}
+{}
+};
+struct VarDecl {
+types::VarId var_id;
+NonnullRefPtr<typename types::CheckedExpression> init;
+utility::Span span;
+template<typename _MemberT0, typename _MemberT1, typename _MemberT2>
+VarDecl(_MemberT0&& member_0, _MemberT1&& member_1, _MemberT2&& member_2):
+var_id{ forward<_MemberT0>(member_0)},
+init{ forward<_MemberT1>(member_1)},
+span{ forward<_MemberT2>(member_2)}
+{}
+};
+struct If {
+NonnullRefPtr<typename types::CheckedExpression> condition;
+types::CheckedBlock then_block;
+JaktInternal::Optional<NonnullRefPtr<typename types::CheckedStatement>> else_statement;
+utility::Span span;
+template<typename _MemberT0, typename _MemberT1, typename _MemberT2, typename _MemberT3>
+If(_MemberT0&& member_0, _MemberT1&& member_1, _MemberT2&& member_2, _MemberT3&& member_3):
+condition{ forward<_MemberT0>(member_0)},
+then_block{ forward<_MemberT1>(member_1)},
+else_statement{ forward<_MemberT2>(member_2)},
+span{ forward<_MemberT3>(member_3)}
+{}
+};
+struct Block {
+types::CheckedBlock block;
+utility::Span span;
+template<typename _MemberT0, typename _MemberT1>
+Block(_MemberT0&& member_0, _MemberT1&& member_1):
+block{ forward<_MemberT0>(member_0)},
+span{ forward<_MemberT1>(member_1)}
+{}
+};
+struct Loop {
+types::CheckedBlock block;
+utility::Span span;
+template<typename _MemberT0, typename _MemberT1>
+Loop(_MemberT0&& member_0, _MemberT1&& member_1):
+block{ forward<_MemberT0>(member_0)},
+span{ forward<_MemberT1>(member_1)}
+{}
+};
+struct While {
+NonnullRefPtr<typename types::CheckedExpression> condition;
+types::CheckedBlock block;
+utility::Span span;
+template<typename _MemberT0, typename _MemberT1, typename _MemberT2>
+While(_MemberT0&& member_0, _MemberT1&& member_1, _MemberT2&& member_2):
+condition{ forward<_MemberT0>(member_0)},
+block{ forward<_MemberT1>(member_1)},
+span{ forward<_MemberT2>(member_2)}
+{}
+};
+struct Return {
+JaktInternal::Optional<NonnullRefPtr<typename types::CheckedExpression>> val;
+JaktInternal::Optional<utility::Span> span;
+template<typename _MemberT0, typename _MemberT1>
+Return(_MemberT0&& member_0, _MemberT1&& member_1):
+val{ forward<_MemberT0>(member_0)},
+span{ forward<_MemberT1>(member_1)}
+{}
+};
+struct Break{
+utility::Span value;
+template<typename _MemberT0>
+Break(_MemberT0&& member_0):
+value{ forward<_MemberT0>(member_0)}
+{}
+};
+struct Continue{
+utility::Span value;
+template<typename _MemberT0>
+Continue(_MemberT0&& member_0):
+value{ forward<_MemberT0>(member_0)}
+{}
+};
+struct Throw {
+NonnullRefPtr<typename types::CheckedExpression> expr;
+utility::Span span;
+template<typename _MemberT0, typename _MemberT1>
+Throw(_MemberT0&& member_0, _MemberT1&& member_1):
+expr{ forward<_MemberT0>(member_0)},
+span{ forward<_MemberT1>(member_1)}
+{}
+};
+struct Yield {
+NonnullRefPtr<typename types::CheckedExpression> expr;
+utility::Span span;
+template<typename _MemberT0, typename _MemberT1>
+Yield(_MemberT0&& member_0, _MemberT1&& member_1):
+expr{ forward<_MemberT0>(member_0)},
+span{ forward<_MemberT1>(member_1)}
+{}
+};
+struct InlineCpp {
+JaktInternal::DynamicArray<DeprecatedString> lines;
+utility::Span span;
+template<typename _MemberT0, typename _MemberT1>
+InlineCpp(_MemberT0&& member_0, _MemberT1&& member_1):
+lines{ forward<_MemberT0>(member_0)},
+span{ forward<_MemberT1>(member_1)}
+{}
+};
+struct Garbage{
+utility::Span value;
+template<typename _MemberT0>
+Garbage(_MemberT0&& member_0):
+value{ forward<_MemberT0>(member_0)}
+{}
+};
+}
+struct CheckedStatement : public Variant<CheckedStatement_Details::Expression, CheckedStatement_Details::Defer, CheckedStatement_Details::DestructuringAssignment, CheckedStatement_Details::VarDecl, CheckedStatement_Details::If, CheckedStatement_Details::Block, CheckedStatement_Details::Loop, CheckedStatement_Details::While, CheckedStatement_Details::Return, CheckedStatement_Details::Break, CheckedStatement_Details::Continue, CheckedStatement_Details::Throw, CheckedStatement_Details::Yield, CheckedStatement_Details::InlineCpp, CheckedStatement_Details::Garbage>, public RefCounted<CheckedStatement> {
+using Variant<CheckedStatement_Details::Expression, CheckedStatement_Details::Defer, CheckedStatement_Details::DestructuringAssignment, CheckedStatement_Details::VarDecl, CheckedStatement_Details::If, CheckedStatement_Details::Block, CheckedStatement_Details::Loop, CheckedStatement_Details::While, CheckedStatement_Details::Return, CheckedStatement_Details::Break, CheckedStatement_Details::Continue, CheckedStatement_Details::Throw, CheckedStatement_Details::Yield, CheckedStatement_Details::InlineCpp, CheckedStatement_Details::Garbage>::Variant;
+    using Expression = CheckedStatement_Details::Expression;
+    using Defer = CheckedStatement_Details::Defer;
+    using DestructuringAssignment = CheckedStatement_Details::DestructuringAssignment;
+    using VarDecl = CheckedStatement_Details::VarDecl;
+    using If = CheckedStatement_Details::If;
+    using Block = CheckedStatement_Details::Block;
+    using Loop = CheckedStatement_Details::Loop;
+    using While = CheckedStatement_Details::While;
+    using Return = CheckedStatement_Details::Return;
+    using Break = CheckedStatement_Details::Break;
+    using Continue = CheckedStatement_Details::Continue;
+    using Throw = CheckedStatement_Details::Throw;
+    using Yield = CheckedStatement_Details::Yield;
+    using InlineCpp = CheckedStatement_Details::InlineCpp;
+    using Garbage = CheckedStatement_Details::Garbage;
+template<typename V, typename... Args> static auto __jakt_create(Args&&... args) {
+return adopt_nonnull_ref_or_enomem(new (nothrow) CheckedStatement(V(forward<Args>(args)...)));
+}
+ErrorOr<DeprecatedString> debug_description() const;
+JaktInternal::Optional<utility::Span> span() const;
+static JaktInternal::Optional<NonnullRefPtr<typename types::CheckedStatement>> none();
+};
+namespace CheckedEnumVariant_Details {
+struct Untyped {
+types::EnumId enum_id;
+DeprecatedString name;
+utility::Span span;
+template<typename _MemberT0, typename _MemberT1, typename _MemberT2>
+Untyped(_MemberT0&& member_0, _MemberT1&& member_1, _MemberT2&& member_2):
+enum_id{ forward<_MemberT0>(member_0)},
+name{ forward<_MemberT1>(member_1)},
+span{ forward<_MemberT2>(member_2)}
+{}
+};
+struct Typed {
+types::EnumId enum_id;
+DeprecatedString name;
+types::TypeId type_id;
+utility::Span span;
+template<typename _MemberT0, typename _MemberT1, typename _MemberT2, typename _MemberT3>
+Typed(_MemberT0&& member_0, _MemberT1&& member_1, _MemberT2&& member_2, _MemberT3&& member_3):
+enum_id{ forward<_MemberT0>(member_0)},
+name{ forward<_MemberT1>(member_1)},
+type_id{ forward<_MemberT2>(member_2)},
+span{ forward<_MemberT3>(member_3)}
+{}
+};
+struct WithValue {
+types::EnumId enum_id;
+DeprecatedString name;
+NonnullRefPtr<typename types::CheckedExpression> expr;
+utility::Span span;
+template<typename _MemberT0, typename _MemberT1, typename _MemberT2, typename _MemberT3>
+WithValue(_MemberT0&& member_0, _MemberT1&& member_1, _MemberT2&& member_2, _MemberT3&& member_3):
+enum_id{ forward<_MemberT0>(member_0)},
+name{ forward<_MemberT1>(member_1)},
+expr{ forward<_MemberT2>(member_2)},
+span{ forward<_MemberT3>(member_3)}
+{}
+};
+struct StructLike {
+types::EnumId enum_id;
+DeprecatedString name;
+JaktInternal::DynamicArray<types::VarId> fields;
+utility::Span span;
+template<typename _MemberT0, typename _MemberT1, typename _MemberT2, typename _MemberT3>
+StructLike(_MemberT0&& member_0, _MemberT1&& member_1, _MemberT2&& member_2, _MemberT3&& member_3):
+enum_id{ forward<_MemberT0>(member_0)},
+name{ forward<_MemberT1>(member_1)},
+fields{ forward<_MemberT2>(member_2)},
+span{ forward<_MemberT3>(member_3)}
+{}
+};
+}
+struct CheckedEnumVariant : public Variant<CheckedEnumVariant_Details::Untyped, CheckedEnumVariant_Details::Typed, CheckedEnumVariant_Details::WithValue, CheckedEnumVariant_Details::StructLike> {
+using Variant<CheckedEnumVariant_Details::Untyped, CheckedEnumVariant_Details::Typed, CheckedEnumVariant_Details::WithValue, CheckedEnumVariant_Details::StructLike>::Variant;
+    using Untyped = CheckedEnumVariant_Details::Untyped;
+    using Typed = CheckedEnumVariant_Details::Typed;
+    using WithValue = CheckedEnumVariant_Details::WithValue;
+    using StructLike = CheckedEnumVariant_Details::StructLike;
+ErrorOr<DeprecatedString> debug_description() const;
+types::EnumId enum_id() const;
+DeprecatedString name() const;
+bool equals(types::CheckedEnumVariant const other) const;
+utility::Span span() const;
+};
+class TypecheckFunctions : public RefCounted<TypecheckFunctions>, public Weakable<TypecheckFunctions> {
+  public:
+virtual ~TypecheckFunctions() = default;
+Function<ErrorOr<types::CheckedBlock>(parser::ParsedBlock, types::ScopeId, types::SafetyMode, JaktInternal::Optional<types::TypeId>)> block;Function<ErrorOr<types::FunctionId>(NonnullRefPtr<types::CheckedFunction>)> register_function;protected:
+explicit TypecheckFunctions(Function<ErrorOr<types::CheckedBlock>(parser::ParsedBlock, types::ScopeId, types::SafetyMode, JaktInternal::Optional<types::TypeId>)> a_block, Function<ErrorOr<types::FunctionId>(NonnullRefPtr<types::CheckedFunction>)> a_register_function);
+public:
+static ErrorOr<NonnullRefPtr<TypecheckFunctions>> __jakt_create(Function<ErrorOr<types::CheckedBlock>(parser::ParsedBlock, types::ScopeId, types::SafetyMode, JaktInternal::Optional<types::TypeId>)> block, Function<ErrorOr<types::FunctionId>(NonnullRefPtr<types::CheckedFunction>)> register_function);
+
+ErrorOr<DeprecatedString> debug_description() const;
+};class Scope : public RefCounted<Scope>, public Weakable<Scope> {
+  public:
+virtual ~Scope() = default;
+JaktInternal::Optional<DeprecatedString> namespace_name;JaktInternal::Optional<parser::ExternalName> external_name;JaktInternal::Dictionary<DeprecatedString,types::VarId> vars;JaktInternal::Dictionary<DeprecatedString,types::Value> comptime_bindings;JaktInternal::Dictionary<DeprecatedString,types::StructId> structs;JaktInternal::Dictionary<DeprecatedString,JaktInternal::DynamicArray<types::FunctionId>> functions;JaktInternal::Dictionary<DeprecatedString,types::EnumId> enums;JaktInternal::Dictionary<DeprecatedString,types::TypeId> types;JaktInternal::Dictionary<DeprecatedString,types::TraitId> traits;JaktInternal::Dictionary<DeprecatedString,types::ModuleId> imports;JaktInternal::Dictionary<DeprecatedString,types::ScopeId> aliases;JaktInternal::Optional<types::ScopeId> parent;JaktInternal::Optional<types::ScopeId> alias_scope;JaktInternal::DynamicArray<types::ScopeId> children;bool can_throw;JaktInternal::Optional<DeprecatedString> import_path_if_extern;JaktInternal::Optional<JaktInternal::DynamicArray<types::ResolvedNamespace>> alias_path;JaktInternal::DynamicArray<parser::IncludeAction> after_extern_include;JaktInternal::DynamicArray<parser::IncludeAction> before_extern_include;DeprecatedString debug_name;JaktInternal::DynamicArray<types::ScopeId> resolution_mixins;bool is_block_scope;JaktInternal::Optional<JaktInternal::DynamicArray<types::ResolvedForallChunk>> resolved_forall_chunks;protected:
+explicit Scope(JaktInternal::Optional<DeprecatedString> a_namespace_name, JaktInternal::Optional<parser::ExternalName> a_external_name, JaktInternal::Dictionary<DeprecatedString,types::VarId> a_vars, JaktInternal::Dictionary<DeprecatedString,types::Value> a_comptime_bindings, JaktInternal::Dictionary<DeprecatedString,types::StructId> a_structs, JaktInternal::Dictionary<DeprecatedString,JaktInternal::DynamicArray<types::FunctionId>> a_functions, JaktInternal::Dictionary<DeprecatedString,types::EnumId> a_enums, JaktInternal::Dictionary<DeprecatedString,types::TypeId> a_types, JaktInternal::Dictionary<DeprecatedString,types::TraitId> a_traits, JaktInternal::Dictionary<DeprecatedString,types::ModuleId> a_imports, JaktInternal::Dictionary<DeprecatedString,types::ScopeId> a_aliases, JaktInternal::Optional<types::ScopeId> a_parent, JaktInternal::Optional<types::ScopeId> a_alias_scope, JaktInternal::DynamicArray<types::ScopeId> a_children, bool a_can_throw, JaktInternal::Optional<DeprecatedString> a_import_path_if_extern, JaktInternal::Optional<JaktInternal::DynamicArray<types::ResolvedNamespace>> a_alias_path, JaktInternal::DynamicArray<parser::IncludeAction> a_after_extern_include, JaktInternal::DynamicArray<parser::IncludeAction> a_before_extern_include, DeprecatedString a_debug_name, JaktInternal::DynamicArray<types::ScopeId> a_resolution_mixins, bool a_is_block_scope, JaktInternal::Optional<JaktInternal::DynamicArray<types::ResolvedForallChunk>> a_resolved_forall_chunks);
+public:
+static ErrorOr<NonnullRefPtr<Scope>> __jakt_create(JaktInternal::Optional<DeprecatedString> namespace_name, JaktInternal::Optional<parser::ExternalName> external_name, JaktInternal::Dictionary<DeprecatedString,types::VarId> vars, JaktInternal::Dictionary<DeprecatedString,types::Value> comptime_bindings, JaktInternal::Dictionary<DeprecatedString,types::StructId> structs, JaktInternal::Dictionary<DeprecatedString,JaktInternal::DynamicArray<types::FunctionId>> functions, JaktInternal::Dictionary<DeprecatedString,types::EnumId> enums, JaktInternal::Dictionary<DeprecatedString,types::TypeId> types, JaktInternal::Dictionary<DeprecatedString,types::TraitId> traits, JaktInternal::Dictionary<DeprecatedString,types::ModuleId> imports, JaktInternal::Dictionary<DeprecatedString,types::ScopeId> aliases, JaktInternal::Optional<types::ScopeId> parent, JaktInternal::Optional<types::ScopeId> alias_scope, JaktInternal::DynamicArray<types::ScopeId> children, bool can_throw, JaktInternal::Optional<DeprecatedString> import_path_if_extern, JaktInternal::Optional<JaktInternal::DynamicArray<types::ResolvedNamespace>> alias_path, JaktInternal::DynamicArray<parser::IncludeAction> after_extern_include, JaktInternal::DynamicArray<parser::IncludeAction> before_extern_include, DeprecatedString debug_name, JaktInternal::DynamicArray<types::ScopeId> resolution_mixins, bool is_block_scope, JaktInternal::Optional<JaktInternal::DynamicArray<types::ResolvedForallChunk>> resolved_forall_chunks);
+
+JaktInternal::Optional<parser::ExternalName> namespace_name_for_codegen() const;
+ErrorOr<DeprecatedString> debug_description() const;
+};class CheckedVariable : public RefCounted<CheckedVariable>, public Weakable<CheckedVariable> {
+  public:
+virtual ~CheckedVariable() = default;
+DeprecatedString name;types::TypeId type_id;bool is_mutable;utility::Span definition_span;JaktInternal::Optional<utility::Span> type_span;types::CheckedVisibility visibility;JaktInternal::Optional<types::ScopeId> owner_scope;JaktInternal::Optional<parser::ExternalName> external_name;ErrorOr<NonnullRefPtr<types::CheckedVariable>> map_types(Function<ErrorOr<types::TypeId>(types::TypeId)> const& map) const;
+parser::ExternalName name_for_codegen() const;
+protected:
+explicit CheckedVariable(DeprecatedString a_name, types::TypeId a_type_id, bool a_is_mutable, utility::Span a_definition_span, JaktInternal::Optional<utility::Span> a_type_span, types::CheckedVisibility a_visibility, JaktInternal::Optional<types::ScopeId> a_owner_scope, JaktInternal::Optional<parser::ExternalName> a_external_name);
+public:
+static ErrorOr<NonnullRefPtr<CheckedVariable>> __jakt_create(DeprecatedString name, types::TypeId type_id, bool is_mutable, utility::Span definition_span, JaktInternal::Optional<utility::Span> type_span, types::CheckedVisibility visibility, JaktInternal::Optional<types::ScopeId> owner_scope, JaktInternal::Optional<parser::ExternalName> external_name);
+
 ErrorOr<DeprecatedString> debug_description() const;
 };namespace ValueImpl_Details {
 struct Void {
@@ -842,131 +1393,236 @@ ErrorOr<DeprecatedString> debug_description() const;
 bool equals(NonnullRefPtr<typename types::ValueImpl> const other) const;
 ErrorOr<NonnullRefPtr<typename types::ValueImpl>> copy() const;
 };
-struct CheckedEnum {
+namespace FunctionGenericParameterKind_Details {
+struct InferenceGuide {
+};
+struct Parameter {
+};
+}
+struct FunctionGenericParameterKind : public Variant<FunctionGenericParameterKind_Details::InferenceGuide, FunctionGenericParameterKind_Details::Parameter> {
+using Variant<FunctionGenericParameterKind_Details::InferenceGuide, FunctionGenericParameterKind_Details::Parameter>::Variant;
+    using InferenceGuide = FunctionGenericParameterKind_Details::InferenceGuide;
+    using Parameter = FunctionGenericParameterKind_Details::Parameter;
+ErrorOr<DeprecatedString> debug_description() const;
+};
+struct CheckedGenericParameter {
   public:
-DeprecatedString name;utility::Span name_span;JaktInternal::DynamicArray<types::CheckedGenericParameter> generic_parameters;JaktInternal::DynamicArray<types::CheckedEnumVariant> variants;JaktInternal::DynamicArray<types::CheckedField> fields;types::ScopeId scope_id;parser::DefinitionLinkage definition_linkage;JaktInternal::Dictionary<DeprecatedString,JaktInternal::DynamicArray<JaktInternal::Tuple<types::TraitId,JaktInternal::DynamicArray<types::TypeId>>>> trait_implementations;parser::RecordType record_type;types::TypeId underlying_type_id;types::TypeId type_id;bool is_boxed;CheckedEnum(DeprecatedString a_name, utility::Span a_name_span, JaktInternal::DynamicArray<types::CheckedGenericParameter> a_generic_parameters, JaktInternal::DynamicArray<types::CheckedEnumVariant> a_variants, JaktInternal::DynamicArray<types::CheckedField> a_fields, types::ScopeId a_scope_id, parser::DefinitionLinkage a_definition_linkage, JaktInternal::Dictionary<DeprecatedString,JaktInternal::DynamicArray<JaktInternal::Tuple<types::TraitId,JaktInternal::DynamicArray<types::TypeId>>>> a_trait_implementations, parser::RecordType a_record_type, types::TypeId a_underlying_type_id, types::TypeId a_type_id, bool a_is_boxed);
+types::TypeId type_id;JaktInternal::DynamicArray<types::TraitId> constraints;utility::Span span;static ErrorOr<types::CheckedGenericParameter> make(types::TypeId const type_id, utility::Span const span);
+CheckedGenericParameter(types::TypeId a_type_id, JaktInternal::DynamicArray<types::TraitId> a_constraints, utility::Span a_span);
 
 ErrorOr<DeprecatedString> debug_description() const;
-};namespace CheckedNumericConstant_Details {
-struct I8{
-i8 value;
+};struct FunctionGenericParameter {
+  public:
+types::FunctionGenericParameterKind kind;types::CheckedGenericParameter checked_parameter;static ErrorOr<types::FunctionGenericParameter> parameter(types::TypeId const type_id, utility::Span const span);
+types::TypeId type_id() const;
+FunctionGenericParameter(types::FunctionGenericParameterKind a_kind, types::CheckedGenericParameter a_checked_parameter);
+
+ErrorOr<DeprecatedString> debug_description() const;
+};class FunctionGenerics : public RefCounted<FunctionGenerics>, public Weakable<FunctionGenerics> {
+  public:
+virtual ~FunctionGenerics() = default;
+types::ScopeId base_scope_id;JaktInternal::DynamicArray<types::CheckedParameter> base_params;JaktInternal::DynamicArray<types::FunctionGenericParameter> params;JaktInternal::DynamicArray<JaktInternal::DynamicArray<types::TypeId>> specializations;protected:
+explicit FunctionGenerics(types::ScopeId a_base_scope_id, JaktInternal::DynamicArray<types::CheckedParameter> a_base_params, JaktInternal::DynamicArray<types::FunctionGenericParameter> a_params, JaktInternal::DynamicArray<JaktInternal::DynamicArray<types::TypeId>> a_specializations);
+public:
+static ErrorOr<NonnullRefPtr<FunctionGenerics>> __jakt_create(types::ScopeId base_scope_id, JaktInternal::DynamicArray<types::CheckedParameter> base_params, JaktInternal::DynamicArray<types::FunctionGenericParameter> params, JaktInternal::DynamicArray<JaktInternal::DynamicArray<types::TypeId>> specializations);
+
+bool is_specialized_for_types(JaktInternal::DynamicArray<types::TypeId> const types) const;
+ErrorOr<DeprecatedString> debug_description() const;
+};namespace CheckedTypeCast_Details {
+struct Fallible{
+types::TypeId value;
 template<typename _MemberT0>
-I8(_MemberT0&& member_0):
+Fallible(_MemberT0&& member_0):
 value{ forward<_MemberT0>(member_0)}
 {}
 };
-struct I16{
-i16 value;
+struct Infallible{
+types::TypeId value;
 template<typename _MemberT0>
-I16(_MemberT0&& member_0):
-value{ forward<_MemberT0>(member_0)}
-{}
-};
-struct I32{
-i32 value;
-template<typename _MemberT0>
-I32(_MemberT0&& member_0):
-value{ forward<_MemberT0>(member_0)}
-{}
-};
-struct I64{
-i64 value;
-template<typename _MemberT0>
-I64(_MemberT0&& member_0):
-value{ forward<_MemberT0>(member_0)}
-{}
-};
-struct U8{
-u8 value;
-template<typename _MemberT0>
-U8(_MemberT0&& member_0):
-value{ forward<_MemberT0>(member_0)}
-{}
-};
-struct U16{
-u16 value;
-template<typename _MemberT0>
-U16(_MemberT0&& member_0):
-value{ forward<_MemberT0>(member_0)}
-{}
-};
-struct U32{
-u32 value;
-template<typename _MemberT0>
-U32(_MemberT0&& member_0):
-value{ forward<_MemberT0>(member_0)}
-{}
-};
-struct U64{
-u64 value;
-template<typename _MemberT0>
-U64(_MemberT0&& member_0):
-value{ forward<_MemberT0>(member_0)}
-{}
-};
-struct USize{
-u64 value;
-template<typename _MemberT0>
-USize(_MemberT0&& member_0):
-value{ forward<_MemberT0>(member_0)}
-{}
-};
-struct F32{
-f32 value;
-template<typename _MemberT0>
-F32(_MemberT0&& member_0):
-value{ forward<_MemberT0>(member_0)}
-{}
-};
-struct F64{
-f64 value;
-template<typename _MemberT0>
-F64(_MemberT0&& member_0):
+Infallible(_MemberT0&& member_0):
 value{ forward<_MemberT0>(member_0)}
 {}
 };
 }
-struct CheckedNumericConstant : public Variant<CheckedNumericConstant_Details::I8, CheckedNumericConstant_Details::I16, CheckedNumericConstant_Details::I32, CheckedNumericConstant_Details::I64, CheckedNumericConstant_Details::U8, CheckedNumericConstant_Details::U16, CheckedNumericConstant_Details::U32, CheckedNumericConstant_Details::U64, CheckedNumericConstant_Details::USize, CheckedNumericConstant_Details::F32, CheckedNumericConstant_Details::F64> {
-using Variant<CheckedNumericConstant_Details::I8, CheckedNumericConstant_Details::I16, CheckedNumericConstant_Details::I32, CheckedNumericConstant_Details::I64, CheckedNumericConstant_Details::U8, CheckedNumericConstant_Details::U16, CheckedNumericConstant_Details::U32, CheckedNumericConstant_Details::U64, CheckedNumericConstant_Details::USize, CheckedNumericConstant_Details::F32, CheckedNumericConstant_Details::F64>::Variant;
-    using I8 = CheckedNumericConstant_Details::I8;
-    using I16 = CheckedNumericConstant_Details::I16;
-    using I32 = CheckedNumericConstant_Details::I32;
-    using I64 = CheckedNumericConstant_Details::I64;
-    using U8 = CheckedNumericConstant_Details::U8;
-    using U16 = CheckedNumericConstant_Details::U16;
-    using U32 = CheckedNumericConstant_Details::U32;
-    using U64 = CheckedNumericConstant_Details::U64;
-    using USize = CheckedNumericConstant_Details::USize;
-    using F32 = CheckedNumericConstant_Details::F32;
-    using F64 = CheckedNumericConstant_Details::F64;
+struct CheckedTypeCast : public Variant<CheckedTypeCast_Details::Fallible, CheckedTypeCast_Details::Infallible> {
+using Variant<CheckedTypeCast_Details::Fallible, CheckedTypeCast_Details::Infallible>::Variant;
+    using Fallible = CheckedTypeCast_Details::Fallible;
+    using Infallible = CheckedTypeCast_Details::Infallible;
 ErrorOr<DeprecatedString> debug_description() const;
-JaktInternal::Optional<types::NumberConstant> number_constant() const;
+types::TypeId type_id() const;
 };
-struct CheckedStringLiteral {
+namespace CheckedUnaryOperator_Details {
+struct PreIncrement {
+};
+struct PostIncrement {
+};
+struct PreDecrement {
+};
+struct PostDecrement {
+};
+struct Negate {
+};
+struct Dereference {
+};
+struct RawAddress {
+};
+struct Reference {
+};
+struct MutableReference {
+};
+struct LogicalNot {
+};
+struct BitwiseNot {
+};
+struct TypeCast{
+types::CheckedTypeCast value;
+template<typename _MemberT0>
+TypeCast(_MemberT0&& member_0):
+value{ forward<_MemberT0>(member_0)}
+{}
+};
+struct Is{
+types::TypeId value;
+template<typename _MemberT0>
+Is(_MemberT0&& member_0):
+value{ forward<_MemberT0>(member_0)}
+{}
+};
+struct IsEnumVariant {
+types::CheckedEnumVariant enum_variant;
+JaktInternal::DynamicArray<types::CheckedEnumVariantBinding> bindings;
+types::TypeId type_id;
+template<typename _MemberT0, typename _MemberT1, typename _MemberT2>
+IsEnumVariant(_MemberT0&& member_0, _MemberT1&& member_1, _MemberT2&& member_2):
+enum_variant{ forward<_MemberT0>(member_0)},
+bindings{ forward<_MemberT1>(member_1)},
+type_id{ forward<_MemberT2>(member_2)}
+{}
+};
+struct IsSome {
+};
+struct IsNone {
+};
+struct Sizeof{
+types::TypeId value;
+template<typename _MemberT0>
+Sizeof(_MemberT0&& member_0):
+value{ forward<_MemberT0>(member_0)}
+{}
+};
+}
+struct CheckedUnaryOperator : public Variant<CheckedUnaryOperator_Details::PreIncrement, CheckedUnaryOperator_Details::PostIncrement, CheckedUnaryOperator_Details::PreDecrement, CheckedUnaryOperator_Details::PostDecrement, CheckedUnaryOperator_Details::Negate, CheckedUnaryOperator_Details::Dereference, CheckedUnaryOperator_Details::RawAddress, CheckedUnaryOperator_Details::Reference, CheckedUnaryOperator_Details::MutableReference, CheckedUnaryOperator_Details::LogicalNot, CheckedUnaryOperator_Details::BitwiseNot, CheckedUnaryOperator_Details::TypeCast, CheckedUnaryOperator_Details::Is, CheckedUnaryOperator_Details::IsEnumVariant, CheckedUnaryOperator_Details::IsSome, CheckedUnaryOperator_Details::IsNone, CheckedUnaryOperator_Details::Sizeof> {
+using Variant<CheckedUnaryOperator_Details::PreIncrement, CheckedUnaryOperator_Details::PostIncrement, CheckedUnaryOperator_Details::PreDecrement, CheckedUnaryOperator_Details::PostDecrement, CheckedUnaryOperator_Details::Negate, CheckedUnaryOperator_Details::Dereference, CheckedUnaryOperator_Details::RawAddress, CheckedUnaryOperator_Details::Reference, CheckedUnaryOperator_Details::MutableReference, CheckedUnaryOperator_Details::LogicalNot, CheckedUnaryOperator_Details::BitwiseNot, CheckedUnaryOperator_Details::TypeCast, CheckedUnaryOperator_Details::Is, CheckedUnaryOperator_Details::IsEnumVariant, CheckedUnaryOperator_Details::IsSome, CheckedUnaryOperator_Details::IsNone, CheckedUnaryOperator_Details::Sizeof>::Variant;
+    using PreIncrement = CheckedUnaryOperator_Details::PreIncrement;
+    using PostIncrement = CheckedUnaryOperator_Details::PostIncrement;
+    using PreDecrement = CheckedUnaryOperator_Details::PreDecrement;
+    using PostDecrement = CheckedUnaryOperator_Details::PostDecrement;
+    using Negate = CheckedUnaryOperator_Details::Negate;
+    using Dereference = CheckedUnaryOperator_Details::Dereference;
+    using RawAddress = CheckedUnaryOperator_Details::RawAddress;
+    using Reference = CheckedUnaryOperator_Details::Reference;
+    using MutableReference = CheckedUnaryOperator_Details::MutableReference;
+    using LogicalNot = CheckedUnaryOperator_Details::LogicalNot;
+    using BitwiseNot = CheckedUnaryOperator_Details::BitwiseNot;
+    using TypeCast = CheckedUnaryOperator_Details::TypeCast;
+    using Is = CheckedUnaryOperator_Details::Is;
+    using IsEnumVariant = CheckedUnaryOperator_Details::IsEnumVariant;
+    using IsSome = CheckedUnaryOperator_Details::IsSome;
+    using IsNone = CheckedUnaryOperator_Details::IsNone;
+    using Sizeof = CheckedUnaryOperator_Details::Sizeof;
+ErrorOr<DeprecatedString> debug_description() const;
+};
+namespace MaybeResolvedScope_Details {
+struct Resolved{
+types::ScopeId value;
+template<typename _MemberT0>
+Resolved(_MemberT0&& member_0):
+value{ forward<_MemberT0>(member_0)}
+{}
+};
+struct Unresolved {
+NonnullRefPtr<typename types::MaybeResolvedScope> parent_scope;
+DeprecatedString relative_name;
+template<typename _MemberT0, typename _MemberT1>
+Unresolved(_MemberT0&& member_0, _MemberT1&& member_1):
+parent_scope{ forward<_MemberT0>(member_0)},
+relative_name{ forward<_MemberT1>(member_1)}
+{}
+};
+}
+struct MaybeResolvedScope : public Variant<MaybeResolvedScope_Details::Resolved, MaybeResolvedScope_Details::Unresolved>, public RefCounted<MaybeResolvedScope> {
+using Variant<MaybeResolvedScope_Details::Resolved, MaybeResolvedScope_Details::Unresolved>::Variant;
+    using Resolved = MaybeResolvedScope_Details::Resolved;
+    using Unresolved = MaybeResolvedScope_Details::Unresolved;
+template<typename V, typename... Args> static auto __jakt_create(Args&&... args) {
+return adopt_nonnull_ref_or_enomem(new (nothrow) MaybeResolvedScope(V(forward<Args>(args)...)));
+}
+ErrorOr<DeprecatedString> debug_description() const;
+ErrorOr<NonnullRefPtr<typename types::MaybeResolvedScope>> try_resolve(NonnullRefPtr<types::CheckedProgram> const program) const;
+};
+namespace StructLikeId_Details {
+struct Struct{
+JaktInternal::Optional<JaktInternal::DynamicArray<types::TypeId>> generic_arguments;
+types::StructId value;
+template<typename _MemberT0, typename _MemberT1>
+Struct(_MemberT0&& member_0, _MemberT1&& member_1):
+generic_arguments{ forward<_MemberT0>(member_0)},
+value{ forward<_MemberT1>(member_1)}
+{}
+};
+struct Enum{
+JaktInternal::Optional<JaktInternal::DynamicArray<types::TypeId>> generic_arguments;
+types::EnumId value;
+template<typename _MemberT0, typename _MemberT1>
+Enum(_MemberT0&& member_0, _MemberT1&& member_1):
+generic_arguments{ forward<_MemberT0>(member_0)},
+value{ forward<_MemberT1>(member_1)}
+{}
+};
+struct Trait{
+JaktInternal::Optional<JaktInternal::DynamicArray<types::TypeId>> generic_arguments;
+types::TraitId value;
+template<typename _MemberT0, typename _MemberT1>
+Trait(_MemberT0&& member_0, _MemberT1&& member_1):
+generic_arguments{ forward<_MemberT0>(member_0)},
+value{ forward<_MemberT1>(member_1)}
+{}
+};
+}
+struct StructLikeId : public Variant<StructLikeId_Details::Struct, StructLikeId_Details::Enum, StructLikeId_Details::Trait> {
+using Variant<StructLikeId_Details::Struct, StructLikeId_Details::Enum, StructLikeId_Details::Trait>::Variant;
+    using Struct = StructLikeId_Details::Struct;
+    using Enum = StructLikeId_Details::Enum;
+    using Trait = StructLikeId_Details::Trait;
+ErrorOr<DeprecatedString> debug_description() const;
+JaktInternal::Optional<JaktInternal::DynamicArray<types::TypeId>> const& generic_arguments() const { switch(this->index()) {case 0 /* Struct */: return this->template get<StructLikeId::Struct>().generic_arguments;
+case 1 /* Enum */: return this->template get<StructLikeId::Enum>().generic_arguments;
+case 2 /* Trait */: return this->template get<StructLikeId::Trait>().generic_arguments;
+default: VERIFY_NOT_REACHED();
+}
+}
+ErrorOr<JaktInternal::DynamicArray<types::TypeId>> generic_parameters(NonnullRefPtr<types::CheckedProgram> const& program) const;
+ErrorOr<types::ScopeId> scope_id(NonnullRefPtr<types::CheckedProgram> const& program) const;
+};
+struct CheckedField {
   public:
-types::StringLiteral value;types::TypeId type_id;bool may_throw;DeprecatedString to_string() const;
-CheckedStringLiteral(types::StringLiteral a_value, types::TypeId a_type_id, bool a_may_throw);
+types::VarId variable_id;JaktInternal::Optional<NonnullRefPtr<typename types::CheckedExpression>> default_value;JaktInternal::Optional<NonnullRefPtr<typename parser::ParsedExpression>> default_value_expression;CheckedField(types::VarId a_variable_id, JaktInternal::Optional<NonnullRefPtr<typename types::CheckedExpression>> a_default_value, JaktInternal::Optional<NonnullRefPtr<typename parser::ParsedExpression>> a_default_value_expression);
 
 ErrorOr<DeprecatedString> debug_description() const;
-};struct CheckedCall {
+};struct ResolvedNamespace {
   public:
-JaktInternal::DynamicArray<types::ResolvedNamespace> namespace_;DeprecatedString name;JaktInternal::DynamicArray<JaktInternal::Tuple<DeprecatedString,NonnullRefPtr<typename types::CheckedExpression>>> args;JaktInternal::DynamicArray<types::TypeId> type_args;JaktInternal::Optional<types::FunctionId> function_id;types::TypeId return_type;bool callee_throws;JaktInternal::Optional<parser::ExternalName> external_name;JaktInternal::Optional<bool> force_inline;CheckedCall(JaktInternal::DynamicArray<types::ResolvedNamespace> a_namespace_, DeprecatedString a_name, JaktInternal::DynamicArray<JaktInternal::Tuple<DeprecatedString,NonnullRefPtr<typename types::CheckedExpression>>> a_args, JaktInternal::DynamicArray<types::TypeId> a_type_args, JaktInternal::Optional<types::FunctionId> a_function_id, types::TypeId a_return_type, bool a_callee_throws, JaktInternal::Optional<parser::ExternalName> a_external_name, JaktInternal::Optional<bool> a_force_inline);
+DeprecatedString name;JaktInternal::Optional<parser::ExternalName> external_name;JaktInternal::Optional<JaktInternal::DynamicArray<types::TypeId>> generic_parameters;ResolvedNamespace(DeprecatedString a_name, JaktInternal::Optional<parser::ExternalName> a_external_name, JaktInternal::Optional<JaktInternal::DynamicArray<types::TypeId>> a_generic_parameters);
 
 parser::ExternalName name_for_codegen() const;
-ErrorOr<DeprecatedString> debug_description() const;
-};struct OperatorTraitImplementation {
-  public:
-types::TraitId trait_id;JaktInternal::DynamicArray<types::TypeId> trait_generic_arguments;types::CheckedCall call_expression;OperatorTraitImplementation(types::TraitId a_trait_id, JaktInternal::DynamicArray<types::TypeId> a_trait_generic_arguments, types::CheckedCall a_call_expression);
-
 ErrorOr<DeprecatedString> debug_description() const;
 };struct CheckedBinaryOperator {
   public:
 parser::BinaryOperator op;JaktInternal::Optional<types::OperatorTraitImplementation> trait_implementation;CheckedBinaryOperator(parser::BinaryOperator a_op, JaktInternal::Optional<types::OperatorTraitImplementation> a_trait_implementation);
 
 ErrorOr<DeprecatedString> debug_description() const;
-};struct VarId {
+};struct CheckedEnumVariantBinding {
   public:
-types::ModuleId module;size_t id;VarId(types::ModuleId a_module, size_t a_id);
+JaktInternal::Optional<DeprecatedString> name;DeprecatedString binding;types::TypeId type_id;utility::Span span;CheckedEnumVariantBinding(JaktInternal::Optional<DeprecatedString> a_name, DeprecatedString a_binding, types::TypeId a_type_id, utility::Span a_span);
 
 ErrorOr<DeprecatedString> debug_description() const;
 };namespace CheckedExpression_Details {
@@ -1470,551 +2126,35 @@ types::TypeId type() const;
 ErrorOr<types::BlockControlFlow> control_flow() const;
 bool is_mutable(NonnullRefPtr<types::CheckedProgram> const program) const;
 };
-class CheckedVariable : public RefCounted<CheckedVariable>, public Weakable<CheckedVariable> {
-  public:
-virtual ~CheckedVariable() = default;
-DeprecatedString name;types::TypeId type_id;bool is_mutable;utility::Span definition_span;JaktInternal::Optional<utility::Span> type_span;types::CheckedVisibility visibility;JaktInternal::Optional<types::ScopeId> owner_scope;JaktInternal::Optional<parser::ExternalName> external_name;ErrorOr<NonnullRefPtr<types::CheckedVariable>> map_types(Function<ErrorOr<types::TypeId>(types::TypeId)> const& map) const;
-parser::ExternalName name_for_codegen() const;
-protected:
-explicit CheckedVariable(DeprecatedString a_name, types::TypeId a_type_id, bool a_is_mutable, utility::Span a_definition_span, JaktInternal::Optional<utility::Span> a_type_span, types::CheckedVisibility a_visibility, JaktInternal::Optional<types::ScopeId> a_owner_scope, JaktInternal::Optional<parser::ExternalName> a_external_name);
-public:
-static ErrorOr<NonnullRefPtr<CheckedVariable>> __jakt_create(DeprecatedString name, types::TypeId type_id, bool is_mutable, utility::Span definition_span, JaktInternal::Optional<utility::Span> type_span, types::CheckedVisibility visibility, JaktInternal::Optional<types::ScopeId> owner_scope, JaktInternal::Optional<parser::ExternalName> external_name);
-
-ErrorOr<DeprecatedString> debug_description() const;
-};struct FieldRecord {
-  public:
-types::StructId struct_id;types::VarId field_id;FieldRecord(types::StructId a_struct_id, types::VarId a_field_id);
-
-ErrorOr<DeprecatedString> debug_description() const;
-};class FunctionGenerics : public RefCounted<FunctionGenerics>, public Weakable<FunctionGenerics> {
-  public:
-virtual ~FunctionGenerics() = default;
-types::ScopeId base_scope_id;JaktInternal::DynamicArray<types::CheckedParameter> base_params;JaktInternal::DynamicArray<types::FunctionGenericParameter> params;JaktInternal::DynamicArray<JaktInternal::DynamicArray<types::TypeId>> specializations;protected:
-explicit FunctionGenerics(types::ScopeId a_base_scope_id, JaktInternal::DynamicArray<types::CheckedParameter> a_base_params, JaktInternal::DynamicArray<types::FunctionGenericParameter> a_params, JaktInternal::DynamicArray<JaktInternal::DynamicArray<types::TypeId>> a_specializations);
-public:
-static ErrorOr<NonnullRefPtr<FunctionGenerics>> __jakt_create(types::ScopeId base_scope_id, JaktInternal::DynamicArray<types::CheckedParameter> base_params, JaktInternal::DynamicArray<types::FunctionGenericParameter> params, JaktInternal::DynamicArray<JaktInternal::DynamicArray<types::TypeId>> specializations);
-
-bool is_specialized_for_types(JaktInternal::DynamicArray<types::TypeId> const types) const;
-ErrorOr<DeprecatedString> debug_description() const;
-};namespace Type_Details {
-struct Void {
-};
-struct Bool {
-};
-struct U8 {
-};
-struct U16 {
-};
-struct U32 {
-};
-struct U64 {
-};
-struct I8 {
-};
-struct I16 {
-};
-struct I32 {
-};
-struct I64 {
-};
-struct F32 {
-};
-struct F64 {
-};
-struct Usize {
-};
-struct JaktString {
-};
-struct CChar {
-};
-struct CInt {
-};
-struct Unknown {
-};
-struct Never {
-};
-struct TypeVariable {
-DeprecatedString name;
-JaktInternal::DynamicArray<types::TypeId> trait_implementations;
-template<typename _MemberT0, typename _MemberT1>
-TypeVariable(_MemberT0&& member_0, _MemberT1&& member_1):
-name{ forward<_MemberT0>(member_0)},
-trait_implementations{ forward<_MemberT1>(member_1)}
-{}
-};
-struct GenericInstance {
-types::StructId id;
-JaktInternal::DynamicArray<types::TypeId> args;
-template<typename _MemberT0, typename _MemberT1>
-GenericInstance(_MemberT0&& member_0, _MemberT1&& member_1):
-id{ forward<_MemberT0>(member_0)},
-args{ forward<_MemberT1>(member_1)}
-{}
-};
-struct GenericEnumInstance {
-types::EnumId id;
-JaktInternal::DynamicArray<types::TypeId> args;
-template<typename _MemberT0, typename _MemberT1>
-GenericEnumInstance(_MemberT0&& member_0, _MemberT1&& member_1):
-id{ forward<_MemberT0>(member_0)},
-args{ forward<_MemberT1>(member_1)}
-{}
-};
-struct GenericTraitInstance {
-types::TraitId id;
-JaktInternal::DynamicArray<types::TypeId> args;
-template<typename _MemberT0, typename _MemberT1>
-GenericTraitInstance(_MemberT0&& member_0, _MemberT1&& member_1):
-id{ forward<_MemberT0>(member_0)},
-args{ forward<_MemberT1>(member_1)}
-{}
-};
-struct GenericResolvedType {
-types::StructId id;
-JaktInternal::DynamicArray<types::TypeId> args;
-template<typename _MemberT0, typename _MemberT1>
-GenericResolvedType(_MemberT0&& member_0, _MemberT1&& member_1):
-id{ forward<_MemberT0>(member_0)},
-args{ forward<_MemberT1>(member_1)}
-{}
-};
-struct Struct{
-types::StructId value;
+namespace NumericOrStringValue_Details {
+struct StringValue{
+DeprecatedString value;
 template<typename _MemberT0>
-Struct(_MemberT0&& member_0):
+StringValue(_MemberT0&& member_0):
 value{ forward<_MemberT0>(member_0)}
 {}
 };
-struct Enum{
-types::EnumId value;
+struct SignedNumericValue{
+i64 value;
 template<typename _MemberT0>
-Enum(_MemberT0&& member_0):
+SignedNumericValue(_MemberT0&& member_0):
 value{ forward<_MemberT0>(member_0)}
 {}
 };
-struct RawPtr{
-types::TypeId value;
+struct UnsignedNumericValue{
+u64 value;
 template<typename _MemberT0>
-RawPtr(_MemberT0&& member_0):
-value{ forward<_MemberT0>(member_0)}
-{}
-};
-struct Trait{
-types::TraitId value;
-template<typename _MemberT0>
-Trait(_MemberT0&& member_0):
-value{ forward<_MemberT0>(member_0)}
-{}
-};
-struct Reference{
-types::TypeId value;
-template<typename _MemberT0>
-Reference(_MemberT0&& member_0):
-value{ forward<_MemberT0>(member_0)}
-{}
-};
-struct MutableReference{
-types::TypeId value;
-template<typename _MemberT0>
-MutableReference(_MemberT0&& member_0):
-value{ forward<_MemberT0>(member_0)}
-{}
-};
-struct Function {
-JaktInternal::DynamicArray<types::TypeId> params;
-bool can_throw;
-types::TypeId return_type_id;
-types::FunctionId pseudo_function_id;
-template<typename _MemberT0, typename _MemberT1, typename _MemberT2, typename _MemberT3>
-Function(_MemberT0&& member_0, _MemberT1&& member_1, _MemberT2&& member_2, _MemberT3&& member_3):
-params{ forward<_MemberT0>(member_0)},
-can_throw{ forward<_MemberT1>(member_1)},
-return_type_id{ forward<_MemberT2>(member_2)},
-pseudo_function_id{ forward<_MemberT3>(member_3)}
-{}
-};
-struct Self {
-};
-}
-struct Type : public Variant<Type_Details::Void, Type_Details::Bool, Type_Details::U8, Type_Details::U16, Type_Details::U32, Type_Details::U64, Type_Details::I8, Type_Details::I16, Type_Details::I32, Type_Details::I64, Type_Details::F32, Type_Details::F64, Type_Details::Usize, Type_Details::JaktString, Type_Details::CChar, Type_Details::CInt, Type_Details::Unknown, Type_Details::Never, Type_Details::TypeVariable, Type_Details::GenericInstance, Type_Details::GenericEnumInstance, Type_Details::GenericTraitInstance, Type_Details::GenericResolvedType, Type_Details::Struct, Type_Details::Enum, Type_Details::RawPtr, Type_Details::Trait, Type_Details::Reference, Type_Details::MutableReference, Type_Details::Function, Type_Details::Self>, public RefCounted<Type> {
-using Variant<Type_Details::Void, Type_Details::Bool, Type_Details::U8, Type_Details::U16, Type_Details::U32, Type_Details::U64, Type_Details::I8, Type_Details::I16, Type_Details::I32, Type_Details::I64, Type_Details::F32, Type_Details::F64, Type_Details::Usize, Type_Details::JaktString, Type_Details::CChar, Type_Details::CInt, Type_Details::Unknown, Type_Details::Never, Type_Details::TypeVariable, Type_Details::GenericInstance, Type_Details::GenericEnumInstance, Type_Details::GenericTraitInstance, Type_Details::GenericResolvedType, Type_Details::Struct, Type_Details::Enum, Type_Details::RawPtr, Type_Details::Trait, Type_Details::Reference, Type_Details::MutableReference, Type_Details::Function, Type_Details::Self>::Variant;
-    using Void = Type_Details::Void;
-    using Bool = Type_Details::Bool;
-    using U8 = Type_Details::U8;
-    using U16 = Type_Details::U16;
-    using U32 = Type_Details::U32;
-    using U64 = Type_Details::U64;
-    using I8 = Type_Details::I8;
-    using I16 = Type_Details::I16;
-    using I32 = Type_Details::I32;
-    using I64 = Type_Details::I64;
-    using F32 = Type_Details::F32;
-    using F64 = Type_Details::F64;
-    using Usize = Type_Details::Usize;
-    using JaktString = Type_Details::JaktString;
-    using CChar = Type_Details::CChar;
-    using CInt = Type_Details::CInt;
-    using Unknown = Type_Details::Unknown;
-    using Never = Type_Details::Never;
-    using TypeVariable = Type_Details::TypeVariable;
-    using GenericInstance = Type_Details::GenericInstance;
-    using GenericEnumInstance = Type_Details::GenericEnumInstance;
-    using GenericTraitInstance = Type_Details::GenericTraitInstance;
-    using GenericResolvedType = Type_Details::GenericResolvedType;
-    using Struct = Type_Details::Struct;
-    using Enum = Type_Details::Enum;
-    using RawPtr = Type_Details::RawPtr;
-    using Trait = Type_Details::Trait;
-    using Reference = Type_Details::Reference;
-    using MutableReference = Type_Details::MutableReference;
-    using Function = Type_Details::Function;
-    using Self = Type_Details::Self;
-template<typename V, typename... Args> static auto __jakt_create(Args&&... args) {
-return adopt_nonnull_ref_or_enomem(new (nothrow) Type(V(forward<Args>(args)...)));
-}
-ErrorOr<DeprecatedString> debug_description() const;
-u64 max() const;
-bool equals(NonnullRefPtr<typename types::Type> const rhs) const;
-ErrorOr<DeprecatedString> constructor_name() const;
-bool is_concrete() const;
-i64 get_bits() const;
-i64 specificity(NonnullRefPtr<types::CheckedProgram> const program, i64 const base_specificity) const;
-types::BuiltinType as_builtin_type() const;
-bool is_builtin() const;
-i64 min() const;
-ErrorOr<types::TypeId> flip_signedness() const;
-bool is_boxed(NonnullRefPtr<types::CheckedProgram> const program) const;
-bool is_signed() const;
-};
-namespace CheckedCapture_Details {
-struct ByValue {
-DeprecatedString name;
-utility::Span span;
-template<typename _MemberT0, typename _MemberT1>
-ByValue(_MemberT0&& member_0, _MemberT1&& member_1):
-name{ forward<_MemberT0>(member_0)},
-span{ forward<_MemberT1>(member_1)}
-{}
-};
-struct ByReference {
-DeprecatedString name;
-utility::Span span;
-template<typename _MemberT0, typename _MemberT1>
-ByReference(_MemberT0&& member_0, _MemberT1&& member_1):
-name{ forward<_MemberT0>(member_0)},
-span{ forward<_MemberT1>(member_1)}
-{}
-};
-struct ByMutableReference {
-DeprecatedString name;
-utility::Span span;
-template<typename _MemberT0, typename _MemberT1>
-ByMutableReference(_MemberT0&& member_0, _MemberT1&& member_1):
-name{ forward<_MemberT0>(member_0)},
-span{ forward<_MemberT1>(member_1)}
-{}
-};
-struct ByComptimeDependency {
-DeprecatedString name;
-utility::Span span;
-template<typename _MemberT0, typename _MemberT1>
-ByComptimeDependency(_MemberT0&& member_0, _MemberT1&& member_1):
-name{ forward<_MemberT0>(member_0)},
-span{ forward<_MemberT1>(member_1)}
-{}
-};
-struct AllByReference {
-DeprecatedString name;
-utility::Span span;
-template<typename _MemberT0, typename _MemberT1>
-AllByReference(_MemberT0&& member_0, _MemberT1&& member_1):
-name{ forward<_MemberT0>(member_0)},
-span{ forward<_MemberT1>(member_1)}
-{}
-};
-}
-struct CheckedCapture : public Variant<CheckedCapture_Details::ByValue, CheckedCapture_Details::ByReference, CheckedCapture_Details::ByMutableReference, CheckedCapture_Details::ByComptimeDependency, CheckedCapture_Details::AllByReference> {
-using Variant<CheckedCapture_Details::ByValue, CheckedCapture_Details::ByReference, CheckedCapture_Details::ByMutableReference, CheckedCapture_Details::ByComptimeDependency, CheckedCapture_Details::AllByReference>::Variant;
-    using ByValue = CheckedCapture_Details::ByValue;
-    using ByReference = CheckedCapture_Details::ByReference;
-    using ByMutableReference = CheckedCapture_Details::ByMutableReference;
-    using ByComptimeDependency = CheckedCapture_Details::ByComptimeDependency;
-    using AllByReference = CheckedCapture_Details::AllByReference;
-ErrorOr<DeprecatedString> debug_description() const;
-DeprecatedString const& name() const { switch(this->index()) {case 0 /* ByValue */: return this->template get<CheckedCapture::ByValue>().name;
-case 1 /* ByReference */: return this->template get<CheckedCapture::ByReference>().name;
-case 2 /* ByMutableReference */: return this->template get<CheckedCapture::ByMutableReference>().name;
-case 3 /* ByComptimeDependency */: return this->template get<CheckedCapture::ByComptimeDependency>().name;
-case 4 /* AllByReference */: return this->template get<CheckedCapture::AllByReference>().name;
-default: VERIFY_NOT_REACHED();
-}
-}
-utility::Span const& span() const { switch(this->index()) {case 0 /* ByValue */: return this->template get<CheckedCapture::ByValue>().span;
-case 1 /* ByReference */: return this->template get<CheckedCapture::ByReference>().span;
-case 2 /* ByMutableReference */: return this->template get<CheckedCapture::ByMutableReference>().span;
-case 3 /* ByComptimeDependency */: return this->template get<CheckedCapture::ByComptimeDependency>().span;
-case 4 /* AllByReference */: return this->template get<CheckedCapture::AllByReference>().span;
-default: VERIFY_NOT_REACHED();
-}
-}
-};
-namespace FunctionGenericParameterKind_Details {
-struct InferenceGuide {
-};
-struct Parameter {
-};
-}
-struct FunctionGenericParameterKind : public Variant<FunctionGenericParameterKind_Details::InferenceGuide, FunctionGenericParameterKind_Details::Parameter> {
-using Variant<FunctionGenericParameterKind_Details::InferenceGuide, FunctionGenericParameterKind_Details::Parameter>::Variant;
-    using InferenceGuide = FunctionGenericParameterKind_Details::InferenceGuide;
-    using Parameter = FunctionGenericParameterKind_Details::Parameter;
-ErrorOr<DeprecatedString> debug_description() const;
-};
-struct CheckedGenericParameter {
-  public:
-types::TypeId type_id;JaktInternal::DynamicArray<types::TraitId> constraints;utility::Span span;static ErrorOr<types::CheckedGenericParameter> make(types::TypeId const type_id, utility::Span const span);
-CheckedGenericParameter(types::TypeId a_type_id, JaktInternal::DynamicArray<types::TraitId> a_constraints, utility::Span a_span);
-
-ErrorOr<DeprecatedString> debug_description() const;
-};struct FunctionGenericParameter {
-  public:
-types::FunctionGenericParameterKind kind;types::CheckedGenericParameter checked_parameter;static ErrorOr<types::FunctionGenericParameter> parameter(types::TypeId const type_id, utility::Span const span);
-types::TypeId type_id() const;
-FunctionGenericParameter(types::FunctionGenericParameterKind a_kind, types::CheckedGenericParameter a_checked_parameter);
-
-ErrorOr<DeprecatedString> debug_description() const;
-};namespace CheckedStatement_Details {
-struct Expression {
-NonnullRefPtr<typename types::CheckedExpression> expr;
-utility::Span span;
-template<typename _MemberT0, typename _MemberT1>
-Expression(_MemberT0&& member_0, _MemberT1&& member_1):
-expr{ forward<_MemberT0>(member_0)},
-span{ forward<_MemberT1>(member_1)}
-{}
-};
-struct Defer {
-NonnullRefPtr<typename types::CheckedStatement> statement;
-utility::Span span;
-template<typename _MemberT0, typename _MemberT1>
-Defer(_MemberT0&& member_0, _MemberT1&& member_1):
-statement{ forward<_MemberT0>(member_0)},
-span{ forward<_MemberT1>(member_1)}
-{}
-};
-struct DestructuringAssignment {
-JaktInternal::DynamicArray<NonnullRefPtr<typename types::CheckedStatement>> vars;
-NonnullRefPtr<typename types::CheckedStatement> var_decl;
-utility::Span span;
-template<typename _MemberT0, typename _MemberT1, typename _MemberT2>
-DestructuringAssignment(_MemberT0&& member_0, _MemberT1&& member_1, _MemberT2&& member_2):
-vars{ forward<_MemberT0>(member_0)},
-var_decl{ forward<_MemberT1>(member_1)},
-span{ forward<_MemberT2>(member_2)}
-{}
-};
-struct VarDecl {
-types::VarId var_id;
-NonnullRefPtr<typename types::CheckedExpression> init;
-utility::Span span;
-template<typename _MemberT0, typename _MemberT1, typename _MemberT2>
-VarDecl(_MemberT0&& member_0, _MemberT1&& member_1, _MemberT2&& member_2):
-var_id{ forward<_MemberT0>(member_0)},
-init{ forward<_MemberT1>(member_1)},
-span{ forward<_MemberT2>(member_2)}
-{}
-};
-struct If {
-NonnullRefPtr<typename types::CheckedExpression> condition;
-types::CheckedBlock then_block;
-JaktInternal::Optional<NonnullRefPtr<typename types::CheckedStatement>> else_statement;
-utility::Span span;
-template<typename _MemberT0, typename _MemberT1, typename _MemberT2, typename _MemberT3>
-If(_MemberT0&& member_0, _MemberT1&& member_1, _MemberT2&& member_2, _MemberT3&& member_3):
-condition{ forward<_MemberT0>(member_0)},
-then_block{ forward<_MemberT1>(member_1)},
-else_statement{ forward<_MemberT2>(member_2)},
-span{ forward<_MemberT3>(member_3)}
-{}
-};
-struct Block {
-types::CheckedBlock block;
-utility::Span span;
-template<typename _MemberT0, typename _MemberT1>
-Block(_MemberT0&& member_0, _MemberT1&& member_1):
-block{ forward<_MemberT0>(member_0)},
-span{ forward<_MemberT1>(member_1)}
-{}
-};
-struct Loop {
-types::CheckedBlock block;
-utility::Span span;
-template<typename _MemberT0, typename _MemberT1>
-Loop(_MemberT0&& member_0, _MemberT1&& member_1):
-block{ forward<_MemberT0>(member_0)},
-span{ forward<_MemberT1>(member_1)}
-{}
-};
-struct While {
-NonnullRefPtr<typename types::CheckedExpression> condition;
-types::CheckedBlock block;
-utility::Span span;
-template<typename _MemberT0, typename _MemberT1, typename _MemberT2>
-While(_MemberT0&& member_0, _MemberT1&& member_1, _MemberT2&& member_2):
-condition{ forward<_MemberT0>(member_0)},
-block{ forward<_MemberT1>(member_1)},
-span{ forward<_MemberT2>(member_2)}
-{}
-};
-struct Return {
-JaktInternal::Optional<NonnullRefPtr<typename types::CheckedExpression>> val;
-JaktInternal::Optional<utility::Span> span;
-template<typename _MemberT0, typename _MemberT1>
-Return(_MemberT0&& member_0, _MemberT1&& member_1):
-val{ forward<_MemberT0>(member_0)},
-span{ forward<_MemberT1>(member_1)}
-{}
-};
-struct Break{
-utility::Span value;
-template<typename _MemberT0>
-Break(_MemberT0&& member_0):
-value{ forward<_MemberT0>(member_0)}
-{}
-};
-struct Continue{
-utility::Span value;
-template<typename _MemberT0>
-Continue(_MemberT0&& member_0):
-value{ forward<_MemberT0>(member_0)}
-{}
-};
-struct Throw {
-NonnullRefPtr<typename types::CheckedExpression> expr;
-utility::Span span;
-template<typename _MemberT0, typename _MemberT1>
-Throw(_MemberT0&& member_0, _MemberT1&& member_1):
-expr{ forward<_MemberT0>(member_0)},
-span{ forward<_MemberT1>(member_1)}
-{}
-};
-struct Yield {
-NonnullRefPtr<typename types::CheckedExpression> expr;
-utility::Span span;
-template<typename _MemberT0, typename _MemberT1>
-Yield(_MemberT0&& member_0, _MemberT1&& member_1):
-expr{ forward<_MemberT0>(member_0)},
-span{ forward<_MemberT1>(member_1)}
-{}
-};
-struct InlineCpp {
-JaktInternal::DynamicArray<DeprecatedString> lines;
-utility::Span span;
-template<typename _MemberT0, typename _MemberT1>
-InlineCpp(_MemberT0&& member_0, _MemberT1&& member_1):
-lines{ forward<_MemberT0>(member_0)},
-span{ forward<_MemberT1>(member_1)}
-{}
-};
-struct Garbage{
-utility::Span value;
-template<typename _MemberT0>
-Garbage(_MemberT0&& member_0):
+UnsignedNumericValue(_MemberT0&& member_0):
 value{ forward<_MemberT0>(member_0)}
 {}
 };
 }
-struct CheckedStatement : public Variant<CheckedStatement_Details::Expression, CheckedStatement_Details::Defer, CheckedStatement_Details::DestructuringAssignment, CheckedStatement_Details::VarDecl, CheckedStatement_Details::If, CheckedStatement_Details::Block, CheckedStatement_Details::Loop, CheckedStatement_Details::While, CheckedStatement_Details::Return, CheckedStatement_Details::Break, CheckedStatement_Details::Continue, CheckedStatement_Details::Throw, CheckedStatement_Details::Yield, CheckedStatement_Details::InlineCpp, CheckedStatement_Details::Garbage>, public RefCounted<CheckedStatement> {
-using Variant<CheckedStatement_Details::Expression, CheckedStatement_Details::Defer, CheckedStatement_Details::DestructuringAssignment, CheckedStatement_Details::VarDecl, CheckedStatement_Details::If, CheckedStatement_Details::Block, CheckedStatement_Details::Loop, CheckedStatement_Details::While, CheckedStatement_Details::Return, CheckedStatement_Details::Break, CheckedStatement_Details::Continue, CheckedStatement_Details::Throw, CheckedStatement_Details::Yield, CheckedStatement_Details::InlineCpp, CheckedStatement_Details::Garbage>::Variant;
-    using Expression = CheckedStatement_Details::Expression;
-    using Defer = CheckedStatement_Details::Defer;
-    using DestructuringAssignment = CheckedStatement_Details::DestructuringAssignment;
-    using VarDecl = CheckedStatement_Details::VarDecl;
-    using If = CheckedStatement_Details::If;
-    using Block = CheckedStatement_Details::Block;
-    using Loop = CheckedStatement_Details::Loop;
-    using While = CheckedStatement_Details::While;
-    using Return = CheckedStatement_Details::Return;
-    using Break = CheckedStatement_Details::Break;
-    using Continue = CheckedStatement_Details::Continue;
-    using Throw = CheckedStatement_Details::Throw;
-    using Yield = CheckedStatement_Details::Yield;
-    using InlineCpp = CheckedStatement_Details::InlineCpp;
-    using Garbage = CheckedStatement_Details::Garbage;
-template<typename V, typename... Args> static auto __jakt_create(Args&&... args) {
-return adopt_nonnull_ref_or_enomem(new (nothrow) CheckedStatement(V(forward<Args>(args)...)));
-}
+struct NumericOrStringValue : public Variant<NumericOrStringValue_Details::StringValue, NumericOrStringValue_Details::SignedNumericValue, NumericOrStringValue_Details::UnsignedNumericValue> {
+using Variant<NumericOrStringValue_Details::StringValue, NumericOrStringValue_Details::SignedNumericValue, NumericOrStringValue_Details::UnsignedNumericValue>::Variant;
+    using StringValue = NumericOrStringValue_Details::StringValue;
+    using SignedNumericValue = NumericOrStringValue_Details::SignedNumericValue;
+    using UnsignedNumericValue = NumericOrStringValue_Details::UnsignedNumericValue;
 ErrorOr<DeprecatedString> debug_description() const;
-JaktInternal::Optional<utility::Span> span() const;
-static JaktInternal::Optional<NonnullRefPtr<typename types::CheckedStatement>> none();
-};
-struct CheckedStruct {
-  public:
-DeprecatedString name;utility::Span name_span;JaktInternal::DynamicArray<types::CheckedGenericParameter> generic_parameters;JaktInternal::DynamicArray<types::CheckedField> fields;types::ScopeId scope_id;parser::DefinitionLinkage definition_linkage;JaktInternal::Dictionary<DeprecatedString,JaktInternal::DynamicArray<JaktInternal::Tuple<types::TraitId,JaktInternal::DynamicArray<types::TypeId>>>> trait_implementations;parser::RecordType record_type;types::TypeId type_id;JaktInternal::Optional<types::StructId> super_struct_id;JaktInternal::Optional<parser::ExternalName> external_name;JaktInternal::Optional<types::TypeId> implements_type;CheckedStruct(DeprecatedString a_name, utility::Span a_name_span, JaktInternal::DynamicArray<types::CheckedGenericParameter> a_generic_parameters, JaktInternal::DynamicArray<types::CheckedField> a_fields, types::ScopeId a_scope_id, parser::DefinitionLinkage a_definition_linkage, JaktInternal::Dictionary<DeprecatedString,JaktInternal::DynamicArray<JaktInternal::Tuple<types::TraitId,JaktInternal::DynamicArray<types::TypeId>>>> a_trait_implementations, parser::RecordType a_record_type, types::TypeId a_type_id, JaktInternal::Optional<types::StructId> a_super_struct_id, JaktInternal::Optional<parser::ExternalName> a_external_name, JaktInternal::Optional<types::TypeId> a_implements_type);
-
-parser::ExternalName name_for_codegen() const;
-ErrorOr<DeprecatedString> debug_description() const;
-};namespace BuiltinType_Details {
-struct Void {
-};
-struct Bool {
-};
-struct U8 {
-};
-struct U16 {
-};
-struct U32 {
-};
-struct U64 {
-};
-struct I8 {
-};
-struct I16 {
-};
-struct I32 {
-};
-struct I64 {
-};
-struct F32 {
-};
-struct F64 {
-};
-struct Usize {
-};
-struct JaktString {
-};
-struct CChar {
-};
-struct CInt {
-};
-struct Unknown {
-};
-struct Never {
-};
-}
-struct BuiltinType : public Variant<BuiltinType_Details::Void, BuiltinType_Details::Bool, BuiltinType_Details::U8, BuiltinType_Details::U16, BuiltinType_Details::U32, BuiltinType_Details::U64, BuiltinType_Details::I8, BuiltinType_Details::I16, BuiltinType_Details::I32, BuiltinType_Details::I64, BuiltinType_Details::F32, BuiltinType_Details::F64, BuiltinType_Details::Usize, BuiltinType_Details::JaktString, BuiltinType_Details::CChar, BuiltinType_Details::CInt, BuiltinType_Details::Unknown, BuiltinType_Details::Never> {
-using Variant<BuiltinType_Details::Void, BuiltinType_Details::Bool, BuiltinType_Details::U8, BuiltinType_Details::U16, BuiltinType_Details::U32, BuiltinType_Details::U64, BuiltinType_Details::I8, BuiltinType_Details::I16, BuiltinType_Details::I32, BuiltinType_Details::I64, BuiltinType_Details::F32, BuiltinType_Details::F64, BuiltinType_Details::Usize, BuiltinType_Details::JaktString, BuiltinType_Details::CChar, BuiltinType_Details::CInt, BuiltinType_Details::Unknown, BuiltinType_Details::Never>::Variant;
-    using Void = BuiltinType_Details::Void;
-    using Bool = BuiltinType_Details::Bool;
-    using U8 = BuiltinType_Details::U8;
-    using U16 = BuiltinType_Details::U16;
-    using U32 = BuiltinType_Details::U32;
-    using U64 = BuiltinType_Details::U64;
-    using I8 = BuiltinType_Details::I8;
-    using I16 = BuiltinType_Details::I16;
-    using I32 = BuiltinType_Details::I32;
-    using I64 = BuiltinType_Details::I64;
-    using F32 = BuiltinType_Details::F32;
-    using F64 = BuiltinType_Details::F64;
-    using Usize = BuiltinType_Details::Usize;
-    using JaktString = BuiltinType_Details::JaktString;
-    using CChar = BuiltinType_Details::CChar;
-    using CInt = BuiltinType_Details::CInt;
-    using Unknown = BuiltinType_Details::Unknown;
-    using Never = BuiltinType_Details::Never;
-ErrorOr<DeprecatedString> debug_description() const;
-ErrorOr<DeprecatedString> constructor_name() const;
-size_t id() const;
 };
 namespace SafetyMode_Details {
 struct Safe {
@@ -2028,108 +2168,33 @@ using Variant<SafetyMode_Details::Safe, SafetyMode_Details::Unsafe>::Variant;
     using Unsafe = SafetyMode_Details::Unsafe;
 ErrorOr<DeprecatedString> debug_description() const;
 };
-class Scope : public RefCounted<Scope>, public Weakable<Scope> {
+class CheckedTrait : public RefCounted<CheckedTrait>, public Weakable<CheckedTrait> {
   public:
-virtual ~Scope() = default;
-JaktInternal::Optional<DeprecatedString> namespace_name;JaktInternal::Optional<parser::ExternalName> external_name;JaktInternal::Dictionary<DeprecatedString,types::VarId> vars;JaktInternal::Dictionary<DeprecatedString,types::Value> comptime_bindings;JaktInternal::Dictionary<DeprecatedString,types::StructId> structs;JaktInternal::Dictionary<DeprecatedString,JaktInternal::DynamicArray<types::FunctionId>> functions;JaktInternal::Dictionary<DeprecatedString,types::EnumId> enums;JaktInternal::Dictionary<DeprecatedString,types::TypeId> types;JaktInternal::Dictionary<DeprecatedString,types::TraitId> traits;JaktInternal::Dictionary<DeprecatedString,types::ModuleId> imports;JaktInternal::Dictionary<DeprecatedString,types::ScopeId> aliases;JaktInternal::Optional<types::ScopeId> parent;JaktInternal::Optional<types::ScopeId> alias_scope;JaktInternal::DynamicArray<types::ScopeId> children;bool can_throw;JaktInternal::Optional<DeprecatedString> import_path_if_extern;JaktInternal::Optional<JaktInternal::DynamicArray<types::ResolvedNamespace>> alias_path;JaktInternal::DynamicArray<parser::IncludeAction> after_extern_include;JaktInternal::DynamicArray<parser::IncludeAction> before_extern_include;DeprecatedString debug_name;JaktInternal::DynamicArray<types::ScopeId> resolution_mixins;bool is_block_scope;JaktInternal::Optional<JaktInternal::DynamicArray<types::ResolvedForallChunk>> resolved_forall_chunks;protected:
-explicit Scope(JaktInternal::Optional<DeprecatedString> a_namespace_name, JaktInternal::Optional<parser::ExternalName> a_external_name, JaktInternal::Dictionary<DeprecatedString,types::VarId> a_vars, JaktInternal::Dictionary<DeprecatedString,types::Value> a_comptime_bindings, JaktInternal::Dictionary<DeprecatedString,types::StructId> a_structs, JaktInternal::Dictionary<DeprecatedString,JaktInternal::DynamicArray<types::FunctionId>> a_functions, JaktInternal::Dictionary<DeprecatedString,types::EnumId> a_enums, JaktInternal::Dictionary<DeprecatedString,types::TypeId> a_types, JaktInternal::Dictionary<DeprecatedString,types::TraitId> a_traits, JaktInternal::Dictionary<DeprecatedString,types::ModuleId> a_imports, JaktInternal::Dictionary<DeprecatedString,types::ScopeId> a_aliases, JaktInternal::Optional<types::ScopeId> a_parent, JaktInternal::Optional<types::ScopeId> a_alias_scope, JaktInternal::DynamicArray<types::ScopeId> a_children, bool a_can_throw, JaktInternal::Optional<DeprecatedString> a_import_path_if_extern, JaktInternal::Optional<JaktInternal::DynamicArray<types::ResolvedNamespace>> a_alias_path, JaktInternal::DynamicArray<parser::IncludeAction> a_after_extern_include, JaktInternal::DynamicArray<parser::IncludeAction> a_before_extern_include, DeprecatedString a_debug_name, JaktInternal::DynamicArray<types::ScopeId> a_resolution_mixins, bool a_is_block_scope, JaktInternal::Optional<JaktInternal::DynamicArray<types::ResolvedForallChunk>> a_resolved_forall_chunks);
+virtual ~CheckedTrait() = default;
+DeprecatedString name;utility::Span name_span;types::CheckedTraitRequirements requirements;JaktInternal::DynamicArray<types::CheckedGenericParameter> generic_parameters;types::ScopeId scope_id;protected:
+explicit CheckedTrait(DeprecatedString a_name, utility::Span a_name_span, types::CheckedTraitRequirements a_requirements, JaktInternal::DynamicArray<types::CheckedGenericParameter> a_generic_parameters, types::ScopeId a_scope_id);
 public:
-static ErrorOr<NonnullRefPtr<Scope>> __jakt_create(JaktInternal::Optional<DeprecatedString> namespace_name, JaktInternal::Optional<parser::ExternalName> external_name, JaktInternal::Dictionary<DeprecatedString,types::VarId> vars, JaktInternal::Dictionary<DeprecatedString,types::Value> comptime_bindings, JaktInternal::Dictionary<DeprecatedString,types::StructId> structs, JaktInternal::Dictionary<DeprecatedString,JaktInternal::DynamicArray<types::FunctionId>> functions, JaktInternal::Dictionary<DeprecatedString,types::EnumId> enums, JaktInternal::Dictionary<DeprecatedString,types::TypeId> types, JaktInternal::Dictionary<DeprecatedString,types::TraitId> traits, JaktInternal::Dictionary<DeprecatedString,types::ModuleId> imports, JaktInternal::Dictionary<DeprecatedString,types::ScopeId> aliases, JaktInternal::Optional<types::ScopeId> parent, JaktInternal::Optional<types::ScopeId> alias_scope, JaktInternal::DynamicArray<types::ScopeId> children, bool can_throw, JaktInternal::Optional<DeprecatedString> import_path_if_extern, JaktInternal::Optional<JaktInternal::DynamicArray<types::ResolvedNamespace>> alias_path, JaktInternal::DynamicArray<parser::IncludeAction> after_extern_include, JaktInternal::DynamicArray<parser::IncludeAction> before_extern_include, DeprecatedString debug_name, JaktInternal::DynamicArray<types::ScopeId> resolution_mixins, bool is_block_scope, JaktInternal::Optional<JaktInternal::DynamicArray<types::ResolvedForallChunk>> resolved_forall_chunks);
+static ErrorOr<NonnullRefPtr<CheckedTrait>> __jakt_create(DeprecatedString name, utility::Span name_span, types::CheckedTraitRequirements requirements, JaktInternal::DynamicArray<types::CheckedGenericParameter> generic_parameters, types::ScopeId scope_id);
 
-JaktInternal::Optional<parser::ExternalName> namespace_name_for_codegen() const;
 ErrorOr<DeprecatedString> debug_description() const;
-};struct LoadedModule {
+};class CheckedFunction : public RefCounted<CheckedFunction>, public Weakable<CheckedFunction> {
   public:
-types::ModuleId module_id;utility::FileId file_id;LoadedModule(types::ModuleId a_module_id, utility::FileId a_file_id);
+virtual ~CheckedFunction() = default;
+DeprecatedString name;utility::Span name_span;types::CheckedVisibility visibility;types::TypeId return_type_id;JaktInternal::Optional<utility::Span> return_type_span;JaktInternal::DynamicArray<types::CheckedParameter> params;NonnullRefPtr<types::FunctionGenerics> generics;types::CheckedBlock block;bool can_throw;parser::FunctionType type;parser::FunctionLinkage linkage;types::ScopeId function_scope_id;JaktInternal::Optional<types::StructId> struct_id;bool is_instantiated;JaktInternal::Optional<parser::ParsedFunction> parsed_function;bool is_comptime;bool is_virtual;bool is_override;bool is_unsafe;JaktInternal::Optional<size_t> specialization_index;JaktInternal::Optional<types::ScopeId> owner_scope;bool is_fully_checked;JaktInternal::Optional<parser::ExternalName> external_name;JaktInternal::Optional<DeprecatedString> deprecated_message;JaktInternal::Optional<JaktInternal::DynamicArray<JaktInternal::Tuple<size_t,parser::ArgumentStoreLevel>>> stores_arguments;JaktInternal::Optional<bool> force_inline;ErrorOr<void> map_types(Function<ErrorOr<types::TypeId>(types::TypeId)> const& map);
+ErrorOr<bool> is_static() const;
+ErrorOr<bool> is_mutating() const;
+protected:
+explicit CheckedFunction(DeprecatedString a_name, utility::Span a_name_span, types::CheckedVisibility a_visibility, types::TypeId a_return_type_id, JaktInternal::Optional<utility::Span> a_return_type_span, JaktInternal::DynamicArray<types::CheckedParameter> a_params, NonnullRefPtr<types::FunctionGenerics> a_generics, types::CheckedBlock a_block, bool a_can_throw, parser::FunctionType a_type, parser::FunctionLinkage a_linkage, types::ScopeId a_function_scope_id, JaktInternal::Optional<types::StructId> a_struct_id, bool a_is_instantiated, JaktInternal::Optional<parser::ParsedFunction> a_parsed_function, bool a_is_comptime, bool a_is_virtual, bool a_is_override, bool a_is_unsafe, JaktInternal::Optional<size_t> a_specialization_index, JaktInternal::Optional<types::ScopeId> a_owner_scope, bool a_is_fully_checked, JaktInternal::Optional<parser::ExternalName> a_external_name, JaktInternal::Optional<DeprecatedString> a_deprecated_message, JaktInternal::Optional<JaktInternal::DynamicArray<JaktInternal::Tuple<size_t,parser::ArgumentStoreLevel>>> a_stores_arguments, JaktInternal::Optional<bool> a_force_inline);
+public:
+static ErrorOr<NonnullRefPtr<CheckedFunction>> __jakt_create(DeprecatedString name, utility::Span name_span, types::CheckedVisibility visibility, types::TypeId return_type_id, JaktInternal::Optional<utility::Span> return_type_span, JaktInternal::DynamicArray<types::CheckedParameter> params, NonnullRefPtr<types::FunctionGenerics> generics, types::CheckedBlock block, bool can_throw, parser::FunctionType type, parser::FunctionLinkage linkage, types::ScopeId function_scope_id, JaktInternal::Optional<types::StructId> struct_id, bool is_instantiated, JaktInternal::Optional<parser::ParsedFunction> parsed_function, bool is_comptime, bool is_virtual, bool is_override, bool is_unsafe, JaktInternal::Optional<size_t> specialization_index, JaktInternal::Optional<types::ScopeId> owner_scope, bool is_fully_checked, JaktInternal::Optional<parser::ExternalName> external_name, JaktInternal::Optional<DeprecatedString> deprecated_message, JaktInternal::Optional<JaktInternal::DynamicArray<JaktInternal::Tuple<size_t,parser::ArgumentStoreLevel>>> stores_arguments, JaktInternal::Optional<bool> force_inline);
 
-ErrorOr<DeprecatedString> debug_description() const;
-};struct CheckedVarDecl {
-  public:
-DeprecatedString name;bool is_mutable;utility::Span span;types::TypeId type_id;CheckedVarDecl(DeprecatedString a_name, bool a_is_mutable, utility::Span a_span, types::TypeId a_type_id);
-
-ErrorOr<DeprecatedString> debug_description() const;
-};namespace CheckedTraitRequirements_Details {
-struct Nothing {
-};
-struct Methods{
-JaktInternal::Dictionary<DeprecatedString,types::FunctionId> value;
-template<typename _MemberT0>
-Methods(_MemberT0&& member_0):
-value{ forward<_MemberT0>(member_0)}
-{}
-};
-struct ComptimeExpression{
-NonnullRefPtr<typename types::CheckedExpression> value;
-template<typename _MemberT0>
-ComptimeExpression(_MemberT0&& member_0):
-value{ forward<_MemberT0>(member_0)}
-{}
-};
-}
-struct CheckedTraitRequirements : public Variant<CheckedTraitRequirements_Details::Nothing, CheckedTraitRequirements_Details::Methods, CheckedTraitRequirements_Details::ComptimeExpression> {
-using Variant<CheckedTraitRequirements_Details::Nothing, CheckedTraitRequirements_Details::Methods, CheckedTraitRequirements_Details::ComptimeExpression>::Variant;
-    using Nothing = CheckedTraitRequirements_Details::Nothing;
-    using Methods = CheckedTraitRequirements_Details::Methods;
-    using ComptimeExpression = CheckedTraitRequirements_Details::ComptimeExpression;
-ErrorOr<DeprecatedString> debug_description() const;
-};
-struct CheckedField {
-  public:
-types::VarId variable_id;JaktInternal::Optional<NonnullRefPtr<typename types::CheckedExpression>> default_value;JaktInternal::Optional<NonnullRefPtr<typename parser::ParsedExpression>> default_value_expression;CheckedField(types::VarId a_variable_id, JaktInternal::Optional<NonnullRefPtr<typename types::CheckedExpression>> a_default_value, JaktInternal::Optional<NonnullRefPtr<typename parser::ParsedExpression>> a_default_value_expression);
-
-ErrorOr<DeprecatedString> debug_description() const;
-};struct GenericInferences {
-  public:
-JaktInternal::Dictionary<DeprecatedString,DeprecatedString> values;ErrorOr<void> set_all(JaktInternal::DynamicArray<types::CheckedGenericParameter> const keys, JaktInternal::DynamicArray<types::TypeId> const values);
-DeprecatedString map_name(DeprecatedString const type) const;
-ErrorOr<void> set_from(JaktInternal::Dictionary<DeprecatedString,DeprecatedString> const checkpoint);
-ErrorOr<JaktInternal::Optional<types::TypeId>> find_and_map(DeprecatedString const name, NonnullRefPtr<types::CheckedProgram> const& program) const;
-GenericInferences(JaktInternal::Dictionary<DeprecatedString,DeprecatedString> a_values);
-
-void restore(JaktInternal::Dictionary<DeprecatedString,DeprecatedString> const checkpoint);
-ErrorOr<void> debug_description(NonnullRefPtr<types::CheckedProgram> const& program) const;
-ErrorOr<types::TypeId> map(types::TypeId const type_id) const;
-ErrorOr<JaktInternal::Dictionary<DeprecatedString,DeprecatedString>> perform_checkpoint(bool const reset);
-JaktInternal::Optional<DeprecatedString> get(DeprecatedString const key) const;
-JaktInternal::Dictionary<DeprecatedString,DeprecatedString> iterator() const;
-ErrorOr<void> set(DeprecatedString const key, DeprecatedString const value);
-ErrorOr<DeprecatedString> debug_description() const;
-};namespace NumberConstant_Details {
-struct Signed{
-i64 value;
-template<typename _MemberT0>
-Signed(_MemberT0&& member_0):
-value{ forward<_MemberT0>(member_0)}
-{}
-};
-struct Unsigned{
-u64 value;
-template<typename _MemberT0>
-Unsigned(_MemberT0&& member_0):
-value{ forward<_MemberT0>(member_0)}
-{}
-};
-struct Floating{
-f64 value;
-template<typename _MemberT0>
-Floating(_MemberT0&& member_0):
-value{ forward<_MemberT0>(member_0)}
-{}
-};
-}
-struct NumberConstant : public Variant<NumberConstant_Details::Signed, NumberConstant_Details::Unsigned, NumberConstant_Details::Floating> {
-using Variant<NumberConstant_Details::Signed, NumberConstant_Details::Unsigned, NumberConstant_Details::Floating>::Variant;
-    using Signed = NumberConstant_Details::Signed;
-    using Unsigned = NumberConstant_Details::Unsigned;
-    using Floating = NumberConstant_Details::Floating;
-ErrorOr<DeprecatedString> debug_description() const;
-ErrorOr<bool> can_fit_number(types::TypeId const type_id, NonnullRefPtr<types::CheckedProgram> const program) const;
-ErrorOr<size_t> to_usize() const;
-};
-struct CheckedNamespace {
-  public:
-DeprecatedString name;types::ScopeId scope;CheckedNamespace(DeprecatedString a_name, types::ScopeId a_scope);
-
+ErrorOr<parser::ParsedFunction> to_parsed_function() const;
+bool is_specialized_for_types(JaktInternal::DynamicArray<types::TypeId> const types) const;
+ErrorOr<NonnullRefPtr<types::CheckedFunction>> copy() const;
+ErrorOr<bool> signature_matches(NonnullRefPtr<types::CheckedFunction> const other, bool const ignore_this) const;
+parser::ExternalName name_for_codegen() const;
+ErrorOr<void> add_param(types::CheckedParameter const checked_param);
+ErrorOr<void> set_params(JaktInternal::DynamicArray<types::CheckedParameter> const checked_params);
 ErrorOr<DeprecatedString> debug_description() const;
 };class Module : public RefCounted<Module>, public Weakable<Module> {
   public:
@@ -2145,213 +2210,10 @@ static ErrorOr<NonnullRefPtr<Module>> __jakt_create(types::ModuleId id, Deprecat
 ErrorOr<types::VarId> add_variable(NonnullRefPtr<types::CheckedVariable> const checked_variable);
 ErrorOr<types::TypeId> new_type_variable(JaktInternal::Optional<JaktInternal::DynamicArray<types::TypeId>> const implemented_traits);
 ErrorOr<DeprecatedString> debug_description() const;
-};namespace StructOrEnumId_Details {
-struct Struct{
-types::StructId value;
-template<typename _MemberT0>
-Struct(_MemberT0&& member_0):
-value{ forward<_MemberT0>(member_0)}
-{}
-};
-struct Enum{
-types::EnumId value;
-template<typename _MemberT0>
-Enum(_MemberT0&& member_0):
-value{ forward<_MemberT0>(member_0)}
-{}
-};
-}
-struct StructOrEnumId : public Variant<StructOrEnumId_Details::Struct, StructOrEnumId_Details::Enum> {
-using Variant<StructOrEnumId_Details::Struct, StructOrEnumId_Details::Enum>::Variant;
-    using Struct = StructOrEnumId_Details::Struct;
-    using Enum = StructOrEnumId_Details::Enum;
-ErrorOr<DeprecatedString> debug_description() const;
-};
-struct CheckedParameter {
-  public:
-bool requires_label;NonnullRefPtr<types::CheckedVariable> variable;JaktInternal::Optional<NonnullRefPtr<typename types::CheckedExpression>> default_value;ErrorOr<types::CheckedParameter> map_types(Function<ErrorOr<types::TypeId>(types::TypeId)> const& map) const;
-CheckedParameter(bool a_requires_label, NonnullRefPtr<types::CheckedVariable> a_variable, JaktInternal::Optional<NonnullRefPtr<typename types::CheckedExpression>> a_default_value);
-
-ErrorOr<DeprecatedString> debug_description() const;
-};namespace MaybeResolvedScope_Details {
-struct Resolved{
-types::ScopeId value;
-template<typename _MemberT0>
-Resolved(_MemberT0&& member_0):
-value{ forward<_MemberT0>(member_0)}
-{}
-};
-struct Unresolved {
-NonnullRefPtr<typename types::MaybeResolvedScope> parent_scope;
-DeprecatedString relative_name;
-template<typename _MemberT0, typename _MemberT1>
-Unresolved(_MemberT0&& member_0, _MemberT1&& member_1):
-parent_scope{ forward<_MemberT0>(member_0)},
-relative_name{ forward<_MemberT1>(member_1)}
-{}
-};
-}
-struct MaybeResolvedScope : public Variant<MaybeResolvedScope_Details::Resolved, MaybeResolvedScope_Details::Unresolved>, public RefCounted<MaybeResolvedScope> {
-using Variant<MaybeResolvedScope_Details::Resolved, MaybeResolvedScope_Details::Unresolved>::Variant;
-    using Resolved = MaybeResolvedScope_Details::Resolved;
-    using Unresolved = MaybeResolvedScope_Details::Unresolved;
-template<typename V, typename... Args> static auto __jakt_create(Args&&... args) {
-return adopt_nonnull_ref_or_enomem(new (nothrow) MaybeResolvedScope(V(forward<Args>(args)...)));
-}
-ErrorOr<DeprecatedString> debug_description() const;
-ErrorOr<NonnullRefPtr<typename types::MaybeResolvedScope>> try_resolve(NonnullRefPtr<types::CheckedProgram> const program) const;
-};
-class CheckedTrait : public RefCounted<CheckedTrait>, public Weakable<CheckedTrait> {
-  public:
-virtual ~CheckedTrait() = default;
-DeprecatedString name;utility::Span name_span;types::CheckedTraitRequirements requirements;JaktInternal::DynamicArray<types::CheckedGenericParameter> generic_parameters;types::ScopeId scope_id;protected:
-explicit CheckedTrait(DeprecatedString a_name, utility::Span a_name_span, types::CheckedTraitRequirements a_requirements, JaktInternal::DynamicArray<types::CheckedGenericParameter> a_generic_parameters, types::ScopeId a_scope_id);
-public:
-static ErrorOr<NonnullRefPtr<CheckedTrait>> __jakt_create(DeprecatedString name, utility::Span name_span, types::CheckedTraitRequirements requirements, JaktInternal::DynamicArray<types::CheckedGenericParameter> generic_parameters, types::ScopeId scope_id);
-
-ErrorOr<DeprecatedString> debug_description() const;
 };}
 } // namespace Jakt
-template<>struct Jakt::Formatter<Jakt::types::ModuleId> : Jakt::Formatter<Jakt::StringView>{
-Jakt::ErrorOr<void> format(Jakt::FormatBuilder& builder, Jakt::types::ModuleId const& value) {
-JaktInternal::PrettyPrint::ScopedEnable pretty_print_enable { m_alternative_form };Jakt::ErrorOr<void> format_error = Jakt::Formatter<Jakt::StringView>::format(builder, MUST(value.debug_description()));return format_error;}
-};
-namespace Jakt {
-} // namespace Jakt
-template<>struct Jakt::Formatter<Jakt::types::TypeId> : Jakt::Formatter<Jakt::StringView>{
-Jakt::ErrorOr<void> format(Jakt::FormatBuilder& builder, Jakt::types::TypeId const& value) {
-JaktInternal::PrettyPrint::ScopedEnable pretty_print_enable { m_alternative_form };Jakt::ErrorOr<void> format_error = Jakt::Formatter<Jakt::StringView>::format(builder, MUST(value.debug_description()));return format_error;}
-};
-namespace Jakt {
-} // namespace Jakt
-template<>struct Jakt::Formatter<Jakt::types::CheckedTypeCast> : Jakt::Formatter<Jakt::StringView>{
-Jakt::ErrorOr<void> format(Jakt::FormatBuilder& builder, Jakt::types::CheckedTypeCast const& value) {
-JaktInternal::PrettyPrint::ScopedEnable pretty_print_enable { m_alternative_form };Jakt::ErrorOr<void> format_error = Jakt::Formatter<Jakt::StringView>::format(builder, MUST(value.debug_description()));return format_error;}
-};
-namespace Jakt {
-} // namespace Jakt
-template<>struct Jakt::Formatter<Jakt::types::EnumId> : Jakt::Formatter<Jakt::StringView>{
-Jakt::ErrorOr<void> format(Jakt::FormatBuilder& builder, Jakt::types::EnumId const& value) {
-JaktInternal::PrettyPrint::ScopedEnable pretty_print_enable { m_alternative_form };Jakt::ErrorOr<void> format_error = Jakt::Formatter<Jakt::StringView>::format(builder, MUST(value.debug_description()));return format_error;}
-};
-namespace Jakt {
-} // namespace Jakt
-template<>struct Jakt::Formatter<Jakt::types::CheckedEnumVariant> : Jakt::Formatter<Jakt::StringView>{
-Jakt::ErrorOr<void> format(Jakt::FormatBuilder& builder, Jakt::types::CheckedEnumVariant const& value) {
-JaktInternal::PrettyPrint::ScopedEnable pretty_print_enable { m_alternative_form };Jakt::ErrorOr<void> format_error = Jakt::Formatter<Jakt::StringView>::format(builder, MUST(value.debug_description()));return format_error;}
-};
-namespace Jakt {
-} // namespace Jakt
-template<>struct Jakt::Formatter<Jakt::types::CheckedUnaryOperator> : Jakt::Formatter<Jakt::StringView>{
-Jakt::ErrorOr<void> format(Jakt::FormatBuilder& builder, Jakt::types::CheckedUnaryOperator const& value) {
-JaktInternal::PrettyPrint::ScopedEnable pretty_print_enable { m_alternative_form };Jakt::ErrorOr<void> format_error = Jakt::Formatter<Jakt::StringView>::format(builder, MUST(value.debug_description()));return format_error;}
-};
-namespace Jakt {
-} // namespace Jakt
-template<>struct Jakt::Formatter<Jakt::types::NumericOrStringValue> : Jakt::Formatter<Jakt::StringView>{
-Jakt::ErrorOr<void> format(Jakt::FormatBuilder& builder, Jakt::types::NumericOrStringValue const& value) {
-JaktInternal::PrettyPrint::ScopedEnable pretty_print_enable { m_alternative_form };Jakt::ErrorOr<void> format_error = Jakt::Formatter<Jakt::StringView>::format(builder, MUST(value.debug_description()));return format_error;}
-};
-namespace Jakt {
-} // namespace Jakt
-template<>struct Jakt::Formatter<Jakt::types::TraitId> : Jakt::Formatter<Jakt::StringView>{
-Jakt::ErrorOr<void> format(Jakt::FormatBuilder& builder, Jakt::types::TraitId const& value) {
-JaktInternal::PrettyPrint::ScopedEnable pretty_print_enable { m_alternative_form };Jakt::ErrorOr<void> format_error = Jakt::Formatter<Jakt::StringView>::format(builder, MUST(value.debug_description()));return format_error;}
-};
-namespace Jakt {
-} // namespace Jakt
-template<>struct Jakt::Formatter<Jakt::types::TypecheckFunctions> : Jakt::Formatter<Jakt::StringView>{
-Jakt::ErrorOr<void> format(Jakt::FormatBuilder& builder, Jakt::types::TypecheckFunctions const& value) {
-JaktInternal::PrettyPrint::ScopedEnable pretty_print_enable { m_alternative_form };Jakt::ErrorOr<void> format_error = Jakt::Formatter<Jakt::StringView>::format(builder, MUST(value.debug_description()));return format_error;}
-};
-namespace Jakt {
-} // namespace Jakt
-template<>struct Jakt::Formatter<Jakt::types::CheckedEnumVariantBinding> : Jakt::Formatter<Jakt::StringView>{
-Jakt::ErrorOr<void> format(Jakt::FormatBuilder& builder, Jakt::types::CheckedEnumVariantBinding const& value) {
-JaktInternal::PrettyPrint::ScopedEnable pretty_print_enable { m_alternative_form };Jakt::ErrorOr<void> format_error = Jakt::Formatter<Jakt::StringView>::format(builder, MUST(value.debug_description()));return format_error;}
-};
-namespace Jakt {
-} // namespace Jakt
-template<>struct Jakt::Formatter<Jakt::types::StringLiteral> : Jakt::Formatter<Jakt::StringView>{
-Jakt::ErrorOr<void> format(Jakt::FormatBuilder& builder, Jakt::types::StringLiteral const& value) {
-JaktInternal::PrettyPrint::ScopedEnable pretty_print_enable { m_alternative_form };Jakt::ErrorOr<void> format_error = Jakt::Formatter<Jakt::StringView>::format(builder, MUST(value.debug_description()));return format_error;}
-};
-namespace Jakt {
-} // namespace Jakt
-template<>struct Jakt::Formatter<Jakt::types::ResolvedNamespace> : Jakt::Formatter<Jakt::StringView>{
-Jakt::ErrorOr<void> format(Jakt::FormatBuilder& builder, Jakt::types::ResolvedNamespace const& value) {
-JaktInternal::PrettyPrint::ScopedEnable pretty_print_enable { m_alternative_form };Jakt::ErrorOr<void> format_error = Jakt::Formatter<Jakt::StringView>::format(builder, MUST(value.debug_description()));return format_error;}
-};
-namespace Jakt {
-} // namespace Jakt
-template<>struct Jakt::Formatter<Jakt::types::CheckedProgram> : Jakt::Formatter<Jakt::StringView>{
-Jakt::ErrorOr<void> format(Jakt::FormatBuilder& builder, Jakt::types::CheckedProgram const& value) {
-JaktInternal::PrettyPrint::ScopedEnable pretty_print_enable { m_alternative_form };Jakt::ErrorOr<void> format_error = Jakt::Formatter<Jakt::StringView>::format(builder, MUST(value.debug_description()));return format_error;}
-};
-namespace Jakt {
-} // namespace Jakt
-template<>struct Jakt::Formatter<Jakt::types::CheckedVisibility> : Jakt::Formatter<Jakt::StringView>{
-Jakt::ErrorOr<void> format(Jakt::FormatBuilder& builder, Jakt::types::CheckedVisibility const& value) {
-JaktInternal::PrettyPrint::ScopedEnable pretty_print_enable { m_alternative_form };Jakt::ErrorOr<void> format_error = Jakt::Formatter<Jakt::StringView>::format(builder, MUST(value.debug_description()));return format_error;}
-};
-namespace Jakt {
-} // namespace Jakt
-template<>struct Jakt::Formatter<Jakt::types::ScopeId> : Jakt::Formatter<Jakt::StringView>{
-Jakt::ErrorOr<void> format(Jakt::FormatBuilder& builder, Jakt::types::ScopeId const& value) {
-JaktInternal::PrettyPrint::ScopedEnable pretty_print_enable { m_alternative_form };Jakt::ErrorOr<void> format_error = Jakt::Formatter<Jakt::StringView>::format(builder, MUST(value.debug_description()));return format_error;}
-};
-namespace Jakt {
-} // namespace Jakt
-template<>struct Jakt::Formatter<Jakt::types::BlockControlFlow> : Jakt::Formatter<Jakt::StringView>{
-Jakt::ErrorOr<void> format(Jakt::FormatBuilder& builder, Jakt::types::BlockControlFlow const& value) {
-JaktInternal::PrettyPrint::ScopedEnable pretty_print_enable { m_alternative_form };Jakt::ErrorOr<void> format_error = Jakt::Formatter<Jakt::StringView>::format(builder, MUST(value.debug_description()));return format_error;}
-};
-namespace Jakt {
-} // namespace Jakt
-template<>struct Jakt::Formatter<Jakt::types::CheckedBlock> : Jakt::Formatter<Jakt::StringView>{
-Jakt::ErrorOr<void> format(Jakt::FormatBuilder& builder, Jakt::types::CheckedBlock const& value) {
-JaktInternal::PrettyPrint::ScopedEnable pretty_print_enable { m_alternative_form };Jakt::ErrorOr<void> format_error = Jakt::Formatter<Jakt::StringView>::format(builder, MUST(value.debug_description()));return format_error;}
-};
-namespace Jakt {
-} // namespace Jakt
-template<>struct Jakt::Formatter<Jakt::types::StructId> : Jakt::Formatter<Jakt::StringView>{
-Jakt::ErrorOr<void> format(Jakt::FormatBuilder& builder, Jakt::types::StructId const& value) {
-JaktInternal::PrettyPrint::ScopedEnable pretty_print_enable { m_alternative_form };Jakt::ErrorOr<void> format_error = Jakt::Formatter<Jakt::StringView>::format(builder, MUST(value.debug_description()));return format_error;}
-};
-namespace Jakt {
-} // namespace Jakt
-template<>struct Jakt::Formatter<Jakt::types::CheckedFunction> : Jakt::Formatter<Jakt::StringView>{
-Jakt::ErrorOr<void> format(Jakt::FormatBuilder& builder, Jakt::types::CheckedFunction const& value) {
-JaktInternal::PrettyPrint::ScopedEnable pretty_print_enable { m_alternative_form };Jakt::ErrorOr<void> format_error = Jakt::Formatter<Jakt::StringView>::format(builder, MUST(value.debug_description()));return format_error;}
-};
-namespace Jakt {
-} // namespace Jakt
-template<>struct Jakt::Formatter<Jakt::types::StructLikeId> : Jakt::Formatter<Jakt::StringView>{
-Jakt::ErrorOr<void> format(Jakt::FormatBuilder& builder, Jakt::types::StructLikeId const& value) {
-JaktInternal::PrettyPrint::ScopedEnable pretty_print_enable { m_alternative_form };Jakt::ErrorOr<void> format_error = Jakt::Formatter<Jakt::StringView>::format(builder, MUST(value.debug_description()));return format_error;}
-};
-namespace Jakt {
-} // namespace Jakt
-template<>struct Jakt::Formatter<Jakt::types::ResolvedForallChunk> : Jakt::Formatter<Jakt::StringView>{
-Jakt::ErrorOr<void> format(Jakt::FormatBuilder& builder, Jakt::types::ResolvedForallChunk const& value) {
-JaktInternal::PrettyPrint::ScopedEnable pretty_print_enable { m_alternative_form };Jakt::ErrorOr<void> format_error = Jakt::Formatter<Jakt::StringView>::format(builder, MUST(value.debug_description()));return format_error;}
-};
-namespace Jakt {
-} // namespace Jakt
-template<>struct Jakt::Formatter<Jakt::types::CheckedMatchBody> : Jakt::Formatter<Jakt::StringView>{
-Jakt::ErrorOr<void> format(Jakt::FormatBuilder& builder, Jakt::types::CheckedMatchBody const& value) {
-JaktInternal::PrettyPrint::ScopedEnable pretty_print_enable { m_alternative_form };Jakt::ErrorOr<void> format_error = Jakt::Formatter<Jakt::StringView>::format(builder, MUST(value.debug_description()));return format_error;}
-};
-namespace Jakt {
-} // namespace Jakt
-template<>struct Jakt::Formatter<Jakt::types::CheckedMatchCase> : Jakt::Formatter<Jakt::StringView>{
-Jakt::ErrorOr<void> format(Jakt::FormatBuilder& builder, Jakt::types::CheckedMatchCase const& value) {
-JaktInternal::PrettyPrint::ScopedEnable pretty_print_enable { m_alternative_form };Jakt::ErrorOr<void> format_error = Jakt::Formatter<Jakt::StringView>::format(builder, MUST(value.debug_description()));return format_error;}
-};
-namespace Jakt {
-} // namespace Jakt
-template<>struct Jakt::Formatter<Jakt::types::FunctionId> : Jakt::Formatter<Jakt::StringView>{
-Jakt::ErrorOr<void> format(Jakt::FormatBuilder& builder, Jakt::types::FunctionId const& value) {
+template<>struct Jakt::Formatter<Jakt::types::CheckedTraitRequirements> : Jakt::Formatter<Jakt::StringView>{
+Jakt::ErrorOr<void> format(Jakt::FormatBuilder& builder, Jakt::types::CheckedTraitRequirements const& value) {
 JaktInternal::PrettyPrint::ScopedEnable pretty_print_enable { m_alternative_form };Jakt::ErrorOr<void> format_error = Jakt::Formatter<Jakt::StringView>::format(builder, MUST(value.debug_description()));return format_error;}
 };
 namespace Jakt {
@@ -2362,26 +2224,56 @@ JaktInternal::PrettyPrint::ScopedEnable pretty_print_enable { m_alternative_form
 };
 namespace Jakt {
 } // namespace Jakt
-template<>struct Jakt::Formatter<Jakt::types::ValueImpl> : Jakt::Formatter<Jakt::StringView>{
-Jakt::ErrorOr<void> format(Jakt::FormatBuilder& builder, Jakt::types::ValueImpl const& value) {
+template<>struct Jakt::Formatter<Jakt::types::ModuleId> : Jakt::Formatter<Jakt::StringView>{
+Jakt::ErrorOr<void> format(Jakt::FormatBuilder& builder, Jakt::types::ModuleId const& value) {
 JaktInternal::PrettyPrint::ScopedEnable pretty_print_enable { m_alternative_form };Jakt::ErrorOr<void> format_error = Jakt::Formatter<Jakt::StringView>::format(builder, MUST(value.debug_description()));return format_error;}
 };
 namespace Jakt {
 } // namespace Jakt
-template<>struct Jakt::Formatter<Jakt::types::CheckedEnum> : Jakt::Formatter<Jakt::StringView>{
-Jakt::ErrorOr<void> format(Jakt::FormatBuilder& builder, Jakt::types::CheckedEnum const& value) {
+template<>struct Jakt::Formatter<Jakt::types::LoadedModule> : Jakt::Formatter<Jakt::StringView>{
+Jakt::ErrorOr<void> format(Jakt::FormatBuilder& builder, Jakt::types::LoadedModule const& value) {
 JaktInternal::PrettyPrint::ScopedEnable pretty_print_enable { m_alternative_form };Jakt::ErrorOr<void> format_error = Jakt::Formatter<Jakt::StringView>::format(builder, MUST(value.debug_description()));return format_error;}
 };
 namespace Jakt {
 } // namespace Jakt
-template<>struct Jakt::Formatter<Jakt::types::CheckedNumericConstant> : Jakt::Formatter<Jakt::StringView>{
-Jakt::ErrorOr<void> format(Jakt::FormatBuilder& builder, Jakt::types::CheckedNumericConstant const& value) {
+template<>struct Jakt::Formatter<Jakt::types::StructId> : Jakt::Formatter<Jakt::StringView>{
+Jakt::ErrorOr<void> format(Jakt::FormatBuilder& builder, Jakt::types::StructId const& value) {
 JaktInternal::PrettyPrint::ScopedEnable pretty_print_enable { m_alternative_form };Jakt::ErrorOr<void> format_error = Jakt::Formatter<Jakt::StringView>::format(builder, MUST(value.debug_description()));return format_error;}
 };
 namespace Jakt {
 } // namespace Jakt
-template<>struct Jakt::Formatter<Jakt::types::CheckedStringLiteral> : Jakt::Formatter<Jakt::StringView>{
-Jakt::ErrorOr<void> format(Jakt::FormatBuilder& builder, Jakt::types::CheckedStringLiteral const& value) {
+template<>struct Jakt::Formatter<Jakt::types::EnumId> : Jakt::Formatter<Jakt::StringView>{
+Jakt::ErrorOr<void> format(Jakt::FormatBuilder& builder, Jakt::types::EnumId const& value) {
+JaktInternal::PrettyPrint::ScopedEnable pretty_print_enable { m_alternative_form };Jakt::ErrorOr<void> format_error = Jakt::Formatter<Jakt::StringView>::format(builder, MUST(value.debug_description()));return format_error;}
+};
+namespace Jakt {
+} // namespace Jakt
+template<>struct Jakt::Formatter<Jakt::types::StructOrEnumId> : Jakt::Formatter<Jakt::StringView>{
+Jakt::ErrorOr<void> format(Jakt::FormatBuilder& builder, Jakt::types::StructOrEnumId const& value) {
+JaktInternal::PrettyPrint::ScopedEnable pretty_print_enable { m_alternative_form };Jakt::ErrorOr<void> format_error = Jakt::Formatter<Jakt::StringView>::format(builder, MUST(value.debug_description()));return format_error;}
+};
+namespace Jakt {
+} // namespace Jakt
+template<>struct Jakt::Formatter<Jakt::types::TraitId> : Jakt::Formatter<Jakt::StringView>{
+Jakt::ErrorOr<void> format(Jakt::FormatBuilder& builder, Jakt::types::TraitId const& value) {
+JaktInternal::PrettyPrint::ScopedEnable pretty_print_enable { m_alternative_form };Jakt::ErrorOr<void> format_error = Jakt::Formatter<Jakt::StringView>::format(builder, MUST(value.debug_description()));return format_error;}
+};
+namespace Jakt {
+} // namespace Jakt
+template<>struct Jakt::Formatter<Jakt::types::TypeId> : Jakt::Formatter<Jakt::StringView>{
+Jakt::ErrorOr<void> format(Jakt::FormatBuilder& builder, Jakt::types::TypeId const& value) {
+JaktInternal::PrettyPrint::ScopedEnable pretty_print_enable { m_alternative_form };Jakt::ErrorOr<void> format_error = Jakt::Formatter<Jakt::StringView>::format(builder, MUST(value.debug_description()));return format_error;}
+};
+namespace Jakt {
+} // namespace Jakt
+template<>struct Jakt::Formatter<Jakt::types::FunctionId> : Jakt::Formatter<Jakt::StringView>{
+Jakt::ErrorOr<void> format(Jakt::FormatBuilder& builder, Jakt::types::FunctionId const& value) {
+JaktInternal::PrettyPrint::ScopedEnable pretty_print_enable { m_alternative_form };Jakt::ErrorOr<void> format_error = Jakt::Formatter<Jakt::StringView>::format(builder, MUST(value.debug_description()));return format_error;}
+};
+namespace Jakt {
+} // namespace Jakt
+template<>struct Jakt::Formatter<Jakt::types::Type> : Jakt::Formatter<Jakt::StringView>{
+Jakt::ErrorOr<void> format(Jakt::FormatBuilder& builder, Jakt::types::Type const& value) {
 JaktInternal::PrettyPrint::ScopedEnable pretty_print_enable { m_alternative_form };Jakt::ErrorOr<void> format_error = Jakt::Formatter<Jakt::StringView>::format(builder, MUST(value.debug_description()));return format_error;}
 };
 namespace Jakt {
@@ -2398,8 +2290,20 @@ JaktInternal::PrettyPrint::ScopedEnable pretty_print_enable { m_alternative_form
 };
 namespace Jakt {
 } // namespace Jakt
-template<>struct Jakt::Formatter<Jakt::types::CheckedBinaryOperator> : Jakt::Formatter<Jakt::StringView>{
-Jakt::ErrorOr<void> format(Jakt::FormatBuilder& builder, Jakt::types::CheckedBinaryOperator const& value) {
+template<>struct Jakt::Formatter<Jakt::types::ScopeId> : Jakt::Formatter<Jakt::StringView>{
+Jakt::ErrorOr<void> format(Jakt::FormatBuilder& builder, Jakt::types::ScopeId const& value) {
+JaktInternal::PrettyPrint::ScopedEnable pretty_print_enable { m_alternative_form };Jakt::ErrorOr<void> format_error = Jakt::Formatter<Jakt::StringView>::format(builder, MUST(value.debug_description()));return format_error;}
+};
+namespace Jakt {
+} // namespace Jakt
+template<>struct Jakt::Formatter<Jakt::types::CheckedEnum> : Jakt::Formatter<Jakt::StringView>{
+Jakt::ErrorOr<void> format(Jakt::FormatBuilder& builder, Jakt::types::CheckedEnum const& value) {
+JaktInternal::PrettyPrint::ScopedEnable pretty_print_enable { m_alternative_form };Jakt::ErrorOr<void> format_error = Jakt::Formatter<Jakt::StringView>::format(builder, MUST(value.debug_description()));return format_error;}
+};
+namespace Jakt {
+} // namespace Jakt
+template<>struct Jakt::Formatter<Jakt::types::CheckedVarDecl> : Jakt::Formatter<Jakt::StringView>{
+Jakt::ErrorOr<void> format(Jakt::FormatBuilder& builder, Jakt::types::CheckedVarDecl const& value) {
 JaktInternal::PrettyPrint::ScopedEnable pretty_print_enable { m_alternative_form };Jakt::ErrorOr<void> format_error = Jakt::Formatter<Jakt::StringView>::format(builder, MUST(value.debug_description()));return format_error;}
 };
 namespace Jakt {
@@ -2410,8 +2314,134 @@ JaktInternal::PrettyPrint::ScopedEnable pretty_print_enable { m_alternative_form
 };
 namespace Jakt {
 } // namespace Jakt
-template<>struct Jakt::Formatter<Jakt::types::CheckedExpression> : Jakt::Formatter<Jakt::StringView>{
-Jakt::ErrorOr<void> format(Jakt::FormatBuilder& builder, Jakt::types::CheckedExpression const& value) {
+template<>struct Jakt::Formatter<Jakt::types::FieldRecord> : Jakt::Formatter<Jakt::StringView>{
+Jakt::ErrorOr<void> format(Jakt::FormatBuilder& builder, Jakt::types::FieldRecord const& value) {
+JaktInternal::PrettyPrint::ScopedEnable pretty_print_enable { m_alternative_form };Jakt::ErrorOr<void> format_error = Jakt::Formatter<Jakt::StringView>::format(builder, MUST(value.debug_description()));return format_error;}
+};
+namespace Jakt {
+} // namespace Jakt
+template<>struct Jakt::Formatter<Jakt::types::BlockControlFlow> : Jakt::Formatter<Jakt::StringView>{
+Jakt::ErrorOr<void> format(Jakt::FormatBuilder& builder, Jakt::types::BlockControlFlow const& value) {
+JaktInternal::PrettyPrint::ScopedEnable pretty_print_enable { m_alternative_form };Jakt::ErrorOr<void> format_error = Jakt::Formatter<Jakt::StringView>::format(builder, MUST(value.debug_description()));return format_error;}
+};
+namespace Jakt {
+} // namespace Jakt
+template<>struct Jakt::Formatter<Jakt::types::CheckedBlock> : Jakt::Formatter<Jakt::StringView>{
+Jakt::ErrorOr<void> format(Jakt::FormatBuilder& builder, Jakt::types::CheckedBlock const& value) {
+JaktInternal::PrettyPrint::ScopedEnable pretty_print_enable { m_alternative_form };Jakt::ErrorOr<void> format_error = Jakt::Formatter<Jakt::StringView>::format(builder, MUST(value.debug_description()));return format_error;}
+};
+namespace Jakt {
+} // namespace Jakt
+template<>struct Jakt::Formatter<Jakt::types::CheckedMatchBody> : Jakt::Formatter<Jakt::StringView>{
+Jakt::ErrorOr<void> format(Jakt::FormatBuilder& builder, Jakt::types::CheckedMatchBody const& value) {
+JaktInternal::PrettyPrint::ScopedEnable pretty_print_enable { m_alternative_form };Jakt::ErrorOr<void> format_error = Jakt::Formatter<Jakt::StringView>::format(builder, MUST(value.debug_description()));return format_error;}
+};
+namespace Jakt {
+} // namespace Jakt
+template<>struct Jakt::Formatter<Jakt::types::CheckedMatchCase> : Jakt::Formatter<Jakt::StringView>{
+Jakt::ErrorOr<void> format(Jakt::FormatBuilder& builder, Jakt::types::CheckedMatchCase const& value) {
+JaktInternal::PrettyPrint::ScopedEnable pretty_print_enable { m_alternative_form };Jakt::ErrorOr<void> format_error = Jakt::Formatter<Jakt::StringView>::format(builder, MUST(value.debug_description()));return format_error;}
+};
+namespace Jakt {
+} // namespace Jakt
+template<>struct Jakt::Formatter<Jakt::types::CheckedNumericConstant> : Jakt::Formatter<Jakt::StringView>{
+Jakt::ErrorOr<void> format(Jakt::FormatBuilder& builder, Jakt::types::CheckedNumericConstant const& value) {
+JaktInternal::PrettyPrint::ScopedEnable pretty_print_enable { m_alternative_form };Jakt::ErrorOr<void> format_error = Jakt::Formatter<Jakt::StringView>::format(builder, MUST(value.debug_description()));return format_error;}
+};
+namespace Jakt {
+} // namespace Jakt
+template<>struct Jakt::Formatter<Jakt::types::CheckedVisibility> : Jakt::Formatter<Jakt::StringView>{
+Jakt::ErrorOr<void> format(Jakt::FormatBuilder& builder, Jakt::types::CheckedVisibility const& value) {
+JaktInternal::PrettyPrint::ScopedEnable pretty_print_enable { m_alternative_form };Jakt::ErrorOr<void> format_error = Jakt::Formatter<Jakt::StringView>::format(builder, MUST(value.debug_description()));return format_error;}
+};
+namespace Jakt {
+} // namespace Jakt
+template<>struct Jakt::Formatter<Jakt::types::NumberConstant> : Jakt::Formatter<Jakt::StringView>{
+Jakt::ErrorOr<void> format(Jakt::FormatBuilder& builder, Jakt::types::NumberConstant const& value) {
+JaktInternal::PrettyPrint::ScopedEnable pretty_print_enable { m_alternative_form };Jakt::ErrorOr<void> format_error = Jakt::Formatter<Jakt::StringView>::format(builder, MUST(value.debug_description()));return format_error;}
+};
+namespace Jakt {
+} // namespace Jakt
+template<>struct Jakt::Formatter<Jakt::types::ResolvedForallChunk> : Jakt::Formatter<Jakt::StringView>{
+Jakt::ErrorOr<void> format(Jakt::FormatBuilder& builder, Jakt::types::ResolvedForallChunk const& value) {
+JaktInternal::PrettyPrint::ScopedEnable pretty_print_enable { m_alternative_form };Jakt::ErrorOr<void> format_error = Jakt::Formatter<Jakt::StringView>::format(builder, MUST(value.debug_description()));return format_error;}
+};
+namespace Jakt {
+} // namespace Jakt
+template<>struct Jakt::Formatter<Jakt::types::CheckedCapture> : Jakt::Formatter<Jakt::StringView>{
+Jakt::ErrorOr<void> format(Jakt::FormatBuilder& builder, Jakt::types::CheckedCapture const& value) {
+JaktInternal::PrettyPrint::ScopedEnable pretty_print_enable { m_alternative_form };Jakt::ErrorOr<void> format_error = Jakt::Formatter<Jakt::StringView>::format(builder, MUST(value.debug_description()));return format_error;}
+};
+namespace Jakt {
+} // namespace Jakt
+template<>struct Jakt::Formatter<Jakt::types::CheckedParameter> : Jakt::Formatter<Jakt::StringView>{
+Jakt::ErrorOr<void> format(Jakt::FormatBuilder& builder, Jakt::types::CheckedParameter const& value) {
+JaktInternal::PrettyPrint::ScopedEnable pretty_print_enable { m_alternative_form };Jakt::ErrorOr<void> format_error = Jakt::Formatter<Jakt::StringView>::format(builder, MUST(value.debug_description()));return format_error;}
+};
+namespace Jakt {
+} // namespace Jakt
+template<>struct Jakt::Formatter<Jakt::types::StringLiteral> : Jakt::Formatter<Jakt::StringView>{
+Jakt::ErrorOr<void> format(Jakt::FormatBuilder& builder, Jakt::types::StringLiteral const& value) {
+JaktInternal::PrettyPrint::ScopedEnable pretty_print_enable { m_alternative_form };Jakt::ErrorOr<void> format_error = Jakt::Formatter<Jakt::StringView>::format(builder, MUST(value.debug_description()));return format_error;}
+};
+namespace Jakt {
+} // namespace Jakt
+template<>struct Jakt::Formatter<Jakt::types::CheckedStringLiteral> : Jakt::Formatter<Jakt::StringView>{
+Jakt::ErrorOr<void> format(Jakt::FormatBuilder& builder, Jakt::types::CheckedStringLiteral const& value) {
+JaktInternal::PrettyPrint::ScopedEnable pretty_print_enable { m_alternative_form };Jakt::ErrorOr<void> format_error = Jakt::Formatter<Jakt::StringView>::format(builder, MUST(value.debug_description()));return format_error;}
+};
+namespace Jakt {
+} // namespace Jakt
+template<>struct Jakt::Formatter<Jakt::types::CheckedStruct> : Jakt::Formatter<Jakt::StringView>{
+Jakt::ErrorOr<void> format(Jakt::FormatBuilder& builder, Jakt::types::CheckedStruct const& value) {
+JaktInternal::PrettyPrint::ScopedEnable pretty_print_enable { m_alternative_form };Jakt::ErrorOr<void> format_error = Jakt::Formatter<Jakt::StringView>::format(builder, MUST(value.debug_description()));return format_error;}
+};
+namespace Jakt {
+} // namespace Jakt
+template<>struct Jakt::Formatter<Jakt::types::BuiltinType> : Jakt::Formatter<Jakt::StringView>{
+Jakt::ErrorOr<void> format(Jakt::FormatBuilder& builder, Jakt::types::BuiltinType const& value) {
+JaktInternal::PrettyPrint::ScopedEnable pretty_print_enable { m_alternative_form };Jakt::ErrorOr<void> format_error = Jakt::Formatter<Jakt::StringView>::format(builder, MUST(value.debug_description()));return format_error;}
+};
+namespace Jakt {
+} // namespace Jakt
+template<>struct Jakt::Formatter<Jakt::types::CheckedNamespace> : Jakt::Formatter<Jakt::StringView>{
+Jakt::ErrorOr<void> format(Jakt::FormatBuilder& builder, Jakt::types::CheckedNamespace const& value) {
+JaktInternal::PrettyPrint::ScopedEnable pretty_print_enable { m_alternative_form };Jakt::ErrorOr<void> format_error = Jakt::Formatter<Jakt::StringView>::format(builder, MUST(value.debug_description()));return format_error;}
+};
+namespace Jakt {
+} // namespace Jakt
+template<>struct Jakt::Formatter<Jakt::types::GenericInferences> : Jakt::Formatter<Jakt::StringView>{
+Jakt::ErrorOr<void> format(Jakt::FormatBuilder& builder, Jakt::types::GenericInferences const& value) {
+JaktInternal::PrettyPrint::ScopedEnable pretty_print_enable { m_alternative_form };Jakt::ErrorOr<void> format_error = Jakt::Formatter<Jakt::StringView>::format(builder, MUST(value.debug_description()));return format_error;}
+};
+namespace Jakt {
+} // namespace Jakt
+template<>struct Jakt::Formatter<Jakt::types::CheckedProgram> : Jakt::Formatter<Jakt::StringView>{
+Jakt::ErrorOr<void> format(Jakt::FormatBuilder& builder, Jakt::types::CheckedProgram const& value) {
+JaktInternal::PrettyPrint::ScopedEnable pretty_print_enable { m_alternative_form };Jakt::ErrorOr<void> format_error = Jakt::Formatter<Jakt::StringView>::format(builder, MUST(value.debug_description()));return format_error;}
+};
+namespace Jakt {
+} // namespace Jakt
+template<>struct Jakt::Formatter<Jakt::types::CheckedStatement> : Jakt::Formatter<Jakt::StringView>{
+Jakt::ErrorOr<void> format(Jakt::FormatBuilder& builder, Jakt::types::CheckedStatement const& value) {
+JaktInternal::PrettyPrint::ScopedEnable pretty_print_enable { m_alternative_form };Jakt::ErrorOr<void> format_error = Jakt::Formatter<Jakt::StringView>::format(builder, MUST(value.debug_description()));return format_error;}
+};
+namespace Jakt {
+} // namespace Jakt
+template<>struct Jakt::Formatter<Jakt::types::CheckedEnumVariant> : Jakt::Formatter<Jakt::StringView>{
+Jakt::ErrorOr<void> format(Jakt::FormatBuilder& builder, Jakt::types::CheckedEnumVariant const& value) {
+JaktInternal::PrettyPrint::ScopedEnable pretty_print_enable { m_alternative_form };Jakt::ErrorOr<void> format_error = Jakt::Formatter<Jakt::StringView>::format(builder, MUST(value.debug_description()));return format_error;}
+};
+namespace Jakt {
+} // namespace Jakt
+template<>struct Jakt::Formatter<Jakt::types::TypecheckFunctions> : Jakt::Formatter<Jakt::StringView>{
+Jakt::ErrorOr<void> format(Jakt::FormatBuilder& builder, Jakt::types::TypecheckFunctions const& value) {
+JaktInternal::PrettyPrint::ScopedEnable pretty_print_enable { m_alternative_form };Jakt::ErrorOr<void> format_error = Jakt::Formatter<Jakt::StringView>::format(builder, MUST(value.debug_description()));return format_error;}
+};
+namespace Jakt {
+} // namespace Jakt
+template<>struct Jakt::Formatter<Jakt::types::Scope> : Jakt::Formatter<Jakt::StringView>{
+Jakt::ErrorOr<void> format(Jakt::FormatBuilder& builder, Jakt::types::Scope const& value) {
 JaktInternal::PrettyPrint::ScopedEnable pretty_print_enable { m_alternative_form };Jakt::ErrorOr<void> format_error = Jakt::Formatter<Jakt::StringView>::format(builder, MUST(value.debug_description()));return format_error;}
 };
 namespace Jakt {
@@ -2422,26 +2452,8 @@ JaktInternal::PrettyPrint::ScopedEnable pretty_print_enable { m_alternative_form
 };
 namespace Jakt {
 } // namespace Jakt
-template<>struct Jakt::Formatter<Jakt::types::FieldRecord> : Jakt::Formatter<Jakt::StringView>{
-Jakt::ErrorOr<void> format(Jakt::FormatBuilder& builder, Jakt::types::FieldRecord const& value) {
-JaktInternal::PrettyPrint::ScopedEnable pretty_print_enable { m_alternative_form };Jakt::ErrorOr<void> format_error = Jakt::Formatter<Jakt::StringView>::format(builder, MUST(value.debug_description()));return format_error;}
-};
-namespace Jakt {
-} // namespace Jakt
-template<>struct Jakt::Formatter<Jakt::types::FunctionGenerics> : Jakt::Formatter<Jakt::StringView>{
-Jakt::ErrorOr<void> format(Jakt::FormatBuilder& builder, Jakt::types::FunctionGenerics const& value) {
-JaktInternal::PrettyPrint::ScopedEnable pretty_print_enable { m_alternative_form };Jakt::ErrorOr<void> format_error = Jakt::Formatter<Jakt::StringView>::format(builder, MUST(value.debug_description()));return format_error;}
-};
-namespace Jakt {
-} // namespace Jakt
-template<>struct Jakt::Formatter<Jakt::types::Type> : Jakt::Formatter<Jakt::StringView>{
-Jakt::ErrorOr<void> format(Jakt::FormatBuilder& builder, Jakt::types::Type const& value) {
-JaktInternal::PrettyPrint::ScopedEnable pretty_print_enable { m_alternative_form };Jakt::ErrorOr<void> format_error = Jakt::Formatter<Jakt::StringView>::format(builder, MUST(value.debug_description()));return format_error;}
-};
-namespace Jakt {
-} // namespace Jakt
-template<>struct Jakt::Formatter<Jakt::types::CheckedCapture> : Jakt::Formatter<Jakt::StringView>{
-Jakt::ErrorOr<void> format(Jakt::FormatBuilder& builder, Jakt::types::CheckedCapture const& value) {
+template<>struct Jakt::Formatter<Jakt::types::ValueImpl> : Jakt::Formatter<Jakt::StringView>{
+Jakt::ErrorOr<void> format(Jakt::FormatBuilder& builder, Jakt::types::ValueImpl const& value) {
 JaktInternal::PrettyPrint::ScopedEnable pretty_print_enable { m_alternative_form };Jakt::ErrorOr<void> format_error = Jakt::Formatter<Jakt::StringView>::format(builder, MUST(value.debug_description()));return format_error;}
 };
 namespace Jakt {
@@ -2464,92 +2476,20 @@ JaktInternal::PrettyPrint::ScopedEnable pretty_print_enable { m_alternative_form
 };
 namespace Jakt {
 } // namespace Jakt
-template<>struct Jakt::Formatter<Jakt::types::CheckedStatement> : Jakt::Formatter<Jakt::StringView>{
-Jakt::ErrorOr<void> format(Jakt::FormatBuilder& builder, Jakt::types::CheckedStatement const& value) {
+template<>struct Jakt::Formatter<Jakt::types::FunctionGenerics> : Jakt::Formatter<Jakt::StringView>{
+Jakt::ErrorOr<void> format(Jakt::FormatBuilder& builder, Jakt::types::FunctionGenerics const& value) {
 JaktInternal::PrettyPrint::ScopedEnable pretty_print_enable { m_alternative_form };Jakt::ErrorOr<void> format_error = Jakt::Formatter<Jakt::StringView>::format(builder, MUST(value.debug_description()));return format_error;}
 };
 namespace Jakt {
 } // namespace Jakt
-template<>struct Jakt::Formatter<Jakt::types::CheckedStruct> : Jakt::Formatter<Jakt::StringView>{
-Jakt::ErrorOr<void> format(Jakt::FormatBuilder& builder, Jakt::types::CheckedStruct const& value) {
+template<>struct Jakt::Formatter<Jakt::types::CheckedTypeCast> : Jakt::Formatter<Jakt::StringView>{
+Jakt::ErrorOr<void> format(Jakt::FormatBuilder& builder, Jakt::types::CheckedTypeCast const& value) {
 JaktInternal::PrettyPrint::ScopedEnable pretty_print_enable { m_alternative_form };Jakt::ErrorOr<void> format_error = Jakt::Formatter<Jakt::StringView>::format(builder, MUST(value.debug_description()));return format_error;}
 };
 namespace Jakt {
 } // namespace Jakt
-template<>struct Jakt::Formatter<Jakt::types::BuiltinType> : Jakt::Formatter<Jakt::StringView>{
-Jakt::ErrorOr<void> format(Jakt::FormatBuilder& builder, Jakt::types::BuiltinType const& value) {
-JaktInternal::PrettyPrint::ScopedEnable pretty_print_enable { m_alternative_form };Jakt::ErrorOr<void> format_error = Jakt::Formatter<Jakt::StringView>::format(builder, MUST(value.debug_description()));return format_error;}
-};
-namespace Jakt {
-} // namespace Jakt
-template<>struct Jakt::Formatter<Jakt::types::SafetyMode> : Jakt::Formatter<Jakt::StringView>{
-Jakt::ErrorOr<void> format(Jakt::FormatBuilder& builder, Jakt::types::SafetyMode const& value) {
-JaktInternal::PrettyPrint::ScopedEnable pretty_print_enable { m_alternative_form };Jakt::ErrorOr<void> format_error = Jakt::Formatter<Jakt::StringView>::format(builder, MUST(value.debug_description()));return format_error;}
-};
-namespace Jakt {
-} // namespace Jakt
-template<>struct Jakt::Formatter<Jakt::types::Scope> : Jakt::Formatter<Jakt::StringView>{
-Jakt::ErrorOr<void> format(Jakt::FormatBuilder& builder, Jakt::types::Scope const& value) {
-JaktInternal::PrettyPrint::ScopedEnable pretty_print_enable { m_alternative_form };Jakt::ErrorOr<void> format_error = Jakt::Formatter<Jakt::StringView>::format(builder, MUST(value.debug_description()));return format_error;}
-};
-namespace Jakt {
-} // namespace Jakt
-template<>struct Jakt::Formatter<Jakt::types::LoadedModule> : Jakt::Formatter<Jakt::StringView>{
-Jakt::ErrorOr<void> format(Jakt::FormatBuilder& builder, Jakt::types::LoadedModule const& value) {
-JaktInternal::PrettyPrint::ScopedEnable pretty_print_enable { m_alternative_form };Jakt::ErrorOr<void> format_error = Jakt::Formatter<Jakt::StringView>::format(builder, MUST(value.debug_description()));return format_error;}
-};
-namespace Jakt {
-} // namespace Jakt
-template<>struct Jakt::Formatter<Jakt::types::CheckedVarDecl> : Jakt::Formatter<Jakt::StringView>{
-Jakt::ErrorOr<void> format(Jakt::FormatBuilder& builder, Jakt::types::CheckedVarDecl const& value) {
-JaktInternal::PrettyPrint::ScopedEnable pretty_print_enable { m_alternative_form };Jakt::ErrorOr<void> format_error = Jakt::Formatter<Jakt::StringView>::format(builder, MUST(value.debug_description()));return format_error;}
-};
-namespace Jakt {
-} // namespace Jakt
-template<>struct Jakt::Formatter<Jakt::types::CheckedTraitRequirements> : Jakt::Formatter<Jakt::StringView>{
-Jakt::ErrorOr<void> format(Jakt::FormatBuilder& builder, Jakt::types::CheckedTraitRequirements const& value) {
-JaktInternal::PrettyPrint::ScopedEnable pretty_print_enable { m_alternative_form };Jakt::ErrorOr<void> format_error = Jakt::Formatter<Jakt::StringView>::format(builder, MUST(value.debug_description()));return format_error;}
-};
-namespace Jakt {
-} // namespace Jakt
-template<>struct Jakt::Formatter<Jakt::types::CheckedField> : Jakt::Formatter<Jakt::StringView>{
-Jakt::ErrorOr<void> format(Jakt::FormatBuilder& builder, Jakt::types::CheckedField const& value) {
-JaktInternal::PrettyPrint::ScopedEnable pretty_print_enable { m_alternative_form };Jakt::ErrorOr<void> format_error = Jakt::Formatter<Jakt::StringView>::format(builder, MUST(value.debug_description()));return format_error;}
-};
-namespace Jakt {
-} // namespace Jakt
-template<>struct Jakt::Formatter<Jakt::types::GenericInferences> : Jakt::Formatter<Jakt::StringView>{
-Jakt::ErrorOr<void> format(Jakt::FormatBuilder& builder, Jakt::types::GenericInferences const& value) {
-JaktInternal::PrettyPrint::ScopedEnable pretty_print_enable { m_alternative_form };Jakt::ErrorOr<void> format_error = Jakt::Formatter<Jakt::StringView>::format(builder, MUST(value.debug_description()));return format_error;}
-};
-namespace Jakt {
-} // namespace Jakt
-template<>struct Jakt::Formatter<Jakt::types::NumberConstant> : Jakt::Formatter<Jakt::StringView>{
-Jakt::ErrorOr<void> format(Jakt::FormatBuilder& builder, Jakt::types::NumberConstant const& value) {
-JaktInternal::PrettyPrint::ScopedEnable pretty_print_enable { m_alternative_form };Jakt::ErrorOr<void> format_error = Jakt::Formatter<Jakt::StringView>::format(builder, MUST(value.debug_description()));return format_error;}
-};
-namespace Jakt {
-} // namespace Jakt
-template<>struct Jakt::Formatter<Jakt::types::CheckedNamespace> : Jakt::Formatter<Jakt::StringView>{
-Jakt::ErrorOr<void> format(Jakt::FormatBuilder& builder, Jakt::types::CheckedNamespace const& value) {
-JaktInternal::PrettyPrint::ScopedEnable pretty_print_enable { m_alternative_form };Jakt::ErrorOr<void> format_error = Jakt::Formatter<Jakt::StringView>::format(builder, MUST(value.debug_description()));return format_error;}
-};
-namespace Jakt {
-} // namespace Jakt
-template<>struct Jakt::Formatter<Jakt::types::Module> : Jakt::Formatter<Jakt::StringView>{
-Jakt::ErrorOr<void> format(Jakt::FormatBuilder& builder, Jakt::types::Module const& value) {
-JaktInternal::PrettyPrint::ScopedEnable pretty_print_enable { m_alternative_form };Jakt::ErrorOr<void> format_error = Jakt::Formatter<Jakt::StringView>::format(builder, MUST(value.debug_description()));return format_error;}
-};
-namespace Jakt {
-} // namespace Jakt
-template<>struct Jakt::Formatter<Jakt::types::StructOrEnumId> : Jakt::Formatter<Jakt::StringView>{
-Jakt::ErrorOr<void> format(Jakt::FormatBuilder& builder, Jakt::types::StructOrEnumId const& value) {
-JaktInternal::PrettyPrint::ScopedEnable pretty_print_enable { m_alternative_form };Jakt::ErrorOr<void> format_error = Jakt::Formatter<Jakt::StringView>::format(builder, MUST(value.debug_description()));return format_error;}
-};
-namespace Jakt {
-} // namespace Jakt
-template<>struct Jakt::Formatter<Jakt::types::CheckedParameter> : Jakt::Formatter<Jakt::StringView>{
-Jakt::ErrorOr<void> format(Jakt::FormatBuilder& builder, Jakt::types::CheckedParameter const& value) {
+template<>struct Jakt::Formatter<Jakt::types::CheckedUnaryOperator> : Jakt::Formatter<Jakt::StringView>{
+Jakt::ErrorOr<void> format(Jakt::FormatBuilder& builder, Jakt::types::CheckedUnaryOperator const& value) {
 JaktInternal::PrettyPrint::ScopedEnable pretty_print_enable { m_alternative_form };Jakt::ErrorOr<void> format_error = Jakt::Formatter<Jakt::StringView>::format(builder, MUST(value.debug_description()));return format_error;}
 };
 namespace Jakt {
@@ -2560,8 +2500,68 @@ JaktInternal::PrettyPrint::ScopedEnable pretty_print_enable { m_alternative_form
 };
 namespace Jakt {
 } // namespace Jakt
+template<>struct Jakt::Formatter<Jakt::types::StructLikeId> : Jakt::Formatter<Jakt::StringView>{
+Jakt::ErrorOr<void> format(Jakt::FormatBuilder& builder, Jakt::types::StructLikeId const& value) {
+JaktInternal::PrettyPrint::ScopedEnable pretty_print_enable { m_alternative_form };Jakt::ErrorOr<void> format_error = Jakt::Formatter<Jakt::StringView>::format(builder, MUST(value.debug_description()));return format_error;}
+};
+namespace Jakt {
+} // namespace Jakt
+template<>struct Jakt::Formatter<Jakt::types::CheckedField> : Jakt::Formatter<Jakt::StringView>{
+Jakt::ErrorOr<void> format(Jakt::FormatBuilder& builder, Jakt::types::CheckedField const& value) {
+JaktInternal::PrettyPrint::ScopedEnable pretty_print_enable { m_alternative_form };Jakt::ErrorOr<void> format_error = Jakt::Formatter<Jakt::StringView>::format(builder, MUST(value.debug_description()));return format_error;}
+};
+namespace Jakt {
+} // namespace Jakt
+template<>struct Jakt::Formatter<Jakt::types::ResolvedNamespace> : Jakt::Formatter<Jakt::StringView>{
+Jakt::ErrorOr<void> format(Jakt::FormatBuilder& builder, Jakt::types::ResolvedNamespace const& value) {
+JaktInternal::PrettyPrint::ScopedEnable pretty_print_enable { m_alternative_form };Jakt::ErrorOr<void> format_error = Jakt::Formatter<Jakt::StringView>::format(builder, MUST(value.debug_description()));return format_error;}
+};
+namespace Jakt {
+} // namespace Jakt
+template<>struct Jakt::Formatter<Jakt::types::CheckedBinaryOperator> : Jakt::Formatter<Jakt::StringView>{
+Jakt::ErrorOr<void> format(Jakt::FormatBuilder& builder, Jakt::types::CheckedBinaryOperator const& value) {
+JaktInternal::PrettyPrint::ScopedEnable pretty_print_enable { m_alternative_form };Jakt::ErrorOr<void> format_error = Jakt::Formatter<Jakt::StringView>::format(builder, MUST(value.debug_description()));return format_error;}
+};
+namespace Jakt {
+} // namespace Jakt
+template<>struct Jakt::Formatter<Jakt::types::CheckedEnumVariantBinding> : Jakt::Formatter<Jakt::StringView>{
+Jakt::ErrorOr<void> format(Jakt::FormatBuilder& builder, Jakt::types::CheckedEnumVariantBinding const& value) {
+JaktInternal::PrettyPrint::ScopedEnable pretty_print_enable { m_alternative_form };Jakt::ErrorOr<void> format_error = Jakt::Formatter<Jakt::StringView>::format(builder, MUST(value.debug_description()));return format_error;}
+};
+namespace Jakt {
+} // namespace Jakt
+template<>struct Jakt::Formatter<Jakt::types::CheckedExpression> : Jakt::Formatter<Jakt::StringView>{
+Jakt::ErrorOr<void> format(Jakt::FormatBuilder& builder, Jakt::types::CheckedExpression const& value) {
+JaktInternal::PrettyPrint::ScopedEnable pretty_print_enable { m_alternative_form };Jakt::ErrorOr<void> format_error = Jakt::Formatter<Jakt::StringView>::format(builder, MUST(value.debug_description()));return format_error;}
+};
+namespace Jakt {
+} // namespace Jakt
+template<>struct Jakt::Formatter<Jakt::types::NumericOrStringValue> : Jakt::Formatter<Jakt::StringView>{
+Jakt::ErrorOr<void> format(Jakt::FormatBuilder& builder, Jakt::types::NumericOrStringValue const& value) {
+JaktInternal::PrettyPrint::ScopedEnable pretty_print_enable { m_alternative_form };Jakt::ErrorOr<void> format_error = Jakt::Formatter<Jakt::StringView>::format(builder, MUST(value.debug_description()));return format_error;}
+};
+namespace Jakt {
+} // namespace Jakt
+template<>struct Jakt::Formatter<Jakt::types::SafetyMode> : Jakt::Formatter<Jakt::StringView>{
+Jakt::ErrorOr<void> format(Jakt::FormatBuilder& builder, Jakt::types::SafetyMode const& value) {
+JaktInternal::PrettyPrint::ScopedEnable pretty_print_enable { m_alternative_form };Jakt::ErrorOr<void> format_error = Jakt::Formatter<Jakt::StringView>::format(builder, MUST(value.debug_description()));return format_error;}
+};
+namespace Jakt {
+} // namespace Jakt
 template<>struct Jakt::Formatter<Jakt::types::CheckedTrait> : Jakt::Formatter<Jakt::StringView>{
 Jakt::ErrorOr<void> format(Jakt::FormatBuilder& builder, Jakt::types::CheckedTrait const& value) {
+JaktInternal::PrettyPrint::ScopedEnable pretty_print_enable { m_alternative_form };Jakt::ErrorOr<void> format_error = Jakt::Formatter<Jakt::StringView>::format(builder, MUST(value.debug_description()));return format_error;}
+};
+namespace Jakt {
+} // namespace Jakt
+template<>struct Jakt::Formatter<Jakt::types::CheckedFunction> : Jakt::Formatter<Jakt::StringView>{
+Jakt::ErrorOr<void> format(Jakt::FormatBuilder& builder, Jakt::types::CheckedFunction const& value) {
+JaktInternal::PrettyPrint::ScopedEnable pretty_print_enable { m_alternative_form };Jakt::ErrorOr<void> format_error = Jakt::Formatter<Jakt::StringView>::format(builder, MUST(value.debug_description()));return format_error;}
+};
+namespace Jakt {
+} // namespace Jakt
+template<>struct Jakt::Formatter<Jakt::types::Module> : Jakt::Formatter<Jakt::StringView>{
+Jakt::ErrorOr<void> format(Jakt::FormatBuilder& builder, Jakt::types::Module const& value) {
 JaktInternal::PrettyPrint::ScopedEnable pretty_print_enable { m_alternative_form };Jakt::ErrorOr<void> format_error = Jakt::Formatter<Jakt::StringView>::format(builder, MUST(value.debug_description()));return format_error;}
 };
 namespace Jakt {

--- a/bootstrap/stage0/types_specializations.cpp
+++ b/bootstrap/stage0/types_specializations.cpp
@@ -28,6 +28,7 @@
 #include "jakt__platform.h"
 #include "jakt__arguments.h"
 #include "jakt__prelude__prelude.h"
+#include "jakt__prelude__hash.h"
 #include "jakt__prelude__operators.h"
 #include "jakt__prelude__string.h"
 #include "jakt__prelude__iteration.h"

--- a/bootstrap/stage0/utility.h
+++ b/bootstrap/stage0/utility.h
@@ -2,13 +2,7 @@
 #include "__unified_forward.h"
 namespace Jakt {
 namespace utility {
-struct FileId {
-  public:
-size_t id;FileId(size_t a_id);
-
-bool equals(utility::FileId const rhs) const;
-ErrorOr<DeprecatedString> debug_description() const;
-};namespace IterationDecision_Details {
+namespace IterationDecision_Details {
 template<typename T>
 struct Break {
 T value;
@@ -46,7 +40,13 @@ break;}
 return builder.to_string();
 }
 };
-struct Span {
+struct FileId {
+  public:
+size_t id;FileId(size_t a_id);
+
+bool equals(utility::FileId const rhs) const;
+ErrorOr<DeprecatedString> debug_description() const;
+};struct Span {
   public:
 utility::FileId file_id;size_t start;size_t end;bool contains(utility::Span const span) const;
 Span(utility::FileId a_file_id, size_t a_start, size_t a_end);
@@ -61,16 +61,16 @@ template <typename T>
 ErrorOr<JaktInternal::DynamicArray<T>> add_arrays(JaktInternal::DynamicArray<T> const a, JaktInternal::DynamicArray<T> const b);
 }
 } // namespace Jakt
-template<>struct Jakt::Formatter<Jakt::utility::FileId> : Jakt::Formatter<Jakt::StringView>{
-Jakt::ErrorOr<void> format(Jakt::FormatBuilder& builder, Jakt::utility::FileId const& value) {
-JaktInternal::PrettyPrint::ScopedEnable pretty_print_enable { m_alternative_form };Jakt::ErrorOr<void> format_error = Jakt::Formatter<Jakt::StringView>::format(builder, MUST(value.debug_description()));return format_error;}
-};
-namespace Jakt {
-} // namespace Jakt
 template<typename T>struct Jakt::Formatter<Jakt::utility::IterationDecision<T>
 > : Jakt::Formatter<Jakt::StringView>{
 Jakt::ErrorOr<void> format(Jakt::FormatBuilder& builder, Jakt::utility::IterationDecision<T>
  const& value) {
+JaktInternal::PrettyPrint::ScopedEnable pretty_print_enable { m_alternative_form };Jakt::ErrorOr<void> format_error = Jakt::Formatter<Jakt::StringView>::format(builder, MUST(value.debug_description()));return format_error;}
+};
+namespace Jakt {
+} // namespace Jakt
+template<>struct Jakt::Formatter<Jakt::utility::FileId> : Jakt::Formatter<Jakt::StringView>{
+Jakt::ErrorOr<void> format(Jakt::FormatBuilder& builder, Jakt::utility::FileId const& value) {
 JaktInternal::PrettyPrint::ScopedEnable pretty_print_enable { m_alternative_form };Jakt::ErrorOr<void> format_error = Jakt::Formatter<Jakt::StringView>::format(builder, MUST(value.debug_description()));return format_error;}
 };
 namespace Jakt {

--- a/bootstrap/stage0/utility_specializations.cpp
+++ b/bootstrap/stage0/utility_specializations.cpp
@@ -28,6 +28,7 @@
 #include "jakt__platform.h"
 #include "jakt__arguments.h"
 #include "jakt__prelude__prelude.h"
+#include "jakt__prelude__hash.h"
 #include "jakt__prelude__operators.h"
 #include "jakt__prelude__string.h"
 #include "jakt__prelude__iteration.h"

--- a/runtime/Builtins/Dictionary.h
+++ b/runtime/Builtins/Dictionary.h
@@ -23,9 +23,27 @@ struct DirectlyPeekableTraits : public Traits<T> {
     using ConstPeekType = T const&;
 };
 
+template<typename T>
+struct JaktHashableKeyTraits : public Traits<T> {
+    static constexpr bool equals(T const& a, T const& b) {
+        if constexpr (requires { { a.equals(b) } -> SameAs<bool>; })
+            return a.equals(b);
+        else
+            return a == b;
+    }
+
+    static constexpr unsigned hash(T value)
+    {
+        if constexpr (requires { { value.hash() } -> SameAs<u32>; })
+            return value.hash();
+        else
+            return Traits<T>::hash(value);
+    }
+};
+
 template<typename K, typename V>
 struct DictionaryStorage : public RefCounted<DictionaryStorage<K, V>> {
-    HashMap<K, V, Traits<K>, DirectlyPeekableTraits<V>> map;
+    HashMap<K, V, JaktHashableKeyTraits<K>, DirectlyPeekableTraits<V>> map;
 };
 
 template<typename K, typename V>

--- a/runtime/Jakt/Forward.h
+++ b/runtime/Jakt/Forward.h
@@ -6,7 +6,7 @@
 
 #pragma once
 
-#include <Jakt/Types.h>
+#include <Jakt/AKIntegration.h>
 
 
 namespace JaktInternal {
@@ -17,78 +17,5 @@ class DynamicArray;
 namespace Jakt {
 
 using JaktInternal::DynamicArray;
-
-class Bitmap;
-class Error;
-class GenericLexer;
-class String;
-class StringBuilder;
-class StringImpl;
-class StringView;
-class Time;
-class Utf8CodePointIterator;
-class Utf8View;
-
-template<typename T>
-class Span;
-
-template<typename T, size_t Size>
-struct Array;
-
-template<typename Container, typename ValueType>
-class SimpleIterator;
-
-using ReadonlyBytes = Span<const u8>;
-using Bytes = Span<u8>;
-
-template<typename T, Jakt::MemoryOrder DefaultMemoryOrder>
-class Atomic;
-
-template<typename T>
-struct Traits;
-
-template<typename T, typename TraitsForT = Traits<T>, bool IsOrdered = false>
-class HashTable;
-
-template<typename T, typename TraitsForT = Traits<T>>
-using OrderedHashTable = HashTable<T, TraitsForT, true>;
-
-template<typename K, typename V, typename KeyTraits = Traits<K>, typename ValueTraits = Traits<V>, bool IsOrdered = false>
-class HashMap;
-
-template<typename K, typename V, typename KeyTraits = Traits<K>, typename ValueTraits = Traits<V>>
-using OrderedHashMap = HashMap<K, V, KeyTraits, ValueTraits, true>;
-
-template<typename>
-class Function;
-
-template<typename Out, typename... In>
-class Function<Out(In...)>;
-
-template<typename T>
-class NonnullRefPtr;
-
-template<typename T>
-class Optional;
-
-#ifdef KERNEL
-template<typename T>
-struct RefPtrTraits;
-
-template<typename T, typename PtrTraits = RefPtrTraits<T>>
-class RefPtr;
-#else
-template<typename T>
-class RefPtr;
-#endif
-
-template<typename T>
-class WeakPtr;
-
-template<typename T, typename ErrorType = Error>
-class [[nodiscard]] ErrorOr;
-
-template<typename T, typename = void>
-struct Formatter;
 
 }

--- a/runtime/jaktlib/prelude/hash.jakt
+++ b/runtime/jaktlib/prelude/hash.jakt
@@ -1,0 +1,34 @@
+trait DefaultHashable = match reflect Self {
+    U8 | U16 | U32 | U64
+    | I8 | I16 | I32 | I64
+    | Usize | CChar | CInt
+    | F32 | F64 | Bool
+    | JaktString => true
+    else => false
+}
+
+import extern "Jakt/Forward.h" {
+    namespace AK {
+        struct Traits<T> {
+            extern fn Traits<U>() -> Traits<U>
+            extern fn hash(this, anon x: T) -> u32
+        }
+    }
+}
+
+trait Hashable {
+    fn hash(this) -> u32
+}
+
+forall<T requires(DefaultHashable)>
+type T implements(Hashable) {
+    [[inline(always)]]
+    fn hash(this) -> u32 => AK::Traits<T>().hash(this)
+}
+
+type String implements(Hashable) {}
+
+type StringView implements(Hashable) {
+    [[inline(always)]]
+    fn hash(this) -> u32 => AK::Traits<StringView>().hash(this)
+}

--- a/runtime/jaktlib/prelude/hash.jakt
+++ b/runtime/jaktlib/prelude/hash.jakt
@@ -14,10 +14,17 @@ import extern "Jakt/Forward.h" {
             extern fn hash(this, anon x: T) -> u32
         }
     }
+
+    extern fn pair_int_hash(anon a: u32, anon b: u32) -> u32
 }
 
 trait Hashable {
     fn hash(this) -> u32
+
+    [[inline(always)]]
+    fn pair_hash_with<T requires(Hashable)>(this, anon other: &T) -> u32 {
+        return pair_int_hash(.hash(), other.hash())
+    }
 }
 
 forall<T requires(DefaultHashable)>

--- a/runtime/jaktlib/prelude/prelude.jakt
+++ b/runtime/jaktlib/prelude/prelude.jakt
@@ -1,3 +1,4 @@
 import jakt::prelude::iteration { IntoIterator, IntoThrowingIterator, Iterable, ThrowingIterable }
 import jakt::prelude::string { FromStringLiteral, ThrowingFromStringLiteral }
 import jakt::prelude::operators { * }
+import jakt::prelude::hash { * }

--- a/samples/traits/basic.jakt
+++ b/samples/traits/basic.jakt
@@ -2,7 +2,7 @@
 /// - output: "100\n69\n"
 
 // trait definition
-trait Hashable {
+trait MyHashable {
     fn hash(this) -> u64
 }
 
@@ -12,14 +12,14 @@ trait Bar {
 
 
 // implementation on a struct
-struct S implements(Hashable, Bar) {
+struct S implements(MyHashable, Bar) {
     fn hash(this) => 100u64
     fn bar(mut this) {
         println("S::bar")
     }
 }
 
-enum Baz implements(Hashable) {
+enum Baz implements(MyHashable) {
     Foo
     Bar
 
@@ -31,14 +31,14 @@ enum Baz implements(Hashable) {
 
 // implementing traits for builtin types can be done
 // through a newtype pattern.
-struct U64Hash implements(Hashable) {
+struct U64Hash implements(MyHashable) {
     value: u64
 
     fn hash(this) -> u64 => .value
 }
 
 // trait requiremennt on function
-fn print_hash<T requires(Hashable)>(anon value: T) {
+fn print_hash<T requires(MyHashable)>(anon value: T) {
     println("{}", value.hash())
 }
 

--- a/selfhost/codegen.jakt
+++ b/selfhost/codegen.jakt
@@ -2053,7 +2053,10 @@ struct CodeGenerator {
                     else => ""
                 }
                 // FIXME: Remove this once we have proper type mutability support
-                RawAddress => "const_cast<" + .codegen_type(type_id) + ">(" + "&"
+                RawAddress => match .program.get_type(type_id).is_boxed(program: .program) {
+                    true => "const_cast<" + .codegen_type_possibly_as_namespace(type_id, as_namespace: true) + ">(" + "&*"
+                    false => "const_cast<" + .codegen_type(type_id) + ">(" + "&"
+                }
                 LogicalNot => "!"
                 BitwiseNot => "~"
                 Sizeof => "sizeof"
@@ -3703,7 +3706,10 @@ struct CodeGenerator {
         CChar => "char"
         CInt => "int"
         Never => "void"
-        RawPtr(type_id) => .codegen_type(type_id) + "*"
+        RawPtr(type_id) => match .program.get_type(type_id).is_boxed(program: .program) {
+            true => .codegen_type_possibly_as_namespace(type_id, as_namespace: true) + "*"
+            false => .codegen_type(type_id) + "*"
+        }
         Reference(type_id) => .codegen_type(type_id) + " const&"
         MutableReference(type_id) => .codegen_type(type_id) + "&"
         GenericResolvedType(id, args) | GenericInstance(id, args) => .codegen_generic_type_instance(id, args, as_namespace)

--- a/selfhost/codegen.jakt
+++ b/selfhost/codegen.jakt
@@ -462,36 +462,35 @@ struct CodeGenerator {
         return result
     }
 
-    fn postorder_traversal(this, encoded_type_id: String, mut visited: {String}, encoded_dependency_graph: [String: [String]], mut output: [TypeId]) throws {
-        let type_id = TypeId::from_string(encoded_type_id)
-        if visited.contains(type_id.to_string()) {
+    fn postorder_traversal(this, type_id: TypeId, mut visited: {TypeId}, dependency_graph: [TypeId: [TypeId]], mut output: [TypeId]) throws {
+        if visited.contains(type_id) {
             return
         }
-        visited.add(type_id.to_string())
-        if encoded_dependency_graph.contains(encoded_type_id) {
-            for dependency in encoded_dependency_graph.get(encoded_type_id)! {
-                .postorder_traversal(encoded_type_id: dependency, visited, encoded_dependency_graph, output)
+        visited.add(type_id)
+        if dependency_graph.contains(type_id) {
+            for dependency in dependency_graph.get(type_id)! {
+                .postorder_traversal(type_id: dependency, visited, dependency_graph, output)
             }
         }
         output.push(type_id)
     }
 
-    fn produce_codegen_dependency_graph(this, scope: Scope) throws -> [String : [String]] {
-        mut dependency_graph: [String : [String]] = [:]
+    fn produce_codegen_dependency_graph(this, scope: Scope) throws -> [TypeId:[TypeId]] {
+        mut dependency_graph: [TypeId:[TypeId]] = [:]
 
         for type_ in scope.types {
-            dependency_graph.set(type_.1.to_string(), .extract_dependencies_from(type_id: type_.1, dependency_graph, top_level: true))
+            dependency_graph.set(type_.1, .extract_dependencies_from(type_id: type_.1, dependency_graph, top_level: true))
         }
 
         return dependency_graph
     }
 
-    fn extract_dependencies_from(this, type_id: TypeId, dependency_graph: [String : [String]], top_level: bool) throws -> [String] {
-        mut dependencies: [String] = []
+    fn extract_dependencies_from(this, type_id: TypeId, dependency_graph: [TypeId:[TypeId]], top_level: bool) throws -> [TypeId] {
+        mut dependencies: [TypeId] = []
 
         let type_ = .program.get_type(type_id)
-        if not type_.is_boxed(program: .program) and dependency_graph.contains(type_id.to_string()) {
-            for dependency in dependency_graph.get(type_id.to_string())! {
+        if not type_.is_boxed(program: .program) and dependency_graph.contains(type_id) {
+            for dependency in dependency_graph.get(type_id)! {
                 dependencies.push(dependency)
             }
             return dependencies
@@ -512,8 +511,8 @@ struct CodeGenerator {
         return dependencies
     }
 
-    fn extract_dependencies_from_enum(this, enum_id: EnumId, dependency_graph: [String : [String]], top_level: bool) throws -> [String] {
-        mut dependencies: [String] = []
+    fn extract_dependencies_from_enum(this, enum_id: EnumId, dependency_graph: [TypeId:[TypeId]], top_level: bool) throws -> [TypeId] {
+        mut dependencies: [TypeId] = []
 
         let enum_ = .program.get_enum(enum_id)
         if enum_.definition_linkage is External {
@@ -526,8 +525,8 @@ struct CodeGenerator {
             // include them in the dependency graph.
             return dependencies
         }
-        dependencies.push(enum_.type_id.to_string())
-        if not enum_.underlying_type_id.equals(unknown_type_id()) {
+        dependencies.push(enum_.type_id)
+        if enum_.underlying_type_id != unknown_type_id() {
             let inner_dependencies = .extract_dependencies_from(type_id: enum_.underlying_type_id, dependency_graph, top_level: false)
             for dependency in inner_dependencies {
                 dependencies.push(dependency)
@@ -557,8 +556,14 @@ struct CodeGenerator {
         return dependencies
     }
 
-    fn extract_dependencies_from_struct(this, struct_id: StructId, dependency_graph: [String : [String]], top_level: bool, args: [TypeId]) throws -> [String] {
-        mut dependencies: [String] = []
+    fn extract_dependencies_from_struct(
+        this
+        struct_id: StructId
+        dependency_graph: [TypeId:[TypeId]]
+        top_level: bool
+        args: [TypeId]
+    ) throws -> [TypeId] {
+        mut dependencies: [TypeId] = []
         let struct_ = .program.get_struct(struct_id)
 
         if struct_.definition_linkage is External and struct_.name != "Optional" {
@@ -589,11 +594,11 @@ struct CodeGenerator {
         mut super_struct_id = struct_.super_struct_id
         while super_struct_id.has_value() {
             let super_struct = .program.get_struct(super_struct_id!)
-            dependencies.push(super_struct.type_id.to_string())
+            dependencies.push(super_struct.type_id)
             super_struct_id = super_struct.super_struct_id
         }
 
-        dependencies.push(struct_.type_id.to_string())
+        dependencies.push(struct_.type_id)
         // The struct's fields are also dependencies.
         for field in struct_.fields {
             let type_id = .program.get_variable(field.variable_id).type_id
@@ -772,7 +777,7 @@ struct CodeGenerator {
         if scope.alias_path.has_value() or scope.import_path_if_extern.has_value() {
             return ""
         }
-        mut seen_types: {String} = {}
+        mut seen_types: {TypeId} = {}
 
         mut output = ""
         if scope.namespace_name.has_value() {
@@ -794,7 +799,7 @@ struct CodeGenerator {
                     continue
                 }
                 let struct_ = .program.get_struct(struct_id)
-                if seen_types.contains(struct_.type_id.to_string()) {
+                if seen_types.contains(struct_.type_id) {
                     continue
                 }
 
@@ -820,7 +825,7 @@ struct CodeGenerator {
                     continue
                 }
                 let enum_ = .program.get_enum(enum_id)
-                if seen_types.contains(enum_.type_id.to_string()) {
+                if seen_types.contains(enum_.type_id) {
                     continue
                 }
 
@@ -863,7 +868,7 @@ struct CodeGenerator {
         if scope.alias_path.has_value() or scope.import_path_if_extern.has_value() {
             return ""
         }
-        mut seen_types: {String} = {}
+        mut seen_types: {TypeId} = {}
 
         if as_forward {
             mut output = ""
@@ -871,13 +876,13 @@ struct CodeGenerator {
                 output += "namespace " + scope.namespace_name! + " {\n"
             }
 
-            let encoded_dependency_graph = .produce_codegen_dependency_graph(scope)
-            for entry in encoded_dependency_graph {
+            let dependency_graph = .produce_codegen_dependency_graph(scope)
+            for entry in dependency_graph {
                 let traversal: [TypeId] = []
                 .postorder_traversal(
-                    encoded_type_id: entry.0
+                    type_id: entry.0
                     visited: seen_types
-                    encoded_dependency_graph
+                    dependency_graph
                     output: traversal
                 )
                 for type_id in traversal {
@@ -912,7 +917,7 @@ struct CodeGenerator {
                             panic(format("Unexpected type in dependency graph: {}", type_))
                         }
                     }
-                    seen_types.add(type_id.to_string())
+                    seen_types.add(type_id)
                 }
             }
 
@@ -921,7 +926,7 @@ struct CodeGenerator {
                     continue
                 }
                 let struct_ = .program.get_struct(struct_id)
-                if seen_types.contains(struct_.type_id.to_string()) {
+                if seen_types.contains(struct_.type_id) {
                     continue
                 }
                 output += .codegen_struct(struct_)
@@ -933,7 +938,7 @@ struct CodeGenerator {
                     continue
                 }
                 let enum_ = .program.get_enum(enum_id)
-                if seen_types.contains(enum_.type_id.to_string()) {
+                if seen_types.contains(enum_.type_id) {
                     continue
                 }
                 output += .codegen_enum(enum_)

--- a/selfhost/ids.jakt
+++ b/selfhost/ids.jakt
@@ -1,0 +1,83 @@
+import jakt::prelude::hash { pair_int_hash }
+
+struct ModuleId implements(Hashable, Equal<ModuleId>) {
+    id: usize
+
+    fn equals(this, anon rhs: ModuleId) -> bool {
+        return this.id == rhs.id
+    }
+
+    fn hash(this) -> u32 {
+        return .id.hash()
+    }
+}
+
+struct VarId {
+    module: ModuleId
+    id: usize
+}
+
+struct FunctionId {
+    module: ModuleId
+    id: usize
+
+    fn equals(this, anon rhs: FunctionId) -> bool {
+        return this.module.id == rhs.module.id and this.id == rhs.id
+    }
+}
+
+struct StructId {
+    module: ModuleId
+    id: usize
+
+    fn equals(this, anon rhs: StructId) -> bool {
+        return this.module.id == rhs.module.id and this.id == rhs.id
+    }
+}
+
+struct EnumId {
+    module: ModuleId
+    id: usize
+
+    fn equals(this, anon rhs: EnumId) -> bool {
+        return this.module.id == rhs.module.id and this.id == rhs.id
+    }
+}
+
+struct TypeId implements(Hashable, Equal<TypeId>) {
+    module: ModuleId
+    id: usize
+
+    fn none() -> TypeId? => None
+
+    fn equals(this, anon rhs: TypeId) -> bool {
+        return this.module.id == rhs.module.id and this.id == rhs.id
+    }
+
+    // FIXME: Using .id.pair_hash_with(&.module) here causes a compiler crash.
+    fn hash(this) -> u32 {
+        return pair_int_hash(.id.hash(), .module.hash())
+    }
+}
+
+struct TraitId {
+    module: ModuleId
+    id: usize
+
+    fn equals(this, anon other: TraitId) -> bool {
+        return this.module.id == other.module.id and this.id == other.id
+    }
+}
+
+struct ScopeId implements(Hashable, Equal<ScopeId>) {
+    module_id: ModuleId
+    id: usize
+
+    fn equals(this, anon other: ScopeId) -> bool {
+        return this.module_id.id == other.module_id.id and this.id == other.id
+    }
+
+    fn hash(this) -> u32 {
+        return pair_int_hash(.id.hash(), .module_id.hash())
+    }
+}

--- a/selfhost/interpreter.jakt
+++ b/selfhost/interpreter.jakt
@@ -990,13 +990,13 @@ enum Deferred {
 class InterpreterScope {
     public bindings: [String:Value]
     public parent: InterpreterScope?
-    public type_bindings: [String:TypeId]
+    public type_bindings: [TypeId:TypeId]
     public defers: [Deferred]
 
     public fn create(
         bindings: [String:Value] = [:]
         parent: InterpreterScope? = None
-        type_bindings: [String: TypeId] = [:]
+        type_bindings: [TypeId:TypeId] = [:]
     ) throws -> InterpreterScope => InterpreterScope(
         bindings
         parent
@@ -1082,15 +1082,14 @@ class InterpreterScope {
     }
 
     public fn map_type(this, anon id: TypeId) throws -> TypeId {
-        let name = id.to_string()
-        if .type_bindings.contains(name) {
-            return .type_bindings[name]
+        if .type_bindings.contains(id) {
+            return .type_bindings[id]
         }
 
         mut scope = .parent
         while scope.has_value() {
-            if scope!.type_bindings.contains(name) {
-                return scope!.type_bindings[name]
+            if scope!.type_bindings.contains(id) {
+                return scope!.type_bindings[id]
             }
             scope = scope!.parent
         }
@@ -1098,18 +1097,18 @@ class InterpreterScope {
         return id
     }
 
-    fn type_map_for_substitution_helper(this, map: &mut [String:String]) throws {
+    fn type_map_for_substitution_helper(this, map: &mut [TypeId:TypeId]) throws {
         if .parent.has_value() {
             .parent!.type_map_for_substitution_helper(map)
         }
 
         for pair in .type_bindings {
-            map.set(pair.0, pair.1.to_string())
+            map.set(pair.0, pair.1)
         }
     }
 
     public fn type_map_for_substitution(this) throws -> GenericInferences {
-        mut map: [String:String] = [:]
+        mut map: [TypeId:TypeId] = [:]
         .type_map_for_substitution_helper(&mut map)
         return GenericInferences(values: map)
     }
@@ -1151,8 +1150,8 @@ class Interpreter {
     public compiler: Compiler
     public program: CheckedProgram
     public spans: [Span]
-    public reflected_type_cache: [String:Value]
-    public seen_reflected_types: {String}
+    public reflected_type_cache: [TypeId:Value]
+    public seen_reflected_types: {TypeId}
     public current_function_id: FunctionId?
     public typecheck_functions: TypecheckFunctions
 
@@ -1535,7 +1534,15 @@ class Interpreter {
         return TypeId(module: ModuleId(id: 0), id: .program.modules[0].types.size() - 1)
     }
 
-    public fn call_prelude_function(mut this, anon prelude_function: String, anon namespace_: [ResolvedNamespace], this_argument: Value?, arguments: [Value], call_span: Span, type_bindings: [String:TypeId]) throws -> StatementResult {
+    public fn call_prelude_function(
+        mut this
+        anon prelude_function: String
+        anon namespace_: [ResolvedNamespace]
+        this_argument: Value?
+        arguments: [Value]
+        call_span: Span
+        type_bindings: [TypeId:TypeId]
+    ) throws -> StatementResult {
         if namespace_.size() != 1 {
             return match prelude_function {
                 "format" => {
@@ -1586,7 +1593,7 @@ class Interpreter {
                         parent_scope_id: .program.prelude_scope_id()
                         function_name: "as_saturated")![0])
 
-                    let output_type_id = type_bindings.get(function.generics.params[0].type_id().to_string())
+                    let output_type_id = type_bindings.get(function.generics.params[0].type_id())
                     yield StatementResult::JustValue(
                         cast_value_to_type(arguments[0], output_type_id!, interpreter: this, saturating: true)
                     )
@@ -3595,7 +3602,7 @@ class Interpreter {
                 namespace_ = effective_namespace
             }
 
-            mut type_bindings: [String:TypeId] = [:]
+            mut type_bindings: [TypeId:TypeId] = [:]
             if invocation_scope.has_value() {
                 type_bindings = invocation_scope!.type_bindings
             }
@@ -6275,12 +6282,12 @@ class Interpreter {
                 })
             }
 
-            mut type_bindings: [String:TypeId] = [:]
+            mut type_bindings: [TypeId:TypeId] = [:]
             for i in 0..function_to_run.generics.params.size() {
                 let param = function_to_run.generics.params[i]
 
                 type_bindings.set(
-                    param.type_id().to_string()
+                    param.type_id()
                     call.type_args[i]
                 )
             }
@@ -7630,14 +7637,13 @@ class Interpreter {
 
     public fn reflect_type(mut this, type_id: TypeId, span: Span, scope: InterpreterScope) throws -> Value {
         let mapped_type_id = scope.map_type(type_id)
-        let mapped_type_key = mapped_type_id.to_string()
 
-        if .reflected_type_cache.contains(mapped_type_key) {
-            return .reflected_type_cache.get(mapped_type_key)!
+        if .reflected_type_cache.contains(mapped_type_id) {
+            return .reflected_type_cache.get(mapped_type_id)!
         }
 
-        .seen_reflected_types.add(mapped_type_key)
-        defer .seen_reflected_types.remove(mapped_type_key)
+        .seen_reflected_types.add(mapped_type_id)
+        defer .seen_reflected_types.remove(mapped_type_id)
 
         let type = .program.get_type(mapped_type_id)
         let reflected_enum_id = match .program.find_reflected_primitive("Type") {
@@ -7655,7 +7661,7 @@ class Interpreter {
             )
             span
         )
-        .reflected_type_cache.set(mapped_type_key, result)
+        .reflected_type_cache.set(mapped_type_id, result)
 
         mut fields: [Value] = []
         let found_constructor = match type {

--- a/selfhost/typechecker.jakt
+++ b/selfhost/typechecker.jakt
@@ -33,7 +33,7 @@ import compiler { Compiler }
 import interpreter { Interpreter, InterpreterScope, ExecutionResult, value_to_checked_expression }
 
 enum FunctionMatchResult {
-    MatchSuccess(args: [CheckedExpression], maybe_this_type_id: TypeId?, used_generic_inferences: [String:String], specificity: i64)
+    MatchSuccess(args: [CheckedExpression], maybe_this_type_id: TypeId?, used_generic_inferences: [TypeId:TypeId], specificity: i64)
     MatchError(errors: [JaktError])
 }
 
@@ -3477,7 +3477,7 @@ struct Typechecker {
                         for field in common_fields {
                             fields.push(field)
                         }
-                        
+
                         if (variant.params is Some(variant_params) and variant.default_values is Some(variant_default_values)) {
                             for i in 0..variant_params.size() {
                                 let param = variant_params[i]
@@ -3504,7 +3504,7 @@ struct Typechecker {
                                     // FIXME: The typechecker can't find expressions that are outside the scope of the enum.
                                     // FIXME: Get the real safety mode from somewhere, right now it assumes it is safe.
                                     checked_default_value = .typecheck_expression(expression, scope_id: enum_.scope_id, safety_mode: SafetyMode::Safe, type_hint: type_id)
-                                } 
+                                }
 
                                 params.push(CheckedParameter(requires_label: true, variable: checked_var, default_value: checked_default_value))
 
@@ -4258,7 +4258,7 @@ struct Typechecker {
                     mut interpreter = .interpreter()
                     mut scope = InterpreterScope::create(
                         type_bindings: [
-                            .find_or_add_type_id(Type::Self).to_string(): generic_argument
+                            .find_or_add_type_id(Type::Self): generic_argument
                         ]
                     )
                     let result = try interpreter.execute_expression(expr, scope)
@@ -4383,9 +4383,9 @@ struct Typechecker {
         let span = parsed_function.name_span
         for generic_parameter in checked_function.generics.params {
             let parameter_type_id = generic_parameter.checked_parameter.type_id
-            let mapped = generic_substitutions.get(parameter_type_id.to_string())
+            let mapped = generic_substitutions.get(parameter_type_id)
             guard mapped.has_value() else { continue }
-            let type_id = TypeId::from_string(mapped!)
+            let type_id = mapped!
             guard .get_type(parameter_type_id) is TypeVariable(name: type_name) else { continue }
 
             let dependent_scope_id: ScopeId? = match .get_type(parameter_type_id) {
@@ -4682,9 +4682,6 @@ struct Typechecker {
             )
         }
 
-        let lhs_type_id_string = lhs_type_id.to_string()
-        let rhs_type_id_string = rhs_type_id.to_string()
-
         let optional_struct_id = .find_struct_in_prelude("Optional")
         let weakptr_struct_id = .find_struct_in_prelude("WeakPtr")
         let array_struct_id = .find_struct_in_prelude("Array")
@@ -4692,9 +4689,9 @@ struct Typechecker {
         match lhs_type {
             TypeVariable => {
                 // If the call expects a generic type variable, let's see if we've already seen it
-                mut seen_type_id_string = generic_inferences.get(lhs_type_id_string)
-                if seen_type_id_string.has_value() {
-                    let seen_type_id = TypeId::from_string(seen_type_id_string!)
+                mut maybe_seen_type_id = generic_inferences.get(lhs_type_id)
+                if maybe_seen_type_id.has_value() {
+                    let seen_type_id = maybe_seen_type_id!
                     if .get_type(seen_type_id) is TypeVariable {
                         return .check_types_for_compat(
                             lhs_type_id: seen_type_id
@@ -4704,7 +4701,7 @@ struct Typechecker {
                     }
                     // We've seen this type variable assigned something before
                     // we should error if it's incompatible.
-                    if seen_type_id_string.value() != rhs_type_id_string {
+                    if seen_type_id != rhs_type_id {
                         .error(
                             format(
                                 "Type mismatch: expected ‘{}’, but got ‘{}’"
@@ -4716,7 +4713,7 @@ struct Typechecker {
                         return false
                     }
                 } else {
-                    generic_inferences.set(key: lhs_type_id_string, value: rhs_type_id_string)
+                    generic_inferences.set(key: lhs_type_id, value: rhs_type_id)
                 }
             }
             GenericEnumInstance(id: lhs_enum_id, args: lhs_args) => {
@@ -4913,21 +4910,21 @@ struct Typechecker {
                         }
                     }
                     TypeVariable => {
-                        let seen_type_id_string = generic_inferences.get(rhs_type_id_string)
-                        if seen_type_id_string.has_value() {
-                            if seen_type_id_string.value() != lhs_type_id_string {
+                        let maybe_seen_type_id = generic_inferences.get(rhs_type_id)
+                        if maybe_seen_type_id.has_value() {
+                            if maybe_seen_type_id! != lhs_type_id {
                                 .error(
                                     format(
                                         "Type mismatch: expected ‘{}’, but got ‘{}’"
                                         .type_name(lhs_type_id)
-                                        .type_name(TypeId::from_string(seen_type_id_string.value()))
+                                        .type_name(maybe_seen_type_id.value())
                                     )
                                     span
                                 )
                                 return false
                             }
                         } else {
-                            generic_inferences.set(key: lhs_type_id_string, value: rhs_type_id_string)
+                            generic_inferences.set(key: lhs_type_id, value: rhs_type_id)
                         }
                     }
                     else => {
@@ -4976,16 +4973,16 @@ struct Typechecker {
                     }
                     TypeVariable => {
                         // If the call expects a generic type variable, let's see if we've already seen it
-                        let seen_type_id_string = generic_inferences.get(rhs_type_id_string)
-                        if seen_type_id_string.has_value() {
+                        let seen_type_id = generic_inferences.get(rhs_type_id)
+                        if seen_type_id.has_value() {
                             // We've seen this type variable assigned something before
                             // we should error if it's incompatible.
 
-                            if seen_type_id_string.value() != lhs_type_id_string {
+                            if seen_type_id.value() != lhs_type_id {
                                 .error(
                                     format(
                                         "Type mismatch: expected ‘{}’, but got ‘{}’"
-                                        .type_name(TypeId::from_string(seen_type_id_string.value()))
+                                        .type_name(seen_type_id.value())
                                         .type_name(rhs_type_id)
                                     )
                                     span
@@ -4993,7 +4990,7 @@ struct Typechecker {
                                 return false
                             }
                         } else {
-                            generic_inferences.set(key: lhs_type_id_string, value: rhs_type_id_string)
+                            generic_inferences.set(key: lhs_type_id, value: rhs_type_id)
                         }
                     }
                     else => {
@@ -5075,7 +5072,7 @@ struct Typechecker {
                 }
             }
             else => {
-                if generic_inferences.map_name(rhs_type_id_string) != generic_inferences.map_name(lhs_type_id_string) {
+                if generic_inferences.map(rhs_type_id) != generic_inferences.map(lhs_type_id) {
                     .error(
                         format("Type mismatch: expected ‘{}’, but got ‘{}’", .type_name(lhs_type_id), .type_name(rhs_type_id))
                         span
@@ -8781,8 +8778,8 @@ struct Typechecker {
         if type_to_match_on is GenericEnumInstance(id, args) {
             let enum_ = .get_enum(id)
             for i in 0..enum_.generic_parameters.size() {
-                let generic = enum_.generic_parameters[i].type_id.to_string()
-                let argument_type = args[i].to_string()
+                let generic = enum_.generic_parameters[i].type_id
+                let argument_type = args[i]
                 if generic != argument_type {
                     .generic_inferences.set(generic, argument_type)
                 }
@@ -9559,7 +9556,7 @@ struct Typechecker {
             let typevar_type_id = callee_candidate.generics.params[type_arg_index].type_id()
 
             if not typevar_type_id.equals(checked_type) {
-                .generic_inferences.set(typevar_type_id.to_string(), checked_type.to_string())
+                .generic_inferences.set(typevar_type_id, checked_type)
             }
 
             type_arg_index += 1
@@ -9582,8 +9579,8 @@ struct Typechecker {
                     }
 
                     .generic_inferences.set(
-                        structure.generic_parameters[i].type_id.to_string()
-                        args[i].to_string()
+                        structure.generic_parameters[i].type_id
+                        args[i]
                     )
                 }
             }
@@ -9716,14 +9713,14 @@ struct Typechecker {
             }
         }
 
-        mut generic_inferences_from_parent: [String:String] = [:]
+        mut generic_inferences_from_parent: [TypeId:TypeId] = [:]
         if parent_id.has_value() and parent_id!.generic_arguments.has_value() {
             let arguments = parent_id!.generic_arguments!
             let parameters = parent_id!.generic_parameters(&.program)
 
             for i in 0..arguments.size() {
-                generic_inferences_from_parent.set(parameters[i].to_string(), arguments[i].to_string())
-                .generic_inferences.set(parameters[i].to_string(), arguments[i].to_string())
+                generic_inferences_from_parent.set(parameters[i], arguments[i])
+                .generic_inferences.set(parameters[i], arguments[i])
             }
         }
 
@@ -9752,7 +9749,7 @@ struct Typechecker {
             else => {
                 mut max_found_specificity = -1i64
                 mut errors_while_trying_to_find_matching_function: [JaktError] = []
-                mut generic_inferences_for_best_match: [String:String] = [:]
+                mut generic_inferences_for_best_match: [TypeId:TypeId] = [:]
                 // find the best match i.e. the most specific implementation that matches the signature
                 for candidate in resolved_function_id_candidates.iterator() {
                     match .match_function_and_resolve_args(call, caller_scope_id, candidate, safety_mode, span, this_expr) {
@@ -9862,9 +9859,9 @@ struct Typechecker {
 
                 for generic_typevar in callee.generics.params {
                     if generic_typevar.kind is Parameter {
-                        let substitution = .generic_inferences.get(generic_typevar.type_id().to_string())
+                        let substitution = .generic_inferences.get(generic_typevar.type_id())
                         if substitution.has_value() {
-                            generic_arguments.push(TypeId::from_string(substitution!))
+                            generic_arguments.push(substitution!)
                         } else if not .in_comptime_function_call {
                             .error("Not all generic parameters have known types", span)
                         } else {
@@ -9997,7 +9994,7 @@ struct Typechecker {
 
             for entry in .generic_inferences.iterator() {
                 let (key, value) = entry
-                eval_scope.type_bindings.set(key, TypeId::from_string(value))
+                eval_scope.type_bindings.set(key, value)
             }
 
             if this_expr.has_value() {
@@ -10050,12 +10047,12 @@ struct Typechecker {
             }
 
 
-            mut type_bindings: [String:TypeId] = [:]
+            mut type_bindings: [TypeId:TypeId] = [:]
             for i in 0uz..resolved_function.generics.params.size() {
                 let param = resolved_function.generics.params[i]
 
                 type_bindings.set(
-                    param.type_id().to_string()
+                    param.type_id()
                     function_call.type_args[i]
                 )
             }
@@ -10481,11 +10478,11 @@ struct AlreadyImplementedFor {
 // helper struct to implement the checking of trait implementations
 struct TraitImplCheck {
     // methods that don't yet have a specified implementation.
-    missing_methods: [String:[String:FunctionId]] // typeid -> [method name -> function id]
+    missing_methods: [TypeId:[String:FunctionId]] // typeid -> [method name -> function id]
     // same name, but signature doesn't match.
-    unmatched_signatures: [String:[String:Span]] // typeid -> [method name -> span]
+    unmatched_signatures: [TypeId:[String:Span]] // typeid -> [method name -> span]
     // same name, signature matches, but isn't marked public.
-    private_matching_methods: [String:[String:Span]] // typeid -> [method name -> span]
+    private_matching_methods: [TypeId:[String:Span]] // typeid -> [method name -> span]
     // 'Cannot implement method X for trait Y since it already implements Z'
     already_implemented_for: [String:AlreadyImplementedFor] // trait name -> (type name, span)
 
@@ -10513,9 +10510,8 @@ struct TraitImplCheck {
             return
         }
 
-        let type_name = trait_type_id.to_string()
-        .unmatched_signatures[type_name] = [:]
-        .private_matching_methods[type_name] = [:]
+        .private_matching_methods[trait_type_id] = [:]
+        .unmatched_signatures[trait_type_id] = [:]
 
         mut missing_methods: [String:FunctionId] = [:]
         missing_methods.ensure_capacity(trait_methods.size())
@@ -10525,12 +10521,12 @@ struct TraitImplCheck {
             missing_methods.set(method_name, method_id)
         }
 
-        .missing_methods.set(type_name, missing_methods)
+        .missing_methods.set(trait_type_id, missing_methods)
     }
 
     fn throw_errors(mut this, record_decl_span: Span, typechecker: &mut Typechecker) throws {
-        for (trait_type_name, missing_methods) in .missing_methods {
-            let (trait_id, trait_generic_arguments) = match typechecker.get_type(TypeId::from_string(trait_type_name)) {
+        for (trait_type_id, missing_methods) in .missing_methods {
+            let (trait_id, trait_generic_arguments) = match typechecker.get_type(trait_type_id) {
                 GenericTraitInstance(id: trait_id, args) | Trait(trait_id) default(args: [TypeId] = []) => (trait_id, args)
                 else => {
                     // unreachable
@@ -10540,8 +10536,8 @@ struct TraitImplCheck {
 
             let trait_name = typechecker.get_trait(trait_id).name
 
-            let unmatched_signatures = .unmatched_signatures[trait_type_name]
-            let private_matching_methods = .private_matching_methods[trait_type_name]
+            let unmatched_signatures = .unmatched_signatures[trait_type_id]
+            let private_matching_methods = .private_matching_methods[trait_type_id]
             for (method_name, trait_method_id) in missing_methods {
                 let already_implemented_for = .already_implemented_for.get(method_name)
                 let unmatched_signature = unmatched_signatures.get(method_name)
@@ -10598,7 +10594,7 @@ struct TraitImplCheck {
         let method = typechecker.get_function(method_id)
 
         // search for a matching method
-        for (trait_type_name, methods) in .missing_methods {
+        for (trait_type_id, methods) in .missing_methods {
             let trait_method_id = methods.get(method_name)
 
             guard trait_method_id.has_value() else {
@@ -10606,7 +10602,7 @@ struct TraitImplCheck {
             }
             let trait_method = typechecker.get_function(trait_method_id!)
 
-            let (trait_id, trait_generic_arguments) = match typechecker.get_type(TypeId::from_string(trait_type_name)) {
+            let (trait_id, trait_generic_arguments) = match typechecker.get_type(trait_type_id) {
                 GenericTraitInstance(id: trait_id, args) | Trait(trait_id) default(args: [TypeId] = []) => (trait_id, args)
                 else => {
                     // unreachable
@@ -10619,19 +10615,19 @@ struct TraitImplCheck {
             defer typechecker.generic_inferences.restore(old_generic_inferences)
 
             guard trait_.generic_parameters.size() == trait_generic_arguments.size() else {
-                .unmatched_signatures[trait_type_name].set(method_name, method.name_span)
+                .unmatched_signatures[trait_type_id].set(method_name, method.name_span)
                 continue
             }
 
             typechecker.generic_inferences.set_all(keys: trait_.generic_parameters, values: trait_generic_arguments)
 
             guard typechecker.signatures_match(self_type_id, trait_method, method) else {
-                .unmatched_signatures[trait_type_name].set(method_name, method.name_span)
+                .unmatched_signatures[trait_type_id].set(method_name, method.name_span)
                 continue
             }
 
             guard method.visibility is Public else {
-                .private_matching_methods[trait_type_name].set(method_name, method.name_span)
+                .private_matching_methods[trait_type_id].set(method_name, method.name_span)
                 continue
             }
 
@@ -10639,7 +10635,7 @@ struct TraitImplCheck {
             // Register it as already implemented so that the rest of the traits
             // that needed a similar method know that the method was already implementing
             // one trait.
-            .missing_methods[trait_type_name].remove(method_name)
+            .missing_methods[trait_type_id].remove(method_name)
             .already_implemented_for[method_name] = AlreadyImplementedFor(trait_name: trait_.name, encounter_span: method.name_span)
             break
         }

--- a/selfhost/typechecker.jakt
+++ b/selfhost/typechecker.jakt
@@ -5302,12 +5302,42 @@ struct Typechecker {
 
             let dict_struct_id = .find_struct_in_prelude("Dictionary")
 
+            // Make sure the key implements Hashable and Equal<itself>
+            .ensure_type_implements_trait(
+                type_id: key_type_id
+                trait_name: "Hashable"
+                scope_id
+                span
+            )
+            .ensure_type_implements_trait(
+                type_id: key_type_id
+                trait_name: "Equal"
+                filter_for_generics: [key_type_id]
+                scope_id
+                span
+            )
+
             yield .find_or_add_type_id(Type::GenericInstance(id: dict_struct_id, args: [key_type_id, value_type_id]))
         }
         Set(inner, span) => {
             let inner_type_id = .typecheck_typename(parsed_type: inner, scope_id, name)
 
             let set_struct_id = .find_struct_in_prelude("Set")
+
+            // Make sure the value implements Hashable and Equal<itself>
+            .ensure_type_implements_trait(
+                type_id: inner_type_id
+                trait_name: "Hashable"
+                scope_id
+                span
+            )
+            .ensure_type_implements_trait(
+                type_id: inner_type_id
+                trait_name: "Equal"
+                filter_for_generics: [inner_type_id]
+                scope_id
+                span
+            )
 
             yield .find_or_add_type_id(Type::GenericInstance(id: set_struct_id, args: [inner_type_id]))
         }
@@ -5405,6 +5435,33 @@ struct Typechecker {
                 return_type_id: checked_function.return_type_id
                 pseudo_function_id: function_id
             ))
+        }
+    }
+
+    fn ensure_type_implements_trait(
+        mut this
+        type_id: TypeId
+        trait_name: String
+        filter_for_generics: [TypeId]? = None
+        scope_id: ScopeId
+        span: Span
+    ) throws {
+        if .get_type(type_id) is TypeVariable {
+            return
+        }
+
+        let implementation = .find_any_singular_trait_implementation(
+            type_id
+            trait_names: [trait_name]
+            scope_id
+            span
+            filter_for_generics
+        )
+        if not implementation.has_value() {
+            .error(
+                format("Type ‘{}’ does not implement trait ‘{}’", .type_name(type_id), trait_name)
+                span
+            )
         }
     }
 
@@ -8474,6 +8531,23 @@ struct Typechecker {
             }
         }
 
+        if not inner_type_id.equals(unknown_type_id()) {
+            // Make sure the key implements Hashable and Equal<itself>
+            .ensure_type_implements_trait(
+                type_id: inner_type_id
+                trait_name: "Hashable"
+                scope_id
+                span
+            )
+            .ensure_type_implements_trait(
+                type_id: inner_type_id
+                trait_name: "Equal"
+                filter_for_generics: [inner_type_id]
+                scope_id
+                span
+            )
+        }
+
         let type_id = .find_or_add_type_id(Type::GenericInstance(
             id: set_struct_id
             args: [inner_type_id]
@@ -9241,6 +9315,23 @@ struct Typechecker {
             } else {
                 .error("Cannot infer key type for Dictionary<K, V>", span)
             }
+        }
+
+        if not key_type_id.equals(unknown_type_id()) {
+            // Make sure the key implements Hashable and Equal<itself>
+            .ensure_type_implements_trait(
+                type_id: key_type_id
+                trait_name: "Hashable"
+                scope_id
+                span
+            )
+            .ensure_type_implements_trait(
+                type_id: key_type_id
+                trait_name: "Equal"
+                filter_for_generics: [key_type_id]
+                scope_id
+                span
+            )
         }
 
         if value_type_id.equals(unknown_type_id()) {

--- a/selfhost/types.jakt
+++ b/selfhost/types.jakt
@@ -111,11 +111,15 @@ enum SafetyMode {
     Unsafe
 }
 
-struct ModuleId {
+struct ModuleId implements(Hashable, Equal<ModuleId>) {
     id: usize
 
     fn equals(this, anon rhs: ModuleId) -> bool {
         return this.id == rhs.id
+    }
+
+    fn hash(this) -> u32 {
+        return .id.hash()
     }
 }
 
@@ -219,7 +223,7 @@ struct TraitId {
     }
 }
 
-struct ScopeId {
+struct ScopeId implements(Hashable, Equal<ScopeId>) {
     module_id: ModuleId
     id: usize
 
@@ -227,7 +231,9 @@ struct ScopeId {
         return this.module_id.id == other.module_id.id and this.id == other.id
     }
 
-    fn to_string(this) throws -> String => format("{}:{}", .module_id.id, .id)
+    fn hash(this) -> u32 {
+        return .id.pair_hash_with(&.module_id)
+    }
 }
 
 enum BuiltinType {
@@ -1981,7 +1987,7 @@ class CheckedProgram {
         anon callback: &fn(scope_id: ScopeId, name_override: String?, is_alias: bool) throws -> IterationDecision<bool>
     ) throws -> bool? {
         mut scopes_to_check = [scope_id]
-        mut seen: {String} = {}
+        mut seen: {ScopeId} = {}
 
         for child in .get_scope(scope_id).children {
             scopes_to_check.insert(before_index: 0, value: child)
@@ -1989,11 +1995,11 @@ class CheckedProgram {
 
         while not scopes_to_check.is_empty() {
             let scope_id = scopes_to_check.pop()!
-            if seen.contains(scope_id.to_string()) {
+            if seen.contains(scope_id) {
                 continue
             }
 
-            seen.add(scope_id.to_string())
+            seen.add(scope_id)
 
             let res = callback(scope_id, name_override: None, is_alias: false)
             match res {
@@ -2018,7 +2024,7 @@ class CheckedProgram {
             for entry in scope.resolution_mixins {
                 scopes_to_check.insert(before_index: 0, value: entry)
                 for child in .get_scope(entry).children {
-                    if not seen.contains(child.to_string()) {
+                    if not seen.contains(child) {
                         scopes_to_check.insert(before_index: 0, value: child)
                     }
                 }
@@ -2027,7 +2033,7 @@ class CheckedProgram {
             if scope.parent.has_value() {
                 scopes_to_check.insert(before_index: 0, value: scope.parent!)
                 for child in .get_scope(scope.parent!).children {
-                    if not seen.contains(child.to_string()) {
+                    if not seen.contains(child) {
                         scopes_to_check.insert(before_index: 0, value: child)
                     }
                 }
@@ -2038,7 +2044,7 @@ class CheckedProgram {
             }
 
             for child in scope.children {
-                if not seen.contains(child.to_string()) {
+                if not seen.contains(child) {
                     scopes_to_check.insert(before_index: 0, value: child)
                 }
             }

--- a/selfhost/types.jakt
+++ b/selfhost/types.jakt
@@ -5,7 +5,7 @@ import parser {
     ParsedParameter, ParsedRecord, ParsedStatement, ParsedType, ParsedVarDecl, Parser, RecordType, TypeCast
     UnaryOperator
 }
-import utility { panic, todo, join, FileId, Span, IterationDecision }
+import utility { FileId, IterationDecision, Queue, Span, join, panic, todo }
 import compiler { Compiler }
 
 enum StructOrEnumId {
@@ -1986,15 +1986,17 @@ class CheckedProgram {
         scope_id: ScopeId
         anon callback: &fn(scope_id: ScopeId, name_override: String?, is_alias: bool) throws -> IterationDecision<bool>
     ) throws -> bool? {
-        mut scopes_to_check = [scope_id]
+        mut scopes_to_check = Queue<ScopeId>()
         mut seen: {ScopeId} = {}
 
+        scopes_to_check.enqueue(scope_id)
+
         for child in .get_scope(scope_id).children {
-            scopes_to_check.insert(before_index: 0, value: child)
+            scopes_to_check.enqueue(child)
         }
 
         while not scopes_to_check.is_empty() {
-            let scope_id = scopes_to_check.pop()!
+            let scope_id = scopes_to_check.dequeue()
             if seen.contains(scope_id) {
                 continue
             }
@@ -2022,19 +2024,19 @@ class CheckedProgram {
             }
 
             for entry in scope.resolution_mixins {
-                scopes_to_check.insert(before_index: 0, value: entry)
+                scopes_to_check.enqueue(entry)
                 for child in .get_scope(entry).children {
                     if not seen.contains(child) {
-                        scopes_to_check.insert(before_index: 0, value: child)
+                        scopes_to_check.enqueue(child)
                     }
                 }
             }
 
             if scope.parent.has_value() {
-                scopes_to_check.insert(before_index: 0, value: scope.parent!)
+                scopes_to_check.enqueue(scope.parent!)
                 for child in .get_scope(scope.parent!).children {
                     if not seen.contains(child) {
-                        scopes_to_check.insert(before_index: 0, value: child)
+                        scopes_to_check.enqueue(child)
                     }
                 }
             }
@@ -2045,7 +2047,7 @@ class CheckedProgram {
 
             for child in scope.children {
                 if not seen.contains(child) {
-                    scopes_to_check.insert(before_index: 0, value: child)
+                    scopes_to_check.enqueue(child)
                 }
             }
         }

--- a/selfhost/types.jakt
+++ b/selfhost/types.jakt
@@ -415,160 +415,143 @@ boxed enum Type {
         Self => "Self"
     }
 
-    fn equals(this, anon rhs: Type) -> bool {
-        if this is Void and rhs is Void {
-            return true
-        } else if this is Bool and rhs is Bool {
-            return true
-        } else if this is U8 and rhs is U8 {
-            return true
-        } else if this is U16 and rhs is U16 {
-            return true
-        } else if this is U32 and rhs is U32 {
-            return true
-        } else if this is U64 and rhs is U64 {
-            return true
-        } else if this is I8 and rhs is I8 {
-            return true
-        } else if this is I16 and rhs is I16 {
-            return true
-        } else if this is I32 and rhs is I32 {
-            return true
-        } else if this is I64 and rhs is I64 {
-            return true
-        } else if this is F32 and rhs is F32 {
-            return true
-        } else if this is F64 and rhs is F64 {
-            return true
-        } else if this is Usize and rhs is Usize {
-            return true
-        } else if this is JaktString and rhs is JaktString {
-            return true
-        } else if this is CChar and rhs is CChar {
-            return true
-        } else if this is CInt and rhs is CInt {
-            return true
-        } else if this is Self and rhs is Self {
-            return true
-        } else if this is Unknown and rhs is Unknown {
-            return true
-        } else if this is Never and rhs is Never {
-            return true
+    fn equals(this, anon rhs: Type) -> bool => match this {
+        Void => rhs is Void
+        Bool => rhs is Bool
+        U8 => rhs is U8
+        U16 => rhs is U16
+        U32 => rhs is U32
+        U64 => rhs is U64
+        I8 => rhs is I8
+        I16 => rhs is I16
+        I32 => rhs is I32
+        I64 => rhs is I64
+        F32 => rhs is F32
+        F64 => rhs is F64
+        Usize => rhs is Usize
+        JaktString => rhs is JaktString
+        CChar => rhs is CChar
+        CInt => rhs is CInt
+        Self => rhs is Self
+        Unknown => rhs is Unknown
+        Never => rhs is Never
+        // FIXME: Check implemented traits for equality.
+        TypeVariable(name: lhs_name) => {
+            if rhs is TypeVariable(name: rhs_name) {
+                return lhs_name == rhs_name
+            }
+            yield false
         }
+        GenericResolvedType(id: lhs_id, args: lhs_args)
+        | GenericInstance(id: lhs_id, args: lhs_args) => {
+            guard rhs is GenericInstance(id: rhs_id, args: rhs_args)
+                and lhs_id.equals(rhs_id)
+                and lhs_args.size() == rhs_args.size() else {
 
-        match this {
-            // FIXME: Check implemented traits for equality.
-            TypeVariable(name: lhs_name) => {
-                if rhs is TypeVariable(name: rhs_name) {
-                    return lhs_name == rhs_name
-                } else {
-                    return false
-                }
-            }
-            GenericInstance(id: lhs_id, args: lhs_args) => {
-                guard rhs is GenericInstance(id: rhs_id, args: rhs_args)
-                    and lhs_id.equals(rhs_id)
-                    and lhs_args.size() == rhs_args.size() else {
-                    return false
-                }
-                mut idx = 0uz
-                while idx < lhs_args.size() {
-                    if not lhs_args[idx].equals(rhs_args[idx]) {
-                        return false
-                    }
-                    idx++
-                }
-                return true
-            }
-            GenericTraitInstance(id: lhs_id, args: lhs_args) => {
-                guard rhs is GenericTraitInstance(id: rhs_id, args: rhs_args)
-                    and lhs_id.equals(rhs_id)
-                    and lhs_args.size() == rhs_args.size() else {
-                    return false
-                }
-                mut idx = 0uz
-                while idx < lhs_args.size() {
-                    if not lhs_args[idx].equals(rhs_args[idx]) {
-                        return false
-                    }
-                    idx++
-                }
-                return true
-            }
-            GenericEnumInstance(id: lhs_id, args: lhs_args) => {
-                guard rhs is GenericEnumInstance(id: rhs_id, args: rhs_args)
-                    and lhs_id.equals(rhs_id)
-                    and lhs_args.size() == rhs_args.size() else {
-                    return false
-                }
-                mut idx = 0uz
-                while idx < lhs_args.size() {
-                    if not lhs_args[idx].equals(rhs_args[idx]) {
-                        return false
-                    }
-                    idx++
-                }
-                return true
-            }
-            Struct(lhs_id) => {
-                if rhs is Struct(rhs_id) {
-                    return lhs_id.equals(rhs_id)
-                }
                 return false
             }
-            Enum(lhs_id) => {
-                if rhs is Enum(rhs_id) {
-                    return lhs_id.equals(rhs_id)
-                } else {
+            mut idx = 0uz
+            while idx < lhs_args.size() {
+                if not lhs_args[idx].equals(rhs_args[idx]) {
                     return false
                 }
+                idx++
             }
-            RawPtr(lhs_id) => {
-                if rhs is RawPtr(rhs_id) {
-                    return lhs_id.equals(rhs_id)
-                } else {
-                    return false
-                }
-            }
-            Reference(lhs_id) => {
-                if rhs is Reference(rhs_id) {
-                    return lhs_id.equals(rhs_id)
-                } else {
-                    return false
-                }
-            }
-            MutableReference(lhs_id) => {
-                if rhs is MutableReference(rhs_id) {
-                    return lhs_id.equals(rhs_id)
-                } else {
-                    return false
-                }
-            }
-            Trait(lhs_id) => {
-                if rhs is Trait(rhs_id) {
-                    return lhs_id.equals(rhs_id)
-                } else {
-                    return false
-                }
-            }
-            Function(params, can_throw, return_type_id) => {
-                guard rhs is Function(params: rhs_params, can_throw: rhs_can_throw, return_type_id: rhs_return_type_id)
-                    and params.size() == rhs_params.size()
-                    and return_type_id.equals(rhs_return_type_id)
-                    and can_throw == rhs_can_throw else {
-                    return false
-                }
-                for i in 0..params.size() {
-                    if not params[i].equals(rhs_params[i]) {
-                        return false
-                    }
-                }
-                return true
-            }
-            else => {}
-        }
 
-        return false
+            return true
+        }
+        GenericTraitInstance(id: lhs_id, args: lhs_args) => {
+            guard rhs is GenericTraitInstance(id: rhs_id, args: rhs_args)
+                and lhs_id.equals(rhs_id)
+                and lhs_args.size() == rhs_args.size() else {
+
+                return false
+            }
+            mut idx = 0uz
+            while idx < lhs_args.size() {
+                if not lhs_args[idx].equals(rhs_args[idx]) {
+                    return false
+                }
+                idx++
+            }
+
+            return true
+        }
+        GenericEnumInstance(id: lhs_id, args: lhs_args) => {
+            guard rhs is GenericEnumInstance(id: rhs_id, args: rhs_args)
+                and lhs_id.equals(rhs_id)
+                and lhs_args.size() == rhs_args.size() else {
+
+                return false
+            }
+            mut idx = 0uz
+            while idx < lhs_args.size() {
+                if not lhs_args[idx].equals(rhs_args[idx]) {
+                    return false
+                }
+                idx++
+            }
+
+            return true
+        }
+        Struct(lhs_id) => {
+            if rhs is Struct(rhs_id) {
+                return lhs_id.equals(rhs_id)
+            }
+
+            return false
+        }
+        Enum(lhs_id) => {
+            if rhs is Enum(rhs_id) {
+                return lhs_id.equals(rhs_id)
+            }
+
+            return false
+        }
+        RawPtr(lhs_id) => {
+            if rhs is RawPtr(rhs_id) {
+                return lhs_id.equals(rhs_id)
+            }
+
+            return false
+        }
+        Reference(lhs_id) => {
+            if rhs is Reference(rhs_id) {
+                return lhs_id.equals(rhs_id)
+            }
+
+            return false
+        }
+        MutableReference(lhs_id) => {
+            if rhs is MutableReference(rhs_id) {
+                return lhs_id.equals(rhs_id)
+            }
+
+            return false
+        }
+        Trait(lhs_id) => {
+            if rhs is Trait(rhs_id) {
+                return lhs_id.equals(rhs_id)
+            }
+
+            return false
+        }
+        Function(params, can_throw, return_type_id) => {
+            guard rhs is Function(params: rhs_params, can_throw: rhs_can_throw, return_type_id: rhs_return_type_id)
+                and params.size() == rhs_params.size()
+                and return_type_id.equals(rhs_return_type_id)
+                and can_throw == rhs_can_throw else {
+
+                return false
+            }
+            for i in 0..params.size() {
+                if not params[i].equals(rhs_params[i]) {
+                    return false
+                }
+            }
+
+            return true
+        }
     }
 
     fn is_builtin(this) -> bool => match this {

--- a/selfhost/types.jakt
+++ b/selfhost/types.jakt
@@ -7,152 +7,11 @@ import parser {
 }
 import utility { FileId, IterationDecision, Queue, Span, join, panic, todo }
 import compiler { Compiler }
+import ids { EnumId, FunctionId, ModuleId, ScopeId, StructId, TraitId, TypeId, VarId }
 
 enum StructOrEnumId {
     Struct(StructId)
     Enum(EnumId)
-}
-
-struct GenericInferences {
-    values: [String:String]
-
-    fn set(mut this, anon key: String, anon value: String) throws {
-        if key == value {
-            println("Warning: Generic parameter {} is being bound to itself", key)
-            abort()
-        }
-
-        let mapped_value = .map_name(value)
-        if key == mapped_value {
-            return
-        }
-
-        .values[key] = mapped_value
-    }
-
-    fn set_all(mut this, keys: [CheckedGenericParameter], values: [TypeId]) throws {
-        for i in 0..(keys.size()) {
-            let key = keys[i].type_id.to_string()
-            let value = values[i].to_string()
-            .set(key, value)
-        }
-    }
-
-    fn get(this, anon key: String) -> String? {
-        return .values.get(key)
-    }
-
-    fn map_name(this, anon type: String) -> String {
-        mut mapped = .values.get(type)
-        mut final_mapped_result = mapped
-        while mapped.has_value() {
-            final_mapped_result = mapped
-            mapped = .values.get(mapped!)
-        }
-        return final_mapped_result ?? type
-    }
-
-    fn map(this, anon type_id: TypeId) throws -> TypeId {
-        return TypeId::from_string(.map_name(type_id.to_string()))
-    }
-
-    fn find_and_map(this, anon name: String, anon program: &CheckedProgram) throws -> TypeId? {
-        for (k, v) in .values {
-            let type_id = TypeId::from_string(k)
-            if program.get_type(type_id) is TypeVariable(name: var_name) and var_name == name {
-                return TypeId::from_string(.map_name(v))
-            }
-        }
-
-        return None
-    }
-
-    fn iterator(this) -> [String:String] => .values
-
-    fn perform_checkpoint(mut this, reset: bool = true) throws -> [String:String] {
-        let result = .values
-        .values = [:]
-
-        if not reset {
-            for (key, value) in result {
-                .values[key] = value
-            }
-        }
-
-        return result
-    }
-
-    fn restore(mut this, anon checkpoint: [String:String]) {
-        .values = checkpoint
-    }
-
-    fn set_from(mut this, anon checkpoint: [String:String]) throws {
-        for (key, value) in checkpoint {
-            .set(key, value)
-        }
-    }
-
-    fn debug_description(this, anon program: &CheckedProgram) throws {
-        eprintln("Generic inferences:")
-        for (key, value) in .values {
-            let key_type = TypeId::from_string(key)
-            let value_type = TypeId::from_string(value)
-            eprintln(
-                "  {} => {}"
-                program.type_name(key_type, debug_mode: true)
-                program.type_name(value_type, debug_mode: true)
-            )
-        }
-    }
-}
-
-enum SafetyMode {
-    Safe
-    Unsafe
-}
-
-struct ModuleId implements(Hashable, Equal<ModuleId>) {
-    id: usize
-
-    fn equals(this, anon rhs: ModuleId) -> bool {
-        return this.id == rhs.id
-    }
-
-    fn hash(this) -> u32 {
-        return .id.hash()
-    }
-}
-
-struct VarId {
-    module: ModuleId
-    id: usize
-}
-
-struct FunctionId {
-    module: ModuleId
-    id: usize
-
-    fn equals(this, anon rhs: FunctionId) -> bool {
-        return this.module.id == rhs.module.id and this.id == rhs.id
-    }
-}
-
-struct StructId {
-    module: ModuleId
-    id: usize
-
-    fn equals(this, anon rhs: StructId) -> bool {
-        return this.module.id == rhs.module.id and this.id == rhs.id
-    }
-}
-
-struct EnumId {
-    module: ModuleId
-    id: usize
-
-    fn equals(this, anon rhs: EnumId) -> bool {
-        return this.module.id == rhs.module.id and this.id == rhs.id
-    }
 }
 
 enum StructLikeId {
@@ -182,58 +41,95 @@ enum StructLikeId {
     }
 }
 
-struct TypeId {
-    module: ModuleId
-    id: usize
+struct GenericInferences {
+    values: [TypeId:TypeId]
 
-    fn none() -> TypeId? => None
-
-    fn equals(this, anon rhs: TypeId) -> bool {
-        return this.module.id == rhs.module.id and this.id == rhs.id
-    }
-
-    // FIXME: Remove when we have language support, used as workaround [String:String] <-> [TypeId:TypeId]
-    fn to_string(this) throws -> String {
-        return format("{}_{}", .module.id, .id)
-    }
-
-    // FIXME: Remove when we have language support, used as workaround [String:String] <-> [TypeId:TypeId]
-    fn from_string(anon type_id_string: String) throws -> TypeId {
-        let parts = type_id_string.split(c'_')
-        if not (parts.size() == 2) {
-            panic(format("Failed to convert string ‘{}’ to a TypeId: Wrong number of parts. (Wanted 2, got {})", type_id_string, parts.size()))
+    fn set(mut this, anon key: TypeId, anon value: TypeId) throws {
+        if key == value {
+            println("Warning: Generic parameter {} is being bound to itself", key)
+            abort()
         }
 
-        let module_id = parts[0].to_uint()
-        let type_id = parts[1].to_uint()
-        if not module_id.has_value() or not type_id.has_value() {
-            panic(format("Failed to convert string ‘{}’ to a TypeId. (module_id = {} ({}), type_id = {} ({}))", type_id_string, module_id, parts[0], type_id, parts[1]))
+        let mapped_value = .map(value)
+        if key == mapped_value {
+            return
         }
 
-        return TypeId(module: ModuleId(id: module_id.value() as! usize), id: type_id.value() as! usize)
+        .values[key] = mapped_value
+    }
+
+    fn set_all(mut this, keys: [CheckedGenericParameter], values: [TypeId]) throws {
+        for i in 0..(keys.size()) {
+            let key = keys[i].type_id
+            let value = values[i]
+            .set(key, value)
+        }
+    }
+
+    fn get(this, anon key: TypeId) -> TypeId? {
+        return .values.get(key)
+    }
+
+    fn map(this, anon type: TypeId) -> TypeId {
+        mut mapped = .values.get(type)
+        mut final_mapped_result = mapped
+        while mapped.has_value() {
+            final_mapped_result = mapped
+            mapped = .values.get(mapped!)
+        }
+        return final_mapped_result ?? type
+    }
+
+    fn find_and_map(this, anon name: String, anon program: &CheckedProgram) throws -> TypeId? {
+        for (type_id, v) in .values {
+            if program.get_type(type_id) is TypeVariable(name: var_name) and var_name == name {
+                return .map(v)
+            }
+        }
+
+        return None
+    }
+
+    fn iterator(this) -> [TypeId:TypeId] => .values
+
+    fn perform_checkpoint(mut this, reset: bool = true) throws -> [TypeId:TypeId] {
+        let result = .values
+        .values = [:]
+
+        if not reset {
+            for (key, value) in result {
+                .values[key] = value
+            }
+        }
+
+        return result
+    }
+
+    fn restore(mut this, anon checkpoint: [TypeId:TypeId]) {
+        .values = checkpoint
+    }
+
+    fn set_from(mut this, anon checkpoint: [TypeId:TypeId]) throws {
+        for (key, value) in checkpoint {
+            .set(key, value)
+        }
+    }
+
+    fn debug_description(this, anon program: &CheckedProgram) throws {
+        eprintln("Generic inferences:")
+        for (key, value) in .values {
+            eprintln(
+                "  {} => {}"
+                program.type_name(key, debug_mode: true)
+                program.type_name(value, debug_mode: true)
+            )
+        }
     }
 }
 
-struct TraitId {
-    module: ModuleId
-    id: usize
-
-    fn equals(this, anon other: TraitId) -> bool {
-        return this.module.id == other.module.id and this.id == other.id
-    }
-}
-
-struct ScopeId implements(Hashable, Equal<ScopeId>) {
-    module_id: ModuleId
-    id: usize
-
-    fn equals(this, anon other: ScopeId) -> bool {
-        return this.module_id.id == other.module_id.id and this.id == other.id
-    }
-
-    fn hash(this) -> u32 {
-        return .id.pair_hash_with(&.module_id)
-    }
+enum SafetyMode {
+    Safe
+    Unsafe
 }
 
 enum BuiltinType {
@@ -898,23 +794,23 @@ class CheckedFunction {
             return false
         }
 
-        mut lhs_generic_type_ids: {String} = {}
-        mut rhs_generic_type_ids: {String} = {}
+        mut lhs_generic_type_ids: {TypeId} = {}
+        mut rhs_generic_type_ids: {TypeId} = {}
         for param in this.generics.params.iterator() {
             let type_id: TypeId = param.type_id()
-            lhs_generic_type_ids.add(type_id.to_string())
+            lhs_generic_type_ids.add(type_id)
         }
         for param in other.generics.params.iterator() {
             let type_id: TypeId = param.type_id()
-            rhs_generic_type_ids.add(type_id.to_string())
+            rhs_generic_type_ids.add(type_id)
         }
 
         for param_index in 0..this.params.size() {
             let lhs_param = this.params[param_index]
             let rhs_param = other.params[param_index]
 
-            let lhs_param_id = lhs_param.variable.type_id.to_string()
-            let rhs_param_id = rhs_param.variable.type_id.to_string()
+            let lhs_param_id = lhs_param.variable.type_id
+            let rhs_param_id = rhs_param.variable.type_id
 
             if not lhs_param.variable.type_id.equals(rhs_param.variable.type_id)
                 and not (lhs_generic_type_ids.contains(lhs_param_id) and rhs_generic_type_ids.contains(rhs_param_id))
@@ -2452,9 +2348,9 @@ class CheckedProgram {
 
         match type_ {
             TypeVariable => {
-                let replacment_type_id_string = generic_inferences.get(type_id.to_string())
-                if replacment_type_id_string.has_value() {
-                    return TypeId::from_string(replacment_type_id_string.value())
+                let replacement_type_id = generic_inferences.get(type_id)
+                if replacement_type_id.has_value() {
+                    return replacement_type_id!
                 }
             }
             GenericTraitInstance(id, args) => {

--- a/selfhost/utility.jakt
+++ b/selfhost/utility.jakt
@@ -173,3 +173,18 @@ enum IterationDecision<T> {
     Break(value: T)
     Continue
 }
+
+import extern "AK/Queue.h" {
+    namespace AK {
+        extern struct Queue<T> {
+            fn Queue<T>() -> Queue<T>
+            fn size(this) -> usize
+            fn is_empty(this) -> bool
+            fn enqueue(mut this, anon value: T)
+            fn dequeue(mut this) -> T
+            fn clear(mut this)
+        }
+    }
+}
+
+use AK::Queue


### PR DESCRIPTION
Depends on fixes in #1423.

Our friend `for_each_scope_accessible_unqualified_from_scope` _really_ loved to convert ScopeIds into strings to put them in a set, and just in case you're not certain, that is indeed a Very Bad Thing to do if you care about performance at all.
This PR introduces the Hashable trait, which allows the user to place any random object implementing it in a set or use it as a dict key.
Using the magical method of wonders called "Strings No Mo", this PR makes the compiler go (a little) faster:

| | Before | After | How much faster is that? |
| :-- | :-: | :-: | :- | 
| Deboog build | 43.5s | 18.2s | 58% |
| Release build | 2.6s | 1.4s | 46% |

tldr:
```
struct Foo implements(Hashable, Equal<Foo>) {
    x: Stuff1
    y: Stuff2
    
    fn equals(this, anon rhs: Foo) -> bool => .x == rhs.x and .y == rhs.y
    fn hash(this) -> u64 => .x.pair_hash_with(&.y)
}

fn foo() {
    let set = {Foo(x: stuff1, y: stuff2)} // yay
}
```