### PR TITLE
tests: Ensure backslashes are replaced correctly in codegen

### DIFF
--- a/tests/codegen/escaped_backslash_cpp.jakt
+++ b/tests/codegen/escaped_backslash_cpp.jakt
@@ -1,0 +1,16 @@
+/// Expect:
+/// - output: "PASS\n"
+
+// #1159: The substitutions for '\\' and '\"' should yield correct C++ without
+// crashing the compiler.
+
+fn main() {
+    let str = "\\\\\\\\\\\\"
+    let str2 = "\\\\"
+    let str3 = "\
+           \\
+        "
+    unsafe { cpp { " auto str4 = \"\\\"\";" } }
+    unsafe { cpp { " auto str5 = \"\\\\\";" } }
+    println("PASS")
+}


### PR DESCRIPTION
This previously caused a crash (#1159). This time it was caused by a bug in AK/StringUtils, and fixed by https://github.com/SerenityOS/serenity/pull/22326, but it'd be nice to detect if codegen messes this up again in the future.

Fixes #1159.

