### PR TITLE
lexer: Do not allow c++ keywords as identifiers

### DIFF
--- a/selfhost/lexer.jakt
+++ b/selfhost/lexer.jakt
@@ -187,6 +187,72 @@ enum Token {
     }
 }
 
+fn is_illegal_cpp_keyword(string: String) throws -> bool => match string {
+    "alignas" => true
+    "alignof" => true
+    "and_eq" => true
+    "asm" => true
+    "auto" => true
+    "bitand" => true
+    "bitor" => true
+    "case" => true
+    "char" => true
+    "char8_t" => true
+    "char16_t" => true
+    "char32_t" => true
+    "compl" => true
+    "concept" => true
+    "const" => true
+    "consteval" => true
+    "constexpr" => true
+    "constinit" => true
+    "const_cast" => true
+    "co_await" => true
+    "co_return" => true
+    "co_yield" => true
+    "decltype" => true
+    "delete" => true
+    "do" => true
+    "double" => true
+    "dynamic_cast" => true
+    "explicit" => true
+    "export" => true
+    "float" => true
+    "friend" => true
+    "goto" => true
+    "int" => true
+    "long" => true
+    "mutable" => true
+    "new" => true
+    "noexcept" => true
+    "not_eq" => true
+    "nullptr" => true
+    "operator" => true
+    "or_eq" => true
+    "protected" => true
+    "register" => true
+    "reinterpret_cast" => true
+    "short" => true
+    "signed" => true
+    "static" => true
+    "static_assert" => true
+    "static_cast" => true
+    "switch" => true
+    "template" => true
+    "thread_local" => true
+    "typedef" => true
+    "typeid" => true
+    "typename" => true
+    "union" => true
+    "unsigned" => true
+    "using" => true
+    "volatile" => true
+    "wchar_t" => true
+    "xor" => true
+    "xor_eq" => true
+    else => false
+}
+
 enum LiteralPrefix {
     None
     Hexadecimal
@@ -368,6 +434,10 @@ struct Lexer implements(ThrowingIterable<Token>) {
 
             if end - start >= 6 and string.substring(start: 0, length: 6) == "__jakt" {
                 .error("reserved identifier name", span)
+            }
+
+            if is_illegal_cpp_keyword(string) {
+                .error("C++ keywords are not allowed to be used as identifiers", span)
             }
 
             return Token::from_keyword_or_identifier(string, span)

--- a/tests/parser/cpp_keywords.jakt
+++ b/tests/parser/cpp_keywords.jakt
@@ -1,0 +1,67 @@
+/// Expect:
+/// - error: "C++ keywords are not allowed to be used as identifiers"
+
+fn main() {
+    let alignas = 1
+    let alignof = 1
+    let and_eq = 1
+    let asm = 1
+    let auto = 1
+    let bitand = 1
+    let bitor = 1
+    let case = 1
+    let char = 1
+    let char8_t = 1
+    let char16_t = 1
+    let char32_t = 1
+    let compl = 1
+    let concept = 1
+    let const = 1
+    let consteval = 1
+    let constexpr = 1
+    let constinit = 1
+    let const_cast = 1
+    let co_await = 1
+    let co_return = 1
+    let co_yield = 1
+    let decltype = 1
+    let delete = 1
+    let do = 1
+    let double = 1
+    let dynamic_cast = 1
+    let explicit = 1
+    let export = 1
+    let float = 1
+    let friend = 1
+    let goto = 1
+    let int = 1
+    let long = 1
+    let mutable = 1
+    let new = 1
+    let noexcept = 1
+    let not_eq = 1
+    let nullptr = 1
+    let operator = 1
+    let or_eq = 1
+    let protected = 1
+    let register = 1
+    let reinterpret_cast = 1
+    let short = 1
+    let signed = 1
+    let static = 1
+    let static_assert = 1
+    let static_cast = 1
+    let switch = 1
+    let template = 1
+    let thread_local = 1
+    let typedef = 1
+    let typeid = 1
+    let typename = 1
+    let union = 1
+    let unsigned = 1
+    let using = 1
+    let volatile = 1
+    let wchar_t = 1
+    let xor = 1
+    let xor_eq = 1
+}


### PR DESCRIPTION
Fixes #545.