### PR TITLE
meta: Syntax highlight jakt files viewed in github

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,3 @@
 * eof=lf
 
+*.jakt linguist-language=rust


### PR DESCRIPTION
I added syntax highlighting to jakt files viewed in github.
Should make looking through PRs and example code for new comers a bit nicer

If you look at a jakt file in my fork you will see that it has colors rust has the most similar syntax so i went with that language.

https://github.com/IrishBruse/jakt/blob/main/samples/apps/cat.jakt

![image](https://github.com/SerenityOS/jakt/assets/14964651/faa037d5-5152-4e14-bd06-55ffedee5800)
