### PR TITLE
typechecker: Report error when creating a string in non-throwsy block

### DIFF
--- a/samples/compiletime_execution/dict.jakt
+++ b/samples/compiletime_execution/dict.jakt
@@ -5,13 +5,13 @@ comptime is_empty() -> bool {
     let dict: Dictionary<String, u8> = [:]
     return dict.is_empty()
 }
-comptime get() => ["a":'a'].get("a")! == 'a'
+comptime get() throws => ["a":'a'].get("a")! == 'a'
 comptime set() throws -> bool {
     mut dict: Dictionary<String, u32> = [:]
     dict.set("b", 'b')
     return dict.contains("b") and dict.get("b")! == 'b'
 }
-comptime remove() -> bool {
+comptime remove() throws -> bool {
     mut dict = ["c":'c']
     dict.remove("c")
     return not dict.contains("c")
@@ -21,12 +21,12 @@ comptime capacity() throws -> bool {
     dict.ensure_capacity(5)
     return dict.capacity() == 5
 }
-comptime clear() -> bool {
+comptime clear() throws -> bool {
     mut dict = ["d":'d',"e":'e',"f":'f']
     dict.clear()
     return dict.is_empty()
 }
-comptime size() -> bool {
+comptime size() throws -> bool {
     mut dict = ["g":'g',"h":'h',"i":'i']
     return dict.size() == 3
 }

--- a/selfhost/typechecker.jakt
+++ b/selfhost/typechecker.jakt
@@ -8002,14 +8002,19 @@ struct Typechecker {
                         span
                     )
                 }
-                else => CheckedExpression::QuotedString(
-                    val: CheckedStringLiteral(
-                        value: StringLiteral::Static(val)
-                        type_id: .prelude_struct_type_named("String")
-                        may_throw: true
+                else => {
+                    if not .get_scope(scope_id).can_throw {
+                        .error("Operation that may throw needs to be in a try statement or a function marked as throws", span)
+                    }
+                    yield CheckedExpression::QuotedString(
+                        val: CheckedStringLiteral(
+                            value: StringLiteral::Static(val)
+                            type_id: .prelude_struct_type_named("String")
+                            may_throw: true
+                        )
+                        span
                     )
-                    span
-                )
+                }
             }
         }
         Call(call, span) => {

--- a/tests/typechecker/fallible_operation_no_throws.jakt
+++ b/tests/typechecker/fallible_operation_no_throws.jakt
@@ -1,0 +1,8 @@
+/// Expect:
+/// - error: "Operation that may throw needs to be in a try statement or a function marked as throws"
+
+fn does_not_throw() {
+    "whf"
+}
+
+fn main() {}


### PR DESCRIPTION
This fixes a cryptic c++ error message when you forget to put `throws` on your function.