### PR TITLE
interpreter: Interpret lvalue assignment

### DIFF
--- a/selfhost/interpreter.jakt
+++ b/selfhost/interpreter.jakt
@@ -6369,16 +6369,15 @@ class Interpreter {
 
             yield match value.impl {
                 JaktArray(values) => {
-                    let numeric_index = match index.impl {
-                        I8(x) | I16(x) | I32(x) | I64(x) | U8(x) | U16(x) | U32(x) | U64(x) | USize(x) => x as! u64
-                        else => {
-                            panic("Invalid type for repeat")
-                        }
+                    let numeric_index = try index.assert_nonnegative_integer() catch e {
+                        let index_span = index_expr.span()
+                        .error(format("{}", e.string()), index_span)
+                        throw e
                     }
 
                     if numeric_index >= (values.size() as! u64) {
                         .error(
-                            format("Index {} out of bounds (max={})", numeric_index, values.size())
+                            format("Index {} out of bounds (max={})", numeric_index, values.size() - 1)
                             span)
                         throw Error::from_string_literal("Invalid type")
                     }
@@ -6616,11 +6615,10 @@ class Interpreter {
                     Throw(value) => {
                         return StatementResult::Throw(value)
                     }
-                    JustValue(value) => match value.impl {
-                        I8(x) | I16(x) | I32(x) | I64(x) | U8(x) | U16(x) | U32(x) | U64(x) | USize(x) => x as! usize
-                        else => {
-                            panic("Invalid type for repeat")
-                        }
+                    JustValue(value) => try value.assert_nonnegative_integer() catch e {
+                        let repeat_span = repeat!.span()
+                        .error(format("{}", e.string()), repeat_span)
+                        throw e
                     }
                     Continue => {
                         return StatementResult::Continue

--- a/selfhost/interpreter.jakt
+++ b/selfhost/interpreter.jakt
@@ -5516,6 +5516,38 @@ class Interpreter {
 
                 fields[field_index] = value
             }
+            IndexedExpression(expr, index) => {
+                let index_span = index.span()
+                // FIXME: This should not be evaluated twice.
+                let idx = match .execute_expression(index, scope) {
+                    JustValue(value) => try value.assert_nonnegative_integer() catch e {
+                        .error(format("{}", e.string()), index_span)
+                        throw e
+                    }
+                    else => {
+                        panic("Should not be happening here")
+                    }
+                }
+                // FIXME: This should not be evaluated twice.
+                mut values = match .execute_expression(expr, scope) {
+                    JustValue(value) => match value.impl {
+                        JaktArray(values) => values
+                        else => {
+                            panic("Invalid left-hand side in assignment")
+                        }
+                    }
+                    else => {
+                        panic("Should not be happening here")
+                    }
+                }
+                if idx as! usize >= values.size() {
+                    .error(
+                        format("Index {} out of bounds (max={})", idx, values.size() - 1)
+                        index_span)
+                    throw Error::from_string_literal("Invalid type")
+                }
+                values[idx] = value
+            }
             else => {
                 .error(
                     format("Invalid left-hand side of assignment {}", binding),

--- a/selfhost/types.jakt
+++ b/selfhost/types.jakt
@@ -3332,6 +3332,19 @@ struct Value {
             else => this
         }
     }
+
+    fn assert_nonnegative_integer(this) throws -> u64 => match .impl {
+        I8(x) | I16(x) | I32(x) | I64(x) => {
+            if x < 0 {
+                throw Error::from_string_literal("Expected value to be nonnegative")
+            }
+            yield x as! u64
+        }
+        U8(x) | U16(x) | U32(x) | U64(x) | USize(x) => x as! u64
+        else => {
+            throw Error::from_string_literal("Invalid type")
+        }
+    }
 }
 
 enum NumericOrStringValue {


### PR DESCRIPTION
we can now interpret the following snippet
```
mut arr: [i64] = [0; 5]
arr[0] = 1
arr[0+1] = 2
```