### PR TITLE
formatter: Add a space before requires in function generics

### DIFF
--- a/selfhost/formatter.jakt
+++ b/selfhost/formatter.jakt
@@ -772,6 +772,7 @@ struct Stage0 {
             .push_state(State::RestrictionList)
             yield .formatted_token(token)
         }
+        Requires => .formatted_token(token, trailing_trivia: [], preceding_trivia: [b' '])
         else => .formatted_token(token)
     }
 


### PR DESCRIPTION
Previously the formatter would turn `fn foo<T requires(...)` into `fn foo<Trequires(...)` which is a compile error. This change adds a space as the preceding trivia to the `requires` token so that the formatter has one fewer reasons to be turned off.