### PR TITLE
typechecker: Ensure that no name is redefined as a different symbol

### DIFF
--- a/selfhost/typechecker.jakt
+++ b/selfhost/typechecker.jakt
@@ -28,7 +28,7 @@ import types {
     builtin, comptime_format_impl, never_type_id, unknown_type_id, void_type_id
 }
 import types
-import utility { FileId, Span, add_arrays, escape_for_quotes, join, panic, todo }
+import utility { FileId, Span, add_arrays, escape_for_quotes, join, panic, todo, map }
 import jakt::path { Path }
 import compiler { Compiler }
 import interpreter { Interpreter, InterpreterScope, ExecutionResult, value_to_checked_expression }
@@ -3144,6 +3144,40 @@ struct Typechecker {
             super_struct_id: None
             external_name: parsed_record.external_name
         ))
+
+        match parsed_record.record_type {
+            Struct(fields) | Class(fields) => {
+                let field_names_and_spans = map(
+                    input: fields
+                    mapper: &fn(item: ParsedField) throws -> (String, Span) =>
+                        (item.var_decl.name, item.var_decl.span)
+                )
+                let method_names_and_spans = map(
+                    input: parsed_record.methods
+                    mapper: &fn(item: ParsedMethod) throws -> (String, Span) =>
+                        (item.parsed_function.name,item.parsed_function.name_span)
+                )
+                for x in field_names_and_spans {
+                    for y in method_names_and_spans {
+                        if x.0 == y.0 {
+                            .error_with_hint(
+                                format(
+                                    "Can't have a member variable and member function both named `{}`"
+                                    x.0
+                                )
+                                Span::last(x.1, y.1)
+                                format(
+                                    "`{}` is first defined here"
+                                    x.0
+                                )
+                                Span::first(x.1, y.1)
+                            )
+                        }
+                    }
+                }
+            }
+            else => {}
+        }
     }
 
     fn typecheck_entity_trait_implementations_predecl(

--- a/selfhost/utility.jakt
+++ b/selfhost/utility.jakt
@@ -74,6 +74,14 @@ fn join(anon strings: [String], separator: String) throws -> String {
     return output
 }
 
+fn map<T, U>(input: [T], mapper: &fn(item: T) throws -> U) throws -> [U] {
+    mut us: [U] = []
+    for t in input {
+        us.push(mapper(item: t))
+    }
+    return us
+}
+
 fn prepend_to_each(anon strings: [String], prefix: String) throws -> [String] {
     mut output: [String] = []
     for str in strings {

--- a/selfhost/utility.jakt
+++ b/selfhost/utility.jakt
@@ -104,6 +104,32 @@ struct Span {
     start: usize
     end: usize
 
+    fn first(anon a: Span, anon b: Span) -> Span {
+        if a.start < b.start {
+            return a
+        }
+        if b.start < a.start {
+            return b
+        }
+        if a.end < b.end {
+            return a
+        }
+        return b
+    }
+
+    fn last(anon a: Span, anon b: Span) -> Span {
+        if a.start > b.start {
+            return a
+        }
+        if b.start > a.start {
+            return b
+        }
+        if a.end > b.end {
+            return a
+        }
+        return b
+    }
+
     fn contains(this, span: Span) -> bool {
         return .file_id.equals(span.file_id) and span.start >= .start and span.end <= .end
     }

--- a/tests/typechecker/class_same_name_function_and_member.jakt
+++ b/tests/typechecker/class_same_name_function_and_member.jakt
@@ -1,0 +1,8 @@
+/// Expect:
+/// - error: "Can't have a member variable and member function both named `foo`\n"
+
+struct S {
+    fn foo() => true
+    foo: i32
+}
+fn main(){}

--- a/tests/typechecker/class_same_name_member_and_function.jakt
+++ b/tests/typechecker/class_same_name_member_and_function.jakt
@@ -1,0 +1,8 @@
+/// Expect:
+/// - error: "Can't have a member variable and member function both named `foo`\n"
+
+struct S {
+    foo: i32
+    fn foo() => true
+}
+fn main(){}


### PR DESCRIPTION
Fixes #1485 