### PR TITLE
typechecker: Only look for implicit default constructors for defaults

### DIFF
--- a/selfhost/typechecker.jakt
+++ b/selfhost/typechecker.jakt
@@ -1003,7 +1003,7 @@ struct Typechecker {
             }
         }
 
-        guard .program.find_function_in_scope(
+        guard .program.find_default_constructors_in_scope(
             parent_scope_id: checked_struct_scope_id
             function_name: parsed_record.name
         ) is Some(constructor_id) else {

--- a/selfhost/types.jakt
+++ b/selfhost/types.jakt
@@ -2081,10 +2081,26 @@ class CheckedProgram {
 
         let functions = results.value()
         if functions.size() != 1 {
-            .compiler.panic(format("internal error: found multiple (or no) functions with name '{}'", function_name))
+            .compiler.panic(format("internal error: found {} functions with name '{}', but expected 1", functions.size(), function_name))
         }
 
         return functions[0]
+    }
+
+    public fn find_default_constructors_in_scope(this, parent_scope_id: ScopeId, function_name: String) throws -> FunctionId? {
+        let results = .find_functions_with_name_in_scope(parent_scope_id, function_name)
+        if not results.has_value() {
+            return None
+        }
+
+        for id in results.value() {
+            let function = .get_function(id)
+            if function.type is ImplicitConstructor {
+                return id
+            }
+        }
+
+        return None
     }
 
     public fn find_functions_with_name_in_scope(this, parent_scope_id: ScopeId, function_name: String) throws -> [FunctionId]? {

--- a/tests/typechecker/multiple_explicit_ctors.jakt
+++ b/tests/typechecker/multiple_explicit_ctors.jakt
@@ -1,0 +1,12 @@
+/// Expect:
+/// - output: ""
+
+// Allow multiple explicit constructors.
+extern struct Test {
+    fn Test(a: i32) -> Test
+    fn Test(a: i64) -> Test
+}
+
+fn main() {
+
+}


### PR DESCRIPTION
This broke since b37e3e3b7287f6cf9358a13ddf67bde24d84e02c as that commit made the default-argument checker require a single constructor (or ICE).
This commit fixes that, and makes the libline-backed repl build again.