### PR TITLE
codegen: Make EnumVariantArg use common section for common enum fields

### DIFF
--- a/selfhost/codegen.jakt
+++ b/selfhost/codegen.jakt
@@ -2848,11 +2848,24 @@ struct CodeGenerator {
             if enum_variant is StructLike {
                 arg_name = arg.name ?? arg.binding
             }
-            let cpp_deref_operator = match .program.get_enum(enum_variant.enum_id()).is_boxed {
+
+            let enum_ = .program.get_enum(enum_variant.enum_id())
+
+            let cpp_deref_operator = match enum_.is_boxed {
                 true => "->"
                 else => "."
             }
-            yield format("({}){}as.{}.{}", var_name, cpp_deref_operator, variant_name, arg_name)
+
+            // use the common section if the binding uses a common field
+            mut section = format("as.{}", variant_name)
+            for field in enum_.fields {
+                let field_name = .program.get_variable(field.variable_id).name_for_codegen().as_name_for_use()
+                if field_name == arg_name {
+                    section = "common.init_common"
+                }
+            }
+
+            yield format("({}){}{}.{}", var_name, cpp_deref_operator, section, arg_name)
         }
         JaktArray(vals, repeat, span, type_id, inner_type_id) => {
             mut output = ""

--- a/tests/codegen/enum_common_bindings.jakt
+++ b/tests/codegen/enum_common_bindings.jakt
@@ -1,0 +1,17 @@
+/// Expect:
+/// - output: "hello Baz(5)!\n"
+
+enum Foo {
+    message: String
+
+    Baz(value: i32)
+    Bar
+}
+
+fn main() {
+    let foo = Foo::Baz(message: "hello", value: 5)
+
+    if foo is Baz(message, value) {
+        println("{} Baz({})!", message, value)
+    }
+}


### PR DESCRIPTION
When destructuring an enum field from an enum variant, codegen needs to
identify what is a common field and what is a variant field:

Given some enum like this:

```jakt
enum Foo {
    value: i32

    Bar(other: i32)
    Baz
}
```

And a usage like this:

```jakt
if foo is Bar(value, other) {
    return value + other
}
```

The generated C++ will use `foo.as.Bar.value` instead of `foo.common.init_common.value`,
which results in a C++ error. This PR fixes this mishap.
