### PR TITLE
CI: Workflow to build Clang on Windows

### DIFF
--- a/.github/workflows/win64_llvm_clang_build_and_cache.yml
+++ b/.github/workflows/win64_llvm_clang_build_and_cache.yml
@@ -1,0 +1,50 @@
+name: Build CMake Libraries
+
+on:
+  workflow_dispatch:
+
+env:
+    LLVM_VER: 16.0.6
+    BRANCH: llvmorg-16.0.6
+
+jobs:
+
+   build:
+    runs-on: windows-latest
+ 
+    steps:
+    - uses: actions/checkout@v3
+    - name: Setup Ninja
+      uses: ashutoshvarma/setup-ninja@master
+      with:
+        # ninja version to download. Default: 1.10.0
+        version: 1.10.0
+        dest: ${{ github.workspace }}/ninja_bin
+               
+    - name: Clone LLVM
+      uses: actions/checkout@v3
+      with:
+        repository: 'llvm/llvm-project'
+        ref: ${{ env.BRANCH }}
+        path: 'llvm-project-${{ env.LLVM_VER }}'
+        fetch-depth: 1
+
+
+    - name: Configure CMake
+      shell: cmd
+      run: |
+        "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvarsall.bat" x64 &^
+        cmake -GNinja -S llvm-project-%LLVM_VER%\llvm -B llvm-build -DCMAKE_CXX_COMPILER=clang-cl -DCMAKE_C_COMPILER=clang-cl -DLLVM_ENABLE_PROJECTS=clang -DCMAKE_BUILD_TYPE=Release -DCMAKE_EXE_LINKER_FLAGS="/machine:x64" -DCMAKE_INSTALL_PREFIX="%GITHUB_WORKSPACE%/llvm-install-%LLVM_VER%/"
+
+    - name: Build
+      shell: cmd
+      run: |
+        "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvarsall.bat" x64 &^
+        ninja -C llvm-project clang install
+
+    - name: Cache LibClang
+      id: cache-clang
+      uses: actions/cache@v3
+      with:
+        path: 'llvm-install-${{ env.LLVM_VER }}/'
+        key: 'libclang-${{ runner.os }}-${{ env.LLVM_VER }}'


### PR DESCRIPTION
This workflow will fetch, build, and cache LLVM Clang on an x64 action runner. The build needs to be done in release mode or the standard runners will not have enough space to complete the build.

This job will take approximately 3 hours and 45 minutes to complete.