### PR TITLE
selfhost: Minimize impact  of Jakt's codegen output to C++ compiler caches

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -157,6 +157,7 @@ set(SELFHOST_SOURCES
   selfhost/compiler.jakt
   selfhost/error.jakt
   selfhost/formatter.jakt
+  selfhost/git.jakt
   selfhost/ide.jakt
   selfhost/ids.jakt
   selfhost/interpreter.jakt

--- a/bootstrap/stage0/__prelude___specializations.cpp
+++ b/bootstrap/stage0/__prelude___specializations.cpp
@@ -1,5 +1,6 @@
 #include "main.h"
 #include "platform__unknown_compiler.h"
+#include "git.h"
 #include "repl.h"
 #include "repl_backend__default.h"
 #include "repl_backend__common.h"

--- a/bootstrap/stage0/__unified_forward.h
+++ b/bootstrap/stage0/__unified_forward.h
@@ -505,12 +505,16 @@ ErrorOr<ByteString> serialize_unary_operation(types::CheckedUnaryOperator const 
 ErrorOr<ByteString> serialize_ast_node(NonnullRefPtr<typename types::CheckedExpression> const node);
 
 }
+namespace git {
+
+ErrorOr<ByteString> commit_hash();
+
+}
 namespace platform__unknown_compiler {
 ErrorOr<JaktInternal::DynamicArray<ByteString>> run_compiler(ByteString const cxx_compiler_path, ByteString const cpp_filename, ByteString const output_filename, ByteString const runtime_path, JaktInternal::DynamicArray<ByteString> const extra_include_paths, JaktInternal::DynamicArray<ByteString> const extra_lib_paths, JaktInternal::DynamicArray<ByteString> const extra_link_libs, bool const optimize, JaktInternal::DynamicArray<ByteString> const extra_compiler_flags, bool const use_ccache);
 
 }
 struct FormatRange;
-
 ByteString usage();
 
 ByteString help();
@@ -532,5 +536,9 @@ ByteString escape_for_depfile(ByteString const input);
 ErrorOr<int> compiler_main(JaktInternal::DynamicArray<ByteString> const args);
 
 ErrorOr<void> format_output(jakt__path::Path const file_path, JaktInternal::DynamicArray<lexer::Token> const tokens, JaktInternal::Optional<FormatRange> const format_range, bool const format_debug, bool const format_inplace);
+
+ErrorOr<void> write_only_if_updated(ByteString const data, ByteString const output_filename);
+
+bool file_needs_updating(ByteString const path, ByteString const new_contents);
 
 } // namespace Jakt

--- a/bootstrap/stage0/build_specializations.cpp
+++ b/bootstrap/stage0/build_specializations.cpp
@@ -1,6 +1,7 @@
 #include "build.h"
 #include "main.h"
 #include "platform__unknown_compiler.h"
+#include "git.h"
 #include "repl.h"
 #include "repl_backend__default.h"
 #include "repl_backend__common.h"

--- a/bootstrap/stage0/compiler_specializations.cpp
+++ b/bootstrap/stage0/compiler_specializations.cpp
@@ -1,6 +1,7 @@
 #include "compiler.h"
 #include "main.h"
 #include "platform__unknown_compiler.h"
+#include "git.h"
 #include "repl.h"
 #include "repl_backend__default.h"
 #include "repl_backend__common.h"

--- a/bootstrap/stage0/cpp_import__common_specializations.cpp
+++ b/bootstrap/stage0/cpp_import__common_specializations.cpp
@@ -1,6 +1,7 @@
 #include "cpp_import__common.h"
 #include "main.h"
 #include "platform__unknown_compiler.h"
+#include "git.h"
 #include "repl.h"
 #include "repl_backend__default.h"
 #include "repl_backend__common.h"

--- a/bootstrap/stage0/cpp_import__none_specializations.cpp
+++ b/bootstrap/stage0/cpp_import__none_specializations.cpp
@@ -1,6 +1,7 @@
 #include "cpp_import__none.h"
 #include "main.h"
 #include "platform__unknown_compiler.h"
+#include "git.h"
 #include "repl.h"
 #include "repl_backend__default.h"
 #include "repl_backend__common.h"

--- a/bootstrap/stage0/error_specializations.cpp
+++ b/bootstrap/stage0/error_specializations.cpp
@@ -1,6 +1,7 @@
 #include "error.h"
 #include "main.h"
 #include "platform__unknown_compiler.h"
+#include "git.h"
 #include "repl.h"
 #include "repl_backend__default.h"
 #include "repl_backend__common.h"

--- a/bootstrap/stage0/formatter_specializations.cpp
+++ b/bootstrap/stage0/formatter_specializations.cpp
@@ -1,6 +1,7 @@
 #include "formatter.h"
 #include "main.h"
 #include "platform__unknown_compiler.h"
+#include "git.h"
 #include "repl.h"
 #include "repl_backend__default.h"
 #include "repl_backend__common.h"

--- a/bootstrap/stage0/git.cpp
+++ b/bootstrap/stage0/git.cpp
@@ -1,0 +1,12 @@
+#include "git.h"
+namespace Jakt {
+namespace git {
+ErrorOr<ByteString> commit_hash() {
+{
+ByteString const hash = (ByteString::must_from_utf8("b1842406dbfff2e0d730d2e7d4d968b7444e7de5"sv));
+return hash;
+}
+}
+
+}
+} // namespace Jakt

--- a/bootstrap/stage0/git.h
+++ b/bootstrap/stage0/git.h
@@ -1,0 +1,7 @@
+#pragma once
+#include "__unified_forward.h"
+#include "utility.h"
+namespace Jakt {
+namespace git {
+}
+} // namespace Jakt

--- a/bootstrap/stage0/git_specializations.cpp
+++ b/bootstrap/stage0/git_specializations.cpp
@@ -1,4 +1,4 @@
-#include "codegen.h"
+#include "git.h"
 #include "main.h"
 #include "platform__unknown_compiler.h"
 #include "git.h"
@@ -40,6 +40,6 @@
 #include "jakt__prelude__iteration.h"
 #include "jakt__prelude__static_array.h"
 namespace Jakt {
-namespace codegen {
+namespace git {
 }
 } // namespace Jakt

--- a/bootstrap/stage0/ide_specializations.cpp
+++ b/bootstrap/stage0/ide_specializations.cpp
@@ -1,6 +1,7 @@
 #include "ide.h"
 #include "main.h"
 #include "platform__unknown_compiler.h"
+#include "git.h"
 #include "repl.h"
 #include "repl_backend__default.h"
 #include "repl_backend__common.h"

--- a/bootstrap/stage0/ids_specializations.cpp
+++ b/bootstrap/stage0/ids_specializations.cpp
@@ -1,6 +1,7 @@
 #include "ids.h"
 #include "main.h"
 #include "platform__unknown_compiler.h"
+#include "git.h"
 #include "repl.h"
 #include "repl_backend__default.h"
 #include "repl_backend__common.h"

--- a/bootstrap/stage0/interpreter_specializations.cpp
+++ b/bootstrap/stage0/interpreter_specializations.cpp
@@ -1,6 +1,7 @@
 #include "interpreter.h"
 #include "main.h"
 #include "platform__unknown_compiler.h"
+#include "git.h"
 #include "repl.h"
 #include "repl_backend__default.h"
 #include "repl_backend__common.h"

--- a/bootstrap/stage0/jakt__arguments_specializations.cpp
+++ b/bootstrap/stage0/jakt__arguments_specializations.cpp
@@ -1,6 +1,7 @@
 #include "jakt__arguments.h"
 #include "main.h"
 #include "platform__unknown_compiler.h"
+#include "git.h"
 #include "repl.h"
 #include "repl_backend__default.h"
 #include "repl_backend__common.h"

--- a/bootstrap/stage0/jakt__file_iterator_specializations.cpp
+++ b/bootstrap/stage0/jakt__file_iterator_specializations.cpp
@@ -1,6 +1,7 @@
 #include "jakt__file_iterator.h"
 #include "main.h"
 #include "platform__unknown_compiler.h"
+#include "git.h"
 #include "repl.h"
 #include "repl_backend__default.h"
 #include "repl_backend__common.h"

--- a/bootstrap/stage0/jakt__libc__io_specializations.cpp
+++ b/bootstrap/stage0/jakt__libc__io_specializations.cpp
@@ -1,6 +1,7 @@
 #include "jakt__libc__io.h"
 #include "main.h"
 #include "platform__unknown_compiler.h"
+#include "git.h"
 #include "repl.h"
 #include "repl_backend__default.h"
 #include "repl_backend__common.h"

--- a/bootstrap/stage0/jakt__path_specializations.cpp
+++ b/bootstrap/stage0/jakt__path_specializations.cpp
@@ -1,6 +1,7 @@
 #include "jakt__path.h"
 #include "main.h"
 #include "platform__unknown_compiler.h"
+#include "git.h"
 #include "repl.h"
 #include "repl_backend__default.h"
 #include "repl_backend__common.h"

--- a/bootstrap/stage0/jakt__platform__unknown_fs_specializations.cpp
+++ b/bootstrap/stage0/jakt__platform__unknown_fs_specializations.cpp
@@ -1,6 +1,7 @@
 #include "jakt__platform__unknown_fs.h"
 #include "main.h"
 #include "platform__unknown_compiler.h"
+#include "git.h"
 #include "repl.h"
 #include "repl_backend__default.h"
 #include "repl_backend__common.h"

--- a/bootstrap/stage0/jakt__platform__unknown_path_specializations.cpp
+++ b/bootstrap/stage0/jakt__platform__unknown_path_specializations.cpp
@@ -1,6 +1,7 @@
 #include "jakt__platform__unknown_path.h"
 #include "main.h"
 #include "platform__unknown_compiler.h"
+#include "git.h"
 #include "repl.h"
 #include "repl_backend__default.h"
 #include "repl_backend__common.h"

--- a/bootstrap/stage0/jakt__platform__unknown_process_specializations.cpp
+++ b/bootstrap/stage0/jakt__platform__unknown_process_specializations.cpp
@@ -1,6 +1,7 @@
 #include "jakt__platform__unknown_process.h"
 #include "main.h"
 #include "platform__unknown_compiler.h"
+#include "git.h"
 #include "repl.h"
 #include "repl_backend__default.h"
 #include "repl_backend__common.h"

--- a/bootstrap/stage0/jakt__platform__utility_specializations.cpp
+++ b/bootstrap/stage0/jakt__platform__utility_specializations.cpp
@@ -1,6 +1,7 @@
 #include "jakt__platform__utility.h"
 #include "main.h"
 #include "platform__unknown_compiler.h"
+#include "git.h"
 #include "repl.h"
 #include "repl_backend__default.h"
 #include "repl_backend__common.h"

--- a/bootstrap/stage0/jakt__platform_specializations.cpp
+++ b/bootstrap/stage0/jakt__platform_specializations.cpp
@@ -1,6 +1,7 @@
 #include "jakt__platform.h"
 #include "main.h"
 #include "platform__unknown_compiler.h"
+#include "git.h"
 #include "repl.h"
 #include "repl_backend__default.h"
 #include "repl_backend__common.h"

--- a/bootstrap/stage0/jakt__prelude__class_name_specializations.cpp
+++ b/bootstrap/stage0/jakt__prelude__class_name_specializations.cpp
@@ -1,6 +1,7 @@
 #include "jakt__prelude__class_name.h"
 #include "main.h"
 #include "platform__unknown_compiler.h"
+#include "git.h"
 #include "repl.h"
 #include "repl_backend__default.h"
 #include "repl_backend__common.h"

--- a/bootstrap/stage0/jakt__prelude__configuration_specializations.cpp
+++ b/bootstrap/stage0/jakt__prelude__configuration_specializations.cpp
@@ -1,6 +1,7 @@
 #include "jakt__prelude__configuration.h"
 #include "main.h"
 #include "platform__unknown_compiler.h"
+#include "git.h"
 #include "repl.h"
 #include "repl_backend__default.h"
 #include "repl_backend__common.h"

--- a/bootstrap/stage0/jakt__prelude__hash_specializations.cpp
+++ b/bootstrap/stage0/jakt__prelude__hash_specializations.cpp
@@ -1,6 +1,7 @@
 #include "jakt__prelude__hash.h"
 #include "main.h"
 #include "platform__unknown_compiler.h"
+#include "git.h"
 #include "repl.h"
 #include "repl_backend__default.h"
 #include "repl_backend__common.h"

--- a/bootstrap/stage0/jakt__prelude__iteration_specializations.cpp
+++ b/bootstrap/stage0/jakt__prelude__iteration_specializations.cpp
@@ -1,6 +1,7 @@
 #include "jakt__prelude__iteration.h"
 #include "main.h"
 #include "platform__unknown_compiler.h"
+#include "git.h"
 #include "repl.h"
 #include "repl_backend__default.h"
 #include "repl_backend__common.h"

--- a/bootstrap/stage0/jakt__prelude__operators_specializations.cpp
+++ b/bootstrap/stage0/jakt__prelude__operators_specializations.cpp
@@ -1,6 +1,7 @@
 #include "jakt__prelude__operators.h"
 #include "main.h"
 #include "platform__unknown_compiler.h"
+#include "git.h"
 #include "repl.h"
 #include "repl_backend__default.h"
 #include "repl_backend__common.h"

--- a/bootstrap/stage0/jakt__prelude__prelude_specializations.cpp
+++ b/bootstrap/stage0/jakt__prelude__prelude_specializations.cpp
@@ -1,6 +1,7 @@
 #include "jakt__prelude__prelude.h"
 #include "main.h"
 #include "platform__unknown_compiler.h"
+#include "git.h"
 #include "repl.h"
 #include "repl_backend__default.h"
 #include "repl_backend__common.h"

--- a/bootstrap/stage0/jakt__prelude__static_array_specializations.cpp
+++ b/bootstrap/stage0/jakt__prelude__static_array_specializations.cpp
@@ -1,6 +1,7 @@
 #include "jakt__prelude__static_array.h"
 #include "main.h"
 #include "platform__unknown_compiler.h"
+#include "git.h"
 #include "repl.h"
 #include "repl_backend__default.h"
 #include "repl_backend__common.h"

--- a/bootstrap/stage0/jakt__prelude__string_specializations.cpp
+++ b/bootstrap/stage0/jakt__prelude__string_specializations.cpp
@@ -1,6 +1,7 @@
 #include "jakt__prelude__string.h"
 #include "main.h"
 #include "platform__unknown_compiler.h"
+#include "git.h"
 #include "repl.h"
 #include "repl_backend__default.h"
 #include "repl_backend__common.h"

--- a/bootstrap/stage0/lexer_specializations.cpp
+++ b/bootstrap/stage0/lexer_specializations.cpp
@@ -1,6 +1,7 @@
 #include "lexer.h"
 #include "main.h"
 #include "platform__unknown_compiler.h"
+#include "git.h"
 #include "repl.h"
 #include "repl_backend__default.h"
 #include "repl_backend__common.h"

--- a/bootstrap/stage0/main.cpp
+++ b/bootstrap/stage0/main.cpp
@@ -965,7 +965,7 @@ outln((StringView::from_string_literal("{}"sv)),help());
 return static_cast<int>(0);
 }
 if (TRY((((args_parser).flag((DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("-v"sv)), (ByteString::must_from_utf8("--version"sv))}))))))){
-outln((StringView::from_string_literal("{}"sv)),(ByteString::must_from_utf8("f24fd6dce7f3556de492df4b5fa97bfea607a141"sv)));
+outln((StringView::from_string_literal("{}"sv)),TRY((git::commit_hash())));
 return static_cast<int>(0);
 }
 jakt__path::Path const current_executable_path = jakt__path::Path::from_string(TRY((File::current_executable_path())));
@@ -1611,7 +1611,7 @@ ByteString const contents = ((contents_module_file_path_).template get<0>());
 ByteString const module_file_path = ((contents_module_file_path_).template get<1>());
 
 jakt__path::Path const path = ((binary_dir).join(file));
-auto __jakt_var_969 = [&]() -> ErrorOr<void> { return TRY((utility::write_to_file(contents,((path).to_string())))), ErrorOr<void>{}; }();
+auto __jakt_var_969 = [&]() -> ErrorOr<void> { return TRY((write_only_if_updated(contents,((path).to_string())))), ErrorOr<void>{}; }();
 if (__jakt_var_969.is_error()) {auto error = __jakt_var_969.release_error();
 {
 warnln((StringView::from_string_literal("Error: Could not write to file: {} ({})"sv)),file,error);
@@ -1626,7 +1626,7 @@ return static_cast<int>(1);
 
 if (((generate_depfile).has_value())){
 auto __jakt_var_970 = [&]() -> ErrorOr<void> {{
-TRY((utility::write_to_file(((depfile_builder).to_string()),(generate_depfile.value()))));
+TRY((write_only_if_updated(((depfile_builder).to_string()),(generate_depfile.value()))));
 }
 
 ;return {};}();
@@ -2041,6 +2041,46 @@ out((StringView::from_string_literal("{}"sv)),((formatted_file).to_string()));
 
 }
 return {};
+}
+
+ErrorOr<void> write_only_if_updated(ByteString const data,ByteString const output_filename) {
+{
+if (file_needs_updating(output_filename,data)){
+TRY((utility::write_to_file(data,output_filename)));
+}
+}
+return {};
+}
+
+bool file_needs_updating(ByteString const path,ByteString const new_contents) {
+{
+JaktInternal::Optional<NonnullRefPtr<File>> maybe_file = ({ Optional<NonnullRefPtr<File>> __jakt_var_977;
+auto __jakt_var_978 = [&]() -> ErrorOr<NonnullRefPtr<File>> { return TRY((File::open_for_reading(path))); }();
+if (!__jakt_var_978.is_error()) __jakt_var_977 = __jakt_var_978.release_value();
+__jakt_var_977; });
+if (((maybe_file).has_value())){
+JaktInternal::Optional<JaktInternal::DynamicArray<u8>> const contents = ({ Optional<JaktInternal::DynamicArray<u8>> __jakt_var_979;
+auto __jakt_var_980 = [&]() -> ErrorOr<JaktInternal::DynamicArray<u8>> { return TRY(((((maybe_file.value()))->read_all()))); }();
+if (!__jakt_var_980.is_error()) __jakt_var_979 = __jakt_var_980.release_value();
+__jakt_var_979; });
+if (((contents).has_value())){
+return [](ByteString const& self, ByteString rhs) -> bool {
+{
+return (!(((self) == (rhs))));
+}
+}
+(utility::to_string((contents.value())),new_contents);
+}
+else {
+return true;
+}
+
+}
+else {
+return true;
+}
+
+}
 }
 
 ErrorOr<ByteString> FormatRange::debug_description() const { auto builder = ByteStringBuilder::create();builder.append("FormatRange("sv);{

--- a/bootstrap/stage0/main.h
+++ b/bootstrap/stage0/main.h
@@ -21,6 +21,7 @@
 #include "typechecker.h"
 #include "types.h"
 #include "utility.h"
+#include "git.h"
 #include "jakt__platform__unknown_fs.h"
 #include "platform__unknown_compiler.h"
 namespace Jakt {

--- a/bootstrap/stage0/main_specializations.cpp
+++ b/bootstrap/stage0/main_specializations.cpp
@@ -1,6 +1,7 @@
 #include "main.h"
 #include "main.h"
 #include "platform__unknown_compiler.h"
+#include "git.h"
 #include "repl.h"
 #include "repl_backend__default.h"
 #include "repl_backend__common.h"

--- a/bootstrap/stage0/parser_specializations.cpp
+++ b/bootstrap/stage0/parser_specializations.cpp
@@ -1,6 +1,7 @@
 #include "parser.h"
 #include "main.h"
 #include "platform__unknown_compiler.h"
+#include "git.h"
 #include "repl.h"
 #include "repl_backend__default.h"
 #include "repl_backend__common.h"

--- a/bootstrap/stage0/platform__unknown_compiler_specializations.cpp
+++ b/bootstrap/stage0/platform__unknown_compiler_specializations.cpp
@@ -1,6 +1,7 @@
 #include "platform__unknown_compiler.h"
 #include "main.h"
 #include "platform__unknown_compiler.h"
+#include "git.h"
 #include "repl.h"
 #include "repl_backend__default.h"
 #include "repl_backend__common.h"

--- a/bootstrap/stage0/platform_specializations.cpp
+++ b/bootstrap/stage0/platform_specializations.cpp
@@ -1,6 +1,7 @@
 #include "platform.h"
 #include "main.h"
 #include "platform__unknown_compiler.h"
+#include "git.h"
 #include "repl.h"
 #include "repl_backend__default.h"
 #include "repl_backend__common.h"

--- a/bootstrap/stage0/project_specializations.cpp
+++ b/bootstrap/stage0/project_specializations.cpp
@@ -1,6 +1,7 @@
 #include "project.h"
 #include "main.h"
 #include "platform__unknown_compiler.h"
+#include "git.h"
 #include "repl.h"
 #include "repl_backend__default.h"
 #include "repl_backend__common.h"

--- a/bootstrap/stage0/repl_backend__common_specializations.cpp
+++ b/bootstrap/stage0/repl_backend__common_specializations.cpp
@@ -1,6 +1,7 @@
 #include "repl_backend__common.h"
 #include "main.h"
 #include "platform__unknown_compiler.h"
+#include "git.h"
 #include "repl.h"
 #include "repl_backend__default.h"
 #include "repl_backend__common.h"

--- a/bootstrap/stage0/repl_backend__default_specializations.cpp
+++ b/bootstrap/stage0/repl_backend__default_specializations.cpp
@@ -1,6 +1,7 @@
 #include "repl_backend__default.h"
 #include "main.h"
 #include "platform__unknown_compiler.h"
+#include "git.h"
 #include "repl.h"
 #include "repl_backend__default.h"
 #include "repl_backend__common.h"

--- a/bootstrap/stage0/repl_specializations.cpp
+++ b/bootstrap/stage0/repl_specializations.cpp
@@ -1,6 +1,7 @@
 #include "repl.h"
 #include "main.h"
 #include "platform__unknown_compiler.h"
+#include "git.h"
 #include "repl.h"
 #include "repl_backend__default.h"
 #include "repl_backend__common.h"

--- a/bootstrap/stage0/typechecker_specializations.cpp
+++ b/bootstrap/stage0/typechecker_specializations.cpp
@@ -1,6 +1,7 @@
 #include "typechecker.h"
 #include "main.h"
 #include "platform__unknown_compiler.h"
+#include "git.h"
 #include "repl.h"
 #include "repl_backend__default.h"
 #include "repl_backend__common.h"

--- a/bootstrap/stage0/types_specializations.cpp
+++ b/bootstrap/stage0/types_specializations.cpp
@@ -1,6 +1,7 @@
 #include "types.h"
 #include "main.h"
 #include "platform__unknown_compiler.h"
+#include "git.h"
 #include "repl.h"
 #include "repl_backend__default.h"
 #include "repl_backend__common.h"

--- a/bootstrap/stage0/utility_specializations.cpp
+++ b/bootstrap/stage0/utility_specializations.cpp
@@ -1,6 +1,7 @@
 #include "utility.h"
 #include "main.h"
 #include "platform__unknown_compiler.h"
+#include "git.h"
 #include "repl.h"
 #include "repl_backend__default.h"
 #include "repl_backend__common.h"

--- a/selfhost/git.jakt
+++ b/selfhost/git.jakt
@@ -1,0 +1,29 @@
+import utility { to_string }
+
+fn commit_hash() throws -> String {
+    let hash = fetch_commit_hash()
+    return hash
+}
+
+// Fetch git hash for build at comptime
+comptime fetch_commit_hash() throws -> String {
+    mut head_file: File? = None // FIXME: implement try expression in comptime
+    try {
+        head_file = File::open_for_reading("../.git/HEAD")
+    } catch {
+        return "unreleased"
+    }
+
+    guard head_file.has_value() else {
+        return "unreleased"
+    }
+
+    let path = to_string(head_file!.read_all())
+    guard path.starts_with("ref: ") and path.ends_with("\n") else {
+        return "HEAD"
+    }
+
+    mut ref_file = File::open_for_reading("../.git/" + path.substring(start: 5, length: path.length() - 6))
+    let hash = to_string(ref_file.read_all())
+    return hash.substring(start: 0, length: hash.length() - 1)
+}

--- a/selfhost/main.jakt
+++ b/selfhost/main.jakt
@@ -26,7 +26,8 @@ import project { Project }
 import repl { REPL, serialize_ast_node }
 import typechecker { Typechecker }
 import types { FunctionId, ResolvedNamespace, ScopeId, ModuleId, Value, ValueImpl }
-import utility { Queue, Span, escape_for_quotes, join, write_to_file, to_string }
+import utility { Queue, Span, escape_for_quotes, join, write_to_file }
+import git
 
 import platform_fs() { DirectoryIterator, make_directory }
 
@@ -36,25 +37,6 @@ import platform_compiler() {
 
 import jakt::platform { Target }
 
-comptime get_current_git_hash() throws -> String {
-    mut head_file: File? = None // FIXME: implement try expression in comptime
-    try {
-        head_file = File::open_for_reading("../.git/HEAD")
-    } catch {
-        return "unreleased"
-    }
-    guard head_file.has_value() else {
-        return "unreleased"
-    }
-    let path = to_string(head_file!.read_all())
-    guard path.starts_with("ref: ") and path.ends_with("\n") else {
-        return "HEAD"
-    }
-
-    mut ref_file = File::open_for_reading("../.git/" + path.substring(start: 5, length: path.length() - 6))
-    let hash = to_string(ref_file.read_all())
-    return hash.substring(start: 0, length: hash.length() - 1)
-}
 
 fn usage() => "usage: jakt [cross] [-h] [OPTIONS] <filename>"
 fn help() -> String {
@@ -488,7 +470,7 @@ fn compiler_main(anon args: [String]) throws -> c_int {
     }
 
     if args_parser.flag(["-v", "--version"]) {
-        println("{}", get_current_git_hash())
+        println("{}", git::commit_hash())
         return 0
     }
 

--- a/selfhost/main.jakt
+++ b/selfhost/main.jakt
@@ -930,7 +930,8 @@ fn compiler_main(anon args: [String]) throws -> c_int {
         let (contents, module_file_path) = contents_and_path
 
         let path = binary_dir.join(file)
-        try write_to_file(data: contents, output_filename: path.to_string()) catch error {
+
+        try write_only_if_updated(data: contents, output_filename: path.to_string()) catch error {
             eprintln("Error: Could not write to file: {} ({})", file, error)
             return 1
         }
@@ -938,7 +939,7 @@ fn compiler_main(anon args: [String]) throws -> c_int {
 
     if generate_depfile.has_value() {
         try {
-            write_to_file(
+            write_only_if_updated(
                 data: depfile_builder.to_string()
                 output_filename: generate_depfile!
             )
@@ -1168,4 +1169,28 @@ fn format_output(file_path: Path, tokens: [Token], format_range: FormatRange?, f
     } else {
         print("{}", formatted_file.to_string())
     }
+}
+
+fn write_only_if_updated(data: String, output_filename: String) throws {
+    if file_needs_updating(path: output_filename, new_contents: data) {
+        write_to_file(data, output_filename)
+    }
+}
+
+fn file_needs_updating(path: String, new_contents: String) -> bool {
+    mut maybe_file = try File::open_for_reading(path)
+
+    // It doesn't exist, write it anyway
+    guard maybe_file.has_value() else {
+        return true
+    }
+
+    let contents = try maybe_file!.read_all()
+
+    // Could not read contents, so write it anyway.
+    guard contents.has_value() else {
+        return true
+    }
+
+    return to_string(contents!) != new_contents
 }


### PR DESCRIPTION
This PR implements a few rudimentary optimizations so that Jakt is a nicer citizen with compiler caches:

- Moving the comptime-generated git commit string to a separate file avoids evicting `main.cpp` from compiler caches on every rebuild after a commit.
- Avoiding writing files with the same content they had originally prevents build systems like Ninja from thinking that those files have to be rebuilt.

