### PR TITLE
typechecker: LHS typevar should be replaced when resolved

### DIFF
--- a/selfhost/typechecker.jakt
+++ b/selfhost/typechecker.jakt
@@ -4688,30 +4688,15 @@ struct Typechecker {
 
         match lhs_type {
             TypeVariable => {
-                // If the call expects a generic type variable, let's see if we've already seen it
-                mut maybe_seen_type_id = generic_inferences.get(lhs_type_id)
-                if maybe_seen_type_id.has_value() {
-                    let seen_type_id = maybe_seen_type_id!
-                    if .get_type(seen_type_id) is TypeVariable {
-                        return .check_types_for_compat(
-                            lhs_type_id: seen_type_id
-                            rhs_type_id: lhs_type_id
-                            generic_inferences
-                            span)
-                    }
-                    // We've seen this type variable assigned something before
-                    // we should error if it's incompatible.
-                    if seen_type_id != rhs_type_id {
-                        .error(
-                            format(
-                                "Type mismatch: expected ‘{}’, but got ‘{}’"
-                                .type_name(seen_type_id)
-                                .type_name(rhs_type_id)
-                            )
-                            span
-                        )
-                        return false
-                    }
+				// Unpack one layer of inference at a time
+                let maybe_resolved_inference = generic_inferences.get(lhs_type_id)
+                if maybe_resolved_inference is Some(resolved_inference) {
+					return .check_types_for_compat(
+						lhs_type_id: resolved_inference
+						rhs_type_id
+						generic_inferences
+						span
+					)
                 } else {
                     generic_inferences.set(key: lhs_type_id, value: rhs_type_id)
                 }

--- a/tests/typechecker/array_type_inference.jakt
+++ b/tests/typechecker/array_type_inference.jakt
@@ -1,0 +1,11 @@
+/// Expect:
+/// - output: ""
+
+// brought up by #1436.
+
+fn main() {
+	mut row: [bool] = [false, false, false, false, false, false, false]
+	mut board: [[bool]] = []
+
+	board.push(row[..].to_array())
+}

--- a/tests/typechecker/match_trait_impl_with_substitutions.jakt
+++ b/tests/typechecker/match_trait_impl_with_substitutions.jakt
@@ -1,0 +1,19 @@
+/// Expect:
+/// - output: "(\"yak\", \"shaved!\")\n"
+
+// brought up by #1246.
+
+struct Foo implements(IntoIterator<(String, String)>) {
+	stuff: [String: String]
+	fn iterator(this) -> DictionaryIterator<String, String> => .stuff.iterator()
+}
+
+fn main() {
+
+	let foo = Foo(stuff: ["yak": "shaved!"])
+
+	for kv in foo {
+		println("{}", kv)
+	}
+	
+}


### PR DESCRIPTION
`When a generic typevar is resolved from LHS, a simple (and working!)
strategy is to just substitute LHS with the resolved type and
re-evaluate the checks, instead of trying to check anything in advance, which will have nuances that are handled in the rest of match cases.

Fixes #1246
Fixes #1436.
