### PR TITLE
Jakt: Configure version number from git hash

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -47,6 +47,7 @@ function(apply_output_rules target)
 endfunction()
 
 include(cmake/jakt-executable.cmake)
+include(cmake/generate-version-from-git.cmake)
 
 add_subdirectory(runtime)
 
@@ -99,6 +100,7 @@ set(SELFHOST_SOURCES
   selfhost/types.jakt
   selfhost/utility.jakt
   selfhost/platform.jakt
+  selfhost/version.jakt
 )
 
 # FIXME: STDLIB target needed

--- a/cmake/generate-version-from-git.cmake
+++ b/cmake/generate-version-from-git.cmake
@@ -1,0 +1,14 @@
+# Get the latest abbreviated commit hash of the working branch
+execute_process(
+  COMMAND git rev-parse HEAD
+  WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+  OUTPUT_VARIABLE GIT_VER
+  OUTPUT_STRIP_TRAILING_WHITESPACE
+)
+
+# Generate version_info.cpp
+configure_file(
+  ${CMAKE_SOURCE_DIR}/cmake/version.jakt.in
+  ${CMAKE_SOURCE_DIR}/selfhost/version.jakt
+  @ONLY
+)

--- a/cmake/version.jakt.in
+++ b/cmake/version.jakt.in
@@ -1,0 +1,5 @@
+struct Version {
+    public fn val(value: String = "@GIT_VER@") -> String {
+        return value
+    }
+}

--- a/selfhost/main.jakt
+++ b/selfhost/main.jakt
@@ -27,6 +27,7 @@ import repl { REPL, serialize_ast_node }
 import typechecker { Typechecker }
 import types { FunctionId, ResolvedNamespace, ScopeId, ModuleId, Value, ValueImpl }
 import utility { Span, escape_for_quotes, join, write_to_file}
+import version { Version }
 
 import platform_fs() {
     make_directory
@@ -158,7 +159,7 @@ fn main(args: [String]) -> c_int {
     }
 
     if args_parser.flag(["-v", "--version"]) {
-        println("unreleased")
+        println("{}", Version::val())
         return 0
     }
 


### PR DESCRIPTION
This change is my attempt at configuring the version number from the git hash. I've tried to keep the change as modular as possible and out of the way of the primary files (selfhost/main.jakt and CMakeLists.txt).

This addresses Andreas' request in issue #1334.