### PR TITLE
parser: Allow extern declaration of enums

### DIFF
--- a/selfhost/parser.jakt
+++ b/selfhost/parser.jakt
@@ -1896,6 +1896,13 @@ struct Parser {
                             parsed_namespace.records.push(parsed_class)
                             saw_an_entity = true
                         }
+                        Enum => {
+                            mut parsed_enum = .parse_enum(DefinitionLinkage::External, is_boxed: false)
+                            .apply_attributes(&mut parsed_enum, &active_attributes)
+                            active_attributes = []
+                            parsed_namespace.records.push(parsed_enum)
+                            saw_an_entity = true
+                        }
                         else => {
                             active_attributes = []
                             .error("Unexpected keyword", .current().span())


### PR DESCRIPTION
Makes this work:
```
import extern "foo.h" {
    extern enum Foo : i32 { _1, _2, _3 }
}
```