### PR TITLE
Take another step towards testing Jakt in serenity

### DIFF
--- a/README.md
+++ b/README.md
@@ -358,6 +358,8 @@ fn do_nothing_in_particular() => match AlertDescription::CloseNotify {
 ## Generics
 
 - [x] Generic types
+- [x] Constant generics (minimal support)
+- [ ] Constant generics (full support)
 - [x] Generic type inference
 - [x] Traits
 
@@ -387,6 +389,13 @@ fn main() {
 }
 ```
 
+```jakt
+struct MyArray<T, comptime U> {
+    // NOTE: There is currently no way to access the value 'U', referring to 'U' is only valid as the type at the moment.
+    data: [T]
+}
+```
+
 ## Namespaces
 
 - [x] Namespace support for functions and struct/class/enum
@@ -413,6 +422,7 @@ There are two built-in casting operators in **Jakt**.
 
 The `as` cast can do these things (note that the implementation may not agree yet):
 - Casts to the same type are infallible and pointless, so might be forbidden in the future.
+- If the source type is _unknown_, the cast is valid as a type assertion.
 - If both types are primitive, a safe conversion is done.
     - Integer casts will fail if the value is out of range. This means that promotion casts like i32 -> i64 are infallible.
     - Float -> Integer casts truncate the decimal point (?)
@@ -522,7 +532,7 @@ Other operators have not yet been converted to traits, decided on, or implemente
 | Operator | Description | Status |
 |----------|-------------|--------|
 | `&` | Bitwise And | Not Decided |
-| `|` | Bitwise Or | Not Decided |
+| `\|` | Bitwise Or | Not Decided |
 | `^` | Bitwise Xor | Not Decided |
 | `~` | Bitwise Not | Not Decided |
 | `<<` | Bitwise Shift Left | Not Decided |

--- a/runtime/jaktlib/path.jakt
+++ b/runtime/jaktlib/path.jakt
@@ -128,6 +128,40 @@ struct Path {
 
     fn exists(this) -> bool => File::exists(.path)
 
+    fn components(this) throws -> [String] {
+        mut parts: [String] = []
+        mut last_slash: usize? = None
+        for i in 0..(.path.length()) {
+            if .path.byte_at(i) == get_path_separator() {
+                if last_slash.has_value() {
+                    if i == last_slash! + 1 {
+                        // Ignore empty path components.
+                        last_slash = i
+                        continue
+                    }
+
+                    parts.push(.path.substring(start: (last_slash! + 1), length: (i - last_slash! - 1)))
+                } else {
+                    if i == 0 {
+                        parts.push("/")
+                    } else {
+                        parts.push(.path.substring(start: 0, length: i))
+                    }
+                }
+                last_slash = i
+            }
+        }
+        if last_slash.has_value() {
+            if last_slash! + 1 < .path.length() {
+                parts.push(.path.substring(start: (last_slash! + 1), length: (.path.length() - last_slash! - 1)))
+            }
+        } else {
+            parts.push(.path)
+        }
+
+        return parts
+    }
+
     private fn split_at_last_slash(this) throws -> (String, String) {
         let len = .path.length()
         let last_slash = Path::last_slash(.path)

--- a/runtime/jaktlib/platform.jakt
+++ b/runtime/jaktlib/platform.jakt
@@ -4,8 +4,7 @@ struct Target {
     os: String
     abi: String
 
-    fn active() throws -> Target {
-        let triple = ___jakt_get_target_triple_string()
+    fn from_triple(anon triple: String) throws -> Target {
         let parts = triple.split(c'-')
         if parts.size() != 4 {
             eprintln("Invalid target triple '{}'", triple)
@@ -20,7 +19,15 @@ struct Target {
         )
     }
 
-    fn name(this) throws -> String => format("{}-{}-{}-{}", .arch, .platform, .os, .abi)
+    fn active() throws -> Target {
+        let triple = ___jakt_get_target_triple_string()
+        return Target::from_triple(triple)
+    }
+
+    fn name(this, abbreviate: bool = false) throws -> String => match abbreviate {
+        true => format("{}-{}-{}", .arch, .platform, .os)
+        false => format("{}-{}-{}-{}", .arch, .platform, .os, .abi)
+    }
 }
 
 fn platform_import_names() throws -> [String] {
@@ -33,7 +40,7 @@ fn platform_import_names() throws -> [String] {
             else => ["windows"]
         }
         "darwin" => ["darwin", "posix"]
-        "linux" | "openbsd" | "serenityos" => [target.os, "posix"]
+        "linux" | "openbsd" | "serenityos" | "serenity" => [target.os, "posix"]
         else => [target.os, "unknown"]
     }
 }

--- a/runtime/lib.h
+++ b/runtime/lib.h
@@ -199,6 +199,12 @@ inline constexpr T arithmetic_shift_right(T value, size_t steps)
     }
 }
 
+template<typename T>
+ALWAYS_INLINE auto assert_type(T&& input) -> decltype(input)
+{
+    return forward<T>(input);
+}
+
 template<typename OutputType, typename InputType>
 ALWAYS_INLINE Optional<OutputType> fallible_integer_cast(InputType input)
 {
@@ -360,6 +366,7 @@ namespace Jakt {
 using JaktInternal::abort;
 using JaktInternal::as_saturated;
 using JaktInternal::as_truncated;
+using JaktInternal::assert_type;
 using JaktInternal::fallible_class_cast;
 using JaktInternal::fallible_integer_cast;
 using JaktInternal::infallible_class_cast;

--- a/samples/generics/const_generics.jakt
+++ b/samples/generics/const_generics.jakt
@@ -1,0 +1,11 @@
+/// Expect:
+/// - output: "42\n"
+
+fn actually_kinda_useless<comptime T>() -> i32 {
+    // FIXME: Can't really acccess the value of 'T' yet.
+    return 42
+}
+
+fn main() {
+    println("{}", actually_kinda_useless<comptime 69>())
+}

--- a/selfhost/build.jakt
+++ b/selfhost/build.jakt
@@ -116,10 +116,12 @@ struct Builder {
 
             .linked_files.push(built_object)
 
-            let id = .pool.run(compiler_invocation(
+            let args = compiler_invocation(
                 input_filename: binary_dir.join(file_name).to_string()
                 output_filename: built_object
-            ))
+            )
+
+            let id = .pool.run(args)
             ids.add(id)
 
             eprintln("{:c}[2LBuilding: {}/{} ({})", 0x1b, ids.size(), .files_to_compile.size(), file_name)

--- a/selfhost/codegen.jakt
+++ b/selfhost/codegen.jakt
@@ -5,16 +5,17 @@
 //
 // SPDX-License-Identifier: BSD-2-Clause
 
-import parser { BinaryOperator, FunctionLinkage }
+import parser { BinaryOperator, FunctionLinkage, ParsedBlock }
 import typechecker {
     BuiltinType, CheckedBinaryOperator, CheckedBlock, CheckedCall, CheckedEnum, CheckedExpression, CheckedFunction
     CheckedMatchBody, CheckedMatchCase, CheckedProgram, CheckedStatement, CheckedStruct, CheckedVariable
     CheckedVisibility, EnumId, FunctionId, Module, ModuleId, Scope, ScopeId, StructId, Type, TypeId, VarId, builtin
     never_type_id, unknown_type_id, void_type_id
 }
-import types { CheckedParameter, StructLikeId }
+import types { CheckedGenericParameter, CheckedParameter, FunctionGenericParameter, SafetyMode, StructLikeId }
 import utility { Queue, Span, interpret_escapes, join, panic, prepend_to_each, todo }
 import compiler { Compiler }
+import interpreter { Interpreter, TypecheckFunctions, value_to_checked_expression }
 
 enum AllowedControlExits {
     /// No control exit statements allowed
@@ -1277,21 +1278,78 @@ struct CodeGenerator {
         return output
     }
 
+    fn codegen_template_parameter_names(
+        mut this
+        anon parameters: [FunctionGenericParameter]
+        names: &mut [String]
+    ) throws -> String {
+        mut ids: [TypeId] = []
+        for parameter in parameters {
+            ids.push(parameter.checked_parameter.type_id)
+        }
+        return .codegen_template_parameter_names(ids, names)
+    }
+
+    fn codegen_template_parameter_names(
+        mut this
+        anon parameters: [FunctionGenericParameter]
+    ) throws -> String {
+        mut names: [String] = []
+        return .codegen_template_parameter_names(parameters, &mut names)
+    }
+
+    fn codegen_template_parameter_names(
+        mut this
+        anon parameters: [CheckedGenericParameter]
+        names: &mut [String]
+    ) throws -> String {
+        mut ids: [TypeId] = []
+        for parameter in parameters {
+            ids.push(parameter.type_id)
+        }
+        return .codegen_template_parameter_names(ids, names)
+    }
+
+    fn codegen_template_parameter_names(
+        mut this
+        anon parameters: [CheckedGenericParameter]
+    ) throws -> String {
+        mut names: [String] = []
+        return .codegen_template_parameter_names(parameters, &mut names)
+    }
+
+    fn codegen_template_parameter_names(
+        mut this
+        anon parameters: [TypeId]
+        names: &mut [String]
+    ) throws -> String {
+        mut output = ""
+        mut first = true
+        for id in parameters {
+            if first {
+                first = false
+            } else {
+                output += ","
+            }
+            if .program.get_type(id) is TypeVariable(is_value) and is_value {
+                output += "auto "
+            } else {
+                output += "typename "
+            }
+            let name = .codegen_type(id)
+
+            output += name
+            names.push(name)
+        }
+        return output
+    }
+
     fn codegen_function_generic_parameters(mut this, function: CheckedFunction) throws -> String {
         mut output = ""
 
         if not function.generics.params.is_empty() {
             output += "template <"
-            mut first = true
-            for generic_parameter in function.generics.params {
-                if first {
-                    first = false
-                } else {
-                    output += ","
-                }
-                output += "typename "
-                output += .codegen_type(generic_parameter.type_id())
-            }
+            output += .codegen_template_parameter_names(function.generics.params)
             output += ">\n"
         }
 
@@ -1395,16 +1453,7 @@ struct CodeGenerator {
 
         if not struct_.generic_parameters.is_empty() {
             output += "template <"
-            mut first = true
-            for generic_parameter in struct_.generic_parameters {
-                if first {
-                    first = false
-                } else {
-                    output += ","
-                }
-                output += "typename "
-                output += .codegen_type(generic_parameter.type_id)
-            }
+            output += .codegen_template_parameter_names(struct_.generic_parameters)
             output += ">"
         }
 
@@ -1429,13 +1478,14 @@ struct CodeGenerator {
 
         mut struct_is_generic = false
         mut generic_parameter_names: [String] = []
+        mut template_parameters = ""
         if not struct_.generic_parameters.is_empty() {
             struct_is_generic = true
-            for generic_parameter in struct_.generic_parameters {
-                generic_parameter_names.push(.codegen_type(generic_parameter.type_id))
-            }
-
-            output += format("template <{}>", join(prepend_to_each(generic_parameter_names, prefix: "typename "), separator: ", "))
+            template_parameters = .codegen_template_parameter_names(
+                struct_.generic_parameters
+                names: &mut generic_parameter_names
+            )
+            output += format("template <{}>", template_parameters)
         }
 
         match struct_.record_type {
@@ -1554,7 +1604,11 @@ struct CodeGenerator {
 
         output += "};"
 
-        .deferred_output += .codegen_ak_formatter(name: struct_.name_for_codegen().as_name_for_definition(), generic_parameter_names)
+        .deferred_output += .codegen_ak_formatter(
+            name: struct_.name_for_codegen().as_name_for_definition()
+            generic_parameter_names
+            template_parameters
+        )
 
         return output
     }
@@ -1571,13 +1625,7 @@ struct CodeGenerator {
         }
 
         let is_generic = not enum_.generic_parameters.is_empty()
-        mut template_args_array: [String] = []
-        for generic_parameter in enum_.generic_parameters {
-            if .program.get_type(generic_parameter.type_id) is TypeVariable(name) {
-                template_args_array.push("typename " + name)
-            }
-        }
-        mut template_args = join(template_args_array, separator: ", ")
+        mut template_args = .codegen_template_parameter_names(enum_.generic_parameters)
 
         output += format("namespace {}_Details", enum_.name) + " {\n"
         for variant in enum_.variants {
@@ -1622,12 +1670,7 @@ struct CodeGenerator {
 
         let is_generic = not enum_.generic_parameters.is_empty()
         mut generic_parameter_names: [String] = []
-        for generic_parameter in enum_.generic_parameters {
-            if .program.get_type(generic_parameter.type_id) is TypeVariable(name) {
-                generic_parameter_names.push(name)
-            }
-        }
-        mut template_args = join(prepend_to_each(generic_parameter_names, prefix: "typename "), separator: ", ")
+        mut template_args = .codegen_template_parameter_names(enum_.generic_parameters, names: &mut generic_parameter_names)
 
         mut common_fields: [(String, String)] = []
         for field in enum_.fields {
@@ -1740,7 +1783,7 @@ struct CodeGenerator {
         if enum_.is_boxed {
             mut fully_instantiated_name = enum_.name
             if is_generic {
-                fully_instantiated_name += format("<{}>", join(generic_parameter_names, separator: ", "))
+                fully_instantiated_name += format("<{}>", template_args)
             }
             output += "template<typename V, typename... Args> static auto __jakt_create(Args&&... args) {\n"
             output += format("return adopt_nonnull_ref_or_enomem(new (nothrow) {}(V(forward<Args>(args)...)));\n", fully_instantiated_name)
@@ -1788,7 +1831,7 @@ struct CodeGenerator {
 
         output += "};\n"
 
-        .deferred_output += .codegen_ak_formatter(name: enum_.name, generic_parameter_names)
+        .deferred_output += .codegen_ak_formatter(name: enum_.name, generic_parameter_names, template_args)
 
         return output
     }
@@ -1798,16 +1841,7 @@ struct CodeGenerator {
 
         if not is_inline and not struct_.generic_parameters.is_empty() {
             output += "template <"
-            mut first = true
-            for param in struct_.generic_parameters {
-                if first {
-                    first = false
-                } else {
-                    output += ","
-                }
-                output += "typename "
-                output += .codegen_type(param.type_id)
-            }
+            output += .codegen_template_parameter_names(struct_.generic_parameters)
             output += ">\n"
         }
 
@@ -1860,16 +1894,7 @@ struct CodeGenerator {
 
         if not is_inline and not enum_.generic_parameters.is_empty() {
             output += "template <"
-            mut first = true
-            for param in enum_.generic_parameters {
-                if first {
-                    first = false
-                } else {
-                    output += ","
-                }
-                output += "typename "
-                output += .codegen_type(param.type_id)
-            }
+            output += .codegen_template_parameter_names(enum_.generic_parameters)
             output += ">\n"
         }
 
@@ -1933,10 +1958,9 @@ struct CodeGenerator {
         return output
     }
 
-    fn codegen_ak_formatter(mut this, name: String, generic_parameter_names: [String]) throws -> String {
+    fn codegen_ak_formatter(mut this, name: String, generic_parameter_names: [String], anon template_args: String) throws -> String {
         mut output = ""
 
-        let template_args = join(prepend_to_each(generic_parameter_names, prefix: "typename "), separator: ", ")
         let generic_type_args = join(generic_parameter_names, separator: ", ")
 
         mut qualified_name = ""
@@ -3560,7 +3584,7 @@ struct CodeGenerator {
         return output
     }
 
-    fn codegen_namespace_path(this, call: CheckedCall) throws -> String {
+    fn codegen_namespace_path(mut this, call: CheckedCall) throws -> String {
         if call.function_id.has_value() {
             let scope = .program.get_function(call.function_id!).owner_scope
             if scope.has_value() {
@@ -3822,11 +3846,11 @@ struct CodeGenerator {
     }
 
 
-    fn codegen_type(this, anon type_id: TypeId) throws -> String {
+    fn codegen_type(mut this, anon type_id: TypeId) throws -> String {
         return .codegen_type_possibly_as_namespace(type_id, as_namespace: false)
     }
 
-    fn codegen_type_possibly_as_namespace(this, type_id: TypeId, as_namespace: bool) throws -> String => match .program.get_type(type_id) {
+    fn codegen_type_possibly_as_namespace(mut this, type_id: TypeId, as_namespace: bool) throws -> String => match .program.get_type(type_id) {
         Void => "void"
         Bool => "bool"
         U8 => "u8"
@@ -3844,6 +3868,31 @@ struct CodeGenerator {
         CChar => "char"
         CInt => "int"
         Never => "void"
+        Const(value) => {
+            mut interpreter = Interpreter::create(
+                compiler: .compiler
+                program: .program
+                typecheck_functions: TypecheckFunctions(
+                    block: fn(
+                        parsed_block: ParsedBlock
+                        parent_scope_id: ScopeId
+                        safety_mode: SafetyMode
+                        yield_type_hint: TypeId?
+                    ) throws -> CheckedBlock {
+                        throw Error::from_string_literal("Cannot typecheck a const block")
+                    }
+
+                    register_function: fn(
+                        function: CheckedFunction
+                    ) throws -> FunctionId {
+                        throw Error::from_string_literal("Cannot typecheck a const function")
+                    }
+                )
+                spans: []
+            )
+            let expr = value_to_checked_expression(value, interpreter)
+            yield .codegen_expression(expr)
+        }
         RawPtr(type_id) => match .program.get_type(type_id).is_boxed(program: .program) {
             true => .codegen_type_possibly_as_namespace(type_id, as_namespace: true) + "*"
             false => .codegen_type(type_id) + "*"
@@ -3892,7 +3941,7 @@ struct CodeGenerator {
         }
     }
 
-    fn codegen_generic_type_instance(this, id: StructId, args: [TypeId], as_namespace: bool) throws -> String {
+    fn codegen_generic_type_instance(mut this, id: StructId, args: [TypeId], as_namespace: bool) throws -> String {
         // FIXME: Handle WeakPtr
         mut output = ""
         let type_module = .program.get_module(id.module)
@@ -3944,7 +3993,7 @@ struct CodeGenerator {
         return output
     }
 
-    fn codegen_generic_enum_instance(this, id: EnumId, args: [TypeId], as_namespace: bool) throws -> String {
+    fn codegen_generic_enum_instance(mut this, id: EnumId, args: [TypeId], as_namespace: bool) throws -> String {
         mut output = ""
         mut close_tag = false
         let enum_ = .program.get_enum(id)
@@ -4088,16 +4137,7 @@ struct CodeGenerator {
 
         if not is_inline and not struct_.generic_parameters.is_empty() {
             output += "template <"
-            mut first = true
-            for param in struct_.generic_parameters {
-                if first {
-                    first = false
-                } else {
-                    output += ","
-                }
-                output += "typename "
-                output += .codegen_type(param.type_id)
-            }
+            output += .codegen_template_parameter_names(struct_.generic_parameters)
             output += ">\n"
         }
 
@@ -4217,16 +4257,7 @@ struct CodeGenerator {
 
         if not is_inline and not structure.generic_parameters.is_empty() {
             output += "template <"
-            mut first = true
-            for param in structure.generic_parameters {
-                if first {
-                    first = false
-                } else {
-                    output += ","
-                }
-                output += "typename "
-                output += .codegen_type(param.type_id)
-            }
+            output += .codegen_template_parameter_names(structure.generic_parameters)
             output += ">\n"
         }
 

--- a/selfhost/codegen.jakt
+++ b/selfhost/codegen.jakt
@@ -2202,7 +2202,9 @@ struct CodeGenerator {
                         }
                         Infallible => {
                             mut cast_type = "verify_cast"
-                            if type.is_boxed(program: .program) {
+                            if expr.type() == unknown_type_id() {
+                                cast_type = "assert_type"
+                            } else if type.is_boxed(program: .program) {
                                 cast_type = "infallible_class_cast"
                             } else if .program.is_integer(type_id) {
                                 cast_type = "infallible_integer_cast"

--- a/selfhost/cpp_import/clang.jakt
+++ b/selfhost/cpp_import/clang.jakt
@@ -90,10 +90,10 @@ fn type_from(
         CXType_LongLong => program.find_or_add_type_id(type: Type::I64, module_id)
         CXType_Float => program.find_or_add_type_id(type: Type::F32, module_id)
         CXType_Double => program.find_or_add_type_id(type: Type::F64, module_id)
-        CXType_Typedef => type_from(program, scope_id, module_id, t: clang_getCanonicalType(t))
+        CXType_Typedef => type_from(program, scope_id, module_id, clang_getCanonicalType(t))
         CXType_Pointer => program.find_or_add_type_id(
             type: Type::RawPtr(
-                type_from(program, scope_id, module_id, t: clang_getPointeeType(t))
+                type_from(program, scope_id, module_id, clang_getPointeeType(t))
             )
             module_id
         )
@@ -118,19 +118,14 @@ fn type_from(
             }
         }
         CXType_Elaborated => type_from(program, scope_id, module_id, clang_Type_getNamedType(t))
-        CXType_Unexposed => {
-            // who knows what this is really
-            // just look it up by name
-            let name = string_from(clang_getTypeSpelling(t))
-            yield program.find_type_in_scope(scope_id, name) ?? program.find_or_add_type_id(type: Type::Unknown, module_id)
-        }
+        CXType_Unexposed => program.find_or_add_type_id(Type::Unknown, module_id)
         CXType_LValueReference => program.find_or_add_type_id(
             type: Type::Reference(
-                type_from(program, scope_id, module_id, t: clang_getPointeeType(t))
+                type_from(program, scope_id, module_id, clang_getPointeeType(t))
             )
             module_id
         )
-        CXType_RValueReference => type_from(program, scope_id, module_id, t: clang_getPointeeType(t))
+        CXType_RValueReference => type_from(program, scope_id, module_id, clang_getPointeeType(t))
         else => {
             let v = clang_getTypeSpelling(t)
             eprintln("Unknown type kind: {} ({})", string_from(v), t.kind as! c_int)

--- a/selfhost/cpp_import/clang.jakt
+++ b/selfhost/cpp_import/clang.jakt
@@ -1,8 +1,9 @@
 import types {
-    BlockControlFlow, CheckedBlock, CheckedField, CheckedFunction, CheckedGenericParameter, CheckedParameter
-    CheckedProgram, CheckedStruct, CheckedVariable, CheckedVisibility, DefinitionLinkage, FileId, FunctionGenerics
-    FunctionLinkage, ModuleId, ScopeId, StructId, Type, TypeId, FunctionGenericParameter, FunctionGenericParameterKind
-    ExternalName, EnumId, CheckedEnum, CheckedEnumVariant
+    BlockControlFlow, CheckedBlock, CheckedEnum, CheckedEnumVariant, CheckedField, CheckedFunction
+    CheckedGenericParameter, CheckedParameter, CheckedProgram, CheckedStruct, CheckedVariable, CheckedVisibility
+    DefinitionLinkage, EnumId, ExternalName, FileId, FunctionGenericParameter, FunctionGenericParameterKind
+    FunctionGenerics, FunctionLinkage, ModuleId, ScopeId, SpecializedType, StructId, Type, TypeId, Value, ValueImpl
+    unknown_type_id
 }
 import parser {
     FunctionType, ParsedField, ParsedVarDecl, RecordType, ParsedType
@@ -20,17 +21,21 @@ import cpp_import::clang_c {
 }
 import cpp_import::clang_c {
     clang_CXXMethod_isConst, clang_CXXMethod_isPureVirtual, clang_CXXMethod_isStatic, clang_CXXMethod_isVirtual
-    clang_Cursor_getNumTemplateArguments, clang_Cursor_getTranslationUnit, clang_Cursor_isNull
-    clang_Type_getNamedType, clang_createIndex, clang_createTranslationUnit, clang_disposeIndex, clang_disposeString
-    clang_disposeTokens, clang_disposeTranslationUnit, clang_getArgType, clang_getCString, clang_getCanonicalCursor
+    clang_Cursor_Evaluate, clang_Cursor_getNumTemplateArguments, clang_Cursor_getTranslationUnit
+    clang_Cursor_isNull, clang_EvalResult_dispose, clang_EvalResult_getAsDouble, clang_EvalResult_getAsInt
+    clang_EvalResult_getAsLongLong, clang_EvalResult_getAsStr, clang_EvalResult_getAsUnsigned
+    clang_EvalResult_getKind, clang_EvalResult_isUnsignedInt, clang_Type_getNamedType, clang_createIndex
+    clang_createTranslationUnit, clang_disposeIndex, clang_disposeString, clang_disposeTokens
+    clang_disposeTranslationUnit, clang_equalCursors, clang_getArgType, clang_getCString, clang_getCanonicalCursor
     clang_getCanonicalType, clang_getCursorDefinition, clang_getCursorExtent, clang_getCursorKind
     clang_getCursorKindSpelling, clang_getCursorLocation, clang_getCursorPrettyPrinted
-    clang_getCursorPrintingPolicy, clang_getCursorResultType, clang_getCursorSpelling, clang_getCursorType
-    clang_getCursorUSR, clang_getEnumDeclIntegerType, clang_getFileName, clang_getNumArgTypes, clang_getPointeeType
-    clang_getResultType, clang_getSpecializedCursorTemplate, clang_getSpellingLocation, clang_getTemplateCursorKind
-    clang_getTokenKind, clang_getTokenSpelling, clang_getTranslationUnitCursor, clang_getTypeDeclaration
-    clang_getTypeKindSpelling, clang_getTypeSpelling, clang_getTypedefDeclUnderlyingType, clang_isCursorDefinition
-    clang_parseTranslationUnit2, clang_saveTranslationUnit, clang_tokenize, clang_visitChildren
+    clang_getCursorPrintingPolicy, clang_getCursorResultType, clang_getCursorSemanticParent, clang_getCursorSpelling
+    clang_getCursorType, clang_getCursorUSR, clang_getEnumDeclIntegerType, clang_getFileName, clang_getNumArgTypes
+    clang_getPointeeType, clang_getResultType, clang_getSpecializedCursorTemplate, clang_getSpellingLocation
+    clang_getTemplateCursorKind, clang_getTokenKind, clang_getTokenSpelling, clang_getTranslationUnitCursor
+    clang_getTypeDeclaration, clang_getTypeKindSpelling, clang_getTypeSpelling, clang_getTypedefDeclUnderlyingType
+    clang_isCursorDefinition, clang_isDeclaration, clang_isExpression, clang_parseTranslationUnit2
+    clang_saveTranslationUnit, clang_tokenize, clang_visitChildren
 }
 import utility { allocate }
 import extern c "stdlib.h" {
@@ -63,6 +68,100 @@ fn string_from(anon string: CXString, dispose: bool = true) throws -> String {
         "value = { clang_getCString(string), strlen(clang_getCString(string)) };"
     } }
     return String::from_string_literal(value)
+}
+
+fn const_type_from(
+    program: &mut CheckedProgram
+    scope_id: ScopeId
+    module_id: ModuleId
+    anon cursor: CXCursor
+) throws -> TypeId {
+    if not clang_isExpression(clang_getCursorKind(cursor)) {
+        eprintln("[ICE] Const type input is not an expression")
+        return program.find_or_add_type_id(type: Type::Unknown, module_id)
+    }
+
+    let eval_result = clang_Cursor_Evaluate(cursor)
+    defer clang_EvalResult_dispose(eval_result)
+
+    let value_impl = match clang_EvalResult_getKind(eval_result) {
+        CXEval_Int => match clang_EvalResult_isUnsignedInt(eval_result) {
+            true => cast_to_type(clang_EvalResult_getAsUnsigned(eval_result) as! u64, clang_getCursorType(cursor))
+            false => cast_to_type(clang_EvalResult_getAsLongLong(eval_result) as! i64, clang_getCursorType(cursor))
+        }
+        CXEval_UnExposed => cast_to_type(clang_EvalResult_getAsInt(eval_result) as! i64, clang_getCursorType(cursor))
+        CXEval_Float => cast_to_type(clang_EvalResult_getAsDouble(eval_result), clang_getCursorType(cursor))
+        CXEval_StrLiteral
+        | CXEval_ObjCStrLiteral
+        | CXEval_CFStr
+        | CXEval_Other => {
+            eprintln("Const type input kind {} not supported", clang_EvalResult_getKind(eval_result) as! c_int)
+            return program.find_or_add_type_id(type: Type::Unknown, module_id)
+        }
+    }
+
+    return program.find_or_add_type_id(type: Type::Const(
+        Value(impl: value_impl, span: empty_span())
+    ), module_id)
+}
+
+fn cpp_static_cast<T, U>(value: U) -> T {
+    mut x = null<T>()
+    unsafe { cpp { "x = static_cast<decltype(x)>(value);" } }
+    return x
+}
+
+fn cast_to_type(
+    anon value: i64
+    anon type: CXType
+) throws -> ValueImpl => match clang_getCanonicalType(type).kind {
+    CXType_Bool => ValueImpl::Bool(cpp_static_cast<bool>(value))
+    CXType_Char_U => ValueImpl::U8(cpp_static_cast<u8>(value))
+    CXType_UChar => ValueImpl::U8(cpp_static_cast<u8>(value))
+    CXType_Char16 => ValueImpl::U16(cpp_static_cast<u16>(value))
+    CXType_Char32 => ValueImpl::U32(cpp_static_cast<u32>(value))
+    CXType_UShort => ValueImpl::U16(cpp_static_cast<u16>(value))
+    CXType_UInt => ValueImpl::U32(cpp_static_cast<u32>(value))
+    CXType_ULong => ValueImpl::U32(cpp_static_cast<u32>(value))
+    CXType_ULongLong => ValueImpl::U64(cpp_static_cast<u64>(value))
+    CXType_Char_S => ValueImpl::I8(cpp_static_cast<i8>(value))
+    CXType_SChar => ValueImpl::I8(cpp_static_cast<i8>(value))
+    CXType_Short => ValueImpl::I16(cpp_static_cast<i16>(value))
+    CXType_Int => ValueImpl::I32(cpp_static_cast<i32>(value))
+    CXType_Long => ValueImpl::I32(cpp_static_cast<i32>(value))
+    CXType_LongLong => ValueImpl::I64(cpp_static_cast<i64>(value))
+    else => ValueImpl::Void
+}
+
+fn cast_to_type(
+    anon value: u64
+    anon type: CXType
+) throws -> ValueImpl => match clang_getCanonicalType(type).kind {
+    CXType_Bool => ValueImpl::Bool(cpp_static_cast<bool>(value))
+    CXType_Char_U => ValueImpl::U8(cpp_static_cast<u8>(value))
+    CXType_UChar => ValueImpl::U8(cpp_static_cast<u8>(value))
+    CXType_Char16 => ValueImpl::U16(cpp_static_cast<u16>(value))
+    CXType_Char32 => ValueImpl::U32(cpp_static_cast<u32>(value))
+    CXType_UShort => ValueImpl::U16(cpp_static_cast<u16>(value))
+    CXType_UInt => ValueImpl::U32(cpp_static_cast<u32>(value))
+    CXType_ULong => ValueImpl::U32(cpp_static_cast<u32>(value))
+    CXType_ULongLong => ValueImpl::U64(cpp_static_cast<u64>(value))
+    CXType_Char_S => ValueImpl::I8(cpp_static_cast<i8>(value))
+    CXType_SChar => ValueImpl::I8(cpp_static_cast<i8>(value))
+    CXType_Short => ValueImpl::I16(cpp_static_cast<i16>(value))
+    CXType_Int => ValueImpl::I32(cpp_static_cast<i32>(value))
+    CXType_Long => ValueImpl::I32(cpp_static_cast<i32>(value))
+    CXType_LongLong => ValueImpl::I64(cpp_static_cast<i64>(value))
+    else => ValueImpl::Void
+}
+
+fn cast_to_type(
+    anon value: f64
+    anon type: CXType
+) throws -> ValueImpl => match clang_getCanonicalType(type).kind {
+    CXType_Float => ValueImpl::F32(cpp_static_cast<f32>(value))
+    CXType_Double => ValueImpl::F64(value)
+    else => ValueImpl::Void
 }
 
 fn type_from(
@@ -138,6 +237,7 @@ struct Context {
     program: CheckedProgram
     module_id: ModuleId
     scope_id: ScopeId
+    this_type: TypeId?
     extra: raw void
 }
 
@@ -161,19 +261,20 @@ fn process_namespace_contents(
     allowed_contents: AllowedContents
     this_type: TypeId?
 ) throws {
-    let extra = (allowed_contents, this_type)
     mut context = Context(
         program: *program
         module_id
         scope_id
-        extra: bitcast<raw void>(&raw extra)
+        this_type
+        extra: bitcast<raw void>(&raw allowed_contents)
     )
 
     clang_visitChildren(
         parent: cursor
         visitor: fn(c: CXCursor, parent: CXCursor, data: CXClientData) -> CXChildVisitResult {
             mut context = unsafe *bitcast<raw Context>(data)
-            let (allowed_contents, this_type) = unsafe *bitcast<raw (AllowedContents, TypeId?)>(context.extra)
+            let this_type = context.this_type
+            let allowed_contents = unsafe *bitcast<raw AllowedContents>(context.extra)
 
             return match clang_getCursorKind(cursor: c) {
                 CXCursor_StructDecl | CXCursor_ClassDecl => {
@@ -216,6 +317,20 @@ fn process_namespace_contents(
                 CXCursor_CXXMethod | CXCursor_FunctionDecl => match allowed_contents {
                     OnlyFunctions | Everything => {
                         try process_function(
+                            program: &mut context.program
+                            parent_scope_id: context.scope_id
+                            module_id: context.module_id
+                            this_type
+                            kind: ExternFunctionKind::Normal
+                            cursor: c
+                        )
+                        yield CXChildVisitResult::CXChildVisit_Continue
+                    }
+                    else => CXChildVisitResult::CXChildVisit_Continue
+                }
+                CXCursor_FunctionTemplate => match allowed_contents {
+                    OnlyFunctions | Everything => {
+                        try process_function_template(
                             program: &mut context.program
                             parent_scope_id: context.scope_id
                             module_id: context.module_id
@@ -277,6 +392,7 @@ fn process_namespace_contents(
                             program: &mut context.program
                             parent_scope_id: context.scope_id
                             module_id: context.module_id
+                            this_type_id: this_type
                             cursor: c
                         )
                         yield CXChildVisitResult::CXChildVisit_Continue
@@ -286,6 +402,18 @@ fn process_namespace_contents(
                 CXCursor_ClassTemplate => match allowed_contents {
                     Everything => {
                         try process_class_template(
+                            program: &mut context.program
+                            parent_scope_id: context.scope_id
+                            module_id: context.module_id
+                            cursor: c
+                        )
+                        yield CXChildVisitResult::CXChildVisit_Continue
+                    }
+                    else => CXChildVisitResult::CXChildVisit_Continue
+                }
+                CXCursor_ClassTemplatePartialSpecialization => match allowed_contents {
+                    Everything => {
+                        try process_class_template_partial_specialization(
                             program: &mut context.program
                             parent_scope_id: context.scope_id
                             module_id: context.module_id
@@ -306,6 +434,208 @@ unsafe fn read_at_offset<T>(anon xs: raw T, anon i: u32) -> T {
     return unsafe *bitcast<raw T>(bitcast<u64>(xs) + (i as! u64 * (sizeof T as! u64)))
 }
 
+fn process_class_template_partial_specialization(
+    program: &mut CheckedProgram
+    parent_scope_id: ScopeId
+    module_id: ModuleId
+    cursor: CXCursor
+) throws {
+    let name = name_from(cursor)
+    let template_parameters = extract_cursors_of_kinds(
+        cursor
+        kinds: {CXCursorKind::CXCursor_TemplateTypeParameter, CXCursorKind::CXCursor_NonTypeTemplateParameter}
+    )
+    let specialization_template_parameters = extract_template_parameters(program, parent_scope_id, module_id, cursor)
+
+    // Resolve arguments
+    let template_arguments = extract_matching_cursors_breaking_at_boundary(
+        cursor
+        &fn(anon kind: CXCursorKind) -> bool => not clang_isDeclaration(kind)
+        skip: template_parameters.size()
+    )
+
+    let struct_id = program.find_struct_in_scope(
+        scope_id: parent_scope_id
+        name
+    )
+    if not struct_id.has_value() {
+        eprintln("[ICE] Couldn't find struct for partial specialization named {}", name)
+        return
+    }
+
+    let base_struct = program.get_struct(struct_id!)
+
+    // Make a specialization
+    mut arguments: [TypeId] = []
+    for argument in template_arguments {
+        mut type = match clang_isExpression(clang_getCursorKind(argument)) {
+            true => const_type_from(
+                program
+                scope_id: parent_scope_id
+                module_id
+                cursor: argument
+            )
+            false => type_from(
+                program
+                scope_id: parent_scope_id
+                module_id
+                clang_getCursorType(argument)
+            )
+        }
+        arguments.push(type)
+    }
+
+    mut specialized_name = ""
+    for argument in arguments {
+        specialized_name = specialized_name + ", " + program.type_name(argument)
+    }
+    if specialized_name.length() > 0 {
+        specialized_name = specialized_name.substring(start: 2, length: specialized_name.length() - 2)
+    }
+
+    process_struct(
+        program
+        parent_scope_id
+        module_id
+        cursor
+        generic_parameters: base_struct.generic_parameters
+        generic_parameter_defaults: base_struct.generic_parameter_defaults
+        named_specialization_disambiguator: specialized_name
+    )
+
+    let base_type_id = program.find_or_add_type_id(Type::Struct(struct_id!), module_id)
+    let specialized_struct_id = program.find_struct_in_scope(
+        scope_id: parent_scope_id
+        name: format("{}<{}>", name, specialized_name)
+    )
+    if not specialized_struct_id.has_value() {
+        eprintln("[ICE] Couldn't find struct for partial specialization named {}", name)
+        abort()
+    }
+
+    let type_id = program.find_or_add_type_id(
+        Type::Struct(specialized_struct_id!)
+        module_id
+    )
+    let specialization = SpecializedType(
+        base_type_id
+        arguments
+        type_id
+    )
+
+    mut scope = program.get_scope(parent_scope_id)
+    scope.explicitly_specialized_types.set(name, specialization)
+}
+
+struct TemplateParameters {
+    params: [CheckedGenericParameter]
+    defaults: [TypeId?]
+}
+
+fn extract_template_parameters(
+    program: &mut CheckedProgram
+    parent_scope_id: ScopeId
+    module_id: ModuleId
+    cursor: CXCursor
+) throws -> TemplateParameters {
+    let template_parameters = extract_cursors_of_kinds(
+        cursor
+        kinds: {CXCursorKind::CXCursor_TemplateTypeParameter, CXCursorKind::CXCursor_NonTypeTemplateParameter}
+    )
+    mut params: [CheckedGenericParameter] = []
+    mut defaults: [TypeId?] = []
+    for parameter in template_parameters {
+        let spelling = string_from(clang_getCursorSpelling(parameter))
+        let name = name_from(parameter)
+        mut constraints_and_default_value = extract_cursors_of_kinds(
+            cursor: parameter
+            kinds: {}
+        )
+        mut default_value_cursor: CXCursor? = None
+        mut constraint_cursor: CXCursor? = None
+
+        match constraints_and_default_value.size() {
+            0 => {}
+            1 => {
+                // We need to figure out if this is a constraint or a default value
+                // Thanks clang-c <3
+                let cursor = constraints_and_default_value[0]
+                if clang_getCursorType(cursor).kind is CXType_Invalid {
+                    // This is not a 'type', so it's a constraint.
+                    constraint_cursor = cursor
+                } else {
+                    default_value_cursor = cursor
+                }
+            }
+            else => {
+                // We're good, [0] is the constraint, and [1] is the default value
+                constraint_cursor = constraints_and_default_value[0]
+                default_value_cursor = constraints_and_default_value[1]
+            }
+        }
+
+        mut default_type: TypeId? = None
+        if default_value_cursor.has_value() {
+            default_type = match clang_isExpression(clang_getCursorKind(default_value_cursor!)) {
+                true => const_type_from(
+                    program
+                    scope_id: parent_scope_id
+                    module_id
+                    cursor: default_value_cursor!
+                )
+                false => type_from(
+                    program
+                    scope_id: parent_scope_id
+                    module_id
+                    clang_getCursorType(default_value_cursor!)
+                )
+            }
+
+            let name = name_from(cursor)
+            if name == "Vector" {
+                eprintln("Vector default value: {} '{}' = {}"
+                    string_from(clang_getTypeSpelling(clang_getCursorType(default_value_cursor!)))
+                    string_from(clang_getCursorSpelling(default_value_cursor!))
+                    program.type_name(default_type!, debug_mode: true)
+                )
+                for entry in constraints_and_default_value {
+                    eprintln("  {} '{}'"
+                        string_from(clang_getTypeSpelling(clang_getCursorType(entry)))
+                        string_from(clang_getCursorSpelling(entry))
+                    )
+                }
+            }
+        }
+
+        // FIXME: Constraints, etc.
+        params.push(
+            CheckedGenericParameter(
+                type_id: program.find_or_add_type_id(
+                    Type::TypeVariable(
+                        name
+                        trait_implementations: []
+                        is_value: clang_getCursorKind(parameter) is CXCursor_NonTypeTemplateParameter
+                    )
+                    module_id
+                )
+                constraints: []
+                span: empty_span()
+            )
+        )
+        defaults.push(default_type)
+    }
+
+    if defaults.size() != params.size() {
+        eprintln("[ICE] Template parameters ({}) and defaults ({}) don't match", params, defaults)
+        abort()
+    }
+
+    return TemplateParameters(
+        params
+        defaults
+    )
+}
+
 fn process_class_template(
     program: &mut CheckedProgram
     parent_scope_id: ScopeId
@@ -315,73 +645,14 @@ fn process_class_template(
     let name = name_from(cursor)
     match clang_getTemplateCursorKind(cursor) {
         CXCursor_StructDecl | CXCursor_ClassDecl => {
-            let template_parameters = extract_cursors_of_kinds(
-                cursor
-                kinds: {CXCursorKind::CXCursor_TemplateTypeParameter}
-            )
-            mut params: [CheckedGenericParameter] = []
-            mut defaults: [TypeId?] = []
-            for parameter in template_parameters {
-                let spelling = string_from(clang_getCursorSpelling(parameter))
-                let name = name_from(parameter)
-                mut constraints_and_default_value = extract_cursors_of_kinds(
-                    cursor: parameter
-                    kinds: {}
-                )
-                mut default_value_cursor: CXCursor? = None
-                mut constraint_cursor: CXCursor? = None
-
-                match constraints_and_default_value.size() {
-                    0 => {}
-                    1 => {
-                        // We need to figure out if this is a constraint or a default value
-                        // Thanks clang-c <3
-                        let cursor = constraints_and_default_value[0]
-                        if clang_getCursorType(cursor).kind is CXType_Invalid {
-                            // This is not a 'type', so it's a constraint.
-                            constraint_cursor = cursor
-                        } else {
-                            default_value_cursor = cursor
-                        }
-                    }
-                    else => {
-                        // We're good, [0] is the constraint, and [1] is the default value
-                        constraint_cursor = constraints_and_default_value[0]
-                        default_value_cursor = constraints_and_default_value[1]
-                    }
-                }
-
-                mut default_type: TypeId? = None
-                if default_value_cursor.has_value() {
-                    default_type = type_from(
-                        program
-                        scope_id: parent_scope_id
-                        module_id
-                        clang_getCursorType(default_value_cursor!)
-                    )
-                }
-
-                // FIXME: Constraints, etc.
-                params.push(
-                    CheckedGenericParameter(
-                        type_id: program.find_or_add_type_id(
-                            Type::TypeVariable(name, trait_implementations: [])
-                            module_id
-                        )
-                        constraints: []
-                        span: empty_span()
-                    )
-                )
-                defaults.push(default_type)
-            }
-
+            let template_parameters = extract_template_parameters(program, parent_scope_id, module_id, cursor)
             process_struct(
                 program
                 parent_scope_id
                 module_id
                 cursor
-                generic_parameters: params
-                generic_parameter_defaults: defaults
+                generic_parameters: template_parameters.params
+                generic_parameter_defaults: template_parameters.defaults
             )
         }
         else => {
@@ -400,7 +671,6 @@ fn extract_cursors_of_kinds(
     cursor: CXCursor
     kinds: {CXCursorKind}
 ) throws -> [CXCursor] {
-    let default_recurse: {CXCursorKind} = {}
     mut context = CursorSearchContext(
         kinds
         result: []
@@ -423,10 +693,43 @@ fn extract_cursors_of_kinds(
     return context.result
 }
 
+fn extract_matching_cursors_breaking_at_boundary(
+    cursor: CXCursor
+    anon predicate: &fn(anon kind: CXCursorKind) -> bool
+    skip: usize = 0
+) throws -> [CXCursor] {
+    mut results: [CXCursor] = []
+    mut context = (&raw predicate, results, skip)
+
+    clang_visitChildren(
+        parent: cursor
+        visitor: fn(c: CXCursor, parent: CXCursor, data: CXClientData) -> CXChildVisitResult {
+            mut ptr = bitcast<raw (raw fn(anon kind: CXCursorKind) -> bool, [CXCursor], usize)>(data)
+            mut context = &mut unsafe *ptr
+            let predicate = &unsafe *context.0
+
+            let kind = clang_getCursorKind(c)
+            if predicate(kind) {
+                try context.1.push(c)
+            } else if context.2 == 0 {
+                return CXChildVisitResult::CXChildVisit_Break
+            } else if context.2 > 0 {
+                context.2 -= 1
+            }
+
+            return CXChildVisitResult::CXChildVisit_Continue
+        }
+        client_data: CXClientData(bitcast<raw void>(&raw context))
+    )
+
+    return results
+}
+
 fn process_type_alias(
     program: &mut CheckedProgram
     parent_scope_id: ScopeId
     module_id: ModuleId
+    this_type_id: TypeId?
     cursor: CXCursor
 ) throws {
     process_namespace_contents(
@@ -435,7 +738,7 @@ fn process_type_alias(
         module_id: module_id
         cursor: cursor
         allowed_contents: AllowedContents::OnlyTypes
-        this_type: None
+        this_type: this_type_id
     )
 
     let name = name_from(cursor)
@@ -530,6 +833,41 @@ fn function_names_from(cursor: CXCursor) throws -> (String, ExternalName?) {
     return (name, extern_name)
 }
 
+fn process_function_template(
+    program: &mut CheckedProgram
+    parent_scope_id: ScopeId
+    module_id: ModuleId
+    this_type: TypeId?
+    kind: ExternFunctionKind
+    cursor: CXCursor
+) throws {
+    let template_parameters = extract_template_parameters(program, parent_scope_id, module_id, cursor)
+    process_function(
+        program
+        parent_scope_id
+        module_id
+        this_type
+        kind
+        cursor
+        template_parameters
+    )
+}
+
+fn function_generic_parameters_from(
+    anon params: [CheckedGenericParameter]?
+) throws -> [FunctionGenericParameter] {
+    mut result: [FunctionGenericParameter] = []
+    if params.has_value() {
+        for param in params! {
+            result.push(FunctionGenericParameter(
+                kind: FunctionGenericParameterKind::Parameter
+                checked_parameter: param
+            ))
+        }
+    }
+    return result
+}
+
 fn process_function(
     program: &mut CheckedProgram
     parent_scope_id: ScopeId
@@ -537,6 +875,7 @@ fn process_function(
     this_type: TypeId?
     kind: ExternFunctionKind
     cursor: CXCursor
+    template_parameters: TemplateParameters? = None
 ) throws {
     if not this_type.has_value() and (kind is Constructor or kind is Destructor) {
         eprintln("[ICE] Constructor or destructor ({}) without a this type", name_from(cursor))
@@ -593,7 +932,12 @@ fn process_function(
     for parameter in parameters {
         let arg_type = clang_getCursorType(parameter)
         let arg_name = name_from(parameter)
-        let arg_type_id = type_from(program, scope_id: function_scope, module_id, arg_type)
+        let arg_type_id = type_from(
+            program
+            scope_id: function_scope
+            module_id
+            arg_type
+        )
         let variable = CheckedVariable(
             name: arg_name
             type_id: arg_type_id
@@ -631,7 +975,7 @@ fn process_function(
         generics: FunctionGenerics(
             base_scope_id: function_scope
             base_params: params
-            params: []
+            params: function_generic_parameters_from(template_parameters?.params)
             specializations: []
         )
         block: CheckedBlock(
@@ -877,6 +1221,7 @@ fn process_struct(
     cursor: CXCursor
     generic_parameters: [CheckedGenericParameter]? = None
     generic_parameter_defaults: [TypeId?]? = None
+    named_specialization_disambiguator: String? = None
 ) throws {
     if generic_parameters.has_value() and generic_parameter_defaults.has_value() {
         if generic_parameters!.size() != generic_parameter_defaults!.size() {
@@ -890,13 +1235,18 @@ fn process_struct(
         name = format("<anonymous@{}>", &raw cursor)
     }
 
+    let specialized_name = match named_specialization_disambiguator.has_value() {
+        true => format("{}<{}>", name, named_specialization_disambiguator!),
+        false => name
+    }
+
     let bases = extract_cursors_of_kinds(
         cursor
         kinds: {CXCursorKind::CXCursor_CXXBaseSpecifier}
     )
 
     mut module = program.get_module(module_id)
-    let existing_struct_id = program.get_scope(parent_scope_id).structs.get(name)
+    let existing_struct_id = program.get_scope(parent_scope_id).structs.get(specialized_name)
 
     let (struct_scope, scope_was_just_made) = match existing_struct_id.has_value() {
         true => (program.get_struct(existing_struct_id!).scope_id, false)
@@ -904,7 +1254,7 @@ fn process_struct(
             program.create_scope(
                 parent_scope_id
                 can_throw: false
-                debug_name: format("cpp-struct({})", name)
+                debug_name: format("cpp-struct({})", specialized_name)
                 module_id
                 for_block: false
             ),
@@ -913,7 +1263,7 @@ fn process_struct(
     }
 
     mut scope = program.get_scope(struct_scope)
-    scope.namespace_name = name
+    scope.namespace_name = specialized_name
 
     if generic_parameters.has_value() {
         for parameter in generic_parameters! {
@@ -951,8 +1301,8 @@ fn process_struct(
         module_id
     )
 
-    parent_scope.structs.set(name, struct_id)
-    parent_scope.types.set(name, struct_type_id)
+    parent_scope.structs.set(specialized_name, struct_id)
+    parent_scope.types.set(specialized_name, struct_type_id)
 
     if scope_was_just_made {
         // This is a predecl, so just add an empty struct for now.
@@ -989,7 +1339,12 @@ fn process_struct(
 
     mut super_struct_ids: [StructId] = []
     for base in bases {
-        match program.get_type(type_from(&mut program, scope_id: parent_scope_id, module_id, t: clang_getCursorType(base))) {
+        match program.get_type(type_from(
+            &mut program
+            scope_id: parent_scope_id
+            module_id
+            clang_getCursorType(base)
+        )) {
             GenericInstance(id) | Struct(id) => { super_struct_ids.push(id) }
             else => {}
         }
@@ -1009,6 +1364,7 @@ fn process_struct(
         program: *program
         module_id
         scope_id: struct_scope
+        this_type: struct_type_id
         extra: bitcast<raw void>(&raw fields)
     )
 
@@ -1029,7 +1385,12 @@ fn process_struct(
                     // if the field is a function (and not a function pointer), skip it here
                     if not (clang_getCursorType(c).kind is CXType_FunctionProto) {
                         let name = name_from(c)
-                        let type_id = type_from(&mut program, scope_id: struct_scope, module_id, t: clang_getCursorType(c))
+                        let type_id = type_from(
+                            &mut program
+                            scope_id: struct_scope
+                            module_id
+                            clang_getCursorType(c)
+                        )
                         let variable = CheckedVariable(
                             name
                             type_id
@@ -1299,5 +1660,60 @@ fn process_cpp_import(
     clang_disposeTranslationUnit(tu)
     clang_disposeIndex(index)
 
+    // dump_scope(import_scope_id, &program)
+
     return import_scope_id
+}
+
+fn dump_scope(anon scope_id: ScopeId, anon program: &CheckedProgram, indent: i64 = 0) throws {
+    mut scope = program.get_scope(scope_id)
+    eprintln("{: >{}}Scope (ns={}) {}", "", indent, scope.namespace_name, scope.debug_name)
+    let cindent = indent + 2
+    eprintln("{: >{}}Types:", "", cindent)
+    for (name, type_id) in scope.types {
+        let type = program.get_type(type_id)
+        eprintln("{: >{}}{}: {}", "", cindent + 2, name, program.type_name(type_id, debug_mode: true))
+    }
+    eprintln("{: >{}}Specializations:", "", cindent)
+    for (name, type) in scope.explicitly_specialized_types {
+        let type_name = program.type_name(type.type_id, debug_mode: true)
+        mut args = ""
+        for arg in type.arguments {
+            args = args + program.type_name(arg, debug_mode: true) + ", "
+        }
+
+        eprintln("{: >{}}{}<{}> = {}", "", cindent + 2, name, args, type_name)
+    }
+    eprintln("{: >{}}Variables:", "", cindent)
+    for (name, var_id) in scope.vars {
+        let var = program.get_variable(var_id)
+        eprintln("{: >{}}{}: {}", "", cindent + 2, name, program.type_name(var.type_id, debug_mode: true))
+    }
+    eprintln("{: >{}}Functions:", "", cindent)
+    for (name, ids) in scope.functions {
+        eprintln("{: >{}}{}:", "", cindent + 2, name)
+        for id in ids {
+            let function = program.get_function(id)
+            mut args = ""
+            for arg in function.params {
+                args = args + program.type_name(arg.variable.type_id, debug_mode: true) + ", "
+            }
+
+            eprintln("{: >{}}fn({}) -> {}", "", cindent + 4, args, program.type_name(function.return_type_id, debug_mode: true))
+        }
+    }
+    eprintln("{: >{}}Structs:", "", cindent)
+    for (name, id) in scope.structs {
+        let struct_ = program.get_struct(id)
+        eprintln("{: >{}}{}@{}: {}", "", cindent + 2, id.id, id.module, struct_.name)
+    }
+    eprintln("{: >{}}Aliases:", "", cindent)
+    for (name, id) in scope.aliases {
+        let scope = program.get_scope(id)
+        eprintln("{: >{}}{}: {}", "", cindent + 2, name, scope.debug_name)
+    }
+    eprintln("{: >{}}Children:", "", cindent)
+    for id in scope.children {
+        dump_scope(id, program, indent: cindent + 2)
+    }
 }

--- a/selfhost/cpp_import/clang_c.jakt
+++ b/selfhost/cpp_import/clang_c.jakt
@@ -535,6 +535,30 @@ import extern c "clang-c/Index.h" {
     extern fn clang_saveTranslationUnit(anon tu: CXTranslationUnit, file_name: raw c_char, options: u32) -> c_int
     extern fn clang_createTranslationUnit(index: CXIndex, file_name: raw c_char) -> CXTranslationUnit
     extern fn clang_getCanonicalCursor(anon cursor: CXCursor) -> CXCursor
+    extern fn clang_isDeclaration(anon kind: CXCursorKind) -> bool
+    extern fn clang_isExpression(anon kind: CXCursorKind) -> bool
+    extern fn clang_equalCursors(anon a: CXCursor, anon b: CXCursor) -> bool
+    extern fn clang_getCursorSemanticParent(anon a: CXCursor) -> CXCursor
+
+    extern struct CXEvalResult {}
+    extern enum CXEvalResultKind : c_int {
+        CXEval_Int
+        CXEval_Float
+        CXEval_ObjCStrLiteral
+        CXEval_StrLiteral
+        CXEval_CFStr
+        CXEval_Other
+        CXEval_UnExposed
+    }
+    extern fn clang_Cursor_Evaluate(cursor: CXCursor) -> CXEvalResult
+    extern fn clang_EvalResult_isUnsignedInt(anon result: CXEvalResult) -> bool
+    extern fn clang_EvalResult_getKind(anon result: CXEvalResult) -> CXEvalResultKind
+    extern fn clang_EvalResult_getAsInt(anon result: CXEvalResult) -> c_int
+    extern fn clang_EvalResult_getAsLongLong(anon result: CXEvalResult) -> i64
+    extern fn clang_EvalResult_getAsUnsigned(anon result: CXEvalResult) -> u64
+    extern fn clang_EvalResult_getAsDouble(anon result: CXEvalResult) -> f64
+    extern fn clang_EvalResult_getAsStr(anon result: CXEvalResult) -> raw c_char
+    extern fn clang_EvalResult_dispose(anon result: CXEvalResult) -> void
 }
 
 type CXTranslationUnit implements(Equal<CXTranslationUnit>) {

--- a/selfhost/ide.jakt
+++ b/selfhost/ide.jakt
@@ -1,10 +1,11 @@
 import parser { ParsedNamespace, ParsedRecord, ParsedFunction, BinaryOperator, FunctionLinkage, merge_spans }
 import typechecker {
-    BuiltinType, CheckedBlock, CheckedCall, CheckedExpression,
-    CheckedFunction, CheckedProgram, CheckedStatement, CheckedStruct,
-    Module, ModuleId, Scope, ScopeId, StructId, EnumId, Type, TypeId,
-    CheckedEnum, unknown_type_id, CheckedMatchCase, FunctionId, CheckedMatchBody, void_type_id,
-    CheckedVariable, NumberConstant, CheckedEnumVariant}
+    BuiltinType, CheckedBlock, CheckedCall, CheckedEnum, CheckedEnumVariant, CheckedExpression, CheckedFunction
+    CheckedMatchBody, CheckedMatchCase, CheckedProgram, CheckedStatement, CheckedStruct, CheckedVariable, EnumId
+    FunctionId, Module, ModuleId, NumberConstant, Scope, ScopeId, StructId, Type, TypeId, unknown_type_id
+    void_type_id
+}
+import types { comptime_format_impl }
 import utility { panic, todo, join, prepend_to_each, Span }
 import compiler { Compiler }
 
@@ -227,6 +228,8 @@ fn find_type_definition_for_type_id(program: CheckedProgram, type_id: TypeId, sp
         Function => span
         Trait(id) => program.get_trait(id).name_span
         Self => span
+        Dependent => span
+        Const(value) => value.span
         GenericInstance(id: struct_id, args) => {
             mut output = span
             if struct_id.equals(array_struct_id) or struct_id.equals(optional_struct_id) or struct_id.equals(range_struct_id) or struct_id.equals(set_struct_id) or struct_id.equals(tuple_struct_id) or struct_id.equals(weak_ptr_struct_id) {
@@ -1046,6 +1049,8 @@ fn get_type_signature(program: CheckedProgram, type_id: TypeId) throws -> String
         Unknown => ""
         Self => "Self"
         Trait(trait_id) => program.get_trait(trait_id).name
+        Dependent(namespace_type, name) => format("{}::{}", program.type_name(namespace_type), name)
+        Const(value) => comptime_format_impl(format_string: "const {}", arguments: [value][..], &program)
         Function(params, return_type_id) => {
             mut param_names: [String] = []
             for x in params {

--- a/selfhost/interpreter.jakt
+++ b/selfhost/interpreter.jakt
@@ -77,6 +77,8 @@ fn align_of_impl(
     CChar => 1
     CInt => Target::active().int_alignment()
     TypeVariable
+    | Const
+    | Dependent
     | GenericTraitInstance
     | GenericResolvedType => 0
     GenericInstance(id: struct_id, args)
@@ -188,6 +190,8 @@ fn size_of_impl(
     CChar => 1
     CInt => Target::active().int_size()
     TypeVariable
+    | Const
+    | Dependent
     | GenericTraitInstance
     | GenericResolvedType => 0
 

--- a/selfhost/interpreter.jakt
+++ b/selfhost/interpreter.jakt
@@ -4,7 +4,8 @@ import types {
     CheckedProgram, CheckedStatement, CheckedStringLiteral, CheckedTypeCast, CheckedUnaryOperator, CheckedVariable
     CheckedVisibility, EnumId, EnumVariantPatternArgument, FunctionGenerics, FunctionId, GenericInferences, ModuleId
     NumericOrStringValue, ParsedStatement, ResolvedNamespace, SafetyMode, Scope, ScopeId, Span, StringLiteral
-    StructId, Type, TypeId, TypecheckFunctions, Value, ValueImpl, VarId, builtin, unknown_type_id, void_type_id
+    StructId, Type, TypeId, TypecheckFunctions, Value, ValueImpl, VarId, builtin, comptime_format_impl
+    unknown_type_id, void_type_id
 }
 import parser { FunctionLinkage, FunctionType, ParsedBlock }
 import utility { escape_for_quotes, interpret_escapes, panic }
@@ -335,227 +336,6 @@ fn size_of_impl(
     MutableReference => Target::active().pointer_size()
     Function => 0
     Self => 0
-}
-
-fn format_value_impl(anon format_string: String, anon value: Value, interpreter: Interpreter) throws -> String => match value.impl {
-    Bool(v)
-    | U8(v)
-    | U16(v)
-    | U32(v)
-    | U64(v)
-    | USize(v)
-    | I8(v)
-    | I16(v)
-    | I32(v)
-    | I64(v)
-    | F32(v)
-    | F64(v)
-    | CChar(v)
-    | CInt(v)
-    | JaktString(v)
-    | StringView(v)
-    => format(format_string, v)
-
-    Struct(fields, struct_id, constructor)
-    | Class(fields, struct_id, constructor)
-    => {
-        let structure = interpreter.program.get_struct(struct_id)
-        mut builder = StringBuilder::create()
-        mut field_names: [String] = []
-
-        builder.append(structure.name)
-        if constructor.has_value() {
-            let function = interpreter.program.get_function(constructor!)
-            builder.append("::")
-            builder.append(function.name)
-            for parameter in function.params {
-                field_names.push(parameter.variable.name)
-            }
-        } else {
-            for field in structure.fields {
-                field_names.push(interpreter.program.get_variable(field.variable_id).name)
-            }
-        }
-        builder.append('(')
-        mut index = 0uz
-        for field in fields {
-            if index > 0 {
-                builder.append(", ")
-            }
-
-            builder.append(field_names[index])
-            builder.append(": ")
-            builder.append(format_value_impl(format_string, field, interpreter))
-            index += 1
-        }
-
-        builder.append(')')
-        yield builder.to_string()
-    }
-
-    Enum(fields, enum_id, constructor) => {
-        let enum_ = interpreter.program.get_enum(enum_id)
-        let function = interpreter.program.get_function(constructor)
-        mut builder = StringBuilder::create()
-        mut field_names: [String] = []
-
-        builder.append(enum_.name)
-        builder.append("::")
-        builder.append(function.name)
-        for parameter in function.params {
-            field_names.push(parameter.variable.name)
-        }
-
-        builder.append('(')
-        mut index = 0uz
-        for field in fields {
-            if index > 0 {
-                builder.append(", ")
-            }
-
-            builder.append(field_names[index])
-            builder.append(": ")
-            builder.append(format_value_impl(format_string, field, interpreter))
-            index += 1
-        }
-
-        builder.append(')')
-        yield builder.to_string()
-    }
-
-    OptionalSome(value) => format_value_impl(
-        format_string: format("Some({})", format_string)
-        value
-        interpreter
-    )
-    OptionalNone => format(format_string, "None")
-
-    JaktTuple(fields)
-    | JaktArray(values: fields)
-    | JaktSet(values: fields) => {
-        mut builder = StringBuilder::create()
-        let surrounding = match value.impl {
-            JaktTuple => ('(', ')')
-            JaktArray => ('[', ']')
-            JaktSet => ('{', '}')
-            else => {
-                abort()
-            }
-        }
-        builder.append(surrounding.0)
-        mut index = 0uz
-        for field in fields {
-            if index > 0 {
-                builder.append(", ")
-            }
-
-            builder.append(format_value_impl(format_string, field, interpreter))
-            index += 1
-        }
-
-        builder.append(surrounding.1)
-        yield builder.to_string()
-    }
-
-    JaktDictionary(keys, values) => {
-        mut builder = StringBuilder::create()
-        builder.append('[')
-        mut index = 0uz
-        for key in keys {
-            if index > 0 {
-                builder.append(", ")
-            }
-
-            builder.append(format_value_impl(format_string, key, interpreter))
-            builder.append(": ")
-            builder.append(format_value_impl(format_string, values[index], interpreter))
-
-            index += 1
-        }
-
-        builder.append(']')
-        yield builder.to_string()
-    }
-
-    else => {
-        throw Error::from_string_literal("Cannot format value of this type")
-    }
-}
-
-fn comptime_format_impl(format_string: String, arguments: ArraySlice<Value>, interpreter: Interpreter) throws -> String {
-    mut builder = StringBuilder::create()
-    mut current_argument_index = 0uz
-    mut format_field_builder = StringBuilder::create()
-    mut index_in_field: usize? = None
-    mut expect_close_brace = false
-
-    let argument_and_index = fn(anon str: String) -> (usize?, String) {
-        mut slice_end = 0uz
-        mut has_index = false
-        for code_point in str.code_points() {
-            guard code_point >= '0' and code_point <= '9' else {
-                break
-            }
-            slice_end += 1
-            has_index = true
-        }
-
-        if has_index {
-            let index_str = str.substring(start: 0, length: slice_end)
-            let index = index_str.to_uint()
-            if index.has_value() {
-                return (index! as! usize, str.substring(start: slice_end, length: str.length() - slice_end))
-            }
-        }
-
-        return (None, str)
-    }
-
-    for code_point in format_string.code_points() {
-        match code_point {
-            '{' => {
-                if index_in_field.has_value() and index_in_field! == 0 {
-                    builder.append('{')
-                    index_in_field = None
-                } else if index_in_field.has_value() {
-                    format_field_builder.append('{')
-                    index_in_field = index_in_field! + 1
-                } else {
-                    index_in_field = 0
-                }
-            }
-            '}' => {
-                if expect_close_brace {
-                    builder.append('}')
-                    expect_close_brace = false
-                } else if not index_in_field.has_value() {
-                    expect_close_brace = true
-                } else {
-                    index_in_field = None
-                    let fmt_string = format_field_builder.to_string()
-                    format_field_builder.clear()
-                    let (index, format_string) = argument_and_index(fmt_string)
-                    let effective_index = index ?? current_argument_index++
-                    if effective_index >= arguments.size() {
-                        throw Error::from_string_literal("Not enough arguments for format string")
-                    }
-
-                    let effective_format_string = format("{{{}}}", format_string)
-
-                    builder.append(format_value_impl(effective_format_string, arguments[effective_index], interpreter))
-                }
-            }
-            else => {
-                if index_in_field.has_value() {
-                    format_field_builder.append(code_point)
-                } else {
-                    builder.append(code_point)
-                }
-            }
-        }
-    }
-
-    return builder.to_string()
 }
 
 fn cast_value_to_type(anon this_value: Value, anon type_id: TypeId, interpreter: Interpreter, saturating: bool = false) throws -> Value {
@@ -1559,7 +1339,7 @@ class Interpreter {
                     yield StatementResult::JustValue(
                         Value(
                             impl: ValueImpl::JaktString(
-                                comptime_format_impl(format_string, arguments: arguments[1..], interpreter: this)
+                                comptime_format_impl(format_string, arguments: arguments[1..], program: &.program)
                             )
                             span: call_span
                         )
@@ -1573,7 +1353,7 @@ class Interpreter {
                             throw Error::from_errno(InterpretError::InvalidType as! i32);
                         }
                     }
-                    let formatted_string = comptime_format_impl(format_string, arguments: arguments[1..], interpreter: this)
+                    let formatted_string = comptime_format_impl(format_string, arguments: arguments[1..], program: &.program)
                     match prelude_function {
                         "println" => println("{}", formatted_string)
                         "eprintln" => eprintln("{}", formatted_string)

--- a/selfhost/lexer.jakt
+++ b/selfhost/lexer.jakt
@@ -254,7 +254,7 @@ struct Lexer implements(ThrowingIterable<Token>) {
             "char32_t",
             "compl",
             "concept",
-            "const",
+            // "const",
             "consteval",
             "constexpr",
             "constinit",

--- a/selfhost/main.jakt
+++ b/selfhost/main.jakt
@@ -63,6 +63,7 @@ fn help() throws -> String {
     output += "  --repl\t\t\t\tStart a Read-Eval-Print loop session.\n"
     output += "  --print-symbols\t\t\tEmit a machine-readable (JSON) symbol tree.\n"
     output += "  --use-ccache\t\t\t\tUse ccache when compiling.\n"
+    output += "  --discover\t\t\t\tDiscover all files in the project, print the dependencies and outputs, then exit.\n"
     output += "  --ak-is-my-only-stdlib\t\tForget about interop, AK is the one and only STL.\n"
 
     output += "\nOptions:\n"
@@ -538,6 +539,7 @@ fn compiler_main(anon args: [String]) throws -> c_int {
     let input_format_range = args_parser.option(["-fr", "--format-range"]) ?? ""
 
     let ak_stdlib = args_parser.flag(["--ak-is-my-only-stdlib"])
+    let discover_only = args_parser.flag(["--discover"])
 
     let max_concurrent = try value_or_throw(compiler_job_count.to_uint()) catch {
         eprintln("error: invalid value for --jobs: {}", compiler_job_count)
@@ -845,6 +847,23 @@ fn compiler_main(anon args: [String]) throws -> c_int {
     }
 
     let codegen_result = CodeGenerator::generate(compiler, checked_program, debug_info: codegen_debug)
+
+    if discover_only {
+        for (file, contents_and_path) in codegen_result {
+            let (_, module_file_path) = contents_and_path
+            if module_file_path == "__prelude__" {
+                continue
+            }
+
+            let path = binary_dir.join(file)
+            println(
+                "{}:{}"
+                path.to_string()
+                module_file_path
+            )
+        }
+        return 0
+    }
 
     mut depfile_builder = StringBuilder::create()
 

--- a/selfhost/main.jakt
+++ b/selfhost/main.jakt
@@ -21,17 +21,14 @@ import ide
 import interpreter { Interpreter, InterpreterScope, value_to_checked_expression }
 import lexer { Lexer, Token }
 import parser { Parser }
-import platform { library_name, platform_compiler }
+import platform { library_name_for_target, platform_compiler }
 import project { Project }
 import repl { REPL, serialize_ast_node }
 import typechecker { Typechecker }
 import types { FunctionId, ResolvedNamespace, ScopeId, ModuleId, Value, ValueImpl }
-import utility { Span, escape_for_quotes, join, write_to_file}
+import utility { Queue, Span, escape_for_quotes, join, write_to_file }
 
-import platform_fs() {
-    make_directory
-    DirectoryIterator
-}
+import platform_fs() { DirectoryIterator, make_directory }
 
 import platform_compiler() {
     run_compiler
@@ -39,18 +36,17 @@ import platform_compiler() {
 
 import jakt::platform { Target }
 
-fn usage() throws => "usage: jakt [-h] [OPTIONS] <filename>"
+fn usage() throws => "usage: jakt [cross] [-h] [OPTIONS] <filename>"
 fn help() throws -> String {
-    mut output = "Flags:\n"
+    mut output = ""
+    output += "Non-cross mode:\n"
+    output += "FLAGS:\n"
     output += "  -h,--help\t\t\t\tPrint this help and exit.\n"
     output += "  -O\t\t\t\t\tBuild an optimized executable.\n"
     output += "  -dl\t\t\t\t\tPrint debug info for the lexer.\n"
     output += "  -dp\t\t\t\t\tPrint debug info for the parser.\n"
     output += "  -dt\t\t\t\t\tPrint debug info for the typechecker.\n"
     output += "  -S,--emit-cpp-source-only\t\tOnly output source (do not build).\n"
-    output += "  -T,--target-triple TARGET\t\tSpecify the target triple used for the build, defaults to native.\n"
-    output += "  --runtime-library-path PATH\t\tSpecify the path to the runtime library.\n"
-    output += "  -J,--jobs NUMBER\t\t\tSpecify the number of jobs to run in parallel, defaults to 2 (1 on windows).\n"
     output += "  -cr,--compile-run\t\t\tBuild and run an executable file.\n"
     output += "  -r,--run\t\t\t\tRun the given file without compiling it (all positional arguments after the file name will be passed to main).\n"
     output += "  -d\t\t\t\t\tInsert debug statement spans in generated C++ code.\n"
@@ -67,8 +63,12 @@ fn help() throws -> String {
     output += "  --repl\t\t\t\tStart a Read-Eval-Print loop session.\n"
     output += "  --print-symbols\t\t\tEmit a machine-readable (JSON) symbol tree.\n"
     output += "  --use-ccache\t\t\t\tUse ccache when compiling.\n"
+    output += "  --ak-is-my-only-stdlib\t\tForget about interop, AK is the one and only STL.\n"
 
     output += "\nOptions:\n"
+    output += "  -T,--target-triple TARGET\t\tSpecify the target triple used for the build, defaults to native.\n"
+    output += "  --runtime-library-path PATH\t\tSpecify the path to the runtime library.\n"
+    output += "  -J,--jobs NUMBER\t\t\tSpecify the number of jobs to run in parallel, defaults to 2 (1 on windows).\n"
     output += "  -F,--clang-format-path PATH\t\tPath to clang-format executable.\n\t\t\t\t\tDefaults to clang-format\n"
     output += "  -D,--dot-clang-format-path PATH\tPath to the .clang-format file to use.\n\t\t\t\t\tDefaults to none, invoking clangs default .clang-format file handling.\n"
     output += "  -R,--runtime-path PATH\t\tPath of the Jakt runtime headers.\n\t\t\t\t\tDefaults to $PWD/runtime.\n"
@@ -83,7 +83,24 @@ fn help() throws -> String {
     output += "  -e,--hover INDEX\t\t\tReturn the type of element at index.\n"
     output += "  -m,--completions INDEX\t\tReturn dot completions at index.\n"
     output += "  --create NAME\t\t\t\tCreate sample project in $PWD/NAME\n"
-    output += "  --ak-is-my-only-stdlib\t\tForget about interop, AK is the one and only STL.\n"
+
+    output += "\nCross mode:\n"
+    output += "  Flags and options not listed below will be passed verbatim to the underlying `jakt' invocation.\n"
+    output += "FLAGS:\n"
+    output += "  --only-support-libs\t\t\tOnly build and install support libraries for the target platform.\n"
+
+    output += "\nOPTIONS:\n"
+    output += "  -T,--target-triple TARGET\t\tSpecify the target triple used for the build, defaults to native.\n"
+    output += "  --sysroot PATH\t\t\tSpecify the sysroot used for the build.\n"
+    output += "  --system-lib-dir PATH\t\t\tSpecify a system library directory to use.\n"
+    output += "  --system-include-dir PATH\t\tSpecify a system include directory to use.\n"
+    output += "  --compiler-include-dir PATH\t\tSpecify a compiler include directory to use.\n"
+    output += "  --compiler-lib-dir PATH\t\tSpecify a compiler library directory to use.\n"
+    output += "  --install-root PATH\t\t\tSpecify the root directory to install to.\n"
+    output += "  --runtime-lib-path PATH\t\tSpecify the path to the host runtime library.\n"
+    output += "  --runtime-path PATH\t\t\tSpecify the path to the host runtime headers.\n"
+    output += "  --source-file PATH\t\t\tSpecify the path to the source file to compile.\n"
+    output += "  -o,--output-filename FILE\t\tName of the output binary.\n"
     return output
 }
 
@@ -143,7 +160,7 @@ fn value_or_throw<T>(anon maybe: T?) throws -> T {
         return maybe!
     }
 
-    throw Error::from_errno(1)
+    throw Error::from_string_literal("Expected value but found none")
 }
 
 fn main(args: [String]) -> c_int {
@@ -152,6 +169,284 @@ fn main(args: [String]) -> c_int {
         return 1
     }
 
+    if args[1] == "cross" {
+        return selfhost_crosscompiler_main(args)
+    }
+
+    return compiler_main(args)
+}
+
+fn install(from: Path, to: Path) throws {
+    mut directories_to_copy: Queue<(Path, Path)> = Queue()
+    directories_to_copy.enqueue((from, Path::from_string(".")))
+    while not directories_to_copy.is_empty() {
+        let (directory, relative_dir) = directories_to_copy.dequeue()
+        for (entry, is_directory) in DirectoryIterator::from_path(path: directory)! {
+            let path = directory.join(entry)
+            let path_relative_to_target = relative_dir.join(entry)
+
+            if is_directory {
+                try make_directory(path: to.join(path_relative_to_target.to_string()).to_string())
+                directories_to_copy.enqueue((path, path_relative_to_target))
+                continue
+            }
+
+            // FIXME: Symlink
+            let target_path = to.join(path_relative_to_target.to_string())
+            mut input_file = File::open_for_reading(path.to_string())
+            mut output_file = File::open_for_writing(target_path.to_string())
+            mut buffer = [0u8; 4096]
+            while true {
+                let bytes_read = input_file.read(buffer)
+                if bytes_read == 0 {
+                    break
+                }
+
+                mut bytes_written: usize = 0
+                while bytes_written < bytes_read {
+                    bytes_written += output_file.write(buffer[bytes_written..bytes_read].to_array())
+                }
+
+                if bytes_written != bytes_read {
+                    throw Error::from_string_literal("Failed to write to file")
+                }
+            }
+        }
+    }
+}
+
+fn selfhost_crosscompiler_main(args: [String]) throws -> c_int {
+    mut compiler_args: [String] = []
+
+    mut target_triple: String? = None
+    mut sysroot: String? = None
+    mut system_lib_dirs: [String] = []
+    mut system_include_dirs: [String] = []
+    mut compiler_include_dir: String? = None
+    mut compiler_lib_dir: String? = None
+
+    mut install_root: String? = None
+    mut runtime_lib_path: Path? = None
+    mut runtime_path: Path? = None
+
+    mut source_file: String? = None
+    mut output_filename: String? = None
+    mut only_support_libs = false
+
+    mut args_to_process: Queue<String> = Queue()
+    for arg in args[1..] {
+        args_to_process.enqueue(arg)
+    }
+
+    while not args_to_process.is_empty() {
+        let arg = args_to_process.dequeue()
+        match arg {
+            "--target-triple" | "-T" => { target_triple = args_to_process.dequeue() }
+            "--sysroot" => { sysroot = args_to_process.dequeue() }
+            "--system-lib-dir" => {
+                system_lib_dirs.push(args_to_process.dequeue())
+            }
+            "--system-include-dir" => {
+                system_include_dirs.push(args_to_process.dequeue())
+            }
+            "--compiler-include-dir" => {
+                compiler_include_dir = args_to_process.dequeue()
+            }
+            "--compiler-lib-dir" => {
+                compiler_lib_dir = args_to_process.dequeue()
+            }
+            "--install-root" => { install_root = args_to_process.dequeue() }
+            "--runtime-lib-path" => { runtime_lib_path = Path::from_string(args_to_process.dequeue()) }
+            "--runtime-path" => { runtime_path = Path::from_string(args_to_process.dequeue()) }
+            "--source-file" => { source_file = args_to_process.dequeue() }
+            "--output-filename" | "-o" => { output_filename = args_to_process.dequeue() }
+            "--only-support-libs" => { only_support_libs = true }
+            else => { compiler_args.push(arg) }
+        }
+    }
+
+    if source_file is None and not only_support_libs {
+        eprintln("error: Expected --source_file to be passed")
+        return 1
+    }
+
+    if install_root is None {
+        eprintln("error: Expected --install-root to be passed")
+        return 1
+    }
+
+    if target_triple is None {
+        eprintln("error: Expected --target-triple to be passed")
+        return 1
+    }
+
+    let abbreviated_triple = Target::from_triple(target_triple!).name(abbreviate: true)
+
+    let install_dir = Path::from_string(install_root!)
+    let install_lib_dir = install_dir.join("lib").join(target_triple!)
+    let install_runtime_dir = install_dir.join("include/runtime")
+    let install_bin_dir = install_dir.join("bin")
+
+    let current_executable_path = Path::from_string(File::current_executable_path())
+    let local_install_base_path = current_executable_path.parent().parent()
+    if runtime_path is None {
+        runtime_path = local_install_base_path.join("include/runtime")
+    }
+    if runtime_lib_path is None {
+        runtime_lib_path = local_install_base_path.join("lib").join(Target::active().name())
+    }
+
+    let compiler_invocation_args = fn[
+        &compiler_args
+        &abbreviated_triple
+        &sysroot
+        &compiler_include_dir
+        &compiler_lib_dir
+        &system_include_dirs
+        &system_lib_dirs
+        &runtime_lib_path
+        &runtime_path
+    ]() throws -> [String] {
+        mut args = compiler_args[..].to_array()
+        args.push("--target-triple")
+        args.push(format("{}-unknown", abbreviated_triple))
+
+        if sysroot.has_value() {
+            args.push("--extra-cpp-flag")
+            args.push(format("--sysroot={}", sysroot!))
+        }
+
+        if compiler_include_dir.has_value() {
+            args.push("-I")
+            args.push(compiler_include_dir!)
+        }
+
+        if compiler_lib_dir.has_value() {
+            args.push("-L")
+            args.push(compiler_lib_dir!)
+        }
+
+        for system_include_dir in system_include_dirs {
+            args.push("-I")
+            args.push(system_include_dir)
+        }
+
+        for system_lib_dir in system_lib_dirs {
+            args.push("-L")
+            args.push(system_lib_dir)
+        }
+
+        if runtime_lib_path.has_value() {
+            args.push("--runtime-library-path")
+            args.push(runtime_lib_path!.to_string())
+        }
+
+        if runtime_path.has_value() {
+            args.push("--runtime-path")
+            args.push(runtime_path!.to_string())
+        }
+
+        return args
+    }
+
+    if not install_lib_dir.exists() { mkdir_p(path: install_lib_dir) }
+    install(from: runtime_path!, to: install_runtime_dir)
+    if not install_bin_dir.exists() { mkdir_p(path: install_bin_dir) }
+
+    let runtime_archive_path = install_lib_dir.join(format("libjakt_runtime_{}.a", target_triple!))
+    let main_archive_path = install_lib_dir.join(format("libjakt_main_{}.a", target_triple!))
+
+    let build_archive = fn[&compiler_invocation_args](anon sources: [Path], anon target: Path) throws -> c_int {
+        mut invocation_args = compiler_invocation_args()
+        for source in sources {
+            invocation_args.push("-X")
+            invocation_args.push(source.to_string())
+        }
+
+        invocation_args.push("--static")
+        invocation_args.push("--link-archive")
+        invocation_args.push(target.to_string())
+        invocation_args.push("/dev/null")
+
+        return compiler_main(invocation_args)
+    }
+
+    if not runtime_archive_path.exists() {
+        eprintln("Building jakt runtime for target {}...", abbreviated_triple)
+        mut sources: [Path] = [runtime_path!.join("IO/File.cpp")]
+        sources.push_values(&find_with_extension(path: runtime_path!.join("AK"), extension: "cpp"))
+        sources.push_values(&find_with_extension(path: runtime_path!.join("Jakt"), extension: "cpp"))
+
+        if build_archive(sources, runtime_archive_path) != 0 {
+            return 1
+        }
+    }
+
+    if not main_archive_path.exists() {
+        eprintln("Building jakt main for target {}...", abbreviated_triple)
+        mut sources: [Path] = [runtime_path!.join("Main.cpp")]
+
+        if build_archive(sources, main_archive_path) != 0 {
+            return 1
+        }
+    }
+
+    runtime_lib_path = install_lib_dir.parent()
+    runtime_path = install_runtime_dir
+
+    if not only_support_libs {
+        mut compiler_args = compiler_invocation_args()
+        let source_path = Path::from_string(source_file!)
+        compiler_args.push(source_path.to_string())
+        compiler_args.push("-o")
+        let default_output_filename = install_bin_dir.join(output_filename ?? source_path.basename(strip_extension: true)).to_string()
+        compiler_args.push(default_output_filename)
+
+        return compiler_main(compiler_args)
+    }
+
+    return 0
+}
+
+fn mkdir_p(anon path: Path) throws {
+    let components = path.components()
+    if components.is_empty() { return }
+
+    mut current_path = Path::from_string(components[0])
+    for part in components[1..] {
+        if not current_path.exists() {
+            eprintln("- mkdir {}", current_path)
+            make_directory(path: current_path.to_string())
+        }
+
+        current_path = current_path.join(part)
+    }
+
+    if not current_path.exists() {
+        make_directory(path: current_path.to_string())
+    }
+}
+
+fn find_with_extension(path: Path, extension: String) throws -> [Path] {
+    mut directories_to_search: Queue<Path> = Queue()
+    directories_to_search.enqueue(path)
+    mut files_found: [Path] = []
+    while not directories_to_search.is_empty() {
+        let directory = directories_to_search.dequeue()
+        for (entry, is_directory) in DirectoryIterator::from_path(path: directory)! {
+            let path = directory.join(entry)
+            if is_directory {
+                directories_to_search.enqueue(path)
+            } else if entry.extension() == extension {
+                files_found.push(path)
+            }
+        }
+    }
+
+    return files_found
+}
+
+fn compiler_main(anon args: [String]) throws -> c_int {
     mut args_parser = ArgsParser::from_args(args)
 
     if args_parser.flag(["-h", "--help"]) {
@@ -207,6 +502,7 @@ fn main(args: [String]) -> c_int {
     let extra_link_libs = args_parser.option_multiple(["-l"])
     let extra_linker_args = args_parser.option_multiple(["-Wl"])
     let extra_cpp_files = args_parser.option_multiple(["-X"])
+    let extra_cpp_flags = args_parser.option_multiple(["--extra-cpp-flag"])
     let set_output_filename = args_parser.option(["-o", "--output-filename"])
     let goto_def = args_parser.option(["-g", "--goto-def"])
     let goto_type_def = args_parser.option(["-t", "--goto-type-def"])
@@ -260,6 +556,10 @@ fn main(args: [String]) -> c_int {
         let project = Project(name: project_name!)
         project.populate()
         return 0
+    }
+
+    let compiler_is = fn[cxx_compiler_path](anon name: String) throws -> bool {
+        return Path::from_string(cxx_compiler_path).basename() == name
     }
 
     mut file_name: String? = None
@@ -629,6 +929,17 @@ fn main(args: [String]) -> c_int {
             extra_compiler_flags.push("-static")
         }
 
+        if target_triple.has_value() {
+            if compiler_is("clang++") and target_triple! != Target::active().name() {
+                extra_compiler_flags.push("-target")
+                extra_compiler_flags.push(target_triple!)
+            }
+        }
+
+        for flag in extra_cpp_flags {
+            extra_compiler_flags.push(flag)
+        }
+
         try builder.build_all(
             binary_dir
             compiler_invocation: &fn[
@@ -666,9 +977,25 @@ fn main(args: [String]) -> c_int {
         } else {
             mut extra_arguments: [String] = ["-g"]
 
+            for flag in extra_cpp_flags {
+                extra_arguments.push(flag)
+            }
+
+            let target = match target_triple.has_value() {
+                true => Target::from_triple(target_triple!)
+                false => Target::active()
+            }
+
+            if target_triple.has_value() {
+                if compiler_is("clang++") and target_triple! != Target::active().name() {
+                    extra_arguments.push("-target")
+                    extra_arguments.push(target.name(abbreviate: true))
+                }
+            }
+
             let runtime_lib_path = Path::from_string(runtime_library_path)
-            extra_arguments.push(runtime_lib_path.join(library_name("main")).to_string())
-            extra_arguments.push(runtime_lib_path.join(library_name("runtime")).to_string())
+            extra_arguments.push(runtime_lib_path.join(library_name_for_target("main", target)).to_string())
+            extra_arguments.push(runtime_lib_path.join(library_name_for_target("runtime", target)).to_string())
 
             for path in extra_lib_paths {
                 extra_arguments.push("-L")
@@ -680,7 +1007,7 @@ fn main(args: [String]) -> c_int {
                 extra_arguments.push(lib)
             }
 
-            if is_windows() and Path::from_string(cxx_compiler_path).basename() == "clang-cl" {
+            if is_windows() and compiler_is("clang-cl") {
                 extra_arguments.push("/link")
                 extra_arguments.push("/subsystem:console")
             }

--- a/selfhost/main.jakt
+++ b/selfhost/main.jakt
@@ -201,10 +201,12 @@ fn main(args: [String]) -> c_int {
     let cxx_compiler_path = args_parser.option(["-C", "--cxx-compiler-path"]) ?? default_compiler_path
     let archiver_path = args_parser.option(["-A", "--archiver"])
     let link_archive = args_parser.option(["-a", "--link-archive"])
+    let build_static = args_parser.flag(["--static"])
     let extra_include_paths = args_parser.option_multiple(["-I"])
     let extra_lib_paths = args_parser.option_multiple(["-L"])
     let extra_link_libs = args_parser.option_multiple(["-l"])
     let extra_linker_args = args_parser.option_multiple(["-Wl"])
+    let extra_cpp_files = args_parser.option_multiple(["-X"])
     let set_output_filename = args_parser.option(["-o", "--output-filename"])
     let goto_def = args_parser.option(["-g", "--goto-def"])
     let goto_type_def = args_parser.option(["-t", "--goto-type-def"])
@@ -609,6 +611,10 @@ fn main(args: [String]) -> c_int {
             files.push(file_name)
         }
 
+        for file in extra_cpp_files {
+            files.push(file)
+        }
+
         mut builder = Builder::for_building(
             files
             max_concurrent
@@ -617,6 +623,10 @@ fn main(args: [String]) -> c_int {
         mut extra_compiler_flags = ["-c"]
         if ak_stdlib {
             extra_compiler_flags.push("-DJAKT_USING_AK_AS_STANDARD_LIBRARY=1")
+        }
+
+        if build_static {
+            extra_compiler_flags.push("-static")
         }
 
         try builder.build_all(
@@ -649,7 +659,7 @@ fn main(args: [String]) -> c_int {
         if link_archive.has_value() {
             try builder.link_into_archive(
                 archiver: archiver_path ?? "ar"
-                archive_filename: link_archive!
+                archive_filename: binary_dir.join(link_archive!).to_string()
             ) catch {
                 return 1
             }

--- a/selfhost/parser.jakt
+++ b/selfhost/parser.jakt
@@ -473,6 +473,7 @@ struct ParsedGenericParameter {
     span: Span
     // the list, if it exists, must have at least one element.
     requires_list: [ParsedNameWithGenericParameters]?
+    is_value: bool
 }
 
 enum ParsedTraitRequirements {
@@ -1479,6 +1480,8 @@ boxed enum ParsedType {
     RawPtr(inner: ParsedType, span: Span)
     WeakPtr(inner: ParsedType, span: Span)
     Function(params: [ParsedParameter], can_throw: bool, return_type: ParsedType, span: Span)
+    Const(expr: ParsedExpression, span: Span)
+    DependentType(base: ParsedType, name: String, span: Span)
     Empty
 
     fn span(this) -> Span => match this {
@@ -1487,6 +1490,10 @@ boxed enum ParsedType {
     }
 
     fn equals(this, anon rhs_parsed_type: ParsedType) -> bool => match this {
+        DependentType(base, name) => match rhs_parsed_type {
+            DependentType(base: rhs_base, name: rhs_name) => base.equals(rhs_base) and name == rhs_name
+            else => false
+        }
         Name(name: lhs_name) => match rhs_parsed_type {
             Name(name: rhs_name) => lhs_name == rhs_name
             else => false
@@ -1609,6 +1616,7 @@ boxed enum ParsedType {
             else => false
         }
         Empty => rhs_parsed_type is Empty
+        Const => false // FIXME: Implement this.
     }
 }
 
@@ -3866,7 +3874,43 @@ struct Parser {
     }
 
     fn parse_typename(mut this) throws -> ParsedType {
+        let base = .parse_typename_base()
+        mut result = base
+        mut done = false
+        while not done {
+            match .current() {
+                ColonColon => {
+                    // This is a dependent type
+                    .index++
+                    if .current() is Identifier(name) {
+                        .index++
+                        result = ParsedType::DependentType(
+                            base: result
+                            name
+                            span: merge_spans(base.span(), .current().span())
+                        )
+                    } else {
+                        .error("Expected identifier after `::`", .current().span())
+                        done = true
+                    }
+                }
+                else => {
+                    done = true
+                }
+            }
+        }
+        return result
+    }
+
+    fn parse_typename_base(mut this) throws -> ParsedType {
         let start = .current().span()
+
+        if .current() is Comptime {
+            .index++
+            let expr = .parse_operand()
+            return ParsedType::Const(expr, span: merge_spans(start, expr.span()))
+        }
+
         mut is_reference = false
         mut is_mutable_reference = false
 
@@ -3925,7 +3969,7 @@ struct Parser {
         Identifier(name) => {
             let span = .current().span()
             .index++
-            mut parsed_type =  ParsedType::Name(name, span)
+            mut parsed_type = ParsedType::Name(name, span)
             if .current() is LessThan {
                 mut params = .parse_type_parameter_list()
                 parsed_type = ParsedType::GenericType(name, generic_parameters: params, span)
@@ -5963,9 +6007,11 @@ struct Parser {
         .skip_newlines()
 
         mut saw_ending_bracket = false
+        mut next_generic_is_value = false
         while not .eof() {
             match .current() {
                 Identifier(name, span) => {
+                    mut effective_name = name
                     mut requires_list: [ParsedNameWithGenericParameters]? = None
 
                     .index++
@@ -5974,10 +6020,17 @@ struct Parser {
                         requires_list = .parse_trait_list()
                     }
 
-                    generic_parameters.push(ParsedGenericParameter(name, span, requires_list))
+                    generic_parameters.push(ParsedGenericParameter(name, span, requires_list, is_value: next_generic_is_value))
+                    next_generic_is_value = false
+
                     if .current() is Comma or .current() is Eol {
                         .index++
                     }
+                }
+                Comptime => {
+                    .index++
+                    next_generic_is_value = true
+                    continue
                 }
                 GreaterThan => {
                     .index++

--- a/selfhost/platform.jakt
+++ b/selfhost/platform.jakt
@@ -3,8 +3,7 @@ import jakt::prelude::configuration { UserConfiguration }
 
 comptime platform_compiler() throws -> [String] => platform_module("platform::compiler")
 
-comptime library_name(anon name: String) throws -> String {
-    let target = Target::active()
+fn library_name_for_target(anon name: String, anon target: Target) throws -> String {
     let target_name = target.name()
     return format("{}/{}"
         target_name
@@ -14,6 +13,8 @@ comptime library_name(anon name: String) throws -> String {
         }
     )
 }
+
+comptime library_name(anon name: String) throws -> String => library_name_for_target(name, target: Target::active())
 
 comptime repl_backend() throws -> String => match UserConfiguration::value_of("jakt.repl_backend") ?? "default" {
     "default" => "repl_backend::default"

--- a/selfhost/typechecker.jakt
+++ b/selfhost/typechecker.jakt
@@ -24,8 +24,8 @@ import types {
     CheckedVariable, CheckedVisibility, ClassInstanceRebind, EnumId, FieldRecord, FunctionGenericParameter
     FunctionGenerics, FunctionId, GenericInferences, IterationDecision, LoadedModule, MaybeResolvedScope, Module
     ModuleId, NumberConstant, OperatorTraitImplementation, ResolvedNamespace, SafetyMode, Scope, ScopeId
-    StringLiteral, StructId, StructLikeId, TraitId, Type, TypeId, Value, VarId, builtin comptime_format_impl,
-    never_type_id, unknown_type_id, void_type_id
+    SpecializedType, StringLiteral, StructId, StructLikeId, TraitId, Type, TypeId, Value, VarId, builtin
+    comptime_format_impl, never_type_id, unknown_type_id, void_type_id
 }
 import types
 import utility { FileId, Span, add_arrays, escape_for_quotes, join, panic, todo }
@@ -5678,7 +5678,107 @@ struct Typechecker {
         }
     }
 
-    fn typecheck_generic_resolved_type(mut this, name: String, checked_inner_types: [TypeId], scope_id: ScopeId, span: Span) throws -> TypeId {
+    fn find_explicitly_specialized_type_in_scope(
+        mut this
+        scope_id: ScopeId
+        name: String
+        arguments: [TypeId]
+        span: Span
+    ) throws -> TypeId? {
+        mut matching_types: [SpecializedType] = []
+        .program.for_each_scope_accessible_unqualified_from_scope(
+            scope_id
+            &fn[
+                &mut matching_types
+                &name
+                &arguments
+                &span
+                this
+            ](scope_id: ScopeId, name_override: String?, is_alias: bool) throws -> IterationDecision<bool> {
+                let scope = .get_scope(scope_id)
+                if not scope.explicitly_specialized_types.contains(name) {
+                    return IterationDecision::Continue
+                }
+
+                let specialized_type = scope.explicitly_specialized_types[name]
+                let checkpoint = .generic_inferences.perform_checkpoint(reset: false)
+                defer .generic_inferences.restore(checkpoint)
+
+                mut is_okay = true
+                for i in 0..specialized_type.arguments.size() {
+                    if arguments.size() <= i {
+                        break
+                    }
+                    let given_arg = arguments[i]
+                    let specialized_arg = specialized_type.arguments[i]
+
+                    let old_ignore_errors = .ignore_errors
+                    defer .ignore_errors = old_ignore_errors
+                    .ignore_errors = true
+
+                    if not .check_types_for_compat(
+                        lhs_type_id: specialized_arg
+                        rhs_type_id: given_arg
+                        generic_inferences: &mut .generic_inferences
+                        span
+                    ) {
+                        is_okay = false
+                        break
+                    }
+                }
+
+                if is_okay { matching_types.push(specialized_type) }
+                return IterationDecision::Continue
+            }
+        )
+
+        mut result: TypeId? = None
+        mut chosen_specialization: SpecializedType? = None
+        mut max_seen_specificity = 0
+        for specialization in matching_types {
+            mut total_specificity = 0
+            for arg in specialization.arguments {
+                total_specificity += .get_type(arg).specificity(program: .program)
+            }
+            if total_specificity > max_seen_specificity {
+                max_seen_specificity = total_specificity
+                result = specialization.type_id
+                chosen_specialization = specialization
+            }
+        }
+
+        if chosen_specialization.has_value() {
+            if StructLikeId::from_type_id(result!, &.program) is Some(struct_like_id) {
+                .generic_inferences.set_all(
+                    keys: struct_like_id.generic_parameters_as_checked(program: &.program)
+                    values: chosen_specialization!.arguments
+                )
+            }
+        }
+        return result
+    }
+
+    fn typecheck_generic_resolved_type(
+        mut this
+        name: String
+        checked_inner_types: [TypeId]
+        scope_id: ScopeId
+        span: Span
+    ) throws -> TypeId {
+        let explicitly_specialized_type = .find_explicitly_specialized_type_in_scope(
+            scope_id
+            name
+            arguments: checked_inner_types
+            span
+        )
+        if explicitly_specialized_type.has_value() {
+            return StructLikeId::from_type_id(explicitly_specialized_type!, program: &.program)!.specialized_by(
+                arguments: checked_inner_types
+                program: &mut .program
+                module_id: .current_module().id
+            )
+        }
+
         let struct_id = .find_struct_in_scope(scope_id, name)
         if struct_id.has_value() {
             let struct_ = .get_struct(struct_id!)
@@ -9973,17 +10073,6 @@ struct Typechecker {
 
         // 2. Look for a function with this name.
         let maybe_overload_set = .find_scoped_functions_with_name_in_scope(parent_scope_id: current_scope_id, function_name: call.name)
-        if call.name == "ptr" {
-            eprintln("Looking for function 'ptr' in scope {} {} => {}",
-                scope_id
-                .debug_description_of(scope_id)
-                maybe_overload_set
-            )
-            if not maybe_overload_set.has_value() {
-                let scope = .get_scope(scope_id)
-                eprintln("All functions in this scope: {:#}", scope.functions.keys())
-            }
-        }
         if maybe_overload_set.has_value() {
             let function = .get_function(maybe_overload_set!.0[0])
             if not must_be_enum_constructor or function.type is ImplicitEnumConstructor {

--- a/selfhost/typechecker.jakt
+++ b/selfhost/typechecker.jakt
@@ -1422,8 +1422,13 @@ struct Typechecker {
             }
             {
                 // Anonymous namespace to ensure imported symbols don't clash with prelude symbols.
+                // (unless the imported namespace is actually named)
                 mut scope = .get_scope(scope_id)
                 scope.children.push(base_import_scope_id)
+                if import_.assigned_namespace.name.has_value() {
+                    .get_scope(base_import_scope_id).namespace_name = import_.assigned_namespace.name!
+                    .get_scope(base_import_scope_id).external_name = ExternalName::Plain("") // global ns
+                }
             }
 
             guard not existing_scope.has_value() else {

--- a/selfhost/typechecker.jakt
+++ b/selfhost/typechecker.jakt
@@ -24,8 +24,8 @@ import types {
     CheckedVariable, CheckedVisibility, ClassInstanceRebind, EnumId, FieldRecord, FunctionGenericParameter
     FunctionGenerics, FunctionId, GenericInferences, IterationDecision, LoadedModule, MaybeResolvedScope, Module
     ModuleId, NumberConstant, OperatorTraitImplementation, ResolvedNamespace, SafetyMode, Scope, ScopeId
-    StringLiteral, StructId, StructLikeId, TraitId, Type, TypeId, Value, VarId, builtin, never_type_id
-    unknown_type_id, void_type_id
+    StringLiteral, StructId, StructLikeId, TraitId, Type, TypeId, Value, VarId, builtin comptime_format_impl,
+    never_type_id, unknown_type_id, void_type_id
 }
 import types
 import utility { FileId, Span, add_arrays, escape_for_quotes, join, panic, todo }
@@ -2251,7 +2251,7 @@ struct Typechecker {
 
             mut trait_implementations: [TypeId] = []
             mut parameter = CheckedGenericParameter::make(parameter_type_id, span: gen_parameter.span)
-            module.types.push(Type::TypeVariable(name: gen_parameter.name, trait_implementations))
+            module.types.push(Type::TypeVariable(name: gen_parameter.name, trait_implementations, gen_parameter.is_value))
 
             if gen_parameter.requires_list.has_value() {
                 .fill_trait_requirements(
@@ -2475,7 +2475,7 @@ struct Typechecker {
             mut checked_param = CheckedGenericParameter::make(parameter_type_id, span: gen_parameter.span)
 
             mut trait_implementations: [TypeId] = []
-            module.types.push(Type::TypeVariable(name: gen_parameter.name, trait_implementations))
+            module.types.push(Type::TypeVariable(name: gen_parameter.name, trait_implementations, is_value: gen_parameter.is_value))
 
             if gen_parameter.requires_list.has_value() {
                 .fill_trait_requirements(
@@ -2578,7 +2578,9 @@ struct Typechecker {
                 mut parameter = FunctionGenericParameter::parameter(type_var_type_id, span: generic_parameter.span)
 
                 mut trait_implementations: [TypeId] = []
-                module.types.push(Type::TypeVariable(name: generic_parameter.name, trait_implementations))
+                module.types.push(
+                    Type::TypeVariable(name: generic_parameter.name, trait_implementations, is_value: generic_parameter.is_value)
+                )
 
                 if generic_parameter.requires_list.has_value() {
                     .fill_trait_requirements(
@@ -2984,7 +2986,7 @@ struct Typechecker {
 
             mut parameter = CheckedGenericParameter::make(parameter_type_id, span: gen_parameter.span)
             mut trait_implementations: [TypeId] = []
-            module.types.push(Type::TypeVariable(name: gen_parameter.name, trait_implementations))
+            module.types.push(Type::TypeVariable(name: gen_parameter.name, trait_implementations, is_value: gen_parameter.is_value))
 
             if gen_parameter.requires_list.has_value() {
                 .fill_trait_requirements(
@@ -3189,7 +3191,7 @@ struct Typechecker {
                             let generic_param = trait_.generic_parameters[i]
                             let generic_param_type = generic_params[i]
 
-                            guard .get_type(generic_param.type_id) is TypeVariable(name) else {
+                            guard .get_type(generic_param.type_id) is TypeVariable(name, is_value) else {
                                 continue
                             }
 
@@ -3199,6 +3201,15 @@ struct Typechecker {
                                 type_id: generic_param_type
                                 span: generic_param.span
                             )
+
+                            if is_value and .get_type(generic_param_type) is Const(value) {
+                                .add_comptime_binding_to_scope(
+                                    scope_id: id
+                                    name
+                                    value
+                                    span: generic_param.span
+                                )
+                            }
 
                             mixin_scope_id = id
                         }
@@ -4142,7 +4153,9 @@ struct Typechecker {
             if base_definition {
                 mut parameter = FunctionGenericParameter::parameter(type_var_type_id, span: generic_parameter.span)
                 mut trait_implementations: [TypeId] = []
-                current_module.types.push(Type::TypeVariable(name: generic_parameter.name, trait_implementations))
+                current_module.types.push(
+                    Type::TypeVariable(name: generic_parameter.name, trait_implementations, is_value: generic_parameter.is_value)
+                )
                 if generic_parameter.requires_list.has_value() {
                     .fill_trait_requirements(
                         names: generic_parameter.requires_list!,
@@ -4812,6 +4825,31 @@ struct Typechecker {
             )
         }
 
+        if rhs_type is Const(rhs) and lhs_type is Const(lhs) {
+            if rhs.impl.equals(lhs.impl) {
+                return true
+            }
+
+            let interpreter = .interpreter()
+            .error(
+                format(
+                    "Literal type value mismatch: expected '{}', found '{}'"
+                    comptime_format_impl(
+                        format_string: "{}"
+                        arguments: [lhs][..]
+                        program: &.program
+                    )
+                    comptime_format_impl(
+                        format_string: "{}"
+                        arguments: [rhs][..]
+                        program: &.program
+                    )
+                )
+                span
+            )
+            return false
+        }
+
         let optional_struct_id = .find_struct_in_prelude("Optional")
         let weakptr_struct_id = .find_struct_in_prelude("WeakPtr")
         let array_struct_id = .find_struct_in_prelude("Array")
@@ -4830,6 +4868,26 @@ struct Typechecker {
                 } else {
                     generic_inferences.set(key: lhs_type_id, value: rhs_type_id)
                 }
+            }
+            Dependent(namespace_type, name) => {
+                if rhs_type is Dependent(namespace_type: rhs_namespace_type, name: rhs_name) {
+                    .check_types_for_compat(
+                        lhs_type_id: namespace_type
+                        rhs_type_id: rhs_namespace_type
+                        generic_inferences
+                        span
+                    )
+
+                    if name != rhs_name {
+                        .error(
+                            format("Type mismatch: mismatched names for dependent types: ‘{}’ and ‘{}’", name, rhs_name)
+                            span
+                        )
+                        return false
+                    }
+                }
+
+                // Can't compare a dependent type to a non-dependent type at this stage, so just assume it's fine
             }
             GenericEnumInstance(id: lhs_enum_id, args: lhs_args) => {
                 if rhs_type is GenericEnumInstance(id: rhs_enum_id, args: rhs_args) {
@@ -5334,6 +5392,28 @@ struct Typechecker {
     }
 
     fn typecheck_typename(mut this, parsed_type: ParsedType, scope_id: ScopeId, name: String?) throws -> TypeId => match parsed_type {
+        DependentType(base, name: dependent_name) => {
+            let base_type = .typecheck_typename(parsed_type: base, scope_id, name)
+            let type_id = .find_or_add_type_id(Type::Dependent(namespace_type: base_type, name: dependent_name))
+            yield .substitute_typevars_in_type(type_id, generic_inferences: .generic_inferences)
+        }
+        Const(expr) => {
+            let checked_expr = .typecheck_expression(
+                expr
+                scope_id
+                safety_mode: SafetyMode::Safe
+                type_hint: None
+            )
+            mut interpreter = .interpreter()
+            mut scope = InterpreterScope::from_runtime_scope(scope_id, program: .program)
+            let value = try interpreter.execute_expression(expr: checked_expr, scope)
+            if value.has_value() and value! is JustValue(resolved_value) {
+                return .find_or_add_type_id(Type::Const(resolved_value))
+            }
+
+            .error("Could not evaluate const expression", expr.span())
+            return .find_or_add_type_id(Type::Unknown)
+        }
         Reference(inner) => {
             let inner_type_id = .typecheck_typename(parsed_type: inner, scope_id, name)
             yield .find_or_add_type_id(Type::Reference(inner_type_id))

--- a/selfhost/typechecker.jakt
+++ b/selfhost/typechecker.jakt
@@ -6689,7 +6689,7 @@ struct Typechecker {
         return None
     }
 
-    fn required_scope_id_in_hierarchy_for(mut this, anon expr: CheckedExpression, current_scope_id: ScopeId) throws -> ScopeId? => match expr {
+    fn required_scope_id_in_hierarchy_for(mut this, anon expr: CheckedExpression, current_scope_id: ScopeId) throws -> (ScopeId?, CheckedExpression) => match expr {
         Boolean
         | NumericConstant
         | QuotedString
@@ -6697,9 +6697,9 @@ struct Typechecker {
         | CharacterConstant
         | CCharacterConstant
         | Reflect
-        => .root_scope_id()
+        => (.root_scope_id(), expr)
         // Immediate values, let's not have lifetime extension for now.
-        BinaryOp => None
+        BinaryOp => (None, expr)
         UnaryOp(op, expr) => match op {
             PreIncrement | PreDecrement => .required_scope_id_in_hierarchy_for(expr, current_scope_id)
             // NOTE: This should be the scope of whatever the pointer points to,
@@ -6707,17 +6707,18 @@ struct Typechecker {
             // outlive the pointer anyway.
             Dereference => .required_scope_id_in_hierarchy_for(expr, current_scope_id)
             Reference | MutableReference => .required_scope_id_in_hierarchy_for(expr, current_scope_id)
-            else => None
+            TypeCast => .required_scope_id_in_hierarchy_for(expr, current_scope_id)
+            else => (None, expr)
         }
         JaktArray(vals) | JaktTuple(vals) | JaktSet(vals) => {
             mut final_scope_id: ScopeId? = None
             for val in vals {
                 final_scope_id = .scope_lifetime_union(
                     final_scope_id
-                    .required_scope_id_in_hierarchy_for(val, current_scope_id)
+                    .required_scope_id_in_hierarchy_for(val, current_scope_id).0
                 )
             }
-            yield final_scope_id
+            yield (final_scope_id, expr)
         }
         JaktDictionary(vals) => {
             mut final_scope_id: ScopeId? = None
@@ -6725,14 +6726,14 @@ struct Typechecker {
                 final_scope_id = .scope_lifetime_union(
                     final_scope_id
                     .scope_lifetime_union(
-                        .required_scope_id_in_hierarchy_for(key, current_scope_id)
-                        .required_scope_id_in_hierarchy_for(val, current_scope_id)
+                        .required_scope_id_in_hierarchy_for(key, current_scope_id).0
+                        .required_scope_id_in_hierarchy_for(val, current_scope_id).0
                     )
                 )
             }
-            yield final_scope_id
+            yield (final_scope_id, expr)
         }
-        Range => None
+        Range => (None, expr)
         IndexedExpression(expr)
         | IndexedDictionary(expr)
         | IndexedTuple(expr)
@@ -6741,18 +6742,18 @@ struct Typechecker {
         | ComptimeIndex(expr)
         => .required_scope_id_in_hierarchy_for(expr, current_scope_id)
         // FIXME: Actually look into the match and figure out the lifetimes.
-        Match => None
+        Match => (None, expr)
         // FIXME: Implement this
-        EnumVariantArg => None
-        Call => None
+        EnumVariantArg => (None, expr)
+        Call => (None, expr)
         // FIXME: This assumes far too much, the returned value might not even be a reference to the internals of the object.
         //        but the absolute smallest guaranteed lifetime for something returned from a member function is the lifetime of the object (for now).
         MethodCall(expr) => .required_scope_id_in_hierarchy_for(expr, current_scope_id)
-        Var(var) | NamespacedVar(var) => var.owner_scope ?? current_scope_id // If the variable doesn't have an owner yet, we're in the process of defining it.
-        OptionalNone => None
-        OptionalSome => None
+        Var(var) | NamespacedVar(var) => (var.owner_scope ?? current_scope_id, expr) // If the variable doesn't have an owner yet, we're in the process of defining it.
+        OptionalNone => (None, expr)
+        OptionalSome => (None, expr)
         ForcedUnwrap(expr) => .required_scope_id_in_hierarchy_for(expr, current_scope_id)
-        Block => None // Blocks can't yield values (for now)
+        Block => (None, expr) // Blocks can't yield values (for now)
         Function(captures) | DependentFunction(captures) => {
             mut final_scope_id: ScopeId? = None
             for capture in captures {
@@ -6763,12 +6764,12 @@ struct Typechecker {
                 }
                 final_scope_id = .scope_lifetime_union(final_scope_id, scope_id)
             }
-            yield final_scope_id
+            yield (final_scope_id, expr)
         }
         // FIXME: Check what the expression actually returns, also check the catch block (if one exists)
-        Try => None
-        TryBlock => None
-        Garbage => None
+        Try => (None, expr)
+        TryBlock => (None, expr)
+        Garbage => (None, expr)
     }
 
     fn typecheck_var_decl(mut this, var: ParsedVarDecl, init: ParsedExpression, scope_id: ScopeId, safety_mode: SafetyMode, span: Span) throws -> CheckedStatement {
@@ -6790,11 +6791,13 @@ struct Typechecker {
 
         if .type_contains_reference(type_id: lhs_type_id) {
             // If the variable type is a reference, we need to make sure that this scope does not outlive the reference.
-            let init_scope_id = .required_scope_id_in_hierarchy_for(checked_expr, current_scope_id: scope_id)
+            let (init_scope_id, cause_expr) = .required_scope_id_in_hierarchy_for(checked_expr, current_scope_id: scope_id)
             if .scope_lifetime_subsumes(scope_id, init_scope_id) {
-                .error(
+                .error_with_hint(
                     "Cannot assign a reference to a variable that outlives the reference"
                     checked_expr.span()
+                    "Limited by this expression's lifetime"
+                    cause_expr.span()
                 )
             }
         }
@@ -10489,10 +10492,10 @@ struct Typechecker {
                         return args[index - 1].1
                     }
 
-                    let arg_scope_id = .required_scope_id_in_hierarchy_for(resolve_arg(index), current_scope_id: caller_scope_id)
+                    let arg_scope_id = .required_scope_id_in_hierarchy_for(resolve_arg(index), current_scope_id: caller_scope_id).0
                     let stored_scope_id = match level {
                         InStaticStorage => Some(.root_scope_id())
-                        InObject(argument_index) => .required_scope_id_in_hierarchy_for(resolve_arg(argument_index), current_scope_id: caller_scope_id)
+                        InObject(argument_index) => .required_scope_id_in_hierarchy_for(resolve_arg(argument_index), current_scope_id: caller_scope_id).0
                     }
 
                     if .scope_lifetime_subsumes(stored_scope_id, arg_scope_id) {

--- a/selfhost/typechecker.jakt
+++ b/selfhost/typechecker.jakt
@@ -5613,7 +5613,7 @@ struct Typechecker {
                 }
             }
 
-            return .find_or_add_type_id(Type::GenericInstance(id: struct_id!, args: checked_inner_types))
+            return .find_or_add_type_id(Type::GenericInstance(id: struct_id!, args: effective_inner_types))
         }
 
         let enum_id = .program.find_enum_in_scope(scope_id, name)

--- a/selfhost/types.jakt
+++ b/selfhost/types.jakt
@@ -585,6 +585,12 @@ boxed enum Type {
     }
 }
 
+struct SpecializedType {
+    base_type_id: TypeId
+    arguments: [TypeId]
+    type_id: TypeId
+}
+
 class Scope {
     public namespace_name: String?
     public external_name: ExternalName?
@@ -613,6 +619,7 @@ class Scope {
     public is_block_scope: bool = true
 
     public resolved_forall_chunks: [ResolvedForallChunk]? = None
+    public explicitly_specialized_types: [String:SpecializedType]
 
     public fn namespace_name_for_codegen(this) -> ExternalName? {
         if .external_name.has_value() { return .external_name }
@@ -1796,6 +1803,7 @@ class CheckedProgram {
             debug_name
             resolution_mixins: []
             is_block_scope: for_block
+            explicitly_specialized_types: [:]
         )
 
         .modules[module_id.id].scopes.push(scope)
@@ -2489,7 +2497,12 @@ class CheckedProgram {
     }
 
     // FIXME: Use [TypeId: TypeID] without TypeId.to_string()/TypeId::from_string() workaround
-    public fn substitute_typevars_in_type(mut this, type_id: TypeId , generic_inferences: GenericInferences, module_id: ModuleId) throws -> TypeId {
+    public fn substitute_typevars_in_type(
+        mut this
+        type_id: TypeId
+        generic_inferences: GenericInferences
+        module_id: ModuleId
+    ) throws -> TypeId {
         mut result = .substitute_typevars_in_type_helper(type_id, generic_inferences, module_id)
 
         loop {
@@ -2506,7 +2519,12 @@ class CheckedProgram {
     }
 
     // FIXME: Use [TypeId: TypeID] without TypeId.to_string()/TypeId::from_string() workaround
-    fn substitute_typevars_in_type_helper(mut this, type_id: TypeId , generic_inferences: GenericInferences, module_id: ModuleId) throws -> TypeId {
+    fn substitute_typevars_in_type_helper(
+        mut this
+        type_id: TypeId
+        generic_inferences: GenericInferences
+        module_id: ModuleId
+    ) throws -> TypeId {
         let type_ = .get_type(type_id)
 
         match type_ {

--- a/selfhost/types.jakt
+++ b/selfhost/types.jakt
@@ -2860,3 +2860,227 @@ class TypecheckFunctions {
         checked_function: CheckedFunction
     ) throws -> FunctionId
 }
+
+fn format_value_impl(anon format_string: String, anon value: Value, program: &CheckedProgram) throws -> String => match value.impl {
+    Bool(v)
+    | U8(v)
+    | U16(v)
+    | U32(v)
+    | U64(v)
+    | USize(v)
+    | I8(v)
+    | I16(v)
+    | I32(v)
+    | I64(v)
+    | F32(v)
+    | F64(v)
+    | CChar(v)
+    | CInt(v)
+    | JaktString(v)
+    | StringView(v)
+    => format(format_string, v)
+
+    Void => format(format_string, "(void)")
+
+    Struct(fields, struct_id, constructor)
+    | Class(fields, struct_id, constructor)
+    => {
+        let structure = program.get_struct(struct_id)
+        mut builder = StringBuilder::create()
+        mut field_names: [String] = []
+
+        builder.append(structure.name)
+        if constructor.has_value() {
+            let function = program.get_function(constructor!)
+            builder.append("::")
+            builder.append(function.name)
+            for parameter in function.params {
+                field_names.push(parameter.variable.name)
+            }
+        } else {
+            for field in structure.fields {
+                field_names.push(program.get_variable(field.variable_id).name)
+            }
+        }
+        builder.append('(')
+        mut index = 0uz
+        for field in fields {
+            if index > 0 {
+                builder.append(", ")
+            }
+
+            builder.append(field_names[index])
+            builder.append(": ")
+            builder.append(format_value_impl(format_string, field, program))
+            index += 1
+        }
+
+        builder.append(')')
+        yield builder.to_string()
+    }
+
+    Enum(fields, enum_id, constructor) => {
+        let enum_ = program.get_enum(enum_id)
+        let function = program.get_function(constructor)
+        mut builder = StringBuilder::create()
+        mut field_names: [String] = []
+
+        builder.append(enum_.name)
+        builder.append("::")
+        builder.append(function.name)
+        for parameter in function.params {
+            field_names.push(parameter.variable.name)
+        }
+
+        builder.append('(')
+        mut index = 0uz
+        for field in fields {
+            if index > 0 {
+                builder.append(", ")
+            }
+
+            builder.append(field_names[index])
+            builder.append(": ")
+            builder.append(format_value_impl(format_string, field, program))
+            index += 1
+        }
+
+        builder.append(')')
+        yield builder.to_string()
+    }
+
+    OptionalSome(value) => format_value_impl(
+        format_string: format("Some({})", format_string)
+        value
+        program
+    )
+    OptionalNone => format(format_string, "None")
+
+    JaktTuple(fields)
+    | JaktArray(values: fields)
+    | JaktSet(values: fields) => {
+        mut builder = StringBuilder::create()
+        let surrounding = match value.impl {
+            JaktTuple => ('(', ')')
+            JaktArray => ('[', ']')
+            JaktSet => ('{', '}')
+            else => {
+                abort()
+            }
+        }
+        builder.append(surrounding.0)
+        mut index = 0uz
+        for field in fields {
+            if index > 0 {
+                builder.append(", ")
+            }
+
+            builder.append(format_value_impl(format_string, field, program))
+            index += 1
+        }
+
+        builder.append(surrounding.1)
+        yield builder.to_string()
+    }
+
+    JaktDictionary(keys, values) => {
+        mut builder = StringBuilder::create()
+        builder.append('[')
+        mut index = 0uz
+        for key in keys {
+            if index > 0 {
+                builder.append(", ")
+            }
+
+            builder.append(format_value_impl(format_string, key, program))
+            builder.append(": ")
+            builder.append(format_value_impl(format_string, values[index], program))
+
+            index += 1
+        }
+
+        builder.append(']')
+        yield builder.to_string()
+    }
+
+    else => {
+        eprintln("Cannot format value {}", value.impl)
+        throw Error::from_string_literal("Cannot format value of this type")
+    }
+}
+
+fn comptime_format_impl(format_string: String, arguments: ArraySlice<Value>, program: &CheckedProgram) throws -> String {
+    mut builder = StringBuilder::create()
+    mut current_argument_index = 0uz
+    mut format_field_builder = StringBuilder::create()
+    mut index_in_field: usize? = None
+    mut expect_close_brace = false
+
+    let argument_and_index = fn(anon str: String) -> (usize?, String) {
+        mut slice_end = 0uz
+        mut has_index = false
+        for code_point in str.code_points() {
+            guard code_point >= '0' and code_point <= '9' else {
+                break
+            }
+            slice_end += 1
+            has_index = true
+        }
+
+        if has_index {
+            let index_str = str.substring(start: 0, length: slice_end)
+            let index = index_str.to_uint()
+            if index.has_value() {
+                return (index! as! usize, str.substring(start: slice_end, length: str.length() - slice_end))
+            }
+        }
+
+        return (None, str)
+    }
+
+    for code_point in format_string.code_points() {
+        match code_point {
+            '{' => {
+                if index_in_field.has_value() and index_in_field! == 0 {
+                    builder.append('{')
+                    index_in_field = None
+                } else if index_in_field.has_value() {
+                    format_field_builder.append('{')
+                    index_in_field = index_in_field! + 1
+                } else {
+                    index_in_field = 0
+                }
+            }
+            '}' => {
+                if expect_close_brace {
+                    builder.append('}')
+                    expect_close_brace = false
+                } else if not index_in_field.has_value() {
+                    expect_close_brace = true
+                } else {
+                    index_in_field = None
+                    let fmt_string = format_field_builder.to_string()
+                    format_field_builder.clear()
+                    let (index, format_string) = argument_and_index(fmt_string)
+                    let effective_index = index ?? current_argument_index++
+                    if effective_index >= arguments.size() {
+                        throw Error::from_string_literal("Not enough arguments for format string")
+                    }
+
+                    let effective_format_string = format("{{{}}}", format_string)
+
+                    builder.append(format_value_impl(effective_format_string, arguments[effective_index], program))
+                }
+            }
+            else => {
+                if index_in_field.has_value() {
+                    format_field_builder.append(code_point)
+                } else {
+                    builder.append(code_point)
+                }
+            }
+        }
+    }
+
+    return builder.to_string()
+}

--- a/selfhost/types.jakt
+++ b/selfhost/types.jakt
@@ -34,7 +34,42 @@ enum StructLikeId {
         return result
     }
 
+    fn generic_parameters_as_checked(this, anon program: &CheckedProgram) throws -> [CheckedGenericParameter] => match this {
+        Struct(id) => program.get_struct(id).generic_parameters
+        Enum(id) => program.get_enum(id).generic_parameters
+        Trait(id) => program.get_trait(id).generic_parameters
+    }
+
     fn scope_id(this, anon program: &CheckedProgram) throws -> ScopeId => match this {
+        Struct(id) => program.get_struct(id).scope_id
+        Enum(id) => program.get_enum(id).scope_id
+        Trait(id) => program.get_trait(id).scope_id
+    }
+
+    fn specialized_by(
+        this
+        anon arguments: [TypeId]
+        anon program: &mut CheckedProgram
+        module_id: ModuleId
+    ) throws -> TypeId => match this {
+        Struct(id) => program.find_or_add_type_id(Type::GenericInstance(id, args: arguments), module_id)
+        Enum(id) => program.find_or_add_type_id(Type::GenericEnumInstance(id, args: arguments), module_id)
+        Trait(id) => program.find_or_add_type_id(Type::GenericTraitInstance(id, args: arguments), module_id)
+    }
+
+    fn from_type_id(anon type_id: TypeId, anon program: &CheckedProgram) throws -> StructLikeId? {
+        return match program.get_type(type_id) {
+            GenericInstance(id: struct_id, args) | Struct(struct_id) default(args: [TypeId] = [])
+                => StructLikeId::Struct(generic_arguments: args, struct_id)
+            GenericEnumInstance(id: enum_id, args) | Enum(enum_id) default(args: [TypeId] = [])
+                => StructLikeId::Enum(generic_arguments: args, enum_id)
+            GenericTraitInstance(id: trait_id, args) | Trait(trait_id) default(args: [TypeId] = [])
+                => StructLikeId::Trait(generic_arguments: args, trait_id)
+            else => None
+        }
+    }
+
+    fn associated_scope_id(this, anon program: &CheckedProgram) throws -> ScopeId => match this {
         Struct(id) => program.get_struct(id).scope_id
         Enum(id) => program.get_enum(id).scope_id
         Trait(id) => program.get_trait(id).scope_id
@@ -214,7 +249,8 @@ boxed enum Type {
     CInt
     Unknown
     Never
-    TypeVariable(name: String, trait_implementations: [TypeId])
+    TypeVariable(name: String, trait_implementations: [TypeId], is_value: bool = false)
+    Dependent(namespace_type: TypeId, name: String)
     GenericInstance(id: StructId, args: [TypeId])
     GenericEnumInstance(id: EnumId, args: [TypeId])
     GenericTraitInstance(id: TraitId, args: [TypeId])
@@ -227,7 +263,7 @@ boxed enum Type {
     MutableReference(TypeId)
     Function(params: [TypeId], can_throw: bool, return_type_id: TypeId, pseudo_function_id: FunctionId)
     Self
-
+    Const(Value)
 
     fn is_boxed(this, program: CheckedProgram) -> bool => match this {
         Struct(struct_id) | GenericInstance(id: struct_id) => program.get_struct(struct_id).record_type is Class
@@ -236,12 +272,14 @@ boxed enum Type {
     }
 
     fn is_concrete(this) -> bool => match this {
-        TypeVariable | Self | Unknown => false
+        TypeVariable | Self | Dependent | Unknown => false
         else => true
     }
 
     fn specificity(this, program: CheckedProgram, base_specificity: i64 = 1<<31) -> i64 => match this {
         TypeVariable => 0
+        Dependent => 0
+        Const => base_specificity
         GenericInstance(args) => {
             mut specificity = base_specificity / 2
             for subtype_id in args.iterator() {
@@ -297,6 +335,7 @@ boxed enum Type {
         Unknown => "Unknown"
         Never => "Never"
         TypeVariable => "TypeVariable"
+        Dependent => "Dependent"
         GenericInstance => "GenericInstance"
         GenericEnumInstance => "GenericEnumInstance"
         GenericTraitInstance => "GenericTraitInstance"
@@ -309,6 +348,7 @@ boxed enum Type {
         MutableReference => "MutableReference"
         Function => "Function"
         Self => "Self"
+        Const => "Const"
     }
 
     fn equals(this, anon rhs: Type) -> bool => match this {
@@ -337,6 +377,16 @@ boxed enum Type {
                 return lhs_name == rhs_name
             }
             yield false
+        }
+        Dependent(namespace_type, name) => {
+            if rhs is Dependent(namespace_type: rhs_namespace_type, name: rhs_name) {
+                return namespace_type.equals(rhs_namespace_type) and name == rhs_name
+            }
+            yield false
+        }
+        Const(lhs_value) => match rhs {
+            Const(rhs_value) => lhs_value.impl.equals(rhs_value.impl)
+            else => false
         }
         GenericResolvedType(id: lhs_id, args: lhs_args)
         | GenericInstance(id: lhs_id, args: lhs_args) => {
@@ -2289,6 +2339,11 @@ class CheckedProgram {
             Void => "void"
             Unknown => "unknown"
             JaktString => "builtin(String)"
+            Dependent(namespace_type, name) => format(
+                "{}::{}"
+                .type_name(namespace_type, debug_mode)
+                name
+            )
             Trait(id) => .get_trait(id).name
             Self => "Self"
             Function(params, return_type_id) => {
@@ -2415,6 +2470,7 @@ class CheckedProgram {
             RawPtr(type_id) => format("raw {}", .type_name(type_id, debug_mode))
             Reference(type_id) => format("&{}", .type_name(type_id, debug_mode))
             MutableReference(type_id) => format("&mut {}", .type_name(type_id, debug_mode))
+            Const(value) => comptime_format_impl(format_string: "comptime {}", arguments: [value][..], program: &this)
         }
     }
 
@@ -2459,6 +2515,41 @@ class CheckedProgram {
                 if replacement_type_id.has_value() {
                     return replacement_type_id!
                 }
+            }
+            Dependent(namespace_type, name) => {
+                let mapped_type_id = .substitute_typevars_in_type(type_id: namespace_type, generic_inferences, module_id)
+                let type = .get_type(mapped_type_id)
+                if type is TypeVariable {
+                    return .find_or_add_type_id(
+                        type: Type::Dependent(namespace_type: mapped_type_id, name)
+                        module_id
+                    )
+                }
+
+                let struct_like_id = StructLikeId::from_type_id(mapped_type_id, &this)
+                guard struct_like_id.has_value() else {
+                    return type_id
+                }
+
+                let scope_id = struct_like_id!.associated_scope_id(&this)
+                let found_type = .find_type_in_scope(scope_id, name)
+                if found_type.has_value() {
+                    mut copied_inferences = generic_inferences
+                    if struct_like_id!.generic_arguments.has_value() {
+                        copied_inferences.set_all(
+                            keys: struct_like_id!.generic_parameters_as_checked(&this)
+                            values: struct_like_id!.generic_arguments!
+                        )
+                    }
+
+                    return .substitute_typevars_in_type(
+                        type_id: found_type!
+                        generic_inferences: copied_inferences
+                        module_id
+                    )
+                }
+
+                return type_id
             }
             GenericTraitInstance(id, args) => {
                 mut new_args: [TypeId] = []

--- a/tests/parser/bogus_generic_call.jakt
+++ b/tests/parser/bogus_generic_call.jakt
@@ -1,5 +1,5 @@
 /// Expect:
-/// - error: "Call to unknown function"
+/// - error: "C++ keywords are not allowed to be used as identifiers"
 
 fn f() {
     // Background: I pasted some C++ into a jakt program and it made the compiler loop infinitely :^)


### PR DESCRIPTION
- Makes it possible to build jakt as part of serenity's toolchain (see https://github.com/alimpfard/serenity/commit/4e8f6b634c6a1267f4301e8deddf8edc57696bc3)
- Const generics (almost) + NTTP support in cpp_import/clang
- Dependent types (`foo<i32>::bar` etc)
- partial support for explicit type specialization (+ support in cpp_import)
- Some random feng shui 