### PR TITLE
nix: Fix various issues with nix devshell

### DIFF
--- a/jakt.nix
+++ b/jakt.nix
@@ -8,6 +8,6 @@ pkgs.mkShell
     cmake
     ninja
     python3
-    clang_14
+    clang_15
   ];
 }

--- a/jakt.nix
+++ b/jakt.nix
@@ -7,6 +7,7 @@ pkgs.mkShell
     pkgconfig
     cmake
     ninja
+    python3
     clang_14
   ];
 }


### PR DESCRIPTION
This PR fixes two issues:

- Jakttest won't run without python3, since it runs `run_one.py` as its helper script.
- Jakt won't build with `clang_14`, it has issues with `StringView` prefix:
```bash
set -xe
rm -rf build
cmake -B build -DCMAKE_CXX_COMPILER=clang++ -G Ninja
ninja -C build
```
<details><summary>Build log:</summary>

```
-- The CXX compiler identification is Clang 14.0.6
-- The C compiler i+ ninja -C build
GNU 11.3.0
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Check for working CXX compiler: /nix/store/32nc0cdhkw8hygcxycychwcdf8r9ipfj-clang-wrapper-14.0.6/bin/clang++ - skipped
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Check for working C compiler: /nix/store/y372k7srz9jm7v9sv2cs84g3crz27z1s-gcc-wrapper-11.3.0/bin/gcc - skipped
-- Detecting C compile features
-- Detecting C compile features - done
-- Performing Test CMAKE_HAVE_LIBC_PTHREAD
-- Performing Test CMAKE_HAVE_LIBC_PTHREAD - Success
-- Found Threads: TRUE  
-- Could NOT find Clang (missing: Clang_DIR)
-- Using none as the cpp import processor (using Clang=OFF)
-- Configuring done
-- Generating done
-- Build files have been written to: /home/gsus/jakt/build
ninja: Entering directory `build'
[0/2] Re-checking globbed directories...
[1/223] Building CXX object CMakeFiles/jakt_stage0.dir/bootstrap/stage0/ids.cpp.o
[2/223] Building CXX object CMakeFiles/jakt_stage0.dir/bootstrap/stage0/jakt__arguments.cpp.o
[3/223] Building CXX object CMakeFiles/jakt_stage0.dir/bootstrap/stage0/error.cpp.o
[4/223] Building CXX object CMakeFiles/jakt_stage0.dir/bootstrap/stage0/build.cpp.o
[5/223] Building CXX object CMakeFiles/jakt_stage0.dir/bootstrap/stage0/compiler.cpp.o
[6/223] Building CXX object CMakeFiles/jakt_stage0.dir/bootstrap/stage0/jakt__file_iterator.cpp.o
[7/223] Building CXX object CMakeFiles/jakt_stage0.dir/bootstrap/stage0/jakt__libc__io.cpp.o
[8/223] Building CXX object CMakeFiles/jakt_stage0.dir/bootstrap/stage0/jakt__path.cpp.o
[9/223] Building CXX object CMakeFiles/jakt_stage0.dir/bootstrap/stage0/jakt__platform.cpp.o
[10/223] Building CXX object CMakeFiles/jakt_stage0.dir/bootstrap/stage0/jakt__platform__unknown_fs.cpp.o
[11/223] Building CXX object CMakeFiles/jakt_stage0.dir/bootstrap/stage0/__prelude___specializations.cpp.o
[12/223] Building CXX object CMakeFiles/jakt_stage0.dir/bootstrap/stage0/error_specializations.cpp.o
[13/223] Building CXX object CMakeFiles/jakt_stage0.dir/bootstrap/stage0/compiler_specializations.cpp.o
[14/223] Building CXX object CMakeFiles/jakt_stage0.dir/bootstrap/stage0/ide_specializations.cpp.o
[15/223] Building CXX object CMakeFiles/jakt_stage0.dir/bootstrap/stage0/build_specializations.cpp.o
[16/223] Building CXX object CMakeFiles/jakt_stage0.dir/bootstrap/stage0/interpreter_specializations.cpp.o
[17/223] Building CXX object CMakeFiles/jakt_stage0.dir/bootstrap/stage0/jakt__platform__unknown_path.cpp.o
[18/223] Building CXX object CMakeFiles/jakt_stage0.dir/bootstrap/stage0/codegen_specializations.cpp.o
[19/223] Building CXX object CMakeFiles/jakt_stage0.dir/bootstrap/stage0/ids_specializations.cpp.o
[20/223] Building CXX object CMakeFiles/jakt_stage0.dir/bootstrap/stage0/jakt__platform__unknown_process.cpp.o
[21/223] Building CXX object CMakeFiles/jakt_stage0.dir/bootstrap/stage0/jakt__prelude__configuration.cpp.o
[22/223] Building CXX object CMakeFiles/jakt_stage0.dir/bootstrap/stage0/jakt__arguments_specializations.cpp.o
[23/223] Building CXX object CMakeFiles/jakt_stage0.dir/bootstrap/stage0/jakt__prelude__hash.cpp.o
[24/223] Building CXX object CMakeFiles/jakt_stage0.dir/bootstrap/stage0/jakt__prelude__iteration.cpp.o
[25/223] Building CXX object CMakeFiles/jakt_stage0.dir/bootstrap/stage0/jakt__prelude__operators.cpp.o
[26/223] Building CXX object CMakeFiles/jakt_stage0.dir/bootstrap/stage0/jakt__file_iterator_specializations.cpp.o
[27/223] Building CXX object CMakeFiles/jakt_stage0.dir/bootstrap/stage0/jakt__prelude__prelude.cpp.o
[28/223] Building CXX object CMakeFiles/jakt_stage0.dir/bootstrap/stage0/jakt__prelude__string.cpp.o
[29/223] Building CXX object CMakeFiles/jakt_stage0.dir/bootstrap/stage0/formatter_specializations.cpp.o
[30/223] Building CXX object CMakeFiles/jakt_stage0.dir/bootstrap/stage0/jakt__libc__io_specializations.cpp.o
[31/223] Building CXX object CMakeFiles/jakt_stage0.dir/bootstrap/stage0/jakt__path_specializations.cpp.o
[32/223] Building CXX object CMakeFiles/jakt_stage0.dir/bootstrap/stage0/jakt__platform__unknown_fs_specializations.cpp.o
[33/223] Building CXX object CMakeFiles/jakt_stage0.dir/bootstrap/stage0/jakt__platform__unknown_path_specializations.cpp.o
[34/223] Building CXX object CMakeFiles/jakt_stage0.dir/bootstrap/stage0/jakt__prelude__configuration_specializations.cpp.o
[35/223] Building CXX object CMakeFiles/jakt_stage0.dir/bootstrap/stage0/jakt__platform_specializations.cpp.o
[36/223] Building CXX object CMakeFiles/jakt_stage0.dir/bootstrap/stage0/platform.cpp.o
[37/223] Building CXX object CMakeFiles/jakt_stage0.dir/bootstrap/stage0/jakt__platform__unknown_process_specializations.cpp.o
[38/223] Building CXX object CMakeFiles/jakt_stage0.dir/bootstrap/stage0/jakt__prelude__iteration_specializations.cpp.o
[39/223] Building CXX object CMakeFiles/jakt_stage0.dir/bootstrap/stage0/jakt__prelude__hash_specializations.cpp.o
[40/223] Building CXX object CMakeFiles/jakt_stage0.dir/bootstrap/stage0/platform__unknown_compiler.cpp.o
[41/223] Building CXX object CMakeFiles/jakt_stage0.dir/bootstrap/stage0/project.cpp.o
[42/223] Building CXX object CMakeFiles/jakt_stage0.dir/bootstrap/stage0/jakt__prelude__operators_specializations.cpp.o
[43/223] Building CXX object CMakeFiles/jakt_stage0.dir/bootstrap/stage0/jakt__prelude__prelude_specializations.cpp.o
[44/223] Building CXX object CMakeFiles/jakt_stage0.dir/bootstrap/stage0/jakt__prelude__string_specializations.cpp.o
[45/223] Building CXX object CMakeFiles/jakt_stage0.dir/bootstrap/stage0/repl_backend__common.cpp.o
[46/223] Building CXX object CMakeFiles/jakt_stage0.dir/bootstrap/stage0/repl_backend__default.cpp.o
[47/223] Building CXX object CMakeFiles/jakt_stage0.dir/bootstrap/stage0/lexer_specializations.cpp.o
[48/223] Building CXX object CMakeFiles/jakt_stage0.dir/bootstrap/stage0/main_specializations.cpp.o
[49/223] Building CXX object CMakeFiles/jakt_stage0.dir/bootstrap/stage0/parser_specializations.cpp.o
[50/223] Building CXX object CMakeFiles/jakt_stage0.dir/bootstrap/stage0/platform_specializations.cpp.o
[51/223] Building CXX object CMakeFiles/jakt_stage0.dir/bootstrap/stage0/platform__unknown_compiler_specializations.cpp.o
[52/223] Building CXX object CMakeFiles/jakt_stage0.dir/bootstrap/stage0/project_specializations.cpp.o
[53/223] Building CXX object CMakeFiles/jakt_stage0.dir/bootstrap/stage0/runtime/Main.cpp.o
[54/223] Building CXX object CMakeFiles/jakt_stage0.dir/bootstrap/stage0/repl_backend__common_specializations.cpp.o
[55/223] Building CXX object CMakeFiles/jakt_stage0.dir/bootstrap/stage0/runtime/AK/Assertions.cpp.o
[56/223] Building CXX object CMakeFiles/jakt_stage0.dir/bootstrap/stage0/utility.cpp.o
[57/223] Building CXX object CMakeFiles/jakt_stage0.dir/bootstrap/stage0/repl_backend__default_specializations.cpp.o
[58/223] Building CXX object CMakeFiles/jakt_stage0.dir/bootstrap/stage0/repl_specializations.cpp.o
[59/223] Building CXX object CMakeFiles/jakt_stage0.dir/bootstrap/stage0/runtime/AK/CountingStream.cpp.o
[60/223] Building CXX object CMakeFiles/jakt_stage0.dir/bootstrap/stage0/runtime/AK/ConstrainedStream.cpp.o
[61/223] Building CXX object CMakeFiles/jakt_stage0.dir/bootstrap/stage0/runtime/AK/Base64.cpp.o
[62/223] Building CXX object CMakeFiles/jakt_stage0.dir/bootstrap/stage0/runtime/AK/Error.cpp.o
[63/223] Building CXX object CMakeFiles/jakt_stage0.dir/bootstrap/stage0/runtime/AK/CircularBuffer.cpp.o
[64/223] Building CXX object CMakeFiles/jakt_stage0.dir/bootstrap/stage0/runtime/AK/DeprecatedFlyString.cpp.o
[65/223] Building CXX object CMakeFiles/jakt_stage0.dir/bootstrap/stage0/runtime/AK/DeprecatedString.cpp.o
[66/223] Building CXX object CMakeFiles/jakt_stage0.dir/bootstrap/stage0/runtime/AK/FuzzyMatch.cpp.o
[67/223] Building CXX object CMakeFiles/jakt_stage0.dir/bootstrap/stage0/runtime/AK/FlyString.cpp.o
[68/223] Building CXX object CMakeFiles/jakt_stage0.dir/bootstrap/stage0/typechecker_specializations.cpp.o
[69/223] Building CXX object CMakeFiles/jakt_stage0.dir/bootstrap/stage0/runtime/AK/GenericLexer.cpp.o
FAILED: CMakeFiles/jakt_stage0.dir/bootstrap/stage0/runtime/AK/GenericLexer.cpp.o 
/nix/store/32nc0cdhkw8hygcxycychwcdf8r9ipfj-clang-wrapper-14.0.6/bin/clang++  -I/home/gsus/jakt/bootstrap/stage0/runtime -Wall -Wextra -Werror -Wno-unused-local-typedefs -Wno-unused-function -Wno-unused-variable -Wno-unused-parameter -Wno-unused-but-set-variable -Wno-unused-result -Wno-implicit-fallthrough -Wno-trigraphs -Wno-parentheses-equality -Wno-unqualified-std-cast-call -Wno-user-defined-literals -Wno-literal-suffix -Wno-return-type -Wno-deprecated-declarations -Wno-unknown-warning-option -Wno-unused-command-line-argument -Wno-unused-lambda-capture -Wno-reorder-ctor -Wno-unknown-attributes -fno-exceptions -fdiagnostics-color=always -std=gnu++20 -MD -MT CMakeFiles/jakt_stage0.dir/bootstrap/stage0/runtime/AK/GenericLexer.cpp.o -MF CMakeFiles/jakt_stage0.dir/bootstrap/stage0/runtime/AK/GenericLexer.cpp.o.d -o CMakeFiles/jakt_stage0.dir/bootstrap/stage0/runtime/AK/GenericLexer.cpp.o -c /home/gsus/jakt/bootstrap/stage0/runtime/AK/GenericLexer.cpp
In file included from /home/gsus/jakt/bootstrap/stage0/runtime/AK/GenericLexer.cpp:9:
/home/gsus/jakt/bootstrap/stage0/runtime/AK/GenericLexer.h:99:112: error: cannot take address of consteval function 'operator""sv' outside of an immediate invocation
    constexpr char consume_escaped_character(char escape_char = '\\', StringView escape_map = "n\nr\rt\tb\bf\f"sv)
                                                                                                               ^
/home/gsus/jakt/bootstrap/stage0/runtime/AK/StringView.h:383:77: note: declared here
[[nodiscard]] ALWAYS_INLINE AK_STRING_VIEW_LITERAL_CONSTEVAL AK::StringView operator"" sv(char const* cstring, size_t length)
                                                                            ^
1 error generated.
[70/223] Building CXX object CMakeFiles/jakt_stage0.dir/bootstrap/stage0/runtime/AK/Hex.cpp.o
[71/223] Building CXX object CMakeFiles/jakt_stage0.dir/bootstrap/stage0/runtime/AK/FloatingPointStringConversions.cpp.o
[72/223] Building CXX object CMakeFiles/jakt_stage0.dir/bootstrap/stage0/runtime/AK/Format.cpp.o
[73/223] Building CXX object CMakeFiles/jakt_stage0.dir/bootstrap/stage0/runtime/AK/JsonParser.cpp.o
[74/223] Building CXX object CMakeFiles/jakt_stage0.dir/bootstrap/stage0/ide.cpp.o
[75/223] Building CXX object CMakeFiles/jakt_stage0.dir/bootstrap/stage0/runtime/AK/JsonObject.cpp.o
[76/223] Building CXX object CMakeFiles/jakt_stage0.dir/bootstrap/stage0/lexer.cpp.o
[77/223] Building CXX object CMakeFiles/jakt_stage0.dir/bootstrap/stage0/main.cpp.o
[78/223] Building CXX object CMakeFiles/jakt_stage0.dir/bootstrap/stage0/utility_specializations.cpp.o
[79/223] Building CXX object CMakeFiles/jakt_stage0.dir/bootstrap/stage0/types_specializations.cpp.o
[80/223] Building CXX object CMakeFiles/jakt_stage0.dir/bootstrap/stage0/repl.cpp.o
[81/223] Building CXX object CMakeFiles/jakt_stage0.dir/bootstrap/stage0/formatter.cpp.o
[82/223] Building CXX object CMakeFiles/jakt_stage0.dir/bootstrap/stage0/codegen.cpp.o
[83/223] Building CXX object CMakeFiles/jakt_stage0.dir/bootstrap/stage0/types.cpp.o
[84/223] Building CXX object CMakeFiles/jakt_stage0.dir/bootstrap/stage0/parser.cpp.o
[85/223] Building CXX object CMakeFiles/jakt_stage0.dir/bootstrap/stage0/interpreter.cpp.o
[86/223] Building CXX object CMakeFiles/jakt_stage0.dir/bootstrap/stage0/typechecker.cpp.o
ninja: build stopped: subcommand failed.
```
</details>