### PR TITLE
selfhost: Add support for casting to float types

### DIFF
--- a/selfhost/codegen.jakt
+++ b/selfhost/codegen.jakt
@@ -2853,7 +2853,7 @@ struct CodeGenerator {
                     }
                     IsNone => "!"
                     TypeCast(cast) => {
-                        mut final_type_id = cast.type_id();
+                        mut final_type_id = cast.type_id()
                         let type = .program.get_type(final_type_id)
                         let cast_type = match cast {
                             Fallible => {
@@ -2871,6 +2871,9 @@ struct CodeGenerator {
                                 } else if .program.is_integer(type_id) {
                                     final_type_id = type_id
                                     cast_type = "fallible_integer_cast"
+                                } else if .program.is_floating(type_id) {
+                                    final_type_id = type_id
+                                    cast_type = "fallible_float_cast"
                                 }
 
                                 yield cast_type
@@ -2887,9 +2890,15 @@ struct CodeGenerator {
                                     cast_type = "infallible_enum_cast"
                                 } else if type is RawPtr(inner) {
                                     cast_type = "reinterpret_cast"
+                                } else if (.program.is_integer(expr.type()) and .program.is_floating(type_id)) or
+                                    (.program.is_floating(expr.type()) and .program.is_integer(type_id)) or
+                                    (.program.is_floating(expr.type()) and .program.is_floating(type_id)) {
+
+                                    cast_type = "infallible_float_cast"
                                 }
                                 yield cast_type
                             }
+                            Identity => "static_cast"
                         }
                         yield cast_type + "<" + .codegen_type(final_type_id) + ">("
                     }

--- a/selfhost/interpreter.jakt
+++ b/selfhost/interpreter.jakt
@@ -1242,6 +1242,7 @@ class Interpreter {
                 TypeCast(cast) => CheckedUnaryOperator::TypeCast(match cast {
                     Fallible(type_id) => CheckedTypeCast::Fallible(scope.map_type(type_id))
                     Infallible(type_id) => CheckedTypeCast::Infallible(scope.map_type(type_id))
+                    Identity(type_id) => CheckedTypeCast::Identity(scope.map_type(type_id))
                 })
                 else => op
             },
@@ -5914,7 +5915,7 @@ class Interpreter {
                         }
                     })
                     TypeCast(cast) => match cast {
-                        Infallible(type_id) => StatementResult::JustValue(cast_value_to_type(value, type_id, interpreter: this))
+                        Identity(type_id) | Infallible(type_id) => StatementResult::JustValue(cast_value_to_type(value, type_id, interpreter: this))
                         Fallible(type_id) => {
                             // FIXME: Actually implement this :)
                             yield StatementResult::JustValue(
@@ -5923,7 +5924,6 @@ class Interpreter {
                                     span
                                 )
                             )
-
                         }
                     }
                     IsEnumVariant(enum_variant, bindings) => match value.impl {

--- a/selfhost/typechecker.jakt
+++ b/selfhost/typechecker.jakt
@@ -8208,6 +8208,24 @@ struct Typechecker {
             let checked_expr = match op {
                 Dereference => .typecheck_expression(expr, scope_id, safety_mode, type_hint: None)
                 Negate => .typecheck_expression_and_dereference_if_needed(expr, scope_id, safety_mode, type_hint, span)
+                TypeCast(cast) => match cast {
+                    Infallible => {
+                        let type_hint = .typecheck_typename(parsed_type: cast.parsed_type(), scope_id, name: None)
+                        // The passed hint may be an actual cast, it may also just be a hint (None as! Foo?)
+                        // First try it as a hint, then try it as a cast.
+                        let old_ignore_errors = .ignore_errors
+                        .had_an_error = false
+                        .ignore_errors = true
+                        mut result = .typecheck_expression_and_dereference_if_needed(expr, scope_id, safety_mode, type_hint, span)
+                        .ignore_errors = old_ignore_errors
+                        if .had_an_error {
+                            result = .typecheck_expression_and_dereference_if_needed(expr, scope_id, safety_mode, type_hint: None, span)
+                            .had_an_error = false
+                        }
+                        yield result
+                    }
+                    else => .typecheck_expression_and_dereference_if_needed(expr, scope_id, safety_mode, type_hint: None, span)
+                }
                 else => .typecheck_expression_and_dereference_if_needed(expr, scope_id, safety_mode, type_hint: None, span)
             }
 
@@ -8234,7 +8252,12 @@ struct Typechecker {
                         }
                         Infallible => CheckedTypeCast::Infallible(type_id)
                     }
-                    yield CheckedUnaryOperator::TypeCast(checked_cast)
+                    mut result = CheckedUnaryOperator::TypeCast(checked_cast)
+                    if checked_cast.type_id() == checked_expr.type() {
+                        // Redundant cast
+                        result = CheckedUnaryOperator::TypeCast(CheckedTypeCast::Identity(type_id))
+                    }
+                    yield result
                 }
                 Sizeof(unchecked_type) => {
                     let type_id = .typecheck_typename(parsed_type: unchecked_type, scope_id, name: None)

--- a/selfhost/types.jakt
+++ b/selfhost/types.jakt
@@ -1445,10 +1445,10 @@ struct CheckedStringLiteral {
 enum CheckedTypeCast {
     Fallible(TypeId)
     Infallible(TypeId)
+    Identity(TypeId)
 
     fn type_id(this) -> TypeId => match this {
-        Fallible(type_id) => type_id
-        Infallible(type_id) => type_id
+        else(type_id) => type_id
     }
 }
 


### PR DESCRIPTION
This makes it possible to cast between integers and floats, or floats of different types.
The runtime code adds a few fixmes about range and representation checks that must be resolved for the casts to be considered "sane", but for now this is reasonable enough.