### PR TITLE
parser: Fix infinite loop on invalid enum variant with type

### DIFF
--- a/selfhost/parser.jakt
+++ b/selfhost/parser.jakt
@@ -2994,6 +2994,12 @@ struct Parser {
 
                     while not .eof() {
                         if .peek(1) is Colon {
+                            guard .current() is Identifier else {
+                                .error("Enum variant missing type", .current().span())
+                                .index++
+                                continue
+                            }
+
                             mut var_decl = .parse_variable_declaration(is_mutable: false)
                             if var_decl.parsed_type is Name(name, span) {
                                 var_decl.inlay_span = span

--- a/tests/parser/invalid_enum_variant_with_type.jakt
+++ b/tests/parser/invalid_enum_variant_with_type.jakt
@@ -1,0 +1,8 @@
+/// Expect:
+/// - error: "Enum variant missing type" 
+
+enum Flag {
+    A({:
+}
+
+fn main() {}


### PR DESCRIPTION
A bit of git stash cleaning 🚿

`parse_variable_declaration()` will not push the `.index` if `.current()` is not an `Identifier`