### PR TITLE
Make string literals non-throwsy

### DIFF
--- a/bootstrap/stage0/build.cpp
+++ b/bootstrap/stage0/build.cpp
@@ -10,7 +10,7 @@ TRY(JaktInternal::PrettyPrint::output_indentation(builder));TRY(builder.appendff
 TRY(builder.append(")"sv));return builder.to_string(); }
 ErrorOr<void> build::Builder::link_into_executable(ByteString const cxx_compiler_path,ByteString const output_filename,JaktInternal::DynamicArray<ByteString> const extra_arguments) {
 {
-JaktInternal::DynamicArray<ByteString> args = (TRY((DynamicArray<ByteString>::create_with({cxx_compiler_path, TRY(ByteString::from_utf8("-o"sv)), output_filename}))));
+JaktInternal::DynamicArray<ByteString> args = (TRY((DynamicArray<ByteString>::create_with({cxx_compiler_path, (ByteString::must_from_utf8("-o"sv)), output_filename}))));
 {
 JaktInternal::ArrayIterator<ByteString> _magic = ((((*this).linked_files)).iterator());
 for (;;){
@@ -63,10 +63,10 @@ JaktInternal::DynamicArray<ByteString> args = (TRY((DynamicArray<ByteString>::cr
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<ByteString,ErrorOr<void>>{
 auto __jakt_enum_value = (((extra_arguments).size()));
 if (__jakt_enum_value == static_cast<size_t>(0ULL)) {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("cr"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("cr"sv)));
 }
 else {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("crT"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("crT"sv)));
 }
 }());
     if (_jakt_value.is_return())
@@ -136,7 +136,7 @@ return Error::from_errno(static_cast<i32>(1));
 }
 }
 
-ByteString const built_object = ((TRY((((binary_dir).join(((TRY((((TRY((jakt__path::Path::from_string(file_name)))).replace_extension(TRY(ByteString::from_utf8("o"sv))))))).to_string())))))).to_string());
+ByteString const built_object = ((TRY((((binary_dir).join(((TRY((((TRY((jakt__path::Path::from_string(file_name)))).replace_extension((ByteString::must_from_utf8("o"sv))))))).to_string())))))).to_string());
 TRY((((((*this).linked_files)).push(built_object))));
 JaktInternal::DynamicArray<ByteString> const args = TRY((compiler_invocation(((TRY((((binary_dir).join(file_name))))).to_string()),built_object)));
 size_t const id = TRY((((((*this).pool)).run(args))));

--- a/bootstrap/stage0/codegen.cpp
+++ b/bootstrap/stage0/codegen.cpp
@@ -7568,7 +7568,9 @@ if (((!(((ids).has_value()))) || (((ids.value())).is_empty()))){
 utility::panic(TRY(ByteString::from_utf8("Internal error: couldn't find a 'from_string_literal' function despite passing typecheck"sv)));
 }
 ByteString const name = TRY((((((((((*this).program))->get_function((((ids.value()))[static_cast<i64>(0LL)]))))->name_for_codegen())).as_name_for_use())));
-ByteString const error_handler = ({
+ByteString const error_handler = "";
+/*
+({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<ByteString,ErrorOr<ByteString>>{
 auto __jakt_enum_value = (((val).may_throw));
 if (__jakt_enum_value == true) {
@@ -7582,6 +7584,7 @@ return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8(""sv)));
         return _jakt_value.release_return();
     _jakt_value.release_value();
 });
+*/
 __jakt_var_637 = TRY((__jakt_format((StringView::from_string_literal("{}({}::{}(\"{}\"sv))"sv)),error_handler,TRY((((*this).codegen_type(((val).type_id))))),name,escaped_value))); goto __jakt_label_542;
 
 }

--- a/bootstrap/stage0/codegen.cpp
+++ b/bootstrap/stage0/codegen.cpp
@@ -34,7 +34,7 @@ if ((returns_void && (!(func_can_throw)))){
 return TRY((__jakt_format((StringView::from_string_literal("JaktInternal::ExplicitValueOrControlFlow<{}, void>()"sv)),cpp_match_result_type)));
 }
 else {
-return TRY(ByteString::from_utf8("_jakt_value.release_return()"sv));
+return (ByteString::must_from_utf8("_jakt_value.release_return()"sv));
 }
 
 }
@@ -52,7 +52,7 @@ return TRY((__jakt_format((StringView::from_string_literal("({{\n    auto&& _jak
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<ByteString,ErrorOr<ByteString>>{
 auto __jakt_enum_value = (((*this).is_match_nested()));
 if (__jakt_enum_value == false) {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("_jakt_value.release_return()"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("_jakt_value.release_return()"sv)));
 }
 else if (__jakt_enum_value == true) {
 return JaktInternal::ExplicitValue(TRY((codegen::ControlFlowState::nested_release_return_expr(func_return_type,func_can_throw,cpp_match_result_type))));
@@ -114,7 +114,7 @@ break;
 }
 JaktInternal::Tuple<ByteString,utility::FileId> file = (_magic_value.value());
 {
-if (((((file).template get<0>())) == (TRY(ByteString::from_utf8("__prelude__"sv))))){
+if (((((file).template get<0>())) == ((ByteString::must_from_utf8("__prelude__"sv))))){
 continue;
 }
 TRY((((((*this).compiler))->set_current_file(((file).template get<1>())))));
@@ -169,7 +169,7 @@ TRY((((*this).gather_line_spans())));
 }
 size_t const file_idx = ((((span).file_id)).id);
 if ((!(((((*this).line_spans)).contains(file_idx))))){
-return TRY(ByteString::from_utf8(""sv));
+return (ByteString::must_from_utf8(""sv));
 }
 size_t line_index = static_cast<size_t>(0ULL);
 while ([](size_t const& self, size_t rhs) -> bool {
@@ -209,7 +209,7 @@ return TRY((__jakt_format((StringView::from_string_literal("{} \"{}\""sv)),JaktI
 }
 ((line_index) += (static_cast<size_t>(1ULL)));
 }
-utility::panic(TRY(ByteString::from_utf8("Reached end of file and could not find index"sv)));
+utility::panic((ByteString::must_from_utf8("Reached end of file and could not find index"sv)));
 }
 }
 
@@ -242,51 +242,51 @@ TRY(JaktInternal::PrettyPrint::output_indentation(builder));TRY(builder.appendff
 TRY(builder.append(")"sv));return builder.to_string(); }
 ErrorOr<JaktInternal::Dictionary<ByteString,JaktInternal::Tuple<ByteString,ByteString>>> codegen::CodeGenerator::generate(NonnullRefPtr<compiler::Compiler> const compiler,NonnullRefPtr<types::CheckedProgram> const program,bool const debug_info) {
 {
-codegen::CodeGenerator generator = codegen::CodeGenerator(compiler,program,codegen::ControlFlowState(codegen::AllowedControlExits::Nothing(),false,false,static_cast<size_t>(0ULL)),(TRY((DynamicArray<JaktInternal::Tuple<ByteString,ByteString>>::create_with({})))),TRY(ByteString::from_utf8(""sv)),JaktInternal::OptionalNone(),false,codegen::CodegenDebugInfo(compiler,(TRY((Dictionary<size_t, JaktInternal::DynamicArray<codegen::LineSpan>>::create_with_entries({})))),debug_info),(TRY((DynamicArray<ByteString>::create_with({})))),static_cast<size_t>(0ULL),static_cast<size_t>(0ULL),JaktInternal::OptionalNone(),JaktInternal::OptionalNone());
+codegen::CodeGenerator generator = codegen::CodeGenerator(compiler,program,codegen::ControlFlowState(codegen::AllowedControlExits::Nothing(),false,false,static_cast<size_t>(0ULL)),(TRY((DynamicArray<JaktInternal::Tuple<ByteString,ByteString>>::create_with({})))),(ByteString::must_from_utf8(""sv)),JaktInternal::OptionalNone(),false,codegen::CodegenDebugInfo(compiler,(TRY((Dictionary<size_t, JaktInternal::DynamicArray<codegen::LineSpan>>::create_with_entries({})))),debug_info),(TRY((DynamicArray<ByteString>::create_with({})))),static_cast<size_t>(0ULL),static_cast<size_t>(0ULL),JaktInternal::OptionalNone(),JaktInternal::OptionalNone());
 JaktInternal::Dictionary<ByteString,JaktInternal::Tuple<ByteString,ByteString>> result = (TRY((Dictionary<ByteString, JaktInternal::Tuple<ByteString,ByteString>>::create_with_entries({}))));
-ByteString output = TRY(ByteString::from_utf8(""sv));
+ByteString output = (ByteString::must_from_utf8(""sv));
 TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 {
 (self = TRY((((self) + (rhs)))));
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8("#pragma once\n"sv)))));
+(output,(ByteString::must_from_utf8("#pragma once\n"sv)))));
 TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 {
 (self = TRY((((self) + (rhs)))));
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8("#include <lib.h>\n"sv)))));
+(output,(ByteString::must_from_utf8("#include <lib.h>\n"sv)))));
 TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 {
 (self = TRY((((self) + (rhs)))));
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8("#ifdef _WIN32\n"sv)))));
+(output,(ByteString::must_from_utf8("#ifdef _WIN32\n"sv)))));
 TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 {
 (self = TRY((((self) + (rhs)))));
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8("extern \"C\" __cdecl int SetConsoleOutputCP(unsigned int code_page);\n"sv)))));
+(output,(ByteString::must_from_utf8("extern \"C\" __cdecl int SetConsoleOutputCP(unsigned int code_page);\n"sv)))));
 TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 {
 (self = TRY((((self) + (rhs)))));
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8("const unsigned int CP_UTF8 = 65001;\n"sv)))));
+(output,(ByteString::must_from_utf8("const unsigned int CP_UTF8 = 65001;\n"sv)))));
 TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 {
 (self = TRY((((self) + (rhs)))));
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8("#endif\n"sv)))));
+(output,(ByteString::must_from_utf8("#endif\n"sv)))));
 JaktInternal::DynamicArray<ids::ModuleId> const sorted_modules = TRY((((generator).topologically_sort_modules())));
 JaktInternal::Dictionary<ByteString,JaktInternal::Tuple<ByteString,ByteString>> imported_paths = (TRY((Dictionary<ByteString, JaktInternal::Tuple<ByteString,ByteString>>::create_with_entries({}))));
 {
@@ -321,8 +321,8 @@ ids::ScopeId child = (_magic_value.value());
 
 if (((((scope)->import_path_if_extern)).has_value())){
 ByteString const path = (((scope)->import_path_if_extern).value());
-ByteString before = TRY(ByteString::from_utf8(""sv));
-ByteString after = TRY(ByteString::from_utf8(""sv));
+ByteString before = (ByteString::must_from_utf8(""sv));
+ByteString after = (ByteString::must_from_utf8(""sv));
 {
 JaktInternal::ArrayIterator<parser::IncludeAction> _magic = ((((scope)->before_extern_include)).iterator());
 for (;;){
@@ -360,7 +360,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(before,TRY(ByteString::from_utf8("#endif\n"sv)))));
+(before,(ByteString::must_from_utf8("#endif\n"sv)))));
 TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 {
 (self = TRY((((self) + (rhs)))));
@@ -394,7 +394,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(before,TRY(ByteString::from_utf8("#endif\n"sv)))));
+(before,(ByteString::must_from_utf8("#endif\n"sv)))));
 }
 return JaktInternal::ExplicitValue<void>();
 };/*case end*/
@@ -451,7 +451,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(after,TRY(ByteString::from_utf8("#endif\n"sv)))));
+(after,(ByteString::must_from_utf8("#endif\n"sv)))));
 TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 {
 (self = TRY((((self) + (rhs)))));
@@ -485,7 +485,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(after,TRY(ByteString::from_utf8("#endif\n"sv)))));
+(after,(ByteString::must_from_utf8("#endif\n"sv)))));
 }
 return JaktInternal::ExplicitValue<void>();
 };/*case end*/
@@ -558,7 +558,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8("namespace Jakt {\n"sv)))));
+(output,(ByteString::must_from_utf8("namespace Jakt {\n"sv)))));
 {
 JaktInternal::Range<size_t> _magic = (JaktInternal::Range<size_t>{static_cast<size_t>(((sorted_modules).size())),static_cast<size_t>(static_cast<size_t>(0ULL))});
 for (;;){
@@ -594,8 +594,8 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8("} // namespace Jakt\n"sv)))));
-TRY((((result).set(TRY(ByteString::from_utf8("__unified_forward.h"sv)),(Tuple{output, (((((compiler)->current_file_path()).value())).to_string())})))));
+(output,(ByteString::must_from_utf8("} // namespace Jakt\n"sv)))));
+TRY((((result).set((ByteString::must_from_utf8("__unified_forward.h"sv)),(Tuple{output, (((((compiler)->current_file_path()).value())).to_string())})))));
 {
 JaktInternal::ArrayIterator<bool> _magic = (((TRY((DynamicArray<bool>::create_with({true, false}))))).iterator());
 for (;;){
@@ -623,14 +623,14 @@ TRY((((((generator).compiler))->dbg_println(TRY((__jakt_format((StringView::from
 ByteString const header_name = TRY((__jakt_format((StringView::from_string_literal("{}.h"sv)),((module)->name))));
 ByteString const impl_name = TRY((__jakt_format((StringView::from_string_literal("{}.cpp"sv)),((module)->name))));
 if (as_forward){
-(output = TRY(ByteString::from_utf8("#pragma once\n"sv)));
+(output = (ByteString::must_from_utf8("#pragma once\n"sv)));
 TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 {
 (self = TRY((((self) + (rhs)))));
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8("#include \"__unified_forward.h\"\n"sv)))));
+(output,(ByteString::must_from_utf8("#include \"__unified_forward.h\"\n"sv)))));
 }
 else {
 (output = TRY((__jakt_format((StringView::from_string_literal("#include \"{}\"\n"sv)),header_name))));
@@ -697,7 +697,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8("#endif\n"sv)))));
+(output,(ByteString::must_from_utf8("#endif\n"sv)))));
 TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 {
 (self = TRY((((self) + (rhs)))));
@@ -731,7 +731,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8("#endif\n"sv)))));
+(output,(ByteString::must_from_utf8("#endif\n"sv)))));
 }
 return JaktInternal::ExplicitValue<void>();
 };/*case end*/
@@ -795,7 +795,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8("#endif\n"sv)))));
+(output,(ByteString::must_from_utf8("#endif\n"sv)))));
 TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 {
 (self = TRY((((self) + (rhs)))));
@@ -829,7 +829,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8("#endif\n"sv)))));
+(output,(ByteString::must_from_utf8("#endif\n"sv)))));
 }
 return JaktInternal::ExplicitValue<void>();
 };/*case end*/
@@ -856,7 +856,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY((((TRY((((TRY(ByteString::from_utf8(" } // namespace "sv))) + ((((scope)->namespace_name).value())))))) + (TRY(ByteString::from_utf8("\n"sv)))))))));
+(output,TRY((((TRY(((((ByteString::must_from_utf8(" } // namespace "sv))) + ((((scope)->namespace_name).value())))))) + ((ByteString::must_from_utf8("\n"sv)))))))));
 }
 }
 }
@@ -893,7 +893,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8("namespace Jakt {\n"sv)))));
+(output,(ByteString::must_from_utf8("namespace Jakt {\n"sv)))));
 if ((!(((module)->is_root)))){
 TRY((((((generator).namespace_stack)).push(((module)->name)))));
 }
@@ -914,14 +914,14 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 return {};
 }
 (output,((generator).deferred_output))));
-(((generator).deferred_output) = TRY(ByteString::from_utf8(""sv)));
+(((generator).deferred_output) = (ByteString::must_from_utf8(""sv)));
 TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 {
 (self = TRY((((self) + (rhs)))));
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8("} // namespace Jakt\n"sv)))));
+(output,(ByteString::must_from_utf8("} // namespace Jakt\n"sv)))));
 if (as_forward){
 TRY((((result).set(header_name,(Tuple{output, ((module)->resolved_import_path)})))));
 }
@@ -953,7 +953,7 @@ NonnullRefPtr<types::Module> const module = ((((((generator).program))->modules)
 ByteString const header_name = TRY((__jakt_format((StringView::from_string_literal("{}.h"sv)),((module)->name))));
 ByteString const impl_name = TRY((__jakt_format((StringView::from_string_literal("{}_specializations.cpp"sv)),((module)->name))));
 if (((i) == (static_cast<size_t>(0ULL)))){
-(output = TRY(ByteString::from_utf8(""sv)));
+(output = (ByteString::must_from_utf8(""sv)));
 }
 else {
 (output = TRY((__jakt_format((StringView::from_string_literal("#include \"{}\"\n"sv)),header_name))));
@@ -992,7 +992,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8("namespace Jakt {\n"sv)))));
+(output,(ByteString::must_from_utf8("namespace Jakt {\n"sv)))));
 if ((!(((module)->is_root)))){
 TRY((((((generator).namespace_stack)).push(((module)->name)))));
 }
@@ -1013,14 +1013,14 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 return {};
 }
 (output,((generator).deferred_output))));
-(((generator).deferred_output) = TRY(ByteString::from_utf8(""sv)));
+(((generator).deferred_output) = (ByteString::must_from_utf8(""sv)));
 TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 {
 (self = TRY((((self) + (rhs)))));
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8("} // namespace Jakt\n"sv)))));
+(output,(ByteString::must_from_utf8("} // namespace Jakt\n"sv)))));
 TRY((((result).set(impl_name,(Tuple{output, ((module)->resolved_import_path)})))));
 }
 
@@ -1033,7 +1033,7 @@ return result;
 
 ErrorOr<ByteString> codegen::CodeGenerator::codegen_destructor(types::CheckedStruct const& struct_,NonnullRefPtr<types::CheckedFunction> const& function,bool const is_inline) {
 {
-ByteString output = TRY(ByteString::from_utf8(""sv));
+ByteString output = (ByteString::must_from_utf8(""sv));
 ByteString const qualified_name = TRY((((*this).codegen_type_possibly_as_namespace(((((struct_))).type_id),true))));
 if (((!(is_inline)) && (!(((((((struct_))).generic_parameters)).is_empty()))))){
 TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
@@ -1042,7 +1042,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8("template <"sv)))));
+(output,(ByteString::must_from_utf8("template <"sv)))));
 TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 {
 (self = TRY((((self) + (rhs)))));
@@ -1056,7 +1056,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8(">\n"sv)))));
+(output,(ByteString::must_from_utf8(">\n"sv)))));
 }
 if (is_inline){
 TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
@@ -1090,7 +1090,7 @@ return output;
 
 ErrorOr<ByteString> codegen::CodeGenerator::codegen_unchecked_binary_op(NonnullRefPtr<typename types::CheckedExpression> const lhs,NonnullRefPtr<typename types::CheckedExpression> const rhs,parser::BinaryOperator const op,ids::TypeId const type_id) {
 {
-ByteString output = TRY(ByteString::from_utf8("static_cast<"sv));
+ByteString output = (ByteString::must_from_utf8("static_cast<"sv));
 TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 {
 (self = TRY((((self) + (rhs)))));
@@ -1104,7 +1104,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8(">("sv)))));
+(output,(ByteString::must_from_utf8(">("sv)))));
 TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 {
 (self = TRY((((self) + (rhs)))));
@@ -1123,19 +1123,19 @@ return {};
 auto&& __jakt_match_variant = op;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 0 /* Add */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8(" + "sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8(" + "sv)));
 };/*case end*/
 case 1 /* Subtract */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8(" - "sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8(" - "sv)));
 };/*case end*/
 case 2 /* Multiply */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8(" * "sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8(" * "sv)));
 };/*case end*/
 case 3 /* Divide */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8(" / "sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8(" / "sv)));
 };/*case end*/
 case 4 /* Modulo */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8(" % "sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8(" % "sv)));
 };/*case end*/
 default: {
 {
@@ -1162,14 +1162,14 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8(")"sv)))));
+(output,(ByteString::must_from_utf8(")"sv)))));
 return output;
 }
 }
 
 ErrorOr<ByteString> codegen::CodeGenerator::codegen_namespace_qualifier(ids::ScopeId const scope_id,bool const skip_current,JaktInternal::Optional<ByteString> const possible_constructor_name,JaktInternal::Optional<JaktInternal::Dictionary<ids::TypeId,ids::TypeId>> const generic_mappings) {
 {
-ByteString output = TRY(ByteString::from_utf8(""sv));
+ByteString output = (ByteString::must_from_utf8(""sv));
 JaktInternal::Optional<ids::ScopeId> current_scope_id = ({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<JaktInternal::Optional<ids::ScopeId>,ErrorOr<ByteString>>{
 auto __jakt_enum_value = (skip_current);
@@ -1207,7 +1207,7 @@ ByteString const args = ({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<ByteString,ErrorOr<ByteString>>{
 auto __jakt_enum_value = (((((scope)->relevant_type_id)).has_value()));
 if (__jakt_enum_value == false) {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8(""sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8(""sv)));
 }
 else if (__jakt_enum_value == true) {
 return JaktInternal::ExplicitValue(({ Optional<ByteString> __jakt_var_613; {
@@ -1274,14 +1274,14 @@ return output;
 
 ErrorOr<ByteString> codegen::CodeGenerator::codegen_checked_binary_op(NonnullRefPtr<typename types::CheckedExpression> const lhs,NonnullRefPtr<typename types::CheckedExpression> const rhs,parser::BinaryOperator const op,ids::TypeId const type_id) {
 {
-ByteString output = TRY(ByteString::from_utf8(""sv));
+ByteString output = (ByteString::must_from_utf8(""sv));
 TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 {
 (self = TRY((((self) + (rhs)))));
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8("JaktInternal::"sv)))));
+(output,(ByteString::must_from_utf8("JaktInternal::"sv)))));
 TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 {
 (self = TRY((((self) + (rhs)))));
@@ -1293,19 +1293,19 @@ return {};
 auto&& __jakt_match_variant = op;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 0 /* Add */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("checked_add"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("checked_add"sv)));
 };/*case end*/
 case 1 /* Subtract */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("checked_sub"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("checked_sub"sv)));
 };/*case end*/
 case 2 /* Multiply */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("checked_mul"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("checked_mul"sv)));
 };/*case end*/
 case 3 /* Divide */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("checked_div"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("checked_div"sv)));
 };/*case end*/
 case 4 /* Modulo */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("checked_mod"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("checked_mod"sv)));
 };/*case end*/
 default: {
 {
@@ -1325,7 +1325,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8("<"sv)))));
+(output,(ByteString::must_from_utf8("<"sv)))));
 TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 {
 (self = TRY((((self) + (rhs)))));
@@ -1339,7 +1339,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8(">("sv)))));
+(output,(ByteString::must_from_utf8(">("sv)))));
 TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 {
 (self = TRY((((self) + (rhs)))));
@@ -1353,7 +1353,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8(","sv)))));
+(output,(ByteString::must_from_utf8(","sv)))));
 TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 {
 (self = TRY((((self) + (rhs)))));
@@ -1367,7 +1367,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8(")"sv)))));
+(output,(ByteString::must_from_utf8(")"sv)))));
 return output;
 }
 }
@@ -1380,14 +1380,14 @@ if (((type_)->__jakt_init_index() == 24 /* Struct */)){
 ids::StructId const struct_id = (type_)->as.Struct.value;
 types::CheckedStruct const structure = ((((*this).program))->get_struct(struct_id));
 if (((((structure).record_type)).__jakt_init_index() == 1 /* Class */)){
-ByteString output = TRY(ByteString::from_utf8(""sv));
+ByteString output = (ByteString::must_from_utf8(""sv));
 TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 {
 (self = TRY((((self) + (rhs)))));
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8("protected:\n"sv)))));
+(output,(ByteString::must_from_utf8("protected:\n"sv)))));
 TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 {
 (self = TRY((((self) + (rhs)))));
@@ -1412,7 +1412,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8(", "sv)))));
+(output,(ByteString::must_from_utf8(", "sv)))));
 }
 else {
 (first = false);
@@ -1432,7 +1432,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8(" a_"sv)))));
+(output,(ByteString::must_from_utf8(" a_"sv)))));
 TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 {
 (self = TRY((((self) + (rhs)))));
@@ -1451,8 +1451,8 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8(");\n"sv)))));
-ByteString class_name_with_generics = TRY(ByteString::from_utf8(""sv));
+(output,(ByteString::must_from_utf8(");\n"sv)))));
+ByteString class_name_with_generics = (ByteString::must_from_utf8(""sv));
 TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 {
 (self = TRY((((self) + (rhs)))));
@@ -1477,7 +1477,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(class_name_with_generics,TRY(ByteString::from_utf8(", "sv)))));
+(class_name_with_generics,(ByteString::must_from_utf8(", "sv)))));
 }
 else {
 TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
@@ -1486,7 +1486,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(class_name_with_generics,TRY(ByteString::from_utf8("<"sv)))));
+(class_name_with_generics,(ByteString::must_from_utf8("<"sv)))));
 (first = false);
 }
 
@@ -1509,7 +1509,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(class_name_with_generics,TRY(ByteString::from_utf8(">"sv)))));
+(class_name_with_generics,(ByteString::must_from_utf8(">"sv)))));
 }
 TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 {
@@ -1517,7 +1517,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8("public:\n"sv)))));
+(output,(ByteString::must_from_utf8("public:\n"sv)))));
 TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 {
 (self = TRY((((self) + (rhs)))));
@@ -1531,7 +1531,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8("("sv)))));
+(output,(ByteString::must_from_utf8("("sv)))));
 (first = true);
 {
 JaktInternal::ArrayIterator<types::CheckedParameter> _magic = ((((function)->params)).iterator());
@@ -1549,7 +1549,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8(", "sv)))));
+(output,(ByteString::must_from_utf8(", "sv)))));
 }
 else {
 (first = false);
@@ -1568,7 +1568,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8(" "sv)))));
+(output,(ByteString::must_from_utf8(" "sv)))));
 TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 {
 (self = TRY((((self) + (rhs)))));
@@ -1587,10 +1587,10 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8(");\n"sv)))));
+(output,(ByteString::must_from_utf8(");\n"sv)))));
 return output;
 }
-ByteString output = TRY(ByteString::from_utf8(""sv));
+ByteString output = (ByteString::must_from_utf8(""sv));
 TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 {
 (self = TRY((((self) + (rhs)))));
@@ -1604,7 +1604,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8("("sv)))));
+(output,(ByteString::must_from_utf8("("sv)))));
 bool first = true;
 {
 JaktInternal::ArrayIterator<types::CheckedParameter> _magic = ((((function)->params)).iterator());
@@ -1622,7 +1622,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8(", "sv)))));
+(output,(ByteString::must_from_utf8(", "sv)))));
 }
 else {
 (first = false);
@@ -1641,7 +1641,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8(" a_"sv)))));
+(output,(ByteString::must_from_utf8(" a_"sv)))));
 TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 {
 (self = TRY((((self) + (rhs)))));
@@ -1660,11 +1660,11 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8(");\n"sv)))));
+(output,(ByteString::must_from_utf8(");\n"sv)))));
 return output;
 }
 else {
-utility::panic(TRY(ByteString::from_utf8("internal error: call to a constructor, but not a struct/class type"sv)));
+utility::panic((ByteString::must_from_utf8("internal error: call to a constructor, but not a struct/class type"sv)));
 }
 
 }
@@ -1718,7 +1718,7 @@ return dependency_graph;
 ErrorOr<ByteString> codegen::CodeGenerator::codegen_statement(NonnullRefPtr<typename types::CheckedStatement> const statement) {
 {
 bool add_newline = true;
-ByteString output = TRY(ByteString::from_utf8(""sv));
+ByteString output = (ByteString::must_from_utf8(""sv));
 if ((((((*this).debug_info)).statement_span_comments) && (((((statement)->span())).has_value()) && add_newline))){
 TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 {
@@ -1740,17 +1740,17 @@ auto&& __jakt_match_variant = *statement;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 11 /* Throw */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Throw;NonnullRefPtr<typename types::CheckedExpression> const& expr = __jakt_match_value.expr;
-return JaktInternal::ExplicitValue(TRY((((TRY((((TRY(ByteString::from_utf8("return "sv))) + (TRY((((*this).codegen_expression(expr))))))))) + (TRY(ByteString::from_utf8(";"sv)))))));
+return JaktInternal::ExplicitValue(TRY((((TRY(((((ByteString::must_from_utf8("return "sv))) + (TRY((((*this).codegen_expression(expr))))))))) + ((ByteString::must_from_utf8(";"sv)))))));
 };/*case end*/
 case 10 /* Continue */: {
 return JaktInternal::ExplicitValue(({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<ByteString,ErrorOr<ByteString>>{
 auto __jakt_enum_value = (((((*this).control_flow_state)).passes_through_match));
 if (__jakt_enum_value == true) {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("return JaktInternal::LoopContinue{};"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("return JaktInternal::LoopContinue{};"sv)));
 }
 else if (__jakt_enum_value == false) {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("continue;"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("continue;"sv)));
 }
 VERIFY_NOT_REACHED();
 }());
@@ -1764,10 +1764,10 @@ return JaktInternal::ExplicitValue(({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<ByteString,ErrorOr<ByteString>>{
 auto __jakt_enum_value = (((((*this).control_flow_state)).passes_through_match));
 if (__jakt_enum_value == true) {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("return JaktInternal::LoopBreak{};"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("return JaktInternal::LoopBreak{};"sv)));
 }
 else if (__jakt_enum_value == false) {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("break;"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("break;"sv)));
 }
 VERIFY_NOT_REACHED();
 }());
@@ -1778,19 +1778,19 @@ VERIFY_NOT_REACHED();
 };/*case end*/
 case 0 /* Expression */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Expression;NonnullRefPtr<typename types::CheckedExpression> const& expr = __jakt_match_value.expr;
-return JaktInternal::ExplicitValue(TRY((((TRY((((*this).codegen_expression(expr))))) + (TRY(ByteString::from_utf8(";"sv)))))));
+return JaktInternal::ExplicitValue(TRY((((TRY((((*this).codegen_expression(expr))))) + ((ByteString::must_from_utf8(";"sv)))))));
 };/*case end*/
 case 1 /* Defer */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Defer;NonnullRefPtr<typename types::CheckedStatement> const& statement = __jakt_match_value.statement;
 return JaktInternal::ExplicitValue(({ Optional<ByteString> __jakt_var_614; {
-ByteString output = TRY(ByteString::from_utf8(""sv));
+ByteString output = (ByteString::must_from_utf8(""sv));
 TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 {
 (self = TRY((((self) + (rhs)))));
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8("ScopeGuard "sv)))));
+(output,(ByteString::must_from_utf8("ScopeGuard "sv)))));
 TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 {
 (self = TRY((((self) + (rhs)))));
@@ -1804,7 +1804,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8("([&] {\n"sv)))));
+(output,(ByteString::must_from_utf8("([&] {\n"sv)))));
 codegen::ControlFlowState const last_control_flow = ((*this).control_flow_state);
 bool const old_inside_defer = ((*this).inside_defer);
 (((((*this).control_flow_state)).passes_through_match) = false);
@@ -1822,7 +1822,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8("});"sv)))));
+(output,(ByteString::must_from_utf8("});"sv)))));
 (((*this).control_flow_state) = last_control_flow);
 (((*this).inside_defer) = old_inside_defer);
 __jakt_var_614 = output; goto __jakt_label_522;
@@ -1842,21 +1842,21 @@ auto __jakt_enum_value = ((((((*this).current_function).value()))->can_throw));
 if (__jakt_enum_value == true) {
 return JaktInternal::ExplicitValue(({ Optional<ByteString> __jakt_var_615; {
 NonnullRefPtr<typename types::Type> const type = ((((*this).program))->get_type((((val.value()))->type())));
-ByteString result = TRY(ByteString::from_utf8(""sv));
+ByteString result = (ByteString::must_from_utf8(""sv));
 if ((((type)->__jakt_init_index() == 0 /* Void */) || ((type)->__jakt_init_index() == 17 /* Never */))){
-(result = TRY((((TRY((((*this).codegen_expression((val.value())))))) + (TRY(ByteString::from_utf8("; return {}"sv)))))));
+(result = TRY((((TRY((((*this).codegen_expression((val.value())))))) + ((ByteString::must_from_utf8("; return {}"sv)))))));
 }
 else {
-(result = TRY((((TRY(ByteString::from_utf8("return "sv))) + (TRY((((*this).codegen_expression((val.value()))))))))));
+(result = TRY(((((ByteString::must_from_utf8("return "sv))) + (TRY((((*this).codegen_expression((val.value()))))))))));
 }
 
-__jakt_var_615 = TRY((((result) + (TRY(ByteString::from_utf8(";"sv)))))); goto __jakt_label_523;
+__jakt_var_615 = TRY((((result) + ((ByteString::must_from_utf8(";"sv)))))); goto __jakt_label_523;
 
 }
 __jakt_label_523:; __jakt_var_615.release_value(); }));
 }
 else if (__jakt_enum_value == false) {
-return JaktInternal::ExplicitValue(TRY((((TRY((((TRY(ByteString::from_utf8("return "sv))) + (TRY((((*this).codegen_expression((val.value())))))))))) + (TRY(ByteString::from_utf8(";"sv)))))));
+return JaktInternal::ExplicitValue(TRY((((TRY(((((ByteString::must_from_utf8("return "sv))) + (TRY((((*this).codegen_expression((val.value())))))))))) + ((ByteString::must_from_utf8(";"sv)))))));
 }
 VERIFY_NOT_REACHED();
 }());
@@ -1871,10 +1871,10 @@ __jakt_var_616 = ({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<ByteString,ErrorOr<ByteString>>{
 auto __jakt_enum_value = ((((((*this).current_function).value()))->can_throw));
 if (__jakt_enum_value == true) {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("return {};"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("return {};"sv)));
 }
 else if (__jakt_enum_value == false) {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("return;"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("return;"sv)));
 }
 VERIFY_NOT_REACHED();
 }());
@@ -1896,7 +1896,7 @@ VERIFY_NOT_REACHED();
 case 6 /* Loop */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Loop;types::CheckedBlock const& block = __jakt_match_value.block;
 return JaktInternal::ExplicitValue(({ Optional<ByteString> __jakt_var_617; {
-ByteString output = TRY(ByteString::from_utf8(""sv));
+ByteString output = (ByteString::must_from_utf8(""sv));
 if ((((((*this).debug_info)).statement_span_comments) && ((((statement)->span())).has_value()))){
 TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 {
@@ -1912,7 +1912,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8("for (;;)"sv)))));
+(output,(ByteString::must_from_utf8("for (;;)"sv)))));
 (add_newline = false);
 codegen::ControlFlowState const last_control_flow = ((*this).control_flow_state);
 (((*this).control_flow_state) = ((last_control_flow).enter_loop()));
@@ -1934,7 +1934,7 @@ case 7 /* While */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.While;NonnullRefPtr<typename types::CheckedExpression> const& condition = __jakt_match_value.condition;
 types::CheckedBlock const& block = __jakt_match_value.block;
 return JaktInternal::ExplicitValue(({ Optional<ByteString> __jakt_var_618; {
-ByteString output = TRY(ByteString::from_utf8(""sv));
+ByteString output = (ByteString::must_from_utf8(""sv));
 if ((((((*this).debug_info)).statement_span_comments) && ((((statement)->span())).has_value()))){
 TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 {
@@ -1950,7 +1950,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8("while ("sv)))));
+(output,(ByteString::must_from_utf8("while ("sv)))));
 TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 {
 (self = TRY((((self) + (rhs)))));
@@ -1964,7 +1964,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8(")"sv)))));
+(output,(ByteString::must_from_utf8(")"sv)))));
 {
 codegen::ControlFlowState const last_control_flow = ((*this).control_flow_state);
 (((*this).control_flow_state) = ((last_control_flow).enter_loop()));
@@ -1991,14 +1991,14 @@ return JaktInternal::ExplicitValue(TRY((((*this).codegen_block(block)))));
 };/*case end*/
 case 14 /* Garbage */: {
 {
-utility::panic(TRY(ByteString::from_utf8("Garbage statement in codegen"sv)));
+utility::panic((ByteString::must_from_utf8("Garbage statement in codegen"sv)));
 }
 };/*case end*/
 case 2 /* DestructuringAssignment */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.DestructuringAssignment;JaktInternal::DynamicArray<NonnullRefPtr<typename types::CheckedStatement>> const& vars = __jakt_match_value.vars;
 NonnullRefPtr<typename types::CheckedStatement> const& var_decl = __jakt_match_value.var_decl;
 return JaktInternal::ExplicitValue(({ Optional<ByteString> __jakt_var_619; {
-ByteString output = TRY(ByteString::from_utf8(""sv));
+ByteString output = (ByteString::must_from_utf8(""sv));
 TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 {
 (self = TRY((((self) + (rhs)))));
@@ -2037,7 +2037,7 @@ auto&& __jakt_match_value = __jakt_match_variant.as.VarDecl;ids::VarId const& va
 NonnullRefPtr<typename types::CheckedExpression> const& init = __jakt_match_value.init;
 return JaktInternal::ExplicitValue(({ Optional<ByteString> __jakt_var_620; {
 NonnullRefPtr<types::CheckedVariable> const var = ((((*this).program))->get_variable(var_id));
-ByteString output = TRY(ByteString::from_utf8(""sv));
+ByteString output = (ByteString::must_from_utf8(""sv));
 NonnullRefPtr<typename types::Type> const var_type = ((((*this).program))->get_type(((var)->type_id)));
 TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 {
@@ -2052,7 +2052,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8(" "sv)))));
+(output,(ByteString::must_from_utf8(" "sv)))));
 if (((!(((var)->is_mutable))) && (!((((var_type)->__jakt_init_index() == 28 /* Reference */) || ((var_type)->__jakt_init_index() == 29 /* MutableReference */)))))){
 TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 {
@@ -2060,7 +2060,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8("const "sv)))));
+(output,(ByteString::must_from_utf8("const "sv)))));
 }
 TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 {
@@ -2075,7 +2075,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8(" = "sv)))));
+(output,(ByteString::must_from_utf8(" = "sv)))));
 TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 {
 (self = TRY((((self) + (rhs)))));
@@ -2089,7 +2089,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8(";"sv)))));
+(output,(ByteString::must_from_utf8(";"sv)))));
 __jakt_var_620 = output; goto __jakt_label_528;
 
 }
@@ -2098,7 +2098,7 @@ __jakt_label_528:; __jakt_var_620.release_value(); }));
 case 13 /* InlineCpp */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.InlineCpp;JaktInternal::DynamicArray<ByteString> const& lines = __jakt_match_value.lines;
 return JaktInternal::ExplicitValue(({ Optional<ByteString> __jakt_var_621; {
-ByteString output = TRY(ByteString::from_utf8(""sv));
+ByteString output = (ByteString::must_from_utf8(""sv));
 {
 JaktInternal::ArrayIterator<ByteString> _magic = ((lines).iterator());
 for (;;){
@@ -2109,8 +2109,8 @@ break;
 ByteString line = (_magic_value.value());
 {
 ByteString escaped_line = line;
-(escaped_line = ((escaped_line).replace(TRY(ByteString::from_utf8("\\\""sv)),TRY(ByteString::from_utf8("\""sv)))));
-(escaped_line = ((escaped_line).replace(TRY(ByteString::from_utf8("\\\\"sv)),TRY(ByteString::from_utf8("\\"sv)))));
+(escaped_line = ((escaped_line).replace((ByteString::must_from_utf8("\\\""sv)),(ByteString::must_from_utf8("\""sv)))));
+(escaped_line = ((escaped_line).replace((ByteString::must_from_utf8("\\\\"sv)),(ByteString::must_from_utf8("\\"sv)))));
 TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 {
 (self = TRY((((self) + (rhs)))));
@@ -2133,7 +2133,7 @@ auto&& __jakt_match_value = __jakt_match_variant.as.If;NonnullRefPtr<typename ty
 types::CheckedBlock const& then_block = __jakt_match_value.then_block;
 JaktInternal::Optional<NonnullRefPtr<typename types::CheckedStatement>> const& else_statement = __jakt_match_value.else_statement;
 return JaktInternal::ExplicitValue(({ Optional<ByteString> __jakt_var_622; {
-ByteString output = TRY(ByteString::from_utf8(""sv));
+ByteString output = (ByteString::must_from_utf8(""sv));
 if ((((((*this).debug_info)).statement_span_comments) && ((((statement)->span())).has_value()))){
 TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 {
@@ -2149,7 +2149,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8("if ("sv)))));
+(output,(ByteString::must_from_utf8("if ("sv)))));
 TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 {
 (self = TRY((((self) + (rhs)))));
@@ -2163,7 +2163,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8(")"sv)))));
+(output,(ByteString::must_from_utf8(")"sv)))));
 TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 {
 (self = TRY((((self) + (rhs)))));
@@ -2181,10 +2181,10 @@ return {};
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<ByteString,ErrorOr<ByteString>>{
 auto __jakt_enum_value = (((else_statement).has_value()));
 if (__jakt_enum_value == true) {
-return JaktInternal::ExplicitValue(TRY((((TRY(ByteString::from_utf8("else "sv))) + (TRY((((*this).codegen_statement((else_statement.value()))))))))));
+return JaktInternal::ExplicitValue(TRY(((((ByteString::must_from_utf8("else "sv))) + (TRY((((*this).codegen_statement((else_statement.value()))))))))));
 }
 else if (__jakt_enum_value == false) {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8(""sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8(""sv)));
 }
 VERIFY_NOT_REACHED();
 }());
@@ -2202,9 +2202,9 @@ case 12 /* Yield */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Yield;NonnullRefPtr<typename types::CheckedExpression> const& expr = __jakt_match_value.expr;
 utility::Span const& span = __jakt_match_value.span;
 return JaktInternal::ExplicitValue(({ Optional<ByteString> __jakt_var_623; {
-ByteString output = TRY(ByteString::from_utf8(""sv));
+ByteString output = (ByteString::must_from_utf8(""sv));
 if (((((((*this).entered_yieldable_blocks)).size())) == (static_cast<size_t>(0ULL)))){
-utility::panic(TRY(ByteString::from_utf8("Must be in a block to yield"sv)));
+utility::panic((ByteString::must_from_utf8("Must be in a block to yield"sv)));
 }
 JaktInternal::Tuple<ByteString,ByteString> const var_name_end_label_ = (((((*this).entered_yieldable_blocks)).last()).value());
 ByteString const var_name = ((var_name_end_label_).template get<0>());
@@ -2223,7 +2223,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8(" = "sv)))));
+(output,(ByteString::must_from_utf8(" = "sv)))));
 TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 {
 (self = TRY((((self) + (rhs)))));
@@ -2237,7 +2237,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8("; goto "sv)))));
+(output,(ByteString::must_from_utf8("; goto "sv)))));
 TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 {
 (self = TRY((((self) + (rhs)))));
@@ -2251,7 +2251,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8(";\n"sv)))));
+(output,(ByteString::must_from_utf8(";\n"sv)))));
 __jakt_var_623 = output; goto __jakt_label_531;
 
 }
@@ -2271,7 +2271,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8("\n"sv)))));
+(output,(ByteString::must_from_utf8("\n"sv)))));
 }
 return output;
 }
@@ -2279,7 +2279,7 @@ return output;
 
 ErrorOr<ByteString> codegen::CodeGenerator::codegen_function_generic_parameters(NonnullRefPtr<types::CheckedFunction> const function) {
 {
-ByteString output = TRY(ByteString::from_utf8(""sv));
+ByteString output = (ByteString::must_from_utf8(""sv));
 if ((!(((((((function)->generics))->params)).is_empty())))){
 TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 {
@@ -2287,7 +2287,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8("template <"sv)))));
+(output,(ByteString::must_from_utf8("template <"sv)))));
 TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 {
 (self = TRY((((self) + (rhs)))));
@@ -2301,7 +2301,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8(">\n"sv)))));
+(output,(ByteString::must_from_utf8(">\n"sv)))));
 }
 return output;
 }
@@ -2309,18 +2309,18 @@ return output;
 
 ErrorOr<ByteString> codegen::CodeGenerator::codegen_function_predecl(NonnullRefPtr<types::CheckedFunction> const function,bool const as_method,bool const allow_generics) {
 {
-ByteString output = TRY(ByteString::from_utf8(""sv));
+ByteString output = (ByteString::must_from_utf8(""sv));
 if (((allow_generics || (!(((((((function)->generics))->params)).is_empty())))) && ((((function)->linkage)).__jakt_init_index() == 1 /* External */))){
-return TRY(ByteString::from_utf8(""sv));
+return (ByteString::must_from_utf8(""sv));
 }
 if (((function)->is_comptime)){
-return TRY(ByteString::from_utf8(""sv));
+return (ByteString::must_from_utf8(""sv));
 }
 if (((((function)->force_inline)).__jakt_init_index() == 2 /* ForceInline */)){
-return TRY(ByteString::from_utf8(""sv));
+return (ByteString::must_from_utf8(""sv));
 }
 if (((((function)->type)).__jakt_init_index() == 2 /* ImplicitConstructor */)){
-return TRY(ByteString::from_utf8(""sv));
+return (ByteString::must_from_utf8(""sv));
 }
 if (((((function)->linkage)).__jakt_init_index() == 1 /* External */)){
 TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
@@ -2329,7 +2329,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8("extern "sv)))));
+(output,(ByteString::must_from_utf8("extern "sv)))));
 }
 TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 {
@@ -2345,16 +2345,16 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8("[[noreturn]] "sv)))));
+(output,(ByteString::must_from_utf8("[[noreturn]] "sv)))));
 }
-if (((TRY((((((function)->name_for_codegen())).as_name_for_definition())))) == (TRY(ByteString::from_utf8("main"sv))))){
+if (((TRY((((((function)->name_for_codegen())).as_name_for_definition())))) == ((ByteString::must_from_utf8("main"sv))))){
 TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 {
 (self = TRY((((self) + (rhs)))));
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8("ErrorOr<int>"sv)))));
+(output,(ByteString::must_from_utf8("ErrorOr<int>"sv)))));
 }
 else {
 if ((as_method && TRY((((function)->is_static()))))){
@@ -2364,7 +2364,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8("static "sv)))));
+(output,(ByteString::must_from_utf8("static "sv)))));
 }
 if (((function)->is_virtual)){
 TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
@@ -2373,7 +2373,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8("virtual "sv)))));
+(output,(ByteString::must_from_utf8("virtual "sv)))));
 }
 ByteString const naked_return_type = TRY((((*this).codegen_type(((function)->return_type_id)))));
 ByteString const return_type = ({
@@ -2406,7 +2406,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8(" "sv)))));
+(output,(ByteString::must_from_utf8(" "sv)))));
 TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 {
 (self = TRY((((self) + (rhs)))));
@@ -2420,7 +2420,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8("("sv)))));
+(output,(ByteString::must_from_utf8("("sv)))));
 bool first = true;
 {
 JaktInternal::ArrayIterator<types::CheckedParameter> _magic = ((((function)->params)).iterator());
@@ -2431,7 +2431,7 @@ break;
 }
 types::CheckedParameter param = (_magic_value.value());
 {
-if ((first && ((((((param).variable))->name)) == (TRY(ByteString::from_utf8("this"sv)))))){
+if ((first && ((((((param).variable))->name)) == ((ByteString::must_from_utf8("this"sv)))))){
 continue;
 }
 if (first){
@@ -2444,7 +2444,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8(", "sv)))));
+(output,(ByteString::must_from_utf8(", "sv)))));
 }
 
 NonnullRefPtr<typename types::Type> const param_type = ((((*this).program))->get_type(((((param).variable))->type_id)));
@@ -2461,7 +2461,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8(" "sv)))));
+(output,(ByteString::must_from_utf8(" "sv)))));
 if (((!(((((param).variable))->is_mutable))) && (!((((param_type)->__jakt_init_index() == 28 /* Reference */) || ((param_type)->__jakt_init_index() == 29 /* MutableReference */)))))){
 TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 {
@@ -2469,7 +2469,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8("const "sv)))));
+(output,(ByteString::must_from_utf8("const "sv)))));
 }
 TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 {
@@ -2489,7 +2489,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8(")"sv)))));
+(output,(ByteString::must_from_utf8(")"sv)))));
 if (((!(TRY((((function)->is_static()))))) && (!(TRY((((function)->is_mutating()))))))){
 TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 {
@@ -2497,7 +2497,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8(" const"sv)))));
+(output,(ByteString::must_from_utf8(" const"sv)))));
 }
 if (((function)->is_override)){
 TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
@@ -2506,7 +2506,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8(" override"sv)))));
+(output,(ByteString::must_from_utf8(" override"sv)))));
 }
 TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 {
@@ -2514,14 +2514,14 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8(";"sv)))));
+(output,(ByteString::must_from_utf8(";"sv)))));
 TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 {
 (self = TRY((((self) + (rhs)))));
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8("\n"sv)))));
+(output,(ByteString::must_from_utf8("\n"sv)))));
 return output;
 }
 }
@@ -2619,7 +2619,7 @@ auto&& __jakt_match_value = __jakt_match_variant.as.Typed;ByteString const& name
 ids::TypeId const& type_id = __jakt_match_value.type_id;
 return JaktInternal::ExplicitValue(({ Optional<JaktInternal::DynamicArray<JaktInternal::Tuple<ByteString,ByteString>>> __jakt_var_625; {
 JaktInternal::DynamicArray<JaktInternal::Tuple<ByteString,ByteString>> fields = (TRY((DynamicArray<JaktInternal::Tuple<ByteString,ByteString>>::create_with({}))));
-TRY((((fields).push((Tuple{TRY(ByteString::from_utf8("value"sv)), TRY((((*this).codegen_type(type_id))))})))));
+TRY((((fields).push((Tuple{(ByteString::must_from_utf8("value"sv)), TRY((((*this).codegen_type(type_id))))})))));
 __jakt_var_625 = fields; goto __jakt_label_533;
 
 }
@@ -2653,7 +2653,7 @@ return (Tuple{common_fields, variant_field_list});
 
 ErrorOr<ByteString> codegen::CodeGenerator::codegen_match_body(types::CheckedMatchBody const body,ids::TypeId const return_type_id) {
 {
-ByteString output = TRY(ByteString::from_utf8(""sv));
+ByteString output = (ByteString::must_from_utf8(""sv));
 ({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<void, ErrorOr<ByteString>>{
 auto&& __jakt_match_variant = body;
@@ -2675,7 +2675,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8("return JaktInternal::ExplicitValue<void>();\n"sv)))));
+(output,(ByteString::must_from_utf8("return JaktInternal::ExplicitValue<void>();\n"sv)))));
 }
 }
 return JaktInternal::ExplicitValue<void>();
@@ -2690,7 +2690,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8("return ("sv)))));
+(output,(ByteString::must_from_utf8("return ("sv)))));
 TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 {
 (self = TRY((((self) + (rhs)))));
@@ -2704,7 +2704,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8("), JaktInternal::ExplicitValue<void>();\n"sv)))));
+(output,(ByteString::must_from_utf8("), JaktInternal::ExplicitValue<void>();\n"sv)))));
 }
 else {
 TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
@@ -2713,7 +2713,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8("return JaktInternal::ExplicitValue("sv)))));
+(output,(ByteString::must_from_utf8("return JaktInternal::ExplicitValue("sv)))));
 TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 {
 (self = TRY((((self) + (rhs)))));
@@ -2727,7 +2727,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8(");\n"sv)))));
+(output,(ByteString::must_from_utf8(");\n"sv)))));
 }
 
 }
@@ -2746,9 +2746,9 @@ return output;
 
 ErrorOr<ByteString> codegen::CodeGenerator::codegen_ak_formatter(ByteString const name,JaktInternal::DynamicArray<ByteString> const generic_parameter_names,ByteString const template_args) {
 {
-ByteString output = TRY(ByteString::from_utf8(""sv));
-ByteString const generic_type_args = TRY((utility::join(generic_parameter_names,TRY(ByteString::from_utf8(", "sv)))));
-ByteString qualified_name = TRY(ByteString::from_utf8(""sv));
+ByteString output = (ByteString::must_from_utf8(""sv));
+ByteString const generic_type_args = TRY((utility::join(generic_parameter_names,(ByteString::must_from_utf8(", "sv)))));
+ByteString qualified_name = (ByteString::must_from_utf8(""sv));
 {
 JaktInternal::ArrayIterator<ByteString> _magic = ((((*this).namespace_stack)).iterator());
 for (;;){
@@ -2792,7 +2792,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8("} // namespace Jakt\n"sv)))));
+(output,(ByteString::must_from_utf8("} // namespace Jakt\n"sv)))));
 TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 {
 (self = TRY((((self) + (rhs)))));
@@ -2813,7 +2813,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8("{\n"sv)))));
+(output,(ByteString::must_from_utf8("{\n"sv)))));
 TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 {
 (self = TRY((((self) + (rhs)))));
@@ -2827,36 +2827,36 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8("JaktInternal::PrettyPrint::ScopedEnable pretty_print_enable { m_alternative_form };"sv)))));
+(output,(ByteString::must_from_utf8("JaktInternal::PrettyPrint::ScopedEnable pretty_print_enable { m_alternative_form };"sv)))));
 TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 {
 (self = TRY((((self) + (rhs)))));
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8("Jakt::ErrorOr<void> format_error = Jakt::Formatter<Jakt::StringView>::format(builder, MUST(value.debug_description()));"sv)))));
+(output,(ByteString::must_from_utf8("Jakt::ErrorOr<void> format_error = Jakt::Formatter<Jakt::StringView>::format(builder, MUST(value.debug_description()));"sv)))));
 TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 {
 (self = TRY((((self) + (rhs)))));
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8("return format_error;"sv)))));
+(output,(ByteString::must_from_utf8("return format_error;"sv)))));
 TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 {
 (self = TRY((((self) + (rhs)))));
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8("}\n"sv)))));
+(output,(ByteString::must_from_utf8("}\n"sv)))));
 TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 {
 (self = TRY((((self) + (rhs)))));
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8("};\n"sv)))));
-return TRY((((output) + (TRY(ByteString::from_utf8("namespace Jakt {\n"sv))))));
+(output,(ByteString::must_from_utf8("};\n"sv)))));
+return TRY((((output) + ((ByteString::must_from_utf8("namespace Jakt {\n"sv))))));
 }
 }
 
@@ -2920,7 +2920,7 @@ return TRY((((*this).codegen_template_parameter_names(parameters,((names))))));
 
 ErrorOr<ByteString> codegen::CodeGenerator::codegen_template_parameter_names(JaktInternal::DynamicArray<ids::TypeId> const parameters,JaktInternal::DynamicArray<ByteString>& names) {
 {
-ByteString output = TRY(ByteString::from_utf8(""sv));
+ByteString output = (ByteString::must_from_utf8(""sv));
 bool first = true;
 {
 JaktInternal::ArrayIterator<ids::TypeId> _magic = ((parameters).iterator());
@@ -2941,7 +2941,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8(","sv)))));
+(output,(ByteString::must_from_utf8(","sv)))));
 }
 
 if (((((((*this).program))->get_type(id)))->__jakt_init_index() == 18 /* TypeVariable */)){
@@ -2953,7 +2953,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8("auto "sv)))));
+(output,(ByteString::must_from_utf8("auto "sv)))));
 }
 else {
 TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
@@ -2962,7 +2962,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8("typename "sv)))));
+(output,(ByteString::must_from_utf8("typename "sv)))));
 }
 
 }
@@ -2973,7 +2973,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8("typename "sv)))));
+(output,(ByteString::must_from_utf8("typename "sv)))));
 }
 
 ByteString const name = TRY((((*this).codegen_type(id))));
@@ -2996,7 +2996,7 @@ return output;
 
 ErrorOr<ByteString> codegen::CodeGenerator::codegen_method_call(NonnullRefPtr<typename types::CheckedExpression> const expr,types::CheckedCall const call,bool const is_optional) {
 {
-ByteString output = TRY(ByteString::from_utf8(""sv));
+ByteString output = (ByteString::must_from_utf8(""sv));
 if (((call).callee_throws)){
 TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 {
@@ -3011,7 +3011,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8("(("sv)))));
+(output,(ByteString::must_from_utf8("(("sv)))));
 }
 ByteString const object = TRY((((*this).codegen_expression_and_deref_if_generic_and_needed(expr))));
 if ((((((call).function_id)).has_value()) && ((((call).force_inline)).__jakt_init_index() == 2 /* ForceInline */))){
@@ -3032,7 +3032,7 @@ VERIFY_NOT_REACHED();
         return _jakt_value.release_return();
     _jakt_value.release_value();
 });
-NonnullRefPtr<types::CheckedVariable> const var = TRY((types::CheckedVariable::__jakt_create(TRY(ByteString::from_utf8("self"sv)),TRY((((((*this).program))->find_or_add_type_id(reference_type,((((expr)->type())).module),false)))),is_mutable,((expr)->span()),JaktInternal::OptionalNone(),types::CheckedVisibility::Public(),JaktInternal::OptionalNone(),JaktInternal::OptionalNone(),JaktInternal::OptionalNone())));
+NonnullRefPtr<types::CheckedVariable> const var = TRY((types::CheckedVariable::__jakt_create((ByteString::must_from_utf8("self"sv)),TRY((((((*this).program))->find_or_add_type_id(reference_type,((((expr)->type())).module),false)))),is_mutable,((expr)->span()),JaktInternal::OptionalNone(),types::CheckedVisibility::Public(),JaktInternal::OptionalNone(),JaktInternal::OptionalNone(),JaktInternal::OptionalNone())));
 JaktInternal::DynamicArray<types::CheckedParameter> params = (TRY((DynamicArray<types::CheckedParameter>::create_with({types::CheckedParameter(false,var,JaktInternal::OptionalNone())}))));
 {
 JaktInternal::ArrayIterator<types::CheckedParameter> _magic = ((((((function)->params))[(JaktInternal::Range<i64>{static_cast<i64>(static_cast<i64>(1LL)),static_cast<i64>(9223372036854775807LL)})])).iterator());
@@ -3055,7 +3055,7 @@ abort();
 }
 NonnullRefPtr<typename types::CheckedExpression> const lambda = TRY((types::CheckedExpression::Function(JaktInternal::OptionalNone(),(TRY((DynamicArray<types::CheckedCapture>::create_with({})))),params,((function)->can_throw),((function)->return_type_id),((function)->block),((expr)->span()),types::unknown_type_id(),((call).function_id),((function)->function_scope_id))));
 JaktInternal::Optional<ByteString> const old_this_replacement = ((*this).this_replacement);
-(((*this).this_replacement) = TRY(ByteString::from_utf8("self"sv)));
+(((*this).this_replacement) = (ByteString::must_from_utf8("self"sv)));
 TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 {
 (self = TRY((((self) + (rhs)))));
@@ -3070,7 +3070,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8("("sv)))));
+(output,(ByteString::must_from_utf8("("sv)))));
 TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 {
 (self = TRY((((self) + (rhs)))));
@@ -3097,7 +3097,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8(","sv)))));
+(output,(ByteString::must_from_utf8(","sv)))));
 TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 {
 (self = TRY((((self) + (rhs)))));
@@ -3116,7 +3116,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8(")"sv)))));
+(output,(ByteString::must_from_utf8(")"sv)))));
 if (((call).callee_throws)){
 TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 {
@@ -3124,7 +3124,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8("))"sv)))));
+(output,(ByteString::must_from_utf8("))"sv)))));
 }
 return output;
 }
@@ -3135,7 +3135,7 @@ ByteString const field_accessor = ({
 auto&& __jakt_match_variant = name;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 2 /* Operator */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8(""sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8(""sv)));
 };/*case end*/
 default: {
 return JaktInternal::ExplicitValue(({
@@ -3143,7 +3143,7 @@ return JaktInternal::ExplicitValue(({
 auto&& __jakt_match_variant = *expression_type;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 26 /* RawPtr */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("->"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("->"sv)));
 };/*case end*/
 case 24 /* Struct */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Struct;ids::StructId const& id = __jakt_match_value.value;
@@ -3154,12 +3154,12 @@ auto __jakt_enum_value = ((((((((((*this).program))->get_struct(id))).record_typ
 return (!(((self) == (rhs))));
 }
 }
-(object,TRY(ByteString::from_utf8("*this"sv)))));
+(object,(ByteString::must_from_utf8("*this"sv)))));
 if (__jakt_enum_value == true) {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("->"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("->"sv)));
 }
 else if (__jakt_enum_value == false) {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("."sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("."sv)));
 }
 VERIFY_NOT_REACHED();
 }());
@@ -3177,12 +3177,12 @@ auto __jakt_enum_value = ((((((((((*this).program))->get_struct(id))).record_typ
 return (!(((self) == (rhs))));
 }
 }
-(object,TRY(ByteString::from_utf8("*this"sv)))));
+(object,(ByteString::must_from_utf8("*this"sv)))));
 if (__jakt_enum_value == true) {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("->"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("->"sv)));
 }
 else if (__jakt_enum_value == false) {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("."sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("."sv)));
 }
 VERIFY_NOT_REACHED();
 }());
@@ -3200,12 +3200,12 @@ auto __jakt_enum_value = ((((((((*this).program))->get_enum(id))).is_boxed) && [
 return (!(((self) == (rhs))));
 }
 }
-(object,TRY(ByteString::from_utf8("*this"sv)))));
+(object,(ByteString::must_from_utf8("*this"sv)))));
 if (__jakt_enum_value == true) {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("->"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("->"sv)));
 }
 else if (__jakt_enum_value == false) {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("."sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("."sv)));
 }
 VERIFY_NOT_REACHED();
 }());
@@ -3219,10 +3219,10 @@ return JaktInternal::ExplicitValue(({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<ByteString,ErrorOr<ByteString>>{
 auto __jakt_enum_value = ((((expression_type)->is_builtin()) && (!(((expression_type)->__jakt_init_index() == 13 /* JaktString */)))));
 if (__jakt_enum_value == true) {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8(""sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8(""sv)));
 }
 else if (__jakt_enum_value == false) {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("."sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("."sv)));
 }
 VERIFY_NOT_REACHED();
 }());
@@ -3266,7 +3266,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8("template "sv)))));
+(output,(ByteString::must_from_utf8("template "sv)))));
 }
 TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 {
@@ -3298,7 +3298,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY((__jakt_format((StringView::from_string_literal("<{}>"sv)),TRY((utility::join(types,TRY(ByteString::from_utf8(", "sv)))))))))));
+(output,TRY((__jakt_format((StringView::from_string_literal("<{}>"sv)),TRY((utility::join(types,(ByteString::must_from_utf8(", "sv)))))))))));
 }
 }
 return {};
@@ -3312,7 +3312,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8("(("sv)))));
+(output,(ByteString::must_from_utf8("(("sv)))));
 TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 {
 (self = TRY((((self) + (rhs)))));
@@ -3326,7 +3326,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8(")"sv)))));
+(output,(ByteString::must_from_utf8(")"sv)))));
 TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 {
 (self = TRY((((self) + (rhs)))));
@@ -3343,7 +3343,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8("("sv)))));
+(output,(ByteString::must_from_utf8("("sv)))));
 TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 {
 (self = TRY((((self) + (rhs)))));
@@ -3360,8 +3360,8 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8("map([&](auto& _value) { return _value"sv)))));
-ByteString access_operator = TRY(ByteString::from_utf8("."sv));
+(output,(ByteString::must_from_utf8("map([&](auto& _value) { return _value"sv)))));
+ByteString access_operator = (ByteString::must_from_utf8("."sv));
 if (((expression_type)->__jakt_init_index() == 20 /* GenericInstance */)){
 JaktInternal::DynamicArray<ids::TypeId> const args = (expression_type)->as.GenericInstance.args;
 if ([](size_t const& self, size_t rhs) -> bool {
@@ -3383,7 +3383,7 @@ case 24 /* Struct */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Struct;ids::StructId const& id = __jakt_match_value.value;
 {
 if (((((((((*this).program))->get_struct(id))).record_type)).__jakt_init_index() == 1 /* Class */)){
-(access_operator = TRY(ByteString::from_utf8("->"sv)));
+(access_operator = (ByteString::must_from_utf8("->"sv)));
 }
 }
 return JaktInternal::ExplicitValue<void>();
@@ -3392,7 +3392,7 @@ case 20 /* GenericInstance */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.GenericInstance;ids::StructId const& id = __jakt_match_value.id;
 {
 if (((((((((*this).program))->get_struct(id))).record_type)).__jakt_init_index() == 1 /* Class */)){
-(access_operator = TRY(ByteString::from_utf8("->"sv)));
+(access_operator = (ByteString::must_from_utf8("->"sv)));
 }
 }
 return JaktInternal::ExplicitValue<void>();
@@ -3427,7 +3427,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8("("sv)))));
+(output,(ByteString::must_from_utf8("("sv)))));
 }
 bool first = is_called_as_method;
 {
@@ -3453,7 +3453,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8(","sv)))));
+(output,(ByteString::must_from_utf8(","sv)))));
 }
 
 TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
@@ -3475,7 +3475,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8(")"sv)))));
+(output,(ByteString::must_from_utf8(")"sv)))));
 }
 if (is_optional){
 TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
@@ -3484,7 +3484,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8("; })"sv)))));
+(output,(ByteString::must_from_utf8("; })"sv)))));
 }
 TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 {
@@ -3492,7 +3492,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8(")"sv)))));
+(output,(ByteString::must_from_utf8(")"sv)))));
 if (((call).callee_throws)){
 TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 {
@@ -3500,7 +3500,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8("))"sv)))));
+(output,(ByteString::must_from_utf8("))"sv)))));
 }
 return output;
 }
@@ -3601,7 +3601,7 @@ return TRY((__jakt_format((StringView::from_string_literal("__jakt_var_{}"sv)),(
 
 ErrorOr<ByteString> codegen::CodeGenerator::codegen_call(types::CheckedCall const call) {
 {
-ByteString output = TRY(ByteString::from_utf8(""sv));
+ByteString output = (ByteString::must_from_utf8(""sv));
 if ((((((call).function_id)).has_value()) && ((((((*this).program))->get_function((((call).function_id).value()))))->is_comptime))){
 return TRY((__jakt_format((StringView::from_string_literal("fail_comptime_call<{}, \"Comptime function {} called outside Jakt compiler\">()"sv)),TRY((((*this).codegen_type(((call).return_type))))),((call).name))));
 }
@@ -3619,33 +3619,33 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8("(("sv)))));
+(output,(ByteString::must_from_utf8("(("sv)))));
 }
 ({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<void,ErrorOr<ByteString>>{
 auto __jakt_enum_value = (((call).name));
-if (__jakt_enum_value == TRY(ByteString::from_utf8("print"sv))) {
+if (__jakt_enum_value == (ByteString::must_from_utf8("print"sv))) {
 {
 ByteString const helper = ({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<ByteString,ErrorOr<ByteString>>{
 auto __jakt_enum_value = (((call).name));
-if (__jakt_enum_value == TRY(ByteString::from_utf8("print"sv))) {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("out"sv)));
+if (__jakt_enum_value == (ByteString::must_from_utf8("print"sv))) {
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("out"sv)));
 }
-else if (__jakt_enum_value == TRY(ByteString::from_utf8("println"sv))) {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("outln"sv)));
+else if (__jakt_enum_value == (ByteString::must_from_utf8("println"sv))) {
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("outln"sv)));
 }
-else if (__jakt_enum_value == TRY(ByteString::from_utf8("eprint"sv))) {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("warn"sv)));
+else if (__jakt_enum_value == (ByteString::must_from_utf8("eprint"sv))) {
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("warn"sv)));
 }
-else if (__jakt_enum_value == TRY(ByteString::from_utf8("eprintln"sv))) {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("warnln"sv)));
+else if (__jakt_enum_value == (ByteString::must_from_utf8("eprintln"sv))) {
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("warnln"sv)));
 }
-else if (__jakt_enum_value == TRY(ByteString::from_utf8("format"sv))) {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("__jakt_format"sv)));
+else if (__jakt_enum_value == (ByteString::must_from_utf8("format"sv))) {
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("__jakt_format"sv)));
 }
 else {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8(""sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8(""sv)));
 }
 }());
     if (_jakt_value.is_return())
@@ -3665,7 +3665,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8("("sv)))));
+(output,(ByteString::must_from_utf8("("sv)))));
 {
 JaktInternal::Range<size_t> _magic = (JaktInternal::Range<size_t>{static_cast<size_t>(static_cast<size_t>(0ULL)),static_cast<size_t>(((((call).args)).size()))});
 for (;;){
@@ -3693,7 +3693,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8(","sv)))));
+(output,(ByteString::must_from_utf8(","sv)))));
 }
 }
 
@@ -3706,32 +3706,32 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8(")"sv)))));
+(output,(ByteString::must_from_utf8(")"sv)))));
 }
 return JaktInternal::ExplicitValue<void>();
 }
-else if (__jakt_enum_value == TRY(ByteString::from_utf8("println"sv))) {
+else if (__jakt_enum_value == (ByteString::must_from_utf8("println"sv))) {
 {
 ByteString const helper = ({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<ByteString,ErrorOr<ByteString>>{
 auto __jakt_enum_value = (((call).name));
-if (__jakt_enum_value == TRY(ByteString::from_utf8("print"sv))) {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("out"sv)));
+if (__jakt_enum_value == (ByteString::must_from_utf8("print"sv))) {
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("out"sv)));
 }
-else if (__jakt_enum_value == TRY(ByteString::from_utf8("println"sv))) {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("outln"sv)));
+else if (__jakt_enum_value == (ByteString::must_from_utf8("println"sv))) {
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("outln"sv)));
 }
-else if (__jakt_enum_value == TRY(ByteString::from_utf8("eprint"sv))) {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("warn"sv)));
+else if (__jakt_enum_value == (ByteString::must_from_utf8("eprint"sv))) {
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("warn"sv)));
 }
-else if (__jakt_enum_value == TRY(ByteString::from_utf8("eprintln"sv))) {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("warnln"sv)));
+else if (__jakt_enum_value == (ByteString::must_from_utf8("eprintln"sv))) {
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("warnln"sv)));
 }
-else if (__jakt_enum_value == TRY(ByteString::from_utf8("format"sv))) {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("__jakt_format"sv)));
+else if (__jakt_enum_value == (ByteString::must_from_utf8("format"sv))) {
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("__jakt_format"sv)));
 }
 else {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8(""sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8(""sv)));
 }
 }());
     if (_jakt_value.is_return())
@@ -3751,7 +3751,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8("("sv)))));
+(output,(ByteString::must_from_utf8("("sv)))));
 {
 JaktInternal::Range<size_t> _magic = (JaktInternal::Range<size_t>{static_cast<size_t>(static_cast<size_t>(0ULL)),static_cast<size_t>(((((call).args)).size()))});
 for (;;){
@@ -3779,7 +3779,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8(","sv)))));
+(output,(ByteString::must_from_utf8(","sv)))));
 }
 }
 
@@ -3792,32 +3792,32 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8(")"sv)))));
+(output,(ByteString::must_from_utf8(")"sv)))));
 }
 return JaktInternal::ExplicitValue<void>();
 }
-else if (__jakt_enum_value == TRY(ByteString::from_utf8("eprintln"sv))) {
+else if (__jakt_enum_value == (ByteString::must_from_utf8("eprintln"sv))) {
 {
 ByteString const helper = ({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<ByteString,ErrorOr<ByteString>>{
 auto __jakt_enum_value = (((call).name));
-if (__jakt_enum_value == TRY(ByteString::from_utf8("print"sv))) {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("out"sv)));
+if (__jakt_enum_value == (ByteString::must_from_utf8("print"sv))) {
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("out"sv)));
 }
-else if (__jakt_enum_value == TRY(ByteString::from_utf8("println"sv))) {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("outln"sv)));
+else if (__jakt_enum_value == (ByteString::must_from_utf8("println"sv))) {
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("outln"sv)));
 }
-else if (__jakt_enum_value == TRY(ByteString::from_utf8("eprint"sv))) {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("warn"sv)));
+else if (__jakt_enum_value == (ByteString::must_from_utf8("eprint"sv))) {
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("warn"sv)));
 }
-else if (__jakt_enum_value == TRY(ByteString::from_utf8("eprintln"sv))) {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("warnln"sv)));
+else if (__jakt_enum_value == (ByteString::must_from_utf8("eprintln"sv))) {
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("warnln"sv)));
 }
-else if (__jakt_enum_value == TRY(ByteString::from_utf8("format"sv))) {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("__jakt_format"sv)));
+else if (__jakt_enum_value == (ByteString::must_from_utf8("format"sv))) {
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("__jakt_format"sv)));
 }
 else {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8(""sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8(""sv)));
 }
 }());
     if (_jakt_value.is_return())
@@ -3837,7 +3837,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8("("sv)))));
+(output,(ByteString::must_from_utf8("("sv)))));
 {
 JaktInternal::Range<size_t> _magic = (JaktInternal::Range<size_t>{static_cast<size_t>(static_cast<size_t>(0ULL)),static_cast<size_t>(((((call).args)).size()))});
 for (;;){
@@ -3865,7 +3865,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8(","sv)))));
+(output,(ByteString::must_from_utf8(","sv)))));
 }
 }
 
@@ -3878,32 +3878,32 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8(")"sv)))));
+(output,(ByteString::must_from_utf8(")"sv)))));
 }
 return JaktInternal::ExplicitValue<void>();
 }
-else if (__jakt_enum_value == TRY(ByteString::from_utf8("eprint"sv))) {
+else if (__jakt_enum_value == (ByteString::must_from_utf8("eprint"sv))) {
 {
 ByteString const helper = ({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<ByteString,ErrorOr<ByteString>>{
 auto __jakt_enum_value = (((call).name));
-if (__jakt_enum_value == TRY(ByteString::from_utf8("print"sv))) {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("out"sv)));
+if (__jakt_enum_value == (ByteString::must_from_utf8("print"sv))) {
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("out"sv)));
 }
-else if (__jakt_enum_value == TRY(ByteString::from_utf8("println"sv))) {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("outln"sv)));
+else if (__jakt_enum_value == (ByteString::must_from_utf8("println"sv))) {
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("outln"sv)));
 }
-else if (__jakt_enum_value == TRY(ByteString::from_utf8("eprint"sv))) {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("warn"sv)));
+else if (__jakt_enum_value == (ByteString::must_from_utf8("eprint"sv))) {
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("warn"sv)));
 }
-else if (__jakt_enum_value == TRY(ByteString::from_utf8("eprintln"sv))) {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("warnln"sv)));
+else if (__jakt_enum_value == (ByteString::must_from_utf8("eprintln"sv))) {
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("warnln"sv)));
 }
-else if (__jakt_enum_value == TRY(ByteString::from_utf8("format"sv))) {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("__jakt_format"sv)));
+else if (__jakt_enum_value == (ByteString::must_from_utf8("format"sv))) {
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("__jakt_format"sv)));
 }
 else {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8(""sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8(""sv)));
 }
 }());
     if (_jakt_value.is_return())
@@ -3923,7 +3923,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8("("sv)))));
+(output,(ByteString::must_from_utf8("("sv)))));
 {
 JaktInternal::Range<size_t> _magic = (JaktInternal::Range<size_t>{static_cast<size_t>(static_cast<size_t>(0ULL)),static_cast<size_t>(((((call).args)).size()))});
 for (;;){
@@ -3951,7 +3951,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8(","sv)))));
+(output,(ByteString::must_from_utf8(","sv)))));
 }
 }
 
@@ -3964,32 +3964,32 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8(")"sv)))));
+(output,(ByteString::must_from_utf8(")"sv)))));
 }
 return JaktInternal::ExplicitValue<void>();
 }
-else if (__jakt_enum_value == TRY(ByteString::from_utf8("format"sv))) {
+else if (__jakt_enum_value == (ByteString::must_from_utf8("format"sv))) {
 {
 ByteString const helper = ({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<ByteString,ErrorOr<ByteString>>{
 auto __jakt_enum_value = (((call).name));
-if (__jakt_enum_value == TRY(ByteString::from_utf8("print"sv))) {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("out"sv)));
+if (__jakt_enum_value == (ByteString::must_from_utf8("print"sv))) {
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("out"sv)));
 }
-else if (__jakt_enum_value == TRY(ByteString::from_utf8("println"sv))) {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("outln"sv)));
+else if (__jakt_enum_value == (ByteString::must_from_utf8("println"sv))) {
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("outln"sv)));
 }
-else if (__jakt_enum_value == TRY(ByteString::from_utf8("eprint"sv))) {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("warn"sv)));
+else if (__jakt_enum_value == (ByteString::must_from_utf8("eprint"sv))) {
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("warn"sv)));
 }
-else if (__jakt_enum_value == TRY(ByteString::from_utf8("eprintln"sv))) {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("warnln"sv)));
+else if (__jakt_enum_value == (ByteString::must_from_utf8("eprintln"sv))) {
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("warnln"sv)));
 }
-else if (__jakt_enum_value == TRY(ByteString::from_utf8("format"sv))) {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("__jakt_format"sv)));
+else if (__jakt_enum_value == (ByteString::must_from_utf8("format"sv))) {
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("__jakt_format"sv)));
 }
 else {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8(""sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8(""sv)));
 }
 }());
     if (_jakt_value.is_return())
@@ -4009,7 +4009,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8("("sv)))));
+(output,(ByteString::must_from_utf8("("sv)))));
 {
 JaktInternal::Range<size_t> _magic = (JaktInternal::Range<size_t>{static_cast<size_t>(static_cast<size_t>(0ULL)),static_cast<size_t>(((((call).args)).size()))});
 for (;;){
@@ -4037,7 +4037,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8(","sv)))));
+(output,(ByteString::must_from_utf8(","sv)))));
 }
 }
 
@@ -4050,7 +4050,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8(")"sv)))));
+(output,(ByteString::must_from_utf8(")"sv)))));
 }
 return JaktInternal::ExplicitValue<void>();
 }
@@ -4093,7 +4093,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8("::__jakt_create"sv)))));
+(output,(ByteString::must_from_utf8("::__jakt_create"sv)))));
 }
 else {
 TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
@@ -4127,7 +4127,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8("<"sv)))));
+(output,(ByteString::must_from_utf8("<"sv)))));
 bool first = true;
 {
 JaktInternal::ArrayIterator<ids::TypeId> _magic = ((args).iterator());
@@ -4145,7 +4145,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8(", "sv)))));
+(output,(ByteString::must_from_utf8(", "sv)))));
 }
 else {
 (first = false);
@@ -4169,7 +4169,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8(">::__jakt_create"sv)))));
+(output,(ByteString::must_from_utf8(">::__jakt_create"sv)))));
 }
 else {
 TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
@@ -4185,7 +4185,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8("<"sv)))));
+(output,(ByteString::must_from_utf8("<"sv)))));
 bool first = true;
 {
 JaktInternal::ArrayIterator<ids::TypeId> _magic = ((args).iterator());
@@ -4203,7 +4203,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8(", "sv)))));
+(output,(ByteString::must_from_utf8(", "sv)))));
 }
 else {
 (first = false);
@@ -4227,7 +4227,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8(">"sv)))));
+(output,(ByteString::must_from_utf8(">"sv)))));
 }
 
 }
@@ -4235,7 +4235,7 @@ return JaktInternal::ExplicitValue<void>();
 };/*case end*/
 default: {
 {
-utility::panic(TRY(ByteString::from_utf8("Should be unreachable"sv)));
+utility::panic((ByteString::must_from_utf8("Should be unreachable"sv)));
 }
 return JaktInternal::ExplicitValue<void>();
 };/*case end*/
@@ -4270,20 +4270,20 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY((((TRY(ByteString::from_utf8("::"sv))) + (TRY((((((call).name_for_codegen())).as_name_for_use()))))))))));
+(output,TRY(((((ByteString::must_from_utf8("::"sv))) + (TRY((((((call).name_for_codegen())).as_name_for_use()))))))))));
 }
 return JaktInternal::ExplicitValue<void>();
 };/*case end*/
 case 21 /* GenericEnumInstance */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.GenericEnumInstance;ids::EnumId const& id = __jakt_match_value.id;
 {
-utility::todo(TRY(ByteString::from_utf8("codegen generic enum instance"sv)));
+utility::todo((ByteString::must_from_utf8("codegen generic enum instance"sv)));
 }
 return JaktInternal::ExplicitValue<void>();
 };/*case end*/
 default: {
 {
-utility::panic(TRY(ByteString::from_utf8("constructor expected enum type"sv)));
+utility::panic((ByteString::must_from_utf8("constructor expected enum type"sv)));
 }
 return JaktInternal::ExplicitValue<void>();
 };/*case end*/
@@ -4354,7 +4354,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY((__jakt_format((StringView::from_string_literal("<{}>"sv)),TRY((utility::join(types,TRY(ByteString::from_utf8(", "sv)))))))))));
+(output,TRY((__jakt_format((StringView::from_string_literal("<{}>"sv)),TRY((utility::join(types,(ByteString::must_from_utf8(", "sv)))))))))));
 }
 JaktInternal::DynamicArray<ByteString> arguments = (TRY((DynamicArray<ByteString>::create_with({}))));
 {
@@ -4378,7 +4378,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY((__jakt_format((StringView::from_string_literal("({})"sv)),TRY((utility::join(arguments,TRY(ByteString::from_utf8(","sv)))))))))));
+(output,TRY((__jakt_format((StringView::from_string_literal("({})"sv)),TRY((utility::join(arguments,(ByteString::must_from_utf8(","sv)))))))))));
 }
 return JaktInternal::ExplicitValue<void>();
 }
@@ -4395,7 +4395,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8("))"sv)))));
+(output,(ByteString::must_from_utf8("))"sv)))));
 }
 return output;
 }
@@ -4404,9 +4404,9 @@ return output;
 ErrorOr<ByteString> codegen::CodeGenerator::codegen_namespace_predecl(NonnullRefPtr<types::Scope> const scope,NonnullRefPtr<types::Module> const current_module) {
 {
 if ((((((scope)->alias_path)).has_value()) || ((((scope)->import_path_if_extern)).has_value()))){
-return TRY(ByteString::from_utf8(""sv));
+return (ByteString::must_from_utf8(""sv));
 }
-ByteString output = TRY(ByteString::from_utf8(""sv));
+ByteString output = (ByteString::must_from_utf8(""sv));
 if (((((scope)->namespace_name)).has_value())){
 TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 {
@@ -4414,7 +4414,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8("namespace "sv)))));
+(output,(ByteString::must_from_utf8("namespace "sv)))));
 TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 {
 (self = TRY((((self) + (rhs)))));
@@ -4428,7 +4428,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8(" {\n"sv)))));
+(output,(ByteString::must_from_utf8(" {\n"sv)))));
 }
 {
 JaktInternal::DictionaryIterator<ByteString,ids::StructId> _magic = ((((scope)->structs)).iterator());
@@ -4460,7 +4460,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8("\n"sv)))));
+(output,(ByteString::must_from_utf8("\n"sv)))));
 }
 
 }
@@ -4496,7 +4496,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8("\n"sv)))));
+(output,(ByteString::must_from_utf8("\n"sv)))));
 }
 
 }
@@ -4562,7 +4562,7 @@ if (((!(((((function)->type)).__jakt_init_index() == 2 /* ImplicitConstructor */
 return (!(((self) == (rhs))));
 }
 }
-(TRY((((((function)->name_for_codegen())).as_name_for_use()))),TRY(ByteString::from_utf8("main"sv))) && ((((((function)->generics))->params)).is_empty()))))){
+(TRY((((((function)->name_for_codegen())).as_name_for_use()))),(ByteString::must_from_utf8("main"sv))) && ((((((function)->generics))->params)).is_empty()))))){
 TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 {
 (self = TRY((((self) + (rhs)))));
@@ -4576,7 +4576,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8("\n"sv)))));
+(output,(ByteString::must_from_utf8("\n"sv)))));
 }
 }
 
@@ -4595,7 +4595,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8("}\n"sv)))));
+(output,(ByteString::must_from_utf8("}\n"sv)))));
 }
 return output;
 }
@@ -4682,13 +4682,13 @@ TRY((((stack).push(ids::ModuleId(((imported_module).id))))));
 if (((((sorted_modules).size())) == (((((((*this).program))->modules)).size())))){
 return sorted_modules;
 }
-utility::panic(TRY(ByteString::from_utf8("Cyclic module imports"sv)));
+utility::panic((ByteString::must_from_utf8("Cyclic module imports"sv)));
 }
 }
 
 ErrorOr<ByteString> codegen::CodeGenerator::codegen_block(types::CheckedBlock const block) {
 {
-ByteString output = TRY(ByteString::from_utf8(""sv));
+ByteString output = (ByteString::must_from_utf8(""sv));
 if (((((block).yielded_type)).has_value())){
 ids::TypeId const yielded_type = (((block).yielded_type).value());
 ByteString const type_output = TRY((((*this).codegen_type(yielded_type))));
@@ -4701,7 +4701,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8("({ Optional<"sv)))));
+(output,(ByteString::must_from_utf8("({ Optional<"sv)))));
 TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 {
 (self = TRY((((self) + (rhs)))));
@@ -4715,7 +4715,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8("> "sv)))));
+(output,(ByteString::must_from_utf8("> "sv)))));
 TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 {
 (self = TRY((((self) + (rhs)))));
@@ -4729,7 +4729,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8("; "sv)))));
+(output,(ByteString::must_from_utf8("; "sv)))));
 }
 TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 {
@@ -4737,7 +4737,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8("{\n"sv)))));
+(output,(ByteString::must_from_utf8("{\n"sv)))));
 {
 JaktInternal::ArrayIterator<NonnullRefPtr<typename types::CheckedStatement>> _magic = ((((block).statements)).iterator());
 for (;;){
@@ -4765,7 +4765,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8("}\n"sv)))));
+(output,(ByteString::must_from_utf8("}\n"sv)))));
 if (((((block).yielded_type)).has_value())){
 JaktInternal::Tuple<ByteString,ByteString> const var_label_ = (((((*this).entered_yieldable_blocks)).pop()).value());
 ByteString const var = ((var_label_).template get<0>());
@@ -4784,7 +4784,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8(":; "sv)))));
+(output,(ByteString::must_from_utf8(":; "sv)))));
 TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 {
 (self = TRY((((self) + (rhs)))));
@@ -4799,7 +4799,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8(".release_value()"sv)))));
+(output,(ByteString::must_from_utf8(".release_value()"sv)))));
 }
 TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 {
@@ -4807,7 +4807,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8("; })"sv)))));
+(output,(ByteString::must_from_utf8("; })"sv)))));
 }
 return output;
 }
@@ -4815,7 +4815,7 @@ return output;
 
 ErrorOr<ByteString> codegen::CodeGenerator::codegen_generic_match(NonnullRefPtr<typename types::CheckedExpression> const expr,JaktInternal::DynamicArray<types::CheckedMatchCase> const cases,ids::TypeId const return_type_id,bool const all_variants_constant) {
 {
-ByteString output = TRY(ByteString::from_utf8(""sv));
+ByteString output = (ByteString::must_from_utf8(""sv));
 bool is_generic_enum = false;
 {
 JaktInternal::ArrayIterator<types::CheckedMatchCase> _magic = ((cases).iterator());
@@ -4843,7 +4843,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY((((TRY((__jakt_format((StringView::from_string_literal("([&]() -> JaktInternal::ExplicitValueOrControlFlow<{},{}>"sv)),cpp_match_result_type,TRY((((*this).codegen_function_return_type((((*this).current_function).value()))))))))) + (TRY(ByteString::from_utf8("{\n"sv)))))))));
+(output,TRY((((TRY((__jakt_format((StringView::from_string_literal("([&]() -> JaktInternal::ExplicitValueOrControlFlow<{},{}>"sv)),cpp_match_result_type,TRY((((*this).codegen_function_return_type((((*this).current_function).value()))))))))) + ((ByteString::must_from_utf8("{\n"sv)))))))));
 if (is_generic_enum){
 TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 {
@@ -4851,7 +4851,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8("auto&& __jakt_enum_value = JaktInternal::deref_if_ref_pointer("sv)))));
+(output,(ByteString::must_from_utf8("auto&& __jakt_enum_value = JaktInternal::deref_if_ref_pointer("sv)))));
 }
 else {
 TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
@@ -4860,7 +4860,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8("auto __jakt_enum_value = ("sv)))));
+(output,(ByteString::must_from_utf8("auto __jakt_enum_value = ("sv)))));
 }
 
 TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
@@ -4876,7 +4876,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8(");\n"sv)))));
+(output,(ByteString::must_from_utf8(");\n"sv)))));
 bool has_default = false;
 bool first = true;
 {
@@ -4954,7 +4954,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 return {};
 }
 (output,TRY((__jakt_format((StringView::from_string_literal("if (__jakt_enum_value.__jakt_init_index() == {} /* {} */) {{\n"sv)),variant_index,name))))));
-ByteString variant_type_name = TRY(ByteString::from_utf8(""sv));
+ByteString variant_type_name = (ByteString::must_from_utf8(""sv));
 ByteString const qualifier = TRY((((*this).codegen_type_possibly_as_namespace(subject_type_id,true))));
 if ((!(((qualifier).is_empty())))){
 TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
@@ -4963,7 +4963,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(variant_type_name,TRY(ByteString::from_utf8("typename JaktInternal::RemoveRefPtr<"sv)))));
+(variant_type_name,(ByteString::must_from_utf8("typename JaktInternal::RemoveRefPtr<"sv)))));
 TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 {
 (self = TRY((((self) + (rhs)))));
@@ -4977,7 +4977,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(variant_type_name,TRY(ByteString::from_utf8(">::"sv)))));
+(variant_type_name,(ByteString::must_from_utf8(">::"sv)))));
 }
 TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 {
@@ -4993,7 +4993,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8("auto& __jakt_match_value = __jakt_enum_value.as."sv)))));
+(output,(ByteString::must_from_utf8("auto& __jakt_match_value = __jakt_enum_value.as."sv)))));
 TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 {
 (self = TRY((((self) + (rhs)))));
@@ -5007,7 +5007,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8(";\n"sv)))));
+(output,(ByteString::must_from_utf8(";\n"sv)))));
 {
 JaktInternal::ArrayIterator<parser::EnumVariantPatternArgument> _magic = ((args).iterator());
 for (;;){
@@ -5023,7 +5023,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8("auto& "sv)))));
+(output,(ByteString::must_from_utf8("auto& "sv)))));
 TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 {
 (self = TRY((((self) + (rhs)))));
@@ -5037,21 +5037,21 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8(" = __jakt_match_value."sv)))));
+(output,(ByteString::must_from_utf8(" = __jakt_match_value."sv)))));
 TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 {
 (self = TRY((((self) + (rhs)))));
 }
 return {};
 }
-(output,TRY((((arg).name).try_value_or_lazy_evaluated([&]() -> ErrorOr<ByteString> { return TRY(ByteString::from_utf8("value"sv)); }))))));
+(output,TRY((((arg).name).try_value_or_lazy_evaluated([&]() -> ErrorOr<ByteString> { return (ByteString::must_from_utf8("value"sv)); }))))));
 TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 {
 (self = TRY((((self) + (rhs)))));
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8(";\n"sv)))));
+(output,(ByteString::must_from_utf8(";\n"sv)))));
 }
 
 }
@@ -5092,7 +5092,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8("}\n"sv)))));
+(output,(ByteString::must_from_utf8("}\n"sv)))));
 }
 return JaktInternal::ExplicitValue<void>();
 };/*case end*/
@@ -5102,7 +5102,7 @@ types::CheckedMatchBody const& body = __jakt_match_value.body;
 utility::Span const& marker_span = __jakt_match_value.marker_span;
 {
 if (has_arguments){
-utility::panic(TRY(ByteString::from_utf8("Bindings should not be present in a generic else"sv)));
+utility::panic((ByteString::must_from_utf8("Bindings should not be present in a generic else"sv)));
 }
 (has_default = true);
 if (first){
@@ -5112,7 +5112,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8("{"sv)))));
+(output,(ByteString::must_from_utf8("{"sv)))));
 }
 else {
 TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
@@ -5121,7 +5121,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8("else {\n"sv)))));
+(output,(ByteString::must_from_utf8("else {\n"sv)))));
 }
 
 {
@@ -5158,7 +5158,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8("}\n"sv)))));
+(output,(ByteString::must_from_utf8("}\n"sv)))));
 }
 return JaktInternal::ExplicitValue<void>();
 };/*case end*/
@@ -5174,7 +5174,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8("else "sv)))));
+(output,(ByteString::must_from_utf8("else "sv)))));
 }
 if (((expression)->__jakt_init_index() == 9 /* Range */)){
 JaktInternal::Optional<NonnullRefPtr<typename types::CheckedExpression>> const from = (expression)->as.Range.from;
@@ -5185,7 +5185,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8("if (__jakt_enum_value"sv)))));
+(output,(ByteString::must_from_utf8("if (__jakt_enum_value"sv)))));
 if (((from).has_value())){
 TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 {
@@ -5193,7 +5193,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8(" >= "sv)))));
+(output,(ByteString::must_from_utf8(" >= "sv)))));
 TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 {
 (self = TRY((((self) + (rhs)))));
@@ -5210,7 +5210,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8("&& __jakt_enum_value "sv)))));
+(output,(ByteString::must_from_utf8("&& __jakt_enum_value "sv)))));
 }
 TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 {
@@ -5218,7 +5218,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8("< "sv)))));
+(output,(ByteString::must_from_utf8("< "sv)))));
 TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 {
 (self = TRY((((self) + (rhs)))));
@@ -5235,7 +5235,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8("if (__jakt_enum_value == "sv)))));
+(output,(ByteString::must_from_utf8("if (__jakt_enum_value == "sv)))));
 TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 {
 (self = TRY((((self) + (rhs)))));
@@ -5251,7 +5251,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8(") {\n"sv)))));
+(output,(ByteString::must_from_utf8(") {\n"sv)))));
 TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 {
 (self = TRY((((self) + (rhs)))));
@@ -5265,7 +5265,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8("}\n"sv)))));
+(output,(ByteString::must_from_utf8("}\n"sv)))));
 }
 return JaktInternal::ExplicitValue<void>();
 };/*case end*/
@@ -5289,7 +5289,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY((__jakt_format((StringView::from_string_literal("auto {} = NonnullRefPtr {{ *static_cast<RawPtr<{}>>(__jakt_enum_value.ptr()) }};\n"sv)),TRY((((rebind_name).map([](auto& _value) { return _value.name; })).try_value_or_lazy_evaluated([&]() -> ErrorOr<ByteString> { return TRY(ByteString::from_utf8("__jakt_match_value"sv)); }))),type_name))))));
+(output,TRY((__jakt_format((StringView::from_string_literal("auto {} = NonnullRefPtr {{ *static_cast<RawPtr<{}>>(__jakt_enum_value.ptr()) }};\n"sv)),TRY((((rebind_name).map([](auto& _value) { return _value.name; })).try_value_or_lazy_evaluated([&]() -> ErrorOr<ByteString> { return (ByteString::must_from_utf8("__jakt_match_value"sv)); }))),type_name))))));
 {
 JaktInternal::ArrayIterator<NonnullRefPtr<typename types::CheckedStatement>> _magic = ((defaults).iterator());
 for (;;){
@@ -5324,7 +5324,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8("}\n"sv)))));
+(output,(ByteString::must_from_utf8("}\n"sv)))));
 }
 return JaktInternal::ExplicitValue<void>();
 };/*case end*/
@@ -5352,7 +5352,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8("return JaktInternal::ExplicitValue<void>();\n"sv)))));
+(output,(ByteString::must_from_utf8("return JaktInternal::ExplicitValue<void>();\n"sv)))));
 }
 else if ((!(has_default))){
 TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
@@ -5361,7 +5361,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8("VERIFY_NOT_REACHED();\n"sv)))));
+(output,(ByteString::must_from_utf8("VERIFY_NOT_REACHED();\n"sv)))));
 }
 TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 {
@@ -5369,14 +5369,14 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8("}())"sv)))));
+(output,(ByteString::must_from_utf8("}())"sv)))));
 return TRY((((((*this).control_flow_state)).apply_control_flow_macro(output,(((((*this).current_function).value()))->return_type_id),(((((*this).current_function).value()))->can_throw),cpp_match_result_type))));
 }
 }
 
 ErrorOr<ByteString> codegen::CodeGenerator::codegen_debug_description_getter(types::CheckedStruct const struct_,bool const is_inline) {
 {
-ByteString output = TRY(ByteString::from_utf8(""sv));
+ByteString output = (ByteString::must_from_utf8(""sv));
 if (((!(is_inline)) && (!(((((struct_).generic_parameters)).is_empty()))))){
 TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 {
@@ -5384,7 +5384,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8("template <"sv)))));
+(output,(ByteString::must_from_utf8("template <"sv)))));
 TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 {
 (self = TRY((((self) + (rhs)))));
@@ -5398,7 +5398,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8(">\n"sv)))));
+(output,(ByteString::must_from_utf8(">\n"sv)))));
 }
 TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 {
@@ -5406,7 +5406,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8("ErrorOr<ByteString> "sv)))));
+(output,(ByteString::must_from_utf8("ErrorOr<ByteString> "sv)))));
 if ((!(is_inline))){
 TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 {
@@ -5421,7 +5421,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8("::"sv)))));
+(output,(ByteString::must_from_utf8("::"sv)))));
 }
 TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 {
@@ -5429,14 +5429,14 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8("debug_description() const { "sv)))));
+(output,(ByteString::must_from_utf8("debug_description() const { "sv)))));
 TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 {
 (self = TRY((((self) + (rhs)))));
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8("auto builder = ByteStringBuilder::create();"sv)))));
+(output,(ByteString::must_from_utf8("auto builder = ByteStringBuilder::create();"sv)))));
 TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 {
 (self = TRY((((self) + (rhs)))));
@@ -5450,14 +5450,14 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8("{\n"sv)))));
+(output,(ByteString::must_from_utf8("{\n"sv)))));
 TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 {
 (self = TRY((((self) + (rhs)))));
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8("JaktInternal::PrettyPrint::ScopedLevelIncrease increase_indent {};\n"sv)))));
+(output,(ByteString::must_from_utf8("JaktInternal::PrettyPrint::ScopedLevelIncrease increase_indent {};\n"sv)))));
 size_t i = static_cast<size_t>(0ULL);
 {
 JaktInternal::ArrayIterator<types::CheckedField> _magic = ((((struct_).fields)).iterator());
@@ -5475,7 +5475,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8("TRY(JaktInternal::PrettyPrint::output_indentation(builder));"sv)))));
+(output,(ByteString::must_from_utf8("TRY(JaktInternal::PrettyPrint::output_indentation(builder));"sv)))));
 TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 {
 (self = TRY((((self) + (rhs)))));
@@ -5490,7 +5490,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8("\\\"{}\\\""sv)))));
+(output,(ByteString::must_from_utf8("\\\"{}\\\""sv)))));
 }
 else {
 TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
@@ -5499,7 +5499,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8("{}"sv)))));
+(output,(ByteString::must_from_utf8("{}"sv)))));
 }
 
 if (((i) != (JaktInternal::checked_sub(((((struct_).fields)).size()),static_cast<size_t>(1ULL))))){
@@ -5509,7 +5509,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8(", "sv)))));
+(output,(ByteString::must_from_utf8(", "sv)))));
 }
 TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 {
@@ -5517,7 +5517,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8("\", "sv)))));
+(output,(ByteString::must_from_utf8("\", "sv)))));
 TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 {
 (self = TRY((((self) + (rhs)))));
@@ -5535,10 +5535,10 @@ return JaktInternal::ExplicitValue(({
 auto&& __jakt_match_variant = ((((((*this).program))->get_struct(struct_id))).record_type);
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 1 /* Class */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("*"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("*"sv)));
 };/*case end*/
 default: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8(""sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8(""sv)));
 };/*case end*/
 }/*switch end*/
 }()
@@ -5553,7 +5553,7 @@ return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8(""sv)));
 }));
 };/*case end*/
 default: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8(""sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8(""sv)));
 };/*case end*/
 }/*switch end*/
 }()
@@ -5572,7 +5572,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY((((TRY((((((field_var)->name_for_codegen())).as_name_for_use())))) + (TRY(ByteString::from_utf8("));\n"sv)))))))));
+(output,TRY((((TRY((((((field_var)->name_for_codegen())).as_name_for_use())))) + ((ByteString::must_from_utf8("));\n"sv)))))))));
 ((i++));
 }
 
@@ -5585,35 +5585,35 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8("}\n"sv)))));
+(output,(ByteString::must_from_utf8("}\n"sv)))));
 TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 {
 (self = TRY((((self) + (rhs)))));
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8("TRY(builder.append(\")\"sv));"sv)))));
+(output,(ByteString::must_from_utf8("TRY(builder.append(\")\"sv));"sv)))));
 TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 {
 (self = TRY((((self) + (rhs)))));
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8("return builder.to_string();"sv)))));
+(output,(ByteString::must_from_utf8("return builder.to_string();"sv)))));
 TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 {
 (self = TRY((((self) + (rhs)))));
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8(" }\n"sv)))));
+(output,(ByteString::must_from_utf8(" }\n"sv)))));
 return output;
 }
 }
 
 ErrorOr<ByteString> codegen::CodeGenerator::codegen_lambda_block(bool const can_throw,types::CheckedBlock const block,ids::TypeId const return_type_id) {
 {
-ByteString output = TRY(ByteString::from_utf8("{\n"sv));
+ByteString output = (ByteString::must_from_utf8("{\n"sv));
 TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 {
 (self = TRY((((self) + (rhs)))));
@@ -5628,7 +5628,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8("return {};\n"sv)))));
+(output,(ByteString::must_from_utf8("return {};\n"sv)))));
 }
 TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 {
@@ -5636,7 +5636,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8("}\n"sv)))));
+(output,(ByteString::must_from_utf8("}\n"sv)))));
 return output;
 }
 }
@@ -5645,7 +5645,7 @@ ErrorOr<ByteString> codegen::CodeGenerator::codegen_match(NonnullRefPtr<typename
 {
 codegen::ControlFlowState const last_control_flow = ((*this).control_flow_state);
 (((*this).control_flow_state) = ((((*this).control_flow_state)).enter_match()));
-ByteString output = TRY(ByteString::from_utf8(""sv));
+ByteString output = (ByteString::must_from_utf8(""sv));
 NonnullRefPtr<typename types::Type> const expr_type = ((((*this).program))->get_type(((expr)->type())));
 if (((expr_type)->__jakt_init_index() == 25 /* Enum */)){
 ids::EnumId const enum_id = (expr_type)->as.Enum.value;
@@ -5675,10 +5675,10 @@ return output;
 ErrorOr<ByteString> codegen::CodeGenerator::codegen_namespace_specializations(NonnullRefPtr<types::Scope> const scope,NonnullRefPtr<types::Module> const current_module) {
 {
 if ((((((scope)->alias_path)).has_value()) || ((((scope)->import_path_if_extern)).has_value()))){
-return TRY(ByteString::from_utf8(""sv));
+return (ByteString::must_from_utf8(""sv));
 }
 JaktInternal::Set<ids::TypeId> seen_types = (TRY((Set<ids::TypeId>::create_with_values({}))));
-ByteString output = TRY(ByteString::from_utf8(""sv));
+ByteString output = (ByteString::must_from_utf8(""sv));
 if (((((scope)->namespace_name)).has_value())){
 TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 {
@@ -5686,7 +5686,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY((((TRY((((TRY(ByteString::from_utf8("namespace "sv))) + ((((scope)->namespace_name).value())))))) + (TRY(ByteString::from_utf8(" {\n"sv)))))))));
+(output,TRY((((TRY(((((ByteString::must_from_utf8("namespace "sv))) + ((((scope)->namespace_name).value())))))) + ((ByteString::must_from_utf8(" {\n"sv)))))))));
 }
 {
 JaktInternal::ArrayIterator<bool> _magic = (((TRY((DynamicArray<bool>::create_with({false, true}))))).iterator());
@@ -5914,7 +5914,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8("}\n"sv)))));
+(output,(ByteString::must_from_utf8("}\n"sv)))));
 }
 return output;
 }
@@ -5929,7 +5929,7 @@ if ((((((struct_).definition_linkage)).__jakt_init_index() == 1 /* External */) 
 return (!(((self) == (rhs))));
 }
 }
-(((struct_).name),TRY(ByteString::from_utf8("Optional"sv))))){
+(((struct_).name),(ByteString::must_from_utf8("Optional"sv))))){
 return dependencies;
 }
 if ((((((struct_).record_type)).__jakt_init_index() == 1 /* Class */) && (!(top_level)))){
@@ -6035,7 +6035,7 @@ return dependencies;
 
 ErrorOr<ByteString> codegen::CodeGenerator::codegen_enum_type(ids::EnumId const id,bool const as_namespace) {
 {
-ByteString output = TRY(ByteString::from_utf8(""sv));
+ByteString output = (ByteString::must_from_utf8(""sv));
 NonnullRefPtr<types::Module> const type_module = ((((*this).program))->get_module(((id).module)));
 types::CheckedEnum const checked_enum = ((((*this).program))->get_enum(id));
 if (((!(as_namespace)) && ((checked_enum).is_boxed))){
@@ -6045,7 +6045,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8("NonnullRefPtr<"sv)))));
+(output,(ByteString::must_from_utf8("NonnullRefPtr<"sv)))));
 ByteString const qualifier = TRY((((*this).codegen_namespace_qualifier(((checked_enum).scope_id),true,JaktInternal::OptionalNone(),JaktInternal::OptionalNone()))));
 if ((!(((qualifier).is_empty())))){
 TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
@@ -6054,7 +6054,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8("typename "sv)))));
+(output,(ByteString::must_from_utf8("typename "sv)))));
 TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 {
 (self = TRY((((self) + (rhs)))));
@@ -6076,7 +6076,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8(">"sv)))));
+(output,(ByteString::must_from_utf8(">"sv)))));
 }
 else {
 ByteString const qualifier = TRY((((*this).codegen_namespace_qualifier(((checked_enum).scope_id),true,JaktInternal::OptionalNone(),JaktInternal::OptionalNone()))));
@@ -6131,21 +6131,21 @@ return JaktInternal::ExplicitValue(TRY((((*this).codegen_expression(expression))
 
 ErrorOr<ByteString> codegen::CodeGenerator::codegen_checked_binary_op_assignment(NonnullRefPtr<typename types::CheckedExpression> const lhs,NonnullRefPtr<typename types::CheckedExpression> const rhs,parser::BinaryOperator const op,ids::TypeId const type_id) {
 {
-ByteString output = TRY(ByteString::from_utf8(""sv));
+ByteString output = (ByteString::must_from_utf8(""sv));
 TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 {
 (self = TRY((((self) + (rhs)))));
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8("{"sv)))));
+(output,(ByteString::must_from_utf8("{"sv)))));
 TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 {
 (self = TRY((((self) + (rhs)))));
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8("auto& _jakt_ref = "sv)))));
+(output,(ByteString::must_from_utf8("auto& _jakt_ref = "sv)))));
 TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 {
 (self = TRY((((self) + (rhs)))));
@@ -6159,14 +6159,14 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8(";"sv)))));
+(output,(ByteString::must_from_utf8(";"sv)))));
 TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 {
 (self = TRY((((self) + (rhs)))));
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8("_jakt_ref = JaktInternal::"sv)))));
+(output,(ByteString::must_from_utf8("_jakt_ref = JaktInternal::"sv)))));
 TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 {
 (self = TRY((((self) + (rhs)))));
@@ -6178,19 +6178,19 @@ return {};
 auto&& __jakt_match_variant = op;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 27 /* AddAssign */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("checked_add"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("checked_add"sv)));
 };/*case end*/
 case 28 /* SubtractAssign */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("checked_sub"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("checked_sub"sv)));
 };/*case end*/
 case 29 /* MultiplyAssign */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("checked_mul"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("checked_mul"sv)));
 };/*case end*/
 case 31 /* DivideAssign */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("checked_div"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("checked_div"sv)));
 };/*case end*/
 case 30 /* ModuloAssign */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("checked_mod"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("checked_mod"sv)));
 };/*case end*/
 default: {
 {
@@ -6210,7 +6210,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8("<"sv)))));
+(output,(ByteString::must_from_utf8("<"sv)))));
 TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 {
 (self = TRY((((self) + (rhs)))));
@@ -6224,7 +6224,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8(">(_jakt_ref, "sv)))));
+(output,(ByteString::must_from_utf8(">(_jakt_ref, "sv)))));
 TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 {
 (self = TRY((((self) + (rhs)))));
@@ -6238,27 +6238,27 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8(");"sv)))));
+(output,(ByteString::must_from_utf8(");"sv)))));
 TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 {
 (self = TRY((((self) + (rhs)))));
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8("}"sv)))));
+(output,(ByteString::must_from_utf8("}"sv)))));
 return output;
 }
 }
 
 ErrorOr<ByteString> codegen::CodeGenerator::codegen_struct(types::CheckedStruct const struct_) {
 {
-ByteString output = TRY(ByteString::from_utf8(""sv));
+ByteString output = (ByteString::must_from_utf8(""sv));
 if (((((struct_).definition_linkage)).__jakt_init_index() == 1 /* External */)){
-return TRY(ByteString::from_utf8(""sv));
+return (ByteString::must_from_utf8(""sv));
 }
 bool struct_is_generic = false;
 JaktInternal::DynamicArray<ByteString> generic_parameter_names = (TRY((DynamicArray<ByteString>::create_with({}))));
-ByteString template_parameters = TRY(ByteString::from_utf8(""sv));
+ByteString template_parameters = (ByteString::must_from_utf8(""sv));
 if ((!(((((struct_).generic_parameters)).is_empty())))){
 (struct_is_generic = true);
 (template_parameters = TRY((((*this).codegen_template_parameter_names(((struct_).generic_parameters),((generic_parameter_names)))))));
@@ -6276,7 +6276,7 @@ auto&& __jakt_match_variant = ((struct_).record_type);
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 1 /* Class */: {
 {
-ByteString class_name_with_generics = TRY(ByteString::from_utf8(""sv));
+ByteString class_name_with_generics = (ByteString::must_from_utf8(""sv));
 TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 {
 (self = TRY((((self) + (rhs)))));
@@ -6301,7 +6301,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(class_name_with_generics,TRY(ByteString::from_utf8(", "sv)))));
+(class_name_with_generics,(ByteString::must_from_utf8(", "sv)))));
 }
 else {
 TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
@@ -6310,7 +6310,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(class_name_with_generics,TRY(ByteString::from_utf8("<"sv)))));
+(class_name_with_generics,(ByteString::must_from_utf8("<"sv)))));
 (first = false);
 }
 
@@ -6333,7 +6333,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(class_name_with_generics,TRY(ByteString::from_utf8(">"sv)))));
+(class_name_with_generics,(ByteString::must_from_utf8(">"sv)))));
 }
 TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 {
@@ -6376,7 +6376,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8("{\n"sv)))));
+(output,(ByteString::must_from_utf8("{\n"sv)))));
 NonnullRefPtr<types::Scope> const scope = TRY((((((*this).program))->get_scope(((struct_).scope_id)))));
 bool has_destructor = false;
 {
@@ -6422,7 +6422,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8("  public:\n"sv)))));
+(output,(ByteString::must_from_utf8("  public:\n"sv)))));
 TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 {
 (self = TRY((((self) + (rhs)))));
@@ -6458,26 +6458,26 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8(" {\n"sv)))));
+(output,(ByteString::must_from_utf8(" {\n"sv)))));
 TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 {
 (self = TRY((((self) + (rhs)))));
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8("  public:\n"sv)))));
+(output,(ByteString::must_from_utf8("  public:\n"sv)))));
 }
 return JaktInternal::ExplicitValue<void>();
 };/*case end*/
 case 3 /* SumEnum */: {
 {
-utility::todo(TRY(ByteString::from_utf8("codegen_struct SumEnum"sv)));
+utility::todo((ByteString::must_from_utf8("codegen_struct SumEnum"sv)));
 }
 return JaktInternal::ExplicitValue<void>();
 };/*case end*/
 case 2 /* ValueEnum */: {
 {
-utility::todo(TRY(ByteString::from_utf8("codegen_struct ValueEnum"sv)));
+utility::todo((ByteString::must_from_utf8("codegen_struct ValueEnum"sv)));
 }
 return JaktInternal::ExplicitValue<void>();
 };/*case end*/
@@ -6507,7 +6507,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8("public: "sv)))));
+(output,(ByteString::must_from_utf8("public: "sv)))));
 }
 return JaktInternal::ExplicitValue<void>();
 };/*case end*/
@@ -6519,7 +6519,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8("public: "sv)))));
+(output,(ByteString::must_from_utf8("public: "sv)))));
 }
 return JaktInternal::ExplicitValue<void>();
 };/*case end*/
@@ -6531,7 +6531,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8("private: "sv)))));
+(output,(ByteString::must_from_utf8("private: "sv)))));
 }
 return JaktInternal::ExplicitValue<void>();
 };/*case end*/
@@ -6570,7 +6570,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8(" "sv)))));
+(output,(ByteString::must_from_utf8(" "sv)))));
 TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 {
 (self = TRY((((self) + (rhs)))));
@@ -6584,7 +6584,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8(";"sv)))));
+(output,(ByteString::must_from_utf8(";"sv)))));
 }
 
 }
@@ -6646,7 +6646,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8("\n"sv)))));
+(output,(ByteString::must_from_utf8("\n"sv)))));
 }
 else if (((((function)->type)).__jakt_init_index() == 2 /* ImplicitConstructor */)){
 if (((((struct_).generic_parameters)).is_empty())){
@@ -6674,7 +6674,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8("\n"sv)))));
+(output,(ByteString::must_from_utf8("\n"sv)))));
 }
 else if (((((function)->force_inline)).__jakt_init_index() == 1 /* MakeDefinitionAvailable */)){
 TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
@@ -6723,7 +6723,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8("ErrorOr<ByteString> debug_description() const;\n"sv)))));
+(output,(ByteString::must_from_utf8("ErrorOr<ByteString> debug_description() const;\n"sv)))));
 }
 else {
 TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
@@ -6741,7 +6741,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8("};"sv)))));
+(output,(ByteString::must_from_utf8("};"sv)))));
 TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 {
 (self = TRY((((self) + (rhs)))));
@@ -6768,7 +6768,7 @@ return type_id;
 ErrorOr<ByteString> codegen::CodeGenerator::codegen_function(NonnullRefPtr<types::CheckedFunction> const function,bool const as_method) {
 {
 if (((function)->is_comptime)){
-return TRY(ByteString::from_utf8(""sv));
+return (ByteString::must_from_utf8(""sv));
 }
 return TRY((((*this).codegen_function_in_namespace(function,JaktInternal::OptionalNone(),as_method,false,JaktInternal::OptionalNone()))));
 }
@@ -6776,9 +6776,9 @@ return TRY((((*this).codegen_function_in_namespace(function,JaktInternal::Option
 
 ErrorOr<ByteString> codegen::CodeGenerator::codegen_generic_type_instance(ids::StructId const id,JaktInternal::DynamicArray<ids::TypeId> const args,bool const as_namespace) {
 {
-ByteString output = TRY(ByteString::from_utf8(""sv));
+ByteString output = (ByteString::must_from_utf8(""sv));
 NonnullRefPtr<types::Module> const type_module = ((((*this).program))->get_module(((id).module)));
-ByteString namespace_ = TRY(ByteString::from_utf8(""sv));
+ByteString namespace_ = (ByteString::must_from_utf8(""sv));
 if (((type_module)->is_prelude())){
 TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 {
@@ -6786,7 +6786,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(namespace_,TRY(ByteString::from_utf8("JaktInternal::"sv)))));
+(namespace_,(ByteString::must_from_utf8("JaktInternal::"sv)))));
 }
 JaktInternal::Optional<ids::StructId> const inner_weak_ptr_struct_id = TRY((((((*this).program))->check_and_extract_weak_ptr(id,args))));
 if (((inner_weak_ptr_struct_id).has_value())){
@@ -6796,7 +6796,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8("WeakPtr<"sv)))));
+(output,(ByteString::must_from_utf8("WeakPtr<"sv)))));
 TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 {
 (self = TRY((((self) + (rhs)))));
@@ -6826,7 +6826,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8(">"sv)))));
+(output,(ByteString::must_from_utf8(">"sv)))));
 }
 else {
 types::CheckedStruct const struct_ = ((((*this).program))->get_struct(id));
@@ -6838,7 +6838,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8("NonnullRefPtr<"sv)))));
+(output,(ByteString::must_from_utf8("NonnullRefPtr<"sv)))));
 }
 TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 {
@@ -6867,7 +6867,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8("<"sv)))));
+(output,(ByteString::must_from_utf8("<"sv)))));
 bool first = true;
 {
 JaktInternal::ArrayIterator<ids::TypeId> _magic = ((args).iterator());
@@ -6885,7 +6885,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8(","sv)))));
+(output,(ByteString::must_from_utf8(","sv)))));
 }
 else {
 (first = false);
@@ -6909,7 +6909,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8(">"sv)))));
+(output,(ByteString::must_from_utf8(">"sv)))));
 if (acquired_by_ref){
 TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 {
@@ -6917,7 +6917,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8(">"sv)))));
+(output,(ByteString::must_from_utf8(">"sv)))));
 }
 }
 
@@ -6932,7 +6932,7 @@ return ({
 auto&& __jakt_match_variant = *((((*this).program))->get_type(id));
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 13 /* JaktString */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("ByteString"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("ByteString"sv)));
 };/*case end*/
 case 20 /* GenericInstance */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.GenericInstance;ids::StructId const& id = __jakt_match_value.id;
@@ -6942,7 +6942,7 @@ __jakt_var_629 = ({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<JaktInternal::Optional<ByteString>,ErrorOr<JaktInternal::Optional<ByteString>>>{
 auto __jakt_enum_value = (((((struct_).record_type)).__jakt_init_index() == 1 /* Class */));
 if (__jakt_enum_value == true) {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("NonnullRefPtr"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("NonnullRefPtr"sv)));
 }
 else if (__jakt_enum_value == false) {
 return JaktInternal::ExplicitValue(TRY((((((struct_).name_for_codegen())).as_name_for_use()))));
@@ -6965,7 +6965,7 @@ __jakt_var_630 = ({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<JaktInternal::Optional<ByteString>,ErrorOr<JaktInternal::Optional<ByteString>>>{
 auto __jakt_enum_value = (((((struct_).record_type)).__jakt_init_index() == 1 /* Class */));
 if (__jakt_enum_value == true) {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("NonnullRefPtr"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("NonnullRefPtr"sv)));
 }
 else if (__jakt_enum_value == false) {
 return JaktInternal::ExplicitValue(TRY((((((struct_).name_for_codegen())).as_name_for_use()))));
@@ -6988,7 +6988,7 @@ __jakt_var_631 = ({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<JaktInternal::Optional<ByteString>,ErrorOr<JaktInternal::Optional<ByteString>>>{
 auto __jakt_enum_value = (((((struct_).record_type)).__jakt_init_index() == 1 /* Class */));
 if (__jakt_enum_value == true) {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("NonnullRefPtr"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("NonnullRefPtr"sv)));
 }
 else if (__jakt_enum_value == false) {
 return JaktInternal::ExplicitValue(TRY((((((struct_).name_for_codegen())).as_name_for_use()))));
@@ -7015,7 +7015,7 @@ __jakt_var_632 = ({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<JaktInternal::Optional<ByteString>,ErrorOr<JaktInternal::Optional<ByteString>>>{
 auto __jakt_enum_value = (((enum_).is_boxed));
 if (__jakt_enum_value == true) {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("NonnullRefPtr"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("NonnullRefPtr"sv)));
 }
 else if (__jakt_enum_value == false) {
 return JaktInternal::ExplicitValue(((enum_).name));
@@ -7038,7 +7038,7 @@ __jakt_var_633 = ({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<JaktInternal::Optional<ByteString>,ErrorOr<JaktInternal::Optional<ByteString>>>{
 auto __jakt_enum_value = (((enum_).is_boxed));
 if (__jakt_enum_value == true) {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("NonnullRefPtr"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("NonnullRefPtr"sv)));
 }
 else if (__jakt_enum_value == false) {
 return JaktInternal::ExplicitValue(((enum_).name));
@@ -7068,7 +7068,7 @@ return JaktInternal::ExplicitValue(JaktInternal::OptionalNone());
 
 ErrorOr<ByteString> codegen::CodeGenerator::codegen_enum_debug_description_getter(types::CheckedEnum const enum_,bool const is_inline) {
 {
-ByteString output = TRY(ByteString::from_utf8(""sv));
+ByteString output = (ByteString::must_from_utf8(""sv));
 if (((!(is_inline)) && (!(((((enum_).generic_parameters)).is_empty()))))){
 TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 {
@@ -7076,7 +7076,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8("template <"sv)))));
+(output,(ByteString::must_from_utf8("template <"sv)))));
 TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 {
 (self = TRY((((self) + (rhs)))));
@@ -7090,7 +7090,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8(">\n"sv)))));
+(output,(ByteString::must_from_utf8(">\n"sv)))));
 }
 TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 {
@@ -7098,7 +7098,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8("ErrorOr<ByteString> "sv)))));
+(output,(ByteString::must_from_utf8("ErrorOr<ByteString> "sv)))));
 if ((!(is_inline))){
 TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 {
@@ -7113,7 +7113,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8("::"sv)))));
+(output,(ByteString::must_from_utf8("::"sv)))));
 }
 TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 {
@@ -7121,21 +7121,21 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8("debug_description() const {\n"sv)))));
+(output,(ByteString::must_from_utf8("debug_description() const {\n"sv)))));
 TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 {
 (self = TRY((((self) + (rhs)))));
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8("auto builder = ByteStringBuilder::create();\n"sv)))));
+(output,(ByteString::must_from_utf8("auto builder = ByteStringBuilder::create();\n"sv)))));
 TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 {
 (self = TRY((((self) + (rhs)))));
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8("switch (this->__jakt_init_index()) {"sv)))));
+(output,(ByteString::must_from_utf8("switch (this->__jakt_init_index()) {"sv)))));
 size_t const common_field_count = ((((enum_).fields)).size());
 {
 JaktInternal::Range<size_t> _magic = (JaktInternal::Range<size_t>{static_cast<size_t>(static_cast<size_t>(0ULL)),static_cast<size_t>(((((enum_).variants)).size()))});
@@ -7182,21 +7182,21 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8("TRY(builder.append(\"(\"sv));\n"sv)))));
+(output,(ByteString::must_from_utf8("TRY(builder.append(\"(\"sv));\n"sv)))));
 TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 {
 (self = TRY((((self) + (rhs)))));
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8("{\n"sv)))));
+(output,(ByteString::must_from_utf8("{\n"sv)))));
 TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 {
 (self = TRY((((self) + (rhs)))));
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8("JaktInternal::PrettyPrint::ScopedLevelIncrease increase_indent {};\n"sv)))));
+(output,(ByteString::must_from_utf8("JaktInternal::PrettyPrint::ScopedLevelIncrease increase_indent {};\n"sv)))));
 size_t i = static_cast<size_t>(0ULL);
 {
 JaktInternal::ArrayIterator<ids::VarId> _magic = ((fields).iterator());
@@ -7213,7 +7213,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8("TRY(JaktInternal::PrettyPrint::output_indentation(builder));\n"sv)))));
+(output,(ByteString::must_from_utf8("TRY(JaktInternal::PrettyPrint::output_indentation(builder));\n"sv)))));
 NonnullRefPtr<types::CheckedVariable> const var = ((((*this).program))->get_variable(field));
 if (TRY((((((*this).program))->is_string(((var)->type_id)))))){
 TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
@@ -7241,7 +7241,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8(", "sv)))));
+(output,(ByteString::must_from_utf8(", "sv)))));
 }
 if ([](size_t const& self, size_t rhs) -> bool {
 {
@@ -7284,14 +7284,14 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8("}\n"sv)))));
+(output,(ByteString::must_from_utf8("}\n"sv)))));
 TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 {
 (self = TRY((((self) + (rhs)))));
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8("TRY(builder.append(\")\"sv));\n"sv)))));
+(output,(ByteString::must_from_utf8("TRY(builder.append(\")\"sv));\n"sv)))));
 }
 return JaktInternal::ExplicitValue<void>();
 };/*case end*/
@@ -7319,7 +7319,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8("TRY(builder.appendff(\"(\\\"{}\\\")\", that.value));\n"sv)))));
+(output,(ByteString::must_from_utf8("TRY(builder.appendff(\"(\\\"{}\\\")\", that.value));\n"sv)))));
 }
 else {
 TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
@@ -7328,7 +7328,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8("TRY(builder.appendff(\"({})\", that.value));\n"sv)))));
+(output,(ByteString::must_from_utf8("TRY(builder.appendff(\"({})\", that.value));\n"sv)))));
 }
 
 }
@@ -7363,7 +7363,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8("break;}\n"sv)))));
+(output,(ByteString::must_from_utf8("break;}\n"sv)))));
 }
 
 }
@@ -7375,7 +7375,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8("}\nreturn builder.to_string();\n}\n"sv)))));
+(output,(ByteString::must_from_utf8("}\nreturn builder.to_string();\n}\n"sv)))));
 return output;
 }
 }
@@ -7401,7 +7401,7 @@ auto&& __jakt_match_value = __jakt_match_variant.as.Range;JaktInternal::Optional
 JaktInternal::Optional<NonnullRefPtr<typename types::CheckedExpression>> const& to = __jakt_match_value.to;
 ids::TypeId const& type_id = __jakt_match_value.type_id;
 return JaktInternal::ExplicitValue(({ Optional<ByteString> __jakt_var_635; {
-ByteString output = TRY(ByteString::from_utf8(""sv));
+ByteString output = (ByteString::must_from_utf8(""sv));
 NonnullRefPtr<typename types::Type> const type = ((((*this).program))->get_type(type_id));
 ids::TypeId const index_type = ({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<ids::TypeId, ErrorOr<ByteString>>{
@@ -7414,7 +7414,7 @@ return JaktInternal::ExplicitValue(((args)[static_cast<i64>(0LL)]));
 };/*case end*/
 default: {
 {
-utility::panic(TRY(ByteString::from_utf8("Internal error: range expression doesn't have Range type"sv)));
+utility::panic((ByteString::must_from_utf8("Internal error: range expression doesn't have Range type"sv)));
 }
 };/*case end*/
 }/*switch end*/
@@ -7430,7 +7430,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8("("sv)))));
+(output,(ByteString::must_from_utf8("("sv)))));
 TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 {
 (self = TRY((((self) + (rhs)))));
@@ -7444,14 +7444,14 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8("{"sv)))));
+(output,(ByteString::must_from_utf8("{"sv)))));
 TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 {
 (self = TRY((((self) + (rhs)))));
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8("static_cast<"sv)))));
+(output,(ByteString::must_from_utf8("static_cast<"sv)))));
 TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 {
 (self = TRY((((self) + (rhs)))));
@@ -7465,7 +7465,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8(">("sv)))));
+(output,(ByteString::must_from_utf8(">("sv)))));
 if (((from).has_value())){
 TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 {
@@ -7482,7 +7482,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8("0LL"sv)))));
+(output,(ByteString::must_from_utf8("0LL"sv)))));
 }
 
 TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
@@ -7491,7 +7491,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8("),static_cast<"sv)))));
+(output,(ByteString::must_from_utf8("),static_cast<"sv)))));
 TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 {
 (self = TRY((((self) + (rhs)))));
@@ -7505,7 +7505,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8(">("sv)))));
+(output,(ByteString::must_from_utf8(">("sv)))));
 if (((to).has_value())){
 TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 {
@@ -7522,7 +7522,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8("9223372036854775807LL"sv)))));
+(output,(ByteString::must_from_utf8("9223372036854775807LL"sv)))));
 }
 
 TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
@@ -7531,60 +7531,57 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8(")})"sv)))));
+(output,(ByteString::must_from_utf8(")})"sv)))));
 __jakt_var_635 = output; goto __jakt_label_540;
 
 }
 __jakt_label_540:; __jakt_var_635.release_value(); }));
 };/*case end*/
 case 25 /* OptionalNone */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("JaktInternal::OptionalNone()"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("JaktInternal::OptionalNone()"sv)));
 };/*case end*/
 case 26 /* OptionalSome */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.OptionalSome;NonnullRefPtr<typename types::CheckedExpression> const& expr = __jakt_match_value.expr;
 ids::TypeId const& type_id = __jakt_match_value.type_id;
-return JaktInternal::ExplicitValue(TRY((((TRY((((TRY((((TRY((((TRY(ByteString::from_utf8("static_cast<"sv))) + (TRY((((*this).codegen_type(type_id))))))))) + (TRY(ByteString::from_utf8(">("sv))))))) + (TRY((((*this).codegen_expression(expr))))))))) + (TRY(ByteString::from_utf8(")"sv)))))));
+return JaktInternal::ExplicitValue(TRY((((TRY((((TRY((((TRY(((((ByteString::must_from_utf8("static_cast<"sv))) + (TRY((((*this).codegen_type(type_id))))))))) + ((ByteString::must_from_utf8(">("sv))))))) + (TRY((((*this).codegen_expression(expr))))))))) + ((ByteString::must_from_utf8(")"sv)))))));
 };/*case end*/
 case 27 /* ForcedUnwrap */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.ForcedUnwrap;NonnullRefPtr<typename types::CheckedExpression> const& expr = __jakt_match_value.expr;
 ids::TypeId const& type_id = __jakt_match_value.type_id;
-return JaktInternal::ExplicitValue(TRY((((TRY((((TRY(ByteString::from_utf8("("sv))) + (TRY((((*this).codegen_expression(expr))))))))) + (TRY(ByteString::from_utf8(".value())"sv)))))));
+return JaktInternal::ExplicitValue(TRY((((TRY(((((ByteString::must_from_utf8("("sv))) + (TRY((((*this).codegen_expression(expr))))))))) + ((ByteString::must_from_utf8(".value())"sv)))))));
 };/*case end*/
 case 2 /* QuotedString */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.QuotedString;types::CheckedStringLiteral const& val = __jakt_match_value.val;
 return JaktInternal::ExplicitValue(({ Optional<ByteString> __jakt_var_636; {
 ByteString const original_string = ((val).to_string());
-ByteString const escaped_value = ((original_string).replace(TRY(ByteString::from_utf8("\n"sv)),TRY(ByteString::from_utf8("\\n"sv))));
+ByteString const escaped_value = ((original_string).replace((ByteString::must_from_utf8("\n"sv)),(ByteString::must_from_utf8("\\n"sv))));
 __jakt_var_636 = ({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<ByteString,ErrorOr<ByteString>>{
 auto __jakt_enum_value = (((((val).type_id)).equals(types::builtin(types::BuiltinType::JaktString()))));
 if (__jakt_enum_value == true) {
-return JaktInternal::ExplicitValue(TRY((((TRY((((TRY(ByteString::from_utf8("Jakt::ByteString(\""sv))) + (escaped_value))))) + (TRY(ByteString::from_utf8("\"sv)"sv)))))));
+return JaktInternal::ExplicitValue(TRY((((TRY(((((ByteString::must_from_utf8("Jakt::ByteString(\""sv))) + (escaped_value))))) + ((ByteString::must_from_utf8("\"sv)"sv)))))));
 }
 else if (__jakt_enum_value == false) {
 return JaktInternal::ExplicitValue(({ Optional<ByteString> __jakt_var_637; {
-JaktInternal::Optional<JaktInternal::DynamicArray<ids::FunctionId>> const ids = TRY((((((*this).program))->find_functions_with_name_in_scope(TRY((((((*this).program))->find_type_scope_id(((val).type_id))))),TRY(ByteString::from_utf8("from_string_literal"sv)),false,JaktInternal::OptionalNone()))));
+JaktInternal::Optional<JaktInternal::DynamicArray<ids::FunctionId>> const ids = TRY((((((*this).program))->find_functions_with_name_in_scope(TRY((((((*this).program))->find_type_scope_id(((val).type_id))))),(ByteString::must_from_utf8("from_string_literal"sv)),false,JaktInternal::OptionalNone()))));
 if (((!(((ids).has_value()))) || (((ids.value())).is_empty()))){
-utility::panic(TRY(ByteString::from_utf8("Internal error: couldn't find a 'from_string_literal' function despite passing typecheck"sv)));
+utility::panic((ByteString::must_from_utf8("Internal error: couldn't find a 'from_string_literal' function despite passing typecheck"sv)));
 }
 ByteString const name = TRY((((((((((*this).program))->get_function((((ids.value()))[static_cast<i64>(0LL)]))))->name_for_codegen())).as_name_for_use())));
-ByteString const error_handler = "";
-/*
-({
+ByteString const error_handler = ({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<ByteString,ErrorOr<ByteString>>{
 auto __jakt_enum_value = (((val).may_throw));
 if (__jakt_enum_value == true) {
 return JaktInternal::ExplicitValue(TRY((((*this).current_error_handler()))));
 }
 else {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8(""sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8(""sv)));
 }
 }());
     if (_jakt_value.is_return())
         return _jakt_value.release_return();
     _jakt_value.release_value();
 });
-*/
 __jakt_var_637 = TRY((__jakt_format((StringView::from_string_literal("{}({}::{}(\"{}\"sv))"sv)),error_handler,TRY((((*this).codegen_type(((val).type_id))))),name,escaped_value))); goto __jakt_label_542;
 
 }
@@ -7602,15 +7599,15 @@ __jakt_label_541:; __jakt_var_636.release_value(); }));
 };/*case end*/
 case 3 /* ByteConstant */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.ByteConstant;ByteString const& val = __jakt_match_value.val;
-return JaktInternal::ExplicitValue(TRY((((TRY((((TRY(ByteString::from_utf8("static_cast<u8>(u8'"sv))) + (val))))) + (TRY(ByteString::from_utf8("')"sv)))))));
+return JaktInternal::ExplicitValue(TRY((((TRY(((((ByteString::must_from_utf8("static_cast<u8>(u8'"sv))) + (val))))) + ((ByteString::must_from_utf8("')"sv)))))));
 };/*case end*/
 case 5 /* CCharacterConstant */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.CCharacterConstant;ByteString const& val = __jakt_match_value.val;
-return JaktInternal::ExplicitValue(TRY((((TRY((((TRY(ByteString::from_utf8("'"sv))) + (val))))) + (TRY(ByteString::from_utf8("'"sv)))))));
+return JaktInternal::ExplicitValue(TRY((((TRY(((((ByteString::must_from_utf8("'"sv))) + (val))))) + ((ByteString::must_from_utf8("'"sv)))))));
 };/*case end*/
 case 4 /* CharacterConstant */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.CharacterConstant;ByteString const& val = __jakt_match_value.val;
-return JaktInternal::ExplicitValue(TRY((((TRY((((TRY(ByteString::from_utf8("static_cast<u32>(U'"sv))) + (val))))) + (TRY(ByteString::from_utf8("')"sv)))))));
+return JaktInternal::ExplicitValue(TRY((((TRY(((((ByteString::must_from_utf8("static_cast<u32>(U'"sv))) + (val))))) + ((ByteString::must_from_utf8("')"sv)))))));
 };/*case end*/
 case 24 /* Var */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Var;NonnullRefPtr<types::CheckedVariable> const& var = __jakt_match_value.var;
@@ -7619,8 +7616,8 @@ ByteString const name = TRY((((((var)->name_for_codegen())).as_name_for_use())))
 __jakt_var_638 = ({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<ByteString,ErrorOr<ByteString>>{
 auto __jakt_enum_value = (name);
-if (__jakt_enum_value == TRY(ByteString::from_utf8("this"sv))) {
-return JaktInternal::ExplicitValue(TRY((((*this).this_replacement).try_value_or_lazy_evaluated([&]() -> ErrorOr<ByteString> { return TRY(ByteString::from_utf8("*this"sv)); }))));
+if (__jakt_enum_value == (ByteString::must_from_utf8("this"sv))) {
+return JaktInternal::ExplicitValue(TRY((((*this).this_replacement).try_value_or_lazy_evaluated([&]() -> ErrorOr<ByteString> { return (ByteString::must_from_utf8("*this"sv)); }))));
 }
 else {
 return JaktInternal::ExplicitValue(name);
@@ -7637,12 +7634,12 @@ __jakt_label_543:; __jakt_var_638.release_value(); }));
 case 13 /* IndexedExpression */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.IndexedExpression;NonnullRefPtr<typename types::CheckedExpression> const& expr = __jakt_match_value.expr;
 NonnullRefPtr<typename types::CheckedExpression> const& index = __jakt_match_value.index;
-return JaktInternal::ExplicitValue(TRY((((TRY((((TRY((((TRY((((TRY(ByteString::from_utf8("(("sv))) + (TRY((((*this).codegen_expression(expr))))))))) + (TRY(ByteString::from_utf8(")["sv))))))) + (TRY((((*this).codegen_expression(index))))))))) + (TRY(ByteString::from_utf8("])"sv)))))));
+return JaktInternal::ExplicitValue(TRY((((TRY((((TRY((((TRY(((((ByteString::must_from_utf8("(("sv))) + (TRY((((*this).codegen_expression(expr))))))))) + ((ByteString::must_from_utf8(")["sv))))))) + (TRY((((*this).codegen_expression(index))))))))) + ((ByteString::must_from_utf8("])"sv)))))));
 };/*case end*/
 case 14 /* IndexedDictionary */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.IndexedDictionary;NonnullRefPtr<typename types::CheckedExpression> const& expr = __jakt_match_value.expr;
 NonnullRefPtr<typename types::CheckedExpression> const& index = __jakt_match_value.index;
-return JaktInternal::ExplicitValue(TRY((((TRY((((TRY((((TRY((((TRY(ByteString::from_utf8("(("sv))) + (TRY((((*this).codegen_expression(expr))))))))) + (TRY(ByteString::from_utf8(")["sv))))))) + (TRY((((*this).codegen_expression(index))))))))) + (TRY(ByteString::from_utf8("])"sv)))))));
+return JaktInternal::ExplicitValue(TRY((((TRY((((TRY((((TRY(((((ByteString::must_from_utf8("(("sv))) + (TRY((((*this).codegen_expression(expr))))))))) + ((ByteString::must_from_utf8(")["sv))))))) + (TRY((((*this).codegen_expression(index))))))))) + ((ByteString::must_from_utf8("])"sv)))))));
 };/*case end*/
 case 15 /* IndexedTuple */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.IndexedTuple;NonnullRefPtr<typename types::CheckedExpression> const& expr = __jakt_match_value.expr;
@@ -7670,7 +7667,7 @@ ByteString const& name = __jakt_match_value.name;
 JaktInternal::Optional<ids::VarId> const& index = __jakt_match_value.index;
 bool const& is_optional = __jakt_match_value.is_optional;
 return JaktInternal::ExplicitValue(({ Optional<ByteString> __jakt_var_639; {
-ByteString output = TRY(ByteString::from_utf8(""sv));
+ByteString output = (ByteString::must_from_utf8(""sv));
 ByteString const object = TRY((((*this).codegen_expression(expr))));
 TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 {
@@ -7678,7 +7675,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8("(("sv)))));
+(output,(ByteString::must_from_utf8("(("sv)))));
 TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 {
 (self = TRY((((self) + (rhs)))));
@@ -7692,7 +7689,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8(")"sv)))));
+(output,(ByteString::must_from_utf8(")"sv)))));
 ByteString const var_name = ({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<ByteString,ErrorOr<ByteString>>{
 auto __jakt_enum_value = (((index).has_value()));
@@ -7721,7 +7718,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8("->"sv)))));
+(output,(ByteString::must_from_utf8("->"sv)))));
 }
 return JaktInternal::ExplicitValue<void>();
 };/*case end*/
@@ -7734,14 +7731,14 @@ if ((((((structure).record_type)).__jakt_init_index() == 1 /* Class */) && [](By
 return (!(((self) == (rhs))));
 }
 }
-(object,TRY(ByteString::from_utf8("*this"sv))))){
+(object,(ByteString::must_from_utf8("*this"sv))))){
 TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 {
 (self = TRY((((self) + (rhs)))));
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8("->"sv)))));
+(output,(ByteString::must_from_utf8("->"sv)))));
 }
 else {
 TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
@@ -7750,7 +7747,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8("."sv)))));
+(output,(ByteString::must_from_utf8("."sv)))));
 }
 
 }
@@ -7765,14 +7762,14 @@ if ((((((structure).record_type)).__jakt_init_index() == 1 /* Class */) && [](By
 return (!(((self) == (rhs))));
 }
 }
-(object,TRY(ByteString::from_utf8("*this"sv))))){
+(object,(ByteString::must_from_utf8("*this"sv))))){
 TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 {
 (self = TRY((((self) + (rhs)))));
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8("->"sv)))));
+(output,(ByteString::must_from_utf8("->"sv)))));
 }
 else {
 TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
@@ -7781,7 +7778,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8("."sv)))));
+(output,(ByteString::must_from_utf8("."sv)))));
 }
 
 }
@@ -7795,7 +7792,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8("."sv)))));
+(output,(ByteString::must_from_utf8("."sv)))));
 }
 return JaktInternal::ExplicitValue<void>();
 };/*case end*/
@@ -7813,8 +7810,8 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8("map([](auto& _value) { return _value"sv)))));
-ByteString access_operator = TRY(ByteString::from_utf8("."sv));
+(output,(ByteString::must_from_utf8("map([](auto& _value) { return _value"sv)))));
+ByteString access_operator = (ByteString::must_from_utf8("."sv));
 if (((expression_type)->__jakt_init_index() == 20 /* GenericInstance */)){
 JaktInternal::DynamicArray<ids::TypeId> const args = (expression_type)->as.GenericInstance.args;
 if ([](size_t const& self, size_t rhs) -> bool {
@@ -7836,7 +7833,7 @@ case 24 /* Struct */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Struct;ids::StructId const& id = __jakt_match_value.value;
 {
 if (((((((((*this).program))->get_struct(id))).record_type)).__jakt_init_index() == 1 /* Class */)){
-(access_operator = TRY(ByteString::from_utf8("->"sv)));
+(access_operator = (ByteString::must_from_utf8("->"sv)));
 }
 }
 return JaktInternal::ExplicitValue<void>();
@@ -7845,7 +7842,7 @@ case 20 /* GenericInstance */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.GenericInstance;ids::StructId const& id = __jakt_match_value.id;
 {
 if (((((((((*this).program))->get_struct(id))).record_type)).__jakt_init_index() == 1 /* Class */)){
-(access_operator = TRY(ByteString::from_utf8("->"sv)));
+(access_operator = (ByteString::must_from_utf8("->"sv)));
 }
 }
 return JaktInternal::ExplicitValue<void>();
@@ -7884,7 +7881,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8("; })"sv)))));
+(output,(ByteString::must_from_utf8("; })"sv)))));
 }
 else {
 TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
@@ -7902,7 +7899,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8(")"sv)))));
+(output,(ByteString::must_from_utf8(")"sv)))));
 __jakt_var_639 = output; goto __jakt_label_544;
 
 }
@@ -7913,7 +7910,7 @@ auto&& __jakt_match_value = __jakt_match_variant.as.IndexedCommonEnumMember;Nonn
 ByteString const& index = __jakt_match_value.index;
 bool const& is_optional = __jakt_match_value.is_optional;
 return JaktInternal::ExplicitValue(({ Optional<ByteString> __jakt_var_640; {
-ByteString output = TRY(ByteString::from_utf8(""sv));
+ByteString output = (ByteString::must_from_utf8(""sv));
 ByteString const object = TRY((((*this).codegen_expression(expr))));
 TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 {
@@ -7921,7 +7918,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8("(("sv)))));
+(output,(ByteString::must_from_utf8("(("sv)))));
 TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 {
 (self = TRY((((self) + (rhs)))));
@@ -7935,7 +7932,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8(")"sv)))));
+(output,(ByteString::must_from_utf8(")"sv)))));
 ({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<void, ErrorOr<ByteString>>{
 auto&& __jakt_match_variant = *((((*this).program))->get_type(((expr)->type())));
@@ -7948,7 +7945,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8("->"sv)))));
+(output,(ByteString::must_from_utf8("->"sv)))));
 }
 return JaktInternal::ExplicitValue<void>();
 };/*case end*/
@@ -7963,14 +7960,14 @@ if ((is_boxed && [](ByteString const& self, ByteString rhs) -> bool {
 return (!(((self) == (rhs))));
 }
 }
-(object,TRY(ByteString::from_utf8("*this"sv))))){
+(object,(ByteString::must_from_utf8("*this"sv))))){
 TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 {
 (self = TRY((((self) + (rhs)))));
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8("->common.init_common."sv)))));
+(output,(ByteString::must_from_utf8("->common.init_common."sv)))));
 }
 else {
 TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
@@ -7979,7 +7976,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8(".common.init_common."sv)))));
+(output,(ByteString::must_from_utf8(".common.init_common."sv)))));
 }
 
 }
@@ -7990,7 +7987,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8(".common.init_common."sv)))));
+(output,(ByteString::must_from_utf8(".common.init_common."sv)))));
 }
 
 }
@@ -8007,14 +8004,14 @@ if ((is_boxed && [](ByteString const& self, ByteString rhs) -> bool {
 return (!(((self) == (rhs))));
 }
 }
-(object,TRY(ByteString::from_utf8("*this"sv))))){
+(object,(ByteString::must_from_utf8("*this"sv))))){
 TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 {
 (self = TRY((((self) + (rhs)))));
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8("->common.init_common."sv)))));
+(output,(ByteString::must_from_utf8("->common.init_common."sv)))));
 }
 else {
 TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
@@ -8023,7 +8020,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8(".common.init_common."sv)))));
+(output,(ByteString::must_from_utf8(".common.init_common."sv)))));
 }
 
 }
@@ -8034,7 +8031,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8(".common.init_common."sv)))));
+(output,(ByteString::must_from_utf8(".common.init_common."sv)))));
 }
 
 }
@@ -8048,7 +8045,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8("."sv)))));
+(output,(ByteString::must_from_utf8("."sv)))));
 }
 return JaktInternal::ExplicitValue<void>();
 };/*case end*/
@@ -8066,7 +8063,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8("map([](auto& _value) { return _value."sv)))));
+(output,(ByteString::must_from_utf8("map([](auto& _value) { return _value."sv)))));
 TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 {
 (self = TRY((((self) + (rhs)))));
@@ -8080,7 +8077,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8("; })"sv)))));
+(output,(ByteString::must_from_utf8("; })"sv)))));
 }
 else {
 TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
@@ -8098,7 +8095,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8(")"sv)))));
+(output,(ByteString::must_from_utf8(")"sv)))));
 __jakt_var_640 = output; goto __jakt_label_545;
 
 }
@@ -8106,7 +8103,7 @@ __jakt_label_545:; __jakt_var_640.release_value(); }));
 };/*case end*/
 case 18 /* ComptimeIndex */: {
 {
-utility::panic(TRY(ByteString::from_utf8("Internal error: ComptimeIndex should have been replaced by now"sv)));
+utility::panic((ByteString::must_from_utf8("Internal error: ComptimeIndex should have been replaced by now"sv)));
 }
 };/*case end*/
 case 28 /* Block */: {
@@ -8129,10 +8126,10 @@ return JaktInternal::ExplicitValue(({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<ByteString,ErrorOr<ByteString>>{
 auto __jakt_enum_value = (val);
 if (__jakt_enum_value == true) {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("true"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("true"sv)));
 }
 else {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("false"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("false"sv)));
 }
 }());
     if (_jakt_value.is_return())
@@ -8145,7 +8142,7 @@ auto&& __jakt_match_value = __jakt_match_variant.as.UnaryOp;NonnullRefPtr<typena
 types::CheckedUnaryOperator const& op = __jakt_match_value.op;
 ids::TypeId const& type_id = __jakt_match_value.type_id;
 return JaktInternal::ExplicitValue(({ Optional<ByteString> __jakt_var_641; {
-ByteString output = TRY(ByteString::from_utf8("("sv));
+ByteString output = (ByteString::must_from_utf8("("sv));
 TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 {
 (self = TRY((((self) + (rhs)))));
@@ -8157,13 +8154,13 @@ return {};
 auto&& __jakt_match_variant = op;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 0 /* PreIncrement */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("++"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("++"sv)));
 };/*case end*/
 case 2 /* PreDecrement */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("--"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("--"sv)));
 };/*case end*/
 case 4 /* Negate */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("-"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("-"sv)));
 };/*case end*/
 case 5 /* Dereference */: {
 return JaktInternal::ExplicitValue(({
@@ -8171,10 +8168,10 @@ return JaktInternal::ExplicitValue(({
 auto&& __jakt_match_variant = *((((*this).program))->get_type(((expr)->type())));
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 26 /* RawPtr */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("*"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("*"sv)));
 };/*case end*/
 default: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8(""sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8(""sv)));
 };/*case end*/
 }/*switch end*/
 }()
@@ -8189,10 +8186,10 @@ return JaktInternal::ExplicitValue(({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<ByteString,ErrorOr<ByteString>>{
 auto __jakt_enum_value = (((((((*this).program))->get_type(((expr)->type()))))->is_boxed(((*this).program))));
 if (__jakt_enum_value == true) {
-return JaktInternal::ExplicitValue(TRY((((TRY((((TRY((((TRY(ByteString::from_utf8("const_cast<"sv))) + (TRY((((*this).codegen_type_possibly_as_namespace(type_id,true))))))))) + (TRY(ByteString::from_utf8(">("sv))))))) + (TRY(ByteString::from_utf8("&*"sv)))))));
+return JaktInternal::ExplicitValue(TRY((((TRY((((TRY(((((ByteString::must_from_utf8("const_cast<"sv))) + (TRY((((*this).codegen_type_possibly_as_namespace(type_id,true))))))))) + ((ByteString::must_from_utf8(">("sv))))))) + ((ByteString::must_from_utf8("&*"sv)))))));
 }
 else if (__jakt_enum_value == false) {
-return JaktInternal::ExplicitValue(TRY((((TRY((((TRY((((TRY(ByteString::from_utf8("const_cast<"sv))) + (TRY((((*this).codegen_type(type_id))))))))) + (TRY(ByteString::from_utf8(">("sv))))))) + (TRY(ByteString::from_utf8("&"sv)))))));
+return JaktInternal::ExplicitValue(TRY((((TRY((((TRY(((((ByteString::must_from_utf8("const_cast<"sv))) + (TRY((((*this).codegen_type(type_id))))))))) + ((ByteString::must_from_utf8(">("sv))))))) + ((ByteString::must_from_utf8("&"sv)))))));
 }
 VERIFY_NOT_REACHED();
 }());
@@ -8202,13 +8199,13 @@ VERIFY_NOT_REACHED();
 }));
 };/*case end*/
 case 9 /* LogicalNot */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("!"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("!"sv)));
 };/*case end*/
 case 10 /* BitwiseNot */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("~"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("~"sv)));
 };/*case end*/
 case 16 /* Sizeof */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("sizeof"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("sizeof"sv)));
 };/*case end*/
 case 12 /* Is */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Is;ids::TypeId const& type_id = __jakt_match_value.value;
@@ -8236,13 +8233,13 @@ return JaktInternal::ExplicitValue(TRY((((*this).codegen_type(type_id)))));
         return _jakt_value.release_return();
     _jakt_value.release_value();
 });
-__jakt_var_642 = TRY((((TRY((((TRY(ByteString::from_utf8("is<"sv))) + (is_type))))) + (TRY(ByteString::from_utf8(">("sv)))))); goto __jakt_label_547;
+__jakt_var_642 = TRY((((TRY(((((ByteString::must_from_utf8("is<"sv))) + (is_type))))) + ((ByteString::must_from_utf8(">("sv)))))); goto __jakt_label_547;
 
 }
 __jakt_label_547:; __jakt_var_642.release_value(); }));
 };/*case end*/
 case 15 /* IsNone */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("!"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("!"sv)));
 };/*case end*/
 case 11 /* TypeCast */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.TypeCast;types::CheckedTypeCast const& cast = __jakt_match_value.value;
@@ -8265,7 +8262,7 @@ return JaktInternal::ExplicitValue(((args)[static_cast<i64>(0LL)]));
 };/*case end*/
 default: {
 {
-utility::panic(TRY(ByteString::from_utf8("Fallible type cast must have Optional result."sv)));
+utility::panic((ByteString::must_from_utf8("Fallible type cast must have Optional result."sv)));
 }
 };/*case end*/
 }/*switch end*/
@@ -8275,21 +8272,21 @@ utility::panic(TRY(ByteString::from_utf8("Fallible type cast must have Optional 
         return _jakt_value.release_return();
     _jakt_value.release_value();
 });
-ByteString cast_type = TRY(ByteString::from_utf8("dynamic_cast"sv));
+ByteString cast_type = (ByteString::must_from_utf8("dynamic_cast"sv));
 if (((((((*this).program))->get_type(type_id)))->__jakt_init_index() == 24 /* Struct */)){
 ids::StructId const struct_id = (((((*this).program))->get_type(type_id)))->as.Struct.value;
 if (((((((((*this).program))->get_struct(struct_id))).record_type)).__jakt_init_index() == 1 /* Class */)){
 (final_type_id = type_id);
-(cast_type = TRY(ByteString::from_utf8("fallible_class_cast"sv)));
+(cast_type = (ByteString::must_from_utf8("fallible_class_cast"sv)));
 }
 else if (((((*this).program))->is_integer(type_id))){
 (final_type_id = type_id);
-(cast_type = TRY(ByteString::from_utf8("fallible_integer_cast"sv)));
+(cast_type = (ByteString::must_from_utf8("fallible_integer_cast"sv)));
 }
 }
 else if (((((*this).program))->is_integer(type_id))){
 (final_type_id = type_id);
-(cast_type = TRY(ByteString::from_utf8("fallible_integer_cast"sv)));
+(cast_type = (ByteString::must_from_utf8("fallible_integer_cast"sv)));
 }
 __jakt_var_645 = cast_type; goto __jakt_label_550;
 
@@ -8298,29 +8295,29 @@ __jakt_label_550:; __jakt_var_645.release_value(); }));
 };/*case end*/
 case 1 /* Infallible */: {
 return JaktInternal::ExplicitValue(({ Optional<ByteString> __jakt_var_646; {
-ByteString cast_type = TRY(ByteString::from_utf8("verify_cast"sv));
+ByteString cast_type = (ByteString::must_from_utf8("verify_cast"sv));
 if (((((expr)->type())).equals(types::unknown_type_id()))){
-(cast_type = TRY(ByteString::from_utf8("assert_type"sv)));
+(cast_type = (ByteString::must_from_utf8("assert_type"sv)));
 }
 else if (((type)->is_boxed(((*this).program)))){
-(cast_type = TRY(ByteString::from_utf8("infallible_class_cast"sv)));
+(cast_type = (ByteString::must_from_utf8("infallible_class_cast"sv)));
 }
 else if (((((*this).program))->is_integer(type_id))){
-(cast_type = TRY(ByteString::from_utf8("infallible_integer_cast"sv)));
+(cast_type = (ByteString::must_from_utf8("infallible_integer_cast"sv)));
 }
 else if (((type)->__jakt_init_index() == 25 /* Enum */)){
 ids::EnumId const enum_id = (type)->as.Enum.value;
 if (((((*this).program))->is_integer(((((((*this).program))->get_enum(enum_id))).underlying_type_id)))){
-(cast_type = TRY(ByteString::from_utf8("infallible_enum_cast"sv)));
+(cast_type = (ByteString::must_from_utf8("infallible_enum_cast"sv)));
 }
 else if (((type)->__jakt_init_index() == 26 /* RawPtr */)){
 ids::TypeId const inner = (type)->as.RawPtr.value;
-(cast_type = TRY(ByteString::from_utf8("reinterpret_cast"sv)));
+(cast_type = (ByteString::must_from_utf8("reinterpret_cast"sv)));
 }
 }
 else if (((type)->__jakt_init_index() == 26 /* RawPtr */)){
 ids::TypeId const inner = (type)->as.RawPtr.value;
-(cast_type = TRY(ByteString::from_utf8("reinterpret_cast"sv)));
+(cast_type = (ByteString::must_from_utf8("reinterpret_cast"sv)));
 }
 __jakt_var_646 = cast_type; goto __jakt_label_551;
 
@@ -8334,13 +8331,13 @@ default: VERIFY_NOT_REACHED();}/*switch end*/
         return _jakt_value.release_return();
     _jakt_value.release_value();
 });
-__jakt_var_644 = TRY((((TRY((((TRY((((cast_type) + (TRY(ByteString::from_utf8("<"sv))))))) + (TRY((((*this).codegen_type(final_type_id))))))))) + (TRY(ByteString::from_utf8(">("sv)))))); goto __jakt_label_549;
+__jakt_var_644 = TRY((((TRY((((TRY((((cast_type) + ((ByteString::must_from_utf8("<"sv))))))) + (TRY((((*this).codegen_type(final_type_id))))))))) + ((ByteString::must_from_utf8(">("sv)))))); goto __jakt_label_549;
 
 }
 __jakt_label_549:; __jakt_var_644.release_value(); }));
 };/*case end*/
 default: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8(""sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8(""sv)));
 };/*case end*/
 }/*switch end*/
 }()
@@ -8355,7 +8352,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8("("sv)))));
+(output,(ByteString::must_from_utf8("("sv)))));
 ByteString const object = ({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<ByteString, ErrorOr<ByteString>>{
 auto&& __jakt_match_variant = op;
@@ -8392,23 +8389,23 @@ return {};
 auto&& __jakt_match_variant = op;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 1 /* PostIncrement */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("++)"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("++)"sv)));
 };/*case end*/
 case 3 /* PostDecrement */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("--)"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("--)"sv)));
 };/*case end*/
 case 11 /* TypeCast */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("))"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("))"sv)));
 };/*case end*/
 case 12 /* Is */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("))"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("))"sv)));
 };/*case end*/
 case 13 /* IsEnumVariant */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.IsEnumVariant;types::CheckedEnumVariant const& enum_variant = __jakt_match_value.enum_variant;
 ids::TypeId const& enum_type_id = __jakt_match_value.type_id;
 return JaktInternal::ExplicitValue(({ Optional<ByteString> __jakt_var_647; {
 ByteString const name = ((enum_variant).name());
-ByteString suffix = TRY(ByteString::from_utf8(")"sv));
+ByteString suffix = (ByteString::must_from_utf8(")"sv));
 types::CheckedEnum const enum_ = ((((*this).program))->get_enum(({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<ids::EnumId, ErrorOr<ByteString>>{
 auto&& __jakt_match_variant = *((((*this).program))->get_type(enum_type_id));
@@ -8445,14 +8442,14 @@ if ((is_boxed && [](ByteString const& self, ByteString rhs) -> bool {
 return (!(((self) == (rhs))));
 }
 }
-(object,TRY(ByteString::from_utf8("*this"sv))))){
+(object,(ByteString::must_from_utf8("*this"sv))))){
 TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 {
 (self = TRY((((self) + (rhs)))));
 }
 return {};
 }
-(suffix,TRY(ByteString::from_utf8("->"sv)))));
+(suffix,(ByteString::must_from_utf8("->"sv)))));
 }
 else {
 TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
@@ -8461,7 +8458,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(suffix,TRY(ByteString::from_utf8("."sv)))));
+(suffix,(ByteString::must_from_utf8("."sv)))));
 }
 
 i64 variant_index = static_cast<i64>(0LL);
@@ -8524,16 +8521,16 @@ __jakt_var_647 = suffix; goto __jakt_label_552;
 __jakt_label_552:; __jakt_var_647.release_value(); }));
 };/*case end*/
 case 14 /* IsSome */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8(").has_value()"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8(").has_value()"sv)));
 };/*case end*/
 case 15 /* IsNone */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8(").has_value()"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8(").has_value()"sv)));
 };/*case end*/
 case 6 /* RawAddress */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("))"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("))"sv)));
 };/*case end*/
 default: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8(")"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8(")"sv)));
 };/*case end*/
 }/*switch end*/
 }()
@@ -8548,7 +8545,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8(")"sv)))));
+(output,(ByteString::must_from_utf8(")"sv)))));
 __jakt_var_641 = output; goto __jakt_label_546;
 
 }
@@ -8570,16 +8567,16 @@ ByteString const suffix = ({
 auto&& __jakt_match_variant = val;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 3 /* I64 */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("LL"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("LL"sv)));
 };/*case end*/
 case 7 /* U64 */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("ULL"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("ULL"sv)));
 };/*case end*/
 case 8 /* USize */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("ULL"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("ULL"sv)));
 };/*case end*/
 default: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8(""sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8(""sv)));
 };/*case end*/
 }/*switch end*/
 }()
@@ -8593,7 +8590,7 @@ ByteString const type_name = ({
 auto&& __jakt_match_variant = val;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 8 /* USize */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("size_t"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("size_t"sv)));
 };/*case end*/
 default: {
 return JaktInternal::ExplicitValue(TRY((((*this).codegen_type(type_id)))));
@@ -8668,7 +8665,7 @@ case 23 /* NamespacedVar */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.NamespacedVar;JaktInternal::DynamicArray<types::CheckedNamespace> const& namespaces = __jakt_match_value.namespaces;
 NonnullRefPtr<types::CheckedVariable> const& var = __jakt_match_value.var;
 return JaktInternal::ExplicitValue(({ Optional<ByteString> __jakt_var_649; {
-ByteString output = TRY(ByteString::from_utf8(""sv));
+ByteString output = (ByteString::must_from_utf8(""sv));
 if (((((var)->name_for_codegen())).is_scopable())){
 if (((((var)->owner_scope)).has_value())){
 (output = TRY((((*this).codegen_namespace_qualifier((((var)->owner_scope).value()),false,JaktInternal::OptionalNone(),JaktInternal::OptionalNone())))));
@@ -8689,7 +8686,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY((((((ns).name)) + (TRY(ByteString::from_utf8("::"sv)))))))));
+(output,TRY((((((ns).name)) + ((ByteString::must_from_utf8("::"sv)))))))));
 }
 
 }
@@ -8718,7 +8715,7 @@ return JaktInternal::ExplicitValue(({ Optional<ByteString> __jakt_var_650; {
 ByteString const var_name = TRY((((*this).codegen_expression(expr))));
 ByteString const enum_type = TRY((((*this).codegen_type_possibly_as_namespace(((expr)->type()),true))));
 ByteString const variant_name = ((enum_variant).name());
-ByteString arg_name = TRY(ByteString::from_utf8("value"sv));
+ByteString arg_name = (ByteString::must_from_utf8("value"sv));
 if (((enum_variant).__jakt_init_index() == 3 /* StructLike */)){
 (arg_name = ((arg).name).value_or_lazy_evaluated([&] { return ((arg).binding); }));
 }
@@ -8727,10 +8724,10 @@ ByteString const cpp_deref_operator = ({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<ByteString,ErrorOr<ByteString>>{
 auto __jakt_enum_value = (((enum_).is_boxed));
 if (__jakt_enum_value == true) {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("->"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("->"sv)));
 }
 else {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("."sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("."sv)));
 }
 }());
     if (_jakt_value.is_return())
@@ -8749,7 +8746,7 @@ types::CheckedField field = (_magic_value.value());
 {
 ByteString const field_name = TRY((((((((((*this).program))->get_variable(((field).variable_id))))->name_for_codegen())).as_name_for_use())));
 if (((field_name) == (arg_name))){
-(section = TRY(ByteString::from_utf8("common.init_common"sv)));
+(section = (ByteString::must_from_utf8("common.init_common"sv)));
 }
 }
 
@@ -8768,7 +8765,7 @@ utility::Span const& span = __jakt_match_value.span;
 ids::TypeId const& type_id = __jakt_match_value.type_id;
 ids::TypeId const& inner_type_id = __jakt_match_value.inner_type_id;
 return JaktInternal::ExplicitValue(({ Optional<ByteString> __jakt_var_651; {
-ByteString output = TRY(ByteString::from_utf8(""sv));
+ByteString output = (ByteString::must_from_utf8(""sv));
 if (((repeat).has_value())){
 NonnullRefPtr<typename types::CheckedExpression> const repeat_val = ((repeat).value());
 TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
@@ -8777,7 +8774,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8("("sv)))));
+(output,(ByteString::must_from_utf8("("sv)))));
 TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 {
 (self = TRY((((self) + (rhs)))));
@@ -8791,7 +8788,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8("((DynamicArray<"sv)))));
+(output,(ByteString::must_from_utf8("((DynamicArray<"sv)))));
 TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 {
 (self = TRY((((self) + (rhs)))));
@@ -8805,7 +8802,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8(">::filled("sv)))));
+(output,(ByteString::must_from_utf8(">::filled("sv)))));
 TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 {
 (self = TRY((((self) + (rhs)))));
@@ -8819,7 +8816,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8(", "sv)))));
+(output,(ByteString::must_from_utf8(", "sv)))));
 TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 {
 (self = TRY((((self) + (rhs)))));
@@ -8833,7 +8830,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8("))))"sv)))));
+(output,(ByteString::must_from_utf8("))))"sv)))));
 }
 else {
 TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
@@ -8842,7 +8839,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8("("sv)))));
+(output,(ByteString::must_from_utf8("("sv)))));
 TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 {
 (self = TRY((((self) + (rhs)))));
@@ -8856,7 +8853,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8("((DynamicArray<"sv)))));
+(output,(ByteString::must_from_utf8("((DynamicArray<"sv)))));
 TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 {
 (self = TRY((((self) + (rhs)))));
@@ -8870,7 +8867,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8(">::create_with({"sv)))));
+(output,(ByteString::must_from_utf8(">::create_with({"sv)))));
 bool first = true;
 {
 JaktInternal::ArrayIterator<NonnullRefPtr<typename types::CheckedExpression>> _magic = ((vals).iterator());
@@ -8888,7 +8885,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8(", "sv)))));
+(output,(ByteString::must_from_utf8(", "sv)))));
 }
 else {
 (first = false);
@@ -8912,7 +8909,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8("}))))"sv)))));
+(output,(ByteString::must_from_utf8("}))))"sv)))));
 }
 
 __jakt_var_651 = output; goto __jakt_label_556;
@@ -8949,7 +8946,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8(", "sv)))));
+(output,(ByteString::must_from_utf8(", "sv)))));
 }
 else {
 (first = false);
@@ -8961,7 +8958,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8("{"sv)))));
+(output,(ByteString::must_from_utf8("{"sv)))));
 TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 {
 (self = TRY((((self) + (rhs)))));
@@ -8975,7 +8972,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8(", "sv)))));
+(output,(ByteString::must_from_utf8(", "sv)))));
 TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 {
 (self = TRY((((self) + (rhs)))));
@@ -8989,7 +8986,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8("}"sv)))));
+(output,(ByteString::must_from_utf8("}"sv)))));
 }
 
 }
@@ -9001,7 +8998,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8("}))))"sv)))));
+(output,(ByteString::must_from_utf8("}))))"sv)))));
 __jakt_var_652 = output; goto __jakt_label_557;
 
 }
@@ -9013,7 +9010,7 @@ utility::Span const& span = __jakt_match_value.span;
 ids::TypeId const& type_id = __jakt_match_value.type_id;
 ids::TypeId const& inner_type_id = __jakt_match_value.inner_type_id;
 return JaktInternal::ExplicitValue(({ Optional<ByteString> __jakt_var_653; {
-ByteString output = TRY(ByteString::from_utf8(""sv));
+ByteString output = (ByteString::must_from_utf8(""sv));
 TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 {
 (self = TRY((((self) + (rhs)))));
@@ -9038,7 +9035,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8(", "sv)))));
+(output,(ByteString::must_from_utf8(", "sv)))));
 }
 else {
 (first = false);
@@ -9062,7 +9059,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8("}))))"sv)))));
+(output,(ByteString::must_from_utf8("}))))"sv)))));
 __jakt_var_653 = output; goto __jakt_label_558;
 
 }
@@ -9073,14 +9070,14 @@ auto&& __jakt_match_value = __jakt_match_variant.as.JaktTuple;JaktInternal::Dyna
 utility::Span const& span = __jakt_match_value.span;
 ids::TypeId const& type_id = __jakt_match_value.type_id;
 return JaktInternal::ExplicitValue(({ Optional<ByteString> __jakt_var_654; {
-ByteString output = TRY(ByteString::from_utf8(""sv));
+ByteString output = (ByteString::must_from_utf8(""sv));
 TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 {
 (self = TRY((((self) + (rhs)))));
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8("(Tuple{"sv)))));
+(output,(ByteString::must_from_utf8("(Tuple{"sv)))));
 bool first = true;
 {
 JaktInternal::ArrayIterator<NonnullRefPtr<typename types::CheckedExpression>> _magic = ((vals).iterator());
@@ -9098,7 +9095,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8(", "sv)))));
+(output,(ByteString::must_from_utf8(", "sv)))));
 }
 else {
 (first = false);
@@ -9122,7 +9119,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8("})"sv)))));
+(output,(ByteString::must_from_utf8("})"sv)))));
 __jakt_var_654 = output; goto __jakt_label_559;
 
 }
@@ -9130,7 +9127,7 @@ __jakt_label_559:; __jakt_var_654.release_value(); }));
 };/*case end*/
 case 30 /* DependentFunction */: {
 {
-TRY((((((*this).compiler))->panic(TRY(ByteString::from_utf8("Dependent functions should have been resolved by now"sv))))));
+TRY((((((*this).compiler))->panic((ByteString::must_from_utf8("Dependent functions should have been resolved by now"sv))))));
 }
 };/*case end*/
 case 29 /* Function */: {
@@ -9159,7 +9156,7 @@ case 0 /* ByValue */: {
 return JaktInternal::ExplicitValue(((capture).common.init_common.name));
 };/*case end*/
 case 4 /* AllByReference */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("&"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("&"sv)));
 };/*case end*/
 default: {
 return JaktInternal::ExplicitValue(TRY((__jakt_format((StringView::from_string_literal("&{}"sv)),((capture).common.init_common.name)))));
@@ -9216,7 +9213,7 @@ codegen::ControlFlowState const last_control_flow = ((*this).control_flow_state)
 ScopeGuard __jakt_var_656([&] {
 (((*this).control_flow_state) = last_control_flow);
 });
-ByteString block_output = TRY(ByteString::from_utf8(""sv));
+ByteString block_output = (ByteString::must_from_utf8(""sv));
 if (((pseudo_function_id).has_value())){
 NonnullRefPtr<types::CheckedFunction> const function = ((((*this).program))->get_function((pseudo_function_id.value())));
 JaktInternal::Optional<NonnullRefPtr<types::CheckedFunction>> const previous_function = ((*this).current_function);
@@ -9230,7 +9227,7 @@ else {
 (block_output = TRY((((*this).codegen_lambda_block(can_throw,block,return_type_id)))));
 }
 
-__jakt_var_655 = TRY((__jakt_format((StringView::from_string_literal("[{}]({}) -> {} {}"sv)),TRY((utility::join(generated_captures,TRY(ByteString::from_utf8(", "sv))))),TRY((utility::join(generated_params,TRY(ByteString::from_utf8(", "sv))))),return_type,block_output))); goto __jakt_label_560;
+__jakt_var_655 = TRY((__jakt_format((StringView::from_string_literal("[{}]({}) -> {} {}"sv)),TRY((utility::join(generated_captures,(ByteString::must_from_utf8(", "sv))))),TRY((utility::join(generated_params,(ByteString::must_from_utf8(", "sv))))),return_type,block_output))); goto __jakt_label_560;
 
 }
 __jakt_label_560:; __jakt_var_655.release_value(); }));
@@ -9241,7 +9238,7 @@ ByteString const& error_name = __jakt_match_value.error_name;
 types::CheckedBlock const& catch_block = __jakt_match_value.catch_block;
 utility::Span const& span = __jakt_match_value.span;
 return JaktInternal::ExplicitValue(({ Optional<ByteString> __jakt_var_658; {
-ByteString output = TRY(ByteString::from_utf8(""sv));
+ByteString output = (ByteString::must_from_utf8(""sv));
 ByteString const try_var = TRY((((*this).fresh_var())));
 TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 {
@@ -9249,7 +9246,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8("auto "sv)))));
+(output,(ByteString::must_from_utf8("auto "sv)))));
 TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 {
 (self = TRY((((self) + (rhs)))));
@@ -9263,7 +9260,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8(" = [&]() -> ErrorOr<void> {"sv)))));
+(output,(ByteString::must_from_utf8(" = [&]() -> ErrorOr<void> {"sv)))));
 codegen::ControlFlowState const last_control_flow = ((*this).control_flow_state);
 (((((*this).control_flow_state)).passes_through_match) = false);
 (((((*this).control_flow_state)).passes_through_try) = true);
@@ -9280,28 +9277,28 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8(";"sv)))));
+(output,(ByteString::must_from_utf8(";"sv)))));
 TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 {
 (self = TRY((((self) + (rhs)))));
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8("return {};"sv)))));
+(output,(ByteString::must_from_utf8("return {};"sv)))));
 TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 {
 (self = TRY((((self) + (rhs)))));
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8("}();\n"sv)))));
+(output,(ByteString::must_from_utf8("}();\n"sv)))));
 TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 {
 (self = TRY((((self) + (rhs)))));
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8("if ("sv)))));
+(output,(ByteString::must_from_utf8("if ("sv)))));
 TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 {
 (self = TRY((((self) + (rhs)))));
@@ -9315,7 +9312,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8(".is_error()) {"sv)))));
+(output,(ByteString::must_from_utf8(".is_error()) {"sv)))));
 if ((!(((error_name).is_empty())))){
 TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 {
@@ -9323,7 +9320,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8("auto "sv)))));
+(output,(ByteString::must_from_utf8("auto "sv)))));
 TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 {
 (self = TRY((((self) + (rhs)))));
@@ -9337,7 +9334,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8(" = "sv)))));
+(output,(ByteString::must_from_utf8(" = "sv)))));
 TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 {
 (self = TRY((((self) + (rhs)))));
@@ -9351,7 +9348,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8(".release_error();"sv)))));
+(output,(ByteString::must_from_utf8(".release_error();"sv)))));
 }
 TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 {
@@ -9367,7 +9364,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8("}"sv)))));
+(output,(ByteString::must_from_utf8("}"sv)))));
 __jakt_var_658 = output; goto __jakt_label_561;
 
 }
@@ -9381,7 +9378,7 @@ utility::Span const& span = __jakt_match_value.span;
 ids::TypeId const& type_id = __jakt_match_value.type_id;
 ids::TypeId const& inner_type_id = __jakt_match_value.inner_type_id;
 return JaktInternal::ExplicitValue(({ Optional<ByteString> __jakt_var_659; {
-ByteString output = TRY(ByteString::from_utf8(""sv));
+ByteString output = (ByteString::must_from_utf8(""sv));
 ByteString const fresh_var = TRY((((*this).fresh_var())));
 bool const is_void = ((inner_type_id).equals(types::void_type_id()));
 ByteString const try_var = TRY((((*this).fresh_var())));
@@ -9401,7 +9398,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8("({ Optional<"sv)))));
+(output,(ByteString::must_from_utf8("({ Optional<"sv)))));
 TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 {
 (self = TRY((((self) + (rhs)))));
@@ -9415,7 +9412,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8("> "sv)))));
+(output,(ByteString::must_from_utf8("> "sv)))));
 TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 {
 (self = TRY((((self) + (rhs)))));
@@ -9429,7 +9426,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8(";\n"sv)))));
+(output,(ByteString::must_from_utf8(";\n"sv)))));
 }
 TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 {
@@ -9437,7 +9434,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8("auto "sv)))));
+(output,(ByteString::must_from_utf8("auto "sv)))));
 TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 {
 (self = TRY((((self) + (rhs)))));
@@ -9451,7 +9448,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8(" = [&]() -> ErrorOr<"sv)))));
+(output,(ByteString::must_from_utf8(" = [&]() -> ErrorOr<"sv)))));
 TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 {
 (self = TRY((((self) + (rhs)))));
@@ -9465,7 +9462,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8("> { return "sv)))));
+(output,(ByteString::must_from_utf8("> { return "sv)))));
 TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 {
 (self = TRY((((self) + (rhs)))));
@@ -9480,7 +9477,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8(", ErrorOr<void>{}"sv)))));
+(output,(ByteString::must_from_utf8(", ErrorOr<void>{}"sv)))));
 }
 TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 {
@@ -9488,7 +9485,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8("; }();\n"sv)))));
+(output,(ByteString::must_from_utf8("; }();\n"sv)))));
 if (((catch_block).has_value())){
 TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 {
@@ -9496,7 +9493,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8("if ("sv)))));
+(output,(ByteString::must_from_utf8("if ("sv)))));
 TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 {
 (self = TRY((((self) + (rhs)))));
@@ -9510,7 +9507,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8(".is_error()) {"sv)))));
+(output,(ByteString::must_from_utf8(".is_error()) {"sv)))));
 if (((catch_name).has_value())){
 TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 {
@@ -9518,7 +9515,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8("auto "sv)))));
+(output,(ByteString::must_from_utf8("auto "sv)))));
 TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 {
 (self = TRY((((self) + (rhs)))));
@@ -9532,7 +9529,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8(" = "sv)))));
+(output,(ByteString::must_from_utf8(" = "sv)))));
 TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 {
 (self = TRY((((self) + (rhs)))));
@@ -9546,7 +9543,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8(".release_error();\n"sv)))));
+(output,(ByteString::must_from_utf8(".release_error();\n"sv)))));
 }
 if ((((((catch_block.value())).yielded_type)).has_value())){
 TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
@@ -9562,7 +9559,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8(" = ("sv)))));
+(output,(ByteString::must_from_utf8(" = ("sv)))));
 TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 {
 (self = TRY((((self) + (rhs)))));
@@ -9576,7 +9573,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8(");\n"sv)))));
+(output,(ByteString::must_from_utf8(");\n"sv)))));
 }
 else {
 TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
@@ -9595,7 +9592,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8("} else {"sv)))));
+(output,(ByteString::must_from_utf8("} else {"sv)))));
 TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 {
 (self = TRY((((self) + (rhs)))));
@@ -9609,7 +9606,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8(" = "sv)))));
+(output,(ByteString::must_from_utf8(" = "sv)))));
 TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 {
 (self = TRY((((self) + (rhs)))));
@@ -9623,7 +9620,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8(".release_value();\n"sv)))));
+(output,(ByteString::must_from_utf8(".release_value();\n"sv)))));
 }
 TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 {
@@ -9631,7 +9628,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8("}\n"sv)))));
+(output,(ByteString::must_from_utf8("}\n"sv)))));
 }
 else if ((!(is_void))){
 TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
@@ -9640,7 +9637,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8("if (!"sv)))));
+(output,(ByteString::must_from_utf8("if (!"sv)))));
 TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 {
 (self = TRY((((self) + (rhs)))));
@@ -9654,7 +9651,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8(".is_error()) "sv)))));
+(output,(ByteString::must_from_utf8(".is_error()) "sv)))));
 TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 {
 (self = TRY((((self) + (rhs)))));
@@ -9668,7 +9665,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8(" = "sv)))));
+(output,(ByteString::must_from_utf8(" = "sv)))));
 TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 {
 (self = TRY((((self) + (rhs)))));
@@ -9682,7 +9679,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8(".release_value();\n"sv)))));
+(output,(ByteString::must_from_utf8(".release_value();\n"sv)))));
 }
 if ((!(is_void))){
 TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
@@ -9699,7 +9696,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8(".release_value()"sv)))));
+(output,(ByteString::must_from_utf8(".release_value()"sv)))));
 }
 TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 {
@@ -9707,7 +9704,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8("; })"sv)))));
+(output,(ByteString::must_from_utf8("; })"sv)))));
 }
 __jakt_var_659 = output; goto __jakt_label_562;
 
@@ -9740,7 +9737,7 @@ if (((((op).op)).__jakt_init_index() == 20 /* NoneCoalescing */)){
 ids::TypeId const rhs_type_id = ((rhs)->type());
 NonnullRefPtr<typename types::Type> const rhs_type = ((((*this).program))->get_type(rhs_type_id));
 bool const rhs_can_throw = ((rhs)->can_throw());
-ByteString output = TRY(ByteString::from_utf8(""sv));
+ByteString output = (ByteString::must_from_utf8(""sv));
 if (rhs_can_throw){
 TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 {
@@ -9755,7 +9752,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8("(("sv)))));
+(output,(ByteString::must_from_utf8("(("sv)))));
 }
 TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 {
@@ -9766,7 +9763,7 @@ return {};
 (output,TRY((((*this).codegen_expression(lhs)))))));
 if (((rhs_type)->__jakt_init_index() == 20 /* GenericInstance */)){
 ids::StructId const id = (rhs_type)->as.GenericInstance.id;
-if (((TRY((((((((((*this).program))->get_struct(id))).name_for_codegen())).as_name_for_definition())))) == (TRY(ByteString::from_utf8("Optional"sv))))){
+if (((TRY((((((((((*this).program))->get_struct(id))).name_for_codegen())).as_name_for_definition())))) == ((ByteString::must_from_utf8("Optional"sv))))){
 if (rhs_can_throw){
 TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 {
@@ -9774,7 +9771,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8(".try_value_or_lazy_evaluated_optional"sv)))));
+(output,(ByteString::must_from_utf8(".try_value_or_lazy_evaluated_optional"sv)))));
 }
 else {
 TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
@@ -9783,30 +9780,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8(".value_or_lazy_evaluated_optional"sv)))));
-}
-
-}
-else {
-if (rhs_can_throw){
-TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
-{
-(self = TRY((((self) + (rhs)))));
-}
-return {};
-}
-(output,TRY(ByteString::from_utf8(".try_value_or_lazy_evaluated"sv)))));
-}
-else {
-TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
-{
-(self = TRY((((self) + (rhs)))));
-}
-return {};
-}
-(output,TRY(ByteString::from_utf8(".value_or_lazy_evaluated"sv)))));
-}
-
+(output,(ByteString::must_from_utf8(".value_or_lazy_evaluated_optional"sv)))));
 }
 
 }
@@ -9818,7 +9792,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8(".try_value_or_lazy_evaluated"sv)))));
+(output,(ByteString::must_from_utf8(".try_value_or_lazy_evaluated"sv)))));
 }
 else {
 TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
@@ -9827,7 +9801,30 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8(".value_or_lazy_evaluated"sv)))));
+(output,(ByteString::must_from_utf8(".value_or_lazy_evaluated"sv)))));
+}
+
+}
+
+}
+else {
+if (rhs_can_throw){
+TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
+{
+(self = TRY((((self) + (rhs)))));
+}
+return {};
+}
+(output,(ByteString::must_from_utf8(".try_value_or_lazy_evaluated"sv)))));
+}
+else {
+TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
+{
+(self = TRY((((self) + (rhs)))));
+}
+return {};
+}
+(output,(ByteString::must_from_utf8(".value_or_lazy_evaluated"sv)))));
 }
 
 }
@@ -9839,7 +9836,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8("([&]() -> ErrorOr<"sv)))));
+(output,(ByteString::must_from_utf8("([&]() -> ErrorOr<"sv)))));
 TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 {
 (self = TRY((((self) + (rhs)))));
@@ -9853,7 +9850,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8("> { return "sv)))));
+(output,(ByteString::must_from_utf8("> { return "sv)))));
 }
 else {
 TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
@@ -9862,7 +9859,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8("([&] { return "sv)))));
+(output,(ByteString::must_from_utf8("([&] { return "sv)))));
 }
 
 TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
@@ -9878,7 +9875,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8("; })"sv)))));
+(output,(ByteString::must_from_utf8("; })"sv)))));
 if (rhs_can_throw){
 TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 {
@@ -9886,7 +9883,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8("))"sv)))));
+(output,(ByteString::must_from_utf8("))"sv)))));
 }
 return output;
 }
@@ -9895,7 +9892,7 @@ ByteString const var = TRY((((*this).fresh_var())));
 return TRY((__jakt_format((StringView::from_string_literal("({{ auto&& {0} = {1}; if (!{0}.has_value()) {0} = {2}; }})"sv)),var,TRY((((*this).codegen_expression(lhs)))),TRY((((*this).codegen_expression(rhs)))))));
 }
 if (((((op).op)).__jakt_init_index() == 17 /* ArithmeticRightShift */)){
-ByteString output = TRY(ByteString::from_utf8("JaktInternal::arithmetic_shift_right("sv));
+ByteString output = (ByteString::must_from_utf8("JaktInternal::arithmetic_shift_right("sv));
 TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 {
 (self = TRY((((self) + (rhs)))));
@@ -9909,7 +9906,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8(","sv)))));
+(output,(ByteString::must_from_utf8(","sv)))));
 TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 {
 (self = TRY((((self) + (rhs)))));
@@ -9923,7 +9920,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8(")"sv)))));
+(output,(ByteString::must_from_utf8(")"sv)))));
 return output;
 }
 if ((((((op).op)).__jakt_init_index() == 21 /* Assign */) && ((lhs)->__jakt_init_index() == 14 /* IndexedDictionary */))){
@@ -9939,10 +9936,10 @@ switch(__jakt_match_variant.__jakt_init_index()) {
 case 0 /* Add */: {
 {
 if (((((*this).compiler))->optimize)){
-return TRY((((TRY((((TRY(ByteString::from_utf8("("sv))) + (TRY((((*this).codegen_unchecked_binary_op(lhs,rhs,((op).op),type_id))))))))) + (TRY(ByteString::from_utf8(")"sv))))));
+return TRY((((TRY(((((ByteString::must_from_utf8("("sv))) + (TRY((((*this).codegen_unchecked_binary_op(lhs,rhs,((op).op),type_id))))))))) + ((ByteString::must_from_utf8(")"sv))))));
 }
 else {
-return TRY((((TRY((((TRY(ByteString::from_utf8("("sv))) + (TRY((((*this).codegen_checked_binary_op(lhs,rhs,((op).op),type_id))))))))) + (TRY(ByteString::from_utf8(")"sv))))));
+return TRY((((TRY(((((ByteString::must_from_utf8("("sv))) + (TRY((((*this).codegen_checked_binary_op(lhs,rhs,((op).op),type_id))))))))) + ((ByteString::must_from_utf8(")"sv))))));
 }
 
 }
@@ -9951,10 +9948,10 @@ return JaktInternal::ExplicitValue<void>();
 case 1 /* Subtract */: {
 {
 if (((((*this).compiler))->optimize)){
-return TRY((((TRY((((TRY(ByteString::from_utf8("("sv))) + (TRY((((*this).codegen_unchecked_binary_op(lhs,rhs,((op).op),type_id))))))))) + (TRY(ByteString::from_utf8(")"sv))))));
+return TRY((((TRY(((((ByteString::must_from_utf8("("sv))) + (TRY((((*this).codegen_unchecked_binary_op(lhs,rhs,((op).op),type_id))))))))) + ((ByteString::must_from_utf8(")"sv))))));
 }
 else {
-return TRY((((TRY((((TRY(ByteString::from_utf8("("sv))) + (TRY((((*this).codegen_checked_binary_op(lhs,rhs,((op).op),type_id))))))))) + (TRY(ByteString::from_utf8(")"sv))))));
+return TRY((((TRY(((((ByteString::must_from_utf8("("sv))) + (TRY((((*this).codegen_checked_binary_op(lhs,rhs,((op).op),type_id))))))))) + ((ByteString::must_from_utf8(")"sv))))));
 }
 
 }
@@ -9963,10 +9960,10 @@ return JaktInternal::ExplicitValue<void>();
 case 2 /* Multiply */: {
 {
 if (((((*this).compiler))->optimize)){
-return TRY((((TRY((((TRY(ByteString::from_utf8("("sv))) + (TRY((((*this).codegen_unchecked_binary_op(lhs,rhs,((op).op),type_id))))))))) + (TRY(ByteString::from_utf8(")"sv))))));
+return TRY((((TRY(((((ByteString::must_from_utf8("("sv))) + (TRY((((*this).codegen_unchecked_binary_op(lhs,rhs,((op).op),type_id))))))))) + ((ByteString::must_from_utf8(")"sv))))));
 }
 else {
-return TRY((((TRY((((TRY(ByteString::from_utf8("("sv))) + (TRY((((*this).codegen_checked_binary_op(lhs,rhs,((op).op),type_id))))))))) + (TRY(ByteString::from_utf8(")"sv))))));
+return TRY((((TRY(((((ByteString::must_from_utf8("("sv))) + (TRY((((*this).codegen_checked_binary_op(lhs,rhs,((op).op),type_id))))))))) + ((ByteString::must_from_utf8(")"sv))))));
 }
 
 }
@@ -9975,10 +9972,10 @@ return JaktInternal::ExplicitValue<void>();
 case 3 /* Divide */: {
 {
 if (((((*this).compiler))->optimize)){
-return TRY((((TRY((((TRY(ByteString::from_utf8("("sv))) + (TRY((((*this).codegen_unchecked_binary_op(lhs,rhs,((op).op),type_id))))))))) + (TRY(ByteString::from_utf8(")"sv))))));
+return TRY((((TRY(((((ByteString::must_from_utf8("("sv))) + (TRY((((*this).codegen_unchecked_binary_op(lhs,rhs,((op).op),type_id))))))))) + ((ByteString::must_from_utf8(")"sv))))));
 }
 else {
-return TRY((((TRY((((TRY(ByteString::from_utf8("("sv))) + (TRY((((*this).codegen_checked_binary_op(lhs,rhs,((op).op),type_id))))))))) + (TRY(ByteString::from_utf8(")"sv))))));
+return TRY((((TRY(((((ByteString::must_from_utf8("("sv))) + (TRY((((*this).codegen_checked_binary_op(lhs,rhs,((op).op),type_id))))))))) + ((ByteString::must_from_utf8(")"sv))))));
 }
 
 }
@@ -9987,10 +9984,10 @@ return JaktInternal::ExplicitValue<void>();
 case 4 /* Modulo */: {
 {
 if (((((*this).compiler))->optimize)){
-return TRY((((TRY((((TRY(ByteString::from_utf8("("sv))) + (TRY((((*this).codegen_unchecked_binary_op(lhs,rhs,((op).op),type_id))))))))) + (TRY(ByteString::from_utf8(")"sv))))));
+return TRY((((TRY(((((ByteString::must_from_utf8("("sv))) + (TRY((((*this).codegen_unchecked_binary_op(lhs,rhs,((op).op),type_id))))))))) + ((ByteString::must_from_utf8(")"sv))))));
 }
 else {
-return TRY((((TRY((((TRY(ByteString::from_utf8("("sv))) + (TRY((((*this).codegen_checked_binary_op(lhs,rhs,((op).op),type_id))))))))) + (TRY(ByteString::from_utf8(")"sv))))));
+return TRY((((TRY(((((ByteString::must_from_utf8("("sv))) + (TRY((((*this).codegen_checked_binary_op(lhs,rhs,((op).op),type_id))))))))) + ((ByteString::must_from_utf8(")"sv))))));
 }
 
 }
@@ -9999,10 +9996,10 @@ return JaktInternal::ExplicitValue<void>();
 case 27 /* AddAssign */: {
 {
 if (((((*this).compiler))->optimize)){
-return TRY((((TRY((((TRY(ByteString::from_utf8("("sv))) + (TRY((((*this).codegen_unchecked_binary_op_assignment(lhs,rhs,((op).op),type_id))))))))) + (TRY(ByteString::from_utf8(")"sv))))));
+return TRY((((TRY(((((ByteString::must_from_utf8("("sv))) + (TRY((((*this).codegen_unchecked_binary_op_assignment(lhs,rhs,((op).op),type_id))))))))) + ((ByteString::must_from_utf8(")"sv))))));
 }
 else {
-return TRY((((TRY((((TRY(ByteString::from_utf8("("sv))) + (TRY((((*this).codegen_checked_binary_op_assignment(lhs,rhs,((op).op),type_id))))))))) + (TRY(ByteString::from_utf8(")"sv))))));
+return TRY((((TRY(((((ByteString::must_from_utf8("("sv))) + (TRY((((*this).codegen_checked_binary_op_assignment(lhs,rhs,((op).op),type_id))))))))) + ((ByteString::must_from_utf8(")"sv))))));
 }
 
 }
@@ -10011,10 +10008,10 @@ return JaktInternal::ExplicitValue<void>();
 case 28 /* SubtractAssign */: {
 {
 if (((((*this).compiler))->optimize)){
-return TRY((((TRY((((TRY(ByteString::from_utf8("("sv))) + (TRY((((*this).codegen_unchecked_binary_op_assignment(lhs,rhs,((op).op),type_id))))))))) + (TRY(ByteString::from_utf8(")"sv))))));
+return TRY((((TRY(((((ByteString::must_from_utf8("("sv))) + (TRY((((*this).codegen_unchecked_binary_op_assignment(lhs,rhs,((op).op),type_id))))))))) + ((ByteString::must_from_utf8(")"sv))))));
 }
 else {
-return TRY((((TRY((((TRY(ByteString::from_utf8("("sv))) + (TRY((((*this).codegen_checked_binary_op_assignment(lhs,rhs,((op).op),type_id))))))))) + (TRY(ByteString::from_utf8(")"sv))))));
+return TRY((((TRY(((((ByteString::must_from_utf8("("sv))) + (TRY((((*this).codegen_checked_binary_op_assignment(lhs,rhs,((op).op),type_id))))))))) + ((ByteString::must_from_utf8(")"sv))))));
 }
 
 }
@@ -10023,10 +10020,10 @@ return JaktInternal::ExplicitValue<void>();
 case 29 /* MultiplyAssign */: {
 {
 if (((((*this).compiler))->optimize)){
-return TRY((((TRY((((TRY(ByteString::from_utf8("("sv))) + (TRY((((*this).codegen_unchecked_binary_op_assignment(lhs,rhs,((op).op),type_id))))))))) + (TRY(ByteString::from_utf8(")"sv))))));
+return TRY((((TRY(((((ByteString::must_from_utf8("("sv))) + (TRY((((*this).codegen_unchecked_binary_op_assignment(lhs,rhs,((op).op),type_id))))))))) + ((ByteString::must_from_utf8(")"sv))))));
 }
 else {
-return TRY((((TRY((((TRY(ByteString::from_utf8("("sv))) + (TRY((((*this).codegen_checked_binary_op_assignment(lhs,rhs,((op).op),type_id))))))))) + (TRY(ByteString::from_utf8(")"sv))))));
+return TRY((((TRY(((((ByteString::must_from_utf8("("sv))) + (TRY((((*this).codegen_checked_binary_op_assignment(lhs,rhs,((op).op),type_id))))))))) + ((ByteString::must_from_utf8(")"sv))))));
 }
 
 }
@@ -10035,10 +10032,10 @@ return JaktInternal::ExplicitValue<void>();
 case 31 /* DivideAssign */: {
 {
 if (((((*this).compiler))->optimize)){
-return TRY((((TRY((((TRY(ByteString::from_utf8("("sv))) + (TRY((((*this).codegen_unchecked_binary_op_assignment(lhs,rhs,((op).op),type_id))))))))) + (TRY(ByteString::from_utf8(")"sv))))));
+return TRY((((TRY(((((ByteString::must_from_utf8("("sv))) + (TRY((((*this).codegen_unchecked_binary_op_assignment(lhs,rhs,((op).op),type_id))))))))) + ((ByteString::must_from_utf8(")"sv))))));
 }
 else {
-return TRY((((TRY((((TRY(ByteString::from_utf8("("sv))) + (TRY((((*this).codegen_checked_binary_op_assignment(lhs,rhs,((op).op),type_id))))))))) + (TRY(ByteString::from_utf8(")"sv))))));
+return TRY((((TRY(((((ByteString::must_from_utf8("("sv))) + (TRY((((*this).codegen_checked_binary_op_assignment(lhs,rhs,((op).op),type_id))))))))) + ((ByteString::must_from_utf8(")"sv))))));
 }
 
 }
@@ -10047,10 +10044,10 @@ return JaktInternal::ExplicitValue<void>();
 case 30 /* ModuloAssign */: {
 {
 if (((((*this).compiler))->optimize)){
-return TRY((((TRY((((TRY(ByteString::from_utf8("("sv))) + (TRY((((*this).codegen_unchecked_binary_op_assignment(lhs,rhs,((op).op),type_id))))))))) + (TRY(ByteString::from_utf8(")"sv))))));
+return TRY((((TRY(((((ByteString::must_from_utf8("("sv))) + (TRY((((*this).codegen_unchecked_binary_op_assignment(lhs,rhs,((op).op),type_id))))))))) + ((ByteString::must_from_utf8(")"sv))))));
 }
 else {
-return TRY((((TRY((((TRY(ByteString::from_utf8("("sv))) + (TRY((((*this).codegen_checked_binary_op_assignment(lhs,rhs,((op).op),type_id))))))))) + (TRY(ByteString::from_utf8(")"sv))))));
+return TRY((((TRY(((((ByteString::must_from_utf8("("sv))) + (TRY((((*this).codegen_checked_binary_op_assignment(lhs,rhs,((op).op),type_id))))))))) + ((ByteString::must_from_utf8(")"sv))))));
 }
 
 }
@@ -10069,7 +10066,7 @@ return JaktInternal::ExplicitValue<void>();
     _jakt_value.release_value();
 });
 }
-ByteString output = TRY(ByteString::from_utf8("("sv));
+ByteString output = (ByteString::must_from_utf8("("sv));
 TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 {
 (self = TRY((((self) + (rhs)))));
@@ -10088,94 +10085,94 @@ return {};
 auto&& __jakt_match_variant = ((op).op);
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 0 /* Add */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8(" + "sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8(" + "sv)));
 };/*case end*/
 case 1 /* Subtract */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8(" - "sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8(" - "sv)));
 };/*case end*/
 case 2 /* Multiply */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8(" * "sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8(" * "sv)));
 };/*case end*/
 case 4 /* Modulo */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8(" % "sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8(" % "sv)));
 };/*case end*/
 case 3 /* Divide */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8(" / "sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8(" / "sv)));
 };/*case end*/
 case 21 /* Assign */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8(" = "sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8(" = "sv)));
 };/*case end*/
 case 27 /* AddAssign */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8(" += "sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8(" += "sv)));
 };/*case end*/
 case 28 /* SubtractAssign */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8(" -= "sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8(" -= "sv)));
 };/*case end*/
 case 29 /* MultiplyAssign */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8(" *= "sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8(" *= "sv)));
 };/*case end*/
 case 30 /* ModuloAssign */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8(" %= "sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8(" %= "sv)));
 };/*case end*/
 case 31 /* DivideAssign */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8(" /= "sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8(" /= "sv)));
 };/*case end*/
 case 22 /* BitwiseAndAssign */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8(" &= "sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8(" &= "sv)));
 };/*case end*/
 case 23 /* BitwiseOrAssign */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8(" |= "sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8(" |= "sv)));
 };/*case end*/
 case 24 /* BitwiseXorAssign */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8(" ^= "sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8(" ^= "sv)));
 };/*case end*/
 case 25 /* BitwiseLeftShiftAssign */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8(" <<= "sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8(" <<= "sv)));
 };/*case end*/
 case 26 /* BitwiseRightShiftAssign */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8(" >>= "sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8(" >>= "sv)));
 };/*case end*/
 case 9 /* Equal */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8(" == "sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8(" == "sv)));
 };/*case end*/
 case 10 /* NotEqual */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8(" != "sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8(" != "sv)));
 };/*case end*/
 case 5 /* LessThan */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8(" < "sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8(" < "sv)));
 };/*case end*/
 case 6 /* LessThanOrEqual */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8(" <= "sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8(" <= "sv)));
 };/*case end*/
 case 7 /* GreaterThan */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8(" > "sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8(" > "sv)));
 };/*case end*/
 case 8 /* GreaterThanOrEqual */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8(" >= "sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8(" >= "sv)));
 };/*case end*/
 case 18 /* LogicalAnd */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8(" && "sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8(" && "sv)));
 };/*case end*/
 case 19 /* LogicalOr */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8(" || "sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8(" || "sv)));
 };/*case end*/
 case 11 /* BitwiseAnd */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8(" & "sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8(" & "sv)));
 };/*case end*/
 case 13 /* BitwiseOr */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8(" | "sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8(" | "sv)));
 };/*case end*/
 case 12 /* BitwiseXor */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8(" ^ "sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8(" ^ "sv)));
 };/*case end*/
 case 16 /* ArithmeticLeftShift */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8(" << "sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8(" << "sv)));
 };/*case end*/
 case 14 /* BitwiseLeftShift */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8(" << "sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8(" << "sv)));
 };/*case end*/
 case 15 /* BitwiseRightShift */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8(" >> "sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8(" >> "sv)));
 };/*case end*/
 default: {
 {
@@ -10202,7 +10199,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8(")"sv)))));
+(output,(ByteString::must_from_utf8(")"sv)))));
 return output;
 }
 }
@@ -10210,22 +10207,22 @@ return output;
 ErrorOr<ByteString> codegen::CodeGenerator::current_error_handler() const {
 {
 if ((((*this).inside_defer) || ((((((*this).current_function)).has_value()) && (((((((*this).current_function).value()))->return_type_id)).equals(types::never_type_id()))) && (!(((((*this).control_flow_state)).passes_through_try)))))){
-return TRY(ByteString::from_utf8("MUST"sv));
+return (ByteString::must_from_utf8("MUST"sv));
 }
-return TRY(ByteString::from_utf8("TRY"sv));
+return (ByteString::must_from_utf8("TRY"sv));
 }
 }
 
 ErrorOr<ByteString> codegen::CodeGenerator::codegen_enum_match(types::CheckedEnum const enum_,NonnullRefPtr<typename types::CheckedExpression> const expr,JaktInternal::DynamicArray<types::CheckedMatchCase> const match_cases,ids::TypeId const type_id,bool const all_variants_constant) {
 {
-ByteString output = TRY(ByteString::from_utf8(""sv));
+ByteString output = (ByteString::must_from_utf8(""sv));
 ByteString const subject = TRY((((*this).codegen_expression(expr))));
 bool const needs_deref = (((enum_).is_boxed) && [](ByteString const& self, ByteString rhs) -> bool {
 {
 return (!(((self) == (rhs))));
 }
 }
-(subject,TRY(ByteString::from_utf8("*this"sv))));
+(subject,(ByteString::must_from_utf8("*this"sv))));
 ByteString const cpp_match_result_type = TRY((((*this).codegen_type(type_id))));
 if (((((enum_).underlying_type_id)).equals(types::void_type_id()))){
 TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
@@ -10234,7 +10231,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8("([&]() -> JaktInternal::ExplicitValueOrControlFlow<"sv)))));
+(output,(ByteString::must_from_utf8("([&]() -> JaktInternal::ExplicitValueOrControlFlow<"sv)))));
 TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 {
 (self = TRY((((self) + (rhs)))));
@@ -10248,7 +10245,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8(", "sv)))));
+(output,(ByteString::must_from_utf8(", "sv)))));
 TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 {
 (self = TRY((((self) + (rhs)))));
@@ -10262,14 +10259,14 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8(">{\n"sv)))));
+(output,(ByteString::must_from_utf8(">{\n"sv)))));
 TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 {
 (self = TRY((((self) + (rhs)))));
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8("auto&& __jakt_match_variant = "sv)))));
+(output,(ByteString::must_from_utf8("auto&& __jakt_match_variant = "sv)))));
 if (needs_deref){
 TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 {
@@ -10277,7 +10274,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8("*"sv)))));
+(output,(ByteString::must_from_utf8("*"sv)))));
 }
 TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 {
@@ -10285,14 +10282,14 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY((((TRY((((*this).codegen_expression(expr))))) + (TRY(ByteString::from_utf8(";\n"sv)))))))));
+(output,TRY((((TRY((((*this).codegen_expression(expr))))) + ((ByteString::must_from_utf8(";\n"sv)))))))));
 TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 {
 (self = TRY((((self) + (rhs)))));
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8("switch(__jakt_match_variant.__jakt_init_index()) {\n"sv)))));
+(output,(ByteString::must_from_utf8("switch(__jakt_match_variant.__jakt_init_index()) {\n"sv)))));
 bool has_default = false;
 {
 JaktInternal::ArrayIterator<types::CheckedMatchCase> _magic = ((match_cases).iterator());
@@ -10326,7 +10323,7 @@ return JaktInternal::ExplicitValue(id);
 };/*case end*/
 default: {
 {
-utility::panic(TRY(ByteString::from_utf8("Expected enum type"sv)));
+utility::panic((ByteString::must_from_utf8("Expected enum type"sv)));
 }
 };/*case end*/
 }/*switch end*/
@@ -10348,7 +10345,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY((((TRY((__jakt_format((StringView::from_string_literal("case {} /* {} */: "sv)),index,((variant).name()))))) + (TRY(ByteString::from_utf8("{\n"sv)))))))));
+(output,TRY((((TRY((__jakt_format((StringView::from_string_literal("case {} /* {} */: "sv)),index,((variant).name()))))) + ((ByteString::must_from_utf8("{\n"sv)))))))));
 ({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<void, ErrorOr<ByteString>>{
 auto&& __jakt_match_variant = variant;
@@ -10387,7 +10384,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8(" const"sv)))));
+(output,(ByteString::must_from_utf8(" const"sv)))));
 }
 TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 {
@@ -10395,7 +10392,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8("& "sv)))));
+(output,(ByteString::must_from_utf8("& "sv)))));
 TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 {
 (self = TRY((((self) + (rhs)))));
@@ -10409,7 +10406,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8(" = __jakt_match_value.value;\n"sv)))));
+(output,(ByteString::must_from_utf8(" = __jakt_match_value.value;\n"sv)))));
 }
 }
 return JaktInternal::ExplicitValue<void>();
@@ -10450,7 +10447,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8(" const"sv)))));
+(output,(ByteString::must_from_utf8(" const"sv)))));
 }
 TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 {
@@ -10458,7 +10455,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8("& "sv)))));
+(output,(ByteString::must_from_utf8("& "sv)))));
 TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 {
 (self = TRY((((self) + (rhs)))));
@@ -10472,7 +10469,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8(" = __jakt_match_value."sv)))));
+(output,(ByteString::must_from_utf8(" = __jakt_match_value."sv)))));
 TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 {
 (self = TRY((((self) + (rhs)))));
@@ -10486,7 +10483,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8(";\n"sv)))));
+(output,(ByteString::must_from_utf8(";\n"sv)))));
 }
 
 }
@@ -10547,7 +10544,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8("};/*case end*/\n"sv)))));
+(output,(ByteString::must_from_utf8("};/*case end*/\n"sv)))));
 }
 return JaktInternal::ExplicitValue<void>();
 };/*case end*/
@@ -10561,7 +10558,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8("default: {\n"sv)))));
+(output,(ByteString::must_from_utf8("default: {\n"sv)))));
 {
 JaktInternal::ArrayIterator<NonnullRefPtr<typename types::CheckedStatement>> _magic = ((((match_case).common.init_common.defaults)).iterator());
 for (;;){
@@ -10596,13 +10593,13 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8("};/*case end*/\n"sv)))));
+(output,(ByteString::must_from_utf8("};/*case end*/\n"sv)))));
 }
 return JaktInternal::ExplicitValue<void>();
 };/*case end*/
 default: {
 {
-utility::panic(TRY(ByteString::from_utf8("Matching enum subject with non-enum value"sv)));
+utility::panic((ByteString::must_from_utf8("Matching enum subject with non-enum value"sv)));
 }
 return JaktInternal::ExplicitValue<void>();
 };/*case end*/
@@ -10624,7 +10621,7 @@ return JaktInternal::ExplicitValue<void>();
 
 if ((!(has_default))){
 if (((((((enum_).variants)).size())) != (((match_cases).size())))){
-utility::panic(TRY(ByteString::from_utf8("Inexhaustive match statement"sv)));
+utility::panic((ByteString::must_from_utf8("Inexhaustive match statement"sv)));
 }
 TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 {
@@ -10632,7 +10629,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8("default: VERIFY_NOT_REACHED();"sv)))));
+(output,(ByteString::must_from_utf8("default: VERIFY_NOT_REACHED();"sv)))));
 }
 TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 {
@@ -10640,14 +10637,14 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8("}/*switch end*/\n"sv)))));
+(output,(ByteString::must_from_utf8("}/*switch end*/\n"sv)))));
 TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 {
 (self = TRY((((self) + (rhs)))));
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8("}()\n)"sv)))));
+(output,(ByteString::must_from_utf8("}()\n)"sv)))));
 }
 else {
 TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
@@ -10656,7 +10653,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8("([&]() -> JaktInternal::ExplicitValueOrControlFlow<"sv)))));
+(output,(ByteString::must_from_utf8("([&]() -> JaktInternal::ExplicitValueOrControlFlow<"sv)))));
 TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 {
 (self = TRY((((self) + (rhs)))));
@@ -10670,7 +10667,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8(", "sv)))));
+(output,(ByteString::must_from_utf8(", "sv)))));
 TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 {
 (self = TRY((((self) + (rhs)))));
@@ -10684,14 +10681,14 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8(">{\n"sv)))));
+(output,(ByteString::must_from_utf8(">{\n"sv)))));
 TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 {
 (self = TRY((((self) + (rhs)))));
 }
 return {};
 }
-(output,TRY((((TRY((((TRY(ByteString::from_utf8("switch ("sv))) + (TRY((((*this).codegen_expression(expr))))))))) + (TRY(ByteString::from_utf8(") {\n"sv)))))))));
+(output,TRY((((TRY(((((ByteString::must_from_utf8("switch ("sv))) + (TRY((((*this).codegen_expression(expr))))))))) + ((ByteString::must_from_utf8(") {\n"sv)))))))));
 {
 JaktInternal::ArrayIterator<types::CheckedMatchCase> _magic = ((match_cases).iterator());
 for (;;){
@@ -10715,7 +10712,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY((((TRY((((TRY((((TRY((((TRY(ByteString::from_utf8("case "sv))) + (((enum_).name)))))) + (TRY(ByteString::from_utf8("::"sv))))))) + (name))))) + (TRY(ByteString::from_utf8(": {\n"sv)))))))));
+(output,TRY((((TRY((((TRY((((TRY(((((ByteString::must_from_utf8("case "sv))) + (((enum_).name)))))) + ((ByteString::must_from_utf8("::"sv))))))) + (name))))) + ((ByteString::must_from_utf8(": {\n"sv)))))))));
 TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 {
 (self = TRY((((self) + (rhs)))));
@@ -10729,7 +10726,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8("}\n"sv)))));
+(output,(ByteString::must_from_utf8("}\n"sv)))));
 }
 return JaktInternal::ExplicitValue<void>();
 };/*case end*/
@@ -10742,7 +10739,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8("default: {\n"sv)))));
+(output,(ByteString::must_from_utf8("default: {\n"sv)))));
 TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 {
 (self = TRY((((self) + (rhs)))));
@@ -10756,7 +10753,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8("}\n"sv)))));
+(output,(ByteString::must_from_utf8("}\n"sv)))));
 }
 return JaktInternal::ExplicitValue<void>();
 };/*case end*/
@@ -10788,14 +10785,14 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8("}/*switch end*/\n"sv)))));
+(output,(ByteString::must_from_utf8("}/*switch end*/\n"sv)))));
 TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 {
 (self = TRY((((self) + (rhs)))));
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8("}()\n)"sv)))));
+(output,(ByteString::must_from_utf8("}()\n)"sv)))));
 }
 
 return TRY((((((*this).control_flow_state)).apply_control_flow_macro(output,(((((*this).current_function).value()))->return_type_id),(((((*this).current_function).value()))->can_throw),cpp_match_result_type))));
@@ -10810,7 +10807,7 @@ if (((((func)->owner_scope)).has_value())){
 return TRY((((*this).codegen_namespace_qualifier((((func)->owner_scope).value()),false,TRY((((((call).name_for_codegen())).as_name_for_use()))),((func)->owner_scope_generics)))));
 }
 }
-ByteString output = TRY(ByteString::from_utf8(""sv));
+ByteString output = (ByteString::must_from_utf8(""sv));
 size_t index = static_cast<size_t>(0ULL);
 {
 JaktInternal::ArrayIterator<types::ResolvedNamespace> _magic = ((((call).namespace_)).iterator());
@@ -10838,7 +10835,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8("<"sv)))));
+(output,(ByteString::must_from_utf8("<"sv)))));
 size_t i = static_cast<size_t>(0ULL);
 {
 JaktInternal::ArrayIterator<ids::TypeId> _magic = (((((namespace_).generic_parameters).value())).iterator());
@@ -10863,7 +10860,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8(","sv)))));
+(output,(ByteString::must_from_utf8(","sv)))));
 }
 (++(i));
 }
@@ -10877,7 +10874,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8(">"sv)))));
+(output,(ByteString::must_from_utf8(">"sv)))));
 }
 TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 {
@@ -10885,7 +10882,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8("::"sv)))));
+(output,(ByteString::must_from_utf8("::"sv)))));
 (++(index));
 }
 
@@ -10989,14 +10986,14 @@ TRY((((output).append(TRY((assign(TRY((__jakt_format((StringView::from_string_li
 }
 
 if (is_constructor){
-TRY((((*this).codegen_for_enum_variants(((enum_)),((placement_new)),TRY(ByteString::from_utf8("rhs.__jakt_init_index()"sv)),((output))))));
+TRY((((*this).codegen_for_enum_variants(((enum_)),((placement_new)),(ByteString::must_from_utf8("rhs.__jakt_init_index()"sv)),((output))))));
 }
 else {
 TRY((((output).append((StringView::from_string_literal("if (this->__jakt_variant_index != rhs.__jakt_variant_index) {\n"sv))))));
 TRY((((output).append((StringView::from_string_literal("this->__jakt_destroy_variant();\n"sv))))));
-TRY((((*this).codegen_for_enum_variants(((enum_)),((placement_new)),TRY(ByteString::from_utf8("rhs.__jakt_init_index()"sv)),((output))))));
+TRY((((*this).codegen_for_enum_variants(((enum_)),((placement_new)),(ByteString::must_from_utf8("rhs.__jakt_init_index()"sv)),((output))))));
 TRY((((output).append((StringView::from_string_literal("} else {\n"sv))))));
-TRY((((*this).codegen_for_enum_variants(((enum_)),((assign)),TRY(ByteString::from_utf8("rhs.__jakt_init_index()"sv)),((output))))));
+TRY((((*this).codegen_for_enum_variants(((enum_)),((assign)),(ByteString::must_from_utf8("rhs.__jakt_init_index()"sv)),((output))))));
 TRY((((output).append((StringView::from_string_literal("}\n"sv))))));
 }
 
@@ -11008,7 +11005,7 @@ return TRY((((output).to_string())));
 
 ErrorOr<ByteString> codegen::CodeGenerator::codegen_enum(types::CheckedEnum const enum_) {
 {
-ByteString output = TRY(ByteString::from_utf8(""sv));
+ByteString output = (ByteString::must_from_utf8(""sv));
 if ([](ids::TypeId const& self, ids::TypeId rhs) -> bool {
 {
 return (!(((self).equals(rhs))));
@@ -11022,7 +11019,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY((((TRY((((TRY((((TRY((((TRY(ByteString::from_utf8("enum class "sv))) + (((enum_).name)))))) + (TRY(ByteString::from_utf8(": "sv))))))) + (TRY((((*this).codegen_type(((enum_).underlying_type_id)))))))))) + (TRY(ByteString::from_utf8(" {\n"sv)))))))));
+(output,TRY((((TRY((((TRY((((TRY(((((ByteString::must_from_utf8("enum class "sv))) + (((enum_).name)))))) + ((ByteString::must_from_utf8(": "sv))))))) + (TRY((((*this).codegen_type(((enum_).underlying_type_id)))))))))) + ((ByteString::must_from_utf8(" {\n"sv)))))))));
 {
 JaktInternal::ArrayIterator<types::CheckedEnumVariant> _magic = ((((enum_).variants)).iterator());
 for (;;){
@@ -11045,7 +11042,7 @@ switch(__jakt_match_variant.__jakt_init_index()) {
 case 2 /* WithValue */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.WithValue;ByteString const& name = __jakt_match_value.name;
 NonnullRefPtr<typename types::CheckedExpression> const& expr = __jakt_match_value.expr;
-return JaktInternal::ExplicitValue(TRY((((TRY((((TRY((((name) + (TRY(ByteString::from_utf8(" = "sv))))))) + (TRY((((*this).codegen_expression(expr))))))))) + (TRY(ByteString::from_utf8(",\n"sv)))))));
+return JaktInternal::ExplicitValue(TRY((((TRY((((TRY((((name) + ((ByteString::must_from_utf8(" = "sv))))))) + (TRY((((*this).codegen_expression(expr))))))))) + ((ByteString::must_from_utf8(",\n"sv)))))));
 };/*case end*/
 default: {
 {
@@ -11068,17 +11065,17 @@ utility::todo(TRY((__jakt_format((StringView::from_string_literal("codegen_enum 
 }
 }
 
-return TRY((((output) + (TRY(ByteString::from_utf8("};\n"sv))))));
+return TRY((((output) + ((ByteString::must_from_utf8("};\n"sv))))));
 }
 else {
-utility::todo(TRY(ByteString::from_utf8("Enums with a non-integer underlying type"sv)));
+utility::todo((ByteString::must_from_utf8("Enums with a non-integer underlying type"sv)));
 }
 
 }
 bool const is_generic = (!(((((enum_).generic_parameters)).is_empty())));
 JaktInternal::DynamicArray<ByteString> generic_parameter_names = (TRY((DynamicArray<ByteString>::create_with({}))));
 ByteString template_args = TRY((((*this).codegen_template_parameter_names(((enum_).generic_parameters),((generic_parameter_names))))));
-ByteString const generic_parameter_list = TRY((utility::join(generic_parameter_names,TRY(ByteString::from_utf8(", "sv)))));
+ByteString const generic_parameter_list = TRY((utility::join(generic_parameter_names,(ByteString::must_from_utf8(", "sv)))));
 if (is_generic){
 TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 {
@@ -11086,7 +11083,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY((((TRY((((TRY(ByteString::from_utf8("template<"sv))) + (template_args))))) + (TRY(ByteString::from_utf8(">\n"sv)))))))));
+(output,TRY((((TRY(((((ByteString::must_from_utf8("template<"sv))) + (template_args))))) + ((ByteString::must_from_utf8(">\n"sv)))))))));
 }
 TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 {
@@ -11110,7 +11107,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY((__jakt_format((StringView::from_string_literal("<{}>"sv)),TRY((utility::join(generic_parameter_names,TRY(ByteString::from_utf8(", "sv)))))))))));
+(output,TRY((__jakt_format((StringView::from_string_literal("<{}>"sv)),TRY((utility::join(generic_parameter_names,(ByteString::must_from_utf8(", "sv)))))))))));
 }
 TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 {
@@ -11118,7 +11115,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8(">"sv)))));
+(output,(ByteString::must_from_utf8(">"sv)))));
 }
 TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 {
@@ -11126,22 +11123,22 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8(" {\n"sv)))));
+(output,(ByteString::must_from_utf8(" {\n"sv)))));
 size_t const max_index_value = ((((enum_).variants)).size());
 ByteString const index_type = ({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<ByteString,ErrorOr<ByteString>>{
 auto __jakt_enum_value = (max_index_value);
 if (__jakt_enum_value >= static_cast<size_t>(0ULL)&& __jakt_enum_value < static_cast<size_t>(256ULL)) {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("u8"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("u8"sv)));
 }
 else if (__jakt_enum_value >= static_cast<size_t>(256ULL)&& __jakt_enum_value < static_cast<size_t>(65536ULL)) {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("u16"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("u16"sv)));
 }
 else if (__jakt_enum_value >= static_cast<size_t>(65536ULL)&& __jakt_enum_value < static_cast<size_t>(4294967296ULL)) {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("u32"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("u32"sv)));
 }
 else {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("size_t"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("size_t"sv)));
 }
 }());
     if (_jakt_value.is_return())
@@ -11166,21 +11163,21 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8("union CommonData {\n"sv)))));
+(output,(ByteString::must_from_utf8("union CommonData {\n"sv)))));
 TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 {
 (self = TRY((((self) + (rhs)))));
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8("u8 __jakt_uninit_common;\n"sv)))));
+(output,(ByteString::must_from_utf8("u8 __jakt_uninit_common;\n"sv)))));
 TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 {
 (self = TRY((((self) + (rhs)))));
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8("struct {\n"sv)))));
+(output,(ByteString::must_from_utf8("struct {\n"sv)))));
 {
 JaktInternal::ArrayIterator<JaktInternal::Tuple<ByteString,ByteString>> _magic = ((common_fields).iterator());
 for (;;){
@@ -11212,28 +11209,28 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8("} init_common;\n"sv)))));
+(output,(ByteString::must_from_utf8("} init_common;\n"sv)))));
 TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 {
 (self = TRY((((self) + (rhs)))));
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8("constexpr CommonData() {}\n"sv)))));
+(output,(ByteString::must_from_utf8("constexpr CommonData() {}\n"sv)))));
 TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 {
 (self = TRY((((self) + (rhs)))));
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8("~CommonData() {}\n"sv)))));
+(output,(ByteString::must_from_utf8("~CommonData() {}\n"sv)))));
 TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 {
 (self = TRY((((self) + (rhs)))));
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8("} common;\n"sv)))));
+(output,(ByteString::must_from_utf8("} common;\n"sv)))));
 }
 TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 {
@@ -11241,14 +11238,14 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8("union VariantData {\n"sv)))));
+(output,(ByteString::must_from_utf8("union VariantData {\n"sv)))));
 TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 {
 (self = TRY((((self) + (rhs)))));
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8("u8 __jakt_uninit_value;\n"sv)))));
+(output,(ByteString::must_from_utf8("u8 __jakt_uninit_value;\n"sv)))));
 {
 JaktInternal::Range<size_t> _magic = (JaktInternal::Range<size_t>{static_cast<size_t>(static_cast<size_t>(0ULL)),static_cast<size_t>(((((enum_).variants)).size()))});
 for (;;){
@@ -11267,7 +11264,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8("struct {\n"sv)))));
+(output,(ByteString::must_from_utf8("struct {\n"sv)))));
 {
 JaktInternal::ArrayIterator<JaktInternal::Tuple<ByteString,ByteString>> _magic = ((fields).iterator());
 for (;;){
@@ -11312,21 +11309,21 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8("constexpr VariantData() {}\n"sv)))));
+(output,(ByteString::must_from_utf8("constexpr VariantData() {}\n"sv)))));
 TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 {
 (self = TRY((((self) + (rhs)))));
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8("~VariantData() {}\n"sv)))));
+(output,(ByteString::must_from_utf8("~VariantData() {}\n"sv)))));
 TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 {
 (self = TRY((((self) + (rhs)))));
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8("} as;\n"sv)))));
+(output,(ByteString::must_from_utf8("} as;\n"sv)))));
 TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 {
 (self = TRY((((self) + (rhs)))));
@@ -11341,7 +11338,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8("ErrorOr<ByteString> debug_description() const;\n"sv)))));
+(output,(ByteString::must_from_utf8("ErrorOr<ByteString> debug_description() const;\n"sv)))));
 }
 else {
 TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
@@ -11375,7 +11372,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8("private: void __jakt_destroy_variant() {\n"sv)))));
+(output,(ByteString::must_from_utf8("private: void __jakt_destroy_variant() {\n"sv)))));
 TRY((((*this).codegen_enum_destroy_variant(enum_,((output))))));
 TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 {
@@ -11383,14 +11380,14 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8("}\n"sv)))));
+(output,(ByteString::must_from_utf8("}\n"sv)))));
 TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 {
 (self = TRY((((self) + (rhs)))));
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8("public:\n"sv)))));
+(output,(ByteString::must_from_utf8("public:\n"sv)))));
 }
 else {
 {
@@ -11413,7 +11410,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8(";\n"sv)))));
+(output,(ByteString::must_from_utf8(";\n"sv)))));
 }
 
 }
@@ -11460,14 +11457,14 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8("private: void __jakt_destroy_variant();\n"sv)))));
+(output,(ByteString::must_from_utf8("private: void __jakt_destroy_variant();\n"sv)))));
 TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 {
 (self = TRY((((self) + (rhs)))));
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8("public:\n"sv)))));
+(output,(ByteString::must_from_utf8("public:\n"sv)))));
 }
 
 NonnullRefPtr<types::Scope> const enum_scope = TRY((((((*this).program))->get_scope(((enum_).scope_id)))));
@@ -11546,7 +11543,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8("};\n"sv)))));
+(output,(ByteString::must_from_utf8("};\n"sv)))));
 TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 {
 (self = TRY((((self) + (rhs)))));
@@ -11560,7 +11557,7 @@ return output;
 
 ErrorOr<ByteString> codegen::CodeGenerator::codegen_struct_type(ids::StructId const id,bool const as_namespace) {
 {
-ByteString output = TRY(ByteString::from_utf8(""sv));
+ByteString output = (ByteString::must_from_utf8(""sv));
 NonnullRefPtr<types::Module> const type_module = ((((*this).program))->get_module(((id).module)));
 types::CheckedStruct const checked_struct = ((((*this).program))->get_struct(id));
 if (((!(as_namespace)) && ((((checked_struct).record_type)).__jakt_init_index() == 1 /* Class */))){
@@ -11570,7 +11567,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8("NonnullRefPtr<"sv)))));
+(output,(ByteString::must_from_utf8("NonnullRefPtr<"sv)))));
 TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 {
 (self = TRY((((self) + (rhs)))));
@@ -11591,7 +11588,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8(">"sv)))));
+(output,(ByteString::must_from_utf8(">"sv)))));
 }
 else {
 TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
@@ -11616,7 +11613,7 @@ return output;
 
 ErrorOr<ByteString> codegen::CodeGenerator::codegen_enum_predecl(types::CheckedEnum const enum_) {
 {
-ByteString output = TRY(ByteString::from_utf8(""sv));
+ByteString output = (ByteString::must_from_utf8(""sv));
 if ([](ids::TypeId const& self, ids::TypeId rhs) -> bool {
 {
 return (!(((self).equals(rhs))));
@@ -11627,7 +11624,7 @@ if (((((*this).program))->is_integer(((enum_).underlying_type_id)))){
 return TRY((__jakt_format((StringView::from_string_literal("enum class {}: {};"sv)),((enum_).name),TRY((((*this).codegen_type(((enum_).underlying_type_id))))))));
 }
 else {
-utility::todo(TRY(ByteString::from_utf8("Enums with a non-integer underlying type"sv)));
+utility::todo((ByteString::must_from_utf8("Enums with a non-integer underlying type"sv)));
 }
 
 }
@@ -11820,7 +11817,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(((output)),TRY(ByteString::from_utf8("[[nodiscard]] "sv)))));
+(((output)),(ByteString::must_from_utf8("[[nodiscard]] "sv)))));
 if (is_inline){
 TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 {
@@ -11948,14 +11945,14 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(((output)),TRY(ByteString::from_utf8(")"sv)))));
+(((output)),(ByteString::must_from_utf8(")"sv)))));
 }
 return {};
 }
 
 ErrorOr<ByteString> codegen::CodeGenerator::codegen_generic_enum_instance(ids::EnumId const id,JaktInternal::DynamicArray<ids::TypeId> const args,bool const as_namespace) {
 {
-ByteString output = TRY(ByteString::from_utf8(""sv));
+ByteString output = (ByteString::must_from_utf8(""sv));
 bool close_tag = false;
 types::CheckedEnum const enum_ = ((((*this).program))->get_enum(id));
 if (((!(as_namespace)) && ((enum_).is_boxed))){
@@ -11965,7 +11962,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8("NonnullRefPtr<"sv)))));
+(output,(ByteString::must_from_utf8("NonnullRefPtr<"sv)))));
 ByteString const qualifier = TRY((((*this).codegen_namespace_qualifier(((enum_).scope_id),true,JaktInternal::OptionalNone(),JaktInternal::OptionalNone()))));
 if ((!(((qualifier).is_empty())))){
 TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
@@ -11974,7 +11971,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8("typename "sv)))));
+(output,(ByteString::must_from_utf8("typename "sv)))));
 TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 {
 (self = TRY((((self) + (rhs)))));
@@ -12002,7 +11999,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8("typename "sv)))));
+(output,(ByteString::must_from_utf8("typename "sv)))));
 }
 TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 {
@@ -12027,7 +12024,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8("<"sv)))));
+(output,(ByteString::must_from_utf8("<"sv)))));
 bool first = true;
 {
 JaktInternal::ArrayIterator<ids::TypeId> _magic = ((args).iterator());
@@ -12045,7 +12042,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8(", "sv)))));
+(output,(ByteString::must_from_utf8(", "sv)))));
 }
 else {
 (first = false);
@@ -12069,7 +12066,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8(">"sv)))));
+(output,(ByteString::must_from_utf8(">"sv)))));
 if (close_tag){
 TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 {
@@ -12077,7 +12074,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8(">"sv)))));
+(output,(ByteString::must_from_utf8(">"sv)))));
 }
 return output;
 }
@@ -12085,7 +12082,7 @@ return output;
 
 ErrorOr<ByteString> codegen::CodeGenerator::codegen_enum_constructors(types::CheckedEnum const enum_,bool const is_inside_struct,JaktInternal::Optional<ByteString> const generic_parameter_list,JaktInternal::DynamicArray<JaktInternal::Tuple<ByteString,JaktInternal::DynamicArray<JaktInternal::Tuple<ByteString,ByteString>>>> const variant_field_list,JaktInternal::DynamicArray<JaktInternal::Tuple<ByteString,ByteString>> const common_fields) const {
 {
-ByteString output = TRY(ByteString::from_utf8(""sv));
+ByteString output = (ByteString::must_from_utf8(""sv));
 bool const is_generic = (!(((((enum_).generic_parameters)).is_empty())));
 ByteString const ctor_result_type = TRY((codegen::CodeGenerator::enum_constructor_result_type(enum_,generic_parameter_list)));
 ByteString const ctor_type = ({
@@ -12107,10 +12104,10 @@ JaktInternal::Tuple<ByteString,ByteString> const declare_uninit_deref_uninit_ = 
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<JaktInternal::Tuple<ByteString,ByteString>,ErrorOr<ByteString>>{
 auto __jakt_enum_value = (((enum_).is_boxed));
 if (__jakt_enum_value == true) {
-return JaktInternal::ExplicitValue((Tuple{TRY((__jakt_format((StringView::from_string_literal("NonnullRefPtr<{0}> __jakt_uninit_enum = TRY(adopt_nonnull_ref_or_enomem(new (nothrow) {0}));\n"sv)),ctor_type))), TRY(ByteString::from_utf8("__jakt_uninit_enum->"sv))}));
+return JaktInternal::ExplicitValue((Tuple{TRY((__jakt_format((StringView::from_string_literal("NonnullRefPtr<{0}> __jakt_uninit_enum = TRY(adopt_nonnull_ref_or_enomem(new (nothrow) {0}));\n"sv)),ctor_type))), (ByteString::must_from_utf8("__jakt_uninit_enum->"sv))}));
 }
 else if (__jakt_enum_value == false) {
-return JaktInternal::ExplicitValue((Tuple{TRY((__jakt_format((StringView::from_string_literal("{} __jakt_uninit_enum;\n"sv)),((enum_).name)))), TRY(ByteString::from_utf8("__jakt_uninit_enum."sv))}));
+return JaktInternal::ExplicitValue((Tuple{TRY((__jakt_format((StringView::from_string_literal("{} __jakt_uninit_enum;\n"sv)),((enum_).name)))), (ByteString::must_from_utf8("__jakt_uninit_enum."sv))}));
 }
 VERIFY_NOT_REACHED();
 }());
@@ -12148,7 +12145,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8("{\n"sv)))));
+(output,(ByteString::must_from_utf8("{\n"sv)))));
 TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 {
 (self = TRY((((self) + (rhs)))));
@@ -12213,14 +12210,14 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8("return __jakt_uninit_enum;\n"sv)))));
+(output,(ByteString::must_from_utf8("return __jakt_uninit_enum;\n"sv)))));
 TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 {
 (self = TRY((((self) + (rhs)))));
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8("}\n"sv)))));
+(output,(ByteString::must_from_utf8("}\n"sv)))));
 }
 
 }
@@ -12251,7 +12248,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8("{\n"sv)))));
+(output,(ByteString::must_from_utf8("{\n"sv)))));
 TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 {
 (self = TRY((((self) + (rhs)))));
@@ -12265,14 +12262,14 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8("return *this;\n"sv)))));
+(output,(ByteString::must_from_utf8("return *this;\n"sv)))));
 TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 {
 (self = TRY((((self) + (rhs)))));
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8("}\n"sv)))));
+(output,(ByteString::must_from_utf8("}\n"sv)))));
 if (is_inside_struct){
 TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 {
@@ -12324,7 +12321,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8("{\n"sv)))));
+(output,(ByteString::must_from_utf8("{\n"sv)))));
 TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 {
 (self = TRY((((self) + (rhs)))));
@@ -12338,14 +12335,14 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8("return *this;\n"sv)))));
+(output,(ByteString::must_from_utf8("return *this;\n"sv)))));
 TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 {
 (self = TRY((((self) + (rhs)))));
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8("}\n"sv)))));
+(output,(ByteString::must_from_utf8("}\n"sv)))));
 if (is_inside_struct){
 TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 {
@@ -12371,7 +12368,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8("{\n"sv)))));
+(output,(ByteString::must_from_utf8("{\n"sv)))));
 TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 {
 (self = TRY((((self) + (rhs)))));
@@ -12385,11 +12382,11 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8("}\n"sv)))));
+(output,(ByteString::must_from_utf8("}\n"sv)))));
 return output;
 }
 else {
-utility::panic(TRY(ByteString::from_utf8("Out of line constructor cannot be generated for generic enum"sv)));
+utility::panic((ByteString::must_from_utf8("Out of line constructor cannot be generated for generic enum"sv)));
 }
 
 }
@@ -12397,8 +12394,8 @@ utility::panic(TRY(ByteString::from_utf8("Out of line constructor cannot be gene
 
 ErrorOr<ByteString> codegen::CodeGenerator::codegen_function_return_type(NonnullRefPtr<types::CheckedFunction> const function) {
 {
-if ((TRY((((function)->is_static()))) && ((TRY((((((function)->name_for_codegen())).as_name_for_use())))) == (TRY(ByteString::from_utf8("main"sv)))))){
-return TRY(ByteString::from_utf8("ErrorOr<int>"sv));
+if ((TRY((((function)->is_static()))) && ((TRY((((((function)->name_for_codegen())).as_name_for_use())))) == ((ByteString::must_from_utf8("main"sv)))))){
+return (ByteString::must_from_utf8("ErrorOr<int>"sv));
 }
 ByteString const type_name = TRY((((*this).codegen_type(((function)->return_type_id)))));
 if (((function)->can_throw)){
@@ -12412,13 +12409,13 @@ ErrorOr<ByteString> codegen::CodeGenerator::codegen_function_in_namespace(Nonnul
 {
 if ((!(((((((function)->generics))->params)).is_empty())))){
 if (((((function)->linkage)).__jakt_init_index() == 1 /* External */)){
-return TRY(ByteString::from_utf8(""sv));
+return (ByteString::must_from_utf8(""sv));
 }
 }
 if (((((function)->force_inline)).__jakt_init_index() == 2 /* ForceInline */)){
-return TRY(ByteString::from_utf8(""sv));
+return (ByteString::must_from_utf8(""sv));
 }
-ByteString output = TRY(ByteString::from_utf8(""sv));
+ByteString output = (ByteString::must_from_utf8(""sv));
 if ((!(skip_template))){
 TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 {
@@ -12428,7 +12425,7 @@ return {};
 }
 (output,TRY((((*this).codegen_function_generic_parameters(function)))))));
 }
-bool const is_main = (((TRY((((((function)->name_for_codegen())).as_name_for_use())))) == (TRY(ByteString::from_utf8("main"sv)))) && (!(((containing_struct).has_value()))));
+bool const is_main = (((TRY((((((function)->name_for_codegen())).as_name_for_use())))) == ((ByteString::must_from_utf8("main"sv)))) && (!(((containing_struct).has_value()))));
 if (((((function)->force_inline)).__jakt_init_index() == 1 /* MakeDefinitionAvailable */)){
 TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 {
@@ -12436,7 +12433,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8("__attribute__((always_inline)) inline "sv)))));
+(output,(ByteString::must_from_utf8("__attribute__((always_inline)) inline "sv)))));
 }
 if (((((function)->return_type_id)).equals(types::never_type_id()))){
 TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
@@ -12445,7 +12442,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8("[[noreturn]] "sv)))));
+(output,(ByteString::must_from_utf8("[[noreturn]] "sv)))));
 }
 if (is_main){
 TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
@@ -12454,7 +12451,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8("ErrorOr<int>"sv)))));
+(output,(ByteString::must_from_utf8("ErrorOr<int>"sv)))));
 }
 else {
 if ((as_method && TRY((((function)->is_static()))))){
@@ -12464,7 +12461,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8("static "sv)))));
+(output,(ByteString::must_from_utf8("static "sv)))));
 }
 if ((!(((((function)->type)).__jakt_init_index() == 1 /* Destructor */)))){
 TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
@@ -12497,7 +12494,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8(" "sv)))));
+(output,(ByteString::must_from_utf8(" "sv)))));
 if (is_main){
 TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 {
@@ -12505,7 +12502,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8("main"sv)))));
+(output,(ByteString::must_from_utf8("main"sv)))));
 }
 else {
 ByteString const qualifier = ({
@@ -12515,7 +12512,7 @@ if (__jakt_enum_value == true) {
 return JaktInternal::ExplicitValue(TRY((((*this).codegen_type_possibly_as_namespace((containing_struct.value()),true)))));
 }
 else if (__jakt_enum_value == false) {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8(""sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8(""sv)));
 }
 VERIFY_NOT_REACHED();
 }());
@@ -12537,7 +12534,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8("::"sv)))));
+(output,(ByteString::must_from_utf8("::"sv)))));
 }
 if (((((function)->type)).__jakt_init_index() == 1 /* Destructor */)){
 if (((((((*this).program))->get_type((containing_struct.value()))))->__jakt_init_index() == 24 /* Struct */)){
@@ -12548,10 +12545,10 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY((((TRY(ByteString::from_utf8("~"sv))) + (TRY((((((((((*this).program))->get_struct(struct_id))).name_for_codegen())).as_name_for_definition()))))))))));
+(output,TRY(((((ByteString::must_from_utf8("~"sv))) + (TRY((((((((((*this).program))->get_struct(struct_id))).name_for_codegen())).as_name_for_definition()))))))))));
 }
 else {
-utility::panic(TRY(ByteString::from_utf8("Destructor doesn't have a containing struct"sv)));
+utility::panic((ByteString::must_from_utf8("Destructor doesn't have a containing struct"sv)));
 }
 
 }
@@ -12574,7 +12571,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8("<"sv)))));
+(output,(ByteString::must_from_utf8("<"sv)))));
 bool first = true;
 {
 JaktInternal::ArrayIterator<ids::TypeId> _magic = (((explicit_generic_instantiation.value())).iterator());
@@ -12592,7 +12589,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8(", "sv)))));
+(output,(ByteString::must_from_utf8(", "sv)))));
 }
 else {
 (first = false);
@@ -12616,7 +12613,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8(">"sv)))));
+(output,(ByteString::must_from_utf8(">"sv)))));
 }
 TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 {
@@ -12624,7 +12621,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8("("sv)))));
+(output,(ByteString::must_from_utf8("("sv)))));
 if ((is_main && ((((function)->params)).is_empty()))){
 TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 {
@@ -12632,7 +12629,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8("DynamicArray<ByteString>"sv)))));
+(output,(ByteString::must_from_utf8("DynamicArray<ByteString>"sv)))));
 }
 bool first = true;
 {
@@ -12645,7 +12642,7 @@ break;
 types::CheckedParameter param = (_magic_value.value());
 {
 NonnullRefPtr<types::CheckedVariable> const variable = ((param).variable);
-if (((((variable)->name)) == (TRY(ByteString::from_utf8("this"sv))))){
+if (((((variable)->name)) == ((ByteString::must_from_utf8("this"sv))))){
 continue;
 }
 if ((!(first))){
@@ -12655,7 +12652,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8(","sv)))));
+(output,(ByteString::must_from_utf8(","sv)))));
 }
 else {
 (first = false);
@@ -12675,7 +12672,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8(" "sv)))));
+(output,(ByteString::must_from_utf8(" "sv)))));
 if (((!(((variable)->is_mutable))) && (!((((variable_type)->__jakt_init_index() == 28 /* Reference */) || ((variable_type)->__jakt_init_index() == 29 /* MutableReference */)))))){
 TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 {
@@ -12683,7 +12680,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8("const "sv)))));
+(output,(ByteString::must_from_utf8("const "sv)))));
 }
 TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 {
@@ -12703,7 +12700,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8(")"sv)))));
+(output,(ByteString::must_from_utf8(")"sv)))));
 if (((!(TRY((((function)->is_static()))))) && (!(TRY((((function)->is_mutating()))))))){
 TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 {
@@ -12711,7 +12708,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8(" const"sv)))));
+(output,(ByteString::must_from_utf8(" const"sv)))));
 }
 TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 {
@@ -12719,7 +12716,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8(" {\n"sv)))));
+(output,(ByteString::must_from_utf8(" {\n"sv)))));
 if (is_main){
 TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 {
@@ -12727,7 +12724,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8("\n\n            #ifdef _WIN32\n            SetConsoleOutputCP(CP_UTF8);\n            // Enable buffering to prevent VS from chopping up UTF-8 byte sequences\n            setvbuf(stdout, nullptr, _IOFBF, 1000);\n            #endif\n"sv)))));
+(output,(ByteString::must_from_utf8("\n\n            #ifdef _WIN32\n            SetConsoleOutputCP(CP_UTF8);\n            // Enable buffering to prevent VS from chopping up UTF-8 byte sequences\n            setvbuf(stdout, nullptr, _IOFBF, 1000);\n            #endif\n"sv)))));
 }
 codegen::ControlFlowState const last_control_flow = ((*this).control_flow_state);
 (((*this).control_flow_state) = ((last_control_flow).enter_function()));
@@ -12747,7 +12744,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8("return 0;\n"sv)))));
+(output,(ByteString::must_from_utf8("return 0;\n"sv)))));
 }
 else {
 if ((((function)->can_throw) && ((((function)->return_type_id)).equals(types::builtin(types::BuiltinType::Void()))))){
@@ -12757,7 +12754,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8("return {};\n"sv)))));
+(output,(ByteString::must_from_utf8("return {};\n"sv)))));
 }
 }
 
@@ -12767,7 +12764,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8("}\n"sv)))));
+(output,(ByteString::must_from_utf8("}\n"sv)))));
 return output;
 }
 }
@@ -12781,7 +12778,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(((output)),TRY(ByteString::from_utf8("switch (this->__jakt_init_index()) {\n"sv)))));
+(((output)),(ByteString::must_from_utf8("switch (this->__jakt_init_index()) {\n"sv)))));
 {
 JaktInternal::Range<size_t> _magic = (JaktInternal::Range<size_t>{static_cast<size_t>(static_cast<size_t>(0ULL)),static_cast<size_t>(((((enum_).variants)).size()))});
 for (;;){
@@ -12880,7 +12877,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(((output)),TRY(ByteString::from_utf8("break;\n"sv)))));
+(((output)),(ByteString::must_from_utf8("break;\n"sv)))));
 }
 
 }
@@ -12892,7 +12889,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(((output)),TRY(ByteString::from_utf8("}\n"sv)))));
+(((output)),(ByteString::must_from_utf8("}\n"sv)))));
 }
 return {};
 }
@@ -12947,10 +12944,10 @@ return JaktInternal::ExplicitValue(false);
 }))))){
 return JaktInternal::OptionalNone();
 }
-ByteString output = TRY(ByteString::from_utf8(""sv));
+ByteString output = (ByteString::must_from_utf8(""sv));
 bool const is_full_respecialization = ((*this).is_full_respecialization(((((((function)->generics))->specializations))[(((function)->specialization_index).value())])));
 if ((define_pass && is_full_respecialization)){
-(output = TRY(ByteString::from_utf8("template<"sv)));
+(output = (ByteString::must_from_utf8("template<"sv)));
 bool first = true;
 {
 JaktInternal::ArrayIterator<ids::TypeId> _magic = ((((((((function)->generics))->specializations))[(((function)->specialization_index).value())])).iterator());
@@ -12973,7 +12970,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8(", "sv)))));
+(output,(ByteString::must_from_utf8(", "sv)))));
 }
 
 TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
@@ -12995,7 +12992,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8(">\n"sv)))));
+(output,(ByteString::must_from_utf8(">\n"sv)))));
 TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 {
 (self = TRY((((self) + (rhs)))));
@@ -13034,7 +13031,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8("\ntemplate<> "sv)))));
+(output,(ByteString::must_from_utf8("\ntemplate<> "sv)))));
 if (((((function)->return_type_id)).equals(types::never_type_id()))){
 TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 {
@@ -13042,7 +13039,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8("[[noreturn]] "sv)))));
+(output,(ByteString::must_from_utf8("[[noreturn]] "sv)))));
 }
 TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 {
@@ -13071,7 +13068,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8(" "sv)))));
+(output,(ByteString::must_from_utf8(" "sv)))));
 ByteString const qualifier = ({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<ByteString,ErrorOr<JaktInternal::Optional<ByteString>>>{
 auto __jakt_enum_value = (((containing_struct).has_value()));
@@ -13079,7 +13076,7 @@ if (__jakt_enum_value == true) {
 return JaktInternal::ExplicitValue(TRY((((*this).codegen_type_possibly_as_namespace((containing_struct.value()),true)))));
 }
 else if (__jakt_enum_value == false) {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8(""sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8(""sv)));
 }
 VERIFY_NOT_REACHED();
 }());
@@ -13101,7 +13098,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8("::"sv)))));
+(output,(ByteString::must_from_utf8("::"sv)))));
 }
 TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 {
@@ -13116,7 +13113,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8("<"sv)))));
+(output,(ByteString::must_from_utf8("<"sv)))));
 bool first = true;
 {
 JaktInternal::ArrayIterator<ids::TypeId> _magic = ((((((((function)->generics))->specializations))[(((function)->specialization_index).value())])).iterator());
@@ -13137,7 +13134,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8(", "sv)))));
+(output,(ByteString::must_from_utf8(", "sv)))));
 }
 
 TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
@@ -13158,7 +13155,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8(">("sv)))));
+(output,(ByteString::must_from_utf8(">("sv)))));
 (first = true);
 {
 JaktInternal::ArrayIterator<types::CheckedParameter> _magic = ((((function)->params)).iterator());
@@ -13170,7 +13167,7 @@ break;
 types::CheckedParameter param = (_magic_value.value());
 {
 NonnullRefPtr<types::CheckedVariable> const variable = ((param).variable);
-if (((((variable)->name)) == (TRY(ByteString::from_utf8("this"sv))))){
+if (((((variable)->name)) == ((ByteString::must_from_utf8("this"sv))))){
 continue;
 }
 if ((!(first))){
@@ -13180,7 +13177,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8(","sv)))));
+(output,(ByteString::must_from_utf8(","sv)))));
 }
 else {
 (first = false);
@@ -13200,7 +13197,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8(" "sv)))));
+(output,(ByteString::must_from_utf8(" "sv)))));
 if (((!(((variable)->is_mutable))) && (!((((variable_type)->__jakt_init_index() == 28 /* Reference */) || ((variable_type)->__jakt_init_index() == 29 /* MutableReference */)))))){
 TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 {
@@ -13208,7 +13205,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8("const "sv)))));
+(output,(ByteString::must_from_utf8("const "sv)))));
 }
 TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 {
@@ -13228,7 +13225,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8(")"sv)))));
+(output,(ByteString::must_from_utf8(")"sv)))));
 if (((!(TRY((((function)->is_static()))))) && (!(TRY((((function)->is_mutating()))))))){
 TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 {
@@ -13236,7 +13233,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8(" const"sv)))));
+(output,(ByteString::must_from_utf8(" const"sv)))));
 }
 TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 {
@@ -13244,7 +13241,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8(";\n"sv)))));
+(output,(ByteString::must_from_utf8(";\n"sv)))));
 }
 else {
 (output = TRY((__jakt_format((StringView::from_string_literal("\n/* specialisation {} of function {} omitted, not fully specialized: {} */\n"sv)),(((function)->specialization_index).value()),((function)->name),((((((function)->generics))->specializations))[(((function)->specialization_index).value())])))));
@@ -13256,21 +13253,21 @@ return output;
 
 ErrorOr<ByteString> codegen::CodeGenerator::codegen_destructor_predecl(types::CheckedStruct const& struct_) {
 {
-ByteString output = TRY(ByteString::from_utf8(""sv));
+ByteString output = (ByteString::must_from_utf8(""sv));
 TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 {
 (self = TRY((((self) + (rhs)))));
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8("public:\n"sv)))));
+(output,(ByteString::must_from_utf8("public:\n"sv)))));
 TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 {
 (self = TRY((((self) + (rhs)))));
 }
 return {};
 }
-(output,TRY((((TRY((((TRY(ByteString::from_utf8("    ~"sv))) + (TRY((((((((struct_))).name_for_codegen())).as_name_for_definition())))))))) + (TRY(ByteString::from_utf8("();\n"sv)))))))));
+(output,TRY((((TRY(((((ByteString::must_from_utf8("    ~"sv))) + (TRY((((((((struct_))).name_for_codegen())).as_name_for_definition())))))))) + ((ByteString::must_from_utf8("();\n"sv)))))))));
 return output;
 }
 }
@@ -13350,11 +13347,11 @@ return dependencies;
 ErrorOr<ByteString> codegen::CodeGenerator::codegen_namespace(NonnullRefPtr<types::Scope> const scope,NonnullRefPtr<types::Module> const current_module,bool const as_forward) {
 {
 if ((((((scope)->alias_path)).has_value()) || ((((scope)->import_path_if_extern)).has_value()))){
-return TRY(ByteString::from_utf8(""sv));
+return (ByteString::must_from_utf8(""sv));
 }
 JaktInternal::Set<ids::TypeId> seen_types = (TRY((Set<ids::TypeId>::create_with_values({}))));
 if (as_forward){
-ByteString output = TRY(ByteString::from_utf8(""sv));
+ByteString output = (ByteString::must_from_utf8(""sv));
 if (((((scope)->namespace_name)).has_value())){
 TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 {
@@ -13362,7 +13359,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY((((TRY((((TRY(ByteString::from_utf8("namespace "sv))) + ((((scope)->namespace_name).value())))))) + (TRY(ByteString::from_utf8(" {\n"sv)))))))));
+(output,TRY((((TRY(((((ByteString::must_from_utf8("namespace "sv))) + ((((scope)->namespace_name).value())))))) + ((ByteString::must_from_utf8(" {\n"sv)))))))));
 }
 JaktInternal::Dictionary<ids::TypeId,JaktInternal::DynamicArray<ids::TypeId>> const dependency_graph = TRY((((*this).produce_codegen_dependency_graph(scope))));
 {
@@ -13496,7 +13493,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8("\n"sv)))));
+(output,(ByteString::must_from_utf8("\n"sv)))));
 }
 
 }
@@ -13535,7 +13532,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8("\n"sv)))));
+(output,(ByteString::must_from_utf8("\n"sv)))));
 }
 
 }
@@ -13634,11 +13631,11 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8("}\n"sv)))));
+(output,(ByteString::must_from_utf8("}\n"sv)))));
 }
 return output;
 }
-ByteString output = TRY(ByteString::from_utf8(""sv));
+ByteString output = (ByteString::must_from_utf8(""sv));
 if (((((scope)->namespace_name)).has_value())){
 TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 {
@@ -13646,7 +13643,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY((((TRY((((TRY(ByteString::from_utf8("namespace "sv))) + ((((scope)->namespace_name).value())))))) + (TRY(ByteString::from_utf8(" {\n"sv)))))))));
+(output,TRY((((TRY(((((ByteString::must_from_utf8("namespace "sv))) + ((((scope)->namespace_name).value())))))) + ((ByteString::must_from_utf8(" {\n"sv)))))))));
 }
 {
 JaktInternal::DictionaryIterator<ByteString,JaktInternal::DynamicArray<ids::FunctionId>> _magic = ((((scope)->functions)).iterator());
@@ -13699,7 +13696,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8("\n"sv)))));
+(output,(ByteString::must_from_utf8("\n"sv)))));
 }
 }
 
@@ -13787,7 +13784,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8("\n"sv)))));
+(output,(ByteString::must_from_utf8("\n"sv)))));
 }
 else if (((((function)->type)).__jakt_init_index() == 1 /* Destructor */)){
 TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
@@ -13803,7 +13800,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8("\n"sv)))));
+(output,(ByteString::must_from_utf8("\n"sv)))));
 }
 else if (((!(((((function)->type)).__jakt_init_index() == 3 /* ImplicitEnumConstructor */))) && ((!(((function)->is_comptime))) && ((((((function)->generics))->params)).is_empty())))){
 TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
@@ -13819,7 +13816,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8("\n"sv)))));
+(output,(ByteString::must_from_utf8("\n"sv)))));
 }
 }
 
@@ -13900,7 +13897,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8("}\n"sv)))));
+(output,(ByteString::must_from_utf8("}\n"sv)))));
 }
 NonnullRefPtr<types::Scope> const scope = TRY((((((*this).program))->get_scope(((enum_).scope_id)))));
 {
@@ -13945,7 +13942,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8("\n"sv)))));
+(output,(ByteString::must_from_utf8("\n"sv)))));
 }
 }
 
@@ -13996,7 +13993,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8("}\n"sv)))));
+(output,(ByteString::must_from_utf8("}\n"sv)))));
 }
 return output;
 }
@@ -14004,21 +14001,21 @@ return output;
 
 ErrorOr<ByteString> codegen::CodeGenerator::codegen_unchecked_binary_op_assignment(NonnullRefPtr<typename types::CheckedExpression> const lhs,NonnullRefPtr<typename types::CheckedExpression> const rhs,parser::BinaryOperator const op,ids::TypeId const type_id) {
 {
-ByteString output = TRY(ByteString::from_utf8(""sv));
+ByteString output = (ByteString::must_from_utf8(""sv));
 TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 {
 (self = TRY((((self) + (rhs)))));
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8("{"sv)))));
+(output,(ByteString::must_from_utf8("{"sv)))));
 TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 {
 (self = TRY((((self) + (rhs)))));
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8("auto& _jakt_ref = "sv)))));
+(output,(ByteString::must_from_utf8("auto& _jakt_ref = "sv)))));
 TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 {
 (self = TRY((((self) + (rhs)))));
@@ -14032,14 +14029,14 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8(";"sv)))));
+(output,(ByteString::must_from_utf8(";"sv)))));
 TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 {
 (self = TRY((((self) + (rhs)))));
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8("_jakt_ref = static_cast<"sv)))));
+(output,(ByteString::must_from_utf8("_jakt_ref = static_cast<"sv)))));
 TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 {
 (self = TRY((((self) + (rhs)))));
@@ -14053,7 +14050,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8(">(_jakt_ref "sv)))));
+(output,(ByteString::must_from_utf8(">(_jakt_ref "sv)))));
 TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 {
 (self = TRY((((self) + (rhs)))));
@@ -14065,19 +14062,19 @@ return {};
 auto&& __jakt_match_variant = op;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 27 /* AddAssign */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8(" + "sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8(" + "sv)));
 };/*case end*/
 case 28 /* SubtractAssign */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8(" - "sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8(" - "sv)));
 };/*case end*/
 case 29 /* MultiplyAssign */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8(" * "sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8(" * "sv)));
 };/*case end*/
 case 31 /* DivideAssign */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8(" / "sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8(" / "sv)));
 };/*case end*/
 case 30 /* ModuloAssign */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8(" % "sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8(" % "sv)));
 };/*case end*/
 default: {
 {
@@ -14104,14 +14101,14 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8(");"sv)))));
+(output,(ByteString::must_from_utf8(");"sv)))));
 TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 {
 (self = TRY((((self) + (rhs)))));
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8("}"sv)))));
+(output,(ByteString::must_from_utf8("}"sv)))));
 return output;
 }
 }
@@ -14124,7 +14121,7 @@ if (((type_)->__jakt_init_index() == 24 /* Struct */)){
 ids::StructId const struct_id = (type_)->as.Struct.value;
 types::CheckedStruct const structure = ((((*this).program))->get_struct(struct_id));
 ByteString const qualified_name = TRY((((*this).codegen_type_possibly_as_namespace(type_id,true))));
-ByteString output = TRY(ByteString::from_utf8(""sv));
+ByteString output = (ByteString::must_from_utf8(""sv));
 if (((!(is_inline)) && (!(((((structure).generic_parameters)).is_empty()))))){
 TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 {
@@ -14132,7 +14129,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8("template <"sv)))));
+(output,(ByteString::must_from_utf8("template <"sv)))));
 TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 {
 (self = TRY((((self) + (rhs)))));
@@ -14146,7 +14143,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8(">\n"sv)))));
+(output,(ByteString::must_from_utf8(">\n"sv)))));
 }
 if ((((((structure).record_type)).__jakt_init_index() == 1 /* Class */) || ((((structure).record_type)).__jakt_init_index() == 0 /* Struct */))){
 if (is_inline){
@@ -14163,7 +14160,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8("("sv)))));
+(output,(ByteString::must_from_utf8("("sv)))));
 }
 else {
 TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
@@ -14192,7 +14189,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8(", "sv)))));
+(output,(ByteString::must_from_utf8(", "sv)))));
 }
 else {
 (first = false);
@@ -14212,7 +14209,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8(" a_"sv)))));
+(output,(ByteString::must_from_utf8(" a_"sv)))));
 TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 {
 (self = TRY((((self) + (rhs)))));
@@ -14231,7 +14228,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8(")"sv)))));
+(output,(ByteString::must_from_utf8(")"sv)))));
 if ((!(((((function)->params)).is_empty())))){
 TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 {
@@ -14239,7 +14236,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8(": "sv)))));
+(output,(ByteString::must_from_utf8(": "sv)))));
 JaktInternal::DynamicArray<ByteString> initializers = (TRY((DynamicArray<ByteString>::create_with({}))));
 size_t const parent_constructor_parameter_count = JaktInternal::checked_sub(((((function)->params)).size()),((((structure).fields)).size()));
 if ([](size_t const& self, size_t rhs) -> bool {
@@ -14253,7 +14250,7 @@ return (infallible_enum_cast<jakt__prelude__operators::Ordering>((JaktInternal::
 }
 }
 (parent_constructor_parameter_count,static_cast<size_t>(0ULL))){
-ByteString parent_initializer = TRY(ByteString::from_utf8(""sv));
+ByteString parent_initializer = (ByteString::must_from_utf8(""sv));
 TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 {
 (self = TRY((((self) + (rhs)))));
@@ -14267,7 +14264,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(parent_initializer,TRY(ByteString::from_utf8("("sv)))));
+(parent_initializer,(ByteString::must_from_utf8("("sv)))));
 JaktInternal::DynamicArray<ByteString> strings = (TRY((DynamicArray<ByteString>::create_with({}))));
 {
 JaktInternal::ArrayIterator<types::CheckedParameter> _magic = ((((((function)->params))[(JaktInternal::Range<size_t>{static_cast<size_t>(static_cast<size_t>(0ULL)),static_cast<size_t>(parent_constructor_parameter_count)})])).iterator());
@@ -14278,7 +14275,7 @@ break;
 }
 types::CheckedParameter param = (_magic_value.value());
 {
-TRY((((strings).push(TRY((((TRY((((TRY(ByteString::from_utf8("move(a_"sv))) + (TRY((((((((param).variable))->name_for_codegen())).as_name_for_use())))))))) + (TRY(ByteString::from_utf8(")"sv))))))))));
+TRY((((strings).push(TRY((((TRY(((((ByteString::must_from_utf8("move(a_"sv))) + (TRY((((((((param).variable))->name_for_codegen())).as_name_for_use())))))))) + ((ByteString::must_from_utf8(")"sv))))))))));
 }
 
 }
@@ -14290,14 +14287,14 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(parent_initializer,TRY((utility::join(strings,TRY(ByteString::from_utf8(", "sv))))))));
+(parent_initializer,TRY((utility::join(strings,(ByteString::must_from_utf8(", "sv))))))));
 TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 {
 (self = TRY((((self) + (rhs)))));
 }
 return {};
 }
-(parent_initializer,TRY(ByteString::from_utf8(")"sv)))));
+(parent_initializer,(ByteString::must_from_utf8(")"sv)))));
 TRY((((initializers).push(parent_initializer))));
 }
 {
@@ -14310,7 +14307,7 @@ break;
 size_t i = (_magic_value.value());
 {
 types::CheckedParameter const param = ((((function)->params))[i]);
-TRY((((initializers).push(TRY((((TRY((((TRY((((TRY((((((((param).variable))->name_for_codegen())).as_name_for_use())))) + (TRY(ByteString::from_utf8("(move(a_"sv))))))) + (TRY((((((((param).variable))->name_for_codegen())).as_name_for_use())))))))) + (TRY(ByteString::from_utf8("))"sv))))))))));
+TRY((((initializers).push(TRY((((TRY((((TRY((((TRY((((((((param).variable))->name_for_codegen())).as_name_for_use())))) + ((ByteString::must_from_utf8("(move(a_"sv))))))) + (TRY((((((((param).variable))->name_for_codegen())).as_name_for_use())))))))) + ((ByteString::must_from_utf8("))"sv))))))))));
 }
 
 }
@@ -14322,7 +14319,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY((utility::join(initializers,TRY(ByteString::from_utf8(", "sv))))))));
+(output,TRY((utility::join(initializers,(ByteString::must_from_utf8(", "sv))))))));
 }
 TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 {
@@ -14330,9 +14327,9 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8("{}\n"sv)))));
+(output,(ByteString::must_from_utf8("{}\n"sv)))));
 if (((((structure).record_type)).__jakt_init_index() == 1 /* Class */)){
-ByteString class_name_with_generics = TRY(ByteString::from_utf8(""sv));
+ByteString class_name_with_generics = (ByteString::must_from_utf8(""sv));
 TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 {
 (self = TRY((((self) + (rhs)))));
@@ -14357,7 +14354,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(class_name_with_generics,TRY(ByteString::from_utf8(", "sv)))));
+(class_name_with_generics,(ByteString::must_from_utf8(", "sv)))));
 }
 else {
 TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
@@ -14366,7 +14363,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(class_name_with_generics,TRY(ByteString::from_utf8("<"sv)))));
+(class_name_with_generics,(ByteString::must_from_utf8("<"sv)))));
 (first = false);
 }
 
@@ -14389,7 +14386,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(class_name_with_generics,TRY(ByteString::from_utf8(">"sv)))));
+(class_name_with_generics,(ByteString::must_from_utf8(">"sv)))));
 }
 if (is_inline){
 TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
@@ -14398,16 +14395,16 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8("static "sv)))));
+(output,(ByteString::must_from_utf8("static "sv)))));
 }
 ByteString const qualified_namespace = ({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<ByteString,ErrorOr<ByteString>>{
 auto __jakt_enum_value = (is_inline);
 if (__jakt_enum_value == true) {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8(""sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8(""sv)));
 }
 else if (__jakt_enum_value == false) {
-return JaktInternal::ExplicitValue(TRY((((qualified_name) + (TRY(ByteString::from_utf8("::"sv)))))));
+return JaktInternal::ExplicitValue(TRY((((qualified_name) + ((ByteString::must_from_utf8("::"sv)))))));
 }
 VERIFY_NOT_REACHED();
 }());
@@ -14428,7 +14425,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8("("sv)))));
+(output,(ByteString::must_from_utf8("("sv)))));
 (first = true);
 {
 JaktInternal::ArrayIterator<types::CheckedParameter> _magic = ((((function)->params)).iterator());
@@ -14446,7 +14443,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8(", "sv)))));
+(output,(ByteString::must_from_utf8(", "sv)))));
 }
 else {
 (first = false);
@@ -14465,7 +14462,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8(" "sv)))));
+(output,(ByteString::must_from_utf8(" "sv)))));
 TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 {
 (self = TRY((((self) + (rhs)))));
@@ -14502,7 +14499,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8(", "sv)))));
+(output,(ByteString::must_from_utf8(", "sv)))));
 }
 else {
 (first = false);
@@ -14514,7 +14511,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8("move("sv)))));
+(output,(ByteString::must_from_utf8("move("sv)))));
 TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 {
 (self = TRY((((self) + (rhs)))));
@@ -14528,7 +14525,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8(")"sv)))));
+(output,(ByteString::must_from_utf8(")"sv)))));
 }
 
 }
@@ -14540,7 +14537,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8("))); return o; }"sv)))));
+(output,(ByteString::must_from_utf8("))); return o; }"sv)))));
 }
 return output;
 }
@@ -14558,7 +14555,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8("::"sv)))));
+(output,(ByteString::must_from_utf8("::"sv)))));
 }
 TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 {
@@ -14573,7 +14570,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8("("sv)))));
+(output,(ByteString::must_from_utf8("("sv)))));
 bool first = true;
 {
 JaktInternal::ArrayIterator<types::CheckedParameter> _magic = ((((function)->params)).iterator());
@@ -14591,7 +14588,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8(", "sv)))));
+(output,(ByteString::must_from_utf8(", "sv)))));
 }
 else {
 (first = false);
@@ -14610,7 +14607,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8(" a_"sv)))));
+(output,(ByteString::must_from_utf8(" a_"sv)))));
 TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 {
 (self = TRY((((self) + (rhs)))));
@@ -14629,7 +14626,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8(") "sv)))));
+(output,(ByteString::must_from_utf8(") "sv)))));
 if ((!(((((function)->params)).is_empty())))){
 TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 {
@@ -14637,7 +14634,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8(":"sv)))));
+(output,(ByteString::must_from_utf8(":"sv)))));
 }
 (first = true);
 {
@@ -14656,7 +14653,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8(", "sv)))));
+(output,(ByteString::must_from_utf8(", "sv)))));
 }
 else {
 (first = false);
@@ -14675,7 +14672,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8("(move(a_"sv)))));
+(output,(ByteString::must_from_utf8("(move(a_"sv)))));
 TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 {
 (self = TRY((((self) + (rhs)))));
@@ -14689,7 +14686,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8("))"sv)))));
+(output,(ByteString::must_from_utf8("))"sv)))));
 }
 
 }
@@ -14701,11 +14698,11 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8("{}\n"sv)))));
+(output,(ByteString::must_from_utf8("{}\n"sv)))));
 return output;
 }
 else {
-utility::panic(TRY(ByteString::from_utf8("internal error: call to a constructor, but not a struct/class type"sv)));
+utility::panic((ByteString::must_from_utf8("internal error: call to a constructor, but not a struct/class type"sv)));
 }
 
 }
@@ -14713,7 +14710,7 @@ utility::panic(TRY(ByteString::from_utf8("internal error: call to a constructor,
 
 ErrorOr<ByteString> codegen::CodeGenerator::codegen_type_possibly_as_namespace(ids::TypeId const type_id,bool const as_namespace) {
 {
-ByteString qualifiers = TRY(ByteString::from_utf8(""sv));
+ByteString qualifiers = (ByteString::must_from_utf8(""sv));
 if (((!(as_namespace)) && ((((((((*this).program))->get_type(type_id)))->common.init_common.qualifiers)).is_immutable))){
 TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 {
@@ -14721,7 +14718,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(qualifiers,TRY(ByteString::from_utf8(" const"sv)))));
+(qualifiers,(ByteString::must_from_utf8(" const"sv)))));
 }
 if (((((*this).generic_inferences)).has_value())){
 JaktInternal::Dictionary<ids::TypeId,ids::TypeId> const mappings = (((*this).generic_inferences).value());
@@ -14735,55 +14732,55 @@ return TRY((((({
 auto&& __jakt_match_variant = *((((*this).program))->get_type(type_id));
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 0 /* Void */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("void"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("void"sv)));
 };/*case end*/
 case 1 /* Bool */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("bool"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("bool"sv)));
 };/*case end*/
 case 2 /* U8 */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("u8"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("u8"sv)));
 };/*case end*/
 case 3 /* U16 */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("u16"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("u16"sv)));
 };/*case end*/
 case 4 /* U32 */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("u32"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("u32"sv)));
 };/*case end*/
 case 5 /* U64 */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("u64"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("u64"sv)));
 };/*case end*/
 case 6 /* I8 */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("i8"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("i8"sv)));
 };/*case end*/
 case 7 /* I16 */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("i16"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("i16"sv)));
 };/*case end*/
 case 8 /* I32 */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("i32"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("i32"sv)));
 };/*case end*/
 case 9 /* I64 */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("i64"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("i64"sv)));
 };/*case end*/
 case 10 /* F32 */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("f32"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("f32"sv)));
 };/*case end*/
 case 11 /* F64 */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("f64"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("f64"sv)));
 };/*case end*/
 case 12 /* Usize */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("size_t"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("size_t"sv)));
 };/*case end*/
 case 13 /* JaktString */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("ByteString"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("ByteString"sv)));
 };/*case end*/
 case 14 /* CChar */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("char"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("char"sv)));
 };/*case end*/
 case 15 /* CInt */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("int"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("int"sv)));
 };/*case end*/
 case 17 /* Never */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("void"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("void"sv)));
 };/*case end*/
 case 32 /* Const */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Const;types::Value const& value = __jakt_match_value.value;
@@ -14811,10 +14808,10 @@ return JaktInternal::ExplicitValue(({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<ByteString,ErrorOr<ByteString>>{
 auto __jakt_enum_value = (((((((*this).program))->get_type(type_id)))->is_boxed(((*this).program))));
 if (__jakt_enum_value == true) {
-return JaktInternal::ExplicitValue(TRY((((TRY((((*this).codegen_type_possibly_as_namespace(type_id,true))))) + (TRY(ByteString::from_utf8("*"sv)))))));
+return JaktInternal::ExplicitValue(TRY((((TRY((((*this).codegen_type_possibly_as_namespace(type_id,true))))) + ((ByteString::must_from_utf8("*"sv)))))));
 }
 else if (__jakt_enum_value == false) {
-return JaktInternal::ExplicitValue(TRY((((TRY((((*this).codegen_type(type_id))))) + (TRY(ByteString::from_utf8("*"sv)))))));
+return JaktInternal::ExplicitValue(TRY((((TRY((((*this).codegen_type(type_id))))) + ((ByteString::must_from_utf8("*"sv)))))));
 }
 VERIFY_NOT_REACHED();
 }());
@@ -14825,11 +14822,11 @@ VERIFY_NOT_REACHED();
 };/*case end*/
 case 28 /* Reference */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Reference;ids::TypeId const& type_id = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(TRY((((TRY((((*this).codegen_type(type_id))))) + (TRY(ByteString::from_utf8(" const&"sv)))))));
+return JaktInternal::ExplicitValue(TRY((((TRY((((*this).codegen_type(type_id))))) + ((ByteString::must_from_utf8(" const&"sv)))))));
 };/*case end*/
 case 29 /* MutableReference */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.MutableReference;ids::TypeId const& type_id = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(TRY((((TRY((((*this).codegen_type(type_id))))) + (TRY(ByteString::from_utf8("&"sv)))))));
+return JaktInternal::ExplicitValue(TRY((((TRY((((*this).codegen_type(type_id))))) + ((ByteString::must_from_utf8("&"sv)))))));
 };/*case end*/
 case 23 /* GenericResolvedType */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.GenericResolvedType;ids::StructId const& id = __jakt_match_value.id;
@@ -14882,7 +14879,7 @@ auto&& __jakt_match_value = __jakt_match_variant.as.Function;JaktInternal::Dynam
 bool const& can_throw = __jakt_match_value.can_throw;
 ids::TypeId const& return_type_id = __jakt_match_value.return_type_id;
 return JaktInternal::ExplicitValue(({ Optional<ByteString> __jakt_var_669; {
-ByteString output = TRY(ByteString::from_utf8("Function<"sv));
+ByteString output = (ByteString::must_from_utf8("Function<"sv));
 if (can_throw){
 TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 {
@@ -14890,7 +14887,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8("ErrorOr<"sv)))));
+(output,(ByteString::must_from_utf8("ErrorOr<"sv)))));
 }
 TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 {
@@ -14906,7 +14903,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8(">"sv)))));
+(output,(ByteString::must_from_utf8(">"sv)))));
 }
 TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 {
@@ -14914,7 +14911,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8("("sv)))));
+(output,(ByteString::must_from_utf8("("sv)))));
 bool first = true;
 {
 JaktInternal::ArrayIterator<ids::TypeId> _magic = ((params).iterator());
@@ -14935,7 +14932,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8(", "sv)))));
+(output,(ByteString::must_from_utf8(", "sv)))));
 }
 
 TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
@@ -14956,7 +14953,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8(")>"sv)))));
+(output,(ByteString::must_from_utf8(")>"sv)))));
 __jakt_var_669 = output; goto __jakt_label_565;
 
 }
@@ -14964,12 +14961,12 @@ __jakt_label_565:; __jakt_var_669.release_value(); }));
 };/*case end*/
 case 22 /* GenericTraitInstance */: {
 {
-utility::panic(TRY(ByteString::from_utf8("Generic trait instance in codegen"sv)));
+utility::panic((ByteString::must_from_utf8("Generic trait instance in codegen"sv)));
 }
 };/*case end*/
 default: {
 return JaktInternal::ExplicitValue(({ Optional<ByteString> __jakt_var_670; {
-__jakt_var_670 = TRY(ByteString::from_utf8("auto"sv)); goto __jakt_label_566;
+__jakt_var_670 = (ByteString::must_from_utf8("auto"sv)); goto __jakt_label_566;
 
 }
 __jakt_label_566:; __jakt_var_670.release_value(); }));
@@ -14992,14 +14989,14 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(((output)),TRY(ByteString::from_utf8("{\n"sv)))));
+(((output)),(ByteString::must_from_utf8("{\n"sv)))));
 TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 {
 (self = TRY((((self) + (rhs)))));
 }
 return {};
 }
-(((output)),TRY(ByteString::from_utf8("if (this->__jakt_variant_index == 0) return;\n"sv)))));
+(((output)),(ByteString::must_from_utf8("if (this->__jakt_variant_index == 0) return;\n"sv)))));
 size_t const common_field_count = ((((enum_).fields)).size());
 {
 JaktInternal::ArrayIterator<types::CheckedField> _magic = ((((enum_).fields)).iterator());
@@ -15033,14 +15030,14 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(((output)),TRY(ByteString::from_utf8("this->__jakt_destroy_variant();\n"sv)))));
+(((output)),(ByteString::must_from_utf8("this->__jakt_destroy_variant();\n"sv)))));
 TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 {
 (self = TRY((((self) + (rhs)))));
 }
 return {};
 }
-(((output)),TRY(ByteString::from_utf8("}\n"sv)))));
+(((output)),(ByteString::must_from_utf8("}\n"sv)))));
 }
 return {};
 }
@@ -15048,9 +15045,9 @@ return {};
 ErrorOr<ByteString> codegen::CodeGenerator::codegen_struct_predecl(types::CheckedStruct const struct_) {
 {
 if (((((struct_).definition_linkage)).__jakt_init_index() == 1 /* External */)){
-return TRY(ByteString::from_utf8(""sv));
+return (ByteString::must_from_utf8(""sv));
 }
-ByteString output = TRY(ByteString::from_utf8(""sv));
+ByteString output = (ByteString::must_from_utf8(""sv));
 if ((!(((((struct_).generic_parameters)).is_empty())))){
 TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 {
@@ -15058,7 +15055,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8("template <"sv)))));
+(output,(ByteString::must_from_utf8("template <"sv)))));
 TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 {
 (self = TRY((((self) + (rhs)))));
@@ -15072,7 +15069,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8(">"sv)))));
+(output,(ByteString::must_from_utf8(">"sv)))));
 }
 TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 {
@@ -15085,13 +15082,13 @@ return {};
 auto&& __jakt_match_variant = ((struct_).record_type);
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 1 /* Class */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("class "sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("class "sv)));
 };/*case end*/
 case 0 /* Struct */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("struct "sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("struct "sv)));
 };/*case end*/
 default: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8(""sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8(""sv)));
 };/*case end*/
 }/*switch end*/
 }()
@@ -15113,7 +15110,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8(";"sv)))));
+(output,(ByteString::must_from_utf8(";"sv)))));
 return output;
 }
 }

--- a/bootstrap/stage0/codegen.h
+++ b/bootstrap/stage0/codegen.h
@@ -8,12 +8,7 @@
 #include "interpreter.h"
 namespace Jakt {
 namespace codegen {
-struct LineSpan {
-  public:
-public: size_t start;public: size_t end;public: LineSpan(size_t a_start, size_t a_end);
-
-public: ErrorOr<ByteString> debug_description() const;
-};struct AllowedControlExits {
+struct AllowedControlExits {
 u8 __jakt_variant_index = 0;
 union VariantData {
 u8 __jakt_uninit_value;
@@ -35,14 +30,7 @@ codegen::AllowedControlExits allow_return() const;
 private:
 AllowedControlExits() {};
 };
-struct CodegenDebugInfo {
-  public:
-public: NonnullRefPtr<compiler::Compiler> compiler;public: JaktInternal::Dictionary<size_t,JaktInternal::DynamicArray<codegen::LineSpan>> line_spans;public: bool statement_span_comments;public: ErrorOr<void> gather_line_spans();
-public: ErrorOr<ByteString> span_to_source_location(utility::Span const span);
-public: CodegenDebugInfo(NonnullRefPtr<compiler::Compiler> a_compiler, JaktInternal::Dictionary<size_t,JaktInternal::DynamicArray<codegen::LineSpan>> a_line_spans, bool a_statement_span_comments);
-
-public: ErrorOr<ByteString> debug_description() const;
-};struct ControlFlowState {
+struct ControlFlowState {
   public:
 public: codegen::AllowedControlExits allowed_exits;public: bool passes_through_match;public: bool passes_through_try;public: size_t match_nest_level;public: codegen::ControlFlowState enter_function() const;
 public: static ErrorOr<ByteString> nested_release_return_expr(ids::TypeId const func_return_type, bool const func_can_throw, ByteString const cpp_match_result_type);
@@ -52,6 +40,18 @@ public: static codegen::ControlFlowState no_control_flow();
 public: bool is_match_nested() const;
 public: codegen::ControlFlowState enter_match() const;
 public: ControlFlowState(codegen::AllowedControlExits a_allowed_exits, bool a_passes_through_match, bool a_passes_through_try, size_t a_match_nest_level);
+
+public: ErrorOr<ByteString> debug_description() const;
+};struct LineSpan {
+  public:
+public: size_t start;public: size_t end;public: LineSpan(size_t a_start, size_t a_end);
+
+public: ErrorOr<ByteString> debug_description() const;
+};struct CodegenDebugInfo {
+  public:
+public: NonnullRefPtr<compiler::Compiler> compiler;public: JaktInternal::Dictionary<size_t,JaktInternal::DynamicArray<codegen::LineSpan>> line_spans;public: bool statement_span_comments;public: ErrorOr<void> gather_line_spans();
+public: ErrorOr<ByteString> span_to_source_location(utility::Span const span);
+public: CodegenDebugInfo(NonnullRefPtr<compiler::Compiler> a_compiler, JaktInternal::Dictionary<size_t,JaktInternal::DynamicArray<codegen::LineSpan>> a_line_spans, bool a_statement_span_comments);
 
 public: ErrorOr<ByteString> debug_description() const;
 };struct CodeGenerator {
@@ -131,26 +131,26 @@ public: ErrorOr<ByteString> codegen_struct_predecl(types::CheckedStruct const st
 public: ErrorOr<ByteString> debug_description() const;
 };}
 } // namespace Jakt
-template<>struct Jakt::Formatter<Jakt::codegen::LineSpan> : Jakt::Formatter<Jakt::StringView>{
-Jakt::ErrorOr<void> format(Jakt::FormatBuilder& builder, Jakt::codegen::LineSpan const& value) {
-JaktInternal::PrettyPrint::ScopedEnable pretty_print_enable { m_alternative_form };Jakt::ErrorOr<void> format_error = Jakt::Formatter<Jakt::StringView>::format(builder, MUST(value.debug_description()));return format_error;}
-};
-namespace Jakt {
-} // namespace Jakt
 template<>struct Jakt::Formatter<Jakt::codegen::AllowedControlExits> : Jakt::Formatter<Jakt::StringView>{
 Jakt::ErrorOr<void> format(Jakt::FormatBuilder& builder, Jakt::codegen::AllowedControlExits const& value) {
 JaktInternal::PrettyPrint::ScopedEnable pretty_print_enable { m_alternative_form };Jakt::ErrorOr<void> format_error = Jakt::Formatter<Jakt::StringView>::format(builder, MUST(value.debug_description()));return format_error;}
 };
 namespace Jakt {
 } // namespace Jakt
-template<>struct Jakt::Formatter<Jakt::codegen::CodegenDebugInfo> : Jakt::Formatter<Jakt::StringView>{
-Jakt::ErrorOr<void> format(Jakt::FormatBuilder& builder, Jakt::codegen::CodegenDebugInfo const& value) {
+template<>struct Jakt::Formatter<Jakt::codegen::ControlFlowState> : Jakt::Formatter<Jakt::StringView>{
+Jakt::ErrorOr<void> format(Jakt::FormatBuilder& builder, Jakt::codegen::ControlFlowState const& value) {
 JaktInternal::PrettyPrint::ScopedEnable pretty_print_enable { m_alternative_form };Jakt::ErrorOr<void> format_error = Jakt::Formatter<Jakt::StringView>::format(builder, MUST(value.debug_description()));return format_error;}
 };
 namespace Jakt {
 } // namespace Jakt
-template<>struct Jakt::Formatter<Jakt::codegen::ControlFlowState> : Jakt::Formatter<Jakt::StringView>{
-Jakt::ErrorOr<void> format(Jakt::FormatBuilder& builder, Jakt::codegen::ControlFlowState const& value) {
+template<>struct Jakt::Formatter<Jakt::codegen::LineSpan> : Jakt::Formatter<Jakt::StringView>{
+Jakt::ErrorOr<void> format(Jakt::FormatBuilder& builder, Jakt::codegen::LineSpan const& value) {
+JaktInternal::PrettyPrint::ScopedEnable pretty_print_enable { m_alternative_form };Jakt::ErrorOr<void> format_error = Jakt::Formatter<Jakt::StringView>::format(builder, MUST(value.debug_description()));return format_error;}
+};
+namespace Jakt {
+} // namespace Jakt
+template<>struct Jakt::Formatter<Jakt::codegen::CodegenDebugInfo> : Jakt::Formatter<Jakt::StringView>{
+Jakt::ErrorOr<void> format(Jakt::FormatBuilder& builder, Jakt::codegen::CodegenDebugInfo const& value) {
 JaktInternal::PrettyPrint::ScopedEnable pretty_print_enable { m_alternative_form };Jakt::ErrorOr<void> format_error = Jakt::Formatter<Jakt::StringView>::format(builder, MUST(value.debug_description()));return format_error;}
 };
 namespace Jakt {

--- a/bootstrap/stage0/compiler.cpp
+++ b/bootstrap/stage0/compiler.cpp
@@ -26,7 +26,7 @@ TRY(JaktInternal::PrettyPrint::output_indentation(builder));TRY(builder.appendff
 TRY(builder.append(")"sv));return builder.to_string(); }
 ErrorOr<void> compiler::Compiler::load_prelude() {
 {
-ByteString const module_name = TRY(ByteString::from_utf8("__prelude__"sv));
+ByteString const module_name = (ByteString::must_from_utf8("__prelude__"sv));
 jakt__path::Path const file_name = TRY((jakt__path::Path::from_string(module_name)));
 TRY((((*this).get_file_id_or_register(file_name))));
 }
@@ -38,7 +38,7 @@ ErrorOr<JaktInternal::Optional<jakt__path::Path>> compiler::Compiler::search_for
 ByteStringBuilder builder = ByteStringBuilder::create();
 TRY((((builder).append(static_cast<u8>(47)))));
 ByteString const separator = TRY((((builder).to_string())));
-ByteString const module_name = ((input_module_name).replace(TRY(ByteString::from_utf8("::"sv)),separator));
+ByteString const module_name = ((input_module_name).replace((ByteString::must_from_utf8("::"sv)),separator));
 if ((!(relative_import))){
 {
 JaktInternal::ArrayIterator<ByteString> _magic = ((((*this).include_paths)).iterator());
@@ -49,7 +49,7 @@ break;
 }
 ByteString include_path = (_magic_value.value());
 {
-jakt__path::Path const candidate_path = TRY((jakt__path::Path::from_parts((TRY((DynamicArray<ByteString>::create_with({include_path, TRY((((module_name) + (TRY(ByteString::from_utf8(".jakt"sv))))))})))))));
+jakt__path::Path const candidate_path = TRY((jakt__path::Path::from_parts((TRY((DynamicArray<ByteString>::create_with({include_path, TRY((((module_name) + ((ByteString::must_from_utf8(".jakt"sv))))))})))))));
 if (((candidate_path).exists())){
 return candidate_path;
 }
@@ -59,15 +59,15 @@ return candidate_path;
 }
 
 }
-ByteString const standard_module_name = TRY(ByteString::from_utf8("jakt"sv));
+ByteString const standard_module_name = (ByteString::must_from_utf8("jakt"sv));
 if (((module_name).starts_with(standard_module_name))){
 ByteString const std_module_name_path = ((module_name).substring(JaktInternal::checked_add(((standard_module_name).length()),static_cast<size_t>(1ULL)),JaktInternal::checked_sub(((module_name).length()),JaktInternal::checked_add(((standard_module_name).length()),static_cast<size_t>(1ULL)))));
-jakt__path::Path const candidate_path = TRY((jakt__path::Path::from_parts((TRY((DynamicArray<ByteString>::create_with({((((*this).std_include_path)).to_string()), TRY((((std_module_name_path) + (TRY(ByteString::from_utf8(".jakt"sv))))))})))))));
+jakt__path::Path const candidate_path = TRY((jakt__path::Path::from_parts((TRY((DynamicArray<ByteString>::create_with({((((*this).std_include_path)).to_string()), TRY((((std_module_name_path) + ((ByteString::must_from_utf8(".jakt"sv))))))})))))));
 if (((candidate_path).exists())){
 return candidate_path;
 }
 }
-return TRY((((*this).find_in_search_paths(TRY((jakt__path::Path::from_string(TRY((((module_name) + (TRY(ByteString::from_utf8(".jakt"sv))))))))),relative_import,parent_path_count))));
+return TRY((((*this).find_in_search_paths(TRY((jakt__path::Path::from_string(TRY((((module_name) + ((ByteString::must_from_utf8(".jakt"sv))))))))),relative_import,parent_path_count))));
 }
 }
 
@@ -294,7 +294,7 @@ return (warnln((StringView::from_string_literal("\u001b[31;1mError\u001b[0m Coul
 }
 else {
 {
-utility::panic(TRY(ByteString::from_utf8("Incurred unrecognized error while trying to open file"sv)));
+utility::panic((ByteString::must_from_utf8("Incurred unrecognized error while trying to open file"sv)));
 }
 return JaktInternal::ExplicitValue<void>();
 }

--- a/bootstrap/stage0/error.cpp
+++ b/bootstrap/stage0/error.cpp
@@ -562,10 +562,10 @@ return ({
 auto&& __jakt_match_variant = *this;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 0 /* Hint */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("94"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("94"sv)));
 };/*case end*/
 case 1 /* Error */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("31"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("31"sv)));
 };/*case end*/
 default: VERIFY_NOT_REACHED();}/*switch end*/
 }()
@@ -584,10 +584,10 @@ return ({
 auto&& __jakt_match_variant = *this;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 0 /* Hint */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("Hint"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("Hint"sv)));
 };/*case end*/
 case 1 /* Error */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("Error"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("Error"sv)));
 };/*case end*/
 default: VERIFY_NOT_REACHED();}/*switch end*/
 }()

--- a/bootstrap/stage0/error.h
+++ b/bootstrap/stage0/error.h
@@ -3,6 +3,28 @@
 #include "utility.h"
 namespace Jakt {
 namespace error {
+struct MessageSeverity {
+u8 __jakt_variant_index = 0;
+union VariantData {
+u8 __jakt_uninit_value;
+constexpr VariantData() {}
+~VariantData() {}
+} as;
+constexpr u8 __jakt_init_index() const noexcept { return __jakt_variant_index - 1; }ErrorOr<ByteString> debug_description() const;
+[[nodiscard]] static MessageSeverity Hint();
+[[nodiscard]] static MessageSeverity Error();
+~MessageSeverity();
+MessageSeverity& operator=(MessageSeverity const &);
+MessageSeverity& operator=(MessageSeverity &&);
+MessageSeverity(MessageSeverity const&);
+MessageSeverity(MessageSeverity &&);
+private: void __jakt_destroy_variant();
+public:
+ErrorOr<ByteString> ansi_color_code() const;
+ErrorOr<ByteString> name() const;
+private:
+MessageSeverity() {};
+};
 struct JaktError {
 u8 __jakt_variant_index = 0;
 union VariantData {
@@ -34,38 +56,16 @@ utility::Span span() const;
 private:
 JaktError() {};
 };
-struct MessageSeverity {
-u8 __jakt_variant_index = 0;
-union VariantData {
-u8 __jakt_uninit_value;
-constexpr VariantData() {}
-~VariantData() {}
-} as;
-constexpr u8 __jakt_init_index() const noexcept { return __jakt_variant_index - 1; }ErrorOr<ByteString> debug_description() const;
-[[nodiscard]] static MessageSeverity Hint();
-[[nodiscard]] static MessageSeverity Error();
-~MessageSeverity();
-MessageSeverity& operator=(MessageSeverity const &);
-MessageSeverity& operator=(MessageSeverity &&);
-MessageSeverity(MessageSeverity const&);
-MessageSeverity(MessageSeverity &&);
-private: void __jakt_destroy_variant();
-public:
-ErrorOr<ByteString> ansi_color_code() const;
-ErrorOr<ByteString> name() const;
-private:
-MessageSeverity() {};
-};
 }
 } // namespace Jakt
-template<>struct Jakt::Formatter<Jakt::error::JaktError> : Jakt::Formatter<Jakt::StringView>{
-Jakt::ErrorOr<void> format(Jakt::FormatBuilder& builder, Jakt::error::JaktError const& value) {
+template<>struct Jakt::Formatter<Jakt::error::MessageSeverity> : Jakt::Formatter<Jakt::StringView>{
+Jakt::ErrorOr<void> format(Jakt::FormatBuilder& builder, Jakt::error::MessageSeverity const& value) {
 JaktInternal::PrettyPrint::ScopedEnable pretty_print_enable { m_alternative_form };Jakt::ErrorOr<void> format_error = Jakt::Formatter<Jakt::StringView>::format(builder, MUST(value.debug_description()));return format_error;}
 };
 namespace Jakt {
 } // namespace Jakt
-template<>struct Jakt::Formatter<Jakt::error::MessageSeverity> : Jakt::Formatter<Jakt::StringView>{
-Jakt::ErrorOr<void> format(Jakt::FormatBuilder& builder, Jakt::error::MessageSeverity const& value) {
+template<>struct Jakt::Formatter<Jakt::error::JaktError> : Jakt::Formatter<Jakt::StringView>{
+Jakt::ErrorOr<void> format(Jakt::FormatBuilder& builder, Jakt::error::JaktError const& value) {
 JaktInternal::PrettyPrint::ScopedEnable pretty_print_enable { m_alternative_form };Jakt::ErrorOr<void> format_error = Jakt::Formatter<Jakt::StringView>::format(builder, MUST(value.debug_description()));return format_error;}
 };
 namespace Jakt {

--- a/bootstrap/stage0/formatter.cpp
+++ b/bootstrap/stage0/formatter.cpp
@@ -58,7 +58,7 @@ switch(__jakt_match_variant.__jakt_init_index()) {
 case 0 /* SingleQuotedString */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.SingleQuotedString;ByteString const& quote = __jakt_match_value.quote;
 JaktInternal::Optional<ByteString> const& prefix = __jakt_match_value.prefix;
-return JaktInternal::ExplicitValue(TRY((__jakt_format((StringView::from_string_literal("{}'{}'"sv)),TRY((prefix.try_value_or_lazy_evaluated([&]() -> ErrorOr<ByteString> { return TRY(ByteString::from_utf8(""sv)); }))),quote))));
+return JaktInternal::ExplicitValue(TRY((__jakt_format((StringView::from_string_literal("{}'{}'"sv)),TRY((prefix.try_value_or_lazy_evaluated([&]() -> ErrorOr<ByteString> { return (ByteString::must_from_utf8(""sv)); }))),quote))));
 };/*case end*/
 case 1 /* QuotedString */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.QuotedString;ByteString const& quote = __jakt_match_value.quote;
@@ -75,331 +75,331 @@ auto&& __jakt_match_value = __jakt_match_variant.as.Identifier;ByteString const&
 return JaktInternal::ExplicitValue(name);
 };/*case end*/
 case 4 /* Semicolon */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8(";"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8(";"sv)));
 };/*case end*/
 case 5 /* Colon */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8(":"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8(":"sv)));
 };/*case end*/
 case 6 /* ColonColon */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("::"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("::"sv)));
 };/*case end*/
 case 7 /* LParen */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("("sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("("sv)));
 };/*case end*/
 case 8 /* RParen */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8(")"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8(")"sv)));
 };/*case end*/
 case 9 /* LCurly */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("{"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("{"sv)));
 };/*case end*/
 case 10 /* RCurly */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("}"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("}"sv)));
 };/*case end*/
 case 11 /* LSquare */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("["sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("["sv)));
 };/*case end*/
 case 12 /* RSquare */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("]"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("]"sv)));
 };/*case end*/
 case 13 /* PercentSign */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("%"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("%"sv)));
 };/*case end*/
 case 14 /* Plus */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("+"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("+"sv)));
 };/*case end*/
 case 15 /* Minus */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("-"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("-"sv)));
 };/*case end*/
 case 16 /* Equal */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("="sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("="sv)));
 };/*case end*/
 case 17 /* PlusEqual */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("+="sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("+="sv)));
 };/*case end*/
 case 18 /* PlusPlus */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("++"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("++"sv)));
 };/*case end*/
 case 19 /* MinusEqual */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("-="sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("-="sv)));
 };/*case end*/
 case 20 /* MinusMinus */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("--"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("--"sv)));
 };/*case end*/
 case 21 /* AsteriskEqual */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("*="sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("*="sv)));
 };/*case end*/
 case 22 /* ForwardSlashEqual */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("/="sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("/="sv)));
 };/*case end*/
 case 23 /* PercentSignEqual */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("%="sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("%="sv)));
 };/*case end*/
 case 24 /* NotEqual */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("!="sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("!="sv)));
 };/*case end*/
 case 25 /* DoubleEqual */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("=="sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("=="sv)));
 };/*case end*/
 case 26 /* GreaterThan */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8(">"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8(">"sv)));
 };/*case end*/
 case 27 /* GreaterThanOrEqual */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8(">="sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8(">="sv)));
 };/*case end*/
 case 28 /* LessThan */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("<"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("<"sv)));
 };/*case end*/
 case 29 /* LessThanOrEqual */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("<="sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("<="sv)));
 };/*case end*/
 case 30 /* LeftArithmeticShift */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("<<<"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("<<<"sv)));
 };/*case end*/
 case 31 /* LeftShift */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("<<"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("<<"sv)));
 };/*case end*/
 case 32 /* LeftShiftEqual */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("<<="sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("<<="sv)));
 };/*case end*/
 case 33 /* RightShift */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8(">>"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8(">>"sv)));
 };/*case end*/
 case 34 /* RightArithmeticShift */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8(">>>"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8(">>>"sv)));
 };/*case end*/
 case 35 /* RightShiftEqual */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8(">>="sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8(">>="sv)));
 };/*case end*/
 case 36 /* Asterisk */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("*"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("*"sv)));
 };/*case end*/
 case 37 /* Ampersand */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("&"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("&"sv)));
 };/*case end*/
 case 38 /* AmpersandEqual */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("&="sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("&="sv)));
 };/*case end*/
 case 39 /* AmpersandAmpersand */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("&&"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("&&"sv)));
 };/*case end*/
 case 40 /* Pipe */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("|"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("|"sv)));
 };/*case end*/
 case 41 /* PipeEqual */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("|="sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("|="sv)));
 };/*case end*/
 case 42 /* PipePipe */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("||"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("||"sv)));
 };/*case end*/
 case 43 /* Caret */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("^"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("^"sv)));
 };/*case end*/
 case 44 /* CaretEqual */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("^="sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("^="sv)));
 };/*case end*/
 case 45 /* Dollar */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("$"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("$"sv)));
 };/*case end*/
 case 46 /* Tilde */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("~"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("~"sv)));
 };/*case end*/
 case 47 /* ForwardSlash */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("/"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("/"sv)));
 };/*case end*/
 case 48 /* ExclamationPoint */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("!"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("!"sv)));
 };/*case end*/
 case 49 /* QuestionMark */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("?"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("?"sv)));
 };/*case end*/
 case 50 /* QuestionMarkQuestionMark */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("??"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("??"sv)));
 };/*case end*/
 case 51 /* QuestionMarkQuestionMarkEqual */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("??="sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("??="sv)));
 };/*case end*/
 case 52 /* Comma */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8(","sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8(","sv)));
 };/*case end*/
 case 53 /* Dot */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("."sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("."sv)));
 };/*case end*/
 case 54 /* DotDot */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8(".."sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8(".."sv)));
 };/*case end*/
 case 55 /* Eol */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8(""sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8(""sv)));
 };/*case end*/
 case 56 /* Eof */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8(""sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8(""sv)));
 };/*case end*/
 case 57 /* FatArrow */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("=>"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("=>"sv)));
 };/*case end*/
 case 58 /* Arrow */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("->"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("->"sv)));
 };/*case end*/
 case 59 /* And */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("and"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("and"sv)));
 };/*case end*/
 case 60 /* Anon */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("anon"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("anon"sv)));
 };/*case end*/
 case 61 /* As */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("as"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("as"sv)));
 };/*case end*/
 case 62 /* Boxed */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("boxed"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("boxed"sv)));
 };/*case end*/
 case 63 /* Break */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("break"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("break"sv)));
 };/*case end*/
 case 64 /* Catch */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("catch"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("catch"sv)));
 };/*case end*/
 case 65 /* Class */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("class"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("class"sv)));
 };/*case end*/
 case 66 /* Continue */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("continue"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("continue"sv)));
 };/*case end*/
 case 67 /* Cpp */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("cpp"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("cpp"sv)));
 };/*case end*/
 case 68 /* Defer */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("defer"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("defer"sv)));
 };/*case end*/
 case 69 /* Destructor */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("destructor"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("destructor"sv)));
 };/*case end*/
 case 70 /* Else */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("else"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("else"sv)));
 };/*case end*/
 case 71 /* Enum */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("enum"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("enum"sv)));
 };/*case end*/
 case 72 /* Extern */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("extern"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("extern"sv)));
 };/*case end*/
 case 73 /* False */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("false"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("false"sv)));
 };/*case end*/
 case 74 /* For */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("for"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("for"sv)));
 };/*case end*/
 case 75 /* Fn */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("fn"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("fn"sv)));
 };/*case end*/
 case 76 /* Comptime */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("comptime"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("comptime"sv)));
 };/*case end*/
 case 77 /* If */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("if"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("if"sv)));
 };/*case end*/
 case 78 /* Import */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("import"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("import"sv)));
 };/*case end*/
 case 79 /* Relative */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("relative"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("relative"sv)));
 };/*case end*/
 case 80 /* In */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("in"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("in"sv)));
 };/*case end*/
 case 81 /* Is */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("is"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("is"sv)));
 };/*case end*/
 case 82 /* Let */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("let"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("let"sv)));
 };/*case end*/
 case 83 /* Loop */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("loop"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("loop"sv)));
 };/*case end*/
 case 84 /* Match */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("match"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("match"sv)));
 };/*case end*/
 case 85 /* Mut */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("mut"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("mut"sv)));
 };/*case end*/
 case 86 /* Namespace */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("namespace"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("namespace"sv)));
 };/*case end*/
 case 87 /* Not */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("not"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("not"sv)));
 };/*case end*/
 case 88 /* Or */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("or"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("or"sv)));
 };/*case end*/
 case 90 /* Private */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("private"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("private"sv)));
 };/*case end*/
 case 91 /* Public */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("public"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("public"sv)));
 };/*case end*/
 case 92 /* Raw */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("raw"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("raw"sv)));
 };/*case end*/
 case 94 /* Return */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("return"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("return"sv)));
 };/*case end*/
 case 95 /* Restricted */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("restricted"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("restricted"sv)));
 };/*case end*/
 case 96 /* Sizeof */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("sizeof"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("sizeof"sv)));
 };/*case end*/
 case 97 /* Struct */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("struct"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("struct"sv)));
 };/*case end*/
 case 98 /* This */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("this"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("this"sv)));
 };/*case end*/
 case 99 /* Throw */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("throw"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("throw"sv)));
 };/*case end*/
 case 100 /* Throws */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("throws"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("throws"sv)));
 };/*case end*/
 case 101 /* True */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("true"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("true"sv)));
 };/*case end*/
 case 102 /* Try */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("try"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("try"sv)));
 };/*case end*/
 case 103 /* Unsafe */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("unsafe"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("unsafe"sv)));
 };/*case end*/
 case 105 /* Weak */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("weak"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("weak"sv)));
 };/*case end*/
 case 106 /* While */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("while"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("while"sv)));
 };/*case end*/
 case 107 /* Yield */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("yield"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("yield"sv)));
 };/*case end*/
 case 108 /* Guard */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("guard"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("guard"sv)));
 };/*case end*/
 case 89 /* Override */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("override"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("override"sv)));
 };/*case end*/
 case 104 /* Virtual */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("virtual"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("virtual"sv)));
 };/*case end*/
 case 109 /* Implements */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("implements"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("implements"sv)));
 };/*case end*/
 case 110 /* Requires */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("requires"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("requires"sv)));
 };/*case end*/
 case 111 /* Trait */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("trait"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("trait"sv)));
 };/*case end*/
 case 93 /* Reflect */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("reflect"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("reflect"sv)));
 };/*case end*/
 case 112 /* Garbage */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8(""sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8(""sv)));
 };/*case end*/
 default: VERIFY_NOT_REACHED();}/*switch end*/
 }()
@@ -423,10 +423,10 @@ return JaktInternal::ExplicitValue(TRY((__jakt_format((StringView::from_string_l
 };/*case end*/
 case 55 /* Eol */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Eol;JaktInternal::Optional<ByteString> const& comment = __jakt_match_value.comment;
-return JaktInternal::ExplicitValue(TRY((__jakt_format((StringView::from_string_literal("Eol: {}"sv)),TRY((comment.try_value_or_lazy_evaluated([&]() -> ErrorOr<ByteString> { return TRY(ByteString::from_utf8(""sv)); })))))));
+return JaktInternal::ExplicitValue(TRY((__jakt_format((StringView::from_string_literal("Eol: {}"sv)),TRY((comment.try_value_or_lazy_evaluated([&]() -> ErrorOr<ByteString> { return (ByteString::must_from_utf8(""sv)); })))))));
 };/*case end*/
 case 56 /* Eof */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("Eof"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("Eof"sv)));
 };/*case end*/
 default: {
 return JaktInternal::ExplicitValue(TRY((((*this).token_text()))));
@@ -1868,7 +1868,7 @@ __jakt_label_572:; __jakt_var_676.release_value(); }));
 case 3 /* Identifier */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Identifier;ByteString const& name = __jakt_match_value.name;
 return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_677; {
-if ((((name) == (TRY(ByteString::from_utf8("type"sv)))) && ((((*this).peek(static_cast<i64>(0LL)))).__jakt_init_index() == 3 /* Identifier */))){
+if ((((name) == ((ByteString::must_from_utf8("type"sv)))) && ((((*this).peek(static_cast<i64>(0LL)))).__jakt_init_index() == 3 /* Identifier */))){
 TRY((((*this).push_state(formatter::State::EntityDeclaration(formatter::Entity::from_token(((token))),true,false,static_cast<size_t>(0ULL),is_extern)))));
 return TRY((((*this).formatted_token(token,(TRY((DynamicArray<u8>::create_with({static_cast<u8>(u8' ')})))),(TRY((DynamicArray<u8>::create_with({}))))))));
 }
@@ -5815,7 +5815,7 @@ return TRY((((*this).next())));
 default: {
 return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_872; {
 JaktInternal::DynamicArray<ByteString> collection = (TRY((DynamicArray<ByteString>::create_with({}))));
-ByteString output = TRY(ByteString::from_utf8(""sv));
+ByteString output = (ByteString::must_from_utf8(""sv));
 utility::Span const span = ((token).span());
 lexer::Token local_token = token;
 while ((!(((local_token).__jakt_init_index() == 10 /* RCurly */)))){
@@ -5857,7 +5857,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8("\n"sv)))));
+(output,(ByteString::must_from_utf8("\n"sv)))));
 {
 JaktInternal::Range<size_t> _magic = (JaktInternal::Range<size_t>{static_cast<size_t>(static_cast<size_t>(0ULL)),static_cast<size_t>(indent_amount)});
 for (;;){
@@ -5873,7 +5873,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8(" "sv)))));
+(output,(ByteString::must_from_utf8(" "sv)))));
 }
 
 }
@@ -5888,7 +5888,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8(", "sv)))));
+(output,(ByteString::must_from_utf8(", "sv)))));
 ((current_len) += (static_cast<size_t>(2ULL)));
 }
 else {
@@ -5918,23 +5918,23 @@ break;
 }
 size_t i = (_magic_value.value());
 {
-(output = TRY((((TRY(ByteString::from_utf8(" "sv))) + (output)))));
+(output = TRY(((((ByteString::must_from_utf8(" "sv))) + (output)))));
 }
 
 }
 }
 
-(output = TRY((((TRY(ByteString::from_utf8("\n"sv))) + (output)))));
+(output = TRY(((((ByteString::must_from_utf8("\n"sv))) + (output)))));
 TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 {
 (self = TRY((((self) + (rhs)))));
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8("\n"sv)))));
+(output,(ByteString::must_from_utf8("\n"sv)))));
 }
 else {
-(output = TRY((((TRY((((TRY(ByteString::from_utf8(" "sv))) + (output))))) + (TRY(ByteString::from_utf8(" "sv)))))));
+(output = TRY((((TRY(((((ByteString::must_from_utf8(" "sv))) + (output))))) + ((ByteString::must_from_utf8(" "sv)))))));
 }
 
 ((*this).pop_state());
@@ -6787,46 +6787,46 @@ return ({
 auto&& __jakt_match_variant = *this;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 0 /* Toplevel */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("toplevel"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("toplevel"sv)));
 };/*case end*/
 case 1 /* Extern */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("extern"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("extern"sv)));
 };/*case end*/
 case 2 /* Import */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("import"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("import"sv)));
 };/*case end*/
 case 3 /* ImportList */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("import list"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("import list"sv)));
 };/*case end*/
 case 5 /* Implements */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("implements"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("implements"sv)));
 };/*case end*/
 case 4 /* EntityDeclaration */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("entity declaration"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("entity declaration"sv)));
 };/*case end*/
 case 6 /* CaptureList */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("capture list"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("capture list"sv)));
 };/*case end*/
 case 7 /* ParameterList */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("parameter list"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("parameter list"sv)));
 };/*case end*/
 case 8 /* RestrictionList */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("restriction list"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("restriction list"sv)));
 };/*case end*/
 case 9 /* EntityDefinition */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("entity definition"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("entity definition"sv)));
 };/*case end*/
 case 10 /* StatementContext */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("statement context"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("statement context"sv)));
 };/*case end*/
 case 11 /* MatchPattern */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("match pattern"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("match pattern"sv)));
 };/*case end*/
 case 12 /* VariableDeclaration */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("variable declaration"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("variable declaration"sv)));
 };/*case end*/
 case 13 /* GenericCallTypeParams */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("generic call type params"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("generic call type params"sv)));
 };/*case end*/
 case 14 /* TypeContext */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.TypeContext;size_t const& open_parens = __jakt_match_value.open_parens;
@@ -6837,7 +6837,7 @@ bool const& seen_start = __jakt_match_value.seen_start;
 return JaktInternal::ExplicitValue(TRY((__jakt_format((StringView::from_string_literal("type context (p{} c{} s{} a{} s:{})"sv)),open_parens,open_curlies,open_squares,open_angles,seen_start))));
 };/*case end*/
 case 15 /* FunctionTypeContext */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("function type context"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("function type context"sv)));
 };/*case end*/
 default: VERIFY_NOT_REACHED();}/*switch end*/
 }()

--- a/bootstrap/stage0/formatter.h
+++ b/bootstrap/stage0/formatter.h
@@ -151,62 +151,7 @@ ErrorOr<ByteString> name() const;
 private:
 State() {};
 };
-struct ReflowState {
-  public:
-public: formatter::FormattedToken token;public: formatter::State state;public: size_t enclosures_to_ignore;public: ReflowState(formatter::FormattedToken a_token, formatter::State a_state, size_t a_enclosures_to_ignore);
-
-public: ErrorOr<ByteString> debug_description() const;
-};struct Stage0 {
-  public:
-public: JaktInternal::DynamicArray<lexer::Token> tokens;public: size_t index;public: JaktInternal::DynamicArray<formatter::State> states;public: size_t indent;public: bool already_seen_enclosure_in_current_line;public: JaktInternal::DynamicArray<size_t> dedents_to_skip;public: bool debug;private: ErrorOr<JaktInternal::Optional<formatter::FormattedToken>> next_in_implements_context(lexer::Token const token);
-public: ErrorOr<JaktInternal::Optional<formatter::FormattedToken>> next();
-private: ErrorOr<void> push_state(formatter::State const state);
-private: ErrorOr<JaktInternal::Optional<formatter::FormattedToken>> next_in_import_context(bool const is_extern, lexer::Token const token);
-private: ErrorOr<JaktInternal::Optional<formatter::FormattedToken>> next_in_toplevel_context(size_t const open_parens, size_t const open_curlies, size_t const open_squares, bool const is_extern, lexer::Token const token);
-private: ErrorOr<JaktInternal::Optional<formatter::FormattedToken>> next_in_entity_declaration_context(formatter::Entity const entity, bool const accept_generics, bool const has_generics, size_t const generic_nesting, bool const is_extern, lexer::Token const token);
-private: lexer::Token consume();
-private: bool line_has_indent() const;
-private: static ErrorOr<JaktInternal::DynamicArray<u8>> to_array(ByteString const x);
-public: static ErrorOr<formatter::Stage0> create(NonnullRefPtr<compiler::Compiler> compiler, JaktInternal::DynamicArray<u8> const source, bool const debug);
-private: ErrorOr<JaktInternal::Optional<formatter::FormattedToken>> next_in_parameter_list_context(size_t const open_parens, lexer::Token const token);
-private: ErrorOr<JaktInternal::Optional<formatter::FormattedToken>> next_in_capture_list_context(lexer::Token const token);
-public: ErrorOr<JaktInternal::Optional<formatter::FormattedToken>> next_impl(bool const reconsume);
-private: ErrorOr<JaktInternal::Optional<formatter::FormattedToken>> next_in_statement_context(size_t const open_parens, size_t const open_curlies, size_t const open_squares, size_t const arrow_indents, JaktInternal::Optional<size_t> const allow_eol, bool const inserted_comma, formatter::ExpressionMode const expression_mode, size_t const dedents_on_open_curly, i64& indent_change, lexer::Token const token);
-private: ErrorOr<JaktInternal::Optional<formatter::FormattedToken>> next_in_generic_call_type_params_context(size_t const open_angles, lexer::Token const token);
-private: ErrorOr<JaktInternal::Optional<formatter::FormattedToken>> next_in_restriction_list_context(lexer::Token const token);
-private: ErrorOr<formatter::FormattedToken> formatted_token(lexer::Token const token) const;
-private: ErrorOr<formatter::FormattedToken> formatted_token(lexer::Token const token, JaktInternal::DynamicArray<u8> const trailing_trivia, JaktInternal::DynamicArray<u8> const preceding_trivia) const;
-public: ErrorOr<JaktInternal::Optional<formatter::FormattedToken>> formatted_peek();
-private: ErrorOr<JaktInternal::Optional<formatter::FormattedToken>> next_in_type_context(size_t const open_parens, size_t const open_curlies, size_t const open_squares, size_t const open_angles, bool const seen_start, lexer::Token const token);
-public: Stage0(JaktInternal::DynamicArray<lexer::Token> a_tokens, size_t a_index, JaktInternal::DynamicArray<formatter::State> a_states, size_t a_indent, bool a_already_seen_enclosure_in_current_line, JaktInternal::DynamicArray<size_t> a_dedents_to_skip, bool a_debug);
-
-public: formatter::State state() const;
-private: ErrorOr<JaktInternal::Optional<formatter::FormattedToken>> next_in_entity_definition_context(formatter::Entity const entity, bool const is_extern, i64& indent_change, lexer::Token const token);
-private: ErrorOr<JaktInternal::Optional<formatter::FormattedToken>> next_in_extern_context(lexer::Token const token);
-private: ErrorOr<JaktInternal::Optional<formatter::FormattedToken>> next_in_function_type_context(bool const seen_final_type, lexer::Token const token);
-private: void pop_state();
-private: lexer::Token peek(i64 const offset) const;
-private: ErrorOr<JaktInternal::Optional<formatter::FormattedToken>> next_in_match_pattern_context(size_t const open_parens, bool const allow_multiple, lexer::Token const token);
-private: ErrorOr<JaktInternal::Optional<formatter::FormattedToken>> next_in_import_list_context(bool const emitted_comma, lexer::Token const token);
-private: ErrorOr<void> replace_state(formatter::State const state);
-private: ErrorOr<JaktInternal::Optional<formatter::FormattedToken>> next_in_variable_declaration_context(size_t const open_parens, lexer::Token const token);
-public: static ErrorOr<formatter::Stage0> for_tokens(JaktInternal::DynamicArray<lexer::Token> const tokens, bool const debug);
-public: ErrorOr<ByteString> debug_description() const;
-};struct Formatter {
-  public:
-public: formatter::Stage0 token_provider;public: JaktInternal::DynamicArray<formatter::ReflowState> current_line;public: size_t current_line_length;public: size_t max_allowed_line_length;public: JaktInternal::DynamicArray<formatter::BreakablePoint> breakable_points_in_current_line;public: JaktInternal::DynamicArray<formatter::ReflowState> tokens_to_reflow;public: JaktInternal::DynamicArray<JaktInternal::Optional<lexer::Token>> replace_commas_in_enclosure;public: size_t enclosures_to_ignore;public: bool in_condition_expr;public: bool in_condition_expr_indented;public: JaktInternal::Optional<size_t> logical_break_indent;public: size_t empty_line_count;public: ErrorOr<JaktInternal::Optional<JaktInternal::DynamicArray<formatter::FormattedToken>>> next();
-private: static bool should_ignore_state(formatter::State const state);
-public: ErrorOr<JaktInternal::Optional<formatter::FormattedToken>> peek();
-public: static ErrorOr<formatter::Formatter> for_tokens(JaktInternal::DynamicArray<lexer::Token> const tokens, bool const debug, size_t const max_allowed_line_length);
-private: static ErrorOr<JaktInternal::DynamicArray<u8>> to_array(ByteString const s);
-private: ErrorOr<void> fixup_tokens_to_reflow();
-public: Formatter(formatter::Stage0 a_token_provider, JaktInternal::DynamicArray<formatter::ReflowState> a_current_line, size_t a_current_line_length, size_t a_max_allowed_line_length, JaktInternal::DynamicArray<formatter::BreakablePoint> a_breakable_points_in_current_line, JaktInternal::DynamicArray<formatter::ReflowState> a_tokens_to_reflow, JaktInternal::DynamicArray<JaktInternal::Optional<lexer::Token>> a_replace_commas_in_enclosure, size_t a_enclosures_to_ignore, bool a_in_condition_expr, bool a_in_condition_expr_indented, JaktInternal::Optional<size_t> a_logical_break_indent, size_t a_empty_line_count);
-
-private: ErrorOr<size_t> token_length(formatter::FormattedToken const token) const;
-public: ErrorOr<void> fixup_closing_enclosures(JaktInternal::DynamicArray<formatter::ReflowState>& line) const;
-private: size_t pick_breaking_point_index() const;
-public: ErrorOr<ByteString> debug_description() const;
-};struct BreakablePoint {
+struct BreakablePoint {
 u8 __jakt_variant_index = 0;
 union VariantData {
 u8 __jakt_uninit_value;
@@ -246,7 +191,62 @@ size_t point() const;
 private:
 BreakablePoint() {};
 };
-template <typename T>
+struct Stage0 {
+  public:
+public: JaktInternal::DynamicArray<lexer::Token> tokens;public: size_t index;public: JaktInternal::DynamicArray<formatter::State> states;public: size_t indent;public: bool already_seen_enclosure_in_current_line;public: JaktInternal::DynamicArray<size_t> dedents_to_skip;public: bool debug;private: ErrorOr<JaktInternal::Optional<formatter::FormattedToken>> next_in_implements_context(lexer::Token const token);
+public: ErrorOr<JaktInternal::Optional<formatter::FormattedToken>> next();
+private: ErrorOr<void> push_state(formatter::State const state);
+private: ErrorOr<JaktInternal::Optional<formatter::FormattedToken>> next_in_import_context(bool const is_extern, lexer::Token const token);
+private: ErrorOr<JaktInternal::Optional<formatter::FormattedToken>> next_in_toplevel_context(size_t const open_parens, size_t const open_curlies, size_t const open_squares, bool const is_extern, lexer::Token const token);
+private: ErrorOr<JaktInternal::Optional<formatter::FormattedToken>> next_in_entity_declaration_context(formatter::Entity const entity, bool const accept_generics, bool const has_generics, size_t const generic_nesting, bool const is_extern, lexer::Token const token);
+private: lexer::Token consume();
+private: bool line_has_indent() const;
+private: static ErrorOr<JaktInternal::DynamicArray<u8>> to_array(ByteString const x);
+public: static ErrorOr<formatter::Stage0> create(NonnullRefPtr<compiler::Compiler> compiler, JaktInternal::DynamicArray<u8> const source, bool const debug);
+private: ErrorOr<JaktInternal::Optional<formatter::FormattedToken>> next_in_parameter_list_context(size_t const open_parens, lexer::Token const token);
+private: ErrorOr<JaktInternal::Optional<formatter::FormattedToken>> next_in_capture_list_context(lexer::Token const token);
+public: ErrorOr<JaktInternal::Optional<formatter::FormattedToken>> next_impl(bool const reconsume);
+private: ErrorOr<JaktInternal::Optional<formatter::FormattedToken>> next_in_statement_context(size_t const open_parens, size_t const open_curlies, size_t const open_squares, size_t const arrow_indents, JaktInternal::Optional<size_t> const allow_eol, bool const inserted_comma, formatter::ExpressionMode const expression_mode, size_t const dedents_on_open_curly, i64& indent_change, lexer::Token const token);
+private: ErrorOr<JaktInternal::Optional<formatter::FormattedToken>> next_in_generic_call_type_params_context(size_t const open_angles, lexer::Token const token);
+private: ErrorOr<JaktInternal::Optional<formatter::FormattedToken>> next_in_restriction_list_context(lexer::Token const token);
+private: ErrorOr<formatter::FormattedToken> formatted_token(lexer::Token const token) const;
+private: ErrorOr<formatter::FormattedToken> formatted_token(lexer::Token const token, JaktInternal::DynamicArray<u8> const trailing_trivia, JaktInternal::DynamicArray<u8> const preceding_trivia) const;
+public: ErrorOr<JaktInternal::Optional<formatter::FormattedToken>> formatted_peek();
+private: ErrorOr<JaktInternal::Optional<formatter::FormattedToken>> next_in_type_context(size_t const open_parens, size_t const open_curlies, size_t const open_squares, size_t const open_angles, bool const seen_start, lexer::Token const token);
+public: Stage0(JaktInternal::DynamicArray<lexer::Token> a_tokens, size_t a_index, JaktInternal::DynamicArray<formatter::State> a_states, size_t a_indent, bool a_already_seen_enclosure_in_current_line, JaktInternal::DynamicArray<size_t> a_dedents_to_skip, bool a_debug);
+
+public: formatter::State state() const;
+private: ErrorOr<JaktInternal::Optional<formatter::FormattedToken>> next_in_entity_definition_context(formatter::Entity const entity, bool const is_extern, i64& indent_change, lexer::Token const token);
+private: ErrorOr<JaktInternal::Optional<formatter::FormattedToken>> next_in_extern_context(lexer::Token const token);
+private: ErrorOr<JaktInternal::Optional<formatter::FormattedToken>> next_in_function_type_context(bool const seen_final_type, lexer::Token const token);
+private: void pop_state();
+private: lexer::Token peek(i64 const offset) const;
+private: ErrorOr<JaktInternal::Optional<formatter::FormattedToken>> next_in_match_pattern_context(size_t const open_parens, bool const allow_multiple, lexer::Token const token);
+private: ErrorOr<JaktInternal::Optional<formatter::FormattedToken>> next_in_import_list_context(bool const emitted_comma, lexer::Token const token);
+private: ErrorOr<void> replace_state(formatter::State const state);
+private: ErrorOr<JaktInternal::Optional<formatter::FormattedToken>> next_in_variable_declaration_context(size_t const open_parens, lexer::Token const token);
+public: static ErrorOr<formatter::Stage0> for_tokens(JaktInternal::DynamicArray<lexer::Token> const tokens, bool const debug);
+public: ErrorOr<ByteString> debug_description() const;
+};struct ReflowState {
+  public:
+public: formatter::FormattedToken token;public: formatter::State state;public: size_t enclosures_to_ignore;public: ReflowState(formatter::FormattedToken a_token, formatter::State a_state, size_t a_enclosures_to_ignore);
+
+public: ErrorOr<ByteString> debug_description() const;
+};struct Formatter {
+  public:
+public: formatter::Stage0 token_provider;public: JaktInternal::DynamicArray<formatter::ReflowState> current_line;public: size_t current_line_length;public: size_t max_allowed_line_length;public: JaktInternal::DynamicArray<formatter::BreakablePoint> breakable_points_in_current_line;public: JaktInternal::DynamicArray<formatter::ReflowState> tokens_to_reflow;public: JaktInternal::DynamicArray<JaktInternal::Optional<lexer::Token>> replace_commas_in_enclosure;public: size_t enclosures_to_ignore;public: bool in_condition_expr;public: bool in_condition_expr_indented;public: JaktInternal::Optional<size_t> logical_break_indent;public: size_t empty_line_count;public: ErrorOr<JaktInternal::Optional<JaktInternal::DynamicArray<formatter::FormattedToken>>> next();
+private: static bool should_ignore_state(formatter::State const state);
+public: ErrorOr<JaktInternal::Optional<formatter::FormattedToken>> peek();
+public: static ErrorOr<formatter::Formatter> for_tokens(JaktInternal::DynamicArray<lexer::Token> const tokens, bool const debug, size_t const max_allowed_line_length);
+private: static ErrorOr<JaktInternal::DynamicArray<u8>> to_array(ByteString const s);
+private: ErrorOr<void> fixup_tokens_to_reflow();
+public: Formatter(formatter::Stage0 a_token_provider, JaktInternal::DynamicArray<formatter::ReflowState> a_current_line, size_t a_current_line_length, size_t a_max_allowed_line_length, JaktInternal::DynamicArray<formatter::BreakablePoint> a_breakable_points_in_current_line, JaktInternal::DynamicArray<formatter::ReflowState> a_tokens_to_reflow, JaktInternal::DynamicArray<JaktInternal::Optional<lexer::Token>> a_replace_commas_in_enclosure, size_t a_enclosures_to_ignore, bool a_in_condition_expr, bool a_in_condition_expr_indented, JaktInternal::Optional<size_t> a_logical_break_indent, size_t a_empty_line_count);
+
+private: ErrorOr<size_t> token_length(formatter::FormattedToken const token) const;
+public: ErrorOr<void> fixup_closing_enclosures(JaktInternal::DynamicArray<formatter::ReflowState>& line) const;
+private: size_t pick_breaking_point_index() const;
+public: ErrorOr<ByteString> debug_description() const;
+};template <typename T>
 ErrorOr<JaktInternal::DynamicArray<T>> concat(JaktInternal::DynamicArray<T> const xs, T const y);
 template <typename T>
 JaktInternal::Optional<T> collapse(JaktInternal::Optional<JaktInternal::Optional<T>> const x);
@@ -278,8 +278,8 @@ JaktInternal::PrettyPrint::ScopedEnable pretty_print_enable { m_alternative_form
 };
 namespace Jakt {
 } // namespace Jakt
-template<>struct Jakt::Formatter<Jakt::formatter::ReflowState> : Jakt::Formatter<Jakt::StringView>{
-Jakt::ErrorOr<void> format(Jakt::FormatBuilder& builder, Jakt::formatter::ReflowState const& value) {
+template<>struct Jakt::Formatter<Jakt::formatter::BreakablePoint> : Jakt::Formatter<Jakt::StringView>{
+Jakt::ErrorOr<void> format(Jakt::FormatBuilder& builder, Jakt::formatter::BreakablePoint const& value) {
 JaktInternal::PrettyPrint::ScopedEnable pretty_print_enable { m_alternative_form };Jakt::ErrorOr<void> format_error = Jakt::Formatter<Jakt::StringView>::format(builder, MUST(value.debug_description()));return format_error;}
 };
 namespace Jakt {
@@ -290,14 +290,14 @@ JaktInternal::PrettyPrint::ScopedEnable pretty_print_enable { m_alternative_form
 };
 namespace Jakt {
 } // namespace Jakt
-template<>struct Jakt::Formatter<Jakt::formatter::Formatter> : Jakt::Formatter<Jakt::StringView>{
-Jakt::ErrorOr<void> format(Jakt::FormatBuilder& builder, Jakt::formatter::Formatter const& value) {
+template<>struct Jakt::Formatter<Jakt::formatter::ReflowState> : Jakt::Formatter<Jakt::StringView>{
+Jakt::ErrorOr<void> format(Jakt::FormatBuilder& builder, Jakt::formatter::ReflowState const& value) {
 JaktInternal::PrettyPrint::ScopedEnable pretty_print_enable { m_alternative_form };Jakt::ErrorOr<void> format_error = Jakt::Formatter<Jakt::StringView>::format(builder, MUST(value.debug_description()));return format_error;}
 };
 namespace Jakt {
 } // namespace Jakt
-template<>struct Jakt::Formatter<Jakt::formatter::BreakablePoint> : Jakt::Formatter<Jakt::StringView>{
-Jakt::ErrorOr<void> format(Jakt::FormatBuilder& builder, Jakt::formatter::BreakablePoint const& value) {
+template<>struct Jakt::Formatter<Jakt::formatter::Formatter> : Jakt::Formatter<Jakt::StringView>{
+Jakt::ErrorOr<void> format(Jakt::FormatBuilder& builder, Jakt::formatter::Formatter const& value) {
 JaktInternal::PrettyPrint::ScopedEnable pretty_print_enable { m_alternative_form };Jakt::ErrorOr<void> format_error = Jakt::Formatter<Jakt::StringView>::format(builder, MUST(value.debug_description()));return format_error;}
 };
 namespace Jakt {

--- a/bootstrap/stage0/ide.cpp
+++ b/bootstrap/stage0/ide.cpp
@@ -21,13 +21,13 @@ break;
 }
 parser::ParsedField field = (_magic_value.value());
 {
-TRY((((children).push(ide::JaktSymbol(((((field).var_decl)).name),JaktInternal::OptionalNone(),TRY(ByteString::from_utf8("field"sv)),((((field).var_decl)).span),((((field).var_decl)).span),(TRY((DynamicArray<ide::JaktSymbol>::create_with({})))))))));
+TRY((((children).push(ide::JaktSymbol(((((field).var_decl)).name),JaktInternal::OptionalNone(),(ByteString::must_from_utf8("field"sv)),((((field).var_decl)).span),((((field).var_decl)).span),(TRY((DynamicArray<ide::JaktSymbol>::create_with({})))))))));
 }
 
 }
 }
 
-__jakt_var_877 = TRY(ByteString::from_utf8("struct"sv)); goto __jakt_label_771;
+__jakt_var_877 = (ByteString::must_from_utf8("struct"sv)); goto __jakt_label_771;
 
 }
 __jakt_label_771:; __jakt_var_877.release_value(); }));
@@ -44,13 +44,13 @@ break;
 }
 parser::ParsedField field = (_magic_value.value());
 {
-TRY((((children).push(ide::JaktSymbol(((((field).var_decl)).name),JaktInternal::OptionalNone(),TRY(ByteString::from_utf8("field"sv)),((((field).var_decl)).span),((((field).var_decl)).span),(TRY((DynamicArray<ide::JaktSymbol>::create_with({})))))))));
+TRY((((children).push(ide::JaktSymbol(((((field).var_decl)).name),JaktInternal::OptionalNone(),(ByteString::must_from_utf8("field"sv)),((((field).var_decl)).span),((((field).var_decl)).span),(TRY((DynamicArray<ide::JaktSymbol>::create_with({})))))))));
 }
 
 }
 }
 
-__jakt_var_878 = TRY(ByteString::from_utf8("class"sv)); goto __jakt_label_772;
+__jakt_var_878 = (ByteString::must_from_utf8("class"sv)); goto __jakt_label_772;
 
 }
 __jakt_label_772:; __jakt_var_878.release_value(); }));
@@ -67,13 +67,13 @@ break;
 }
 parser::ValueEnumVariant variant = (_magic_value.value());
 {
-TRY((((children).push(ide::JaktSymbol(((variant).name),JaktInternal::OptionalNone(),TRY(ByteString::from_utf8("enum-member"sv)),((variant).span),((variant).span),(TRY((DynamicArray<ide::JaktSymbol>::create_with({})))))))));
+TRY((((children).push(ide::JaktSymbol(((variant).name),JaktInternal::OptionalNone(),(ByteString::must_from_utf8("enum-member"sv)),((variant).span),((variant).span),(TRY((DynamicArray<ide::JaktSymbol>::create_with({})))))))));
 }
 
 }
 }
 
-__jakt_var_879 = TRY(ByteString::from_utf8("enum"sv)); goto __jakt_label_773;
+__jakt_var_879 = (ByteString::must_from_utf8("enum"sv)); goto __jakt_label_773;
 
 }
 __jakt_label_773:; __jakt_var_879.release_value(); }));
@@ -106,8 +106,8 @@ if ([](ByteString const& self, ByteString rhs) -> bool {
 return (!(((self) == (rhs))));
 }
 }
-(((param).name),TRY(ByteString::from_utf8(""sv)))){
-TRY((((variant_children).push(ide::JaktSymbol(((param).name),JaktInternal::OptionalNone(),TRY(ByteString::from_utf8("field"sv)),((param).span),((param).span),(TRY((DynamicArray<ide::JaktSymbol>::create_with({})))))))));
+(((param).name),(ByteString::must_from_utf8(""sv)))){
+TRY((((variant_children).push(ide::JaktSymbol(((param).name),JaktInternal::OptionalNone(),(ByteString::must_from_utf8("field"sv)),((param).span),((param).span),(TRY((DynamicArray<ide::JaktSymbol>::create_with({})))))))));
 }
 }
 
@@ -115,19 +115,19 @@ TRY((((variant_children).push(ide::JaktSymbol(((param).name),JaktInternal::Optio
 }
 
 }
-TRY((((children).push(ide::JaktSymbol(((variant).name),JaktInternal::OptionalNone(),TRY(ByteString::from_utf8("enum-member"sv)),((variant).span),((variant).span),variant_children)))));
+TRY((((children).push(ide::JaktSymbol(((variant).name),JaktInternal::OptionalNone(),(ByteString::must_from_utf8("enum-member"sv)),((variant).span),((variant).span),variant_children)))));
 }
 
 }
 }
 
-__jakt_var_880 = TRY(ByteString::from_utf8("enum"sv)); goto __jakt_label_774;
+__jakt_var_880 = (ByteString::must_from_utf8("enum"sv)); goto __jakt_label_774;
 
 }
 __jakt_label_774:; __jakt_var_880.release_value(); }));
 };/*case end*/
 case 4 /* Garbage */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("garbage"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("garbage"sv)));
 };/*case end*/
 default: VERIFY_NOT_REACHED();}/*switch end*/
 }()
@@ -145,7 +145,7 @@ break;
 }
 parser::ParsedMethod method = (_magic_value.value());
 {
-ide::JaktSymbol const function_symbol = TRY((ide::function_to_symbol(((method).parsed_function),TRY(ByteString::from_utf8("method"sv)))));
+ide::JaktSymbol const function_symbol = TRY((ide::function_to_symbol(((method).parsed_function),(ByteString::must_from_utf8("method"sv)))));
 TRY((((children).push(function_symbol))));
 (record_span = TRY((parser::merge_spans(record_span,((function_symbol).range)))));
 }
@@ -213,13 +213,13 @@ return ide::Usage::EnumVariant(span,name,type_id,variants,number_constant);
 }
 }
 
-utility::panic(TRY(ByteString::from_utf8("unreachable: should have found variant"sv)));
+utility::panic((ByteString::must_from_utf8("unreachable: should have found variant"sv)));
 }
 
 }
 }
 
-utility::panic(TRY(ByteString::from_utf8("unreachable: should have found variant"sv)));
+utility::panic((ByteString::must_from_utf8("unreachable: should have found variant"sv)));
 }
 }
 
@@ -483,84 +483,84 @@ default: VERIFY_NOT_REACHED();}/*switch end*/
 }
 }
 
-return TRY(ByteString::from_utf8(""sv));
+return (ByteString::must_from_utf8(""sv));
 }
 }
 
 ErrorOr<ByteString> get_type_signature(NonnullRefPtr<types::CheckedProgram> const program,ids::TypeId const type_id) {
 {
-ids::StructId const array_struct_id = TRY((((program)->find_struct_in_prelude(TRY(ByteString::from_utf8("Array"sv))))));
-ids::StructId const dictionary_struct_id = TRY((((program)->find_struct_in_prelude(TRY(ByteString::from_utf8("Dictionary"sv))))));
-ids::StructId const optional_struct_id = TRY((((program)->find_struct_in_prelude(TRY(ByteString::from_utf8("Optional"sv))))));
-ids::StructId const range_struct_id = TRY((((program)->find_struct_in_prelude(TRY(ByteString::from_utf8("Range"sv))))));
-ids::StructId const set_struct_id = TRY((((program)->find_struct_in_prelude(TRY(ByteString::from_utf8("Set"sv))))));
-ids::StructId const tuple_struct_id = TRY((((program)->find_struct_in_prelude(TRY(ByteString::from_utf8("Tuple"sv))))));
-ids::StructId const weak_ptr_struct_id = TRY((((program)->find_struct_in_prelude(TRY(ByteString::from_utf8("WeakPtr"sv))))));
+ids::StructId const array_struct_id = TRY((((program)->find_struct_in_prelude((ByteString::must_from_utf8("Array"sv))))));
+ids::StructId const dictionary_struct_id = TRY((((program)->find_struct_in_prelude((ByteString::must_from_utf8("Dictionary"sv))))));
+ids::StructId const optional_struct_id = TRY((((program)->find_struct_in_prelude((ByteString::must_from_utf8("Optional"sv))))));
+ids::StructId const range_struct_id = TRY((((program)->find_struct_in_prelude((ByteString::must_from_utf8("Range"sv))))));
+ids::StructId const set_struct_id = TRY((((program)->find_struct_in_prelude((ByteString::must_from_utf8("Set"sv))))));
+ids::StructId const tuple_struct_id = TRY((((program)->find_struct_in_prelude((ByteString::must_from_utf8("Tuple"sv))))));
+ids::StructId const weak_ptr_struct_id = TRY((((program)->find_struct_in_prelude((ByteString::must_from_utf8("WeakPtr"sv))))));
 NonnullRefPtr<typename types::Type> const type = ((program)->get_type(type_id));
 return ({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<ByteString, ErrorOr<ByteString>>{
 auto&& __jakt_match_variant = *type;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 17 /* Never */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("never"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("never"sv)));
 };/*case end*/
 case 0 /* Void */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("void"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("void"sv)));
 };/*case end*/
 case 1 /* Bool */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("bool"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("bool"sv)));
 };/*case end*/
 case 2 /* U8 */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("u8"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("u8"sv)));
 };/*case end*/
 case 3 /* U16 */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("u16"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("u16"sv)));
 };/*case end*/
 case 4 /* U32 */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("u32"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("u32"sv)));
 };/*case end*/
 case 5 /* U64 */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("u64"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("u64"sv)));
 };/*case end*/
 case 6 /* I8 */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("i8"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("i8"sv)));
 };/*case end*/
 case 7 /* I16 */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("i16"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("i16"sv)));
 };/*case end*/
 case 8 /* I32 */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("i32"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("i32"sv)));
 };/*case end*/
 case 9 /* I64 */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("i64"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("i64"sv)));
 };/*case end*/
 case 10 /* F32 */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("f32"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("f32"sv)));
 };/*case end*/
 case 11 /* F64 */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("f64"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("f64"sv)));
 };/*case end*/
 case 12 /* Usize */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("usize"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("usize"sv)));
 };/*case end*/
 case 13 /* JaktString */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("String"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("String"sv)));
 };/*case end*/
 case 15 /* CInt */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("c_int"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("c_int"sv)));
 };/*case end*/
 case 14 /* CChar */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("c_char"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("c_char"sv)));
 };/*case end*/
 case 18 /* TypeVariable */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.TypeVariable;ByteString const& name = __jakt_match_value.name;
 return JaktInternal::ExplicitValue(name);
 };/*case end*/
 case 16 /* Unknown */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8(""sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8(""sv)));
 };/*case end*/
 case 31 /* Self */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("Self"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("Self"sv)));
 };/*case end*/
 case 27 /* Trait */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Trait;ids::TraitId const& trait_id = __jakt_match_value.value;
@@ -573,7 +573,7 @@ return JaktInternal::ExplicitValue(TRY((__jakt_format((StringView::from_string_l
 };/*case end*/
 case 32 /* Const */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Const;types::Value const& value = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(TRY((types::comptime_format_impl(TRY(ByteString::from_utf8("const {}"sv)),(((TRY((DynamicArray<types::Value>::create_with({value})))))[(JaktInternal::Range<i64>{static_cast<i64>(0LL),static_cast<i64>(9223372036854775807LL)})]),((program))))));
+return JaktInternal::ExplicitValue(TRY((types::comptime_format_impl((ByteString::must_from_utf8("const {}"sv)),(((TRY((DynamicArray<types::Value>::create_with({value})))))[(JaktInternal::Range<i64>{static_cast<i64>(0LL),static_cast<i64>(9223372036854775807LL)})]),((program))))));
 };/*case end*/
 case 30 /* Function */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Function;JaktInternal::DynamicArray<ids::TypeId> const& params = __jakt_match_value.params;
@@ -596,14 +596,14 @@ TRY((((param_names).push(TRY((((program)->type_name(x,false))))))));
 }
 
 ByteString const return_type = TRY((((program)->type_name(return_type_id,false))));
-__jakt_var_885 = TRY((__jakt_format((StringView::from_string_literal("fn({}) -> {}"sv)),TRY((utility::join(param_names,TRY(ByteString::from_utf8(", "sv))))),return_type))); goto __jakt_label_779;
+__jakt_var_885 = TRY((__jakt_format((StringView::from_string_literal("fn({}) -> {}"sv)),TRY((utility::join(param_names,(ByteString::must_from_utf8(", "sv))))),return_type))); goto __jakt_label_779;
 
 }
 __jakt_label_779:; __jakt_var_885.release_value(); }));
 };/*case end*/
 case 26 /* RawPtr */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.RawPtr;ids::TypeId const& type_id = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(TRY((((TRY(ByteString::from_utf8("raw "sv))) + (TRY((ide::get_type_signature(program,type_id))))))));
+return JaktInternal::ExplicitValue(TRY(((((ByteString::must_from_utf8("raw "sv))) + (TRY((ide::get_type_signature(program,type_id))))))));
 };/*case end*/
 case 25 /* Enum */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Enum;ids::EnumId const& id = __jakt_match_value.value;
@@ -613,16 +613,16 @@ __jakt_var_886 = TRY((((TRY((((({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<ByteString,ErrorOr<ByteString>>{
 auto __jakt_enum_value = (((enum_).is_boxed));
 if (__jakt_enum_value == true) {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("boxed "sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("boxed "sv)));
 }
 else {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8(""sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8(""sv)));
 }
 }());
     if (_jakt_value.is_return())
         return _jakt_value.release_return();
     _jakt_value.release_value();
-})) + (TRY(ByteString::from_utf8("enum "sv))))))) + (((enum_).name))))); goto __jakt_label_780;
+})) + ((ByteString::must_from_utf8("enum "sv))))))) + (((enum_).name))))); goto __jakt_label_780;
 
 }
 __jakt_label_780:; __jakt_var_886.release_value(); }));
@@ -636,14 +636,14 @@ __jakt_var_887 = TRY((((({
 auto&& __jakt_match_variant = ((struct_).record_type);
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 1 /* Class */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("class "sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("class "sv)));
 };/*case end*/
 case 0 /* Struct */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("struct "sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("struct "sv)));
 };/*case end*/
 default: {
 {
-utility::panic(TRY(ByteString::from_utf8("unreachable: should've been struct"sv)));
+utility::panic((ByteString::must_from_utf8("unreachable: should've been struct"sv)));
 }
 };/*case end*/
 }/*switch end*/
@@ -669,7 +669,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8("<"sv)))));
+(output,(ByteString::must_from_utf8("<"sv)))));
 if ((!(((args).is_empty())))){
 TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 {
@@ -693,7 +693,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8(", "sv)))));
+(output,(ByteString::must_from_utf8(", "sv)))));
 TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 {
 (self = TRY((((self) + (rhs)))));
@@ -707,7 +707,7 @@ return {};
 }
 
 }
-__jakt_var_888 = TRY((((output) + (TRY(ByteString::from_utf8(">"sv)))))); goto __jakt_label_782;
+__jakt_var_888 = TRY((((output) + ((ByteString::must_from_utf8(">"sv)))))); goto __jakt_label_782;
 
 }
 __jakt_label_782:; __jakt_var_888.release_value(); }));
@@ -717,7 +717,7 @@ auto&& __jakt_match_value = __jakt_match_variant.as.GenericEnumInstance;ids::Enu
 JaktInternal::DynamicArray<ids::TypeId> const& args = __jakt_match_value.args;
 return JaktInternal::ExplicitValue(({ Optional<ByteString> __jakt_var_889; {
 types::CheckedEnum const enum_ = ((program)->get_enum(id));
-ByteString output = TRY(ByteString::from_utf8(""sv));
+ByteString output = (ByteString::must_from_utf8(""sv));
 if (((enum_).is_boxed)){
 TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 {
@@ -725,7 +725,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8("boxed "sv)))));
+(output,(ByteString::must_from_utf8("boxed "sv)))));
 }
 TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 {
@@ -733,7 +733,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8("enum "sv)))));
+(output,(ByteString::must_from_utf8("enum "sv)))));
 TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 {
 (self = TRY((((self) + (rhs)))));
@@ -747,7 +747,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8("<"sv)))));
+(output,(ByteString::must_from_utf8("<"sv)))));
 if ((!(((args).is_empty())))){
 TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 {
@@ -771,7 +771,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8(", "sv)))));
+(output,(ByteString::must_from_utf8(", "sv)))));
 TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 {
 (self = TRY((((self) + (rhs)))));
@@ -785,7 +785,7 @@ return {};
 }
 
 }
-__jakt_var_889 = TRY((((output) + (TRY(ByteString::from_utf8(">"sv)))))); goto __jakt_label_783;
+__jakt_var_889 = TRY((((output) + ((ByteString::must_from_utf8(">"sv)))))); goto __jakt_label_783;
 
 }
 __jakt_label_783:; __jakt_var_889.release_value(); }));
@@ -795,14 +795,14 @@ auto&& __jakt_match_value = __jakt_match_variant.as.GenericTraitInstance;ids::Tr
 JaktInternal::DynamicArray<ids::TypeId> const& args = __jakt_match_value.args;
 return JaktInternal::ExplicitValue(({ Optional<ByteString> __jakt_var_890; {
 NonnullRefPtr<types::CheckedTrait> const trait_ = ((program)->get_trait(id));
-ByteString output = TRY(ByteString::from_utf8(""sv));
+ByteString output = (ByteString::must_from_utf8(""sv));
 TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 {
 (self = TRY((((self) + (rhs)))));
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8("trait "sv)))));
+(output,(ByteString::must_from_utf8("trait "sv)))));
 TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 {
 (self = TRY((((self) + (rhs)))));
@@ -816,7 +816,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8("<"sv)))));
+(output,(ByteString::must_from_utf8("<"sv)))));
 if ((!(((args).is_empty())))){
 TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 {
@@ -840,7 +840,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8(", "sv)))));
+(output,(ByteString::must_from_utf8(", "sv)))));
 TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 {
 (self = TRY((((self) + (rhs)))));
@@ -854,7 +854,7 @@ return {};
 }
 
 }
-__jakt_var_890 = TRY((((output) + (TRY(ByteString::from_utf8(">"sv)))))); goto __jakt_label_784;
+__jakt_var_890 = TRY((((output) + ((ByteString::must_from_utf8(">"sv)))))); goto __jakt_label_784;
 
 }
 __jakt_label_784:; __jakt_var_890.release_value(); }));
@@ -865,7 +865,7 @@ JaktInternal::DynamicArray<ids::TypeId> const& args = __jakt_match_value.args;
 return JaktInternal::ExplicitValue(({ Optional<ByteString> __jakt_var_891; {
 if (((id).equals(array_struct_id))){
 if (((args).is_empty())){
-return TRY(ByteString::from_utf8("[]"sv));
+return (ByteString::must_from_utf8("[]"sv));
 }
 return TRY((__jakt_format((StringView::from_string_literal("[{}]"sv)),TRY((ide::get_type_signature(program,((args)[static_cast<i64>(0LL)])))))));
 }
@@ -881,30 +881,30 @@ return (infallible_enum_cast<jakt__prelude__operators::Ordering>((JaktInternal::
 }
 }
 (((args).size()),static_cast<size_t>(2ULL))){
-return TRY(ByteString::from_utf8("[:]"sv));
+return (ByteString::must_from_utf8("[:]"sv));
 }
 return TRY((__jakt_format((StringView::from_string_literal("[{}: {}]"sv)),TRY((ide::get_type_signature(program,((args)[static_cast<i64>(0LL)])))),TRY((ide::get_type_signature(program,((args)[static_cast<i64>(1LL)])))))));
 }
 if (((id).equals(optional_struct_id))){
 if (((args).is_empty())){
-return TRY(ByteString::from_utf8(""sv));
+return (ByteString::must_from_utf8(""sv));
 }
 return TRY((__jakt_format((StringView::from_string_literal("{}?"sv)),TRY((ide::get_type_signature(program,((args)[static_cast<i64>(0LL)])))))));
 }
 if (((id).equals(range_struct_id))){
 if (((args).is_empty())){
-return TRY(ByteString::from_utf8(""sv));
+return (ByteString::must_from_utf8(""sv));
 }
 return TRY((__jakt_format((StringView::from_string_literal("{}..{}"sv)),TRY((ide::get_type_signature(program,((args)[static_cast<i64>(0LL)])))),TRY((((program)->type_name(((args)[static_cast<i64>(0LL)]),false)))))));
 }
 if (((id).equals(set_struct_id))){
 if (((args).is_empty())){
-return TRY(ByteString::from_utf8(""sv));
+return (ByteString::must_from_utf8(""sv));
 }
 return TRY((__jakt_format((StringView::from_string_literal("{{{}}}"sv)),TRY((ide::get_type_signature(program,((args)[static_cast<i64>(0LL)])))))));
 }
 if (((id).equals(tuple_struct_id))){
-ByteString output = TRY(ByteString::from_utf8("("sv));
+ByteString output = (ByteString::must_from_utf8("("sv));
 if ((!(((args).is_empty())))){
 TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 {
@@ -928,7 +928,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8(", "sv)))));
+(output,(ByteString::must_from_utf8(", "sv)))));
 TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 {
 (self = TRY((((self) + (rhs)))));
@@ -942,11 +942,11 @@ return {};
 }
 
 }
-return TRY((((output) + (TRY(ByteString::from_utf8(")"sv))))));
+return TRY((((output) + ((ByteString::must_from_utf8(")"sv))))));
 }
 if (((id).equals(weak_ptr_struct_id))){
 if (((args).is_empty())){
-return TRY(ByteString::from_utf8(""sv));
+return (ByteString::must_from_utf8(""sv));
 }
 return TRY((__jakt_format((StringView::from_string_literal("weak {}"sv)),TRY((ide::get_type_signature(program,((args)[static_cast<i64>(0LL)])))))));
 }
@@ -956,23 +956,23 @@ ByteString output = ({
 auto&& __jakt_match_variant = ((record).record_type);
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 1 /* Class */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("class "sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("class "sv)));
 };/*case end*/
 case 0 /* Struct */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("struct "sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("struct "sv)));
 };/*case end*/
 case 2 /* ValueEnum */: {
 {
-utility::panic(TRY(ByteString::from_utf8("unreachable: can't be an enum"sv)));
+utility::panic((ByteString::must_from_utf8("unreachable: can't be an enum"sv)));
 }
 };/*case end*/
 case 3 /* SumEnum */: {
 {
-utility::panic(TRY(ByteString::from_utf8("unreachable: can't be an enum"sv)));
+utility::panic((ByteString::must_from_utf8("unreachable: can't be an enum"sv)));
 }
 };/*case end*/
 case 4 /* Garbage */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8(""sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8(""sv)));
 };/*case end*/
 default: VERIFY_NOT_REACHED();}/*switch end*/
 }()
@@ -994,7 +994,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8("<"sv)))));
+(output,(ByteString::must_from_utf8("<"sv)))));
 if ((!(((args).is_empty())))){
 TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 {
@@ -1018,7 +1018,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8(", "sv)))));
+(output,(ByteString::must_from_utf8(", "sv)))));
 TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 {
 (self = TRY((((self) + (rhs)))));
@@ -1032,7 +1032,7 @@ return {};
 }
 
 }
-__jakt_var_891 = TRY((((output) + (TRY(ByteString::from_utf8(">"sv)))))); goto __jakt_label_785;
+__jakt_var_891 = TRY((((output) + ((ByteString::must_from_utf8(">"sv)))))); goto __jakt_label_785;
 
 }
 __jakt_label_785:; __jakt_var_891.release_value(); }));
@@ -1271,13 +1271,13 @@ ByteString const mut_string = ({
 auto&& __jakt_match_variant = mutability;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 2 /* Mutable */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("mut"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("mut"sv)));
 };/*case end*/
 case 1 /* Immutable */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("let"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("let"sv)));
 };/*case end*/
 default: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8(""sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8(""sv)));
 };/*case end*/
 }/*switch end*/
 }()
@@ -1294,7 +1294,7 @@ __jakt_label_788:; __jakt_var_894.release_value(); }));
 };/*case end*/
 case 1 /* Field */: {
 {
-ByteString record_string = TRY(ByteString::from_utf8(""sv));
+ByteString record_string = (ByteString::must_from_utf8(""sv));
 if (((struct_type_id).has_value())){
 (record_string = TRY((ide::get_type_signature(program,(struct_type_id.value())))));
 }
@@ -1303,13 +1303,13 @@ ByteString const visibility_string = ({
 auto&& __jakt_match_variant = visibility;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 1 /* Public */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("public "sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("public "sv)));
 };/*case end*/
 case 2 /* Private */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("private "sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("private "sv)));
 };/*case end*/
 default: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8(""sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8(""sv)));
 };/*case end*/
 }/*switch end*/
 }()
@@ -1324,7 +1324,7 @@ if ([](ByteString const& self, ByteString rhs) -> bool {
 return (!(((self) == (rhs))));
 }
 }
-(record_string,TRY(ByteString::from_utf8(""sv)))){
+(record_string,(ByteString::must_from_utf8(""sv)))){
 return TRY((__jakt_format((StringView::from_string_literal("{}\\n\\t{}{}: {}"sv)),record_string,visibility_string,name,type_name)));
 }
 else {
@@ -1365,7 +1365,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8("("sv)))));
+(output,(ByteString::must_from_utf8("("sv)))));
 bool first = true;
 {
 JaktInternal::ArrayIterator<types::CheckedField> _magic = ((((struct_).fields)).iterator());
@@ -1386,7 +1386,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8(", "sv)))));
+(output,(ByteString::must_from_utf8(", "sv)))));
 }
 
 NonnullRefPtr<types::CheckedVariable> const variable = ((program)->get_variable(((field).variable_id)));
@@ -1397,7 +1397,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8("mut "sv)))));
+(output,(ByteString::must_from_utf8("mut "sv)))));
 }
 TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 {
@@ -1417,7 +1417,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8(")"sv)))));
+(output,(ByteString::must_from_utf8(")"sv)))));
 return output;
 }
 }
@@ -1425,7 +1425,7 @@ return output;
 }
 }
 
-return TRY(ByteString::from_utf8(""sv));
+return (ByteString::must_from_utf8(""sv));
 }
 }
 
@@ -2260,7 +2260,7 @@ ids::FunctionId function_id = (_magic_value.value());
 NonnullRefPtr<types::CheckedFunction> const checked_function = ((program)->get_function(function_id));
 if (((((((checked_function)->params)).first())).has_value())){
 types::CheckedParameter const param = (((((checked_function)->params)).first()).value());
-if (((((((param).variable))->name)) == (TRY(ByteString::from_utf8("this"sv))))){
+if (((((((param).variable))->name)) == ((ByteString::must_from_utf8("this"sv))))){
 ByteString full_call = ((checked_function)->name);
 bool first = true;
 TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
@@ -2269,7 +2269,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(full_call,TRY(ByteString::from_utf8("("sv)))));
+(full_call,(ByteString::must_from_utf8("("sv)))));
 JaktInternal::ArrayIterator<types::CheckedParameter> iter = ((((checked_function)->params)).iterator());
 JaktInternal::Optional<types::CheckedParameter> const dummy = ((iter).next());
 {
@@ -2288,7 +2288,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(full_call,TRY(ByteString::from_utf8(", "sv)))));
+(full_call,(ByteString::must_from_utf8(", "sv)))));
 }
 else {
 (first = false);
@@ -2312,7 +2312,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(full_call,TRY(ByteString::from_utf8(")"sv)))));
+(full_call,(ByteString::must_from_utf8(")"sv)))));
 TRY((((output).push(full_call))));
 }
 }
@@ -2361,7 +2361,7 @@ break;
 }
 parser::ParsedFunction function = (_magic_value.value());
 {
-TRY((((symbols).push(TRY((ide::function_to_symbol(function,TRY(ByteString::from_utf8("function"sv)))))))));
+TRY((((symbols).push(TRY((ide::function_to_symbol(function,(ByteString::must_from_utf8("function"sv)))))))));
 }
 
 }
@@ -2399,7 +2399,7 @@ ide::JaktSymbol child = (_magic_value.value());
 }
 }
 
-return (TRY((DynamicArray<ide::JaktSymbol>::create_with({ide::JaktSymbol((((namespace_).name).value()),JaktInternal::OptionalNone(),TRY(ByteString::from_utf8("namespace"sv)),namespace_span,(((namespace_).name_span).value()),symbols)}))));
+return (TRY((DynamicArray<ide::JaktSymbol>::create_with({ide::JaktSymbol((((namespace_).name).value()),JaktInternal::OptionalNone(),(ByteString::must_from_utf8("namespace"sv)),namespace_span,(((namespace_).name_span).value()),symbols)}))));
 }
 else {
 return symbols;
@@ -2479,7 +2479,7 @@ __jakt_label_813:; __jakt_var_919.release_value(); }));
 case 3 /* NameSet */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.NameSet;JaktInternal::DynamicArray<ByteString> const& names = __jakt_match_value.value;
 return JaktInternal::ExplicitValue(({ Optional<JaktInternal::Optional<ByteString>> __jakt_var_920; {
-ByteString output = TRY(ByteString::from_utf8(""sv));
+ByteString output = (ByteString::must_from_utf8(""sv));
 bool first = true;
 {
 JaktInternal::ArrayIterator<ByteString> _magic = ((names).iterator());
@@ -2497,7 +2497,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8(" | "sv)))));
+(output,(ByteString::must_from_utf8(" | "sv)))));
 }
 else {
 (first = false);
@@ -2549,13 +2549,13 @@ return JaktInternal::OptionalNone();
 
 ErrorOr<utility::Span> find_type_definition_for_type_id(NonnullRefPtr<types::CheckedProgram> const program,ids::TypeId const type_id,utility::Span const span) {
 {
-ids::StructId const array_struct_id = TRY((((program)->find_struct_in_prelude(TRY(ByteString::from_utf8("Array"sv))))));
-ids::StructId const dictionary_struct_id = TRY((((program)->find_struct_in_prelude(TRY(ByteString::from_utf8("Dictionary"sv))))));
-ids::StructId const optional_struct_id = TRY((((program)->find_struct_in_prelude(TRY(ByteString::from_utf8("Optional"sv))))));
-ids::StructId const range_struct_id = TRY((((program)->find_struct_in_prelude(TRY(ByteString::from_utf8("Range"sv))))));
-ids::StructId const set_struct_id = TRY((((program)->find_struct_in_prelude(TRY(ByteString::from_utf8("Set"sv))))));
-ids::StructId const tuple_struct_id = TRY((((program)->find_struct_in_prelude(TRY(ByteString::from_utf8("Tuple"sv))))));
-ids::StructId const weak_ptr_struct_id = TRY((((program)->find_struct_in_prelude(TRY(ByteString::from_utf8("WeakPtr"sv))))));
+ids::StructId const array_struct_id = TRY((((program)->find_struct_in_prelude((ByteString::must_from_utf8("Array"sv))))));
+ids::StructId const dictionary_struct_id = TRY((((program)->find_struct_in_prelude((ByteString::must_from_utf8("Dictionary"sv))))));
+ids::StructId const optional_struct_id = TRY((((program)->find_struct_in_prelude((ByteString::must_from_utf8("Optional"sv))))));
+ids::StructId const range_struct_id = TRY((((program)->find_struct_in_prelude((ByteString::must_from_utf8("Range"sv))))));
+ids::StructId const set_struct_id = TRY((((program)->find_struct_in_prelude((ByteString::must_from_utf8("Set"sv))))));
+ids::StructId const tuple_struct_id = TRY((((program)->find_struct_in_prelude((ByteString::must_from_utf8("Tuple"sv))))));
+ids::StructId const weak_ptr_struct_id = TRY((((program)->find_struct_in_prelude((ByteString::must_from_utf8("WeakPtr"sv))))));
 return ({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<utility::Span, ErrorOr<utility::Span>>{
 auto&& __jakt_match_variant = *((program)->get_type(type_id));
@@ -2879,7 +2879,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8("::"sv)))));
+(output,(ByteString::must_from_utf8("::"sv)))));
 TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 {
 (self = TRY((((self) + (rhs)))));
@@ -2894,7 +2894,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8("("sv)))));
+(output,(ByteString::must_from_utf8("("sv)))));
 bool first = true;
 {
 JaktInternal::ArrayIterator<JaktInternal::Tuple<JaktInternal::Optional<ByteString>,ids::TypeId>> _magic = ((variants).iterator());
@@ -2919,7 +2919,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8(", "sv)))));
+(output,(ByteString::must_from_utf8(", "sv)))));
 }
 
 if (((variant_name).has_value())){
@@ -2936,7 +2936,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8(": "sv)))));
+(output,(ByteString::must_from_utf8(": "sv)))));
 }
 TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 {
@@ -2956,7 +2956,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8(")"sv)))));
+(output,(ByteString::must_from_utf8(")"sv)))));
 }
 if (((number_constant).has_value())){
 TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
@@ -2965,7 +2965,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8(" = "sv)))));
+(output,(ByteString::must_from_utf8(" = "sv)))));
 ({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<void, ErrorOr<ByteString>>{
 auto&& __jakt_match_variant = (number_constant.value());
@@ -3223,7 +3223,7 @@ return JaktInternal::ExplicitValue<void>();
         return _jakt_value.release_return();
     _jakt_value.release_value();
 });
-ByteString generic_parameters = TRY(ByteString::from_utf8(""sv));
+ByteString generic_parameters = (ByteString::must_from_utf8(""sv));
 bool is_first_param = true;
 if ((!(((((((checked_function)->generics))->params)).is_empty())))){
 TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
@@ -3232,7 +3232,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(generic_parameters,TRY(ByteString::from_utf8("<"sv)))));
+(generic_parameters,(ByteString::must_from_utf8("<"sv)))));
 {
 JaktInternal::ArrayIterator<types::FunctionGenericParameter> _magic = ((((((checked_function)->generics))->params)).iterator());
 for (;;){
@@ -3247,10 +3247,10 @@ ByteString const separator = ({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<ByteString,ErrorOr<ByteString>>{
 auto __jakt_enum_value = (is_first_param);
 if (__jakt_enum_value == true) {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8(""sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8(""sv)));
 }
 else if (__jakt_enum_value == false) {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8(", "sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8(", "sv)));
 }
 VERIFY_NOT_REACHED();
 }());
@@ -3281,9 +3281,9 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(generic_parameters,TRY(ByteString::from_utf8(">"sv)))));
+(generic_parameters,(ByteString::must_from_utf8(">"sv)))));
 }
-ByteString parameters = TRY(ByteString::from_utf8(""sv));
+ByteString parameters = (ByteString::must_from_utf8(""sv));
 (is_first_param = true);
 {
 JaktInternal::ArrayIterator<types::CheckedParameter> _magic = ((((checked_function)->params)).iterator());
@@ -3298,10 +3298,10 @@ ByteString const anon_value = ({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<ByteString,ErrorOr<ByteString>>{
 auto __jakt_enum_value = (((param).requires_label));
 if (__jakt_enum_value == true) {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8(""sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8(""sv)));
 }
 else if (__jakt_enum_value == false) {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("anon "sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("anon "sv)));
 }
 VERIFY_NOT_REACHED();
 }());
@@ -3317,10 +3317,10 @@ ByteString const is_mutable = ({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<ByteString,ErrorOr<ByteString>>{
 auto __jakt_enum_value = (((((param).variable))->is_mutable));
 if (__jakt_enum_value == true) {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("mut "sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("mut "sv)));
 }
 else if (__jakt_enum_value == false) {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8(""sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8(""sv)));
 }
 VERIFY_NOT_REACHED();
 }());
@@ -3338,21 +3338,21 @@ if ([](ByteString const& self, ByteString rhs) -> bool {
 return (!(((self) == (rhs))));
 }
 }
-(variable_type,TRY(ByteString::from_utf8("void"sv)))){
-(variable_type = TRY((((TRY(ByteString::from_utf8(": "sv))) + (variable_type)))));
+(variable_type,(ByteString::must_from_utf8("void"sv)))){
+(variable_type = TRY(((((ByteString::must_from_utf8(": "sv))) + (variable_type)))));
 }
 else {
-(variable_type = TRY(ByteString::from_utf8(""sv)));
+(variable_type = (ByteString::must_from_utf8(""sv)));
 }
 
 ByteString const separator = ({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<ByteString,ErrorOr<ByteString>>{
 auto __jakt_enum_value = (is_first_param);
 if (__jakt_enum_value == true) {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8(""sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8(""sv)));
 }
 else if (__jakt_enum_value == false) {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8(", "sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8(", "sv)));
 }
 VERIFY_NOT_REACHED();
 }());
@@ -3385,7 +3385,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(parameters,TRY(ByteString::from_utf8(".."sv)))));
+(parameters,(ByteString::must_from_utf8(".."sv)))));
 }
 else {
 TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
@@ -3394,7 +3394,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(parameters,TRY(ByteString::from_utf8(", .."sv)))));
+(parameters,(ByteString::must_from_utf8(", .."sv)))));
 }
 
 }
@@ -3402,10 +3402,10 @@ ByteString const throws_str = ({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<ByteString,ErrorOr<ByteString>>{
 auto __jakt_enum_value = (((checked_function)->can_throw));
 if (__jakt_enum_value == true) {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8(" throws"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8(" throws"sv)));
 }
 else if (__jakt_enum_value == false) {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8(""sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8(""sv)));
 }
 VERIFY_NOT_REACHED();
 }());
@@ -3419,11 +3419,11 @@ if ([](ByteString const& self, ByteString rhs) -> bool {
 return (!(((self) == (rhs))));
 }
 }
-(returns,TRY(ByteString::from_utf8("void"sv)))){
-(returns = TRY((((TRY(ByteString::from_utf8(" -> "sv))) + (returns)))));
+(returns,(ByteString::must_from_utf8("void"sv)))){
+(returns = TRY(((((ByteString::must_from_utf8(" -> "sv))) + (returns)))));
 }
 else {
-(returns = TRY(ByteString::from_utf8(""sv)));
+(returns = (ByteString::must_from_utf8(""sv)));
 }
 
 return TRY((__jakt_format((StringView::from_string_literal("fn {}{}({}){}{}"sv)),((checked_function)->name),generic_parameters,parameters,throws_str,returns)));
@@ -3445,7 +3445,7 @@ ide::JaktSymbol::JaktSymbol(ByteString a_name, JaktInternal::Optional<ByteString
 ErrorOr<ByteString> ide::JaktSymbol::to_json() const {
 {
 ByteStringBuilder json_builder = ByteStringBuilder::create();
-TRY((((json_builder).append_string(TRY(ByteString::from_utf8("{"sv))))));
+TRY((((json_builder).append_string((ByteString::must_from_utf8("{"sv))))));
 TRY((((json_builder).append_string(TRY((__jakt_format((StringView::from_string_literal("\"name\": \"{}\","sv)),((*this).name))))))));
 if (((((*this).detail)).has_value())){
 TRY((((json_builder).append_string(TRY((__jakt_format((StringView::from_string_literal("\"detail\": \"{}\","sv)),((*this).detail))))))));
@@ -3470,8 +3470,8 @@ TRY((((child_symbols).push(TRY((((child).to_json())))))));
 }
 }
 
-TRY((((json_builder).append_string(TRY((__jakt_format((StringView::from_string_literal("\"children\": [{}]"sv)),TRY((utility::join(child_symbols,TRY(ByteString::from_utf8(","sv))))))))))));
-TRY((((json_builder).append_string(TRY(ByteString::from_utf8("}"sv))))));
+TRY((((json_builder).append_string(TRY((__jakt_format((StringView::from_string_literal("\"children\": [{}]"sv)),TRY((utility::join(child_symbols,(ByteString::must_from_utf8(","sv))))))))))));
+TRY((((json_builder).append_string((ByteString::must_from_utf8("}"sv))))));
 return TRY((((json_builder).to_string())));
 }
 }

--- a/bootstrap/stage0/ide.h
+++ b/bootstrap/stage0/ide.h
@@ -7,13 +7,27 @@
 #include "compiler.h"
 namespace Jakt {
 namespace ide {
-struct JaktSymbol {
-  public:
-public: ByteString name;public: JaktInternal::Optional<ByteString> detail;public: ByteString kind;public: utility::Span range;public: utility::Span selection_range;public: JaktInternal::DynamicArray<ide::JaktSymbol> children;public: JaktSymbol(ByteString a_name, JaktInternal::Optional<ByteString> a_detail, ByteString a_kind, utility::Span a_range, utility::Span a_selection_range, JaktInternal::DynamicArray<ide::JaktSymbol> a_children);
-
-public: ErrorOr<ByteString> to_json() const;
-public: ErrorOr<ByteString> debug_description() const;
-};struct VarVisibility {
+struct VarType {
+u8 __jakt_variant_index = 0;
+union VariantData {
+u8 __jakt_uninit_value;
+constexpr VariantData() {}
+~VariantData() {}
+} as;
+constexpr u8 __jakt_init_index() const noexcept { return __jakt_variant_index - 1; }ErrorOr<ByteString> debug_description() const;
+[[nodiscard]] static VarType Variable();
+[[nodiscard]] static VarType Field();
+~VarType();
+VarType& operator=(VarType const &);
+VarType& operator=(VarType &&);
+VarType(VarType const&);
+VarType(VarType &&);
+private: void __jakt_destroy_variant();
+public:
+private:
+VarType() {};
+};
+struct VarVisibility {
 u8 __jakt_variant_index = 0;
 union VariantData {
 u8 __jakt_uninit_value;
@@ -35,7 +49,13 @@ public:
 private:
 VarVisibility() {};
 };
-struct Mutability {
+struct JaktSymbol {
+  public:
+public: ByteString name;public: JaktInternal::Optional<ByteString> detail;public: ByteString kind;public: utility::Span range;public: utility::Span selection_range;public: JaktInternal::DynamicArray<ide::JaktSymbol> children;public: JaktSymbol(ByteString a_name, JaktInternal::Optional<ByteString> a_detail, ByteString a_kind, utility::Span a_range, utility::Span a_selection_range, JaktInternal::DynamicArray<ide::JaktSymbol> a_children);
+
+public: ErrorOr<ByteString> to_json() const;
+public: ErrorOr<ByteString> debug_description() const;
+};struct Mutability {
 u8 __jakt_variant_index = 0;
 union VariantData {
 u8 __jakt_uninit_value;
@@ -55,26 +75,6 @@ private: void __jakt_destroy_variant();
 public:
 private:
 Mutability() {};
-};
-struct VarType {
-u8 __jakt_variant_index = 0;
-union VariantData {
-u8 __jakt_uninit_value;
-constexpr VariantData() {}
-~VariantData() {}
-} as;
-constexpr u8 __jakt_init_index() const noexcept { return __jakt_variant_index - 1; }ErrorOr<ByteString> debug_description() const;
-[[nodiscard]] static VarType Variable();
-[[nodiscard]] static VarType Field();
-~VarType();
-VarType& operator=(VarType const &);
-VarType& operator=(VarType &&);
-VarType(VarType const&);
-VarType(VarType &&);
-private: void __jakt_destroy_variant();
-public:
-private:
-VarType() {};
 };
 struct Usage {
 u8 __jakt_variant_index = 0;
@@ -126,8 +126,8 @@ Usage() {};
 };
 }
 } // namespace Jakt
-template<>struct Jakt::Formatter<Jakt::ide::JaktSymbol> : Jakt::Formatter<Jakt::StringView>{
-Jakt::ErrorOr<void> format(Jakt::FormatBuilder& builder, Jakt::ide::JaktSymbol const& value) {
+template<>struct Jakt::Formatter<Jakt::ide::VarType> : Jakt::Formatter<Jakt::StringView>{
+Jakt::ErrorOr<void> format(Jakt::FormatBuilder& builder, Jakt::ide::VarType const& value) {
 JaktInternal::PrettyPrint::ScopedEnable pretty_print_enable { m_alternative_form };Jakt::ErrorOr<void> format_error = Jakt::Formatter<Jakt::StringView>::format(builder, MUST(value.debug_description()));return format_error;}
 };
 namespace Jakt {
@@ -138,14 +138,14 @@ JaktInternal::PrettyPrint::ScopedEnable pretty_print_enable { m_alternative_form
 };
 namespace Jakt {
 } // namespace Jakt
-template<>struct Jakt::Formatter<Jakt::ide::Mutability> : Jakt::Formatter<Jakt::StringView>{
-Jakt::ErrorOr<void> format(Jakt::FormatBuilder& builder, Jakt::ide::Mutability const& value) {
+template<>struct Jakt::Formatter<Jakt::ide::JaktSymbol> : Jakt::Formatter<Jakt::StringView>{
+Jakt::ErrorOr<void> format(Jakt::FormatBuilder& builder, Jakt::ide::JaktSymbol const& value) {
 JaktInternal::PrettyPrint::ScopedEnable pretty_print_enable { m_alternative_form };Jakt::ErrorOr<void> format_error = Jakt::Formatter<Jakt::StringView>::format(builder, MUST(value.debug_description()));return format_error;}
 };
 namespace Jakt {
 } // namespace Jakt
-template<>struct Jakt::Formatter<Jakt::ide::VarType> : Jakt::Formatter<Jakt::StringView>{
-Jakt::ErrorOr<void> format(Jakt::FormatBuilder& builder, Jakt::ide::VarType const& value) {
+template<>struct Jakt::Formatter<Jakt::ide::Mutability> : Jakt::Formatter<Jakt::StringView>{
+Jakt::ErrorOr<void> format(Jakt::FormatBuilder& builder, Jakt::ide::Mutability const& value) {
 JaktInternal::PrettyPrint::ScopedEnable pretty_print_enable { m_alternative_form };Jakt::ErrorOr<void> format_error = Jakt::Formatter<Jakt::StringView>::format(builder, MUST(value.debug_description()));return format_error;}
 };
 namespace Jakt {

--- a/bootstrap/stage0/ids.h
+++ b/bootstrap/stage0/ids.h
@@ -23,41 +23,6 @@ return ((((*this).id)) == (((rhs).id)));
 public: ModuleId(size_t a_id);
 
 public: public: ErrorOr<ByteString> debug_description() const;
-};struct VarId {
-  public:
-public: ids::ModuleId module;public: size_t id;public: VarId(ids::ModuleId a_module, size_t a_id);
-
-public: ErrorOr<ByteString> debug_description() const;
-};struct TypeId {
-  public:
-public: ids::ModuleId module;public: size_t id;public: __attribute__((always_inline)) inline u32 hash() const {
-{
-return [](size_t const& self, ids::ModuleId const& other) -> u32 {
-{
-return pair_int_hash([](size_t const& self) -> u32 {
-{
-return ((AK::Traits<size_t>()).hash(self));
-}
-}
-(self),((((other))).hash()));
-}
-}
-(((*this).id),((((*this).module))));
-}
-}
-public: __attribute__((always_inline)) inline static JaktInternal::Optional<ids::TypeId> none() {
-{
-return JaktInternal::OptionalNone();
-}
-}
-public: TypeId(ids::ModuleId a_module, size_t a_id);
-
-public: public: __attribute__((always_inline)) inline bool equals(ids::TypeId const rhs) const {
-{
-return (((((((*this).module)).id)) == (((((rhs).module)).id))) && ((((*this).id)) == (((rhs).id))));
-}
-}
-public: public: ErrorOr<ByteString> debug_description() const;
 };struct EnumId {
   public:
 public: ids::ModuleId module;public: size_t id;public: __attribute__((always_inline)) inline bool equals(ids::EnumId const rhs) const {
@@ -66,6 +31,11 @@ return (((((((*this).module)).id)) == (((((rhs).module)).id))) && ((((*this).id)
 }
 }
 public: EnumId(ids::ModuleId a_module, size_t a_id);
+
+public: ErrorOr<ByteString> debug_description() const;
+};struct VarId {
+  public:
+public: ids::ModuleId module;public: size_t id;public: VarId(ids::ModuleId a_module, size_t a_id);
 
 public: ErrorOr<ByteString> debug_description() const;
 };struct StructId {
@@ -113,6 +83,36 @@ return (((((((*this).module)).id)) == (((((other).module)).id))) && ((((*this).i
 public: TraitId(ids::ModuleId a_module, size_t a_id);
 
 public: ErrorOr<ByteString> debug_description() const;
+};struct TypeId {
+  public:
+public: ids::ModuleId module;public: size_t id;public: __attribute__((always_inline)) inline u32 hash() const {
+{
+return [](size_t const& self, ids::ModuleId const& other) -> u32 {
+{
+return pair_int_hash([](size_t const& self) -> u32 {
+{
+return ((AK::Traits<size_t>()).hash(self));
+}
+}
+(self),((((other))).hash()));
+}
+}
+(((*this).id),((((*this).module))));
+}
+}
+public: __attribute__((always_inline)) inline static JaktInternal::Optional<ids::TypeId> none() {
+{
+return JaktInternal::OptionalNone();
+}
+}
+public: TypeId(ids::ModuleId a_module, size_t a_id);
+
+public: public: __attribute__((always_inline)) inline bool equals(ids::TypeId const rhs) const {
+{
+return (((((((*this).module)).id)) == (((((rhs).module)).id))) && ((((*this).id)) == (((rhs).id))));
+}
+}
+public: public: ErrorOr<ByteString> debug_description() const;
 };struct FunctionId {
   public:
 public: ids::ModuleId module;public: size_t id;public: FunctionId(ids::ModuleId a_module, size_t a_id);
@@ -131,20 +131,14 @@ JaktInternal::PrettyPrint::ScopedEnable pretty_print_enable { m_alternative_form
 };
 namespace Jakt {
 } // namespace Jakt
-template<>struct Jakt::Formatter<Jakt::ids::VarId> : Jakt::Formatter<Jakt::StringView>{
-Jakt::ErrorOr<void> format(Jakt::FormatBuilder& builder, Jakt::ids::VarId const& value) {
-JaktInternal::PrettyPrint::ScopedEnable pretty_print_enable { m_alternative_form };Jakt::ErrorOr<void> format_error = Jakt::Formatter<Jakt::StringView>::format(builder, MUST(value.debug_description()));return format_error;}
-};
-namespace Jakt {
-} // namespace Jakt
-template<>struct Jakt::Formatter<Jakt::ids::TypeId> : Jakt::Formatter<Jakt::StringView>{
-Jakt::ErrorOr<void> format(Jakt::FormatBuilder& builder, Jakt::ids::TypeId const& value) {
-JaktInternal::PrettyPrint::ScopedEnable pretty_print_enable { m_alternative_form };Jakt::ErrorOr<void> format_error = Jakt::Formatter<Jakt::StringView>::format(builder, MUST(value.debug_description()));return format_error;}
-};
-namespace Jakt {
-} // namespace Jakt
 template<>struct Jakt::Formatter<Jakt::ids::EnumId> : Jakt::Formatter<Jakt::StringView>{
 Jakt::ErrorOr<void> format(Jakt::FormatBuilder& builder, Jakt::ids::EnumId const& value) {
+JaktInternal::PrettyPrint::ScopedEnable pretty_print_enable { m_alternative_form };Jakt::ErrorOr<void> format_error = Jakt::Formatter<Jakt::StringView>::format(builder, MUST(value.debug_description()));return format_error;}
+};
+namespace Jakt {
+} // namespace Jakt
+template<>struct Jakt::Formatter<Jakt::ids::VarId> : Jakt::Formatter<Jakt::StringView>{
+Jakt::ErrorOr<void> format(Jakt::FormatBuilder& builder, Jakt::ids::VarId const& value) {
 JaktInternal::PrettyPrint::ScopedEnable pretty_print_enable { m_alternative_form };Jakt::ErrorOr<void> format_error = Jakt::Formatter<Jakt::StringView>::format(builder, MUST(value.debug_description()));return format_error;}
 };
 namespace Jakt {
@@ -163,6 +157,12 @@ namespace Jakt {
 } // namespace Jakt
 template<>struct Jakt::Formatter<Jakt::ids::TraitId> : Jakt::Formatter<Jakt::StringView>{
 Jakt::ErrorOr<void> format(Jakt::FormatBuilder& builder, Jakt::ids::TraitId const& value) {
+JaktInternal::PrettyPrint::ScopedEnable pretty_print_enable { m_alternative_form };Jakt::ErrorOr<void> format_error = Jakt::Formatter<Jakt::StringView>::format(builder, MUST(value.debug_description()));return format_error;}
+};
+namespace Jakt {
+} // namespace Jakt
+template<>struct Jakt::Formatter<Jakt::ids::TypeId> : Jakt::Formatter<Jakt::StringView>{
+Jakt::ErrorOr<void> format(Jakt::FormatBuilder& builder, Jakt::ids::TypeId const& value) {
 JaktInternal::PrettyPrint::ScopedEnable pretty_print_enable { m_alternative_form };Jakt::ErrorOr<void> format_error = Jakt::Formatter<Jakt::StringView>::format(builder, MUST(value.debug_description()));return format_error;}
 };
 namespace Jakt {

--- a/bootstrap/stage0/interpreter.cpp
+++ b/bootstrap/stage0/interpreter.cpp
@@ -1322,7 +1322,7 @@ auto&& __jakt_match_variant = *type;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 20 /* GenericInstance */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.GenericInstance;ids::StructId const& id = __jakt_match_value.id;
-return JaktInternal::ExplicitValue(((id).equals(TRY((((((interpreter)->program))->find_struct_in_prelude(TRY(ByteString::from_utf8("Optional"sv)))))))));
+return JaktInternal::ExplicitValue(((id).equals(TRY((((((interpreter)->program))->find_struct_in_prelude((ByteString::must_from_utf8("Optional"sv)))))))));
 };/*case end*/
 default: {
 return JaktInternal::ExplicitValue(false);
@@ -1777,7 +1777,7 @@ auto&& __jakt_match_variant = *((this_value).impl);
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 0 /* Void */: {
 {
-TRY((((interpreter)->error(TRY(ByteString::from_utf8("Cannot convert void to expression"sv)),((this_value).span)))));
+TRY((((interpreter)->error((ByteString::must_from_utf8("Cannot convert void to expression"sv)),((this_value).span)))));
 return Error::__jakt_from_string_literal((StringView::from_string_literal("Invalid type"sv)));
 }
 };/*case end*/
@@ -1831,11 +1831,11 @@ return JaktInternal::ExplicitValue(TRY((types::CheckedExpression::NumericConstan
 };/*case end*/
 case 13 /* JaktString */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.JaktString;ByteString const& x = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(TRY((types::CheckedExpression::QuotedString(JaktInternal::OptionalNone(),types::CheckedStringLiteral(types::StringLiteral::Static(TRY((utility::escape_for_quotes(x)))),TRY((((((interpreter)->program))->find_or_add_type_id(TRY((types::Type::Struct(parser::CheckedQualifiers(false),TRY((((((interpreter)->program))->find_struct_in_prelude(TRY(ByteString::from_utf8("String"sv))))))))),((((interpreter)->program))->prelude_module_id()),false)))),true),((this_value).span)))));
+return JaktInternal::ExplicitValue(TRY((types::CheckedExpression::QuotedString(JaktInternal::OptionalNone(),types::CheckedStringLiteral(types::StringLiteral::Static(TRY((utility::escape_for_quotes(x)))),TRY((((((interpreter)->program))->find_or_add_type_id(TRY((types::Type::Struct(parser::CheckedQualifiers(false),TRY((((((interpreter)->program))->find_struct_in_prelude((ByteString::must_from_utf8("String"sv))))))))),((((interpreter)->program))->prelude_module_id()),false)))),false),((this_value).span)))));
 };/*case end*/
 case 14 /* StringView */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.StringView;ByteString const& x = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(TRY((types::CheckedExpression::QuotedString(JaktInternal::OptionalNone(),types::CheckedStringLiteral(types::StringLiteral::Static(TRY((utility::escape_for_quotes(x)))),TRY((((((interpreter)->program))->find_or_add_type_id(TRY((types::Type::Struct(parser::CheckedQualifiers(false),TRY((((((interpreter)->program))->find_struct_in_prelude(TRY(ByteString::from_utf8("StringView"sv))))))))),((((interpreter)->program))->prelude_module_id()),false)))),true),((this_value).span)))));
+return JaktInternal::ExplicitValue(TRY((types::CheckedExpression::QuotedString(JaktInternal::OptionalNone(),types::CheckedStringLiteral(types::StringLiteral::Static(TRY((utility::escape_for_quotes(x)))),TRY((((((interpreter)->program))->find_or_add_type_id(TRY((types::Type::Struct(parser::CheckedQualifiers(false),TRY((((((interpreter)->program))->find_struct_in_prelude((ByteString::must_from_utf8("StringView"sv))))))))),((((interpreter)->program))->prelude_module_id()),false)))),false),((this_value).span)))));
 };/*case end*/
 case 15 /* CChar */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.CChar;char const& x = __jakt_match_value.value;
@@ -1853,7 +1853,7 @@ auto&& __jakt_match_value = __jakt_match_variant.as.OptionalSome;types::Value co
 return JaktInternal::ExplicitValue(({ Optional<NonnullRefPtr<typename types::CheckedExpression>> __jakt_var_192; {
 NonnullRefPtr<typename types::CheckedExpression> const expr = TRY((interpreter::value_to_checked_expression(value,interpreter)));
 ids::TypeId const inner_type_id = ((expr)->type());
-ids::StructId const optional_struct_id = TRY((((((interpreter)->program))->find_struct_in_prelude(TRY(ByteString::from_utf8("Optional"sv))))));
+ids::StructId const optional_struct_id = TRY((((((interpreter)->program))->find_struct_in_prelude((ByteString::must_from_utf8("Optional"sv))))));
 NonnullRefPtr<typename types::Type> const type = TRY((types::Type::GenericInstance(parser::CheckedQualifiers(false),optional_struct_id,(TRY((DynamicArray<ids::TypeId>::create_with({inner_type_id})))))));
 ids::TypeId const type_id = TRY((((interpreter)->find_or_add_type_id(type))));
 __jakt_var_192 = TRY((types::CheckedExpression::OptionalSome(JaktInternal::OptionalNone(),expr,((this_value).span),type_id))); goto __jakt_label_178;
@@ -1892,7 +1892,7 @@ ids::StructId const& struct_id = __jakt_match_value.struct_id;
 JaktInternal::Optional<ids::FunctionId> const& constructor = __jakt_match_value.constructor;
 return JaktInternal::ExplicitValue(({ Optional<NonnullRefPtr<typename types::CheckedExpression>> __jakt_var_194; {
 if ((!(((constructor).has_value())))){
-TRY((((interpreter)->error_with_hint(TRY(ByteString::from_utf8("Cannot convert struct to expression without constructor"sv)),((this_value).span),TRY(ByteString::from_utf8("Given struct cannot be created from its contents in any known way"sv)),((this_value).span)))));
+TRY((((interpreter)->error_with_hint((ByteString::must_from_utf8("Cannot convert struct to expression without constructor"sv)),((this_value).span),(ByteString::must_from_utf8("Given struct cannot be created from its contents in any known way"sv)),((this_value).span)))));
 return Error::__jakt_from_string_literal((StringView::from_string_literal("Invalid type"sv)));
 }
 JaktInternal::DynamicArray<NonnullRefPtr<typename types::CheckedExpression>> materialised_fields = (TRY((DynamicArray<NonnullRefPtr<typename types::CheckedExpression>>::create_with({}))));
@@ -1949,7 +1949,7 @@ return (infallible_enum_cast<jakt__prelude__operators::Ordering>((JaktInternal::
 }
 }
 (((materialised_fields).size()),((((callee)->params)).size()))){
-TRY((((interpreter)->error_with_hint(TRY(ByteString::from_utf8("Too many arguments for constructor"sv)),((this_value).span),TRY((__jakt_format((StringView::from_string_literal("Expected at most {} arguments, got {}"sv)),((((callee)->params)).size()),((materialised_fields).size())))),((this_value).span)))));
+TRY((((interpreter)->error_with_hint((ByteString::must_from_utf8("Too many arguments for constructor"sv)),((this_value).span),TRY((__jakt_format((StringView::from_string_literal("Expected at most {} arguments, got {}"sv)),((((callee)->params)).size()),((materialised_fields).size())))),((this_value).span)))));
 return Error::__jakt_from_string_literal((StringView::from_string_literal("Invalid type"sv)));
 }
 ByteString const name = ((struct_).name);
@@ -1983,7 +1983,7 @@ ids::StructId const& struct_id = __jakt_match_value.struct_id;
 JaktInternal::Optional<ids::FunctionId> const& constructor = __jakt_match_value.constructor;
 return JaktInternal::ExplicitValue(({ Optional<NonnullRefPtr<typename types::CheckedExpression>> __jakt_var_195; {
 if ((!(((constructor).has_value())))){
-TRY((((interpreter)->error_with_hint(TRY(ByteString::from_utf8("Cannot convert struct to expression without constructor"sv)),((this_value).span),TRY(ByteString::from_utf8("Given struct cannot be created from its contents in any known way"sv)),((this_value).span)))));
+TRY((((interpreter)->error_with_hint((ByteString::must_from_utf8("Cannot convert struct to expression without constructor"sv)),((this_value).span),(ByteString::must_from_utf8("Given struct cannot be created from its contents in any known way"sv)),((this_value).span)))));
 return Error::__jakt_from_string_literal((StringView::from_string_literal("Invalid type"sv)));
 }
 JaktInternal::DynamicArray<NonnullRefPtr<typename types::CheckedExpression>> materialised_fields = (TRY((DynamicArray<NonnullRefPtr<typename types::CheckedExpression>>::create_with({}))));
@@ -2040,7 +2040,7 @@ return (infallible_enum_cast<jakt__prelude__operators::Ordering>((JaktInternal::
 }
 }
 (((materialised_fields).size()),((((callee)->params)).size()))){
-TRY((((interpreter)->error_with_hint(TRY(ByteString::from_utf8("Too many arguments for constructor"sv)),((this_value).span),TRY((__jakt_format((StringView::from_string_literal("Expected at most {} arguments, got {}"sv)),((((callee)->params)).size()),((materialised_fields).size())))),((this_value).span)))));
+TRY((((interpreter)->error_with_hint((ByteString::must_from_utf8("Too many arguments for constructor"sv)),((this_value).span),TRY((__jakt_format((StringView::from_string_literal("Expected at most {} arguments, got {}"sv)),((((callee)->params)).size()),((materialised_fields).size())))),((this_value).span)))));
 return Error::__jakt_from_string_literal((StringView::from_string_literal("Invalid type"sv)));
 }
 ByteString const name = ((struct_).name);
@@ -2128,7 +2128,7 @@ break;
 size_t i = (_magic_value.value());
 {
 NonnullRefPtr<typename types::CheckedExpression> const arg = ((materialised_fields)[i]);
-TRY((((args).push((Tuple{TRY(ByteString::from_utf8(""sv)), arg})))));
+TRY((((args).push((Tuple{(ByteString::must_from_utf8(""sv)), arg})))));
 }
 
 }
@@ -2171,7 +2171,7 @@ return JaktInternal::ExplicitValue(((args)[static_cast<i64>(0LL)]));
 };/*case end*/
 default: {
 {
-utility::panic(TRY(ByteString::from_utf8("Expected generic instance of Array while materialising an array"sv)));
+utility::panic((ByteString::must_from_utf8("Expected generic instance of Array while materialising an array"sv)));
 }
 };/*case end*/
 }/*switch end*/
@@ -2217,7 +2217,7 @@ return JaktInternal::ExplicitValue((Tuple{((args)[static_cast<i64>(0LL)]), ((arg
 };/*case end*/
 default: {
 {
-utility::panic(TRY(ByteString::from_utf8("Expected generic instance of Dictionary while materialising an array"sv)));
+utility::panic((ByteString::must_from_utf8("Expected generic instance of Dictionary while materialising an array"sv)));
 }
 };/*case end*/
 }/*switch end*/
@@ -2265,7 +2265,7 @@ return JaktInternal::ExplicitValue(((args)[static_cast<i64>(0LL)]));
 };/*case end*/
 default: {
 {
-utility::panic(TRY(ByteString::from_utf8("Expected generic instance of Set while materialising an array"sv)));
+utility::panic((ByteString::must_from_utf8("Expected generic instance of Set while materialising an array"sv)));
 }
 };/*case end*/
 }/*switch end*/
@@ -2313,7 +2313,7 @@ TRY((((((inherited_scope)->comptime_bindings)).set(((capture).template get<0>())
 
 TRY((((statements).push_values(((((block).statements)))))));
 types::CheckedBlock const new_block = types::CheckedBlock(statements,inherited_scope_id,((block).control_flow),((block).yielded_type),((block).yielded_none));
-NonnullRefPtr<types::CheckedFunction> const checked_function = TRY((types::CheckedFunction::__jakt_create(TRY(ByteString::from_utf8("synthetic_lambda"sv)),((this_value).span),types::CheckedVisibility::Public(),return_type_id,JaktInternal::OptionalNone(),checked_params,TRY((types::FunctionGenerics::__jakt_create(inherited_scope_id,checked_params,(TRY((DynamicArray<types::FunctionGenericParameter>::create_with({})))),(TRY((DynamicArray<JaktInternal::DynamicArray<ids::TypeId>>::create_with({}))))))),new_block,can_throw,parser::FunctionType::Expression(),parser::FunctionLinkage::Internal(),inherited_scope_id,JaktInternal::OptionalNone(),true,JaktInternal::OptionalNone(),false,false,false,false,false,JaktInternal::OptionalNone(),JaktInternal::OptionalNone(),JaktInternal::OptionalNone(),false,JaktInternal::OptionalNone(),JaktInternal::OptionalNone(),JaktInternal::OptionalNone(),parser::InlineState::Default())));
+NonnullRefPtr<types::CheckedFunction> const checked_function = TRY((types::CheckedFunction::__jakt_create((ByteString::must_from_utf8("synthetic_lambda"sv)),((this_value).span),types::CheckedVisibility::Public(),return_type_id,JaktInternal::OptionalNone(),checked_params,TRY((types::FunctionGenerics::__jakt_create(inherited_scope_id,checked_params,(TRY((DynamicArray<types::FunctionGenericParameter>::create_with({})))),(TRY((DynamicArray<JaktInternal::DynamicArray<ids::TypeId>>::create_with({}))))))),new_block,can_throw,parser::FunctionType::Expression(),parser::FunctionLinkage::Internal(),inherited_scope_id,JaktInternal::OptionalNone(),true,JaktInternal::OptionalNone(),false,false,false,false,false,JaktInternal::OptionalNone(),JaktInternal::OptionalNone(),JaktInternal::OptionalNone(),false,JaktInternal::OptionalNone(),JaktInternal::OptionalNone(),JaktInternal::OptionalNone(),parser::InlineState::Default())));
 Function<ErrorOr<ids::FunctionId>(NonnullRefPtr<types::CheckedFunction>)> const& register_function = ((((((interpreter)->typecheck_functions))->register_function)));
 ids::FunctionId const pseudo_function_id = TRY((register_function(checked_function)));
 __jakt_var_200 = TRY((types::CheckedExpression::Function(JaktInternal::OptionalNone(),(TRY((DynamicArray<types::CheckedCapture>::create_with({})))),checked_params,can_throw,return_type_id,new_block,((this_value).span),type_id,pseudo_function_id,scope_id))); goto __jakt_label_186;
@@ -2597,7 +2597,7 @@ return JaktInternal::ExplicitValue(x);
 };/*case end*/
 default: {
 {
-TRY((((*this).error(TRY(ByteString::from_utf8("Expected string value"sv)),((value).span)))));
+TRY((((*this).error((ByteString::must_from_utf8("Expected string value"sv)),((value).span)))));
 return Error::__jakt_from_string_literal((StringView::from_string_literal("Invalid type"sv)));
 }
 };/*case end*/
@@ -2658,7 +2658,7 @@ return JaktInternal::ExplicitValue((Tuple{fields, struct_id}));
 };/*case end*/
 default: {
 {
-utility::panic(TRY(ByteString::from_utf8("Invalid left-hand side in assignment"sv)));
+utility::panic((ByteString::must_from_utf8("Invalid left-hand side in assignment"sv)));
 }
 };/*case end*/
 }/*switch end*/
@@ -2671,7 +2671,7 @@ utility::panic(TRY(ByteString::from_utf8("Invalid left-hand side in assignment"s
 };/*case end*/
 default: {
 {
-utility::panic(TRY(ByteString::from_utf8("Should not be happening here"sv)));
+utility::panic((ByteString::must_from_utf8("Should not be happening here"sv)));
 }
 };/*case end*/
 }/*switch end*/
@@ -2729,7 +2729,7 @@ return JaktInternal::ExplicitValue((Tuple{fields, enum_id}));
 };/*case end*/
 default: {
 {
-utility::panic(TRY(ByteString::from_utf8("Invalid left-hand side in assignment"sv)));
+utility::panic((ByteString::must_from_utf8("Invalid left-hand side in assignment"sv)));
 }
 };/*case end*/
 }/*switch end*/
@@ -2742,7 +2742,7 @@ utility::panic(TRY(ByteString::from_utf8("Invalid left-hand side in assignment"s
 };/*case end*/
 default: {
 {
-utility::panic(TRY(ByteString::from_utf8("Should not be happening here"sv)));
+utility::panic((ByteString::must_from_utf8("Should not be happening here"sv)));
 }
 };/*case end*/
 }/*switch end*/
@@ -2809,7 +2809,7 @@ ErrorOr<types::Value> interpreter::Interpreter::reflect_methods(ids::ScopeId con
 {
 ids::StructId const method_struct_id = ({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<ids::StructId, ErrorOr<types::Value>>{
-auto&& __jakt_match_variant = TRY((((((*this).program))->find_reflected_primitive(TRY(ByteString::from_utf8("Method"sv))))));
+auto&& __jakt_match_variant = TRY((((((*this).program))->find_reflected_primitive((ByteString::must_from_utf8("Method"sv))))));
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 0 /* Struct */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Struct;ids::StructId const& id = __jakt_match_value.value;
@@ -2817,7 +2817,7 @@ return JaktInternal::ExplicitValue(id);
 };/*case end*/
 default: {
 {
-utility::panic(TRY(ByteString::from_utf8("Expected Method to be a struct"sv)));
+utility::panic((ByteString::must_from_utf8("Expected Method to be a struct"sv)));
 }
 };/*case end*/
 }/*switch end*/
@@ -2829,7 +2829,7 @@ utility::panic(TRY(ByteString::from_utf8("Expected Method to be a struct"sv)));
 });
 ids::StructId const function_struct_id = ({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<ids::StructId, ErrorOr<types::Value>>{
-auto&& __jakt_match_variant = TRY((((((*this).program))->find_reflected_primitive(TRY(ByteString::from_utf8("Function"sv))))));
+auto&& __jakt_match_variant = TRY((((((*this).program))->find_reflected_primitive((ByteString::must_from_utf8("Function"sv))))));
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 0 /* Struct */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Struct;ids::StructId const& id = __jakt_match_value.value;
@@ -2837,7 +2837,7 @@ return JaktInternal::ExplicitValue(id);
 };/*case end*/
 default: {
 {
-utility::panic(TRY(ByteString::from_utf8("Expected Function to be a struct"sv)));
+utility::panic((ByteString::must_from_utf8("Expected Function to be a struct"sv)));
 }
 };/*case end*/
 }/*switch end*/
@@ -2847,11 +2847,11 @@ utility::panic(TRY(ByteString::from_utf8("Expected Function to be a struct"sv)))
         return _jakt_value.release_return();
     _jakt_value.release_value();
 });
-ids::FunctionId const method_struct_constructor = (TRY((((((*this).program))->find_function_in_scope(((((((*this).program))->get_struct(method_struct_id))).scope_id),TRY(ByteString::from_utf8("Method"sv)),JaktInternal::OptionalNone())))).value());
-ids::FunctionId const function_struct_constructor = (TRY((((((*this).program))->find_function_in_scope(((((((*this).program))->get_struct(function_struct_id))).scope_id),TRY(ByteString::from_utf8("Function"sv)),JaktInternal::OptionalNone())))).value());
+ids::FunctionId const method_struct_constructor = (TRY((((((*this).program))->find_function_in_scope(((((((*this).program))->get_struct(method_struct_id))).scope_id),(ByteString::must_from_utf8("Method"sv)),JaktInternal::OptionalNone())))).value());
+ids::FunctionId const function_struct_constructor = (TRY((((((*this).program))->find_function_in_scope(((((((*this).program))->get_struct(function_struct_id))).scope_id),(ByteString::must_from_utf8("Function"sv)),JaktInternal::OptionalNone())))).value());
 ids::TypeId const type_type_id = ({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<ids::TypeId, ErrorOr<types::Value>>{
-auto&& __jakt_match_variant = TRY((((((*this).program))->find_reflected_primitive(TRY(ByteString::from_utf8("Type"sv))))));
+auto&& __jakt_match_variant = TRY((((((*this).program))->find_reflected_primitive((ByteString::must_from_utf8("Type"sv))))));
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 1 /* Enum */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Enum;ids::EnumId const& id = __jakt_match_value.value;
@@ -2859,7 +2859,7 @@ return JaktInternal::ExplicitValue(((((((*this).program))->get_enum(id))).type_i
 };/*case end*/
 default: {
 {
-utility::panic(TRY(ByteString::from_utf8("Expected Type to be an enum"sv)));
+utility::panic((ByteString::must_from_utf8("Expected Type to be an enum"sv)));
 }
 };/*case end*/
 }/*switch end*/
@@ -3027,7 +3027,7 @@ auto&& __jakt_match_value = __jakt_match_variant.as.StringValue;ByteString const
 {
 ids::TypeId const checked_expr_type_id = TRY((((scope)->map_type(((expr)->type())))));
 NonnullRefPtr<typename types::Type> const checked_expr_type = ((((*this).program))->get_type(checked_expr_type_id));
-ids::StructId const optional_struct_id = TRY((((((*this).program))->find_struct_in_prelude(TRY(ByteString::from_utf8("Optional"sv))))));
+ids::StructId const optional_struct_id = TRY((((((*this).program))->find_struct_in_prelude((ByteString::must_from_utf8("Optional"sv))))));
 ({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<void, ErrorOr<NonnullRefPtr<typename types::CheckedExpression>>>{
 auto&& __jakt_match_variant = *checked_expr_type;
@@ -3039,7 +3039,7 @@ JaktInternal::DynamicArray<ids::TypeId> const& args = __jakt_match_value.args;
 ids::TypeId type_id = checked_expr_type_id;
 if (is_optional){
 if ((!(((id).equals(optional_struct_id))))){
-TRY((((*this).error(TRY(ByteString::from_utf8("Optional chaining is only allowed on optional types"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("Optional chaining is only allowed on optional types"sv)),span))));
 return Error::__jakt_from_string_literal((StringView::from_string_literal("Invalid operation"sv)));
 }
 (type_id = ((args)[static_cast<i64>(0LL)]));
@@ -3131,7 +3131,7 @@ case 24 /* Struct */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Struct;ids::StructId const& struct_id = __jakt_match_value.value;
 {
 if (is_optional){
-TRY((((*this).error(TRY(ByteString::from_utf8("Optional chaining is not allowed on non-optional types"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("Optional chaining is not allowed on non-optional types"sv)),span))));
 return Error::__jakt_from_string_literal((StringView::from_string_literal("Invalid operation"sv)));
 }
 types::CheckedStruct const structure = ((((*this).program))->get_struct(struct_id));
@@ -3179,7 +3179,7 @@ return JaktInternal::ExplicitValue<void>();
 case 2 /* UnsignedNumericValue */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.UnsignedNumericValue;u64 const& val = __jakt_match_value.value;
 {
-TRY((((*this).error(TRY(ByteString::from_utf8("Unimplemented expression"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("Unimplemented expression"sv)),span))));
 return Error::__jakt_from_string_literal((StringView::from_string_literal("Not yet implemented"sv)));
 }
 return JaktInternal::ExplicitValue<void>();
@@ -3187,7 +3187,7 @@ return JaktInternal::ExplicitValue<void>();
 case 1 /* SignedNumericValue */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.SignedNumericValue;i64 const& val = __jakt_match_value.value;
 {
-TRY((((*this).error(TRY(ByteString::from_utf8("Unimplemented expression"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("Unimplemented expression"sv)),span))));
 return Error::__jakt_from_string_literal((StringView::from_string_literal("Not yet implemented"sv)));
 }
 return JaktInternal::ExplicitValue<void>();
@@ -3571,7 +3571,7 @@ default: VERIFY_NOT_REACHED();}/*switch end*/
 
 ErrorOr<types::Value> interpreter::Interpreter::array_value_of_type(JaktInternal::DynamicArray<types::Value> const values,ids::TypeId const type,utility::Span const span) {
 {
-ids::StructId const array_struct_id = TRY((((((*this).program))->find_struct_in_prelude(TRY(ByteString::from_utf8("Array"sv))))));
+ids::StructId const array_struct_id = TRY((((((*this).program))->find_struct_in_prelude((ByteString::must_from_utf8("Array"sv))))));
 NonnullRefPtr<typename types::Type> const array_type = TRY((types::Type::GenericInstance(parser::CheckedQualifiers(false),array_struct_id,(TRY((DynamicArray<ids::TypeId>::create_with({type})))))));
 ids::TypeId const array_type_id = TRY((((*this).find_or_add_type_id(array_type))));
 return types::Value(TRY((types::ValueImpl::JaktArray(values,array_type_id))),span);
@@ -3580,7 +3580,7 @@ return types::Value(TRY((types::ValueImpl::JaktArray(values,array_type_id))),spa
 
 ErrorOr<ids::TypeId> interpreter::Interpreter::string_type() {
 {
-ids::StructId const string_struct_id = TRY((((((*this).program))->find_struct_in_prelude(TRY(ByteString::from_utf8("String"sv))))));
+ids::StructId const string_struct_id = TRY((((((*this).program))->find_struct_in_prelude((ByteString::must_from_utf8("String"sv))))));
 NonnullRefPtr<typename types::Type> const type = TRY((types::Type::Struct(parser::CheckedQualifiers(false),string_struct_id)));
 return TRY((((*this).find_or_add_type_id(type))));
 }
@@ -3600,7 +3600,7 @@ if (((((namespace_).size())) != (static_cast<size_t>(1ULL)))){
 return ({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<interpreter::StatementResult,ErrorOr<interpreter::StatementResult>>{
 auto __jakt_enum_value = (prelude_function);
-if (__jakt_enum_value == TRY(ByteString::from_utf8("format"sv))) {
+if (__jakt_enum_value == (ByteString::must_from_utf8("format"sv))) {
 return JaktInternal::ExplicitValue(({ Optional<interpreter::StatementResult> __jakt_var_207; {
 ByteString const format_string = ({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<ByteString, ErrorOr<interpreter::StatementResult>>{
@@ -3628,7 +3628,7 @@ __jakt_var_207 = interpreter::StatementResult::JustValue(types::Value(TRY((types
 }
 __jakt_label_193:; __jakt_var_207.release_value(); }));
 }
-else if (__jakt_enum_value == TRY(ByteString::from_utf8("println"sv))) {
+else if (__jakt_enum_value == (ByteString::must_from_utf8("println"sv))) {
 return JaktInternal::ExplicitValue(({ Optional<interpreter::StatementResult> __jakt_var_208; {
 ByteString const format_string = ({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<ByteString, ErrorOr<interpreter::StatementResult>>{
@@ -3655,13 +3655,13 @@ ByteString const formatted_string = TRY((types::comptime_format_impl(format_stri
 ({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<void,ErrorOr<interpreter::StatementResult>>{
 auto __jakt_enum_value = (prelude_function);
-if (__jakt_enum_value == TRY(ByteString::from_utf8("println"sv))) {
+if (__jakt_enum_value == (ByteString::must_from_utf8("println"sv))) {
 return (outln((StringView::from_string_literal("{}"sv)),formatted_string)), JaktInternal::ExplicitValue<void>();
 }
-else if (__jakt_enum_value == TRY(ByteString::from_utf8("eprintln"sv))) {
+else if (__jakt_enum_value == (ByteString::must_from_utf8("eprintln"sv))) {
 return (warnln((StringView::from_string_literal("{}"sv)),formatted_string)), JaktInternal::ExplicitValue<void>();
 }
-else if (__jakt_enum_value == TRY(ByteString::from_utf8("print"sv))) {
+else if (__jakt_enum_value == (ByteString::must_from_utf8("print"sv))) {
 return (out((StringView::from_string_literal("{}"sv)),formatted_string)), JaktInternal::ExplicitValue<void>();
 }
 else {
@@ -3678,7 +3678,7 @@ __jakt_var_208 = interpreter::StatementResult::JustValue(types::Value(TRY((types
 }
 __jakt_label_194:; __jakt_var_208.release_value(); }));
 }
-else if (__jakt_enum_value == TRY(ByteString::from_utf8("eprintln"sv))) {
+else if (__jakt_enum_value == (ByteString::must_from_utf8("eprintln"sv))) {
 return JaktInternal::ExplicitValue(({ Optional<interpreter::StatementResult> __jakt_var_209; {
 ByteString const format_string = ({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<ByteString, ErrorOr<interpreter::StatementResult>>{
@@ -3705,13 +3705,13 @@ ByteString const formatted_string = TRY((types::comptime_format_impl(format_stri
 ({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<void,ErrorOr<interpreter::StatementResult>>{
 auto __jakt_enum_value = (prelude_function);
-if (__jakt_enum_value == TRY(ByteString::from_utf8("println"sv))) {
+if (__jakt_enum_value == (ByteString::must_from_utf8("println"sv))) {
 return (outln((StringView::from_string_literal("{}"sv)),formatted_string)), JaktInternal::ExplicitValue<void>();
 }
-else if (__jakt_enum_value == TRY(ByteString::from_utf8("eprintln"sv))) {
+else if (__jakt_enum_value == (ByteString::must_from_utf8("eprintln"sv))) {
 return (warnln((StringView::from_string_literal("{}"sv)),formatted_string)), JaktInternal::ExplicitValue<void>();
 }
-else if (__jakt_enum_value == TRY(ByteString::from_utf8("print"sv))) {
+else if (__jakt_enum_value == (ByteString::must_from_utf8("print"sv))) {
 return (out((StringView::from_string_literal("{}"sv)),formatted_string)), JaktInternal::ExplicitValue<void>();
 }
 else {
@@ -3728,7 +3728,7 @@ __jakt_var_209 = interpreter::StatementResult::JustValue(types::Value(TRY((types
 }
 __jakt_label_195:; __jakt_var_209.release_value(); }));
 }
-else if (__jakt_enum_value == TRY(ByteString::from_utf8("print"sv))) {
+else if (__jakt_enum_value == (ByteString::must_from_utf8("print"sv))) {
 return JaktInternal::ExplicitValue(({ Optional<interpreter::StatementResult> __jakt_var_210; {
 ByteString const format_string = ({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<ByteString, ErrorOr<interpreter::StatementResult>>{
@@ -3755,13 +3755,13 @@ ByteString const formatted_string = TRY((types::comptime_format_impl(format_stri
 ({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<void,ErrorOr<interpreter::StatementResult>>{
 auto __jakt_enum_value = (prelude_function);
-if (__jakt_enum_value == TRY(ByteString::from_utf8("println"sv))) {
+if (__jakt_enum_value == (ByteString::must_from_utf8("println"sv))) {
 return (outln((StringView::from_string_literal("{}"sv)),formatted_string)), JaktInternal::ExplicitValue<void>();
 }
-else if (__jakt_enum_value == TRY(ByteString::from_utf8("eprintln"sv))) {
+else if (__jakt_enum_value == (ByteString::must_from_utf8("eprintln"sv))) {
 return (warnln((StringView::from_string_literal("{}"sv)),formatted_string)), JaktInternal::ExplicitValue<void>();
 }
-else if (__jakt_enum_value == TRY(ByteString::from_utf8("print"sv))) {
+else if (__jakt_enum_value == (ByteString::must_from_utf8("print"sv))) {
 return (out((StringView::from_string_literal("{}"sv)),formatted_string)), JaktInternal::ExplicitValue<void>();
 }
 else {
@@ -3778,7 +3778,7 @@ __jakt_var_210 = interpreter::StatementResult::JustValue(types::Value(TRY((types
 }
 __jakt_label_196:; __jakt_var_210.release_value(); }));
 }
-else if (__jakt_enum_value == TRY(ByteString::from_utf8("eprint"sv))) {
+else if (__jakt_enum_value == (ByteString::must_from_utf8("eprint"sv))) {
 return JaktInternal::ExplicitValue(({ Optional<interpreter::StatementResult> __jakt_var_211; {
 ByteString const format_string = ({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<ByteString, ErrorOr<interpreter::StatementResult>>{
@@ -3805,13 +3805,13 @@ ByteString const formatted_string = TRY((types::comptime_format_impl(format_stri
 ({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<void,ErrorOr<interpreter::StatementResult>>{
 auto __jakt_enum_value = (prelude_function);
-if (__jakt_enum_value == TRY(ByteString::from_utf8("println"sv))) {
+if (__jakt_enum_value == (ByteString::must_from_utf8("println"sv))) {
 return (outln((StringView::from_string_literal("{}"sv)),formatted_string)), JaktInternal::ExplicitValue<void>();
 }
-else if (__jakt_enum_value == TRY(ByteString::from_utf8("eprintln"sv))) {
+else if (__jakt_enum_value == (ByteString::must_from_utf8("eprintln"sv))) {
 return (warnln((StringView::from_string_literal("{}"sv)),formatted_string)), JaktInternal::ExplicitValue<void>();
 }
-else if (__jakt_enum_value == TRY(ByteString::from_utf8("print"sv))) {
+else if (__jakt_enum_value == (ByteString::must_from_utf8("print"sv))) {
 return (out((StringView::from_string_literal("{}"sv)),formatted_string)), JaktInternal::ExplicitValue<void>();
 }
 else {
@@ -3828,16 +3828,16 @@ __jakt_var_211 = interpreter::StatementResult::JustValue(types::Value(TRY((types
 }
 __jakt_label_197:; __jakt_var_211.release_value(); }));
 }
-else if (__jakt_enum_value == TRY(ByteString::from_utf8("as_saturated"sv))) {
+else if (__jakt_enum_value == (ByteString::must_from_utf8("as_saturated"sv))) {
 return JaktInternal::ExplicitValue(({ Optional<interpreter::StatementResult> __jakt_var_212; {
-NonnullRefPtr<types::CheckedFunction> const function = ((((*this).program))->get_function((((TRY((((((*this).program))->find_functions_with_name_in_scope(((((*this).program))->prelude_scope_id()),TRY(ByteString::from_utf8("as_saturated"sv)),false,JaktInternal::OptionalNone())))).value()))[static_cast<i64>(0LL)])));
+NonnullRefPtr<types::CheckedFunction> const function = ((((*this).program))->get_function((((TRY((((((*this).program))->find_functions_with_name_in_scope(((((*this).program))->prelude_scope_id()),(ByteString::must_from_utf8("as_saturated"sv)),false,JaktInternal::OptionalNone())))).value()))[static_cast<i64>(0LL)])));
 JaktInternal::Optional<ids::TypeId> const output_type_id = ((type_bindings).get(((((((((function)->generics))->params))[static_cast<i64>(0LL)])).type_id())));
 __jakt_var_212 = interpreter::StatementResult::JustValue(TRY((interpreter::cast_value_to_type(((arguments)[static_cast<i64>(0LL)]),(output_type_id.value()),*this,true)))); goto __jakt_label_198;
 
 }
 __jakt_label_198:; __jakt_var_212.release_value(); }));
 }
-else if (__jakt_enum_value == TRY(ByteString::from_utf8("unchecked_mul"sv))) {
+else if (__jakt_enum_value == (ByteString::must_from_utf8("unchecked_mul"sv))) {
 return JaktInternal::ExplicitValue(({ Optional<interpreter::StatementResult> __jakt_var_213; {
 types::Value const lhs_value = ((arguments)[static_cast<i64>(0LL)]);
 types::Value const rhs_value = ((arguments)[static_cast<i64>(1LL)]);
@@ -4127,7 +4127,7 @@ return Error::__jakt_from_string_literal((StringView::from_string_literal("Inval
 }
 __jakt_label_199:; __jakt_var_213.release_value(); }));
 }
-else if (__jakt_enum_value == TRY(ByteString::from_utf8("unchecked_add"sv))) {
+else if (__jakt_enum_value == (ByteString::must_from_utf8("unchecked_add"sv))) {
 return JaktInternal::ExplicitValue(({ Optional<interpreter::StatementResult> __jakt_var_214; {
 types::Value const lhs_value = ((arguments)[static_cast<i64>(0LL)]);
 types::Value const rhs_value = ((arguments)[static_cast<i64>(1LL)]);
@@ -4417,10 +4417,10 @@ return Error::__jakt_from_string_literal((StringView::from_string_literal("Inval
 }
 __jakt_label_200:; __jakt_var_214.release_value(); }));
 }
-else if (__jakt_enum_value == TRY(ByteString::from_utf8("___jakt_get_target_triple_string"sv))) {
+else if (__jakt_enum_value == (ByteString::must_from_utf8("___jakt_get_target_triple_string"sv))) {
 return JaktInternal::ExplicitValue(interpreter::StatementResult::JustValue(types::Value(TRY((types::ValueImpl::JaktString(TRY((((((*this).compiler))->target_triple).try_value_or_lazy_evaluated([&]() -> ErrorOr<ByteString> { return TRY((___jakt_get_target_triple_string())); })))))),call_span)));
 }
-else if (__jakt_enum_value == TRY(ByteString::from_utf8("___jakt_get_user_configuration_value"sv))) {
+else if (__jakt_enum_value == (ByteString::must_from_utf8("___jakt_get_user_configuration_value"sv))) {
 return JaktInternal::ExplicitValue(({ Optional<interpreter::StatementResult> __jakt_var_215; {
 NonnullRefPtr<typename types::ValueImpl> impl = TRY((types::ValueImpl::OptionalNone()));
 JaktInternal::Optional<ByteString> const value = ((((((*this).compiler))->user_configuration)).get(TRY((((*this).string_from_value(((arguments)[static_cast<i64>(0LL)])))))));
@@ -4432,38 +4432,38 @@ __jakt_var_215 = interpreter::StatementResult::JustValue(types::Value(impl,call_
 }
 __jakt_label_201:; __jakt_var_215.release_value(); }));
 }
-else if (__jakt_enum_value == TRY(ByteString::from_utf8("abort"sv))) {
+else if (__jakt_enum_value == (ByteString::must_from_utf8("abort"sv))) {
 {
 abort();
 }
 }
-else if (__jakt_enum_value == TRY(ByteString::from_utf8("Set"sv))) {
+else if (__jakt_enum_value == (ByteString::must_from_utf8("Set"sv))) {
 return JaktInternal::ExplicitValue(({ Optional<interpreter::StatementResult> __jakt_var_216; {
 if (((((type_bindings).size())) != (static_cast<size_t>(1ULL)))){
-TRY((((*this).error(TRY(ByteString::from_utf8("Set constructor expects one generic argument"sv)),call_span))));
+TRY((((*this).error((ByteString::must_from_utf8("Set constructor expects one generic argument"sv)),call_span))));
 return Error::__jakt_from_string_literal((StringView::from_string_literal("Invalid type"sv)));
 }
-ids::StructId const set_struct_id = TRY((((((*this).program))->find_struct_in_prelude(TRY(ByteString::from_utf8("Set"sv))))));
+ids::StructId const set_struct_id = TRY((((((*this).program))->find_struct_in_prelude((ByteString::must_from_utf8("Set"sv))))));
 ids::TypeId const type_id = TRY((((*this).find_or_add_type_id(TRY((types::Type::GenericInstance(parser::CheckedQualifiers(false),set_struct_id,(TRY((DynamicArray<ids::TypeId>::create_with({(((type_bindings).get(((TRY((((type_bindings).keys()))))[static_cast<i64>(0LL)]))).value())})))))))))));
 __jakt_var_216 = interpreter::StatementResult::JustValue(types::Value(TRY((types::ValueImpl::JaktSet((TRY((DynamicArray<types::Value>::create_with({})))),type_id))),call_span)); goto __jakt_label_202;
 
 }
 __jakt_label_202:; __jakt_var_216.release_value(); }));
 }
-else if (__jakt_enum_value == TRY(ByteString::from_utf8("Dictionary"sv))) {
+else if (__jakt_enum_value == (ByteString::must_from_utf8("Dictionary"sv))) {
 return JaktInternal::ExplicitValue(({ Optional<interpreter::StatementResult> __jakt_var_217; {
 if (((((type_bindings).size())) != (static_cast<size_t>(2ULL)))){
-TRY((((*this).error(TRY(ByteString::from_utf8("Dictionary constructor expects two generic argumenst"sv)),call_span))));
+TRY((((*this).error((ByteString::must_from_utf8("Dictionary constructor expects two generic argumenst"sv)),call_span))));
 return Error::__jakt_from_string_literal((StringView::from_string_literal("Invalid type"sv)));
 }
-ids::StructId const dictionary_struct_id = TRY((((((*this).program))->find_struct_in_prelude(TRY(ByteString::from_utf8("Dictionary"sv))))));
+ids::StructId const dictionary_struct_id = TRY((((((*this).program))->find_struct_in_prelude((ByteString::must_from_utf8("Dictionary"sv))))));
 ids::TypeId const type_id = TRY((((*this).find_or_add_type_id(TRY((types::Type::GenericInstance(parser::CheckedQualifiers(false),dictionary_struct_id,(TRY((DynamicArray<ids::TypeId>::create_with({(((type_bindings).get(((TRY((((type_bindings).keys()))))[static_cast<i64>(0LL)]))).value()), (((type_bindings).get(((TRY((((type_bindings).keys()))))[static_cast<i64>(1LL)]))).value())})))))))))));
 __jakt_var_217 = interpreter::StatementResult::JustValue(types::Value(TRY((types::ValueImpl::JaktDictionary((TRY((DynamicArray<types::Value>::create_with({})))),(TRY((DynamicArray<types::Value>::create_with({})))),type_id))),call_span)); goto __jakt_label_203;
 
 }
 __jakt_label_203:; __jakt_var_217.release_value(); }));
 }
-else if (__jakt_enum_value == TRY(ByteString::from_utf8("from_string_literal"sv))) {
+else if (__jakt_enum_value == (ByteString::must_from_utf8("from_string_literal"sv))) {
 return JaktInternal::ExplicitValue(({ Optional<interpreter::StatementResult> __jakt_var_218; {
 __jakt_var_218 = interpreter::StatementResult::JustValue(((arguments)[static_cast<i64>(0LL)])); goto __jakt_label_204;
 
@@ -4485,35 +4485,35 @@ return Error::__jakt_from_string_literal((StringView::from_string_literal("Not y
 return ({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<interpreter::StatementResult,ErrorOr<interpreter::StatementResult>>{
 auto __jakt_enum_value = (((((namespace_)[static_cast<i64>(0LL)])).name));
-if (__jakt_enum_value == TRY(ByteString::from_utf8("Error"sv))) {
+if (__jakt_enum_value == (ByteString::must_from_utf8("Error"sv))) {
 return JaktInternal::ExplicitValue(({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<interpreter::StatementResult,ErrorOr<interpreter::StatementResult>>{
 auto __jakt_enum_value = (prelude_function);
-if (__jakt_enum_value == TRY(ByteString::from_utf8("from_errno"sv))) {
+if (__jakt_enum_value == (ByteString::must_from_utf8("from_errno"sv))) {
 return JaktInternal::ExplicitValue(({ Optional<interpreter::StatementResult> __jakt_var_219; {
 types::Value const err = ((arguments)[static_cast<i64>(0LL)]);
-ids::StructId const error_struct_id = TRY((((((*this).program))->find_struct_in_prelude(TRY(ByteString::from_utf8("Error"sv))))));
+ids::StructId const error_struct_id = TRY((((((*this).program))->find_struct_in_prelude((ByteString::must_from_utf8("Error"sv))))));
 types::CheckedStruct const error_struct = ((((*this).program))->get_struct(error_struct_id));
 NonnullRefPtr<types::Scope> const scope = TRY((((((*this).program))->get_scope(((error_struct).scope_id)))));
-JaktInternal::Optional<JaktInternal::DynamicArray<ids::FunctionId>> const constructors = ((((scope)->functions)).get(TRY(ByteString::from_utf8("from_errno"sv))));
+JaktInternal::Optional<JaktInternal::DynamicArray<ids::FunctionId>> const constructors = ((((scope)->functions)).get((ByteString::must_from_utf8("from_errno"sv))));
 __jakt_var_219 = interpreter::StatementResult::JustValue(types::Value(TRY((types::ValueImpl::Struct((TRY((DynamicArray<types::Value>::create_with({err})))),error_struct_id,(((constructors.value()))[static_cast<i64>(0LL)])))),call_span)); goto __jakt_label_205;
 
 }
 __jakt_label_205:; __jakt_var_219.release_value(); }));
 }
-else if (__jakt_enum_value == TRY(ByteString::from_utf8("from_string_literal"sv))) {
+else if (__jakt_enum_value == (ByteString::must_from_utf8("from_string_literal"sv))) {
 return JaktInternal::ExplicitValue(({ Optional<interpreter::StatementResult> __jakt_var_220; {
 types::Value const err = ((arguments)[static_cast<i64>(0LL)]);
-ids::StructId const error_struct_id = TRY((((((*this).program))->find_struct_in_prelude(TRY(ByteString::from_utf8("Error"sv))))));
+ids::StructId const error_struct_id = TRY((((((*this).program))->find_struct_in_prelude((ByteString::must_from_utf8("Error"sv))))));
 types::CheckedStruct const error_struct = ((((*this).program))->get_struct(error_struct_id));
 NonnullRefPtr<types::Scope> const scope = TRY((((((*this).program))->get_scope(((error_struct).scope_id)))));
-JaktInternal::Optional<JaktInternal::DynamicArray<ids::FunctionId>> const constructors = ((((scope)->functions)).get(TRY(ByteString::from_utf8("from_string_literal"sv))));
+JaktInternal::Optional<JaktInternal::DynamicArray<ids::FunctionId>> const constructors = ((((scope)->functions)).get((ByteString::must_from_utf8("from_string_literal"sv))));
 __jakt_var_220 = interpreter::StatementResult::JustValue(types::Value(TRY((types::ValueImpl::Struct((TRY((DynamicArray<types::Value>::create_with({err})))),error_struct_id,(((constructors.value()))[static_cast<i64>(0LL)])))),call_span)); goto __jakt_label_206;
 
 }
 __jakt_label_206:; __jakt_var_220.release_value(); }));
 }
-else if (__jakt_enum_value == TRY(ByteString::from_utf8("code"sv))) {
+else if (__jakt_enum_value == (ByteString::must_from_utf8("code"sv))) {
 return JaktInternal::ExplicitValue(({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<interpreter::StatementResult, ErrorOr<interpreter::StatementResult>>{
 auto&& __jakt_match_variant = *(((this_argument.value())).impl);
@@ -4568,11 +4568,11 @@ return Error::__jakt_from_string_literal((StringView::from_string_literal("Not y
     _jakt_value.release_value();
 }));
 }
-else if (__jakt_enum_value == TRY(ByteString::from_utf8("File"sv))) {
+else if (__jakt_enum_value == (ByteString::must_from_utf8("File"sv))) {
 return JaktInternal::ExplicitValue(({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<interpreter::StatementResult,ErrorOr<interpreter::StatementResult>>{
 auto __jakt_enum_value = (prelude_function);
-if (__jakt_enum_value == TRY(ByteString::from_utf8("open_for_reading"sv))) {
+if (__jakt_enum_value == (ByteString::must_from_utf8("open_for_reading"sv))) {
 return JaktInternal::ExplicitValue(({ Optional<interpreter::StatementResult> __jakt_var_221; {
 ByteString const requested_path = ({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<ByteString, ErrorOr<interpreter::StatementResult>>{
@@ -4600,16 +4600,16 @@ types::Value const path_value = types::Value(TRY((types::ValueImpl::JaktString((
 if ((!(((path).exists())))){
 return interpreter::StatementResult::Throw(TRY((((*this).error_value(TRY((__jakt_format((StringView::from_string_literal("Could not find file at path {}"sv)),((path).to_string())))),call_span)))));
 }
-ids::StructId const file_struct_id = TRY((((((*this).program))->find_struct_in_prelude(TRY(ByteString::from_utf8("File"sv))))));
+ids::StructId const file_struct_id = TRY((((((*this).program))->find_struct_in_prelude((ByteString::must_from_utf8("File"sv))))));
 types::CheckedStruct const file_struct = ((((*this).program))->get_struct(file_struct_id));
 NonnullRefPtr<types::Scope> const scope = TRY((((((*this).program))->get_scope(((file_struct).scope_id)))));
-JaktInternal::Optional<JaktInternal::DynamicArray<ids::FunctionId>> const constructors = ((((scope)->functions)).get(TRY(ByteString::from_utf8("open_for_reading"sv))));
+JaktInternal::Optional<JaktInternal::DynamicArray<ids::FunctionId>> const constructors = ((((scope)->functions)).get((ByteString::must_from_utf8("open_for_reading"sv))));
 __jakt_var_221 = interpreter::StatementResult::JustValue(types::Value(TRY((types::ValueImpl::Struct((TRY((DynamicArray<types::Value>::create_with({path_value})))),file_struct_id,(((constructors.value()))[static_cast<i64>(0LL)])))),call_span)); goto __jakt_label_207;
 
 }
 __jakt_label_207:; __jakt_var_221.release_value(); }));
 }
-else if (__jakt_enum_value == TRY(ByteString::from_utf8("open_for_writing"sv))) {
+else if (__jakt_enum_value == (ByteString::must_from_utf8("open_for_writing"sv))) {
 return JaktInternal::ExplicitValue(({ Optional<interpreter::StatementResult> __jakt_var_222; {
 ByteString const requested_path = ({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<ByteString, ErrorOr<interpreter::StatementResult>>{
@@ -4637,16 +4637,16 @@ types::Value const path_value = types::Value(TRY((types::ValueImpl::JaktString((
 if ((!(((path).exists())))){
 return interpreter::StatementResult::Throw(TRY((((*this).error_value(TRY((__jakt_format((StringView::from_string_literal("Could not find file at path {}"sv)),((path).to_string())))),call_span)))));
 }
-ids::StructId const file_struct_id = TRY((((((*this).program))->find_struct_in_prelude(TRY(ByteString::from_utf8("File"sv))))));
+ids::StructId const file_struct_id = TRY((((((*this).program))->find_struct_in_prelude((ByteString::must_from_utf8("File"sv))))));
 types::CheckedStruct const file_struct = ((((*this).program))->get_struct(file_struct_id));
 NonnullRefPtr<types::Scope> const scope = TRY((((((*this).program))->get_scope(((file_struct).scope_id)))));
-JaktInternal::Optional<JaktInternal::DynamicArray<ids::FunctionId>> const constructor = ((((scope)->functions)).get(TRY(ByteString::from_utf8("open_for_writing"sv))));
+JaktInternal::Optional<JaktInternal::DynamicArray<ids::FunctionId>> const constructor = ((((scope)->functions)).get((ByteString::must_from_utf8("open_for_writing"sv))));
 __jakt_var_222 = interpreter::StatementResult::JustValue(types::Value(TRY((types::ValueImpl::Struct((TRY((DynamicArray<types::Value>::create_with({path_value})))),file_struct_id,(((constructor.value()))[static_cast<i64>(0LL)])))),call_span)); goto __jakt_label_208;
 
 }
 __jakt_label_208:; __jakt_var_222.release_value(); }));
 }
-else if (__jakt_enum_value == TRY(ByteString::from_utf8("read_all"sv))) {
+else if (__jakt_enum_value == (ByteString::must_from_utf8("read_all"sv))) {
 return JaktInternal::ExplicitValue(({ Optional<interpreter::StatementResult> __jakt_var_223; {
 ByteString const path = ({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<ByteString, ErrorOr<interpreter::StatementResult>>{
@@ -4664,7 +4664,7 @@ return JaktInternal::ExplicitValue(x);
 };/*case end*/
 default: {
 {
-utility::panic(TRY(ByteString::from_utf8("invalid type for File::read_all"sv)));
+utility::panic((ByteString::must_from_utf8("invalid type for File::read_all"sv)));
 }
 };/*case end*/
 }/*switch end*/
@@ -4688,10 +4688,10 @@ return Error::__jakt_from_string_literal((StringView::from_string_literal("Inval
         return _jakt_value.release_return();
     _jakt_value.release_value();
 });
-ids::StructId const file_struct_id = TRY((((((*this).program))->find_struct_in_prelude(TRY(ByteString::from_utf8("File"sv))))));
+ids::StructId const file_struct_id = TRY((((((*this).program))->find_struct_in_prelude((ByteString::must_from_utf8("File"sv))))));
 types::CheckedStruct const file_struct = ((((*this).program))->get_struct(file_struct_id));
 NonnullRefPtr<types::Scope> const scope = TRY((((((*this).program))->get_scope(((file_struct).scope_id)))));
-ids::FunctionId const open_for_reading = (((((((scope)->functions)).get(TRY(ByteString::from_utf8("open_for_reading"sv)))).value()))[static_cast<i64>(0LL)]);
+ids::FunctionId const open_for_reading = (((((((scope)->functions)).get((ByteString::must_from_utf8("open_for_reading"sv)))).value()))[static_cast<i64>(0LL)]);
 ({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<void, ErrorOr<interpreter::StatementResult>>{
 auto&& __jakt_match_variant = *(((this_argument.value())).impl);
@@ -4700,7 +4700,7 @@ case 17 /* Struct */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Struct;JaktInternal::Optional<ids::FunctionId> const& constructor = __jakt_match_value.constructor;
 {
 if (((!(((constructor).has_value()))) || (!((((constructor.value())).equals(open_for_reading)))))){
-TRY((((*this).error(TRY(ByteString::from_utf8("Cannot read from a file not opened for reading"sv)),call_span))));
+TRY((((*this).error((ByteString::must_from_utf8("Cannot read from a file not opened for reading"sv)),call_span))));
 return Error::__jakt_from_string_literal((StringView::from_string_literal("Invalid type"sv)));
 }
 }
@@ -4708,7 +4708,7 @@ return JaktInternal::ExplicitValue<void>();
 };/*case end*/
 default: {
 {
-utility::panic(TRY(ByteString::from_utf8("expected struct as this argument"sv)));
+utility::panic((ByteString::must_from_utf8("expected struct as this argument"sv)));
 }
 return JaktInternal::ExplicitValue<void>();
 };/*case end*/
@@ -4736,13 +4736,13 @@ TRY((((result_values).push(types::Value(TRY((types::ValueImpl::U8(byte))),call_s
 }
 }
 
-ids::StructId const array_struct_id = TRY((((((*this).program))->find_struct_in_prelude(TRY(ByteString::from_utf8("Array"sv))))));
+ids::StructId const array_struct_id = TRY((((((*this).program))->find_struct_in_prelude((ByteString::must_from_utf8("Array"sv))))));
 __jakt_var_223 = interpreter::StatementResult::JustValue(types::Value(TRY((types::ValueImpl::JaktArray(result_values,TRY((((*this).find_or_add_type_id(TRY((types::Type::GenericInstance(parser::CheckedQualifiers(false),array_struct_id,(TRY((DynamicArray<ids::TypeId>::create_with({types::builtin(types::BuiltinType::U8())})))))))))))))),call_span)); goto __jakt_label_209;
 
 }
 __jakt_label_209:; __jakt_var_223.release_value(); }));
 }
-else if (__jakt_enum_value == TRY(ByteString::from_utf8("read"sv))) {
+else if (__jakt_enum_value == (ByteString::must_from_utf8("read"sv))) {
 return JaktInternal::ExplicitValue(({ Optional<interpreter::StatementResult> __jakt_var_224; {
 ByteString const path = ({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<ByteString, ErrorOr<interpreter::StatementResult>>{
@@ -4760,7 +4760,7 @@ return JaktInternal::ExplicitValue(x);
 };/*case end*/
 default: {
 {
-utility::panic(TRY(ByteString::from_utf8("invalid type for File::read"sv)));
+utility::panic((ByteString::must_from_utf8("invalid type for File::read"sv)));
 }
 };/*case end*/
 }/*switch end*/
@@ -4784,10 +4784,10 @@ return Error::__jakt_from_string_literal((StringView::from_string_literal("Inval
         return _jakt_value.release_return();
     _jakt_value.release_value();
 });
-ids::StructId const file_struct_id = TRY((((((*this).program))->find_struct_in_prelude(TRY(ByteString::from_utf8("File"sv))))));
+ids::StructId const file_struct_id = TRY((((((*this).program))->find_struct_in_prelude((ByteString::must_from_utf8("File"sv))))));
 types::CheckedStruct const file_struct = ((((*this).program))->get_struct(file_struct_id));
 NonnullRefPtr<types::Scope> const scope = TRY((((((*this).program))->get_scope(((file_struct).scope_id)))));
-ids::FunctionId const open_for_reading = (((((((scope)->functions)).get(TRY(ByteString::from_utf8("open_for_reading"sv)))).value()))[static_cast<i64>(0LL)]);
+ids::FunctionId const open_for_reading = (((((((scope)->functions)).get((ByteString::must_from_utf8("open_for_reading"sv)))).value()))[static_cast<i64>(0LL)]);
 ({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<void, ErrorOr<interpreter::StatementResult>>{
 auto&& __jakt_match_variant = *(((this_argument.value())).impl);
@@ -4796,7 +4796,7 @@ case 17 /* Struct */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Struct;JaktInternal::Optional<ids::FunctionId> const& constructor = __jakt_match_value.constructor;
 {
 if (((!(((constructor).has_value()))) || (!((((constructor.value())).equals(open_for_reading)))))){
-TRY((((*this).error(TRY(ByteString::from_utf8("Cannot read from a file not opened for reading"sv)),call_span))));
+TRY((((*this).error((ByteString::must_from_utf8("Cannot read from a file not opened for reading"sv)),call_span))));
 return Error::__jakt_from_string_literal((StringView::from_string_literal("Invalid type"sv)));
 }
 }
@@ -4804,7 +4804,7 @@ return JaktInternal::ExplicitValue<void>();
 };/*case end*/
 default: {
 {
-utility::panic(TRY(ByteString::from_utf8("expected struct as this argument"sv)));
+utility::panic((ByteString::must_from_utf8("expected struct as this argument"sv)));
 }
 return JaktInternal::ExplicitValue<void>();
 };/*case end*/
@@ -4859,7 +4859,7 @@ __jakt_var_224 = interpreter::StatementResult::JustValue(types::Value(TRY((types
 }
 __jakt_label_210:; __jakt_var_224.release_value(); }));
 }
-else if (__jakt_enum_value == TRY(ByteString::from_utf8("exists"sv))) {
+else if (__jakt_enum_value == (ByteString::must_from_utf8("exists"sv))) {
 return JaktInternal::ExplicitValue(({ Optional<interpreter::StatementResult> __jakt_var_225; {
 ByteString const requested_path = ({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<ByteString, ErrorOr<interpreter::StatementResult>>{
@@ -4888,7 +4888,7 @@ __jakt_var_225 = interpreter::StatementResult::JustValue(types::Value(TRY((types
 }
 __jakt_label_211:; __jakt_var_225.release_value(); }));
 }
-else if (__jakt_enum_value == TRY(ByteString::from_utf8("write"sv))) {
+else if (__jakt_enum_value == (ByteString::must_from_utf8("write"sv))) {
 return JaktInternal::ExplicitValue(({ Optional<interpreter::StatementResult> __jakt_var_226; {
 ByteString const path = ({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<ByteString, ErrorOr<interpreter::StatementResult>>{
@@ -4906,7 +4906,7 @@ return JaktInternal::ExplicitValue(x);
 };/*case end*/
 default: {
 {
-utility::panic(TRY(ByteString::from_utf8("invalid type for File::write"sv)));
+utility::panic((ByteString::must_from_utf8("invalid type for File::write"sv)));
 }
 };/*case end*/
 }/*switch end*/
@@ -4930,10 +4930,10 @@ return Error::__jakt_from_string_literal((StringView::from_string_literal("Inval
         return _jakt_value.release_return();
     _jakt_value.release_value();
 });
-ids::StructId const file_struct_id = TRY((((((*this).program))->find_struct_in_prelude(TRY(ByteString::from_utf8("File"sv))))));
+ids::StructId const file_struct_id = TRY((((((*this).program))->find_struct_in_prelude((ByteString::must_from_utf8("File"sv))))));
 types::CheckedStruct const file_struct = ((((*this).program))->get_struct(file_struct_id));
 NonnullRefPtr<types::Scope> const scope = TRY((((((*this).program))->get_scope(((file_struct).scope_id)))));
-ids::FunctionId const open_for_writing = (((((((scope)->functions)).get(TRY(ByteString::from_utf8("open_for_writing"sv)))).value()))[static_cast<i64>(0LL)]);
+ids::FunctionId const open_for_writing = (((((((scope)->functions)).get((ByteString::must_from_utf8("open_for_writing"sv)))).value()))[static_cast<i64>(0LL)]);
 ({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<void, ErrorOr<interpreter::StatementResult>>{
 auto&& __jakt_match_variant = *(((this_argument.value())).impl);
@@ -4942,7 +4942,7 @@ case 17 /* Struct */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Struct;JaktInternal::Optional<ids::FunctionId> const& constructor = __jakt_match_value.constructor;
 {
 if (((!(((constructor).has_value()))) || (!((((constructor.value())).equals(open_for_writing)))))){
-TRY((((*this).error(TRY(ByteString::from_utf8("Cannot write to a file not opened for writing"sv)),call_span))));
+TRY((((*this).error((ByteString::must_from_utf8("Cannot write to a file not opened for writing"sv)),call_span))));
 return Error::__jakt_from_string_literal((StringView::from_string_literal("Invalid type"sv)));
 }
 }
@@ -4950,7 +4950,7 @@ return JaktInternal::ExplicitValue<void>();
 };/*case end*/
 default: {
 {
-utility::panic(TRY(ByteString::from_utf8("expected struct as this argument"sv)));
+utility::panic((ByteString::must_from_utf8("expected struct as this argument"sv)));
 }
 return JaktInternal::ExplicitValue<void>();
 };/*case end*/
@@ -5003,7 +5003,7 @@ return JaktInternal::ExplicitValue(x);
 };/*case end*/
 default: {
 {
-utility::panic(TRY(ByteString::from_utf8("expected byte"sv)));
+utility::panic((ByteString::must_from_utf8("expected byte"sv)));
 }
 };/*case end*/
 }/*switch end*/
@@ -5040,19 +5040,19 @@ return Error::__jakt_from_string_literal((StringView::from_string_literal("Not y
     _jakt_value.release_value();
 }));
 }
-else if (__jakt_enum_value == TRY(ByteString::from_utf8("StringBuilder"sv))) {
+else if (__jakt_enum_value == (ByteString::must_from_utf8("StringBuilder"sv))) {
 return JaktInternal::ExplicitValue(({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<interpreter::StatementResult,ErrorOr<interpreter::StatementResult>>{
 auto __jakt_enum_value = (prelude_function);
-if (__jakt_enum_value == TRY(ByteString::from_utf8("create"sv))) {
+if (__jakt_enum_value == (ByteString::must_from_utf8("create"sv))) {
 return JaktInternal::ExplicitValue(({ Optional<interpreter::StatementResult> __jakt_var_227; {
-ids::StructId const string_builder_struct_id = TRY((((((*this).program))->find_struct_in_prelude(TRY(ByteString::from_utf8("StringBuilder"sv))))));
-__jakt_var_227 = interpreter::StatementResult::JustValue(types::Value(TRY((types::ValueImpl::Struct((TRY((DynamicArray<types::Value>::create_with({types::Value(TRY((types::ValueImpl::JaktString(TRY(ByteString::from_utf8(""sv))))),call_span)})))),string_builder_struct_id,JaktInternal::OptionalNone()))),call_span)); goto __jakt_label_213;
+ids::StructId const string_builder_struct_id = TRY((((((*this).program))->find_struct_in_prelude((ByteString::must_from_utf8("StringBuilder"sv))))));
+__jakt_var_227 = interpreter::StatementResult::JustValue(types::Value(TRY((types::ValueImpl::Struct((TRY((DynamicArray<types::Value>::create_with({types::Value(TRY((types::ValueImpl::JaktString((ByteString::must_from_utf8(""sv))))),call_span)})))),string_builder_struct_id,JaktInternal::OptionalNone()))),call_span)); goto __jakt_label_213;
 
 }
 __jakt_label_213:; __jakt_var_227.release_value(); }));
 }
-else if (__jakt_enum_value == TRY(ByteString::from_utf8("append"sv))) {
+else if (__jakt_enum_value == (ByteString::must_from_utf8("append"sv))) {
 return JaktInternal::ExplicitValue(({ Optional<interpreter::StatementResult> __jakt_var_228; {
 JaktInternal::Tuple<JaktInternal::DynamicArray<types::Value>,ByteString> fields_current_string_ = ({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<JaktInternal::Tuple<JaktInternal::DynamicArray<types::Value>,ByteString>, ErrorOr<interpreter::StatementResult>>{
@@ -5070,7 +5070,7 @@ return JaktInternal::ExplicitValue((Tuple{fields, value}));
 };/*case end*/
 default: {
 {
-utility::panic(TRY(ByteString::from_utf8("Invalid use of prelude StringBuilder"sv)));
+utility::panic((ByteString::must_from_utf8("Invalid use of prelude StringBuilder"sv)));
 }
 };/*case end*/
 }/*switch end*/
@@ -5102,7 +5102,7 @@ TRY((((builder).append_string(current_string))));
 ({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<void,ErrorOr<interpreter::StatementResult>>{
 auto __jakt_enum_value = (prelude_function);
-if (__jakt_enum_value == TRY(ByteString::from_utf8("append"sv))) {
+if (__jakt_enum_value == (ByteString::must_from_utf8("append"sv))) {
 return (({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<void, ErrorOr<interpreter::StatementResult>>{
 auto&& __jakt_match_variant = *((((arguments)[static_cast<i64>(0LL)])).impl);
@@ -5134,7 +5134,7 @@ return JaktInternal::ExplicitValue<void>();
     _jakt_value.release_value();
 })), JaktInternal::ExplicitValue<void>();
 }
-else if (__jakt_enum_value == TRY(ByteString::from_utf8("append_string"sv))) {
+else if (__jakt_enum_value == (ByteString::must_from_utf8("append_string"sv))) {
 return (TRY((((builder).append_string(({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<ByteString, ErrorOr<interpreter::StatementResult>>{
 auto&& __jakt_match_variant = *((((arguments)[static_cast<i64>(0LL)])).impl);
@@ -5145,7 +5145,7 @@ return JaktInternal::ExplicitValue(value);
 };/*case end*/
 default: {
 {
-TRY((((*this).error(TRY(ByteString::from_utf8("Invalid use of StringBuilder::append_string()"sv)),call_span))));
+TRY((((*this).error((ByteString::must_from_utf8("Invalid use of StringBuilder::append_string()"sv)),call_span))));
 return Error::__jakt_from_string_literal((StringView::from_string_literal("Invalid type"sv)));
 }
 };/*case end*/
@@ -5157,7 +5157,7 @@ return Error::__jakt_from_string_literal((StringView::from_string_literal("Inval
     _jakt_value.release_value();
 })))))), JaktInternal::ExplicitValue<void>();
 }
-else if (__jakt_enum_value == TRY(ByteString::from_utf8("append_escaped_for_json"sv))) {
+else if (__jakt_enum_value == (ByteString::must_from_utf8("append_escaped_for_json"sv))) {
 return (TRY((((builder).append_escaped_for_json(({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<ByteString, ErrorOr<interpreter::StatementResult>>{
 auto&& __jakt_match_variant = *((((arguments)[static_cast<i64>(0LL)])).impl);
@@ -5168,7 +5168,7 @@ return JaktInternal::ExplicitValue(value);
 };/*case end*/
 default: {
 {
-TRY((((*this).error(TRY(ByteString::from_utf8("Invalid use of StringBuilder::append_escaped_for_json()"sv)),call_span))));
+TRY((((*this).error((ByteString::must_from_utf8("Invalid use of StringBuilder::append_escaped_for_json()"sv)),call_span))));
 return Error::__jakt_from_string_literal((StringView::from_string_literal("Invalid type"sv)));
 }
 };/*case end*/
@@ -5180,7 +5180,7 @@ return Error::__jakt_from_string_literal((StringView::from_string_literal("Inval
     _jakt_value.release_value();
 })))))), JaktInternal::ExplicitValue<void>();
 }
-else if (__jakt_enum_value == TRY(ByteString::from_utf8("append_code_point"sv))) {
+else if (__jakt_enum_value == (ByteString::must_from_utf8("append_code_point"sv))) {
 return (TRY((((builder).append_code_point(({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<u32, ErrorOr<interpreter::StatementResult>>{
 auto&& __jakt_match_variant = *((((arguments)[static_cast<i64>(0LL)])).impl);
@@ -5191,7 +5191,7 @@ return JaktInternal::ExplicitValue(value);
 };/*case end*/
 default: {
 {
-TRY((((*this).error(TRY(ByteString::from_utf8("Invalid use of StringBuilder::append_code_point()"sv)),call_span))));
+TRY((((*this).error((ByteString::must_from_utf8("Invalid use of StringBuilder::append_code_point()"sv)),call_span))));
 return Error::__jakt_from_string_literal((StringView::from_string_literal("Invalid type"sv)));
 }
 };/*case end*/
@@ -5221,7 +5221,7 @@ __jakt_var_228 = interpreter::StatementResult::JustValue(types::Value(TRY((types
 }
 __jakt_label_214:; __jakt_var_228.release_value(); }));
 }
-else if (__jakt_enum_value == TRY(ByteString::from_utf8("append_string"sv))) {
+else if (__jakt_enum_value == (ByteString::must_from_utf8("append_string"sv))) {
 return JaktInternal::ExplicitValue(({ Optional<interpreter::StatementResult> __jakt_var_229; {
 JaktInternal::Tuple<JaktInternal::DynamicArray<types::Value>,ByteString> fields_current_string_ = ({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<JaktInternal::Tuple<JaktInternal::DynamicArray<types::Value>,ByteString>, ErrorOr<interpreter::StatementResult>>{
@@ -5239,7 +5239,7 @@ return JaktInternal::ExplicitValue((Tuple{fields, value}));
 };/*case end*/
 default: {
 {
-utility::panic(TRY(ByteString::from_utf8("Invalid use of prelude StringBuilder"sv)));
+utility::panic((ByteString::must_from_utf8("Invalid use of prelude StringBuilder"sv)));
 }
 };/*case end*/
 }/*switch end*/
@@ -5271,7 +5271,7 @@ TRY((((builder).append_string(current_string))));
 ({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<void,ErrorOr<interpreter::StatementResult>>{
 auto __jakt_enum_value = (prelude_function);
-if (__jakt_enum_value == TRY(ByteString::from_utf8("append"sv))) {
+if (__jakt_enum_value == (ByteString::must_from_utf8("append"sv))) {
 return (({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<void, ErrorOr<interpreter::StatementResult>>{
 auto&& __jakt_match_variant = *((((arguments)[static_cast<i64>(0LL)])).impl);
@@ -5303,7 +5303,7 @@ return JaktInternal::ExplicitValue<void>();
     _jakt_value.release_value();
 })), JaktInternal::ExplicitValue<void>();
 }
-else if (__jakt_enum_value == TRY(ByteString::from_utf8("append_string"sv))) {
+else if (__jakt_enum_value == (ByteString::must_from_utf8("append_string"sv))) {
 return (TRY((((builder).append_string(({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<ByteString, ErrorOr<interpreter::StatementResult>>{
 auto&& __jakt_match_variant = *((((arguments)[static_cast<i64>(0LL)])).impl);
@@ -5314,7 +5314,7 @@ return JaktInternal::ExplicitValue(value);
 };/*case end*/
 default: {
 {
-TRY((((*this).error(TRY(ByteString::from_utf8("Invalid use of StringBuilder::append_string()"sv)),call_span))));
+TRY((((*this).error((ByteString::must_from_utf8("Invalid use of StringBuilder::append_string()"sv)),call_span))));
 return Error::__jakt_from_string_literal((StringView::from_string_literal("Invalid type"sv)));
 }
 };/*case end*/
@@ -5326,7 +5326,7 @@ return Error::__jakt_from_string_literal((StringView::from_string_literal("Inval
     _jakt_value.release_value();
 })))))), JaktInternal::ExplicitValue<void>();
 }
-else if (__jakt_enum_value == TRY(ByteString::from_utf8("append_escaped_for_json"sv))) {
+else if (__jakt_enum_value == (ByteString::must_from_utf8("append_escaped_for_json"sv))) {
 return (TRY((((builder).append_escaped_for_json(({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<ByteString, ErrorOr<interpreter::StatementResult>>{
 auto&& __jakt_match_variant = *((((arguments)[static_cast<i64>(0LL)])).impl);
@@ -5337,7 +5337,7 @@ return JaktInternal::ExplicitValue(value);
 };/*case end*/
 default: {
 {
-TRY((((*this).error(TRY(ByteString::from_utf8("Invalid use of StringBuilder::append_escaped_for_json()"sv)),call_span))));
+TRY((((*this).error((ByteString::must_from_utf8("Invalid use of StringBuilder::append_escaped_for_json()"sv)),call_span))));
 return Error::__jakt_from_string_literal((StringView::from_string_literal("Invalid type"sv)));
 }
 };/*case end*/
@@ -5349,7 +5349,7 @@ return Error::__jakt_from_string_literal((StringView::from_string_literal("Inval
     _jakt_value.release_value();
 })))))), JaktInternal::ExplicitValue<void>();
 }
-else if (__jakt_enum_value == TRY(ByteString::from_utf8("append_code_point"sv))) {
+else if (__jakt_enum_value == (ByteString::must_from_utf8("append_code_point"sv))) {
 return (TRY((((builder).append_code_point(({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<u32, ErrorOr<interpreter::StatementResult>>{
 auto&& __jakt_match_variant = *((((arguments)[static_cast<i64>(0LL)])).impl);
@@ -5360,7 +5360,7 @@ return JaktInternal::ExplicitValue(value);
 };/*case end*/
 default: {
 {
-TRY((((*this).error(TRY(ByteString::from_utf8("Invalid use of StringBuilder::append_code_point()"sv)),call_span))));
+TRY((((*this).error((ByteString::must_from_utf8("Invalid use of StringBuilder::append_code_point()"sv)),call_span))));
 return Error::__jakt_from_string_literal((StringView::from_string_literal("Invalid type"sv)));
 }
 };/*case end*/
@@ -5390,7 +5390,7 @@ __jakt_var_229 = interpreter::StatementResult::JustValue(types::Value(TRY((types
 }
 __jakt_label_215:; __jakt_var_229.release_value(); }));
 }
-else if (__jakt_enum_value == TRY(ByteString::from_utf8("append_code_point"sv))) {
+else if (__jakt_enum_value == (ByteString::must_from_utf8("append_code_point"sv))) {
 return JaktInternal::ExplicitValue(({ Optional<interpreter::StatementResult> __jakt_var_230; {
 JaktInternal::Tuple<JaktInternal::DynamicArray<types::Value>,ByteString> fields_current_string_ = ({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<JaktInternal::Tuple<JaktInternal::DynamicArray<types::Value>,ByteString>, ErrorOr<interpreter::StatementResult>>{
@@ -5408,7 +5408,7 @@ return JaktInternal::ExplicitValue((Tuple{fields, value}));
 };/*case end*/
 default: {
 {
-utility::panic(TRY(ByteString::from_utf8("Invalid use of prelude StringBuilder"sv)));
+utility::panic((ByteString::must_from_utf8("Invalid use of prelude StringBuilder"sv)));
 }
 };/*case end*/
 }/*switch end*/
@@ -5440,7 +5440,7 @@ TRY((((builder).append_string(current_string))));
 ({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<void,ErrorOr<interpreter::StatementResult>>{
 auto __jakt_enum_value = (prelude_function);
-if (__jakt_enum_value == TRY(ByteString::from_utf8("append"sv))) {
+if (__jakt_enum_value == (ByteString::must_from_utf8("append"sv))) {
 return (({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<void, ErrorOr<interpreter::StatementResult>>{
 auto&& __jakt_match_variant = *((((arguments)[static_cast<i64>(0LL)])).impl);
@@ -5472,7 +5472,7 @@ return JaktInternal::ExplicitValue<void>();
     _jakt_value.release_value();
 })), JaktInternal::ExplicitValue<void>();
 }
-else if (__jakt_enum_value == TRY(ByteString::from_utf8("append_string"sv))) {
+else if (__jakt_enum_value == (ByteString::must_from_utf8("append_string"sv))) {
 return (TRY((((builder).append_string(({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<ByteString, ErrorOr<interpreter::StatementResult>>{
 auto&& __jakt_match_variant = *((((arguments)[static_cast<i64>(0LL)])).impl);
@@ -5483,7 +5483,7 @@ return JaktInternal::ExplicitValue(value);
 };/*case end*/
 default: {
 {
-TRY((((*this).error(TRY(ByteString::from_utf8("Invalid use of StringBuilder::append_string()"sv)),call_span))));
+TRY((((*this).error((ByteString::must_from_utf8("Invalid use of StringBuilder::append_string()"sv)),call_span))));
 return Error::__jakt_from_string_literal((StringView::from_string_literal("Invalid type"sv)));
 }
 };/*case end*/
@@ -5495,7 +5495,7 @@ return Error::__jakt_from_string_literal((StringView::from_string_literal("Inval
     _jakt_value.release_value();
 })))))), JaktInternal::ExplicitValue<void>();
 }
-else if (__jakt_enum_value == TRY(ByteString::from_utf8("append_escaped_for_json"sv))) {
+else if (__jakt_enum_value == (ByteString::must_from_utf8("append_escaped_for_json"sv))) {
 return (TRY((((builder).append_escaped_for_json(({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<ByteString, ErrorOr<interpreter::StatementResult>>{
 auto&& __jakt_match_variant = *((((arguments)[static_cast<i64>(0LL)])).impl);
@@ -5506,7 +5506,7 @@ return JaktInternal::ExplicitValue(value);
 };/*case end*/
 default: {
 {
-TRY((((*this).error(TRY(ByteString::from_utf8("Invalid use of StringBuilder::append_escaped_for_json()"sv)),call_span))));
+TRY((((*this).error((ByteString::must_from_utf8("Invalid use of StringBuilder::append_escaped_for_json()"sv)),call_span))));
 return Error::__jakt_from_string_literal((StringView::from_string_literal("Invalid type"sv)));
 }
 };/*case end*/
@@ -5518,7 +5518,7 @@ return Error::__jakt_from_string_literal((StringView::from_string_literal("Inval
     _jakt_value.release_value();
 })))))), JaktInternal::ExplicitValue<void>();
 }
-else if (__jakt_enum_value == TRY(ByteString::from_utf8("append_code_point"sv))) {
+else if (__jakt_enum_value == (ByteString::must_from_utf8("append_code_point"sv))) {
 return (TRY((((builder).append_code_point(({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<u32, ErrorOr<interpreter::StatementResult>>{
 auto&& __jakt_match_variant = *((((arguments)[static_cast<i64>(0LL)])).impl);
@@ -5529,7 +5529,7 @@ return JaktInternal::ExplicitValue(value);
 };/*case end*/
 default: {
 {
-TRY((((*this).error(TRY(ByteString::from_utf8("Invalid use of StringBuilder::append_code_point()"sv)),call_span))));
+TRY((((*this).error((ByteString::must_from_utf8("Invalid use of StringBuilder::append_code_point()"sv)),call_span))));
 return Error::__jakt_from_string_literal((StringView::from_string_literal("Invalid type"sv)));
 }
 };/*case end*/
@@ -5559,7 +5559,7 @@ __jakt_var_230 = interpreter::StatementResult::JustValue(types::Value(TRY((types
 }
 __jakt_label_216:; __jakt_var_230.release_value(); }));
 }
-else if (__jakt_enum_value == TRY(ByteString::from_utf8("append_escaped_for_json"sv))) {
+else if (__jakt_enum_value == (ByteString::must_from_utf8("append_escaped_for_json"sv))) {
 return JaktInternal::ExplicitValue(({ Optional<interpreter::StatementResult> __jakt_var_231; {
 JaktInternal::Tuple<JaktInternal::DynamicArray<types::Value>,ByteString> fields_current_string_ = ({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<JaktInternal::Tuple<JaktInternal::DynamicArray<types::Value>,ByteString>, ErrorOr<interpreter::StatementResult>>{
@@ -5577,7 +5577,7 @@ return JaktInternal::ExplicitValue((Tuple{fields, value}));
 };/*case end*/
 default: {
 {
-utility::panic(TRY(ByteString::from_utf8("Invalid use of prelude StringBuilder"sv)));
+utility::panic((ByteString::must_from_utf8("Invalid use of prelude StringBuilder"sv)));
 }
 };/*case end*/
 }/*switch end*/
@@ -5609,7 +5609,7 @@ TRY((((builder).append_string(current_string))));
 ({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<void,ErrorOr<interpreter::StatementResult>>{
 auto __jakt_enum_value = (prelude_function);
-if (__jakt_enum_value == TRY(ByteString::from_utf8("append"sv))) {
+if (__jakt_enum_value == (ByteString::must_from_utf8("append"sv))) {
 return (({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<void, ErrorOr<interpreter::StatementResult>>{
 auto&& __jakt_match_variant = *((((arguments)[static_cast<i64>(0LL)])).impl);
@@ -5641,7 +5641,7 @@ return JaktInternal::ExplicitValue<void>();
     _jakt_value.release_value();
 })), JaktInternal::ExplicitValue<void>();
 }
-else if (__jakt_enum_value == TRY(ByteString::from_utf8("append_string"sv))) {
+else if (__jakt_enum_value == (ByteString::must_from_utf8("append_string"sv))) {
 return (TRY((((builder).append_string(({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<ByteString, ErrorOr<interpreter::StatementResult>>{
 auto&& __jakt_match_variant = *((((arguments)[static_cast<i64>(0LL)])).impl);
@@ -5652,7 +5652,7 @@ return JaktInternal::ExplicitValue(value);
 };/*case end*/
 default: {
 {
-TRY((((*this).error(TRY(ByteString::from_utf8("Invalid use of StringBuilder::append_string()"sv)),call_span))));
+TRY((((*this).error((ByteString::must_from_utf8("Invalid use of StringBuilder::append_string()"sv)),call_span))));
 return Error::__jakt_from_string_literal((StringView::from_string_literal("Invalid type"sv)));
 }
 };/*case end*/
@@ -5664,7 +5664,7 @@ return Error::__jakt_from_string_literal((StringView::from_string_literal("Inval
     _jakt_value.release_value();
 })))))), JaktInternal::ExplicitValue<void>();
 }
-else if (__jakt_enum_value == TRY(ByteString::from_utf8("append_escaped_for_json"sv))) {
+else if (__jakt_enum_value == (ByteString::must_from_utf8("append_escaped_for_json"sv))) {
 return (TRY((((builder).append_escaped_for_json(({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<ByteString, ErrorOr<interpreter::StatementResult>>{
 auto&& __jakt_match_variant = *((((arguments)[static_cast<i64>(0LL)])).impl);
@@ -5675,7 +5675,7 @@ return JaktInternal::ExplicitValue(value);
 };/*case end*/
 default: {
 {
-TRY((((*this).error(TRY(ByteString::from_utf8("Invalid use of StringBuilder::append_escaped_for_json()"sv)),call_span))));
+TRY((((*this).error((ByteString::must_from_utf8("Invalid use of StringBuilder::append_escaped_for_json()"sv)),call_span))));
 return Error::__jakt_from_string_literal((StringView::from_string_literal("Invalid type"sv)));
 }
 };/*case end*/
@@ -5687,7 +5687,7 @@ return Error::__jakt_from_string_literal((StringView::from_string_literal("Inval
     _jakt_value.release_value();
 })))))), JaktInternal::ExplicitValue<void>();
 }
-else if (__jakt_enum_value == TRY(ByteString::from_utf8("append_code_point"sv))) {
+else if (__jakt_enum_value == (ByteString::must_from_utf8("append_code_point"sv))) {
 return (TRY((((builder).append_code_point(({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<u32, ErrorOr<interpreter::StatementResult>>{
 auto&& __jakt_match_variant = *((((arguments)[static_cast<i64>(0LL)])).impl);
@@ -5698,7 +5698,7 @@ return JaktInternal::ExplicitValue(value);
 };/*case end*/
 default: {
 {
-TRY((((*this).error(TRY(ByteString::from_utf8("Invalid use of StringBuilder::append_code_point()"sv)),call_span))));
+TRY((((*this).error((ByteString::must_from_utf8("Invalid use of StringBuilder::append_code_point()"sv)),call_span))));
 return Error::__jakt_from_string_literal((StringView::from_string_literal("Invalid type"sv)));
 }
 };/*case end*/
@@ -5728,7 +5728,7 @@ __jakt_var_231 = interpreter::StatementResult::JustValue(types::Value(TRY((types
 }
 __jakt_label_217:; __jakt_var_231.release_value(); }));
 }
-else if (__jakt_enum_value == TRY(ByteString::from_utf8("to_string"sv))) {
+else if (__jakt_enum_value == (ByteString::must_from_utf8("to_string"sv))) {
 return JaktInternal::ExplicitValue(({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<interpreter::StatementResult, ErrorOr<interpreter::StatementResult>>{
 auto&& __jakt_match_variant = *(((this_argument.value())).impl);
@@ -5751,7 +5751,7 @@ return Error::__jakt_from_string_literal((StringView::from_string_literal("Not y
     _jakt_value.release_value();
 }));
 }
-else if (__jakt_enum_value == TRY(ByteString::from_utf8("is_empty"sv))) {
+else if (__jakt_enum_value == (ByteString::must_from_utf8("is_empty"sv))) {
 return JaktInternal::ExplicitValue(({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<interpreter::StatementResult, ErrorOr<interpreter::StatementResult>>{
 auto&& __jakt_match_variant = *(((this_argument.value())).impl);
@@ -5768,7 +5768,7 @@ return JaktInternal::ExplicitValue(interpreter::StatementResult::JustValue(types
 };/*case end*/
 default: {
 {
-utility::panic(TRY(ByteString::from_utf8("Invalid use of prelude StringBuilder"sv)));
+utility::panic((ByteString::must_from_utf8("Invalid use of prelude StringBuilder"sv)));
 }
 };/*case end*/
 }/*switch end*/
@@ -5793,7 +5793,7 @@ return Error::__jakt_from_string_literal((StringView::from_string_literal("Not y
     _jakt_value.release_value();
 }));
 }
-else if (__jakt_enum_value == TRY(ByteString::from_utf8("length"sv))) {
+else if (__jakt_enum_value == (ByteString::must_from_utf8("length"sv))) {
 return JaktInternal::ExplicitValue(({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<interpreter::StatementResult, ErrorOr<interpreter::StatementResult>>{
 auto&& __jakt_match_variant = *(((this_argument.value())).impl);
@@ -5810,7 +5810,7 @@ return JaktInternal::ExplicitValue(interpreter::StatementResult::JustValue(types
 };/*case end*/
 default: {
 {
-utility::panic(TRY(ByteString::from_utf8("Invalid use of prelude StringBuilder"sv)));
+utility::panic((ByteString::must_from_utf8("Invalid use of prelude StringBuilder"sv)));
 }
 };/*case end*/
 }/*switch end*/
@@ -5835,7 +5835,7 @@ return Error::__jakt_from_string_literal((StringView::from_string_literal("Not y
     _jakt_value.release_value();
 }));
 }
-else if (__jakt_enum_value == TRY(ByteString::from_utf8("clear"sv))) {
+else if (__jakt_enum_value == (ByteString::must_from_utf8("clear"sv))) {
 return JaktInternal::ExplicitValue(({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<interpreter::StatementResult, ErrorOr<interpreter::StatementResult>>{
 auto&& __jakt_match_variant = *(((this_argument.value())).impl);
@@ -5844,7 +5844,7 @@ case 17 /* Struct */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Struct;JaktInternal::DynamicArray<types::Value> const& fields = __jakt_match_value.fields;
 return JaktInternal::ExplicitValue(({ Optional<interpreter::StatementResult> __jakt_var_232; {
 JaktInternal::DynamicArray<types::Value> mutable_fields = fields;
-(((((mutable_fields)[static_cast<i64>(0LL)])).impl) = TRY((types::ValueImpl::JaktString(TRY(ByteString::from_utf8(""sv))))));
+(((((mutable_fields)[static_cast<i64>(0LL)])).impl) = TRY((types::ValueImpl::JaktString((ByteString::must_from_utf8(""sv))))));
 __jakt_var_232 = interpreter::StatementResult::JustValue(types::Value(TRY((types::ValueImpl::Void())),call_span)); goto __jakt_label_218;
 
 }
@@ -5876,24 +5876,24 @@ return Error::__jakt_from_string_literal((StringView::from_string_literal("Not y
     _jakt_value.release_value();
 }));
 }
-else if (__jakt_enum_value == TRY(ByteString::from_utf8("Dictionary"sv))) {
+else if (__jakt_enum_value == (ByteString::must_from_utf8("Dictionary"sv))) {
 return JaktInternal::ExplicitValue(({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<interpreter::StatementResult,ErrorOr<interpreter::StatementResult>>{
 auto __jakt_enum_value = (prelude_function);
-if (__jakt_enum_value == TRY(ByteString::from_utf8("Dictionary"sv))) {
+if (__jakt_enum_value == (ByteString::must_from_utf8("Dictionary"sv))) {
 return JaktInternal::ExplicitValue(({ Optional<interpreter::StatementResult> __jakt_var_233; {
 if (((((type_bindings).size())) != (static_cast<size_t>(2ULL)))){
-TRY((((*this).error(TRY(ByteString::from_utf8("Dictionary constructor expects two generic argumenst"sv)),call_span))));
+TRY((((*this).error((ByteString::must_from_utf8("Dictionary constructor expects two generic argumenst"sv)),call_span))));
 return Error::__jakt_from_string_literal((StringView::from_string_literal("Invalid type"sv)));
 }
-ids::StructId const dictionary_struct_id = TRY((((((*this).program))->find_struct_in_prelude(TRY(ByteString::from_utf8("Dictionary"sv))))));
+ids::StructId const dictionary_struct_id = TRY((((((*this).program))->find_struct_in_prelude((ByteString::must_from_utf8("Dictionary"sv))))));
 ids::TypeId const type_id = TRY((((*this).find_or_add_type_id(TRY((types::Type::GenericInstance(parser::CheckedQualifiers(false),dictionary_struct_id,(TRY((DynamicArray<ids::TypeId>::create_with({(((type_bindings).get(((TRY((((type_bindings).keys()))))[static_cast<i64>(0LL)]))).value()), (((type_bindings).get(((TRY((((type_bindings).keys()))))[static_cast<i64>(1LL)]))).value())})))))))))));
 __jakt_var_233 = interpreter::StatementResult::JustValue(types::Value(TRY((types::ValueImpl::JaktDictionary((TRY((DynamicArray<types::Value>::create_with({})))),(TRY((DynamicArray<types::Value>::create_with({})))),type_id))),call_span)); goto __jakt_label_219;
 
 }
 __jakt_label_219:; __jakt_var_233.release_value(); }));
 }
-else if (__jakt_enum_value == TRY(ByteString::from_utf8("get"sv))) {
+else if (__jakt_enum_value == (ByteString::must_from_utf8("get"sv))) {
 return JaktInternal::ExplicitValue(({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<interpreter::StatementResult, ErrorOr<interpreter::StatementResult>>{
 auto&& __jakt_match_variant = *(((this_argument.value())).impl);
@@ -5941,7 +5941,7 @@ __jakt_label_220:; __jakt_var_234.release_value(); }));
 };/*case end*/
 default: {
 {
-utility::panic(TRY(ByteString::from_utf8("Invalid use of Dictionary::get()"sv)));
+utility::panic((ByteString::must_from_utf8("Invalid use of Dictionary::get()"sv)));
 }
 };/*case end*/
 }/*switch end*/
@@ -5952,7 +5952,7 @@ utility::panic(TRY(ByteString::from_utf8("Invalid use of Dictionary::get()"sv)))
     _jakt_value.release_value();
 }));
 }
-else if (__jakt_enum_value == TRY(ByteString::from_utf8("set"sv))) {
+else if (__jakt_enum_value == (ByteString::must_from_utf8("set"sv))) {
 return JaktInternal::ExplicitValue(({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<interpreter::StatementResult, ErrorOr<interpreter::StatementResult>>{
 auto&& __jakt_match_variant = *(((this_argument.value())).impl);
@@ -5997,7 +5997,7 @@ __jakt_label_221:; __jakt_var_235.release_value(); }));
 };/*case end*/
 default: {
 {
-utility::panic(TRY(ByteString::from_utf8("Invalid use of Dictionary::set()"sv)));
+utility::panic((ByteString::must_from_utf8("Invalid use of Dictionary::set()"sv)));
 }
 };/*case end*/
 }/*switch end*/
@@ -6008,7 +6008,7 @@ utility::panic(TRY(ByteString::from_utf8("Invalid use of Dictionary::set()"sv)))
     _jakt_value.release_value();
 }));
 }
-else if (__jakt_enum_value == TRY(ByteString::from_utf8("is_empty"sv))) {
+else if (__jakt_enum_value == (ByteString::must_from_utf8("is_empty"sv))) {
 return JaktInternal::ExplicitValue(({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<interpreter::StatementResult, ErrorOr<interpreter::StatementResult>>{
 auto&& __jakt_match_variant = *(((this_argument.value())).impl);
@@ -6020,7 +6020,7 @@ return JaktInternal::ExplicitValue(interpreter::StatementResult::JustValue(types
 };/*case end*/
 default: {
 {
-utility::panic(TRY(ByteString::from_utf8("Invalid use of Dictionary::is_empty()"sv)));
+utility::panic((ByteString::must_from_utf8("Invalid use of Dictionary::is_empty()"sv)));
 }
 };/*case end*/
 }/*switch end*/
@@ -6031,7 +6031,7 @@ utility::panic(TRY(ByteString::from_utf8("Invalid use of Dictionary::is_empty()"
     _jakt_value.release_value();
 }));
 }
-else if (__jakt_enum_value == TRY(ByteString::from_utf8("contains"sv))) {
+else if (__jakt_enum_value == (ByteString::must_from_utf8("contains"sv))) {
 return JaktInternal::ExplicitValue(({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<interpreter::StatementResult, ErrorOr<interpreter::StatementResult>>{
 auto&& __jakt_match_variant = *(((this_argument.value())).impl);
@@ -6065,7 +6065,7 @@ __jakt_label_222:; __jakt_var_236.release_value(); }));
 };/*case end*/
 default: {
 {
-utility::panic(TRY(ByteString::from_utf8("Invalid use of Dictionary::contains()"sv)));
+utility::panic((ByteString::must_from_utf8("Invalid use of Dictionary::contains()"sv)));
 }
 };/*case end*/
 }/*switch end*/
@@ -6076,7 +6076,7 @@ utility::panic(TRY(ByteString::from_utf8("Invalid use of Dictionary::contains()"
     _jakt_value.release_value();
 }));
 }
-else if (__jakt_enum_value == TRY(ByteString::from_utf8("remove"sv))) {
+else if (__jakt_enum_value == (ByteString::must_from_utf8("remove"sv))) {
 return JaktInternal::ExplicitValue(({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<interpreter::StatementResult, ErrorOr<interpreter::StatementResult>>{
 auto&& __jakt_match_variant = *(((this_argument.value())).impl);
@@ -6154,7 +6154,7 @@ __jakt_label_223:; __jakt_var_237.release_value(); }));
 };/*case end*/
 default: {
 {
-utility::panic(TRY(ByteString::from_utf8("Invalid use of Dictionary::remove()"sv)));
+utility::panic((ByteString::must_from_utf8("Invalid use of Dictionary::remove()"sv)));
 }
 };/*case end*/
 }/*switch end*/
@@ -6165,7 +6165,7 @@ utility::panic(TRY(ByteString::from_utf8("Invalid use of Dictionary::remove()"sv
     _jakt_value.release_value();
 }));
 }
-else if (__jakt_enum_value == TRY(ByteString::from_utf8("ensure_capacity"sv))) {
+else if (__jakt_enum_value == (ByteString::must_from_utf8("ensure_capacity"sv))) {
 return JaktInternal::ExplicitValue(({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<interpreter::StatementResult, ErrorOr<interpreter::StatementResult>>{
 auto&& __jakt_match_variant = *(((this_argument.value())).impl);
@@ -6191,7 +6191,7 @@ __jakt_label_224:; __jakt_var_238.release_value(); }));
 };/*case end*/
 default: {
 {
-TRY((((*this).error(TRY(ByteString::from_utf8("Dictionary::ensure_capacity must be called with a usize"sv)),((((arguments)[static_cast<i64>(0LL)])).span)))));
+TRY((((*this).error((ByteString::must_from_utf8("Dictionary::ensure_capacity must be called with a usize"sv)),((((arguments)[static_cast<i64>(0LL)])).span)))));
 return Error::__jakt_from_string_literal((StringView::from_string_literal("Invalid type"sv)));
 }
 };/*case end*/
@@ -6205,7 +6205,7 @@ return Error::__jakt_from_string_literal((StringView::from_string_literal("Inval
 };/*case end*/
 default: {
 {
-utility::panic(TRY(ByteString::from_utf8("Invalid use of Dictionary::ensure_capacity()"sv)));
+utility::panic((ByteString::must_from_utf8("Invalid use of Dictionary::ensure_capacity()"sv)));
 }
 };/*case end*/
 }/*switch end*/
@@ -6216,7 +6216,7 @@ utility::panic(TRY(ByteString::from_utf8("Invalid use of Dictionary::ensure_capa
     _jakt_value.release_value();
 }));
 }
-else if (__jakt_enum_value == TRY(ByteString::from_utf8("capacity"sv))) {
+else if (__jakt_enum_value == (ByteString::must_from_utf8("capacity"sv))) {
 return JaktInternal::ExplicitValue(({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<interpreter::StatementResult, ErrorOr<interpreter::StatementResult>>{
 auto&& __jakt_match_variant = *(((this_argument.value())).impl);
@@ -6227,7 +6227,7 @@ return JaktInternal::ExplicitValue(interpreter::StatementResult::JustValue(types
 };/*case end*/
 default: {
 {
-utility::panic(TRY(ByteString::from_utf8("Invalid use of Dictionary::capacity()"sv)));
+utility::panic((ByteString::must_from_utf8("Invalid use of Dictionary::capacity()"sv)));
 }
 };/*case end*/
 }/*switch end*/
@@ -6238,7 +6238,7 @@ utility::panic(TRY(ByteString::from_utf8("Invalid use of Dictionary::capacity()"
     _jakt_value.release_value();
 }));
 }
-else if (__jakt_enum_value == TRY(ByteString::from_utf8("clear"sv))) {
+else if (__jakt_enum_value == (ByteString::must_from_utf8("clear"sv))) {
 return JaktInternal::ExplicitValue(({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<interpreter::StatementResult, ErrorOr<interpreter::StatementResult>>{
 auto&& __jakt_match_variant = *(((this_argument.value())).impl);
@@ -6258,7 +6258,7 @@ __jakt_label_225:; __jakt_var_239.release_value(); }));
 };/*case end*/
 default: {
 {
-utility::panic(TRY(ByteString::from_utf8("Invalid use of Dictionary::clear()"sv)));
+utility::panic((ByteString::must_from_utf8("Invalid use of Dictionary::clear()"sv)));
 }
 };/*case end*/
 }/*switch end*/
@@ -6269,7 +6269,7 @@ utility::panic(TRY(ByteString::from_utf8("Invalid use of Dictionary::clear()"sv)
     _jakt_value.release_value();
 }));
 }
-else if (__jakt_enum_value == TRY(ByteString::from_utf8("size"sv))) {
+else if (__jakt_enum_value == (ByteString::must_from_utf8("size"sv))) {
 return JaktInternal::ExplicitValue(({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<interpreter::StatementResult, ErrorOr<interpreter::StatementResult>>{
 auto&& __jakt_match_variant = *(((this_argument.value())).impl);
@@ -6280,7 +6280,7 @@ return JaktInternal::ExplicitValue(interpreter::StatementResult::JustValue(types
 };/*case end*/
 default: {
 {
-utility::panic(TRY(ByteString::from_utf8("Invalid use of Dictionary::size()"sv)));
+utility::panic((ByteString::must_from_utf8("Invalid use of Dictionary::size()"sv)));
 }
 };/*case end*/
 }/*switch end*/
@@ -6291,7 +6291,7 @@ utility::panic(TRY(ByteString::from_utf8("Invalid use of Dictionary::size()"sv))
     _jakt_value.release_value();
 }));
 }
-else if (__jakt_enum_value == TRY(ByteString::from_utf8("keys"sv))) {
+else if (__jakt_enum_value == (ByteString::must_from_utf8("keys"sv))) {
 return JaktInternal::ExplicitValue(({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<interpreter::StatementResult, ErrorOr<interpreter::StatementResult>>{
 auto&& __jakt_match_variant = *(((this_argument.value())).impl);
@@ -6310,7 +6310,7 @@ return JaktInternal::ExplicitValue(args);
 };/*case end*/
 default: {
 {
-utility::panic(TRY(ByteString::from_utf8("expected generic instance"sv)));
+utility::panic((ByteString::must_from_utf8("expected generic instance"sv)));
 }
 };/*case end*/
 }/*switch end*/
@@ -6325,7 +6325,7 @@ __jakt_var_240 = ({
 auto __jakt_enum_value = (((((generics).size())) == (static_cast<size_t>(2ULL))));
 if (__jakt_enum_value == true) {
 return JaktInternal::ExplicitValue(({ Optional<interpreter::StatementResult> __jakt_var_241; {
-ids::StructId const array_struct_id = TRY((((((*this).program))->find_struct_in_prelude(TRY(ByteString::from_utf8("Array"sv))))));
+ids::StructId const array_struct_id = TRY((((((*this).program))->find_struct_in_prelude((ByteString::must_from_utf8("Array"sv))))));
 ids::TypeId const type_id = TRY((((*this).find_or_add_type_id(TRY((types::Type::GenericInstance(parser::CheckedQualifiers(false),array_struct_id,(TRY((DynamicArray<ids::TypeId>::create_with({((generics)[static_cast<i64>(0LL)])})))))))))));
 __jakt_var_241 = interpreter::StatementResult::JustValue(types::Value(TRY((types::ValueImpl::JaktArray(keys,type_id))),call_span)); goto __jakt_label_227;
 
@@ -6334,7 +6334,7 @@ __jakt_label_227:; __jakt_var_241.release_value(); }));
 }
 else {
 {
-utility::panic(TRY(ByteString::from_utf8("dictionary should have 2 generic args. one for keys, one for values"sv)));
+utility::panic((ByteString::must_from_utf8("dictionary should have 2 generic args. one for keys, one for values"sv)));
 }
 }
 }());
@@ -6348,7 +6348,7 @@ __jakt_label_226:; __jakt_var_240.release_value(); }));
 };/*case end*/
 default: {
 {
-utility::panic(TRY(ByteString::from_utf8("Invalid use of Dictionary::keys()"sv)));
+utility::panic((ByteString::must_from_utf8("Invalid use of Dictionary::keys()"sv)));
 }
 };/*case end*/
 }/*switch end*/
@@ -6359,14 +6359,14 @@ utility::panic(TRY(ByteString::from_utf8("Invalid use of Dictionary::keys()"sv))
     _jakt_value.release_value();
 }));
 }
-else if (__jakt_enum_value == TRY(ByteString::from_utf8("iterator"sv))) {
+else if (__jakt_enum_value == (ByteString::must_from_utf8("iterator"sv))) {
 return JaktInternal::ExplicitValue(({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<interpreter::StatementResult, ErrorOr<interpreter::StatementResult>>{
 auto&& __jakt_match_variant = *(((this_argument.value())).impl);
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 21 /* JaktDictionary */: {
 return JaktInternal::ExplicitValue(({ Optional<interpreter::StatementResult> __jakt_var_242; {
-ids::StructId const struct_id = TRY((((((*this).program))->find_struct_in_prelude(TRY(ByteString::from_utf8("DictionaryIterator"sv))))));
+ids::StructId const struct_id = TRY((((((*this).program))->find_struct_in_prelude((ByteString::must_from_utf8("DictionaryIterator"sv))))));
 __jakt_var_242 = interpreter::StatementResult::JustValue(types::Value(TRY((types::ValueImpl::Struct((TRY((DynamicArray<types::Value>::create_with({(this_argument.value()), types::Value(TRY((types::ValueImpl::USize(static_cast<size_t>(0ULL)))),call_span)})))),struct_id,JaktInternal::OptionalNone()))),call_span)); goto __jakt_label_228;
 
 }
@@ -6374,7 +6374,7 @@ __jakt_label_228:; __jakt_var_242.release_value(); }));
 };/*case end*/
 default: {
 {
-utility::panic(TRY(ByteString::from_utf8("Invalid use of Dictionary::iterator()"sv)));
+utility::panic((ByteString::must_from_utf8("Invalid use of Dictionary::iterator()"sv)));
 }
 };/*case end*/
 }/*switch end*/
@@ -6397,18 +6397,18 @@ return Error::__jakt_from_string_literal((StringView::from_string_literal("Not y
     _jakt_value.release_value();
 }));
 }
-else if (__jakt_enum_value == TRY(ByteString::from_utf8("Array"sv))) {
+else if (__jakt_enum_value == (ByteString::must_from_utf8("Array"sv))) {
 return JaktInternal::ExplicitValue(({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<interpreter::StatementResult,ErrorOr<interpreter::StatementResult>>{
 auto __jakt_enum_value = (prelude_function);
-if (__jakt_enum_value == TRY(ByteString::from_utf8("iterator"sv))) {
+if (__jakt_enum_value == (ByteString::must_from_utf8("iterator"sv))) {
 return JaktInternal::ExplicitValue(({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<interpreter::StatementResult, ErrorOr<interpreter::StatementResult>>{
 auto&& __jakt_match_variant = *(((this_argument.value())).impl);
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 20 /* JaktArray */: {
 return JaktInternal::ExplicitValue(({ Optional<interpreter::StatementResult> __jakt_var_243; {
-ids::StructId const struct_id = TRY((((((*this).program))->find_struct_in_prelude(TRY(ByteString::from_utf8("ArrayIterator"sv))))));
+ids::StructId const struct_id = TRY((((((*this).program))->find_struct_in_prelude((ByteString::must_from_utf8("ArrayIterator"sv))))));
 __jakt_var_243 = interpreter::StatementResult::JustValue(types::Value(TRY((types::ValueImpl::Struct((TRY((DynamicArray<types::Value>::create_with({(this_argument.value()), types::Value(TRY((types::ValueImpl::USize(static_cast<size_t>(0ULL)))),call_span)})))),struct_id,JaktInternal::OptionalNone()))),call_span)); goto __jakt_label_229;
 
 }
@@ -6416,7 +6416,7 @@ __jakt_label_229:; __jakt_var_243.release_value(); }));
 };/*case end*/
 default: {
 {
-utility::panic(TRY(ByteString::from_utf8("Invalid use of Array::iterator()"sv)));
+utility::panic((ByteString::must_from_utf8("Invalid use of Array::iterator()"sv)));
 }
 };/*case end*/
 }/*switch end*/
@@ -6427,7 +6427,7 @@ utility::panic(TRY(ByteString::from_utf8("Invalid use of Array::iterator()"sv)))
     _jakt_value.release_value();
 }));
 }
-else if (__jakt_enum_value == TRY(ByteString::from_utf8("size"sv))) {
+else if (__jakt_enum_value == (ByteString::must_from_utf8("size"sv))) {
 return JaktInternal::ExplicitValue(({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<interpreter::StatementResult, ErrorOr<interpreter::StatementResult>>{
 auto&& __jakt_match_variant = *(((this_argument.value())).impl);
@@ -6442,7 +6442,7 @@ __jakt_label_230:; __jakt_var_244.release_value(); }));
 };/*case end*/
 default: {
 {
-utility::panic(TRY(ByteString::from_utf8("Invalid use of Array::size()"sv)));
+utility::panic((ByteString::must_from_utf8("Invalid use of Array::size()"sv)));
 }
 };/*case end*/
 }/*switch end*/
@@ -6453,7 +6453,7 @@ utility::panic(TRY(ByteString::from_utf8("Invalid use of Array::size()"sv)));
     _jakt_value.release_value();
 }));
 }
-else if (__jakt_enum_value == TRY(ByteString::from_utf8("push"sv))) {
+else if (__jakt_enum_value == (ByteString::must_from_utf8("push"sv))) {
 return JaktInternal::ExplicitValue(({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<interpreter::StatementResult, ErrorOr<interpreter::StatementResult>>{
 auto&& __jakt_match_variant = *(((this_argument.value())).impl);
@@ -6470,7 +6470,7 @@ __jakt_label_231:; __jakt_var_245.release_value(); }));
 };/*case end*/
 default: {
 {
-utility::panic(TRY(ByteString::from_utf8("Invalid use of Array::push()"sv)));
+utility::panic((ByteString::must_from_utf8("Invalid use of Array::push()"sv)));
 }
 };/*case end*/
 }/*switch end*/
@@ -6481,7 +6481,7 @@ utility::panic(TRY(ByteString::from_utf8("Invalid use of Array::push()"sv)));
     _jakt_value.release_value();
 }));
 }
-else if (__jakt_enum_value == TRY(ByteString::from_utf8("push_values"sv))) {
+else if (__jakt_enum_value == (ByteString::must_from_utf8("push_values"sv))) {
 return JaktInternal::ExplicitValue(({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<interpreter::StatementResult, ErrorOr<interpreter::StatementResult>>{
 auto&& __jakt_match_variant = *(((this_argument.value())).impl);
@@ -6516,7 +6516,7 @@ TRY((((mutable_values).push(value))));
 return JaktInternal::ExplicitValue<void>();
 };/*case end*/
 default: {
-return (TRY((((*this).error(TRY(ByteString::from_utf8("Only argument to push_values needs to be another Array"sv)),call_span))))), JaktInternal::ExplicitValue<void>();
+return (TRY((((*this).error((ByteString::must_from_utf8("Only argument to push_values needs to be another Array"sv)),call_span))))), JaktInternal::ExplicitValue<void>();
 };/*case end*/
 }/*switch end*/
 }()
@@ -6532,7 +6532,7 @@ __jakt_label_232:; __jakt_var_246.release_value(); }));
 };/*case end*/
 default: {
 {
-utility::panic(TRY(ByteString::from_utf8("Invalid use of Array::push_values()"sv)));
+utility::panic((ByteString::must_from_utf8("Invalid use of Array::push_values()"sv)));
 }
 };/*case end*/
 }/*switch end*/
@@ -6543,7 +6543,7 @@ utility::panic(TRY(ByteString::from_utf8("Invalid use of Array::push_values()"sv
     _jakt_value.release_value();
 }));
 }
-else if (__jakt_enum_value == TRY(ByteString::from_utf8("pop"sv))) {
+else if (__jakt_enum_value == (ByteString::must_from_utf8("pop"sv))) {
 return JaktInternal::ExplicitValue(({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<interpreter::StatementResult, ErrorOr<interpreter::StatementResult>>{
 auto&& __jakt_match_variant = *(((this_argument.value())).impl);
@@ -6574,7 +6574,7 @@ __jakt_label_233:; __jakt_var_247.release_value(); }));
 };/*case end*/
 default: {
 {
-utility::panic(TRY(ByteString::from_utf8("Invalid use of Array::push()"sv)));
+utility::panic((ByteString::must_from_utf8("Invalid use of Array::push()"sv)));
 }
 };/*case end*/
 }/*switch end*/
@@ -6585,7 +6585,7 @@ utility::panic(TRY(ByteString::from_utf8("Invalid use of Array::push()"sv)));
     _jakt_value.release_value();
 }));
 }
-else if (__jakt_enum_value == TRY(ByteString::from_utf8("first"sv))) {
+else if (__jakt_enum_value == (ByteString::must_from_utf8("first"sv))) {
 return JaktInternal::ExplicitValue(({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<interpreter::StatementResult, ErrorOr<interpreter::StatementResult>>{
 auto&& __jakt_match_variant = *(((this_argument.value())).impl);
@@ -6616,7 +6616,7 @@ __jakt_label_234:; __jakt_var_248.release_value(); }));
 };/*case end*/
 default: {
 {
-utility::panic(TRY(ByteString::from_utf8("Invalid use of Array::push()"sv)));
+utility::panic((ByteString::must_from_utf8("Invalid use of Array::push()"sv)));
 }
 };/*case end*/
 }/*switch end*/
@@ -6627,7 +6627,7 @@ utility::panic(TRY(ByteString::from_utf8("Invalid use of Array::push()"sv)));
     _jakt_value.release_value();
 }));
 }
-else if (__jakt_enum_value == TRY(ByteString::from_utf8("last"sv))) {
+else if (__jakt_enum_value == (ByteString::must_from_utf8("last"sv))) {
 return JaktInternal::ExplicitValue(({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<interpreter::StatementResult, ErrorOr<interpreter::StatementResult>>{
 auto&& __jakt_match_variant = *(((this_argument.value())).impl);
@@ -6658,7 +6658,7 @@ __jakt_label_235:; __jakt_var_249.release_value(); }));
 };/*case end*/
 default: {
 {
-utility::panic(TRY(ByteString::from_utf8("Invalid use of Array::push()"sv)));
+utility::panic((ByteString::must_from_utf8("Invalid use of Array::push()"sv)));
 }
 };/*case end*/
 }/*switch end*/
@@ -6669,7 +6669,7 @@ utility::panic(TRY(ByteString::from_utf8("Invalid use of Array::push()"sv)));
     _jakt_value.release_value();
 }));
 }
-else if (__jakt_enum_value == TRY(ByteString::from_utf8("contains"sv))) {
+else if (__jakt_enum_value == (ByteString::must_from_utf8("contains"sv))) {
 return JaktInternal::ExplicitValue(({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<interpreter::StatementResult, ErrorOr<interpreter::StatementResult>>{
 auto&& __jakt_match_variant = *(((this_argument.value())).impl);
@@ -6703,7 +6703,7 @@ __jakt_label_236:; __jakt_var_250.release_value(); }));
 };/*case end*/
 default: {
 {
-utility::panic(TRY(ByteString::from_utf8("Invalid use of Array::contains()"sv)));
+utility::panic((ByteString::must_from_utf8("Invalid use of Array::contains()"sv)));
 }
 };/*case end*/
 }/*switch end*/
@@ -6714,7 +6714,7 @@ utility::panic(TRY(ByteString::from_utf8("Invalid use of Array::contains()"sv)))
     _jakt_value.release_value();
 }));
 }
-else if (__jakt_enum_value == TRY(ByteString::from_utf8("is_empty"sv))) {
+else if (__jakt_enum_value == (ByteString::must_from_utf8("is_empty"sv))) {
 return JaktInternal::ExplicitValue(({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<interpreter::StatementResult, ErrorOr<interpreter::StatementResult>>{
 auto&& __jakt_match_variant = *(((this_argument.value())).impl);
@@ -6725,7 +6725,7 @@ return JaktInternal::ExplicitValue(interpreter::StatementResult::JustValue(types
 };/*case end*/
 default: {
 {
-utility::panic(TRY(ByteString::from_utf8("Invalid use of Array::is_empty()"sv)));
+utility::panic((ByteString::must_from_utf8("Invalid use of Array::is_empty()"sv)));
 }
 };/*case end*/
 }/*switch end*/
@@ -6736,7 +6736,7 @@ utility::panic(TRY(ByteString::from_utf8("Invalid use of Array::is_empty()"sv)))
     _jakt_value.release_value();
 }));
 }
-else if (__jakt_enum_value == TRY(ByteString::from_utf8("capacity"sv))) {
+else if (__jakt_enum_value == (ByteString::must_from_utf8("capacity"sv))) {
 return JaktInternal::ExplicitValue(({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<interpreter::StatementResult, ErrorOr<interpreter::StatementResult>>{
 auto&& __jakt_match_variant = *(((this_argument.value())).impl);
@@ -6751,7 +6751,7 @@ __jakt_label_237:; __jakt_var_251.release_value(); }));
 };/*case end*/
 default: {
 {
-utility::panic(TRY(ByteString::from_utf8("Invalid use of Array::capacity()"sv)));
+utility::panic((ByteString::must_from_utf8("Invalid use of Array::capacity()"sv)));
 }
 };/*case end*/
 }/*switch end*/
@@ -6762,7 +6762,7 @@ utility::panic(TRY(ByteString::from_utf8("Invalid use of Array::capacity()"sv)))
     _jakt_value.release_value();
 }));
 }
-else if (__jakt_enum_value == TRY(ByteString::from_utf8("ensure_capacity"sv))) {
+else if (__jakt_enum_value == (ByteString::must_from_utf8("ensure_capacity"sv))) {
 return JaktInternal::ExplicitValue(({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<interpreter::StatementResult, ErrorOr<interpreter::StatementResult>>{
 auto&& __jakt_match_variant = *(((this_argument.value())).impl);
@@ -6785,7 +6785,7 @@ __jakt_label_238:; __jakt_var_252.release_value(); }));
 };/*case end*/
 default: {
 {
-TRY((((*this).error(TRY(ByteString::from_utf8("Array::ensure_capacity must be called with a usize"sv)),((((arguments)[static_cast<i64>(0LL)])).span)))));
+TRY((((*this).error((ByteString::must_from_utf8("Array::ensure_capacity must be called with a usize"sv)),((((arguments)[static_cast<i64>(0LL)])).span)))));
 return Error::__jakt_from_string_literal((StringView::from_string_literal("Invalid type"sv)));
 }
 };/*case end*/
@@ -6799,7 +6799,7 @@ return Error::__jakt_from_string_literal((StringView::from_string_literal("Inval
 };/*case end*/
 default: {
 {
-utility::panic(TRY(ByteString::from_utf8("Invalid use of Array::ensure_capacity()"sv)));
+utility::panic((ByteString::must_from_utf8("Invalid use of Array::ensure_capacity()"sv)));
 }
 };/*case end*/
 }/*switch end*/
@@ -6810,7 +6810,7 @@ utility::panic(TRY(ByteString::from_utf8("Invalid use of Array::ensure_capacity(
     _jakt_value.release_value();
 }));
 }
-else if (__jakt_enum_value == TRY(ByteString::from_utf8("add_capacity"sv))) {
+else if (__jakt_enum_value == (ByteString::must_from_utf8("add_capacity"sv))) {
 return JaktInternal::ExplicitValue(({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<interpreter::StatementResult, ErrorOr<interpreter::StatementResult>>{
 auto&& __jakt_match_variant = *(((this_argument.value())).impl);
@@ -6833,7 +6833,7 @@ __jakt_label_239:; __jakt_var_253.release_value(); }));
 };/*case end*/
 default: {
 {
-TRY((((*this).error(TRY(ByteString::from_utf8("Array::add_capacity must be called with a usize"sv)),((((arguments)[static_cast<i64>(0LL)])).span)))));
+TRY((((*this).error((ByteString::must_from_utf8("Array::add_capacity must be called with a usize"sv)),((((arguments)[static_cast<i64>(0LL)])).span)))));
 return Error::__jakt_from_string_literal((StringView::from_string_literal("Invalid type"sv)));
 }
 };/*case end*/
@@ -6847,7 +6847,7 @@ return Error::__jakt_from_string_literal((StringView::from_string_literal("Inval
 };/*case end*/
 default: {
 {
-utility::panic(TRY(ByteString::from_utf8("Invalid use of Array::add_capacity()"sv)));
+utility::panic((ByteString::must_from_utf8("Invalid use of Array::add_capacity()"sv)));
 }
 };/*case end*/
 }/*switch end*/
@@ -6858,7 +6858,7 @@ utility::panic(TRY(ByteString::from_utf8("Invalid use of Array::add_capacity()"s
     _jakt_value.release_value();
 }));
 }
-else if (__jakt_enum_value == TRY(ByteString::from_utf8("shrink"sv))) {
+else if (__jakt_enum_value == (ByteString::must_from_utf8("shrink"sv))) {
 return JaktInternal::ExplicitValue(({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<interpreter::StatementResult, ErrorOr<interpreter::StatementResult>>{
 auto&& __jakt_match_variant = *(((this_argument.value())).impl);
@@ -6881,7 +6881,7 @@ __jakt_label_240:; __jakt_var_254.release_value(); }));
 };/*case end*/
 default: {
 {
-TRY((((*this).error(TRY(ByteString::from_utf8("Array::shrink must be called with a usize"sv)),((((arguments)[static_cast<i64>(0LL)])).span)))));
+TRY((((*this).error((ByteString::must_from_utf8("Array::shrink must be called with a usize"sv)),((((arguments)[static_cast<i64>(0LL)])).span)))));
 return Error::__jakt_from_string_literal((StringView::from_string_literal("Invalid type"sv)));
 }
 };/*case end*/
@@ -6895,7 +6895,7 @@ return Error::__jakt_from_string_literal((StringView::from_string_literal("Inval
 };/*case end*/
 default: {
 {
-utility::panic(TRY(ByteString::from_utf8("Invalid use of Array::shrink()"sv)));
+utility::panic((ByteString::must_from_utf8("Invalid use of Array::shrink()"sv)));
 }
 };/*case end*/
 }/*switch end*/
@@ -6918,11 +6918,11 @@ return Error::__jakt_from_string_literal((StringView::from_string_literal("Not y
     _jakt_value.release_value();
 }));
 }
-else if (__jakt_enum_value == TRY(ByteString::from_utf8("ArrayIterator"sv))) {
+else if (__jakt_enum_value == (ByteString::must_from_utf8("ArrayIterator"sv))) {
 return JaktInternal::ExplicitValue(({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<interpreter::StatementResult,ErrorOr<interpreter::StatementResult>>{
 auto __jakt_enum_value = (prelude_function);
-if (__jakt_enum_value == TRY(ByteString::from_utf8("next"sv))) {
+if (__jakt_enum_value == (ByteString::must_from_utf8("next"sv))) {
 return JaktInternal::ExplicitValue(({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<interpreter::StatementResult, ErrorOr<interpreter::StatementResult>>{
 auto&& __jakt_match_variant = *(((this_argument.value())).impl);
@@ -6940,7 +6940,7 @@ return JaktInternal::ExplicitValue(value);
 };/*case end*/
 default: {
 {
-utility::panic(TRY(ByteString::from_utf8("Invalid ArrayIterator index configuration"sv)));
+utility::panic((ByteString::must_from_utf8("Invalid ArrayIterator index configuration"sv)));
 }
 };/*case end*/
 }/*switch end*/
@@ -6989,7 +6989,7 @@ return JaktInternal::ExplicitValue(types::Value(TRY((types::ValueImpl::OptionalN
 };/*case end*/
 default: {
 {
-utility::panic(TRY(ByteString::from_utf8("Invalid ArrayIterator configuration"sv)));
+utility::panic((ByteString::must_from_utf8("Invalid ArrayIterator configuration"sv)));
 }
 };/*case end*/
 }/*switch end*/
@@ -7005,7 +7005,7 @@ __jakt_label_241:; __jakt_var_255.release_value(); }));
 };/*case end*/
 default: {
 {
-utility::panic(TRY(ByteString::from_utf8("Invalid ArrayIterator configuration"sv)));
+utility::panic((ByteString::must_from_utf8("Invalid ArrayIterator configuration"sv)));
 }
 };/*case end*/
 }/*switch end*/
@@ -7028,11 +7028,11 @@ return Error::__jakt_from_string_literal((StringView::from_string_literal("Not y
     _jakt_value.release_value();
 }));
 }
-else if (__jakt_enum_value == TRY(ByteString::from_utf8("Range"sv))) {
+else if (__jakt_enum_value == (ByteString::must_from_utf8("Range"sv))) {
 return JaktInternal::ExplicitValue(({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<interpreter::StatementResult,ErrorOr<interpreter::StatementResult>>{
 auto __jakt_enum_value = (prelude_function);
-if (__jakt_enum_value == TRY(ByteString::from_utf8("next"sv))) {
+if (__jakt_enum_value == (ByteString::must_from_utf8("next"sv))) {
 return JaktInternal::ExplicitValue(({ Optional<interpreter::StatementResult> __jakt_var_257; {
 JaktInternal::DynamicArray<types::Value> fields = ({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<JaktInternal::DynamicArray<types::Value>, ErrorOr<interpreter::StatementResult>>{
@@ -7044,7 +7044,7 @@ return JaktInternal::ExplicitValue(fields);
 };/*case end*/
 default: {
 {
-utility::panic(TRY(ByteString::from_utf8("Invalid use of Range::next()"sv)));
+utility::panic((ByteString::must_from_utf8("Invalid use of Range::next()"sv)));
 }
 };/*case end*/
 }/*switch end*/
@@ -7096,7 +7096,7 @@ return JaktInternal::ExplicitValue((infallible_integer_cast<u64>((x))));
 };/*case end*/
 default: {
 {
-utility::panic(TRY(ByteString::from_utf8("Invalid type for comptime range"sv)));
+utility::panic((ByteString::must_from_utf8("Invalid type for comptime range"sv)));
 }
 };/*case end*/
 }/*switch end*/
@@ -7148,7 +7148,7 @@ return JaktInternal::ExplicitValue((infallible_integer_cast<u64>((x))));
 };/*case end*/
 default: {
 {
-utility::panic(TRY(ByteString::from_utf8("Invalid type for comptime range"sv)));
+utility::panic((ByteString::must_from_utf8("Invalid type for comptime range"sv)));
 }
 };/*case end*/
 }/*switch end*/
@@ -7183,7 +7183,7 @@ __jakt_var_257 = interpreter::StatementResult::JustValue(types::Value(TRY((types
 }
 __jakt_label_243:; __jakt_var_257.release_value(); }));
 }
-else if (__jakt_enum_value == TRY(ByteString::from_utf8("inclusive"sv))) {
+else if (__jakt_enum_value == (ByteString::must_from_utf8("inclusive"sv))) {
 return JaktInternal::ExplicitValue(({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<interpreter::StatementResult, ErrorOr<interpreter::StatementResult>>{
 auto&& __jakt_match_variant = *(((this_argument.value())).impl);
@@ -7236,7 +7236,7 @@ return JaktInternal::ExplicitValue((infallible_integer_cast<u64>((x))));
 };/*case end*/
 default: {
 {
-utility::panic(TRY(ByteString::from_utf8("Invalid type for comptime range"sv)));
+utility::panic((ByteString::must_from_utf8("Invalid type for comptime range"sv)));
 }
 };/*case end*/
 }/*switch end*/
@@ -7254,7 +7254,7 @@ __jakt_label_244:; __jakt_var_258.release_value(); }));
 };/*case end*/
 default: {
 {
-utility::panic(TRY(ByteString::from_utf8("Invalid use of Range::inclusive()"sv)));
+utility::panic((ByteString::must_from_utf8("Invalid use of Range::inclusive()"sv)));
 }
 };/*case end*/
 }/*switch end*/
@@ -7265,7 +7265,7 @@ utility::panic(TRY(ByteString::from_utf8("Invalid use of Range::inclusive()"sv))
     _jakt_value.release_value();
 }));
 }
-else if (__jakt_enum_value == TRY(ByteString::from_utf8("exclusive"sv))) {
+else if (__jakt_enum_value == (ByteString::must_from_utf8("exclusive"sv))) {
 return JaktInternal::ExplicitValue(({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<interpreter::StatementResult, ErrorOr<interpreter::StatementResult>>{
 auto&& __jakt_match_variant = *(((this_argument.value())).impl);
@@ -7275,7 +7275,7 @@ return JaktInternal::ExplicitValue(interpreter::StatementResult::JustValue((this
 };/*case end*/
 default: {
 {
-utility::panic(TRY(ByteString::from_utf8("Invalid use of Range::exclusive()"sv)));
+utility::panic((ByteString::must_from_utf8("Invalid use of Range::exclusive()"sv)));
 }
 };/*case end*/
 }/*switch end*/
@@ -7298,11 +7298,11 @@ return Error::__jakt_from_string_literal((StringView::from_string_literal("Not y
     _jakt_value.release_value();
 }));
 }
-else if (__jakt_enum_value == TRY(ByteString::from_utf8("String"sv))) {
+else if (__jakt_enum_value == (ByteString::must_from_utf8("String"sv))) {
 return JaktInternal::ExplicitValue(({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<interpreter::StatementResult,ErrorOr<interpreter::StatementResult>>{
 auto __jakt_enum_value = (prelude_function);
-if (__jakt_enum_value == TRY(ByteString::from_utf8("is_empty"sv))) {
+if (__jakt_enum_value == (ByteString::must_from_utf8("is_empty"sv))) {
 return JaktInternal::ExplicitValue(({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<interpreter::StatementResult, ErrorOr<interpreter::StatementResult>>{
 auto&& __jakt_match_variant = *(((this_argument.value())).impl);
@@ -7313,7 +7313,7 @@ return JaktInternal::ExplicitValue(interpreter::StatementResult::JustValue(types
 };/*case end*/
 default: {
 {
-utility::panic(TRY(ByteString::from_utf8("Invalid String"sv)));
+utility::panic((ByteString::must_from_utf8("Invalid String"sv)));
 }
 };/*case end*/
 }/*switch end*/
@@ -7324,7 +7324,7 @@ utility::panic(TRY(ByteString::from_utf8("Invalid String"sv)));
     _jakt_value.release_value();
 }));
 }
-else if (__jakt_enum_value == TRY(ByteString::from_utf8("length"sv))) {
+else if (__jakt_enum_value == (ByteString::must_from_utf8("length"sv))) {
 return JaktInternal::ExplicitValue(({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<interpreter::StatementResult, ErrorOr<interpreter::StatementResult>>{
 auto&& __jakt_match_variant = *(((this_argument.value())).impl);
@@ -7335,7 +7335,7 @@ return JaktInternal::ExplicitValue(interpreter::StatementResult::JustValue(types
 };/*case end*/
 default: {
 {
-utility::panic(TRY(ByteString::from_utf8("Invalid String"sv)));
+utility::panic((ByteString::must_from_utf8("Invalid String"sv)));
 }
 };/*case end*/
 }/*switch end*/
@@ -7346,7 +7346,7 @@ utility::panic(TRY(ByteString::from_utf8("Invalid String"sv)));
     _jakt_value.release_value();
 }));
 }
-else if (__jakt_enum_value == TRY(ByteString::from_utf8("hash"sv))) {
+else if (__jakt_enum_value == (ByteString::must_from_utf8("hash"sv))) {
 return JaktInternal::ExplicitValue(({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<interpreter::StatementResult, ErrorOr<interpreter::StatementResult>>{
 auto&& __jakt_match_variant = *(((this_argument.value())).impl);
@@ -7357,7 +7357,7 @@ return JaktInternal::ExplicitValue(interpreter::StatementResult::JustValue(types
 };/*case end*/
 default: {
 {
-utility::panic(TRY(ByteString::from_utf8("Invalid String"sv)));
+utility::panic((ByteString::must_from_utf8("Invalid String"sv)));
 }
 };/*case end*/
 }/*switch end*/
@@ -7368,7 +7368,7 @@ utility::panic(TRY(ByteString::from_utf8("Invalid String"sv)));
     _jakt_value.release_value();
 }));
 }
-else if (__jakt_enum_value == TRY(ByteString::from_utf8("substring"sv))) {
+else if (__jakt_enum_value == (ByteString::must_from_utf8("substring"sv))) {
 return JaktInternal::ExplicitValue(({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<interpreter::StatementResult, ErrorOr<interpreter::StatementResult>>{
 auto&& __jakt_match_variant = *(((this_argument.value())).impl);
@@ -7432,7 +7432,7 @@ __jakt_label_249:; __jakt_var_263.release_value(); }));
 };/*case end*/
 default: {
 {
-TRY((((*this).error(TRY(ByteString::from_utf8("String::substring must be called with unsigned arguments"sv)),((((arguments)[static_cast<i64>(1LL)])).span)))));
+TRY((((*this).error((ByteString::must_from_utf8("String::substring must be called with unsigned arguments"sv)),((((arguments)[static_cast<i64>(1LL)])).span)))));
 return Error::__jakt_from_string_literal((StringView::from_string_literal("Invalid type"sv)));
 }
 };/*case end*/
@@ -7497,7 +7497,7 @@ __jakt_label_254:; __jakt_var_268.release_value(); }));
 };/*case end*/
 default: {
 {
-TRY((((*this).error(TRY(ByteString::from_utf8("String::substring must be called with unsigned arguments"sv)),((((arguments)[static_cast<i64>(1LL)])).span)))));
+TRY((((*this).error((ByteString::must_from_utf8("String::substring must be called with unsigned arguments"sv)),((((arguments)[static_cast<i64>(1LL)])).span)))));
 return Error::__jakt_from_string_literal((StringView::from_string_literal("Invalid type"sv)));
 }
 };/*case end*/
@@ -7562,7 +7562,7 @@ __jakt_label_259:; __jakt_var_273.release_value(); }));
 };/*case end*/
 default: {
 {
-TRY((((*this).error(TRY(ByteString::from_utf8("String::substring must be called with unsigned arguments"sv)),((((arguments)[static_cast<i64>(1LL)])).span)))));
+TRY((((*this).error((ByteString::must_from_utf8("String::substring must be called with unsigned arguments"sv)),((((arguments)[static_cast<i64>(1LL)])).span)))));
 return Error::__jakt_from_string_literal((StringView::from_string_literal("Invalid type"sv)));
 }
 };/*case end*/
@@ -7627,7 +7627,7 @@ __jakt_label_264:; __jakt_var_278.release_value(); }));
 };/*case end*/
 default: {
 {
-TRY((((*this).error(TRY(ByteString::from_utf8("String::substring must be called with unsigned arguments"sv)),((((arguments)[static_cast<i64>(1LL)])).span)))));
+TRY((((*this).error((ByteString::must_from_utf8("String::substring must be called with unsigned arguments"sv)),((((arguments)[static_cast<i64>(1LL)])).span)))));
 return Error::__jakt_from_string_literal((StringView::from_string_literal("Invalid type"sv)));
 }
 };/*case end*/
@@ -7692,7 +7692,7 @@ __jakt_label_269:; __jakt_var_283.release_value(); }));
 };/*case end*/
 default: {
 {
-TRY((((*this).error(TRY(ByteString::from_utf8("String::substring must be called with unsigned arguments"sv)),((((arguments)[static_cast<i64>(1LL)])).span)))));
+TRY((((*this).error((ByteString::must_from_utf8("String::substring must be called with unsigned arguments"sv)),((((arguments)[static_cast<i64>(1LL)])).span)))));
 return Error::__jakt_from_string_literal((StringView::from_string_literal("Invalid type"sv)));
 }
 };/*case end*/
@@ -7706,7 +7706,7 @@ return Error::__jakt_from_string_literal((StringView::from_string_literal("Inval
 };/*case end*/
 default: {
 {
-TRY((((*this).error(TRY(ByteString::from_utf8("String::substring must be called with unsigned arguments"sv)),((((arguments)[static_cast<i64>(0LL)])).span)))));
+TRY((((*this).error((ByteString::must_from_utf8("String::substring must be called with unsigned arguments"sv)),((((arguments)[static_cast<i64>(0LL)])).span)))));
 return Error::__jakt_from_string_literal((StringView::from_string_literal("Invalid type"sv)));
 }
 };/*case end*/
@@ -7720,7 +7720,7 @@ return Error::__jakt_from_string_literal((StringView::from_string_literal("Inval
 };/*case end*/
 default: {
 {
-utility::panic(TRY(ByteString::from_utf8("Invalid String"sv)));
+utility::panic((ByteString::must_from_utf8("Invalid String"sv)));
 }
 };/*case end*/
 }/*switch end*/
@@ -7731,7 +7731,7 @@ utility::panic(TRY(ByteString::from_utf8("Invalid String"sv)));
     _jakt_value.release_value();
 }));
 }
-else if (__jakt_enum_value == TRY(ByteString::from_utf8("number"sv))) {
+else if (__jakt_enum_value == (ByteString::must_from_utf8("number"sv))) {
 return JaktInternal::ExplicitValue(({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<interpreter::StatementResult, ErrorOr<interpreter::StatementResult>>{
 auto&& __jakt_match_variant = *((((arguments)[static_cast<i64>(0LL)])).impl);
@@ -7766,19 +7766,19 @@ return JaktInternal::ExplicitValue(interpreter::StatementResult::JustValue(types
 };/*case end*/
 case 12 /* USize */: {
 {
-TRY((((*this).error(TRY(ByteString::from_utf8("String::number must not be called with a usize or u64"sv)),((((arguments)[static_cast<i64>(0LL)])).span)))));
+TRY((((*this).error((ByteString::must_from_utf8("String::number must not be called with a usize or u64"sv)),((((arguments)[static_cast<i64>(0LL)])).span)))));
 return Error::__jakt_from_string_literal((StringView::from_string_literal("Invalid type"sv)));
 }
 };/*case end*/
 case 5 /* U64 */: {
 {
-TRY((((*this).error(TRY(ByteString::from_utf8("String::number must not be called with a usize or u64"sv)),((((arguments)[static_cast<i64>(0LL)])).span)))));
+TRY((((*this).error((ByteString::must_from_utf8("String::number must not be called with a usize or u64"sv)),((((arguments)[static_cast<i64>(0LL)])).span)))));
 return Error::__jakt_from_string_literal((StringView::from_string_literal("Invalid type"sv)));
 }
 };/*case end*/
 default: {
 {
-TRY((((*this).error(TRY(ByteString::from_utf8("String::number must be called with an integer"sv)),((((arguments)[static_cast<i64>(0LL)])).span)))));
+TRY((((*this).error((ByteString::must_from_utf8("String::number must be called with an integer"sv)),((((arguments)[static_cast<i64>(0LL)])).span)))));
 return Error::__jakt_from_string_literal((StringView::from_string_literal("Invalid type"sv)));
 }
 };/*case end*/
@@ -7790,7 +7790,7 @@ return Error::__jakt_from_string_literal((StringView::from_string_literal("Inval
     _jakt_value.release_value();
 }));
 }
-else if (__jakt_enum_value == TRY(ByteString::from_utf8("to_uint"sv))) {
+else if (__jakt_enum_value == (ByteString::must_from_utf8("to_uint"sv))) {
 return JaktInternal::ExplicitValue(({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<interpreter::StatementResult, ErrorOr<interpreter::StatementResult>>{
 auto&& __jakt_match_variant = *(((this_argument.value())).impl);
@@ -7819,7 +7819,7 @@ __jakt_label_270:; __jakt_var_284.release_value(); }));
 };/*case end*/
 default: {
 {
-utility::panic(TRY(ByteString::from_utf8("Invalid String"sv)));
+utility::panic((ByteString::must_from_utf8("Invalid String"sv)));
 }
 };/*case end*/
 }/*switch end*/
@@ -7830,7 +7830,7 @@ utility::panic(TRY(ByteString::from_utf8("Invalid String"sv)));
     _jakt_value.release_value();
 }));
 }
-else if (__jakt_enum_value == TRY(ByteString::from_utf8("to_int"sv))) {
+else if (__jakt_enum_value == (ByteString::must_from_utf8("to_int"sv))) {
 return JaktInternal::ExplicitValue(({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<interpreter::StatementResult, ErrorOr<interpreter::StatementResult>>{
 auto&& __jakt_match_variant = *(((this_argument.value())).impl);
@@ -7860,7 +7860,7 @@ __jakt_label_271:; __jakt_var_285.release_value(); }));
 };/*case end*/
 default: {
 {
-utility::panic(TRY(ByteString::from_utf8("Invalid String"sv)));
+utility::panic((ByteString::must_from_utf8("Invalid String"sv)));
 }
 };/*case end*/
 }/*switch end*/
@@ -7871,7 +7871,7 @@ utility::panic(TRY(ByteString::from_utf8("Invalid String"sv)));
     _jakt_value.release_value();
 }));
 }
-else if (__jakt_enum_value == TRY(ByteString::from_utf8("is_whitespace"sv))) {
+else if (__jakt_enum_value == (ByteString::must_from_utf8("is_whitespace"sv))) {
 return JaktInternal::ExplicitValue(({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<interpreter::StatementResult, ErrorOr<interpreter::StatementResult>>{
 auto&& __jakt_match_variant = *(((this_argument.value())).impl);
@@ -7882,7 +7882,7 @@ return JaktInternal::ExplicitValue(interpreter::StatementResult::JustValue(types
 };/*case end*/
 default: {
 {
-utility::panic(TRY(ByteString::from_utf8("Invalid String"sv)));
+utility::panic((ByteString::must_from_utf8("Invalid String"sv)));
 }
 };/*case end*/
 }/*switch end*/
@@ -7893,7 +7893,7 @@ utility::panic(TRY(ByteString::from_utf8("Invalid String"sv)));
     _jakt_value.release_value();
 }));
 }
-else if (__jakt_enum_value == TRY(ByteString::from_utf8("contains"sv))) {
+else if (__jakt_enum_value == (ByteString::must_from_utf8("contains"sv))) {
 return JaktInternal::ExplicitValue(({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<interpreter::StatementResult, ErrorOr<interpreter::StatementResult>>{
 auto&& __jakt_match_variant = *(((this_argument.value())).impl);
@@ -7910,7 +7910,7 @@ return JaktInternal::ExplicitValue(interpreter::StatementResult::JustValue(types
 };/*case end*/
 default: {
 {
-TRY((((*this).error(TRY(ByteString::from_utf8("String::contains must be called with a string"sv)),((((arguments)[static_cast<i64>(0LL)])).span)))));
+TRY((((*this).error((ByteString::must_from_utf8("String::contains must be called with a string"sv)),((((arguments)[static_cast<i64>(0LL)])).span)))));
 return Error::__jakt_from_string_literal((StringView::from_string_literal("Invalid type"sv)));
 }
 };/*case end*/
@@ -7924,7 +7924,7 @@ return Error::__jakt_from_string_literal((StringView::from_string_literal("Inval
 };/*case end*/
 default: {
 {
-utility::panic(TRY(ByteString::from_utf8("Invalid String"sv)));
+utility::panic((ByteString::must_from_utf8("Invalid String"sv)));
 }
 };/*case end*/
 }/*switch end*/
@@ -7935,7 +7935,7 @@ utility::panic(TRY(ByteString::from_utf8("Invalid String"sv)));
     _jakt_value.release_value();
 }));
 }
-else if (__jakt_enum_value == TRY(ByteString::from_utf8("replace"sv))) {
+else if (__jakt_enum_value == (ByteString::must_from_utf8("replace"sv))) {
 return JaktInternal::ExplicitValue(({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<interpreter::StatementResult, ErrorOr<interpreter::StatementResult>>{
 auto&& __jakt_match_variant = *(((this_argument.value())).impl);
@@ -7958,7 +7958,7 @@ return JaktInternal::ExplicitValue(interpreter::StatementResult::JustValue(types
 };/*case end*/
 default: {
 {
-TRY((((*this).error(TRY(ByteString::from_utf8("String::replace must be called with strings"sv)),((((arguments)[static_cast<i64>(1LL)])).span)))));
+TRY((((*this).error((ByteString::must_from_utf8("String::replace must be called with strings"sv)),((((arguments)[static_cast<i64>(1LL)])).span)))));
 return Error::__jakt_from_string_literal((StringView::from_string_literal("Invalid type"sv)));
 }
 };/*case end*/
@@ -7972,7 +7972,7 @@ return Error::__jakt_from_string_literal((StringView::from_string_literal("Inval
 };/*case end*/
 default: {
 {
-TRY((((*this).error(TRY(ByteString::from_utf8("String::replace must be called with strings"sv)),((((arguments)[static_cast<i64>(0LL)])).span)))));
+TRY((((*this).error((ByteString::must_from_utf8("String::replace must be called with strings"sv)),((((arguments)[static_cast<i64>(0LL)])).span)))));
 return Error::__jakt_from_string_literal((StringView::from_string_literal("Invalid type"sv)));
 }
 };/*case end*/
@@ -7986,7 +7986,7 @@ return Error::__jakt_from_string_literal((StringView::from_string_literal("Inval
 };/*case end*/
 default: {
 {
-utility::panic(TRY(ByteString::from_utf8("Invalid String"sv)));
+utility::panic((ByteString::must_from_utf8("Invalid String"sv)));
 }
 };/*case end*/
 }/*switch end*/
@@ -7997,7 +7997,7 @@ utility::panic(TRY(ByteString::from_utf8("Invalid String"sv)));
     _jakt_value.release_value();
 }));
 }
-else if (__jakt_enum_value == TRY(ByteString::from_utf8("byte_at"sv))) {
+else if (__jakt_enum_value == (ByteString::must_from_utf8("byte_at"sv))) {
 return JaktInternal::ExplicitValue(({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<interpreter::StatementResult, ErrorOr<interpreter::StatementResult>>{
 auto&& __jakt_match_variant = *(((this_argument.value())).impl);
@@ -8030,7 +8030,7 @@ return JaktInternal::ExplicitValue(interpreter::StatementResult::JustValue(types
 };/*case end*/
 default: {
 {
-TRY((((*this).error(TRY(ByteString::from_utf8("String::byte_at must be called with an unsigned integer"sv)),((((arguments)[static_cast<i64>(0LL)])).span)))));
+TRY((((*this).error((ByteString::must_from_utf8("String::byte_at must be called with an unsigned integer"sv)),((((arguments)[static_cast<i64>(0LL)])).span)))));
 return Error::__jakt_from_string_literal((StringView::from_string_literal("Invalid type"sv)));
 }
 };/*case end*/
@@ -8044,7 +8044,7 @@ return Error::__jakt_from_string_literal((StringView::from_string_literal("Inval
 };/*case end*/
 default: {
 {
-utility::panic(TRY(ByteString::from_utf8("Invalid String"sv)));
+utility::panic((ByteString::must_from_utf8("Invalid String"sv)));
 }
 };/*case end*/
 }/*switch end*/
@@ -8055,7 +8055,7 @@ utility::panic(TRY(ByteString::from_utf8("Invalid String"sv)));
     _jakt_value.release_value();
 }));
 }
-else if (__jakt_enum_value == TRY(ByteString::from_utf8("split"sv))) {
+else if (__jakt_enum_value == (ByteString::must_from_utf8("split"sv))) {
 return JaktInternal::ExplicitValue(({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<interpreter::StatementResult, ErrorOr<interpreter::StatementResult>>{
 auto&& __jakt_match_variant = *(((this_argument.value())).impl);
@@ -8086,7 +8086,7 @@ TRY((((result).push(types::Value(TRY((types::ValueImpl::JaktString(value))),call
 }
 }
 
-ids::StructId const array_struct_id = TRY((((((*this).program))->find_struct_in_prelude(TRY(ByteString::from_utf8("Array"sv))))));
+ids::StructId const array_struct_id = TRY((((((*this).program))->find_struct_in_prelude((ByteString::must_from_utf8("Array"sv))))));
 __jakt_var_286 = interpreter::StatementResult::JustValue(types::Value(TRY((types::ValueImpl::JaktArray(result,TRY((((*this).find_or_add_type_id(TRY((types::Type::GenericInstance(parser::CheckedQualifiers(false),array_struct_id,(TRY((DynamicArray<ids::TypeId>::create_with({TRY((((*this).string_type())))})))))))))))))),call_span)); goto __jakt_label_272;
 
 }
@@ -8094,7 +8094,7 @@ __jakt_label_272:; __jakt_var_286.release_value(); }));
 };/*case end*/
 default: {
 {
-TRY((((*this).error(TRY(ByteString::from_utf8("String::split must be called with a c_char"sv)),((((arguments)[static_cast<i64>(0LL)])).span)))));
+TRY((((*this).error((ByteString::must_from_utf8("String::split must be called with a c_char"sv)),((((arguments)[static_cast<i64>(0LL)])).span)))));
 return Error::__jakt_from_string_literal((StringView::from_string_literal("Invalid type"sv)));
 }
 };/*case end*/
@@ -8108,7 +8108,7 @@ return Error::__jakt_from_string_literal((StringView::from_string_literal("Inval
 };/*case end*/
 default: {
 {
-utility::panic(TRY(ByteString::from_utf8("Invalid String"sv)));
+utility::panic((ByteString::must_from_utf8("Invalid String"sv)));
 }
 };/*case end*/
 }/*switch end*/
@@ -8119,7 +8119,7 @@ utility::panic(TRY(ByteString::from_utf8("Invalid String"sv)));
     _jakt_value.release_value();
 }));
 }
-else if (__jakt_enum_value == TRY(ByteString::from_utf8("starts_with"sv))) {
+else if (__jakt_enum_value == (ByteString::must_from_utf8("starts_with"sv))) {
 return JaktInternal::ExplicitValue(({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<interpreter::StatementResult, ErrorOr<interpreter::StatementResult>>{
 auto&& __jakt_match_variant = *(((this_argument.value())).impl);
@@ -8136,7 +8136,7 @@ return JaktInternal::ExplicitValue(interpreter::StatementResult::JustValue(types
 };/*case end*/
 default: {
 {
-TRY((((*this).error(TRY(ByteString::from_utf8("String::starts_with must be called with a string"sv)),((((arguments)[static_cast<i64>(0LL)])).span)))));
+TRY((((*this).error((ByteString::must_from_utf8("String::starts_with must be called with a string"sv)),((((arguments)[static_cast<i64>(0LL)])).span)))));
 return Error::__jakt_from_string_literal((StringView::from_string_literal("Invalid type"sv)));
 }
 };/*case end*/
@@ -8150,7 +8150,7 @@ return Error::__jakt_from_string_literal((StringView::from_string_literal("Inval
 };/*case end*/
 default: {
 {
-utility::panic(TRY(ByteString::from_utf8("Invalid String"sv)));
+utility::panic((ByteString::must_from_utf8("Invalid String"sv)));
 }
 };/*case end*/
 }/*switch end*/
@@ -8161,7 +8161,7 @@ utility::panic(TRY(ByteString::from_utf8("Invalid String"sv)));
     _jakt_value.release_value();
 }));
 }
-else if (__jakt_enum_value == TRY(ByteString::from_utf8("ends_with"sv))) {
+else if (__jakt_enum_value == (ByteString::must_from_utf8("ends_with"sv))) {
 return JaktInternal::ExplicitValue(({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<interpreter::StatementResult, ErrorOr<interpreter::StatementResult>>{
 auto&& __jakt_match_variant = *(((this_argument.value())).impl);
@@ -8178,7 +8178,7 @@ return JaktInternal::ExplicitValue(interpreter::StatementResult::JustValue(types
 };/*case end*/
 default: {
 {
-TRY((((*this).error(TRY(ByteString::from_utf8("String::ends_with must be called with a string"sv)),((((arguments)[static_cast<i64>(0LL)])).span)))));
+TRY((((*this).error((ByteString::must_from_utf8("String::ends_with must be called with a string"sv)),((((arguments)[static_cast<i64>(0LL)])).span)))));
 return Error::__jakt_from_string_literal((StringView::from_string_literal("Invalid type"sv)));
 }
 };/*case end*/
@@ -8192,7 +8192,7 @@ return Error::__jakt_from_string_literal((StringView::from_string_literal("Inval
 };/*case end*/
 default: {
 {
-utility::panic(TRY(ByteString::from_utf8("Invalid String"sv)));
+utility::panic((ByteString::must_from_utf8("Invalid String"sv)));
 }
 };/*case end*/
 }/*switch end*/
@@ -8203,10 +8203,10 @@ utility::panic(TRY(ByteString::from_utf8("Invalid String"sv)));
     _jakt_value.release_value();
 }));
 }
-else if (__jakt_enum_value == TRY(ByteString::from_utf8("repeated"sv))) {
+else if (__jakt_enum_value == (ByteString::must_from_utf8("repeated"sv))) {
 return JaktInternal::ExplicitValue(({ Optional<interpreter::StatementResult> __jakt_var_287; {
 if (((((arguments).size())) != (static_cast<size_t>(2ULL)))){
-TRY((((*this).error(TRY(ByteString::from_utf8("String::repeated must be called with a c_char and a usize"sv)),call_span))));
+TRY((((*this).error((ByteString::must_from_utf8("String::repeated must be called with a c_char and a usize"sv)),call_span))));
 return Error::__jakt_from_string_literal((StringView::from_string_literal("Invalid type"sv)));
 }
 JaktInternal::Tuple<char,size_t> const character_count_ = ({
@@ -8225,7 +8225,7 @@ return JaktInternal::ExplicitValue((Tuple{arg, c}));
 };/*case end*/
 default: {
 {
-TRY((((*this).error(TRY(ByteString::from_utf8("String::repeated must be called with a usize"sv)),((((arguments)[static_cast<i64>(1LL)])).span)))));
+TRY((((*this).error((ByteString::must_from_utf8("String::repeated must be called with a usize"sv)),((((arguments)[static_cast<i64>(1LL)])).span)))));
 return Error::__jakt_from_string_literal((StringView::from_string_literal("Invalid type"sv)));
 }
 };/*case end*/
@@ -8239,7 +8239,7 @@ return Error::__jakt_from_string_literal((StringView::from_string_literal("Inval
 };/*case end*/
 default: {
 {
-TRY((((*this).error(TRY(ByteString::from_utf8("String::repeated must be called with a c_char"sv)),((((arguments)[static_cast<i64>(0LL)])).span)))));
+TRY((((*this).error((ByteString::must_from_utf8("String::repeated must be called with a c_char"sv)),((((arguments)[static_cast<i64>(0LL)])).span)))));
 return Error::__jakt_from_string_literal((StringView::from_string_literal("Invalid type"sv)));
 }
 };/*case end*/
@@ -8270,24 +8270,24 @@ return Error::__jakt_from_string_literal((StringView::from_string_literal("Not y
     _jakt_value.release_value();
 }));
 }
-else if (__jakt_enum_value == TRY(ByteString::from_utf8("Set"sv))) {
+else if (__jakt_enum_value == (ByteString::must_from_utf8("Set"sv))) {
 return JaktInternal::ExplicitValue(({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<interpreter::StatementResult,ErrorOr<interpreter::StatementResult>>{
 auto __jakt_enum_value = (prelude_function);
-if (__jakt_enum_value == TRY(ByteString::from_utf8("Set"sv))) {
+if (__jakt_enum_value == (ByteString::must_from_utf8("Set"sv))) {
 return JaktInternal::ExplicitValue(({ Optional<interpreter::StatementResult> __jakt_var_288; {
 if (((((type_bindings).size())) != (static_cast<size_t>(1ULL)))){
-TRY((((*this).error(TRY(ByteString::from_utf8("Set constructor expects one generic argument"sv)),call_span))));
+TRY((((*this).error((ByteString::must_from_utf8("Set constructor expects one generic argument"sv)),call_span))));
 return Error::__jakt_from_string_literal((StringView::from_string_literal("Invalid type"sv)));
 }
-ids::StructId const set_struct_id = TRY((((((*this).program))->find_struct_in_prelude(TRY(ByteString::from_utf8("Set"sv))))));
+ids::StructId const set_struct_id = TRY((((((*this).program))->find_struct_in_prelude((ByteString::must_from_utf8("Set"sv))))));
 ids::TypeId const type_id = TRY((((*this).find_or_add_type_id(TRY((types::Type::GenericInstance(parser::CheckedQualifiers(false),set_struct_id,(TRY((DynamicArray<ids::TypeId>::create_with({(((type_bindings).get(((TRY((((type_bindings).keys()))))[static_cast<i64>(0LL)]))).value())})))))))))));
 __jakt_var_288 = interpreter::StatementResult::JustValue(types::Value(TRY((types::ValueImpl::JaktSet((TRY((DynamicArray<types::Value>::create_with({})))),type_id))),call_span)); goto __jakt_label_274;
 
 }
 __jakt_label_274:; __jakt_var_288.release_value(); }));
 }
-else if (__jakt_enum_value == TRY(ByteString::from_utf8("is_empty"sv))) {
+else if (__jakt_enum_value == (ByteString::must_from_utf8("is_empty"sv))) {
 return JaktInternal::ExplicitValue(({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<interpreter::StatementResult, ErrorOr<interpreter::StatementResult>>{
 auto&& __jakt_match_variant = *(((this_argument.value())).impl);
@@ -8298,7 +8298,7 @@ return JaktInternal::ExplicitValue(interpreter::StatementResult::JustValue(types
 };/*case end*/
 default: {
 {
-utility::panic(TRY(ByteString::from_utf8("Invalid Set"sv)));
+utility::panic((ByteString::must_from_utf8("Invalid Set"sv)));
 }
 };/*case end*/
 }/*switch end*/
@@ -8309,7 +8309,7 @@ utility::panic(TRY(ByteString::from_utf8("Invalid Set"sv)));
     _jakt_value.release_value();
 }));
 }
-else if (__jakt_enum_value == TRY(ByteString::from_utf8("contains"sv))) {
+else if (__jakt_enum_value == (ByteString::must_from_utf8("contains"sv))) {
 return JaktInternal::ExplicitValue(({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<interpreter::StatementResult, ErrorOr<interpreter::StatementResult>>{
 auto&& __jakt_match_variant = *(((this_argument.value())).impl);
@@ -8343,7 +8343,7 @@ __jakt_label_275:; __jakt_var_289.release_value(); }));
 };/*case end*/
 default: {
 {
-utility::panic(TRY(ByteString::from_utf8("Invalid Set"sv)));
+utility::panic((ByteString::must_from_utf8("Invalid Set"sv)));
 }
 };/*case end*/
 }/*switch end*/
@@ -8354,7 +8354,7 @@ utility::panic(TRY(ByteString::from_utf8("Invalid Set"sv)));
     _jakt_value.release_value();
 }));
 }
-else if (__jakt_enum_value == TRY(ByteString::from_utf8("add"sv))) {
+else if (__jakt_enum_value == (ByteString::must_from_utf8("add"sv))) {
 return JaktInternal::ExplicitValue(({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<interpreter::StatementResult, ErrorOr<interpreter::StatementResult>>{
 auto&& __jakt_match_variant = *(((this_argument.value())).impl);
@@ -8371,7 +8371,7 @@ __jakt_label_276:; __jakt_var_290.release_value(); }));
 };/*case end*/
 default: {
 {
-utility::panic(TRY(ByteString::from_utf8("Invalid Set"sv)));
+utility::panic((ByteString::must_from_utf8("Invalid Set"sv)));
 }
 };/*case end*/
 }/*switch end*/
@@ -8382,7 +8382,7 @@ utility::panic(TRY(ByteString::from_utf8("Invalid Set"sv)));
     _jakt_value.release_value();
 }));
 }
-else if (__jakt_enum_value == TRY(ByteString::from_utf8("remove"sv))) {
+else if (__jakt_enum_value == (ByteString::must_from_utf8("remove"sv))) {
 return JaktInternal::ExplicitValue(({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<interpreter::StatementResult, ErrorOr<interpreter::StatementResult>>{
 auto&& __jakt_match_variant = *(((this_argument.value())).impl);
@@ -8435,7 +8435,7 @@ __jakt_label_277:; __jakt_var_291.release_value(); }));
 };/*case end*/
 default: {
 {
-utility::panic(TRY(ByteString::from_utf8("Invalid Set"sv)));
+utility::panic((ByteString::must_from_utf8("Invalid Set"sv)));
 }
 };/*case end*/
 }/*switch end*/
@@ -8446,7 +8446,7 @@ utility::panic(TRY(ByteString::from_utf8("Invalid Set"sv)));
     _jakt_value.release_value();
 }));
 }
-else if (__jakt_enum_value == TRY(ByteString::from_utf8("clear"sv))) {
+else if (__jakt_enum_value == (ByteString::must_from_utf8("clear"sv))) {
 return JaktInternal::ExplicitValue(({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<interpreter::StatementResult, ErrorOr<interpreter::StatementResult>>{
 auto&& __jakt_match_variant = *(((this_argument.value())).impl);
@@ -8463,7 +8463,7 @@ __jakt_label_278:; __jakt_var_292.release_value(); }));
 };/*case end*/
 default: {
 {
-utility::panic(TRY(ByteString::from_utf8("Invalid Set"sv)));
+utility::panic((ByteString::must_from_utf8("Invalid Set"sv)));
 }
 };/*case end*/
 }/*switch end*/
@@ -8474,7 +8474,7 @@ utility::panic(TRY(ByteString::from_utf8("Invalid Set"sv)));
     _jakt_value.release_value();
 }));
 }
-else if (__jakt_enum_value == TRY(ByteString::from_utf8("size"sv))) {
+else if (__jakt_enum_value == (ByteString::must_from_utf8("size"sv))) {
 return JaktInternal::ExplicitValue(({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<interpreter::StatementResult, ErrorOr<interpreter::StatementResult>>{
 auto&& __jakt_match_variant = *(((this_argument.value())).impl);
@@ -8485,7 +8485,7 @@ return JaktInternal::ExplicitValue(interpreter::StatementResult::JustValue(types
 };/*case end*/
 default: {
 {
-utility::panic(TRY(ByteString::from_utf8("Invalid Set"sv)));
+utility::panic((ByteString::must_from_utf8("Invalid Set"sv)));
 }
 };/*case end*/
 }/*switch end*/
@@ -8496,7 +8496,7 @@ utility::panic(TRY(ByteString::from_utf8("Invalid Set"sv)));
     _jakt_value.release_value();
 }));
 }
-else if (__jakt_enum_value == TRY(ByteString::from_utf8("capacity"sv))) {
+else if (__jakt_enum_value == (ByteString::must_from_utf8("capacity"sv))) {
 return JaktInternal::ExplicitValue(({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<interpreter::StatementResult, ErrorOr<interpreter::StatementResult>>{
 auto&& __jakt_match_variant = *(((this_argument.value())).impl);
@@ -8507,7 +8507,7 @@ return JaktInternal::ExplicitValue(interpreter::StatementResult::JustValue(types
 };/*case end*/
 default: {
 {
-utility::panic(TRY(ByteString::from_utf8("Invalid Set"sv)));
+utility::panic((ByteString::must_from_utf8("Invalid Set"sv)));
 }
 };/*case end*/
 }/*switch end*/
@@ -8518,7 +8518,7 @@ utility::panic(TRY(ByteString::from_utf8("Invalid Set"sv)));
     _jakt_value.release_value();
 }));
 }
-else if (__jakt_enum_value == TRY(ByteString::from_utf8("ensure_capacity"sv))) {
+else if (__jakt_enum_value == (ByteString::must_from_utf8("ensure_capacity"sv))) {
 return JaktInternal::ExplicitValue(({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<interpreter::StatementResult, ErrorOr<interpreter::StatementResult>>{
 auto&& __jakt_match_variant = *(((this_argument.value())).impl);
@@ -8541,7 +8541,7 @@ __jakt_label_279:; __jakt_var_293.release_value(); }));
 };/*case end*/
 default: {
 {
-TRY((((*this).error(TRY(ByteString::from_utf8("Set::ensure_capacity must be called with a usize"sv)),((((arguments)[static_cast<i64>(0LL)])).span)))));
+TRY((((*this).error((ByteString::must_from_utf8("Set::ensure_capacity must be called with a usize"sv)),((((arguments)[static_cast<i64>(0LL)])).span)))));
 return Error::__jakt_from_string_literal((StringView::from_string_literal("Invalid type"sv)));
 }
 };/*case end*/
@@ -8555,7 +8555,7 @@ return Error::__jakt_from_string_literal((StringView::from_string_literal("Inval
 };/*case end*/
 default: {
 {
-utility::panic(TRY(ByteString::from_utf8("Invalid Set"sv)));
+utility::panic((ByteString::must_from_utf8("Invalid Set"sv)));
 }
 };/*case end*/
 }/*switch end*/
@@ -8566,14 +8566,14 @@ utility::panic(TRY(ByteString::from_utf8("Invalid Set"sv)));
     _jakt_value.release_value();
 }));
 }
-else if (__jakt_enum_value == TRY(ByteString::from_utf8("iterator"sv))) {
+else if (__jakt_enum_value == (ByteString::must_from_utf8("iterator"sv))) {
 return JaktInternal::ExplicitValue(({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<interpreter::StatementResult, ErrorOr<interpreter::StatementResult>>{
 auto&& __jakt_match_variant = *(((this_argument.value())).impl);
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 22 /* JaktSet */: {
 return JaktInternal::ExplicitValue(({ Optional<interpreter::StatementResult> __jakt_var_294; {
-ids::StructId const struct_id = TRY((((((*this).program))->find_struct_in_prelude(TRY(ByteString::from_utf8("SetIterator"sv))))));
+ids::StructId const struct_id = TRY((((((*this).program))->find_struct_in_prelude((ByteString::must_from_utf8("SetIterator"sv))))));
 __jakt_var_294 = interpreter::StatementResult::JustValue(types::Value(TRY((types::ValueImpl::Struct((TRY((DynamicArray<types::Value>::create_with({(this_argument.value()), types::Value(TRY((types::ValueImpl::USize(static_cast<size_t>(0ULL)))),call_span)})))),struct_id,JaktInternal::OptionalNone()))),call_span)); goto __jakt_label_280;
 
 }
@@ -8581,7 +8581,7 @@ __jakt_label_280:; __jakt_var_294.release_value(); }));
 };/*case end*/
 default: {
 {
-utility::panic(TRY(ByteString::from_utf8("Invalid use of Set::iterator()"sv)));
+utility::panic((ByteString::must_from_utf8("Invalid use of Set::iterator()"sv)));
 }
 };/*case end*/
 }/*switch end*/
@@ -8604,11 +8604,11 @@ return Error::__jakt_from_string_literal((StringView::from_string_literal("Not y
     _jakt_value.release_value();
 }));
 }
-else if (__jakt_enum_value == TRY(ByteString::from_utf8("SetIterator"sv))) {
+else if (__jakt_enum_value == (ByteString::must_from_utf8("SetIterator"sv))) {
 return JaktInternal::ExplicitValue(({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<interpreter::StatementResult,ErrorOr<interpreter::StatementResult>>{
 auto __jakt_enum_value = (prelude_function);
-if (__jakt_enum_value == TRY(ByteString::from_utf8("next"sv))) {
+if (__jakt_enum_value == (ByteString::must_from_utf8("next"sv))) {
 return JaktInternal::ExplicitValue(({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<interpreter::StatementResult, ErrorOr<interpreter::StatementResult>>{
 auto&& __jakt_match_variant = *(((this_argument.value())).impl);
@@ -8626,7 +8626,7 @@ return JaktInternal::ExplicitValue(value);
 };/*case end*/
 default: {
 {
-utility::panic(TRY(ByteString::from_utf8("Invalid SetIterator index configuration"sv)));
+utility::panic((ByteString::must_from_utf8("Invalid SetIterator index configuration"sv)));
 }
 };/*case end*/
 }/*switch end*/
@@ -8675,7 +8675,7 @@ return JaktInternal::ExplicitValue(types::Value(TRY((types::ValueImpl::OptionalN
 };/*case end*/
 default: {
 {
-utility::panic(TRY(ByteString::from_utf8("Invalid SetIterator configuration"sv)));
+utility::panic((ByteString::must_from_utf8("Invalid SetIterator configuration"sv)));
 }
 };/*case end*/
 }/*switch end*/
@@ -8691,7 +8691,7 @@ __jakt_label_281:; __jakt_var_295.release_value(); }));
 };/*case end*/
 default: {
 {
-utility::panic(TRY(ByteString::from_utf8("Invalid SetIterator configuration"sv)));
+utility::panic((ByteString::must_from_utf8("Invalid SetIterator configuration"sv)));
 }
 };/*case end*/
 }/*switch end*/
@@ -8714,11 +8714,11 @@ return Error::__jakt_from_string_literal((StringView::from_string_literal("Not y
     _jakt_value.release_value();
 }));
 }
-else if (__jakt_enum_value == TRY(ByteString::from_utf8("DictionaryIterator"sv))) {
+else if (__jakt_enum_value == (ByteString::must_from_utf8("DictionaryIterator"sv))) {
 return JaktInternal::ExplicitValue(({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<interpreter::StatementResult,ErrorOr<interpreter::StatementResult>>{
 auto __jakt_enum_value = (prelude_function);
-if (__jakt_enum_value == TRY(ByteString::from_utf8("next"sv))) {
+if (__jakt_enum_value == (ByteString::must_from_utf8("next"sv))) {
 return JaktInternal::ExplicitValue(({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<interpreter::StatementResult, ErrorOr<interpreter::StatementResult>>{
 auto&& __jakt_match_variant = *(((this_argument.value())).impl);
@@ -8736,7 +8736,7 @@ return JaktInternal::ExplicitValue(value);
 };/*case end*/
 default: {
 {
-utility::panic(TRY(ByteString::from_utf8("Invalid DictionaryIterator index configuration"sv)));
+utility::panic((ByteString::must_from_utf8("Invalid DictionaryIterator index configuration"sv)));
 }
 };/*case end*/
 }/*switch end*/
@@ -8791,7 +8791,7 @@ return JaktInternal::ExplicitValue(args);
 };/*case end*/
 default: {
 {
-utility::panic(TRY(ByteString::from_utf8("expected generic instance"sv)));
+utility::panic((ByteString::must_from_utf8("expected generic instance"sv)));
 }
 };/*case end*/
 }/*switch end*/
@@ -8801,7 +8801,7 @@ utility::panic(TRY(ByteString::from_utf8("expected generic instance"sv)));
         return _jakt_value.release_return();
     _jakt_value.release_value();
 });
-ids::StructId const tuple_struct_id = TRY((((((*this).program))->find_struct_in_prelude(TRY(ByteString::from_utf8("Tuple"sv))))));
+ids::StructId const tuple_struct_id = TRY((((((*this).program))->find_struct_in_prelude((ByteString::must_from_utf8("Tuple"sv))))));
 ids::TypeId const tuple_type_id = TRY((((*this).find_or_add_type_id(TRY((types::Type::GenericInstance(parser::CheckedQualifiers(false),tuple_struct_id,generics)))))));
 __jakt_var_298 = types::Value(TRY((types::ValueImpl::OptionalSome(types::Value(TRY((types::ValueImpl::JaktTuple((TRY((DynamicArray<types::Value>::create_with({((keys)[index]), ((values)[index])})))),tuple_type_id))),call_span)))),call_span); goto __jakt_label_284;
 
@@ -8820,7 +8820,7 @@ VERIFY_NOT_REACHED();
 };/*case end*/
 default: {
 {
-utility::panic(TRY(ByteString::from_utf8("Invalid DictionaryIterator configuration"sv)));
+utility::panic((ByteString::must_from_utf8("Invalid DictionaryIterator configuration"sv)));
 }
 };/*case end*/
 }/*switch end*/
@@ -8836,7 +8836,7 @@ __jakt_label_283:; __jakt_var_297.release_value(); }));
 };/*case end*/
 default: {
 {
-utility::panic(TRY(ByteString::from_utf8("Invalid DictionaryIterator configuration"sv)));
+utility::panic((ByteString::must_from_utf8("Invalid DictionaryIterator configuration"sv)));
 }
 };/*case end*/
 }/*switch end*/
@@ -8859,11 +8859,11 @@ return Error::__jakt_from_string_literal((StringView::from_string_literal("Not y
     _jakt_value.release_value();
 }));
 }
-else if (__jakt_enum_value == TRY(ByteString::from_utf8("Optional"sv))) {
+else if (__jakt_enum_value == (ByteString::must_from_utf8("Optional"sv))) {
 return JaktInternal::ExplicitValue(({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<interpreter::StatementResult,ErrorOr<interpreter::StatementResult>>{
 auto __jakt_enum_value = (prelude_function);
-if (__jakt_enum_value == TRY(ByteString::from_utf8("has_value"sv))) {
+if (__jakt_enum_value == (ByteString::must_from_utf8("has_value"sv))) {
 return JaktInternal::ExplicitValue(({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<interpreter::StatementResult, ErrorOr<interpreter::StatementResult>>{
 auto&& __jakt_match_variant = *(((this_argument.value())).impl);
@@ -8876,7 +8876,7 @@ return JaktInternal::ExplicitValue(interpreter::StatementResult::JustValue(types
 };/*case end*/
 default: {
 {
-utility::panic(TRY(ByteString::from_utf8("Invalid Optional configuration"sv)));
+utility::panic((ByteString::must_from_utf8("Invalid Optional configuration"sv)));
 }
 };/*case end*/
 }/*switch end*/
@@ -8887,7 +8887,7 @@ utility::panic(TRY(ByteString::from_utf8("Invalid Optional configuration"sv)));
     _jakt_value.release_value();
 }));
 }
-else if (__jakt_enum_value == TRY(ByteString::from_utf8("value"sv))) {
+else if (__jakt_enum_value == (ByteString::must_from_utf8("value"sv))) {
 return JaktInternal::ExplicitValue(({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<interpreter::StatementResult, ErrorOr<interpreter::StatementResult>>{
 auto&& __jakt_match_variant = *(((this_argument.value())).impl);
@@ -8904,7 +8904,7 @@ return Error::__jakt_from_string_literal((StringView::from_string_literal("Attem
 };/*case end*/
 default: {
 {
-utility::panic(TRY(ByteString::from_utf8("Invalid Optional configuration"sv)));
+utility::panic((ByteString::must_from_utf8("Invalid Optional configuration"sv)));
 }
 };/*case end*/
 }/*switch end*/
@@ -8915,7 +8915,7 @@ utility::panic(TRY(ByteString::from_utf8("Invalid Optional configuration"sv)));
     _jakt_value.release_value();
 }));
 }
-else if (__jakt_enum_value == TRY(ByteString::from_utf8("map"sv))) {
+else if (__jakt_enum_value == (ByteString::must_from_utf8("map"sv))) {
 return JaktInternal::ExplicitValue(({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<interpreter::StatementResult, ErrorOr<interpreter::StatementResult>>{
 auto&& __jakt_match_variant = *(((this_argument.value())).impl);
@@ -8990,7 +8990,7 @@ __jakt_label_286:; __jakt_var_300.release_value(); }));
 }
 else {
 {
-utility::panic(TRY(ByteString::from_utf8("Invalid mapper type in Optional::map"sv)));
+utility::panic((ByteString::must_from_utf8("Invalid mapper type in Optional::map"sv)));
 }
 }
 }());
@@ -9007,7 +9007,7 @@ return JaktInternal::ExplicitValue(interpreter::StatementResult::JustValue((this
 };/*case end*/
 default: {
 {
-utility::panic(TRY(ByteString::from_utf8("Invalid Optional configuration"sv)));
+utility::panic((ByteString::must_from_utf8("Invalid Optional configuration"sv)));
 }
 };/*case end*/
 }/*switch end*/
@@ -9018,7 +9018,7 @@ utility::panic(TRY(ByteString::from_utf8("Invalid Optional configuration"sv)));
     _jakt_value.release_value();
 }));
 }
-else if (__jakt_enum_value == TRY(ByteString::from_utf8("value_or"sv))) {
+else if (__jakt_enum_value == (ByteString::must_from_utf8("value_or"sv))) {
 return JaktInternal::ExplicitValue(({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<interpreter::StatementResult, ErrorOr<interpreter::StatementResult>>{
 auto&& __jakt_match_variant = *(((this_argument.value())).impl);
@@ -9032,7 +9032,7 @@ return JaktInternal::ExplicitValue(interpreter::StatementResult::JustValue(((arg
 };/*case end*/
 default: {
 {
-utility::panic(TRY(ByteString::from_utf8("Invalid Optional configuration"sv)));
+utility::panic((ByteString::must_from_utf8("Invalid Optional configuration"sv)));
 }
 };/*case end*/
 }/*switch end*/
@@ -9177,7 +9177,7 @@ return interpreter::StatementResult::Break();
 case 2 /* Yield */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Yield;types::Value const& expr = __jakt_match_value.value;
 {
-utility::panic(TRY(ByteString::from_utf8("Invalid control flow"sv)));
+utility::panic((ByteString::must_from_utf8("Invalid control flow"sv)));
 }
 };/*case end*/
 default: VERIFY_NOT_REACHED();}/*switch end*/
@@ -9230,7 +9230,7 @@ return interpreter::StatementResult::Break();
 case 2 /* Yield */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Yield;types::Value const& expr = __jakt_match_value.value;
 {
-utility::panic(TRY(ByteString::from_utf8("Invalid control flow"sv)));
+utility::panic((ByteString::must_from_utf8("Invalid control flow"sv)));
 }
 };/*case end*/
 default: VERIFY_NOT_REACHED();}/*switch end*/
@@ -9247,7 +9247,7 @@ return JaktInternal::ExplicitValue(value);
 };/*case end*/
 default: {
 {
-utility::panic(TRY(ByteString::from_utf8("Invalid left-hand side of NoneCoalescing"sv)));
+utility::panic((ByteString::must_from_utf8("Invalid left-hand side of NoneCoalescing"sv)));
 }
 };/*case end*/
 }/*switch end*/
@@ -9297,7 +9297,7 @@ return interpreter::StatementResult::Break();
 case 2 /* Yield */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Yield;types::Value const& expr = __jakt_match_value.value;
 {
-utility::panic(TRY(ByteString::from_utf8("Invalid control flow"sv)));
+utility::panic((ByteString::must_from_utf8("Invalid control flow"sv)));
 }
 };/*case end*/
 default: VERIFY_NOT_REACHED();}/*switch end*/
@@ -9314,7 +9314,7 @@ return JaktInternal::ExplicitValue(value);
 };/*case end*/
 default: {
 {
-utility::panic(TRY(ByteString::from_utf8("Invalid left-hand side of NoneCoalescing"sv)));
+utility::panic((ByteString::must_from_utf8("Invalid left-hand side of NoneCoalescing"sv)));
 }
 };/*case end*/
 }/*switch end*/
@@ -9369,7 +9369,7 @@ return interpreter::StatementResult::Break();
 case 2 /* Yield */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Yield;types::Value const& expr = __jakt_match_value.value;
 {
-utility::panic(TRY(ByteString::from_utf8("Invalid control flow"sv)));
+utility::panic((ByteString::must_from_utf8("Invalid control flow"sv)));
 }
 };/*case end*/
 default: VERIFY_NOT_REACHED();}/*switch end*/
@@ -9447,7 +9447,7 @@ return interpreter::StatementResult::Break();
 case 2 /* Yield */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Yield;types::Value const& expr = __jakt_match_value.value;
 {
-utility::panic(TRY(ByteString::from_utf8("Invalid control flow"sv)));
+utility::panic((ByteString::must_from_utf8("Invalid control flow"sv)));
 }
 };/*case end*/
 default: VERIFY_NOT_REACHED();}/*switch end*/
@@ -9516,7 +9516,7 @@ return interpreter::StatementResult::Break();
 case 2 /* Yield */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Yield;types::Value const& expr = __jakt_match_value.value;
 {
-utility::panic(TRY(ByteString::from_utf8("Invalid control flow"sv)));
+utility::panic((ByteString::must_from_utf8("Invalid control flow"sv)));
 }
 };/*case end*/
 default: VERIFY_NOT_REACHED();}/*switch end*/
@@ -9697,7 +9697,7 @@ return interpreter::StatementResult::Break();
 case 2 /* Yield */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Yield;types::Value const& expr = __jakt_match_value.value;
 {
-utility::panic(TRY(ByteString::from_utf8("Invalid control flow"sv)));
+utility::panic((ByteString::must_from_utf8("Invalid control flow"sv)));
 }
 };/*case end*/
 default: VERIFY_NOT_REACHED();}/*switch end*/
@@ -10360,7 +10360,7 @@ return interpreter::StatementResult::Break();
 case 2 /* Yield */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Yield;types::Value const& expr = __jakt_match_value.value;
 {
-utility::panic(TRY(ByteString::from_utf8("Invalid control flow"sv)));
+utility::panic((ByteString::must_from_utf8("Invalid control flow"sv)));
 }
 };/*case end*/
 default: VERIFY_NOT_REACHED();}/*switch end*/
@@ -10373,7 +10373,7 @@ default: VERIFY_NOT_REACHED();}/*switch end*/
 }
 else if (__jakt_enum_value == false) {
 {
-TRY((((*this).error(TRY(ByteString::from_utf8("Partial ranges are not implemented"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("Partial ranges are not implemented"sv)),span))));
 return Error::__jakt_from_string_literal((StringView::from_string_literal("Not yet implemented"sv)));
 }
 }
@@ -10420,7 +10420,7 @@ return interpreter::StatementResult::Break();
 case 2 /* Yield */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Yield;types::Value const& expr = __jakt_match_value.value;
 {
-utility::panic(TRY(ByteString::from_utf8("Invalid control flow"sv)));
+utility::panic((ByteString::must_from_utf8("Invalid control flow"sv)));
 }
 };/*case end*/
 default: VERIFY_NOT_REACHED();}/*switch end*/
@@ -10433,7 +10433,7 @@ default: VERIFY_NOT_REACHED();}/*switch end*/
 }
 else if (__jakt_enum_value == false) {
 {
-TRY((((*this).error(TRY(ByteString::from_utf8("Partial ranges are not implemented"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("Partial ranges are not implemented"sv)),span))));
 return Error::__jakt_from_string_literal((StringView::from_string_literal("Not yet implemented"sv)));
 }
 }
@@ -10443,8 +10443,8 @@ VERIFY_NOT_REACHED();
         return _jakt_value.release_return();
     _jakt_value.release_value();
 });
-ids::StructId const range_struct_id = TRY((((((*this).program))->find_struct_in_prelude(TRY(ByteString::from_utf8("Range"sv))))));
-JaktInternal::DynamicArray<ids::FunctionId> const range_constructors = (TRY((((((*this).program))->find_functions_with_name_in_scope(((((((*this).program))->get_struct(range_struct_id))).scope_id),TRY(ByteString::from_utf8("Range"sv)),false,JaktInternal::OptionalNone())))).value());
+ids::StructId const range_struct_id = TRY((((((*this).program))->find_struct_in_prelude((ByteString::must_from_utf8("Range"sv))))));
+JaktInternal::DynamicArray<ids::FunctionId> const range_constructors = (TRY((((((*this).program))->find_functions_with_name_in_scope(((((((*this).program))->get_struct(range_struct_id))).scope_id),(ByteString::must_from_utf8("Range"sv)),false,JaktInternal::OptionalNone())))).value());
 __jakt_var_351 = interpreter::StatementResult::JustValue(types::Value(TRY((types::ValueImpl::Struct((TRY((DynamicArray<types::Value>::create_with({start, end})))),range_struct_id,((range_constructors)[static_cast<i64>(0LL)])))),span)); goto __jakt_label_337;
 
 }
@@ -10498,7 +10498,7 @@ return interpreter::StatementResult::Break();
 case 2 /* Yield */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Yield;types::Value const& expr = __jakt_match_value.value;
 {
-utility::panic(TRY(ByteString::from_utf8("Invalid control flow"sv)));
+utility::panic((ByteString::must_from_utf8("Invalid control flow"sv)));
 }
 };/*case end*/
 default: VERIFY_NOT_REACHED();}/*switch end*/
@@ -10568,7 +10568,7 @@ return interpreter::StatementResult::Break();
 case 2 /* Yield */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Yield;types::Value const& expr = __jakt_match_value.value;
 {
-utility::panic(TRY(ByteString::from_utf8("Invalid control flow"sv)));
+utility::panic((ByteString::must_from_utf8("Invalid control flow"sv)));
 }
 };/*case end*/
 default: VERIFY_NOT_REACHED();}/*switch end*/
@@ -10666,7 +10666,7 @@ return interpreter::StatementResult::Break();
 case 2 /* Yield */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Yield;types::Value const& expr = __jakt_match_value.value;
 {
-utility::panic(TRY(ByteString::from_utf8("Invalid control flow"sv)));
+utility::panic((ByteString::must_from_utf8("Invalid control flow"sv)));
 }
 };/*case end*/
 default: VERIFY_NOT_REACHED();}/*switch end*/
@@ -10684,7 +10684,7 @@ switch(__jakt_match_variant.__jakt_init_index()) {
 case 13 /* JaktString */: {
 {
 JaktInternal::DynamicArray<ids::TypeId> const generic_parameters = (TRY((DynamicArray<ids::TypeId>::create_with({}))));
-TRY((((effective_namespace).push(types::ResolvedNamespace(TRY(ByteString::from_utf8("String"sv)),JaktInternal::OptionalNone(),generic_parameters)))));
+TRY((((effective_namespace).push(types::ResolvedNamespace((ByteString::must_from_utf8("String"sv)),JaktInternal::OptionalNone(),generic_parameters)))));
 }
 return JaktInternal::ExplicitValue<void>();
 };/*case end*/
@@ -10701,7 +10701,7 @@ return JaktInternal::ExplicitValue(args);
 };/*case end*/
 default: {
 {
-TRY((((*this).error(TRY(ByteString::from_utf8("Attempted to call a prelude function  on a non-generic array"sv)),((this_argument).span)))));
+TRY((((*this).error((ByteString::must_from_utf8("Attempted to call a prelude function  on a non-generic array"sv)),((this_argument).span)))));
 return Error::__jakt_from_string_literal((StringView::from_string_literal("Invalid type"sv)));
 }
 };/*case end*/
@@ -10712,7 +10712,7 @@ return Error::__jakt_from_string_literal((StringView::from_string_literal("Inval
         return _jakt_value.release_return();
     _jakt_value.release_value();
 });
-TRY((((effective_namespace).push(types::ResolvedNamespace(TRY(ByteString::from_utf8("Array"sv)),JaktInternal::OptionalNone(),generic_parameters)))));
+TRY((((effective_namespace).push(types::ResolvedNamespace((ByteString::must_from_utf8("Array"sv)),JaktInternal::OptionalNone(),generic_parameters)))));
 }
 return JaktInternal::ExplicitValue<void>();
 };/*case end*/
@@ -10729,7 +10729,7 @@ return JaktInternal::ExplicitValue(args);
 };/*case end*/
 default: {
 {
-TRY((((*this).error(TRY(ByteString::from_utf8("Attempted to call a prelude function  on a non-generic dictionary"sv)),((this_argument).span)))));
+TRY((((*this).error((ByteString::must_from_utf8("Attempted to call a prelude function  on a non-generic dictionary"sv)),((this_argument).span)))));
 return Error::__jakt_from_string_literal((StringView::from_string_literal("Invalid type"sv)));
 }
 };/*case end*/
@@ -10740,7 +10740,7 @@ return Error::__jakt_from_string_literal((StringView::from_string_literal("Inval
         return _jakt_value.release_return();
     _jakt_value.release_value();
 });
-TRY((((effective_namespace).push(types::ResolvedNamespace(TRY(ByteString::from_utf8("Dictionary"sv)),JaktInternal::OptionalNone(),generic_parameters)))));
+TRY((((effective_namespace).push(types::ResolvedNamespace((ByteString::must_from_utf8("Dictionary"sv)),JaktInternal::OptionalNone(),generic_parameters)))));
 }
 return JaktInternal::ExplicitValue<void>();
 };/*case end*/
@@ -10749,10 +10749,10 @@ auto&& __jakt_match_value = __jakt_match_variant.as.JaktSet;ids::TypeId const& t
 {
 if (((((((*this).program))->get_type(type_id)))->__jakt_init_index() == 20 /* GenericInstance */)){
 JaktInternal::DynamicArray<ids::TypeId> const generic_parameters = (((((*this).program))->get_type(type_id)))->as.GenericInstance.args;
-TRY((((effective_namespace).push(types::ResolvedNamespace(TRY(ByteString::from_utf8("Set"sv)),JaktInternal::OptionalNone(),generic_parameters)))));
+TRY((((effective_namespace).push(types::ResolvedNamespace((ByteString::must_from_utf8("Set"sv)),JaktInternal::OptionalNone(),generic_parameters)))));
 }
 else {
-TRY((((*this).error(TRY(ByteString::from_utf8("Attempted to call a prelude function  on a non-generic set"sv)),((this_argument).span)))));
+TRY((((*this).error((ByteString::must_from_utf8("Attempted to call a prelude function  on a non-generic set"sv)),((this_argument).span)))));
 return Error::__jakt_from_string_literal((StringView::from_string_literal("Invalid type"sv)));
 }
 
@@ -10786,20 +10786,20 @@ return JaktInternal::ExplicitValue<void>();
 case 25 /* OptionalNone */: {
 {
 JaktInternal::DynamicArray<ids::TypeId> const generic_parameters = (TRY((DynamicArray<ids::TypeId>::create_with({}))));
-TRY((((effective_namespace).push(types::ResolvedNamespace(TRY(ByteString::from_utf8("Optional"sv)),JaktInternal::OptionalNone(),generic_parameters)))));
+TRY((((effective_namespace).push(types::ResolvedNamespace((ByteString::must_from_utf8("Optional"sv)),JaktInternal::OptionalNone(),generic_parameters)))));
 }
 return JaktInternal::ExplicitValue<void>();
 };/*case end*/
 case 24 /* OptionalSome */: {
 {
 JaktInternal::DynamicArray<ids::TypeId> const generic_parameters = (TRY((DynamicArray<ids::TypeId>::create_with({}))));
-TRY((((effective_namespace).push(types::ResolvedNamespace(TRY(ByteString::from_utf8("Optional"sv)),JaktInternal::OptionalNone(),generic_parameters)))));
+TRY((((effective_namespace).push(types::ResolvedNamespace((ByteString::must_from_utf8("Optional"sv)),JaktInternal::OptionalNone(),generic_parameters)))));
 }
 return JaktInternal::ExplicitValue<void>();
 };/*case end*/
 default: {
 {
-TRY((((*this).error(TRY(ByteString::from_utf8("Attempted to call an instance method on a non-struct/enum type"sv)),((this_argument).span)))));
+TRY((((*this).error((ByteString::must_from_utf8("Attempted to call an instance method on a non-struct/enum type"sv)),((this_argument).span)))));
 return Error::__jakt_from_string_literal((StringView::from_string_literal("Invalid type"sv)));
 }
 return JaktInternal::ExplicitValue<void>();
@@ -10855,7 +10855,7 @@ return interpreter::StatementResult::Break();
 case 2 /* Yield */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Yield;types::Value const& expr = __jakt_match_value.value;
 {
-utility::panic(TRY(ByteString::from_utf8("Invalid control flow"sv)));
+utility::panic((ByteString::must_from_utf8("Invalid control flow"sv)));
 }
 };/*case end*/
 default: VERIFY_NOT_REACHED();}/*switch end*/
@@ -10920,7 +10920,7 @@ return interpreter::StatementResult::Break();
 case 2 /* Yield */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Yield;types::Value const& expr = __jakt_match_value.value;
 {
-utility::panic(TRY(ByteString::from_utf8("Invalid control flow"sv)));
+utility::panic((ByteString::must_from_utf8("Invalid control flow"sv)));
 }
 };/*case end*/
 default: VERIFY_NOT_REACHED();}/*switch end*/
@@ -11014,7 +11014,7 @@ return interpreter::StatementResult::Break();
 case 2 /* Yield */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Yield;types::Value const& expr = __jakt_match_value.value;
 {
-utility::panic(TRY(ByteString::from_utf8("Invalid control flow"sv)));
+utility::panic((ByteString::must_from_utf8("Invalid control flow"sv)));
 }
 };/*case end*/
 default: VERIFY_NOT_REACHED();}/*switch end*/
@@ -11025,7 +11025,7 @@ default: VERIFY_NOT_REACHED();}/*switch end*/
     _jakt_value.release_value();
 });
 if (((((value).impl))->__jakt_init_index() == 25 /* OptionalNone */)){
-TRY((((*this).error(TRY(ByteString::from_utf8("Attempted to unwrap an optional value that was None"sv)),((value).span)))));
+TRY((((*this).error((ByteString::must_from_utf8("Attempted to unwrap an optional value that was None"sv)),((value).span)))));
 return Error::__jakt_from_string_literal((StringView::from_string_literal("Invalid type"sv)));
 }
 __jakt_var_354 = ({
@@ -11038,7 +11038,7 @@ return JaktInternal::ExplicitValue(interpreter::StatementResult::JustValue(value
 };/*case end*/
 default: {
 {
-TRY((((*this).error(TRY(ByteString::from_utf8("Invalid type for unwrap"sv)),((value).span)))));
+TRY((((*this).error((ByteString::must_from_utf8("Invalid type for unwrap"sv)),((value).span)))));
 return Error::__jakt_from_string_literal((StringView::from_string_literal("Invalid type"sv)));
 }
 };/*case end*/
@@ -11105,7 +11105,7 @@ return interpreter::StatementResult::Break();
 case 2 /* Yield */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Yield;types::Value const& expr = __jakt_match_value.value;
 {
-utility::panic(TRY(ByteString::from_utf8("Invalid control flow"sv)));
+utility::panic((ByteString::must_from_utf8("Invalid control flow"sv)));
 }
 };/*case end*/
 default: VERIFY_NOT_REACHED();}/*switch end*/
@@ -11148,7 +11148,7 @@ return interpreter::StatementResult::Break();
 case 2 /* Yield */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Yield;types::Value const& expr = __jakt_match_value.value;
 {
-utility::panic(TRY(ByteString::from_utf8("Invalid control flow"sv)));
+utility::panic((ByteString::must_from_utf8("Invalid control flow"sv)));
 }
 };/*case end*/
 default: VERIFY_NOT_REACHED();}/*switch end*/
@@ -11207,7 +11207,7 @@ return JaktInternal::ExplicitValue((infallible_integer_cast<u64>((x))));
 };/*case end*/
 default: {
 {
-utility::panic(TRY(ByteString::from_utf8("Invalid type for repeat"sv)));
+utility::panic((ByteString::must_from_utf8("Invalid type for repeat"sv)));
 }
 };/*case end*/
 }/*switch end*/
@@ -11238,7 +11238,7 @@ __jakt_label_342:; __jakt_var_356.release_value(); }));
 };/*case end*/
 default: {
 {
-TRY((((*this).error(TRY(ByteString::from_utf8("Invalid or unsupported indexed expression"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("Invalid or unsupported indexed expression"sv)),span))));
 return Error::__jakt_from_string_literal((StringView::from_string_literal("Invalid type"sv)));
 }
 };/*case end*/
@@ -11295,7 +11295,7 @@ return interpreter::StatementResult::Break();
 case 2 /* Yield */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Yield;types::Value const& expr = __jakt_match_value.value;
 {
-utility::panic(TRY(ByteString::from_utf8("Invalid control flow"sv)));
+utility::panic((ByteString::must_from_utf8("Invalid control flow"sv)));
 }
 };/*case end*/
 default: VERIFY_NOT_REACHED();}/*switch end*/
@@ -11336,7 +11336,7 @@ break;
 }
 
 if ((!(((found_index).has_value())))){
-TRY((((*this).error(TRY(ByteString::from_utf8("Attempted to access a field that does not exist"sv)),((value).span)))));
+TRY((((*this).error((ByteString::must_from_utf8("Attempted to access a field that does not exist"sv)),((value).span)))));
 return Error::__jakt_from_string_literal((StringView::from_string_literal("Invalid type"sv)));
 }
 __jakt_var_358 = interpreter::StatementResult::JustValue(((fields)[(found_index.value())])); goto __jakt_label_344;
@@ -11371,7 +11371,7 @@ break;
 }
 
 if ((!(((found_index).has_value())))){
-TRY((((*this).error(TRY(ByteString::from_utf8("Attempted to access a field that does not exist"sv)),((value).span)))));
+TRY((((*this).error((ByteString::must_from_utf8("Attempted to access a field that does not exist"sv)),((value).span)))));
 return Error::__jakt_from_string_literal((StringView::from_string_literal("Invalid type"sv)));
 }
 __jakt_var_359 = interpreter::StatementResult::JustValue(((fields)[(found_index.value())])); goto __jakt_label_345;
@@ -11381,7 +11381,7 @@ __jakt_label_345:; __jakt_var_359.release_value(); }));
 };/*case end*/
 default: {
 {
-TRY((((*this).error(TRY(ByteString::from_utf8("Attempted to access a field on a non-struct/enum type"sv)),((value).span)))));
+TRY((((*this).error((ByteString::must_from_utf8("Attempted to access a field on a non-struct/enum type"sv)),((value).span)))));
 return Error::__jakt_from_string_literal((StringView::from_string_literal("Invalid type"sv)));
 }
 };/*case end*/
@@ -11433,7 +11433,7 @@ return interpreter::StatementResult::Break();
 case 2 /* Yield */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Yield;types::Value const& expr = __jakt_match_value.value;
 {
-utility::panic(TRY(ByteString::from_utf8("Invalid control flow"sv)));
+utility::panic((ByteString::must_from_utf8("Invalid control flow"sv)));
 }
 };/*case end*/
 default: VERIFY_NOT_REACHED();}/*switch end*/
@@ -11474,7 +11474,7 @@ break;
 }
 
 if ((!(((found_index).has_value())))){
-TRY((((*this).error(TRY(ByteString::from_utf8("Attempted to access a field that does not exist"sv)),((value).span)))));
+TRY((((*this).error((ByteString::must_from_utf8("Attempted to access a field that does not exist"sv)),((value).span)))));
 return Error::__jakt_from_string_literal((StringView::from_string_literal("Invalid type"sv)));
 }
 __jakt_var_361 = interpreter::StatementResult::JustValue(((fields)[(found_index.value())])); goto __jakt_label_347;
@@ -11484,7 +11484,7 @@ __jakt_label_347:; __jakt_var_361.release_value(); }));
 };/*case end*/
 default: {
 {
-TRY((((*this).error(TRY(ByteString::from_utf8("Attempted to access a field on a non-struct/enum type"sv)),((value).span)))));
+TRY((((*this).error((ByteString::must_from_utf8("Attempted to access a field on a non-struct/enum type"sv)),((value).span)))));
 return Error::__jakt_from_string_literal((StringView::from_string_literal("Invalid type"sv)));
 }
 };/*case end*/
@@ -11552,7 +11552,7 @@ return interpreter::StatementResult::Break();
 case 2 /* Yield */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Yield;types::Value const& expr = __jakt_match_value.value;
 {
-utility::panic(TRY(ByteString::from_utf8("Invalid control flow"sv)));
+utility::panic((ByteString::must_from_utf8("Invalid control flow"sv)));
 }
 };/*case end*/
 default: VERIFY_NOT_REACHED();}/*switch end*/
@@ -11599,7 +11599,7 @@ return interpreter::StatementResult::Break();
 case 2 /* Yield */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Yield;types::Value const& expr = __jakt_match_value.value;
 {
-utility::panic(TRY(ByteString::from_utf8("Invalid control flow"sv)));
+utility::panic((ByteString::must_from_utf8("Invalid control flow"sv)));
 }
 };/*case end*/
 default: VERIFY_NOT_REACHED();}/*switch end*/
@@ -11703,7 +11703,7 @@ case 24 /* Struct */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Struct;ids::StructId const& struct_id = __jakt_match_value.value;
 return JaktInternal::ExplicitValue(({ Optional<ids::FunctionId> __jakt_var_364; {
 NonnullRefPtr<types::Scope> const scope = TRY((((((*this).program))->get_scope(((((((*this).program))->get_struct(struct_id))).scope_id)))));
-JaktInternal::Optional<JaktInternal::DynamicArray<ids::FunctionId>> const overloads = ((((scope)->functions)).get(TRY(ByteString::from_utf8("from_string_literal"sv))));
+JaktInternal::Optional<JaktInternal::DynamicArray<ids::FunctionId>> const overloads = ((((scope)->functions)).get((ByteString::must_from_utf8("from_string_literal"sv))));
 if ((!(((overloads).has_value())))){
 utility::panic(TRY((__jakt_format((StringView::from_string_literal("Failed to find a from_string_literal overload in {}"sv)),TRY((((((*this).program))->type_name(((val).type_id),false))))))));
 }
@@ -11716,7 +11716,7 @@ case 20 /* GenericInstance */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.GenericInstance;ids::StructId const& struct_id = __jakt_match_value.id;
 return JaktInternal::ExplicitValue(({ Optional<ids::FunctionId> __jakt_var_365; {
 NonnullRefPtr<types::Scope> const scope = TRY((((((*this).program))->get_scope(((((((*this).program))->get_struct(struct_id))).scope_id)))));
-JaktInternal::Optional<JaktInternal::DynamicArray<ids::FunctionId>> const overloads = ((((scope)->functions)).get(TRY(ByteString::from_utf8("from_string_literal"sv))));
+JaktInternal::Optional<JaktInternal::DynamicArray<ids::FunctionId>> const overloads = ((((scope)->functions)).get((ByteString::must_from_utf8("from_string_literal"sv))));
 if ((!(((overloads).has_value())))){
 utility::panic(TRY((__jakt_format((StringView::from_string_literal("Failed to find a from_string_literal overload in {}"sv)),TRY((((((*this).program))->type_name(((val).type_id),false))))))));
 }
@@ -11729,9 +11729,9 @@ case 25 /* Enum */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Enum;ids::EnumId const& enum_id = __jakt_match_value.value;
 return JaktInternal::ExplicitValue(({ Optional<ids::FunctionId> __jakt_var_366; {
 NonnullRefPtr<types::Scope> const scope = TRY((((((*this).program))->get_scope(((((((*this).program))->get_enum(enum_id))).scope_id)))));
-JaktInternal::Optional<JaktInternal::DynamicArray<ids::FunctionId>> const overloads = ((((scope)->functions)).get(TRY(ByteString::from_utf8("from_string_literal"sv))));
+JaktInternal::Optional<JaktInternal::DynamicArray<ids::FunctionId>> const overloads = ((((scope)->functions)).get((ByteString::must_from_utf8("from_string_literal"sv))));
 if ((!(((overloads).has_value())))){
-utility::panic(TRY(ByteString::from_utf8("Failed to find a from_string_literal overload"sv)));
+utility::panic((ByteString::must_from_utf8("Failed to find a from_string_literal overload"sv)));
 }
 __jakt_var_366 = ((((overloads.value())).first()).value()); goto __jakt_label_352;
 
@@ -11742,9 +11742,9 @@ case 21 /* GenericEnumInstance */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.GenericEnumInstance;ids::EnumId const& enum_id = __jakt_match_value.id;
 return JaktInternal::ExplicitValue(({ Optional<ids::FunctionId> __jakt_var_367; {
 NonnullRefPtr<types::Scope> const scope = TRY((((((*this).program))->get_scope(((((((*this).program))->get_enum(enum_id))).scope_id)))));
-JaktInternal::Optional<JaktInternal::DynamicArray<ids::FunctionId>> const overloads = ((((scope)->functions)).get(TRY(ByteString::from_utf8("from_string_literal"sv))));
+JaktInternal::Optional<JaktInternal::DynamicArray<ids::FunctionId>> const overloads = ((((scope)->functions)).get((ByteString::must_from_utf8("from_string_literal"sv))));
 if ((!(((overloads).has_value())))){
-utility::panic(TRY(ByteString::from_utf8("Failed to find a from_string_literal overload"sv)));
+utility::panic((ByteString::must_from_utf8("Failed to find a from_string_literal overload"sv)));
 }
 __jakt_var_367 = ((((overloads.value())).first()).value()); goto __jakt_label_353;
 
@@ -11807,7 +11807,7 @@ return JaktInternal::ExplicitValue(({ Optional<interpreter::StatementResult> __j
 DeprecatedStringCodePointIterator code_points = ((val).code_points());
 JaktInternal::Optional<u32> const code_point = ((code_points).next());
 if ((!(((code_point).has_value())))){
-TRY((((*this).error(TRY(ByteString::from_utf8("Invalid character constant"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("Invalid character constant"sv)),span))));
 return Error::__jakt_from_string_literal((StringView::from_string_literal("Invalid character constant"sv)));
 }
 __jakt_var_368 = interpreter::StatementResult::JustValue(types::Value(TRY((types::ValueImpl::U32((code_point.value())))),span)); goto __jakt_label_354;
@@ -11885,7 +11885,7 @@ return JaktInternal::ExplicitValue((infallible_integer_cast<size_t>((x))));
 };/*case end*/
 default: {
 {
-utility::panic(TRY(ByteString::from_utf8("Invalid type for repeat"sv)));
+utility::panic((ByteString::must_from_utf8("Invalid type for repeat"sv)));
 }
 };/*case end*/
 }/*switch end*/
@@ -11909,7 +11909,7 @@ return interpreter::StatementResult::Break();
 case 2 /* Yield */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Yield;types::Value const& expr = __jakt_match_value.value;
 {
-utility::panic(TRY(ByteString::from_utf8("Invalid control flow"sv)));
+utility::panic((ByteString::must_from_utf8("Invalid control flow"sv)));
 }
 };/*case end*/
 default: VERIFY_NOT_REACHED();}/*switch end*/
@@ -11952,7 +11952,7 @@ return interpreter::StatementResult::Break();
 case 2 /* Yield */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Yield;types::Value const& expr = __jakt_match_value.value;
 {
-utility::panic(TRY(ByteString::from_utf8("Invalid control flow"sv)));
+utility::panic((ByteString::must_from_utf8("Invalid control flow"sv)));
 }
 };/*case end*/
 default: VERIFY_NOT_REACHED();}/*switch end*/
@@ -12012,7 +12012,7 @@ return interpreter::StatementResult::Break();
 case 2 /* Yield */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Yield;types::Value const& expr = __jakt_match_value.value;
 {
-utility::panic(TRY(ByteString::from_utf8("Invalid control flow"sv)));
+utility::panic((ByteString::must_from_utf8("Invalid control flow"sv)));
 }
 };/*case end*/
 default: VERIFY_NOT_REACHED();}/*switch end*/
@@ -12079,7 +12079,7 @@ return interpreter::StatementResult::Break();
 };/*case end*/
 case 2 /* Yield */: {
 {
-utility::panic(TRY(ByteString::from_utf8("Invalid control flow"sv)));
+utility::panic((ByteString::must_from_utf8("Invalid control flow"sv)));
 }
 };/*case end*/
 default: VERIFY_NOT_REACHED();}/*switch end*/
@@ -12102,7 +12102,7 @@ __jakt_label_358:; __jakt_var_372.release_value(); }));
 }
 else {
 {
-utility::panic(TRY(ByteString::from_utf8("expected tuple"sv)));
+utility::panic((ByteString::must_from_utf8("expected tuple"sv)));
 }
 }
 }());
@@ -12152,7 +12152,7 @@ return interpreter::StatementResult::Break();
 };/*case end*/
 case 2 /* Yield */: {
 {
-utility::panic(TRY(ByteString::from_utf8("Invalid control flow"sv)));
+utility::panic((ByteString::must_from_utf8("Invalid control flow"sv)));
 }
 };/*case end*/
 default: VERIFY_NOT_REACHED();}/*switch end*/
@@ -12216,7 +12216,7 @@ return JaktInternal::ExplicitValue<void>();
 case 2 /* ClassInstance */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.ClassInstance;utility::Span const& marker_span = __jakt_match_value.marker_span;
 {
-TRY((((*this).error(TRY(ByteString::from_utf8("Value matches are not allowed on enums"sv)),marker_span))));
+TRY((((*this).error((ByteString::must_from_utf8("Value matches are not allowed on enums"sv)),marker_span))));
 return Error::__jakt_from_string_literal((StringView::from_string_literal("Invalid type"sv)));
 }
 return JaktInternal::ExplicitValue<void>();
@@ -12224,7 +12224,7 @@ return JaktInternal::ExplicitValue<void>();
 case 1 /* Expression */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Expression;utility::Span const& marker_span = __jakt_match_value.marker_span;
 {
-TRY((((*this).error(TRY(ByteString::from_utf8("Value matches are not allowed on enums"sv)),marker_span))));
+TRY((((*this).error((ByteString::must_from_utf8("Value matches are not allowed on enums"sv)),marker_span))));
 return Error::__jakt_from_string_literal((StringView::from_string_literal("Invalid type"sv)));
 }
 return JaktInternal::ExplicitValue<void>();
@@ -12256,7 +12256,7 @@ default: VERIFY_NOT_REACHED();}/*switch end*/
 }
 
 if (((!(((catch_all_case).has_value()))) && (!(((found_body).has_value()))))){
-TRY((((*this).error(TRY(ByteString::from_utf8("Match is not exhaustive"sv)),(span.value())))));
+TRY((((*this).error((ByteString::must_from_utf8("Match is not exhaustive"sv)),(span.value())))));
 return Error::__jakt_from_string_literal((StringView::from_string_literal("Invalid type"sv)));
 }
 (found_body = found_body.value_or_lazy_evaluated([&] { return (catch_all_case.value()); }));
@@ -12496,7 +12496,7 @@ return interpreter::StatementResult::Break();
 };/*case end*/
 case 2 /* Yield */: {
 {
-utility::panic(TRY(ByteString::from_utf8("Invalid control flow"sv)));
+utility::panic((ByteString::must_from_utf8("Invalid control flow"sv)));
 }
 };/*case end*/
 default: VERIFY_NOT_REACHED();}/*switch end*/
@@ -12531,7 +12531,7 @@ return JaktInternal::ExplicitValue<void>();
 case 2 /* ClassInstance */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.ClassInstance;utility::Span const& marker_span = __jakt_match_value.marker_span;
 {
-TRY((((*this).error(TRY(ByteString::from_utf8("Class instance matches are not implemented yet"sv)),marker_span))));
+TRY((((*this).error((ByteString::must_from_utf8("Class instance matches are not implemented yet"sv)),marker_span))));
 return Error::__jakt_from_string_literal((StringView::from_string_literal("Invalid type"sv)));
 }
 return JaktInternal::ExplicitValue<void>();
@@ -12709,7 +12709,7 @@ return interpreter::StatementResult::Break();
 };/*case end*/
 case 2 /* Yield */: {
 {
-utility::panic(TRY(ByteString::from_utf8("Invalid control flow"sv)));
+utility::panic((ByteString::must_from_utf8("Invalid control flow"sv)));
 }
 };/*case end*/
 default: VERIFY_NOT_REACHED();}/*switch end*/
@@ -12861,7 +12861,7 @@ return interpreter::StatementResult::Break();
 };/*case end*/
 case 2 /* Yield */: {
 {
-utility::panic(TRY(ByteString::from_utf8("Invalid control flow"sv)));
+utility::panic((ByteString::must_from_utf8("Invalid control flow"sv)));
 }
 };/*case end*/
 default: VERIFY_NOT_REACHED();}/*switch end*/
@@ -12934,7 +12934,7 @@ return interpreter::StatementResult::Break();
 case 2 /* Yield */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Yield;types::Value const& expr = __jakt_match_value.value;
 {
-utility::panic(TRY(ByteString::from_utf8("Invalid control flow"sv)));
+utility::panic((ByteString::must_from_utf8("Invalid control flow"sv)));
 }
 };/*case end*/
 default: VERIFY_NOT_REACHED();}/*switch end*/
@@ -13169,7 +13169,7 @@ return JaktInternal::ExplicitValue<void>();
 };/*case end*/
 case 2 /* Yield */: {
 {
-utility::panic(TRY(ByteString::from_utf8("Invalid control flow"sv)));
+utility::panic((ByteString::must_from_utf8("Invalid control flow"sv)));
 }
 return JaktInternal::ExplicitValue<void>();
 };/*case end*/
@@ -18584,7 +18584,7 @@ return Error::__jakt_from_string_literal((StringView::from_string_literal("Not y
 
 ErrorOr<ids::TypeId> interpreter::Interpreter::array_type_of_struct(ids::StructId const struct_id) {
 {
-ids::StructId const array_struct_id = TRY((((((*this).program))->find_struct_in_prelude(TRY(ByteString::from_utf8("Array"sv))))));
+ids::StructId const array_struct_id = TRY((((((*this).program))->find_struct_in_prelude((ByteString::must_from_utf8("Array"sv))))));
 NonnullRefPtr<typename types::Type> const type = TRY((types::Type::GenericInstance(parser::CheckedQualifiers(false),array_struct_id,(TRY((DynamicArray<ids::TypeId>::create_with({((((((*this).program))->get_struct(struct_id))).type_id)})))))));
 return TRY((((*this).find_or_add_type_id(type))));
 }
@@ -18600,7 +18600,7 @@ ErrorOr<JaktInternal::DynamicArray<types::Value>> interpreter::Interpreter::refl
 {
 ids::StructId const field_struct_id = ({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<ids::StructId, ErrorOr<JaktInternal::DynamicArray<types::Value>>>{
-auto&& __jakt_match_variant = TRY((((((*this).program))->find_reflected_primitive(TRY(ByteString::from_utf8("Field"sv))))));
+auto&& __jakt_match_variant = TRY((((((*this).program))->find_reflected_primitive((ByteString::must_from_utf8("Field"sv))))));
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 0 /* Struct */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Struct;ids::StructId const& id = __jakt_match_value.value;
@@ -18608,7 +18608,7 @@ return JaktInternal::ExplicitValue(id);
 };/*case end*/
 default: {
 {
-utility::panic(TRY(ByteString::from_utf8("Expected Field to be a struct"sv)));
+utility::panic((ByteString::must_from_utf8("Expected Field to be a struct"sv)));
 }
 };/*case end*/
 }/*switch end*/
@@ -18618,10 +18618,10 @@ utility::panic(TRY(ByteString::from_utf8("Expected Field to be a struct"sv)));
         return _jakt_value.release_return();
     _jakt_value.release_value();
 });
-ids::FunctionId const field_struct_constructor = (TRY((((((*this).program))->find_function_in_scope(((((((*this).program))->get_struct(field_struct_id))).scope_id),TRY(ByteString::from_utf8("Field"sv)),JaktInternal::OptionalNone())))).value());
+ids::FunctionId const field_struct_constructor = (TRY((((((*this).program))->find_function_in_scope(((((((*this).program))->get_struct(field_struct_id))).scope_id),(ByteString::must_from_utf8("Field"sv)),JaktInternal::OptionalNone())))).value());
 ids::EnumId const visibility_enum_id = ({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<ids::EnumId, ErrorOr<JaktInternal::DynamicArray<types::Value>>>{
-auto&& __jakt_match_variant = TRY((((((*this).program))->find_reflected_primitive(TRY(ByteString::from_utf8("Visibility"sv))))));
+auto&& __jakt_match_variant = TRY((((((*this).program))->find_reflected_primitive((ByteString::must_from_utf8("Visibility"sv))))));
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 1 /* Enum */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Enum;ids::EnumId const& id = __jakt_match_value.value;
@@ -18629,7 +18629,7 @@ return JaktInternal::ExplicitValue(id);
 };/*case end*/
 default: {
 {
-utility::panic(TRY(ByteString::from_utf8("Expected Visibility to be an enum"sv)));
+utility::panic((ByteString::must_from_utf8("Expected Visibility to be an enum"sv)));
 }
 };/*case end*/
 }/*switch end*/
@@ -18639,11 +18639,11 @@ utility::panic(TRY(ByteString::from_utf8("Expected Visibility to be an enum"sv))
         return _jakt_value.release_return();
     _jakt_value.release_value();
 });
-ids::FunctionId const visibility_public_constructor = (TRY((((((*this).program))->find_function_in_scope(((((((*this).program))->get_enum(visibility_enum_id))).scope_id),TRY(ByteString::from_utf8("Public"sv)),JaktInternal::OptionalNone())))).value());
-ids::FunctionId const visibility_private_constructor = (TRY((((((*this).program))->find_function_in_scope(((((((*this).program))->get_enum(visibility_enum_id))).scope_id),TRY(ByteString::from_utf8("Private"sv)),JaktInternal::OptionalNone())))).value());
+ids::FunctionId const visibility_public_constructor = (TRY((((((*this).program))->find_function_in_scope(((((((*this).program))->get_enum(visibility_enum_id))).scope_id),(ByteString::must_from_utf8("Public"sv)),JaktInternal::OptionalNone())))).value());
+ids::FunctionId const visibility_private_constructor = (TRY((((((*this).program))->find_function_in_scope(((((((*this).program))->get_enum(visibility_enum_id))).scope_id),(ByteString::must_from_utf8("Private"sv)),JaktInternal::OptionalNone())))).value());
 ids::StructId const variable_declaration_struct_id = ({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<ids::StructId, ErrorOr<JaktInternal::DynamicArray<types::Value>>>{
-auto&& __jakt_match_variant = TRY((((((*this).program))->find_reflected_primitive(TRY(ByteString::from_utf8("VariableDeclaration"sv))))));
+auto&& __jakt_match_variant = TRY((((((*this).program))->find_reflected_primitive((ByteString::must_from_utf8("VariableDeclaration"sv))))));
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 0 /* Struct */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Struct;ids::StructId const& id = __jakt_match_value.value;
@@ -18651,7 +18651,7 @@ return JaktInternal::ExplicitValue(id);
 };/*case end*/
 default: {
 {
-utility::panic(TRY(ByteString::from_utf8("Expected VariableDeclaration to be a struct"sv)));
+utility::panic((ByteString::must_from_utf8("Expected VariableDeclaration to be a struct"sv)));
 }
 };/*case end*/
 }/*switch end*/
@@ -18661,7 +18661,7 @@ utility::panic(TRY(ByteString::from_utf8("Expected VariableDeclaration to be a s
         return _jakt_value.release_return();
     _jakt_value.release_value();
 });
-ids::FunctionId const variable_declaration_struct_constructor = (TRY((((((*this).program))->find_function_in_scope(((((((*this).program))->get_struct(variable_declaration_struct_id))).scope_id),TRY(ByteString::from_utf8("VariableDeclaration"sv)),JaktInternal::OptionalNone())))).value());
+ids::FunctionId const variable_declaration_struct_constructor = (TRY((((((*this).program))->find_function_in_scope(((((((*this).program))->get_struct(variable_declaration_struct_id))).scope_id),(ByteString::must_from_utf8("VariableDeclaration"sv)),JaktInternal::OptionalNone())))).value());
 JaktInternal::DynamicArray<types::Value> record_type_fields = (TRY((DynamicArray<types::Value>::create_with({}))));
 {
 JaktInternal::ArrayIterator<ids::VarId> _magic = ((fields).iterator());
@@ -18686,7 +18686,7 @@ return JaktInternal::ExplicitValue(visibility_private_constructor);
 };/*case end*/
 default: {
 {
-utility::panic(TRY(ByteString::from_utf8("Not implemented"sv)));
+utility::panic((ByteString::must_from_utf8("Not implemented"sv)));
 }
 };/*case end*/
 }/*switch end*/
@@ -18796,7 +18796,7 @@ return JaktInternal::ExplicitValue<void>();
 };/*case end*/
 case 2 /* Yield */: {
 {
-utility::panic(TRY(ByteString::from_utf8("Invalid control flow"sv)));
+utility::panic((ByteString::must_from_utf8("Invalid control flow"sv)));
 }
 return JaktInternal::ExplicitValue<void>();
 };/*case end*/
@@ -18858,7 +18858,7 @@ return JaktInternal::ExplicitValue<void>();
 };/*case end*/
 case 2 /* Yield */: {
 {
-utility::panic(TRY(ByteString::from_utf8("Invalid control flow"sv)));
+utility::panic((ByteString::must_from_utf8("Invalid control flow"sv)));
 }
 return JaktInternal::ExplicitValue<void>();
 };/*case end*/
@@ -18875,7 +18875,7 @@ default: VERIFY_NOT_REACHED();}/*switch end*/
 });
 }
 else {
-utility::panic(TRY(ByteString::from_utf8("expected vardecl"sv)));
+utility::panic((ByteString::must_from_utf8("expected vardecl"sv)));
 }
 
 }
@@ -18885,7 +18885,7 @@ utility::panic(TRY(ByteString::from_utf8("expected vardecl"sv)));
 
 }
 else {
-utility::panic(TRY(ByteString::from_utf8("expected vardecl"sv)));
+utility::panic((ByteString::must_from_utf8("expected vardecl"sv)));
 }
 
 }
@@ -18943,7 +18943,7 @@ return JaktInternal::ExplicitValue<void>();
 };/*case end*/
 case 2 /* Yield */: {
 {
-utility::panic(TRY(ByteString::from_utf8("Invalid control flow"sv)));
+utility::panic((ByteString::must_from_utf8("Invalid control flow"sv)));
 }
 return JaktInternal::ExplicitValue<void>();
 };/*case end*/
@@ -19015,7 +19015,7 @@ return interpreter::StatementResult::Break();
 };/*case end*/
 case 2 /* Yield */: {
 {
-utility::panic(TRY(ByteString::from_utf8("Invalid control flow"sv)));
+utility::panic((ByteString::must_from_utf8("Invalid control flow"sv)));
 }
 };/*case end*/
 default: VERIFY_NOT_REACHED();}/*switch end*/
@@ -19078,7 +19078,7 @@ return JaktInternal::ExplicitValue(interpreter::StatementResult::Break());
 };/*case end*/
 case 2 /* Yield */: {
 {
-utility::panic(TRY(ByteString::from_utf8("Invalid control flow"sv)));
+utility::panic((ByteString::must_from_utf8("Invalid control flow"sv)));
 }
 };/*case end*/
 default: VERIFY_NOT_REACHED();}/*switch end*/
@@ -19146,7 +19146,7 @@ return JaktInternal::ExplicitValue<void>();
 };/*case end*/
 case 2 /* Yield */: {
 {
-utility::panic(TRY(ByteString::from_utf8("Invalid control flow"sv)));
+utility::panic((ByteString::must_from_utf8("Invalid control flow"sv)));
 }
 return JaktInternal::ExplicitValue<void>();
 };/*case end*/
@@ -19215,7 +19215,7 @@ return JaktInternal::ExplicitValue<void>();
 };/*case end*/
 case 2 /* Yield */: {
 {
-utility::panic(TRY(ByteString::from_utf8("Invalid control flow"sv)));
+utility::panic((ByteString::must_from_utf8("Invalid control flow"sv)));
 }
 return JaktInternal::ExplicitValue<void>();
 };/*case end*/
@@ -19267,7 +19267,7 @@ return JaktInternal::ExplicitValue<void>();
 };/*case end*/
 case 2 /* Yield */: {
 {
-utility::panic(TRY(ByteString::from_utf8("Invalid control flow"sv)));
+utility::panic((ByteString::must_from_utf8("Invalid control flow"sv)));
 }
 return JaktInternal::ExplicitValue<void>();
 };/*case end*/
@@ -19314,7 +19314,7 @@ return JaktInternal::ExplicitValue(interpreter::StatementResult::Break());
 };/*case end*/
 case 2 /* Yield */: {
 {
-utility::panic(TRY(ByteString::from_utf8("Invalid control flow"sv)));
+utility::panic((ByteString::must_from_utf8("Invalid control flow"sv)));
 }
 };/*case end*/
 default: VERIFY_NOT_REACHED();}/*switch end*/
@@ -19382,7 +19382,7 @@ return JaktInternal::ExplicitValue<void>();
 };/*case end*/
 case 2 /* Yield */: {
 {
-utility::panic(TRY(ByteString::from_utf8("Invalid control flow"sv)));
+utility::panic((ByteString::must_from_utf8("Invalid control flow"sv)));
 }
 return JaktInternal::ExplicitValue<void>();
 };/*case end*/
@@ -19435,7 +19435,7 @@ return JaktInternal::ExplicitValue<void>();
 };/*case end*/
 case 2 /* Yield */: {
 {
-utility::panic(TRY(ByteString::from_utf8("Invalid control flow"sv)));
+utility::panic((ByteString::must_from_utf8("Invalid control flow"sv)));
 }
 return JaktInternal::ExplicitValue<void>();
 };/*case end*/
@@ -19449,11 +19449,11 @@ default: VERIFY_NOT_REACHED();}/*switch end*/
 };/*case end*/
 case 13 /* InlineCpp */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.InlineCpp;utility::Span const& span = __jakt_match_value.span;
-return (TRY((((*this).error(TRY(ByteString::from_utf8("Cannot run inline cpp at compile time"sv)),span))))), JaktInternal::ExplicitValue<void>();
+return (TRY((((*this).error((ByteString::must_from_utf8("Cannot run inline cpp at compile time"sv)),span))))), JaktInternal::ExplicitValue<void>();
 };/*case end*/
 case 14 /* Garbage */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Garbage;utility::Span const& span = __jakt_match_value.value;
-return (TRY((((*this).error(TRY(ByteString::from_utf8("Cannot run invalid statements at compile time"sv)),span))))), JaktInternal::ExplicitValue<void>();
+return (TRY((((*this).error((ByteString::must_from_utf8("Cannot run invalid statements at compile time"sv)),span))))), JaktInternal::ExplicitValue<void>();
 };/*case end*/
 default: VERIFY_NOT_REACHED();}/*switch end*/
 }()
@@ -19470,7 +19470,7 @@ ErrorOr<JaktInternal::DynamicArray<types::Value>> interpreter::Interpreter::refl
 {
 ids::EnumId const sum_enum_variant_enum_id = ({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<ids::EnumId, ErrorOr<JaktInternal::DynamicArray<types::Value>>>{
-auto&& __jakt_match_variant = TRY((((((*this).program))->find_reflected_primitive(TRY(ByteString::from_utf8("SumEnumVariant"sv))))));
+auto&& __jakt_match_variant = TRY((((((*this).program))->find_reflected_primitive((ByteString::must_from_utf8("SumEnumVariant"sv))))));
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 1 /* Enum */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Enum;ids::EnumId const& id = __jakt_match_value.value;
@@ -19478,7 +19478,7 @@ return JaktInternal::ExplicitValue(id);
 };/*case end*/
 default: {
 {
-utility::panic(TRY(ByteString::from_utf8("Expected SumEnumVariant to be an enum"sv)));
+utility::panic((ByteString::must_from_utf8("Expected SumEnumVariant to be an enum"sv)));
 }
 };/*case end*/
 }/*switch end*/
@@ -19488,12 +19488,12 @@ utility::panic(TRY(ByteString::from_utf8("Expected SumEnumVariant to be an enum"
         return _jakt_value.release_return();
     _jakt_value.release_value();
 });
-ids::FunctionId const typed_variant_constructor = (TRY((((((*this).program))->find_function_in_scope(((((((*this).program))->get_enum(sum_enum_variant_enum_id))).scope_id),TRY(ByteString::from_utf8("Typed"sv)),JaktInternal::OptionalNone())))).value());
-ids::FunctionId const struct_like_variant_constructor = (TRY((((((*this).program))->find_function_in_scope(((((((*this).program))->get_enum(sum_enum_variant_enum_id))).scope_id),TRY(ByteString::from_utf8("StructLike"sv)),JaktInternal::OptionalNone())))).value());
-ids::FunctionId const untyped_variant_constructor = (TRY((((((*this).program))->find_function_in_scope(((((((*this).program))->get_enum(sum_enum_variant_enum_id))).scope_id),TRY(ByteString::from_utf8("Untyped"sv)),JaktInternal::OptionalNone())))).value());
+ids::FunctionId const typed_variant_constructor = (TRY((((((*this).program))->find_function_in_scope(((((((*this).program))->get_enum(sum_enum_variant_enum_id))).scope_id),(ByteString::must_from_utf8("Typed"sv)),JaktInternal::OptionalNone())))).value());
+ids::FunctionId const struct_like_variant_constructor = (TRY((((((*this).program))->find_function_in_scope(((((((*this).program))->get_enum(sum_enum_variant_enum_id))).scope_id),(ByteString::must_from_utf8("StructLike"sv)),JaktInternal::OptionalNone())))).value());
+ids::FunctionId const untyped_variant_constructor = (TRY((((((*this).program))->find_function_in_scope(((((((*this).program))->get_enum(sum_enum_variant_enum_id))).scope_id),(ByteString::must_from_utf8("Untyped"sv)),JaktInternal::OptionalNone())))).value());
 ids::StructId const field_struct_id = ({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<ids::StructId, ErrorOr<JaktInternal::DynamicArray<types::Value>>>{
-auto&& __jakt_match_variant = TRY((((((*this).program))->find_reflected_primitive(TRY(ByteString::from_utf8("Field"sv))))));
+auto&& __jakt_match_variant = TRY((((((*this).program))->find_reflected_primitive((ByteString::must_from_utf8("Field"sv))))));
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 0 /* Struct */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Struct;ids::StructId const& id = __jakt_match_value.value;
@@ -19501,7 +19501,7 @@ return JaktInternal::ExplicitValue(id);
 };/*case end*/
 default: {
 {
-utility::panic(TRY(ByteString::from_utf8("Expected Field to be a struct"sv)));
+utility::panic((ByteString::must_from_utf8("Expected Field to be a struct"sv)));
 }
 };/*case end*/
 }/*switch end*/
@@ -19601,13 +19601,13 @@ return Error::__jakt_from_string_literal((StringView::from_string_literal("Attem
 (is_prelude_function = true);
 }
 if (((TRY((((function_to_run)->is_static())))) == (((this_argument).has_value())))){
-ByteString expected = TRY(ByteString::from_utf8("did not expect"sv));
+ByteString expected = (ByteString::must_from_utf8("did not expect"sv));
 if ((!(TRY((((function_to_run)->is_static())))))){
-(expected = TRY(ByteString::from_utf8("expected"sv)));
+(expected = (ByteString::must_from_utf8("expected"sv)));
 }
-ByteString not_provided = TRY(ByteString::from_utf8(" not"sv));
+ByteString not_provided = (ByteString::must_from_utf8(" not"sv));
 if (((this_argument).has_value())){
-(not_provided = TRY(ByteString::from_utf8(""sv)));
+(not_provided = (ByteString::must_from_utf8(""sv)));
 }
 TRY((((((((*this).compiler))->errors)).push(error::JaktError::Message(TRY((__jakt_format((StringView::from_string_literal("function call {} a this argument, yet one was{} provided"sv)),expected,not_provided))),((function_to_run)->name_span))))));
 return Error::__jakt_from_string_literal((StringView::from_string_literal("Invalid this argument"sv)));
@@ -19630,7 +19630,7 @@ switch(__jakt_match_variant.__jakt_init_index()) {
 case 13 /* JaktString */: {
 {
 JaktInternal::DynamicArray<ids::TypeId> const generic_parameters = (TRY((DynamicArray<ids::TypeId>::create_with({}))));
-TRY((((effective_namespace).push(types::ResolvedNamespace(TRY(ByteString::from_utf8("String"sv)),JaktInternal::OptionalNone(),generic_parameters)))));
+TRY((((effective_namespace).push(types::ResolvedNamespace((ByteString::must_from_utf8("String"sv)),JaktInternal::OptionalNone(),generic_parameters)))));
 }
 return JaktInternal::ExplicitValue<void>();
 };/*case end*/
@@ -19647,7 +19647,7 @@ return JaktInternal::ExplicitValue(args);
 };/*case end*/
 default: {
 {
-TRY((((*this).error(TRY(ByteString::from_utf8("Attempted to call a prelude function  on a non-generic array"sv)),call_span))));
+TRY((((*this).error((ByteString::must_from_utf8("Attempted to call a prelude function  on a non-generic array"sv)),call_span))));
 return Error::__jakt_from_string_literal((StringView::from_string_literal("Invalid type"sv)));
 }
 };/*case end*/
@@ -19658,7 +19658,7 @@ return Error::__jakt_from_string_literal((StringView::from_string_literal("Inval
         return _jakt_value.release_return();
     _jakt_value.release_value();
 });
-TRY((((effective_namespace).push(types::ResolvedNamespace(TRY(ByteString::from_utf8("Array"sv)),JaktInternal::OptionalNone(),generic_parameters)))));
+TRY((((effective_namespace).push(types::ResolvedNamespace((ByteString::must_from_utf8("Array"sv)),JaktInternal::OptionalNone(),generic_parameters)))));
 }
 return JaktInternal::ExplicitValue<void>();
 };/*case end*/
@@ -19675,7 +19675,7 @@ return JaktInternal::ExplicitValue(args);
 };/*case end*/
 default: {
 {
-TRY((((*this).error(TRY(ByteString::from_utf8("Attempted to call a prelude function  on a non-generic dictionary"sv)),call_span))));
+TRY((((*this).error((ByteString::must_from_utf8("Attempted to call a prelude function  on a non-generic dictionary"sv)),call_span))));
 return Error::__jakt_from_string_literal((StringView::from_string_literal("Invalid type"sv)));
 }
 };/*case end*/
@@ -19686,7 +19686,7 @@ return Error::__jakt_from_string_literal((StringView::from_string_literal("Inval
         return _jakt_value.release_return();
     _jakt_value.release_value();
 });
-TRY((((effective_namespace).push(types::ResolvedNamespace(TRY(ByteString::from_utf8("Dictionary"sv)),JaktInternal::OptionalNone(),generic_parameters)))));
+TRY((((effective_namespace).push(types::ResolvedNamespace((ByteString::must_from_utf8("Dictionary"sv)),JaktInternal::OptionalNone(),generic_parameters)))));
 }
 return JaktInternal::ExplicitValue<void>();
 };/*case end*/
@@ -19695,10 +19695,10 @@ auto&& __jakt_match_value = __jakt_match_variant.as.JaktSet;ids::TypeId const& t
 {
 if (((((((*this).program))->get_type(type_id)))->__jakt_init_index() == 20 /* GenericInstance */)){
 JaktInternal::DynamicArray<ids::TypeId> const generic_parameters = (((((*this).program))->get_type(type_id)))->as.GenericInstance.args;
-TRY((((effective_namespace).push(types::ResolvedNamespace(TRY(ByteString::from_utf8("Set"sv)),JaktInternal::OptionalNone(),generic_parameters)))));
+TRY((((effective_namespace).push(types::ResolvedNamespace((ByteString::must_from_utf8("Set"sv)),JaktInternal::OptionalNone(),generic_parameters)))));
 }
 else {
-TRY((((*this).error(TRY(ByteString::from_utf8("Attempted to call a prelude function  on a non-generic set"sv)),call_span))));
+TRY((((*this).error((ByteString::must_from_utf8("Attempted to call a prelude function  on a non-generic set"sv)),call_span))));
 return Error::__jakt_from_string_literal((StringView::from_string_literal("Invalid type"sv)));
 }
 
@@ -19732,20 +19732,20 @@ return JaktInternal::ExplicitValue<void>();
 case 25 /* OptionalNone */: {
 {
 JaktInternal::DynamicArray<ids::TypeId> const generic_parameters = (TRY((DynamicArray<ids::TypeId>::create_with({}))));
-TRY((((effective_namespace).push(types::ResolvedNamespace(TRY(ByteString::from_utf8("Optional"sv)),JaktInternal::OptionalNone(),generic_parameters)))));
+TRY((((effective_namespace).push(types::ResolvedNamespace((ByteString::must_from_utf8("Optional"sv)),JaktInternal::OptionalNone(),generic_parameters)))));
 }
 return JaktInternal::ExplicitValue<void>();
 };/*case end*/
 case 24 /* OptionalSome */: {
 {
 JaktInternal::DynamicArray<ids::TypeId> const generic_parameters = (TRY((DynamicArray<ids::TypeId>::create_with({}))));
-TRY((((effective_namespace).push(types::ResolvedNamespace(TRY(ByteString::from_utf8("Optional"sv)),JaktInternal::OptionalNone(),generic_parameters)))));
+TRY((((effective_namespace).push(types::ResolvedNamespace((ByteString::must_from_utf8("Optional"sv)),JaktInternal::OptionalNone(),generic_parameters)))));
 }
 return JaktInternal::ExplicitValue<void>();
 };/*case end*/
 default: {
 {
-TRY((((*this).error(TRY(ByteString::from_utf8("Attempted to call an instance method on a non-struct/enum type"sv)),call_span))));
+TRY((((*this).error((ByteString::must_from_utf8("Attempted to call an instance method on a non-struct/enum type"sv)),call_span))));
 return Error::__jakt_from_string_literal((StringView::from_string_literal("Invalid type"sv)));
 }
 return JaktInternal::ExplicitValue<void>();
@@ -19781,17 +19781,17 @@ return JaktInternal::ExplicitValue(interpreter::ExecutionResult::Throw(value));
 };/*case end*/
 case 3 /* Continue */: {
 {
-utility::panic(TRY(ByteString::from_utf8("Invalid control flow"sv)));
+utility::panic((ByteString::must_from_utf8("Invalid control flow"sv)));
 }
 };/*case end*/
 case 4 /* Break */: {
 {
-utility::panic(TRY(ByteString::from_utf8("Invalid control flow"sv)));
+utility::panic((ByteString::must_from_utf8("Invalid control flow"sv)));
 }
 };/*case end*/
 case 2 /* Yield */: {
 {
-utility::panic(TRY(ByteString::from_utf8("Invalid control flow"sv)));
+utility::panic((ByteString::must_from_utf8("Invalid control flow"sv)));
 }
 };/*case end*/
 default: VERIFY_NOT_REACHED();}/*switch end*/
@@ -19836,7 +19836,7 @@ TRY(((scope)->bindings).set(param_name, param_value));
 }
 
 if (((this_argument).has_value())){
-TRY((((((scope)->bindings)).set(TRY(ByteString::from_utf8("this"sv)),(this_argument.value())))));
+TRY((((((scope)->bindings)).set((ByteString::must_from_utf8("this"sv)),(this_argument.value())))));
 }
 interpreter::StatementResult const blk = TRY((((*this).execute_block(((function_to_run)->block),scope,call_span))));
 if (((blk).__jakt_init_index() == 5 /* JustValue */)){
@@ -19864,17 +19864,17 @@ return JaktInternal::ExplicitValue(interpreter::ExecutionResult::Throw(value));
 };/*case end*/
 case 3 /* Continue */: {
 {
-utility::panic(TRY(ByteString::from_utf8("Invalid control flow"sv)));
+utility::panic((ByteString::must_from_utf8("Invalid control flow"sv)));
 }
 };/*case end*/
 case 4 /* Break */: {
 {
-utility::panic(TRY(ByteString::from_utf8("Invalid control flow"sv)));
+utility::panic((ByteString::must_from_utf8("Invalid control flow"sv)));
 }
 };/*case end*/
 case 2 /* Yield */: {
 {
-utility::panic(TRY(ByteString::from_utf8("Invalid control flow"sv)));
+utility::panic((ByteString::must_from_utf8("Invalid control flow"sv)));
 }
 };/*case end*/
 default: VERIFY_NOT_REACHED();}/*switch end*/
@@ -19917,7 +19917,7 @@ TRY(((scope)->bindings).set(param_name, param_value));
 }
 
 if (((this_argument).has_value())){
-TRY((((((scope)->bindings)).set(TRY(ByteString::from_utf8("this"sv)),(this_argument.value())))));
+TRY((((((scope)->bindings)).set((ByteString::must_from_utf8("this"sv)),(this_argument.value())))));
 }
 return ({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<interpreter::ExecutionResult, ErrorOr<interpreter::ExecutionResult>>{
@@ -19937,17 +19937,17 @@ return JaktInternal::ExplicitValue(interpreter::ExecutionResult::Throw(value));
 };/*case end*/
 case 3 /* Continue */: {
 {
-utility::panic(TRY(ByteString::from_utf8("Invalid control flow"sv)));
+utility::panic((ByteString::must_from_utf8("Invalid control flow"sv)));
 }
 };/*case end*/
 case 4 /* Break */: {
 {
-utility::panic(TRY(ByteString::from_utf8("Invalid control flow"sv)));
+utility::panic((ByteString::must_from_utf8("Invalid control flow"sv)));
 }
 };/*case end*/
 case 2 /* Yield */: {
 {
-utility::panic(TRY(ByteString::from_utf8("Invalid control flow"sv)));
+utility::panic((ByteString::must_from_utf8("Invalid control flow"sv)));
 }
 };/*case end*/
 default: VERIFY_NOT_REACHED();}/*switch end*/
@@ -19990,7 +19990,7 @@ TRY(((scope)->bindings).set(param_name, param_value));
 }
 
 if (((this_argument).has_value())){
-TRY((((((scope)->bindings)).set(TRY(ByteString::from_utf8("this"sv)),(this_argument.value())))));
+TRY((((((scope)->bindings)).set((ByteString::must_from_utf8("this"sv)),(this_argument.value())))));
 }
 return ({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<interpreter::ExecutionResult, ErrorOr<interpreter::ExecutionResult>>{
@@ -20010,17 +20010,17 @@ return JaktInternal::ExplicitValue(interpreter::ExecutionResult::Throw(value));
 };/*case end*/
 case 3 /* Continue */: {
 {
-utility::panic(TRY(ByteString::from_utf8("Invalid control flow"sv)));
+utility::panic((ByteString::must_from_utf8("Invalid control flow"sv)));
 }
 };/*case end*/
 case 4 /* Break */: {
 {
-utility::panic(TRY(ByteString::from_utf8("Invalid control flow"sv)));
+utility::panic((ByteString::must_from_utf8("Invalid control flow"sv)));
 }
 };/*case end*/
 case 2 /* Yield */: {
 {
-utility::panic(TRY(ByteString::from_utf8("Invalid control flow"sv)));
+utility::panic((ByteString::must_from_utf8("Invalid control flow"sv)));
 }
 };/*case end*/
 default: VERIFY_NOT_REACHED();}/*switch end*/
@@ -20190,7 +20190,7 @@ return TRY((function(block,parent_scope_id,types::SafetyMode::Safe(),JaktInterna
 
 ErrorOr<ids::TypeId> interpreter::Interpreter::tuple_type(JaktInternal::DynamicArray<ids::TypeId> const members) {
 {
-ids::StructId const tuple_struct_id = TRY((((((*this).program))->find_struct_in_prelude(TRY(ByteString::from_utf8("Tuple"sv))))));
+ids::StructId const tuple_struct_id = TRY((((((*this).program))->find_struct_in_prelude((ByteString::must_from_utf8("Tuple"sv))))));
 NonnullRefPtr<typename types::Type> const type = TRY((types::Type::GenericInstance(parser::CheckedQualifiers(false),tuple_struct_id,members)));
 return TRY((((*this).find_or_add_type_id(type))));
 }
@@ -20198,8 +20198,8 @@ return TRY((((*this).find_or_add_type_id(type))));
 
 ErrorOr<types::Value> interpreter::Interpreter::error_value(ByteString const string,utility::Span const span) {
 {
-ids::StructId const struct_id = TRY((((((*this).program))->find_struct_in_prelude(TRY(ByteString::from_utf8("Error"sv))))));
-ids::FunctionId const constructor = (TRY((((((*this).program))->find_function_in_scope(((((((*this).program))->get_struct(struct_id))).scope_id),TRY(ByteString::from_utf8("from_string_literal"sv)),JaktInternal::OptionalNone())))).value());
+ids::StructId const struct_id = TRY((((((*this).program))->find_struct_in_prelude((ByteString::must_from_utf8("Error"sv))))));
+ids::FunctionId const constructor = (TRY((((((*this).program))->find_function_in_scope(((((((*this).program))->get_struct(struct_id))).scope_id),(ByteString::must_from_utf8("from_string_literal"sv)),JaktInternal::OptionalNone())))).value());
 return types::Value(TRY((types::ValueImpl::Struct((TRY((DynamicArray<types::Value>::create_with({TRY((((*this).string_value(string,span))))})))),struct_id,constructor))),span);
 }
 }
@@ -20294,7 +20294,7 @@ ScopeGuard __jakt_var_397([&] {
 NonnullRefPtr<typename types::Type> const type = ((((*this).program))->get_type(mapped_type_id));
 ids::EnumId const reflected_enum_id = ({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<ids::EnumId, ErrorOr<types::Value>>{
-auto&& __jakt_match_variant = TRY((((((*this).program))->find_reflected_primitive(TRY(ByteString::from_utf8("Type"sv))))));
+auto&& __jakt_match_variant = TRY((((((*this).program))->find_reflected_primitive((ByteString::must_from_utf8("Type"sv))))));
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 1 /* Enum */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Enum;ids::EnumId const& id = __jakt_match_value.value;
@@ -20302,7 +20302,7 @@ return JaktInternal::ExplicitValue(id);
 };/*case end*/
 default: {
 {
-utility::panic(TRY(ByteString::from_utf8("Expected Reflect::Type to be an enum"sv)));
+utility::panic((ByteString::must_from_utf8("Expected Reflect::Type to be an enum"sv)));
 }
 };/*case end*/
 }/*switch end*/
@@ -20324,7 +20324,7 @@ case 0 /* Void */: {
 return JaktInternal::ExplicitValue(({ Optional<ids::FunctionId> __jakt_var_398; {
 JaktInternal::Optional<ids::FunctionId> const constructor = TRY((((((*this).program))->find_function_in_scope(((((((*this).program))->get_enum(reflected_enum_id))).scope_id),TRY((((type)->constructor_name()))),JaktInternal::OptionalNone()))));
 if ((!(((constructor).has_value())))){
-TRY((((*this).error(TRY(ByteString::from_utf8("Attempted to access a variant that does not exist"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("Attempted to access a variant that does not exist"sv)),span))));
 return Error::__jakt_from_string_literal((StringView::from_string_literal("Invalid type"sv)));
 }
 __jakt_var_398 = (constructor.value()); goto __jakt_label_374;
@@ -20336,7 +20336,7 @@ case 6 /* I8 */: {
 return JaktInternal::ExplicitValue(({ Optional<ids::FunctionId> __jakt_var_399; {
 JaktInternal::Optional<ids::FunctionId> const constructor = TRY((((((*this).program))->find_function_in_scope(((((((*this).program))->get_enum(reflected_enum_id))).scope_id),TRY((((type)->constructor_name()))),JaktInternal::OptionalNone()))));
 if ((!(((constructor).has_value())))){
-TRY((((*this).error(TRY(ByteString::from_utf8("Attempted to access a variant that does not exist"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("Attempted to access a variant that does not exist"sv)),span))));
 return Error::__jakt_from_string_literal((StringView::from_string_literal("Invalid type"sv)));
 }
 __jakt_var_399 = (constructor.value()); goto __jakt_label_375;
@@ -20348,7 +20348,7 @@ case 7 /* I16 */: {
 return JaktInternal::ExplicitValue(({ Optional<ids::FunctionId> __jakt_var_400; {
 JaktInternal::Optional<ids::FunctionId> const constructor = TRY((((((*this).program))->find_function_in_scope(((((((*this).program))->get_enum(reflected_enum_id))).scope_id),TRY((((type)->constructor_name()))),JaktInternal::OptionalNone()))));
 if ((!(((constructor).has_value())))){
-TRY((((*this).error(TRY(ByteString::from_utf8("Attempted to access a variant that does not exist"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("Attempted to access a variant that does not exist"sv)),span))));
 return Error::__jakt_from_string_literal((StringView::from_string_literal("Invalid type"sv)));
 }
 __jakt_var_400 = (constructor.value()); goto __jakt_label_376;
@@ -20360,7 +20360,7 @@ case 8 /* I32 */: {
 return JaktInternal::ExplicitValue(({ Optional<ids::FunctionId> __jakt_var_401; {
 JaktInternal::Optional<ids::FunctionId> const constructor = TRY((((((*this).program))->find_function_in_scope(((((((*this).program))->get_enum(reflected_enum_id))).scope_id),TRY((((type)->constructor_name()))),JaktInternal::OptionalNone()))));
 if ((!(((constructor).has_value())))){
-TRY((((*this).error(TRY(ByteString::from_utf8("Attempted to access a variant that does not exist"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("Attempted to access a variant that does not exist"sv)),span))));
 return Error::__jakt_from_string_literal((StringView::from_string_literal("Invalid type"sv)));
 }
 __jakt_var_401 = (constructor.value()); goto __jakt_label_377;
@@ -20372,7 +20372,7 @@ case 9 /* I64 */: {
 return JaktInternal::ExplicitValue(({ Optional<ids::FunctionId> __jakt_var_402; {
 JaktInternal::Optional<ids::FunctionId> const constructor = TRY((((((*this).program))->find_function_in_scope(((((((*this).program))->get_enum(reflected_enum_id))).scope_id),TRY((((type)->constructor_name()))),JaktInternal::OptionalNone()))));
 if ((!(((constructor).has_value())))){
-TRY((((*this).error(TRY(ByteString::from_utf8("Attempted to access a variant that does not exist"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("Attempted to access a variant that does not exist"sv)),span))));
 return Error::__jakt_from_string_literal((StringView::from_string_literal("Invalid type"sv)));
 }
 __jakt_var_402 = (constructor.value()); goto __jakt_label_378;
@@ -20384,7 +20384,7 @@ case 2 /* U8 */: {
 return JaktInternal::ExplicitValue(({ Optional<ids::FunctionId> __jakt_var_403; {
 JaktInternal::Optional<ids::FunctionId> const constructor = TRY((((((*this).program))->find_function_in_scope(((((((*this).program))->get_enum(reflected_enum_id))).scope_id),TRY((((type)->constructor_name()))),JaktInternal::OptionalNone()))));
 if ((!(((constructor).has_value())))){
-TRY((((*this).error(TRY(ByteString::from_utf8("Attempted to access a variant that does not exist"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("Attempted to access a variant that does not exist"sv)),span))));
 return Error::__jakt_from_string_literal((StringView::from_string_literal("Invalid type"sv)));
 }
 __jakt_var_403 = (constructor.value()); goto __jakt_label_379;
@@ -20396,7 +20396,7 @@ case 3 /* U16 */: {
 return JaktInternal::ExplicitValue(({ Optional<ids::FunctionId> __jakt_var_404; {
 JaktInternal::Optional<ids::FunctionId> const constructor = TRY((((((*this).program))->find_function_in_scope(((((((*this).program))->get_enum(reflected_enum_id))).scope_id),TRY((((type)->constructor_name()))),JaktInternal::OptionalNone()))));
 if ((!(((constructor).has_value())))){
-TRY((((*this).error(TRY(ByteString::from_utf8("Attempted to access a variant that does not exist"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("Attempted to access a variant that does not exist"sv)),span))));
 return Error::__jakt_from_string_literal((StringView::from_string_literal("Invalid type"sv)));
 }
 __jakt_var_404 = (constructor.value()); goto __jakt_label_380;
@@ -20408,7 +20408,7 @@ case 4 /* U32 */: {
 return JaktInternal::ExplicitValue(({ Optional<ids::FunctionId> __jakt_var_405; {
 JaktInternal::Optional<ids::FunctionId> const constructor = TRY((((((*this).program))->find_function_in_scope(((((((*this).program))->get_enum(reflected_enum_id))).scope_id),TRY((((type)->constructor_name()))),JaktInternal::OptionalNone()))));
 if ((!(((constructor).has_value())))){
-TRY((((*this).error(TRY(ByteString::from_utf8("Attempted to access a variant that does not exist"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("Attempted to access a variant that does not exist"sv)),span))));
 return Error::__jakt_from_string_literal((StringView::from_string_literal("Invalid type"sv)));
 }
 __jakt_var_405 = (constructor.value()); goto __jakt_label_381;
@@ -20420,7 +20420,7 @@ case 5 /* U64 */: {
 return JaktInternal::ExplicitValue(({ Optional<ids::FunctionId> __jakt_var_406; {
 JaktInternal::Optional<ids::FunctionId> const constructor = TRY((((((*this).program))->find_function_in_scope(((((((*this).program))->get_enum(reflected_enum_id))).scope_id),TRY((((type)->constructor_name()))),JaktInternal::OptionalNone()))));
 if ((!(((constructor).has_value())))){
-TRY((((*this).error(TRY(ByteString::from_utf8("Attempted to access a variant that does not exist"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("Attempted to access a variant that does not exist"sv)),span))));
 return Error::__jakt_from_string_literal((StringView::from_string_literal("Invalid type"sv)));
 }
 __jakt_var_406 = (constructor.value()); goto __jakt_label_382;
@@ -20432,7 +20432,7 @@ case 12 /* Usize */: {
 return JaktInternal::ExplicitValue(({ Optional<ids::FunctionId> __jakt_var_407; {
 JaktInternal::Optional<ids::FunctionId> const constructor = TRY((((((*this).program))->find_function_in_scope(((((((*this).program))->get_enum(reflected_enum_id))).scope_id),TRY((((type)->constructor_name()))),JaktInternal::OptionalNone()))));
 if ((!(((constructor).has_value())))){
-TRY((((*this).error(TRY(ByteString::from_utf8("Attempted to access a variant that does not exist"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("Attempted to access a variant that does not exist"sv)),span))));
 return Error::__jakt_from_string_literal((StringView::from_string_literal("Invalid type"sv)));
 }
 __jakt_var_407 = (constructor.value()); goto __jakt_label_383;
@@ -20444,7 +20444,7 @@ case 10 /* F32 */: {
 return JaktInternal::ExplicitValue(({ Optional<ids::FunctionId> __jakt_var_408; {
 JaktInternal::Optional<ids::FunctionId> const constructor = TRY((((((*this).program))->find_function_in_scope(((((((*this).program))->get_enum(reflected_enum_id))).scope_id),TRY((((type)->constructor_name()))),JaktInternal::OptionalNone()))));
 if ((!(((constructor).has_value())))){
-TRY((((*this).error(TRY(ByteString::from_utf8("Attempted to access a variant that does not exist"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("Attempted to access a variant that does not exist"sv)),span))));
 return Error::__jakt_from_string_literal((StringView::from_string_literal("Invalid type"sv)));
 }
 __jakt_var_408 = (constructor.value()); goto __jakt_label_384;
@@ -20456,7 +20456,7 @@ case 11 /* F64 */: {
 return JaktInternal::ExplicitValue(({ Optional<ids::FunctionId> __jakt_var_409; {
 JaktInternal::Optional<ids::FunctionId> const constructor = TRY((((((*this).program))->find_function_in_scope(((((((*this).program))->get_enum(reflected_enum_id))).scope_id),TRY((((type)->constructor_name()))),JaktInternal::OptionalNone()))));
 if ((!(((constructor).has_value())))){
-TRY((((*this).error(TRY(ByteString::from_utf8("Attempted to access a variant that does not exist"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("Attempted to access a variant that does not exist"sv)),span))));
 return Error::__jakt_from_string_literal((StringView::from_string_literal("Invalid type"sv)));
 }
 __jakt_var_409 = (constructor.value()); goto __jakt_label_385;
@@ -20468,7 +20468,7 @@ case 13 /* JaktString */: {
 return JaktInternal::ExplicitValue(({ Optional<ids::FunctionId> __jakt_var_410; {
 JaktInternal::Optional<ids::FunctionId> const constructor = TRY((((((*this).program))->find_function_in_scope(((((((*this).program))->get_enum(reflected_enum_id))).scope_id),TRY((((type)->constructor_name()))),JaktInternal::OptionalNone()))));
 if ((!(((constructor).has_value())))){
-TRY((((*this).error(TRY(ByteString::from_utf8("Attempted to access a variant that does not exist"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("Attempted to access a variant that does not exist"sv)),span))));
 return Error::__jakt_from_string_literal((StringView::from_string_literal("Invalid type"sv)));
 }
 __jakt_var_410 = (constructor.value()); goto __jakt_label_386;
@@ -20480,7 +20480,7 @@ case 14 /* CChar */: {
 return JaktInternal::ExplicitValue(({ Optional<ids::FunctionId> __jakt_var_411; {
 JaktInternal::Optional<ids::FunctionId> const constructor = TRY((((((*this).program))->find_function_in_scope(((((((*this).program))->get_enum(reflected_enum_id))).scope_id),TRY((((type)->constructor_name()))),JaktInternal::OptionalNone()))));
 if ((!(((constructor).has_value())))){
-TRY((((*this).error(TRY(ByteString::from_utf8("Attempted to access a variant that does not exist"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("Attempted to access a variant that does not exist"sv)),span))));
 return Error::__jakt_from_string_literal((StringView::from_string_literal("Invalid type"sv)));
 }
 __jakt_var_411 = (constructor.value()); goto __jakt_label_387;
@@ -20492,7 +20492,7 @@ case 15 /* CInt */: {
 return JaktInternal::ExplicitValue(({ Optional<ids::FunctionId> __jakt_var_412; {
 JaktInternal::Optional<ids::FunctionId> const constructor = TRY((((((*this).program))->find_function_in_scope(((((((*this).program))->get_enum(reflected_enum_id))).scope_id),TRY((((type)->constructor_name()))),JaktInternal::OptionalNone()))));
 if ((!(((constructor).has_value())))){
-TRY((((*this).error(TRY(ByteString::from_utf8("Attempted to access a variant that does not exist"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("Attempted to access a variant that does not exist"sv)),span))));
 return Error::__jakt_from_string_literal((StringView::from_string_literal("Invalid type"sv)));
 }
 __jakt_var_412 = (constructor.value()); goto __jakt_label_388;
@@ -20504,7 +20504,7 @@ case 1 /* Bool */: {
 return JaktInternal::ExplicitValue(({ Optional<ids::FunctionId> __jakt_var_413; {
 JaktInternal::Optional<ids::FunctionId> const constructor = TRY((((((*this).program))->find_function_in_scope(((((((*this).program))->get_enum(reflected_enum_id))).scope_id),TRY((((type)->constructor_name()))),JaktInternal::OptionalNone()))));
 if ((!(((constructor).has_value())))){
-TRY((((*this).error(TRY(ByteString::from_utf8("Attempted to access a variant that does not exist"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("Attempted to access a variant that does not exist"sv)),span))));
 return Error::__jakt_from_string_literal((StringView::from_string_literal("Invalid type"sv)));
 }
 __jakt_var_413 = (constructor.value()); goto __jakt_label_389;
@@ -20516,7 +20516,7 @@ case 16 /* Unknown */: {
 return JaktInternal::ExplicitValue(({ Optional<ids::FunctionId> __jakt_var_414; {
 JaktInternal::Optional<ids::FunctionId> const constructor = TRY((((((*this).program))->find_function_in_scope(((((((*this).program))->get_enum(reflected_enum_id))).scope_id),TRY((((type)->constructor_name()))),JaktInternal::OptionalNone()))));
 if ((!(((constructor).has_value())))){
-TRY((((*this).error(TRY(ByteString::from_utf8("Attempted to access a variant that does not exist"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("Attempted to access a variant that does not exist"sv)),span))));
 return Error::__jakt_from_string_literal((StringView::from_string_literal("Invalid type"sv)));
 }
 __jakt_var_414 = (constructor.value()); goto __jakt_label_390;
@@ -20528,7 +20528,7 @@ case 17 /* Never */: {
 return JaktInternal::ExplicitValue(({ Optional<ids::FunctionId> __jakt_var_415; {
 JaktInternal::Optional<ids::FunctionId> const constructor = TRY((((((*this).program))->find_function_in_scope(((((((*this).program))->get_enum(reflected_enum_id))).scope_id),TRY((((type)->constructor_name()))),JaktInternal::OptionalNone()))));
 if ((!(((constructor).has_value())))){
-TRY((((*this).error(TRY(ByteString::from_utf8("Attempted to access a variant that does not exist"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("Attempted to access a variant that does not exist"sv)),span))));
 return Error::__jakt_from_string_literal((StringView::from_string_literal("Invalid type"sv)));
 }
 __jakt_var_415 = (constructor.value()); goto __jakt_label_391;
@@ -20539,9 +20539,9 @@ __jakt_label_391:; __jakt_var_415.release_value(); }));
 case 18 /* TypeVariable */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.TypeVariable;ByteString const& name = __jakt_match_value.name;
 return JaktInternal::ExplicitValue(({ Optional<ids::FunctionId> __jakt_var_416; {
-JaktInternal::Optional<ids::FunctionId> const constructor = TRY((((((*this).program))->find_function_in_scope(((((((*this).program))->get_enum(reflected_enum_id))).scope_id),TRY(ByteString::from_utf8("TypeVariable"sv)),JaktInternal::OptionalNone()))));
+JaktInternal::Optional<ids::FunctionId> const constructor = TRY((((((*this).program))->find_function_in_scope(((((((*this).program))->get_enum(reflected_enum_id))).scope_id),(ByteString::must_from_utf8("TypeVariable"sv)),JaktInternal::OptionalNone()))));
 if ((!(((constructor).has_value())))){
-TRY((((*this).error(TRY(ByteString::from_utf8("Attempted to access a variant that does not exist"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("Attempted to access a variant that does not exist"sv)),span))));
 return Error::__jakt_from_string_literal((StringView::from_string_literal("Invalid type"sv)));
 }
 (fields = (TRY((DynamicArray<types::Value>::create_with({TRY((((*this).string_value(name,span))))})))));
@@ -20584,14 +20584,14 @@ case 20 /* GenericInstance */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.GenericInstance;ids::StructId const& struct_id = __jakt_match_value.id;
 return JaktInternal::ExplicitValue(({ Optional<ids::FunctionId> __jakt_var_420; {
 types::CheckedStruct const subject_struct = ((((*this).program))->get_struct(struct_id));
-JaktInternal::Optional<ids::FunctionId> const constructor = TRY((((((*this).program))->find_function_in_scope(((((((*this).program))->get_enum(reflected_enum_id))).scope_id),TRY(ByteString::from_utf8("StructureOrEnum"sv)),JaktInternal::OptionalNone()))));
+JaktInternal::Optional<ids::FunctionId> const constructor = TRY((((((*this).program))->find_function_in_scope(((((((*this).program))->get_enum(reflected_enum_id))).scope_id),(ByteString::must_from_utf8("StructureOrEnum"sv)),JaktInternal::OptionalNone()))));
 if ((!(((constructor).has_value())))){
-TRY((((*this).error(TRY(ByteString::from_utf8("Attempted to access a variant that does not exist"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("Attempted to access a variant that does not exist"sv)),span))));
 return Error::__jakt_from_string_literal((StringView::from_string_literal("Invalid type"sv)));
 }
 ids::StructId const record_struct_id = ({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<ids::StructId, ErrorOr<types::Value>>{
-auto&& __jakt_match_variant = TRY((((((*this).program))->find_reflected_primitive(TRY(ByteString::from_utf8("Record"sv))))));
+auto&& __jakt_match_variant = TRY((((((*this).program))->find_reflected_primitive((ByteString::must_from_utf8("Record"sv))))));
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 0 /* Struct */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Struct;ids::StructId const& id = __jakt_match_value.value;
@@ -20599,7 +20599,7 @@ return JaktInternal::ExplicitValue(id);
 };/*case end*/
 default: {
 {
-utility::panic(TRY(ByteString::from_utf8("Expected Record to be a struct"sv)));
+utility::panic((ByteString::must_from_utf8("Expected Record to be a struct"sv)));
 }
 };/*case end*/
 }/*switch end*/
@@ -20609,10 +20609,10 @@ utility::panic(TRY(ByteString::from_utf8("Expected Record to be a struct"sv)));
         return _jakt_value.release_return();
     _jakt_value.release_value();
 });
-ids::FunctionId const record_struct_constructor = (TRY((((((*this).program))->find_function_in_scope(((((((*this).program))->get_struct(record_struct_id))).scope_id),TRY(ByteString::from_utf8("Record"sv)),JaktInternal::OptionalNone())))).value());
+ids::FunctionId const record_struct_constructor = (TRY((((((*this).program))->find_function_in_scope(((((((*this).program))->get_struct(record_struct_id))).scope_id),(ByteString::must_from_utf8("Record"sv)),JaktInternal::OptionalNone())))).value());
 ids::EnumId const record_type_enum_id = ({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<ids::EnumId, ErrorOr<types::Value>>{
-auto&& __jakt_match_variant = TRY((((((*this).program))->find_reflected_primitive(TRY(ByteString::from_utf8("RecordType"sv))))));
+auto&& __jakt_match_variant = TRY((((((*this).program))->find_reflected_primitive((ByteString::must_from_utf8("RecordType"sv))))));
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 1 /* Enum */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Enum;ids::EnumId const& id = __jakt_match_value.value;
@@ -20620,7 +20620,7 @@ return JaktInternal::ExplicitValue(id);
 };/*case end*/
 default: {
 {
-utility::panic(TRY(ByteString::from_utf8("Expected RecordType to be an enum"sv)));
+utility::panic((ByteString::must_from_utf8("Expected RecordType to be an enum"sv)));
 }
 };/*case end*/
 }/*switch end*/
@@ -20630,7 +20630,7 @@ utility::panic(TRY(ByteString::from_utf8("Expected RecordType to be an enum"sv))
         return _jakt_value.release_return();
     _jakt_value.release_value();
 });
-ids::FunctionId const record_type_struct_constructor = (TRY((((((*this).program))->find_function_in_scope(((((((*this).program))->get_enum(record_type_enum_id))).scope_id),TRY(ByteString::from_utf8("Struct"sv)),JaktInternal::OptionalNone())))).value());
+ids::FunctionId const record_type_struct_constructor = (TRY((((((*this).program))->find_function_in_scope(((((((*this).program))->get_enum(record_type_enum_id))).scope_id),(ByteString::must_from_utf8("Struct"sv)),JaktInternal::OptionalNone())))).value());
 types::Value const methods = TRY((((*this).reflect_methods(((subject_struct).scope_id),span,scope))));
 ids::TypeId const tuple_type = TRY((((*this).tuple_type((TRY((DynamicArray<ids::TypeId>::create_with({TRY((((*this).string_type()))), ((reflected_enum).type_id)}))))))));
 types::Value const generic_parameters = TRY((((*this).array_value_of_type(({
@@ -20661,7 +20661,7 @@ return JaktInternal::ExplicitValue(name);
 };/*case end*/
 default: {
 {
-utility::panic(TRY(ByteString::from_utf8("Unknown kind of generic parameter in struct definition"sv)));
+utility::panic((ByteString::must_from_utf8("Unknown kind of generic parameter in struct definition"sv)));
 }
 };/*case end*/
 }/*switch end*/
@@ -20745,7 +20745,7 @@ TRY((((reflected_fields).push(((field).variable_id)))));
 JaktInternal::DynamicArray<types::Value> const record_type_fields = TRY((((*this).reflect_fields(reflected_fields,span,scope))));
 ids::StructId const field_struct_id = ({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<ids::StructId, ErrorOr<types::Value>>{
-auto&& __jakt_match_variant = TRY((((((*this).program))->find_reflected_primitive(TRY(ByteString::from_utf8("Field"sv))))));
+auto&& __jakt_match_variant = TRY((((((*this).program))->find_reflected_primitive((ByteString::must_from_utf8("Field"sv))))));
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 0 /* Struct */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Struct;ids::StructId const& id = __jakt_match_value.value;
@@ -20753,7 +20753,7 @@ return JaktInternal::ExplicitValue(id);
 };/*case end*/
 default: {
 {
-utility::panic(TRY(ByteString::from_utf8("Expected Field to be a struct"sv)));
+utility::panic((ByteString::must_from_utf8("Expected Field to be a struct"sv)));
 }
 };/*case end*/
 }/*switch end*/
@@ -20773,14 +20773,14 @@ case 24 /* Struct */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Struct;ids::StructId const& struct_id = __jakt_match_value.value;
 return JaktInternal::ExplicitValue(({ Optional<ids::FunctionId> __jakt_var_422; {
 types::CheckedStruct const subject_struct = ((((*this).program))->get_struct(struct_id));
-JaktInternal::Optional<ids::FunctionId> const constructor = TRY((((((*this).program))->find_function_in_scope(((((((*this).program))->get_enum(reflected_enum_id))).scope_id),TRY(ByteString::from_utf8("StructureOrEnum"sv)),JaktInternal::OptionalNone()))));
+JaktInternal::Optional<ids::FunctionId> const constructor = TRY((((((*this).program))->find_function_in_scope(((((((*this).program))->get_enum(reflected_enum_id))).scope_id),(ByteString::must_from_utf8("StructureOrEnum"sv)),JaktInternal::OptionalNone()))));
 if ((!(((constructor).has_value())))){
-TRY((((*this).error(TRY(ByteString::from_utf8("Attempted to access a variant that does not exist"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("Attempted to access a variant that does not exist"sv)),span))));
 return Error::__jakt_from_string_literal((StringView::from_string_literal("Invalid type"sv)));
 }
 ids::StructId const record_struct_id = ({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<ids::StructId, ErrorOr<types::Value>>{
-auto&& __jakt_match_variant = TRY((((((*this).program))->find_reflected_primitive(TRY(ByteString::from_utf8("Record"sv))))));
+auto&& __jakt_match_variant = TRY((((((*this).program))->find_reflected_primitive((ByteString::must_from_utf8("Record"sv))))));
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 0 /* Struct */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Struct;ids::StructId const& id = __jakt_match_value.value;
@@ -20788,7 +20788,7 @@ return JaktInternal::ExplicitValue(id);
 };/*case end*/
 default: {
 {
-utility::panic(TRY(ByteString::from_utf8("Expected Record to be a struct"sv)));
+utility::panic((ByteString::must_from_utf8("Expected Record to be a struct"sv)));
 }
 };/*case end*/
 }/*switch end*/
@@ -20798,10 +20798,10 @@ utility::panic(TRY(ByteString::from_utf8("Expected Record to be a struct"sv)));
         return _jakt_value.release_return();
     _jakt_value.release_value();
 });
-ids::FunctionId const record_struct_constructor = (TRY((((((*this).program))->find_function_in_scope(((((((*this).program))->get_struct(record_struct_id))).scope_id),TRY(ByteString::from_utf8("Record"sv)),JaktInternal::OptionalNone())))).value());
+ids::FunctionId const record_struct_constructor = (TRY((((((*this).program))->find_function_in_scope(((((((*this).program))->get_struct(record_struct_id))).scope_id),(ByteString::must_from_utf8("Record"sv)),JaktInternal::OptionalNone())))).value());
 ids::EnumId const record_type_enum_id = ({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<ids::EnumId, ErrorOr<types::Value>>{
-auto&& __jakt_match_variant = TRY((((((*this).program))->find_reflected_primitive(TRY(ByteString::from_utf8("RecordType"sv))))));
+auto&& __jakt_match_variant = TRY((((((*this).program))->find_reflected_primitive((ByteString::must_from_utf8("RecordType"sv))))));
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 1 /* Enum */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Enum;ids::EnumId const& id = __jakt_match_value.value;
@@ -20809,7 +20809,7 @@ return JaktInternal::ExplicitValue(id);
 };/*case end*/
 default: {
 {
-utility::panic(TRY(ByteString::from_utf8("Expected RecordType to be an enum"sv)));
+utility::panic((ByteString::must_from_utf8("Expected RecordType to be an enum"sv)));
 }
 };/*case end*/
 }/*switch end*/
@@ -20819,7 +20819,7 @@ utility::panic(TRY(ByteString::from_utf8("Expected RecordType to be an enum"sv))
         return _jakt_value.release_return();
     _jakt_value.release_value();
 });
-ids::FunctionId const record_type_struct_constructor = (TRY((((((*this).program))->find_function_in_scope(((((((*this).program))->get_enum(record_type_enum_id))).scope_id),TRY(ByteString::from_utf8("Struct"sv)),JaktInternal::OptionalNone())))).value());
+ids::FunctionId const record_type_struct_constructor = (TRY((((((*this).program))->find_function_in_scope(((((((*this).program))->get_enum(record_type_enum_id))).scope_id),(ByteString::must_from_utf8("Struct"sv)),JaktInternal::OptionalNone())))).value());
 types::Value const methods = TRY((((*this).reflect_methods(((subject_struct).scope_id),span,scope))));
 ids::TypeId const tuple_type = TRY((((*this).tuple_type((TRY((DynamicArray<ids::TypeId>::create_with({TRY((((*this).string_type()))), ((reflected_enum).type_id)}))))))));
 types::Value const generic_parameters = TRY((((*this).array_value_of_type(({
@@ -20850,7 +20850,7 @@ return JaktInternal::ExplicitValue(name);
 };/*case end*/
 default: {
 {
-utility::panic(TRY(ByteString::from_utf8("Unknown kind of generic parameter in struct definition"sv)));
+utility::panic((ByteString::must_from_utf8("Unknown kind of generic parameter in struct definition"sv)));
 }
 };/*case end*/
 }/*switch end*/
@@ -20934,7 +20934,7 @@ TRY((((reflected_fields).push(((field).variable_id)))));
 JaktInternal::DynamicArray<types::Value> const record_type_fields = TRY((((*this).reflect_fields(reflected_fields,span,scope))));
 ids::StructId const field_struct_id = ({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<ids::StructId, ErrorOr<types::Value>>{
-auto&& __jakt_match_variant = TRY((((((*this).program))->find_reflected_primitive(TRY(ByteString::from_utf8("Field"sv))))));
+auto&& __jakt_match_variant = TRY((((((*this).program))->find_reflected_primitive((ByteString::must_from_utf8("Field"sv))))));
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 0 /* Struct */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Struct;ids::StructId const& id = __jakt_match_value.value;
@@ -20942,7 +20942,7 @@ return JaktInternal::ExplicitValue(id);
 };/*case end*/
 default: {
 {
-utility::panic(TRY(ByteString::from_utf8("Expected Field to be a struct"sv)));
+utility::panic((ByteString::must_from_utf8("Expected Field to be a struct"sv)));
 }
 };/*case end*/
 }/*switch end*/
@@ -20962,14 +20962,14 @@ case 21 /* GenericEnumInstance */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.GenericEnumInstance;ids::EnumId const& enum_id = __jakt_match_value.id;
 return JaktInternal::ExplicitValue(({ Optional<ids::FunctionId> __jakt_var_424; {
 types::CheckedEnum const subject_enum = ((((*this).program))->get_enum(enum_id));
-JaktInternal::Optional<ids::FunctionId> const constructor = TRY((((((*this).program))->find_function_in_scope(((((((*this).program))->get_enum(reflected_enum_id))).scope_id),TRY(ByteString::from_utf8("StructureOrEnum"sv)),JaktInternal::OptionalNone()))));
+JaktInternal::Optional<ids::FunctionId> const constructor = TRY((((((*this).program))->find_function_in_scope(((((((*this).program))->get_enum(reflected_enum_id))).scope_id),(ByteString::must_from_utf8("StructureOrEnum"sv)),JaktInternal::OptionalNone()))));
 if ((!(((constructor).has_value())))){
-TRY((((*this).error(TRY(ByteString::from_utf8("Attempted to access a variant that does not exist"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("Attempted to access a variant that does not exist"sv)),span))));
 return Error::__jakt_from_string_literal((StringView::from_string_literal("Invalid type"sv)));
 }
 ids::StructId const record_struct_id = ({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<ids::StructId, ErrorOr<types::Value>>{
-auto&& __jakt_match_variant = TRY((((((*this).program))->find_reflected_primitive(TRY(ByteString::from_utf8("Record"sv))))));
+auto&& __jakt_match_variant = TRY((((((*this).program))->find_reflected_primitive((ByteString::must_from_utf8("Record"sv))))));
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 0 /* Struct */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Struct;ids::StructId const& id = __jakt_match_value.value;
@@ -20977,7 +20977,7 @@ return JaktInternal::ExplicitValue(id);
 };/*case end*/
 default: {
 {
-utility::panic(TRY(ByteString::from_utf8("Expected Record to be a struct"sv)));
+utility::panic((ByteString::must_from_utf8("Expected Record to be a struct"sv)));
 }
 };/*case end*/
 }/*switch end*/
@@ -20987,10 +20987,10 @@ utility::panic(TRY(ByteString::from_utf8("Expected Record to be a struct"sv)));
         return _jakt_value.release_return();
     _jakt_value.release_value();
 });
-ids::FunctionId const record_struct_constructor = (TRY((((((*this).program))->find_function_in_scope(((((((*this).program))->get_struct(record_struct_id))).scope_id),TRY(ByteString::from_utf8("Record"sv)),JaktInternal::OptionalNone())))).value());
+ids::FunctionId const record_struct_constructor = (TRY((((((*this).program))->find_function_in_scope(((((((*this).program))->get_struct(record_struct_id))).scope_id),(ByteString::must_from_utf8("Record"sv)),JaktInternal::OptionalNone())))).value());
 ids::EnumId const record_type_enum_id = ({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<ids::EnumId, ErrorOr<types::Value>>{
-auto&& __jakt_match_variant = TRY((((((*this).program))->find_reflected_primitive(TRY(ByteString::from_utf8("RecordType"sv))))));
+auto&& __jakt_match_variant = TRY((((((*this).program))->find_reflected_primitive((ByteString::must_from_utf8("RecordType"sv))))));
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 1 /* Enum */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Enum;ids::EnumId const& id = __jakt_match_value.value;
@@ -20998,7 +20998,7 @@ return JaktInternal::ExplicitValue(id);
 };/*case end*/
 default: {
 {
-utility::panic(TRY(ByteString::from_utf8("Expected RecordType to be an enum"sv)));
+utility::panic((ByteString::must_from_utf8("Expected RecordType to be an enum"sv)));
 }
 };/*case end*/
 }/*switch end*/
@@ -21013,10 +21013,10 @@ ids::FunctionId const record_type_struct_constructor = ({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<ids::FunctionId,ErrorOr<types::Value>>{
 auto __jakt_enum_value = (is_value_enum);
 if (__jakt_enum_value == true) {
-return JaktInternal::ExplicitValue((TRY((((((*this).program))->find_function_in_scope(((((((*this).program))->get_enum(record_type_enum_id))).scope_id),TRY(ByteString::from_utf8("ValueEnum"sv)),JaktInternal::OptionalNone())))).value()));
+return JaktInternal::ExplicitValue((TRY((((((*this).program))->find_function_in_scope(((((((*this).program))->get_enum(record_type_enum_id))).scope_id),(ByteString::must_from_utf8("ValueEnum"sv)),JaktInternal::OptionalNone())))).value()));
 }
 else {
-return JaktInternal::ExplicitValue((TRY((((((*this).program))->find_function_in_scope(((((((*this).program))->get_enum(record_type_enum_id))).scope_id),TRY(ByteString::from_utf8("SumEnum"sv)),JaktInternal::OptionalNone())))).value()));
+return JaktInternal::ExplicitValue((TRY((((((*this).program))->find_function_in_scope(((((((*this).program))->get_enum(record_type_enum_id))).scope_id),(ByteString::must_from_utf8("SumEnum"sv)),JaktInternal::OptionalNone())))).value()));
 }
 }());
     if (_jakt_value.is_return())
@@ -21053,7 +21053,7 @@ return JaktInternal::ExplicitValue(name);
 };/*case end*/
 default: {
 {
-utility::panic(TRY(ByteString::from_utf8("Unknown kind of generic parameter in struct definition"sv)));
+utility::panic((ByteString::must_from_utf8("Unknown kind of generic parameter in struct definition"sv)));
 }
 };/*case end*/
 }/*switch end*/
@@ -21120,7 +21120,7 @@ return JaktInternal::ExplicitValue((TRY((DynamicArray<types::Value>::create_with
 }),tuple_type,span))));
 JaktInternal::DynamicArray<types::Value> record_type_fields = (TRY((DynamicArray<types::Value>::create_with({}))));
 if (is_value_enum){
-TRY((((*this).error(TRY(ByteString::from_utf8("Unimplemented reflected type: value enum"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("Unimplemented reflected type: value enum"sv)),span))));
 return Error::__jakt_from_string_literal((StringView::from_string_literal("Not yet implemented"sv)));
 }
 else {
@@ -21129,7 +21129,7 @@ else {
 
 ids::StructId const field_struct_id = ({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<ids::StructId, ErrorOr<types::Value>>{
-auto&& __jakt_match_variant = TRY((((((*this).program))->find_reflected_primitive(TRY(ByteString::from_utf8("Field"sv))))));
+auto&& __jakt_match_variant = TRY((((((*this).program))->find_reflected_primitive((ByteString::must_from_utf8("Field"sv))))));
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 0 /* Struct */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Struct;ids::StructId const& id = __jakt_match_value.value;
@@ -21137,7 +21137,7 @@ return JaktInternal::ExplicitValue(id);
 };/*case end*/
 default: {
 {
-utility::panic(TRY(ByteString::from_utf8("Expected Field to be a struct"sv)));
+utility::panic((ByteString::must_from_utf8("Expected Field to be a struct"sv)));
 }
 };/*case end*/
 }/*switch end*/
@@ -21157,14 +21157,14 @@ case 25 /* Enum */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Enum;ids::EnumId const& enum_id = __jakt_match_value.value;
 return JaktInternal::ExplicitValue(({ Optional<ids::FunctionId> __jakt_var_426; {
 types::CheckedEnum const subject_enum = ((((*this).program))->get_enum(enum_id));
-JaktInternal::Optional<ids::FunctionId> const constructor = TRY((((((*this).program))->find_function_in_scope(((((((*this).program))->get_enum(reflected_enum_id))).scope_id),TRY(ByteString::from_utf8("StructureOrEnum"sv)),JaktInternal::OptionalNone()))));
+JaktInternal::Optional<ids::FunctionId> const constructor = TRY((((((*this).program))->find_function_in_scope(((((((*this).program))->get_enum(reflected_enum_id))).scope_id),(ByteString::must_from_utf8("StructureOrEnum"sv)),JaktInternal::OptionalNone()))));
 if ((!(((constructor).has_value())))){
-TRY((((*this).error(TRY(ByteString::from_utf8("Attempted to access a variant that does not exist"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("Attempted to access a variant that does not exist"sv)),span))));
 return Error::__jakt_from_string_literal((StringView::from_string_literal("Invalid type"sv)));
 }
 ids::StructId const record_struct_id = ({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<ids::StructId, ErrorOr<types::Value>>{
-auto&& __jakt_match_variant = TRY((((((*this).program))->find_reflected_primitive(TRY(ByteString::from_utf8("Record"sv))))));
+auto&& __jakt_match_variant = TRY((((((*this).program))->find_reflected_primitive((ByteString::must_from_utf8("Record"sv))))));
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 0 /* Struct */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Struct;ids::StructId const& id = __jakt_match_value.value;
@@ -21172,7 +21172,7 @@ return JaktInternal::ExplicitValue(id);
 };/*case end*/
 default: {
 {
-utility::panic(TRY(ByteString::from_utf8("Expected Record to be a struct"sv)));
+utility::panic((ByteString::must_from_utf8("Expected Record to be a struct"sv)));
 }
 };/*case end*/
 }/*switch end*/
@@ -21182,10 +21182,10 @@ utility::panic(TRY(ByteString::from_utf8("Expected Record to be a struct"sv)));
         return _jakt_value.release_return();
     _jakt_value.release_value();
 });
-ids::FunctionId const record_struct_constructor = (TRY((((((*this).program))->find_function_in_scope(((((((*this).program))->get_struct(record_struct_id))).scope_id),TRY(ByteString::from_utf8("Record"sv)),JaktInternal::OptionalNone())))).value());
+ids::FunctionId const record_struct_constructor = (TRY((((((*this).program))->find_function_in_scope(((((((*this).program))->get_struct(record_struct_id))).scope_id),(ByteString::must_from_utf8("Record"sv)),JaktInternal::OptionalNone())))).value());
 ids::EnumId const record_type_enum_id = ({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<ids::EnumId, ErrorOr<types::Value>>{
-auto&& __jakt_match_variant = TRY((((((*this).program))->find_reflected_primitive(TRY(ByteString::from_utf8("RecordType"sv))))));
+auto&& __jakt_match_variant = TRY((((((*this).program))->find_reflected_primitive((ByteString::must_from_utf8("RecordType"sv))))));
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 1 /* Enum */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Enum;ids::EnumId const& id = __jakt_match_value.value;
@@ -21193,7 +21193,7 @@ return JaktInternal::ExplicitValue(id);
 };/*case end*/
 default: {
 {
-utility::panic(TRY(ByteString::from_utf8("Expected RecordType to be an enum"sv)));
+utility::panic((ByteString::must_from_utf8("Expected RecordType to be an enum"sv)));
 }
 };/*case end*/
 }/*switch end*/
@@ -21208,10 +21208,10 @@ ids::FunctionId const record_type_struct_constructor = ({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<ids::FunctionId,ErrorOr<types::Value>>{
 auto __jakt_enum_value = (is_value_enum);
 if (__jakt_enum_value == true) {
-return JaktInternal::ExplicitValue((TRY((((((*this).program))->find_function_in_scope(((((((*this).program))->get_enum(record_type_enum_id))).scope_id),TRY(ByteString::from_utf8("ValueEnum"sv)),JaktInternal::OptionalNone())))).value()));
+return JaktInternal::ExplicitValue((TRY((((((*this).program))->find_function_in_scope(((((((*this).program))->get_enum(record_type_enum_id))).scope_id),(ByteString::must_from_utf8("ValueEnum"sv)),JaktInternal::OptionalNone())))).value()));
 }
 else {
-return JaktInternal::ExplicitValue((TRY((((((*this).program))->find_function_in_scope(((((((*this).program))->get_enum(record_type_enum_id))).scope_id),TRY(ByteString::from_utf8("SumEnum"sv)),JaktInternal::OptionalNone())))).value()));
+return JaktInternal::ExplicitValue((TRY((((((*this).program))->find_function_in_scope(((((((*this).program))->get_enum(record_type_enum_id))).scope_id),(ByteString::must_from_utf8("SumEnum"sv)),JaktInternal::OptionalNone())))).value()));
 }
 }());
     if (_jakt_value.is_return())
@@ -21248,7 +21248,7 @@ return JaktInternal::ExplicitValue(name);
 };/*case end*/
 default: {
 {
-utility::panic(TRY(ByteString::from_utf8("Unknown kind of generic parameter in struct definition"sv)));
+utility::panic((ByteString::must_from_utf8("Unknown kind of generic parameter in struct definition"sv)));
 }
 };/*case end*/
 }/*switch end*/
@@ -21315,7 +21315,7 @@ return JaktInternal::ExplicitValue((TRY((DynamicArray<types::Value>::create_with
 }),tuple_type,span))));
 JaktInternal::DynamicArray<types::Value> record_type_fields = (TRY((DynamicArray<types::Value>::create_with({}))));
 if (is_value_enum){
-TRY((((*this).error(TRY(ByteString::from_utf8("Unimplemented reflected type: value enum"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("Unimplemented reflected type: value enum"sv)),span))));
 return Error::__jakt_from_string_literal((StringView::from_string_literal("Not yet implemented"sv)));
 }
 else {
@@ -21324,7 +21324,7 @@ else {
 
 ids::StructId const field_struct_id = ({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<ids::StructId, ErrorOr<types::Value>>{
-auto&& __jakt_match_variant = TRY((((((*this).program))->find_reflected_primitive(TRY(ByteString::from_utf8("Field"sv))))));
+auto&& __jakt_match_variant = TRY((((((*this).program))->find_reflected_primitive((ByteString::must_from_utf8("Field"sv))))));
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 0 /* Struct */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Struct;ids::StructId const& id = __jakt_match_value.value;
@@ -21332,7 +21332,7 @@ return JaktInternal::ExplicitValue(id);
 };/*case end*/
 default: {
 {
-utility::panic(TRY(ByteString::from_utf8("Expected Field to be a struct"sv)));
+utility::panic((ByteString::must_from_utf8("Expected Field to be a struct"sv)));
 }
 };/*case end*/
 }/*switch end*/
@@ -21350,9 +21350,9 @@ __jakt_label_402:; __jakt_var_426.release_value(); }));
 };/*case end*/
 case 30 /* Function */: {
 return JaktInternal::ExplicitValue(({ Optional<ids::FunctionId> __jakt_var_428; {
-JaktInternal::Optional<ids::FunctionId> const constructor = TRY((((((*this).program))->find_function_in_scope(((((((*this).program))->get_enum(reflected_enum_id))).scope_id),TRY(ByteString::from_utf8("Function"sv)),JaktInternal::OptionalNone()))));
+JaktInternal::Optional<ids::FunctionId> const constructor = TRY((((((*this).program))->find_function_in_scope(((((((*this).program))->get_enum(reflected_enum_id))).scope_id),(ByteString::must_from_utf8("Function"sv)),JaktInternal::OptionalNone()))));
 if ((!(((constructor).has_value())))){
-TRY((((*this).error(TRY(ByteString::from_utf8("Attempted to access a variant that does not exist"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("Attempted to access a variant that does not exist"sv)),span))));
 return Error::__jakt_from_string_literal((StringView::from_string_literal("Invalid type"sv)));
 }
 (fields = (TRY((DynamicArray<types::Value>::create_with({})))));

--- a/bootstrap/stage0/interpreter.h
+++ b/bootstrap/stage0/interpreter.h
@@ -8,63 +8,6 @@
 #include "jakt__platform.h"
 namespace Jakt {
 namespace interpreter {
-class InterpreterScope :public RefCounted<InterpreterScope>, public Weakable<InterpreterScope> {
-  public:
-virtual ~InterpreterScope() = default;
-public: JaktInternal::Dictionary<ByteString,types::Value> bindings;public: JaktInternal::Optional<NonnullRefPtr<interpreter::InterpreterScope>> parent;public: JaktInternal::Dictionary<ids::TypeId,ids::TypeId> type_bindings;public: JaktInternal::DynamicArray<interpreter::Deferred> defers;public: ErrorOr<void> set(ByteString const name, types::Value const value);
-public: static ErrorOr<NonnullRefPtr<interpreter::InterpreterScope>> create(JaktInternal::Dictionary<ByteString,types::Value> const bindings, JaktInternal::Optional<NonnullRefPtr<interpreter::InterpreterScope>> const parent, JaktInternal::Dictionary<ids::TypeId,ids::TypeId> const type_bindings);
-public: ErrorOr<void> defer_statement(NonnullRefPtr<typename types::CheckedStatement> const statement);
-public: ErrorOr<void> perform_defers(NonnullRefPtr<interpreter::Interpreter> interpreter, utility::Span const span);
-public: static ErrorOr<NonnullRefPtr<interpreter::InterpreterScope>> from_runtime_scope(ids::ScopeId const scope_id, NonnullRefPtr<types::CheckedProgram> const program, JaktInternal::Optional<NonnullRefPtr<interpreter::InterpreterScope>> const parent);
-public: ErrorOr<JaktInternal::Dictionary<ByteString,types::Value>> all_bindings() const;
-private: ErrorOr<void> type_map_for_substitution_helper(JaktInternal::Dictionary<ids::TypeId,ids::TypeId>& map) const;
-public: ErrorOr<types::GenericInferences> type_map_for_substitution() const;
-public: protected:
-explicit InterpreterScope(JaktInternal::Dictionary<ByteString,types::Value> a_bindings, JaktInternal::Optional<NonnullRefPtr<interpreter::InterpreterScope>> a_parent, JaktInternal::Dictionary<ids::TypeId,ids::TypeId> a_type_bindings, JaktInternal::DynamicArray<interpreter::Deferred> a_defers);
-public:
-static ErrorOr<NonnullRefPtr<InterpreterScope>> __jakt_create(JaktInternal::Dictionary<ByteString,types::Value> bindings, JaktInternal::Optional<NonnullRefPtr<interpreter::InterpreterScope>> parent, JaktInternal::Dictionary<ids::TypeId,ids::TypeId> type_bindings, JaktInternal::DynamicArray<interpreter::Deferred> defers);
-
-public: ErrorOr<void> defer_expression(NonnullRefPtr<typename types::CheckedExpression> const expr);
-public: ErrorOr<types::Value> must_get(ByteString const name) const;
-public: ErrorOr<ids::TypeId> map_type(ids::TypeId const id) const;
-public: ErrorOr<ByteString> debug_description() const;
-};struct Deferred {
-u8 __jakt_variant_index = 0;
-union VariantData {
-u8 __jakt_uninit_value;
-struct {
-NonnullRefPtr<typename types::CheckedExpression> value;
-} Expression;
-struct {
-NonnullRefPtr<typename types::CheckedStatement> value;
-} Statement;
-constexpr VariantData() {}
-~VariantData() {}
-} as;
-constexpr u8 __jakt_init_index() const noexcept { return __jakt_variant_index - 1; }ErrorOr<ByteString> debug_description() const;
-[[nodiscard]] static Deferred Expression(NonnullRefPtr<typename types::CheckedExpression> value);
-[[nodiscard]] static Deferred Statement(NonnullRefPtr<typename types::CheckedStatement> value);
-~Deferred();
-Deferred& operator=(Deferred const &);
-Deferred& operator=(Deferred &&);
-Deferred(Deferred const&);
-Deferred(Deferred &&);
-private: void __jakt_destroy_variant();
-public:
-private:
-Deferred() {};
-};
-enum class InterpretError: i32 {
-CallToExternalFunction = (infallible_integer_cast<i32>((static_cast<i32>(42)))),
-MismatchingArguments = (infallible_integer_cast<i32>((static_cast<u64>(43ULL)))),
-InvalidThisArgument = (infallible_integer_cast<i32>((static_cast<u64>(44ULL)))),
-InvalidOperation = (infallible_integer_cast<i32>((static_cast<u64>(45ULL)))),
-InvalidType = (infallible_integer_cast<i32>((static_cast<u64>(46ULL)))),
-UnknownVariable = (infallible_integer_cast<i32>((static_cast<u64>(47ULL)))),
-Unimplemented = (infallible_integer_cast<i32>((static_cast<u64>(48ULL)))),
-UnwrapOptionalNone = (infallible_integer_cast<i32>((static_cast<u64>(49ULL)))),
-InvalidCharacterConstant = (infallible_integer_cast<i32>((static_cast<u64>(50ULL)))),
-};
 class Interpreter :public RefCounted<Interpreter>, public Weakable<Interpreter> {
   public:
 virtual ~Interpreter() = default;
@@ -108,7 +51,18 @@ public: ErrorOr<types::Value> error_value(ByteString const string, utility::Span
 public: ErrorOr<interpreter::StatementResult> execute_block(types::CheckedBlock const block, NonnullRefPtr<interpreter::InterpreterScope> scope, utility::Span const call_span);
 public: ErrorOr<types::Value> reflect_type(ids::TypeId const type_id, utility::Span const span, NonnullRefPtr<interpreter::InterpreterScope> const scope);
 public: ErrorOr<ByteString> debug_description() const;
-};struct StatementResult {
+};enum class InterpretError: i32 {
+CallToExternalFunction = (infallible_integer_cast<i32>((static_cast<i32>(42)))),
+MismatchingArguments = (infallible_integer_cast<i32>((static_cast<u64>(43ULL)))),
+InvalidThisArgument = (infallible_integer_cast<i32>((static_cast<u64>(44ULL)))),
+InvalidOperation = (infallible_integer_cast<i32>((static_cast<u64>(45ULL)))),
+InvalidType = (infallible_integer_cast<i32>((static_cast<u64>(46ULL)))),
+UnknownVariable = (infallible_integer_cast<i32>((static_cast<u64>(47ULL)))),
+Unimplemented = (infallible_integer_cast<i32>((static_cast<u64>(48ULL)))),
+UnwrapOptionalNone = (infallible_integer_cast<i32>((static_cast<u64>(49ULL)))),
+InvalidCharacterConstant = (infallible_integer_cast<i32>((static_cast<u64>(50ULL)))),
+};
+struct StatementResult {
 u8 __jakt_variant_index = 0;
 union VariantData {
 u8 __jakt_uninit_value;
@@ -170,19 +124,53 @@ public:
 private:
 ExecutionResult() {};
 };
+class InterpreterScope :public RefCounted<InterpreterScope>, public Weakable<InterpreterScope> {
+  public:
+virtual ~InterpreterScope() = default;
+public: JaktInternal::Dictionary<ByteString,types::Value> bindings;public: JaktInternal::Optional<NonnullRefPtr<interpreter::InterpreterScope>> parent;public: JaktInternal::Dictionary<ids::TypeId,ids::TypeId> type_bindings;public: JaktInternal::DynamicArray<interpreter::Deferred> defers;public: ErrorOr<void> set(ByteString const name, types::Value const value);
+public: static ErrorOr<NonnullRefPtr<interpreter::InterpreterScope>> create(JaktInternal::Dictionary<ByteString,types::Value> const bindings, JaktInternal::Optional<NonnullRefPtr<interpreter::InterpreterScope>> const parent, JaktInternal::Dictionary<ids::TypeId,ids::TypeId> const type_bindings);
+public: ErrorOr<void> defer_statement(NonnullRefPtr<typename types::CheckedStatement> const statement);
+public: ErrorOr<void> perform_defers(NonnullRefPtr<interpreter::Interpreter> interpreter, utility::Span const span);
+public: static ErrorOr<NonnullRefPtr<interpreter::InterpreterScope>> from_runtime_scope(ids::ScopeId const scope_id, NonnullRefPtr<types::CheckedProgram> const program, JaktInternal::Optional<NonnullRefPtr<interpreter::InterpreterScope>> const parent);
+public: ErrorOr<JaktInternal::Dictionary<ByteString,types::Value>> all_bindings() const;
+private: ErrorOr<void> type_map_for_substitution_helper(JaktInternal::Dictionary<ids::TypeId,ids::TypeId>& map) const;
+public: ErrorOr<types::GenericInferences> type_map_for_substitution() const;
+public: protected:
+explicit InterpreterScope(JaktInternal::Dictionary<ByteString,types::Value> a_bindings, JaktInternal::Optional<NonnullRefPtr<interpreter::InterpreterScope>> a_parent, JaktInternal::Dictionary<ids::TypeId,ids::TypeId> a_type_bindings, JaktInternal::DynamicArray<interpreter::Deferred> a_defers);
+public:
+static ErrorOr<NonnullRefPtr<InterpreterScope>> __jakt_create(JaktInternal::Dictionary<ByteString,types::Value> bindings, JaktInternal::Optional<NonnullRefPtr<interpreter::InterpreterScope>> parent, JaktInternal::Dictionary<ids::TypeId,ids::TypeId> type_bindings, JaktInternal::DynamicArray<interpreter::Deferred> defers);
+
+public: ErrorOr<void> defer_expression(NonnullRefPtr<typename types::CheckedExpression> const expr);
+public: ErrorOr<types::Value> must_get(ByteString const name) const;
+public: ErrorOr<ids::TypeId> map_type(ids::TypeId const id) const;
+public: ErrorOr<ByteString> debug_description() const;
+};struct Deferred {
+u8 __jakt_variant_index = 0;
+union VariantData {
+u8 __jakt_uninit_value;
+struct {
+NonnullRefPtr<typename types::CheckedExpression> value;
+} Expression;
+struct {
+NonnullRefPtr<typename types::CheckedStatement> value;
+} Statement;
+constexpr VariantData() {}
+~VariantData() {}
+} as;
+constexpr u8 __jakt_init_index() const noexcept { return __jakt_variant_index - 1; }ErrorOr<ByteString> debug_description() const;
+[[nodiscard]] static Deferred Expression(NonnullRefPtr<typename types::CheckedExpression> value);
+[[nodiscard]] static Deferred Statement(NonnullRefPtr<typename types::CheckedStatement> value);
+~Deferred();
+Deferred& operator=(Deferred const &);
+Deferred& operator=(Deferred &&);
+Deferred(Deferred const&);
+Deferred(Deferred &&);
+private: void __jakt_destroy_variant();
+public:
+private:
+Deferred() {};
+};
 }
-} // namespace Jakt
-template<>struct Jakt::Formatter<Jakt::interpreter::InterpreterScope> : Jakt::Formatter<Jakt::StringView>{
-Jakt::ErrorOr<void> format(Jakt::FormatBuilder& builder, Jakt::interpreter::InterpreterScope const& value) {
-JaktInternal::PrettyPrint::ScopedEnable pretty_print_enable { m_alternative_form };Jakt::ErrorOr<void> format_error = Jakt::Formatter<Jakt::StringView>::format(builder, MUST(value.debug_description()));return format_error;}
-};
-namespace Jakt {
-} // namespace Jakt
-template<>struct Jakt::Formatter<Jakt::interpreter::Deferred> : Jakt::Formatter<Jakt::StringView>{
-Jakt::ErrorOr<void> format(Jakt::FormatBuilder& builder, Jakt::interpreter::Deferred const& value) {
-JaktInternal::PrettyPrint::ScopedEnable pretty_print_enable { m_alternative_form };Jakt::ErrorOr<void> format_error = Jakt::Formatter<Jakt::StringView>::format(builder, MUST(value.debug_description()));return format_error;}
-};
-namespace Jakt {
 } // namespace Jakt
 template<>struct Jakt::Formatter<Jakt::interpreter::Interpreter> : Jakt::Formatter<Jakt::StringView>{
 Jakt::ErrorOr<void> format(Jakt::FormatBuilder& builder, Jakt::interpreter::Interpreter const& value) {
@@ -198,6 +186,18 @@ namespace Jakt {
 } // namespace Jakt
 template<>struct Jakt::Formatter<Jakt::interpreter::ExecutionResult> : Jakt::Formatter<Jakt::StringView>{
 Jakt::ErrorOr<void> format(Jakt::FormatBuilder& builder, Jakt::interpreter::ExecutionResult const& value) {
+JaktInternal::PrettyPrint::ScopedEnable pretty_print_enable { m_alternative_form };Jakt::ErrorOr<void> format_error = Jakt::Formatter<Jakt::StringView>::format(builder, MUST(value.debug_description()));return format_error;}
+};
+namespace Jakt {
+} // namespace Jakt
+template<>struct Jakt::Formatter<Jakt::interpreter::InterpreterScope> : Jakt::Formatter<Jakt::StringView>{
+Jakt::ErrorOr<void> format(Jakt::FormatBuilder& builder, Jakt::interpreter::InterpreterScope const& value) {
+JaktInternal::PrettyPrint::ScopedEnable pretty_print_enable { m_alternative_form };Jakt::ErrorOr<void> format_error = Jakt::Formatter<Jakt::StringView>::format(builder, MUST(value.debug_description()));return format_error;}
+};
+namespace Jakt {
+} // namespace Jakt
+template<>struct Jakt::Formatter<Jakt::interpreter::Deferred> : Jakt::Formatter<Jakt::StringView>{
+Jakt::ErrorOr<void> format(Jakt::FormatBuilder& builder, Jakt::interpreter::Deferred const& value) {
 JaktInternal::PrettyPrint::ScopedEnable pretty_print_enable { m_alternative_form };Jakt::ErrorOr<void> format_error = Jakt::Formatter<Jakt::StringView>::format(builder, MUST(value.debug_description()));return format_error;}
 };
 namespace Jakt {

--- a/bootstrap/stage0/jakt__arguments.cpp
+++ b/bootstrap/stage0/jakt__arguments.cpp
@@ -21,7 +21,7 @@ break;
 }
 ByteString arg = (_magic_value.value());
 {
-if (((arg) == (TRY(ByteString::from_utf8("--"sv))))){
+if (((arg) == ((ByteString::must_from_utf8("--"sv))))){
 (((parser).definitely_positional_args) = TRY((((((((parser).args))[(JaktInternal::Range<size_t>{static_cast<size_t>(JaktInternal::checked_add(i,static_cast<size_t>(1ULL))),static_cast<size_t>(((((parser).args)).size()))})])).to_array()))));
 (((parser).args) = TRY((((((((parser).args))[(JaktInternal::Range<size_t>{static_cast<size_t>(static_cast<size_t>(0ULL)),static_cast<size_t>(i)})])).to_array()))));
 break;

--- a/bootstrap/stage0/jakt__path.cpp
+++ b/bootstrap/stage0/jakt__path.cpp
@@ -35,7 +35,7 @@ return ((((*this).path)).substring(JaktInternal::checked_add(i,static_cast<size_
 }
 }
 
-return TRY(ByteString::from_utf8(""sv));
+return (ByteString::must_from_utf8(""sv));
 }
 }
 
@@ -67,7 +67,7 @@ return ((parts).template get<1>());
 
 ErrorOr<jakt__path::Path> jakt__path::Path::join(ByteString const path) const {
 {
-if ((((((*this).path)) == (TRY(ByteString::from_utf8("."sv)))) || ((((((*this).path)).length())) == (static_cast<size_t>(0ULL))))){
+if ((((((*this).path)) == ((ByteString::must_from_utf8("."sv)))) || ((((((*this).path)).length())) == (static_cast<size_t>(0ULL))))){
 return jakt__path::Path(path);
 }
 if (((path).is_empty())){
@@ -112,11 +112,11 @@ ByteString const basename = TRY((((*this).basename(true))));
 ByteString const extension = ({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<ByteString,ErrorOr<jakt__path::Path>>{
 auto __jakt_enum_value = (new_extension);
-if (__jakt_enum_value == TRY(ByteString::from_utf8(""sv))) {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8(""sv)));
+if (__jakt_enum_value == (ByteString::must_from_utf8(""sv))) {
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8(""sv)));
 }
 else {
-return JaktInternal::ExplicitValue(TRY((((TRY(ByteString::from_utf8("."sv))) + (new_extension)))));
+return JaktInternal::ExplicitValue(TRY(((((ByteString::must_from_utf8("."sv))) + (new_extension)))));
 }
 }());
     if (_jakt_value.is_return())
@@ -161,7 +161,7 @@ return path;
 
 ErrorOr<jakt__path::Path> jakt__path::Path::from_parts(JaktInternal::DynamicArray<ByteString> const parts) {
 {
-jakt__path::Path path = jakt__path::Path(TRY(ByteString::from_utf8("."sv)));
+jakt__path::Path path = jakt__path::Path((ByteString::must_from_utf8("."sv)));
 {
 JaktInternal::ArrayIterator<ByteString> _magic = ((parts).iterator());
 for (;;){
@@ -190,15 +190,15 @@ ByteString const dir = ((((*this).path)).substring(static_cast<size_t>(0ULL),(la
 ByteString const base = ((((*this).path)).substring(JaktInternal::checked_add((last_slash.value()),static_cast<size_t>(1ULL)),JaktInternal::checked_sub(JaktInternal::checked_sub(len,(last_slash.value())),static_cast<size_t>(1ULL))));
 return (Tuple{dir, base});
 }
-return (Tuple{TRY(ByteString::from_utf8(""sv)), ((*this).path)});
+return (Tuple{(ByteString::must_from_utf8(""sv)), ((*this).path)});
 }
 }
 
 ErrorOr<jakt__path::Path> jakt__path::Path::parent() const {
 {
 JaktInternal::Tuple<ByteString,ByteString> const parts = TRY((((*this).split_at_last_slash())));
-if (((((parts).template get<0>())) == (TRY(ByteString::from_utf8(""sv))))){
-return jakt__path::Path(TRY(ByteString::from_utf8("."sv)));
+if (((((parts).template get<0>())) == ((ByteString::must_from_utf8(""sv))))){
+return jakt__path::Path((ByteString::must_from_utf8("."sv)));
 }
 return jakt__path::Path(((parts).template get<0>()));
 }
@@ -259,7 +259,7 @@ TRY((((parts).push(((((*this).path)).substring(JaktInternal::checked_add((last_s
 }
 else {
 if (((i) == (static_cast<size_t>(0ULL)))){
-TRY((((parts).push(TRY(ByteString::from_utf8("/"sv))))));
+TRY((((parts).push((ByteString::must_from_utf8("/"sv))))));
 }
 else {
 TRY((((parts).push(((((*this).path)).substring(static_cast<size_t>(0ULL),i))))));
@@ -299,7 +299,7 @@ return parts;
 
 ErrorOr<bool> jakt__path::Path::is_dot() const {
 {
-return (((((*this).path)) == (TRY(ByteString::from_utf8("."sv)))) || ((((*this).path)) == (TRY(ByteString::from_utf8(".."sv)))));
+return (((((*this).path)) == ((ByteString::must_from_utf8("."sv)))) || ((((*this).path)) == ((ByteString::must_from_utf8(".."sv)))));
 }
 }
 

--- a/bootstrap/stage0/jakt__platform.cpp
+++ b/bootstrap/stage0/jakt__platform.cpp
@@ -52,18 +52,18 @@ jakt__platform::Target const target = TRY((jakt__platform::Target::active()));
 return ({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<JaktInternal::DynamicArray<ByteString>,ErrorOr<JaktInternal::DynamicArray<ByteString>>>{
 auto __jakt_enum_value = (((target).os));
-if (__jakt_enum_value == TRY(ByteString::from_utf8("windows"sv))) {
+if (__jakt_enum_value == (ByteString::must_from_utf8("windows"sv))) {
 return JaktInternal::ExplicitValue(({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<JaktInternal::DynamicArray<ByteString>,ErrorOr<JaktInternal::DynamicArray<ByteString>>>{
 auto __jakt_enum_value = (((target).arch));
-if (__jakt_enum_value == TRY(ByteString::from_utf8("x86_64"sv))) {
-return JaktInternal::ExplicitValue((TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("win64"sv)), TRY(ByteString::from_utf8("windows"sv))})))));
+if (__jakt_enum_value == (ByteString::must_from_utf8("x86_64"sv))) {
+return JaktInternal::ExplicitValue((TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("win64"sv)), (ByteString::must_from_utf8("windows"sv))})))));
 }
-else if (__jakt_enum_value == TRY(ByteString::from_utf8("i686"sv))) {
-return JaktInternal::ExplicitValue((TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("win32"sv)), TRY(ByteString::from_utf8("windows"sv))})))));
+else if (__jakt_enum_value == (ByteString::must_from_utf8("i686"sv))) {
+return JaktInternal::ExplicitValue((TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("win32"sv)), (ByteString::must_from_utf8("windows"sv))})))));
 }
 else {
-return JaktInternal::ExplicitValue((TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("windows"sv))})))));
+return JaktInternal::ExplicitValue((TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("windows"sv))})))));
 }
 }());
     if (_jakt_value.is_return())
@@ -71,23 +71,23 @@ return JaktInternal::ExplicitValue((TRY((DynamicArray<ByteString>::create_with({
     _jakt_value.release_value();
 }));
 }
-else if (__jakt_enum_value == TRY(ByteString::from_utf8("darwin"sv))) {
-return JaktInternal::ExplicitValue((TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("darwin"sv)), TRY(ByteString::from_utf8("posix"sv))})))));
+else if (__jakt_enum_value == (ByteString::must_from_utf8("darwin"sv))) {
+return JaktInternal::ExplicitValue((TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("darwin"sv)), (ByteString::must_from_utf8("posix"sv))})))));
 }
-else if (__jakt_enum_value == TRY(ByteString::from_utf8("linux"sv))) {
-return JaktInternal::ExplicitValue((TRY((DynamicArray<ByteString>::create_with({((target).os), TRY(ByteString::from_utf8("posix"sv))})))));
+else if (__jakt_enum_value == (ByteString::must_from_utf8("linux"sv))) {
+return JaktInternal::ExplicitValue((TRY((DynamicArray<ByteString>::create_with({((target).os), (ByteString::must_from_utf8("posix"sv))})))));
 }
-else if (__jakt_enum_value == TRY(ByteString::from_utf8("openbsd"sv))) {
-return JaktInternal::ExplicitValue((TRY((DynamicArray<ByteString>::create_with({((target).os), TRY(ByteString::from_utf8("posix"sv))})))));
+else if (__jakt_enum_value == (ByteString::must_from_utf8("openbsd"sv))) {
+return JaktInternal::ExplicitValue((TRY((DynamicArray<ByteString>::create_with({((target).os), (ByteString::must_from_utf8("posix"sv))})))));
 }
-else if (__jakt_enum_value == TRY(ByteString::from_utf8("serenityos"sv))) {
-return JaktInternal::ExplicitValue((TRY((DynamicArray<ByteString>::create_with({((target).os), TRY(ByteString::from_utf8("posix"sv))})))));
+else if (__jakt_enum_value == (ByteString::must_from_utf8("serenityos"sv))) {
+return JaktInternal::ExplicitValue((TRY((DynamicArray<ByteString>::create_with({((target).os), (ByteString::must_from_utf8("posix"sv))})))));
 }
-else if (__jakt_enum_value == TRY(ByteString::from_utf8("serenity"sv))) {
-return JaktInternal::ExplicitValue((TRY((DynamicArray<ByteString>::create_with({((target).os), TRY(ByteString::from_utf8("posix"sv))})))));
+else if (__jakt_enum_value == (ByteString::must_from_utf8("serenity"sv))) {
+return JaktInternal::ExplicitValue((TRY((DynamicArray<ByteString>::create_with({((target).os), (ByteString::must_from_utf8("posix"sv))})))));
 }
 else {
-return JaktInternal::ExplicitValue((TRY((DynamicArray<ByteString>::create_with({((target).os), TRY(ByteString::from_utf8("unknown"sv))})))));
+return JaktInternal::ExplicitValue((TRY((DynamicArray<ByteString>::create_with({((target).os), (ByteString::must_from_utf8("unknown"sv))})))));
 }
 }());
     if (_jakt_value.is_return())
@@ -129,10 +129,10 @@ ErrorOr<size_t> jakt__platform::Target::pointer_size() const {
 return ({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<size_t,ErrorOr<size_t>>{
 auto __jakt_enum_value = (((*this).arch));
-if (__jakt_enum_value == TRY(ByteString::from_utf8("x86_64"sv))) {
+if (__jakt_enum_value == (ByteString::must_from_utf8("x86_64"sv))) {
 return JaktInternal::ExplicitValue(static_cast<size_t>(8ULL));
 }
-else if (__jakt_enum_value == TRY(ByteString::from_utf8("x86"sv))) {
+else if (__jakt_enum_value == (ByteString::must_from_utf8("x86"sv))) {
 return JaktInternal::ExplicitValue(static_cast<size_t>(4ULL));
 }
 else {
@@ -186,10 +186,10 @@ ErrorOr<size_t> jakt__platform::Target::size_t_size() const {
 return ({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<size_t,ErrorOr<size_t>>{
 auto __jakt_enum_value = (((*this).arch));
-if (__jakt_enum_value == TRY(ByteString::from_utf8("x86_64"sv))) {
+if (__jakt_enum_value == (ByteString::must_from_utf8("x86_64"sv))) {
 return JaktInternal::ExplicitValue(static_cast<size_t>(8ULL));
 }
-else if (__jakt_enum_value == TRY(ByteString::from_utf8("x86"sv))) {
+else if (__jakt_enum_value == (ByteString::must_from_utf8("x86"sv))) {
 return JaktInternal::ExplicitValue(static_cast<size_t>(4ULL));
 }
 else {
@@ -210,10 +210,10 @@ ErrorOr<size_t> jakt__platform::Target::int_size() const {
 return ({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<size_t,ErrorOr<size_t>>{
 auto __jakt_enum_value = (((*this).arch));
-if (__jakt_enum_value == TRY(ByteString::from_utf8("x86_64"sv))) {
+if (__jakt_enum_value == (ByteString::must_from_utf8("x86_64"sv))) {
 return JaktInternal::ExplicitValue(static_cast<size_t>(4ULL));
 }
-else if (__jakt_enum_value == TRY(ByteString::from_utf8("x86"sv))) {
+else if (__jakt_enum_value == (ByteString::must_from_utf8("x86"sv))) {
 return JaktInternal::ExplicitValue(static_cast<size_t>(4ULL));
 }
 else {

--- a/bootstrap/stage0/jakt__platform__utility.cpp
+++ b/bootstrap/stage0/jakt__platform__utility.cpp
@@ -3,7 +3,7 @@ namespace Jakt {
 namespace jakt__platform__utility {
 ErrorOr<ByteString> join(JaktInternal::DynamicArray<ByteString> const strings,ByteString const separator) {
 {
-ByteString output = TRY(ByteString::from_utf8(""sv));
+ByteString output = (ByteString::must_from_utf8(""sv));
 size_t i = static_cast<size_t>(0ULL);
 {
 JaktInternal::ArrayIterator<ByteString> _magic = ((strings).iterator());

--- a/bootstrap/stage0/lexer.cpp
+++ b/bootstrap/stage0/lexer.cpp
@@ -42,7 +42,7 @@ ErrorOr<lexer::Token> lexer::Lexer::lex_quoted_string(u8 const delimiter) {
 size_t const start = ((*this).index);
 (++(((*this).index)));
 if (((*this).eof())){
-TRY((((*this).error(TRY(ByteString::from_utf8("unexpected eof"sv)),((*this).span(start,start))))));
+TRY((((*this).error((ByteString::must_from_utf8("unexpected eof"sv)),((*this).span(start,start))))));
 return lexer::Token::Garbage(JaktInternal::OptionalNone(),((*this).span(start,start)));
 }
 bool escaped = false;
@@ -203,10 +203,10 @@ JaktInternal::Optional<ByteString> const prefix = ({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<JaktInternal::Optional<ByteString>,ErrorOr<lexer::Token>>{
 auto __jakt_enum_value = (((*this).peek()));
 if (__jakt_enum_value == static_cast<u8>(u8'b')) {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("b"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("b"sv)));
 }
 else if (__jakt_enum_value == static_cast<u8>(u8'c')) {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("c"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("c"sv)));
 }
 else {
 return JaktInternal::ExplicitValue(JaktInternal::OptionalNone());
@@ -255,7 +255,7 @@ if (((!(escaped)) && ((((*this).peek())) == (static_cast<u8>(u8'\\'))))){
 ((((*this).index)++));
 }
 if ((((*this).eof()) || ((((*this).peek())) != (static_cast<u8>(u8'\''))))){
-TRY((((*this).error(TRY(ByteString::from_utf8("Expected single quote"sv)),((*this).span(start,start))))));
+TRY((((*this).error((ByteString::must_from_utf8("Expected single quote"sv)),((*this).span(start,start))))));
 }
 ((((*this).index)) += (static_cast<size_t>(1ULL)));
 ByteStringBuilder builder = ByteStringBuilder::create();
@@ -472,7 +472,7 @@ ErrorOr<lexer::Token> lexer::Lexer::lex_number_or_name() {
 {
 size_t const start = ((*this).index);
 if (((*this).eof())){
-TRY((((*this).error(TRY(ByteString::from_utf8("unexpected eof"sv)),((*this).span(start,start))))));
+TRY((((*this).error((ByteString::must_from_utf8("unexpected eof"sv)),((*this).span(start,start))))));
 return lexer::Token::Garbage(JaktInternal::OptionalNone(),((*this).span(start,start)));
 }
 if (utility::is_ascii_digit(((*this).peek()))){
@@ -498,11 +498,11 @@ return (infallible_enum_cast<jakt__prelude__operators::Ordering>((JaktInternal::
 (self,rhs))))) != (static_cast<u8>(0)));
 }
 }
-(JaktInternal::checked_sub(end,start),static_cast<size_t>(6ULL)) && ((((string).substring(static_cast<size_t>(0ULL),static_cast<size_t>(6ULL)))) == (TRY(ByteString::from_utf8("__jakt"sv)))))){
-TRY((((*this).error(TRY(ByteString::from_utf8("reserved identifier name"sv)),span))));
+(JaktInternal::checked_sub(end,start),static_cast<size_t>(6ULL)) && ((((string).substring(static_cast<size_t>(0ULL),static_cast<size_t>(6ULL)))) == ((ByteString::must_from_utf8("__jakt"sv)))))){
+TRY((((*this).error((ByteString::must_from_utf8("reserved identifier name"sv)),span))));
 }
 if (((((*this).illegal_cpp_keywords)).contains(string))){
-TRY((((*this).error(TRY(ByteString::from_utf8("C++ keywords are not allowed to be used as identifiers"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("C++ keywords are not allowed to be used as identifiers"sv)),span))));
 }
 return TRY((lexer::Token::from_keyword_or_identifier(string,span)));
 }
@@ -1055,7 +1055,7 @@ return lexer::Token::Number(prefix,TRY((((number).to_string()))),suffix,((*this)
 
 ErrorOr<JaktInternal::DynamicArray<lexer::Token>> lexer::Lexer::lex(NonnullRefPtr<compiler::Compiler> const compiler) {
 {
-JaktInternal::Set<ByteString> const illegal_cpp_keywords = (TRY((Set<ByteString>::create_with_values({TRY(ByteString::from_utf8("alignas"sv)), TRY(ByteString::from_utf8("alignof"sv)), TRY(ByteString::from_utf8("and_eq"sv)), TRY(ByteString::from_utf8("asm"sv)), TRY(ByteString::from_utf8("auto"sv)), TRY(ByteString::from_utf8("bitand"sv)), TRY(ByteString::from_utf8("bitor"sv)), TRY(ByteString::from_utf8("case"sv)), TRY(ByteString::from_utf8("char"sv)), TRY(ByteString::from_utf8("char8_t"sv)), TRY(ByteString::from_utf8("char16_t"sv)), TRY(ByteString::from_utf8("char32_t"sv)), TRY(ByteString::from_utf8("compl"sv)), TRY(ByteString::from_utf8("concept"sv)), TRY(ByteString::from_utf8("consteval"sv)), TRY(ByteString::from_utf8("constexpr"sv)), TRY(ByteString::from_utf8("constinit"sv)), TRY(ByteString::from_utf8("const_cast"sv)), TRY(ByteString::from_utf8("co_await"sv)), TRY(ByteString::from_utf8("co_return"sv)), TRY(ByteString::from_utf8("co_yield"sv)), TRY(ByteString::from_utf8("decltype"sv)), TRY(ByteString::from_utf8("delete"sv)), TRY(ByteString::from_utf8("do"sv)), TRY(ByteString::from_utf8("double"sv)), TRY(ByteString::from_utf8("dynamic_cast"sv)), TRY(ByteString::from_utf8("explicit"sv)), TRY(ByteString::from_utf8("export"sv)), TRY(ByteString::from_utf8("float"sv)), TRY(ByteString::from_utf8("friend"sv)), TRY(ByteString::from_utf8("goto"sv)), TRY(ByteString::from_utf8("int"sv)), TRY(ByteString::from_utf8("long"sv)), TRY(ByteString::from_utf8("mutable"sv)), TRY(ByteString::from_utf8("new"sv)), TRY(ByteString::from_utf8("noexcept"sv)), TRY(ByteString::from_utf8("not_eq"sv)), TRY(ByteString::from_utf8("nullptr"sv)), TRY(ByteString::from_utf8("operator"sv)), TRY(ByteString::from_utf8("or_eq"sv)), TRY(ByteString::from_utf8("protected"sv)), TRY(ByteString::from_utf8("register"sv)), TRY(ByteString::from_utf8("reinterpret_cast"sv)), TRY(ByteString::from_utf8("short"sv)), TRY(ByteString::from_utf8("signed"sv)), TRY(ByteString::from_utf8("static"sv)), TRY(ByteString::from_utf8("static_assert"sv)), TRY(ByteString::from_utf8("static_cast"sv)), TRY(ByteString::from_utf8("switch"sv)), TRY(ByteString::from_utf8("template"sv)), TRY(ByteString::from_utf8("thread_local"sv)), TRY(ByteString::from_utf8("typedef"sv)), TRY(ByteString::from_utf8("typeid"sv)), TRY(ByteString::from_utf8("typename"sv)), TRY(ByteString::from_utf8("union"sv)), TRY(ByteString::from_utf8("unsigned"sv)), TRY(ByteString::from_utf8("using"sv)), TRY(ByteString::from_utf8("volatile"sv)), TRY(ByteString::from_utf8("wchar_t"sv)), TRY(ByteString::from_utf8("xor"sv)), TRY(ByteString::from_utf8("xor_eq"sv))}))));
+JaktInternal::Set<ByteString> const illegal_cpp_keywords = (TRY((Set<ByteString>::create_with_values({(ByteString::must_from_utf8("alignas"sv)), (ByteString::must_from_utf8("alignof"sv)), (ByteString::must_from_utf8("and_eq"sv)), (ByteString::must_from_utf8("asm"sv)), (ByteString::must_from_utf8("auto"sv)), (ByteString::must_from_utf8("bitand"sv)), (ByteString::must_from_utf8("bitor"sv)), (ByteString::must_from_utf8("case"sv)), (ByteString::must_from_utf8("char"sv)), (ByteString::must_from_utf8("char8_t"sv)), (ByteString::must_from_utf8("char16_t"sv)), (ByteString::must_from_utf8("char32_t"sv)), (ByteString::must_from_utf8("compl"sv)), (ByteString::must_from_utf8("concept"sv)), (ByteString::must_from_utf8("consteval"sv)), (ByteString::must_from_utf8("constexpr"sv)), (ByteString::must_from_utf8("constinit"sv)), (ByteString::must_from_utf8("const_cast"sv)), (ByteString::must_from_utf8("co_await"sv)), (ByteString::must_from_utf8("co_return"sv)), (ByteString::must_from_utf8("co_yield"sv)), (ByteString::must_from_utf8("decltype"sv)), (ByteString::must_from_utf8("delete"sv)), (ByteString::must_from_utf8("do"sv)), (ByteString::must_from_utf8("double"sv)), (ByteString::must_from_utf8("dynamic_cast"sv)), (ByteString::must_from_utf8("explicit"sv)), (ByteString::must_from_utf8("export"sv)), (ByteString::must_from_utf8("float"sv)), (ByteString::must_from_utf8("friend"sv)), (ByteString::must_from_utf8("goto"sv)), (ByteString::must_from_utf8("int"sv)), (ByteString::must_from_utf8("long"sv)), (ByteString::must_from_utf8("mutable"sv)), (ByteString::must_from_utf8("new"sv)), (ByteString::must_from_utf8("noexcept"sv)), (ByteString::must_from_utf8("not_eq"sv)), (ByteString::must_from_utf8("nullptr"sv)), (ByteString::must_from_utf8("operator"sv)), (ByteString::must_from_utf8("or_eq"sv)), (ByteString::must_from_utf8("protected"sv)), (ByteString::must_from_utf8("register"sv)), (ByteString::must_from_utf8("reinterpret_cast"sv)), (ByteString::must_from_utf8("short"sv)), (ByteString::must_from_utf8("signed"sv)), (ByteString::must_from_utf8("static"sv)), (ByteString::must_from_utf8("static_assert"sv)), (ByteString::must_from_utf8("static_cast"sv)), (ByteString::must_from_utf8("switch"sv)), (ByteString::must_from_utf8("template"sv)), (ByteString::must_from_utf8("thread_local"sv)), (ByteString::must_from_utf8("typedef"sv)), (ByteString::must_from_utf8("typeid"sv)), (ByteString::must_from_utf8("typename"sv)), (ByteString::must_from_utf8("union"sv)), (ByteString::must_from_utf8("unsigned"sv)), (ByteString::must_from_utf8("using"sv)), (ByteString::must_from_utf8("volatile"sv)), (ByteString::must_from_utf8("wchar_t"sv)), (ByteString::must_from_utf8("xor"sv)), (ByteString::must_from_utf8("xor_eq"sv))}))));
 lexer::Lexer lexer = lexer::Lexer(static_cast<size_t>(0ULL),((compiler)->current_file_contents),compiler,JaktInternal::OptionalNone(),illegal_cpp_keywords);
 JaktInternal::DynamicArray<lexer::Token> tokens = (TRY((DynamicArray<lexer::Token>::create_with({}))));
 {
@@ -1389,40 +1389,40 @@ return ({
 auto&& __jakt_match_variant = *this;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 0 /* None */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8(""sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8(""sv)));
 };/*case end*/
 case 1 /* UZ */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("uz"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("uz"sv)));
 };/*case end*/
 case 2 /* U8 */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("u8"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("u8"sv)));
 };/*case end*/
 case 3 /* U16 */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("u16"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("u16"sv)));
 };/*case end*/
 case 4 /* U32 */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("u32"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("u32"sv)));
 };/*case end*/
 case 5 /* U64 */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("u64"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("u64"sv)));
 };/*case end*/
 case 6 /* I8 */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("i8"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("i8"sv)));
 };/*case end*/
 case 7 /* I16 */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("i16"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("i16"sv)));
 };/*case end*/
 case 8 /* I32 */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("i32"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("i32"sv)));
 };/*case end*/
 case 9 /* I64 */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("i64"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("i64"sv)));
 };/*case end*/
 case 10 /* F32 */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("f32"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("f32"sv)));
 };/*case end*/
 case 11 /* F64 */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("f64"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("f64"sv)));
 };/*case end*/
 default: VERIFY_NOT_REACHED();}/*switch end*/
 }()
@@ -5121,163 +5121,163 @@ ErrorOr<lexer::Token> lexer::Token::from_keyword_or_identifier(ByteString const 
 return ({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<lexer::Token,ErrorOr<lexer::Token>>{
 auto __jakt_enum_value = (string);
-if (__jakt_enum_value == TRY(ByteString::from_utf8("and"sv))) {
+if (__jakt_enum_value == (ByteString::must_from_utf8("and"sv))) {
 return JaktInternal::ExplicitValue(lexer::Token::And(span));
 }
-else if (__jakt_enum_value == TRY(ByteString::from_utf8("anon"sv))) {
+else if (__jakt_enum_value == (ByteString::must_from_utf8("anon"sv))) {
 return JaktInternal::ExplicitValue(lexer::Token::Anon(span));
 }
-else if (__jakt_enum_value == TRY(ByteString::from_utf8("as"sv))) {
+else if (__jakt_enum_value == (ByteString::must_from_utf8("as"sv))) {
 return JaktInternal::ExplicitValue(lexer::Token::As(span));
 }
-else if (__jakt_enum_value == TRY(ByteString::from_utf8("boxed"sv))) {
+else if (__jakt_enum_value == (ByteString::must_from_utf8("boxed"sv))) {
 return JaktInternal::ExplicitValue(lexer::Token::Boxed(span));
 }
-else if (__jakt_enum_value == TRY(ByteString::from_utf8("break"sv))) {
+else if (__jakt_enum_value == (ByteString::must_from_utf8("break"sv))) {
 return JaktInternal::ExplicitValue(lexer::Token::Break(span));
 }
-else if (__jakt_enum_value == TRY(ByteString::from_utf8("catch"sv))) {
+else if (__jakt_enum_value == (ByteString::must_from_utf8("catch"sv))) {
 return JaktInternal::ExplicitValue(lexer::Token::Catch(span));
 }
-else if (__jakt_enum_value == TRY(ByteString::from_utf8("class"sv))) {
+else if (__jakt_enum_value == (ByteString::must_from_utf8("class"sv))) {
 return JaktInternal::ExplicitValue(lexer::Token::Class(span));
 }
-else if (__jakt_enum_value == TRY(ByteString::from_utf8("continue"sv))) {
+else if (__jakt_enum_value == (ByteString::must_from_utf8("continue"sv))) {
 return JaktInternal::ExplicitValue(lexer::Token::Continue(span));
 }
-else if (__jakt_enum_value == TRY(ByteString::from_utf8("cpp"sv))) {
+else if (__jakt_enum_value == (ByteString::must_from_utf8("cpp"sv))) {
 return JaktInternal::ExplicitValue(lexer::Token::Cpp(span));
 }
-else if (__jakt_enum_value == TRY(ByteString::from_utf8("defer"sv))) {
+else if (__jakt_enum_value == (ByteString::must_from_utf8("defer"sv))) {
 return JaktInternal::ExplicitValue(lexer::Token::Defer(span));
 }
-else if (__jakt_enum_value == TRY(ByteString::from_utf8("destructor"sv))) {
+else if (__jakt_enum_value == (ByteString::must_from_utf8("destructor"sv))) {
 return JaktInternal::ExplicitValue(lexer::Token::Destructor(span));
 }
-else if (__jakt_enum_value == TRY(ByteString::from_utf8("else"sv))) {
+else if (__jakt_enum_value == (ByteString::must_from_utf8("else"sv))) {
 return JaktInternal::ExplicitValue(lexer::Token::Else(span));
 }
-else if (__jakt_enum_value == TRY(ByteString::from_utf8("enum"sv))) {
+else if (__jakt_enum_value == (ByteString::must_from_utf8("enum"sv))) {
 return JaktInternal::ExplicitValue(lexer::Token::Enum(span));
 }
-else if (__jakt_enum_value == TRY(ByteString::from_utf8("extern"sv))) {
+else if (__jakt_enum_value == (ByteString::must_from_utf8("extern"sv))) {
 return JaktInternal::ExplicitValue(lexer::Token::Extern(span));
 }
-else if (__jakt_enum_value == TRY(ByteString::from_utf8("false"sv))) {
+else if (__jakt_enum_value == (ByteString::must_from_utf8("false"sv))) {
 return JaktInternal::ExplicitValue(lexer::Token::False(span));
 }
-else if (__jakt_enum_value == TRY(ByteString::from_utf8("for"sv))) {
+else if (__jakt_enum_value == (ByteString::must_from_utf8("for"sv))) {
 return JaktInternal::ExplicitValue(lexer::Token::For(span));
 }
-else if (__jakt_enum_value == TRY(ByteString::from_utf8("fn"sv))) {
+else if (__jakt_enum_value == (ByteString::must_from_utf8("fn"sv))) {
 return JaktInternal::ExplicitValue(lexer::Token::Fn(span));
 }
-else if (__jakt_enum_value == TRY(ByteString::from_utf8("comptime"sv))) {
+else if (__jakt_enum_value == (ByteString::must_from_utf8("comptime"sv))) {
 return JaktInternal::ExplicitValue(lexer::Token::Comptime(span));
 }
-else if (__jakt_enum_value == TRY(ByteString::from_utf8("if"sv))) {
+else if (__jakt_enum_value == (ByteString::must_from_utf8("if"sv))) {
 return JaktInternal::ExplicitValue(lexer::Token::If(span));
 }
-else if (__jakt_enum_value == TRY(ByteString::from_utf8("import"sv))) {
+else if (__jakt_enum_value == (ByteString::must_from_utf8("import"sv))) {
 return JaktInternal::ExplicitValue(lexer::Token::Import(span));
 }
-else if (__jakt_enum_value == TRY(ByteString::from_utf8("relative"sv))) {
+else if (__jakt_enum_value == (ByteString::must_from_utf8("relative"sv))) {
 return JaktInternal::ExplicitValue(lexer::Token::Relative(span));
 }
-else if (__jakt_enum_value == TRY(ByteString::from_utf8("in"sv))) {
+else if (__jakt_enum_value == (ByteString::must_from_utf8("in"sv))) {
 return JaktInternal::ExplicitValue(lexer::Token::In(span));
 }
-else if (__jakt_enum_value == TRY(ByteString::from_utf8("is"sv))) {
+else if (__jakt_enum_value == (ByteString::must_from_utf8("is"sv))) {
 return JaktInternal::ExplicitValue(lexer::Token::Is(span));
 }
-else if (__jakt_enum_value == TRY(ByteString::from_utf8("let"sv))) {
+else if (__jakt_enum_value == (ByteString::must_from_utf8("let"sv))) {
 return JaktInternal::ExplicitValue(lexer::Token::Let(span));
 }
-else if (__jakt_enum_value == TRY(ByteString::from_utf8("loop"sv))) {
+else if (__jakt_enum_value == (ByteString::must_from_utf8("loop"sv))) {
 return JaktInternal::ExplicitValue(lexer::Token::Loop(span));
 }
-else if (__jakt_enum_value == TRY(ByteString::from_utf8("match"sv))) {
+else if (__jakt_enum_value == (ByteString::must_from_utf8("match"sv))) {
 return JaktInternal::ExplicitValue(lexer::Token::Match(span));
 }
-else if (__jakt_enum_value == TRY(ByteString::from_utf8("mut"sv))) {
+else if (__jakt_enum_value == (ByteString::must_from_utf8("mut"sv))) {
 return JaktInternal::ExplicitValue(lexer::Token::Mut(span));
 }
-else if (__jakt_enum_value == TRY(ByteString::from_utf8("namespace"sv))) {
+else if (__jakt_enum_value == (ByteString::must_from_utf8("namespace"sv))) {
 return JaktInternal::ExplicitValue(lexer::Token::Namespace(span));
 }
-else if (__jakt_enum_value == TRY(ByteString::from_utf8("not"sv))) {
+else if (__jakt_enum_value == (ByteString::must_from_utf8("not"sv))) {
 return JaktInternal::ExplicitValue(lexer::Token::Not(span));
 }
-else if (__jakt_enum_value == TRY(ByteString::from_utf8("or"sv))) {
+else if (__jakt_enum_value == (ByteString::must_from_utf8("or"sv))) {
 return JaktInternal::ExplicitValue(lexer::Token::Or(span));
 }
-else if (__jakt_enum_value == TRY(ByteString::from_utf8("override"sv))) {
+else if (__jakt_enum_value == (ByteString::must_from_utf8("override"sv))) {
 return JaktInternal::ExplicitValue(lexer::Token::Override(span));
 }
-else if (__jakt_enum_value == TRY(ByteString::from_utf8("private"sv))) {
+else if (__jakt_enum_value == (ByteString::must_from_utf8("private"sv))) {
 return JaktInternal::ExplicitValue(lexer::Token::Private(span));
 }
-else if (__jakt_enum_value == TRY(ByteString::from_utf8("public"sv))) {
+else if (__jakt_enum_value == (ByteString::must_from_utf8("public"sv))) {
 return JaktInternal::ExplicitValue(lexer::Token::Public(span));
 }
-else if (__jakt_enum_value == TRY(ByteString::from_utf8("raw"sv))) {
+else if (__jakt_enum_value == (ByteString::must_from_utf8("raw"sv))) {
 return JaktInternal::ExplicitValue(lexer::Token::Raw(span));
 }
-else if (__jakt_enum_value == TRY(ByteString::from_utf8("reflect"sv))) {
+else if (__jakt_enum_value == (ByteString::must_from_utf8("reflect"sv))) {
 return JaktInternal::ExplicitValue(lexer::Token::Reflect(span));
 }
-else if (__jakt_enum_value == TRY(ByteString::from_utf8("return"sv))) {
+else if (__jakt_enum_value == (ByteString::must_from_utf8("return"sv))) {
 return JaktInternal::ExplicitValue(lexer::Token::Return(span));
 }
-else if (__jakt_enum_value == TRY(ByteString::from_utf8("restricted"sv))) {
+else if (__jakt_enum_value == (ByteString::must_from_utf8("restricted"sv))) {
 return JaktInternal::ExplicitValue(lexer::Token::Restricted(span));
 }
-else if (__jakt_enum_value == TRY(ByteString::from_utf8("sizeof"sv))) {
+else if (__jakt_enum_value == (ByteString::must_from_utf8("sizeof"sv))) {
 return JaktInternal::ExplicitValue(lexer::Token::Sizeof(span));
 }
-else if (__jakt_enum_value == TRY(ByteString::from_utf8("struct"sv))) {
+else if (__jakt_enum_value == (ByteString::must_from_utf8("struct"sv))) {
 return JaktInternal::ExplicitValue(lexer::Token::Struct(span));
 }
-else if (__jakt_enum_value == TRY(ByteString::from_utf8("this"sv))) {
+else if (__jakt_enum_value == (ByteString::must_from_utf8("this"sv))) {
 return JaktInternal::ExplicitValue(lexer::Token::This(span));
 }
-else if (__jakt_enum_value == TRY(ByteString::from_utf8("throw"sv))) {
+else if (__jakt_enum_value == (ByteString::must_from_utf8("throw"sv))) {
 return JaktInternal::ExplicitValue(lexer::Token::Throw(span));
 }
-else if (__jakt_enum_value == TRY(ByteString::from_utf8("throws"sv))) {
+else if (__jakt_enum_value == (ByteString::must_from_utf8("throws"sv))) {
 return JaktInternal::ExplicitValue(lexer::Token::Throws(span));
 }
-else if (__jakt_enum_value == TRY(ByteString::from_utf8("true"sv))) {
+else if (__jakt_enum_value == (ByteString::must_from_utf8("true"sv))) {
 return JaktInternal::ExplicitValue(lexer::Token::True(span));
 }
-else if (__jakt_enum_value == TRY(ByteString::from_utf8("try"sv))) {
+else if (__jakt_enum_value == (ByteString::must_from_utf8("try"sv))) {
 return JaktInternal::ExplicitValue(lexer::Token::Try(span));
 }
-else if (__jakt_enum_value == TRY(ByteString::from_utf8("unsafe"sv))) {
+else if (__jakt_enum_value == (ByteString::must_from_utf8("unsafe"sv))) {
 return JaktInternal::ExplicitValue(lexer::Token::Unsafe(span));
 }
-else if (__jakt_enum_value == TRY(ByteString::from_utf8("virtual"sv))) {
+else if (__jakt_enum_value == (ByteString::must_from_utf8("virtual"sv))) {
 return JaktInternal::ExplicitValue(lexer::Token::Virtual(span));
 }
-else if (__jakt_enum_value == TRY(ByteString::from_utf8("weak"sv))) {
+else if (__jakt_enum_value == (ByteString::must_from_utf8("weak"sv))) {
 return JaktInternal::ExplicitValue(lexer::Token::Weak(span));
 }
-else if (__jakt_enum_value == TRY(ByteString::from_utf8("while"sv))) {
+else if (__jakt_enum_value == (ByteString::must_from_utf8("while"sv))) {
 return JaktInternal::ExplicitValue(lexer::Token::While(span));
 }
-else if (__jakt_enum_value == TRY(ByteString::from_utf8("yield"sv))) {
+else if (__jakt_enum_value == (ByteString::must_from_utf8("yield"sv))) {
 return JaktInternal::ExplicitValue(lexer::Token::Yield(span));
 }
-else if (__jakt_enum_value == TRY(ByteString::from_utf8("guard"sv))) {
+else if (__jakt_enum_value == (ByteString::must_from_utf8("guard"sv))) {
 return JaktInternal::ExplicitValue(lexer::Token::Guard(span));
 }
-else if (__jakt_enum_value == TRY(ByteString::from_utf8("requires"sv))) {
+else if (__jakt_enum_value == (ByteString::must_from_utf8("requires"sv))) {
 return JaktInternal::ExplicitValue(lexer::Token::Requires(span));
 }
-else if (__jakt_enum_value == TRY(ByteString::from_utf8("implements"sv))) {
+else if (__jakt_enum_value == (ByteString::must_from_utf8("implements"sv))) {
 return JaktInternal::ExplicitValue(lexer::Token::Implements(span));
 }
-else if (__jakt_enum_value == TRY(ByteString::from_utf8("trait"sv))) {
+else if (__jakt_enum_value == (ByteString::must_from_utf8("trait"sv))) {
 return JaktInternal::ExplicitValue(lexer::Token::Trait(span));
 }
 else {
@@ -5903,16 +5903,16 @@ return ({
 auto&& __jakt_match_variant = *this;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 0 /* None */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8(""sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8(""sv)));
 };/*case end*/
 case 1 /* Hexadecimal */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("0x"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("0x"sv)));
 };/*case end*/
 case 2 /* Octal */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("0o"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("0o"sv)));
 };/*case end*/
 case 3 /* Binary */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("0b"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("0b"sv)));
 };/*case end*/
 default: VERIFY_NOT_REACHED();}/*switch end*/
 }()

--- a/bootstrap/stage0/lexer.h
+++ b/bootstrap/stage0/lexer.h
@@ -5,43 +5,30 @@
 #include "compiler.h"
 namespace Jakt {
 namespace lexer {
-struct Lexer {
-  public:
-public: size_t index;public: JaktInternal::DynamicArray<u8> input;public: NonnullRefPtr<compiler::Compiler> compiler;public: JaktInternal::Optional<JaktInternal::DynamicArray<u8>> comment_contents;public: JaktInternal::Set<ByteString> illegal_cpp_keywords;public: ErrorOr<JaktInternal::Optional<ByteString>> consume_comment_contents();
-public: ErrorOr<lexer::Token> lex_quoted_string(u8 const delimiter);
-public: ErrorOr<JaktInternal::Optional<lexer::Token>> next();
-public: ErrorOr<lexer::Token> lex_character_constant_or_name();
-public: lexer::Token lex_dot();
-public: lexer::Token lex_question_mark();
-public: ErrorOr<lexer::Token> lex_forward_slash();
-public: u8 peek_behind(size_t const steps) const;
-public: u8 peek_ahead(size_t const steps) const;
-public: lexer::Token lex_asterisk();
-public: lexer::Token lex_minus();
-public: u8 peek() const;
-public: lexer::Token lex_percent_sign();
-public: ErrorOr<lexer::Token> lex_number_or_name();
-public: lexer::Token lex_less_than();
-public: bool eof() const;
-public: Lexer(size_t a_index, JaktInternal::DynamicArray<u8> a_input, NonnullRefPtr<compiler::Compiler> a_compiler, JaktInternal::Optional<JaktInternal::DynamicArray<u8>> a_comment_contents, JaktInternal::Set<ByteString> a_illegal_cpp_keywords);
-
-public: lexer::Token lex_ampersand();
-public: utility::Span span(size_t const start, size_t const end) const;
-public: lexer::Token lex_plus();
-public: lexer::Token lex_exclamation_point();
-public: ErrorOr<lexer::LiteralSuffix> consume_numeric_literal_suffix();
-public: lexer::Token lex_colon();
-public: bool valid_digit(lexer::LiteralPrefix const prefix, u8 const digit, bool const decimal_allowed);
-public: ErrorOr<void> error(ByteString const message, utility::Span const span);
-public: lexer::Token lex_equals();
-public: ErrorOr<ByteString> substring(size_t const start, size_t const length) const;
-public: lexer::Token lex_greater_than();
-public: lexer::Token lex_pipe();
-public: lexer::Token lex_caret();
-public: ErrorOr<lexer::Token> lex_number();
-public: static ErrorOr<JaktInternal::DynamicArray<lexer::Token>> lex(NonnullRefPtr<compiler::Compiler> const compiler);
-public: ErrorOr<ByteString> debug_description() const;
-};struct LiteralSuffix {
+struct LiteralPrefix {
+u8 __jakt_variant_index = 0;
+union VariantData {
+u8 __jakt_uninit_value;
+constexpr VariantData() {}
+~VariantData() {}
+} as;
+constexpr u8 __jakt_init_index() const noexcept { return __jakt_variant_index - 1; }ErrorOr<ByteString> debug_description() const;
+[[nodiscard]] static LiteralPrefix None();
+[[nodiscard]] static LiteralPrefix Hexadecimal();
+[[nodiscard]] static LiteralPrefix Octal();
+[[nodiscard]] static LiteralPrefix Binary();
+~LiteralPrefix();
+LiteralPrefix& operator=(LiteralPrefix const &);
+LiteralPrefix& operator=(LiteralPrefix &&);
+LiteralPrefix(LiteralPrefix const&);
+LiteralPrefix(LiteralPrefix &&);
+private: void __jakt_destroy_variant();
+public:
+ErrorOr<ByteString> to_string() const;
+private:
+LiteralPrefix() {};
+};
+struct LiteralSuffix {
 u8 __jakt_variant_index = 0;
 union VariantData {
 u8 __jakt_uninit_value;
@@ -71,29 +58,6 @@ public:
 ErrorOr<ByteString> to_string() const;
 private:
 LiteralSuffix() {};
-};
-struct LiteralPrefix {
-u8 __jakt_variant_index = 0;
-union VariantData {
-u8 __jakt_uninit_value;
-constexpr VariantData() {}
-~VariantData() {}
-} as;
-constexpr u8 __jakt_init_index() const noexcept { return __jakt_variant_index - 1; }ErrorOr<ByteString> debug_description() const;
-[[nodiscard]] static LiteralPrefix None();
-[[nodiscard]] static LiteralPrefix Hexadecimal();
-[[nodiscard]] static LiteralPrefix Octal();
-[[nodiscard]] static LiteralPrefix Binary();
-~LiteralPrefix();
-LiteralPrefix& operator=(LiteralPrefix const &);
-LiteralPrefix& operator=(LiteralPrefix &&);
-LiteralPrefix(LiteralPrefix const&);
-LiteralPrefix(LiteralPrefix &&);
-private: void __jakt_destroy_variant();
-public:
-ErrorOr<ByteString> to_string() const;
-private:
-LiteralPrefix() {};
 };
 struct Token {
 u8 __jakt_variant_index = 0;
@@ -576,10 +540,46 @@ utility::Span span() const;
 private:
 Token() {};
 };
-}
+struct Lexer {
+  public:
+public: size_t index;public: JaktInternal::DynamicArray<u8> input;public: NonnullRefPtr<compiler::Compiler> compiler;public: JaktInternal::Optional<JaktInternal::DynamicArray<u8>> comment_contents;public: JaktInternal::Set<ByteString> illegal_cpp_keywords;public: ErrorOr<JaktInternal::Optional<ByteString>> consume_comment_contents();
+public: ErrorOr<lexer::Token> lex_quoted_string(u8 const delimiter);
+public: ErrorOr<JaktInternal::Optional<lexer::Token>> next();
+public: ErrorOr<lexer::Token> lex_character_constant_or_name();
+public: lexer::Token lex_dot();
+public: lexer::Token lex_question_mark();
+public: ErrorOr<lexer::Token> lex_forward_slash();
+public: u8 peek_behind(size_t const steps) const;
+public: u8 peek_ahead(size_t const steps) const;
+public: lexer::Token lex_asterisk();
+public: lexer::Token lex_minus();
+public: u8 peek() const;
+public: lexer::Token lex_percent_sign();
+public: ErrorOr<lexer::Token> lex_number_or_name();
+public: lexer::Token lex_less_than();
+public: bool eof() const;
+public: Lexer(size_t a_index, JaktInternal::DynamicArray<u8> a_input, NonnullRefPtr<compiler::Compiler> a_compiler, JaktInternal::Optional<JaktInternal::DynamicArray<u8>> a_comment_contents, JaktInternal::Set<ByteString> a_illegal_cpp_keywords);
+
+public: lexer::Token lex_ampersand();
+public: utility::Span span(size_t const start, size_t const end) const;
+public: lexer::Token lex_plus();
+public: lexer::Token lex_exclamation_point();
+public: ErrorOr<lexer::LiteralSuffix> consume_numeric_literal_suffix();
+public: lexer::Token lex_colon();
+public: bool valid_digit(lexer::LiteralPrefix const prefix, u8 const digit, bool const decimal_allowed);
+public: ErrorOr<void> error(ByteString const message, utility::Span const span);
+public: lexer::Token lex_equals();
+public: ErrorOr<ByteString> substring(size_t const start, size_t const length) const;
+public: lexer::Token lex_greater_than();
+public: lexer::Token lex_pipe();
+public: lexer::Token lex_caret();
+public: ErrorOr<lexer::Token> lex_number();
+public: static ErrorOr<JaktInternal::DynamicArray<lexer::Token>> lex(NonnullRefPtr<compiler::Compiler> const compiler);
+public: ErrorOr<ByteString> debug_description() const;
+};}
 } // namespace Jakt
-template<>struct Jakt::Formatter<Jakt::lexer::Lexer> : Jakt::Formatter<Jakt::StringView>{
-Jakt::ErrorOr<void> format(Jakt::FormatBuilder& builder, Jakt::lexer::Lexer const& value) {
+template<>struct Jakt::Formatter<Jakt::lexer::LiteralPrefix> : Jakt::Formatter<Jakt::StringView>{
+Jakt::ErrorOr<void> format(Jakt::FormatBuilder& builder, Jakt::lexer::LiteralPrefix const& value) {
 JaktInternal::PrettyPrint::ScopedEnable pretty_print_enable { m_alternative_form };Jakt::ErrorOr<void> format_error = Jakt::Formatter<Jakt::StringView>::format(builder, MUST(value.debug_description()));return format_error;}
 };
 namespace Jakt {
@@ -590,14 +590,14 @@ JaktInternal::PrettyPrint::ScopedEnable pretty_print_enable { m_alternative_form
 };
 namespace Jakt {
 } // namespace Jakt
-template<>struct Jakt::Formatter<Jakt::lexer::LiteralPrefix> : Jakt::Formatter<Jakt::StringView>{
-Jakt::ErrorOr<void> format(Jakt::FormatBuilder& builder, Jakt::lexer::LiteralPrefix const& value) {
+template<>struct Jakt::Formatter<Jakt::lexer::Token> : Jakt::Formatter<Jakt::StringView>{
+Jakt::ErrorOr<void> format(Jakt::FormatBuilder& builder, Jakt::lexer::Token const& value) {
 JaktInternal::PrettyPrint::ScopedEnable pretty_print_enable { m_alternative_form };Jakt::ErrorOr<void> format_error = Jakt::Formatter<Jakt::StringView>::format(builder, MUST(value.debug_description()));return format_error;}
 };
 namespace Jakt {
 } // namespace Jakt
-template<>struct Jakt::Formatter<Jakt::lexer::Token> : Jakt::Formatter<Jakt::StringView>{
-Jakt::ErrorOr<void> format(Jakt::FormatBuilder& builder, Jakt::lexer::Token const& value) {
+template<>struct Jakt::Formatter<Jakt::lexer::Lexer> : Jakt::Formatter<Jakt::StringView>{
+Jakt::ErrorOr<void> format(Jakt::FormatBuilder& builder, Jakt::lexer::Lexer const& value) {
 JaktInternal::PrettyPrint::ScopedEnable pretty_print_enable { m_alternative_form };Jakt::ErrorOr<void> format_error = Jakt::Formatter<Jakt::StringView>::format(builder, MUST(value.debug_description()));return format_error;}
 };
 namespace Jakt {

--- a/bootstrap/stage0/main.cpp
+++ b/bootstrap/stage0/main.cpp
@@ -56,16 +56,16 @@ ByteString const space = ({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<ByteString,ErrorOr<void>>{
 auto __jakt_enum_value = (next_char);
 if (__jakt_enum_value == static_cast<u8>(u8' ')) {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8(""sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8(""sv)));
 }
 else if (__jakt_enum_value == static_cast<u8>(u8'\t')) {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8(""sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8(""sv)));
 }
 else if (__jakt_enum_value == static_cast<u8>(u8'/')) {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8(""sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8(""sv)));
 }
 else {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8(" "sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8(" "sv)));
 }
 }());
     if (_jakt_value.is_return())
@@ -83,7 +83,7 @@ if (__jakt_enum_value == true) {
 return JaktInternal::ExplicitValue(TRY((indent(((formatted_token).indent)))));
 }
 else {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8(" "sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8(" "sv)));
 }
 }());
     if (_jakt_value.is_return())
@@ -146,7 +146,7 @@ TRY((((formatted_file).append_string(TRY((__jakt_format((StringView::from_string
 }
 
 if (((((formatted_token).token)).__jakt_init_index() == 55 /* Eol */)){
-TRY((((formatted_file).append_string(TRY(ByteString::from_utf8("\n"sv))))));
+TRY((((formatted_file).append_string((ByteString::must_from_utf8("\n"sv))))));
 }
 }
 
@@ -172,7 +172,7 @@ return {};
 ErrorOr<void> install(jakt__path::Path const from,jakt__path::Path const to) {
 {
 AK::Queue<JaktInternal::Tuple<jakt__path::Path,jakt__path::Path>> directories_to_copy = AK::Queue<JaktInternal::Tuple<jakt__path::Path,jakt__path::Path>>();
-((directories_to_copy).enqueue((Tuple{from, TRY((jakt__path::Path::from_string(TRY(ByteString::from_utf8("."sv)))))})));
+((directories_to_copy).enqueue((Tuple{from, TRY((jakt__path::Path::from_string((ByteString::must_from_utf8("."sv)))))})));
 while ((!(((directories_to_copy).is_empty())))){
 JaktInternal::Tuple<jakt__path::Path,jakt__path::Path> const directory_relative_dir_ = ((directories_to_copy).dequeue());
 jakt__path::Path const directory = ((directory_relative_dir_).template get<0>());
@@ -294,7 +294,7 @@ return (infallible_enum_cast<jakt__prelude__operators::Ordering>((JaktInternal::
 warnln((StringView::from_string_literal("{}"sv)),TRY((usage())));
 return static_cast<int>(1);
 }
-if (((((args)[static_cast<i64>(1LL)])) == (TRY(ByteString::from_utf8("cross"sv))))){
+if (((((args)[static_cast<i64>(1LL)])) == ((ByteString::must_from_utf8("cross"sv))))){
 return TRY((selfhost_crosscompiler_main(args)));
 }
 return TRY((compiler_main(args)));
@@ -304,7 +304,7 @@ return 0;
 
 ErrorOr<ByteString> usage() {
 {
-return TRY(ByteString::from_utf8("usage: jakt [cross] [-h] [OPTIONS] <filename>"sv));
+return (ByteString::must_from_utf8("usage: jakt [cross] [-h] [OPTIONS] <filename>"sv));
 }
 }
 
@@ -348,78 +348,78 @@ return files_found;
 ErrorOr<int> compiler_main(JaktInternal::DynamicArray<ByteString> const args) {
 {
 jakt__arguments::ArgsParser args_parser = TRY((jakt__arguments::ArgsParser::from_args(args)));
-if (TRY((((args_parser).flag((TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("-h"sv)), TRY(ByteString::from_utf8("--help"sv))}))))))))){
+if (TRY((((args_parser).flag((TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("-h"sv)), (ByteString::must_from_utf8("--help"sv))}))))))))){
 outln((StringView::from_string_literal("{}\n"sv)),TRY((usage())));
 outln((StringView::from_string_literal("{}"sv)),TRY((help())));
 return static_cast<int>(0);
 }
-if (TRY((((args_parser).flag((TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("-v"sv)), TRY(ByteString::from_utf8("--version"sv))}))))))))){
-outln((StringView::from_string_literal("{}"sv)),TRY(ByteString::from_utf8("07312d7561c2ecc1f3d0e2c208a93d90a36acb62"sv)));
+if (TRY((((args_parser).flag((TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("-v"sv)), (ByteString::must_from_utf8("--version"sv))}))))))))){
+outln((StringView::from_string_literal("{}"sv)),(ByteString::must_from_utf8("9ac9a328936b5806ab73b9b5051e1bcc2b9911a9"sv)));
 return static_cast<int>(0);
 }
 jakt__path::Path const current_executable_path = TRY((jakt__path::Path::from_string(TRY((File::current_executable_path())))));
 jakt__path::Path const install_base_path = TRY((((TRY((((current_executable_path).parent())))).parent())));
-jakt__path::Path const default_runtime_path = TRY((((install_base_path).join(TRY(ByteString::from_utf8("include/runtime"sv))))));
-jakt__path::Path const default_runtime_library_path = TRY((((install_base_path).join(TRY(ByteString::from_utf8("lib"sv))))));
+jakt__path::Path const default_runtime_path = TRY((((install_base_path).join((ByteString::must_from_utf8("include/runtime"sv))))));
+jakt__path::Path const default_runtime_library_path = TRY((((install_base_path).join((ByteString::must_from_utf8("lib"sv))))));
 ByteString const default_compiler_path = ({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<ByteString,ErrorOr<int>>{
 auto __jakt_enum_value = (false);
 if (__jakt_enum_value == true) {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("clang-cl"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("clang-cl"sv)));
 }
 else {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("clang++"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("clang++"sv)));
 }
 }());
     if (_jakt_value.is_return())
         return _jakt_value.release_return();
     _jakt_value.release_value();
 });
-bool const optimize = TRY((((args_parser).flag((TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("-O"sv))}))))))));
-bool const lexer_debug = TRY((((args_parser).flag((TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("-dl"sv))}))))))));
-bool const parser_debug = TRY((((args_parser).flag((TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("-dp"sv))}))))))));
-bool const typechecker_debug = TRY((((args_parser).flag((TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("-dt"sv))}))))))));
-bool const build_executable = (!(TRY((((args_parser).flag((TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("-S"sv)), TRY(ByteString::from_utf8("--emit-cpp-source-only"sv))}))))))))));
-bool const run_executable = TRY((((args_parser).flag((TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("-cr"sv)), TRY(ByteString::from_utf8("--compile-run"sv))}))))))));
-bool const codegen_debug = TRY((((args_parser).flag((TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("-d"sv))}))))))));
-bool const debug_print = TRY((((args_parser).flag((TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("--debug-print"sv))}))))))));
-bool const prettify_cpp_source = TRY((((args_parser).flag((TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("-p"sv)), TRY(ByteString::from_utf8("--prettify-cpp-source"sv))}))))))));
-bool const json_errors = TRY((((args_parser).flag((TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("-j"sv)), TRY(ByteString::from_utf8("--json-errors"sv))}))))))));
-bool const dump_type_hints = TRY((((args_parser).flag((TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("-H"sv)), TRY(ByteString::from_utf8("--type-hints"sv))}))))))));
-bool const dump_try_hints = TRY((((args_parser).flag((TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("--try-hints"sv))}))))))));
-bool const check_only = TRY((((args_parser).flag((TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("-c"sv)), TRY(ByteString::from_utf8("--check-only"sv))}))))))));
-JaktInternal::Optional<ByteString> const generate_depfile = TRY((((args_parser).option((TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("-M"sv)), TRY(ByteString::from_utf8("--dep-file"sv))}))))))));
-JaktInternal::Optional<ByteString> const target_triple = TRY((((args_parser).option((TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("-T"sv)), TRY(ByteString::from_utf8("--target-triple"sv))}))))))));
-ByteString const runtime_library_path = TRY((((args_parser).option((TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("-RLP"sv)), TRY(ByteString::from_utf8("--runtime-library-path"sv))})))))))).value_or_lazy_evaluated([&] { return ((default_runtime_library_path).to_string()); });
-ByteString compiler_job_count = TRY((TRY((((args_parser).option((TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("-J"sv)), TRY(ByteString::from_utf8("--jobs"sv))})))))))).try_value_or_lazy_evaluated([&]() -> ErrorOr<ByteString> { return TRY(ByteString::from_utf8("2"sv)); })));
+bool const optimize = TRY((((args_parser).flag((TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("-O"sv))}))))))));
+bool const lexer_debug = TRY((((args_parser).flag((TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("-dl"sv))}))))))));
+bool const parser_debug = TRY((((args_parser).flag((TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("-dp"sv))}))))))));
+bool const typechecker_debug = TRY((((args_parser).flag((TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("-dt"sv))}))))))));
+bool const build_executable = (!(TRY((((args_parser).flag((TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("-S"sv)), (ByteString::must_from_utf8("--emit-cpp-source-only"sv))}))))))))));
+bool const run_executable = TRY((((args_parser).flag((TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("-cr"sv)), (ByteString::must_from_utf8("--compile-run"sv))}))))))));
+bool const codegen_debug = TRY((((args_parser).flag((TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("-d"sv))}))))))));
+bool const debug_print = TRY((((args_parser).flag((TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("--debug-print"sv))}))))))));
+bool const prettify_cpp_source = TRY((((args_parser).flag((TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("-p"sv)), (ByteString::must_from_utf8("--prettify-cpp-source"sv))}))))))));
+bool const json_errors = TRY((((args_parser).flag((TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("-j"sv)), (ByteString::must_from_utf8("--json-errors"sv))}))))))));
+bool const dump_type_hints = TRY((((args_parser).flag((TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("-H"sv)), (ByteString::must_from_utf8("--type-hints"sv))}))))))));
+bool const dump_try_hints = TRY((((args_parser).flag((TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("--try-hints"sv))}))))))));
+bool const check_only = TRY((((args_parser).flag((TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("-c"sv)), (ByteString::must_from_utf8("--check-only"sv))}))))))));
+JaktInternal::Optional<ByteString> const generate_depfile = TRY((((args_parser).option((TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("-M"sv)), (ByteString::must_from_utf8("--dep-file"sv))}))))))));
+JaktInternal::Optional<ByteString> const target_triple = TRY((((args_parser).option((TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("-T"sv)), (ByteString::must_from_utf8("--target-triple"sv))}))))))));
+ByteString const runtime_library_path = TRY((((args_parser).option((TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("-RLP"sv)), (ByteString::must_from_utf8("--runtime-library-path"sv))})))))))).value_or_lazy_evaluated([&] { return ((default_runtime_library_path).to_string()); });
+ByteString compiler_job_count = TRY((TRY((((args_parser).option((TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("-J"sv)), (ByteString::must_from_utf8("--jobs"sv))})))))))).try_value_or_lazy_evaluated([&]() -> ErrorOr<ByteString> { return (ByteString::must_from_utf8("2"sv)); })));
 if (false){
-(compiler_job_count = TRY(ByteString::from_utf8("1"sv)));
+(compiler_job_count = (ByteString::must_from_utf8("1"sv)));
 }
-ByteString const clang_format_path = TRY((TRY((((args_parser).option((TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("-F"sv)), TRY(ByteString::from_utf8("--clang-format-path"sv))})))))))).try_value_or_lazy_evaluated([&]() -> ErrorOr<ByteString> { return TRY(ByteString::from_utf8("clang-format"sv)); })));
-ByteString const runtime_path = TRY((((args_parser).option((TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("-R"sv)), TRY(ByteString::from_utf8("--runtime-path"sv))})))))))).value_or_lazy_evaluated([&] { return ((default_runtime_path).to_string()); });
-JaktInternal::Optional<ByteString> const assume_main_file_path = TRY((((args_parser).option((TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("--assume-main-file-path"sv))}))))))));
-jakt__path::Path const binary_dir = TRY((jakt__path::Path::from_string(TRY((TRY((((args_parser).option((TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("-B"sv)), TRY(ByteString::from_utf8("--binary-dir"sv))})))))))).try_value_or_lazy_evaluated([&]() -> ErrorOr<ByteString> { return TRY(ByteString::from_utf8("build"sv)); }))))));
-JaktInternal::Optional<ByteString> const dot_clang_format_path = TRY((((args_parser).option((TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("-D"sv)), TRY(ByteString::from_utf8("--dot-clang-format-path"sv))}))))))));
-ByteString const cxx_compiler_path = TRY((((args_parser).option((TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("-C"sv)), TRY(ByteString::from_utf8("--cxx-compiler-path"sv))})))))))).value_or_lazy_evaluated([&] { return default_compiler_path; });
-JaktInternal::Optional<ByteString> const archiver_path = TRY((((args_parser).option((TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("-A"sv)), TRY(ByteString::from_utf8("--archiver"sv))}))))))));
-JaktInternal::Optional<ByteString> const link_archive = TRY((((args_parser).option((TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("-a"sv)), TRY(ByteString::from_utf8("--link-archive"sv))}))))))));
-bool const archive_link_support_libs = TRY((((args_parser).flag((TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("--archive-link-support-libs"sv))}))))))));
-bool const build_static = TRY((((args_parser).flag((TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("--static"sv))}))))))));
-JaktInternal::DynamicArray<ByteString> const extra_include_paths = TRY((((args_parser).option_multiple((TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("-I"sv))}))))))));
-JaktInternal::DynamicArray<ByteString> const extra_lib_paths = TRY((((args_parser).option_multiple((TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("-L"sv))}))))))));
-JaktInternal::DynamicArray<ByteString> const extra_link_libs = TRY((((args_parser).option_multiple((TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("-l"sv))}))))))));
-JaktInternal::DynamicArray<ByteString> const extra_linker_args = TRY((((args_parser).option_multiple((TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("-Wl"sv))}))))))));
-JaktInternal::DynamicArray<ByteString> const extra_cpp_files = TRY((((args_parser).option_multiple((TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("-X"sv))}))))))));
-JaktInternal::DynamicArray<ByteString> const extra_cpp_flags = TRY((((args_parser).option_multiple((TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("--extra-cpp-flag"sv))}))))))));
-JaktInternal::Optional<ByteString> const set_output_filename = TRY((((args_parser).option((TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("-o"sv)), TRY(ByteString::from_utf8("--output-filename"sv))}))))))));
-JaktInternal::Optional<ByteString> const goto_def = TRY((((args_parser).option((TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("-g"sv)), TRY(ByteString::from_utf8("--goto-def"sv))}))))))));
-JaktInternal::Optional<ByteString> const goto_type_def = TRY((((args_parser).option((TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("-t"sv)), TRY(ByteString::from_utf8("--goto-type-def"sv))}))))))));
-JaktInternal::Optional<ByteString> const hover = TRY((((args_parser).option((TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("-e"sv)), TRY(ByteString::from_utf8("--hover"sv))}))))))));
-JaktInternal::Optional<ByteString> const completions = TRY((((args_parser).option((TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("-m"sv)), TRY(ByteString::from_utf8("--completions"sv))}))))))));
-bool const print_symbols = TRY((((args_parser).flag((TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("--print-symbols"sv))}))))))));
-JaktInternal::Optional<ByteString> const project_name = TRY((((args_parser).option((TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("--create"sv))}))))))));
-bool const use_ccache = TRY((((args_parser).flag((TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("--use-ccache"sv))}))))))));
-JaktInternal::DynamicArray<ByteString> const user_configuration_specs = TRY((((args_parser).option_multiple((TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("--config"sv))}))))))));
+ByteString const clang_format_path = TRY((TRY((((args_parser).option((TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("-F"sv)), (ByteString::must_from_utf8("--clang-format-path"sv))})))))))).try_value_or_lazy_evaluated([&]() -> ErrorOr<ByteString> { return (ByteString::must_from_utf8("clang-format"sv)); })));
+ByteString const runtime_path = TRY((((args_parser).option((TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("-R"sv)), (ByteString::must_from_utf8("--runtime-path"sv))})))))))).value_or_lazy_evaluated([&] { return ((default_runtime_path).to_string()); });
+JaktInternal::Optional<ByteString> const assume_main_file_path = TRY((((args_parser).option((TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("--assume-main-file-path"sv))}))))))));
+jakt__path::Path const binary_dir = TRY((jakt__path::Path::from_string(TRY((TRY((((args_parser).option((TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("-B"sv)), (ByteString::must_from_utf8("--binary-dir"sv))})))))))).try_value_or_lazy_evaluated([&]() -> ErrorOr<ByteString> { return (ByteString::must_from_utf8("build"sv)); }))))));
+JaktInternal::Optional<ByteString> const dot_clang_format_path = TRY((((args_parser).option((TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("-D"sv)), (ByteString::must_from_utf8("--dot-clang-format-path"sv))}))))))));
+ByteString const cxx_compiler_path = TRY((((args_parser).option((TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("-C"sv)), (ByteString::must_from_utf8("--cxx-compiler-path"sv))})))))))).value_or_lazy_evaluated([&] { return default_compiler_path; });
+JaktInternal::Optional<ByteString> const archiver_path = TRY((((args_parser).option((TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("-A"sv)), (ByteString::must_from_utf8("--archiver"sv))}))))))));
+JaktInternal::Optional<ByteString> const link_archive = TRY((((args_parser).option((TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("-a"sv)), (ByteString::must_from_utf8("--link-archive"sv))}))))))));
+bool const archive_link_support_libs = TRY((((args_parser).flag((TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("--archive-link-support-libs"sv))}))))))));
+bool const build_static = TRY((((args_parser).flag((TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("--static"sv))}))))))));
+JaktInternal::DynamicArray<ByteString> const extra_include_paths = TRY((((args_parser).option_multiple((TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("-I"sv))}))))))));
+JaktInternal::DynamicArray<ByteString> const extra_lib_paths = TRY((((args_parser).option_multiple((TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("-L"sv))}))))))));
+JaktInternal::DynamicArray<ByteString> const extra_link_libs = TRY((((args_parser).option_multiple((TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("-l"sv))}))))))));
+JaktInternal::DynamicArray<ByteString> const extra_linker_args = TRY((((args_parser).option_multiple((TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("-Wl"sv))}))))))));
+JaktInternal::DynamicArray<ByteString> const extra_cpp_files = TRY((((args_parser).option_multiple((TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("-X"sv))}))))))));
+JaktInternal::DynamicArray<ByteString> const extra_cpp_flags = TRY((((args_parser).option_multiple((TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("--extra-cpp-flag"sv))}))))))));
+JaktInternal::Optional<ByteString> const set_output_filename = TRY((((args_parser).option((TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("-o"sv)), (ByteString::must_from_utf8("--output-filename"sv))}))))))));
+JaktInternal::Optional<ByteString> const goto_def = TRY((((args_parser).option((TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("-g"sv)), (ByteString::must_from_utf8("--goto-def"sv))}))))))));
+JaktInternal::Optional<ByteString> const goto_type_def = TRY((((args_parser).option((TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("-t"sv)), (ByteString::must_from_utf8("--goto-type-def"sv))}))))))));
+JaktInternal::Optional<ByteString> const hover = TRY((((args_parser).option((TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("-e"sv)), (ByteString::must_from_utf8("--hover"sv))}))))))));
+JaktInternal::Optional<ByteString> const completions = TRY((((args_parser).option((TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("-m"sv)), (ByteString::must_from_utf8("--completions"sv))}))))))));
+bool const print_symbols = TRY((((args_parser).flag((TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("--print-symbols"sv))}))))))));
+JaktInternal::Optional<ByteString> const project_name = TRY((((args_parser).option((TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("--create"sv))}))))))));
+bool const use_ccache = TRY((((args_parser).flag((TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("--use-ccache"sv))}))))))));
+JaktInternal::DynamicArray<ByteString> const user_configuration_specs = TRY((((args_parser).option_multiple((TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("--config"sv))}))))))));
 JaktInternal::Dictionary<ByteString,ByteString> user_configuration = (TRY((Dictionary<ByteString, ByteString>::create_with_entries({}))));
 {
 JaktInternal::ArrayIterator<ByteString> _magic = ((user_configuration_specs).iterator());
@@ -436,7 +436,7 @@ JaktInternal::DynamicArray<ByteString> const parts = ((spec).split('='));
 auto __jakt_enum_value = (((parts).size()));
 if (__jakt_enum_value == static_cast<size_t>(1ULL)) {
 {
-TRY(user_configuration.set(((parts)[static_cast<i64>(0LL)]), TRY(ByteString::from_utf8("true"sv))));
+TRY(user_configuration.set(((parts)[static_cast<i64>(0LL)]), (ByteString::must_from_utf8("true"sv))));
 }
 return JaktInternal::ExplicitValue<void>();
 }
@@ -468,13 +468,13 @@ return JaktInternal::ExplicitValue<void>();
 }
 }
 
-bool const interpret_run = TRY((((args_parser).flag((TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("-r"sv)), TRY(ByteString::from_utf8("--run"sv))}))))))));
-bool const format = TRY((((args_parser).flag((TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("-f"sv)), TRY(ByteString::from_utf8("--format"sv))}))))))));
-bool const format_inplace = TRY((((args_parser).flag((TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("-fi"sv)), TRY(ByteString::from_utf8("--format-inplace"sv))}))))))));
-bool const format_debug = TRY((((args_parser).flag((TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("-fd"sv)), TRY(ByteString::from_utf8("--format-debug"sv))}))))))));
-ByteString const input_format_range = TRY((TRY((((args_parser).option((TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("-fr"sv)), TRY(ByteString::from_utf8("--format-range"sv))})))))))).try_value_or_lazy_evaluated([&]() -> ErrorOr<ByteString> { return TRY(ByteString::from_utf8(""sv)); })));
-bool const ak_stdlib = TRY((((args_parser).flag((TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("--ak-is-my-only-stdlib"sv))}))))))));
-bool const discover_only = TRY((((args_parser).flag((TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("--discover"sv))}))))))));
+bool const interpret_run = TRY((((args_parser).flag((TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("-r"sv)), (ByteString::must_from_utf8("--run"sv))}))))))));
+bool const format = TRY((((args_parser).flag((TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("-f"sv)), (ByteString::must_from_utf8("--format"sv))}))))))));
+bool const format_inplace = TRY((((args_parser).flag((TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("-fi"sv)), (ByteString::must_from_utf8("--format-inplace"sv))}))))))));
+bool const format_debug = TRY((((args_parser).flag((TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("-fd"sv)), (ByteString::must_from_utf8("--format-debug"sv))}))))))));
+ByteString const input_format_range = TRY((TRY((((args_parser).option((TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("-fr"sv)), (ByteString::must_from_utf8("--format-range"sv))})))))))).try_value_or_lazy_evaluated([&]() -> ErrorOr<ByteString> { return (ByteString::must_from_utf8(""sv)); })));
+bool const ak_stdlib = TRY((((args_parser).flag((TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("--ak-is-my-only-stdlib"sv))}))))))));
+bool const discover_only = TRY((((args_parser).flag((TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("--discover"sv))}))))))));
 size_t const max_concurrent = (infallible_integer_cast<size_t>((({ Optional<u32> __jakt_var_961;
 auto __jakt_var_962 = [&]() -> ErrorOr<u32> { return TRY((value_or_throw<u32>(((compiler_job_count).to_uint())))); }();
 if (__jakt_var_962.is_error()) {{
@@ -484,8 +484,8 @@ return static_cast<int>(1);
 } else {__jakt_var_961 = __jakt_var_962.release_value();
 }
 __jakt_var_961.release_value(); }))));
-if (TRY((((args_parser).flag((TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("--repl"sv))}))))))))){
-repl::REPL repl = TRY((repl::REPL::create(TRY((jakt__path::Path::from_parts((TRY((DynamicArray<ByteString>::create_with({runtime_path, TRY(ByteString::from_utf8("jaktlib"sv))}))))))),target_triple,user_configuration)));
+if (TRY((((args_parser).flag((TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("--repl"sv))}))))))))){
+repl::REPL repl = TRY((repl::REPL::create(TRY((jakt__path::Path::from_parts((TRY((DynamicArray<ByteString>::create_with({runtime_path, (ByteString::must_from_utf8("jaktlib"sv))}))))))),target_triple,user_configuration)));
 TRY((((repl).run())));
 return static_cast<int>(0);
 }
@@ -541,7 +541,7 @@ jakt__path::Path const file_path = TRY((jakt__path::Path::from_string((file_name
 ByteString const guessed_output_filename = TRY((((file_path).basename(true))));
 ByteString const output_filename = ((TRY((((binary_dir).join(set_output_filename.value_or_lazy_evaluated([&] { return guessed_output_filename; })))))).to_string());
 JaktInternal::DynamicArray<error::JaktError> errors = (TRY((DynamicArray<error::JaktError>::create_with({}))));
-NonnullRefPtr<compiler::Compiler> compiler = TRY((compiler::Compiler::__jakt_create((TRY((DynamicArray<jakt__path::Path>::create_with({})))),(TRY((Dictionary<ByteString, utility::FileId>::create_with_entries({})))),(TRY((DynamicArray<error::JaktError>::create_with({})))),JaktInternal::OptionalNone(),(TRY((DynamicArray<u8>::create_with({})))),lexer_debug,parser_debug,false,debug_print,TRY((jakt__path::Path::from_parts((TRY((DynamicArray<ByteString>::create_with({runtime_path, TRY(ByteString::from_utf8("jaktlib"sv))}))))))),extra_include_paths,json_errors,dump_type_hints,dump_try_hints,optimize,target_triple,user_configuration,binary_dir,({
+NonnullRefPtr<compiler::Compiler> compiler = TRY((compiler::Compiler::__jakt_create((TRY((DynamicArray<jakt__path::Path>::create_with({})))),(TRY((Dictionary<ByteString, utility::FileId>::create_with_entries({})))),(TRY((DynamicArray<error::JaktError>::create_with({})))),JaktInternal::OptionalNone(),(TRY((DynamicArray<u8>::create_with({})))),lexer_debug,parser_debug,false,debug_print,TRY((jakt__path::Path::from_parts((TRY((DynamicArray<ByteString>::create_with({runtime_path, (ByteString::must_from_utf8("jaktlib"sv))}))))))),extra_include_paths,json_errors,dump_type_hints,dump_try_hints,optimize,target_triple,user_configuration,binary_dir,({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<JaktInternal::Optional<jakt__path::Path>,ErrorOr<int>>{
 auto __jakt_enum_value = (((assume_main_file_path).has_value()));
 if (__jakt_enum_value == true) {
@@ -558,7 +558,7 @@ VERIFY_NOT_REACHED();
 }))));
 TRY((((compiler)->load_prelude())));
 if (((format || format_debug) || format_inplace)){
-NonnullRefPtr<jakt__file_iterator::RecursiveFileIterator> const directory_or_file_paths = TRY((jakt__file_iterator::RecursiveFileIterator::make(file_path,TRY(ByteString::from_utf8("jakt"sv)))));
+NonnullRefPtr<jakt__file_iterator::RecursiveFileIterator> const directory_or_file_paths = TRY((jakt__file_iterator::RecursiveFileIterator::make(file_path,(ByteString::must_from_utf8("jakt"sv)))));
 {
 NonnullRefPtr<jakt__file_iterator::RecursiveFileIterator> _magic = directory_or_file_paths;
 for (;;){
@@ -632,7 +632,7 @@ TRY((((symbol_representations).push(TRY((((symbol).to_json())))))));
 }
 }
 
-outln((StringView::from_string_literal("[{}]"sv)),TRY((utility::join(symbol_representations,TRY(ByteString::from_utf8(","sv))))));
+outln((StringView::from_string_literal("[{}]"sv)),TRY((utility::join(symbol_representations,(ByteString::must_from_utf8(","sv))))));
 return static_cast<int>(0);
 }
 typechecker::Typechecker typechecker = TRY((typechecker::Typechecker::typecheck(compiler,parsed_namespace)));
@@ -675,7 +675,7 @@ JaktInternal::Tuple<ByteString,JaktInternal::DynamicArray<ids::FunctionId>> cons
 ByteString const function_name = ((jakt__function_name__overload_set__).template get<0>());
 JaktInternal::DynamicArray<ids::FunctionId> const overload_set = ((jakt__function_name__overload_set__).template get<1>());
 
-if (((function_name) == (TRY(ByteString::from_utf8("main"sv))))){
+if (((function_name) == ((ByteString::must_from_utf8("main"sv))))){
 (main_function_id = ((overload_set)[static_cast<i64>(0LL)]));
 break;
 }
@@ -897,7 +897,7 @@ JaktInternal::Tuple<ByteString,ByteString> const __module_file_path_ = contents_
 ByteString const _ = ((__module_file_path_).template get<0>());
 ByteString const module_file_path = ((__module_file_path_).template get<1>());
 
-if (((module_file_path) == (TRY(ByteString::from_utf8("__prelude__"sv))))){
+if (((module_file_path) == ((ByteString::must_from_utf8("__prelude__"sv))))){
 continue;
 }
 jakt__path::Path const path = TRY((((binary_dir).join(file))));
@@ -937,7 +937,7 @@ JaktInternal::Tuple<ByteString,ByteString> const contents_module_file_path_ = co
 ByteString const contents = ((contents_module_file_path_).template get<0>());
 ByteString const module_file_path = ((contents_module_file_path_).template get<1>());
 
-if (((module_file_path) == (TRY(ByteString::from_utf8("__prelude__"sv))))){
+if (((module_file_path) == ((ByteString::must_from_utf8("__prelude__"sv))))){
 continue;
 }
 ByteString const file = TRY((escape_for_depfile(module_file_path)));
@@ -1068,7 +1068,7 @@ JaktInternal::Tuple<ByteString,JaktInternal::Tuple<ByteString,ByteString>> const
 ByteString const file_name = ((jakt__file_name_____).template get<0>());
 JaktInternal::Tuple<ByteString,ByteString> const _ = ((jakt__file_name_____).template get<1>());
 
-if (((file_name).ends_with(TRY(ByteString::from_utf8(".h"sv))))){
+if (((file_name).ends_with((ByteString::must_from_utf8(".h"sv))))){
 continue;
 }
 TRY((((files).push(file_name))));
@@ -1093,21 +1093,21 @@ TRY((((files).push(file))));
 }
 
 build::Builder builder = TRY((build::Builder::for_building(files,max_concurrent)));
-JaktInternal::DynamicArray<ByteString> extra_compiler_flags = (TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("-c"sv))}))));
+JaktInternal::DynamicArray<ByteString> extra_compiler_flags = (TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("-c"sv))}))));
 if (ak_stdlib){
-TRY((((extra_compiler_flags).push(TRY(ByteString::from_utf8("-DJAKT_USING_AK_AS_STANDARD_LIBRARY=1"sv))))));
+TRY((((extra_compiler_flags).push((ByteString::must_from_utf8("-DJAKT_USING_AK_AS_STANDARD_LIBRARY=1"sv))))));
 }
 if (build_static){
-TRY((((extra_compiler_flags).push(TRY(ByteString::from_utf8("-static"sv))))));
+TRY((((extra_compiler_flags).push((ByteString::must_from_utf8("-static"sv))))));
 }
 if (((target_triple).has_value())){
-if ((TRY((compiler_is(TRY(ByteString::from_utf8("clang++"sv))))) && [](ByteString const& self, ByteString rhs) -> bool {
+if ((TRY((compiler_is((ByteString::must_from_utf8("clang++"sv))))) && [](ByteString const& self, ByteString rhs) -> bool {
 {
 return (!(((self) == (rhs))));
 }
 }
 ((target_triple.value()),TRY((((TRY((jakt__platform::Target::active()))).name(false))))))){
-TRY((((extra_compiler_flags).push(TRY(ByteString::from_utf8("-target"sv))))));
+TRY((((extra_compiler_flags).push((ByteString::must_from_utf8("-target"sv))))));
 TRY((((extra_compiler_flags).push((target_triple.value())))));
 }
 }
@@ -1156,10 +1156,10 @@ VERIFY_NOT_REACHED();
 if (((link_archive).has_value())){
 JaktInternal::DynamicArray<ByteString> extra_arguments = (TRY((DynamicArray<ByteString>::create_with({}))));
 if (archive_link_support_libs){
-TRY((((extra_arguments).push(((TRY((((runtime_lib_path).join(TRY((platform::library_name_for_target(TRY(ByteString::from_utf8("main"sv)),target)))))))).to_string())))));
-TRY((((extra_arguments).push(((TRY((((runtime_lib_path).join(TRY((platform::library_name_for_target(TRY(ByteString::from_utf8("runtime"sv)),target)))))))).to_string())))));
+TRY((((extra_arguments).push(((TRY((((runtime_lib_path).join(TRY((platform::library_name_for_target((ByteString::must_from_utf8("main"sv)),target)))))))).to_string())))));
+TRY((((extra_arguments).push(((TRY((((runtime_lib_path).join(TRY((platform::library_name_for_target((ByteString::must_from_utf8("runtime"sv)),target)))))))).to_string())))));
 }
-auto __jakt_var_970 = [&]() -> ErrorOr<void> { return TRY((((builder).link_into_archive(TRY((archiver_path.try_value_or_lazy_evaluated([&]() -> ErrorOr<ByteString> { return TRY(ByteString::from_utf8("ar"sv)); }))),((TRY((((binary_dir).join((link_archive.value())))))).to_string()),extra_arguments)))), ErrorOr<void>{}; }();
+auto __jakt_var_970 = [&]() -> ErrorOr<void> { return TRY((((builder).link_into_archive(TRY((archiver_path.try_value_or_lazy_evaluated([&]() -> ErrorOr<ByteString> { return (ByteString::must_from_utf8("ar"sv)); }))),((TRY((((binary_dir).join((link_archive.value())))))).to_string()),extra_arguments)))), ErrorOr<void>{}; }();
 if (__jakt_var_970.is_error()) {{
 return static_cast<int>(1);
 }
@@ -1167,7 +1167,7 @@ return static_cast<int>(1);
 ;
 }
 else {
-JaktInternal::DynamicArray<ByteString> extra_arguments = (TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("-g"sv))}))));
+JaktInternal::DynamicArray<ByteString> extra_arguments = (TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("-g"sv))}))));
 {
 JaktInternal::ArrayIterator<ByteString> _magic = ((extra_cpp_flags).iterator());
 for (;;){
@@ -1184,18 +1184,18 @@ TRY((((extra_arguments).push(flag))));
 }
 
 if (((target_triple).has_value())){
-if ((TRY((compiler_is(TRY(ByteString::from_utf8("clang++"sv))))) && [](ByteString const& self, ByteString rhs) -> bool {
+if ((TRY((compiler_is((ByteString::must_from_utf8("clang++"sv))))) && [](ByteString const& self, ByteString rhs) -> bool {
 {
 return (!(((self) == (rhs))));
 }
 }
 ((target_triple.value()),TRY((((TRY((jakt__platform::Target::active()))).name(false))))))){
-TRY((((extra_arguments).push(TRY(ByteString::from_utf8("-target"sv))))));
+TRY((((extra_arguments).push((ByteString::must_from_utf8("-target"sv))))));
 TRY((((extra_arguments).push(TRY((((target).name(true))))))));
 }
 }
-TRY((((extra_arguments).push(((TRY((((runtime_lib_path).join(TRY((platform::library_name_for_target(TRY(ByteString::from_utf8("main"sv)),target)))))))).to_string())))));
-TRY((((extra_arguments).push(((TRY((((runtime_lib_path).join(TRY((platform::library_name_for_target(TRY(ByteString::from_utf8("runtime"sv)),target)))))))).to_string())))));
+TRY((((extra_arguments).push(((TRY((((runtime_lib_path).join(TRY((platform::library_name_for_target((ByteString::must_from_utf8("main"sv)),target)))))))).to_string())))));
+TRY((((extra_arguments).push(((TRY((((runtime_lib_path).join(TRY((platform::library_name_for_target((ByteString::must_from_utf8("runtime"sv)),target)))))))).to_string())))));
 {
 JaktInternal::ArrayIterator<ByteString> _magic = ((extra_lib_paths).iterator());
 for (;;){
@@ -1205,7 +1205,7 @@ break;
 }
 ByteString path = (_magic_value.value());
 {
-TRY((((extra_arguments).push(TRY(ByteString::from_utf8("-L"sv))))));
+TRY((((extra_arguments).push((ByteString::must_from_utf8("-L"sv))))));
 TRY((((extra_arguments).push(path))));
 }
 
@@ -1221,16 +1221,16 @@ break;
 }
 ByteString lib = (_magic_value.value());
 {
-TRY((((extra_arguments).push(TRY(ByteString::from_utf8("-l"sv))))));
+TRY((((extra_arguments).push((ByteString::must_from_utf8("-l"sv))))));
 TRY((((extra_arguments).push(lib))));
 }
 
 }
 }
 
-if ((false && TRY((compiler_is(TRY(ByteString::from_utf8("clang-cl"sv))))))){
-TRY((((extra_arguments).push(TRY(ByteString::from_utf8("/link"sv))))));
-TRY((((extra_arguments).push(TRY(ByteString::from_utf8("/subsystem:console"sv))))));
+if ((false && TRY((compiler_is((ByteString::must_from_utf8("clang-cl"sv))))))){
+TRY((((extra_arguments).push((ByteString::must_from_utf8("/link"sv))))));
+TRY((((extra_arguments).push((ByteString::must_from_utf8("/subsystem:console"sv))))));
 }
 {
 JaktInternal::ArrayIterator<ByteString> _magic = ((extra_linker_args).iterator());
@@ -1265,489 +1265,489 @@ return static_cast<int>(0);
 
 ErrorOr<ByteString> escape_for_depfile(ByteString const input) {
 {
-return ((((((input).replace(TRY(ByteString::from_utf8("$"sv)),TRY(ByteString::from_utf8("$$"sv))))).replace(TRY(ByteString::from_utf8("#"sv)),TRY(ByteString::from_utf8("\\#"sv))))).replace(TRY(ByteString::from_utf8(" "sv)),TRY(ByteString::from_utf8("\\ "sv))));
+return ((((((input).replace((ByteString::must_from_utf8("$"sv)),(ByteString::must_from_utf8("$$"sv))))).replace((ByteString::must_from_utf8("#"sv)),(ByteString::must_from_utf8("\\#"sv))))).replace((ByteString::must_from_utf8(" "sv)),(ByteString::must_from_utf8("\\ "sv))));
 }
 }
 
 ErrorOr<ByteString> help() {
 {
-ByteString output = TRY(ByteString::from_utf8(""sv));
+ByteString output = (ByteString::must_from_utf8(""sv));
 TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 {
 (self = TRY((((self) + (rhs)))));
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8("Non-cross mode:\n"sv)))));
+(output,(ByteString::must_from_utf8("Non-cross mode:\n"sv)))));
 TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 {
 (self = TRY((((self) + (rhs)))));
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8("= General:\n"sv)))));
+(output,(ByteString::must_from_utf8("= General:\n"sv)))));
 TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 {
 (self = TRY((((self) + (rhs)))));
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8("  -h,--help\t\t\t\tPrint this help and exit.\n"sv)))));
+(output,(ByteString::must_from_utf8("  -h,--help\t\t\t\tPrint this help and exit.\n"sv)))));
 TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 {
 (self = TRY((((self) + (rhs)))));
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8("  -v,--version\t\t\t\tPrint the compiler's version and exit.\n"sv)))));
+(output,(ByteString::must_from_utf8("  -v,--version\t\t\t\tPrint the compiler's version and exit.\n"sv)))));
 TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 {
 (self = TRY((((self) + (rhs)))));
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8("  -cr,--compile-run\t\t\tBuild and run an executable file.\n"sv)))));
+(output,(ByteString::must_from_utf8("  -cr,--compile-run\t\t\tBuild and run an executable file.\n"sv)))));
 TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 {
 (self = TRY((((self) + (rhs)))));
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8("  -r,--run\t\t\t\tRun the given file without compiling it (all positional arguments after the file name will be passed to main).\n"sv)))));
+(output,(ByteString::must_from_utf8("  -r,--run\t\t\t\tRun the given file without compiling it (all positional arguments after the file name will be passed to main).\n"sv)))));
 TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 {
 (self = TRY((((self) + (rhs)))));
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8("  --repl\t\t\t\tStart a Read-Eval-Print loop session.\n"sv)))));
+(output,(ByteString::must_from_utf8("  --repl\t\t\t\tStart a Read-Eval-Print loop session.\n"sv)))));
 TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 {
 (self = TRY((((self) + (rhs)))));
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8("  --create NAME\t\t\t\tCreate sample project in $PWD/NAME\n"sv)))));
+(output,(ByteString::must_from_utf8("  --create NAME\t\t\t\tCreate sample project in $PWD/NAME\n"sv)))));
 TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 {
 (self = TRY((((self) + (rhs)))));
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8("= Compilation:\n"sv)))));
+(output,(ByteString::must_from_utf8("= Compilation:\n"sv)))));
 TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 {
 (self = TRY((((self) + (rhs)))));
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8("  --config KEY=VALUE\t\t\tSet a user configuration value.\n"sv)))));
+(output,(ByteString::must_from_utf8("  --config KEY=VALUE\t\t\tSet a user configuration value.\n"sv)))));
 TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 {
 (self = TRY((((self) + (rhs)))));
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8("  -c,--check-only\t\t\tOnly check the code for errors.\n"sv)))));
+(output,(ByteString::must_from_utf8("  -c,--check-only\t\t\tOnly check the code for errors.\n"sv)))));
 TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 {
 (self = TRY((((self) + (rhs)))));
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8("  -d\t\t\t\t\tInsert debug statement spans in generated C++ code.\n"sv)))));
+(output,(ByteString::must_from_utf8("  -d\t\t\t\t\tInsert debug statement spans in generated C++ code.\n"sv)))));
 TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 {
 (self = TRY((((self) + (rhs)))));
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8("  -O\t\t\t\t\tBuild an optimized executable.\n"sv)))));
+(output,(ByteString::must_from_utf8("  -O\t\t\t\t\tBuild an optimized executable.\n"sv)))));
 TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 {
 (self = TRY((((self) + (rhs)))));
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8("  -S,--emit-cpp-source-only\t\tOnly output source (do not build).\n"sv)))));
+(output,(ByteString::must_from_utf8("  -S,--emit-cpp-source-only\t\tOnly output source (do not build).\n"sv)))));
 TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 {
 (self = TRY((((self) + (rhs)))));
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8("  --ak-is-my-only-stdlib\t\tForget about interop, AK is the one and only STL.\n"sv)))));
+(output,(ByteString::must_from_utf8("  --ak-is-my-only-stdlib\t\tForget about interop, AK is the one and only STL.\n"sv)))));
 TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 {
 (self = TRY((((self) + (rhs)))));
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8("  --cxx-compiler-path PATH\t\tPath of the C++ compiler to use when compiling the generated sources.\n\t\t\t\t\tDefaults to clang++.\n"sv)))));
+(output,(ByteString::must_from_utf8("  --cxx-compiler-path PATH\t\tPath of the C++ compiler to use when compiling the generated sources.\n\t\t\t\t\tDefaults to clang++.\n"sv)))));
 TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 {
 (self = TRY((((self) + (rhs)))));
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8("  -M,--dep-file FILE\t\t\tEmit a depfile listing dependencies of the main output.\n"sv)))));
+(output,(ByteString::must_from_utf8("  -M,--dep-file FILE\t\t\tEmit a depfile listing dependencies of the main output.\n"sv)))));
 TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 {
 (self = TRY((((self) + (rhs)))));
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8("  --extra-cpp-flagFLAG\t\t\tPass FLAG to the compiler. Can be specified multiple times.\n"sv)))));
+(output,(ByteString::must_from_utf8("  --extra-cpp-flagFLAG\t\t\tPass FLAG to the compiler. Can be specified multiple times.\n"sv)))));
 TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 {
 (self = TRY((((self) + (rhs)))));
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8("  --use-ccache\t\t\t\tUse ccache when compiling.\n"sv)))));
+(output,(ByteString::must_from_utf8("  --use-ccache\t\t\t\tUse ccache when compiling.\n"sv)))));
 TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 {
 (self = TRY((((self) + (rhs)))));
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8("  -o,--output-filename FILE\t\tName of the output binary.\n\t\t\t\t\tDefaults to the input-filename without the extension.\n"sv)))));
+(output,(ByteString::must_from_utf8("  -o,--output-filename FILE\t\tName of the output binary.\n\t\t\t\t\tDefaults to the input-filename without the extension.\n"sv)))));
 TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 {
 (self = TRY((((self) + (rhs)))));
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8("  -B,--binary-dir PATH\t\t\tOutput directory for compiled files.\n\t\t\t\t\tDefaults to $PWD/build.\n"sv)))));
+(output,(ByteString::must_from_utf8("  -B,--binary-dir PATH\t\t\tOutput directory for compiled files.\n\t\t\t\t\tDefaults to $PWD/build.\n"sv)))));
 TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 {
 (self = TRY((((self) + (rhs)))));
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8("  -I PATH\t\t\t\tAdd PATH to compiler's include list. Can be specified multiple times.\n"sv)))));
+(output,(ByteString::must_from_utf8("  -I PATH\t\t\t\tAdd PATH to compiler's include list. Can be specified multiple times.\n"sv)))));
 TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 {
 (self = TRY((((self) + (rhs)))));
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8("  -J,--jobs NUMBER\t\t\tSpecify the number of jobs to run in parallel, defaults to 2 (1 on windows).\n"sv)))));
+(output,(ByteString::must_from_utf8("  -J,--jobs NUMBER\t\t\tSpecify the number of jobs to run in parallel, defaults to 2 (1 on windows).\n"sv)))));
 TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 {
 (self = TRY((((self) + (rhs)))));
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8("  -L PATH\t\t\t\tAdd PATH to linker's search list. Can be specified multiple times.\n"sv)))));
+(output,(ByteString::must_from_utf8("  -L PATH\t\t\t\tAdd PATH to linker's search list. Can be specified multiple times.\n"sv)))));
 TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 {
 (self = TRY((((self) + (rhs)))));
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8("  -l,--link-with LIB\t\t\tLink executable with LIB. Can be specified multiple times.\n"sv)))));
+(output,(ByteString::must_from_utf8("  -l,--link-with LIB\t\t\tLink executable with LIB. Can be specified multiple times.\n"sv)))));
 TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 {
 (self = TRY((((self) + (rhs)))));
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8("  -T,--target-triple TARGET\t\tSpecify the target triple used for the build, defaults to native.\n"sv)))));
+(output,(ByteString::must_from_utf8("  -T,--target-triple TARGET\t\tSpecify the target triple used for the build, defaults to native.\n"sv)))));
 TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 {
 (self = TRY((((self) + (rhs)))));
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8("  -WlARG\t\t\t\tPass ARG to the linker. Can be specified multiple times.\n"sv)))));
+(output,(ByteString::must_from_utf8("  -WlARG\t\t\t\tPass ARG to the linker. Can be specified multiple times.\n"sv)))));
 TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 {
 (self = TRY((((self) + (rhs)))));
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8("  -X FILE\t\t\t\tPass FILE to the compiler. Can be specified multiple times.\n"sv)))));
+(output,(ByteString::must_from_utf8("  -X FILE\t\t\t\tPass FILE to the compiler. Can be specified multiple times.\n"sv)))));
 TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 {
 (self = TRY((((self) + (rhs)))));
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8("= Debugging:\n"sv)))));
+(output,(ByteString::must_from_utf8("= Debugging:\n"sv)))));
 TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 {
 (self = TRY((((self) + (rhs)))));
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8("  -dl\t\t\t\t\tPrint debug info for the lexer.\n"sv)))));
+(output,(ByteString::must_from_utf8("  -dl\t\t\t\t\tPrint debug info for the lexer.\n"sv)))));
 TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 {
 (self = TRY((((self) + (rhs)))));
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8("  -dp\t\t\t\t\tPrint debug info for the parser.\n"sv)))));
+(output,(ByteString::must_from_utf8("  -dp\t\t\t\t\tPrint debug info for the parser.\n"sv)))));
 TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 {
 (self = TRY((((self) + (rhs)))));
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8("  -dt\t\t\t\t\tPrint debug info for the typechecker.\n"sv)))));
+(output,(ByteString::must_from_utf8("  -dt\t\t\t\t\tPrint debug info for the typechecker.\n"sv)))));
 TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 {
 (self = TRY((((self) + (rhs)))));
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8("  -fd,--format-debug\t\t\tOutput debug info for the formatter.\n"sv)))));
+(output,(ByteString::must_from_utf8("  -fd,--format-debug\t\t\tOutput debug info for the formatter.\n"sv)))));
 TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 {
 (self = TRY((((self) + (rhs)))));
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8("  -p,--prettify-cpp-source\t\tRun emitted C++ source through clang-format.\n"sv)))));
+(output,(ByteString::must_from_utf8("  -p,--prettify-cpp-source\t\tRun emitted C++ source through clang-format.\n"sv)))));
 TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 {
 (self = TRY((((self) + (rhs)))));
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8("  -D,--dot-clang-format-path PATH\tPath to the .clang-format file to use.\n\t\t\t\t\tDefaults to none, invoking clangs default .clang-format file handling.\n"sv)))));
+(output,(ByteString::must_from_utf8("  -D,--dot-clang-format-path PATH\tPath to the .clang-format file to use.\n\t\t\t\t\tDefaults to none, invoking clangs default .clang-format file handling.\n"sv)))));
 TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 {
 (self = TRY((((self) + (rhs)))));
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8("  -F,--clang-format-path PATH\t\tPath to clang-format executable.\n\t\t\t\t\tDefaults to clang-format\n"sv)))));
+(output,(ByteString::must_from_utf8("  -F,--clang-format-path PATH\t\tPath to clang-format executable.\n\t\t\t\t\tDefaults to clang-format\n"sv)))));
 TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 {
 (self = TRY((((self) + (rhs)))));
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8("  --debug-print\t\t\t\tOutput debug print.\n"sv)))));
+(output,(ByteString::must_from_utf8("  --debug-print\t\t\t\tOutput debug print.\n"sv)))));
 TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 {
 (self = TRY((((self) + (rhs)))));
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8("= Formatting:\n"sv)))));
+(output,(ByteString::must_from_utf8("= Formatting:\n"sv)))));
 TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 {
 (self = TRY((((self) + (rhs)))));
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8("  -f,--format\t\t\t\tFormat a file or directory and output the result.\n"sv)))));
+(output,(ByteString::must_from_utf8("  -f,--format\t\t\t\tFormat a file or directory and output the result.\n"sv)))));
 TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 {
 (self = TRY((((self) + (rhs)))));
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8("  -fi,--format-inplace\t\t\tFormat a file or directory and save the result inplace.\n"sv)))));
+(output,(ByteString::must_from_utf8("  -fi,--format-inplace\t\t\tFormat a file or directory and save the result inplace.\n"sv)))));
 TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 {
 (self = TRY((((self) + (rhs)))));
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8("  -fr,--format-range RANGE\t\tEmit part of the document with formatting applied.\n"sv)))));
+(output,(ByteString::must_from_utf8("  -fr,--format-range RANGE\t\tEmit part of the document with formatting applied.\n"sv)))));
 TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 {
 (self = TRY((((self) + (rhs)))));
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8("= IDE integration:\n"sv)))));
+(output,(ByteString::must_from_utf8("= IDE integration:\n"sv)))));
 TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 {
 (self = TRY((((self) + (rhs)))));
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8("  -e,--hover INDEX\t\t\tReturn the type of element at index.\n"sv)))));
+(output,(ByteString::must_from_utf8("  -e,--hover INDEX\t\t\tReturn the type of element at index.\n"sv)))));
 TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 {
 (self = TRY((((self) + (rhs)))));
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8("  -g,--goto-def INDEX\t\t\tReturn the span for the definition at index.\n"sv)))));
+(output,(ByteString::must_from_utf8("  -g,--goto-def INDEX\t\t\tReturn the span for the definition at index.\n"sv)))));
 TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 {
 (self = TRY((((self) + (rhs)))));
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8("  -H,--type-hints\t\t\tEmit machine-readable type hints (for IDE integration).\n"sv)))));
+(output,(ByteString::must_from_utf8("  -H,--type-hints\t\t\tEmit machine-readable type hints (for IDE integration).\n"sv)))));
 TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 {
 (self = TRY((((self) + (rhs)))));
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8("  -m,--completions INDEX\t\tReturn dot completions at index.\n"sv)))));
+(output,(ByteString::must_from_utf8("  -m,--completions INDEX\t\tReturn dot completions at index.\n"sv)))));
 TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 {
 (self = TRY((((self) + (rhs)))));
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8("  --print-symbols\t\t\tEmit a machine-readable (JSON) symbol tree.\n"sv)))));
+(output,(ByteString::must_from_utf8("  --print-symbols\t\t\tEmit a machine-readable (JSON) symbol tree.\n"sv)))));
 TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 {
 (self = TRY((((self) + (rhs)))));
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8("  --try-hints\t\t\t\tEmit machine-readable try hints (for IDE integration).\n"sv)))));
+(output,(ByteString::must_from_utf8("  --try-hints\t\t\t\tEmit machine-readable try hints (for IDE integration).\n"sv)))));
 TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 {
 (self = TRY((((self) + (rhs)))));
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8("  -t,--goto-type-def INDEX\t\tReturn the span for the type definition at index.\n"sv)))));
+(output,(ByteString::must_from_utf8("  -t,--goto-type-def INDEX\t\tReturn the span for the type definition at index.\n"sv)))));
 TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 {
 (self = TRY((((self) + (rhs)))));
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8("= Misc:\n"sv)))));
+(output,(ByteString::must_from_utf8("= Misc:\n"sv)))));
 TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 {
 (self = TRY((((self) + (rhs)))));
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8("  --discover\t\t\t\tDiscover all files in the project, print the dependencies and outputs, then exit.\n"sv)))));
+(output,(ByteString::must_from_utf8("  --discover\t\t\t\tDiscover all files in the project, print the dependencies and outputs, then exit.\n"sv)))));
 TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 {
 (self = TRY((((self) + (rhs)))));
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8("  -j,--json-errors\t\t\tEmit machine-readable (JSON) errors.\n"sv)))));
+(output,(ByteString::must_from_utf8("  -j,--json-errors\t\t\tEmit machine-readable (JSON) errors.\n"sv)))));
 TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 {
 (self = TRY((((self) + (rhs)))));
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8("  --runtime-library-path PATH\t\tSpecify the path to the runtime library.\n"sv)))));
+(output,(ByteString::must_from_utf8("  --runtime-library-path PATH\t\tSpecify the path to the runtime library.\n"sv)))));
 TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 {
 (self = TRY((((self) + (rhs)))));
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8("  --runtime-path PATH\t\t\tSpecify the path to the host runtime headers.\n"sv)))));
+(output,(ByteString::must_from_utf8("  --runtime-path PATH\t\t\tSpecify the path to the host runtime headers.\n"sv)))));
 TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 {
 (self = TRY((((self) + (rhs)))));
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8("  -R,--runtime-path PATH\t\tPath of the Jakt runtime headers.\n\t\t\t\t\tDefaults to $PWD/runtime.\n"sv)))));
+(output,(ByteString::must_from_utf8("  -R,--runtime-path PATH\t\tPath of the Jakt runtime headers.\n\t\t\t\t\tDefaults to $PWD/runtime.\n"sv)))));
 TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 {
 (self = TRY((((self) + (rhs)))));
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8("  --assume-main-file-path PATH\t\tAssume the main file is at PATH.\n"sv)))));
+(output,(ByteString::must_from_utf8("  --assume-main-file-path PATH\t\tAssume the main file is at PATH.\n"sv)))));
 TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 {
 (self = TRY((((self) + (rhs)))));
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8("\nCross mode:\n"sv)))));
+(output,(ByteString::must_from_utf8("\nCross mode:\n"sv)))));
 TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 {
 (self = TRY((((self) + (rhs)))));
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8("All other given options and flags will be passed to the compiler invocation verbatim.\n"sv)))));
+(output,(ByteString::must_from_utf8("All other given options and flags will be passed to the compiler invocation verbatim.\n"sv)))));
 TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 {
 (self = TRY((((self) + (rhs)))));
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8("  --source-file PATH\t\t\tSpecify the path to the source file to compile.\n"sv)))));
+(output,(ByteString::must_from_utf8("  --source-file PATH\t\t\tSpecify the path to the source file to compile.\n"sv)))));
 TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 {
 (self = TRY((((self) + (rhs)))));
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8("  -T,--target-triple TARGET\t\tSpecify the target triple used for the build, defaults to native.\n"sv)))));
+(output,(ByteString::must_from_utf8("  -T,--target-triple TARGET\t\tSpecify the target triple used for the build, defaults to native.\n"sv)))));
 TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 {
 (self = TRY((((self) + (rhs)))));
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8("  --sysroot PATH\t\t\tSpecify the sysroot used for the build.\n"sv)))));
+(output,(ByteString::must_from_utf8("  --sysroot PATH\t\t\tSpecify the sysroot used for the build.\n"sv)))));
 TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 {
 (self = TRY((((self) + (rhs)))));
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8("  --system-include-dir PATH\t\tSpecify a system include directory to use.\n"sv)))));
+(output,(ByteString::must_from_utf8("  --system-include-dir PATH\t\tSpecify a system include directory to use.\n"sv)))));
 TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 {
 (self = TRY((((self) + (rhs)))));
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8("  --system-lib-dir PATH\t\t\tSpecify a system library directory to use.\n"sv)))));
+(output,(ByteString::must_from_utf8("  --system-lib-dir PATH\t\t\tSpecify a system library directory to use.\n"sv)))));
 TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 {
 (self = TRY((((self) + (rhs)))));
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8("  --compiler-include-dir PATH\t\tSpecify a compiler include directory to use.\n"sv)))));
+(output,(ByteString::must_from_utf8("  --compiler-include-dir PATH\t\tSpecify a compiler include directory to use.\n"sv)))));
 TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 {
 (self = TRY((((self) + (rhs)))));
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8("  --compiler-lib-dir PATH\t\tSpecify a compiler library directory to use.\n"sv)))));
+(output,(ByteString::must_from_utf8("  --compiler-lib-dir PATH\t\tSpecify a compiler library directory to use.\n"sv)))));
 TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 {
 (self = TRY((((self) + (rhs)))));
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8("  --install-root PATH\t\t\tSpecify the root directory to install to.\n"sv)))));
+(output,(ByteString::must_from_utf8("  --install-root PATH\t\t\tSpecify the root directory to install to.\n"sv)))));
 TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 {
 (self = TRY((((self) + (rhs)))));
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8("  --only-support-libs\t\t\tOnly build and install support libraries for the target platform.\n"sv)))));
+(output,(ByteString::must_from_utf8("  --only-support-libs\t\t\tOnly build and install support libraries for the target platform.\n"sv)))));
 TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 {
 (self = TRY((((self) + (rhs)))));
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8("  --runtime-lib-path PATH\t\tSpecify the path to the host runtime library.\n"sv)))));
+(output,(ByteString::must_from_utf8("  --runtime-lib-path PATH\t\tSpecify the path to the host runtime library.\n"sv)))));
 return output;
 }
 }
@@ -1796,7 +1796,7 @@ return FormatRange(start,end);
 
 ErrorOr<ByteString> indent(size_t const level) {
 {
-ByteString output = TRY(ByteString::from_utf8(""sv));
+ByteString output = (ByteString::must_from_utf8(""sv));
 {
 JaktInternal::Range<size_t> _magic = (JaktInternal::Range<size_t>{static_cast<size_t>(static_cast<size_t>(0ULL)),static_cast<size_t>(level)});
 for (;;){
@@ -1812,7 +1812,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8("    "sv)))));
+(output,(ByteString::must_from_utf8("    "sv)))));
 }
 
 }
@@ -1858,85 +1858,85 @@ ByteString const arg = ((args_to_process).dequeue());
 ({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<void,ErrorOr<int>>{
 auto __jakt_enum_value = (arg);
-if (__jakt_enum_value == TRY(ByteString::from_utf8("--target-triple"sv))) {
+if (__jakt_enum_value == (ByteString::must_from_utf8("--target-triple"sv))) {
 {
 (target_triple = ((args_to_process).dequeue()));
 }
 return JaktInternal::ExplicitValue<void>();
 }
-else if (__jakt_enum_value == TRY(ByteString::from_utf8("-T"sv))) {
+else if (__jakt_enum_value == (ByteString::must_from_utf8("-T"sv))) {
 {
 (target_triple = ((args_to_process).dequeue()));
 }
 return JaktInternal::ExplicitValue<void>();
 }
-else if (__jakt_enum_value == TRY(ByteString::from_utf8("--sysroot"sv))) {
+else if (__jakt_enum_value == (ByteString::must_from_utf8("--sysroot"sv))) {
 {
 (sysroot = ((args_to_process).dequeue()));
 }
 return JaktInternal::ExplicitValue<void>();
 }
-else if (__jakt_enum_value == TRY(ByteString::from_utf8("--system-lib-dir"sv))) {
+else if (__jakt_enum_value == (ByteString::must_from_utf8("--system-lib-dir"sv))) {
 {
 TRY((((system_lib_dirs).push(((args_to_process).dequeue())))));
 }
 return JaktInternal::ExplicitValue<void>();
 }
-else if (__jakt_enum_value == TRY(ByteString::from_utf8("--system-include-dir"sv))) {
+else if (__jakt_enum_value == (ByteString::must_from_utf8("--system-include-dir"sv))) {
 {
 TRY((((system_include_dirs).push(((args_to_process).dequeue())))));
 }
 return JaktInternal::ExplicitValue<void>();
 }
-else if (__jakt_enum_value == TRY(ByteString::from_utf8("--compiler-include-dir"sv))) {
+else if (__jakt_enum_value == (ByteString::must_from_utf8("--compiler-include-dir"sv))) {
 {
 (compiler_include_dir = ((args_to_process).dequeue()));
 }
 return JaktInternal::ExplicitValue<void>();
 }
-else if (__jakt_enum_value == TRY(ByteString::from_utf8("--compiler-lib-dir"sv))) {
+else if (__jakt_enum_value == (ByteString::must_from_utf8("--compiler-lib-dir"sv))) {
 {
 (compiler_lib_dir = ((args_to_process).dequeue()));
 }
 return JaktInternal::ExplicitValue<void>();
 }
-else if (__jakt_enum_value == TRY(ByteString::from_utf8("--install-root"sv))) {
+else if (__jakt_enum_value == (ByteString::must_from_utf8("--install-root"sv))) {
 {
 (install_root = ((args_to_process).dequeue()));
 }
 return JaktInternal::ExplicitValue<void>();
 }
-else if (__jakt_enum_value == TRY(ByteString::from_utf8("--runtime-lib-path"sv))) {
+else if (__jakt_enum_value == (ByteString::must_from_utf8("--runtime-lib-path"sv))) {
 {
 (runtime_lib_path = TRY((jakt__path::Path::from_string(((args_to_process).dequeue())))));
 }
 return JaktInternal::ExplicitValue<void>();
 }
-else if (__jakt_enum_value == TRY(ByteString::from_utf8("--runtime-path"sv))) {
+else if (__jakt_enum_value == (ByteString::must_from_utf8("--runtime-path"sv))) {
 {
 (runtime_path = TRY((jakt__path::Path::from_string(((args_to_process).dequeue())))));
 }
 return JaktInternal::ExplicitValue<void>();
 }
-else if (__jakt_enum_value == TRY(ByteString::from_utf8("--source-file"sv))) {
+else if (__jakt_enum_value == (ByteString::must_from_utf8("--source-file"sv))) {
 {
 (source_file = ((args_to_process).dequeue()));
 }
 return JaktInternal::ExplicitValue<void>();
 }
-else if (__jakt_enum_value == TRY(ByteString::from_utf8("--output-filename"sv))) {
+else if (__jakt_enum_value == (ByteString::must_from_utf8("--output-filename"sv))) {
 {
 (output_filename = ((args_to_process).dequeue()));
 }
 return JaktInternal::ExplicitValue<void>();
 }
-else if (__jakt_enum_value == TRY(ByteString::from_utf8("-o"sv))) {
+else if (__jakt_enum_value == (ByteString::must_from_utf8("-o"sv))) {
 {
 (output_filename = ((args_to_process).dequeue()));
 }
 return JaktInternal::ExplicitValue<void>();
 }
-else if (__jakt_enum_value == TRY(ByteString::from_utf8("--only-support-libs"sv))) {
+else if (__jakt_enum_value == (ByteString::must_from_utf8("--only-support-libs"sv))) {
 {
 (only_support_libs = true);
 }
@@ -1973,32 +1973,32 @@ return static_cast<int>(1);
 }
 ByteString const abbreviated_triple = TRY((((TRY((jakt__platform::Target::from_triple((target_triple.value()))))).name(true))));
 jakt__path::Path const install_dir = TRY((jakt__path::Path::from_string((install_root.value()))));
-jakt__path::Path const install_lib_dir = TRY((((TRY((((install_dir).join(TRY(ByteString::from_utf8("lib"sv))))))).join((target_triple.value())))));
-jakt__path::Path const install_runtime_dir = TRY((((install_dir).join(TRY(ByteString::from_utf8("include/runtime"sv))))));
-jakt__path::Path const install_bin_dir = TRY((((install_dir).join(TRY(ByteString::from_utf8("bin"sv))))));
+jakt__path::Path const install_lib_dir = TRY((((TRY((((install_dir).join((ByteString::must_from_utf8("lib"sv))))))).join((target_triple.value())))));
+jakt__path::Path const install_runtime_dir = TRY((((install_dir).join((ByteString::must_from_utf8("include/runtime"sv))))));
+jakt__path::Path const install_bin_dir = TRY((((install_dir).join((ByteString::must_from_utf8("bin"sv))))));
 jakt__path::Path const current_executable_path = TRY((jakt__path::Path::from_string(TRY((File::current_executable_path())))));
 jakt__path::Path const local_install_base_path = TRY((((TRY((((current_executable_path).parent())))).parent())));
 if ((!(runtime_path).has_value())){
-(runtime_path = TRY((((local_install_base_path).join(TRY(ByteString::from_utf8("include/runtime"sv)))))));
+(runtime_path = TRY((((local_install_base_path).join((ByteString::must_from_utf8("include/runtime"sv)))))));
 }
 if ((!(runtime_lib_path).has_value())){
-(runtime_lib_path = TRY((((TRY((((local_install_base_path).join(TRY(ByteString::from_utf8("lib"sv))))))).join(TRY((((TRY((jakt__platform::Target::active()))).name(false)))))))));
+(runtime_lib_path = TRY((((TRY((((local_install_base_path).join((ByteString::must_from_utf8("lib"sv))))))).join(TRY((((TRY((jakt__platform::Target::active()))).name(false)))))))));
 }
 Function<ErrorOr<JaktInternal::DynamicArray<ByteString>>()> const compiler_invocation_args = [&compiler_args, &abbreviated_triple, &sysroot, &compiler_include_dir, &compiler_lib_dir, &system_include_dirs, &system_lib_dirs, &runtime_lib_path, &runtime_path]() -> ErrorOr<JaktInternal::DynamicArray<ByteString>> {
 {
 JaktInternal::DynamicArray<ByteString> args = TRY((((((compiler_args)[(JaktInternal::Range<i64>{static_cast<i64>(0LL),static_cast<i64>(9223372036854775807LL)})])).to_array())));
-TRY((((args).push(TRY(ByteString::from_utf8("--target-triple"sv))))));
+TRY((((args).push((ByteString::must_from_utf8("--target-triple"sv))))));
 TRY((((args).push(TRY((__jakt_format((StringView::from_string_literal("{}-unknown"sv)),abbreviated_triple)))))));
 if (((sysroot).has_value())){
-TRY((((args).push(TRY(ByteString::from_utf8("--extra-cpp-flag"sv))))));
+TRY((((args).push((ByteString::must_from_utf8("--extra-cpp-flag"sv))))));
 TRY((((args).push(TRY((__jakt_format((StringView::from_string_literal("--sysroot={}"sv)),(sysroot.value()))))))));
 }
 if (((compiler_include_dir).has_value())){
-TRY((((args).push(TRY(ByteString::from_utf8("-I"sv))))));
+TRY((((args).push((ByteString::must_from_utf8("-I"sv))))));
 TRY((((args).push((compiler_include_dir.value())))));
 }
 if (((compiler_lib_dir).has_value())){
-TRY((((args).push(TRY(ByteString::from_utf8("-L"sv))))));
+TRY((((args).push((ByteString::must_from_utf8("-L"sv))))));
 TRY((((args).push((compiler_lib_dir.value())))));
 }
 {
@@ -2010,7 +2010,7 @@ break;
 }
 ByteString system_include_dir = (_magic_value.value());
 {
-TRY((((args).push(TRY(ByteString::from_utf8("-I"sv))))));
+TRY((((args).push((ByteString::must_from_utf8("-I"sv))))));
 TRY((((args).push(system_include_dir))));
 }
 
@@ -2026,7 +2026,7 @@ break;
 }
 ByteString system_lib_dir = (_magic_value.value());
 {
-TRY((((args).push(TRY(ByteString::from_utf8("-L"sv))))));
+TRY((((args).push((ByteString::must_from_utf8("-L"sv))))));
 TRY((((args).push(system_lib_dir))));
 }
 
@@ -2034,11 +2034,11 @@ TRY((((args).push(system_lib_dir))));
 }
 
 if (((runtime_lib_path).has_value())){
-TRY((((args).push(TRY(ByteString::from_utf8("--runtime-library-path"sv))))));
+TRY((((args).push((ByteString::must_from_utf8("--runtime-library-path"sv))))));
 TRY((((args).push((((runtime_lib_path.value())).to_string())))));
 }
 if (((runtime_path).has_value())){
-TRY((((args).push(TRY(ByteString::from_utf8("--runtime-path"sv))))));
+TRY((((args).push((ByteString::must_from_utf8("--runtime-path"sv))))));
 TRY((((args).push((((runtime_path.value())).to_string())))));
 }
 return args;
@@ -2066,33 +2066,33 @@ break;
 }
 jakt__path::Path source = (_magic_value.value());
 {
-TRY((((invocation_args).push(TRY(ByteString::from_utf8("-X"sv))))));
+TRY((((invocation_args).push((ByteString::must_from_utf8("-X"sv))))));
 TRY((((invocation_args).push(((source).to_string())))));
 }
 
 }
 }
 
-TRY((((invocation_args).push(TRY(ByteString::from_utf8("--static"sv))))));
-TRY((((invocation_args).push(TRY(ByteString::from_utf8("--link-archive"sv))))));
+TRY((((invocation_args).push((ByteString::must_from_utf8("--static"sv))))));
+TRY((((invocation_args).push((ByteString::must_from_utf8("--link-archive"sv))))));
 TRY((((invocation_args).push(((target).to_string())))));
-TRY((((invocation_args).push(TRY(ByteString::from_utf8("/dev/null"sv))))));
+TRY((((invocation_args).push((ByteString::must_from_utf8("/dev/null"sv))))));
 return TRY((compiler_main(invocation_args)));
 }
 }
 ;
 if ((!(((runtime_archive_path).exists())))){
 warnln((StringView::from_string_literal("Building jakt runtime for target {}..."sv)),abbreviated_triple);
-JaktInternal::DynamicArray<jakt__path::Path> sources = (TRY((DynamicArray<jakt__path::Path>::create_with({TRY(((((runtime_path.value())).join(TRY(ByteString::from_utf8("IO/File.cpp"sv))))))}))));
-TRY((((sources).push_values(((TRY((find_with_extension(TRY(((((runtime_path.value())).join(TRY(ByteString::from_utf8("AK"sv)))))),TRY(ByteString::from_utf8("cpp"sv)))))))))));
-TRY((((sources).push_values(((TRY((find_with_extension(TRY(((((runtime_path.value())).join(TRY(ByteString::from_utf8("Jakt"sv)))))),TRY(ByteString::from_utf8("cpp"sv)))))))))));
+JaktInternal::DynamicArray<jakt__path::Path> sources = (TRY((DynamicArray<jakt__path::Path>::create_with({TRY(((((runtime_path.value())).join((ByteString::must_from_utf8("IO/File.cpp"sv))))))}))));
+TRY((((sources).push_values(((TRY((find_with_extension(TRY(((((runtime_path.value())).join((ByteString::must_from_utf8("AK"sv)))))),(ByteString::must_from_utf8("cpp"sv)))))))))));
+TRY((((sources).push_values(((TRY((find_with_extension(TRY(((((runtime_path.value())).join((ByteString::must_from_utf8("Jakt"sv)))))),(ByteString::must_from_utf8("cpp"sv)))))))))));
 if (((TRY((build_archive(sources,runtime_archive_path)))) != (static_cast<int>(0)))){
 return static_cast<int>(1);
 }
 }
 if ((!(((main_archive_path).exists())))){
 warnln((StringView::from_string_literal("Building jakt main for target {}..."sv)),abbreviated_triple);
-JaktInternal::DynamicArray<jakt__path::Path> sources = (TRY((DynamicArray<jakt__path::Path>::create_with({TRY(((((runtime_path.value())).join(TRY(ByteString::from_utf8("Main.cpp"sv))))))}))));
+JaktInternal::DynamicArray<jakt__path::Path> sources = (TRY((DynamicArray<jakt__path::Path>::create_with({TRY(((((runtime_path.value())).join((ByteString::must_from_utf8("Main.cpp"sv))))))}))));
 if (((TRY((build_archive(sources,main_archive_path)))) != (static_cast<int>(0)))){
 return static_cast<int>(1);
 }
@@ -2103,7 +2103,7 @@ if ((!(only_support_libs))){
 JaktInternal::DynamicArray<ByteString> compiler_args = TRY((compiler_invocation_args()));
 jakt__path::Path const source_path = TRY((jakt__path::Path::from_string((source_file.value()))));
 TRY((((compiler_args).push(((source_path).to_string())))));
-TRY((((compiler_args).push(TRY(ByteString::from_utf8("-o"sv))))));
+TRY((((compiler_args).push((ByteString::must_from_utf8("-o"sv))))));
 ByteString const default_output_filename = ((TRY((((install_bin_dir).join(TRY((output_filename.try_value_or_lazy_evaluated([&]() -> ErrorOr<ByteString> { return TRY((((source_path).basename(true)))); })))))))).to_string());
 TRY((((compiler_args).push(default_output_filename))));
 return TRY((compiler_main(compiler_args)));

--- a/bootstrap/stage0/parser.cpp
+++ b/bootstrap/stage0/parser.cpp
@@ -618,7 +618,7 @@ switch(__jakt_match_variant.__jakt_init_index()) {
 case 53 /* Dot */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Dot;utility::Span const& span = __jakt_match_value.value;
 return JaktInternal::ExplicitValue(({ Optional<NonnullRefPtr<typename parser::ParsedExpression>> __jakt_var_7; {
-__jakt_var_7 = TRY((parser::ParsedExpression::Var(TRY(ByteString::from_utf8("this"sv)),span))); goto __jakt_label_3;
+__jakt_var_7 = TRY((parser::ParsedExpression::Var((ByteString::must_from_utf8("this"sv)),span))); goto __jakt_label_3;
 
 }
 __jakt_label_3:; __jakt_var_7.release_value(); }));
@@ -716,7 +716,7 @@ case 98 /* This */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.This;utility::Span const& span = __jakt_match_value.value;
 return JaktInternal::ExplicitValue(({ Optional<NonnullRefPtr<typename parser::ParsedExpression>> __jakt_var_14; {
 ((((*this).index)++));
-__jakt_var_14 = TRY((parser::ParsedExpression::Var(TRY(ByteString::from_utf8("this"sv)),span))); goto __jakt_label_10;
+__jakt_var_14 = TRY((parser::ParsedExpression::Var((ByteString::must_from_utf8("this"sv)),span))); goto __jakt_label_10;
 
 }
 __jakt_label_10:; __jakt_var_14.release_value(); }));
@@ -774,7 +774,7 @@ auto&& __jakt_match_value = __jakt_match_variant.as.Identifier;ByteString const&
 utility::Span const& span = __jakt_match_value.span;
 return JaktInternal::ExplicitValue(({ Optional<NonnullRefPtr<typename parser::ParsedExpression>> __jakt_var_19; {
 if (((((*this).peek(static_cast<size_t>(1ULL)))).__jakt_init_index() == 7 /* LParen */)){
-if (((name) == (TRY(ByteString::from_utf8("Some"sv))))){
+if (((name) == ((ByteString::must_from_utf8("Some"sv))))){
 ((((*this).index)++));
 NonnullRefPtr<typename parser::ParsedExpression> const expr = TRY((((*this).parse_expression(false,false))));
 return TRY((parser::ParsedExpression::OptionalSome(expr,span)));
@@ -790,7 +790,7 @@ if ((!(((call).has_value())))){
 return ({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<NonnullRefPtr<typename parser::ParsedExpression>,ErrorOr<NonnullRefPtr<typename parser::ParsedExpression>>>{
 auto __jakt_enum_value = (name);
-if (__jakt_enum_value == TRY(ByteString::from_utf8("None"sv))) {
+if (__jakt_enum_value == (ByteString::must_from_utf8("None"sv))) {
 return JaktInternal::ExplicitValue(TRY((parser::ParsedExpression::OptionalNone(span))));
 }
 else {
@@ -805,7 +805,7 @@ return JaktInternal::ExplicitValue(TRY((parser::ParsedExpression::Var(name,span)
 return TRY((parser::ParsedExpression::Call((call.value()),span)));
 }
 ((((*this).index)++));
-if (((name) == (TRY(ByteString::from_utf8("None"sv))))){
+if (((name) == ((ByteString::must_from_utf8("None"sv))))){
 return TRY((parser::ParsedExpression::OptionalNone(span)));
 }
 __jakt_var_19 = TRY((parser::ParsedExpression::Var(name,span))); goto __jakt_label_15;
@@ -880,7 +880,7 @@ return JaktInternal::ExplicitValue<void>();
 });
 }
 if (((*this).eof())){
-TRY((((*this).error(TRY(ByteString::from_utf8("Expected ')'"sv)),((((*this).current())).span())))));
+TRY((((*this).error((ByteString::must_from_utf8("Expected ')'"sv)),((((*this).current())).span())))));
 }
 (expr = TRY((parser::ParsedExpression::JaktTuple(tuple_exprs,TRY((parser::merge_spans(start_span,end_span)))))));
 }
@@ -888,7 +888,7 @@ return JaktInternal::ExplicitValue<void>();
 };/*case end*/
 default: {
 {
-TRY((((*this).error(TRY(ByteString::from_utf8("Expected ')'"sv)),((((*this).current())).span())))));
+TRY((((*this).error((ByteString::must_from_utf8("Expected ')'"sv)),((((*this).current())).span())))));
 }
 return JaktInternal::ExplicitValue<void>();
 };/*case end*/
@@ -922,7 +922,7 @@ return JaktInternal::ExplicitValue(parser::UnaryOperator::Negate());
 };/*case end*/
 default: {
 {
-TRY((((((*this).compiler))->panic(TRY(ByteString::from_utf8("unreachable"sv))))));
+TRY((((((*this).compiler))->panic((ByteString::must_from_utf8("unreachable"sv))))));
 }
 };/*case end*/
 }/*switch end*/
@@ -959,7 +959,7 @@ return JaktInternal::ExplicitValue(parser::UnaryOperator::Negate());
 };/*case end*/
 default: {
 {
-TRY((((((*this).compiler))->panic(TRY(ByteString::from_utf8("unreachable"sv))))));
+TRY((((((*this).compiler))->panic((ByteString::must_from_utf8("unreachable"sv))))));
 }
 };/*case end*/
 }/*switch end*/
@@ -996,7 +996,7 @@ return JaktInternal::ExplicitValue(parser::UnaryOperator::Negate());
 };/*case end*/
 default: {
 {
-TRY((((((*this).compiler))->panic(TRY(ByteString::from_utf8("unreachable"sv))))));
+TRY((((((*this).compiler))->panic((ByteString::must_from_utf8("unreachable"sv))))));
 }
 };/*case end*/
 }/*switch end*/
@@ -1055,7 +1055,7 @@ default: {
 return JaktInternal::ExplicitValue(({ Optional<NonnullRefPtr<typename parser::ParsedExpression>> __jakt_var_27; {
 utility::Span const span = ((((*this).current())).span());
 ((((*this).index)++));
-TRY((((*this).error(TRY(ByteString::from_utf8("Unsupported expression"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("Unsupported expression"sv)),span))));
 __jakt_var_27 = TRY((parser::ParsedExpression::Garbage(span))); goto __jakt_label_23;
 
 }
@@ -1247,7 +1247,7 @@ if (can_throw){
 ((((*this).index)++));
 }
 if (((fn_parameters).has_varargs)){
-TRY((((*this).error(TRY(ByteString::from_utf8("Anonymous functions cannot have varargs"sv)),((((*this).current())).span())))));
+TRY((((*this).error((ByteString::must_from_utf8("Anonymous functions cannot have varargs"sv)),((((*this).current())).span())))));
 }
 NonnullRefPtr<typename parser::ParsedType> return_type = ({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<NonnullRefPtr<typename parser::ParsedType>, ErrorOr<NonnullRefPtr<typename parser::ParsedExpression>>>{
@@ -1372,7 +1372,7 @@ TRY((((namespaces).push(namespace_name))));
 ((((*this).index)++));
 }
 else {
-TRY((((*this).error(TRY(ByteString::from_utf8("Expected ‘::’ here"sv)),utility::Span(((span).file_id),((span).start),((span).start))))));
+TRY((((*this).error((ByteString::must_from_utf8("Expected ‘::’ here"sv)),utility::Span(((span).file_id),((span).start),((span).start))))));
 return JaktInternal::LoopBreak{};
 }
 
@@ -1385,7 +1385,7 @@ if (((((*this).previous())).__jakt_init_index() == 3 /* Identifier */)){
 ((((*this).index)++));
 }
 else {
-TRY((((*this).error(TRY(ByteString::from_utf8("Expected name after"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("Expected name after"sv)),span))));
 return JaktInternal::LoopBreak{};
 }
 
@@ -1425,7 +1425,7 @@ utility::Span const start = ((((*this).current())).span());
 ((((*this).index)++));
 parser::ParsedFunctionParameters const fn_parameters = TRY((((*this).parse_function_parameters(false))));
 if (((fn_parameters).has_varargs)){
-TRY((((*this).error(TRY(ByteString::from_utf8("Function type cannot have variadic arguments"sv)),((((*this).current())).span())))));
+TRY((((*this).error((ByteString::must_from_utf8("Function type cannot have variadic arguments"sv)),((((*this).current())).span())))));
 }
 bool const can_throw = ((((*this).current())).__jakt_init_index() == 100 /* Throws */);
 if (can_throw){
@@ -1437,7 +1437,7 @@ if (((((*this).current())).__jakt_init_index() == 58 /* Arrow */)){
 (return_type = TRY((((*this).parse_typename()))));
 }
 else {
-TRY((((*this).error(TRY(ByteString::from_utf8("Expected '->'"sv)),((((*this).current())).span())))));
+TRY((((*this).error((ByteString::must_from_utf8("Expected '->'"sv)),((((*this).current())).span())))));
 }
 
 __jakt_var_33 = TRY((parser::ParsedType::Function(qualifiers,((fn_parameters).parameters),can_throw,return_type,TRY((parser::merge_spans(start,((return_type)->span()))))))); goto __jakt_label_29;
@@ -1447,7 +1447,7 @@ __jakt_label_29:; __jakt_var_33.release_value(); }));
 };/*case end*/
 default: {
 return JaktInternal::ExplicitValue(({ Optional<NonnullRefPtr<typename parser::ParsedType>> __jakt_var_34; {
-TRY((((*this).error(TRY(ByteString::from_utf8("Expected type name"sv)),((((*this).current())).span())))));
+TRY((((*this).error((ByteString::must_from_utf8("Expected type name"sv)),((((*this).current())).span())))));
 __jakt_var_34 = TRY((parser::ParsedType::Empty(qualifiers))); goto __jakt_label_30;
 
 }
@@ -1541,7 +1541,7 @@ default: {
 size_t const index_before = ((*this).index);
 NonnullRefPtr<typename parser::ParsedType> const inner_type = TRY((((*this).parse_typename())));
 if (((index_before) == (((*this).index)))){
-TRY((((*this).error(TRY(ByteString::from_utf8("Expected type name"sv)),((((*this).current())).span())))));
+TRY((((*this).error((ByteString::must_from_utf8("Expected type name"sv)),((((*this).current())).span())))));
 return JaktInternal::LoopBreak{};
 }
 TRY((((((parsed_name).generic_parameters)).push(inner_type))));
@@ -1568,7 +1568,7 @@ return JaktInternal::ExplicitValue<void>();
 case 0 /* SingleQuotedString */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.SingleQuotedString;utility::Span const& span = __jakt_match_value.span;
 {
-TRY((((*this).error(TRY(ByteString::from_utf8("Expected alias target name"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("Expected alias target name"sv)),span))));
 return JaktInternal::LoopBreak{};
 }
 return JaktInternal::ExplicitValue<void>();
@@ -1576,7 +1576,7 @@ return JaktInternal::ExplicitValue<void>();
 case 1 /* QuotedString */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.QuotedString;utility::Span const& span = __jakt_match_value.span;
 {
-TRY((((*this).error(TRY(ByteString::from_utf8("Expected alias target name"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("Expected alias target name"sv)),span))));
 return JaktInternal::LoopBreak{};
 }
 return JaktInternal::ExplicitValue<void>();
@@ -1584,7 +1584,7 @@ return JaktInternal::ExplicitValue<void>();
 case 2 /* Number */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Number;utility::Span const& span = __jakt_match_value.span;
 {
-TRY((((*this).error(TRY(ByteString::from_utf8("Expected alias target name"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("Expected alias target name"sv)),span))));
 return JaktInternal::LoopBreak{};
 }
 return JaktInternal::ExplicitValue<void>();
@@ -1592,7 +1592,7 @@ return JaktInternal::ExplicitValue<void>();
 case 4 /* Semicolon */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Semicolon;utility::Span const& span = __jakt_match_value.value;
 {
-TRY((((*this).error(TRY(ByteString::from_utf8("Expected alias target name"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("Expected alias target name"sv)),span))));
 return JaktInternal::LoopBreak{};
 }
 return JaktInternal::ExplicitValue<void>();
@@ -1600,7 +1600,7 @@ return JaktInternal::ExplicitValue<void>();
 case 5 /* Colon */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Colon;utility::Span const& span = __jakt_match_value.value;
 {
-TRY((((*this).error(TRY(ByteString::from_utf8("Expected alias target name"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("Expected alias target name"sv)),span))));
 return JaktInternal::LoopBreak{};
 }
 return JaktInternal::ExplicitValue<void>();
@@ -1608,7 +1608,7 @@ return JaktInternal::ExplicitValue<void>();
 case 7 /* LParen */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.LParen;utility::Span const& span = __jakt_match_value.value;
 {
-TRY((((*this).error(TRY(ByteString::from_utf8("Expected alias target name"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("Expected alias target name"sv)),span))));
 return JaktInternal::LoopBreak{};
 }
 return JaktInternal::ExplicitValue<void>();
@@ -1616,7 +1616,7 @@ return JaktInternal::ExplicitValue<void>();
 case 8 /* RParen */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.RParen;utility::Span const& span = __jakt_match_value.value;
 {
-TRY((((*this).error(TRY(ByteString::from_utf8("Expected alias target name"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("Expected alias target name"sv)),span))));
 return JaktInternal::LoopBreak{};
 }
 return JaktInternal::ExplicitValue<void>();
@@ -1624,7 +1624,7 @@ return JaktInternal::ExplicitValue<void>();
 case 9 /* LCurly */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.LCurly;utility::Span const& span = __jakt_match_value.value;
 {
-TRY((((*this).error(TRY(ByteString::from_utf8("Expected alias target name"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("Expected alias target name"sv)),span))));
 return JaktInternal::LoopBreak{};
 }
 return JaktInternal::ExplicitValue<void>();
@@ -1632,7 +1632,7 @@ return JaktInternal::ExplicitValue<void>();
 case 10 /* RCurly */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.RCurly;utility::Span const& span = __jakt_match_value.value;
 {
-TRY((((*this).error(TRY(ByteString::from_utf8("Expected alias target name"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("Expected alias target name"sv)),span))));
 return JaktInternal::LoopBreak{};
 }
 return JaktInternal::ExplicitValue<void>();
@@ -1640,7 +1640,7 @@ return JaktInternal::ExplicitValue<void>();
 case 11 /* LSquare */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.LSquare;utility::Span const& span = __jakt_match_value.value;
 {
-TRY((((*this).error(TRY(ByteString::from_utf8("Expected alias target name"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("Expected alias target name"sv)),span))));
 return JaktInternal::LoopBreak{};
 }
 return JaktInternal::ExplicitValue<void>();
@@ -1648,7 +1648,7 @@ return JaktInternal::ExplicitValue<void>();
 case 12 /* RSquare */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.RSquare;utility::Span const& span = __jakt_match_value.value;
 {
-TRY((((*this).error(TRY(ByteString::from_utf8("Expected alias target name"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("Expected alias target name"sv)),span))));
 return JaktInternal::LoopBreak{};
 }
 return JaktInternal::ExplicitValue<void>();
@@ -1656,7 +1656,7 @@ return JaktInternal::ExplicitValue<void>();
 case 13 /* PercentSign */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.PercentSign;utility::Span const& span = __jakt_match_value.value;
 {
-TRY((((*this).error(TRY(ByteString::from_utf8("Expected alias target name"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("Expected alias target name"sv)),span))));
 return JaktInternal::LoopBreak{};
 }
 return JaktInternal::ExplicitValue<void>();
@@ -1664,7 +1664,7 @@ return JaktInternal::ExplicitValue<void>();
 case 14 /* Plus */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Plus;utility::Span const& span = __jakt_match_value.value;
 {
-TRY((((*this).error(TRY(ByteString::from_utf8("Expected alias target name"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("Expected alias target name"sv)),span))));
 return JaktInternal::LoopBreak{};
 }
 return JaktInternal::ExplicitValue<void>();
@@ -1672,7 +1672,7 @@ return JaktInternal::ExplicitValue<void>();
 case 15 /* Minus */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Minus;utility::Span const& span = __jakt_match_value.value;
 {
-TRY((((*this).error(TRY(ByteString::from_utf8("Expected alias target name"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("Expected alias target name"sv)),span))));
 return JaktInternal::LoopBreak{};
 }
 return JaktInternal::ExplicitValue<void>();
@@ -1680,7 +1680,7 @@ return JaktInternal::ExplicitValue<void>();
 case 16 /* Equal */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Equal;utility::Span const& span = __jakt_match_value.value;
 {
-TRY((((*this).error(TRY(ByteString::from_utf8("Expected alias target name"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("Expected alias target name"sv)),span))));
 return JaktInternal::LoopBreak{};
 }
 return JaktInternal::ExplicitValue<void>();
@@ -1688,7 +1688,7 @@ return JaktInternal::ExplicitValue<void>();
 case 17 /* PlusEqual */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.PlusEqual;utility::Span const& span = __jakt_match_value.value;
 {
-TRY((((*this).error(TRY(ByteString::from_utf8("Expected alias target name"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("Expected alias target name"sv)),span))));
 return JaktInternal::LoopBreak{};
 }
 return JaktInternal::ExplicitValue<void>();
@@ -1696,7 +1696,7 @@ return JaktInternal::ExplicitValue<void>();
 case 18 /* PlusPlus */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.PlusPlus;utility::Span const& span = __jakt_match_value.value;
 {
-TRY((((*this).error(TRY(ByteString::from_utf8("Expected alias target name"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("Expected alias target name"sv)),span))));
 return JaktInternal::LoopBreak{};
 }
 return JaktInternal::ExplicitValue<void>();
@@ -1704,7 +1704,7 @@ return JaktInternal::ExplicitValue<void>();
 case 19 /* MinusEqual */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.MinusEqual;utility::Span const& span = __jakt_match_value.value;
 {
-TRY((((*this).error(TRY(ByteString::from_utf8("Expected alias target name"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("Expected alias target name"sv)),span))));
 return JaktInternal::LoopBreak{};
 }
 return JaktInternal::ExplicitValue<void>();
@@ -1712,7 +1712,7 @@ return JaktInternal::ExplicitValue<void>();
 case 20 /* MinusMinus */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.MinusMinus;utility::Span const& span = __jakt_match_value.value;
 {
-TRY((((*this).error(TRY(ByteString::from_utf8("Expected alias target name"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("Expected alias target name"sv)),span))));
 return JaktInternal::LoopBreak{};
 }
 return JaktInternal::ExplicitValue<void>();
@@ -1720,7 +1720,7 @@ return JaktInternal::ExplicitValue<void>();
 case 21 /* AsteriskEqual */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.AsteriskEqual;utility::Span const& span = __jakt_match_value.value;
 {
-TRY((((*this).error(TRY(ByteString::from_utf8("Expected alias target name"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("Expected alias target name"sv)),span))));
 return JaktInternal::LoopBreak{};
 }
 return JaktInternal::ExplicitValue<void>();
@@ -1728,7 +1728,7 @@ return JaktInternal::ExplicitValue<void>();
 case 22 /* ForwardSlashEqual */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.ForwardSlashEqual;utility::Span const& span = __jakt_match_value.value;
 {
-TRY((((*this).error(TRY(ByteString::from_utf8("Expected alias target name"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("Expected alias target name"sv)),span))));
 return JaktInternal::LoopBreak{};
 }
 return JaktInternal::ExplicitValue<void>();
@@ -1736,7 +1736,7 @@ return JaktInternal::ExplicitValue<void>();
 case 23 /* PercentSignEqual */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.PercentSignEqual;utility::Span const& span = __jakt_match_value.value;
 {
-TRY((((*this).error(TRY(ByteString::from_utf8("Expected alias target name"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("Expected alias target name"sv)),span))));
 return JaktInternal::LoopBreak{};
 }
 return JaktInternal::ExplicitValue<void>();
@@ -1744,7 +1744,7 @@ return JaktInternal::ExplicitValue<void>();
 case 24 /* NotEqual */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.NotEqual;utility::Span const& span = __jakt_match_value.value;
 {
-TRY((((*this).error(TRY(ByteString::from_utf8("Expected alias target name"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("Expected alias target name"sv)),span))));
 return JaktInternal::LoopBreak{};
 }
 return JaktInternal::ExplicitValue<void>();
@@ -1752,7 +1752,7 @@ return JaktInternal::ExplicitValue<void>();
 case 25 /* DoubleEqual */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.DoubleEqual;utility::Span const& span = __jakt_match_value.value;
 {
-TRY((((*this).error(TRY(ByteString::from_utf8("Expected alias target name"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("Expected alias target name"sv)),span))));
 return JaktInternal::LoopBreak{};
 }
 return JaktInternal::ExplicitValue<void>();
@@ -1760,7 +1760,7 @@ return JaktInternal::ExplicitValue<void>();
 case 26 /* GreaterThan */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.GreaterThan;utility::Span const& span = __jakt_match_value.value;
 {
-TRY((((*this).error(TRY(ByteString::from_utf8("Expected alias target name"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("Expected alias target name"sv)),span))));
 return JaktInternal::LoopBreak{};
 }
 return JaktInternal::ExplicitValue<void>();
@@ -1768,7 +1768,7 @@ return JaktInternal::ExplicitValue<void>();
 case 27 /* GreaterThanOrEqual */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.GreaterThanOrEqual;utility::Span const& span = __jakt_match_value.value;
 {
-TRY((((*this).error(TRY(ByteString::from_utf8("Expected alias target name"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("Expected alias target name"sv)),span))));
 return JaktInternal::LoopBreak{};
 }
 return JaktInternal::ExplicitValue<void>();
@@ -1776,7 +1776,7 @@ return JaktInternal::ExplicitValue<void>();
 case 28 /* LessThan */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.LessThan;utility::Span const& span = __jakt_match_value.value;
 {
-TRY((((*this).error(TRY(ByteString::from_utf8("Expected alias target name"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("Expected alias target name"sv)),span))));
 return JaktInternal::LoopBreak{};
 }
 return JaktInternal::ExplicitValue<void>();
@@ -1784,7 +1784,7 @@ return JaktInternal::ExplicitValue<void>();
 case 29 /* LessThanOrEqual */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.LessThanOrEqual;utility::Span const& span = __jakt_match_value.value;
 {
-TRY((((*this).error(TRY(ByteString::from_utf8("Expected alias target name"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("Expected alias target name"sv)),span))));
 return JaktInternal::LoopBreak{};
 }
 return JaktInternal::ExplicitValue<void>();
@@ -1792,7 +1792,7 @@ return JaktInternal::ExplicitValue<void>();
 case 30 /* LeftArithmeticShift */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.LeftArithmeticShift;utility::Span const& span = __jakt_match_value.value;
 {
-TRY((((*this).error(TRY(ByteString::from_utf8("Expected alias target name"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("Expected alias target name"sv)),span))));
 return JaktInternal::LoopBreak{};
 }
 return JaktInternal::ExplicitValue<void>();
@@ -1800,7 +1800,7 @@ return JaktInternal::ExplicitValue<void>();
 case 31 /* LeftShift */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.LeftShift;utility::Span const& span = __jakt_match_value.value;
 {
-TRY((((*this).error(TRY(ByteString::from_utf8("Expected alias target name"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("Expected alias target name"sv)),span))));
 return JaktInternal::LoopBreak{};
 }
 return JaktInternal::ExplicitValue<void>();
@@ -1808,7 +1808,7 @@ return JaktInternal::ExplicitValue<void>();
 case 32 /* LeftShiftEqual */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.LeftShiftEqual;utility::Span const& span = __jakt_match_value.value;
 {
-TRY((((*this).error(TRY(ByteString::from_utf8("Expected alias target name"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("Expected alias target name"sv)),span))));
 return JaktInternal::LoopBreak{};
 }
 return JaktInternal::ExplicitValue<void>();
@@ -1816,7 +1816,7 @@ return JaktInternal::ExplicitValue<void>();
 case 33 /* RightShift */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.RightShift;utility::Span const& span = __jakt_match_value.value;
 {
-TRY((((*this).error(TRY(ByteString::from_utf8("Expected alias target name"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("Expected alias target name"sv)),span))));
 return JaktInternal::LoopBreak{};
 }
 return JaktInternal::ExplicitValue<void>();
@@ -1824,7 +1824,7 @@ return JaktInternal::ExplicitValue<void>();
 case 34 /* RightArithmeticShift */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.RightArithmeticShift;utility::Span const& span = __jakt_match_value.value;
 {
-TRY((((*this).error(TRY(ByteString::from_utf8("Expected alias target name"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("Expected alias target name"sv)),span))));
 return JaktInternal::LoopBreak{};
 }
 return JaktInternal::ExplicitValue<void>();
@@ -1832,7 +1832,7 @@ return JaktInternal::ExplicitValue<void>();
 case 35 /* RightShiftEqual */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.RightShiftEqual;utility::Span const& span = __jakt_match_value.value;
 {
-TRY((((*this).error(TRY(ByteString::from_utf8("Expected alias target name"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("Expected alias target name"sv)),span))));
 return JaktInternal::LoopBreak{};
 }
 return JaktInternal::ExplicitValue<void>();
@@ -1840,7 +1840,7 @@ return JaktInternal::ExplicitValue<void>();
 case 36 /* Asterisk */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Asterisk;utility::Span const& span = __jakt_match_value.value;
 {
-TRY((((*this).error(TRY(ByteString::from_utf8("Expected alias target name"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("Expected alias target name"sv)),span))));
 return JaktInternal::LoopBreak{};
 }
 return JaktInternal::ExplicitValue<void>();
@@ -1848,7 +1848,7 @@ return JaktInternal::ExplicitValue<void>();
 case 37 /* Ampersand */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Ampersand;utility::Span const& span = __jakt_match_value.value;
 {
-TRY((((*this).error(TRY(ByteString::from_utf8("Expected alias target name"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("Expected alias target name"sv)),span))));
 return JaktInternal::LoopBreak{};
 }
 return JaktInternal::ExplicitValue<void>();
@@ -1856,7 +1856,7 @@ return JaktInternal::ExplicitValue<void>();
 case 38 /* AmpersandEqual */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.AmpersandEqual;utility::Span const& span = __jakt_match_value.value;
 {
-TRY((((*this).error(TRY(ByteString::from_utf8("Expected alias target name"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("Expected alias target name"sv)),span))));
 return JaktInternal::LoopBreak{};
 }
 return JaktInternal::ExplicitValue<void>();
@@ -1864,7 +1864,7 @@ return JaktInternal::ExplicitValue<void>();
 case 39 /* AmpersandAmpersand */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.AmpersandAmpersand;utility::Span const& span = __jakt_match_value.value;
 {
-TRY((((*this).error(TRY(ByteString::from_utf8("Expected alias target name"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("Expected alias target name"sv)),span))));
 return JaktInternal::LoopBreak{};
 }
 return JaktInternal::ExplicitValue<void>();
@@ -1872,7 +1872,7 @@ return JaktInternal::ExplicitValue<void>();
 case 40 /* Pipe */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Pipe;utility::Span const& span = __jakt_match_value.value;
 {
-TRY((((*this).error(TRY(ByteString::from_utf8("Expected alias target name"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("Expected alias target name"sv)),span))));
 return JaktInternal::LoopBreak{};
 }
 return JaktInternal::ExplicitValue<void>();
@@ -1880,7 +1880,7 @@ return JaktInternal::ExplicitValue<void>();
 case 41 /* PipeEqual */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.PipeEqual;utility::Span const& span = __jakt_match_value.value;
 {
-TRY((((*this).error(TRY(ByteString::from_utf8("Expected alias target name"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("Expected alias target name"sv)),span))));
 return JaktInternal::LoopBreak{};
 }
 return JaktInternal::ExplicitValue<void>();
@@ -1888,7 +1888,7 @@ return JaktInternal::ExplicitValue<void>();
 case 42 /* PipePipe */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.PipePipe;utility::Span const& span = __jakt_match_value.value;
 {
-TRY((((*this).error(TRY(ByteString::from_utf8("Expected alias target name"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("Expected alias target name"sv)),span))));
 return JaktInternal::LoopBreak{};
 }
 return JaktInternal::ExplicitValue<void>();
@@ -1896,7 +1896,7 @@ return JaktInternal::ExplicitValue<void>();
 case 43 /* Caret */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Caret;utility::Span const& span = __jakt_match_value.value;
 {
-TRY((((*this).error(TRY(ByteString::from_utf8("Expected alias target name"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("Expected alias target name"sv)),span))));
 return JaktInternal::LoopBreak{};
 }
 return JaktInternal::ExplicitValue<void>();
@@ -1904,7 +1904,7 @@ return JaktInternal::ExplicitValue<void>();
 case 44 /* CaretEqual */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.CaretEqual;utility::Span const& span = __jakt_match_value.value;
 {
-TRY((((*this).error(TRY(ByteString::from_utf8("Expected alias target name"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("Expected alias target name"sv)),span))));
 return JaktInternal::LoopBreak{};
 }
 return JaktInternal::ExplicitValue<void>();
@@ -1912,7 +1912,7 @@ return JaktInternal::ExplicitValue<void>();
 case 45 /* Dollar */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Dollar;utility::Span const& span = __jakt_match_value.value;
 {
-TRY((((*this).error(TRY(ByteString::from_utf8("Expected alias target name"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("Expected alias target name"sv)),span))));
 return JaktInternal::LoopBreak{};
 }
 return JaktInternal::ExplicitValue<void>();
@@ -1920,7 +1920,7 @@ return JaktInternal::ExplicitValue<void>();
 case 46 /* Tilde */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Tilde;utility::Span const& span = __jakt_match_value.value;
 {
-TRY((((*this).error(TRY(ByteString::from_utf8("Expected alias target name"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("Expected alias target name"sv)),span))));
 return JaktInternal::LoopBreak{};
 }
 return JaktInternal::ExplicitValue<void>();
@@ -1928,7 +1928,7 @@ return JaktInternal::ExplicitValue<void>();
 case 47 /* ForwardSlash */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.ForwardSlash;utility::Span const& span = __jakt_match_value.value;
 {
-TRY((((*this).error(TRY(ByteString::from_utf8("Expected alias target name"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("Expected alias target name"sv)),span))));
 return JaktInternal::LoopBreak{};
 }
 return JaktInternal::ExplicitValue<void>();
@@ -1936,7 +1936,7 @@ return JaktInternal::ExplicitValue<void>();
 case 48 /* ExclamationPoint */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.ExclamationPoint;utility::Span const& span = __jakt_match_value.value;
 {
-TRY((((*this).error(TRY(ByteString::from_utf8("Expected alias target name"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("Expected alias target name"sv)),span))));
 return JaktInternal::LoopBreak{};
 }
 return JaktInternal::ExplicitValue<void>();
@@ -1944,7 +1944,7 @@ return JaktInternal::ExplicitValue<void>();
 case 49 /* QuestionMark */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.QuestionMark;utility::Span const& span = __jakt_match_value.value;
 {
-TRY((((*this).error(TRY(ByteString::from_utf8("Expected alias target name"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("Expected alias target name"sv)),span))));
 return JaktInternal::LoopBreak{};
 }
 return JaktInternal::ExplicitValue<void>();
@@ -1952,7 +1952,7 @@ return JaktInternal::ExplicitValue<void>();
 case 50 /* QuestionMarkQuestionMark */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.QuestionMarkQuestionMark;utility::Span const& span = __jakt_match_value.value;
 {
-TRY((((*this).error(TRY(ByteString::from_utf8("Expected alias target name"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("Expected alias target name"sv)),span))));
 return JaktInternal::LoopBreak{};
 }
 return JaktInternal::ExplicitValue<void>();
@@ -1960,7 +1960,7 @@ return JaktInternal::ExplicitValue<void>();
 case 51 /* QuestionMarkQuestionMarkEqual */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.QuestionMarkQuestionMarkEqual;utility::Span const& span = __jakt_match_value.value;
 {
-TRY((((*this).error(TRY(ByteString::from_utf8("Expected alias target name"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("Expected alias target name"sv)),span))));
 return JaktInternal::LoopBreak{};
 }
 return JaktInternal::ExplicitValue<void>();
@@ -1968,7 +1968,7 @@ return JaktInternal::ExplicitValue<void>();
 case 52 /* Comma */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Comma;utility::Span const& span = __jakt_match_value.value;
 {
-TRY((((*this).error(TRY(ByteString::from_utf8("Expected alias target name"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("Expected alias target name"sv)),span))));
 return JaktInternal::LoopBreak{};
 }
 return JaktInternal::ExplicitValue<void>();
@@ -1976,7 +1976,7 @@ return JaktInternal::ExplicitValue<void>();
 case 53 /* Dot */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Dot;utility::Span const& span = __jakt_match_value.value;
 {
-TRY((((*this).error(TRY(ByteString::from_utf8("Expected alias target name"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("Expected alias target name"sv)),span))));
 return JaktInternal::LoopBreak{};
 }
 return JaktInternal::ExplicitValue<void>();
@@ -1984,7 +1984,7 @@ return JaktInternal::ExplicitValue<void>();
 case 54 /* DotDot */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.DotDot;utility::Span const& span = __jakt_match_value.value;
 {
-TRY((((*this).error(TRY(ByteString::from_utf8("Expected alias target name"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("Expected alias target name"sv)),span))));
 return JaktInternal::LoopBreak{};
 }
 return JaktInternal::ExplicitValue<void>();
@@ -1992,7 +1992,7 @@ return JaktInternal::ExplicitValue<void>();
 case 57 /* FatArrow */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.FatArrow;utility::Span const& span = __jakt_match_value.value;
 {
-TRY((((*this).error(TRY(ByteString::from_utf8("Expected alias target name"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("Expected alias target name"sv)),span))));
 return JaktInternal::LoopBreak{};
 }
 return JaktInternal::ExplicitValue<void>();
@@ -2000,7 +2000,7 @@ return JaktInternal::ExplicitValue<void>();
 case 58 /* Arrow */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Arrow;utility::Span const& span = __jakt_match_value.value;
 {
-TRY((((*this).error(TRY(ByteString::from_utf8("Expected alias target name"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("Expected alias target name"sv)),span))));
 return JaktInternal::LoopBreak{};
 }
 return JaktInternal::ExplicitValue<void>();
@@ -2008,7 +2008,7 @@ return JaktInternal::ExplicitValue<void>();
 case 59 /* And */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.And;utility::Span const& span = __jakt_match_value.value;
 {
-TRY((((*this).error(TRY(ByteString::from_utf8("Expected alias target name"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("Expected alias target name"sv)),span))));
 return JaktInternal::LoopBreak{};
 }
 return JaktInternal::ExplicitValue<void>();
@@ -2016,7 +2016,7 @@ return JaktInternal::ExplicitValue<void>();
 case 60 /* Anon */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Anon;utility::Span const& span = __jakt_match_value.value;
 {
-TRY((((*this).error(TRY(ByteString::from_utf8("Expected alias target name"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("Expected alias target name"sv)),span))));
 return JaktInternal::LoopBreak{};
 }
 return JaktInternal::ExplicitValue<void>();
@@ -2024,7 +2024,7 @@ return JaktInternal::ExplicitValue<void>();
 case 62 /* Boxed */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Boxed;utility::Span const& span = __jakt_match_value.value;
 {
-TRY((((*this).error(TRY(ByteString::from_utf8("Expected alias target name"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("Expected alias target name"sv)),span))));
 return JaktInternal::LoopBreak{};
 }
 return JaktInternal::ExplicitValue<void>();
@@ -2032,7 +2032,7 @@ return JaktInternal::ExplicitValue<void>();
 case 63 /* Break */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Break;utility::Span const& span = __jakt_match_value.value;
 {
-TRY((((*this).error(TRY(ByteString::from_utf8("Expected alias target name"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("Expected alias target name"sv)),span))));
 return JaktInternal::LoopBreak{};
 }
 return JaktInternal::ExplicitValue<void>();
@@ -2040,7 +2040,7 @@ return JaktInternal::ExplicitValue<void>();
 case 64 /* Catch */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Catch;utility::Span const& span = __jakt_match_value.value;
 {
-TRY((((*this).error(TRY(ByteString::from_utf8("Expected alias target name"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("Expected alias target name"sv)),span))));
 return JaktInternal::LoopBreak{};
 }
 return JaktInternal::ExplicitValue<void>();
@@ -2048,7 +2048,7 @@ return JaktInternal::ExplicitValue<void>();
 case 65 /* Class */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Class;utility::Span const& span = __jakt_match_value.value;
 {
-TRY((((*this).error(TRY(ByteString::from_utf8("Expected alias target name"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("Expected alias target name"sv)),span))));
 return JaktInternal::LoopBreak{};
 }
 return JaktInternal::ExplicitValue<void>();
@@ -2056,7 +2056,7 @@ return JaktInternal::ExplicitValue<void>();
 case 66 /* Continue */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Continue;utility::Span const& span = __jakt_match_value.value;
 {
-TRY((((*this).error(TRY(ByteString::from_utf8("Expected alias target name"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("Expected alias target name"sv)),span))));
 return JaktInternal::LoopBreak{};
 }
 return JaktInternal::ExplicitValue<void>();
@@ -2064,7 +2064,7 @@ return JaktInternal::ExplicitValue<void>();
 case 67 /* Cpp */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Cpp;utility::Span const& span = __jakt_match_value.value;
 {
-TRY((((*this).error(TRY(ByteString::from_utf8("Expected alias target name"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("Expected alias target name"sv)),span))));
 return JaktInternal::LoopBreak{};
 }
 return JaktInternal::ExplicitValue<void>();
@@ -2072,7 +2072,7 @@ return JaktInternal::ExplicitValue<void>();
 case 68 /* Defer */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Defer;utility::Span const& span = __jakt_match_value.value;
 {
-TRY((((*this).error(TRY(ByteString::from_utf8("Expected alias target name"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("Expected alias target name"sv)),span))));
 return JaktInternal::LoopBreak{};
 }
 return JaktInternal::ExplicitValue<void>();
@@ -2080,7 +2080,7 @@ return JaktInternal::ExplicitValue<void>();
 case 69 /* Destructor */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Destructor;utility::Span const& span = __jakt_match_value.value;
 {
-TRY((((*this).error(TRY(ByteString::from_utf8("Expected alias target name"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("Expected alias target name"sv)),span))));
 return JaktInternal::LoopBreak{};
 }
 return JaktInternal::ExplicitValue<void>();
@@ -2088,7 +2088,7 @@ return JaktInternal::ExplicitValue<void>();
 case 70 /* Else */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Else;utility::Span const& span = __jakt_match_value.value;
 {
-TRY((((*this).error(TRY(ByteString::from_utf8("Expected alias target name"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("Expected alias target name"sv)),span))));
 return JaktInternal::LoopBreak{};
 }
 return JaktInternal::ExplicitValue<void>();
@@ -2096,7 +2096,7 @@ return JaktInternal::ExplicitValue<void>();
 case 71 /* Enum */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Enum;utility::Span const& span = __jakt_match_value.value;
 {
-TRY((((*this).error(TRY(ByteString::from_utf8("Expected alias target name"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("Expected alias target name"sv)),span))));
 return JaktInternal::LoopBreak{};
 }
 return JaktInternal::ExplicitValue<void>();
@@ -2104,7 +2104,7 @@ return JaktInternal::ExplicitValue<void>();
 case 72 /* Extern */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Extern;utility::Span const& span = __jakt_match_value.value;
 {
-TRY((((*this).error(TRY(ByteString::from_utf8("Expected alias target name"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("Expected alias target name"sv)),span))));
 return JaktInternal::LoopBreak{};
 }
 return JaktInternal::ExplicitValue<void>();
@@ -2112,7 +2112,7 @@ return JaktInternal::ExplicitValue<void>();
 case 73 /* False */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.False;utility::Span const& span = __jakt_match_value.value;
 {
-TRY((((*this).error(TRY(ByteString::from_utf8("Expected alias target name"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("Expected alias target name"sv)),span))));
 return JaktInternal::LoopBreak{};
 }
 return JaktInternal::ExplicitValue<void>();
@@ -2120,7 +2120,7 @@ return JaktInternal::ExplicitValue<void>();
 case 74 /* For */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.For;utility::Span const& span = __jakt_match_value.value;
 {
-TRY((((*this).error(TRY(ByteString::from_utf8("Expected alias target name"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("Expected alias target name"sv)),span))));
 return JaktInternal::LoopBreak{};
 }
 return JaktInternal::ExplicitValue<void>();
@@ -2128,7 +2128,7 @@ return JaktInternal::ExplicitValue<void>();
 case 75 /* Fn */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Fn;utility::Span const& span = __jakt_match_value.value;
 {
-TRY((((*this).error(TRY(ByteString::from_utf8("Expected alias target name"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("Expected alias target name"sv)),span))));
 return JaktInternal::LoopBreak{};
 }
 return JaktInternal::ExplicitValue<void>();
@@ -2136,7 +2136,7 @@ return JaktInternal::ExplicitValue<void>();
 case 76 /* Comptime */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Comptime;utility::Span const& span = __jakt_match_value.value;
 {
-TRY((((*this).error(TRY(ByteString::from_utf8("Expected alias target name"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("Expected alias target name"sv)),span))));
 return JaktInternal::LoopBreak{};
 }
 return JaktInternal::ExplicitValue<void>();
@@ -2144,7 +2144,7 @@ return JaktInternal::ExplicitValue<void>();
 case 77 /* If */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.If;utility::Span const& span = __jakt_match_value.value;
 {
-TRY((((*this).error(TRY(ByteString::from_utf8("Expected alias target name"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("Expected alias target name"sv)),span))));
 return JaktInternal::LoopBreak{};
 }
 return JaktInternal::ExplicitValue<void>();
@@ -2152,7 +2152,7 @@ return JaktInternal::ExplicitValue<void>();
 case 78 /* Import */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Import;utility::Span const& span = __jakt_match_value.value;
 {
-TRY((((*this).error(TRY(ByteString::from_utf8("Expected alias target name"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("Expected alias target name"sv)),span))));
 return JaktInternal::LoopBreak{};
 }
 return JaktInternal::ExplicitValue<void>();
@@ -2160,7 +2160,7 @@ return JaktInternal::ExplicitValue<void>();
 case 79 /* Relative */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Relative;utility::Span const& span = __jakt_match_value.value;
 {
-TRY((((*this).error(TRY(ByteString::from_utf8("Expected alias target name"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("Expected alias target name"sv)),span))));
 return JaktInternal::LoopBreak{};
 }
 return JaktInternal::ExplicitValue<void>();
@@ -2168,7 +2168,7 @@ return JaktInternal::ExplicitValue<void>();
 case 80 /* In */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.In;utility::Span const& span = __jakt_match_value.value;
 {
-TRY((((*this).error(TRY(ByteString::from_utf8("Expected alias target name"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("Expected alias target name"sv)),span))));
 return JaktInternal::LoopBreak{};
 }
 return JaktInternal::ExplicitValue<void>();
@@ -2176,7 +2176,7 @@ return JaktInternal::ExplicitValue<void>();
 case 81 /* Is */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Is;utility::Span const& span = __jakt_match_value.value;
 {
-TRY((((*this).error(TRY(ByteString::from_utf8("Expected alias target name"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("Expected alias target name"sv)),span))));
 return JaktInternal::LoopBreak{};
 }
 return JaktInternal::ExplicitValue<void>();
@@ -2184,7 +2184,7 @@ return JaktInternal::ExplicitValue<void>();
 case 82 /* Let */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Let;utility::Span const& span = __jakt_match_value.value;
 {
-TRY((((*this).error(TRY(ByteString::from_utf8("Expected alias target name"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("Expected alias target name"sv)),span))));
 return JaktInternal::LoopBreak{};
 }
 return JaktInternal::ExplicitValue<void>();
@@ -2192,7 +2192,7 @@ return JaktInternal::ExplicitValue<void>();
 case 83 /* Loop */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Loop;utility::Span const& span = __jakt_match_value.value;
 {
-TRY((((*this).error(TRY(ByteString::from_utf8("Expected alias target name"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("Expected alias target name"sv)),span))));
 return JaktInternal::LoopBreak{};
 }
 return JaktInternal::ExplicitValue<void>();
@@ -2200,7 +2200,7 @@ return JaktInternal::ExplicitValue<void>();
 case 84 /* Match */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Match;utility::Span const& span = __jakt_match_value.value;
 {
-TRY((((*this).error(TRY(ByteString::from_utf8("Expected alias target name"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("Expected alias target name"sv)),span))));
 return JaktInternal::LoopBreak{};
 }
 return JaktInternal::ExplicitValue<void>();
@@ -2208,7 +2208,7 @@ return JaktInternal::ExplicitValue<void>();
 case 85 /* Mut */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Mut;utility::Span const& span = __jakt_match_value.value;
 {
-TRY((((*this).error(TRY(ByteString::from_utf8("Expected alias target name"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("Expected alias target name"sv)),span))));
 return JaktInternal::LoopBreak{};
 }
 return JaktInternal::ExplicitValue<void>();
@@ -2216,7 +2216,7 @@ return JaktInternal::ExplicitValue<void>();
 case 86 /* Namespace */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Namespace;utility::Span const& span = __jakt_match_value.value;
 {
-TRY((((*this).error(TRY(ByteString::from_utf8("Expected alias target name"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("Expected alias target name"sv)),span))));
 return JaktInternal::LoopBreak{};
 }
 return JaktInternal::ExplicitValue<void>();
@@ -2224,7 +2224,7 @@ return JaktInternal::ExplicitValue<void>();
 case 87 /* Not */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Not;utility::Span const& span = __jakt_match_value.value;
 {
-TRY((((*this).error(TRY(ByteString::from_utf8("Expected alias target name"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("Expected alias target name"sv)),span))));
 return JaktInternal::LoopBreak{};
 }
 return JaktInternal::ExplicitValue<void>();
@@ -2232,7 +2232,7 @@ return JaktInternal::ExplicitValue<void>();
 case 88 /* Or */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Or;utility::Span const& span = __jakt_match_value.value;
 {
-TRY((((*this).error(TRY(ByteString::from_utf8("Expected alias target name"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("Expected alias target name"sv)),span))));
 return JaktInternal::LoopBreak{};
 }
 return JaktInternal::ExplicitValue<void>();
@@ -2240,7 +2240,7 @@ return JaktInternal::ExplicitValue<void>();
 case 89 /* Override */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Override;utility::Span const& span = __jakt_match_value.value;
 {
-TRY((((*this).error(TRY(ByteString::from_utf8("Expected alias target name"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("Expected alias target name"sv)),span))));
 return JaktInternal::LoopBreak{};
 }
 return JaktInternal::ExplicitValue<void>();
@@ -2248,7 +2248,7 @@ return JaktInternal::ExplicitValue<void>();
 case 90 /* Private */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Private;utility::Span const& span = __jakt_match_value.value;
 {
-TRY((((*this).error(TRY(ByteString::from_utf8("Expected alias target name"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("Expected alias target name"sv)),span))));
 return JaktInternal::LoopBreak{};
 }
 return JaktInternal::ExplicitValue<void>();
@@ -2256,7 +2256,7 @@ return JaktInternal::ExplicitValue<void>();
 case 91 /* Public */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Public;utility::Span const& span = __jakt_match_value.value;
 {
-TRY((((*this).error(TRY(ByteString::from_utf8("Expected alias target name"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("Expected alias target name"sv)),span))));
 return JaktInternal::LoopBreak{};
 }
 return JaktInternal::ExplicitValue<void>();
@@ -2264,7 +2264,7 @@ return JaktInternal::ExplicitValue<void>();
 case 92 /* Raw */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Raw;utility::Span const& span = __jakt_match_value.value;
 {
-TRY((((*this).error(TRY(ByteString::from_utf8("Expected alias target name"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("Expected alias target name"sv)),span))));
 return JaktInternal::LoopBreak{};
 }
 return JaktInternal::ExplicitValue<void>();
@@ -2272,7 +2272,7 @@ return JaktInternal::ExplicitValue<void>();
 case 93 /* Reflect */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Reflect;utility::Span const& span = __jakt_match_value.value;
 {
-TRY((((*this).error(TRY(ByteString::from_utf8("Expected alias target name"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("Expected alias target name"sv)),span))));
 return JaktInternal::LoopBreak{};
 }
 return JaktInternal::ExplicitValue<void>();
@@ -2280,7 +2280,7 @@ return JaktInternal::ExplicitValue<void>();
 case 94 /* Return */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Return;utility::Span const& span = __jakt_match_value.value;
 {
-TRY((((*this).error(TRY(ByteString::from_utf8("Expected alias target name"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("Expected alias target name"sv)),span))));
 return JaktInternal::LoopBreak{};
 }
 return JaktInternal::ExplicitValue<void>();
@@ -2288,7 +2288,7 @@ return JaktInternal::ExplicitValue<void>();
 case 95 /* Restricted */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Restricted;utility::Span const& span = __jakt_match_value.value;
 {
-TRY((((*this).error(TRY(ByteString::from_utf8("Expected alias target name"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("Expected alias target name"sv)),span))));
 return JaktInternal::LoopBreak{};
 }
 return JaktInternal::ExplicitValue<void>();
@@ -2296,7 +2296,7 @@ return JaktInternal::ExplicitValue<void>();
 case 96 /* Sizeof */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Sizeof;utility::Span const& span = __jakt_match_value.value;
 {
-TRY((((*this).error(TRY(ByteString::from_utf8("Expected alias target name"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("Expected alias target name"sv)),span))));
 return JaktInternal::LoopBreak{};
 }
 return JaktInternal::ExplicitValue<void>();
@@ -2304,7 +2304,7 @@ return JaktInternal::ExplicitValue<void>();
 case 97 /* Struct */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Struct;utility::Span const& span = __jakt_match_value.value;
 {
-TRY((((*this).error(TRY(ByteString::from_utf8("Expected alias target name"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("Expected alias target name"sv)),span))));
 return JaktInternal::LoopBreak{};
 }
 return JaktInternal::ExplicitValue<void>();
@@ -2312,7 +2312,7 @@ return JaktInternal::ExplicitValue<void>();
 case 98 /* This */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.This;utility::Span const& span = __jakt_match_value.value;
 {
-TRY((((*this).error(TRY(ByteString::from_utf8("Expected alias target name"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("Expected alias target name"sv)),span))));
 return JaktInternal::LoopBreak{};
 }
 return JaktInternal::ExplicitValue<void>();
@@ -2320,7 +2320,7 @@ return JaktInternal::ExplicitValue<void>();
 case 99 /* Throw */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Throw;utility::Span const& span = __jakt_match_value.value;
 {
-TRY((((*this).error(TRY(ByteString::from_utf8("Expected alias target name"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("Expected alias target name"sv)),span))));
 return JaktInternal::LoopBreak{};
 }
 return JaktInternal::ExplicitValue<void>();
@@ -2328,7 +2328,7 @@ return JaktInternal::ExplicitValue<void>();
 case 100 /* Throws */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Throws;utility::Span const& span = __jakt_match_value.value;
 {
-TRY((((*this).error(TRY(ByteString::from_utf8("Expected alias target name"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("Expected alias target name"sv)),span))));
 return JaktInternal::LoopBreak{};
 }
 return JaktInternal::ExplicitValue<void>();
@@ -2336,7 +2336,7 @@ return JaktInternal::ExplicitValue<void>();
 case 101 /* True */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.True;utility::Span const& span = __jakt_match_value.value;
 {
-TRY((((*this).error(TRY(ByteString::from_utf8("Expected alias target name"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("Expected alias target name"sv)),span))));
 return JaktInternal::LoopBreak{};
 }
 return JaktInternal::ExplicitValue<void>();
@@ -2344,7 +2344,7 @@ return JaktInternal::ExplicitValue<void>();
 case 102 /* Try */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Try;utility::Span const& span = __jakt_match_value.value;
 {
-TRY((((*this).error(TRY(ByteString::from_utf8("Expected alias target name"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("Expected alias target name"sv)),span))));
 return JaktInternal::LoopBreak{};
 }
 return JaktInternal::ExplicitValue<void>();
@@ -2352,7 +2352,7 @@ return JaktInternal::ExplicitValue<void>();
 case 103 /* Unsafe */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Unsafe;utility::Span const& span = __jakt_match_value.value;
 {
-TRY((((*this).error(TRY(ByteString::from_utf8("Expected alias target name"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("Expected alias target name"sv)),span))));
 return JaktInternal::LoopBreak{};
 }
 return JaktInternal::ExplicitValue<void>();
@@ -2360,7 +2360,7 @@ return JaktInternal::ExplicitValue<void>();
 case 104 /* Virtual */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Virtual;utility::Span const& span = __jakt_match_value.value;
 {
-TRY((((*this).error(TRY(ByteString::from_utf8("Expected alias target name"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("Expected alias target name"sv)),span))));
 return JaktInternal::LoopBreak{};
 }
 return JaktInternal::ExplicitValue<void>();
@@ -2368,7 +2368,7 @@ return JaktInternal::ExplicitValue<void>();
 case 105 /* Weak */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Weak;utility::Span const& span = __jakt_match_value.value;
 {
-TRY((((*this).error(TRY(ByteString::from_utf8("Expected alias target name"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("Expected alias target name"sv)),span))));
 return JaktInternal::LoopBreak{};
 }
 return JaktInternal::ExplicitValue<void>();
@@ -2376,7 +2376,7 @@ return JaktInternal::ExplicitValue<void>();
 case 106 /* While */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.While;utility::Span const& span = __jakt_match_value.value;
 {
-TRY((((*this).error(TRY(ByteString::from_utf8("Expected alias target name"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("Expected alias target name"sv)),span))));
 return JaktInternal::LoopBreak{};
 }
 return JaktInternal::ExplicitValue<void>();
@@ -2384,7 +2384,7 @@ return JaktInternal::ExplicitValue<void>();
 case 107 /* Yield */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Yield;utility::Span const& span = __jakt_match_value.value;
 {
-TRY((((*this).error(TRY(ByteString::from_utf8("Expected alias target name"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("Expected alias target name"sv)),span))));
 return JaktInternal::LoopBreak{};
 }
 return JaktInternal::ExplicitValue<void>();
@@ -2392,7 +2392,7 @@ return JaktInternal::ExplicitValue<void>();
 case 108 /* Guard */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Guard;utility::Span const& span = __jakt_match_value.value;
 {
-TRY((((*this).error(TRY(ByteString::from_utf8("Expected alias target name"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("Expected alias target name"sv)),span))));
 return JaktInternal::LoopBreak{};
 }
 return JaktInternal::ExplicitValue<void>();
@@ -2400,7 +2400,7 @@ return JaktInternal::ExplicitValue<void>();
 case 109 /* Implements */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Implements;utility::Span const& span = __jakt_match_value.value;
 {
-TRY((((*this).error(TRY(ByteString::from_utf8("Expected alias target name"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("Expected alias target name"sv)),span))));
 return JaktInternal::LoopBreak{};
 }
 return JaktInternal::ExplicitValue<void>();
@@ -2408,7 +2408,7 @@ return JaktInternal::ExplicitValue<void>();
 case 110 /* Requires */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Requires;utility::Span const& span = __jakt_match_value.value;
 {
-TRY((((*this).error(TRY(ByteString::from_utf8("Expected alias target name"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("Expected alias target name"sv)),span))));
 return JaktInternal::LoopBreak{};
 }
 return JaktInternal::ExplicitValue<void>();
@@ -2416,7 +2416,7 @@ return JaktInternal::ExplicitValue<void>();
 case 111 /* Trait */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Trait;utility::Span const& span = __jakt_match_value.value;
 {
-TRY((((*this).error(TRY(ByteString::from_utf8("Expected alias target name"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("Expected alias target name"sv)),span))));
 return JaktInternal::LoopBreak{};
 }
 return JaktInternal::ExplicitValue<void>();
@@ -2424,7 +2424,7 @@ return JaktInternal::ExplicitValue<void>();
 case 112 /* Garbage */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Garbage;utility::Span const& span = __jakt_match_value.span;
 {
-TRY((((*this).error(TRY(ByteString::from_utf8("Expected alias target name"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("Expected alias target name"sv)),span))));
 return JaktInternal::LoopBreak{};
 }
 return JaktInternal::ExplicitValue<void>();
@@ -2443,7 +2443,7 @@ default: VERIFY_NOT_REACHED();}/*switch end*/
 }
 if (((((*this).previous())).__jakt_init_index() == 6 /* ColonColon */)){
 utility::Span const span = (((*this).previous())).as.ColonColon.value;
-TRY((((*this).error(TRY(ByteString::from_utf8("Expected alias target name"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("Expected alias target name"sv)),span))));
 }
 if (((((*this).current())).__jakt_init_index() == 61 /* As */)){
 ((((*this).index)++));
@@ -2463,784 +2463,784 @@ return JaktInternal::ExplicitValue<void>();
 case 0 /* SingleQuotedString */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.SingleQuotedString;utility::Span const& span = __jakt_match_value.span;
 {
-TRY((((*this).error(TRY(ByteString::from_utf8("Expected alias name"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("Expected alias name"sv)),span))));
 }
 return JaktInternal::ExplicitValue<void>();
 };/*case end*/
 case 1 /* QuotedString */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.QuotedString;utility::Span const& span = __jakt_match_value.span;
 {
-TRY((((*this).error(TRY(ByteString::from_utf8("Expected alias name"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("Expected alias name"sv)),span))));
 }
 return JaktInternal::ExplicitValue<void>();
 };/*case end*/
 case 2 /* Number */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Number;utility::Span const& span = __jakt_match_value.span;
 {
-TRY((((*this).error(TRY(ByteString::from_utf8("Expected alias name"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("Expected alias name"sv)),span))));
 }
 return JaktInternal::ExplicitValue<void>();
 };/*case end*/
 case 4 /* Semicolon */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Semicolon;utility::Span const& span = __jakt_match_value.value;
 {
-TRY((((*this).error(TRY(ByteString::from_utf8("Expected alias name"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("Expected alias name"sv)),span))));
 }
 return JaktInternal::ExplicitValue<void>();
 };/*case end*/
 case 5 /* Colon */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Colon;utility::Span const& span = __jakt_match_value.value;
 {
-TRY((((*this).error(TRY(ByteString::from_utf8("Expected alias name"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("Expected alias name"sv)),span))));
 }
 return JaktInternal::ExplicitValue<void>();
 };/*case end*/
 case 6 /* ColonColon */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.ColonColon;utility::Span const& span = __jakt_match_value.value;
 {
-TRY((((*this).error(TRY(ByteString::from_utf8("Expected alias name"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("Expected alias name"sv)),span))));
 }
 return JaktInternal::ExplicitValue<void>();
 };/*case end*/
 case 7 /* LParen */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.LParen;utility::Span const& span = __jakt_match_value.value;
 {
-TRY((((*this).error(TRY(ByteString::from_utf8("Expected alias name"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("Expected alias name"sv)),span))));
 }
 return JaktInternal::ExplicitValue<void>();
 };/*case end*/
 case 8 /* RParen */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.RParen;utility::Span const& span = __jakt_match_value.value;
 {
-TRY((((*this).error(TRY(ByteString::from_utf8("Expected alias name"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("Expected alias name"sv)),span))));
 }
 return JaktInternal::ExplicitValue<void>();
 };/*case end*/
 case 9 /* LCurly */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.LCurly;utility::Span const& span = __jakt_match_value.value;
 {
-TRY((((*this).error(TRY(ByteString::from_utf8("Expected alias name"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("Expected alias name"sv)),span))));
 }
 return JaktInternal::ExplicitValue<void>();
 };/*case end*/
 case 10 /* RCurly */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.RCurly;utility::Span const& span = __jakt_match_value.value;
 {
-TRY((((*this).error(TRY(ByteString::from_utf8("Expected alias name"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("Expected alias name"sv)),span))));
 }
 return JaktInternal::ExplicitValue<void>();
 };/*case end*/
 case 11 /* LSquare */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.LSquare;utility::Span const& span = __jakt_match_value.value;
 {
-TRY((((*this).error(TRY(ByteString::from_utf8("Expected alias name"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("Expected alias name"sv)),span))));
 }
 return JaktInternal::ExplicitValue<void>();
 };/*case end*/
 case 12 /* RSquare */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.RSquare;utility::Span const& span = __jakt_match_value.value;
 {
-TRY((((*this).error(TRY(ByteString::from_utf8("Expected alias name"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("Expected alias name"sv)),span))));
 }
 return JaktInternal::ExplicitValue<void>();
 };/*case end*/
 case 13 /* PercentSign */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.PercentSign;utility::Span const& span = __jakt_match_value.value;
 {
-TRY((((*this).error(TRY(ByteString::from_utf8("Expected alias name"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("Expected alias name"sv)),span))));
 }
 return JaktInternal::ExplicitValue<void>();
 };/*case end*/
 case 14 /* Plus */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Plus;utility::Span const& span = __jakt_match_value.value;
 {
-TRY((((*this).error(TRY(ByteString::from_utf8("Expected alias name"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("Expected alias name"sv)),span))));
 }
 return JaktInternal::ExplicitValue<void>();
 };/*case end*/
 case 15 /* Minus */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Minus;utility::Span const& span = __jakt_match_value.value;
 {
-TRY((((*this).error(TRY(ByteString::from_utf8("Expected alias name"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("Expected alias name"sv)),span))));
 }
 return JaktInternal::ExplicitValue<void>();
 };/*case end*/
 case 16 /* Equal */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Equal;utility::Span const& span = __jakt_match_value.value;
 {
-TRY((((*this).error(TRY(ByteString::from_utf8("Expected alias name"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("Expected alias name"sv)),span))));
 }
 return JaktInternal::ExplicitValue<void>();
 };/*case end*/
 case 17 /* PlusEqual */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.PlusEqual;utility::Span const& span = __jakt_match_value.value;
 {
-TRY((((*this).error(TRY(ByteString::from_utf8("Expected alias name"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("Expected alias name"sv)),span))));
 }
 return JaktInternal::ExplicitValue<void>();
 };/*case end*/
 case 18 /* PlusPlus */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.PlusPlus;utility::Span const& span = __jakt_match_value.value;
 {
-TRY((((*this).error(TRY(ByteString::from_utf8("Expected alias name"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("Expected alias name"sv)),span))));
 }
 return JaktInternal::ExplicitValue<void>();
 };/*case end*/
 case 19 /* MinusEqual */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.MinusEqual;utility::Span const& span = __jakt_match_value.value;
 {
-TRY((((*this).error(TRY(ByteString::from_utf8("Expected alias name"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("Expected alias name"sv)),span))));
 }
 return JaktInternal::ExplicitValue<void>();
 };/*case end*/
 case 20 /* MinusMinus */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.MinusMinus;utility::Span const& span = __jakt_match_value.value;
 {
-TRY((((*this).error(TRY(ByteString::from_utf8("Expected alias name"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("Expected alias name"sv)),span))));
 }
 return JaktInternal::ExplicitValue<void>();
 };/*case end*/
 case 21 /* AsteriskEqual */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.AsteriskEqual;utility::Span const& span = __jakt_match_value.value;
 {
-TRY((((*this).error(TRY(ByteString::from_utf8("Expected alias name"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("Expected alias name"sv)),span))));
 }
 return JaktInternal::ExplicitValue<void>();
 };/*case end*/
 case 22 /* ForwardSlashEqual */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.ForwardSlashEqual;utility::Span const& span = __jakt_match_value.value;
 {
-TRY((((*this).error(TRY(ByteString::from_utf8("Expected alias name"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("Expected alias name"sv)),span))));
 }
 return JaktInternal::ExplicitValue<void>();
 };/*case end*/
 case 23 /* PercentSignEqual */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.PercentSignEqual;utility::Span const& span = __jakt_match_value.value;
 {
-TRY((((*this).error(TRY(ByteString::from_utf8("Expected alias name"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("Expected alias name"sv)),span))));
 }
 return JaktInternal::ExplicitValue<void>();
 };/*case end*/
 case 24 /* NotEqual */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.NotEqual;utility::Span const& span = __jakt_match_value.value;
 {
-TRY((((*this).error(TRY(ByteString::from_utf8("Expected alias name"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("Expected alias name"sv)),span))));
 }
 return JaktInternal::ExplicitValue<void>();
 };/*case end*/
 case 25 /* DoubleEqual */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.DoubleEqual;utility::Span const& span = __jakt_match_value.value;
 {
-TRY((((*this).error(TRY(ByteString::from_utf8("Expected alias name"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("Expected alias name"sv)),span))));
 }
 return JaktInternal::ExplicitValue<void>();
 };/*case end*/
 case 26 /* GreaterThan */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.GreaterThan;utility::Span const& span = __jakt_match_value.value;
 {
-TRY((((*this).error(TRY(ByteString::from_utf8("Expected alias name"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("Expected alias name"sv)),span))));
 }
 return JaktInternal::ExplicitValue<void>();
 };/*case end*/
 case 27 /* GreaterThanOrEqual */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.GreaterThanOrEqual;utility::Span const& span = __jakt_match_value.value;
 {
-TRY((((*this).error(TRY(ByteString::from_utf8("Expected alias name"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("Expected alias name"sv)),span))));
 }
 return JaktInternal::ExplicitValue<void>();
 };/*case end*/
 case 28 /* LessThan */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.LessThan;utility::Span const& span = __jakt_match_value.value;
 {
-TRY((((*this).error(TRY(ByteString::from_utf8("Expected alias name"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("Expected alias name"sv)),span))));
 }
 return JaktInternal::ExplicitValue<void>();
 };/*case end*/
 case 29 /* LessThanOrEqual */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.LessThanOrEqual;utility::Span const& span = __jakt_match_value.value;
 {
-TRY((((*this).error(TRY(ByteString::from_utf8("Expected alias name"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("Expected alias name"sv)),span))));
 }
 return JaktInternal::ExplicitValue<void>();
 };/*case end*/
 case 30 /* LeftArithmeticShift */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.LeftArithmeticShift;utility::Span const& span = __jakt_match_value.value;
 {
-TRY((((*this).error(TRY(ByteString::from_utf8("Expected alias name"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("Expected alias name"sv)),span))));
 }
 return JaktInternal::ExplicitValue<void>();
 };/*case end*/
 case 31 /* LeftShift */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.LeftShift;utility::Span const& span = __jakt_match_value.value;
 {
-TRY((((*this).error(TRY(ByteString::from_utf8("Expected alias name"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("Expected alias name"sv)),span))));
 }
 return JaktInternal::ExplicitValue<void>();
 };/*case end*/
 case 32 /* LeftShiftEqual */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.LeftShiftEqual;utility::Span const& span = __jakt_match_value.value;
 {
-TRY((((*this).error(TRY(ByteString::from_utf8("Expected alias name"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("Expected alias name"sv)),span))));
 }
 return JaktInternal::ExplicitValue<void>();
 };/*case end*/
 case 33 /* RightShift */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.RightShift;utility::Span const& span = __jakt_match_value.value;
 {
-TRY((((*this).error(TRY(ByteString::from_utf8("Expected alias name"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("Expected alias name"sv)),span))));
 }
 return JaktInternal::ExplicitValue<void>();
 };/*case end*/
 case 34 /* RightArithmeticShift */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.RightArithmeticShift;utility::Span const& span = __jakt_match_value.value;
 {
-TRY((((*this).error(TRY(ByteString::from_utf8("Expected alias name"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("Expected alias name"sv)),span))));
 }
 return JaktInternal::ExplicitValue<void>();
 };/*case end*/
 case 35 /* RightShiftEqual */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.RightShiftEqual;utility::Span const& span = __jakt_match_value.value;
 {
-TRY((((*this).error(TRY(ByteString::from_utf8("Expected alias name"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("Expected alias name"sv)),span))));
 }
 return JaktInternal::ExplicitValue<void>();
 };/*case end*/
 case 36 /* Asterisk */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Asterisk;utility::Span const& span = __jakt_match_value.value;
 {
-TRY((((*this).error(TRY(ByteString::from_utf8("Expected alias name"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("Expected alias name"sv)),span))));
 }
 return JaktInternal::ExplicitValue<void>();
 };/*case end*/
 case 37 /* Ampersand */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Ampersand;utility::Span const& span = __jakt_match_value.value;
 {
-TRY((((*this).error(TRY(ByteString::from_utf8("Expected alias name"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("Expected alias name"sv)),span))));
 }
 return JaktInternal::ExplicitValue<void>();
 };/*case end*/
 case 38 /* AmpersandEqual */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.AmpersandEqual;utility::Span const& span = __jakt_match_value.value;
 {
-TRY((((*this).error(TRY(ByteString::from_utf8("Expected alias name"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("Expected alias name"sv)),span))));
 }
 return JaktInternal::ExplicitValue<void>();
 };/*case end*/
 case 39 /* AmpersandAmpersand */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.AmpersandAmpersand;utility::Span const& span = __jakt_match_value.value;
 {
-TRY((((*this).error(TRY(ByteString::from_utf8("Expected alias name"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("Expected alias name"sv)),span))));
 }
 return JaktInternal::ExplicitValue<void>();
 };/*case end*/
 case 40 /* Pipe */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Pipe;utility::Span const& span = __jakt_match_value.value;
 {
-TRY((((*this).error(TRY(ByteString::from_utf8("Expected alias name"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("Expected alias name"sv)),span))));
 }
 return JaktInternal::ExplicitValue<void>();
 };/*case end*/
 case 41 /* PipeEqual */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.PipeEqual;utility::Span const& span = __jakt_match_value.value;
 {
-TRY((((*this).error(TRY(ByteString::from_utf8("Expected alias name"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("Expected alias name"sv)),span))));
 }
 return JaktInternal::ExplicitValue<void>();
 };/*case end*/
 case 42 /* PipePipe */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.PipePipe;utility::Span const& span = __jakt_match_value.value;
 {
-TRY((((*this).error(TRY(ByteString::from_utf8("Expected alias name"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("Expected alias name"sv)),span))));
 }
 return JaktInternal::ExplicitValue<void>();
 };/*case end*/
 case 43 /* Caret */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Caret;utility::Span const& span = __jakt_match_value.value;
 {
-TRY((((*this).error(TRY(ByteString::from_utf8("Expected alias name"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("Expected alias name"sv)),span))));
 }
 return JaktInternal::ExplicitValue<void>();
 };/*case end*/
 case 44 /* CaretEqual */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.CaretEqual;utility::Span const& span = __jakt_match_value.value;
 {
-TRY((((*this).error(TRY(ByteString::from_utf8("Expected alias name"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("Expected alias name"sv)),span))));
 }
 return JaktInternal::ExplicitValue<void>();
 };/*case end*/
 case 45 /* Dollar */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Dollar;utility::Span const& span = __jakt_match_value.value;
 {
-TRY((((*this).error(TRY(ByteString::from_utf8("Expected alias name"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("Expected alias name"sv)),span))));
 }
 return JaktInternal::ExplicitValue<void>();
 };/*case end*/
 case 46 /* Tilde */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Tilde;utility::Span const& span = __jakt_match_value.value;
 {
-TRY((((*this).error(TRY(ByteString::from_utf8("Expected alias name"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("Expected alias name"sv)),span))));
 }
 return JaktInternal::ExplicitValue<void>();
 };/*case end*/
 case 47 /* ForwardSlash */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.ForwardSlash;utility::Span const& span = __jakt_match_value.value;
 {
-TRY((((*this).error(TRY(ByteString::from_utf8("Expected alias name"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("Expected alias name"sv)),span))));
 }
 return JaktInternal::ExplicitValue<void>();
 };/*case end*/
 case 48 /* ExclamationPoint */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.ExclamationPoint;utility::Span const& span = __jakt_match_value.value;
 {
-TRY((((*this).error(TRY(ByteString::from_utf8("Expected alias name"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("Expected alias name"sv)),span))));
 }
 return JaktInternal::ExplicitValue<void>();
 };/*case end*/
 case 49 /* QuestionMark */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.QuestionMark;utility::Span const& span = __jakt_match_value.value;
 {
-TRY((((*this).error(TRY(ByteString::from_utf8("Expected alias name"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("Expected alias name"sv)),span))));
 }
 return JaktInternal::ExplicitValue<void>();
 };/*case end*/
 case 50 /* QuestionMarkQuestionMark */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.QuestionMarkQuestionMark;utility::Span const& span = __jakt_match_value.value;
 {
-TRY((((*this).error(TRY(ByteString::from_utf8("Expected alias name"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("Expected alias name"sv)),span))));
 }
 return JaktInternal::ExplicitValue<void>();
 };/*case end*/
 case 51 /* QuestionMarkQuestionMarkEqual */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.QuestionMarkQuestionMarkEqual;utility::Span const& span = __jakt_match_value.value;
 {
-TRY((((*this).error(TRY(ByteString::from_utf8("Expected alias name"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("Expected alias name"sv)),span))));
 }
 return JaktInternal::ExplicitValue<void>();
 };/*case end*/
 case 52 /* Comma */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Comma;utility::Span const& span = __jakt_match_value.value;
 {
-TRY((((*this).error(TRY(ByteString::from_utf8("Expected alias name"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("Expected alias name"sv)),span))));
 }
 return JaktInternal::ExplicitValue<void>();
 };/*case end*/
 case 53 /* Dot */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Dot;utility::Span const& span = __jakt_match_value.value;
 {
-TRY((((*this).error(TRY(ByteString::from_utf8("Expected alias name"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("Expected alias name"sv)),span))));
 }
 return JaktInternal::ExplicitValue<void>();
 };/*case end*/
 case 54 /* DotDot */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.DotDot;utility::Span const& span = __jakt_match_value.value;
 {
-TRY((((*this).error(TRY(ByteString::from_utf8("Expected alias name"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("Expected alias name"sv)),span))));
 }
 return JaktInternal::ExplicitValue<void>();
 };/*case end*/
 case 55 /* Eol */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Eol;utility::Span const& span = __jakt_match_value.span;
 {
-TRY((((*this).error(TRY(ByteString::from_utf8("Expected alias name"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("Expected alias name"sv)),span))));
 }
 return JaktInternal::ExplicitValue<void>();
 };/*case end*/
 case 56 /* Eof */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Eof;utility::Span const& span = __jakt_match_value.value;
 {
-TRY((((*this).error(TRY(ByteString::from_utf8("Expected alias name"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("Expected alias name"sv)),span))));
 }
 return JaktInternal::ExplicitValue<void>();
 };/*case end*/
 case 57 /* FatArrow */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.FatArrow;utility::Span const& span = __jakt_match_value.value;
 {
-TRY((((*this).error(TRY(ByteString::from_utf8("Expected alias name"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("Expected alias name"sv)),span))));
 }
 return JaktInternal::ExplicitValue<void>();
 };/*case end*/
 case 58 /* Arrow */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Arrow;utility::Span const& span = __jakt_match_value.value;
 {
-TRY((((*this).error(TRY(ByteString::from_utf8("Expected alias name"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("Expected alias name"sv)),span))));
 }
 return JaktInternal::ExplicitValue<void>();
 };/*case end*/
 case 59 /* And */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.And;utility::Span const& span = __jakt_match_value.value;
 {
-TRY((((*this).error(TRY(ByteString::from_utf8("Expected alias name"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("Expected alias name"sv)),span))));
 }
 return JaktInternal::ExplicitValue<void>();
 };/*case end*/
 case 60 /* Anon */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Anon;utility::Span const& span = __jakt_match_value.value;
 {
-TRY((((*this).error(TRY(ByteString::from_utf8("Expected alias name"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("Expected alias name"sv)),span))));
 }
 return JaktInternal::ExplicitValue<void>();
 };/*case end*/
 case 61 /* As */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.As;utility::Span const& span = __jakt_match_value.value;
 {
-TRY((((*this).error(TRY(ByteString::from_utf8("Expected alias name"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("Expected alias name"sv)),span))));
 }
 return JaktInternal::ExplicitValue<void>();
 };/*case end*/
 case 62 /* Boxed */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Boxed;utility::Span const& span = __jakt_match_value.value;
 {
-TRY((((*this).error(TRY(ByteString::from_utf8("Expected alias name"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("Expected alias name"sv)),span))));
 }
 return JaktInternal::ExplicitValue<void>();
 };/*case end*/
 case 63 /* Break */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Break;utility::Span const& span = __jakt_match_value.value;
 {
-TRY((((*this).error(TRY(ByteString::from_utf8("Expected alias name"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("Expected alias name"sv)),span))));
 }
 return JaktInternal::ExplicitValue<void>();
 };/*case end*/
 case 64 /* Catch */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Catch;utility::Span const& span = __jakt_match_value.value;
 {
-TRY((((*this).error(TRY(ByteString::from_utf8("Expected alias name"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("Expected alias name"sv)),span))));
 }
 return JaktInternal::ExplicitValue<void>();
 };/*case end*/
 case 65 /* Class */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Class;utility::Span const& span = __jakt_match_value.value;
 {
-TRY((((*this).error(TRY(ByteString::from_utf8("Expected alias name"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("Expected alias name"sv)),span))));
 }
 return JaktInternal::ExplicitValue<void>();
 };/*case end*/
 case 66 /* Continue */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Continue;utility::Span const& span = __jakt_match_value.value;
 {
-TRY((((*this).error(TRY(ByteString::from_utf8("Expected alias name"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("Expected alias name"sv)),span))));
 }
 return JaktInternal::ExplicitValue<void>();
 };/*case end*/
 case 67 /* Cpp */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Cpp;utility::Span const& span = __jakt_match_value.value;
 {
-TRY((((*this).error(TRY(ByteString::from_utf8("Expected alias name"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("Expected alias name"sv)),span))));
 }
 return JaktInternal::ExplicitValue<void>();
 };/*case end*/
 case 68 /* Defer */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Defer;utility::Span const& span = __jakt_match_value.value;
 {
-TRY((((*this).error(TRY(ByteString::from_utf8("Expected alias name"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("Expected alias name"sv)),span))));
 }
 return JaktInternal::ExplicitValue<void>();
 };/*case end*/
 case 69 /* Destructor */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Destructor;utility::Span const& span = __jakt_match_value.value;
 {
-TRY((((*this).error(TRY(ByteString::from_utf8("Expected alias name"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("Expected alias name"sv)),span))));
 }
 return JaktInternal::ExplicitValue<void>();
 };/*case end*/
 case 70 /* Else */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Else;utility::Span const& span = __jakt_match_value.value;
 {
-TRY((((*this).error(TRY(ByteString::from_utf8("Expected alias name"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("Expected alias name"sv)),span))));
 }
 return JaktInternal::ExplicitValue<void>();
 };/*case end*/
 case 71 /* Enum */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Enum;utility::Span const& span = __jakt_match_value.value;
 {
-TRY((((*this).error(TRY(ByteString::from_utf8("Expected alias name"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("Expected alias name"sv)),span))));
 }
 return JaktInternal::ExplicitValue<void>();
 };/*case end*/
 case 72 /* Extern */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Extern;utility::Span const& span = __jakt_match_value.value;
 {
-TRY((((*this).error(TRY(ByteString::from_utf8("Expected alias name"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("Expected alias name"sv)),span))));
 }
 return JaktInternal::ExplicitValue<void>();
 };/*case end*/
 case 73 /* False */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.False;utility::Span const& span = __jakt_match_value.value;
 {
-TRY((((*this).error(TRY(ByteString::from_utf8("Expected alias name"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("Expected alias name"sv)),span))));
 }
 return JaktInternal::ExplicitValue<void>();
 };/*case end*/
 case 74 /* For */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.For;utility::Span const& span = __jakt_match_value.value;
 {
-TRY((((*this).error(TRY(ByteString::from_utf8("Expected alias name"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("Expected alias name"sv)),span))));
 }
 return JaktInternal::ExplicitValue<void>();
 };/*case end*/
 case 75 /* Fn */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Fn;utility::Span const& span = __jakt_match_value.value;
 {
-TRY((((*this).error(TRY(ByteString::from_utf8("Expected alias name"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("Expected alias name"sv)),span))));
 }
 return JaktInternal::ExplicitValue<void>();
 };/*case end*/
 case 76 /* Comptime */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Comptime;utility::Span const& span = __jakt_match_value.value;
 {
-TRY((((*this).error(TRY(ByteString::from_utf8("Expected alias name"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("Expected alias name"sv)),span))));
 }
 return JaktInternal::ExplicitValue<void>();
 };/*case end*/
 case 77 /* If */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.If;utility::Span const& span = __jakt_match_value.value;
 {
-TRY((((*this).error(TRY(ByteString::from_utf8("Expected alias name"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("Expected alias name"sv)),span))));
 }
 return JaktInternal::ExplicitValue<void>();
 };/*case end*/
 case 78 /* Import */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Import;utility::Span const& span = __jakt_match_value.value;
 {
-TRY((((*this).error(TRY(ByteString::from_utf8("Expected alias name"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("Expected alias name"sv)),span))));
 }
 return JaktInternal::ExplicitValue<void>();
 };/*case end*/
 case 79 /* Relative */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Relative;utility::Span const& span = __jakt_match_value.value;
 {
-TRY((((*this).error(TRY(ByteString::from_utf8("Expected alias name"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("Expected alias name"sv)),span))));
 }
 return JaktInternal::ExplicitValue<void>();
 };/*case end*/
 case 80 /* In */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.In;utility::Span const& span = __jakt_match_value.value;
 {
-TRY((((*this).error(TRY(ByteString::from_utf8("Expected alias name"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("Expected alias name"sv)),span))));
 }
 return JaktInternal::ExplicitValue<void>();
 };/*case end*/
 case 81 /* Is */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Is;utility::Span const& span = __jakt_match_value.value;
 {
-TRY((((*this).error(TRY(ByteString::from_utf8("Expected alias name"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("Expected alias name"sv)),span))));
 }
 return JaktInternal::ExplicitValue<void>();
 };/*case end*/
 case 82 /* Let */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Let;utility::Span const& span = __jakt_match_value.value;
 {
-TRY((((*this).error(TRY(ByteString::from_utf8("Expected alias name"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("Expected alias name"sv)),span))));
 }
 return JaktInternal::ExplicitValue<void>();
 };/*case end*/
 case 83 /* Loop */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Loop;utility::Span const& span = __jakt_match_value.value;
 {
-TRY((((*this).error(TRY(ByteString::from_utf8("Expected alias name"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("Expected alias name"sv)),span))));
 }
 return JaktInternal::ExplicitValue<void>();
 };/*case end*/
 case 84 /* Match */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Match;utility::Span const& span = __jakt_match_value.value;
 {
-TRY((((*this).error(TRY(ByteString::from_utf8("Expected alias name"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("Expected alias name"sv)),span))));
 }
 return JaktInternal::ExplicitValue<void>();
 };/*case end*/
 case 85 /* Mut */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Mut;utility::Span const& span = __jakt_match_value.value;
 {
-TRY((((*this).error(TRY(ByteString::from_utf8("Expected alias name"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("Expected alias name"sv)),span))));
 }
 return JaktInternal::ExplicitValue<void>();
 };/*case end*/
 case 86 /* Namespace */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Namespace;utility::Span const& span = __jakt_match_value.value;
 {
-TRY((((*this).error(TRY(ByteString::from_utf8("Expected alias name"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("Expected alias name"sv)),span))));
 }
 return JaktInternal::ExplicitValue<void>();
 };/*case end*/
 case 87 /* Not */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Not;utility::Span const& span = __jakt_match_value.value;
 {
-TRY((((*this).error(TRY(ByteString::from_utf8("Expected alias name"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("Expected alias name"sv)),span))));
 }
 return JaktInternal::ExplicitValue<void>();
 };/*case end*/
 case 88 /* Or */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Or;utility::Span const& span = __jakt_match_value.value;
 {
-TRY((((*this).error(TRY(ByteString::from_utf8("Expected alias name"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("Expected alias name"sv)),span))));
 }
 return JaktInternal::ExplicitValue<void>();
 };/*case end*/
 case 89 /* Override */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Override;utility::Span const& span = __jakt_match_value.value;
 {
-TRY((((*this).error(TRY(ByteString::from_utf8("Expected alias name"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("Expected alias name"sv)),span))));
 }
 return JaktInternal::ExplicitValue<void>();
 };/*case end*/
 case 90 /* Private */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Private;utility::Span const& span = __jakt_match_value.value;
 {
-TRY((((*this).error(TRY(ByteString::from_utf8("Expected alias name"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("Expected alias name"sv)),span))));
 }
 return JaktInternal::ExplicitValue<void>();
 };/*case end*/
 case 91 /* Public */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Public;utility::Span const& span = __jakt_match_value.value;
 {
-TRY((((*this).error(TRY(ByteString::from_utf8("Expected alias name"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("Expected alias name"sv)),span))));
 }
 return JaktInternal::ExplicitValue<void>();
 };/*case end*/
 case 92 /* Raw */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Raw;utility::Span const& span = __jakt_match_value.value;
 {
-TRY((((*this).error(TRY(ByteString::from_utf8("Expected alias name"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("Expected alias name"sv)),span))));
 }
 return JaktInternal::ExplicitValue<void>();
 };/*case end*/
 case 93 /* Reflect */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Reflect;utility::Span const& span = __jakt_match_value.value;
 {
-TRY((((*this).error(TRY(ByteString::from_utf8("Expected alias name"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("Expected alias name"sv)),span))));
 }
 return JaktInternal::ExplicitValue<void>();
 };/*case end*/
 case 94 /* Return */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Return;utility::Span const& span = __jakt_match_value.value;
 {
-TRY((((*this).error(TRY(ByteString::from_utf8("Expected alias name"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("Expected alias name"sv)),span))));
 }
 return JaktInternal::ExplicitValue<void>();
 };/*case end*/
 case 95 /* Restricted */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Restricted;utility::Span const& span = __jakt_match_value.value;
 {
-TRY((((*this).error(TRY(ByteString::from_utf8("Expected alias name"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("Expected alias name"sv)),span))));
 }
 return JaktInternal::ExplicitValue<void>();
 };/*case end*/
 case 96 /* Sizeof */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Sizeof;utility::Span const& span = __jakt_match_value.value;
 {
-TRY((((*this).error(TRY(ByteString::from_utf8("Expected alias name"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("Expected alias name"sv)),span))));
 }
 return JaktInternal::ExplicitValue<void>();
 };/*case end*/
 case 97 /* Struct */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Struct;utility::Span const& span = __jakt_match_value.value;
 {
-TRY((((*this).error(TRY(ByteString::from_utf8("Expected alias name"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("Expected alias name"sv)),span))));
 }
 return JaktInternal::ExplicitValue<void>();
 };/*case end*/
 case 98 /* This */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.This;utility::Span const& span = __jakt_match_value.value;
 {
-TRY((((*this).error(TRY(ByteString::from_utf8("Expected alias name"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("Expected alias name"sv)),span))));
 }
 return JaktInternal::ExplicitValue<void>();
 };/*case end*/
 case 99 /* Throw */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Throw;utility::Span const& span = __jakt_match_value.value;
 {
-TRY((((*this).error(TRY(ByteString::from_utf8("Expected alias name"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("Expected alias name"sv)),span))));
 }
 return JaktInternal::ExplicitValue<void>();
 };/*case end*/
 case 100 /* Throws */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Throws;utility::Span const& span = __jakt_match_value.value;
 {
-TRY((((*this).error(TRY(ByteString::from_utf8("Expected alias name"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("Expected alias name"sv)),span))));
 }
 return JaktInternal::ExplicitValue<void>();
 };/*case end*/
 case 101 /* True */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.True;utility::Span const& span = __jakt_match_value.value;
 {
-TRY((((*this).error(TRY(ByteString::from_utf8("Expected alias name"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("Expected alias name"sv)),span))));
 }
 return JaktInternal::ExplicitValue<void>();
 };/*case end*/
 case 102 /* Try */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Try;utility::Span const& span = __jakt_match_value.value;
 {
-TRY((((*this).error(TRY(ByteString::from_utf8("Expected alias name"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("Expected alias name"sv)),span))));
 }
 return JaktInternal::ExplicitValue<void>();
 };/*case end*/
 case 103 /* Unsafe */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Unsafe;utility::Span const& span = __jakt_match_value.value;
 {
-TRY((((*this).error(TRY(ByteString::from_utf8("Expected alias name"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("Expected alias name"sv)),span))));
 }
 return JaktInternal::ExplicitValue<void>();
 };/*case end*/
 case 104 /* Virtual */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Virtual;utility::Span const& span = __jakt_match_value.value;
 {
-TRY((((*this).error(TRY(ByteString::from_utf8("Expected alias name"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("Expected alias name"sv)),span))));
 }
 return JaktInternal::ExplicitValue<void>();
 };/*case end*/
 case 105 /* Weak */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Weak;utility::Span const& span = __jakt_match_value.value;
 {
-TRY((((*this).error(TRY(ByteString::from_utf8("Expected alias name"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("Expected alias name"sv)),span))));
 }
 return JaktInternal::ExplicitValue<void>();
 };/*case end*/
 case 106 /* While */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.While;utility::Span const& span = __jakt_match_value.value;
 {
-TRY((((*this).error(TRY(ByteString::from_utf8("Expected alias name"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("Expected alias name"sv)),span))));
 }
 return JaktInternal::ExplicitValue<void>();
 };/*case end*/
 case 107 /* Yield */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Yield;utility::Span const& span = __jakt_match_value.value;
 {
-TRY((((*this).error(TRY(ByteString::from_utf8("Expected alias name"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("Expected alias name"sv)),span))));
 }
 return JaktInternal::ExplicitValue<void>();
 };/*case end*/
 case 108 /* Guard */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Guard;utility::Span const& span = __jakt_match_value.value;
 {
-TRY((((*this).error(TRY(ByteString::from_utf8("Expected alias name"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("Expected alias name"sv)),span))));
 }
 return JaktInternal::ExplicitValue<void>();
 };/*case end*/
 case 109 /* Implements */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Implements;utility::Span const& span = __jakt_match_value.value;
 {
-TRY((((*this).error(TRY(ByteString::from_utf8("Expected alias name"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("Expected alias name"sv)),span))));
 }
 return JaktInternal::ExplicitValue<void>();
 };/*case end*/
 case 110 /* Requires */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Requires;utility::Span const& span = __jakt_match_value.value;
 {
-TRY((((*this).error(TRY(ByteString::from_utf8("Expected alias name"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("Expected alias name"sv)),span))));
 }
 return JaktInternal::ExplicitValue<void>();
 };/*case end*/
 case 111 /* Trait */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Trait;utility::Span const& span = __jakt_match_value.value;
 {
-TRY((((*this).error(TRY(ByteString::from_utf8("Expected alias name"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("Expected alias name"sv)),span))));
 }
 return JaktInternal::ExplicitValue<void>();
 };/*case end*/
 case 112 /* Garbage */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Garbage;utility::Span const& span = __jakt_match_value.span;
 {
-TRY((((*this).error(TRY(ByteString::from_utf8("Expected alias name"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("Expected alias name"sv)),span))));
 }
 return JaktInternal::ExplicitValue<void>();
 };/*case end*/
@@ -3300,7 +3300,7 @@ if ((!(for_trailing_closure))){
 return JaktInternal::LoopBreak{};
 }
 if ((!(error))){
-TRY((((*this).error(TRY(ByteString::from_utf8("Expected parameter"sv)),((((*this).current())).span())))));
+TRY((((*this).error((ByteString::must_from_utf8("Expected parameter"sv)),((((*this).current())).span())))));
 (error = true);
 }
 ((((*this).index)++));
@@ -3314,7 +3314,7 @@ if (for_trailing_closure){
 return JaktInternal::LoopBreak{};
 }
 if ((!(error))){
-TRY((((*this).error(TRY(ByteString::from_utf8("Expected parameter"sv)),((((*this).current())).span())))));
+TRY((((*this).error((ByteString::must_from_utf8("Expected parameter"sv)),((((*this).current())).span())))));
 (error = true);
 }
 ((((*this).index)++));
@@ -3324,7 +3324,7 @@ return JaktInternal::ExplicitValue<void>();
 case 52 /* Comma */: {
 {
 if (((!(parameter_complete)) && (!(error)))){
-TRY((((*this).error(TRY(ByteString::from_utf8("Expected parameter"sv)),((((*this).current())).span())))));
+TRY((((*this).error((ByteString::must_from_utf8("Expected parameter"sv)),((((*this).current())).span())))));
 (error = true);
 }
 ((((*this).index)++));
@@ -3337,7 +3337,7 @@ return JaktInternal::ExplicitValue<void>();
 case 55 /* Eol */: {
 {
 if (((!(parameter_complete)) && (!(error)))){
-TRY((((*this).error(TRY(ByteString::from_utf8("Expected parameter"sv)),((((*this).current())).span())))));
+TRY((((*this).error((ByteString::must_from_utf8("Expected parameter"sv)),((((*this).current())).span())))));
 (error = true);
 }
 ((((*this).index)++));
@@ -3350,15 +3350,15 @@ return JaktInternal::ExplicitValue<void>();
 case 54 /* DotDot */: {
 {
 if (((result).has_varargs)){
-TRY((((*this).error(TRY(ByteString::from_utf8("Multiple varargs cannot be present in one parameter list"sv)),((((*this).current())).span())))));
+TRY((((*this).error((ByteString::must_from_utf8("Multiple varargs cannot be present in one parameter list"sv)),((((*this).current())).span())))));
 (error = true);
 }
 if (current_param_is_mutable){
-TRY((((*this).error(TRY(ByteString::from_utf8("A variadic argument cannot be mutable"sv)),((((*this).current())).span())))));
+TRY((((*this).error((ByteString::must_from_utf8("A variadic argument cannot be mutable"sv)),((((*this).current())).span())))));
 (error = true);
 }
 if ((!(current_param_requires_label))){
-TRY((((*this).error(TRY(ByteString::from_utf8("A variadic argument cannot be anonymous"sv)),((((*this).current())).span())))));
+TRY((((*this).error((ByteString::must_from_utf8("A variadic argument cannot be anonymous"sv)),((((*this).current())).span())))));
 (error = true);
 }
 (((result).has_varargs) = true);
@@ -3372,19 +3372,19 @@ return JaktInternal::ExplicitValue<void>();
 case 60 /* Anon */: {
 {
 if (((result).has_varargs)){
-TRY((((*this).error(TRY(ByteString::from_utf8("A variadic argument may only appear at the end of a parameter list"sv)),((((*this).current())).span())))));
+TRY((((*this).error((ByteString::must_from_utf8("A variadic argument may only appear at the end of a parameter list"sv)),((((*this).current())).span())))));
 (error = true);
 }
 if ((parameter_complete && (!(error)))){
-TRY((((*this).error(TRY(ByteString::from_utf8("‘anon’ must appear at start of parameter declaration, not the end"sv)),((((*this).current())).span())))));
+TRY((((*this).error((ByteString::must_from_utf8("‘anon’ must appear at start of parameter declaration, not the end"sv)),((((*this).current())).span())))));
 (error = true);
 }
 if ((current_param_is_mutable && (!(error)))){
-TRY((((*this).error(TRY(ByteString::from_utf8("‘anon’ must appear before ‘mut’"sv)),((((*this).current())).span())))));
+TRY((((*this).error((ByteString::must_from_utf8("‘anon’ must appear before ‘mut’"sv)),((((*this).current())).span())))));
 (error = true);
 }
 if (((!(current_param_requires_label)) && (!(error)))){
-TRY((((*this).error(TRY(ByteString::from_utf8("‘anon’ cannot appear multiple times in one parameter declaration"sv)),((((*this).current())).span())))));
+TRY((((*this).error((ByteString::must_from_utf8("‘anon’ cannot appear multiple times in one parameter declaration"sv)),((((*this).current())).span())))));
 (error = true);
 }
 ((((*this).index)++));
@@ -3395,15 +3395,15 @@ return JaktInternal::ExplicitValue<void>();
 case 85 /* Mut */: {
 {
 if (((result).has_varargs)){
-TRY((((*this).error(TRY(ByteString::from_utf8("A variadic argument may only appear at the end of a parameter list"sv)),((((*this).current())).span())))));
+TRY((((*this).error((ByteString::must_from_utf8("A variadic argument may only appear at the end of a parameter list"sv)),((((*this).current())).span())))));
 (error = true);
 }
 if ((parameter_complete && (!(error)))){
-TRY((((*this).error(TRY(ByteString::from_utf8("‘mut’ must appear at start of parameter declaration, not the end"sv)),((((*this).current())).span())))));
+TRY((((*this).error((ByteString::must_from_utf8("‘mut’ must appear at start of parameter declaration, not the end"sv)),((((*this).current())).span())))));
 (error = true);
 }
 if ((current_param_is_mutable && (!(error)))){
-TRY((((*this).error(TRY(ByteString::from_utf8("‘mut’ cannot appear multiple times in one parameter declaration"sv)),((((*this).current())).span())))));
+TRY((((*this).error((ByteString::must_from_utf8("‘mut’ cannot appear multiple times in one parameter declaration"sv)),((((*this).current())).span())))));
 (error = true);
 }
 ((((*this).index)++));
@@ -3414,10 +3414,10 @@ return JaktInternal::ExplicitValue<void>();
 case 98 /* This */: {
 {
 if (((result).has_varargs)){
-TRY((((*this).error(TRY(ByteString::from_utf8("A variadic argument may only appear at the end of a parameter list"sv)),((((*this).current())).span())))));
+TRY((((*this).error((ByteString::must_from_utf8("A variadic argument may only appear at the end of a parameter list"sv)),((((*this).current())).span())))));
 (error = true);
 }
-TRY((((((result).parameters)).push(parser::ParsedParameter(false,parser::ParsedVariable(TRY(ByteString::from_utf8("this"sv)),TRY((parser::ParsedType::Empty(JaktInternal::OptionalNone()))),current_param_is_mutable,((((*this).current())).span())),JaktInternal::OptionalNone(),((((*this).current())).span()))))));
+TRY((((((result).parameters)).push(parser::ParsedParameter(false,parser::ParsedVariable((ByteString::must_from_utf8("this"sv)),TRY((parser::ParsedType::Empty(JaktInternal::OptionalNone()))),current_param_is_mutable,((((*this).current())).span())),JaktInternal::OptionalNone(),((((*this).current())).span()))))));
 ((((*this).index)++));
 (parameter_complete = true);
 }
@@ -3428,7 +3428,7 @@ auto&& __jakt_match_value = __jakt_match_variant.as.Identifier;ByteString const&
 utility::Span const& span = __jakt_match_value.span;
 {
 if (((result).has_varargs)){
-TRY((((*this).error(TRY(ByteString::from_utf8("A variadic argument may only appear at the end of a parameter list"sv)),((((*this).current())).span())))));
+TRY((((*this).error((ByteString::must_from_utf8("A variadic argument may only appear at the end of a parameter list"sv)),((((*this).current())).span())))));
 (error = true);
 }
 parser::ParsedVarDecl const var_decl = TRY((((*this).parse_variable_declaration(current_param_is_mutable))));
@@ -3445,7 +3445,7 @@ return JaktInternal::ExplicitValue<void>();
 default: {
 {
 if ((!(error))){
-TRY((((*this).error(TRY(ByteString::from_utf8("Expected parameter"sv)),((((*this).current())).span())))));
+TRY((((*this).error((ByteString::must_from_utf8("Expected parameter"sv)),((((*this).current())).span())))));
 (error = true);
 }
 ((((*this).index)++));
@@ -3473,7 +3473,7 @@ ErrorOr<JaktInternal::DynamicArray<parser::ParsedMatchCase>> parser::Parser::par
 JaktInternal::DynamicArray<parser::ParsedMatchCase> cases = (TRY((DynamicArray<parser::ParsedMatchCase>::create_with({}))));
 ((*this).skip_newlines());
 if ((!(((((*this).current())).__jakt_init_index() == 9 /* LCurly */)))){
-TRY((((*this).error(TRY(ByteString::from_utf8("Expected ‘{’"sv)),((((*this).current())).span())))));
+TRY((((*this).error((ByteString::must_from_utf8("Expected ‘{’"sv)),((((*this).current())).span())))));
 return cases;
 }
 ((((*this).index)++));
@@ -3487,7 +3487,7 @@ if (((((*this).current())).__jakt_init_index() == 57 /* FatArrow */)){
 ((((*this).index)++));
 }
 else {
-TRY((((*this).error(TRY(ByteString::from_utf8("Expected ‘=>’"sv)),((((*this).current())).span())))));
+TRY((((*this).error((ByteString::must_from_utf8("Expected ‘=>’"sv)),((((*this).current())).span())))));
 }
 
 ((*this).skip_newlines());
@@ -3537,7 +3537,7 @@ if ((((((*this).current())).__jakt_init_index() == 55 /* Eol */) || ((((*this).c
 }
 ((*this).skip_newlines());
 if ((!(((((*this).current())).__jakt_init_index() == 10 /* RCurly */)))){
-TRY((((*this).error(TRY(ByteString::from_utf8("Expected ‘}’"sv)),((((*this).current())).span())))));
+TRY((((*this).error((ByteString::must_from_utf8("Expected ‘}’"sv)),((((*this).current())).span())))));
 }
 ((((*this).index)++));
 return cases;
@@ -3563,14 +3563,14 @@ __jakt_label_31:; __jakt_var_35.release_value(); }));
 case 98 /* This */: {
 return JaktInternal::ExplicitValue(({ Optional<ByteString> __jakt_var_36; {
 ((((*this).index)++));
-__jakt_var_36 = TRY(ByteString::from_utf8("this"sv)); goto __jakt_label_32;
+__jakt_var_36 = (ByteString::must_from_utf8("this"sv)); goto __jakt_label_32;
 
 }
 __jakt_label_32:; __jakt_var_36.release_value(); }));
 };/*case end*/
 default: {
 {
-TRY((((*this).error(TRY(ByteString::from_utf8("Expected identifier"sv)),((((*this).current())).span())))));
+TRY((((*this).error((ByteString::must_from_utf8("Expected identifier"sv)),((((*this).current())).span())))));
 ((((*this).index)++));
 return JaktInternal::OptionalNone();
 }
@@ -3603,7 +3603,7 @@ __jakt_label_33:; __jakt_var_37.release_value(); }));
 case 98 /* This */: {
 return JaktInternal::ExplicitValue(({ Optional<ByteString> __jakt_var_38; {
 ((((*this).index)++));
-__jakt_var_38 = TRY(ByteString::from_utf8("this"sv)); goto __jakt_label_34;
+__jakt_var_38 = (ByteString::must_from_utf8("this"sv)); goto __jakt_label_34;
 
 }
 __jakt_label_34:; __jakt_var_38.release_value(); }));
@@ -3619,7 +3619,7 @@ __jakt_label_35:; __jakt_var_39.release_value(); }));
 };/*case end*/
 default: {
 {
-TRY((((*this).error(TRY(ByteString::from_utf8("Expected identifier or string literal"sv)),((((*this).current())).span())))));
+TRY((((*this).error((ByteString::must_from_utf8("Expected identifier or string literal"sv)),((((*this).current())).span())))));
 return JaktInternal::OptionalNone();
 }
 };/*case end*/
@@ -3653,7 +3653,7 @@ __jakt_label_36:; __jakt_var_40.release_value(); }));
 case 98 /* This */: {
 return JaktInternal::ExplicitValue(({ Optional<ByteString> __jakt_var_41; {
 ((((*this).index)++));
-__jakt_var_41 = TRY(ByteString::from_utf8("this"sv)); goto __jakt_label_37;
+__jakt_var_41 = (ByteString::must_from_utf8("this"sv)); goto __jakt_label_37;
 
 }
 __jakt_label_37:; __jakt_var_41.release_value(); }));
@@ -3669,7 +3669,7 @@ __jakt_label_38:; __jakt_var_42.release_value(); }));
 };/*case end*/
 default: {
 {
-TRY((((*this).error(TRY(ByteString::from_utf8("Expected identifier or string literal"sv)),((((*this).current())).span())))));
+TRY((((*this).error((ByteString::must_from_utf8("Expected identifier or string literal"sv)),((((*this).current())).span())))));
 return JaktInternal::OptionalNone();
 }
 };/*case end*/
@@ -3690,7 +3690,7 @@ if (((((*this).current())).__jakt_init_index() == 52 /* Comma */)){
 ((((*this).index)++));
 }
 else if ((!(((((*this).current())).__jakt_init_index() == 8 /* RParen */)))){
-TRY((((*this).error(TRY(ByteString::from_utf8("Expected ‘,’ or ‘)’"sv)),((((*this).current())).span())))));
+TRY((((*this).error((ByteString::must_from_utf8("Expected ‘,’ or ‘)’"sv)),((((*this).current())).span())))));
 break;
 }
 }
@@ -3698,7 +3698,7 @@ if (((((*this).current())).__jakt_init_index() == 8 /* RParen */)){
 ((((*this).index)++));
 }
 else {
-TRY((((*this).error(TRY(ByteString::from_utf8("Expected ‘)’"sv)),((((*this).current())).span())))));
+TRY((((*this).error((ByteString::must_from_utf8("Expected ‘)’"sv)),((((*this).current())).span())))));
 }
 
 }
@@ -3721,7 +3721,7 @@ __jakt_label_39:; __jakt_var_43.release_value(); }));
 case 98 /* This */: {
 return JaktInternal::ExplicitValue(({ Optional<ByteString> __jakt_var_44; {
 ((((*this).index)++));
-__jakt_var_44 = TRY(ByteString::from_utf8("this"sv)); goto __jakt_label_40;
+__jakt_var_44 = (ByteString::must_from_utf8("this"sv)); goto __jakt_label_40;
 
 }
 __jakt_label_40:; __jakt_var_44.release_value(); }));
@@ -3737,7 +3737,7 @@ __jakt_label_41:; __jakt_var_45.release_value(); }));
 };/*case end*/
 default: {
 return JaktInternal::ExplicitValue(({ Optional<ByteString> __jakt_var_46; {
-TRY((((*this).error(TRY(ByteString::from_utf8("Expected identifier or string literal"sv)),((((*this).current())).span())))));
+TRY((((*this).error((ByteString::must_from_utf8("Expected identifier or string literal"sv)),((((*this).current())).span())))));
 __jakt_var_46 = JaktInternal::OptionalNone(); goto __jakt_label_42;
 
 }
@@ -3781,7 +3781,7 @@ switch(__jakt_match_variant.__jakt_init_index()) {
 case 111 /* Trait */: {
 {
 if ((!(((active_attributes).is_empty())))){
-TRY((((*this).error(TRY(ByteString::from_utf8("Cannot apply attributes to trait declarations"sv)),((((active_attributes)[static_cast<i64>(0LL)])).span)))));
+TRY((((*this).error((ByteString::must_from_utf8("Cannot apply attributes to trait declarations"sv)),((((active_attributes)[static_cast<i64>(0LL)])).span)))));
 (active_attributes = (TRY((DynamicArray<parser::ParsedAttribute>::create_with({})))));
 }
 ((((*this).index)++));
@@ -3795,10 +3795,10 @@ auto&& __jakt_match_value = __jakt_match_variant.as.Identifier;ByteString const&
 return (({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<void,ErrorOr<parser::ParsedNamespace>>{
 auto __jakt_enum_value = (name);
-if (__jakt_enum_value == TRY(ByteString::from_utf8("type"sv))) {
+if (__jakt_enum_value == (ByteString::must_from_utf8("type"sv))) {
 {
 if ((!(((active_attributes).is_empty())))){
-TRY((((*this).error(TRY(ByteString::from_utf8("Cannot apply attributes to external trait declarations"sv)),((((active_attributes)[static_cast<i64>(0LL)])).span)))));
+TRY((((*this).error((ByteString::must_from_utf8("Cannot apply attributes to external trait declarations"sv)),((((active_attributes)[static_cast<i64>(0LL)])).span)))));
 (active_attributes = (TRY((DynamicArray<parser::ParsedAttribute>::create_with({})))));
 }
 ((((*this).index)++));
@@ -3807,10 +3807,10 @@ TRY((((((parsed_namespace).external_trait_implementations)).push(TRY((((*this).p
 }
 return JaktInternal::ExplicitValue<void>();
 }
-else if (__jakt_enum_value == TRY(ByteString::from_utf8("use"sv))) {
+else if (__jakt_enum_value == (ByteString::must_from_utf8("use"sv))) {
 {
 if ((!(((active_attributes).is_empty())))){
-TRY((((*this).error(TRY(ByteString::from_utf8("Cannot apply attributes to use declarations"sv)),((((active_attributes)[static_cast<i64>(0LL)])).span)))));
+TRY((((*this).error((ByteString::must_from_utf8("Cannot apply attributes to use declarations"sv)),((((active_attributes)[static_cast<i64>(0LL)])).span)))));
 (active_attributes = (TRY((DynamicArray<parser::ParsedAttribute>::create_with({})))));
 }
 ((((*this).index)++));
@@ -3819,10 +3819,10 @@ TRY((((((parsed_namespace).aliases)).push(TRY((((*this).parse_using())))))));
 }
 return JaktInternal::ExplicitValue<void>();
 }
-else if (__jakt_enum_value == TRY(ByteString::from_utf8("forall"sv))) {
+else if (__jakt_enum_value == (ByteString::must_from_utf8("forall"sv))) {
 {
 if ((!(((active_attributes).is_empty())))){
-TRY((((*this).error(TRY(ByteString::from_utf8("Cannot apply attributes to forall declarations"sv)),((((active_attributes)[static_cast<i64>(0LL)])).span)))));
+TRY((((*this).error((ByteString::must_from_utf8("Cannot apply attributes to forall declarations"sv)),((((active_attributes)[static_cast<i64>(0LL)])).span)))));
 (active_attributes = (TRY((DynamicArray<parser::ParsedAttribute>::create_with({})))));
 }
 ((((*this).index)++));
@@ -3834,7 +3834,7 @@ return JaktInternal::ExplicitValue<void>();
 else {
 {
 (active_attributes = (TRY((DynamicArray<parser::ParsedAttribute>::create_with({})))));
-TRY((((*this).error(TRY(ByteString::from_utf8("Unexpected token (expected keyword)"sv)),((((*this).current())).span())))));
+TRY((((*this).error((ByteString::must_from_utf8("Unexpected token (expected keyword)"sv)),((((*this).current())).span())))));
 return JaktInternal::LoopBreak{};
 }
 return JaktInternal::ExplicitValue<void>();
@@ -3853,7 +3853,7 @@ return JaktInternal::ExplicitValue<void>();
 case 78 /* Import */: {
 {
 if ((!(((active_attributes).is_empty())))){
-TRY((((*this).error(TRY(ByteString::from_utf8("Cannot apply attributes to imports"sv)),((((active_attributes)[static_cast<i64>(0LL)])).span)))));
+TRY((((*this).error((ByteString::must_from_utf8("Cannot apply attributes to imports"sv)),((((active_attributes)[static_cast<i64>(0LL)])).span)))));
 (active_attributes = (TRY((DynamicArray<parser::ParsedAttribute>::create_with({})))));
 }
 ((((*this).index)++));
@@ -3869,7 +3869,7 @@ if (((((*this).peek(static_cast<size_t>(1ULL)))).__jakt_init_index() == 11 /* LS
 TRY((((*this).parse_attribute_list(((active_attributes))))));
 }
 else {
-TRY((((*this).error(TRY(ByteString::from_utf8("Unexpected token (expected ‘[[’)"sv)),((((*this).current())).span())))));
+TRY((((*this).error((ByteString::must_from_utf8("Unexpected token (expected ‘[[’)"sv)),((((*this).current())).span())))));
 ((((*this).index)) += (static_cast<size_t>(1ULL)));
 }
 
@@ -3887,7 +3887,7 @@ TRY((((((parsed_namespace).functions)).push(parsed_function))));
 (saw_an_entity = true);
 }
 else {
-TRY((((*this).error(TRY(ByteString::from_utf8("Expected 'fn' after 'unsafe'"sv)),((((*this).current())).span())))));
+TRY((((*this).error((ByteString::must_from_utf8("Expected 'fn' after 'unsafe'"sv)),((((*this).current())).span())))));
 }
 
 }
@@ -3989,7 +3989,7 @@ if (((((*this).current())).__jakt_init_index() == 9 /* LCurly */)){
 ((((*this).index)++));
 }
 else {
-TRY((((*this).error(TRY(ByteString::from_utf8("Expected ‘{’"sv)),((((*this).current())).span())))));
+TRY((((*this).error((ByteString::must_from_utf8("Expected ‘{’"sv)),((((*this).current())).span())))));
 }
 
 parser::ParsedNamespace namespace_ = TRY((((*this).parse_namespace(false))));
@@ -3997,7 +3997,7 @@ if (((((*this).current())).__jakt_init_index() == 10 /* RCurly */)){
 ((((*this).index)++));
 }
 else {
-TRY((((*this).error(TRY(ByteString::from_utf8("Incomplete namespace"sv)),((((*this).previous())).span())))));
+TRY((((*this).error((ByteString::must_from_utf8("Incomplete namespace"sv)),((((*this).previous())).span())))));
 }
 
 if (((name).has_value())){
@@ -4029,7 +4029,7 @@ TRY((((((parsed_namespace).functions)).push(parsed_function))));
 (saw_an_entity = true);
 }
 else {
-TRY((((*this).error(TRY(ByteString::from_utf8("Expected 'fn' after 'unsafe'"sv)),((((*this).current())).span())))));
+TRY((((*this).error((ByteString::must_from_utf8("Expected 'fn' after 'unsafe'"sv)),((((*this).current())).span())))));
 }
 
 }
@@ -4078,7 +4078,7 @@ return JaktInternal::ExplicitValue<void>();
 default: {
 {
 (active_attributes = (TRY((DynamicArray<parser::ParsedAttribute>::create_with({})))));
-TRY((((*this).error(TRY(ByteString::from_utf8("Unexpected keyword"sv)),((((*this).current())).span())))));
+TRY((((*this).error((ByteString::must_from_utf8("Unexpected keyword"sv)),((((*this).current())).span())))));
 }
 return JaktInternal::ExplicitValue<void>();
 };/*case end*/
@@ -4110,7 +4110,7 @@ return JaktInternal::ExplicitValue<void>();
 };/*case end*/
 default: {
 {
-TRY((((*this).error(TRY(ByteString::from_utf8("Unexpected token (expected keyword)"sv)),((((*this).current())).span())))));
+TRY((((*this).error((ByteString::must_from_utf8("Unexpected token (expected keyword)"sv)),((((*this).current())).span())))));
 return JaktInternal::LoopBreak{};
 }
 return JaktInternal::ExplicitValue<void>();
@@ -4154,12 +4154,12 @@ return parser::ParsedVarDecl(name,TRY((parser::ParsedType::Empty(JaktInternal::O
 
 NonnullRefPtr<typename parser::ParsedType> const parsed_type = TRY((((*this).parse_typename())));
 if ((is_mutable && (((parsed_type)->__jakt_init_index() == 8 /* Reference */) || ((parsed_type)->__jakt_init_index() == 9 /* MutableReference */)))){
-TRY((((*this).error(TRY(ByteString::from_utf8("Reference parameter can not be mutable"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("Reference parameter can not be mutable"sv)),span))));
 }
 return parser::ParsedVarDecl(name,parsed_type,is_mutable,JaktInternal::OptionalNone(),span,JaktInternal::OptionalNone());
 }
 else {
-return parser::ParsedVarDecl(TRY(ByteString::from_utf8(""sv)),TRY((parser::ParsedType::Empty(JaktInternal::OptionalNone()))),false,JaktInternal::OptionalNone(),span,JaktInternal::OptionalNone());
+return parser::ParsedVarDecl((ByteString::must_from_utf8(""sv)),TRY((parser::ParsedType::Empty(JaktInternal::OptionalNone()))),false,JaktInternal::OptionalNone(),span,JaktInternal::OptionalNone());
 }
 
 }
@@ -4176,7 +4176,7 @@ if (((((*this).current())).__jakt_init_index() == 10 /* RCurly */)){
 ((((*this).index)++));
 return TRY((parser::ParsedType::Set(qualifiers,inner,TRY((parser::merge_spans(start,((((*this).current())).span())))))));
 }
-TRY((((*this).error(TRY(ByteString::from_utf8("Expected '}'"sv)),((((*this).current())).span())))));
+TRY((((*this).error((ByteString::must_from_utf8("Expected '}'"sv)),((((*this).current())).span())))));
 return TRY((parser::ParsedType::Empty(qualifiers)));
 }
 }
@@ -4184,7 +4184,7 @@ return TRY((parser::ParsedType::Empty(qualifiers)));
 ErrorOr<NonnullRefPtr<typename parser::ParsedStatement>> parser::Parser::parse_if_statement() {
 {
 if ((!(((((*this).current())).__jakt_init_index() == 77 /* If */)))){
-TRY((((*this).error(TRY(ByteString::from_utf8("Expected ‘if’ statement"sv)),((((*this).current())).span())))));
+TRY((((*this).error((ByteString::must_from_utf8("Expected ‘if’ statement"sv)),((((*this).current())).span())))));
 return TRY((parser::ParsedStatement::Garbage(((((*this).current())).span()))));
 }
 utility::Span const start_span = ((((*this).current())).span());
@@ -4213,7 +4213,7 @@ case 9 /* LCurly */: {
 {
 parser::ParsedBlock const block = TRY((((*this).parse_block())));
 if (((then_block).equals(block))){
-TRY((((*this).error(TRY(ByteString::from_utf8("if and else have identical blocks"sv)),((((*this).current())).span())))));
+TRY((((*this).error((ByteString::must_from_utf8("if and else have identical blocks"sv)),((((*this).current())).span())))));
 }
 (else_statement = TRY((parser::ParsedStatement::Block(block,TRY((parser::merge_spans(start_span,((((*this).previous())).span()))))))));
 }
@@ -4221,7 +4221,7 @@ return JaktInternal::ExplicitValue<void>();
 };/*case end*/
 default: {
 {
-TRY((((*this).error(TRY(ByteString::from_utf8("‘else’ missing ‘if’ or block"sv)),((((*this).previous())).span())))));
+TRY((((*this).error((ByteString::must_from_utf8("‘else’ missing ‘if’ or block"sv)),((((*this).previous())).span())))));
 }
 return JaktInternal::ExplicitValue<void>();
 };/*case end*/
@@ -4239,7 +4239,7 @@ return TRY((parser::ParsedStatement::If(condition,then_block,else_statement,TRY(
 
 ErrorOr<JaktInternal::Optional<parser::ParsedCall>> parser::Parser::parse_call() {
 {
-parser::ParsedCall call = parser::ParsedCall((TRY((DynamicArray<ByteString>::create_with({})))),TRY(ByteString::from_utf8(""sv)),(TRY((DynamicArray<JaktInternal::Tuple<ByteString,utility::Span,NonnullRefPtr<typename parser::ParsedExpression>>>::create_with({})))),(TRY((DynamicArray<NonnullRefPtr<typename parser::ParsedType>>::create_with({})))));
+parser::ParsedCall call = parser::ParsedCall((TRY((DynamicArray<ByteString>::create_with({})))),(ByteString::must_from_utf8(""sv)),(TRY((DynamicArray<JaktInternal::Tuple<ByteString,utility::Span,NonnullRefPtr<typename parser::ParsedExpression>>>::create_with({})))),(TRY((DynamicArray<NonnullRefPtr<typename parser::ParsedType>>::create_with({})))));
 if (((((*this).current())).__jakt_init_index() == 3 /* Identifier */)){
 ByteString const name = (((*this).current())).as.Identifier.name;
 (((call).name) = name);
@@ -4311,7 +4311,7 @@ if (((((*this).current())).__jakt_init_index() == 7 /* LParen */)){
 }
 else {
 (((*this).index) = index_reset);
-TRY((((*this).error(TRY(ByteString::from_utf8("Expected '('"sv)),((((*this).current())).span())))));
+TRY((((*this).error((ByteString::must_from_utf8("Expected '('"sv)),((((*this).current())).span())))));
 return JaktInternal::OptionalNone();
 }
 
@@ -4399,14 +4399,14 @@ return JaktInternal::ExplicitValue<void>();
 });
 if (((((*this).current())).__jakt_init_index() == 9 /* LCurly */)){
 if (has_varargs){
-TRY((((*this).error(TRY(ByteString::from_utf8("Function expressions cannot have varargs"sv)),((((*this).current())).span())))));
+TRY((((*this).error((ByteString::must_from_utf8("Function expressions cannot have varargs"sv)),((((*this).current())).span())))));
 }
 (block = TRY((((*this).parse_block()))));
 utility::Span const span = TRY((parser::merge_spans(start,((((*this).current())).span()))));
-JaktInternal::DynamicArray<parser::ParsedCapture> const captures = (TRY((DynamicArray<parser::ParsedCapture>::create_with({parser::ParsedCapture::AllByReference(TRY(ByteString::from_utf8(""sv)),((*this).empty_span()))}))));
+JaktInternal::DynamicArray<parser::ParsedCapture> const captures = (TRY((DynamicArray<parser::ParsedCapture>::create_with({parser::ParsedCapture::AllByReference((ByteString::must_from_utf8(""sv)),((*this).empty_span()))}))));
 NonnullRefPtr<typename parser::ParsedExpression> const trailing_closure = TRY((parser::ParsedExpression::Function(captures,params,false,false,TRY((parser::ParsedType::Empty(JaktInternal::OptionalNone()))),(block.value()),span)));
 NonnullRefPtr<typename parser::ParsedExpression> const reference_to_closure = TRY((parser::ParsedExpression::UnaryOp(trailing_closure,parser::UnaryOperator::Reference(),span)));
-TRY((((((call).args)).push((Tuple{TRY(ByteString::from_utf8(""sv)), ((*this).empty_span()), reference_to_closure})))));
+TRY((((((call).args)).push((Tuple{(ByteString::must_from_utf8(""sv)), ((*this).empty_span()), reference_to_closure})))));
 }
 else {
 (((*this).index) = start_index);
@@ -4418,7 +4418,7 @@ return call;
 return call;
 }
 else {
-TRY((((*this).error(TRY(ByteString::from_utf8("Expected function call"sv)),((((*this).current())).span())))));
+TRY((((*this).error((ByteString::must_from_utf8("Expected function call"sv)),((((*this).current())).span())))));
 return call;
 }
 
@@ -4434,18 +4434,18 @@ return {};
 
 ErrorOr<parser::ParsedRecord> parser::Parser::parse_class(parser::DefinitionLinkage const definition_linkage) {
 {
-parser::ParsedRecord parsed_class = parser::ParsedRecord(TRY(ByteString::from_utf8(""sv)),((*this).empty_span()),(TRY((DynamicArray<parser::ParsedGenericParameter>::create_with({})))),definition_linkage,JaktInternal::OptionalNone(),(TRY((DynamicArray<parser::ParsedMethod>::create_with({})))),parser::RecordType::Garbage(),(TRY((DynamicArray<parser::ParsedRecord>::create_with({})))),JaktInternal::OptionalNone());
+parser::ParsedRecord parsed_class = parser::ParsedRecord((ByteString::must_from_utf8(""sv)),((*this).empty_span()),(TRY((DynamicArray<parser::ParsedGenericParameter>::create_with({})))),definition_linkage,JaktInternal::OptionalNone(),(TRY((DynamicArray<parser::ParsedMethod>::create_with({})))),parser::RecordType::Garbage(),(TRY((DynamicArray<parser::ParsedRecord>::create_with({})))),JaktInternal::OptionalNone());
 JaktInternal::Optional<NonnullRefPtr<typename parser::ParsedType>> super_type = JaktInternal::OptionalNone();
 if (((((*this).current())).__jakt_init_index() == 65 /* Class */)){
 ((((*this).index)++));
 }
 else {
-TRY((((*this).error(TRY(ByteString::from_utf8("Expected `class` keyword"sv)),((((*this).current())).span())))));
+TRY((((*this).error((ByteString::must_from_utf8("Expected `class` keyword"sv)),((((*this).current())).span())))));
 return parsed_class;
 }
 
 if (((*this).eof())){
-TRY((((*this).error(TRY(ByteString::from_utf8("Incomplete class definition, expected name"sv)),((((*this).current())).span())))));
+TRY((((*this).error((ByteString::must_from_utf8("Incomplete class definition, expected name"sv)),((((*this).current())).span())))));
 return parsed_class;
 }
 if (((((*this).current())).__jakt_init_index() == 3 /* Identifier */)){
@@ -4456,11 +4456,11 @@ utility::Span const span = (((*this).current())).as.Identifier.span;
 (((parsed_class).name_span) = span);
 }
 else {
-TRY((((*this).error(TRY(ByteString::from_utf8("Incomplete class definition, expected name"sv)),((((*this).current())).span())))));
+TRY((((*this).error((ByteString::must_from_utf8("Incomplete class definition, expected name"sv)),((((*this).current())).span())))));
 }
 
 if (((*this).eof())){
-TRY((((*this).error(TRY(ByteString::from_utf8("Incomplete class definition, expected generic parameters or super class or body"sv)),((((*this).current())).span())))));
+TRY((((*this).error((ByteString::must_from_utf8("Incomplete class definition, expected generic parameters or super class or body"sv)),((((*this).current())).span())))));
 return parsed_class;
 }
 (((parsed_class).generic_parameters) = TRY((((*this).parse_generic_parameters()))));
@@ -4469,7 +4469,7 @@ if (((((*this).current())).__jakt_init_index() == 109 /* Implements */)){
 (((parsed_class).implements_list) = TRY((((*this).parse_trait_list()))));
 }
 if (((*this).eof())){
-TRY((((*this).error(TRY(ByteString::from_utf8("Incomplete class definition, expected super class or body"sv)),((((*this).current())).span())))));
+TRY((((*this).error((ByteString::must_from_utf8("Incomplete class definition, expected super class or body"sv)),((((*this).current())).span())))));
 return parsed_class;
 }
 if (((((*this).current())).__jakt_init_index() == 5 /* Colon */)){
@@ -4478,7 +4478,7 @@ if (((((*this).current())).__jakt_init_index() == 5 /* Colon */)){
 }
 ((*this).skip_newlines());
 if (((*this).eof())){
-TRY((((*this).error(TRY(ByteString::from_utf8("Incomplete class definition, expected body"sv)),((((*this).current())).span())))));
+TRY((((*this).error((ByteString::must_from_utf8("Incomplete class definition, expected body"sv)),((((*this).current())).span())))));
 return parsed_class;
 }
 JaktInternal::Tuple<JaktInternal::DynamicArray<parser::ParsedField>,JaktInternal::DynamicArray<parser::ParsedMethod>,JaktInternal::DynamicArray<parser::ParsedRecord>> const fields_methods_records_ = TRY((((*this).parse_struct_class_body(definition_linkage,parser::Visibility::Private(),true))));
@@ -4501,12 +4501,12 @@ if (((((*this).current())).__jakt_init_index() == 109 /* Implements */)){
 ((((*this).index)++));
 }
 else {
-TRY((((*this).error(TRY(ByteString::from_utf8("Expected ‘implements’"sv)),((((*this).current())).span())))));
+TRY((((*this).error((ByteString::must_from_utf8("Expected ‘implements’"sv)),((((*this).current())).span())))));
 }
 
 JaktInternal::Optional<JaktInternal::DynamicArray<parser::ParsedNameWithGenericParameters>> const trait_list = TRY((((*this).parse_trait_list())));
 if ((!(((trait_list).has_value())))){
-TRY((((*this).error(TRY(ByteString::from_utf8("Expected non-empty trait list"sv)),((((*this).current())).span())))));
+TRY((((*this).error((ByteString::must_from_utf8("Expected non-empty trait list"sv)),((((*this).current())).span())))));
 return parser::ParsedExternalTraitImplementation(type_name,(TRY((DynamicArray<parser::ParsedNameWithGenericParameters>::create_with({})))),(TRY((DynamicArray<parser::ParsedMethod>::create_with({})))));
 }
 ((*this).skip_newlines());
@@ -4517,15 +4517,15 @@ JaktInternal::DynamicArray<parser::ParsedMethod> const methods = ((fields_method
 JaktInternal::DynamicArray<parser::ParsedRecord> const records = ((fields_methods_records_).template get<2>());
 
 if ((!(((records).is_empty())))){
-TRY((((*this).error(TRY(ByteString::from_utf8("External trait implementations cannot have nested records"sv)),((((records)[static_cast<i64>(0LL)])).name_span)))));
+TRY((((*this).error((ByteString::must_from_utf8("External trait implementations cannot have nested records"sv)),((((records)[static_cast<i64>(0LL)])).name_span)))));
 }
 if ((!(((fields).is_empty())))){
-TRY((((*this).error(TRY(ByteString::from_utf8("External trait implementations cannot have fields"sv)),((((((fields)[static_cast<i64>(0LL)])).var_decl)).span)))));
+TRY((((*this).error((ByteString::must_from_utf8("External trait implementations cannot have fields"sv)),((((((fields)[static_cast<i64>(0LL)])).var_decl)).span)))));
 }
 return parser::ParsedExternalTraitImplementation(type_name,(trait_list.value()),methods);
 }
 else {
-TRY((((*this).error(TRY(ByteString::from_utf8("Expected ‘{’"sv)),((((*this).current())).span())))));
+TRY((((*this).error((ByteString::must_from_utf8("Expected ‘{’"sv)),((((*this).current())).span())))));
 return parser::ParsedExternalTraitImplementation(type_name,(trait_list.value()),(TRY((DynamicArray<parser::ParsedMethod>::create_with({})))));
 }
 
@@ -4626,7 +4626,7 @@ __jakt_label_45:; __jakt_var_49.release_value(); }));
 };/*case end*/
 default: {
 return JaktInternal::ExplicitValue(({ Optional<parser::ParsedMatchPattern> __jakt_var_50; {
-TRY((((*this).error(TRY(ByteString::from_utf8("Expected pattern or ‘else’"sv)),((((*this).current())).span())))));
+TRY((((*this).error((ByteString::must_from_utf8("Expected pattern or ‘else’"sv)),((((*this).current())).span())))));
 __jakt_var_50 = parser::ParsedMatchPattern::Invalid((TRY((Dictionary<ByteString, parser::ParsedPatternDefault>::create_with_entries({}))))); goto __jakt_label_46;
 
 }
@@ -4644,20 +4644,20 @@ __jakt_label_46:; __jakt_var_50.release_value(); }));
 
 ErrorOr<parser::ParsedFunction> parser::Parser::parse_function(parser::FunctionLinkage const linkage,parser::Visibility const visibility,bool const is_comptime,bool const is_destructor,bool const is_unsafe,bool const allow_missing_body) {
 {
-parser::ParsedFunction parsed_function = parser::ParsedFunction(((((*this).next_function_id)++)),TRY(ByteString::from_utf8(""sv)),((*this).empty_span()),visibility,(TRY((DynamicArray<parser::ParsedParameter>::create_with({})))),(TRY((DynamicArray<parser::ParsedGenericParameter>::create_with({})))),parser::ParsedBlock((TRY((DynamicArray<NonnullRefPtr<typename parser::ParsedStatement>>::create_with({}))))),TRY((parser::ParsedType::Empty(JaktInternal::OptionalNone()))),((*this).span(static_cast<size_t>(0ULL),static_cast<size_t>(0ULL))),false,parser::FunctionType::Normal(),linkage,false,is_comptime,false,is_unsafe,false,false,JaktInternal::OptionalNone(),JaktInternal::OptionalNone(),JaktInternal::OptionalNone(),parser::InlineState::Default());
+parser::ParsedFunction parsed_function = parser::ParsedFunction(((((*this).next_function_id)++)),(ByteString::must_from_utf8(""sv)),((*this).empty_span()),visibility,(TRY((DynamicArray<parser::ParsedParameter>::create_with({})))),(TRY((DynamicArray<parser::ParsedGenericParameter>::create_with({})))),parser::ParsedBlock((TRY((DynamicArray<NonnullRefPtr<typename parser::ParsedStatement>>::create_with({}))))),TRY((parser::ParsedType::Empty(JaktInternal::OptionalNone()))),((*this).span(static_cast<size_t>(0ULL),static_cast<size_t>(0ULL))),false,parser::FunctionType::Normal(),linkage,false,is_comptime,false,is_unsafe,false,false,JaktInternal::OptionalNone(),JaktInternal::OptionalNone(),JaktInternal::OptionalNone(),parser::InlineState::Default());
 if (is_destructor){
 (((parsed_function).type) = parser::FunctionType::Destructor());
-TRY((((((parsed_function).params)).push(parser::ParsedParameter(false,parser::ParsedVariable(TRY(ByteString::from_utf8("this"sv)),TRY((parser::ParsedType::Empty(JaktInternal::OptionalNone()))),true,((((*this).current())).span())),JaktInternal::OptionalNone(),((((*this).current())).span()))))));
+TRY((((((parsed_function).params)).push(parser::ParsedParameter(false,parser::ParsedVariable((ByteString::must_from_utf8("this"sv)),TRY((parser::ParsedType::Empty(JaktInternal::OptionalNone()))),true,((((*this).current())).span())),JaktInternal::OptionalNone(),((((*this).current())).span()))))));
 }
 if ((!(is_destructor))){
 ((((*this).index)++));
 }
 if (((*this).eof())){
-TRY((((*this).error(TRY(ByteString::from_utf8("Incomplete function definition"sv)),((((*this).current())).span())))));
+TRY((((*this).error((ByteString::must_from_utf8("Incomplete function definition"sv)),((((*this).current())).span())))));
 return parsed_function;
 }
 if (is_destructor){
-(((parsed_function).name) = TRY(ByteString::from_utf8("~"sv)));
+(((parsed_function).name) = (ByteString::must_from_utf8("~"sv)));
 (((parsed_function).name_span) = ((((*this).previous())).span()));
 }
 else {
@@ -4667,7 +4667,7 @@ ByteString const name = (((*this).current())).as.Identifier.name;
 (((parsed_function).name_span) = ((((*this).current())).span()));
 }
 else {
-TRY((((*this).error(TRY(ByteString::from_utf8("Incomplete function definition"sv)),((((*this).current())).span())))));
+TRY((((*this).error((ByteString::must_from_utf8("Incomplete function definition"sv)),((((*this).current())).span())))));
 return parsed_function;
 }
 
@@ -4678,18 +4678,18 @@ if ((!(is_destructor))){
 (((parsed_function).generic_parameters) = TRY((((*this).parse_generic_parameters()))));
 }
 if (((*this).eof())){
-TRY((((*this).error(TRY(ByteString::from_utf8("Incomplete function"sv)),((((*this).current())).span())))));
+TRY((((*this).error((ByteString::must_from_utf8("Incomplete function"sv)),((((*this).current())).span())))));
 }
 if ((!(is_destructor))){
 parser::ParsedFunctionParameters const fn_parameters = TRY((((*this).parse_function_parameters(false))));
 (((parsed_function).params) = ((fn_parameters).parameters));
 (((parsed_function).has_varargs) = ((fn_parameters).has_varargs));
 }
-(((parsed_function).is_jakt_main) = ((((parsed_function).name)) == (TRY(ByteString::from_utf8("main"sv)))));
+(((parsed_function).is_jakt_main) = ((((parsed_function).name)) == ((ByteString::must_from_utf8("main"sv)))));
 bool can_throw = ((parsed_function).is_jakt_main);
 if (((((*this).current())).__jakt_init_index() == 100 /* Throws */)){
 if (is_destructor){
-TRY((((*this).error(TRY(ByteString::from_utf8("Destructor cannot throw"sv)),((((*this).current())).span())))));
+TRY((((*this).error((ByteString::must_from_utf8("Destructor cannot throw"sv)),((((*this).current())).span())))));
 }
 else {
 (can_throw = true);
@@ -4706,7 +4706,7 @@ utility::Span const start = ((((*this).current())).span());
 }
 else {
 if (((parsed_function).is_jakt_main)){
-(((parsed_function).return_type) = TRY((parser::ParsedType::Name(JaktInternal::OptionalNone(),TRY(ByteString::from_utf8("c_int"sv)),((((*this).previous())).span())))));
+(((parsed_function).return_type) = TRY((parser::ParsedType::Name(JaktInternal::OptionalNone(),(ByteString::must_from_utf8("c_int"sv)),((((*this).previous())).span())))));
 }
 (((parsed_function).return_type_span) = ((((*this).previous())).span()));
 }
@@ -4742,11 +4742,11 @@ if (((((*this).current())).__jakt_init_index() == 3 /* Identifier */)){
 ByteString const name = (((*this).current())).as.Identifier.name;
 utility::Span const span = (((*this).current())).as.Identifier.span;
 ((((*this).index)++));
-if ((((name) == (TRY(ByteString::from_utf8("c"sv)))) || ((name) == (TRY(ByteString::from_utf8("C"sv)))))){
+if ((((name) == ((ByteString::must_from_utf8("c"sv)))) || ((name) == ((ByteString::must_from_utf8("C"sv)))))){
 (((parsed_import).is_c) = true);
 }
 else {
-TRY((((*this).error(TRY(ByteString::from_utf8("Expected 'c' or path after `import extern`"sv)),((((*this).current())).span())))));
+TRY((((*this).error((ByteString::must_from_utf8("Expected 'c' or path after `import extern`"sv)),((((*this).current())).span())))));
 }
 
 }
@@ -4766,8 +4766,8 @@ __jakt_label_47:; __jakt_var_51.release_value(); }));
 };/*case end*/
 default: {
 return JaktInternal::ExplicitValue(({ Optional<ByteString> __jakt_var_52; {
-TRY((((*this).error(TRY(ByteString::from_utf8("Expected path after `import extern`"sv)),((((*this).current())).span())))));
-__jakt_var_52 = TRY(ByteString::from_utf8(""sv)); goto __jakt_label_48;
+TRY((((*this).error((ByteString::must_from_utf8("Expected path after `import extern`"sv)),((((*this).current())).span())))));
+__jakt_var_52 = (ByteString::must_from_utf8(""sv)); goto __jakt_label_48;
 
 }
 __jakt_label_48:; __jakt_var_52.release_value(); }));
@@ -4789,7 +4789,7 @@ utility::Span const span = (((*this).current())).as.Identifier.span;
 (((((parsed_import).assigned_namespace)).name_span) = span);
 }
 else {
-TRY((((*this).error(TRY(ByteString::from_utf8("Expected name after 'as' keyword to name the extern import"sv)),((((*this).current())).span())))));
+TRY((((*this).error((ByteString::must_from_utf8("Expected name after 'as' keyword to name the extern import"sv)),((((*this).current())).span())))));
 }
 
 }
@@ -4803,7 +4803,7 @@ if (((((*this).current())).__jakt_init_index() == 10 /* RCurly */)){
 ((((*this).index)++));
 }
 else {
-TRY((((*this).error(TRY(ByteString::from_utf8("Expected '}' to end namespace for the extern import"sv)),((((*this).current())).span())))));
+TRY((((*this).error((ByteString::must_from_utf8("Expected '}' to end namespace for the extern import"sv)),((((*this).current())).span())))));
 }
 
 }
@@ -4822,7 +4822,7 @@ ByteString const name = (((*this).current())).as.Identifier.name;
 ({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<void,ErrorOr<parser::ParsedExternImport>>{
 auto __jakt_enum_value = (name);
-if (__jakt_enum_value == TRY(ByteString::from_utf8("before_include"sv))) {
+if (__jakt_enum_value == (ByteString::must_from_utf8("before_include"sv))) {
 {
 ((((*this).index)++));
 JaktInternal::Optional<JaktInternal::DynamicArray<parser::IncludeAction>> const actions = TRY((((*this).parse_include_action())));
@@ -4832,7 +4832,7 @@ TRY((((((parsed_import).before_include)).push_values((((actions.value())))))));
 }
 return JaktInternal::ExplicitValue<void>();
 }
-else if (__jakt_enum_value == TRY(ByteString::from_utf8("after_include"sv))) {
+else if (__jakt_enum_value == (ByteString::must_from_utf8("after_include"sv))) {
 {
 ((((*this).index)++));
 JaktInternal::Optional<JaktInternal::DynamicArray<parser::IncludeAction>> const actions = TRY((((*this).parse_include_action())));
@@ -4887,7 +4887,7 @@ ByteString const name = (((*this).current())).as.Identifier.name;
 (result = TRY((parser::ParsedType::DependentType(JaktInternal::OptionalNone(),result,name,TRY((parser::merge_spans(((base)->span()),((((*this).current())).span()))))))));
 }
 else {
-TRY((((*this).error(TRY(ByteString::from_utf8("Expected identifier after `::`"sv)),((((*this).current())).span())))));
+TRY((((*this).error((ByteString::must_from_utf8("Expected identifier after `::`"sv)),((((*this).current())).span())))));
 (done = true);
 }
 
@@ -4922,7 +4922,7 @@ if (((((*this).current())).__jakt_init_index() == 9 /* LCurly */)){
 ((((*this).index)++));
 }
 else {
-TRY((((*this).error(TRY(ByteString::from_utf8("Expected ‘{’"sv)),((((*this).current())).span())))));
+TRY((((*this).error((ByteString::must_from_utf8("Expected ‘{’"sv)),((((*this).current())).span())))));
 }
 
 JaktInternal::DynamicArray<parser::ParsedField> fields = (TRY((DynamicArray<parser::ParsedField>::create_with({}))));
@@ -4944,10 +4944,10 @@ switch(__jakt_match_variant.__jakt_init_index()) {
 case 10 /* RCurly */: {
 {
 if (((last_visibility).has_value())){
-TRY((((*this).error(TRY(ByteString::from_utf8("Expected function or parameter after visibility modifier"sv)),((token).span())))));
+TRY((((*this).error((ByteString::must_from_utf8("Expected function or parameter after visibility modifier"sv)),((token).span())))));
 }
 if ((!(((active_attributes).is_empty())))){
-TRY((((*this).error(TRY(ByteString::from_utf8("Expected function after attribute"sv)),((token).span())))));
+TRY((((*this).error((ByteString::must_from_utf8("Expected function after attribute"sv)),((token).span())))));
 }
 ((((*this).index)++));
 return (Tuple{fields, methods, records});
@@ -4977,7 +4977,7 @@ case 91 /* Public */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Public;utility::Span const& span = __jakt_match_value.value;
 {
 if (((last_visibility).has_value())){
-TRY((((*this).error_with_hint(TRY(ByteString::from_utf8("Multiple visibility modifiers on one field or method are not allowed"sv)),span,TRY(ByteString::from_utf8("Previous modifier is here"sv)),(last_visibility_span.value())))));
+TRY((((*this).error_with_hint((ByteString::must_from_utf8("Multiple visibility modifiers on one field or method are not allowed"sv)),span,(ByteString::must_from_utf8("Previous modifier is here"sv)),(last_visibility_span.value())))));
 }
 (last_visibility = parser::Visibility::Public());
 (last_visibility_span = span);
@@ -4989,7 +4989,7 @@ case 90 /* Private */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Private;utility::Span const& span = __jakt_match_value.value;
 {
 if (((last_visibility).has_value())){
-TRY((((*this).error_with_hint(TRY(ByteString::from_utf8("Multiple visibility modifiers on one field or method are not allowed"sv)),span,TRY(ByteString::from_utf8("Previous modifier is here"sv)),(last_visibility_span.value())))));
+TRY((((*this).error_with_hint((ByteString::must_from_utf8("Multiple visibility modifiers on one field or method are not allowed"sv)),span,(ByteString::must_from_utf8("Previous modifier is here"sv)),(last_visibility_span.value())))));
 }
 (last_visibility = parser::Visibility::Private());
 (last_visibility_span = span);
@@ -5001,7 +5001,7 @@ case 95 /* Restricted */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Restricted;utility::Span const& span = __jakt_match_value.value;
 {
 if (((last_visibility).has_value())){
-TRY((((*this).error_with_hint(TRY(ByteString::from_utf8("Multiple visibility modifiers on one field or method are not allowed"sv)),span,TRY(ByteString::from_utf8("Previous modifier is here"sv)),(last_visibility_span.value())))));
+TRY((((*this).error_with_hint((ByteString::must_from_utf8("Multiple visibility modifiers on one field or method are not allowed"sv)),span,(ByteString::must_from_utf8("Previous modifier is here"sv)),(last_visibility_span.value())))));
 }
 (last_visibility = TRY((((*this).parse_restricted_visibility_modifier()))));
 (last_visibility_span = span);
@@ -5015,7 +5015,7 @@ if (((((*this).peek(static_cast<size_t>(1ULL)))).__jakt_init_index() == 11 /* LS
 TRY((((*this).parse_attribute_list(((active_attributes))))));
 }
 else {
-TRY((((*this).error(TRY(ByteString::from_utf8("Unexpected token (expected ‘[[’)"sv)),((((*this).current())).span())))));
+TRY((((*this).error((ByteString::must_from_utf8("Unexpected token (expected ‘[[’)"sv)),((((*this).current())).span())))));
 ((((*this).index)) += (static_cast<size_t>(1ULL)));
 }
 
@@ -5028,12 +5028,12 @@ parser::Visibility const visibility = last_visibility.value_or_lazy_evaluated([&
 (last_visibility = JaktInternal::OptionalNone());
 (last_visibility_span = JaktInternal::OptionalNone());
 if ((last_virtual || last_override)){
-TRY((((*this).error(TRY(ByteString::from_utf8("Fields cannot be ‘virtual’ or ‘override’"sv)),((((*this).current())).span())))));
+TRY((((*this).error((ByteString::must_from_utf8("Fields cannot be ‘virtual’ or ‘override’"sv)),((((*this).current())).span())))));
 }
 (last_virtual = false);
 (last_override = false);
 if (last_extern){
-TRY((((*this).error(TRY(ByteString::from_utf8("Fields cannot be ‘extern’"sv)),((((*this).current())).span())))));
+TRY((((*this).error((ByteString::must_from_utf8("Fields cannot be ‘extern’"sv)),((((*this).current())).span())))));
 }
 (last_extern = false);
 parser::ParsedField field = TRY((((*this).parse_field(visibility))));
@@ -5088,7 +5088,7 @@ default: VERIFY_NOT_REACHED();}/*switch end*/
 });
 (last_extern = false);
 if ((((function_linkage).__jakt_init_index() == 1 /* External */) && is_comptime)){
-TRY((((*this).error(TRY(ByteString::from_utf8("External functions cannot be comptime"sv)),((((*this).current())).span())))));
+TRY((((*this).error((ByteString::must_from_utf8("External functions cannot be comptime"sv)),((((*this).current())).span())))));
 }
 parser::Visibility const visibility = last_visibility.value_or_lazy_evaluated([&] { return default_visibility; });
 (last_visibility = JaktInternal::OptionalNone());
@@ -5149,7 +5149,7 @@ default: VERIFY_NOT_REACHED();}/*switch end*/
 });
 (last_extern = false);
 if ((((function_linkage).__jakt_init_index() == 1 /* External */) && is_comptime)){
-TRY((((*this).error(TRY(ByteString::from_utf8("External functions cannot be comptime"sv)),((((*this).current())).span())))));
+TRY((((*this).error((ByteString::must_from_utf8("External functions cannot be comptime"sv)),((((*this).current())).span())))));
 }
 parser::Visibility const visibility = last_visibility.value_or_lazy_evaluated([&] { return default_visibility; });
 (last_visibility = JaktInternal::OptionalNone());
@@ -5210,7 +5210,7 @@ default: VERIFY_NOT_REACHED();}/*switch end*/
 });
 (last_extern = false);
 if ((((function_linkage).__jakt_init_index() == 1 /* External */) && is_comptime)){
-TRY((((*this).error(TRY(ByteString::from_utf8("External functions cannot be comptime"sv)),((((*this).current())).span())))));
+TRY((((*this).error((ByteString::must_from_utf8("External functions cannot be comptime"sv)),((((*this).current())).span())))));
 }
 parser::Visibility const visibility = last_visibility.value_or_lazy_evaluated([&] { return default_visibility; });
 (last_visibility = JaktInternal::OptionalNone());
@@ -5243,12 +5243,12 @@ return JaktInternal::ExplicitValue<void>();
 case 97 /* Struct */: {
 {
 if ((last_virtual || last_override)){
-TRY((((*this).error(TRY(ByteString::from_utf8("Nested types cannot be ‘virtual’ or ‘override’"sv)),((((*this).current())).span())))));
+TRY((((*this).error((ByteString::must_from_utf8("Nested types cannot be ‘virtual’ or ‘override’"sv)),((((*this).current())).span())))));
 (last_virtual = false);
 (last_override = false);
 }
 if (((last_visibility).has_value())){
-TRY((((*this).error(TRY(ByteString::from_utf8("Nested types cannot have visibility modifiers"sv)),((((*this).current())).span())))));
+TRY((((*this).error((ByteString::must_from_utf8("Nested types cannot have visibility modifiers"sv)),((((*this).current())).span())))));
 (last_visibility = JaktInternal::OptionalNone());
 }
 parser::ParsedRecord parsed_record = TRY((((*this).parse_record(({
@@ -5279,12 +5279,12 @@ return JaktInternal::ExplicitValue<void>();
 case 71 /* Enum */: {
 {
 if ((last_virtual || last_override)){
-TRY((((*this).error(TRY(ByteString::from_utf8("Nested types cannot be ‘virtual’ or ‘override’"sv)),((((*this).current())).span())))));
+TRY((((*this).error((ByteString::must_from_utf8("Nested types cannot be ‘virtual’ or ‘override’"sv)),((((*this).current())).span())))));
 (last_virtual = false);
 (last_override = false);
 }
 if (((last_visibility).has_value())){
-TRY((((*this).error(TRY(ByteString::from_utf8("Nested types cannot have visibility modifiers"sv)),((((*this).current())).span())))));
+TRY((((*this).error((ByteString::must_from_utf8("Nested types cannot have visibility modifiers"sv)),((((*this).current())).span())))));
 (last_visibility = JaktInternal::OptionalNone());
 }
 parser::ParsedRecord parsed_record = TRY((((*this).parse_record(({
@@ -5315,12 +5315,12 @@ return JaktInternal::ExplicitValue<void>();
 case 62 /* Boxed */: {
 {
 if ((last_virtual || last_override)){
-TRY((((*this).error(TRY(ByteString::from_utf8("Nested types cannot be ‘virtual’ or ‘override’"sv)),((((*this).current())).span())))));
+TRY((((*this).error((ByteString::must_from_utf8("Nested types cannot be ‘virtual’ or ‘override’"sv)),((((*this).current())).span())))));
 (last_virtual = false);
 (last_override = false);
 }
 if (((last_visibility).has_value())){
-TRY((((*this).error(TRY(ByteString::from_utf8("Nested types cannot have visibility modifiers"sv)),((((*this).current())).span())))));
+TRY((((*this).error((ByteString::must_from_utf8("Nested types cannot have visibility modifiers"sv)),((((*this).current())).span())))));
 (last_visibility = JaktInternal::OptionalNone());
 }
 parser::ParsedRecord parsed_record = TRY((((*this).parse_record(({
@@ -5351,12 +5351,12 @@ return JaktInternal::ExplicitValue<void>();
 case 65 /* Class */: {
 {
 if ((last_virtual || last_override)){
-TRY((((*this).error(TRY(ByteString::from_utf8("Nested types cannot be ‘virtual’ or ‘override’"sv)),((((*this).current())).span())))));
+TRY((((*this).error((ByteString::must_from_utf8("Nested types cannot be ‘virtual’ or ‘override’"sv)),((((*this).current())).span())))));
 (last_virtual = false);
 (last_override = false);
 }
 if (((last_visibility).has_value())){
-TRY((((*this).error(TRY(ByteString::from_utf8("Nested types cannot have visibility modifiers"sv)),((((*this).current())).span())))));
+TRY((((*this).error((ByteString::must_from_utf8("Nested types cannot have visibility modifiers"sv)),((((*this).current())).span())))));
 (last_visibility = JaktInternal::OptionalNone());
 }
 parser::ParsedRecord parsed_record = TRY((((*this).parse_record(({
@@ -5408,10 +5408,10 @@ return JaktInternal::ExplicitValue<void>();
 });
 }
 if (is_class){
-TRY((((*this).error(TRY(ByteString::from_utf8("Incomplete class body, expected ‘}’"sv)),((((*this).current())).span())))));
+TRY((((*this).error((ByteString::must_from_utf8("Incomplete class body, expected ‘}’"sv)),((((*this).current())).span())))));
 }
 else {
-TRY((((*this).error(TRY(ByteString::from_utf8("Incomplete struct body, expected ‘}’"sv)),((((*this).current())).span())))));
+TRY((((*this).error((ByteString::must_from_utf8("Incomplete struct body, expected ‘}’"sv)),((((*this).current())).span())))));
 }
 
 return (Tuple{fields, methods, records});
@@ -5531,12 +5531,12 @@ if (((((*this).current())).__jakt_init_index() == 9 /* LCurly */)){
 ((((*this).index)++));
 }
 else {
-TRY((((*this).error(TRY(ByteString::from_utf8("Expected `{` to start the enum body"sv)),((((*this).current())).span())))));
+TRY((((*this).error((ByteString::must_from_utf8("Expected `{` to start the enum body"sv)),((((*this).current())).span())))));
 }
 
 ((*this).skip_newlines());
 if (((*this).eof())){
-TRY((((*this).error(TRY(ByteString::from_utf8("Incomplete enum definition, expected variant name"sv)),((((*this).previous())).span())))));
+TRY((((*this).error((ByteString::must_from_utf8("Incomplete enum definition, expected variant name"sv)),((((*this).previous())).span())))));
 return (Tuple{variants, methods});
 }
 JaktInternal::Optional<parser::Visibility> last_visibility = JaktInternal::OptionalNone();
@@ -5585,7 +5585,7 @@ case 90 /* Private */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Private;utility::Span const& span = __jakt_match_value.value;
 {
 if (((last_visibility).has_value())){
-TRY((((*this).error_with_hint(TRY(ByteString::from_utf8("Multiple visibility modifiers on one field or method are not allowed"sv)),span,TRY(ByteString::from_utf8("Previous modifier is here"sv)),(last_visibility_span.value())))));
+TRY((((*this).error_with_hint((ByteString::must_from_utf8("Multiple visibility modifiers on one field or method are not allowed"sv)),span,(ByteString::must_from_utf8("Previous modifier is here"sv)),(last_visibility_span.value())))));
 }
 (last_visibility = parser::Visibility::Private());
 (last_visibility_span = span);
@@ -5597,7 +5597,7 @@ case 91 /* Public */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Public;utility::Span const& span = __jakt_match_value.value;
 {
 if (((last_visibility).has_value())){
-TRY((((*this).error_with_hint(TRY(ByteString::from_utf8("Multiple visibility modifiers on one field or method are not allowed"sv)),span,TRY(ByteString::from_utf8("Previous modifier is here"sv)),(last_visibility_span.value())))));
+TRY((((*this).error_with_hint((ByteString::must_from_utf8("Multiple visibility modifiers on one field or method are not allowed"sv)),span,(ByteString::must_from_utf8("Previous modifier is here"sv)),(last_visibility_span.value())))));
 }
 (last_visibility = parser::Visibility::Public());
 (last_visibility_span = span);
@@ -5630,7 +5630,7 @@ default: VERIFY_NOT_REACHED();}/*switch end*/
     _jakt_value.release_value();
 });
 if ((((function_linkage).__jakt_init_index() == 1 /* External */) && is_comptime)){
-TRY((((*this).error(TRY(ByteString::from_utf8("External functions cannot be comptime"sv)),((((*this).current())).span())))));
+TRY((((*this).error((ByteString::must_from_utf8("External functions cannot be comptime"sv)),((((*this).current())).span())))));
 }
 parser::Visibility const visibility = last_visibility.value_or_lazy_evaluated([&] { return parser::Visibility::Public(); });
 (last_visibility = JaktInternal::OptionalNone());
@@ -5665,7 +5665,7 @@ default: VERIFY_NOT_REACHED();}/*switch end*/
     _jakt_value.release_value();
 });
 if ((((function_linkage).__jakt_init_index() == 1 /* External */) && is_comptime)){
-TRY((((*this).error(TRY(ByteString::from_utf8("External functions cannot be comptime"sv)),((((*this).current())).span())))));
+TRY((((*this).error((ByteString::must_from_utf8("External functions cannot be comptime"sv)),((((*this).current())).span())))));
 }
 parser::Visibility const visibility = last_visibility.value_or_lazy_evaluated([&] { return parser::Visibility::Public(); });
 (last_visibility = JaktInternal::OptionalNone());
@@ -5677,7 +5677,7 @@ return JaktInternal::ExplicitValue<void>();
 };/*case end*/
 default: {
 {
-TRY((((*this).error(TRY(ByteString::from_utf8("Expected identifier or the end of enum block"sv)),((((*this).current())).span())))));
+TRY((((*this).error((ByteString::must_from_utf8("Expected identifier or the end of enum block"sv)),((((*this).current())).span())))));
 ((((*this).index)++));
 }
 return JaktInternal::ExplicitValue<void>();
@@ -5695,12 +5695,12 @@ return JaktInternal::ExplicitValue<void>();
 });
 }
 if ((!(((((*this).current())).__jakt_init_index() == 10 /* RCurly */)))){
-TRY((((*this).error(TRY(ByteString::from_utf8("Invalid enum definition, expected `}`"sv)),((((*this).current())).span())))));
+TRY((((*this).error((ByteString::must_from_utf8("Invalid enum definition, expected `}`"sv)),((((*this).current())).span())))));
 return (Tuple{variants, methods});
 }
 ((((*this).index)++));
 if (((variants).is_empty())){
-TRY((((*this).error(TRY(ByteString::from_utf8("Empty enums are not allowed"sv)),((partial_enum).name_span)))));
+TRY((((*this).error((ByteString::must_from_utf8("Empty enums are not allowed"sv)),((partial_enum).name_span)))));
 }
 return (Tuple{variants, methods});
 }
@@ -5758,7 +5758,7 @@ default: {
 size_t index_before = ((*this).index);
 TRY((((params).push(TRY((((*this).parse_typename())))))));
 if (((((*this).index)) == (index_before))){
-TRY((((*this).error(TRY(ByteString::from_utf8("Expected type parameter"sv)),((((*this).current())).span())))));
+TRY((((*this).error((ByteString::must_from_utf8("Expected type parameter"sv)),((((*this).current())).span())))));
 return JaktInternal::LoopBreak{};
 }
 if (((((*this).current())).__jakt_init_index() == 52 /* Comma */)){
@@ -5780,7 +5780,7 @@ return JaktInternal::ExplicitValue<void>();
 });
 }
 if ((!(saw_ending_bracket))){
-TRY((((*this).error(TRY(ByteString::from_utf8("Expected `>` after type parameters"sv)),((((*this).current())).span())))));
+TRY((((*this).error((ByteString::must_from_utf8("Expected `>` after type parameters"sv)),((((*this).current())).span())))));
 }
 }
 return params;
@@ -5829,7 +5829,7 @@ utility::Span const span = ((((*this).current())).span());
 TRY((((variant_arguments).push(parser::EnumVariantPatternArgument(static_cast<JaktInternal::Optional<ByteString>>(arg_name),static_cast<JaktInternal::Optional<utility::Span>>(arg_name_span),arg_binding,span,is_reference,is_mutable)))));
 }
 else {
-TRY((((*this).error(TRY(ByteString::from_utf8("Expected binding after ‘:’"sv)),((((*this).current())).span())))));
+TRY((((*this).error((ByteString::must_from_utf8("Expected binding after ‘:’"sv)),((((*this).current())).span())))));
 }
 
 }
@@ -5858,7 +5858,7 @@ return JaktInternal::ExplicitValue<void>();
 };/*case end*/
 default: {
 {
-TRY((((*this).error(TRY(ByteString::from_utf8("Expected pattern argument name"sv)),((((*this).current())).span())))));
+TRY((((*this).error((ByteString::must_from_utf8("Expected pattern argument name"sv)),((((*this).current())).span())))));
 return JaktInternal::LoopBreak{};
 }
 return JaktInternal::ExplicitValue<void>();
@@ -5892,7 +5892,7 @@ if (((((*this).current())).__jakt_init_index() == 70 /* Else */)){
 ((((*this).index)++));
 }
 else {
-TRY((((*this).error(TRY(ByteString::from_utf8("Expected `else` keyword"sv)),((((*this).current())).span())))));
+TRY((((*this).error((ByteString::must_from_utf8("Expected `else` keyword"sv)),((((*this).current())).span())))));
 }
 
 parser::ParsedBlock const else_block = TRY((((*this).parse_block())));
@@ -6006,7 +6006,7 @@ break;
 size_t k = (_magic_value.value());
 {
 if (((((cases)[i])).has_equal_pattern(((cases)[k])))){
-TRY((((*this).error_with_hint(TRY(ByteString::from_utf8("Duplicated match pattern"sv)),((((cases)[k])).marker_span),TRY(ByteString::from_utf8("Original pattern here"sv)),((((cases)[i])).marker_span)))));
+TRY((((*this).error_with_hint((ByteString::must_from_utf8("Duplicated match pattern"sv)),((((cases)[k])).marker_span),(ByteString::must_from_utf8("Original pattern here"sv)),((((cases)[i])).marker_span)))));
 }
 }
 
@@ -6037,7 +6037,7 @@ parser::ParsedAttribute attribute = (_magic_value.value());
 ({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<void,ErrorOr<void>>{
 auto __jakt_enum_value = (((attribute).name));
-if (__jakt_enum_value == TRY(ByteString::from_utf8("extern_import"sv))) {
+if (__jakt_enum_value == (ByteString::must_from_utf8("extern_import"sv))) {
 {
 if ((!(((((attribute).assigned_value)).has_value())))){
 {
@@ -6052,23 +6052,23 @@ parser::ParsedAttributeArgument argument = (_magic_value.value());
 ({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<void,ErrorOr<void>>{
 auto __jakt_enum_value = (((argument).name));
-if (__jakt_enum_value == TRY(ByteString::from_utf8("from"sv))) {
+if (__jakt_enum_value == (ByteString::must_from_utf8("from"sv))) {
 {
 (((((namespace_))).import_path_if_extern) = ((argument).assigned_value));
 }
 return JaktInternal::ExplicitValue<void>();
 }
-else if (__jakt_enum_value == TRY(ByteString::from_utf8("define_before"sv))) {
+else if (__jakt_enum_value == (ByteString::must_from_utf8("define_before"sv))) {
 {
 if (((((argument).assigned_value)).has_value())){
-if (((((argument).name)).starts_with(TRY(ByteString::from_utf8("define"sv))))){
+if (((((argument).name)).starts_with((ByteString::must_from_utf8("define"sv))))){
 JaktInternal::DynamicArray<ByteString> const parts = (((((argument).assigned_value).value())).split('='));
 if (((((parts).size())) != (static_cast<size_t>(2ULL)))){
 TRY((((*this).error(TRY((__jakt_format((StringView::from_string_literal("The argument '{}' expects a value in the form 'name=value'"sv)),((argument).name)))),((argument).span)))));
 return JaktInternal::LoopContinue{};
 }
 parser::IncludeAction const action = parser::IncludeAction::Define(((parts)[static_cast<i64>(0LL)]),((attribute).span),((parts)[static_cast<i64>(1LL)]));
-if (((((argument).name)).ends_with(TRY(ByteString::from_utf8("before"sv))))){
+if (((((argument).name)).ends_with((ByteString::must_from_utf8("before"sv))))){
 TRY((((((((namespace_))).generating_import_extern_before_include)).push(action))));
 }
 else {
@@ -6078,7 +6078,7 @@ TRY((((((((namespace_))).generating_import_extern_after_include)).push(action)))
 }
 else {
 parser::IncludeAction const action = parser::IncludeAction::Undefine((((argument).assigned_value).value()),((attribute).span));
-if (((((argument).name)).ends_with(TRY(ByteString::from_utf8("before"sv))))){
+if (((((argument).name)).ends_with((ByteString::must_from_utf8("before"sv))))){
 TRY((((((((namespace_))).generating_import_extern_before_include)).push(action))));
 }
 else {
@@ -6096,17 +6096,17 @@ return JaktInternal::LoopContinue{};
 }
 return JaktInternal::ExplicitValue<void>();
 }
-else if (__jakt_enum_value == TRY(ByteString::from_utf8("undefine_before"sv))) {
+else if (__jakt_enum_value == (ByteString::must_from_utf8("undefine_before"sv))) {
 {
 if (((((argument).assigned_value)).has_value())){
-if (((((argument).name)).starts_with(TRY(ByteString::from_utf8("define"sv))))){
+if (((((argument).name)).starts_with((ByteString::must_from_utf8("define"sv))))){
 JaktInternal::DynamicArray<ByteString> const parts = (((((argument).assigned_value).value())).split('='));
 if (((((parts).size())) != (static_cast<size_t>(2ULL)))){
 TRY((((*this).error(TRY((__jakt_format((StringView::from_string_literal("The argument '{}' expects a value in the form 'name=value'"sv)),((argument).name)))),((argument).span)))));
 return JaktInternal::LoopContinue{};
 }
 parser::IncludeAction const action = parser::IncludeAction::Define(((parts)[static_cast<i64>(0LL)]),((attribute).span),((parts)[static_cast<i64>(1LL)]));
-if (((((argument).name)).ends_with(TRY(ByteString::from_utf8("before"sv))))){
+if (((((argument).name)).ends_with((ByteString::must_from_utf8("before"sv))))){
 TRY((((((((namespace_))).generating_import_extern_before_include)).push(action))));
 }
 else {
@@ -6116,7 +6116,7 @@ TRY((((((((namespace_))).generating_import_extern_after_include)).push(action)))
 }
 else {
 parser::IncludeAction const action = parser::IncludeAction::Undefine((((argument).assigned_value).value()),((attribute).span));
-if (((((argument).name)).ends_with(TRY(ByteString::from_utf8("before"sv))))){
+if (((((argument).name)).ends_with((ByteString::must_from_utf8("before"sv))))){
 TRY((((((((namespace_))).generating_import_extern_before_include)).push(action))));
 }
 else {
@@ -6134,17 +6134,17 @@ return JaktInternal::LoopContinue{};
 }
 return JaktInternal::ExplicitValue<void>();
 }
-else if (__jakt_enum_value == TRY(ByteString::from_utf8("define_after"sv))) {
+else if (__jakt_enum_value == (ByteString::must_from_utf8("define_after"sv))) {
 {
 if (((((argument).assigned_value)).has_value())){
-if (((((argument).name)).starts_with(TRY(ByteString::from_utf8("define"sv))))){
+if (((((argument).name)).starts_with((ByteString::must_from_utf8("define"sv))))){
 JaktInternal::DynamicArray<ByteString> const parts = (((((argument).assigned_value).value())).split('='));
 if (((((parts).size())) != (static_cast<size_t>(2ULL)))){
 TRY((((*this).error(TRY((__jakt_format((StringView::from_string_literal("The argument '{}' expects a value in the form 'name=value'"sv)),((argument).name)))),((argument).span)))));
 return JaktInternal::LoopContinue{};
 }
 parser::IncludeAction const action = parser::IncludeAction::Define(((parts)[static_cast<i64>(0LL)]),((attribute).span),((parts)[static_cast<i64>(1LL)]));
-if (((((argument).name)).ends_with(TRY(ByteString::from_utf8("before"sv))))){
+if (((((argument).name)).ends_with((ByteString::must_from_utf8("before"sv))))){
 TRY((((((((namespace_))).generating_import_extern_before_include)).push(action))));
 }
 else {
@@ -6154,7 +6154,7 @@ TRY((((((((namespace_))).generating_import_extern_after_include)).push(action)))
 }
 else {
 parser::IncludeAction const action = parser::IncludeAction::Undefine((((argument).assigned_value).value()),((attribute).span));
-if (((((argument).name)).ends_with(TRY(ByteString::from_utf8("before"sv))))){
+if (((((argument).name)).ends_with((ByteString::must_from_utf8("before"sv))))){
 TRY((((((((namespace_))).generating_import_extern_before_include)).push(action))));
 }
 else {
@@ -6172,17 +6172,17 @@ return JaktInternal::LoopContinue{};
 }
 return JaktInternal::ExplicitValue<void>();
 }
-else if (__jakt_enum_value == TRY(ByteString::from_utf8("undefine_after"sv))) {
+else if (__jakt_enum_value == (ByteString::must_from_utf8("undefine_after"sv))) {
 {
 if (((((argument).assigned_value)).has_value())){
-if (((((argument).name)).starts_with(TRY(ByteString::from_utf8("define"sv))))){
+if (((((argument).name)).starts_with((ByteString::must_from_utf8("define"sv))))){
 JaktInternal::DynamicArray<ByteString> const parts = (((((argument).assigned_value).value())).split('='));
 if (((((parts).size())) != (static_cast<size_t>(2ULL)))){
 TRY((((*this).error(TRY((__jakt_format((StringView::from_string_literal("The argument '{}' expects a value in the form 'name=value'"sv)),((argument).name)))),((argument).span)))));
 return JaktInternal::LoopContinue{};
 }
 parser::IncludeAction const action = parser::IncludeAction::Define(((parts)[static_cast<i64>(0LL)]),((attribute).span),((parts)[static_cast<i64>(1LL)]));
-if (((((argument).name)).ends_with(TRY(ByteString::from_utf8("before"sv))))){
+if (((((argument).name)).ends_with((ByteString::must_from_utf8("before"sv))))){
 TRY((((((((namespace_))).generating_import_extern_before_include)).push(action))));
 }
 else {
@@ -6192,7 +6192,7 @@ TRY((((((((namespace_))).generating_import_extern_after_include)).push(action)))
 }
 else {
 parser::IncludeAction const action = parser::IncludeAction::Undefine((((argument).assigned_value).value()),((attribute).span));
-if (((((argument).name)).ends_with(TRY(ByteString::from_utf8("before"sv))))){
+if (((((argument).name)).ends_with((ByteString::must_from_utf8("before"sv))))){
 TRY((((((((namespace_))).generating_import_extern_before_include)).push(action))));
 }
 else {
@@ -6240,7 +6240,7 @@ return JaktInternal::LoopContinue{};
 }
 return JaktInternal::ExplicitValue<void>();
 }
-else if (__jakt_enum_value == TRY(ByteString::from_utf8("generated"sv))) {
+else if (__jakt_enum_value == (ByteString::must_from_utf8("generated"sv))) {
 {
 if ((!(((((attribute).assigned_value)).has_value())))){
 (((((namespace_))).is_generated_code) = true);
@@ -6292,18 +6292,18 @@ parser::ParsedAttribute attribute = (_magic_value.value());
 ({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<void,ErrorOr<void>>{
 auto __jakt_enum_value = (((attribute).name));
-if (__jakt_enum_value == TRY(ByteString::from_utf8("name"sv))) {
+if (__jakt_enum_value == (ByteString::must_from_utf8("name"sv))) {
 {
 if (((((attribute).assigned_value)).has_value())){
 if (((((((((field))).var_decl)).external_name)).has_value())){
 TRY((((*this).error(TRY((__jakt_format((StringView::from_string_literal("The attribute '{}' cannot be applied more than once"sv)),((attribute).name)))),((attribute).span)))));
 return JaktInternal::LoopContinue{};
 }
-if (((((((attribute).assigned_value).value())).starts_with(TRY(ByteString::from_utf8("operator("sv)))) && (((((attribute).assigned_value).value())).ends_with(TRY(ByteString::from_utf8(")"sv)))))){
+if (((((((attribute).assigned_value).value())).starts_with((ByteString::must_from_utf8("operator("sv)))) && (((((attribute).assigned_value).value())).ends_with((ByteString::must_from_utf8(")"sv)))))){
 ByteString const operator_name = (((((attribute).assigned_value).value())).substring(static_cast<size_t>(9ULL),JaktInternal::checked_sub((((((attribute).assigned_value).value())).length()),static_cast<size_t>(10ULL))));
 (((((((field))).var_decl)).external_name) = parser::ExternalName::Operator(operator_name,false));
 }
-else if (((((((attribute).assigned_value).value())).starts_with(TRY(ByteString::from_utf8("prefix-operator("sv)))) && (((((attribute).assigned_value).value())).ends_with(TRY(ByteString::from_utf8(")"sv)))))){
+else if (((((((attribute).assigned_value).value())).starts_with((ByteString::must_from_utf8("prefix-operator("sv)))) && (((((attribute).assigned_value).value())).ends_with((ByteString::must_from_utf8(")"sv)))))){
 ByteString const operator_name = (((((attribute).assigned_value).value())).substring(static_cast<size_t>(16ULL),JaktInternal::checked_sub((((((attribute).assigned_value).value())).length()),static_cast<size_t>(17ULL))));
 (((((((field))).var_decl)).external_name) = parser::ExternalName::Operator(operator_name,true));
 }
@@ -6359,18 +6359,18 @@ parser::ParsedAttribute attribute = (_magic_value.value());
 ({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<void,ErrorOr<void>>{
 auto __jakt_enum_value = (((attribute).name));
-if (__jakt_enum_value == TRY(ByteString::from_utf8("name"sv))) {
+if (__jakt_enum_value == (ByteString::must_from_utf8("name"sv))) {
 {
 if (((((attribute).assigned_value)).has_value())){
 if (((((((parsed_function))).external_name)).has_value())){
 TRY((((*this).error(TRY((__jakt_format((StringView::from_string_literal("The attribute '{}' cannot be applied more than once"sv)),((attribute).name)))),((attribute).span)))));
 return JaktInternal::LoopContinue{};
 }
-if (((((((attribute).assigned_value).value())).starts_with(TRY(ByteString::from_utf8("operator("sv)))) && (((((attribute).assigned_value).value())).ends_with(TRY(ByteString::from_utf8(")"sv)))))){
+if (((((((attribute).assigned_value).value())).starts_with((ByteString::must_from_utf8("operator("sv)))) && (((((attribute).assigned_value).value())).ends_with((ByteString::must_from_utf8(")"sv)))))){
 ByteString const operator_name = (((((attribute).assigned_value).value())).substring(static_cast<size_t>(9ULL),JaktInternal::checked_sub((((((attribute).assigned_value).value())).length()),static_cast<size_t>(10ULL))));
 (((((parsed_function))).external_name) = parser::ExternalName::Operator(operator_name,false));
 }
-else if (((((((attribute).assigned_value).value())).starts_with(TRY(ByteString::from_utf8("prefix-operator("sv)))) && (((((attribute).assigned_value).value())).ends_with(TRY(ByteString::from_utf8(")"sv)))))){
+else if (((((((attribute).assigned_value).value())).starts_with((ByteString::must_from_utf8("prefix-operator("sv)))) && (((((attribute).assigned_value).value())).ends_with((ByteString::must_from_utf8(")"sv)))))){
 ByteString const operator_name = (((((attribute).assigned_value).value())).substring(static_cast<size_t>(16ULL),JaktInternal::checked_sub((((((attribute).assigned_value).value())).length()),static_cast<size_t>(17ULL))));
 (((((parsed_function))).external_name) = parser::ExternalName::Operator(operator_name,true));
 }
@@ -6387,7 +6387,7 @@ return JaktInternal::LoopContinue{};
 }
 return JaktInternal::ExplicitValue<void>();
 }
-else if (__jakt_enum_value == TRY(ByteString::from_utf8("deprecated"sv))) {
+else if (__jakt_enum_value == (ByteString::must_from_utf8("deprecated"sv))) {
 {
 if (((((((parsed_function))).deprecated_message)).has_value())){
 TRY((((*this).error(TRY((__jakt_format((StringView::from_string_literal("The attribute '{}' cannot be applied more than once"sv)),((attribute).name)))),((attribute).span)))));
@@ -6398,7 +6398,7 @@ ByteString const message = TRY((((((((attribute).arguments)).first())).map([](au
 }
 return JaktInternal::ExplicitValue<void>();
 }
-else if (__jakt_enum_value == TRY(ByteString::from_utf8("inline"sv))) {
+else if (__jakt_enum_value == (ByteString::must_from_utf8("inline"sv))) {
 {
 if ((!(((((((parsed_function))).force_inline)).__jakt_init_index() == 0 /* Default */)))){
 TRY((((*this).error(TRY((__jakt_format((StringView::from_string_literal("The attribute '{}' cannot be applied more than once"sv)),((attribute).name)))),((attribute).span)))));
@@ -6406,17 +6406,17 @@ return JaktInternal::LoopContinue{};
 }
 parser::InlineState const inline_state = ({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<parser::InlineState,ErrorOr<void>>{
-auto __jakt_enum_value = (TRY((((((((attribute).arguments)).first())).map([](auto& _value) { return _value.name; })).try_value_or_lazy_evaluated([&]() -> ErrorOr<ByteString> { return TRY(ByteString::from_utf8(""sv)); }))));
-if (__jakt_enum_value == TRY(ByteString::from_utf8("never"sv))) {
+auto __jakt_enum_value = (TRY((((((((attribute).arguments)).first())).map([](auto& _value) { return _value.name; })).try_value_or_lazy_evaluated([&]() -> ErrorOr<ByteString> { return (ByteString::must_from_utf8(""sv)); }))));
+if (__jakt_enum_value == (ByteString::must_from_utf8("never"sv))) {
 return JaktInternal::ExplicitValue(parser::InlineState::Default());
 }
-else if (__jakt_enum_value == TRY(ByteString::from_utf8(""sv))) {
+else if (__jakt_enum_value == (ByteString::must_from_utf8(""sv))) {
 return JaktInternal::ExplicitValue(parser::InlineState::ForceInline());
 }
-else if (__jakt_enum_value == TRY(ByteString::from_utf8("always"sv))) {
+else if (__jakt_enum_value == (ByteString::must_from_utf8("always"sv))) {
 return JaktInternal::ExplicitValue(parser::InlineState::ForceInline());
 }
-else if (__jakt_enum_value == TRY(ByteString::from_utf8("make_available"sv))) {
+else if (__jakt_enum_value == (ByteString::must_from_utf8("make_available"sv))) {
 return JaktInternal::ExplicitValue(parser::InlineState::MakeDefinitionAvailable());
 }
 else {
@@ -6438,7 +6438,7 @@ return JaktInternal::LoopContinue{};
 }
 return JaktInternal::ExplicitValue<void>();
 }
-else if (__jakt_enum_value == TRY(ByteString::from_utf8("stores_arguments"sv))) {
+else if (__jakt_enum_value == (ByteString::must_from_utf8("stores_arguments"sv))) {
 {
 JaktInternal::DynamicArray<JaktInternal::Tuple<size_t,parser::ArgumentStoreLevel>> stores_arguments = (TRY((DynamicArray<JaktInternal::Tuple<size_t,parser::ArgumentStoreLevel>>::create_with({}))));
 {
@@ -6551,15 +6551,15 @@ parser::ParsedAttribute attribute = (_magic_value.value());
 ({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<void,ErrorOr<void>>{
 auto __jakt_enum_value = (((attribute).name));
-if (__jakt_enum_value == TRY(ByteString::from_utf8("name"sv))) {
+if (__jakt_enum_value == (ByteString::must_from_utf8("name"sv))) {
 {
 if (((((attribute).assigned_value)).has_value())){
 if (((((((parsed_record))).external_name)).has_value())){
 TRY((((*this).error(TRY((__jakt_format((StringView::from_string_literal("The attribute '{}' cannot be applied more than once"sv)),((attribute).name)))),((attribute).span)))));
 return JaktInternal::LoopContinue{};
 }
-if (((((((attribute).assigned_value).value())).starts_with(TRY(ByteString::from_utf8("operator("sv)))) && (((((attribute).assigned_value).value())).ends_with(TRY(ByteString::from_utf8(")"sv)))))){
-TRY((((*this).error(TRY(ByteString::from_utf8("A record cannot be renamed to an operator"sv)),((attribute).span)))));
+if (((((((attribute).assigned_value).value())).starts_with((ByteString::must_from_utf8("operator("sv)))) && (((((attribute).assigned_value).value())).ends_with((ByteString::must_from_utf8(")"sv)))))){
+TRY((((*this).error((ByteString::must_from_utf8("A record cannot be renamed to an operator"sv)),((attribute).span)))));
 return JaktInternal::LoopContinue{};
 }
 (((((parsed_record))).external_name) = parser::ExternalName::Plain((((attribute).assigned_value).value())));
@@ -6605,18 +6605,18 @@ return ((*this).peek(static_cast<size_t>(0ULL)));
 
 ErrorOr<parser::ParsedRecord> parser::Parser::parse_enum(parser::DefinitionLinkage const definition_linkage,bool const is_boxed) {
 {
-parser::ParsedRecord parsed_enum = parser::ParsedRecord(TRY(ByteString::from_utf8(""sv)),((*this).empty_span()),(TRY((DynamicArray<parser::ParsedGenericParameter>::create_with({})))),definition_linkage,JaktInternal::OptionalNone(),(TRY((DynamicArray<parser::ParsedMethod>::create_with({})))),parser::RecordType::Garbage(),(TRY((DynamicArray<parser::ParsedRecord>::create_with({})))),JaktInternal::OptionalNone());
+parser::ParsedRecord parsed_enum = parser::ParsedRecord((ByteString::must_from_utf8(""sv)),((*this).empty_span()),(TRY((DynamicArray<parser::ParsedGenericParameter>::create_with({})))),definition_linkage,JaktInternal::OptionalNone(),(TRY((DynamicArray<parser::ParsedMethod>::create_with({})))),parser::RecordType::Garbage(),(TRY((DynamicArray<parser::ParsedRecord>::create_with({})))),JaktInternal::OptionalNone());
 JaktInternal::Optional<NonnullRefPtr<typename parser::ParsedType>> underlying_type = JaktInternal::OptionalNone();
 if (((((*this).current())).__jakt_init_index() == 71 /* Enum */)){
 ((((*this).index)++));
 }
 else {
-TRY((((*this).error(TRY(ByteString::from_utf8("Expected ‘enum’ keyword"sv)),((((*this).current())).span())))));
+TRY((((*this).error((ByteString::must_from_utf8("Expected ‘enum’ keyword"sv)),((((*this).current())).span())))));
 return parsed_enum;
 }
 
 if (((*this).eof())){
-TRY((((*this).error(TRY(ByteString::from_utf8("Incomplete enum definition, expected name"sv)),((((*this).current())).span())))));
+TRY((((*this).error((ByteString::must_from_utf8("Incomplete enum definition, expected name"sv)),((((*this).current())).span())))));
 return parsed_enum;
 }
 if (((((*this).current())).__jakt_init_index() == 3 /* Identifier */)){
@@ -6627,11 +6627,11 @@ utility::Span const span = (((*this).current())).as.Identifier.span;
 ((((*this).index)++));
 }
 else {
-TRY((((*this).error(TRY(ByteString::from_utf8("Incomplete enum definition, expected name"sv)),((((*this).current())).span())))));
+TRY((((*this).error((ByteString::must_from_utf8("Incomplete enum definition, expected name"sv)),((((*this).current())).span())))));
 }
 
 if (((*this).eof())){
-TRY((((*this).error(TRY(ByteString::from_utf8("Incomplete enum definition, expected generic parameters or underlying type or body"sv)),((((*this).current())).span())))));
+TRY((((*this).error((ByteString::must_from_utf8("Incomplete enum definition, expected generic parameters or underlying type or body"sv)),((((*this).current())).span())))));
 return parsed_enum;
 }
 if (((((*this).current())).__jakt_init_index() == 28 /* LessThan */)){
@@ -6642,19 +6642,19 @@ if (((((*this).current())).__jakt_init_index() == 109 /* Implements */)){
 (((parsed_enum).implements_list) = TRY((((*this).parse_trait_list()))));
 }
 if (((*this).eof())){
-TRY((((*this).error(TRY(ByteString::from_utf8("Incomplete enum definition, expected underlying type or body"sv)),((((*this).current())).span())))));
+TRY((((*this).error((ByteString::must_from_utf8("Incomplete enum definition, expected underlying type or body"sv)),((((*this).current())).span())))));
 return parsed_enum;
 }
 if (((((*this).current())).__jakt_init_index() == 5 /* Colon */)){
 if (is_boxed){
-TRY((((*this).error(TRY(ByteString::from_utf8("Invalid enum definition: Value enums must not have an underlying type"sv)),((((*this).current())).span())))));
+TRY((((*this).error((ByteString::must_from_utf8("Invalid enum definition: Value enums must not have an underlying type"sv)),((((*this).current())).span())))));
 }
 ((((*this).index)++));
 (underlying_type = TRY((((*this).parse_typename()))));
 }
 ((*this).skip_newlines());
 if (((*this).eof())){
-TRY((((*this).error(TRY(ByteString::from_utf8("Incomplete enum definition, expected body"sv)),((((*this).current())).span())))));
+TRY((((*this).error((ByteString::must_from_utf8("Incomplete enum definition, expected body"sv)),((((*this).current())).span())))));
 return parsed_enum;
 }
 if (((underlying_type).has_value())){
@@ -6686,7 +6686,7 @@ ErrorOr<parser::ParsedBlock> parser::Parser::parse_block() {
 utility::Span const start = ((((*this).current())).span());
 parser::ParsedBlock block = parser::ParsedBlock((TRY((DynamicArray<NonnullRefPtr<typename parser::ParsedStatement>>::create_with({})))));
 if (((*this).eof())){
-TRY((((*this).error(TRY(ByteString::from_utf8("Incomplete block"sv)),start))));
+TRY((((*this).error((ByteString::must_from_utf8("Incomplete block"sv)),start))));
 return block;
 }
 ((*this).skip_newlines());
@@ -6694,7 +6694,7 @@ if (((((*this).current())).__jakt_init_index() == 9 /* LCurly */)){
 ((((*this).index)++));
 }
 else {
-TRY((((*this).error(TRY(ByteString::from_utf8("Expected '{'"sv)),start))));
+TRY((((*this).error((ByteString::must_from_utf8("Expected '{'"sv)),start))));
 }
 
 while ((!(((*this).eof())))){
@@ -6739,7 +6739,7 @@ return JaktInternal::ExplicitValue<void>();
     _jakt_value.release_value();
 });
 }
-TRY((((*this).error(TRY(ByteString::from_utf8("Expected complete block"sv)),((((*this).current())).span())))));
+TRY((((*this).error((ByteString::must_from_utf8("Expected complete block"sv)),((((*this).current())).span())))));
 return block;
 }
 }
@@ -6759,7 +6759,7 @@ ByteString const name = (expr)->as.Var.name;
 TRY((((namespace_).push(name))));
 }
 else {
-TRY((((*this).error(TRY(ByteString::from_utf8("Expected namespace"sv)),((expr)->span())))));
+TRY((((*this).error((ByteString::must_from_utf8("Expected namespace"sv)),((expr)->span())))));
 }
 
 while ((!(((*this).eof())))){
@@ -6788,7 +6788,7 @@ ByteString const name = (((*this).previous())).as.Identifier.name;
 TRY((((namespace_).push(name))));
 }
 else {
-TRY((((*this).error(TRY(ByteString::from_utf8("Expected namespace"sv)),((expr)->span())))));
+TRY((((*this).error((ByteString::must_from_utf8("Expected namespace"sv)),((expr)->span())))));
 }
 
 ((((*this).index)++));
@@ -6799,12 +6799,12 @@ return TRY((parser::ParsedExpression::NamespacedVar(current_name,namespace_,TRY(
 
 }
 else {
-TRY((((*this).error(TRY(ByteString::from_utf8("Unsupported static method call"sv)),((((*this).current())).span())))));
+TRY((((*this).error((ByteString::must_from_utf8("Unsupported static method call"sv)),((((*this).current())).span())))));
 return expr;
 }
 
 }
-TRY((((*this).error(TRY(ByteString::from_utf8("Incomplete static method call"sv)),((((*this).current())).span())))));
+TRY((((*this).error((ByteString::must_from_utf8("Incomplete static method call"sv)),((((*this).current())).span())))));
 return expr;
 }
 }
@@ -6820,7 +6820,7 @@ return {};
 
 ErrorOr<parser::ParsedTrait> parser::Parser::parse_trait() {
 {
-parser::ParsedTrait parsed_trait = parser::ParsedTrait(TRY(ByteString::from_utf8(""sv)),((*this).empty_span()),(TRY((DynamicArray<parser::ParsedGenericParameter>::create_with({})))),parser::ParsedTraitRequirements::Nothing());
+parser::ParsedTrait parsed_trait = parser::ParsedTrait((ByteString::must_from_utf8(""sv)),((*this).empty_span()),(TRY((DynamicArray<parser::ParsedGenericParameter>::create_with({})))),parser::ParsedTraitRequirements::Nothing());
 if (((((*this).current())).__jakt_init_index() == 3 /* Identifier */)){
 ByteString const name = (((*this).current())).as.Identifier.name;
 utility::Span const name_span = (((*this).current())).as.Identifier.span;
@@ -6854,7 +6854,7 @@ return JaktInternal::ExplicitValue<void>();
 case 56 /* Eof */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Eof;utility::Span const& span = __jakt_match_value.value;
 {
-TRY((((*this).error(TRY(ByteString::from_utf8("Expected '}' to close the trait body"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("Expected '}' to close the trait body"sv)),span))));
 }
 return JaktInternal::ExplicitValue<void>();
 };/*case end*/
@@ -6865,7 +6865,7 @@ if (((((*this).peek(static_cast<size_t>(1ULL)))).__jakt_init_index() == 11 /* LS
 TRY((((*this).parse_attribute_list(((active_attributes))))));
 }
 else {
-TRY((((*this).error(TRY(ByteString::from_utf8("Unexpected token (expected ‘[[’)"sv)),((((*this).current())).span())))));
+TRY((((*this).error((ByteString::must_from_utf8("Unexpected token (expected ‘[[’)"sv)),((((*this).current())).span())))));
 ((((*this).index)) += (static_cast<size_t>(1ULL)));
 }
 
@@ -6894,7 +6894,7 @@ return JaktInternal::ExplicitValue<void>();
 case 0 /* SingleQuotedString */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.SingleQuotedString;utility::Span const& span = __jakt_match_value.span;
 {
-TRY((((*this).error_with_hint(TRY(ByteString::from_utf8("Expected 'function' keyword inside trait definition"sv)),span,TRY((__jakt_format((StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv)),((parsed_trait).name)))),((parsed_trait).name_span)))));
+TRY((((*this).error_with_hint((ByteString::must_from_utf8("Expected 'function' keyword inside trait definition"sv)),span,TRY((__jakt_format((StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv)),((parsed_trait).name)))),((parsed_trait).name_span)))));
 return parsed_trait;
 }
 return JaktInternal::ExplicitValue<void>();
@@ -6902,7 +6902,7 @@ return JaktInternal::ExplicitValue<void>();
 case 1 /* QuotedString */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.QuotedString;utility::Span const& span = __jakt_match_value.span;
 {
-TRY((((*this).error_with_hint(TRY(ByteString::from_utf8("Expected 'function' keyword inside trait definition"sv)),span,TRY((__jakt_format((StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv)),((parsed_trait).name)))),((parsed_trait).name_span)))));
+TRY((((*this).error_with_hint((ByteString::must_from_utf8("Expected 'function' keyword inside trait definition"sv)),span,TRY((__jakt_format((StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv)),((parsed_trait).name)))),((parsed_trait).name_span)))));
 return parsed_trait;
 }
 return JaktInternal::ExplicitValue<void>();
@@ -6910,7 +6910,7 @@ return JaktInternal::ExplicitValue<void>();
 case 2 /* Number */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Number;utility::Span const& span = __jakt_match_value.span;
 {
-TRY((((*this).error_with_hint(TRY(ByteString::from_utf8("Expected 'function' keyword inside trait definition"sv)),span,TRY((__jakt_format((StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv)),((parsed_trait).name)))),((parsed_trait).name_span)))));
+TRY((((*this).error_with_hint((ByteString::must_from_utf8("Expected 'function' keyword inside trait definition"sv)),span,TRY((__jakt_format((StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv)),((parsed_trait).name)))),((parsed_trait).name_span)))));
 return parsed_trait;
 }
 return JaktInternal::ExplicitValue<void>();
@@ -6918,7 +6918,7 @@ return JaktInternal::ExplicitValue<void>();
 case 3 /* Identifier */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Identifier;utility::Span const& span = __jakt_match_value.span;
 {
-TRY((((*this).error_with_hint(TRY(ByteString::from_utf8("Expected 'function' keyword inside trait definition"sv)),span,TRY((__jakt_format((StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv)),((parsed_trait).name)))),((parsed_trait).name_span)))));
+TRY((((*this).error_with_hint((ByteString::must_from_utf8("Expected 'function' keyword inside trait definition"sv)),span,TRY((__jakt_format((StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv)),((parsed_trait).name)))),((parsed_trait).name_span)))));
 return parsed_trait;
 }
 return JaktInternal::ExplicitValue<void>();
@@ -6926,7 +6926,7 @@ return JaktInternal::ExplicitValue<void>();
 case 4 /* Semicolon */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Semicolon;utility::Span const& span = __jakt_match_value.value;
 {
-TRY((((*this).error_with_hint(TRY(ByteString::from_utf8("Expected 'function' keyword inside trait definition"sv)),span,TRY((__jakt_format((StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv)),((parsed_trait).name)))),((parsed_trait).name_span)))));
+TRY((((*this).error_with_hint((ByteString::must_from_utf8("Expected 'function' keyword inside trait definition"sv)),span,TRY((__jakt_format((StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv)),((parsed_trait).name)))),((parsed_trait).name_span)))));
 return parsed_trait;
 }
 return JaktInternal::ExplicitValue<void>();
@@ -6934,7 +6934,7 @@ return JaktInternal::ExplicitValue<void>();
 case 5 /* Colon */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Colon;utility::Span const& span = __jakt_match_value.value;
 {
-TRY((((*this).error_with_hint(TRY(ByteString::from_utf8("Expected 'function' keyword inside trait definition"sv)),span,TRY((__jakt_format((StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv)),((parsed_trait).name)))),((parsed_trait).name_span)))));
+TRY((((*this).error_with_hint((ByteString::must_from_utf8("Expected 'function' keyword inside trait definition"sv)),span,TRY((__jakt_format((StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv)),((parsed_trait).name)))),((parsed_trait).name_span)))));
 return parsed_trait;
 }
 return JaktInternal::ExplicitValue<void>();
@@ -6942,7 +6942,7 @@ return JaktInternal::ExplicitValue<void>();
 case 6 /* ColonColon */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.ColonColon;utility::Span const& span = __jakt_match_value.value;
 {
-TRY((((*this).error_with_hint(TRY(ByteString::from_utf8("Expected 'function' keyword inside trait definition"sv)),span,TRY((__jakt_format((StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv)),((parsed_trait).name)))),((parsed_trait).name_span)))));
+TRY((((*this).error_with_hint((ByteString::must_from_utf8("Expected 'function' keyword inside trait definition"sv)),span,TRY((__jakt_format((StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv)),((parsed_trait).name)))),((parsed_trait).name_span)))));
 return parsed_trait;
 }
 return JaktInternal::ExplicitValue<void>();
@@ -6950,7 +6950,7 @@ return JaktInternal::ExplicitValue<void>();
 case 7 /* LParen */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.LParen;utility::Span const& span = __jakt_match_value.value;
 {
-TRY((((*this).error_with_hint(TRY(ByteString::from_utf8("Expected 'function' keyword inside trait definition"sv)),span,TRY((__jakt_format((StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv)),((parsed_trait).name)))),((parsed_trait).name_span)))));
+TRY((((*this).error_with_hint((ByteString::must_from_utf8("Expected 'function' keyword inside trait definition"sv)),span,TRY((__jakt_format((StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv)),((parsed_trait).name)))),((parsed_trait).name_span)))));
 return parsed_trait;
 }
 return JaktInternal::ExplicitValue<void>();
@@ -6958,7 +6958,7 @@ return JaktInternal::ExplicitValue<void>();
 case 8 /* RParen */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.RParen;utility::Span const& span = __jakt_match_value.value;
 {
-TRY((((*this).error_with_hint(TRY(ByteString::from_utf8("Expected 'function' keyword inside trait definition"sv)),span,TRY((__jakt_format((StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv)),((parsed_trait).name)))),((parsed_trait).name_span)))));
+TRY((((*this).error_with_hint((ByteString::must_from_utf8("Expected 'function' keyword inside trait definition"sv)),span,TRY((__jakt_format((StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv)),((parsed_trait).name)))),((parsed_trait).name_span)))));
 return parsed_trait;
 }
 return JaktInternal::ExplicitValue<void>();
@@ -6966,7 +6966,7 @@ return JaktInternal::ExplicitValue<void>();
 case 9 /* LCurly */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.LCurly;utility::Span const& span = __jakt_match_value.value;
 {
-TRY((((*this).error_with_hint(TRY(ByteString::from_utf8("Expected 'function' keyword inside trait definition"sv)),span,TRY((__jakt_format((StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv)),((parsed_trait).name)))),((parsed_trait).name_span)))));
+TRY((((*this).error_with_hint((ByteString::must_from_utf8("Expected 'function' keyword inside trait definition"sv)),span,TRY((__jakt_format((StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv)),((parsed_trait).name)))),((parsed_trait).name_span)))));
 return parsed_trait;
 }
 return JaktInternal::ExplicitValue<void>();
@@ -6974,7 +6974,7 @@ return JaktInternal::ExplicitValue<void>();
 case 12 /* RSquare */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.RSquare;utility::Span const& span = __jakt_match_value.value;
 {
-TRY((((*this).error_with_hint(TRY(ByteString::from_utf8("Expected 'function' keyword inside trait definition"sv)),span,TRY((__jakt_format((StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv)),((parsed_trait).name)))),((parsed_trait).name_span)))));
+TRY((((*this).error_with_hint((ByteString::must_from_utf8("Expected 'function' keyword inside trait definition"sv)),span,TRY((__jakt_format((StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv)),((parsed_trait).name)))),((parsed_trait).name_span)))));
 return parsed_trait;
 }
 return JaktInternal::ExplicitValue<void>();
@@ -6982,7 +6982,7 @@ return JaktInternal::ExplicitValue<void>();
 case 13 /* PercentSign */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.PercentSign;utility::Span const& span = __jakt_match_value.value;
 {
-TRY((((*this).error_with_hint(TRY(ByteString::from_utf8("Expected 'function' keyword inside trait definition"sv)),span,TRY((__jakt_format((StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv)),((parsed_trait).name)))),((parsed_trait).name_span)))));
+TRY((((*this).error_with_hint((ByteString::must_from_utf8("Expected 'function' keyword inside trait definition"sv)),span,TRY((__jakt_format((StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv)),((parsed_trait).name)))),((parsed_trait).name_span)))));
 return parsed_trait;
 }
 return JaktInternal::ExplicitValue<void>();
@@ -6990,7 +6990,7 @@ return JaktInternal::ExplicitValue<void>();
 case 14 /* Plus */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Plus;utility::Span const& span = __jakt_match_value.value;
 {
-TRY((((*this).error_with_hint(TRY(ByteString::from_utf8("Expected 'function' keyword inside trait definition"sv)),span,TRY((__jakt_format((StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv)),((parsed_trait).name)))),((parsed_trait).name_span)))));
+TRY((((*this).error_with_hint((ByteString::must_from_utf8("Expected 'function' keyword inside trait definition"sv)),span,TRY((__jakt_format((StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv)),((parsed_trait).name)))),((parsed_trait).name_span)))));
 return parsed_trait;
 }
 return JaktInternal::ExplicitValue<void>();
@@ -6998,7 +6998,7 @@ return JaktInternal::ExplicitValue<void>();
 case 15 /* Minus */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Minus;utility::Span const& span = __jakt_match_value.value;
 {
-TRY((((*this).error_with_hint(TRY(ByteString::from_utf8("Expected 'function' keyword inside trait definition"sv)),span,TRY((__jakt_format((StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv)),((parsed_trait).name)))),((parsed_trait).name_span)))));
+TRY((((*this).error_with_hint((ByteString::must_from_utf8("Expected 'function' keyword inside trait definition"sv)),span,TRY((__jakt_format((StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv)),((parsed_trait).name)))),((parsed_trait).name_span)))));
 return parsed_trait;
 }
 return JaktInternal::ExplicitValue<void>();
@@ -7006,7 +7006,7 @@ return JaktInternal::ExplicitValue<void>();
 case 16 /* Equal */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Equal;utility::Span const& span = __jakt_match_value.value;
 {
-TRY((((*this).error_with_hint(TRY(ByteString::from_utf8("Expected 'function' keyword inside trait definition"sv)),span,TRY((__jakt_format((StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv)),((parsed_trait).name)))),((parsed_trait).name_span)))));
+TRY((((*this).error_with_hint((ByteString::must_from_utf8("Expected 'function' keyword inside trait definition"sv)),span,TRY((__jakt_format((StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv)),((parsed_trait).name)))),((parsed_trait).name_span)))));
 return parsed_trait;
 }
 return JaktInternal::ExplicitValue<void>();
@@ -7014,7 +7014,7 @@ return JaktInternal::ExplicitValue<void>();
 case 17 /* PlusEqual */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.PlusEqual;utility::Span const& span = __jakt_match_value.value;
 {
-TRY((((*this).error_with_hint(TRY(ByteString::from_utf8("Expected 'function' keyword inside trait definition"sv)),span,TRY((__jakt_format((StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv)),((parsed_trait).name)))),((parsed_trait).name_span)))));
+TRY((((*this).error_with_hint((ByteString::must_from_utf8("Expected 'function' keyword inside trait definition"sv)),span,TRY((__jakt_format((StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv)),((parsed_trait).name)))),((parsed_trait).name_span)))));
 return parsed_trait;
 }
 return JaktInternal::ExplicitValue<void>();
@@ -7022,7 +7022,7 @@ return JaktInternal::ExplicitValue<void>();
 case 18 /* PlusPlus */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.PlusPlus;utility::Span const& span = __jakt_match_value.value;
 {
-TRY((((*this).error_with_hint(TRY(ByteString::from_utf8("Expected 'function' keyword inside trait definition"sv)),span,TRY((__jakt_format((StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv)),((parsed_trait).name)))),((parsed_trait).name_span)))));
+TRY((((*this).error_with_hint((ByteString::must_from_utf8("Expected 'function' keyword inside trait definition"sv)),span,TRY((__jakt_format((StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv)),((parsed_trait).name)))),((parsed_trait).name_span)))));
 return parsed_trait;
 }
 return JaktInternal::ExplicitValue<void>();
@@ -7030,7 +7030,7 @@ return JaktInternal::ExplicitValue<void>();
 case 19 /* MinusEqual */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.MinusEqual;utility::Span const& span = __jakt_match_value.value;
 {
-TRY((((*this).error_with_hint(TRY(ByteString::from_utf8("Expected 'function' keyword inside trait definition"sv)),span,TRY((__jakt_format((StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv)),((parsed_trait).name)))),((parsed_trait).name_span)))));
+TRY((((*this).error_with_hint((ByteString::must_from_utf8("Expected 'function' keyword inside trait definition"sv)),span,TRY((__jakt_format((StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv)),((parsed_trait).name)))),((parsed_trait).name_span)))));
 return parsed_trait;
 }
 return JaktInternal::ExplicitValue<void>();
@@ -7038,7 +7038,7 @@ return JaktInternal::ExplicitValue<void>();
 case 20 /* MinusMinus */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.MinusMinus;utility::Span const& span = __jakt_match_value.value;
 {
-TRY((((*this).error_with_hint(TRY(ByteString::from_utf8("Expected 'function' keyword inside trait definition"sv)),span,TRY((__jakt_format((StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv)),((parsed_trait).name)))),((parsed_trait).name_span)))));
+TRY((((*this).error_with_hint((ByteString::must_from_utf8("Expected 'function' keyword inside trait definition"sv)),span,TRY((__jakt_format((StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv)),((parsed_trait).name)))),((parsed_trait).name_span)))));
 return parsed_trait;
 }
 return JaktInternal::ExplicitValue<void>();
@@ -7046,7 +7046,7 @@ return JaktInternal::ExplicitValue<void>();
 case 21 /* AsteriskEqual */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.AsteriskEqual;utility::Span const& span = __jakt_match_value.value;
 {
-TRY((((*this).error_with_hint(TRY(ByteString::from_utf8("Expected 'function' keyword inside trait definition"sv)),span,TRY((__jakt_format((StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv)),((parsed_trait).name)))),((parsed_trait).name_span)))));
+TRY((((*this).error_with_hint((ByteString::must_from_utf8("Expected 'function' keyword inside trait definition"sv)),span,TRY((__jakt_format((StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv)),((parsed_trait).name)))),((parsed_trait).name_span)))));
 return parsed_trait;
 }
 return JaktInternal::ExplicitValue<void>();
@@ -7054,7 +7054,7 @@ return JaktInternal::ExplicitValue<void>();
 case 22 /* ForwardSlashEqual */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.ForwardSlashEqual;utility::Span const& span = __jakt_match_value.value;
 {
-TRY((((*this).error_with_hint(TRY(ByteString::from_utf8("Expected 'function' keyword inside trait definition"sv)),span,TRY((__jakt_format((StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv)),((parsed_trait).name)))),((parsed_trait).name_span)))));
+TRY((((*this).error_with_hint((ByteString::must_from_utf8("Expected 'function' keyword inside trait definition"sv)),span,TRY((__jakt_format((StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv)),((parsed_trait).name)))),((parsed_trait).name_span)))));
 return parsed_trait;
 }
 return JaktInternal::ExplicitValue<void>();
@@ -7062,7 +7062,7 @@ return JaktInternal::ExplicitValue<void>();
 case 23 /* PercentSignEqual */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.PercentSignEqual;utility::Span const& span = __jakt_match_value.value;
 {
-TRY((((*this).error_with_hint(TRY(ByteString::from_utf8("Expected 'function' keyword inside trait definition"sv)),span,TRY((__jakt_format((StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv)),((parsed_trait).name)))),((parsed_trait).name_span)))));
+TRY((((*this).error_with_hint((ByteString::must_from_utf8("Expected 'function' keyword inside trait definition"sv)),span,TRY((__jakt_format((StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv)),((parsed_trait).name)))),((parsed_trait).name_span)))));
 return parsed_trait;
 }
 return JaktInternal::ExplicitValue<void>();
@@ -7070,7 +7070,7 @@ return JaktInternal::ExplicitValue<void>();
 case 24 /* NotEqual */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.NotEqual;utility::Span const& span = __jakt_match_value.value;
 {
-TRY((((*this).error_with_hint(TRY(ByteString::from_utf8("Expected 'function' keyword inside trait definition"sv)),span,TRY((__jakt_format((StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv)),((parsed_trait).name)))),((parsed_trait).name_span)))));
+TRY((((*this).error_with_hint((ByteString::must_from_utf8("Expected 'function' keyword inside trait definition"sv)),span,TRY((__jakt_format((StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv)),((parsed_trait).name)))),((parsed_trait).name_span)))));
 return parsed_trait;
 }
 return JaktInternal::ExplicitValue<void>();
@@ -7078,7 +7078,7 @@ return JaktInternal::ExplicitValue<void>();
 case 25 /* DoubleEqual */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.DoubleEqual;utility::Span const& span = __jakt_match_value.value;
 {
-TRY((((*this).error_with_hint(TRY(ByteString::from_utf8("Expected 'function' keyword inside trait definition"sv)),span,TRY((__jakt_format((StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv)),((parsed_trait).name)))),((parsed_trait).name_span)))));
+TRY((((*this).error_with_hint((ByteString::must_from_utf8("Expected 'function' keyword inside trait definition"sv)),span,TRY((__jakt_format((StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv)),((parsed_trait).name)))),((parsed_trait).name_span)))));
 return parsed_trait;
 }
 return JaktInternal::ExplicitValue<void>();
@@ -7086,7 +7086,7 @@ return JaktInternal::ExplicitValue<void>();
 case 26 /* GreaterThan */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.GreaterThan;utility::Span const& span = __jakt_match_value.value;
 {
-TRY((((*this).error_with_hint(TRY(ByteString::from_utf8("Expected 'function' keyword inside trait definition"sv)),span,TRY((__jakt_format((StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv)),((parsed_trait).name)))),((parsed_trait).name_span)))));
+TRY((((*this).error_with_hint((ByteString::must_from_utf8("Expected 'function' keyword inside trait definition"sv)),span,TRY((__jakt_format((StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv)),((parsed_trait).name)))),((parsed_trait).name_span)))));
 return parsed_trait;
 }
 return JaktInternal::ExplicitValue<void>();
@@ -7094,7 +7094,7 @@ return JaktInternal::ExplicitValue<void>();
 case 27 /* GreaterThanOrEqual */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.GreaterThanOrEqual;utility::Span const& span = __jakt_match_value.value;
 {
-TRY((((*this).error_with_hint(TRY(ByteString::from_utf8("Expected 'function' keyword inside trait definition"sv)),span,TRY((__jakt_format((StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv)),((parsed_trait).name)))),((parsed_trait).name_span)))));
+TRY((((*this).error_with_hint((ByteString::must_from_utf8("Expected 'function' keyword inside trait definition"sv)),span,TRY((__jakt_format((StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv)),((parsed_trait).name)))),((parsed_trait).name_span)))));
 return parsed_trait;
 }
 return JaktInternal::ExplicitValue<void>();
@@ -7102,7 +7102,7 @@ return JaktInternal::ExplicitValue<void>();
 case 28 /* LessThan */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.LessThan;utility::Span const& span = __jakt_match_value.value;
 {
-TRY((((*this).error_with_hint(TRY(ByteString::from_utf8("Expected 'function' keyword inside trait definition"sv)),span,TRY((__jakt_format((StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv)),((parsed_trait).name)))),((parsed_trait).name_span)))));
+TRY((((*this).error_with_hint((ByteString::must_from_utf8("Expected 'function' keyword inside trait definition"sv)),span,TRY((__jakt_format((StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv)),((parsed_trait).name)))),((parsed_trait).name_span)))));
 return parsed_trait;
 }
 return JaktInternal::ExplicitValue<void>();
@@ -7110,7 +7110,7 @@ return JaktInternal::ExplicitValue<void>();
 case 29 /* LessThanOrEqual */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.LessThanOrEqual;utility::Span const& span = __jakt_match_value.value;
 {
-TRY((((*this).error_with_hint(TRY(ByteString::from_utf8("Expected 'function' keyword inside trait definition"sv)),span,TRY((__jakt_format((StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv)),((parsed_trait).name)))),((parsed_trait).name_span)))));
+TRY((((*this).error_with_hint((ByteString::must_from_utf8("Expected 'function' keyword inside trait definition"sv)),span,TRY((__jakt_format((StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv)),((parsed_trait).name)))),((parsed_trait).name_span)))));
 return parsed_trait;
 }
 return JaktInternal::ExplicitValue<void>();
@@ -7118,7 +7118,7 @@ return JaktInternal::ExplicitValue<void>();
 case 30 /* LeftArithmeticShift */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.LeftArithmeticShift;utility::Span const& span = __jakt_match_value.value;
 {
-TRY((((*this).error_with_hint(TRY(ByteString::from_utf8("Expected 'function' keyword inside trait definition"sv)),span,TRY((__jakt_format((StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv)),((parsed_trait).name)))),((parsed_trait).name_span)))));
+TRY((((*this).error_with_hint((ByteString::must_from_utf8("Expected 'function' keyword inside trait definition"sv)),span,TRY((__jakt_format((StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv)),((parsed_trait).name)))),((parsed_trait).name_span)))));
 return parsed_trait;
 }
 return JaktInternal::ExplicitValue<void>();
@@ -7126,7 +7126,7 @@ return JaktInternal::ExplicitValue<void>();
 case 31 /* LeftShift */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.LeftShift;utility::Span const& span = __jakt_match_value.value;
 {
-TRY((((*this).error_with_hint(TRY(ByteString::from_utf8("Expected 'function' keyword inside trait definition"sv)),span,TRY((__jakt_format((StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv)),((parsed_trait).name)))),((parsed_trait).name_span)))));
+TRY((((*this).error_with_hint((ByteString::must_from_utf8("Expected 'function' keyword inside trait definition"sv)),span,TRY((__jakt_format((StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv)),((parsed_trait).name)))),((parsed_trait).name_span)))));
 return parsed_trait;
 }
 return JaktInternal::ExplicitValue<void>();
@@ -7134,7 +7134,7 @@ return JaktInternal::ExplicitValue<void>();
 case 32 /* LeftShiftEqual */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.LeftShiftEqual;utility::Span const& span = __jakt_match_value.value;
 {
-TRY((((*this).error_with_hint(TRY(ByteString::from_utf8("Expected 'function' keyword inside trait definition"sv)),span,TRY((__jakt_format((StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv)),((parsed_trait).name)))),((parsed_trait).name_span)))));
+TRY((((*this).error_with_hint((ByteString::must_from_utf8("Expected 'function' keyword inside trait definition"sv)),span,TRY((__jakt_format((StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv)),((parsed_trait).name)))),((parsed_trait).name_span)))));
 return parsed_trait;
 }
 return JaktInternal::ExplicitValue<void>();
@@ -7142,7 +7142,7 @@ return JaktInternal::ExplicitValue<void>();
 case 33 /* RightShift */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.RightShift;utility::Span const& span = __jakt_match_value.value;
 {
-TRY((((*this).error_with_hint(TRY(ByteString::from_utf8("Expected 'function' keyword inside trait definition"sv)),span,TRY((__jakt_format((StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv)),((parsed_trait).name)))),((parsed_trait).name_span)))));
+TRY((((*this).error_with_hint((ByteString::must_from_utf8("Expected 'function' keyword inside trait definition"sv)),span,TRY((__jakt_format((StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv)),((parsed_trait).name)))),((parsed_trait).name_span)))));
 return parsed_trait;
 }
 return JaktInternal::ExplicitValue<void>();
@@ -7150,7 +7150,7 @@ return JaktInternal::ExplicitValue<void>();
 case 34 /* RightArithmeticShift */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.RightArithmeticShift;utility::Span const& span = __jakt_match_value.value;
 {
-TRY((((*this).error_with_hint(TRY(ByteString::from_utf8("Expected 'function' keyword inside trait definition"sv)),span,TRY((__jakt_format((StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv)),((parsed_trait).name)))),((parsed_trait).name_span)))));
+TRY((((*this).error_with_hint((ByteString::must_from_utf8("Expected 'function' keyword inside trait definition"sv)),span,TRY((__jakt_format((StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv)),((parsed_trait).name)))),((parsed_trait).name_span)))));
 return parsed_trait;
 }
 return JaktInternal::ExplicitValue<void>();
@@ -7158,7 +7158,7 @@ return JaktInternal::ExplicitValue<void>();
 case 35 /* RightShiftEqual */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.RightShiftEqual;utility::Span const& span = __jakt_match_value.value;
 {
-TRY((((*this).error_with_hint(TRY(ByteString::from_utf8("Expected 'function' keyword inside trait definition"sv)),span,TRY((__jakt_format((StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv)),((parsed_trait).name)))),((parsed_trait).name_span)))));
+TRY((((*this).error_with_hint((ByteString::must_from_utf8("Expected 'function' keyword inside trait definition"sv)),span,TRY((__jakt_format((StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv)),((parsed_trait).name)))),((parsed_trait).name_span)))));
 return parsed_trait;
 }
 return JaktInternal::ExplicitValue<void>();
@@ -7166,7 +7166,7 @@ return JaktInternal::ExplicitValue<void>();
 case 36 /* Asterisk */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Asterisk;utility::Span const& span = __jakt_match_value.value;
 {
-TRY((((*this).error_with_hint(TRY(ByteString::from_utf8("Expected 'function' keyword inside trait definition"sv)),span,TRY((__jakt_format((StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv)),((parsed_trait).name)))),((parsed_trait).name_span)))));
+TRY((((*this).error_with_hint((ByteString::must_from_utf8("Expected 'function' keyword inside trait definition"sv)),span,TRY((__jakt_format((StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv)),((parsed_trait).name)))),((parsed_trait).name_span)))));
 return parsed_trait;
 }
 return JaktInternal::ExplicitValue<void>();
@@ -7174,7 +7174,7 @@ return JaktInternal::ExplicitValue<void>();
 case 37 /* Ampersand */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Ampersand;utility::Span const& span = __jakt_match_value.value;
 {
-TRY((((*this).error_with_hint(TRY(ByteString::from_utf8("Expected 'function' keyword inside trait definition"sv)),span,TRY((__jakt_format((StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv)),((parsed_trait).name)))),((parsed_trait).name_span)))));
+TRY((((*this).error_with_hint((ByteString::must_from_utf8("Expected 'function' keyword inside trait definition"sv)),span,TRY((__jakt_format((StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv)),((parsed_trait).name)))),((parsed_trait).name_span)))));
 return parsed_trait;
 }
 return JaktInternal::ExplicitValue<void>();
@@ -7182,7 +7182,7 @@ return JaktInternal::ExplicitValue<void>();
 case 38 /* AmpersandEqual */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.AmpersandEqual;utility::Span const& span = __jakt_match_value.value;
 {
-TRY((((*this).error_with_hint(TRY(ByteString::from_utf8("Expected 'function' keyword inside trait definition"sv)),span,TRY((__jakt_format((StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv)),((parsed_trait).name)))),((parsed_trait).name_span)))));
+TRY((((*this).error_with_hint((ByteString::must_from_utf8("Expected 'function' keyword inside trait definition"sv)),span,TRY((__jakt_format((StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv)),((parsed_trait).name)))),((parsed_trait).name_span)))));
 return parsed_trait;
 }
 return JaktInternal::ExplicitValue<void>();
@@ -7190,7 +7190,7 @@ return JaktInternal::ExplicitValue<void>();
 case 39 /* AmpersandAmpersand */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.AmpersandAmpersand;utility::Span const& span = __jakt_match_value.value;
 {
-TRY((((*this).error_with_hint(TRY(ByteString::from_utf8("Expected 'function' keyword inside trait definition"sv)),span,TRY((__jakt_format((StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv)),((parsed_trait).name)))),((parsed_trait).name_span)))));
+TRY((((*this).error_with_hint((ByteString::must_from_utf8("Expected 'function' keyword inside trait definition"sv)),span,TRY((__jakt_format((StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv)),((parsed_trait).name)))),((parsed_trait).name_span)))));
 return parsed_trait;
 }
 return JaktInternal::ExplicitValue<void>();
@@ -7198,7 +7198,7 @@ return JaktInternal::ExplicitValue<void>();
 case 40 /* Pipe */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Pipe;utility::Span const& span = __jakt_match_value.value;
 {
-TRY((((*this).error_with_hint(TRY(ByteString::from_utf8("Expected 'function' keyword inside trait definition"sv)),span,TRY((__jakt_format((StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv)),((parsed_trait).name)))),((parsed_trait).name_span)))));
+TRY((((*this).error_with_hint((ByteString::must_from_utf8("Expected 'function' keyword inside trait definition"sv)),span,TRY((__jakt_format((StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv)),((parsed_trait).name)))),((parsed_trait).name_span)))));
 return parsed_trait;
 }
 return JaktInternal::ExplicitValue<void>();
@@ -7206,7 +7206,7 @@ return JaktInternal::ExplicitValue<void>();
 case 41 /* PipeEqual */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.PipeEqual;utility::Span const& span = __jakt_match_value.value;
 {
-TRY((((*this).error_with_hint(TRY(ByteString::from_utf8("Expected 'function' keyword inside trait definition"sv)),span,TRY((__jakt_format((StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv)),((parsed_trait).name)))),((parsed_trait).name_span)))));
+TRY((((*this).error_with_hint((ByteString::must_from_utf8("Expected 'function' keyword inside trait definition"sv)),span,TRY((__jakt_format((StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv)),((parsed_trait).name)))),((parsed_trait).name_span)))));
 return parsed_trait;
 }
 return JaktInternal::ExplicitValue<void>();
@@ -7214,7 +7214,7 @@ return JaktInternal::ExplicitValue<void>();
 case 42 /* PipePipe */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.PipePipe;utility::Span const& span = __jakt_match_value.value;
 {
-TRY((((*this).error_with_hint(TRY(ByteString::from_utf8("Expected 'function' keyword inside trait definition"sv)),span,TRY((__jakt_format((StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv)),((parsed_trait).name)))),((parsed_trait).name_span)))));
+TRY((((*this).error_with_hint((ByteString::must_from_utf8("Expected 'function' keyword inside trait definition"sv)),span,TRY((__jakt_format((StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv)),((parsed_trait).name)))),((parsed_trait).name_span)))));
 return parsed_trait;
 }
 return JaktInternal::ExplicitValue<void>();
@@ -7222,7 +7222,7 @@ return JaktInternal::ExplicitValue<void>();
 case 43 /* Caret */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Caret;utility::Span const& span = __jakt_match_value.value;
 {
-TRY((((*this).error_with_hint(TRY(ByteString::from_utf8("Expected 'function' keyword inside trait definition"sv)),span,TRY((__jakt_format((StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv)),((parsed_trait).name)))),((parsed_trait).name_span)))));
+TRY((((*this).error_with_hint((ByteString::must_from_utf8("Expected 'function' keyword inside trait definition"sv)),span,TRY((__jakt_format((StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv)),((parsed_trait).name)))),((parsed_trait).name_span)))));
 return parsed_trait;
 }
 return JaktInternal::ExplicitValue<void>();
@@ -7230,7 +7230,7 @@ return JaktInternal::ExplicitValue<void>();
 case 44 /* CaretEqual */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.CaretEqual;utility::Span const& span = __jakt_match_value.value;
 {
-TRY((((*this).error_with_hint(TRY(ByteString::from_utf8("Expected 'function' keyword inside trait definition"sv)),span,TRY((__jakt_format((StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv)),((parsed_trait).name)))),((parsed_trait).name_span)))));
+TRY((((*this).error_with_hint((ByteString::must_from_utf8("Expected 'function' keyword inside trait definition"sv)),span,TRY((__jakt_format((StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv)),((parsed_trait).name)))),((parsed_trait).name_span)))));
 return parsed_trait;
 }
 return JaktInternal::ExplicitValue<void>();
@@ -7238,7 +7238,7 @@ return JaktInternal::ExplicitValue<void>();
 case 45 /* Dollar */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Dollar;utility::Span const& span = __jakt_match_value.value;
 {
-TRY((((*this).error_with_hint(TRY(ByteString::from_utf8("Expected 'function' keyword inside trait definition"sv)),span,TRY((__jakt_format((StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv)),((parsed_trait).name)))),((parsed_trait).name_span)))));
+TRY((((*this).error_with_hint((ByteString::must_from_utf8("Expected 'function' keyword inside trait definition"sv)),span,TRY((__jakt_format((StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv)),((parsed_trait).name)))),((parsed_trait).name_span)))));
 return parsed_trait;
 }
 return JaktInternal::ExplicitValue<void>();
@@ -7246,7 +7246,7 @@ return JaktInternal::ExplicitValue<void>();
 case 46 /* Tilde */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Tilde;utility::Span const& span = __jakt_match_value.value;
 {
-TRY((((*this).error_with_hint(TRY(ByteString::from_utf8("Expected 'function' keyword inside trait definition"sv)),span,TRY((__jakt_format((StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv)),((parsed_trait).name)))),((parsed_trait).name_span)))));
+TRY((((*this).error_with_hint((ByteString::must_from_utf8("Expected 'function' keyword inside trait definition"sv)),span,TRY((__jakt_format((StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv)),((parsed_trait).name)))),((parsed_trait).name_span)))));
 return parsed_trait;
 }
 return JaktInternal::ExplicitValue<void>();
@@ -7254,7 +7254,7 @@ return JaktInternal::ExplicitValue<void>();
 case 47 /* ForwardSlash */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.ForwardSlash;utility::Span const& span = __jakt_match_value.value;
 {
-TRY((((*this).error_with_hint(TRY(ByteString::from_utf8("Expected 'function' keyword inside trait definition"sv)),span,TRY((__jakt_format((StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv)),((parsed_trait).name)))),((parsed_trait).name_span)))));
+TRY((((*this).error_with_hint((ByteString::must_from_utf8("Expected 'function' keyword inside trait definition"sv)),span,TRY((__jakt_format((StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv)),((parsed_trait).name)))),((parsed_trait).name_span)))));
 return parsed_trait;
 }
 return JaktInternal::ExplicitValue<void>();
@@ -7262,7 +7262,7 @@ return JaktInternal::ExplicitValue<void>();
 case 48 /* ExclamationPoint */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.ExclamationPoint;utility::Span const& span = __jakt_match_value.value;
 {
-TRY((((*this).error_with_hint(TRY(ByteString::from_utf8("Expected 'function' keyword inside trait definition"sv)),span,TRY((__jakt_format((StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv)),((parsed_trait).name)))),((parsed_trait).name_span)))));
+TRY((((*this).error_with_hint((ByteString::must_from_utf8("Expected 'function' keyword inside trait definition"sv)),span,TRY((__jakt_format((StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv)),((parsed_trait).name)))),((parsed_trait).name_span)))));
 return parsed_trait;
 }
 return JaktInternal::ExplicitValue<void>();
@@ -7270,7 +7270,7 @@ return JaktInternal::ExplicitValue<void>();
 case 49 /* QuestionMark */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.QuestionMark;utility::Span const& span = __jakt_match_value.value;
 {
-TRY((((*this).error_with_hint(TRY(ByteString::from_utf8("Expected 'function' keyword inside trait definition"sv)),span,TRY((__jakt_format((StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv)),((parsed_trait).name)))),((parsed_trait).name_span)))));
+TRY((((*this).error_with_hint((ByteString::must_from_utf8("Expected 'function' keyword inside trait definition"sv)),span,TRY((__jakt_format((StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv)),((parsed_trait).name)))),((parsed_trait).name_span)))));
 return parsed_trait;
 }
 return JaktInternal::ExplicitValue<void>();
@@ -7278,7 +7278,7 @@ return JaktInternal::ExplicitValue<void>();
 case 50 /* QuestionMarkQuestionMark */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.QuestionMarkQuestionMark;utility::Span const& span = __jakt_match_value.value;
 {
-TRY((((*this).error_with_hint(TRY(ByteString::from_utf8("Expected 'function' keyword inside trait definition"sv)),span,TRY((__jakt_format((StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv)),((parsed_trait).name)))),((parsed_trait).name_span)))));
+TRY((((*this).error_with_hint((ByteString::must_from_utf8("Expected 'function' keyword inside trait definition"sv)),span,TRY((__jakt_format((StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv)),((parsed_trait).name)))),((parsed_trait).name_span)))));
 return parsed_trait;
 }
 return JaktInternal::ExplicitValue<void>();
@@ -7286,7 +7286,7 @@ return JaktInternal::ExplicitValue<void>();
 case 51 /* QuestionMarkQuestionMarkEqual */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.QuestionMarkQuestionMarkEqual;utility::Span const& span = __jakt_match_value.value;
 {
-TRY((((*this).error_with_hint(TRY(ByteString::from_utf8("Expected 'function' keyword inside trait definition"sv)),span,TRY((__jakt_format((StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv)),((parsed_trait).name)))),((parsed_trait).name_span)))));
+TRY((((*this).error_with_hint((ByteString::must_from_utf8("Expected 'function' keyword inside trait definition"sv)),span,TRY((__jakt_format((StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv)),((parsed_trait).name)))),((parsed_trait).name_span)))));
 return parsed_trait;
 }
 return JaktInternal::ExplicitValue<void>();
@@ -7294,7 +7294,7 @@ return JaktInternal::ExplicitValue<void>();
 case 52 /* Comma */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Comma;utility::Span const& span = __jakt_match_value.value;
 {
-TRY((((*this).error_with_hint(TRY(ByteString::from_utf8("Expected 'function' keyword inside trait definition"sv)),span,TRY((__jakt_format((StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv)),((parsed_trait).name)))),((parsed_trait).name_span)))));
+TRY((((*this).error_with_hint((ByteString::must_from_utf8("Expected 'function' keyword inside trait definition"sv)),span,TRY((__jakt_format((StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv)),((parsed_trait).name)))),((parsed_trait).name_span)))));
 return parsed_trait;
 }
 return JaktInternal::ExplicitValue<void>();
@@ -7302,7 +7302,7 @@ return JaktInternal::ExplicitValue<void>();
 case 53 /* Dot */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Dot;utility::Span const& span = __jakt_match_value.value;
 {
-TRY((((*this).error_with_hint(TRY(ByteString::from_utf8("Expected 'function' keyword inside trait definition"sv)),span,TRY((__jakt_format((StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv)),((parsed_trait).name)))),((parsed_trait).name_span)))));
+TRY((((*this).error_with_hint((ByteString::must_from_utf8("Expected 'function' keyword inside trait definition"sv)),span,TRY((__jakt_format((StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv)),((parsed_trait).name)))),((parsed_trait).name_span)))));
 return parsed_trait;
 }
 return JaktInternal::ExplicitValue<void>();
@@ -7310,7 +7310,7 @@ return JaktInternal::ExplicitValue<void>();
 case 54 /* DotDot */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.DotDot;utility::Span const& span = __jakt_match_value.value;
 {
-TRY((((*this).error_with_hint(TRY(ByteString::from_utf8("Expected 'function' keyword inside trait definition"sv)),span,TRY((__jakt_format((StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv)),((parsed_trait).name)))),((parsed_trait).name_span)))));
+TRY((((*this).error_with_hint((ByteString::must_from_utf8("Expected 'function' keyword inside trait definition"sv)),span,TRY((__jakt_format((StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv)),((parsed_trait).name)))),((parsed_trait).name_span)))));
 return parsed_trait;
 }
 return JaktInternal::ExplicitValue<void>();
@@ -7318,7 +7318,7 @@ return JaktInternal::ExplicitValue<void>();
 case 57 /* FatArrow */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.FatArrow;utility::Span const& span = __jakt_match_value.value;
 {
-TRY((((*this).error_with_hint(TRY(ByteString::from_utf8("Expected 'function' keyword inside trait definition"sv)),span,TRY((__jakt_format((StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv)),((parsed_trait).name)))),((parsed_trait).name_span)))));
+TRY((((*this).error_with_hint((ByteString::must_from_utf8("Expected 'function' keyword inside trait definition"sv)),span,TRY((__jakt_format((StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv)),((parsed_trait).name)))),((parsed_trait).name_span)))));
 return parsed_trait;
 }
 return JaktInternal::ExplicitValue<void>();
@@ -7326,7 +7326,7 @@ return JaktInternal::ExplicitValue<void>();
 case 58 /* Arrow */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Arrow;utility::Span const& span = __jakt_match_value.value;
 {
-TRY((((*this).error_with_hint(TRY(ByteString::from_utf8("Expected 'function' keyword inside trait definition"sv)),span,TRY((__jakt_format((StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv)),((parsed_trait).name)))),((parsed_trait).name_span)))));
+TRY((((*this).error_with_hint((ByteString::must_from_utf8("Expected 'function' keyword inside trait definition"sv)),span,TRY((__jakt_format((StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv)),((parsed_trait).name)))),((parsed_trait).name_span)))));
 return parsed_trait;
 }
 return JaktInternal::ExplicitValue<void>();
@@ -7334,7 +7334,7 @@ return JaktInternal::ExplicitValue<void>();
 case 59 /* And */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.And;utility::Span const& span = __jakt_match_value.value;
 {
-TRY((((*this).error_with_hint(TRY(ByteString::from_utf8("Expected 'function' keyword inside trait definition"sv)),span,TRY((__jakt_format((StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv)),((parsed_trait).name)))),((parsed_trait).name_span)))));
+TRY((((*this).error_with_hint((ByteString::must_from_utf8("Expected 'function' keyword inside trait definition"sv)),span,TRY((__jakt_format((StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv)),((parsed_trait).name)))),((parsed_trait).name_span)))));
 return parsed_trait;
 }
 return JaktInternal::ExplicitValue<void>();
@@ -7342,7 +7342,7 @@ return JaktInternal::ExplicitValue<void>();
 case 60 /* Anon */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Anon;utility::Span const& span = __jakt_match_value.value;
 {
-TRY((((*this).error_with_hint(TRY(ByteString::from_utf8("Expected 'function' keyword inside trait definition"sv)),span,TRY((__jakt_format((StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv)),((parsed_trait).name)))),((parsed_trait).name_span)))));
+TRY((((*this).error_with_hint((ByteString::must_from_utf8("Expected 'function' keyword inside trait definition"sv)),span,TRY((__jakt_format((StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv)),((parsed_trait).name)))),((parsed_trait).name_span)))));
 return parsed_trait;
 }
 return JaktInternal::ExplicitValue<void>();
@@ -7350,7 +7350,7 @@ return JaktInternal::ExplicitValue<void>();
 case 61 /* As */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.As;utility::Span const& span = __jakt_match_value.value;
 {
-TRY((((*this).error_with_hint(TRY(ByteString::from_utf8("Expected 'function' keyword inside trait definition"sv)),span,TRY((__jakt_format((StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv)),((parsed_trait).name)))),((parsed_trait).name_span)))));
+TRY((((*this).error_with_hint((ByteString::must_from_utf8("Expected 'function' keyword inside trait definition"sv)),span,TRY((__jakt_format((StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv)),((parsed_trait).name)))),((parsed_trait).name_span)))));
 return parsed_trait;
 }
 return JaktInternal::ExplicitValue<void>();
@@ -7358,7 +7358,7 @@ return JaktInternal::ExplicitValue<void>();
 case 62 /* Boxed */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Boxed;utility::Span const& span = __jakt_match_value.value;
 {
-TRY((((*this).error_with_hint(TRY(ByteString::from_utf8("Expected 'function' keyword inside trait definition"sv)),span,TRY((__jakt_format((StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv)),((parsed_trait).name)))),((parsed_trait).name_span)))));
+TRY((((*this).error_with_hint((ByteString::must_from_utf8("Expected 'function' keyword inside trait definition"sv)),span,TRY((__jakt_format((StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv)),((parsed_trait).name)))),((parsed_trait).name_span)))));
 return parsed_trait;
 }
 return JaktInternal::ExplicitValue<void>();
@@ -7366,7 +7366,7 @@ return JaktInternal::ExplicitValue<void>();
 case 63 /* Break */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Break;utility::Span const& span = __jakt_match_value.value;
 {
-TRY((((*this).error_with_hint(TRY(ByteString::from_utf8("Expected 'function' keyword inside trait definition"sv)),span,TRY((__jakt_format((StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv)),((parsed_trait).name)))),((parsed_trait).name_span)))));
+TRY((((*this).error_with_hint((ByteString::must_from_utf8("Expected 'function' keyword inside trait definition"sv)),span,TRY((__jakt_format((StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv)),((parsed_trait).name)))),((parsed_trait).name_span)))));
 return parsed_trait;
 }
 return JaktInternal::ExplicitValue<void>();
@@ -7374,7 +7374,7 @@ return JaktInternal::ExplicitValue<void>();
 case 64 /* Catch */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Catch;utility::Span const& span = __jakt_match_value.value;
 {
-TRY((((*this).error_with_hint(TRY(ByteString::from_utf8("Expected 'function' keyword inside trait definition"sv)),span,TRY((__jakt_format((StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv)),((parsed_trait).name)))),((parsed_trait).name_span)))));
+TRY((((*this).error_with_hint((ByteString::must_from_utf8("Expected 'function' keyword inside trait definition"sv)),span,TRY((__jakt_format((StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv)),((parsed_trait).name)))),((parsed_trait).name_span)))));
 return parsed_trait;
 }
 return JaktInternal::ExplicitValue<void>();
@@ -7382,7 +7382,7 @@ return JaktInternal::ExplicitValue<void>();
 case 65 /* Class */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Class;utility::Span const& span = __jakt_match_value.value;
 {
-TRY((((*this).error_with_hint(TRY(ByteString::from_utf8("Expected 'function' keyword inside trait definition"sv)),span,TRY((__jakt_format((StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv)),((parsed_trait).name)))),((parsed_trait).name_span)))));
+TRY((((*this).error_with_hint((ByteString::must_from_utf8("Expected 'function' keyword inside trait definition"sv)),span,TRY((__jakt_format((StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv)),((parsed_trait).name)))),((parsed_trait).name_span)))));
 return parsed_trait;
 }
 return JaktInternal::ExplicitValue<void>();
@@ -7390,7 +7390,7 @@ return JaktInternal::ExplicitValue<void>();
 case 66 /* Continue */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Continue;utility::Span const& span = __jakt_match_value.value;
 {
-TRY((((*this).error_with_hint(TRY(ByteString::from_utf8("Expected 'function' keyword inside trait definition"sv)),span,TRY((__jakt_format((StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv)),((parsed_trait).name)))),((parsed_trait).name_span)))));
+TRY((((*this).error_with_hint((ByteString::must_from_utf8("Expected 'function' keyword inside trait definition"sv)),span,TRY((__jakt_format((StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv)),((parsed_trait).name)))),((parsed_trait).name_span)))));
 return parsed_trait;
 }
 return JaktInternal::ExplicitValue<void>();
@@ -7398,7 +7398,7 @@ return JaktInternal::ExplicitValue<void>();
 case 67 /* Cpp */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Cpp;utility::Span const& span = __jakt_match_value.value;
 {
-TRY((((*this).error_with_hint(TRY(ByteString::from_utf8("Expected 'function' keyword inside trait definition"sv)),span,TRY((__jakt_format((StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv)),((parsed_trait).name)))),((parsed_trait).name_span)))));
+TRY((((*this).error_with_hint((ByteString::must_from_utf8("Expected 'function' keyword inside trait definition"sv)),span,TRY((__jakt_format((StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv)),((parsed_trait).name)))),((parsed_trait).name_span)))));
 return parsed_trait;
 }
 return JaktInternal::ExplicitValue<void>();
@@ -7406,7 +7406,7 @@ return JaktInternal::ExplicitValue<void>();
 case 68 /* Defer */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Defer;utility::Span const& span = __jakt_match_value.value;
 {
-TRY((((*this).error_with_hint(TRY(ByteString::from_utf8("Expected 'function' keyword inside trait definition"sv)),span,TRY((__jakt_format((StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv)),((parsed_trait).name)))),((parsed_trait).name_span)))));
+TRY((((*this).error_with_hint((ByteString::must_from_utf8("Expected 'function' keyword inside trait definition"sv)),span,TRY((__jakt_format((StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv)),((parsed_trait).name)))),((parsed_trait).name_span)))));
 return parsed_trait;
 }
 return JaktInternal::ExplicitValue<void>();
@@ -7414,7 +7414,7 @@ return JaktInternal::ExplicitValue<void>();
 case 69 /* Destructor */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Destructor;utility::Span const& span = __jakt_match_value.value;
 {
-TRY((((*this).error_with_hint(TRY(ByteString::from_utf8("Expected 'function' keyword inside trait definition"sv)),span,TRY((__jakt_format((StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv)),((parsed_trait).name)))),((parsed_trait).name_span)))));
+TRY((((*this).error_with_hint((ByteString::must_from_utf8("Expected 'function' keyword inside trait definition"sv)),span,TRY((__jakt_format((StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv)),((parsed_trait).name)))),((parsed_trait).name_span)))));
 return parsed_trait;
 }
 return JaktInternal::ExplicitValue<void>();
@@ -7422,7 +7422,7 @@ return JaktInternal::ExplicitValue<void>();
 case 70 /* Else */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Else;utility::Span const& span = __jakt_match_value.value;
 {
-TRY((((*this).error_with_hint(TRY(ByteString::from_utf8("Expected 'function' keyword inside trait definition"sv)),span,TRY((__jakt_format((StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv)),((parsed_trait).name)))),((parsed_trait).name_span)))));
+TRY((((*this).error_with_hint((ByteString::must_from_utf8("Expected 'function' keyword inside trait definition"sv)),span,TRY((__jakt_format((StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv)),((parsed_trait).name)))),((parsed_trait).name_span)))));
 return parsed_trait;
 }
 return JaktInternal::ExplicitValue<void>();
@@ -7430,7 +7430,7 @@ return JaktInternal::ExplicitValue<void>();
 case 71 /* Enum */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Enum;utility::Span const& span = __jakt_match_value.value;
 {
-TRY((((*this).error_with_hint(TRY(ByteString::from_utf8("Expected 'function' keyword inside trait definition"sv)),span,TRY((__jakt_format((StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv)),((parsed_trait).name)))),((parsed_trait).name_span)))));
+TRY((((*this).error_with_hint((ByteString::must_from_utf8("Expected 'function' keyword inside trait definition"sv)),span,TRY((__jakt_format((StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv)),((parsed_trait).name)))),((parsed_trait).name_span)))));
 return parsed_trait;
 }
 return JaktInternal::ExplicitValue<void>();
@@ -7438,7 +7438,7 @@ return JaktInternal::ExplicitValue<void>();
 case 72 /* Extern */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Extern;utility::Span const& span = __jakt_match_value.value;
 {
-TRY((((*this).error_with_hint(TRY(ByteString::from_utf8("Expected 'function' keyword inside trait definition"sv)),span,TRY((__jakt_format((StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv)),((parsed_trait).name)))),((parsed_trait).name_span)))));
+TRY((((*this).error_with_hint((ByteString::must_from_utf8("Expected 'function' keyword inside trait definition"sv)),span,TRY((__jakt_format((StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv)),((parsed_trait).name)))),((parsed_trait).name_span)))));
 return parsed_trait;
 }
 return JaktInternal::ExplicitValue<void>();
@@ -7446,7 +7446,7 @@ return JaktInternal::ExplicitValue<void>();
 case 73 /* False */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.False;utility::Span const& span = __jakt_match_value.value;
 {
-TRY((((*this).error_with_hint(TRY(ByteString::from_utf8("Expected 'function' keyword inside trait definition"sv)),span,TRY((__jakt_format((StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv)),((parsed_trait).name)))),((parsed_trait).name_span)))));
+TRY((((*this).error_with_hint((ByteString::must_from_utf8("Expected 'function' keyword inside trait definition"sv)),span,TRY((__jakt_format((StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv)),((parsed_trait).name)))),((parsed_trait).name_span)))));
 return parsed_trait;
 }
 return JaktInternal::ExplicitValue<void>();
@@ -7454,7 +7454,7 @@ return JaktInternal::ExplicitValue<void>();
 case 74 /* For */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.For;utility::Span const& span = __jakt_match_value.value;
 {
-TRY((((*this).error_with_hint(TRY(ByteString::from_utf8("Expected 'function' keyword inside trait definition"sv)),span,TRY((__jakt_format((StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv)),((parsed_trait).name)))),((parsed_trait).name_span)))));
+TRY((((*this).error_with_hint((ByteString::must_from_utf8("Expected 'function' keyword inside trait definition"sv)),span,TRY((__jakt_format((StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv)),((parsed_trait).name)))),((parsed_trait).name_span)))));
 return parsed_trait;
 }
 return JaktInternal::ExplicitValue<void>();
@@ -7462,7 +7462,7 @@ return JaktInternal::ExplicitValue<void>();
 case 76 /* Comptime */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Comptime;utility::Span const& span = __jakt_match_value.value;
 {
-TRY((((*this).error_with_hint(TRY(ByteString::from_utf8("Expected 'function' keyword inside trait definition"sv)),span,TRY((__jakt_format((StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv)),((parsed_trait).name)))),((parsed_trait).name_span)))));
+TRY((((*this).error_with_hint((ByteString::must_from_utf8("Expected 'function' keyword inside trait definition"sv)),span,TRY((__jakt_format((StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv)),((parsed_trait).name)))),((parsed_trait).name_span)))));
 return parsed_trait;
 }
 return JaktInternal::ExplicitValue<void>();
@@ -7470,7 +7470,7 @@ return JaktInternal::ExplicitValue<void>();
 case 77 /* If */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.If;utility::Span const& span = __jakt_match_value.value;
 {
-TRY((((*this).error_with_hint(TRY(ByteString::from_utf8("Expected 'function' keyword inside trait definition"sv)),span,TRY((__jakt_format((StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv)),((parsed_trait).name)))),((parsed_trait).name_span)))));
+TRY((((*this).error_with_hint((ByteString::must_from_utf8("Expected 'function' keyword inside trait definition"sv)),span,TRY((__jakt_format((StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv)),((parsed_trait).name)))),((parsed_trait).name_span)))));
 return parsed_trait;
 }
 return JaktInternal::ExplicitValue<void>();
@@ -7478,7 +7478,7 @@ return JaktInternal::ExplicitValue<void>();
 case 78 /* Import */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Import;utility::Span const& span = __jakt_match_value.value;
 {
-TRY((((*this).error_with_hint(TRY(ByteString::from_utf8("Expected 'function' keyword inside trait definition"sv)),span,TRY((__jakt_format((StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv)),((parsed_trait).name)))),((parsed_trait).name_span)))));
+TRY((((*this).error_with_hint((ByteString::must_from_utf8("Expected 'function' keyword inside trait definition"sv)),span,TRY((__jakt_format((StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv)),((parsed_trait).name)))),((parsed_trait).name_span)))));
 return parsed_trait;
 }
 return JaktInternal::ExplicitValue<void>();
@@ -7486,7 +7486,7 @@ return JaktInternal::ExplicitValue<void>();
 case 79 /* Relative */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Relative;utility::Span const& span = __jakt_match_value.value;
 {
-TRY((((*this).error_with_hint(TRY(ByteString::from_utf8("Expected 'function' keyword inside trait definition"sv)),span,TRY((__jakt_format((StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv)),((parsed_trait).name)))),((parsed_trait).name_span)))));
+TRY((((*this).error_with_hint((ByteString::must_from_utf8("Expected 'function' keyword inside trait definition"sv)),span,TRY((__jakt_format((StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv)),((parsed_trait).name)))),((parsed_trait).name_span)))));
 return parsed_trait;
 }
 return JaktInternal::ExplicitValue<void>();
@@ -7494,7 +7494,7 @@ return JaktInternal::ExplicitValue<void>();
 case 80 /* In */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.In;utility::Span const& span = __jakt_match_value.value;
 {
-TRY((((*this).error_with_hint(TRY(ByteString::from_utf8("Expected 'function' keyword inside trait definition"sv)),span,TRY((__jakt_format((StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv)),((parsed_trait).name)))),((parsed_trait).name_span)))));
+TRY((((*this).error_with_hint((ByteString::must_from_utf8("Expected 'function' keyword inside trait definition"sv)),span,TRY((__jakt_format((StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv)),((parsed_trait).name)))),((parsed_trait).name_span)))));
 return parsed_trait;
 }
 return JaktInternal::ExplicitValue<void>();
@@ -7502,7 +7502,7 @@ return JaktInternal::ExplicitValue<void>();
 case 81 /* Is */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Is;utility::Span const& span = __jakt_match_value.value;
 {
-TRY((((*this).error_with_hint(TRY(ByteString::from_utf8("Expected 'function' keyword inside trait definition"sv)),span,TRY((__jakt_format((StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv)),((parsed_trait).name)))),((parsed_trait).name_span)))));
+TRY((((*this).error_with_hint((ByteString::must_from_utf8("Expected 'function' keyword inside trait definition"sv)),span,TRY((__jakt_format((StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv)),((parsed_trait).name)))),((parsed_trait).name_span)))));
 return parsed_trait;
 }
 return JaktInternal::ExplicitValue<void>();
@@ -7510,7 +7510,7 @@ return JaktInternal::ExplicitValue<void>();
 case 82 /* Let */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Let;utility::Span const& span = __jakt_match_value.value;
 {
-TRY((((*this).error_with_hint(TRY(ByteString::from_utf8("Expected 'function' keyword inside trait definition"sv)),span,TRY((__jakt_format((StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv)),((parsed_trait).name)))),((parsed_trait).name_span)))));
+TRY((((*this).error_with_hint((ByteString::must_from_utf8("Expected 'function' keyword inside trait definition"sv)),span,TRY((__jakt_format((StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv)),((parsed_trait).name)))),((parsed_trait).name_span)))));
 return parsed_trait;
 }
 return JaktInternal::ExplicitValue<void>();
@@ -7518,7 +7518,7 @@ return JaktInternal::ExplicitValue<void>();
 case 83 /* Loop */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Loop;utility::Span const& span = __jakt_match_value.value;
 {
-TRY((((*this).error_with_hint(TRY(ByteString::from_utf8("Expected 'function' keyword inside trait definition"sv)),span,TRY((__jakt_format((StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv)),((parsed_trait).name)))),((parsed_trait).name_span)))));
+TRY((((*this).error_with_hint((ByteString::must_from_utf8("Expected 'function' keyword inside trait definition"sv)),span,TRY((__jakt_format((StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv)),((parsed_trait).name)))),((parsed_trait).name_span)))));
 return parsed_trait;
 }
 return JaktInternal::ExplicitValue<void>();
@@ -7526,7 +7526,7 @@ return JaktInternal::ExplicitValue<void>();
 case 84 /* Match */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Match;utility::Span const& span = __jakt_match_value.value;
 {
-TRY((((*this).error_with_hint(TRY(ByteString::from_utf8("Expected 'function' keyword inside trait definition"sv)),span,TRY((__jakt_format((StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv)),((parsed_trait).name)))),((parsed_trait).name_span)))));
+TRY((((*this).error_with_hint((ByteString::must_from_utf8("Expected 'function' keyword inside trait definition"sv)),span,TRY((__jakt_format((StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv)),((parsed_trait).name)))),((parsed_trait).name_span)))));
 return parsed_trait;
 }
 return JaktInternal::ExplicitValue<void>();
@@ -7534,7 +7534,7 @@ return JaktInternal::ExplicitValue<void>();
 case 85 /* Mut */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Mut;utility::Span const& span = __jakt_match_value.value;
 {
-TRY((((*this).error_with_hint(TRY(ByteString::from_utf8("Expected 'function' keyword inside trait definition"sv)),span,TRY((__jakt_format((StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv)),((parsed_trait).name)))),((parsed_trait).name_span)))));
+TRY((((*this).error_with_hint((ByteString::must_from_utf8("Expected 'function' keyword inside trait definition"sv)),span,TRY((__jakt_format((StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv)),((parsed_trait).name)))),((parsed_trait).name_span)))));
 return parsed_trait;
 }
 return JaktInternal::ExplicitValue<void>();
@@ -7542,7 +7542,7 @@ return JaktInternal::ExplicitValue<void>();
 case 86 /* Namespace */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Namespace;utility::Span const& span = __jakt_match_value.value;
 {
-TRY((((*this).error_with_hint(TRY(ByteString::from_utf8("Expected 'function' keyword inside trait definition"sv)),span,TRY((__jakt_format((StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv)),((parsed_trait).name)))),((parsed_trait).name_span)))));
+TRY((((*this).error_with_hint((ByteString::must_from_utf8("Expected 'function' keyword inside trait definition"sv)),span,TRY((__jakt_format((StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv)),((parsed_trait).name)))),((parsed_trait).name_span)))));
 return parsed_trait;
 }
 return JaktInternal::ExplicitValue<void>();
@@ -7550,7 +7550,7 @@ return JaktInternal::ExplicitValue<void>();
 case 87 /* Not */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Not;utility::Span const& span = __jakt_match_value.value;
 {
-TRY((((*this).error_with_hint(TRY(ByteString::from_utf8("Expected 'function' keyword inside trait definition"sv)),span,TRY((__jakt_format((StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv)),((parsed_trait).name)))),((parsed_trait).name_span)))));
+TRY((((*this).error_with_hint((ByteString::must_from_utf8("Expected 'function' keyword inside trait definition"sv)),span,TRY((__jakt_format((StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv)),((parsed_trait).name)))),((parsed_trait).name_span)))));
 return parsed_trait;
 }
 return JaktInternal::ExplicitValue<void>();
@@ -7558,7 +7558,7 @@ return JaktInternal::ExplicitValue<void>();
 case 88 /* Or */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Or;utility::Span const& span = __jakt_match_value.value;
 {
-TRY((((*this).error_with_hint(TRY(ByteString::from_utf8("Expected 'function' keyword inside trait definition"sv)),span,TRY((__jakt_format((StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv)),((parsed_trait).name)))),((parsed_trait).name_span)))));
+TRY((((*this).error_with_hint((ByteString::must_from_utf8("Expected 'function' keyword inside trait definition"sv)),span,TRY((__jakt_format((StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv)),((parsed_trait).name)))),((parsed_trait).name_span)))));
 return parsed_trait;
 }
 return JaktInternal::ExplicitValue<void>();
@@ -7566,7 +7566,7 @@ return JaktInternal::ExplicitValue<void>();
 case 89 /* Override */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Override;utility::Span const& span = __jakt_match_value.value;
 {
-TRY((((*this).error_with_hint(TRY(ByteString::from_utf8("Expected 'function' keyword inside trait definition"sv)),span,TRY((__jakt_format((StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv)),((parsed_trait).name)))),((parsed_trait).name_span)))));
+TRY((((*this).error_with_hint((ByteString::must_from_utf8("Expected 'function' keyword inside trait definition"sv)),span,TRY((__jakt_format((StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv)),((parsed_trait).name)))),((parsed_trait).name_span)))));
 return parsed_trait;
 }
 return JaktInternal::ExplicitValue<void>();
@@ -7574,7 +7574,7 @@ return JaktInternal::ExplicitValue<void>();
 case 90 /* Private */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Private;utility::Span const& span = __jakt_match_value.value;
 {
-TRY((((*this).error_with_hint(TRY(ByteString::from_utf8("Expected 'function' keyword inside trait definition"sv)),span,TRY((__jakt_format((StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv)),((parsed_trait).name)))),((parsed_trait).name_span)))));
+TRY((((*this).error_with_hint((ByteString::must_from_utf8("Expected 'function' keyword inside trait definition"sv)),span,TRY((__jakt_format((StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv)),((parsed_trait).name)))),((parsed_trait).name_span)))));
 return parsed_trait;
 }
 return JaktInternal::ExplicitValue<void>();
@@ -7582,7 +7582,7 @@ return JaktInternal::ExplicitValue<void>();
 case 91 /* Public */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Public;utility::Span const& span = __jakt_match_value.value;
 {
-TRY((((*this).error_with_hint(TRY(ByteString::from_utf8("Expected 'function' keyword inside trait definition"sv)),span,TRY((__jakt_format((StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv)),((parsed_trait).name)))),((parsed_trait).name_span)))));
+TRY((((*this).error_with_hint((ByteString::must_from_utf8("Expected 'function' keyword inside trait definition"sv)),span,TRY((__jakt_format((StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv)),((parsed_trait).name)))),((parsed_trait).name_span)))));
 return parsed_trait;
 }
 return JaktInternal::ExplicitValue<void>();
@@ -7590,7 +7590,7 @@ return JaktInternal::ExplicitValue<void>();
 case 92 /* Raw */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Raw;utility::Span const& span = __jakt_match_value.value;
 {
-TRY((((*this).error_with_hint(TRY(ByteString::from_utf8("Expected 'function' keyword inside trait definition"sv)),span,TRY((__jakt_format((StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv)),((parsed_trait).name)))),((parsed_trait).name_span)))));
+TRY((((*this).error_with_hint((ByteString::must_from_utf8("Expected 'function' keyword inside trait definition"sv)),span,TRY((__jakt_format((StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv)),((parsed_trait).name)))),((parsed_trait).name_span)))));
 return parsed_trait;
 }
 return JaktInternal::ExplicitValue<void>();
@@ -7598,7 +7598,7 @@ return JaktInternal::ExplicitValue<void>();
 case 93 /* Reflect */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Reflect;utility::Span const& span = __jakt_match_value.value;
 {
-TRY((((*this).error_with_hint(TRY(ByteString::from_utf8("Expected 'function' keyword inside trait definition"sv)),span,TRY((__jakt_format((StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv)),((parsed_trait).name)))),((parsed_trait).name_span)))));
+TRY((((*this).error_with_hint((ByteString::must_from_utf8("Expected 'function' keyword inside trait definition"sv)),span,TRY((__jakt_format((StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv)),((parsed_trait).name)))),((parsed_trait).name_span)))));
 return parsed_trait;
 }
 return JaktInternal::ExplicitValue<void>();
@@ -7606,7 +7606,7 @@ return JaktInternal::ExplicitValue<void>();
 case 94 /* Return */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Return;utility::Span const& span = __jakt_match_value.value;
 {
-TRY((((*this).error_with_hint(TRY(ByteString::from_utf8("Expected 'function' keyword inside trait definition"sv)),span,TRY((__jakt_format((StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv)),((parsed_trait).name)))),((parsed_trait).name_span)))));
+TRY((((*this).error_with_hint((ByteString::must_from_utf8("Expected 'function' keyword inside trait definition"sv)),span,TRY((__jakt_format((StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv)),((parsed_trait).name)))),((parsed_trait).name_span)))));
 return parsed_trait;
 }
 return JaktInternal::ExplicitValue<void>();
@@ -7614,7 +7614,7 @@ return JaktInternal::ExplicitValue<void>();
 case 95 /* Restricted */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Restricted;utility::Span const& span = __jakt_match_value.value;
 {
-TRY((((*this).error_with_hint(TRY(ByteString::from_utf8("Expected 'function' keyword inside trait definition"sv)),span,TRY((__jakt_format((StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv)),((parsed_trait).name)))),((parsed_trait).name_span)))));
+TRY((((*this).error_with_hint((ByteString::must_from_utf8("Expected 'function' keyword inside trait definition"sv)),span,TRY((__jakt_format((StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv)),((parsed_trait).name)))),((parsed_trait).name_span)))));
 return parsed_trait;
 }
 return JaktInternal::ExplicitValue<void>();
@@ -7622,7 +7622,7 @@ return JaktInternal::ExplicitValue<void>();
 case 96 /* Sizeof */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Sizeof;utility::Span const& span = __jakt_match_value.value;
 {
-TRY((((*this).error_with_hint(TRY(ByteString::from_utf8("Expected 'function' keyword inside trait definition"sv)),span,TRY((__jakt_format((StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv)),((parsed_trait).name)))),((parsed_trait).name_span)))));
+TRY((((*this).error_with_hint((ByteString::must_from_utf8("Expected 'function' keyword inside trait definition"sv)),span,TRY((__jakt_format((StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv)),((parsed_trait).name)))),((parsed_trait).name_span)))));
 return parsed_trait;
 }
 return JaktInternal::ExplicitValue<void>();
@@ -7630,7 +7630,7 @@ return JaktInternal::ExplicitValue<void>();
 case 97 /* Struct */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Struct;utility::Span const& span = __jakt_match_value.value;
 {
-TRY((((*this).error_with_hint(TRY(ByteString::from_utf8("Expected 'function' keyword inside trait definition"sv)),span,TRY((__jakt_format((StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv)),((parsed_trait).name)))),((parsed_trait).name_span)))));
+TRY((((*this).error_with_hint((ByteString::must_from_utf8("Expected 'function' keyword inside trait definition"sv)),span,TRY((__jakt_format((StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv)),((parsed_trait).name)))),((parsed_trait).name_span)))));
 return parsed_trait;
 }
 return JaktInternal::ExplicitValue<void>();
@@ -7638,7 +7638,7 @@ return JaktInternal::ExplicitValue<void>();
 case 98 /* This */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.This;utility::Span const& span = __jakt_match_value.value;
 {
-TRY((((*this).error_with_hint(TRY(ByteString::from_utf8("Expected 'function' keyword inside trait definition"sv)),span,TRY((__jakt_format((StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv)),((parsed_trait).name)))),((parsed_trait).name_span)))));
+TRY((((*this).error_with_hint((ByteString::must_from_utf8("Expected 'function' keyword inside trait definition"sv)),span,TRY((__jakt_format((StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv)),((parsed_trait).name)))),((parsed_trait).name_span)))));
 return parsed_trait;
 }
 return JaktInternal::ExplicitValue<void>();
@@ -7646,7 +7646,7 @@ return JaktInternal::ExplicitValue<void>();
 case 99 /* Throw */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Throw;utility::Span const& span = __jakt_match_value.value;
 {
-TRY((((*this).error_with_hint(TRY(ByteString::from_utf8("Expected 'function' keyword inside trait definition"sv)),span,TRY((__jakt_format((StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv)),((parsed_trait).name)))),((parsed_trait).name_span)))));
+TRY((((*this).error_with_hint((ByteString::must_from_utf8("Expected 'function' keyword inside trait definition"sv)),span,TRY((__jakt_format((StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv)),((parsed_trait).name)))),((parsed_trait).name_span)))));
 return parsed_trait;
 }
 return JaktInternal::ExplicitValue<void>();
@@ -7654,7 +7654,7 @@ return JaktInternal::ExplicitValue<void>();
 case 100 /* Throws */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Throws;utility::Span const& span = __jakt_match_value.value;
 {
-TRY((((*this).error_with_hint(TRY(ByteString::from_utf8("Expected 'function' keyword inside trait definition"sv)),span,TRY((__jakt_format((StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv)),((parsed_trait).name)))),((parsed_trait).name_span)))));
+TRY((((*this).error_with_hint((ByteString::must_from_utf8("Expected 'function' keyword inside trait definition"sv)),span,TRY((__jakt_format((StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv)),((parsed_trait).name)))),((parsed_trait).name_span)))));
 return parsed_trait;
 }
 return JaktInternal::ExplicitValue<void>();
@@ -7662,7 +7662,7 @@ return JaktInternal::ExplicitValue<void>();
 case 101 /* True */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.True;utility::Span const& span = __jakt_match_value.value;
 {
-TRY((((*this).error_with_hint(TRY(ByteString::from_utf8("Expected 'function' keyword inside trait definition"sv)),span,TRY((__jakt_format((StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv)),((parsed_trait).name)))),((parsed_trait).name_span)))));
+TRY((((*this).error_with_hint((ByteString::must_from_utf8("Expected 'function' keyword inside trait definition"sv)),span,TRY((__jakt_format((StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv)),((parsed_trait).name)))),((parsed_trait).name_span)))));
 return parsed_trait;
 }
 return JaktInternal::ExplicitValue<void>();
@@ -7670,7 +7670,7 @@ return JaktInternal::ExplicitValue<void>();
 case 102 /* Try */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Try;utility::Span const& span = __jakt_match_value.value;
 {
-TRY((((*this).error_with_hint(TRY(ByteString::from_utf8("Expected 'function' keyword inside trait definition"sv)),span,TRY((__jakt_format((StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv)),((parsed_trait).name)))),((parsed_trait).name_span)))));
+TRY((((*this).error_with_hint((ByteString::must_from_utf8("Expected 'function' keyword inside trait definition"sv)),span,TRY((__jakt_format((StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv)),((parsed_trait).name)))),((parsed_trait).name_span)))));
 return parsed_trait;
 }
 return JaktInternal::ExplicitValue<void>();
@@ -7678,7 +7678,7 @@ return JaktInternal::ExplicitValue<void>();
 case 103 /* Unsafe */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Unsafe;utility::Span const& span = __jakt_match_value.value;
 {
-TRY((((*this).error_with_hint(TRY(ByteString::from_utf8("Expected 'function' keyword inside trait definition"sv)),span,TRY((__jakt_format((StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv)),((parsed_trait).name)))),((parsed_trait).name_span)))));
+TRY((((*this).error_with_hint((ByteString::must_from_utf8("Expected 'function' keyword inside trait definition"sv)),span,TRY((__jakt_format((StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv)),((parsed_trait).name)))),((parsed_trait).name_span)))));
 return parsed_trait;
 }
 return JaktInternal::ExplicitValue<void>();
@@ -7686,7 +7686,7 @@ return JaktInternal::ExplicitValue<void>();
 case 104 /* Virtual */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Virtual;utility::Span const& span = __jakt_match_value.value;
 {
-TRY((((*this).error_with_hint(TRY(ByteString::from_utf8("Expected 'function' keyword inside trait definition"sv)),span,TRY((__jakt_format((StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv)),((parsed_trait).name)))),((parsed_trait).name_span)))));
+TRY((((*this).error_with_hint((ByteString::must_from_utf8("Expected 'function' keyword inside trait definition"sv)),span,TRY((__jakt_format((StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv)),((parsed_trait).name)))),((parsed_trait).name_span)))));
 return parsed_trait;
 }
 return JaktInternal::ExplicitValue<void>();
@@ -7694,7 +7694,7 @@ return JaktInternal::ExplicitValue<void>();
 case 105 /* Weak */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Weak;utility::Span const& span = __jakt_match_value.value;
 {
-TRY((((*this).error_with_hint(TRY(ByteString::from_utf8("Expected 'function' keyword inside trait definition"sv)),span,TRY((__jakt_format((StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv)),((parsed_trait).name)))),((parsed_trait).name_span)))));
+TRY((((*this).error_with_hint((ByteString::must_from_utf8("Expected 'function' keyword inside trait definition"sv)),span,TRY((__jakt_format((StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv)),((parsed_trait).name)))),((parsed_trait).name_span)))));
 return parsed_trait;
 }
 return JaktInternal::ExplicitValue<void>();
@@ -7702,7 +7702,7 @@ return JaktInternal::ExplicitValue<void>();
 case 106 /* While */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.While;utility::Span const& span = __jakt_match_value.value;
 {
-TRY((((*this).error_with_hint(TRY(ByteString::from_utf8("Expected 'function' keyword inside trait definition"sv)),span,TRY((__jakt_format((StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv)),((parsed_trait).name)))),((parsed_trait).name_span)))));
+TRY((((*this).error_with_hint((ByteString::must_from_utf8("Expected 'function' keyword inside trait definition"sv)),span,TRY((__jakt_format((StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv)),((parsed_trait).name)))),((parsed_trait).name_span)))));
 return parsed_trait;
 }
 return JaktInternal::ExplicitValue<void>();
@@ -7710,7 +7710,7 @@ return JaktInternal::ExplicitValue<void>();
 case 107 /* Yield */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Yield;utility::Span const& span = __jakt_match_value.value;
 {
-TRY((((*this).error_with_hint(TRY(ByteString::from_utf8("Expected 'function' keyword inside trait definition"sv)),span,TRY((__jakt_format((StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv)),((parsed_trait).name)))),((parsed_trait).name_span)))));
+TRY((((*this).error_with_hint((ByteString::must_from_utf8("Expected 'function' keyword inside trait definition"sv)),span,TRY((__jakt_format((StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv)),((parsed_trait).name)))),((parsed_trait).name_span)))));
 return parsed_trait;
 }
 return JaktInternal::ExplicitValue<void>();
@@ -7718,7 +7718,7 @@ return JaktInternal::ExplicitValue<void>();
 case 108 /* Guard */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Guard;utility::Span const& span = __jakt_match_value.value;
 {
-TRY((((*this).error_with_hint(TRY(ByteString::from_utf8("Expected 'function' keyword inside trait definition"sv)),span,TRY((__jakt_format((StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv)),((parsed_trait).name)))),((parsed_trait).name_span)))));
+TRY((((*this).error_with_hint((ByteString::must_from_utf8("Expected 'function' keyword inside trait definition"sv)),span,TRY((__jakt_format((StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv)),((parsed_trait).name)))),((parsed_trait).name_span)))));
 return parsed_trait;
 }
 return JaktInternal::ExplicitValue<void>();
@@ -7726,7 +7726,7 @@ return JaktInternal::ExplicitValue<void>();
 case 109 /* Implements */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Implements;utility::Span const& span = __jakt_match_value.value;
 {
-TRY((((*this).error_with_hint(TRY(ByteString::from_utf8("Expected 'function' keyword inside trait definition"sv)),span,TRY((__jakt_format((StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv)),((parsed_trait).name)))),((parsed_trait).name_span)))));
+TRY((((*this).error_with_hint((ByteString::must_from_utf8("Expected 'function' keyword inside trait definition"sv)),span,TRY((__jakt_format((StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv)),((parsed_trait).name)))),((parsed_trait).name_span)))));
 return parsed_trait;
 }
 return JaktInternal::ExplicitValue<void>();
@@ -7734,7 +7734,7 @@ return JaktInternal::ExplicitValue<void>();
 case 110 /* Requires */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Requires;utility::Span const& span = __jakt_match_value.value;
 {
-TRY((((*this).error_with_hint(TRY(ByteString::from_utf8("Expected 'function' keyword inside trait definition"sv)),span,TRY((__jakt_format((StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv)),((parsed_trait).name)))),((parsed_trait).name_span)))));
+TRY((((*this).error_with_hint((ByteString::must_from_utf8("Expected 'function' keyword inside trait definition"sv)),span,TRY((__jakt_format((StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv)),((parsed_trait).name)))),((parsed_trait).name_span)))));
 return parsed_trait;
 }
 return JaktInternal::ExplicitValue<void>();
@@ -7742,7 +7742,7 @@ return JaktInternal::ExplicitValue<void>();
 case 111 /* Trait */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Trait;utility::Span const& span = __jakt_match_value.value;
 {
-TRY((((*this).error_with_hint(TRY(ByteString::from_utf8("Expected 'function' keyword inside trait definition"sv)),span,TRY((__jakt_format((StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv)),((parsed_trait).name)))),((parsed_trait).name_span)))));
+TRY((((*this).error_with_hint((ByteString::must_from_utf8("Expected 'function' keyword inside trait definition"sv)),span,TRY((__jakt_format((StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv)),((parsed_trait).name)))),((parsed_trait).name_span)))));
 return parsed_trait;
 }
 return JaktInternal::ExplicitValue<void>();
@@ -7750,7 +7750,7 @@ return JaktInternal::ExplicitValue<void>();
 case 112 /* Garbage */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Garbage;utility::Span const& span = __jakt_match_value.span;
 {
-TRY((((*this).error_with_hint(TRY(ByteString::from_utf8("Expected 'function' keyword inside trait definition"sv)),span,TRY((__jakt_format((StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv)),((parsed_trait).name)))),((parsed_trait).name_span)))));
+TRY((((*this).error_with_hint((ByteString::must_from_utf8("Expected 'function' keyword inside trait definition"sv)),span,TRY((__jakt_format((StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv)),((parsed_trait).name)))),((parsed_trait).name_span)))));
 return parsed_trait;
 }
 return JaktInternal::ExplicitValue<void>();
@@ -7781,7 +7781,7 @@ return JaktInternal::ExplicitValue<void>();
 };/*case end*/
 default: {
 {
-TRY((((*this).error(TRY(ByteString::from_utf8("Expected '{' to enter the body of the trait, or '=' to specify trait requirements"sv)),((((*this).current())).span())))));
+TRY((((*this).error((ByteString::must_from_utf8("Expected '{' to enter the body of the trait, or '=' to specify trait requirements"sv)),((((*this).current())).span())))));
 return parsed_trait;
 }
 return JaktInternal::ExplicitValue<void>();
@@ -7796,7 +7796,7 @@ return JaktInternal::ExplicitValue<void>();
 return parsed_trait;
 }
 else {
-TRY((((*this).error(TRY(ByteString::from_utf8("Expected trait name"sv)),((((*this).current())).span())))));
+TRY((((*this).error((ByteString::must_from_utf8("Expected trait name"sv)),((((*this).current())).span())))));
 return parsed_trait;
 }
 
@@ -7811,7 +7811,7 @@ if (((((*this).current())).__jakt_init_index() == 7 /* LParen */)){
 ((((*this).index)++));
 }
 else {
-TRY((((*this).error(TRY(ByteString::from_utf8("Expected ‘(’"sv)),((((*this).current())).span())))));
+TRY((((*this).error((ByteString::must_from_utf8("Expected ‘(’"sv)),((((*this).current())).span())))));
 return parser::Visibility::Restricted((TRY((DynamicArray<parser::VisibilityRestriction>::create_with({})))),restricted_span);
 }
 
@@ -7845,7 +7845,7 @@ if (expect_comma){
 (expect_comma = false);
 }
 else {
-TRY((((*this).error(TRY(ByteString::from_utf8("Unexpected comma"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("Unexpected comma"sv)),span))));
 }
 
 ((((*this).index)++));
@@ -7855,7 +7855,7 @@ return JaktInternal::ExplicitValue<void>();
 default: {
 {
 if (expect_comma){
-TRY((((*this).error(TRY(ByteString::from_utf8("Expected comma"sv)),((((*this).current())).span())))));
+TRY((((*this).error((ByteString::must_from_utf8("Expected comma"sv)),((((*this).current())).span())))));
 }
 ((*this).skip_newlines());
 JaktInternal::DynamicArray<ByteString> names = (TRY((DynamicArray<ByteString>::create_with({}))));
@@ -7878,7 +7878,7 @@ break;
 
 }
 if (((names).is_empty())){
-TRY((((*this).error(TRY(ByteString::from_utf8("Expected identifier"sv)),((((*this).current())).span())))));
+TRY((((*this).error((ByteString::must_from_utf8("Expected identifier"sv)),((((*this).current())).span())))));
 }
 else {
 ByteString const name = (((names).pop()).value());
@@ -7903,13 +7903,13 @@ return JaktInternal::ExplicitValue<void>();
 }
 (((restricted_span).end) = ((((((*this).current())).span())).end));
 if (((whitelist).is_empty())){
-TRY((((*this).error_with_hint(TRY(ByteString::from_utf8("Restriction list cannot be empty"sv)),restricted_span,TRY(ByteString::from_utf8("Did you mean to use ‘private’ instead of ‘restricted’?"sv)),restricted_span))));
+TRY((((*this).error_with_hint((ByteString::must_from_utf8("Restriction list cannot be empty"sv)),restricted_span,(ByteString::must_from_utf8("Did you mean to use ‘private’ instead of ‘restricted’?"sv)),restricted_span))));
 }
 if (((((*this).current())).__jakt_init_index() == 8 /* RParen */)){
 ((((*this).index)++));
 }
 else {
-TRY((((*this).error(TRY(ByteString::from_utf8("Expected ‘)’"sv)),((((*this).current())).span())))));
+TRY((((*this).error((ByteString::must_from_utf8("Expected ‘)’"sv)),((((*this).current())).span())))));
 }
 
 return parser::Visibility::Restricted(whitelist,restricted_span);
@@ -7947,7 +7947,7 @@ return JaktInternal::ExplicitValue<void>();
 };/*case end*/
 default: {
 {
-TRY((((*this).error(TRY(ByteString::from_utf8("Expected close of destructuring assignment block"sv)),((((*this).current())).span())))));
+TRY((((*this).error((ByteString::must_from_utf8("Expected close of destructuring assignment block"sv)),((((*this).current())).span())))));
 (var_declarations = (TRY((DynamicArray<parser::ParsedVarDecl>::create_with({})))));
 return JaktInternal::LoopBreak{};
 }
@@ -8079,7 +8079,7 @@ __jakt_label_55:; __jakt_var_60.release_value(); }));
 };/*case end*/
 default: {
 return JaktInternal::ExplicitValue(({ Optional<parser::TypeCast> __jakt_var_61; {
-TRY((((*this).error_with_hint(TRY(ByteString::from_utf8("Invalid cast syntax"sv)),cast_span,TRY(ByteString::from_utf8("Use `as!` for an infallible cast, or `as?` for a fallible cast"sv)),((((*this).previous())).span())))));
+TRY((((*this).error_with_hint((ByteString::must_from_utf8("Invalid cast syntax"sv)),cast_span,(ByteString::must_from_utf8("Use `as!` for an infallible cast, or `as?` for a fallible cast"sv)),((((*this).previous())).span())))));
 __jakt_var_61 = parser::TypeCast::Fallible(TRY((((*this).parse_typename())))); goto __jakt_label_56;
 
 }
@@ -8131,7 +8131,7 @@ bool const is_optional = ((((*this).current())).__jakt_init_index() == 49 /* Que
 if (is_optional){
 ((((*this).index)++));
 if ((!(((((*this).current())).__jakt_init_index() == 53 /* Dot */)))){
-TRY((((*this).error(TRY(ByteString::from_utf8("Expected ‘.’ after ‘?’ for optional chaining access"sv)),((((*this).current())).span())))));
+TRY((((*this).error((ByteString::must_from_utf8("Expected ‘.’ after ‘?’ for optional chaining access"sv)),((((*this).current())).span())))));
 }
 }
 ((((*this).index)++));
@@ -8160,7 +8160,7 @@ __jakt_label_60:; __jakt_var_65.release_value(); }));
 }
 else {
 {
-TRY((((*this).error(TRY(ByteString::from_utf8("Invalid Numeric Constant"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("Invalid Numeric Constant"sv)),span))));
 return expr;
 }
 }
@@ -8251,7 +8251,7 @@ return JaktInternal::ExplicitValue(({ Optional<NonnullRefPtr<typename parser::Pa
 ((((*this).index)++));
 NonnullRefPtr<typename parser::ParsedExpression> const index = TRY((((*this).parse_expression(false,false))));
 if ((!(((((*this).current())).__jakt_init_index() == 12 /* RSquare */)))){
-TRY((((*this).error(TRY(ByteString::from_utf8("Expected ‘]’ to close the index"sv)),((((*this).current())).span())))));
+TRY((((*this).error((ByteString::must_from_utf8("Expected ‘]’ to close the index"sv)),((((*this).current())).span())))));
 }
 ((((*this).index)++));
 __jakt_var_70 = TRY((parser::ParsedExpression::ComptimeIndex(result,index,is_optional,TRY((parser::merge_spans(start,((((*this).previous())).span()))))))); goto __jakt_label_65;
@@ -8261,7 +8261,7 @@ __jakt_label_65:; __jakt_var_70.release_value(); }));
 };/*case end*/
 default: {
 return JaktInternal::ExplicitValue(({ Optional<NonnullRefPtr<typename parser::ParsedExpression>> __jakt_var_71; {
-TRY((((*this).error(TRY(ByteString::from_utf8("Unsupported dot operation"sv)),((((*this).current())).span())))));
+TRY((((*this).error((ByteString::must_from_utf8("Unsupported dot operation"sv)),((((*this).current())).span())))));
 ((((*this).index)++));
 __jakt_var_71 = result; goto __jakt_label_66;
 
@@ -8289,7 +8289,7 @@ bool const is_optional = ((((*this).current())).__jakt_init_index() == 49 /* Que
 if (is_optional){
 ((((*this).index)++));
 if ((!(((((*this).current())).__jakt_init_index() == 53 /* Dot */)))){
-TRY((((*this).error(TRY(ByteString::from_utf8("Expected ‘.’ after ‘?’ for optional chaining access"sv)),((((*this).current())).span())))));
+TRY((((*this).error((ByteString::must_from_utf8("Expected ‘.’ after ‘?’ for optional chaining access"sv)),((((*this).current())).span())))));
 }
 }
 ((((*this).index)++));
@@ -8318,7 +8318,7 @@ __jakt_label_69:; __jakt_var_74.release_value(); }));
 }
 else {
 {
-TRY((((*this).error(TRY(ByteString::from_utf8("Invalid Numeric Constant"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("Invalid Numeric Constant"sv)),span))));
 return expr;
 }
 }
@@ -8409,7 +8409,7 @@ return JaktInternal::ExplicitValue(({ Optional<NonnullRefPtr<typename parser::Pa
 ((((*this).index)++));
 NonnullRefPtr<typename parser::ParsedExpression> const index = TRY((((*this).parse_expression(false,false))));
 if ((!(((((*this).current())).__jakt_init_index() == 12 /* RSquare */)))){
-TRY((((*this).error(TRY(ByteString::from_utf8("Expected ‘]’ to close the index"sv)),((((*this).current())).span())))));
+TRY((((*this).error((ByteString::must_from_utf8("Expected ‘]’ to close the index"sv)),((((*this).current())).span())))));
 }
 ((((*this).index)++));
 __jakt_var_79 = TRY((parser::ParsedExpression::ComptimeIndex(result,index,is_optional,TRY((parser::merge_spans(start,((((*this).previous())).span()))))))); goto __jakt_label_74;
@@ -8419,7 +8419,7 @@ __jakt_label_74:; __jakt_var_79.release_value(); }));
 };/*case end*/
 default: {
 return JaktInternal::ExplicitValue(({ Optional<NonnullRefPtr<typename parser::ParsedExpression>> __jakt_var_80; {
-TRY((((*this).error(TRY(ByteString::from_utf8("Unsupported dot operation"sv)),((((*this).current())).span())))));
+TRY((((*this).error((ByteString::must_from_utf8("Unsupported dot operation"sv)),((((*this).current())).span())))));
 ((((*this).index)++));
 __jakt_var_80 = result; goto __jakt_label_75;
 
@@ -8449,7 +8449,7 @@ if (((((*this).current())).__jakt_init_index() == 12 /* RSquare */)){
 ((((*this).index)++));
 }
 else {
-TRY((((*this).error(TRY(ByteString::from_utf8("Expected ']'"sv)),((((*this).current())).span())))));
+TRY((((*this).error((ByteString::must_from_utf8("Expected ']'"sv)),((((*this).current())).span())))));
 }
 
 size_t const end = JaktInternal::checked_sub(((*this).index),static_cast<size_t>(1ULL));
@@ -8483,7 +8483,7 @@ ErrorOr<NonnullRefPtr<typename parser::ParsedExpression>> parser::Parser::parse_
 {
 utility::Span const start = ((((*this).current())).span());
 if ((!(((((*this).current())).__jakt_init_index() == 9 /* LCurly */)))){
-TRY((((*this).error(TRY(ByteString::from_utf8("Expected ‘{’"sv)),((((*this).current())).span())))));
+TRY((((*this).error((ByteString::must_from_utf8("Expected ‘{’"sv)),((((*this).current())).span())))));
 return TRY((parser::ParsedExpression::Garbage(((((*this).current())).span()))));
 }
 ((((*this).index)++));
@@ -8546,7 +8546,7 @@ return (infallible_enum_cast<jakt__prelude__operators::Ordering>((JaktInternal::
 }
 }
 (end,((((*this).tokens)).size())) || (!(((((((*this).tokens))[end])).__jakt_init_index() == 10 /* RCurly */))))){
-TRY((((*this).error(TRY(ByteString::from_utf8("Expected ‘}’ to close the set"sv)),((((((*this).tokens))[end])).span())))));
+TRY((((*this).error((ByteString::must_from_utf8("Expected ‘}’ to close the set"sv)),((((((*this).tokens))[end])).span())))));
 }
 return TRY((parser::ParsedExpression::Set(output,TRY((parser::merge_spans(start,((((((*this).tokens))[end])).span())))))));
 }
@@ -8564,7 +8564,7 @@ if ((((((*this).current())).__jakt_init_index() == 12 /* RSquare */) && ((((*thi
 ((((*this).index)) += (static_cast<size_t>(2ULL)));
 }
 else {
-TRY((((*this).error(TRY(ByteString::from_utf8("Expected ‘]]’"sv)),((((*this).current())).span())))));
+TRY((((*this).error((ByteString::must_from_utf8("Expected ‘]]’"sv)),((((*this).current())).span())))));
 }
 
 }
@@ -8654,7 +8654,7 @@ return JaktInternal::ExplicitValue<void>();
 };/*case end*/
 default: {
 {
-TRY((((((*this).compiler))->panic(TRY(ByteString::from_utf8("operator is not an operator"sv))))));
+TRY((((((*this).compiler))->panic((ByteString::must_from_utf8("operator is not an operator"sv))))));
 }
 return JaktInternal::ExplicitValue<void>();
 };/*case end*/
@@ -8703,7 +8703,7 @@ return JaktInternal::ExplicitValue<void>();
 };/*case end*/
 default: {
 {
-TRY((((((*this).compiler))->panic(TRY(ByteString::from_utf8("operator is not an operator"sv))))));
+TRY((((((*this).compiler))->panic((ByteString::must_from_utf8("operator is not an operator"sv))))));
 }
 return JaktInternal::ExplicitValue<void>();
 };/*case end*/
@@ -8777,7 +8777,7 @@ return JaktInternal::ExplicitValue(parser::BinaryOperator::BitwiseAnd());
 };/*case end*/
 case 39 /* AmpersandAmpersand */: {
 return JaktInternal::ExplicitValue(({ Optional<parser::BinaryOperator> __jakt_var_82; {
-TRY((((*this).error(TRY(ByteString::from_utf8("‘&&’ is not allowed, use ‘and’ instead"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("‘&&’ is not allowed, use ‘and’ instead"sv)),span))));
 __jakt_var_82 = parser::BinaryOperator::LogicalAnd(); goto __jakt_label_77;
 
 }
@@ -8788,7 +8788,7 @@ return JaktInternal::ExplicitValue(parser::BinaryOperator::BitwiseOr());
 };/*case end*/
 case 42 /* PipePipe */: {
 return JaktInternal::ExplicitValue(({ Optional<parser::BinaryOperator> __jakt_var_83; {
-TRY((((*this).error(TRY(ByteString::from_utf8("‘||’ is not allowed, use ‘or’ instead"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("‘||’ is not allowed, use ‘or’ instead"sv)),span))));
 __jakt_var_83 = parser::BinaryOperator::LogicalOr(); goto __jakt_label_78;
 
 }
@@ -8859,7 +8859,7 @@ return TRY((parser::ParsedExpression::Garbage(span)));
 });
 ((((*this).index)++));
 if (((!(allow_assignments)) && ((op).is_assignment()))){
-TRY((((*this).error(TRY(ByteString::from_utf8("Assignment is not allowed in this position"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("Assignment is not allowed in this position"sv)),span))));
 return TRY((parser::ParsedExpression::Operator(op,span)));
 }
 return TRY((parser::ParsedExpression::Operator(op,span)));
@@ -8870,7 +8870,7 @@ ErrorOr<NonnullRefPtr<typename parser::ParsedStatement>> parser::Parser::parse_f
 {
 utility::Span const start_span = ((((*this).current())).span());
 ((((*this).index)++));
-ByteString iterator_name = TRY(ByteString::from_utf8(""sv));
+ByteString iterator_name = (ByteString::must_from_utf8(""sv));
 JaktInternal::DynamicArray<parser::ParsedVarDecl> destructured_var_decls = (TRY((DynamicArray<parser::ParsedVarDecl>::create_with({}))));
 utility::Span name_span = ((((*this).current())).span());
 ({
@@ -8889,7 +8889,7 @@ case 7 /* LParen */: {
 {
 parser::ParsedVarDeclTuple const destructured_assignment = TRY((((*this).parse_destructuring_assignment(false))));
 (destructured_var_decls = ((destructured_assignment).var_decls));
-ByteString tuple_var_name = TRY(ByteString::from_utf8(""sv));
+ByteString tuple_var_name = (ByteString::must_from_utf8(""sv));
 {
 JaktInternal::ArrayIterator<parser::ParsedVarDecl> _magic = ((destructured_var_decls).iterator());
 for (;;){
@@ -8912,7 +8912,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(tuple_var_name,TRY(ByteString::from_utf8("__"sv)))));
+(tuple_var_name,(ByteString::must_from_utf8("__"sv)))));
 }
 
 }
@@ -8925,7 +8925,7 @@ return JaktInternal::ExplicitValue<void>();
 };/*case end*/
 default: {
 {
-TRY((((*this).error(TRY(ByteString::from_utf8("Expected iterator name or destructuring pattern"sv)),((((*this).current())).span())))));
+TRY((((*this).error((ByteString::must_from_utf8("Expected iterator name or destructuring pattern"sv)),((((*this).current())).span())))));
 return TRY((parser::ParsedStatement::Garbage(TRY((parser::merge_spans(start_span,((((*this).current())).span())))))));
 }
 return JaktInternal::ExplicitValue<void>();
@@ -8941,7 +8941,7 @@ if (((((*this).current())).__jakt_init_index() == 80 /* In */)){
 ((((*this).index)++));
 }
 else {
-TRY((((*this).error(TRY(ByteString::from_utf8("Expected ‘in’"sv)),((((*this).current())).span())))));
+TRY((((*this).error((ByteString::must_from_utf8("Expected ‘in’"sv)),((((*this).current())).span())))));
 return TRY((parser::ParsedStatement::Garbage(TRY((parser::merge_spans(start_span,((((*this).current())).span())))))));
 }
 
@@ -8963,7 +8963,7 @@ return (infallible_enum_cast<jakt__prelude__operators::Ordering>((JaktInternal::
 }
 (((destructured_var_decls).size()),static_cast<size_t>(0ULL))){
 (is_destructuring = true);
-ByteString tuple_var_name = TRY(ByteString::from_utf8("jakt__"sv));
+ByteString tuple_var_name = (ByteString::must_from_utf8("jakt__"sv));
 TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 {
 (self = TRY((((self) + (rhs)))));
@@ -9005,7 +9005,7 @@ if (((((*this).current())).__jakt_init_index() == 85 /* Mut */)){
 }
 if (((((*this).current())).__jakt_init_index() == 3 /* Identifier */)){
 ByteString const name = (((*this).current())).as.Identifier.name;
-if (((name) == (TRY(ByteString::from_utf8("const"sv))))){
+if (((name) == ((ByteString::must_from_utf8("const"sv))))){
 (((qualifiers).is_immutable) = true);
 ((((*this).index)++));
 }
@@ -9062,12 +9062,12 @@ if (((((*this).current())).__jakt_init_index() == 9 /* LCurly */)){
 ((((*this).index)++));
 }
 else {
-TRY((((*this).error(TRY(ByteString::from_utf8("Expected `{` to start the enum body"sv)),((((*this).current())).span())))));
+TRY((((*this).error((ByteString::must_from_utf8("Expected `{` to start the enum body"sv)),((((*this).current())).span())))));
 }
 
 ((*this).skip_newlines());
 if (((*this).eof())){
-TRY((((*this).error(TRY(ByteString::from_utf8("Incomplete enum definition, expected variant or field name"sv)),((((*this).previous())).span())))));
+TRY((((*this).error((ByteString::must_from_utf8("Incomplete enum definition, expected variant or field name"sv)),((((*this).previous())).span())))));
 return (Tuple{variants, fields, methods, records});
 }
 JaktInternal::Optional<parser::Visibility> last_visibility = JaktInternal::OptionalNone();
@@ -9082,7 +9082,7 @@ switch(__jakt_match_variant.__jakt_init_index()) {
 case 72 /* Extern */: {
 {
 if (last_extern){
-TRY((((*this).error(TRY(ByteString::from_utf8("Multiple extern modifiers are not allowed"sv)),((((*this).current())).span())))));
+TRY((((*this).error((ByteString::must_from_utf8("Multiple extern modifiers are not allowed"sv)),((((*this).current())).span())))));
 }
 (last_extern = true);
 ((((*this).index)++));
@@ -9094,17 +9094,17 @@ auto&& __jakt_match_value = __jakt_match_variant.as.Identifier;ByteString const&
 utility::Span const& span = __jakt_match_value.span;
 {
 if (last_extern){
-TRY((((*this).error(TRY(ByteString::from_utf8("An enum variant or common field cannot be extern"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("An enum variant or common field cannot be extern"sv)),span))));
 (last_extern = false);
 }
 if ((!(((active_attributes).is_empty())))){
-TRY((((*this).error(TRY(ByteString::from_utf8("An enum variant or common field cannot have attributes"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("An enum variant or common field cannot have attributes"sv)),span))));
 (active_attributes = (TRY((DynamicArray<parser::ParsedAttribute>::create_with({})))));
 }
 if (((((*this).peek(static_cast<size_t>(1ULL)))).__jakt_init_index() == 5 /* Colon */)){
 parser::ParsedField const field = TRY((((*this).parse_field(last_visibility.value_or_lazy_evaluated([&] { return parser::Visibility::Public(); })))));
 if (seen_a_variant){
-TRY((((*this).error_with_hint(TRY(ByteString::from_utf8("Common enum fields must be declared before variants"sv)),span,TRY(ByteString::from_utf8("Previous variant is here"sv)),(((((variants).last()).value())).span)))));
+TRY((((*this).error_with_hint((ByteString::must_from_utf8("Common enum fields must be declared before variants"sv)),span,(ByteString::must_from_utf8("Previous variant is here"sv)),(((((variants).last()).value())).span)))));
 }
 else {
 TRY((((fields).push(field))));
@@ -9130,14 +9130,14 @@ ByteString const name = (((var_decl).parsed_type))->as.Name.name;
 utility::Span const span = (((var_decl).parsed_type))->as.Name.span;
 (((var_decl).inlay_span) = span);
 if ((((name) == (((partial_enum).name))) && (!(is_boxed)))){
-TRY((((*this).error(TRY(ByteString::from_utf8("use 'boxed enum' to make the enum recursive"sv)),((var_decl).span)))));
+TRY((((*this).error((ByteString::must_from_utf8("use 'boxed enum' to make the enum recursive"sv)),((var_decl).span)))));
 }
 }
 TRY((((var_decls).push(var_decl))));
 continue;
 }
 else {
-TRY((((*this).error(TRY(ByteString::from_utf8("Enum variant missing type"sv)),((((*this).current())).span())))));
+TRY((((*this).error((ByteString::must_from_utf8("Enum variant missing type"sv)),((((*this).current())).span())))));
 ((((*this).index)++));
 continue;
 }
@@ -9149,19 +9149,19 @@ auto&& __jakt_match_variant = ((*this).current());
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 3 /* Identifier */: {
 {
-TRY((((var_decls).push(parser::ParsedVarDecl(TRY(ByteString::from_utf8(""sv)),TRY((((*this).parse_typename()))),false,JaktInternal::OptionalNone(),((((*this).current())).span()),JaktInternal::OptionalNone())))));
+TRY((((var_decls).push(parser::ParsedVarDecl((ByteString::must_from_utf8(""sv)),TRY((((*this).parse_typename()))),false,JaktInternal::OptionalNone(),((((*this).current())).span()),JaktInternal::OptionalNone())))));
 }
 return JaktInternal::ExplicitValue<void>();
 };/*case end*/
 case 11 /* LSquare */: {
 {
-TRY((((var_decls).push(parser::ParsedVarDecl(TRY(ByteString::from_utf8(""sv)),TRY((((*this).parse_typename()))),false,JaktInternal::OptionalNone(),((((*this).current())).span()),JaktInternal::OptionalNone())))));
+TRY((((var_decls).push(parser::ParsedVarDecl((ByteString::must_from_utf8(""sv)),TRY((((*this).parse_typename()))),false,JaktInternal::OptionalNone(),((((*this).current())).span()),JaktInternal::OptionalNone())))));
 }
 return JaktInternal::ExplicitValue<void>();
 };/*case end*/
 case 9 /* LCurly */: {
 {
-TRY((((var_decls).push(parser::ParsedVarDecl(TRY(ByteString::from_utf8(""sv)),TRY((((*this).parse_typename()))),false,JaktInternal::OptionalNone(),((((*this).current())).span()),JaktInternal::OptionalNone())))));
+TRY((((var_decls).push(parser::ParsedVarDecl((ByteString::must_from_utf8(""sv)),TRY((((*this).parse_typename()))),false,JaktInternal::OptionalNone(),((((*this).current())).span()),JaktInternal::OptionalNone())))));
 }
 return JaktInternal::ExplicitValue<void>();
 };/*case end*/
@@ -9281,7 +9281,7 @@ if (((((*this).peek(static_cast<size_t>(1ULL)))).__jakt_init_index() == 11 /* LS
 TRY((((*this).parse_attribute_list(((active_attributes))))));
 }
 else {
-TRY((((*this).error(TRY(ByteString::from_utf8("Unexpected token (expected ‘[[’)"sv)),((((*this).current())).span())))));
+TRY((((*this).error((ByteString::must_from_utf8("Unexpected token (expected ‘[[’)"sv)),((((*this).current())).span())))));
 ((((*this).index)) += (static_cast<size_t>(1ULL)));
 }
 
@@ -9292,7 +9292,7 @@ case 90 /* Private */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Private;utility::Span const& span = __jakt_match_value.value;
 {
 if (((last_visibility).has_value())){
-TRY((((*this).error_with_hint(TRY(ByteString::from_utf8("Multiple visibility modifiers on one field or method are not allowed"sv)),span,TRY(ByteString::from_utf8("Previous modifier is here"sv)),(last_visibility_span.value())))));
+TRY((((*this).error_with_hint((ByteString::must_from_utf8("Multiple visibility modifiers on one field or method are not allowed"sv)),span,(ByteString::must_from_utf8("Previous modifier is here"sv)),(last_visibility_span.value())))));
 }
 (last_visibility = parser::Visibility::Private());
 (last_visibility_span = span);
@@ -9304,7 +9304,7 @@ case 91 /* Public */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Public;utility::Span const& span = __jakt_match_value.value;
 {
 if (((last_visibility).has_value())){
-TRY((((*this).error_with_hint(TRY(ByteString::from_utf8("Multiple visibility modifiers on one field or method are not allowed"sv)),span,TRY(ByteString::from_utf8("Previous modifier is here"sv)),(last_visibility_span.value())))));
+TRY((((*this).error_with_hint((ByteString::must_from_utf8("Multiple visibility modifiers on one field or method are not allowed"sv)),span,(ByteString::must_from_utf8("Previous modifier is here"sv)),(last_visibility_span.value())))));
 }
 (last_visibility = parser::Visibility::Public());
 (last_visibility_span = span);
@@ -9355,7 +9355,7 @@ VERIFY_NOT_REACHED();
     _jakt_value.release_value();
 });
 if ((((function_linkage).__jakt_init_index() == 1 /* External */) && is_comptime)){
-TRY((((*this).error(TRY(ByteString::from_utf8("External functions cannot be comptime"sv)),((((*this).current())).span())))));
+TRY((((*this).error((ByteString::must_from_utf8("External functions cannot be comptime"sv)),((((*this).current())).span())))));
 }
 parser::Visibility const visibility = last_visibility.value_or_lazy_evaluated([&] { return parser::Visibility::Public(); });
 (last_visibility = JaktInternal::OptionalNone());
@@ -9410,7 +9410,7 @@ VERIFY_NOT_REACHED();
     _jakt_value.release_value();
 });
 if ((((function_linkage).__jakt_init_index() == 1 /* External */) && is_comptime)){
-TRY((((*this).error(TRY(ByteString::from_utf8("External functions cannot be comptime"sv)),((((*this).current())).span())))));
+TRY((((*this).error((ByteString::must_from_utf8("External functions cannot be comptime"sv)),((((*this).current())).span())))));
 }
 parser::Visibility const visibility = last_visibility.value_or_lazy_evaluated([&] { return parser::Visibility::Public(); });
 (last_visibility = JaktInternal::OptionalNone());
@@ -9425,7 +9425,7 @@ return JaktInternal::ExplicitValue<void>();
 case 97 /* Struct */: {
 {
 if (((last_visibility).has_value())){
-TRY((((*this).error(TRY(ByteString::from_utf8("Nested types cannot have visibility modifiers"sv)),((((*this).current())).span())))));
+TRY((((*this).error((ByteString::must_from_utf8("Nested types cannot have visibility modifiers"sv)),((((*this).current())).span())))));
 (last_visibility = JaktInternal::OptionalNone());
 }
 parser::ParsedRecord parsed_record = TRY((((*this).parse_record(({
@@ -9456,7 +9456,7 @@ return JaktInternal::ExplicitValue<void>();
 case 71 /* Enum */: {
 {
 if (((last_visibility).has_value())){
-TRY((((*this).error(TRY(ByteString::from_utf8("Nested types cannot have visibility modifiers"sv)),((((*this).current())).span())))));
+TRY((((*this).error((ByteString::must_from_utf8("Nested types cannot have visibility modifiers"sv)),((((*this).current())).span())))));
 (last_visibility = JaktInternal::OptionalNone());
 }
 parser::ParsedRecord parsed_record = TRY((((*this).parse_record(({
@@ -9487,7 +9487,7 @@ return JaktInternal::ExplicitValue<void>();
 case 62 /* Boxed */: {
 {
 if (((last_visibility).has_value())){
-TRY((((*this).error(TRY(ByteString::from_utf8("Nested types cannot have visibility modifiers"sv)),((((*this).current())).span())))));
+TRY((((*this).error((ByteString::must_from_utf8("Nested types cannot have visibility modifiers"sv)),((((*this).current())).span())))));
 (last_visibility = JaktInternal::OptionalNone());
 }
 parser::ParsedRecord parsed_record = TRY((((*this).parse_record(({
@@ -9518,7 +9518,7 @@ return JaktInternal::ExplicitValue<void>();
 case 65 /* Class */: {
 {
 if (((last_visibility).has_value())){
-TRY((((*this).error(TRY(ByteString::from_utf8("Nested types cannot have visibility modifiers"sv)),((((*this).current())).span())))));
+TRY((((*this).error((ByteString::must_from_utf8("Nested types cannot have visibility modifiers"sv)),((((*this).current())).span())))));
 (last_visibility = JaktInternal::OptionalNone());
 }
 parser::ParsedRecord parsed_record = TRY((((*this).parse_record(({
@@ -9548,7 +9548,7 @@ return JaktInternal::ExplicitValue<void>();
 };/*case end*/
 default: {
 {
-TRY((((*this).error(TRY(ByteString::from_utf8("Expected identifier or the end of enum block"sv)),((((*this).current())).span())))));
+TRY((((*this).error((ByteString::must_from_utf8("Expected identifier or the end of enum block"sv)),((((*this).current())).span())))));
 ((((*this).index)++));
 }
 return JaktInternal::ExplicitValue<void>();
@@ -9566,12 +9566,12 @@ return JaktInternal::ExplicitValue<void>();
 });
 }
 if ((!(((((*this).current())).__jakt_init_index() == 10 /* RCurly */)))){
-TRY((((*this).error(TRY(ByteString::from_utf8("Invalid enum definition, expected `}`"sv)),((((*this).current())).span())))));
+TRY((((*this).error((ByteString::must_from_utf8("Invalid enum definition, expected `}`"sv)),((((*this).current())).span())))));
 return (Tuple{variants, fields, methods, records});
 }
 ((((*this).index)++));
 if (((variants).is_empty())){
-TRY((((*this).error(TRY(ByteString::from_utf8("Empty enums are not allowed"sv)),((partial_enum).name_span)))));
+TRY((((*this).error((ByteString::must_from_utf8("Empty enums are not allowed"sv)),((partial_enum).name_span)))));
 }
 return (Tuple{variants, fields, methods, records});
 }
@@ -9672,7 +9672,7 @@ return JaktInternal::ExplicitValue<void>();
 };/*case end*/
 case 98 /* This */: {
 {
-TRY((((captures).push(parser::ParsedCapture::ByValue(TRY(ByteString::from_utf8("this"sv)),((((*this).current())).span()))))));
+TRY((((captures).push(parser::ParsedCapture::ByValue((ByteString::must_from_utf8("this"sv)),((((*this).current())).span()))))));
 ((((*this).index)++));
 }
 return JaktInternal::ExplicitValue<void>();
@@ -9997,13 +9997,13 @@ return TRY((parser::ParsedExpression::Garbage(span)));
 
 ErrorOr<parser::ParsedModuleImport> parser::Parser::parse_module_import() {
 {
-parser::ParsedModuleImport parsed_import = parser::ParsedModuleImport(parser::ImportName::Literal(TRY(ByteString::from_utf8(""sv)),((*this).empty_span())),JaktInternal::OptionalNone(),parser::ImportList::List((TRY((DynamicArray<parser::ImportName>::create_with({}))))),false,static_cast<size_t>(0ULL));
+parser::ParsedModuleImport parsed_import = parser::ParsedModuleImport(parser::ImportName::Literal((ByteString::must_from_utf8(""sv)),((*this).empty_span())),JaktInternal::OptionalNone(),parser::ImportList::List((TRY((DynamicArray<parser::ImportName>::create_with({}))))),false,static_cast<size_t>(0ULL));
 if (((((*this).current())).__jakt_init_index() == 79 /* Relative */)){
 (((parsed_import).relative_path) = true);
 ((((*this).index)++));
 if (((((*this).current())).__jakt_init_index() == 3 /* Identifier */)){
 ByteString const name = (((*this).current())).as.Identifier.name;
-if (((name) == (TRY(ByteString::from_utf8("parent"sv))))){
+if (((name) == ((ByteString::must_from_utf8("parent"sv))))){
 ((((*this).index)++));
 ((((parsed_import).parent_path_count)++));
 while (((((*this).current())).__jakt_init_index() == 6 /* ColonColon */)){
@@ -10020,7 +10020,7 @@ if ([](ByteString const& self, ByteString rhs) -> bool {
 return (!(((self) == (rhs))));
 }
 }
-(name,TRY(ByteString::from_utf8("parent"sv)))){
+(name,(ByteString::must_from_utf8("parent"sv)))){
 return JaktInternal::LoopBreak{};
 }
 ((((*this).index)++));
@@ -10072,7 +10072,7 @@ parser::NumericConstant const val = (numeric_constant)->as.NumericConstant.val;
 (((parsed_import).parent_path_count) = ((val).to_usize()));
 }
 else {
-TRY((((*this).error(TRY(ByteString::from_utf8("Invalid Numeric Constant"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("Invalid Numeric Constant"sv)),span))));
 return JaktInternal::LoopBreak{};
 }
 
@@ -10146,7 +10146,7 @@ return JaktInternal::ExplicitValue(parser::ImportName::Literal(name,span));
 };/*case end*/
 default: {
 {
-TRY((((*this).error(TRY(ByteString::from_utf8("Expected module name"sv)),((((*this).current())).span())))));
+TRY((((*this).error((ByteString::must_from_utf8("Expected module name"sv)),((((*this).current())).span())))));
 return parsed_import;
 }
 };/*case end*/
@@ -10172,7 +10172,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(module_name,TRY(ByteString::from_utf8("::"sv)))));
+(module_name,(ByteString::must_from_utf8("::"sv)))));
 ({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<void, ErrorOr<parser::ParsedModuleImport>>{
 auto&& __jakt_match_variant = ((*this).current());
@@ -10207,7 +10207,7 @@ return JaktInternal::ExplicitValue<void>();
 };/*case end*/
 default: {
 {
-TRY((((*this).error(TRY(ByteString::from_utf8("Expected module name fragment"sv)),((((*this).current())).span())))));
+TRY((((*this).error((ByteString::must_from_utf8("Expected module name fragment"sv)),((((*this).current())).span())))));
 return parsed_import;
 }
 return JaktInternal::ExplicitValue<void>();
@@ -10235,7 +10235,7 @@ utility::Span const span = (((*this).current())).as.Identifier.span;
 (((parsed_import).alias_name) = parser::ImportName::Literal(name,span));
 }
 else {
-TRY((((*this).error(TRY(ByteString::from_utf8("Expected name"sv)),((((*this).current())).span())))));
+TRY((((*this).error((ByteString::must_from_utf8("Expected name"sv)),((((*this).current())).span())))));
 ((((*this).index)++));
 }
 
@@ -10244,7 +10244,7 @@ if (((*this).eol())){
 return parsed_import;
 }
 if ((!(((((*this).current())).__jakt_init_index() == 9 /* LCurly */)))){
-TRY((((*this).error(TRY(ByteString::from_utf8("Expected '{'"sv)),((((*this).current())).span())))));
+TRY((((*this).error((ByteString::must_from_utf8("Expected '{'"sv)),((((*this).current())).span())))));
 }
 ((((*this).index)++));
 while ((!(((*this).eof())))){
@@ -10262,7 +10262,7 @@ JaktInternal::DynamicArray<parser::ImportName> mutable_names = names;
 TRY((((mutable_names).push(parser::ImportName::Literal(name,span)))));
 }
 else {
-TRY((((*this).error_with_hint(TRY((__jakt_format((StringView::from_string_literal("Already importing everything from '{}'"sv)),TRY((((((parsed_import).module_name)).literal_name())))))),((((*this).current())).span()),TRY(ByteString::from_utf8("Remove the '*' to import specific names"sv)),((((*this).current())).span())))));
+TRY((((*this).error_with_hint(TRY((__jakt_format((StringView::from_string_literal("Already importing everything from '{}'"sv)),TRY((((((parsed_import).module_name)).literal_name())))))),((((*this).current())).span()),(ByteString::must_from_utf8("Remove the '*' to import specific names"sv)),((((*this).current())).span())))));
 }
 
 ((((*this).index)++));
@@ -10322,7 +10322,7 @@ return JaktInternal::ExplicitValue<void>();
 };/*case end*/
 default: {
 {
-TRY((((*this).error(TRY(ByteString::from_utf8("Expected import symbol"sv)),((((*this).current())).span())))));
+TRY((((*this).error((ByteString::must_from_utf8("Expected import symbol"sv)),((((*this).current())).span())))));
 ((((*this).index)++));
 }
 return JaktInternal::ExplicitValue<void>();
@@ -10368,8 +10368,8 @@ __jakt_label_82:; __jakt_var_87.release_value(); }));
 };/*case end*/
 default: {
 return JaktInternal::ExplicitValue(({ Optional<parser::ParsedRecord> __jakt_var_88; {
-TRY((((*this).error(TRY(ByteString::from_utf8("Expected `struct`, `class`, `enum`, or `boxed`"sv)),((((*this).current())).span())))));
-__jakt_var_88 = parser::ParsedRecord(TRY(ByteString::from_utf8(""sv)),((*this).empty_span()),(TRY((DynamicArray<parser::ParsedGenericParameter>::create_with({})))),definition_linkage,JaktInternal::OptionalNone(),(TRY((DynamicArray<parser::ParsedMethod>::create_with({})))),parser::RecordType::Garbage(),(TRY((DynamicArray<parser::ParsedRecord>::create_with({})))),JaktInternal::OptionalNone()); goto __jakt_label_83;
+TRY((((*this).error((ByteString::must_from_utf8("Expected `struct`, `class`, `enum`, or `boxed`"sv)),((((*this).current())).span())))));
+__jakt_var_88 = parser::ParsedRecord((ByteString::must_from_utf8(""sv)),((*this).empty_span()),(TRY((DynamicArray<parser::ParsedGenericParameter>::create_with({})))),definition_linkage,JaktInternal::OptionalNone(),(TRY((DynamicArray<parser::ParsedMethod>::create_with({})))),parser::RecordType::Garbage(),(TRY((DynamicArray<parser::ParsedRecord>::create_with({})))),JaktInternal::OptionalNone()); goto __jakt_label_83;
 
 }
 __jakt_label_83:; __jakt_var_88.release_value(); }));
@@ -10428,12 +10428,12 @@ if (((((*this).current())).__jakt_init_index() == 12 /* RSquare */)){
 ((((*this).index)++));
 }
 else {
-TRY((((*this).error(TRY(ByteString::from_utf8("Expected ']'"sv)),((((*this).current())).span())))));
+TRY((((*this).error((ByteString::must_from_utf8("Expected ']'"sv)),((((*this).current())).span())))));
 }
 
 return TRY((parser::ParsedType::Dictionary(qualifiers,inner,value,TRY((parser::merge_spans(start,((((*this).current())).span())))))));
 }
-TRY((((*this).error(TRY(ByteString::from_utf8("Expected shorthand type"sv)),((((*this).current())).span())))));
+TRY((((*this).error((ByteString::must_from_utf8("Expected shorthand type"sv)),((((*this).current())).span())))));
 return TRY((parser::ParsedType::Empty(qualifiers)));
 }
 }
@@ -10459,7 +10459,7 @@ break;
 }
 TRY((((types).push(type))));
 }
-TRY((((*this).error(TRY(ByteString::from_utf8("Expected ‘)’"sv)),((((*this).current())).span())))));
+TRY((((*this).error((ByteString::must_from_utf8("Expected ‘)’"sv)),((((*this).current())).span())))));
 return TRY((parser::ParsedType::Empty(qualifiers)));
 }
 }
@@ -10475,7 +10475,7 @@ ErrorOr<NonnullRefPtr<typename parser::ParsedExpression>> parser::Parser::parse_
 bool is_dictionary = false;
 utility::Span const start = ((((*this).current())).span());
 if ((!(((((*this).current())).__jakt_init_index() == 11 /* LSquare */)))){
-TRY((((*this).error(TRY(ByteString::from_utf8("Expected ‘[’"sv)),((((*this).current())).span())))));
+TRY((((*this).error((ByteString::must_from_utf8("Expected ‘[’"sv)),((((*this).current())).span())))));
 return TRY((parser::ParsedExpression::Garbage(((((*this).current())).span()))));
 }
 ((((*this).index)++));
@@ -10513,7 +10513,7 @@ if (((((output).size())) == (static_cast<size_t>(1ULL)))){
 (fill_size_expr = TRY((((*this).parse_expression(false,false)))));
 }
 else {
-TRY((((*this).error(TRY(ByteString::from_utf8("Can't fill an Array with more than one expression"sv)),((((*this).current())).span())))));
+TRY((((*this).error((ByteString::must_from_utf8("Can't fill an Array with more than one expression"sv)),((((*this).current())).span())))));
 ((((*this).index)++));
 }
 
@@ -10530,12 +10530,12 @@ if (((((*this).current())).__jakt_init_index() == 12 /* RSquare */)){
 return JaktInternal::LoopBreak{};
 }
 else {
-TRY((((*this).error(TRY(ByteString::from_utf8("Expected ‘]’"sv)),((((*this).current())).span())))));
+TRY((((*this).error((ByteString::must_from_utf8("Expected ‘]’"sv)),((((*this).current())).span())))));
 }
 
 }
 else {
-TRY((((*this).error(TRY(ByteString::from_utf8("Missing key in dictionary literal"sv)),((((*this).current())).span())))));
+TRY((((*this).error((ByteString::must_from_utf8("Missing key in dictionary literal"sv)),((((*this).current())).span())))));
 }
 
 }
@@ -10549,12 +10549,12 @@ return JaktInternal::LoopBreak{};
 }
 if (((((*this).current())).__jakt_init_index() == 5 /* Colon */)){
 if ((!(((output).is_empty())))){
-TRY((((*this).error(TRY(ByteString::from_utf8("Mixing dictionary and array values"sv)),((((*this).current())).span())))));
+TRY((((*this).error((ByteString::must_from_utf8("Mixing dictionary and array values"sv)),((((*this).current())).span())))));
 }
 (is_dictionary = true);
 ((((*this).index)++));
 if (((*this).eof())){
-TRY((((*this).error(TRY(ByteString::from_utf8("Key missing value in dictionary"sv)),((((*this).current())).span())))));
+TRY((((*this).error((ByteString::must_from_utf8("Key missing value in dictionary"sv)),((((*this).current())).span())))));
 return TRY((parser::ParsedExpression::Garbage(((((*this).current())).span()))));
 }
 NonnullRefPtr<typename parser::ParsedExpression> const value = TRY((((*this).parse_expression(false,false))));
@@ -10590,7 +10590,7 @@ return (infallible_enum_cast<jakt__prelude__operators::Ordering>((JaktInternal::
 }
 }
 (end,((((*this).tokens)).size())) || (!(((((((*this).tokens))[end])).__jakt_init_index() == 12 /* RSquare */))))){
-TRY((((*this).error(TRY(ByteString::from_utf8("Expected ‘]’ to close the array"sv)),((((((*this).tokens))[end])).span())))));
+TRY((((*this).error((ByteString::must_from_utf8("Expected ‘]’ to close the array"sv)),((((((*this).tokens))[end])).span())))));
 }
 if (is_dictionary){
 return TRY((parser::ParsedExpression::JaktDictionary(dict_output,TRY((parser::merge_spans(start,((((((*this).tokens))[end])).span())))))));
@@ -10615,11 +10615,11 @@ JaktInternal::Dictionary<ByteString,parser::ParsedPatternDefault> defaults = ((p
 ((*this).skip_newlines());
 if (((((*this).current())).__jakt_init_index() == 3 /* Identifier */)){
 ByteString const name = (((*this).current())).as.Identifier.name;
-if (((name) == (TRY(ByteString::from_utf8("default"sv))))){
+if (((name) == ((ByteString::must_from_utf8("default"sv))))){
 JaktInternal::Dictionary<ByteString,parser::ParsedPatternDefault> defaults = ((pattern).common.init_common.defaults);
 ((((*this).index)) += (static_cast<size_t>(1ULL)));
 if ((!(((((*this).current())).__jakt_init_index() == 7 /* LParen */)))){
-TRY((((*this).error(TRY(ByteString::from_utf8("Expected '(' after 'default'"sv)),((((*this).current())).span())))));
+TRY((((*this).error((ByteString::must_from_utf8("Expected '(' after 'default'"sv)),((((*this).current())).span())))));
 continue;
 }
 ((((*this).index)) += (static_cast<size_t>(1ULL)));
@@ -10643,7 +10643,7 @@ __jakt_label_84:; __jakt_var_90.release_value(); }));
 };/*case end*/
 default: {
 return JaktInternal::ExplicitValue(({ Optional<NonnullRefPtr<typename parser::ParsedExpression>> __jakt_var_91; {
-TRY((((*this).error(TRY(ByteString::from_utf8("Expected initializer"sv)),((((*this).current())).span())))));
+TRY((((*this).error((ByteString::must_from_utf8("Expected initializer"sv)),((((*this).current())).span())))));
 __jakt_var_91 = TRY((parser::ParsedExpression::Garbage(((((*this).current())).span())))); goto __jakt_label_85;
 
 }
@@ -10666,7 +10666,7 @@ if (((((*this).current())).__jakt_init_index() == 8 /* RParen */)){
 ((((*this).index)) += (static_cast<size_t>(1ULL)));
 }
 else {
-TRY((((*this).error(TRY(ByteString::from_utf8("Expected a ')' to end 'defaults' list"sv)),((((*this).current())).span())))));
+TRY((((*this).error((ByteString::must_from_utf8("Expected a ')' to end 'defaults' list"sv)),((((*this).current())).span())))));
 }
 
 }
@@ -10802,7 +10802,7 @@ return JaktInternal::ExplicitValue(({ Optional<NonnullRefPtr<typename parser::Pa
 ((((*this).index)++));
 NonnullRefPtr<typename parser::ParsedExpression> const expr = TRY((((*this).parse_expression(false,false))));
 if ((!(inside_block))){
-TRY((((*this).error(TRY(ByteString::from_utf8("‘yield’ can only be used inside a block"sv)),TRY((parser::merge_spans(start,((expr)->span()))))))));
+TRY((((*this).error((ByteString::must_from_utf8("‘yield’ can only be used inside a block"sv)),TRY((parser::merge_spans(start,((expr)->span()))))))));
 }
 __jakt_var_101 = TRY((parser::ParsedStatement::Yield(expr,TRY((parser::merge_spans(start,((((*this).previous())).span()))))))); goto __jakt_label_95;
 
@@ -10845,8 +10845,8 @@ bool const is_mutable = ((((*this).current())).__jakt_init_index() == 85 /* Mut 
 ((((*this).index)++));
 JaktInternal::DynamicArray<parser::ParsedVarDecl> vars = (TRY((DynamicArray<parser::ParsedVarDecl>::create_with({}))));
 bool is_destructuring_assingment = false;
-ByteString tuple_var_name = TRY(ByteString::from_utf8(""sv));
-parser::ParsedVarDecl tuple_var_decl = parser::ParsedVarDecl(TRY(ByteString::from_utf8(""sv)),TRY((parser::ParsedType::Empty(JaktInternal::OptionalNone()))),is_mutable,JaktInternal::OptionalNone(),((((*this).current())).span()),JaktInternal::OptionalNone());
+ByteString tuple_var_name = (ByteString::must_from_utf8(""sv));
+parser::ParsedVarDecl tuple_var_decl = parser::ParsedVarDecl((ByteString::must_from_utf8(""sv)),TRY((parser::ParsedType::Empty(JaktInternal::OptionalNone()))),is_mutable,JaktInternal::OptionalNone(),((((*this).current())).span()),JaktInternal::OptionalNone());
 if (((((*this).current())).__jakt_init_index() == 7 /* LParen */)){
 (vars = ((TRY((((*this).parse_destructuring_assignment(is_mutable))))).var_decls));
 {
@@ -10871,7 +10871,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(tuple_var_name,TRY(ByteString::from_utf8("_"sv)))));
+(tuple_var_name,(ByteString::must_from_utf8("_"sv)))));
 }
 
 }
@@ -10898,7 +10898,7 @@ __jakt_label_98:; __jakt_var_104.release_value(); }));
 };/*case end*/
 default: {
 return JaktInternal::ExplicitValue(({ Optional<NonnullRefPtr<typename parser::ParsedExpression>> __jakt_var_105; {
-TRY((((*this).error(TRY(ByteString::from_utf8("Expected initializer"sv)),((((*this).current())).span())))));
+TRY((((*this).error((ByteString::must_from_utf8("Expected initializer"sv)),((((*this).current())).span())))));
 __jakt_var_105 = TRY((parser::ParsedExpression::Garbage(((((*this).current())).span())))); goto __jakt_label_99;
 
 }
@@ -10927,8 +10927,8 @@ bool const is_mutable = ((((*this).current())).__jakt_init_index() == 85 /* Mut 
 ((((*this).index)++));
 JaktInternal::DynamicArray<parser::ParsedVarDecl> vars = (TRY((DynamicArray<parser::ParsedVarDecl>::create_with({}))));
 bool is_destructuring_assingment = false;
-ByteString tuple_var_name = TRY(ByteString::from_utf8(""sv));
-parser::ParsedVarDecl tuple_var_decl = parser::ParsedVarDecl(TRY(ByteString::from_utf8(""sv)),TRY((parser::ParsedType::Empty(JaktInternal::OptionalNone()))),is_mutable,JaktInternal::OptionalNone(),((((*this).current())).span()),JaktInternal::OptionalNone());
+ByteString tuple_var_name = (ByteString::must_from_utf8(""sv));
+parser::ParsedVarDecl tuple_var_decl = parser::ParsedVarDecl((ByteString::must_from_utf8(""sv)),TRY((parser::ParsedType::Empty(JaktInternal::OptionalNone()))),is_mutable,JaktInternal::OptionalNone(),((((*this).current())).span()),JaktInternal::OptionalNone());
 if (((((*this).current())).__jakt_init_index() == 7 /* LParen */)){
 (vars = ((TRY((((*this).parse_destructuring_assignment(is_mutable))))).var_decls));
 {
@@ -10953,7 +10953,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(tuple_var_name,TRY(ByteString::from_utf8("_"sv)))));
+(tuple_var_name,(ByteString::must_from_utf8("_"sv)))));
 }
 
 }
@@ -10980,7 +10980,7 @@ __jakt_label_101:; __jakt_var_107.release_value(); }));
 };/*case end*/
 default: {
 return JaktInternal::ExplicitValue(({ Optional<NonnullRefPtr<typename parser::ParsedExpression>> __jakt_var_108; {
-TRY((((*this).error(TRY(ByteString::from_utf8("Expected initializer"sv)),((((*this).current())).span())))));
+TRY((((*this).error((ByteString::must_from_utf8("Expected initializer"sv)),((((*this).current())).span())))));
 __jakt_var_108 = TRY((parser::ParsedExpression::Garbage(((((*this).current())).span())))); goto __jakt_label_102;
 
 }
@@ -11042,7 +11042,7 @@ ErrorOr<parser::ParsedField> parser::Parser::parse_field(parser::Visibility cons
 {
 parser::ParsedVarDecl const parsed_variable_declaration = TRY((((*this).parse_variable_declaration(true))));
 if (((((parsed_variable_declaration).parsed_type))->__jakt_init_index() == 15 /* Empty */)){
-TRY((((*this).error(TRY(ByteString::from_utf8("Field missing type"sv)),((parsed_variable_declaration).span)))));
+TRY((((*this).error((ByteString::must_from_utf8("Field missing type"sv)),((parsed_variable_declaration).span)))));
 }
 JaktInternal::Optional<NonnullRefPtr<typename parser::ParsedExpression>> default_value = JaktInternal::OptionalNone();
 if (((((*this).peek(static_cast<size_t>(0ULL)))).__jakt_init_index() == 16 /* Equal */)){
@@ -11060,7 +11060,7 @@ ByteString const name = (((*this).current())).as.Identifier.name;
 ((((*this).index)) += (static_cast<size_t>(2ULL)));
 return name;
 }
-return TRY(ByteString::from_utf8(""sv));
+return (ByteString::must_from_utf8(""sv));
 }
 }
 
@@ -11091,7 +11091,7 @@ ByteString const name = (((*this).current())).as.Identifier.name;
 ({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<void,ErrorOr<JaktInternal::Optional<JaktInternal::DynamicArray<parser::IncludeAction>>>>{
 auto __jakt_enum_value = (name);
-if (__jakt_enum_value == TRY(ByteString::from_utf8("define"sv))) {
+if (__jakt_enum_value == (ByteString::must_from_utf8("define"sv))) {
 {
 ((((*this).index)++));
 ((*this).skip_newlines());
@@ -11100,7 +11100,7 @@ if (((((*this).current())).__jakt_init_index() == 9 /* LCurly */)){
 ((*this).skip_newlines());
 }
 else {
-TRY((((*this).error(TRY(ByteString::from_utf8("Expected '{' to start define action"sv)),((((*this).current())).span())))));
+TRY((((*this).error((ByteString::must_from_utf8("Expected '{' to start define action"sv)),((((*this).current())).span())))));
 return JaktInternal::OptionalNone();
 }
 
@@ -11115,7 +11115,7 @@ if (((((*this).current())).__jakt_init_index() == 16 /* Equal */)){
 ((((*this).index)++));
 }
 else {
-TRY((((*this).error(TRY(ByteString::from_utf8("Expected '=' to assign value to defined symbols"sv)),((((*this).current())).span())))));
+TRY((((*this).error((ByteString::must_from_utf8("Expected '=' to assign value to defined symbols"sv)),((((*this).current())).span())))));
 continue;
 }
 
@@ -11134,8 +11134,8 @@ __jakt_label_105:; __jakt_var_111.release_value(); }));
 };/*case end*/
 default: {
 return JaktInternal::ExplicitValue(({ Optional<ByteString> __jakt_var_112; {
-TRY((((*this).error(TRY(ByteString::from_utf8("Expected quoted string to assign value to defined symbols"sv)),((((*this).current())).span())))));
-__jakt_var_112 = TRY(ByteString::from_utf8(""sv)); goto __jakt_label_106;
+TRY((((*this).error((ByteString::must_from_utf8("Expected quoted string to assign value to defined symbols"sv)),((((*this).current())).span())))));
+__jakt_var_112 = (ByteString::must_from_utf8(""sv)); goto __jakt_label_106;
 
 }
 __jakt_label_106:; __jakt_var_112.release_value(); }));
@@ -11167,14 +11167,14 @@ if (((((*this).current())).__jakt_init_index() == 10 /* RCurly */)){
 ((((*this).index)++));
 }
 else {
-TRY((((*this).error(TRY(ByteString::from_utf8("Expected '}' to end define action"sv)),((((*this).current())).span())))));
+TRY((((*this).error((ByteString::must_from_utf8("Expected '}' to end define action"sv)),((((*this).current())).span())))));
 }
 
 return static_cast<JaktInternal::Optional<JaktInternal::DynamicArray<parser::IncludeAction>>>(defines);
 }
 return JaktInternal::ExplicitValue<void>();
 }
-else if (__jakt_enum_value == TRY(ByteString::from_utf8("undefine"sv))) {
+else if (__jakt_enum_value == (ByteString::must_from_utf8("undefine"sv))) {
 {
 ((((*this).index)++));
 ((*this).skip_newlines());
@@ -11183,7 +11183,7 @@ if (((((*this).current())).__jakt_init_index() == 9 /* LCurly */)){
 ((*this).skip_newlines());
 }
 else {
-TRY((((*this).error(TRY(ByteString::from_utf8("Expected '{' to start undefine include action"sv)),((((*this).current())).span())))));
+TRY((((*this).error((ByteString::must_from_utf8("Expected '{' to start undefine include action"sv)),((((*this).current())).span())))));
 return JaktInternal::OptionalNone();
 }
 
@@ -11209,7 +11209,7 @@ if (((((*this).current())).__jakt_init_index() == 10 /* RCurly */)){
 ((((*this).index)++));
 }
 else {
-TRY((((*this).error(TRY(ByteString::from_utf8("Expected '}' to end undefine action"sv)),((((*this).current())).span())))));
+TRY((((*this).error((ByteString::must_from_utf8("Expected '}' to end undefine action"sv)),((((*this).current())).span())))));
 }
 
 return static_cast<JaktInternal::Optional<JaktInternal::DynamicArray<parser::IncludeAction>>>(defines);
@@ -11227,11 +11227,11 @@ return JaktInternal::ExplicitValue<void>();
         return _jakt_value.release_return();
     _jakt_value.release_value();
 });
-TRY((((*this).error(TRY(ByteString::from_utf8("Expected 'define' or 'undefine' in include action"sv)),((((*this).current())).span())))));
+TRY((((*this).error((ByteString::must_from_utf8("Expected 'define' or 'undefine' in include action"sv)),((((*this).current())).span())))));
 return JaktInternal::OptionalNone();
 }
 else {
-TRY((((*this).error(TRY(ByteString::from_utf8("Expected 'define' or 'undefine' in include action"sv)),((((*this).current())).span())))));
+TRY((((*this).error((ByteString::must_from_utf8("Expected 'define' or 'undefine' in include action"sv)),((((*this).current())).span())))));
 return JaktInternal::OptionalNone();
 }
 
@@ -11242,7 +11242,7 @@ ErrorOr<NonnullRefPtr<typename parser::ParsedExpression>> parser::Parser::parse_
 {
 utility::Span const start_span = ((((*this).current())).span());
 NonnullRefPtr<typename parser::ParsedStatement> const stmt = TRY((((*this).parse_statement(false))));
-ByteString error_name = TRY(ByteString::from_utf8(""sv));
+ByteString error_name = (ByteString::must_from_utf8(""sv));
 utility::Span error_span = ((((*this).current())).span());
 if (((((*this).current())).__jakt_init_index() == 64 /* Catch */)){
 ((((*this).index)++));
@@ -11254,7 +11254,7 @@ ByteString const name = (((*this).current())).as.Identifier.name;
 }
 }
 else {
-TRY((((*this).error(TRY(ByteString::from_utf8("Expected ‘catch’"sv)),((((*this).current())).span())))));
+TRY((((*this).error((ByteString::must_from_utf8("Expected ‘catch’"sv)),((((*this).current())).span())))));
 }
 
 parser::ParsedBlock const catch_block = TRY((((*this).parse_block())));
@@ -11323,14 +11323,14 @@ return JaktInternal::ExplicitValue<void>();
 };/*case end*/
 case 112 /* Garbage */: {
 {
-TRY((((*this).error(TRY(ByteString::from_utf8("Expected `>` to end the generic parameters"sv)),((((*this).current())).span())))));
+TRY((((*this).error((ByteString::must_from_utf8("Expected `>` to end the generic parameters"sv)),((((*this).current())).span())))));
 return generic_parameters;
 }
 return JaktInternal::ExplicitValue<void>();
 };/*case end*/
 default: {
 {
-TRY((((*this).error(TRY(ByteString::from_utf8("Expected generic parameter name"sv)),((((*this).current())).span())))));
+TRY((((*this).error((ByteString::must_from_utf8("Expected generic parameter name"sv)),((((*this).current())).span())))));
 return generic_parameters;
 }
 return JaktInternal::ExplicitValue<void>();
@@ -11348,7 +11348,7 @@ return JaktInternal::ExplicitValue<void>();
 });
 }
 if ((!(saw_ending_bracket))){
-TRY((((*this).error(TRY(ByteString::from_utf8("Expected `>` to end the generic parameters"sv)),((((*this).current())).span())))));
+TRY((((*this).error((ByteString::must_from_utf8("Expected `>` to end the generic parameters"sv)),((((*this).current())).span())))));
 return generic_parameters;
 }
 return generic_parameters;
@@ -11357,17 +11357,17 @@ return generic_parameters;
 
 ErrorOr<parser::ParsedRecord> parser::Parser::parse_struct(parser::DefinitionLinkage const definition_linkage) {
 {
-parser::ParsedRecord parsed_struct = parser::ParsedRecord(TRY(ByteString::from_utf8(""sv)),((*this).empty_span()),(TRY((DynamicArray<parser::ParsedGenericParameter>::create_with({})))),definition_linkage,JaktInternal::OptionalNone(),(TRY((DynamicArray<parser::ParsedMethod>::create_with({})))),parser::RecordType::Garbage(),(TRY((DynamicArray<parser::ParsedRecord>::create_with({})))),JaktInternal::OptionalNone());
+parser::ParsedRecord parsed_struct = parser::ParsedRecord((ByteString::must_from_utf8(""sv)),((*this).empty_span()),(TRY((DynamicArray<parser::ParsedGenericParameter>::create_with({})))),definition_linkage,JaktInternal::OptionalNone(),(TRY((DynamicArray<parser::ParsedMethod>::create_with({})))),parser::RecordType::Garbage(),(TRY((DynamicArray<parser::ParsedRecord>::create_with({})))),JaktInternal::OptionalNone());
 if (((((*this).current())).__jakt_init_index() == 97 /* Struct */)){
 ((((*this).index)++));
 }
 else {
-TRY((((*this).error(TRY(ByteString::from_utf8("Expected `struct` keyword"sv)),((((*this).current())).span())))));
+TRY((((*this).error((ByteString::must_from_utf8("Expected `struct` keyword"sv)),((((*this).current())).span())))));
 return parsed_struct;
 }
 
 if (((*this).eof())){
-TRY((((*this).error(TRY(ByteString::from_utf8("Incomplete struct definition, expected name"sv)),((((*this).current())).span())))));
+TRY((((*this).error((ByteString::must_from_utf8("Incomplete struct definition, expected name"sv)),((((*this).current())).span())))));
 return parsed_struct;
 }
 if (((((*this).current())).__jakt_init_index() == 3 /* Identifier */)){
@@ -11378,11 +11378,11 @@ utility::Span const span = (((*this).current())).as.Identifier.span;
 (((parsed_struct).name_span) = span);
 }
 else {
-TRY((((*this).error(TRY(ByteString::from_utf8("Incomplete struct definition, expected name"sv)),((((*this).current())).span())))));
+TRY((((*this).error((ByteString::must_from_utf8("Incomplete struct definition, expected name"sv)),((((*this).current())).span())))));
 }
 
 if (((*this).eof())){
-TRY((((*this).error(TRY(ByteString::from_utf8("Incomplete struct definition, expected generic parameters or body"sv)),((((*this).current())).span())))));
+TRY((((*this).error((ByteString::must_from_utf8("Incomplete struct definition, expected generic parameters or body"sv)),((((*this).current())).span())))));
 return parsed_struct;
 }
 (((parsed_struct).generic_parameters) = TRY((((*this).parse_generic_parameters()))));
@@ -11397,7 +11397,7 @@ if (((((*this).current())).__jakt_init_index() == 5 /* Colon */)){
 }
 ((*this).skip_newlines());
 if (((*this).eof())){
-TRY((((*this).error(TRY(ByteString::from_utf8("Incomplete struct definition, expected body"sv)),((((*this).current())).span())))));
+TRY((((*this).error((ByteString::must_from_utf8("Incomplete struct definition, expected body"sv)),((((*this).current())).span())))));
 return parsed_struct;
 }
 JaktInternal::Tuple<JaktInternal::DynamicArray<parser::ParsedField>,JaktInternal::DynamicArray<parser::ParsedMethod>,JaktInternal::DynamicArray<parser::ParsedRecord>> const fields_methods_records_ = TRY((((*this).parse_struct_class_body(definition_linkage,parser::Visibility::Public(),false))));
@@ -11439,7 +11439,7 @@ return JaktInternal::ExplicitValue<void>();
 case 56 /* Eof */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Eof;utility::Span const& span = __jakt_match_value.value;
 {
-TRY((((*this).error(TRY(ByteString::from_utf8("Expected ')' to close the trait list"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("Expected ')' to close the trait list"sv)),span))));
 return JaktInternal::LoopBreak{};
 }
 return JaktInternal::ExplicitValue<void>();
@@ -11465,7 +11465,7 @@ return JaktInternal::ExplicitValue<void>();
 case 0 /* SingleQuotedString */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.SingleQuotedString;utility::Span const& span = __jakt_match_value.span;
 {
-TRY((((*this).error(TRY(ByteString::from_utf8("Expected trait name"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("Expected trait name"sv)),span))));
 return JaktInternal::LoopBreak{};
 }
 return JaktInternal::ExplicitValue<void>();
@@ -11473,7 +11473,7 @@ return JaktInternal::ExplicitValue<void>();
 case 1 /* QuotedString */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.QuotedString;utility::Span const& span = __jakt_match_value.span;
 {
-TRY((((*this).error(TRY(ByteString::from_utf8("Expected trait name"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("Expected trait name"sv)),span))));
 return JaktInternal::LoopBreak{};
 }
 return JaktInternal::ExplicitValue<void>();
@@ -11481,7 +11481,7 @@ return JaktInternal::ExplicitValue<void>();
 case 2 /* Number */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Number;utility::Span const& span = __jakt_match_value.span;
 {
-TRY((((*this).error(TRY(ByteString::from_utf8("Expected trait name"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("Expected trait name"sv)),span))));
 return JaktInternal::LoopBreak{};
 }
 return JaktInternal::ExplicitValue<void>();
@@ -11489,7 +11489,7 @@ return JaktInternal::ExplicitValue<void>();
 case 4 /* Semicolon */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Semicolon;utility::Span const& span = __jakt_match_value.value;
 {
-TRY((((*this).error(TRY(ByteString::from_utf8("Expected trait name"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("Expected trait name"sv)),span))));
 return JaktInternal::LoopBreak{};
 }
 return JaktInternal::ExplicitValue<void>();
@@ -11497,7 +11497,7 @@ return JaktInternal::ExplicitValue<void>();
 case 5 /* Colon */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Colon;utility::Span const& span = __jakt_match_value.value;
 {
-TRY((((*this).error(TRY(ByteString::from_utf8("Expected trait name"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("Expected trait name"sv)),span))));
 return JaktInternal::LoopBreak{};
 }
 return JaktInternal::ExplicitValue<void>();
@@ -11505,7 +11505,7 @@ return JaktInternal::ExplicitValue<void>();
 case 6 /* ColonColon */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.ColonColon;utility::Span const& span = __jakt_match_value.value;
 {
-TRY((((*this).error(TRY(ByteString::from_utf8("Expected trait name"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("Expected trait name"sv)),span))));
 return JaktInternal::LoopBreak{};
 }
 return JaktInternal::ExplicitValue<void>();
@@ -11513,7 +11513,7 @@ return JaktInternal::ExplicitValue<void>();
 case 7 /* LParen */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.LParen;utility::Span const& span = __jakt_match_value.value;
 {
-TRY((((*this).error(TRY(ByteString::from_utf8("Expected trait name"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("Expected trait name"sv)),span))));
 return JaktInternal::LoopBreak{};
 }
 return JaktInternal::ExplicitValue<void>();
@@ -11521,7 +11521,7 @@ return JaktInternal::ExplicitValue<void>();
 case 9 /* LCurly */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.LCurly;utility::Span const& span = __jakt_match_value.value;
 {
-TRY((((*this).error(TRY(ByteString::from_utf8("Expected trait name"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("Expected trait name"sv)),span))));
 return JaktInternal::LoopBreak{};
 }
 return JaktInternal::ExplicitValue<void>();
@@ -11529,7 +11529,7 @@ return JaktInternal::ExplicitValue<void>();
 case 10 /* RCurly */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.RCurly;utility::Span const& span = __jakt_match_value.value;
 {
-TRY((((*this).error(TRY(ByteString::from_utf8("Expected trait name"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("Expected trait name"sv)),span))));
 return JaktInternal::LoopBreak{};
 }
 return JaktInternal::ExplicitValue<void>();
@@ -11537,7 +11537,7 @@ return JaktInternal::ExplicitValue<void>();
 case 11 /* LSquare */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.LSquare;utility::Span const& span = __jakt_match_value.value;
 {
-TRY((((*this).error(TRY(ByteString::from_utf8("Expected trait name"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("Expected trait name"sv)),span))));
 return JaktInternal::LoopBreak{};
 }
 return JaktInternal::ExplicitValue<void>();
@@ -11545,7 +11545,7 @@ return JaktInternal::ExplicitValue<void>();
 case 12 /* RSquare */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.RSquare;utility::Span const& span = __jakt_match_value.value;
 {
-TRY((((*this).error(TRY(ByteString::from_utf8("Expected trait name"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("Expected trait name"sv)),span))));
 return JaktInternal::LoopBreak{};
 }
 return JaktInternal::ExplicitValue<void>();
@@ -11553,7 +11553,7 @@ return JaktInternal::ExplicitValue<void>();
 case 13 /* PercentSign */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.PercentSign;utility::Span const& span = __jakt_match_value.value;
 {
-TRY((((*this).error(TRY(ByteString::from_utf8("Expected trait name"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("Expected trait name"sv)),span))));
 return JaktInternal::LoopBreak{};
 }
 return JaktInternal::ExplicitValue<void>();
@@ -11561,7 +11561,7 @@ return JaktInternal::ExplicitValue<void>();
 case 14 /* Plus */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Plus;utility::Span const& span = __jakt_match_value.value;
 {
-TRY((((*this).error(TRY(ByteString::from_utf8("Expected trait name"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("Expected trait name"sv)),span))));
 return JaktInternal::LoopBreak{};
 }
 return JaktInternal::ExplicitValue<void>();
@@ -11569,7 +11569,7 @@ return JaktInternal::ExplicitValue<void>();
 case 15 /* Minus */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Minus;utility::Span const& span = __jakt_match_value.value;
 {
-TRY((((*this).error(TRY(ByteString::from_utf8("Expected trait name"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("Expected trait name"sv)),span))));
 return JaktInternal::LoopBreak{};
 }
 return JaktInternal::ExplicitValue<void>();
@@ -11577,7 +11577,7 @@ return JaktInternal::ExplicitValue<void>();
 case 16 /* Equal */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Equal;utility::Span const& span = __jakt_match_value.value;
 {
-TRY((((*this).error(TRY(ByteString::from_utf8("Expected trait name"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("Expected trait name"sv)),span))));
 return JaktInternal::LoopBreak{};
 }
 return JaktInternal::ExplicitValue<void>();
@@ -11585,7 +11585,7 @@ return JaktInternal::ExplicitValue<void>();
 case 17 /* PlusEqual */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.PlusEqual;utility::Span const& span = __jakt_match_value.value;
 {
-TRY((((*this).error(TRY(ByteString::from_utf8("Expected trait name"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("Expected trait name"sv)),span))));
 return JaktInternal::LoopBreak{};
 }
 return JaktInternal::ExplicitValue<void>();
@@ -11593,7 +11593,7 @@ return JaktInternal::ExplicitValue<void>();
 case 18 /* PlusPlus */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.PlusPlus;utility::Span const& span = __jakt_match_value.value;
 {
-TRY((((*this).error(TRY(ByteString::from_utf8("Expected trait name"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("Expected trait name"sv)),span))));
 return JaktInternal::LoopBreak{};
 }
 return JaktInternal::ExplicitValue<void>();
@@ -11601,7 +11601,7 @@ return JaktInternal::ExplicitValue<void>();
 case 19 /* MinusEqual */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.MinusEqual;utility::Span const& span = __jakt_match_value.value;
 {
-TRY((((*this).error(TRY(ByteString::from_utf8("Expected trait name"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("Expected trait name"sv)),span))));
 return JaktInternal::LoopBreak{};
 }
 return JaktInternal::ExplicitValue<void>();
@@ -11609,7 +11609,7 @@ return JaktInternal::ExplicitValue<void>();
 case 20 /* MinusMinus */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.MinusMinus;utility::Span const& span = __jakt_match_value.value;
 {
-TRY((((*this).error(TRY(ByteString::from_utf8("Expected trait name"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("Expected trait name"sv)),span))));
 return JaktInternal::LoopBreak{};
 }
 return JaktInternal::ExplicitValue<void>();
@@ -11617,7 +11617,7 @@ return JaktInternal::ExplicitValue<void>();
 case 21 /* AsteriskEqual */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.AsteriskEqual;utility::Span const& span = __jakt_match_value.value;
 {
-TRY((((*this).error(TRY(ByteString::from_utf8("Expected trait name"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("Expected trait name"sv)),span))));
 return JaktInternal::LoopBreak{};
 }
 return JaktInternal::ExplicitValue<void>();
@@ -11625,7 +11625,7 @@ return JaktInternal::ExplicitValue<void>();
 case 22 /* ForwardSlashEqual */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.ForwardSlashEqual;utility::Span const& span = __jakt_match_value.value;
 {
-TRY((((*this).error(TRY(ByteString::from_utf8("Expected trait name"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("Expected trait name"sv)),span))));
 return JaktInternal::LoopBreak{};
 }
 return JaktInternal::ExplicitValue<void>();
@@ -11633,7 +11633,7 @@ return JaktInternal::ExplicitValue<void>();
 case 23 /* PercentSignEqual */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.PercentSignEqual;utility::Span const& span = __jakt_match_value.value;
 {
-TRY((((*this).error(TRY(ByteString::from_utf8("Expected trait name"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("Expected trait name"sv)),span))));
 return JaktInternal::LoopBreak{};
 }
 return JaktInternal::ExplicitValue<void>();
@@ -11641,7 +11641,7 @@ return JaktInternal::ExplicitValue<void>();
 case 24 /* NotEqual */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.NotEqual;utility::Span const& span = __jakt_match_value.value;
 {
-TRY((((*this).error(TRY(ByteString::from_utf8("Expected trait name"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("Expected trait name"sv)),span))));
 return JaktInternal::LoopBreak{};
 }
 return JaktInternal::ExplicitValue<void>();
@@ -11649,7 +11649,7 @@ return JaktInternal::ExplicitValue<void>();
 case 25 /* DoubleEqual */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.DoubleEqual;utility::Span const& span = __jakt_match_value.value;
 {
-TRY((((*this).error(TRY(ByteString::from_utf8("Expected trait name"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("Expected trait name"sv)),span))));
 return JaktInternal::LoopBreak{};
 }
 return JaktInternal::ExplicitValue<void>();
@@ -11657,7 +11657,7 @@ return JaktInternal::ExplicitValue<void>();
 case 26 /* GreaterThan */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.GreaterThan;utility::Span const& span = __jakt_match_value.value;
 {
-TRY((((*this).error(TRY(ByteString::from_utf8("Expected trait name"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("Expected trait name"sv)),span))));
 return JaktInternal::LoopBreak{};
 }
 return JaktInternal::ExplicitValue<void>();
@@ -11665,7 +11665,7 @@ return JaktInternal::ExplicitValue<void>();
 case 27 /* GreaterThanOrEqual */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.GreaterThanOrEqual;utility::Span const& span = __jakt_match_value.value;
 {
-TRY((((*this).error(TRY(ByteString::from_utf8("Expected trait name"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("Expected trait name"sv)),span))));
 return JaktInternal::LoopBreak{};
 }
 return JaktInternal::ExplicitValue<void>();
@@ -11673,7 +11673,7 @@ return JaktInternal::ExplicitValue<void>();
 case 28 /* LessThan */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.LessThan;utility::Span const& span = __jakt_match_value.value;
 {
-TRY((((*this).error(TRY(ByteString::from_utf8("Expected trait name"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("Expected trait name"sv)),span))));
 return JaktInternal::LoopBreak{};
 }
 return JaktInternal::ExplicitValue<void>();
@@ -11681,7 +11681,7 @@ return JaktInternal::ExplicitValue<void>();
 case 29 /* LessThanOrEqual */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.LessThanOrEqual;utility::Span const& span = __jakt_match_value.value;
 {
-TRY((((*this).error(TRY(ByteString::from_utf8("Expected trait name"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("Expected trait name"sv)),span))));
 return JaktInternal::LoopBreak{};
 }
 return JaktInternal::ExplicitValue<void>();
@@ -11689,7 +11689,7 @@ return JaktInternal::ExplicitValue<void>();
 case 30 /* LeftArithmeticShift */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.LeftArithmeticShift;utility::Span const& span = __jakt_match_value.value;
 {
-TRY((((*this).error(TRY(ByteString::from_utf8("Expected trait name"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("Expected trait name"sv)),span))));
 return JaktInternal::LoopBreak{};
 }
 return JaktInternal::ExplicitValue<void>();
@@ -11697,7 +11697,7 @@ return JaktInternal::ExplicitValue<void>();
 case 31 /* LeftShift */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.LeftShift;utility::Span const& span = __jakt_match_value.value;
 {
-TRY((((*this).error(TRY(ByteString::from_utf8("Expected trait name"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("Expected trait name"sv)),span))));
 return JaktInternal::LoopBreak{};
 }
 return JaktInternal::ExplicitValue<void>();
@@ -11705,7 +11705,7 @@ return JaktInternal::ExplicitValue<void>();
 case 32 /* LeftShiftEqual */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.LeftShiftEqual;utility::Span const& span = __jakt_match_value.value;
 {
-TRY((((*this).error(TRY(ByteString::from_utf8("Expected trait name"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("Expected trait name"sv)),span))));
 return JaktInternal::LoopBreak{};
 }
 return JaktInternal::ExplicitValue<void>();
@@ -11713,7 +11713,7 @@ return JaktInternal::ExplicitValue<void>();
 case 33 /* RightShift */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.RightShift;utility::Span const& span = __jakt_match_value.value;
 {
-TRY((((*this).error(TRY(ByteString::from_utf8("Expected trait name"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("Expected trait name"sv)),span))));
 return JaktInternal::LoopBreak{};
 }
 return JaktInternal::ExplicitValue<void>();
@@ -11721,7 +11721,7 @@ return JaktInternal::ExplicitValue<void>();
 case 34 /* RightArithmeticShift */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.RightArithmeticShift;utility::Span const& span = __jakt_match_value.value;
 {
-TRY((((*this).error(TRY(ByteString::from_utf8("Expected trait name"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("Expected trait name"sv)),span))));
 return JaktInternal::LoopBreak{};
 }
 return JaktInternal::ExplicitValue<void>();
@@ -11729,7 +11729,7 @@ return JaktInternal::ExplicitValue<void>();
 case 35 /* RightShiftEqual */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.RightShiftEqual;utility::Span const& span = __jakt_match_value.value;
 {
-TRY((((*this).error(TRY(ByteString::from_utf8("Expected trait name"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("Expected trait name"sv)),span))));
 return JaktInternal::LoopBreak{};
 }
 return JaktInternal::ExplicitValue<void>();
@@ -11737,7 +11737,7 @@ return JaktInternal::ExplicitValue<void>();
 case 36 /* Asterisk */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Asterisk;utility::Span const& span = __jakt_match_value.value;
 {
-TRY((((*this).error(TRY(ByteString::from_utf8("Expected trait name"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("Expected trait name"sv)),span))));
 return JaktInternal::LoopBreak{};
 }
 return JaktInternal::ExplicitValue<void>();
@@ -11745,7 +11745,7 @@ return JaktInternal::ExplicitValue<void>();
 case 37 /* Ampersand */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Ampersand;utility::Span const& span = __jakt_match_value.value;
 {
-TRY((((*this).error(TRY(ByteString::from_utf8("Expected trait name"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("Expected trait name"sv)),span))));
 return JaktInternal::LoopBreak{};
 }
 return JaktInternal::ExplicitValue<void>();
@@ -11753,7 +11753,7 @@ return JaktInternal::ExplicitValue<void>();
 case 38 /* AmpersandEqual */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.AmpersandEqual;utility::Span const& span = __jakt_match_value.value;
 {
-TRY((((*this).error(TRY(ByteString::from_utf8("Expected trait name"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("Expected trait name"sv)),span))));
 return JaktInternal::LoopBreak{};
 }
 return JaktInternal::ExplicitValue<void>();
@@ -11761,7 +11761,7 @@ return JaktInternal::ExplicitValue<void>();
 case 39 /* AmpersandAmpersand */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.AmpersandAmpersand;utility::Span const& span = __jakt_match_value.value;
 {
-TRY((((*this).error(TRY(ByteString::from_utf8("Expected trait name"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("Expected trait name"sv)),span))));
 return JaktInternal::LoopBreak{};
 }
 return JaktInternal::ExplicitValue<void>();
@@ -11769,7 +11769,7 @@ return JaktInternal::ExplicitValue<void>();
 case 40 /* Pipe */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Pipe;utility::Span const& span = __jakt_match_value.value;
 {
-TRY((((*this).error(TRY(ByteString::from_utf8("Expected trait name"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("Expected trait name"sv)),span))));
 return JaktInternal::LoopBreak{};
 }
 return JaktInternal::ExplicitValue<void>();
@@ -11777,7 +11777,7 @@ return JaktInternal::ExplicitValue<void>();
 case 41 /* PipeEqual */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.PipeEqual;utility::Span const& span = __jakt_match_value.value;
 {
-TRY((((*this).error(TRY(ByteString::from_utf8("Expected trait name"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("Expected trait name"sv)),span))));
 return JaktInternal::LoopBreak{};
 }
 return JaktInternal::ExplicitValue<void>();
@@ -11785,7 +11785,7 @@ return JaktInternal::ExplicitValue<void>();
 case 42 /* PipePipe */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.PipePipe;utility::Span const& span = __jakt_match_value.value;
 {
-TRY((((*this).error(TRY(ByteString::from_utf8("Expected trait name"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("Expected trait name"sv)),span))));
 return JaktInternal::LoopBreak{};
 }
 return JaktInternal::ExplicitValue<void>();
@@ -11793,7 +11793,7 @@ return JaktInternal::ExplicitValue<void>();
 case 43 /* Caret */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Caret;utility::Span const& span = __jakt_match_value.value;
 {
-TRY((((*this).error(TRY(ByteString::from_utf8("Expected trait name"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("Expected trait name"sv)),span))));
 return JaktInternal::LoopBreak{};
 }
 return JaktInternal::ExplicitValue<void>();
@@ -11801,7 +11801,7 @@ return JaktInternal::ExplicitValue<void>();
 case 44 /* CaretEqual */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.CaretEqual;utility::Span const& span = __jakt_match_value.value;
 {
-TRY((((*this).error(TRY(ByteString::from_utf8("Expected trait name"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("Expected trait name"sv)),span))));
 return JaktInternal::LoopBreak{};
 }
 return JaktInternal::ExplicitValue<void>();
@@ -11809,7 +11809,7 @@ return JaktInternal::ExplicitValue<void>();
 case 45 /* Dollar */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Dollar;utility::Span const& span = __jakt_match_value.value;
 {
-TRY((((*this).error(TRY(ByteString::from_utf8("Expected trait name"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("Expected trait name"sv)),span))));
 return JaktInternal::LoopBreak{};
 }
 return JaktInternal::ExplicitValue<void>();
@@ -11817,7 +11817,7 @@ return JaktInternal::ExplicitValue<void>();
 case 46 /* Tilde */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Tilde;utility::Span const& span = __jakt_match_value.value;
 {
-TRY((((*this).error(TRY(ByteString::from_utf8("Expected trait name"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("Expected trait name"sv)),span))));
 return JaktInternal::LoopBreak{};
 }
 return JaktInternal::ExplicitValue<void>();
@@ -11825,7 +11825,7 @@ return JaktInternal::ExplicitValue<void>();
 case 47 /* ForwardSlash */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.ForwardSlash;utility::Span const& span = __jakt_match_value.value;
 {
-TRY((((*this).error(TRY(ByteString::from_utf8("Expected trait name"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("Expected trait name"sv)),span))));
 return JaktInternal::LoopBreak{};
 }
 return JaktInternal::ExplicitValue<void>();
@@ -11833,7 +11833,7 @@ return JaktInternal::ExplicitValue<void>();
 case 48 /* ExclamationPoint */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.ExclamationPoint;utility::Span const& span = __jakt_match_value.value;
 {
-TRY((((*this).error(TRY(ByteString::from_utf8("Expected trait name"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("Expected trait name"sv)),span))));
 return JaktInternal::LoopBreak{};
 }
 return JaktInternal::ExplicitValue<void>();
@@ -11841,7 +11841,7 @@ return JaktInternal::ExplicitValue<void>();
 case 49 /* QuestionMark */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.QuestionMark;utility::Span const& span = __jakt_match_value.value;
 {
-TRY((((*this).error(TRY(ByteString::from_utf8("Expected trait name"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("Expected trait name"sv)),span))));
 return JaktInternal::LoopBreak{};
 }
 return JaktInternal::ExplicitValue<void>();
@@ -11849,7 +11849,7 @@ return JaktInternal::ExplicitValue<void>();
 case 50 /* QuestionMarkQuestionMark */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.QuestionMarkQuestionMark;utility::Span const& span = __jakt_match_value.value;
 {
-TRY((((*this).error(TRY(ByteString::from_utf8("Expected trait name"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("Expected trait name"sv)),span))));
 return JaktInternal::LoopBreak{};
 }
 return JaktInternal::ExplicitValue<void>();
@@ -11857,7 +11857,7 @@ return JaktInternal::ExplicitValue<void>();
 case 51 /* QuestionMarkQuestionMarkEqual */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.QuestionMarkQuestionMarkEqual;utility::Span const& span = __jakt_match_value.value;
 {
-TRY((((*this).error(TRY(ByteString::from_utf8("Expected trait name"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("Expected trait name"sv)),span))));
 return JaktInternal::LoopBreak{};
 }
 return JaktInternal::ExplicitValue<void>();
@@ -11865,7 +11865,7 @@ return JaktInternal::ExplicitValue<void>();
 case 53 /* Dot */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Dot;utility::Span const& span = __jakt_match_value.value;
 {
-TRY((((*this).error(TRY(ByteString::from_utf8("Expected trait name"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("Expected trait name"sv)),span))));
 return JaktInternal::LoopBreak{};
 }
 return JaktInternal::ExplicitValue<void>();
@@ -11873,7 +11873,7 @@ return JaktInternal::ExplicitValue<void>();
 case 54 /* DotDot */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.DotDot;utility::Span const& span = __jakt_match_value.value;
 {
-TRY((((*this).error(TRY(ByteString::from_utf8("Expected trait name"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("Expected trait name"sv)),span))));
 return JaktInternal::LoopBreak{};
 }
 return JaktInternal::ExplicitValue<void>();
@@ -11881,7 +11881,7 @@ return JaktInternal::ExplicitValue<void>();
 case 57 /* FatArrow */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.FatArrow;utility::Span const& span = __jakt_match_value.value;
 {
-TRY((((*this).error(TRY(ByteString::from_utf8("Expected trait name"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("Expected trait name"sv)),span))));
 return JaktInternal::LoopBreak{};
 }
 return JaktInternal::ExplicitValue<void>();
@@ -11889,7 +11889,7 @@ return JaktInternal::ExplicitValue<void>();
 case 58 /* Arrow */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Arrow;utility::Span const& span = __jakt_match_value.value;
 {
-TRY((((*this).error(TRY(ByteString::from_utf8("Expected trait name"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("Expected trait name"sv)),span))));
 return JaktInternal::LoopBreak{};
 }
 return JaktInternal::ExplicitValue<void>();
@@ -11897,7 +11897,7 @@ return JaktInternal::ExplicitValue<void>();
 case 59 /* And */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.And;utility::Span const& span = __jakt_match_value.value;
 {
-TRY((((*this).error(TRY(ByteString::from_utf8("Expected trait name"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("Expected trait name"sv)),span))));
 return JaktInternal::LoopBreak{};
 }
 return JaktInternal::ExplicitValue<void>();
@@ -11905,7 +11905,7 @@ return JaktInternal::ExplicitValue<void>();
 case 60 /* Anon */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Anon;utility::Span const& span = __jakt_match_value.value;
 {
-TRY((((*this).error(TRY(ByteString::from_utf8("Expected trait name"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("Expected trait name"sv)),span))));
 return JaktInternal::LoopBreak{};
 }
 return JaktInternal::ExplicitValue<void>();
@@ -11913,7 +11913,7 @@ return JaktInternal::ExplicitValue<void>();
 case 61 /* As */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.As;utility::Span const& span = __jakt_match_value.value;
 {
-TRY((((*this).error(TRY(ByteString::from_utf8("Expected trait name"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("Expected trait name"sv)),span))));
 return JaktInternal::LoopBreak{};
 }
 return JaktInternal::ExplicitValue<void>();
@@ -11921,7 +11921,7 @@ return JaktInternal::ExplicitValue<void>();
 case 62 /* Boxed */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Boxed;utility::Span const& span = __jakt_match_value.value;
 {
-TRY((((*this).error(TRY(ByteString::from_utf8("Expected trait name"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("Expected trait name"sv)),span))));
 return JaktInternal::LoopBreak{};
 }
 return JaktInternal::ExplicitValue<void>();
@@ -11929,7 +11929,7 @@ return JaktInternal::ExplicitValue<void>();
 case 63 /* Break */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Break;utility::Span const& span = __jakt_match_value.value;
 {
-TRY((((*this).error(TRY(ByteString::from_utf8("Expected trait name"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("Expected trait name"sv)),span))));
 return JaktInternal::LoopBreak{};
 }
 return JaktInternal::ExplicitValue<void>();
@@ -11937,7 +11937,7 @@ return JaktInternal::ExplicitValue<void>();
 case 64 /* Catch */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Catch;utility::Span const& span = __jakt_match_value.value;
 {
-TRY((((*this).error(TRY(ByteString::from_utf8("Expected trait name"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("Expected trait name"sv)),span))));
 return JaktInternal::LoopBreak{};
 }
 return JaktInternal::ExplicitValue<void>();
@@ -11945,7 +11945,7 @@ return JaktInternal::ExplicitValue<void>();
 case 65 /* Class */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Class;utility::Span const& span = __jakt_match_value.value;
 {
-TRY((((*this).error(TRY(ByteString::from_utf8("Expected trait name"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("Expected trait name"sv)),span))));
 return JaktInternal::LoopBreak{};
 }
 return JaktInternal::ExplicitValue<void>();
@@ -11953,7 +11953,7 @@ return JaktInternal::ExplicitValue<void>();
 case 66 /* Continue */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Continue;utility::Span const& span = __jakt_match_value.value;
 {
-TRY((((*this).error(TRY(ByteString::from_utf8("Expected trait name"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("Expected trait name"sv)),span))));
 return JaktInternal::LoopBreak{};
 }
 return JaktInternal::ExplicitValue<void>();
@@ -11961,7 +11961,7 @@ return JaktInternal::ExplicitValue<void>();
 case 67 /* Cpp */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Cpp;utility::Span const& span = __jakt_match_value.value;
 {
-TRY((((*this).error(TRY(ByteString::from_utf8("Expected trait name"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("Expected trait name"sv)),span))));
 return JaktInternal::LoopBreak{};
 }
 return JaktInternal::ExplicitValue<void>();
@@ -11969,7 +11969,7 @@ return JaktInternal::ExplicitValue<void>();
 case 68 /* Defer */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Defer;utility::Span const& span = __jakt_match_value.value;
 {
-TRY((((*this).error(TRY(ByteString::from_utf8("Expected trait name"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("Expected trait name"sv)),span))));
 return JaktInternal::LoopBreak{};
 }
 return JaktInternal::ExplicitValue<void>();
@@ -11977,7 +11977,7 @@ return JaktInternal::ExplicitValue<void>();
 case 69 /* Destructor */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Destructor;utility::Span const& span = __jakt_match_value.value;
 {
-TRY((((*this).error(TRY(ByteString::from_utf8("Expected trait name"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("Expected trait name"sv)),span))));
 return JaktInternal::LoopBreak{};
 }
 return JaktInternal::ExplicitValue<void>();
@@ -11985,7 +11985,7 @@ return JaktInternal::ExplicitValue<void>();
 case 70 /* Else */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Else;utility::Span const& span = __jakt_match_value.value;
 {
-TRY((((*this).error(TRY(ByteString::from_utf8("Expected trait name"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("Expected trait name"sv)),span))));
 return JaktInternal::LoopBreak{};
 }
 return JaktInternal::ExplicitValue<void>();
@@ -11993,7 +11993,7 @@ return JaktInternal::ExplicitValue<void>();
 case 71 /* Enum */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Enum;utility::Span const& span = __jakt_match_value.value;
 {
-TRY((((*this).error(TRY(ByteString::from_utf8("Expected trait name"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("Expected trait name"sv)),span))));
 return JaktInternal::LoopBreak{};
 }
 return JaktInternal::ExplicitValue<void>();
@@ -12001,7 +12001,7 @@ return JaktInternal::ExplicitValue<void>();
 case 72 /* Extern */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Extern;utility::Span const& span = __jakt_match_value.value;
 {
-TRY((((*this).error(TRY(ByteString::from_utf8("Expected trait name"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("Expected trait name"sv)),span))));
 return JaktInternal::LoopBreak{};
 }
 return JaktInternal::ExplicitValue<void>();
@@ -12009,7 +12009,7 @@ return JaktInternal::ExplicitValue<void>();
 case 73 /* False */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.False;utility::Span const& span = __jakt_match_value.value;
 {
-TRY((((*this).error(TRY(ByteString::from_utf8("Expected trait name"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("Expected trait name"sv)),span))));
 return JaktInternal::LoopBreak{};
 }
 return JaktInternal::ExplicitValue<void>();
@@ -12017,7 +12017,7 @@ return JaktInternal::ExplicitValue<void>();
 case 74 /* For */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.For;utility::Span const& span = __jakt_match_value.value;
 {
-TRY((((*this).error(TRY(ByteString::from_utf8("Expected trait name"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("Expected trait name"sv)),span))));
 return JaktInternal::LoopBreak{};
 }
 return JaktInternal::ExplicitValue<void>();
@@ -12025,7 +12025,7 @@ return JaktInternal::ExplicitValue<void>();
 case 75 /* Fn */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Fn;utility::Span const& span = __jakt_match_value.value;
 {
-TRY((((*this).error(TRY(ByteString::from_utf8("Expected trait name"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("Expected trait name"sv)),span))));
 return JaktInternal::LoopBreak{};
 }
 return JaktInternal::ExplicitValue<void>();
@@ -12033,7 +12033,7 @@ return JaktInternal::ExplicitValue<void>();
 case 76 /* Comptime */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Comptime;utility::Span const& span = __jakt_match_value.value;
 {
-TRY((((*this).error(TRY(ByteString::from_utf8("Expected trait name"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("Expected trait name"sv)),span))));
 return JaktInternal::LoopBreak{};
 }
 return JaktInternal::ExplicitValue<void>();
@@ -12041,7 +12041,7 @@ return JaktInternal::ExplicitValue<void>();
 case 77 /* If */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.If;utility::Span const& span = __jakt_match_value.value;
 {
-TRY((((*this).error(TRY(ByteString::from_utf8("Expected trait name"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("Expected trait name"sv)),span))));
 return JaktInternal::LoopBreak{};
 }
 return JaktInternal::ExplicitValue<void>();
@@ -12049,7 +12049,7 @@ return JaktInternal::ExplicitValue<void>();
 case 78 /* Import */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Import;utility::Span const& span = __jakt_match_value.value;
 {
-TRY((((*this).error(TRY(ByteString::from_utf8("Expected trait name"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("Expected trait name"sv)),span))));
 return JaktInternal::LoopBreak{};
 }
 return JaktInternal::ExplicitValue<void>();
@@ -12057,7 +12057,7 @@ return JaktInternal::ExplicitValue<void>();
 case 79 /* Relative */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Relative;utility::Span const& span = __jakt_match_value.value;
 {
-TRY((((*this).error(TRY(ByteString::from_utf8("Expected trait name"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("Expected trait name"sv)),span))));
 return JaktInternal::LoopBreak{};
 }
 return JaktInternal::ExplicitValue<void>();
@@ -12065,7 +12065,7 @@ return JaktInternal::ExplicitValue<void>();
 case 80 /* In */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.In;utility::Span const& span = __jakt_match_value.value;
 {
-TRY((((*this).error(TRY(ByteString::from_utf8("Expected trait name"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("Expected trait name"sv)),span))));
 return JaktInternal::LoopBreak{};
 }
 return JaktInternal::ExplicitValue<void>();
@@ -12073,7 +12073,7 @@ return JaktInternal::ExplicitValue<void>();
 case 81 /* Is */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Is;utility::Span const& span = __jakt_match_value.value;
 {
-TRY((((*this).error(TRY(ByteString::from_utf8("Expected trait name"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("Expected trait name"sv)),span))));
 return JaktInternal::LoopBreak{};
 }
 return JaktInternal::ExplicitValue<void>();
@@ -12081,7 +12081,7 @@ return JaktInternal::ExplicitValue<void>();
 case 82 /* Let */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Let;utility::Span const& span = __jakt_match_value.value;
 {
-TRY((((*this).error(TRY(ByteString::from_utf8("Expected trait name"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("Expected trait name"sv)),span))));
 return JaktInternal::LoopBreak{};
 }
 return JaktInternal::ExplicitValue<void>();
@@ -12089,7 +12089,7 @@ return JaktInternal::ExplicitValue<void>();
 case 83 /* Loop */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Loop;utility::Span const& span = __jakt_match_value.value;
 {
-TRY((((*this).error(TRY(ByteString::from_utf8("Expected trait name"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("Expected trait name"sv)),span))));
 return JaktInternal::LoopBreak{};
 }
 return JaktInternal::ExplicitValue<void>();
@@ -12097,7 +12097,7 @@ return JaktInternal::ExplicitValue<void>();
 case 84 /* Match */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Match;utility::Span const& span = __jakt_match_value.value;
 {
-TRY((((*this).error(TRY(ByteString::from_utf8("Expected trait name"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("Expected trait name"sv)),span))));
 return JaktInternal::LoopBreak{};
 }
 return JaktInternal::ExplicitValue<void>();
@@ -12105,7 +12105,7 @@ return JaktInternal::ExplicitValue<void>();
 case 85 /* Mut */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Mut;utility::Span const& span = __jakt_match_value.value;
 {
-TRY((((*this).error(TRY(ByteString::from_utf8("Expected trait name"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("Expected trait name"sv)),span))));
 return JaktInternal::LoopBreak{};
 }
 return JaktInternal::ExplicitValue<void>();
@@ -12113,7 +12113,7 @@ return JaktInternal::ExplicitValue<void>();
 case 86 /* Namespace */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Namespace;utility::Span const& span = __jakt_match_value.value;
 {
-TRY((((*this).error(TRY(ByteString::from_utf8("Expected trait name"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("Expected trait name"sv)),span))));
 return JaktInternal::LoopBreak{};
 }
 return JaktInternal::ExplicitValue<void>();
@@ -12121,7 +12121,7 @@ return JaktInternal::ExplicitValue<void>();
 case 87 /* Not */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Not;utility::Span const& span = __jakt_match_value.value;
 {
-TRY((((*this).error(TRY(ByteString::from_utf8("Expected trait name"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("Expected trait name"sv)),span))));
 return JaktInternal::LoopBreak{};
 }
 return JaktInternal::ExplicitValue<void>();
@@ -12129,7 +12129,7 @@ return JaktInternal::ExplicitValue<void>();
 case 88 /* Or */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Or;utility::Span const& span = __jakt_match_value.value;
 {
-TRY((((*this).error(TRY(ByteString::from_utf8("Expected trait name"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("Expected trait name"sv)),span))));
 return JaktInternal::LoopBreak{};
 }
 return JaktInternal::ExplicitValue<void>();
@@ -12137,7 +12137,7 @@ return JaktInternal::ExplicitValue<void>();
 case 89 /* Override */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Override;utility::Span const& span = __jakt_match_value.value;
 {
-TRY((((*this).error(TRY(ByteString::from_utf8("Expected trait name"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("Expected trait name"sv)),span))));
 return JaktInternal::LoopBreak{};
 }
 return JaktInternal::ExplicitValue<void>();
@@ -12145,7 +12145,7 @@ return JaktInternal::ExplicitValue<void>();
 case 90 /* Private */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Private;utility::Span const& span = __jakt_match_value.value;
 {
-TRY((((*this).error(TRY(ByteString::from_utf8("Expected trait name"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("Expected trait name"sv)),span))));
 return JaktInternal::LoopBreak{};
 }
 return JaktInternal::ExplicitValue<void>();
@@ -12153,7 +12153,7 @@ return JaktInternal::ExplicitValue<void>();
 case 91 /* Public */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Public;utility::Span const& span = __jakt_match_value.value;
 {
-TRY((((*this).error(TRY(ByteString::from_utf8("Expected trait name"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("Expected trait name"sv)),span))));
 return JaktInternal::LoopBreak{};
 }
 return JaktInternal::ExplicitValue<void>();
@@ -12161,7 +12161,7 @@ return JaktInternal::ExplicitValue<void>();
 case 92 /* Raw */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Raw;utility::Span const& span = __jakt_match_value.value;
 {
-TRY((((*this).error(TRY(ByteString::from_utf8("Expected trait name"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("Expected trait name"sv)),span))));
 return JaktInternal::LoopBreak{};
 }
 return JaktInternal::ExplicitValue<void>();
@@ -12169,7 +12169,7 @@ return JaktInternal::ExplicitValue<void>();
 case 93 /* Reflect */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Reflect;utility::Span const& span = __jakt_match_value.value;
 {
-TRY((((*this).error(TRY(ByteString::from_utf8("Expected trait name"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("Expected trait name"sv)),span))));
 return JaktInternal::LoopBreak{};
 }
 return JaktInternal::ExplicitValue<void>();
@@ -12177,7 +12177,7 @@ return JaktInternal::ExplicitValue<void>();
 case 94 /* Return */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Return;utility::Span const& span = __jakt_match_value.value;
 {
-TRY((((*this).error(TRY(ByteString::from_utf8("Expected trait name"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("Expected trait name"sv)),span))));
 return JaktInternal::LoopBreak{};
 }
 return JaktInternal::ExplicitValue<void>();
@@ -12185,7 +12185,7 @@ return JaktInternal::ExplicitValue<void>();
 case 95 /* Restricted */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Restricted;utility::Span const& span = __jakt_match_value.value;
 {
-TRY((((*this).error(TRY(ByteString::from_utf8("Expected trait name"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("Expected trait name"sv)),span))));
 return JaktInternal::LoopBreak{};
 }
 return JaktInternal::ExplicitValue<void>();
@@ -12193,7 +12193,7 @@ return JaktInternal::ExplicitValue<void>();
 case 96 /* Sizeof */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Sizeof;utility::Span const& span = __jakt_match_value.value;
 {
-TRY((((*this).error(TRY(ByteString::from_utf8("Expected trait name"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("Expected trait name"sv)),span))));
 return JaktInternal::LoopBreak{};
 }
 return JaktInternal::ExplicitValue<void>();
@@ -12201,7 +12201,7 @@ return JaktInternal::ExplicitValue<void>();
 case 97 /* Struct */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Struct;utility::Span const& span = __jakt_match_value.value;
 {
-TRY((((*this).error(TRY(ByteString::from_utf8("Expected trait name"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("Expected trait name"sv)),span))));
 return JaktInternal::LoopBreak{};
 }
 return JaktInternal::ExplicitValue<void>();
@@ -12209,7 +12209,7 @@ return JaktInternal::ExplicitValue<void>();
 case 98 /* This */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.This;utility::Span const& span = __jakt_match_value.value;
 {
-TRY((((*this).error(TRY(ByteString::from_utf8("Expected trait name"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("Expected trait name"sv)),span))));
 return JaktInternal::LoopBreak{};
 }
 return JaktInternal::ExplicitValue<void>();
@@ -12217,7 +12217,7 @@ return JaktInternal::ExplicitValue<void>();
 case 99 /* Throw */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Throw;utility::Span const& span = __jakt_match_value.value;
 {
-TRY((((*this).error(TRY(ByteString::from_utf8("Expected trait name"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("Expected trait name"sv)),span))));
 return JaktInternal::LoopBreak{};
 }
 return JaktInternal::ExplicitValue<void>();
@@ -12225,7 +12225,7 @@ return JaktInternal::ExplicitValue<void>();
 case 100 /* Throws */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Throws;utility::Span const& span = __jakt_match_value.value;
 {
-TRY((((*this).error(TRY(ByteString::from_utf8("Expected trait name"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("Expected trait name"sv)),span))));
 return JaktInternal::LoopBreak{};
 }
 return JaktInternal::ExplicitValue<void>();
@@ -12233,7 +12233,7 @@ return JaktInternal::ExplicitValue<void>();
 case 101 /* True */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.True;utility::Span const& span = __jakt_match_value.value;
 {
-TRY((((*this).error(TRY(ByteString::from_utf8("Expected trait name"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("Expected trait name"sv)),span))));
 return JaktInternal::LoopBreak{};
 }
 return JaktInternal::ExplicitValue<void>();
@@ -12241,7 +12241,7 @@ return JaktInternal::ExplicitValue<void>();
 case 102 /* Try */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Try;utility::Span const& span = __jakt_match_value.value;
 {
-TRY((((*this).error(TRY(ByteString::from_utf8("Expected trait name"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("Expected trait name"sv)),span))));
 return JaktInternal::LoopBreak{};
 }
 return JaktInternal::ExplicitValue<void>();
@@ -12249,7 +12249,7 @@ return JaktInternal::ExplicitValue<void>();
 case 103 /* Unsafe */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Unsafe;utility::Span const& span = __jakt_match_value.value;
 {
-TRY((((*this).error(TRY(ByteString::from_utf8("Expected trait name"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("Expected trait name"sv)),span))));
 return JaktInternal::LoopBreak{};
 }
 return JaktInternal::ExplicitValue<void>();
@@ -12257,7 +12257,7 @@ return JaktInternal::ExplicitValue<void>();
 case 104 /* Virtual */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Virtual;utility::Span const& span = __jakt_match_value.value;
 {
-TRY((((*this).error(TRY(ByteString::from_utf8("Expected trait name"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("Expected trait name"sv)),span))));
 return JaktInternal::LoopBreak{};
 }
 return JaktInternal::ExplicitValue<void>();
@@ -12265,7 +12265,7 @@ return JaktInternal::ExplicitValue<void>();
 case 105 /* Weak */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Weak;utility::Span const& span = __jakt_match_value.value;
 {
-TRY((((*this).error(TRY(ByteString::from_utf8("Expected trait name"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("Expected trait name"sv)),span))));
 return JaktInternal::LoopBreak{};
 }
 return JaktInternal::ExplicitValue<void>();
@@ -12273,7 +12273,7 @@ return JaktInternal::ExplicitValue<void>();
 case 106 /* While */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.While;utility::Span const& span = __jakt_match_value.value;
 {
-TRY((((*this).error(TRY(ByteString::from_utf8("Expected trait name"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("Expected trait name"sv)),span))));
 return JaktInternal::LoopBreak{};
 }
 return JaktInternal::ExplicitValue<void>();
@@ -12281,7 +12281,7 @@ return JaktInternal::ExplicitValue<void>();
 case 107 /* Yield */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Yield;utility::Span const& span = __jakt_match_value.value;
 {
-TRY((((*this).error(TRY(ByteString::from_utf8("Expected trait name"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("Expected trait name"sv)),span))));
 return JaktInternal::LoopBreak{};
 }
 return JaktInternal::ExplicitValue<void>();
@@ -12289,7 +12289,7 @@ return JaktInternal::ExplicitValue<void>();
 case 108 /* Guard */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Guard;utility::Span const& span = __jakt_match_value.value;
 {
-TRY((((*this).error(TRY(ByteString::from_utf8("Expected trait name"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("Expected trait name"sv)),span))));
 return JaktInternal::LoopBreak{};
 }
 return JaktInternal::ExplicitValue<void>();
@@ -12297,7 +12297,7 @@ return JaktInternal::ExplicitValue<void>();
 case 109 /* Implements */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Implements;utility::Span const& span = __jakt_match_value.value;
 {
-TRY((((*this).error(TRY(ByteString::from_utf8("Expected trait name"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("Expected trait name"sv)),span))));
 return JaktInternal::LoopBreak{};
 }
 return JaktInternal::ExplicitValue<void>();
@@ -12305,7 +12305,7 @@ return JaktInternal::ExplicitValue<void>();
 case 110 /* Requires */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Requires;utility::Span const& span = __jakt_match_value.value;
 {
-TRY((((*this).error(TRY(ByteString::from_utf8("Expected trait name"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("Expected trait name"sv)),span))));
 return JaktInternal::LoopBreak{};
 }
 return JaktInternal::ExplicitValue<void>();
@@ -12313,7 +12313,7 @@ return JaktInternal::ExplicitValue<void>();
 case 111 /* Trait */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Trait;utility::Span const& span = __jakt_match_value.value;
 {
-TRY((((*this).error(TRY(ByteString::from_utf8("Expected trait name"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("Expected trait name"sv)),span))));
 return JaktInternal::LoopBreak{};
 }
 return JaktInternal::ExplicitValue<void>();
@@ -12321,7 +12321,7 @@ return JaktInternal::ExplicitValue<void>();
 case 112 /* Garbage */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Garbage;utility::Span const& span = __jakt_match_value.span;
 {
-TRY((((*this).error(TRY(ByteString::from_utf8("Expected trait name"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("Expected trait name"sv)),span))));
 return JaktInternal::LoopBreak{};
 }
 return JaktInternal::ExplicitValue<void>();
@@ -12339,7 +12339,7 @@ default: VERIFY_NOT_REACHED();}/*switch end*/
 });
 }
 if (((result).is_empty())){
-TRY((((*this).error(TRY(ByteString::from_utf8("Expected trait list to have at least one trait inside it"sv)),((((*this).previous())).span())))));
+TRY((((*this).error((ByteString::must_from_utf8("Expected trait list to have at least one trait inside it"sv)),((((*this).previous())).span())))));
 return JaktInternal::OptionalNone();
 }
 else {
@@ -12348,7 +12348,7 @@ return static_cast<JaktInternal::Optional<JaktInternal::DynamicArray<parser::Par
 
 }
 else {
-TRY((((*this).error(TRY(ByteString::from_utf8("Expected '(' to start the trait list"sv)),((((*this).current())).span())))));
+TRY((((*this).error((ByteString::must_from_utf8("Expected '(' to start the trait list"sv)),((((*this).current())).span())))));
 return JaktInternal::OptionalNone();
 }
 
@@ -12944,7 +12944,7 @@ return JaktInternal::ExplicitValue(name);
 };/*case end*/
 case 2 /* Operator */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Operator;ByteString const& name = __jakt_match_value.name;
-return JaktInternal::ExplicitValue(TRY((((TRY(ByteString::from_utf8("operator"sv))) + (name)))));
+return JaktInternal::ExplicitValue(TRY(((((ByteString::must_from_utf8("operator"sv))) + (name)))));
 };/*case end*/
 default: VERIFY_NOT_REACHED();}/*switch end*/
 }()
@@ -13100,7 +13100,7 @@ ByteString const name = (*this).as.Literal.name;
 return name;
 }
 else {
-utility::panic(TRY(ByteString::from_utf8("Cannot get literal name of non-literal import name"sv)));
+utility::panic((ByteString::must_from_utf8("Cannot get literal name of non-literal import name"sv)));
 }
 
 }
@@ -23401,19 +23401,19 @@ return ({
 auto&& __jakt_match_variant = *this;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 0 /* Struct */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("struct"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("struct"sv)));
 };/*case end*/
 case 1 /* Class */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("class"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("class"sv)));
 };/*case end*/
 case 2 /* ValueEnum */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("value enum"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("value enum"sv)));
 };/*case end*/
 case 3 /* SumEnum */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("sum enum"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("sum enum"sv)));
 };/*case end*/
 case 4 /* Garbage */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("<garbage record type>"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("<garbage record type>"sv)));
 };/*case end*/
 default: VERIFY_NOT_REACHED();}/*switch end*/
 }()

--- a/bootstrap/stage0/parser.h
+++ b/bootstrap/stage0/parser.h
@@ -6,54 +6,67 @@
 #include "compiler.h"
 namespace Jakt {
 namespace parser {
-struct ValueEnumVariant {
-  public:
-public: ByteString name;public: utility::Span span;public: JaktInternal::Optional<NonnullRefPtr<typename parser::ParsedExpression>> value;public: ValueEnumVariant(ByteString a_name, utility::Span a_span, JaktInternal::Optional<NonnullRefPtr<typename parser::ParsedExpression>> a_value);
-
-public: ErrorOr<ByteString> debug_description() const;
-};struct EnumVariantPatternArgument {
-  public:
-public: JaktInternal::Optional<ByteString> name;public: JaktInternal::Optional<utility::Span> name_span;public: ByteString binding;public: utility::Span span;public: bool is_reference;public: bool is_mutable;public: utility::Span name_in_enum_span() const;
-public: ByteString name_in_enum() const;
-public: EnumVariantPatternArgument(JaktInternal::Optional<ByteString> a_name, JaktInternal::Optional<utility::Span> a_name_span, ByteString a_binding, utility::Span a_span, bool a_is_reference, bool a_is_mutable);
-
-public: bool equals(parser::EnumVariantPatternArgument const rhs_variant_pattern_argument) const;
-public: ErrorOr<ByteString> debug_description() const;
-};struct Visibility {
+struct ParsedTraitRequirements {
 u8 __jakt_variant_index = 0;
 union VariantData {
 u8 __jakt_uninit_value;
 struct {
-JaktInternal::DynamicArray<parser::VisibilityRestriction> whitelist;
-utility::Span span;
-} Restricted;
+JaktInternal::DynamicArray<parser::ParsedFunction> value;
+} Methods;
+struct {
+NonnullRefPtr<typename parser::ParsedExpression> value;
+} ComptimeExpression;
 constexpr VariantData() {}
 ~VariantData() {}
 } as;
 constexpr u8 __jakt_init_index() const noexcept { return __jakt_variant_index - 1; }ErrorOr<ByteString> debug_description() const;
-[[nodiscard]] static Visibility Public();
-[[nodiscard]] static Visibility Private();
-[[nodiscard]] static Visibility Restricted(JaktInternal::DynamicArray<parser::VisibilityRestriction> whitelist, utility::Span span);
-~Visibility();
-Visibility& operator=(Visibility const &);
-Visibility& operator=(Visibility &&);
-Visibility(Visibility const&);
-Visibility(Visibility &&);
+[[nodiscard]] static ParsedTraitRequirements Nothing();
+[[nodiscard]] static ParsedTraitRequirements Methods(JaktInternal::DynamicArray<parser::ParsedFunction> value);
+[[nodiscard]] static ParsedTraitRequirements ComptimeExpression(NonnullRefPtr<typename parser::ParsedExpression> value);
+~ParsedTraitRequirements();
+ParsedTraitRequirements& operator=(ParsedTraitRequirements const &);
+ParsedTraitRequirements& operator=(ParsedTraitRequirements &&);
+ParsedTraitRequirements(ParsedTraitRequirements const&);
+ParsedTraitRequirements(ParsedTraitRequirements &&);
 private: void __jakt_destroy_variant();
 public:
 private:
-Visibility() {};
+ParsedTraitRequirements() {};
 };
-struct ParsedBlock {
+struct ParsedTrait {
   public:
-public: JaktInternal::DynamicArray<NonnullRefPtr<typename parser::ParsedStatement>> stmts;public: ParsedBlock(JaktInternal::DynamicArray<NonnullRefPtr<typename parser::ParsedStatement>> a_stmts);
+public: ByteString name;public: utility::Span name_span;public: JaktInternal::DynamicArray<parser::ParsedGenericParameter> generic_parameters;public: parser::ParsedTraitRequirements requirements;public: ParsedTrait(ByteString a_name, utility::Span a_name_span, JaktInternal::DynamicArray<parser::ParsedGenericParameter> a_generic_parameters, parser::ParsedTraitRequirements a_requirements);
 
-public: JaktInternal::Optional<utility::Span> find_yield_span() const;
-public: bool equals(parser::ParsedBlock const rhs_block) const;
-public: ErrorOr<JaktInternal::Optional<utility::Span>> span(parser::Parser const parser) const;
-public: JaktInternal::Optional<utility::Span> find_yield_keyword_span() const;
 public: ErrorOr<ByteString> debug_description() const;
-};struct ExternalName {
+};struct ParsedNameWithGenericParameters {
+  public:
+public: ByteString name;public: utility::Span name_span;public: JaktInternal::DynamicArray<NonnullRefPtr<typename parser::ParsedType>> generic_parameters;public: ParsedNameWithGenericParameters(ByteString a_name, utility::Span a_name_span, JaktInternal::DynamicArray<NonnullRefPtr<typename parser::ParsedType>> a_generic_parameters);
+
+public: ErrorOr<ByteString> debug_description() const;
+};struct ArgumentStoreLevel {
+u8 __jakt_variant_index = 0;
+union VariantData {
+u8 __jakt_uninit_value;
+struct {
+size_t argument_index;
+} InObject;
+constexpr VariantData() {}
+~VariantData() {}
+} as;
+constexpr u8 __jakt_init_index() const noexcept { return __jakt_variant_index - 1; }ErrorOr<ByteString> debug_description() const;
+[[nodiscard]] static ArgumentStoreLevel InObject(size_t argument_index);
+[[nodiscard]] static ArgumentStoreLevel InStaticStorage();
+~ArgumentStoreLevel();
+ArgumentStoreLevel& operator=(ArgumentStoreLevel const &);
+ArgumentStoreLevel& operator=(ArgumentStoreLevel &&);
+ArgumentStoreLevel(ArgumentStoreLevel const&);
+ArgumentStoreLevel(ArgumentStoreLevel &&);
+private: void __jakt_destroy_variant();
+public:
+private:
+ArgumentStoreLevel() {};
+};
+struct ExternalName {
 u8 __jakt_variant_index = 0;
 union VariantData {
 u8 __jakt_uninit_value;
@@ -94,252 +107,41 @@ public: ByteString name;public: NonnullRefPtr<typename parser::ParsedType> parse
 public: ParsedVarDecl(ByteString a_name, NonnullRefPtr<typename parser::ParsedType> a_parsed_type, bool a_is_mutable, JaktInternal::Optional<utility::Span> a_inlay_span, utility::Span a_span, JaktInternal::Optional<parser::ExternalName> a_external_name);
 
 public: ErrorOr<ByteString> debug_description() const;
-};struct ParsedStatement: public RefCounted<ParsedStatement> {
+};struct Visibility {
 u8 __jakt_variant_index = 0;
 union VariantData {
 u8 __jakt_uninit_value;
 struct {
-NonnullRefPtr<typename parser::ParsedExpression> expr;
+JaktInternal::DynamicArray<parser::VisibilityRestriction> whitelist;
 utility::Span span;
-} Expression;
-struct {
-NonnullRefPtr<typename parser::ParsedStatement> statement;
-utility::Span span;
-} Defer;
-struct {
-parser::ParsedBlock block;
-utility::Span span;
-} UnsafeBlock;
-struct {
-JaktInternal::DynamicArray<parser::ParsedVarDecl> vars;
-NonnullRefPtr<typename parser::ParsedStatement> var_decl;
-utility::Span span;
-} DestructuringAssignment;
-struct {
-parser::ParsedVarDecl var;
-NonnullRefPtr<typename parser::ParsedExpression> init;
-utility::Span span;
-} VarDecl;
-struct {
-NonnullRefPtr<typename parser::ParsedExpression> condition;
-parser::ParsedBlock then_block;
-JaktInternal::Optional<NonnullRefPtr<typename parser::ParsedStatement>> else_statement;
-utility::Span span;
-} If;
-struct {
-parser::ParsedBlock block;
-utility::Span span;
-} Block;
-struct {
-parser::ParsedBlock block;
-utility::Span span;
-} Loop;
-struct {
-NonnullRefPtr<typename parser::ParsedExpression> condition;
-parser::ParsedBlock block;
-utility::Span span;
-} While;
-struct {
-ByteString iterator_name;
-utility::Span name_span;
-bool is_destructuring;
-NonnullRefPtr<typename parser::ParsedExpression> range;
-parser::ParsedBlock block;
-utility::Span span;
-} For;
-struct {
-utility::Span value;
-} Break;
-struct {
-utility::Span value;
-} Continue;
-struct {
-JaktInternal::Optional<NonnullRefPtr<typename parser::ParsedExpression>> expr;
-utility::Span span;
-} Return;
-struct {
-NonnullRefPtr<typename parser::ParsedExpression> expr;
-utility::Span span;
-} Throw;
-struct {
-NonnullRefPtr<typename parser::ParsedExpression> expr;
-utility::Span span;
-} Yield;
-struct {
-parser::ParsedBlock block;
-utility::Span span;
-} InlineCpp;
-struct {
-NonnullRefPtr<typename parser::ParsedExpression> expr;
-parser::ParsedBlock else_block;
-parser::ParsedBlock remaining_code;
-utility::Span span;
-} Guard;
-struct {
-utility::Span value;
-} Garbage;
+} Restricted;
 constexpr VariantData() {}
 ~VariantData() {}
 } as;
 constexpr u8 __jakt_init_index() const noexcept { return __jakt_variant_index - 1; }ErrorOr<ByteString> debug_description() const;
-[[nodiscard]] static ErrorOr<NonnullRefPtr<ParsedStatement>> Expression(NonnullRefPtr<typename parser::ParsedExpression> expr, utility::Span span);
-[[nodiscard]] static ErrorOr<NonnullRefPtr<ParsedStatement>> Defer(NonnullRefPtr<typename parser::ParsedStatement> statement, utility::Span span);
-[[nodiscard]] static ErrorOr<NonnullRefPtr<ParsedStatement>> UnsafeBlock(parser::ParsedBlock block, utility::Span span);
-[[nodiscard]] static ErrorOr<NonnullRefPtr<ParsedStatement>> DestructuringAssignment(JaktInternal::DynamicArray<parser::ParsedVarDecl> vars, NonnullRefPtr<typename parser::ParsedStatement> var_decl, utility::Span span);
-[[nodiscard]] static ErrorOr<NonnullRefPtr<ParsedStatement>> VarDecl(parser::ParsedVarDecl var, NonnullRefPtr<typename parser::ParsedExpression> init, utility::Span span);
-[[nodiscard]] static ErrorOr<NonnullRefPtr<ParsedStatement>> If(NonnullRefPtr<typename parser::ParsedExpression> condition, parser::ParsedBlock then_block, JaktInternal::Optional<NonnullRefPtr<typename parser::ParsedStatement>> else_statement, utility::Span span);
-[[nodiscard]] static ErrorOr<NonnullRefPtr<ParsedStatement>> Block(parser::ParsedBlock block, utility::Span span);
-[[nodiscard]] static ErrorOr<NonnullRefPtr<ParsedStatement>> Loop(parser::ParsedBlock block, utility::Span span);
-[[nodiscard]] static ErrorOr<NonnullRefPtr<ParsedStatement>> While(NonnullRefPtr<typename parser::ParsedExpression> condition, parser::ParsedBlock block, utility::Span span);
-[[nodiscard]] static ErrorOr<NonnullRefPtr<ParsedStatement>> For(ByteString iterator_name, utility::Span name_span, bool is_destructuring, NonnullRefPtr<typename parser::ParsedExpression> range, parser::ParsedBlock block, utility::Span span);
-[[nodiscard]] static ErrorOr<NonnullRefPtr<ParsedStatement>> Break(utility::Span value);
-[[nodiscard]] static ErrorOr<NonnullRefPtr<ParsedStatement>> Continue(utility::Span value);
-[[nodiscard]] static ErrorOr<NonnullRefPtr<ParsedStatement>> Return(JaktInternal::Optional<NonnullRefPtr<typename parser::ParsedExpression>> expr, utility::Span span);
-[[nodiscard]] static ErrorOr<NonnullRefPtr<ParsedStatement>> Throw(NonnullRefPtr<typename parser::ParsedExpression> expr, utility::Span span);
-[[nodiscard]] static ErrorOr<NonnullRefPtr<ParsedStatement>> Yield(NonnullRefPtr<typename parser::ParsedExpression> expr, utility::Span span);
-[[nodiscard]] static ErrorOr<NonnullRefPtr<ParsedStatement>> InlineCpp(parser::ParsedBlock block, utility::Span span);
-[[nodiscard]] static ErrorOr<NonnullRefPtr<ParsedStatement>> Guard(NonnullRefPtr<typename parser::ParsedExpression> expr, parser::ParsedBlock else_block, parser::ParsedBlock remaining_code, utility::Span span);
-[[nodiscard]] static ErrorOr<NonnullRefPtr<ParsedStatement>> Garbage(utility::Span value);
-~ParsedStatement();
-ParsedStatement& operator=(ParsedStatement const &);
-ParsedStatement& operator=(ParsedStatement &&);
-ParsedStatement(ParsedStatement const&);
-ParsedStatement(ParsedStatement &&);
+[[nodiscard]] static Visibility Public();
+[[nodiscard]] static Visibility Private();
+[[nodiscard]] static Visibility Restricted(JaktInternal::DynamicArray<parser::VisibilityRestriction> whitelist, utility::Span span);
+~Visibility();
+Visibility& operator=(Visibility const &);
+Visibility& operator=(Visibility &&);
+Visibility(Visibility const&);
+Visibility(Visibility &&);
 private: void __jakt_destroy_variant();
 public:
-bool equals(NonnullRefPtr<typename parser::ParsedStatement> const rhs_statement) const;
-utility::Span span() const;
 private:
-ParsedStatement() {};
+Visibility() {};
 };
-struct ParsedGenericParameter {
+struct ParsedBlock {
   public:
-public: ByteString name;public: utility::Span span;public: JaktInternal::Optional<JaktInternal::DynamicArray<parser::ParsedNameWithGenericParameters>> requires_list;public: bool is_value;public: ParsedGenericParameter(ByteString a_name, utility::Span a_span, JaktInternal::Optional<JaktInternal::DynamicArray<parser::ParsedNameWithGenericParameters>> a_requires_list, bool a_is_value);
+public: JaktInternal::DynamicArray<NonnullRefPtr<typename parser::ParsedStatement>> stmts;public: ParsedBlock(JaktInternal::DynamicArray<NonnullRefPtr<typename parser::ParsedStatement>> a_stmts);
 
+public: JaktInternal::Optional<utility::Span> find_yield_span() const;
+public: bool equals(parser::ParsedBlock const rhs_block) const;
+public: ErrorOr<JaktInternal::Optional<utility::Span>> span(parser::Parser const parser) const;
+public: JaktInternal::Optional<utility::Span> find_yield_keyword_span() const;
 public: ErrorOr<ByteString> debug_description() const;
-};struct ParsedField {
-  public:
-public: parser::ParsedVarDecl var_decl;public: parser::Visibility visibility;public: JaktInternal::Optional<NonnullRefPtr<typename parser::ParsedExpression>> default_value;public: ParsedField(parser::ParsedVarDecl a_var_decl, parser::Visibility a_visibility, JaktInternal::Optional<NonnullRefPtr<typename parser::ParsedExpression>> a_default_value);
-
-public: ErrorOr<ByteString> debug_description() const;
-};struct ParsedName {
-  public:
-public: ByteString name;public: utility::Span span;public: ParsedName(ByteString a_name, utility::Span a_span);
-
-public: ErrorOr<ByteString> debug_description() const;
-};struct ParsedVariable {
-  public:
-public: ByteString name;public: NonnullRefPtr<typename parser::ParsedType> parsed_type;public: bool is_mutable;public: utility::Span span;public: ParsedVariable(ByteString a_name, NonnullRefPtr<typename parser::ParsedType> a_parsed_type, bool a_is_mutable, utility::Span a_span);
-
-public: bool equals(parser::ParsedVariable const rhs_parsed_varible) const;
-public: ErrorOr<ByteString> debug_description() const;
-};struct ParsedParameter {
-  public:
-public: bool requires_label;public: parser::ParsedVariable variable;public: JaktInternal::Optional<NonnullRefPtr<typename parser::ParsedExpression>> default_argument;public: utility::Span span;public: ParsedParameter(bool a_requires_label, parser::ParsedVariable a_variable, JaktInternal::Optional<NonnullRefPtr<typename parser::ParsedExpression>> a_default_argument, utility::Span a_span);
-
-public: bool equals(parser::ParsedParameter const rhs_param) const;
-public: ErrorOr<ByteString> debug_description() const;
-};struct ParsedPatternDefault {
-  public:
-public: parser::ParsedVarDecl variable;public: NonnullRefPtr<typename parser::ParsedExpression> value;public: ParsedPatternDefault(parser::ParsedVarDecl a_variable, NonnullRefPtr<typename parser::ParsedExpression> a_value);
-
-public: ErrorOr<ByteString> debug_description() const;
-};struct ParsedMatchBody {
-u8 __jakt_variant_index = 0;
-union VariantData {
-u8 __jakt_uninit_value;
-struct {
-NonnullRefPtr<typename parser::ParsedExpression> value;
-} Expression;
-struct {
-parser::ParsedBlock value;
-} Block;
-constexpr VariantData() {}
-~VariantData() {}
-} as;
-constexpr u8 __jakt_init_index() const noexcept { return __jakt_variant_index - 1; }ErrorOr<ByteString> debug_description() const;
-[[nodiscard]] static ParsedMatchBody Expression(NonnullRefPtr<typename parser::ParsedExpression> value);
-[[nodiscard]] static ParsedMatchBody Block(parser::ParsedBlock value);
-~ParsedMatchBody();
-ParsedMatchBody& operator=(ParsedMatchBody const &);
-ParsedMatchBody& operator=(ParsedMatchBody &&);
-ParsedMatchBody(ParsedMatchBody const&);
-ParsedMatchBody(ParsedMatchBody &&);
-private: void __jakt_destroy_variant();
-public:
-bool equals(parser::ParsedMatchBody const rhs_match_body) const;
-private:
-ParsedMatchBody() {};
-};
-struct ParsedMatchCase {
-  public:
-public: JaktInternal::DynamicArray<parser::ParsedMatchPattern> patterns;public: utility::Span marker_span;public: parser::ParsedMatchBody body;public: bool has_equal_pattern(parser::ParsedMatchCase const rhs_match_case) const;
-public: bool equals(parser::ParsedMatchCase const rhs_match_case) const;
-public: ParsedMatchCase(JaktInternal::DynamicArray<parser::ParsedMatchPattern> a_patterns, utility::Span a_marker_span, parser::ParsedMatchBody a_body);
-
-public: ErrorOr<ByteString> debug_description() const;
-};struct ParsedExternalTraitImplementation {
-  public:
-public: NonnullRefPtr<typename parser::ParsedType> for_type;public: JaktInternal::DynamicArray<parser::ParsedNameWithGenericParameters> traits;public: JaktInternal::DynamicArray<parser::ParsedMethod> methods;public: ParsedExternalTraitImplementation(NonnullRefPtr<typename parser::ParsedType> a_for_type, JaktInternal::DynamicArray<parser::ParsedNameWithGenericParameters> a_traits, JaktInternal::DynamicArray<parser::ParsedMethod> a_methods);
-
-public: ErrorOr<ByteString> debug_description() const;
-};struct ParsedNamespace {
-  public:
-public: JaktInternal::Optional<ByteString> name;public: JaktInternal::Optional<utility::Span> name_span;public: JaktInternal::DynamicArray<parser::ParsedFunction> functions;public: JaktInternal::DynamicArray<parser::ParsedRecord> records;public: JaktInternal::DynamicArray<parser::ParsedTrait> traits;public: JaktInternal::DynamicArray<parser::ParsedExternalTraitImplementation> external_trait_implementations;public: JaktInternal::DynamicArray<parser::ParsedNamespace> namespaces;public: JaktInternal::DynamicArray<parser::ParsedAlias> aliases;public: JaktInternal::DynamicArray<parser::ParsedModuleImport> module_imports;public: JaktInternal::DynamicArray<parser::ParsedExternImport> extern_imports;public: JaktInternal::Optional<ByteString> import_path_if_extern;public: JaktInternal::DynamicArray<parser::IncludeAction> generating_import_extern_before_include;public: JaktInternal::DynamicArray<parser::IncludeAction> generating_import_extern_after_include;public: JaktInternal::DynamicArray<JaktInternal::Tuple<JaktInternal::DynamicArray<parser::ParsedGenericParameter>,parser::ParsedNamespace>> forall_chunks;public: bool is_generated_code;public: bool is_auto_extern_imported;public: ErrorOr<void> add_child_namespace(parser::ParsedNamespace const namespace_);
-public: ParsedNamespace(JaktInternal::Optional<ByteString> a_name, JaktInternal::Optional<utility::Span> a_name_span, JaktInternal::DynamicArray<parser::ParsedFunction> a_functions, JaktInternal::DynamicArray<parser::ParsedRecord> a_records, JaktInternal::DynamicArray<parser::ParsedTrait> a_traits, JaktInternal::DynamicArray<parser::ParsedExternalTraitImplementation> a_external_trait_implementations, JaktInternal::DynamicArray<parser::ParsedNamespace> a_namespaces, JaktInternal::DynamicArray<parser::ParsedAlias> a_aliases, JaktInternal::DynamicArray<parser::ParsedModuleImport> a_module_imports, JaktInternal::DynamicArray<parser::ParsedExternImport> a_extern_imports, JaktInternal::Optional<ByteString> a_import_path_if_extern, JaktInternal::DynamicArray<parser::IncludeAction> a_generating_import_extern_before_include, JaktInternal::DynamicArray<parser::IncludeAction> a_generating_import_extern_after_include, JaktInternal::DynamicArray<JaktInternal::Tuple<JaktInternal::DynamicArray<parser::ParsedGenericParameter>,parser::ParsedNamespace>> a_forall_chunks, bool a_is_generated_code, bool a_is_auto_extern_imported);
-
-public: bool is_equivalent_to(parser::ParsedNamespace const other) const;
-public: ErrorOr<void> add_extern_import(parser::ParsedExternImport const import_);
-public: ErrorOr<void> add_alias(parser::ParsedAlias const alias);
-public: ErrorOr<void> merge_with(parser::ParsedNamespace const namespace_);
-public: ErrorOr<void> add_module_import(parser::ParsedModuleImport const import_);
-public: ErrorOr<ByteString> debug_description() const;
-};struct ParsedFunctionParameters {
-  public:
-public: JaktInternal::DynamicArray<parser::ParsedParameter> parameters;public: bool has_varargs;public: ParsedFunctionParameters(JaktInternal::DynamicArray<parser::ParsedParameter> a_parameters, bool a_has_varargs);
-
-public: ErrorOr<ByteString> debug_description() const;
-};struct ParsedVarDeclTuple {
-  public:
-public: JaktInternal::DynamicArray<parser::ParsedVarDecl> var_decls;public: utility::Span span;public: ParsedVarDeclTuple(JaktInternal::DynamicArray<parser::ParsedVarDecl> a_var_decls, utility::Span a_span);
-
-public: ErrorOr<ByteString> debug_description() const;
-};struct ParsedNameWithGenericParameters {
-  public:
-public: ByteString name;public: utility::Span name_span;public: JaktInternal::DynamicArray<NonnullRefPtr<typename parser::ParsedType>> generic_parameters;public: ParsedNameWithGenericParameters(ByteString a_name, utility::Span a_name_span, JaktInternal::DynamicArray<NonnullRefPtr<typename parser::ParsedType>> a_generic_parameters);
-
-public: ErrorOr<ByteString> debug_description() const;
-};struct ImportName {
-u8 __jakt_variant_index = 0;
-union VariantData {
-u8 __jakt_uninit_value;
-struct {
-ByteString name;
-utility::Span span;
-} Literal;
-struct {
-NonnullRefPtr<typename parser::ParsedExpression> expression;
-} Comptime;
-constexpr VariantData() {}
-~VariantData() {}
-} as;
-constexpr u8 __jakt_init_index() const noexcept { return __jakt_variant_index - 1; }ErrorOr<ByteString> debug_description() const;
-[[nodiscard]] static ImportName Literal(ByteString name, utility::Span span);
-[[nodiscard]] static ImportName Comptime(NonnullRefPtr<typename parser::ParsedExpression> expression);
-~ImportName();
-ImportName& operator=(ImportName const &);
-ImportName& operator=(ImportName &&);
-ImportName(ImportName const&);
-ImportName(ImportName &&);
-private: void __jakt_destroy_variant();
-public:
-ErrorOr<ByteString> literal_name() const;
-bool equals(parser::ImportName const other) const;
-utility::Span span() const;
-private:
-ImportName() {};
-};
-struct FunctionType {
+};struct FunctionType {
 u8 __jakt_variant_index = 0;
 union VariantData {
 u8 __jakt_uninit_value;
@@ -364,156 +166,7 @@ public:
 private:
 FunctionType() {};
 };
-struct Parser {
-  public:
-public: size_t index;public: JaktInternal::DynamicArray<lexer::Token> tokens;public: NonnullRefPtr<compiler::Compiler> compiler;public: bool can_have_trailing_closure;public: size_t next_function_id;public: ErrorOr<NonnullRefPtr<typename parser::ParsedExpression>> parse_operand_base();
-public: utility::Span span(size_t const start, size_t const end) const;
-public: ErrorOr<JaktInternal::Optional<parser::NumericConstant>> make_integer_numeric_constant(u64 const number, lexer::LiteralSuffix const suffix, utility::Span const span);
-public: ErrorOr<NonnullRefPtr<typename parser::ParsedType>> parse_type_shorthand(parser::ParsedTypeQualifiers const qualifiers);
-public: ErrorOr<NonnullRefPtr<typename parser::ParsedExpression>> parse_lambda();
-public: ErrorOr<NonnullRefPtr<typename parser::ParsedType>> parse_type_longhand(parser::ParsedTypeQualifiers const qualifiers);
-public: ErrorOr<parser::ParsedAlias> parse_using();
-public: ErrorOr<parser::ParsedFunctionParameters> parse_function_parameters(bool const for_trailing_closure);
-public: ErrorOr<JaktInternal::DynamicArray<parser::ParsedMatchCase>> parse_match_cases();
-public: ErrorOr<JaktInternal::Optional<parser::ParsedAttribute>> parse_attribute();
-public: ErrorOr<parser::ParsedMethod> parse_method(parser::FunctionLinkage const linkage, parser::Visibility const visibility, bool const is_virtual, bool const is_override, bool const is_comptime, bool const is_destructor, bool const is_unsafe);
-public: ErrorOr<parser::ParsedNamespace> parse_namespace(bool const process_only_one_entity);
-public: ErrorOr<JaktInternal::Tuple<JaktInternal::DynamicArray<parser::ParsedGenericParameter>,parser::ParsedNamespace>> parse_forall();
-public: ErrorOr<parser::ParsedVarDecl> parse_variable_declaration(bool const is_mutable);
-public: ErrorOr<NonnullRefPtr<typename parser::ParsedType>> parse_type_shorthand_set(parser::ParsedTypeQualifiers const qualifiers);
-public: ErrorOr<NonnullRefPtr<typename parser::ParsedStatement>> parse_if_statement();
-public: ErrorOr<JaktInternal::Optional<parser::ParsedCall>> parse_call();
-public: ErrorOr<void> inject_token(lexer::Token const token);
-public: ErrorOr<parser::ParsedRecord> parse_class(parser::DefinitionLinkage const definition_linkage);
-public: ErrorOr<parser::ParsedExternalTraitImplementation> parse_external_trait_implementation();
-public: ErrorOr<parser::ParsedMatchPattern> parse_match_pattern();
-public: ErrorOr<parser::ParsedFunction> parse_function(parser::FunctionLinkage const linkage, parser::Visibility const visibility, bool const is_comptime, bool const is_destructor, bool const is_unsafe, bool const allow_missing_body);
-public: ErrorOr<parser::ParsedExternImport> parse_extern_import(parser::ParsedNamespace& parent);
-public: ErrorOr<NonnullRefPtr<typename parser::ParsedType>> parse_typename();
-public: ErrorOr<JaktInternal::Tuple<JaktInternal::DynamicArray<parser::ParsedField>,JaktInternal::DynamicArray<parser::ParsedMethod>,JaktInternal::DynamicArray<parser::ParsedRecord>>> parse_struct_class_body(parser::DefinitionLinkage const definition_linkage, parser::Visibility const default_visibility, bool const is_class);
-public: ErrorOr<NonnullRefPtr<typename parser::ParsedExpression>> parse_unsafe_expr();
-public: static ErrorOr<parser::ParsedNamespace> parse(NonnullRefPtr<compiler::Compiler> const compiler, JaktInternal::DynamicArray<lexer::Token> const tokens);
-public: ErrorOr<JaktInternal::Optional<parser::NumericConstant>> make_float_numeric_constant(f64 const number, lexer::LiteralSuffix const suffix, utility::Span const span);
-public: ErrorOr<NonnullRefPtr<typename parser::ParsedExpression>> parse_range();
-public: ErrorOr<parser::ParsedBlock> parse_fat_arrow();
-public: void skip_newlines();
-public: ErrorOr<JaktInternal::Tuple<JaktInternal::DynamicArray<parser::ValueEnumVariant>,JaktInternal::DynamicArray<parser::ParsedMethod>>> parse_value_enum_body(parser::ParsedRecord const partial_enum, parser::DefinitionLinkage const definition_linkage);
-public: lexer::Token previous() const;
-public: ErrorOr<JaktInternal::DynamicArray<NonnullRefPtr<typename parser::ParsedType>>> parse_type_parameter_list();
-public: ErrorOr<JaktInternal::DynamicArray<parser::EnumVariantPatternArgument>> parse_variant_arguments();
-public: ErrorOr<NonnullRefPtr<typename parser::ParsedStatement>> parse_guard_statement();
-public: bool eof() const;
-public: ErrorOr<NonnullRefPtr<typename parser::ParsedExpression>> parse_asterisk();
-public: ErrorOr<NonnullRefPtr<typename parser::ParsedExpression>> parse_match_expression();
-public: ErrorOr<void> apply_attributes(parser::ParsedNamespace& namespace_, JaktInternal::DynamicArray<parser::ParsedAttribute> const& active_attributes);
-public: ErrorOr<void> apply_attributes(parser::ParsedField& field, JaktInternal::DynamicArray<parser::ParsedAttribute> const& active_attributes);
-public: ErrorOr<void> apply_attributes(parser::ParsedFunction& parsed_function, JaktInternal::DynamicArray<parser::ParsedAttribute> const& active_attributes);
-public: ErrorOr<void> apply_attributes(parser::ParsedMethod& parsed_method, JaktInternal::DynamicArray<parser::ParsedAttribute> const& active_attributes);
-public: ErrorOr<void> apply_attributes(parser::ParsedRecord& parsed_record, JaktInternal::DynamicArray<parser::ParsedAttribute> const& active_attributes);
-public: lexer::Token current() const;
-public: ErrorOr<parser::ParsedRecord> parse_enum(parser::DefinitionLinkage const definition_linkage, bool const is_boxed);
-public: ErrorOr<parser::ParsedBlock> parse_block();
-public: utility::Span empty_span() const;
-public: ErrorOr<NonnullRefPtr<typename parser::ParsedExpression>> parse_postfix_colon_colon(utility::Span const start, NonnullRefPtr<typename parser::ParsedExpression> const expr);
-public: ErrorOr<void> error(ByteString const message, utility::Span const span);
-public: ErrorOr<parser::ParsedTrait> parse_trait();
-public: ErrorOr<parser::Visibility> parse_restricted_visibility_modifier();
-public: ErrorOr<parser::ParsedVarDeclTuple> parse_destructuring_assignment(bool const is_mutable);
-public: ErrorOr<NonnullRefPtr<typename parser::ParsedExpression>> parse_operand_postfix_operator(utility::Span const start, NonnullRefPtr<typename parser::ParsedExpression> const expr);
-public: ErrorOr<NonnullRefPtr<typename parser::ParsedExpression>> parse_set_literal();
-public: ErrorOr<void> parse_attribute_list(JaktInternal::DynamicArray<parser::ParsedAttribute>& active_attributes);
-public: Parser(size_t a_index, JaktInternal::DynamicArray<lexer::Token> a_tokens, NonnullRefPtr<compiler::Compiler> a_compiler, bool a_can_have_trailing_closure, size_t a_next_function_id);
-
-public: ErrorOr<NonnullRefPtr<typename parser::ParsedExpression>> parse_expression(bool const allow_assignments, bool const allow_newlines);
-public: ErrorOr<NonnullRefPtr<typename parser::ParsedExpression>> parse_operator(bool const allow_assignments);
-public: ErrorOr<NonnullRefPtr<typename parser::ParsedStatement>> parse_for_statement();
-public: ErrorOr<NonnullRefPtr<typename parser::ParsedType>> parse_typename_base();
-public: ErrorOr<NonnullRefPtr<typename parser::ParsedExpression>> parse_operand();
-public: ErrorOr<JaktInternal::Tuple<JaktInternal::DynamicArray<parser::SumEnumVariant>,JaktInternal::DynamicArray<parser::ParsedField>,JaktInternal::DynamicArray<parser::ParsedMethod>,JaktInternal::DynamicArray<parser::ParsedRecord>>> parse_sum_enum_body(parser::ParsedRecord const partial_enum, parser::DefinitionLinkage const definition_linkage, bool const is_boxed);
-public: ErrorOr<JaktInternal::DynamicArray<parser::ParsedCapture>> parse_captures();
-public: ErrorOr<NonnullRefPtr<typename parser::ParsedExpression>> parse_number(lexer::LiteralPrefix const prefix, ByteString const number, lexer::LiteralSuffix suffix, utility::Span const span);
-public: ErrorOr<parser::ParsedModuleImport> parse_module_import();
-public: ErrorOr<parser::ParsedRecord> parse_record(parser::DefinitionLinkage const definition_linkage);
-public: lexer::Token peek(size_t const steps) const;
-public: ErrorOr<void> error_with_hint(ByteString const message, utility::Span const span, ByteString const hint, utility::Span const hint_span);
-public: ErrorOr<NonnullRefPtr<typename parser::ParsedType>> parse_type_shorthand_array_or_dictionary(parser::ParsedTypeQualifiers const qualifiers);
-public: ErrorOr<NonnullRefPtr<typename parser::ParsedType>> parse_type_shorthand_tuple(parser::ParsedTypeQualifiers const qualifiers);
-public: bool eol() const;
-public: ErrorOr<NonnullRefPtr<typename parser::ParsedExpression>> parse_array_or_dictionary_literal();
-public: ErrorOr<JaktInternal::DynamicArray<parser::ParsedMatchPattern>> parse_match_patterns();
-public: ErrorOr<void> parse_import(parser::ParsedNamespace& parent);
-public: ErrorOr<NonnullRefPtr<typename parser::ParsedStatement>> parse_statement(bool const inside_block);
-public: ErrorOr<parser::ParsedField> parse_field(parser::Visibility const visibility);
-public: ErrorOr<ByteString> parse_argument_label();
-public: ErrorOr<NonnullRefPtr<typename parser::ParsedExpression>> parse_ampersand();
-public: ErrorOr<JaktInternal::Optional<JaktInternal::DynamicArray<parser::IncludeAction>>> parse_include_action();
-public: ErrorOr<NonnullRefPtr<typename parser::ParsedExpression>> parse_try_block();
-public: ErrorOr<JaktInternal::DynamicArray<parser::ParsedGenericParameter>> parse_generic_parameters();
-public: ErrorOr<parser::ParsedRecord> parse_struct(parser::DefinitionLinkage const definition_linkage);
-public: ErrorOr<JaktInternal::Optional<JaktInternal::DynamicArray<parser::ParsedNameWithGenericParameters>>> parse_trait_list();
-public: ErrorOr<ByteString> debug_description() const;
-};struct DefinitionLinkage {
-u8 __jakt_variant_index = 0;
-union VariantData {
-u8 __jakt_uninit_value;
-constexpr VariantData() {}
-~VariantData() {}
-} as;
-constexpr u8 __jakt_init_index() const noexcept { return __jakt_variant_index - 1; }ErrorOr<ByteString> debug_description() const;
-[[nodiscard]] static DefinitionLinkage Internal();
-[[nodiscard]] static DefinitionLinkage External();
-~DefinitionLinkage();
-DefinitionLinkage& operator=(DefinitionLinkage const &);
-DefinitionLinkage& operator=(DefinitionLinkage &&);
-DefinitionLinkage(DefinitionLinkage const&);
-DefinitionLinkage(DefinitionLinkage &&);
-private: void __jakt_destroy_variant();
-public:
-private:
-DefinitionLinkage() {};
-};
-struct ParsedTraitRequirements {
-u8 __jakt_variant_index = 0;
-union VariantData {
-u8 __jakt_uninit_value;
-struct {
-JaktInternal::DynamicArray<parser::ParsedFunction> value;
-} Methods;
-struct {
-NonnullRefPtr<typename parser::ParsedExpression> value;
-} ComptimeExpression;
-constexpr VariantData() {}
-~VariantData() {}
-} as;
-constexpr u8 __jakt_init_index() const noexcept { return __jakt_variant_index - 1; }ErrorOr<ByteString> debug_description() const;
-[[nodiscard]] static ParsedTraitRequirements Nothing();
-[[nodiscard]] static ParsedTraitRequirements Methods(JaktInternal::DynamicArray<parser::ParsedFunction> value);
-[[nodiscard]] static ParsedTraitRequirements ComptimeExpression(NonnullRefPtr<typename parser::ParsedExpression> value);
-~ParsedTraitRequirements();
-ParsedTraitRequirements& operator=(ParsedTraitRequirements const &);
-ParsedTraitRequirements& operator=(ParsedTraitRequirements &&);
-ParsedTraitRequirements(ParsedTraitRequirements const&);
-ParsedTraitRequirements(ParsedTraitRequirements &&);
-private: void __jakt_destroy_variant();
-public:
-private:
-ParsedTraitRequirements() {};
-};
-struct CheckedQualifiers {
-  public:
-public: bool is_immutable;public: bool equals(parser::CheckedQualifiers const other) const;
-public: CheckedQualifiers(bool a_is_immutable);
-
-public: public: ErrorOr<ByteString> debug_description() const;
-};struct ParsedExternImport {
-  public:
-public: bool is_c;public: parser::ParsedNamespace assigned_namespace;public: JaktInternal::DynamicArray<parser::IncludeAction> before_include;public: JaktInternal::DynamicArray<parser::IncludeAction> after_include;public: bool should_auto_import;public: ErrorOr<bool> is_equivalent_to(parser::ParsedExternImport const other) const;
-public: ParsedExternImport(bool a_is_c, parser::ParsedNamespace a_assigned_namespace, JaktInternal::DynamicArray<parser::IncludeAction> a_before_include, JaktInternal::DynamicArray<parser::IncludeAction> a_after_include, bool a_should_auto_import);
-
-public: ByteString get_path() const;
-public: ByteString get_name() const;
-public: ErrorOr<ByteString> debug_description() const;
-};struct FunctionLinkage {
+struct FunctionLinkage {
 u8 __jakt_variant_index = 0;
 union VariantData {
 u8 __jakt_uninit_value;
@@ -560,175 +213,46 @@ public: size_t id;public: ByteString name;public: utility::Span name_span;public
 
 public: bool equals(parser::ParsedFunction const other, bool const ignore_block) const;
 public: ErrorOr<ByteString> debug_description() const;
-};struct ArgumentStoreLevel {
-u8 __jakt_variant_index = 0;
-union VariantData {
-u8 __jakt_uninit_value;
-struct {
-size_t argument_index;
-} InObject;
-constexpr VariantData() {}
-~VariantData() {}
-} as;
-constexpr u8 __jakt_init_index() const noexcept { return __jakt_variant_index - 1; }ErrorOr<ByteString> debug_description() const;
-[[nodiscard]] static ArgumentStoreLevel InObject(size_t argument_index);
-[[nodiscard]] static ArgumentStoreLevel InStaticStorage();
-~ArgumentStoreLevel();
-ArgumentStoreLevel& operator=(ArgumentStoreLevel const &);
-ArgumentStoreLevel& operator=(ArgumentStoreLevel &&);
-ArgumentStoreLevel(ArgumentStoreLevel const&);
-ArgumentStoreLevel(ArgumentStoreLevel &&);
-private: void __jakt_destroy_variant();
-public:
-private:
-ArgumentStoreLevel() {};
-};
-struct ParsedMatchPattern {
-u8 __jakt_variant_index = 0;
-union CommonData {
-u8 __jakt_uninit_common;
-struct {
-JaktInternal::Dictionary<ByteString,parser::ParsedPatternDefault> defaults;
-} init_common;
-constexpr CommonData() {}
-~CommonData() {}
-} common;
-union VariantData {
-u8 __jakt_uninit_value;
-struct {
-JaktInternal::DynamicArray<JaktInternal::Tuple<ByteString,utility::Span>> variant_names;
-JaktInternal::DynamicArray<parser::EnumVariantPatternArgument> variant_arguments;
-utility::Span arguments_span;
-} EnumVariant;
-struct {
-NonnullRefPtr<typename parser::ParsedExpression> value;
-} Expression;
-struct {
-JaktInternal::DynamicArray<parser::EnumVariantPatternArgument> variant_arguments;
-utility::Span arguments_span;
-} CatchAll;
-constexpr VariantData() {}
-~VariantData() {}
-} as;
-constexpr u8 __jakt_init_index() const noexcept { return __jakt_variant_index - 1; }ErrorOr<ByteString> debug_description() const;
-[[nodiscard]] static ParsedMatchPattern EnumVariant(JaktInternal::Dictionary<ByteString,parser::ParsedPatternDefault> defaults, JaktInternal::DynamicArray<JaktInternal::Tuple<ByteString,utility::Span>> variant_names, JaktInternal::DynamicArray<parser::EnumVariantPatternArgument> variant_arguments, utility::Span arguments_span);
-[[nodiscard]] static ParsedMatchPattern Expression(JaktInternal::Dictionary<ByteString,parser::ParsedPatternDefault> defaults, NonnullRefPtr<typename parser::ParsedExpression> value);
-[[nodiscard]] static ParsedMatchPattern CatchAll(JaktInternal::Dictionary<ByteString,parser::ParsedPatternDefault> defaults, JaktInternal::DynamicArray<parser::EnumVariantPatternArgument> variant_arguments, utility::Span arguments_span);
-[[nodiscard]] static ParsedMatchPattern Invalid(JaktInternal::Dictionary<ByteString,parser::ParsedPatternDefault> defaults);
-~ParsedMatchPattern();
-ParsedMatchPattern& operator=(ParsedMatchPattern const &);
-ParsedMatchPattern& operator=(ParsedMatchPattern &&);
-ParsedMatchPattern(ParsedMatchPattern const&);
-ParsedMatchPattern(ParsedMatchPattern &&);
-private: void __jakt_destroy_variant();
-public:
-bool equals(parser::ParsedMatchPattern const rhs_parsed_match_pattern) const;
-bool is_equal_pattern(parser::ParsedMatchPattern const rhs_parsed_match_pattern) const;
-bool defaults_equal(JaktInternal::Dictionary<ByteString,parser::ParsedPatternDefault> const defaults) const;
-private:
-ParsedMatchPattern() {};
-};
-struct RecordType {
-u8 __jakt_variant_index = 0;
-union VariantData {
-u8 __jakt_uninit_value;
-struct {
-JaktInternal::DynamicArray<parser::ParsedField> fields;
-JaktInternal::Optional<NonnullRefPtr<typename parser::ParsedType>> super_type;
-} Struct;
-struct {
-JaktInternal::DynamicArray<parser::ParsedField> fields;
-JaktInternal::Optional<NonnullRefPtr<typename parser::ParsedType>> super_type;
-} Class;
-struct {
-NonnullRefPtr<typename parser::ParsedType> underlying_type;
-JaktInternal::DynamicArray<parser::ValueEnumVariant> variants;
-} ValueEnum;
-struct {
-bool is_boxed;
-JaktInternal::DynamicArray<parser::ParsedField> fields;
-JaktInternal::DynamicArray<parser::SumEnumVariant> variants;
-} SumEnum;
-constexpr VariantData() {}
-~VariantData() {}
-} as;
-constexpr u8 __jakt_init_index() const noexcept { return __jakt_variant_index - 1; }ErrorOr<ByteString> debug_description() const;
-[[nodiscard]] static RecordType Struct(JaktInternal::DynamicArray<parser::ParsedField> fields, JaktInternal::Optional<NonnullRefPtr<typename parser::ParsedType>> super_type);
-[[nodiscard]] static RecordType Class(JaktInternal::DynamicArray<parser::ParsedField> fields, JaktInternal::Optional<NonnullRefPtr<typename parser::ParsedType>> super_type);
-[[nodiscard]] static RecordType ValueEnum(NonnullRefPtr<typename parser::ParsedType> underlying_type, JaktInternal::DynamicArray<parser::ValueEnumVariant> variants);
-[[nodiscard]] static RecordType SumEnum(bool is_boxed, JaktInternal::DynamicArray<parser::ParsedField> fields, JaktInternal::DynamicArray<parser::SumEnumVariant> variants);
-[[nodiscard]] static RecordType Garbage();
-~RecordType();
-RecordType& operator=(RecordType const &);
-RecordType& operator=(RecordType &&);
-RecordType(RecordType const&);
-RecordType(RecordType &&);
-private: void __jakt_destroy_variant();
-public:
-ErrorOr<ByteString> record_type_name() const;
-private:
-RecordType() {};
-};
-struct ParsedRecord {
+};struct ParsedExternalTraitImplementation {
   public:
-public: ByteString name;public: utility::Span name_span;public: JaktInternal::DynamicArray<parser::ParsedGenericParameter> generic_parameters;public: parser::DefinitionLinkage definition_linkage;public: JaktInternal::Optional<JaktInternal::DynamicArray<parser::ParsedNameWithGenericParameters>> implements_list;public: JaktInternal::DynamicArray<parser::ParsedMethod> methods;public: parser::RecordType record_type;public: JaktInternal::DynamicArray<parser::ParsedRecord> nested_records;public: JaktInternal::Optional<parser::ExternalName> external_name;public: ParsedRecord(ByteString a_name, utility::Span a_name_span, JaktInternal::DynamicArray<parser::ParsedGenericParameter> a_generic_parameters, parser::DefinitionLinkage a_definition_linkage, JaktInternal::Optional<JaktInternal::DynamicArray<parser::ParsedNameWithGenericParameters>> a_implements_list, JaktInternal::DynamicArray<parser::ParsedMethod> a_methods, parser::RecordType a_record_type, JaktInternal::DynamicArray<parser::ParsedRecord> a_nested_records, JaktInternal::Optional<parser::ExternalName> a_external_name);
+public: NonnullRefPtr<typename parser::ParsedType> for_type;public: JaktInternal::DynamicArray<parser::ParsedNameWithGenericParameters> traits;public: JaktInternal::DynamicArray<parser::ParsedMethod> methods;public: ParsedExternalTraitImplementation(NonnullRefPtr<typename parser::ParsedType> a_for_type, JaktInternal::DynamicArray<parser::ParsedNameWithGenericParameters> a_traits, JaktInternal::DynamicArray<parser::ParsedMethod> a_methods);
 
 public: ErrorOr<ByteString> debug_description() const;
-};struct BinaryOperator {
-u8 __jakt_variant_index = 0;
-union VariantData {
-u8 __jakt_uninit_value;
-constexpr VariantData() {}
-~VariantData() {}
-} as;
-constexpr u8 __jakt_init_index() const noexcept { return __jakt_variant_index - 1; }ErrorOr<ByteString> debug_description() const;
-[[nodiscard]] static BinaryOperator Add();
-[[nodiscard]] static BinaryOperator Subtract();
-[[nodiscard]] static BinaryOperator Multiply();
-[[nodiscard]] static BinaryOperator Divide();
-[[nodiscard]] static BinaryOperator Modulo();
-[[nodiscard]] static BinaryOperator LessThan();
-[[nodiscard]] static BinaryOperator LessThanOrEqual();
-[[nodiscard]] static BinaryOperator GreaterThan();
-[[nodiscard]] static BinaryOperator GreaterThanOrEqual();
-[[nodiscard]] static BinaryOperator Equal();
-[[nodiscard]] static BinaryOperator NotEqual();
-[[nodiscard]] static BinaryOperator BitwiseAnd();
-[[nodiscard]] static BinaryOperator BitwiseXor();
-[[nodiscard]] static BinaryOperator BitwiseOr();
-[[nodiscard]] static BinaryOperator BitwiseLeftShift();
-[[nodiscard]] static BinaryOperator BitwiseRightShift();
-[[nodiscard]] static BinaryOperator ArithmeticLeftShift();
-[[nodiscard]] static BinaryOperator ArithmeticRightShift();
-[[nodiscard]] static BinaryOperator LogicalAnd();
-[[nodiscard]] static BinaryOperator LogicalOr();
-[[nodiscard]] static BinaryOperator NoneCoalescing();
-[[nodiscard]] static BinaryOperator Assign();
-[[nodiscard]] static BinaryOperator BitwiseAndAssign();
-[[nodiscard]] static BinaryOperator BitwiseOrAssign();
-[[nodiscard]] static BinaryOperator BitwiseXorAssign();
-[[nodiscard]] static BinaryOperator BitwiseLeftShiftAssign();
-[[nodiscard]] static BinaryOperator BitwiseRightShiftAssign();
-[[nodiscard]] static BinaryOperator AddAssign();
-[[nodiscard]] static BinaryOperator SubtractAssign();
-[[nodiscard]] static BinaryOperator MultiplyAssign();
-[[nodiscard]] static BinaryOperator ModuloAssign();
-[[nodiscard]] static BinaryOperator DivideAssign();
-[[nodiscard]] static BinaryOperator NoneCoalescingAssign();
-[[nodiscard]] static BinaryOperator Garbage();
-~BinaryOperator();
-BinaryOperator& operator=(BinaryOperator const &);
-BinaryOperator& operator=(BinaryOperator &&);
-BinaryOperator(BinaryOperator const&);
-BinaryOperator(BinaryOperator &&);
-private: void __jakt_destroy_variant();
-public:
-bool equals(parser::BinaryOperator const rhs_op) const;
-bool is_assignment() const;
-private:
-BinaryOperator() {};
-};
-struct ImportList {
+};struct ParsedGenericParameter {
+  public:
+public: ByteString name;public: utility::Span span;public: JaktInternal::Optional<JaktInternal::DynamicArray<parser::ParsedNameWithGenericParameters>> requires_list;public: bool is_value;public: ParsedGenericParameter(ByteString a_name, utility::Span a_span, JaktInternal::Optional<JaktInternal::DynamicArray<parser::ParsedNameWithGenericParameters>> a_requires_list, bool a_is_value);
+
+public: ErrorOr<ByteString> debug_description() const;
+};struct SumEnumVariant {
+  public:
+public: ByteString name;public: utility::Span span;public: JaktInternal::Optional<JaktInternal::DynamicArray<parser::ParsedVarDecl>> params;public: JaktInternal::Optional<JaktInternal::DynamicArray<JaktInternal::Optional<NonnullRefPtr<typename parser::ParsedExpression>>>> default_values;public: SumEnumVariant(ByteString a_name, utility::Span a_span, JaktInternal::Optional<JaktInternal::DynamicArray<parser::ParsedVarDecl>> a_params, JaktInternal::Optional<JaktInternal::DynamicArray<JaktInternal::Optional<NonnullRefPtr<typename parser::ParsedExpression>>>> a_default_values);
+
+public: ErrorOr<ByteString> debug_description() const;
+};struct ParsedAttribute {
+  public:
+public: ByteString name;public: utility::Span span;public: JaktInternal::Optional<ByteString> assigned_value;public: JaktInternal::DynamicArray<parser::ParsedAttributeArgument> arguments;public: ParsedAttribute(ByteString a_name, utility::Span a_span, JaktInternal::Optional<ByteString> a_assigned_value, JaktInternal::DynamicArray<parser::ParsedAttributeArgument> a_arguments);
+
+public: ErrorOr<ByteString> debug_description() const;
+};struct ParsedNamespace {
+  public:
+public: JaktInternal::Optional<ByteString> name;public: JaktInternal::Optional<utility::Span> name_span;public: JaktInternal::DynamicArray<parser::ParsedFunction> functions;public: JaktInternal::DynamicArray<parser::ParsedRecord> records;public: JaktInternal::DynamicArray<parser::ParsedTrait> traits;public: JaktInternal::DynamicArray<parser::ParsedExternalTraitImplementation> external_trait_implementations;public: JaktInternal::DynamicArray<parser::ParsedNamespace> namespaces;public: JaktInternal::DynamicArray<parser::ParsedAlias> aliases;public: JaktInternal::DynamicArray<parser::ParsedModuleImport> module_imports;public: JaktInternal::DynamicArray<parser::ParsedExternImport> extern_imports;public: JaktInternal::Optional<ByteString> import_path_if_extern;public: JaktInternal::DynamicArray<parser::IncludeAction> generating_import_extern_before_include;public: JaktInternal::DynamicArray<parser::IncludeAction> generating_import_extern_after_include;public: JaktInternal::DynamicArray<JaktInternal::Tuple<JaktInternal::DynamicArray<parser::ParsedGenericParameter>,parser::ParsedNamespace>> forall_chunks;public: bool is_generated_code;public: bool is_auto_extern_imported;public: ErrorOr<void> add_child_namespace(parser::ParsedNamespace const namespace_);
+public: ParsedNamespace(JaktInternal::Optional<ByteString> a_name, JaktInternal::Optional<utility::Span> a_name_span, JaktInternal::DynamicArray<parser::ParsedFunction> a_functions, JaktInternal::DynamicArray<parser::ParsedRecord> a_records, JaktInternal::DynamicArray<parser::ParsedTrait> a_traits, JaktInternal::DynamicArray<parser::ParsedExternalTraitImplementation> a_external_trait_implementations, JaktInternal::DynamicArray<parser::ParsedNamespace> a_namespaces, JaktInternal::DynamicArray<parser::ParsedAlias> a_aliases, JaktInternal::DynamicArray<parser::ParsedModuleImport> a_module_imports, JaktInternal::DynamicArray<parser::ParsedExternImport> a_extern_imports, JaktInternal::Optional<ByteString> a_import_path_if_extern, JaktInternal::DynamicArray<parser::IncludeAction> a_generating_import_extern_before_include, JaktInternal::DynamicArray<parser::IncludeAction> a_generating_import_extern_after_include, JaktInternal::DynamicArray<JaktInternal::Tuple<JaktInternal::DynamicArray<parser::ParsedGenericParameter>,parser::ParsedNamespace>> a_forall_chunks, bool a_is_generated_code, bool a_is_auto_extern_imported);
+
+public: bool is_equivalent_to(parser::ParsedNamespace const other) const;
+public: ErrorOr<void> add_extern_import(parser::ParsedExternImport const import_);
+public: ErrorOr<void> add_alias(parser::ParsedAlias const alias);
+public: ErrorOr<void> merge_with(parser::ParsedNamespace const namespace_);
+public: ErrorOr<void> add_module_import(parser::ParsedModuleImport const import_);
+public: ErrorOr<ByteString> debug_description() const;
+};struct ParsedExternImport {
+  public:
+public: bool is_c;public: parser::ParsedNamespace assigned_namespace;public: JaktInternal::DynamicArray<parser::IncludeAction> before_include;public: JaktInternal::DynamicArray<parser::IncludeAction> after_include;public: bool should_auto_import;public: ErrorOr<bool> is_equivalent_to(parser::ParsedExternImport const other) const;
+public: ParsedExternImport(bool a_is_c, parser::ParsedNamespace a_assigned_namespace, JaktInternal::DynamicArray<parser::IncludeAction> a_before_include, JaktInternal::DynamicArray<parser::IncludeAction> a_after_include, bool a_should_auto_import);
+
+public: ByteString get_path() const;
+public: ByteString get_name() const;
+public: ErrorOr<ByteString> debug_description() const;
+};struct ImportList {
 u8 __jakt_variant_index = 0;
 union VariantData {
 u8 __jakt_uninit_value;
@@ -752,112 +276,6 @@ ErrorOr<void> add(parser::ImportName const name);
 bool is_empty() const;
 private:
 ImportList() {};
-};
-struct ParsedTrait {
-  public:
-public: ByteString name;public: utility::Span name_span;public: JaktInternal::DynamicArray<parser::ParsedGenericParameter> generic_parameters;public: parser::ParsedTraitRequirements requirements;public: ParsedTrait(ByteString a_name, utility::Span a_name_span, JaktInternal::DynamicArray<parser::ParsedGenericParameter> a_generic_parameters, parser::ParsedTraitRequirements a_requirements);
-
-public: ErrorOr<ByteString> debug_description() const;
-};struct IncludeAction {
-u8 __jakt_variant_index = 0;
-union VariantData {
-u8 __jakt_uninit_value;
-struct {
-ByteString name;
-utility::Span span;
-ByteString value;
-} Define;
-struct {
-ByteString name;
-utility::Span span;
-} Undefine;
-constexpr VariantData() {}
-~VariantData() {}
-} as;
-constexpr u8 __jakt_init_index() const noexcept { return __jakt_variant_index - 1; }ErrorOr<ByteString> debug_description() const;
-[[nodiscard]] static IncludeAction Define(ByteString name, utility::Span span, ByteString value);
-[[nodiscard]] static IncludeAction Undefine(ByteString name, utility::Span span);
-~IncludeAction();
-IncludeAction& operator=(IncludeAction const &);
-IncludeAction& operator=(IncludeAction &&);
-IncludeAction(IncludeAction const&);
-IncludeAction(IncludeAction &&);
-private: void __jakt_destroy_variant();
-public:
-private:
-IncludeAction() {};
-};
-struct ParsedAttribute {
-  public:
-public: ByteString name;public: utility::Span span;public: JaktInternal::Optional<ByteString> assigned_value;public: JaktInternal::DynamicArray<parser::ParsedAttributeArgument> arguments;public: ParsedAttribute(ByteString a_name, utility::Span a_span, JaktInternal::Optional<ByteString> a_assigned_value, JaktInternal::DynamicArray<parser::ParsedAttributeArgument> a_arguments);
-
-public: ErrorOr<ByteString> debug_description() const;
-};struct ParsedAlias {
-  public:
-public: JaktInternal::Optional<parser::ParsedName> alias_name;public: JaktInternal::DynamicArray<parser::ParsedNameWithGenericParameters> target;public: ParsedAlias(JaktInternal::Optional<parser::ParsedName> a_alias_name, JaktInternal::DynamicArray<parser::ParsedNameWithGenericParameters> a_target);
-
-public: ErrorOr<ByteString> debug_description() const;
-};struct ParsedAttributeArgument {
-  public:
-public: ByteString name;public: utility::Span span;public: JaktInternal::Optional<ByteString> assigned_value;public: ParsedAttributeArgument(ByteString a_name, utility::Span a_span, JaktInternal::Optional<ByteString> a_assigned_value);
-
-public: ErrorOr<ByteString> debug_description() const;
-};struct ParsedMethod {
-  public:
-public: parser::ParsedFunction parsed_function;public: parser::Visibility visibility;public: bool is_virtual;public: bool is_override;public: ParsedMethod(parser::ParsedFunction a_parsed_function, parser::Visibility a_visibility, bool a_is_virtual, bool a_is_override);
-
-public: ErrorOr<ByteString> debug_description() const;
-};struct ParsedModuleImport {
-  public:
-public: parser::ImportName module_name;public: JaktInternal::Optional<parser::ImportName> alias_name;public: parser::ImportList import_list;public: bool relative_path;public: size_t parent_path_count;public: bool has_same_alias_than(parser::ParsedModuleImport const other) const;
-public: ParsedModuleImport(parser::ImportName a_module_name, JaktInternal::Optional<parser::ImportName> a_alias_name, parser::ImportList a_import_list, bool a_relative_path, size_t a_parent_path_count);
-
-public: bool has_same_import_semantics(parser::ParsedModuleImport const other) const;
-public: ErrorOr<void> merge_import_list(parser::ImportList const list);
-public: bool is_equivalent_to(parser::ParsedModuleImport const other) const;
-public: ErrorOr<ByteString> debug_description() const;
-};struct ParsedCall {
-  public:
-public: JaktInternal::DynamicArray<ByteString> namespace_;public: ByteString name;public: JaktInternal::DynamicArray<JaktInternal::Tuple<ByteString,utility::Span,NonnullRefPtr<typename parser::ParsedExpression>>> args;public: JaktInternal::DynamicArray<NonnullRefPtr<typename parser::ParsedType>> type_args;public: ParsedCall(JaktInternal::DynamicArray<ByteString> a_namespace_, ByteString a_name, JaktInternal::DynamicArray<JaktInternal::Tuple<ByteString,utility::Span,NonnullRefPtr<typename parser::ParsedExpression>>> a_args, JaktInternal::DynamicArray<NonnullRefPtr<typename parser::ParsedType>> a_type_args);
-
-public: bool equals(parser::ParsedCall const rhs_parsed_call) const;
-public: ErrorOr<ByteString> debug_description() const;
-};struct VisibilityRestriction {
-  public:
-public: JaktInternal::DynamicArray<ByteString> namespace_;public: ByteString name;public: VisibilityRestriction(JaktInternal::DynamicArray<ByteString> a_namespace_, ByteString a_name);
-
-public: ErrorOr<ByteString> debug_description() const;
-};struct ParsedTypeQualifiers {
-  public:
-public: bool is_mutable;public: bool is_immutable;public: ParsedTypeQualifiers(bool a_is_mutable, bool a_is_immutable);
-
-public: ErrorOr<ByteString> debug_description() const;
-};struct TypeCast {
-u8 __jakt_variant_index = 0;
-union VariantData {
-u8 __jakt_uninit_value;
-struct {
-NonnullRefPtr<typename parser::ParsedType> value;
-} Fallible;
-struct {
-NonnullRefPtr<typename parser::ParsedType> value;
-} Infallible;
-constexpr VariantData() {}
-~VariantData() {}
-} as;
-constexpr u8 __jakt_init_index() const noexcept { return __jakt_variant_index - 1; }ErrorOr<ByteString> debug_description() const;
-[[nodiscard]] static TypeCast Fallible(NonnullRefPtr<typename parser::ParsedType> value);
-[[nodiscard]] static TypeCast Infallible(NonnullRefPtr<typename parser::ParsedType> value);
-~TypeCast();
-TypeCast& operator=(TypeCast const &);
-TypeCast& operator=(TypeCast &&);
-TypeCast(TypeCast const&);
-TypeCast(TypeCast &&);
-private: void __jakt_destroy_variant();
-public:
-NonnullRefPtr<typename parser::ParsedType> parsed_type() const;
-private:
-TypeCast() {};
 };
 struct NumericConstant {
 u8 __jakt_variant_index = 0;
@@ -930,6 +348,39 @@ size_t to_usize() const;
 private:
 NumericConstant() {};
 };
+struct ParsedCall {
+  public:
+public: JaktInternal::DynamicArray<ByteString> namespace_;public: ByteString name;public: JaktInternal::DynamicArray<JaktInternal::Tuple<ByteString,utility::Span,NonnullRefPtr<typename parser::ParsedExpression>>> args;public: JaktInternal::DynamicArray<NonnullRefPtr<typename parser::ParsedType>> type_args;public: ParsedCall(JaktInternal::DynamicArray<ByteString> a_namespace_, ByteString a_name, JaktInternal::DynamicArray<JaktInternal::Tuple<ByteString,utility::Span,NonnullRefPtr<typename parser::ParsedExpression>>> a_args, JaktInternal::DynamicArray<NonnullRefPtr<typename parser::ParsedType>> a_type_args);
+
+public: bool equals(parser::ParsedCall const rhs_parsed_call) const;
+public: ErrorOr<ByteString> debug_description() const;
+};struct TypeCast {
+u8 __jakt_variant_index = 0;
+union VariantData {
+u8 __jakt_uninit_value;
+struct {
+NonnullRefPtr<typename parser::ParsedType> value;
+} Fallible;
+struct {
+NonnullRefPtr<typename parser::ParsedType> value;
+} Infallible;
+constexpr VariantData() {}
+~VariantData() {}
+} as;
+constexpr u8 __jakt_init_index() const noexcept { return __jakt_variant_index - 1; }ErrorOr<ByteString> debug_description() const;
+[[nodiscard]] static TypeCast Fallible(NonnullRefPtr<typename parser::ParsedType> value);
+[[nodiscard]] static TypeCast Infallible(NonnullRefPtr<typename parser::ParsedType> value);
+~TypeCast();
+TypeCast& operator=(TypeCast const &);
+TypeCast& operator=(TypeCast &&);
+TypeCast(TypeCast const&);
+TypeCast(TypeCast &&);
+private: void __jakt_destroy_variant();
+public:
+NonnullRefPtr<typename parser::ParsedType> parsed_type() const;
+private:
+TypeCast() {};
+};
 struct UnaryOperator {
 u8 __jakt_variant_index = 0;
 union VariantData {
@@ -977,7 +428,69 @@ bool equals(parser::UnaryOperator const rhs_op) const;
 private:
 UnaryOperator() {};
 };
-struct ParsedExpression: public RefCounted<ParsedExpression> {
+struct BinaryOperator {
+u8 __jakt_variant_index = 0;
+union VariantData {
+u8 __jakt_uninit_value;
+constexpr VariantData() {}
+~VariantData() {}
+} as;
+constexpr u8 __jakt_init_index() const noexcept { return __jakt_variant_index - 1; }ErrorOr<ByteString> debug_description() const;
+[[nodiscard]] static BinaryOperator Add();
+[[nodiscard]] static BinaryOperator Subtract();
+[[nodiscard]] static BinaryOperator Multiply();
+[[nodiscard]] static BinaryOperator Divide();
+[[nodiscard]] static BinaryOperator Modulo();
+[[nodiscard]] static BinaryOperator LessThan();
+[[nodiscard]] static BinaryOperator LessThanOrEqual();
+[[nodiscard]] static BinaryOperator GreaterThan();
+[[nodiscard]] static BinaryOperator GreaterThanOrEqual();
+[[nodiscard]] static BinaryOperator Equal();
+[[nodiscard]] static BinaryOperator NotEqual();
+[[nodiscard]] static BinaryOperator BitwiseAnd();
+[[nodiscard]] static BinaryOperator BitwiseXor();
+[[nodiscard]] static BinaryOperator BitwiseOr();
+[[nodiscard]] static BinaryOperator BitwiseLeftShift();
+[[nodiscard]] static BinaryOperator BitwiseRightShift();
+[[nodiscard]] static BinaryOperator ArithmeticLeftShift();
+[[nodiscard]] static BinaryOperator ArithmeticRightShift();
+[[nodiscard]] static BinaryOperator LogicalAnd();
+[[nodiscard]] static BinaryOperator LogicalOr();
+[[nodiscard]] static BinaryOperator NoneCoalescing();
+[[nodiscard]] static BinaryOperator Assign();
+[[nodiscard]] static BinaryOperator BitwiseAndAssign();
+[[nodiscard]] static BinaryOperator BitwiseOrAssign();
+[[nodiscard]] static BinaryOperator BitwiseXorAssign();
+[[nodiscard]] static BinaryOperator BitwiseLeftShiftAssign();
+[[nodiscard]] static BinaryOperator BitwiseRightShiftAssign();
+[[nodiscard]] static BinaryOperator AddAssign();
+[[nodiscard]] static BinaryOperator SubtractAssign();
+[[nodiscard]] static BinaryOperator MultiplyAssign();
+[[nodiscard]] static BinaryOperator ModuloAssign();
+[[nodiscard]] static BinaryOperator DivideAssign();
+[[nodiscard]] static BinaryOperator NoneCoalescingAssign();
+[[nodiscard]] static BinaryOperator Garbage();
+~BinaryOperator();
+BinaryOperator& operator=(BinaryOperator const &);
+BinaryOperator& operator=(BinaryOperator &&);
+BinaryOperator(BinaryOperator const&);
+BinaryOperator(BinaryOperator &&);
+private: void __jakt_destroy_variant();
+public:
+bool equals(parser::BinaryOperator const rhs_op) const;
+bool is_assignment() const;
+private:
+BinaryOperator() {};
+};
+struct EnumVariantPatternArgument {
+  public:
+public: JaktInternal::Optional<ByteString> name;public: JaktInternal::Optional<utility::Span> name_span;public: ByteString binding;public: utility::Span span;public: bool is_reference;public: bool is_mutable;public: utility::Span name_in_enum_span() const;
+public: ByteString name_in_enum() const;
+public: EnumVariantPatternArgument(JaktInternal::Optional<ByteString> a_name, JaktInternal::Optional<utility::Span> a_name_span, ByteString a_binding, utility::Span a_span, bool a_is_reference, bool a_is_mutable);
+
+public: bool equals(parser::EnumVariantPatternArgument const rhs_variant_pattern_argument) const;
+public: ErrorOr<ByteString> debug_description() const;
+};struct ParsedExpression: public RefCounted<ParsedExpression> {
 u8 __jakt_variant_index = 0;
 union VariantData {
 u8 __jakt_uninit_value;
@@ -1182,7 +695,255 @@ i64 precedence() const;
 private:
 ParsedExpression() {};
 };
-struct ParsedType: public RefCounted<ParsedType> {
+struct ParsedTypeQualifiers {
+  public:
+public: bool is_mutable;public: bool is_immutable;public: ParsedTypeQualifiers(bool a_is_mutable, bool a_is_immutable);
+
+public: ErrorOr<ByteString> debug_description() const;
+};struct ParsedMethod {
+  public:
+public: parser::ParsedFunction parsed_function;public: parser::Visibility visibility;public: bool is_virtual;public: bool is_override;public: ParsedMethod(parser::ParsedFunction a_parsed_function, parser::Visibility a_visibility, bool a_is_virtual, bool a_is_override);
+
+public: ErrorOr<ByteString> debug_description() const;
+};struct ParsedStatement: public RefCounted<ParsedStatement> {
+u8 __jakt_variant_index = 0;
+union VariantData {
+u8 __jakt_uninit_value;
+struct {
+NonnullRefPtr<typename parser::ParsedExpression> expr;
+utility::Span span;
+} Expression;
+struct {
+NonnullRefPtr<typename parser::ParsedStatement> statement;
+utility::Span span;
+} Defer;
+struct {
+parser::ParsedBlock block;
+utility::Span span;
+} UnsafeBlock;
+struct {
+JaktInternal::DynamicArray<parser::ParsedVarDecl> vars;
+NonnullRefPtr<typename parser::ParsedStatement> var_decl;
+utility::Span span;
+} DestructuringAssignment;
+struct {
+parser::ParsedVarDecl var;
+NonnullRefPtr<typename parser::ParsedExpression> init;
+utility::Span span;
+} VarDecl;
+struct {
+NonnullRefPtr<typename parser::ParsedExpression> condition;
+parser::ParsedBlock then_block;
+JaktInternal::Optional<NonnullRefPtr<typename parser::ParsedStatement>> else_statement;
+utility::Span span;
+} If;
+struct {
+parser::ParsedBlock block;
+utility::Span span;
+} Block;
+struct {
+parser::ParsedBlock block;
+utility::Span span;
+} Loop;
+struct {
+NonnullRefPtr<typename parser::ParsedExpression> condition;
+parser::ParsedBlock block;
+utility::Span span;
+} While;
+struct {
+ByteString iterator_name;
+utility::Span name_span;
+bool is_destructuring;
+NonnullRefPtr<typename parser::ParsedExpression> range;
+parser::ParsedBlock block;
+utility::Span span;
+} For;
+struct {
+utility::Span value;
+} Break;
+struct {
+utility::Span value;
+} Continue;
+struct {
+JaktInternal::Optional<NonnullRefPtr<typename parser::ParsedExpression>> expr;
+utility::Span span;
+} Return;
+struct {
+NonnullRefPtr<typename parser::ParsedExpression> expr;
+utility::Span span;
+} Throw;
+struct {
+NonnullRefPtr<typename parser::ParsedExpression> expr;
+utility::Span span;
+} Yield;
+struct {
+parser::ParsedBlock block;
+utility::Span span;
+} InlineCpp;
+struct {
+NonnullRefPtr<typename parser::ParsedExpression> expr;
+parser::ParsedBlock else_block;
+parser::ParsedBlock remaining_code;
+utility::Span span;
+} Guard;
+struct {
+utility::Span value;
+} Garbage;
+constexpr VariantData() {}
+~VariantData() {}
+} as;
+constexpr u8 __jakt_init_index() const noexcept { return __jakt_variant_index - 1; }ErrorOr<ByteString> debug_description() const;
+[[nodiscard]] static ErrorOr<NonnullRefPtr<ParsedStatement>> Expression(NonnullRefPtr<typename parser::ParsedExpression> expr, utility::Span span);
+[[nodiscard]] static ErrorOr<NonnullRefPtr<ParsedStatement>> Defer(NonnullRefPtr<typename parser::ParsedStatement> statement, utility::Span span);
+[[nodiscard]] static ErrorOr<NonnullRefPtr<ParsedStatement>> UnsafeBlock(parser::ParsedBlock block, utility::Span span);
+[[nodiscard]] static ErrorOr<NonnullRefPtr<ParsedStatement>> DestructuringAssignment(JaktInternal::DynamicArray<parser::ParsedVarDecl> vars, NonnullRefPtr<typename parser::ParsedStatement> var_decl, utility::Span span);
+[[nodiscard]] static ErrorOr<NonnullRefPtr<ParsedStatement>> VarDecl(parser::ParsedVarDecl var, NonnullRefPtr<typename parser::ParsedExpression> init, utility::Span span);
+[[nodiscard]] static ErrorOr<NonnullRefPtr<ParsedStatement>> If(NonnullRefPtr<typename parser::ParsedExpression> condition, parser::ParsedBlock then_block, JaktInternal::Optional<NonnullRefPtr<typename parser::ParsedStatement>> else_statement, utility::Span span);
+[[nodiscard]] static ErrorOr<NonnullRefPtr<ParsedStatement>> Block(parser::ParsedBlock block, utility::Span span);
+[[nodiscard]] static ErrorOr<NonnullRefPtr<ParsedStatement>> Loop(parser::ParsedBlock block, utility::Span span);
+[[nodiscard]] static ErrorOr<NonnullRefPtr<ParsedStatement>> While(NonnullRefPtr<typename parser::ParsedExpression> condition, parser::ParsedBlock block, utility::Span span);
+[[nodiscard]] static ErrorOr<NonnullRefPtr<ParsedStatement>> For(ByteString iterator_name, utility::Span name_span, bool is_destructuring, NonnullRefPtr<typename parser::ParsedExpression> range, parser::ParsedBlock block, utility::Span span);
+[[nodiscard]] static ErrorOr<NonnullRefPtr<ParsedStatement>> Break(utility::Span value);
+[[nodiscard]] static ErrorOr<NonnullRefPtr<ParsedStatement>> Continue(utility::Span value);
+[[nodiscard]] static ErrorOr<NonnullRefPtr<ParsedStatement>> Return(JaktInternal::Optional<NonnullRefPtr<typename parser::ParsedExpression>> expr, utility::Span span);
+[[nodiscard]] static ErrorOr<NonnullRefPtr<ParsedStatement>> Throw(NonnullRefPtr<typename parser::ParsedExpression> expr, utility::Span span);
+[[nodiscard]] static ErrorOr<NonnullRefPtr<ParsedStatement>> Yield(NonnullRefPtr<typename parser::ParsedExpression> expr, utility::Span span);
+[[nodiscard]] static ErrorOr<NonnullRefPtr<ParsedStatement>> InlineCpp(parser::ParsedBlock block, utility::Span span);
+[[nodiscard]] static ErrorOr<NonnullRefPtr<ParsedStatement>> Guard(NonnullRefPtr<typename parser::ParsedExpression> expr, parser::ParsedBlock else_block, parser::ParsedBlock remaining_code, utility::Span span);
+[[nodiscard]] static ErrorOr<NonnullRefPtr<ParsedStatement>> Garbage(utility::Span value);
+~ParsedStatement();
+ParsedStatement& operator=(ParsedStatement const &);
+ParsedStatement& operator=(ParsedStatement &&);
+ParsedStatement(ParsedStatement const&);
+ParsedStatement(ParsedStatement &&);
+private: void __jakt_destroy_variant();
+public:
+bool equals(NonnullRefPtr<typename parser::ParsedStatement> const rhs_statement) const;
+utility::Span span() const;
+private:
+ParsedStatement() {};
+};
+struct ParsedField {
+  public:
+public: parser::ParsedVarDecl var_decl;public: parser::Visibility visibility;public: JaktInternal::Optional<NonnullRefPtr<typename parser::ParsedExpression>> default_value;public: ParsedField(parser::ParsedVarDecl a_var_decl, parser::Visibility a_visibility, JaktInternal::Optional<NonnullRefPtr<typename parser::ParsedExpression>> a_default_value);
+
+public: ErrorOr<ByteString> debug_description() const;
+};struct ParsedName {
+  public:
+public: ByteString name;public: utility::Span span;public: ParsedName(ByteString a_name, utility::Span a_span);
+
+public: ErrorOr<ByteString> debug_description() const;
+};struct ParsedVariable {
+  public:
+public: ByteString name;public: NonnullRefPtr<typename parser::ParsedType> parsed_type;public: bool is_mutable;public: utility::Span span;public: ParsedVariable(ByteString a_name, NonnullRefPtr<typename parser::ParsedType> a_parsed_type, bool a_is_mutable, utility::Span a_span);
+
+public: bool equals(parser::ParsedVariable const rhs_parsed_varible) const;
+public: ErrorOr<ByteString> debug_description() const;
+};struct CheckedQualifiers {
+  public:
+public: bool is_immutable;public: bool equals(parser::CheckedQualifiers const other) const;
+public: CheckedQualifiers(bool a_is_immutable);
+
+public: public: ErrorOr<ByteString> debug_description() const;
+};struct DefinitionLinkage {
+u8 __jakt_variant_index = 0;
+union VariantData {
+u8 __jakt_uninit_value;
+constexpr VariantData() {}
+~VariantData() {}
+} as;
+constexpr u8 __jakt_init_index() const noexcept { return __jakt_variant_index - 1; }ErrorOr<ByteString> debug_description() const;
+[[nodiscard]] static DefinitionLinkage Internal();
+[[nodiscard]] static DefinitionLinkage External();
+~DefinitionLinkage();
+DefinitionLinkage& operator=(DefinitionLinkage const &);
+DefinitionLinkage& operator=(DefinitionLinkage &&);
+DefinitionLinkage(DefinitionLinkage const&);
+DefinitionLinkage(DefinitionLinkage &&);
+private: void __jakt_destroy_variant();
+public:
+private:
+DefinitionLinkage() {};
+};
+struct ParsedVarDeclTuple {
+  public:
+public: JaktInternal::DynamicArray<parser::ParsedVarDecl> var_decls;public: utility::Span span;public: ParsedVarDeclTuple(JaktInternal::DynamicArray<parser::ParsedVarDecl> a_var_decls, utility::Span a_span);
+
+public: ErrorOr<ByteString> debug_description() const;
+};struct ParsedMatchBody {
+u8 __jakt_variant_index = 0;
+union VariantData {
+u8 __jakt_uninit_value;
+struct {
+NonnullRefPtr<typename parser::ParsedExpression> value;
+} Expression;
+struct {
+parser::ParsedBlock value;
+} Block;
+constexpr VariantData() {}
+~VariantData() {}
+} as;
+constexpr u8 __jakt_init_index() const noexcept { return __jakt_variant_index - 1; }ErrorOr<ByteString> debug_description() const;
+[[nodiscard]] static ParsedMatchBody Expression(NonnullRefPtr<typename parser::ParsedExpression> value);
+[[nodiscard]] static ParsedMatchBody Block(parser::ParsedBlock value);
+~ParsedMatchBody();
+ParsedMatchBody& operator=(ParsedMatchBody const &);
+ParsedMatchBody& operator=(ParsedMatchBody &&);
+ParsedMatchBody(ParsedMatchBody const&);
+ParsedMatchBody(ParsedMatchBody &&);
+private: void __jakt_destroy_variant();
+public:
+bool equals(parser::ParsedMatchBody const rhs_match_body) const;
+private:
+ParsedMatchBody() {};
+};
+struct RecordType {
+u8 __jakt_variant_index = 0;
+union VariantData {
+u8 __jakt_uninit_value;
+struct {
+JaktInternal::DynamicArray<parser::ParsedField> fields;
+JaktInternal::Optional<NonnullRefPtr<typename parser::ParsedType>> super_type;
+} Struct;
+struct {
+JaktInternal::DynamicArray<parser::ParsedField> fields;
+JaktInternal::Optional<NonnullRefPtr<typename parser::ParsedType>> super_type;
+} Class;
+struct {
+NonnullRefPtr<typename parser::ParsedType> underlying_type;
+JaktInternal::DynamicArray<parser::ValueEnumVariant> variants;
+} ValueEnum;
+struct {
+bool is_boxed;
+JaktInternal::DynamicArray<parser::ParsedField> fields;
+JaktInternal::DynamicArray<parser::SumEnumVariant> variants;
+} SumEnum;
+constexpr VariantData() {}
+~VariantData() {}
+} as;
+constexpr u8 __jakt_init_index() const noexcept { return __jakt_variant_index - 1; }ErrorOr<ByteString> debug_description() const;
+[[nodiscard]] static RecordType Struct(JaktInternal::DynamicArray<parser::ParsedField> fields, JaktInternal::Optional<NonnullRefPtr<typename parser::ParsedType>> super_type);
+[[nodiscard]] static RecordType Class(JaktInternal::DynamicArray<parser::ParsedField> fields, JaktInternal::Optional<NonnullRefPtr<typename parser::ParsedType>> super_type);
+[[nodiscard]] static RecordType ValueEnum(NonnullRefPtr<typename parser::ParsedType> underlying_type, JaktInternal::DynamicArray<parser::ValueEnumVariant> variants);
+[[nodiscard]] static RecordType SumEnum(bool is_boxed, JaktInternal::DynamicArray<parser::ParsedField> fields, JaktInternal::DynamicArray<parser::SumEnumVariant> variants);
+[[nodiscard]] static RecordType Garbage();
+~RecordType();
+RecordType& operator=(RecordType const &);
+RecordType& operator=(RecordType &&);
+RecordType(RecordType const&);
+RecordType(RecordType &&);
+private: void __jakt_destroy_variant();
+public:
+ErrorOr<ByteString> record_type_name() const;
+private:
+RecordType() {};
+};
+struct ParsedFunctionParameters {
+  public:
+public: JaktInternal::DynamicArray<parser::ParsedParameter> parameters;public: bool has_varargs;public: ParsedFunctionParameters(JaktInternal::DynamicArray<parser::ParsedParameter> a_parameters, bool a_has_varargs);
+
+public: ErrorOr<ByteString> debug_description() const;
+};struct ParsedType: public RefCounted<ParsedType> {
 u8 __jakt_variant_index = 0;
 union CommonData {
 u8 __jakt_uninit_common;
@@ -1293,6 +1054,230 @@ utility::Span span() const;
 private:
 ParsedType() {};
 };
+struct ParsedAlias {
+  public:
+public: JaktInternal::Optional<parser::ParsedName> alias_name;public: JaktInternal::DynamicArray<parser::ParsedNameWithGenericParameters> target;public: ParsedAlias(JaktInternal::Optional<parser::ParsedName> a_alias_name, JaktInternal::DynamicArray<parser::ParsedNameWithGenericParameters> a_target);
+
+public: ErrorOr<ByteString> debug_description() const;
+};struct ParsedMatchCase {
+  public:
+public: JaktInternal::DynamicArray<parser::ParsedMatchPattern> patterns;public: utility::Span marker_span;public: parser::ParsedMatchBody body;public: bool has_equal_pattern(parser::ParsedMatchCase const rhs_match_case) const;
+public: bool equals(parser::ParsedMatchCase const rhs_match_case) const;
+public: ParsedMatchCase(JaktInternal::DynamicArray<parser::ParsedMatchPattern> a_patterns, utility::Span a_marker_span, parser::ParsedMatchBody a_body);
+
+public: ErrorOr<ByteString> debug_description() const;
+};struct ImportName {
+u8 __jakt_variant_index = 0;
+union VariantData {
+u8 __jakt_uninit_value;
+struct {
+ByteString name;
+utility::Span span;
+} Literal;
+struct {
+NonnullRefPtr<typename parser::ParsedExpression> expression;
+} Comptime;
+constexpr VariantData() {}
+~VariantData() {}
+} as;
+constexpr u8 __jakt_init_index() const noexcept { return __jakt_variant_index - 1; }ErrorOr<ByteString> debug_description() const;
+[[nodiscard]] static ImportName Literal(ByteString name, utility::Span span);
+[[nodiscard]] static ImportName Comptime(NonnullRefPtr<typename parser::ParsedExpression> expression);
+~ImportName();
+ImportName& operator=(ImportName const &);
+ImportName& operator=(ImportName &&);
+ImportName(ImportName const&);
+ImportName(ImportName &&);
+private: void __jakt_destroy_variant();
+public:
+ErrorOr<ByteString> literal_name() const;
+bool equals(parser::ImportName const other) const;
+utility::Span span() const;
+private:
+ImportName() {};
+};
+struct ParsedModuleImport {
+  public:
+public: parser::ImportName module_name;public: JaktInternal::Optional<parser::ImportName> alias_name;public: parser::ImportList import_list;public: bool relative_path;public: size_t parent_path_count;public: bool has_same_alias_than(parser::ParsedModuleImport const other) const;
+public: ParsedModuleImport(parser::ImportName a_module_name, JaktInternal::Optional<parser::ImportName> a_alias_name, parser::ImportList a_import_list, bool a_relative_path, size_t a_parent_path_count);
+
+public: bool has_same_import_semantics(parser::ParsedModuleImport const other) const;
+public: ErrorOr<void> merge_import_list(parser::ImportList const list);
+public: bool is_equivalent_to(parser::ParsedModuleImport const other) const;
+public: ErrorOr<ByteString> debug_description() const;
+};struct VisibilityRestriction {
+  public:
+public: JaktInternal::DynamicArray<ByteString> namespace_;public: ByteString name;public: VisibilityRestriction(JaktInternal::DynamicArray<ByteString> a_namespace_, ByteString a_name);
+
+public: ErrorOr<ByteString> debug_description() const;
+};struct Parser {
+  public:
+public: size_t index;public: JaktInternal::DynamicArray<lexer::Token> tokens;public: NonnullRefPtr<compiler::Compiler> compiler;public: bool can_have_trailing_closure;public: size_t next_function_id;public: ErrorOr<NonnullRefPtr<typename parser::ParsedExpression>> parse_operand_base();
+public: utility::Span span(size_t const start, size_t const end) const;
+public: ErrorOr<JaktInternal::Optional<parser::NumericConstant>> make_integer_numeric_constant(u64 const number, lexer::LiteralSuffix const suffix, utility::Span const span);
+public: ErrorOr<NonnullRefPtr<typename parser::ParsedType>> parse_type_shorthand(parser::ParsedTypeQualifiers const qualifiers);
+public: ErrorOr<NonnullRefPtr<typename parser::ParsedExpression>> parse_lambda();
+public: ErrorOr<NonnullRefPtr<typename parser::ParsedType>> parse_type_longhand(parser::ParsedTypeQualifiers const qualifiers);
+public: ErrorOr<parser::ParsedAlias> parse_using();
+public: ErrorOr<parser::ParsedFunctionParameters> parse_function_parameters(bool const for_trailing_closure);
+public: ErrorOr<JaktInternal::DynamicArray<parser::ParsedMatchCase>> parse_match_cases();
+public: ErrorOr<JaktInternal::Optional<parser::ParsedAttribute>> parse_attribute();
+public: ErrorOr<parser::ParsedMethod> parse_method(parser::FunctionLinkage const linkage, parser::Visibility const visibility, bool const is_virtual, bool const is_override, bool const is_comptime, bool const is_destructor, bool const is_unsafe);
+public: ErrorOr<parser::ParsedNamespace> parse_namespace(bool const process_only_one_entity);
+public: ErrorOr<JaktInternal::Tuple<JaktInternal::DynamicArray<parser::ParsedGenericParameter>,parser::ParsedNamespace>> parse_forall();
+public: ErrorOr<parser::ParsedVarDecl> parse_variable_declaration(bool const is_mutable);
+public: ErrorOr<NonnullRefPtr<typename parser::ParsedType>> parse_type_shorthand_set(parser::ParsedTypeQualifiers const qualifiers);
+public: ErrorOr<NonnullRefPtr<typename parser::ParsedStatement>> parse_if_statement();
+public: ErrorOr<JaktInternal::Optional<parser::ParsedCall>> parse_call();
+public: ErrorOr<void> inject_token(lexer::Token const token);
+public: ErrorOr<parser::ParsedRecord> parse_class(parser::DefinitionLinkage const definition_linkage);
+public: ErrorOr<parser::ParsedExternalTraitImplementation> parse_external_trait_implementation();
+public: ErrorOr<parser::ParsedMatchPattern> parse_match_pattern();
+public: ErrorOr<parser::ParsedFunction> parse_function(parser::FunctionLinkage const linkage, parser::Visibility const visibility, bool const is_comptime, bool const is_destructor, bool const is_unsafe, bool const allow_missing_body);
+public: ErrorOr<parser::ParsedExternImport> parse_extern_import(parser::ParsedNamespace& parent);
+public: ErrorOr<NonnullRefPtr<typename parser::ParsedType>> parse_typename();
+public: ErrorOr<JaktInternal::Tuple<JaktInternal::DynamicArray<parser::ParsedField>,JaktInternal::DynamicArray<parser::ParsedMethod>,JaktInternal::DynamicArray<parser::ParsedRecord>>> parse_struct_class_body(parser::DefinitionLinkage const definition_linkage, parser::Visibility const default_visibility, bool const is_class);
+public: ErrorOr<NonnullRefPtr<typename parser::ParsedExpression>> parse_unsafe_expr();
+public: static ErrorOr<parser::ParsedNamespace> parse(NonnullRefPtr<compiler::Compiler> const compiler, JaktInternal::DynamicArray<lexer::Token> const tokens);
+public: ErrorOr<JaktInternal::Optional<parser::NumericConstant>> make_float_numeric_constant(f64 const number, lexer::LiteralSuffix const suffix, utility::Span const span);
+public: ErrorOr<NonnullRefPtr<typename parser::ParsedExpression>> parse_range();
+public: ErrorOr<parser::ParsedBlock> parse_fat_arrow();
+public: void skip_newlines();
+public: ErrorOr<JaktInternal::Tuple<JaktInternal::DynamicArray<parser::ValueEnumVariant>,JaktInternal::DynamicArray<parser::ParsedMethod>>> parse_value_enum_body(parser::ParsedRecord const partial_enum, parser::DefinitionLinkage const definition_linkage);
+public: lexer::Token previous() const;
+public: ErrorOr<JaktInternal::DynamicArray<NonnullRefPtr<typename parser::ParsedType>>> parse_type_parameter_list();
+public: ErrorOr<JaktInternal::DynamicArray<parser::EnumVariantPatternArgument>> parse_variant_arguments();
+public: ErrorOr<NonnullRefPtr<typename parser::ParsedStatement>> parse_guard_statement();
+public: bool eof() const;
+public: ErrorOr<NonnullRefPtr<typename parser::ParsedExpression>> parse_asterisk();
+public: ErrorOr<NonnullRefPtr<typename parser::ParsedExpression>> parse_match_expression();
+public: ErrorOr<void> apply_attributes(parser::ParsedNamespace& namespace_, JaktInternal::DynamicArray<parser::ParsedAttribute> const& active_attributes);
+public: ErrorOr<void> apply_attributes(parser::ParsedField& field, JaktInternal::DynamicArray<parser::ParsedAttribute> const& active_attributes);
+public: ErrorOr<void> apply_attributes(parser::ParsedFunction& parsed_function, JaktInternal::DynamicArray<parser::ParsedAttribute> const& active_attributes);
+public: ErrorOr<void> apply_attributes(parser::ParsedMethod& parsed_method, JaktInternal::DynamicArray<parser::ParsedAttribute> const& active_attributes);
+public: ErrorOr<void> apply_attributes(parser::ParsedRecord& parsed_record, JaktInternal::DynamicArray<parser::ParsedAttribute> const& active_attributes);
+public: lexer::Token current() const;
+public: ErrorOr<parser::ParsedRecord> parse_enum(parser::DefinitionLinkage const definition_linkage, bool const is_boxed);
+public: ErrorOr<parser::ParsedBlock> parse_block();
+public: utility::Span empty_span() const;
+public: ErrorOr<NonnullRefPtr<typename parser::ParsedExpression>> parse_postfix_colon_colon(utility::Span const start, NonnullRefPtr<typename parser::ParsedExpression> const expr);
+public: ErrorOr<void> error(ByteString const message, utility::Span const span);
+public: ErrorOr<parser::ParsedTrait> parse_trait();
+public: ErrorOr<parser::Visibility> parse_restricted_visibility_modifier();
+public: ErrorOr<parser::ParsedVarDeclTuple> parse_destructuring_assignment(bool const is_mutable);
+public: ErrorOr<NonnullRefPtr<typename parser::ParsedExpression>> parse_operand_postfix_operator(utility::Span const start, NonnullRefPtr<typename parser::ParsedExpression> const expr);
+public: ErrorOr<NonnullRefPtr<typename parser::ParsedExpression>> parse_set_literal();
+public: ErrorOr<void> parse_attribute_list(JaktInternal::DynamicArray<parser::ParsedAttribute>& active_attributes);
+public: Parser(size_t a_index, JaktInternal::DynamicArray<lexer::Token> a_tokens, NonnullRefPtr<compiler::Compiler> a_compiler, bool a_can_have_trailing_closure, size_t a_next_function_id);
+
+public: ErrorOr<NonnullRefPtr<typename parser::ParsedExpression>> parse_expression(bool const allow_assignments, bool const allow_newlines);
+public: ErrorOr<NonnullRefPtr<typename parser::ParsedExpression>> parse_operator(bool const allow_assignments);
+public: ErrorOr<NonnullRefPtr<typename parser::ParsedStatement>> parse_for_statement();
+public: ErrorOr<NonnullRefPtr<typename parser::ParsedType>> parse_typename_base();
+public: ErrorOr<NonnullRefPtr<typename parser::ParsedExpression>> parse_operand();
+public: ErrorOr<JaktInternal::Tuple<JaktInternal::DynamicArray<parser::SumEnumVariant>,JaktInternal::DynamicArray<parser::ParsedField>,JaktInternal::DynamicArray<parser::ParsedMethod>,JaktInternal::DynamicArray<parser::ParsedRecord>>> parse_sum_enum_body(parser::ParsedRecord const partial_enum, parser::DefinitionLinkage const definition_linkage, bool const is_boxed);
+public: ErrorOr<JaktInternal::DynamicArray<parser::ParsedCapture>> parse_captures();
+public: ErrorOr<NonnullRefPtr<typename parser::ParsedExpression>> parse_number(lexer::LiteralPrefix const prefix, ByteString const number, lexer::LiteralSuffix suffix, utility::Span const span);
+public: ErrorOr<parser::ParsedModuleImport> parse_module_import();
+public: ErrorOr<parser::ParsedRecord> parse_record(parser::DefinitionLinkage const definition_linkage);
+public: lexer::Token peek(size_t const steps) const;
+public: ErrorOr<void> error_with_hint(ByteString const message, utility::Span const span, ByteString const hint, utility::Span const hint_span);
+public: ErrorOr<NonnullRefPtr<typename parser::ParsedType>> parse_type_shorthand_array_or_dictionary(parser::ParsedTypeQualifiers const qualifiers);
+public: ErrorOr<NonnullRefPtr<typename parser::ParsedType>> parse_type_shorthand_tuple(parser::ParsedTypeQualifiers const qualifiers);
+public: bool eol() const;
+public: ErrorOr<NonnullRefPtr<typename parser::ParsedExpression>> parse_array_or_dictionary_literal();
+public: ErrorOr<JaktInternal::DynamicArray<parser::ParsedMatchPattern>> parse_match_patterns();
+public: ErrorOr<void> parse_import(parser::ParsedNamespace& parent);
+public: ErrorOr<NonnullRefPtr<typename parser::ParsedStatement>> parse_statement(bool const inside_block);
+public: ErrorOr<parser::ParsedField> parse_field(parser::Visibility const visibility);
+public: ErrorOr<ByteString> parse_argument_label();
+public: ErrorOr<NonnullRefPtr<typename parser::ParsedExpression>> parse_ampersand();
+public: ErrorOr<JaktInternal::Optional<JaktInternal::DynamicArray<parser::IncludeAction>>> parse_include_action();
+public: ErrorOr<NonnullRefPtr<typename parser::ParsedExpression>> parse_try_block();
+public: ErrorOr<JaktInternal::DynamicArray<parser::ParsedGenericParameter>> parse_generic_parameters();
+public: ErrorOr<parser::ParsedRecord> parse_struct(parser::DefinitionLinkage const definition_linkage);
+public: ErrorOr<JaktInternal::Optional<JaktInternal::DynamicArray<parser::ParsedNameWithGenericParameters>>> parse_trait_list();
+public: ErrorOr<ByteString> debug_description() const;
+};struct ParsedMatchPattern {
+u8 __jakt_variant_index = 0;
+union CommonData {
+u8 __jakt_uninit_common;
+struct {
+JaktInternal::Dictionary<ByteString,parser::ParsedPatternDefault> defaults;
+} init_common;
+constexpr CommonData() {}
+~CommonData() {}
+} common;
+union VariantData {
+u8 __jakt_uninit_value;
+struct {
+JaktInternal::DynamicArray<JaktInternal::Tuple<ByteString,utility::Span>> variant_names;
+JaktInternal::DynamicArray<parser::EnumVariantPatternArgument> variant_arguments;
+utility::Span arguments_span;
+} EnumVariant;
+struct {
+NonnullRefPtr<typename parser::ParsedExpression> value;
+} Expression;
+struct {
+JaktInternal::DynamicArray<parser::EnumVariantPatternArgument> variant_arguments;
+utility::Span arguments_span;
+} CatchAll;
+constexpr VariantData() {}
+~VariantData() {}
+} as;
+constexpr u8 __jakt_init_index() const noexcept { return __jakt_variant_index - 1; }ErrorOr<ByteString> debug_description() const;
+[[nodiscard]] static ParsedMatchPattern EnumVariant(JaktInternal::Dictionary<ByteString,parser::ParsedPatternDefault> defaults, JaktInternal::DynamicArray<JaktInternal::Tuple<ByteString,utility::Span>> variant_names, JaktInternal::DynamicArray<parser::EnumVariantPatternArgument> variant_arguments, utility::Span arguments_span);
+[[nodiscard]] static ParsedMatchPattern Expression(JaktInternal::Dictionary<ByteString,parser::ParsedPatternDefault> defaults, NonnullRefPtr<typename parser::ParsedExpression> value);
+[[nodiscard]] static ParsedMatchPattern CatchAll(JaktInternal::Dictionary<ByteString,parser::ParsedPatternDefault> defaults, JaktInternal::DynamicArray<parser::EnumVariantPatternArgument> variant_arguments, utility::Span arguments_span);
+[[nodiscard]] static ParsedMatchPattern Invalid(JaktInternal::Dictionary<ByteString,parser::ParsedPatternDefault> defaults);
+~ParsedMatchPattern();
+ParsedMatchPattern& operator=(ParsedMatchPattern const &);
+ParsedMatchPattern& operator=(ParsedMatchPattern &&);
+ParsedMatchPattern(ParsedMatchPattern const&);
+ParsedMatchPattern(ParsedMatchPattern &&);
+private: void __jakt_destroy_variant();
+public:
+bool equals(parser::ParsedMatchPattern const rhs_parsed_match_pattern) const;
+bool is_equal_pattern(parser::ParsedMatchPattern const rhs_parsed_match_pattern) const;
+bool defaults_equal(JaktInternal::Dictionary<ByteString,parser::ParsedPatternDefault> const defaults) const;
+private:
+ParsedMatchPattern() {};
+};
+struct ParsedParameter {
+  public:
+public: bool requires_label;public: parser::ParsedVariable variable;public: JaktInternal::Optional<NonnullRefPtr<typename parser::ParsedExpression>> default_argument;public: utility::Span span;public: ParsedParameter(bool a_requires_label, parser::ParsedVariable a_variable, JaktInternal::Optional<NonnullRefPtr<typename parser::ParsedExpression>> a_default_argument, utility::Span a_span);
+
+public: bool equals(parser::ParsedParameter const rhs_param) const;
+public: ErrorOr<ByteString> debug_description() const;
+};struct IncludeAction {
+u8 __jakt_variant_index = 0;
+union VariantData {
+u8 __jakt_uninit_value;
+struct {
+ByteString name;
+utility::Span span;
+ByteString value;
+} Define;
+struct {
+ByteString name;
+utility::Span span;
+} Undefine;
+constexpr VariantData() {}
+~VariantData() {}
+} as;
+constexpr u8 __jakt_init_index() const noexcept { return __jakt_variant_index - 1; }ErrorOr<ByteString> debug_description() const;
+[[nodiscard]] static IncludeAction Define(ByteString name, utility::Span span, ByteString value);
+[[nodiscard]] static IncludeAction Undefine(ByteString name, utility::Span span);
+~IncludeAction();
+IncludeAction& operator=(IncludeAction const &);
+IncludeAction& operator=(IncludeAction &&);
+IncludeAction(IncludeAction const&);
+IncludeAction(IncludeAction &&);
+private: void __jakt_destroy_variant();
+public:
+private:
+IncludeAction() {};
+};
 struct ParsedCapture {
 u8 __jakt_variant_index = 0;
 union CommonData {
@@ -1325,35 +1310,50 @@ public:
 private:
 ParsedCapture() {};
 };
-struct SumEnumVariant {
+struct ValueEnumVariant {
   public:
-public: ByteString name;public: utility::Span span;public: JaktInternal::Optional<JaktInternal::DynamicArray<parser::ParsedVarDecl>> params;public: JaktInternal::Optional<JaktInternal::DynamicArray<JaktInternal::Optional<NonnullRefPtr<typename parser::ParsedExpression>>>> default_values;public: SumEnumVariant(ByteString a_name, utility::Span a_span, JaktInternal::Optional<JaktInternal::DynamicArray<parser::ParsedVarDecl>> a_params, JaktInternal::Optional<JaktInternal::DynamicArray<JaktInternal::Optional<NonnullRefPtr<typename parser::ParsedExpression>>>> a_default_values);
+public: ByteString name;public: utility::Span span;public: JaktInternal::Optional<NonnullRefPtr<typename parser::ParsedExpression>> value;public: ValueEnumVariant(ByteString a_name, utility::Span a_span, JaktInternal::Optional<NonnullRefPtr<typename parser::ParsedExpression>> a_value);
+
+public: ErrorOr<ByteString> debug_description() const;
+};struct ParsedAttributeArgument {
+  public:
+public: ByteString name;public: utility::Span span;public: JaktInternal::Optional<ByteString> assigned_value;public: ParsedAttributeArgument(ByteString a_name, utility::Span a_span, JaktInternal::Optional<ByteString> a_assigned_value);
+
+public: ErrorOr<ByteString> debug_description() const;
+};struct ParsedPatternDefault {
+  public:
+public: parser::ParsedVarDecl variable;public: NonnullRefPtr<typename parser::ParsedExpression> value;public: ParsedPatternDefault(parser::ParsedVarDecl a_variable, NonnullRefPtr<typename parser::ParsedExpression> a_value);
+
+public: ErrorOr<ByteString> debug_description() const;
+};struct ParsedRecord {
+  public:
+public: ByteString name;public: utility::Span name_span;public: JaktInternal::DynamicArray<parser::ParsedGenericParameter> generic_parameters;public: parser::DefinitionLinkage definition_linkage;public: JaktInternal::Optional<JaktInternal::DynamicArray<parser::ParsedNameWithGenericParameters>> implements_list;public: JaktInternal::DynamicArray<parser::ParsedMethod> methods;public: parser::RecordType record_type;public: JaktInternal::DynamicArray<parser::ParsedRecord> nested_records;public: JaktInternal::Optional<parser::ExternalName> external_name;public: ParsedRecord(ByteString a_name, utility::Span a_name_span, JaktInternal::DynamicArray<parser::ParsedGenericParameter> a_generic_parameters, parser::DefinitionLinkage a_definition_linkage, JaktInternal::Optional<JaktInternal::DynamicArray<parser::ParsedNameWithGenericParameters>> a_implements_list, JaktInternal::DynamicArray<parser::ParsedMethod> a_methods, parser::RecordType a_record_type, JaktInternal::DynamicArray<parser::ParsedRecord> a_nested_records, JaktInternal::Optional<parser::ExternalName> a_external_name);
 
 public: ErrorOr<ByteString> debug_description() const;
 };template <typename T>
 T u64_to_float(u64 const number);
 }
 } // namespace Jakt
-template<>struct Jakt::Formatter<Jakt::parser::ValueEnumVariant> : Jakt::Formatter<Jakt::StringView>{
-Jakt::ErrorOr<void> format(Jakt::FormatBuilder& builder, Jakt::parser::ValueEnumVariant const& value) {
+template<>struct Jakt::Formatter<Jakt::parser::ParsedTraitRequirements> : Jakt::Formatter<Jakt::StringView>{
+Jakt::ErrorOr<void> format(Jakt::FormatBuilder& builder, Jakt::parser::ParsedTraitRequirements const& value) {
 JaktInternal::PrettyPrint::ScopedEnable pretty_print_enable { m_alternative_form };Jakt::ErrorOr<void> format_error = Jakt::Formatter<Jakt::StringView>::format(builder, MUST(value.debug_description()));return format_error;}
 };
 namespace Jakt {
 } // namespace Jakt
-template<>struct Jakt::Formatter<Jakt::parser::EnumVariantPatternArgument> : Jakt::Formatter<Jakt::StringView>{
-Jakt::ErrorOr<void> format(Jakt::FormatBuilder& builder, Jakt::parser::EnumVariantPatternArgument const& value) {
+template<>struct Jakt::Formatter<Jakt::parser::ParsedTrait> : Jakt::Formatter<Jakt::StringView>{
+Jakt::ErrorOr<void> format(Jakt::FormatBuilder& builder, Jakt::parser::ParsedTrait const& value) {
 JaktInternal::PrettyPrint::ScopedEnable pretty_print_enable { m_alternative_form };Jakt::ErrorOr<void> format_error = Jakt::Formatter<Jakt::StringView>::format(builder, MUST(value.debug_description()));return format_error;}
 };
 namespace Jakt {
 } // namespace Jakt
-template<>struct Jakt::Formatter<Jakt::parser::Visibility> : Jakt::Formatter<Jakt::StringView>{
-Jakt::ErrorOr<void> format(Jakt::FormatBuilder& builder, Jakt::parser::Visibility const& value) {
+template<>struct Jakt::Formatter<Jakt::parser::ParsedNameWithGenericParameters> : Jakt::Formatter<Jakt::StringView>{
+Jakt::ErrorOr<void> format(Jakt::FormatBuilder& builder, Jakt::parser::ParsedNameWithGenericParameters const& value) {
 JaktInternal::PrettyPrint::ScopedEnable pretty_print_enable { m_alternative_form };Jakt::ErrorOr<void> format_error = Jakt::Formatter<Jakt::StringView>::format(builder, MUST(value.debug_description()));return format_error;}
 };
 namespace Jakt {
 } // namespace Jakt
-template<>struct Jakt::Formatter<Jakt::parser::ParsedBlock> : Jakt::Formatter<Jakt::StringView>{
-Jakt::ErrorOr<void> format(Jakt::FormatBuilder& builder, Jakt::parser::ParsedBlock const& value) {
+template<>struct Jakt::Formatter<Jakt::parser::ArgumentStoreLevel> : Jakt::Formatter<Jakt::StringView>{
+Jakt::ErrorOr<void> format(Jakt::FormatBuilder& builder, Jakt::parser::ArgumentStoreLevel const& value) {
 JaktInternal::PrettyPrint::ScopedEnable pretty_print_enable { m_alternative_form };Jakt::ErrorOr<void> format_error = Jakt::Formatter<Jakt::StringView>::format(builder, MUST(value.debug_description()));return format_error;}
 };
 namespace Jakt {
@@ -1370,128 +1370,20 @@ JaktInternal::PrettyPrint::ScopedEnable pretty_print_enable { m_alternative_form
 };
 namespace Jakt {
 } // namespace Jakt
-template<>struct Jakt::Formatter<Jakt::parser::ParsedStatement> : Jakt::Formatter<Jakt::StringView>{
-Jakt::ErrorOr<void> format(Jakt::FormatBuilder& builder, Jakt::parser::ParsedStatement const& value) {
+template<>struct Jakt::Formatter<Jakt::parser::Visibility> : Jakt::Formatter<Jakt::StringView>{
+Jakt::ErrorOr<void> format(Jakt::FormatBuilder& builder, Jakt::parser::Visibility const& value) {
 JaktInternal::PrettyPrint::ScopedEnable pretty_print_enable { m_alternative_form };Jakt::ErrorOr<void> format_error = Jakt::Formatter<Jakt::StringView>::format(builder, MUST(value.debug_description()));return format_error;}
 };
 namespace Jakt {
 } // namespace Jakt
-template<>struct Jakt::Formatter<Jakt::parser::ParsedGenericParameter> : Jakt::Formatter<Jakt::StringView>{
-Jakt::ErrorOr<void> format(Jakt::FormatBuilder& builder, Jakt::parser::ParsedGenericParameter const& value) {
-JaktInternal::PrettyPrint::ScopedEnable pretty_print_enable { m_alternative_form };Jakt::ErrorOr<void> format_error = Jakt::Formatter<Jakt::StringView>::format(builder, MUST(value.debug_description()));return format_error;}
-};
-namespace Jakt {
-} // namespace Jakt
-template<>struct Jakt::Formatter<Jakt::parser::ParsedField> : Jakt::Formatter<Jakt::StringView>{
-Jakt::ErrorOr<void> format(Jakt::FormatBuilder& builder, Jakt::parser::ParsedField const& value) {
-JaktInternal::PrettyPrint::ScopedEnable pretty_print_enable { m_alternative_form };Jakt::ErrorOr<void> format_error = Jakt::Formatter<Jakt::StringView>::format(builder, MUST(value.debug_description()));return format_error;}
-};
-namespace Jakt {
-} // namespace Jakt
-template<>struct Jakt::Formatter<Jakt::parser::ParsedName> : Jakt::Formatter<Jakt::StringView>{
-Jakt::ErrorOr<void> format(Jakt::FormatBuilder& builder, Jakt::parser::ParsedName const& value) {
-JaktInternal::PrettyPrint::ScopedEnable pretty_print_enable { m_alternative_form };Jakt::ErrorOr<void> format_error = Jakt::Formatter<Jakt::StringView>::format(builder, MUST(value.debug_description()));return format_error;}
-};
-namespace Jakt {
-} // namespace Jakt
-template<>struct Jakt::Formatter<Jakt::parser::ParsedVariable> : Jakt::Formatter<Jakt::StringView>{
-Jakt::ErrorOr<void> format(Jakt::FormatBuilder& builder, Jakt::parser::ParsedVariable const& value) {
-JaktInternal::PrettyPrint::ScopedEnable pretty_print_enable { m_alternative_form };Jakt::ErrorOr<void> format_error = Jakt::Formatter<Jakt::StringView>::format(builder, MUST(value.debug_description()));return format_error;}
-};
-namespace Jakt {
-} // namespace Jakt
-template<>struct Jakt::Formatter<Jakt::parser::ParsedParameter> : Jakt::Formatter<Jakt::StringView>{
-Jakt::ErrorOr<void> format(Jakt::FormatBuilder& builder, Jakt::parser::ParsedParameter const& value) {
-JaktInternal::PrettyPrint::ScopedEnable pretty_print_enable { m_alternative_form };Jakt::ErrorOr<void> format_error = Jakt::Formatter<Jakt::StringView>::format(builder, MUST(value.debug_description()));return format_error;}
-};
-namespace Jakt {
-} // namespace Jakt
-template<>struct Jakt::Formatter<Jakt::parser::ParsedPatternDefault> : Jakt::Formatter<Jakt::StringView>{
-Jakt::ErrorOr<void> format(Jakt::FormatBuilder& builder, Jakt::parser::ParsedPatternDefault const& value) {
-JaktInternal::PrettyPrint::ScopedEnable pretty_print_enable { m_alternative_form };Jakt::ErrorOr<void> format_error = Jakt::Formatter<Jakt::StringView>::format(builder, MUST(value.debug_description()));return format_error;}
-};
-namespace Jakt {
-} // namespace Jakt
-template<>struct Jakt::Formatter<Jakt::parser::ParsedMatchBody> : Jakt::Formatter<Jakt::StringView>{
-Jakt::ErrorOr<void> format(Jakt::FormatBuilder& builder, Jakt::parser::ParsedMatchBody const& value) {
-JaktInternal::PrettyPrint::ScopedEnable pretty_print_enable { m_alternative_form };Jakt::ErrorOr<void> format_error = Jakt::Formatter<Jakt::StringView>::format(builder, MUST(value.debug_description()));return format_error;}
-};
-namespace Jakt {
-} // namespace Jakt
-template<>struct Jakt::Formatter<Jakt::parser::ParsedMatchCase> : Jakt::Formatter<Jakt::StringView>{
-Jakt::ErrorOr<void> format(Jakt::FormatBuilder& builder, Jakt::parser::ParsedMatchCase const& value) {
-JaktInternal::PrettyPrint::ScopedEnable pretty_print_enable { m_alternative_form };Jakt::ErrorOr<void> format_error = Jakt::Formatter<Jakt::StringView>::format(builder, MUST(value.debug_description()));return format_error;}
-};
-namespace Jakt {
-} // namespace Jakt
-template<>struct Jakt::Formatter<Jakt::parser::ParsedExternalTraitImplementation> : Jakt::Formatter<Jakt::StringView>{
-Jakt::ErrorOr<void> format(Jakt::FormatBuilder& builder, Jakt::parser::ParsedExternalTraitImplementation const& value) {
-JaktInternal::PrettyPrint::ScopedEnable pretty_print_enable { m_alternative_form };Jakt::ErrorOr<void> format_error = Jakt::Formatter<Jakt::StringView>::format(builder, MUST(value.debug_description()));return format_error;}
-};
-namespace Jakt {
-} // namespace Jakt
-template<>struct Jakt::Formatter<Jakt::parser::ParsedNamespace> : Jakt::Formatter<Jakt::StringView>{
-Jakt::ErrorOr<void> format(Jakt::FormatBuilder& builder, Jakt::parser::ParsedNamespace const& value) {
-JaktInternal::PrettyPrint::ScopedEnable pretty_print_enable { m_alternative_form };Jakt::ErrorOr<void> format_error = Jakt::Formatter<Jakt::StringView>::format(builder, MUST(value.debug_description()));return format_error;}
-};
-namespace Jakt {
-} // namespace Jakt
-template<>struct Jakt::Formatter<Jakt::parser::ParsedFunctionParameters> : Jakt::Formatter<Jakt::StringView>{
-Jakt::ErrorOr<void> format(Jakt::FormatBuilder& builder, Jakt::parser::ParsedFunctionParameters const& value) {
-JaktInternal::PrettyPrint::ScopedEnable pretty_print_enable { m_alternative_form };Jakt::ErrorOr<void> format_error = Jakt::Formatter<Jakt::StringView>::format(builder, MUST(value.debug_description()));return format_error;}
-};
-namespace Jakt {
-} // namespace Jakt
-template<>struct Jakt::Formatter<Jakt::parser::ParsedVarDeclTuple> : Jakt::Formatter<Jakt::StringView>{
-Jakt::ErrorOr<void> format(Jakt::FormatBuilder& builder, Jakt::parser::ParsedVarDeclTuple const& value) {
-JaktInternal::PrettyPrint::ScopedEnable pretty_print_enable { m_alternative_form };Jakt::ErrorOr<void> format_error = Jakt::Formatter<Jakt::StringView>::format(builder, MUST(value.debug_description()));return format_error;}
-};
-namespace Jakt {
-} // namespace Jakt
-template<>struct Jakt::Formatter<Jakt::parser::ParsedNameWithGenericParameters> : Jakt::Formatter<Jakt::StringView>{
-Jakt::ErrorOr<void> format(Jakt::FormatBuilder& builder, Jakt::parser::ParsedNameWithGenericParameters const& value) {
-JaktInternal::PrettyPrint::ScopedEnable pretty_print_enable { m_alternative_form };Jakt::ErrorOr<void> format_error = Jakt::Formatter<Jakt::StringView>::format(builder, MUST(value.debug_description()));return format_error;}
-};
-namespace Jakt {
-} // namespace Jakt
-template<>struct Jakt::Formatter<Jakt::parser::ImportName> : Jakt::Formatter<Jakt::StringView>{
-Jakt::ErrorOr<void> format(Jakt::FormatBuilder& builder, Jakt::parser::ImportName const& value) {
+template<>struct Jakt::Formatter<Jakt::parser::ParsedBlock> : Jakt::Formatter<Jakt::StringView>{
+Jakt::ErrorOr<void> format(Jakt::FormatBuilder& builder, Jakt::parser::ParsedBlock const& value) {
 JaktInternal::PrettyPrint::ScopedEnable pretty_print_enable { m_alternative_form };Jakt::ErrorOr<void> format_error = Jakt::Formatter<Jakt::StringView>::format(builder, MUST(value.debug_description()));return format_error;}
 };
 namespace Jakt {
 } // namespace Jakt
 template<>struct Jakt::Formatter<Jakt::parser::FunctionType> : Jakt::Formatter<Jakt::StringView>{
 Jakt::ErrorOr<void> format(Jakt::FormatBuilder& builder, Jakt::parser::FunctionType const& value) {
-JaktInternal::PrettyPrint::ScopedEnable pretty_print_enable { m_alternative_form };Jakt::ErrorOr<void> format_error = Jakt::Formatter<Jakt::StringView>::format(builder, MUST(value.debug_description()));return format_error;}
-};
-namespace Jakt {
-} // namespace Jakt
-template<>struct Jakt::Formatter<Jakt::parser::Parser> : Jakt::Formatter<Jakt::StringView>{
-Jakt::ErrorOr<void> format(Jakt::FormatBuilder& builder, Jakt::parser::Parser const& value) {
-JaktInternal::PrettyPrint::ScopedEnable pretty_print_enable { m_alternative_form };Jakt::ErrorOr<void> format_error = Jakt::Formatter<Jakt::StringView>::format(builder, MUST(value.debug_description()));return format_error;}
-};
-namespace Jakt {
-} // namespace Jakt
-template<>struct Jakt::Formatter<Jakt::parser::DefinitionLinkage> : Jakt::Formatter<Jakt::StringView>{
-Jakt::ErrorOr<void> format(Jakt::FormatBuilder& builder, Jakt::parser::DefinitionLinkage const& value) {
-JaktInternal::PrettyPrint::ScopedEnable pretty_print_enable { m_alternative_form };Jakt::ErrorOr<void> format_error = Jakt::Formatter<Jakt::StringView>::format(builder, MUST(value.debug_description()));return format_error;}
-};
-namespace Jakt {
-} // namespace Jakt
-template<>struct Jakt::Formatter<Jakt::parser::ParsedTraitRequirements> : Jakt::Formatter<Jakt::StringView>{
-Jakt::ErrorOr<void> format(Jakt::FormatBuilder& builder, Jakt::parser::ParsedTraitRequirements const& value) {
-JaktInternal::PrettyPrint::ScopedEnable pretty_print_enable { m_alternative_form };Jakt::ErrorOr<void> format_error = Jakt::Formatter<Jakt::StringView>::format(builder, MUST(value.debug_description()));return format_error;}
-};
-namespace Jakt {
-} // namespace Jakt
-template<>struct Jakt::Formatter<Jakt::parser::CheckedQualifiers> : Jakt::Formatter<Jakt::StringView>{
-Jakt::ErrorOr<void> format(Jakt::FormatBuilder& builder, Jakt::parser::CheckedQualifiers const& value) {
-JaktInternal::PrettyPrint::ScopedEnable pretty_print_enable { m_alternative_form };Jakt::ErrorOr<void> format_error = Jakt::Formatter<Jakt::StringView>::format(builder, MUST(value.debug_description()));return format_error;}
-};
-namespace Jakt {
-} // namespace Jakt
-template<>struct Jakt::Formatter<Jakt::parser::ParsedExternImport> : Jakt::Formatter<Jakt::StringView>{
-Jakt::ErrorOr<void> format(Jakt::FormatBuilder& builder, Jakt::parser::ParsedExternImport const& value) {
 JaktInternal::PrettyPrint::ScopedEnable pretty_print_enable { m_alternative_form };Jakt::ErrorOr<void> format_error = Jakt::Formatter<Jakt::StringView>::format(builder, MUST(value.debug_description()));return format_error;}
 };
 namespace Jakt {
@@ -1514,50 +1406,20 @@ JaktInternal::PrettyPrint::ScopedEnable pretty_print_enable { m_alternative_form
 };
 namespace Jakt {
 } // namespace Jakt
-template<>struct Jakt::Formatter<Jakt::parser::ArgumentStoreLevel> : Jakt::Formatter<Jakt::StringView>{
-Jakt::ErrorOr<void> format(Jakt::FormatBuilder& builder, Jakt::parser::ArgumentStoreLevel const& value) {
+template<>struct Jakt::Formatter<Jakt::parser::ParsedExternalTraitImplementation> : Jakt::Formatter<Jakt::StringView>{
+Jakt::ErrorOr<void> format(Jakt::FormatBuilder& builder, Jakt::parser::ParsedExternalTraitImplementation const& value) {
 JaktInternal::PrettyPrint::ScopedEnable pretty_print_enable { m_alternative_form };Jakt::ErrorOr<void> format_error = Jakt::Formatter<Jakt::StringView>::format(builder, MUST(value.debug_description()));return format_error;}
 };
 namespace Jakt {
 } // namespace Jakt
-template<>struct Jakt::Formatter<Jakt::parser::ParsedMatchPattern> : Jakt::Formatter<Jakt::StringView>{
-Jakt::ErrorOr<void> format(Jakt::FormatBuilder& builder, Jakt::parser::ParsedMatchPattern const& value) {
+template<>struct Jakt::Formatter<Jakt::parser::ParsedGenericParameter> : Jakt::Formatter<Jakt::StringView>{
+Jakt::ErrorOr<void> format(Jakt::FormatBuilder& builder, Jakt::parser::ParsedGenericParameter const& value) {
 JaktInternal::PrettyPrint::ScopedEnable pretty_print_enable { m_alternative_form };Jakt::ErrorOr<void> format_error = Jakt::Formatter<Jakt::StringView>::format(builder, MUST(value.debug_description()));return format_error;}
 };
 namespace Jakt {
 } // namespace Jakt
-template<>struct Jakt::Formatter<Jakt::parser::RecordType> : Jakt::Formatter<Jakt::StringView>{
-Jakt::ErrorOr<void> format(Jakt::FormatBuilder& builder, Jakt::parser::RecordType const& value) {
-JaktInternal::PrettyPrint::ScopedEnable pretty_print_enable { m_alternative_form };Jakt::ErrorOr<void> format_error = Jakt::Formatter<Jakt::StringView>::format(builder, MUST(value.debug_description()));return format_error;}
-};
-namespace Jakt {
-} // namespace Jakt
-template<>struct Jakt::Formatter<Jakt::parser::ParsedRecord> : Jakt::Formatter<Jakt::StringView>{
-Jakt::ErrorOr<void> format(Jakt::FormatBuilder& builder, Jakt::parser::ParsedRecord const& value) {
-JaktInternal::PrettyPrint::ScopedEnable pretty_print_enable { m_alternative_form };Jakt::ErrorOr<void> format_error = Jakt::Formatter<Jakt::StringView>::format(builder, MUST(value.debug_description()));return format_error;}
-};
-namespace Jakt {
-} // namespace Jakt
-template<>struct Jakt::Formatter<Jakt::parser::BinaryOperator> : Jakt::Formatter<Jakt::StringView>{
-Jakt::ErrorOr<void> format(Jakt::FormatBuilder& builder, Jakt::parser::BinaryOperator const& value) {
-JaktInternal::PrettyPrint::ScopedEnable pretty_print_enable { m_alternative_form };Jakt::ErrorOr<void> format_error = Jakt::Formatter<Jakt::StringView>::format(builder, MUST(value.debug_description()));return format_error;}
-};
-namespace Jakt {
-} // namespace Jakt
-template<>struct Jakt::Formatter<Jakt::parser::ImportList> : Jakt::Formatter<Jakt::StringView>{
-Jakt::ErrorOr<void> format(Jakt::FormatBuilder& builder, Jakt::parser::ImportList const& value) {
-JaktInternal::PrettyPrint::ScopedEnable pretty_print_enable { m_alternative_form };Jakt::ErrorOr<void> format_error = Jakt::Formatter<Jakt::StringView>::format(builder, MUST(value.debug_description()));return format_error;}
-};
-namespace Jakt {
-} // namespace Jakt
-template<>struct Jakt::Formatter<Jakt::parser::ParsedTrait> : Jakt::Formatter<Jakt::StringView>{
-Jakt::ErrorOr<void> format(Jakt::FormatBuilder& builder, Jakt::parser::ParsedTrait const& value) {
-JaktInternal::PrettyPrint::ScopedEnable pretty_print_enable { m_alternative_form };Jakt::ErrorOr<void> format_error = Jakt::Formatter<Jakt::StringView>::format(builder, MUST(value.debug_description()));return format_error;}
-};
-namespace Jakt {
-} // namespace Jakt
-template<>struct Jakt::Formatter<Jakt::parser::IncludeAction> : Jakt::Formatter<Jakt::StringView>{
-Jakt::ErrorOr<void> format(Jakt::FormatBuilder& builder, Jakt::parser::IncludeAction const& value) {
+template<>struct Jakt::Formatter<Jakt::parser::SumEnumVariant> : Jakt::Formatter<Jakt::StringView>{
+Jakt::ErrorOr<void> format(Jakt::FormatBuilder& builder, Jakt::parser::SumEnumVariant const& value) {
 JaktInternal::PrettyPrint::ScopedEnable pretty_print_enable { m_alternative_form };Jakt::ErrorOr<void> format_error = Jakt::Formatter<Jakt::StringView>::format(builder, MUST(value.debug_description()));return format_error;}
 };
 namespace Jakt {
@@ -1568,50 +1430,20 @@ JaktInternal::PrettyPrint::ScopedEnable pretty_print_enable { m_alternative_form
 };
 namespace Jakt {
 } // namespace Jakt
-template<>struct Jakt::Formatter<Jakt::parser::ParsedAlias> : Jakt::Formatter<Jakt::StringView>{
-Jakt::ErrorOr<void> format(Jakt::FormatBuilder& builder, Jakt::parser::ParsedAlias const& value) {
+template<>struct Jakt::Formatter<Jakt::parser::ParsedNamespace> : Jakt::Formatter<Jakt::StringView>{
+Jakt::ErrorOr<void> format(Jakt::FormatBuilder& builder, Jakt::parser::ParsedNamespace const& value) {
 JaktInternal::PrettyPrint::ScopedEnable pretty_print_enable { m_alternative_form };Jakt::ErrorOr<void> format_error = Jakt::Formatter<Jakt::StringView>::format(builder, MUST(value.debug_description()));return format_error;}
 };
 namespace Jakt {
 } // namespace Jakt
-template<>struct Jakt::Formatter<Jakt::parser::ParsedAttributeArgument> : Jakt::Formatter<Jakt::StringView>{
-Jakt::ErrorOr<void> format(Jakt::FormatBuilder& builder, Jakt::parser::ParsedAttributeArgument const& value) {
+template<>struct Jakt::Formatter<Jakt::parser::ParsedExternImport> : Jakt::Formatter<Jakt::StringView>{
+Jakt::ErrorOr<void> format(Jakt::FormatBuilder& builder, Jakt::parser::ParsedExternImport const& value) {
 JaktInternal::PrettyPrint::ScopedEnable pretty_print_enable { m_alternative_form };Jakt::ErrorOr<void> format_error = Jakt::Formatter<Jakt::StringView>::format(builder, MUST(value.debug_description()));return format_error;}
 };
 namespace Jakt {
 } // namespace Jakt
-template<>struct Jakt::Formatter<Jakt::parser::ParsedMethod> : Jakt::Formatter<Jakt::StringView>{
-Jakt::ErrorOr<void> format(Jakt::FormatBuilder& builder, Jakt::parser::ParsedMethod const& value) {
-JaktInternal::PrettyPrint::ScopedEnable pretty_print_enable { m_alternative_form };Jakt::ErrorOr<void> format_error = Jakt::Formatter<Jakt::StringView>::format(builder, MUST(value.debug_description()));return format_error;}
-};
-namespace Jakt {
-} // namespace Jakt
-template<>struct Jakt::Formatter<Jakt::parser::ParsedModuleImport> : Jakt::Formatter<Jakt::StringView>{
-Jakt::ErrorOr<void> format(Jakt::FormatBuilder& builder, Jakt::parser::ParsedModuleImport const& value) {
-JaktInternal::PrettyPrint::ScopedEnable pretty_print_enable { m_alternative_form };Jakt::ErrorOr<void> format_error = Jakt::Formatter<Jakt::StringView>::format(builder, MUST(value.debug_description()));return format_error;}
-};
-namespace Jakt {
-} // namespace Jakt
-template<>struct Jakt::Formatter<Jakt::parser::ParsedCall> : Jakt::Formatter<Jakt::StringView>{
-Jakt::ErrorOr<void> format(Jakt::FormatBuilder& builder, Jakt::parser::ParsedCall const& value) {
-JaktInternal::PrettyPrint::ScopedEnable pretty_print_enable { m_alternative_form };Jakt::ErrorOr<void> format_error = Jakt::Formatter<Jakt::StringView>::format(builder, MUST(value.debug_description()));return format_error;}
-};
-namespace Jakt {
-} // namespace Jakt
-template<>struct Jakt::Formatter<Jakt::parser::VisibilityRestriction> : Jakt::Formatter<Jakt::StringView>{
-Jakt::ErrorOr<void> format(Jakt::FormatBuilder& builder, Jakt::parser::VisibilityRestriction const& value) {
-JaktInternal::PrettyPrint::ScopedEnable pretty_print_enable { m_alternative_form };Jakt::ErrorOr<void> format_error = Jakt::Formatter<Jakt::StringView>::format(builder, MUST(value.debug_description()));return format_error;}
-};
-namespace Jakt {
-} // namespace Jakt
-template<>struct Jakt::Formatter<Jakt::parser::ParsedTypeQualifiers> : Jakt::Formatter<Jakt::StringView>{
-Jakt::ErrorOr<void> format(Jakt::FormatBuilder& builder, Jakt::parser::ParsedTypeQualifiers const& value) {
-JaktInternal::PrettyPrint::ScopedEnable pretty_print_enable { m_alternative_form };Jakt::ErrorOr<void> format_error = Jakt::Formatter<Jakt::StringView>::format(builder, MUST(value.debug_description()));return format_error;}
-};
-namespace Jakt {
-} // namespace Jakt
-template<>struct Jakt::Formatter<Jakt::parser::TypeCast> : Jakt::Formatter<Jakt::StringView>{
-Jakt::ErrorOr<void> format(Jakt::FormatBuilder& builder, Jakt::parser::TypeCast const& value) {
+template<>struct Jakt::Formatter<Jakt::parser::ImportList> : Jakt::Formatter<Jakt::StringView>{
+Jakt::ErrorOr<void> format(Jakt::FormatBuilder& builder, Jakt::parser::ImportList const& value) {
 JaktInternal::PrettyPrint::ScopedEnable pretty_print_enable { m_alternative_form };Jakt::ErrorOr<void> format_error = Jakt::Formatter<Jakt::StringView>::format(builder, MUST(value.debug_description()));return format_error;}
 };
 namespace Jakt {
@@ -1622,8 +1454,32 @@ JaktInternal::PrettyPrint::ScopedEnable pretty_print_enable { m_alternative_form
 };
 namespace Jakt {
 } // namespace Jakt
+template<>struct Jakt::Formatter<Jakt::parser::ParsedCall> : Jakt::Formatter<Jakt::StringView>{
+Jakt::ErrorOr<void> format(Jakt::FormatBuilder& builder, Jakt::parser::ParsedCall const& value) {
+JaktInternal::PrettyPrint::ScopedEnable pretty_print_enable { m_alternative_form };Jakt::ErrorOr<void> format_error = Jakt::Formatter<Jakt::StringView>::format(builder, MUST(value.debug_description()));return format_error;}
+};
+namespace Jakt {
+} // namespace Jakt
+template<>struct Jakt::Formatter<Jakt::parser::TypeCast> : Jakt::Formatter<Jakt::StringView>{
+Jakt::ErrorOr<void> format(Jakt::FormatBuilder& builder, Jakt::parser::TypeCast const& value) {
+JaktInternal::PrettyPrint::ScopedEnable pretty_print_enable { m_alternative_form };Jakt::ErrorOr<void> format_error = Jakt::Formatter<Jakt::StringView>::format(builder, MUST(value.debug_description()));return format_error;}
+};
+namespace Jakt {
+} // namespace Jakt
 template<>struct Jakt::Formatter<Jakt::parser::UnaryOperator> : Jakt::Formatter<Jakt::StringView>{
 Jakt::ErrorOr<void> format(Jakt::FormatBuilder& builder, Jakt::parser::UnaryOperator const& value) {
+JaktInternal::PrettyPrint::ScopedEnable pretty_print_enable { m_alternative_form };Jakt::ErrorOr<void> format_error = Jakt::Formatter<Jakt::StringView>::format(builder, MUST(value.debug_description()));return format_error;}
+};
+namespace Jakt {
+} // namespace Jakt
+template<>struct Jakt::Formatter<Jakt::parser::BinaryOperator> : Jakt::Formatter<Jakt::StringView>{
+Jakt::ErrorOr<void> format(Jakt::FormatBuilder& builder, Jakt::parser::BinaryOperator const& value) {
+JaktInternal::PrettyPrint::ScopedEnable pretty_print_enable { m_alternative_form };Jakt::ErrorOr<void> format_error = Jakt::Formatter<Jakt::StringView>::format(builder, MUST(value.debug_description()));return format_error;}
+};
+namespace Jakt {
+} // namespace Jakt
+template<>struct Jakt::Formatter<Jakt::parser::EnumVariantPatternArgument> : Jakt::Formatter<Jakt::StringView>{
+Jakt::ErrorOr<void> format(Jakt::FormatBuilder& builder, Jakt::parser::EnumVariantPatternArgument const& value) {
 JaktInternal::PrettyPrint::ScopedEnable pretty_print_enable { m_alternative_form };Jakt::ErrorOr<void> format_error = Jakt::Formatter<Jakt::StringView>::format(builder, MUST(value.debug_description()));return format_error;}
 };
 namespace Jakt {
@@ -1634,8 +1490,134 @@ JaktInternal::PrettyPrint::ScopedEnable pretty_print_enable { m_alternative_form
 };
 namespace Jakt {
 } // namespace Jakt
+template<>struct Jakt::Formatter<Jakt::parser::ParsedTypeQualifiers> : Jakt::Formatter<Jakt::StringView>{
+Jakt::ErrorOr<void> format(Jakt::FormatBuilder& builder, Jakt::parser::ParsedTypeQualifiers const& value) {
+JaktInternal::PrettyPrint::ScopedEnable pretty_print_enable { m_alternative_form };Jakt::ErrorOr<void> format_error = Jakt::Formatter<Jakt::StringView>::format(builder, MUST(value.debug_description()));return format_error;}
+};
+namespace Jakt {
+} // namespace Jakt
+template<>struct Jakt::Formatter<Jakt::parser::ParsedMethod> : Jakt::Formatter<Jakt::StringView>{
+Jakt::ErrorOr<void> format(Jakt::FormatBuilder& builder, Jakt::parser::ParsedMethod const& value) {
+JaktInternal::PrettyPrint::ScopedEnable pretty_print_enable { m_alternative_form };Jakt::ErrorOr<void> format_error = Jakt::Formatter<Jakt::StringView>::format(builder, MUST(value.debug_description()));return format_error;}
+};
+namespace Jakt {
+} // namespace Jakt
+template<>struct Jakt::Formatter<Jakt::parser::ParsedStatement> : Jakt::Formatter<Jakt::StringView>{
+Jakt::ErrorOr<void> format(Jakt::FormatBuilder& builder, Jakt::parser::ParsedStatement const& value) {
+JaktInternal::PrettyPrint::ScopedEnable pretty_print_enable { m_alternative_form };Jakt::ErrorOr<void> format_error = Jakt::Formatter<Jakt::StringView>::format(builder, MUST(value.debug_description()));return format_error;}
+};
+namespace Jakt {
+} // namespace Jakt
+template<>struct Jakt::Formatter<Jakt::parser::ParsedField> : Jakt::Formatter<Jakt::StringView>{
+Jakt::ErrorOr<void> format(Jakt::FormatBuilder& builder, Jakt::parser::ParsedField const& value) {
+JaktInternal::PrettyPrint::ScopedEnable pretty_print_enable { m_alternative_form };Jakt::ErrorOr<void> format_error = Jakt::Formatter<Jakt::StringView>::format(builder, MUST(value.debug_description()));return format_error;}
+};
+namespace Jakt {
+} // namespace Jakt
+template<>struct Jakt::Formatter<Jakt::parser::ParsedName> : Jakt::Formatter<Jakt::StringView>{
+Jakt::ErrorOr<void> format(Jakt::FormatBuilder& builder, Jakt::parser::ParsedName const& value) {
+JaktInternal::PrettyPrint::ScopedEnable pretty_print_enable { m_alternative_form };Jakt::ErrorOr<void> format_error = Jakt::Formatter<Jakt::StringView>::format(builder, MUST(value.debug_description()));return format_error;}
+};
+namespace Jakt {
+} // namespace Jakt
+template<>struct Jakt::Formatter<Jakt::parser::ParsedVariable> : Jakt::Formatter<Jakt::StringView>{
+Jakt::ErrorOr<void> format(Jakt::FormatBuilder& builder, Jakt::parser::ParsedVariable const& value) {
+JaktInternal::PrettyPrint::ScopedEnable pretty_print_enable { m_alternative_form };Jakt::ErrorOr<void> format_error = Jakt::Formatter<Jakt::StringView>::format(builder, MUST(value.debug_description()));return format_error;}
+};
+namespace Jakt {
+} // namespace Jakt
+template<>struct Jakt::Formatter<Jakt::parser::CheckedQualifiers> : Jakt::Formatter<Jakt::StringView>{
+Jakt::ErrorOr<void> format(Jakt::FormatBuilder& builder, Jakt::parser::CheckedQualifiers const& value) {
+JaktInternal::PrettyPrint::ScopedEnable pretty_print_enable { m_alternative_form };Jakt::ErrorOr<void> format_error = Jakt::Formatter<Jakt::StringView>::format(builder, MUST(value.debug_description()));return format_error;}
+};
+namespace Jakt {
+} // namespace Jakt
+template<>struct Jakt::Formatter<Jakt::parser::DefinitionLinkage> : Jakt::Formatter<Jakt::StringView>{
+Jakt::ErrorOr<void> format(Jakt::FormatBuilder& builder, Jakt::parser::DefinitionLinkage const& value) {
+JaktInternal::PrettyPrint::ScopedEnable pretty_print_enable { m_alternative_form };Jakt::ErrorOr<void> format_error = Jakt::Formatter<Jakt::StringView>::format(builder, MUST(value.debug_description()));return format_error;}
+};
+namespace Jakt {
+} // namespace Jakt
+template<>struct Jakt::Formatter<Jakt::parser::ParsedVarDeclTuple> : Jakt::Formatter<Jakt::StringView>{
+Jakt::ErrorOr<void> format(Jakt::FormatBuilder& builder, Jakt::parser::ParsedVarDeclTuple const& value) {
+JaktInternal::PrettyPrint::ScopedEnable pretty_print_enable { m_alternative_form };Jakt::ErrorOr<void> format_error = Jakt::Formatter<Jakt::StringView>::format(builder, MUST(value.debug_description()));return format_error;}
+};
+namespace Jakt {
+} // namespace Jakt
+template<>struct Jakt::Formatter<Jakt::parser::ParsedMatchBody> : Jakt::Formatter<Jakt::StringView>{
+Jakt::ErrorOr<void> format(Jakt::FormatBuilder& builder, Jakt::parser::ParsedMatchBody const& value) {
+JaktInternal::PrettyPrint::ScopedEnable pretty_print_enable { m_alternative_form };Jakt::ErrorOr<void> format_error = Jakt::Formatter<Jakt::StringView>::format(builder, MUST(value.debug_description()));return format_error;}
+};
+namespace Jakt {
+} // namespace Jakt
+template<>struct Jakt::Formatter<Jakt::parser::RecordType> : Jakt::Formatter<Jakt::StringView>{
+Jakt::ErrorOr<void> format(Jakt::FormatBuilder& builder, Jakt::parser::RecordType const& value) {
+JaktInternal::PrettyPrint::ScopedEnable pretty_print_enable { m_alternative_form };Jakt::ErrorOr<void> format_error = Jakt::Formatter<Jakt::StringView>::format(builder, MUST(value.debug_description()));return format_error;}
+};
+namespace Jakt {
+} // namespace Jakt
+template<>struct Jakt::Formatter<Jakt::parser::ParsedFunctionParameters> : Jakt::Formatter<Jakt::StringView>{
+Jakt::ErrorOr<void> format(Jakt::FormatBuilder& builder, Jakt::parser::ParsedFunctionParameters const& value) {
+JaktInternal::PrettyPrint::ScopedEnable pretty_print_enable { m_alternative_form };Jakt::ErrorOr<void> format_error = Jakt::Formatter<Jakt::StringView>::format(builder, MUST(value.debug_description()));return format_error;}
+};
+namespace Jakt {
+} // namespace Jakt
 template<>struct Jakt::Formatter<Jakt::parser::ParsedType> : Jakt::Formatter<Jakt::StringView>{
 Jakt::ErrorOr<void> format(Jakt::FormatBuilder& builder, Jakt::parser::ParsedType const& value) {
+JaktInternal::PrettyPrint::ScopedEnable pretty_print_enable { m_alternative_form };Jakt::ErrorOr<void> format_error = Jakt::Formatter<Jakt::StringView>::format(builder, MUST(value.debug_description()));return format_error;}
+};
+namespace Jakt {
+} // namespace Jakt
+template<>struct Jakt::Formatter<Jakt::parser::ParsedAlias> : Jakt::Formatter<Jakt::StringView>{
+Jakt::ErrorOr<void> format(Jakt::FormatBuilder& builder, Jakt::parser::ParsedAlias const& value) {
+JaktInternal::PrettyPrint::ScopedEnable pretty_print_enable { m_alternative_form };Jakt::ErrorOr<void> format_error = Jakt::Formatter<Jakt::StringView>::format(builder, MUST(value.debug_description()));return format_error;}
+};
+namespace Jakt {
+} // namespace Jakt
+template<>struct Jakt::Formatter<Jakt::parser::ParsedMatchCase> : Jakt::Formatter<Jakt::StringView>{
+Jakt::ErrorOr<void> format(Jakt::FormatBuilder& builder, Jakt::parser::ParsedMatchCase const& value) {
+JaktInternal::PrettyPrint::ScopedEnable pretty_print_enable { m_alternative_form };Jakt::ErrorOr<void> format_error = Jakt::Formatter<Jakt::StringView>::format(builder, MUST(value.debug_description()));return format_error;}
+};
+namespace Jakt {
+} // namespace Jakt
+template<>struct Jakt::Formatter<Jakt::parser::ImportName> : Jakt::Formatter<Jakt::StringView>{
+Jakt::ErrorOr<void> format(Jakt::FormatBuilder& builder, Jakt::parser::ImportName const& value) {
+JaktInternal::PrettyPrint::ScopedEnable pretty_print_enable { m_alternative_form };Jakt::ErrorOr<void> format_error = Jakt::Formatter<Jakt::StringView>::format(builder, MUST(value.debug_description()));return format_error;}
+};
+namespace Jakt {
+} // namespace Jakt
+template<>struct Jakt::Formatter<Jakt::parser::ParsedModuleImport> : Jakt::Formatter<Jakt::StringView>{
+Jakt::ErrorOr<void> format(Jakt::FormatBuilder& builder, Jakt::parser::ParsedModuleImport const& value) {
+JaktInternal::PrettyPrint::ScopedEnable pretty_print_enable { m_alternative_form };Jakt::ErrorOr<void> format_error = Jakt::Formatter<Jakt::StringView>::format(builder, MUST(value.debug_description()));return format_error;}
+};
+namespace Jakt {
+} // namespace Jakt
+template<>struct Jakt::Formatter<Jakt::parser::VisibilityRestriction> : Jakt::Formatter<Jakt::StringView>{
+Jakt::ErrorOr<void> format(Jakt::FormatBuilder& builder, Jakt::parser::VisibilityRestriction const& value) {
+JaktInternal::PrettyPrint::ScopedEnable pretty_print_enable { m_alternative_form };Jakt::ErrorOr<void> format_error = Jakt::Formatter<Jakt::StringView>::format(builder, MUST(value.debug_description()));return format_error;}
+};
+namespace Jakt {
+} // namespace Jakt
+template<>struct Jakt::Formatter<Jakt::parser::Parser> : Jakt::Formatter<Jakt::StringView>{
+Jakt::ErrorOr<void> format(Jakt::FormatBuilder& builder, Jakt::parser::Parser const& value) {
+JaktInternal::PrettyPrint::ScopedEnable pretty_print_enable { m_alternative_form };Jakt::ErrorOr<void> format_error = Jakt::Formatter<Jakt::StringView>::format(builder, MUST(value.debug_description()));return format_error;}
+};
+namespace Jakt {
+} // namespace Jakt
+template<>struct Jakt::Formatter<Jakt::parser::ParsedMatchPattern> : Jakt::Formatter<Jakt::StringView>{
+Jakt::ErrorOr<void> format(Jakt::FormatBuilder& builder, Jakt::parser::ParsedMatchPattern const& value) {
+JaktInternal::PrettyPrint::ScopedEnable pretty_print_enable { m_alternative_form };Jakt::ErrorOr<void> format_error = Jakt::Formatter<Jakt::StringView>::format(builder, MUST(value.debug_description()));return format_error;}
+};
+namespace Jakt {
+} // namespace Jakt
+template<>struct Jakt::Formatter<Jakt::parser::ParsedParameter> : Jakt::Formatter<Jakt::StringView>{
+Jakt::ErrorOr<void> format(Jakt::FormatBuilder& builder, Jakt::parser::ParsedParameter const& value) {
+JaktInternal::PrettyPrint::ScopedEnable pretty_print_enable { m_alternative_form };Jakt::ErrorOr<void> format_error = Jakt::Formatter<Jakt::StringView>::format(builder, MUST(value.debug_description()));return format_error;}
+};
+namespace Jakt {
+} // namespace Jakt
+template<>struct Jakt::Formatter<Jakt::parser::IncludeAction> : Jakt::Formatter<Jakt::StringView>{
+Jakt::ErrorOr<void> format(Jakt::FormatBuilder& builder, Jakt::parser::IncludeAction const& value) {
 JaktInternal::PrettyPrint::ScopedEnable pretty_print_enable { m_alternative_form };Jakt::ErrorOr<void> format_error = Jakt::Formatter<Jakt::StringView>::format(builder, MUST(value.debug_description()));return format_error;}
 };
 namespace Jakt {
@@ -1646,8 +1628,26 @@ JaktInternal::PrettyPrint::ScopedEnable pretty_print_enable { m_alternative_form
 };
 namespace Jakt {
 } // namespace Jakt
-template<>struct Jakt::Formatter<Jakt::parser::SumEnumVariant> : Jakt::Formatter<Jakt::StringView>{
-Jakt::ErrorOr<void> format(Jakt::FormatBuilder& builder, Jakt::parser::SumEnumVariant const& value) {
+template<>struct Jakt::Formatter<Jakt::parser::ValueEnumVariant> : Jakt::Formatter<Jakt::StringView>{
+Jakt::ErrorOr<void> format(Jakt::FormatBuilder& builder, Jakt::parser::ValueEnumVariant const& value) {
+JaktInternal::PrettyPrint::ScopedEnable pretty_print_enable { m_alternative_form };Jakt::ErrorOr<void> format_error = Jakt::Formatter<Jakt::StringView>::format(builder, MUST(value.debug_description()));return format_error;}
+};
+namespace Jakt {
+} // namespace Jakt
+template<>struct Jakt::Formatter<Jakt::parser::ParsedAttributeArgument> : Jakt::Formatter<Jakt::StringView>{
+Jakt::ErrorOr<void> format(Jakt::FormatBuilder& builder, Jakt::parser::ParsedAttributeArgument const& value) {
+JaktInternal::PrettyPrint::ScopedEnable pretty_print_enable { m_alternative_form };Jakt::ErrorOr<void> format_error = Jakt::Formatter<Jakt::StringView>::format(builder, MUST(value.debug_description()));return format_error;}
+};
+namespace Jakt {
+} // namespace Jakt
+template<>struct Jakt::Formatter<Jakt::parser::ParsedPatternDefault> : Jakt::Formatter<Jakt::StringView>{
+Jakt::ErrorOr<void> format(Jakt::FormatBuilder& builder, Jakt::parser::ParsedPatternDefault const& value) {
+JaktInternal::PrettyPrint::ScopedEnable pretty_print_enable { m_alternative_form };Jakt::ErrorOr<void> format_error = Jakt::Formatter<Jakt::StringView>::format(builder, MUST(value.debug_description()));return format_error;}
+};
+namespace Jakt {
+} // namespace Jakt
+template<>struct Jakt::Formatter<Jakt::parser::ParsedRecord> : Jakt::Formatter<Jakt::StringView>{
+Jakt::ErrorOr<void> format(Jakt::FormatBuilder& builder, Jakt::parser::ParsedRecord const& value) {
 JaktInternal::PrettyPrint::ScopedEnable pretty_print_enable { m_alternative_form };Jakt::ErrorOr<void> format_error = Jakt::Formatter<Jakt::StringView>::format(builder, MUST(value.debug_description()));return format_error;}
 };
 namespace Jakt {

--- a/bootstrap/stage0/platform.cpp
+++ b/bootstrap/stage0/platform.cpp
@@ -7,7 +7,7 @@ ByteString const target_name = TRY((((target).name(false))));
 return TRY((__jakt_format((StringView::from_string_literal("{}/{}"sv)),target_name,({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<ByteString,ErrorOr<ByteString>>{
 auto __jakt_enum_value = (((target).os));
-if (__jakt_enum_value == TRY(ByteString::from_utf8("windows"sv))) {
+if (__jakt_enum_value == (ByteString::must_from_utf8("windows"sv))) {
 return JaktInternal::ExplicitValue(TRY((__jakt_format((StringView::from_string_literal("jakt_{}_{}.lib"sv)),name,target_name))));
 }
 else {

--- a/bootstrap/stage0/project.cpp
+++ b/bootstrap/stage0/project.cpp
@@ -8,8 +8,8 @@ TRY(JaktInternal::PrettyPrint::output_indentation(builder));TRY(builder.appendff
 TRY(builder.append(")"sv));return builder.to_string(); }
 ErrorOr<void> project::Project::create_template_cmake_lists(ByteString const project_directory) const {
 {
-ByteString const cml_contents = TRY((((TRY((((TRY((((TRY((((TRY(ByteString::from_utf8("cmake_minimum_required(VERSION 3.20)\nproject("sv))) + (((*this).name)))))) + (TRY(ByteString::from_utf8("\n   VERSION 1.0.0\n   LANGUAGES CXX\n)\n\nfind_package(Jakt REQUIRED)\n\nadd_jakt_executable("sv))))))) + (((*this).name)))))) + (TRY(ByteString::from_utf8("\n   MAIN_SOURCE src/main.jakt\n   MODULE_SOURCES\n     src/second_module.jakt\n)\n"sv))))));
-TRY((utility::write_to_file(cml_contents,TRY((((project_directory) + (TRY(ByteString::from_utf8("/CMakeLists.txt"sv)))))))));
+ByteString const cml_contents = TRY((((TRY((((TRY((((TRY(((((ByteString::must_from_utf8("cmake_minimum_required(VERSION 3.20)\nproject("sv))) + (((*this).name)))))) + ((ByteString::must_from_utf8("\n   VERSION 1.0.0\n   LANGUAGES CXX\n)\n\nfind_package(Jakt REQUIRED)\n\nadd_jakt_executable("sv))))))) + (((*this).name)))))) + ((ByteString::must_from_utf8("\n   MAIN_SOURCE src/main.jakt\n   MODULE_SOURCES\n     src/second_module.jakt\n)\n"sv))))));
+TRY((utility::write_to_file(cml_contents,TRY((((project_directory) + ((ByteString::must_from_utf8("/CMakeLists.txt"sv)))))))));
 }
 return {};
 }
@@ -17,10 +17,10 @@ return {};
 ErrorOr<void> project::Project::populate() const {
 {
 ByteString const current_directory = TRY((jakt__platform__unknown_fs::current_directory()));
-ByteString const project_directory = TRY((((TRY((((current_directory) + (TRY(ByteString::from_utf8("/"sv))))))) + (((*this).name)))));
+ByteString const project_directory = TRY((((TRY((((current_directory) + ((ByteString::must_from_utf8("/"sv))))))) + (((*this).name)))));
 outln((StringView::from_string_literal("Creating jakt project in {}.."sv)),project_directory);
 TRY((jakt__platform__unknown_fs::make_directory(project_directory)));
-TRY((jakt__platform__unknown_fs::make_directory(TRY((((project_directory) + (TRY(ByteString::from_utf8("/src"sv)))))))));
+TRY((jakt__platform__unknown_fs::make_directory(TRY((((project_directory) + ((ByteString::must_from_utf8("/src"sv)))))))));
 out((StringView::from_string_literal("\tGenerating CMakeLists.txt..."sv)));
 TRY((((*this).create_template_cmake_lists(project_directory))));
 outln((StringView::from_string_literal(" done"sv)));
@@ -37,18 +37,18 @@ return {};
 
 ErrorOr<void> project::Project::create_readme(ByteString const project_directory) const {
 {
-ByteString const readme_text = TRY((((TRY((((TRY((((TRY((((TRY(ByteString::from_utf8("# Example Jakt Project\n\nThis example jakt project has two modules, hurray!\n\n## Building with jakt\n\n```console\njakt src/main.jakt -o "sv))) + (((*this).name)))))) + (TRY(ByteString::from_utf8("\n```\n\n## Building with CMake\n\nMake sure to install the ``jakt`` compiler somewhere. For example, ``/path/to/jakt-install``.\n\nThis can be done by cloning ``jakt``, and running the following commands from its directory:\n\n```console\njakt> cmake -GNinja -B build -DCMAKE_CXX_COMPILER=clang++ -DCMAKE_INSTALL_PREFIX=/path/to/jakt-install\njakt> cmake --build build\njakt> cmake --install build\n```\n\nNext you can build this project by configuring CMake to know where to find the ``jakt`` cmake helper scripts.\n\n```console\n> cmake -GNinja -B build -DCMAKE_CXX_COMPILER=clang++ -DCMAKE_PREFIX_PATH=/path/to/jakt-install\n> cmake --build build\n```\n\n## Running the application\n\nAfter building, the program will be in the ``build`` directory\n\n```console\n./build/"sv))))))) + (((*this).name)))))) + (TRY(ByteString::from_utf8("\n```\n\nWhich should print:\n\n```console\nHello, World!\n```\n"sv))))));
-TRY((utility::write_to_file(readme_text,TRY((((project_directory) + (TRY(ByteString::from_utf8("/README.md"sv)))))))));
+ByteString const readme_text = TRY((((TRY((((TRY((((TRY(((((ByteString::must_from_utf8("# Example Jakt Project\n\nThis example jakt project has two modules, hurray!\n\n## Building with jakt\n\n```console\njakt src/main.jakt -o "sv))) + (((*this).name)))))) + ((ByteString::must_from_utf8("\n```\n\n## Building with CMake\n\nMake sure to install the ``jakt`` compiler somewhere. For example, ``/path/to/jakt-install``.\n\nThis can be done by cloning ``jakt``, and running the following commands from its directory:\n\n```console\njakt> cmake -GNinja -B build -DCMAKE_CXX_COMPILER=clang++ -DCMAKE_INSTALL_PREFIX=/path/to/jakt-install\njakt> cmake --build build\njakt> cmake --install build\n```\n\nNext you can build this project by configuring CMake to know where to find the ``jakt`` cmake helper scripts.\n\n```console\n> cmake -GNinja -B build -DCMAKE_CXX_COMPILER=clang++ -DCMAKE_PREFIX_PATH=/path/to/jakt-install\n> cmake --build build\n```\n\n## Running the application\n\nAfter building, the program will be in the ``build`` directory\n\n```console\n./build/"sv))))))) + (((*this).name)))))) + ((ByteString::must_from_utf8("\n```\n\nWhich should print:\n\n```console\nHello, World!\n```\n"sv))))));
+TRY((utility::write_to_file(readme_text,TRY((((project_directory) + ((ByteString::must_from_utf8("/README.md"sv)))))))));
 }
 return {};
 }
 
 ErrorOr<void> project::Project::create_sample_jakt_files(ByteString const project_directory) const {
 {
-ByteString const main_jakt = TRY(ByteString::from_utf8("import second_module { get_string }\n\nfn main() throws -> c_int {\n    println(\"{}!\", get_string())\n    return 0\n}\n"sv));
-ByteString const second_module_jakt = TRY(ByteString::from_utf8("fn get_string() throws -> String {\n    return \"Hello, World\"\n}\n"sv));
-TRY((utility::write_to_file(main_jakt,TRY((((project_directory) + (TRY(ByteString::from_utf8("/src/main.jakt"sv)))))))));
-TRY((utility::write_to_file(second_module_jakt,TRY((((project_directory) + (TRY(ByteString::from_utf8("/src/second_module.jakt"sv)))))))));
+ByteString const main_jakt = (ByteString::must_from_utf8("import second_module { get_string }\n\nfn main() throws -> c_int {\n    println(\"{}!\", get_string())\n    return 0\n}\n"sv));
+ByteString const second_module_jakt = (ByteString::must_from_utf8("fn get_string() throws -> String {\n    return \"Hello, World\"\n}\n"sv));
+TRY((utility::write_to_file(main_jakt,TRY((((project_directory) + ((ByteString::must_from_utf8("/src/main.jakt"sv)))))))));
+TRY((utility::write_to_file(second_module_jakt,TRY((((project_directory) + ((ByteString::must_from_utf8("/src/second_module.jakt"sv)))))))));
 }
 return {};
 }

--- a/bootstrap/stage0/repl.cpp
+++ b/bootstrap/stage0/repl.cpp
@@ -8,40 +8,40 @@ return ({
 auto&& __jakt_match_variant = op;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 0 /* PreIncrement */: {
-return JaktInternal::ExplicitValue(TRY((((TRY(ByteString::from_utf8("++"sv))) + (expr)))));
+return JaktInternal::ExplicitValue(TRY(((((ByteString::must_from_utf8("++"sv))) + (expr)))));
 };/*case end*/
 case 1 /* PostIncrement */: {
-return JaktInternal::ExplicitValue(TRY((((expr) + (TRY(ByteString::from_utf8("++"sv)))))));
+return JaktInternal::ExplicitValue(TRY((((expr) + ((ByteString::must_from_utf8("++"sv)))))));
 };/*case end*/
 case 2 /* PreDecrement */: {
-return JaktInternal::ExplicitValue(TRY((((TRY(ByteString::from_utf8("--"sv))) + (expr)))));
+return JaktInternal::ExplicitValue(TRY(((((ByteString::must_from_utf8("--"sv))) + (expr)))));
 };/*case end*/
 case 3 /* PostDecrement */: {
-return JaktInternal::ExplicitValue(TRY((((expr) + (TRY(ByteString::from_utf8("--"sv)))))));
+return JaktInternal::ExplicitValue(TRY((((expr) + ((ByteString::must_from_utf8("--"sv)))))));
 };/*case end*/
 case 4 /* Negate */: {
-return JaktInternal::ExplicitValue(TRY((((TRY(ByteString::from_utf8("-"sv))) + (expr)))));
+return JaktInternal::ExplicitValue(TRY(((((ByteString::must_from_utf8("-"sv))) + (expr)))));
 };/*case end*/
 case 5 /* Dereference */: {
-return JaktInternal::ExplicitValue(TRY((((TRY(ByteString::from_utf8("*"sv))) + (expr)))));
+return JaktInternal::ExplicitValue(TRY(((((ByteString::must_from_utf8("*"sv))) + (expr)))));
 };/*case end*/
 case 6 /* RawAddress */: {
-return JaktInternal::ExplicitValue(TRY((((TRY(ByteString::from_utf8("&raw "sv))) + (expr)))));
+return JaktInternal::ExplicitValue(TRY(((((ByteString::must_from_utf8("&raw "sv))) + (expr)))));
 };/*case end*/
 case 7 /* Reference */: {
-return JaktInternal::ExplicitValue(TRY((((TRY(ByteString::from_utf8("&"sv))) + (expr)))));
+return JaktInternal::ExplicitValue(TRY(((((ByteString::must_from_utf8("&"sv))) + (expr)))));
 };/*case end*/
 case 8 /* MutableReference */: {
-return JaktInternal::ExplicitValue(TRY((((TRY(ByteString::from_utf8("&mut "sv))) + (expr)))));
+return JaktInternal::ExplicitValue(TRY(((((ByteString::must_from_utf8("&mut "sv))) + (expr)))));
 };/*case end*/
 case 9 /* LogicalNot */: {
-return JaktInternal::ExplicitValue(TRY((((TRY(ByteString::from_utf8("not "sv))) + (expr)))));
+return JaktInternal::ExplicitValue(TRY(((((ByteString::must_from_utf8("not "sv))) + (expr)))));
 };/*case end*/
 case 10 /* BitwiseNot */: {
-return JaktInternal::ExplicitValue(TRY((((TRY(ByteString::from_utf8("~"sv))) + (expr)))));
+return JaktInternal::ExplicitValue(TRY(((((ByteString::must_from_utf8("~"sv))) + (expr)))));
 };/*case end*/
 default: {
-return JaktInternal::ExplicitValue(TRY((((TRY((((TRY(ByteString::from_utf8("(<Unimplemented unary operator> "sv))) + (expr))))) + (TRY(ByteString::from_utf8(")"sv)))))));
+return JaktInternal::ExplicitValue(TRY((((TRY(((((ByteString::must_from_utf8("(<Unimplemented unary operator> "sv))) + (expr))))) + ((ByteString::must_from_utf8(")"sv)))))));
 };/*case end*/
 }/*switch end*/
 }()
@@ -159,7 +159,7 @@ case 8 /* JaktTuple */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.JaktTuple;JaktInternal::DynamicArray<NonnullRefPtr<typename types::CheckedExpression>> const& vals = __jakt_match_value.vals;
 return JaktInternal::ExplicitValue(({ Optional<ByteString> __jakt_var_928; {
 ByteStringBuilder builder = ByteStringBuilder::create();
-TRY((((builder).append_string(TRY(ByteString::from_utf8("("sv))))));
+TRY((((builder).append_string((ByteString::must_from_utf8("("sv))))));
 {
 JaktInternal::Range<size_t> _magic = (JaktInternal::Range<size_t>{static_cast<size_t>(static_cast<size_t>(0ULL)),static_cast<size_t>(((vals).size()))});
 for (;;){
@@ -170,7 +170,7 @@ break;
 size_t i = (_magic_value.value());
 {
 if (((i) != (static_cast<size_t>(0ULL)))){
-TRY((((builder).append_string(TRY(ByteString::from_utf8(", "sv))))));
+TRY((((builder).append_string((ByteString::must_from_utf8(", "sv))))));
 }
 TRY((((builder).append_string(TRY((repl::serialize_ast_node(((vals)[i]))))))));
 }
@@ -178,7 +178,7 @@ TRY((((builder).append_string(TRY((repl::serialize_ast_node(((vals)[i]))))))));
 }
 }
 
-TRY((((builder).append_string(TRY(ByteString::from_utf8(")"sv))))));
+TRY((((builder).append_string((ByteString::must_from_utf8(")"sv))))));
 __jakt_var_928 = TRY((((builder).to_string()))); goto __jakt_label_822;
 
 }
@@ -188,11 +188,11 @@ case 9 /* Range */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Range;JaktInternal::Optional<NonnullRefPtr<typename types::CheckedExpression>> const& from = __jakt_match_value.from;
 JaktInternal::Optional<NonnullRefPtr<typename types::CheckedExpression>> const& to = __jakt_match_value.to;
 return JaktInternal::ExplicitValue(({ Optional<ByteString> __jakt_var_929; {
-ByteString from_output = TRY(ByteString::from_utf8(""sv));
+ByteString from_output = (ByteString::must_from_utf8(""sv));
 if (((from).has_value())){
 (from_output = TRY((repl::serialize_ast_node((from.value())))));
 }
-ByteString to_output = TRY(ByteString::from_utf8(""sv));
+ByteString to_output = (ByteString::must_from_utf8(""sv));
 if (((to).has_value())){
 (to_output = TRY((repl::serialize_ast_node((to.value())))));
 }
@@ -205,7 +205,7 @@ case 10 /* JaktArray */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.JaktArray;JaktInternal::DynamicArray<NonnullRefPtr<typename types::CheckedExpression>> const& vals = __jakt_match_value.vals;
 return JaktInternal::ExplicitValue(({ Optional<ByteString> __jakt_var_930; {
 ByteStringBuilder builder = ByteStringBuilder::create();
-TRY((((builder).append_string(TRY(ByteString::from_utf8("["sv))))));
+TRY((((builder).append_string((ByteString::must_from_utf8("["sv))))));
 {
 JaktInternal::Range<size_t> _magic = (JaktInternal::Range<size_t>{static_cast<size_t>(static_cast<size_t>(0ULL)),static_cast<size_t>(((vals).size()))});
 for (;;){
@@ -216,7 +216,7 @@ break;
 size_t i = (_magic_value.value());
 {
 if (((i) != (static_cast<size_t>(0ULL)))){
-TRY((((builder).append_string(TRY(ByteString::from_utf8(", "sv))))));
+TRY((((builder).append_string((ByteString::must_from_utf8(", "sv))))));
 }
 TRY((((builder).append_string(TRY((repl::serialize_ast_node(((vals)[i]))))))));
 }
@@ -224,7 +224,7 @@ TRY((((builder).append_string(TRY((repl::serialize_ast_node(((vals)[i]))))))));
 }
 }
 
-TRY((((builder).append_string(TRY(ByteString::from_utf8("]"sv))))));
+TRY((((builder).append_string((ByteString::must_from_utf8("]"sv))))));
 __jakt_var_930 = TRY((((builder).to_string()))); goto __jakt_label_824;
 
 }
@@ -234,7 +234,7 @@ case 11 /* JaktSet */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.JaktSet;JaktInternal::DynamicArray<NonnullRefPtr<typename types::CheckedExpression>> const& vals = __jakt_match_value.vals;
 return JaktInternal::ExplicitValue(({ Optional<ByteString> __jakt_var_931; {
 ByteStringBuilder builder = ByteStringBuilder::create();
-TRY((((builder).append_string(TRY(ByteString::from_utf8("{"sv))))));
+TRY((((builder).append_string((ByteString::must_from_utf8("{"sv))))));
 {
 JaktInternal::Range<size_t> _magic = (JaktInternal::Range<size_t>{static_cast<size_t>(static_cast<size_t>(0ULL)),static_cast<size_t>(((vals).size()))});
 for (;;){
@@ -245,7 +245,7 @@ break;
 size_t i = (_magic_value.value());
 {
 if (((i) != (static_cast<size_t>(0ULL)))){
-TRY((((builder).append_string(TRY(ByteString::from_utf8(", "sv))))));
+TRY((((builder).append_string((ByteString::must_from_utf8(", "sv))))));
 }
 TRY((((builder).append_string(TRY((repl::serialize_ast_node(((vals)[i]))))))));
 }
@@ -253,7 +253,7 @@ TRY((((builder).append_string(TRY((repl::serialize_ast_node(((vals)[i]))))))));
 }
 }
 
-TRY((((builder).append_string(TRY(ByteString::from_utf8("}"sv))))));
+TRY((((builder).append_string((ByteString::must_from_utf8("}"sv))))));
 __jakt_var_931 = TRY((((builder).to_string()))); goto __jakt_label_825;
 
 }
@@ -263,7 +263,7 @@ case 12 /* JaktDictionary */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.JaktDictionary;JaktInternal::DynamicArray<JaktInternal::Tuple<NonnullRefPtr<typename types::CheckedExpression>,NonnullRefPtr<typename types::CheckedExpression>>> const& vals = __jakt_match_value.vals;
 return JaktInternal::ExplicitValue(({ Optional<ByteString> __jakt_var_932; {
 ByteStringBuilder builder = ByteStringBuilder::create();
-TRY((((builder).append_string(TRY(ByteString::from_utf8("["sv))))));
+TRY((((builder).append_string((ByteString::must_from_utf8("["sv))))));
 {
 JaktInternal::Range<size_t> _magic = (JaktInternal::Range<size_t>{static_cast<size_t>(static_cast<size_t>(0ULL)),static_cast<size_t>(((vals).size()))});
 for (;;){
@@ -274,18 +274,18 @@ break;
 size_t i = (_magic_value.value());
 {
 if (((i) != (static_cast<size_t>(0ULL)))){
-TRY((((builder).append_string(TRY(ByteString::from_utf8(", "sv))))));
+TRY((((builder).append_string((ByteString::must_from_utf8(", "sv))))));
 }
 JaktInternal::Tuple<NonnullRefPtr<typename types::CheckedExpression>,NonnullRefPtr<typename types::CheckedExpression>> const val = ((vals)[i]);
 TRY((((builder).append_string(TRY((repl::serialize_ast_node(((val).template get<0>()))))))));
-TRY((((builder).append_string(TRY(ByteString::from_utf8(": "sv))))));
+TRY((((builder).append_string((ByteString::must_from_utf8(": "sv))))));
 TRY((((builder).append_string(TRY((repl::serialize_ast_node(((val).template get<1>()))))))));
 }
 
 }
 }
 
-TRY((((builder).append_string(TRY(ByteString::from_utf8("]"sv))))));
+TRY((((builder).append_string((ByteString::must_from_utf8("]"sv))))));
 __jakt_var_932 = TRY((((builder).to_string()))); goto __jakt_label_826;
 
 }
@@ -326,7 +326,7 @@ break;
 types::CheckedNamespace namespace_ = (_magic_value.value());
 {
 TRY((((builder).append_string(((namespace_).name)))));
-TRY((((builder).append_string(TRY(ByteString::from_utf8("::"sv))))));
+TRY((((builder).append_string((ByteString::must_from_utf8("::"sv))))));
 }
 
 }
@@ -343,7 +343,7 @@ auto&& __jakt_match_value = __jakt_match_variant.as.Var;NonnullRefPtr<types::Che
 return JaktInternal::ExplicitValue(((var)->name));
 };/*case end*/
 case 25 /* OptionalNone */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("None"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("None"sv)));
 };/*case end*/
 case 26 /* OptionalSome */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.OptionalSome;NonnullRefPtr<typename types::CheckedExpression> const& expr = __jakt_match_value.expr;
@@ -367,14 +367,14 @@ break;
 types::ResolvedNamespace namespace_ = (_magic_value.value());
 {
 TRY((((builder).append_string(((namespace_).name)))));
-TRY((((builder).append_string(TRY(ByteString::from_utf8("::"sv))))));
+TRY((((builder).append_string((ByteString::must_from_utf8("::"sv))))));
 }
 
 }
 }
 
 TRY((((builder).append_string(((call).name)))));
-TRY((((builder).append_string(TRY(ByteString::from_utf8("("sv))))));
+TRY((((builder).append_string((ByteString::must_from_utf8("("sv))))));
 {
 JaktInternal::Range<size_t> _magic = (JaktInternal::Range<size_t>{static_cast<size_t>(static_cast<size_t>(0ULL)),static_cast<size_t>(((((call).args)).size()))});
 for (;;){
@@ -385,12 +385,12 @@ break;
 size_t i = (_magic_value.value());
 {
 if (((i) != (static_cast<size_t>(0ULL)))){
-TRY((((builder).append_string(TRY(ByteString::from_utf8(", "sv))))));
+TRY((((builder).append_string((ByteString::must_from_utf8(", "sv))))));
 }
 JaktInternal::Tuple<ByteString,NonnullRefPtr<typename types::CheckedExpression>> const arg = ((((call).args))[i]);
 if ((!(((((arg).template get<0>())).is_empty())))){
 TRY((((builder).append_string(((arg).template get<0>())))));
-TRY((((builder).append_string(TRY(ByteString::from_utf8(": "sv))))));
+TRY((((builder).append_string((ByteString::must_from_utf8(": "sv))))));
 }
 TRY((((builder).append_string(TRY((repl::serialize_ast_node(((arg).template get<1>()))))))));
 }
@@ -398,17 +398,17 @@ TRY((((builder).append_string(TRY((repl::serialize_ast_node(((arg).template get<
 }
 }
 
-TRY((((builder).append_string(TRY(ByteString::from_utf8(")"sv))))));
+TRY((((builder).append_string((ByteString::must_from_utf8(")"sv))))));
 __jakt_var_934 = TRY((((builder).to_string()))); goto __jakt_label_828;
 
 }
 __jakt_label_828:; __jakt_var_934.release_value(); }));
 };/*case end*/
 case 34 /* Garbage */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("<Garbage>"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("<Garbage>"sv)));
 };/*case end*/
 default: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("<Unimplemented>"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("<Unimplemented>"sv)));
 };/*case end*/
 }/*switch end*/
 }()
@@ -431,11 +431,11 @@ TRY(JaktInternal::PrettyPrint::output_indentation(builder));TRY(builder.appendff
 TRY(builder.append(")"sv));return builder.to_string(); }
 ErrorOr<repl::REPL> repl::REPL::create(jakt__path::Path const runtime_path,JaktInternal::Optional<ByteString> const target_triple,JaktInternal::Dictionary<ByteString,ByteString> const user_configuration) {
 {
-NonnullRefPtr<compiler::Compiler> compiler = TRY((compiler::Compiler::__jakt_create((TRY((DynamicArray<jakt__path::Path>::create_with({})))),(TRY((Dictionary<ByteString, utility::FileId>::create_with_entries({})))),(TRY((DynamicArray<error::JaktError>::create_with({})))),JaktInternal::OptionalNone(),(TRY((DynamicArray<u8>::create_with({})))),false,false,false,false,runtime_path,(TRY((DynamicArray<ByteString>::create_with({})))),false,false,false,false,target_triple,user_configuration,TRY((jakt__path::Path::from_string(TRY(ByteString::from_utf8("build"sv))))),TRY((jakt__path::Path::from_string(TRY(ByteString::from_utf8("repl.jakt"sv))))))));
+NonnullRefPtr<compiler::Compiler> compiler = TRY((compiler::Compiler::__jakt_create((TRY((DynamicArray<jakt__path::Path>::create_with({})))),(TRY((Dictionary<ByteString, utility::FileId>::create_with_entries({})))),(TRY((DynamicArray<error::JaktError>::create_with({})))),JaktInternal::OptionalNone(),(TRY((DynamicArray<u8>::create_with({})))),false,false,false,false,runtime_path,(TRY((DynamicArray<ByteString>::create_with({})))),false,false,false,false,target_triple,user_configuration,TRY((jakt__path::Path::from_string((ByteString::must_from_utf8("build"sv))))),TRY((jakt__path::Path::from_string((ByteString::must_from_utf8("repl.jakt"sv))))))));
 TRY((((compiler)->load_prelude())));
-utility::FileId const file_id = TRY((((compiler)->get_file_id_or_register(TRY((jakt__path::Path::from_string(TRY(ByteString::from_utf8("<repl>"sv)))))))));
+utility::FileId const file_id = TRY((((compiler)->get_file_id_or_register(TRY((jakt__path::Path::from_string((ByteString::must_from_utf8("<repl>"sv)))))))));
 ids::ModuleId const placeholder_module_id = ids::ModuleId(static_cast<size_t>(0ULL));
-ByteString const root_module_name = TRY(ByteString::from_utf8("repl"sv));
+ByteString const root_module_name = (ByteString::must_from_utf8("repl"sv));
 typechecker::Typechecker typechecker = typechecker::Typechecker(compiler,TRY((types::CheckedProgram::__jakt_create(compiler,(TRY((DynamicArray<NonnullRefPtr<types::Module>>::create_with({})))),(TRY((Dictionary<ByteString, types::LoadedModule>::create_with_entries({}))))))),placeholder_module_id,ids::TypeId::none(),JaktInternal::OptionalNone(),false,static_cast<size_t>(0ULL),false,((compiler)->dump_type_hints),((compiler)->dump_try_hints),static_cast<u64>(0ULL),types::GenericInferences((TRY((Dictionary<ids::TypeId, ids::TypeId>::create_with_entries({}))))),JaktInternal::OptionalNone(),root_module_name,false,false,(TRY((Dictionary<ByteString, ids::ScopeId>::create_with_entries({})))),JaktInternal::OptionalNone());
 (((compiler)->current_file) = file_id);
 TRY((((typechecker).include_prelude())));
@@ -443,8 +443,8 @@ ids::ModuleId const root_module_id = TRY((((typechecker).create_module(root_modu
 (((typechecker).current_module_id) = root_module_id);
 TRY((((((typechecker).program))->set_loaded_module(root_module_name,types::LoadedModule(root_module_id,file_id)))));
 ids::ScopeId const PRELUDE_SCOPE_ID = ((typechecker).prelude_scope_id());
-ids::ScopeId const root_scope_id = TRY((((typechecker).create_scope(PRELUDE_SCOPE_ID,true,TRY(ByteString::from_utf8("root"sv)),true))));
-TRY((((typechecker).typecheck_module_import(parser::ParsedModuleImport(parser::ImportName::Literal(TRY(ByteString::from_utf8("jakt::prelude::prelude"sv)),utility::Span(utility::FileId(static_cast<size_t>(0ULL)),static_cast<size_t>(0ULL),static_cast<size_t>(0ULL))),JaktInternal::OptionalNone(),parser::ImportList::All(),false,static_cast<size_t>(0ULL)),root_scope_id))));
+ids::ScopeId const root_scope_id = TRY((((typechecker).create_scope(PRELUDE_SCOPE_ID,true,(ByteString::must_from_utf8("root"sv)),true))));
+TRY((((typechecker).typecheck_module_import(parser::ParsedModuleImport(parser::ImportName::Literal((ByteString::must_from_utf8("jakt::prelude::prelude"sv)),utility::Span(utility::FileId(static_cast<size_t>(0ULL)),static_cast<size_t>(0ULL),static_cast<size_t>(0ULL))),JaktInternal::OptionalNone(),parser::ImportList::All(),false,static_cast<size_t>(0ULL)),root_scope_id))));
 NonnullRefPtr<interpreter::InterpreterScope> const root_interpreter_scope = TRY((interpreter::InterpreterScope::create((TRY((Dictionary<ByteString, types::Value>::create_with_entries({})))),JaktInternal::OptionalNone(),(TRY((Dictionary<ids::TypeId, ids::TypeId>::create_with_entries({})))))));
 return repl::REPL(compiler,typechecker,root_scope_id,root_interpreter_scope,file_id);
 }
@@ -787,7 +787,7 @@ return JaktInternal::ExplicitValue<void>();
 return {};
 }
 ;
-repl_backend__default::Editor editor = TRY((repl_backend__default::Editor::create(TRY(ByteString::from_utf8("> "sv)),((syntax_highlight_handler)))));
+repl_backend__default::Editor editor = TRY((repl_backend__default::Editor::create((ByteString::must_from_utf8("> "sv)),((syntax_highlight_handler)))));
 ScopeGuard __jakt_var_938([&] {
 ((editor).destroy());
 });
@@ -808,10 +808,10 @@ return {};
 __jakt_var_939.release_value(); });
 if (((line_result).__jakt_init_index() == 0 /* Line */)){
 ByteString const line = (line_result).as.Line.value;
-if (((line) == (TRY(ByteString::from_utf8("\n"sv))))){
+if (((line) == ((ByteString::must_from_utf8("\n"sv))))){
 continue;
 }
-if (((line) == (TRY(ByteString::from_utf8(".exit\n"sv))))){
+if (((line) == ((ByteString::must_from_utf8(".exit\n"sv))))){
 break;
 }
 (((((*this).compiler))->current_file) = ((*this).file_id));
@@ -832,7 +832,7 @@ ByteStringBuilder sb = ByteStringBuilder::create();
 TRY((((sb).append_string(line))));
 while ((!(repl::REPL::check_parens(tokens)))){
 repl_backend__common::LineResult const line_result = ({ Optional<repl_backend__common::LineResult> __jakt_var_943;
-auto __jakt_var_944 = [&]() -> ErrorOr<repl_backend__common::LineResult> { return TRY((((editor).get_line(TRY(ByteString::from_utf8(".."sv)))))); }();
+auto __jakt_var_944 = [&]() -> ErrorOr<repl_backend__common::LineResult> { return TRY((((editor).get_line((ByteString::must_from_utf8(".."sv)))))); }();
 if (__jakt_var_944.is_error()) {auto error = __jakt_var_944.release_error();
 {
 return {};
@@ -993,7 +993,7 @@ return JaktInternal::ExplicitValue(TRY((repl::serialize_ast_node(TRY((interprete
 };/*case end*/
 case 1 /* Throw */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Throw;types::Value const& value = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(TRY((((TRY(ByteString::from_utf8("throw "sv))) + (TRY((repl::serialize_ast_node(TRY((interpreter::value_to_checked_expression(value,interpreter)))))))))));
+return JaktInternal::ExplicitValue(TRY(((((ByteString::must_from_utf8("throw "sv))) + (TRY((repl::serialize_ast_node(TRY((interpreter::value_to_checked_expression(value,interpreter)))))))))));
 };/*case end*/
 case 4 /* Break */: {
 {

--- a/bootstrap/stage0/repl_backend__default.cpp
+++ b/bootstrap/stage0/repl_backend__default.cpp
@@ -20,7 +20,7 @@ free(line_pointer);
 
 ErrorOr<repl_backend__default::Editor> repl_backend__default::Editor::create(ByteString const prompt,Function<ErrorOr<void>(repl_backend__default::Editor&)> const& syntax_highlight_handler) {
 {
-FILE* std_in = fopen(((TRY(ByteString::from_utf8("/dev/stdin"sv))).characters()),((TRY(ByteString::from_utf8("r"sv))).characters()));
+FILE* std_in = fopen((((ByteString::must_from_utf8("/dev/stdin"sv))).characters()),(((ByteString::must_from_utf8("r"sv))).characters()));
 if ((std_in == jakt__platform__utility::null<FILE*>())){
 warnln((StringView::from_string_literal("Could not open /dev/stdin for reading"sv)));
 return Error::from_errno(static_cast<i32>(42));

--- a/bootstrap/stage0/runtime/AK/ByteString.h
+++ b/bootstrap/stage0/runtime/AK/ByteString.h
@@ -90,6 +90,7 @@ public:
 
     static ErrorOr<ByteString> from_utf8(ReadonlyBytes);
     static ErrorOr<ByteString> from_utf8(StringView string) { return from_utf8(string.bytes()); }
+    static ByteString must_from_utf8(StringView string) { return MUST(from_utf8(string)); }
 
     [[nodiscard]] static ByteString repeated(char, size_t count);
     [[nodiscard]] static ByteString repeated(StringView, size_t count);

--- a/bootstrap/stage0/runtime/jaktlib/prelude/string.jakt
+++ b/bootstrap/stage0/runtime/jaktlib/prelude/string.jakt
@@ -10,7 +10,7 @@ type StringView implements(FromStringLiteral) {
     fn from_string_literal(anon string: StringView) -> StringView => string
 }
 
-type String implements(ThrowingFromStringLiteral) {
-    [[name=from_utf8]]
-    extern fn from_string_literal(anon string: StringView) throws -> String
+type String implements(FromStringLiteral) {
+    [[name=must_from_utf8]]
+    extern fn from_string_literal(anon string: StringView) -> String
 }

--- a/bootstrap/stage0/typechecker.cpp
+++ b/bootstrap/stage0/typechecker.cpp
@@ -30,9 +30,9 @@ return defines;
 ErrorOr<void> dump_scope(ids::ScopeId const scope_id,NonnullRefPtr<types::CheckedProgram> const& program,i64 const indent) {
 {
 NonnullRefPtr<types::Scope> scope = TRY((((((program)))->get_scope(scope_id))));
-warnln((StringView::from_string_literal("{: >{}}Scope (ns={}) {}"sv)),TRY(ByteString::from_utf8(""sv)),indent,((scope)->namespace_name),((scope)->debug_name));
+warnln((StringView::from_string_literal("{: >{}}Scope (ns={}) {}"sv)),(ByteString::must_from_utf8(""sv)),indent,((scope)->namespace_name),((scope)->debug_name));
 i64 const cindent = JaktInternal::checked_add(indent,static_cast<i64>(2LL));
-warnln((StringView::from_string_literal("{: >{}}Types:"sv)),TRY(ByteString::from_utf8(""sv)),cindent);
+warnln((StringView::from_string_literal("{: >{}}Types:"sv)),(ByteString::must_from_utf8(""sv)),cindent);
 {
 JaktInternal::DictionaryIterator<ByteString,ids::TypeId> _magic = ((((scope)->types)).iterator());
 for (;;){
@@ -47,13 +47,13 @@ ByteString const name = ((jakt__name__type_id__).template get<0>());
 ids::TypeId const type_id = ((jakt__name__type_id__).template get<1>());
 
 NonnullRefPtr<typename types::Type> const type = ((((program)))->get_type(type_id));
-warnln((StringView::from_string_literal("{: >{}}{}: {}"sv)),TRY(ByteString::from_utf8(""sv)),JaktInternal::checked_add(cindent,static_cast<i64>(2LL)),name,TRY((((((program)))->type_name(type_id,true)))));
+warnln((StringView::from_string_literal("{: >{}}{}: {}"sv)),(ByteString::must_from_utf8(""sv)),JaktInternal::checked_add(cindent,static_cast<i64>(2LL)),name,TRY((((((program)))->type_name(type_id,true)))));
 }
 
 }
 }
 
-warnln((StringView::from_string_literal("{: >{}}Specializations:"sv)),TRY(ByteString::from_utf8(""sv)),cindent);
+warnln((StringView::from_string_literal("{: >{}}Specializations:"sv)),(ByteString::must_from_utf8(""sv)),cindent);
 {
 JaktInternal::DictionaryIterator<ByteString,types::SpecializedType> _magic = ((((scope)->explicitly_specialized_types)).iterator());
 for (;;){
@@ -68,7 +68,7 @@ ByteString const name = ((jakt__name__type__).template get<0>());
 types::SpecializedType const type = ((jakt__name__type__).template get<1>());
 
 ByteString const type_name = TRY((((((program)))->type_name(((type).type_id),true))));
-ByteString args = TRY(ByteString::from_utf8(""sv));
+ByteString args = (ByteString::must_from_utf8(""sv));
 {
 JaktInternal::ArrayIterator<ids::TypeId> _magic = ((((type).arguments)).iterator());
 for (;;){
@@ -78,19 +78,19 @@ break;
 }
 ids::TypeId arg = (_magic_value.value());
 {
-(args = TRY((((TRY((((args) + (TRY((((((program)))->type_name(arg,true))))))))) + (TRY(ByteString::from_utf8(", "sv)))))));
+(args = TRY((((TRY((((args) + (TRY((((((program)))->type_name(arg,true))))))))) + ((ByteString::must_from_utf8(", "sv)))))));
 }
 
 }
 }
 
-warnln((StringView::from_string_literal("{: >{}}{}<{}> = {}"sv)),TRY(ByteString::from_utf8(""sv)),JaktInternal::checked_add(cindent,static_cast<i64>(2LL)),name,args,type_name);
+warnln((StringView::from_string_literal("{: >{}}{}<{}> = {}"sv)),(ByteString::must_from_utf8(""sv)),JaktInternal::checked_add(cindent,static_cast<i64>(2LL)),name,args,type_name);
 }
 
 }
 }
 
-warnln((StringView::from_string_literal("{: >{}}Variables:"sv)),TRY(ByteString::from_utf8(""sv)),cindent);
+warnln((StringView::from_string_literal("{: >{}}Variables:"sv)),(ByteString::must_from_utf8(""sv)),cindent);
 {
 JaktInternal::DictionaryIterator<ByteString,ids::VarId> _magic = ((((scope)->vars)).iterator());
 for (;;){
@@ -105,13 +105,13 @@ ByteString const name = ((jakt__name__var_id__).template get<0>());
 ids::VarId const var_id = ((jakt__name__var_id__).template get<1>());
 
 NonnullRefPtr<types::CheckedVariable> const var = ((((program)))->get_variable(var_id));
-warnln((StringView::from_string_literal("{: >{}}{}: {}"sv)),TRY(ByteString::from_utf8(""sv)),JaktInternal::checked_add(cindent,static_cast<i64>(2LL)),name,TRY((((((program)))->type_name(((var)->type_id),true)))));
+warnln((StringView::from_string_literal("{: >{}}{}: {}"sv)),(ByteString::must_from_utf8(""sv)),JaktInternal::checked_add(cindent,static_cast<i64>(2LL)),name,TRY((((((program)))->type_name(((var)->type_id),true)))));
 }
 
 }
 }
 
-warnln((StringView::from_string_literal("{: >{}}Functions:"sv)),TRY(ByteString::from_utf8(""sv)),cindent);
+warnln((StringView::from_string_literal("{: >{}}Functions:"sv)),(ByteString::must_from_utf8(""sv)),cindent);
 {
 JaktInternal::DictionaryIterator<ByteString,JaktInternal::DynamicArray<ids::FunctionId>> _magic = ((((scope)->functions)).iterator());
 for (;;){
@@ -125,7 +125,7 @@ JaktInternal::Tuple<ByteString,JaktInternal::DynamicArray<ids::FunctionId>> cons
 ByteString const name = ((jakt__name__ids__).template get<0>());
 JaktInternal::DynamicArray<ids::FunctionId> const ids = ((jakt__name__ids__).template get<1>());
 
-warnln((StringView::from_string_literal("{: >{}}{}:"sv)),TRY(ByteString::from_utf8(""sv)),JaktInternal::checked_add(cindent,static_cast<i64>(2LL)),name);
+warnln((StringView::from_string_literal("{: >{}}{}:"sv)),(ByteString::must_from_utf8(""sv)),JaktInternal::checked_add(cindent,static_cast<i64>(2LL)),name);
 {
 JaktInternal::ArrayIterator<ids::FunctionId> _magic = ((ids).iterator());
 for (;;){
@@ -136,7 +136,7 @@ break;
 ids::FunctionId id = (_magic_value.value());
 {
 NonnullRefPtr<types::CheckedFunction> const function = ((((program)))->get_function(id));
-ByteString args = TRY(ByteString::from_utf8(""sv));
+ByteString args = (ByteString::must_from_utf8(""sv));
 {
 JaktInternal::ArrayIterator<types::CheckedParameter> _magic = ((((function)->params)).iterator());
 for (;;){
@@ -146,13 +146,13 @@ break;
 }
 types::CheckedParameter arg = (_magic_value.value());
 {
-(args = TRY((((TRY((((args) + (TRY((((((program)))->type_name(((((arg).variable))->type_id),true))))))))) + (TRY(ByteString::from_utf8(", "sv)))))));
+(args = TRY((((TRY((((args) + (TRY((((((program)))->type_name(((((arg).variable))->type_id),true))))))))) + ((ByteString::must_from_utf8(", "sv)))))));
 }
 
 }
 }
 
-ByteString generics = TRY(ByteString::from_utf8(""sv));
+ByteString generics = (ByteString::must_from_utf8(""sv));
 {
 JaktInternal::ArrayIterator<types::FunctionGenericParameter> _magic = ((((((function)->generics))->params)).iterator());
 for (;;){
@@ -162,7 +162,7 @@ break;
 }
 types::FunctionGenericParameter generic = (_magic_value.value());
 {
-(generics = TRY((((TRY((((generics) + (TRY((((((program)))->type_name(((generic).type_id()),true))))))))) + (TRY(ByteString::from_utf8(", "sv)))))));
+(generics = TRY((((TRY((((generics) + (TRY((((((program)))->type_name(((generic).type_id()),true))))))))) + ((ByteString::must_from_utf8(", "sv)))))));
 }
 
 }
@@ -171,7 +171,7 @@ types::FunctionGenericParameter generic = (_magic_value.value());
 if ((!(((generics).is_empty())))){
 (generics = TRY((__jakt_format((StringView::from_string_literal("<{}>"sv)),generics))));
 }
-warnln((StringView::from_string_literal("{: >{}}fn{}({}) -> {}"sv)),TRY(ByteString::from_utf8(""sv)),JaktInternal::checked_add(cindent,static_cast<i64>(4LL)),generics,args,TRY((((((program)))->type_name(((function)->return_type_id),true)))));
+warnln((StringView::from_string_literal("{: >{}}fn{}({}) -> {}"sv)),(ByteString::must_from_utf8(""sv)),JaktInternal::checked_add(cindent,static_cast<i64>(4LL)),generics,args,TRY((((((program)))->type_name(((function)->return_type_id),true)))));
 }
 
 }
@@ -182,7 +182,7 @@ warnln((StringView::from_string_literal("{: >{}}fn{}({}) -> {}"sv)),TRY(ByteStri
 }
 }
 
-warnln((StringView::from_string_literal("{: >{}}Structs:"sv)),TRY(ByteString::from_utf8(""sv)),cindent);
+warnln((StringView::from_string_literal("{: >{}}Structs:"sv)),(ByteString::must_from_utf8(""sv)),cindent);
 {
 JaktInternal::DictionaryIterator<ByteString,ids::StructId> _magic = ((((scope)->structs)).iterator());
 for (;;){
@@ -197,13 +197,13 @@ ByteString const name = ((jakt__name__id__).template get<0>());
 ids::StructId const id = ((jakt__name__id__).template get<1>());
 
 types::CheckedStruct const struct_ = ((((program)))->get_struct(id));
-warnln((StringView::from_string_literal("{: >{}}{}@{}: {}"sv)),TRY(ByteString::from_utf8(""sv)),JaktInternal::checked_add(cindent,static_cast<i64>(2LL)),((id).id),((id).module),((struct_).name));
+warnln((StringView::from_string_literal("{: >{}}{}@{}: {}"sv)),(ByteString::must_from_utf8(""sv)),JaktInternal::checked_add(cindent,static_cast<i64>(2LL)),((id).id),((id).module),((struct_).name));
 }
 
 }
 }
 
-warnln((StringView::from_string_literal("{: >{}}Aliases:"sv)),TRY(ByteString::from_utf8(""sv)),cindent);
+warnln((StringView::from_string_literal("{: >{}}Aliases:"sv)),(ByteString::must_from_utf8(""sv)),cindent);
 {
 JaktInternal::DictionaryIterator<ByteString,ids::ScopeId> _magic = ((((scope)->aliases)).iterator());
 for (;;){
@@ -218,13 +218,13 @@ ByteString const name = ((jakt__name__id__).template get<0>());
 ids::ScopeId const id = ((jakt__name__id__).template get<1>());
 
 NonnullRefPtr<types::Scope> const scope = TRY((((((program)))->get_scope(id))));
-warnln((StringView::from_string_literal("{: >{}}{}: {}"sv)),TRY(ByteString::from_utf8(""sv)),JaktInternal::checked_add(cindent,static_cast<i64>(2LL)),name,((scope)->debug_name));
+warnln((StringView::from_string_literal("{: >{}}{}: {}"sv)),(ByteString::must_from_utf8(""sv)),JaktInternal::checked_add(cindent,static_cast<i64>(2LL)),name,((scope)->debug_name));
 }
 
 }
 }
 
-warnln((StringView::from_string_literal("{: >{}}Children:"sv)),TRY(ByteString::from_utf8(""sv)),cindent);
+warnln((StringView::from_string_literal("{: >{}}Children:"sv)),(ByteString::must_from_utf8(""sv)),cindent);
 {
 JaktInternal::ArrayIterator<ids::ScopeId> _magic = ((((scope)->children)).iterator());
 for (;;){
@@ -333,7 +333,7 @@ TRY((((((typechecker))).error(TRY((__jakt_format((StringView::from_string_litera
 }
 else if (((private_matching_method).has_value())){
 utility::Span const span = (private_matching_method.value());
-TRY((((((typechecker))).error_with_hint(TRY((__jakt_format((StringView::from_string_literal("Implementation of ‘{}’ for trait ‘{}’ is valid but is not public"sv)),method_name,trait_name))),span,TRY(ByteString::from_utf8("Consider adding ‘public’ to make the method accessible"sv)),span))));
+TRY((((((typechecker))).error_with_hint(TRY((__jakt_format((StringView::from_string_literal("Implementation of ‘{}’ for trait ‘{}’ is valid but is not public"sv)),method_name,trait_name))),span,(ByteString::must_from_utf8("Consider adding ‘public’ to make the method accessible"sv)),span))));
 }
 else {
 NonnullRefPtr<types::CheckedFunction> const func = ((((typechecker))).get_function(trait_method_id));
@@ -345,12 +345,12 @@ JaktInternal::Tuple<utility::Span,JaktInternal::DynamicArray<error::JaktError>> 
 utility::Span const method_span = ((method_span_errors_).template get<0>());
 JaktInternal::DynamicArray<error::JaktError> const errors = ((method_span_errors_).template get<1>());
 
-TRY((((((typechecker))).error_with_hint(TRY((__jakt_format((StringView::from_string_literal("Missing implementation for method ‘{}’ of trait ‘{}’ on type ‘{}’"sv)),method_name,trait_name,TRY((((((typechecker))).type_name(trait_type_id,false))))))),record_decl_span,TRY(ByteString::from_utf8("The method is declared here, but its signature doesn't match"sv)),method_span))));
+TRY((((((typechecker))).error_with_hint(TRY((__jakt_format((StringView::from_string_literal("Missing implementation for method ‘{}’ of trait ‘{}’ on type ‘{}’"sv)),method_name,trait_name,TRY((((((typechecker))).type_name(trait_type_id,false))))))),record_decl_span,(ByteString::must_from_utf8("The method is declared here, but its signature doesn't match"sv)),method_span))));
 TRY((((((((((typechecker))).compiler))->errors)).push_values(((errors))))));
 }
 else {
 utility::Span const trait_method_span = ((((((typechecker))).get_function(trait_method_id)))->name_span);
-TRY((((((typechecker))).error_with_hint(TRY((__jakt_format((StringView::from_string_literal("Missing implementation for method ‘{}’ of trait ‘{}’"sv)),method_name,trait_name))),record_decl_span,TRY(ByteString::from_utf8("Consider implementing the method with the signature specified here"sv)),trait_method_span))));
+TRY((((((typechecker))).error_with_hint(TRY((__jakt_format((StringView::from_string_literal("Missing implementation for method ‘{}’ of trait ‘{}’"sv)),method_name,trait_name))),record_decl_span,(ByteString::must_from_utf8("Consider implementing the method with the signature specified here"sv)),trait_method_span))));
 }
 
 }
@@ -798,7 +798,7 @@ return TRY((((((*this).program))->create_scope(parent_scope_id,can_throw,debug_n
 ErrorOr<NonnullRefPtr<typename types::CheckedStatement>> typechecker::Typechecker::typecheck_return(JaktInternal::Optional<NonnullRefPtr<typename parser::ParsedExpression>> const expr,utility::Span const span,ids::ScopeId const scope_id,types::SafetyMode const safety_mode) {
 {
 if (((*this).inside_defer)){
-TRY((((*this).error(TRY(ByteString::from_utf8("‘return’ is not allowed inside ‘defer’"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("‘return’ is not allowed inside ‘defer’"sv)),span))));
 }
 if ((!(((expr).has_value())))){
 if (((((*this).current_function_id)).has_value())){
@@ -811,7 +811,7 @@ TRY((((*this).error_with_hint(TRY((__jakt_format((StringView::from_string_litera
 return TRY((types::CheckedStatement::Return(JaktInternal::OptionalNone(),span)));
 }
 if (((!((((((*this).current_function_id)).has_value()) && ((((*this).get_function((((*this).current_function_id).value()))))->is_comptime)))) && (((expr.value()))->__jakt_init_index() == 25 /* Function */))){
-TRY((((*this).error(TRY(ByteString::from_utf8("Returning a function is not currently supported"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("Returning a function is not currently supported"sv)),span))));
 }
 JaktInternal::Optional<ids::TypeId> type_hint = JaktInternal::OptionalNone();
 if (((((*this).current_function_id)).has_value())){
@@ -829,12 +829,12 @@ utility::Span const span = (checked_expr)->as.OptionalNone.span;
 if (((((*this).get_type((type_hint.value()))))->__jakt_init_index() == 20 /* GenericInstance */)){
 ids::StructId const id = (((*this).get_type((type_hint.value()))))->as.GenericInstance.id;
 JaktInternal::DynamicArray<ids::TypeId> const args = (((*this).get_type((type_hint.value()))))->as.GenericInstance.args;
-if (((!(((id).equals(TRY((((*this).find_struct_in_prelude(TRY(ByteString::from_utf8("Optional"sv)))))))))) && (!(((id).equals(TRY((((*this).find_struct_in_prelude(TRY(ByteString::from_utf8("WeakPtr"sv)))))))))))){
-TRY((((*this).error(TRY(ByteString::from_utf8("Cannot assign None to a non-optional type"sv)),span))));
+if (((!(((id).equals(TRY((((*this).find_struct_in_prelude((ByteString::must_from_utf8("Optional"sv)))))))))) && (!(((id).equals(TRY((((*this).find_struct_in_prelude((ByteString::must_from_utf8("WeakPtr"sv)))))))))))){
+TRY((((*this).error((ByteString::must_from_utf8("Cannot assign None to a non-optional type"sv)),span))));
 }
 }
 else {
-TRY((((*this).error(TRY(ByteString::from_utf8("Cannot assign None to a non-optional type"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("Cannot assign None to a non-optional type"sv)),span))));
 }
 
 }
@@ -1084,12 +1084,12 @@ if (((*this).dump_try_hints)){
 TRY((((*this).dump_try_hint(span))));
 }
 if ((!(((TRY((((*this).get_scope(scope_id)))))->can_throw)))){
-TRY((((*this).error(TRY(ByteString::from_utf8("Set initialization needs to be in a try statement or a function marked as throws"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("Set initialization needs to be in a try statement or a function marked as throws"sv)),span))));
 }
 ids::TypeId inner_type_id = types::unknown_type_id();
 JaktInternal::Optional<utility::Span> inner_type_span = JaktInternal::OptionalNone();
 JaktInternal::DynamicArray<NonnullRefPtr<typename types::CheckedExpression>> output = (TRY((DynamicArray<NonnullRefPtr<typename types::CheckedExpression>>::create_with({}))));
-ids::StructId const set_struct_id = TRY((((*this).find_struct_in_prelude(TRY(ByteString::from_utf8("Set"sv))))));
+ids::StructId const set_struct_id = TRY((((*this).find_struct_in_prelude((ByteString::must_from_utf8("Set"sv))))));
 JaktInternal::Optional<ids::TypeId> inner_hint = JaktInternal::OptionalNone();
 JaktInternal::Optional<JaktInternal::DynamicArray<ids::TypeId>> const type_hint_ids = TRY((((*this).get_type_ids_from_type_hint_if_struct_ids_match(type_hint,set_struct_id))));
 if (((type_hint_ids).has_value())){
@@ -1108,7 +1108,7 @@ NonnullRefPtr<typename types::CheckedExpression> const checked_value = TRY((((*t
 ids::TypeId const current_value_type_id = ((checked_value)->type());
 if (((inner_type_id).equals(types::unknown_type_id()))){
 if ((((current_value_type_id).equals(types::void_type_id())) || ((current_value_type_id).equals(types::unknown_type_id())))){
-TRY((((*this).error(TRY(ByteString::from_utf8("Cannot create a set with values of type void"sv)),((value)->span())))));
+TRY((((*this).error((ByteString::must_from_utf8("Cannot create a set with values of type void"sv)),((value)->span())))));
 }
 (inner_type_id = current_value_type_id);
 (inner_type_span = ((value)->span()));
@@ -1128,13 +1128,13 @@ if (((inner_hint).has_value())){
 (inner_type_id = (inner_hint.value()));
 }
 else {
-TRY((((*this).error(TRY(ByteString::from_utf8("Cannot infer generic type for Set<T>"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("Cannot infer generic type for Set<T>"sv)),span))));
 }
 
 }
 if ((!(((inner_type_id).equals(types::unknown_type_id()))))){
-TRY((((*this).ensure_type_implements_trait(inner_type_id,TRY(ByteString::from_utf8("Hashable"sv)),JaktInternal::OptionalNone(),scope_id,span))));
-TRY((((*this).ensure_type_implements_trait(inner_type_id,TRY(ByteString::from_utf8("Equal"sv)),(TRY((DynamicArray<ids::TypeId>::create_with({inner_type_id})))),scope_id,span))));
+TRY((((*this).ensure_type_implements_trait(inner_type_id,(ByteString::must_from_utf8("Hashable"sv)),JaktInternal::OptionalNone(),scope_id,span))));
+TRY((((*this).ensure_type_implements_trait(inner_type_id,(ByteString::must_from_utf8("Equal"sv)),(TRY((DynamicArray<ids::TypeId>::create_with({inner_type_id})))),scope_id,span))));
 }
 ids::TypeId const type_id = TRY((((*this).find_or_add_type_id(TRY((types::Type::GenericInstance(parser::CheckedQualifiers(false),set_struct_id,(TRY((DynamicArray<ids::TypeId>::create_with({inner_type_id})))))))))));
 return TRY((types::CheckedExpression::JaktSet(JaktInternal::OptionalNone(),output,span,type_id,inner_type_id)));
@@ -1180,10 +1180,10 @@ NonnullRefPtr<types::CheckedFunction> checked_function = ((*this).get_function(f
 (((checked_function)->is_virtual) = ((method).is_virtual));
 (((checked_function)->visibility) = TRY((((*this).typecheck_visibility(((method).visibility),struct_scope_id)))));
 if ((((checked_function)->is_virtual) && TRY((((checked_function)->is_static()))))){
-TRY((((*this).error(TRY(ByteString::from_utf8("Functions cannot be both virtual and static"sv)),((checked_function)->name_span)))));
+TRY((((*this).error((ByteString::must_from_utf8("Functions cannot be both virtual and static"sv)),((checked_function)->name_span)))));
 }
 if ((((checked_function)->is_override) && TRY((((checked_function)->is_static()))))){
-TRY((((*this).error(TRY(ByteString::from_utf8("Functions cannot be both override and static"sv)),((checked_function)->name_span)))));
+TRY((((*this).error((ByteString::must_from_utf8("Functions cannot be both override and static"sv)),((checked_function)->name_span)))));
 }
 }
 
@@ -1343,18 +1343,18 @@ return TRY((((((*this).program))->find_comptime_binding_in_scope(scope_id,name,f
 
 ErrorOr<NonnullRefPtr<typename types::CheckedExpression>> typechecker::Typechecker::typecheck_try_block(NonnullRefPtr<typename parser::ParsedStatement> const stmt,ByteString const error_name,utility::Span const error_span,parser::ParsedBlock const catch_block,ids::ScopeId const scope_id,types::SafetyMode const safety_mode,utility::Span const span) {
 {
-ids::ScopeId const try_scope_id = TRY((((*this).create_scope(scope_id,true,TRY(ByteString::from_utf8("try"sv)),true))));
+ids::ScopeId const try_scope_id = TRY((((*this).create_scope(scope_id,true,(ByteString::must_from_utf8("try"sv)),true))));
 NonnullRefPtr<typename types::CheckedStatement> const checked_stmt = TRY((((*this).typecheck_statement(stmt,try_scope_id,safety_mode,JaktInternal::OptionalNone()))));
-ids::StructId const error_struct_id = TRY((((*this).find_struct_in_prelude(TRY(ByteString::from_utf8("Error"sv))))));
+ids::StructId const error_struct_id = TRY((((*this).find_struct_in_prelude((ByteString::must_from_utf8("Error"sv))))));
 NonnullRefPtr<types::CheckedVariable> const error_decl = TRY((types::CheckedVariable::__jakt_create(error_name,((((*this).get_struct(error_struct_id))).type_id),false,error_span,JaktInternal::OptionalNone(),types::CheckedVisibility::Public(),JaktInternal::OptionalNone(),JaktInternal::OptionalNone(),JaktInternal::OptionalNone())));
 NonnullRefPtr<types::Module> module = ((*this).current_module());
 ids::VarId const error_id = TRY((((module)->add_variable(error_decl))));
 NonnullRefPtr<types::Scope> const parent_scope = TRY((((*this).get_scope(scope_id))));
-ids::ScopeId const catch_scope_id = TRY((((*this).create_scope(scope_id,((parent_scope)->can_throw),TRY(ByteString::from_utf8("catch"sv)),true))));
+ids::ScopeId const catch_scope_id = TRY((((*this).create_scope(scope_id,((parent_scope)->can_throw),(ByteString::must_from_utf8("catch"sv)),true))));
 TRY((((*this).add_var_to_scope(catch_scope_id,error_name,error_id,error_span))));
 types::CheckedBlock const checked_catch_block = TRY((((*this).typecheck_block(catch_block,catch_scope_id,safety_mode,JaktInternal::OptionalNone()))));
 if (((((checked_catch_block).yielded_type)).has_value())){
-TRY((((*this).error(TRY(ByteString::from_utf8("A ‘catch’ block as part of a try block is not allowed to yield values"sv)),(((catch_block).find_yield_span()).value())))));
+TRY((((*this).error((ByteString::must_from_utf8("A ‘catch’ block as part of a try block is not allowed to yield values"sv)),(((catch_block).find_yield_span()).value())))));
 }
 return TRY((types::CheckedExpression::TryBlock(JaktInternal::OptionalNone(),checked_stmt,checked_catch_block,error_name,error_span,span,types::void_type_id())));
 }
@@ -1480,7 +1480,7 @@ return JaktInternal::ExplicitValue(JaktInternal::checked_add(val,static_cast<u64
 case 2 /* Floating */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Floating;f64 const& val = __jakt_match_value.value;
 {
-utility::todo(TRY(ByteString::from_utf8("Implement floats"sv)));
+utility::todo((ByteString::must_from_utf8("Implement floats"sv)));
 }
 };/*case end*/
 default: VERIFY_NOT_REACHED();}/*switch end*/
@@ -1578,8 +1578,8 @@ return (infallible_enum_cast<jakt__prelude__operators::Ordering>((JaktInternal::
 return (!(((self) == (rhs))));
 }
 }
-((((((((variant).params).value()))[static_cast<i64>(0LL)])).name),TRY(ByteString::from_utf8(""sv))));
-bool const is_typed = ((((((variant).params)).has_value()) && (((((((variant).params).value())).size())) == (static_cast<size_t>(1ULL)))) && (((((((((variant).params).value()))[static_cast<i64>(0LL)])).name)) == (TRY(ByteString::from_utf8(""sv)))));
+((((((((variant).params).value()))[static_cast<i64>(0LL)])).name),(ByteString::must_from_utf8(""sv))));
+bool const is_typed = ((((((variant).params)).has_value()) && (((((((variant).params).value())).size())) == (static_cast<size_t>(1ULL)))) && (((((((((variant).params).value()))[static_cast<i64>(0LL)])).name)) == ((ByteString::must_from_utf8(""sv)))));
 if (is_structlike){
 JaktInternal::Set<ByteString> seen_fields = (TRY((Set<ByteString>::create_with_values({}))));
 {
@@ -1719,7 +1719,7 @@ if ((!(((maybe_enum_variant_constructor).has_value())))){
 bool const can_function_throw = is_boxed;
 ids::ScopeId const function_scope_id = TRY((((*this).create_scope(parent_scope_id,can_function_throw,TRY((__jakt_format((StringView::from_string_literal("enum-variant-constructor({}::{})"sv)),((enum_).name),((variant).name)))),true))));
 ids::ScopeId const block_scope_id = TRY((((*this).create_scope(function_scope_id,can_function_throw,TRY((__jakt_format((StringView::from_string_literal("enum-variant-constructor-block({}::{})"sv)),((enum_).name),((variant).name)))),true))));
-NonnullRefPtr<types::CheckedVariable> const variable = TRY((types::CheckedVariable::__jakt_create(TRY(ByteString::from_utf8("value"sv)),type_id,false,((param).span),JaktInternal::OptionalNone(),types::CheckedVisibility::Public(),JaktInternal::OptionalNone(),JaktInternal::OptionalNone(),JaktInternal::OptionalNone())));
+NonnullRefPtr<types::CheckedVariable> const variable = TRY((types::CheckedVariable::__jakt_create((ByteString::must_from_utf8("value"sv)),type_id,false,((param).span),JaktInternal::OptionalNone(),types::CheckedVisibility::Public(),JaktInternal::OptionalNone(),JaktInternal::OptionalNone(),JaktInternal::OptionalNone())));
 TRY((((params).push(types::CheckedParameter(false,variable,JaktInternal::OptionalNone())))));
 NonnullRefPtr<types::CheckedFunction> const checked_function = TRY((types::CheckedFunction::__jakt_create(((variant).name),((variant).span),types::CheckedVisibility::Public(),TRY((((*this).find_or_add_type_id(TRY((types::Type::Enum(parser::CheckedQualifiers(false),enum_id))))))),JaktInternal::OptionalNone(),params,TRY((types::FunctionGenerics::__jakt_create(function_scope_id,params,(TRY((DynamicArray<types::FunctionGenericParameter>::create_with({})))),(TRY((DynamicArray<JaktInternal::DynamicArray<ids::TypeId>>::create_with({}))))))),types::CheckedBlock((TRY((DynamicArray<NonnullRefPtr<typename types::CheckedStatement>>::create_with({})))),block_scope_id,types::BlockControlFlow::AlwaysReturns(),ids::TypeId::none(),false),can_function_throw,parser::FunctionType::ImplicitEnumConstructor(),parser::FunctionLinkage::Internal(),function_scope_id,JaktInternal::OptionalNone(),true,JaktInternal::OptionalNone(),false,false,false,false,false,JaktInternal::OptionalNone(),JaktInternal::OptionalNone(),JaktInternal::OptionalNone(),false,JaktInternal::OptionalNone(),JaktInternal::OptionalNone(),JaktInternal::OptionalNone(),parser::InlineState::Default())));
 ids::FunctionId const function_id = TRY((((module)->add_function(checked_function))));
@@ -1827,7 +1827,7 @@ return (infallible_enum_cast<jakt__prelude__operators::Ordering>((JaktInternal::
 }
 }
 (((((((callee_candidate)->generics))->params)).size()),type_arg_index)){
-TRY((((*this).error(TRY(ByteString::from_utf8("Trying to access generic parameter out of bounds"sv)),((parsed_type)->span())))));
+TRY((((*this).error((ByteString::must_from_utf8("Trying to access generic parameter out of bounds"sv)),((parsed_type)->span())))));
 continue;
 }
 ids::TypeId const typevar_type_id = ((((((((callee_candidate)->generics))->params))[type_arg_index])).type_id());
@@ -1869,18 +1869,18 @@ TRY((((((*this).generic_inferences)).set(((((((structure).generic_parameters))[i
 
 }
 if (TRY((((callee_candidate)->is_static())))){
-TRY((((*this).error(TRY(ByteString::from_utf8("Cannot call static method on an instance of an object"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("Cannot call static method on an instance of an object"sv)),span))));
 }
 else {
 (arg_offset = static_cast<size_t>(1ULL));
 }
 
 if ((TRY((((callee_candidate)->is_mutating()))) && (!((((this_expr.value()))->is_mutable(((*this).program))))))){
-TRY((((*this).error(TRY(ByteString::from_utf8("Cannot call mutating method on an immutable object instance"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("Cannot call mutating method on an immutable object instance"sv)),span))));
 }
 }
 else if ((!(TRY((((callee_candidate)->is_static())))))){
-TRY((((*this).error_with_hint(TRY(ByteString::from_utf8("Cannot call an instance method statically"sv)),span,TRY(ByteString::from_utf8("Add a dot before the method name to call an instance method"sv)),span))));
+TRY((((*this).error_with_hint((ByteString::must_from_utf8("Cannot call an instance method statically"sv)),span,(ByteString::must_from_utf8("Add a dot before the method name to call an instance method"sv)),span))));
 }
 i64 total_function_specificity = static_cast<i64>(0LL);
 JaktInternal::DynamicArray<JaktInternal::Tuple<ByteString,utility::Span,NonnullRefPtr<typename types::CheckedExpression>>> const resolved_args = TRY((((*this).resolve_default_params(((((callee_candidate)->generics))->base_params),((callee_candidate)->has_varargs),((call).args),caller_scope_id,safety_mode,arg_offset,span))));
@@ -2056,7 +2056,7 @@ break;
 }
 
 }
-return TRY((utility::join(ss,TRY(ByteString::from_utf8(" -> "sv)))));
+return TRY((utility::join(ss,(ByteString::must_from_utf8(" -> "sv)))));
 }
 }
 
@@ -2603,7 +2603,7 @@ return JaktInternal::ExplicitValue(types::CheckedNumericConstant::I64((infallibl
 };/*case end*/
 default: {
 {
-utility::panic(TRY(ByteString::from_utf8("Unreachable"sv)));
+utility::panic((ByteString::must_from_utf8("Unreachable"sv)));
 }
 };/*case end*/
 }/*switch end*/
@@ -2630,7 +2630,7 @@ return {};
 JaktInternal::Optional<ids::FunctionId> const function_id = TRY((((*this).find_function_matching_signature_in_scope(parent_scope_id,parsed_function))));
 if (((function_id).has_value())){
 (((*this).current_function_id) = (function_id.value()));
-if (((((parsed_function).name)) == (TRY(ByteString::from_utf8("main"sv))))){
+if (((((parsed_function).name)) == ((ByteString::must_from_utf8("main"sv))))){
 TRY((((*this).typecheck_jakt_main(parsed_function,parent_scope_id))));
 }
 NonnullRefPtr<types::CheckedFunction> checked_function = ((*this).get_function((function_id.value())));
@@ -2638,7 +2638,7 @@ ids::ScopeId const function_scope_id = ((checked_function)->function_scope_id);
 parser::FunctionLinkage const function_linkage = ((checked_function)->linkage);
 if (((checked_function)->is_fully_checked)){
 if ((!(((TRY((((*this).get_scope(parent_scope_id)))))->is_from_generated_code)))){
-TRY((((*this).error_with_hint(TRY((__jakt_format((StringView::from_string_literal("Function ‘{}’ is already defined"sv)),((parsed_function).name)))),((parsed_function).name_span),TRY(ByteString::from_utf8("Try removing this definition"sv)),(((((checked_function)->parsed_function).value())).name_span)))));
+TRY((((*this).error_with_hint(TRY((__jakt_format((StringView::from_string_literal("Function ‘{}’ is already defined"sv)),((parsed_function).name)))),((parsed_function).name_span),(ByteString::must_from_utf8("Try removing this definition"sv)),(((((checked_function)->parsed_function).value())).name_span)))));
 }
 return {};
 }
@@ -2669,7 +2669,7 @@ if (((!(((parsed_function).is_fat_arrow))) && (((((parsed_function).return_type)
 return (!(((self) == (rhs))));
 }
 }
-(((parsed_function).name),TRY(ByteString::from_utf8("main"sv)))))){
+(((parsed_function).name),(ByteString::must_from_utf8("main"sv)))))){
 (function_return_type_id = types::void_type_id());
 }
 if (((function_return_type_id).equals(types::never_type_id()))){
@@ -2678,7 +2678,7 @@ NonnullRefPtr<types::Scope> scope = TRY((((*this).get_scope(function_scope_id)))
 }
 types::CheckedBlock const block = TRY((((*this).typecheck_block(((parsed_function).block),function_scope_id,types::SafetyMode::Safe(),JaktInternal::OptionalNone()))));
 if (((((block).yielded_type)).has_value())){
-TRY((((*this).error_with_hint(TRY(ByteString::from_utf8("Functions are not allowed to yield values"sv)),(((((parsed_function).block)).find_yield_span()).value()),TRY(ByteString::from_utf8("You might want to return instead"sv)),(((((parsed_function).block)).find_yield_keyword_span()).value())))));
+TRY((((*this).error_with_hint((ByteString::must_from_utf8("Functions are not allowed to yield values"sv)),(((((parsed_function).block)).find_yield_span()).value()),(ByteString::must_from_utf8("You might want to return instead"sv)),(((((parsed_function).block)).find_yield_keyword_span()).value())))));
 }
 ids::TypeId const return_type_id = ({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<ids::TypeId,ErrorOr<void>>{
@@ -2696,10 +2696,10 @@ return JaktInternal::ExplicitValue(TRY((((*this).resolve_type_var(function_retur
 });
 if (((!(((function_linkage).__jakt_init_index() == 1 /* External */))) && ((!(((return_type_id).equals(types::void_type_id())))) && (!(((((block).control_flow)).always_transfers_control())))))){
 if ((((return_type_id).equals(types::never_type_id())) && (!(((((block).control_flow)).never_returns()))))){
-TRY((((*this).error(TRY(ByteString::from_utf8("Control reaches end of never-returning function"sv)),((parsed_function).name_span)))));
+TRY((((*this).error((ByteString::must_from_utf8("Control reaches end of never-returning function"sv)),((parsed_function).name_span)))));
 }
 else if (((!(((((block).control_flow)).never_returns()))) && (!(((parsed_function).is_jakt_main))))){
-TRY((((*this).error(TRY(ByteString::from_utf8("Control reaches end of non-void function"sv)),((parsed_function).name_span)))));
+TRY((((*this).error((ByteString::must_from_utf8("Control reaches end of non-void function"sv)),((parsed_function).name_span)))));
 }
 }
 (((checked_function)->block) = block);
@@ -2801,7 +2801,7 @@ case 0 /* Struct */: {
 return JaktInternal::ExplicitValue(({ Optional<types::StructLikeId> __jakt_var_447; {
 JaktInternal::Optional<ids::StructId> const struct_id = TRY((((*this).find_struct_in_scope(scope_id,((record).name),JaktInternal::OptionalNone()))));
 if ((!(((struct_id).has_value())))){
-TRY((((((*this).compiler))->panic(TRY(ByteString::from_utf8("can't find struct that has been previous added"sv))))));
+TRY((((((*this).compiler))->panic((ByteString::must_from_utf8("can't find struct that has been previous added"sv))))));
 }
 TRY((((*this).typecheck_struct(record,(struct_id.value()),scope_id))));
 __jakt_var_447 = types::StructLikeId::Struct(JaktInternal::OptionalNone(),(struct_id.value())); goto __jakt_label_412;
@@ -2813,7 +2813,7 @@ case 1 /* Class */: {
 return JaktInternal::ExplicitValue(({ Optional<types::StructLikeId> __jakt_var_448; {
 JaktInternal::Optional<ids::StructId> const struct_id = TRY((((*this).find_struct_in_scope(scope_id,((record).name),JaktInternal::OptionalNone()))));
 if ((!(((struct_id).has_value())))){
-TRY((((((*this).compiler))->panic(TRY(ByteString::from_utf8("can't find struct that has been previous added"sv))))));
+TRY((((((*this).compiler))->panic((ByteString::must_from_utf8("can't find struct that has been previous added"sv))))));
 }
 TRY((((*this).typecheck_struct(record,(struct_id.value()),scope_id))));
 __jakt_var_448 = types::StructLikeId::Struct(JaktInternal::OptionalNone(),(struct_id.value())); goto __jakt_label_413;
@@ -2825,7 +2825,7 @@ case 3 /* SumEnum */: {
 return JaktInternal::ExplicitValue(({ Optional<types::StructLikeId> __jakt_var_449; {
 JaktInternal::Optional<ids::EnumId> const enum_id = TRY((((((*this).program))->find_enum_in_scope(scope_id,((record).name),false,JaktInternal::OptionalNone()))));
 if ((!(((enum_id).has_value())))){
-TRY((((((*this).compiler))->panic(TRY(ByteString::from_utf8("can't find enum that has been previous added"sv))))));
+TRY((((((*this).compiler))->panic((ByteString::must_from_utf8("can't find enum that has been previous added"sv))))));
 }
 TRY((((*this).typecheck_enum(record,(enum_id.value()),scope_id))));
 __jakt_var_449 = types::StructLikeId::Enum(JaktInternal::OptionalNone(),(enum_id.value())); goto __jakt_label_414;
@@ -2837,7 +2837,7 @@ case 2 /* ValueEnum */: {
 return JaktInternal::ExplicitValue(({ Optional<types::StructLikeId> __jakt_var_450; {
 JaktInternal::Optional<ids::EnumId> const enum_id = TRY((((((*this).program))->find_enum_in_scope(scope_id,((record).name),false,JaktInternal::OptionalNone()))));
 if ((!(((enum_id).has_value())))){
-TRY((((((*this).compiler))->panic(TRY(ByteString::from_utf8("can't find enum that has been previous added"sv))))));
+TRY((((((*this).compiler))->panic((ByteString::must_from_utf8("can't find enum that has been previous added"sv))))));
 }
 TRY((((*this).typecheck_enum(record,(enum_id.value()),scope_id))));
 __jakt_var_450 = types::StructLikeId::Enum(JaktInternal::OptionalNone(),(enum_id.value())); goto __jakt_label_415;
@@ -2892,7 +2892,7 @@ if (((trait_id).has_value())){
 TRY((((*this).typecheck_trait(parsed_trait,(trait_id.value()),scope_id,false))));
 }
 else {
-TRY((((((*this).compiler))->panic(TRY(ByteString::from_utf8("can't find trait that has been previous added"sv))))));
+TRY((((((*this).compiler))->panic((ByteString::must_from_utf8("can't find trait that has been previous added"sv))))));
 }
 
 }
@@ -2952,7 +2952,7 @@ break;
 }
 parser::ParsedMethod method = (_magic_value.value());
 {
-if (((TRY((((((((((((method).parsed_function)).params)).first())).map([](auto& _value) { return _value.variable; }))).map([](auto& _value) { return _value.name; })).try_value_or_lazy_evaluated([&]() -> ErrorOr<ByteString> { return TRY(ByteString::from_utf8(""sv)); })))) == (TRY(ByteString::from_utf8("this"sv))))){
+if (((TRY((((((((((((method).parsed_function)).params)).first())).map([](auto& _value) { return _value.variable; }))).map([](auto& _value) { return _value.name; })).try_value_or_lazy_evaluated([&]() -> ErrorOr<ByteString> { return (ByteString::must_from_utf8(""sv)); })))) == ((ByteString::must_from_utf8("this"sv))))){
 TRY((((*this).typecheck_method(((method).parsed_function),types::StructLikeId::Struct(JaktInternal::OptionalNone(),struct_id)))));
 }
 else {
@@ -2980,7 +2980,7 @@ break;
 }
 parser::ParsedMethod method = (_magic_value.value());
 {
-if (((TRY((((((((((((method).parsed_function)).params)).first())).map([](auto& _value) { return _value.variable; }))).map([](auto& _value) { return _value.name; })).try_value_or_lazy_evaluated([&]() -> ErrorOr<ByteString> { return TRY(ByteString::from_utf8(""sv)); })))) == (TRY(ByteString::from_utf8("this"sv))))){
+if (((TRY((((((((((((method).parsed_function)).params)).first())).map([](auto& _value) { return _value.variable; }))).map([](auto& _value) { return _value.name; })).try_value_or_lazy_evaluated([&]() -> ErrorOr<ByteString> { return (ByteString::must_from_utf8(""sv)); })))) == ((ByteString::must_from_utf8("this"sv))))){
 TRY((((*this).typecheck_method(((method).parsed_function),types::StructLikeId::Struct(JaktInternal::OptionalNone(),struct_id)))));
 }
 else {
@@ -3008,7 +3008,7 @@ break;
 }
 parser::ParsedMethod method = (_magic_value.value());
 {
-if (((TRY((((((((((((method).parsed_function)).params)).first())).map([](auto& _value) { return _value.variable; }))).map([](auto& _value) { return _value.name; })).try_value_or_lazy_evaluated([&]() -> ErrorOr<ByteString> { return TRY(ByteString::from_utf8(""sv)); })))) == (TRY(ByteString::from_utf8("this"sv))))){
+if (((TRY((((((((((((method).parsed_function)).params)).first())).map([](auto& _value) { return _value.variable; }))).map([](auto& _value) { return _value.name; })).try_value_or_lazy_evaluated([&]() -> ErrorOr<ByteString> { return (ByteString::must_from_utf8(""sv)); })))) == ((ByteString::must_from_utf8("this"sv))))){
 TRY((((*this).typecheck_method(((method).parsed_function),types::StructLikeId::Enum(JaktInternal::OptionalNone(),enum_id)))));
 }
 else {
@@ -3036,7 +3036,7 @@ break;
 }
 parser::ParsedMethod method = (_magic_value.value());
 {
-if (((TRY((((((((((((method).parsed_function)).params)).first())).map([](auto& _value) { return _value.variable; }))).map([](auto& _value) { return _value.name; })).try_value_or_lazy_evaluated([&]() -> ErrorOr<ByteString> { return TRY(ByteString::from_utf8(""sv)); })))) == (TRY(ByteString::from_utf8("this"sv))))){
+if (((TRY((((((((((((method).parsed_function)).params)).first())).map([](auto& _value) { return _value.variable; }))).map([](auto& _value) { return _value.name; })).try_value_or_lazy_evaluated([&]() -> ErrorOr<ByteString> { return (ByteString::must_from_utf8(""sv)); })))) == ((ByteString::must_from_utf8("this"sv))))){
 TRY((((*this).typecheck_method(((method).parsed_function),types::StructLikeId::Enum(JaktInternal::OptionalNone(),enum_id)))));
 }
 else {
@@ -3305,7 +3305,7 @@ case 0 /* Nothing */: {
 ByteString const trait_name = ((trait_)->name);
 JaktInternal::Optional<JaktInternal::DynamicArray<JaktInternal::Tuple<ids::TraitId,JaktInternal::DynamicArray<ids::TypeId>>>> const implemented_trait = ((implemented_traits).get(trait_name));
 if (((!(((implemented_trait).has_value()))) || (!((((((((implemented_trait.value())).first())).map([](auto& _value) { return _value.template get<0>(); }))).map([&](auto& _value) { return _value.equals(constraint); })).value_or_lazy_evaluated([&] { return false; }))))){
-TRY((((*this).error_with_hint(TRY((__jakt_format((StringView::from_string_literal("Cannot use ‘{}’ here as it doesn't implement the trait ‘{}’"sv)),TRY((((*this).type_name(generic_argument,false)))),trait_name))),arg_span,TRY(ByteString::from_utf8("Consider implementing the required trait for this type"sv)),decl_span))));
+TRY((((*this).error_with_hint(TRY((__jakt_format((StringView::from_string_literal("Cannot use ‘{}’ here as it doesn't implement the trait ‘{}’"sv)),TRY((((*this).type_name(generic_argument,false)))),trait_name))),arg_span,(ByteString::must_from_utf8("Consider implementing the required trait for this type"sv)),decl_span))));
 }
 }
 return JaktInternal::ExplicitValue<void>();
@@ -3315,7 +3315,7 @@ case 1 /* Methods */: {
 ByteString const trait_name = ((trait_)->name);
 JaktInternal::Optional<JaktInternal::DynamicArray<JaktInternal::Tuple<ids::TraitId,JaktInternal::DynamicArray<ids::TypeId>>>> const implemented_trait = ((implemented_traits).get(trait_name));
 if (((!(((implemented_trait).has_value()))) || (!((((((((implemented_trait.value())).first())).map([](auto& _value) { return _value.template get<0>(); }))).map([&](auto& _value) { return _value.equals(constraint); })).value_or_lazy_evaluated([&] { return false; }))))){
-TRY((((*this).error_with_hint(TRY((__jakt_format((StringView::from_string_literal("Cannot use ‘{}’ here as it doesn't implement the trait ‘{}’"sv)),TRY((((*this).type_name(generic_argument,false)))),trait_name))),arg_span,TRY(ByteString::from_utf8("Consider implementing the required trait for this type"sv)),decl_span))));
+TRY((((*this).error_with_hint(TRY((__jakt_format((StringView::from_string_literal("Cannot use ‘{}’ here as it doesn't implement the trait ‘{}’"sv)),TRY((((*this).type_name(generic_argument,false)))),trait_name))),arg_span,(ByteString::must_from_utf8("Consider implementing the required trait for this type"sv)),decl_span))));
 }
 }
 return JaktInternal::ExplicitValue<void>();
@@ -3580,7 +3580,7 @@ ErrorOr<NonnullRefPtr<typename types::CheckedStatement>> typechecker::Typechecke
 {
 types::CheckedBlock const checked_block = TRY((((*this).typecheck_block(parsed_block,scope_id,safety_mode,JaktInternal::OptionalNone()))));
 if (((((checked_block).yielded_type)).has_value())){
-TRY((((*this).error(TRY(ByteString::from_utf8("A ‘loop’ block is not allowed to yield values"sv)),(((parsed_block).find_yield_span()).value())))));
+TRY((((*this).error((ByteString::must_from_utf8("A ‘loop’ block is not allowed to yield values"sv)),(((parsed_block).find_yield_span()).value())))));
 }
 return TRY((types::CheckedStatement::Loop(checked_block,span)));
 }
@@ -3595,15 +3595,15 @@ return TRY((((((*this).program))->get_scope(id))));
 ErrorOr<NonnullRefPtr<typename types::CheckedExpression>> typechecker::Typechecker::typecheck_indexed_tuple(NonnullRefPtr<typename parser::ParsedExpression> const expr,size_t const index,ids::ScopeId const scope_id,bool const is_optional,types::SafetyMode const safety_mode,utility::Span const span) {
 {
 NonnullRefPtr<typename types::CheckedExpression> const checked_expr = TRY((((*this).typecheck_expression_and_dereference_if_needed(expr,scope_id,safety_mode,JaktInternal::OptionalNone(),span))));
-ids::StructId const tuple_struct_id = TRY((((*this).find_struct_in_prelude(TRY(ByteString::from_utf8("Tuple"sv))))));
-ids::StructId const optional_struct_id = TRY((((*this).find_struct_in_prelude(TRY(ByteString::from_utf8("Optional"sv))))));
+ids::StructId const tuple_struct_id = TRY((((*this).find_struct_in_prelude((ByteString::must_from_utf8("Tuple"sv))))));
+ids::StructId const optional_struct_id = TRY((((*this).find_struct_in_prelude((ByteString::must_from_utf8("Optional"sv))))));
 ids::TypeId expr_type_id = types::unknown_type_id();
 if (((((*this).get_type(((checked_expr)->type()))))->__jakt_init_index() == 20 /* GenericInstance */)){
 ids::StructId const id = (((*this).get_type(((checked_expr)->type()))))->as.GenericInstance.id;
 JaktInternal::DynamicArray<ids::TypeId> const args = (((*this).get_type(((checked_expr)->type()))))->as.GenericInstance.args;
 if (((id).equals(tuple_struct_id))){
 if (is_optional){
-TRY((((*this).error(TRY(ByteString::from_utf8("Optional chaining is not allowed on a non-optional tuple type"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("Optional chaining is not allowed on a non-optional tuple type"sv)),span))));
 }
 if ([](size_t const& self, size_t rhs) -> bool {
 {
@@ -3616,7 +3616,7 @@ return (infallible_enum_cast<jakt__prelude__operators::Ordering>((JaktInternal::
 }
 }
 (index,((args).size()))){
-TRY((((*this).error(TRY(ByteString::from_utf8("Tuple index past the end of the tuple"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("Tuple index past the end of the tuple"sv)),span))));
 }
 else {
 (expr_type_id = ((args)[index]));
@@ -3640,7 +3640,7 @@ return (infallible_enum_cast<jakt__prelude__operators::Ordering>((JaktInternal::
 }
 }
 (index,((args).size()))){
-TRY((((*this).error(TRY(ByteString::from_utf8("Optional-chained tuple index past the end of the tuple"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("Optional-chained tuple index past the end of the tuple"sv)),span))));
 }
 else {
 (expr_type_id = TRY((((*this).find_or_add_type_id(TRY((types::Type::GenericInstance(parser::CheckedQualifiers(false),optional_struct_id,(TRY((DynamicArray<ids::TypeId>::create_with({((args)[index])}))))))))))));
@@ -3649,16 +3649,16 @@ else {
 }
 }
 else {
-TRY((((*this).error(TRY(ByteString::from_utf8("Optional-chained tuple index used on non-tuple value"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("Optional-chained tuple index used on non-tuple value"sv)),span))));
 }
 
 }
 }
 else if (is_optional){
-TRY((((*this).error(TRY(ByteString::from_utf8("Optional-chained tuple index used on non-tuple value"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("Optional-chained tuple index used on non-tuple value"sv)),span))));
 }
 else {
-TRY((((*this).error(TRY(ByteString::from_utf8("Tuple index used on non-tuple value"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("Tuple index used on non-tuple value"sv)),span))));
 }
 
 return TRY((types::CheckedExpression::IndexedTuple(JaktInternal::OptionalNone(),checked_expr,index,span,is_optional,expr_type_id)));
@@ -3689,13 +3689,13 @@ continue;
 TRY((((named_requirements).push((Tuple{((parameter).name), ((parameter).span), trait_requirements})))));
 }
 else {
-TRY((((*this).error_with_hint(TRY((__jakt_format((StringView::from_string_literal("forall type '{}' is not allowed to be unconditional"sv)),((parameter).name)))),((parameter).span),TRY(ByteString::from_utf8("Try adding a 'requires' clause to the this type"sv)),((parameter).span)))));
+TRY((((*this).error_with_hint(TRY((__jakt_format((StringView::from_string_literal("forall type '{}' is not allowed to be unconditional"sv)),((parameter).name)))),((parameter).span),(ByteString::must_from_utf8("Try adding a 'requires' clause to the this type"sv)),((parameter).span)))));
 continue;
 }
 
 }
 else {
-TRY((((*this).error_with_hint(TRY((__jakt_format((StringView::from_string_literal("forall type '{}' is not allowed to be unconditional"sv)),((parameter).name)))),((parameter).span),TRY(ByteString::from_utf8("Try adding a 'requires' clause to the this type"sv)),((parameter).span)))));
+TRY((((*this).error_with_hint(TRY((__jakt_format((StringView::from_string_literal("forall type '{}' is not allowed to be unconditional"sv)),((parameter).name)))),((parameter).span),(ByteString::must_from_utf8("Try adding a 'requires' clause to the this type"sv)),((parameter).span)))));
 continue;
 }
 
@@ -3771,11 +3771,11 @@ ErrorOr<NonnullRefPtr<typename types::CheckedStatement>> typechecker::Typechecke
 {
 NonnullRefPtr<typename types::CheckedExpression> const checked_condition = TRY((((*this).typecheck_expression_and_dereference_if_needed(condition,scope_id,safety_mode,JaktInternal::OptionalNone(),span))));
 if ((!(((((checked_condition)->type())).equals(types::builtin(types::BuiltinType::Bool())))))){
-TRY((((*this).error(TRY(ByteString::from_utf8("Condition must be a boolean expression"sv)),((condition)->span())))));
+TRY((((*this).error((ByteString::must_from_utf8("Condition must be a boolean expression"sv)),((condition)->span())))));
 }
 types::CheckedBlock const checked_block = TRY((((*this).typecheck_block(block,scope_id,safety_mode,JaktInternal::OptionalNone()))));
 if (((((checked_block).yielded_type)).has_value())){
-TRY((((*this).error(TRY(ByteString::from_utf8("A ‘while’ block is not allowed to yield values"sv)),(((block).find_yield_span()).value())))));
+TRY((((*this).error((ByteString::must_from_utf8("A ‘while’ block is not allowed to yield values"sv)),(((block).find_yield_span()).value())))));
 }
 return TRY((types::CheckedStatement::While(checked_condition,checked_block,span)));
 }
@@ -3952,7 +3952,7 @@ NonnullRefPtr<types::Scope> scope = TRY((((*this).get_scope(scope_id))));
 JaktInternal::Optional<ids::VarId> const existing_var = ((((scope)->vars)).get(name));
 if (((existing_var).has_value())){
 NonnullRefPtr<types::CheckedVariable> const variable_ = ((*this).get_variable((existing_var.value())));
-TRY((((*this).error_with_hint(TRY((__jakt_format((StringView::from_string_literal("Redefinition of variable ‘{}’"sv)),name))),span,TRY(ByteString::from_utf8("previous definition here"sv)),((variable_)->definition_span)))));
+TRY((((*this).error_with_hint(TRY((__jakt_format((StringView::from_string_literal("Redefinition of variable ‘{}’"sv)),name))),span,(ByteString::must_from_utf8("previous definition here"sv)),((variable_)->definition_span)))));
 }
 TRY((((((scope)->vars)).set(name,var_id))));
 TRY((((((*this).program))->set_owner_scope_if_needed(scope_id,var_id))));
@@ -3965,7 +3965,7 @@ ErrorOr<bool> typechecker::Typechecker::add_comptime_binding_to_scope(ids::Scope
 NonnullRefPtr<types::Scope> scope = TRY((((*this).get_scope(scope_id))));
 JaktInternal::Optional<types::Value> const existing_binding = ((((scope)->comptime_bindings)).get(name));
 if (((existing_binding).has_value())){
-TRY((((*this).error_with_hint(TRY((__jakt_format((StringView::from_string_literal("Redefinition of comptime variable ‘{}’"sv)),name))),span,TRY(ByteString::from_utf8("previous definition here"sv)),(((existing_binding.value())).span)))));
+TRY((((*this).error_with_hint(TRY((__jakt_format((StringView::from_string_literal("Redefinition of comptime variable ‘{}’"sv)),name))),span,(ByteString::must_from_utf8("previous definition here"sv)),(((existing_binding.value())).span)))));
 }
 TRY((((((scope)->comptime_bindings)).set(name,value))));
 return true;
@@ -4120,10 +4120,10 @@ auto&& __jakt_match_value = __jakt_match_variant.as.CatchAll;JaktInternal::Dynam
 utility::Span const& arguments_span = __jakt_match_value.arguments_span;
 {
 if (((current_case_index) != (JaktInternal::checked_sub(case_count,static_cast<size_t>(1ULL))))){
-TRY((((*this).error(TRY(ByteString::from_utf8("Match else case is only allowed as the last case"sv)),((case_).marker_span)))));
+TRY((((*this).error((ByteString::must_from_utf8("Match else case is only allowed as the last case"sv)),((case_).marker_span)))));
 }
 if (seen_catch_all){
-TRY((((*this).error(TRY(ByteString::from_utf8("Multiple catch-all cases in match are not allowed"sv)),((case_).marker_span)))));
+TRY((((*this).error((ByteString::must_from_utf8("Multiple catch-all cases in match are not allowed"sv)),((case_).marker_span)))));
 }
 else {
 (seen_catch_all = true);
@@ -4171,7 +4171,7 @@ TRY((((checked_cases).push(checked_match_case))));
 
 }
 else {
-ids::ScopeId const new_scope_id = TRY((((*this).create_scope(scope_id,((TRY((((*this).get_scope(scope_id)))))->can_throw),TRY(ByteString::from_utf8("catch-all"sv)),true))));
+ids::ScopeId const new_scope_id = TRY((((*this).create_scope(scope_id,((TRY((((*this).get_scope(scope_id)))))->can_throw),(ByteString::must_from_utf8("catch-all"sv)),true))));
 JaktInternal::DynamicArray<NonnullRefPtr<typename types::CheckedStatement>> defaults = (TRY((DynamicArray<NonnullRefPtr<typename types::CheckedStatement>>::create_with({}))));
 {
 JaktInternal::DictionaryIterator<ByteString,parser::ParsedPatternDefault> _magic = ((((pattern).common.init_common.defaults)).iterator());
@@ -4278,11 +4278,11 @@ return (infallible_enum_cast<jakt__prelude__operators::Ordering>((JaktInternal::
 }
 (((missing_variants).size()),static_cast<size_t>(0ULL))){
 if ((!(seen_catch_all))){
-TRY((((*this).error(TRY((__jakt_format((StringView::from_string_literal("Match expression is not exhaustive, missing variants are: {}"sv)),TRY((utility::join(missing_variants,TRY(ByteString::from_utf8(", "sv)))))))),span))));
+TRY((((*this).error(TRY((__jakt_format((StringView::from_string_literal("Match expression is not exhaustive, missing variants are: {}"sv)),TRY((utility::join(missing_variants,(ByteString::must_from_utf8(", "sv)))))))),span))));
 }
 }
 else if ((seen_catch_all && (!(expanded_catch_all)))){
-TRY((((*this).error(TRY(ByteString::from_utf8("All variants are covered, but an irrefutable pattern is also present"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("All variants are covered, but an irrefutable pattern is also present"sv)),span))));
 }
 }
 return JaktInternal::ExplicitValue<void>();
@@ -4385,10 +4385,10 @@ auto&& __jakt_match_value = __jakt_match_variant.as.CatchAll;JaktInternal::Dynam
 utility::Span const& arguments_span = __jakt_match_value.arguments_span;
 {
 if (((current_case_index) != (JaktInternal::checked_sub(case_count,static_cast<size_t>(1ULL))))){
-TRY((((*this).error(TRY(ByteString::from_utf8("Match else case is only allowed as the last case"sv)),((case_).marker_span)))));
+TRY((((*this).error((ByteString::must_from_utf8("Match else case is only allowed as the last case"sv)),((case_).marker_span)))));
 }
 if (seen_catch_all){
-TRY((((*this).error(TRY(ByteString::from_utf8("Multiple catch-all cases in match are not allowed"sv)),((case_).marker_span)))));
+TRY((((*this).error((ByteString::must_from_utf8("Multiple catch-all cases in match are not allowed"sv)),((case_).marker_span)))));
 }
 else {
 (seen_catch_all = true);
@@ -4436,7 +4436,7 @@ TRY((((checked_cases).push(checked_match_case))));
 
 }
 else {
-ids::ScopeId const new_scope_id = TRY((((*this).create_scope(scope_id,((TRY((((*this).get_scope(scope_id)))))->can_throw),TRY(ByteString::from_utf8("catch-all"sv)),true))));
+ids::ScopeId const new_scope_id = TRY((((*this).create_scope(scope_id,((TRY((((*this).get_scope(scope_id)))))->can_throw),(ByteString::must_from_utf8("catch-all"sv)),true))));
 JaktInternal::DynamicArray<NonnullRefPtr<typename types::CheckedStatement>> defaults = (TRY((DynamicArray<NonnullRefPtr<typename types::CheckedStatement>>::create_with({}))));
 {
 JaktInternal::DictionaryIterator<ByteString,parser::ParsedPatternDefault> _magic = ((((pattern).common.init_common.defaults)).iterator());
@@ -4543,18 +4543,18 @@ return (infallible_enum_cast<jakt__prelude__operators::Ordering>((JaktInternal::
 }
 (((missing_variants).size()),static_cast<size_t>(0ULL))){
 if ((!(seen_catch_all))){
-TRY((((*this).error(TRY((__jakt_format((StringView::from_string_literal("Match expression is not exhaustive, missing variants are: {}"sv)),TRY((utility::join(missing_variants,TRY(ByteString::from_utf8(", "sv)))))))),span))));
+TRY((((*this).error(TRY((__jakt_format((StringView::from_string_literal("Match expression is not exhaustive, missing variants are: {}"sv)),TRY((utility::join(missing_variants,(ByteString::must_from_utf8(", "sv)))))))),span))));
 }
 }
 else if ((seen_catch_all && (!(expanded_catch_all)))){
-TRY((((*this).error(TRY(ByteString::from_utf8("All variants are covered, but an irrefutable pattern is also present"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("All variants are covered, but an irrefutable pattern is also present"sv)),span))));
 }
 }
 return JaktInternal::ExplicitValue<void>();
 };/*case end*/
 case 0 /* Void */: {
 {
-TRY((((*this).error(TRY(ByteString::from_utf8("Can't match on 'void' type"sv)),((checked_expr)->span())))));
+TRY((((*this).error((ByteString::must_from_utf8("Can't match on 'void' type"sv)),((checked_expr)->span())))));
 }
 return JaktInternal::ExplicitValue<void>();
 };/*case end*/
@@ -4578,7 +4578,7 @@ return JaktInternal::ExplicitValue((Tuple{id, TRY((((*this).struct_inheritance_c
 };/*case end*/
 default: {
 {
-TRY((((((*this).compiler))->panic(TRY(ByteString::from_utf8("Expected struct or generic instance in inheritance-style match expression"sv))))));
+TRY((((((*this).compiler))->panic((ByteString::must_from_utf8("Expected struct or generic instance in inheritance-style match expression"sv))))));
 }
 };/*case end*/
 }/*switch end*/
@@ -4640,14 +4640,14 @@ TRY((((names).push(((name).template get<0>())))));
 
 ids::TypeId const type = TRY((((*this).typecheck_typename(TRY((parser::ParsedType::NamespacedName(JaktInternal::OptionalNone(),(((names).last()).value()),TRY((((((names)[(JaktInternal::Range<size_t>{static_cast<size_t>(0LL),static_cast<size_t>(JaktInternal::checked_sub(((names).size()),static_cast<size_t>(1ULL)))})])).to_array()))),(TRY((DynamicArray<NonnullRefPtr<typename parser::ParsedType>>::create_with({})))),((case_).marker_span)))),scope_id,JaktInternal::OptionalNone()))));
 if (seen_catch_all){
-TRY((((*this).error_with_hint(TRY(ByteString::from_utf8("This case is unreachable because a catch-all case is present before it"sv)),((case_).marker_span),({
+TRY((((*this).error_with_hint((ByteString::must_from_utf8("This case is unreachable because a catch-all case is present before it"sv)),((case_).marker_span),({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<ByteString,ErrorOr<NonnullRefPtr<typename types::CheckedExpression>>>{
 auto __jakt_enum_value = (catch_all_matches_original_type);
 if (__jakt_enum_value == true) {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("Catch-all case matching the original subject type seen here"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("Catch-all case matching the original subject type seen here"sv)));
 }
 else if (__jakt_enum_value == false) {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("Catch-all case seen here"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("Catch-all case seen here"sv)));
 }
 VERIFY_NOT_REACHED();
 }());
@@ -4685,7 +4685,7 @@ return {};
 ;
 if (((type).equals(subject_type_id))){
 if (seen_catch_all){
-TRY((((*this).error(TRY(ByteString::from_utf8("Multiple catch-all cases in match are not allowed"sv)),((case_).marker_span)))));
+TRY((((*this).error((ByteString::must_from_utf8("Multiple catch-all cases in match are not allowed"sv)),((case_).marker_span)))));
 }
 else {
 (seen_catch_all = true);
@@ -4751,14 +4751,14 @@ ids::ScopeId const new_scope_id = TRY((((*this).create_scope(scope_id,((TRY((((*
 JaktInternal::Optional<types::ClassInstanceRebind> rebind_name = JaktInternal::OptionalNone();
 if ((!(((variant_arguments).is_empty())))){
 if (((((variant_arguments).size())) != (static_cast<size_t>(1ULL)))){
-TRY((((*this).error(TRY(ByteString::from_utf8("Class instance matches may only have one match argument (the name to rebind to)"sv)),arguments_span))));
+TRY((((*this).error((ByteString::must_from_utf8("Class instance matches may only have one match argument (the name to rebind to)"sv)),arguments_span))));
 }
 parser::EnumVariantPatternArgument const arg = ((variant_arguments)[static_cast<i64>(0LL)]);
 (rebind_name = types::ClassInstanceRebind(((arg).name_in_enum()),((arg).name_in_enum_span()),((arg).is_mutable),((arg).is_reference)));
 NonnullRefPtr<types::Module> module = ((*this).current_module());
 ids::VarId const variable_id = TRY((((module)->add_variable(TRY((types::CheckedVariable::__jakt_create((((rebind_name.value())).name),type,(((rebind_name.value())).is_mutable),(((rebind_name.value())).name_span),((case_).marker_span),types::CheckedVisibility::Public(),JaktInternal::OptionalNone(),JaktInternal::OptionalNone(),JaktInternal::OptionalNone())))))));
 if (((((rebind_name.value())).is_mutable) && (!(((checked_expr)->is_mutable(((*this).program))))))){
-TRY((((*this).error(TRY(ByteString::from_utf8("Cannot call mutating method on an immutable object instance"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("Cannot call mutating method on an immutable object instance"sv)),span))));
 }
 TRY((((*this).add_var_to_scope(new_scope_id,(((rebind_name.value())).name),variable_id,(((rebind_name.value())).name_span)))));
 }
@@ -4776,14 +4776,14 @@ auto&& __jakt_match_value = __jakt_match_variant.as.CatchAll;JaktInternal::Dynam
 utility::Span const& arguments_span = __jakt_match_value.arguments_span;
 {
 if (seen_catch_all){
-TRY((((*this).error(TRY(ByteString::from_utf8("Multiple catch-all cases in match are not allowed"sv)),((case_).marker_span)))));
+TRY((((*this).error((ByteString::must_from_utf8("Multiple catch-all cases in match are not allowed"sv)),((case_).marker_span)))));
 }
 else {
 (seen_catch_all = true);
 (catch_all_marker_span = ((case_).marker_span));
-ids::ScopeId const new_scope_id = TRY((((*this).create_scope(scope_id,((TRY((((*this).get_scope(scope_id)))))->can_throw),TRY(ByteString::from_utf8("class-variant(else)"sv)),true))));
+ids::ScopeId const new_scope_id = TRY((((*this).create_scope(scope_id,((TRY((((*this).get_scope(scope_id)))))->can_throw),(ByteString::must_from_utf8("class-variant(else)"sv)),true))));
 if ((!(((variant_arguments).is_empty())))){
-TRY((((*this).error(TRY(ByteString::from_utf8("Catch-all cases in class instance matches cannot have arguments"sv)),arguments_span))));
+TRY((((*this).error((ByteString::must_from_utf8("Catch-all cases in class instance matches cannot have arguments"sv)),arguments_span))));
 }
 JaktInternal::Tuple<types::CheckedMatchBody,JaktInternal::Optional<ids::TypeId>> const checked_body_result_type_ = TRY((((*this).typecheck_match_body(((case_).body),new_scope_id,safety_mode,((((*this).generic_inferences))),final_result_type,((case_).marker_span)))));
 types::CheckedMatchBody const checked_body = ((checked_body_result_type_).template get<0>());
@@ -4798,7 +4798,7 @@ return JaktInternal::ExplicitValue<void>();
 };/*case end*/
 default: {
 {
-TRY((((*this).error(TRY(ByteString::from_utf8("Only named types and 'else' patterns are allowed in class instance match expressions"sv)),((case_).marker_span)))));
+TRY((((*this).error((ByteString::must_from_utf8("Only named types and 'else' patterns are allowed in class instance match expressions"sv)),((case_).marker_span)))));
 }
 return JaktInternal::ExplicitValue<void>();
 };/*case end*/
@@ -4915,10 +4915,10 @@ JaktInternal::DynamicArray<parser::EnumVariantPatternArgument> const& variant_ar
 utility::Span const& arguments_span = __jakt_match_value.arguments_span;
 {
 if (is_value_match){
-TRY((((*this).error(TRY(ByteString::from_utf8("Cannot have an enum match case in a match expression containing value matches"sv)),((case_).marker_span)))));
+TRY((((*this).error((ByteString::must_from_utf8("Cannot have an enum match case in a match expression containing value matches"sv)),((case_).marker_span)))));
 }
 if (((((variant_names).size())) == (static_cast<size_t>(0ULL)))){
-TRY((((((*this).compiler))->panic(TRY(ByteString::from_utf8("typecheck_match - else - EnumVariant - variant_names.size() == 0"sv))))));
+TRY((((((*this).compiler))->panic((ByteString::must_from_utf8("typecheck_match - else - EnumVariant - variant_names.size() == 0"sv))))));
 }
 (is_enum_match = true);
 ids::ScopeId const new_scope_id = TRY((((*this).create_scope(scope_id,((TRY((((*this).get_scope(scope_id)))))->can_throw),TRY((__jakt_format((StringView::from_string_literal("catch-enum-variant({})"sv)),variant_names))),true))));
@@ -4957,11 +4957,11 @@ case 2 /* CatchAll */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.CatchAll;JaktInternal::DynamicArray<parser::EnumVariantPatternArgument> const& variant_arguments = __jakt_match_value.variant_arguments;
 {
 if (((current_case_index) != (JaktInternal::checked_sub(case_count,static_cast<size_t>(1ULL))))){
-TRY((((*this).error(TRY(ByteString::from_utf8("Match else case is only allowed as the last case"sv)),((case_).marker_span)))));
+TRY((((*this).error((ByteString::must_from_utf8("Match else case is only allowed as the last case"sv)),((case_).marker_span)))));
 }
 (catch_all_span = ((case_).marker_span));
 if (seen_catch_all){
-TRY((((*this).error(TRY(ByteString::from_utf8("Multiple catch-all cases in match are not allowed"sv)),((case_).marker_span)))));
+TRY((((*this).error((ByteString::must_from_utf8("Multiple catch-all cases in match are not allowed"sv)),((case_).marker_span)))));
 }
 else {
 (seen_catch_all = true);
@@ -4970,11 +4970,11 @@ else {
 if (((((variant_arguments).size())) != (static_cast<size_t>(0ULL)))){
 bool const old_ignore_errors = ((*this).ignore_errors);
 (((*this).ignore_errors) = false);
-TRY((((*this).error(TRY(ByteString::from_utf8("Bindings aren't allowed in a generic else"sv)),((case_).marker_span)))));
+TRY((((*this).error((ByteString::must_from_utf8("Bindings aren't allowed in a generic else"sv)),((case_).marker_span)))));
 (((*this).ignore_errors) = old_ignore_errors);
 (((*this).had_an_error) = false);
 }
-ids::ScopeId const new_scope_id = TRY((((*this).create_scope(scope_id,((TRY((((*this).get_scope(scope_id)))))->can_throw),TRY(ByteString::from_utf8("catch-all"sv)),true))));
+ids::ScopeId const new_scope_id = TRY((((*this).create_scope(scope_id,((TRY((((*this).get_scope(scope_id)))))->can_throw),(ByteString::must_from_utf8("catch-all"sv)),true))));
 JaktInternal::DynamicArray<NonnullRefPtr<typename types::CheckedStatement>> defaults = (TRY((DynamicArray<NonnullRefPtr<typename types::CheckedStatement>>::create_with({}))));
 {
 JaktInternal::DictionaryIterator<ByteString,parser::ParsedPatternDefault> _magic = ((((pattern).common.init_common.defaults)).iterator());
@@ -5010,7 +5010,7 @@ case 1 /* Expression */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Expression;NonnullRefPtr<typename parser::ParsedExpression> const& expr = __jakt_match_value.value;
 {
 if (is_enum_match){
-TRY((((*this).error(TRY(ByteString::from_utf8("Cannot have a value match case in a match expression containing enum matches"sv)),((case_).marker_span)))));
+TRY((((*this).error((ByteString::must_from_utf8("Cannot have a value match case in a match expression containing enum matches"sv)),((case_).marker_span)))));
 }
 (is_value_match = true);
 JaktInternal::Tuple<NonnullRefPtr<typename parser::ParsedExpression>,JaktInternal::Optional<parser::ParsedBlock>,JaktInternal::Optional<NonnullRefPtr<typename parser::ParsedStatement>>> const new_condition_new_then_block_new_else_statement_ = TRY((((*this).expand_context_for_bindings(expr,JaktInternal::OptionalNone(),JaktInternal::OptionalNone(),JaktInternal::OptionalNone(),scope_id,span))));
@@ -5045,14 +5045,14 @@ else if (((to).has_value())){
 }
 }
 else {
-TRY((((*this).error(TRY(ByteString::from_utf8("There has to be at least a 'from', or a 'to' in a range expression"sv)),((expr)->span())))));
+TRY((((*this).error((ByteString::must_from_utf8("There has to be at least a 'from', or a 'to' in a range expression"sv)),((expr)->span())))));
 return JaktInternal::LoopContinue{};
 }
 
 }
 TRY((((*this).check_types_for_compat(expression_type,subject_type_id,((((*this).generic_inferences))),((case_).marker_span)))));
 if ((!(((((pattern).common.init_common.defaults)).is_empty())))){
-TRY((((*this).error(TRY(ByteString::from_utf8("Expression patterns cannot have default bindings"sv)),((case_).marker_span)))));
+TRY((((*this).error((ByteString::must_from_utf8("Expression patterns cannot have default bindings"sv)),((case_).marker_span)))));
 }
 ids::ScopeId const new_scope_id = TRY((((*this).create_scope(scope_id,((TRY((((*this).get_scope(scope_id)))))->can_throw),TRY((__jakt_format((StringView::from_string_literal("catch-expression({})"sv)),expr))),true))));
 JaktInternal::Tuple<types::CheckedMatchBody,JaktInternal::Optional<ids::TypeId>> const checked_body_result_type_ = TRY((((*this).typecheck_match_body(((case_).body),new_scope_id,safety_mode,((((*this).generic_inferences))),final_result_type,((case_).marker_span)))));
@@ -5093,10 +5093,10 @@ return JaktInternal::ExplicitValue<void>();
 }
 
 if ((is_value_match && (!((seen_catch_all || ((is_boolean_match && seen_true) && seen_false)))))){
-TRY((((*this).error(TRY(ByteString::from_utf8("Match expression is not exhaustive, a value match must contain an irrefutable 'else' pattern"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("Match expression is not exhaustive, a value match must contain an irrefutable 'else' pattern"sv)),span))));
 }
 if ((is_value_match && (seen_catch_all && (is_boolean_match && (seen_true && seen_false))))){
-TRY((((*this).error(TRY(ByteString::from_utf8("All cases are covered, but an irrefutable pattern is also present"sv)),(catch_all_span.value())))));
+TRY((((*this).error((ByteString::must_from_utf8("All cases are covered, but an irrefutable pattern is also present"sv)),(catch_all_span.value())))));
 }
 }
 return JaktInternal::ExplicitValue<void>();
@@ -5171,13 +5171,13 @@ return {};
 ErrorOr<NonnullRefPtr<typename types::CheckedStatement>> typechecker::Typechecker::typecheck_throw(NonnullRefPtr<typename parser::ParsedExpression> const expr,ids::ScopeId const scope_id,types::SafetyMode const safety_mode,utility::Span const span) {
 {
 NonnullRefPtr<typename types::CheckedExpression> const checked_expr = TRY((((*this).typecheck_expression_and_dereference_if_needed(expr,scope_id,safety_mode,JaktInternal::OptionalNone(),span))));
-ids::TypeId const error_type_id = TRY((((*this).find_type_in_prelude(TRY(ByteString::from_utf8("Error"sv))))));
+ids::TypeId const error_type_id = TRY((((*this).find_type_in_prelude((ByteString::must_from_utf8("Error"sv))))));
 if ((!(((((checked_expr)->type())).equals(error_type_id))))){
-TRY((((*this).error(TRY(ByteString::from_utf8("throw expression does not produce an error"sv)),((expr)->span())))));
+TRY((((*this).error((ByteString::must_from_utf8("throw expression does not produce an error"sv)),((expr)->span())))));
 }
 NonnullRefPtr<types::Scope> const scope = TRY((((*this).get_scope(scope_id))));
 if ((!(((scope)->can_throw)))){
-TRY((((*this).error(TRY(ByteString::from_utf8("Throw statement needs to be in a try statement or a function marked as throws"sv)),((expr)->span())))));
+TRY((((*this).error((ByteString::must_from_utf8("Throw statement needs to be in a try statement or a function marked as throws"sv)),((expr)->span())))));
 }
 return TRY((types::CheckedStatement::Throw(checked_expr,span)));
 }
@@ -5325,7 +5325,7 @@ ErrorOr<NonnullRefPtr<typename types::CheckedExpression>> typechecker::Typecheck
 if (((*this).dump_try_hints)){
 TRY((((*this).dump_try_hint(span))));
 }
-ids::StructId const dictionary_struct_id = TRY((((*this).find_struct_in_prelude(TRY(ByteString::from_utf8("Dictionary"sv))))));
+ids::StructId const dictionary_struct_id = TRY((((*this).find_struct_in_prelude((ByteString::must_from_utf8("Dictionary"sv))))));
 JaktInternal::DynamicArray<JaktInternal::Tuple<NonnullRefPtr<typename types::CheckedExpression>,NonnullRefPtr<typename types::CheckedExpression>>> checked_kv_pairs = (TRY((DynamicArray<JaktInternal::Tuple<NonnullRefPtr<typename types::CheckedExpression>,NonnullRefPtr<typename types::CheckedExpression>>>::create_with({}))));
 ids::TypeId key_type_id = types::unknown_type_id();
 JaktInternal::Optional<utility::Span> key_type_span = JaktInternal::OptionalNone();
@@ -5358,10 +5358,10 @@ ids::TypeId const current_value_type_id = ((checked_value)->type());
 ids::TypeId const VOID_TYPE_ID = types::builtin(types::BuiltinType::Void());
 if ((((key_type_id).equals(types::unknown_type_id())) && ((value_type_id).equals(types::unknown_type_id())))){
 if (((current_key_type_id).equals(VOID_TYPE_ID))){
-TRY((((*this).error(TRY(ByteString::from_utf8("Can't create a dictionary with keys of type void"sv)),((key)->span())))));
+TRY((((*this).error((ByteString::must_from_utf8("Can't create a dictionary with keys of type void"sv)),((key)->span())))));
 }
 if (((current_value_type_id).equals(VOID_TYPE_ID))){
-TRY((((*this).error(TRY(ByteString::from_utf8("Can't create a dictionary with values of type void"sv)),((value)->span())))));
+TRY((((*this).error((ByteString::must_from_utf8("Can't create a dictionary with values of type void"sv)),((value)->span())))));
 }
 (key_type_id = current_key_type_id);
 (key_type_span = static_cast<JaktInternal::Optional<utility::Span>>(((key)->span())));
@@ -5392,20 +5392,20 @@ if (((key_hint).has_value())){
 (key_type_id = (key_hint.value()));
 }
 else {
-TRY((((*this).error(TRY(ByteString::from_utf8("Cannot infer key type for Dictionary<K, V>"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("Cannot infer key type for Dictionary<K, V>"sv)),span))));
 }
 
 }
 if ((!(((key_type_id).equals(types::unknown_type_id()))))){
-TRY((((*this).ensure_type_implements_trait(key_type_id,TRY(ByteString::from_utf8("Hashable"sv)),JaktInternal::OptionalNone(),scope_id,span))));
-TRY((((*this).ensure_type_implements_trait(key_type_id,TRY(ByteString::from_utf8("Equal"sv)),(TRY((DynamicArray<ids::TypeId>::create_with({key_type_id})))),scope_id,span))));
+TRY((((*this).ensure_type_implements_trait(key_type_id,(ByteString::must_from_utf8("Hashable"sv)),JaktInternal::OptionalNone(),scope_id,span))));
+TRY((((*this).ensure_type_implements_trait(key_type_id,(ByteString::must_from_utf8("Equal"sv)),(TRY((DynamicArray<ids::TypeId>::create_with({key_type_id})))),scope_id,span))));
 }
 if (((value_type_id).equals(types::unknown_type_id()))){
 if (((value_hint).has_value())){
 (value_type_id = (value_hint.value()));
 }
 else {
-TRY((((*this).error(TRY(ByteString::from_utf8("Cannot infer value type for Dictionary"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("Cannot infer value type for Dictionary"sv)),span))));
 }
 
 }
@@ -5417,7 +5417,7 @@ return TRY((types::CheckedExpression::JaktDictionary(JaktInternal::OptionalNone(
 ErrorOr<types::CheckedBlock> typechecker::Typechecker::typecheck_block(parser::ParsedBlock const parsed_block,ids::ScopeId const parent_scope_id,types::SafetyMode const safety_mode,JaktInternal::Optional<ids::TypeId> const yield_type_hint) {
 {
 bool const parent_throws = ((TRY((((*this).get_scope(parent_scope_id)))))->can_throw);
-ids::ScopeId const block_scope_id = TRY((((*this).create_scope(parent_scope_id,parent_throws,TRY(ByteString::from_utf8("block"sv)),true))));
+ids::ScopeId const block_scope_id = TRY((((*this).create_scope(parent_scope_id,parent_throws,(ByteString::must_from_utf8("block"sv)),true))));
 types::CheckedBlock checked_block = types::CheckedBlock((TRY((DynamicArray<NonnullRefPtr<typename types::CheckedStatement>>::create_with({})))),block_scope_id,types::BlockControlFlow::MayReturn(),ids::TypeId::none(),false);
 {
 JaktInternal::ArrayIterator<NonnullRefPtr<typename parser::ParsedStatement>> _magic = ((((parsed_block).stmts)).iterator());
@@ -5429,7 +5429,7 @@ break;
 NonnullRefPtr<typename parser::ParsedStatement> parsed_statement = (_magic_value.value());
 {
 if ((!(((((checked_block).control_flow)).is_reachable())))){
-TRY((((*this).error(TRY(ByteString::from_utf8("Unreachable code"sv)),((parsed_statement)->span())))));
+TRY((((*this).error((ByteString::must_from_utf8("Unreachable code"sv)),((parsed_statement)->span())))));
 }
 NonnullRefPtr<typename types::CheckedStatement> const checked_statement = TRY((((*this).typecheck_statement(parsed_statement,block_scope_id,safety_mode,yield_type_hint))));
 (((checked_block).control_flow) = ((((checked_block).control_flow)).updated(TRY((((*this).statement_control_flow(checked_statement)))))));
@@ -5510,8 +5510,8 @@ return checked_block;
 
 ErrorOr<void> typechecker::Typechecker::typecheck_jakt_main(parser::ParsedFunction const parsed_function,ids::ScopeId const parent_scope_id) {
 {
-ByteString const param_type_error = TRY(ByteString::from_utf8("Main function must take a single array of strings as its parameter"sv));
-JaktInternal::Optional<JaktInternal::DynamicArray<ids::FunctionId>> const func_ids = TRY((((*this).find_functions_with_name_in_scope(parent_scope_id,TRY(ByteString::from_utf8("main"sv)),JaktInternal::OptionalNone()))));
+ByteString const param_type_error = (ByteString::must_from_utf8("Main function must take a single array of strings as its parameter"sv));
+JaktInternal::Optional<JaktInternal::DynamicArray<ids::FunctionId>> const func_ids = TRY((((*this).find_functions_with_name_in_scope(parent_scope_id,(ByteString::must_from_utf8("main"sv)),JaktInternal::OptionalNone()))));
 if ([](size_t const& self, size_t rhs) -> bool {
 {
 return (((infallible_integer_cast<u8>(([](size_t const& self, size_t rhs) -> jakt__prelude__operators::Ordering {
@@ -5523,7 +5523,7 @@ return (infallible_enum_cast<jakt__prelude__operators::Ordering>((JaktInternal::
 }
 }
 ((((func_ids.value())).size()),static_cast<size_t>(1ULL))){
-TRY((((*this).error(TRY(ByteString::from_utf8("Function 'main' declared multiple times."sv)),((parsed_function).name_span)))));
+TRY((((*this).error((ByteString::must_from_utf8("Function 'main' declared multiple times."sv)),((parsed_function).name_span)))));
 }
 if ([](size_t const& self, size_t rhs) -> bool {
 {
@@ -5550,7 +5550,7 @@ if ([](ByteString const& self, ByteString rhs) -> bool {
 return (!(((self) == (rhs))));
 }
 }
-(name,TRY(ByteString::from_utf8("String"sv)))){
+(name,(ByteString::must_from_utf8("String"sv)))){
 TRY((((*this).error(param_type_error,span))));
 }
 }
@@ -5564,7 +5564,7 @@ TRY((((*this).error(param_type_error,((parsed_function).name_span)))));
 }
 
 }
-ByteString const return_type_error = TRY(ByteString::from_utf8("Main function must return c_int"sv));
+ByteString const return_type_error = (ByteString::must_from_utf8("Main function must return c_int"sv));
 ({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<void, ErrorOr<void>>{
 auto&& __jakt_match_variant = *((parsed_function).return_type);
@@ -5583,7 +5583,7 @@ if ([](ByteString const& self, ByteString rhs) -> bool {
 return (!(((self) == (rhs))));
 }
 }
-(name,TRY(ByteString::from_utf8("c_int"sv)))){
+(name,(ByteString::must_from_utf8("c_int"sv)))){
 TRY((((*this).error(return_type_error,span))));
 }
 }
@@ -5626,12 +5626,12 @@ if (((checked_lhs)->__jakt_init_index() == 24 /* Var */)){
 NonnullRefPtr<types::CheckedVariable> const var = (checked_lhs)->as.Var.var;
 utility::Span const span = (checked_lhs)->as.Var.span;
 if ((!(((var)->is_mutable)))){
-TRY((((*this).error_with_hint(TRY(ByteString::from_utf8("left-hand side of ??= must be a mutable variable"sv)),span,TRY(ByteString::from_utf8("This variable isn't marked as mutable"sv)),((var)->definition_span)))));
+TRY((((*this).error_with_hint((ByteString::must_from_utf8("left-hand side of ??= must be a mutable variable"sv)),span,(ByteString::must_from_utf8("This variable isn't marked as mutable"sv)),((var)->definition_span)))));
 return (Tuple{checked_operator, types::unknown_type_id()});
 }
 }
 else {
-TRY((((*this).error(TRY(ByteString::from_utf8("left-hand side of ??= must be a mutable variable"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("left-hand side of ??= must be a mutable variable"sv)),span))));
 return (Tuple{checked_operator, types::unknown_type_id()});
 }
 
@@ -5639,7 +5639,7 @@ return (Tuple{checked_operator, types::unknown_type_id()});
 if (((((*this).get_type(lhs_type_id)))->__jakt_init_index() == 20 /* GenericInstance */)){
 ids::StructId const id = (((*this).get_type(lhs_type_id)))->as.GenericInstance.id;
 JaktInternal::DynamicArray<ids::TypeId> const args = (((*this).get_type(lhs_type_id)))->as.GenericInstance.args;
-if (((id).equals(TRY((((*this).find_struct_in_prelude(TRY(ByteString::from_utf8("Optional"sv))))))))){
+if (((id).equals(TRY((((*this).find_struct_in_prelude((ByteString::must_from_utf8("Optional"sv))))))))){
 if (((lhs_type_id).equals(rhs_type_id))){
 return (Tuple{checked_operator, lhs_type_id});
 }
@@ -5649,12 +5649,12 @@ return (Tuple{checked_operator, inner_type_id});
 }
 }
 else {
-TRY((((*this).error_with_hint(TRY((__jakt_format((StringView::from_string_literal("None coalescing (??) with incompatible types (‘{}’ and ‘{}’)"sv)),TRY((((*this).type_name(lhs_type_id,false)))),TRY((((*this).type_name(rhs_type_id,false))))))),span,TRY(ByteString::from_utf8("Left side of ?? must be an Optional but isn't"sv)),lhs_span))));
+TRY((((*this).error_with_hint(TRY((__jakt_format((StringView::from_string_literal("None coalescing (??) with incompatible types (‘{}’ and ‘{}’)"sv)),TRY((((*this).type_name(lhs_type_id,false)))),TRY((((*this).type_name(rhs_type_id,false))))))),span,(ByteString::must_from_utf8("Left side of ?? must be an Optional but isn't"sv)),lhs_span))));
 }
 
 }
 else {
-TRY((((*this).error_with_hint(TRY((__jakt_format((StringView::from_string_literal("None coalescing (??) with incompatible types (‘{}’ and ‘{}’)"sv)),TRY((((*this).type_name(lhs_type_id,false)))),TRY((((*this).type_name(rhs_type_id,false))))))),span,TRY(ByteString::from_utf8("Left side of ?? must be an Optional but isn't"sv)),lhs_span))));
+TRY((((*this).error_with_hint(TRY((__jakt_format((StringView::from_string_literal("None coalescing (??) with incompatible types (‘{}’ and ‘{}’)"sv)),TRY((((*this).type_name(lhs_type_id,false)))),TRY((((*this).type_name(rhs_type_id,false))))))),span,(ByteString::must_from_utf8("Left side of ?? must be an Optional but isn't"sv)),lhs_span))));
 }
 
 TRY((((*this).error(TRY((__jakt_format((StringView::from_string_literal("None coalescing (??) with incompatible types (‘{}’ and ‘{}’)"sv)),TRY((((*this).type_name(lhs_type_id,false)))),TRY((((*this).type_name(rhs_type_id,false))))))),span))));
@@ -5669,12 +5669,12 @@ if (((checked_lhs)->__jakt_init_index() == 24 /* Var */)){
 NonnullRefPtr<types::CheckedVariable> const var = (checked_lhs)->as.Var.var;
 utility::Span const span = (checked_lhs)->as.Var.span;
 if ((!(((var)->is_mutable)))){
-TRY((((*this).error_with_hint(TRY(ByteString::from_utf8("left-hand side of ??= must be a mutable variable"sv)),span,TRY(ByteString::from_utf8("This variable isn't marked as mutable"sv)),((var)->definition_span)))));
+TRY((((*this).error_with_hint((ByteString::must_from_utf8("left-hand side of ??= must be a mutable variable"sv)),span,(ByteString::must_from_utf8("This variable isn't marked as mutable"sv)),((var)->definition_span)))));
 return (Tuple{checked_operator, types::unknown_type_id()});
 }
 }
 else {
-TRY((((*this).error(TRY(ByteString::from_utf8("left-hand side of ??= must be a mutable variable"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("left-hand side of ??= must be a mutable variable"sv)),span))));
 return (Tuple{checked_operator, types::unknown_type_id()});
 }
 
@@ -5682,7 +5682,7 @@ return (Tuple{checked_operator, types::unknown_type_id()});
 if (((((*this).get_type(lhs_type_id)))->__jakt_init_index() == 20 /* GenericInstance */)){
 ids::StructId const id = (((*this).get_type(lhs_type_id)))->as.GenericInstance.id;
 JaktInternal::DynamicArray<ids::TypeId> const args = (((*this).get_type(lhs_type_id)))->as.GenericInstance.args;
-if (((id).equals(TRY((((*this).find_struct_in_prelude(TRY(ByteString::from_utf8("Optional"sv))))))))){
+if (((id).equals(TRY((((*this).find_struct_in_prelude((ByteString::must_from_utf8("Optional"sv))))))))){
 if (((lhs_type_id).equals(rhs_type_id))){
 return (Tuple{checked_operator, lhs_type_id});
 }
@@ -5692,12 +5692,12 @@ return (Tuple{checked_operator, inner_type_id});
 }
 }
 else {
-TRY((((*this).error_with_hint(TRY((__jakt_format((StringView::from_string_literal("None coalescing (??) with incompatible types (‘{}’ and ‘{}’)"sv)),TRY((((*this).type_name(lhs_type_id,false)))),TRY((((*this).type_name(rhs_type_id,false))))))),span,TRY(ByteString::from_utf8("Left side of ?? must be an Optional but isn't"sv)),lhs_span))));
+TRY((((*this).error_with_hint(TRY((__jakt_format((StringView::from_string_literal("None coalescing (??) with incompatible types (‘{}’ and ‘{}’)"sv)),TRY((((*this).type_name(lhs_type_id,false)))),TRY((((*this).type_name(rhs_type_id,false))))))),span,(ByteString::must_from_utf8("Left side of ?? must be an Optional but isn't"sv)),lhs_span))));
 }
 
 }
 else {
-TRY((((*this).error_with_hint(TRY((__jakt_format((StringView::from_string_literal("None coalescing (??) with incompatible types (‘{}’ and ‘{}’)"sv)),TRY((((*this).type_name(lhs_type_id,false)))),TRY((((*this).type_name(rhs_type_id,false))))))),span,TRY(ByteString::from_utf8("Left side of ?? must be an Optional but isn't"sv)),lhs_span))));
+TRY((((*this).error_with_hint(TRY((__jakt_format((StringView::from_string_literal("None coalescing (??) with incompatible types (‘{}’ and ‘{}’)"sv)),TRY((((*this).type_name(lhs_type_id,false)))),TRY((((*this).type_name(rhs_type_id,false))))))),span,(ByteString::must_from_utf8("Left side of ?? must be an Optional but isn't"sv)),lhs_span))));
 }
 
 TRY((((*this).error(TRY((__jakt_format((StringView::from_string_literal("None coalescing (??) with incompatible types (‘{}’ and ‘{}’)"sv)),TRY((((*this).type_name(lhs_type_id,false)))),TRY((((*this).type_name(rhs_type_id,false))))))),span))));
@@ -5708,10 +5708,10 @@ return JaktInternal::ExplicitValue<void>();
 case 18 /* LogicalAnd */: {
 {
 if ((!(((lhs_type_id).equals(types::builtin(types::BuiltinType::Bool())))))){
-TRY((((*this).error(TRY(ByteString::from_utf8("left side of logical binary operation is not a boolean"sv)),lhs_span))));
+TRY((((*this).error((ByteString::must_from_utf8("left side of logical binary operation is not a boolean"sv)),lhs_span))));
 }
 if ((!(((rhs_type_id).equals(types::builtin(types::BuiltinType::Bool())))))){
-TRY((((*this).error(TRY(ByteString::from_utf8("right side of logical binary operation is not a boolean"sv)),rhs_span))));
+TRY((((*this).error((ByteString::must_from_utf8("right side of logical binary operation is not a boolean"sv)),rhs_span))));
 }
 (type_id = types::builtin(types::BuiltinType::Bool()));
 }
@@ -5720,10 +5720,10 @@ return JaktInternal::ExplicitValue<void>();
 case 19 /* LogicalOr */: {
 {
 if ((!(((lhs_type_id).equals(types::builtin(types::BuiltinType::Bool())))))){
-TRY((((*this).error(TRY(ByteString::from_utf8("left side of logical binary operation is not a boolean"sv)),lhs_span))));
+TRY((((*this).error((ByteString::must_from_utf8("left side of logical binary operation is not a boolean"sv)),lhs_span))));
 }
 if ((!(((rhs_type_id).equals(types::builtin(types::BuiltinType::Bool())))))){
-TRY((((*this).error(TRY(ByteString::from_utf8("right side of logical binary operation is not a boolean"sv)),rhs_span))));
+TRY((((*this).error((ByteString::must_from_utf8("right side of logical binary operation is not a boolean"sv)),rhs_span))));
 }
 (type_id = types::builtin(types::BuiltinType::Bool()));
 }
@@ -5732,7 +5732,7 @@ return JaktInternal::ExplicitValue<void>();
 case 21 /* Assign */: {
 {
 if ((!(((checked_lhs)->is_mutable(((*this).program)))))){
-TRY((((*this).error(TRY(ByteString::from_utf8("Assignment to immutable variable"sv)),((checked_lhs)->span())))));
+TRY((((*this).error((ByteString::must_from_utf8("Assignment to immutable variable"sv)),((checked_lhs)->span())))));
 return (Tuple{checked_operator, lhs_type_id});
 }
 if (((checked_rhs)->__jakt_init_index() == 25 /* OptionalNone */)){
@@ -5741,15 +5741,15 @@ ids::TypeId const type_id = (checked_rhs)->as.OptionalNone.type_id;
 if (((((*this).get_type(lhs_type_id)))->__jakt_init_index() == 20 /* GenericInstance */)){
 ids::StructId const id = (((*this).get_type(lhs_type_id)))->as.GenericInstance.id;
 JaktInternal::DynamicArray<ids::TypeId> const args = (((*this).get_type(lhs_type_id)))->as.GenericInstance.args;
-if (((id).equals(TRY((((*this).find_struct_in_prelude(TRY(ByteString::from_utf8("Optional"sv))))))))){
+if (((id).equals(TRY((((*this).find_struct_in_prelude((ByteString::must_from_utf8("Optional"sv))))))))){
 return (Tuple{checked_operator, lhs_type_id});
 }
-if ((!(((id).equals(TRY((((*this).find_struct_in_prelude(TRY(ByteString::from_utf8("WeakPtr"sv))))))))))){
-TRY((((*this).error(TRY(ByteString::from_utf8("Cannot assign None to a non-optional type"sv)),span))));
+if ((!(((id).equals(TRY((((*this).find_struct_in_prelude((ByteString::must_from_utf8("WeakPtr"sv))))))))))){
+TRY((((*this).error((ByteString::must_from_utf8("Cannot assign None to a non-optional type"sv)),span))));
 }
 }
 else {
-TRY((((*this).error(TRY(ByteString::from_utf8("Cannot assign None to a non-optional type"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("Cannot assign None to a non-optional type"sv)),span))));
 }
 
 }
@@ -5757,7 +5757,7 @@ NonnullRefPtr<typename types::Type> const lhs_type = TRY((((*this).unwrap_type_f
 if (((lhs_type)->__jakt_init_index() == 20 /* GenericInstance */)){
 ids::StructId const id = (lhs_type)->as.GenericInstance.id;
 JaktInternal::DynamicArray<ids::TypeId> const args = (lhs_type)->as.GenericInstance.args;
-if ((((((((((*this).program))->get_struct(id))).name)) == (TRY(ByteString::from_utf8("WeakPtr"sv)))) && (!(((lhs_type_id).equals(rhs_type_id)))))){
+if ((((((((((*this).program))->get_struct(id))).name)) == ((ByteString::must_from_utf8("WeakPtr"sv)))) && (!(((lhs_type_id).equals(rhs_type_id)))))){
 JaktInternal::Optional<ids::TypeId> const unified_type = TRY((((*this).unify(((args)[static_cast<i64>(0LL)]),lhs_span,((checked_rhs)->type()),rhs_span))));
 if (((unified_type).has_value())){
 return (Tuple{checked_operator, (unified_type.value())});
@@ -5781,67 +5781,67 @@ JaktInternal::Tuple<JaktInternal::DynamicArray<ByteString>,bool> const trait_nam
 auto&& __jakt_match_variant = op;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 0 /* Add */: {
-return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("Add"sv)), TRY(ByteString::from_utf8("ThrowingAdd"sv))})))), false}));
+return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("Add"sv)), (ByteString::must_from_utf8("ThrowingAdd"sv))})))), false}));
 };/*case end*/
 case 1 /* Subtract */: {
-return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("Subtract"sv)), TRY(ByteString::from_utf8("ThrowingSubtract"sv))})))), false}));
+return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("Subtract"sv)), (ByteString::must_from_utf8("ThrowingSubtract"sv))})))), false}));
 };/*case end*/
 case 2 /* Multiply */: {
-return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("Multiply"sv)), TRY(ByteString::from_utf8("ThrowingMultiply"sv))})))), false}));
+return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("Multiply"sv)), (ByteString::must_from_utf8("ThrowingMultiply"sv))})))), false}));
 };/*case end*/
 case 3 /* Divide */: {
-return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("Divide"sv)), TRY(ByteString::from_utf8("ThrowingDivide"sv))})))), false}));
+return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("Divide"sv)), (ByteString::must_from_utf8("ThrowingDivide"sv))})))), false}));
 };/*case end*/
 case 4 /* Modulo */: {
-return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("Modulo"sv)), TRY(ByteString::from_utf8("ThrowingModulo"sv))})))), false}));
+return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("Modulo"sv)), (ByteString::must_from_utf8("ThrowingModulo"sv))})))), false}));
 };/*case end*/
 case 5 /* LessThan */: {
-return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("Compare"sv)), TRY(ByteString::from_utf8("ThrowingCompare"sv))})))), false}));
+return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("Compare"sv)), (ByteString::must_from_utf8("ThrowingCompare"sv))})))), false}));
 };/*case end*/
 case 6 /* LessThanOrEqual */: {
-return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("Compare"sv)), TRY(ByteString::from_utf8("ThrowingCompare"sv))})))), false}));
+return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("Compare"sv)), (ByteString::must_from_utf8("ThrowingCompare"sv))})))), false}));
 };/*case end*/
 case 7 /* GreaterThan */: {
-return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("Compare"sv)), TRY(ByteString::from_utf8("ThrowingCompare"sv))})))), false}));
+return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("Compare"sv)), (ByteString::must_from_utf8("ThrowingCompare"sv))})))), false}));
 };/*case end*/
 case 8 /* GreaterThanOrEqual */: {
-return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("Compare"sv)), TRY(ByteString::from_utf8("ThrowingCompare"sv))})))), false}));
+return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("Compare"sv)), (ByteString::must_from_utf8("ThrowingCompare"sv))})))), false}));
 };/*case end*/
 case 9 /* Equal */: {
-return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("Equal"sv)), TRY(ByteString::from_utf8("ThrowingEqual"sv))})))), false}));
+return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("Equal"sv)), (ByteString::must_from_utf8("ThrowingEqual"sv))})))), false}));
 };/*case end*/
 case 10 /* NotEqual */: {
-return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("Equal"sv)), TRY(ByteString::from_utf8("ThrowingEqual"sv))})))), false}));
+return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("Equal"sv)), (ByteString::must_from_utf8("ThrowingEqual"sv))})))), false}));
 };/*case end*/
 case 27 /* AddAssign */: {
-return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("AddAssign"sv)), TRY(ByteString::from_utf8("ThrowingAddAssign"sv))})))), true}));
+return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("AddAssign"sv)), (ByteString::must_from_utf8("ThrowingAddAssign"sv))})))), true}));
 };/*case end*/
 case 28 /* SubtractAssign */: {
-return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("SubtractAssign"sv)), TRY(ByteString::from_utf8("ThrowingSubtractAssign"sv))})))), true}));
+return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("SubtractAssign"sv)), (ByteString::must_from_utf8("ThrowingSubtractAssign"sv))})))), true}));
 };/*case end*/
 case 29 /* MultiplyAssign */: {
-return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("MultiplyAssign"sv)), TRY(ByteString::from_utf8("ThrowingMultiplyAssign"sv))})))), true}));
+return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("MultiplyAssign"sv)), (ByteString::must_from_utf8("ThrowingMultiplyAssign"sv))})))), true}));
 };/*case end*/
 case 31 /* DivideAssign */: {
-return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("DivideAssign"sv)), TRY(ByteString::from_utf8("ThrowingDivideAssign"sv))})))), true}));
+return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("DivideAssign"sv)), (ByteString::must_from_utf8("ThrowingDivideAssign"sv))})))), true}));
 };/*case end*/
 case 30 /* ModuloAssign */: {
-return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("ModuloAssign"sv)), TRY(ByteString::from_utf8("ThrowingModuloAssign"sv))})))), true}));
+return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("ModuloAssign"sv)), (ByteString::must_from_utf8("ThrowingModuloAssign"sv))})))), true}));
 };/*case end*/
 case 22 /* BitwiseAndAssign */: {
-return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("BitwiseAndAssign"sv)), TRY(ByteString::from_utf8("ThrowingBitwiseAndAssign"sv))})))), true}));
+return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("BitwiseAndAssign"sv)), (ByteString::must_from_utf8("ThrowingBitwiseAndAssign"sv))})))), true}));
 };/*case end*/
 case 23 /* BitwiseOrAssign */: {
-return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("BitwiseOrAssign"sv)), TRY(ByteString::from_utf8("ThrowingBitwiseOrAssign"sv))})))), true}));
+return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("BitwiseOrAssign"sv)), (ByteString::must_from_utf8("ThrowingBitwiseOrAssign"sv))})))), true}));
 };/*case end*/
 case 24 /* BitwiseXorAssign */: {
-return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("BitwiseXorAssign"sv)), TRY(ByteString::from_utf8("ThrowingBitwiseXorAssign"sv))})))), true}));
+return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("BitwiseXorAssign"sv)), (ByteString::must_from_utf8("ThrowingBitwiseXorAssign"sv))})))), true}));
 };/*case end*/
 case 25 /* BitwiseLeftShiftAssign */: {
-return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("BitwiseLeftShiftAssign"sv)), TRY(ByteString::from_utf8("ThrowingBitwiseLeftShiftAssign"sv))})))), true}));
+return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("BitwiseLeftShiftAssign"sv)), (ByteString::must_from_utf8("ThrowingBitwiseLeftShiftAssign"sv))})))), true}));
 };/*case end*/
 case 26 /* BitwiseRightShiftAssign */: {
-return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("BitwiseRightShiftAssign"sv)), TRY(ByteString::from_utf8("ThrowingBitwiseRightShiftAssign"sv))})))), true}));
+return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("BitwiseRightShiftAssign"sv)), (ByteString::must_from_utf8("ThrowingBitwiseRightShiftAssign"sv))})))), true}));
 };/*case end*/
 default: {
 return JaktInternal::ExplicitValue((Tuple{empty_array, false}));
@@ -5861,70 +5861,70 @@ ByteString const function_name = ({
 auto&& __jakt_match_variant = op;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 0 /* Add */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("add"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("add"sv)));
 };/*case end*/
 case 1 /* Subtract */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("subtract"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("subtract"sv)));
 };/*case end*/
 case 2 /* Multiply */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("multiply"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("multiply"sv)));
 };/*case end*/
 case 3 /* Divide */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("divide"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("divide"sv)));
 };/*case end*/
 case 4 /* Modulo */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("modulo"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("modulo"sv)));
 };/*case end*/
 case 5 /* LessThan */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("less_than"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("less_than"sv)));
 };/*case end*/
 case 6 /* LessThanOrEqual */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("less_than_or_equal"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("less_than_or_equal"sv)));
 };/*case end*/
 case 7 /* GreaterThan */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("greater_than"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("greater_than"sv)));
 };/*case end*/
 case 8 /* GreaterThanOrEqual */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("greater_than_or_equal"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("greater_than_or_equal"sv)));
 };/*case end*/
 case 9 /* Equal */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("equals"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("equals"sv)));
 };/*case end*/
 case 10 /* NotEqual */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("not_equals"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("not_equals"sv)));
 };/*case end*/
 case 27 /* AddAssign */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("add_assign"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("add_assign"sv)));
 };/*case end*/
 case 28 /* SubtractAssign */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("subtract_assign"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("subtract_assign"sv)));
 };/*case end*/
 case 29 /* MultiplyAssign */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("multiply_assign"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("multiply_assign"sv)));
 };/*case end*/
 case 31 /* DivideAssign */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("divide_assign"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("divide_assign"sv)));
 };/*case end*/
 case 30 /* ModuloAssign */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("modulo_assign"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("modulo_assign"sv)));
 };/*case end*/
 case 22 /* BitwiseAndAssign */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("bitwise_and_assign"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("bitwise_and_assign"sv)));
 };/*case end*/
 case 23 /* BitwiseOrAssign */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("bitwise_or_assign"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("bitwise_or_assign"sv)));
 };/*case end*/
 case 24 /* BitwiseXorAssign */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("bitwise_xor_assign"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("bitwise_xor_assign"sv)));
 };/*case end*/
 case 25 /* BitwiseLeftShiftAssign */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("bitwise_left_shift_assign"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("bitwise_left_shift_assign"sv)));
 };/*case end*/
 case 26 /* BitwiseRightShiftAssign */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("bitwise_right_shift_assign"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("bitwise_right_shift_assign"sv)));
 };/*case end*/
 default: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8(""sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8(""sv)));
 };/*case end*/
 }/*switch end*/
 }()
@@ -5936,8 +5936,8 @@ return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8(""sv)));
 JaktInternal::Optional<typechecker::TraitImplementationDescriptor> const add_trait_implementation = TRY((((*this).find_any_singular_trait_implementation(lhs_type_id,trait_names,scope_id,lhs_span,(TRY((DynamicArray<ids::TypeId>::create_with({rhs_type_id}))))))));
 if (((add_trait_implementation).has_value())){
 typechecker::TraitImplementationDescriptor const implementation = (add_trait_implementation.value());
-if ((((((implementation).trait_name)).starts_with(TRY(ByteString::from_utf8("Throwing"sv)))) && (!(((scope)->can_throw))))){
-TRY((((*this).error(TRY(ByteString::from_utf8("Call to function that may throw needs to be in a try statement or a function marked as throws"sv)),span))));
+if ((((((implementation).trait_name)).starts_with((ByteString::must_from_utf8("Throwing"sv)))) && (!(((scope)->can_throw))))){
+TRY((((*this).error((ByteString::must_from_utf8("Call to function that may throw needs to be in a try statement or a function marked as throws"sv)),span))));
 }
 JaktInternal::Tuple<JaktInternal::Optional<types::StructLikeId>,bool> const parent_id___ = TRY((((*this).struct_like_id_from_type_id(lhs_type_id,scope_id,span,false,true))));
 JaktInternal::Optional<types::StructLikeId> const parent_id = ((parent_id___).template get<0>());
@@ -5948,15 +5948,15 @@ if (((implementation_function_id).has_value())){
 NonnullRefPtr<types::CheckedFunction> const implementation_function = ((*this).get_function((implementation_function_id.value())));
 if ((TRY((((implementation_function)->is_mutating()))) && (!(((checked_lhs)->is_mutable(((*this).program))))))){
 if (is_assignment){
-TRY((((*this).error(TRY(ByteString::from_utf8("Assignment to immutable variable"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("Assignment to immutable variable"sv)),span))));
 }
 else {
-TRY((((*this).error(TRY(ByteString::from_utf8("Cannot call mutating function on an immutable object instance"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("Cannot call mutating function on an immutable object instance"sv)),span))));
 }
 
 }
 (type_id = ((implementation_function)->return_type_id));
-types::CheckedCall call_expression = types::CheckedCall((TRY((DynamicArray<types::ResolvedNamespace>::create_with({})))),function_name,(TRY((DynamicArray<JaktInternal::Tuple<ByteString,NonnullRefPtr<typename types::CheckedExpression>>>::create_with({(Tuple{TRY(ByteString::from_utf8(""sv)), checked_rhs})})))),(TRY((DynamicArray<ids::TypeId>::create_with({})))),implementation_function_id,type_id,((implementation_function)->can_throw),((implementation_function)->external_name),((implementation_function)->force_inline));
+types::CheckedCall call_expression = types::CheckedCall((TRY((DynamicArray<types::ResolvedNamespace>::create_with({})))),function_name,(TRY((DynamicArray<JaktInternal::Tuple<ByteString,NonnullRefPtr<typename types::CheckedExpression>>>::create_with({(Tuple{(ByteString::must_from_utf8(""sv)), checked_rhs})})))),(TRY((DynamicArray<ids::TypeId>::create_with({})))),implementation_function_id,type_id,((implementation_function)->can_throw),((implementation_function)->external_name),((implementation_function)->force_inline));
 (((checked_operator).trait_implementation) = types::OperatorTraitImplementation(((implementation).trait_id),((implementation).implemented_type_args),call_expression));
 }
 else {
@@ -6033,67 +6033,67 @@ JaktInternal::Tuple<JaktInternal::DynamicArray<ByteString>,bool> const trait_nam
 auto&& __jakt_match_variant = op;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 0 /* Add */: {
-return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("Add"sv)), TRY(ByteString::from_utf8("ThrowingAdd"sv))})))), false}));
+return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("Add"sv)), (ByteString::must_from_utf8("ThrowingAdd"sv))})))), false}));
 };/*case end*/
 case 1 /* Subtract */: {
-return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("Subtract"sv)), TRY(ByteString::from_utf8("ThrowingSubtract"sv))})))), false}));
+return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("Subtract"sv)), (ByteString::must_from_utf8("ThrowingSubtract"sv))})))), false}));
 };/*case end*/
 case 2 /* Multiply */: {
-return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("Multiply"sv)), TRY(ByteString::from_utf8("ThrowingMultiply"sv))})))), false}));
+return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("Multiply"sv)), (ByteString::must_from_utf8("ThrowingMultiply"sv))})))), false}));
 };/*case end*/
 case 3 /* Divide */: {
-return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("Divide"sv)), TRY(ByteString::from_utf8("ThrowingDivide"sv))})))), false}));
+return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("Divide"sv)), (ByteString::must_from_utf8("ThrowingDivide"sv))})))), false}));
 };/*case end*/
 case 4 /* Modulo */: {
-return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("Modulo"sv)), TRY(ByteString::from_utf8("ThrowingModulo"sv))})))), false}));
+return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("Modulo"sv)), (ByteString::must_from_utf8("ThrowingModulo"sv))})))), false}));
 };/*case end*/
 case 5 /* LessThan */: {
-return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("Compare"sv)), TRY(ByteString::from_utf8("ThrowingCompare"sv))})))), false}));
+return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("Compare"sv)), (ByteString::must_from_utf8("ThrowingCompare"sv))})))), false}));
 };/*case end*/
 case 6 /* LessThanOrEqual */: {
-return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("Compare"sv)), TRY(ByteString::from_utf8("ThrowingCompare"sv))})))), false}));
+return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("Compare"sv)), (ByteString::must_from_utf8("ThrowingCompare"sv))})))), false}));
 };/*case end*/
 case 7 /* GreaterThan */: {
-return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("Compare"sv)), TRY(ByteString::from_utf8("ThrowingCompare"sv))})))), false}));
+return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("Compare"sv)), (ByteString::must_from_utf8("ThrowingCompare"sv))})))), false}));
 };/*case end*/
 case 8 /* GreaterThanOrEqual */: {
-return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("Compare"sv)), TRY(ByteString::from_utf8("ThrowingCompare"sv))})))), false}));
+return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("Compare"sv)), (ByteString::must_from_utf8("ThrowingCompare"sv))})))), false}));
 };/*case end*/
 case 9 /* Equal */: {
-return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("Equal"sv)), TRY(ByteString::from_utf8("ThrowingEqual"sv))})))), false}));
+return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("Equal"sv)), (ByteString::must_from_utf8("ThrowingEqual"sv))})))), false}));
 };/*case end*/
 case 10 /* NotEqual */: {
-return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("Equal"sv)), TRY(ByteString::from_utf8("ThrowingEqual"sv))})))), false}));
+return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("Equal"sv)), (ByteString::must_from_utf8("ThrowingEqual"sv))})))), false}));
 };/*case end*/
 case 27 /* AddAssign */: {
-return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("AddAssign"sv)), TRY(ByteString::from_utf8("ThrowingAddAssign"sv))})))), true}));
+return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("AddAssign"sv)), (ByteString::must_from_utf8("ThrowingAddAssign"sv))})))), true}));
 };/*case end*/
 case 28 /* SubtractAssign */: {
-return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("SubtractAssign"sv)), TRY(ByteString::from_utf8("ThrowingSubtractAssign"sv))})))), true}));
+return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("SubtractAssign"sv)), (ByteString::must_from_utf8("ThrowingSubtractAssign"sv))})))), true}));
 };/*case end*/
 case 29 /* MultiplyAssign */: {
-return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("MultiplyAssign"sv)), TRY(ByteString::from_utf8("ThrowingMultiplyAssign"sv))})))), true}));
+return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("MultiplyAssign"sv)), (ByteString::must_from_utf8("ThrowingMultiplyAssign"sv))})))), true}));
 };/*case end*/
 case 31 /* DivideAssign */: {
-return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("DivideAssign"sv)), TRY(ByteString::from_utf8("ThrowingDivideAssign"sv))})))), true}));
+return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("DivideAssign"sv)), (ByteString::must_from_utf8("ThrowingDivideAssign"sv))})))), true}));
 };/*case end*/
 case 30 /* ModuloAssign */: {
-return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("ModuloAssign"sv)), TRY(ByteString::from_utf8("ThrowingModuloAssign"sv))})))), true}));
+return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("ModuloAssign"sv)), (ByteString::must_from_utf8("ThrowingModuloAssign"sv))})))), true}));
 };/*case end*/
 case 22 /* BitwiseAndAssign */: {
-return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("BitwiseAndAssign"sv)), TRY(ByteString::from_utf8("ThrowingBitwiseAndAssign"sv))})))), true}));
+return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("BitwiseAndAssign"sv)), (ByteString::must_from_utf8("ThrowingBitwiseAndAssign"sv))})))), true}));
 };/*case end*/
 case 23 /* BitwiseOrAssign */: {
-return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("BitwiseOrAssign"sv)), TRY(ByteString::from_utf8("ThrowingBitwiseOrAssign"sv))})))), true}));
+return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("BitwiseOrAssign"sv)), (ByteString::must_from_utf8("ThrowingBitwiseOrAssign"sv))})))), true}));
 };/*case end*/
 case 24 /* BitwiseXorAssign */: {
-return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("BitwiseXorAssign"sv)), TRY(ByteString::from_utf8("ThrowingBitwiseXorAssign"sv))})))), true}));
+return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("BitwiseXorAssign"sv)), (ByteString::must_from_utf8("ThrowingBitwiseXorAssign"sv))})))), true}));
 };/*case end*/
 case 25 /* BitwiseLeftShiftAssign */: {
-return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("BitwiseLeftShiftAssign"sv)), TRY(ByteString::from_utf8("ThrowingBitwiseLeftShiftAssign"sv))})))), true}));
+return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("BitwiseLeftShiftAssign"sv)), (ByteString::must_from_utf8("ThrowingBitwiseLeftShiftAssign"sv))})))), true}));
 };/*case end*/
 case 26 /* BitwiseRightShiftAssign */: {
-return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("BitwiseRightShiftAssign"sv)), TRY(ByteString::from_utf8("ThrowingBitwiseRightShiftAssign"sv))})))), true}));
+return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("BitwiseRightShiftAssign"sv)), (ByteString::must_from_utf8("ThrowingBitwiseRightShiftAssign"sv))})))), true}));
 };/*case end*/
 default: {
 return JaktInternal::ExplicitValue((Tuple{empty_array, false}));
@@ -6113,70 +6113,70 @@ ByteString const function_name = ({
 auto&& __jakt_match_variant = op;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 0 /* Add */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("add"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("add"sv)));
 };/*case end*/
 case 1 /* Subtract */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("subtract"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("subtract"sv)));
 };/*case end*/
 case 2 /* Multiply */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("multiply"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("multiply"sv)));
 };/*case end*/
 case 3 /* Divide */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("divide"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("divide"sv)));
 };/*case end*/
 case 4 /* Modulo */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("modulo"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("modulo"sv)));
 };/*case end*/
 case 5 /* LessThan */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("less_than"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("less_than"sv)));
 };/*case end*/
 case 6 /* LessThanOrEqual */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("less_than_or_equal"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("less_than_or_equal"sv)));
 };/*case end*/
 case 7 /* GreaterThan */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("greater_than"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("greater_than"sv)));
 };/*case end*/
 case 8 /* GreaterThanOrEqual */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("greater_than_or_equal"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("greater_than_or_equal"sv)));
 };/*case end*/
 case 9 /* Equal */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("equals"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("equals"sv)));
 };/*case end*/
 case 10 /* NotEqual */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("not_equals"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("not_equals"sv)));
 };/*case end*/
 case 27 /* AddAssign */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("add_assign"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("add_assign"sv)));
 };/*case end*/
 case 28 /* SubtractAssign */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("subtract_assign"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("subtract_assign"sv)));
 };/*case end*/
 case 29 /* MultiplyAssign */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("multiply_assign"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("multiply_assign"sv)));
 };/*case end*/
 case 31 /* DivideAssign */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("divide_assign"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("divide_assign"sv)));
 };/*case end*/
 case 30 /* ModuloAssign */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("modulo_assign"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("modulo_assign"sv)));
 };/*case end*/
 case 22 /* BitwiseAndAssign */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("bitwise_and_assign"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("bitwise_and_assign"sv)));
 };/*case end*/
 case 23 /* BitwiseOrAssign */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("bitwise_or_assign"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("bitwise_or_assign"sv)));
 };/*case end*/
 case 24 /* BitwiseXorAssign */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("bitwise_xor_assign"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("bitwise_xor_assign"sv)));
 };/*case end*/
 case 25 /* BitwiseLeftShiftAssign */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("bitwise_left_shift_assign"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("bitwise_left_shift_assign"sv)));
 };/*case end*/
 case 26 /* BitwiseRightShiftAssign */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("bitwise_right_shift_assign"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("bitwise_right_shift_assign"sv)));
 };/*case end*/
 default: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8(""sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8(""sv)));
 };/*case end*/
 }/*switch end*/
 }()
@@ -6188,8 +6188,8 @@ return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8(""sv)));
 JaktInternal::Optional<typechecker::TraitImplementationDescriptor> const add_trait_implementation = TRY((((*this).find_any_singular_trait_implementation(lhs_type_id,trait_names,scope_id,lhs_span,(TRY((DynamicArray<ids::TypeId>::create_with({rhs_type_id}))))))));
 if (((add_trait_implementation).has_value())){
 typechecker::TraitImplementationDescriptor const implementation = (add_trait_implementation.value());
-if ((((((implementation).trait_name)).starts_with(TRY(ByteString::from_utf8("Throwing"sv)))) && (!(((scope)->can_throw))))){
-TRY((((*this).error(TRY(ByteString::from_utf8("Call to function that may throw needs to be in a try statement or a function marked as throws"sv)),span))));
+if ((((((implementation).trait_name)).starts_with((ByteString::must_from_utf8("Throwing"sv)))) && (!(((scope)->can_throw))))){
+TRY((((*this).error((ByteString::must_from_utf8("Call to function that may throw needs to be in a try statement or a function marked as throws"sv)),span))));
 }
 JaktInternal::Tuple<JaktInternal::Optional<types::StructLikeId>,bool> const parent_id___ = TRY((((*this).struct_like_id_from_type_id(lhs_type_id,scope_id,span,false,true))));
 JaktInternal::Optional<types::StructLikeId> const parent_id = ((parent_id___).template get<0>());
@@ -6200,15 +6200,15 @@ if (((implementation_function_id).has_value())){
 NonnullRefPtr<types::CheckedFunction> const implementation_function = ((*this).get_function((implementation_function_id.value())));
 if ((TRY((((implementation_function)->is_mutating()))) && (!(((checked_lhs)->is_mutable(((*this).program))))))){
 if (is_assignment){
-TRY((((*this).error(TRY(ByteString::from_utf8("Assignment to immutable variable"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("Assignment to immutable variable"sv)),span))));
 }
 else {
-TRY((((*this).error(TRY(ByteString::from_utf8("Cannot call mutating function on an immutable object instance"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("Cannot call mutating function on an immutable object instance"sv)),span))));
 }
 
 }
 (type_id = ((implementation_function)->return_type_id));
-types::CheckedCall call_expression = types::CheckedCall((TRY((DynamicArray<types::ResolvedNamespace>::create_with({})))),function_name,(TRY((DynamicArray<JaktInternal::Tuple<ByteString,NonnullRefPtr<typename types::CheckedExpression>>>::create_with({(Tuple{TRY(ByteString::from_utf8(""sv)), checked_rhs})})))),(TRY((DynamicArray<ids::TypeId>::create_with({})))),implementation_function_id,type_id,((implementation_function)->can_throw),((implementation_function)->external_name),((implementation_function)->force_inline));
+types::CheckedCall call_expression = types::CheckedCall((TRY((DynamicArray<types::ResolvedNamespace>::create_with({})))),function_name,(TRY((DynamicArray<JaktInternal::Tuple<ByteString,NonnullRefPtr<typename types::CheckedExpression>>>::create_with({(Tuple{(ByteString::must_from_utf8(""sv)), checked_rhs})})))),(TRY((DynamicArray<ids::TypeId>::create_with({})))),implementation_function_id,type_id,((implementation_function)->can_throw),((implementation_function)->external_name),((implementation_function)->force_inline));
 (((checked_operator).trait_implementation) = types::OperatorTraitImplementation(((implementation).trait_id),((implementation).implemented_type_args),call_expression));
 }
 else {
@@ -6285,67 +6285,67 @@ JaktInternal::Tuple<JaktInternal::DynamicArray<ByteString>,bool> const trait_nam
 auto&& __jakt_match_variant = op;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 0 /* Add */: {
-return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("Add"sv)), TRY(ByteString::from_utf8("ThrowingAdd"sv))})))), false}));
+return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("Add"sv)), (ByteString::must_from_utf8("ThrowingAdd"sv))})))), false}));
 };/*case end*/
 case 1 /* Subtract */: {
-return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("Subtract"sv)), TRY(ByteString::from_utf8("ThrowingSubtract"sv))})))), false}));
+return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("Subtract"sv)), (ByteString::must_from_utf8("ThrowingSubtract"sv))})))), false}));
 };/*case end*/
 case 2 /* Multiply */: {
-return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("Multiply"sv)), TRY(ByteString::from_utf8("ThrowingMultiply"sv))})))), false}));
+return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("Multiply"sv)), (ByteString::must_from_utf8("ThrowingMultiply"sv))})))), false}));
 };/*case end*/
 case 3 /* Divide */: {
-return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("Divide"sv)), TRY(ByteString::from_utf8("ThrowingDivide"sv))})))), false}));
+return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("Divide"sv)), (ByteString::must_from_utf8("ThrowingDivide"sv))})))), false}));
 };/*case end*/
 case 4 /* Modulo */: {
-return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("Modulo"sv)), TRY(ByteString::from_utf8("ThrowingModulo"sv))})))), false}));
+return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("Modulo"sv)), (ByteString::must_from_utf8("ThrowingModulo"sv))})))), false}));
 };/*case end*/
 case 5 /* LessThan */: {
-return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("Compare"sv)), TRY(ByteString::from_utf8("ThrowingCompare"sv))})))), false}));
+return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("Compare"sv)), (ByteString::must_from_utf8("ThrowingCompare"sv))})))), false}));
 };/*case end*/
 case 6 /* LessThanOrEqual */: {
-return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("Compare"sv)), TRY(ByteString::from_utf8("ThrowingCompare"sv))})))), false}));
+return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("Compare"sv)), (ByteString::must_from_utf8("ThrowingCompare"sv))})))), false}));
 };/*case end*/
 case 7 /* GreaterThan */: {
-return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("Compare"sv)), TRY(ByteString::from_utf8("ThrowingCompare"sv))})))), false}));
+return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("Compare"sv)), (ByteString::must_from_utf8("ThrowingCompare"sv))})))), false}));
 };/*case end*/
 case 8 /* GreaterThanOrEqual */: {
-return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("Compare"sv)), TRY(ByteString::from_utf8("ThrowingCompare"sv))})))), false}));
+return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("Compare"sv)), (ByteString::must_from_utf8("ThrowingCompare"sv))})))), false}));
 };/*case end*/
 case 9 /* Equal */: {
-return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("Equal"sv)), TRY(ByteString::from_utf8("ThrowingEqual"sv))})))), false}));
+return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("Equal"sv)), (ByteString::must_from_utf8("ThrowingEqual"sv))})))), false}));
 };/*case end*/
 case 10 /* NotEqual */: {
-return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("Equal"sv)), TRY(ByteString::from_utf8("ThrowingEqual"sv))})))), false}));
+return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("Equal"sv)), (ByteString::must_from_utf8("ThrowingEqual"sv))})))), false}));
 };/*case end*/
 case 27 /* AddAssign */: {
-return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("AddAssign"sv)), TRY(ByteString::from_utf8("ThrowingAddAssign"sv))})))), true}));
+return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("AddAssign"sv)), (ByteString::must_from_utf8("ThrowingAddAssign"sv))})))), true}));
 };/*case end*/
 case 28 /* SubtractAssign */: {
-return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("SubtractAssign"sv)), TRY(ByteString::from_utf8("ThrowingSubtractAssign"sv))})))), true}));
+return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("SubtractAssign"sv)), (ByteString::must_from_utf8("ThrowingSubtractAssign"sv))})))), true}));
 };/*case end*/
 case 29 /* MultiplyAssign */: {
-return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("MultiplyAssign"sv)), TRY(ByteString::from_utf8("ThrowingMultiplyAssign"sv))})))), true}));
+return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("MultiplyAssign"sv)), (ByteString::must_from_utf8("ThrowingMultiplyAssign"sv))})))), true}));
 };/*case end*/
 case 31 /* DivideAssign */: {
-return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("DivideAssign"sv)), TRY(ByteString::from_utf8("ThrowingDivideAssign"sv))})))), true}));
+return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("DivideAssign"sv)), (ByteString::must_from_utf8("ThrowingDivideAssign"sv))})))), true}));
 };/*case end*/
 case 30 /* ModuloAssign */: {
-return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("ModuloAssign"sv)), TRY(ByteString::from_utf8("ThrowingModuloAssign"sv))})))), true}));
+return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("ModuloAssign"sv)), (ByteString::must_from_utf8("ThrowingModuloAssign"sv))})))), true}));
 };/*case end*/
 case 22 /* BitwiseAndAssign */: {
-return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("BitwiseAndAssign"sv)), TRY(ByteString::from_utf8("ThrowingBitwiseAndAssign"sv))})))), true}));
+return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("BitwiseAndAssign"sv)), (ByteString::must_from_utf8("ThrowingBitwiseAndAssign"sv))})))), true}));
 };/*case end*/
 case 23 /* BitwiseOrAssign */: {
-return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("BitwiseOrAssign"sv)), TRY(ByteString::from_utf8("ThrowingBitwiseOrAssign"sv))})))), true}));
+return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("BitwiseOrAssign"sv)), (ByteString::must_from_utf8("ThrowingBitwiseOrAssign"sv))})))), true}));
 };/*case end*/
 case 24 /* BitwiseXorAssign */: {
-return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("BitwiseXorAssign"sv)), TRY(ByteString::from_utf8("ThrowingBitwiseXorAssign"sv))})))), true}));
+return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("BitwiseXorAssign"sv)), (ByteString::must_from_utf8("ThrowingBitwiseXorAssign"sv))})))), true}));
 };/*case end*/
 case 25 /* BitwiseLeftShiftAssign */: {
-return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("BitwiseLeftShiftAssign"sv)), TRY(ByteString::from_utf8("ThrowingBitwiseLeftShiftAssign"sv))})))), true}));
+return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("BitwiseLeftShiftAssign"sv)), (ByteString::must_from_utf8("ThrowingBitwiseLeftShiftAssign"sv))})))), true}));
 };/*case end*/
 case 26 /* BitwiseRightShiftAssign */: {
-return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("BitwiseRightShiftAssign"sv)), TRY(ByteString::from_utf8("ThrowingBitwiseRightShiftAssign"sv))})))), true}));
+return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("BitwiseRightShiftAssign"sv)), (ByteString::must_from_utf8("ThrowingBitwiseRightShiftAssign"sv))})))), true}));
 };/*case end*/
 default: {
 return JaktInternal::ExplicitValue((Tuple{empty_array, false}));
@@ -6365,70 +6365,70 @@ ByteString const function_name = ({
 auto&& __jakt_match_variant = op;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 0 /* Add */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("add"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("add"sv)));
 };/*case end*/
 case 1 /* Subtract */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("subtract"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("subtract"sv)));
 };/*case end*/
 case 2 /* Multiply */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("multiply"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("multiply"sv)));
 };/*case end*/
 case 3 /* Divide */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("divide"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("divide"sv)));
 };/*case end*/
 case 4 /* Modulo */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("modulo"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("modulo"sv)));
 };/*case end*/
 case 5 /* LessThan */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("less_than"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("less_than"sv)));
 };/*case end*/
 case 6 /* LessThanOrEqual */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("less_than_or_equal"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("less_than_or_equal"sv)));
 };/*case end*/
 case 7 /* GreaterThan */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("greater_than"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("greater_than"sv)));
 };/*case end*/
 case 8 /* GreaterThanOrEqual */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("greater_than_or_equal"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("greater_than_or_equal"sv)));
 };/*case end*/
 case 9 /* Equal */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("equals"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("equals"sv)));
 };/*case end*/
 case 10 /* NotEqual */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("not_equals"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("not_equals"sv)));
 };/*case end*/
 case 27 /* AddAssign */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("add_assign"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("add_assign"sv)));
 };/*case end*/
 case 28 /* SubtractAssign */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("subtract_assign"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("subtract_assign"sv)));
 };/*case end*/
 case 29 /* MultiplyAssign */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("multiply_assign"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("multiply_assign"sv)));
 };/*case end*/
 case 31 /* DivideAssign */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("divide_assign"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("divide_assign"sv)));
 };/*case end*/
 case 30 /* ModuloAssign */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("modulo_assign"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("modulo_assign"sv)));
 };/*case end*/
 case 22 /* BitwiseAndAssign */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("bitwise_and_assign"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("bitwise_and_assign"sv)));
 };/*case end*/
 case 23 /* BitwiseOrAssign */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("bitwise_or_assign"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("bitwise_or_assign"sv)));
 };/*case end*/
 case 24 /* BitwiseXorAssign */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("bitwise_xor_assign"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("bitwise_xor_assign"sv)));
 };/*case end*/
 case 25 /* BitwiseLeftShiftAssign */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("bitwise_left_shift_assign"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("bitwise_left_shift_assign"sv)));
 };/*case end*/
 case 26 /* BitwiseRightShiftAssign */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("bitwise_right_shift_assign"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("bitwise_right_shift_assign"sv)));
 };/*case end*/
 default: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8(""sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8(""sv)));
 };/*case end*/
 }/*switch end*/
 }()
@@ -6440,8 +6440,8 @@ return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8(""sv)));
 JaktInternal::Optional<typechecker::TraitImplementationDescriptor> const add_trait_implementation = TRY((((*this).find_any_singular_trait_implementation(lhs_type_id,trait_names,scope_id,lhs_span,(TRY((DynamicArray<ids::TypeId>::create_with({rhs_type_id}))))))));
 if (((add_trait_implementation).has_value())){
 typechecker::TraitImplementationDescriptor const implementation = (add_trait_implementation.value());
-if ((((((implementation).trait_name)).starts_with(TRY(ByteString::from_utf8("Throwing"sv)))) && (!(((scope)->can_throw))))){
-TRY((((*this).error(TRY(ByteString::from_utf8("Call to function that may throw needs to be in a try statement or a function marked as throws"sv)),span))));
+if ((((((implementation).trait_name)).starts_with((ByteString::must_from_utf8("Throwing"sv)))) && (!(((scope)->can_throw))))){
+TRY((((*this).error((ByteString::must_from_utf8("Call to function that may throw needs to be in a try statement or a function marked as throws"sv)),span))));
 }
 JaktInternal::Tuple<JaktInternal::Optional<types::StructLikeId>,bool> const parent_id___ = TRY((((*this).struct_like_id_from_type_id(lhs_type_id,scope_id,span,false,true))));
 JaktInternal::Optional<types::StructLikeId> const parent_id = ((parent_id___).template get<0>());
@@ -6452,15 +6452,15 @@ if (((implementation_function_id).has_value())){
 NonnullRefPtr<types::CheckedFunction> const implementation_function = ((*this).get_function((implementation_function_id.value())));
 if ((TRY((((implementation_function)->is_mutating()))) && (!(((checked_lhs)->is_mutable(((*this).program))))))){
 if (is_assignment){
-TRY((((*this).error(TRY(ByteString::from_utf8("Assignment to immutable variable"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("Assignment to immutable variable"sv)),span))));
 }
 else {
-TRY((((*this).error(TRY(ByteString::from_utf8("Cannot call mutating function on an immutable object instance"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("Cannot call mutating function on an immutable object instance"sv)),span))));
 }
 
 }
 (type_id = ((implementation_function)->return_type_id));
-types::CheckedCall call_expression = types::CheckedCall((TRY((DynamicArray<types::ResolvedNamespace>::create_with({})))),function_name,(TRY((DynamicArray<JaktInternal::Tuple<ByteString,NonnullRefPtr<typename types::CheckedExpression>>>::create_with({(Tuple{TRY(ByteString::from_utf8(""sv)), checked_rhs})})))),(TRY((DynamicArray<ids::TypeId>::create_with({})))),implementation_function_id,type_id,((implementation_function)->can_throw),((implementation_function)->external_name),((implementation_function)->force_inline));
+types::CheckedCall call_expression = types::CheckedCall((TRY((DynamicArray<types::ResolvedNamespace>::create_with({})))),function_name,(TRY((DynamicArray<JaktInternal::Tuple<ByteString,NonnullRefPtr<typename types::CheckedExpression>>>::create_with({(Tuple{(ByteString::must_from_utf8(""sv)), checked_rhs})})))),(TRY((DynamicArray<ids::TypeId>::create_with({})))),implementation_function_id,type_id,((implementation_function)->can_throw),((implementation_function)->external_name),((implementation_function)->force_inline));
 (((checked_operator).trait_implementation) = types::OperatorTraitImplementation(((implementation).trait_id),((implementation).implemented_type_args),call_expression));
 }
 else {
@@ -6537,67 +6537,67 @@ JaktInternal::Tuple<JaktInternal::DynamicArray<ByteString>,bool> const trait_nam
 auto&& __jakt_match_variant = op;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 0 /* Add */: {
-return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("Add"sv)), TRY(ByteString::from_utf8("ThrowingAdd"sv))})))), false}));
+return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("Add"sv)), (ByteString::must_from_utf8("ThrowingAdd"sv))})))), false}));
 };/*case end*/
 case 1 /* Subtract */: {
-return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("Subtract"sv)), TRY(ByteString::from_utf8("ThrowingSubtract"sv))})))), false}));
+return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("Subtract"sv)), (ByteString::must_from_utf8("ThrowingSubtract"sv))})))), false}));
 };/*case end*/
 case 2 /* Multiply */: {
-return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("Multiply"sv)), TRY(ByteString::from_utf8("ThrowingMultiply"sv))})))), false}));
+return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("Multiply"sv)), (ByteString::must_from_utf8("ThrowingMultiply"sv))})))), false}));
 };/*case end*/
 case 3 /* Divide */: {
-return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("Divide"sv)), TRY(ByteString::from_utf8("ThrowingDivide"sv))})))), false}));
+return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("Divide"sv)), (ByteString::must_from_utf8("ThrowingDivide"sv))})))), false}));
 };/*case end*/
 case 4 /* Modulo */: {
-return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("Modulo"sv)), TRY(ByteString::from_utf8("ThrowingModulo"sv))})))), false}));
+return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("Modulo"sv)), (ByteString::must_from_utf8("ThrowingModulo"sv))})))), false}));
 };/*case end*/
 case 5 /* LessThan */: {
-return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("Compare"sv)), TRY(ByteString::from_utf8("ThrowingCompare"sv))})))), false}));
+return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("Compare"sv)), (ByteString::must_from_utf8("ThrowingCompare"sv))})))), false}));
 };/*case end*/
 case 6 /* LessThanOrEqual */: {
-return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("Compare"sv)), TRY(ByteString::from_utf8("ThrowingCompare"sv))})))), false}));
+return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("Compare"sv)), (ByteString::must_from_utf8("ThrowingCompare"sv))})))), false}));
 };/*case end*/
 case 7 /* GreaterThan */: {
-return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("Compare"sv)), TRY(ByteString::from_utf8("ThrowingCompare"sv))})))), false}));
+return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("Compare"sv)), (ByteString::must_from_utf8("ThrowingCompare"sv))})))), false}));
 };/*case end*/
 case 8 /* GreaterThanOrEqual */: {
-return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("Compare"sv)), TRY(ByteString::from_utf8("ThrowingCompare"sv))})))), false}));
+return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("Compare"sv)), (ByteString::must_from_utf8("ThrowingCompare"sv))})))), false}));
 };/*case end*/
 case 9 /* Equal */: {
-return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("Equal"sv)), TRY(ByteString::from_utf8("ThrowingEqual"sv))})))), false}));
+return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("Equal"sv)), (ByteString::must_from_utf8("ThrowingEqual"sv))})))), false}));
 };/*case end*/
 case 10 /* NotEqual */: {
-return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("Equal"sv)), TRY(ByteString::from_utf8("ThrowingEqual"sv))})))), false}));
+return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("Equal"sv)), (ByteString::must_from_utf8("ThrowingEqual"sv))})))), false}));
 };/*case end*/
 case 27 /* AddAssign */: {
-return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("AddAssign"sv)), TRY(ByteString::from_utf8("ThrowingAddAssign"sv))})))), true}));
+return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("AddAssign"sv)), (ByteString::must_from_utf8("ThrowingAddAssign"sv))})))), true}));
 };/*case end*/
 case 28 /* SubtractAssign */: {
-return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("SubtractAssign"sv)), TRY(ByteString::from_utf8("ThrowingSubtractAssign"sv))})))), true}));
+return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("SubtractAssign"sv)), (ByteString::must_from_utf8("ThrowingSubtractAssign"sv))})))), true}));
 };/*case end*/
 case 29 /* MultiplyAssign */: {
-return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("MultiplyAssign"sv)), TRY(ByteString::from_utf8("ThrowingMultiplyAssign"sv))})))), true}));
+return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("MultiplyAssign"sv)), (ByteString::must_from_utf8("ThrowingMultiplyAssign"sv))})))), true}));
 };/*case end*/
 case 31 /* DivideAssign */: {
-return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("DivideAssign"sv)), TRY(ByteString::from_utf8("ThrowingDivideAssign"sv))})))), true}));
+return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("DivideAssign"sv)), (ByteString::must_from_utf8("ThrowingDivideAssign"sv))})))), true}));
 };/*case end*/
 case 30 /* ModuloAssign */: {
-return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("ModuloAssign"sv)), TRY(ByteString::from_utf8("ThrowingModuloAssign"sv))})))), true}));
+return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("ModuloAssign"sv)), (ByteString::must_from_utf8("ThrowingModuloAssign"sv))})))), true}));
 };/*case end*/
 case 22 /* BitwiseAndAssign */: {
-return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("BitwiseAndAssign"sv)), TRY(ByteString::from_utf8("ThrowingBitwiseAndAssign"sv))})))), true}));
+return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("BitwiseAndAssign"sv)), (ByteString::must_from_utf8("ThrowingBitwiseAndAssign"sv))})))), true}));
 };/*case end*/
 case 23 /* BitwiseOrAssign */: {
-return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("BitwiseOrAssign"sv)), TRY(ByteString::from_utf8("ThrowingBitwiseOrAssign"sv))})))), true}));
+return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("BitwiseOrAssign"sv)), (ByteString::must_from_utf8("ThrowingBitwiseOrAssign"sv))})))), true}));
 };/*case end*/
 case 24 /* BitwiseXorAssign */: {
-return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("BitwiseXorAssign"sv)), TRY(ByteString::from_utf8("ThrowingBitwiseXorAssign"sv))})))), true}));
+return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("BitwiseXorAssign"sv)), (ByteString::must_from_utf8("ThrowingBitwiseXorAssign"sv))})))), true}));
 };/*case end*/
 case 25 /* BitwiseLeftShiftAssign */: {
-return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("BitwiseLeftShiftAssign"sv)), TRY(ByteString::from_utf8("ThrowingBitwiseLeftShiftAssign"sv))})))), true}));
+return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("BitwiseLeftShiftAssign"sv)), (ByteString::must_from_utf8("ThrowingBitwiseLeftShiftAssign"sv))})))), true}));
 };/*case end*/
 case 26 /* BitwiseRightShiftAssign */: {
-return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("BitwiseRightShiftAssign"sv)), TRY(ByteString::from_utf8("ThrowingBitwiseRightShiftAssign"sv))})))), true}));
+return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("BitwiseRightShiftAssign"sv)), (ByteString::must_from_utf8("ThrowingBitwiseRightShiftAssign"sv))})))), true}));
 };/*case end*/
 default: {
 return JaktInternal::ExplicitValue((Tuple{empty_array, false}));
@@ -6617,70 +6617,70 @@ ByteString const function_name = ({
 auto&& __jakt_match_variant = op;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 0 /* Add */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("add"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("add"sv)));
 };/*case end*/
 case 1 /* Subtract */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("subtract"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("subtract"sv)));
 };/*case end*/
 case 2 /* Multiply */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("multiply"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("multiply"sv)));
 };/*case end*/
 case 3 /* Divide */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("divide"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("divide"sv)));
 };/*case end*/
 case 4 /* Modulo */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("modulo"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("modulo"sv)));
 };/*case end*/
 case 5 /* LessThan */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("less_than"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("less_than"sv)));
 };/*case end*/
 case 6 /* LessThanOrEqual */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("less_than_or_equal"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("less_than_or_equal"sv)));
 };/*case end*/
 case 7 /* GreaterThan */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("greater_than"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("greater_than"sv)));
 };/*case end*/
 case 8 /* GreaterThanOrEqual */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("greater_than_or_equal"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("greater_than_or_equal"sv)));
 };/*case end*/
 case 9 /* Equal */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("equals"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("equals"sv)));
 };/*case end*/
 case 10 /* NotEqual */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("not_equals"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("not_equals"sv)));
 };/*case end*/
 case 27 /* AddAssign */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("add_assign"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("add_assign"sv)));
 };/*case end*/
 case 28 /* SubtractAssign */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("subtract_assign"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("subtract_assign"sv)));
 };/*case end*/
 case 29 /* MultiplyAssign */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("multiply_assign"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("multiply_assign"sv)));
 };/*case end*/
 case 31 /* DivideAssign */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("divide_assign"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("divide_assign"sv)));
 };/*case end*/
 case 30 /* ModuloAssign */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("modulo_assign"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("modulo_assign"sv)));
 };/*case end*/
 case 22 /* BitwiseAndAssign */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("bitwise_and_assign"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("bitwise_and_assign"sv)));
 };/*case end*/
 case 23 /* BitwiseOrAssign */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("bitwise_or_assign"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("bitwise_or_assign"sv)));
 };/*case end*/
 case 24 /* BitwiseXorAssign */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("bitwise_xor_assign"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("bitwise_xor_assign"sv)));
 };/*case end*/
 case 25 /* BitwiseLeftShiftAssign */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("bitwise_left_shift_assign"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("bitwise_left_shift_assign"sv)));
 };/*case end*/
 case 26 /* BitwiseRightShiftAssign */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("bitwise_right_shift_assign"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("bitwise_right_shift_assign"sv)));
 };/*case end*/
 default: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8(""sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8(""sv)));
 };/*case end*/
 }/*switch end*/
 }()
@@ -6692,8 +6692,8 @@ return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8(""sv)));
 JaktInternal::Optional<typechecker::TraitImplementationDescriptor> const add_trait_implementation = TRY((((*this).find_any_singular_trait_implementation(lhs_type_id,trait_names,scope_id,lhs_span,(TRY((DynamicArray<ids::TypeId>::create_with({rhs_type_id}))))))));
 if (((add_trait_implementation).has_value())){
 typechecker::TraitImplementationDescriptor const implementation = (add_trait_implementation.value());
-if ((((((implementation).trait_name)).starts_with(TRY(ByteString::from_utf8("Throwing"sv)))) && (!(((scope)->can_throw))))){
-TRY((((*this).error(TRY(ByteString::from_utf8("Call to function that may throw needs to be in a try statement or a function marked as throws"sv)),span))));
+if ((((((implementation).trait_name)).starts_with((ByteString::must_from_utf8("Throwing"sv)))) && (!(((scope)->can_throw))))){
+TRY((((*this).error((ByteString::must_from_utf8("Call to function that may throw needs to be in a try statement or a function marked as throws"sv)),span))));
 }
 JaktInternal::Tuple<JaktInternal::Optional<types::StructLikeId>,bool> const parent_id___ = TRY((((*this).struct_like_id_from_type_id(lhs_type_id,scope_id,span,false,true))));
 JaktInternal::Optional<types::StructLikeId> const parent_id = ((parent_id___).template get<0>());
@@ -6704,15 +6704,15 @@ if (((implementation_function_id).has_value())){
 NonnullRefPtr<types::CheckedFunction> const implementation_function = ((*this).get_function((implementation_function_id.value())));
 if ((TRY((((implementation_function)->is_mutating()))) && (!(((checked_lhs)->is_mutable(((*this).program))))))){
 if (is_assignment){
-TRY((((*this).error(TRY(ByteString::from_utf8("Assignment to immutable variable"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("Assignment to immutable variable"sv)),span))));
 }
 else {
-TRY((((*this).error(TRY(ByteString::from_utf8("Cannot call mutating function on an immutable object instance"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("Cannot call mutating function on an immutable object instance"sv)),span))));
 }
 
 }
 (type_id = ((implementation_function)->return_type_id));
-types::CheckedCall call_expression = types::CheckedCall((TRY((DynamicArray<types::ResolvedNamespace>::create_with({})))),function_name,(TRY((DynamicArray<JaktInternal::Tuple<ByteString,NonnullRefPtr<typename types::CheckedExpression>>>::create_with({(Tuple{TRY(ByteString::from_utf8(""sv)), checked_rhs})})))),(TRY((DynamicArray<ids::TypeId>::create_with({})))),implementation_function_id,type_id,((implementation_function)->can_throw),((implementation_function)->external_name),((implementation_function)->force_inline));
+types::CheckedCall call_expression = types::CheckedCall((TRY((DynamicArray<types::ResolvedNamespace>::create_with({})))),function_name,(TRY((DynamicArray<JaktInternal::Tuple<ByteString,NonnullRefPtr<typename types::CheckedExpression>>>::create_with({(Tuple{(ByteString::must_from_utf8(""sv)), checked_rhs})})))),(TRY((DynamicArray<ids::TypeId>::create_with({})))),implementation_function_id,type_id,((implementation_function)->can_throw),((implementation_function)->external_name),((implementation_function)->force_inline));
 (((checked_operator).trait_implementation) = types::OperatorTraitImplementation(((implementation).trait_id),((implementation).implemented_type_args),call_expression));
 }
 else {
@@ -6789,67 +6789,67 @@ JaktInternal::Tuple<JaktInternal::DynamicArray<ByteString>,bool> const trait_nam
 auto&& __jakt_match_variant = op;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 0 /* Add */: {
-return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("Add"sv)), TRY(ByteString::from_utf8("ThrowingAdd"sv))})))), false}));
+return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("Add"sv)), (ByteString::must_from_utf8("ThrowingAdd"sv))})))), false}));
 };/*case end*/
 case 1 /* Subtract */: {
-return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("Subtract"sv)), TRY(ByteString::from_utf8("ThrowingSubtract"sv))})))), false}));
+return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("Subtract"sv)), (ByteString::must_from_utf8("ThrowingSubtract"sv))})))), false}));
 };/*case end*/
 case 2 /* Multiply */: {
-return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("Multiply"sv)), TRY(ByteString::from_utf8("ThrowingMultiply"sv))})))), false}));
+return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("Multiply"sv)), (ByteString::must_from_utf8("ThrowingMultiply"sv))})))), false}));
 };/*case end*/
 case 3 /* Divide */: {
-return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("Divide"sv)), TRY(ByteString::from_utf8("ThrowingDivide"sv))})))), false}));
+return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("Divide"sv)), (ByteString::must_from_utf8("ThrowingDivide"sv))})))), false}));
 };/*case end*/
 case 4 /* Modulo */: {
-return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("Modulo"sv)), TRY(ByteString::from_utf8("ThrowingModulo"sv))})))), false}));
+return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("Modulo"sv)), (ByteString::must_from_utf8("ThrowingModulo"sv))})))), false}));
 };/*case end*/
 case 5 /* LessThan */: {
-return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("Compare"sv)), TRY(ByteString::from_utf8("ThrowingCompare"sv))})))), false}));
+return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("Compare"sv)), (ByteString::must_from_utf8("ThrowingCompare"sv))})))), false}));
 };/*case end*/
 case 6 /* LessThanOrEqual */: {
-return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("Compare"sv)), TRY(ByteString::from_utf8("ThrowingCompare"sv))})))), false}));
+return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("Compare"sv)), (ByteString::must_from_utf8("ThrowingCompare"sv))})))), false}));
 };/*case end*/
 case 7 /* GreaterThan */: {
-return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("Compare"sv)), TRY(ByteString::from_utf8("ThrowingCompare"sv))})))), false}));
+return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("Compare"sv)), (ByteString::must_from_utf8("ThrowingCompare"sv))})))), false}));
 };/*case end*/
 case 8 /* GreaterThanOrEqual */: {
-return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("Compare"sv)), TRY(ByteString::from_utf8("ThrowingCompare"sv))})))), false}));
+return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("Compare"sv)), (ByteString::must_from_utf8("ThrowingCompare"sv))})))), false}));
 };/*case end*/
 case 9 /* Equal */: {
-return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("Equal"sv)), TRY(ByteString::from_utf8("ThrowingEqual"sv))})))), false}));
+return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("Equal"sv)), (ByteString::must_from_utf8("ThrowingEqual"sv))})))), false}));
 };/*case end*/
 case 10 /* NotEqual */: {
-return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("Equal"sv)), TRY(ByteString::from_utf8("ThrowingEqual"sv))})))), false}));
+return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("Equal"sv)), (ByteString::must_from_utf8("ThrowingEqual"sv))})))), false}));
 };/*case end*/
 case 27 /* AddAssign */: {
-return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("AddAssign"sv)), TRY(ByteString::from_utf8("ThrowingAddAssign"sv))})))), true}));
+return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("AddAssign"sv)), (ByteString::must_from_utf8("ThrowingAddAssign"sv))})))), true}));
 };/*case end*/
 case 28 /* SubtractAssign */: {
-return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("SubtractAssign"sv)), TRY(ByteString::from_utf8("ThrowingSubtractAssign"sv))})))), true}));
+return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("SubtractAssign"sv)), (ByteString::must_from_utf8("ThrowingSubtractAssign"sv))})))), true}));
 };/*case end*/
 case 29 /* MultiplyAssign */: {
-return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("MultiplyAssign"sv)), TRY(ByteString::from_utf8("ThrowingMultiplyAssign"sv))})))), true}));
+return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("MultiplyAssign"sv)), (ByteString::must_from_utf8("ThrowingMultiplyAssign"sv))})))), true}));
 };/*case end*/
 case 31 /* DivideAssign */: {
-return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("DivideAssign"sv)), TRY(ByteString::from_utf8("ThrowingDivideAssign"sv))})))), true}));
+return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("DivideAssign"sv)), (ByteString::must_from_utf8("ThrowingDivideAssign"sv))})))), true}));
 };/*case end*/
 case 30 /* ModuloAssign */: {
-return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("ModuloAssign"sv)), TRY(ByteString::from_utf8("ThrowingModuloAssign"sv))})))), true}));
+return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("ModuloAssign"sv)), (ByteString::must_from_utf8("ThrowingModuloAssign"sv))})))), true}));
 };/*case end*/
 case 22 /* BitwiseAndAssign */: {
-return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("BitwiseAndAssign"sv)), TRY(ByteString::from_utf8("ThrowingBitwiseAndAssign"sv))})))), true}));
+return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("BitwiseAndAssign"sv)), (ByteString::must_from_utf8("ThrowingBitwiseAndAssign"sv))})))), true}));
 };/*case end*/
 case 23 /* BitwiseOrAssign */: {
-return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("BitwiseOrAssign"sv)), TRY(ByteString::from_utf8("ThrowingBitwiseOrAssign"sv))})))), true}));
+return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("BitwiseOrAssign"sv)), (ByteString::must_from_utf8("ThrowingBitwiseOrAssign"sv))})))), true}));
 };/*case end*/
 case 24 /* BitwiseXorAssign */: {
-return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("BitwiseXorAssign"sv)), TRY(ByteString::from_utf8("ThrowingBitwiseXorAssign"sv))})))), true}));
+return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("BitwiseXorAssign"sv)), (ByteString::must_from_utf8("ThrowingBitwiseXorAssign"sv))})))), true}));
 };/*case end*/
 case 25 /* BitwiseLeftShiftAssign */: {
-return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("BitwiseLeftShiftAssign"sv)), TRY(ByteString::from_utf8("ThrowingBitwiseLeftShiftAssign"sv))})))), true}));
+return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("BitwiseLeftShiftAssign"sv)), (ByteString::must_from_utf8("ThrowingBitwiseLeftShiftAssign"sv))})))), true}));
 };/*case end*/
 case 26 /* BitwiseRightShiftAssign */: {
-return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("BitwiseRightShiftAssign"sv)), TRY(ByteString::from_utf8("ThrowingBitwiseRightShiftAssign"sv))})))), true}));
+return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("BitwiseRightShiftAssign"sv)), (ByteString::must_from_utf8("ThrowingBitwiseRightShiftAssign"sv))})))), true}));
 };/*case end*/
 default: {
 return JaktInternal::ExplicitValue((Tuple{empty_array, false}));
@@ -6869,70 +6869,70 @@ ByteString const function_name = ({
 auto&& __jakt_match_variant = op;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 0 /* Add */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("add"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("add"sv)));
 };/*case end*/
 case 1 /* Subtract */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("subtract"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("subtract"sv)));
 };/*case end*/
 case 2 /* Multiply */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("multiply"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("multiply"sv)));
 };/*case end*/
 case 3 /* Divide */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("divide"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("divide"sv)));
 };/*case end*/
 case 4 /* Modulo */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("modulo"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("modulo"sv)));
 };/*case end*/
 case 5 /* LessThan */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("less_than"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("less_than"sv)));
 };/*case end*/
 case 6 /* LessThanOrEqual */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("less_than_or_equal"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("less_than_or_equal"sv)));
 };/*case end*/
 case 7 /* GreaterThan */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("greater_than"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("greater_than"sv)));
 };/*case end*/
 case 8 /* GreaterThanOrEqual */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("greater_than_or_equal"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("greater_than_or_equal"sv)));
 };/*case end*/
 case 9 /* Equal */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("equals"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("equals"sv)));
 };/*case end*/
 case 10 /* NotEqual */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("not_equals"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("not_equals"sv)));
 };/*case end*/
 case 27 /* AddAssign */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("add_assign"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("add_assign"sv)));
 };/*case end*/
 case 28 /* SubtractAssign */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("subtract_assign"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("subtract_assign"sv)));
 };/*case end*/
 case 29 /* MultiplyAssign */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("multiply_assign"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("multiply_assign"sv)));
 };/*case end*/
 case 31 /* DivideAssign */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("divide_assign"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("divide_assign"sv)));
 };/*case end*/
 case 30 /* ModuloAssign */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("modulo_assign"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("modulo_assign"sv)));
 };/*case end*/
 case 22 /* BitwiseAndAssign */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("bitwise_and_assign"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("bitwise_and_assign"sv)));
 };/*case end*/
 case 23 /* BitwiseOrAssign */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("bitwise_or_assign"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("bitwise_or_assign"sv)));
 };/*case end*/
 case 24 /* BitwiseXorAssign */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("bitwise_xor_assign"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("bitwise_xor_assign"sv)));
 };/*case end*/
 case 25 /* BitwiseLeftShiftAssign */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("bitwise_left_shift_assign"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("bitwise_left_shift_assign"sv)));
 };/*case end*/
 case 26 /* BitwiseRightShiftAssign */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("bitwise_right_shift_assign"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("bitwise_right_shift_assign"sv)));
 };/*case end*/
 default: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8(""sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8(""sv)));
 };/*case end*/
 }/*switch end*/
 }()
@@ -6944,8 +6944,8 @@ return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8(""sv)));
 JaktInternal::Optional<typechecker::TraitImplementationDescriptor> const add_trait_implementation = TRY((((*this).find_any_singular_trait_implementation(lhs_type_id,trait_names,scope_id,lhs_span,(TRY((DynamicArray<ids::TypeId>::create_with({rhs_type_id}))))))));
 if (((add_trait_implementation).has_value())){
 typechecker::TraitImplementationDescriptor const implementation = (add_trait_implementation.value());
-if ((((((implementation).trait_name)).starts_with(TRY(ByteString::from_utf8("Throwing"sv)))) && (!(((scope)->can_throw))))){
-TRY((((*this).error(TRY(ByteString::from_utf8("Call to function that may throw needs to be in a try statement or a function marked as throws"sv)),span))));
+if ((((((implementation).trait_name)).starts_with((ByteString::must_from_utf8("Throwing"sv)))) && (!(((scope)->can_throw))))){
+TRY((((*this).error((ByteString::must_from_utf8("Call to function that may throw needs to be in a try statement or a function marked as throws"sv)),span))));
 }
 JaktInternal::Tuple<JaktInternal::Optional<types::StructLikeId>,bool> const parent_id___ = TRY((((*this).struct_like_id_from_type_id(lhs_type_id,scope_id,span,false,true))));
 JaktInternal::Optional<types::StructLikeId> const parent_id = ((parent_id___).template get<0>());
@@ -6956,15 +6956,15 @@ if (((implementation_function_id).has_value())){
 NonnullRefPtr<types::CheckedFunction> const implementation_function = ((*this).get_function((implementation_function_id.value())));
 if ((TRY((((implementation_function)->is_mutating()))) && (!(((checked_lhs)->is_mutable(((*this).program))))))){
 if (is_assignment){
-TRY((((*this).error(TRY(ByteString::from_utf8("Assignment to immutable variable"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("Assignment to immutable variable"sv)),span))));
 }
 else {
-TRY((((*this).error(TRY(ByteString::from_utf8("Cannot call mutating function on an immutable object instance"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("Cannot call mutating function on an immutable object instance"sv)),span))));
 }
 
 }
 (type_id = ((implementation_function)->return_type_id));
-types::CheckedCall call_expression = types::CheckedCall((TRY((DynamicArray<types::ResolvedNamespace>::create_with({})))),function_name,(TRY((DynamicArray<JaktInternal::Tuple<ByteString,NonnullRefPtr<typename types::CheckedExpression>>>::create_with({(Tuple{TRY(ByteString::from_utf8(""sv)), checked_rhs})})))),(TRY((DynamicArray<ids::TypeId>::create_with({})))),implementation_function_id,type_id,((implementation_function)->can_throw),((implementation_function)->external_name),((implementation_function)->force_inline));
+types::CheckedCall call_expression = types::CheckedCall((TRY((DynamicArray<types::ResolvedNamespace>::create_with({})))),function_name,(TRY((DynamicArray<JaktInternal::Tuple<ByteString,NonnullRefPtr<typename types::CheckedExpression>>>::create_with({(Tuple{(ByteString::must_from_utf8(""sv)), checked_rhs})})))),(TRY((DynamicArray<ids::TypeId>::create_with({})))),implementation_function_id,type_id,((implementation_function)->can_throw),((implementation_function)->external_name),((implementation_function)->force_inline));
 (((checked_operator).trait_implementation) = types::OperatorTraitImplementation(((implementation).trait_id),((implementation).implemented_type_args),call_expression));
 }
 else {
@@ -7041,67 +7041,67 @@ JaktInternal::Tuple<JaktInternal::DynamicArray<ByteString>,bool> const trait_nam
 auto&& __jakt_match_variant = op;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 0 /* Add */: {
-return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("Add"sv)), TRY(ByteString::from_utf8("ThrowingAdd"sv))})))), false}));
+return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("Add"sv)), (ByteString::must_from_utf8("ThrowingAdd"sv))})))), false}));
 };/*case end*/
 case 1 /* Subtract */: {
-return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("Subtract"sv)), TRY(ByteString::from_utf8("ThrowingSubtract"sv))})))), false}));
+return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("Subtract"sv)), (ByteString::must_from_utf8("ThrowingSubtract"sv))})))), false}));
 };/*case end*/
 case 2 /* Multiply */: {
-return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("Multiply"sv)), TRY(ByteString::from_utf8("ThrowingMultiply"sv))})))), false}));
+return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("Multiply"sv)), (ByteString::must_from_utf8("ThrowingMultiply"sv))})))), false}));
 };/*case end*/
 case 3 /* Divide */: {
-return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("Divide"sv)), TRY(ByteString::from_utf8("ThrowingDivide"sv))})))), false}));
+return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("Divide"sv)), (ByteString::must_from_utf8("ThrowingDivide"sv))})))), false}));
 };/*case end*/
 case 4 /* Modulo */: {
-return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("Modulo"sv)), TRY(ByteString::from_utf8("ThrowingModulo"sv))})))), false}));
+return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("Modulo"sv)), (ByteString::must_from_utf8("ThrowingModulo"sv))})))), false}));
 };/*case end*/
 case 5 /* LessThan */: {
-return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("Compare"sv)), TRY(ByteString::from_utf8("ThrowingCompare"sv))})))), false}));
+return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("Compare"sv)), (ByteString::must_from_utf8("ThrowingCompare"sv))})))), false}));
 };/*case end*/
 case 6 /* LessThanOrEqual */: {
-return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("Compare"sv)), TRY(ByteString::from_utf8("ThrowingCompare"sv))})))), false}));
+return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("Compare"sv)), (ByteString::must_from_utf8("ThrowingCompare"sv))})))), false}));
 };/*case end*/
 case 7 /* GreaterThan */: {
-return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("Compare"sv)), TRY(ByteString::from_utf8("ThrowingCompare"sv))})))), false}));
+return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("Compare"sv)), (ByteString::must_from_utf8("ThrowingCompare"sv))})))), false}));
 };/*case end*/
 case 8 /* GreaterThanOrEqual */: {
-return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("Compare"sv)), TRY(ByteString::from_utf8("ThrowingCompare"sv))})))), false}));
+return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("Compare"sv)), (ByteString::must_from_utf8("ThrowingCompare"sv))})))), false}));
 };/*case end*/
 case 9 /* Equal */: {
-return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("Equal"sv)), TRY(ByteString::from_utf8("ThrowingEqual"sv))})))), false}));
+return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("Equal"sv)), (ByteString::must_from_utf8("ThrowingEqual"sv))})))), false}));
 };/*case end*/
 case 10 /* NotEqual */: {
-return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("Equal"sv)), TRY(ByteString::from_utf8("ThrowingEqual"sv))})))), false}));
+return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("Equal"sv)), (ByteString::must_from_utf8("ThrowingEqual"sv))})))), false}));
 };/*case end*/
 case 27 /* AddAssign */: {
-return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("AddAssign"sv)), TRY(ByteString::from_utf8("ThrowingAddAssign"sv))})))), true}));
+return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("AddAssign"sv)), (ByteString::must_from_utf8("ThrowingAddAssign"sv))})))), true}));
 };/*case end*/
 case 28 /* SubtractAssign */: {
-return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("SubtractAssign"sv)), TRY(ByteString::from_utf8("ThrowingSubtractAssign"sv))})))), true}));
+return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("SubtractAssign"sv)), (ByteString::must_from_utf8("ThrowingSubtractAssign"sv))})))), true}));
 };/*case end*/
 case 29 /* MultiplyAssign */: {
-return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("MultiplyAssign"sv)), TRY(ByteString::from_utf8("ThrowingMultiplyAssign"sv))})))), true}));
+return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("MultiplyAssign"sv)), (ByteString::must_from_utf8("ThrowingMultiplyAssign"sv))})))), true}));
 };/*case end*/
 case 31 /* DivideAssign */: {
-return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("DivideAssign"sv)), TRY(ByteString::from_utf8("ThrowingDivideAssign"sv))})))), true}));
+return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("DivideAssign"sv)), (ByteString::must_from_utf8("ThrowingDivideAssign"sv))})))), true}));
 };/*case end*/
 case 30 /* ModuloAssign */: {
-return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("ModuloAssign"sv)), TRY(ByteString::from_utf8("ThrowingModuloAssign"sv))})))), true}));
+return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("ModuloAssign"sv)), (ByteString::must_from_utf8("ThrowingModuloAssign"sv))})))), true}));
 };/*case end*/
 case 22 /* BitwiseAndAssign */: {
-return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("BitwiseAndAssign"sv)), TRY(ByteString::from_utf8("ThrowingBitwiseAndAssign"sv))})))), true}));
+return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("BitwiseAndAssign"sv)), (ByteString::must_from_utf8("ThrowingBitwiseAndAssign"sv))})))), true}));
 };/*case end*/
 case 23 /* BitwiseOrAssign */: {
-return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("BitwiseOrAssign"sv)), TRY(ByteString::from_utf8("ThrowingBitwiseOrAssign"sv))})))), true}));
+return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("BitwiseOrAssign"sv)), (ByteString::must_from_utf8("ThrowingBitwiseOrAssign"sv))})))), true}));
 };/*case end*/
 case 24 /* BitwiseXorAssign */: {
-return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("BitwiseXorAssign"sv)), TRY(ByteString::from_utf8("ThrowingBitwiseXorAssign"sv))})))), true}));
+return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("BitwiseXorAssign"sv)), (ByteString::must_from_utf8("ThrowingBitwiseXorAssign"sv))})))), true}));
 };/*case end*/
 case 25 /* BitwiseLeftShiftAssign */: {
-return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("BitwiseLeftShiftAssign"sv)), TRY(ByteString::from_utf8("ThrowingBitwiseLeftShiftAssign"sv))})))), true}));
+return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("BitwiseLeftShiftAssign"sv)), (ByteString::must_from_utf8("ThrowingBitwiseLeftShiftAssign"sv))})))), true}));
 };/*case end*/
 case 26 /* BitwiseRightShiftAssign */: {
-return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("BitwiseRightShiftAssign"sv)), TRY(ByteString::from_utf8("ThrowingBitwiseRightShiftAssign"sv))})))), true}));
+return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("BitwiseRightShiftAssign"sv)), (ByteString::must_from_utf8("ThrowingBitwiseRightShiftAssign"sv))})))), true}));
 };/*case end*/
 default: {
 return JaktInternal::ExplicitValue((Tuple{empty_array, false}));
@@ -7121,70 +7121,70 @@ ByteString const function_name = ({
 auto&& __jakt_match_variant = op;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 0 /* Add */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("add"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("add"sv)));
 };/*case end*/
 case 1 /* Subtract */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("subtract"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("subtract"sv)));
 };/*case end*/
 case 2 /* Multiply */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("multiply"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("multiply"sv)));
 };/*case end*/
 case 3 /* Divide */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("divide"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("divide"sv)));
 };/*case end*/
 case 4 /* Modulo */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("modulo"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("modulo"sv)));
 };/*case end*/
 case 5 /* LessThan */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("less_than"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("less_than"sv)));
 };/*case end*/
 case 6 /* LessThanOrEqual */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("less_than_or_equal"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("less_than_or_equal"sv)));
 };/*case end*/
 case 7 /* GreaterThan */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("greater_than"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("greater_than"sv)));
 };/*case end*/
 case 8 /* GreaterThanOrEqual */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("greater_than_or_equal"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("greater_than_or_equal"sv)));
 };/*case end*/
 case 9 /* Equal */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("equals"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("equals"sv)));
 };/*case end*/
 case 10 /* NotEqual */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("not_equals"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("not_equals"sv)));
 };/*case end*/
 case 27 /* AddAssign */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("add_assign"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("add_assign"sv)));
 };/*case end*/
 case 28 /* SubtractAssign */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("subtract_assign"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("subtract_assign"sv)));
 };/*case end*/
 case 29 /* MultiplyAssign */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("multiply_assign"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("multiply_assign"sv)));
 };/*case end*/
 case 31 /* DivideAssign */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("divide_assign"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("divide_assign"sv)));
 };/*case end*/
 case 30 /* ModuloAssign */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("modulo_assign"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("modulo_assign"sv)));
 };/*case end*/
 case 22 /* BitwiseAndAssign */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("bitwise_and_assign"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("bitwise_and_assign"sv)));
 };/*case end*/
 case 23 /* BitwiseOrAssign */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("bitwise_or_assign"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("bitwise_or_assign"sv)));
 };/*case end*/
 case 24 /* BitwiseXorAssign */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("bitwise_xor_assign"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("bitwise_xor_assign"sv)));
 };/*case end*/
 case 25 /* BitwiseLeftShiftAssign */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("bitwise_left_shift_assign"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("bitwise_left_shift_assign"sv)));
 };/*case end*/
 case 26 /* BitwiseRightShiftAssign */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("bitwise_right_shift_assign"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("bitwise_right_shift_assign"sv)));
 };/*case end*/
 default: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8(""sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8(""sv)));
 };/*case end*/
 }/*switch end*/
 }()
@@ -7196,8 +7196,8 @@ return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8(""sv)));
 JaktInternal::Optional<typechecker::TraitImplementationDescriptor> const add_trait_implementation = TRY((((*this).find_any_singular_trait_implementation(lhs_type_id,trait_names,scope_id,lhs_span,(TRY((DynamicArray<ids::TypeId>::create_with({rhs_type_id}))))))));
 if (((add_trait_implementation).has_value())){
 typechecker::TraitImplementationDescriptor const implementation = (add_trait_implementation.value());
-if ((((((implementation).trait_name)).starts_with(TRY(ByteString::from_utf8("Throwing"sv)))) && (!(((scope)->can_throw))))){
-TRY((((*this).error(TRY(ByteString::from_utf8("Call to function that may throw needs to be in a try statement or a function marked as throws"sv)),span))));
+if ((((((implementation).trait_name)).starts_with((ByteString::must_from_utf8("Throwing"sv)))) && (!(((scope)->can_throw))))){
+TRY((((*this).error((ByteString::must_from_utf8("Call to function that may throw needs to be in a try statement or a function marked as throws"sv)),span))));
 }
 JaktInternal::Tuple<JaktInternal::Optional<types::StructLikeId>,bool> const parent_id___ = TRY((((*this).struct_like_id_from_type_id(lhs_type_id,scope_id,span,false,true))));
 JaktInternal::Optional<types::StructLikeId> const parent_id = ((parent_id___).template get<0>());
@@ -7208,15 +7208,15 @@ if (((implementation_function_id).has_value())){
 NonnullRefPtr<types::CheckedFunction> const implementation_function = ((*this).get_function((implementation_function_id.value())));
 if ((TRY((((implementation_function)->is_mutating()))) && (!(((checked_lhs)->is_mutable(((*this).program))))))){
 if (is_assignment){
-TRY((((*this).error(TRY(ByteString::from_utf8("Assignment to immutable variable"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("Assignment to immutable variable"sv)),span))));
 }
 else {
-TRY((((*this).error(TRY(ByteString::from_utf8("Cannot call mutating function on an immutable object instance"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("Cannot call mutating function on an immutable object instance"sv)),span))));
 }
 
 }
 (type_id = ((implementation_function)->return_type_id));
-types::CheckedCall call_expression = types::CheckedCall((TRY((DynamicArray<types::ResolvedNamespace>::create_with({})))),function_name,(TRY((DynamicArray<JaktInternal::Tuple<ByteString,NonnullRefPtr<typename types::CheckedExpression>>>::create_with({(Tuple{TRY(ByteString::from_utf8(""sv)), checked_rhs})})))),(TRY((DynamicArray<ids::TypeId>::create_with({})))),implementation_function_id,type_id,((implementation_function)->can_throw),((implementation_function)->external_name),((implementation_function)->force_inline));
+types::CheckedCall call_expression = types::CheckedCall((TRY((DynamicArray<types::ResolvedNamespace>::create_with({})))),function_name,(TRY((DynamicArray<JaktInternal::Tuple<ByteString,NonnullRefPtr<typename types::CheckedExpression>>>::create_with({(Tuple{(ByteString::must_from_utf8(""sv)), checked_rhs})})))),(TRY((DynamicArray<ids::TypeId>::create_with({})))),implementation_function_id,type_id,((implementation_function)->can_throw),((implementation_function)->external_name),((implementation_function)->force_inline));
 (((checked_operator).trait_implementation) = types::OperatorTraitImplementation(((implementation).trait_id),((implementation).implemented_type_args),call_expression));
 }
 else {
@@ -7293,67 +7293,67 @@ JaktInternal::Tuple<JaktInternal::DynamicArray<ByteString>,bool> const trait_nam
 auto&& __jakt_match_variant = op;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 0 /* Add */: {
-return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("Add"sv)), TRY(ByteString::from_utf8("ThrowingAdd"sv))})))), false}));
+return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("Add"sv)), (ByteString::must_from_utf8("ThrowingAdd"sv))})))), false}));
 };/*case end*/
 case 1 /* Subtract */: {
-return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("Subtract"sv)), TRY(ByteString::from_utf8("ThrowingSubtract"sv))})))), false}));
+return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("Subtract"sv)), (ByteString::must_from_utf8("ThrowingSubtract"sv))})))), false}));
 };/*case end*/
 case 2 /* Multiply */: {
-return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("Multiply"sv)), TRY(ByteString::from_utf8("ThrowingMultiply"sv))})))), false}));
+return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("Multiply"sv)), (ByteString::must_from_utf8("ThrowingMultiply"sv))})))), false}));
 };/*case end*/
 case 3 /* Divide */: {
-return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("Divide"sv)), TRY(ByteString::from_utf8("ThrowingDivide"sv))})))), false}));
+return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("Divide"sv)), (ByteString::must_from_utf8("ThrowingDivide"sv))})))), false}));
 };/*case end*/
 case 4 /* Modulo */: {
-return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("Modulo"sv)), TRY(ByteString::from_utf8("ThrowingModulo"sv))})))), false}));
+return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("Modulo"sv)), (ByteString::must_from_utf8("ThrowingModulo"sv))})))), false}));
 };/*case end*/
 case 5 /* LessThan */: {
-return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("Compare"sv)), TRY(ByteString::from_utf8("ThrowingCompare"sv))})))), false}));
+return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("Compare"sv)), (ByteString::must_from_utf8("ThrowingCompare"sv))})))), false}));
 };/*case end*/
 case 6 /* LessThanOrEqual */: {
-return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("Compare"sv)), TRY(ByteString::from_utf8("ThrowingCompare"sv))})))), false}));
+return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("Compare"sv)), (ByteString::must_from_utf8("ThrowingCompare"sv))})))), false}));
 };/*case end*/
 case 7 /* GreaterThan */: {
-return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("Compare"sv)), TRY(ByteString::from_utf8("ThrowingCompare"sv))})))), false}));
+return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("Compare"sv)), (ByteString::must_from_utf8("ThrowingCompare"sv))})))), false}));
 };/*case end*/
 case 8 /* GreaterThanOrEqual */: {
-return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("Compare"sv)), TRY(ByteString::from_utf8("ThrowingCompare"sv))})))), false}));
+return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("Compare"sv)), (ByteString::must_from_utf8("ThrowingCompare"sv))})))), false}));
 };/*case end*/
 case 9 /* Equal */: {
-return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("Equal"sv)), TRY(ByteString::from_utf8("ThrowingEqual"sv))})))), false}));
+return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("Equal"sv)), (ByteString::must_from_utf8("ThrowingEqual"sv))})))), false}));
 };/*case end*/
 case 10 /* NotEqual */: {
-return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("Equal"sv)), TRY(ByteString::from_utf8("ThrowingEqual"sv))})))), false}));
+return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("Equal"sv)), (ByteString::must_from_utf8("ThrowingEqual"sv))})))), false}));
 };/*case end*/
 case 27 /* AddAssign */: {
-return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("AddAssign"sv)), TRY(ByteString::from_utf8("ThrowingAddAssign"sv))})))), true}));
+return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("AddAssign"sv)), (ByteString::must_from_utf8("ThrowingAddAssign"sv))})))), true}));
 };/*case end*/
 case 28 /* SubtractAssign */: {
-return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("SubtractAssign"sv)), TRY(ByteString::from_utf8("ThrowingSubtractAssign"sv))})))), true}));
+return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("SubtractAssign"sv)), (ByteString::must_from_utf8("ThrowingSubtractAssign"sv))})))), true}));
 };/*case end*/
 case 29 /* MultiplyAssign */: {
-return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("MultiplyAssign"sv)), TRY(ByteString::from_utf8("ThrowingMultiplyAssign"sv))})))), true}));
+return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("MultiplyAssign"sv)), (ByteString::must_from_utf8("ThrowingMultiplyAssign"sv))})))), true}));
 };/*case end*/
 case 31 /* DivideAssign */: {
-return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("DivideAssign"sv)), TRY(ByteString::from_utf8("ThrowingDivideAssign"sv))})))), true}));
+return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("DivideAssign"sv)), (ByteString::must_from_utf8("ThrowingDivideAssign"sv))})))), true}));
 };/*case end*/
 case 30 /* ModuloAssign */: {
-return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("ModuloAssign"sv)), TRY(ByteString::from_utf8("ThrowingModuloAssign"sv))})))), true}));
+return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("ModuloAssign"sv)), (ByteString::must_from_utf8("ThrowingModuloAssign"sv))})))), true}));
 };/*case end*/
 case 22 /* BitwiseAndAssign */: {
-return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("BitwiseAndAssign"sv)), TRY(ByteString::from_utf8("ThrowingBitwiseAndAssign"sv))})))), true}));
+return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("BitwiseAndAssign"sv)), (ByteString::must_from_utf8("ThrowingBitwiseAndAssign"sv))})))), true}));
 };/*case end*/
 case 23 /* BitwiseOrAssign */: {
-return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("BitwiseOrAssign"sv)), TRY(ByteString::from_utf8("ThrowingBitwiseOrAssign"sv))})))), true}));
+return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("BitwiseOrAssign"sv)), (ByteString::must_from_utf8("ThrowingBitwiseOrAssign"sv))})))), true}));
 };/*case end*/
 case 24 /* BitwiseXorAssign */: {
-return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("BitwiseXorAssign"sv)), TRY(ByteString::from_utf8("ThrowingBitwiseXorAssign"sv))})))), true}));
+return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("BitwiseXorAssign"sv)), (ByteString::must_from_utf8("ThrowingBitwiseXorAssign"sv))})))), true}));
 };/*case end*/
 case 25 /* BitwiseLeftShiftAssign */: {
-return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("BitwiseLeftShiftAssign"sv)), TRY(ByteString::from_utf8("ThrowingBitwiseLeftShiftAssign"sv))})))), true}));
+return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("BitwiseLeftShiftAssign"sv)), (ByteString::must_from_utf8("ThrowingBitwiseLeftShiftAssign"sv))})))), true}));
 };/*case end*/
 case 26 /* BitwiseRightShiftAssign */: {
-return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("BitwiseRightShiftAssign"sv)), TRY(ByteString::from_utf8("ThrowingBitwiseRightShiftAssign"sv))})))), true}));
+return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("BitwiseRightShiftAssign"sv)), (ByteString::must_from_utf8("ThrowingBitwiseRightShiftAssign"sv))})))), true}));
 };/*case end*/
 default: {
 return JaktInternal::ExplicitValue((Tuple{empty_array, false}));
@@ -7373,70 +7373,70 @@ ByteString const function_name = ({
 auto&& __jakt_match_variant = op;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 0 /* Add */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("add"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("add"sv)));
 };/*case end*/
 case 1 /* Subtract */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("subtract"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("subtract"sv)));
 };/*case end*/
 case 2 /* Multiply */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("multiply"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("multiply"sv)));
 };/*case end*/
 case 3 /* Divide */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("divide"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("divide"sv)));
 };/*case end*/
 case 4 /* Modulo */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("modulo"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("modulo"sv)));
 };/*case end*/
 case 5 /* LessThan */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("less_than"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("less_than"sv)));
 };/*case end*/
 case 6 /* LessThanOrEqual */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("less_than_or_equal"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("less_than_or_equal"sv)));
 };/*case end*/
 case 7 /* GreaterThan */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("greater_than"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("greater_than"sv)));
 };/*case end*/
 case 8 /* GreaterThanOrEqual */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("greater_than_or_equal"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("greater_than_or_equal"sv)));
 };/*case end*/
 case 9 /* Equal */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("equals"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("equals"sv)));
 };/*case end*/
 case 10 /* NotEqual */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("not_equals"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("not_equals"sv)));
 };/*case end*/
 case 27 /* AddAssign */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("add_assign"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("add_assign"sv)));
 };/*case end*/
 case 28 /* SubtractAssign */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("subtract_assign"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("subtract_assign"sv)));
 };/*case end*/
 case 29 /* MultiplyAssign */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("multiply_assign"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("multiply_assign"sv)));
 };/*case end*/
 case 31 /* DivideAssign */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("divide_assign"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("divide_assign"sv)));
 };/*case end*/
 case 30 /* ModuloAssign */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("modulo_assign"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("modulo_assign"sv)));
 };/*case end*/
 case 22 /* BitwiseAndAssign */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("bitwise_and_assign"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("bitwise_and_assign"sv)));
 };/*case end*/
 case 23 /* BitwiseOrAssign */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("bitwise_or_assign"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("bitwise_or_assign"sv)));
 };/*case end*/
 case 24 /* BitwiseXorAssign */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("bitwise_xor_assign"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("bitwise_xor_assign"sv)));
 };/*case end*/
 case 25 /* BitwiseLeftShiftAssign */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("bitwise_left_shift_assign"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("bitwise_left_shift_assign"sv)));
 };/*case end*/
 case 26 /* BitwiseRightShiftAssign */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("bitwise_right_shift_assign"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("bitwise_right_shift_assign"sv)));
 };/*case end*/
 default: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8(""sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8(""sv)));
 };/*case end*/
 }/*switch end*/
 }()
@@ -7448,8 +7448,8 @@ return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8(""sv)));
 JaktInternal::Optional<typechecker::TraitImplementationDescriptor> const add_trait_implementation = TRY((((*this).find_any_singular_trait_implementation(lhs_type_id,trait_names,scope_id,lhs_span,(TRY((DynamicArray<ids::TypeId>::create_with({rhs_type_id}))))))));
 if (((add_trait_implementation).has_value())){
 typechecker::TraitImplementationDescriptor const implementation = (add_trait_implementation.value());
-if ((((((implementation).trait_name)).starts_with(TRY(ByteString::from_utf8("Throwing"sv)))) && (!(((scope)->can_throw))))){
-TRY((((*this).error(TRY(ByteString::from_utf8("Call to function that may throw needs to be in a try statement or a function marked as throws"sv)),span))));
+if ((((((implementation).trait_name)).starts_with((ByteString::must_from_utf8("Throwing"sv)))) && (!(((scope)->can_throw))))){
+TRY((((*this).error((ByteString::must_from_utf8("Call to function that may throw needs to be in a try statement or a function marked as throws"sv)),span))));
 }
 JaktInternal::Tuple<JaktInternal::Optional<types::StructLikeId>,bool> const parent_id___ = TRY((((*this).struct_like_id_from_type_id(lhs_type_id,scope_id,span,false,true))));
 JaktInternal::Optional<types::StructLikeId> const parent_id = ((parent_id___).template get<0>());
@@ -7460,15 +7460,15 @@ if (((implementation_function_id).has_value())){
 NonnullRefPtr<types::CheckedFunction> const implementation_function = ((*this).get_function((implementation_function_id.value())));
 if ((TRY((((implementation_function)->is_mutating()))) && (!(((checked_lhs)->is_mutable(((*this).program))))))){
 if (is_assignment){
-TRY((((*this).error(TRY(ByteString::from_utf8("Assignment to immutable variable"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("Assignment to immutable variable"sv)),span))));
 }
 else {
-TRY((((*this).error(TRY(ByteString::from_utf8("Cannot call mutating function on an immutable object instance"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("Cannot call mutating function on an immutable object instance"sv)),span))));
 }
 
 }
 (type_id = ((implementation_function)->return_type_id));
-types::CheckedCall call_expression = types::CheckedCall((TRY((DynamicArray<types::ResolvedNamespace>::create_with({})))),function_name,(TRY((DynamicArray<JaktInternal::Tuple<ByteString,NonnullRefPtr<typename types::CheckedExpression>>>::create_with({(Tuple{TRY(ByteString::from_utf8(""sv)), checked_rhs})})))),(TRY((DynamicArray<ids::TypeId>::create_with({})))),implementation_function_id,type_id,((implementation_function)->can_throw),((implementation_function)->external_name),((implementation_function)->force_inline));
+types::CheckedCall call_expression = types::CheckedCall((TRY((DynamicArray<types::ResolvedNamespace>::create_with({})))),function_name,(TRY((DynamicArray<JaktInternal::Tuple<ByteString,NonnullRefPtr<typename types::CheckedExpression>>>::create_with({(Tuple{(ByteString::must_from_utf8(""sv)), checked_rhs})})))),(TRY((DynamicArray<ids::TypeId>::create_with({})))),implementation_function_id,type_id,((implementation_function)->can_throw),((implementation_function)->external_name),((implementation_function)->force_inline));
 (((checked_operator).trait_implementation) = types::OperatorTraitImplementation(((implementation).trait_id),((implementation).implemented_type_args),call_expression));
 }
 else {
@@ -7545,67 +7545,67 @@ JaktInternal::Tuple<JaktInternal::DynamicArray<ByteString>,bool> const trait_nam
 auto&& __jakt_match_variant = op;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 0 /* Add */: {
-return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("Add"sv)), TRY(ByteString::from_utf8("ThrowingAdd"sv))})))), false}));
+return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("Add"sv)), (ByteString::must_from_utf8("ThrowingAdd"sv))})))), false}));
 };/*case end*/
 case 1 /* Subtract */: {
-return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("Subtract"sv)), TRY(ByteString::from_utf8("ThrowingSubtract"sv))})))), false}));
+return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("Subtract"sv)), (ByteString::must_from_utf8("ThrowingSubtract"sv))})))), false}));
 };/*case end*/
 case 2 /* Multiply */: {
-return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("Multiply"sv)), TRY(ByteString::from_utf8("ThrowingMultiply"sv))})))), false}));
+return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("Multiply"sv)), (ByteString::must_from_utf8("ThrowingMultiply"sv))})))), false}));
 };/*case end*/
 case 3 /* Divide */: {
-return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("Divide"sv)), TRY(ByteString::from_utf8("ThrowingDivide"sv))})))), false}));
+return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("Divide"sv)), (ByteString::must_from_utf8("ThrowingDivide"sv))})))), false}));
 };/*case end*/
 case 4 /* Modulo */: {
-return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("Modulo"sv)), TRY(ByteString::from_utf8("ThrowingModulo"sv))})))), false}));
+return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("Modulo"sv)), (ByteString::must_from_utf8("ThrowingModulo"sv))})))), false}));
 };/*case end*/
 case 5 /* LessThan */: {
-return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("Compare"sv)), TRY(ByteString::from_utf8("ThrowingCompare"sv))})))), false}));
+return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("Compare"sv)), (ByteString::must_from_utf8("ThrowingCompare"sv))})))), false}));
 };/*case end*/
 case 6 /* LessThanOrEqual */: {
-return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("Compare"sv)), TRY(ByteString::from_utf8("ThrowingCompare"sv))})))), false}));
+return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("Compare"sv)), (ByteString::must_from_utf8("ThrowingCompare"sv))})))), false}));
 };/*case end*/
 case 7 /* GreaterThan */: {
-return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("Compare"sv)), TRY(ByteString::from_utf8("ThrowingCompare"sv))})))), false}));
+return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("Compare"sv)), (ByteString::must_from_utf8("ThrowingCompare"sv))})))), false}));
 };/*case end*/
 case 8 /* GreaterThanOrEqual */: {
-return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("Compare"sv)), TRY(ByteString::from_utf8("ThrowingCompare"sv))})))), false}));
+return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("Compare"sv)), (ByteString::must_from_utf8("ThrowingCompare"sv))})))), false}));
 };/*case end*/
 case 9 /* Equal */: {
-return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("Equal"sv)), TRY(ByteString::from_utf8("ThrowingEqual"sv))})))), false}));
+return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("Equal"sv)), (ByteString::must_from_utf8("ThrowingEqual"sv))})))), false}));
 };/*case end*/
 case 10 /* NotEqual */: {
-return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("Equal"sv)), TRY(ByteString::from_utf8("ThrowingEqual"sv))})))), false}));
+return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("Equal"sv)), (ByteString::must_from_utf8("ThrowingEqual"sv))})))), false}));
 };/*case end*/
 case 27 /* AddAssign */: {
-return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("AddAssign"sv)), TRY(ByteString::from_utf8("ThrowingAddAssign"sv))})))), true}));
+return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("AddAssign"sv)), (ByteString::must_from_utf8("ThrowingAddAssign"sv))})))), true}));
 };/*case end*/
 case 28 /* SubtractAssign */: {
-return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("SubtractAssign"sv)), TRY(ByteString::from_utf8("ThrowingSubtractAssign"sv))})))), true}));
+return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("SubtractAssign"sv)), (ByteString::must_from_utf8("ThrowingSubtractAssign"sv))})))), true}));
 };/*case end*/
 case 29 /* MultiplyAssign */: {
-return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("MultiplyAssign"sv)), TRY(ByteString::from_utf8("ThrowingMultiplyAssign"sv))})))), true}));
+return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("MultiplyAssign"sv)), (ByteString::must_from_utf8("ThrowingMultiplyAssign"sv))})))), true}));
 };/*case end*/
 case 31 /* DivideAssign */: {
-return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("DivideAssign"sv)), TRY(ByteString::from_utf8("ThrowingDivideAssign"sv))})))), true}));
+return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("DivideAssign"sv)), (ByteString::must_from_utf8("ThrowingDivideAssign"sv))})))), true}));
 };/*case end*/
 case 30 /* ModuloAssign */: {
-return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("ModuloAssign"sv)), TRY(ByteString::from_utf8("ThrowingModuloAssign"sv))})))), true}));
+return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("ModuloAssign"sv)), (ByteString::must_from_utf8("ThrowingModuloAssign"sv))})))), true}));
 };/*case end*/
 case 22 /* BitwiseAndAssign */: {
-return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("BitwiseAndAssign"sv)), TRY(ByteString::from_utf8("ThrowingBitwiseAndAssign"sv))})))), true}));
+return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("BitwiseAndAssign"sv)), (ByteString::must_from_utf8("ThrowingBitwiseAndAssign"sv))})))), true}));
 };/*case end*/
 case 23 /* BitwiseOrAssign */: {
-return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("BitwiseOrAssign"sv)), TRY(ByteString::from_utf8("ThrowingBitwiseOrAssign"sv))})))), true}));
+return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("BitwiseOrAssign"sv)), (ByteString::must_from_utf8("ThrowingBitwiseOrAssign"sv))})))), true}));
 };/*case end*/
 case 24 /* BitwiseXorAssign */: {
-return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("BitwiseXorAssign"sv)), TRY(ByteString::from_utf8("ThrowingBitwiseXorAssign"sv))})))), true}));
+return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("BitwiseXorAssign"sv)), (ByteString::must_from_utf8("ThrowingBitwiseXorAssign"sv))})))), true}));
 };/*case end*/
 case 25 /* BitwiseLeftShiftAssign */: {
-return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("BitwiseLeftShiftAssign"sv)), TRY(ByteString::from_utf8("ThrowingBitwiseLeftShiftAssign"sv))})))), true}));
+return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("BitwiseLeftShiftAssign"sv)), (ByteString::must_from_utf8("ThrowingBitwiseLeftShiftAssign"sv))})))), true}));
 };/*case end*/
 case 26 /* BitwiseRightShiftAssign */: {
-return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("BitwiseRightShiftAssign"sv)), TRY(ByteString::from_utf8("ThrowingBitwiseRightShiftAssign"sv))})))), true}));
+return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("BitwiseRightShiftAssign"sv)), (ByteString::must_from_utf8("ThrowingBitwiseRightShiftAssign"sv))})))), true}));
 };/*case end*/
 default: {
 return JaktInternal::ExplicitValue((Tuple{empty_array, false}));
@@ -7625,70 +7625,70 @@ ByteString const function_name = ({
 auto&& __jakt_match_variant = op;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 0 /* Add */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("add"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("add"sv)));
 };/*case end*/
 case 1 /* Subtract */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("subtract"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("subtract"sv)));
 };/*case end*/
 case 2 /* Multiply */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("multiply"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("multiply"sv)));
 };/*case end*/
 case 3 /* Divide */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("divide"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("divide"sv)));
 };/*case end*/
 case 4 /* Modulo */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("modulo"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("modulo"sv)));
 };/*case end*/
 case 5 /* LessThan */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("less_than"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("less_than"sv)));
 };/*case end*/
 case 6 /* LessThanOrEqual */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("less_than_or_equal"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("less_than_or_equal"sv)));
 };/*case end*/
 case 7 /* GreaterThan */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("greater_than"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("greater_than"sv)));
 };/*case end*/
 case 8 /* GreaterThanOrEqual */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("greater_than_or_equal"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("greater_than_or_equal"sv)));
 };/*case end*/
 case 9 /* Equal */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("equals"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("equals"sv)));
 };/*case end*/
 case 10 /* NotEqual */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("not_equals"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("not_equals"sv)));
 };/*case end*/
 case 27 /* AddAssign */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("add_assign"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("add_assign"sv)));
 };/*case end*/
 case 28 /* SubtractAssign */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("subtract_assign"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("subtract_assign"sv)));
 };/*case end*/
 case 29 /* MultiplyAssign */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("multiply_assign"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("multiply_assign"sv)));
 };/*case end*/
 case 31 /* DivideAssign */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("divide_assign"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("divide_assign"sv)));
 };/*case end*/
 case 30 /* ModuloAssign */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("modulo_assign"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("modulo_assign"sv)));
 };/*case end*/
 case 22 /* BitwiseAndAssign */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("bitwise_and_assign"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("bitwise_and_assign"sv)));
 };/*case end*/
 case 23 /* BitwiseOrAssign */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("bitwise_or_assign"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("bitwise_or_assign"sv)));
 };/*case end*/
 case 24 /* BitwiseXorAssign */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("bitwise_xor_assign"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("bitwise_xor_assign"sv)));
 };/*case end*/
 case 25 /* BitwiseLeftShiftAssign */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("bitwise_left_shift_assign"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("bitwise_left_shift_assign"sv)));
 };/*case end*/
 case 26 /* BitwiseRightShiftAssign */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("bitwise_right_shift_assign"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("bitwise_right_shift_assign"sv)));
 };/*case end*/
 default: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8(""sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8(""sv)));
 };/*case end*/
 }/*switch end*/
 }()
@@ -7700,8 +7700,8 @@ return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8(""sv)));
 JaktInternal::Optional<typechecker::TraitImplementationDescriptor> const add_trait_implementation = TRY((((*this).find_any_singular_trait_implementation(lhs_type_id,trait_names,scope_id,lhs_span,(TRY((DynamicArray<ids::TypeId>::create_with({rhs_type_id}))))))));
 if (((add_trait_implementation).has_value())){
 typechecker::TraitImplementationDescriptor const implementation = (add_trait_implementation.value());
-if ((((((implementation).trait_name)).starts_with(TRY(ByteString::from_utf8("Throwing"sv)))) && (!(((scope)->can_throw))))){
-TRY((((*this).error(TRY(ByteString::from_utf8("Call to function that may throw needs to be in a try statement or a function marked as throws"sv)),span))));
+if ((((((implementation).trait_name)).starts_with((ByteString::must_from_utf8("Throwing"sv)))) && (!(((scope)->can_throw))))){
+TRY((((*this).error((ByteString::must_from_utf8("Call to function that may throw needs to be in a try statement or a function marked as throws"sv)),span))));
 }
 JaktInternal::Tuple<JaktInternal::Optional<types::StructLikeId>,bool> const parent_id___ = TRY((((*this).struct_like_id_from_type_id(lhs_type_id,scope_id,span,false,true))));
 JaktInternal::Optional<types::StructLikeId> const parent_id = ((parent_id___).template get<0>());
@@ -7712,15 +7712,15 @@ if (((implementation_function_id).has_value())){
 NonnullRefPtr<types::CheckedFunction> const implementation_function = ((*this).get_function((implementation_function_id.value())));
 if ((TRY((((implementation_function)->is_mutating()))) && (!(((checked_lhs)->is_mutable(((*this).program))))))){
 if (is_assignment){
-TRY((((*this).error(TRY(ByteString::from_utf8("Assignment to immutable variable"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("Assignment to immutable variable"sv)),span))));
 }
 else {
-TRY((((*this).error(TRY(ByteString::from_utf8("Cannot call mutating function on an immutable object instance"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("Cannot call mutating function on an immutable object instance"sv)),span))));
 }
 
 }
 (type_id = ((implementation_function)->return_type_id));
-types::CheckedCall call_expression = types::CheckedCall((TRY((DynamicArray<types::ResolvedNamespace>::create_with({})))),function_name,(TRY((DynamicArray<JaktInternal::Tuple<ByteString,NonnullRefPtr<typename types::CheckedExpression>>>::create_with({(Tuple{TRY(ByteString::from_utf8(""sv)), checked_rhs})})))),(TRY((DynamicArray<ids::TypeId>::create_with({})))),implementation_function_id,type_id,((implementation_function)->can_throw),((implementation_function)->external_name),((implementation_function)->force_inline));
+types::CheckedCall call_expression = types::CheckedCall((TRY((DynamicArray<types::ResolvedNamespace>::create_with({})))),function_name,(TRY((DynamicArray<JaktInternal::Tuple<ByteString,NonnullRefPtr<typename types::CheckedExpression>>>::create_with({(Tuple{(ByteString::must_from_utf8(""sv)), checked_rhs})})))),(TRY((DynamicArray<ids::TypeId>::create_with({})))),implementation_function_id,type_id,((implementation_function)->can_throw),((implementation_function)->external_name),((implementation_function)->force_inline));
 (((checked_operator).trait_implementation) = types::OperatorTraitImplementation(((implementation).trait_id),((implementation).implemented_type_args),call_expression));
 }
 else {
@@ -7797,67 +7797,67 @@ JaktInternal::Tuple<JaktInternal::DynamicArray<ByteString>,bool> const trait_nam
 auto&& __jakt_match_variant = op;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 0 /* Add */: {
-return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("Add"sv)), TRY(ByteString::from_utf8("ThrowingAdd"sv))})))), false}));
+return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("Add"sv)), (ByteString::must_from_utf8("ThrowingAdd"sv))})))), false}));
 };/*case end*/
 case 1 /* Subtract */: {
-return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("Subtract"sv)), TRY(ByteString::from_utf8("ThrowingSubtract"sv))})))), false}));
+return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("Subtract"sv)), (ByteString::must_from_utf8("ThrowingSubtract"sv))})))), false}));
 };/*case end*/
 case 2 /* Multiply */: {
-return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("Multiply"sv)), TRY(ByteString::from_utf8("ThrowingMultiply"sv))})))), false}));
+return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("Multiply"sv)), (ByteString::must_from_utf8("ThrowingMultiply"sv))})))), false}));
 };/*case end*/
 case 3 /* Divide */: {
-return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("Divide"sv)), TRY(ByteString::from_utf8("ThrowingDivide"sv))})))), false}));
+return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("Divide"sv)), (ByteString::must_from_utf8("ThrowingDivide"sv))})))), false}));
 };/*case end*/
 case 4 /* Modulo */: {
-return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("Modulo"sv)), TRY(ByteString::from_utf8("ThrowingModulo"sv))})))), false}));
+return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("Modulo"sv)), (ByteString::must_from_utf8("ThrowingModulo"sv))})))), false}));
 };/*case end*/
 case 5 /* LessThan */: {
-return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("Compare"sv)), TRY(ByteString::from_utf8("ThrowingCompare"sv))})))), false}));
+return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("Compare"sv)), (ByteString::must_from_utf8("ThrowingCompare"sv))})))), false}));
 };/*case end*/
 case 6 /* LessThanOrEqual */: {
-return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("Compare"sv)), TRY(ByteString::from_utf8("ThrowingCompare"sv))})))), false}));
+return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("Compare"sv)), (ByteString::must_from_utf8("ThrowingCompare"sv))})))), false}));
 };/*case end*/
 case 7 /* GreaterThan */: {
-return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("Compare"sv)), TRY(ByteString::from_utf8("ThrowingCompare"sv))})))), false}));
+return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("Compare"sv)), (ByteString::must_from_utf8("ThrowingCompare"sv))})))), false}));
 };/*case end*/
 case 8 /* GreaterThanOrEqual */: {
-return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("Compare"sv)), TRY(ByteString::from_utf8("ThrowingCompare"sv))})))), false}));
+return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("Compare"sv)), (ByteString::must_from_utf8("ThrowingCompare"sv))})))), false}));
 };/*case end*/
 case 9 /* Equal */: {
-return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("Equal"sv)), TRY(ByteString::from_utf8("ThrowingEqual"sv))})))), false}));
+return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("Equal"sv)), (ByteString::must_from_utf8("ThrowingEqual"sv))})))), false}));
 };/*case end*/
 case 10 /* NotEqual */: {
-return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("Equal"sv)), TRY(ByteString::from_utf8("ThrowingEqual"sv))})))), false}));
+return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("Equal"sv)), (ByteString::must_from_utf8("ThrowingEqual"sv))})))), false}));
 };/*case end*/
 case 27 /* AddAssign */: {
-return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("AddAssign"sv)), TRY(ByteString::from_utf8("ThrowingAddAssign"sv))})))), true}));
+return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("AddAssign"sv)), (ByteString::must_from_utf8("ThrowingAddAssign"sv))})))), true}));
 };/*case end*/
 case 28 /* SubtractAssign */: {
-return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("SubtractAssign"sv)), TRY(ByteString::from_utf8("ThrowingSubtractAssign"sv))})))), true}));
+return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("SubtractAssign"sv)), (ByteString::must_from_utf8("ThrowingSubtractAssign"sv))})))), true}));
 };/*case end*/
 case 29 /* MultiplyAssign */: {
-return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("MultiplyAssign"sv)), TRY(ByteString::from_utf8("ThrowingMultiplyAssign"sv))})))), true}));
+return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("MultiplyAssign"sv)), (ByteString::must_from_utf8("ThrowingMultiplyAssign"sv))})))), true}));
 };/*case end*/
 case 31 /* DivideAssign */: {
-return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("DivideAssign"sv)), TRY(ByteString::from_utf8("ThrowingDivideAssign"sv))})))), true}));
+return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("DivideAssign"sv)), (ByteString::must_from_utf8("ThrowingDivideAssign"sv))})))), true}));
 };/*case end*/
 case 30 /* ModuloAssign */: {
-return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("ModuloAssign"sv)), TRY(ByteString::from_utf8("ThrowingModuloAssign"sv))})))), true}));
+return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("ModuloAssign"sv)), (ByteString::must_from_utf8("ThrowingModuloAssign"sv))})))), true}));
 };/*case end*/
 case 22 /* BitwiseAndAssign */: {
-return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("BitwiseAndAssign"sv)), TRY(ByteString::from_utf8("ThrowingBitwiseAndAssign"sv))})))), true}));
+return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("BitwiseAndAssign"sv)), (ByteString::must_from_utf8("ThrowingBitwiseAndAssign"sv))})))), true}));
 };/*case end*/
 case 23 /* BitwiseOrAssign */: {
-return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("BitwiseOrAssign"sv)), TRY(ByteString::from_utf8("ThrowingBitwiseOrAssign"sv))})))), true}));
+return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("BitwiseOrAssign"sv)), (ByteString::must_from_utf8("ThrowingBitwiseOrAssign"sv))})))), true}));
 };/*case end*/
 case 24 /* BitwiseXorAssign */: {
-return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("BitwiseXorAssign"sv)), TRY(ByteString::from_utf8("ThrowingBitwiseXorAssign"sv))})))), true}));
+return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("BitwiseXorAssign"sv)), (ByteString::must_from_utf8("ThrowingBitwiseXorAssign"sv))})))), true}));
 };/*case end*/
 case 25 /* BitwiseLeftShiftAssign */: {
-return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("BitwiseLeftShiftAssign"sv)), TRY(ByteString::from_utf8("ThrowingBitwiseLeftShiftAssign"sv))})))), true}));
+return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("BitwiseLeftShiftAssign"sv)), (ByteString::must_from_utf8("ThrowingBitwiseLeftShiftAssign"sv))})))), true}));
 };/*case end*/
 case 26 /* BitwiseRightShiftAssign */: {
-return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("BitwiseRightShiftAssign"sv)), TRY(ByteString::from_utf8("ThrowingBitwiseRightShiftAssign"sv))})))), true}));
+return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("BitwiseRightShiftAssign"sv)), (ByteString::must_from_utf8("ThrowingBitwiseRightShiftAssign"sv))})))), true}));
 };/*case end*/
 default: {
 return JaktInternal::ExplicitValue((Tuple{empty_array, false}));
@@ -7877,70 +7877,70 @@ ByteString const function_name = ({
 auto&& __jakt_match_variant = op;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 0 /* Add */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("add"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("add"sv)));
 };/*case end*/
 case 1 /* Subtract */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("subtract"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("subtract"sv)));
 };/*case end*/
 case 2 /* Multiply */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("multiply"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("multiply"sv)));
 };/*case end*/
 case 3 /* Divide */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("divide"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("divide"sv)));
 };/*case end*/
 case 4 /* Modulo */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("modulo"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("modulo"sv)));
 };/*case end*/
 case 5 /* LessThan */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("less_than"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("less_than"sv)));
 };/*case end*/
 case 6 /* LessThanOrEqual */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("less_than_or_equal"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("less_than_or_equal"sv)));
 };/*case end*/
 case 7 /* GreaterThan */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("greater_than"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("greater_than"sv)));
 };/*case end*/
 case 8 /* GreaterThanOrEqual */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("greater_than_or_equal"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("greater_than_or_equal"sv)));
 };/*case end*/
 case 9 /* Equal */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("equals"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("equals"sv)));
 };/*case end*/
 case 10 /* NotEqual */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("not_equals"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("not_equals"sv)));
 };/*case end*/
 case 27 /* AddAssign */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("add_assign"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("add_assign"sv)));
 };/*case end*/
 case 28 /* SubtractAssign */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("subtract_assign"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("subtract_assign"sv)));
 };/*case end*/
 case 29 /* MultiplyAssign */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("multiply_assign"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("multiply_assign"sv)));
 };/*case end*/
 case 31 /* DivideAssign */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("divide_assign"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("divide_assign"sv)));
 };/*case end*/
 case 30 /* ModuloAssign */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("modulo_assign"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("modulo_assign"sv)));
 };/*case end*/
 case 22 /* BitwiseAndAssign */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("bitwise_and_assign"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("bitwise_and_assign"sv)));
 };/*case end*/
 case 23 /* BitwiseOrAssign */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("bitwise_or_assign"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("bitwise_or_assign"sv)));
 };/*case end*/
 case 24 /* BitwiseXorAssign */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("bitwise_xor_assign"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("bitwise_xor_assign"sv)));
 };/*case end*/
 case 25 /* BitwiseLeftShiftAssign */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("bitwise_left_shift_assign"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("bitwise_left_shift_assign"sv)));
 };/*case end*/
 case 26 /* BitwiseRightShiftAssign */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("bitwise_right_shift_assign"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("bitwise_right_shift_assign"sv)));
 };/*case end*/
 default: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8(""sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8(""sv)));
 };/*case end*/
 }/*switch end*/
 }()
@@ -7952,8 +7952,8 @@ return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8(""sv)));
 JaktInternal::Optional<typechecker::TraitImplementationDescriptor> const add_trait_implementation = TRY((((*this).find_any_singular_trait_implementation(lhs_type_id,trait_names,scope_id,lhs_span,(TRY((DynamicArray<ids::TypeId>::create_with({rhs_type_id}))))))));
 if (((add_trait_implementation).has_value())){
 typechecker::TraitImplementationDescriptor const implementation = (add_trait_implementation.value());
-if ((((((implementation).trait_name)).starts_with(TRY(ByteString::from_utf8("Throwing"sv)))) && (!(((scope)->can_throw))))){
-TRY((((*this).error(TRY(ByteString::from_utf8("Call to function that may throw needs to be in a try statement or a function marked as throws"sv)),span))));
+if ((((((implementation).trait_name)).starts_with((ByteString::must_from_utf8("Throwing"sv)))) && (!(((scope)->can_throw))))){
+TRY((((*this).error((ByteString::must_from_utf8("Call to function that may throw needs to be in a try statement or a function marked as throws"sv)),span))));
 }
 JaktInternal::Tuple<JaktInternal::Optional<types::StructLikeId>,bool> const parent_id___ = TRY((((*this).struct_like_id_from_type_id(lhs_type_id,scope_id,span,false,true))));
 JaktInternal::Optional<types::StructLikeId> const parent_id = ((parent_id___).template get<0>());
@@ -7964,15 +7964,15 @@ if (((implementation_function_id).has_value())){
 NonnullRefPtr<types::CheckedFunction> const implementation_function = ((*this).get_function((implementation_function_id.value())));
 if ((TRY((((implementation_function)->is_mutating()))) && (!(((checked_lhs)->is_mutable(((*this).program))))))){
 if (is_assignment){
-TRY((((*this).error(TRY(ByteString::from_utf8("Assignment to immutable variable"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("Assignment to immutable variable"sv)),span))));
 }
 else {
-TRY((((*this).error(TRY(ByteString::from_utf8("Cannot call mutating function on an immutable object instance"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("Cannot call mutating function on an immutable object instance"sv)),span))));
 }
 
 }
 (type_id = ((implementation_function)->return_type_id));
-types::CheckedCall call_expression = types::CheckedCall((TRY((DynamicArray<types::ResolvedNamespace>::create_with({})))),function_name,(TRY((DynamicArray<JaktInternal::Tuple<ByteString,NonnullRefPtr<typename types::CheckedExpression>>>::create_with({(Tuple{TRY(ByteString::from_utf8(""sv)), checked_rhs})})))),(TRY((DynamicArray<ids::TypeId>::create_with({})))),implementation_function_id,type_id,((implementation_function)->can_throw),((implementation_function)->external_name),((implementation_function)->force_inline));
+types::CheckedCall call_expression = types::CheckedCall((TRY((DynamicArray<types::ResolvedNamespace>::create_with({})))),function_name,(TRY((DynamicArray<JaktInternal::Tuple<ByteString,NonnullRefPtr<typename types::CheckedExpression>>>::create_with({(Tuple{(ByteString::must_from_utf8(""sv)), checked_rhs})})))),(TRY((DynamicArray<ids::TypeId>::create_with({})))),implementation_function_id,type_id,((implementation_function)->can_throw),((implementation_function)->external_name),((implementation_function)->force_inline));
 (((checked_operator).trait_implementation) = types::OperatorTraitImplementation(((implementation).trait_id),((implementation).implemented_type_args),call_expression));
 }
 else {
@@ -8049,67 +8049,67 @@ JaktInternal::Tuple<JaktInternal::DynamicArray<ByteString>,bool> const trait_nam
 auto&& __jakt_match_variant = op;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 0 /* Add */: {
-return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("Add"sv)), TRY(ByteString::from_utf8("ThrowingAdd"sv))})))), false}));
+return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("Add"sv)), (ByteString::must_from_utf8("ThrowingAdd"sv))})))), false}));
 };/*case end*/
 case 1 /* Subtract */: {
-return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("Subtract"sv)), TRY(ByteString::from_utf8("ThrowingSubtract"sv))})))), false}));
+return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("Subtract"sv)), (ByteString::must_from_utf8("ThrowingSubtract"sv))})))), false}));
 };/*case end*/
 case 2 /* Multiply */: {
-return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("Multiply"sv)), TRY(ByteString::from_utf8("ThrowingMultiply"sv))})))), false}));
+return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("Multiply"sv)), (ByteString::must_from_utf8("ThrowingMultiply"sv))})))), false}));
 };/*case end*/
 case 3 /* Divide */: {
-return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("Divide"sv)), TRY(ByteString::from_utf8("ThrowingDivide"sv))})))), false}));
+return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("Divide"sv)), (ByteString::must_from_utf8("ThrowingDivide"sv))})))), false}));
 };/*case end*/
 case 4 /* Modulo */: {
-return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("Modulo"sv)), TRY(ByteString::from_utf8("ThrowingModulo"sv))})))), false}));
+return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("Modulo"sv)), (ByteString::must_from_utf8("ThrowingModulo"sv))})))), false}));
 };/*case end*/
 case 5 /* LessThan */: {
-return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("Compare"sv)), TRY(ByteString::from_utf8("ThrowingCompare"sv))})))), false}));
+return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("Compare"sv)), (ByteString::must_from_utf8("ThrowingCompare"sv))})))), false}));
 };/*case end*/
 case 6 /* LessThanOrEqual */: {
-return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("Compare"sv)), TRY(ByteString::from_utf8("ThrowingCompare"sv))})))), false}));
+return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("Compare"sv)), (ByteString::must_from_utf8("ThrowingCompare"sv))})))), false}));
 };/*case end*/
 case 7 /* GreaterThan */: {
-return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("Compare"sv)), TRY(ByteString::from_utf8("ThrowingCompare"sv))})))), false}));
+return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("Compare"sv)), (ByteString::must_from_utf8("ThrowingCompare"sv))})))), false}));
 };/*case end*/
 case 8 /* GreaterThanOrEqual */: {
-return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("Compare"sv)), TRY(ByteString::from_utf8("ThrowingCompare"sv))})))), false}));
+return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("Compare"sv)), (ByteString::must_from_utf8("ThrowingCompare"sv))})))), false}));
 };/*case end*/
 case 9 /* Equal */: {
-return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("Equal"sv)), TRY(ByteString::from_utf8("ThrowingEqual"sv))})))), false}));
+return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("Equal"sv)), (ByteString::must_from_utf8("ThrowingEqual"sv))})))), false}));
 };/*case end*/
 case 10 /* NotEqual */: {
-return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("Equal"sv)), TRY(ByteString::from_utf8("ThrowingEqual"sv))})))), false}));
+return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("Equal"sv)), (ByteString::must_from_utf8("ThrowingEqual"sv))})))), false}));
 };/*case end*/
 case 27 /* AddAssign */: {
-return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("AddAssign"sv)), TRY(ByteString::from_utf8("ThrowingAddAssign"sv))})))), true}));
+return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("AddAssign"sv)), (ByteString::must_from_utf8("ThrowingAddAssign"sv))})))), true}));
 };/*case end*/
 case 28 /* SubtractAssign */: {
-return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("SubtractAssign"sv)), TRY(ByteString::from_utf8("ThrowingSubtractAssign"sv))})))), true}));
+return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("SubtractAssign"sv)), (ByteString::must_from_utf8("ThrowingSubtractAssign"sv))})))), true}));
 };/*case end*/
 case 29 /* MultiplyAssign */: {
-return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("MultiplyAssign"sv)), TRY(ByteString::from_utf8("ThrowingMultiplyAssign"sv))})))), true}));
+return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("MultiplyAssign"sv)), (ByteString::must_from_utf8("ThrowingMultiplyAssign"sv))})))), true}));
 };/*case end*/
 case 31 /* DivideAssign */: {
-return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("DivideAssign"sv)), TRY(ByteString::from_utf8("ThrowingDivideAssign"sv))})))), true}));
+return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("DivideAssign"sv)), (ByteString::must_from_utf8("ThrowingDivideAssign"sv))})))), true}));
 };/*case end*/
 case 30 /* ModuloAssign */: {
-return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("ModuloAssign"sv)), TRY(ByteString::from_utf8("ThrowingModuloAssign"sv))})))), true}));
+return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("ModuloAssign"sv)), (ByteString::must_from_utf8("ThrowingModuloAssign"sv))})))), true}));
 };/*case end*/
 case 22 /* BitwiseAndAssign */: {
-return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("BitwiseAndAssign"sv)), TRY(ByteString::from_utf8("ThrowingBitwiseAndAssign"sv))})))), true}));
+return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("BitwiseAndAssign"sv)), (ByteString::must_from_utf8("ThrowingBitwiseAndAssign"sv))})))), true}));
 };/*case end*/
 case 23 /* BitwiseOrAssign */: {
-return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("BitwiseOrAssign"sv)), TRY(ByteString::from_utf8("ThrowingBitwiseOrAssign"sv))})))), true}));
+return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("BitwiseOrAssign"sv)), (ByteString::must_from_utf8("ThrowingBitwiseOrAssign"sv))})))), true}));
 };/*case end*/
 case 24 /* BitwiseXorAssign */: {
-return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("BitwiseXorAssign"sv)), TRY(ByteString::from_utf8("ThrowingBitwiseXorAssign"sv))})))), true}));
+return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("BitwiseXorAssign"sv)), (ByteString::must_from_utf8("ThrowingBitwiseXorAssign"sv))})))), true}));
 };/*case end*/
 case 25 /* BitwiseLeftShiftAssign */: {
-return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("BitwiseLeftShiftAssign"sv)), TRY(ByteString::from_utf8("ThrowingBitwiseLeftShiftAssign"sv))})))), true}));
+return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("BitwiseLeftShiftAssign"sv)), (ByteString::must_from_utf8("ThrowingBitwiseLeftShiftAssign"sv))})))), true}));
 };/*case end*/
 case 26 /* BitwiseRightShiftAssign */: {
-return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("BitwiseRightShiftAssign"sv)), TRY(ByteString::from_utf8("ThrowingBitwiseRightShiftAssign"sv))})))), true}));
+return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("BitwiseRightShiftAssign"sv)), (ByteString::must_from_utf8("ThrowingBitwiseRightShiftAssign"sv))})))), true}));
 };/*case end*/
 default: {
 return JaktInternal::ExplicitValue((Tuple{empty_array, false}));
@@ -8129,70 +8129,70 @@ ByteString const function_name = ({
 auto&& __jakt_match_variant = op;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 0 /* Add */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("add"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("add"sv)));
 };/*case end*/
 case 1 /* Subtract */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("subtract"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("subtract"sv)));
 };/*case end*/
 case 2 /* Multiply */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("multiply"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("multiply"sv)));
 };/*case end*/
 case 3 /* Divide */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("divide"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("divide"sv)));
 };/*case end*/
 case 4 /* Modulo */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("modulo"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("modulo"sv)));
 };/*case end*/
 case 5 /* LessThan */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("less_than"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("less_than"sv)));
 };/*case end*/
 case 6 /* LessThanOrEqual */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("less_than_or_equal"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("less_than_or_equal"sv)));
 };/*case end*/
 case 7 /* GreaterThan */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("greater_than"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("greater_than"sv)));
 };/*case end*/
 case 8 /* GreaterThanOrEqual */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("greater_than_or_equal"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("greater_than_or_equal"sv)));
 };/*case end*/
 case 9 /* Equal */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("equals"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("equals"sv)));
 };/*case end*/
 case 10 /* NotEqual */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("not_equals"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("not_equals"sv)));
 };/*case end*/
 case 27 /* AddAssign */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("add_assign"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("add_assign"sv)));
 };/*case end*/
 case 28 /* SubtractAssign */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("subtract_assign"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("subtract_assign"sv)));
 };/*case end*/
 case 29 /* MultiplyAssign */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("multiply_assign"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("multiply_assign"sv)));
 };/*case end*/
 case 31 /* DivideAssign */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("divide_assign"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("divide_assign"sv)));
 };/*case end*/
 case 30 /* ModuloAssign */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("modulo_assign"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("modulo_assign"sv)));
 };/*case end*/
 case 22 /* BitwiseAndAssign */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("bitwise_and_assign"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("bitwise_and_assign"sv)));
 };/*case end*/
 case 23 /* BitwiseOrAssign */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("bitwise_or_assign"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("bitwise_or_assign"sv)));
 };/*case end*/
 case 24 /* BitwiseXorAssign */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("bitwise_xor_assign"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("bitwise_xor_assign"sv)));
 };/*case end*/
 case 25 /* BitwiseLeftShiftAssign */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("bitwise_left_shift_assign"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("bitwise_left_shift_assign"sv)));
 };/*case end*/
 case 26 /* BitwiseRightShiftAssign */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("bitwise_right_shift_assign"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("bitwise_right_shift_assign"sv)));
 };/*case end*/
 default: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8(""sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8(""sv)));
 };/*case end*/
 }/*switch end*/
 }()
@@ -8204,8 +8204,8 @@ return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8(""sv)));
 JaktInternal::Optional<typechecker::TraitImplementationDescriptor> const add_trait_implementation = TRY((((*this).find_any_singular_trait_implementation(lhs_type_id,trait_names,scope_id,lhs_span,(TRY((DynamicArray<ids::TypeId>::create_with({rhs_type_id}))))))));
 if (((add_trait_implementation).has_value())){
 typechecker::TraitImplementationDescriptor const implementation = (add_trait_implementation.value());
-if ((((((implementation).trait_name)).starts_with(TRY(ByteString::from_utf8("Throwing"sv)))) && (!(((scope)->can_throw))))){
-TRY((((*this).error(TRY(ByteString::from_utf8("Call to function that may throw needs to be in a try statement or a function marked as throws"sv)),span))));
+if ((((((implementation).trait_name)).starts_with((ByteString::must_from_utf8("Throwing"sv)))) && (!(((scope)->can_throw))))){
+TRY((((*this).error((ByteString::must_from_utf8("Call to function that may throw needs to be in a try statement or a function marked as throws"sv)),span))));
 }
 JaktInternal::Tuple<JaktInternal::Optional<types::StructLikeId>,bool> const parent_id___ = TRY((((*this).struct_like_id_from_type_id(lhs_type_id,scope_id,span,false,true))));
 JaktInternal::Optional<types::StructLikeId> const parent_id = ((parent_id___).template get<0>());
@@ -8216,15 +8216,15 @@ if (((implementation_function_id).has_value())){
 NonnullRefPtr<types::CheckedFunction> const implementation_function = ((*this).get_function((implementation_function_id.value())));
 if ((TRY((((implementation_function)->is_mutating()))) && (!(((checked_lhs)->is_mutable(((*this).program))))))){
 if (is_assignment){
-TRY((((*this).error(TRY(ByteString::from_utf8("Assignment to immutable variable"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("Assignment to immutable variable"sv)),span))));
 }
 else {
-TRY((((*this).error(TRY(ByteString::from_utf8("Cannot call mutating function on an immutable object instance"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("Cannot call mutating function on an immutable object instance"sv)),span))));
 }
 
 }
 (type_id = ((implementation_function)->return_type_id));
-types::CheckedCall call_expression = types::CheckedCall((TRY((DynamicArray<types::ResolvedNamespace>::create_with({})))),function_name,(TRY((DynamicArray<JaktInternal::Tuple<ByteString,NonnullRefPtr<typename types::CheckedExpression>>>::create_with({(Tuple{TRY(ByteString::from_utf8(""sv)), checked_rhs})})))),(TRY((DynamicArray<ids::TypeId>::create_with({})))),implementation_function_id,type_id,((implementation_function)->can_throw),((implementation_function)->external_name),((implementation_function)->force_inline));
+types::CheckedCall call_expression = types::CheckedCall((TRY((DynamicArray<types::ResolvedNamespace>::create_with({})))),function_name,(TRY((DynamicArray<JaktInternal::Tuple<ByteString,NonnullRefPtr<typename types::CheckedExpression>>>::create_with({(Tuple{(ByteString::must_from_utf8(""sv)), checked_rhs})})))),(TRY((DynamicArray<ids::TypeId>::create_with({})))),implementation_function_id,type_id,((implementation_function)->can_throw),((implementation_function)->external_name),((implementation_function)->force_inline));
 (((checked_operator).trait_implementation) = types::OperatorTraitImplementation(((implementation).trait_id),((implementation).implemented_type_args),call_expression));
 }
 else {
@@ -8301,67 +8301,67 @@ JaktInternal::Tuple<JaktInternal::DynamicArray<ByteString>,bool> const trait_nam
 auto&& __jakt_match_variant = op;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 0 /* Add */: {
-return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("Add"sv)), TRY(ByteString::from_utf8("ThrowingAdd"sv))})))), false}));
+return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("Add"sv)), (ByteString::must_from_utf8("ThrowingAdd"sv))})))), false}));
 };/*case end*/
 case 1 /* Subtract */: {
-return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("Subtract"sv)), TRY(ByteString::from_utf8("ThrowingSubtract"sv))})))), false}));
+return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("Subtract"sv)), (ByteString::must_from_utf8("ThrowingSubtract"sv))})))), false}));
 };/*case end*/
 case 2 /* Multiply */: {
-return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("Multiply"sv)), TRY(ByteString::from_utf8("ThrowingMultiply"sv))})))), false}));
+return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("Multiply"sv)), (ByteString::must_from_utf8("ThrowingMultiply"sv))})))), false}));
 };/*case end*/
 case 3 /* Divide */: {
-return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("Divide"sv)), TRY(ByteString::from_utf8("ThrowingDivide"sv))})))), false}));
+return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("Divide"sv)), (ByteString::must_from_utf8("ThrowingDivide"sv))})))), false}));
 };/*case end*/
 case 4 /* Modulo */: {
-return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("Modulo"sv)), TRY(ByteString::from_utf8("ThrowingModulo"sv))})))), false}));
+return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("Modulo"sv)), (ByteString::must_from_utf8("ThrowingModulo"sv))})))), false}));
 };/*case end*/
 case 5 /* LessThan */: {
-return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("Compare"sv)), TRY(ByteString::from_utf8("ThrowingCompare"sv))})))), false}));
+return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("Compare"sv)), (ByteString::must_from_utf8("ThrowingCompare"sv))})))), false}));
 };/*case end*/
 case 6 /* LessThanOrEqual */: {
-return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("Compare"sv)), TRY(ByteString::from_utf8("ThrowingCompare"sv))})))), false}));
+return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("Compare"sv)), (ByteString::must_from_utf8("ThrowingCompare"sv))})))), false}));
 };/*case end*/
 case 7 /* GreaterThan */: {
-return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("Compare"sv)), TRY(ByteString::from_utf8("ThrowingCompare"sv))})))), false}));
+return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("Compare"sv)), (ByteString::must_from_utf8("ThrowingCompare"sv))})))), false}));
 };/*case end*/
 case 8 /* GreaterThanOrEqual */: {
-return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("Compare"sv)), TRY(ByteString::from_utf8("ThrowingCompare"sv))})))), false}));
+return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("Compare"sv)), (ByteString::must_from_utf8("ThrowingCompare"sv))})))), false}));
 };/*case end*/
 case 9 /* Equal */: {
-return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("Equal"sv)), TRY(ByteString::from_utf8("ThrowingEqual"sv))})))), false}));
+return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("Equal"sv)), (ByteString::must_from_utf8("ThrowingEqual"sv))})))), false}));
 };/*case end*/
 case 10 /* NotEqual */: {
-return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("Equal"sv)), TRY(ByteString::from_utf8("ThrowingEqual"sv))})))), false}));
+return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("Equal"sv)), (ByteString::must_from_utf8("ThrowingEqual"sv))})))), false}));
 };/*case end*/
 case 27 /* AddAssign */: {
-return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("AddAssign"sv)), TRY(ByteString::from_utf8("ThrowingAddAssign"sv))})))), true}));
+return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("AddAssign"sv)), (ByteString::must_from_utf8("ThrowingAddAssign"sv))})))), true}));
 };/*case end*/
 case 28 /* SubtractAssign */: {
-return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("SubtractAssign"sv)), TRY(ByteString::from_utf8("ThrowingSubtractAssign"sv))})))), true}));
+return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("SubtractAssign"sv)), (ByteString::must_from_utf8("ThrowingSubtractAssign"sv))})))), true}));
 };/*case end*/
 case 29 /* MultiplyAssign */: {
-return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("MultiplyAssign"sv)), TRY(ByteString::from_utf8("ThrowingMultiplyAssign"sv))})))), true}));
+return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("MultiplyAssign"sv)), (ByteString::must_from_utf8("ThrowingMultiplyAssign"sv))})))), true}));
 };/*case end*/
 case 31 /* DivideAssign */: {
-return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("DivideAssign"sv)), TRY(ByteString::from_utf8("ThrowingDivideAssign"sv))})))), true}));
+return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("DivideAssign"sv)), (ByteString::must_from_utf8("ThrowingDivideAssign"sv))})))), true}));
 };/*case end*/
 case 30 /* ModuloAssign */: {
-return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("ModuloAssign"sv)), TRY(ByteString::from_utf8("ThrowingModuloAssign"sv))})))), true}));
+return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("ModuloAssign"sv)), (ByteString::must_from_utf8("ThrowingModuloAssign"sv))})))), true}));
 };/*case end*/
 case 22 /* BitwiseAndAssign */: {
-return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("BitwiseAndAssign"sv)), TRY(ByteString::from_utf8("ThrowingBitwiseAndAssign"sv))})))), true}));
+return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("BitwiseAndAssign"sv)), (ByteString::must_from_utf8("ThrowingBitwiseAndAssign"sv))})))), true}));
 };/*case end*/
 case 23 /* BitwiseOrAssign */: {
-return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("BitwiseOrAssign"sv)), TRY(ByteString::from_utf8("ThrowingBitwiseOrAssign"sv))})))), true}));
+return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("BitwiseOrAssign"sv)), (ByteString::must_from_utf8("ThrowingBitwiseOrAssign"sv))})))), true}));
 };/*case end*/
 case 24 /* BitwiseXorAssign */: {
-return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("BitwiseXorAssign"sv)), TRY(ByteString::from_utf8("ThrowingBitwiseXorAssign"sv))})))), true}));
+return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("BitwiseXorAssign"sv)), (ByteString::must_from_utf8("ThrowingBitwiseXorAssign"sv))})))), true}));
 };/*case end*/
 case 25 /* BitwiseLeftShiftAssign */: {
-return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("BitwiseLeftShiftAssign"sv)), TRY(ByteString::from_utf8("ThrowingBitwiseLeftShiftAssign"sv))})))), true}));
+return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("BitwiseLeftShiftAssign"sv)), (ByteString::must_from_utf8("ThrowingBitwiseLeftShiftAssign"sv))})))), true}));
 };/*case end*/
 case 26 /* BitwiseRightShiftAssign */: {
-return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("BitwiseRightShiftAssign"sv)), TRY(ByteString::from_utf8("ThrowingBitwiseRightShiftAssign"sv))})))), true}));
+return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("BitwiseRightShiftAssign"sv)), (ByteString::must_from_utf8("ThrowingBitwiseRightShiftAssign"sv))})))), true}));
 };/*case end*/
 default: {
 return JaktInternal::ExplicitValue((Tuple{empty_array, false}));
@@ -8381,70 +8381,70 @@ ByteString const function_name = ({
 auto&& __jakt_match_variant = op;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 0 /* Add */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("add"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("add"sv)));
 };/*case end*/
 case 1 /* Subtract */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("subtract"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("subtract"sv)));
 };/*case end*/
 case 2 /* Multiply */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("multiply"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("multiply"sv)));
 };/*case end*/
 case 3 /* Divide */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("divide"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("divide"sv)));
 };/*case end*/
 case 4 /* Modulo */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("modulo"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("modulo"sv)));
 };/*case end*/
 case 5 /* LessThan */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("less_than"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("less_than"sv)));
 };/*case end*/
 case 6 /* LessThanOrEqual */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("less_than_or_equal"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("less_than_or_equal"sv)));
 };/*case end*/
 case 7 /* GreaterThan */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("greater_than"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("greater_than"sv)));
 };/*case end*/
 case 8 /* GreaterThanOrEqual */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("greater_than_or_equal"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("greater_than_or_equal"sv)));
 };/*case end*/
 case 9 /* Equal */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("equals"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("equals"sv)));
 };/*case end*/
 case 10 /* NotEqual */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("not_equals"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("not_equals"sv)));
 };/*case end*/
 case 27 /* AddAssign */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("add_assign"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("add_assign"sv)));
 };/*case end*/
 case 28 /* SubtractAssign */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("subtract_assign"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("subtract_assign"sv)));
 };/*case end*/
 case 29 /* MultiplyAssign */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("multiply_assign"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("multiply_assign"sv)));
 };/*case end*/
 case 31 /* DivideAssign */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("divide_assign"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("divide_assign"sv)));
 };/*case end*/
 case 30 /* ModuloAssign */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("modulo_assign"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("modulo_assign"sv)));
 };/*case end*/
 case 22 /* BitwiseAndAssign */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("bitwise_and_assign"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("bitwise_and_assign"sv)));
 };/*case end*/
 case 23 /* BitwiseOrAssign */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("bitwise_or_assign"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("bitwise_or_assign"sv)));
 };/*case end*/
 case 24 /* BitwiseXorAssign */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("bitwise_xor_assign"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("bitwise_xor_assign"sv)));
 };/*case end*/
 case 25 /* BitwiseLeftShiftAssign */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("bitwise_left_shift_assign"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("bitwise_left_shift_assign"sv)));
 };/*case end*/
 case 26 /* BitwiseRightShiftAssign */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("bitwise_right_shift_assign"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("bitwise_right_shift_assign"sv)));
 };/*case end*/
 default: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8(""sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8(""sv)));
 };/*case end*/
 }/*switch end*/
 }()
@@ -8456,8 +8456,8 @@ return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8(""sv)));
 JaktInternal::Optional<typechecker::TraitImplementationDescriptor> const add_trait_implementation = TRY((((*this).find_any_singular_trait_implementation(lhs_type_id,trait_names,scope_id,lhs_span,(TRY((DynamicArray<ids::TypeId>::create_with({rhs_type_id}))))))));
 if (((add_trait_implementation).has_value())){
 typechecker::TraitImplementationDescriptor const implementation = (add_trait_implementation.value());
-if ((((((implementation).trait_name)).starts_with(TRY(ByteString::from_utf8("Throwing"sv)))) && (!(((scope)->can_throw))))){
-TRY((((*this).error(TRY(ByteString::from_utf8("Call to function that may throw needs to be in a try statement or a function marked as throws"sv)),span))));
+if ((((((implementation).trait_name)).starts_with((ByteString::must_from_utf8("Throwing"sv)))) && (!(((scope)->can_throw))))){
+TRY((((*this).error((ByteString::must_from_utf8("Call to function that may throw needs to be in a try statement or a function marked as throws"sv)),span))));
 }
 JaktInternal::Tuple<JaktInternal::Optional<types::StructLikeId>,bool> const parent_id___ = TRY((((*this).struct_like_id_from_type_id(lhs_type_id,scope_id,span,false,true))));
 JaktInternal::Optional<types::StructLikeId> const parent_id = ((parent_id___).template get<0>());
@@ -8468,15 +8468,15 @@ if (((implementation_function_id).has_value())){
 NonnullRefPtr<types::CheckedFunction> const implementation_function = ((*this).get_function((implementation_function_id.value())));
 if ((TRY((((implementation_function)->is_mutating()))) && (!(((checked_lhs)->is_mutable(((*this).program))))))){
 if (is_assignment){
-TRY((((*this).error(TRY(ByteString::from_utf8("Assignment to immutable variable"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("Assignment to immutable variable"sv)),span))));
 }
 else {
-TRY((((*this).error(TRY(ByteString::from_utf8("Cannot call mutating function on an immutable object instance"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("Cannot call mutating function on an immutable object instance"sv)),span))));
 }
 
 }
 (type_id = ((implementation_function)->return_type_id));
-types::CheckedCall call_expression = types::CheckedCall((TRY((DynamicArray<types::ResolvedNamespace>::create_with({})))),function_name,(TRY((DynamicArray<JaktInternal::Tuple<ByteString,NonnullRefPtr<typename types::CheckedExpression>>>::create_with({(Tuple{TRY(ByteString::from_utf8(""sv)), checked_rhs})})))),(TRY((DynamicArray<ids::TypeId>::create_with({})))),implementation_function_id,type_id,((implementation_function)->can_throw),((implementation_function)->external_name),((implementation_function)->force_inline));
+types::CheckedCall call_expression = types::CheckedCall((TRY((DynamicArray<types::ResolvedNamespace>::create_with({})))),function_name,(TRY((DynamicArray<JaktInternal::Tuple<ByteString,NonnullRefPtr<typename types::CheckedExpression>>>::create_with({(Tuple{(ByteString::must_from_utf8(""sv)), checked_rhs})})))),(TRY((DynamicArray<ids::TypeId>::create_with({})))),implementation_function_id,type_id,((implementation_function)->can_throw),((implementation_function)->external_name),((implementation_function)->force_inline));
 (((checked_operator).trait_implementation) = types::OperatorTraitImplementation(((implementation).trait_id),((implementation).implemented_type_args),call_expression));
 }
 else {
@@ -8553,67 +8553,67 @@ JaktInternal::Tuple<JaktInternal::DynamicArray<ByteString>,bool> const trait_nam
 auto&& __jakt_match_variant = op;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 0 /* Add */: {
-return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("Add"sv)), TRY(ByteString::from_utf8("ThrowingAdd"sv))})))), false}));
+return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("Add"sv)), (ByteString::must_from_utf8("ThrowingAdd"sv))})))), false}));
 };/*case end*/
 case 1 /* Subtract */: {
-return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("Subtract"sv)), TRY(ByteString::from_utf8("ThrowingSubtract"sv))})))), false}));
+return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("Subtract"sv)), (ByteString::must_from_utf8("ThrowingSubtract"sv))})))), false}));
 };/*case end*/
 case 2 /* Multiply */: {
-return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("Multiply"sv)), TRY(ByteString::from_utf8("ThrowingMultiply"sv))})))), false}));
+return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("Multiply"sv)), (ByteString::must_from_utf8("ThrowingMultiply"sv))})))), false}));
 };/*case end*/
 case 3 /* Divide */: {
-return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("Divide"sv)), TRY(ByteString::from_utf8("ThrowingDivide"sv))})))), false}));
+return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("Divide"sv)), (ByteString::must_from_utf8("ThrowingDivide"sv))})))), false}));
 };/*case end*/
 case 4 /* Modulo */: {
-return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("Modulo"sv)), TRY(ByteString::from_utf8("ThrowingModulo"sv))})))), false}));
+return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("Modulo"sv)), (ByteString::must_from_utf8("ThrowingModulo"sv))})))), false}));
 };/*case end*/
 case 5 /* LessThan */: {
-return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("Compare"sv)), TRY(ByteString::from_utf8("ThrowingCompare"sv))})))), false}));
+return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("Compare"sv)), (ByteString::must_from_utf8("ThrowingCompare"sv))})))), false}));
 };/*case end*/
 case 6 /* LessThanOrEqual */: {
-return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("Compare"sv)), TRY(ByteString::from_utf8("ThrowingCompare"sv))})))), false}));
+return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("Compare"sv)), (ByteString::must_from_utf8("ThrowingCompare"sv))})))), false}));
 };/*case end*/
 case 7 /* GreaterThan */: {
-return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("Compare"sv)), TRY(ByteString::from_utf8("ThrowingCompare"sv))})))), false}));
+return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("Compare"sv)), (ByteString::must_from_utf8("ThrowingCompare"sv))})))), false}));
 };/*case end*/
 case 8 /* GreaterThanOrEqual */: {
-return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("Compare"sv)), TRY(ByteString::from_utf8("ThrowingCompare"sv))})))), false}));
+return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("Compare"sv)), (ByteString::must_from_utf8("ThrowingCompare"sv))})))), false}));
 };/*case end*/
 case 9 /* Equal */: {
-return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("Equal"sv)), TRY(ByteString::from_utf8("ThrowingEqual"sv))})))), false}));
+return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("Equal"sv)), (ByteString::must_from_utf8("ThrowingEqual"sv))})))), false}));
 };/*case end*/
 case 10 /* NotEqual */: {
-return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("Equal"sv)), TRY(ByteString::from_utf8("ThrowingEqual"sv))})))), false}));
+return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("Equal"sv)), (ByteString::must_from_utf8("ThrowingEqual"sv))})))), false}));
 };/*case end*/
 case 27 /* AddAssign */: {
-return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("AddAssign"sv)), TRY(ByteString::from_utf8("ThrowingAddAssign"sv))})))), true}));
+return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("AddAssign"sv)), (ByteString::must_from_utf8("ThrowingAddAssign"sv))})))), true}));
 };/*case end*/
 case 28 /* SubtractAssign */: {
-return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("SubtractAssign"sv)), TRY(ByteString::from_utf8("ThrowingSubtractAssign"sv))})))), true}));
+return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("SubtractAssign"sv)), (ByteString::must_from_utf8("ThrowingSubtractAssign"sv))})))), true}));
 };/*case end*/
 case 29 /* MultiplyAssign */: {
-return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("MultiplyAssign"sv)), TRY(ByteString::from_utf8("ThrowingMultiplyAssign"sv))})))), true}));
+return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("MultiplyAssign"sv)), (ByteString::must_from_utf8("ThrowingMultiplyAssign"sv))})))), true}));
 };/*case end*/
 case 31 /* DivideAssign */: {
-return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("DivideAssign"sv)), TRY(ByteString::from_utf8("ThrowingDivideAssign"sv))})))), true}));
+return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("DivideAssign"sv)), (ByteString::must_from_utf8("ThrowingDivideAssign"sv))})))), true}));
 };/*case end*/
 case 30 /* ModuloAssign */: {
-return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("ModuloAssign"sv)), TRY(ByteString::from_utf8("ThrowingModuloAssign"sv))})))), true}));
+return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("ModuloAssign"sv)), (ByteString::must_from_utf8("ThrowingModuloAssign"sv))})))), true}));
 };/*case end*/
 case 22 /* BitwiseAndAssign */: {
-return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("BitwiseAndAssign"sv)), TRY(ByteString::from_utf8("ThrowingBitwiseAndAssign"sv))})))), true}));
+return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("BitwiseAndAssign"sv)), (ByteString::must_from_utf8("ThrowingBitwiseAndAssign"sv))})))), true}));
 };/*case end*/
 case 23 /* BitwiseOrAssign */: {
-return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("BitwiseOrAssign"sv)), TRY(ByteString::from_utf8("ThrowingBitwiseOrAssign"sv))})))), true}));
+return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("BitwiseOrAssign"sv)), (ByteString::must_from_utf8("ThrowingBitwiseOrAssign"sv))})))), true}));
 };/*case end*/
 case 24 /* BitwiseXorAssign */: {
-return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("BitwiseXorAssign"sv)), TRY(ByteString::from_utf8("ThrowingBitwiseXorAssign"sv))})))), true}));
+return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("BitwiseXorAssign"sv)), (ByteString::must_from_utf8("ThrowingBitwiseXorAssign"sv))})))), true}));
 };/*case end*/
 case 25 /* BitwiseLeftShiftAssign */: {
-return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("BitwiseLeftShiftAssign"sv)), TRY(ByteString::from_utf8("ThrowingBitwiseLeftShiftAssign"sv))})))), true}));
+return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("BitwiseLeftShiftAssign"sv)), (ByteString::must_from_utf8("ThrowingBitwiseLeftShiftAssign"sv))})))), true}));
 };/*case end*/
 case 26 /* BitwiseRightShiftAssign */: {
-return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("BitwiseRightShiftAssign"sv)), TRY(ByteString::from_utf8("ThrowingBitwiseRightShiftAssign"sv))})))), true}));
+return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("BitwiseRightShiftAssign"sv)), (ByteString::must_from_utf8("ThrowingBitwiseRightShiftAssign"sv))})))), true}));
 };/*case end*/
 default: {
 return JaktInternal::ExplicitValue((Tuple{empty_array, false}));
@@ -8633,70 +8633,70 @@ ByteString const function_name = ({
 auto&& __jakt_match_variant = op;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 0 /* Add */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("add"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("add"sv)));
 };/*case end*/
 case 1 /* Subtract */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("subtract"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("subtract"sv)));
 };/*case end*/
 case 2 /* Multiply */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("multiply"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("multiply"sv)));
 };/*case end*/
 case 3 /* Divide */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("divide"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("divide"sv)));
 };/*case end*/
 case 4 /* Modulo */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("modulo"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("modulo"sv)));
 };/*case end*/
 case 5 /* LessThan */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("less_than"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("less_than"sv)));
 };/*case end*/
 case 6 /* LessThanOrEqual */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("less_than_or_equal"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("less_than_or_equal"sv)));
 };/*case end*/
 case 7 /* GreaterThan */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("greater_than"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("greater_than"sv)));
 };/*case end*/
 case 8 /* GreaterThanOrEqual */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("greater_than_or_equal"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("greater_than_or_equal"sv)));
 };/*case end*/
 case 9 /* Equal */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("equals"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("equals"sv)));
 };/*case end*/
 case 10 /* NotEqual */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("not_equals"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("not_equals"sv)));
 };/*case end*/
 case 27 /* AddAssign */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("add_assign"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("add_assign"sv)));
 };/*case end*/
 case 28 /* SubtractAssign */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("subtract_assign"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("subtract_assign"sv)));
 };/*case end*/
 case 29 /* MultiplyAssign */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("multiply_assign"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("multiply_assign"sv)));
 };/*case end*/
 case 31 /* DivideAssign */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("divide_assign"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("divide_assign"sv)));
 };/*case end*/
 case 30 /* ModuloAssign */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("modulo_assign"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("modulo_assign"sv)));
 };/*case end*/
 case 22 /* BitwiseAndAssign */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("bitwise_and_assign"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("bitwise_and_assign"sv)));
 };/*case end*/
 case 23 /* BitwiseOrAssign */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("bitwise_or_assign"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("bitwise_or_assign"sv)));
 };/*case end*/
 case 24 /* BitwiseXorAssign */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("bitwise_xor_assign"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("bitwise_xor_assign"sv)));
 };/*case end*/
 case 25 /* BitwiseLeftShiftAssign */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("bitwise_left_shift_assign"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("bitwise_left_shift_assign"sv)));
 };/*case end*/
 case 26 /* BitwiseRightShiftAssign */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("bitwise_right_shift_assign"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("bitwise_right_shift_assign"sv)));
 };/*case end*/
 default: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8(""sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8(""sv)));
 };/*case end*/
 }/*switch end*/
 }()
@@ -8708,8 +8708,8 @@ return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8(""sv)));
 JaktInternal::Optional<typechecker::TraitImplementationDescriptor> const add_trait_implementation = TRY((((*this).find_any_singular_trait_implementation(lhs_type_id,trait_names,scope_id,lhs_span,(TRY((DynamicArray<ids::TypeId>::create_with({rhs_type_id}))))))));
 if (((add_trait_implementation).has_value())){
 typechecker::TraitImplementationDescriptor const implementation = (add_trait_implementation.value());
-if ((((((implementation).trait_name)).starts_with(TRY(ByteString::from_utf8("Throwing"sv)))) && (!(((scope)->can_throw))))){
-TRY((((*this).error(TRY(ByteString::from_utf8("Call to function that may throw needs to be in a try statement or a function marked as throws"sv)),span))));
+if ((((((implementation).trait_name)).starts_with((ByteString::must_from_utf8("Throwing"sv)))) && (!(((scope)->can_throw))))){
+TRY((((*this).error((ByteString::must_from_utf8("Call to function that may throw needs to be in a try statement or a function marked as throws"sv)),span))));
 }
 JaktInternal::Tuple<JaktInternal::Optional<types::StructLikeId>,bool> const parent_id___ = TRY((((*this).struct_like_id_from_type_id(lhs_type_id,scope_id,span,false,true))));
 JaktInternal::Optional<types::StructLikeId> const parent_id = ((parent_id___).template get<0>());
@@ -8720,15 +8720,15 @@ if (((implementation_function_id).has_value())){
 NonnullRefPtr<types::CheckedFunction> const implementation_function = ((*this).get_function((implementation_function_id.value())));
 if ((TRY((((implementation_function)->is_mutating()))) && (!(((checked_lhs)->is_mutable(((*this).program))))))){
 if (is_assignment){
-TRY((((*this).error(TRY(ByteString::from_utf8("Assignment to immutable variable"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("Assignment to immutable variable"sv)),span))));
 }
 else {
-TRY((((*this).error(TRY(ByteString::from_utf8("Cannot call mutating function on an immutable object instance"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("Cannot call mutating function on an immutable object instance"sv)),span))));
 }
 
 }
 (type_id = ((implementation_function)->return_type_id));
-types::CheckedCall call_expression = types::CheckedCall((TRY((DynamicArray<types::ResolvedNamespace>::create_with({})))),function_name,(TRY((DynamicArray<JaktInternal::Tuple<ByteString,NonnullRefPtr<typename types::CheckedExpression>>>::create_with({(Tuple{TRY(ByteString::from_utf8(""sv)), checked_rhs})})))),(TRY((DynamicArray<ids::TypeId>::create_with({})))),implementation_function_id,type_id,((implementation_function)->can_throw),((implementation_function)->external_name),((implementation_function)->force_inline));
+types::CheckedCall call_expression = types::CheckedCall((TRY((DynamicArray<types::ResolvedNamespace>::create_with({})))),function_name,(TRY((DynamicArray<JaktInternal::Tuple<ByteString,NonnullRefPtr<typename types::CheckedExpression>>>::create_with({(Tuple{(ByteString::must_from_utf8(""sv)), checked_rhs})})))),(TRY((DynamicArray<ids::TypeId>::create_with({})))),implementation_function_id,type_id,((implementation_function)->can_throw),((implementation_function)->external_name),((implementation_function)->force_inline));
 (((checked_operator).trait_implementation) = types::OperatorTraitImplementation(((implementation).trait_id),((implementation).implemented_type_args),call_expression));
 }
 else {
@@ -8805,67 +8805,67 @@ JaktInternal::Tuple<JaktInternal::DynamicArray<ByteString>,bool> const trait_nam
 auto&& __jakt_match_variant = op;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 0 /* Add */: {
-return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("Add"sv)), TRY(ByteString::from_utf8("ThrowingAdd"sv))})))), false}));
+return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("Add"sv)), (ByteString::must_from_utf8("ThrowingAdd"sv))})))), false}));
 };/*case end*/
 case 1 /* Subtract */: {
-return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("Subtract"sv)), TRY(ByteString::from_utf8("ThrowingSubtract"sv))})))), false}));
+return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("Subtract"sv)), (ByteString::must_from_utf8("ThrowingSubtract"sv))})))), false}));
 };/*case end*/
 case 2 /* Multiply */: {
-return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("Multiply"sv)), TRY(ByteString::from_utf8("ThrowingMultiply"sv))})))), false}));
+return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("Multiply"sv)), (ByteString::must_from_utf8("ThrowingMultiply"sv))})))), false}));
 };/*case end*/
 case 3 /* Divide */: {
-return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("Divide"sv)), TRY(ByteString::from_utf8("ThrowingDivide"sv))})))), false}));
+return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("Divide"sv)), (ByteString::must_from_utf8("ThrowingDivide"sv))})))), false}));
 };/*case end*/
 case 4 /* Modulo */: {
-return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("Modulo"sv)), TRY(ByteString::from_utf8("ThrowingModulo"sv))})))), false}));
+return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("Modulo"sv)), (ByteString::must_from_utf8("ThrowingModulo"sv))})))), false}));
 };/*case end*/
 case 5 /* LessThan */: {
-return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("Compare"sv)), TRY(ByteString::from_utf8("ThrowingCompare"sv))})))), false}));
+return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("Compare"sv)), (ByteString::must_from_utf8("ThrowingCompare"sv))})))), false}));
 };/*case end*/
 case 6 /* LessThanOrEqual */: {
-return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("Compare"sv)), TRY(ByteString::from_utf8("ThrowingCompare"sv))})))), false}));
+return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("Compare"sv)), (ByteString::must_from_utf8("ThrowingCompare"sv))})))), false}));
 };/*case end*/
 case 7 /* GreaterThan */: {
-return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("Compare"sv)), TRY(ByteString::from_utf8("ThrowingCompare"sv))})))), false}));
+return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("Compare"sv)), (ByteString::must_from_utf8("ThrowingCompare"sv))})))), false}));
 };/*case end*/
 case 8 /* GreaterThanOrEqual */: {
-return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("Compare"sv)), TRY(ByteString::from_utf8("ThrowingCompare"sv))})))), false}));
+return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("Compare"sv)), (ByteString::must_from_utf8("ThrowingCompare"sv))})))), false}));
 };/*case end*/
 case 9 /* Equal */: {
-return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("Equal"sv)), TRY(ByteString::from_utf8("ThrowingEqual"sv))})))), false}));
+return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("Equal"sv)), (ByteString::must_from_utf8("ThrowingEqual"sv))})))), false}));
 };/*case end*/
 case 10 /* NotEqual */: {
-return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("Equal"sv)), TRY(ByteString::from_utf8("ThrowingEqual"sv))})))), false}));
+return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("Equal"sv)), (ByteString::must_from_utf8("ThrowingEqual"sv))})))), false}));
 };/*case end*/
 case 27 /* AddAssign */: {
-return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("AddAssign"sv)), TRY(ByteString::from_utf8("ThrowingAddAssign"sv))})))), true}));
+return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("AddAssign"sv)), (ByteString::must_from_utf8("ThrowingAddAssign"sv))})))), true}));
 };/*case end*/
 case 28 /* SubtractAssign */: {
-return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("SubtractAssign"sv)), TRY(ByteString::from_utf8("ThrowingSubtractAssign"sv))})))), true}));
+return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("SubtractAssign"sv)), (ByteString::must_from_utf8("ThrowingSubtractAssign"sv))})))), true}));
 };/*case end*/
 case 29 /* MultiplyAssign */: {
-return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("MultiplyAssign"sv)), TRY(ByteString::from_utf8("ThrowingMultiplyAssign"sv))})))), true}));
+return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("MultiplyAssign"sv)), (ByteString::must_from_utf8("ThrowingMultiplyAssign"sv))})))), true}));
 };/*case end*/
 case 31 /* DivideAssign */: {
-return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("DivideAssign"sv)), TRY(ByteString::from_utf8("ThrowingDivideAssign"sv))})))), true}));
+return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("DivideAssign"sv)), (ByteString::must_from_utf8("ThrowingDivideAssign"sv))})))), true}));
 };/*case end*/
 case 30 /* ModuloAssign */: {
-return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("ModuloAssign"sv)), TRY(ByteString::from_utf8("ThrowingModuloAssign"sv))})))), true}));
+return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("ModuloAssign"sv)), (ByteString::must_from_utf8("ThrowingModuloAssign"sv))})))), true}));
 };/*case end*/
 case 22 /* BitwiseAndAssign */: {
-return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("BitwiseAndAssign"sv)), TRY(ByteString::from_utf8("ThrowingBitwiseAndAssign"sv))})))), true}));
+return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("BitwiseAndAssign"sv)), (ByteString::must_from_utf8("ThrowingBitwiseAndAssign"sv))})))), true}));
 };/*case end*/
 case 23 /* BitwiseOrAssign */: {
-return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("BitwiseOrAssign"sv)), TRY(ByteString::from_utf8("ThrowingBitwiseOrAssign"sv))})))), true}));
+return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("BitwiseOrAssign"sv)), (ByteString::must_from_utf8("ThrowingBitwiseOrAssign"sv))})))), true}));
 };/*case end*/
 case 24 /* BitwiseXorAssign */: {
-return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("BitwiseXorAssign"sv)), TRY(ByteString::from_utf8("ThrowingBitwiseXorAssign"sv))})))), true}));
+return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("BitwiseXorAssign"sv)), (ByteString::must_from_utf8("ThrowingBitwiseXorAssign"sv))})))), true}));
 };/*case end*/
 case 25 /* BitwiseLeftShiftAssign */: {
-return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("BitwiseLeftShiftAssign"sv)), TRY(ByteString::from_utf8("ThrowingBitwiseLeftShiftAssign"sv))})))), true}));
+return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("BitwiseLeftShiftAssign"sv)), (ByteString::must_from_utf8("ThrowingBitwiseLeftShiftAssign"sv))})))), true}));
 };/*case end*/
 case 26 /* BitwiseRightShiftAssign */: {
-return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("BitwiseRightShiftAssign"sv)), TRY(ByteString::from_utf8("ThrowingBitwiseRightShiftAssign"sv))})))), true}));
+return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("BitwiseRightShiftAssign"sv)), (ByteString::must_from_utf8("ThrowingBitwiseRightShiftAssign"sv))})))), true}));
 };/*case end*/
 default: {
 return JaktInternal::ExplicitValue((Tuple{empty_array, false}));
@@ -8885,70 +8885,70 @@ ByteString const function_name = ({
 auto&& __jakt_match_variant = op;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 0 /* Add */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("add"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("add"sv)));
 };/*case end*/
 case 1 /* Subtract */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("subtract"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("subtract"sv)));
 };/*case end*/
 case 2 /* Multiply */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("multiply"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("multiply"sv)));
 };/*case end*/
 case 3 /* Divide */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("divide"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("divide"sv)));
 };/*case end*/
 case 4 /* Modulo */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("modulo"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("modulo"sv)));
 };/*case end*/
 case 5 /* LessThan */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("less_than"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("less_than"sv)));
 };/*case end*/
 case 6 /* LessThanOrEqual */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("less_than_or_equal"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("less_than_or_equal"sv)));
 };/*case end*/
 case 7 /* GreaterThan */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("greater_than"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("greater_than"sv)));
 };/*case end*/
 case 8 /* GreaterThanOrEqual */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("greater_than_or_equal"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("greater_than_or_equal"sv)));
 };/*case end*/
 case 9 /* Equal */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("equals"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("equals"sv)));
 };/*case end*/
 case 10 /* NotEqual */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("not_equals"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("not_equals"sv)));
 };/*case end*/
 case 27 /* AddAssign */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("add_assign"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("add_assign"sv)));
 };/*case end*/
 case 28 /* SubtractAssign */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("subtract_assign"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("subtract_assign"sv)));
 };/*case end*/
 case 29 /* MultiplyAssign */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("multiply_assign"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("multiply_assign"sv)));
 };/*case end*/
 case 31 /* DivideAssign */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("divide_assign"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("divide_assign"sv)));
 };/*case end*/
 case 30 /* ModuloAssign */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("modulo_assign"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("modulo_assign"sv)));
 };/*case end*/
 case 22 /* BitwiseAndAssign */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("bitwise_and_assign"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("bitwise_and_assign"sv)));
 };/*case end*/
 case 23 /* BitwiseOrAssign */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("bitwise_or_assign"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("bitwise_or_assign"sv)));
 };/*case end*/
 case 24 /* BitwiseXorAssign */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("bitwise_xor_assign"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("bitwise_xor_assign"sv)));
 };/*case end*/
 case 25 /* BitwiseLeftShiftAssign */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("bitwise_left_shift_assign"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("bitwise_left_shift_assign"sv)));
 };/*case end*/
 case 26 /* BitwiseRightShiftAssign */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("bitwise_right_shift_assign"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("bitwise_right_shift_assign"sv)));
 };/*case end*/
 default: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8(""sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8(""sv)));
 };/*case end*/
 }/*switch end*/
 }()
@@ -8960,8 +8960,8 @@ return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8(""sv)));
 JaktInternal::Optional<typechecker::TraitImplementationDescriptor> const add_trait_implementation = TRY((((*this).find_any_singular_trait_implementation(lhs_type_id,trait_names,scope_id,lhs_span,(TRY((DynamicArray<ids::TypeId>::create_with({rhs_type_id}))))))));
 if (((add_trait_implementation).has_value())){
 typechecker::TraitImplementationDescriptor const implementation = (add_trait_implementation.value());
-if ((((((implementation).trait_name)).starts_with(TRY(ByteString::from_utf8("Throwing"sv)))) && (!(((scope)->can_throw))))){
-TRY((((*this).error(TRY(ByteString::from_utf8("Call to function that may throw needs to be in a try statement or a function marked as throws"sv)),span))));
+if ((((((implementation).trait_name)).starts_with((ByteString::must_from_utf8("Throwing"sv)))) && (!(((scope)->can_throw))))){
+TRY((((*this).error((ByteString::must_from_utf8("Call to function that may throw needs to be in a try statement or a function marked as throws"sv)),span))));
 }
 JaktInternal::Tuple<JaktInternal::Optional<types::StructLikeId>,bool> const parent_id___ = TRY((((*this).struct_like_id_from_type_id(lhs_type_id,scope_id,span,false,true))));
 JaktInternal::Optional<types::StructLikeId> const parent_id = ((parent_id___).template get<0>());
@@ -8972,15 +8972,15 @@ if (((implementation_function_id).has_value())){
 NonnullRefPtr<types::CheckedFunction> const implementation_function = ((*this).get_function((implementation_function_id.value())));
 if ((TRY((((implementation_function)->is_mutating()))) && (!(((checked_lhs)->is_mutable(((*this).program))))))){
 if (is_assignment){
-TRY((((*this).error(TRY(ByteString::from_utf8("Assignment to immutable variable"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("Assignment to immutable variable"sv)),span))));
 }
 else {
-TRY((((*this).error(TRY(ByteString::from_utf8("Cannot call mutating function on an immutable object instance"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("Cannot call mutating function on an immutable object instance"sv)),span))));
 }
 
 }
 (type_id = ((implementation_function)->return_type_id));
-types::CheckedCall call_expression = types::CheckedCall((TRY((DynamicArray<types::ResolvedNamespace>::create_with({})))),function_name,(TRY((DynamicArray<JaktInternal::Tuple<ByteString,NonnullRefPtr<typename types::CheckedExpression>>>::create_with({(Tuple{TRY(ByteString::from_utf8(""sv)), checked_rhs})})))),(TRY((DynamicArray<ids::TypeId>::create_with({})))),implementation_function_id,type_id,((implementation_function)->can_throw),((implementation_function)->external_name),((implementation_function)->force_inline));
+types::CheckedCall call_expression = types::CheckedCall((TRY((DynamicArray<types::ResolvedNamespace>::create_with({})))),function_name,(TRY((DynamicArray<JaktInternal::Tuple<ByteString,NonnullRefPtr<typename types::CheckedExpression>>>::create_with({(Tuple{(ByteString::must_from_utf8(""sv)), checked_rhs})})))),(TRY((DynamicArray<ids::TypeId>::create_with({})))),implementation_function_id,type_id,((implementation_function)->can_throw),((implementation_function)->external_name),((implementation_function)->force_inline));
 (((checked_operator).trait_implementation) = types::OperatorTraitImplementation(((implementation).trait_id),((implementation).implemented_type_args),call_expression));
 }
 else {
@@ -9057,67 +9057,67 @@ JaktInternal::Tuple<JaktInternal::DynamicArray<ByteString>,bool> const trait_nam
 auto&& __jakt_match_variant = op;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 0 /* Add */: {
-return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("Add"sv)), TRY(ByteString::from_utf8("ThrowingAdd"sv))})))), false}));
+return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("Add"sv)), (ByteString::must_from_utf8("ThrowingAdd"sv))})))), false}));
 };/*case end*/
 case 1 /* Subtract */: {
-return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("Subtract"sv)), TRY(ByteString::from_utf8("ThrowingSubtract"sv))})))), false}));
+return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("Subtract"sv)), (ByteString::must_from_utf8("ThrowingSubtract"sv))})))), false}));
 };/*case end*/
 case 2 /* Multiply */: {
-return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("Multiply"sv)), TRY(ByteString::from_utf8("ThrowingMultiply"sv))})))), false}));
+return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("Multiply"sv)), (ByteString::must_from_utf8("ThrowingMultiply"sv))})))), false}));
 };/*case end*/
 case 3 /* Divide */: {
-return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("Divide"sv)), TRY(ByteString::from_utf8("ThrowingDivide"sv))})))), false}));
+return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("Divide"sv)), (ByteString::must_from_utf8("ThrowingDivide"sv))})))), false}));
 };/*case end*/
 case 4 /* Modulo */: {
-return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("Modulo"sv)), TRY(ByteString::from_utf8("ThrowingModulo"sv))})))), false}));
+return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("Modulo"sv)), (ByteString::must_from_utf8("ThrowingModulo"sv))})))), false}));
 };/*case end*/
 case 5 /* LessThan */: {
-return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("Compare"sv)), TRY(ByteString::from_utf8("ThrowingCompare"sv))})))), false}));
+return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("Compare"sv)), (ByteString::must_from_utf8("ThrowingCompare"sv))})))), false}));
 };/*case end*/
 case 6 /* LessThanOrEqual */: {
-return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("Compare"sv)), TRY(ByteString::from_utf8("ThrowingCompare"sv))})))), false}));
+return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("Compare"sv)), (ByteString::must_from_utf8("ThrowingCompare"sv))})))), false}));
 };/*case end*/
 case 7 /* GreaterThan */: {
-return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("Compare"sv)), TRY(ByteString::from_utf8("ThrowingCompare"sv))})))), false}));
+return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("Compare"sv)), (ByteString::must_from_utf8("ThrowingCompare"sv))})))), false}));
 };/*case end*/
 case 8 /* GreaterThanOrEqual */: {
-return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("Compare"sv)), TRY(ByteString::from_utf8("ThrowingCompare"sv))})))), false}));
+return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("Compare"sv)), (ByteString::must_from_utf8("ThrowingCompare"sv))})))), false}));
 };/*case end*/
 case 9 /* Equal */: {
-return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("Equal"sv)), TRY(ByteString::from_utf8("ThrowingEqual"sv))})))), false}));
+return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("Equal"sv)), (ByteString::must_from_utf8("ThrowingEqual"sv))})))), false}));
 };/*case end*/
 case 10 /* NotEqual */: {
-return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("Equal"sv)), TRY(ByteString::from_utf8("ThrowingEqual"sv))})))), false}));
+return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("Equal"sv)), (ByteString::must_from_utf8("ThrowingEqual"sv))})))), false}));
 };/*case end*/
 case 27 /* AddAssign */: {
-return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("AddAssign"sv)), TRY(ByteString::from_utf8("ThrowingAddAssign"sv))})))), true}));
+return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("AddAssign"sv)), (ByteString::must_from_utf8("ThrowingAddAssign"sv))})))), true}));
 };/*case end*/
 case 28 /* SubtractAssign */: {
-return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("SubtractAssign"sv)), TRY(ByteString::from_utf8("ThrowingSubtractAssign"sv))})))), true}));
+return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("SubtractAssign"sv)), (ByteString::must_from_utf8("ThrowingSubtractAssign"sv))})))), true}));
 };/*case end*/
 case 29 /* MultiplyAssign */: {
-return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("MultiplyAssign"sv)), TRY(ByteString::from_utf8("ThrowingMultiplyAssign"sv))})))), true}));
+return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("MultiplyAssign"sv)), (ByteString::must_from_utf8("ThrowingMultiplyAssign"sv))})))), true}));
 };/*case end*/
 case 31 /* DivideAssign */: {
-return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("DivideAssign"sv)), TRY(ByteString::from_utf8("ThrowingDivideAssign"sv))})))), true}));
+return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("DivideAssign"sv)), (ByteString::must_from_utf8("ThrowingDivideAssign"sv))})))), true}));
 };/*case end*/
 case 30 /* ModuloAssign */: {
-return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("ModuloAssign"sv)), TRY(ByteString::from_utf8("ThrowingModuloAssign"sv))})))), true}));
+return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("ModuloAssign"sv)), (ByteString::must_from_utf8("ThrowingModuloAssign"sv))})))), true}));
 };/*case end*/
 case 22 /* BitwiseAndAssign */: {
-return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("BitwiseAndAssign"sv)), TRY(ByteString::from_utf8("ThrowingBitwiseAndAssign"sv))})))), true}));
+return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("BitwiseAndAssign"sv)), (ByteString::must_from_utf8("ThrowingBitwiseAndAssign"sv))})))), true}));
 };/*case end*/
 case 23 /* BitwiseOrAssign */: {
-return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("BitwiseOrAssign"sv)), TRY(ByteString::from_utf8("ThrowingBitwiseOrAssign"sv))})))), true}));
+return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("BitwiseOrAssign"sv)), (ByteString::must_from_utf8("ThrowingBitwiseOrAssign"sv))})))), true}));
 };/*case end*/
 case 24 /* BitwiseXorAssign */: {
-return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("BitwiseXorAssign"sv)), TRY(ByteString::from_utf8("ThrowingBitwiseXorAssign"sv))})))), true}));
+return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("BitwiseXorAssign"sv)), (ByteString::must_from_utf8("ThrowingBitwiseXorAssign"sv))})))), true}));
 };/*case end*/
 case 25 /* BitwiseLeftShiftAssign */: {
-return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("BitwiseLeftShiftAssign"sv)), TRY(ByteString::from_utf8("ThrowingBitwiseLeftShiftAssign"sv))})))), true}));
+return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("BitwiseLeftShiftAssign"sv)), (ByteString::must_from_utf8("ThrowingBitwiseLeftShiftAssign"sv))})))), true}));
 };/*case end*/
 case 26 /* BitwiseRightShiftAssign */: {
-return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("BitwiseRightShiftAssign"sv)), TRY(ByteString::from_utf8("ThrowingBitwiseRightShiftAssign"sv))})))), true}));
+return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("BitwiseRightShiftAssign"sv)), (ByteString::must_from_utf8("ThrowingBitwiseRightShiftAssign"sv))})))), true}));
 };/*case end*/
 default: {
 return JaktInternal::ExplicitValue((Tuple{empty_array, false}));
@@ -9137,70 +9137,70 @@ ByteString const function_name = ({
 auto&& __jakt_match_variant = op;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 0 /* Add */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("add"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("add"sv)));
 };/*case end*/
 case 1 /* Subtract */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("subtract"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("subtract"sv)));
 };/*case end*/
 case 2 /* Multiply */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("multiply"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("multiply"sv)));
 };/*case end*/
 case 3 /* Divide */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("divide"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("divide"sv)));
 };/*case end*/
 case 4 /* Modulo */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("modulo"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("modulo"sv)));
 };/*case end*/
 case 5 /* LessThan */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("less_than"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("less_than"sv)));
 };/*case end*/
 case 6 /* LessThanOrEqual */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("less_than_or_equal"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("less_than_or_equal"sv)));
 };/*case end*/
 case 7 /* GreaterThan */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("greater_than"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("greater_than"sv)));
 };/*case end*/
 case 8 /* GreaterThanOrEqual */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("greater_than_or_equal"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("greater_than_or_equal"sv)));
 };/*case end*/
 case 9 /* Equal */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("equals"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("equals"sv)));
 };/*case end*/
 case 10 /* NotEqual */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("not_equals"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("not_equals"sv)));
 };/*case end*/
 case 27 /* AddAssign */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("add_assign"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("add_assign"sv)));
 };/*case end*/
 case 28 /* SubtractAssign */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("subtract_assign"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("subtract_assign"sv)));
 };/*case end*/
 case 29 /* MultiplyAssign */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("multiply_assign"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("multiply_assign"sv)));
 };/*case end*/
 case 31 /* DivideAssign */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("divide_assign"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("divide_assign"sv)));
 };/*case end*/
 case 30 /* ModuloAssign */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("modulo_assign"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("modulo_assign"sv)));
 };/*case end*/
 case 22 /* BitwiseAndAssign */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("bitwise_and_assign"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("bitwise_and_assign"sv)));
 };/*case end*/
 case 23 /* BitwiseOrAssign */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("bitwise_or_assign"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("bitwise_or_assign"sv)));
 };/*case end*/
 case 24 /* BitwiseXorAssign */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("bitwise_xor_assign"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("bitwise_xor_assign"sv)));
 };/*case end*/
 case 25 /* BitwiseLeftShiftAssign */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("bitwise_left_shift_assign"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("bitwise_left_shift_assign"sv)));
 };/*case end*/
 case 26 /* BitwiseRightShiftAssign */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("bitwise_right_shift_assign"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("bitwise_right_shift_assign"sv)));
 };/*case end*/
 default: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8(""sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8(""sv)));
 };/*case end*/
 }/*switch end*/
 }()
@@ -9212,8 +9212,8 @@ return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8(""sv)));
 JaktInternal::Optional<typechecker::TraitImplementationDescriptor> const add_trait_implementation = TRY((((*this).find_any_singular_trait_implementation(lhs_type_id,trait_names,scope_id,lhs_span,(TRY((DynamicArray<ids::TypeId>::create_with({rhs_type_id}))))))));
 if (((add_trait_implementation).has_value())){
 typechecker::TraitImplementationDescriptor const implementation = (add_trait_implementation.value());
-if ((((((implementation).trait_name)).starts_with(TRY(ByteString::from_utf8("Throwing"sv)))) && (!(((scope)->can_throw))))){
-TRY((((*this).error(TRY(ByteString::from_utf8("Call to function that may throw needs to be in a try statement or a function marked as throws"sv)),span))));
+if ((((((implementation).trait_name)).starts_with((ByteString::must_from_utf8("Throwing"sv)))) && (!(((scope)->can_throw))))){
+TRY((((*this).error((ByteString::must_from_utf8("Call to function that may throw needs to be in a try statement or a function marked as throws"sv)),span))));
 }
 JaktInternal::Tuple<JaktInternal::Optional<types::StructLikeId>,bool> const parent_id___ = TRY((((*this).struct_like_id_from_type_id(lhs_type_id,scope_id,span,false,true))));
 JaktInternal::Optional<types::StructLikeId> const parent_id = ((parent_id___).template get<0>());
@@ -9224,15 +9224,15 @@ if (((implementation_function_id).has_value())){
 NonnullRefPtr<types::CheckedFunction> const implementation_function = ((*this).get_function((implementation_function_id.value())));
 if ((TRY((((implementation_function)->is_mutating()))) && (!(((checked_lhs)->is_mutable(((*this).program))))))){
 if (is_assignment){
-TRY((((*this).error(TRY(ByteString::from_utf8("Assignment to immutable variable"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("Assignment to immutable variable"sv)),span))));
 }
 else {
-TRY((((*this).error(TRY(ByteString::from_utf8("Cannot call mutating function on an immutable object instance"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("Cannot call mutating function on an immutable object instance"sv)),span))));
 }
 
 }
 (type_id = ((implementation_function)->return_type_id));
-types::CheckedCall call_expression = types::CheckedCall((TRY((DynamicArray<types::ResolvedNamespace>::create_with({})))),function_name,(TRY((DynamicArray<JaktInternal::Tuple<ByteString,NonnullRefPtr<typename types::CheckedExpression>>>::create_with({(Tuple{TRY(ByteString::from_utf8(""sv)), checked_rhs})})))),(TRY((DynamicArray<ids::TypeId>::create_with({})))),implementation_function_id,type_id,((implementation_function)->can_throw),((implementation_function)->external_name),((implementation_function)->force_inline));
+types::CheckedCall call_expression = types::CheckedCall((TRY((DynamicArray<types::ResolvedNamespace>::create_with({})))),function_name,(TRY((DynamicArray<JaktInternal::Tuple<ByteString,NonnullRefPtr<typename types::CheckedExpression>>>::create_with({(Tuple{(ByteString::must_from_utf8(""sv)), checked_rhs})})))),(TRY((DynamicArray<ids::TypeId>::create_with({})))),implementation_function_id,type_id,((implementation_function)->can_throw),((implementation_function)->external_name),((implementation_function)->force_inline));
 (((checked_operator).trait_implementation) = types::OperatorTraitImplementation(((implementation).trait_id),((implementation).implemented_type_args),call_expression));
 }
 else {
@@ -9309,67 +9309,67 @@ JaktInternal::Tuple<JaktInternal::DynamicArray<ByteString>,bool> const trait_nam
 auto&& __jakt_match_variant = op;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 0 /* Add */: {
-return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("Add"sv)), TRY(ByteString::from_utf8("ThrowingAdd"sv))})))), false}));
+return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("Add"sv)), (ByteString::must_from_utf8("ThrowingAdd"sv))})))), false}));
 };/*case end*/
 case 1 /* Subtract */: {
-return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("Subtract"sv)), TRY(ByteString::from_utf8("ThrowingSubtract"sv))})))), false}));
+return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("Subtract"sv)), (ByteString::must_from_utf8("ThrowingSubtract"sv))})))), false}));
 };/*case end*/
 case 2 /* Multiply */: {
-return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("Multiply"sv)), TRY(ByteString::from_utf8("ThrowingMultiply"sv))})))), false}));
+return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("Multiply"sv)), (ByteString::must_from_utf8("ThrowingMultiply"sv))})))), false}));
 };/*case end*/
 case 3 /* Divide */: {
-return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("Divide"sv)), TRY(ByteString::from_utf8("ThrowingDivide"sv))})))), false}));
+return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("Divide"sv)), (ByteString::must_from_utf8("ThrowingDivide"sv))})))), false}));
 };/*case end*/
 case 4 /* Modulo */: {
-return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("Modulo"sv)), TRY(ByteString::from_utf8("ThrowingModulo"sv))})))), false}));
+return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("Modulo"sv)), (ByteString::must_from_utf8("ThrowingModulo"sv))})))), false}));
 };/*case end*/
 case 5 /* LessThan */: {
-return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("Compare"sv)), TRY(ByteString::from_utf8("ThrowingCompare"sv))})))), false}));
+return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("Compare"sv)), (ByteString::must_from_utf8("ThrowingCompare"sv))})))), false}));
 };/*case end*/
 case 6 /* LessThanOrEqual */: {
-return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("Compare"sv)), TRY(ByteString::from_utf8("ThrowingCompare"sv))})))), false}));
+return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("Compare"sv)), (ByteString::must_from_utf8("ThrowingCompare"sv))})))), false}));
 };/*case end*/
 case 7 /* GreaterThan */: {
-return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("Compare"sv)), TRY(ByteString::from_utf8("ThrowingCompare"sv))})))), false}));
+return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("Compare"sv)), (ByteString::must_from_utf8("ThrowingCompare"sv))})))), false}));
 };/*case end*/
 case 8 /* GreaterThanOrEqual */: {
-return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("Compare"sv)), TRY(ByteString::from_utf8("ThrowingCompare"sv))})))), false}));
+return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("Compare"sv)), (ByteString::must_from_utf8("ThrowingCompare"sv))})))), false}));
 };/*case end*/
 case 9 /* Equal */: {
-return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("Equal"sv)), TRY(ByteString::from_utf8("ThrowingEqual"sv))})))), false}));
+return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("Equal"sv)), (ByteString::must_from_utf8("ThrowingEqual"sv))})))), false}));
 };/*case end*/
 case 10 /* NotEqual */: {
-return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("Equal"sv)), TRY(ByteString::from_utf8("ThrowingEqual"sv))})))), false}));
+return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("Equal"sv)), (ByteString::must_from_utf8("ThrowingEqual"sv))})))), false}));
 };/*case end*/
 case 27 /* AddAssign */: {
-return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("AddAssign"sv)), TRY(ByteString::from_utf8("ThrowingAddAssign"sv))})))), true}));
+return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("AddAssign"sv)), (ByteString::must_from_utf8("ThrowingAddAssign"sv))})))), true}));
 };/*case end*/
 case 28 /* SubtractAssign */: {
-return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("SubtractAssign"sv)), TRY(ByteString::from_utf8("ThrowingSubtractAssign"sv))})))), true}));
+return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("SubtractAssign"sv)), (ByteString::must_from_utf8("ThrowingSubtractAssign"sv))})))), true}));
 };/*case end*/
 case 29 /* MultiplyAssign */: {
-return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("MultiplyAssign"sv)), TRY(ByteString::from_utf8("ThrowingMultiplyAssign"sv))})))), true}));
+return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("MultiplyAssign"sv)), (ByteString::must_from_utf8("ThrowingMultiplyAssign"sv))})))), true}));
 };/*case end*/
 case 31 /* DivideAssign */: {
-return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("DivideAssign"sv)), TRY(ByteString::from_utf8("ThrowingDivideAssign"sv))})))), true}));
+return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("DivideAssign"sv)), (ByteString::must_from_utf8("ThrowingDivideAssign"sv))})))), true}));
 };/*case end*/
 case 30 /* ModuloAssign */: {
-return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("ModuloAssign"sv)), TRY(ByteString::from_utf8("ThrowingModuloAssign"sv))})))), true}));
+return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("ModuloAssign"sv)), (ByteString::must_from_utf8("ThrowingModuloAssign"sv))})))), true}));
 };/*case end*/
 case 22 /* BitwiseAndAssign */: {
-return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("BitwiseAndAssign"sv)), TRY(ByteString::from_utf8("ThrowingBitwiseAndAssign"sv))})))), true}));
+return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("BitwiseAndAssign"sv)), (ByteString::must_from_utf8("ThrowingBitwiseAndAssign"sv))})))), true}));
 };/*case end*/
 case 23 /* BitwiseOrAssign */: {
-return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("BitwiseOrAssign"sv)), TRY(ByteString::from_utf8("ThrowingBitwiseOrAssign"sv))})))), true}));
+return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("BitwiseOrAssign"sv)), (ByteString::must_from_utf8("ThrowingBitwiseOrAssign"sv))})))), true}));
 };/*case end*/
 case 24 /* BitwiseXorAssign */: {
-return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("BitwiseXorAssign"sv)), TRY(ByteString::from_utf8("ThrowingBitwiseXorAssign"sv))})))), true}));
+return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("BitwiseXorAssign"sv)), (ByteString::must_from_utf8("ThrowingBitwiseXorAssign"sv))})))), true}));
 };/*case end*/
 case 25 /* BitwiseLeftShiftAssign */: {
-return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("BitwiseLeftShiftAssign"sv)), TRY(ByteString::from_utf8("ThrowingBitwiseLeftShiftAssign"sv))})))), true}));
+return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("BitwiseLeftShiftAssign"sv)), (ByteString::must_from_utf8("ThrowingBitwiseLeftShiftAssign"sv))})))), true}));
 };/*case end*/
 case 26 /* BitwiseRightShiftAssign */: {
-return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("BitwiseRightShiftAssign"sv)), TRY(ByteString::from_utf8("ThrowingBitwiseRightShiftAssign"sv))})))), true}));
+return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("BitwiseRightShiftAssign"sv)), (ByteString::must_from_utf8("ThrowingBitwiseRightShiftAssign"sv))})))), true}));
 };/*case end*/
 default: {
 return JaktInternal::ExplicitValue((Tuple{empty_array, false}));
@@ -9389,70 +9389,70 @@ ByteString const function_name = ({
 auto&& __jakt_match_variant = op;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 0 /* Add */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("add"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("add"sv)));
 };/*case end*/
 case 1 /* Subtract */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("subtract"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("subtract"sv)));
 };/*case end*/
 case 2 /* Multiply */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("multiply"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("multiply"sv)));
 };/*case end*/
 case 3 /* Divide */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("divide"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("divide"sv)));
 };/*case end*/
 case 4 /* Modulo */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("modulo"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("modulo"sv)));
 };/*case end*/
 case 5 /* LessThan */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("less_than"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("less_than"sv)));
 };/*case end*/
 case 6 /* LessThanOrEqual */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("less_than_or_equal"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("less_than_or_equal"sv)));
 };/*case end*/
 case 7 /* GreaterThan */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("greater_than"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("greater_than"sv)));
 };/*case end*/
 case 8 /* GreaterThanOrEqual */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("greater_than_or_equal"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("greater_than_or_equal"sv)));
 };/*case end*/
 case 9 /* Equal */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("equals"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("equals"sv)));
 };/*case end*/
 case 10 /* NotEqual */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("not_equals"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("not_equals"sv)));
 };/*case end*/
 case 27 /* AddAssign */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("add_assign"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("add_assign"sv)));
 };/*case end*/
 case 28 /* SubtractAssign */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("subtract_assign"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("subtract_assign"sv)));
 };/*case end*/
 case 29 /* MultiplyAssign */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("multiply_assign"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("multiply_assign"sv)));
 };/*case end*/
 case 31 /* DivideAssign */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("divide_assign"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("divide_assign"sv)));
 };/*case end*/
 case 30 /* ModuloAssign */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("modulo_assign"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("modulo_assign"sv)));
 };/*case end*/
 case 22 /* BitwiseAndAssign */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("bitwise_and_assign"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("bitwise_and_assign"sv)));
 };/*case end*/
 case 23 /* BitwiseOrAssign */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("bitwise_or_assign"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("bitwise_or_assign"sv)));
 };/*case end*/
 case 24 /* BitwiseXorAssign */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("bitwise_xor_assign"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("bitwise_xor_assign"sv)));
 };/*case end*/
 case 25 /* BitwiseLeftShiftAssign */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("bitwise_left_shift_assign"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("bitwise_left_shift_assign"sv)));
 };/*case end*/
 case 26 /* BitwiseRightShiftAssign */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("bitwise_right_shift_assign"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("bitwise_right_shift_assign"sv)));
 };/*case end*/
 default: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8(""sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8(""sv)));
 };/*case end*/
 }/*switch end*/
 }()
@@ -9464,8 +9464,8 @@ return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8(""sv)));
 JaktInternal::Optional<typechecker::TraitImplementationDescriptor> const add_trait_implementation = TRY((((*this).find_any_singular_trait_implementation(lhs_type_id,trait_names,scope_id,lhs_span,(TRY((DynamicArray<ids::TypeId>::create_with({rhs_type_id}))))))));
 if (((add_trait_implementation).has_value())){
 typechecker::TraitImplementationDescriptor const implementation = (add_trait_implementation.value());
-if ((((((implementation).trait_name)).starts_with(TRY(ByteString::from_utf8("Throwing"sv)))) && (!(((scope)->can_throw))))){
-TRY((((*this).error(TRY(ByteString::from_utf8("Call to function that may throw needs to be in a try statement or a function marked as throws"sv)),span))));
+if ((((((implementation).trait_name)).starts_with((ByteString::must_from_utf8("Throwing"sv)))) && (!(((scope)->can_throw))))){
+TRY((((*this).error((ByteString::must_from_utf8("Call to function that may throw needs to be in a try statement or a function marked as throws"sv)),span))));
 }
 JaktInternal::Tuple<JaktInternal::Optional<types::StructLikeId>,bool> const parent_id___ = TRY((((*this).struct_like_id_from_type_id(lhs_type_id,scope_id,span,false,true))));
 JaktInternal::Optional<types::StructLikeId> const parent_id = ((parent_id___).template get<0>());
@@ -9476,15 +9476,15 @@ if (((implementation_function_id).has_value())){
 NonnullRefPtr<types::CheckedFunction> const implementation_function = ((*this).get_function((implementation_function_id.value())));
 if ((TRY((((implementation_function)->is_mutating()))) && (!(((checked_lhs)->is_mutable(((*this).program))))))){
 if (is_assignment){
-TRY((((*this).error(TRY(ByteString::from_utf8("Assignment to immutable variable"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("Assignment to immutable variable"sv)),span))));
 }
 else {
-TRY((((*this).error(TRY(ByteString::from_utf8("Cannot call mutating function on an immutable object instance"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("Cannot call mutating function on an immutable object instance"sv)),span))));
 }
 
 }
 (type_id = ((implementation_function)->return_type_id));
-types::CheckedCall call_expression = types::CheckedCall((TRY((DynamicArray<types::ResolvedNamespace>::create_with({})))),function_name,(TRY((DynamicArray<JaktInternal::Tuple<ByteString,NonnullRefPtr<typename types::CheckedExpression>>>::create_with({(Tuple{TRY(ByteString::from_utf8(""sv)), checked_rhs})})))),(TRY((DynamicArray<ids::TypeId>::create_with({})))),implementation_function_id,type_id,((implementation_function)->can_throw),((implementation_function)->external_name),((implementation_function)->force_inline));
+types::CheckedCall call_expression = types::CheckedCall((TRY((DynamicArray<types::ResolvedNamespace>::create_with({})))),function_name,(TRY((DynamicArray<JaktInternal::Tuple<ByteString,NonnullRefPtr<typename types::CheckedExpression>>>::create_with({(Tuple{(ByteString::must_from_utf8(""sv)), checked_rhs})})))),(TRY((DynamicArray<ids::TypeId>::create_with({})))),implementation_function_id,type_id,((implementation_function)->can_throw),((implementation_function)->external_name),((implementation_function)->force_inline));
 (((checked_operator).trait_implementation) = types::OperatorTraitImplementation(((implementation).trait_id),((implementation).implemented_type_args),call_expression));
 }
 else {
@@ -9561,67 +9561,67 @@ JaktInternal::Tuple<JaktInternal::DynamicArray<ByteString>,bool> const trait_nam
 auto&& __jakt_match_variant = op;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 0 /* Add */: {
-return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("Add"sv)), TRY(ByteString::from_utf8("ThrowingAdd"sv))})))), false}));
+return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("Add"sv)), (ByteString::must_from_utf8("ThrowingAdd"sv))})))), false}));
 };/*case end*/
 case 1 /* Subtract */: {
-return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("Subtract"sv)), TRY(ByteString::from_utf8("ThrowingSubtract"sv))})))), false}));
+return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("Subtract"sv)), (ByteString::must_from_utf8("ThrowingSubtract"sv))})))), false}));
 };/*case end*/
 case 2 /* Multiply */: {
-return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("Multiply"sv)), TRY(ByteString::from_utf8("ThrowingMultiply"sv))})))), false}));
+return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("Multiply"sv)), (ByteString::must_from_utf8("ThrowingMultiply"sv))})))), false}));
 };/*case end*/
 case 3 /* Divide */: {
-return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("Divide"sv)), TRY(ByteString::from_utf8("ThrowingDivide"sv))})))), false}));
+return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("Divide"sv)), (ByteString::must_from_utf8("ThrowingDivide"sv))})))), false}));
 };/*case end*/
 case 4 /* Modulo */: {
-return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("Modulo"sv)), TRY(ByteString::from_utf8("ThrowingModulo"sv))})))), false}));
+return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("Modulo"sv)), (ByteString::must_from_utf8("ThrowingModulo"sv))})))), false}));
 };/*case end*/
 case 5 /* LessThan */: {
-return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("Compare"sv)), TRY(ByteString::from_utf8("ThrowingCompare"sv))})))), false}));
+return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("Compare"sv)), (ByteString::must_from_utf8("ThrowingCompare"sv))})))), false}));
 };/*case end*/
 case 6 /* LessThanOrEqual */: {
-return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("Compare"sv)), TRY(ByteString::from_utf8("ThrowingCompare"sv))})))), false}));
+return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("Compare"sv)), (ByteString::must_from_utf8("ThrowingCompare"sv))})))), false}));
 };/*case end*/
 case 7 /* GreaterThan */: {
-return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("Compare"sv)), TRY(ByteString::from_utf8("ThrowingCompare"sv))})))), false}));
+return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("Compare"sv)), (ByteString::must_from_utf8("ThrowingCompare"sv))})))), false}));
 };/*case end*/
 case 8 /* GreaterThanOrEqual */: {
-return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("Compare"sv)), TRY(ByteString::from_utf8("ThrowingCompare"sv))})))), false}));
+return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("Compare"sv)), (ByteString::must_from_utf8("ThrowingCompare"sv))})))), false}));
 };/*case end*/
 case 9 /* Equal */: {
-return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("Equal"sv)), TRY(ByteString::from_utf8("ThrowingEqual"sv))})))), false}));
+return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("Equal"sv)), (ByteString::must_from_utf8("ThrowingEqual"sv))})))), false}));
 };/*case end*/
 case 10 /* NotEqual */: {
-return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("Equal"sv)), TRY(ByteString::from_utf8("ThrowingEqual"sv))})))), false}));
+return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("Equal"sv)), (ByteString::must_from_utf8("ThrowingEqual"sv))})))), false}));
 };/*case end*/
 case 27 /* AddAssign */: {
-return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("AddAssign"sv)), TRY(ByteString::from_utf8("ThrowingAddAssign"sv))})))), true}));
+return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("AddAssign"sv)), (ByteString::must_from_utf8("ThrowingAddAssign"sv))})))), true}));
 };/*case end*/
 case 28 /* SubtractAssign */: {
-return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("SubtractAssign"sv)), TRY(ByteString::from_utf8("ThrowingSubtractAssign"sv))})))), true}));
+return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("SubtractAssign"sv)), (ByteString::must_from_utf8("ThrowingSubtractAssign"sv))})))), true}));
 };/*case end*/
 case 29 /* MultiplyAssign */: {
-return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("MultiplyAssign"sv)), TRY(ByteString::from_utf8("ThrowingMultiplyAssign"sv))})))), true}));
+return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("MultiplyAssign"sv)), (ByteString::must_from_utf8("ThrowingMultiplyAssign"sv))})))), true}));
 };/*case end*/
 case 31 /* DivideAssign */: {
-return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("DivideAssign"sv)), TRY(ByteString::from_utf8("ThrowingDivideAssign"sv))})))), true}));
+return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("DivideAssign"sv)), (ByteString::must_from_utf8("ThrowingDivideAssign"sv))})))), true}));
 };/*case end*/
 case 30 /* ModuloAssign */: {
-return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("ModuloAssign"sv)), TRY(ByteString::from_utf8("ThrowingModuloAssign"sv))})))), true}));
+return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("ModuloAssign"sv)), (ByteString::must_from_utf8("ThrowingModuloAssign"sv))})))), true}));
 };/*case end*/
 case 22 /* BitwiseAndAssign */: {
-return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("BitwiseAndAssign"sv)), TRY(ByteString::from_utf8("ThrowingBitwiseAndAssign"sv))})))), true}));
+return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("BitwiseAndAssign"sv)), (ByteString::must_from_utf8("ThrowingBitwiseAndAssign"sv))})))), true}));
 };/*case end*/
 case 23 /* BitwiseOrAssign */: {
-return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("BitwiseOrAssign"sv)), TRY(ByteString::from_utf8("ThrowingBitwiseOrAssign"sv))})))), true}));
+return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("BitwiseOrAssign"sv)), (ByteString::must_from_utf8("ThrowingBitwiseOrAssign"sv))})))), true}));
 };/*case end*/
 case 24 /* BitwiseXorAssign */: {
-return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("BitwiseXorAssign"sv)), TRY(ByteString::from_utf8("ThrowingBitwiseXorAssign"sv))})))), true}));
+return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("BitwiseXorAssign"sv)), (ByteString::must_from_utf8("ThrowingBitwiseXorAssign"sv))})))), true}));
 };/*case end*/
 case 25 /* BitwiseLeftShiftAssign */: {
-return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("BitwiseLeftShiftAssign"sv)), TRY(ByteString::from_utf8("ThrowingBitwiseLeftShiftAssign"sv))})))), true}));
+return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("BitwiseLeftShiftAssign"sv)), (ByteString::must_from_utf8("ThrowingBitwiseLeftShiftAssign"sv))})))), true}));
 };/*case end*/
 case 26 /* BitwiseRightShiftAssign */: {
-return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("BitwiseRightShiftAssign"sv)), TRY(ByteString::from_utf8("ThrowingBitwiseRightShiftAssign"sv))})))), true}));
+return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("BitwiseRightShiftAssign"sv)), (ByteString::must_from_utf8("ThrowingBitwiseRightShiftAssign"sv))})))), true}));
 };/*case end*/
 default: {
 return JaktInternal::ExplicitValue((Tuple{empty_array, false}));
@@ -9641,70 +9641,70 @@ ByteString const function_name = ({
 auto&& __jakt_match_variant = op;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 0 /* Add */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("add"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("add"sv)));
 };/*case end*/
 case 1 /* Subtract */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("subtract"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("subtract"sv)));
 };/*case end*/
 case 2 /* Multiply */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("multiply"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("multiply"sv)));
 };/*case end*/
 case 3 /* Divide */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("divide"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("divide"sv)));
 };/*case end*/
 case 4 /* Modulo */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("modulo"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("modulo"sv)));
 };/*case end*/
 case 5 /* LessThan */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("less_than"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("less_than"sv)));
 };/*case end*/
 case 6 /* LessThanOrEqual */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("less_than_or_equal"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("less_than_or_equal"sv)));
 };/*case end*/
 case 7 /* GreaterThan */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("greater_than"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("greater_than"sv)));
 };/*case end*/
 case 8 /* GreaterThanOrEqual */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("greater_than_or_equal"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("greater_than_or_equal"sv)));
 };/*case end*/
 case 9 /* Equal */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("equals"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("equals"sv)));
 };/*case end*/
 case 10 /* NotEqual */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("not_equals"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("not_equals"sv)));
 };/*case end*/
 case 27 /* AddAssign */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("add_assign"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("add_assign"sv)));
 };/*case end*/
 case 28 /* SubtractAssign */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("subtract_assign"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("subtract_assign"sv)));
 };/*case end*/
 case 29 /* MultiplyAssign */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("multiply_assign"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("multiply_assign"sv)));
 };/*case end*/
 case 31 /* DivideAssign */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("divide_assign"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("divide_assign"sv)));
 };/*case end*/
 case 30 /* ModuloAssign */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("modulo_assign"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("modulo_assign"sv)));
 };/*case end*/
 case 22 /* BitwiseAndAssign */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("bitwise_and_assign"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("bitwise_and_assign"sv)));
 };/*case end*/
 case 23 /* BitwiseOrAssign */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("bitwise_or_assign"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("bitwise_or_assign"sv)));
 };/*case end*/
 case 24 /* BitwiseXorAssign */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("bitwise_xor_assign"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("bitwise_xor_assign"sv)));
 };/*case end*/
 case 25 /* BitwiseLeftShiftAssign */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("bitwise_left_shift_assign"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("bitwise_left_shift_assign"sv)));
 };/*case end*/
 case 26 /* BitwiseRightShiftAssign */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("bitwise_right_shift_assign"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("bitwise_right_shift_assign"sv)));
 };/*case end*/
 default: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8(""sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8(""sv)));
 };/*case end*/
 }/*switch end*/
 }()
@@ -9716,8 +9716,8 @@ return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8(""sv)));
 JaktInternal::Optional<typechecker::TraitImplementationDescriptor> const add_trait_implementation = TRY((((*this).find_any_singular_trait_implementation(lhs_type_id,trait_names,scope_id,lhs_span,(TRY((DynamicArray<ids::TypeId>::create_with({rhs_type_id}))))))));
 if (((add_trait_implementation).has_value())){
 typechecker::TraitImplementationDescriptor const implementation = (add_trait_implementation.value());
-if ((((((implementation).trait_name)).starts_with(TRY(ByteString::from_utf8("Throwing"sv)))) && (!(((scope)->can_throw))))){
-TRY((((*this).error(TRY(ByteString::from_utf8("Call to function that may throw needs to be in a try statement or a function marked as throws"sv)),span))));
+if ((((((implementation).trait_name)).starts_with((ByteString::must_from_utf8("Throwing"sv)))) && (!(((scope)->can_throw))))){
+TRY((((*this).error((ByteString::must_from_utf8("Call to function that may throw needs to be in a try statement or a function marked as throws"sv)),span))));
 }
 JaktInternal::Tuple<JaktInternal::Optional<types::StructLikeId>,bool> const parent_id___ = TRY((((*this).struct_like_id_from_type_id(lhs_type_id,scope_id,span,false,true))));
 JaktInternal::Optional<types::StructLikeId> const parent_id = ((parent_id___).template get<0>());
@@ -9728,15 +9728,15 @@ if (((implementation_function_id).has_value())){
 NonnullRefPtr<types::CheckedFunction> const implementation_function = ((*this).get_function((implementation_function_id.value())));
 if ((TRY((((implementation_function)->is_mutating()))) && (!(((checked_lhs)->is_mutable(((*this).program))))))){
 if (is_assignment){
-TRY((((*this).error(TRY(ByteString::from_utf8("Assignment to immutable variable"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("Assignment to immutable variable"sv)),span))));
 }
 else {
-TRY((((*this).error(TRY(ByteString::from_utf8("Cannot call mutating function on an immutable object instance"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("Cannot call mutating function on an immutable object instance"sv)),span))));
 }
 
 }
 (type_id = ((implementation_function)->return_type_id));
-types::CheckedCall call_expression = types::CheckedCall((TRY((DynamicArray<types::ResolvedNamespace>::create_with({})))),function_name,(TRY((DynamicArray<JaktInternal::Tuple<ByteString,NonnullRefPtr<typename types::CheckedExpression>>>::create_with({(Tuple{TRY(ByteString::from_utf8(""sv)), checked_rhs})})))),(TRY((DynamicArray<ids::TypeId>::create_with({})))),implementation_function_id,type_id,((implementation_function)->can_throw),((implementation_function)->external_name),((implementation_function)->force_inline));
+types::CheckedCall call_expression = types::CheckedCall((TRY((DynamicArray<types::ResolvedNamespace>::create_with({})))),function_name,(TRY((DynamicArray<JaktInternal::Tuple<ByteString,NonnullRefPtr<typename types::CheckedExpression>>>::create_with({(Tuple{(ByteString::must_from_utf8(""sv)), checked_rhs})})))),(TRY((DynamicArray<ids::TypeId>::create_with({})))),implementation_function_id,type_id,((implementation_function)->can_throw),((implementation_function)->external_name),((implementation_function)->force_inline));
 (((checked_operator).trait_implementation) = types::OperatorTraitImplementation(((implementation).trait_id),((implementation).implemented_type_args),call_expression));
 }
 else {
@@ -9813,67 +9813,67 @@ JaktInternal::Tuple<JaktInternal::DynamicArray<ByteString>,bool> const trait_nam
 auto&& __jakt_match_variant = op;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 0 /* Add */: {
-return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("Add"sv)), TRY(ByteString::from_utf8("ThrowingAdd"sv))})))), false}));
+return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("Add"sv)), (ByteString::must_from_utf8("ThrowingAdd"sv))})))), false}));
 };/*case end*/
 case 1 /* Subtract */: {
-return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("Subtract"sv)), TRY(ByteString::from_utf8("ThrowingSubtract"sv))})))), false}));
+return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("Subtract"sv)), (ByteString::must_from_utf8("ThrowingSubtract"sv))})))), false}));
 };/*case end*/
 case 2 /* Multiply */: {
-return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("Multiply"sv)), TRY(ByteString::from_utf8("ThrowingMultiply"sv))})))), false}));
+return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("Multiply"sv)), (ByteString::must_from_utf8("ThrowingMultiply"sv))})))), false}));
 };/*case end*/
 case 3 /* Divide */: {
-return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("Divide"sv)), TRY(ByteString::from_utf8("ThrowingDivide"sv))})))), false}));
+return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("Divide"sv)), (ByteString::must_from_utf8("ThrowingDivide"sv))})))), false}));
 };/*case end*/
 case 4 /* Modulo */: {
-return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("Modulo"sv)), TRY(ByteString::from_utf8("ThrowingModulo"sv))})))), false}));
+return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("Modulo"sv)), (ByteString::must_from_utf8("ThrowingModulo"sv))})))), false}));
 };/*case end*/
 case 5 /* LessThan */: {
-return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("Compare"sv)), TRY(ByteString::from_utf8("ThrowingCompare"sv))})))), false}));
+return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("Compare"sv)), (ByteString::must_from_utf8("ThrowingCompare"sv))})))), false}));
 };/*case end*/
 case 6 /* LessThanOrEqual */: {
-return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("Compare"sv)), TRY(ByteString::from_utf8("ThrowingCompare"sv))})))), false}));
+return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("Compare"sv)), (ByteString::must_from_utf8("ThrowingCompare"sv))})))), false}));
 };/*case end*/
 case 7 /* GreaterThan */: {
-return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("Compare"sv)), TRY(ByteString::from_utf8("ThrowingCompare"sv))})))), false}));
+return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("Compare"sv)), (ByteString::must_from_utf8("ThrowingCompare"sv))})))), false}));
 };/*case end*/
 case 8 /* GreaterThanOrEqual */: {
-return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("Compare"sv)), TRY(ByteString::from_utf8("ThrowingCompare"sv))})))), false}));
+return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("Compare"sv)), (ByteString::must_from_utf8("ThrowingCompare"sv))})))), false}));
 };/*case end*/
 case 9 /* Equal */: {
-return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("Equal"sv)), TRY(ByteString::from_utf8("ThrowingEqual"sv))})))), false}));
+return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("Equal"sv)), (ByteString::must_from_utf8("ThrowingEqual"sv))})))), false}));
 };/*case end*/
 case 10 /* NotEqual */: {
-return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("Equal"sv)), TRY(ByteString::from_utf8("ThrowingEqual"sv))})))), false}));
+return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("Equal"sv)), (ByteString::must_from_utf8("ThrowingEqual"sv))})))), false}));
 };/*case end*/
 case 27 /* AddAssign */: {
-return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("AddAssign"sv)), TRY(ByteString::from_utf8("ThrowingAddAssign"sv))})))), true}));
+return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("AddAssign"sv)), (ByteString::must_from_utf8("ThrowingAddAssign"sv))})))), true}));
 };/*case end*/
 case 28 /* SubtractAssign */: {
-return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("SubtractAssign"sv)), TRY(ByteString::from_utf8("ThrowingSubtractAssign"sv))})))), true}));
+return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("SubtractAssign"sv)), (ByteString::must_from_utf8("ThrowingSubtractAssign"sv))})))), true}));
 };/*case end*/
 case 29 /* MultiplyAssign */: {
-return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("MultiplyAssign"sv)), TRY(ByteString::from_utf8("ThrowingMultiplyAssign"sv))})))), true}));
+return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("MultiplyAssign"sv)), (ByteString::must_from_utf8("ThrowingMultiplyAssign"sv))})))), true}));
 };/*case end*/
 case 31 /* DivideAssign */: {
-return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("DivideAssign"sv)), TRY(ByteString::from_utf8("ThrowingDivideAssign"sv))})))), true}));
+return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("DivideAssign"sv)), (ByteString::must_from_utf8("ThrowingDivideAssign"sv))})))), true}));
 };/*case end*/
 case 30 /* ModuloAssign */: {
-return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("ModuloAssign"sv)), TRY(ByteString::from_utf8("ThrowingModuloAssign"sv))})))), true}));
+return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("ModuloAssign"sv)), (ByteString::must_from_utf8("ThrowingModuloAssign"sv))})))), true}));
 };/*case end*/
 case 22 /* BitwiseAndAssign */: {
-return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("BitwiseAndAssign"sv)), TRY(ByteString::from_utf8("ThrowingBitwiseAndAssign"sv))})))), true}));
+return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("BitwiseAndAssign"sv)), (ByteString::must_from_utf8("ThrowingBitwiseAndAssign"sv))})))), true}));
 };/*case end*/
 case 23 /* BitwiseOrAssign */: {
-return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("BitwiseOrAssign"sv)), TRY(ByteString::from_utf8("ThrowingBitwiseOrAssign"sv))})))), true}));
+return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("BitwiseOrAssign"sv)), (ByteString::must_from_utf8("ThrowingBitwiseOrAssign"sv))})))), true}));
 };/*case end*/
 case 24 /* BitwiseXorAssign */: {
-return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("BitwiseXorAssign"sv)), TRY(ByteString::from_utf8("ThrowingBitwiseXorAssign"sv))})))), true}));
+return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("BitwiseXorAssign"sv)), (ByteString::must_from_utf8("ThrowingBitwiseXorAssign"sv))})))), true}));
 };/*case end*/
 case 25 /* BitwiseLeftShiftAssign */: {
-return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("BitwiseLeftShiftAssign"sv)), TRY(ByteString::from_utf8("ThrowingBitwiseLeftShiftAssign"sv))})))), true}));
+return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("BitwiseLeftShiftAssign"sv)), (ByteString::must_from_utf8("ThrowingBitwiseLeftShiftAssign"sv))})))), true}));
 };/*case end*/
 case 26 /* BitwiseRightShiftAssign */: {
-return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("BitwiseRightShiftAssign"sv)), TRY(ByteString::from_utf8("ThrowingBitwiseRightShiftAssign"sv))})))), true}));
+return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("BitwiseRightShiftAssign"sv)), (ByteString::must_from_utf8("ThrowingBitwiseRightShiftAssign"sv))})))), true}));
 };/*case end*/
 default: {
 return JaktInternal::ExplicitValue((Tuple{empty_array, false}));
@@ -9893,70 +9893,70 @@ ByteString const function_name = ({
 auto&& __jakt_match_variant = op;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 0 /* Add */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("add"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("add"sv)));
 };/*case end*/
 case 1 /* Subtract */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("subtract"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("subtract"sv)));
 };/*case end*/
 case 2 /* Multiply */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("multiply"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("multiply"sv)));
 };/*case end*/
 case 3 /* Divide */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("divide"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("divide"sv)));
 };/*case end*/
 case 4 /* Modulo */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("modulo"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("modulo"sv)));
 };/*case end*/
 case 5 /* LessThan */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("less_than"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("less_than"sv)));
 };/*case end*/
 case 6 /* LessThanOrEqual */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("less_than_or_equal"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("less_than_or_equal"sv)));
 };/*case end*/
 case 7 /* GreaterThan */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("greater_than"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("greater_than"sv)));
 };/*case end*/
 case 8 /* GreaterThanOrEqual */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("greater_than_or_equal"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("greater_than_or_equal"sv)));
 };/*case end*/
 case 9 /* Equal */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("equals"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("equals"sv)));
 };/*case end*/
 case 10 /* NotEqual */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("not_equals"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("not_equals"sv)));
 };/*case end*/
 case 27 /* AddAssign */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("add_assign"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("add_assign"sv)));
 };/*case end*/
 case 28 /* SubtractAssign */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("subtract_assign"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("subtract_assign"sv)));
 };/*case end*/
 case 29 /* MultiplyAssign */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("multiply_assign"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("multiply_assign"sv)));
 };/*case end*/
 case 31 /* DivideAssign */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("divide_assign"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("divide_assign"sv)));
 };/*case end*/
 case 30 /* ModuloAssign */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("modulo_assign"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("modulo_assign"sv)));
 };/*case end*/
 case 22 /* BitwiseAndAssign */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("bitwise_and_assign"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("bitwise_and_assign"sv)));
 };/*case end*/
 case 23 /* BitwiseOrAssign */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("bitwise_or_assign"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("bitwise_or_assign"sv)));
 };/*case end*/
 case 24 /* BitwiseXorAssign */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("bitwise_xor_assign"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("bitwise_xor_assign"sv)));
 };/*case end*/
 case 25 /* BitwiseLeftShiftAssign */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("bitwise_left_shift_assign"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("bitwise_left_shift_assign"sv)));
 };/*case end*/
 case 26 /* BitwiseRightShiftAssign */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("bitwise_right_shift_assign"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("bitwise_right_shift_assign"sv)));
 };/*case end*/
 default: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8(""sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8(""sv)));
 };/*case end*/
 }/*switch end*/
 }()
@@ -9968,8 +9968,8 @@ return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8(""sv)));
 JaktInternal::Optional<typechecker::TraitImplementationDescriptor> const add_trait_implementation = TRY((((*this).find_any_singular_trait_implementation(lhs_type_id,trait_names,scope_id,lhs_span,(TRY((DynamicArray<ids::TypeId>::create_with({rhs_type_id}))))))));
 if (((add_trait_implementation).has_value())){
 typechecker::TraitImplementationDescriptor const implementation = (add_trait_implementation.value());
-if ((((((implementation).trait_name)).starts_with(TRY(ByteString::from_utf8("Throwing"sv)))) && (!(((scope)->can_throw))))){
-TRY((((*this).error(TRY(ByteString::from_utf8("Call to function that may throw needs to be in a try statement or a function marked as throws"sv)),span))));
+if ((((((implementation).trait_name)).starts_with((ByteString::must_from_utf8("Throwing"sv)))) && (!(((scope)->can_throw))))){
+TRY((((*this).error((ByteString::must_from_utf8("Call to function that may throw needs to be in a try statement or a function marked as throws"sv)),span))));
 }
 JaktInternal::Tuple<JaktInternal::Optional<types::StructLikeId>,bool> const parent_id___ = TRY((((*this).struct_like_id_from_type_id(lhs_type_id,scope_id,span,false,true))));
 JaktInternal::Optional<types::StructLikeId> const parent_id = ((parent_id___).template get<0>());
@@ -9980,15 +9980,15 @@ if (((implementation_function_id).has_value())){
 NonnullRefPtr<types::CheckedFunction> const implementation_function = ((*this).get_function((implementation_function_id.value())));
 if ((TRY((((implementation_function)->is_mutating()))) && (!(((checked_lhs)->is_mutable(((*this).program))))))){
 if (is_assignment){
-TRY((((*this).error(TRY(ByteString::from_utf8("Assignment to immutable variable"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("Assignment to immutable variable"sv)),span))));
 }
 else {
-TRY((((*this).error(TRY(ByteString::from_utf8("Cannot call mutating function on an immutable object instance"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("Cannot call mutating function on an immutable object instance"sv)),span))));
 }
 
 }
 (type_id = ((implementation_function)->return_type_id));
-types::CheckedCall call_expression = types::CheckedCall((TRY((DynamicArray<types::ResolvedNamespace>::create_with({})))),function_name,(TRY((DynamicArray<JaktInternal::Tuple<ByteString,NonnullRefPtr<typename types::CheckedExpression>>>::create_with({(Tuple{TRY(ByteString::from_utf8(""sv)), checked_rhs})})))),(TRY((DynamicArray<ids::TypeId>::create_with({})))),implementation_function_id,type_id,((implementation_function)->can_throw),((implementation_function)->external_name),((implementation_function)->force_inline));
+types::CheckedCall call_expression = types::CheckedCall((TRY((DynamicArray<types::ResolvedNamespace>::create_with({})))),function_name,(TRY((DynamicArray<JaktInternal::Tuple<ByteString,NonnullRefPtr<typename types::CheckedExpression>>>::create_with({(Tuple{(ByteString::must_from_utf8(""sv)), checked_rhs})})))),(TRY((DynamicArray<ids::TypeId>::create_with({})))),implementation_function_id,type_id,((implementation_function)->can_throw),((implementation_function)->external_name),((implementation_function)->force_inline));
 (((checked_operator).trait_implementation) = types::OperatorTraitImplementation(((implementation).trait_id),((implementation).implemented_type_args),call_expression));
 }
 else {
@@ -10065,67 +10065,67 @@ JaktInternal::Tuple<JaktInternal::DynamicArray<ByteString>,bool> const trait_nam
 auto&& __jakt_match_variant = op;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 0 /* Add */: {
-return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("Add"sv)), TRY(ByteString::from_utf8("ThrowingAdd"sv))})))), false}));
+return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("Add"sv)), (ByteString::must_from_utf8("ThrowingAdd"sv))})))), false}));
 };/*case end*/
 case 1 /* Subtract */: {
-return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("Subtract"sv)), TRY(ByteString::from_utf8("ThrowingSubtract"sv))})))), false}));
+return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("Subtract"sv)), (ByteString::must_from_utf8("ThrowingSubtract"sv))})))), false}));
 };/*case end*/
 case 2 /* Multiply */: {
-return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("Multiply"sv)), TRY(ByteString::from_utf8("ThrowingMultiply"sv))})))), false}));
+return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("Multiply"sv)), (ByteString::must_from_utf8("ThrowingMultiply"sv))})))), false}));
 };/*case end*/
 case 3 /* Divide */: {
-return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("Divide"sv)), TRY(ByteString::from_utf8("ThrowingDivide"sv))})))), false}));
+return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("Divide"sv)), (ByteString::must_from_utf8("ThrowingDivide"sv))})))), false}));
 };/*case end*/
 case 4 /* Modulo */: {
-return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("Modulo"sv)), TRY(ByteString::from_utf8("ThrowingModulo"sv))})))), false}));
+return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("Modulo"sv)), (ByteString::must_from_utf8("ThrowingModulo"sv))})))), false}));
 };/*case end*/
 case 5 /* LessThan */: {
-return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("Compare"sv)), TRY(ByteString::from_utf8("ThrowingCompare"sv))})))), false}));
+return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("Compare"sv)), (ByteString::must_from_utf8("ThrowingCompare"sv))})))), false}));
 };/*case end*/
 case 6 /* LessThanOrEqual */: {
-return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("Compare"sv)), TRY(ByteString::from_utf8("ThrowingCompare"sv))})))), false}));
+return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("Compare"sv)), (ByteString::must_from_utf8("ThrowingCompare"sv))})))), false}));
 };/*case end*/
 case 7 /* GreaterThan */: {
-return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("Compare"sv)), TRY(ByteString::from_utf8("ThrowingCompare"sv))})))), false}));
+return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("Compare"sv)), (ByteString::must_from_utf8("ThrowingCompare"sv))})))), false}));
 };/*case end*/
 case 8 /* GreaterThanOrEqual */: {
-return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("Compare"sv)), TRY(ByteString::from_utf8("ThrowingCompare"sv))})))), false}));
+return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("Compare"sv)), (ByteString::must_from_utf8("ThrowingCompare"sv))})))), false}));
 };/*case end*/
 case 9 /* Equal */: {
-return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("Equal"sv)), TRY(ByteString::from_utf8("ThrowingEqual"sv))})))), false}));
+return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("Equal"sv)), (ByteString::must_from_utf8("ThrowingEqual"sv))})))), false}));
 };/*case end*/
 case 10 /* NotEqual */: {
-return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("Equal"sv)), TRY(ByteString::from_utf8("ThrowingEqual"sv))})))), false}));
+return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("Equal"sv)), (ByteString::must_from_utf8("ThrowingEqual"sv))})))), false}));
 };/*case end*/
 case 27 /* AddAssign */: {
-return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("AddAssign"sv)), TRY(ByteString::from_utf8("ThrowingAddAssign"sv))})))), true}));
+return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("AddAssign"sv)), (ByteString::must_from_utf8("ThrowingAddAssign"sv))})))), true}));
 };/*case end*/
 case 28 /* SubtractAssign */: {
-return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("SubtractAssign"sv)), TRY(ByteString::from_utf8("ThrowingSubtractAssign"sv))})))), true}));
+return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("SubtractAssign"sv)), (ByteString::must_from_utf8("ThrowingSubtractAssign"sv))})))), true}));
 };/*case end*/
 case 29 /* MultiplyAssign */: {
-return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("MultiplyAssign"sv)), TRY(ByteString::from_utf8("ThrowingMultiplyAssign"sv))})))), true}));
+return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("MultiplyAssign"sv)), (ByteString::must_from_utf8("ThrowingMultiplyAssign"sv))})))), true}));
 };/*case end*/
 case 31 /* DivideAssign */: {
-return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("DivideAssign"sv)), TRY(ByteString::from_utf8("ThrowingDivideAssign"sv))})))), true}));
+return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("DivideAssign"sv)), (ByteString::must_from_utf8("ThrowingDivideAssign"sv))})))), true}));
 };/*case end*/
 case 30 /* ModuloAssign */: {
-return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("ModuloAssign"sv)), TRY(ByteString::from_utf8("ThrowingModuloAssign"sv))})))), true}));
+return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("ModuloAssign"sv)), (ByteString::must_from_utf8("ThrowingModuloAssign"sv))})))), true}));
 };/*case end*/
 case 22 /* BitwiseAndAssign */: {
-return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("BitwiseAndAssign"sv)), TRY(ByteString::from_utf8("ThrowingBitwiseAndAssign"sv))})))), true}));
+return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("BitwiseAndAssign"sv)), (ByteString::must_from_utf8("ThrowingBitwiseAndAssign"sv))})))), true}));
 };/*case end*/
 case 23 /* BitwiseOrAssign */: {
-return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("BitwiseOrAssign"sv)), TRY(ByteString::from_utf8("ThrowingBitwiseOrAssign"sv))})))), true}));
+return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("BitwiseOrAssign"sv)), (ByteString::must_from_utf8("ThrowingBitwiseOrAssign"sv))})))), true}));
 };/*case end*/
 case 24 /* BitwiseXorAssign */: {
-return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("BitwiseXorAssign"sv)), TRY(ByteString::from_utf8("ThrowingBitwiseXorAssign"sv))})))), true}));
+return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("BitwiseXorAssign"sv)), (ByteString::must_from_utf8("ThrowingBitwiseXorAssign"sv))})))), true}));
 };/*case end*/
 case 25 /* BitwiseLeftShiftAssign */: {
-return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("BitwiseLeftShiftAssign"sv)), TRY(ByteString::from_utf8("ThrowingBitwiseLeftShiftAssign"sv))})))), true}));
+return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("BitwiseLeftShiftAssign"sv)), (ByteString::must_from_utf8("ThrowingBitwiseLeftShiftAssign"sv))})))), true}));
 };/*case end*/
 case 26 /* BitwiseRightShiftAssign */: {
-return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("BitwiseRightShiftAssign"sv)), TRY(ByteString::from_utf8("ThrowingBitwiseRightShiftAssign"sv))})))), true}));
+return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("BitwiseRightShiftAssign"sv)), (ByteString::must_from_utf8("ThrowingBitwiseRightShiftAssign"sv))})))), true}));
 };/*case end*/
 default: {
 return JaktInternal::ExplicitValue((Tuple{empty_array, false}));
@@ -10145,70 +10145,70 @@ ByteString const function_name = ({
 auto&& __jakt_match_variant = op;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 0 /* Add */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("add"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("add"sv)));
 };/*case end*/
 case 1 /* Subtract */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("subtract"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("subtract"sv)));
 };/*case end*/
 case 2 /* Multiply */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("multiply"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("multiply"sv)));
 };/*case end*/
 case 3 /* Divide */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("divide"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("divide"sv)));
 };/*case end*/
 case 4 /* Modulo */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("modulo"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("modulo"sv)));
 };/*case end*/
 case 5 /* LessThan */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("less_than"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("less_than"sv)));
 };/*case end*/
 case 6 /* LessThanOrEqual */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("less_than_or_equal"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("less_than_or_equal"sv)));
 };/*case end*/
 case 7 /* GreaterThan */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("greater_than"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("greater_than"sv)));
 };/*case end*/
 case 8 /* GreaterThanOrEqual */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("greater_than_or_equal"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("greater_than_or_equal"sv)));
 };/*case end*/
 case 9 /* Equal */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("equals"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("equals"sv)));
 };/*case end*/
 case 10 /* NotEqual */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("not_equals"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("not_equals"sv)));
 };/*case end*/
 case 27 /* AddAssign */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("add_assign"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("add_assign"sv)));
 };/*case end*/
 case 28 /* SubtractAssign */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("subtract_assign"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("subtract_assign"sv)));
 };/*case end*/
 case 29 /* MultiplyAssign */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("multiply_assign"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("multiply_assign"sv)));
 };/*case end*/
 case 31 /* DivideAssign */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("divide_assign"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("divide_assign"sv)));
 };/*case end*/
 case 30 /* ModuloAssign */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("modulo_assign"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("modulo_assign"sv)));
 };/*case end*/
 case 22 /* BitwiseAndAssign */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("bitwise_and_assign"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("bitwise_and_assign"sv)));
 };/*case end*/
 case 23 /* BitwiseOrAssign */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("bitwise_or_assign"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("bitwise_or_assign"sv)));
 };/*case end*/
 case 24 /* BitwiseXorAssign */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("bitwise_xor_assign"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("bitwise_xor_assign"sv)));
 };/*case end*/
 case 25 /* BitwiseLeftShiftAssign */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("bitwise_left_shift_assign"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("bitwise_left_shift_assign"sv)));
 };/*case end*/
 case 26 /* BitwiseRightShiftAssign */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("bitwise_right_shift_assign"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("bitwise_right_shift_assign"sv)));
 };/*case end*/
 default: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8(""sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8(""sv)));
 };/*case end*/
 }/*switch end*/
 }()
@@ -10220,8 +10220,8 @@ return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8(""sv)));
 JaktInternal::Optional<typechecker::TraitImplementationDescriptor> const add_trait_implementation = TRY((((*this).find_any_singular_trait_implementation(lhs_type_id,trait_names,scope_id,lhs_span,(TRY((DynamicArray<ids::TypeId>::create_with({rhs_type_id}))))))));
 if (((add_trait_implementation).has_value())){
 typechecker::TraitImplementationDescriptor const implementation = (add_trait_implementation.value());
-if ((((((implementation).trait_name)).starts_with(TRY(ByteString::from_utf8("Throwing"sv)))) && (!(((scope)->can_throw))))){
-TRY((((*this).error(TRY(ByteString::from_utf8("Call to function that may throw needs to be in a try statement or a function marked as throws"sv)),span))));
+if ((((((implementation).trait_name)).starts_with((ByteString::must_from_utf8("Throwing"sv)))) && (!(((scope)->can_throw))))){
+TRY((((*this).error((ByteString::must_from_utf8("Call to function that may throw needs to be in a try statement or a function marked as throws"sv)),span))));
 }
 JaktInternal::Tuple<JaktInternal::Optional<types::StructLikeId>,bool> const parent_id___ = TRY((((*this).struct_like_id_from_type_id(lhs_type_id,scope_id,span,false,true))));
 JaktInternal::Optional<types::StructLikeId> const parent_id = ((parent_id___).template get<0>());
@@ -10232,15 +10232,15 @@ if (((implementation_function_id).has_value())){
 NonnullRefPtr<types::CheckedFunction> const implementation_function = ((*this).get_function((implementation_function_id.value())));
 if ((TRY((((implementation_function)->is_mutating()))) && (!(((checked_lhs)->is_mutable(((*this).program))))))){
 if (is_assignment){
-TRY((((*this).error(TRY(ByteString::from_utf8("Assignment to immutable variable"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("Assignment to immutable variable"sv)),span))));
 }
 else {
-TRY((((*this).error(TRY(ByteString::from_utf8("Cannot call mutating function on an immutable object instance"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("Cannot call mutating function on an immutable object instance"sv)),span))));
 }
 
 }
 (type_id = ((implementation_function)->return_type_id));
-types::CheckedCall call_expression = types::CheckedCall((TRY((DynamicArray<types::ResolvedNamespace>::create_with({})))),function_name,(TRY((DynamicArray<JaktInternal::Tuple<ByteString,NonnullRefPtr<typename types::CheckedExpression>>>::create_with({(Tuple{TRY(ByteString::from_utf8(""sv)), checked_rhs})})))),(TRY((DynamicArray<ids::TypeId>::create_with({})))),implementation_function_id,type_id,((implementation_function)->can_throw),((implementation_function)->external_name),((implementation_function)->force_inline));
+types::CheckedCall call_expression = types::CheckedCall((TRY((DynamicArray<types::ResolvedNamespace>::create_with({})))),function_name,(TRY((DynamicArray<JaktInternal::Tuple<ByteString,NonnullRefPtr<typename types::CheckedExpression>>>::create_with({(Tuple{(ByteString::must_from_utf8(""sv)), checked_rhs})})))),(TRY((DynamicArray<ids::TypeId>::create_with({})))),implementation_function_id,type_id,((implementation_function)->can_throw),((implementation_function)->external_name),((implementation_function)->force_inline));
 (((checked_operator).trait_implementation) = types::OperatorTraitImplementation(((implementation).trait_id),((implementation).implemented_type_args),call_expression));
 }
 else {
@@ -10317,67 +10317,67 @@ JaktInternal::Tuple<JaktInternal::DynamicArray<ByteString>,bool> const trait_nam
 auto&& __jakt_match_variant = op;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 0 /* Add */: {
-return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("Add"sv)), TRY(ByteString::from_utf8("ThrowingAdd"sv))})))), false}));
+return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("Add"sv)), (ByteString::must_from_utf8("ThrowingAdd"sv))})))), false}));
 };/*case end*/
 case 1 /* Subtract */: {
-return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("Subtract"sv)), TRY(ByteString::from_utf8("ThrowingSubtract"sv))})))), false}));
+return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("Subtract"sv)), (ByteString::must_from_utf8("ThrowingSubtract"sv))})))), false}));
 };/*case end*/
 case 2 /* Multiply */: {
-return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("Multiply"sv)), TRY(ByteString::from_utf8("ThrowingMultiply"sv))})))), false}));
+return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("Multiply"sv)), (ByteString::must_from_utf8("ThrowingMultiply"sv))})))), false}));
 };/*case end*/
 case 3 /* Divide */: {
-return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("Divide"sv)), TRY(ByteString::from_utf8("ThrowingDivide"sv))})))), false}));
+return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("Divide"sv)), (ByteString::must_from_utf8("ThrowingDivide"sv))})))), false}));
 };/*case end*/
 case 4 /* Modulo */: {
-return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("Modulo"sv)), TRY(ByteString::from_utf8("ThrowingModulo"sv))})))), false}));
+return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("Modulo"sv)), (ByteString::must_from_utf8("ThrowingModulo"sv))})))), false}));
 };/*case end*/
 case 5 /* LessThan */: {
-return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("Compare"sv)), TRY(ByteString::from_utf8("ThrowingCompare"sv))})))), false}));
+return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("Compare"sv)), (ByteString::must_from_utf8("ThrowingCompare"sv))})))), false}));
 };/*case end*/
 case 6 /* LessThanOrEqual */: {
-return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("Compare"sv)), TRY(ByteString::from_utf8("ThrowingCompare"sv))})))), false}));
+return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("Compare"sv)), (ByteString::must_from_utf8("ThrowingCompare"sv))})))), false}));
 };/*case end*/
 case 7 /* GreaterThan */: {
-return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("Compare"sv)), TRY(ByteString::from_utf8("ThrowingCompare"sv))})))), false}));
+return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("Compare"sv)), (ByteString::must_from_utf8("ThrowingCompare"sv))})))), false}));
 };/*case end*/
 case 8 /* GreaterThanOrEqual */: {
-return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("Compare"sv)), TRY(ByteString::from_utf8("ThrowingCompare"sv))})))), false}));
+return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("Compare"sv)), (ByteString::must_from_utf8("ThrowingCompare"sv))})))), false}));
 };/*case end*/
 case 9 /* Equal */: {
-return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("Equal"sv)), TRY(ByteString::from_utf8("ThrowingEqual"sv))})))), false}));
+return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("Equal"sv)), (ByteString::must_from_utf8("ThrowingEqual"sv))})))), false}));
 };/*case end*/
 case 10 /* NotEqual */: {
-return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("Equal"sv)), TRY(ByteString::from_utf8("ThrowingEqual"sv))})))), false}));
+return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("Equal"sv)), (ByteString::must_from_utf8("ThrowingEqual"sv))})))), false}));
 };/*case end*/
 case 27 /* AddAssign */: {
-return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("AddAssign"sv)), TRY(ByteString::from_utf8("ThrowingAddAssign"sv))})))), true}));
+return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("AddAssign"sv)), (ByteString::must_from_utf8("ThrowingAddAssign"sv))})))), true}));
 };/*case end*/
 case 28 /* SubtractAssign */: {
-return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("SubtractAssign"sv)), TRY(ByteString::from_utf8("ThrowingSubtractAssign"sv))})))), true}));
+return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("SubtractAssign"sv)), (ByteString::must_from_utf8("ThrowingSubtractAssign"sv))})))), true}));
 };/*case end*/
 case 29 /* MultiplyAssign */: {
-return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("MultiplyAssign"sv)), TRY(ByteString::from_utf8("ThrowingMultiplyAssign"sv))})))), true}));
+return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("MultiplyAssign"sv)), (ByteString::must_from_utf8("ThrowingMultiplyAssign"sv))})))), true}));
 };/*case end*/
 case 31 /* DivideAssign */: {
-return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("DivideAssign"sv)), TRY(ByteString::from_utf8("ThrowingDivideAssign"sv))})))), true}));
+return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("DivideAssign"sv)), (ByteString::must_from_utf8("ThrowingDivideAssign"sv))})))), true}));
 };/*case end*/
 case 30 /* ModuloAssign */: {
-return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("ModuloAssign"sv)), TRY(ByteString::from_utf8("ThrowingModuloAssign"sv))})))), true}));
+return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("ModuloAssign"sv)), (ByteString::must_from_utf8("ThrowingModuloAssign"sv))})))), true}));
 };/*case end*/
 case 22 /* BitwiseAndAssign */: {
-return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("BitwiseAndAssign"sv)), TRY(ByteString::from_utf8("ThrowingBitwiseAndAssign"sv))})))), true}));
+return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("BitwiseAndAssign"sv)), (ByteString::must_from_utf8("ThrowingBitwiseAndAssign"sv))})))), true}));
 };/*case end*/
 case 23 /* BitwiseOrAssign */: {
-return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("BitwiseOrAssign"sv)), TRY(ByteString::from_utf8("ThrowingBitwiseOrAssign"sv))})))), true}));
+return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("BitwiseOrAssign"sv)), (ByteString::must_from_utf8("ThrowingBitwiseOrAssign"sv))})))), true}));
 };/*case end*/
 case 24 /* BitwiseXorAssign */: {
-return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("BitwiseXorAssign"sv)), TRY(ByteString::from_utf8("ThrowingBitwiseXorAssign"sv))})))), true}));
+return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("BitwiseXorAssign"sv)), (ByteString::must_from_utf8("ThrowingBitwiseXorAssign"sv))})))), true}));
 };/*case end*/
 case 25 /* BitwiseLeftShiftAssign */: {
-return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("BitwiseLeftShiftAssign"sv)), TRY(ByteString::from_utf8("ThrowingBitwiseLeftShiftAssign"sv))})))), true}));
+return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("BitwiseLeftShiftAssign"sv)), (ByteString::must_from_utf8("ThrowingBitwiseLeftShiftAssign"sv))})))), true}));
 };/*case end*/
 case 26 /* BitwiseRightShiftAssign */: {
-return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("BitwiseRightShiftAssign"sv)), TRY(ByteString::from_utf8("ThrowingBitwiseRightShiftAssign"sv))})))), true}));
+return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("BitwiseRightShiftAssign"sv)), (ByteString::must_from_utf8("ThrowingBitwiseRightShiftAssign"sv))})))), true}));
 };/*case end*/
 default: {
 return JaktInternal::ExplicitValue((Tuple{empty_array, false}));
@@ -10397,70 +10397,70 @@ ByteString const function_name = ({
 auto&& __jakt_match_variant = op;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 0 /* Add */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("add"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("add"sv)));
 };/*case end*/
 case 1 /* Subtract */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("subtract"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("subtract"sv)));
 };/*case end*/
 case 2 /* Multiply */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("multiply"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("multiply"sv)));
 };/*case end*/
 case 3 /* Divide */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("divide"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("divide"sv)));
 };/*case end*/
 case 4 /* Modulo */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("modulo"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("modulo"sv)));
 };/*case end*/
 case 5 /* LessThan */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("less_than"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("less_than"sv)));
 };/*case end*/
 case 6 /* LessThanOrEqual */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("less_than_or_equal"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("less_than_or_equal"sv)));
 };/*case end*/
 case 7 /* GreaterThan */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("greater_than"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("greater_than"sv)));
 };/*case end*/
 case 8 /* GreaterThanOrEqual */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("greater_than_or_equal"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("greater_than_or_equal"sv)));
 };/*case end*/
 case 9 /* Equal */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("equals"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("equals"sv)));
 };/*case end*/
 case 10 /* NotEqual */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("not_equals"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("not_equals"sv)));
 };/*case end*/
 case 27 /* AddAssign */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("add_assign"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("add_assign"sv)));
 };/*case end*/
 case 28 /* SubtractAssign */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("subtract_assign"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("subtract_assign"sv)));
 };/*case end*/
 case 29 /* MultiplyAssign */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("multiply_assign"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("multiply_assign"sv)));
 };/*case end*/
 case 31 /* DivideAssign */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("divide_assign"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("divide_assign"sv)));
 };/*case end*/
 case 30 /* ModuloAssign */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("modulo_assign"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("modulo_assign"sv)));
 };/*case end*/
 case 22 /* BitwiseAndAssign */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("bitwise_and_assign"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("bitwise_and_assign"sv)));
 };/*case end*/
 case 23 /* BitwiseOrAssign */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("bitwise_or_assign"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("bitwise_or_assign"sv)));
 };/*case end*/
 case 24 /* BitwiseXorAssign */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("bitwise_xor_assign"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("bitwise_xor_assign"sv)));
 };/*case end*/
 case 25 /* BitwiseLeftShiftAssign */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("bitwise_left_shift_assign"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("bitwise_left_shift_assign"sv)));
 };/*case end*/
 case 26 /* BitwiseRightShiftAssign */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("bitwise_right_shift_assign"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("bitwise_right_shift_assign"sv)));
 };/*case end*/
 default: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8(""sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8(""sv)));
 };/*case end*/
 }/*switch end*/
 }()
@@ -10472,8 +10472,8 @@ return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8(""sv)));
 JaktInternal::Optional<typechecker::TraitImplementationDescriptor> const add_trait_implementation = TRY((((*this).find_any_singular_trait_implementation(lhs_type_id,trait_names,scope_id,lhs_span,(TRY((DynamicArray<ids::TypeId>::create_with({rhs_type_id}))))))));
 if (((add_trait_implementation).has_value())){
 typechecker::TraitImplementationDescriptor const implementation = (add_trait_implementation.value());
-if ((((((implementation).trait_name)).starts_with(TRY(ByteString::from_utf8("Throwing"sv)))) && (!(((scope)->can_throw))))){
-TRY((((*this).error(TRY(ByteString::from_utf8("Call to function that may throw needs to be in a try statement or a function marked as throws"sv)),span))));
+if ((((((implementation).trait_name)).starts_with((ByteString::must_from_utf8("Throwing"sv)))) && (!(((scope)->can_throw))))){
+TRY((((*this).error((ByteString::must_from_utf8("Call to function that may throw needs to be in a try statement or a function marked as throws"sv)),span))));
 }
 JaktInternal::Tuple<JaktInternal::Optional<types::StructLikeId>,bool> const parent_id___ = TRY((((*this).struct_like_id_from_type_id(lhs_type_id,scope_id,span,false,true))));
 JaktInternal::Optional<types::StructLikeId> const parent_id = ((parent_id___).template get<0>());
@@ -10484,15 +10484,15 @@ if (((implementation_function_id).has_value())){
 NonnullRefPtr<types::CheckedFunction> const implementation_function = ((*this).get_function((implementation_function_id.value())));
 if ((TRY((((implementation_function)->is_mutating()))) && (!(((checked_lhs)->is_mutable(((*this).program))))))){
 if (is_assignment){
-TRY((((*this).error(TRY(ByteString::from_utf8("Assignment to immutable variable"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("Assignment to immutable variable"sv)),span))));
 }
 else {
-TRY((((*this).error(TRY(ByteString::from_utf8("Cannot call mutating function on an immutable object instance"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("Cannot call mutating function on an immutable object instance"sv)),span))));
 }
 
 }
 (type_id = ((implementation_function)->return_type_id));
-types::CheckedCall call_expression = types::CheckedCall((TRY((DynamicArray<types::ResolvedNamespace>::create_with({})))),function_name,(TRY((DynamicArray<JaktInternal::Tuple<ByteString,NonnullRefPtr<typename types::CheckedExpression>>>::create_with({(Tuple{TRY(ByteString::from_utf8(""sv)), checked_rhs})})))),(TRY((DynamicArray<ids::TypeId>::create_with({})))),implementation_function_id,type_id,((implementation_function)->can_throw),((implementation_function)->external_name),((implementation_function)->force_inline));
+types::CheckedCall call_expression = types::CheckedCall((TRY((DynamicArray<types::ResolvedNamespace>::create_with({})))),function_name,(TRY((DynamicArray<JaktInternal::Tuple<ByteString,NonnullRefPtr<typename types::CheckedExpression>>>::create_with({(Tuple{(ByteString::must_from_utf8(""sv)), checked_rhs})})))),(TRY((DynamicArray<ids::TypeId>::create_with({})))),implementation_function_id,type_id,((implementation_function)->can_throw),((implementation_function)->external_name),((implementation_function)->force_inline));
 (((checked_operator).trait_implementation) = types::OperatorTraitImplementation(((implementation).trait_id),((implementation).implemented_type_args),call_expression));
 }
 else {
@@ -10569,67 +10569,67 @@ JaktInternal::Tuple<JaktInternal::DynamicArray<ByteString>,bool> const trait_nam
 auto&& __jakt_match_variant = op;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 0 /* Add */: {
-return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("Add"sv)), TRY(ByteString::from_utf8("ThrowingAdd"sv))})))), false}));
+return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("Add"sv)), (ByteString::must_from_utf8("ThrowingAdd"sv))})))), false}));
 };/*case end*/
 case 1 /* Subtract */: {
-return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("Subtract"sv)), TRY(ByteString::from_utf8("ThrowingSubtract"sv))})))), false}));
+return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("Subtract"sv)), (ByteString::must_from_utf8("ThrowingSubtract"sv))})))), false}));
 };/*case end*/
 case 2 /* Multiply */: {
-return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("Multiply"sv)), TRY(ByteString::from_utf8("ThrowingMultiply"sv))})))), false}));
+return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("Multiply"sv)), (ByteString::must_from_utf8("ThrowingMultiply"sv))})))), false}));
 };/*case end*/
 case 3 /* Divide */: {
-return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("Divide"sv)), TRY(ByteString::from_utf8("ThrowingDivide"sv))})))), false}));
+return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("Divide"sv)), (ByteString::must_from_utf8("ThrowingDivide"sv))})))), false}));
 };/*case end*/
 case 4 /* Modulo */: {
-return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("Modulo"sv)), TRY(ByteString::from_utf8("ThrowingModulo"sv))})))), false}));
+return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("Modulo"sv)), (ByteString::must_from_utf8("ThrowingModulo"sv))})))), false}));
 };/*case end*/
 case 5 /* LessThan */: {
-return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("Compare"sv)), TRY(ByteString::from_utf8("ThrowingCompare"sv))})))), false}));
+return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("Compare"sv)), (ByteString::must_from_utf8("ThrowingCompare"sv))})))), false}));
 };/*case end*/
 case 6 /* LessThanOrEqual */: {
-return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("Compare"sv)), TRY(ByteString::from_utf8("ThrowingCompare"sv))})))), false}));
+return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("Compare"sv)), (ByteString::must_from_utf8("ThrowingCompare"sv))})))), false}));
 };/*case end*/
 case 7 /* GreaterThan */: {
-return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("Compare"sv)), TRY(ByteString::from_utf8("ThrowingCompare"sv))})))), false}));
+return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("Compare"sv)), (ByteString::must_from_utf8("ThrowingCompare"sv))})))), false}));
 };/*case end*/
 case 8 /* GreaterThanOrEqual */: {
-return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("Compare"sv)), TRY(ByteString::from_utf8("ThrowingCompare"sv))})))), false}));
+return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("Compare"sv)), (ByteString::must_from_utf8("ThrowingCompare"sv))})))), false}));
 };/*case end*/
 case 9 /* Equal */: {
-return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("Equal"sv)), TRY(ByteString::from_utf8("ThrowingEqual"sv))})))), false}));
+return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("Equal"sv)), (ByteString::must_from_utf8("ThrowingEqual"sv))})))), false}));
 };/*case end*/
 case 10 /* NotEqual */: {
-return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("Equal"sv)), TRY(ByteString::from_utf8("ThrowingEqual"sv))})))), false}));
+return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("Equal"sv)), (ByteString::must_from_utf8("ThrowingEqual"sv))})))), false}));
 };/*case end*/
 case 27 /* AddAssign */: {
-return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("AddAssign"sv)), TRY(ByteString::from_utf8("ThrowingAddAssign"sv))})))), true}));
+return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("AddAssign"sv)), (ByteString::must_from_utf8("ThrowingAddAssign"sv))})))), true}));
 };/*case end*/
 case 28 /* SubtractAssign */: {
-return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("SubtractAssign"sv)), TRY(ByteString::from_utf8("ThrowingSubtractAssign"sv))})))), true}));
+return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("SubtractAssign"sv)), (ByteString::must_from_utf8("ThrowingSubtractAssign"sv))})))), true}));
 };/*case end*/
 case 29 /* MultiplyAssign */: {
-return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("MultiplyAssign"sv)), TRY(ByteString::from_utf8("ThrowingMultiplyAssign"sv))})))), true}));
+return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("MultiplyAssign"sv)), (ByteString::must_from_utf8("ThrowingMultiplyAssign"sv))})))), true}));
 };/*case end*/
 case 31 /* DivideAssign */: {
-return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("DivideAssign"sv)), TRY(ByteString::from_utf8("ThrowingDivideAssign"sv))})))), true}));
+return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("DivideAssign"sv)), (ByteString::must_from_utf8("ThrowingDivideAssign"sv))})))), true}));
 };/*case end*/
 case 30 /* ModuloAssign */: {
-return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("ModuloAssign"sv)), TRY(ByteString::from_utf8("ThrowingModuloAssign"sv))})))), true}));
+return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("ModuloAssign"sv)), (ByteString::must_from_utf8("ThrowingModuloAssign"sv))})))), true}));
 };/*case end*/
 case 22 /* BitwiseAndAssign */: {
-return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("BitwiseAndAssign"sv)), TRY(ByteString::from_utf8("ThrowingBitwiseAndAssign"sv))})))), true}));
+return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("BitwiseAndAssign"sv)), (ByteString::must_from_utf8("ThrowingBitwiseAndAssign"sv))})))), true}));
 };/*case end*/
 case 23 /* BitwiseOrAssign */: {
-return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("BitwiseOrAssign"sv)), TRY(ByteString::from_utf8("ThrowingBitwiseOrAssign"sv))})))), true}));
+return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("BitwiseOrAssign"sv)), (ByteString::must_from_utf8("ThrowingBitwiseOrAssign"sv))})))), true}));
 };/*case end*/
 case 24 /* BitwiseXorAssign */: {
-return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("BitwiseXorAssign"sv)), TRY(ByteString::from_utf8("ThrowingBitwiseXorAssign"sv))})))), true}));
+return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("BitwiseXorAssign"sv)), (ByteString::must_from_utf8("ThrowingBitwiseXorAssign"sv))})))), true}));
 };/*case end*/
 case 25 /* BitwiseLeftShiftAssign */: {
-return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("BitwiseLeftShiftAssign"sv)), TRY(ByteString::from_utf8("ThrowingBitwiseLeftShiftAssign"sv))})))), true}));
+return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("BitwiseLeftShiftAssign"sv)), (ByteString::must_from_utf8("ThrowingBitwiseLeftShiftAssign"sv))})))), true}));
 };/*case end*/
 case 26 /* BitwiseRightShiftAssign */: {
-return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("BitwiseRightShiftAssign"sv)), TRY(ByteString::from_utf8("ThrowingBitwiseRightShiftAssign"sv))})))), true}));
+return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("BitwiseRightShiftAssign"sv)), (ByteString::must_from_utf8("ThrowingBitwiseRightShiftAssign"sv))})))), true}));
 };/*case end*/
 default: {
 return JaktInternal::ExplicitValue((Tuple{empty_array, false}));
@@ -10649,70 +10649,70 @@ ByteString const function_name = ({
 auto&& __jakt_match_variant = op;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 0 /* Add */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("add"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("add"sv)));
 };/*case end*/
 case 1 /* Subtract */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("subtract"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("subtract"sv)));
 };/*case end*/
 case 2 /* Multiply */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("multiply"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("multiply"sv)));
 };/*case end*/
 case 3 /* Divide */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("divide"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("divide"sv)));
 };/*case end*/
 case 4 /* Modulo */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("modulo"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("modulo"sv)));
 };/*case end*/
 case 5 /* LessThan */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("less_than"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("less_than"sv)));
 };/*case end*/
 case 6 /* LessThanOrEqual */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("less_than_or_equal"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("less_than_or_equal"sv)));
 };/*case end*/
 case 7 /* GreaterThan */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("greater_than"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("greater_than"sv)));
 };/*case end*/
 case 8 /* GreaterThanOrEqual */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("greater_than_or_equal"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("greater_than_or_equal"sv)));
 };/*case end*/
 case 9 /* Equal */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("equals"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("equals"sv)));
 };/*case end*/
 case 10 /* NotEqual */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("not_equals"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("not_equals"sv)));
 };/*case end*/
 case 27 /* AddAssign */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("add_assign"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("add_assign"sv)));
 };/*case end*/
 case 28 /* SubtractAssign */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("subtract_assign"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("subtract_assign"sv)));
 };/*case end*/
 case 29 /* MultiplyAssign */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("multiply_assign"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("multiply_assign"sv)));
 };/*case end*/
 case 31 /* DivideAssign */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("divide_assign"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("divide_assign"sv)));
 };/*case end*/
 case 30 /* ModuloAssign */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("modulo_assign"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("modulo_assign"sv)));
 };/*case end*/
 case 22 /* BitwiseAndAssign */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("bitwise_and_assign"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("bitwise_and_assign"sv)));
 };/*case end*/
 case 23 /* BitwiseOrAssign */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("bitwise_or_assign"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("bitwise_or_assign"sv)));
 };/*case end*/
 case 24 /* BitwiseXorAssign */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("bitwise_xor_assign"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("bitwise_xor_assign"sv)));
 };/*case end*/
 case 25 /* BitwiseLeftShiftAssign */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("bitwise_left_shift_assign"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("bitwise_left_shift_assign"sv)));
 };/*case end*/
 case 26 /* BitwiseRightShiftAssign */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("bitwise_right_shift_assign"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("bitwise_right_shift_assign"sv)));
 };/*case end*/
 default: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8(""sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8(""sv)));
 };/*case end*/
 }/*switch end*/
 }()
@@ -10724,8 +10724,8 @@ return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8(""sv)));
 JaktInternal::Optional<typechecker::TraitImplementationDescriptor> const add_trait_implementation = TRY((((*this).find_any_singular_trait_implementation(lhs_type_id,trait_names,scope_id,lhs_span,(TRY((DynamicArray<ids::TypeId>::create_with({rhs_type_id}))))))));
 if (((add_trait_implementation).has_value())){
 typechecker::TraitImplementationDescriptor const implementation = (add_trait_implementation.value());
-if ((((((implementation).trait_name)).starts_with(TRY(ByteString::from_utf8("Throwing"sv)))) && (!(((scope)->can_throw))))){
-TRY((((*this).error(TRY(ByteString::from_utf8("Call to function that may throw needs to be in a try statement or a function marked as throws"sv)),span))));
+if ((((((implementation).trait_name)).starts_with((ByteString::must_from_utf8("Throwing"sv)))) && (!(((scope)->can_throw))))){
+TRY((((*this).error((ByteString::must_from_utf8("Call to function that may throw needs to be in a try statement or a function marked as throws"sv)),span))));
 }
 JaktInternal::Tuple<JaktInternal::Optional<types::StructLikeId>,bool> const parent_id___ = TRY((((*this).struct_like_id_from_type_id(lhs_type_id,scope_id,span,false,true))));
 JaktInternal::Optional<types::StructLikeId> const parent_id = ((parent_id___).template get<0>());
@@ -10736,15 +10736,15 @@ if (((implementation_function_id).has_value())){
 NonnullRefPtr<types::CheckedFunction> const implementation_function = ((*this).get_function((implementation_function_id.value())));
 if ((TRY((((implementation_function)->is_mutating()))) && (!(((checked_lhs)->is_mutable(((*this).program))))))){
 if (is_assignment){
-TRY((((*this).error(TRY(ByteString::from_utf8("Assignment to immutable variable"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("Assignment to immutable variable"sv)),span))));
 }
 else {
-TRY((((*this).error(TRY(ByteString::from_utf8("Cannot call mutating function on an immutable object instance"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("Cannot call mutating function on an immutable object instance"sv)),span))));
 }
 
 }
 (type_id = ((implementation_function)->return_type_id));
-types::CheckedCall call_expression = types::CheckedCall((TRY((DynamicArray<types::ResolvedNamespace>::create_with({})))),function_name,(TRY((DynamicArray<JaktInternal::Tuple<ByteString,NonnullRefPtr<typename types::CheckedExpression>>>::create_with({(Tuple{TRY(ByteString::from_utf8(""sv)), checked_rhs})})))),(TRY((DynamicArray<ids::TypeId>::create_with({})))),implementation_function_id,type_id,((implementation_function)->can_throw),((implementation_function)->external_name),((implementation_function)->force_inline));
+types::CheckedCall call_expression = types::CheckedCall((TRY((DynamicArray<types::ResolvedNamespace>::create_with({})))),function_name,(TRY((DynamicArray<JaktInternal::Tuple<ByteString,NonnullRefPtr<typename types::CheckedExpression>>>::create_with({(Tuple{(ByteString::must_from_utf8(""sv)), checked_rhs})})))),(TRY((DynamicArray<ids::TypeId>::create_with({})))),implementation_function_id,type_id,((implementation_function)->can_throw),((implementation_function)->external_name),((implementation_function)->force_inline));
 (((checked_operator).trait_implementation) = types::OperatorTraitImplementation(((implementation).trait_id),((implementation).implemented_type_args),call_expression));
 }
 else {
@@ -10821,67 +10821,67 @@ JaktInternal::Tuple<JaktInternal::DynamicArray<ByteString>,bool> const trait_nam
 auto&& __jakt_match_variant = op;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 0 /* Add */: {
-return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("Add"sv)), TRY(ByteString::from_utf8("ThrowingAdd"sv))})))), false}));
+return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("Add"sv)), (ByteString::must_from_utf8("ThrowingAdd"sv))})))), false}));
 };/*case end*/
 case 1 /* Subtract */: {
-return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("Subtract"sv)), TRY(ByteString::from_utf8("ThrowingSubtract"sv))})))), false}));
+return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("Subtract"sv)), (ByteString::must_from_utf8("ThrowingSubtract"sv))})))), false}));
 };/*case end*/
 case 2 /* Multiply */: {
-return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("Multiply"sv)), TRY(ByteString::from_utf8("ThrowingMultiply"sv))})))), false}));
+return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("Multiply"sv)), (ByteString::must_from_utf8("ThrowingMultiply"sv))})))), false}));
 };/*case end*/
 case 3 /* Divide */: {
-return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("Divide"sv)), TRY(ByteString::from_utf8("ThrowingDivide"sv))})))), false}));
+return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("Divide"sv)), (ByteString::must_from_utf8("ThrowingDivide"sv))})))), false}));
 };/*case end*/
 case 4 /* Modulo */: {
-return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("Modulo"sv)), TRY(ByteString::from_utf8("ThrowingModulo"sv))})))), false}));
+return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("Modulo"sv)), (ByteString::must_from_utf8("ThrowingModulo"sv))})))), false}));
 };/*case end*/
 case 5 /* LessThan */: {
-return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("Compare"sv)), TRY(ByteString::from_utf8("ThrowingCompare"sv))})))), false}));
+return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("Compare"sv)), (ByteString::must_from_utf8("ThrowingCompare"sv))})))), false}));
 };/*case end*/
 case 6 /* LessThanOrEqual */: {
-return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("Compare"sv)), TRY(ByteString::from_utf8("ThrowingCompare"sv))})))), false}));
+return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("Compare"sv)), (ByteString::must_from_utf8("ThrowingCompare"sv))})))), false}));
 };/*case end*/
 case 7 /* GreaterThan */: {
-return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("Compare"sv)), TRY(ByteString::from_utf8("ThrowingCompare"sv))})))), false}));
+return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("Compare"sv)), (ByteString::must_from_utf8("ThrowingCompare"sv))})))), false}));
 };/*case end*/
 case 8 /* GreaterThanOrEqual */: {
-return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("Compare"sv)), TRY(ByteString::from_utf8("ThrowingCompare"sv))})))), false}));
+return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("Compare"sv)), (ByteString::must_from_utf8("ThrowingCompare"sv))})))), false}));
 };/*case end*/
 case 9 /* Equal */: {
-return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("Equal"sv)), TRY(ByteString::from_utf8("ThrowingEqual"sv))})))), false}));
+return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("Equal"sv)), (ByteString::must_from_utf8("ThrowingEqual"sv))})))), false}));
 };/*case end*/
 case 10 /* NotEqual */: {
-return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("Equal"sv)), TRY(ByteString::from_utf8("ThrowingEqual"sv))})))), false}));
+return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("Equal"sv)), (ByteString::must_from_utf8("ThrowingEqual"sv))})))), false}));
 };/*case end*/
 case 27 /* AddAssign */: {
-return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("AddAssign"sv)), TRY(ByteString::from_utf8("ThrowingAddAssign"sv))})))), true}));
+return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("AddAssign"sv)), (ByteString::must_from_utf8("ThrowingAddAssign"sv))})))), true}));
 };/*case end*/
 case 28 /* SubtractAssign */: {
-return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("SubtractAssign"sv)), TRY(ByteString::from_utf8("ThrowingSubtractAssign"sv))})))), true}));
+return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("SubtractAssign"sv)), (ByteString::must_from_utf8("ThrowingSubtractAssign"sv))})))), true}));
 };/*case end*/
 case 29 /* MultiplyAssign */: {
-return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("MultiplyAssign"sv)), TRY(ByteString::from_utf8("ThrowingMultiplyAssign"sv))})))), true}));
+return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("MultiplyAssign"sv)), (ByteString::must_from_utf8("ThrowingMultiplyAssign"sv))})))), true}));
 };/*case end*/
 case 31 /* DivideAssign */: {
-return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("DivideAssign"sv)), TRY(ByteString::from_utf8("ThrowingDivideAssign"sv))})))), true}));
+return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("DivideAssign"sv)), (ByteString::must_from_utf8("ThrowingDivideAssign"sv))})))), true}));
 };/*case end*/
 case 30 /* ModuloAssign */: {
-return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("ModuloAssign"sv)), TRY(ByteString::from_utf8("ThrowingModuloAssign"sv))})))), true}));
+return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("ModuloAssign"sv)), (ByteString::must_from_utf8("ThrowingModuloAssign"sv))})))), true}));
 };/*case end*/
 case 22 /* BitwiseAndAssign */: {
-return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("BitwiseAndAssign"sv)), TRY(ByteString::from_utf8("ThrowingBitwiseAndAssign"sv))})))), true}));
+return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("BitwiseAndAssign"sv)), (ByteString::must_from_utf8("ThrowingBitwiseAndAssign"sv))})))), true}));
 };/*case end*/
 case 23 /* BitwiseOrAssign */: {
-return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("BitwiseOrAssign"sv)), TRY(ByteString::from_utf8("ThrowingBitwiseOrAssign"sv))})))), true}));
+return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("BitwiseOrAssign"sv)), (ByteString::must_from_utf8("ThrowingBitwiseOrAssign"sv))})))), true}));
 };/*case end*/
 case 24 /* BitwiseXorAssign */: {
-return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("BitwiseXorAssign"sv)), TRY(ByteString::from_utf8("ThrowingBitwiseXorAssign"sv))})))), true}));
+return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("BitwiseXorAssign"sv)), (ByteString::must_from_utf8("ThrowingBitwiseXorAssign"sv))})))), true}));
 };/*case end*/
 case 25 /* BitwiseLeftShiftAssign */: {
-return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("BitwiseLeftShiftAssign"sv)), TRY(ByteString::from_utf8("ThrowingBitwiseLeftShiftAssign"sv))})))), true}));
+return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("BitwiseLeftShiftAssign"sv)), (ByteString::must_from_utf8("ThrowingBitwiseLeftShiftAssign"sv))})))), true}));
 };/*case end*/
 case 26 /* BitwiseRightShiftAssign */: {
-return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("BitwiseRightShiftAssign"sv)), TRY(ByteString::from_utf8("ThrowingBitwiseRightShiftAssign"sv))})))), true}));
+return JaktInternal::ExplicitValue((Tuple{(TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("BitwiseRightShiftAssign"sv)), (ByteString::must_from_utf8("ThrowingBitwiseRightShiftAssign"sv))})))), true}));
 };/*case end*/
 default: {
 return JaktInternal::ExplicitValue((Tuple{empty_array, false}));
@@ -10901,70 +10901,70 @@ ByteString const function_name = ({
 auto&& __jakt_match_variant = op;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 0 /* Add */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("add"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("add"sv)));
 };/*case end*/
 case 1 /* Subtract */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("subtract"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("subtract"sv)));
 };/*case end*/
 case 2 /* Multiply */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("multiply"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("multiply"sv)));
 };/*case end*/
 case 3 /* Divide */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("divide"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("divide"sv)));
 };/*case end*/
 case 4 /* Modulo */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("modulo"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("modulo"sv)));
 };/*case end*/
 case 5 /* LessThan */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("less_than"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("less_than"sv)));
 };/*case end*/
 case 6 /* LessThanOrEqual */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("less_than_or_equal"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("less_than_or_equal"sv)));
 };/*case end*/
 case 7 /* GreaterThan */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("greater_than"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("greater_than"sv)));
 };/*case end*/
 case 8 /* GreaterThanOrEqual */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("greater_than_or_equal"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("greater_than_or_equal"sv)));
 };/*case end*/
 case 9 /* Equal */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("equals"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("equals"sv)));
 };/*case end*/
 case 10 /* NotEqual */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("not_equals"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("not_equals"sv)));
 };/*case end*/
 case 27 /* AddAssign */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("add_assign"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("add_assign"sv)));
 };/*case end*/
 case 28 /* SubtractAssign */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("subtract_assign"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("subtract_assign"sv)));
 };/*case end*/
 case 29 /* MultiplyAssign */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("multiply_assign"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("multiply_assign"sv)));
 };/*case end*/
 case 31 /* DivideAssign */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("divide_assign"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("divide_assign"sv)));
 };/*case end*/
 case 30 /* ModuloAssign */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("modulo_assign"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("modulo_assign"sv)));
 };/*case end*/
 case 22 /* BitwiseAndAssign */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("bitwise_and_assign"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("bitwise_and_assign"sv)));
 };/*case end*/
 case 23 /* BitwiseOrAssign */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("bitwise_or_assign"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("bitwise_or_assign"sv)));
 };/*case end*/
 case 24 /* BitwiseXorAssign */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("bitwise_xor_assign"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("bitwise_xor_assign"sv)));
 };/*case end*/
 case 25 /* BitwiseLeftShiftAssign */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("bitwise_left_shift_assign"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("bitwise_left_shift_assign"sv)));
 };/*case end*/
 case 26 /* BitwiseRightShiftAssign */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("bitwise_right_shift_assign"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("bitwise_right_shift_assign"sv)));
 };/*case end*/
 default: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8(""sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8(""sv)));
 };/*case end*/
 }/*switch end*/
 }()
@@ -10976,8 +10976,8 @@ return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8(""sv)));
 JaktInternal::Optional<typechecker::TraitImplementationDescriptor> const add_trait_implementation = TRY((((*this).find_any_singular_trait_implementation(lhs_type_id,trait_names,scope_id,lhs_span,(TRY((DynamicArray<ids::TypeId>::create_with({rhs_type_id}))))))));
 if (((add_trait_implementation).has_value())){
 typechecker::TraitImplementationDescriptor const implementation = (add_trait_implementation.value());
-if ((((((implementation).trait_name)).starts_with(TRY(ByteString::from_utf8("Throwing"sv)))) && (!(((scope)->can_throw))))){
-TRY((((*this).error(TRY(ByteString::from_utf8("Call to function that may throw needs to be in a try statement or a function marked as throws"sv)),span))));
+if ((((((implementation).trait_name)).starts_with((ByteString::must_from_utf8("Throwing"sv)))) && (!(((scope)->can_throw))))){
+TRY((((*this).error((ByteString::must_from_utf8("Call to function that may throw needs to be in a try statement or a function marked as throws"sv)),span))));
 }
 JaktInternal::Tuple<JaktInternal::Optional<types::StructLikeId>,bool> const parent_id___ = TRY((((*this).struct_like_id_from_type_id(lhs_type_id,scope_id,span,false,true))));
 JaktInternal::Optional<types::StructLikeId> const parent_id = ((parent_id___).template get<0>());
@@ -10988,15 +10988,15 @@ if (((implementation_function_id).has_value())){
 NonnullRefPtr<types::CheckedFunction> const implementation_function = ((*this).get_function((implementation_function_id.value())));
 if ((TRY((((implementation_function)->is_mutating()))) && (!(((checked_lhs)->is_mutable(((*this).program))))))){
 if (is_assignment){
-TRY((((*this).error(TRY(ByteString::from_utf8("Assignment to immutable variable"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("Assignment to immutable variable"sv)),span))));
 }
 else {
-TRY((((*this).error(TRY(ByteString::from_utf8("Cannot call mutating function on an immutable object instance"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("Cannot call mutating function on an immutable object instance"sv)),span))));
 }
 
 }
 (type_id = ((implementation_function)->return_type_id));
-types::CheckedCall call_expression = types::CheckedCall((TRY((DynamicArray<types::ResolvedNamespace>::create_with({})))),function_name,(TRY((DynamicArray<JaktInternal::Tuple<ByteString,NonnullRefPtr<typename types::CheckedExpression>>>::create_with({(Tuple{TRY(ByteString::from_utf8(""sv)), checked_rhs})})))),(TRY((DynamicArray<ids::TypeId>::create_with({})))),implementation_function_id,type_id,((implementation_function)->can_throw),((implementation_function)->external_name),((implementation_function)->force_inline));
+types::CheckedCall call_expression = types::CheckedCall((TRY((DynamicArray<types::ResolvedNamespace>::create_with({})))),function_name,(TRY((DynamicArray<JaktInternal::Tuple<ByteString,NonnullRefPtr<typename types::CheckedExpression>>>::create_with({(Tuple{(ByteString::must_from_utf8(""sv)), checked_rhs})})))),(TRY((DynamicArray<ids::TypeId>::create_with({})))),implementation_function_id,type_id,((implementation_function)->can_throw),((implementation_function)->external_name),((implementation_function)->force_inline));
 (((checked_operator).trait_implementation) = types::OperatorTraitImplementation(((implementation).trait_id),((implementation).implemented_type_args),call_expression));
 }
 else {
@@ -11382,7 +11382,7 @@ case 0 /* Struct */: {
 return JaktInternal::ExplicitValue(({ Optional<types::StructLikeId> __jakt_var_466; {
 JaktInternal::Optional<ids::StructId> const struct_id = TRY((((*this).find_struct_in_scope(scope_id,((record).name),JaktInternal::OptionalNone()))));
 if ((!(((struct_id).has_value())))){
-TRY((((((*this).compiler))->panic(TRY(ByteString::from_utf8("can't find previously added struct"sv))))));
+TRY((((((*this).compiler))->panic((ByteString::must_from_utf8("can't find previously added struct"sv))))));
 }
 TRY((((*this).typecheck_struct_fields(record,(struct_id.value())))));
 __jakt_var_466 = types::StructLikeId::Struct(JaktInternal::OptionalNone(),(struct_id.value())); goto __jakt_label_421;
@@ -11394,7 +11394,7 @@ case 1 /* Class */: {
 return JaktInternal::ExplicitValue(({ Optional<types::StructLikeId> __jakt_var_467; {
 JaktInternal::Optional<ids::StructId> const struct_id = TRY((((*this).find_struct_in_scope(scope_id,((record).name),JaktInternal::OptionalNone()))));
 if ((!(((struct_id).has_value())))){
-TRY((((((*this).compiler))->panic(TRY(ByteString::from_utf8("can't find previously added struct"sv))))));
+TRY((((((*this).compiler))->panic((ByteString::must_from_utf8("can't find previously added struct"sv))))));
 }
 TRY((((*this).typecheck_struct_fields(record,(struct_id.value())))));
 __jakt_var_467 = types::StructLikeId::Struct(JaktInternal::OptionalNone(),(struct_id.value())); goto __jakt_label_422;
@@ -11406,7 +11406,7 @@ case 2 /* ValueEnum */: {
 return JaktInternal::ExplicitValue(({ Optional<types::StructLikeId> __jakt_var_468; {
 JaktInternal::Optional<ids::EnumId> const enum_id = TRY((((((*this).program))->find_enum_in_scope(scope_id,((record).name),false,JaktInternal::OptionalNone()))));
 if ((!(((enum_id).has_value())))){
-TRY((((((*this).compiler))->panic(TRY(ByteString::from_utf8("can't find previously added enum"sv))))));
+TRY((((((*this).compiler))->panic((ByteString::must_from_utf8("can't find previously added enum"sv))))));
 }
 __jakt_var_468 = types::StructLikeId::Enum(JaktInternal::OptionalNone(),(enum_id.value())); goto __jakt_label_423;
 
@@ -11417,7 +11417,7 @@ case 3 /* SumEnum */: {
 return JaktInternal::ExplicitValue(({ Optional<types::StructLikeId> __jakt_var_469; {
 JaktInternal::Optional<ids::EnumId> const enum_id = TRY((((((*this).program))->find_enum_in_scope(scope_id,((record).name),false,JaktInternal::OptionalNone()))));
 if ((!(((enum_id).has_value())))){
-TRY((((((*this).compiler))->panic(TRY(ByteString::from_utf8("can't find previously added enum"sv))))));
+TRY((((((*this).compiler))->panic((ByteString::must_from_utf8("can't find previously added enum"sv))))));
 }
 __jakt_var_469 = types::StructLikeId::Enum(JaktInternal::OptionalNone(),(enum_id.value())); goto __jakt_label_424;
 
@@ -11517,7 +11517,7 @@ return JaktInternal::ExplicitValue<void>();
         return _jakt_value.release_return();
     _jakt_value.release_value();
 });
-return TRY(ByteString::from_utf8(""sv));
+return (ByteString::must_from_utf8(""sv));
 }
 }
 
@@ -11543,7 +11543,7 @@ ScopeGuard __jakt_var_470([&] {
 NonnullRefPtr<types::Module> module = ((*this).current_module());
 ids::FunctionId const new_function_id = ((module)->next_function_id());
 parser::ParsedFunction parsed_function = TRY((((checked_function)->to_parsed_function())));
-ByteString arg_names = TRY(ByteString::from_utf8(""sv));
+ByteString arg_names = (ByteString::must_from_utf8(""sv));
 {
 JaktInternal::ArrayIterator<ids::TypeId> _magic = ((generic_arguments).iterator());
 for (;;){
@@ -11560,7 +11560,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(arg_names,TRY(ByteString::from_utf8(", "sv)))));
+(arg_names,(ByteString::must_from_utf8(", "sv)))));
 }
 TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 {
@@ -12329,7 +12329,7 @@ TRY((((unused_field_names).push(field_name))));
 }
 }
 
-TRY((((*this).error_with_hint(TRY((__jakt_format((StringView::from_string_literal("Match case argument '{}' for struct-like enum variant '{}' cannot be anon"sv)),((arg).binding),name))),((arg).span),TRY((__jakt_format((StringView::from_string_literal("Available arguments for '{}' are: {}\n"sv)),name,TRY((utility::join(unused_field_names,TRY(ByteString::from_utf8(", "sv)))))))),((arg).span)))));
+TRY((((*this).error_with_hint(TRY((__jakt_format((StringView::from_string_literal("Match case argument '{}' for struct-like enum variant '{}' cannot be anon"sv)),((arg).binding),name))),((arg).span),TRY((__jakt_format((StringView::from_string_literal("Available arguments for '{}' are: {}\n"sv)),name,TRY((utility::join(unused_field_names,(ByteString::must_from_utf8(", "sv)))))))),((arg).span)))));
 continue;
 }
 }
@@ -12424,7 +12424,7 @@ return (Tuple{covered_name, checked_match_case, result_type});
 
 ErrorOr<void> typechecker::Typechecker::include_prelude() {
 {
-ByteString const module_name = TRY(ByteString::from_utf8("__prelude__"sv));
+ByteString const module_name = (ByteString::must_from_utf8("__prelude__"sv));
 jakt__path::Path const file_name = TRY((jakt__path::Path::from_string(module_name)));
 JaktInternal::DynamicArray<u8> const file_contents = (TRY((DynamicArray<u8>::create_with({static_cast<u8>(101), static_cast<u8>(120), static_cast<u8>(116), static_cast<u8>(101), static_cast<u8>(114), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(115), static_cast<u8>(116), static_cast<u8>(114), static_cast<u8>(117), static_cast<u8>(99), static_cast<u8>(116), static_cast<u8>(32), static_cast<u8>(79), static_cast<u8>(112), static_cast<u8>(116), static_cast<u8>(105), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(97), static_cast<u8>(108), static_cast<u8>(60), static_cast<u8>(84), static_cast<u8>(62), static_cast<u8>(32), static_cast<u8>(123), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(102), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(104), static_cast<u8>(97), static_cast<u8>(115), static_cast<u8>(95), static_cast<u8>(118), static_cast<u8>(97), static_cast<u8>(108), static_cast<u8>(117), static_cast<u8>(101), static_cast<u8>(40), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(105), static_cast<u8>(115), static_cast<u8>(41), static_cast<u8>(32), static_cast<u8>(45), static_cast<u8>(62), static_cast<u8>(32), static_cast<u8>(98), static_cast<u8>(111), static_cast<u8>(111), static_cast<u8>(108), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(102), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(118), static_cast<u8>(97), static_cast<u8>(108), static_cast<u8>(117), static_cast<u8>(101), static_cast<u8>(40), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(105), static_cast<u8>(115), static_cast<u8>(41), static_cast<u8>(32), static_cast<u8>(45), static_cast<u8>(62), static_cast<u8>(32), static_cast<u8>(84), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(102), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(118), static_cast<u8>(97), static_cast<u8>(108), static_cast<u8>(117), static_cast<u8>(101), static_cast<u8>(95), static_cast<u8>(111), static_cast<u8>(114), static_cast<u8>(40), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(105), static_cast<u8>(115), static_cast<u8>(44), static_cast<u8>(32), static_cast<u8>(97), static_cast<u8>(110), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(120), static_cast<u8>(58), static_cast<u8>(32), static_cast<u8>(84), static_cast<u8>(41), static_cast<u8>(32), static_cast<u8>(45), static_cast<u8>(62), static_cast<u8>(32), static_cast<u8>(84), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(102), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(79), static_cast<u8>(112), static_cast<u8>(116), static_cast<u8>(105), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(97), static_cast<u8>(108), static_cast<u8>(60), static_cast<u8>(83), static_cast<u8>(62), static_cast<u8>(40), static_cast<u8>(97), static_cast<u8>(110), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(120), static_cast<u8>(58), static_cast<u8>(32), static_cast<u8>(83), static_cast<u8>(41), static_cast<u8>(32), static_cast<u8>(45), static_cast<u8>(62), static_cast<u8>(32), static_cast<u8>(79), static_cast<u8>(112), static_cast<u8>(116), static_cast<u8>(105), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(97), static_cast<u8>(108), static_cast<u8>(60), static_cast<u8>(83), static_cast<u8>(62), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(102), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(109), static_cast<u8>(97), static_cast<u8>(112), static_cast<u8>(60), static_cast<u8>(85), static_cast<u8>(62), static_cast<u8>(40), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(105), static_cast<u8>(115), static_cast<u8>(44), static_cast<u8>(32), static_cast<u8>(97), static_cast<u8>(110), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(109), static_cast<u8>(97), static_cast<u8>(112), static_cast<u8>(112), static_cast<u8>(101), static_cast<u8>(114), static_cast<u8>(58), static_cast<u8>(32), static_cast<u8>(102), static_cast<u8>(110), static_cast<u8>(40), static_cast<u8>(97), static_cast<u8>(110), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(120), static_cast<u8>(58), static_cast<u8>(32), static_cast<u8>(38), static_cast<u8>(84), static_cast<u8>(41), static_cast<u8>(32), static_cast<u8>(45), static_cast<u8>(62), static_cast<u8>(32), static_cast<u8>(85), static_cast<u8>(41), static_cast<u8>(32), static_cast<u8>(45), static_cast<u8>(62), static_cast<u8>(32), static_cast<u8>(79), static_cast<u8>(112), static_cast<u8>(116), static_cast<u8>(105), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(97), static_cast<u8>(108), static_cast<u8>(60), static_cast<u8>(85), static_cast<u8>(62), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(102), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(109), static_cast<u8>(97), static_cast<u8>(112), static_cast<u8>(60), static_cast<u8>(85), static_cast<u8>(62), static_cast<u8>(40), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(105), static_cast<u8>(115), static_cast<u8>(44), static_cast<u8>(32), static_cast<u8>(97), static_cast<u8>(110), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(109), static_cast<u8>(97), static_cast<u8>(112), static_cast<u8>(112), static_cast<u8>(101), static_cast<u8>(114), static_cast<u8>(58), static_cast<u8>(32), static_cast<u8>(102), static_cast<u8>(110), static_cast<u8>(40), static_cast<u8>(97), static_cast<u8>(110), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(120), static_cast<u8>(58), static_cast<u8>(32), static_cast<u8>(38), static_cast<u8>(84), static_cast<u8>(41), static_cast<u8>(32), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(114), static_cast<u8>(111), static_cast<u8>(119), static_cast<u8>(115), static_cast<u8>(32), static_cast<u8>(45), static_cast<u8>(62), static_cast<u8>(32), static_cast<u8>(85), static_cast<u8>(41), static_cast<u8>(32), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(114), static_cast<u8>(111), static_cast<u8>(119), static_cast<u8>(115), static_cast<u8>(32), static_cast<u8>(45), static_cast<u8>(62), static_cast<u8>(32), static_cast<u8>(79), static_cast<u8>(112), static_cast<u8>(116), static_cast<u8>(105), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(97), static_cast<u8>(108), static_cast<u8>(60), static_cast<u8>(85), static_cast<u8>(62), static_cast<u8>(10), static_cast<u8>(125), static_cast<u8>(10), static_cast<u8>(10), static_cast<u8>(101), static_cast<u8>(120), static_cast<u8>(116), static_cast<u8>(101), static_cast<u8>(114), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(115), static_cast<u8>(116), static_cast<u8>(114), static_cast<u8>(117), static_cast<u8>(99), static_cast<u8>(116), static_cast<u8>(32), static_cast<u8>(65), static_cast<u8>(114), static_cast<u8>(114), static_cast<u8>(97), static_cast<u8>(121), static_cast<u8>(73), static_cast<u8>(116), static_cast<u8>(101), static_cast<u8>(114), static_cast<u8>(97), static_cast<u8>(116), static_cast<u8>(111), static_cast<u8>(114), static_cast<u8>(60), static_cast<u8>(84), static_cast<u8>(62), static_cast<u8>(32), static_cast<u8>(123), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(102), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(110), static_cast<u8>(101), static_cast<u8>(120), static_cast<u8>(116), static_cast<u8>(40), static_cast<u8>(109), static_cast<u8>(117), static_cast<u8>(116), static_cast<u8>(32), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(105), static_cast<u8>(115), static_cast<u8>(41), static_cast<u8>(32), static_cast<u8>(45), static_cast<u8>(62), static_cast<u8>(32), static_cast<u8>(84), static_cast<u8>(63), static_cast<u8>(10), static_cast<u8>(125), static_cast<u8>(10), static_cast<u8>(10), static_cast<u8>(91), static_cast<u8>(91), static_cast<u8>(110), static_cast<u8>(97), static_cast<u8>(109), static_cast<u8>(101), static_cast<u8>(61), static_cast<u8>(68), static_cast<u8>(121), static_cast<u8>(110), static_cast<u8>(97), static_cast<u8>(109), static_cast<u8>(105), static_cast<u8>(99), static_cast<u8>(65), static_cast<u8>(114), static_cast<u8>(114), static_cast<u8>(97), static_cast<u8>(121), static_cast<u8>(93), static_cast<u8>(93), static_cast<u8>(10), static_cast<u8>(101), static_cast<u8>(120), static_cast<u8>(116), static_cast<u8>(101), static_cast<u8>(114), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(115), static_cast<u8>(116), static_cast<u8>(114), static_cast<u8>(117), static_cast<u8>(99), static_cast<u8>(116), static_cast<u8>(32), static_cast<u8>(65), static_cast<u8>(114), static_cast<u8>(114), static_cast<u8>(97), static_cast<u8>(121), static_cast<u8>(60), static_cast<u8>(84), static_cast<u8>(62), static_cast<u8>(32), static_cast<u8>(123), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(102), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(105), static_cast<u8>(115), static_cast<u8>(95), static_cast<u8>(101), static_cast<u8>(109), static_cast<u8>(112), static_cast<u8>(116), static_cast<u8>(121), static_cast<u8>(40), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(105), static_cast<u8>(115), static_cast<u8>(41), static_cast<u8>(32), static_cast<u8>(45), static_cast<u8>(62), static_cast<u8>(32), static_cast<u8>(98), static_cast<u8>(111), static_cast<u8>(111), static_cast<u8>(108), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(102), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(99), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(116), static_cast<u8>(97), static_cast<u8>(105), static_cast<u8>(110), static_cast<u8>(115), static_cast<u8>(40), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(105), static_cast<u8>(115), static_cast<u8>(44), static_cast<u8>(32), static_cast<u8>(97), static_cast<u8>(110), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(118), static_cast<u8>(97), static_cast<u8>(108), static_cast<u8>(117), static_cast<u8>(101), static_cast<u8>(58), static_cast<u8>(32), static_cast<u8>(84), static_cast<u8>(41), static_cast<u8>(32), static_cast<u8>(45), static_cast<u8>(62), static_cast<u8>(32), static_cast<u8>(98), static_cast<u8>(111), static_cast<u8>(111), static_cast<u8>(108), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(102), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(115), static_cast<u8>(105), static_cast<u8>(122), static_cast<u8>(101), static_cast<u8>(40), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(105), static_cast<u8>(115), static_cast<u8>(41), static_cast<u8>(32), static_cast<u8>(45), static_cast<u8>(62), static_cast<u8>(32), static_cast<u8>(117), static_cast<u8>(115), static_cast<u8>(105), static_cast<u8>(122), static_cast<u8>(101), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(102), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(99), static_cast<u8>(97), static_cast<u8>(112), static_cast<u8>(97), static_cast<u8>(99), static_cast<u8>(105), static_cast<u8>(116), static_cast<u8>(121), static_cast<u8>(40), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(105), static_cast<u8>(115), static_cast<u8>(41), static_cast<u8>(32), static_cast<u8>(45), static_cast<u8>(62), static_cast<u8>(32), static_cast<u8>(117), static_cast<u8>(115), static_cast<u8>(105), static_cast<u8>(122), static_cast<u8>(101), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(102), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(101), static_cast<u8>(110), static_cast<u8>(115), static_cast<u8>(117), static_cast<u8>(114), static_cast<u8>(101), static_cast<u8>(95), static_cast<u8>(99), static_cast<u8>(97), static_cast<u8>(112), static_cast<u8>(97), static_cast<u8>(99), static_cast<u8>(105), static_cast<u8>(116), static_cast<u8>(121), static_cast<u8>(40), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(105), static_cast<u8>(115), static_cast<u8>(44), static_cast<u8>(32), static_cast<u8>(97), static_cast<u8>(110), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(99), static_cast<u8>(97), static_cast<u8>(112), static_cast<u8>(97), static_cast<u8>(99), static_cast<u8>(105), static_cast<u8>(116), static_cast<u8>(121), static_cast<u8>(58), static_cast<u8>(32), static_cast<u8>(117), static_cast<u8>(115), static_cast<u8>(105), static_cast<u8>(122), static_cast<u8>(101), static_cast<u8>(41), static_cast<u8>(32), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(114), static_cast<u8>(111), static_cast<u8>(119), static_cast<u8>(115), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(102), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(97), static_cast<u8>(100), static_cast<u8>(100), static_cast<u8>(95), static_cast<u8>(99), static_cast<u8>(97), static_cast<u8>(112), static_cast<u8>(97), static_cast<u8>(99), static_cast<u8>(105), static_cast<u8>(116), static_cast<u8>(121), static_cast<u8>(40), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(105), static_cast<u8>(115), static_cast<u8>(44), static_cast<u8>(32), static_cast<u8>(97), static_cast<u8>(110), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(99), static_cast<u8>(97), static_cast<u8>(112), static_cast<u8>(97), static_cast<u8>(99), static_cast<u8>(105), static_cast<u8>(116), static_cast<u8>(121), static_cast<u8>(58), static_cast<u8>(32), static_cast<u8>(117), static_cast<u8>(115), static_cast<u8>(105), static_cast<u8>(122), static_cast<u8>(101), static_cast<u8>(41), static_cast<u8>(32), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(114), static_cast<u8>(111), static_cast<u8>(119), static_cast<u8>(115), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(102), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(114), static_cast<u8>(101), static_cast<u8>(115), static_cast<u8>(105), static_cast<u8>(122), static_cast<u8>(101), static_cast<u8>(40), static_cast<u8>(109), static_cast<u8>(117), static_cast<u8>(116), static_cast<u8>(32), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(105), static_cast<u8>(115), static_cast<u8>(44), static_cast<u8>(32), static_cast<u8>(97), static_cast<u8>(110), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(115), static_cast<u8>(105), static_cast<u8>(122), static_cast<u8>(101), static_cast<u8>(58), static_cast<u8>(32), static_cast<u8>(117), static_cast<u8>(115), static_cast<u8>(105), static_cast<u8>(122), static_cast<u8>(101), static_cast<u8>(41), static_cast<u8>(32), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(114), static_cast<u8>(111), static_cast<u8>(119), static_cast<u8>(115), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(102), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(115), static_cast<u8>(104), static_cast<u8>(114), static_cast<u8>(105), static_cast<u8>(110), static_cast<u8>(107), static_cast<u8>(40), static_cast<u8>(109), static_cast<u8>(117), static_cast<u8>(116), static_cast<u8>(32), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(105), static_cast<u8>(115), static_cast<u8>(44), static_cast<u8>(32), static_cast<u8>(97), static_cast<u8>(110), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(115), static_cast<u8>(105), static_cast<u8>(122), static_cast<u8>(101), static_cast<u8>(58), static_cast<u8>(32), static_cast<u8>(117), static_cast<u8>(115), static_cast<u8>(105), static_cast<u8>(122), static_cast<u8>(101), static_cast<u8>(41), static_cast<u8>(32), static_cast<u8>(45), static_cast<u8>(62), static_cast<u8>(32), static_cast<u8>(118), static_cast<u8>(111), static_cast<u8>(105), static_cast<u8>(100), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(102), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(112), static_cast<u8>(117), static_cast<u8>(115), static_cast<u8>(104), static_cast<u8>(40), static_cast<u8>(109), static_cast<u8>(117), static_cast<u8>(116), static_cast<u8>(32), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(105), static_cast<u8>(115), static_cast<u8>(44), static_cast<u8>(32), static_cast<u8>(97), static_cast<u8>(110), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(118), static_cast<u8>(97), static_cast<u8>(108), static_cast<u8>(117), static_cast<u8>(101), static_cast<u8>(58), static_cast<u8>(32), static_cast<u8>(84), static_cast<u8>(41), static_cast<u8>(32), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(114), static_cast<u8>(111), static_cast<u8>(119), static_cast<u8>(115), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(102), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(112), static_cast<u8>(117), static_cast<u8>(115), static_cast<u8>(104), static_cast<u8>(95), static_cast<u8>(118), static_cast<u8>(97), static_cast<u8>(108), static_cast<u8>(117), static_cast<u8>(101), static_cast<u8>(115), static_cast<u8>(40), static_cast<u8>(109), static_cast<u8>(117), static_cast<u8>(116), static_cast<u8>(32), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(105), static_cast<u8>(115), static_cast<u8>(44), static_cast<u8>(32), static_cast<u8>(97), static_cast<u8>(110), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(111), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(101), static_cast<u8>(114), static_cast<u8>(58), static_cast<u8>(32), static_cast<u8>(38), static_cast<u8>(65), static_cast<u8>(114), static_cast<u8>(114), static_cast<u8>(97), static_cast<u8>(121), static_cast<u8>(60), static_cast<u8>(84), static_cast<u8>(62), static_cast<u8>(41), static_cast<u8>(32), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(114), static_cast<u8>(111), static_cast<u8>(119), static_cast<u8>(115), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(102), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(112), static_cast<u8>(111), static_cast<u8>(112), static_cast<u8>(40), static_cast<u8>(109), static_cast<u8>(117), static_cast<u8>(116), static_cast<u8>(32), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(105), static_cast<u8>(115), static_cast<u8>(41), static_cast<u8>(32), static_cast<u8>(45), static_cast<u8>(62), static_cast<u8>(32), static_cast<u8>(84), static_cast<u8>(63), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(102), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(105), static_cast<u8>(116), static_cast<u8>(101), static_cast<u8>(114), static_cast<u8>(97), static_cast<u8>(116), static_cast<u8>(111), static_cast<u8>(114), static_cast<u8>(40), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(105), static_cast<u8>(115), static_cast<u8>(41), static_cast<u8>(32), static_cast<u8>(45), static_cast<u8>(62), static_cast<u8>(32), static_cast<u8>(65), static_cast<u8>(114), static_cast<u8>(114), static_cast<u8>(97), static_cast<u8>(121), static_cast<u8>(73), static_cast<u8>(116), static_cast<u8>(101), static_cast<u8>(114), static_cast<u8>(97), static_cast<u8>(116), static_cast<u8>(111), static_cast<u8>(114), static_cast<u8>(60), static_cast<u8>(84), static_cast<u8>(62), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(102), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(102), static_cast<u8>(105), static_cast<u8>(114), static_cast<u8>(115), static_cast<u8>(116), static_cast<u8>(40), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(105), static_cast<u8>(115), static_cast<u8>(41), static_cast<u8>(32), static_cast<u8>(45), static_cast<u8>(62), static_cast<u8>(32), static_cast<u8>(84), static_cast<u8>(63), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(102), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(108), static_cast<u8>(97), static_cast<u8>(115), static_cast<u8>(116), static_cast<u8>(40), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(105), static_cast<u8>(115), static_cast<u8>(41), static_cast<u8>(32), static_cast<u8>(45), static_cast<u8>(62), static_cast<u8>(32), static_cast<u8>(84), static_cast<u8>(63), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(102), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(105), static_cast<u8>(110), static_cast<u8>(115), static_cast<u8>(101), static_cast<u8>(114), static_cast<u8>(116), static_cast<u8>(40), static_cast<u8>(109), static_cast<u8>(117), static_cast<u8>(116), static_cast<u8>(32), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(105), static_cast<u8>(115), static_cast<u8>(44), static_cast<u8>(32), static_cast<u8>(98), static_cast<u8>(101), static_cast<u8>(102), static_cast<u8>(111), static_cast<u8>(114), static_cast<u8>(101), static_cast<u8>(95), static_cast<u8>(105), static_cast<u8>(110), static_cast<u8>(100), static_cast<u8>(101), static_cast<u8>(120), static_cast<u8>(58), static_cast<u8>(32), static_cast<u8>(117), static_cast<u8>(115), static_cast<u8>(105), static_cast<u8>(122), static_cast<u8>(101), static_cast<u8>(44), static_cast<u8>(32), static_cast<u8>(118), static_cast<u8>(97), static_cast<u8>(108), static_cast<u8>(117), static_cast<u8>(101), static_cast<u8>(58), static_cast<u8>(32), static_cast<u8>(84), static_cast<u8>(41), static_cast<u8>(32), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(114), static_cast<u8>(111), static_cast<u8>(119), static_cast<u8>(115), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(102), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(117), static_cast<u8>(110), static_cast<u8>(115), static_cast<u8>(97), static_cast<u8>(102), static_cast<u8>(101), static_cast<u8>(95), static_cast<u8>(100), static_cast<u8>(97), static_cast<u8>(116), static_cast<u8>(97), static_cast<u8>(40), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(105), static_cast<u8>(115), static_cast<u8>(41), static_cast<u8>(32), static_cast<u8>(45), static_cast<u8>(62), static_cast<u8>(32), static_cast<u8>(114), static_cast<u8>(97), static_cast<u8>(119), static_cast<u8>(32), static_cast<u8>(84), static_cast<u8>(10), static_cast<u8>(125), static_cast<u8>(10), static_cast<u8>(10), static_cast<u8>(101), static_cast<u8>(120), static_cast<u8>(116), static_cast<u8>(101), static_cast<u8>(114), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(115), static_cast<u8>(116), static_cast<u8>(114), static_cast<u8>(117), static_cast<u8>(99), static_cast<u8>(116), static_cast<u8>(32), static_cast<u8>(65), static_cast<u8>(114), static_cast<u8>(114), static_cast<u8>(97), static_cast<u8>(121), static_cast<u8>(83), static_cast<u8>(108), static_cast<u8>(105), static_cast<u8>(99), static_cast<u8>(101), static_cast<u8>(60), static_cast<u8>(84), static_cast<u8>(62), static_cast<u8>(32), static_cast<u8>(123), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(102), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(105), static_cast<u8>(115), static_cast<u8>(95), static_cast<u8>(101), static_cast<u8>(109), static_cast<u8>(112), static_cast<u8>(116), static_cast<u8>(121), static_cast<u8>(40), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(105), static_cast<u8>(115), static_cast<u8>(41), static_cast<u8>(32), static_cast<u8>(45), static_cast<u8>(62), static_cast<u8>(32), static_cast<u8>(98), static_cast<u8>(111), static_cast<u8>(111), static_cast<u8>(108), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(102), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(99), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(116), static_cast<u8>(97), static_cast<u8>(105), static_cast<u8>(110), static_cast<u8>(115), static_cast<u8>(40), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(105), static_cast<u8>(115), static_cast<u8>(44), static_cast<u8>(32), static_cast<u8>(97), static_cast<u8>(110), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(118), static_cast<u8>(97), static_cast<u8>(108), static_cast<u8>(117), static_cast<u8>(101), static_cast<u8>(58), static_cast<u8>(32), static_cast<u8>(84), static_cast<u8>(41), static_cast<u8>(32), static_cast<u8>(45), static_cast<u8>(62), static_cast<u8>(32), static_cast<u8>(98), static_cast<u8>(111), static_cast<u8>(111), static_cast<u8>(108), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(102), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(115), static_cast<u8>(105), static_cast<u8>(122), static_cast<u8>(101), static_cast<u8>(40), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(105), static_cast<u8>(115), static_cast<u8>(41), static_cast<u8>(32), static_cast<u8>(45), static_cast<u8>(62), static_cast<u8>(32), static_cast<u8>(117), static_cast<u8>(115), static_cast<u8>(105), static_cast<u8>(122), static_cast<u8>(101), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(102), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(105), static_cast<u8>(116), static_cast<u8>(101), static_cast<u8>(114), static_cast<u8>(97), static_cast<u8>(116), static_cast<u8>(111), static_cast<u8>(114), static_cast<u8>(40), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(105), static_cast<u8>(115), static_cast<u8>(41), static_cast<u8>(32), static_cast<u8>(45), static_cast<u8>(62), static_cast<u8>(32), static_cast<u8>(65), static_cast<u8>(114), static_cast<u8>(114), static_cast<u8>(97), static_cast<u8>(121), static_cast<u8>(73), static_cast<u8>(116), static_cast<u8>(101), static_cast<u8>(114), static_cast<u8>(97), static_cast<u8>(116), static_cast<u8>(111), static_cast<u8>(114), static_cast<u8>(60), static_cast<u8>(84), static_cast<u8>(62), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(102), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(116), static_cast<u8>(111), static_cast<u8>(95), static_cast<u8>(97), static_cast<u8>(114), static_cast<u8>(114), static_cast<u8>(97), static_cast<u8>(121), static_cast<u8>(40), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(105), static_cast<u8>(115), static_cast<u8>(41), static_cast<u8>(32), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(114), static_cast<u8>(111), static_cast<u8>(119), static_cast<u8>(115), static_cast<u8>(32), static_cast<u8>(45), static_cast<u8>(62), static_cast<u8>(32), static_cast<u8>(65), static_cast<u8>(114), static_cast<u8>(114), static_cast<u8>(97), static_cast<u8>(121), static_cast<u8>(60), static_cast<u8>(84), static_cast<u8>(62), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(102), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(102), static_cast<u8>(105), static_cast<u8>(114), static_cast<u8>(115), static_cast<u8>(116), static_cast<u8>(40), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(105), static_cast<u8>(115), static_cast<u8>(41), static_cast<u8>(32), static_cast<u8>(45), static_cast<u8>(62), static_cast<u8>(32), static_cast<u8>(84), static_cast<u8>(63), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(102), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(108), static_cast<u8>(97), static_cast<u8>(115), static_cast<u8>(116), static_cast<u8>(40), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(105), static_cast<u8>(115), static_cast<u8>(41), static_cast<u8>(32), static_cast<u8>(45), static_cast<u8>(62), static_cast<u8>(32), static_cast<u8>(84), static_cast<u8>(63), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(102), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(117), static_cast<u8>(110), static_cast<u8>(115), static_cast<u8>(97), static_cast<u8>(102), static_cast<u8>(101), static_cast<u8>(95), static_cast<u8>(100), static_cast<u8>(97), static_cast<u8>(116), static_cast<u8>(97), static_cast<u8>(40), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(105), static_cast<u8>(115), static_cast<u8>(41), static_cast<u8>(32), static_cast<u8>(45), static_cast<u8>(62), static_cast<u8>(32), static_cast<u8>(114), static_cast<u8>(97), static_cast<u8>(119), static_cast<u8>(32), static_cast<u8>(84), static_cast<u8>(10), static_cast<u8>(125), static_cast<u8>(10), static_cast<u8>(10), static_cast<u8>(91), static_cast<u8>(91), static_cast<u8>(110), static_cast<u8>(97), static_cast<u8>(109), static_cast<u8>(101), static_cast<u8>(61), static_cast<u8>(68), static_cast<u8>(101), static_cast<u8>(112), static_cast<u8>(114), static_cast<u8>(101), static_cast<u8>(99), static_cast<u8>(97), static_cast<u8>(116), static_cast<u8>(101), static_cast<u8>(100), static_cast<u8>(83), static_cast<u8>(116), static_cast<u8>(114), static_cast<u8>(105), static_cast<u8>(110), static_cast<u8>(103), static_cast<u8>(67), static_cast<u8>(111), static_cast<u8>(100), static_cast<u8>(101), static_cast<u8>(80), static_cast<u8>(111), static_cast<u8>(105), static_cast<u8>(110), static_cast<u8>(116), static_cast<u8>(73), static_cast<u8>(116), static_cast<u8>(101), static_cast<u8>(114), static_cast<u8>(97), static_cast<u8>(116), static_cast<u8>(111), static_cast<u8>(114), static_cast<u8>(93), static_cast<u8>(93), static_cast<u8>(10), static_cast<u8>(101), static_cast<u8>(120), static_cast<u8>(116), static_cast<u8>(101), static_cast<u8>(114), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(115), static_cast<u8>(116), static_cast<u8>(114), static_cast<u8>(117), static_cast<u8>(99), static_cast<u8>(116), static_cast<u8>(32), static_cast<u8>(67), static_cast<u8>(111), static_cast<u8>(100), static_cast<u8>(101), static_cast<u8>(80), static_cast<u8>(111), static_cast<u8>(105), static_cast<u8>(110), static_cast<u8>(116), static_cast<u8>(73), static_cast<u8>(116), static_cast<u8>(101), static_cast<u8>(114), static_cast<u8>(97), static_cast<u8>(116), static_cast<u8>(111), static_cast<u8>(114), static_cast<u8>(32), static_cast<u8>(123), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(102), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(110), static_cast<u8>(101), static_cast<u8>(120), static_cast<u8>(116), static_cast<u8>(40), static_cast<u8>(109), static_cast<u8>(117), static_cast<u8>(116), static_cast<u8>(32), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(105), static_cast<u8>(115), static_cast<u8>(41), static_cast<u8>(32), static_cast<u8>(45), static_cast<u8>(62), static_cast<u8>(32), static_cast<u8>(117), static_cast<u8>(51), static_cast<u8>(50), static_cast<u8>(63), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(102), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(112), static_cast<u8>(101), static_cast<u8>(101), static_cast<u8>(107), static_cast<u8>(40), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(105), static_cast<u8>(115), static_cast<u8>(41), static_cast<u8>(32), static_cast<u8>(45), static_cast<u8>(62), static_cast<u8>(32), static_cast<u8>(117), static_cast<u8>(51), static_cast<u8>(50), static_cast<u8>(63), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(102), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(98), static_cast<u8>(121), static_cast<u8>(116), static_cast<u8>(101), static_cast<u8>(95), static_cast<u8>(111), static_cast<u8>(102), static_cast<u8>(102), static_cast<u8>(115), static_cast<u8>(101), static_cast<u8>(116), static_cast<u8>(40), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(105), static_cast<u8>(115), static_cast<u8>(41), static_cast<u8>(32), static_cast<u8>(45), static_cast<u8>(62), static_cast<u8>(32), static_cast<u8>(117), static_cast<u8>(115), static_cast<u8>(105), static_cast<u8>(122), static_cast<u8>(101), static_cast<u8>(10), static_cast<u8>(125), static_cast<u8>(10), static_cast<u8>(10), static_cast<u8>(91), static_cast<u8>(91), static_cast<u8>(110), static_cast<u8>(97), static_cast<u8>(109), static_cast<u8>(101), static_cast<u8>(61), static_cast<u8>(66), static_cast<u8>(121), static_cast<u8>(116), static_cast<u8>(101), static_cast<u8>(83), static_cast<u8>(116), static_cast<u8>(114), static_cast<u8>(105), static_cast<u8>(110), static_cast<u8>(103), static_cast<u8>(93), static_cast<u8>(93), static_cast<u8>(10), static_cast<u8>(101), static_cast<u8>(120), static_cast<u8>(116), static_cast<u8>(101), static_cast<u8>(114), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(115), static_cast<u8>(116), static_cast<u8>(114), static_cast<u8>(117), static_cast<u8>(99), static_cast<u8>(116), static_cast<u8>(32), static_cast<u8>(83), static_cast<u8>(116), static_cast<u8>(114), static_cast<u8>(105), static_cast<u8>(110), static_cast<u8>(103), static_cast<u8>(32), static_cast<u8>(123), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(102), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(99), static_cast<u8>(111), static_cast<u8>(100), static_cast<u8>(101), static_cast<u8>(95), static_cast<u8>(112), static_cast<u8>(111), static_cast<u8>(105), static_cast<u8>(110), static_cast<u8>(116), static_cast<u8>(115), static_cast<u8>(40), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(105), static_cast<u8>(115), static_cast<u8>(41), static_cast<u8>(32), static_cast<u8>(45), static_cast<u8>(62), static_cast<u8>(32), static_cast<u8>(67), static_cast<u8>(111), static_cast<u8>(100), static_cast<u8>(101), static_cast<u8>(80), static_cast<u8>(111), static_cast<u8>(105), static_cast<u8>(110), static_cast<u8>(116), static_cast<u8>(73), static_cast<u8>(116), static_cast<u8>(101), static_cast<u8>(114), static_cast<u8>(97), static_cast<u8>(116), static_cast<u8>(111), static_cast<u8>(114), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(102), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(102), static_cast<u8>(114), static_cast<u8>(111), static_cast<u8>(109), static_cast<u8>(95), static_cast<u8>(117), static_cast<u8>(116), static_cast<u8>(102), static_cast<u8>(56), static_cast<u8>(40), static_cast<u8>(97), static_cast<u8>(110), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(98), static_cast<u8>(121), static_cast<u8>(116), static_cast<u8>(101), static_cast<u8>(115), static_cast<u8>(58), static_cast<u8>(32), static_cast<u8>(91), static_cast<u8>(117), static_cast<u8>(56), static_cast<u8>(93), static_cast<u8>(41), static_cast<u8>(32), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(114), static_cast<u8>(111), static_cast<u8>(119), static_cast<u8>(115), static_cast<u8>(32), static_cast<u8>(45), static_cast<u8>(62), static_cast<u8>(32), static_cast<u8>(83), static_cast<u8>(116), static_cast<u8>(114), static_cast<u8>(105), static_cast<u8>(110), static_cast<u8>(103), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(102), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(110), static_cast<u8>(117), static_cast<u8>(109), static_cast<u8>(98), static_cast<u8>(101), static_cast<u8>(114), static_cast<u8>(40), static_cast<u8>(97), static_cast<u8>(110), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(110), static_cast<u8>(117), static_cast<u8>(109), static_cast<u8>(98), static_cast<u8>(101), static_cast<u8>(114), static_cast<u8>(58), static_cast<u8>(32), static_cast<u8>(105), static_cast<u8>(54), static_cast<u8>(52), static_cast<u8>(41), static_cast<u8>(32), static_cast<u8>(45), static_cast<u8>(62), static_cast<u8>(32), static_cast<u8>(83), static_cast<u8>(116), static_cast<u8>(114), static_cast<u8>(105), static_cast<u8>(110), static_cast<u8>(103), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(102), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(115), static_cast<u8>(112), static_cast<u8>(108), static_cast<u8>(105), static_cast<u8>(116), static_cast<u8>(40), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(105), static_cast<u8>(115), static_cast<u8>(44), static_cast<u8>(32), static_cast<u8>(97), static_cast<u8>(110), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(99), static_cast<u8>(58), static_cast<u8>(32), static_cast<u8>(99), static_cast<u8>(95), static_cast<u8>(99), static_cast<u8>(104), static_cast<u8>(97), static_cast<u8>(114), static_cast<u8>(41), static_cast<u8>(32), static_cast<u8>(45), static_cast<u8>(62), static_cast<u8>(32), static_cast<u8>(91), static_cast<u8>(83), static_cast<u8>(116), static_cast<u8>(114), static_cast<u8>(105), static_cast<u8>(110), static_cast<u8>(103), static_cast<u8>(93), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(91), static_cast<u8>(91), static_cast<u8>(110), static_cast<u8>(97), static_cast<u8>(109), static_cast<u8>(101), static_cast<u8>(61), static_cast<u8>(99), static_cast<u8>(104), static_cast<u8>(97), static_cast<u8>(114), static_cast<u8>(97), static_cast<u8>(99), static_cast<u8>(116), static_cast<u8>(101), static_cast<u8>(114), static_cast<u8>(115), static_cast<u8>(93), static_cast<u8>(93), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(102), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(99), static_cast<u8>(95), static_cast<u8>(115), static_cast<u8>(116), static_cast<u8>(114), static_cast<u8>(105), static_cast<u8>(110), static_cast<u8>(103), static_cast<u8>(40), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(105), static_cast<u8>(115), static_cast<u8>(41), static_cast<u8>(32), static_cast<u8>(45), static_cast<u8>(62), static_cast<u8>(32), static_cast<u8>(114), static_cast<u8>(97), static_cast<u8>(119), static_cast<u8>(32), static_cast<u8>(99), static_cast<u8>(95), static_cast<u8>(99), static_cast<u8>(104), static_cast<u8>(97), static_cast<u8>(114), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(102), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(116), static_cast<u8>(111), static_cast<u8>(95), static_cast<u8>(105), static_cast<u8>(110), static_cast<u8>(116), static_cast<u8>(40), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(105), static_cast<u8>(115), static_cast<u8>(41), static_cast<u8>(32), static_cast<u8>(45), static_cast<u8>(62), static_cast<u8>(32), static_cast<u8>(105), static_cast<u8>(51), static_cast<u8>(50), static_cast<u8>(63), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(102), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(116), static_cast<u8>(111), static_cast<u8>(95), static_cast<u8>(117), static_cast<u8>(105), static_cast<u8>(110), static_cast<u8>(116), static_cast<u8>(40), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(105), static_cast<u8>(115), static_cast<u8>(41), static_cast<u8>(32), static_cast<u8>(45), static_cast<u8>(62), static_cast<u8>(32), static_cast<u8>(117), static_cast<u8>(51), static_cast<u8>(50), static_cast<u8>(63), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(102), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(105), static_cast<u8>(115), static_cast<u8>(95), static_cast<u8>(119), static_cast<u8>(104), static_cast<u8>(105), static_cast<u8>(116), static_cast<u8>(101), static_cast<u8>(115), static_cast<u8>(112), static_cast<u8>(97), static_cast<u8>(99), static_cast<u8>(101), static_cast<u8>(40), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(105), static_cast<u8>(115), static_cast<u8>(41), static_cast<u8>(32), static_cast<u8>(45), static_cast<u8>(62), static_cast<u8>(32), static_cast<u8>(98), static_cast<u8>(111), static_cast<u8>(111), static_cast<u8>(108), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(102), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(104), static_cast<u8>(97), static_cast<u8>(115), static_cast<u8>(104), static_cast<u8>(40), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(105), static_cast<u8>(115), static_cast<u8>(41), static_cast<u8>(32), static_cast<u8>(45), static_cast<u8>(62), static_cast<u8>(32), static_cast<u8>(117), static_cast<u8>(51), static_cast<u8>(50), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(102), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(115), static_cast<u8>(117), static_cast<u8>(98), static_cast<u8>(115), static_cast<u8>(116), static_cast<u8>(114), static_cast<u8>(105), static_cast<u8>(110), static_cast<u8>(103), static_cast<u8>(40), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(105), static_cast<u8>(115), static_cast<u8>(44), static_cast<u8>(32), static_cast<u8>(115), static_cast<u8>(116), static_cast<u8>(97), static_cast<u8>(114), static_cast<u8>(116), static_cast<u8>(58), static_cast<u8>(32), static_cast<u8>(117), static_cast<u8>(115), static_cast<u8>(105), static_cast<u8>(122), static_cast<u8>(101), static_cast<u8>(44), static_cast<u8>(32), static_cast<u8>(108), static_cast<u8>(101), static_cast<u8>(110), static_cast<u8>(103), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(58), static_cast<u8>(32), static_cast<u8>(117), static_cast<u8>(115), static_cast<u8>(105), static_cast<u8>(122), static_cast<u8>(101), static_cast<u8>(41), static_cast<u8>(32), static_cast<u8>(45), static_cast<u8>(62), static_cast<u8>(32), static_cast<u8>(83), static_cast<u8>(116), static_cast<u8>(114), static_cast<u8>(105), static_cast<u8>(110), static_cast<u8>(103), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(102), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(114), static_cast<u8>(101), static_cast<u8>(112), static_cast<u8>(101), static_cast<u8>(97), static_cast<u8>(116), static_cast<u8>(101), static_cast<u8>(100), static_cast<u8>(40), static_cast<u8>(99), static_cast<u8>(104), static_cast<u8>(97), static_cast<u8>(114), static_cast<u8>(97), static_cast<u8>(99), static_cast<u8>(116), static_cast<u8>(101), static_cast<u8>(114), static_cast<u8>(58), static_cast<u8>(32), static_cast<u8>(99), static_cast<u8>(95), static_cast<u8>(99), static_cast<u8>(104), static_cast<u8>(97), static_cast<u8>(114), static_cast<u8>(44), static_cast<u8>(32), static_cast<u8>(99), static_cast<u8>(111), static_cast<u8>(117), static_cast<u8>(110), static_cast<u8>(116), static_cast<u8>(58), static_cast<u8>(32), static_cast<u8>(117), static_cast<u8>(115), static_cast<u8>(105), static_cast<u8>(122), static_cast<u8>(101), static_cast<u8>(41), static_cast<u8>(32), static_cast<u8>(45), static_cast<u8>(62), static_cast<u8>(32), static_cast<u8>(83), static_cast<u8>(116), static_cast<u8>(114), static_cast<u8>(105), static_cast<u8>(110), static_cast<u8>(103), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(102), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(105), static_cast<u8>(115), static_cast<u8>(95), static_cast<u8>(101), static_cast<u8>(109), static_cast<u8>(112), static_cast<u8>(116), static_cast<u8>(121), static_cast<u8>(40), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(105), static_cast<u8>(115), static_cast<u8>(41), static_cast<u8>(32), static_cast<u8>(45), static_cast<u8>(62), static_cast<u8>(32), static_cast<u8>(98), static_cast<u8>(111), static_cast<u8>(111), static_cast<u8>(108), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(102), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(108), static_cast<u8>(101), static_cast<u8>(110), static_cast<u8>(103), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(40), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(105), static_cast<u8>(115), static_cast<u8>(41), static_cast<u8>(32), static_cast<u8>(45), static_cast<u8>(62), static_cast<u8>(32), static_cast<u8>(117), static_cast<u8>(115), static_cast<u8>(105), static_cast<u8>(122), static_cast<u8>(101), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(102), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(98), static_cast<u8>(121), static_cast<u8>(116), static_cast<u8>(101), static_cast<u8>(95), static_cast<u8>(97), static_cast<u8>(116), static_cast<u8>(40), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(105), static_cast<u8>(115), static_cast<u8>(44), static_cast<u8>(32), static_cast<u8>(97), static_cast<u8>(110), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(105), static_cast<u8>(110), static_cast<u8>(100), static_cast<u8>(101), static_cast<u8>(120), static_cast<u8>(58), static_cast<u8>(32), static_cast<u8>(117), static_cast<u8>(115), static_cast<u8>(105), static_cast<u8>(122), static_cast<u8>(101), static_cast<u8>(41), static_cast<u8>(32), static_cast<u8>(45), static_cast<u8>(62), static_cast<u8>(32), static_cast<u8>(117), static_cast<u8>(56), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(102), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(99), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(116), static_cast<u8>(97), static_cast<u8>(105), static_cast<u8>(110), static_cast<u8>(115), static_cast<u8>(40), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(105), static_cast<u8>(115), static_cast<u8>(44), static_cast<u8>(32), static_cast<u8>(97), static_cast<u8>(110), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(110), static_cast<u8>(101), static_cast<u8>(101), static_cast<u8>(100), static_cast<u8>(108), static_cast<u8>(101), static_cast<u8>(58), static_cast<u8>(32), static_cast<u8>(83), static_cast<u8>(116), static_cast<u8>(114), static_cast<u8>(105), static_cast<u8>(110), static_cast<u8>(103), static_cast<u8>(41), static_cast<u8>(32), static_cast<u8>(45), static_cast<u8>(62), static_cast<u8>(32), static_cast<u8>(98), static_cast<u8>(111), static_cast<u8>(111), static_cast<u8>(108), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(102), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(114), static_cast<u8>(101), static_cast<u8>(112), static_cast<u8>(108), static_cast<u8>(97), static_cast<u8>(99), static_cast<u8>(101), static_cast<u8>(40), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(105), static_cast<u8>(115), static_cast<u8>(44), static_cast<u8>(32), static_cast<u8>(114), static_cast<u8>(101), static_cast<u8>(112), static_cast<u8>(108), static_cast<u8>(97), static_cast<u8>(99), static_cast<u8>(101), static_cast<u8>(58), static_cast<u8>(32), static_cast<u8>(83), static_cast<u8>(116), static_cast<u8>(114), static_cast<u8>(105), static_cast<u8>(110), static_cast<u8>(103), static_cast<u8>(44), static_cast<u8>(32), static_cast<u8>(119), static_cast<u8>(105), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(58), static_cast<u8>(32), static_cast<u8>(83), static_cast<u8>(116), static_cast<u8>(114), static_cast<u8>(105), static_cast<u8>(110), static_cast<u8>(103), static_cast<u8>(41), static_cast<u8>(32), static_cast<u8>(45), static_cast<u8>(62), static_cast<u8>(32), static_cast<u8>(83), static_cast<u8>(116), static_cast<u8>(114), static_cast<u8>(105), static_cast<u8>(110), static_cast<u8>(103), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(102), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(115), static_cast<u8>(116), static_cast<u8>(97), static_cast<u8>(114), static_cast<u8>(116), static_cast<u8>(115), static_cast<u8>(95), static_cast<u8>(119), static_cast<u8>(105), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(40), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(105), static_cast<u8>(115), static_cast<u8>(44), static_cast<u8>(32), static_cast<u8>(97), static_cast<u8>(110), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(110), static_cast<u8>(101), static_cast<u8>(101), static_cast<u8>(100), static_cast<u8>(108), static_cast<u8>(101), static_cast<u8>(58), static_cast<u8>(32), static_cast<u8>(83), static_cast<u8>(116), static_cast<u8>(114), static_cast<u8>(105), static_cast<u8>(110), static_cast<u8>(103), static_cast<u8>(41), static_cast<u8>(32), static_cast<u8>(45), static_cast<u8>(62), static_cast<u8>(32), static_cast<u8>(98), static_cast<u8>(111), static_cast<u8>(111), static_cast<u8>(108), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(102), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(101), static_cast<u8>(110), static_cast<u8>(100), static_cast<u8>(115), static_cast<u8>(95), static_cast<u8>(119), static_cast<u8>(105), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(40), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(105), static_cast<u8>(115), static_cast<u8>(44), static_cast<u8>(32), static_cast<u8>(97), static_cast<u8>(110), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(110), static_cast<u8>(101), static_cast<u8>(101), static_cast<u8>(100), static_cast<u8>(108), static_cast<u8>(101), static_cast<u8>(58), static_cast<u8>(32), static_cast<u8>(83), static_cast<u8>(116), static_cast<u8>(114), static_cast<u8>(105), static_cast<u8>(110), static_cast<u8>(103), static_cast<u8>(41), static_cast<u8>(32), static_cast<u8>(45), static_cast<u8>(62), static_cast<u8>(32), static_cast<u8>(98), static_cast<u8>(111), static_cast<u8>(111), static_cast<u8>(108), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(102), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(99), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(116), static_cast<u8>(97), static_cast<u8>(105), static_cast<u8>(110), static_cast<u8>(115), static_cast<u8>(40), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(105), static_cast<u8>(115), static_cast<u8>(44), static_cast<u8>(32), static_cast<u8>(97), static_cast<u8>(110), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(110), static_cast<u8>(101), static_cast<u8>(101), static_cast<u8>(100), static_cast<u8>(108), static_cast<u8>(101), static_cast<u8>(58), static_cast<u8>(32), static_cast<u8>(83), static_cast<u8>(116), static_cast<u8>(114), static_cast<u8>(105), static_cast<u8>(110), static_cast<u8>(103), static_cast<u8>(86), static_cast<u8>(105), static_cast<u8>(101), static_cast<u8>(119), static_cast<u8>(41), static_cast<u8>(32), static_cast<u8>(45), static_cast<u8>(62), static_cast<u8>(32), static_cast<u8>(98), static_cast<u8>(111), static_cast<u8>(111), static_cast<u8>(108), static_cast<u8>(10), static_cast<u8>(125), static_cast<u8>(10), static_cast<u8>(10), static_cast<u8>(91), static_cast<u8>(91), static_cast<u8>(110), static_cast<u8>(97), static_cast<u8>(109), static_cast<u8>(101), static_cast<u8>(61), static_cast<u8>(66), static_cast<u8>(121), static_cast<u8>(116), static_cast<u8>(101), static_cast<u8>(83), static_cast<u8>(116), static_cast<u8>(114), static_cast<u8>(105), static_cast<u8>(110), static_cast<u8>(103), static_cast<u8>(66), static_cast<u8>(117), static_cast<u8>(105), static_cast<u8>(108), static_cast<u8>(100), static_cast<u8>(101), static_cast<u8>(114), static_cast<u8>(93), static_cast<u8>(93), static_cast<u8>(10), static_cast<u8>(101), static_cast<u8>(120), static_cast<u8>(116), static_cast<u8>(101), static_cast<u8>(114), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(115), static_cast<u8>(116), static_cast<u8>(114), static_cast<u8>(117), static_cast<u8>(99), static_cast<u8>(116), static_cast<u8>(32), static_cast<u8>(83), static_cast<u8>(116), static_cast<u8>(114), static_cast<u8>(105), static_cast<u8>(110), static_cast<u8>(103), static_cast<u8>(66), static_cast<u8>(117), static_cast<u8>(105), static_cast<u8>(108), static_cast<u8>(100), static_cast<u8>(101), static_cast<u8>(114), static_cast<u8>(32), static_cast<u8>(123), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(102), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(97), static_cast<u8>(112), static_cast<u8>(112), static_cast<u8>(101), static_cast<u8>(110), static_cast<u8>(100), static_cast<u8>(40), static_cast<u8>(109), static_cast<u8>(117), static_cast<u8>(116), static_cast<u8>(32), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(105), static_cast<u8>(115), static_cast<u8>(44), static_cast<u8>(32), static_cast<u8>(97), static_cast<u8>(110), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(98), static_cast<u8>(58), static_cast<u8>(32), static_cast<u8>(117), static_cast<u8>(56), static_cast<u8>(41), static_cast<u8>(32), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(114), static_cast<u8>(111), static_cast<u8>(119), static_cast<u8>(115), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(102), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(97), static_cast<u8>(112), static_cast<u8>(112), static_cast<u8>(101), static_cast<u8>(110), static_cast<u8>(100), static_cast<u8>(40), static_cast<u8>(109), static_cast<u8>(117), static_cast<u8>(116), static_cast<u8>(32), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(105), static_cast<u8>(115), static_cast<u8>(44), static_cast<u8>(32), static_cast<u8>(97), static_cast<u8>(110), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(115), static_cast<u8>(58), static_cast<u8>(32), static_cast<u8>(83), static_cast<u8>(116), static_cast<u8>(114), static_cast<u8>(105), static_cast<u8>(110), static_cast<u8>(103), static_cast<u8>(86), static_cast<u8>(105), static_cast<u8>(101), static_cast<u8>(119), static_cast<u8>(41), static_cast<u8>(32), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(114), static_cast<u8>(111), static_cast<u8>(119), static_cast<u8>(115), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(102), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(97), static_cast<u8>(112), static_cast<u8>(112), static_cast<u8>(101), static_cast<u8>(110), static_cast<u8>(100), static_cast<u8>(40), static_cast<u8>(109), static_cast<u8>(117), static_cast<u8>(116), static_cast<u8>(32), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(105), static_cast<u8>(115), static_cast<u8>(44), static_cast<u8>(32), static_cast<u8>(97), static_cast<u8>(110), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(115), static_cast<u8>(58), static_cast<u8>(32), static_cast<u8>(83), static_cast<u8>(116), static_cast<u8>(114), static_cast<u8>(105), static_cast<u8>(110), static_cast<u8>(103), static_cast<u8>(41), static_cast<u8>(32), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(114), static_cast<u8>(111), static_cast<u8>(119), static_cast<u8>(115), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(102), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(97), static_cast<u8>(112), static_cast<u8>(112), static_cast<u8>(101), static_cast<u8>(110), static_cast<u8>(100), static_cast<u8>(40), static_cast<u8>(109), static_cast<u8>(117), static_cast<u8>(116), static_cast<u8>(32), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(105), static_cast<u8>(115), static_cast<u8>(44), static_cast<u8>(32), static_cast<u8>(115), static_cast<u8>(116), static_cast<u8>(114), static_cast<u8>(105), static_cast<u8>(110), static_cast<u8>(103), static_cast<u8>(58), static_cast<u8>(32), static_cast<u8>(114), static_cast<u8>(97), static_cast<u8>(119), static_cast<u8>(32), static_cast<u8>(99), static_cast<u8>(95), static_cast<u8>(99), static_cast<u8>(104), static_cast<u8>(97), static_cast<u8>(114), static_cast<u8>(44), static_cast<u8>(32), static_cast<u8>(115), static_cast<u8>(105), static_cast<u8>(122), static_cast<u8>(101), static_cast<u8>(58), static_cast<u8>(32), static_cast<u8>(117), static_cast<u8>(115), static_cast<u8>(105), static_cast<u8>(122), static_cast<u8>(101), static_cast<u8>(41), static_cast<u8>(32), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(114), static_cast<u8>(111), static_cast<u8>(119), static_cast<u8>(115), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(91), static_cast<u8>(91), static_cast<u8>(110), static_cast<u8>(97), static_cast<u8>(109), static_cast<u8>(101), static_cast<u8>(61), static_cast<u8>(97), static_cast<u8>(112), static_cast<u8>(112), static_cast<u8>(101), static_cast<u8>(110), static_cast<u8>(100), static_cast<u8>(95), static_cast<u8>(99), static_cast<u8>(111), static_cast<u8>(100), static_cast<u8>(101), static_cast<u8>(95), static_cast<u8>(112), static_cast<u8>(111), static_cast<u8>(105), static_cast<u8>(110), static_cast<u8>(116), static_cast<u8>(93), static_cast<u8>(93), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(102), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(97), static_cast<u8>(112), static_cast<u8>(112), static_cast<u8>(101), static_cast<u8>(110), static_cast<u8>(100), static_cast<u8>(40), static_cast<u8>(109), static_cast<u8>(117), static_cast<u8>(116), static_cast<u8>(32), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(105), static_cast<u8>(115), static_cast<u8>(44), static_cast<u8>(32), static_cast<u8>(97), static_cast<u8>(110), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(99), static_cast<u8>(111), static_cast<u8>(100), static_cast<u8>(101), static_cast<u8>(95), static_cast<u8>(112), static_cast<u8>(111), static_cast<u8>(105), static_cast<u8>(110), static_cast<u8>(116), static_cast<u8>(58), static_cast<u8>(32), static_cast<u8>(117), static_cast<u8>(51), static_cast<u8>(50), static_cast<u8>(41), static_cast<u8>(32), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(114), static_cast<u8>(111), static_cast<u8>(119), static_cast<u8>(115), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(102), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(97), static_cast<u8>(112), static_cast<u8>(112), static_cast<u8>(101), static_cast<u8>(110), static_cast<u8>(100), static_cast<u8>(95), static_cast<u8>(101), static_cast<u8>(115), static_cast<u8>(99), static_cast<u8>(97), static_cast<u8>(112), static_cast<u8>(101), static_cast<u8>(100), static_cast<u8>(95), static_cast<u8>(102), static_cast<u8>(111), static_cast<u8>(114), static_cast<u8>(95), static_cast<u8>(106), static_cast<u8>(115), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(40), static_cast<u8>(109), static_cast<u8>(117), static_cast<u8>(116), static_cast<u8>(32), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(105), static_cast<u8>(115), static_cast<u8>(44), static_cast<u8>(32), static_cast<u8>(97), static_cast<u8>(110), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(115), static_cast<u8>(58), static_cast<u8>(32), static_cast<u8>(83), static_cast<u8>(116), static_cast<u8>(114), static_cast<u8>(105), static_cast<u8>(110), static_cast<u8>(103), static_cast<u8>(41), static_cast<u8>(32), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(114), static_cast<u8>(111), static_cast<u8>(119), static_cast<u8>(115), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(102), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(116), static_cast<u8>(111), static_cast<u8>(95), static_cast<u8>(115), static_cast<u8>(116), static_cast<u8>(114), static_cast<u8>(105), static_cast<u8>(110), static_cast<u8>(103), static_cast<u8>(40), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(105), static_cast<u8>(115), static_cast<u8>(41), static_cast<u8>(32), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(114), static_cast<u8>(111), static_cast<u8>(119), static_cast<u8>(115), static_cast<u8>(32), static_cast<u8>(45), static_cast<u8>(62), static_cast<u8>(32), static_cast<u8>(83), static_cast<u8>(116), static_cast<u8>(114), static_cast<u8>(105), static_cast<u8>(110), static_cast<u8>(103), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(102), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(105), static_cast<u8>(115), static_cast<u8>(95), static_cast<u8>(101), static_cast<u8>(109), static_cast<u8>(112), static_cast<u8>(116), static_cast<u8>(121), static_cast<u8>(40), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(105), static_cast<u8>(115), static_cast<u8>(41), static_cast<u8>(32), static_cast<u8>(45), static_cast<u8>(62), static_cast<u8>(32), static_cast<u8>(98), static_cast<u8>(111), static_cast<u8>(111), static_cast<u8>(108), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(102), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(108), static_cast<u8>(101), static_cast<u8>(110), static_cast<u8>(103), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(40), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(105), static_cast<u8>(115), static_cast<u8>(41), static_cast<u8>(32), static_cast<u8>(45), static_cast<u8>(62), static_cast<u8>(32), static_cast<u8>(117), static_cast<u8>(115), static_cast<u8>(105), static_cast<u8>(122), static_cast<u8>(101), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(102), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(99), static_cast<u8>(108), static_cast<u8>(101), static_cast<u8>(97), static_cast<u8>(114), static_cast<u8>(40), static_cast<u8>(109), static_cast<u8>(117), static_cast<u8>(116), static_cast<u8>(32), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(105), static_cast<u8>(115), static_cast<u8>(41), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(102), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(99), static_cast<u8>(114), static_cast<u8>(101), static_cast<u8>(97), static_cast<u8>(116), static_cast<u8>(101), static_cast<u8>(40), static_cast<u8>(41), static_cast<u8>(32), static_cast<u8>(45), static_cast<u8>(62), static_cast<u8>(32), static_cast<u8>(83), static_cast<u8>(116), static_cast<u8>(114), static_cast<u8>(105), static_cast<u8>(110), static_cast<u8>(103), static_cast<u8>(66), static_cast<u8>(117), static_cast<u8>(105), static_cast<u8>(108), static_cast<u8>(100), static_cast<u8>(101), static_cast<u8>(114), static_cast<u8>(10), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(47), static_cast<u8>(47), static_cast<u8>(32), static_cast<u8>(68), static_cast<u8>(101), static_cast<u8>(112), static_cast<u8>(114), static_cast<u8>(101), static_cast<u8>(99), static_cast<u8>(97), static_cast<u8>(116), static_cast<u8>(101), static_cast<u8>(100), static_cast<u8>(32), static_cast<u8>(65), static_cast<u8>(80), static_cast<u8>(73), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(102), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(97), static_cast<u8>(112), static_cast<u8>(112), static_cast<u8>(101), static_cast<u8>(110), static_cast<u8>(100), static_cast<u8>(95), static_cast<u8>(115), static_cast<u8>(116), static_cast<u8>(114), static_cast<u8>(105), static_cast<u8>(110), static_cast<u8>(103), static_cast<u8>(40), static_cast<u8>(109), static_cast<u8>(117), static_cast<u8>(116), static_cast<u8>(32), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(105), static_cast<u8>(115), static_cast<u8>(44), static_cast<u8>(32), static_cast<u8>(97), static_cast<u8>(110), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(115), static_cast<u8>(58), static_cast<u8>(32), static_cast<u8>(83), static_cast<u8>(116), static_cast<u8>(114), static_cast<u8>(105), static_cast<u8>(110), static_cast<u8>(103), static_cast<u8>(41), static_cast<u8>(32), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(114), static_cast<u8>(111), static_cast<u8>(119), static_cast<u8>(115), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(102), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(97), static_cast<u8>(112), static_cast<u8>(112), static_cast<u8>(101), static_cast<u8>(110), static_cast<u8>(100), static_cast<u8>(95), static_cast<u8>(99), static_cast<u8>(95), static_cast<u8>(115), static_cast<u8>(116), static_cast<u8>(114), static_cast<u8>(105), static_cast<u8>(110), static_cast<u8>(103), static_cast<u8>(40), static_cast<u8>(109), static_cast<u8>(117), static_cast<u8>(116), static_cast<u8>(32), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(105), static_cast<u8>(115), static_cast<u8>(44), static_cast<u8>(32), static_cast<u8>(97), static_cast<u8>(110), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(115), static_cast<u8>(58), static_cast<u8>(32), static_cast<u8>(114), static_cast<u8>(97), static_cast<u8>(119), static_cast<u8>(32), static_cast<u8>(99), static_cast<u8>(95), static_cast<u8>(99), static_cast<u8>(104), static_cast<u8>(97), static_cast<u8>(114), static_cast<u8>(41), static_cast<u8>(32), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(114), static_cast<u8>(111), static_cast<u8>(119), static_cast<u8>(115), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(102), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(97), static_cast<u8>(112), static_cast<u8>(112), static_cast<u8>(101), static_cast<u8>(110), static_cast<u8>(100), static_cast<u8>(95), static_cast<u8>(99), static_cast<u8>(111), static_cast<u8>(100), static_cast<u8>(101), static_cast<u8>(95), static_cast<u8>(112), static_cast<u8>(111), static_cast<u8>(105), static_cast<u8>(110), static_cast<u8>(116), static_cast<u8>(40), static_cast<u8>(109), static_cast<u8>(117), static_cast<u8>(116), static_cast<u8>(32), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(105), static_cast<u8>(115), static_cast<u8>(44), static_cast<u8>(32), static_cast<u8>(97), static_cast<u8>(110), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(99), static_cast<u8>(111), static_cast<u8>(100), static_cast<u8>(101), static_cast<u8>(95), static_cast<u8>(112), static_cast<u8>(111), static_cast<u8>(105), static_cast<u8>(110), static_cast<u8>(116), static_cast<u8>(58), static_cast<u8>(32), static_cast<u8>(117), static_cast<u8>(51), static_cast<u8>(50), static_cast<u8>(41), static_cast<u8>(32), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(114), static_cast<u8>(111), static_cast<u8>(119), static_cast<u8>(115), static_cast<u8>(10), static_cast<u8>(125), static_cast<u8>(10), static_cast<u8>(10), static_cast<u8>(101), static_cast<u8>(120), static_cast<u8>(116), static_cast<u8>(101), static_cast<u8>(114), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(115), static_cast<u8>(116), static_cast<u8>(114), static_cast<u8>(117), static_cast<u8>(99), static_cast<u8>(116), static_cast<u8>(32), static_cast<u8>(87), static_cast<u8>(101), static_cast<u8>(97), static_cast<u8>(107), static_cast<u8>(80), static_cast<u8>(116), static_cast<u8>(114), static_cast<u8>(60), static_cast<u8>(84), static_cast<u8>(62), static_cast<u8>(32), static_cast<u8>(123), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(102), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(104), static_cast<u8>(97), static_cast<u8>(115), static_cast<u8>(95), static_cast<u8>(118), static_cast<u8>(97), static_cast<u8>(108), static_cast<u8>(117), static_cast<u8>(101), static_cast<u8>(40), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(105), static_cast<u8>(115), static_cast<u8>(41), static_cast<u8>(32), static_cast<u8>(45), static_cast<u8>(62), static_cast<u8>(32), static_cast<u8>(98), static_cast<u8>(111), static_cast<u8>(111), static_cast<u8>(108), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(102), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(99), static_cast<u8>(108), static_cast<u8>(101), static_cast<u8>(97), static_cast<u8>(114), static_cast<u8>(40), static_cast<u8>(109), static_cast<u8>(117), static_cast<u8>(116), static_cast<u8>(32), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(105), static_cast<u8>(115), static_cast<u8>(41), static_cast<u8>(10), static_cast<u8>(125), static_cast<u8>(10), static_cast<u8>(10), static_cast<u8>(101), static_cast<u8>(120), static_cast<u8>(116), static_cast<u8>(101), static_cast<u8>(114), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(115), static_cast<u8>(116), static_cast<u8>(114), static_cast<u8>(117), static_cast<u8>(99), static_cast<u8>(116), static_cast<u8>(32), static_cast<u8>(84), static_cast<u8>(117), static_cast<u8>(112), static_cast<u8>(108), static_cast<u8>(101), static_cast<u8>(32), static_cast<u8>(123), static_cast<u8>(125), static_cast<u8>(10), static_cast<u8>(10), static_cast<u8>(101), static_cast<u8>(120), static_cast<u8>(116), static_cast<u8>(101), static_cast<u8>(114), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(115), static_cast<u8>(116), static_cast<u8>(114), static_cast<u8>(117), static_cast<u8>(99), static_cast<u8>(116), static_cast<u8>(32), static_cast<u8>(68), static_cast<u8>(105), static_cast<u8>(99), static_cast<u8>(116), static_cast<u8>(105), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(97), static_cast<u8>(114), static_cast<u8>(121), static_cast<u8>(73), static_cast<u8>(116), static_cast<u8>(101), static_cast<u8>(114), static_cast<u8>(97), static_cast<u8>(116), static_cast<u8>(111), static_cast<u8>(114), static_cast<u8>(60), static_cast<u8>(75), static_cast<u8>(44), static_cast<u8>(32), static_cast<u8>(86), static_cast<u8>(62), static_cast<u8>(32), static_cast<u8>(123), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(102), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(110), static_cast<u8>(101), static_cast<u8>(120), static_cast<u8>(116), static_cast<u8>(40), static_cast<u8>(109), static_cast<u8>(117), static_cast<u8>(116), static_cast<u8>(32), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(105), static_cast<u8>(115), static_cast<u8>(41), static_cast<u8>(32), static_cast<u8>(45), static_cast<u8>(62), static_cast<u8>(32), static_cast<u8>(40), static_cast<u8>(75), static_cast<u8>(44), static_cast<u8>(32), static_cast<u8>(86), static_cast<u8>(41), static_cast<u8>(63), static_cast<u8>(10), static_cast<u8>(125), static_cast<u8>(10), static_cast<u8>(10), static_cast<u8>(101), static_cast<u8>(120), static_cast<u8>(116), static_cast<u8>(101), static_cast<u8>(114), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(115), static_cast<u8>(116), static_cast<u8>(114), static_cast<u8>(117), static_cast<u8>(99), static_cast<u8>(116), static_cast<u8>(32), static_cast<u8>(68), static_cast<u8>(105), static_cast<u8>(99), static_cast<u8>(116), static_cast<u8>(105), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(97), static_cast<u8>(114), static_cast<u8>(121), static_cast<u8>(60), static_cast<u8>(75), static_cast<u8>(44), static_cast<u8>(32), static_cast<u8>(86), static_cast<u8>(62), static_cast<u8>(32), static_cast<u8>(123), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(102), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(105), static_cast<u8>(115), static_cast<u8>(95), static_cast<u8>(101), static_cast<u8>(109), static_cast<u8>(112), static_cast<u8>(116), static_cast<u8>(121), static_cast<u8>(40), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(105), static_cast<u8>(115), static_cast<u8>(41), static_cast<u8>(32), static_cast<u8>(45), static_cast<u8>(62), static_cast<u8>(32), static_cast<u8>(98), static_cast<u8>(111), static_cast<u8>(111), static_cast<u8>(108), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(102), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(103), static_cast<u8>(101), static_cast<u8>(116), static_cast<u8>(40), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(105), static_cast<u8>(115), static_cast<u8>(44), static_cast<u8>(32), static_cast<u8>(97), static_cast<u8>(110), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(107), static_cast<u8>(101), static_cast<u8>(121), static_cast<u8>(58), static_cast<u8>(32), static_cast<u8>(75), static_cast<u8>(41), static_cast<u8>(32), static_cast<u8>(45), static_cast<u8>(62), static_cast<u8>(32), static_cast<u8>(86), static_cast<u8>(63), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(102), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(99), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(116), static_cast<u8>(97), static_cast<u8>(105), static_cast<u8>(110), static_cast<u8>(115), static_cast<u8>(40), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(105), static_cast<u8>(115), static_cast<u8>(44), static_cast<u8>(32), static_cast<u8>(97), static_cast<u8>(110), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(107), static_cast<u8>(101), static_cast<u8>(121), static_cast<u8>(58), static_cast<u8>(32), static_cast<u8>(75), static_cast<u8>(41), static_cast<u8>(32), static_cast<u8>(45), static_cast<u8>(62), static_cast<u8>(32), static_cast<u8>(98), static_cast<u8>(111), static_cast<u8>(111), static_cast<u8>(108), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(102), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(115), static_cast<u8>(101), static_cast<u8>(116), static_cast<u8>(40), static_cast<u8>(109), static_cast<u8>(117), static_cast<u8>(116), static_cast<u8>(32), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(105), static_cast<u8>(115), static_cast<u8>(44), static_cast<u8>(32), static_cast<u8>(97), static_cast<u8>(110), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(107), static_cast<u8>(101), static_cast<u8>(121), static_cast<u8>(58), static_cast<u8>(32), static_cast<u8>(75), static_cast<u8>(44), static_cast<u8>(32), static_cast<u8>(97), static_cast<u8>(110), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(118), static_cast<u8>(97), static_cast<u8>(108), static_cast<u8>(117), static_cast<u8>(101), static_cast<u8>(58), static_cast<u8>(32), static_cast<u8>(86), static_cast<u8>(41), static_cast<u8>(32), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(114), static_cast<u8>(111), static_cast<u8>(119), static_cast<u8>(115), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(102), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(114), static_cast<u8>(101), static_cast<u8>(109), static_cast<u8>(111), static_cast<u8>(118), static_cast<u8>(101), static_cast<u8>(40), static_cast<u8>(109), static_cast<u8>(117), static_cast<u8>(116), static_cast<u8>(32), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(105), static_cast<u8>(115), static_cast<u8>(44), static_cast<u8>(32), static_cast<u8>(97), static_cast<u8>(110), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(107), static_cast<u8>(101), static_cast<u8>(121), static_cast<u8>(58), static_cast<u8>(32), static_cast<u8>(75), static_cast<u8>(41), static_cast<u8>(32), static_cast<u8>(45), static_cast<u8>(62), static_cast<u8>(32), static_cast<u8>(98), static_cast<u8>(111), static_cast<u8>(111), static_cast<u8>(108), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(102), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(101), static_cast<u8>(110), static_cast<u8>(115), static_cast<u8>(117), static_cast<u8>(114), static_cast<u8>(101), static_cast<u8>(95), static_cast<u8>(99), static_cast<u8>(97), static_cast<u8>(112), static_cast<u8>(97), static_cast<u8>(99), static_cast<u8>(105), static_cast<u8>(116), static_cast<u8>(121), static_cast<u8>(40), static_cast<u8>(109), static_cast<u8>(117), static_cast<u8>(116), static_cast<u8>(32), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(105), static_cast<u8>(115), static_cast<u8>(44), static_cast<u8>(32), static_cast<u8>(97), static_cast<u8>(110), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(99), static_cast<u8>(97), static_cast<u8>(112), static_cast<u8>(97), static_cast<u8>(99), static_cast<u8>(105), static_cast<u8>(116), static_cast<u8>(121), static_cast<u8>(58), static_cast<u8>(32), static_cast<u8>(117), static_cast<u8>(115), static_cast<u8>(105), static_cast<u8>(122), static_cast<u8>(101), static_cast<u8>(41), static_cast<u8>(32), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(114), static_cast<u8>(111), static_cast<u8>(119), static_cast<u8>(115), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(102), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(99), static_cast<u8>(108), static_cast<u8>(101), static_cast<u8>(97), static_cast<u8>(114), static_cast<u8>(40), static_cast<u8>(109), static_cast<u8>(117), static_cast<u8>(116), static_cast<u8>(32), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(105), static_cast<u8>(115), static_cast<u8>(41), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(102), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(115), static_cast<u8>(105), static_cast<u8>(122), static_cast<u8>(101), static_cast<u8>(40), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(105), static_cast<u8>(115), static_cast<u8>(41), static_cast<u8>(32), static_cast<u8>(45), static_cast<u8>(62), static_cast<u8>(32), static_cast<u8>(117), static_cast<u8>(115), static_cast<u8>(105), static_cast<u8>(122), static_cast<u8>(101), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(102), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(99), static_cast<u8>(97), static_cast<u8>(112), static_cast<u8>(97), static_cast<u8>(99), static_cast<u8>(105), static_cast<u8>(116), static_cast<u8>(121), static_cast<u8>(40), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(105), static_cast<u8>(115), static_cast<u8>(41), static_cast<u8>(32), static_cast<u8>(45), static_cast<u8>(62), static_cast<u8>(32), static_cast<u8>(117), static_cast<u8>(115), static_cast<u8>(105), static_cast<u8>(122), static_cast<u8>(101), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(102), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(107), static_cast<u8>(101), static_cast<u8>(121), static_cast<u8>(115), static_cast<u8>(40), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(105), static_cast<u8>(115), static_cast<u8>(41), static_cast<u8>(32), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(114), static_cast<u8>(111), static_cast<u8>(119), static_cast<u8>(115), static_cast<u8>(32), static_cast<u8>(45), static_cast<u8>(62), static_cast<u8>(32), static_cast<u8>(91), static_cast<u8>(75), static_cast<u8>(93), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(102), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(104), static_cast<u8>(97), static_cast<u8>(115), static_cast<u8>(104), static_cast<u8>(40), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(105), static_cast<u8>(115), static_cast<u8>(41), static_cast<u8>(32), static_cast<u8>(45), static_cast<u8>(62), static_cast<u8>(32), static_cast<u8>(117), static_cast<u8>(51), static_cast<u8>(50), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(102), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(68), static_cast<u8>(105), static_cast<u8>(99), static_cast<u8>(116), static_cast<u8>(105), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(97), static_cast<u8>(114), static_cast<u8>(121), static_cast<u8>(60), static_cast<u8>(65), static_cast<u8>(44), static_cast<u8>(32), static_cast<u8>(66), static_cast<u8>(62), static_cast<u8>(40), static_cast<u8>(41), static_cast<u8>(32), static_cast<u8>(45), static_cast<u8>(62), static_cast<u8>(32), static_cast<u8>(68), static_cast<u8>(105), static_cast<u8>(99), static_cast<u8>(116), static_cast<u8>(105), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(97), static_cast<u8>(114), static_cast<u8>(121), static_cast<u8>(60), static_cast<u8>(65), static_cast<u8>(44), static_cast<u8>(32), static_cast<u8>(66), static_cast<u8>(62), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(102), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(105), static_cast<u8>(116), static_cast<u8>(101), static_cast<u8>(114), static_cast<u8>(97), static_cast<u8>(116), static_cast<u8>(111), static_cast<u8>(114), static_cast<u8>(40), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(105), static_cast<u8>(115), static_cast<u8>(41), static_cast<u8>(32), static_cast<u8>(45), static_cast<u8>(62), static_cast<u8>(32), static_cast<u8>(68), static_cast<u8>(105), static_cast<u8>(99), static_cast<u8>(116), static_cast<u8>(105), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(97), static_cast<u8>(114), static_cast<u8>(121), static_cast<u8>(73), static_cast<u8>(116), static_cast<u8>(101), static_cast<u8>(114), static_cast<u8>(97), static_cast<u8>(116), static_cast<u8>(111), static_cast<u8>(114), static_cast<u8>(60), static_cast<u8>(75), static_cast<u8>(44), static_cast<u8>(32), static_cast<u8>(86), static_cast<u8>(62), static_cast<u8>(10), static_cast<u8>(125), static_cast<u8>(10), static_cast<u8>(10), static_cast<u8>(101), static_cast<u8>(120), static_cast<u8>(116), static_cast<u8>(101), static_cast<u8>(114), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(115), static_cast<u8>(116), static_cast<u8>(114), static_cast<u8>(117), static_cast<u8>(99), static_cast<u8>(116), static_cast<u8>(32), static_cast<u8>(83), static_cast<u8>(101), static_cast<u8>(116), static_cast<u8>(73), static_cast<u8>(116), static_cast<u8>(101), static_cast<u8>(114), static_cast<u8>(97), static_cast<u8>(116), static_cast<u8>(111), static_cast<u8>(114), static_cast<u8>(60), static_cast<u8>(84), static_cast<u8>(62), static_cast<u8>(32), static_cast<u8>(123), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(102), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(110), static_cast<u8>(101), static_cast<u8>(120), static_cast<u8>(116), static_cast<u8>(40), static_cast<u8>(109), static_cast<u8>(117), static_cast<u8>(116), static_cast<u8>(32), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(105), static_cast<u8>(115), static_cast<u8>(41), static_cast<u8>(32), static_cast<u8>(45), static_cast<u8>(62), static_cast<u8>(32), static_cast<u8>(84), static_cast<u8>(63), static_cast<u8>(10), static_cast<u8>(125), static_cast<u8>(10), static_cast<u8>(10), static_cast<u8>(101), static_cast<u8>(120), static_cast<u8>(116), static_cast<u8>(101), static_cast<u8>(114), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(115), static_cast<u8>(116), static_cast<u8>(114), static_cast<u8>(117), static_cast<u8>(99), static_cast<u8>(116), static_cast<u8>(32), static_cast<u8>(83), static_cast<u8>(101), static_cast<u8>(116), static_cast<u8>(60), static_cast<u8>(86), static_cast<u8>(62), static_cast<u8>(32), static_cast<u8>(123), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(102), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(105), static_cast<u8>(115), static_cast<u8>(95), static_cast<u8>(101), static_cast<u8>(109), static_cast<u8>(112), static_cast<u8>(116), static_cast<u8>(121), static_cast<u8>(40), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(105), static_cast<u8>(115), static_cast<u8>(41), static_cast<u8>(32), static_cast<u8>(45), static_cast<u8>(62), static_cast<u8>(32), static_cast<u8>(98), static_cast<u8>(111), static_cast<u8>(111), static_cast<u8>(108), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(102), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(99), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(116), static_cast<u8>(97), static_cast<u8>(105), static_cast<u8>(110), static_cast<u8>(115), static_cast<u8>(40), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(105), static_cast<u8>(115), static_cast<u8>(44), static_cast<u8>(32), static_cast<u8>(97), static_cast<u8>(110), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(118), static_cast<u8>(97), static_cast<u8>(108), static_cast<u8>(117), static_cast<u8>(101), static_cast<u8>(58), static_cast<u8>(32), static_cast<u8>(86), static_cast<u8>(41), static_cast<u8>(32), static_cast<u8>(45), static_cast<u8>(62), static_cast<u8>(32), static_cast<u8>(98), static_cast<u8>(111), static_cast<u8>(111), static_cast<u8>(108), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(102), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(97), static_cast<u8>(100), static_cast<u8>(100), static_cast<u8>(40), static_cast<u8>(109), static_cast<u8>(117), static_cast<u8>(116), static_cast<u8>(32), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(105), static_cast<u8>(115), static_cast<u8>(44), static_cast<u8>(32), static_cast<u8>(97), static_cast<u8>(110), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(118), static_cast<u8>(97), static_cast<u8>(108), static_cast<u8>(117), static_cast<u8>(101), static_cast<u8>(58), static_cast<u8>(32), static_cast<u8>(86), static_cast<u8>(41), static_cast<u8>(32), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(114), static_cast<u8>(111), static_cast<u8>(119), static_cast<u8>(115), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(102), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(114), static_cast<u8>(101), static_cast<u8>(109), static_cast<u8>(111), static_cast<u8>(118), static_cast<u8>(101), static_cast<u8>(40), static_cast<u8>(109), static_cast<u8>(117), static_cast<u8>(116), static_cast<u8>(32), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(105), static_cast<u8>(115), static_cast<u8>(44), static_cast<u8>(32), static_cast<u8>(97), static_cast<u8>(110), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(118), static_cast<u8>(97), static_cast<u8>(108), static_cast<u8>(117), static_cast<u8>(101), static_cast<u8>(58), static_cast<u8>(32), static_cast<u8>(86), static_cast<u8>(41), static_cast<u8>(32), static_cast<u8>(45), static_cast<u8>(62), static_cast<u8>(32), static_cast<u8>(98), static_cast<u8>(111), static_cast<u8>(111), static_cast<u8>(108), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(102), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(101), static_cast<u8>(110), static_cast<u8>(115), static_cast<u8>(117), static_cast<u8>(114), static_cast<u8>(101), static_cast<u8>(95), static_cast<u8>(99), static_cast<u8>(97), static_cast<u8>(112), static_cast<u8>(97), static_cast<u8>(99), static_cast<u8>(105), static_cast<u8>(116), static_cast<u8>(121), static_cast<u8>(40), static_cast<u8>(109), static_cast<u8>(117), static_cast<u8>(116), static_cast<u8>(32), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(105), static_cast<u8>(115), static_cast<u8>(44), static_cast<u8>(32), static_cast<u8>(97), static_cast<u8>(110), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(99), static_cast<u8>(97), static_cast<u8>(112), static_cast<u8>(97), static_cast<u8>(99), static_cast<u8>(105), static_cast<u8>(116), static_cast<u8>(121), static_cast<u8>(58), static_cast<u8>(32), static_cast<u8>(117), static_cast<u8>(115), static_cast<u8>(105), static_cast<u8>(122), static_cast<u8>(101), static_cast<u8>(41), static_cast<u8>(32), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(114), static_cast<u8>(111), static_cast<u8>(119), static_cast<u8>(115), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(102), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(99), static_cast<u8>(108), static_cast<u8>(101), static_cast<u8>(97), static_cast<u8>(114), static_cast<u8>(40), static_cast<u8>(109), static_cast<u8>(117), static_cast<u8>(116), static_cast<u8>(32), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(105), static_cast<u8>(115), static_cast<u8>(41), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(102), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(115), static_cast<u8>(105), static_cast<u8>(122), static_cast<u8>(101), static_cast<u8>(40), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(105), static_cast<u8>(115), static_cast<u8>(41), static_cast<u8>(32), static_cast<u8>(45), static_cast<u8>(62), static_cast<u8>(32), static_cast<u8>(117), static_cast<u8>(115), static_cast<u8>(105), static_cast<u8>(122), static_cast<u8>(101), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(102), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(99), static_cast<u8>(97), static_cast<u8>(112), static_cast<u8>(97), static_cast<u8>(99), static_cast<u8>(105), static_cast<u8>(116), static_cast<u8>(121), static_cast<u8>(40), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(105), static_cast<u8>(115), static_cast<u8>(41), static_cast<u8>(32), static_cast<u8>(45), static_cast<u8>(62), static_cast<u8>(32), static_cast<u8>(117), static_cast<u8>(115), static_cast<u8>(105), static_cast<u8>(122), static_cast<u8>(101), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(102), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(104), static_cast<u8>(97), static_cast<u8>(115), static_cast<u8>(104), static_cast<u8>(40), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(105), static_cast<u8>(115), static_cast<u8>(41), static_cast<u8>(32), static_cast<u8>(45), static_cast<u8>(62), static_cast<u8>(32), static_cast<u8>(117), static_cast<u8>(51), static_cast<u8>(50), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(102), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(83), static_cast<u8>(101), static_cast<u8>(116), static_cast<u8>(60), static_cast<u8>(65), static_cast<u8>(62), static_cast<u8>(40), static_cast<u8>(41), static_cast<u8>(32), static_cast<u8>(45), static_cast<u8>(62), static_cast<u8>(32), static_cast<u8>(83), static_cast<u8>(101), static_cast<u8>(116), static_cast<u8>(60), static_cast<u8>(65), static_cast<u8>(62), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(102), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(105), static_cast<u8>(116), static_cast<u8>(101), static_cast<u8>(114), static_cast<u8>(97), static_cast<u8>(116), static_cast<u8>(111), static_cast<u8>(114), static_cast<u8>(40), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(105), static_cast<u8>(115), static_cast<u8>(41), static_cast<u8>(32), static_cast<u8>(45), static_cast<u8>(62), static_cast<u8>(32), static_cast<u8>(83), static_cast<u8>(101), static_cast<u8>(116), static_cast<u8>(73), static_cast<u8>(116), static_cast<u8>(101), static_cast<u8>(114), static_cast<u8>(97), static_cast<u8>(116), static_cast<u8>(111), static_cast<u8>(114), static_cast<u8>(60), static_cast<u8>(86), static_cast<u8>(62), static_cast<u8>(10), static_cast<u8>(125), static_cast<u8>(10), static_cast<u8>(10), static_cast<u8>(101), static_cast<u8>(120), static_cast<u8>(116), static_cast<u8>(101), static_cast<u8>(114), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(115), static_cast<u8>(116), static_cast<u8>(114), static_cast<u8>(117), static_cast<u8>(99), static_cast<u8>(116), static_cast<u8>(32), static_cast<u8>(82), static_cast<u8>(97), static_cast<u8>(110), static_cast<u8>(103), static_cast<u8>(101), static_cast<u8>(60), static_cast<u8>(84), static_cast<u8>(62), static_cast<u8>(32), static_cast<u8>(123), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(102), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(82), static_cast<u8>(97), static_cast<u8>(110), static_cast<u8>(103), static_cast<u8>(101), static_cast<u8>(60), static_cast<u8>(85), static_cast<u8>(62), static_cast<u8>(40), static_cast<u8>(97), static_cast<u8>(110), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(115), static_cast<u8>(116), static_cast<u8>(97), static_cast<u8>(114), static_cast<u8>(116), static_cast<u8>(58), static_cast<u8>(32), static_cast<u8>(85), static_cast<u8>(44), static_cast<u8>(32), static_cast<u8>(97), static_cast<u8>(110), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(101), static_cast<u8>(110), static_cast<u8>(100), static_cast<u8>(58), static_cast<u8>(32), static_cast<u8>(85), static_cast<u8>(41), static_cast<u8>(32), static_cast<u8>(45), static_cast<u8>(62), static_cast<u8>(32), static_cast<u8>(82), static_cast<u8>(97), static_cast<u8>(110), static_cast<u8>(103), static_cast<u8>(101), static_cast<u8>(60), static_cast<u8>(85), static_cast<u8>(62), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(102), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(110), static_cast<u8>(101), static_cast<u8>(120), static_cast<u8>(116), static_cast<u8>(40), static_cast<u8>(109), static_cast<u8>(117), static_cast<u8>(116), static_cast<u8>(32), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(105), static_cast<u8>(115), static_cast<u8>(41), static_cast<u8>(32), static_cast<u8>(45), static_cast<u8>(62), static_cast<u8>(32), static_cast<u8>(84), static_cast<u8>(63), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(102), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(105), static_cast<u8>(110), static_cast<u8>(99), static_cast<u8>(108), static_cast<u8>(117), static_cast<u8>(115), static_cast<u8>(105), static_cast<u8>(118), static_cast<u8>(101), static_cast<u8>(40), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(105), static_cast<u8>(115), static_cast<u8>(41), static_cast<u8>(32), static_cast<u8>(45), static_cast<u8>(62), static_cast<u8>(32), static_cast<u8>(82), static_cast<u8>(97), static_cast<u8>(110), static_cast<u8>(103), static_cast<u8>(101), static_cast<u8>(60), static_cast<u8>(84), static_cast<u8>(62), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(102), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(101), static_cast<u8>(120), static_cast<u8>(99), static_cast<u8>(108), static_cast<u8>(117), static_cast<u8>(115), static_cast<u8>(105), static_cast<u8>(118), static_cast<u8>(101), static_cast<u8>(40), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(105), static_cast<u8>(115), static_cast<u8>(41), static_cast<u8>(32), static_cast<u8>(45), static_cast<u8>(62), static_cast<u8>(32), static_cast<u8>(82), static_cast<u8>(97), static_cast<u8>(110), static_cast<u8>(103), static_cast<u8>(101), static_cast<u8>(60), static_cast<u8>(84), static_cast<u8>(62), static_cast<u8>(10), static_cast<u8>(125), static_cast<u8>(10), static_cast<u8>(10), static_cast<u8>(101), static_cast<u8>(120), static_cast<u8>(116), static_cast<u8>(101), static_cast<u8>(114), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(115), static_cast<u8>(116), static_cast<u8>(114), static_cast<u8>(117), static_cast<u8>(99), static_cast<u8>(116), static_cast<u8>(32), static_cast<u8>(83), static_cast<u8>(116), static_cast<u8>(114), static_cast<u8>(105), static_cast<u8>(110), static_cast<u8>(103), static_cast<u8>(86), static_cast<u8>(105), static_cast<u8>(101), static_cast<u8>(119), static_cast<u8>(32), static_cast<u8>(123), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(102), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(116), static_cast<u8>(111), static_cast<u8>(95), static_cast<u8>(115), static_cast<u8>(116), static_cast<u8>(114), static_cast<u8>(105), static_cast<u8>(110), static_cast<u8>(103), static_cast<u8>(40), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(105), static_cast<u8>(115), static_cast<u8>(41), static_cast<u8>(32), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(114), static_cast<u8>(111), static_cast<u8>(119), static_cast<u8>(115), static_cast<u8>(32), static_cast<u8>(45), static_cast<u8>(62), static_cast<u8>(32), static_cast<u8>(83), static_cast<u8>(116), static_cast<u8>(114), static_cast<u8>(105), static_cast<u8>(110), static_cast<u8>(103), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(102), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(108), static_cast<u8>(101), static_cast<u8>(110), static_cast<u8>(103), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(40), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(105), static_cast<u8>(115), static_cast<u8>(41), static_cast<u8>(32), static_cast<u8>(45), static_cast<u8>(62), static_cast<u8>(32), static_cast<u8>(117), static_cast<u8>(115), static_cast<u8>(105), static_cast<u8>(122), static_cast<u8>(101), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(91), static_cast<u8>(91), static_cast<u8>(110), static_cast<u8>(97), static_cast<u8>(109), static_cast<u8>(101), static_cast<u8>(61), static_cast<u8>(34), static_cast<u8>(111), static_cast<u8>(112), static_cast<u8>(101), static_cast<u8>(114), static_cast<u8>(97), static_cast<u8>(116), static_cast<u8>(111), static_cast<u8>(114), static_cast<u8>(91), static_cast<u8>(93), static_cast<u8>(34), static_cast<u8>(93), static_cast<u8>(93), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(102), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(98), static_cast<u8>(121), static_cast<u8>(116), static_cast<u8>(101), static_cast<u8>(95), static_cast<u8>(97), static_cast<u8>(116), static_cast<u8>(40), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(105), static_cast<u8>(115), static_cast<u8>(44), static_cast<u8>(32), static_cast<u8>(97), static_cast<u8>(110), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(105), static_cast<u8>(110), static_cast<u8>(100), static_cast<u8>(101), static_cast<u8>(120), static_cast<u8>(58), static_cast<u8>(32), static_cast<u8>(117), static_cast<u8>(115), static_cast<u8>(105), static_cast<u8>(122), static_cast<u8>(101), static_cast<u8>(41), static_cast<u8>(32), static_cast<u8>(45), static_cast<u8>(62), static_cast<u8>(32), static_cast<u8>(117), static_cast<u8>(56), static_cast<u8>(10), static_cast<u8>(125), static_cast<u8>(10), static_cast<u8>(10), static_cast<u8>(101), static_cast<u8>(120), static_cast<u8>(116), static_cast<u8>(101), static_cast<u8>(114), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(115), static_cast<u8>(116), static_cast<u8>(114), static_cast<u8>(117), static_cast<u8>(99), static_cast<u8>(116), static_cast<u8>(32), static_cast<u8>(69), static_cast<u8>(114), static_cast<u8>(114), static_cast<u8>(111), static_cast<u8>(114), static_cast<u8>(32), static_cast<u8>(123), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(102), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(99), static_cast<u8>(111), static_cast<u8>(100), static_cast<u8>(101), static_cast<u8>(40), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(105), static_cast<u8>(115), static_cast<u8>(41), static_cast<u8>(32), static_cast<u8>(45), static_cast<u8>(62), static_cast<u8>(32), static_cast<u8>(105), static_cast<u8>(51), static_cast<u8>(50), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(91), static_cast<u8>(91), static_cast<u8>(110), static_cast<u8>(97), static_cast<u8>(109), static_cast<u8>(101), static_cast<u8>(61), static_cast<u8>(115), static_cast<u8>(116), static_cast<u8>(114), static_cast<u8>(105), static_cast<u8>(110), static_cast<u8>(103), static_cast<u8>(95), static_cast<u8>(108), static_cast<u8>(105), static_cast<u8>(116), static_cast<u8>(101), static_cast<u8>(114), static_cast<u8>(97), static_cast<u8>(108), static_cast<u8>(93), static_cast<u8>(93), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(102), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(115), static_cast<u8>(116), static_cast<u8>(114), static_cast<u8>(105), static_cast<u8>(110), static_cast<u8>(103), static_cast<u8>(40), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(105), static_cast<u8>(115), static_cast<u8>(41), static_cast<u8>(32), static_cast<u8>(45), static_cast<u8>(62), static_cast<u8>(32), static_cast<u8>(83), static_cast<u8>(116), static_cast<u8>(114), static_cast<u8>(105), static_cast<u8>(110), static_cast<u8>(103), static_cast<u8>(86), static_cast<u8>(105), static_cast<u8>(101), static_cast<u8>(119), static_cast<u8>(10), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(102), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(102), static_cast<u8>(114), static_cast<u8>(111), static_cast<u8>(109), static_cast<u8>(95), static_cast<u8>(101), static_cast<u8>(114), static_cast<u8>(114), static_cast<u8>(110), static_cast<u8>(111), static_cast<u8>(40), static_cast<u8>(97), static_cast<u8>(110), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(101), static_cast<u8>(114), static_cast<u8>(114), static_cast<u8>(110), static_cast<u8>(111), static_cast<u8>(58), static_cast<u8>(32), static_cast<u8>(105), static_cast<u8>(51), static_cast<u8>(50), static_cast<u8>(41), static_cast<u8>(32), static_cast<u8>(45), static_cast<u8>(62), static_cast<u8>(32), static_cast<u8>(69), static_cast<u8>(114), static_cast<u8>(114), static_cast<u8>(111), static_cast<u8>(114), static_cast<u8>(10), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(91), static_cast<u8>(91), static_cast<u8>(110), static_cast<u8>(97), static_cast<u8>(109), static_cast<u8>(101), static_cast<u8>(61), static_cast<u8>(34), static_cast<u8>(95), static_cast<u8>(95), static_cast<u8>(106), static_cast<u8>(97), static_cast<u8>(107), static_cast<u8>(116), static_cast<u8>(95), static_cast<u8>(102), static_cast<u8>(114), static_cast<u8>(111), static_cast<u8>(109), static_cast<u8>(95), static_cast<u8>(115), static_cast<u8>(116), static_cast<u8>(114), static_cast<u8>(105), static_cast<u8>(110), static_cast<u8>(103), static_cast<u8>(95), static_cast<u8>(108), static_cast<u8>(105), static_cast<u8>(116), static_cast<u8>(101), static_cast<u8>(114), static_cast<u8>(97), static_cast<u8>(108), static_cast<u8>(34), static_cast<u8>(93), static_cast<u8>(93), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(102), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(102), static_cast<u8>(114), static_cast<u8>(111), static_cast<u8>(109), static_cast<u8>(95), static_cast<u8>(115), static_cast<u8>(116), static_cast<u8>(114), static_cast<u8>(105), static_cast<u8>(110), static_cast<u8>(103), static_cast<u8>(95), static_cast<u8>(108), static_cast<u8>(105), static_cast<u8>(116), static_cast<u8>(101), static_cast<u8>(114), static_cast<u8>(97), static_cast<u8>(108), static_cast<u8>(40), static_cast<u8>(97), static_cast<u8>(110), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(115), static_cast<u8>(116), static_cast<u8>(114), static_cast<u8>(105), static_cast<u8>(110), static_cast<u8>(103), static_cast<u8>(58), static_cast<u8>(32), static_cast<u8>(83), static_cast<u8>(116), static_cast<u8>(114), static_cast<u8>(105), static_cast<u8>(110), static_cast<u8>(103), static_cast<u8>(86), static_cast<u8>(105), static_cast<u8>(101), static_cast<u8>(119), static_cast<u8>(41), static_cast<u8>(32), static_cast<u8>(45), static_cast<u8>(62), static_cast<u8>(32), static_cast<u8>(69), static_cast<u8>(114), static_cast<u8>(114), static_cast<u8>(111), static_cast<u8>(114), static_cast<u8>(10), static_cast<u8>(125), static_cast<u8>(10), static_cast<u8>(10), static_cast<u8>(101), static_cast<u8>(120), static_cast<u8>(116), static_cast<u8>(101), static_cast<u8>(114), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(99), static_cast<u8>(108), static_cast<u8>(97), static_cast<u8>(115), static_cast<u8>(115), static_cast<u8>(32), static_cast<u8>(70), static_cast<u8>(105), static_cast<u8>(108), static_cast<u8>(101), static_cast<u8>(32), static_cast<u8>(123), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(112), static_cast<u8>(117), static_cast<u8>(98), static_cast<u8>(108), static_cast<u8>(105), static_cast<u8>(99), static_cast<u8>(32), static_cast<u8>(102), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(111), static_cast<u8>(112), static_cast<u8>(101), static_cast<u8>(110), static_cast<u8>(95), static_cast<u8>(102), static_cast<u8>(111), static_cast<u8>(114), static_cast<u8>(95), static_cast<u8>(114), static_cast<u8>(101), static_cast<u8>(97), static_cast<u8>(100), static_cast<u8>(105), static_cast<u8>(110), static_cast<u8>(103), static_cast<u8>(40), static_cast<u8>(97), static_cast<u8>(110), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(112), static_cast<u8>(97), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(58), static_cast<u8>(32), static_cast<u8>(83), static_cast<u8>(116), static_cast<u8>(114), static_cast<u8>(105), static_cast<u8>(110), static_cast<u8>(103), static_cast<u8>(41), static_cast<u8>(32), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(114), static_cast<u8>(111), static_cast<u8>(119), static_cast<u8>(115), static_cast<u8>(32), static_cast<u8>(45), static_cast<u8>(62), static_cast<u8>(32), static_cast<u8>(70), static_cast<u8>(105), static_cast<u8>(108), static_cast<u8>(101), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(112), static_cast<u8>(117), static_cast<u8>(98), static_cast<u8>(108), static_cast<u8>(105), static_cast<u8>(99), static_cast<u8>(32), static_cast<u8>(102), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(111), static_cast<u8>(112), static_cast<u8>(101), static_cast<u8>(110), static_cast<u8>(95), static_cast<u8>(102), static_cast<u8>(111), static_cast<u8>(114), static_cast<u8>(95), static_cast<u8>(119), static_cast<u8>(114), static_cast<u8>(105), static_cast<u8>(116), static_cast<u8>(105), static_cast<u8>(110), static_cast<u8>(103), static_cast<u8>(40), static_cast<u8>(97), static_cast<u8>(110), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(112), static_cast<u8>(97), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(58), static_cast<u8>(32), static_cast<u8>(83), static_cast<u8>(116), static_cast<u8>(114), static_cast<u8>(105), static_cast<u8>(110), static_cast<u8>(103), static_cast<u8>(41), static_cast<u8>(32), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(114), static_cast<u8>(111), static_cast<u8>(119), static_cast<u8>(115), static_cast<u8>(32), static_cast<u8>(45), static_cast<u8>(62), static_cast<u8>(32), static_cast<u8>(70), static_cast<u8>(105), static_cast<u8>(108), static_cast<u8>(101), static_cast<u8>(10), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(112), static_cast<u8>(117), static_cast<u8>(98), static_cast<u8>(108), static_cast<u8>(105), static_cast<u8>(99), static_cast<u8>(32), static_cast<u8>(102), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(114), static_cast<u8>(101), static_cast<u8>(97), static_cast<u8>(100), static_cast<u8>(40), static_cast<u8>(109), static_cast<u8>(117), static_cast<u8>(116), static_cast<u8>(32), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(105), static_cast<u8>(115), static_cast<u8>(44), static_cast<u8>(32), static_cast<u8>(97), static_cast<u8>(110), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(98), static_cast<u8>(117), static_cast<u8>(102), static_cast<u8>(102), static_cast<u8>(101), static_cast<u8>(114), static_cast<u8>(58), static_cast<u8>(32), static_cast<u8>(91), static_cast<u8>(117), static_cast<u8>(56), static_cast<u8>(93), static_cast<u8>(41), static_cast<u8>(32), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(114), static_cast<u8>(111), static_cast<u8>(119), static_cast<u8>(115), static_cast<u8>(32), static_cast<u8>(45), static_cast<u8>(62), static_cast<u8>(32), static_cast<u8>(117), static_cast<u8>(115), static_cast<u8>(105), static_cast<u8>(122), static_cast<u8>(101), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(112), static_cast<u8>(117), static_cast<u8>(98), static_cast<u8>(108), static_cast<u8>(105), static_cast<u8>(99), static_cast<u8>(32), static_cast<u8>(102), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(119), static_cast<u8>(114), static_cast<u8>(105), static_cast<u8>(116), static_cast<u8>(101), static_cast<u8>(40), static_cast<u8>(109), static_cast<u8>(117), static_cast<u8>(116), static_cast<u8>(32), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(105), static_cast<u8>(115), static_cast<u8>(44), static_cast<u8>(32), static_cast<u8>(97), static_cast<u8>(110), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(100), static_cast<u8>(97), static_cast<u8>(116), static_cast<u8>(97), static_cast<u8>(58), static_cast<u8>(32), static_cast<u8>(91), static_cast<u8>(117), static_cast<u8>(56), static_cast<u8>(93), static_cast<u8>(41), static_cast<u8>(32), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(114), static_cast<u8>(111), static_cast<u8>(119), static_cast<u8>(115), static_cast<u8>(32), static_cast<u8>(45), static_cast<u8>(62), static_cast<u8>(32), static_cast<u8>(117), static_cast<u8>(115), static_cast<u8>(105), static_cast<u8>(122), static_cast<u8>(101), static_cast<u8>(10), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(112), static_cast<u8>(117), static_cast<u8>(98), static_cast<u8>(108), static_cast<u8>(105), static_cast<u8>(99), static_cast<u8>(32), static_cast<u8>(102), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(114), static_cast<u8>(101), static_cast<u8>(97), static_cast<u8>(100), static_cast<u8>(95), static_cast<u8>(97), static_cast<u8>(108), static_cast<u8>(108), static_cast<u8>(40), static_cast<u8>(109), static_cast<u8>(117), static_cast<u8>(116), static_cast<u8>(32), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(105), static_cast<u8>(115), static_cast<u8>(41), static_cast<u8>(32), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(114), static_cast<u8>(111), static_cast<u8>(119), static_cast<u8>(115), static_cast<u8>(32), static_cast<u8>(45), static_cast<u8>(62), static_cast<u8>(32), static_cast<u8>(91), static_cast<u8>(117), static_cast<u8>(56), static_cast<u8>(93), static_cast<u8>(10), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(112), static_cast<u8>(117), static_cast<u8>(98), static_cast<u8>(108), static_cast<u8>(105), static_cast<u8>(99), static_cast<u8>(32), static_cast<u8>(102), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(101), static_cast<u8>(120), static_cast<u8>(105), static_cast<u8>(115), static_cast<u8>(116), static_cast<u8>(115), static_cast<u8>(40), static_cast<u8>(97), static_cast<u8>(110), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(112), static_cast<u8>(97), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(58), static_cast<u8>(32), static_cast<u8>(83), static_cast<u8>(116), static_cast<u8>(114), static_cast<u8>(105), static_cast<u8>(110), static_cast<u8>(103), static_cast<u8>(41), static_cast<u8>(32), static_cast<u8>(45), static_cast<u8>(62), static_cast<u8>(32), static_cast<u8>(98), static_cast<u8>(111), static_cast<u8>(111), static_cast<u8>(108), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(112), static_cast<u8>(117), static_cast<u8>(98), static_cast<u8>(108), static_cast<u8>(105), static_cast<u8>(99), static_cast<u8>(32), static_cast<u8>(102), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(99), static_cast<u8>(117), static_cast<u8>(114), static_cast<u8>(114), static_cast<u8>(101), static_cast<u8>(110), static_cast<u8>(116), static_cast<u8>(95), static_cast<u8>(101), static_cast<u8>(120), static_cast<u8>(101), static_cast<u8>(99), static_cast<u8>(117), static_cast<u8>(116), static_cast<u8>(97), static_cast<u8>(98), static_cast<u8>(108), static_cast<u8>(101), static_cast<u8>(95), static_cast<u8>(112), static_cast<u8>(97), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(40), static_cast<u8>(41), static_cast<u8>(32), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(114), static_cast<u8>(111), static_cast<u8>(119), static_cast<u8>(115), static_cast<u8>(32), static_cast<u8>(45), static_cast<u8>(62), static_cast<u8>(32), static_cast<u8>(83), static_cast<u8>(116), static_cast<u8>(114), static_cast<u8>(105), static_cast<u8>(110), static_cast<u8>(103), static_cast<u8>(10), static_cast<u8>(125), static_cast<u8>(10), static_cast<u8>(10), static_cast<u8>(101), static_cast<u8>(120), static_cast<u8>(116), static_cast<u8>(101), static_cast<u8>(114), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(102), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(95), static_cast<u8>(95), static_cast<u8>(95), static_cast<u8>(106), static_cast<u8>(97), static_cast<u8>(107), static_cast<u8>(116), static_cast<u8>(95), static_cast<u8>(103), static_cast<u8>(101), static_cast<u8>(116), static_cast<u8>(95), static_cast<u8>(116), static_cast<u8>(97), static_cast<u8>(114), static_cast<u8>(103), static_cast<u8>(101), static_cast<u8>(116), static_cast<u8>(95), static_cast<u8>(116), static_cast<u8>(114), static_cast<u8>(105), static_cast<u8>(112), static_cast<u8>(108), static_cast<u8>(101), static_cast<u8>(95), static_cast<u8>(115), static_cast<u8>(116), static_cast<u8>(114), static_cast<u8>(105), static_cast<u8>(110), static_cast<u8>(103), static_cast<u8>(40), static_cast<u8>(41), static_cast<u8>(32), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(114), static_cast<u8>(111), static_cast<u8>(119), static_cast<u8>(115), static_cast<u8>(32), static_cast<u8>(45), static_cast<u8>(62), static_cast<u8>(32), static_cast<u8>(83), static_cast<u8>(116), static_cast<u8>(114), static_cast<u8>(105), static_cast<u8>(110), static_cast<u8>(103), static_cast<u8>(10), static_cast<u8>(10), static_cast<u8>(101), static_cast<u8>(120), static_cast<u8>(116), static_cast<u8>(101), static_cast<u8>(114), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(102), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(97), static_cast<u8>(98), static_cast<u8>(111), static_cast<u8>(114), static_cast<u8>(116), static_cast<u8>(40), static_cast<u8>(41), static_cast<u8>(32), static_cast<u8>(45), static_cast<u8>(62), static_cast<u8>(32), static_cast<u8>(110), static_cast<u8>(101), static_cast<u8>(118), static_cast<u8>(101), static_cast<u8>(114), static_cast<u8>(10), static_cast<u8>(101), static_cast<u8>(120), static_cast<u8>(116), static_cast<u8>(101), static_cast<u8>(114), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(102), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(97), static_cast<u8>(115), static_cast<u8>(95), static_cast<u8>(115), static_cast<u8>(97), static_cast<u8>(116), static_cast<u8>(117), static_cast<u8>(114), static_cast<u8>(97), static_cast<u8>(116), static_cast<u8>(101), static_cast<u8>(100), static_cast<u8>(60), static_cast<u8>(85), static_cast<u8>(44), static_cast<u8>(32), static_cast<u8>(84), static_cast<u8>(62), static_cast<u8>(40), static_cast<u8>(97), static_cast<u8>(110), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(105), static_cast<u8>(110), static_cast<u8>(112), static_cast<u8>(117), static_cast<u8>(116), static_cast<u8>(58), static_cast<u8>(32), static_cast<u8>(84), static_cast<u8>(41), static_cast<u8>(32), static_cast<u8>(45), static_cast<u8>(62), static_cast<u8>(32), static_cast<u8>(85), static_cast<u8>(10), static_cast<u8>(101), static_cast<u8>(120), static_cast<u8>(116), static_cast<u8>(101), static_cast<u8>(114), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(102), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(97), static_cast<u8>(115), static_cast<u8>(95), static_cast<u8>(116), static_cast<u8>(114), static_cast<u8>(117), static_cast<u8>(110), static_cast<u8>(99), static_cast<u8>(97), static_cast<u8>(116), static_cast<u8>(101), static_cast<u8>(100), static_cast<u8>(60), static_cast<u8>(85), static_cast<u8>(44), static_cast<u8>(32), static_cast<u8>(84), static_cast<u8>(62), static_cast<u8>(40), static_cast<u8>(97), static_cast<u8>(110), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(105), static_cast<u8>(110), static_cast<u8>(112), static_cast<u8>(117), static_cast<u8>(116), static_cast<u8>(58), static_cast<u8>(32), static_cast<u8>(84), static_cast<u8>(41), static_cast<u8>(32), static_cast<u8>(45), static_cast<u8>(62), static_cast<u8>(32), static_cast<u8>(85), static_cast<u8>(10), static_cast<u8>(101), static_cast<u8>(120), static_cast<u8>(116), static_cast<u8>(101), static_cast<u8>(114), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(102), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(117), static_cast<u8>(110), static_cast<u8>(99), static_cast<u8>(104), static_cast<u8>(101), static_cast<u8>(99), static_cast<u8>(107), static_cast<u8>(101), static_cast<u8>(100), static_cast<u8>(95), static_cast<u8>(97), static_cast<u8>(100), static_cast<u8>(100), static_cast<u8>(60), static_cast<u8>(84), static_cast<u8>(62), static_cast<u8>(40), static_cast<u8>(97), static_cast<u8>(110), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(97), static_cast<u8>(58), static_cast<u8>(32), static_cast<u8>(84), static_cast<u8>(44), static_cast<u8>(32), static_cast<u8>(97), static_cast<u8>(110), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(98), static_cast<u8>(58), static_cast<u8>(32), static_cast<u8>(84), static_cast<u8>(41), static_cast<u8>(32), static_cast<u8>(45), static_cast<u8>(62), static_cast<u8>(32), static_cast<u8>(84), static_cast<u8>(10), static_cast<u8>(101), static_cast<u8>(120), static_cast<u8>(116), static_cast<u8>(101), static_cast<u8>(114), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(102), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(117), static_cast<u8>(110), static_cast<u8>(99), static_cast<u8>(104), static_cast<u8>(101), static_cast<u8>(99), static_cast<u8>(107), static_cast<u8>(101), static_cast<u8>(100), static_cast<u8>(95), static_cast<u8>(115), static_cast<u8>(117), static_cast<u8>(98), static_cast<u8>(60), static_cast<u8>(84), static_cast<u8>(62), static_cast<u8>(40), static_cast<u8>(97), static_cast<u8>(110), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(97), static_cast<u8>(58), static_cast<u8>(32), static_cast<u8>(84), static_cast<u8>(44), static_cast<u8>(32), static_cast<u8>(97), static_cast<u8>(110), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(98), static_cast<u8>(58), static_cast<u8>(32), static_cast<u8>(84), static_cast<u8>(41), static_cast<u8>(32), static_cast<u8>(45), static_cast<u8>(62), static_cast<u8>(32), static_cast<u8>(84), static_cast<u8>(10), static_cast<u8>(101), static_cast<u8>(120), static_cast<u8>(116), static_cast<u8>(101), static_cast<u8>(114), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(102), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(117), static_cast<u8>(110), static_cast<u8>(99), static_cast<u8>(104), static_cast<u8>(101), static_cast<u8>(99), static_cast<u8>(107), static_cast<u8>(101), static_cast<u8>(100), static_cast<u8>(95), static_cast<u8>(109), static_cast<u8>(117), static_cast<u8>(108), static_cast<u8>(60), static_cast<u8>(84), static_cast<u8>(62), static_cast<u8>(40), static_cast<u8>(97), static_cast<u8>(110), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(97), static_cast<u8>(58), static_cast<u8>(32), static_cast<u8>(84), static_cast<u8>(44), static_cast<u8>(32), static_cast<u8>(97), static_cast<u8>(110), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(98), static_cast<u8>(58), static_cast<u8>(32), static_cast<u8>(84), static_cast<u8>(41), static_cast<u8>(32), static_cast<u8>(45), static_cast<u8>(62), static_cast<u8>(32), static_cast<u8>(84), static_cast<u8>(10), static_cast<u8>(101), static_cast<u8>(120), static_cast<u8>(116), static_cast<u8>(101), static_cast<u8>(114), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(102), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(117), static_cast<u8>(110), static_cast<u8>(99), static_cast<u8>(104), static_cast<u8>(101), static_cast<u8>(99), static_cast<u8>(107), static_cast<u8>(101), static_cast<u8>(100), static_cast<u8>(95), static_cast<u8>(100), static_cast<u8>(105), static_cast<u8>(118), static_cast<u8>(60), static_cast<u8>(84), static_cast<u8>(62), static_cast<u8>(40), static_cast<u8>(97), static_cast<u8>(110), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(97), static_cast<u8>(58), static_cast<u8>(32), static_cast<u8>(84), static_cast<u8>(44), static_cast<u8>(32), static_cast<u8>(97), static_cast<u8>(110), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(98), static_cast<u8>(58), static_cast<u8>(32), static_cast<u8>(84), static_cast<u8>(41), static_cast<u8>(32), static_cast<u8>(45), static_cast<u8>(62), static_cast<u8>(32), static_cast<u8>(84), static_cast<u8>(10), static_cast<u8>(10), static_cast<u8>(110), static_cast<u8>(97), static_cast<u8>(109), static_cast<u8>(101), static_cast<u8>(115), static_cast<u8>(112), static_cast<u8>(97), static_cast<u8>(99), static_cast<u8>(101), static_cast<u8>(32), static_cast<u8>(82), static_cast<u8>(101), static_cast<u8>(102), static_cast<u8>(108), static_cast<u8>(101), static_cast<u8>(99), static_cast<u8>(116), static_cast<u8>(32), static_cast<u8>(123), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(115), static_cast<u8>(116), static_cast<u8>(114), static_cast<u8>(117), static_cast<u8>(99), static_cast<u8>(116), static_cast<u8>(32), static_cast<u8>(83), static_cast<u8>(112), static_cast<u8>(97), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(123), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(115), static_cast<u8>(116), static_cast<u8>(97), static_cast<u8>(114), static_cast<u8>(116), static_cast<u8>(58), static_cast<u8>(32), static_cast<u8>(117), static_cast<u8>(115), static_cast<u8>(105), static_cast<u8>(122), static_cast<u8>(101), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(101), static_cast<u8>(110), static_cast<u8>(100), static_cast<u8>(58), static_cast<u8>(32), static_cast<u8>(117), static_cast<u8>(115), static_cast<u8>(105), static_cast<u8>(122), static_cast<u8>(101), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(102), static_cast<u8>(105), static_cast<u8>(108), static_cast<u8>(101), static_cast<u8>(58), static_cast<u8>(32), static_cast<u8>(83), static_cast<u8>(116), static_cast<u8>(114), static_cast<u8>(105), static_cast<u8>(110), static_cast<u8>(103), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(125), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(101), static_cast<u8>(110), static_cast<u8>(117), static_cast<u8>(109), static_cast<u8>(32), static_cast<u8>(86), static_cast<u8>(105), static_cast<u8>(115), static_cast<u8>(105), static_cast<u8>(98), static_cast<u8>(105), static_cast<u8>(108), static_cast<u8>(105), static_cast<u8>(116), static_cast<u8>(121), static_cast<u8>(32), static_cast<u8>(123), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(80), static_cast<u8>(117), static_cast<u8>(98), static_cast<u8>(108), static_cast<u8>(105), static_cast<u8>(99), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(80), static_cast<u8>(114), static_cast<u8>(105), static_cast<u8>(118), static_cast<u8>(97), static_cast<u8>(116), static_cast<u8>(101), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(47), static_cast<u8>(47), static_cast<u8>(32), static_cast<u8>(82), static_cast<u8>(101), static_cast<u8>(115), static_cast<u8>(116), static_cast<u8>(114), static_cast<u8>(105), static_cast<u8>(99), static_cast<u8>(116), static_cast<u8>(101), static_cast<u8>(100), static_cast<u8>(40), static_cast<u8>(119), static_cast<u8>(104), static_cast<u8>(105), static_cast<u8>(116), static_cast<u8>(101), static_cast<u8>(108), static_cast<u8>(105), static_cast<u8>(115), static_cast<u8>(116), static_cast<u8>(58), static_cast<u8>(32), static_cast<u8>(91), static_cast<u8>(82), static_cast<u8>(101), static_cast<u8>(102), static_cast<u8>(108), static_cast<u8>(101), static_cast<u8>(99), static_cast<u8>(116), static_cast<u8>(58), static_cast<u8>(58), static_cast<u8>(84), static_cast<u8>(121), static_cast<u8>(112), static_cast<u8>(101), static_cast<u8>(93), static_cast<u8>(41), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(125), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(115), static_cast<u8>(116), static_cast<u8>(114), static_cast<u8>(117), static_cast<u8>(99), static_cast<u8>(116), static_cast<u8>(32), static_cast<u8>(86), static_cast<u8>(97), static_cast<u8>(114), static_cast<u8>(105), static_cast<u8>(97), static_cast<u8>(98), static_cast<u8>(108), static_cast<u8>(101), static_cast<u8>(68), static_cast<u8>(101), static_cast<u8>(99), static_cast<u8>(108), static_cast<u8>(97), static_cast<u8>(114), static_cast<u8>(97), static_cast<u8>(116), static_cast<u8>(105), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(123), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(110), static_cast<u8>(97), static_cast<u8>(109), static_cast<u8>(101), static_cast<u8>(58), static_cast<u8>(32), static_cast<u8>(83), static_cast<u8>(116), static_cast<u8>(114), static_cast<u8>(105), static_cast<u8>(110), static_cast<u8>(103), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(116), static_cast<u8>(121), static_cast<u8>(112), static_cast<u8>(101), static_cast<u8>(58), static_cast<u8>(32), static_cast<u8>(82), static_cast<u8>(101), static_cast<u8>(102), static_cast<u8>(108), static_cast<u8>(101), static_cast<u8>(99), static_cast<u8>(116), static_cast<u8>(58), static_cast<u8>(58), static_cast<u8>(84), static_cast<u8>(121), static_cast<u8>(112), static_cast<u8>(101), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(105), static_cast<u8>(115), static_cast<u8>(95), static_cast<u8>(109), static_cast<u8>(117), static_cast<u8>(116), static_cast<u8>(97), static_cast<u8>(98), static_cast<u8>(108), static_cast<u8>(101), static_cast<u8>(58), static_cast<u8>(32), static_cast<u8>(98), static_cast<u8>(111), static_cast<u8>(111), static_cast<u8>(108), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(125), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(115), static_cast<u8>(116), static_cast<u8>(114), static_cast<u8>(117), static_cast<u8>(99), static_cast<u8>(116), static_cast<u8>(32), static_cast<u8>(70), static_cast<u8>(105), static_cast<u8>(101), static_cast<u8>(108), static_cast<u8>(100), static_cast<u8>(32), static_cast<u8>(123), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(118), static_cast<u8>(97), static_cast<u8>(114), static_cast<u8>(105), static_cast<u8>(97), static_cast<u8>(98), static_cast<u8>(108), static_cast<u8>(101), static_cast<u8>(58), static_cast<u8>(32), static_cast<u8>(82), static_cast<u8>(101), static_cast<u8>(102), static_cast<u8>(108), static_cast<u8>(101), static_cast<u8>(99), static_cast<u8>(116), static_cast<u8>(58), static_cast<u8>(58), static_cast<u8>(86), static_cast<u8>(97), static_cast<u8>(114), static_cast<u8>(105), static_cast<u8>(97), static_cast<u8>(98), static_cast<u8>(108), static_cast<u8>(101), static_cast<u8>(68), static_cast<u8>(101), static_cast<u8>(99), static_cast<u8>(108), static_cast<u8>(97), static_cast<u8>(114), static_cast<u8>(97), static_cast<u8>(116), static_cast<u8>(105), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(118), static_cast<u8>(105), static_cast<u8>(115), static_cast<u8>(105), static_cast<u8>(98), static_cast<u8>(105), static_cast<u8>(108), static_cast<u8>(105), static_cast<u8>(116), static_cast<u8>(121), static_cast<u8>(58), static_cast<u8>(32), static_cast<u8>(82), static_cast<u8>(101), static_cast<u8>(102), static_cast<u8>(108), static_cast<u8>(101), static_cast<u8>(99), static_cast<u8>(116), static_cast<u8>(58), static_cast<u8>(58), static_cast<u8>(86), static_cast<u8>(105), static_cast<u8>(115), static_cast<u8>(105), static_cast<u8>(98), static_cast<u8>(105), static_cast<u8>(108), static_cast<u8>(105), static_cast<u8>(116), static_cast<u8>(121), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(47), static_cast<u8>(47), static_cast<u8>(32), static_cast<u8>(99), static_cast<u8>(111), static_cast<u8>(109), static_cast<u8>(112), static_cast<u8>(116), static_cast<u8>(105), static_cast<u8>(109), static_cast<u8>(101), static_cast<u8>(32), static_cast<u8>(115), static_cast<u8>(101), static_cast<u8>(116), static_cast<u8>(116), static_cast<u8>(101), static_cast<u8>(114), static_cast<u8>(60), static_cast<u8>(84), static_cast<u8>(44), static_cast<u8>(32), static_cast<u8>(85), static_cast<u8>(62), static_cast<u8>(40), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(105), static_cast<u8>(115), static_cast<u8>(41), static_cast<u8>(32), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(114), static_cast<u8>(111), static_cast<u8>(119), static_cast<u8>(115), static_cast<u8>(32), static_cast<u8>(123), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(47), static_cast<u8>(47), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(108), static_cast<u8>(101), static_cast<u8>(116), static_cast<u8>(32), static_cast<u8>(110), static_cast<u8>(97), static_cast<u8>(109), static_cast<u8>(101), static_cast<u8>(32), static_cast<u8>(61), static_cast<u8>(32), static_cast<u8>(46), static_cast<u8>(118), static_cast<u8>(97), static_cast<u8>(114), static_cast<u8>(105), static_cast<u8>(97), static_cast<u8>(98), static_cast<u8>(108), static_cast<u8>(101), static_cast<u8>(46), static_cast<u8>(110), static_cast<u8>(97), static_cast<u8>(109), static_cast<u8>(101), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(47), static_cast<u8>(47), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(114), static_cast<u8>(101), static_cast<u8>(116), static_cast<u8>(117), static_cast<u8>(114), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(102), static_cast<u8>(110), static_cast<u8>(91), static_cast<u8>(110), static_cast<u8>(97), static_cast<u8>(109), static_cast<u8>(101), static_cast<u8>(93), static_cast<u8>(40), static_cast<u8>(97), static_cast<u8>(110), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(115), static_cast<u8>(58), static_cast<u8>(32), static_cast<u8>(38), static_cast<u8>(109), static_cast<u8>(117), static_cast<u8>(116), static_cast<u8>(32), static_cast<u8>(84), static_cast<u8>(44), static_cast<u8>(32), static_cast<u8>(97), static_cast<u8>(110), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(118), static_cast<u8>(97), static_cast<u8>(108), static_cast<u8>(117), static_cast<u8>(101), static_cast<u8>(58), static_cast<u8>(32), static_cast<u8>(85), static_cast<u8>(41), static_cast<u8>(32), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(114), static_cast<u8>(111), static_cast<u8>(119), static_cast<u8>(115), static_cast<u8>(32), static_cast<u8>(123), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(47), static_cast<u8>(47), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(82), static_cast<u8>(101), static_cast<u8>(102), static_cast<u8>(108), static_cast<u8>(101), static_cast<u8>(99), static_cast<u8>(116), static_cast<u8>(58), static_cast<u8>(58), static_cast<u8>(73), static_cast<u8>(110), static_cast<u8>(116), static_cast<u8>(101), static_cast<u8>(114), static_cast<u8>(110), static_cast<u8>(97), static_cast<u8>(108), static_cast<u8>(58), static_cast<u8>(58), static_cast<u8>(115), static_cast<u8>(101), static_cast<u8>(116), static_cast<u8>(95), static_cast<u8>(102), static_cast<u8>(105), static_cast<u8>(101), static_cast<u8>(108), static_cast<u8>(100), static_cast<u8>(40), static_cast<u8>(110), static_cast<u8>(97), static_cast<u8>(109), static_cast<u8>(101), static_cast<u8>(44), static_cast<u8>(32), static_cast<u8>(115), static_cast<u8>(44), static_cast<u8>(32), static_cast<u8>(118), static_cast<u8>(97), static_cast<u8>(108), static_cast<u8>(117), static_cast<u8>(101), static_cast<u8>(41), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(47), static_cast<u8>(47), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(125), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(47), static_cast<u8>(47), static_cast<u8>(32), static_cast<u8>(125), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(125), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(115), static_cast<u8>(116), static_cast<u8>(114), static_cast<u8>(117), static_cast<u8>(99), static_cast<u8>(116), static_cast<u8>(32), static_cast<u8>(77), static_cast<u8>(101), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(111), static_cast<u8>(100), static_cast<u8>(32), static_cast<u8>(123), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(102), static_cast<u8>(117), static_cast<u8>(110), static_cast<u8>(99), static_cast<u8>(116), static_cast<u8>(105), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(58), static_cast<u8>(32), static_cast<u8>(82), static_cast<u8>(101), static_cast<u8>(102), static_cast<u8>(108), static_cast<u8>(101), static_cast<u8>(99), static_cast<u8>(116), static_cast<u8>(58), static_cast<u8>(58), static_cast<u8>(70), static_cast<u8>(117), static_cast<u8>(110), static_cast<u8>(99), static_cast<u8>(116), static_cast<u8>(105), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(118), static_cast<u8>(105), static_cast<u8>(115), static_cast<u8>(105), static_cast<u8>(98), static_cast<u8>(105), static_cast<u8>(108), static_cast<u8>(105), static_cast<u8>(116), static_cast<u8>(121), static_cast<u8>(58), static_cast<u8>(32), static_cast<u8>(82), static_cast<u8>(101), static_cast<u8>(102), static_cast<u8>(108), static_cast<u8>(101), static_cast<u8>(99), static_cast<u8>(116), static_cast<u8>(58), static_cast<u8>(58), static_cast<u8>(86), static_cast<u8>(105), static_cast<u8>(115), static_cast<u8>(105), static_cast<u8>(98), static_cast<u8>(105), static_cast<u8>(108), static_cast<u8>(105), static_cast<u8>(116), static_cast<u8>(121), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(125), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(115), static_cast<u8>(116), static_cast<u8>(114), static_cast<u8>(117), static_cast<u8>(99), static_cast<u8>(116), static_cast<u8>(32), static_cast<u8>(70), static_cast<u8>(117), static_cast<u8>(110), static_cast<u8>(99), static_cast<u8>(116), static_cast<u8>(105), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(123), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(110), static_cast<u8>(97), static_cast<u8>(109), static_cast<u8>(101), static_cast<u8>(58), static_cast<u8>(32), static_cast<u8>(83), static_cast<u8>(116), static_cast<u8>(114), static_cast<u8>(105), static_cast<u8>(110), static_cast<u8>(103), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(47), static_cast<u8>(47), static_cast<u8>(32), static_cast<u8>(112), static_cast<u8>(97), static_cast<u8>(114), static_cast<u8>(97), static_cast<u8>(109), static_cast<u8>(101), static_cast<u8>(116), static_cast<u8>(101), static_cast<u8>(114), static_cast<u8>(115), static_cast<u8>(58), static_cast<u8>(32), static_cast<u8>(91), static_cast<u8>(82), static_cast<u8>(101), static_cast<u8>(102), static_cast<u8>(108), static_cast<u8>(101), static_cast<u8>(99), static_cast<u8>(116), static_cast<u8>(58), static_cast<u8>(58), static_cast<u8>(80), static_cast<u8>(97), static_cast<u8>(114), static_cast<u8>(97), static_cast<u8>(109), static_cast<u8>(101), static_cast<u8>(116), static_cast<u8>(101), static_cast<u8>(114), static_cast<u8>(93), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(103), static_cast<u8>(101), static_cast<u8>(110), static_cast<u8>(101), static_cast<u8>(114), static_cast<u8>(105), static_cast<u8>(99), static_cast<u8>(95), static_cast<u8>(112), static_cast<u8>(97), static_cast<u8>(114), static_cast<u8>(97), static_cast<u8>(109), static_cast<u8>(101), static_cast<u8>(116), static_cast<u8>(101), static_cast<u8>(114), static_cast<u8>(115), static_cast<u8>(58), static_cast<u8>(32), static_cast<u8>(91), static_cast<u8>(83), static_cast<u8>(116), static_cast<u8>(114), static_cast<u8>(105), static_cast<u8>(110), static_cast<u8>(103), static_cast<u8>(93), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(47), static_cast<u8>(47), static_cast<u8>(32), static_cast<u8>(98), static_cast<u8>(108), static_cast<u8>(111), static_cast<u8>(99), static_cast<u8>(107), static_cast<u8>(58), static_cast<u8>(32), static_cast<u8>(82), static_cast<u8>(101), static_cast<u8>(102), static_cast<u8>(108), static_cast<u8>(101), static_cast<u8>(99), static_cast<u8>(116), static_cast<u8>(58), static_cast<u8>(58), static_cast<u8>(66), static_cast<u8>(108), static_cast<u8>(111), static_cast<u8>(99), static_cast<u8>(107), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(114), static_cast<u8>(101), static_cast<u8>(116), static_cast<u8>(117), static_cast<u8>(114), static_cast<u8>(110), static_cast<u8>(95), static_cast<u8>(116), static_cast<u8>(121), static_cast<u8>(112), static_cast<u8>(101), static_cast<u8>(58), static_cast<u8>(32), static_cast<u8>(82), static_cast<u8>(101), static_cast<u8>(102), static_cast<u8>(108), static_cast<u8>(101), static_cast<u8>(99), static_cast<u8>(116), static_cast<u8>(58), static_cast<u8>(58), static_cast<u8>(84), static_cast<u8>(121), static_cast<u8>(112), static_cast<u8>(101), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(99), static_cast<u8>(97), static_cast<u8>(110), static_cast<u8>(95), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(114), static_cast<u8>(111), static_cast<u8>(119), static_cast<u8>(58), static_cast<u8>(32), static_cast<u8>(98), static_cast<u8>(111), static_cast<u8>(111), static_cast<u8>(108), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(105), static_cast<u8>(115), static_cast<u8>(95), static_cast<u8>(99), static_cast<u8>(111), static_cast<u8>(109), static_cast<u8>(112), static_cast<u8>(116), static_cast<u8>(105), static_cast<u8>(109), static_cast<u8>(101), static_cast<u8>(58), static_cast<u8>(32), static_cast<u8>(98), static_cast<u8>(111), static_cast<u8>(111), static_cast<u8>(108), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(125), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(101), static_cast<u8>(110), static_cast<u8>(117), static_cast<u8>(109), static_cast<u8>(32), static_cast<u8>(83), static_cast<u8>(117), static_cast<u8>(109), static_cast<u8>(69), static_cast<u8>(110), static_cast<u8>(117), static_cast<u8>(109), static_cast<u8>(86), static_cast<u8>(97), static_cast<u8>(114), static_cast<u8>(105), static_cast<u8>(97), static_cast<u8>(110), static_cast<u8>(116), static_cast<u8>(32), static_cast<u8>(123), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(83), static_cast<u8>(116), static_cast<u8>(114), static_cast<u8>(117), static_cast<u8>(99), static_cast<u8>(116), static_cast<u8>(76), static_cast<u8>(105), static_cast<u8>(107), static_cast<u8>(101), static_cast<u8>(40), static_cast<u8>(110), static_cast<u8>(97), static_cast<u8>(109), static_cast<u8>(101), static_cast<u8>(58), static_cast<u8>(32), static_cast<u8>(83), static_cast<u8>(116), static_cast<u8>(114), static_cast<u8>(105), static_cast<u8>(110), static_cast<u8>(103), static_cast<u8>(44), static_cast<u8>(32), static_cast<u8>(102), static_cast<u8>(105), static_cast<u8>(101), static_cast<u8>(108), static_cast<u8>(100), static_cast<u8>(115), static_cast<u8>(58), static_cast<u8>(32), static_cast<u8>(91), static_cast<u8>(82), static_cast<u8>(101), static_cast<u8>(102), static_cast<u8>(108), static_cast<u8>(101), static_cast<u8>(99), static_cast<u8>(116), static_cast<u8>(58), static_cast<u8>(58), static_cast<u8>(70), static_cast<u8>(105), static_cast<u8>(101), static_cast<u8>(108), static_cast<u8>(100), static_cast<u8>(93), static_cast<u8>(41), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(84), static_cast<u8>(121), static_cast<u8>(112), static_cast<u8>(101), static_cast<u8>(100), static_cast<u8>(40), static_cast<u8>(110), static_cast<u8>(97), static_cast<u8>(109), static_cast<u8>(101), static_cast<u8>(58), static_cast<u8>(32), static_cast<u8>(83), static_cast<u8>(116), static_cast<u8>(114), static_cast<u8>(105), static_cast<u8>(110), static_cast<u8>(103), static_cast<u8>(44), static_cast<u8>(32), static_cast<u8>(116), static_cast<u8>(121), static_cast<u8>(112), static_cast<u8>(101), static_cast<u8>(58), static_cast<u8>(32), static_cast<u8>(82), static_cast<u8>(101), static_cast<u8>(102), static_cast<u8>(108), static_cast<u8>(101), static_cast<u8>(99), static_cast<u8>(116), static_cast<u8>(58), static_cast<u8>(58), static_cast<u8>(84), static_cast<u8>(121), static_cast<u8>(112), static_cast<u8>(101), static_cast<u8>(41), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(85), static_cast<u8>(110), static_cast<u8>(116), static_cast<u8>(121), static_cast<u8>(112), static_cast<u8>(101), static_cast<u8>(100), static_cast<u8>(40), static_cast<u8>(110), static_cast<u8>(97), static_cast<u8>(109), static_cast<u8>(101), static_cast<u8>(58), static_cast<u8>(32), static_cast<u8>(83), static_cast<u8>(116), static_cast<u8>(114), static_cast<u8>(105), static_cast<u8>(110), static_cast<u8>(103), static_cast<u8>(41), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(125), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(101), static_cast<u8>(110), static_cast<u8>(117), static_cast<u8>(109), static_cast<u8>(32), static_cast<u8>(82), static_cast<u8>(101), static_cast<u8>(99), static_cast<u8>(111), static_cast<u8>(114), static_cast<u8>(100), static_cast<u8>(84), static_cast<u8>(121), static_cast<u8>(112), static_cast<u8>(101), static_cast<u8>(32), static_cast<u8>(123), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(83), static_cast<u8>(116), static_cast<u8>(114), static_cast<u8>(117), static_cast<u8>(99), static_cast<u8>(116), static_cast<u8>(40), static_cast<u8>(102), static_cast<u8>(105), static_cast<u8>(101), static_cast<u8>(108), static_cast<u8>(100), static_cast<u8>(115), static_cast<u8>(58), static_cast<u8>(32), static_cast<u8>(91), static_cast<u8>(82), static_cast<u8>(101), static_cast<u8>(102), static_cast<u8>(108), static_cast<u8>(101), static_cast<u8>(99), static_cast<u8>(116), static_cast<u8>(58), static_cast<u8>(58), static_cast<u8>(70), static_cast<u8>(105), static_cast<u8>(101), static_cast<u8>(108), static_cast<u8>(100), static_cast<u8>(93), static_cast<u8>(41), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(67), static_cast<u8>(108), static_cast<u8>(97), static_cast<u8>(115), static_cast<u8>(115), static_cast<u8>(40), static_cast<u8>(102), static_cast<u8>(105), static_cast<u8>(101), static_cast<u8>(108), static_cast<u8>(100), static_cast<u8>(115), static_cast<u8>(58), static_cast<u8>(32), static_cast<u8>(91), static_cast<u8>(82), static_cast<u8>(101), static_cast<u8>(102), static_cast<u8>(108), static_cast<u8>(101), static_cast<u8>(99), static_cast<u8>(116), static_cast<u8>(58), static_cast<u8>(58), static_cast<u8>(70), static_cast<u8>(105), static_cast<u8>(101), static_cast<u8>(108), static_cast<u8>(100), static_cast<u8>(93), static_cast<u8>(41), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(47), static_cast<u8>(47), static_cast<u8>(32), static_cast<u8>(86), static_cast<u8>(97), static_cast<u8>(108), static_cast<u8>(117), static_cast<u8>(101), static_cast<u8>(69), static_cast<u8>(110), static_cast<u8>(117), static_cast<u8>(109), static_cast<u8>(40), static_cast<u8>(117), static_cast<u8>(110), static_cast<u8>(100), static_cast<u8>(101), static_cast<u8>(114), static_cast<u8>(108), static_cast<u8>(121), static_cast<u8>(105), static_cast<u8>(110), static_cast<u8>(103), static_cast<u8>(95), static_cast<u8>(116), static_cast<u8>(121), static_cast<u8>(112), static_cast<u8>(101), static_cast<u8>(58), static_cast<u8>(32), static_cast<u8>(82), static_cast<u8>(101), static_cast<u8>(102), static_cast<u8>(108), static_cast<u8>(101), static_cast<u8>(99), static_cast<u8>(116), static_cast<u8>(58), static_cast<u8>(58), static_cast<u8>(84), static_cast<u8>(121), static_cast<u8>(112), static_cast<u8>(101), static_cast<u8>(44), static_cast<u8>(32), static_cast<u8>(118), static_cast<u8>(97), static_cast<u8>(114), static_cast<u8>(105), static_cast<u8>(97), static_cast<u8>(110), static_cast<u8>(116), static_cast<u8>(115), static_cast<u8>(58), static_cast<u8>(32), static_cast<u8>(91), static_cast<u8>(82), static_cast<u8>(101), static_cast<u8>(102), static_cast<u8>(108), static_cast<u8>(101), static_cast<u8>(99), static_cast<u8>(116), static_cast<u8>(58), static_cast<u8>(58), static_cast<u8>(86), static_cast<u8>(97), static_cast<u8>(108), static_cast<u8>(117), static_cast<u8>(101), static_cast<u8>(69), static_cast<u8>(110), static_cast<u8>(117), static_cast<u8>(109), static_cast<u8>(86), static_cast<u8>(97), static_cast<u8>(114), static_cast<u8>(105), static_cast<u8>(97), static_cast<u8>(110), static_cast<u8>(116), static_cast<u8>(93), static_cast<u8>(41), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(83), static_cast<u8>(117), static_cast<u8>(109), static_cast<u8>(69), static_cast<u8>(110), static_cast<u8>(117), static_cast<u8>(109), static_cast<u8>(40), static_cast<u8>(105), static_cast<u8>(115), static_cast<u8>(95), static_cast<u8>(98), static_cast<u8>(111), static_cast<u8>(120), static_cast<u8>(101), static_cast<u8>(100), static_cast<u8>(58), static_cast<u8>(32), static_cast<u8>(98), static_cast<u8>(111), static_cast<u8>(111), static_cast<u8>(108), static_cast<u8>(44), static_cast<u8>(32), static_cast<u8>(118), static_cast<u8>(97), static_cast<u8>(114), static_cast<u8>(105), static_cast<u8>(97), static_cast<u8>(110), static_cast<u8>(116), static_cast<u8>(115), static_cast<u8>(58), static_cast<u8>(32), static_cast<u8>(91), static_cast<u8>(82), static_cast<u8>(101), static_cast<u8>(102), static_cast<u8>(108), static_cast<u8>(101), static_cast<u8>(99), static_cast<u8>(116), static_cast<u8>(58), static_cast<u8>(58), static_cast<u8>(83), static_cast<u8>(117), static_cast<u8>(109), static_cast<u8>(69), static_cast<u8>(110), static_cast<u8>(117), static_cast<u8>(109), static_cast<u8>(86), static_cast<u8>(97), static_cast<u8>(114), static_cast<u8>(105), static_cast<u8>(97), static_cast<u8>(110), static_cast<u8>(116), static_cast<u8>(93), static_cast<u8>(41), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(125), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(115), static_cast<u8>(116), static_cast<u8>(114), static_cast<u8>(117), static_cast<u8>(99), static_cast<u8>(116), static_cast<u8>(32), static_cast<u8>(82), static_cast<u8>(101), static_cast<u8>(99), static_cast<u8>(111), static_cast<u8>(114), static_cast<u8>(100), static_cast<u8>(32), static_cast<u8>(123), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(110), static_cast<u8>(97), static_cast<u8>(109), static_cast<u8>(101), static_cast<u8>(58), static_cast<u8>(32), static_cast<u8>(83), static_cast<u8>(116), static_cast<u8>(114), static_cast<u8>(105), static_cast<u8>(110), static_cast<u8>(103), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(109), static_cast<u8>(101), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(111), static_cast<u8>(100), static_cast<u8>(115), static_cast<u8>(58), static_cast<u8>(32), static_cast<u8>(91), static_cast<u8>(82), static_cast<u8>(101), static_cast<u8>(102), static_cast<u8>(108), static_cast<u8>(101), static_cast<u8>(99), static_cast<u8>(116), static_cast<u8>(58), static_cast<u8>(58), static_cast<u8>(77), static_cast<u8>(101), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(111), static_cast<u8>(100), static_cast<u8>(93), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(103), static_cast<u8>(101), static_cast<u8>(110), static_cast<u8>(101), static_cast<u8>(114), static_cast<u8>(105), static_cast<u8>(99), static_cast<u8>(95), static_cast<u8>(109), static_cast<u8>(97), static_cast<u8>(112), static_cast<u8>(112), static_cast<u8>(105), static_cast<u8>(110), static_cast<u8>(103), static_cast<u8>(115), static_cast<u8>(58), static_cast<u8>(32), static_cast<u8>(91), static_cast<u8>(40), static_cast<u8>(83), static_cast<u8>(116), static_cast<u8>(114), static_cast<u8>(105), static_cast<u8>(110), static_cast<u8>(103), static_cast<u8>(44), static_cast<u8>(32), static_cast<u8>(82), static_cast<u8>(101), static_cast<u8>(102), static_cast<u8>(108), static_cast<u8>(101), static_cast<u8>(99), static_cast<u8>(116), static_cast<u8>(58), static_cast<u8>(58), static_cast<u8>(84), static_cast<u8>(121), static_cast<u8>(112), static_cast<u8>(101), static_cast<u8>(41), static_cast<u8>(93), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(114), static_cast<u8>(101), static_cast<u8>(99), static_cast<u8>(111), static_cast<u8>(114), static_cast<u8>(100), static_cast<u8>(95), static_cast<u8>(116), static_cast<u8>(121), static_cast<u8>(112), static_cast<u8>(101), static_cast<u8>(58), static_cast<u8>(32), static_cast<u8>(82), static_cast<u8>(101), static_cast<u8>(102), static_cast<u8>(108), static_cast<u8>(101), static_cast<u8>(99), static_cast<u8>(116), static_cast<u8>(58), static_cast<u8>(58), static_cast<u8>(82), static_cast<u8>(101), static_cast<u8>(99), static_cast<u8>(111), static_cast<u8>(114), static_cast<u8>(100), static_cast<u8>(84), static_cast<u8>(121), static_cast<u8>(112), static_cast<u8>(101), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(125), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(98), static_cast<u8>(111), static_cast<u8>(120), static_cast<u8>(101), static_cast<u8>(100), static_cast<u8>(32), static_cast<u8>(101), static_cast<u8>(110), static_cast<u8>(117), static_cast<u8>(109), static_cast<u8>(32), static_cast<u8>(84), static_cast<u8>(121), static_cast<u8>(112), static_cast<u8>(101), static_cast<u8>(32), static_cast<u8>(123), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(86), static_cast<u8>(111), static_cast<u8>(105), static_cast<u8>(100), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(66), static_cast<u8>(111), static_cast<u8>(111), static_cast<u8>(108), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(85), static_cast<u8>(56), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(85), static_cast<u8>(49), static_cast<u8>(54), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(85), static_cast<u8>(51), static_cast<u8>(50), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(85), static_cast<u8>(54), static_cast<u8>(52), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(73), static_cast<u8>(56), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(73), static_cast<u8>(49), static_cast<u8>(54), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(73), static_cast<u8>(51), static_cast<u8>(50), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(73), static_cast<u8>(54), static_cast<u8>(52), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(70), static_cast<u8>(51), static_cast<u8>(50), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(70), static_cast<u8>(54), static_cast<u8>(52), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(85), static_cast<u8>(115), static_cast<u8>(105), static_cast<u8>(122), static_cast<u8>(101), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(74), static_cast<u8>(97), static_cast<u8>(107), static_cast<u8>(116), static_cast<u8>(83), static_cast<u8>(116), static_cast<u8>(114), static_cast<u8>(105), static_cast<u8>(110), static_cast<u8>(103), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(67), static_cast<u8>(67), static_cast<u8>(104), static_cast<u8>(97), static_cast<u8>(114), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(67), static_cast<u8>(73), static_cast<u8>(110), static_cast<u8>(116), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(85), static_cast<u8>(110), static_cast<u8>(107), static_cast<u8>(110), static_cast<u8>(111), static_cast<u8>(119), static_cast<u8>(110), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(78), static_cast<u8>(101), static_cast<u8>(118), static_cast<u8>(101), static_cast<u8>(114), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(83), static_cast<u8>(116), static_cast<u8>(114), static_cast<u8>(117), static_cast<u8>(99), static_cast<u8>(116), static_cast<u8>(117), static_cast<u8>(114), static_cast<u8>(101), static_cast<u8>(79), static_cast<u8>(114), static_cast<u8>(69), static_cast<u8>(110), static_cast<u8>(117), static_cast<u8>(109), static_cast<u8>(40), static_cast<u8>(82), static_cast<u8>(101), static_cast<u8>(102), static_cast<u8>(108), static_cast<u8>(101), static_cast<u8>(99), static_cast<u8>(116), static_cast<u8>(58), static_cast<u8>(58), static_cast<u8>(82), static_cast<u8>(101), static_cast<u8>(99), static_cast<u8>(111), static_cast<u8>(114), static_cast<u8>(100), static_cast<u8>(41), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(84), static_cast<u8>(121), static_cast<u8>(112), static_cast<u8>(101), static_cast<u8>(86), static_cast<u8>(97), static_cast<u8>(114), static_cast<u8>(105), static_cast<u8>(97), static_cast<u8>(98), static_cast<u8>(108), static_cast<u8>(101), static_cast<u8>(40), static_cast<u8>(83), static_cast<u8>(116), static_cast<u8>(114), static_cast<u8>(105), static_cast<u8>(110), static_cast<u8>(103), static_cast<u8>(41), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(82), static_cast<u8>(97), static_cast<u8>(119), static_cast<u8>(80), static_cast<u8>(116), static_cast<u8>(114), static_cast<u8>(40), static_cast<u8>(82), static_cast<u8>(101), static_cast<u8>(102), static_cast<u8>(108), static_cast<u8>(101), static_cast<u8>(99), static_cast<u8>(116), static_cast<u8>(58), static_cast<u8>(58), static_cast<u8>(84), static_cast<u8>(121), static_cast<u8>(112), static_cast<u8>(101), static_cast<u8>(41), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(82), static_cast<u8>(101), static_cast<u8>(102), static_cast<u8>(101), static_cast<u8>(114), static_cast<u8>(101), static_cast<u8>(110), static_cast<u8>(99), static_cast<u8>(101), static_cast<u8>(40), static_cast<u8>(82), static_cast<u8>(101), static_cast<u8>(102), static_cast<u8>(108), static_cast<u8>(101), static_cast<u8>(99), static_cast<u8>(116), static_cast<u8>(58), static_cast<u8>(58), static_cast<u8>(84), static_cast<u8>(121), static_cast<u8>(112), static_cast<u8>(101), static_cast<u8>(41), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(77), static_cast<u8>(117), static_cast<u8>(116), static_cast<u8>(97), static_cast<u8>(98), static_cast<u8>(108), static_cast<u8>(101), static_cast<u8>(82), static_cast<u8>(101), static_cast<u8>(102), static_cast<u8>(101), static_cast<u8>(114), static_cast<u8>(101), static_cast<u8>(110), static_cast<u8>(99), static_cast<u8>(101), static_cast<u8>(40), static_cast<u8>(82), static_cast<u8>(101), static_cast<u8>(102), static_cast<u8>(108), static_cast<u8>(101), static_cast<u8>(99), static_cast<u8>(116), static_cast<u8>(58), static_cast<u8>(58), static_cast<u8>(84), static_cast<u8>(121), static_cast<u8>(112), static_cast<u8>(101), static_cast<u8>(41), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(70), static_cast<u8>(117), static_cast<u8>(110), static_cast<u8>(99), static_cast<u8>(116), static_cast<u8>(105), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(10), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(102), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(110), static_cast<u8>(97), static_cast<u8>(109), static_cast<u8>(101), static_cast<u8>(40), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(105), static_cast<u8>(115), static_cast<u8>(41), static_cast<u8>(32), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(114), static_cast<u8>(111), static_cast<u8>(119), static_cast<u8>(115), static_cast<u8>(32), static_cast<u8>(61), static_cast<u8>(62), static_cast<u8>(32), static_cast<u8>(109), static_cast<u8>(97), static_cast<u8>(116), static_cast<u8>(99), static_cast<u8>(104), static_cast<u8>(32), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(105), static_cast<u8>(115), static_cast<u8>(32), static_cast<u8>(123), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(86), static_cast<u8>(111), static_cast<u8>(105), static_cast<u8>(100), static_cast<u8>(32), static_cast<u8>(61), static_cast<u8>(62), static_cast<u8>(32), static_cast<u8>(34), static_cast<u8>(118), static_cast<u8>(111), static_cast<u8>(105), static_cast<u8>(100), static_cast<u8>(34), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(66), static_cast<u8>(111), static_cast<u8>(111), static_cast<u8>(108), static_cast<u8>(32), static_cast<u8>(61), static_cast<u8>(62), static_cast<u8>(32), static_cast<u8>(34), static_cast<u8>(98), static_cast<u8>(111), static_cast<u8>(111), static_cast<u8>(108), static_cast<u8>(34), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(85), static_cast<u8>(56), static_cast<u8>(32), static_cast<u8>(61), static_cast<u8>(62), static_cast<u8>(32), static_cast<u8>(34), static_cast<u8>(117), static_cast<u8>(56), static_cast<u8>(34), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(85), static_cast<u8>(49), static_cast<u8>(54), static_cast<u8>(32), static_cast<u8>(61), static_cast<u8>(62), static_cast<u8>(32), static_cast<u8>(34), static_cast<u8>(117), static_cast<u8>(49), static_cast<u8>(54), static_cast<u8>(34), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(85), static_cast<u8>(51), static_cast<u8>(50), static_cast<u8>(32), static_cast<u8>(61), static_cast<u8>(62), static_cast<u8>(32), static_cast<u8>(34), static_cast<u8>(117), static_cast<u8>(51), static_cast<u8>(50), static_cast<u8>(34), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(85), static_cast<u8>(54), static_cast<u8>(52), static_cast<u8>(32), static_cast<u8>(61), static_cast<u8>(62), static_cast<u8>(32), static_cast<u8>(34), static_cast<u8>(117), static_cast<u8>(54), static_cast<u8>(52), static_cast<u8>(34), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(73), static_cast<u8>(56), static_cast<u8>(32), static_cast<u8>(61), static_cast<u8>(62), static_cast<u8>(32), static_cast<u8>(34), static_cast<u8>(105), static_cast<u8>(56), static_cast<u8>(34), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(73), static_cast<u8>(49), static_cast<u8>(54), static_cast<u8>(32), static_cast<u8>(61), static_cast<u8>(62), static_cast<u8>(32), static_cast<u8>(34), static_cast<u8>(105), static_cast<u8>(49), static_cast<u8>(54), static_cast<u8>(34), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(73), static_cast<u8>(51), static_cast<u8>(50), static_cast<u8>(32), static_cast<u8>(61), static_cast<u8>(62), static_cast<u8>(32), static_cast<u8>(34), static_cast<u8>(105), static_cast<u8>(51), static_cast<u8>(50), static_cast<u8>(34), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(73), static_cast<u8>(54), static_cast<u8>(52), static_cast<u8>(32), static_cast<u8>(61), static_cast<u8>(62), static_cast<u8>(32), static_cast<u8>(34), static_cast<u8>(105), static_cast<u8>(54), static_cast<u8>(52), static_cast<u8>(34), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(70), static_cast<u8>(51), static_cast<u8>(50), static_cast<u8>(32), static_cast<u8>(61), static_cast<u8>(62), static_cast<u8>(32), static_cast<u8>(34), static_cast<u8>(102), static_cast<u8>(51), static_cast<u8>(50), static_cast<u8>(34), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(70), static_cast<u8>(54), static_cast<u8>(52), static_cast<u8>(32), static_cast<u8>(61), static_cast<u8>(62), static_cast<u8>(32), static_cast<u8>(34), static_cast<u8>(102), static_cast<u8>(54), static_cast<u8>(52), static_cast<u8>(34), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(85), static_cast<u8>(115), static_cast<u8>(105), static_cast<u8>(122), static_cast<u8>(101), static_cast<u8>(32), static_cast<u8>(61), static_cast<u8>(62), static_cast<u8>(32), static_cast<u8>(34), static_cast<u8>(117), static_cast<u8>(115), static_cast<u8>(105), static_cast<u8>(122), static_cast<u8>(101), static_cast<u8>(34), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(74), static_cast<u8>(97), static_cast<u8>(107), static_cast<u8>(116), static_cast<u8>(83), static_cast<u8>(116), static_cast<u8>(114), static_cast<u8>(105), static_cast<u8>(110), static_cast<u8>(103), static_cast<u8>(32), static_cast<u8>(61), static_cast<u8>(62), static_cast<u8>(32), static_cast<u8>(34), static_cast<u8>(83), static_cast<u8>(116), static_cast<u8>(114), static_cast<u8>(105), static_cast<u8>(110), static_cast<u8>(103), static_cast<u8>(34), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(67), static_cast<u8>(67), static_cast<u8>(104), static_cast<u8>(97), static_cast<u8>(114), static_cast<u8>(32), static_cast<u8>(61), static_cast<u8>(62), static_cast<u8>(32), static_cast<u8>(34), static_cast<u8>(99), static_cast<u8>(95), static_cast<u8>(99), static_cast<u8>(104), static_cast<u8>(97), static_cast<u8>(114), static_cast<u8>(34), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(67), static_cast<u8>(73), static_cast<u8>(110), static_cast<u8>(116), static_cast<u8>(32), static_cast<u8>(61), static_cast<u8>(62), static_cast<u8>(32), static_cast<u8>(34), static_cast<u8>(99), static_cast<u8>(95), static_cast<u8>(105), static_cast<u8>(110), static_cast<u8>(116), static_cast<u8>(34), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(85), static_cast<u8>(110), static_cast<u8>(107), static_cast<u8>(110), static_cast<u8>(111), static_cast<u8>(119), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(61), static_cast<u8>(62), static_cast<u8>(32), static_cast<u8>(34), static_cast<u8>(117), static_cast<u8>(110), static_cast<u8>(107), static_cast<u8>(110), static_cast<u8>(111), static_cast<u8>(119), static_cast<u8>(110), static_cast<u8>(34), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(78), static_cast<u8>(101), static_cast<u8>(118), static_cast<u8>(101), static_cast<u8>(114), static_cast<u8>(32), static_cast<u8>(61), static_cast<u8>(62), static_cast<u8>(32), static_cast<u8>(34), static_cast<u8>(110), static_cast<u8>(101), static_cast<u8>(118), static_cast<u8>(101), static_cast<u8>(114), static_cast<u8>(34), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(83), static_cast<u8>(116), static_cast<u8>(114), static_cast<u8>(117), static_cast<u8>(99), static_cast<u8>(116), static_cast<u8>(117), static_cast<u8>(114), static_cast<u8>(101), static_cast<u8>(79), static_cast<u8>(114), static_cast<u8>(69), static_cast<u8>(110), static_cast<u8>(117), static_cast<u8>(109), static_cast<u8>(40), static_cast<u8>(114), static_cast<u8>(101), static_cast<u8>(99), static_cast<u8>(111), static_cast<u8>(114), static_cast<u8>(100), static_cast<u8>(41), static_cast<u8>(32), static_cast<u8>(61), static_cast<u8>(62), static_cast<u8>(32), static_cast<u8>(102), static_cast<u8>(111), static_cast<u8>(114), static_cast<u8>(109), static_cast<u8>(97), static_cast<u8>(116), static_cast<u8>(40), static_cast<u8>(34), static_cast<u8>(115), static_cast<u8>(116), static_cast<u8>(114), static_cast<u8>(117), static_cast<u8>(99), static_cast<u8>(116), static_cast<u8>(32), static_cast<u8>(123), static_cast<u8>(125), static_cast<u8>(34), static_cast<u8>(44), static_cast<u8>(32), static_cast<u8>(114), static_cast<u8>(101), static_cast<u8>(99), static_cast<u8>(111), static_cast<u8>(114), static_cast<u8>(100), static_cast<u8>(46), static_cast<u8>(110), static_cast<u8>(97), static_cast<u8>(109), static_cast<u8>(101), static_cast<u8>(41), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(84), static_cast<u8>(121), static_cast<u8>(112), static_cast<u8>(101), static_cast<u8>(86), static_cast<u8>(97), static_cast<u8>(114), static_cast<u8>(105), static_cast<u8>(97), static_cast<u8>(98), static_cast<u8>(108), static_cast<u8>(101), static_cast<u8>(40), static_cast<u8>(110), static_cast<u8>(97), static_cast<u8>(109), static_cast<u8>(101), static_cast<u8>(41), static_cast<u8>(32), static_cast<u8>(61), static_cast<u8>(62), static_cast<u8>(32), static_cast<u8>(102), static_cast<u8>(111), static_cast<u8>(114), static_cast<u8>(109), static_cast<u8>(97), static_cast<u8>(116), static_cast<u8>(40), static_cast<u8>(34), static_cast<u8>(123), static_cast<u8>(125), static_cast<u8>(34), static_cast<u8>(44), static_cast<u8>(32), static_cast<u8>(110), static_cast<u8>(97), static_cast<u8>(109), static_cast<u8>(101), static_cast<u8>(41), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(82), static_cast<u8>(97), static_cast<u8>(119), static_cast<u8>(80), static_cast<u8>(116), static_cast<u8>(114), static_cast<u8>(40), static_cast<u8>(116), static_cast<u8>(121), static_cast<u8>(112), static_cast<u8>(101), static_cast<u8>(41), static_cast<u8>(32), static_cast<u8>(61), static_cast<u8>(62), static_cast<u8>(32), static_cast<u8>(102), static_cast<u8>(111), static_cast<u8>(114), static_cast<u8>(109), static_cast<u8>(97), static_cast<u8>(116), static_cast<u8>(40), static_cast<u8>(34), static_cast<u8>(114), static_cast<u8>(97), static_cast<u8>(119), static_cast<u8>(32), static_cast<u8>(123), static_cast<u8>(125), static_cast<u8>(34), static_cast<u8>(44), static_cast<u8>(32), static_cast<u8>(116), static_cast<u8>(121), static_cast<u8>(112), static_cast<u8>(101), static_cast<u8>(46), static_cast<u8>(110), static_cast<u8>(97), static_cast<u8>(109), static_cast<u8>(101), static_cast<u8>(40), static_cast<u8>(41), static_cast<u8>(41), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(82), static_cast<u8>(101), static_cast<u8>(102), static_cast<u8>(101), static_cast<u8>(114), static_cast<u8>(101), static_cast<u8>(110), static_cast<u8>(99), static_cast<u8>(101), static_cast<u8>(40), static_cast<u8>(116), static_cast<u8>(121), static_cast<u8>(112), static_cast<u8>(101), static_cast<u8>(41), static_cast<u8>(32), static_cast<u8>(61), static_cast<u8>(62), static_cast<u8>(32), static_cast<u8>(102), static_cast<u8>(111), static_cast<u8>(114), static_cast<u8>(109), static_cast<u8>(97), static_cast<u8>(116), static_cast<u8>(40), static_cast<u8>(34), static_cast<u8>(38), static_cast<u8>(32), static_cast<u8>(123), static_cast<u8>(125), static_cast<u8>(34), static_cast<u8>(44), static_cast<u8>(32), static_cast<u8>(116), static_cast<u8>(121), static_cast<u8>(112), static_cast<u8>(101), static_cast<u8>(46), static_cast<u8>(110), static_cast<u8>(97), static_cast<u8>(109), static_cast<u8>(101), static_cast<u8>(40), static_cast<u8>(41), static_cast<u8>(41), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(77), static_cast<u8>(117), static_cast<u8>(116), static_cast<u8>(97), static_cast<u8>(98), static_cast<u8>(108), static_cast<u8>(101), static_cast<u8>(82), static_cast<u8>(101), static_cast<u8>(102), static_cast<u8>(101), static_cast<u8>(114), static_cast<u8>(101), static_cast<u8>(110), static_cast<u8>(99), static_cast<u8>(101), static_cast<u8>(40), static_cast<u8>(116), static_cast<u8>(121), static_cast<u8>(112), static_cast<u8>(101), static_cast<u8>(41), static_cast<u8>(32), static_cast<u8>(61), static_cast<u8>(62), static_cast<u8>(32), static_cast<u8>(102), static_cast<u8>(111), static_cast<u8>(114), static_cast<u8>(109), static_cast<u8>(97), static_cast<u8>(116), static_cast<u8>(40), static_cast<u8>(34), static_cast<u8>(38), static_cast<u8>(109), static_cast<u8>(117), static_cast<u8>(116), static_cast<u8>(32), static_cast<u8>(123), static_cast<u8>(125), static_cast<u8>(34), static_cast<u8>(44), static_cast<u8>(32), static_cast<u8>(116), static_cast<u8>(121), static_cast<u8>(112), static_cast<u8>(101), static_cast<u8>(46), static_cast<u8>(110), static_cast<u8>(97), static_cast<u8>(109), static_cast<u8>(101), static_cast<u8>(40), static_cast<u8>(41), static_cast<u8>(41), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(70), static_cast<u8>(117), static_cast<u8>(110), static_cast<u8>(99), static_cast<u8>(116), static_cast<u8>(105), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(61), static_cast<u8>(62), static_cast<u8>(32), static_cast<u8>(34), static_cast<u8>(102), static_cast<u8>(110), static_cast<u8>(34), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(125), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(125), static_cast<u8>(10), static_cast<u8>(125), static_cast<u8>(10), static_cast<u8>(10)}))));
 JaktInternal::Optional<utility::FileId> const old_file_id = ((((*this).compiler))->current_file);
@@ -12442,7 +12442,7 @@ utility::FileId const file_id = TRY((((((*this).compiler))->get_file_id_or_regis
 ids::ModuleId const prelude_module_id = TRY((((*this).create_module(module_name,false,JaktInternal::OptionalNone()))));
 (((*this).current_module_id) = prelude_module_id);
 TRY((((((*this).program))->set_loaded_module(module_name,types::LoadedModule(prelude_module_id,file_id)))));
-ids::ScopeId const prelude_scope_id = TRY((((*this).create_scope(JaktInternal::OptionalNone(),false,TRY(ByteString::from_utf8("prelude"sv)),false))));
+ids::ScopeId const prelude_scope_id = TRY((((*this).create_scope(JaktInternal::OptionalNone(),false,(ByteString::must_from_utf8("prelude"sv)),false))));
 JaktInternal::DynamicArray<lexer::Token> const tokens = TRY((lexer::Lexer::lex(((*this).compiler))));
 if (((((*this).compiler))->dump_lexer)){
 {
@@ -12577,7 +12577,7 @@ return JaktInternal::ExplicitValue(call);
 };/*case end*/
 default: {
 {
-TRY((((((*this).compiler))->panic(TRY(ByteString::from_utf8("typecheck_call returned something other than a CheckedCall"sv))))));
+TRY((((((*this).compiler))->panic((ByteString::must_from_utf8("typecheck_call returned something other than a CheckedCall"sv))))));
 }
 };/*case end*/
 }/*switch end*/
@@ -12632,7 +12632,7 @@ ids::StructId const struct_id = (super_type)->as.Struct.value;
 (super_struct_id = struct_id);
 }
 else {
-TRY((((*this).error(TRY(ByteString::from_utf8("Class can only inherit from another class"sv)),(((super_parsed_type.value()))->span())))));
+TRY((((*this).error((ByteString::must_from_utf8("Class can only inherit from another class"sv)),(((super_parsed_type.value()))->span())))));
 }
 
 }
@@ -12664,7 +12664,7 @@ ids::StructId const struct_id = (super_type)->as.Struct.value;
 (super_struct_id = struct_id);
 }
 else {
-TRY((((*this).error(TRY(ByteString::from_utf8("Struct can only inherit from another struct"sv)),(((super_parsed_type.value()))->span())))));
+TRY((((*this).error((ByteString::must_from_utf8("Struct can only inherit from another struct"sv)),(((super_parsed_type.value()))->span())))));
 }
 
 }
@@ -12684,7 +12684,7 @@ return JaktInternal::ExplicitValue<void>();
 };/*case end*/
 default: {
 {
-utility::panic(TRY(ByteString::from_utf8("Expected Struct or Class in typecheck_struct_predecl"sv)));
+utility::panic((ByteString::must_from_utf8("Expected Struct or Class in typecheck_struct_predecl"sv)));
 }
 return JaktInternal::ExplicitValue<void>();
 };/*case end*/
@@ -12741,11 +12741,11 @@ case 0 /* PreIncrement */: {
 {
 if (((*this).is_integer(expr_type_id))){
 if ((!(((checked_expr)->is_mutable(((*this).program)))))){
-TRY((((*this).error(TRY(ByteString::from_utf8("Increment/decrement of immutable variable"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("Increment/decrement of immutable variable"sv)),span))));
 }
 }
 else {
-TRY((((*this).error(TRY(ByteString::from_utf8("Increment/decrement of non-numeric value"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("Increment/decrement of non-numeric value"sv)),span))));
 }
 
 }
@@ -12755,11 +12755,11 @@ case 1 /* PostIncrement */: {
 {
 if (((*this).is_integer(expr_type_id))){
 if ((!(((checked_expr)->is_mutable(((*this).program)))))){
-TRY((((*this).error(TRY(ByteString::from_utf8("Increment/decrement of immutable variable"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("Increment/decrement of immutable variable"sv)),span))));
 }
 }
 else {
-TRY((((*this).error(TRY(ByteString::from_utf8("Increment/decrement of non-numeric value"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("Increment/decrement of non-numeric value"sv)),span))));
 }
 
 }
@@ -12769,11 +12769,11 @@ case 2 /* PreDecrement */: {
 {
 if (((*this).is_integer(expr_type_id))){
 if ((!(((checked_expr)->is_mutable(((*this).program)))))){
-TRY((((*this).error(TRY(ByteString::from_utf8("Increment/decrement of immutable variable"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("Increment/decrement of immutable variable"sv)),span))));
 }
 }
 else {
-TRY((((*this).error(TRY(ByteString::from_utf8("Increment/decrement of non-numeric value"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("Increment/decrement of non-numeric value"sv)),span))));
 }
 
 }
@@ -12783,11 +12783,11 @@ case 3 /* PostDecrement */: {
 {
 if (((*this).is_integer(expr_type_id))){
 if ((!(((checked_expr)->is_mutable(((*this).program)))))){
-TRY((((*this).error(TRY(ByteString::from_utf8("Increment/decrement of immutable variable"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("Increment/decrement of immutable variable"sv)),span))));
 }
 }
 else {
-TRY((((*this).error(TRY(ByteString::from_utf8("Increment/decrement of non-numeric value"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("Increment/decrement of non-numeric value"sv)),span))));
 }
 
 }
@@ -12796,7 +12796,7 @@ return JaktInternal::ExplicitValue<void>();
 case 9 /* LogicalNot */: {
 {
 if ((!(TRY((((*this).check_types_for_compat(types::builtin(types::BuiltinType::Bool()),((checked_expr)->type()),((((*this).generic_inferences))),span))))))){
-TRY((((*this).error(TRY(ByteString::from_utf8("Cannot use a logical Not on a value of non-boolean type"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("Cannot use a logical Not on a value of non-boolean type"sv)),span))));
 }
 return TRY((types::CheckedExpression::UnaryOp(JaktInternal::OptionalNone(),checked_expr,checked_op,span,expr_type_id)));
 }
@@ -12866,7 +12866,7 @@ return JaktInternal::ExplicitValue<void>();
 case 8 /* MutableReference */: {
 {
 if ((!(((checked_expr)->is_mutable(((*this).program)))))){
-TRY((((*this).error(TRY(ByteString::from_utf8("Cannot make mutable reference to immutable value"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("Cannot make mutable reference to immutable value"sv)),span))));
 }
 return TRY((types::CheckedExpression::UnaryOp(JaktInternal::OptionalNone(),checked_expr,checked_op,span,TRY((((*this).find_or_add_type_id(TRY((types::Type::MutableReference(parser::CheckedQualifiers(false),expr_type_id))))))))));
 }
@@ -12882,7 +12882,7 @@ case 26 /* RawPtr */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.RawPtr;ids::TypeId const& type_id = __jakt_match_value.value;
 {
 if (((safety_mode).__jakt_init_index() == 0 /* Safe */)){
-TRY((((*this).error(TRY(ByteString::from_utf8("Dereference of raw pointer outside of unsafe block"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("Dereference of raw pointer outside of unsafe block"sv)),span))));
 }
 return TRY((types::CheckedExpression::UnaryOp(JaktInternal::OptionalNone(),checked_expr,checked_op,span,type_id)));
 }
@@ -12932,7 +12932,7 @@ return TRY((types::CheckedExpression::UnaryOp(JaktInternal::OptionalNone(),check
 ErrorOr<void> typechecker::Typechecker::warn_about_unimplemented_nested_record(parser::ParsedRecord const record) {
 {
 if (((((record).definition_linkage)).__jakt_init_index() == 0 /* Internal */)){
-TRY((((*this).error(TRY(ByteString::from_utf8("Only external nested types are currently supported"sv)),((record).name_span)))));
+TRY((((*this).error((ByteString::must_from_utf8("Only external nested types are currently supported"sv)),((record).name_span)))));
 }
 }
 return {};
@@ -12957,7 +12957,7 @@ return (infallible_enum_cast<jakt__prelude__operators::Ordering>((JaktInternal::
 }
 }
 (((type_)->max()),val)){
-TRY((((*this).error_with_hint(TRY(ByteString::from_utf8("Integer promotion failed"sv)),span,TRY((__jakt_format((StringView::from_string_literal("Cannot fit value into range [{}, {}] of type {}."sv)),((type_)->min()),((type_)->max()),TRY((((*this).type_name(builtin_typeid,false))))))),span))));
+TRY((((*this).error_with_hint((ByteString::must_from_utf8("Integer promotion failed"sv)),span,TRY((__jakt_format((StringView::from_string_literal("Cannot fit value into range [{}, {}] of type {}."sv)),((type_)->min()),((type_)->max()),TRY((((*this).type_name(builtin_typeid,false))))))),span))));
 }
 else {
 (expr = TRY((types::CheckedExpression::NumericConstant(JaktInternal::OptionalNone(),types::CheckedNumericConstant::I8((infallible_integer_cast<i8>((val)))),span,types::builtin(types::BuiltinType::I8())))));
@@ -12978,7 +12978,7 @@ return (infallible_enum_cast<jakt__prelude__operators::Ordering>((JaktInternal::
 }
 }
 (((type_)->max()),val)){
-TRY((((*this).error_with_hint(TRY(ByteString::from_utf8("Integer promotion failed"sv)),span,TRY((__jakt_format((StringView::from_string_literal("Cannot fit value into range [{}, {}] of type {}."sv)),((type_)->min()),((type_)->max()),TRY((((*this).type_name(builtin_typeid,false))))))),span))));
+TRY((((*this).error_with_hint((ByteString::must_from_utf8("Integer promotion failed"sv)),span,TRY((__jakt_format((StringView::from_string_literal("Cannot fit value into range [{}, {}] of type {}."sv)),((type_)->min()),((type_)->max()),TRY((((*this).type_name(builtin_typeid,false))))))),span))));
 }
 else {
 (expr = TRY((types::CheckedExpression::NumericConstant(JaktInternal::OptionalNone(),types::CheckedNumericConstant::I16((infallible_integer_cast<i16>((val)))),span,types::builtin(types::BuiltinType::I16())))));
@@ -12999,7 +12999,7 @@ return (infallible_enum_cast<jakt__prelude__operators::Ordering>((JaktInternal::
 }
 }
 (((type_)->max()),val)){
-TRY((((*this).error_with_hint(TRY(ByteString::from_utf8("Integer promotion failed"sv)),span,TRY((__jakt_format((StringView::from_string_literal("Cannot fit value into range [{}, {}] of type {}."sv)),((type_)->min()),((type_)->max()),TRY((((*this).type_name(builtin_typeid,false))))))),span))));
+TRY((((*this).error_with_hint((ByteString::must_from_utf8("Integer promotion failed"sv)),span,TRY((__jakt_format((StringView::from_string_literal("Cannot fit value into range [{}, {}] of type {}."sv)),((type_)->min()),((type_)->max()),TRY((((*this).type_name(builtin_typeid,false))))))),span))));
 }
 else {
 (expr = TRY((types::CheckedExpression::NumericConstant(JaktInternal::OptionalNone(),types::CheckedNumericConstant::I32((infallible_integer_cast<i32>((val)))),span,types::builtin(types::BuiltinType::I32())))));
@@ -13020,7 +13020,7 @@ return (infallible_enum_cast<jakt__prelude__operators::Ordering>((JaktInternal::
 }
 }
 (((type_)->max()),val)){
-TRY((((*this).error_with_hint(TRY(ByteString::from_utf8("Integer promotion failed"sv)),span,TRY((__jakt_format((StringView::from_string_literal("Cannot fit value into range [{}, {}] of type {}."sv)),((type_)->min()),((type_)->max()),TRY((((*this).type_name(builtin_typeid,false))))))),span))));
+TRY((((*this).error_with_hint((ByteString::must_from_utf8("Integer promotion failed"sv)),span,TRY((__jakt_format((StringView::from_string_literal("Cannot fit value into range [{}, {}] of type {}."sv)),((type_)->min()),((type_)->max()),TRY((((*this).type_name(builtin_typeid,false))))))),span))));
 }
 else {
 (expr = TRY((types::CheckedExpression::NumericConstant(JaktInternal::OptionalNone(),types::CheckedNumericConstant::U8((infallible_integer_cast<u8>((val)))),span,types::builtin(types::BuiltinType::U8())))));
@@ -13041,7 +13041,7 @@ return (infallible_enum_cast<jakt__prelude__operators::Ordering>((JaktInternal::
 }
 }
 (((type_)->max()),val)){
-TRY((((*this).error_with_hint(TRY(ByteString::from_utf8("Integer promotion failed"sv)),span,TRY((__jakt_format((StringView::from_string_literal("Cannot fit value into range [{}, {}] of type {}."sv)),((type_)->min()),((type_)->max()),TRY((((*this).type_name(builtin_typeid,false))))))),span))));
+TRY((((*this).error_with_hint((ByteString::must_from_utf8("Integer promotion failed"sv)),span,TRY((__jakt_format((StringView::from_string_literal("Cannot fit value into range [{}, {}] of type {}."sv)),((type_)->min()),((type_)->max()),TRY((((*this).type_name(builtin_typeid,false))))))),span))));
 }
 else {
 (expr = TRY((types::CheckedExpression::NumericConstant(JaktInternal::OptionalNone(),types::CheckedNumericConstant::U16((infallible_integer_cast<u16>((val)))),span,types::builtin(types::BuiltinType::U16())))));
@@ -13062,7 +13062,7 @@ return (infallible_enum_cast<jakt__prelude__operators::Ordering>((JaktInternal::
 }
 }
 (((type_)->max()),val)){
-TRY((((*this).error_with_hint(TRY(ByteString::from_utf8("Integer promotion failed"sv)),span,TRY((__jakt_format((StringView::from_string_literal("Cannot fit value into range [{}, {}] of type {}."sv)),((type_)->min()),((type_)->max()),TRY((((*this).type_name(builtin_typeid,false))))))),span))));
+TRY((((*this).error_with_hint((ByteString::must_from_utf8("Integer promotion failed"sv)),span,TRY((__jakt_format((StringView::from_string_literal("Cannot fit value into range [{}, {}] of type {}."sv)),((type_)->min()),((type_)->max()),TRY((((*this).type_name(builtin_typeid,false))))))),span))));
 }
 else {
 (expr = TRY((types::CheckedExpression::NumericConstant(JaktInternal::OptionalNone(),types::CheckedNumericConstant::U32((infallible_integer_cast<u32>((val)))),span,types::builtin(types::BuiltinType::U32())))));
@@ -13092,7 +13092,7 @@ return (infallible_enum_cast<jakt__prelude__operators::Ordering>((JaktInternal::
 }
 }
 (val,static_cast<u64>(255ULL))){
-TRY((((*this).error_with_hint(TRY(ByteString::from_utf8("Integer promotion failed"sv)),span,TRY((__jakt_format((StringView::from_string_literal("Cannot fit value into range [{}, {}] of type {}."sv)),((type_)->min()),((type_)->max()),TRY((((*this).type_name(builtin_typeid,false))))))),span))));
+TRY((((*this).error_with_hint((ByteString::must_from_utf8("Integer promotion failed"sv)),span,TRY((__jakt_format((StringView::from_string_literal("Cannot fit value into range [{}, {}] of type {}."sv)),((type_)->min()),((type_)->max()),TRY((((*this).type_name(builtin_typeid,false))))))),span))));
 }
 else {
 (expr = TRY((types::CheckedExpression::NumericConstant(JaktInternal::OptionalNone(),types::CheckedNumericConstant::U8((infallible_integer_cast<u8>((val)))),span,types::builtin(types::BuiltinType::CChar())))));
@@ -13114,7 +13114,7 @@ case 20 /* GenericInstance */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.GenericInstance;ids::StructId const& id = __jakt_match_value.id;
 JaktInternal::DynamicArray<ids::TypeId> const& args = __jakt_match_value.args;
 return JaktInternal::ExplicitValue(({ Optional<ids::TypeId> __jakt_var_481; {
-if (((id).equals(TRY((((*this).find_struct_in_prelude(TRY(ByteString::from_utf8("Optional"sv))))))))){
+if (((id).equals(TRY((((*this).find_struct_in_prelude((ByteString::must_from_utf8("Optional"sv))))))))){
 return ((args)[static_cast<i64>(0LL)]);
 }
 __jakt_var_481 = type_id; goto __jakt_label_431;
@@ -13186,7 +13186,7 @@ return JaktInternal::OptionalNone();
 ErrorOr<types::CheckedParameter> typechecker::Typechecker::typecheck_parameter(parser::ParsedParameter const parameter,ids::ScopeId const scope_id,bool const first,JaktInternal::Optional<ids::TypeId> const this_arg_type_id,JaktInternal::Optional<ids::ScopeId> const check_scope) {
 {
 ids::TypeId type_id = TRY((((*this).typecheck_typename(((((parameter).variable)).parsed_type),scope_id,((((parameter).variable)).name)))));
-if ((first && ((((((parameter).variable)).name)) == (TRY(ByteString::from_utf8("this"sv)))))){
+if ((first && ((((((parameter).variable)).name)) == ((ByteString::must_from_utf8("this"sv)))))){
 if (((this_arg_type_id).has_value())){
 (type_id = (this_arg_type_id.value()));
 }
@@ -13194,7 +13194,7 @@ if (((this_arg_type_id).has_value())){
 if (((((((*this).get_type(type_id)))->common.init_common.qualifiers)).is_immutable)){
 (type_id = TRY((((*this).with_qualifiers(parser::CheckedQualifiers(false),type_id)))));
 if (((((parameter).variable)).is_mutable)){
-TRY((((*this).error(TRY(ByteString::from_utf8("Cannot have a mutable binding to an immutable parameter"sv)),((((parameter).variable)).span)))));
+TRY((((*this).error((ByteString::must_from_utf8("Cannot have a mutable binding to an immutable parameter"sv)),((((parameter).variable)).span)))));
 }
 }
 NonnullRefPtr<types::CheckedVariable> const variable = TRY((types::CheckedVariable::__jakt_create(((((parameter).variable)).name),type_id,((((parameter).variable)).is_mutable),((((parameter).variable)).span),JaktInternal::OptionalNone(),types::CheckedVisibility::Public(),JaktInternal::OptionalNone(),JaktInternal::OptionalNone(),JaktInternal::OptionalNone())));
@@ -13287,7 +13287,7 @@ if (__jakt_enum_value == true) {
 return JaktInternal::ExplicitValue(types::StructLikeId::Struct(JaktInternal::OptionalNone(),TRY((((((*this).program))->builtin_implementation_struct(((type)->as_builtin_type()),((((*this).program))->prelude_module_id())))))));
 }
 else if (__jakt_enum_value == false) {
-return JaktInternal::ExplicitValue(static_cast<JaktInternal::Optional<types::StructLikeId>>(types::StructLikeId::Struct(JaktInternal::OptionalNone(),TRY((((*this).find_struct_in_prelude(TRY(ByteString::from_utf8("String"sv)))))))));
+return JaktInternal::ExplicitValue(static_cast<JaktInternal::Optional<types::StructLikeId>>(types::StructLikeId::Struct(JaktInternal::OptionalNone(),TRY((((*this).find_struct_in_prelude((ByteString::must_from_utf8("String"sv)))))))));
 }
 VERIFY_NOT_REACHED();
 }());
@@ -13305,7 +13305,7 @@ __jakt_var_482 = ({
 auto __jakt_enum_value = (for_optional_chain);
 if (__jakt_enum_value == true) {
 return JaktInternal::ExplicitValue(({ Optional<JaktInternal::Optional<types::StructLikeId>> __jakt_var_483; {
-ids::StructId const optional_struct_id = TRY((((*this).find_struct_in_prelude(TRY(ByteString::from_utf8("Optional"sv))))));
+ids::StructId const optional_struct_id = TRY((((*this).find_struct_in_prelude((ByteString::must_from_utf8("Optional"sv))))));
 JaktInternal::Optional<types::StructLikeId> struct_id = JaktInternal::OptionalNone();
 if ((!(((id).equals(optional_struct_id))))){
 TRY((((*this).error(TRY((__jakt_format((StringView::from_string_literal("Can't use ‘{}’ as an optional type in optional chained call"sv)),((((*this).get_struct(id))).name)))),span))));
@@ -13334,7 +13334,7 @@ return JaktInternal::ExplicitValue(types::StructLikeId::Enum(JaktInternal::Optio
 };/*case end*/
 default: {
 return JaktInternal::ExplicitValue(({ Optional<types::StructLikeId> __jakt_var_484; {
-TRY((((*this).error(TRY(ByteString::from_utf8("Can't use non-struct type as an optional type in optional chained call"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("Can't use non-struct type as an optional type in optional chained call"sv)),span))));
 (found_optional = false);
 __jakt_var_484 = types::StructLikeId::Struct(JaktInternal::OptionalNone(),optional_struct_id); goto __jakt_label_434;
 
@@ -13510,7 +13510,7 @@ return (infallible_enum_cast<jakt__prelude__operators::Ordering>((JaktInternal::
 }
 }
 (val,(infallible_integer_cast<i64>((((type_)->max()))))))){
-TRY((((*this).error_with_hint(TRY(ByteString::from_utf8("Integer promotion failed"sv)),span,TRY((__jakt_format((StringView::from_string_literal("Cannot fit value into range [{}, {}] of type {}."sv)),((type_)->min()),((type_)->max()),TRY((((*this).type_name(builtin_typeid,false))))))),span))));
+TRY((((*this).error_with_hint((ByteString::must_from_utf8("Integer promotion failed"sv)),span,TRY((__jakt_format((StringView::from_string_literal("Cannot fit value into range [{}, {}] of type {}."sv)),((type_)->min()),((type_)->max()),TRY((((*this).type_name(builtin_typeid,false))))))),span))));
 }
 else {
 (expr = TRY((types::CheckedExpression::NumericConstant(JaktInternal::OptionalNone(),types::CheckedNumericConstant::I8((infallible_integer_cast<i8>((val)))),span,types::builtin(types::BuiltinType::I8())))));
@@ -13541,7 +13541,7 @@ return (infallible_enum_cast<jakt__prelude__operators::Ordering>((JaktInternal::
 }
 }
 (val,(infallible_integer_cast<i64>((((type_)->max()))))))){
-TRY((((*this).error_with_hint(TRY(ByteString::from_utf8("Integer promotion failed"sv)),span,TRY((__jakt_format((StringView::from_string_literal("Cannot fit value into range [{}, {}] of type {}."sv)),((type_)->min()),((type_)->max()),TRY((((*this).type_name(builtin_typeid,false))))))),span))));
+TRY((((*this).error_with_hint((ByteString::must_from_utf8("Integer promotion failed"sv)),span,TRY((__jakt_format((StringView::from_string_literal("Cannot fit value into range [{}, {}] of type {}."sv)),((type_)->min()),((type_)->max()),TRY((((*this).type_name(builtin_typeid,false))))))),span))));
 }
 else {
 (expr = TRY((types::CheckedExpression::NumericConstant(JaktInternal::OptionalNone(),types::CheckedNumericConstant::I16((infallible_integer_cast<i16>((val)))),span,types::builtin(types::BuiltinType::I16())))));
@@ -13572,7 +13572,7 @@ return (infallible_enum_cast<jakt__prelude__operators::Ordering>((JaktInternal::
 }
 }
 (val,(infallible_integer_cast<i64>((((type_)->max()))))))){
-TRY((((*this).error_with_hint(TRY(ByteString::from_utf8("Integer promotion failed"sv)),span,TRY((__jakt_format((StringView::from_string_literal("Cannot fit value into range [{}, {}] of type {}."sv)),((type_)->min()),((type_)->max()),TRY((((*this).type_name(builtin_typeid,false))))))),span))));
+TRY((((*this).error_with_hint((ByteString::must_from_utf8("Integer promotion failed"sv)),span,TRY((__jakt_format((StringView::from_string_literal("Cannot fit value into range [{}, {}] of type {}."sv)),((type_)->min()),((type_)->max()),TRY((((*this).type_name(builtin_typeid,false))))))),span))));
 }
 else {
 (expr = TRY((types::CheckedExpression::NumericConstant(JaktInternal::OptionalNone(),types::CheckedNumericConstant::I32((infallible_integer_cast<i32>((val)))),span,types::builtin(types::BuiltinType::I32())))));
@@ -13603,7 +13603,7 @@ return (infallible_enum_cast<jakt__prelude__operators::Ordering>((JaktInternal::
 }
 }
 (val,(infallible_integer_cast<i64>((((type_)->max()))))))){
-TRY((((*this).error_with_hint(TRY(ByteString::from_utf8("Integer promotion failed"sv)),span,TRY((__jakt_format((StringView::from_string_literal("Cannot fit value into range [{}, {}] of type {}."sv)),((type_)->min()),((type_)->max()),TRY((((*this).type_name(builtin_typeid,false))))))),span))));
+TRY((((*this).error_with_hint((ByteString::must_from_utf8("Integer promotion failed"sv)),span,TRY((__jakt_format((StringView::from_string_literal("Cannot fit value into range [{}, {}] of type {}."sv)),((type_)->min()),((type_)->max()),TRY((((*this).type_name(builtin_typeid,false))))))),span))));
 }
 else {
 (expr = TRY((types::CheckedExpression::NumericConstant(JaktInternal::OptionalNone(),types::CheckedNumericConstant::U8((infallible_integer_cast<u8>((val)))),span,types::builtin(types::BuiltinType::U8())))));
@@ -13634,7 +13634,7 @@ return (infallible_enum_cast<jakt__prelude__operators::Ordering>((JaktInternal::
 }
 }
 (val,(infallible_integer_cast<i64>((((type_)->max()))))))){
-TRY((((*this).error_with_hint(TRY(ByteString::from_utf8("Integer promotion failed"sv)),span,TRY((__jakt_format((StringView::from_string_literal("Cannot fit value into range [{}, {}] of type {}."sv)),((type_)->min()),((type_)->max()),TRY((((*this).type_name(builtin_typeid,false))))))),span))));
+TRY((((*this).error_with_hint((ByteString::must_from_utf8("Integer promotion failed"sv)),span,TRY((__jakt_format((StringView::from_string_literal("Cannot fit value into range [{}, {}] of type {}."sv)),((type_)->min()),((type_)->max()),TRY((((*this).type_name(builtin_typeid,false))))))),span))));
 }
 else {
 (expr = TRY((types::CheckedExpression::NumericConstant(JaktInternal::OptionalNone(),types::CheckedNumericConstant::U16((infallible_integer_cast<u16>((val)))),span,types::builtin(types::BuiltinType::U16())))));
@@ -13665,7 +13665,7 @@ return (infallible_enum_cast<jakt__prelude__operators::Ordering>((JaktInternal::
 }
 }
 (val,(infallible_integer_cast<i64>((((type_)->max()))))))){
-TRY((((*this).error_with_hint(TRY(ByteString::from_utf8("Integer promotion failed"sv)),span,TRY((__jakt_format((StringView::from_string_literal("Cannot fit value into range [{}, {}] of type {}."sv)),((type_)->min()),((type_)->max()),TRY((((*this).type_name(builtin_typeid,false))))))),span))));
+TRY((((*this).error_with_hint((ByteString::must_from_utf8("Integer promotion failed"sv)),span,TRY((__jakt_format((StringView::from_string_literal("Cannot fit value into range [{}, {}] of type {}."sv)),((type_)->min()),((type_)->max()),TRY((((*this).type_name(builtin_typeid,false))))))),span))));
 }
 else {
 (expr = TRY((types::CheckedExpression::NumericConstant(JaktInternal::OptionalNone(),types::CheckedNumericConstant::U32((infallible_integer_cast<u32>((val)))),span,types::builtin(types::BuiltinType::U32())))));
@@ -13686,7 +13686,7 @@ return (infallible_enum_cast<jakt__prelude__operators::Ordering>((JaktInternal::
 }
 }
 (val,static_cast<i64>(0LL))){
-TRY((((*this).error_with_hint(TRY(ByteString::from_utf8("Integer promotion failed"sv)),span,TRY((__jakt_format((StringView::from_string_literal("Cannot fit value into range [{}, {}] of type {}."sv)),((type_)->min()),((type_)->max()),TRY((((*this).type_name(builtin_typeid,false))))))),span))));
+TRY((((*this).error_with_hint((ByteString::must_from_utf8("Integer promotion failed"sv)),span,TRY((__jakt_format((StringView::from_string_literal("Cannot fit value into range [{}, {}] of type {}."sv)),((type_)->min()),((type_)->max()),TRY((((*this).type_name(builtin_typeid,false))))))),span))));
 }
 else {
 (expr = TRY((types::CheckedExpression::NumericConstant(JaktInternal::OptionalNone(),types::CheckedNumericConstant::U64((infallible_integer_cast<u64>((val)))),span,types::builtin(types::BuiltinType::U64())))));
@@ -13707,7 +13707,7 @@ return (infallible_enum_cast<jakt__prelude__operators::Ordering>((JaktInternal::
 }
 }
 (val,static_cast<i64>(0LL))){
-TRY((((*this).error_with_hint(TRY(ByteString::from_utf8("Integer promotion failed"sv)),span,TRY((__jakt_format((StringView::from_string_literal("Cannot fit value into range [{}, {}] of type {}."sv)),((type_)->min()),((type_)->max()),TRY((((*this).type_name(builtin_typeid,false))))))),span))));
+TRY((((*this).error_with_hint((ByteString::must_from_utf8("Integer promotion failed"sv)),span,TRY((__jakt_format((StringView::from_string_literal("Cannot fit value into range [{}, {}] of type {}."sv)),((type_)->min()),((type_)->max()),TRY((((*this).type_name(builtin_typeid,false))))))),span))));
 }
 else {
 (expr = TRY((types::CheckedExpression::NumericConstant(JaktInternal::OptionalNone(),types::CheckedNumericConstant::USize((infallible_integer_cast<u64>((val)))),span,types::builtin(types::BuiltinType::Usize())))));
@@ -13728,7 +13728,7 @@ return (infallible_enum_cast<jakt__prelude__operators::Ordering>((JaktInternal::
 }
 }
 (val,static_cast<i64>(0LL))){
-TRY((((*this).error_with_hint(TRY(ByteString::from_utf8("Integer promotion failed"sv)),span,TRY((__jakt_format((StringView::from_string_literal("Cannot fit value into range [{}, {}] of type {}."sv)),((type_)->min()),((type_)->max()),TRY((((*this).type_name(builtin_typeid,false))))))),span))));
+TRY((((*this).error_with_hint((ByteString::must_from_utf8("Integer promotion failed"sv)),span,TRY((__jakt_format((StringView::from_string_literal("Cannot fit value into range [{}, {}] of type {}."sv)),((type_)->min()),((type_)->max()),TRY((((*this).type_name(builtin_typeid,false))))))),span))));
 }
 else {
 (expr = TRY((types::CheckedExpression::NumericConstant(JaktInternal::OptionalNone(),types::CheckedNumericConstant::I32((infallible_integer_cast<i32>((val)))),span,types::builtin(types::BuiltinType::CInt())))));
@@ -13759,7 +13759,7 @@ return (infallible_enum_cast<jakt__prelude__operators::Ordering>((JaktInternal::
 }
 }
 (val,static_cast<i64>(255LL)))){
-TRY((((*this).error_with_hint(TRY(ByteString::from_utf8("Integer promotion failed"sv)),span,TRY((__jakt_format((StringView::from_string_literal("Cannot fit value into range [{}, {}] of type {}."sv)),((type_)->min()),((type_)->max()),TRY((((*this).type_name(builtin_typeid,false))))))),span))));
+TRY((((*this).error_with_hint((ByteString::must_from_utf8("Integer promotion failed"sv)),span,TRY((__jakt_format((StringView::from_string_literal("Cannot fit value into range [{}, {}] of type {}."sv)),((type_)->min()),((type_)->max()),TRY((((*this).type_name(builtin_typeid,false))))))),span))));
 }
 else {
 (expr = TRY((types::CheckedExpression::NumericConstant(JaktInternal::OptionalNone(),types::CheckedNumericConstant::U8((infallible_integer_cast<u8>((val)))),span,types::builtin(types::BuiltinType::CChar())))));
@@ -13968,7 +13968,7 @@ return true;
 }
 if (((lhs_type)->__jakt_init_index() == 31 /* Self */)){
 if ((!(((((*this).self_type_id)).has_value())))){
-TRY((((*this).error(TRY(ByteString::from_utf8("Invalid use of the 'Self' type"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("Invalid use of the 'Self' type"sv)),span))));
 }
 else {
 return TRY((((*this).check_types_for_compat((((*this).self_type_id).value()),rhs_type_id,generic_inferences,span))));
@@ -13977,7 +13977,7 @@ return TRY((((*this).check_types_for_compat((((*this).self_type_id).value()),rhs
 }
 if (((rhs_type)->__jakt_init_index() == 31 /* Self */)){
 if ((!(((((*this).self_type_id)).has_value())))){
-TRY((((*this).error(TRY(ByteString::from_utf8("Invalid use of the 'Self' type"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("Invalid use of the 'Self' type"sv)),span))));
 }
 else {
 return TRY((((*this).check_types_for_compat(lhs_type_id,(((*this).self_type_id).value()),generic_inferences,span))));
@@ -13995,13 +13995,13 @@ if (((((rhs).impl))->equals(((lhs).impl)))){
 return true;
 }
 NonnullRefPtr<interpreter::Interpreter> const interpreter = TRY((((*this).interpreter())));
-TRY((((*this).error(TRY((__jakt_format((StringView::from_string_literal("Literal type value mismatch: expected '{}', found '{}'"sv)),TRY((types::comptime_format_impl(TRY(ByteString::from_utf8("{}"sv)),(((TRY((DynamicArray<types::Value>::create_with({lhs})))))[(JaktInternal::Range<i64>{static_cast<i64>(0LL),static_cast<i64>(9223372036854775807LL)})]),((((*this).program)))))),TRY((types::comptime_format_impl(TRY(ByteString::from_utf8("{}"sv)),(((TRY((DynamicArray<types::Value>::create_with({rhs})))))[(JaktInternal::Range<i64>{static_cast<i64>(0LL),static_cast<i64>(9223372036854775807LL)})]),((((*this).program))))))))),span))));
+TRY((((*this).error(TRY((__jakt_format((StringView::from_string_literal("Literal type value mismatch: expected '{}', found '{}'"sv)),TRY((types::comptime_format_impl((ByteString::must_from_utf8("{}"sv)),(((TRY((DynamicArray<types::Value>::create_with({lhs})))))[(JaktInternal::Range<i64>{static_cast<i64>(0LL),static_cast<i64>(9223372036854775807LL)})]),((((*this).program)))))),TRY((types::comptime_format_impl((ByteString::must_from_utf8("{}"sv)),(((TRY((DynamicArray<types::Value>::create_with({rhs})))))[(JaktInternal::Range<i64>{static_cast<i64>(0LL),static_cast<i64>(9223372036854775807LL)})]),((((*this).program))))))))),span))));
 return false;
 }
 }
-ids::StructId const optional_struct_id = TRY((((*this).find_struct_in_prelude(TRY(ByteString::from_utf8("Optional"sv))))));
-ids::StructId const weakptr_struct_id = TRY((((*this).find_struct_in_prelude(TRY(ByteString::from_utf8("WeakPtr"sv))))));
-ids::StructId const array_struct_id = TRY((((*this).find_struct_in_prelude(TRY(ByteString::from_utf8("Array"sv))))));
+ids::StructId const optional_struct_id = TRY((((*this).find_struct_in_prelude((ByteString::must_from_utf8("Optional"sv))))));
+ids::StructId const weakptr_struct_id = TRY((((*this).find_struct_in_prelude((ByteString::must_from_utf8("WeakPtr"sv))))));
+ids::StructId const array_struct_id = TRY((((*this).find_struct_in_prelude((ByteString::must_from_utf8("Array"sv))))));
 ({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<void, ErrorOr<bool>>{
 auto&& __jakt_match_variant = *lhs_type;
@@ -14100,10 +14100,10 @@ ByteString const lhs_throw = ({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<ByteString,ErrorOr<bool>>{
 auto __jakt_enum_value = (lhs_can_throw);
 if (__jakt_enum_value == true) {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("Yes"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("Yes"sv)));
 }
 else {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("No"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("No"sv)));
 }
 }());
     if (_jakt_value.is_return())
@@ -14114,10 +14114,10 @@ ByteString const rhs_throw = ({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<ByteString,ErrorOr<bool>>{
 auto __jakt_enum_value = (rhs_can_throw);
 if (__jakt_enum_value == true) {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("Yes"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("Yes"sv)));
 }
 else if (__jakt_enum_value == false) {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("No"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("No"sv)));
 }
 VERIFY_NOT_REACHED();
 }());
@@ -14695,7 +14695,7 @@ if (TRY((((first)->is_static())))){
 if (TRY((((second)->is_static())))){
 }
 else {
-TRY((((*this).error(TRY(ByteString::from_utf8("Function signatures don't match: one is static and the other isn't"sv)),((first)->name_span)))));
+TRY((((*this).error((ByteString::must_from_utf8("Function signatures don't match: one is static and the other isn't"sv)),((first)->name_span)))));
 return false;
 }
 
@@ -14706,13 +14706,13 @@ if (((TRY((((first)->is_mutating())))) == (TRY((((second)->is_mutating())))))){
 (arg_start = static_cast<size_t>(1ULL));
 }
 else {
-TRY((((*this).error(TRY(ByteString::from_utf8("Function signatures don't match: one is mutating and the other isn't"sv)),((first)->name_span)))));
+TRY((((*this).error((ByteString::must_from_utf8("Function signatures don't match: one is mutating and the other isn't"sv)),((first)->name_span)))));
 return false;
 }
 
 }
 else {
-TRY((((*this).error(TRY(ByteString::from_utf8("Function signatures don't match: one is static and the other isn't"sv)),((first)->name_span)))));
+TRY((((*this).error((ByteString::must_from_utf8("Function signatures don't match: one is static and the other isn't"sv)),((first)->name_span)))));
 return false;
 }
 
@@ -14741,13 +14741,13 @@ return false;
 return true;
 }
 else {
-TRY((((*this).error(TRY(ByteString::from_utf8("Function signatures don't match: different number of parameters"sv)),((first)->name_span)))));
+TRY((((*this).error((ByteString::must_from_utf8("Function signatures don't match: different number of parameters"sv)),((first)->name_span)))));
 return false;
 }
 
 }
 else {
-TRY((((*this).error(TRY(ByteString::from_utf8("Function signatures don't match: one can throw and the other can't"sv)),((first)->name_span)))));
+TRY((((*this).error((ByteString::must_from_utf8("Function signatures don't match: one can throw and the other can't"sv)),((first)->name_span)))));
 return false;
 }
 
@@ -14776,7 +14776,7 @@ return JaktInternal::ExplicitValue<void>();
 case 2 /* Restricted */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Restricted;JaktInternal::DynamicArray<NonnullRefPtr<typename types::MaybeResolvedScope>> const& scopes = __jakt_match_value.scopes;
 {
-TRY((((*this).check_restricted_access(accessor,TRY(ByteString::from_utf8("field"sv)),accessee,((member)->name),scopes,span))));
+TRY((((*this).check_restricted_access(accessor,(ByteString::must_from_utf8("field"sv)),accessee,((member)->name),scopes,span))));
 }
 return JaktInternal::ExplicitValue<void>();
 };/*case end*/
@@ -14847,7 +14847,7 @@ return (Tuple{result, errors});
 
 ErrorOr<NonnullRefPtr<typename types::Type>> typechecker::Typechecker::unwrap_type_from_optional_if_needed(NonnullRefPtr<typename types::Type> const type) const {
 {
-ids::StructId const optional_struct_id = TRY((((*this).find_struct_in_prelude(TRY(ByteString::from_utf8("Optional"sv))))));
+ids::StructId const optional_struct_id = TRY((((*this).find_struct_in_prelude((ByteString::must_from_utf8("Optional"sv))))));
 if (((type)->__jakt_init_index() == 20 /* GenericInstance */)){
 ids::StructId const id = (type)->as.GenericInstance.id;
 JaktInternal::DynamicArray<ids::TypeId> const args = (type)->as.GenericInstance.args;
@@ -14926,7 +14926,7 @@ return JaktInternal::ExplicitValue<void>();
 
 types::CheckedBlock const checked_else_block = TRY((((*this).typecheck_block(else_block,scope_id,safety_mode,JaktInternal::OptionalNone()))));
 if (((!(seen_scope_exit)) && ((((checked_else_block).control_flow)).may_return()))){
-TRY((((*this).error(TRY(ByteString::from_utf8("Else block of guard must either `return`, `break`, `continue`, or `throw`"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("Else block of guard must either `return`, `break`, `continue`, or `throw`"sv)),span))));
 }
 JaktInternal::Tuple<NonnullRefPtr<typename parser::ParsedExpression>,JaktInternal::Optional<parser::ParsedBlock>,JaktInternal::Optional<NonnullRefPtr<typename parser::ParsedStatement>>> const new_condition_new_then_block_new_else_statement_ = TRY((((*this).expand_context_for_bindings(expr,JaktInternal::OptionalNone(),remaining_code,TRY((parser::ParsedStatement::Block(else_block,span))),scope_id,span))));
 NonnullRefPtr<typename parser::ParsedExpression> const new_condition = ((new_condition_new_then_block_new_else_statement_).template get<0>());
@@ -14935,7 +14935,7 @@ JaktInternal::Optional<NonnullRefPtr<typename parser::ParsedStatement>> const ne
 
 NonnullRefPtr<typename types::CheckedExpression> const checked_condition = TRY((((*this).typecheck_expression_and_dereference_if_needed(new_condition,scope_id,safety_mode,JaktInternal::OptionalNone(),span))));
 if ((!(((((checked_condition)->type())).equals(types::builtin(types::BuiltinType::Bool())))))){
-TRY((((*this).error(TRY(ByteString::from_utf8("Condition must be a boolean expression"sv)),((new_condition)->span())))));
+TRY((((*this).error((ByteString::must_from_utf8("Condition must be a boolean expression"sv)),((new_condition)->span())))));
 }
 types::CheckedBlock const checked_block = TRY((((*this).typecheck_block((new_then_block.value()),scope_id,safety_mode,JaktInternal::OptionalNone()))));
 JaktInternal::Optional<NonnullRefPtr<typename types::CheckedStatement>> checked_else = JaktInternal::OptionalNone();
@@ -15060,7 +15060,7 @@ NonnullRefPtr<typename types::CheckedExpression> const init = (checked_tuple_var
 (tuple_var_id = var_id);
 }
 else {
-TRY((((*this).error(TRY(ByteString::from_utf8("Destructuting assignment should be a variable declaration"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("Destructuting assignment should be a variable declaration"sv)),span))));
 }
 
 JaktInternal::DynamicArray<ids::TypeId> inner_types = (TRY((DynamicArray<ids::TypeId>::create_with({}))));
@@ -15070,7 +15070,7 @@ JaktInternal::DynamicArray<ids::TypeId> const args = (tuple_type)->as.GenericIns
 (inner_types = args);
 }
 else {
-TRY((((*this).error(TRY(ByteString::from_utf8("Tuple Type should be Generic Instance"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("Tuple Type should be Generic Instance"sv)),span))));
 }
 
 NonnullRefPtr<types::CheckedVariable> const tuple_variable = ((((*this).program))->get_variable(tuple_var_id));
@@ -15095,7 +15095,7 @@ TRY((((var_decls).push(TRY((((*this).typecheck_var_decl(((vars)[i]),init,scope_i
 
 }
 else {
-TRY((((*this).error(TRY(ByteString::from_utf8("Tuple inner types sould have same size as tuple members"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("Tuple inner types sould have same size as tuple members"sv)),span))));
 }
 
 return TRY((types::CheckedStatement::DestructuringAssignment(var_decls,checked_tuple_var_decl,span)));
@@ -15194,7 +15194,7 @@ case 0 /* Struct */: {
 return JaktInternal::ExplicitValue(({ Optional<types::StructLikeId> __jakt_var_490; {
 JaktInternal::Optional<ids::StructId> const struct_id = TRY((((*this).find_struct_in_scope(scope_id,((record).name),JaktInternal::OptionalNone()))));
 if ((!(((struct_id).has_value())))){
-TRY((((((*this).compiler))->panic(TRY(ByteString::from_utf8("can't find previously added struct"sv))))));
+TRY((((((*this).compiler))->panic((ByteString::must_from_utf8("can't find previously added struct"sv))))));
 }
 TRY((((*this).typecheck_struct_constructor(record,(struct_id.value()),scope_id))));
 __jakt_var_490 = types::StructLikeId::Struct(JaktInternal::OptionalNone(),(struct_id.value())); goto __jakt_label_437;
@@ -15206,7 +15206,7 @@ case 1 /* Class */: {
 return JaktInternal::ExplicitValue(({ Optional<types::StructLikeId> __jakt_var_491; {
 JaktInternal::Optional<ids::StructId> const struct_id = TRY((((*this).find_struct_in_scope(scope_id,((record).name),JaktInternal::OptionalNone()))));
 if ((!(((struct_id).has_value())))){
-TRY((((((*this).compiler))->panic(TRY(ByteString::from_utf8("can't find previously added struct"sv))))));
+TRY((((((*this).compiler))->panic((ByteString::must_from_utf8("can't find previously added struct"sv))))));
 }
 TRY((((*this).typecheck_struct_constructor(record,(struct_id.value()),scope_id))));
 __jakt_var_491 = types::StructLikeId::Struct(JaktInternal::OptionalNone(),(struct_id.value())); goto __jakt_label_438;
@@ -15218,7 +15218,7 @@ case 3 /* SumEnum */: {
 return JaktInternal::ExplicitValue(({ Optional<types::StructLikeId> __jakt_var_492; {
 JaktInternal::Optional<ids::EnumId> const enum_id = TRY((((((*this).program))->find_enum_in_scope(scope_id,((record).name),false,JaktInternal::OptionalNone()))));
 if ((!(((enum_id).has_value())))){
-TRY((((((*this).compiler))->panic(TRY(ByteString::from_utf8("can't find previously added enum"sv))))));
+TRY((((((*this).compiler))->panic((ByteString::must_from_utf8("can't find previously added enum"sv))))));
 }
 TRY((((*this).typecheck_enum_constructor(record,(enum_id.value()),scope_id))));
 __jakt_var_492 = types::StructLikeId::Enum(JaktInternal::OptionalNone(),(enum_id.value())); goto __jakt_label_439;
@@ -15230,7 +15230,7 @@ case 2 /* ValueEnum */: {
 return JaktInternal::ExplicitValue(({ Optional<types::StructLikeId> __jakt_var_493; {
 JaktInternal::Optional<ids::EnumId> const enum_id = TRY((((((*this).program))->find_enum_in_scope(scope_id,((record).name),false,JaktInternal::OptionalNone()))));
 if ((!(((enum_id).has_value())))){
-TRY((((((*this).compiler))->panic(TRY(ByteString::from_utf8("can't find previously added enum"sv))))));
+TRY((((((*this).compiler))->panic((ByteString::must_from_utf8("can't find previously added enum"sv))))));
 }
 TRY((((*this).typecheck_enum_constructor(record,(enum_id.value()),scope_id))));
 __jakt_var_493 = types::StructLikeId::Enum(JaktInternal::OptionalNone(),(enum_id.value())); goto __jakt_label_440;
@@ -15279,7 +15279,7 @@ ErrorOr<NonnullRefPtr<typename types::CheckedStatement>> typechecker::Typechecke
 {
 types::CheckedBlock const checked_block = TRY((((*this).typecheck_block(parsed_block,scope_id,safety_mode,JaktInternal::OptionalNone()))));
 if (((((checked_block).yielded_type)).has_value())){
-TRY((((*this).error(TRY(ByteString::from_utf8("A block used as a statement cannot yield values, as the value cannot be observed in any way"sv)),(((parsed_block).find_yield_span()).value())))));
+TRY((((*this).error((ByteString::must_from_utf8("A block used as a statement cannot yield values, as the value cannot be observed in any way"sv)),(((parsed_block).find_yield_span()).value())))));
 }
 return TRY((types::CheckedStatement::Block(checked_block,span)));
 }
@@ -15304,7 +15304,7 @@ bool const is_generic_function = (!(((((parsed_function).generic_parameters)).is
 bool const is_generic = (is_generic_function || (((this_arg_type_id).has_value()) && ((((*this).get_type((this_arg_type_id.value()))))->__jakt_init_index() == 20 /* GenericInstance */)));
 bool has_varargs = ((parsed_function).has_varargs);
 if ((has_varargs && ((((parsed_function).linkage)).__jakt_init_index() == 0 /* Internal */))){
-TRY((((*this).error(TRY(ByteString::from_utf8("Only external functions are allowed to be declared using varargs"sv)),((parsed_function).name_span)))));
+TRY((((*this).error((ByteString::must_from_utf8("Only external functions are allowed to be declared using varargs"sv)),((parsed_function).name_span)))));
 (has_varargs = false);
 }
 NonnullRefPtr<types::CheckedFunction> checked_function = TRY((types::CheckedFunction::__jakt_create(((parsed_function).name),((parsed_function).name_span),TRY((((*this).typecheck_visibility(((parsed_function).visibility),parent_scope_id)))),types::unknown_type_id(),((parsed_function).return_type_span),(TRY((DynamicArray<types::CheckedParameter>::create_with({})))),(generics.value()),types::CheckedBlock((TRY((DynamicArray<NonnullRefPtr<typename types::CheckedStatement>>::create_with({})))),block_scope_id,types::BlockControlFlow::MayReturn(),ids::TypeId::none(),false),((parsed_function).can_throw),((parsed_function).type),((parsed_function).linkage),function_scope_id,JaktInternal::OptionalNone(),((!(is_generic)) || (!(base_definition))),parsed_function,((parsed_function).is_comptime),false,false,((parsed_function).is_unsafe),has_varargs,JaktInternal::OptionalNone(),JaktInternal::OptionalNone(),JaktInternal::OptionalNone(),false,((parsed_function).external_name),((parsed_function).deprecated_message),JaktInternal::OptionalNone(),((parsed_function).force_inline))));
@@ -15408,7 +15408,7 @@ return (infallible_enum_cast<jakt__prelude__operators::Ordering>((JaktInternal::
 }
 }
 (index,((((checked_function)->params)).size()))){
-TRY((((((*this).compiler))->panic(TRY(ByteString::from_utf8("stores_argument() index out of bounds"sv))))));
+TRY((((((*this).compiler))->panic((ByteString::must_from_utf8("stores_argument() index out of bounds"sv))))));
 }
 ({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<void, ErrorOr<ids::FunctionId>>{
@@ -15426,7 +15426,7 @@ return JaktInternal::ExplicitValue<void>();
 };/*case end*/
 default: {
 {
-TRY((((*this).error_with_hint(TRY(ByteString::from_utf8("This parameter is not a reference"sv)),((((((((checked_function)->params))[index])).variable))->definition_span),TRY(ByteString::from_utf8("stores_argument() may only be used to declare reference lifetime requirements"sv)),((((((((checked_function)->params))[index])).variable))->definition_span)))));
+TRY((((*this).error_with_hint((ByteString::must_from_utf8("This parameter is not a reference"sv)),((((((((checked_function)->params))[index])).variable))->definition_span),(ByteString::must_from_utf8("stores_argument() may only be used to declare reference lifetime requirements"sv)),((((((((checked_function)->params))[index])).variable))->definition_span)))));
 }
 return JaktInternal::ExplicitValue<void>();
 };/*case end*/
@@ -15458,7 +15458,7 @@ types::CheckedBlock const block = TRY((((*this).typecheck_block(((parsed_functio
 if (((*this).had_an_error)){
 (function_return_type_id = types::void_type_id());
 (((*this).ignore_errors) = false);
-TRY((((*this).error_with_hint(TRY(ByteString::from_utf8("Can't infer the return type of this function"sv)),((parsed_function).return_type_span),TRY(ByteString::from_utf8("Try adding an explicit return type to the function here"sv)),((parsed_function).return_type_span)))));
+TRY((((*this).error_with_hint((ByteString::must_from_utf8("Can't infer the return type of this function"sv)),((parsed_function).return_type_span),(ByteString::must_from_utf8("Try adding an explicit return type to the function here"sv)),((parsed_function).return_type_span)))));
 }
 else {
 (function_return_type_id = ((*this).infer_function_return_type(block)));
@@ -15515,7 +15515,7 @@ ErrorOr<typechecker::Typechecker> typechecker::Typechecker::typecheck(NonnullRef
 {
 JaktInternal::Optional<utility::FileId> const input_file = ((compiler)->current_file);
 if ((!(((input_file).has_value())))){
-TRY((((compiler)->panic(TRY(ByteString::from_utf8("trying to typecheck a non-existent file"sv))))));
+TRY((((compiler)->panic((ByteString::must_from_utf8("trying to typecheck a non-existent file"sv))))));
 }
 ByteString const true_module_name = TRY((((((((compiler)->files))[(((input_file.value())).id)])).basename(true))));
 ids::ModuleId const placeholder_module_id = ids::ModuleId(static_cast<size_t>(0ULL));
@@ -15528,8 +15528,8 @@ TRY((((compiler)->set_current_file((input_file.value())))));
 types::LoadedModule const loaded_module = types::LoadedModule(root_module_id,(input_file.value()));
 TRY((((((typechecker).program))->set_loaded_module(true_module_name,loaded_module))));
 ids::ScopeId const PRELUDE_SCOPE_ID = ((typechecker).prelude_scope_id());
-ids::ScopeId const root_scope_id = TRY((((typechecker).create_scope(PRELUDE_SCOPE_ID,false,TRY(ByteString::from_utf8("root"sv)),false))));
-TRY((((typechecker).typecheck_module_import(parser::ParsedModuleImport(parser::ImportName::Literal(TRY(ByteString::from_utf8("jakt::prelude::prelude"sv)),utility::Span(utility::FileId(static_cast<size_t>(0ULL)),static_cast<size_t>(0ULL),static_cast<size_t>(0ULL))),JaktInternal::OptionalNone(),parser::ImportList::All(),false,static_cast<size_t>(0ULL)),root_scope_id))));
+ids::ScopeId const root_scope_id = TRY((((typechecker).create_scope(PRELUDE_SCOPE_ID,false,(ByteString::must_from_utf8("root"sv)),false))));
+TRY((((typechecker).typecheck_module_import(parser::ParsedModuleImport(parser::ImportName::Literal((ByteString::must_from_utf8("jakt::prelude::prelude"sv)),utility::Span(utility::FileId(static_cast<size_t>(0ULL)),static_cast<size_t>(0ULL),static_cast<size_t>(0ULL))),JaktInternal::OptionalNone(),parser::ImportList::All(),false,static_cast<size_t>(0ULL)),root_scope_id))));
 {
 JaktInternal::DictionaryIterator<size_t,ids::StructId> _magic = ((((((((((typechecker).program))->modules))[static_cast<i64>(0LL)]))->builtin_implementation_structs)).iterator());
 for (;;){
@@ -15766,7 +15766,7 @@ return JaktInternal::ExplicitValue((Tuple{return_type_id, pseudo_function_id}));
 };/*case end*/
 default: {
 {
-TRY((((((*this).compiler))->panic(TRY(ByteString::from_utf8("Expected the just-checked function to be of a function type"sv))))));
+TRY((((((*this).compiler))->panic((ByteString::must_from_utf8("Expected the just-checked function to be of a function type"sv))))));
 }
 };/*case end*/
 }/*switch end*/
@@ -15786,7 +15786,7 @@ while (((effective_namespace_parent_scope)->is_block_scope)){
 (effective_namespace_parent_scope_id = (((effective_namespace_parent_scope)->parent).value()));
 (effective_namespace_parent_scope = TRY((((*this).get_scope(effective_namespace_parent_scope_id)))));
 }
-ids::ScopeId lambda_scope_id = TRY((((*this).create_scope(effective_namespace_parent_scope_id,can_throw,TRY(ByteString::from_utf8("lambda"sv)),true))));
+ids::ScopeId lambda_scope_id = TRY((((*this).create_scope(effective_namespace_parent_scope_id,can_throw,(ByteString::must_from_utf8("lambda"sv)),true))));
 bool is_capturing_everything = false;
 JaktInternal::DynamicArray<types::CheckedCapture> checked_captures = (TRY((DynamicArray<types::CheckedCapture>::create_with({}))));
 bool has_dependent_capture = false;
@@ -15800,10 +15800,10 @@ break;
 parser::ParsedCapture capture = (_magic_value.value());
 {
 if (((capture).__jakt_init_index() == 4 /* AllByReference */)){
-TRY((((checked_captures).push(types::CheckedCapture::AllByReference(TRY(ByteString::from_utf8(""sv)),((capture).common.init_common.span))))));
+TRY((((checked_captures).push(types::CheckedCapture::AllByReference((ByteString::must_from_utf8(""sv)),((capture).common.init_common.span))))));
 if ((!(is_capturing_everything))){
 (is_capturing_everything = true);
-(lambda_scope_id = TRY((((*this).create_scope(scope_id,can_throw,TRY(ByteString::from_utf8("lambda"sv)),true)))));
+(lambda_scope_id = TRY((((*this).create_scope(scope_id,can_throw,(ByteString::must_from_utf8("lambda"sv)),true)))));
 }
 }
 else if (((TRY((((*this).find_var_in_scope(scope_id,((capture).common.init_common.name),JaktInternal::OptionalNone()))))).has_value())){
@@ -15835,7 +15835,7 @@ __jakt_label_441:; __jakt_var_496.release_value(); }));
 };/*case end*/
 case 4 /* AllByReference */: {
 {
-TRY((((((*this).compiler))->panic(TRY(ByteString::from_utf8("AllByReference capture should not be looked up by name"sv))))));
+TRY((((((*this).compiler))->panic((ByteString::must_from_utf8("AllByReference capture should not be looked up by name"sv))))));
 }
 };/*case end*/
 default: VERIFY_NOT_REACHED();}/*switch end*/
@@ -15851,7 +15851,7 @@ default: VERIFY_NOT_REACHED();}/*switch end*/
 })))));
 if ((!(is_capturing_everything))){
 NonnullRefPtr<types::CheckedVariable> const var = (TRY((((*this).find_var_in_scope(scope_id,((capture).common.init_common.name),JaktInternal::OptionalNone())))).value());
-bool const is_this = ((((var)->name)) == (TRY(ByteString::from_utf8("this"sv))));
+bool const is_this = ((((var)->name)) == ((ByteString::must_from_utf8("this"sv))));
 ids::VarId const var_id = TRY((((module)->add_variable(TRY((types::CheckedVariable::__jakt_create(name,((var)->type_id),(((var)->is_mutable) && ((is_this || ((capture).__jakt_init_index() == 1 /* ByReference */)) || ((capture).__jakt_init_index() == 2 /* ByMutableReference */))),((var)->definition_span),((var)->type_span),((var)->visibility),((var)->owner_scope),JaktInternal::OptionalNone(),JaktInternal::OptionalNone())))))));
 TRY((((*this).add_var_to_scope(lambda_scope_id,name,var_id,span))));
 }
@@ -15933,7 +15933,7 @@ return JaktInternal::ExplicitValue(TRY((((*this).find_or_add_type_id(TRY((types:
 };/*case end*/
 default: {
 {
-TRY((((((*this).compiler))->panic(TRY(ByteString::from_utf8("Expected the just-checked function to be of a function type"sv))))));
+TRY((((((*this).compiler))->panic((ByteString::must_from_utf8("Expected the just-checked function to be of a function type"sv))))));
 }
 };/*case end*/
 }/*switch end*/
@@ -16129,7 +16129,7 @@ TRY((((resolved_args).push((Tuple{name, span, TRY((((*this).typecheck_expression
 return resolved_args;
 }
 else {
-TRY((((*this).error(TRY(ByteString::from_utf8("Wrong number of arguments"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("Wrong number of arguments"sv)),span))));
 return (TRY((DynamicArray<JaktInternal::Tuple<ByteString,utility::Span,NonnullRefPtr<typename types::CheckedExpression>>>::create_with({}))));
 }
 
@@ -16458,7 +16458,7 @@ return JaktInternal::ExplicitValue(fields);
 };/*case end*/
 default: {
 {
-TRY((((((*this).compiler))->panic(TRY(ByteString::from_utf8("typecheck_struct_fields cannot handle non-structs"sv))))));
+TRY((((((*this).compiler))->panic((ByteString::must_from_utf8("typecheck_struct_fields cannot handle non-structs"sv))))));
 }
 };/*case end*/
 }/*switch end*/
@@ -16532,19 +16532,19 @@ ScopeGuard __jakt_var_509([&] {
 bool const is_print_like = (((((call).namespace_)).is_empty()) && ({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<bool,ErrorOr<NonnullRefPtr<typename types::CheckedExpression>>>{
 auto __jakt_enum_value = (((call).name));
-if (__jakt_enum_value == TRY(ByteString::from_utf8("print"sv))) {
+if (__jakt_enum_value == (ByteString::must_from_utf8("print"sv))) {
 return JaktInternal::ExplicitValue(true);
 }
-else if (__jakt_enum_value == TRY(ByteString::from_utf8("println"sv))) {
+else if (__jakt_enum_value == (ByteString::must_from_utf8("println"sv))) {
 return JaktInternal::ExplicitValue(true);
 }
-else if (__jakt_enum_value == TRY(ByteString::from_utf8("eprintln"sv))) {
+else if (__jakt_enum_value == (ByteString::must_from_utf8("eprintln"sv))) {
 return JaktInternal::ExplicitValue(true);
 }
-else if (__jakt_enum_value == TRY(ByteString::from_utf8("eprint"sv))) {
+else if (__jakt_enum_value == (ByteString::must_from_utf8("eprint"sv))) {
 return JaktInternal::ExplicitValue(true);
 }
-else if (__jakt_enum_value == TRY(ByteString::from_utf8("format"sv))) {
+else if (__jakt_enum_value == (ByteString::must_from_utf8("format"sv))) {
 return JaktInternal::ExplicitValue(true);
 }
 else {
@@ -16689,7 +16689,7 @@ auto __jakt_enum_value = (first);
 if (__jakt_enum_value == true) {
 return JaktInternal::ExplicitValue(({ Optional<JaktInternal::Optional<ids::TypeId>> __jakt_var_514; {
 (first = false);
-__jakt_var_514 = static_cast<JaktInternal::Optional<ids::TypeId>>(TRY((((*this).prelude_struct_type_named(TRY(ByteString::from_utf8("StringView"sv))))))); goto __jakt_label_452;
+__jakt_var_514 = static_cast<JaktInternal::Optional<ids::TypeId>>(TRY((((*this).prelude_struct_type_named((ByteString::must_from_utf8("StringView"sv))))))); goto __jakt_label_452;
 
 }
 __jakt_label_452:; __jakt_var_514.release_value(); }));
@@ -16714,8 +16714,8 @@ TRY((((args).push((Tuple{((call).name), checked_arg})))));
 }
 }
 
-if (((((call).name)) == (TRY(ByteString::from_utf8("format"sv))))){
-(return_type = TRY((((*this).prelude_struct_type_named(TRY(ByteString::from_utf8("String"sv)))))));
+if (((((call).name)) == ((ByteString::must_from_utf8("format"sv))))){
+(return_type = TRY((((*this).prelude_struct_type_named((ByteString::must_from_utf8("String"sv)))))));
 (callee_throws = true);
 }
 }
@@ -16817,7 +16817,7 @@ default: VERIFY_NOT_REACHED();}/*switch end*/
 
 if ((!(((resolved_function_id).has_value())))){
 if ((!(((resolved_function_id_candidates).is_empty())))){
-TRY((((*this).error(TRY(ByteString::from_utf8("No function with matching signature found."sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("No function with matching signature found."sv)),span))));
 {
 JaktInternal::ArrayIterator<error::JaktError> _magic = ((errors_while_trying_to_find_matching_function).iterator());
 for (;;){
@@ -16892,7 +16892,7 @@ NonnullRefPtr<types::CheckedFunction> const callee = ((*this).get_function((reso
 (callee_throws = ((callee)->can_throw));
 (return_type = ((callee)->return_type_id));
 if ((((callee)->is_unsafe) && ((safety_mode).__jakt_init_index() == 0 /* Safe */))){
-TRY((((*this).error(TRY(ByteString::from_utf8("Cannot call unsafe function in safe context"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("Cannot call unsafe function in safe context"sv)),span))));
 }
 if ((((type_hint).has_value()) && (!(((((type_hint).value())).equals(types::unknown_type_id())))))){
 bool const old_ignore_errors = ((*this).ignore_errors);
@@ -16926,7 +16926,7 @@ if (((substitution).has_value())){
 TRY((((generic_arguments).push((substitution.value())))));
 }
 else if ((!(((*this).in_comptime_function_call)))){
-TRY((((*this).error(TRY(ByteString::from_utf8("Not all generic parameters have known types"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("Not all generic parameters have known types"sv)),span))));
 }
 else {
 TRY((((generic_arguments).push(((generic_typevar).type_id())))));
@@ -16950,7 +16950,7 @@ TRY((((*this).check_types_for_compat((type_hint.value()),return_type,((((*this).
 
 (return_type = TRY((((*this).substitute_typevars_in_type(return_type,((*this).generic_inferences))))));
 if ((callee_throws && (!(((TRY((((*this).get_scope(caller_scope_id)))))->can_throw))))){
-TRY((((*this).error(TRY(ByteString::from_utf8("Call to function that may throw needs to be in a try statement or a function marked as throws"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("Call to function that may throw needs to be in a try statement or a function marked as throws"sv)),span))));
 }
 if (((generic_checked_function_to_instantiate).has_value())){
 if (((maybe_this_type_id).has_value())){
@@ -17037,7 +17037,7 @@ default: VERIFY_NOT_REACHED();}/*switch end*/
     _jakt_value.release_value();
 });
 if (TRY((((*this).scope_lifetime_subsumes(stored_scope_id,arg_scope_id))))){
-TRY((((*this).error(TRY(ByteString::from_utf8("Cannot pass this argument by reference, it is not guaranteed to outlive the object it will be stored in"sv)),((TRY((resolve_arg(index))))->span())))));
+TRY((((*this).error((ByteString::must_from_utf8("Cannot pass this argument by reference, it is not guaranteed to outlive the object it will be stored in"sv)),((TRY((resolve_arg(index))))->span())))));
 }
 }
 
@@ -17102,14 +17102,14 @@ types::Value const value = (evaluated_this).as.Throw.value;
 TRY((((*this).error(TRY((__jakt_format((StringView::from_string_literal("Error executing this expression (evaluation threw {})"sv)),value))),(((this_expr.value()))->span())))));
 }
 else {
-TRY((((*this).error(TRY(ByteString::from_utf8("Invalid this expression"sv)),(((this_expr.value()))->span())))));
+TRY((((*this).error((ByteString::must_from_utf8("Invalid this expression"sv)),(((this_expr.value()))->span())))));
 }
 
 }
 
 ;return {};}();
 if (__jakt_var_516.is_error()) {{
-TRY((((*this).error(TRY(ByteString::from_utf8("Error executing this expression"sv)),(((this_expr.value()))->span())))));
+TRY((((*this).error((ByteString::must_from_utf8("Error executing this expression"sv)),(((this_expr.value()))->span())))));
 }
 };
 }
@@ -17125,7 +17125,7 @@ JaktInternal::Tuple<ByteString,NonnullRefPtr<typename types::CheckedExpression>>
 interpreter::StatementResult const value = ({ Optional<interpreter::StatementResult> __jakt_var_517;
 auto __jakt_var_518 = [&]() -> ErrorOr<interpreter::StatementResult> { return TRY((((interpreter)->execute_expression(((argument).template get<1>()),eval_scope)))); }();
 if (__jakt_var_518.is_error()) {{
-TRY((((*this).error(TRY(ByteString::from_utf8("Error in argument"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("Error in argument"sv)),span))));
 continue;
 }
 } else {__jakt_var_517 = __jakt_var_518.release_value();
@@ -17337,7 +17337,7 @@ return JaktInternal::ExplicitValue<void>();
     _jakt_value.release_value();
 });
 }
-TRY((((*this).error(TRY((__jakt_format((StringView::from_string_literal("Not a namespace, enum, class, or struct: ‘{}’"sv)),TRY((utility::join(((call).namespace_),TRY(ByteString::from_utf8("::"sv)))))))),span))));
+TRY((((*this).error(TRY((__jakt_format((StringView::from_string_literal("Not a namespace, enum, class, or struct: ‘{}’"sv)),TRY((utility::join(((call).namespace_),(ByteString::must_from_utf8("::"sv)))))))),span))));
 }
 
 }
@@ -17599,7 +17599,7 @@ ids::ScopeId const import_scope_id = ({ Optional<ids::ScopeId> __jakt_var_523;
 auto __jakt_var_524 = [&]() -> ErrorOr<ids::ScopeId> { return TRY((((*this).cache_or_process_cpp_import(output,child_scope_id,false,(TRY((Dictionary<ByteString, ByteString>::create_with_entries({})))))))); }();
 if (__jakt_var_524.is_error()) {auto e = __jakt_var_524.release_error();
 {
-if (((TRY((ByteString::from_utf8(((e).string_literal()))))) == (TRY((ByteString::from_utf8(cpp_import__common::CppImportErrors::path_not_found())))))){
+if (((ByteString::must_from_utf8(((e).string_literal()))) == (ByteString::must_from_utf8(cpp_import__common::CppImportErrors::path_not_found())))){
 {
 JaktInternal::ArrayIterator<parser::ParsedExternImport> _magic = ((imports).iterator());
 for (;;){
@@ -17609,7 +17609,7 @@ break;
 }
 parser::ParsedExternImport import_ = (_magic_value.value());
 {
-TRY((((*this).error_with_hint(TRY((__jakt_format((StringView::from_string_literal("Could not find imported extern file '{}'"sv)),((import_).get_path())))),(((((import_).assigned_namespace)).name_span).value()),TRY(ByteString::from_utf8("make sure the file exists and is in the include path"sv)),(((((import_).assigned_namespace)).name_span).value())))));
+TRY((((*this).error_with_hint(TRY((__jakt_format((StringView::from_string_literal("Could not find imported extern file '{}'"sv)),((import_).get_path())))),(((((import_).assigned_namespace)).name_span).value()),(ByteString::must_from_utf8("make sure the file exists and is in the include path"sv)),(((((import_).assigned_namespace)).name_span).value())))));
 }
 
 }
@@ -17653,11 +17653,11 @@ JaktInternal::Optional<NonnullRefPtr<typename parser::ParsedStatement>> const ne
 
 NonnullRefPtr<typename types::CheckedExpression> const checked_condition = TRY((((*this).typecheck_expression_and_dereference_if_needed(new_condition,scope_id,safety_mode,JaktInternal::OptionalNone(),span))));
 if ((!(((((checked_condition)->type())).equals(types::builtin(types::BuiltinType::Bool())))))){
-TRY((((*this).error(TRY(ByteString::from_utf8("Condition must be a boolean expression"sv)),((new_condition)->span())))));
+TRY((((*this).error((ByteString::must_from_utf8("Condition must be a boolean expression"sv)),((new_condition)->span())))));
 }
 types::CheckedBlock const checked_block = TRY((((*this).typecheck_block((new_then_block.value()),scope_id,safety_mode,JaktInternal::OptionalNone()))));
 if (((((checked_block).yielded_type)).has_value())){
-TRY((((*this).error(TRY(ByteString::from_utf8("An 'if' block is not allowed to yield values"sv)),((((new_then_block.value())).find_yield_span()).value())))));
+TRY((((*this).error((ByteString::must_from_utf8("An 'if' block is not allowed to yield values"sv)),((((new_then_block.value())).find_yield_span()).value())))));
 }
 JaktInternal::Optional<NonnullRefPtr<typename types::CheckedStatement>> checked_else = JaktInternal::OptionalNone();
 if (((new_else_statement).has_value())){
@@ -17989,20 +17989,20 @@ ErrorOr<NonnullRefPtr<typename types::CheckedStatement>> typechecker::Typechecke
 {
 JaktInternal::Optional<utility::Span> const maybe_span = ((block).find_yield_span());
 if (((maybe_span).has_value())){
-TRY((((*this).error(TRY(ByteString::from_utf8("a 'for' loop block is not allowed to yield values"sv)),(maybe_span.value())))));
+TRY((((*this).error((ByteString::must_from_utf8("a 'for' loop block is not allowed to yield values"sv)),(maybe_span.value())))));
 }
 NonnullRefPtr<typename types::CheckedExpression> iterable_expr = TRY((((*this).typecheck_expression_and_dereference_if_needed(range,scope_id,safety_mode,JaktInternal::OptionalNone(),span))));
 ids::TypeId resolved_iterable_result_type = types::unknown_type_id();
 NonnullRefPtr<typename parser::ParsedExpression> expression_to_iterate = range;
-JaktInternal::Optional<typechecker::TraitImplementationDescriptor> const iterable_trait_implementation = TRY((((*this).find_any_singular_trait_implementation(((iterable_expr)->type()),(TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("Iterable"sv)), TRY(ByteString::from_utf8("ThrowingIterable"sv))})))),scope_id,((iterable_expr)->span()),JaktInternal::OptionalNone()))));
+JaktInternal::Optional<typechecker::TraitImplementationDescriptor> const iterable_trait_implementation = TRY((((*this).find_any_singular_trait_implementation(((iterable_expr)->type()),(TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("Iterable"sv)), (ByteString::must_from_utf8("ThrowingIterable"sv))})))),scope_id,((iterable_expr)->span()),JaktInternal::OptionalNone()))));
 if ((!(((iterable_trait_implementation).has_value())))){
-JaktInternal::Optional<typechecker::TraitImplementationDescriptor> const into_iterator_trait_implementation = TRY((((*this).find_any_singular_trait_implementation(((iterable_expr)->type()),(TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("IntoIterator"sv)), TRY(ByteString::from_utf8("IntoThrowingIterator"sv))})))),scope_id,((iterable_expr)->span()),JaktInternal::OptionalNone()))));
+JaktInternal::Optional<typechecker::TraitImplementationDescriptor> const into_iterator_trait_implementation = TRY((((*this).find_any_singular_trait_implementation(((iterable_expr)->type()),(TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("IntoIterator"sv)), (ByteString::must_from_utf8("IntoThrowingIterator"sv))})))),scope_id,((iterable_expr)->span()),JaktInternal::OptionalNone()))));
 if ((!(((into_iterator_trait_implementation).has_value())))){
-TRY((((*this).error_with_hint(TRY(ByteString::from_utf8("Iterable expression is not iterable"sv)),((range)->span()),TRY((__jakt_format((StringView::from_string_literal("Consider implementing (Throwing)Iterable<T> or Into(Throwing)Iterator<T> for the type of this expression (‘{}’)"sv)),TRY((((*this).type_name(((iterable_expr)->type()),false))))))),((range)->span())))));
+TRY((((*this).error_with_hint((ByteString::must_from_utf8("Iterable expression is not iterable"sv)),((range)->span()),TRY((__jakt_format((StringView::from_string_literal("Consider implementing (Throwing)Iterable<T> or Into(Throwing)Iterator<T> for the type of this expression (‘{}’)"sv)),TRY((((*this).type_name(((iterable_expr)->type()),false))))))),((range)->span())))));
 }
 else {
 (resolved_iterable_result_type = (((((into_iterator_trait_implementation.value())).implemented_type_args))[static_cast<i64>(0LL)]));
-(expression_to_iterate = TRY((parser::ParsedExpression::MethodCall(range,parser::ParsedCall((TRY((DynamicArray<ByteString>::create_with({})))),TRY(ByteString::from_utf8("iterator"sv)),(TRY((DynamicArray<JaktInternal::Tuple<ByteString,utility::Span,NonnullRefPtr<typename parser::ParsedExpression>>>::create_with({})))),(TRY((DynamicArray<NonnullRefPtr<typename parser::ParsedType>>::create_with({}))))),false,name_span))));
+(expression_to_iterate = TRY((parser::ParsedExpression::MethodCall(range,parser::ParsedCall((TRY((DynamicArray<ByteString>::create_with({})))),(ByteString::must_from_utf8("iterator"sv)),(TRY((DynamicArray<JaktInternal::Tuple<ByteString,utility::Span,NonnullRefPtr<typename parser::ParsedExpression>>>::create_with({})))),(TRY((DynamicArray<NonnullRefPtr<typename parser::ParsedType>>::create_with({}))))),false,name_span))));
 }
 
 }
@@ -18010,7 +18010,7 @@ else {
 (resolved_iterable_result_type = (((((iterable_trait_implementation.value())).implemented_type_args))[static_cast<i64>(0LL)]));
 }
 
-NonnullRefPtr<typename parser::ParsedStatement> const rewritten_statement = TRY((parser::ParsedStatement::Block(parser::ParsedBlock((TRY((DynamicArray<NonnullRefPtr<typename parser::ParsedStatement>>::create_with({TRY((parser::ParsedStatement::VarDecl(parser::ParsedVarDecl(TRY(ByteString::from_utf8("_magic"sv)),TRY((parser::ParsedType::Empty(JaktInternal::OptionalNone()))),true,JaktInternal::OptionalNone(),name_span,JaktInternal::OptionalNone()),expression_to_iterate,span))), TRY((parser::ParsedStatement::Loop(parser::ParsedBlock((TRY((DynamicArray<NonnullRefPtr<typename parser::ParsedStatement>>::create_with({TRY((parser::ParsedStatement::VarDecl(parser::ParsedVarDecl(TRY(ByteString::from_utf8("_magic_value"sv)),TRY((parser::ParsedType::Empty(JaktInternal::OptionalNone()))),false,JaktInternal::OptionalNone(),name_span,JaktInternal::OptionalNone()),TRY((parser::ParsedExpression::MethodCall(TRY((parser::ParsedExpression::Var(TRY(ByteString::from_utf8("_magic"sv)),name_span))),parser::ParsedCall((TRY((DynamicArray<ByteString>::create_with({})))),TRY(ByteString::from_utf8("next"sv)),(TRY((DynamicArray<JaktInternal::Tuple<ByteString,utility::Span,NonnullRefPtr<typename parser::ParsedExpression>>>::create_with({})))),(TRY((DynamicArray<NonnullRefPtr<typename parser::ParsedType>>::create_with({}))))),false,name_span))),span))), TRY((parser::ParsedStatement::If(TRY((parser::ParsedExpression::UnaryOp(TRY((parser::ParsedExpression::MethodCall(TRY((parser::ParsedExpression::Var(TRY(ByteString::from_utf8("_magic_value"sv)),name_span))),parser::ParsedCall((TRY((DynamicArray<ByteString>::create_with({})))),TRY(ByteString::from_utf8("has_value"sv)),(TRY((DynamicArray<JaktInternal::Tuple<ByteString,utility::Span,NonnullRefPtr<typename parser::ParsedExpression>>>::create_with({})))),(TRY((DynamicArray<NonnullRefPtr<typename parser::ParsedType>>::create_with({}))))),false,name_span))),parser::UnaryOperator::LogicalNot(),name_span))),parser::ParsedBlock((TRY((DynamicArray<NonnullRefPtr<typename parser::ParsedStatement>>::create_with({TRY((parser::ParsedStatement::Break(span)))}))))),JaktInternal::OptionalNone(),span))), TRY((parser::ParsedStatement::VarDecl(parser::ParsedVarDecl(iterator_name,TRY((parser::ParsedType::Empty(JaktInternal::OptionalNone()))),true,({
+NonnullRefPtr<typename parser::ParsedStatement> const rewritten_statement = TRY((parser::ParsedStatement::Block(parser::ParsedBlock((TRY((DynamicArray<NonnullRefPtr<typename parser::ParsedStatement>>::create_with({TRY((parser::ParsedStatement::VarDecl(parser::ParsedVarDecl((ByteString::must_from_utf8("_magic"sv)),TRY((parser::ParsedType::Empty(JaktInternal::OptionalNone()))),true,JaktInternal::OptionalNone(),name_span,JaktInternal::OptionalNone()),expression_to_iterate,span))), TRY((parser::ParsedStatement::Loop(parser::ParsedBlock((TRY((DynamicArray<NonnullRefPtr<typename parser::ParsedStatement>>::create_with({TRY((parser::ParsedStatement::VarDecl(parser::ParsedVarDecl((ByteString::must_from_utf8("_magic_value"sv)),TRY((parser::ParsedType::Empty(JaktInternal::OptionalNone()))),false,JaktInternal::OptionalNone(),name_span,JaktInternal::OptionalNone()),TRY((parser::ParsedExpression::MethodCall(TRY((parser::ParsedExpression::Var((ByteString::must_from_utf8("_magic"sv)),name_span))),parser::ParsedCall((TRY((DynamicArray<ByteString>::create_with({})))),(ByteString::must_from_utf8("next"sv)),(TRY((DynamicArray<JaktInternal::Tuple<ByteString,utility::Span,NonnullRefPtr<typename parser::ParsedExpression>>>::create_with({})))),(TRY((DynamicArray<NonnullRefPtr<typename parser::ParsedType>>::create_with({}))))),false,name_span))),span))), TRY((parser::ParsedStatement::If(TRY((parser::ParsedExpression::UnaryOp(TRY((parser::ParsedExpression::MethodCall(TRY((parser::ParsedExpression::Var((ByteString::must_from_utf8("_magic_value"sv)),name_span))),parser::ParsedCall((TRY((DynamicArray<ByteString>::create_with({})))),(ByteString::must_from_utf8("has_value"sv)),(TRY((DynamicArray<JaktInternal::Tuple<ByteString,utility::Span,NonnullRefPtr<typename parser::ParsedExpression>>>::create_with({})))),(TRY((DynamicArray<NonnullRefPtr<typename parser::ParsedType>>::create_with({}))))),false,name_span))),parser::UnaryOperator::LogicalNot(),name_span))),parser::ParsedBlock((TRY((DynamicArray<NonnullRefPtr<typename parser::ParsedStatement>>::create_with({TRY((parser::ParsedStatement::Break(span)))}))))),JaktInternal::OptionalNone(),span))), TRY((parser::ParsedStatement::VarDecl(parser::ParsedVarDecl(iterator_name,TRY((parser::ParsedType::Empty(JaktInternal::OptionalNone()))),true,({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<JaktInternal::Optional<utility::Span>,ErrorOr<NonnullRefPtr<typename types::CheckedStatement>>>{
 auto __jakt_enum_value = (is_destructuring);
 if (__jakt_enum_value == true) {
@@ -18024,7 +18024,7 @@ VERIFY_NOT_REACHED();
     if (_jakt_value.is_return())
         return _jakt_value.release_return();
     _jakt_value.release_value();
-}),name_span,JaktInternal::OptionalNone()),TRY((parser::ParsedExpression::ForcedUnwrap(TRY((parser::ParsedExpression::Var(TRY(ByteString::from_utf8("_magic_value"sv)),name_span))),name_span))),span))), TRY((parser::ParsedStatement::Block(block,span)))}))))),span)))}))))),span)));
+}),name_span,JaktInternal::OptionalNone()),TRY((parser::ParsedExpression::ForcedUnwrap(TRY((parser::ParsedExpression::Var((ByteString::must_from_utf8("_magic_value"sv)),name_span))),name_span))),span))), TRY((parser::ParsedStatement::Block(block,span)))}))))),span)))}))))),span)));
 return TRY((((*this).typecheck_statement(rewritten_statement,scope_id,safety_mode,JaktInternal::OptionalNone()))));
 }
 }
@@ -18147,7 +18147,7 @@ break;
 parser::ParsedMethod method = (_magic_value.value());
 {
 JaktInternal::Optional<ids::TypeId> this_arg_type_id = JaktInternal::OptionalNone();
-if (((TRY((((((((((((method).parsed_function)).params)).first())).map([](auto& _value) { return _value.variable; }))).map([](auto& _value) { return _value.name; })).try_value_or_lazy_evaluated([&]() -> ErrorOr<ByteString> { return TRY(ByteString::from_utf8(""sv)); })))) == (TRY(ByteString::from_utf8("this"sv))))){
+if (((TRY((((((((((((method).parsed_function)).params)).first())).map([](auto& _value) { return _value.variable; }))).map([](auto& _value) { return _value.name; })).try_value_or_lazy_evaluated([&]() -> ErrorOr<ByteString> { return (ByteString::must_from_utf8(""sv)); })))) == ((ByteString::must_from_utf8("this"sv))))){
 (this_arg_type_id = ({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<JaktInternal::Optional<ids::TypeId>, ErrorOr<void>>{
 auto&& __jakt_match_variant = *((*this).get_type(for_type));
@@ -18243,7 +18243,7 @@ if (((*this).dump_try_hints)){
 TRY((((*this).dump_try_hint(span))));
 }
 if ((!(((TRY((((*this).get_scope(scope_id)))))->can_throw)))){
-ByteString const message = TRY(ByteString::from_utf8("Array initialization inside non-throwing scope"sv));
+ByteString const message = (ByteString::must_from_utf8("Array initialization inside non-throwing scope"sv));
 if (((((*this).current_function_id)).has_value())){
 NonnullRefPtr<types::CheckedFunction> const current_function = ((*this).get_function((((*this).current_function_id).value())));
 TRY((((*this).error_with_hint(message,span,TRY((__jakt_format((StringView::from_string_literal("Add `throws` keyword to function {}"sv)),((current_function)->name)))),((current_function)->name_span)))));
@@ -18263,7 +18263,7 @@ TRY((((*this).error(TRY((__jakt_format((StringView::from_string_literal("Type '{
 }
 (repeat = fill_size_checked);
 }
-ids::StructId const array_struct_id = TRY((((*this).find_struct_in_prelude(TRY(ByteString::from_utf8("Array"sv))))));
+ids::StructId const array_struct_id = TRY((((*this).find_struct_in_prelude((ByteString::must_from_utf8("Array"sv))))));
 ids::TypeId inner_type_id = types::unknown_type_id();
 JaktInternal::Optional<utility::Span> inferred_type_span = JaktInternal::OptionalNone();
 JaktInternal::Optional<ids::TypeId> inner_hint = JaktInternal::OptionalNone();
@@ -18284,7 +18284,7 @@ NonnullRefPtr<typename parser::ParsedExpression> value = (_magic_value.value());
 NonnullRefPtr<typename types::CheckedExpression> const checked_expr = TRY((((*this).typecheck_expression(value,scope_id,safety_mode,inner_hint))));
 ids::TypeId const current_value_type_id = ((checked_expr)->type());
 if (((current_value_type_id).equals(types::void_type_id()))){
-TRY((((*this).error(TRY(ByteString::from_utf8("Cannot create an array with values of type void\n"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("Cannot create an array with values of type void\n"sv)),span))));
 }
 if (((inner_type_id).equals(types::unknown_type_id()))){
 (inner_type_id = current_value_type_id);
@@ -18304,7 +18304,7 @@ if (((inner_hint).has_value())){
 (inner_type_id = (inner_hint.value()));
 }
 else if ((((type_hint).has_value()) && (((type_hint.value())).equals(types::unknown_type_id())))){
-TRY((((*this).error(TRY(ByteString::from_utf8("Cannot infer generic type for Array<T>"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("Cannot infer generic type for Array<T>"sv)),span))));
 }
 }
 ids::TypeId const type_id = TRY((((*this).find_or_add_type_id(TRY((types::Type::GenericInstance(parser::CheckedQualifiers(false),array_struct_id,(TRY((DynamicArray<ids::TypeId>::create_with({inner_type_id})))))))))));
@@ -18439,7 +18439,7 @@ return {};
 ErrorOr<void> typechecker::Typechecker::typecheck_trait_predecl(parser::ParsedTrait const parsed_trait,ids::ScopeId const scope_id) {
 {
 ids::ScopeId const trait_scope_id = TRY((((*this).create_scope(scope_id,false,TRY((__jakt_format((StringView::from_string_literal("trait({})"sv)),((parsed_trait).name)))),false))));
-TRY((((*this).add_type_to_scope(trait_scope_id,TRY(ByteString::from_utf8("Self"sv)),TRY((((*this).find_or_add_type_id(TRY((types::Type::Self(parser::CheckedQualifiers(false)))))))),((parsed_trait).name_span)))));
+TRY((((*this).add_type_to_scope(trait_scope_id,(ByteString::must_from_utf8("Self"sv)),TRY((((*this).find_or_add_type_id(TRY((types::Type::Self(parser::CheckedQualifiers(false)))))))),((parsed_trait).name_span)))));
 NonnullRefPtr<types::CheckedTrait> checked_trait = TRY((types::CheckedTrait::__jakt_create(((parsed_trait).name),((parsed_trait).name_span),({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<types::CheckedTraitRequirements, ErrorOr<void>>{
 auto&& __jakt_match_variant = ((parsed_trait).requirements);
@@ -18516,7 +18516,7 @@ parser::ParsedFunction parsed_function = (_magic_value.value());
 ids::ScopeId const method_scope_id = TRY((((*this).create_scope(trait_scope_id,((parsed_function).can_throw),TRY((__jakt_format((StringView::from_string_literal("trait-method({}::{})"sv)),((parsed_trait).name),((parsed_function).name)))),true))));
 ids::FunctionId const function_id = ((((((*this).program))->get_module(((*this).current_module_id))))->next_function_id());
 JaktInternal::Optional<ids::TypeId> this_arg_type_id = JaktInternal::OptionalNone();
-if (((!(((((parsed_function).params)).is_empty()))) && (((((((((((parsed_function).params)).first()).value())).variable)).name)) == (TRY(ByteString::from_utf8("this"sv)))))){
+if (((!(((((parsed_function).params)).is_empty()))) && (((((((((((parsed_function).params)).first()).value())).variable)).name)) == ((ByteString::must_from_utf8("this"sv)))))){
 (this_arg_type_id = struct_type_id);
 }
 TRY((((*this).typecheck_function_predecl(parsed_function,trait_scope_id,this_arg_type_id,JaktInternal::OptionalNone(),JaktInternal::OptionalNone()))));
@@ -18620,7 +18620,7 @@ auto&& __jakt_match_value = __jakt_match_variant.as.Comptime;NonnullRefPtr<typen
 return JaktInternal::ExplicitValue(({ Optional<JaktInternal::Optional<JaktInternal::DynamicArray<JaktInternal::Tuple<ByteString,utility::Span>>>> __jakt_var_535; {
 NonnullRefPtr<interpreter::Interpreter> interpreter = TRY((((*this).interpreter())));
 NonnullRefPtr<interpreter::InterpreterScope> eval_scope = TRY((interpreter::InterpreterScope::from_runtime_scope(scope_id,((*this).program),JaktInternal::OptionalNone())));
-ids::ScopeId const exec_scope = TRY((((*this).create_scope(scope_id,true,TRY(ByteString::from_utf8("comptime-import"sv)),true))));
+ids::ScopeId const exec_scope = TRY((((*this).create_scope(scope_id,true,(ByteString::must_from_utf8("comptime-import"sv)),true))));
 interpreter::StatementResult const result = TRY((((interpreter)->execute_expression(TRY((((*this).typecheck_expression(expression,exec_scope,types::SafetyMode::Safe(),JaktInternal::OptionalNone())))),eval_scope))));
 __jakt_var_535 = ({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<JaktInternal::Optional<JaktInternal::DynamicArray<JaktInternal::Tuple<ByteString,utility::Span>>>, ErrorOr<void>>{
@@ -18628,7 +18628,7 @@ auto&& __jakt_match_variant = result;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 0 /* Return */: {
 return JaktInternal::ExplicitValue(({ Optional<JaktInternal::DynamicArray<JaktInternal::Tuple<ByteString,utility::Span>>> __jakt_var_536; {
-TRY((((*this).error_with_hint(TRY(ByteString::from_utf8("module name must evaluate to a string literal or an array of strings"sv)),((expression)->span()),TRY(ByteString::from_utf8("this expression evaluates to an invalid value"sv)),((expression)->span())))));
+TRY((((*this).error_with_hint((ByteString::must_from_utf8("module name must evaluate to a string literal or an array of strings"sv)),((expression)->span()),(ByteString::must_from_utf8("this expression evaluates to an invalid value"sv)),((expression)->span())))));
 __jakt_var_536 = JaktInternal::OptionalNone(); goto __jakt_label_458;
 
 }
@@ -18636,7 +18636,7 @@ __jakt_label_458:; __jakt_var_536; }));
 };/*case end*/
 case 2 /* Yield */: {
 return JaktInternal::ExplicitValue(({ Optional<JaktInternal::DynamicArray<JaktInternal::Tuple<ByteString,utility::Span>>> __jakt_var_537; {
-TRY((((*this).error_with_hint(TRY(ByteString::from_utf8("module name must evaluate to a string literal or an array of strings"sv)),((expression)->span()),TRY(ByteString::from_utf8("this expression evaluates to an invalid value"sv)),((expression)->span())))));
+TRY((((*this).error_with_hint((ByteString::must_from_utf8("module name must evaluate to a string literal or an array of strings"sv)),((expression)->span()),(ByteString::must_from_utf8("this expression evaluates to an invalid value"sv)),((expression)->span())))));
 __jakt_var_537 = JaktInternal::OptionalNone(); goto __jakt_label_459;
 
 }
@@ -18644,7 +18644,7 @@ __jakt_label_459:; __jakt_var_537; }));
 };/*case end*/
 case 3 /* Continue */: {
 return JaktInternal::ExplicitValue(({ Optional<JaktInternal::DynamicArray<JaktInternal::Tuple<ByteString,utility::Span>>> __jakt_var_538; {
-TRY((((*this).error_with_hint(TRY(ByteString::from_utf8("module name must evaluate to a string literal or an array of strings"sv)),((expression)->span()),TRY(ByteString::from_utf8("this expression evaluates to an invalid value"sv)),((expression)->span())))));
+TRY((((*this).error_with_hint((ByteString::must_from_utf8("module name must evaluate to a string literal or an array of strings"sv)),((expression)->span()),(ByteString::must_from_utf8("this expression evaluates to an invalid value"sv)),((expression)->span())))));
 __jakt_var_538 = JaktInternal::OptionalNone(); goto __jakt_label_460;
 
 }
@@ -18652,7 +18652,7 @@ __jakt_label_460:; __jakt_var_538; }));
 };/*case end*/
 case 4 /* Break */: {
 return JaktInternal::ExplicitValue(({ Optional<JaktInternal::DynamicArray<JaktInternal::Tuple<ByteString,utility::Span>>> __jakt_var_539; {
-TRY((((*this).error_with_hint(TRY(ByteString::from_utf8("module name must evaluate to a string literal or an array of strings"sv)),((expression)->span()),TRY(ByteString::from_utf8("this expression evaluates to an invalid value"sv)),((expression)->span())))));
+TRY((((*this).error_with_hint((ByteString::must_from_utf8("module name must evaluate to a string literal or an array of strings"sv)),((expression)->span()),(ByteString::must_from_utf8("this expression evaluates to an invalid value"sv)),((expression)->span())))));
 __jakt_var_539 = JaktInternal::OptionalNone(); goto __jakt_label_461;
 
 }
@@ -18661,7 +18661,7 @@ __jakt_label_461:; __jakt_var_539; }));
 case 1 /* Throw */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Throw;types::Value const& error = __jakt_match_value.value;
 return JaktInternal::ExplicitValue(({ Optional<JaktInternal::DynamicArray<JaktInternal::Tuple<ByteString,utility::Span>>> __jakt_var_540; {
-TRY((((*this).error_with_hint(TRY(ByteString::from_utf8("module name must evaluate to a string literal or an array of strings"sv)),((expression)->span()),TRY((__jakt_format((StringView::from_string_literal("this expression threw an error: {}"sv)),error))),((expression)->span())))));
+TRY((((*this).error_with_hint((ByteString::must_from_utf8("module name must evaluate to a string literal or an array of strings"sv)),((expression)->span()),TRY((__jakt_format((StringView::from_string_literal("this expression threw an error: {}"sv)),error))),((expression)->span())))));
 __jakt_var_540 = JaktInternal::OptionalNone(); goto __jakt_label_462;
 
 }
@@ -18681,7 +18681,7 @@ case 20 /* JaktArray */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.JaktArray;JaktInternal::DynamicArray<types::Value> const& values = __jakt_match_value.values;
 return JaktInternal::ExplicitValue(({ Optional<JaktInternal::Optional<JaktInternal::DynamicArray<JaktInternal::Tuple<ByteString,utility::Span>>>> __jakt_var_541; {
 if (((values).is_empty())){
-TRY((((*this).error_with_hint(TRY(ByteString::from_utf8("module name must evaluate to a string literal or an array of strings"sv)),((expression)->span()),TRY(ByteString::from_utf8("this expression evaluates to an empty array"sv)),((expression)->span())))));
+TRY((((*this).error_with_hint((ByteString::must_from_utf8("module name must evaluate to a string literal or an array of strings"sv)),((expression)->span()),(ByteString::must_from_utf8("this expression evaluates to an empty array"sv)),((expression)->span())))));
 }
 JaktInternal::DynamicArray<JaktInternal::Tuple<ByteString,utility::Span>> result = (TRY((DynamicArray<JaktInternal::Tuple<ByteString,utility::Span>>::create_with({}))));
 {
@@ -18703,7 +18703,7 @@ return (TRY((((result).push((Tuple{string, ((value).span)})))))), JaktInternal::
 };/*case end*/
 default: {
 {
-TRY((((*this).error_with_hint(TRY(ByteString::from_utf8("module name must evaluate to a string literal or an array of strings"sv)),((value).span),TRY(ByteString::from_utf8("this expression evaluates to an invalid value"sv)),((value).span)))));
+TRY((((*this).error_with_hint((ByteString::must_from_utf8("module name must evaluate to a string literal or an array of strings"sv)),((value).span),(ByteString::must_from_utf8("this expression evaluates to an invalid value"sv)),((value).span)))));
 }
 return JaktInternal::ExplicitValue<void>();
 };/*case end*/
@@ -18730,7 +18730,7 @@ __jakt_label_463:; __jakt_var_541.release_value(); }));
 };/*case end*/
 default: {
 return JaktInternal::ExplicitValue(({ Optional<JaktInternal::DynamicArray<JaktInternal::Tuple<ByteString,utility::Span>>> __jakt_var_542; {
-TRY((((*this).error_with_hint(TRY(ByteString::from_utf8("module name must evaluate to a string literal"sv)),((expression)->span()),TRY(ByteString::from_utf8("this expression evaluates to a non-string value"sv)),((expression)->span())))));
+TRY((((*this).error_with_hint((ByteString::must_from_utf8("module name must evaluate to a string literal"sv)),((expression)->span()),(ByteString::must_from_utf8("this expression evaluates to a non-string value"sv)),((expression)->span())))));
 __jakt_var_542 = JaktInternal::OptionalNone(); goto __jakt_label_464;
 
 }
@@ -18789,7 +18789,7 @@ if (__jakt_enum_value == true) {
 return JaktInternal::ExplicitValue((maybe_file_name.value()));
 }
 else if (__jakt_enum_value == false) {
-return JaktInternal::ExplicitValue(TRY((((TRY((((TRY((((TRY((((*this).get_root_path())))).parent())))).join(((name_and_span).template get<0>())))))).replace_extension(TRY(ByteString::from_utf8("jakt"sv)))))));
+return JaktInternal::ExplicitValue(TRY((((TRY((((TRY((((TRY((((*this).get_root_path())))).parent())))).join(((name_and_span).template get<0>())))))).replace_extension((ByteString::must_from_utf8("jakt"sv)))))));
 }
 VERIFY_NOT_REACHED();
 }());
@@ -18817,14 +18817,14 @@ break;
 }
 
 if ((!(((module_name_and_span).has_value())))){
-TRY((((*this).error(TRY((__jakt_format((StringView::from_string_literal("No module in module set {{{}}} was found"sv)),TRY((utility::join(names,TRY(ByteString::from_utf8(", "sv)))))))),((((import_).module_name)).span())))));
+TRY((((*this).error(TRY((__jakt_format((StringView::from_string_literal("No module in module set {{{}}} was found"sv)),TRY((utility::join(names,(ByteString::must_from_utf8(", "sv)))))))),((((import_).module_name)).span())))));
 return {};
 }
 JaktInternal::Tuple<ByteString,utility::Span> const module_name_module_span_ = (module_name_and_span.value());
 ByteString const module_name = ((module_name_module_span_).template get<0>());
 utility::Span const module_span = ((module_name_module_span_).template get<1>());
 
-ByteString const sanitized_module_name = ((module_name).replace(TRY(ByteString::from_utf8(":"sv)),TRY(ByteString::from_utf8("_"sv))));
+ByteString const sanitized_module_name = ((module_name).replace((ByteString::must_from_utf8(":"sv)),(ByteString::must_from_utf8("_"sv))));
 ids::ModuleId imported_module_id = ids::ModuleId(static_cast<size_t>(0ULL));
 JaktInternal::Optional<types::LoadedModule> maybe_loaded_module = ((((*this).program))->get_loaded_module(sanitized_module_name));
 if ((!(((maybe_loaded_module).has_value())))){
@@ -18836,7 +18836,7 @@ if (__jakt_enum_value == true) {
 return JaktInternal::ExplicitValue((maybe_file_name.value()));
 }
 else if (__jakt_enum_value == false) {
-return JaktInternal::ExplicitValue(TRY((((TRY((((TRY((((TRY((((*this).get_root_path())))).parent())))).join(module_name))))).replace_extension(TRY(ByteString::from_utf8("jakt"sv)))))));
+return JaktInternal::ExplicitValue(TRY((((TRY((((TRY((((TRY((((*this).get_root_path())))).parent())))).join(module_name))))).replace_extension((ByteString::must_from_utf8("jakt"sv)))))));
 }
 VERIFY_NOT_REACHED();
 }());
@@ -19110,13 +19110,13 @@ break;
 parser::ParsedFunction f = (_magic_value.value());
 {
 if ((!(((((f).linkage)).__jakt_init_index() == 1 /* External */)))){
-TRY((((*this).error(TRY(ByteString::from_utf8("Expected all functions in an `import extern` to be be external"sv)),((f).name_span)))));
+TRY((((*this).error((ByteString::must_from_utf8("Expected all functions in an `import extern` to be be external"sv)),((f).name_span)))));
 }
 if ((((import_).is_c) && (!(((((f).generic_parameters)).is_empty()))))){
-TRY((((*this).error_with_hint(TRY((__jakt_format((StringView::from_string_literal("imported function '{}' is declared to have C linkage, but is generic"sv)),((f).name)))),((f).name_span),TRY(ByteString::from_utf8("this function may not be generic"sv)),((f).name_span)))));
+TRY((((*this).error_with_hint(TRY((__jakt_format((StringView::from_string_literal("imported function '{}' is declared to have C linkage, but is generic"sv)),((f).name)))),((f).name_span),(ByteString::must_from_utf8("this function may not be generic"sv)),((f).name_span)))));
 }
 if ((!(((((((f).block)).stmts)).is_empty())))){
-TRY((((*this).error(TRY(ByteString::from_utf8("imported extern function is not allowed to have a body"sv)),((f).name_span)))));
+TRY((((*this).error((ByteString::must_from_utf8("imported extern function is not allowed to have a body"sv)),((f).name_span)))));
 }
 }
 
@@ -19133,7 +19133,7 @@ break;
 parser::ParsedRecord record = (_magic_value.value());
 {
 if ((!(((((record).definition_linkage)).__jakt_init_index() == 1 /* External */)))){
-TRY((((*this).error(TRY(ByteString::from_utf8("Expected all records in an `import extern` to be external"sv)),((record).name_span)))));
+TRY((((*this).error((ByteString::must_from_utf8("Expected all records in an `import extern` to be external"sv)),((record).name_span)))));
 }
 if ((((import_).is_c) && (!(((((record).generic_parameters)).is_empty()))))){
 TRY((((*this).error_with_hint(TRY((__jakt_format((StringView::from_string_literal("imported {} '{}' is declared to have C linkage, but is generic"sv)),TRY((((((record).record_type)).record_type_name()))),((record).name)))),((record).name_span),TRY((__jakt_format((StringView::from_string_literal("this {} may not be generic"sv)),TRY((((((record).record_type)).record_type_name())))))),((record).name_span)))));
@@ -19157,13 +19157,13 @@ if (((override_target).has_value())){
 JaktInternal::Optional<ids::FunctionId> const method_id = TRY((((*this).find_function_matching_signature_in_scope(parent_scope_id,((method).parsed_function)))));
 NonnullRefPtr<types::CheckedFunction> const method_function = ((*this).get_function((method_id.value())));
 if ((!(((((method_function)->return_type_id)).equals((((override_target.value()))->return_type_id)))))){
-TRY((((*this).error(TRY(ByteString::from_utf8("Override function return type does not match virtual function"sv)),((method_function)->return_type_span).value_or_lazy_evaluated([&] { return ((method_function)->name_span); })))));
+TRY((((*this).error((ByteString::must_from_utf8("Override function return type does not match virtual function"sv)),((method_function)->return_type_span).value_or_lazy_evaluated([&] { return ((method_function)->name_span); })))));
 }
 if (((((method_function)->can_throw)) != ((((override_target.value()))->can_throw)))){
-TRY((((*this).error(TRY(ByteString::from_utf8("Override function throwability does not match virtual function"sv)),((method_function)->name_span)))));
+TRY((((*this).error((ByteString::must_from_utf8("Override function throwability does not match virtual function"sv)),((method_function)->name_span)))));
 }
 if (((((((method_function)->params)).size())) != ((((((override_target.value()))->params)).size())))){
-TRY((((*this).error(TRY(ByteString::from_utf8("Override function parameters do not match virtual function"sv)),((method_function)->name_span)))));
+TRY((((*this).error((ByteString::must_from_utf8("Override function parameters do not match virtual function"sv)),((method_function)->name_span)))));
 return {};
 }
 {
@@ -19178,13 +19178,13 @@ size_t param_index = (_magic_value.value());
 types::CheckedParameter const method_param = ((((method_function)->params))[param_index]);
 types::CheckedParameter const virtual_param = (((((override_target.value()))->params))[param_index]);
 if (((((((virtual_param).variable))->is_mutable)) != (((((method_param).variable))->is_mutable)))){
-TRY((((*this).error(TRY(ByteString::from_utf8("Override function parameter mutability does not match virtual function"sv)),((((method_param).variable))->definition_span)))));
+TRY((((*this).error((ByteString::must_from_utf8("Override function parameter mutability does not match virtual function"sv)),((((method_param).variable))->definition_span)))));
 }
-if ((((param_index) == (static_cast<size_t>(0ULL))) && ((((((method_param).variable))->name)) == (TRY(ByteString::from_utf8("this"sv)))))){
+if ((((param_index) == (static_cast<size_t>(0ULL))) && ((((((method_param).variable))->name)) == ((ByteString::must_from_utf8("this"sv)))))){
 continue;
 }
 if ((!(((((((method_param).variable))->type_id)).equals(((((virtual_param).variable))->type_id)))))){
-TRY((((*this).error(TRY(ByteString::from_utf8("Override function parameter type does not match virtual function"sv)),((((method_param).variable))->type_span).value_or_lazy_evaluated([&] { return ((((method_param).variable))->definition_span); })))));
+TRY((((*this).error((ByteString::must_from_utf8("Override function parameter type does not match virtual function"sv)),((((method_param).variable))->type_span).value_or_lazy_evaluated([&] { return ((((method_param).variable))->definition_span); })))));
 }
 }
 
@@ -19193,20 +19193,20 @@ TRY((((*this).error(TRY(ByteString::from_utf8("Override function parameter type 
 
 }
 else {
-TRY((((*this).error(TRY(ByteString::from_utf8("Missing virtual for override"sv)),((((method).parsed_function)).name_span)))));
+TRY((((*this).error((ByteString::must_from_utf8("Missing virtual for override"sv)),((((method).parsed_function)).name_span)))));
 return {};
 }
 
 }
 else {
-TRY((((*this).error(TRY(ByteString::from_utf8("Missing virtual for override"sv)),((((method).parsed_function)).name_span)))));
+TRY((((*this).error((ByteString::must_from_utf8("Missing virtual for override"sv)),((((method).parsed_function)).name_span)))));
 return {};
 }
 
 }
 else {
 if (((all_virtuals).contains(((((method).parsed_function)).name)))){
-TRY((((*this).error(TRY(ByteString::from_utf8("Missing override keyword on function that is virtual"sv)),((((method).parsed_function)).name_span)))));
+TRY((((*this).error((ByteString::must_from_utf8("Missing override keyword on function that is virtual"sv)),((((method).parsed_function)).name_span)))));
 }
 return {};
 }
@@ -19728,7 +19728,7 @@ NonnullRefPtr<typename types::CheckedStatement> const checked_statement = TRY(((
 if (((checked_statement)->__jakt_init_index() == 5 /* Block */)){
 types::CheckedBlock const block = (checked_statement)->as.Block.block;
 if (((((block).yielded_type)).has_value())){
-TRY((((*this).error(TRY(ByteString::from_utf8("‘yield’ inside ‘defer’ is meaningless"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("‘yield’ inside ‘defer’ is meaningless"sv)),span))));
 }
 }
 return TRY((types::CheckedStatement::Defer(checked_statement,span)));
@@ -19764,7 +19764,7 @@ if (TRY((((function_to_add)->signature_matches(existing_function,false))))){
 if (((TRY((((*this).get_scope(parent_scope_id)))))->is_from_generated_code)){
 continue;
 }
-TRY((((*this).error_with_hint(TRY((__jakt_format((StringView::from_string_literal("Redefinition of function ‘{}’."sv)),((function_to_add)->name)))),(((((function_to_add)->parsed_function).value())).name_span),TRY(ByteString::from_utf8("Previous definition is here"sv)),(((((existing_function)->parsed_function).value())).name_span)))));
+TRY((((*this).error_with_hint(TRY((__jakt_format((StringView::from_string_literal("Redefinition of function ‘{}’."sv)),((function_to_add)->name)))),(((((function_to_add)->parsed_function).value())).name_span),(ByteString::must_from_utf8("Previous definition is here"sv)),(((((existing_function)->parsed_function).value())).name_span)))));
 }
 }
 
@@ -19797,7 +19797,7 @@ case 1 /* Private */: {
 {
 if ((!(TRY((((*this).scope_can_access(accessor,accessee))))))){
 if ((!(((((method)->type)).__jakt_init_index() == 0 /* Normal */)))){
-TRY((((*this).error_with_hint(TRY((__jakt_format((StringView::from_string_literal("Can't access constructor ‘{}’, because it is marked private"sv)),((method)->name)))),span,TRY(ByteString::from_utf8("Private constructors are created if any fields are private"sv)),span))));
+TRY((((*this).error_with_hint(TRY((__jakt_format((StringView::from_string_literal("Can't access constructor ‘{}’, because it is marked private"sv)),((method)->name)))),span,(ByteString::must_from_utf8("Private constructors are created if any fields are private"sv)),span))));
 }
 else {
 TRY((((*this).error(TRY((__jakt_format((StringView::from_string_literal("Can't access method ‘{}’, because it is marked private"sv)),((method)->name)))),span))));
@@ -19810,7 +19810,7 @@ return JaktInternal::ExplicitValue<void>();
 case 2 /* Restricted */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Restricted;JaktInternal::DynamicArray<NonnullRefPtr<typename types::MaybeResolvedScope>> const& scopes = __jakt_match_value.scopes;
 {
-TRY((((*this).check_restricted_access(accessor,TRY(ByteString::from_utf8("function"sv)),accessee,((method)->name),scopes,span))));
+TRY((((*this).check_restricted_access(accessor,(ByteString::must_from_utf8("function"sv)),accessee,((method)->name),scopes,span))));
 }
 return JaktInternal::ExplicitValue<void>();
 };/*case end*/
@@ -19899,7 +19899,7 @@ ids::ScopeId const block_scope_id = TRY((((*this).create_scope(method_scope_id,(
 bool const is_generic = ((!(((((parsed_record).generic_parameters)).is_empty()))) || (!(((((func).generic_parameters)).is_empty()))));
 bool has_varargs = ((((method).parsed_function)).has_varargs);
 if ((has_varargs && ((((((method).parsed_function)).linkage)).__jakt_init_index() == 0 /* Internal */))){
-TRY((((*this).error(TRY(ByteString::from_utf8("Only external functions are allowed to be declared using varargs"sv)),((((method).parsed_function)).name_span)))));
+TRY((((*this).error((ByteString::must_from_utf8("Only external functions are allowed to be declared using varargs"sv)),((((method).parsed_function)).name_span)))));
 (has_varargs = false);
 }
 NonnullRefPtr<types::CheckedFunction> checked_function = TRY((types::CheckedFunction::__jakt_create(((func).name),((func).name_span),TRY((((*this).typecheck_visibility(((method).visibility),scope_id)))),types::unknown_type_id(),JaktInternal::OptionalNone(),(TRY((DynamicArray<types::CheckedParameter>::create_with({})))),TRY((types::FunctionGenerics::__jakt_create(method_scope_id,(TRY((DynamicArray<types::CheckedParameter>::create_with({})))),(TRY((DynamicArray<types::FunctionGenericParameter>::create_with({})))),(TRY((DynamicArray<JaktInternal::DynamicArray<ids::TypeId>>::create_with({}))))))),types::CheckedBlock((TRY((DynamicArray<NonnullRefPtr<typename types::CheckedStatement>>::create_with({})))),block_scope_id,types::BlockControlFlow::MayReturn(),ids::TypeId::none(),false),((func).can_throw),((func).type),((func).linkage),method_scope_id,JaktInternal::OptionalNone(),((!(is_generic)) || is_extern),func,((func).is_comptime),false,false,((func).is_unsafe),has_varargs,JaktInternal::OptionalNone(),JaktInternal::OptionalNone(),JaktInternal::OptionalNone(),false,JaktInternal::OptionalNone(),JaktInternal::OptionalNone(),JaktInternal::OptionalNone(),parser::InlineState::Default())));
@@ -19940,7 +19940,7 @@ break;
 }
 parser::ParsedParameter param = (_magic_value.value());
 {
-if (((((((param).variable)).name)) == (TRY(ByteString::from_utf8("this"sv))))){
+if (((((((param).variable)).name)) == ((ByteString::must_from_utf8("this"sv))))){
 NonnullRefPtr<types::CheckedVariable> const checked_variable = TRY((types::CheckedVariable::__jakt_create(((((param).variable)).name),enum_type_id,((((param).variable)).is_mutable),((((param).variable)).span),JaktInternal::OptionalNone(),types::CheckedVisibility::Public(),JaktInternal::OptionalNone(),JaktInternal::OptionalNone(),JaktInternal::OptionalNone())));
 TRY((((checked_function)->add_param(types::CheckedParameter(((param).requires_label),checked_variable,JaktInternal::OptionalNone())))));
 }
@@ -20340,7 +20340,7 @@ break;
 }
 parser::ParsedNamespace namespace_ = (_magic_value.value());
 {
-ByteString debug_name = TRY(ByteString::from_utf8("namespace("sv));
+ByteString debug_name = (ByteString::must_from_utf8("namespace("sv));
 if (((((namespace_).name)).has_value())){
 TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 {
@@ -20357,7 +20357,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(debug_name,TRY(ByteString::from_utf8("unnamed-namespace"sv)))));
+(debug_name,(ByteString::must_from_utf8("unnamed-namespace"sv)))));
 }
 
 TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
@@ -20366,7 +20366,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(debug_name,TRY(ByteString::from_utf8(")"sv)))));
+(debug_name,(ByteString::must_from_utf8(")"sv)))));
 JaktInternal::Optional<ids::ScopeId> existing_scope_id = ({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<JaktInternal::Optional<ids::ScopeId>,ErrorOr<void>>{
 auto __jakt_enum_value = (((((namespace_).name)).has_value()));
@@ -20395,7 +20395,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(debug_name,TRY(ByteString::from_utf8(" (extern "sv)))));
+(debug_name,(ByteString::must_from_utf8(" (extern "sv)))));
 TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 {
 (self = TRY((((self) + (rhs)))));
@@ -20409,7 +20409,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(debug_name,TRY(ByteString::from_utf8(")"sv)))));
+(debug_name,(ByteString::must_from_utf8(")"sv)))));
 }
 ids::ScopeId const parent_scope_id = ({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<ids::ScopeId,ErrorOr<void>>{
@@ -20669,7 +20669,7 @@ if (((trait_id).has_value())){
 TRY((((*this).typecheck_trait(parsed_trait,(trait_id.value()),scope_id,true))));
 }
 else {
-TRY((((((*this).compiler))->panic(TRY(ByteString::from_utf8("can't find trait that has been previous added"sv))))));
+TRY((((((*this).compiler))->panic((ByteString::must_from_utf8("can't find trait that has been previous added"sv))))));
 }
 
 }
@@ -20784,26 +20784,26 @@ ids::TypeId lhs_type_id = TRY((((*this).typecheck_typename(((var).parsed_type),s
 NonnullRefPtr<typename types::CheckedExpression> checked_expr = TRY((((*this).typecheck_expression(init,scope_id,safety_mode,lhs_type_id))));
 ids::TypeId const rhs_type_id = ((checked_expr)->type());
 if (((rhs_type_id).equals(types::void_type_id()))){
-TRY((((*this).error(TRY(ByteString::from_utf8("Cannot assign `void` to a variable"sv)),((checked_expr)->span())))));
+TRY((((*this).error((ByteString::must_from_utf8("Cannot assign `void` to a variable"sv)),((checked_expr)->span())))));
 }
 if (((((((*this).get_type(lhs_type_id)))->common.init_common.qualifiers)).is_immutable)){
 (lhs_type_id = TRY((((*this).with_qualifiers(parser::CheckedQualifiers(false),lhs_type_id)))));
 if (((var).is_mutable)){
-TRY((((*this).error(TRY(ByteString::from_utf8("Cannot have a mutable binding to an immutable object"sv)),((var).span)))));
+TRY((((*this).error((ByteString::must_from_utf8("Cannot have a mutable binding to an immutable object"sv)),((var).span)))));
 }
 }
 if ((((lhs_type_id).equals(types::unknown_type_id())) && (!(((rhs_type_id).equals(types::unknown_type_id())))))){
 (lhs_type_id = rhs_type_id);
 }
-ids::StructId const weak_ptr_struct_id = TRY((((*this).find_struct_in_prelude(TRY(ByteString::from_utf8("WeakPtr"sv))))));
-ids::StructId const optional_struct_id = TRY((((*this).find_struct_in_prelude(TRY(ByteString::from_utf8("Optional"sv))))));
+ids::StructId const weak_ptr_struct_id = TRY((((*this).find_struct_in_prelude((ByteString::must_from_utf8("WeakPtr"sv))))));
+ids::StructId const optional_struct_id = TRY((((*this).find_struct_in_prelude((ByteString::must_from_utf8("Optional"sv))))));
 if (TRY((((*this).type_contains_reference(lhs_type_id))))){
 JaktInternal::Tuple<JaktInternal::Optional<ids::ScopeId>,NonnullRefPtr<typename types::CheckedExpression>> const init_scope_id_cause_expr_ = TRY((((*this).required_scope_id_in_hierarchy_for(checked_expr,scope_id))));
 JaktInternal::Optional<ids::ScopeId> const init_scope_id = ((init_scope_id_cause_expr_).template get<0>());
 NonnullRefPtr<typename types::CheckedExpression> const cause_expr = ((init_scope_id_cause_expr_).template get<1>());
 
 if (TRY((((*this).scope_lifetime_subsumes(scope_id,init_scope_id))))){
-TRY((((*this).error_with_hint(TRY(ByteString::from_utf8("Cannot assign a reference to a variable that outlives the reference"sv)),((checked_expr)->span()),TRY(ByteString::from_utf8("Limited by this expression's lifetime"sv)),((cause_expr)->span())))));
+TRY((((*this).error_with_hint((ByteString::must_from_utf8("Cannot assign a reference to a variable that outlives the reference"sv)),((checked_expr)->span()),(ByteString::must_from_utf8("Limited by this expression's lifetime"sv)),((cause_expr)->span())))));
 }
 }
 NonnullRefPtr<typename types::Type> const lhs_type = ((*this).get_type(lhs_type_id));
@@ -20814,11 +20814,11 @@ if (((lhs_type)->__jakt_init_index() == 20 /* GenericInstance */)){
 ids::StructId const id = (lhs_type)->as.GenericInstance.id;
 JaktInternal::DynamicArray<ids::TypeId> const args = (lhs_type)->as.GenericInstance.args;
 if ((!((((id).equals(optional_struct_id)) || ((id).equals(weak_ptr_struct_id)))))){
-TRY((((*this).error(TRY(ByteString::from_utf8("Cannot assign None to a non-optional type"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("Cannot assign None to a non-optional type"sv)),span))));
 }
 }
 else {
-TRY((((*this).error(TRY(ByteString::from_utf8("Cannot assign None to a non-optional type"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("Cannot assign None to a non-optional type"sv)),span))));
 }
 
 }
@@ -20895,7 +20895,7 @@ return TRY((types::CheckedStatement::VarDecl(var_id,checked_expr,span)));
 ErrorOr<NonnullRefPtr<typename types::CheckedStatement>> typechecker::Typechecker::typecheck_inline_cpp(parser::ParsedBlock const block,utility::Span const span,types::SafetyMode const safety_mode) {
 {
 if (((safety_mode).__jakt_init_index() == 0 /* Safe */)){
-TRY((((*this).error(TRY(ByteString::from_utf8("Use of inline cpp block outside of unsafe block"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("Use of inline cpp block outside of unsafe block"sv)),span))));
 }
 JaktInternal::DynamicArray<ByteString> strings = (TRY((DynamicArray<ByteString>::create_with({}))));
 {
@@ -20915,12 +20915,12 @@ utility::Span const span = (expr)->as.QuotedString.span;
 TRY((((strings).push(val))));
 }
 else {
-TRY((((*this).error(TRY(ByteString::from_utf8("Expected block of strings"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("Expected block of strings"sv)),span))));
 }
 
 }
 else {
-TRY((((*this).error(TRY(ByteString::from_utf8("Expected block of strings"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("Expected block of strings"sv)),span))));
 }
 
 }
@@ -20983,7 +20983,7 @@ JaktInternal::Optional<ids::TypeId> type_hint_unwrapped = type_hint;
 if ((((type_hint).has_value()) && ((((*this).get_type((type_hint.value()))))->__jakt_init_index() == 20 /* GenericInstance */))){
 ids::StructId const id = (((*this).get_type((type_hint.value()))))->as.GenericInstance.id;
 JaktInternal::DynamicArray<ids::TypeId> const args = (((*this).get_type((type_hint.value()))))->as.GenericInstance.args;
-ids::StructId const optional_struct_id = TRY((((*this).find_struct_in_prelude(TRY(ByteString::from_utf8("Optional"sv))))));
+ids::StructId const optional_struct_id = TRY((((*this).find_struct_in_prelude((ByteString::must_from_utf8("Optional"sv))))));
 if (((id).equals(optional_struct_id))){
 (type_hint_unwrapped = ((args)[static_cast<i64>(0LL)]));
 }
@@ -21061,14 +21061,14 @@ JaktInternal::Optional<ByteString> const& prefix = __jakt_match_value.prefix;
 utility::Span const& span = __jakt_match_value.span;
 return JaktInternal::ExplicitValue(({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<NonnullRefPtr<typename types::CheckedExpression>,ErrorOr<NonnullRefPtr<typename types::CheckedExpression>>>{
-auto __jakt_enum_value = (TRY((prefix.try_value_or_lazy_evaluated([&]() -> ErrorOr<ByteString> { return TRY(ByteString::from_utf8(""sv)); }))));
-if (__jakt_enum_value == TRY(ByteString::from_utf8(""sv))) {
+auto __jakt_enum_value = (TRY((prefix.try_value_or_lazy_evaluated([&]() -> ErrorOr<ByteString> { return (ByteString::must_from_utf8(""sv)); }))));
+if (__jakt_enum_value == (ByteString::must_from_utf8(""sv))) {
 return JaktInternal::ExplicitValue(TRY((types::CheckedExpression::CharacterConstant(JaktInternal::OptionalNone(),val,span))));
 }
-else if (__jakt_enum_value == TRY(ByteString::from_utf8("b"sv))) {
+else if (__jakt_enum_value == (ByteString::must_from_utf8("b"sv))) {
 return JaktInternal::ExplicitValue(TRY((types::CheckedExpression::ByteConstant(JaktInternal::OptionalNone(),val,span))));
 }
-else if (__jakt_enum_value == TRY(ByteString::from_utf8("c"sv))) {
+else if (__jakt_enum_value == (ByteString::must_from_utf8("c"sv))) {
 return JaktInternal::ExplicitValue(TRY((types::CheckedExpression::CCharacterConstant(JaktInternal::OptionalNone(),val,span))));
 }
 else {
@@ -21095,29 +21095,28 @@ auto __jakt_enum_value = ((((type_hint).has_value()) && (!((((type_hint.value())
 if (__jakt_enum_value == true) {
 return JaktInternal::ExplicitValue(({ Optional<NonnullRefPtr<typename types::CheckedExpression>> __jakt_var_563; {
 ids::TypeId type_id = TRY((((*this).strip_optional_from_type(((((*this).generic_inferences)).map((type_hint.value())))))));
-ids::TypeId const prelude_string_type_id = TRY((((*this).prelude_struct_type_named(TRY(ByteString::from_utf8("String"sv))))));
-ids::TypeId const prelude_string_view_type_id = TRY((((*this).prelude_struct_type_named(TRY(ByteString::from_utf8("StringView"sv))))));
-bool may_throw = ((type_id).equals(prelude_string_type_id));
+ids::TypeId const prelude_string_type_id = TRY((((*this).prelude_struct_type_named((ByteString::must_from_utf8("String"sv))))));
+ids::TypeId const prelude_string_view_type_id = TRY((((*this).prelude_struct_type_named((ByteString::must_from_utf8("StringView"sv))))));
+bool may_throw = false;
 if (((!(((type_id).equals(prelude_string_type_id)))) && (!(((type_id).equals(prelude_string_view_type_id)))))){
 if (((((*this).get_type(type_id)))->is_concrete())){
-JaktInternal::Optional<typechecker::TraitImplementationDescriptor> const trait_implementation = TRY((((*this).find_any_singular_trait_implementation(type_id,(TRY((DynamicArray<ByteString>::create_with({TRY(ByteString::from_utf8("FromStringLiteral"sv)), TRY(ByteString::from_utf8("ThrowingFromStringLiteral"sv))})))),scope_id,span,JaktInternal::OptionalNone()))));
+JaktInternal::Optional<typechecker::TraitImplementationDescriptor> const trait_implementation = TRY((((*this).find_any_singular_trait_implementation(type_id,(TRY((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("FromStringLiteral"sv)), (ByteString::must_from_utf8("ThrowingFromStringLiteral"sv))})))),scope_id,span,JaktInternal::OptionalNone()))));
 if ((!(((trait_implementation).has_value())))){
 TRY((((*this).error_with_hint(TRY((__jakt_format((StringView::from_string_literal("Type {} cannot be used as an overloaded string literal type"sv)),TRY((((*this).type_name(type_id,true))))))),span,TRY((__jakt_format((StringView::from_string_literal("Consider implementing the FromStringLiteral trait for {}"sv)),TRY((((*this).type_name(type_id,false))))))),span))));
 (type_id = prelude_string_type_id);
 }
 else {
-(may_throw = (((((trait_implementation.value())).trait_name)) == (TRY(ByteString::from_utf8("ThrowingFromStringLiteral"sv)))));
+(may_throw = (((((trait_implementation.value())).trait_name)) == ((ByteString::must_from_utf8("ThrowingFromStringLiteral"sv)))));
 }
 
 }
 else if ((!(((((*this).get_type(type_id)))->is_concrete())))){
-(type_id = TRY((((*this).prelude_struct_type_named(TRY(ByteString::from_utf8("String"sv)))))));
-(may_throw = true);
+(type_id = TRY((((*this).prelude_struct_type_named((ByteString::must_from_utf8("String"sv)))))));
 }
 }
 TRY((((*this).unify((type_hint.value()),span,type_id,span))));
 if ((may_throw && (!(((TRY((((*this).get_scope(scope_id)))))->can_throw))))){
-TRY((((*this).error(TRY(ByteString::from_utf8("Operation that may throw needs to be in a try statement or a function marked as throws"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("Operation that may throw needs to be in a try statement or a function marked as throws"sv)),span))));
 }
 __jakt_var_563 = TRY((types::CheckedExpression::QuotedString(JaktInternal::OptionalNone(),types::CheckedStringLiteral(types::StringLiteral::Static(val),type_id,may_throw),span))); goto __jakt_label_480;
 
@@ -21126,10 +21125,7 @@ __jakt_label_480:; __jakt_var_563.release_value(); }));
 }
 else {
 return JaktInternal::ExplicitValue(({ Optional<NonnullRefPtr<typename types::CheckedExpression>> __jakt_var_564; {
-if ((!(((TRY((((*this).get_scope(scope_id)))))->can_throw)))){
-TRY((((*this).error(TRY(ByteString::from_utf8("Operation that may throw needs to be in a try statement or a function marked as throws"sv)),span))));
-}
-__jakt_var_564 = TRY((types::CheckedExpression::QuotedString(JaktInternal::OptionalNone(),types::CheckedStringLiteral(types::StringLiteral::Static(val),TRY((((*this).prelude_struct_type_named(TRY(ByteString::from_utf8("String"sv)))))),true),span))); goto __jakt_label_481;
+__jakt_var_564 = TRY((types::CheckedExpression::QuotedString(JaktInternal::OptionalNone(),types::CheckedStringLiteral(types::StringLiteral::Static(val),TRY((((*this).prelude_struct_type_named((ByteString::must_from_utf8("String"sv)))))),false),span))); goto __jakt_label_481;
 
 }
 __jakt_label_481:; __jakt_var_564.release_value(); }));
@@ -21180,7 +21176,7 @@ auto&& __jakt_match_value = __jakt_match_variant.as.Call;types::CheckedCall cons
 return JaktInternal::ExplicitValue(({ Optional<NonnullRefPtr<typename types::CheckedExpression>> __jakt_var_567; {
 ids::TypeId result_type = ((call).return_type);
 if (is_optional){
-ids::StructId const optional_struct_id = TRY((((*this).find_struct_in_prelude(TRY(ByteString::from_utf8("Optional"sv))))));
+ids::StructId const optional_struct_id = TRY((((*this).find_struct_in_prelude((ByteString::must_from_utf8("Optional"sv))))));
 (result_type = TRY((((*this).find_or_add_type_id(TRY((types::Type::GenericInstance(parser::CheckedQualifiers(false),optional_struct_id,(TRY((DynamicArray<ids::TypeId>::create_with({result_type}))))))))))));
 }
 __jakt_var_567 = TRY((types::CheckedExpression::MethodCall(JaktInternal::OptionalNone(),checked_expr,call,span,is_optional,result_type))); goto __jakt_label_484;
@@ -21190,7 +21186,7 @@ __jakt_label_484:; __jakt_var_567.release_value(); }));
 };/*case end*/
 default: {
 {
-TRY((((((*this).compiler))->panic(TRY(ByteString::from_utf8("typecheck_call should return `CheckedExpression::Call()`"sv))))));
+TRY((((((*this).compiler))->panic((ByteString::must_from_utf8("typecheck_call should return `CheckedExpression::Call()`"sv))))));
 }
 };/*case end*/
 }/*switch end*/
@@ -21234,7 +21230,7 @@ JaktInternal::Optional<ids::TypeId> values_type_id = JaktInternal::OptionalNone(
 if ((((from).has_value()) && ((to).has_value()))){
 (values_type_id = TRY((((*this).unify((from_type.value()),from_span,to_type,from_span)))));
 if ((!(((values_type_id).has_value())))){
-TRY((((*this).error(TRY(ByteString::from_utf8("Range values differ in types"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("Range values differ in types"sv)),span))));
 }
 }
 else if (((from).has_value())){
@@ -21243,7 +21239,7 @@ else if (((from).has_value())){
 else if (((to).has_value())){
 (values_type_id = to_type);
 }
-ids::StructId const range_struct_id = TRY((((*this).find_struct_in_prelude(TRY(ByteString::from_utf8("Range"sv))))));
+ids::StructId const range_struct_id = TRY((((*this).find_struct_in_prelude((ByteString::must_from_utf8("Range"sv))))));
 NonnullRefPtr<typename types::Type> const range_type = TRY((types::Type::GenericInstance(parser::CheckedQualifiers(false),range_struct_id,(TRY((DynamicArray<ids::TypeId>::create_with({((values_type_id).value_or(types::builtin(types::BuiltinType::I64())))})))))));
 ids::TypeId const type_id = TRY((((*this).find_or_add_type_id(range_type))));
 __jakt_var_568 = TRY((types::CheckedExpression::Range(JaktInternal::OptionalNone(),checked_from,checked_to,span,type_id))); goto __jakt_label_485;
@@ -21257,7 +21253,7 @@ utility::Span const& span = __jakt_match_value.span;
 return JaktInternal::ExplicitValue(({ Optional<NonnullRefPtr<typename types::CheckedExpression>> __jakt_var_569; {
 ids::EnumId const reflected_type_enum_id = ({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<ids::EnumId, ErrorOr<NonnullRefPtr<typename types::CheckedExpression>>>{
-auto&& __jakt_match_variant = TRY((((((*this).program))->find_reflected_primitive(TRY(ByteString::from_utf8("Type"sv))))));
+auto&& __jakt_match_variant = TRY((((((*this).program))->find_reflected_primitive((ByteString::must_from_utf8("Type"sv))))));
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 1 /* Enum */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Enum;ids::EnumId const& id = __jakt_match_value.value;
@@ -21265,7 +21261,7 @@ return JaktInternal::ExplicitValue(id);
 };/*case end*/
 default: {
 {
-TRY((((((*this).compiler))->panic(TRY(ByteString::from_utf8("unreachable"sv))))));
+TRY((((((*this).compiler))->panic((ByteString::must_from_utf8("unreachable"sv))))));
 }
 };/*case end*/
 }/*switch end*/
@@ -21353,7 +21349,7 @@ auto&& __jakt_match_variant = cast;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 0 /* Fallible */: {
 return JaktInternal::ExplicitValue(({ Optional<types::CheckedTypeCast> __jakt_var_572; {
-ids::StructId const optional_struct_id = TRY((((*this).find_struct_in_prelude(TRY(ByteString::from_utf8("Optional"sv))))));
+ids::StructId const optional_struct_id = TRY((((*this).find_struct_in_prelude((ByteString::must_from_utf8("Optional"sv))))));
 NonnullRefPtr<typename types::Type> const optional_type = TRY((types::Type::GenericInstance(parser::CheckedQualifiers(false),optional_struct_id,(TRY((DynamicArray<ids::TypeId>::create_with({type_id})))))));
 ids::TypeId const optional_type_id = TRY((((*this).find_or_add_type_id(optional_type))));
 __jakt_var_572 = types::CheckedTypeCast::Fallible(optional_type_id); goto __jakt_label_489;
@@ -21454,8 +21450,8 @@ if (((!(exists)) && ((type_id).equals(types::unknown_type_id())))){
 TRY((((*this).error(TRY((__jakt_format((StringView::from_string_literal("Enum variant {} does not exist on {}"sv)),name,TRY((((*this).type_name(expr_type_id,false))))))),span))));
 }
 }
-else if ((((name) == (TRY(ByteString::from_utf8("Some"sv)))) || ((name) == (TRY(ByteString::from_utf8("None"sv)))))){
-ids::StructId const optional_struct_id = TRY((((*this).find_struct_in_prelude(TRY(ByteString::from_utf8("Optional"sv))))));
+else if ((((name) == ((ByteString::must_from_utf8("Some"sv)))) || ((name) == ((ByteString::must_from_utf8("None"sv)))))){
+ids::StructId const optional_struct_id = TRY((((*this).find_struct_in_prelude((ByteString::must_from_utf8("Optional"sv))))));
 NonnullRefPtr<typename types::Type> const checked_expr_type = ((*this).get_type(((checked_expr)->type())));
 if ((!(((checked_expr_type)->__jakt_init_index() == 20 /* GenericInstance */)))){
 TRY((((*this).error(TRY((__jakt_format((StringView::from_string_literal("The left-hand side of an `is {}` statement must have a {} variant"sv)),name,name))),((checked_expr)->span())))));
@@ -21463,15 +21459,15 @@ TRY((((*this).error(TRY((__jakt_format((StringView::from_string_literal("The lef
 (operator_is = ({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<types::CheckedUnaryOperator,ErrorOr<NonnullRefPtr<typename types::CheckedExpression>>>{
 auto __jakt_enum_value = (name);
-if (__jakt_enum_value == TRY(ByteString::from_utf8("Some"sv))) {
+if (__jakt_enum_value == (ByteString::must_from_utf8("Some"sv))) {
 return JaktInternal::ExplicitValue(types::CheckedUnaryOperator::IsSome());
 }
-else if (__jakt_enum_value == TRY(ByteString::from_utf8("None"sv))) {
+else if (__jakt_enum_value == (ByteString::must_from_utf8("None"sv))) {
 return JaktInternal::ExplicitValue(types::CheckedUnaryOperator::IsNone());
 }
 else {
 {
-utility::panic(TRY(ByteString::from_utf8("unreachable"sv)));
+utility::panic((ByteString::must_from_utf8("unreachable"sv)));
 }
 }
 }());
@@ -21485,7 +21481,7 @@ TRY((((*this).error(TRY((__jakt_format((StringView::from_string_literal("Unknown
 }
 }
 else {
-TRY((((*this).error(TRY(ByteString::from_utf8("The right-hand side of an `is` operator must be a type name or enum variant"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("The right-hand side of an `is` operator must be a type name or enum variant"sv)),span))));
 }
 
 __jakt_var_574 = operator_is; goto __jakt_label_491;
@@ -21549,7 +21545,7 @@ ids::TypeId const hint = (((checked_lhs.value()))->type());
 if ((TRY((((*this).type_contains_reference((((original_checked_lhs.value()))->type()))))) && ((rhs)->__jakt_init_index() == 11 /* UnaryOp */))){
 parser::UnaryOperator const op = (rhs)->as.UnaryOp.op;
 if ((((op).__jakt_init_index() == 7 /* Reference */) || ((op).__jakt_init_index() == 8 /* MutableReference */))){
-TRY((((*this).error_with_hint(TRY(ByteString::from_utf8("Attempt to rebind a reference will result in write-through"sv)),span,TRY(ByteString::from_utf8("This reference will be immediately dereferenced and then assigned"sv)),((rhs)->span())))));
+TRY((((*this).error_with_hint((ByteString::must_from_utf8("Attempt to rebind a reference will result in write-through"sv)),span,(ByteString::must_from_utf8("This reference will be immediately dereferenced and then assigned"sv)),((rhs)->span())))));
 }
 }
 JaktInternal::Tuple<types::CheckedBinaryOperator,ids::TypeId> const checked_operator_output_type_ = TRY((((*this).typecheck_binary_operation((checked_lhs.value()),op,(checked_rhs.value()),scope_id,span))));
@@ -21568,7 +21564,7 @@ JaktInternal::Optional<ids::TypeId> type_hint_unwrapped = type_hint;
 if ((((type_hint).has_value()) && ((((*this).get_type((type_hint.value()))))->__jakt_init_index() == 20 /* GenericInstance */))){
 ids::StructId const id = (((*this).get_type((type_hint.value()))))->as.GenericInstance.id;
 JaktInternal::DynamicArray<ids::TypeId> const args = (((*this).get_type((type_hint.value()))))->as.GenericInstance.args;
-ids::StructId const optional_struct_id = TRY((((*this).find_struct_in_prelude(TRY(ByteString::from_utf8("Optional"sv))))));
+ids::StructId const optional_struct_id = TRY((((*this).find_struct_in_prelude((ByteString::must_from_utf8("Optional"sv))))));
 if (((id).equals(optional_struct_id))){
 (type_hint_unwrapped = ((args)[static_cast<i64>(0LL)]));
 }
@@ -21584,7 +21580,7 @@ utility::Span const& span = __jakt_match_value.span;
 return JaktInternal::ExplicitValue(({ Optional<NonnullRefPtr<typename types::CheckedExpression>> __jakt_var_577; {
 NonnullRefPtr<typename types::CheckedExpression> const checked_expr = TRY((((*this).typecheck_expression(expr,scope_id,safety_mode,JaktInternal::OptionalNone()))));
 ids::TypeId const type_id = ((checked_expr)->type());
-ids::StructId const optional_struct_id = TRY((((*this).find_struct_in_prelude(TRY(ByteString::from_utf8("Optional"sv))))));
+ids::StructId const optional_struct_id = TRY((((*this).find_struct_in_prelude((ByteString::must_from_utf8("Optional"sv))))));
 NonnullRefPtr<typename types::Type> const optional_type = TRY((types::Type::GenericInstance(parser::CheckedQualifiers(false),optional_struct_id,(TRY((DynamicArray<ids::TypeId>::create_with({type_id})))))));
 ids::TypeId const optional_type_id = TRY((((*this).find_or_add_type_id(optional_type))));
 __jakt_var_577 = TRY((types::CheckedExpression::OptionalSome(JaktInternal::OptionalNone(),checked_expr,span,optional_type_id))); goto __jakt_label_494;
@@ -21624,8 +21620,8 @@ utility::Span const& span = __jakt_match_value.span;
 return JaktInternal::ExplicitValue(({ Optional<NonnullRefPtr<typename types::CheckedExpression>> __jakt_var_579; {
 NonnullRefPtr<typename types::CheckedExpression> const checked_expr = TRY((((*this).typecheck_expression_and_dereference_if_needed(expr,scope_id,safety_mode,JaktInternal::OptionalNone(),span))));
 NonnullRefPtr<typename types::Type> const type = ((*this).get_type(((checked_expr)->type())));
-ids::StructId const optional_struct_id = TRY((((*this).find_struct_in_prelude(TRY(ByteString::from_utf8("Optional"sv))))));
-ids::StructId const weakptr_struct_id = TRY((((*this).find_struct_in_prelude(TRY(ByteString::from_utf8("WeakPtr"sv))))));
+ids::StructId const optional_struct_id = TRY((((*this).find_struct_in_prelude((ByteString::must_from_utf8("Optional"sv))))));
+ids::StructId const weakptr_struct_id = TRY((((*this).find_struct_in_prelude((ByteString::must_from_utf8("WeakPtr"sv))))));
 ids::TypeId const type_id = ({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<ids::TypeId, ErrorOr<NonnullRefPtr<typename types::CheckedExpression>>>{
 auto&& __jakt_match_variant = *type;
@@ -21639,7 +21635,7 @@ if ((((id).equals(optional_struct_id)) || ((id).equals(weakptr_struct_id)))){
 (inner_type_id = ((args)[static_cast<i64>(0LL)]));
 }
 else {
-TRY((((*this).error(TRY(ByteString::from_utf8("Forced unwrap only works on Optional"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("Forced unwrap only works on Optional"sv)),span))));
 }
 
 __jakt_var_580 = inner_type_id; goto __jakt_label_497;
@@ -21649,7 +21645,7 @@ __jakt_label_497:; __jakt_var_580.release_value(); }));
 };/*case end*/
 default: {
 return JaktInternal::ExplicitValue(({ Optional<ids::TypeId> __jakt_var_581; {
-TRY((((*this).error(TRY(ByteString::from_utf8("Forced unwrap only works on Optional"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("Forced unwrap only works on Optional"sv)),span))));
 __jakt_var_581 = types::unknown_type_id(); goto __jakt_label_498;
 
 }
@@ -21680,7 +21676,7 @@ return JaktInternal::ExplicitValue(({ Optional<NonnullRefPtr<typename types::Che
 ids::TypeId const VOID_TYPE_ID = types::builtin(types::BuiltinType::Void());
 JaktInternal::DynamicArray<NonnullRefPtr<typename types::CheckedExpression>> checked_values = (TRY((DynamicArray<NonnullRefPtr<typename types::CheckedExpression>>::create_with({}))));
 JaktInternal::DynamicArray<ids::TypeId> checked_types = (TRY((DynamicArray<ids::TypeId>::create_with({}))));
-ids::StructId const optional_struct_id = TRY((((*this).find_struct_in_prelude(TRY(ByteString::from_utf8("Optional"sv))))));
+ids::StructId const optional_struct_id = TRY((((*this).find_struct_in_prelude((ByteString::must_from_utf8("Optional"sv))))));
 {
 JaktInternal::ArrayIterator<NonnullRefPtr<typename parser::ParsedExpression>> _magic = ((values).iterator());
 for (;;){
@@ -21693,7 +21689,7 @@ NonnullRefPtr<typename parser::ParsedExpression> value = (_magic_value.value());
 NonnullRefPtr<typename types::CheckedExpression> const checked_value = TRY((((*this).typecheck_expression(value,scope_id,safety_mode,JaktInternal::OptionalNone()))));
 ids::TypeId const type_id = ((checked_value)->type());
 if (((type_id).equals(VOID_TYPE_ID))){
-TRY((((*this).error(TRY(ByteString::from_utf8("Cannot create a tuple that contains a value of type void"sv)),((value)->span())))));
+TRY((((*this).error((ByteString::must_from_utf8("Cannot create a tuple that contains a value of type void"sv)),((value)->span())))));
 }
 TRY((((checked_types).push(type_id))));
 TRY((((checked_values).push(checked_value))));
@@ -21751,7 +21747,7 @@ ids::TypeId const optional_type_id = TRY((((*this).find_or_add_type_id(optional_
 
 }
 }
-ids::StructId const tuple_struct_id = TRY((((*this).find_struct_in_prelude(TRY(ByteString::from_utf8("Tuple"sv))))));
+ids::StructId const tuple_struct_id = TRY((((*this).find_struct_in_prelude((ByteString::must_from_utf8("Tuple"sv))))));
 ids::TypeId const type_id = TRY((((*this).find_or_add_type_id(TRY((types::Type::GenericInstance(parser::CheckedQualifiers(false),tuple_struct_id,checked_types)))))));
 if (((type_hint).has_value())){
 TRY((((*this).check_types_for_compat((type_hint.value()),type_id,((((*this).generic_inferences))),span))));
@@ -21776,9 +21772,9 @@ case 20 /* GenericInstance */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.GenericInstance;ids::StructId const& id = __jakt_match_value.id;
 JaktInternal::DynamicArray<ids::TypeId> const& args = __jakt_match_value.args;
 return JaktInternal::ExplicitValue(({ Optional<NonnullRefPtr<typename types::CheckedExpression>> __jakt_var_584; {
-ids::StructId const array_struct_id = TRY((((*this).find_struct_in_prelude(TRY(ByteString::from_utf8("Array"sv))))));
-ids::StructId const array_slice_struct_id = TRY((((*this).find_struct_in_prelude(TRY(ByteString::from_utf8("ArraySlice"sv))))));
-ids::StructId const dictionary_struct_id = TRY((((*this).find_struct_in_prelude(TRY(ByteString::from_utf8("Dictionary"sv))))));
+ids::StructId const array_struct_id = TRY((((*this).find_struct_in_prelude((ByteString::must_from_utf8("Array"sv))))));
+ids::StructId const array_slice_struct_id = TRY((((*this).find_struct_in_prelude((ByteString::must_from_utf8("ArraySlice"sv))))));
+ids::StructId const dictionary_struct_id = TRY((((*this).find_struct_in_prelude((ByteString::must_from_utf8("Dictionary"sv))))));
 NonnullRefPtr<typename types::CheckedExpression> result = TRY((types::CheckedExpression::Garbage(JaktInternal::OptionalNone(),span,types::builtin(types::BuiltinType::Void()))));
 if ((((id).equals(array_struct_id)) || ((id).equals(array_slice_struct_id)))){
 if ((((*this).is_integer(((checked_index)->type()))) || ((checked_index)->__jakt_init_index() == 9 /* Range */))){
@@ -21788,7 +21784,7 @@ auto&& __jakt_match_variant = *checked_index;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 9 /* Range */: {
 return JaktInternal::ExplicitValue(({ Optional<ids::TypeId> __jakt_var_585; {
-ids::StructId const array_slice_struct_id = TRY((((*this).find_struct_in_prelude(TRY(ByteString::from_utf8("ArraySlice"sv))))));
+ids::StructId const array_slice_struct_id = TRY((((*this).find_struct_in_prelude((ByteString::must_from_utf8("ArraySlice"sv))))));
 __jakt_var_585 = TRY((((*this).find_or_add_type_id(TRY((types::Type::GenericInstance(parser::CheckedQualifiers(false),array_slice_struct_id,args))))))); goto __jakt_label_502;
 
 }
@@ -21807,7 +21803,7 @@ return JaktInternal::ExplicitValue(((args)[static_cast<i64>(0LL)]));
 (result = TRY((types::CheckedExpression::IndexedExpression(JaktInternal::OptionalNone(),checked_base,checked_index,span,type_id))));
 }
 else {
-TRY((((*this).error(TRY(ByteString::from_utf8("Index must be an integer or a range"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("Index must be an integer or a range"sv)),span))));
 }
 
 }
@@ -21821,7 +21817,7 @@ __jakt_label_501:; __jakt_var_584.release_value(); }));
 };/*case end*/
 default: {
 return JaktInternal::ExplicitValue(({ Optional<NonnullRefPtr<typename types::CheckedExpression>> __jakt_var_586; {
-TRY((((*this).error(TRY(ByteString::from_utf8("Index used on value that cannot be indexed"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("Index used on value that cannot be indexed"sv)),span))));
 __jakt_var_586 = TRY((types::CheckedExpression::Garbage(JaktInternal::OptionalNone(),span,types::builtin(types::BuiltinType::Void())))); goto __jakt_label_503;
 
 }
@@ -21868,7 +21864,7 @@ NonnullRefPtr<typename parser::ParsedType> const& enum_variant = __jakt_match_va
 utility::Span const& span = __jakt_match_value.span;
 return JaktInternal::ExplicitValue(({ Optional<NonnullRefPtr<typename types::CheckedExpression>> __jakt_var_587; {
 NonnullRefPtr<typename types::CheckedExpression> const checked_expr = TRY((((*this).typecheck_expression_and_dereference_if_needed(inner_expr,scope_id,safety_mode,JaktInternal::OptionalNone(),span))));
-types::CheckedEnumVariantBinding checked_binding = types::CheckedEnumVariantBinding(TRY(ByteString::from_utf8(""sv)),TRY(ByteString::from_utf8(""sv)),types::unknown_type_id(),span);
+types::CheckedEnumVariantBinding checked_binding = types::CheckedEnumVariantBinding((ByteString::must_from_utf8(""sv)),(ByteString::must_from_utf8(""sv)),types::unknown_type_id(),span);
 JaktInternal::Optional<types::CheckedEnumVariant> checked_enum_variant = JaktInternal::OptionalNone();
 ({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<void, ErrorOr<NonnullRefPtr<typename types::CheckedExpression>>>{
@@ -22019,7 +22015,7 @@ return JaktInternal::ExplicitValue(TRY((((*this).typecheck_expression(expr,scope
 };/*case end*/
 case 13 /* Operator */: {
 {
-TRY((((((*this).compiler))->panic(TRY(ByteString::from_utf8("idk how to handle this thing"sv))))));
+TRY((((((*this).compiler))->panic((ByteString::must_from_utf8("idk how to handle this thing"sv))))));
 }
 };/*case end*/
 default: VERIFY_NOT_REACHED();}/*switch end*/
@@ -22037,7 +22033,7 @@ ErrorOr<NonnullRefPtr<typename types::CheckedExpression>> typechecker::Typecheck
 NonnullRefPtr<typename types::CheckedExpression> const checked_expr = TRY((((*this).typecheck_expression_and_dereference_if_needed(expr,scope_id,safety_mode,JaktInternal::OptionalNone(),span))));
 ids::TypeId const checked_expr_type_id = ((checked_expr)->type());
 NonnullRefPtr<typename types::Type> const checked_expr_type = ((*this).get_type(checked_expr_type_id));
-ids::StructId const optional_struct_id = TRY((((*this).find_struct_in_prelude(TRY(ByteString::from_utf8("Optional"sv))))));
+ids::StructId const optional_struct_id = TRY((((*this).find_struct_in_prelude((ByteString::must_from_utf8("Optional"sv))))));
 ({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<void, ErrorOr<NonnullRefPtr<typename types::CheckedExpression>>>{
 auto&& __jakt_match_variant = *checked_expr_type;
@@ -22049,7 +22045,7 @@ JaktInternal::DynamicArray<ids::TypeId> const& args = __jakt_match_value.args;
 ids::TypeId type_id = checked_expr_type_id;
 if (is_optional){
 if ((!(((id).equals(optional_struct_id))))){
-TRY((((*this).error(TRY(ByteString::from_utf8("Optional chaining is only allowed on optional types"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("Optional chaining is only allowed on optional types"sv)),span))));
 return TRY((types::CheckedExpression::IndexedStruct(JaktInternal::OptionalNone(),checked_expr,field_name,JaktInternal::OptionalNone(),span,is_optional,types::unknown_type_id())));
 }
 (type_id = ((args)[static_cast<i64>(0LL)]));
@@ -22205,7 +22201,7 @@ case 24 /* Struct */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Struct;ids::StructId const& struct_id = __jakt_match_value.value;
 {
 if (is_optional){
-TRY((((*this).error(TRY(ByteString::from_utf8("Optional chaining is not allowed on non-optional types"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("Optional chaining is not allowed on non-optional types"sv)),span))));
 }
 types::CheckedStruct const structure = ((*this).get_struct(struct_id));
 JaktInternal::Optional<types::FieldRecord> const field_record = TRY((((*this).lookup_struct_field(struct_id,field_name))));
@@ -22224,7 +22220,7 @@ auto&& __jakt_match_value = __jakt_match_variant.as.GenericEnumInstance;ids::Enu
 JaktInternal::DynamicArray<ids::TypeId> const& args = __jakt_match_value.args;
 {
 if (is_optional){
-TRY((((*this).error(TRY(ByteString::from_utf8("Optional chaining is not allowed on non-optional types"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("Optional chaining is not allowed on non-optional types"sv)),span))));
 }
 JaktInternal::Dictionary<ids::TypeId,ids::TypeId> const checkpoint = TRY((((((*this).generic_inferences)).perform_checkpoint(false))));
 ScopeGuard __jakt_var_589([&] {
@@ -22264,7 +22260,7 @@ auto&& __jakt_match_value = __jakt_match_variant.as.Enum;ids::EnumId const& enum
 JaktInternal::DynamicArray<ids::TypeId> const args = (TRY((DynamicArray<ids::TypeId>::create_with({}))));
 {
 if (is_optional){
-TRY((((*this).error(TRY(ByteString::from_utf8("Optional chaining is not allowed on non-optional types"sv)),span))));
+TRY((((*this).error((ByteString::must_from_utf8("Optional chaining is not allowed on non-optional types"sv)),span))));
 }
 JaktInternal::Dictionary<ids::TypeId,ids::TypeId> const checkpoint = TRY((((((*this).generic_inferences)).perform_checkpoint(false))));
 ScopeGuard __jakt_var_590([&] {
@@ -22351,7 +22347,7 @@ NonnullRefPtr<types::Scope> scope = TRY((((*this).get_scope(scope_id))));
 TRY((((((scope)->resolution_mixins)).push(import_scope_id))));
 if (((((((extern_import).assigned_namespace)).name)).has_value())){
 (((TRY((((*this).get_scope(import_scope_id)))))->namespace_name) = (((((extern_import).assigned_namespace)).name).value()));
-(((TRY((((*this).get_scope(import_scope_id)))))->external_name) = parser::ExternalName::Plain(TRY(ByteString::from_utf8(""sv))));
+(((TRY((((*this).get_scope(import_scope_id)))))->external_name) = parser::ExternalName::Plain((ByteString::must_from_utf8(""sv))));
 }
 continue;
 }
@@ -22362,7 +22358,7 @@ TRY((((coalesced_imports).push(extern_import))));
 }
 
 if ((!(((coalesced_imports).is_empty())))){
-ids::ScopeId const child_scope_id = TRY((((*this).create_scope(((*this).root_scope_id()),false,TRY(ByteString::from_utf8("coalesced-extern-imports"sv)),false))));
+ids::ScopeId const child_scope_id = TRY((((*this).create_scope(((*this).root_scope_id()),false,(ByteString::must_from_utf8("coalesced-extern-imports"sv)),false))));
 {
 NonnullRefPtr<types::Scope> scope = TRY((((*this).get_scope(scope_id))));
 TRY((((((scope)->resolution_mixins)).push(child_scope_id))));
@@ -22398,7 +22394,7 @@ if (((root_module).has_value())){
 utility::FileId const file_id = (((root_module.value())).file_id);
 return (TRY((((((*this).compiler))->get_file_path(file_id)))).value());
 }
-return TRY((jakt__path::Path::from_string(TRY(ByteString::from_utf8("."sv)))));
+return TRY((jakt__path::Path::from_string((ByteString::must_from_utf8("."sv)))));
 }
 }
 
@@ -22505,7 +22501,7 @@ if ((((value).has_value()) && (((value.value())).__jakt_init_index() == 5 /* Jus
 types::Value const resolved_value = ((value.value())).as.JustValue.value;
 return TRY((((*this).find_or_add_type_id(TRY((types::Type::Const(parser::CheckedQualifiers(false),resolved_value)))))));
 }
-TRY((((*this).error(TRY(ByteString::from_utf8("Could not evaluate const expression"sv)),((expr)->span())))));
+TRY((((*this).error((ByteString::must_from_utf8("Could not evaluate const expression"sv)),((expr)->span())))));
 return TRY((((*this).find_or_add_type_id(TRY((types::Type::Unknown(parser::CheckedQualifiers(false))))))));
 }
 };/*case end*/
@@ -22601,52 +22597,52 @@ return TRY((((*this).with_qualifiers(((*this).typecheck_type_qualifiers(((parsed
 __jakt_var_597 = ({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<ids::TypeId,ErrorOr<ids::TypeId>>{
 auto __jakt_enum_value = (name);
-if (__jakt_enum_value == TRY(ByteString::from_utf8("i8"sv))) {
+if (__jakt_enum_value == (ByteString::must_from_utf8("i8"sv))) {
 return JaktInternal::ExplicitValue(types::builtin(types::BuiltinType::I8()));
 }
-else if (__jakt_enum_value == TRY(ByteString::from_utf8("i16"sv))) {
+else if (__jakt_enum_value == (ByteString::must_from_utf8("i16"sv))) {
 return JaktInternal::ExplicitValue(types::builtin(types::BuiltinType::I16()));
 }
-else if (__jakt_enum_value == TRY(ByteString::from_utf8("i32"sv))) {
+else if (__jakt_enum_value == (ByteString::must_from_utf8("i32"sv))) {
 return JaktInternal::ExplicitValue(types::builtin(types::BuiltinType::I32()));
 }
-else if (__jakt_enum_value == TRY(ByteString::from_utf8("i64"sv))) {
+else if (__jakt_enum_value == (ByteString::must_from_utf8("i64"sv))) {
 return JaktInternal::ExplicitValue(types::builtin(types::BuiltinType::I64()));
 }
-else if (__jakt_enum_value == TRY(ByteString::from_utf8("u8"sv))) {
+else if (__jakt_enum_value == (ByteString::must_from_utf8("u8"sv))) {
 return JaktInternal::ExplicitValue(types::builtin(types::BuiltinType::U8()));
 }
-else if (__jakt_enum_value == TRY(ByteString::from_utf8("u16"sv))) {
+else if (__jakt_enum_value == (ByteString::must_from_utf8("u16"sv))) {
 return JaktInternal::ExplicitValue(types::builtin(types::BuiltinType::U16()));
 }
-else if (__jakt_enum_value == TRY(ByteString::from_utf8("u32"sv))) {
+else if (__jakt_enum_value == (ByteString::must_from_utf8("u32"sv))) {
 return JaktInternal::ExplicitValue(types::builtin(types::BuiltinType::U32()));
 }
-else if (__jakt_enum_value == TRY(ByteString::from_utf8("u64"sv))) {
+else if (__jakt_enum_value == (ByteString::must_from_utf8("u64"sv))) {
 return JaktInternal::ExplicitValue(types::builtin(types::BuiltinType::U64()));
 }
-else if (__jakt_enum_value == TRY(ByteString::from_utf8("f32"sv))) {
+else if (__jakt_enum_value == (ByteString::must_from_utf8("f32"sv))) {
 return JaktInternal::ExplicitValue(types::builtin(types::BuiltinType::F32()));
 }
-else if (__jakt_enum_value == TRY(ByteString::from_utf8("f64"sv))) {
+else if (__jakt_enum_value == (ByteString::must_from_utf8("f64"sv))) {
 return JaktInternal::ExplicitValue(types::builtin(types::BuiltinType::F64()));
 }
-else if (__jakt_enum_value == TRY(ByteString::from_utf8("c_char"sv))) {
+else if (__jakt_enum_value == (ByteString::must_from_utf8("c_char"sv))) {
 return JaktInternal::ExplicitValue(types::builtin(types::BuiltinType::CChar()));
 }
-else if (__jakt_enum_value == TRY(ByteString::from_utf8("c_int"sv))) {
+else if (__jakt_enum_value == (ByteString::must_from_utf8("c_int"sv))) {
 return JaktInternal::ExplicitValue(types::builtin(types::BuiltinType::CInt()));
 }
-else if (__jakt_enum_value == TRY(ByteString::from_utf8("usize"sv))) {
+else if (__jakt_enum_value == (ByteString::must_from_utf8("usize"sv))) {
 return JaktInternal::ExplicitValue(types::builtin(types::BuiltinType::Usize()));
 }
-else if (__jakt_enum_value == TRY(ByteString::from_utf8("bool"sv))) {
+else if (__jakt_enum_value == (ByteString::must_from_utf8("bool"sv))) {
 return JaktInternal::ExplicitValue(types::builtin(types::BuiltinType::Bool()));
 }
-else if (__jakt_enum_value == TRY(ByteString::from_utf8("void"sv))) {
+else if (__jakt_enum_value == (ByteString::must_from_utf8("void"sv))) {
 return JaktInternal::ExplicitValue(types::builtin(types::BuiltinType::Void()));
 }
-else if (__jakt_enum_value == TRY(ByteString::from_utf8("never"sv))) {
+else if (__jakt_enum_value == (ByteString::must_from_utf8("never"sv))) {
 return JaktInternal::ExplicitValue(types::builtin(types::BuiltinType::Never()));
 }
 else {
@@ -22654,7 +22650,7 @@ return JaktInternal::ExplicitValue(({ Optional<ids::TypeId> __jakt_var_598; {
 if (((maybe_type_and_scope).has_value())){
 return (((maybe_type_and_scope.value())).template get<0>());
 }
-if ((((TRY((((*this).get_scope(scope_id)))))->is_from_generated_code) && ((name) == (TRY(ByteString::from_utf8("unknown"sv)))))){
+if ((((TRY((((*this).get_scope(scope_id)))))->is_from_generated_code) && ((name) == ((ByteString::must_from_utf8("unknown"sv)))))){
 return types::builtin(types::BuiltinType::Unknown());
 }
 TRY((((*this).error(TRY((__jakt_format((StringView::from_string_literal("Unknown type ‘{}’ in scope {}"sv)),name,TRY((((*this).debug_description_of(scope_id))))))),span))));
@@ -22699,7 +22695,7 @@ TRY((((checked_types).push(TRY((((*this).typecheck_typename(parsed_type,scope_id
 }
 }
 
-ids::StructId const tuple_struct_id = TRY((((*this).find_struct_in_prelude(TRY(ByteString::from_utf8("Tuple"sv))))));
+ids::StructId const tuple_struct_id = TRY((((*this).find_struct_in_prelude((ByteString::must_from_utf8("Tuple"sv))))));
 __jakt_var_600 = TRY((((*this).find_or_add_type_id(TRY((types::Type::GenericInstance(parser::CheckedQualifiers(false),tuple_struct_id,checked_types))))))); goto __jakt_label_512;
 
 }
@@ -22710,7 +22706,7 @@ auto&& __jakt_match_value = __jakt_match_variant.as.JaktArray;NonnullRefPtr<type
 utility::Span const& span = __jakt_match_value.span;
 return JaktInternal::ExplicitValue(({ Optional<ids::TypeId> __jakt_var_601; {
 ids::TypeId const inner_type_id = TRY((((*this).typecheck_typename(inner,scope_id,name))));
-ids::StructId const array_struct_id = TRY((((*this).find_struct_in_prelude(TRY(ByteString::from_utf8("Array"sv))))));
+ids::StructId const array_struct_id = TRY((((*this).find_struct_in_prelude((ByteString::must_from_utf8("Array"sv))))));
 __jakt_var_601 = TRY((((*this).find_or_add_type_id(TRY((types::Type::GenericInstance(parser::CheckedQualifiers(false),array_struct_id,(TRY((DynamicArray<ids::TypeId>::create_with({inner_type_id}))))))))))); goto __jakt_label_513;
 
 }
@@ -22723,9 +22719,9 @@ utility::Span const& span = __jakt_match_value.span;
 return JaktInternal::ExplicitValue(({ Optional<ids::TypeId> __jakt_var_602; {
 ids::TypeId const key_type_id = TRY((((*this).typecheck_typename(key,scope_id,name))));
 ids::TypeId const value_type_id = TRY((((*this).typecheck_typename(value,scope_id,name))));
-ids::StructId const dict_struct_id = TRY((((*this).find_struct_in_prelude(TRY(ByteString::from_utf8("Dictionary"sv))))));
-TRY((((*this).ensure_type_implements_trait(key_type_id,TRY(ByteString::from_utf8("Hashable"sv)),JaktInternal::OptionalNone(),scope_id,span))));
-TRY((((*this).ensure_type_implements_trait(key_type_id,TRY(ByteString::from_utf8("Equal"sv)),(TRY((DynamicArray<ids::TypeId>::create_with({key_type_id})))),scope_id,span))));
+ids::StructId const dict_struct_id = TRY((((*this).find_struct_in_prelude((ByteString::must_from_utf8("Dictionary"sv))))));
+TRY((((*this).ensure_type_implements_trait(key_type_id,(ByteString::must_from_utf8("Hashable"sv)),JaktInternal::OptionalNone(),scope_id,span))));
+TRY((((*this).ensure_type_implements_trait(key_type_id,(ByteString::must_from_utf8("Equal"sv)),(TRY((DynamicArray<ids::TypeId>::create_with({key_type_id})))),scope_id,span))));
 __jakt_var_602 = TRY((((*this).find_or_add_type_id(TRY((types::Type::GenericInstance(parser::CheckedQualifiers(false),dict_struct_id,(TRY((DynamicArray<ids::TypeId>::create_with({key_type_id, value_type_id}))))))))))); goto __jakt_label_514;
 
 }
@@ -22736,9 +22732,9 @@ auto&& __jakt_match_value = __jakt_match_variant.as.Set;NonnullRefPtr<typename p
 utility::Span const& span = __jakt_match_value.span;
 return JaktInternal::ExplicitValue(({ Optional<ids::TypeId> __jakt_var_603; {
 ids::TypeId const inner_type_id = TRY((((*this).typecheck_typename(inner,scope_id,name))));
-ids::StructId const set_struct_id = TRY((((*this).find_struct_in_prelude(TRY(ByteString::from_utf8("Set"sv))))));
-TRY((((*this).ensure_type_implements_trait(inner_type_id,TRY(ByteString::from_utf8("Hashable"sv)),JaktInternal::OptionalNone(),scope_id,span))));
-TRY((((*this).ensure_type_implements_trait(inner_type_id,TRY(ByteString::from_utf8("Equal"sv)),(TRY((DynamicArray<ids::TypeId>::create_with({inner_type_id})))),scope_id,span))));
+ids::StructId const set_struct_id = TRY((((*this).find_struct_in_prelude((ByteString::must_from_utf8("Set"sv))))));
+TRY((((*this).ensure_type_implements_trait(inner_type_id,(ByteString::must_from_utf8("Hashable"sv)),JaktInternal::OptionalNone(),scope_id,span))));
+TRY((((*this).ensure_type_implements_trait(inner_type_id,(ByteString::must_from_utf8("Equal"sv)),(TRY((DynamicArray<ids::TypeId>::create_with({inner_type_id})))),scope_id,span))));
 __jakt_var_603 = TRY((((*this).find_or_add_type_id(TRY((types::Type::GenericInstance(parser::CheckedQualifiers(false),set_struct_id,(TRY((DynamicArray<ids::TypeId>::create_with({inner_type_id}))))))))))); goto __jakt_label_515;
 
 }
@@ -22749,7 +22745,7 @@ auto&& __jakt_match_value = __jakt_match_variant.as.Optional;NonnullRefPtr<typen
 utility::Span const& span = __jakt_match_value.span;
 return JaktInternal::ExplicitValue(({ Optional<ids::TypeId> __jakt_var_604; {
 ids::TypeId const inner_type_id = TRY((((*this).typecheck_typename(inner,scope_id,name))));
-ids::StructId const optional_struct_id = TRY((((*this).find_struct_in_prelude(TRY(ByteString::from_utf8("Optional"sv))))));
+ids::StructId const optional_struct_id = TRY((((*this).find_struct_in_prelude((ByteString::must_from_utf8("Optional"sv))))));
 __jakt_var_604 = TRY((((*this).find_or_add_type_id(TRY((types::Type::GenericInstance(parser::CheckedQualifiers(false),optional_struct_id,(TRY((DynamicArray<ids::TypeId>::create_with({inner_type_id}))))))))))); goto __jakt_label_516;
 
 }
@@ -22760,7 +22756,7 @@ auto&& __jakt_match_value = __jakt_match_variant.as.WeakPtr;NonnullRefPtr<typena
 utility::Span const& span = __jakt_match_value.span;
 return JaktInternal::ExplicitValue(({ Optional<ids::TypeId> __jakt_var_605; {
 ids::TypeId const inner_type_id = TRY((((*this).typecheck_typename(inner,scope_id,name))));
-ids::StructId const weakptr_struct_id = TRY((((*this).find_struct_in_prelude(TRY(ByteString::from_utf8("WeakPtr"sv))))));
+ids::StructId const weakptr_struct_id = TRY((((*this).find_struct_in_prelude((ByteString::must_from_utf8("WeakPtr"sv))))));
 __jakt_var_605 = TRY((((*this).find_or_add_type_id(TRY((types::Type::GenericInstance(parser::CheckedQualifiers(false),weakptr_struct_id,(TRY((DynamicArray<ids::TypeId>::create_with({inner_type_id}))))))))))); goto __jakt_label_517;
 
 }
@@ -22819,7 +22815,7 @@ else {
 return JaktInternal::ExplicitValue(TRY((({ Optional<ByteString> __jakt_var_609;
 auto __jakt_var_610 = [&]() -> ErrorOr<ByteString> { return TRY((__jakt_format((StringView::from_string_literal("lambda{}"sv)),((((*this).lambda_count)++))))); }();
 if (!__jakt_var_610.is_error()) __jakt_var_609 = __jakt_var_610.release_value();
-__jakt_var_609; }).try_value_or_lazy_evaluated([&]() -> ErrorOr<ByteString> { return TRY(ByteString::from_utf8(""sv)); }))));
+__jakt_var_609; }).try_value_or_lazy_evaluated([&]() -> ErrorOr<ByteString> { return (ByteString::must_from_utf8(""sv)); }))));
 }
 }());
     if (_jakt_value.is_return())
@@ -22889,21 +22885,21 @@ return TRY((((*this).with_qualifiers(qualifiers,output))));
 
 ErrorOr<NonnullRefPtr<typename types::CheckedExpression>> typechecker::Typechecker::typecheck_try(NonnullRefPtr<typename parser::ParsedExpression> const expr,JaktInternal::Optional<parser::ParsedBlock> const catch_block,JaktInternal::Optional<utility::Span> const catch_span,JaktInternal::Optional<ByteString> const catch_name,ids::ScopeId const scope_id,types::SafetyMode const safety_mode,utility::Span const span,JaktInternal::Optional<ids::TypeId> const type_hint) {
 {
-ids::ScopeId const try_scope_id = TRY((((*this).create_scope(scope_id,true,TRY(ByteString::from_utf8("try"sv)),true))));
+ids::ScopeId const try_scope_id = TRY((((*this).create_scope(scope_id,true,(ByteString::must_from_utf8("try"sv)),true))));
 NonnullRefPtr<typename types::CheckedExpression> const checked_expr = TRY((((*this).typecheck_expression(expr,try_scope_id,safety_mode,type_hint))));
-ids::StructId const error_struct_id = TRY((((*this).find_struct_in_prelude(TRY(ByteString::from_utf8("Error"sv))))));
+ids::StructId const error_struct_id = TRY((((*this).find_struct_in_prelude((ByteString::must_from_utf8("Error"sv))))));
 NonnullRefPtr<types::Module> module = ((*this).current_module());
 JaktInternal::Optional<types::CheckedBlock> checked_catch_block = JaktInternal::OptionalNone();
 ids::TypeId const expression_type_id = ((checked_expr)->type());
-ids::StructId const optional_struct_id = TRY((((*this).find_struct_in_prelude(TRY(ByteString::from_utf8("Optional"sv))))));
+ids::StructId const optional_struct_id = TRY((((*this).find_struct_in_prelude((ByteString::must_from_utf8("Optional"sv))))));
 NonnullRefPtr<typename types::Type> const optional_type = TRY((types::Type::GenericInstance(parser::CheckedQualifiers(false),optional_struct_id,(TRY((DynamicArray<ids::TypeId>::create_with({expression_type_id})))))));
 ids::TypeId const optional_type_id = TRY((((*this).find_or_add_type_id(optional_type))));
 ids::TypeId type_id = optional_type_id;
 if (((catch_block).has_value())){
 NonnullRefPtr<types::Scope> const parent_scope = TRY((((*this).get_scope(scope_id))));
-ids::ScopeId const catch_scope_id = TRY((((*this).create_scope(scope_id,((parent_scope)->can_throw),TRY(ByteString::from_utf8("catch"sv)),true))));
+ids::ScopeId const catch_scope_id = TRY((((*this).create_scope(scope_id,((parent_scope)->can_throw),(ByteString::must_from_utf8("catch"sv)),true))));
 if (((catch_name).has_value())){
-ids::StructId const error_struct_id = TRY((((*this).find_struct_in_prelude(TRY(ByteString::from_utf8("Error"sv))))));
+ids::StructId const error_struct_id = TRY((((*this).find_struct_in_prelude((ByteString::must_from_utf8("Error"sv))))));
 NonnullRefPtr<types::CheckedVariable> const error_decl = TRY((types::CheckedVariable::__jakt_create((catch_name.value()),((((*this).get_struct(error_struct_id))).type_id),false,span,JaktInternal::OptionalNone(),types::CheckedVisibility::Public(),JaktInternal::OptionalNone(),JaktInternal::OptionalNone(),JaktInternal::OptionalNone())));
 NonnullRefPtr<types::Module> module = ((*this).current_module());
 ids::VarId const error_id = TRY((((module)->add_variable(error_decl))));
@@ -22921,7 +22917,7 @@ else {
 }
 else {
 if ((!(((expression_type_id).equals(types::builtin(types::BuiltinType::Void())))))){
-TRY((((*this).error(TRY(ByteString::from_utf8("In a try expression that returns a value, 'catch' block must either yield a value or transfer control flow"sv)),catch_span.value_or_lazy_evaluated([&] { return span; })))));
+TRY((((*this).error((ByteString::must_from_utf8("In a try expression that returns a value, 'catch' block must either yield a value or transfer control flow"sv)),catch_span.value_or_lazy_evaluated([&] { return span; })))));
 }
 }
 

--- a/bootstrap/stage0/typechecker.h
+++ b/bootstrap/stage0/typechecker.h
@@ -15,7 +15,52 @@
 #include "jakt__platform__unknown_fs.h"
 namespace Jakt {
 namespace typechecker {
-template <typename K,typename V>struct InternalDictionaryProduct {
+struct TraitImplementationDescriptor {
+  public:
+public: ids::TraitId trait_id;public: ByteString trait_name;public: JaktInternal::DynamicArray<ids::TypeId> implemented_type_args;public: TraitImplementationDescriptor(ids::TraitId a_trait_id, ByteString a_trait_name, JaktInternal::DynamicArray<ids::TypeId> a_implemented_type_args);
+
+public: ErrorOr<ByteString> debug_description() const;
+};struct AlreadyImplementedFor {
+  public:
+public: ByteString trait_name;public: utility::Span encounter_span;public: AlreadyImplementedFor(ByteString a_trait_name, utility::Span a_encounter_span);
+
+public: ErrorOr<ByteString> debug_description() const;
+};struct FunctionMatchResult {
+u8 __jakt_variant_index = 0;
+union VariantData {
+u8 __jakt_uninit_value;
+struct {
+JaktInternal::DynamicArray<NonnullRefPtr<typename types::CheckedExpression>> args;
+JaktInternal::Optional<ids::TypeId> maybe_this_type_id;
+JaktInternal::Dictionary<ids::TypeId,ids::TypeId> used_generic_inferences;
+i64 specificity;
+} MatchSuccess;
+struct {
+JaktInternal::DynamicArray<error::JaktError> errors;
+} MatchError;
+constexpr VariantData() {}
+~VariantData() {}
+} as;
+constexpr u8 __jakt_init_index() const noexcept { return __jakt_variant_index - 1; }ErrorOr<ByteString> debug_description() const;
+[[nodiscard]] static FunctionMatchResult MatchSuccess(JaktInternal::DynamicArray<NonnullRefPtr<typename types::CheckedExpression>> args, JaktInternal::Optional<ids::TypeId> maybe_this_type_id, JaktInternal::Dictionary<ids::TypeId,ids::TypeId> used_generic_inferences, i64 specificity);
+[[nodiscard]] static FunctionMatchResult MatchError(JaktInternal::DynamicArray<error::JaktError> errors);
+~FunctionMatchResult();
+FunctionMatchResult& operator=(FunctionMatchResult const &);
+FunctionMatchResult& operator=(FunctionMatchResult &&);
+FunctionMatchResult(FunctionMatchResult const&);
+FunctionMatchResult(FunctionMatchResult &&);
+private: void __jakt_destroy_variant();
+public:
+private:
+FunctionMatchResult() {};
+};
+struct ImportRestrictions {
+  public:
+public: bool functions;public: bool structs;public: bool enums;public: bool types;public: bool traits;public: bool namespaces;public: ImportRestrictions(bool a_functions, bool a_structs, bool a_enums, bool a_types, bool a_traits, bool a_namespaces);
+
+public: static typechecker::ImportRestrictions all();
+public: ErrorOr<ByteString> debug_description() const;
+};template <typename K,typename V>struct InternalDictionaryProduct {
   public:
 public: JaktInternal::Dictionary<K,JaktInternal::DynamicArray<V>> dict;public: JaktInternal::Dictionary<K,V> current;public: JaktInternal::Dictionary<K,size_t> current_index;public: bool done;public: ErrorOr<JaktInternal::Optional<JaktInternal::Dictionary<K,V>>> next() {
 {
@@ -88,57 +133,37 @@ TRY(JaktInternal::PrettyPrint::output_indentation(builder));TRY(builder.appendff
 TRY(JaktInternal::PrettyPrint::output_indentation(builder));TRY(builder.appendff("done: {}", done));
 }
 TRY(builder.append(")"sv));return builder.to_string(); }
-};struct ImportRestrictions {
-  public:
-public: bool functions;public: bool structs;public: bool enums;public: bool types;public: bool traits;public: bool namespaces;public: ImportRestrictions(bool a_functions, bool a_structs, bool a_enums, bool a_types, bool a_traits, bool a_namespaces);
-
-public: static typechecker::ImportRestrictions all();
-public: ErrorOr<ByteString> debug_description() const;
-};struct FunctionMatchResult {
+};struct NumericOrStringValue {
 u8 __jakt_variant_index = 0;
 union VariantData {
 u8 __jakt_uninit_value;
 struct {
-JaktInternal::DynamicArray<NonnullRefPtr<typename types::CheckedExpression>> args;
-JaktInternal::Optional<ids::TypeId> maybe_this_type_id;
-JaktInternal::Dictionary<ids::TypeId,ids::TypeId> used_generic_inferences;
-i64 specificity;
-} MatchSuccess;
+ByteString value;
+} StringValue;
 struct {
-JaktInternal::DynamicArray<error::JaktError> errors;
-} MatchError;
+i64 value;
+} SignedNumericValue;
+struct {
+u64 value;
+} UnsignedNumericValue;
 constexpr VariantData() {}
 ~VariantData() {}
 } as;
 constexpr u8 __jakt_init_index() const noexcept { return __jakt_variant_index - 1; }ErrorOr<ByteString> debug_description() const;
-[[nodiscard]] static FunctionMatchResult MatchSuccess(JaktInternal::DynamicArray<NonnullRefPtr<typename types::CheckedExpression>> args, JaktInternal::Optional<ids::TypeId> maybe_this_type_id, JaktInternal::Dictionary<ids::TypeId,ids::TypeId> used_generic_inferences, i64 specificity);
-[[nodiscard]] static FunctionMatchResult MatchError(JaktInternal::DynamicArray<error::JaktError> errors);
-~FunctionMatchResult();
-FunctionMatchResult& operator=(FunctionMatchResult const &);
-FunctionMatchResult& operator=(FunctionMatchResult &&);
-FunctionMatchResult(FunctionMatchResult const&);
-FunctionMatchResult(FunctionMatchResult &&);
+[[nodiscard]] static NumericOrStringValue StringValue(ByteString value);
+[[nodiscard]] static NumericOrStringValue SignedNumericValue(i64 value);
+[[nodiscard]] static NumericOrStringValue UnsignedNumericValue(u64 value);
+~NumericOrStringValue();
+NumericOrStringValue& operator=(NumericOrStringValue const &);
+NumericOrStringValue& operator=(NumericOrStringValue &&);
+NumericOrStringValue(NumericOrStringValue const&);
+NumericOrStringValue(NumericOrStringValue &&);
 private: void __jakt_destroy_variant();
 public:
 private:
-FunctionMatchResult() {};
+NumericOrStringValue() {};
 };
-struct TraitImplCheck {
-  public:
-public: JaktInternal::Dictionary<ids::TypeId,JaktInternal::Dictionary<ByteString,ids::FunctionId>> missing_methods;public: JaktInternal::Dictionary<ids::TypeId,JaktInternal::Dictionary<ByteString,JaktInternal::Tuple<utility::Span,JaktInternal::DynamicArray<error::JaktError>>>> unmatched_signatures;public: JaktInternal::Dictionary<ids::TypeId,JaktInternal::Dictionary<ByteString,utility::Span>> private_matching_methods;public: JaktInternal::Dictionary<ByteString,typechecker::AlreadyImplementedFor> already_implemented_for;public: ErrorOr<void> throw_errors(utility::Span const record_decl_span, typechecker::Typechecker& typechecker);
-public: ErrorOr<void> ensure_capacity(size_t const count);
-public: ErrorOr<void> register_method(ids::TypeId const self_type_id, ByteString const method_name, ids::FunctionId const method_id, typechecker::Typechecker& typechecker);
-public: static ErrorOr<typechecker::TraitImplCheck> make();
-public: TraitImplCheck(JaktInternal::Dictionary<ids::TypeId,JaktInternal::Dictionary<ByteString,ids::FunctionId>> a_missing_methods, JaktInternal::Dictionary<ids::TypeId,JaktInternal::Dictionary<ByteString,JaktInternal::Tuple<utility::Span,JaktInternal::DynamicArray<error::JaktError>>>> a_unmatched_signatures, JaktInternal::Dictionary<ids::TypeId,JaktInternal::Dictionary<ByteString,utility::Span>> a_private_matching_methods, JaktInternal::Dictionary<ByteString,typechecker::AlreadyImplementedFor> a_already_implemented_for);
-
-public: ErrorOr<void> register_trait(ids::TypeId const trait_type_id, ByteString const trait_name, types::CheckedTraitRequirements const requirements);
-public: ErrorOr<ByteString> debug_description() const;
-};struct TraitImplementationDescriptor {
-  public:
-public: ids::TraitId trait_id;public: ByteString trait_name;public: JaktInternal::DynamicArray<ids::TypeId> implemented_type_args;public: TraitImplementationDescriptor(ids::TraitId a_trait_id, ByteString a_trait_name, JaktInternal::DynamicArray<ids::TypeId> a_implemented_type_args);
-
-public: ErrorOr<ByteString> debug_description() const;
-};struct Typechecker {
+struct Typechecker {
   public:
 public: NonnullRefPtr<compiler::Compiler> compiler;public: NonnullRefPtr<types::CheckedProgram> program;public: ids::ModuleId current_module_id;public: JaktInternal::Optional<ids::TypeId> current_struct_type_id;public: JaktInternal::Optional<ids::FunctionId> current_function_id;public: bool inside_defer;public: size_t checkidx;public: bool ignore_errors;public: bool dump_type_hints;public: bool dump_try_hints;public: u64 lambda_count;public: types::GenericInferences generic_inferences;public: JaktInternal::Optional<ids::TypeId> self_type_id;public: ByteString root_module_name;public: bool in_comptime_function_call;public: bool had_an_error;public: JaktInternal::Dictionary<ByteString,ids::ScopeId> cpp_import_cache;public: JaktInternal::Optional<cpp_import__none::CppImportProcessor> cpp_import_processor;public: ErrorOr<void> typecheck_struct_predecl_initial(parser::ParsedRecord const parsed_record, size_t const struct_index, size_t const module_struct_len, ids::ScopeId const scope_id);
 public: ErrorOr<void> ensure_type_implements_trait(ids::TypeId const type_id, ByteString const trait_name, JaktInternal::Optional<JaktInternal::DynamicArray<ids::TypeId>> const filter_for_generics, ids::ScopeId const scope_id, utility::Span const span);
@@ -330,79 +355,22 @@ public: ErrorOr<NonnullRefPtr<typename types::CheckedExpression>> typecheck_try(
 public: ids::TypeId infer_function_return_type(types::CheckedBlock const block) const;
 public: ErrorOr<bool> scope_lifetime_subsumes(JaktInternal::Optional<ids::ScopeId> const larger, JaktInternal::Optional<ids::ScopeId> const smaller) const;
 public: ErrorOr<ByteString> debug_description() const;
-};struct AlreadyImplementedFor {
+};struct TraitImplCheck {
   public:
-public: ByteString trait_name;public: utility::Span encounter_span;public: AlreadyImplementedFor(ByteString a_trait_name, utility::Span a_encounter_span);
+public: JaktInternal::Dictionary<ids::TypeId,JaktInternal::Dictionary<ByteString,ids::FunctionId>> missing_methods;public: JaktInternal::Dictionary<ids::TypeId,JaktInternal::Dictionary<ByteString,JaktInternal::Tuple<utility::Span,JaktInternal::DynamicArray<error::JaktError>>>> unmatched_signatures;public: JaktInternal::Dictionary<ids::TypeId,JaktInternal::Dictionary<ByteString,utility::Span>> private_matching_methods;public: JaktInternal::Dictionary<ByteString,typechecker::AlreadyImplementedFor> already_implemented_for;public: ErrorOr<void> throw_errors(utility::Span const record_decl_span, typechecker::Typechecker& typechecker);
+public: ErrorOr<void> ensure_capacity(size_t const count);
+public: ErrorOr<void> register_method(ids::TypeId const self_type_id, ByteString const method_name, ids::FunctionId const method_id, typechecker::Typechecker& typechecker);
+public: static ErrorOr<typechecker::TraitImplCheck> make();
+public: TraitImplCheck(JaktInternal::Dictionary<ids::TypeId,JaktInternal::Dictionary<ByteString,ids::FunctionId>> a_missing_methods, JaktInternal::Dictionary<ids::TypeId,JaktInternal::Dictionary<ByteString,JaktInternal::Tuple<utility::Span,JaktInternal::DynamicArray<error::JaktError>>>> a_unmatched_signatures, JaktInternal::Dictionary<ids::TypeId,JaktInternal::Dictionary<ByteString,utility::Span>> a_private_matching_methods, JaktInternal::Dictionary<ByteString,typechecker::AlreadyImplementedFor> a_already_implemented_for);
 
+public: ErrorOr<void> register_trait(ids::TypeId const trait_type_id, ByteString const trait_name, types::CheckedTraitRequirements const requirements);
 public: ErrorOr<ByteString> debug_description() const;
-};struct NumericOrStringValue {
-u8 __jakt_variant_index = 0;
-union VariantData {
-u8 __jakt_uninit_value;
-struct {
-ByteString value;
-} StringValue;
-struct {
-i64 value;
-} SignedNumericValue;
-struct {
-u64 value;
-} UnsignedNumericValue;
-constexpr VariantData() {}
-~VariantData() {}
-} as;
-constexpr u8 __jakt_init_index() const noexcept { return __jakt_variant_index - 1; }ErrorOr<ByteString> debug_description() const;
-[[nodiscard]] static NumericOrStringValue StringValue(ByteString value);
-[[nodiscard]] static NumericOrStringValue SignedNumericValue(i64 value);
-[[nodiscard]] static NumericOrStringValue UnsignedNumericValue(u64 value);
-~NumericOrStringValue();
-NumericOrStringValue& operator=(NumericOrStringValue const &);
-NumericOrStringValue& operator=(NumericOrStringValue &&);
-NumericOrStringValue(NumericOrStringValue const&);
-NumericOrStringValue(NumericOrStringValue &&);
-private: void __jakt_destroy_variant();
-public:
-private:
-NumericOrStringValue() {};
-};
-template <typename R,typename S>
+};template <typename R,typename S>
 ErrorOr<typechecker::InternalDictionaryProduct<R,S>> create_internal_dictionary_product(JaktInternal::Dictionary<R,JaktInternal::DynamicArray<S>> const dict);
 }
 } // namespace Jakt
-template<typename K,typename V>struct Jakt::Formatter<Jakt::typechecker::InternalDictionaryProduct<K, V>
-> : Jakt::Formatter<Jakt::StringView>{
-Jakt::ErrorOr<void> format(Jakt::FormatBuilder& builder, Jakt::typechecker::InternalDictionaryProduct<K, V>
- const& value) {
-JaktInternal::PrettyPrint::ScopedEnable pretty_print_enable { m_alternative_form };Jakt::ErrorOr<void> format_error = Jakt::Formatter<Jakt::StringView>::format(builder, MUST(value.debug_description()));return format_error;}
-};
-namespace Jakt {
-} // namespace Jakt
-template<>struct Jakt::Formatter<Jakt::typechecker::ImportRestrictions> : Jakt::Formatter<Jakt::StringView>{
-Jakt::ErrorOr<void> format(Jakt::FormatBuilder& builder, Jakt::typechecker::ImportRestrictions const& value) {
-JaktInternal::PrettyPrint::ScopedEnable pretty_print_enable { m_alternative_form };Jakt::ErrorOr<void> format_error = Jakt::Formatter<Jakt::StringView>::format(builder, MUST(value.debug_description()));return format_error;}
-};
-namespace Jakt {
-} // namespace Jakt
-template<>struct Jakt::Formatter<Jakt::typechecker::FunctionMatchResult> : Jakt::Formatter<Jakt::StringView>{
-Jakt::ErrorOr<void> format(Jakt::FormatBuilder& builder, Jakt::typechecker::FunctionMatchResult const& value) {
-JaktInternal::PrettyPrint::ScopedEnable pretty_print_enable { m_alternative_form };Jakt::ErrorOr<void> format_error = Jakt::Formatter<Jakt::StringView>::format(builder, MUST(value.debug_description()));return format_error;}
-};
-namespace Jakt {
-} // namespace Jakt
-template<>struct Jakt::Formatter<Jakt::typechecker::TraitImplCheck> : Jakt::Formatter<Jakt::StringView>{
-Jakt::ErrorOr<void> format(Jakt::FormatBuilder& builder, Jakt::typechecker::TraitImplCheck const& value) {
-JaktInternal::PrettyPrint::ScopedEnable pretty_print_enable { m_alternative_form };Jakt::ErrorOr<void> format_error = Jakt::Formatter<Jakt::StringView>::format(builder, MUST(value.debug_description()));return format_error;}
-};
-namespace Jakt {
-} // namespace Jakt
 template<>struct Jakt::Formatter<Jakt::typechecker::TraitImplementationDescriptor> : Jakt::Formatter<Jakt::StringView>{
 Jakt::ErrorOr<void> format(Jakt::FormatBuilder& builder, Jakt::typechecker::TraitImplementationDescriptor const& value) {
-JaktInternal::PrettyPrint::ScopedEnable pretty_print_enable { m_alternative_form };Jakt::ErrorOr<void> format_error = Jakt::Formatter<Jakt::StringView>::format(builder, MUST(value.debug_description()));return format_error;}
-};
-namespace Jakt {
-} // namespace Jakt
-template<>struct Jakt::Formatter<Jakt::typechecker::Typechecker> : Jakt::Formatter<Jakt::StringView>{
-Jakt::ErrorOr<void> format(Jakt::FormatBuilder& builder, Jakt::typechecker::Typechecker const& value) {
 JaktInternal::PrettyPrint::ScopedEnable pretty_print_enable { m_alternative_form };Jakt::ErrorOr<void> format_error = Jakt::Formatter<Jakt::StringView>::format(builder, MUST(value.debug_description()));return format_error;}
 };
 namespace Jakt {
@@ -413,8 +381,40 @@ JaktInternal::PrettyPrint::ScopedEnable pretty_print_enable { m_alternative_form
 };
 namespace Jakt {
 } // namespace Jakt
+template<>struct Jakt::Formatter<Jakt::typechecker::FunctionMatchResult> : Jakt::Formatter<Jakt::StringView>{
+Jakt::ErrorOr<void> format(Jakt::FormatBuilder& builder, Jakt::typechecker::FunctionMatchResult const& value) {
+JaktInternal::PrettyPrint::ScopedEnable pretty_print_enable { m_alternative_form };Jakt::ErrorOr<void> format_error = Jakt::Formatter<Jakt::StringView>::format(builder, MUST(value.debug_description()));return format_error;}
+};
+namespace Jakt {
+} // namespace Jakt
+template<>struct Jakt::Formatter<Jakt::typechecker::ImportRestrictions> : Jakt::Formatter<Jakt::StringView>{
+Jakt::ErrorOr<void> format(Jakt::FormatBuilder& builder, Jakt::typechecker::ImportRestrictions const& value) {
+JaktInternal::PrettyPrint::ScopedEnable pretty_print_enable { m_alternative_form };Jakt::ErrorOr<void> format_error = Jakt::Formatter<Jakt::StringView>::format(builder, MUST(value.debug_description()));return format_error;}
+};
+namespace Jakt {
+} // namespace Jakt
+template<typename K,typename V>struct Jakt::Formatter<Jakt::typechecker::InternalDictionaryProduct<K, V>
+> : Jakt::Formatter<Jakt::StringView>{
+Jakt::ErrorOr<void> format(Jakt::FormatBuilder& builder, Jakt::typechecker::InternalDictionaryProduct<K, V>
+ const& value) {
+JaktInternal::PrettyPrint::ScopedEnable pretty_print_enable { m_alternative_form };Jakt::ErrorOr<void> format_error = Jakt::Formatter<Jakt::StringView>::format(builder, MUST(value.debug_description()));return format_error;}
+};
+namespace Jakt {
+} // namespace Jakt
 template<>struct Jakt::Formatter<Jakt::typechecker::NumericOrStringValue> : Jakt::Formatter<Jakt::StringView>{
 Jakt::ErrorOr<void> format(Jakt::FormatBuilder& builder, Jakt::typechecker::NumericOrStringValue const& value) {
+JaktInternal::PrettyPrint::ScopedEnable pretty_print_enable { m_alternative_form };Jakt::ErrorOr<void> format_error = Jakt::Formatter<Jakt::StringView>::format(builder, MUST(value.debug_description()));return format_error;}
+};
+namespace Jakt {
+} // namespace Jakt
+template<>struct Jakt::Formatter<Jakt::typechecker::Typechecker> : Jakt::Formatter<Jakt::StringView>{
+Jakt::ErrorOr<void> format(Jakt::FormatBuilder& builder, Jakt::typechecker::Typechecker const& value) {
+JaktInternal::PrettyPrint::ScopedEnable pretty_print_enable { m_alternative_form };Jakt::ErrorOr<void> format_error = Jakt::Formatter<Jakt::StringView>::format(builder, MUST(value.debug_description()));return format_error;}
+};
+namespace Jakt {
+} // namespace Jakt
+template<>struct Jakt::Formatter<Jakt::typechecker::TraitImplCheck> : Jakt::Formatter<Jakt::StringView>{
+Jakt::ErrorOr<void> format(Jakt::FormatBuilder& builder, Jakt::typechecker::TraitImplCheck const& value) {
 JaktInternal::PrettyPrint::ScopedEnable pretty_print_enable { m_alternative_form };Jakt::ErrorOr<void> format_error = Jakt::Formatter<Jakt::StringView>::format(builder, MUST(value.debug_description()));return format_error;}
 };
 namespace Jakt {

--- a/bootstrap/stage0/types.cpp
+++ b/bootstrap/stage0/types.cpp
@@ -258,7 +258,7 @@ auto&& __jakt_match_value = __jakt_match_variant.as.StringView;ByteString const&
 return JaktInternal::ExplicitValue(TRY((__jakt_format(format_string,v))));
 };/*case end*/
 case 0 /* Void */: {
-return JaktInternal::ExplicitValue(TRY((__jakt_format(format_string,TRY(ByteString::from_utf8("(void)"sv))))));
+return JaktInternal::ExplicitValue(TRY((__jakt_format(format_string,(ByteString::must_from_utf8("(void)"sv))))));
 };/*case end*/
 case 17 /* Struct */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Struct;JaktInternal::DynamicArray<types::Value> const& fields = __jakt_match_value.fields;
@@ -503,7 +503,7 @@ auto&& __jakt_match_value = __jakt_match_variant.as.OptionalSome;types::Value co
 return JaktInternal::ExplicitValue(TRY((types::format_value_impl(TRY((__jakt_format((StringView::from_string_literal("Some({})"sv)),format_string))),value,program))));
 };/*case end*/
 case 25 /* OptionalNone */: {
-return JaktInternal::ExplicitValue(TRY((__jakt_format(format_string,TRY(ByteString::from_utf8("None"sv))))));
+return JaktInternal::ExplicitValue(TRY((__jakt_format(format_string,(ByteString::must_from_utf8("None"sv))))));
 };/*case end*/
 case 26 /* JaktTuple */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.JaktTuple;JaktInternal::DynamicArray<types::Value> const& fields = __jakt_match_value.fields;
@@ -1358,10 +1358,10 @@ return TRY((((TRY((((({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<ByteString,ErrorOr<ByteString>>{
 auto __jakt_enum_value = (((((type)->common.init_common.qualifiers)).is_immutable));
 if (__jakt_enum_value == true) {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("const "sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("const "sv)));
 }
 else if (__jakt_enum_value == false) {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8(""sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8(""sv)));
 }
 VERIFY_NOT_REACHED();
 }());
@@ -1377,10 +1377,10 @@ return JaktInternal::ExplicitValue(TRY((((TRY((__jakt_format((StringView::from_s
 auto&& __jakt_match_variant = *type;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 18 /* TypeVariable */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("var "sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("var "sv)));
 };/*case end*/
 default: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8(""sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8(""sv)));
 };/*case end*/
 }/*switch end*/
 }()
@@ -1391,7 +1391,7 @@ return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8(""sv)));
 }))))));
 }
 else {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8(""sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8(""sv)));
 }
 }());
     if (_jakt_value.is_return())
@@ -1402,58 +1402,58 @@ return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8(""sv)));
 auto&& __jakt_match_variant = *type;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 17 /* Never */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("never"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("never"sv)));
 };/*case end*/
 case 10 /* F32 */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("f32"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("f32"sv)));
 };/*case end*/
 case 11 /* F64 */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("f64"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("f64"sv)));
 };/*case end*/
 case 6 /* I8 */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("i8"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("i8"sv)));
 };/*case end*/
 case 7 /* I16 */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("i16"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("i16"sv)));
 };/*case end*/
 case 8 /* I32 */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("i32"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("i32"sv)));
 };/*case end*/
 case 9 /* I64 */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("i64"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("i64"sv)));
 };/*case end*/
 case 2 /* U8 */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("u8"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("u8"sv)));
 };/*case end*/
 case 3 /* U16 */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("u16"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("u16"sv)));
 };/*case end*/
 case 4 /* U32 */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("u32"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("u32"sv)));
 };/*case end*/
 case 5 /* U64 */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("u64"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("u64"sv)));
 };/*case end*/
 case 12 /* Usize */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("usize"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("usize"sv)));
 };/*case end*/
 case 14 /* CChar */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("c_char"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("c_char"sv)));
 };/*case end*/
 case 15 /* CInt */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("c_int"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("c_int"sv)));
 };/*case end*/
 case 1 /* Bool */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("bool"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("bool"sv)));
 };/*case end*/
 case 0 /* Void */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("void"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("void"sv)));
 };/*case end*/
 case 16 /* Unknown */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("unknown"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("unknown"sv)));
 };/*case end*/
 case 13 /* JaktString */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("builtin(String)"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("builtin(String)"sv)));
 };/*case end*/
 case 19 /* Dependent */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Dependent;ids::TypeId const& namespace_type = __jakt_match_value.namespace_type;
@@ -1465,7 +1465,7 @@ auto&& __jakt_match_value = __jakt_match_variant.as.Trait;ids::TraitId const& id
 return JaktInternal::ExplicitValue(((((*this).get_trait(id)))->name));
 };/*case end*/
 case 31 /* Self */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("Self"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("Self"sv)));
 };/*case end*/
 case 30 /* Function */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Function;JaktInternal::DynamicArray<ids::TypeId> const& params = __jakt_match_value.params;
@@ -1488,7 +1488,7 @@ TRY((((param_names).push(TRY((((*this).type_name(x,debug_mode))))))));
 }
 
 ByteString const return_type = TRY((((*this).type_name(return_type_id,debug_mode))));
-__jakt_var_137 = TRY((__jakt_format((StringView::from_string_literal("fn({}) -> {}"sv)),TRY((utility::join(param_names,TRY(ByteString::from_utf8(", "sv))))),return_type))); goto __jakt_label_131;
+__jakt_var_137 = TRY((__jakt_format((StringView::from_string_literal("fn({}) -> {}"sv)),TRY((utility::join(param_names,(ByteString::must_from_utf8(", "sv))))),return_type))); goto __jakt_label_131;
 
 }
 __jakt_label_131:; __jakt_var_137.release_value(); }));
@@ -1512,7 +1512,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8("<"sv)))));
+(output,(ByteString::must_from_utf8("<"sv)))));
 bool first = true;
 {
 JaktInternal::ArrayIterator<ids::TypeId> _magic = ((args).iterator());
@@ -1530,7 +1530,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8(", "sv)))));
+(output,(ByteString::must_from_utf8(", "sv)))));
 }
 else {
 (first = false);
@@ -1554,7 +1554,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8(">"sv)))));
+(output,(ByteString::must_from_utf8(">"sv)))));
 __jakt_var_138 = output; goto __jakt_label_132;
 
 }
@@ -1571,7 +1571,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8("<"sv)))));
+(output,(ByteString::must_from_utf8("<"sv)))));
 bool first = true;
 {
 JaktInternal::ArrayIterator<ids::TypeId> _magic = ((args).iterator());
@@ -1589,7 +1589,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8(", "sv)))));
+(output,(ByteString::must_from_utf8(", "sv)))));
 }
 else {
 (first = false);
@@ -1613,7 +1613,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8(">"sv)))));
+(output,(ByteString::must_from_utf8(">"sv)))));
 __jakt_var_139 = output; goto __jakt_label_133;
 
 }
@@ -1623,14 +1623,14 @@ case 20 /* GenericInstance */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.GenericInstance;ids::StructId const& id = __jakt_match_value.id;
 JaktInternal::DynamicArray<ids::TypeId> const& args = __jakt_match_value.args;
 return JaktInternal::ExplicitValue(({ Optional<ByteString> __jakt_var_140; {
-ids::StructId const array_struct_id = TRY((((*this).find_struct_in_prelude(TRY(ByteString::from_utf8("Array"sv))))));
-ids::StructId const dictionary_struct_id = TRY((((*this).find_struct_in_prelude(TRY(ByteString::from_utf8("Dictionary"sv))))));
-ids::StructId const optional_struct_id = TRY((((*this).find_struct_in_prelude(TRY(ByteString::from_utf8("Optional"sv))))));
-ids::StructId const range_struct_id = TRY((((*this).find_struct_in_prelude(TRY(ByteString::from_utf8("Range"sv))))));
-ids::StructId const set_struct_id = TRY((((*this).find_struct_in_prelude(TRY(ByteString::from_utf8("Set"sv))))));
-ids::StructId const tuple_struct_id = TRY((((*this).find_struct_in_prelude(TRY(ByteString::from_utf8("Tuple"sv))))));
-ids::StructId const weak_ptr_struct_id = TRY((((*this).find_struct_in_prelude(TRY(ByteString::from_utf8("WeakPtr"sv))))));
-ByteString output = TRY(ByteString::from_utf8(""sv));
+ids::StructId const array_struct_id = TRY((((*this).find_struct_in_prelude((ByteString::must_from_utf8("Array"sv))))));
+ids::StructId const dictionary_struct_id = TRY((((*this).find_struct_in_prelude((ByteString::must_from_utf8("Dictionary"sv))))));
+ids::StructId const optional_struct_id = TRY((((*this).find_struct_in_prelude((ByteString::must_from_utf8("Optional"sv))))));
+ids::StructId const range_struct_id = TRY((((*this).find_struct_in_prelude((ByteString::must_from_utf8("Range"sv))))));
+ids::StructId const set_struct_id = TRY((((*this).find_struct_in_prelude((ByteString::must_from_utf8("Set"sv))))));
+ids::StructId const tuple_struct_id = TRY((((*this).find_struct_in_prelude((ByteString::must_from_utf8("Tuple"sv))))));
+ids::StructId const weak_ptr_struct_id = TRY((((*this).find_struct_in_prelude((ByteString::must_from_utf8("WeakPtr"sv))))));
+ByteString output = (ByteString::must_from_utf8(""sv));
 if (((id).equals(array_struct_id))){
 (output = TRY((__jakt_format((StringView::from_string_literal("[{}]"sv)),TRY((((*this).type_name(((args)[static_cast<i64>(0LL)]),debug_mode))))))));
 }
@@ -1647,7 +1647,7 @@ else if (((id).equals(set_struct_id))){
 (output = TRY((__jakt_format((StringView::from_string_literal("{{{}}}"sv)),TRY((((*this).type_name(((args)[static_cast<i64>(0LL)]),debug_mode))))))));
 }
 else if (((id).equals(tuple_struct_id))){
-(output = TRY(ByteString::from_utf8("("sv)));
+(output = (ByteString::must_from_utf8("("sv)));
 bool first = true;
 {
 JaktInternal::ArrayIterator<ids::TypeId> _magic = ((args).iterator());
@@ -1665,7 +1665,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8(", "sv)))));
+(output,(ByteString::must_from_utf8(", "sv)))));
 }
 else {
 (first = false);
@@ -1689,7 +1689,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8(")"sv)))));
+(output,(ByteString::must_from_utf8(")"sv)))));
 }
 else if (((id).equals(weak_ptr_struct_id))){
 (output = TRY((__jakt_format((StringView::from_string_literal("weak {}"sv)),TRY((((*this).type_name(((args)[static_cast<i64>(0LL)]),debug_mode))))))));
@@ -1703,7 +1703,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8("<"sv)))));
+(output,(ByteString::must_from_utf8("<"sv)))));
 bool first = true;
 {
 JaktInternal::ArrayIterator<ids::TypeId> _magic = ((args).iterator());
@@ -1721,7 +1721,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8(", "sv)))));
+(output,(ByteString::must_from_utf8(", "sv)))));
 }
 else {
 (first = false);
@@ -1745,7 +1745,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8(">"sv)))));
+(output,(ByteString::must_from_utf8(">"sv)))));
 }
 
 __jakt_var_140 = output; goto __jakt_label_134;
@@ -1765,7 +1765,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8("<"sv)))));
+(output,(ByteString::must_from_utf8("<"sv)))));
 {
 JaktInternal::ArrayIterator<ids::TypeId> _magic = ((args).iterator());
 for (;;){
@@ -1782,7 +1782,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8(", "sv)))));
+(output,(ByteString::must_from_utf8(", "sv)))));
 }
 else {
 (first = false);
@@ -1806,7 +1806,7 @@ TRY(([](ByteString& self, ByteString rhs) -> ErrorOr<void> {
 }
 return {};
 }
-(output,TRY(ByteString::from_utf8(">"sv)))));
+(output,(ByteString::must_from_utf8(">"sv)))));
 __jakt_var_141 = output; goto __jakt_label_135;
 
 }
@@ -1830,7 +1830,7 @@ return JaktInternal::ExplicitValue(TRY((__jakt_format((StringView::from_string_l
 };/*case end*/
 case 32 /* Const */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Const;types::Value const& value = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(TRY((types::comptime_format_impl(TRY(ByteString::from_utf8("comptime {}"sv)),(((TRY((DynamicArray<types::Value>::create_with({value})))))[(JaktInternal::Range<i64>{static_cast<i64>(0LL),static_cast<i64>(9223372036854775807LL)})]),((*this))))));
+return JaktInternal::ExplicitValue(TRY((types::comptime_format_impl((ByteString::must_from_utf8("comptime {}"sv)),(((TRY((DynamicArray<types::Value>::create_with({value})))))[(JaktInternal::Range<i64>{static_cast<i64>(0LL),static_cast<i64>(9223372036854775807LL)})]),((*this))))));
 };/*case end*/
 default: VERIFY_NOT_REACHED();}/*switch end*/
 }()
@@ -2063,7 +2063,7 @@ break;
 }
 
 }
-return TRY((utility::join(ss,TRY(ByteString::from_utf8(" -> "sv)))));
+return TRY((utility::join(ss,(ByteString::must_from_utf8(" -> "sv)))));
 }
 }
 
@@ -2078,7 +2078,7 @@ return JaktInternal::ExplicitValue(true);
 };/*case end*/
 case 24 /* Struct */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Struct;ids::StructId const& struct_id = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(((TRY((((*this).find_struct_in_prelude(TRY(ByteString::from_utf8("String"sv))))))).equals(struct_id)));
+return JaktInternal::ExplicitValue(((TRY((((*this).find_struct_in_prelude((ByteString::must_from_utf8("String"sv))))))).equals(struct_id)));
 };/*case end*/
 default: {
 return JaktInternal::ExplicitValue(false);
@@ -3023,7 +3023,7 @@ return ((((((((*this).modules))[((((id).module)).id)]))->structures))[((id).id)]
 
 ErrorOr<JaktInternal::Optional<ids::StructId>> types::CheckedProgram::check_and_extract_weak_ptr(ids::StructId const struct_id,JaktInternal::DynamicArray<ids::TypeId> const args) const {
 {
-ids::StructId const weak_ptr_struct_id = TRY((((*this).find_struct_in_prelude(TRY(ByteString::from_utf8("WeakPtr"sv))))));
+ids::StructId const weak_ptr_struct_id = TRY((((*this).find_struct_in_prelude((ByteString::must_from_utf8("WeakPtr"sv))))));
 if (((struct_id).equals(weak_ptr_struct_id))){
 if (((((args).size())) != (static_cast<size_t>(1ULL)))){
 TRY((((((*this).compiler))->panic(TRY((__jakt_format((StringView::from_string_literal("Internal error: Generic type is WeakPtr but there are not exactly 1 type parameter. There are {} parameters."sv)),((args).size()))))))));
@@ -3105,7 +3105,7 @@ return (((*this).is_integer(type_id)) || ((*this).is_floating(type_id)));
 ErrorOr<types::StructOrEnumId> types::CheckedProgram::find_reflected_primitive(ByteString const primitive) const {
 {
 ids::ScopeId const scope_id = ((*this).prelude_scope_id());
-JaktInternal::Optional<JaktInternal::Tuple<ids::ScopeId,bool>> const maybe_namespace = TRY((((*this).find_namespace_in_scope(scope_id,TRY(ByteString::from_utf8("Reflect"sv)),false,true,JaktInternal::OptionalNone()))));
+JaktInternal::Optional<JaktInternal::Tuple<ids::ScopeId,bool>> const maybe_namespace = TRY((((*this).find_namespace_in_scope(scope_id,(ByteString::must_from_utf8("Reflect"sv)),false,true,JaktInternal::OptionalNone()))));
 if ((!(((maybe_namespace).has_value())))){
 TRY((((((*this).compiler))->panic(TRY((__jakt_format((StringView::from_string_literal("internal error: builtin namespace 'Reflect' not found"sv)))))))));
 }
@@ -3379,88 +3379,88 @@ return ({
 auto&& __jakt_match_variant = *((*this).impl);
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 0 /* Void */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("void"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("void"sv)));
 };/*case end*/
 case 1 /* Bool */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("bool"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("bool"sv)));
 };/*case end*/
 case 2 /* U8 */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("u8"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("u8"sv)));
 };/*case end*/
 case 3 /* U16 */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("u16"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("u16"sv)));
 };/*case end*/
 case 4 /* U32 */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("u32"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("u32"sv)));
 };/*case end*/
 case 5 /* U64 */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("u64"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("u64"sv)));
 };/*case end*/
 case 6 /* I8 */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("i18"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("i18"sv)));
 };/*case end*/
 case 7 /* I16 */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("i16"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("i16"sv)));
 };/*case end*/
 case 8 /* I32 */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("i32"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("i32"sv)));
 };/*case end*/
 case 9 /* I64 */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("i64"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("i64"sv)));
 };/*case end*/
 case 10 /* F32 */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("f32"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("f32"sv)));
 };/*case end*/
 case 11 /* F64 */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("f64"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("f64"sv)));
 };/*case end*/
 case 12 /* USize */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("usize"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("usize"sv)));
 };/*case end*/
 case 13 /* JaktString */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("String"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("String"sv)));
 };/*case end*/
 case 14 /* StringView */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("StringView"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("StringView"sv)));
 };/*case end*/
 case 15 /* CChar */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("c_char"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("c_char"sv)));
 };/*case end*/
 case 16 /* CInt */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("c_int"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("c_int"sv)));
 };/*case end*/
 case 17 /* Struct */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("struct <T>"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("struct <T>"sv)));
 };/*case end*/
 case 18 /* Class */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("class <T>"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("class <T>"sv)));
 };/*case end*/
 case 19 /* Enum */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("enum <T>"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("enum <T>"sv)));
 };/*case end*/
 case 20 /* JaktArray */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("Array"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("Array"sv)));
 };/*case end*/
 case 21 /* JaktDictionary */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("Dictionary"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("Dictionary"sv)));
 };/*case end*/
 case 22 /* JaktSet */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("Set"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("Set"sv)));
 };/*case end*/
 case 23 /* RawPtr */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("raw <T>"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("raw <T>"sv)));
 };/*case end*/
 case 24 /* OptionalSome */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("Some"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("Some"sv)));
 };/*case end*/
 case 25 /* OptionalNone */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("None"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("None"sv)));
 };/*case end*/
 case 26 /* JaktTuple */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("Tuple"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("Tuple"sv)));
 };/*case end*/
 case 27 /* Function */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("Function"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("Function"sv)));
 };/*case end*/
 default: VERIFY_NOT_REACHED();}/*switch end*/
 }()
@@ -3801,7 +3801,7 @@ return [](ByteString const& self, ByteString rhs) -> bool {
 return (!(((self) == (rhs))));
 }
 }
-(((((((((*this).params))[static_cast<i64>(0LL)])).variable))->name),TRY(ByteString::from_utf8("this"sv)));
+(((((((((*this).params))[static_cast<i64>(0LL)])).variable))->name),(ByteString::must_from_utf8("this"sv)));
 }
 }
 
@@ -3821,7 +3821,7 @@ return (infallible_enum_cast<jakt__prelude__operators::Ordering>((JaktInternal::
 return false;
 }
 NonnullRefPtr<types::CheckedVariable> const first_param_variable = ((((((*this).params))[static_cast<i64>(0LL)])).variable);
-return (((((first_param_variable)->name)) == (TRY(ByteString::from_utf8("this"sv)))) && ((first_param_variable)->is_mutable));
+return (((((first_param_variable)->name)) == ((ByteString::must_from_utf8("this"sv)))) && ((first_param_variable)->is_mutable));
 }
 }
 
@@ -3830,7 +3830,7 @@ ErrorOr<NonnullRefPtr<CheckedFunction>> types::CheckedFunction::__jakt_create(By
 ErrorOr<parser::ParsedFunction> types::CheckedFunction::to_parsed_function() const {
 {
 if ((!(((((*this).parsed_function)).has_value())))){
-utility::panic(TRY(ByteString::from_utf8("to_parsed_function() called on a synthetic function"sv)));
+utility::panic((ByteString::must_from_utf8("to_parsed_function() called on a synthetic function"sv)));
 }
 return (((*this).parsed_function).value());
 }
@@ -6361,103 +6361,103 @@ return ({
 auto&& __jakt_match_variant = *this;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 0 /* Void */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("Void"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("Void"sv)));
 };/*case end*/
 case 1 /* Bool */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("Bool"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("Bool"sv)));
 };/*case end*/
 case 2 /* U8 */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("U8"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("U8"sv)));
 };/*case end*/
 case 3 /* U16 */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("U16"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("U16"sv)));
 };/*case end*/
 case 4 /* U32 */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("U32"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("U32"sv)));
 };/*case end*/
 case 5 /* U64 */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("U64"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("U64"sv)));
 };/*case end*/
 case 6 /* I8 */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("I8"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("I8"sv)));
 };/*case end*/
 case 7 /* I16 */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("I16"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("I16"sv)));
 };/*case end*/
 case 8 /* I32 */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("I32"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("I32"sv)));
 };/*case end*/
 case 9 /* I64 */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("I64"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("I64"sv)));
 };/*case end*/
 case 10 /* F32 */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("F32"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("F32"sv)));
 };/*case end*/
 case 11 /* F64 */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("F64"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("F64"sv)));
 };/*case end*/
 case 12 /* Usize */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("Usize"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("Usize"sv)));
 };/*case end*/
 case 13 /* JaktString */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("JaktString"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("JaktString"sv)));
 };/*case end*/
 case 14 /* CChar */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("CChar"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("CChar"sv)));
 };/*case end*/
 case 15 /* CInt */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("CInt"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("CInt"sv)));
 };/*case end*/
 case 16 /* Unknown */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("Unknown"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("Unknown"sv)));
 };/*case end*/
 case 17 /* Never */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("Never"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("Never"sv)));
 };/*case end*/
 case 18 /* TypeVariable */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("TypeVariable"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("TypeVariable"sv)));
 };/*case end*/
 case 19 /* Dependent */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("Dependent"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("Dependent"sv)));
 };/*case end*/
 case 20 /* GenericInstance */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("GenericInstance"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("GenericInstance"sv)));
 };/*case end*/
 case 21 /* GenericEnumInstance */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("GenericEnumInstance"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("GenericEnumInstance"sv)));
 };/*case end*/
 case 22 /* GenericTraitInstance */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("GenericTraitInstance"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("GenericTraitInstance"sv)));
 };/*case end*/
 case 23 /* GenericResolvedType */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("GenericResolvedType"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("GenericResolvedType"sv)));
 };/*case end*/
 case 24 /* Struct */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("Struct"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("Struct"sv)));
 };/*case end*/
 case 25 /* Enum */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("Enum"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("Enum"sv)));
 };/*case end*/
 case 26 /* RawPtr */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("RawPtr"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("RawPtr"sv)));
 };/*case end*/
 case 27 /* Trait */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("Trait"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("Trait"sv)));
 };/*case end*/
 case 28 /* Reference */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("Reference"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("Reference"sv)));
 };/*case end*/
 case 29 /* MutableReference */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("MutableReference"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("MutableReference"sv)));
 };/*case end*/
 case 30 /* Function */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("Function"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("Function"sv)));
 };/*case end*/
 case 31 /* Self */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("Self"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("Self"sv)));
 };/*case end*/
 case 32 /* Const */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("Const"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("Const"sv)));
 };/*case end*/
 default: VERIFY_NOT_REACHED();}/*switch end*/
 }()
@@ -8545,7 +8545,7 @@ case 12 /* USize */: {
 return JaktInternal::ExplicitValue(types::builtin(types::BuiltinType::Usize()));
 };/*case end*/
 case 13 /* JaktString */: {
-return JaktInternal::ExplicitValue((TRY((((((program)))->find_type_in_scope(((((program)))->prelude_scope_id()),TRY(ByteString::from_utf8("String"sv)),false,JaktInternal::OptionalNone())))).value()));
+return JaktInternal::ExplicitValue((TRY((((((program)))->find_type_in_scope(((((program)))->prelude_scope_id()),(ByteString::must_from_utf8("String"sv)),false,JaktInternal::OptionalNone())))).value()));
 };/*case end*/
 case 14 /* StringView */: {
 return JaktInternal::ExplicitValue(types::builtin(types::BuiltinType::JaktString()));
@@ -8570,7 +8570,7 @@ return JaktInternal::ExplicitValue(TRY((((((program)))->find_or_add_type_id(TRY(
 };/*case end*/
 default: {
 {
-utility::panic(TRY(ByteString::from_utf8("Reflected value type not implemented"sv)));
+utility::panic((ByteString::must_from_utf8("Reflected value type not implemented"sv)));
 }
 };/*case end*/
 }/*switch end*/
@@ -12030,7 +12030,7 @@ auto&& __jakt_match_variant = *type_;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 10 /* F32 */: {
 {
-utility::todo(TRY(ByteString::from_utf8("Implement casting f32 to f64"sv)));
+utility::todo((ByteString::must_from_utf8("Implement casting f32 to f64"sv)));
 }
 };/*case end*/
 case 11 /* F64 */: {
@@ -12074,7 +12074,7 @@ return JaktInternal::ExplicitValue((infallible_integer_cast<size_t>((value))));
 case 2 /* Floating */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Floating;f64 const& value = __jakt_match_value.value;
 {
-utility::panic(TRY(ByteString::from_utf8("to_usize on a floating point constant"sv)));
+utility::panic((ByteString::must_from_utf8("to_usize on a floating point constant"sv)));
 }
 };/*case end*/
 default: VERIFY_NOT_REACHED();}/*switch end*/
@@ -16830,7 +16830,7 @@ __jakt_label_156:; __jakt_var_162.release_value(); }));
 }
 else {
 {
-utility::panic(TRY(ByteString::from_utf8("Try block doesn't have a block"sv)));
+utility::panic((ByteString::must_from_utf8("Try block doesn't have a block"sv)));
 }
 }
 }());
@@ -17487,58 +17487,58 @@ return ({
 auto&& __jakt_match_variant = *this;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 0 /* Void */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("Void"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("Void"sv)));
 };/*case end*/
 case 1 /* Bool */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("Bool"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("Bool"sv)));
 };/*case end*/
 case 2 /* U8 */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("U8"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("U8"sv)));
 };/*case end*/
 case 3 /* U16 */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("U16"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("U16"sv)));
 };/*case end*/
 case 4 /* U32 */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("U32"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("U32"sv)));
 };/*case end*/
 case 5 /* U64 */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("U64"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("U64"sv)));
 };/*case end*/
 case 6 /* I8 */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("I8"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("I8"sv)));
 };/*case end*/
 case 7 /* I16 */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("I16"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("I16"sv)));
 };/*case end*/
 case 8 /* I32 */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("I32"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("I32"sv)));
 };/*case end*/
 case 9 /* I64 */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("I64"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("I64"sv)));
 };/*case end*/
 case 10 /* F32 */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("F32"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("F32"sv)));
 };/*case end*/
 case 11 /* F64 */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("F64"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("F64"sv)));
 };/*case end*/
 case 12 /* Usize */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("Usize"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("Usize"sv)));
 };/*case end*/
 case 13 /* JaktString */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("JaktString"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("JaktString"sv)));
 };/*case end*/
 case 14 /* CChar */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("CChar"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("CChar"sv)));
 };/*case end*/
 case 15 /* CInt */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("CInt"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("CInt"sv)));
 };/*case end*/
 case 16 /* Unknown */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("Unknown"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("Unknown"sv)));
 };/*case end*/
 case 17 /* Never */: {
-return JaktInternal::ExplicitValue(TRY(ByteString::from_utf8("Never"sv)));
+return JaktInternal::ExplicitValue((ByteString::must_from_utf8("Never"sv)));
 };/*case end*/
 default: VERIFY_NOT_REACHED();}/*switch end*/
 }()

--- a/bootstrap/stage0/types.h
+++ b/bootstrap/stage0/types.h
@@ -59,7 +59,33 @@ struct CheckedBlock {
 public: JaktInternal::DynamicArray<NonnullRefPtr<typename types::CheckedStatement>> statements;public: ids::ScopeId scope_id;public: types::BlockControlFlow control_flow;public: JaktInternal::Optional<ids::TypeId> yielded_type;public: bool yielded_none;public: CheckedBlock(JaktInternal::DynamicArray<NonnullRefPtr<typename types::CheckedStatement>> a_statements, ids::ScopeId a_scope_id, types::BlockControlFlow a_control_flow, JaktInternal::Optional<ids::TypeId> a_yielded_type, bool a_yielded_none);
 
 public: ErrorOr<ByteString> debug_description() const;
-};struct BuiltinType {
+};struct CheckedMatchBody {
+u8 __jakt_variant_index = 0;
+union VariantData {
+u8 __jakt_uninit_value;
+struct {
+NonnullRefPtr<typename types::CheckedExpression> value;
+} Expression;
+struct {
+types::CheckedBlock value;
+} Block;
+constexpr VariantData() {}
+~VariantData() {}
+} as;
+constexpr u8 __jakt_init_index() const noexcept { return __jakt_variant_index - 1; }ErrorOr<ByteString> debug_description() const;
+[[nodiscard]] static CheckedMatchBody Expression(NonnullRefPtr<typename types::CheckedExpression> value);
+[[nodiscard]] static CheckedMatchBody Block(types::CheckedBlock value);
+~CheckedMatchBody();
+CheckedMatchBody& operator=(CheckedMatchBody const &);
+CheckedMatchBody& operator=(CheckedMatchBody &&);
+CheckedMatchBody(CheckedMatchBody const&);
+CheckedMatchBody(CheckedMatchBody &&);
+private: void __jakt_destroy_variant();
+public:
+private:
+CheckedMatchBody() {};
+};
+struct FunctionGenericParameterKind {
 u8 __jakt_variant_index = 0;
 union VariantData {
 u8 __jakt_uninit_value;
@@ -67,98 +93,408 @@ constexpr VariantData() {}
 ~VariantData() {}
 } as;
 constexpr u8 __jakt_init_index() const noexcept { return __jakt_variant_index - 1; }ErrorOr<ByteString> debug_description() const;
-[[nodiscard]] static BuiltinType Void();
-[[nodiscard]] static BuiltinType Bool();
-[[nodiscard]] static BuiltinType U8();
-[[nodiscard]] static BuiltinType U16();
-[[nodiscard]] static BuiltinType U32();
-[[nodiscard]] static BuiltinType U64();
-[[nodiscard]] static BuiltinType I8();
-[[nodiscard]] static BuiltinType I16();
-[[nodiscard]] static BuiltinType I32();
-[[nodiscard]] static BuiltinType I64();
-[[nodiscard]] static BuiltinType F32();
-[[nodiscard]] static BuiltinType F64();
-[[nodiscard]] static BuiltinType Usize();
-[[nodiscard]] static BuiltinType JaktString();
-[[nodiscard]] static BuiltinType CChar();
-[[nodiscard]] static BuiltinType CInt();
-[[nodiscard]] static BuiltinType Unknown();
-[[nodiscard]] static BuiltinType Never();
-~BuiltinType();
-BuiltinType& operator=(BuiltinType const &);
-BuiltinType& operator=(BuiltinType &&);
-BuiltinType(BuiltinType const&);
-BuiltinType(BuiltinType &&);
-private: void __jakt_destroy_variant();
-public:
-ErrorOr<ByteString> constructor_name() const;
-size_t id() const;
-private:
-BuiltinType() {};
-};
-struct CheckedVisibility {
-u8 __jakt_variant_index = 0;
-union VariantData {
-u8 __jakt_uninit_value;
-struct {
-JaktInternal::DynamicArray<NonnullRefPtr<typename types::MaybeResolvedScope>> scopes;
-utility::Span span;
-} Restricted;
-constexpr VariantData() {}
-~VariantData() {}
-} as;
-constexpr u8 __jakt_init_index() const noexcept { return __jakt_variant_index - 1; }ErrorOr<ByteString> debug_description() const;
-[[nodiscard]] static CheckedVisibility Public();
-[[nodiscard]] static CheckedVisibility Private();
-[[nodiscard]] static CheckedVisibility Restricted(JaktInternal::DynamicArray<NonnullRefPtr<typename types::MaybeResolvedScope>> scopes, utility::Span span);
-~CheckedVisibility();
-CheckedVisibility& operator=(CheckedVisibility const &);
-CheckedVisibility& operator=(CheckedVisibility &&);
-CheckedVisibility(CheckedVisibility const&);
-CheckedVisibility(CheckedVisibility &&);
+[[nodiscard]] static FunctionGenericParameterKind InferenceGuide();
+[[nodiscard]] static FunctionGenericParameterKind Parameter();
+~FunctionGenericParameterKind();
+FunctionGenericParameterKind& operator=(FunctionGenericParameterKind const &);
+FunctionGenericParameterKind& operator=(FunctionGenericParameterKind &&);
+FunctionGenericParameterKind(FunctionGenericParameterKind const&);
+FunctionGenericParameterKind(FunctionGenericParameterKind &&);
 private: void __jakt_destroy_variant();
 public:
 private:
-CheckedVisibility() {};
+FunctionGenericParameterKind() {};
 };
-struct NumericOrStringValue {
+struct CheckedGenericParameter {
+  public:
+public: ids::TypeId type_id;public: JaktInternal::DynamicArray<ids::TraitId> constraints;public: utility::Span span;public: static ErrorOr<types::CheckedGenericParameter> make(ids::TypeId const type_id, utility::Span const span);
+public: CheckedGenericParameter(ids::TypeId a_type_id, JaktInternal::DynamicArray<ids::TraitId> a_constraints, utility::Span a_span);
+
+public: ErrorOr<ByteString> debug_description() const;
+};struct FunctionGenericParameter {
+  public:
+public: types::FunctionGenericParameterKind kind;public: types::CheckedGenericParameter checked_parameter;public: static ErrorOr<types::FunctionGenericParameter> parameter(ids::TypeId const type_id, utility::Span const span);
+public: ids::TypeId type_id() const;
+public: FunctionGenericParameter(types::FunctionGenericParameterKind a_kind, types::CheckedGenericParameter a_checked_parameter);
+
+public: ErrorOr<ByteString> debug_description() const;
+};struct NumberConstant {
 u8 __jakt_variant_index = 0;
 union VariantData {
 u8 __jakt_uninit_value;
-struct {
-ByteString value;
-} StringValue;
 struct {
 i64 value;
-} SignedNumericValue;
+} Signed;
 struct {
 u64 value;
-} UnsignedNumericValue;
+} Unsigned;
+struct {
+f64 value;
+} Floating;
 constexpr VariantData() {}
 ~VariantData() {}
 } as;
 constexpr u8 __jakt_init_index() const noexcept { return __jakt_variant_index - 1; }ErrorOr<ByteString> debug_description() const;
-[[nodiscard]] static NumericOrStringValue StringValue(ByteString value);
-[[nodiscard]] static NumericOrStringValue SignedNumericValue(i64 value);
-[[nodiscard]] static NumericOrStringValue UnsignedNumericValue(u64 value);
-~NumericOrStringValue();
-NumericOrStringValue& operator=(NumericOrStringValue const &);
-NumericOrStringValue& operator=(NumericOrStringValue &&);
-NumericOrStringValue(NumericOrStringValue const&);
-NumericOrStringValue(NumericOrStringValue &&);
+[[nodiscard]] static NumberConstant Signed(i64 value);
+[[nodiscard]] static NumberConstant Unsigned(u64 value);
+[[nodiscard]] static NumberConstant Floating(f64 value);
+~NumberConstant();
+NumberConstant& operator=(NumberConstant const &);
+NumberConstant& operator=(NumberConstant &&);
+NumberConstant(NumberConstant const&);
+NumberConstant(NumberConstant &&);
 private: void __jakt_destroy_variant();
 public:
+ErrorOr<bool> can_fit_number(ids::TypeId const type_id, NonnullRefPtr<types::CheckedProgram> const program) const;
+ErrorOr<size_t> to_usize() const;
 private:
-NumericOrStringValue() {};
+NumberConstant() {};
 };
-struct CheckedStruct {
+struct ClassInstanceRebind {
   public:
-public: ByteString name;public: utility::Span name_span;public: JaktInternal::DynamicArray<types::CheckedGenericParameter> generic_parameters;public: JaktInternal::Optional<JaktInternal::DynamicArray<JaktInternal::Optional<ids::TypeId>>> generic_parameter_defaults;public: JaktInternal::DynamicArray<types::CheckedField> fields;public: ids::ScopeId scope_id;public: parser::DefinitionLinkage definition_linkage;public: JaktInternal::Dictionary<ByteString,JaktInternal::DynamicArray<JaktInternal::Tuple<ids::TraitId,JaktInternal::DynamicArray<ids::TypeId>>>> trait_implementations;public: parser::RecordType record_type;public: ids::TypeId type_id;public: JaktInternal::Optional<ids::StructId> super_struct_id;public: JaktInternal::Optional<parser::ExternalName> external_name;public: JaktInternal::Optional<ids::TypeId> implements_type;public: CheckedStruct(ByteString a_name, utility::Span a_name_span, JaktInternal::DynamicArray<types::CheckedGenericParameter> a_generic_parameters, JaktInternal::Optional<JaktInternal::DynamicArray<JaktInternal::Optional<ids::TypeId>>> a_generic_parameter_defaults, JaktInternal::DynamicArray<types::CheckedField> a_fields, ids::ScopeId a_scope_id, parser::DefinitionLinkage a_definition_linkage, JaktInternal::Dictionary<ByteString,JaktInternal::DynamicArray<JaktInternal::Tuple<ids::TraitId,JaktInternal::DynamicArray<ids::TypeId>>>> a_trait_implementations, parser::RecordType a_record_type, ids::TypeId a_type_id, JaktInternal::Optional<ids::StructId> a_super_struct_id, JaktInternal::Optional<parser::ExternalName> a_external_name, JaktInternal::Optional<ids::TypeId> a_implements_type);
+public: ByteString name;public: utility::Span name_span;public: bool is_mutable;public: bool is_reference;public: ClassInstanceRebind(ByteString a_name, utility::Span a_name_span, bool a_is_mutable, bool a_is_reference);
+
+public: ErrorOr<ByteString> debug_description() const;
+};struct CheckedCall {
+  public:
+public: JaktInternal::DynamicArray<types::ResolvedNamespace> namespace_;public: ByteString name;public: JaktInternal::DynamicArray<JaktInternal::Tuple<ByteString,NonnullRefPtr<typename types::CheckedExpression>>> args;public: JaktInternal::DynamicArray<ids::TypeId> type_args;public: JaktInternal::Optional<ids::FunctionId> function_id;public: ids::TypeId return_type;public: bool callee_throws;public: JaktInternal::Optional<parser::ExternalName> external_name;public: parser::InlineState force_inline;public: CheckedCall(JaktInternal::DynamicArray<types::ResolvedNamespace> a_namespace_, ByteString a_name, JaktInternal::DynamicArray<JaktInternal::Tuple<ByteString,NonnullRefPtr<typename types::CheckedExpression>>> a_args, JaktInternal::DynamicArray<ids::TypeId> a_type_args, JaktInternal::Optional<ids::FunctionId> a_function_id, ids::TypeId a_return_type, bool a_callee_throws, JaktInternal::Optional<parser::ExternalName> a_external_name, parser::InlineState a_force_inline);
 
 public: parser::ExternalName name_for_codegen() const;
 public: ErrorOr<ByteString> debug_description() const;
-};struct CheckedNumericConstant {
+};struct OperatorTraitImplementation {
+  public:
+public: ids::TraitId trait_id;public: JaktInternal::DynamicArray<ids::TypeId> trait_generic_arguments;public: types::CheckedCall call_expression;public: OperatorTraitImplementation(ids::TraitId a_trait_id, JaktInternal::DynamicArray<ids::TypeId> a_trait_generic_arguments, types::CheckedCall a_call_expression);
+
+public: ErrorOr<ByteString> debug_description() const;
+};struct CheckedBinaryOperator {
+  public:
+public: parser::BinaryOperator op;public: JaktInternal::Optional<types::OperatorTraitImplementation> trait_implementation;public: CheckedBinaryOperator(parser::BinaryOperator a_op, JaktInternal::Optional<types::OperatorTraitImplementation> a_trait_implementation);
+
+public: ErrorOr<ByteString> debug_description() const;
+};class Module :public RefCounted<Module>, public Weakable<Module> {
+  public:
+virtual ~Module() = default;
+public: ids::ModuleId id;public: ByteString name;public: JaktInternal::DynamicArray<NonnullRefPtr<types::CheckedFunction>> functions;public: JaktInternal::DynamicArray<types::CheckedStruct> structures;public: JaktInternal::DynamicArray<types::CheckedEnum> enums;public: JaktInternal::DynamicArray<NonnullRefPtr<types::Scope>> scopes;public: JaktInternal::DynamicArray<NonnullRefPtr<typename types::Type>> types;public: JaktInternal::DynamicArray<NonnullRefPtr<types::CheckedTrait>> traits;public: JaktInternal::DynamicArray<NonnullRefPtr<types::CheckedVariable>> variables;public: JaktInternal::DynamicArray<ids::ModuleId> imports;public: ByteString resolved_import_path;public: JaktInternal::Dictionary<size_t,ids::StructId> builtin_implementation_structs;public: bool is_root;public: ids::FunctionId next_function_id() const;
+public: ErrorOr<ids::FunctionId> add_function(NonnullRefPtr<types::CheckedFunction> const checked_function);
+public: bool is_prelude() const;
+public: protected:
+explicit Module(ids::ModuleId a_id, ByteString a_name, JaktInternal::DynamicArray<NonnullRefPtr<types::CheckedFunction>> a_functions, JaktInternal::DynamicArray<types::CheckedStruct> a_structures, JaktInternal::DynamicArray<types::CheckedEnum> a_enums, JaktInternal::DynamicArray<NonnullRefPtr<types::Scope>> a_scopes, JaktInternal::DynamicArray<NonnullRefPtr<typename types::Type>> a_types, JaktInternal::DynamicArray<NonnullRefPtr<types::CheckedTrait>> a_traits, JaktInternal::DynamicArray<NonnullRefPtr<types::CheckedVariable>> a_variables, JaktInternal::DynamicArray<ids::ModuleId> a_imports, ByteString a_resolved_import_path, JaktInternal::Dictionary<size_t,ids::StructId> a_builtin_implementation_structs, bool a_is_root);
+public:
+static ErrorOr<NonnullRefPtr<Module>> __jakt_create(ids::ModuleId id, ByteString name, JaktInternal::DynamicArray<NonnullRefPtr<types::CheckedFunction>> functions, JaktInternal::DynamicArray<types::CheckedStruct> structures, JaktInternal::DynamicArray<types::CheckedEnum> enums, JaktInternal::DynamicArray<NonnullRefPtr<types::Scope>> scopes, JaktInternal::DynamicArray<NonnullRefPtr<typename types::Type>> types, JaktInternal::DynamicArray<NonnullRefPtr<types::CheckedTrait>> traits, JaktInternal::DynamicArray<NonnullRefPtr<types::CheckedVariable>> variables, JaktInternal::DynamicArray<ids::ModuleId> imports, ByteString resolved_import_path, JaktInternal::Dictionary<size_t,ids::StructId> builtin_implementation_structs, bool is_root);
+
+public: ErrorOr<ids::VarId> add_variable(NonnullRefPtr<types::CheckedVariable> const checked_variable);
+public: ErrorOr<ids::TypeId> new_type_variable(JaktInternal::Optional<JaktInternal::DynamicArray<ids::TypeId>> const implemented_traits);
+public: ErrorOr<ByteString> debug_description() const;
+};struct Value {
+  public:
+public: NonnullRefPtr<typename types::ValueImpl> impl;public: utility::Span span;public: ErrorOr<types::Value> copy() const;
+public: ErrorOr<ByteString> type_name() const;
+public: Value(NonnullRefPtr<typename types::ValueImpl> a_impl, utility::Span a_span);
+
+public: ErrorOr<types::Value> cast(types::Value const expected, utility::Span const span) const;
+public: ErrorOr<ByteString> debug_description() const;
+};struct CheckedTypeCast {
+u8 __jakt_variant_index = 0;
+union VariantData {
+u8 __jakt_uninit_value;
+struct {
+ids::TypeId value;
+} Fallible;
+struct {
+ids::TypeId value;
+} Infallible;
+constexpr VariantData() {}
+~VariantData() {}
+} as;
+constexpr u8 __jakt_init_index() const noexcept { return __jakt_variant_index - 1; }ErrorOr<ByteString> debug_description() const;
+[[nodiscard]] static CheckedTypeCast Fallible(ids::TypeId value);
+[[nodiscard]] static CheckedTypeCast Infallible(ids::TypeId value);
+~CheckedTypeCast();
+CheckedTypeCast& operator=(CheckedTypeCast const &);
+CheckedTypeCast& operator=(CheckedTypeCast &&);
+CheckedTypeCast(CheckedTypeCast const&);
+CheckedTypeCast(CheckedTypeCast &&);
+private: void __jakt_destroy_variant();
+public:
+ids::TypeId type_id() const;
+private:
+CheckedTypeCast() {};
+};
+struct CheckedEnumVariant {
+u8 __jakt_variant_index = 0;
+union VariantData {
+u8 __jakt_uninit_value;
+struct {
+ids::EnumId enum_id;
+ByteString name;
+utility::Span span;
+} Untyped;
+struct {
+ids::EnumId enum_id;
+ByteString name;
+ids::TypeId type_id;
+utility::Span span;
+} Typed;
+struct {
+ids::EnumId enum_id;
+ByteString name;
+NonnullRefPtr<typename types::CheckedExpression> expr;
+utility::Span span;
+} WithValue;
+struct {
+ids::EnumId enum_id;
+ByteString name;
+JaktInternal::DynamicArray<ids::VarId> fields;
+utility::Span span;
+} StructLike;
+constexpr VariantData() {}
+~VariantData() {}
+} as;
+constexpr u8 __jakt_init_index() const noexcept { return __jakt_variant_index - 1; }ErrorOr<ByteString> debug_description() const;
+[[nodiscard]] static CheckedEnumVariant Untyped(ids::EnumId enum_id, ByteString name, utility::Span span);
+[[nodiscard]] static CheckedEnumVariant Typed(ids::EnumId enum_id, ByteString name, ids::TypeId type_id, utility::Span span);
+[[nodiscard]] static CheckedEnumVariant WithValue(ids::EnumId enum_id, ByteString name, NonnullRefPtr<typename types::CheckedExpression> expr, utility::Span span);
+[[nodiscard]] static CheckedEnumVariant StructLike(ids::EnumId enum_id, ByteString name, JaktInternal::DynamicArray<ids::VarId> fields, utility::Span span);
+~CheckedEnumVariant();
+CheckedEnumVariant& operator=(CheckedEnumVariant const &);
+CheckedEnumVariant& operator=(CheckedEnumVariant &&);
+CheckedEnumVariant(CheckedEnumVariant const&);
+CheckedEnumVariant(CheckedEnumVariant &&);
+private: void __jakt_destroy_variant();
+public:
+ids::EnumId enum_id() const;
+ByteString name() const;
+bool equals(types::CheckedEnumVariant const other) const;
+utility::Span span() const;
+private:
+CheckedEnumVariant() {};
+};
+struct CheckedUnaryOperator {
+u8 __jakt_variant_index = 0;
+union VariantData {
+u8 __jakt_uninit_value;
+struct {
+types::CheckedTypeCast value;
+} TypeCast;
+struct {
+ids::TypeId value;
+} Is;
+struct {
+types::CheckedEnumVariant enum_variant;
+JaktInternal::DynamicArray<types::CheckedEnumVariantBinding> bindings;
+ids::TypeId type_id;
+} IsEnumVariant;
+struct {
+ids::TypeId value;
+} Sizeof;
+constexpr VariantData() {}
+~VariantData() {}
+} as;
+constexpr u8 __jakt_init_index() const noexcept { return __jakt_variant_index - 1; }ErrorOr<ByteString> debug_description() const;
+[[nodiscard]] static CheckedUnaryOperator PreIncrement();
+[[nodiscard]] static CheckedUnaryOperator PostIncrement();
+[[nodiscard]] static CheckedUnaryOperator PreDecrement();
+[[nodiscard]] static CheckedUnaryOperator PostDecrement();
+[[nodiscard]] static CheckedUnaryOperator Negate();
+[[nodiscard]] static CheckedUnaryOperator Dereference();
+[[nodiscard]] static CheckedUnaryOperator RawAddress();
+[[nodiscard]] static CheckedUnaryOperator Reference();
+[[nodiscard]] static CheckedUnaryOperator MutableReference();
+[[nodiscard]] static CheckedUnaryOperator LogicalNot();
+[[nodiscard]] static CheckedUnaryOperator BitwiseNot();
+[[nodiscard]] static CheckedUnaryOperator TypeCast(types::CheckedTypeCast value);
+[[nodiscard]] static CheckedUnaryOperator Is(ids::TypeId value);
+[[nodiscard]] static CheckedUnaryOperator IsEnumVariant(types::CheckedEnumVariant enum_variant, JaktInternal::DynamicArray<types::CheckedEnumVariantBinding> bindings, ids::TypeId type_id);
+[[nodiscard]] static CheckedUnaryOperator IsSome();
+[[nodiscard]] static CheckedUnaryOperator IsNone();
+[[nodiscard]] static CheckedUnaryOperator Sizeof(ids::TypeId value);
+~CheckedUnaryOperator();
+CheckedUnaryOperator& operator=(CheckedUnaryOperator const &);
+CheckedUnaryOperator& operator=(CheckedUnaryOperator &&);
+CheckedUnaryOperator(CheckedUnaryOperator const&);
+CheckedUnaryOperator(CheckedUnaryOperator &&);
+private: void __jakt_destroy_variant();
+public:
+private:
+CheckedUnaryOperator() {};
+};
+struct MaybeResolvedScope: public RefCounted<MaybeResolvedScope> {
+u8 __jakt_variant_index = 0;
+union VariantData {
+u8 __jakt_uninit_value;
+struct {
+ids::ScopeId value;
+} Resolved;
+struct {
+NonnullRefPtr<typename types::MaybeResolvedScope> parent_scope;
+ByteString relative_name;
+} Unresolved;
+constexpr VariantData() {}
+~VariantData() {}
+} as;
+constexpr u8 __jakt_init_index() const noexcept { return __jakt_variant_index - 1; }ErrorOr<ByteString> debug_description() const;
+[[nodiscard]] static ErrorOr<NonnullRefPtr<MaybeResolvedScope>> Resolved(ids::ScopeId value);
+[[nodiscard]] static ErrorOr<NonnullRefPtr<MaybeResolvedScope>> Unresolved(NonnullRefPtr<typename types::MaybeResolvedScope> parent_scope, ByteString relative_name);
+~MaybeResolvedScope();
+MaybeResolvedScope& operator=(MaybeResolvedScope const &);
+MaybeResolvedScope& operator=(MaybeResolvedScope &&);
+MaybeResolvedScope(MaybeResolvedScope const&);
+MaybeResolvedScope(MaybeResolvedScope &&);
+private: void __jakt_destroy_variant();
+public:
+ErrorOr<NonnullRefPtr<typename types::MaybeResolvedScope>> try_resolve(NonnullRefPtr<types::CheckedProgram> const program) const;
+private:
+MaybeResolvedScope() {};
+};
+struct CheckedCapture {
+u8 __jakt_variant_index = 0;
+union CommonData {
+u8 __jakt_uninit_common;
+struct {
+ByteString name;
+utility::Span span;
+} init_common;
+constexpr CommonData() {}
+~CommonData() {}
+} common;
+union VariantData {
+u8 __jakt_uninit_value;
+constexpr VariantData() {}
+~VariantData() {}
+} as;
+constexpr u8 __jakt_init_index() const noexcept { return __jakt_variant_index - 1; }ErrorOr<ByteString> debug_description() const;
+[[nodiscard]] static CheckedCapture ByValue(ByteString name, utility::Span span);
+[[nodiscard]] static CheckedCapture ByReference(ByteString name, utility::Span span);
+[[nodiscard]] static CheckedCapture ByMutableReference(ByteString name, utility::Span span);
+[[nodiscard]] static CheckedCapture ByComptimeDependency(ByteString name, utility::Span span);
+[[nodiscard]] static CheckedCapture AllByReference(ByteString name, utility::Span span);
+~CheckedCapture();
+CheckedCapture& operator=(CheckedCapture const &);
+CheckedCapture& operator=(CheckedCapture &&);
+CheckedCapture(CheckedCapture const&);
+CheckedCapture(CheckedCapture &&);
+private: void __jakt_destroy_variant();
+public:
+private:
+CheckedCapture() {};
+};
+struct CheckedField {
+  public:
+public: ids::VarId variable_id;public: JaktInternal::Optional<JaktInternal::Tuple<NonnullRefPtr<typename parser::ParsedExpression>,ids::ScopeId>> default_value_expression;public: CheckedField(ids::VarId a_variable_id, JaktInternal::Optional<JaktInternal::Tuple<NonnullRefPtr<typename parser::ParsedExpression>,ids::ScopeId>> a_default_value_expression);
+
+public: ErrorOr<ByteString> debug_description() const;
+};struct GenericInferences {
+  public:
+public: JaktInternal::Dictionary<ids::TypeId,ids::TypeId> values;public: ErrorOr<void> set_all(JaktInternal::DynamicArray<types::CheckedGenericParameter> const keys, JaktInternal::DynamicArray<ids::TypeId> const values);
+public: ErrorOr<void> set_from(JaktInternal::Dictionary<ids::TypeId,ids::TypeId> const checkpoint);
+public: ErrorOr<JaktInternal::Optional<ids::TypeId>> find_and_map(ByteString const name, NonnullRefPtr<types::CheckedProgram> const& program) const;
+public: GenericInferences(JaktInternal::Dictionary<ids::TypeId,ids::TypeId> a_values);
+
+public: void restore(JaktInternal::Dictionary<ids::TypeId,ids::TypeId> const checkpoint);
+public: ErrorOr<void> debug_description(NonnullRefPtr<types::CheckedProgram> const& program) const;
+public: ids::TypeId map(ids::TypeId const type) const;
+public: ErrorOr<JaktInternal::Dictionary<ids::TypeId,ids::TypeId>> perform_checkpoint(bool const reset);
+public: JaktInternal::Optional<ids::TypeId> get(ids::TypeId const key) const;
+public: JaktInternal::Dictionary<ids::TypeId,ids::TypeId> iterator() const;
+public: ErrorOr<void> set(ids::TypeId const key, ids::TypeId const value);
+public: ErrorOr<ByteString> debug_description() const;
+};struct CheckedTraitRequirements {
+u8 __jakt_variant_index = 0;
+union VariantData {
+u8 __jakt_uninit_value;
+struct {
+JaktInternal::Dictionary<ByteString,ids::FunctionId> value;
+} Methods;
+struct {
+NonnullRefPtr<typename types::CheckedExpression> value;
+} ComptimeExpression;
+constexpr VariantData() {}
+~VariantData() {}
+} as;
+constexpr u8 __jakt_init_index() const noexcept { return __jakt_variant_index - 1; }ErrorOr<ByteString> debug_description() const;
+[[nodiscard]] static CheckedTraitRequirements Nothing();
+[[nodiscard]] static CheckedTraitRequirements Methods(JaktInternal::Dictionary<ByteString,ids::FunctionId> value);
+[[nodiscard]] static CheckedTraitRequirements ComptimeExpression(NonnullRefPtr<typename types::CheckedExpression> value);
+~CheckedTraitRequirements();
+CheckedTraitRequirements& operator=(CheckedTraitRequirements const &);
+CheckedTraitRequirements& operator=(CheckedTraitRequirements &&);
+CheckedTraitRequirements(CheckedTraitRequirements const&);
+CheckedTraitRequirements(CheckedTraitRequirements &&);
+private: void __jakt_destroy_variant();
+public:
+private:
+CheckedTraitRequirements() {};
+};
+class Scope :public RefCounted<Scope>, public Weakable<Scope> {
+  public:
+virtual ~Scope() = default;
+public: JaktInternal::Optional<ByteString> namespace_name;public: JaktInternal::Optional<parser::ExternalName> external_name;public: JaktInternal::Dictionary<ByteString,ids::VarId> vars;public: JaktInternal::Dictionary<ByteString,types::Value> comptime_bindings;public: JaktInternal::Dictionary<ByteString,ids::StructId> structs;public: JaktInternal::Dictionary<ByteString,JaktInternal::DynamicArray<ids::FunctionId>> functions;public: JaktInternal::Dictionary<ByteString,ids::EnumId> enums;public: JaktInternal::Dictionary<ByteString,ids::TypeId> types;public: JaktInternal::Dictionary<ByteString,ids::TraitId> traits;public: JaktInternal::Dictionary<ByteString,ids::ModuleId> imports;public: JaktInternal::Dictionary<ByteString,ids::ScopeId> aliases;public: JaktInternal::Optional<ids::ScopeId> parent;public: JaktInternal::Optional<ids::ScopeId> alias_scope;public: JaktInternal::DynamicArray<ids::ScopeId> children;public: bool can_throw;public: JaktInternal::Optional<ByteString> import_path_if_extern;public: JaktInternal::Optional<JaktInternal::DynamicArray<types::ResolvedNamespace>> alias_path;public: JaktInternal::DynamicArray<parser::IncludeAction> after_extern_include;public: JaktInternal::DynamicArray<parser::IncludeAction> before_extern_include;public: ByteString debug_name;public: JaktInternal::DynamicArray<ids::ScopeId> resolution_mixins;public: JaktInternal::Optional<ids::TypeId> relevant_type_id;public: bool is_block_scope;public: JaktInternal::Optional<JaktInternal::DynamicArray<types::ResolvedForallChunk>> resolved_forall_chunks;public: JaktInternal::Dictionary<ByteString,types::SpecializedType> explicitly_specialized_types;public: bool is_from_generated_code;public: protected:
+explicit Scope(JaktInternal::Optional<ByteString> a_namespace_name, JaktInternal::Optional<parser::ExternalName> a_external_name, JaktInternal::Dictionary<ByteString,ids::VarId> a_vars, JaktInternal::Dictionary<ByteString,types::Value> a_comptime_bindings, JaktInternal::Dictionary<ByteString,ids::StructId> a_structs, JaktInternal::Dictionary<ByteString,JaktInternal::DynamicArray<ids::FunctionId>> a_functions, JaktInternal::Dictionary<ByteString,ids::EnumId> a_enums, JaktInternal::Dictionary<ByteString,ids::TypeId> a_types, JaktInternal::Dictionary<ByteString,ids::TraitId> a_traits, JaktInternal::Dictionary<ByteString,ids::ModuleId> a_imports, JaktInternal::Dictionary<ByteString,ids::ScopeId> a_aliases, JaktInternal::Optional<ids::ScopeId> a_parent, JaktInternal::Optional<ids::ScopeId> a_alias_scope, JaktInternal::DynamicArray<ids::ScopeId> a_children, bool a_can_throw, JaktInternal::Optional<ByteString> a_import_path_if_extern, JaktInternal::Optional<JaktInternal::DynamicArray<types::ResolvedNamespace>> a_alias_path, JaktInternal::DynamicArray<parser::IncludeAction> a_after_extern_include, JaktInternal::DynamicArray<parser::IncludeAction> a_before_extern_include, ByteString a_debug_name, JaktInternal::DynamicArray<ids::ScopeId> a_resolution_mixins, JaktInternal::Optional<ids::TypeId> a_relevant_type_id, bool a_is_block_scope, JaktInternal::Optional<JaktInternal::DynamicArray<types::ResolvedForallChunk>> a_resolved_forall_chunks, JaktInternal::Dictionary<ByteString,types::SpecializedType> a_explicitly_specialized_types, bool a_is_from_generated_code);
+public:
+static ErrorOr<NonnullRefPtr<Scope>> __jakt_create(JaktInternal::Optional<ByteString> namespace_name, JaktInternal::Optional<parser::ExternalName> external_name, JaktInternal::Dictionary<ByteString,ids::VarId> vars, JaktInternal::Dictionary<ByteString,types::Value> comptime_bindings, JaktInternal::Dictionary<ByteString,ids::StructId> structs, JaktInternal::Dictionary<ByteString,JaktInternal::DynamicArray<ids::FunctionId>> functions, JaktInternal::Dictionary<ByteString,ids::EnumId> enums, JaktInternal::Dictionary<ByteString,ids::TypeId> types, JaktInternal::Dictionary<ByteString,ids::TraitId> traits, JaktInternal::Dictionary<ByteString,ids::ModuleId> imports, JaktInternal::Dictionary<ByteString,ids::ScopeId> aliases, JaktInternal::Optional<ids::ScopeId> parent, JaktInternal::Optional<ids::ScopeId> alias_scope, JaktInternal::DynamicArray<ids::ScopeId> children, bool can_throw, JaktInternal::Optional<ByteString> import_path_if_extern, JaktInternal::Optional<JaktInternal::DynamicArray<types::ResolvedNamespace>> alias_path, JaktInternal::DynamicArray<parser::IncludeAction> after_extern_include, JaktInternal::DynamicArray<parser::IncludeAction> before_extern_include, ByteString debug_name, JaktInternal::DynamicArray<ids::ScopeId> resolution_mixins, JaktInternal::Optional<ids::TypeId> relevant_type_id, bool is_block_scope, JaktInternal::Optional<JaktInternal::DynamicArray<types::ResolvedForallChunk>> resolved_forall_chunks, JaktInternal::Dictionary<ByteString,types::SpecializedType> explicitly_specialized_types, bool is_from_generated_code);
+
+public: JaktInternal::Optional<parser::ExternalName> namespace_name_for_codegen() const;
+public: ErrorOr<ByteString> debug_description() const;
+};class FunctionGenerics :public RefCounted<FunctionGenerics>, public Weakable<FunctionGenerics> {
+  public:
+virtual ~FunctionGenerics() = default;
+public: ids::ScopeId base_scope_id;public: JaktInternal::DynamicArray<types::CheckedParameter> base_params;public: JaktInternal::DynamicArray<types::FunctionGenericParameter> params;public: JaktInternal::DynamicArray<JaktInternal::DynamicArray<ids::TypeId>> specializations;public: protected:
+explicit FunctionGenerics(ids::ScopeId a_base_scope_id, JaktInternal::DynamicArray<types::CheckedParameter> a_base_params, JaktInternal::DynamicArray<types::FunctionGenericParameter> a_params, JaktInternal::DynamicArray<JaktInternal::DynamicArray<ids::TypeId>> a_specializations);
+public:
+static ErrorOr<NonnullRefPtr<FunctionGenerics>> __jakt_create(ids::ScopeId base_scope_id, JaktInternal::DynamicArray<types::CheckedParameter> base_params, JaktInternal::DynamicArray<types::FunctionGenericParameter> params, JaktInternal::DynamicArray<JaktInternal::DynamicArray<ids::TypeId>> specializations);
+
+public: bool is_specialized_for_types(JaktInternal::DynamicArray<ids::TypeId> const types) const;
+public: ErrorOr<ByteString> debug_description() const;
+};struct CheckedVarDecl {
+  public:
+public: ByteString name;public: bool is_mutable;public: utility::Span span;public: ids::TypeId type_id;public: CheckedVarDecl(ByteString a_name, bool a_is_mutable, utility::Span a_span, ids::TypeId a_type_id);
+
+public: ErrorOr<ByteString> debug_description() const;
+};struct StructLikeId {
+u8 __jakt_variant_index = 0;
+union CommonData {
+u8 __jakt_uninit_common;
+struct {
+JaktInternal::Optional<JaktInternal::DynamicArray<ids::TypeId>> generic_arguments;
+} init_common;
+constexpr CommonData() {}
+~CommonData() {}
+} common;
+union VariantData {
+u8 __jakt_uninit_value;
+struct {
+ids::StructId value;
+} Struct;
+struct {
+ids::EnumId value;
+} Enum;
+struct {
+ids::TraitId value;
+} Trait;
+constexpr VariantData() {}
+~VariantData() {}
+} as;
+constexpr u8 __jakt_init_index() const noexcept { return __jakt_variant_index - 1; }ErrorOr<ByteString> debug_description() const;
+[[nodiscard]] static StructLikeId Struct(JaktInternal::Optional<JaktInternal::DynamicArray<ids::TypeId>> generic_arguments, ids::StructId value);
+[[nodiscard]] static StructLikeId Enum(JaktInternal::Optional<JaktInternal::DynamicArray<ids::TypeId>> generic_arguments, ids::EnumId value);
+[[nodiscard]] static StructLikeId Trait(JaktInternal::Optional<JaktInternal::DynamicArray<ids::TypeId>> generic_arguments, ids::TraitId value);
+~StructLikeId();
+StructLikeId& operator=(StructLikeId const &);
+StructLikeId& operator=(StructLikeId &&);
+StructLikeId(StructLikeId const&);
+StructLikeId(StructLikeId &&);
+private: void __jakt_destroy_variant();
+public:
+static ErrorOr<JaktInternal::Optional<types::StructLikeId>> from_type_id(ids::TypeId const type_id, NonnullRefPtr<types::CheckedProgram> const& program);
+ErrorOr<JaktInternal::DynamicArray<ids::TypeId>> generic_parameters(NonnullRefPtr<types::CheckedProgram> const& program) const;
+ErrorOr<ids::ScopeId> associated_scope_id(NonnullRefPtr<types::CheckedProgram> const& program) const;
+ErrorOr<JaktInternal::DynamicArray<types::CheckedGenericParameter>> generic_parameters_as_checked(NonnullRefPtr<types::CheckedProgram> const& program) const;
+ErrorOr<ids::ScopeId> scope_id(NonnullRefPtr<types::CheckedProgram> const& program) const;
+ErrorOr<ids::TypeId> specialized_by(JaktInternal::DynamicArray<ids::TypeId> const arguments, NonnullRefPtr<types::CheckedProgram>& program, ids::ModuleId const module_id, parser::CheckedQualifiers const qualifiers) const;
+private:
+StructLikeId() {};
+};
+struct CheckedNumericConstant {
 u8 __jakt_variant_index = 0;
 union VariantData {
 u8 __jakt_uninit_value;
@@ -221,304 +557,131 @@ JaktInternal::Optional<types::NumberConstant> number_constant() const;
 private:
 CheckedNumericConstant() {};
 };
-struct CheckedCall {
+struct SafetyMode {
+u8 __jakt_variant_index = 0;
+union VariantData {
+u8 __jakt_uninit_value;
+constexpr VariantData() {}
+~VariantData() {}
+} as;
+constexpr u8 __jakt_init_index() const noexcept { return __jakt_variant_index - 1; }ErrorOr<ByteString> debug_description() const;
+[[nodiscard]] static SafetyMode Safe();
+[[nodiscard]] static SafetyMode Unsafe();
+~SafetyMode();
+SafetyMode& operator=(SafetyMode const &);
+SafetyMode& operator=(SafetyMode &&);
+SafetyMode(SafetyMode const&);
+SafetyMode(SafetyMode &&);
+private: void __jakt_destroy_variant();
+public:
+private:
+SafetyMode() {};
+};
+struct CheckedVisibility {
+u8 __jakt_variant_index = 0;
+union VariantData {
+u8 __jakt_uninit_value;
+struct {
+JaktInternal::DynamicArray<NonnullRefPtr<typename types::MaybeResolvedScope>> scopes;
+utility::Span span;
+} Restricted;
+constexpr VariantData() {}
+~VariantData() {}
+} as;
+constexpr u8 __jakt_init_index() const noexcept { return __jakt_variant_index - 1; }ErrorOr<ByteString> debug_description() const;
+[[nodiscard]] static CheckedVisibility Public();
+[[nodiscard]] static CheckedVisibility Private();
+[[nodiscard]] static CheckedVisibility Restricted(JaktInternal::DynamicArray<NonnullRefPtr<typename types::MaybeResolvedScope>> scopes, utility::Span span);
+~CheckedVisibility();
+CheckedVisibility& operator=(CheckedVisibility const &);
+CheckedVisibility& operator=(CheckedVisibility &&);
+CheckedVisibility(CheckedVisibility const&);
+CheckedVisibility(CheckedVisibility &&);
+private: void __jakt_destroy_variant();
+public:
+private:
+CheckedVisibility() {};
+};
+class CheckedVariable :public RefCounted<CheckedVariable>, public Weakable<CheckedVariable> {
   public:
-public: JaktInternal::DynamicArray<types::ResolvedNamespace> namespace_;public: ByteString name;public: JaktInternal::DynamicArray<JaktInternal::Tuple<ByteString,NonnullRefPtr<typename types::CheckedExpression>>> args;public: JaktInternal::DynamicArray<ids::TypeId> type_args;public: JaktInternal::Optional<ids::FunctionId> function_id;public: ids::TypeId return_type;public: bool callee_throws;public: JaktInternal::Optional<parser::ExternalName> external_name;public: parser::InlineState force_inline;public: CheckedCall(JaktInternal::DynamicArray<types::ResolvedNamespace> a_namespace_, ByteString a_name, JaktInternal::DynamicArray<JaktInternal::Tuple<ByteString,NonnullRefPtr<typename types::CheckedExpression>>> a_args, JaktInternal::DynamicArray<ids::TypeId> a_type_args, JaktInternal::Optional<ids::FunctionId> a_function_id, ids::TypeId a_return_type, bool a_callee_throws, JaktInternal::Optional<parser::ExternalName> a_external_name, parser::InlineState a_force_inline);
-
+virtual ~CheckedVariable() = default;
+public: ByteString name;public: ids::TypeId type_id;public: bool is_mutable;public: utility::Span definition_span;public: JaktInternal::Optional<utility::Span> type_span;public: types::CheckedVisibility visibility;public: JaktInternal::Optional<ids::ScopeId> owner_scope;public: JaktInternal::Optional<JaktInternal::Dictionary<ids::TypeId,ids::TypeId>> owner_scope_generics;public: JaktInternal::Optional<parser::ExternalName> external_name;public: ErrorOr<NonnullRefPtr<types::CheckedVariable>> map_types(Function<ErrorOr<ids::TypeId>(ids::TypeId)> const& map) const;
 public: parser::ExternalName name_for_codegen() const;
-public: ErrorOr<ByteString> debug_description() const;
-};struct OperatorTraitImplementation {
-  public:
-public: ids::TraitId trait_id;public: JaktInternal::DynamicArray<ids::TypeId> trait_generic_arguments;public: types::CheckedCall call_expression;public: OperatorTraitImplementation(ids::TraitId a_trait_id, JaktInternal::DynamicArray<ids::TypeId> a_trait_generic_arguments, types::CheckedCall a_call_expression);
-
-public: ErrorOr<ByteString> debug_description() const;
-};struct CheckedBinaryOperator {
-  public:
-public: parser::BinaryOperator op;public: JaktInternal::Optional<types::OperatorTraitImplementation> trait_implementation;public: CheckedBinaryOperator(parser::BinaryOperator a_op, JaktInternal::Optional<types::OperatorTraitImplementation> a_trait_implementation);
-
-public: ErrorOr<ByteString> debug_description() const;
-};struct StructLikeId {
-u8 __jakt_variant_index = 0;
-union CommonData {
-u8 __jakt_uninit_common;
-struct {
-JaktInternal::Optional<JaktInternal::DynamicArray<ids::TypeId>> generic_arguments;
-} init_common;
-constexpr CommonData() {}
-~CommonData() {}
-} common;
-union VariantData {
-u8 __jakt_uninit_value;
-struct {
-ids::StructId value;
-} Struct;
-struct {
-ids::EnumId value;
-} Enum;
-struct {
-ids::TraitId value;
-} Trait;
-constexpr VariantData() {}
-~VariantData() {}
-} as;
-constexpr u8 __jakt_init_index() const noexcept { return __jakt_variant_index - 1; }ErrorOr<ByteString> debug_description() const;
-[[nodiscard]] static StructLikeId Struct(JaktInternal::Optional<JaktInternal::DynamicArray<ids::TypeId>> generic_arguments, ids::StructId value);
-[[nodiscard]] static StructLikeId Enum(JaktInternal::Optional<JaktInternal::DynamicArray<ids::TypeId>> generic_arguments, ids::EnumId value);
-[[nodiscard]] static StructLikeId Trait(JaktInternal::Optional<JaktInternal::DynamicArray<ids::TypeId>> generic_arguments, ids::TraitId value);
-~StructLikeId();
-StructLikeId& operator=(StructLikeId const &);
-StructLikeId& operator=(StructLikeId &&);
-StructLikeId(StructLikeId const&);
-StructLikeId(StructLikeId &&);
-private: void __jakt_destroy_variant();
-public:
-static ErrorOr<JaktInternal::Optional<types::StructLikeId>> from_type_id(ids::TypeId const type_id, NonnullRefPtr<types::CheckedProgram> const& program);
-ErrorOr<JaktInternal::DynamicArray<ids::TypeId>> generic_parameters(NonnullRefPtr<types::CheckedProgram> const& program) const;
-ErrorOr<ids::ScopeId> associated_scope_id(NonnullRefPtr<types::CheckedProgram> const& program) const;
-ErrorOr<JaktInternal::DynamicArray<types::CheckedGenericParameter>> generic_parameters_as_checked(NonnullRefPtr<types::CheckedProgram> const& program) const;
-ErrorOr<ids::ScopeId> scope_id(NonnullRefPtr<types::CheckedProgram> const& program) const;
-ErrorOr<ids::TypeId> specialized_by(JaktInternal::DynamicArray<ids::TypeId> const arguments, NonnullRefPtr<types::CheckedProgram>& program, ids::ModuleId const module_id, parser::CheckedQualifiers const qualifiers) const;
-private:
-StructLikeId() {};
-};
-class CheckedProgram :public RefCounted<CheckedProgram>, public Weakable<CheckedProgram> {
-  public:
-virtual ~CheckedProgram() = default;
-public: NonnullRefPtr<compiler::Compiler> compiler;public: JaktInternal::DynamicArray<NonnullRefPtr<types::Module>> modules;public: JaktInternal::Dictionary<ByteString,types::LoadedModule> loaded_modules;public: ErrorOr<ids::TypeId> substitute_typevars_in_type(ids::TypeId const type_id, types::GenericInferences const generic_inferences, ids::ModuleId const module_id);
-public: ids::ModuleId prelude_module_id() const;
-public: ErrorOr<JaktInternal::Optional<ids::ScopeId>> find_namespace_in_immediate_children_of_scope(ids::ScopeId const scope_id, ByteString const name, bool const treat_aliases_as_imports) const;
-public: ErrorOr<ids::StructId> find_struct_in_prelude(ByteString const name) const;
-public: ErrorOr<NonnullRefPtr<types::Scope>> get_scope(ids::ScopeId const id) const;
-public: bool is_floating(ids::TypeId const type_id) const;
-public: ErrorOr<JaktInternal::Optional<ids::FunctionId>> find_default_constructors_in_scope(ids::ScopeId const parent_scope_id, ByteString const function_name, JaktInternal::Optional<ids::ScopeId> const root_scope) const;
-public: ErrorOr<JaktInternal::Optional<ids::StructId>> find_struct_in_scope(ids::ScopeId const scope_id, ByteString const name, bool const ignore_mixin_scopes, JaktInternal::Optional<ids::ScopeId> const root_scope) const;
-public: ErrorOr<JaktInternal::Optional<ids::TypeId>> find_type_in_scope(ids::ScopeId const scope_id, ByteString const name, bool const ignore_mixin_scopes, JaktInternal::Optional<ids::ScopeId> const root_scope) const;
-public: ErrorOr<void> set_loaded_module(ByteString const module_name, types::LoadedModule const loaded_module);
-public: ErrorOr<ids::ScopeId> find_type_scope_id(ids::TypeId const type_id);
-public: bool is_integer(ids::TypeId const type_id) const;
-public: ErrorOr<ids::ScopeId> create_scope(JaktInternal::Optional<ids::ScopeId> const parent_scope_id, bool const can_throw, ByteString const debug_name, ids::ModuleId const module_id, bool const for_block);
-public: NonnullRefPtr<types::Module> get_module(ids::ModuleId const id) const;
-public: ErrorOr<ByteString> type_name(ids::TypeId const type_id, bool const debug_mode) const;
-private: ErrorOr<JaktInternal::Optional<bool>> for_each_scope_accessible_unqualified_from_scope_impl(ids::ScopeId const scope_id, Function<ErrorOr<typename utility::IterationDecision<bool>>(ids::ScopeId, JaktInternal::Optional<ByteString>, bool)> const& callback, bool const ignore_mixin_scopes, JaktInternal::Optional<ids::ScopeId> const root_scope) const;
-public: ErrorOr<bool> is_scope_directly_accessible_from(ids::ScopeId const check_scope_id, ids::ScopeId const scope_id, bool const ignore_mixin_scopes) const;
-public: ErrorOr<ByteString> debug_description_of(ids::ScopeId const scope_id) const;
-public: ErrorOr<bool> is_string(ids::TypeId const type_id) const;
-public: ids::ScopeId prelude_scope_id() const;
-public: NonnullRefPtr<types::CheckedTrait> get_trait(ids::TraitId const id) const;
-public: NonnullRefPtr<types::CheckedVariable> get_variable(ids::VarId const id) const;
 public: protected:
-explicit CheckedProgram(NonnullRefPtr<compiler::Compiler> a_compiler, JaktInternal::DynamicArray<NonnullRefPtr<types::Module>> a_modules, JaktInternal::Dictionary<ByteString,types::LoadedModule> a_loaded_modules);
+explicit CheckedVariable(ByteString a_name, ids::TypeId a_type_id, bool a_is_mutable, utility::Span a_definition_span, JaktInternal::Optional<utility::Span> a_type_span, types::CheckedVisibility a_visibility, JaktInternal::Optional<ids::ScopeId> a_owner_scope, JaktInternal::Optional<JaktInternal::Dictionary<ids::TypeId,ids::TypeId>> a_owner_scope_generics, JaktInternal::Optional<parser::ExternalName> a_external_name);
 public:
-static ErrorOr<NonnullRefPtr<CheckedProgram>> __jakt_create(NonnullRefPtr<compiler::Compiler> compiler, JaktInternal::DynamicArray<NonnullRefPtr<types::Module>> modules, JaktInternal::Dictionary<ByteString,types::LoadedModule> loaded_modules);
-
-public: ErrorOr<ids::ModuleId> create_module(ByteString const name, bool const is_root, JaktInternal::Optional<ByteString> const path);
-public: NonnullRefPtr<types::CheckedFunction> get_function(ids::FunctionId const id) const;
-public: ErrorOr<JaktInternal::Optional<JaktInternal::Tuple<ids::TypeId,ids::ScopeId>>> find_type_scope(ids::ScopeId const scope_id, ByteString const name, bool const ignore_mixin_scopes, JaktInternal::Optional<ids::ScopeId> const root_scope) const;
-public: ErrorOr<ids::StructId> builtin_implementation_struct(types::BuiltinType const builtin, ids::ModuleId const for_module);
-public: ErrorOr<JaktInternal::Optional<types::Value>> find_comptime_binding_in_scope(ids::ScopeId const scope_id, ByteString const name, bool const ignore_mixin_scopes, JaktInternal::Optional<ids::ScopeId> const root_scope) const;
-private: ErrorOr<ids::TypeId> substitute_typevars_in_type_helper(ids::TypeId const type_id, types::GenericInferences const generic_inferences, ids::ModuleId const module_id);
-private: ErrorOr<JaktInternal::Optional<bool>> for_each_scope_accessible_unqualified_from_scope_direct_chain(ids::ScopeId const scope_id, Function<ErrorOr<typename utility::IterationDecision<bool>>(ids::ScopeId, JaktInternal::Optional<ByteString>, bool)> const& callback, JaktInternal::Optional<ids::ScopeId> const root_scope) const;
-public: i64 get_bits(ids::TypeId const type_id) const;
-public: NonnullRefPtr<typename types::Type> get_type(ids::TypeId const id) const;
-public: ErrorOr<ids::TypeId> find_or_add_type_id(NonnullRefPtr<typename types::Type> const type, ids::ModuleId const module_id, bool const only_in_current_module);
-public: ErrorOr<JaktInternal::Optional<JaktInternal::Tuple<ids::ScopeId,bool>>> find_namespace_in_scope(ids::ScopeId const scope_id, ByteString const name, bool const treat_aliases_as_imports, bool const ignore_mixin_scopes, JaktInternal::Optional<ids::ScopeId> const root_scope) const;
-public: ErrorOr<void> set_owner_scope_if_needed(ids::ScopeId const parent_scope_id, JaktInternal::DynamicArray<ids::FunctionId> const overload_set, utility::Span const span);
-public: ErrorOr<void> set_owner_scope_if_needed(ids::ScopeId const parent_scope_id, ids::VarId const var_id);
-public: types::CheckedEnum get_enum(ids::EnumId const id) const;
-public: ErrorOr<JaktInternal::Optional<ids::TraitId>> find_trait_in_scope(ids::ScopeId const scope_id, ByteString const name, bool const ignore_mixin_scopes, JaktInternal::Optional<ids::ScopeId> const root_scope) const;
-public: ErrorOr<ids::TypeId> apply_qualifiers_to_type(parser::CheckedQualifiers const qualifiers, ids::TypeId const type_id);
-public: ErrorOr<JaktInternal::Optional<JaktInternal::DynamicArray<ids::FunctionId>>> find_functions_with_name_in_scope(ids::ScopeId const parent_scope_id, ByteString const function_name, bool const ignore_mixin_scopes, JaktInternal::Optional<ids::ScopeId> const root_scope) const;
-public: ErrorOr<JaktInternal::Optional<NonnullRefPtr<types::CheckedVariable>>> find_var_in_scope(ids::ScopeId const scope_id, ByteString const var, bool const ignore_mixin_scopes, JaktInternal::Optional<ids::ScopeId> const root_scope) const;
-public: ErrorOr<JaktInternal::Optional<ids::FunctionId>> find_function_in_scope(ids::ScopeId const parent_scope_id, ByteString const function_name, JaktInternal::Optional<ids::ScopeId> const root_scope) const;
-public: types::CheckedStruct get_struct(ids::StructId const id) const;
-public: ErrorOr<JaktInternal::Optional<ids::StructId>> check_and_extract_weak_ptr(ids::StructId const struct_id, JaktInternal::DynamicArray<ids::TypeId> const args) const;
-public: ErrorOr<JaktInternal::Optional<ids::EnumId>> find_enum_in_scope(ids::ScopeId const scope_id, ByteString const name, bool const ignore_mixin_scopes, JaktInternal::Optional<ids::ScopeId> const root_scope) const;
-public: JaktInternal::Optional<types::LoadedModule> get_loaded_module(ByteString const module_name) const;
-public: ErrorOr<JaktInternal::Optional<JaktInternal::Tuple<JaktInternal::DynamicArray<ids::FunctionId>,ids::ScopeId>>> find_scoped_functions_with_name_in_scope(ids::ScopeId const parent_scope_id, ByteString const function_name, bool const ignore_mixin_scopes, JaktInternal::Optional<ids::ScopeId> const root_scope) const;
-public: bool is_signed(ids::TypeId const type_id) const;
-public: bool is_numeric(ids::TypeId const type_id) const;
-public: template <typename T>
-ErrorOr<JaktInternal::Optional<T>> for_each_scope_accessible_unqualified_from_scope(ids::ScopeId const scope_id, Function<ErrorOr<typename utility::IterationDecision<T>>(ids::ScopeId, JaktInternal::Optional<ByteString>, bool)> const& callback, bool const ignore_mixin_scopes, JaktInternal::Optional<ids::ScopeId> const root_scope) const;
-public: public: public: public: public: public: public: public: public: public: ErrorOr<types::StructOrEnumId> find_reflected_primitive(ByteString const primitive) const;
-public: ErrorOr<ByteString> debug_description() const;
-};struct CheckedField {
-  public:
-public: ids::VarId variable_id;public: JaktInternal::Optional<JaktInternal::Tuple<NonnullRefPtr<typename parser::ParsedExpression>,ids::ScopeId>> default_value_expression;public: CheckedField(ids::VarId a_variable_id, JaktInternal::Optional<JaktInternal::Tuple<NonnullRefPtr<typename parser::ParsedExpression>,ids::ScopeId>> a_default_value_expression);
+static ErrorOr<NonnullRefPtr<CheckedVariable>> __jakt_create(ByteString name, ids::TypeId type_id, bool is_mutable, utility::Span definition_span, JaktInternal::Optional<utility::Span> type_span, types::CheckedVisibility visibility, JaktInternal::Optional<ids::ScopeId> owner_scope, JaktInternal::Optional<JaktInternal::Dictionary<ids::TypeId,ids::TypeId>> owner_scope_generics, JaktInternal::Optional<parser::ExternalName> external_name);
 
 public: ErrorOr<ByteString> debug_description() const;
-};struct CheckedEnumVariant {
-u8 __jakt_variant_index = 0;
-union VariantData {
-u8 __jakt_uninit_value;
-struct {
-ids::EnumId enum_id;
-ByteString name;
-utility::Span span;
-} Untyped;
-struct {
-ids::EnumId enum_id;
-ByteString name;
-ids::TypeId type_id;
-utility::Span span;
-} Typed;
-struct {
-ids::EnumId enum_id;
-ByteString name;
-NonnullRefPtr<typename types::CheckedExpression> expr;
-utility::Span span;
-} WithValue;
-struct {
-ids::EnumId enum_id;
-ByteString name;
-JaktInternal::DynamicArray<ids::VarId> fields;
-utility::Span span;
-} StructLike;
-constexpr VariantData() {}
-~VariantData() {}
-} as;
-constexpr u8 __jakt_init_index() const noexcept { return __jakt_variant_index - 1; }ErrorOr<ByteString> debug_description() const;
-[[nodiscard]] static CheckedEnumVariant Untyped(ids::EnumId enum_id, ByteString name, utility::Span span);
-[[nodiscard]] static CheckedEnumVariant Typed(ids::EnumId enum_id, ByteString name, ids::TypeId type_id, utility::Span span);
-[[nodiscard]] static CheckedEnumVariant WithValue(ids::EnumId enum_id, ByteString name, NonnullRefPtr<typename types::CheckedExpression> expr, utility::Span span);
-[[nodiscard]] static CheckedEnumVariant StructLike(ids::EnumId enum_id, ByteString name, JaktInternal::DynamicArray<ids::VarId> fields, utility::Span span);
-~CheckedEnumVariant();
-CheckedEnumVariant& operator=(CheckedEnumVariant const &);
-CheckedEnumVariant& operator=(CheckedEnumVariant &&);
-CheckedEnumVariant(CheckedEnumVariant const&);
-CheckedEnumVariant(CheckedEnumVariant &&);
-private: void __jakt_destroy_variant();
-public:
-ids::EnumId enum_id() const;
-ByteString name() const;
-bool equals(types::CheckedEnumVariant const other) const;
-utility::Span span() const;
-private:
-CheckedEnumVariant() {};
-};
-struct CheckedTypeCast {
-u8 __jakt_variant_index = 0;
-union VariantData {
-u8 __jakt_uninit_value;
-struct {
-ids::TypeId value;
-} Fallible;
-struct {
-ids::TypeId value;
-} Infallible;
-constexpr VariantData() {}
-~VariantData() {}
-} as;
-constexpr u8 __jakt_init_index() const noexcept { return __jakt_variant_index - 1; }ErrorOr<ByteString> debug_description() const;
-[[nodiscard]] static CheckedTypeCast Fallible(ids::TypeId value);
-[[nodiscard]] static CheckedTypeCast Infallible(ids::TypeId value);
-~CheckedTypeCast();
-CheckedTypeCast& operator=(CheckedTypeCast const &);
-CheckedTypeCast& operator=(CheckedTypeCast &&);
-CheckedTypeCast(CheckedTypeCast const&);
-CheckedTypeCast(CheckedTypeCast &&);
-private: void __jakt_destroy_variant();
-public:
-ids::TypeId type_id() const;
-private:
-CheckedTypeCast() {};
-};
-struct CheckedUnaryOperator {
-u8 __jakt_variant_index = 0;
-union VariantData {
-u8 __jakt_uninit_value;
-struct {
-types::CheckedTypeCast value;
-} TypeCast;
-struct {
-ids::TypeId value;
-} Is;
-struct {
-types::CheckedEnumVariant enum_variant;
-JaktInternal::DynamicArray<types::CheckedEnumVariantBinding> bindings;
-ids::TypeId type_id;
-} IsEnumVariant;
-struct {
-ids::TypeId value;
-} Sizeof;
-constexpr VariantData() {}
-~VariantData() {}
-} as;
-constexpr u8 __jakt_init_index() const noexcept { return __jakt_variant_index - 1; }ErrorOr<ByteString> debug_description() const;
-[[nodiscard]] static CheckedUnaryOperator PreIncrement();
-[[nodiscard]] static CheckedUnaryOperator PostIncrement();
-[[nodiscard]] static CheckedUnaryOperator PreDecrement();
-[[nodiscard]] static CheckedUnaryOperator PostDecrement();
-[[nodiscard]] static CheckedUnaryOperator Negate();
-[[nodiscard]] static CheckedUnaryOperator Dereference();
-[[nodiscard]] static CheckedUnaryOperator RawAddress();
-[[nodiscard]] static CheckedUnaryOperator Reference();
-[[nodiscard]] static CheckedUnaryOperator MutableReference();
-[[nodiscard]] static CheckedUnaryOperator LogicalNot();
-[[nodiscard]] static CheckedUnaryOperator BitwiseNot();
-[[nodiscard]] static CheckedUnaryOperator TypeCast(types::CheckedTypeCast value);
-[[nodiscard]] static CheckedUnaryOperator Is(ids::TypeId value);
-[[nodiscard]] static CheckedUnaryOperator IsEnumVariant(types::CheckedEnumVariant enum_variant, JaktInternal::DynamicArray<types::CheckedEnumVariantBinding> bindings, ids::TypeId type_id);
-[[nodiscard]] static CheckedUnaryOperator IsSome();
-[[nodiscard]] static CheckedUnaryOperator IsNone();
-[[nodiscard]] static CheckedUnaryOperator Sizeof(ids::TypeId value);
-~CheckedUnaryOperator();
-CheckedUnaryOperator& operator=(CheckedUnaryOperator const &);
-CheckedUnaryOperator& operator=(CheckedUnaryOperator &&);
-CheckedUnaryOperator(CheckedUnaryOperator const&);
-CheckedUnaryOperator(CheckedUnaryOperator &&);
-private: void __jakt_destroy_variant();
-public:
-private:
-CheckedUnaryOperator() {};
-};
-struct FunctionGenericParameterKind {
-u8 __jakt_variant_index = 0;
-union VariantData {
-u8 __jakt_uninit_value;
-constexpr VariantData() {}
-~VariantData() {}
-} as;
-constexpr u8 __jakt_init_index() const noexcept { return __jakt_variant_index - 1; }ErrorOr<ByteString> debug_description() const;
-[[nodiscard]] static FunctionGenericParameterKind InferenceGuide();
-[[nodiscard]] static FunctionGenericParameterKind Parameter();
-~FunctionGenericParameterKind();
-FunctionGenericParameterKind& operator=(FunctionGenericParameterKind const &);
-FunctionGenericParameterKind& operator=(FunctionGenericParameterKind &&);
-FunctionGenericParameterKind(FunctionGenericParameterKind const&);
-FunctionGenericParameterKind(FunctionGenericParameterKind &&);
-private: void __jakt_destroy_variant();
-public:
-private:
-FunctionGenericParameterKind() {};
-};
-struct LoadedModule {
+};struct CheckedParameter {
   public:
-public: ids::ModuleId module_id;public: utility::FileId file_id;public: LoadedModule(ids::ModuleId a_module_id, utility::FileId a_file_id);
+public: bool requires_label;public: NonnullRefPtr<types::CheckedVariable> variable;public: JaktInternal::Optional<JaktInternal::Tuple<NonnullRefPtr<typename parser::ParsedExpression>,ids::ScopeId>> default_value_expression;public: ErrorOr<types::CheckedParameter> map_types(Function<ErrorOr<ids::TypeId>(ids::TypeId)> const& map) const;
+public: CheckedParameter(bool a_requires_label, NonnullRefPtr<types::CheckedVariable> a_variable, JaktInternal::Optional<JaktInternal::Tuple<NonnullRefPtr<typename parser::ParsedExpression>,ids::ScopeId>> a_default_value_expression);
 
-public: ErrorOr<ByteString> debug_description() const;
-};struct CheckedGenericParameter {
-  public:
-public: ids::TypeId type_id;public: JaktInternal::DynamicArray<ids::TraitId> constraints;public: utility::Span span;public: static ErrorOr<types::CheckedGenericParameter> make(ids::TypeId const type_id, utility::Span const span);
-public: CheckedGenericParameter(ids::TypeId a_type_id, JaktInternal::DynamicArray<ids::TraitId> a_constraints, utility::Span a_span);
-
-public: ErrorOr<ByteString> debug_description() const;
-};struct ResolvedForallChunk {
-  public:
-public: JaktInternal::Dictionary<ByteString,JaktInternal::DynamicArray<JaktInternal::Tuple<utility::Span,ids::TypeId>>> parameters;public: parser::ParsedNamespace parsed_namespace;public: JaktInternal::DynamicArray<ids::ScopeId> generated_scopes;public: ResolvedForallChunk(JaktInternal::Dictionary<ByteString,JaktInternal::DynamicArray<JaktInternal::Tuple<utility::Span,ids::TypeId>>> a_parameters, parser::ParsedNamespace a_parsed_namespace, JaktInternal::DynamicArray<ids::ScopeId> a_generated_scopes);
-
-public: ErrorOr<ByteString> debug_description() const;
-};struct Value {
-  public:
-public: NonnullRefPtr<typename types::ValueImpl> impl;public: utility::Span span;public: ErrorOr<types::Value> copy() const;
-public: ErrorOr<ByteString> type_name() const;
-public: Value(NonnullRefPtr<typename types::ValueImpl> a_impl, utility::Span a_span);
-
-public: ErrorOr<types::Value> cast(types::Value const expected, utility::Span const span) const;
 public: ErrorOr<ByteString> debug_description() const;
 };struct FieldRecord {
   public:
 public: ids::StructId struct_id;public: ids::VarId field_id;public: FieldRecord(ids::StructId a_struct_id, ids::VarId a_field_id);
 
+public: ErrorOr<ByteString> debug_description() const;
+};class CheckedFunction :public RefCounted<CheckedFunction>, public Weakable<CheckedFunction> {
+  public:
+virtual ~CheckedFunction() = default;
+public: ByteString name;public: utility::Span name_span;public: types::CheckedVisibility visibility;public: ids::TypeId return_type_id;public: JaktInternal::Optional<utility::Span> return_type_span;public: JaktInternal::DynamicArray<types::CheckedParameter> params;public: NonnullRefPtr<types::FunctionGenerics> generics;public: types::CheckedBlock block;public: bool can_throw;public: parser::FunctionType type;public: parser::FunctionLinkage linkage;public: ids::ScopeId function_scope_id;public: JaktInternal::Optional<ids::StructId> struct_id;public: bool is_instantiated;public: JaktInternal::Optional<parser::ParsedFunction> parsed_function;public: bool is_comptime;public: bool is_virtual;public: bool is_override;public: bool is_unsafe;public: bool has_varargs;public: JaktInternal::Optional<size_t> specialization_index;public: JaktInternal::Optional<ids::ScopeId> owner_scope;public: JaktInternal::Optional<JaktInternal::Dictionary<ids::TypeId,ids::TypeId>> owner_scope_generics;public: bool is_fully_checked;public: JaktInternal::Optional<parser::ExternalName> external_name;public: JaktInternal::Optional<ByteString> deprecated_message;public: JaktInternal::Optional<JaktInternal::DynamicArray<JaktInternal::Tuple<size_t,parser::ArgumentStoreLevel>>> stores_arguments;public: parser::InlineState force_inline;public: ErrorOr<void> map_types(Function<ErrorOr<ids::TypeId>(ids::TypeId)> const& map);
+public: ErrorOr<bool> is_static() const;
+public: ErrorOr<bool> is_mutating() const;
+public: protected:
+explicit CheckedFunction(ByteString a_name, utility::Span a_name_span, types::CheckedVisibility a_visibility, ids::TypeId a_return_type_id, JaktInternal::Optional<utility::Span> a_return_type_span, JaktInternal::DynamicArray<types::CheckedParameter> a_params, NonnullRefPtr<types::FunctionGenerics> a_generics, types::CheckedBlock a_block, bool a_can_throw, parser::FunctionType a_type, parser::FunctionLinkage a_linkage, ids::ScopeId a_function_scope_id, JaktInternal::Optional<ids::StructId> a_struct_id, bool a_is_instantiated, JaktInternal::Optional<parser::ParsedFunction> a_parsed_function, bool a_is_comptime, bool a_is_virtual, bool a_is_override, bool a_is_unsafe, bool a_has_varargs, JaktInternal::Optional<size_t> a_specialization_index, JaktInternal::Optional<ids::ScopeId> a_owner_scope, JaktInternal::Optional<JaktInternal::Dictionary<ids::TypeId,ids::TypeId>> a_owner_scope_generics, bool a_is_fully_checked, JaktInternal::Optional<parser::ExternalName> a_external_name, JaktInternal::Optional<ByteString> a_deprecated_message, JaktInternal::Optional<JaktInternal::DynamicArray<JaktInternal::Tuple<size_t,parser::ArgumentStoreLevel>>> a_stores_arguments, parser::InlineState a_force_inline);
+public:
+static ErrorOr<NonnullRefPtr<CheckedFunction>> __jakt_create(ByteString name, utility::Span name_span, types::CheckedVisibility visibility, ids::TypeId return_type_id, JaktInternal::Optional<utility::Span> return_type_span, JaktInternal::DynamicArray<types::CheckedParameter> params, NonnullRefPtr<types::FunctionGenerics> generics, types::CheckedBlock block, bool can_throw, parser::FunctionType type, parser::FunctionLinkage linkage, ids::ScopeId function_scope_id, JaktInternal::Optional<ids::StructId> struct_id, bool is_instantiated, JaktInternal::Optional<parser::ParsedFunction> parsed_function, bool is_comptime, bool is_virtual, bool is_override, bool is_unsafe, bool has_varargs, JaktInternal::Optional<size_t> specialization_index, JaktInternal::Optional<ids::ScopeId> owner_scope, JaktInternal::Optional<JaktInternal::Dictionary<ids::TypeId,ids::TypeId>> owner_scope_generics, bool is_fully_checked, JaktInternal::Optional<parser::ExternalName> external_name, JaktInternal::Optional<ByteString> deprecated_message, JaktInternal::Optional<JaktInternal::DynamicArray<JaktInternal::Tuple<size_t,parser::ArgumentStoreLevel>>> stores_arguments, parser::InlineState force_inline);
+
+public: ErrorOr<parser::ParsedFunction> to_parsed_function() const;
+public: bool is_specialized_for_types(JaktInternal::DynamicArray<ids::TypeId> const types) const;
+public: ErrorOr<NonnullRefPtr<types::CheckedFunction>> copy() const;
+public: ErrorOr<bool> signature_matches(NonnullRefPtr<types::CheckedFunction> const other, bool const ignore_this) const;
+public: parser::ExternalName name_for_codegen() const;
+public: ErrorOr<void> add_param(types::CheckedParameter const checked_param);
+public: ErrorOr<void> set_params(JaktInternal::DynamicArray<types::CheckedParameter> const checked_params);
+public: ErrorOr<ByteString> debug_description() const;
+};struct CheckedEnum {
+  public:
+public: ByteString name;public: utility::Span name_span;public: JaktInternal::DynamicArray<types::CheckedGenericParameter> generic_parameters;public: JaktInternal::DynamicArray<types::CheckedEnumVariant> variants;public: JaktInternal::DynamicArray<types::CheckedField> fields;public: ids::ScopeId scope_id;public: parser::DefinitionLinkage definition_linkage;public: JaktInternal::Dictionary<ByteString,JaktInternal::DynamicArray<JaktInternal::Tuple<ids::TraitId,JaktInternal::DynamicArray<ids::TypeId>>>> trait_implementations;public: parser::RecordType record_type;public: ids::TypeId underlying_type_id;public: ids::TypeId type_id;public: bool is_boxed;public: CheckedEnum(ByteString a_name, utility::Span a_name_span, JaktInternal::DynamicArray<types::CheckedGenericParameter> a_generic_parameters, JaktInternal::DynamicArray<types::CheckedEnumVariant> a_variants, JaktInternal::DynamicArray<types::CheckedField> a_fields, ids::ScopeId a_scope_id, parser::DefinitionLinkage a_definition_linkage, JaktInternal::Dictionary<ByteString,JaktInternal::DynamicArray<JaktInternal::Tuple<ids::TraitId,JaktInternal::DynamicArray<ids::TypeId>>>> a_trait_implementations, parser::RecordType a_record_type, ids::TypeId a_underlying_type_id, ids::TypeId a_type_id, bool a_is_boxed);
+
+public: ErrorOr<ByteString> debug_description() const;
+};struct StringLiteral {
+u8 __jakt_variant_index = 0;
+union VariantData {
+u8 __jakt_uninit_value;
+struct {
+ByteString value;
+} Static;
+constexpr VariantData() {}
+~VariantData() {}
+} as;
+constexpr u8 __jakt_init_index() const noexcept { return __jakt_variant_index - 1; }ErrorOr<ByteString> debug_description() const;
+[[nodiscard]] static StringLiteral Static(ByteString value);
+~StringLiteral();
+StringLiteral& operator=(StringLiteral const &);
+StringLiteral& operator=(StringLiteral &&);
+StringLiteral(StringLiteral const&);
+StringLiteral(StringLiteral &&);
+private: void __jakt_destroy_variant();
+public:
+ByteString to_string() const;
+private:
+StringLiteral() {};
+};
+struct CheckedStringLiteral {
+  public:
+public: types::StringLiteral value;public: ids::TypeId type_id;public: bool may_throw;public: ByteString to_string() const;
+public: CheckedStringLiteral(types::StringLiteral a_value, ids::TypeId a_type_id, bool a_may_throw);
+
+public: ErrorOr<ByteString> debug_description() const;
+};struct ResolvedNamespace {
+  public:
+public: ByteString name;public: JaktInternal::Optional<parser::ExternalName> external_name;public: JaktInternal::Optional<JaktInternal::DynamicArray<ids::TypeId>> generic_parameters;public: ResolvedNamespace(ByteString a_name, JaktInternal::Optional<parser::ExternalName> a_external_name, JaktInternal::Optional<JaktInternal::DynamicArray<ids::TypeId>> a_generic_parameters);
+
+public: parser::ExternalName name_for_codegen() const;
 public: ErrorOr<ByteString> debug_description() const;
 };struct Type: public RefCounted<Type> {
 u8 __jakt_variant_index = 0;
@@ -644,189 +807,23 @@ bool is_signed() const;
 private:
 Type() {};
 };
-class Scope :public RefCounted<Scope>, public Weakable<Scope> {
+struct CheckedStruct {
   public:
-virtual ~Scope() = default;
-public: JaktInternal::Optional<ByteString> namespace_name;public: JaktInternal::Optional<parser::ExternalName> external_name;public: JaktInternal::Dictionary<ByteString,ids::VarId> vars;public: JaktInternal::Dictionary<ByteString,types::Value> comptime_bindings;public: JaktInternal::Dictionary<ByteString,ids::StructId> structs;public: JaktInternal::Dictionary<ByteString,JaktInternal::DynamicArray<ids::FunctionId>> functions;public: JaktInternal::Dictionary<ByteString,ids::EnumId> enums;public: JaktInternal::Dictionary<ByteString,ids::TypeId> types;public: JaktInternal::Dictionary<ByteString,ids::TraitId> traits;public: JaktInternal::Dictionary<ByteString,ids::ModuleId> imports;public: JaktInternal::Dictionary<ByteString,ids::ScopeId> aliases;public: JaktInternal::Optional<ids::ScopeId> parent;public: JaktInternal::Optional<ids::ScopeId> alias_scope;public: JaktInternal::DynamicArray<ids::ScopeId> children;public: bool can_throw;public: JaktInternal::Optional<ByteString> import_path_if_extern;public: JaktInternal::Optional<JaktInternal::DynamicArray<types::ResolvedNamespace>> alias_path;public: JaktInternal::DynamicArray<parser::IncludeAction> after_extern_include;public: JaktInternal::DynamicArray<parser::IncludeAction> before_extern_include;public: ByteString debug_name;public: JaktInternal::DynamicArray<ids::ScopeId> resolution_mixins;public: JaktInternal::Optional<ids::TypeId> relevant_type_id;public: bool is_block_scope;public: JaktInternal::Optional<JaktInternal::DynamicArray<types::ResolvedForallChunk>> resolved_forall_chunks;public: JaktInternal::Dictionary<ByteString,types::SpecializedType> explicitly_specialized_types;public: bool is_from_generated_code;public: protected:
-explicit Scope(JaktInternal::Optional<ByteString> a_namespace_name, JaktInternal::Optional<parser::ExternalName> a_external_name, JaktInternal::Dictionary<ByteString,ids::VarId> a_vars, JaktInternal::Dictionary<ByteString,types::Value> a_comptime_bindings, JaktInternal::Dictionary<ByteString,ids::StructId> a_structs, JaktInternal::Dictionary<ByteString,JaktInternal::DynamicArray<ids::FunctionId>> a_functions, JaktInternal::Dictionary<ByteString,ids::EnumId> a_enums, JaktInternal::Dictionary<ByteString,ids::TypeId> a_types, JaktInternal::Dictionary<ByteString,ids::TraitId> a_traits, JaktInternal::Dictionary<ByteString,ids::ModuleId> a_imports, JaktInternal::Dictionary<ByteString,ids::ScopeId> a_aliases, JaktInternal::Optional<ids::ScopeId> a_parent, JaktInternal::Optional<ids::ScopeId> a_alias_scope, JaktInternal::DynamicArray<ids::ScopeId> a_children, bool a_can_throw, JaktInternal::Optional<ByteString> a_import_path_if_extern, JaktInternal::Optional<JaktInternal::DynamicArray<types::ResolvedNamespace>> a_alias_path, JaktInternal::DynamicArray<parser::IncludeAction> a_after_extern_include, JaktInternal::DynamicArray<parser::IncludeAction> a_before_extern_include, ByteString a_debug_name, JaktInternal::DynamicArray<ids::ScopeId> a_resolution_mixins, JaktInternal::Optional<ids::TypeId> a_relevant_type_id, bool a_is_block_scope, JaktInternal::Optional<JaktInternal::DynamicArray<types::ResolvedForallChunk>> a_resolved_forall_chunks, JaktInternal::Dictionary<ByteString,types::SpecializedType> a_explicitly_specialized_types, bool a_is_from_generated_code);
-public:
-static ErrorOr<NonnullRefPtr<Scope>> __jakt_create(JaktInternal::Optional<ByteString> namespace_name, JaktInternal::Optional<parser::ExternalName> external_name, JaktInternal::Dictionary<ByteString,ids::VarId> vars, JaktInternal::Dictionary<ByteString,types::Value> comptime_bindings, JaktInternal::Dictionary<ByteString,ids::StructId> structs, JaktInternal::Dictionary<ByteString,JaktInternal::DynamicArray<ids::FunctionId>> functions, JaktInternal::Dictionary<ByteString,ids::EnumId> enums, JaktInternal::Dictionary<ByteString,ids::TypeId> types, JaktInternal::Dictionary<ByteString,ids::TraitId> traits, JaktInternal::Dictionary<ByteString,ids::ModuleId> imports, JaktInternal::Dictionary<ByteString,ids::ScopeId> aliases, JaktInternal::Optional<ids::ScopeId> parent, JaktInternal::Optional<ids::ScopeId> alias_scope, JaktInternal::DynamicArray<ids::ScopeId> children, bool can_throw, JaktInternal::Optional<ByteString> import_path_if_extern, JaktInternal::Optional<JaktInternal::DynamicArray<types::ResolvedNamespace>> alias_path, JaktInternal::DynamicArray<parser::IncludeAction> after_extern_include, JaktInternal::DynamicArray<parser::IncludeAction> before_extern_include, ByteString debug_name, JaktInternal::DynamicArray<ids::ScopeId> resolution_mixins, JaktInternal::Optional<ids::TypeId> relevant_type_id, bool is_block_scope, JaktInternal::Optional<JaktInternal::DynamicArray<types::ResolvedForallChunk>> resolved_forall_chunks, JaktInternal::Dictionary<ByteString,types::SpecializedType> explicitly_specialized_types, bool is_from_generated_code);
+public: ByteString name;public: utility::Span name_span;public: JaktInternal::DynamicArray<types::CheckedGenericParameter> generic_parameters;public: JaktInternal::Optional<JaktInternal::DynamicArray<JaktInternal::Optional<ids::TypeId>>> generic_parameter_defaults;public: JaktInternal::DynamicArray<types::CheckedField> fields;public: ids::ScopeId scope_id;public: parser::DefinitionLinkage definition_linkage;public: JaktInternal::Dictionary<ByteString,JaktInternal::DynamicArray<JaktInternal::Tuple<ids::TraitId,JaktInternal::DynamicArray<ids::TypeId>>>> trait_implementations;public: parser::RecordType record_type;public: ids::TypeId type_id;public: JaktInternal::Optional<ids::StructId> super_struct_id;public: JaktInternal::Optional<parser::ExternalName> external_name;public: JaktInternal::Optional<ids::TypeId> implements_type;public: CheckedStruct(ByteString a_name, utility::Span a_name_span, JaktInternal::DynamicArray<types::CheckedGenericParameter> a_generic_parameters, JaktInternal::Optional<JaktInternal::DynamicArray<JaktInternal::Optional<ids::TypeId>>> a_generic_parameter_defaults, JaktInternal::DynamicArray<types::CheckedField> a_fields, ids::ScopeId a_scope_id, parser::DefinitionLinkage a_definition_linkage, JaktInternal::Dictionary<ByteString,JaktInternal::DynamicArray<JaktInternal::Tuple<ids::TraitId,JaktInternal::DynamicArray<ids::TypeId>>>> a_trait_implementations, parser::RecordType a_record_type, ids::TypeId a_type_id, JaktInternal::Optional<ids::StructId> a_super_struct_id, JaktInternal::Optional<parser::ExternalName> a_external_name, JaktInternal::Optional<ids::TypeId> a_implements_type);
 
-public: JaktInternal::Optional<parser::ExternalName> namespace_name_for_codegen() const;
+public: parser::ExternalName name_for_codegen() const;
 public: ErrorOr<ByteString> debug_description() const;
-};struct ValueImpl: public RefCounted<ValueImpl> {
-u8 __jakt_variant_index = 0;
-union VariantData {
-u8 __jakt_uninit_value;
-struct {
-bool value;
-} Bool;
-struct {
-u8 value;
-} U8;
-struct {
-u16 value;
-} U16;
-struct {
-u32 value;
-} U32;
-struct {
-u64 value;
-} U64;
-struct {
-i8 value;
-} I8;
-struct {
-i16 value;
-} I16;
-struct {
-i32 value;
-} I32;
-struct {
-i64 value;
-} I64;
-struct {
-f32 value;
-} F32;
-struct {
-f64 value;
-} F64;
-struct {
-size_t value;
-} USize;
-struct {
-ByteString value;
-} JaktString;
-struct {
-ByteString value;
-} StringView;
-struct {
-char value;
-} CChar;
-struct {
-int value;
-} CInt;
-struct {
-JaktInternal::DynamicArray<types::Value> fields;
-ids::StructId struct_id;
-JaktInternal::Optional<ids::FunctionId> constructor;
-} Struct;
-struct {
-JaktInternal::DynamicArray<types::Value> fields;
-ids::StructId struct_id;
-JaktInternal::Optional<ids::FunctionId> constructor;
-} Class;
-struct {
-JaktInternal::DynamicArray<types::Value> fields;
-ids::EnumId enum_id;
-ids::FunctionId constructor;
-} Enum;
-struct {
-JaktInternal::DynamicArray<types::Value> values;
-ids::TypeId type_id;
-} JaktArray;
-struct {
-JaktInternal::DynamicArray<types::Value> keys;
-JaktInternal::DynamicArray<types::Value> values;
-ids::TypeId type_id;
-} JaktDictionary;
-struct {
-JaktInternal::DynamicArray<types::Value> values;
-ids::TypeId type_id;
-} JaktSet;
-struct {
-NonnullRefPtr<typename types::ValueImpl> value;
-} RawPtr;
-struct {
-types::Value value;
-} OptionalSome;
-struct {
-JaktInternal::DynamicArray<types::Value> fields;
-ids::TypeId type_id;
-} JaktTuple;
-struct {
-JaktInternal::Dictionary<ByteString,types::Value> captures;
-JaktInternal::Dictionary<ByteString,JaktInternal::Tuple<ids::TypeId,JaktInternal::Optional<JaktInternal::Tuple<NonnullRefPtr<typename parser::ParsedExpression>,ids::ScopeId>>>> params;
-ids::TypeId return_type_id;
-ids::TypeId type_id;
-types::CheckedBlock block;
-bool can_throw;
-JaktInternal::DynamicArray<types::CheckedParameter> checked_params;
-ids::ScopeId scope_id;
-JaktInternal::Optional<ids::FunctionId> pseudo_function_id;
-} Function;
-constexpr VariantData() {}
-~VariantData() {}
-} as;
-constexpr u8 __jakt_init_index() const noexcept { return __jakt_variant_index - 1; }ErrorOr<ByteString> debug_description() const;
-[[nodiscard]] static ErrorOr<NonnullRefPtr<ValueImpl>> Void();
-[[nodiscard]] static ErrorOr<NonnullRefPtr<ValueImpl>> Bool(bool value);
-[[nodiscard]] static ErrorOr<NonnullRefPtr<ValueImpl>> U8(u8 value);
-[[nodiscard]] static ErrorOr<NonnullRefPtr<ValueImpl>> U16(u16 value);
-[[nodiscard]] static ErrorOr<NonnullRefPtr<ValueImpl>> U32(u32 value);
-[[nodiscard]] static ErrorOr<NonnullRefPtr<ValueImpl>> U64(u64 value);
-[[nodiscard]] static ErrorOr<NonnullRefPtr<ValueImpl>> I8(i8 value);
-[[nodiscard]] static ErrorOr<NonnullRefPtr<ValueImpl>> I16(i16 value);
-[[nodiscard]] static ErrorOr<NonnullRefPtr<ValueImpl>> I32(i32 value);
-[[nodiscard]] static ErrorOr<NonnullRefPtr<ValueImpl>> I64(i64 value);
-[[nodiscard]] static ErrorOr<NonnullRefPtr<ValueImpl>> F32(f32 value);
-[[nodiscard]] static ErrorOr<NonnullRefPtr<ValueImpl>> F64(f64 value);
-[[nodiscard]] static ErrorOr<NonnullRefPtr<ValueImpl>> USize(size_t value);
-[[nodiscard]] static ErrorOr<NonnullRefPtr<ValueImpl>> JaktString(ByteString value);
-[[nodiscard]] static ErrorOr<NonnullRefPtr<ValueImpl>> StringView(ByteString value);
-[[nodiscard]] static ErrorOr<NonnullRefPtr<ValueImpl>> CChar(char value);
-[[nodiscard]] static ErrorOr<NonnullRefPtr<ValueImpl>> CInt(int value);
-[[nodiscard]] static ErrorOr<NonnullRefPtr<ValueImpl>> Struct(JaktInternal::DynamicArray<types::Value> fields, ids::StructId struct_id, JaktInternal::Optional<ids::FunctionId> constructor);
-[[nodiscard]] static ErrorOr<NonnullRefPtr<ValueImpl>> Class(JaktInternal::DynamicArray<types::Value> fields, ids::StructId struct_id, JaktInternal::Optional<ids::FunctionId> constructor);
-[[nodiscard]] static ErrorOr<NonnullRefPtr<ValueImpl>> Enum(JaktInternal::DynamicArray<types::Value> fields, ids::EnumId enum_id, ids::FunctionId constructor);
-[[nodiscard]] static ErrorOr<NonnullRefPtr<ValueImpl>> JaktArray(JaktInternal::DynamicArray<types::Value> values, ids::TypeId type_id);
-[[nodiscard]] static ErrorOr<NonnullRefPtr<ValueImpl>> JaktDictionary(JaktInternal::DynamicArray<types::Value> keys, JaktInternal::DynamicArray<types::Value> values, ids::TypeId type_id);
-[[nodiscard]] static ErrorOr<NonnullRefPtr<ValueImpl>> JaktSet(JaktInternal::DynamicArray<types::Value> values, ids::TypeId type_id);
-[[nodiscard]] static ErrorOr<NonnullRefPtr<ValueImpl>> RawPtr(NonnullRefPtr<typename types::ValueImpl> value);
-[[nodiscard]] static ErrorOr<NonnullRefPtr<ValueImpl>> OptionalSome(types::Value value);
-[[nodiscard]] static ErrorOr<NonnullRefPtr<ValueImpl>> OptionalNone();
-[[nodiscard]] static ErrorOr<NonnullRefPtr<ValueImpl>> JaktTuple(JaktInternal::DynamicArray<types::Value> fields, ids::TypeId type_id);
-[[nodiscard]] static ErrorOr<NonnullRefPtr<ValueImpl>> Function(JaktInternal::Dictionary<ByteString,types::Value> captures, JaktInternal::Dictionary<ByteString,JaktInternal::Tuple<ids::TypeId,JaktInternal::Optional<JaktInternal::Tuple<NonnullRefPtr<typename parser::ParsedExpression>,ids::ScopeId>>>> params, ids::TypeId return_type_id, ids::TypeId type_id, types::CheckedBlock block, bool can_throw, JaktInternal::DynamicArray<types::CheckedParameter> checked_params, ids::ScopeId scope_id, JaktInternal::Optional<ids::FunctionId> pseudo_function_id);
-~ValueImpl();
-ValueImpl& operator=(ValueImpl const &);
-ValueImpl& operator=(ValueImpl &&);
-ValueImpl(ValueImpl const&);
-ValueImpl(ValueImpl &&);
-private: void __jakt_destroy_variant();
-public:
-bool equals(NonnullRefPtr<typename types::ValueImpl> const other) const;
-ErrorOr<ids::TypeId> type_id(NonnullRefPtr<types::CheckedProgram>& program) const;
-ErrorOr<NonnullRefPtr<typename types::ValueImpl>> copy() const;
-private:
-ValueImpl() {};
-};
-struct StructOrEnumId {
-u8 __jakt_variant_index = 0;
-union VariantData {
-u8 __jakt_uninit_value;
-struct {
-ids::StructId value;
-} Struct;
-struct {
-ids::EnumId value;
-} Enum;
-constexpr VariantData() {}
-~VariantData() {}
-} as;
-constexpr u8 __jakt_init_index() const noexcept { return __jakt_variant_index - 1; }ErrorOr<ByteString> debug_description() const;
-[[nodiscard]] static StructOrEnumId Struct(ids::StructId value);
-[[nodiscard]] static StructOrEnumId Enum(ids::EnumId value);
-~StructOrEnumId();
-StructOrEnumId& operator=(StructOrEnumId const &);
-StructOrEnumId& operator=(StructOrEnumId &&);
-StructOrEnumId(StructOrEnumId const&);
-StructOrEnumId(StructOrEnumId &&);
-private: void __jakt_destroy_variant();
-public:
-private:
-StructOrEnumId() {};
-};
-struct CheckedStatement: public RefCounted<CheckedStatement> {
+};struct CheckedNamespace {
+  public:
+public: ByteString name;public: ids::ScopeId scope;public: CheckedNamespace(ByteString a_name, ids::ScopeId a_scope);
+
+public: ErrorOr<ByteString> debug_description() const;
+};struct LoadedModule {
+  public:
+public: ids::ModuleId module_id;public: utility::FileId file_id;public: LoadedModule(ids::ModuleId a_module_id, utility::FileId a_file_id);
+
+public: ErrorOr<ByteString> debug_description() const;
+};struct CheckedStatement: public RefCounted<CheckedStatement> {
 u8 __jakt_variant_index = 0;
 union VariantData {
 u8 __jakt_uninit_value;
@@ -923,124 +920,9 @@ static JaktInternal::Optional<NonnullRefPtr<typename types::CheckedStatement>> n
 private:
 CheckedStatement() {};
 };
-struct GenericInferences {
+struct SpecializedType {
   public:
-public: JaktInternal::Dictionary<ids::TypeId,ids::TypeId> values;public: ErrorOr<void> set_all(JaktInternal::DynamicArray<types::CheckedGenericParameter> const keys, JaktInternal::DynamicArray<ids::TypeId> const values);
-public: ErrorOr<void> set_from(JaktInternal::Dictionary<ids::TypeId,ids::TypeId> const checkpoint);
-public: ErrorOr<JaktInternal::Optional<ids::TypeId>> find_and_map(ByteString const name, NonnullRefPtr<types::CheckedProgram> const& program) const;
-public: GenericInferences(JaktInternal::Dictionary<ids::TypeId,ids::TypeId> a_values);
-
-public: void restore(JaktInternal::Dictionary<ids::TypeId,ids::TypeId> const checkpoint);
-public: ErrorOr<void> debug_description(NonnullRefPtr<types::CheckedProgram> const& program) const;
-public: ids::TypeId map(ids::TypeId const type) const;
-public: ErrorOr<JaktInternal::Dictionary<ids::TypeId,ids::TypeId>> perform_checkpoint(bool const reset);
-public: JaktInternal::Optional<ids::TypeId> get(ids::TypeId const key) const;
-public: JaktInternal::Dictionary<ids::TypeId,ids::TypeId> iterator() const;
-public: ErrorOr<void> set(ids::TypeId const key, ids::TypeId const value);
-public: ErrorOr<ByteString> debug_description() const;
-};struct NumberConstant {
-u8 __jakt_variant_index = 0;
-union VariantData {
-u8 __jakt_uninit_value;
-struct {
-i64 value;
-} Signed;
-struct {
-u64 value;
-} Unsigned;
-struct {
-f64 value;
-} Floating;
-constexpr VariantData() {}
-~VariantData() {}
-} as;
-constexpr u8 __jakt_init_index() const noexcept { return __jakt_variant_index - 1; }ErrorOr<ByteString> debug_description() const;
-[[nodiscard]] static NumberConstant Signed(i64 value);
-[[nodiscard]] static NumberConstant Unsigned(u64 value);
-[[nodiscard]] static NumberConstant Floating(f64 value);
-~NumberConstant();
-NumberConstant& operator=(NumberConstant const &);
-NumberConstant& operator=(NumberConstant &&);
-NumberConstant(NumberConstant const&);
-NumberConstant(NumberConstant &&);
-private: void __jakt_destroy_variant();
-public:
-ErrorOr<bool> can_fit_number(ids::TypeId const type_id, NonnullRefPtr<types::CheckedProgram> const program) const;
-ErrorOr<size_t> to_usize() const;
-private:
-NumberConstant() {};
-};
-struct CheckedTraitRequirements {
-u8 __jakt_variant_index = 0;
-union VariantData {
-u8 __jakt_uninit_value;
-struct {
-JaktInternal::Dictionary<ByteString,ids::FunctionId> value;
-} Methods;
-struct {
-NonnullRefPtr<typename types::CheckedExpression> value;
-} ComptimeExpression;
-constexpr VariantData() {}
-~VariantData() {}
-} as;
-constexpr u8 __jakt_init_index() const noexcept { return __jakt_variant_index - 1; }ErrorOr<ByteString> debug_description() const;
-[[nodiscard]] static CheckedTraitRequirements Nothing();
-[[nodiscard]] static CheckedTraitRequirements Methods(JaktInternal::Dictionary<ByteString,ids::FunctionId> value);
-[[nodiscard]] static CheckedTraitRequirements ComptimeExpression(NonnullRefPtr<typename types::CheckedExpression> value);
-~CheckedTraitRequirements();
-CheckedTraitRequirements& operator=(CheckedTraitRequirements const &);
-CheckedTraitRequirements& operator=(CheckedTraitRequirements &&);
-CheckedTraitRequirements(CheckedTraitRequirements const&);
-CheckedTraitRequirements(CheckedTraitRequirements &&);
-private: void __jakt_destroy_variant();
-public:
-private:
-CheckedTraitRequirements() {};
-};
-struct CheckedEnum {
-  public:
-public: ByteString name;public: utility::Span name_span;public: JaktInternal::DynamicArray<types::CheckedGenericParameter> generic_parameters;public: JaktInternal::DynamicArray<types::CheckedEnumVariant> variants;public: JaktInternal::DynamicArray<types::CheckedField> fields;public: ids::ScopeId scope_id;public: parser::DefinitionLinkage definition_linkage;public: JaktInternal::Dictionary<ByteString,JaktInternal::DynamicArray<JaktInternal::Tuple<ids::TraitId,JaktInternal::DynamicArray<ids::TypeId>>>> trait_implementations;public: parser::RecordType record_type;public: ids::TypeId underlying_type_id;public: ids::TypeId type_id;public: bool is_boxed;public: CheckedEnum(ByteString a_name, utility::Span a_name_span, JaktInternal::DynamicArray<types::CheckedGenericParameter> a_generic_parameters, JaktInternal::DynamicArray<types::CheckedEnumVariant> a_variants, JaktInternal::DynamicArray<types::CheckedField> a_fields, ids::ScopeId a_scope_id, parser::DefinitionLinkage a_definition_linkage, JaktInternal::Dictionary<ByteString,JaktInternal::DynamicArray<JaktInternal::Tuple<ids::TraitId,JaktInternal::DynamicArray<ids::TypeId>>>> a_trait_implementations, parser::RecordType a_record_type, ids::TypeId a_underlying_type_id, ids::TypeId a_type_id, bool a_is_boxed);
-
-public: ErrorOr<ByteString> debug_description() const;
-};struct ClassInstanceRebind {
-  public:
-public: ByteString name;public: utility::Span name_span;public: bool is_mutable;public: bool is_reference;public: ClassInstanceRebind(ByteString a_name, utility::Span a_name_span, bool a_is_mutable, bool a_is_reference);
-
-public: ErrorOr<ByteString> debug_description() const;
-};struct StringLiteral {
-u8 __jakt_variant_index = 0;
-union VariantData {
-u8 __jakt_uninit_value;
-struct {
-ByteString value;
-} Static;
-constexpr VariantData() {}
-~VariantData() {}
-} as;
-constexpr u8 __jakt_init_index() const noexcept { return __jakt_variant_index - 1; }ErrorOr<ByteString> debug_description() const;
-[[nodiscard]] static StringLiteral Static(ByteString value);
-~StringLiteral();
-StringLiteral& operator=(StringLiteral const &);
-StringLiteral& operator=(StringLiteral &&);
-StringLiteral(StringLiteral const&);
-StringLiteral(StringLiteral &&);
-private: void __jakt_destroy_variant();
-public:
-ByteString to_string() const;
-private:
-StringLiteral() {};
-};
-struct CheckedStringLiteral {
-  public:
-public: types::StringLiteral value;public: ids::TypeId type_id;public: bool may_throw;public: ByteString to_string() const;
-public: CheckedStringLiteral(types::StringLiteral a_value, ids::TypeId a_type_id, bool a_may_throw);
-
-public: ErrorOr<ByteString> debug_description() const;
-};struct FunctionGenericParameter {
-  public:
-public: types::FunctionGenericParameterKind kind;public: types::CheckedGenericParameter checked_parameter;public: static ErrorOr<types::FunctionGenericParameter> parameter(ids::TypeId const type_id, utility::Span const span);
-public: ids::TypeId type_id() const;
-public: FunctionGenericParameter(types::FunctionGenericParameterKind a_kind, types::CheckedGenericParameter a_checked_parameter);
+public: ids::TypeId base_type_id;public: JaktInternal::DynamicArray<ids::TypeId> arguments;public: ids::TypeId type_id;public: SpecializedType(ids::TypeId a_base_type_id, JaktInternal::DynamicArray<ids::TypeId> a_arguments, ids::TypeId a_type_id);
 
 public: ErrorOr<ByteString> debug_description() const;
 };class CheckedTrait :public RefCounted<CheckedTrait>, public Weakable<CheckedTrait> {
@@ -1052,7 +934,71 @@ public:
 static ErrorOr<NonnullRefPtr<CheckedTrait>> __jakt_create(ByteString name, utility::Span name_span, types::CheckedTraitRequirements requirements, JaktInternal::DynamicArray<types::CheckedGenericParameter> generic_parameters, ids::ScopeId scope_id);
 
 public: ErrorOr<ByteString> debug_description() const;
-};struct CheckedEnumVariantBinding {
+};struct BuiltinType {
+u8 __jakt_variant_index = 0;
+union VariantData {
+u8 __jakt_uninit_value;
+constexpr VariantData() {}
+~VariantData() {}
+} as;
+constexpr u8 __jakt_init_index() const noexcept { return __jakt_variant_index - 1; }ErrorOr<ByteString> debug_description() const;
+[[nodiscard]] static BuiltinType Void();
+[[nodiscard]] static BuiltinType Bool();
+[[nodiscard]] static BuiltinType U8();
+[[nodiscard]] static BuiltinType U16();
+[[nodiscard]] static BuiltinType U32();
+[[nodiscard]] static BuiltinType U64();
+[[nodiscard]] static BuiltinType I8();
+[[nodiscard]] static BuiltinType I16();
+[[nodiscard]] static BuiltinType I32();
+[[nodiscard]] static BuiltinType I64();
+[[nodiscard]] static BuiltinType F32();
+[[nodiscard]] static BuiltinType F64();
+[[nodiscard]] static BuiltinType Usize();
+[[nodiscard]] static BuiltinType JaktString();
+[[nodiscard]] static BuiltinType CChar();
+[[nodiscard]] static BuiltinType CInt();
+[[nodiscard]] static BuiltinType Unknown();
+[[nodiscard]] static BuiltinType Never();
+~BuiltinType();
+BuiltinType& operator=(BuiltinType const &);
+BuiltinType& operator=(BuiltinType &&);
+BuiltinType(BuiltinType const&);
+BuiltinType(BuiltinType &&);
+private: void __jakt_destroy_variant();
+public:
+ErrorOr<ByteString> constructor_name() const;
+size_t id() const;
+private:
+BuiltinType() {};
+};
+struct StructOrEnumId {
+u8 __jakt_variant_index = 0;
+union VariantData {
+u8 __jakt_uninit_value;
+struct {
+ids::StructId value;
+} Struct;
+struct {
+ids::EnumId value;
+} Enum;
+constexpr VariantData() {}
+~VariantData() {}
+} as;
+constexpr u8 __jakt_init_index() const noexcept { return __jakt_variant_index - 1; }ErrorOr<ByteString> debug_description() const;
+[[nodiscard]] static StructOrEnumId Struct(ids::StructId value);
+[[nodiscard]] static StructOrEnumId Enum(ids::EnumId value);
+~StructOrEnumId();
+StructOrEnumId& operator=(StructOrEnumId const &);
+StructOrEnumId& operator=(StructOrEnumId &&);
+StructOrEnumId(StructOrEnumId const&);
+StructOrEnumId(StructOrEnumId &&);
+private: void __jakt_destroy_variant();
+public:
+private:
+StructOrEnumId() {};
+};
+struct CheckedEnumVariantBinding {
   public:
 public: JaktInternal::Optional<ByteString> name;public: ByteString binding;public: ids::TypeId type_id;public: utility::Span span;public: CheckedEnumVariantBinding(JaktInternal::Optional<ByteString> a_name, ByteString a_binding, ids::TypeId a_type_id, utility::Span a_span);
 
@@ -1334,196 +1280,211 @@ bool is_mutable(NonnullRefPtr<types::CheckedProgram> const program) const;
 private:
 CheckedExpression() {};
 };
-struct CheckedParameter {
+class CheckedProgram :public RefCounted<CheckedProgram>, public Weakable<CheckedProgram> {
   public:
-public: bool requires_label;public: NonnullRefPtr<types::CheckedVariable> variable;public: JaktInternal::Optional<JaktInternal::Tuple<NonnullRefPtr<typename parser::ParsedExpression>,ids::ScopeId>> default_value_expression;public: ErrorOr<types::CheckedParameter> map_types(Function<ErrorOr<ids::TypeId>(ids::TypeId)> const& map) const;
-public: CheckedParameter(bool a_requires_label, NonnullRefPtr<types::CheckedVariable> a_variable, JaktInternal::Optional<JaktInternal::Tuple<NonnullRefPtr<typename parser::ParsedExpression>,ids::ScopeId>> a_default_value_expression);
-
-public: ErrorOr<ByteString> debug_description() const;
-};struct SafetyMode {
-u8 __jakt_variant_index = 0;
-union VariantData {
-u8 __jakt_uninit_value;
-constexpr VariantData() {}
-~VariantData() {}
-} as;
-constexpr u8 __jakt_init_index() const noexcept { return __jakt_variant_index - 1; }ErrorOr<ByteString> debug_description() const;
-[[nodiscard]] static SafetyMode Safe();
-[[nodiscard]] static SafetyMode Unsafe();
-~SafetyMode();
-SafetyMode& operator=(SafetyMode const &);
-SafetyMode& operator=(SafetyMode &&);
-SafetyMode(SafetyMode const&);
-SafetyMode(SafetyMode &&);
-private: void __jakt_destroy_variant();
-public:
-private:
-SafetyMode() {};
-};
-struct SpecializedType {
-  public:
-public: ids::TypeId base_type_id;public: JaktInternal::DynamicArray<ids::TypeId> arguments;public: ids::TypeId type_id;public: SpecializedType(ids::TypeId a_base_type_id, JaktInternal::DynamicArray<ids::TypeId> a_arguments, ids::TypeId a_type_id);
-
-public: ErrorOr<ByteString> debug_description() const;
-};class TypecheckFunctions :public RefCounted<TypecheckFunctions>, public Weakable<TypecheckFunctions> {
-  public:
-virtual ~TypecheckFunctions() = default;
-public: Function<ErrorOr<types::CheckedBlock>(parser::ParsedBlock, ids::ScopeId, types::SafetyMode, JaktInternal::Optional<ids::TypeId>, JaktInternal::Optional<ids::FunctionId>)> block;public: Function<ErrorOr<ids::FunctionId>(NonnullRefPtr<types::CheckedFunction>)> register_function;public: protected:
-explicit TypecheckFunctions(Function<ErrorOr<types::CheckedBlock>(parser::ParsedBlock, ids::ScopeId, types::SafetyMode, JaktInternal::Optional<ids::TypeId>, JaktInternal::Optional<ids::FunctionId>)> a_block, Function<ErrorOr<ids::FunctionId>(NonnullRefPtr<types::CheckedFunction>)> a_register_function);
-public:
-static ErrorOr<NonnullRefPtr<TypecheckFunctions>> __jakt_create(Function<ErrorOr<types::CheckedBlock>(parser::ParsedBlock, ids::ScopeId, types::SafetyMode, JaktInternal::Optional<ids::TypeId>, JaktInternal::Optional<ids::FunctionId>)> block, Function<ErrorOr<ids::FunctionId>(NonnullRefPtr<types::CheckedFunction>)> register_function);
-
-public: ErrorOr<ByteString> debug_description() const;
-};class CheckedFunction :public RefCounted<CheckedFunction>, public Weakable<CheckedFunction> {
-  public:
-virtual ~CheckedFunction() = default;
-public: ByteString name;public: utility::Span name_span;public: types::CheckedVisibility visibility;public: ids::TypeId return_type_id;public: JaktInternal::Optional<utility::Span> return_type_span;public: JaktInternal::DynamicArray<types::CheckedParameter> params;public: NonnullRefPtr<types::FunctionGenerics> generics;public: types::CheckedBlock block;public: bool can_throw;public: parser::FunctionType type;public: parser::FunctionLinkage linkage;public: ids::ScopeId function_scope_id;public: JaktInternal::Optional<ids::StructId> struct_id;public: bool is_instantiated;public: JaktInternal::Optional<parser::ParsedFunction> parsed_function;public: bool is_comptime;public: bool is_virtual;public: bool is_override;public: bool is_unsafe;public: bool has_varargs;public: JaktInternal::Optional<size_t> specialization_index;public: JaktInternal::Optional<ids::ScopeId> owner_scope;public: JaktInternal::Optional<JaktInternal::Dictionary<ids::TypeId,ids::TypeId>> owner_scope_generics;public: bool is_fully_checked;public: JaktInternal::Optional<parser::ExternalName> external_name;public: JaktInternal::Optional<ByteString> deprecated_message;public: JaktInternal::Optional<JaktInternal::DynamicArray<JaktInternal::Tuple<size_t,parser::ArgumentStoreLevel>>> stores_arguments;public: parser::InlineState force_inline;public: ErrorOr<void> map_types(Function<ErrorOr<ids::TypeId>(ids::TypeId)> const& map);
-public: ErrorOr<bool> is_static() const;
-public: ErrorOr<bool> is_mutating() const;
+virtual ~CheckedProgram() = default;
+public: NonnullRefPtr<compiler::Compiler> compiler;public: JaktInternal::DynamicArray<NonnullRefPtr<types::Module>> modules;public: JaktInternal::Dictionary<ByteString,types::LoadedModule> loaded_modules;public: ErrorOr<ids::TypeId> substitute_typevars_in_type(ids::TypeId const type_id, types::GenericInferences const generic_inferences, ids::ModuleId const module_id);
+public: ids::ModuleId prelude_module_id() const;
+public: ErrorOr<JaktInternal::Optional<ids::ScopeId>> find_namespace_in_immediate_children_of_scope(ids::ScopeId const scope_id, ByteString const name, bool const treat_aliases_as_imports) const;
+public: ErrorOr<ids::StructId> find_struct_in_prelude(ByteString const name) const;
+public: ErrorOr<NonnullRefPtr<types::Scope>> get_scope(ids::ScopeId const id) const;
+public: bool is_floating(ids::TypeId const type_id) const;
+public: ErrorOr<JaktInternal::Optional<ids::FunctionId>> find_default_constructors_in_scope(ids::ScopeId const parent_scope_id, ByteString const function_name, JaktInternal::Optional<ids::ScopeId> const root_scope) const;
+public: ErrorOr<JaktInternal::Optional<ids::StructId>> find_struct_in_scope(ids::ScopeId const scope_id, ByteString const name, bool const ignore_mixin_scopes, JaktInternal::Optional<ids::ScopeId> const root_scope) const;
+public: ErrorOr<JaktInternal::Optional<ids::TypeId>> find_type_in_scope(ids::ScopeId const scope_id, ByteString const name, bool const ignore_mixin_scopes, JaktInternal::Optional<ids::ScopeId> const root_scope) const;
+public: ErrorOr<void> set_loaded_module(ByteString const module_name, types::LoadedModule const loaded_module);
+public: ErrorOr<ids::ScopeId> find_type_scope_id(ids::TypeId const type_id);
+public: bool is_integer(ids::TypeId const type_id) const;
+public: ErrorOr<ids::ScopeId> create_scope(JaktInternal::Optional<ids::ScopeId> const parent_scope_id, bool const can_throw, ByteString const debug_name, ids::ModuleId const module_id, bool const for_block);
+public: NonnullRefPtr<types::Module> get_module(ids::ModuleId const id) const;
+public: ErrorOr<ByteString> type_name(ids::TypeId const type_id, bool const debug_mode) const;
+private: ErrorOr<JaktInternal::Optional<bool>> for_each_scope_accessible_unqualified_from_scope_impl(ids::ScopeId const scope_id, Function<ErrorOr<typename utility::IterationDecision<bool>>(ids::ScopeId, JaktInternal::Optional<ByteString>, bool)> const& callback, bool const ignore_mixin_scopes, JaktInternal::Optional<ids::ScopeId> const root_scope) const;
+public: ErrorOr<bool> is_scope_directly_accessible_from(ids::ScopeId const check_scope_id, ids::ScopeId const scope_id, bool const ignore_mixin_scopes) const;
+public: ErrorOr<ByteString> debug_description_of(ids::ScopeId const scope_id) const;
+public: ErrorOr<bool> is_string(ids::TypeId const type_id) const;
+public: ids::ScopeId prelude_scope_id() const;
+public: NonnullRefPtr<types::CheckedTrait> get_trait(ids::TraitId const id) const;
+public: NonnullRefPtr<types::CheckedVariable> get_variable(ids::VarId const id) const;
 public: protected:
-explicit CheckedFunction(ByteString a_name, utility::Span a_name_span, types::CheckedVisibility a_visibility, ids::TypeId a_return_type_id, JaktInternal::Optional<utility::Span> a_return_type_span, JaktInternal::DynamicArray<types::CheckedParameter> a_params, NonnullRefPtr<types::FunctionGenerics> a_generics, types::CheckedBlock a_block, bool a_can_throw, parser::FunctionType a_type, parser::FunctionLinkage a_linkage, ids::ScopeId a_function_scope_id, JaktInternal::Optional<ids::StructId> a_struct_id, bool a_is_instantiated, JaktInternal::Optional<parser::ParsedFunction> a_parsed_function, bool a_is_comptime, bool a_is_virtual, bool a_is_override, bool a_is_unsafe, bool a_has_varargs, JaktInternal::Optional<size_t> a_specialization_index, JaktInternal::Optional<ids::ScopeId> a_owner_scope, JaktInternal::Optional<JaktInternal::Dictionary<ids::TypeId,ids::TypeId>> a_owner_scope_generics, bool a_is_fully_checked, JaktInternal::Optional<parser::ExternalName> a_external_name, JaktInternal::Optional<ByteString> a_deprecated_message, JaktInternal::Optional<JaktInternal::DynamicArray<JaktInternal::Tuple<size_t,parser::ArgumentStoreLevel>>> a_stores_arguments, parser::InlineState a_force_inline);
+explicit CheckedProgram(NonnullRefPtr<compiler::Compiler> a_compiler, JaktInternal::DynamicArray<NonnullRefPtr<types::Module>> a_modules, JaktInternal::Dictionary<ByteString,types::LoadedModule> a_loaded_modules);
 public:
-static ErrorOr<NonnullRefPtr<CheckedFunction>> __jakt_create(ByteString name, utility::Span name_span, types::CheckedVisibility visibility, ids::TypeId return_type_id, JaktInternal::Optional<utility::Span> return_type_span, JaktInternal::DynamicArray<types::CheckedParameter> params, NonnullRefPtr<types::FunctionGenerics> generics, types::CheckedBlock block, bool can_throw, parser::FunctionType type, parser::FunctionLinkage linkage, ids::ScopeId function_scope_id, JaktInternal::Optional<ids::StructId> struct_id, bool is_instantiated, JaktInternal::Optional<parser::ParsedFunction> parsed_function, bool is_comptime, bool is_virtual, bool is_override, bool is_unsafe, bool has_varargs, JaktInternal::Optional<size_t> specialization_index, JaktInternal::Optional<ids::ScopeId> owner_scope, JaktInternal::Optional<JaktInternal::Dictionary<ids::TypeId,ids::TypeId>> owner_scope_generics, bool is_fully_checked, JaktInternal::Optional<parser::ExternalName> external_name, JaktInternal::Optional<ByteString> deprecated_message, JaktInternal::Optional<JaktInternal::DynamicArray<JaktInternal::Tuple<size_t,parser::ArgumentStoreLevel>>> stores_arguments, parser::InlineState force_inline);
+static ErrorOr<NonnullRefPtr<CheckedProgram>> __jakt_create(NonnullRefPtr<compiler::Compiler> compiler, JaktInternal::DynamicArray<NonnullRefPtr<types::Module>> modules, JaktInternal::Dictionary<ByteString,types::LoadedModule> loaded_modules);
 
-public: ErrorOr<parser::ParsedFunction> to_parsed_function() const;
-public: bool is_specialized_for_types(JaktInternal::DynamicArray<ids::TypeId> const types) const;
-public: ErrorOr<NonnullRefPtr<types::CheckedFunction>> copy() const;
-public: ErrorOr<bool> signature_matches(NonnullRefPtr<types::CheckedFunction> const other, bool const ignore_this) const;
-public: parser::ExternalName name_for_codegen() const;
-public: ErrorOr<void> add_param(types::CheckedParameter const checked_param);
-public: ErrorOr<void> set_params(JaktInternal::DynamicArray<types::CheckedParameter> const checked_params);
+public: ErrorOr<ids::ModuleId> create_module(ByteString const name, bool const is_root, JaktInternal::Optional<ByteString> const path);
+public: NonnullRefPtr<types::CheckedFunction> get_function(ids::FunctionId const id) const;
+public: ErrorOr<JaktInternal::Optional<JaktInternal::Tuple<ids::TypeId,ids::ScopeId>>> find_type_scope(ids::ScopeId const scope_id, ByteString const name, bool const ignore_mixin_scopes, JaktInternal::Optional<ids::ScopeId> const root_scope) const;
+public: ErrorOr<ids::StructId> builtin_implementation_struct(types::BuiltinType const builtin, ids::ModuleId const for_module);
+public: ErrorOr<JaktInternal::Optional<types::Value>> find_comptime_binding_in_scope(ids::ScopeId const scope_id, ByteString const name, bool const ignore_mixin_scopes, JaktInternal::Optional<ids::ScopeId> const root_scope) const;
+private: ErrorOr<ids::TypeId> substitute_typevars_in_type_helper(ids::TypeId const type_id, types::GenericInferences const generic_inferences, ids::ModuleId const module_id);
+private: ErrorOr<JaktInternal::Optional<bool>> for_each_scope_accessible_unqualified_from_scope_direct_chain(ids::ScopeId const scope_id, Function<ErrorOr<typename utility::IterationDecision<bool>>(ids::ScopeId, JaktInternal::Optional<ByteString>, bool)> const& callback, JaktInternal::Optional<ids::ScopeId> const root_scope) const;
+public: i64 get_bits(ids::TypeId const type_id) const;
+public: NonnullRefPtr<typename types::Type> get_type(ids::TypeId const id) const;
+public: ErrorOr<ids::TypeId> find_or_add_type_id(NonnullRefPtr<typename types::Type> const type, ids::ModuleId const module_id, bool const only_in_current_module);
+public: ErrorOr<JaktInternal::Optional<JaktInternal::Tuple<ids::ScopeId,bool>>> find_namespace_in_scope(ids::ScopeId const scope_id, ByteString const name, bool const treat_aliases_as_imports, bool const ignore_mixin_scopes, JaktInternal::Optional<ids::ScopeId> const root_scope) const;
+public: ErrorOr<void> set_owner_scope_if_needed(ids::ScopeId const parent_scope_id, JaktInternal::DynamicArray<ids::FunctionId> const overload_set, utility::Span const span);
+public: ErrorOr<void> set_owner_scope_if_needed(ids::ScopeId const parent_scope_id, ids::VarId const var_id);
+public: types::CheckedEnum get_enum(ids::EnumId const id) const;
+public: ErrorOr<JaktInternal::Optional<ids::TraitId>> find_trait_in_scope(ids::ScopeId const scope_id, ByteString const name, bool const ignore_mixin_scopes, JaktInternal::Optional<ids::ScopeId> const root_scope) const;
+public: ErrorOr<ids::TypeId> apply_qualifiers_to_type(parser::CheckedQualifiers const qualifiers, ids::TypeId const type_id);
+public: ErrorOr<JaktInternal::Optional<JaktInternal::DynamicArray<ids::FunctionId>>> find_functions_with_name_in_scope(ids::ScopeId const parent_scope_id, ByteString const function_name, bool const ignore_mixin_scopes, JaktInternal::Optional<ids::ScopeId> const root_scope) const;
+public: ErrorOr<JaktInternal::Optional<NonnullRefPtr<types::CheckedVariable>>> find_var_in_scope(ids::ScopeId const scope_id, ByteString const var, bool const ignore_mixin_scopes, JaktInternal::Optional<ids::ScopeId> const root_scope) const;
+public: ErrorOr<JaktInternal::Optional<ids::FunctionId>> find_function_in_scope(ids::ScopeId const parent_scope_id, ByteString const function_name, JaktInternal::Optional<ids::ScopeId> const root_scope) const;
+public: types::CheckedStruct get_struct(ids::StructId const id) const;
+public: ErrorOr<JaktInternal::Optional<ids::StructId>> check_and_extract_weak_ptr(ids::StructId const struct_id, JaktInternal::DynamicArray<ids::TypeId> const args) const;
+public: ErrorOr<JaktInternal::Optional<ids::EnumId>> find_enum_in_scope(ids::ScopeId const scope_id, ByteString const name, bool const ignore_mixin_scopes, JaktInternal::Optional<ids::ScopeId> const root_scope) const;
+public: JaktInternal::Optional<types::LoadedModule> get_loaded_module(ByteString const module_name) const;
+public: ErrorOr<JaktInternal::Optional<JaktInternal::Tuple<JaktInternal::DynamicArray<ids::FunctionId>,ids::ScopeId>>> find_scoped_functions_with_name_in_scope(ids::ScopeId const parent_scope_id, ByteString const function_name, bool const ignore_mixin_scopes, JaktInternal::Optional<ids::ScopeId> const root_scope) const;
+public: bool is_signed(ids::TypeId const type_id) const;
+public: bool is_numeric(ids::TypeId const type_id) const;
+public: template <typename T>
+ErrorOr<JaktInternal::Optional<T>> for_each_scope_accessible_unqualified_from_scope(ids::ScopeId const scope_id, Function<ErrorOr<typename utility::IterationDecision<T>>(ids::ScopeId, JaktInternal::Optional<ByteString>, bool)> const& callback, bool const ignore_mixin_scopes, JaktInternal::Optional<ids::ScopeId> const root_scope) const;
+public: public: public: public: public: public: public: public: public: public: ErrorOr<types::StructOrEnumId> find_reflected_primitive(ByteString const primitive) const;
 public: ErrorOr<ByteString> debug_description() const;
-};struct CheckedCapture {
-u8 __jakt_variant_index = 0;
-union CommonData {
-u8 __jakt_uninit_common;
-struct {
-ByteString name;
-utility::Span span;
-} init_common;
-constexpr CommonData() {}
-~CommonData() {}
-} common;
-union VariantData {
-u8 __jakt_uninit_value;
-constexpr VariantData() {}
-~VariantData() {}
-} as;
-constexpr u8 __jakt_init_index() const noexcept { return __jakt_variant_index - 1; }ErrorOr<ByteString> debug_description() const;
-[[nodiscard]] static CheckedCapture ByValue(ByteString name, utility::Span span);
-[[nodiscard]] static CheckedCapture ByReference(ByteString name, utility::Span span);
-[[nodiscard]] static CheckedCapture ByMutableReference(ByteString name, utility::Span span);
-[[nodiscard]] static CheckedCapture ByComptimeDependency(ByteString name, utility::Span span);
-[[nodiscard]] static CheckedCapture AllByReference(ByteString name, utility::Span span);
-~CheckedCapture();
-CheckedCapture& operator=(CheckedCapture const &);
-CheckedCapture& operator=(CheckedCapture &&);
-CheckedCapture(CheckedCapture const&);
-CheckedCapture(CheckedCapture &&);
-private: void __jakt_destroy_variant();
-public:
-private:
-CheckedCapture() {};
-};
-struct ResolvedNamespace {
-  public:
-public: ByteString name;public: JaktInternal::Optional<parser::ExternalName> external_name;public: JaktInternal::Optional<JaktInternal::DynamicArray<ids::TypeId>> generic_parameters;public: ResolvedNamespace(ByteString a_name, JaktInternal::Optional<parser::ExternalName> a_external_name, JaktInternal::Optional<JaktInternal::DynamicArray<ids::TypeId>> a_generic_parameters);
-
-public: parser::ExternalName name_for_codegen() const;
-public: ErrorOr<ByteString> debug_description() const;
-};struct MaybeResolvedScope: public RefCounted<MaybeResolvedScope> {
+};struct ValueImpl: public RefCounted<ValueImpl> {
 u8 __jakt_variant_index = 0;
 union VariantData {
 u8 __jakt_uninit_value;
 struct {
-ids::ScopeId value;
-} Resolved;
+bool value;
+} Bool;
 struct {
-NonnullRefPtr<typename types::MaybeResolvedScope> parent_scope;
-ByteString relative_name;
-} Unresolved;
+u8 value;
+} U8;
+struct {
+u16 value;
+} U16;
+struct {
+u32 value;
+} U32;
+struct {
+u64 value;
+} U64;
+struct {
+i8 value;
+} I8;
+struct {
+i16 value;
+} I16;
+struct {
+i32 value;
+} I32;
+struct {
+i64 value;
+} I64;
+struct {
+f32 value;
+} F32;
+struct {
+f64 value;
+} F64;
+struct {
+size_t value;
+} USize;
+struct {
+ByteString value;
+} JaktString;
+struct {
+ByteString value;
+} StringView;
+struct {
+char value;
+} CChar;
+struct {
+int value;
+} CInt;
+struct {
+JaktInternal::DynamicArray<types::Value> fields;
+ids::StructId struct_id;
+JaktInternal::Optional<ids::FunctionId> constructor;
+} Struct;
+struct {
+JaktInternal::DynamicArray<types::Value> fields;
+ids::StructId struct_id;
+JaktInternal::Optional<ids::FunctionId> constructor;
+} Class;
+struct {
+JaktInternal::DynamicArray<types::Value> fields;
+ids::EnumId enum_id;
+ids::FunctionId constructor;
+} Enum;
+struct {
+JaktInternal::DynamicArray<types::Value> values;
+ids::TypeId type_id;
+} JaktArray;
+struct {
+JaktInternal::DynamicArray<types::Value> keys;
+JaktInternal::DynamicArray<types::Value> values;
+ids::TypeId type_id;
+} JaktDictionary;
+struct {
+JaktInternal::DynamicArray<types::Value> values;
+ids::TypeId type_id;
+} JaktSet;
+struct {
+NonnullRefPtr<typename types::ValueImpl> value;
+} RawPtr;
+struct {
+types::Value value;
+} OptionalSome;
+struct {
+JaktInternal::DynamicArray<types::Value> fields;
+ids::TypeId type_id;
+} JaktTuple;
+struct {
+JaktInternal::Dictionary<ByteString,types::Value> captures;
+JaktInternal::Dictionary<ByteString,JaktInternal::Tuple<ids::TypeId,JaktInternal::Optional<JaktInternal::Tuple<NonnullRefPtr<typename parser::ParsedExpression>,ids::ScopeId>>>> params;
+ids::TypeId return_type_id;
+ids::TypeId type_id;
+types::CheckedBlock block;
+bool can_throw;
+JaktInternal::DynamicArray<types::CheckedParameter> checked_params;
+ids::ScopeId scope_id;
+JaktInternal::Optional<ids::FunctionId> pseudo_function_id;
+} Function;
 constexpr VariantData() {}
 ~VariantData() {}
 } as;
 constexpr u8 __jakt_init_index() const noexcept { return __jakt_variant_index - 1; }ErrorOr<ByteString> debug_description() const;
-[[nodiscard]] static ErrorOr<NonnullRefPtr<MaybeResolvedScope>> Resolved(ids::ScopeId value);
-[[nodiscard]] static ErrorOr<NonnullRefPtr<MaybeResolvedScope>> Unresolved(NonnullRefPtr<typename types::MaybeResolvedScope> parent_scope, ByteString relative_name);
-~MaybeResolvedScope();
-MaybeResolvedScope& operator=(MaybeResolvedScope const &);
-MaybeResolvedScope& operator=(MaybeResolvedScope &&);
-MaybeResolvedScope(MaybeResolvedScope const&);
-MaybeResolvedScope(MaybeResolvedScope &&);
+[[nodiscard]] static ErrorOr<NonnullRefPtr<ValueImpl>> Void();
+[[nodiscard]] static ErrorOr<NonnullRefPtr<ValueImpl>> Bool(bool value);
+[[nodiscard]] static ErrorOr<NonnullRefPtr<ValueImpl>> U8(u8 value);
+[[nodiscard]] static ErrorOr<NonnullRefPtr<ValueImpl>> U16(u16 value);
+[[nodiscard]] static ErrorOr<NonnullRefPtr<ValueImpl>> U32(u32 value);
+[[nodiscard]] static ErrorOr<NonnullRefPtr<ValueImpl>> U64(u64 value);
+[[nodiscard]] static ErrorOr<NonnullRefPtr<ValueImpl>> I8(i8 value);
+[[nodiscard]] static ErrorOr<NonnullRefPtr<ValueImpl>> I16(i16 value);
+[[nodiscard]] static ErrorOr<NonnullRefPtr<ValueImpl>> I32(i32 value);
+[[nodiscard]] static ErrorOr<NonnullRefPtr<ValueImpl>> I64(i64 value);
+[[nodiscard]] static ErrorOr<NonnullRefPtr<ValueImpl>> F32(f32 value);
+[[nodiscard]] static ErrorOr<NonnullRefPtr<ValueImpl>> F64(f64 value);
+[[nodiscard]] static ErrorOr<NonnullRefPtr<ValueImpl>> USize(size_t value);
+[[nodiscard]] static ErrorOr<NonnullRefPtr<ValueImpl>> JaktString(ByteString value);
+[[nodiscard]] static ErrorOr<NonnullRefPtr<ValueImpl>> StringView(ByteString value);
+[[nodiscard]] static ErrorOr<NonnullRefPtr<ValueImpl>> CChar(char value);
+[[nodiscard]] static ErrorOr<NonnullRefPtr<ValueImpl>> CInt(int value);
+[[nodiscard]] static ErrorOr<NonnullRefPtr<ValueImpl>> Struct(JaktInternal::DynamicArray<types::Value> fields, ids::StructId struct_id, JaktInternal::Optional<ids::FunctionId> constructor);
+[[nodiscard]] static ErrorOr<NonnullRefPtr<ValueImpl>> Class(JaktInternal::DynamicArray<types::Value> fields, ids::StructId struct_id, JaktInternal::Optional<ids::FunctionId> constructor);
+[[nodiscard]] static ErrorOr<NonnullRefPtr<ValueImpl>> Enum(JaktInternal::DynamicArray<types::Value> fields, ids::EnumId enum_id, ids::FunctionId constructor);
+[[nodiscard]] static ErrorOr<NonnullRefPtr<ValueImpl>> JaktArray(JaktInternal::DynamicArray<types::Value> values, ids::TypeId type_id);
+[[nodiscard]] static ErrorOr<NonnullRefPtr<ValueImpl>> JaktDictionary(JaktInternal::DynamicArray<types::Value> keys, JaktInternal::DynamicArray<types::Value> values, ids::TypeId type_id);
+[[nodiscard]] static ErrorOr<NonnullRefPtr<ValueImpl>> JaktSet(JaktInternal::DynamicArray<types::Value> values, ids::TypeId type_id);
+[[nodiscard]] static ErrorOr<NonnullRefPtr<ValueImpl>> RawPtr(NonnullRefPtr<typename types::ValueImpl> value);
+[[nodiscard]] static ErrorOr<NonnullRefPtr<ValueImpl>> OptionalSome(types::Value value);
+[[nodiscard]] static ErrorOr<NonnullRefPtr<ValueImpl>> OptionalNone();
+[[nodiscard]] static ErrorOr<NonnullRefPtr<ValueImpl>> JaktTuple(JaktInternal::DynamicArray<types::Value> fields, ids::TypeId type_id);
+[[nodiscard]] static ErrorOr<NonnullRefPtr<ValueImpl>> Function(JaktInternal::Dictionary<ByteString,types::Value> captures, JaktInternal::Dictionary<ByteString,JaktInternal::Tuple<ids::TypeId,JaktInternal::Optional<JaktInternal::Tuple<NonnullRefPtr<typename parser::ParsedExpression>,ids::ScopeId>>>> params, ids::TypeId return_type_id, ids::TypeId type_id, types::CheckedBlock block, bool can_throw, JaktInternal::DynamicArray<types::CheckedParameter> checked_params, ids::ScopeId scope_id, JaktInternal::Optional<ids::FunctionId> pseudo_function_id);
+~ValueImpl();
+ValueImpl& operator=(ValueImpl const &);
+ValueImpl& operator=(ValueImpl &&);
+ValueImpl(ValueImpl const&);
+ValueImpl(ValueImpl &&);
 private: void __jakt_destroy_variant();
 public:
-ErrorOr<NonnullRefPtr<typename types::MaybeResolvedScope>> try_resolve(NonnullRefPtr<types::CheckedProgram> const program) const;
+bool equals(NonnullRefPtr<typename types::ValueImpl> const other) const;
+ErrorOr<ids::TypeId> type_id(NonnullRefPtr<types::CheckedProgram>& program) const;
+ErrorOr<NonnullRefPtr<typename types::ValueImpl>> copy() const;
 private:
-MaybeResolvedScope() {};
-};
-class FunctionGenerics :public RefCounted<FunctionGenerics>, public Weakable<FunctionGenerics> {
-  public:
-virtual ~FunctionGenerics() = default;
-public: ids::ScopeId base_scope_id;public: JaktInternal::DynamicArray<types::CheckedParameter> base_params;public: JaktInternal::DynamicArray<types::FunctionGenericParameter> params;public: JaktInternal::DynamicArray<JaktInternal::DynamicArray<ids::TypeId>> specializations;public: protected:
-explicit FunctionGenerics(ids::ScopeId a_base_scope_id, JaktInternal::DynamicArray<types::CheckedParameter> a_base_params, JaktInternal::DynamicArray<types::FunctionGenericParameter> a_params, JaktInternal::DynamicArray<JaktInternal::DynamicArray<ids::TypeId>> a_specializations);
-public:
-static ErrorOr<NonnullRefPtr<FunctionGenerics>> __jakt_create(ids::ScopeId base_scope_id, JaktInternal::DynamicArray<types::CheckedParameter> base_params, JaktInternal::DynamicArray<types::FunctionGenericParameter> params, JaktInternal::DynamicArray<JaktInternal::DynamicArray<ids::TypeId>> specializations);
-
-public: bool is_specialized_for_types(JaktInternal::DynamicArray<ids::TypeId> const types) const;
-public: ErrorOr<ByteString> debug_description() const;
-};class Module :public RefCounted<Module>, public Weakable<Module> {
-  public:
-virtual ~Module() = default;
-public: ids::ModuleId id;public: ByteString name;public: JaktInternal::DynamicArray<NonnullRefPtr<types::CheckedFunction>> functions;public: JaktInternal::DynamicArray<types::CheckedStruct> structures;public: JaktInternal::DynamicArray<types::CheckedEnum> enums;public: JaktInternal::DynamicArray<NonnullRefPtr<types::Scope>> scopes;public: JaktInternal::DynamicArray<NonnullRefPtr<typename types::Type>> types;public: JaktInternal::DynamicArray<NonnullRefPtr<types::CheckedTrait>> traits;public: JaktInternal::DynamicArray<NonnullRefPtr<types::CheckedVariable>> variables;public: JaktInternal::DynamicArray<ids::ModuleId> imports;public: ByteString resolved_import_path;public: JaktInternal::Dictionary<size_t,ids::StructId> builtin_implementation_structs;public: bool is_root;public: ids::FunctionId next_function_id() const;
-public: ErrorOr<ids::FunctionId> add_function(NonnullRefPtr<types::CheckedFunction> const checked_function);
-public: bool is_prelude() const;
-public: protected:
-explicit Module(ids::ModuleId a_id, ByteString a_name, JaktInternal::DynamicArray<NonnullRefPtr<types::CheckedFunction>> a_functions, JaktInternal::DynamicArray<types::CheckedStruct> a_structures, JaktInternal::DynamicArray<types::CheckedEnum> a_enums, JaktInternal::DynamicArray<NonnullRefPtr<types::Scope>> a_scopes, JaktInternal::DynamicArray<NonnullRefPtr<typename types::Type>> a_types, JaktInternal::DynamicArray<NonnullRefPtr<types::CheckedTrait>> a_traits, JaktInternal::DynamicArray<NonnullRefPtr<types::CheckedVariable>> a_variables, JaktInternal::DynamicArray<ids::ModuleId> a_imports, ByteString a_resolved_import_path, JaktInternal::Dictionary<size_t,ids::StructId> a_builtin_implementation_structs, bool a_is_root);
-public:
-static ErrorOr<NonnullRefPtr<Module>> __jakt_create(ids::ModuleId id, ByteString name, JaktInternal::DynamicArray<NonnullRefPtr<types::CheckedFunction>> functions, JaktInternal::DynamicArray<types::CheckedStruct> structures, JaktInternal::DynamicArray<types::CheckedEnum> enums, JaktInternal::DynamicArray<NonnullRefPtr<types::Scope>> scopes, JaktInternal::DynamicArray<NonnullRefPtr<typename types::Type>> types, JaktInternal::DynamicArray<NonnullRefPtr<types::CheckedTrait>> traits, JaktInternal::DynamicArray<NonnullRefPtr<types::CheckedVariable>> variables, JaktInternal::DynamicArray<ids::ModuleId> imports, ByteString resolved_import_path, JaktInternal::Dictionary<size_t,ids::StructId> builtin_implementation_structs, bool is_root);
-
-public: ErrorOr<ids::VarId> add_variable(NonnullRefPtr<types::CheckedVariable> const checked_variable);
-public: ErrorOr<ids::TypeId> new_type_variable(JaktInternal::Optional<JaktInternal::DynamicArray<ids::TypeId>> const implemented_traits);
-public: ErrorOr<ByteString> debug_description() const;
-};class CheckedVariable :public RefCounted<CheckedVariable>, public Weakable<CheckedVariable> {
-  public:
-virtual ~CheckedVariable() = default;
-public: ByteString name;public: ids::TypeId type_id;public: bool is_mutable;public: utility::Span definition_span;public: JaktInternal::Optional<utility::Span> type_span;public: types::CheckedVisibility visibility;public: JaktInternal::Optional<ids::ScopeId> owner_scope;public: JaktInternal::Optional<JaktInternal::Dictionary<ids::TypeId,ids::TypeId>> owner_scope_generics;public: JaktInternal::Optional<parser::ExternalName> external_name;public: ErrorOr<NonnullRefPtr<types::CheckedVariable>> map_types(Function<ErrorOr<ids::TypeId>(ids::TypeId)> const& map) const;
-public: parser::ExternalName name_for_codegen() const;
-public: protected:
-explicit CheckedVariable(ByteString a_name, ids::TypeId a_type_id, bool a_is_mutable, utility::Span a_definition_span, JaktInternal::Optional<utility::Span> a_type_span, types::CheckedVisibility a_visibility, JaktInternal::Optional<ids::ScopeId> a_owner_scope, JaktInternal::Optional<JaktInternal::Dictionary<ids::TypeId,ids::TypeId>> a_owner_scope_generics, JaktInternal::Optional<parser::ExternalName> a_external_name);
-public:
-static ErrorOr<NonnullRefPtr<CheckedVariable>> __jakt_create(ByteString name, ids::TypeId type_id, bool is_mutable, utility::Span definition_span, JaktInternal::Optional<utility::Span> type_span, types::CheckedVisibility visibility, JaktInternal::Optional<ids::ScopeId> owner_scope, JaktInternal::Optional<JaktInternal::Dictionary<ids::TypeId,ids::TypeId>> owner_scope_generics, JaktInternal::Optional<parser::ExternalName> external_name);
-
-public: ErrorOr<ByteString> debug_description() const;
-};struct CheckedNamespace {
-  public:
-public: ByteString name;public: ids::ScopeId scope;public: CheckedNamespace(ByteString a_name, ids::ScopeId a_scope);
-
-public: ErrorOr<ByteString> debug_description() const;
-};struct CheckedMatchBody {
-u8 __jakt_variant_index = 0;
-union VariantData {
-u8 __jakt_uninit_value;
-struct {
-NonnullRefPtr<typename types::CheckedExpression> value;
-} Expression;
-struct {
-types::CheckedBlock value;
-} Block;
-constexpr VariantData() {}
-~VariantData() {}
-} as;
-constexpr u8 __jakt_init_index() const noexcept { return __jakt_variant_index - 1; }ErrorOr<ByteString> debug_description() const;
-[[nodiscard]] static CheckedMatchBody Expression(NonnullRefPtr<typename types::CheckedExpression> value);
-[[nodiscard]] static CheckedMatchBody Block(types::CheckedBlock value);
-~CheckedMatchBody();
-CheckedMatchBody& operator=(CheckedMatchBody const &);
-CheckedMatchBody& operator=(CheckedMatchBody &&);
-CheckedMatchBody(CheckedMatchBody const&);
-CheckedMatchBody(CheckedMatchBody &&);
-private: void __jakt_destroy_variant();
-public:
-private:
-CheckedMatchBody() {};
+ValueImpl() {};
 };
 struct CheckedMatchCase {
 u8 __jakt_variant_index = 0;
@@ -1580,12 +1541,51 @@ public:
 private:
 CheckedMatchCase() {};
 };
-struct CheckedVarDecl {
+struct ResolvedForallChunk {
   public:
-public: ByteString name;public: bool is_mutable;public: utility::Span span;public: ids::TypeId type_id;public: CheckedVarDecl(ByteString a_name, bool a_is_mutable, utility::Span a_span, ids::TypeId a_type_id);
+public: JaktInternal::Dictionary<ByteString,JaktInternal::DynamicArray<JaktInternal::Tuple<utility::Span,ids::TypeId>>> parameters;public: parser::ParsedNamespace parsed_namespace;public: JaktInternal::DynamicArray<ids::ScopeId> generated_scopes;public: ResolvedForallChunk(JaktInternal::Dictionary<ByteString,JaktInternal::DynamicArray<JaktInternal::Tuple<utility::Span,ids::TypeId>>> a_parameters, parser::ParsedNamespace a_parsed_namespace, JaktInternal::DynamicArray<ids::ScopeId> a_generated_scopes);
 
 public: ErrorOr<ByteString> debug_description() const;
-};}
+};class TypecheckFunctions :public RefCounted<TypecheckFunctions>, public Weakable<TypecheckFunctions> {
+  public:
+virtual ~TypecheckFunctions() = default;
+public: Function<ErrorOr<types::CheckedBlock>(parser::ParsedBlock, ids::ScopeId, types::SafetyMode, JaktInternal::Optional<ids::TypeId>, JaktInternal::Optional<ids::FunctionId>)> block;public: Function<ErrorOr<ids::FunctionId>(NonnullRefPtr<types::CheckedFunction>)> register_function;public: protected:
+explicit TypecheckFunctions(Function<ErrorOr<types::CheckedBlock>(parser::ParsedBlock, ids::ScopeId, types::SafetyMode, JaktInternal::Optional<ids::TypeId>, JaktInternal::Optional<ids::FunctionId>)> a_block, Function<ErrorOr<ids::FunctionId>(NonnullRefPtr<types::CheckedFunction>)> a_register_function);
+public:
+static ErrorOr<NonnullRefPtr<TypecheckFunctions>> __jakt_create(Function<ErrorOr<types::CheckedBlock>(parser::ParsedBlock, ids::ScopeId, types::SafetyMode, JaktInternal::Optional<ids::TypeId>, JaktInternal::Optional<ids::FunctionId>)> block, Function<ErrorOr<ids::FunctionId>(NonnullRefPtr<types::CheckedFunction>)> register_function);
+
+public: ErrorOr<ByteString> debug_description() const;
+};struct NumericOrStringValue {
+u8 __jakt_variant_index = 0;
+union VariantData {
+u8 __jakt_uninit_value;
+struct {
+ByteString value;
+} StringValue;
+struct {
+i64 value;
+} SignedNumericValue;
+struct {
+u64 value;
+} UnsignedNumericValue;
+constexpr VariantData() {}
+~VariantData() {}
+} as;
+constexpr u8 __jakt_init_index() const noexcept { return __jakt_variant_index - 1; }ErrorOr<ByteString> debug_description() const;
+[[nodiscard]] static NumericOrStringValue StringValue(ByteString value);
+[[nodiscard]] static NumericOrStringValue SignedNumericValue(i64 value);
+[[nodiscard]] static NumericOrStringValue UnsignedNumericValue(u64 value);
+~NumericOrStringValue();
+NumericOrStringValue& operator=(NumericOrStringValue const &);
+NumericOrStringValue& operator=(NumericOrStringValue &&);
+NumericOrStringValue(NumericOrStringValue const&);
+NumericOrStringValue(NumericOrStringValue &&);
+private: void __jakt_destroy_variant();
+public:
+private:
+NumericOrStringValue() {};
+};
+}
 } // namespace Jakt
 template<>struct Jakt::Formatter<Jakt::types::BlockControlFlow> : Jakt::Formatter<Jakt::StringView>{
 Jakt::ErrorOr<void> format(Jakt::FormatBuilder& builder, Jakt::types::BlockControlFlow const& value) {
@@ -1599,32 +1599,38 @@ JaktInternal::PrettyPrint::ScopedEnable pretty_print_enable { m_alternative_form
 };
 namespace Jakt {
 } // namespace Jakt
-template<>struct Jakt::Formatter<Jakt::types::BuiltinType> : Jakt::Formatter<Jakt::StringView>{
-Jakt::ErrorOr<void> format(Jakt::FormatBuilder& builder, Jakt::types::BuiltinType const& value) {
+template<>struct Jakt::Formatter<Jakt::types::CheckedMatchBody> : Jakt::Formatter<Jakt::StringView>{
+Jakt::ErrorOr<void> format(Jakt::FormatBuilder& builder, Jakt::types::CheckedMatchBody const& value) {
 JaktInternal::PrettyPrint::ScopedEnable pretty_print_enable { m_alternative_form };Jakt::ErrorOr<void> format_error = Jakt::Formatter<Jakt::StringView>::format(builder, MUST(value.debug_description()));return format_error;}
 };
 namespace Jakt {
 } // namespace Jakt
-template<>struct Jakt::Formatter<Jakt::types::CheckedVisibility> : Jakt::Formatter<Jakt::StringView>{
-Jakt::ErrorOr<void> format(Jakt::FormatBuilder& builder, Jakt::types::CheckedVisibility const& value) {
+template<>struct Jakt::Formatter<Jakt::types::FunctionGenericParameterKind> : Jakt::Formatter<Jakt::StringView>{
+Jakt::ErrorOr<void> format(Jakt::FormatBuilder& builder, Jakt::types::FunctionGenericParameterKind const& value) {
 JaktInternal::PrettyPrint::ScopedEnable pretty_print_enable { m_alternative_form };Jakt::ErrorOr<void> format_error = Jakt::Formatter<Jakt::StringView>::format(builder, MUST(value.debug_description()));return format_error;}
 };
 namespace Jakt {
 } // namespace Jakt
-template<>struct Jakt::Formatter<Jakt::types::NumericOrStringValue> : Jakt::Formatter<Jakt::StringView>{
-Jakt::ErrorOr<void> format(Jakt::FormatBuilder& builder, Jakt::types::NumericOrStringValue const& value) {
+template<>struct Jakt::Formatter<Jakt::types::CheckedGenericParameter> : Jakt::Formatter<Jakt::StringView>{
+Jakt::ErrorOr<void> format(Jakt::FormatBuilder& builder, Jakt::types::CheckedGenericParameter const& value) {
 JaktInternal::PrettyPrint::ScopedEnable pretty_print_enable { m_alternative_form };Jakt::ErrorOr<void> format_error = Jakt::Formatter<Jakt::StringView>::format(builder, MUST(value.debug_description()));return format_error;}
 };
 namespace Jakt {
 } // namespace Jakt
-template<>struct Jakt::Formatter<Jakt::types::CheckedStruct> : Jakt::Formatter<Jakt::StringView>{
-Jakt::ErrorOr<void> format(Jakt::FormatBuilder& builder, Jakt::types::CheckedStruct const& value) {
+template<>struct Jakt::Formatter<Jakt::types::FunctionGenericParameter> : Jakt::Formatter<Jakt::StringView>{
+Jakt::ErrorOr<void> format(Jakt::FormatBuilder& builder, Jakt::types::FunctionGenericParameter const& value) {
 JaktInternal::PrettyPrint::ScopedEnable pretty_print_enable { m_alternative_form };Jakt::ErrorOr<void> format_error = Jakt::Formatter<Jakt::StringView>::format(builder, MUST(value.debug_description()));return format_error;}
 };
 namespace Jakt {
 } // namespace Jakt
-template<>struct Jakt::Formatter<Jakt::types::CheckedNumericConstant> : Jakt::Formatter<Jakt::StringView>{
-Jakt::ErrorOr<void> format(Jakt::FormatBuilder& builder, Jakt::types::CheckedNumericConstant const& value) {
+template<>struct Jakt::Formatter<Jakt::types::NumberConstant> : Jakt::Formatter<Jakt::StringView>{
+Jakt::ErrorOr<void> format(Jakt::FormatBuilder& builder, Jakt::types::NumberConstant const& value) {
+JaktInternal::PrettyPrint::ScopedEnable pretty_print_enable { m_alternative_form };Jakt::ErrorOr<void> format_error = Jakt::Formatter<Jakt::StringView>::format(builder, MUST(value.debug_description()));return format_error;}
+};
+namespace Jakt {
+} // namespace Jakt
+template<>struct Jakt::Formatter<Jakt::types::ClassInstanceRebind> : Jakt::Formatter<Jakt::StringView>{
+Jakt::ErrorOr<void> format(Jakt::FormatBuilder& builder, Jakt::types::ClassInstanceRebind const& value) {
 JaktInternal::PrettyPrint::ScopedEnable pretty_print_enable { m_alternative_form };Jakt::ErrorOr<void> format_error = Jakt::Formatter<Jakt::StringView>::format(builder, MUST(value.debug_description()));return format_error;}
 };
 namespace Jakt {
@@ -1647,62 +1653,8 @@ JaktInternal::PrettyPrint::ScopedEnable pretty_print_enable { m_alternative_form
 };
 namespace Jakt {
 } // namespace Jakt
-template<>struct Jakt::Formatter<Jakt::types::StructLikeId> : Jakt::Formatter<Jakt::StringView>{
-Jakt::ErrorOr<void> format(Jakt::FormatBuilder& builder, Jakt::types::StructLikeId const& value) {
-JaktInternal::PrettyPrint::ScopedEnable pretty_print_enable { m_alternative_form };Jakt::ErrorOr<void> format_error = Jakt::Formatter<Jakt::StringView>::format(builder, MUST(value.debug_description()));return format_error;}
-};
-namespace Jakt {
-} // namespace Jakt
-template<>struct Jakt::Formatter<Jakt::types::CheckedProgram> : Jakt::Formatter<Jakt::StringView>{
-Jakt::ErrorOr<void> format(Jakt::FormatBuilder& builder, Jakt::types::CheckedProgram const& value) {
-JaktInternal::PrettyPrint::ScopedEnable pretty_print_enable { m_alternative_form };Jakt::ErrorOr<void> format_error = Jakt::Formatter<Jakt::StringView>::format(builder, MUST(value.debug_description()));return format_error;}
-};
-namespace Jakt {
-} // namespace Jakt
-template<>struct Jakt::Formatter<Jakt::types::CheckedField> : Jakt::Formatter<Jakt::StringView>{
-Jakt::ErrorOr<void> format(Jakt::FormatBuilder& builder, Jakt::types::CheckedField const& value) {
-JaktInternal::PrettyPrint::ScopedEnable pretty_print_enable { m_alternative_form };Jakt::ErrorOr<void> format_error = Jakt::Formatter<Jakt::StringView>::format(builder, MUST(value.debug_description()));return format_error;}
-};
-namespace Jakt {
-} // namespace Jakt
-template<>struct Jakt::Formatter<Jakt::types::CheckedEnumVariant> : Jakt::Formatter<Jakt::StringView>{
-Jakt::ErrorOr<void> format(Jakt::FormatBuilder& builder, Jakt::types::CheckedEnumVariant const& value) {
-JaktInternal::PrettyPrint::ScopedEnable pretty_print_enable { m_alternative_form };Jakt::ErrorOr<void> format_error = Jakt::Formatter<Jakt::StringView>::format(builder, MUST(value.debug_description()));return format_error;}
-};
-namespace Jakt {
-} // namespace Jakt
-template<>struct Jakt::Formatter<Jakt::types::CheckedTypeCast> : Jakt::Formatter<Jakt::StringView>{
-Jakt::ErrorOr<void> format(Jakt::FormatBuilder& builder, Jakt::types::CheckedTypeCast const& value) {
-JaktInternal::PrettyPrint::ScopedEnable pretty_print_enable { m_alternative_form };Jakt::ErrorOr<void> format_error = Jakt::Formatter<Jakt::StringView>::format(builder, MUST(value.debug_description()));return format_error;}
-};
-namespace Jakt {
-} // namespace Jakt
-template<>struct Jakt::Formatter<Jakt::types::CheckedUnaryOperator> : Jakt::Formatter<Jakt::StringView>{
-Jakt::ErrorOr<void> format(Jakt::FormatBuilder& builder, Jakt::types::CheckedUnaryOperator const& value) {
-JaktInternal::PrettyPrint::ScopedEnable pretty_print_enable { m_alternative_form };Jakt::ErrorOr<void> format_error = Jakt::Formatter<Jakt::StringView>::format(builder, MUST(value.debug_description()));return format_error;}
-};
-namespace Jakt {
-} // namespace Jakt
-template<>struct Jakt::Formatter<Jakt::types::FunctionGenericParameterKind> : Jakt::Formatter<Jakt::StringView>{
-Jakt::ErrorOr<void> format(Jakt::FormatBuilder& builder, Jakt::types::FunctionGenericParameterKind const& value) {
-JaktInternal::PrettyPrint::ScopedEnable pretty_print_enable { m_alternative_form };Jakt::ErrorOr<void> format_error = Jakt::Formatter<Jakt::StringView>::format(builder, MUST(value.debug_description()));return format_error;}
-};
-namespace Jakt {
-} // namespace Jakt
-template<>struct Jakt::Formatter<Jakt::types::LoadedModule> : Jakt::Formatter<Jakt::StringView>{
-Jakt::ErrorOr<void> format(Jakt::FormatBuilder& builder, Jakt::types::LoadedModule const& value) {
-JaktInternal::PrettyPrint::ScopedEnable pretty_print_enable { m_alternative_form };Jakt::ErrorOr<void> format_error = Jakt::Formatter<Jakt::StringView>::format(builder, MUST(value.debug_description()));return format_error;}
-};
-namespace Jakt {
-} // namespace Jakt
-template<>struct Jakt::Formatter<Jakt::types::CheckedGenericParameter> : Jakt::Formatter<Jakt::StringView>{
-Jakt::ErrorOr<void> format(Jakt::FormatBuilder& builder, Jakt::types::CheckedGenericParameter const& value) {
-JaktInternal::PrettyPrint::ScopedEnable pretty_print_enable { m_alternative_form };Jakt::ErrorOr<void> format_error = Jakt::Formatter<Jakt::StringView>::format(builder, MUST(value.debug_description()));return format_error;}
-};
-namespace Jakt {
-} // namespace Jakt
-template<>struct Jakt::Formatter<Jakt::types::ResolvedForallChunk> : Jakt::Formatter<Jakt::StringView>{
-Jakt::ErrorOr<void> format(Jakt::FormatBuilder& builder, Jakt::types::ResolvedForallChunk const& value) {
+template<>struct Jakt::Formatter<Jakt::types::Module> : Jakt::Formatter<Jakt::StringView>{
+Jakt::ErrorOr<void> format(Jakt::FormatBuilder& builder, Jakt::types::Module const& value) {
 JaktInternal::PrettyPrint::ScopedEnable pretty_print_enable { m_alternative_form };Jakt::ErrorOr<void> format_error = Jakt::Formatter<Jakt::StringView>::format(builder, MUST(value.debug_description()));return format_error;}
 };
 namespace Jakt {
@@ -1713,38 +1665,38 @@ JaktInternal::PrettyPrint::ScopedEnable pretty_print_enable { m_alternative_form
 };
 namespace Jakt {
 } // namespace Jakt
-template<>struct Jakt::Formatter<Jakt::types::FieldRecord> : Jakt::Formatter<Jakt::StringView>{
-Jakt::ErrorOr<void> format(Jakt::FormatBuilder& builder, Jakt::types::FieldRecord const& value) {
+template<>struct Jakt::Formatter<Jakt::types::CheckedTypeCast> : Jakt::Formatter<Jakt::StringView>{
+Jakt::ErrorOr<void> format(Jakt::FormatBuilder& builder, Jakt::types::CheckedTypeCast const& value) {
 JaktInternal::PrettyPrint::ScopedEnable pretty_print_enable { m_alternative_form };Jakt::ErrorOr<void> format_error = Jakt::Formatter<Jakt::StringView>::format(builder, MUST(value.debug_description()));return format_error;}
 };
 namespace Jakt {
 } // namespace Jakt
-template<>struct Jakt::Formatter<Jakt::types::Type> : Jakt::Formatter<Jakt::StringView>{
-Jakt::ErrorOr<void> format(Jakt::FormatBuilder& builder, Jakt::types::Type const& value) {
+template<>struct Jakt::Formatter<Jakt::types::CheckedEnumVariant> : Jakt::Formatter<Jakt::StringView>{
+Jakt::ErrorOr<void> format(Jakt::FormatBuilder& builder, Jakt::types::CheckedEnumVariant const& value) {
 JaktInternal::PrettyPrint::ScopedEnable pretty_print_enable { m_alternative_form };Jakt::ErrorOr<void> format_error = Jakt::Formatter<Jakt::StringView>::format(builder, MUST(value.debug_description()));return format_error;}
 };
 namespace Jakt {
 } // namespace Jakt
-template<>struct Jakt::Formatter<Jakt::types::Scope> : Jakt::Formatter<Jakt::StringView>{
-Jakt::ErrorOr<void> format(Jakt::FormatBuilder& builder, Jakt::types::Scope const& value) {
+template<>struct Jakt::Formatter<Jakt::types::CheckedUnaryOperator> : Jakt::Formatter<Jakt::StringView>{
+Jakt::ErrorOr<void> format(Jakt::FormatBuilder& builder, Jakt::types::CheckedUnaryOperator const& value) {
 JaktInternal::PrettyPrint::ScopedEnable pretty_print_enable { m_alternative_form };Jakt::ErrorOr<void> format_error = Jakt::Formatter<Jakt::StringView>::format(builder, MUST(value.debug_description()));return format_error;}
 };
 namespace Jakt {
 } // namespace Jakt
-template<>struct Jakt::Formatter<Jakt::types::ValueImpl> : Jakt::Formatter<Jakt::StringView>{
-Jakt::ErrorOr<void> format(Jakt::FormatBuilder& builder, Jakt::types::ValueImpl const& value) {
+template<>struct Jakt::Formatter<Jakt::types::MaybeResolvedScope> : Jakt::Formatter<Jakt::StringView>{
+Jakt::ErrorOr<void> format(Jakt::FormatBuilder& builder, Jakt::types::MaybeResolvedScope const& value) {
 JaktInternal::PrettyPrint::ScopedEnable pretty_print_enable { m_alternative_form };Jakt::ErrorOr<void> format_error = Jakt::Formatter<Jakt::StringView>::format(builder, MUST(value.debug_description()));return format_error;}
 };
 namespace Jakt {
 } // namespace Jakt
-template<>struct Jakt::Formatter<Jakt::types::StructOrEnumId> : Jakt::Formatter<Jakt::StringView>{
-Jakt::ErrorOr<void> format(Jakt::FormatBuilder& builder, Jakt::types::StructOrEnumId const& value) {
+template<>struct Jakt::Formatter<Jakt::types::CheckedCapture> : Jakt::Formatter<Jakt::StringView>{
+Jakt::ErrorOr<void> format(Jakt::FormatBuilder& builder, Jakt::types::CheckedCapture const& value) {
 JaktInternal::PrettyPrint::ScopedEnable pretty_print_enable { m_alternative_form };Jakt::ErrorOr<void> format_error = Jakt::Formatter<Jakt::StringView>::format(builder, MUST(value.debug_description()));return format_error;}
 };
 namespace Jakt {
 } // namespace Jakt
-template<>struct Jakt::Formatter<Jakt::types::CheckedStatement> : Jakt::Formatter<Jakt::StringView>{
-Jakt::ErrorOr<void> format(Jakt::FormatBuilder& builder, Jakt::types::CheckedStatement const& value) {
+template<>struct Jakt::Formatter<Jakt::types::CheckedField> : Jakt::Formatter<Jakt::StringView>{
+Jakt::ErrorOr<void> format(Jakt::FormatBuilder& builder, Jakt::types::CheckedField const& value) {
 JaktInternal::PrettyPrint::ScopedEnable pretty_print_enable { m_alternative_form };Jakt::ErrorOr<void> format_error = Jakt::Formatter<Jakt::StringView>::format(builder, MUST(value.debug_description()));return format_error;}
 };
 namespace Jakt {
@@ -1755,26 +1707,80 @@ JaktInternal::PrettyPrint::ScopedEnable pretty_print_enable { m_alternative_form
 };
 namespace Jakt {
 } // namespace Jakt
-template<>struct Jakt::Formatter<Jakt::types::NumberConstant> : Jakt::Formatter<Jakt::StringView>{
-Jakt::ErrorOr<void> format(Jakt::FormatBuilder& builder, Jakt::types::NumberConstant const& value) {
-JaktInternal::PrettyPrint::ScopedEnable pretty_print_enable { m_alternative_form };Jakt::ErrorOr<void> format_error = Jakt::Formatter<Jakt::StringView>::format(builder, MUST(value.debug_description()));return format_error;}
-};
-namespace Jakt {
-} // namespace Jakt
 template<>struct Jakt::Formatter<Jakt::types::CheckedTraitRequirements> : Jakt::Formatter<Jakt::StringView>{
 Jakt::ErrorOr<void> format(Jakt::FormatBuilder& builder, Jakt::types::CheckedTraitRequirements const& value) {
 JaktInternal::PrettyPrint::ScopedEnable pretty_print_enable { m_alternative_form };Jakt::ErrorOr<void> format_error = Jakt::Formatter<Jakt::StringView>::format(builder, MUST(value.debug_description()));return format_error;}
 };
 namespace Jakt {
 } // namespace Jakt
-template<>struct Jakt::Formatter<Jakt::types::CheckedEnum> : Jakt::Formatter<Jakt::StringView>{
-Jakt::ErrorOr<void> format(Jakt::FormatBuilder& builder, Jakt::types::CheckedEnum const& value) {
+template<>struct Jakt::Formatter<Jakt::types::Scope> : Jakt::Formatter<Jakt::StringView>{
+Jakt::ErrorOr<void> format(Jakt::FormatBuilder& builder, Jakt::types::Scope const& value) {
 JaktInternal::PrettyPrint::ScopedEnable pretty_print_enable { m_alternative_form };Jakt::ErrorOr<void> format_error = Jakt::Formatter<Jakt::StringView>::format(builder, MUST(value.debug_description()));return format_error;}
 };
 namespace Jakt {
 } // namespace Jakt
-template<>struct Jakt::Formatter<Jakt::types::ClassInstanceRebind> : Jakt::Formatter<Jakt::StringView>{
-Jakt::ErrorOr<void> format(Jakt::FormatBuilder& builder, Jakt::types::ClassInstanceRebind const& value) {
+template<>struct Jakt::Formatter<Jakt::types::FunctionGenerics> : Jakt::Formatter<Jakt::StringView>{
+Jakt::ErrorOr<void> format(Jakt::FormatBuilder& builder, Jakt::types::FunctionGenerics const& value) {
+JaktInternal::PrettyPrint::ScopedEnable pretty_print_enable { m_alternative_form };Jakt::ErrorOr<void> format_error = Jakt::Formatter<Jakt::StringView>::format(builder, MUST(value.debug_description()));return format_error;}
+};
+namespace Jakt {
+} // namespace Jakt
+template<>struct Jakt::Formatter<Jakt::types::CheckedVarDecl> : Jakt::Formatter<Jakt::StringView>{
+Jakt::ErrorOr<void> format(Jakt::FormatBuilder& builder, Jakt::types::CheckedVarDecl const& value) {
+JaktInternal::PrettyPrint::ScopedEnable pretty_print_enable { m_alternative_form };Jakt::ErrorOr<void> format_error = Jakt::Formatter<Jakt::StringView>::format(builder, MUST(value.debug_description()));return format_error;}
+};
+namespace Jakt {
+} // namespace Jakt
+template<>struct Jakt::Formatter<Jakt::types::StructLikeId> : Jakt::Formatter<Jakt::StringView>{
+Jakt::ErrorOr<void> format(Jakt::FormatBuilder& builder, Jakt::types::StructLikeId const& value) {
+JaktInternal::PrettyPrint::ScopedEnable pretty_print_enable { m_alternative_form };Jakt::ErrorOr<void> format_error = Jakt::Formatter<Jakt::StringView>::format(builder, MUST(value.debug_description()));return format_error;}
+};
+namespace Jakt {
+} // namespace Jakt
+template<>struct Jakt::Formatter<Jakt::types::CheckedNumericConstant> : Jakt::Formatter<Jakt::StringView>{
+Jakt::ErrorOr<void> format(Jakt::FormatBuilder& builder, Jakt::types::CheckedNumericConstant const& value) {
+JaktInternal::PrettyPrint::ScopedEnable pretty_print_enable { m_alternative_form };Jakt::ErrorOr<void> format_error = Jakt::Formatter<Jakt::StringView>::format(builder, MUST(value.debug_description()));return format_error;}
+};
+namespace Jakt {
+} // namespace Jakt
+template<>struct Jakt::Formatter<Jakt::types::SafetyMode> : Jakt::Formatter<Jakt::StringView>{
+Jakt::ErrorOr<void> format(Jakt::FormatBuilder& builder, Jakt::types::SafetyMode const& value) {
+JaktInternal::PrettyPrint::ScopedEnable pretty_print_enable { m_alternative_form };Jakt::ErrorOr<void> format_error = Jakt::Formatter<Jakt::StringView>::format(builder, MUST(value.debug_description()));return format_error;}
+};
+namespace Jakt {
+} // namespace Jakt
+template<>struct Jakt::Formatter<Jakt::types::CheckedVisibility> : Jakt::Formatter<Jakt::StringView>{
+Jakt::ErrorOr<void> format(Jakt::FormatBuilder& builder, Jakt::types::CheckedVisibility const& value) {
+JaktInternal::PrettyPrint::ScopedEnable pretty_print_enable { m_alternative_form };Jakt::ErrorOr<void> format_error = Jakt::Formatter<Jakt::StringView>::format(builder, MUST(value.debug_description()));return format_error;}
+};
+namespace Jakt {
+} // namespace Jakt
+template<>struct Jakt::Formatter<Jakt::types::CheckedVariable> : Jakt::Formatter<Jakt::StringView>{
+Jakt::ErrorOr<void> format(Jakt::FormatBuilder& builder, Jakt::types::CheckedVariable const& value) {
+JaktInternal::PrettyPrint::ScopedEnable pretty_print_enable { m_alternative_form };Jakt::ErrorOr<void> format_error = Jakt::Formatter<Jakt::StringView>::format(builder, MUST(value.debug_description()));return format_error;}
+};
+namespace Jakt {
+} // namespace Jakt
+template<>struct Jakt::Formatter<Jakt::types::CheckedParameter> : Jakt::Formatter<Jakt::StringView>{
+Jakt::ErrorOr<void> format(Jakt::FormatBuilder& builder, Jakt::types::CheckedParameter const& value) {
+JaktInternal::PrettyPrint::ScopedEnable pretty_print_enable { m_alternative_form };Jakt::ErrorOr<void> format_error = Jakt::Formatter<Jakt::StringView>::format(builder, MUST(value.debug_description()));return format_error;}
+};
+namespace Jakt {
+} // namespace Jakt
+template<>struct Jakt::Formatter<Jakt::types::FieldRecord> : Jakt::Formatter<Jakt::StringView>{
+Jakt::ErrorOr<void> format(Jakt::FormatBuilder& builder, Jakt::types::FieldRecord const& value) {
+JaktInternal::PrettyPrint::ScopedEnable pretty_print_enable { m_alternative_form };Jakt::ErrorOr<void> format_error = Jakt::Formatter<Jakt::StringView>::format(builder, MUST(value.debug_description()));return format_error;}
+};
+namespace Jakt {
+} // namespace Jakt
+template<>struct Jakt::Formatter<Jakt::types::CheckedFunction> : Jakt::Formatter<Jakt::StringView>{
+Jakt::ErrorOr<void> format(Jakt::FormatBuilder& builder, Jakt::types::CheckedFunction const& value) {
+JaktInternal::PrettyPrint::ScopedEnable pretty_print_enable { m_alternative_form };Jakt::ErrorOr<void> format_error = Jakt::Formatter<Jakt::StringView>::format(builder, MUST(value.debug_description()));return format_error;}
+};
+namespace Jakt {
+} // namespace Jakt
+template<>struct Jakt::Formatter<Jakt::types::CheckedEnum> : Jakt::Formatter<Jakt::StringView>{
+Jakt::ErrorOr<void> format(Jakt::FormatBuilder& builder, Jakt::types::CheckedEnum const& value) {
 JaktInternal::PrettyPrint::ScopedEnable pretty_print_enable { m_alternative_form };Jakt::ErrorOr<void> format_error = Jakt::Formatter<Jakt::StringView>::format(builder, MUST(value.debug_description()));return format_error;}
 };
 namespace Jakt {
@@ -1791,14 +1797,62 @@ JaktInternal::PrettyPrint::ScopedEnable pretty_print_enable { m_alternative_form
 };
 namespace Jakt {
 } // namespace Jakt
-template<>struct Jakt::Formatter<Jakt::types::FunctionGenericParameter> : Jakt::Formatter<Jakt::StringView>{
-Jakt::ErrorOr<void> format(Jakt::FormatBuilder& builder, Jakt::types::FunctionGenericParameter const& value) {
+template<>struct Jakt::Formatter<Jakt::types::ResolvedNamespace> : Jakt::Formatter<Jakt::StringView>{
+Jakt::ErrorOr<void> format(Jakt::FormatBuilder& builder, Jakt::types::ResolvedNamespace const& value) {
+JaktInternal::PrettyPrint::ScopedEnable pretty_print_enable { m_alternative_form };Jakt::ErrorOr<void> format_error = Jakt::Formatter<Jakt::StringView>::format(builder, MUST(value.debug_description()));return format_error;}
+};
+namespace Jakt {
+} // namespace Jakt
+template<>struct Jakt::Formatter<Jakt::types::Type> : Jakt::Formatter<Jakt::StringView>{
+Jakt::ErrorOr<void> format(Jakt::FormatBuilder& builder, Jakt::types::Type const& value) {
+JaktInternal::PrettyPrint::ScopedEnable pretty_print_enable { m_alternative_form };Jakt::ErrorOr<void> format_error = Jakt::Formatter<Jakt::StringView>::format(builder, MUST(value.debug_description()));return format_error;}
+};
+namespace Jakt {
+} // namespace Jakt
+template<>struct Jakt::Formatter<Jakt::types::CheckedStruct> : Jakt::Formatter<Jakt::StringView>{
+Jakt::ErrorOr<void> format(Jakt::FormatBuilder& builder, Jakt::types::CheckedStruct const& value) {
+JaktInternal::PrettyPrint::ScopedEnable pretty_print_enable { m_alternative_form };Jakt::ErrorOr<void> format_error = Jakt::Formatter<Jakt::StringView>::format(builder, MUST(value.debug_description()));return format_error;}
+};
+namespace Jakt {
+} // namespace Jakt
+template<>struct Jakt::Formatter<Jakt::types::CheckedNamespace> : Jakt::Formatter<Jakt::StringView>{
+Jakt::ErrorOr<void> format(Jakt::FormatBuilder& builder, Jakt::types::CheckedNamespace const& value) {
+JaktInternal::PrettyPrint::ScopedEnable pretty_print_enable { m_alternative_form };Jakt::ErrorOr<void> format_error = Jakt::Formatter<Jakt::StringView>::format(builder, MUST(value.debug_description()));return format_error;}
+};
+namespace Jakt {
+} // namespace Jakt
+template<>struct Jakt::Formatter<Jakt::types::LoadedModule> : Jakt::Formatter<Jakt::StringView>{
+Jakt::ErrorOr<void> format(Jakt::FormatBuilder& builder, Jakt::types::LoadedModule const& value) {
+JaktInternal::PrettyPrint::ScopedEnable pretty_print_enable { m_alternative_form };Jakt::ErrorOr<void> format_error = Jakt::Formatter<Jakt::StringView>::format(builder, MUST(value.debug_description()));return format_error;}
+};
+namespace Jakt {
+} // namespace Jakt
+template<>struct Jakt::Formatter<Jakt::types::CheckedStatement> : Jakt::Formatter<Jakt::StringView>{
+Jakt::ErrorOr<void> format(Jakt::FormatBuilder& builder, Jakt::types::CheckedStatement const& value) {
+JaktInternal::PrettyPrint::ScopedEnable pretty_print_enable { m_alternative_form };Jakt::ErrorOr<void> format_error = Jakt::Formatter<Jakt::StringView>::format(builder, MUST(value.debug_description()));return format_error;}
+};
+namespace Jakt {
+} // namespace Jakt
+template<>struct Jakt::Formatter<Jakt::types::SpecializedType> : Jakt::Formatter<Jakt::StringView>{
+Jakt::ErrorOr<void> format(Jakt::FormatBuilder& builder, Jakt::types::SpecializedType const& value) {
 JaktInternal::PrettyPrint::ScopedEnable pretty_print_enable { m_alternative_form };Jakt::ErrorOr<void> format_error = Jakt::Formatter<Jakt::StringView>::format(builder, MUST(value.debug_description()));return format_error;}
 };
 namespace Jakt {
 } // namespace Jakt
 template<>struct Jakt::Formatter<Jakt::types::CheckedTrait> : Jakt::Formatter<Jakt::StringView>{
 Jakt::ErrorOr<void> format(Jakt::FormatBuilder& builder, Jakt::types::CheckedTrait const& value) {
+JaktInternal::PrettyPrint::ScopedEnable pretty_print_enable { m_alternative_form };Jakt::ErrorOr<void> format_error = Jakt::Formatter<Jakt::StringView>::format(builder, MUST(value.debug_description()));return format_error;}
+};
+namespace Jakt {
+} // namespace Jakt
+template<>struct Jakt::Formatter<Jakt::types::BuiltinType> : Jakt::Formatter<Jakt::StringView>{
+Jakt::ErrorOr<void> format(Jakt::FormatBuilder& builder, Jakt::types::BuiltinType const& value) {
+JaktInternal::PrettyPrint::ScopedEnable pretty_print_enable { m_alternative_form };Jakt::ErrorOr<void> format_error = Jakt::Formatter<Jakt::StringView>::format(builder, MUST(value.debug_description()));return format_error;}
+};
+namespace Jakt {
+} // namespace Jakt
+template<>struct Jakt::Formatter<Jakt::types::StructOrEnumId> : Jakt::Formatter<Jakt::StringView>{
+Jakt::ErrorOr<void> format(Jakt::FormatBuilder& builder, Jakt::types::StructOrEnumId const& value) {
 JaktInternal::PrettyPrint::ScopedEnable pretty_print_enable { m_alternative_form };Jakt::ErrorOr<void> format_error = Jakt::Formatter<Jakt::StringView>::format(builder, MUST(value.debug_description()));return format_error;}
 };
 namespace Jakt {
@@ -1815,80 +1869,14 @@ JaktInternal::PrettyPrint::ScopedEnable pretty_print_enable { m_alternative_form
 };
 namespace Jakt {
 } // namespace Jakt
-template<>struct Jakt::Formatter<Jakt::types::CheckedParameter> : Jakt::Formatter<Jakt::StringView>{
-Jakt::ErrorOr<void> format(Jakt::FormatBuilder& builder, Jakt::types::CheckedParameter const& value) {
+template<>struct Jakt::Formatter<Jakt::types::CheckedProgram> : Jakt::Formatter<Jakt::StringView>{
+Jakt::ErrorOr<void> format(Jakt::FormatBuilder& builder, Jakt::types::CheckedProgram const& value) {
 JaktInternal::PrettyPrint::ScopedEnable pretty_print_enable { m_alternative_form };Jakt::ErrorOr<void> format_error = Jakt::Formatter<Jakt::StringView>::format(builder, MUST(value.debug_description()));return format_error;}
 };
 namespace Jakt {
 } // namespace Jakt
-template<>struct Jakt::Formatter<Jakt::types::SafetyMode> : Jakt::Formatter<Jakt::StringView>{
-Jakt::ErrorOr<void> format(Jakt::FormatBuilder& builder, Jakt::types::SafetyMode const& value) {
-JaktInternal::PrettyPrint::ScopedEnable pretty_print_enable { m_alternative_form };Jakt::ErrorOr<void> format_error = Jakt::Formatter<Jakt::StringView>::format(builder, MUST(value.debug_description()));return format_error;}
-};
-namespace Jakt {
-} // namespace Jakt
-template<>struct Jakt::Formatter<Jakt::types::SpecializedType> : Jakt::Formatter<Jakt::StringView>{
-Jakt::ErrorOr<void> format(Jakt::FormatBuilder& builder, Jakt::types::SpecializedType const& value) {
-JaktInternal::PrettyPrint::ScopedEnable pretty_print_enable { m_alternative_form };Jakt::ErrorOr<void> format_error = Jakt::Formatter<Jakt::StringView>::format(builder, MUST(value.debug_description()));return format_error;}
-};
-namespace Jakt {
-} // namespace Jakt
-template<>struct Jakt::Formatter<Jakt::types::TypecheckFunctions> : Jakt::Formatter<Jakt::StringView>{
-Jakt::ErrorOr<void> format(Jakt::FormatBuilder& builder, Jakt::types::TypecheckFunctions const& value) {
-JaktInternal::PrettyPrint::ScopedEnable pretty_print_enable { m_alternative_form };Jakt::ErrorOr<void> format_error = Jakt::Formatter<Jakt::StringView>::format(builder, MUST(value.debug_description()));return format_error;}
-};
-namespace Jakt {
-} // namespace Jakt
-template<>struct Jakt::Formatter<Jakt::types::CheckedFunction> : Jakt::Formatter<Jakt::StringView>{
-Jakt::ErrorOr<void> format(Jakt::FormatBuilder& builder, Jakt::types::CheckedFunction const& value) {
-JaktInternal::PrettyPrint::ScopedEnable pretty_print_enable { m_alternative_form };Jakt::ErrorOr<void> format_error = Jakt::Formatter<Jakt::StringView>::format(builder, MUST(value.debug_description()));return format_error;}
-};
-namespace Jakt {
-} // namespace Jakt
-template<>struct Jakt::Formatter<Jakt::types::CheckedCapture> : Jakt::Formatter<Jakt::StringView>{
-Jakt::ErrorOr<void> format(Jakt::FormatBuilder& builder, Jakt::types::CheckedCapture const& value) {
-JaktInternal::PrettyPrint::ScopedEnable pretty_print_enable { m_alternative_form };Jakt::ErrorOr<void> format_error = Jakt::Formatter<Jakt::StringView>::format(builder, MUST(value.debug_description()));return format_error;}
-};
-namespace Jakt {
-} // namespace Jakt
-template<>struct Jakt::Formatter<Jakt::types::ResolvedNamespace> : Jakt::Formatter<Jakt::StringView>{
-Jakt::ErrorOr<void> format(Jakt::FormatBuilder& builder, Jakt::types::ResolvedNamespace const& value) {
-JaktInternal::PrettyPrint::ScopedEnable pretty_print_enable { m_alternative_form };Jakt::ErrorOr<void> format_error = Jakt::Formatter<Jakt::StringView>::format(builder, MUST(value.debug_description()));return format_error;}
-};
-namespace Jakt {
-} // namespace Jakt
-template<>struct Jakt::Formatter<Jakt::types::MaybeResolvedScope> : Jakt::Formatter<Jakt::StringView>{
-Jakt::ErrorOr<void> format(Jakt::FormatBuilder& builder, Jakt::types::MaybeResolvedScope const& value) {
-JaktInternal::PrettyPrint::ScopedEnable pretty_print_enable { m_alternative_form };Jakt::ErrorOr<void> format_error = Jakt::Formatter<Jakt::StringView>::format(builder, MUST(value.debug_description()));return format_error;}
-};
-namespace Jakt {
-} // namespace Jakt
-template<>struct Jakt::Formatter<Jakt::types::FunctionGenerics> : Jakt::Formatter<Jakt::StringView>{
-Jakt::ErrorOr<void> format(Jakt::FormatBuilder& builder, Jakt::types::FunctionGenerics const& value) {
-JaktInternal::PrettyPrint::ScopedEnable pretty_print_enable { m_alternative_form };Jakt::ErrorOr<void> format_error = Jakt::Formatter<Jakt::StringView>::format(builder, MUST(value.debug_description()));return format_error;}
-};
-namespace Jakt {
-} // namespace Jakt
-template<>struct Jakt::Formatter<Jakt::types::Module> : Jakt::Formatter<Jakt::StringView>{
-Jakt::ErrorOr<void> format(Jakt::FormatBuilder& builder, Jakt::types::Module const& value) {
-JaktInternal::PrettyPrint::ScopedEnable pretty_print_enable { m_alternative_form };Jakt::ErrorOr<void> format_error = Jakt::Formatter<Jakt::StringView>::format(builder, MUST(value.debug_description()));return format_error;}
-};
-namespace Jakt {
-} // namespace Jakt
-template<>struct Jakt::Formatter<Jakt::types::CheckedVariable> : Jakt::Formatter<Jakt::StringView>{
-Jakt::ErrorOr<void> format(Jakt::FormatBuilder& builder, Jakt::types::CheckedVariable const& value) {
-JaktInternal::PrettyPrint::ScopedEnable pretty_print_enable { m_alternative_form };Jakt::ErrorOr<void> format_error = Jakt::Formatter<Jakt::StringView>::format(builder, MUST(value.debug_description()));return format_error;}
-};
-namespace Jakt {
-} // namespace Jakt
-template<>struct Jakt::Formatter<Jakt::types::CheckedNamespace> : Jakt::Formatter<Jakt::StringView>{
-Jakt::ErrorOr<void> format(Jakt::FormatBuilder& builder, Jakt::types::CheckedNamespace const& value) {
-JaktInternal::PrettyPrint::ScopedEnable pretty_print_enable { m_alternative_form };Jakt::ErrorOr<void> format_error = Jakt::Formatter<Jakt::StringView>::format(builder, MUST(value.debug_description()));return format_error;}
-};
-namespace Jakt {
-} // namespace Jakt
-template<>struct Jakt::Formatter<Jakt::types::CheckedMatchBody> : Jakt::Formatter<Jakt::StringView>{
-Jakt::ErrorOr<void> format(Jakt::FormatBuilder& builder, Jakt::types::CheckedMatchBody const& value) {
+template<>struct Jakt::Formatter<Jakt::types::ValueImpl> : Jakt::Formatter<Jakt::StringView>{
+Jakt::ErrorOr<void> format(Jakt::FormatBuilder& builder, Jakt::types::ValueImpl const& value) {
 JaktInternal::PrettyPrint::ScopedEnable pretty_print_enable { m_alternative_form };Jakt::ErrorOr<void> format_error = Jakt::Formatter<Jakt::StringView>::format(builder, MUST(value.debug_description()));return format_error;}
 };
 namespace Jakt {
@@ -1899,8 +1887,20 @@ JaktInternal::PrettyPrint::ScopedEnable pretty_print_enable { m_alternative_form
 };
 namespace Jakt {
 } // namespace Jakt
-template<>struct Jakt::Formatter<Jakt::types::CheckedVarDecl> : Jakt::Formatter<Jakt::StringView>{
-Jakt::ErrorOr<void> format(Jakt::FormatBuilder& builder, Jakt::types::CheckedVarDecl const& value) {
+template<>struct Jakt::Formatter<Jakt::types::ResolvedForallChunk> : Jakt::Formatter<Jakt::StringView>{
+Jakt::ErrorOr<void> format(Jakt::FormatBuilder& builder, Jakt::types::ResolvedForallChunk const& value) {
+JaktInternal::PrettyPrint::ScopedEnable pretty_print_enable { m_alternative_form };Jakt::ErrorOr<void> format_error = Jakt::Formatter<Jakt::StringView>::format(builder, MUST(value.debug_description()));return format_error;}
+};
+namespace Jakt {
+} // namespace Jakt
+template<>struct Jakt::Formatter<Jakt::types::TypecheckFunctions> : Jakt::Formatter<Jakt::StringView>{
+Jakt::ErrorOr<void> format(Jakt::FormatBuilder& builder, Jakt::types::TypecheckFunctions const& value) {
+JaktInternal::PrettyPrint::ScopedEnable pretty_print_enable { m_alternative_form };Jakt::ErrorOr<void> format_error = Jakt::Formatter<Jakt::StringView>::format(builder, MUST(value.debug_description()));return format_error;}
+};
+namespace Jakt {
+} // namespace Jakt
+template<>struct Jakt::Formatter<Jakt::types::NumericOrStringValue> : Jakt::Formatter<Jakt::StringView>{
+Jakt::ErrorOr<void> format(Jakt::FormatBuilder& builder, Jakt::types::NumericOrStringValue const& value) {
 JaktInternal::PrettyPrint::ScopedEnable pretty_print_enable { m_alternative_form };Jakt::ErrorOr<void> format_error = Jakt::Formatter<Jakt::StringView>::format(builder, MUST(value.debug_description()));return format_error;}
 };
 namespace Jakt {

--- a/bootstrap/stage0/utility.cpp
+++ b/bootstrap/stage0/utility.cpp
@@ -47,7 +47,7 @@ return (((c) == (static_cast<u8>(u8'0'))) || ((c) == (static_cast<u8>(u8'1'))));
 
 ErrorOr<ByteString> join(JaktInternal::DynamicArray<ByteString> const strings,ByteString const separator) {
 {
-ByteString output = TRY(ByteString::from_utf8(""sv));
+ByteString output = (ByteString::must_from_utf8(""sv));
 size_t i = static_cast<size_t>(0ULL);
 {
 JaktInternal::ArrayIterator<ByteString> _magic = ((strings).iterator());
@@ -140,19 +140,19 @@ u32 cp = (_magic_value.value());
 auto __jakt_enum_value = (cp);
 if (__jakt_enum_value == (infallible_integer_cast<u32>((static_cast<u8>(u8'"'))))) {
 {
-TRY((((builder).append_string(TRY(ByteString::from_utf8("\\\""sv))))));
+TRY((((builder).append_string((ByteString::must_from_utf8("\\\""sv))))));
 }
 return JaktInternal::ExplicitValue<void>();
 }
 else if (__jakt_enum_value == (infallible_integer_cast<u32>((static_cast<u8>(u8'\\'))))) {
 {
-TRY((((builder).append_string(TRY(ByteString::from_utf8("\\\\"sv))))));
+TRY((((builder).append_string((ByteString::must_from_utf8("\\\\"sv))))));
 }
 return JaktInternal::ExplicitValue<void>();
 }
 else if (__jakt_enum_value == (infallible_integer_cast<u32>((static_cast<u8>(u8'\n'))))) {
 {
-TRY((((builder).append_string(TRY(ByteString::from_utf8("\\n"sv))))));
+TRY((((builder).append_string((ByteString::must_from_utf8("\\n"sv))))));
 }
 return JaktInternal::ExplicitValue<void>();
 }

--- a/bootstrap/stage0/utility.h
+++ b/bootstrap/stage0/utility.h
@@ -4,22 +4,7 @@
 #include "jakt__platform__utility.h"
 namespace Jakt {
 namespace utility {
-struct FileId {
-  public:
-public: size_t id;public: FileId(size_t a_id);
-
-public: bool equals(utility::FileId const rhs) const;
-public: ErrorOr<ByteString> debug_description() const;
-};struct Span {
-  public:
-public: utility::FileId file_id;public: size_t start;public: size_t end;public: bool contains(utility::Span const span) const;
-public: Span(utility::FileId a_file_id, size_t a_start, size_t a_end);
-
-public: static utility::Span first(utility::Span const a, utility::Span const b);
-public: bool is_in_offset_range(size_t const start, size_t const end) const;
-public: static utility::Span last(utility::Span const a, utility::Span const b);
-public: ErrorOr<ByteString> debug_description() const;
-};template<typename T>
+template<typename T>
 struct IterationDecision {
 u8 __jakt_variant_index = 0;
 union VariantData {
@@ -145,11 +130,34 @@ public:
 private:
 IterationDecision() {};
 };
-template <typename T,typename U>
+struct FileId {
+  public:
+public: size_t id;public: FileId(size_t a_id);
+
+public: bool equals(utility::FileId const rhs) const;
+public: ErrorOr<ByteString> debug_description() const;
+};struct Span {
+  public:
+public: utility::FileId file_id;public: size_t start;public: size_t end;public: bool contains(utility::Span const span) const;
+public: Span(utility::FileId a_file_id, size_t a_start, size_t a_end);
+
+public: static utility::Span first(utility::Span const a, utility::Span const b);
+public: bool is_in_offset_range(size_t const start, size_t const end) const;
+public: static utility::Span last(utility::Span const a, utility::Span const b);
+public: ErrorOr<ByteString> debug_description() const;
+};template <typename T,typename U>
 ErrorOr<JaktInternal::DynamicArray<U>> map(JaktInternal::DynamicArray<T> const input, Function<ErrorOr<U>(T)> const& mapper);
 template <typename T>
 ErrorOr<JaktInternal::DynamicArray<T>> add_arrays(JaktInternal::DynamicArray<T> const a, JaktInternal::DynamicArray<T> const b);
 }
+} // namespace Jakt
+template<typename T>struct Jakt::Formatter<Jakt::utility::IterationDecision<T>
+> : Jakt::Formatter<Jakt::StringView>{
+Jakt::ErrorOr<void> format(Jakt::FormatBuilder& builder, Jakt::utility::IterationDecision<T>
+ const& value) {
+JaktInternal::PrettyPrint::ScopedEnable pretty_print_enable { m_alternative_form };Jakt::ErrorOr<void> format_error = Jakt::Formatter<Jakt::StringView>::format(builder, MUST(value.debug_description()));return format_error;}
+};
+namespace Jakt {
 } // namespace Jakt
 template<>struct Jakt::Formatter<Jakt::utility::FileId> : Jakt::Formatter<Jakt::StringView>{
 Jakt::ErrorOr<void> format(Jakt::FormatBuilder& builder, Jakt::utility::FileId const& value) {
@@ -159,14 +167,6 @@ namespace Jakt {
 } // namespace Jakt
 template<>struct Jakt::Formatter<Jakt::utility::Span> : Jakt::Formatter<Jakt::StringView>{
 Jakt::ErrorOr<void> format(Jakt::FormatBuilder& builder, Jakt::utility::Span const& value) {
-JaktInternal::PrettyPrint::ScopedEnable pretty_print_enable { m_alternative_form };Jakt::ErrorOr<void> format_error = Jakt::Formatter<Jakt::StringView>::format(builder, MUST(value.debug_description()));return format_error;}
-};
-namespace Jakt {
-} // namespace Jakt
-template<typename T>struct Jakt::Formatter<Jakt::utility::IterationDecision<T>
-> : Jakt::Formatter<Jakt::StringView>{
-Jakt::ErrorOr<void> format(Jakt::FormatBuilder& builder, Jakt::utility::IterationDecision<T>
- const& value) {
 JaktInternal::PrettyPrint::ScopedEnable pretty_print_enable { m_alternative_form };Jakt::ErrorOr<void> format_error = Jakt::Formatter<Jakt::StringView>::format(builder, MUST(value.debug_description()));return format_error;}
 };
 namespace Jakt {

--- a/runtime/jaktlib/prelude/string.jakt
+++ b/runtime/jaktlib/prelude/string.jakt
@@ -10,7 +10,7 @@ type StringView implements(FromStringLiteral) {
     fn from_string_literal(anon string: StringView) -> StringView => string
 }
 
-type String implements(ThrowingFromStringLiteral) {
-    [[name=from_utf8]]
-    extern fn from_string_literal(anon string: StringView) throws -> String
+type String implements(FromStringLiteral) {
+    [[name=must_from_utf8]]
+    extern fn from_string_literal(anon string: StringView) -> String
 }

--- a/selfhost/codegen.jakt
+++ b/selfhost/codegen.jakt
@@ -2559,7 +2559,6 @@ struct CodeGenerator {
                         }
 
                         let name = .program.get_function(ids![0]).name_for_codegen().as_name_for_use()
-
                         let error_handler = match val.may_throw { true => .current_error_handler(), else => "" }
                         yield format(
                             "{}({}::{}(\"{}\"sv))"

--- a/selfhost/interpreter.jakt
+++ b/selfhost/interpreter.jakt
@@ -467,7 +467,7 @@ fn value_to_checked_expression(anon this_value: Value, anon mut interpreter: Int
                 type: Type::Struct(interpreter.program.find_struct_in_prelude("String"))
                 module_id: interpreter.program.prelude_module_id()
             )
-            may_throw: true
+            may_throw: false
         )
         span: this_value.span
     )
@@ -479,7 +479,7 @@ fn value_to_checked_expression(anon this_value: Value, anon mut interpreter: Int
                 type: Type::Struct(interpreter.program.find_struct_in_prelude("StringView"))
                 module_id: interpreter.program.prelude_module_id()
             )
-            may_throw: true
+            may_throw: false
         )
         span: this_value.span
     )

--- a/selfhost/typechecker.jakt
+++ b/selfhost/typechecker.jakt
@@ -8137,7 +8137,7 @@ struct Typechecker {
                     mut type_id = .strip_optional_from_type(.generic_inferences.map(type_hint!))
                     let prelude_string_type_id = .prelude_struct_type_named("String")
                     let prelude_string_view_type_id = .prelude_struct_type_named("StringView")
-                    mut may_throw = type_id.equals(prelude_string_type_id)
+                    mut may_throw = false
                     if not type_id.equals(prelude_string_type_id) and not type_id.equals(prelude_string_view_type_id) {
                         if .get_type(type_id).is_concrete() {
                             let trait_implementation = .find_any_singular_trait_implementation(
@@ -8159,7 +8159,6 @@ struct Typechecker {
                             }
                         } else if not .get_type(type_id).is_concrete() {
                             type_id = .prelude_struct_type_named("String")
-                            may_throw = true
                         }
                     }
 
@@ -8184,14 +8183,11 @@ struct Typechecker {
                     )
                 }
                 else => {
-                    if not .get_scope(scope_id).can_throw {
-                        .error("Operation that may throw needs to be in a try statement or a function marked as throws", span)
-                    }
                     yield CheckedExpression::QuotedString(
                         val: CheckedStringLiteral(
                             value: StringLiteral::Static(val)
                             type_id: .prelude_struct_type_named("String")
-                            may_throw: true
+                            may_throw: false
                         )
                         span
                     )

--- a/tests/typechecker/fallible_operation_no_throws.jakt
+++ b/tests/typechecker/fallible_operation_no_throws.jakt
@@ -1,8 +1,0 @@
-/// Expect:
-/// - error: "Operation that may throw needs to be in a try statement or a function marked as throws"
-
-fn does_not_throw() {
-    "whf"
-}
-
-fn main() {}


### PR DESCRIPTION
This matches the direction we've taken in SerenityOS, where String literals don't produce an Error on allocation failure.