### PR TITLE
codegen: Nested branch `release_return` handles `void` explicitly

### DIFF
--- a/selfhost/codegen.jakt
+++ b/selfhost/codegen.jakt
@@ -78,21 +78,41 @@ struct ControlFlowState {
         )
     }
     fn is_match_nested(this) -> bool => .match_nest_level != 0
-    fn apply_control_flow_macro(this, anon x: String) throws -> String {
+
+    // Instead of trying to use `release_return()` which returns `void`, we'll
+    // directly construct a `ExplicitValueOrControlFlow<MatchResult, void>` so
+    // that the compiler doesn't try to construct one from a `void` value,
+    // which it doesn't know how to do.
+    fn nested_release_return_expr(func_return_type: TypeId, func_can_throw: bool, cpp_match_result_type: String) throws -> String {
+
+        let returns_void = func_return_type.equals(void_type_id()) or func_return_type.equals(unknown_type_id())
+
+        // The C++ function won't return 'void' if it can throw, but rather
+        // `ErrorOr`.
+        if returns_void and not func_can_throw {
+            return format("JaktInternal::ExplicitValueOrControlFlow<{}, void>()", cpp_match_result_type)
+        } else {
+            return "_jakt_value.release_return()"
+        }
+    }
+
+    fn apply_control_flow_macro(this, anon x: String, func_return_type: TypeId, func_can_throw: bool, cpp_match_result_type: String) throws -> String {
         if are_loop_exits_allowed(.allowed_exits) {
             if .is_match_nested() {
+
                 return format(
                     "({{
     auto&& _jakt_value = {};
     if (_jakt_value.is_return())
-        return _jakt_value.release_return();
+        return {};
     if (_jakt_value.is_loop_break())
         return JaktInternal::LoopBreak {{}};
     if (_jakt_value.is_loop_continue())
         return JaktInternal::LoopContinue {{}};
     _jakt_value.release_value();
 }})",
-                    x
+                    x,
+                    nested_release_return_expr(func_return_type, func_can_throw, cpp_match_result_type)
                 )
             }
             return format(
@@ -113,10 +133,14 @@ struct ControlFlowState {
             "({{
     auto&& _jakt_value = {};
     if (_jakt_value.is_return())
-        return _jakt_value.release_return();
+        return {};
     _jakt_value.release_value();
 }})",
-            x
+            x,
+            match .is_match_nested() {
+                false => "_jakt_value.release_return()",
+                true => nested_release_return_expr(func_return_type, func_can_throw, cpp_match_result_type),
+            }
         )
     }
 }
@@ -2535,10 +2559,12 @@ struct CodeGenerator {
         }
         let match_values_all_constant = all_variants_constant and not is_generic_enum
 
+        let cpp_match_result_type = .codegen_type(return_type_id)
+
         // TODO: Use switch statement if all values are constant
         output += format(
             "([&]() -> JaktInternal::ExplicitValueOrControlFlow<{},{}>"
-            .codegen_type(return_type_id)
+            cpp_match_result_type,
             .codegen_function_return_type(function: .current_function!)
         ) + "{\n"
 
@@ -2664,7 +2690,12 @@ struct CodeGenerator {
 
         output += "}())"
 
-        return .control_flow_state.apply_control_flow_macro(output)
+        return .control_flow_state.apply_control_flow_macro(
+            output,
+            func_return_type: .current_function!.return_type_id,
+            func_can_throw: .current_function!.can_throw,
+            cpp_match_result_type
+        )
     }
 
     fn codegen_enum_match(mut this, enum_: CheckedEnum, expr: CheckedExpression, match_cases: [CheckedMatchCase], type_id: TypeId, all_variants_constant: bool) throws -> String {
@@ -2673,9 +2704,11 @@ struct CodeGenerator {
         let subject = .codegen_expression(expr)
         let needs_deref = enum_.is_boxed and subject != "*this"
 
+        let cpp_match_result_type = .codegen_type(type_id)
+
         if enum_.underlying_type_id.equals(void_type_id()) {
             output += "([&]() -> JaktInternal::ExplicitValueOrControlFlow<"
-            output += .codegen_type(type_id)
+            output += cpp_match_result_type
             output += ", "
             output += .codegen_function_return_type(function: .current_function!)
             output += ">{\n"
@@ -2784,7 +2817,7 @@ struct CodeGenerator {
             output += "}()\n)"
         } else {
             output += "([&]() -> JaktInternal::ExplicitValueOrControlFlow<"
-            output += .codegen_type(type_id)
+            output += cpp_match_result_type
             output += ", "
             output += .codegen_function_return_type(function: .current_function!)
             output += ">{\n"
@@ -2811,7 +2844,12 @@ struct CodeGenerator {
             output += "}()\n)"
         }
 
-        return .control_flow_state.apply_control_flow_macro(output)
+        return .control_flow_state.apply_control_flow_macro(
+            output,
+            func_return_type: .current_function!.return_type_id,
+            func_can_throw: .current_function!.can_throw,
+            cpp_match_result_type
+        )
     }
 
     fn codegen_match_body(mut this, body: CheckedMatchBody, return_type_id: TypeId) throws -> String {

--- a/tests/codegen/explicit_void_in_nested_match.jakt
+++ b/tests/codegen/explicit_void_in_nested_match.jakt
@@ -1,0 +1,19 @@
+/// Expect:
+/// - output: ""
+
+// Brought up by @robryanx on Discord.
+fn test() {
+    let x = 1
+        
+    match x {
+        else => {
+            match x {
+                else => {}
+            }
+        }
+    }
+}
+
+fn main() {
+    test()
+}


### PR DESCRIPTION
Since C++ can't implicitly construct `ExplicitValue<void>` from `void`,
Jakt outputs explicit constructors of `ExplicitValue<void>()`. Now it
also outputs them when calling `release_return` under nested matches.
