### PR TITLE
runtime: Don't hardcode PATH_MAX

### DIFF
--- a/runtime/jaktlib/platform/darwin_errno.jakt
+++ b/runtime/jaktlib/platform/darwin_errno.jakt
@@ -7,3 +7,10 @@ fn errno_value() -> i32 {
         return (*__error()) as! i32
     }
 }
+
+// FIXME: hacky helper until Jakt supports importing C macros
+fn erange_value() -> i32 {
+    mut erange: i32 = 0
+    unsafe { cpp { "erange = ERANGE;" } }
+    return erange
+}

--- a/runtime/jaktlib/platform/posix_errno.jakt
+++ b/runtime/jaktlib/platform/posix_errno.jakt
@@ -7,3 +7,10 @@ fn errno_value() -> i32 {
         return *__errno_location()
     }
 }
+
+// FIXME: hacky helper until Jakt supports importing C macros
+fn erange_value() -> i32 {
+    mut erange: i32 = 0
+    unsafe { cpp { "erange = ERANGE;" } }
+    return erange
+}

--- a/runtime/jaktlib/platform/posix_fs.jakt
+++ b/runtime/jaktlib/platform/posix_fs.jakt
@@ -1,6 +1,6 @@
 import jakt::path { Path }
 import jakt::platform { platform_module, platform_errno }
-import platform_errno() { errno_value }
+import platform_errno() { errno_value, erange_value }
 import utility { allocate, null }
 
 import extern c "sys/stat.h" {
@@ -37,36 +37,43 @@ fn make_directory(path: String) throws {
 }
 
 fn current_directory() throws -> String {
-    let buffer_size : usize = 4096; // Roughly PATH_MAX
-    mut buffer = allocate<c_char>(count: buffer_size  + 1)
-    defer {
-        unsafe { cpp { "free(buffer);" } }
-    }
+    // Initial guess at path length, resembles PATH_MAX and the page-size of some systems
+    mut buffer_size : usize = 4096;
+    loop {
+        mut buffer = allocate<c_char>(count: buffer_size)
+        defer {
+            unsafe { cpp { "free(buffer);" } }
+        }
 
-    let buf = getcwd(buffer, buffer_size)
-    if buf == null<c_char>() {
-        throw Error::from_errno(errno_value())
-    }
+        let buf = getcwd(buffer, buffer_size)
+        if buf == null<c_char>() {
+            let getcwd_errno = errno_value()
+            if getcwd_errno == erange_value() {
+                // grow buffer and try again
+                buffer_size *= 2
+                continue
+            } else {
+               throw Error::from_errno(getcwd_errno)
+            }
+        }
 
-    mut b = StringBuilder::create()
-    b.append_c_string(buf)
-    return b.to_string()
+        mut b = StringBuilder::create()
+        b.append_c_string(buf)
+        return b.to_string()
+    }
 }
 
 fn real_path(anon path: String) throws -> String {
-    let buffer_size : usize = 4096; // Roughly PATH_MAX
-    mut buffer = allocate<c_char>(count: buffer_size  + 1)
+    let buffer = realpath(path: path.c_string(), resolved_path: null<c_char>())
+    if buffer == null<c_char>() {
+        throw Error::from_errno(errno_value())
+    }
     defer {
         unsafe { cpp { "free(buffer);" } }
     }
 
-    let buf = realpath(path: path.c_string(), resolved_path: buffer)
-    if buf == null<c_char>() {
-        throw Error::from_errno(errno_value())
-    }
-
     mut b = StringBuilder::create()
-    b.append_c_string(buf)
+    b.append_c_string(buffer)
     return b.to_string()
 }
 

--- a/runtime/jaktlib/platform/windows_fs.jakt
+++ b/runtime/jaktlib/platform/windows_fs.jakt
@@ -31,36 +31,30 @@ fn make_directory(path: String) throws {
 }
 
 fn real_path(anon path: String) throws -> String {
-    let buffer_size : i32 = 4096; // Roughly PATH_MAX
-    mut buffer = allocate<c_char>(count: buffer_size as! usize + 1)
+    let buffer = _fullpath(abs_path: null<c_char>(), rel_path: path.c_string(), max_length: 0)
+    if buffer == null<c_char>() {
+        throw Error::from_errno(errno_value())
+    }
     defer {
         unsafe { cpp { "free(buffer);" } }
     }
 
-    let buf = _fullpath(abs_path: buffer, rel_path: path.c_string(), max_length: buffer_size)
-    if buf == null<c_char>() {
-        throw Error::from_errno(errno_value())
-    }
-
     mut b = StringBuilder::create()
-    b.append_c_string(buf)
+    b.append_c_string(buffer)
     return b.to_string()
 }
 
 fn current_directory() throws -> String {
-    let buffer_size : i32 = 4096; // Roughly PATH_MAX
-    mut buffer = allocate<c_char>(count: buffer_size as! usize + 1)
+    let buffer = _getcwd(buffer: null<c_char>(), maxlen: 0)
+    if buffer == null<c_char>() {
+        throw Error::from_errno(errno_value())
+    }
     defer {
         unsafe { cpp { "free(buffer);" } }
     }
 
-    let buf = _getcwd(buffer, buffer_size)
-    if buf == null<c_char>() {
-        throw Error::from_errno(errno_value())
-    }
-
     mut b = StringBuilder::create()
-    b.append_c_string(buf)
+    b.append_c_string(buffer)
     return b.to_string()
 }
 


### PR DESCRIPTION
Windows' _fullpath and _getcwd will handle allocation if we pass NULL as the buffer, but please note that this [will not remove path length limitations](https://learn.microsoft.com/en-us/windows/win32/fileio/maximum-file-path-limitation).

Unfortunately, posix_fs.jakt is not so straightforward.
realpath: POSIX.1-2008 lets us pass NULL for the second argument, resolved_path; libc will allocate for us.
getcwd: Linux lets us pass NULL, but POSIX defines this as undefined behavior. Can and should we special-case any os/libc whose getcwd will do the allocation for us?