### PR TITLE
CMake: More Windows build fixes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -76,7 +76,7 @@ target_include_directories(jakt_stage0
     $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}/runtime>
 )
 apply_output_rules(jakt_stage0)
-if (MSVC)
+if (MSVC OR (DEFINED MSVC_VERSION AND CMAKE_CXX_COMPILER_ID STREQUAL "Clang"))
     target_link_options(jakt_stage0 PRIVATE LINKER:/STACK:0x800000)
 endif()
 
@@ -155,7 +155,7 @@ target_include_directories(jakt_stage1
 )
 add_executable(Jakt::jakt_stage1 ALIAS jakt_stage1)
 apply_output_rules(jakt_stage1)
-if (MSVC)
+if (MSVC OR (DEFINED MSVC_VERSION AND CMAKE_CXX_COMPILER_FRONTEND_VARIANT STREQUAL "GNU"))
     target_link_options(jakt_stage1 PRIVATE LINKER:/STACK:0x800000)
 endif()
 
@@ -175,7 +175,7 @@ if (FINAL_STAGE GREATER_EQUAL 2)
   )
   add_executable(Jakt::jakt_stage2 ALIAS jakt_stage2)
   apply_output_rules(jakt_stage2)
-  if (MSVC)
+  if (MSVC OR (DEFINED MSVC_VERSION AND CMAKE_CXX_COMPILER_ID STREQUAL "Clang"))
     target_link_options(jakt_stage2 PRIVATE LINKER:/STACK:0x800000)
   endif()
 endif()

--- a/cmake/jakt-executable.cmake
+++ b/cmake/jakt-executable.cmake
@@ -9,7 +9,6 @@ STRING(TOLOWER ${JAKT_TARGET_IN} JAKT_TARGET)
 
 function(add_jakt_compiler_flags target)
   target_compile_options("${target}" PRIVATE
-    -Wall
     -Wextra
     -Werror
     -Wno-unused-local-typedefs
@@ -36,9 +35,9 @@ function(add_jakt_compiler_flags target)
   )
   if (MSVC)
     # For clang-cl, which shows up to CMake as MSVC and accepts both kinds of arguments
-    target_compile_options("${target}" PRIVATE /permissive- /utf-8 /EHsc-)
+    target_compile_options("${target}" PRIVATE /permissive- /utf-8 /EHsc- -W4)
   else()
-    target_compile_options("${target}" PRIVATE -fno-exceptions -fdiagnostics-color=always)
+    target_compile_options("${target}" PRIVATE -fno-exceptions -fdiagnostics-color=always -Wall)
   endif()
   if (CYGWIN OR MSYS)
     target_compile_options("${target}" PRIVATE -Wa,-mbig-obj)

--- a/cmake/jakt-executable.cmake
+++ b/cmake/jakt-executable.cmake
@@ -35,7 +35,7 @@ function(add_jakt_compiler_flags target)
   )
   if (MSVC)
     # For clang-cl, which shows up to CMake as MSVC and accepts both kinds of arguments
-    target_compile_options("${target}" PRIVATE /permissive- /utf-8 /EHsc- -W4)
+    target_compile_options("${target}" PRIVATE /permissive- /utf-8 /EHsc- -W[123])
   else()
     target_compile_options("${target}" PRIVATE -fno-exceptions -fdiagnostics-color=always -Wall)
   endif()

--- a/documentation/cmake-bootstrap.md
+++ b/documentation/cmake-bootstrap.md
@@ -45,7 +45,19 @@ for validation, set the CMake cache variable `FINAL_STAGE` to `2`.
 
 Jakt is known to compile with clang >=13 on Linux, macOS and Windows. g++ also works, provided the version is >=10.2.
 
-MSVC is not supported, however clang-cl.exe and clang.exe do work and clang-cl is used in CI.
+MSVC is not supported, however clang-cl.exe and clang.exe do work and clang-cl is used in CI. If you have the Clang tools installed through Visual Studio then you must specify `-T ClangCL` or if you want to use Ninja, specify `-GNinja`. Doing neither may cause the build process to fail. Additionally, clang-cl seems dependent on environment variables to find MSVC, so ensure you're running it from the Developer or PowerShell Command Prompt. Clang++ doesn't seem to have the same requirement.
+
+
+```sh
+# Developer/PowerShell Command Prompt and clang-cl with VS packaged Clang
+cmake -B build -T ClangCL
+# Developer/PowerShell Command Prompt and clang-cl
+cmake -B build -GNinja -DCMAKE_CXX_COMPILER=clang-cl
+# Windows Clang++ example
+cmake -B build -GNinja -DCMAKE_CXX_COMPILER=clang++
+```
+
+
 
 On MSYS2, g++ may error out with a "string table overflow" error. In that case, re-configure the build directory with -DCMAKE_BUILD_TYPE=MinSizeRel to get the -Os flag. Do note that using WSL2 or clang directly on windows is a more supported build platform. Maintainers will be reluctant to merge runtime or jakttest patches for MSYS2 quirks to keep the number of supported platfoms under control.
 


### PR DESCRIPTION
There was some inconsistent behaviour when building on Windows depending on the environment and options provided. These changes aim to capture those and provide direction.

If a generator isn't specified with -GNinja, cmake may try to use Visual Studio which won't work. The CMake documentation states that projects shouldn't set CMAKE_GENERATOR, so an error is thrown. SEND_ERROR doesn't halt the build, so it may make sense to change this to FATAL_ERROR.

MSVC only gets set by clang-cl, not clang++. The MSVC test blocks have been expanded to better catch clang++.

Using -Wall with clang-cl enables a bunch of C++ version errors that aren't suppressed by /std:c++20. Using -W[123] with clang-cl specifically solves this. See
https://github.com/llvm/llvm-project/issues/42913

The bootstrap documentation has had a few lines added to assist with understanding these quirks and getting things going on Windows.