### PR TITLE
  codegen: Simplify control flow forwarding rules for match IIFEs

### DIFF
--- a/bootstrap/stage0/codegen.h
+++ b/bootstrap/stage0/codegen.h
@@ -32,14 +32,13 @@ AllowedControlExits() {};
 };
 struct ControlFlowState {
   public:
-public: codegen::AllowedControlExits allowed_exits;public: bool passes_through_match;public: bool passes_through_try;public: size_t match_nest_level;public: static codegen::ControlFlowState no_control_flow();
+public: codegen::AllowedControlExits allowed_exits;public: bool passes_through_try;public: bool directly_inside_match;public: bool indirectly_inside_match;public: static codegen::ControlFlowState no_control_flow();
 public: codegen::ControlFlowState enter_function() const;
 public: codegen::ControlFlowState enter_loop() const;
 public: codegen::ControlFlowState enter_match() const;
-public: bool is_match_nested() const;
 public: static ByteString nested_release_return_expr(ids::TypeId const func_return_type, bool const func_can_throw, ByteString const cpp_match_result_type);
 public: ErrorOr<ByteString> apply_control_flow_macro(ByteString const x, ids::TypeId const func_return_type, bool const func_can_throw, ByteString const cpp_match_result_type) const;
-public: ControlFlowState(codegen::AllowedControlExits a_allowed_exits, bool a_passes_through_match, bool a_passes_through_try, size_t a_match_nest_level);
+public: ControlFlowState(codegen::AllowedControlExits a_allowed_exits, bool a_passes_through_try, bool a_directly_inside_match, bool a_indirectly_inside_match);
 
 public: ByteString debug_description() const;
 };struct LineSpan {
@@ -97,8 +96,8 @@ public: ByteString codegen_ak_formatter(ByteString const name, JaktInternal::Dyn
 public: ErrorOr<ByteString> codegen_expression_and_deref_if_generic_and_needed(NonnullRefPtr<typename types::CheckedExpression> const expression);
 public: ErrorOr<ByteString> codegen_expression(NonnullRefPtr<typename types::CheckedExpression> const expression);
 public: ErrorOr<ByteString> codegen_match(NonnullRefPtr<typename types::CheckedExpression> const expr, JaktInternal::DynamicArray<types::CheckedMatchCase> const match_cases, ids::TypeId const type_id, bool const all_variants_constant);
-public: ErrorOr<ByteString> codegen_generic_match(NonnullRefPtr<typename types::CheckedExpression> const expr, JaktInternal::DynamicArray<types::CheckedMatchCase> const cases, ids::TypeId const return_type_id, bool const all_variants_constant);
-public: ErrorOr<ByteString> codegen_enum_match(types::CheckedEnum const enum_, NonnullRefPtr<typename types::CheckedExpression> const expr, JaktInternal::DynamicArray<types::CheckedMatchCase> const match_cases, ids::TypeId const type_id, bool const all_variants_constant);
+public: ErrorOr<ByteString> codegen_generic_match(NonnullRefPtr<typename types::CheckedExpression> const expr, JaktInternal::DynamicArray<types::CheckedMatchCase> const cases, ids::TypeId const return_type_id, ByteString const cpp_match_result_type, bool const all_variants_constant);
+public: ErrorOr<ByteString> codegen_enum_match(types::CheckedEnum const enum_, NonnullRefPtr<typename types::CheckedExpression> const expr, JaktInternal::DynamicArray<types::CheckedMatchCase> const match_cases, ids::TypeId const type_id, ByteString const cpp_match_result_type, bool const all_variants_constant);
 public: ErrorOr<ByteString> codegen_match_body(types::CheckedMatchBody const body, ids::TypeId const return_type_id);
 public: ErrorOr<ByteString> codegen_function_return_type(NonnullRefPtr<types::CheckedFunction> const function);
 public: ErrorOr<ByteString> codegen_binary_expression(NonnullRefPtr<typename types::CheckedExpression> const expression, ids::TypeId const type_id, NonnullRefPtr<typename types::CheckedExpression> const lhs, NonnullRefPtr<typename types::CheckedExpression> const rhs, types::CheckedBinaryOperator const op);

--- a/bootstrap/stage0/formatter.cpp
+++ b/bootstrap/stage0/formatter.cpp
@@ -467,7 +467,7 @@ ErrorOr<formatter::Stage0> formatter::Stage0::create(NonnullRefPtr<compiler::Com
 {
 JaktInternal::DynamicArray<u8> const old_file_contents = ((compiler)->current_file_contents);
 (((compiler)->current_file_contents) = source);
-ScopeGuard __jakt_var_670([&] {
+ScopeGuard __jakt_var_671([&] {
 {
 (((compiler)->current_file_contents) = old_file_contents);
 }
@@ -625,18 +625,6 @@ return ({
 auto&& __jakt_match_variant = token;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 97 /* Struct */: {
-return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_671; {
-TRY((((*this).push_state(formatter::State::EntityDeclaration(formatter::Entity::from_token(((token))),(!(((token).__jakt_init_index() == 86 /* Namespace */))),false,static_cast<size_t>(0ULL),true)))));
-JaktInternal::DynamicArray<u8> trailing_trivia = DynamicArray<u8>::create_with({});
-if ((((token).__jakt_init_index() == 86 /* Namespace */) || (!(((((*this).peek(static_cast<i64>(0LL)))).__jakt_init_index() == 28 /* LessThan */))))){
-((trailing_trivia).push(static_cast<u8>(u8' ')));
-}
-__jakt_var_671 = ((*this).formatted_token(token,trailing_trivia,DynamicArray<u8>::create_with({}))); goto __jakt_label_566;
-
-}
-__jakt_label_566:; __jakt_var_671.release_value(); }));
-};/*case end*/
-case 65 /* Class */: {
 return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_672; {
 TRY((((*this).push_state(formatter::State::EntityDeclaration(formatter::Entity::from_token(((token))),(!(((token).__jakt_init_index() == 86 /* Namespace */))),false,static_cast<size_t>(0ULL),true)))));
 JaktInternal::DynamicArray<u8> trailing_trivia = DynamicArray<u8>::create_with({});
@@ -648,13 +636,25 @@ __jakt_var_672 = ((*this).formatted_token(token,trailing_trivia,DynamicArray<u8>
 }
 __jakt_label_567:; __jakt_var_672.release_value(); }));
 };/*case end*/
-default: {
+case 65 /* Class */: {
 return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_673; {
-((*this).pop_state());
-__jakt_var_673 = TRY((((*this).formatted_token(token)))); goto __jakt_label_568;
+TRY((((*this).push_state(formatter::State::EntityDeclaration(formatter::Entity::from_token(((token))),(!(((token).__jakt_init_index() == 86 /* Namespace */))),false,static_cast<size_t>(0ULL),true)))));
+JaktInternal::DynamicArray<u8> trailing_trivia = DynamicArray<u8>::create_with({});
+if ((((token).__jakt_init_index() == 86 /* Namespace */) || (!(((((*this).peek(static_cast<i64>(0LL)))).__jakt_init_index() == 28 /* LessThan */))))){
+((trailing_trivia).push(static_cast<u8>(u8' ')));
+}
+__jakt_var_673 = ((*this).formatted_token(token,trailing_trivia,DynamicArray<u8>::create_with({}))); goto __jakt_label_568;
 
 }
 __jakt_label_568:; __jakt_var_673.release_value(); }));
+};/*case end*/
+default: {
+return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_674; {
+((*this).pop_state());
+__jakt_var_674 = TRY((((*this).formatted_token(token)))); goto __jakt_label_569;
+
+}
+__jakt_label_569:; __jakt_var_674.release_value(); }));
 };/*case end*/
 }/*switch end*/
 }()
@@ -673,7 +673,7 @@ return ({
 auto&& __jakt_match_variant = token;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 72 /* Extern */: {
-return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_674; {
+return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_675; {
 ({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<void, ErrorOr<JaktInternal::Optional<formatter::FormattedToken>>>{
 auto&& __jakt_match_variant = ((*this).peek(static_cast<i64>(0LL)));
@@ -702,36 +702,24 @@ return JaktInternal::ExplicitValue<void>();
         return _jakt_value.release_return();
     _jakt_value.release_value();
 });
-__jakt_var_674 = ((*this).formatted_token(token,DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}),DynamicArray<u8>::create_with({}))); goto __jakt_label_569;
-
-}
-__jakt_label_569:; __jakt_var_674.release_value(); }));
-};/*case end*/
-case 3 /* Identifier */: {
-auto&& __jakt_match_value = __jakt_match_variant.as.Identifier;ByteString const& name = __jakt_match_value.name;
-return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_675; {
-if ((((name) == ((ByteString::from_utf8_without_validation("type"sv)))) && ((((*this).peek(static_cast<i64>(0LL)))).__jakt_init_index() == 3 /* Identifier */))){
-TRY((((*this).push_state(formatter::State::EntityDeclaration(formatter::Entity::from_token(((token))),true,false,static_cast<size_t>(0ULL),is_extern)))));
-return ((*this).formatted_token(token,DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}),DynamicArray<u8>::create_with({})));
-}
-__jakt_var_675 = TRY((((*this).formatted_token(token)))); goto __jakt_label_570;
+__jakt_var_675 = ((*this).formatted_token(token,DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}),DynamicArray<u8>::create_with({}))); goto __jakt_label_570;
 
 }
 __jakt_label_570:; __jakt_var_675.release_value(); }));
 };/*case end*/
-case 71 /* Enum */: {
+case 3 /* Identifier */: {
+auto&& __jakt_match_value = __jakt_match_variant.as.Identifier;ByteString const& name = __jakt_match_value.name;
 return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_676; {
-TRY((((*this).push_state(formatter::State::EntityDeclaration(formatter::Entity::from_token(((token))),(!(((token).__jakt_init_index() == 86 /* Namespace */))),false,static_cast<size_t>(0ULL),is_extern)))));
-JaktInternal::DynamicArray<u8> trailing_trivia = DynamicArray<u8>::create_with({});
-if ((((token).__jakt_init_index() == 86 /* Namespace */) || (!(((((*this).peek(static_cast<i64>(0LL)))).__jakt_init_index() == 28 /* LessThan */))))){
-((trailing_trivia).push(static_cast<u8>(u8' ')));
+if ((((name) == ((ByteString::from_utf8_without_validation("type"sv)))) && ((((*this).peek(static_cast<i64>(0LL)))).__jakt_init_index() == 3 /* Identifier */))){
+TRY((((*this).push_state(formatter::State::EntityDeclaration(formatter::Entity::from_token(((token))),true,false,static_cast<size_t>(0ULL),is_extern)))));
+return ((*this).formatted_token(token,DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}),DynamicArray<u8>::create_with({})));
 }
-__jakt_var_676 = ((*this).formatted_token(token,trailing_trivia,DynamicArray<u8>::create_with({}))); goto __jakt_label_571;
+__jakt_var_676 = TRY((((*this).formatted_token(token)))); goto __jakt_label_571;
 
 }
 __jakt_label_571:; __jakt_var_676.release_value(); }));
 };/*case end*/
-case 65 /* Class */: {
+case 71 /* Enum */: {
 return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_677; {
 TRY((((*this).push_state(formatter::State::EntityDeclaration(formatter::Entity::from_token(((token))),(!(((token).__jakt_init_index() == 86 /* Namespace */))),false,static_cast<size_t>(0ULL),is_extern)))));
 JaktInternal::DynamicArray<u8> trailing_trivia = DynamicArray<u8>::create_with({});
@@ -743,7 +731,7 @@ __jakt_var_677 = ((*this).formatted_token(token,trailing_trivia,DynamicArray<u8>
 }
 __jakt_label_572:; __jakt_var_677.release_value(); }));
 };/*case end*/
-case 97 /* Struct */: {
+case 65 /* Class */: {
 return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_678; {
 TRY((((*this).push_state(formatter::State::EntityDeclaration(formatter::Entity::from_token(((token))),(!(((token).__jakt_init_index() == 86 /* Namespace */))),false,static_cast<size_t>(0ULL),is_extern)))));
 JaktInternal::DynamicArray<u8> trailing_trivia = DynamicArray<u8>::create_with({});
@@ -755,7 +743,7 @@ __jakt_var_678 = ((*this).formatted_token(token,trailing_trivia,DynamicArray<u8>
 }
 __jakt_label_573:; __jakt_var_678.release_value(); }));
 };/*case end*/
-case 111 /* Trait */: {
+case 97 /* Struct */: {
 return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_679; {
 TRY((((*this).push_state(formatter::State::EntityDeclaration(formatter::Entity::from_token(((token))),(!(((token).__jakt_init_index() == 86 /* Namespace */))),false,static_cast<size_t>(0ULL),is_extern)))));
 JaktInternal::DynamicArray<u8> trailing_trivia = DynamicArray<u8>::create_with({});
@@ -767,7 +755,7 @@ __jakt_var_679 = ((*this).formatted_token(token,trailing_trivia,DynamicArray<u8>
 }
 __jakt_label_574:; __jakt_var_679.release_value(); }));
 };/*case end*/
-case 75 /* Fn */: {
+case 111 /* Trait */: {
 return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_680; {
 TRY((((*this).push_state(formatter::State::EntityDeclaration(formatter::Entity::from_token(((token))),(!(((token).__jakt_init_index() == 86 /* Namespace */))),false,static_cast<size_t>(0ULL),is_extern)))));
 JaktInternal::DynamicArray<u8> trailing_trivia = DynamicArray<u8>::create_with({});
@@ -779,7 +767,7 @@ __jakt_var_680 = ((*this).formatted_token(token,trailing_trivia,DynamicArray<u8>
 }
 __jakt_label_575:; __jakt_var_680.release_value(); }));
 };/*case end*/
-case 76 /* Comptime */: {
+case 75 /* Fn */: {
 return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_681; {
 TRY((((*this).push_state(formatter::State::EntityDeclaration(formatter::Entity::from_token(((token))),(!(((token).__jakt_init_index() == 86 /* Namespace */))),false,static_cast<size_t>(0ULL),is_extern)))));
 JaktInternal::DynamicArray<u8> trailing_trivia = DynamicArray<u8>::create_with({});
@@ -791,7 +779,7 @@ __jakt_var_681 = ((*this).formatted_token(token,trailing_trivia,DynamicArray<u8>
 }
 __jakt_label_576:; __jakt_var_681.release_value(); }));
 };/*case end*/
-case 86 /* Namespace */: {
+case 76 /* Comptime */: {
 return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_682; {
 TRY((((*this).push_state(formatter::State::EntityDeclaration(formatter::Entity::from_token(((token))),(!(((token).__jakt_init_index() == 86 /* Namespace */))),false,static_cast<size_t>(0ULL),is_extern)))));
 JaktInternal::DynamicArray<u8> trailing_trivia = DynamicArray<u8>::create_with({});
@@ -803,84 +791,96 @@ __jakt_var_682 = ((*this).formatted_token(token,trailing_trivia,DynamicArray<u8>
 }
 __jakt_label_577:; __jakt_var_682.release_value(); }));
 };/*case end*/
-case 11 /* LSquare */: {
+case 86 /* Namespace */: {
 return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_683; {
-TRY((((*this).replace_state(formatter::State::Toplevel(open_parens,open_curlies,JaktInternal::checked_add(open_squares,static_cast<size_t>(1ULL)),is_extern)))));
-__jakt_var_683 = TRY((((*this).formatted_token(token)))); goto __jakt_label_578;
+TRY((((*this).push_state(formatter::State::EntityDeclaration(formatter::Entity::from_token(((token))),(!(((token).__jakt_init_index() == 86 /* Namespace */))),false,static_cast<size_t>(0ULL),is_extern)))));
+JaktInternal::DynamicArray<u8> trailing_trivia = DynamicArray<u8>::create_with({});
+if ((((token).__jakt_init_index() == 86 /* Namespace */) || (!(((((*this).peek(static_cast<i64>(0LL)))).__jakt_init_index() == 28 /* LessThan */))))){
+((trailing_trivia).push(static_cast<u8>(u8' ')));
+}
+__jakt_var_683 = ((*this).formatted_token(token,trailing_trivia,DynamicArray<u8>::create_with({}))); goto __jakt_label_578;
 
 }
 __jakt_label_578:; __jakt_var_683.release_value(); }));
 };/*case end*/
-case 12 /* RSquare */: {
+case 11 /* LSquare */: {
 return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_684; {
+TRY((((*this).replace_state(formatter::State::Toplevel(open_parens,open_curlies,JaktInternal::checked_add(open_squares,static_cast<size_t>(1ULL)),is_extern)))));
+__jakt_var_684 = TRY((((*this).formatted_token(token)))); goto __jakt_label_579;
+
+}
+__jakt_label_579:; __jakt_var_684.release_value(); }));
+};/*case end*/
+case 12 /* RSquare */: {
+return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_685; {
 if (((open_squares) == (static_cast<size_t>(0ULL)))){
 ((*this).pop_state());
 ((((*this).index)--));
 return TRY((((*this).next_impl(true))));
 }
 TRY((((*this).replace_state(formatter::State::Toplevel(open_parens,open_curlies,JaktInternal::checked_sub(open_squares,static_cast<size_t>(1ULL)),is_extern)))));
-__jakt_var_684 = TRY((((*this).formatted_token(token)))); goto __jakt_label_579;
-
-}
-__jakt_label_579:; __jakt_var_684.release_value(); }));
-};/*case end*/
-case 7 /* LParen */: {
-return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_685; {
-TRY((((*this).replace_state(formatter::State::Toplevel(JaktInternal::checked_add(open_parens,static_cast<size_t>(1ULL)),open_curlies,open_squares,is_extern)))));
 __jakt_var_685 = TRY((((*this).formatted_token(token)))); goto __jakt_label_580;
 
 }
 __jakt_label_580:; __jakt_var_685.release_value(); }));
 };/*case end*/
-case 8 /* RParen */: {
+case 7 /* LParen */: {
 return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_686; {
+TRY((((*this).replace_state(formatter::State::Toplevel(JaktInternal::checked_add(open_parens,static_cast<size_t>(1ULL)),open_curlies,open_squares,is_extern)))));
+__jakt_var_686 = TRY((((*this).formatted_token(token)))); goto __jakt_label_581;
+
+}
+__jakt_label_581:; __jakt_var_686.release_value(); }));
+};/*case end*/
+case 8 /* RParen */: {
+return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_687; {
 if (((open_parens) == (static_cast<size_t>(0ULL)))){
 ((*this).pop_state());
 ((((*this).index)--));
 return TRY((((*this).next_impl(true))));
 }
 TRY((((*this).replace_state(formatter::State::Toplevel(JaktInternal::checked_sub(open_parens,static_cast<size_t>(1ULL)),open_curlies,open_squares,is_extern)))));
-__jakt_var_686 = TRY((((*this).formatted_token(token)))); goto __jakt_label_581;
-
-}
-__jakt_label_581:; __jakt_var_686.release_value(); }));
-};/*case end*/
-case 9 /* LCurly */: {
-return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_687; {
-TRY((((*this).replace_state(formatter::State::Toplevel(open_parens,JaktInternal::checked_add(open_curlies,static_cast<size_t>(1ULL)),open_squares,is_extern)))));
-__jakt_var_687 = ((*this).formatted_token(token,DynamicArray<u8>::create_with({}),DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}))); goto __jakt_label_582;
+__jakt_var_687 = TRY((((*this).formatted_token(token)))); goto __jakt_label_582;
 
 }
 __jakt_label_582:; __jakt_var_687.release_value(); }));
 };/*case end*/
-case 10 /* RCurly */: {
+case 9 /* LCurly */: {
 return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_688; {
+TRY((((*this).replace_state(formatter::State::Toplevel(open_parens,JaktInternal::checked_add(open_curlies,static_cast<size_t>(1ULL)),open_squares,is_extern)))));
+__jakt_var_688 = ((*this).formatted_token(token,DynamicArray<u8>::create_with({}),DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}))); goto __jakt_label_583;
+
+}
+__jakt_label_583:; __jakt_var_688.release_value(); }));
+};/*case end*/
+case 10 /* RCurly */: {
+return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_689; {
 if (((open_curlies) == (static_cast<size_t>(0ULL)))){
 ((*this).pop_state());
 ((((*this).index)) -= (static_cast<size_t>(1ULL)));
 return TRY((((*this).next_impl(true))));
 }
 TRY((((*this).replace_state(formatter::State::Toplevel(open_parens,JaktInternal::checked_sub(open_curlies,static_cast<size_t>(1ULL)),open_squares,is_extern)))));
-__jakt_var_688 = TRY((((*this).formatted_token(token)))); goto __jakt_label_583;
-
-}
-__jakt_label_583:; __jakt_var_688.release_value(); }));
-};/*case end*/
-case 5 /* Colon */: {
-return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_689; {
-TRY((((*this).push_state(formatter::State::TypeContext(static_cast<size_t>(0ULL),static_cast<size_t>(0ULL),static_cast<size_t>(0ULL),static_cast<size_t>(0ULL),false)))));
-__jakt_var_689 = ((*this).formatted_token(token,DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}),DynamicArray<u8>::create_with({}))); goto __jakt_label_584;
+__jakt_var_689 = TRY((((*this).formatted_token(token)))); goto __jakt_label_584;
 
 }
 __jakt_label_584:; __jakt_var_689.release_value(); }));
 };/*case end*/
-case 78 /* Import */: {
+case 5 /* Colon */: {
 return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_690; {
-TRY((((*this).push_state(formatter::State::Import(((((*this).peek(static_cast<i64>(0LL)))).__jakt_init_index() == 72 /* Extern */))))));
+TRY((((*this).push_state(formatter::State::TypeContext(static_cast<size_t>(0ULL),static_cast<size_t>(0ULL),static_cast<size_t>(0ULL),static_cast<size_t>(0ULL),false)))));
 __jakt_var_690 = ((*this).formatted_token(token,DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}),DynamicArray<u8>::create_with({}))); goto __jakt_label_585;
 
 }
 __jakt_label_585:; __jakt_var_690.release_value(); }));
+};/*case end*/
+case 78 /* Import */: {
+return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_691; {
+TRY((((*this).push_state(formatter::State::Import(((((*this).peek(static_cast<i64>(0LL)))).__jakt_init_index() == 72 /* Extern */))))));
+__jakt_var_691 = ((*this).formatted_token(token,DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}),DynamicArray<u8>::create_with({}))); goto __jakt_label_586;
+
+}
+__jakt_label_586:; __jakt_var_691.release_value(); }));
 };/*case end*/
 case 91 /* Public */: {
 return JaktInternal::ExplicitValue(((*this).formatted_token(token,DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}),DynamicArray<u8>::create_with({}))));
@@ -901,23 +901,23 @@ case 103 /* Unsafe */: {
 return JaktInternal::ExplicitValue(((*this).formatted_token(token,DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}),DynamicArray<u8>::create_with({}))));
 };/*case end*/
 case 95 /* Restricted */: {
-return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_691; {
+return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_692; {
 TRY((((*this).push_state(formatter::State::RestrictionList()))));
-__jakt_var_691 = TRY((((*this).formatted_token(token)))); goto __jakt_label_586;
+__jakt_var_692 = TRY((((*this).formatted_token(token)))); goto __jakt_label_587;
 
 }
-__jakt_label_586:; __jakt_var_691.release_value(); }));
+__jakt_label_587:; __jakt_var_692.release_value(); }));
 };/*case end*/
 case 52 /* Comma */: {
 return JaktInternal::ExplicitValue(((*this).formatted_token(token,DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}),DynamicArray<u8>::create_with({}))));
 };/*case end*/
 case 16 /* Equal */: {
-return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_692; {
+return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_693; {
 TRY((((*this).push_state(formatter::State::StatementContext(static_cast<size_t>(0ULL),static_cast<size_t>(0ULL),static_cast<size_t>(0ULL),static_cast<size_t>(0ULL),static_cast<size_t>(0ULL),false,formatter::ExpressionMode::AtExpressionStart(),static_cast<size_t>(0ULL))))));
-__jakt_var_692 = ((*this).formatted_token(token,DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}),DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}))); goto __jakt_label_587;
+__jakt_var_693 = ((*this).formatted_token(token,DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}),DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}))); goto __jakt_label_588;
 
 }
-__jakt_label_587:; __jakt_var_692.release_value(); }));
+__jakt_label_588:; __jakt_var_693.release_value(); }));
 };/*case end*/
 default: {
 return JaktInternal::ExplicitValue(TRY((((*this).formatted_token(token)))));
@@ -945,7 +945,7 @@ case 61 /* As */: {
 return JaktInternal::ExplicitValue(((*this).formatted_token(token,DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}),DynamicArray<u8>::create_with({}))));
 };/*case end*/
 case 3 /* Identifier */: {
-return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_693; {
+return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_694; {
 if (((!(is_extern)) && ((((*this).peek(static_cast<i64>(0LL)))).__jakt_init_index() == 7 /* LParen */))){
 return TRY((((*this).formatted_token(token))));
 }
@@ -955,16 +955,16 @@ return TRY((((*this).formatted_token(token))));
 if (((!(is_extern)) && ((!(((((*this).peek(static_cast<i64>(0LL)))).__jakt_init_index() == 9 /* LCurly */))) && (!(((((*this).peek(static_cast<i64>(0LL)))).__jakt_init_index() == 61 /* As */)))))){
 ((*this).pop_state());
 }
-__jakt_var_693 = ((*this).formatted_token(token,DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}),DynamicArray<u8>::create_with({}))); goto __jakt_label_588;
+__jakt_var_694 = ((*this).formatted_token(token,DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}),DynamicArray<u8>::create_with({}))); goto __jakt_label_589;
 
 }
-__jakt_label_588:; __jakt_var_693.release_value(); }));
+__jakt_label_589:; __jakt_var_694.release_value(); }));
 };/*case end*/
 case 7 /* LParen */: {
 return JaktInternal::ExplicitValue(TRY((((*this).formatted_token(token)))));
 };/*case end*/
 case 9 /* LCurly */: {
-return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_694; {
+return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_695; {
 if (is_extern){
 TRY((((*this).push_state(formatter::State::Toplevel(static_cast<size_t>(0ULL),static_cast<size_t>(0ULL),static_cast<size_t>(0ULL),is_extern)))));
 }
@@ -972,22 +972,22 @@ else {
 TRY((((*this).push_state(formatter::State::ImportList(true)))));
 }
 
-__jakt_var_694 = TRY((((*this).formatted_token(token)))); goto __jakt_label_589;
-
-}
-__jakt_label_589:; __jakt_var_694.release_value(); }));
-};/*case end*/
-case 10 /* RCurly */: {
-return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_695; {
-((*this).pop_state());
 __jakt_var_695 = TRY((((*this).formatted_token(token)))); goto __jakt_label_590;
 
 }
 __jakt_label_590:; __jakt_var_695.release_value(); }));
 };/*case end*/
-case 52 /* Comma */: {
+case 10 /* RCurly */: {
 return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_696; {
-__jakt_var_696 = ((*this).formatted_token(token,({
+((*this).pop_state());
+__jakt_var_696 = TRY((((*this).formatted_token(token)))); goto __jakt_label_591;
+
+}
+__jakt_label_591:; __jakt_var_696.release_value(); }));
+};/*case end*/
+case 52 /* Comma */: {
+return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_697; {
+__jakt_var_697 = ((*this).formatted_token(token,({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<JaktInternal::DynamicArray<u8>, ErrorOr<JaktInternal::Optional<formatter::FormattedToken>>>{
 auto&& __jakt_match_variant = ((*this).peek(static_cast<i64>(0LL)));
 switch(__jakt_match_variant.__jakt_init_index()) {
@@ -1003,10 +1003,10 @@ return JaktInternal::ExplicitValue(DynamicArray<u8>::create_with({static_cast<u8
     if (_jakt_value.is_return())
         return _jakt_value.release_return();
     _jakt_value.release_value();
-}),DynamicArray<u8>::create_with({}))); goto __jakt_label_591;
+}),DynamicArray<u8>::create_with({}))); goto __jakt_label_592;
 
 }
-__jakt_label_591:; __jakt_var_696.release_value(); }));
+__jakt_label_592:; __jakt_var_697.release_value(); }));
 };/*case end*/
 case 6 /* ColonColon */: {
 return JaktInternal::ExplicitValue(TRY((((*this).formatted_token(token)))));
@@ -1031,12 +1031,12 @@ return ({
 auto&& __jakt_match_variant = token;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 8 /* RParen */: {
-return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_697; {
+return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_698; {
 ((*this).pop_state());
-__jakt_var_697 = TRY((((*this).formatted_token(token)))); goto __jakt_label_592;
+__jakt_var_698 = TRY((((*this).formatted_token(token)))); goto __jakt_label_593;
 
 }
-__jakt_label_592:; __jakt_var_697.release_value(); }));
+__jakt_label_593:; __jakt_var_698.release_value(); }));
 };/*case end*/
 default: {
 return JaktInternal::ExplicitValue(TRY((((*this).formatted_token(token)))));
@@ -1065,12 +1065,12 @@ return TRY((((*this).next_impl(true))));
 }
 };/*case end*/
 case 52 /* Comma */: {
-return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_698; {
+return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_699; {
 TRY((((*this).replace_state(formatter::State::ImportList(true)))));
-__jakt_var_698 = ((*this).formatted_token(token,DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}),DynamicArray<u8>::create_with({}))); goto __jakt_label_593;
+__jakt_var_699 = ((*this).formatted_token(token,DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}),DynamicArray<u8>::create_with({}))); goto __jakt_label_594;
 
 }
-__jakt_label_593:; __jakt_var_698.release_value(); }));
+__jakt_label_594:; __jakt_var_699.release_value(); }));
 };/*case end*/
 case 55 /* Eol */: {
 {
@@ -1078,7 +1078,7 @@ return TRY((((*this).next())));
 }
 };/*case end*/
 default: {
-return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_699; {
+return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_700; {
 JaktInternal::DynamicArray<ByteString> collection = DynamicArray<ByteString>::create_with({});
 ByteString output = (ByteString::from_utf8_without_validation(""sv));
 utility::Span const span = ((token).span());
@@ -1199,10 +1199,10 @@ else {
 
 ((*this).pop_state());
 ((((*this).index)--));
-__jakt_var_699 = TRY((((*this).formatted_token(lexer::Token::Identifier(output,span))))); goto __jakt_label_594;
+__jakt_var_700 = TRY((((*this).formatted_token(lexer::Token::Identifier(output,span))))); goto __jakt_label_595;
 
 }
-__jakt_label_594:; __jakt_var_699.release_value(); }));
+__jakt_label_595:; __jakt_var_700.release_value(); }));
 };/*case end*/
 }/*switch end*/
 }()
@@ -1221,17 +1221,17 @@ return ({
 auto&& __jakt_match_variant = token;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 28 /* LessThan */: {
-return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_700; {
+return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_701; {
 if (accept_generics){
 TRY((((*this).replace_state(formatter::State::EntityDeclaration(entity,accept_generics,true,JaktInternal::checked_add(generic_nesting,static_cast<size_t>(1ULL)),is_extern)))));
 }
-__jakt_var_700 = TRY((((*this).formatted_token(token)))); goto __jakt_label_595;
+__jakt_var_701 = TRY((((*this).formatted_token(token)))); goto __jakt_label_596;
 
 }
-__jakt_label_595:; __jakt_var_700.release_value(); }));
+__jakt_label_596:; __jakt_var_701.release_value(); }));
 };/*case end*/
 case 26 /* GreaterThan */: {
-return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_701; {
+return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_702; {
 if (accept_generics){
 if ([](size_t const& self, size_t rhs) -> bool {
 {
@@ -1251,13 +1251,13 @@ TRY((((*this).replace_state(formatter::State::EntityDefinition(entity,is_extern)
 }
 
 }
-__jakt_var_701 = TRY((((*this).formatted_token(token)))); goto __jakt_label_596;
+__jakt_var_702 = TRY((((*this).formatted_token(token)))); goto __jakt_label_597;
 
 }
-__jakt_label_596:; __jakt_var_701.release_value(); }));
+__jakt_label_597:; __jakt_var_702.release_value(); }));
 };/*case end*/
 case 3 /* Identifier */: {
-return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_702; {
+return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_703; {
 if ((((generic_nesting) == (static_cast<size_t>(0ULL))) && ((!(((((*this).peek(static_cast<i64>(0LL)))).__jakt_init_index() == 28 /* LessThan */))) && (!(has_generics))))){
 TRY((((*this).replace_state(formatter::State::EntityDefinition(entity,is_extern)))));
 }
@@ -1265,29 +1265,29 @@ if (((((*this).peek(static_cast<i64>(0LL)))).__jakt_init_index() == 109 /* Imple
 TRY((((*this).push_state(formatter::State::Implements()))));
 return ((*this).formatted_token(token,DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}),DynamicArray<u8>::create_with({})));
 }
-__jakt_var_702 = TRY((((*this).formatted_token(token)))); goto __jakt_label_597;
-
-}
-__jakt_label_597:; __jakt_var_702.release_value(); }));
-};/*case end*/
-case 52 /* Comma */: {
-return JaktInternal::ExplicitValue(((*this).formatted_token(token,DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}),DynamicArray<u8>::create_with({}))));
-};/*case end*/
-case 10 /* RCurly */: {
-return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_703; {
-((*this).pop_state());
 __jakt_var_703 = TRY((((*this).formatted_token(token)))); goto __jakt_label_598;
 
 }
 __jakt_label_598:; __jakt_var_703.release_value(); }));
 };/*case end*/
-case 55 /* Eol */: {
+case 52 /* Comma */: {
+return JaktInternal::ExplicitValue(((*this).formatted_token(token,DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}),DynamicArray<u8>::create_with({}))));
+};/*case end*/
+case 10 /* RCurly */: {
 return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_704; {
 ((*this).pop_state());
 __jakt_var_704 = TRY((((*this).formatted_token(token)))); goto __jakt_label_599;
 
 }
 __jakt_label_599:; __jakt_var_704.release_value(); }));
+};/*case end*/
+case 55 /* Eol */: {
+return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_705; {
+((*this).pop_state());
+__jakt_var_705 = TRY((((*this).formatted_token(token)))); goto __jakt_label_600;
+
+}
+__jakt_label_600:; __jakt_var_705.release_value(); }));
 };/*case end*/
 case 91 /* Public */: {
 return JaktInternal::ExplicitValue(((*this).formatted_token(token,DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}),DynamicArray<u8>::create_with({}))));
@@ -1302,12 +1302,12 @@ case 89 /* Override */: {
 return JaktInternal::ExplicitValue(((*this).formatted_token(token,DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}),DynamicArray<u8>::create_with({}))));
 };/*case end*/
 case 95 /* Restricted */: {
-return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_705; {
+return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_706; {
 TRY((((*this).push_state(formatter::State::RestrictionList()))));
-__jakt_var_705 = TRY((((*this).formatted_token(token)))); goto __jakt_label_600;
+__jakt_var_706 = TRY((((*this).formatted_token(token)))); goto __jakt_label_601;
 
 }
-__jakt_label_600:; __jakt_var_705.release_value(); }));
+__jakt_label_601:; __jakt_var_706.release_value(); }));
 };/*case end*/
 case 110 /* Requires */: {
 return JaktInternal::ExplicitValue(((*this).formatted_token(token,DynamicArray<u8>::create_with({}),DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}))));
@@ -1337,9 +1337,9 @@ return JaktInternal::ExplicitValue(({
 auto&& __jakt_match_variant = token;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 10 /* RCurly */: {
-return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_706; {
+return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_707; {
 ((*this).pop_state());
-__jakt_var_706 = ((*this).formatted_token(token,DynamicArray<u8>::create_with({}),({
+__jakt_var_707 = ((*this).formatted_token(token,DynamicArray<u8>::create_with({}),({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<JaktInternal::DynamicArray<u8>, ErrorOr<JaktInternal::Optional<formatter::FormattedToken>>>{
 auto&& __jakt_match_variant = ((*this).peek((-(static_cast<i64>(1LL)))));
 switch(__jakt_match_variant.__jakt_init_index()) {
@@ -1358,15 +1358,15 @@ return JaktInternal::ExplicitValue(DynamicArray<u8>::create_with({static_cast<u8
     if (_jakt_value.is_return())
         return _jakt_value.release_return();
     _jakt_value.release_value();
-}))); goto __jakt_label_601;
+}))); goto __jakt_label_602;
 
 }
-__jakt_label_601:; __jakt_var_706.release_value(); }));
+__jakt_label_602:; __jakt_var_707.release_value(); }));
 };/*case end*/
 case 9 /* LCurly */: {
-return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_707; {
+return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_708; {
 TRY((((*this).push_state(formatter::State::Toplevel(static_cast<size_t>(0ULL),static_cast<size_t>(0ULL),static_cast<size_t>(0ULL),is_extern)))));
-__jakt_var_707 = ((*this).formatted_token(token,({
+__jakt_var_708 = ((*this).formatted_token(token,({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<JaktInternal::DynamicArray<u8>, ErrorOr<JaktInternal::Optional<formatter::FormattedToken>>>{
 auto&& __jakt_match_variant = ((*this).peek(static_cast<i64>(0LL)));
 switch(__jakt_match_variant.__jakt_init_index()) {
@@ -1385,10 +1385,10 @@ return JaktInternal::ExplicitValue(DynamicArray<u8>::create_with({static_cast<u8
     if (_jakt_value.is_return())
         return _jakt_value.release_return();
     _jakt_value.release_value();
-}),DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}))); goto __jakt_label_602;
+}),DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}))); goto __jakt_label_603;
 
 }
-__jakt_label_602:; __jakt_var_707.release_value(); }));
+__jakt_label_603:; __jakt_var_708.release_value(); }));
 };/*case end*/
 case 5 /* Colon */: {
 return JaktInternal::ExplicitValue(((*this).formatted_token(token,DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}),DynamicArray<u8>::create_with({}))));
@@ -1416,9 +1416,9 @@ return JaktInternal::ExplicitValue(({
 auto&& __jakt_match_variant = token;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 10 /* RCurly */: {
-return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_708; {
+return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_709; {
 ((*this).pop_state());
-__jakt_var_708 = ((*this).formatted_token(token,DynamicArray<u8>::create_with({}),({
+__jakt_var_709 = ((*this).formatted_token(token,DynamicArray<u8>::create_with({}),({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<JaktInternal::DynamicArray<u8>, ErrorOr<JaktInternal::Optional<formatter::FormattedToken>>>{
 auto&& __jakt_match_variant = ((*this).peek((-(static_cast<i64>(1LL)))));
 switch(__jakt_match_variant.__jakt_init_index()) {
@@ -1437,15 +1437,15 @@ return JaktInternal::ExplicitValue(DynamicArray<u8>::create_with({static_cast<u8
     if (_jakt_value.is_return())
         return _jakt_value.release_return();
     _jakt_value.release_value();
-}))); goto __jakt_label_603;
+}))); goto __jakt_label_604;
 
 }
-__jakt_label_603:; __jakt_var_708.release_value(); }));
+__jakt_label_604:; __jakt_var_709.release_value(); }));
 };/*case end*/
 case 9 /* LCurly */: {
-return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_709; {
+return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_710; {
 TRY((((*this).push_state(formatter::State::Toplevel(static_cast<size_t>(0ULL),static_cast<size_t>(0ULL),static_cast<size_t>(0ULL),is_extern)))));
-__jakt_var_709 = ((*this).formatted_token(token,({
+__jakt_var_710 = ((*this).formatted_token(token,({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<JaktInternal::DynamicArray<u8>, ErrorOr<JaktInternal::Optional<formatter::FormattedToken>>>{
 auto&& __jakt_match_variant = ((*this).peek(static_cast<i64>(0LL)));
 switch(__jakt_match_variant.__jakt_init_index()) {
@@ -1464,10 +1464,10 @@ return JaktInternal::ExplicitValue(DynamicArray<u8>::create_with({static_cast<u8
     if (_jakt_value.is_return())
         return _jakt_value.release_return();
     _jakt_value.release_value();
-}),DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}))); goto __jakt_label_604;
+}),DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}))); goto __jakt_label_605;
 
 }
-__jakt_label_604:; __jakt_var_709.release_value(); }));
+__jakt_label_605:; __jakt_var_710.release_value(); }));
 };/*case end*/
 case 5 /* Colon */: {
 return JaktInternal::ExplicitValue(((*this).formatted_token(token,DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}),DynamicArray<u8>::create_with({}))));
@@ -1495,9 +1495,9 @@ return JaktInternal::ExplicitValue(({
 auto&& __jakt_match_variant = token;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 10 /* RCurly */: {
-return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_710; {
+return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_711; {
 ((*this).pop_state());
-__jakt_var_710 = ((*this).formatted_token(token,DynamicArray<u8>::create_with({}),({
+__jakt_var_711 = ((*this).formatted_token(token,DynamicArray<u8>::create_with({}),({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<JaktInternal::DynamicArray<u8>, ErrorOr<JaktInternal::Optional<formatter::FormattedToken>>>{
 auto&& __jakt_match_variant = ((*this).peek((-(static_cast<i64>(1LL)))));
 switch(__jakt_match_variant.__jakt_init_index()) {
@@ -1516,15 +1516,15 @@ return JaktInternal::ExplicitValue(DynamicArray<u8>::create_with({static_cast<u8
     if (_jakt_value.is_return())
         return _jakt_value.release_return();
     _jakt_value.release_value();
-}))); goto __jakt_label_605;
+}))); goto __jakt_label_606;
 
 }
-__jakt_label_605:; __jakt_var_710.release_value(); }));
+__jakt_label_606:; __jakt_var_711.release_value(); }));
 };/*case end*/
 case 9 /* LCurly */: {
-return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_711; {
+return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_712; {
 TRY((((*this).push_state(formatter::State::Toplevel(static_cast<size_t>(0ULL),static_cast<size_t>(0ULL),static_cast<size_t>(0ULL),is_extern)))));
-__jakt_var_711 = ((*this).formatted_token(token,({
+__jakt_var_712 = ((*this).formatted_token(token,({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<JaktInternal::DynamicArray<u8>, ErrorOr<JaktInternal::Optional<formatter::FormattedToken>>>{
 auto&& __jakt_match_variant = ((*this).peek(static_cast<i64>(0LL)));
 switch(__jakt_match_variant.__jakt_init_index()) {
@@ -1543,10 +1543,10 @@ return JaktInternal::ExplicitValue(DynamicArray<u8>::create_with({static_cast<u8
     if (_jakt_value.is_return())
         return _jakt_value.release_return();
     _jakt_value.release_value();
-}),DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}))); goto __jakt_label_606;
+}),DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}))); goto __jakt_label_607;
 
 }
-__jakt_label_606:; __jakt_var_711.release_value(); }));
+__jakt_label_607:; __jakt_var_712.release_value(); }));
 };/*case end*/
 case 5 /* Colon */: {
 return JaktInternal::ExplicitValue(((*this).formatted_token(token,DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}),DynamicArray<u8>::create_with({}))));
@@ -1576,7 +1576,7 @@ return JaktInternal::ExplicitValue(({
 auto&& __jakt_match_variant = token;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 57 /* FatArrow */: {
-return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_712; {
+return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_713; {
 bool const next_is_eol = ((((*this).peek(static_cast<i64>(0LL)))).__jakt_init_index() == 55 /* Eol */);
 TRY((((*this).replace_state(formatter::State::EntityDefinition(formatter::Entity::Function(true,next_is_eol),is_extern)))));
 if (next_is_eol){
@@ -1592,26 +1592,26 @@ if (next_is_eol){
 (eols_allowed = static_cast<size_t>(1ULL));
 }
 TRY((((*this).push_state(formatter::State::StatementContext(static_cast<size_t>(0ULL),static_cast<size_t>(0ULL),static_cast<size_t>(0ULL),static_cast<size_t>(0ULL),eols_allowed,false,formatter::ExpressionMode::BeforeExpressions(),static_cast<size_t>(0ULL))))));
-__jakt_var_712 = ((*this).formatted_token(token,DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}),DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}))); goto __jakt_label_607;
-
-}
-__jakt_label_607:; __jakt_var_712.release_value(); }));
-};/*case end*/
-case 58 /* Arrow */: {
-return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_713; {
-TRY((((*this).push_state(formatter::State::TypeContext(static_cast<size_t>(0ULL),static_cast<size_t>(0ULL),static_cast<size_t>(0ULL),static_cast<size_t>(0ULL),false)))));
 __jakt_var_713 = ((*this).formatted_token(token,DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}),DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}))); goto __jakt_label_608;
 
 }
 __jakt_label_608:; __jakt_var_713.release_value(); }));
 };/*case end*/
-case 7 /* LParen */: {
+case 58 /* Arrow */: {
 return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_714; {
-TRY((((*this).push_state(formatter::State::ParameterList(static_cast<size_t>(0ULL))))));
-__jakt_var_714 = TRY((((*this).formatted_token(token)))); goto __jakt_label_609;
+TRY((((*this).push_state(formatter::State::TypeContext(static_cast<size_t>(0ULL),static_cast<size_t>(0ULL),static_cast<size_t>(0ULL),static_cast<size_t>(0ULL),false)))));
+__jakt_var_714 = ((*this).formatted_token(token,DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}),DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}))); goto __jakt_label_609;
 
 }
 __jakt_label_609:; __jakt_var_714.release_value(); }));
+};/*case end*/
+case 7 /* LParen */: {
+return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_715; {
+TRY((((*this).push_state(formatter::State::ParameterList(static_cast<size_t>(0ULL))))));
+__jakt_var_715 = TRY((((*this).formatted_token(token)))); goto __jakt_label_610;
+
+}
+__jakt_label_610:; __jakt_var_715.release_value(); }));
 };/*case end*/
 case 8 /* RParen */: {
 return JaktInternal::ExplicitValue(((*this).formatted_token(token,({
@@ -1633,23 +1633,23 @@ return JaktInternal::ExplicitValue(DynamicArray<u8>::create_with({}));
 }),DynamicArray<u8>::create_with({}))));
 };/*case end*/
 case 9 /* LCurly */: {
-return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_715; {
-TRY((((*this).push_state(formatter::State::StatementContext(static_cast<size_t>(0ULL),static_cast<size_t>(0ULL),static_cast<size_t>(0ULL),static_cast<size_t>(0ULL),JaktInternal::OptionalNone(),false,formatter::ExpressionMode::OutsideExpression(),static_cast<size_t>(0ULL))))));
-__jakt_var_715 = ((*this).formatted_token(token,DynamicArray<u8>::create_with({}),DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}))); goto __jakt_label_610;
-
-}
-__jakt_label_610:; __jakt_var_715.release_value(); }));
-};/*case end*/
-case 10 /* RCurly */: {
 return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_716; {
-((*this).pop_state());
-__jakt_var_716 = TRY((((*this).formatted_token(token)))); goto __jakt_label_611;
+TRY((((*this).push_state(formatter::State::StatementContext(static_cast<size_t>(0ULL),static_cast<size_t>(0ULL),static_cast<size_t>(0ULL),static_cast<size_t>(0ULL),JaktInternal::OptionalNone(),false,formatter::ExpressionMode::OutsideExpression(),static_cast<size_t>(0ULL))))));
+__jakt_var_716 = ((*this).formatted_token(token,DynamicArray<u8>::create_with({}),DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}))); goto __jakt_label_611;
 
 }
 __jakt_label_611:; __jakt_var_716.release_value(); }));
 };/*case end*/
-case 55 /* Eol */: {
+case 10 /* RCurly */: {
 return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_717; {
+((*this).pop_state());
+__jakt_var_717 = TRY((((*this).formatted_token(token)))); goto __jakt_label_612;
+
+}
+__jakt_label_612:; __jakt_var_717.release_value(); }));
+};/*case end*/
+case 55 /* Eol */: {
+return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_718; {
 if ((!(arrow))){
 ((*this).pop_state());
 return TRY((((*this).formatted_token(token))));
@@ -1686,10 +1686,10 @@ return (infallible_enum_cast<jakt__prelude__operators::Ordering>((JaktInternal::
 ((((((*this).dedents_to_skip))[JaktInternal::checked_sub(((((*this).dedents_to_skip)).size()),static_cast<size_t>(1ULL))])) -= (static_cast<size_t>(1ULL)));
 }
 }
-__jakt_var_717 = TRY((((*this).formatted_token(token)))); goto __jakt_label_612;
+__jakt_var_718 = TRY((((*this).formatted_token(token)))); goto __jakt_label_613;
 
 }
-__jakt_label_612:; __jakt_var_717.release_value(); }));
+__jakt_label_613:; __jakt_var_718.release_value(); }));
 };/*case end*/
 default: {
 return JaktInternal::ExplicitValue(TRY((((*this).formatted_token(token)))));
@@ -1719,43 +1719,32 @@ return ({
 auto&& __jakt_match_variant = token;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 82 /* Let */: {
-return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_718; {
+return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_719; {
 TRY((((*this).replace_state(formatter::State::StatementContext(open_parens,open_curlies,open_squares,arrow_indents,allow_eol,inserted_comma,formatter::ExpressionMode::OutsideExpression(),dedents_on_open_curly)))));
 TRY((((*this).push_state(formatter::State::VariableDeclaration(static_cast<size_t>(0ULL))))));
-__jakt_var_718 = ((*this).formatted_token(token,DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}),DynamicArray<u8>::create_with({}))); goto __jakt_label_613;
-
-}
-__jakt_label_613:; __jakt_var_718.release_value(); }));
-};/*case end*/
-case 85 /* Mut */: {
-return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_719; {
-TRY((((*this).replace_state(formatter::State::StatementContext(open_parens,open_curlies,open_squares,arrow_indents,allow_eol,inserted_comma,formatter::ExpressionMode::AtExpressionStart(),dedents_on_open_curly)))));
-if (((expression_mode).__jakt_init_index() == 0 /* OutsideExpression */)){
-TRY((((*this).push_state(formatter::State::VariableDeclaration(static_cast<size_t>(0ULL))))));
-}
 __jakt_var_719 = ((*this).formatted_token(token,DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}),DynamicArray<u8>::create_with({}))); goto __jakt_label_614;
 
 }
 __jakt_label_614:; __jakt_var_719.release_value(); }));
 };/*case end*/
-case 84 /* Match */: {
+case 85 /* Mut */: {
 return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_720; {
+TRY((((*this).replace_state(formatter::State::StatementContext(open_parens,open_curlies,open_squares,arrow_indents,allow_eol,inserted_comma,formatter::ExpressionMode::AtExpressionStart(),dedents_on_open_curly)))));
+if (((expression_mode).__jakt_init_index() == 0 /* OutsideExpression */)){
+TRY((((*this).push_state(formatter::State::VariableDeclaration(static_cast<size_t>(0ULL))))));
+}
+__jakt_var_720 = ((*this).formatted_token(token,DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}),DynamicArray<u8>::create_with({}))); goto __jakt_label_615;
+
+}
+__jakt_label_615:; __jakt_var_720.release_value(); }));
+};/*case end*/
+case 84 /* Match */: {
+return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_721; {
 size_t const added_indent = ({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<size_t, ErrorOr<JaktInternal::Optional<formatter::FormattedToken>>>{
 auto&& __jakt_match_variant = token;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 84 /* Match */: {
-return JaktInternal::ExplicitValue(({ Optional<size_t> __jakt_var_721; {
-size_t indent = static_cast<size_t>(1ULL);
-if (((*this).line_has_indent())){
-(indent = static_cast<size_t>(0ULL));
-}
-__jakt_var_721 = indent; goto __jakt_label_616;
-
-}
-__jakt_label_616:; __jakt_var_721.release_value(); }));
-};/*case end*/
-case 74 /* For */: {
 return JaktInternal::ExplicitValue(({ Optional<size_t> __jakt_var_722; {
 size_t indent = static_cast<size_t>(1ULL);
 if (((*this).line_has_indent())){
@@ -1766,7 +1755,7 @@ __jakt_var_722 = indent; goto __jakt_label_617;
 }
 __jakt_label_617:; __jakt_var_722.release_value(); }));
 };/*case end*/
-case 106 /* While */: {
+case 74 /* For */: {
 return JaktInternal::ExplicitValue(({ Optional<size_t> __jakt_var_723; {
 size_t indent = static_cast<size_t>(1ULL);
 if (((*this).line_has_indent())){
@@ -1777,7 +1766,7 @@ __jakt_var_723 = indent; goto __jakt_label_618;
 }
 __jakt_label_618:; __jakt_var_723.release_value(); }));
 };/*case end*/
-case 77 /* If */: {
+case 106 /* While */: {
 return JaktInternal::ExplicitValue(({ Optional<size_t> __jakt_var_724; {
 size_t indent = static_cast<size_t>(1ULL);
 if (((*this).line_has_indent())){
@@ -1788,7 +1777,7 @@ __jakt_var_724 = indent; goto __jakt_label_619;
 }
 __jakt_label_619:; __jakt_var_724.release_value(); }));
 };/*case end*/
-case 108 /* Guard */: {
+case 77 /* If */: {
 return JaktInternal::ExplicitValue(({ Optional<size_t> __jakt_var_725; {
 size_t indent = static_cast<size_t>(1ULL);
 if (((*this).line_has_indent())){
@@ -1799,6 +1788,17 @@ __jakt_var_725 = indent; goto __jakt_label_620;
 }
 __jakt_label_620:; __jakt_var_725.release_value(); }));
 };/*case end*/
+case 108 /* Guard */: {
+return JaktInternal::ExplicitValue(({ Optional<size_t> __jakt_var_726; {
+size_t indent = static_cast<size_t>(1ULL);
+if (((*this).line_has_indent())){
+(indent = static_cast<size_t>(0ULL));
+}
+__jakt_var_726 = indent; goto __jakt_label_621;
+
+}
+__jakt_label_621:; __jakt_var_726.release_value(); }));
+};/*case end*/
 default: {
 return JaktInternal::ExplicitValue(static_cast<size_t>(0ULL));
 };/*case end*/
@@ -1811,29 +1811,18 @@ return JaktInternal::ExplicitValue(static_cast<size_t>(0ULL));
 });
 TRY((((*this).replace_state(formatter::State::StatementContext(open_parens,open_curlies,open_squares,arrow_indents,allow_eol,inserted_comma,formatter::ExpressionMode::AtExpressionStart(),JaktInternal::checked_add(dedents_on_open_curly,added_indent))))));
 ((((indent_change))) += ((infallible_integer_cast<i64>((added_indent)))));
-__jakt_var_720 = ((*this).formatted_token(token,DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}),DynamicArray<u8>::create_with({}))); goto __jakt_label_615;
+__jakt_var_721 = ((*this).formatted_token(token,DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}),DynamicArray<u8>::create_with({}))); goto __jakt_label_616;
 
 }
-__jakt_label_615:; __jakt_var_720.release_value(); }));
+__jakt_label_616:; __jakt_var_721.release_value(); }));
 };/*case end*/
 case 74 /* For */: {
-return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_726; {
+return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_727; {
 size_t const added_indent = ({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<size_t, ErrorOr<JaktInternal::Optional<formatter::FormattedToken>>>{
 auto&& __jakt_match_variant = token;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 84 /* Match */: {
-return JaktInternal::ExplicitValue(({ Optional<size_t> __jakt_var_727; {
-size_t indent = static_cast<size_t>(1ULL);
-if (((*this).line_has_indent())){
-(indent = static_cast<size_t>(0ULL));
-}
-__jakt_var_727 = indent; goto __jakt_label_622;
-
-}
-__jakt_label_622:; __jakt_var_727.release_value(); }));
-};/*case end*/
-case 74 /* For */: {
 return JaktInternal::ExplicitValue(({ Optional<size_t> __jakt_var_728; {
 size_t indent = static_cast<size_t>(1ULL);
 if (((*this).line_has_indent())){
@@ -1844,7 +1833,7 @@ __jakt_var_728 = indent; goto __jakt_label_623;
 }
 __jakt_label_623:; __jakt_var_728.release_value(); }));
 };/*case end*/
-case 106 /* While */: {
+case 74 /* For */: {
 return JaktInternal::ExplicitValue(({ Optional<size_t> __jakt_var_729; {
 size_t indent = static_cast<size_t>(1ULL);
 if (((*this).line_has_indent())){
@@ -1855,7 +1844,7 @@ __jakt_var_729 = indent; goto __jakt_label_624;
 }
 __jakt_label_624:; __jakt_var_729.release_value(); }));
 };/*case end*/
-case 77 /* If */: {
+case 106 /* While */: {
 return JaktInternal::ExplicitValue(({ Optional<size_t> __jakt_var_730; {
 size_t indent = static_cast<size_t>(1ULL);
 if (((*this).line_has_indent())){
@@ -1866,7 +1855,7 @@ __jakt_var_730 = indent; goto __jakt_label_625;
 }
 __jakt_label_625:; __jakt_var_730.release_value(); }));
 };/*case end*/
-case 108 /* Guard */: {
+case 77 /* If */: {
 return JaktInternal::ExplicitValue(({ Optional<size_t> __jakt_var_731; {
 size_t indent = static_cast<size_t>(1ULL);
 if (((*this).line_has_indent())){
@@ -1877,6 +1866,17 @@ __jakt_var_731 = indent; goto __jakt_label_626;
 }
 __jakt_label_626:; __jakt_var_731.release_value(); }));
 };/*case end*/
+case 108 /* Guard */: {
+return JaktInternal::ExplicitValue(({ Optional<size_t> __jakt_var_732; {
+size_t indent = static_cast<size_t>(1ULL);
+if (((*this).line_has_indent())){
+(indent = static_cast<size_t>(0ULL));
+}
+__jakt_var_732 = indent; goto __jakt_label_627;
+
+}
+__jakt_label_627:; __jakt_var_732.release_value(); }));
+};/*case end*/
 default: {
 return JaktInternal::ExplicitValue(static_cast<size_t>(0ULL));
 };/*case end*/
@@ -1889,29 +1889,18 @@ return JaktInternal::ExplicitValue(static_cast<size_t>(0ULL));
 });
 TRY((((*this).replace_state(formatter::State::StatementContext(open_parens,open_curlies,open_squares,arrow_indents,allow_eol,inserted_comma,formatter::ExpressionMode::AtExpressionStart(),JaktInternal::checked_add(dedents_on_open_curly,added_indent))))));
 ((((indent_change))) += ((infallible_integer_cast<i64>((added_indent)))));
-__jakt_var_726 = ((*this).formatted_token(token,DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}),DynamicArray<u8>::create_with({}))); goto __jakt_label_621;
+__jakt_var_727 = ((*this).formatted_token(token,DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}),DynamicArray<u8>::create_with({}))); goto __jakt_label_622;
 
 }
-__jakt_label_621:; __jakt_var_726.release_value(); }));
+__jakt_label_622:; __jakt_var_727.release_value(); }));
 };/*case end*/
 case 106 /* While */: {
-return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_732; {
+return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_733; {
 size_t const added_indent = ({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<size_t, ErrorOr<JaktInternal::Optional<formatter::FormattedToken>>>{
 auto&& __jakt_match_variant = token;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 84 /* Match */: {
-return JaktInternal::ExplicitValue(({ Optional<size_t> __jakt_var_733; {
-size_t indent = static_cast<size_t>(1ULL);
-if (((*this).line_has_indent())){
-(indent = static_cast<size_t>(0ULL));
-}
-__jakt_var_733 = indent; goto __jakt_label_628;
-
-}
-__jakt_label_628:; __jakt_var_733.release_value(); }));
-};/*case end*/
-case 74 /* For */: {
 return JaktInternal::ExplicitValue(({ Optional<size_t> __jakt_var_734; {
 size_t indent = static_cast<size_t>(1ULL);
 if (((*this).line_has_indent())){
@@ -1922,7 +1911,7 @@ __jakt_var_734 = indent; goto __jakt_label_629;
 }
 __jakt_label_629:; __jakt_var_734.release_value(); }));
 };/*case end*/
-case 106 /* While */: {
+case 74 /* For */: {
 return JaktInternal::ExplicitValue(({ Optional<size_t> __jakt_var_735; {
 size_t indent = static_cast<size_t>(1ULL);
 if (((*this).line_has_indent())){
@@ -1933,7 +1922,7 @@ __jakt_var_735 = indent; goto __jakt_label_630;
 }
 __jakt_label_630:; __jakt_var_735.release_value(); }));
 };/*case end*/
-case 77 /* If */: {
+case 106 /* While */: {
 return JaktInternal::ExplicitValue(({ Optional<size_t> __jakt_var_736; {
 size_t indent = static_cast<size_t>(1ULL);
 if (((*this).line_has_indent())){
@@ -1944,7 +1933,7 @@ __jakt_var_736 = indent; goto __jakt_label_631;
 }
 __jakt_label_631:; __jakt_var_736.release_value(); }));
 };/*case end*/
-case 108 /* Guard */: {
+case 77 /* If */: {
 return JaktInternal::ExplicitValue(({ Optional<size_t> __jakt_var_737; {
 size_t indent = static_cast<size_t>(1ULL);
 if (((*this).line_has_indent())){
@@ -1955,6 +1944,17 @@ __jakt_var_737 = indent; goto __jakt_label_632;
 }
 __jakt_label_632:; __jakt_var_737.release_value(); }));
 };/*case end*/
+case 108 /* Guard */: {
+return JaktInternal::ExplicitValue(({ Optional<size_t> __jakt_var_738; {
+size_t indent = static_cast<size_t>(1ULL);
+if (((*this).line_has_indent())){
+(indent = static_cast<size_t>(0ULL));
+}
+__jakt_var_738 = indent; goto __jakt_label_633;
+
+}
+__jakt_label_633:; __jakt_var_738.release_value(); }));
+};/*case end*/
 default: {
 return JaktInternal::ExplicitValue(static_cast<size_t>(0ULL));
 };/*case end*/
@@ -1967,29 +1967,18 @@ return JaktInternal::ExplicitValue(static_cast<size_t>(0ULL));
 });
 TRY((((*this).replace_state(formatter::State::StatementContext(open_parens,open_curlies,open_squares,arrow_indents,allow_eol,inserted_comma,formatter::ExpressionMode::AtExpressionStart(),JaktInternal::checked_add(dedents_on_open_curly,added_indent))))));
 ((((indent_change))) += ((infallible_integer_cast<i64>((added_indent)))));
-__jakt_var_732 = ((*this).formatted_token(token,DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}),DynamicArray<u8>::create_with({}))); goto __jakt_label_627;
+__jakt_var_733 = ((*this).formatted_token(token,DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}),DynamicArray<u8>::create_with({}))); goto __jakt_label_628;
 
 }
-__jakt_label_627:; __jakt_var_732.release_value(); }));
+__jakt_label_628:; __jakt_var_733.release_value(); }));
 };/*case end*/
 case 77 /* If */: {
-return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_738; {
+return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_739; {
 size_t const added_indent = ({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<size_t, ErrorOr<JaktInternal::Optional<formatter::FormattedToken>>>{
 auto&& __jakt_match_variant = token;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 84 /* Match */: {
-return JaktInternal::ExplicitValue(({ Optional<size_t> __jakt_var_739; {
-size_t indent = static_cast<size_t>(1ULL);
-if (((*this).line_has_indent())){
-(indent = static_cast<size_t>(0ULL));
-}
-__jakt_var_739 = indent; goto __jakt_label_634;
-
-}
-__jakt_label_634:; __jakt_var_739.release_value(); }));
-};/*case end*/
-case 74 /* For */: {
 return JaktInternal::ExplicitValue(({ Optional<size_t> __jakt_var_740; {
 size_t indent = static_cast<size_t>(1ULL);
 if (((*this).line_has_indent())){
@@ -2000,7 +1989,7 @@ __jakt_var_740 = indent; goto __jakt_label_635;
 }
 __jakt_label_635:; __jakt_var_740.release_value(); }));
 };/*case end*/
-case 106 /* While */: {
+case 74 /* For */: {
 return JaktInternal::ExplicitValue(({ Optional<size_t> __jakt_var_741; {
 size_t indent = static_cast<size_t>(1ULL);
 if (((*this).line_has_indent())){
@@ -2011,7 +2000,7 @@ __jakt_var_741 = indent; goto __jakt_label_636;
 }
 __jakt_label_636:; __jakt_var_741.release_value(); }));
 };/*case end*/
-case 77 /* If */: {
+case 106 /* While */: {
 return JaktInternal::ExplicitValue(({ Optional<size_t> __jakt_var_742; {
 size_t indent = static_cast<size_t>(1ULL);
 if (((*this).line_has_indent())){
@@ -2022,7 +2011,7 @@ __jakt_var_742 = indent; goto __jakt_label_637;
 }
 __jakt_label_637:; __jakt_var_742.release_value(); }));
 };/*case end*/
-case 108 /* Guard */: {
+case 77 /* If */: {
 return JaktInternal::ExplicitValue(({ Optional<size_t> __jakt_var_743; {
 size_t indent = static_cast<size_t>(1ULL);
 if (((*this).line_has_indent())){
@@ -2033,6 +2022,17 @@ __jakt_var_743 = indent; goto __jakt_label_638;
 }
 __jakt_label_638:; __jakt_var_743.release_value(); }));
 };/*case end*/
+case 108 /* Guard */: {
+return JaktInternal::ExplicitValue(({ Optional<size_t> __jakt_var_744; {
+size_t indent = static_cast<size_t>(1ULL);
+if (((*this).line_has_indent())){
+(indent = static_cast<size_t>(0ULL));
+}
+__jakt_var_744 = indent; goto __jakt_label_639;
+
+}
+__jakt_label_639:; __jakt_var_744.release_value(); }));
+};/*case end*/
 default: {
 return JaktInternal::ExplicitValue(static_cast<size_t>(0ULL));
 };/*case end*/
@@ -2045,29 +2045,18 @@ return JaktInternal::ExplicitValue(static_cast<size_t>(0ULL));
 });
 TRY((((*this).replace_state(formatter::State::StatementContext(open_parens,open_curlies,open_squares,arrow_indents,allow_eol,inserted_comma,formatter::ExpressionMode::AtExpressionStart(),JaktInternal::checked_add(dedents_on_open_curly,added_indent))))));
 ((((indent_change))) += ((infallible_integer_cast<i64>((added_indent)))));
-__jakt_var_738 = ((*this).formatted_token(token,DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}),DynamicArray<u8>::create_with({}))); goto __jakt_label_633;
+__jakt_var_739 = ((*this).formatted_token(token,DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}),DynamicArray<u8>::create_with({}))); goto __jakt_label_634;
 
 }
-__jakt_label_633:; __jakt_var_738.release_value(); }));
+__jakt_label_634:; __jakt_var_739.release_value(); }));
 };/*case end*/
 case 102 /* Try */: {
-return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_744; {
+return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_745; {
 size_t const added_indent = ({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<size_t, ErrorOr<JaktInternal::Optional<formatter::FormattedToken>>>{
 auto&& __jakt_match_variant = token;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 84 /* Match */: {
-return JaktInternal::ExplicitValue(({ Optional<size_t> __jakt_var_745; {
-size_t indent = static_cast<size_t>(1ULL);
-if (((*this).line_has_indent())){
-(indent = static_cast<size_t>(0ULL));
-}
-__jakt_var_745 = indent; goto __jakt_label_640;
-
-}
-__jakt_label_640:; __jakt_var_745.release_value(); }));
-};/*case end*/
-case 74 /* For */: {
 return JaktInternal::ExplicitValue(({ Optional<size_t> __jakt_var_746; {
 size_t indent = static_cast<size_t>(1ULL);
 if (((*this).line_has_indent())){
@@ -2078,7 +2067,7 @@ __jakt_var_746 = indent; goto __jakt_label_641;
 }
 __jakt_label_641:; __jakt_var_746.release_value(); }));
 };/*case end*/
-case 106 /* While */: {
+case 74 /* For */: {
 return JaktInternal::ExplicitValue(({ Optional<size_t> __jakt_var_747; {
 size_t indent = static_cast<size_t>(1ULL);
 if (((*this).line_has_indent())){
@@ -2089,7 +2078,7 @@ __jakt_var_747 = indent; goto __jakt_label_642;
 }
 __jakt_label_642:; __jakt_var_747.release_value(); }));
 };/*case end*/
-case 77 /* If */: {
+case 106 /* While */: {
 return JaktInternal::ExplicitValue(({ Optional<size_t> __jakt_var_748; {
 size_t indent = static_cast<size_t>(1ULL);
 if (((*this).line_has_indent())){
@@ -2100,7 +2089,7 @@ __jakt_var_748 = indent; goto __jakt_label_643;
 }
 __jakt_label_643:; __jakt_var_748.release_value(); }));
 };/*case end*/
-case 108 /* Guard */: {
+case 77 /* If */: {
 return JaktInternal::ExplicitValue(({ Optional<size_t> __jakt_var_749; {
 size_t indent = static_cast<size_t>(1ULL);
 if (((*this).line_has_indent())){
@@ -2111,6 +2100,17 @@ __jakt_var_749 = indent; goto __jakt_label_644;
 }
 __jakt_label_644:; __jakt_var_749.release_value(); }));
 };/*case end*/
+case 108 /* Guard */: {
+return JaktInternal::ExplicitValue(({ Optional<size_t> __jakt_var_750; {
+size_t indent = static_cast<size_t>(1ULL);
+if (((*this).line_has_indent())){
+(indent = static_cast<size_t>(0ULL));
+}
+__jakt_var_750 = indent; goto __jakt_label_645;
+
+}
+__jakt_label_645:; __jakt_var_750.release_value(); }));
+};/*case end*/
 default: {
 return JaktInternal::ExplicitValue(static_cast<size_t>(0ULL));
 };/*case end*/
@@ -2123,29 +2123,18 @@ return JaktInternal::ExplicitValue(static_cast<size_t>(0ULL));
 });
 TRY((((*this).replace_state(formatter::State::StatementContext(open_parens,open_curlies,open_squares,arrow_indents,allow_eol,inserted_comma,formatter::ExpressionMode::AtExpressionStart(),JaktInternal::checked_add(dedents_on_open_curly,added_indent))))));
 ((((indent_change))) += ((infallible_integer_cast<i64>((added_indent)))));
-__jakt_var_744 = ((*this).formatted_token(token,DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}),DynamicArray<u8>::create_with({}))); goto __jakt_label_639;
+__jakt_var_745 = ((*this).formatted_token(token,DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}),DynamicArray<u8>::create_with({}))); goto __jakt_label_640;
 
 }
-__jakt_label_639:; __jakt_var_744.release_value(); }));
+__jakt_label_640:; __jakt_var_745.release_value(); }));
 };/*case end*/
 case 83 /* Loop */: {
-return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_750; {
+return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_751; {
 size_t const added_indent = ({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<size_t, ErrorOr<JaktInternal::Optional<formatter::FormattedToken>>>{
 auto&& __jakt_match_variant = token;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 84 /* Match */: {
-return JaktInternal::ExplicitValue(({ Optional<size_t> __jakt_var_751; {
-size_t indent = static_cast<size_t>(1ULL);
-if (((*this).line_has_indent())){
-(indent = static_cast<size_t>(0ULL));
-}
-__jakt_var_751 = indent; goto __jakt_label_646;
-
-}
-__jakt_label_646:; __jakt_var_751.release_value(); }));
-};/*case end*/
-case 74 /* For */: {
 return JaktInternal::ExplicitValue(({ Optional<size_t> __jakt_var_752; {
 size_t indent = static_cast<size_t>(1ULL);
 if (((*this).line_has_indent())){
@@ -2156,7 +2145,7 @@ __jakt_var_752 = indent; goto __jakt_label_647;
 }
 __jakt_label_647:; __jakt_var_752.release_value(); }));
 };/*case end*/
-case 106 /* While */: {
+case 74 /* For */: {
 return JaktInternal::ExplicitValue(({ Optional<size_t> __jakt_var_753; {
 size_t indent = static_cast<size_t>(1ULL);
 if (((*this).line_has_indent())){
@@ -2167,7 +2156,7 @@ __jakt_var_753 = indent; goto __jakt_label_648;
 }
 __jakt_label_648:; __jakt_var_753.release_value(); }));
 };/*case end*/
-case 77 /* If */: {
+case 106 /* While */: {
 return JaktInternal::ExplicitValue(({ Optional<size_t> __jakt_var_754; {
 size_t indent = static_cast<size_t>(1ULL);
 if (((*this).line_has_indent())){
@@ -2178,7 +2167,7 @@ __jakt_var_754 = indent; goto __jakt_label_649;
 }
 __jakt_label_649:; __jakt_var_754.release_value(); }));
 };/*case end*/
-case 108 /* Guard */: {
+case 77 /* If */: {
 return JaktInternal::ExplicitValue(({ Optional<size_t> __jakt_var_755; {
 size_t indent = static_cast<size_t>(1ULL);
 if (((*this).line_has_indent())){
@@ -2189,6 +2178,17 @@ __jakt_var_755 = indent; goto __jakt_label_650;
 }
 __jakt_label_650:; __jakt_var_755.release_value(); }));
 };/*case end*/
+case 108 /* Guard */: {
+return JaktInternal::ExplicitValue(({ Optional<size_t> __jakt_var_756; {
+size_t indent = static_cast<size_t>(1ULL);
+if (((*this).line_has_indent())){
+(indent = static_cast<size_t>(0ULL));
+}
+__jakt_var_756 = indent; goto __jakt_label_651;
+
+}
+__jakt_label_651:; __jakt_var_756.release_value(); }));
+};/*case end*/
 default: {
 return JaktInternal::ExplicitValue(static_cast<size_t>(0ULL));
 };/*case end*/
@@ -2201,29 +2201,18 @@ return JaktInternal::ExplicitValue(static_cast<size_t>(0ULL));
 });
 TRY((((*this).replace_state(formatter::State::StatementContext(open_parens,open_curlies,open_squares,arrow_indents,allow_eol,inserted_comma,formatter::ExpressionMode::AtExpressionStart(),JaktInternal::checked_add(dedents_on_open_curly,added_indent))))));
 ((((indent_change))) += ((infallible_integer_cast<i64>((added_indent)))));
-__jakt_var_750 = ((*this).formatted_token(token,DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}),DynamicArray<u8>::create_with({}))); goto __jakt_label_645;
+__jakt_var_751 = ((*this).formatted_token(token,DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}),DynamicArray<u8>::create_with({}))); goto __jakt_label_646;
 
 }
-__jakt_label_645:; __jakt_var_750.release_value(); }));
+__jakt_label_646:; __jakt_var_751.release_value(); }));
 };/*case end*/
 case 108 /* Guard */: {
-return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_756; {
+return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_757; {
 size_t const added_indent = ({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<size_t, ErrorOr<JaktInternal::Optional<formatter::FormattedToken>>>{
 auto&& __jakt_match_variant = token;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 84 /* Match */: {
-return JaktInternal::ExplicitValue(({ Optional<size_t> __jakt_var_757; {
-size_t indent = static_cast<size_t>(1ULL);
-if (((*this).line_has_indent())){
-(indent = static_cast<size_t>(0ULL));
-}
-__jakt_var_757 = indent; goto __jakt_label_652;
-
-}
-__jakt_label_652:; __jakt_var_757.release_value(); }));
-};/*case end*/
-case 74 /* For */: {
 return JaktInternal::ExplicitValue(({ Optional<size_t> __jakt_var_758; {
 size_t indent = static_cast<size_t>(1ULL);
 if (((*this).line_has_indent())){
@@ -2234,7 +2223,7 @@ __jakt_var_758 = indent; goto __jakt_label_653;
 }
 __jakt_label_653:; __jakt_var_758.release_value(); }));
 };/*case end*/
-case 106 /* While */: {
+case 74 /* For */: {
 return JaktInternal::ExplicitValue(({ Optional<size_t> __jakt_var_759; {
 size_t indent = static_cast<size_t>(1ULL);
 if (((*this).line_has_indent())){
@@ -2245,7 +2234,7 @@ __jakt_var_759 = indent; goto __jakt_label_654;
 }
 __jakt_label_654:; __jakt_var_759.release_value(); }));
 };/*case end*/
-case 77 /* If */: {
+case 106 /* While */: {
 return JaktInternal::ExplicitValue(({ Optional<size_t> __jakt_var_760; {
 size_t indent = static_cast<size_t>(1ULL);
 if (((*this).line_has_indent())){
@@ -2256,7 +2245,7 @@ __jakt_var_760 = indent; goto __jakt_label_655;
 }
 __jakt_label_655:; __jakt_var_760.release_value(); }));
 };/*case end*/
-case 108 /* Guard */: {
+case 77 /* If */: {
 return JaktInternal::ExplicitValue(({ Optional<size_t> __jakt_var_761; {
 size_t indent = static_cast<size_t>(1ULL);
 if (((*this).line_has_indent())){
@@ -2267,6 +2256,17 @@ __jakt_var_761 = indent; goto __jakt_label_656;
 }
 __jakt_label_656:; __jakt_var_761.release_value(); }));
 };/*case end*/
+case 108 /* Guard */: {
+return JaktInternal::ExplicitValue(({ Optional<size_t> __jakt_var_762; {
+size_t indent = static_cast<size_t>(1ULL);
+if (((*this).line_has_indent())){
+(indent = static_cast<size_t>(0ULL));
+}
+__jakt_var_762 = indent; goto __jakt_label_657;
+
+}
+__jakt_label_657:; __jakt_var_762.release_value(); }));
+};/*case end*/
 default: {
 return JaktInternal::ExplicitValue(static_cast<size_t>(0ULL));
 };/*case end*/
@@ -2279,29 +2279,18 @@ return JaktInternal::ExplicitValue(static_cast<size_t>(0ULL));
 });
 TRY((((*this).replace_state(formatter::State::StatementContext(open_parens,open_curlies,open_squares,arrow_indents,allow_eol,inserted_comma,formatter::ExpressionMode::AtExpressionStart(),JaktInternal::checked_add(dedents_on_open_curly,added_indent))))));
 ((((indent_change))) += ((infallible_integer_cast<i64>((added_indent)))));
-__jakt_var_756 = ((*this).formatted_token(token,DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}),DynamicArray<u8>::create_with({}))); goto __jakt_label_651;
+__jakt_var_757 = ((*this).formatted_token(token,DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}),DynamicArray<u8>::create_with({}))); goto __jakt_label_652;
 
 }
-__jakt_label_651:; __jakt_var_756.release_value(); }));
+__jakt_label_652:; __jakt_var_757.release_value(); }));
 };/*case end*/
 case 68 /* Defer */: {
-return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_762; {
+return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_763; {
 size_t const added_indent = ({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<size_t, ErrorOr<JaktInternal::Optional<formatter::FormattedToken>>>{
 auto&& __jakt_match_variant = token;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 84 /* Match */: {
-return JaktInternal::ExplicitValue(({ Optional<size_t> __jakt_var_763; {
-size_t indent = static_cast<size_t>(1ULL);
-if (((*this).line_has_indent())){
-(indent = static_cast<size_t>(0ULL));
-}
-__jakt_var_763 = indent; goto __jakt_label_658;
-
-}
-__jakt_label_658:; __jakt_var_763.release_value(); }));
-};/*case end*/
-case 74 /* For */: {
 return JaktInternal::ExplicitValue(({ Optional<size_t> __jakt_var_764; {
 size_t indent = static_cast<size_t>(1ULL);
 if (((*this).line_has_indent())){
@@ -2312,7 +2301,7 @@ __jakt_var_764 = indent; goto __jakt_label_659;
 }
 __jakt_label_659:; __jakt_var_764.release_value(); }));
 };/*case end*/
-case 106 /* While */: {
+case 74 /* For */: {
 return JaktInternal::ExplicitValue(({ Optional<size_t> __jakt_var_765; {
 size_t indent = static_cast<size_t>(1ULL);
 if (((*this).line_has_indent())){
@@ -2323,7 +2312,7 @@ __jakt_var_765 = indent; goto __jakt_label_660;
 }
 __jakt_label_660:; __jakt_var_765.release_value(); }));
 };/*case end*/
-case 77 /* If */: {
+case 106 /* While */: {
 return JaktInternal::ExplicitValue(({ Optional<size_t> __jakt_var_766; {
 size_t indent = static_cast<size_t>(1ULL);
 if (((*this).line_has_indent())){
@@ -2334,7 +2323,7 @@ __jakt_var_766 = indent; goto __jakt_label_661;
 }
 __jakt_label_661:; __jakt_var_766.release_value(); }));
 };/*case end*/
-case 108 /* Guard */: {
+case 77 /* If */: {
 return JaktInternal::ExplicitValue(({ Optional<size_t> __jakt_var_767; {
 size_t indent = static_cast<size_t>(1ULL);
 if (((*this).line_has_indent())){
@@ -2344,6 +2333,17 @@ __jakt_var_767 = indent; goto __jakt_label_662;
 
 }
 __jakt_label_662:; __jakt_var_767.release_value(); }));
+};/*case end*/
+case 108 /* Guard */: {
+return JaktInternal::ExplicitValue(({ Optional<size_t> __jakt_var_768; {
+size_t indent = static_cast<size_t>(1ULL);
+if (((*this).line_has_indent())){
+(indent = static_cast<size_t>(0ULL));
+}
+__jakt_var_768 = indent; goto __jakt_label_663;
+
+}
+__jakt_label_663:; __jakt_var_768.release_value(); }));
 };/*case end*/
 default: {
 return JaktInternal::ExplicitValue(static_cast<size_t>(0ULL));
@@ -2357,61 +2357,12 @@ return JaktInternal::ExplicitValue(static_cast<size_t>(0ULL));
 });
 TRY((((*this).replace_state(formatter::State::StatementContext(open_parens,open_curlies,open_squares,arrow_indents,allow_eol,inserted_comma,formatter::ExpressionMode::AtExpressionStart(),JaktInternal::checked_add(dedents_on_open_curly,added_indent))))));
 ((((indent_change))) += ((infallible_integer_cast<i64>((added_indent)))));
-__jakt_var_762 = ((*this).formatted_token(token,DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}),DynamicArray<u8>::create_with({}))); goto __jakt_label_657;
+__jakt_var_763 = ((*this).formatted_token(token,DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}),DynamicArray<u8>::create_with({}))); goto __jakt_label_658;
 
 }
-__jakt_label_657:; __jakt_var_762.release_value(); }));
+__jakt_label_658:; __jakt_var_763.release_value(); }));
 };/*case end*/
 case 64 /* Catch */: {
-return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_768; {
-TRY((((*this).replace_state(formatter::State::StatementContext(open_parens,open_curlies,open_squares,arrow_indents,allow_eol,inserted_comma,formatter::ExpressionMode::OutsideExpression(),dedents_on_open_curly)))));
-__jakt_var_768 = ((*this).formatted_token(token,({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<JaktInternal::DynamicArray<u8>, ErrorOr<JaktInternal::Optional<formatter::FormattedToken>>>{
-auto&& __jakt_match_variant = ((*this).peek(static_cast<i64>(0LL)));
-switch(__jakt_match_variant.__jakt_init_index()) {
-case 55 /* Eol */: {
-return JaktInternal::ExplicitValue(DynamicArray<u8>::create_with({}));
-};/*case end*/
-case 57 /* FatArrow */: {
-return JaktInternal::ExplicitValue(DynamicArray<u8>::create_with({}));
-};/*case end*/
-case 7 /* LParen */: {
-return JaktInternal::ExplicitValue(DynamicArray<u8>::create_with({}));
-};/*case end*/
-default: {
-return JaktInternal::ExplicitValue(DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}));
-};/*case end*/
-}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}),({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<JaktInternal::DynamicArray<u8>, ErrorOr<JaktInternal::Optional<formatter::FormattedToken>>>{
-auto&& __jakt_match_variant = ((*this).peek((-(static_cast<i64>(1LL)))));
-switch(__jakt_match_variant.__jakt_init_index()) {
-case 55 /* Eol */: {
-return JaktInternal::ExplicitValue(DynamicArray<u8>::create_with({}));
-};/*case end*/
-case 40 /* Pipe */: {
-return JaktInternal::ExplicitValue(DynamicArray<u8>::create_with({}));
-};/*case end*/
-default: {
-return JaktInternal::ExplicitValue(DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}));
-};/*case end*/
-}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-}))); goto __jakt_label_663;
-
-}
-__jakt_label_663:; __jakt_var_768.release_value(); }));
-};/*case end*/
-case 70 /* Else */: {
 return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_769; {
 TRY((((*this).replace_state(formatter::State::StatementContext(open_parens,open_curlies,open_squares,arrow_indents,allow_eol,inserted_comma,formatter::ExpressionMode::OutsideExpression(),dedents_on_open_curly)))));
 __jakt_var_769 = ((*this).formatted_token(token,({
@@ -2460,8 +2411,57 @@ return JaktInternal::ExplicitValue(DynamicArray<u8>::create_with({static_cast<u8
 }
 __jakt_label_664:; __jakt_var_769.release_value(); }));
 };/*case end*/
-case 55 /* Eol */: {
+case 70 /* Else */: {
 return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_770; {
+TRY((((*this).replace_state(formatter::State::StatementContext(open_parens,open_curlies,open_squares,arrow_indents,allow_eol,inserted_comma,formatter::ExpressionMode::OutsideExpression(),dedents_on_open_curly)))));
+__jakt_var_770 = ((*this).formatted_token(token,({
+    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<JaktInternal::DynamicArray<u8>, ErrorOr<JaktInternal::Optional<formatter::FormattedToken>>>{
+auto&& __jakt_match_variant = ((*this).peek(static_cast<i64>(0LL)));
+switch(__jakt_match_variant.__jakt_init_index()) {
+case 55 /* Eol */: {
+return JaktInternal::ExplicitValue(DynamicArray<u8>::create_with({}));
+};/*case end*/
+case 57 /* FatArrow */: {
+return JaktInternal::ExplicitValue(DynamicArray<u8>::create_with({}));
+};/*case end*/
+case 7 /* LParen */: {
+return JaktInternal::ExplicitValue(DynamicArray<u8>::create_with({}));
+};/*case end*/
+default: {
+return JaktInternal::ExplicitValue(DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}));
+};/*case end*/
+}/*switch end*/
+}()
+);
+    if (_jakt_value.is_return())
+        return _jakt_value.release_return();
+    _jakt_value.release_value();
+}),({
+    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<JaktInternal::DynamicArray<u8>, ErrorOr<JaktInternal::Optional<formatter::FormattedToken>>>{
+auto&& __jakt_match_variant = ((*this).peek((-(static_cast<i64>(1LL)))));
+switch(__jakt_match_variant.__jakt_init_index()) {
+case 55 /* Eol */: {
+return JaktInternal::ExplicitValue(DynamicArray<u8>::create_with({}));
+};/*case end*/
+case 40 /* Pipe */: {
+return JaktInternal::ExplicitValue(DynamicArray<u8>::create_with({}));
+};/*case end*/
+default: {
+return JaktInternal::ExplicitValue(DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}));
+};/*case end*/
+}/*switch end*/
+}()
+);
+    if (_jakt_value.is_return())
+        return _jakt_value.release_return();
+    _jakt_value.release_value();
+}))); goto __jakt_label_665;
+
+}
+__jakt_label_665:; __jakt_var_770.release_value(); }));
+};/*case end*/
+case 55 /* Eol */: {
+return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_771; {
 if ((((expression_mode).__jakt_init_index() == 1 /* BeforeExpressions */) && ((((*this).peek(static_cast<i64>(0LL)))).__jakt_init_index() == 55 /* Eol */))){
 return TRY((((*this).next())));
 }
@@ -2535,23 +2535,23 @@ return (infallible_enum_cast<jakt__prelude__operators::Ordering>((JaktInternal::
 }
 
 TRY((((*this).replace_state(formatter::State::StatementContext(open_parens,open_curlies,open_squares,new_arrow_indents,new_allow_eol,inserted_comma,new_expression_mode,dedents_on_open_curly)))));
-__jakt_var_770 = TRY((((*this).formatted_token(token)))); goto __jakt_label_665;
-
-}
-__jakt_label_665:; __jakt_var_770.release_value(); }));
-};/*case end*/
-case 75 /* Fn */: {
-return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_771; {
-TRY((((*this).push_state(formatter::State::FunctionTypeContext(false)))));
 __jakt_var_771 = TRY((((*this).formatted_token(token)))); goto __jakt_label_666;
 
 }
 __jakt_label_666:; __jakt_var_771.release_value(); }));
 };/*case end*/
+case 75 /* Fn */: {
+return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_772; {
+TRY((((*this).push_state(formatter::State::FunctionTypeContext(false)))));
+__jakt_var_772 = TRY((((*this).formatted_token(token)))); goto __jakt_label_667;
+
+}
+__jakt_label_667:; __jakt_var_772.release_value(); }));
+};/*case end*/
 case 52 /* Comma */: {
-return JaktInternal::ExplicitValue(({ Optional<JaktInternal::Optional<formatter::FormattedToken>> __jakt_var_772; {
+return JaktInternal::ExplicitValue(({ Optional<JaktInternal::Optional<formatter::FormattedToken>> __jakt_var_773; {
 TRY((((*this).replace_state(formatter::State::StatementContext(open_parens,open_curlies,open_squares,arrow_indents,allow_eol,inserted_comma,formatter::ExpressionMode::AtExpressionStart(),dedents_on_open_curly)))));
-__jakt_var_772 = ({
+__jakt_var_773 = ({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<JaktInternal::Optional<formatter::FormattedToken>, ErrorOr<JaktInternal::Optional<formatter::FormattedToken>>>{
 auto&& __jakt_match_variant = ((*this).peek(static_cast<i64>(0LL)));
 switch(__jakt_match_variant.__jakt_init_index()) {
@@ -2567,10 +2567,10 @@ return JaktInternal::ExplicitValue(((*this).formatted_token(token,DynamicArray<u
     if (_jakt_value.is_return())
         return _jakt_value.release_return();
     _jakt_value.release_value();
-}); goto __jakt_label_667;
+}); goto __jakt_label_668;
 
 }
-__jakt_label_667:; __jakt_var_772.release_value(); }));
+__jakt_label_668:; __jakt_var_773.release_value(); }));
 };/*case end*/
 case 94 /* Return */: {
 return JaktInternal::ExplicitValue(({
@@ -2578,14 +2578,6 @@ return JaktInternal::ExplicitValue(({
 auto&& __jakt_match_variant = ((*this).peek(static_cast<i64>(0LL)));
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 4 /* Semicolon */: {
-return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_773; {
-TRY((((*this).replace_state(formatter::State::StatementContext(open_parens,open_curlies,open_squares,arrow_indents,allow_eol,inserted_comma,formatter::ExpressionMode::OutsideExpression(),dedents_on_open_curly)))));
-__jakt_var_773 = TRY((((*this).formatted_token(token)))); goto __jakt_label_668;
-
-}
-__jakt_label_668:; __jakt_var_773.release_value(); }));
-};/*case end*/
-case 55 /* Eol */: {
 return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_774; {
 TRY((((*this).replace_state(formatter::State::StatementContext(open_parens,open_curlies,open_squares,arrow_indents,allow_eol,inserted_comma,formatter::ExpressionMode::OutsideExpression(),dedents_on_open_curly)))));
 __jakt_var_774 = TRY((((*this).formatted_token(token)))); goto __jakt_label_669;
@@ -2593,13 +2585,21 @@ __jakt_var_774 = TRY((((*this).formatted_token(token)))); goto __jakt_label_669;
 }
 __jakt_label_669:; __jakt_var_774.release_value(); }));
 };/*case end*/
-default: {
+case 55 /* Eol */: {
 return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_775; {
-TRY((((*this).replace_state(formatter::State::StatementContext(open_parens,open_curlies,open_squares,arrow_indents,allow_eol,inserted_comma,formatter::ExpressionMode::AtExpressionStart(),dedents_on_open_curly)))));
-__jakt_var_775 = ((*this).formatted_token(token,DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}),DynamicArray<u8>::create_with({}))); goto __jakt_label_670;
+TRY((((*this).replace_state(formatter::State::StatementContext(open_parens,open_curlies,open_squares,arrow_indents,allow_eol,inserted_comma,formatter::ExpressionMode::OutsideExpression(),dedents_on_open_curly)))));
+__jakt_var_775 = TRY((((*this).formatted_token(token)))); goto __jakt_label_670;
 
 }
 __jakt_label_670:; __jakt_var_775.release_value(); }));
+};/*case end*/
+default: {
+return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_776; {
+TRY((((*this).replace_state(formatter::State::StatementContext(open_parens,open_curlies,open_squares,arrow_indents,allow_eol,inserted_comma,formatter::ExpressionMode::AtExpressionStart(),dedents_on_open_curly)))));
+__jakt_var_776 = ((*this).formatted_token(token,DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}),DynamicArray<u8>::create_with({}))); goto __jakt_label_671;
+
+}
+__jakt_label_671:; __jakt_var_776.release_value(); }));
 };/*case end*/
 }/*switch end*/
 }()
@@ -2615,14 +2615,6 @@ return JaktInternal::ExplicitValue(({
 auto&& __jakt_match_variant = ((*this).peek(static_cast<i64>(0LL)));
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 4 /* Semicolon */: {
-return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_776; {
-TRY((((*this).replace_state(formatter::State::StatementContext(open_parens,open_curlies,open_squares,arrow_indents,allow_eol,inserted_comma,formatter::ExpressionMode::OutsideExpression(),dedents_on_open_curly)))));
-__jakt_var_776 = TRY((((*this).formatted_token(token)))); goto __jakt_label_671;
-
-}
-__jakt_label_671:; __jakt_var_776.release_value(); }));
-};/*case end*/
-case 55 /* Eol */: {
 return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_777; {
 TRY((((*this).replace_state(formatter::State::StatementContext(open_parens,open_curlies,open_squares,arrow_indents,allow_eol,inserted_comma,formatter::ExpressionMode::OutsideExpression(),dedents_on_open_curly)))));
 __jakt_var_777 = TRY((((*this).formatted_token(token)))); goto __jakt_label_672;
@@ -2630,13 +2622,21 @@ __jakt_var_777 = TRY((((*this).formatted_token(token)))); goto __jakt_label_672;
 }
 __jakt_label_672:; __jakt_var_777.release_value(); }));
 };/*case end*/
-default: {
+case 55 /* Eol */: {
 return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_778; {
-TRY((((*this).replace_state(formatter::State::StatementContext(open_parens,open_curlies,open_squares,arrow_indents,allow_eol,inserted_comma,formatter::ExpressionMode::AtExpressionStart(),dedents_on_open_curly)))));
-__jakt_var_778 = ((*this).formatted_token(token,DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}),DynamicArray<u8>::create_with({}))); goto __jakt_label_673;
+TRY((((*this).replace_state(formatter::State::StatementContext(open_parens,open_curlies,open_squares,arrow_indents,allow_eol,inserted_comma,formatter::ExpressionMode::OutsideExpression(),dedents_on_open_curly)))));
+__jakt_var_778 = TRY((((*this).formatted_token(token)))); goto __jakt_label_673;
 
 }
 __jakt_label_673:; __jakt_var_778.release_value(); }));
+};/*case end*/
+default: {
+return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_779; {
+TRY((((*this).replace_state(formatter::State::StatementContext(open_parens,open_curlies,open_squares,arrow_indents,allow_eol,inserted_comma,formatter::ExpressionMode::AtExpressionStart(),dedents_on_open_curly)))));
+__jakt_var_779 = ((*this).formatted_token(token,DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}),DynamicArray<u8>::create_with({}))); goto __jakt_label_674;
+
+}
+__jakt_label_674:; __jakt_var_779.release_value(); }));
 };/*case end*/
 }/*switch end*/
 }()
@@ -2652,14 +2652,6 @@ return JaktInternal::ExplicitValue(({
 auto&& __jakt_match_variant = ((*this).peek(static_cast<i64>(0LL)));
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 4 /* Semicolon */: {
-return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_779; {
-TRY((((*this).replace_state(formatter::State::StatementContext(open_parens,open_curlies,open_squares,arrow_indents,allow_eol,inserted_comma,formatter::ExpressionMode::OutsideExpression(),dedents_on_open_curly)))));
-__jakt_var_779 = TRY((((*this).formatted_token(token)))); goto __jakt_label_674;
-
-}
-__jakt_label_674:; __jakt_var_779.release_value(); }));
-};/*case end*/
-case 55 /* Eol */: {
 return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_780; {
 TRY((((*this).replace_state(formatter::State::StatementContext(open_parens,open_curlies,open_squares,arrow_indents,allow_eol,inserted_comma,formatter::ExpressionMode::OutsideExpression(),dedents_on_open_curly)))));
 __jakt_var_780 = TRY((((*this).formatted_token(token)))); goto __jakt_label_675;
@@ -2667,13 +2659,21 @@ __jakt_var_780 = TRY((((*this).formatted_token(token)))); goto __jakt_label_675;
 }
 __jakt_label_675:; __jakt_var_780.release_value(); }));
 };/*case end*/
-default: {
+case 55 /* Eol */: {
 return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_781; {
-TRY((((*this).replace_state(formatter::State::StatementContext(open_parens,open_curlies,open_squares,arrow_indents,allow_eol,inserted_comma,formatter::ExpressionMode::AtExpressionStart(),dedents_on_open_curly)))));
-__jakt_var_781 = ((*this).formatted_token(token,DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}),DynamicArray<u8>::create_with({}))); goto __jakt_label_676;
+TRY((((*this).replace_state(formatter::State::StatementContext(open_parens,open_curlies,open_squares,arrow_indents,allow_eol,inserted_comma,formatter::ExpressionMode::OutsideExpression(),dedents_on_open_curly)))));
+__jakt_var_781 = TRY((((*this).formatted_token(token)))); goto __jakt_label_676;
 
 }
 __jakt_label_676:; __jakt_var_781.release_value(); }));
+};/*case end*/
+default: {
+return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_782; {
+TRY((((*this).replace_state(formatter::State::StatementContext(open_parens,open_curlies,open_squares,arrow_indents,allow_eol,inserted_comma,formatter::ExpressionMode::AtExpressionStart(),dedents_on_open_curly)))));
+__jakt_var_782 = ((*this).formatted_token(token,DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}),DynamicArray<u8>::create_with({}))); goto __jakt_label_677;
+
+}
+__jakt_label_677:; __jakt_var_782.release_value(); }));
 };/*case end*/
 }/*switch end*/
 }()
@@ -2684,7 +2684,7 @@ __jakt_label_676:; __jakt_var_781.release_value(); }));
 }));
 };/*case end*/
 case 57 /* FatArrow */: {
-return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_782; {
+return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_783; {
 bool const next_is_eol = ((((*this).peek(static_cast<i64>(0LL)))).__jakt_init_index() == 55 /* Eol */);
 size_t new_arrow_indents = arrow_indents;
 if (next_is_eol){
@@ -2713,55 +2713,55 @@ return JaktInternal::ExplicitValue(formatter::ExpressionMode::BeforeExpressions(
         return _jakt_value.release_return();
     _jakt_value.release_value();
 }),dedents_on_open_curly)))));
-__jakt_var_782 = ((*this).formatted_token(token,DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}),DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}))); goto __jakt_label_677;
-
-}
-__jakt_label_677:; __jakt_var_782.release_value(); }));
-};/*case end*/
-case 11 /* LSquare */: {
-return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_783; {
-TRY((((*this).replace_state(formatter::State::StatementContext(open_parens,open_curlies,JaktInternal::checked_add(open_squares,static_cast<size_t>(1ULL)),arrow_indents,allow_eol,inserted_comma,formatter::ExpressionMode::AtExpressionStart(),dedents_on_open_curly)))));
-__jakt_var_783 = TRY((((*this).formatted_token(token)))); goto __jakt_label_678;
+__jakt_var_783 = ((*this).formatted_token(token,DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}),DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}))); goto __jakt_label_678;
 
 }
 __jakt_label_678:; __jakt_var_783.release_value(); }));
 };/*case end*/
-case 12 /* RSquare */: {
+case 11 /* LSquare */: {
 return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_784; {
+TRY((((*this).replace_state(formatter::State::StatementContext(open_parens,open_curlies,JaktInternal::checked_add(open_squares,static_cast<size_t>(1ULL)),arrow_indents,allow_eol,inserted_comma,formatter::ExpressionMode::AtExpressionStart(),dedents_on_open_curly)))));
+__jakt_var_784 = TRY((((*this).formatted_token(token)))); goto __jakt_label_679;
+
+}
+__jakt_label_679:; __jakt_var_784.release_value(); }));
+};/*case end*/
+case 12 /* RSquare */: {
+return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_785; {
 if (((open_squares) == (static_cast<size_t>(0ULL)))){
 ((*this).pop_state());
 ((((*this).index)--));
 return TRY((((*this).next_impl(true))));
 }
 TRY((((*this).replace_state(formatter::State::StatementContext(open_parens,open_curlies,JaktInternal::checked_sub(open_squares,static_cast<size_t>(1ULL)),arrow_indents,allow_eol,inserted_comma,formatter::ExpressionMode::AtExpressionStart(),dedents_on_open_curly)))));
-__jakt_var_784 = TRY((((*this).formatted_token(token)))); goto __jakt_label_679;
-
-}
-__jakt_label_679:; __jakt_var_784.release_value(); }));
-};/*case end*/
-case 7 /* LParen */: {
-return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_785; {
-TRY((((*this).replace_state(formatter::State::StatementContext(JaktInternal::checked_add(open_parens,static_cast<size_t>(1ULL)),open_curlies,open_squares,arrow_indents,allow_eol,inserted_comma,formatter::ExpressionMode::AtExpressionStart(),dedents_on_open_curly)))));
 __jakt_var_785 = TRY((((*this).formatted_token(token)))); goto __jakt_label_680;
 
 }
 __jakt_label_680:; __jakt_var_785.release_value(); }));
 };/*case end*/
-case 8 /* RParen */: {
+case 7 /* LParen */: {
 return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_786; {
+TRY((((*this).replace_state(formatter::State::StatementContext(JaktInternal::checked_add(open_parens,static_cast<size_t>(1ULL)),open_curlies,open_squares,arrow_indents,allow_eol,inserted_comma,formatter::ExpressionMode::AtExpressionStart(),dedents_on_open_curly)))));
+__jakt_var_786 = TRY((((*this).formatted_token(token)))); goto __jakt_label_681;
+
+}
+__jakt_label_681:; __jakt_var_786.release_value(); }));
+};/*case end*/
+case 8 /* RParen */: {
+return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_787; {
 if (((open_parens) == (static_cast<size_t>(0ULL)))){
 ((*this).pop_state());
 ((((*this).index)--));
 return TRY((((*this).next_impl(true))));
 }
 TRY((((*this).replace_state(formatter::State::StatementContext(JaktInternal::checked_sub(open_parens,static_cast<size_t>(1ULL)),open_curlies,open_squares,arrow_indents,allow_eol,inserted_comma,formatter::ExpressionMode::InExpression(),dedents_on_open_curly)))));
-__jakt_var_786 = TRY((((*this).formatted_token(token)))); goto __jakt_label_681;
+__jakt_var_787 = TRY((((*this).formatted_token(token)))); goto __jakt_label_682;
 
 }
-__jakt_label_681:; __jakt_var_786.release_value(); }));
+__jakt_label_682:; __jakt_var_787.release_value(); }));
 };/*case end*/
 case 9 /* LCurly */: {
-return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_787; {
+return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_788; {
 size_t dedented = static_cast<size_t>(0ULL);
 if ([](size_t const& self, size_t rhs) -> bool {
 {
@@ -2778,7 +2778,7 @@ return (infallible_enum_cast<jakt__prelude__operators::Ordering>((JaktInternal::
 (dedented = static_cast<size_t>(1ULL));
 }
 TRY((((*this).replace_state(formatter::State::StatementContext(open_parens,JaktInternal::checked_add(open_curlies,static_cast<size_t>(1ULL)),open_squares,arrow_indents,allow_eol,inserted_comma,formatter::ExpressionMode::AtExpressionStart(),JaktInternal::checked_sub(dedents_on_open_curly,dedented))))));
-__jakt_var_787 = ((*this).formatted_token(token,({
+__jakt_var_788 = ((*this).formatted_token(token,({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<JaktInternal::DynamicArray<u8>, ErrorOr<JaktInternal::Optional<formatter::FormattedToken>>>{
 auto&& __jakt_match_variant = expression_mode;
 switch(__jakt_match_variant.__jakt_init_index()) {
@@ -2850,20 +2850,20 @@ return JaktInternal::ExplicitValue(DynamicArray<u8>::create_with({static_cast<u8
     if (_jakt_value.is_return())
         return _jakt_value.release_return();
     _jakt_value.release_value();
-}))); goto __jakt_label_682;
+}))); goto __jakt_label_683;
 
 }
-__jakt_label_682:; __jakt_var_787.release_value(); }));
+__jakt_label_683:; __jakt_var_788.release_value(); }));
 };/*case end*/
 case 10 /* RCurly */: {
-return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_788; {
+return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_789; {
 if (((open_curlies) == (static_cast<size_t>(0ULL)))){
 ((*this).pop_state());
 ((((*this).index)) -= (static_cast<size_t>(1ULL)));
 return TRY((((*this).next_impl(true))));
 }
 TRY((((*this).replace_state(formatter::State::StatementContext(open_parens,JaktInternal::checked_sub(open_curlies,static_cast<size_t>(1ULL)),open_squares,arrow_indents,allow_eol,inserted_comma,formatter::ExpressionMode::InExpression(),dedents_on_open_curly)))));
-__jakt_var_788 = ((*this).formatted_token(token,DynamicArray<u8>::create_with({}),({
+__jakt_var_789 = ((*this).formatted_token(token,DynamicArray<u8>::create_with({}),({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<JaktInternal::DynamicArray<u8>, ErrorOr<JaktInternal::Optional<formatter::FormattedToken>>>{
 auto&& __jakt_match_variant = ((*this).peek((-(static_cast<i64>(1LL)))));
 switch(__jakt_match_variant.__jakt_init_index()) {
@@ -2882,30 +2882,30 @@ return JaktInternal::ExplicitValue(DynamicArray<u8>::create_with({static_cast<u8
     if (_jakt_value.is_return())
         return _jakt_value.release_return();
     _jakt_value.release_value();
-}))); goto __jakt_label_683;
-
-}
-__jakt_label_683:; __jakt_var_788.release_value(); }));
-};/*case end*/
-case 87 /* Not */: {
-return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_789; {
-TRY((((*this).replace_state(formatter::State::StatementContext(open_parens,open_curlies,open_squares,arrow_indents,allow_eol,inserted_comma,formatter::ExpressionMode::AtExpressionStart(),dedents_on_open_curly)))));
-__jakt_var_789 = ((*this).formatted_token(token,DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}),DynamicArray<u8>::create_with({}))); goto __jakt_label_684;
+}))); goto __jakt_label_684;
 
 }
 __jakt_label_684:; __jakt_var_789.release_value(); }));
 };/*case end*/
-case 96 /* Sizeof */: {
+case 87 /* Not */: {
 return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_790; {
+TRY((((*this).replace_state(formatter::State::StatementContext(open_parens,open_curlies,open_squares,arrow_indents,allow_eol,inserted_comma,formatter::ExpressionMode::AtExpressionStart(),dedents_on_open_curly)))));
 __jakt_var_790 = ((*this).formatted_token(token,DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}),DynamicArray<u8>::create_with({}))); goto __jakt_label_685;
 
 }
 __jakt_label_685:; __jakt_var_790.release_value(); }));
 };/*case end*/
-case 5 /* Colon */: {
+case 96 /* Sizeof */: {
 return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_791; {
+__jakt_var_791 = ((*this).formatted_token(token,DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}),DynamicArray<u8>::create_with({}))); goto __jakt_label_686;
+
+}
+__jakt_label_686:; __jakt_var_791.release_value(); }));
+};/*case end*/
+case 5 /* Colon */: {
+return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_792; {
 TRY((((*this).replace_state(formatter::State::StatementContext(open_parens,open_curlies,open_squares,arrow_indents,allow_eol,inserted_comma,formatter::ExpressionMode::AtExpressionStart(),dedents_on_open_curly)))));
-__jakt_var_791 = ((*this).formatted_token(token,({
+__jakt_var_792 = ((*this).formatted_token(token,({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<JaktInternal::DynamicArray<u8>, ErrorOr<JaktInternal::Optional<formatter::FormattedToken>>>{
 auto&& __jakt_match_variant = ((*this).peek(static_cast<i64>(0LL)));
 switch(__jakt_match_variant.__jakt_init_index()) {
@@ -2921,37 +2921,12 @@ return JaktInternal::ExplicitValue(DynamicArray<u8>::create_with({static_cast<u8
     if (_jakt_value.is_return())
         return _jakt_value.release_return();
     _jakt_value.release_value();
-}),DynamicArray<u8>::create_with({}))); goto __jakt_label_686;
-
-}
-__jakt_label_686:; __jakt_var_791.release_value(); }));
-};/*case end*/
-case 15 /* Minus */: {
-return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_792; {
-TRY((((*this).replace_state(formatter::State::StatementContext(open_parens,open_curlies,open_squares,arrow_indents,allow_eol,inserted_comma,formatter::ExpressionMode::AtExpressionStart(),dedents_on_open_curly)))));
-JaktInternal::DynamicArray<u8> const trivia = ({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<JaktInternal::DynamicArray<u8>, ErrorOr<JaktInternal::Optional<formatter::FormattedToken>>>{
-auto&& __jakt_match_variant = expression_mode;
-switch(__jakt_match_variant.__jakt_init_index()) {
-case 3 /* InExpression */: {
-return JaktInternal::ExplicitValue(DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}));
-};/*case end*/
-default: {
-return JaktInternal::ExplicitValue(DynamicArray<u8>::create_with({}));
-};/*case end*/
-}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    _jakt_value.release_value();
-});
-__jakt_var_792 = ((*this).formatted_token(token,trivia,trivia)); goto __jakt_label_687;
+}),DynamicArray<u8>::create_with({}))); goto __jakt_label_687;
 
 }
 __jakt_label_687:; __jakt_var_792.release_value(); }));
 };/*case end*/
-case 36 /* Asterisk */: {
+case 15 /* Minus */: {
 return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_793; {
 TRY((((*this).replace_state(formatter::State::StatementContext(open_parens,open_curlies,open_squares,arrow_indents,allow_eol,inserted_comma,formatter::ExpressionMode::AtExpressionStart(),dedents_on_open_curly)))));
 JaktInternal::DynamicArray<u8> const trivia = ({
@@ -2976,7 +2951,7 @@ __jakt_var_793 = ((*this).formatted_token(token,trivia,trivia)); goto __jakt_lab
 }
 __jakt_label_688:; __jakt_var_793.release_value(); }));
 };/*case end*/
-case 37 /* Ampersand */: {
+case 36 /* Asterisk */: {
 return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_794; {
 TRY((((*this).replace_state(formatter::State::StatementContext(open_parens,open_curlies,open_squares,arrow_indents,allow_eol,inserted_comma,formatter::ExpressionMode::AtExpressionStart(),dedents_on_open_curly)))));
 JaktInternal::DynamicArray<u8> const trivia = ({
@@ -3001,15 +2976,32 @@ __jakt_var_794 = ((*this).formatted_token(token,trivia,trivia)); goto __jakt_lab
 }
 __jakt_label_689:; __jakt_var_794.release_value(); }));
 };/*case end*/
-case 13 /* PercentSign */: {
+case 37 /* Ampersand */: {
 return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_795; {
 TRY((((*this).replace_state(formatter::State::StatementContext(open_parens,open_curlies,open_squares,arrow_indents,allow_eol,inserted_comma,formatter::ExpressionMode::AtExpressionStart(),dedents_on_open_curly)))));
-__jakt_var_795 = ((*this).formatted_token(token,DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}),DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}))); goto __jakt_label_690;
+JaktInternal::DynamicArray<u8> const trivia = ({
+    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<JaktInternal::DynamicArray<u8>, ErrorOr<JaktInternal::Optional<formatter::FormattedToken>>>{
+auto&& __jakt_match_variant = expression_mode;
+switch(__jakt_match_variant.__jakt_init_index()) {
+case 3 /* InExpression */: {
+return JaktInternal::ExplicitValue(DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}));
+};/*case end*/
+default: {
+return JaktInternal::ExplicitValue(DynamicArray<u8>::create_with({}));
+};/*case end*/
+}/*switch end*/
+}()
+);
+    if (_jakt_value.is_return())
+        return _jakt_value.release_return();
+    _jakt_value.release_value();
+});
+__jakt_var_795 = ((*this).formatted_token(token,trivia,trivia)); goto __jakt_label_690;
 
 }
 __jakt_label_690:; __jakt_var_795.release_value(); }));
 };/*case end*/
-case 14 /* Plus */: {
+case 13 /* PercentSign */: {
 return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_796; {
 TRY((((*this).replace_state(formatter::State::StatementContext(open_parens,open_curlies,open_squares,arrow_indents,allow_eol,inserted_comma,formatter::ExpressionMode::AtExpressionStart(),dedents_on_open_curly)))));
 __jakt_var_796 = ((*this).formatted_token(token,DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}),DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}))); goto __jakt_label_691;
@@ -3017,7 +3009,7 @@ __jakt_var_796 = ((*this).formatted_token(token,DynamicArray<u8>::create_with({s
 }
 __jakt_label_691:; __jakt_var_796.release_value(); }));
 };/*case end*/
-case 16 /* Equal */: {
+case 14 /* Plus */: {
 return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_797; {
 TRY((((*this).replace_state(formatter::State::StatementContext(open_parens,open_curlies,open_squares,arrow_indents,allow_eol,inserted_comma,formatter::ExpressionMode::AtExpressionStart(),dedents_on_open_curly)))));
 __jakt_var_797 = ((*this).formatted_token(token,DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}),DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}))); goto __jakt_label_692;
@@ -3025,7 +3017,7 @@ __jakt_var_797 = ((*this).formatted_token(token,DynamicArray<u8>::create_with({s
 }
 __jakt_label_692:; __jakt_var_797.release_value(); }));
 };/*case end*/
-case 40 /* Pipe */: {
+case 16 /* Equal */: {
 return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_798; {
 TRY((((*this).replace_state(formatter::State::StatementContext(open_parens,open_curlies,open_squares,arrow_indents,allow_eol,inserted_comma,formatter::ExpressionMode::AtExpressionStart(),dedents_on_open_curly)))));
 __jakt_var_798 = ((*this).formatted_token(token,DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}),DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}))); goto __jakt_label_693;
@@ -3033,7 +3025,7 @@ __jakt_var_798 = ((*this).formatted_token(token,DynamicArray<u8>::create_with({s
 }
 __jakt_label_693:; __jakt_var_798.release_value(); }));
 };/*case end*/
-case 17 /* PlusEqual */: {
+case 40 /* Pipe */: {
 return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_799; {
 TRY((((*this).replace_state(formatter::State::StatementContext(open_parens,open_curlies,open_squares,arrow_indents,allow_eol,inserted_comma,formatter::ExpressionMode::AtExpressionStart(),dedents_on_open_curly)))));
 __jakt_var_799 = ((*this).formatted_token(token,DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}),DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}))); goto __jakt_label_694;
@@ -3041,7 +3033,7 @@ __jakt_var_799 = ((*this).formatted_token(token,DynamicArray<u8>::create_with({s
 }
 __jakt_label_694:; __jakt_var_799.release_value(); }));
 };/*case end*/
-case 19 /* MinusEqual */: {
+case 17 /* PlusEqual */: {
 return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_800; {
 TRY((((*this).replace_state(formatter::State::StatementContext(open_parens,open_curlies,open_squares,arrow_indents,allow_eol,inserted_comma,formatter::ExpressionMode::AtExpressionStart(),dedents_on_open_curly)))));
 __jakt_var_800 = ((*this).formatted_token(token,DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}),DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}))); goto __jakt_label_695;
@@ -3049,7 +3041,7 @@ __jakt_var_800 = ((*this).formatted_token(token,DynamicArray<u8>::create_with({s
 }
 __jakt_label_695:; __jakt_var_800.release_value(); }));
 };/*case end*/
-case 21 /* AsteriskEqual */: {
+case 19 /* MinusEqual */: {
 return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_801; {
 TRY((((*this).replace_state(formatter::State::StatementContext(open_parens,open_curlies,open_squares,arrow_indents,allow_eol,inserted_comma,formatter::ExpressionMode::AtExpressionStart(),dedents_on_open_curly)))));
 __jakt_var_801 = ((*this).formatted_token(token,DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}),DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}))); goto __jakt_label_696;
@@ -3057,7 +3049,7 @@ __jakt_var_801 = ((*this).formatted_token(token,DynamicArray<u8>::create_with({s
 }
 __jakt_label_696:; __jakt_var_801.release_value(); }));
 };/*case end*/
-case 22 /* ForwardSlashEqual */: {
+case 21 /* AsteriskEqual */: {
 return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_802; {
 TRY((((*this).replace_state(formatter::State::StatementContext(open_parens,open_curlies,open_squares,arrow_indents,allow_eol,inserted_comma,formatter::ExpressionMode::AtExpressionStart(),dedents_on_open_curly)))));
 __jakt_var_802 = ((*this).formatted_token(token,DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}),DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}))); goto __jakt_label_697;
@@ -3065,7 +3057,7 @@ __jakt_var_802 = ((*this).formatted_token(token,DynamicArray<u8>::create_with({s
 }
 __jakt_label_697:; __jakt_var_802.release_value(); }));
 };/*case end*/
-case 23 /* PercentSignEqual */: {
+case 22 /* ForwardSlashEqual */: {
 return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_803; {
 TRY((((*this).replace_state(formatter::State::StatementContext(open_parens,open_curlies,open_squares,arrow_indents,allow_eol,inserted_comma,formatter::ExpressionMode::AtExpressionStart(),dedents_on_open_curly)))));
 __jakt_var_803 = ((*this).formatted_token(token,DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}),DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}))); goto __jakt_label_698;
@@ -3073,7 +3065,7 @@ __jakt_var_803 = ((*this).formatted_token(token,DynamicArray<u8>::create_with({s
 }
 __jakt_label_698:; __jakt_var_803.release_value(); }));
 };/*case end*/
-case 24 /* NotEqual */: {
+case 23 /* PercentSignEqual */: {
 return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_804; {
 TRY((((*this).replace_state(formatter::State::StatementContext(open_parens,open_curlies,open_squares,arrow_indents,allow_eol,inserted_comma,formatter::ExpressionMode::AtExpressionStart(),dedents_on_open_curly)))));
 __jakt_var_804 = ((*this).formatted_token(token,DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}),DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}))); goto __jakt_label_699;
@@ -3081,7 +3073,7 @@ __jakt_var_804 = ((*this).formatted_token(token,DynamicArray<u8>::create_with({s
 }
 __jakt_label_699:; __jakt_var_804.release_value(); }));
 };/*case end*/
-case 25 /* DoubleEqual */: {
+case 24 /* NotEqual */: {
 return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_805; {
 TRY((((*this).replace_state(formatter::State::StatementContext(open_parens,open_curlies,open_squares,arrow_indents,allow_eol,inserted_comma,formatter::ExpressionMode::AtExpressionStart(),dedents_on_open_curly)))));
 __jakt_var_805 = ((*this).formatted_token(token,DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}),DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}))); goto __jakt_label_700;
@@ -3089,7 +3081,7 @@ __jakt_var_805 = ((*this).formatted_token(token,DynamicArray<u8>::create_with({s
 }
 __jakt_label_700:; __jakt_var_805.release_value(); }));
 };/*case end*/
-case 26 /* GreaterThan */: {
+case 25 /* DoubleEqual */: {
 return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_806; {
 TRY((((*this).replace_state(formatter::State::StatementContext(open_parens,open_curlies,open_squares,arrow_indents,allow_eol,inserted_comma,formatter::ExpressionMode::AtExpressionStart(),dedents_on_open_curly)))));
 __jakt_var_806 = ((*this).formatted_token(token,DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}),DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}))); goto __jakt_label_701;
@@ -3097,7 +3089,7 @@ __jakt_var_806 = ((*this).formatted_token(token,DynamicArray<u8>::create_with({s
 }
 __jakt_label_701:; __jakt_var_806.release_value(); }));
 };/*case end*/
-case 27 /* GreaterThanOrEqual */: {
+case 26 /* GreaterThan */: {
 return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_807; {
 TRY((((*this).replace_state(formatter::State::StatementContext(open_parens,open_curlies,open_squares,arrow_indents,allow_eol,inserted_comma,formatter::ExpressionMode::AtExpressionStart(),dedents_on_open_curly)))));
 __jakt_var_807 = ((*this).formatted_token(token,DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}),DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}))); goto __jakt_label_702;
@@ -3105,7 +3097,7 @@ __jakt_var_807 = ((*this).formatted_token(token,DynamicArray<u8>::create_with({s
 }
 __jakt_label_702:; __jakt_var_807.release_value(); }));
 };/*case end*/
-case 28 /* LessThan */: {
+case 27 /* GreaterThanOrEqual */: {
 return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_808; {
 TRY((((*this).replace_state(formatter::State::StatementContext(open_parens,open_curlies,open_squares,arrow_indents,allow_eol,inserted_comma,formatter::ExpressionMode::AtExpressionStart(),dedents_on_open_curly)))));
 __jakt_var_808 = ((*this).formatted_token(token,DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}),DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}))); goto __jakt_label_703;
@@ -3113,7 +3105,7 @@ __jakt_var_808 = ((*this).formatted_token(token,DynamicArray<u8>::create_with({s
 }
 __jakt_label_703:; __jakt_var_808.release_value(); }));
 };/*case end*/
-case 29 /* LessThanOrEqual */: {
+case 28 /* LessThan */: {
 return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_809; {
 TRY((((*this).replace_state(formatter::State::StatementContext(open_parens,open_curlies,open_squares,arrow_indents,allow_eol,inserted_comma,formatter::ExpressionMode::AtExpressionStart(),dedents_on_open_curly)))));
 __jakt_var_809 = ((*this).formatted_token(token,DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}),DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}))); goto __jakt_label_704;
@@ -3121,7 +3113,7 @@ __jakt_var_809 = ((*this).formatted_token(token,DynamicArray<u8>::create_with({s
 }
 __jakt_label_704:; __jakt_var_809.release_value(); }));
 };/*case end*/
-case 30 /* LeftArithmeticShift */: {
+case 29 /* LessThanOrEqual */: {
 return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_810; {
 TRY((((*this).replace_state(formatter::State::StatementContext(open_parens,open_curlies,open_squares,arrow_indents,allow_eol,inserted_comma,formatter::ExpressionMode::AtExpressionStart(),dedents_on_open_curly)))));
 __jakt_var_810 = ((*this).formatted_token(token,DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}),DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}))); goto __jakt_label_705;
@@ -3129,7 +3121,7 @@ __jakt_var_810 = ((*this).formatted_token(token,DynamicArray<u8>::create_with({s
 }
 __jakt_label_705:; __jakt_var_810.release_value(); }));
 };/*case end*/
-case 31 /* LeftShift */: {
+case 30 /* LeftArithmeticShift */: {
 return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_811; {
 TRY((((*this).replace_state(formatter::State::StatementContext(open_parens,open_curlies,open_squares,arrow_indents,allow_eol,inserted_comma,formatter::ExpressionMode::AtExpressionStart(),dedents_on_open_curly)))));
 __jakt_var_811 = ((*this).formatted_token(token,DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}),DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}))); goto __jakt_label_706;
@@ -3137,7 +3129,7 @@ __jakt_var_811 = ((*this).formatted_token(token,DynamicArray<u8>::create_with({s
 }
 __jakt_label_706:; __jakt_var_811.release_value(); }));
 };/*case end*/
-case 33 /* RightShift */: {
+case 31 /* LeftShift */: {
 return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_812; {
 TRY((((*this).replace_state(formatter::State::StatementContext(open_parens,open_curlies,open_squares,arrow_indents,allow_eol,inserted_comma,formatter::ExpressionMode::AtExpressionStart(),dedents_on_open_curly)))));
 __jakt_var_812 = ((*this).formatted_token(token,DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}),DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}))); goto __jakt_label_707;
@@ -3145,7 +3137,7 @@ __jakt_var_812 = ((*this).formatted_token(token,DynamicArray<u8>::create_with({s
 }
 __jakt_label_707:; __jakt_var_812.release_value(); }));
 };/*case end*/
-case 32 /* LeftShiftEqual */: {
+case 33 /* RightShift */: {
 return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_813; {
 TRY((((*this).replace_state(formatter::State::StatementContext(open_parens,open_curlies,open_squares,arrow_indents,allow_eol,inserted_comma,formatter::ExpressionMode::AtExpressionStart(),dedents_on_open_curly)))));
 __jakt_var_813 = ((*this).formatted_token(token,DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}),DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}))); goto __jakt_label_708;
@@ -3153,7 +3145,7 @@ __jakt_var_813 = ((*this).formatted_token(token,DynamicArray<u8>::create_with({s
 }
 __jakt_label_708:; __jakt_var_813.release_value(); }));
 };/*case end*/
-case 34 /* RightArithmeticShift */: {
+case 32 /* LeftShiftEqual */: {
 return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_814; {
 TRY((((*this).replace_state(formatter::State::StatementContext(open_parens,open_curlies,open_squares,arrow_indents,allow_eol,inserted_comma,formatter::ExpressionMode::AtExpressionStart(),dedents_on_open_curly)))));
 __jakt_var_814 = ((*this).formatted_token(token,DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}),DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}))); goto __jakt_label_709;
@@ -3161,7 +3153,7 @@ __jakt_var_814 = ((*this).formatted_token(token,DynamicArray<u8>::create_with({s
 }
 __jakt_label_709:; __jakt_var_814.release_value(); }));
 };/*case end*/
-case 35 /* RightShiftEqual */: {
+case 34 /* RightArithmeticShift */: {
 return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_815; {
 TRY((((*this).replace_state(formatter::State::StatementContext(open_parens,open_curlies,open_squares,arrow_indents,allow_eol,inserted_comma,formatter::ExpressionMode::AtExpressionStart(),dedents_on_open_curly)))));
 __jakt_var_815 = ((*this).formatted_token(token,DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}),DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}))); goto __jakt_label_710;
@@ -3169,7 +3161,7 @@ __jakt_var_815 = ((*this).formatted_token(token,DynamicArray<u8>::create_with({s
 }
 __jakt_label_710:; __jakt_var_815.release_value(); }));
 };/*case end*/
-case 38 /* AmpersandEqual */: {
+case 35 /* RightShiftEqual */: {
 return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_816; {
 TRY((((*this).replace_state(formatter::State::StatementContext(open_parens,open_curlies,open_squares,arrow_indents,allow_eol,inserted_comma,formatter::ExpressionMode::AtExpressionStart(),dedents_on_open_curly)))));
 __jakt_var_816 = ((*this).formatted_token(token,DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}),DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}))); goto __jakt_label_711;
@@ -3177,7 +3169,7 @@ __jakt_var_816 = ((*this).formatted_token(token,DynamicArray<u8>::create_with({s
 }
 __jakt_label_711:; __jakt_var_816.release_value(); }));
 };/*case end*/
-case 41 /* PipeEqual */: {
+case 38 /* AmpersandEqual */: {
 return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_817; {
 TRY((((*this).replace_state(formatter::State::StatementContext(open_parens,open_curlies,open_squares,arrow_indents,allow_eol,inserted_comma,formatter::ExpressionMode::AtExpressionStart(),dedents_on_open_curly)))));
 __jakt_var_817 = ((*this).formatted_token(token,DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}),DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}))); goto __jakt_label_712;
@@ -3185,7 +3177,7 @@ __jakt_var_817 = ((*this).formatted_token(token,DynamicArray<u8>::create_with({s
 }
 __jakt_label_712:; __jakt_var_817.release_value(); }));
 };/*case end*/
-case 43 /* Caret */: {
+case 41 /* PipeEqual */: {
 return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_818; {
 TRY((((*this).replace_state(formatter::State::StatementContext(open_parens,open_curlies,open_squares,arrow_indents,allow_eol,inserted_comma,formatter::ExpressionMode::AtExpressionStart(),dedents_on_open_curly)))));
 __jakt_var_818 = ((*this).formatted_token(token,DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}),DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}))); goto __jakt_label_713;
@@ -3193,7 +3185,7 @@ __jakt_var_818 = ((*this).formatted_token(token,DynamicArray<u8>::create_with({s
 }
 __jakt_label_713:; __jakt_var_818.release_value(); }));
 };/*case end*/
-case 44 /* CaretEqual */: {
+case 43 /* Caret */: {
 return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_819; {
 TRY((((*this).replace_state(formatter::State::StatementContext(open_parens,open_curlies,open_squares,arrow_indents,allow_eol,inserted_comma,formatter::ExpressionMode::AtExpressionStart(),dedents_on_open_curly)))));
 __jakt_var_819 = ((*this).formatted_token(token,DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}),DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}))); goto __jakt_label_714;
@@ -3201,7 +3193,7 @@ __jakt_var_819 = ((*this).formatted_token(token,DynamicArray<u8>::create_with({s
 }
 __jakt_label_714:; __jakt_var_819.release_value(); }));
 };/*case end*/
-case 47 /* ForwardSlash */: {
+case 44 /* CaretEqual */: {
 return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_820; {
 TRY((((*this).replace_state(formatter::State::StatementContext(open_parens,open_curlies,open_squares,arrow_indents,allow_eol,inserted_comma,formatter::ExpressionMode::AtExpressionStart(),dedents_on_open_curly)))));
 __jakt_var_820 = ((*this).formatted_token(token,DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}),DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}))); goto __jakt_label_715;
@@ -3209,7 +3201,7 @@ __jakt_var_820 = ((*this).formatted_token(token,DynamicArray<u8>::create_with({s
 }
 __jakt_label_715:; __jakt_var_820.release_value(); }));
 };/*case end*/
-case 50 /* QuestionMarkQuestionMark */: {
+case 47 /* ForwardSlash */: {
 return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_821; {
 TRY((((*this).replace_state(formatter::State::StatementContext(open_parens,open_curlies,open_squares,arrow_indents,allow_eol,inserted_comma,formatter::ExpressionMode::AtExpressionStart(),dedents_on_open_curly)))));
 __jakt_var_821 = ((*this).formatted_token(token,DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}),DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}))); goto __jakt_label_716;
@@ -3217,7 +3209,7 @@ __jakt_var_821 = ((*this).formatted_token(token,DynamicArray<u8>::create_with({s
 }
 __jakt_label_716:; __jakt_var_821.release_value(); }));
 };/*case end*/
-case 51 /* QuestionMarkQuestionMarkEqual */: {
+case 50 /* QuestionMarkQuestionMark */: {
 return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_822; {
 TRY((((*this).replace_state(formatter::State::StatementContext(open_parens,open_curlies,open_squares,arrow_indents,allow_eol,inserted_comma,formatter::ExpressionMode::AtExpressionStart(),dedents_on_open_curly)))));
 __jakt_var_822 = ((*this).formatted_token(token,DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}),DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}))); goto __jakt_label_717;
@@ -3225,7 +3217,7 @@ __jakt_var_822 = ((*this).formatted_token(token,DynamicArray<u8>::create_with({s
 }
 __jakt_label_717:; __jakt_var_822.release_value(); }));
 };/*case end*/
-case 59 /* And */: {
+case 51 /* QuestionMarkQuestionMarkEqual */: {
 return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_823; {
 TRY((((*this).replace_state(formatter::State::StatementContext(open_parens,open_curlies,open_squares,arrow_indents,allow_eol,inserted_comma,formatter::ExpressionMode::AtExpressionStart(),dedents_on_open_curly)))));
 __jakt_var_823 = ((*this).formatted_token(token,DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}),DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}))); goto __jakt_label_718;
@@ -3233,7 +3225,7 @@ __jakt_var_823 = ((*this).formatted_token(token,DynamicArray<u8>::create_with({s
 }
 __jakt_label_718:; __jakt_var_823.release_value(); }));
 };/*case end*/
-case 80 /* In */: {
+case 59 /* And */: {
 return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_824; {
 TRY((((*this).replace_state(formatter::State::StatementContext(open_parens,open_curlies,open_squares,arrow_indents,allow_eol,inserted_comma,formatter::ExpressionMode::AtExpressionStart(),dedents_on_open_curly)))));
 __jakt_var_824 = ((*this).formatted_token(token,DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}),DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}))); goto __jakt_label_719;
@@ -3241,7 +3233,7 @@ __jakt_var_824 = ((*this).formatted_token(token,DynamicArray<u8>::create_with({s
 }
 __jakt_label_719:; __jakt_var_824.release_value(); }));
 };/*case end*/
-case 88 /* Or */: {
+case 80 /* In */: {
 return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_825; {
 TRY((((*this).replace_state(formatter::State::StatementContext(open_parens,open_curlies,open_squares,arrow_indents,allow_eol,inserted_comma,formatter::ExpressionMode::AtExpressionStart(),dedents_on_open_curly)))));
 __jakt_var_825 = ((*this).formatted_token(token,DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}),DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}))); goto __jakt_label_720;
@@ -3249,13 +3241,21 @@ __jakt_var_825 = ((*this).formatted_token(token,DynamicArray<u8>::create_with({s
 }
 __jakt_label_720:; __jakt_var_825.release_value(); }));
 };/*case end*/
-case 81 /* Is */: {
+case 88 /* Or */: {
 return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_826; {
-TRY((((*this).push_state(formatter::State::MatchPattern(static_cast<size_t>(0ULL),false)))));
+TRY((((*this).replace_state(formatter::State::StatementContext(open_parens,open_curlies,open_squares,arrow_indents,allow_eol,inserted_comma,formatter::ExpressionMode::AtExpressionStart(),dedents_on_open_curly)))));
 __jakt_var_826 = ((*this).formatted_token(token,DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}),DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}))); goto __jakt_label_721;
 
 }
 __jakt_label_721:; __jakt_var_826.release_value(); }));
+};/*case end*/
+case 81 /* Is */: {
+return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_827; {
+TRY((((*this).push_state(formatter::State::MatchPattern(static_cast<size_t>(0ULL),false)))));
+__jakt_var_827 = ((*this).formatted_token(token,DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}),DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}))); goto __jakt_label_722;
+
+}
+__jakt_label_722:; __jakt_var_827.release_value(); }));
 };/*case end*/
 case 61 /* As */: {
 return JaktInternal::ExplicitValue(((*this).formatted_token(token,({
@@ -3318,272 +3318,6 @@ return JaktInternal::ExplicitValue(TRY((((*this).formatted_token(token)))));
 }));
 };/*case end*/
 case 3 /* Identifier */: {
-return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_827; {
-if ((((((*this).peek((-(static_cast<i64>(1LL)))))).__jakt_init_index() == 3 /* Identifier */) && (!(inserted_comma)))){
-((((*this).index)--));
-TRY((((*this).replace_state(formatter::State::StatementContext(open_parens,open_curlies,open_squares,arrow_indents,allow_eol,true,formatter::ExpressionMode::InExpression(),dedents_on_open_curly)))));
-return ((*this).formatted_token(lexer::Token::Comma(((token).span())),DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}),DynamicArray<u8>::create_with({})));
-}
-TRY((((*this).replace_state(formatter::State::StatementContext(open_parens,open_curlies,open_squares,arrow_indents,allow_eol,false,formatter::ExpressionMode::InExpression(),dedents_on_open_curly)))));
-if (((((*this).peek(static_cast<i64>(0LL)))).__jakt_init_index() == 7 /* LParen */)){
-return TRY((((*this).formatted_token(token))));
-}
-if ((!(((((*this).peek(static_cast<i64>(0LL)))).__jakt_init_index() == 28 /* LessThan */)))){
-return TRY((((*this).formatted_token(token))));
-}
-i64 open_angles = static_cast<i64>(1LL);
-i64 lookahead_index = static_cast<i64>(2LL);
-while ([](i64 const& self, i64 rhs) -> bool {
-{
-return (((infallible_integer_cast<u8>(([](i64 const& self, i64 rhs) -> jakt__prelude__operators::Ordering {
-{
-return (infallible_enum_cast<jakt__prelude__operators::Ordering>((JaktInternal::compare(self,rhs))));
-}
-}
-(self,rhs))))) == (static_cast<u8>(2)));
-}
-}
-(open_angles,static_cast<i64>(0LL))){
-({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<void, ErrorOr<JaktInternal::Optional<formatter::FormattedToken>>>{
-auto&& __jakt_match_variant = ((*this).peek(((lookahead_index++))));
-switch(__jakt_match_variant.__jakt_init_index()) {
-case 28 /* LessThan */: {
-{
-((open_angles) += (static_cast<i64>(1LL)));
-}
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
-case 26 /* GreaterThan */: {
-{
-((open_angles) -= (static_cast<i64>(1LL)));
-}
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
-case 55 /* Eol */: {
-{
-return JaktInternal::LoopBreak{};
-}
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
-case 13 /* PercentSign */: {
-{
-return JaktInternal::LoopBreak{};
-}
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
-case 14 /* Plus */: {
-{
-return JaktInternal::LoopBreak{};
-}
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
-case 15 /* Minus */: {
-{
-return JaktInternal::LoopBreak{};
-}
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
-case 16 /* Equal */: {
-{
-return JaktInternal::LoopBreak{};
-}
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
-case 17 /* PlusEqual */: {
-{
-return JaktInternal::LoopBreak{};
-}
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
-case 19 /* MinusEqual */: {
-{
-return JaktInternal::LoopBreak{};
-}
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
-case 21 /* AsteriskEqual */: {
-{
-return JaktInternal::LoopBreak{};
-}
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
-case 22 /* ForwardSlashEqual */: {
-{
-return JaktInternal::LoopBreak{};
-}
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
-case 23 /* PercentSignEqual */: {
-{
-return JaktInternal::LoopBreak{};
-}
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
-case 24 /* NotEqual */: {
-{
-return JaktInternal::LoopBreak{};
-}
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
-case 25 /* DoubleEqual */: {
-{
-return JaktInternal::LoopBreak{};
-}
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
-case 27 /* GreaterThanOrEqual */: {
-{
-return JaktInternal::LoopBreak{};
-}
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
-case 29 /* LessThanOrEqual */: {
-{
-return JaktInternal::LoopBreak{};
-}
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
-case 30 /* LeftArithmeticShift */: {
-{
-return JaktInternal::LoopBreak{};
-}
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
-case 31 /* LeftShift */: {
-{
-return JaktInternal::LoopBreak{};
-}
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
-case 33 /* RightShift */: {
-{
-return JaktInternal::LoopBreak{};
-}
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
-case 32 /* LeftShiftEqual */: {
-{
-return JaktInternal::LoopBreak{};
-}
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
-case 34 /* RightArithmeticShift */: {
-{
-return JaktInternal::LoopBreak{};
-}
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
-case 35 /* RightShiftEqual */: {
-{
-return JaktInternal::LoopBreak{};
-}
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
-case 36 /* Asterisk */: {
-{
-return JaktInternal::LoopBreak{};
-}
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
-case 38 /* AmpersandEqual */: {
-{
-return JaktInternal::LoopBreak{};
-}
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
-case 40 /* Pipe */: {
-{
-return JaktInternal::LoopBreak{};
-}
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
-case 41 /* PipeEqual */: {
-{
-return JaktInternal::LoopBreak{};
-}
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
-case 43 /* Caret */: {
-{
-return JaktInternal::LoopBreak{};
-}
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
-case 44 /* CaretEqual */: {
-{
-return JaktInternal::LoopBreak{};
-}
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
-case 47 /* ForwardSlash */: {
-{
-return JaktInternal::LoopBreak{};
-}
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
-case 50 /* QuestionMarkQuestionMark */: {
-{
-return JaktInternal::LoopBreak{};
-}
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
-case 51 /* QuestionMarkQuestionMarkEqual */: {
-{
-return JaktInternal::LoopBreak{};
-}
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
-case 59 /* And */: {
-{
-return JaktInternal::LoopBreak{};
-}
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
-case 80 /* In */: {
-{
-return JaktInternal::LoopBreak{};
-}
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
-case 81 /* Is */: {
-{
-return JaktInternal::LoopBreak{};
-}
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
-case 88 /* Or */: {
-{
-return JaktInternal::LoopBreak{};
-}
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
-default: {
-{
-}
-return JaktInternal::ExplicitValue<void>();
-};/*case end*/
-}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    if (_jakt_value.is_loop_break())
-        break;
-    if (_jakt_value.is_loop_continue())
-        continue;
-    _jakt_value.release_value();
-});
-}
-if ((((open_angles) == (static_cast<i64>(0LL))) && ((((*this).peek(lookahead_index))).__jakt_init_index() == 7 /* LParen */))){
-TRY((((*this).push_state(formatter::State::GenericCallTypeParams(static_cast<size_t>(0ULL))))));
-}
-__jakt_var_827 = TRY((((*this).formatted_token(token)))); goto __jakt_label_722;
-
-}
-__jakt_label_722:; __jakt_var_827.release_value(); }));
-};/*case end*/
-case 2 /* Number */: {
 return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_828; {
 if ((((((*this).peek((-(static_cast<i64>(1LL)))))).__jakt_init_index() == 3 /* Identifier */) && (!(inserted_comma)))){
 ((((*this).index)--));
@@ -3849,8 +3583,274 @@ __jakt_var_828 = TRY((((*this).formatted_token(token)))); goto __jakt_label_723;
 }
 __jakt_label_723:; __jakt_var_828.release_value(); }));
 };/*case end*/
-case 4 /* Semicolon */: {
+case 2 /* Number */: {
 return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_829; {
+if ((((((*this).peek((-(static_cast<i64>(1LL)))))).__jakt_init_index() == 3 /* Identifier */) && (!(inserted_comma)))){
+((((*this).index)--));
+TRY((((*this).replace_state(formatter::State::StatementContext(open_parens,open_curlies,open_squares,arrow_indents,allow_eol,true,formatter::ExpressionMode::InExpression(),dedents_on_open_curly)))));
+return ((*this).formatted_token(lexer::Token::Comma(((token).span())),DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}),DynamicArray<u8>::create_with({})));
+}
+TRY((((*this).replace_state(formatter::State::StatementContext(open_parens,open_curlies,open_squares,arrow_indents,allow_eol,false,formatter::ExpressionMode::InExpression(),dedents_on_open_curly)))));
+if (((((*this).peek(static_cast<i64>(0LL)))).__jakt_init_index() == 7 /* LParen */)){
+return TRY((((*this).formatted_token(token))));
+}
+if ((!(((((*this).peek(static_cast<i64>(0LL)))).__jakt_init_index() == 28 /* LessThan */)))){
+return TRY((((*this).formatted_token(token))));
+}
+i64 open_angles = static_cast<i64>(1LL);
+i64 lookahead_index = static_cast<i64>(2LL);
+while ([](i64 const& self, i64 rhs) -> bool {
+{
+return (((infallible_integer_cast<u8>(([](i64 const& self, i64 rhs) -> jakt__prelude__operators::Ordering {
+{
+return (infallible_enum_cast<jakt__prelude__operators::Ordering>((JaktInternal::compare(self,rhs))));
+}
+}
+(self,rhs))))) == (static_cast<u8>(2)));
+}
+}
+(open_angles,static_cast<i64>(0LL))){
+({
+    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<void, ErrorOr<JaktInternal::Optional<formatter::FormattedToken>>>{
+auto&& __jakt_match_variant = ((*this).peek(((lookahead_index++))));
+switch(__jakt_match_variant.__jakt_init_index()) {
+case 28 /* LessThan */: {
+{
+((open_angles) += (static_cast<i64>(1LL)));
+}
+return JaktInternal::ExplicitValue<void>();
+};/*case end*/
+case 26 /* GreaterThan */: {
+{
+((open_angles) -= (static_cast<i64>(1LL)));
+}
+return JaktInternal::ExplicitValue<void>();
+};/*case end*/
+case 55 /* Eol */: {
+{
+return JaktInternal::LoopBreak{};
+}
+return JaktInternal::ExplicitValue<void>();
+};/*case end*/
+case 13 /* PercentSign */: {
+{
+return JaktInternal::LoopBreak{};
+}
+return JaktInternal::ExplicitValue<void>();
+};/*case end*/
+case 14 /* Plus */: {
+{
+return JaktInternal::LoopBreak{};
+}
+return JaktInternal::ExplicitValue<void>();
+};/*case end*/
+case 15 /* Minus */: {
+{
+return JaktInternal::LoopBreak{};
+}
+return JaktInternal::ExplicitValue<void>();
+};/*case end*/
+case 16 /* Equal */: {
+{
+return JaktInternal::LoopBreak{};
+}
+return JaktInternal::ExplicitValue<void>();
+};/*case end*/
+case 17 /* PlusEqual */: {
+{
+return JaktInternal::LoopBreak{};
+}
+return JaktInternal::ExplicitValue<void>();
+};/*case end*/
+case 19 /* MinusEqual */: {
+{
+return JaktInternal::LoopBreak{};
+}
+return JaktInternal::ExplicitValue<void>();
+};/*case end*/
+case 21 /* AsteriskEqual */: {
+{
+return JaktInternal::LoopBreak{};
+}
+return JaktInternal::ExplicitValue<void>();
+};/*case end*/
+case 22 /* ForwardSlashEqual */: {
+{
+return JaktInternal::LoopBreak{};
+}
+return JaktInternal::ExplicitValue<void>();
+};/*case end*/
+case 23 /* PercentSignEqual */: {
+{
+return JaktInternal::LoopBreak{};
+}
+return JaktInternal::ExplicitValue<void>();
+};/*case end*/
+case 24 /* NotEqual */: {
+{
+return JaktInternal::LoopBreak{};
+}
+return JaktInternal::ExplicitValue<void>();
+};/*case end*/
+case 25 /* DoubleEqual */: {
+{
+return JaktInternal::LoopBreak{};
+}
+return JaktInternal::ExplicitValue<void>();
+};/*case end*/
+case 27 /* GreaterThanOrEqual */: {
+{
+return JaktInternal::LoopBreak{};
+}
+return JaktInternal::ExplicitValue<void>();
+};/*case end*/
+case 29 /* LessThanOrEqual */: {
+{
+return JaktInternal::LoopBreak{};
+}
+return JaktInternal::ExplicitValue<void>();
+};/*case end*/
+case 30 /* LeftArithmeticShift */: {
+{
+return JaktInternal::LoopBreak{};
+}
+return JaktInternal::ExplicitValue<void>();
+};/*case end*/
+case 31 /* LeftShift */: {
+{
+return JaktInternal::LoopBreak{};
+}
+return JaktInternal::ExplicitValue<void>();
+};/*case end*/
+case 33 /* RightShift */: {
+{
+return JaktInternal::LoopBreak{};
+}
+return JaktInternal::ExplicitValue<void>();
+};/*case end*/
+case 32 /* LeftShiftEqual */: {
+{
+return JaktInternal::LoopBreak{};
+}
+return JaktInternal::ExplicitValue<void>();
+};/*case end*/
+case 34 /* RightArithmeticShift */: {
+{
+return JaktInternal::LoopBreak{};
+}
+return JaktInternal::ExplicitValue<void>();
+};/*case end*/
+case 35 /* RightShiftEqual */: {
+{
+return JaktInternal::LoopBreak{};
+}
+return JaktInternal::ExplicitValue<void>();
+};/*case end*/
+case 36 /* Asterisk */: {
+{
+return JaktInternal::LoopBreak{};
+}
+return JaktInternal::ExplicitValue<void>();
+};/*case end*/
+case 38 /* AmpersandEqual */: {
+{
+return JaktInternal::LoopBreak{};
+}
+return JaktInternal::ExplicitValue<void>();
+};/*case end*/
+case 40 /* Pipe */: {
+{
+return JaktInternal::LoopBreak{};
+}
+return JaktInternal::ExplicitValue<void>();
+};/*case end*/
+case 41 /* PipeEqual */: {
+{
+return JaktInternal::LoopBreak{};
+}
+return JaktInternal::ExplicitValue<void>();
+};/*case end*/
+case 43 /* Caret */: {
+{
+return JaktInternal::LoopBreak{};
+}
+return JaktInternal::ExplicitValue<void>();
+};/*case end*/
+case 44 /* CaretEqual */: {
+{
+return JaktInternal::LoopBreak{};
+}
+return JaktInternal::ExplicitValue<void>();
+};/*case end*/
+case 47 /* ForwardSlash */: {
+{
+return JaktInternal::LoopBreak{};
+}
+return JaktInternal::ExplicitValue<void>();
+};/*case end*/
+case 50 /* QuestionMarkQuestionMark */: {
+{
+return JaktInternal::LoopBreak{};
+}
+return JaktInternal::ExplicitValue<void>();
+};/*case end*/
+case 51 /* QuestionMarkQuestionMarkEqual */: {
+{
+return JaktInternal::LoopBreak{};
+}
+return JaktInternal::ExplicitValue<void>();
+};/*case end*/
+case 59 /* And */: {
+{
+return JaktInternal::LoopBreak{};
+}
+return JaktInternal::ExplicitValue<void>();
+};/*case end*/
+case 80 /* In */: {
+{
+return JaktInternal::LoopBreak{};
+}
+return JaktInternal::ExplicitValue<void>();
+};/*case end*/
+case 81 /* Is */: {
+{
+return JaktInternal::LoopBreak{};
+}
+return JaktInternal::ExplicitValue<void>();
+};/*case end*/
+case 88 /* Or */: {
+{
+return JaktInternal::LoopBreak{};
+}
+return JaktInternal::ExplicitValue<void>();
+};/*case end*/
+default: {
+{
+}
+return JaktInternal::ExplicitValue<void>();
+};/*case end*/
+}/*switch end*/
+}()
+);
+    if (_jakt_value.is_return())
+        return _jakt_value.release_return();
+    if (_jakt_value.is_loop_break())
+        break;
+    if (_jakt_value.is_loop_continue())
+        continue;
+    _jakt_value.release_value();
+});
+}
+if ((((open_angles) == (static_cast<i64>(0LL))) && ((((*this).peek(lookahead_index))).__jakt_init_index() == 7 /* LParen */))){
+TRY((((*this).push_state(formatter::State::GenericCallTypeParams(static_cast<size_t>(0ULL))))));
+}
+__jakt_var_829 = TRY((((*this).formatted_token(token)))); goto __jakt_label_724;
+
+}
+__jakt_label_724:; __jakt_var_829.release_value(); }));
+};/*case end*/
+case 4 /* Semicolon */: {
+return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_830; {
 if (((open_squares) == (static_cast<size_t>(0ULL)))){
 return ({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<JaktInternal::Optional<formatter::FormattedToken>, ErrorOr<JaktInternal::Optional<formatter::FormattedToken>>>{
@@ -3870,34 +3870,34 @@ return JaktInternal::ExplicitValue(TRY((((*this).formatted_token(lexer::Token::E
     _jakt_value.release_value();
 });
 }
-__jakt_var_829 = ((*this).formatted_token(token,DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}),DynamicArray<u8>::create_with({}))); goto __jakt_label_724;
-
-}
-__jakt_label_724:; __jakt_var_829.release_value(); }));
-};/*case end*/
-case 92 /* Raw */: {
-return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_830; {
-TRY((((*this).replace_state(formatter::State::StatementContext(open_parens,open_curlies,open_squares,arrow_indents,allow_eol,inserted_comma,formatter::ExpressionMode::AtExpressionStart(),dedents_on_open_curly)))));
 __jakt_var_830 = ((*this).formatted_token(token,DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}),DynamicArray<u8>::create_with({}))); goto __jakt_label_725;
 
 }
 __jakt_label_725:; __jakt_var_830.release_value(); }));
 };/*case end*/
-case 93 /* Reflect */: {
+case 92 /* Raw */: {
 return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_831; {
-TRY((((*this).replace_state(formatter::State::TypeContext(static_cast<size_t>(0ULL),static_cast<size_t>(0ULL),static_cast<size_t>(0ULL),static_cast<size_t>(0ULL),false)))));
-__jakt_var_831 = formatter::FormattedToken(token,((*this).indent),DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}),DynamicArray<u8>::create_with({})); goto __jakt_label_726;
+TRY((((*this).replace_state(formatter::State::StatementContext(open_parens,open_curlies,open_squares,arrow_indents,allow_eol,inserted_comma,formatter::ExpressionMode::AtExpressionStart(),dedents_on_open_curly)))));
+__jakt_var_831 = ((*this).formatted_token(token,DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}),DynamicArray<u8>::create_with({}))); goto __jakt_label_726;
 
 }
 __jakt_label_726:; __jakt_var_831.release_value(); }));
 };/*case end*/
-default: {
+case 93 /* Reflect */: {
 return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_832; {
-TRY((((*this).replace_state(formatter::State::StatementContext(open_parens,open_curlies,open_squares,arrow_indents,allow_eol,inserted_comma,formatter::ExpressionMode::InExpression(),dedents_on_open_curly)))));
-__jakt_var_832 = TRY((((*this).formatted_token(token)))); goto __jakt_label_727;
+TRY((((*this).replace_state(formatter::State::TypeContext(static_cast<size_t>(0ULL),static_cast<size_t>(0ULL),static_cast<size_t>(0ULL),static_cast<size_t>(0ULL),false)))));
+__jakt_var_832 = formatter::FormattedToken(token,((*this).indent),DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}),DynamicArray<u8>::create_with({})); goto __jakt_label_727;
 
 }
 __jakt_label_727:; __jakt_var_832.release_value(); }));
+};/*case end*/
+default: {
+return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_833; {
+TRY((((*this).replace_state(formatter::State::StatementContext(open_parens,open_curlies,open_squares,arrow_indents,allow_eol,inserted_comma,formatter::ExpressionMode::InExpression(),dedents_on_open_curly)))));
+__jakt_var_833 = TRY((((*this).formatted_token(token)))); goto __jakt_label_728;
+
+}
+__jakt_label_728:; __jakt_var_833.release_value(); }));
 };/*case end*/
 }/*switch end*/
 }()
@@ -3916,15 +3916,15 @@ return ({
 auto&& __jakt_match_variant = token;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 28 /* LessThan */: {
-return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_833; {
+return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_834; {
 TRY((((*this).push_state(formatter::State::TypeContext(static_cast<size_t>(0ULL),static_cast<size_t>(0ULL),static_cast<size_t>(0ULL),static_cast<size_t>(0ULL),false)))));
-__jakt_var_833 = TRY((((*this).formatted_token(token)))); goto __jakt_label_728;
+__jakt_var_834 = TRY((((*this).formatted_token(token)))); goto __jakt_label_729;
 
 }
-__jakt_label_728:; __jakt_var_833.release_value(); }));
+__jakt_label_729:; __jakt_var_834.release_value(); }));
 };/*case end*/
 case 26 /* GreaterThan */: {
-return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_834; {
+return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_835; {
 if ([](size_t const& self, size_t rhs) -> bool {
 {
 return (((infallible_integer_cast<u8>(([](size_t const& self, size_t rhs) -> jakt__prelude__operators::Ordering {
@@ -3942,18 +3942,18 @@ else {
 TRY((((*this).replace_state(formatter::State::GenericCallTypeParams(JaktInternal::checked_sub(open_angles,static_cast<size_t>(1ULL)))))));
 }
 
-__jakt_var_834 = TRY((((*this).formatted_token(token)))); goto __jakt_label_729;
-
-}
-__jakt_label_729:; __jakt_var_834.release_value(); }));
-};/*case end*/
-case 52 /* Comma */: {
-return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_835; {
-TRY((((*this).push_state(formatter::State::TypeContext(static_cast<size_t>(0ULL),static_cast<size_t>(0ULL),static_cast<size_t>(0ULL),static_cast<size_t>(0ULL),false)))));
-__jakt_var_835 = ((*this).formatted_token(token,DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}),DynamicArray<u8>::create_with({}))); goto __jakt_label_730;
+__jakt_var_835 = TRY((((*this).formatted_token(token)))); goto __jakt_label_730;
 
 }
 __jakt_label_730:; __jakt_var_835.release_value(); }));
+};/*case end*/
+case 52 /* Comma */: {
+return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_836; {
+TRY((((*this).push_state(formatter::State::TypeContext(static_cast<size_t>(0ULL),static_cast<size_t>(0ULL),static_cast<size_t>(0ULL),static_cast<size_t>(0ULL),false)))));
+__jakt_var_836 = ((*this).formatted_token(token,DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}),DynamicArray<u8>::create_with({}))); goto __jakt_label_731;
+
+}
+__jakt_label_731:; __jakt_var_836.release_value(); }));
 };/*case end*/
 default: {
 return JaktInternal::ExplicitValue(TRY((((*this).formatted_token(token)))));
@@ -3975,41 +3975,41 @@ return ({
 auto&& __jakt_match_variant = token;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 5 /* Colon */: {
-return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_836; {
-TRY((((*this).push_state(formatter::State::TypeContext(static_cast<size_t>(0ULL),static_cast<size_t>(0ULL),static_cast<size_t>(0ULL),static_cast<size_t>(0ULL),false)))));
-__jakt_var_836 = ((*this).formatted_token(token,DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}),DynamicArray<u8>::create_with({}))); goto __jakt_label_731;
-
-}
-__jakt_label_731:; __jakt_var_836.release_value(); }));
-};/*case end*/
-case 7 /* LParen */: {
 return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_837; {
-TRY((((*this).replace_state(formatter::State::VariableDeclaration(JaktInternal::checked_add(open_parens,static_cast<size_t>(1ULL)))))));
-__jakt_var_837 = TRY((((*this).formatted_token(token)))); goto __jakt_label_732;
+TRY((((*this).push_state(formatter::State::TypeContext(static_cast<size_t>(0ULL),static_cast<size_t>(0ULL),static_cast<size_t>(0ULL),static_cast<size_t>(0ULL),false)))));
+__jakt_var_837 = ((*this).formatted_token(token,DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}),DynamicArray<u8>::create_with({}))); goto __jakt_label_732;
 
 }
 __jakt_label_732:; __jakt_var_837.release_value(); }));
 };/*case end*/
-case 8 /* RParen */: {
+case 7 /* LParen */: {
 return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_838; {
+TRY((((*this).replace_state(formatter::State::VariableDeclaration(JaktInternal::checked_add(open_parens,static_cast<size_t>(1ULL)))))));
+__jakt_var_838 = TRY((((*this).formatted_token(token)))); goto __jakt_label_733;
+
+}
+__jakt_label_733:; __jakt_var_838.release_value(); }));
+};/*case end*/
+case 8 /* RParen */: {
+return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_839; {
 if (((open_parens) == (static_cast<size_t>(0ULL)))){
 ((*this).pop_state());
 ((((*this).index)--));
 return TRY((((*this).next_impl(true))));
 }
 TRY((((*this).replace_state(formatter::State::VariableDeclaration(JaktInternal::checked_sub(open_parens,static_cast<size_t>(1ULL)))))));
-__jakt_var_838 = TRY((((*this).formatted_token(token)))); goto __jakt_label_733;
-
-}
-__jakt_label_733:; __jakt_var_838.release_value(); }));
-};/*case end*/
-case 16 /* Equal */: {
-return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_839; {
-((*this).pop_state());
-__jakt_var_839 = ((*this).formatted_token(token,DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}),DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}))); goto __jakt_label_734;
+__jakt_var_839 = TRY((((*this).formatted_token(token)))); goto __jakt_label_734;
 
 }
 __jakt_label_734:; __jakt_var_839.release_value(); }));
+};/*case end*/
+case 16 /* Equal */: {
+return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_840; {
+((*this).pop_state());
+__jakt_var_840 = ((*this).formatted_token(token,DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}),DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}))); goto __jakt_label_735;
+
+}
+__jakt_label_735:; __jakt_var_840.release_value(); }));
 };/*case end*/
 case 52 /* Comma */: {
 return JaktInternal::ExplicitValue(((*this).formatted_token(token,DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}),DynamicArray<u8>::create_with({}))));
@@ -4034,20 +4034,20 @@ return ({
 auto&& __jakt_match_variant = token;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 52 /* Comma */: {
-return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_840; {
-TRY((((*this).push_state(formatter::State::TypeContext(static_cast<size_t>(0ULL),static_cast<size_t>(0ULL),static_cast<size_t>(0ULL),static_cast<size_t>(0ULL),false)))));
-__jakt_var_840 = ((*this).formatted_token(token,DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}),DynamicArray<u8>::create_with({}))); goto __jakt_label_735;
-
-}
-__jakt_label_735:; __jakt_var_840.release_value(); }));
-};/*case end*/
-case 8 /* RParen */: {
 return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_841; {
-((*this).pop_state());
+TRY((((*this).push_state(formatter::State::TypeContext(static_cast<size_t>(0ULL),static_cast<size_t>(0ULL),static_cast<size_t>(0ULL),static_cast<size_t>(0ULL),false)))));
 __jakt_var_841 = ((*this).formatted_token(token,DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}),DynamicArray<u8>::create_with({}))); goto __jakt_label_736;
 
 }
 __jakt_label_736:; __jakt_var_841.release_value(); }));
+};/*case end*/
+case 8 /* RParen */: {
+return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_842; {
+((*this).pop_state());
+__jakt_var_842 = ((*this).formatted_token(token,DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}),DynamicArray<u8>::create_with({}))); goto __jakt_label_737;
+
+}
+__jakt_label_737:; __jakt_var_842.release_value(); }));
 };/*case end*/
 default: {
 return JaktInternal::ExplicitValue(TRY((((*this).formatted_token(token)))));
@@ -4075,44 +4075,44 @@ case 85 /* Mut */: {
 return JaktInternal::ExplicitValue(((*this).formatted_token(token,DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}),DynamicArray<u8>::create_with({}))));
 };/*case end*/
 case 5 /* Colon */: {
-return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_842; {
+return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_843; {
 TRY((((*this).push_state(formatter::State::TypeContext(static_cast<size_t>(0ULL),static_cast<size_t>(0ULL),static_cast<size_t>(0ULL),static_cast<size_t>(0ULL),false)))));
-__jakt_var_842 = ((*this).formatted_token(token,DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}),DynamicArray<u8>::create_with({}))); goto __jakt_label_737;
+__jakt_var_843 = ((*this).formatted_token(token,DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}),DynamicArray<u8>::create_with({}))); goto __jakt_label_738;
 
 }
-__jakt_label_737:; __jakt_var_842.release_value(); }));
+__jakt_label_738:; __jakt_var_843.release_value(); }));
 };/*case end*/
 case 52 /* Comma */: {
 return JaktInternal::ExplicitValue(((*this).formatted_token(token,DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}),DynamicArray<u8>::create_with({}))));
 };/*case end*/
 case 16 /* Equal */: {
-return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_843; {
-TRY((((*this).push_state(formatter::State::StatementContext(static_cast<size_t>(0ULL),static_cast<size_t>(0ULL),static_cast<size_t>(0ULL),static_cast<size_t>(0ULL),static_cast<size_t>(0ULL),false,formatter::ExpressionMode::AtExpressionStart(),static_cast<size_t>(0ULL))))));
-__jakt_var_843 = ((*this).formatted_token(token,DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}),DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}))); goto __jakt_label_738;
-
-}
-__jakt_label_738:; __jakt_var_843.release_value(); }));
-};/*case end*/
-case 7 /* LParen */: {
 return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_844; {
-TRY((((*this).replace_state(formatter::State::ParameterList(JaktInternal::checked_add(open_parens,static_cast<size_t>(1ULL)))))));
-__jakt_var_844 = TRY((((*this).formatted_token(token)))); goto __jakt_label_739;
+TRY((((*this).push_state(formatter::State::StatementContext(static_cast<size_t>(0ULL),static_cast<size_t>(0ULL),static_cast<size_t>(0ULL),static_cast<size_t>(0ULL),static_cast<size_t>(0ULL),false,formatter::ExpressionMode::AtExpressionStart(),static_cast<size_t>(0ULL))))));
+__jakt_var_844 = ((*this).formatted_token(token,DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}),DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}))); goto __jakt_label_739;
 
 }
 __jakt_label_739:; __jakt_var_844.release_value(); }));
 };/*case end*/
-case 8 /* RParen */: {
+case 7 /* LParen */: {
 return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_845; {
+TRY((((*this).replace_state(formatter::State::ParameterList(JaktInternal::checked_add(open_parens,static_cast<size_t>(1ULL)))))));
+__jakt_var_845 = TRY((((*this).formatted_token(token)))); goto __jakt_label_740;
+
+}
+__jakt_label_740:; __jakt_var_845.release_value(); }));
+};/*case end*/
+case 8 /* RParen */: {
+return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_846; {
 if (((open_parens) == (static_cast<size_t>(0ULL)))){
 ((*this).pop_state());
 ((((*this).index)--));
 return TRY((((*this).next_impl(true))));
 }
 TRY((((*this).replace_state(formatter::State::ParameterList(JaktInternal::checked_sub(open_parens,static_cast<size_t>(1ULL)))))));
-__jakt_var_845 = TRY((((*this).formatted_token(token)))); goto __jakt_label_740;
+__jakt_var_846 = TRY((((*this).formatted_token(token)))); goto __jakt_label_741;
 
 }
-__jakt_label_740:; __jakt_var_845.release_value(); }));
+__jakt_label_741:; __jakt_var_846.release_value(); }));
 };/*case end*/
 default: {
 return JaktInternal::ExplicitValue(TRY((((*this).formatted_token(token)))));
@@ -4134,48 +4134,48 @@ return ({
 auto&& __jakt_match_variant = token;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 5 /* Colon */: {
-return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_846; {
-TRY((((*this).push_state(formatter::State::TypeContext(static_cast<size_t>(0ULL),static_cast<size_t>(0ULL),static_cast<size_t>(0ULL),static_cast<size_t>(0ULL),false)))));
-__jakt_var_846 = TRY((((*this).formatted_token(token)))); goto __jakt_label_741;
-
-}
-__jakt_label_741:; __jakt_var_846.release_value(); }));
-};/*case end*/
-case 28 /* LessThan */: {
 return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_847; {
-TRY((((*this).replace_state(formatter::State::TypeContext(open_parens,open_curlies,open_squares,JaktInternal::checked_add(open_angles,static_cast<size_t>(1ULL)),seen_start)))));
+TRY((((*this).push_state(formatter::State::TypeContext(static_cast<size_t>(0ULL),static_cast<size_t>(0ULL),static_cast<size_t>(0ULL),static_cast<size_t>(0ULL),false)))));
 __jakt_var_847 = TRY((((*this).formatted_token(token)))); goto __jakt_label_742;
 
 }
 __jakt_label_742:; __jakt_var_847.release_value(); }));
 };/*case end*/
-case 26 /* GreaterThan */: {
+case 28 /* LessThan */: {
 return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_848; {
+TRY((((*this).replace_state(formatter::State::TypeContext(open_parens,open_curlies,open_squares,JaktInternal::checked_add(open_angles,static_cast<size_t>(1ULL)),seen_start)))));
+__jakt_var_848 = TRY((((*this).formatted_token(token)))); goto __jakt_label_743;
+
+}
+__jakt_label_743:; __jakt_var_848.release_value(); }));
+};/*case end*/
+case 26 /* GreaterThan */: {
+return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_849; {
 if (((open_angles) == (static_cast<size_t>(0ULL)))){
 ((*this).pop_state());
 ((((*this).index)--));
 return TRY((((*this).next_impl(true))));
 }
 TRY((((*this).replace_state(formatter::State::TypeContext(open_parens,open_curlies,open_squares,JaktInternal::checked_sub(open_angles,static_cast<size_t>(1ULL)),seen_start)))));
-__jakt_var_848 = TRY((((*this).formatted_token(token)))); goto __jakt_label_743;
-
-}
-__jakt_label_743:; __jakt_var_848.release_value(); }));
-};/*case end*/
-case 55 /* Eol */: {
-return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_849; {
-if (((JaktInternal::checked_add(JaktInternal::checked_add(JaktInternal::checked_add(open_parens,open_curlies),open_squares),open_angles)) == (static_cast<size_t>(0ULL)))){
-((*this).pop_state());
-((((*this).index)--));
-return TRY((((*this).next_impl(true))));
-}
 __jakt_var_849 = TRY((((*this).formatted_token(token)))); goto __jakt_label_744;
 
 }
 __jakt_label_744:; __jakt_var_849.release_value(); }));
 };/*case end*/
-case 11 /* LSquare */: {
+case 55 /* Eol */: {
 return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_850; {
+if (((JaktInternal::checked_add(JaktInternal::checked_add(JaktInternal::checked_add(open_parens,open_curlies),open_squares),open_angles)) == (static_cast<size_t>(0ULL)))){
+((*this).pop_state());
+((((*this).index)--));
+return TRY((((*this).next_impl(true))));
+}
+__jakt_var_850 = TRY((((*this).formatted_token(token)))); goto __jakt_label_745;
+
+}
+__jakt_label_745:; __jakt_var_850.release_value(); }));
+};/*case end*/
+case 11 /* LSquare */: {
+return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_851; {
 if (seen_start){
 ((((*this).index)--));
 ((*this).pop_state());
@@ -4183,26 +4183,26 @@ return TRY((((*this).next_impl(true))));
 }
 TRY((((*this).replace_state(formatter::State::TypeContext(open_parens,open_curlies,JaktInternal::checked_add(open_squares,static_cast<size_t>(1ULL)),open_angles,true)))));
 TRY((((*this).push_state(formatter::State::TypeContext(static_cast<size_t>(0ULL),static_cast<size_t>(0ULL),static_cast<size_t>(0ULL),static_cast<size_t>(0ULL),false)))));
-__jakt_var_850 = TRY((((*this).formatted_token(token)))); goto __jakt_label_745;
+__jakt_var_851 = TRY((((*this).formatted_token(token)))); goto __jakt_label_746;
 
 }
-__jakt_label_745:; __jakt_var_850.release_value(); }));
+__jakt_label_746:; __jakt_var_851.release_value(); }));
 };/*case end*/
 case 12 /* RSquare */: {
-return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_851; {
+return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_852; {
 if (((open_squares) == (static_cast<size_t>(0ULL)))){
 ((*this).pop_state());
 ((((*this).index)--));
 return TRY((((*this).next_impl(true))));
 }
 TRY((((*this).replace_state(formatter::State::TypeContext(open_parens,open_curlies,JaktInternal::checked_sub(open_squares,static_cast<size_t>(1ULL)),open_angles,seen_start)))));
-__jakt_var_851 = TRY((((*this).formatted_token(token)))); goto __jakt_label_746;
+__jakt_var_852 = TRY((((*this).formatted_token(token)))); goto __jakt_label_747;
 
 }
-__jakt_label_746:; __jakt_var_851.release_value(); }));
+__jakt_label_747:; __jakt_var_852.release_value(); }));
 };/*case end*/
 case 7 /* LParen */: {
-return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_852; {
+return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_853; {
 if (seen_start){
 ((((*this).index)--));
 ((*this).pop_state());
@@ -4210,26 +4210,26 @@ return TRY((((*this).next_impl(true))));
 }
 TRY((((*this).replace_state(formatter::State::TypeContext(JaktInternal::checked_add(open_parens,static_cast<size_t>(1ULL)),open_curlies,open_squares,open_angles,true)))));
 TRY((((*this).push_state(formatter::State::TypeContext(static_cast<size_t>(0ULL),static_cast<size_t>(0ULL),static_cast<size_t>(0ULL),static_cast<size_t>(0ULL),false)))));
-__jakt_var_852 = TRY((((*this).formatted_token(token)))); goto __jakt_label_747;
+__jakt_var_853 = TRY((((*this).formatted_token(token)))); goto __jakt_label_748;
 
 }
-__jakt_label_747:; __jakt_var_852.release_value(); }));
+__jakt_label_748:; __jakt_var_853.release_value(); }));
 };/*case end*/
 case 8 /* RParen */: {
-return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_853; {
+return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_854; {
 if (((open_parens) == (static_cast<size_t>(0ULL)))){
 ((*this).pop_state());
 ((((*this).index)--));
 return TRY((((*this).next_impl(true))));
 }
 TRY((((*this).replace_state(formatter::State::TypeContext(JaktInternal::checked_sub(open_parens,static_cast<size_t>(1ULL)),open_curlies,open_squares,open_angles,seen_start)))));
-__jakt_var_853 = TRY((((*this).formatted_token(token)))); goto __jakt_label_748;
+__jakt_var_854 = TRY((((*this).formatted_token(token)))); goto __jakt_label_749;
 
 }
-__jakt_label_748:; __jakt_var_853.release_value(); }));
+__jakt_label_749:; __jakt_var_854.release_value(); }));
 };/*case end*/
 case 9 /* LCurly */: {
-return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_854; {
+return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_855; {
 if (seen_start){
 ((((*this).index)--));
 ((*this).pop_state());
@@ -4237,33 +4237,25 @@ return TRY((((*this).next_impl(true))));
 }
 TRY((((*this).replace_state(formatter::State::TypeContext(open_parens,JaktInternal::checked_add(open_curlies,static_cast<size_t>(1ULL)),open_squares,open_angles,true)))));
 TRY((((*this).push_state(formatter::State::TypeContext(static_cast<size_t>(0ULL),static_cast<size_t>(0ULL),static_cast<size_t>(0ULL),static_cast<size_t>(0ULL),false)))));
-__jakt_var_854 = TRY((((*this).formatted_token(token)))); goto __jakt_label_749;
+__jakt_var_855 = TRY((((*this).formatted_token(token)))); goto __jakt_label_750;
 
 }
-__jakt_label_749:; __jakt_var_854.release_value(); }));
+__jakt_label_750:; __jakt_var_855.release_value(); }));
 };/*case end*/
 case 10 /* RCurly */: {
-return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_855; {
+return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_856; {
 if (((open_curlies) == (static_cast<size_t>(0ULL)))){
 ((*this).pop_state());
 ((((*this).index)) -= (static_cast<size_t>(1ULL)));
 return TRY((((*this).next_impl(true))));
 }
 TRY((((*this).replace_state(formatter::State::TypeContext(open_parens,JaktInternal::checked_sub(open_curlies,static_cast<size_t>(1ULL)),open_squares,open_angles,seen_start)))));
-__jakt_var_855 = TRY((((*this).formatted_token(token)))); goto __jakt_label_750;
-
-}
-__jakt_label_750:; __jakt_var_855.release_value(); }));
-};/*case end*/
-case 92 /* Raw */: {
-return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_856; {
-TRY((((*this).replace_state(formatter::State::TypeContext(open_parens,open_curlies,open_squares,open_angles,true)))));
-__jakt_var_856 = ((*this).formatted_token(token,DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}),DynamicArray<u8>::create_with({}))); goto __jakt_label_751;
+__jakt_var_856 = TRY((((*this).formatted_token(token)))); goto __jakt_label_751;
 
 }
 __jakt_label_751:; __jakt_var_856.release_value(); }));
 };/*case end*/
-case 85 /* Mut */: {
+case 92 /* Raw */: {
 return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_857; {
 TRY((((*this).replace_state(formatter::State::TypeContext(open_parens,open_curlies,open_squares,open_angles,true)))));
 __jakt_var_857 = ((*this).formatted_token(token,DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}),DynamicArray<u8>::create_with({}))); goto __jakt_label_752;
@@ -4271,43 +4263,51 @@ __jakt_var_857 = ((*this).formatted_token(token,DynamicArray<u8>::create_with({s
 }
 __jakt_label_752:; __jakt_var_857.release_value(); }));
 };/*case end*/
-case 37 /* Ampersand */: {
+case 85 /* Mut */: {
 return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_858; {
 TRY((((*this).replace_state(formatter::State::TypeContext(open_parens,open_curlies,open_squares,open_angles,true)))));
-__jakt_var_858 = TRY((((*this).formatted_token(token)))); goto __jakt_label_753;
+__jakt_var_858 = ((*this).formatted_token(token,DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}),DynamicArray<u8>::create_with({}))); goto __jakt_label_753;
 
 }
 __jakt_label_753:; __jakt_var_858.release_value(); }));
 };/*case end*/
-case 75 /* Fn */: {
+case 37 /* Ampersand */: {
 return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_859; {
 TRY((((*this).replace_state(formatter::State::TypeContext(open_parens,open_curlies,open_squares,open_angles,true)))));
-TRY((((*this).push_state(formatter::State::FunctionTypeContext(false)))));
 __jakt_var_859 = TRY((((*this).formatted_token(token)))); goto __jakt_label_754;
 
 }
 __jakt_label_754:; __jakt_var_859.release_value(); }));
 };/*case end*/
-case 52 /* Comma */: {
+case 75 /* Fn */: {
 return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_860; {
+TRY((((*this).replace_state(formatter::State::TypeContext(open_parens,open_curlies,open_squares,open_angles,true)))));
+TRY((((*this).push_state(formatter::State::FunctionTypeContext(false)))));
+__jakt_var_860 = TRY((((*this).formatted_token(token)))); goto __jakt_label_755;
+
+}
+__jakt_label_755:; __jakt_var_860.release_value(); }));
+};/*case end*/
+case 52 /* Comma */: {
+return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_861; {
 if (((JaktInternal::checked_add(open_angles,open_parens)) == (static_cast<size_t>(0ULL)))){
 ((((*this).index)--));
 ((*this).pop_state());
 return TRY((((*this).next_impl(true))));
 }
 TRY((((*this).push_state(formatter::State::TypeContext(static_cast<size_t>(0ULL),static_cast<size_t>(0ULL),static_cast<size_t>(0ULL),static_cast<size_t>(0ULL),false)))));
-__jakt_var_860 = ((*this).formatted_token(token,DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}),DynamicArray<u8>::create_with({}))); goto __jakt_label_755;
-
-}
-__jakt_label_755:; __jakt_var_860.release_value(); }));
-};/*case end*/
-case 3 /* Identifier */: {
-return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_861; {
-TRY((((*this).replace_state(formatter::State::TypeContext(open_parens,open_curlies,open_squares,open_angles,true)))));
-__jakt_var_861 = TRY((((*this).formatted_token(token)))); goto __jakt_label_756;
+__jakt_var_861 = ((*this).formatted_token(token,DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}),DynamicArray<u8>::create_with({}))); goto __jakt_label_756;
 
 }
 __jakt_label_756:; __jakt_var_861.release_value(); }));
+};/*case end*/
+case 3 /* Identifier */: {
+return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_862; {
+TRY((((*this).replace_state(formatter::State::TypeContext(open_parens,open_curlies,open_squares,open_angles,true)))));
+__jakt_var_862 = TRY((((*this).formatted_token(token)))); goto __jakt_label_757;
+
+}
+__jakt_label_757:; __jakt_var_862.release_value(); }));
 };/*case end*/
 case 105 /* Weak */: {
 return JaktInternal::ExplicitValue(((*this).formatted_token(token,DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}),DynamicArray<u8>::create_with({}))));
@@ -4353,33 +4353,33 @@ return ({
 auto&& __jakt_match_variant = token;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 12 /* RSquare */: {
-return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_862; {
-((*this).pop_state());
-__jakt_var_862 = TRY((((*this).formatted_token(token)))); goto __jakt_label_757;
-
-}
-__jakt_label_757:; __jakt_var_862.release_value(); }));
-};/*case end*/
-case 52 /* Comma */: {
 return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_863; {
-__jakt_var_863 = ((*this).formatted_token(token,DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}),DynamicArray<u8>::create_with({}))); goto __jakt_label_758;
+((*this).pop_state());
+__jakt_var_863 = TRY((((*this).formatted_token(token)))); goto __jakt_label_758;
 
 }
 __jakt_label_758:; __jakt_var_863.release_value(); }));
 };/*case end*/
-case 85 /* Mut */: {
+case 52 /* Comma */: {
 return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_864; {
 __jakt_var_864 = ((*this).formatted_token(token,DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}),DynamicArray<u8>::create_with({}))); goto __jakt_label_759;
 
 }
 __jakt_label_759:; __jakt_var_864.release_value(); }));
 };/*case end*/
-default: {
+case 85 /* Mut */: {
 return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_865; {
-__jakt_var_865 = TRY((((*this).formatted_token(token)))); goto __jakt_label_760;
+__jakt_var_865 = ((*this).formatted_token(token,DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}),DynamicArray<u8>::create_with({}))); goto __jakt_label_760;
 
 }
 __jakt_label_760:; __jakt_var_865.release_value(); }));
+};/*case end*/
+default: {
+return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_866; {
+__jakt_var_866 = TRY((((*this).formatted_token(token)))); goto __jakt_label_761;
+
+}
+__jakt_label_761:; __jakt_var_866.release_value(); }));
 };/*case end*/
 }/*switch end*/
 }()
@@ -4412,7 +4412,7 @@ return TRY((((*this).next_impl(true))));
 }
 };/*case end*/
 case 58 /* Arrow */: {
-return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_866; {
+return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_867; {
 if (seen_final_type){
 ((*this).pop_state());
 ((((*this).index)--));
@@ -4420,40 +4420,40 @@ return TRY((((*this).next_impl(true))));
 }
 TRY((((*this).replace_state(formatter::State::FunctionTypeContext(true)))));
 TRY((((*this).push_state(formatter::State::TypeContext(static_cast<size_t>(0ULL),static_cast<size_t>(0ULL),static_cast<size_t>(0ULL),static_cast<size_t>(0ULL),false)))));
-__jakt_var_866 = ((*this).formatted_token(token,DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}),DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}))); goto __jakt_label_761;
-
-}
-__jakt_label_761:; __jakt_var_866.release_value(); }));
-};/*case end*/
-case 11 /* LSquare */: {
-return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_867; {
-TRY((((*this).push_state(formatter::State::CaptureList()))));
-__jakt_var_867 = TRY((((*this).formatted_token(token)))); goto __jakt_label_762;
+__jakt_var_867 = ((*this).formatted_token(token,DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}),DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}))); goto __jakt_label_762;
 
 }
 __jakt_label_762:; __jakt_var_867.release_value(); }));
 };/*case end*/
-case 7 /* LParen */: {
+case 11 /* LSquare */: {
 return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_868; {
-if (seen_final_type){
-((*this).pop_state());
-((((*this).index)--));
-return TRY((((*this).next_impl(true))));
-}
-TRY((((*this).push_state(formatter::State::ParameterList(static_cast<size_t>(0ULL))))));
+TRY((((*this).push_state(formatter::State::CaptureList()))));
 __jakt_var_868 = TRY((((*this).formatted_token(token)))); goto __jakt_label_763;
 
 }
 __jakt_label_763:; __jakt_var_868.release_value(); }));
 };/*case end*/
-case 8 /* RParen */: {
+case 7 /* LParen */: {
 return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_869; {
 if (seen_final_type){
 ((*this).pop_state());
 ((((*this).index)--));
 return TRY((((*this).next_impl(true))));
 }
-__jakt_var_869 = ((*this).formatted_token(token,({
+TRY((((*this).push_state(formatter::State::ParameterList(static_cast<size_t>(0ULL))))));
+__jakt_var_869 = TRY((((*this).formatted_token(token)))); goto __jakt_label_764;
+
+}
+__jakt_label_764:; __jakt_var_869.release_value(); }));
+};/*case end*/
+case 8 /* RParen */: {
+return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_870; {
+if (seen_final_type){
+((*this).pop_state());
+((((*this).index)--));
+return TRY((((*this).next_impl(true))));
+}
+__jakt_var_870 = ((*this).formatted_token(token,({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<JaktInternal::DynamicArray<u8>, ErrorOr<JaktInternal::Optional<formatter::FormattedToken>>>{
 auto&& __jakt_match_variant = ((*this).peek(static_cast<i64>(0LL)));
 switch(__jakt_match_variant.__jakt_init_index()) {
@@ -4469,25 +4469,25 @@ return JaktInternal::ExplicitValue(DynamicArray<u8>::create_with({}));
     if (_jakt_value.is_return())
         return _jakt_value.release_return();
     _jakt_value.release_value();
-}),DynamicArray<u8>::create_with({}))); goto __jakt_label_764;
+}),DynamicArray<u8>::create_with({}))); goto __jakt_label_765;
 
 }
-__jakt_label_764:; __jakt_var_869.release_value(); }));
+__jakt_label_765:; __jakt_var_870.release_value(); }));
 };/*case end*/
 case 100 /* Throws */: {
 return JaktInternal::ExplicitValue(TRY((((*this).formatted_token(token)))));
 };/*case end*/
 default: {
-return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_870; {
+return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_871; {
 if (seen_final_type){
 ((*this).pop_state());
 ((((*this).index)--));
 return TRY((((*this).next_impl(true))));
 }
-__jakt_var_870 = TRY((((*this).formatted_token(token)))); goto __jakt_label_765;
+__jakt_var_871 = TRY((((*this).formatted_token(token)))); goto __jakt_label_766;
 
 }
-__jakt_label_765:; __jakt_var_870.release_value(); }));
+__jakt_label_766:; __jakt_var_871.release_value(); }));
 };/*case end*/
 }/*switch end*/
 }()
@@ -4506,53 +4506,53 @@ return ({
 auto&& __jakt_match_variant = token;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 7 /* LParen */: {
-return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_871; {
+return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_872; {
 TRY((((*this).replace_state(formatter::State::MatchPattern(JaktInternal::checked_add(open_parens,static_cast<size_t>(1ULL)),allow_multiple)))));
 TRY((((*this).push_state(formatter::State::StatementContext(static_cast<size_t>(0ULL),static_cast<size_t>(0ULL),static_cast<size_t>(0ULL),static_cast<size_t>(0ULL),static_cast<size_t>(0ULL),false,formatter::ExpressionMode::OutsideExpression(),static_cast<size_t>(0ULL))))));
-__jakt_var_871 = TRY((((*this).formatted_token(token)))); goto __jakt_label_766;
+__jakt_var_872 = TRY((((*this).formatted_token(token)))); goto __jakt_label_767;
 
 }
-__jakt_label_766:; __jakt_var_871.release_value(); }));
+__jakt_label_767:; __jakt_var_872.release_value(); }));
 };/*case end*/
 case 8 /* RParen */: {
-return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_872; {
+return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_873; {
 if (((open_parens) == (static_cast<size_t>(0ULL)))){
 ((*this).pop_state());
 ((((*this).index)) -= (static_cast<size_t>(1ULL)));
 return TRY((((*this).next_impl(true))));
 }
 TRY((((*this).replace_state(formatter::State::MatchPattern(JaktInternal::checked_sub(open_parens,static_cast<size_t>(1ULL)),allow_multiple)))));
-__jakt_var_872 = TRY((((*this).formatted_token(token)))); goto __jakt_label_767;
-
-}
-__jakt_label_767:; __jakt_var_872.release_value(); }));
-};/*case end*/
-case 55 /* Eol */: {
-return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_873; {
-if ((!(allow_multiple))){
-((*this).pop_state());
-((((*this).index)) -= (static_cast<size_t>(1ULL)));
-return TRY((((*this).next_impl(true))));
-}
 __jakt_var_873 = TRY((((*this).formatted_token(token)))); goto __jakt_label_768;
 
 }
 __jakt_label_768:; __jakt_var_873.release_value(); }));
 };/*case end*/
-case 3 /* Identifier */: {
-return JaktInternal::ExplicitValue(TRY((((*this).formatted_token(token)))));
-};/*case end*/
-case 40 /* Pipe */: {
+case 55 /* Eol */: {
 return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_874; {
 if ((!(allow_multiple))){
 ((*this).pop_state());
 ((((*this).index)) -= (static_cast<size_t>(1ULL)));
 return TRY((((*this).next_impl(true))));
 }
-__jakt_var_874 = ((*this).formatted_token(token,DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}),DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}))); goto __jakt_label_769;
+__jakt_var_874 = TRY((((*this).formatted_token(token)))); goto __jakt_label_769;
 
 }
 __jakt_label_769:; __jakt_var_874.release_value(); }));
+};/*case end*/
+case 3 /* Identifier */: {
+return JaktInternal::ExplicitValue(TRY((((*this).formatted_token(token)))));
+};/*case end*/
+case 40 /* Pipe */: {
+return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_875; {
+if ((!(allow_multiple))){
+((*this).pop_state());
+((((*this).index)) -= (static_cast<size_t>(1ULL)));
+return TRY((((*this).next_impl(true))));
+}
+__jakt_var_875 = ((*this).formatted_token(token,DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}),DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}))); goto __jakt_label_770;
+
+}
+__jakt_label_770:; __jakt_var_875.release_value(); }));
 };/*case end*/
 default: {
 {
@@ -4646,7 +4646,7 @@ return (infallible_enum_cast<jakt__prelude__operators::Ordering>((JaktInternal::
 }
 }
 }
-ScopeGuard __jakt_var_875([&] {
+ScopeGuard __jakt_var_876([&] {
 {
 if ([](i64 const& self, i64 rhs) -> bool {
 {

--- a/bootstrap/stage0/git.cpp
+++ b/bootstrap/stage0/git.cpp
@@ -3,7 +3,7 @@ namespace Jakt {
 namespace git {
 ErrorOr<ByteString> commit_hash() {
 {
-ByteString const hash = (ByteString::from_utf8_without_validation("a0c80d988ed0ac2f8450b077be12ced5df95394a"sv));
+ByteString const hash = (ByteString::from_utf8_without_validation("66f2ff20007adf10661688c7d809caa058c02f6e"sv));
 return hash;
 }
 }

--- a/bootstrap/stage0/ide.cpp
+++ b/bootstrap/stage0/ide.cpp
@@ -85,29 +85,6 @@ auto&& __jakt_match_variant = ((record).record_type);
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 0 /* Struct */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Struct;JaktInternal::DynamicArray<parser::ParsedField> const& fields = __jakt_match_value.fields;
-return JaktInternal::ExplicitValue(({ Optional<ByteString> __jakt_var_876; {
-{
-JaktInternal::ArrayIterator<parser::ParsedField> _magic = ((fields).iterator());
-for (;;){
-JaktInternal::Optional<parser::ParsedField> const _magic_value = ((_magic).next());
-if ((!(((_magic_value).has_value())))){
-break;
-}
-parser::ParsedField field = (_magic_value.value());
-{
-((children).push(ide::JaktSymbol(((((field).var_decl)).name),JaktInternal::OptionalNone(),(ByteString::from_utf8_without_validation("field"sv)),((((field).var_decl)).span),((((field).var_decl)).span),DynamicArray<ide::JaktSymbol>::create_with({}))));
-}
-
-}
-}
-
-__jakt_var_876 = (ByteString::from_utf8_without_validation("struct"sv)); goto __jakt_label_770;
-
-}
-__jakt_label_770:; __jakt_var_876.release_value(); }));
-};/*case end*/
-case 1 /* Class */: {
-auto&& __jakt_match_value = __jakt_match_variant.as.Class;JaktInternal::DynamicArray<parser::ParsedField> const& fields = __jakt_match_value.fields;
 return JaktInternal::ExplicitValue(({ Optional<ByteString> __jakt_var_877; {
 {
 JaktInternal::ArrayIterator<parser::ParsedField> _magic = ((fields).iterator());
@@ -124,14 +101,37 @@ parser::ParsedField field = (_magic_value.value());
 }
 }
 
-__jakt_var_877 = (ByteString::from_utf8_without_validation("class"sv)); goto __jakt_label_771;
+__jakt_var_877 = (ByteString::from_utf8_without_validation("struct"sv)); goto __jakt_label_771;
 
 }
 __jakt_label_771:; __jakt_var_877.release_value(); }));
 };/*case end*/
+case 1 /* Class */: {
+auto&& __jakt_match_value = __jakt_match_variant.as.Class;JaktInternal::DynamicArray<parser::ParsedField> const& fields = __jakt_match_value.fields;
+return JaktInternal::ExplicitValue(({ Optional<ByteString> __jakt_var_878; {
+{
+JaktInternal::ArrayIterator<parser::ParsedField> _magic = ((fields).iterator());
+for (;;){
+JaktInternal::Optional<parser::ParsedField> const _magic_value = ((_magic).next());
+if ((!(((_magic_value).has_value())))){
+break;
+}
+parser::ParsedField field = (_magic_value.value());
+{
+((children).push(ide::JaktSymbol(((((field).var_decl)).name),JaktInternal::OptionalNone(),(ByteString::from_utf8_without_validation("field"sv)),((((field).var_decl)).span),((((field).var_decl)).span),DynamicArray<ide::JaktSymbol>::create_with({}))));
+}
+
+}
+}
+
+__jakt_var_878 = (ByteString::from_utf8_without_validation("class"sv)); goto __jakt_label_772;
+
+}
+__jakt_label_772:; __jakt_var_878.release_value(); }));
+};/*case end*/
 case 2 /* ValueEnum */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.ValueEnum;JaktInternal::DynamicArray<parser::ValueEnumVariant> const& variants = __jakt_match_value.variants;
-return JaktInternal::ExplicitValue(({ Optional<ByteString> __jakt_var_878; {
+return JaktInternal::ExplicitValue(({ Optional<ByteString> __jakt_var_879; {
 {
 JaktInternal::ArrayIterator<parser::ValueEnumVariant> _magic = ((variants).iterator());
 for (;;){
@@ -147,14 +147,14 @@ parser::ValueEnumVariant variant = (_magic_value.value());
 }
 }
 
-__jakt_var_878 = (ByteString::from_utf8_without_validation("enum"sv)); goto __jakt_label_772;
+__jakt_var_879 = (ByteString::from_utf8_without_validation("enum"sv)); goto __jakt_label_773;
 
 }
-__jakt_label_772:; __jakt_var_878.release_value(); }));
+__jakt_label_773:; __jakt_var_879.release_value(); }));
 };/*case end*/
 case 3 /* SumEnum */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.SumEnum;JaktInternal::DynamicArray<parser::SumEnumVariant> const& variants = __jakt_match_value.variants;
-return JaktInternal::ExplicitValue(({ Optional<ByteString> __jakt_var_879; {
+return JaktInternal::ExplicitValue(({ Optional<ByteString> __jakt_var_880; {
 {
 JaktInternal::ArrayIterator<parser::SumEnumVariant> _magic = ((variants).iterator());
 for (;;){
@@ -195,10 +195,10 @@ return (!(((self) == (rhs))));
 }
 }
 
-__jakt_var_879 = (ByteString::from_utf8_without_validation("enum"sv)); goto __jakt_label_773;
+__jakt_var_880 = (ByteString::from_utf8_without_validation("enum"sv)); goto __jakt_label_774;
 
 }
-__jakt_label_773:; __jakt_var_879.release_value(); }));
+__jakt_label_774:; __jakt_var_880.release_value(); }));
 };/*case end*/
 case 4 /* Garbage */: {
 return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("garbage"sv)));
@@ -382,7 +382,7 @@ return JaktInternal::ExplicitValue(((value).span));
 case 20 /* GenericInstance */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.GenericInstance;ids::StructId const& struct_id = __jakt_match_value.id;
 JaktInternal::DynamicArray<ids::TypeId> const& args = __jakt_match_value.args;
-return JaktInternal::ExplicitValue(({ Optional<utility::Span> __jakt_var_880; {
+return JaktInternal::ExplicitValue(({ Optional<utility::Span> __jakt_var_881; {
 utility::Span output = span;
 if ((((((((struct_id).equals(array_struct_id)) || ((struct_id).equals(optional_struct_id))) || ((struct_id).equals(range_struct_id))) || ((struct_id).equals(set_struct_id))) || ((struct_id).equals(tuple_struct_id))) || ((struct_id).equals(weak_ptr_struct_id)))){
 (output = TRY((ide::find_type_definition_for_type_id(program,((args)[static_cast<i64>(0LL)]),span))));
@@ -394,10 +394,10 @@ else {
 (output = ((((program)->get_struct(struct_id))).name_span));
 }
 
-__jakt_var_880 = output; goto __jakt_label_774;
+__jakt_var_881 = output; goto __jakt_label_775;
 
 }
-__jakt_label_774:; __jakt_var_880.release_value(); }));
+__jakt_label_775:; __jakt_var_881.release_value(); }));
 };/*case end*/
 case 24 /* Struct */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Struct;ids::StructId const& struct_id = __jakt_match_value.value;
@@ -455,27 +455,27 @@ switch(__jakt_match_variant.__jakt_init_index()) {
 case 0 /* Variable */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Variable;utility::Span const& span = __jakt_match_value.span;
 ids::TypeId const& type_id = __jakt_match_value.type_id;
-return JaktInternal::ExplicitValue(({ Optional<utility::Span> __jakt_var_881; {
-__jakt_var_881 = TRY((ide::find_type_definition_for_type_id(program,type_id,span))); goto __jakt_label_775;
-
-}
-__jakt_label_775:; __jakt_var_881.release_value(); }));
-};/*case end*/
-case 1 /* Call */: {
-auto&& __jakt_match_value = __jakt_match_variant.as.Call;ids::FunctionId const& function_id = __jakt_match_value.value;
 return JaktInternal::ExplicitValue(({ Optional<utility::Span> __jakt_var_882; {
-__jakt_var_882 = ((((program)->get_function(function_id)))->name_span); goto __jakt_label_776;
+__jakt_var_882 = TRY((ide::find_type_definition_for_type_id(program,type_id,span))); goto __jakt_label_776;
 
 }
 __jakt_label_776:; __jakt_var_882.release_value(); }));
 };/*case end*/
-case 2 /* Typename */: {
-auto&& __jakt_match_value = __jakt_match_variant.as.Typename;ids::TypeId const& type_id = __jakt_match_value.value;
+case 1 /* Call */: {
+auto&& __jakt_match_value = __jakt_match_variant.as.Call;ids::FunctionId const& function_id = __jakt_match_value.value;
 return JaktInternal::ExplicitValue(({ Optional<utility::Span> __jakt_var_883; {
-__jakt_var_883 = TRY((ide::find_type_definition_for_type_id(program,type_id,span))); goto __jakt_label_777;
+__jakt_var_883 = ((((program)->get_function(function_id)))->name_span); goto __jakt_label_777;
 
 }
 __jakt_label_777:; __jakt_var_883.release_value(); }));
+};/*case end*/
+case 2 /* Typename */: {
+auto&& __jakt_match_value = __jakt_match_variant.as.Typename;ids::TypeId const& type_id = __jakt_match_value.value;
+return JaktInternal::ExplicitValue(({ Optional<utility::Span> __jakt_var_884; {
+__jakt_var_884 = TRY((ide::find_type_definition_for_type_id(program,type_id,span))); goto __jakt_label_778;
+
+}
+__jakt_label_778:; __jakt_var_884.release_value(); }));
 };/*case end*/
 case 3 /* NameSet */: {
 return JaktInternal::ExplicitValue(span);
@@ -514,34 +514,34 @@ ide::Mutability const& mutability = __jakt_match_value.mutability;
 ide::VarType const& var_type = __jakt_match_value.var_type;
 ide::VarVisibility const& visibility = __jakt_match_value.visibility;
 JaktInternal::Optional<ids::TypeId> const& struct_type_id = __jakt_match_value.struct_type_id;
-return JaktInternal::ExplicitValue(({ Optional<JaktInternal::Optional<ByteString>> __jakt_var_884; {
-ByteString const result = TRY((ide::get_var_signature(program,name,type_id,mutability,var_type,visibility,struct_type_id)));
-__jakt_var_884 = static_cast<JaktInternal::Optional<ByteString>>(result); goto __jakt_label_778;
-
-}
-__jakt_label_778:; __jakt_var_884.release_value(); }));
-};/*case end*/
-case 1 /* Call */: {
-auto&& __jakt_match_value = __jakt_match_variant.as.Call;ids::FunctionId const& function_id = __jakt_match_value.value;
 return JaktInternal::ExplicitValue(({ Optional<JaktInternal::Optional<ByteString>> __jakt_var_885; {
-ByteString const result = TRY((ide::get_function_signature(program,function_id)));
+ByteString const result = TRY((ide::get_var_signature(program,name,type_id,mutability,var_type,visibility,struct_type_id)));
 __jakt_var_885 = static_cast<JaktInternal::Optional<ByteString>>(result); goto __jakt_label_779;
 
 }
 __jakt_label_779:; __jakt_var_885.release_value(); }));
 };/*case end*/
-case 2 /* Typename */: {
-auto&& __jakt_match_value = __jakt_match_variant.as.Typename;ids::TypeId const& type_id = __jakt_match_value.value;
+case 1 /* Call */: {
+auto&& __jakt_match_value = __jakt_match_variant.as.Call;ids::FunctionId const& function_id = __jakt_match_value.value;
 return JaktInternal::ExplicitValue(({ Optional<JaktInternal::Optional<ByteString>> __jakt_var_886; {
-ByteString const result = TRY((ide::get_type_signature(program,type_id)));
+ByteString const result = TRY((ide::get_function_signature(program,function_id)));
 __jakt_var_886 = static_cast<JaktInternal::Optional<ByteString>>(result); goto __jakt_label_780;
 
 }
 __jakt_label_780:; __jakt_var_886.release_value(); }));
 };/*case end*/
+case 2 /* Typename */: {
+auto&& __jakt_match_value = __jakt_match_variant.as.Typename;ids::TypeId const& type_id = __jakt_match_value.value;
+return JaktInternal::ExplicitValue(({ Optional<JaktInternal::Optional<ByteString>> __jakt_var_887; {
+ByteString const result = TRY((ide::get_type_signature(program,type_id)));
+__jakt_var_887 = static_cast<JaktInternal::Optional<ByteString>>(result); goto __jakt_label_781;
+
+}
+__jakt_label_781:; __jakt_var_887.release_value(); }));
+};/*case end*/
 case 3 /* NameSet */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.NameSet;JaktInternal::DynamicArray<ByteString> const& names = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(({ Optional<JaktInternal::Optional<ByteString>> __jakt_var_887; {
+return JaktInternal::ExplicitValue(({ Optional<JaktInternal::Optional<ByteString>> __jakt_var_888; {
 ByteString output = (ByteString::from_utf8_without_validation(""sv));
 bool first = true;
 {
@@ -576,22 +576,22 @@ else {
 }
 }
 
-__jakt_var_887 = static_cast<JaktInternal::Optional<ByteString>>(output); goto __jakt_label_781;
+__jakt_var_888 = static_cast<JaktInternal::Optional<ByteString>>(output); goto __jakt_label_782;
 
 }
-__jakt_label_781:; __jakt_var_887.release_value(); }));
+__jakt_label_782:; __jakt_var_888.release_value(); }));
 };/*case end*/
 case 4 /* EnumVariant */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.EnumVariant;ByteString const& name = __jakt_match_value.name;
 ids::TypeId const& type_id = __jakt_match_value.type_id;
 JaktInternal::DynamicArray<JaktInternal::Tuple<JaktInternal::Optional<ByteString>,ids::TypeId>> const& variants = __jakt_match_value.variants;
 JaktInternal::Optional<types::NumberConstant> const& number_constant = __jakt_match_value.number_constant;
-return JaktInternal::ExplicitValue(({ Optional<JaktInternal::Optional<ByteString>> __jakt_var_888; {
+return JaktInternal::ExplicitValue(({ Optional<JaktInternal::Optional<ByteString>> __jakt_var_889; {
 ByteString const result = TRY((ide::get_enum_variant_signature(program,name,type_id,variants,number_constant)));
-__jakt_var_888 = static_cast<JaktInternal::Optional<ByteString>>(result); goto __jakt_label_782;
+__jakt_var_889 = static_cast<JaktInternal::Optional<ByteString>>(result); goto __jakt_label_783;
 
 }
-__jakt_label_782:; __jakt_var_888.release_value(); }));
+__jakt_label_783:; __jakt_var_889.release_value(); }));
 };/*case end*/
 default: VERIFY_NOT_REACHED();}/*switch end*/
 }()
@@ -796,20 +796,20 @@ auto&& __jakt_match_variant = (result.value());
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 0 /* Variable */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Variable;ids::TypeId const& type_id = __jakt_match_value.type_id;
-return JaktInternal::ExplicitValue(({ Optional<JaktInternal::DynamicArray<ByteString>> __jakt_var_889; {
-__jakt_var_889 = TRY((ide::completions_for_type_id(program,type_id))); goto __jakt_label_783;
-
-}
-__jakt_label_783:; __jakt_var_889.release_value(); }));
-};/*case end*/
-case 1 /* Call */: {
-auto&& __jakt_match_value = __jakt_match_variant.as.Call;ids::FunctionId const& function_id = __jakt_match_value.value;
 return JaktInternal::ExplicitValue(({ Optional<JaktInternal::DynamicArray<ByteString>> __jakt_var_890; {
-ids::TypeId const result_type_id = ((((program)->get_function(function_id)))->return_type_id);
-__jakt_var_890 = TRY((ide::completions_for_type_id(program,result_type_id))); goto __jakt_label_784;
+__jakt_var_890 = TRY((ide::completions_for_type_id(program,type_id))); goto __jakt_label_784;
 
 }
 __jakt_label_784:; __jakt_var_890.release_value(); }));
+};/*case end*/
+case 1 /* Call */: {
+auto&& __jakt_match_value = __jakt_match_variant.as.Call;ids::FunctionId const& function_id = __jakt_match_value.value;
+return JaktInternal::ExplicitValue(({ Optional<JaktInternal::DynamicArray<ByteString>> __jakt_var_891; {
+ids::TypeId const result_type_id = ((((program)->get_function(function_id)))->return_type_id);
+__jakt_var_891 = TRY((ide::completions_for_type_id(program,result_type_id))); goto __jakt_label_785;
+
+}
+__jakt_label_785:; __jakt_var_891.release_value(); }));
 };/*case end*/
 default: {
 return JaktInternal::ExplicitValue(DynamicArray<ByteString>::create_with({}));
@@ -1169,7 +1169,7 @@ case 4 /* If */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.If;NonnullRefPtr<typename types::CheckedExpression> const& condition = __jakt_match_value.condition;
 types::CheckedBlock const& then_block = __jakt_match_value.then_block;
 JaktInternal::Optional<NonnullRefPtr<typename types::CheckedStatement>> const& else_statement = __jakt_match_value.else_statement;
-return JaktInternal::ExplicitValue(({ Optional<JaktInternal::Optional<ide::Usage>> __jakt_var_891; {
+return JaktInternal::ExplicitValue(({ Optional<JaktInternal::Optional<ide::Usage>> __jakt_var_892; {
 JaktInternal::Optional<ide::Usage> found = TRY((ide::find_span_in_expression(program,condition,span)));
 if (((found).has_value())){
 return found;
@@ -1181,18 +1181,18 @@ return found;
 if (((else_statement).has_value())){
 return TRY((ide::find_span_in_statement(program,(else_statement.value()),span)));
 }
-__jakt_var_891 = none; goto __jakt_label_785;
-
-}
-__jakt_label_785:; __jakt_var_891.release_value(); }));
-};/*case end*/
-case 13 /* InlineCpp */: {
-return JaktInternal::ExplicitValue(({ Optional<JaktInternal::Optional<ide::Usage>> __jakt_var_892; {
-JaktInternal::Optional<ide::Usage> const output = JaktInternal::OptionalNone();
-__jakt_var_892 = output; goto __jakt_label_786;
+__jakt_var_892 = none; goto __jakt_label_786;
 
 }
 __jakt_label_786:; __jakt_var_892.release_value(); }));
+};/*case end*/
+case 13 /* InlineCpp */: {
+return JaktInternal::ExplicitValue(({ Optional<JaktInternal::Optional<ide::Usage>> __jakt_var_893; {
+JaktInternal::Optional<ide::Usage> const output = JaktInternal::OptionalNone();
+__jakt_var_893 = output; goto __jakt_label_787;
+
+}
+__jakt_label_787:; __jakt_var_893.release_value(); }));
 };/*case end*/
 case 6 /* Loop */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Loop;types::CheckedBlock const& block = __jakt_match_value.block;
@@ -1222,7 +1222,7 @@ return JaktInternal::ExplicitValue(TRY((ide::find_span_in_expression(program,exp
 case 3 /* VarDecl */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.VarDecl;ids::VarId const& var_id = __jakt_match_value.var_id;
 NonnullRefPtr<typename types::CheckedExpression> const& init = __jakt_match_value.init;
-return JaktInternal::ExplicitValue(({ Optional<JaktInternal::Optional<ide::Usage>> __jakt_var_893; {
+return JaktInternal::ExplicitValue(({ Optional<JaktInternal::Optional<ide::Usage>> __jakt_var_894; {
 NonnullRefPtr<types::CheckedVariable> const checked_var = ((program)->get_variable(var_id));
 JaktInternal::Optional<ide::Usage> const found = TRY((ide::find_span_in_expression(program,init,span)));
 if (((found).has_value())){
@@ -1252,28 +1252,28 @@ VERIFY_NOT_REACHED();
 });
 return static_cast<JaktInternal::Optional<ide::Usage>>(ide::Usage::Variable(((checked_var)->definition_span),((checked_var)->name),((checked_var)->type_id),mutability,ide::VarType::Variable(),ide::VarVisibility::DoesNotApply(),JaktInternal::OptionalNone()));
 }
-__jakt_var_893 = none; goto __jakt_label_787;
-
-}
-__jakt_label_787:; __jakt_var_893.release_value(); }));
-};/*case end*/
-case 7 /* While */: {
-auto&& __jakt_match_value = __jakt_match_variant.as.While;NonnullRefPtr<typename types::CheckedExpression> const& condition = __jakt_match_value.condition;
-types::CheckedBlock const& block = __jakt_match_value.block;
-return JaktInternal::ExplicitValue(({ Optional<JaktInternal::Optional<ide::Usage>> __jakt_var_894; {
-JaktInternal::Optional<ide::Usage> const found = TRY((ide::find_span_in_expression(program,condition,span)));
-if (((found).has_value())){
-return found;
-}
-__jakt_var_894 = TRY((ide::find_span_in_block(program,block,span))); goto __jakt_label_788;
+__jakt_var_894 = none; goto __jakt_label_788;
 
 }
 __jakt_label_788:; __jakt_var_894.release_value(); }));
 };/*case end*/
+case 7 /* While */: {
+auto&& __jakt_match_value = __jakt_match_variant.as.While;NonnullRefPtr<typename types::CheckedExpression> const& condition = __jakt_match_value.condition;
+types::CheckedBlock const& block = __jakt_match_value.block;
+return JaktInternal::ExplicitValue(({ Optional<JaktInternal::Optional<ide::Usage>> __jakt_var_895; {
+JaktInternal::Optional<ide::Usage> const found = TRY((ide::find_span_in_expression(program,condition,span)));
+if (((found).has_value())){
+return found;
+}
+__jakt_var_895 = TRY((ide::find_span_in_block(program,block,span))); goto __jakt_label_789;
+
+}
+__jakt_label_789:; __jakt_var_895.release_value(); }));
+};/*case end*/
 case 2 /* DestructuringAssignment */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.DestructuringAssignment;JaktInternal::DynamicArray<NonnullRefPtr<typename types::CheckedStatement>> const& vars = __jakt_match_value.vars;
 NonnullRefPtr<typename types::CheckedStatement> const& var_decl = __jakt_match_value.var_decl;
-return JaktInternal::ExplicitValue(({ Optional<JaktInternal::Optional<ide::Usage>> __jakt_var_895; {
+return JaktInternal::ExplicitValue(({ Optional<JaktInternal::Optional<ide::Usage>> __jakt_var_896; {
 {
 JaktInternal::ArrayIterator<NonnullRefPtr<typename types::CheckedStatement>> _magic = ((vars).iterator());
 for (;;){
@@ -1292,10 +1292,10 @@ return found;
 }
 }
 
-__jakt_var_895 = TRY((ide::find_span_in_statement(program,var_decl,span))); goto __jakt_label_789;
+__jakt_var_896 = TRY((ide::find_span_in_statement(program,var_decl,span))); goto __jakt_label_790;
 
 }
-__jakt_label_789:; __jakt_var_895.release_value(); }));
+__jakt_label_790:; __jakt_var_896.release_value(); }));
 };/*case end*/
 case 12 /* Yield */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Yield;NonnullRefPtr<typename types::CheckedExpression> const& expr = __jakt_match_value.expr;
@@ -1331,20 +1331,20 @@ case 7 /* BinaryOp */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.BinaryOp;NonnullRefPtr<typename types::CheckedExpression> const& lhs = __jakt_match_value.lhs;
 types::CheckedBinaryOperator const& op = __jakt_match_value.op;
 NonnullRefPtr<typename types::CheckedExpression> const& rhs = __jakt_match_value.rhs;
-return JaktInternal::ExplicitValue(({ Optional<JaktInternal::Optional<ide::Usage>> __jakt_var_896; {
+return JaktInternal::ExplicitValue(({ Optional<JaktInternal::Optional<ide::Usage>> __jakt_var_897; {
 JaktInternal::Optional<ide::Usage> const found = TRY((ide::find_span_in_expression(program,lhs,span)));
 if (((found).has_value())){
 return found;
 }
-__jakt_var_896 = TRY((ide::find_span_in_expression(program,rhs,span))); goto __jakt_label_790;
+__jakt_var_897 = TRY((ide::find_span_in_expression(program,rhs,span))); goto __jakt_label_791;
 
 }
-__jakt_label_790:; __jakt_var_896.release_value(); }));
+__jakt_label_791:; __jakt_var_897.release_value(); }));
 };/*case end*/
 case 10 /* JaktArray */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.JaktArray;JaktInternal::DynamicArray<NonnullRefPtr<typename types::CheckedExpression>> const& vals = __jakt_match_value.vals;
 JaktInternal::Optional<NonnullRefPtr<typename types::CheckedExpression>> const& repeat = __jakt_match_value.repeat;
-return JaktInternal::ExplicitValue(({ Optional<JaktInternal::Optional<ide::Usage>> __jakt_var_897; {
+return JaktInternal::ExplicitValue(({ Optional<JaktInternal::Optional<ide::Usage>> __jakt_var_898; {
 {
 JaktInternal::ArrayIterator<NonnullRefPtr<typename types::CheckedExpression>> _magic = ((vals).iterator());
 for (;;){
@@ -1366,10 +1366,10 @@ return found;
 if (((repeat).has_value())){
 return TRY((ide::find_span_in_expression(program,(repeat.value()),span)));
 }
-__jakt_var_897 = none; goto __jakt_label_791;
+__jakt_var_898 = none; goto __jakt_label_792;
 
 }
-__jakt_label_791:; __jakt_var_897.release_value(); }));
+__jakt_label_792:; __jakt_var_898.release_value(); }));
 };/*case end*/
 case 28 /* Block */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Block;types::CheckedBlock const& block = __jakt_match_value.block;
@@ -1378,7 +1378,7 @@ return JaktInternal::ExplicitValue(TRY((ide::find_span_in_block(program,block,sp
 case 21 /* Call */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Call;types::CheckedCall const& call = __jakt_match_value.call;
 utility::Span const& call_span = __jakt_match_value.span;
-return JaktInternal::ExplicitValue(({ Optional<JaktInternal::Optional<ide::Usage>> __jakt_var_898; {
+return JaktInternal::ExplicitValue(({ Optional<JaktInternal::Optional<ide::Usage>> __jakt_var_899; {
 {
 JaktInternal::ArrayIterator<JaktInternal::Tuple<ByteString,NonnullRefPtr<typename types::CheckedExpression>>> _magic = ((((call).args)).iterator());
 for (;;){
@@ -1404,14 +1404,14 @@ return found;
 if ((((((call).function_id)).has_value()) && ((call_span).contains(span)))){
 return static_cast<JaktInternal::Optional<ide::Usage>>(ide::Usage::Call((((call).function_id).value())));
 }
-__jakt_var_898 = none; goto __jakt_label_792;
+__jakt_var_899 = none; goto __jakt_label_793;
 
 }
-__jakt_label_792:; __jakt_var_898.release_value(); }));
+__jakt_label_793:; __jakt_var_899.release_value(); }));
 };/*case end*/
 case 12 /* JaktDictionary */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.JaktDictionary;JaktInternal::DynamicArray<JaktInternal::Tuple<NonnullRefPtr<typename types::CheckedExpression>,NonnullRefPtr<typename types::CheckedExpression>>> const& vals = __jakt_match_value.vals;
-return JaktInternal::ExplicitValue(({ Optional<JaktInternal::Optional<ide::Usage>> __jakt_var_899; {
+return JaktInternal::ExplicitValue(({ Optional<JaktInternal::Optional<ide::Usage>> __jakt_var_900; {
 {
 JaktInternal::ArrayIterator<JaktInternal::Tuple<NonnullRefPtr<typename types::CheckedExpression>,NonnullRefPtr<typename types::CheckedExpression>>> _magic = ((vals).iterator());
 for (;;){
@@ -1438,15 +1438,15 @@ return found;
 }
 }
 
-__jakt_var_899 = none; goto __jakt_label_793;
+__jakt_var_900 = none; goto __jakt_label_794;
 
 }
-__jakt_label_793:; __jakt_var_899.release_value(); }));
+__jakt_label_794:; __jakt_var_900.release_value(); }));
 };/*case end*/
 case 13 /* IndexedExpression */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.IndexedExpression;NonnullRefPtr<typename types::CheckedExpression> const& expr = __jakt_match_value.expr;
 NonnullRefPtr<typename types::CheckedExpression> const& index = __jakt_match_value.index;
-return JaktInternal::ExplicitValue(({ Optional<JaktInternal::Optional<ide::Usage>> __jakt_var_900; {
+return JaktInternal::ExplicitValue(({ Optional<JaktInternal::Optional<ide::Usage>> __jakt_var_901; {
 JaktInternal::Optional<ide::Usage> found = TRY((ide::find_span_in_expression(program,expr,span)));
 if (((found).has_value())){
 return found;
@@ -1455,17 +1455,17 @@ return found;
 if (((found).has_value())){
 return found;
 }
-__jakt_var_900 = none; goto __jakt_label_794;
+__jakt_var_901 = none; goto __jakt_label_795;
 
 }
-__jakt_label_794:; __jakt_var_900.release_value(); }));
+__jakt_label_795:; __jakt_var_901.release_value(); }));
 };/*case end*/
 case 16 /* IndexedStruct */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.IndexedStruct;NonnullRefPtr<typename types::CheckedExpression> const& expr = __jakt_match_value.expr;
 ByteString const& name = __jakt_match_value.name;
 utility::Span const& index_span = __jakt_match_value.span;
 ids::TypeId const& known_type_id = __jakt_match_value.type_id;
-return JaktInternal::ExplicitValue(({ Optional<JaktInternal::Optional<ide::Usage>> __jakt_var_901; {
+return JaktInternal::ExplicitValue(({ Optional<JaktInternal::Optional<ide::Usage>> __jakt_var_902; {
 JaktInternal::Optional<ide::Usage> const found = TRY((ide::find_span_in_expression(program,expr,span)));
 if (((found).has_value())){
 return found;
@@ -1527,30 +1527,30 @@ default: VERIFY_NOT_REACHED();}/*switch end*/
 
 }
 }
-__jakt_var_901 = none; goto __jakt_label_795;
+__jakt_var_902 = none; goto __jakt_label_796;
 
 }
-__jakt_label_795:; __jakt_var_901.release_value(); }));
+__jakt_label_796:; __jakt_var_902.release_value(); }));
 };/*case end*/
 case 14 /* IndexedDictionary */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.IndexedDictionary;NonnullRefPtr<typename types::CheckedExpression> const& expr = __jakt_match_value.expr;
 NonnullRefPtr<typename types::CheckedExpression> const& index = __jakt_match_value.index;
-return JaktInternal::ExplicitValue(({ Optional<JaktInternal::Optional<ide::Usage>> __jakt_var_902; {
+return JaktInternal::ExplicitValue(({ Optional<JaktInternal::Optional<ide::Usage>> __jakt_var_903; {
 JaktInternal::Optional<ide::Usage> const found = TRY((ide::find_span_in_expression(program,expr,span)));
 if (((found).has_value())){
 return found;
 }
-__jakt_var_902 = TRY((ide::find_span_in_expression(program,index,span))); goto __jakt_label_796;
+__jakt_var_903 = TRY((ide::find_span_in_expression(program,index,span))); goto __jakt_label_797;
 
 }
-__jakt_label_796:; __jakt_var_902.release_value(); }));
+__jakt_label_797:; __jakt_var_903.release_value(); }));
 };/*case end*/
 case 19 /* Match */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Match;NonnullRefPtr<typename types::CheckedExpression> const& expr = __jakt_match_value.expr;
 JaktInternal::DynamicArray<types::CheckedMatchCase> const& match_cases = __jakt_match_value.match_cases;
 utility::Span const& match_span = __jakt_match_value.span;
 ids::TypeId const& type_id = __jakt_match_value.type_id;
-return JaktInternal::ExplicitValue(({ Optional<JaktInternal::Optional<ide::Usage>> __jakt_var_903; {
+return JaktInternal::ExplicitValue(({ Optional<JaktInternal::Optional<ide::Usage>> __jakt_var_904; {
 {
 JaktInternal::ArrayIterator<types::CheckedMatchCase> _magic = ((match_cases).iterator());
 for (;;){
@@ -1572,44 +1572,9 @@ size_t const& index = __jakt_match_value.index;
 ids::ScopeId const& scope_id = __jakt_match_value.scope_id;
 types::CheckedMatchBody const& body = __jakt_match_value.body;
 utility::Span const& marker_span = __jakt_match_value.marker_span;
-return JaktInternal::ExplicitValue(({ Optional<JaktInternal::Optional<ide::Usage>> __jakt_var_904; {
+return JaktInternal::ExplicitValue(({ Optional<JaktInternal::Optional<ide::Usage>> __jakt_var_905; {
 if (((marker_span).contains(span))){
 return static_cast<JaktInternal::Optional<ide::Usage>>(ide::get_enum_variant_usage_from_type_id_and_name(program,subject_type_id,name));
-}
-__jakt_var_904 = ({
-    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<JaktInternal::Optional<ide::Usage>, ErrorOr<JaktInternal::Optional<ide::Usage>>>{
-auto&& __jakt_match_variant = body;
-switch(__jakt_match_variant.__jakt_init_index()) {
-case 1 /* Block */: {
-auto&& __jakt_match_value = __jakt_match_variant.as.Block;types::CheckedBlock const& block = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(TRY((ide::find_span_in_block(program,block,span))));
-};/*case end*/
-case 0 /* Expression */: {
-auto&& __jakt_match_value = __jakt_match_variant.as.Expression;NonnullRefPtr<typename types::CheckedExpression> const& expr = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(TRY((ide::find_span_in_expression(program,expr,span))));
-};/*case end*/
-default: VERIFY_NOT_REACHED();}/*switch end*/
-}()
-);
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    if (_jakt_value.is_loop_break())
-        return JaktInternal::LoopBreak {};
-    if (_jakt_value.is_loop_continue())
-        return JaktInternal::LoopContinue {};
-    _jakt_value.release_value();
-}); goto __jakt_label_798;
-
-}
-__jakt_label_798:; __jakt_var_904.release_value(); }));
-};/*case end*/
-case 1 /* Expression */: {
-auto&& __jakt_match_value = __jakt_match_variant.as.Expression;NonnullRefPtr<typename types::CheckedExpression> const& expr = __jakt_match_value.expression;
-types::CheckedMatchBody const& body = __jakt_match_value.body;
-return JaktInternal::ExplicitValue(({ Optional<JaktInternal::Optional<ide::Usage>> __jakt_var_905; {
-JaktInternal::Optional<ide::Usage> const found = TRY((ide::find_span_in_expression(program,expr,span)));
-if (((found).has_value())){
-return found;
 }
 __jakt_var_905 = ({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<JaktInternal::Optional<ide::Usage>, ErrorOr<JaktInternal::Optional<ide::Usage>>>{
@@ -1638,6 +1603,41 @@ default: VERIFY_NOT_REACHED();}/*switch end*/
 }
 __jakt_label_799:; __jakt_var_905.release_value(); }));
 };/*case end*/
+case 1 /* Expression */: {
+auto&& __jakt_match_value = __jakt_match_variant.as.Expression;NonnullRefPtr<typename types::CheckedExpression> const& expr = __jakt_match_value.expression;
+types::CheckedMatchBody const& body = __jakt_match_value.body;
+return JaktInternal::ExplicitValue(({ Optional<JaktInternal::Optional<ide::Usage>> __jakt_var_906; {
+JaktInternal::Optional<ide::Usage> const found = TRY((ide::find_span_in_expression(program,expr,span)));
+if (((found).has_value())){
+return found;
+}
+__jakt_var_906 = ({
+    auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<JaktInternal::Optional<ide::Usage>, ErrorOr<JaktInternal::Optional<ide::Usage>>>{
+auto&& __jakt_match_variant = body;
+switch(__jakt_match_variant.__jakt_init_index()) {
+case 1 /* Block */: {
+auto&& __jakt_match_value = __jakt_match_variant.as.Block;types::CheckedBlock const& block = __jakt_match_value.value;
+return JaktInternal::ExplicitValue(TRY((ide::find_span_in_block(program,block,span))));
+};/*case end*/
+case 0 /* Expression */: {
+auto&& __jakt_match_value = __jakt_match_variant.as.Expression;NonnullRefPtr<typename types::CheckedExpression> const& expr = __jakt_match_value.value;
+return JaktInternal::ExplicitValue(TRY((ide::find_span_in_expression(program,expr,span))));
+};/*case end*/
+default: VERIFY_NOT_REACHED();}/*switch end*/
+}()
+);
+    if (_jakt_value.is_return())
+        return _jakt_value.release_return();
+    if (_jakt_value.is_loop_break())
+        return JaktInternal::LoopBreak {};
+    if (_jakt_value.is_loop_continue())
+        return JaktInternal::LoopContinue {};
+    _jakt_value.release_value();
+}); goto __jakt_label_800;
+
+}
+__jakt_label_800:; __jakt_var_906.release_value(); }));
+};/*case end*/
 case 3 /* CatchAll */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.CatchAll;types::CheckedMatchBody const& body = __jakt_match_value.body;
 utility::Span const& marker_span = __jakt_match_value.marker_span;
@@ -1645,38 +1645,13 @@ return JaktInternal::ExplicitValue(({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<JaktInternal::Optional<ide::Usage>,ErrorOr<JaktInternal::Optional<ide::Usage>>>{
 auto __jakt_enum_value = (((marker_span).contains(span)));
 if (__jakt_enum_value == true) {
-return JaktInternal::ExplicitValue(({ Optional<JaktInternal::Optional<ide::Usage>> __jakt_var_906; {
+return JaktInternal::ExplicitValue(({ Optional<JaktInternal::Optional<ide::Usage>> __jakt_var_907; {
 JaktInternal::Set<ByteString> const all_cases = ({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<JaktInternal::Set<ByteString>, ErrorOr<JaktInternal::Optional<ide::Usage>>>{
 auto&& __jakt_match_variant = *((program)->get_type(type_id));
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 25 /* Enum */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Enum;ids::EnumId const& enum_id = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(({ Optional<JaktInternal::Set<ByteString>> __jakt_var_907; {
-JaktInternal::Set<ByteString> names = Set<ByteString>::create_with_values({});
-types::CheckedEnum const enum_ = ((program)->get_enum(enum_id));
-{
-JaktInternal::ArrayIterator<types::CheckedEnumVariant> _magic = ((((enum_).variants)).iterator());
-for (;;){
-JaktInternal::Optional<types::CheckedEnumVariant> const _magic_value = ((_magic).next());
-if ((!(((_magic_value).has_value())))){
-break;
-}
-types::CheckedEnumVariant variant = (_magic_value.value());
-{
-((names).add(((variant).name())));
-}
-
-}
-}
-
-__jakt_var_907 = names; goto __jakt_label_801;
-
-}
-__jakt_label_801:; __jakt_var_907.release_value(); }));
-};/*case end*/
-case 21 /* GenericEnumInstance */: {
-auto&& __jakt_match_value = __jakt_match_variant.as.GenericEnumInstance;ids::EnumId const& enum_id = __jakt_match_value.id;
 return JaktInternal::ExplicitValue(({ Optional<JaktInternal::Set<ByteString>> __jakt_var_908; {
 JaktInternal::Set<ByteString> names = Set<ByteString>::create_with_values({});
 types::CheckedEnum const enum_ = ((program)->get_enum(enum_id));
@@ -1700,12 +1675,37 @@ __jakt_var_908 = names; goto __jakt_label_802;
 }
 __jakt_label_802:; __jakt_var_908.release_value(); }));
 };/*case end*/
-default: {
+case 21 /* GenericEnumInstance */: {
+auto&& __jakt_match_value = __jakt_match_variant.as.GenericEnumInstance;ids::EnumId const& enum_id = __jakt_match_value.id;
 return JaktInternal::ExplicitValue(({ Optional<JaktInternal::Set<ByteString>> __jakt_var_909; {
-__jakt_var_909 = Set<ByteString>::create_with_values({__jakt_format((StringView::from_string_literal("else ({})"sv)),TRY((((program)->type_name(type_id,false)))))}); goto __jakt_label_803;
+JaktInternal::Set<ByteString> names = Set<ByteString>::create_with_values({});
+types::CheckedEnum const enum_ = ((program)->get_enum(enum_id));
+{
+JaktInternal::ArrayIterator<types::CheckedEnumVariant> _magic = ((((enum_).variants)).iterator());
+for (;;){
+JaktInternal::Optional<types::CheckedEnumVariant> const _magic_value = ((_magic).next());
+if ((!(((_magic_value).has_value())))){
+break;
+}
+types::CheckedEnumVariant variant = (_magic_value.value());
+{
+((names).add(((variant).name())));
+}
+
+}
+}
+
+__jakt_var_909 = names; goto __jakt_label_803;
 
 }
 __jakt_label_803:; __jakt_var_909.release_value(); }));
+};/*case end*/
+default: {
+return JaktInternal::ExplicitValue(({ Optional<JaktInternal::Set<ByteString>> __jakt_var_910; {
+__jakt_var_910 = Set<ByteString>::create_with_values({__jakt_format((StringView::from_string_literal("else ({})"sv)),TRY((((program)->type_name(type_id,false)))))}); goto __jakt_label_804;
+
+}
+__jakt_label_804:; __jakt_var_910.release_value(); }));
 };/*case end*/
 }/*switch end*/
 }()
@@ -1737,11 +1737,11 @@ ByteString const name = (other_case).as.EnumVariant.name;
 }
 }
 
-__jakt_var_906 = ({
+__jakt_var_907 = ({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<JaktInternal::Optional<ide::Usage>,ErrorOr<JaktInternal::Optional<ide::Usage>>>{
 auto __jakt_enum_value = (((remaining_cases).is_empty()));
 if (__jakt_enum_value == false) {
-return JaktInternal::ExplicitValue(({ Optional<JaktInternal::Optional<ide::Usage>> __jakt_var_910; {
+return JaktInternal::ExplicitValue(({ Optional<JaktInternal::Optional<ide::Usage>> __jakt_var_911; {
 JaktInternal::DynamicArray<ByteString> cases_array = DynamicArray<ByteString>::create_with({});
 ((cases_array).ensure_capacity(((remaining_cases).size())));
 {
@@ -1759,10 +1759,10 @@ ByteString name = (_magic_value.value());
 }
 }
 
-__jakt_var_910 = static_cast<JaktInternal::Optional<ide::Usage>>(ide::Usage::NameSet(cases_array)); goto __jakt_label_804;
+__jakt_var_911 = static_cast<JaktInternal::Optional<ide::Usage>>(ide::Usage::NameSet(cases_array)); goto __jakt_label_805;
 
 }
-__jakt_label_804:; __jakt_var_910.release_value(); }));
+__jakt_label_805:; __jakt_var_911.release_value(); }));
 }
 else if (__jakt_enum_value == true) {
 return JaktInternal::ExplicitValue(JaktInternal::OptionalNone());
@@ -1776,10 +1776,10 @@ VERIFY_NOT_REACHED();
     if (_jakt_value.is_loop_continue())
         return JaktInternal::LoopContinue {};
     _jakt_value.release_value();
-}); goto __jakt_label_800;
+}); goto __jakt_label_801;
 
 }
-__jakt_label_800:; __jakt_var_906.release_value(); }));
+__jakt_label_801:; __jakt_var_907.release_value(); }));
 }
 else {
 return JaktInternal::ExplicitValue(({
@@ -1879,10 +1879,10 @@ return found;
 }
 }
 
-__jakt_var_903 = TRY((ide::find_span_in_expression(program,expr,span))); goto __jakt_label_797;
+__jakt_var_904 = TRY((ide::find_span_in_expression(program,expr,span))); goto __jakt_label_798;
 
 }
-__jakt_label_797:; __jakt_var_903.release_value(); }));
+__jakt_label_798:; __jakt_var_904.release_value(); }));
 };/*case end*/
 case 27 /* ForcedUnwrap */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.ForcedUnwrap;NonnullRefPtr<typename types::CheckedExpression> const& expr = __jakt_match_value.expr;
@@ -1959,7 +1959,7 @@ case 23 /* NamespacedVar */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.NamespacedVar;JaktInternal::DynamicArray<types::CheckedNamespace> const& namespaces = __jakt_match_value.namespaces;
 NonnullRefPtr<types::CheckedVariable> const& var = __jakt_match_value.var;
 utility::Span const& var_span = __jakt_match_value.span;
-return JaktInternal::ExplicitValue(({ Optional<JaktInternal::Optional<ide::Usage>> __jakt_var_911; {
+return JaktInternal::ExplicitValue(({ Optional<JaktInternal::Optional<ide::Usage>> __jakt_var_912; {
 if ((((var_span).contains(span)) && (!(((namespaces).is_empty()))))){
 types::CheckedNamespace const last_ns = (((namespaces).last()).value());
 if (((((((program)->get_scope(((last_ns).scope))))->namespace_name)).has_value())){
@@ -1970,34 +1970,34 @@ return static_cast<JaktInternal::Optional<ide::Usage>>(ide::get_enum_variant_usa
 }
 }
 }
-__jakt_var_911 = none; goto __jakt_label_805;
+__jakt_var_912 = none; goto __jakt_label_806;
 
 }
-__jakt_label_805:; __jakt_var_911.release_value(); }));
+__jakt_label_806:; __jakt_var_912.release_value(); }));
 };/*case end*/
 case 32 /* TryBlock */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.TryBlock;NonnullRefPtr<typename types::CheckedStatement> const& stmt = __jakt_match_value.stmt;
 ByteString const& error_name = __jakt_match_value.error_name;
 types::CheckedBlock const& catch_block = __jakt_match_value.catch_block;
-return JaktInternal::ExplicitValue(({ Optional<JaktInternal::Optional<ide::Usage>> __jakt_var_912; {
+return JaktInternal::ExplicitValue(({ Optional<JaktInternal::Optional<ide::Usage>> __jakt_var_913; {
 JaktInternal::Optional<ide::Usage> const found = TRY((ide::find_span_in_statement(program,stmt,span)));
 if (((found).has_value())){
 return found;
 }
-__jakt_var_912 = TRY((ide::find_span_in_block(program,catch_block,span))); goto __jakt_label_806;
+__jakt_var_913 = TRY((ide::find_span_in_block(program,catch_block,span))); goto __jakt_label_807;
 
 }
-__jakt_label_806:; __jakt_var_912.release_value(); }));
+__jakt_label_807:; __jakt_var_913.release_value(); }));
 };/*case end*/
 case 31 /* Try */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Try;NonnullRefPtr<typename types::CheckedExpression> const& expr = __jakt_match_value.expr;
 JaktInternal::Optional<types::CheckedBlock> const& catch_block = __jakt_match_value.catch_block;
-return JaktInternal::ExplicitValue(({ Optional<JaktInternal::Optional<ide::Usage>> __jakt_var_913; {
+return JaktInternal::ExplicitValue(({ Optional<JaktInternal::Optional<ide::Usage>> __jakt_var_914; {
 JaktInternal::Optional<ide::Usage> const found = TRY((ide::find_span_in_expression(program,expr,span)));
 if (((found).has_value())){
 return found;
 }
-__jakt_var_913 = ({
+__jakt_var_914 = ({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<JaktInternal::Optional<ide::Usage>,ErrorOr<JaktInternal::Optional<ide::Usage>>>{
 auto __jakt_enum_value = (((catch_block).has_value()));
 if (__jakt_enum_value == true) {
@@ -2011,15 +2011,15 @@ VERIFY_NOT_REACHED();
     if (_jakt_value.is_return())
         return _jakt_value.release_return();
     _jakt_value.release_value();
-}); goto __jakt_label_807;
+}); goto __jakt_label_808;
 
 }
-__jakt_label_807:; __jakt_var_913.release_value(); }));
+__jakt_label_808:; __jakt_var_914.release_value(); }));
 };/*case end*/
 case 9 /* Range */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Range;JaktInternal::Optional<NonnullRefPtr<typename types::CheckedExpression>> const& from = __jakt_match_value.from;
 JaktInternal::Optional<NonnullRefPtr<typename types::CheckedExpression>> const& to = __jakt_match_value.to;
-return JaktInternal::ExplicitValue(({ Optional<JaktInternal::Optional<ide::Usage>> __jakt_var_914; {
+return JaktInternal::ExplicitValue(({ Optional<JaktInternal::Optional<ide::Usage>> __jakt_var_915; {
 if (((from).has_value())){
 JaktInternal::Optional<ide::Usage> const found = TRY((ide::find_span_in_expression(program,(from.value()),span)));
 if (((found).has_value())){
@@ -2029,10 +2029,10 @@ return found;
 if (((to).has_value())){
 return TRY((ide::find_span_in_expression(program,(to.value()),span)));
 }
-__jakt_var_914 = none; goto __jakt_label_808;
+__jakt_var_915 = none; goto __jakt_label_809;
 
 }
-__jakt_label_808:; __jakt_var_914.release_value(); }));
+__jakt_label_809:; __jakt_var_915.release_value(); }));
 };/*case end*/
 default: {
 return JaktInternal::ExplicitValue(none);
@@ -2288,7 +2288,7 @@ return ({
 auto&& __jakt_match_variant = var_type;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 0 /* Variable */: {
-return JaktInternal::ExplicitValue(({ Optional<ByteString> __jakt_var_915; {
+return JaktInternal::ExplicitValue(({ Optional<ByteString> __jakt_var_916; {
 ByteString const mut_string = ({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<ByteString, ErrorOr<ByteString>>{
 auto&& __jakt_match_variant = mutability;
@@ -2310,10 +2310,10 @@ return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation(""s
     _jakt_value.release_value();
 });
 ByteString const type_name = TRY((ide::get_type_signature(program,var_type_id)));
-__jakt_var_915 = __jakt_format((StringView::from_string_literal("{} {}: {}"sv)),mut_string,name,type_name); goto __jakt_label_809;
+__jakt_var_916 = __jakt_format((StringView::from_string_literal("{} {}: {}"sv)),mut_string,name,type_name); goto __jakt_label_810;
 
 }
-__jakt_label_809:; __jakt_var_915.release_value(); }));
+__jakt_label_810:; __jakt_var_916.release_value(); }));
 };/*case end*/
 case 1 /* Field */: {
 {
@@ -2457,7 +2457,7 @@ return JaktInternal::ExplicitValue(TRY((types::comptime_format_impl((ByteString:
 case 30 /* Function */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Function;JaktInternal::DynamicArray<ids::TypeId> const& params = __jakt_match_value.params;
 ids::TypeId const& return_type_id = __jakt_match_value.return_type_id;
-return JaktInternal::ExplicitValue(({ Optional<ByteString> __jakt_var_916; {
+return JaktInternal::ExplicitValue(({ Optional<ByteString> __jakt_var_917; {
 JaktInternal::DynamicArray<ByteString> param_names = DynamicArray<ByteString>::create_with({});
 {
 JaktInternal::ArrayIterator<ids::TypeId> _magic = ((params).iterator());
@@ -2475,10 +2475,10 @@ ids::TypeId x = (_magic_value.value());
 }
 
 ByteString const return_type = TRY((((program)->type_name(return_type_id,false))));
-__jakt_var_916 = __jakt_format((StringView::from_string_literal("fn({}) -> {}"sv)),utility::join(param_names,(ByteString::from_utf8_without_validation(", "sv))),return_type); goto __jakt_label_810;
+__jakt_var_917 = __jakt_format((StringView::from_string_literal("fn({}) -> {}"sv)),utility::join(param_names,(ByteString::from_utf8_without_validation(", "sv))),return_type); goto __jakt_label_811;
 
 }
-__jakt_label_810:; __jakt_var_916.release_value(); }));
+__jakt_label_811:; __jakt_var_917.release_value(); }));
 };/*case end*/
 case 26 /* RawPtr */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.RawPtr;ids::TypeId const& type_id = __jakt_match_value.value;
@@ -2486,9 +2486,9 @@ return JaktInternal::ExplicitValue((((ByteString::from_utf8_without_validation("
 };/*case end*/
 case 25 /* Enum */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Enum;ids::EnumId const& id = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(({ Optional<ByteString> __jakt_var_917; {
+return JaktInternal::ExplicitValue(({ Optional<ByteString> __jakt_var_918; {
 types::CheckedEnum const enum_ = ((program)->get_enum(id));
-__jakt_var_917 = ((((({
+__jakt_var_918 = ((((({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<ByteString,ErrorOr<ByteString>>{
 auto __jakt_enum_value = (((enum_).is_boxed));
 if (__jakt_enum_value == true) {
@@ -2501,16 +2501,16 @@ return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation(""s
     if (_jakt_value.is_return())
         return _jakt_value.release_return();
     _jakt_value.release_value();
-})) + ((ByteString::from_utf8_without_validation("enum "sv))))) + (((enum_).name))); goto __jakt_label_811;
+})) + ((ByteString::from_utf8_without_validation("enum "sv))))) + (((enum_).name))); goto __jakt_label_812;
 
 }
-__jakt_label_811:; __jakt_var_917.release_value(); }));
+__jakt_label_812:; __jakt_var_918.release_value(); }));
 };/*case end*/
 case 24 /* Struct */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Struct;ids::StructId const& id = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(({ Optional<ByteString> __jakt_var_918; {
+return JaktInternal::ExplicitValue(({ Optional<ByteString> __jakt_var_919; {
 types::CheckedStruct const struct_ = ((program)->get_struct(id));
-__jakt_var_918 = ((({
+__jakt_var_919 = ((({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<ByteString, ErrorOr<ByteString>>{
 auto&& __jakt_match_variant = ((struct_).record_type);
 switch(__jakt_match_variant.__jakt_init_index()) {
@@ -2531,15 +2531,15 @@ utility::panic((ByteString::from_utf8_without_validation("unreachable: should've
     if (_jakt_value.is_return())
         return _jakt_value.release_return();
     _jakt_value.release_value();
-})) + (((struct_).name))); goto __jakt_label_812;
+})) + (((struct_).name))); goto __jakt_label_813;
 
 }
-__jakt_label_812:; __jakt_var_918.release_value(); }));
+__jakt_label_813:; __jakt_var_919.release_value(); }));
 };/*case end*/
 case 23 /* GenericResolvedType */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.GenericResolvedType;ids::StructId const& id = __jakt_match_value.id;
 JaktInternal::DynamicArray<ids::TypeId> const& args = __jakt_match_value.args;
-return JaktInternal::ExplicitValue(({ Optional<ByteString> __jakt_var_919; {
+return JaktInternal::ExplicitValue(({ Optional<ByteString> __jakt_var_920; {
 types::CheckedStruct const record = ((program)->get_struct(id));
 ByteString output = ((record).name);
 [](ByteString& self, ByteString rhs) -> void {
@@ -2582,15 +2582,15 @@ size_t i = (_magic_value.value());
 }
 
 }
-__jakt_var_919 = ((output) + ((ByteString::from_utf8_without_validation(">"sv)))); goto __jakt_label_813;
+__jakt_var_920 = ((output) + ((ByteString::from_utf8_without_validation(">"sv)))); goto __jakt_label_814;
 
 }
-__jakt_label_813:; __jakt_var_919.release_value(); }));
+__jakt_label_814:; __jakt_var_920.release_value(); }));
 };/*case end*/
 case 21 /* GenericEnumInstance */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.GenericEnumInstance;ids::EnumId const& id = __jakt_match_value.id;
 JaktInternal::DynamicArray<ids::TypeId> const& args = __jakt_match_value.args;
-return JaktInternal::ExplicitValue(({ Optional<ByteString> __jakt_var_920; {
+return JaktInternal::ExplicitValue(({ Optional<ByteString> __jakt_var_921; {
 types::CheckedEnum const enum_ = ((program)->get_enum(id));
 ByteString output = (ByteString::from_utf8_without_validation(""sv));
 if (((enum_).is_boxed)){
@@ -2653,15 +2653,15 @@ size_t i = (_magic_value.value());
 }
 
 }
-__jakt_var_920 = ((output) + ((ByteString::from_utf8_without_validation(">"sv)))); goto __jakt_label_814;
+__jakt_var_921 = ((output) + ((ByteString::from_utf8_without_validation(">"sv)))); goto __jakt_label_815;
 
 }
-__jakt_label_814:; __jakt_var_920.release_value(); }));
+__jakt_label_815:; __jakt_var_921.release_value(); }));
 };/*case end*/
 case 22 /* GenericTraitInstance */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.GenericTraitInstance;ids::TraitId const& id = __jakt_match_value.id;
 JaktInternal::DynamicArray<ids::TypeId> const& args = __jakt_match_value.args;
-return JaktInternal::ExplicitValue(({ Optional<ByteString> __jakt_var_921; {
+return JaktInternal::ExplicitValue(({ Optional<ByteString> __jakt_var_922; {
 NonnullRefPtr<types::CheckedTrait> const trait_ = ((program)->get_trait(id));
 ByteString output = (ByteString::from_utf8_without_validation(""sv));
 [](ByteString& self, ByteString rhs) -> void {
@@ -2716,15 +2716,15 @@ size_t i = (_magic_value.value());
 }
 
 }
-__jakt_var_921 = ((output) + ((ByteString::from_utf8_without_validation(">"sv)))); goto __jakt_label_815;
+__jakt_var_922 = ((output) + ((ByteString::from_utf8_without_validation(">"sv)))); goto __jakt_label_816;
 
 }
-__jakt_label_815:; __jakt_var_921.release_value(); }));
+__jakt_label_816:; __jakt_var_922.release_value(); }));
 };/*case end*/
 case 20 /* GenericInstance */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.GenericInstance;ids::StructId const& id = __jakt_match_value.id;
 JaktInternal::DynamicArray<ids::TypeId> const& args = __jakt_match_value.args;
-return JaktInternal::ExplicitValue(({ Optional<ByteString> __jakt_var_922; {
+return JaktInternal::ExplicitValue(({ Optional<ByteString> __jakt_var_923; {
 if (((id).equals(array_struct_id))){
 if (((args).is_empty())){
 return (ByteString::from_utf8_without_validation("[]"sv));
@@ -2886,10 +2886,10 @@ size_t i = (_magic_value.value());
 }
 
 }
-__jakt_var_922 = ((output) + ((ByteString::from_utf8_without_validation(">"sv)))); goto __jakt_label_816;
+__jakt_var_923 = ((output) + ((ByteString::from_utf8_without_validation(">"sv)))); goto __jakt_label_817;
 
 }
-__jakt_label_816:; __jakt_var_922.release_value(); }));
+__jakt_label_817:; __jakt_var_923.release_value(); }));
 };/*case end*/
 case 28 /* Reference */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Reference;ids::TypeId const& type_id = __jakt_match_value.value;
@@ -3107,19 +3107,19 @@ auto&& __jakt_match_variant = variant;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 2 /* WithValue */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.WithValue;NonnullRefPtr<typename types::CheckedExpression> const& expr = __jakt_match_value.expr;
-return JaktInternal::ExplicitValue(({ Optional<JaktInternal::Optional<types::NumberConstant>> __jakt_var_923; {
-__jakt_var_923 = ((expr)->to_number_constant(program)); goto __jakt_label_817;
-
-}
-__jakt_label_817:; __jakt_var_923.release_value(); }));
-};/*case end*/
-default: {
 return JaktInternal::ExplicitValue(({ Optional<JaktInternal::Optional<types::NumberConstant>> __jakt_var_924; {
-JaktInternal::Optional<types::NumberConstant> const none = JaktInternal::OptionalNone();
-__jakt_var_924 = none; goto __jakt_label_818;
+__jakt_var_924 = ((expr)->to_number_constant(program)); goto __jakt_label_818;
 
 }
 __jakt_label_818:; __jakt_var_924.release_value(); }));
+};/*case end*/
+default: {
+return JaktInternal::ExplicitValue(({ Optional<JaktInternal::Optional<types::NumberConstant>> __jakt_var_925; {
+JaktInternal::Optional<types::NumberConstant> const none = JaktInternal::OptionalNone();
+__jakt_var_925 = none; goto __jakt_label_819;
+
+}
+__jakt_label_819:; __jakt_var_925.release_value(); }));
 };/*case end*/
 }/*switch end*/
 }()
@@ -3248,7 +3248,7 @@ auto&& __jakt_match_variant = checked_enum_variant;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 3 /* StructLike */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.StructLike;JaktInternal::DynamicArray<ids::VarId> const& fields = __jakt_match_value.fields;
-return JaktInternal::ExplicitValue(({ Optional<JaktInternal::DynamicArray<JaktInternal::Tuple<JaktInternal::Optional<ByteString>,ids::TypeId>>> __jakt_var_925; {
+return JaktInternal::ExplicitValue(({ Optional<JaktInternal::DynamicArray<JaktInternal::Tuple<JaktInternal::Optional<ByteString>,ids::TypeId>>> __jakt_var_926; {
 JaktInternal::DynamicArray<JaktInternal::Tuple<JaktInternal::Optional<ByteString>,ids::TypeId>> output = DynamicArray<JaktInternal::Tuple<JaktInternal::Optional<ByteString>,ids::TypeId>>::create_with({});
 {
 JaktInternal::ArrayIterator<ids::VarId> _magic = ((fields).iterator());
@@ -3268,19 +3268,19 @@ JaktInternal::Tuple<JaktInternal::Optional<ByteString>,ids::TypeId> const o = (T
 }
 }
 
-__jakt_var_925 = output; goto __jakt_label_819;
-
-}
-__jakt_label_819:; __jakt_var_925.release_value(); }));
-};/*case end*/
-case 1 /* Typed */: {
-auto&& __jakt_match_value = __jakt_match_variant.as.Typed;ids::TypeId const& type_id = __jakt_match_value.type_id;
-return JaktInternal::ExplicitValue(({ Optional<JaktInternal::DynamicArray<JaktInternal::Tuple<JaktInternal::Optional<ByteString>,ids::TypeId>>> __jakt_var_926; {
-JaktInternal::Optional<ByteString> const string_none = JaktInternal::OptionalNone();
-__jakt_var_926 = DynamicArray<JaktInternal::Tuple<JaktInternal::Optional<ByteString>,ids::TypeId>>::create_with({(Tuple{string_none, type_id})}); goto __jakt_label_820;
+__jakt_var_926 = output; goto __jakt_label_820;
 
 }
 __jakt_label_820:; __jakt_var_926.release_value(); }));
+};/*case end*/
+case 1 /* Typed */: {
+auto&& __jakt_match_value = __jakt_match_variant.as.Typed;ids::TypeId const& type_id = __jakt_match_value.type_id;
+return JaktInternal::ExplicitValue(({ Optional<JaktInternal::DynamicArray<JaktInternal::Tuple<JaktInternal::Optional<ByteString>,ids::TypeId>>> __jakt_var_927; {
+JaktInternal::Optional<ByteString> const string_none = JaktInternal::OptionalNone();
+__jakt_var_927 = DynamicArray<JaktInternal::Tuple<JaktInternal::Optional<ByteString>,ids::TypeId>>::create_with({(Tuple{string_none, type_id})}); goto __jakt_label_821;
+
+}
+__jakt_label_821:; __jakt_var_927.release_value(); }));
 };/*case end*/
 default: {
 return JaktInternal::ExplicitValue(DynamicArray<JaktInternal::Tuple<JaktInternal::Optional<ByteString>,ids::TypeId>>::create_with({}));

--- a/bootstrap/stage0/main.cpp
+++ b/bootstrap/stage0/main.cpp
@@ -466,15 +466,15 @@ if (__jakt_enum_value == static_cast<size_t>(1ULL)) {
 return JaktInternal::ExplicitValue(input_file_length);
 }
 else if (__jakt_enum_value == static_cast<size_t>(2ULL)) {
-return JaktInternal::ExplicitValue(({ Optional<size_t> __jakt_var_956; {
+return JaktInternal::ExplicitValue(({ Optional<size_t> __jakt_var_957; {
 JaktInternal::Optional<u32> const end_input = ((((parts)[static_cast<i64>(1LL)])).to_uint());
 if ((!(((end_input).has_value())))){
 return JaktInternal::OptionalNone();
 }
-__jakt_var_956 = (infallible_integer_cast<size_t>(((end_input.value())))); goto __jakt_label_828;
+__jakt_var_957 = (infallible_integer_cast<size_t>(((end_input.value())))); goto __jakt_label_829;
 
 }
-__jakt_label_828:; __jakt_var_956.release_value(); }));
+__jakt_label_829:; __jakt_var_957.release_value(); }));
 }
 else {
 {
@@ -546,12 +546,12 @@ bool const is_directory = ((jakt__entry__is_directory__).template get<1>());
 jakt__path::Path const path = ((directory).join(entry));
 jakt__path::Path const path_relative_to_target = ((relative_dir).join(entry));
 if (is_directory){
-auto __jakt_var_958 = [&]() -> ErrorOr<void> { return TRY((jakt__platform__unknown_fs::make_directory(((((to).join(((path_relative_to_target).to_string())))).to_string())))), ErrorOr<void>{}; }();
+auto __jakt_var_959 = [&]() -> ErrorOr<void> { return TRY((jakt__platform__unknown_fs::make_directory(((((to).join(((path_relative_to_target).to_string())))).to_string())))), ErrorOr<void>{}; }();
 ;
 ((directories_to_copy).enqueue((Tuple{path, path_relative_to_target})));
 continue;
 }
-auto __jakt_var_960 = [&]() -> ErrorOr<void> { return TRY((mkdir_p(((((to).join(((path_relative_to_target).to_string())))).parent())))), ErrorOr<void>{}; }();
+auto __jakt_var_961 = [&]() -> ErrorOr<void> { return TRY((mkdir_p(((((to).join(((path_relative_to_target).to_string())))).parent())))), ErrorOr<void>{}; }();
 ;
 jakt__path::Path const target_path = ((to).join(((path_relative_to_target).to_string())));
 NonnullRefPtr<File> input_file = TRY((File::open_for_reading(((path).to_string()))));
@@ -1086,15 +1086,15 @@ bool const format_debug = TRY((((args_parser).flag(DynamicArray<ByteString>::cre
 ByteString const input_format_range = TRY((TRY((((args_parser).option(DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("-fr"sv)), (ByteString::from_utf8_without_validation("--format-range"sv))}))))).try_value_or_lazy_evaluated([&]() -> ErrorOr<ByteString> { return (ByteString::from_utf8_without_validation(""sv)); })));
 bool const ak_stdlib = TRY((((args_parser).flag(DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("--ak-is-my-only-stdlib"sv))})))));
 bool const discover_only = TRY((((args_parser).flag(DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("--discover"sv))})))));
-size_t const max_concurrent = (infallible_integer_cast<size_t>((({ Optional<u32> __jakt_var_961;
-auto __jakt_var_962 = [&]() -> ErrorOr<u32> { return TRY((value_or_throw<u32>(((compiler_job_count).to_uint())))); }();
-if (__jakt_var_962.is_error()) {{
+size_t const max_concurrent = (infallible_integer_cast<size_t>((({ Optional<u32> __jakt_var_962;
+auto __jakt_var_963 = [&]() -> ErrorOr<u32> { return TRY((value_or_throw<u32>(((compiler_job_count).to_uint())))); }();
+if (__jakt_var_963.is_error()) {{
 warnln((StringView::from_string_literal("error: invalid value for --jobs: {}"sv)),compiler_job_count);
 return static_cast<int>(1);
 }
-} else {__jakt_var_961 = __jakt_var_962.release_value();
+} else {__jakt_var_962 = __jakt_var_963.release_value();
 }
-__jakt_var_961.release_value(); }))));
+__jakt_var_962.release_value(); }))));
 if (TRY((((args_parser).flag(DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("--repl"sv))})))))){
 repl::REPL repl = TRY((repl::REPL::create(jakt__path::Path::from_parts(DynamicArray<ByteString>::create_with({runtime_path, (ByteString::from_utf8_without_validation("jaktlib"sv))})),target_triple,user_configuration)));
 TRY((((repl).run())));
@@ -1322,7 +1322,7 @@ JaktInternal::DynamicArray<types::Value> const arguments = ({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<JaktInternal::DynamicArray<types::Value>,ErrorOr<int>>{
 auto __jakt_enum_value = (((first_main_param).has_value()));
 if (__jakt_enum_value == true) {
-return JaktInternal::ExplicitValue(({ Optional<JaktInternal::DynamicArray<types::Value>> __jakt_var_963; {
+return JaktInternal::ExplicitValue(({ Optional<JaktInternal::DynamicArray<types::Value>> __jakt_var_964; {
 JaktInternal::DynamicArray<types::Value> passed_arguments = DynamicArray<types::Value>::create_with({types::Value(types::ValueImpl::JaktString((file_name.value())),call_span)});
 {
 JaktInternal::ArrayIterator<ByteString> _magic = ((interpreted_main_arguments).iterator());
@@ -1339,10 +1339,10 @@ ByteString argument = (_magic_value.value());
 }
 }
 
-__jakt_var_963 = DynamicArray<types::Value>::create_with({types::Value(types::ValueImpl::JaktArray(passed_arguments,(((((first_main_param.value())).variable))->type_id)),call_span)}); goto __jakt_label_829;
+__jakt_var_964 = DynamicArray<types::Value>::create_with({types::Value(types::ValueImpl::JaktArray(passed_arguments,(((((first_main_param.value())).variable))->type_id)),call_span)}); goto __jakt_label_830;
 
 }
-__jakt_label_829:; __jakt_var_963.release_value(); }));
+__jakt_label_830:; __jakt_var_964.release_value(); }));
 }
 else if (__jakt_enum_value == false) {
 return JaktInternal::ExplicitValue(DynamicArray<types::Value>::create_with({}));
@@ -1611,8 +1611,8 @@ ByteString const contents = ((contents_module_file_path_).template get<0>());
 ByteString const module_file_path = ((contents_module_file_path_).template get<1>());
 
 jakt__path::Path const path = ((binary_dir).join(file));
-auto __jakt_var_965 = [&]() -> ErrorOr<void> { return TRY((write_only_if_updated(contents,((path).to_string())))), ErrorOr<void>{}; }();
-if (__jakt_var_965.is_error()) {auto error = __jakt_var_965.release_error();
+auto __jakt_var_966 = [&]() -> ErrorOr<void> { return TRY((write_only_if_updated(contents,((path).to_string())))), ErrorOr<void>{}; }();
+if (__jakt_var_966.is_error()) {auto error = __jakt_var_966.release_error();
 {
 warnln((StringView::from_string_literal("Error: Could not write to file: {} ({})"sv)),file,error);
 return static_cast<int>(1);
@@ -1625,12 +1625,12 @@ return static_cast<int>(1);
 }
 
 if (((generate_depfile).has_value())){
-auto __jakt_var_966 = [&]() -> ErrorOr<void> {{
+auto __jakt_var_967 = [&]() -> ErrorOr<void> {{
 TRY((write_only_if_updated(((depfile_builder).to_string()),(generate_depfile.value()))));
 }
 
 ;return {};}();
-if (__jakt_var_966.is_error()) {auto error = __jakt_var_966.release_error();{
+if (__jakt_var_967.is_error()) {auto error = __jakt_var_967.release_error();{
 warnln((StringView::from_string_literal("Error: Could not write to file list ({})"sv)),error);
 return static_cast<int>(1);
 }
@@ -1737,13 +1737,13 @@ ByteString flag = (_magic_value.value());
 }
 }
 
-auto __jakt_var_968 = [&]() -> ErrorOr<void> { return TRY((((builder).build_all(binary_dir,(([use_ccache, cxx_compiler_path, runtime_path, extra_include_paths, optimize, extra_compiler_flags](ByteString input_filename, ByteString output_filename) -> ErrorOr<JaktInternal::DynamicArray<ByteString>> {
+auto __jakt_var_969 = [&]() -> ErrorOr<void> { return TRY((((builder).build_all(binary_dir,(([use_ccache, cxx_compiler_path, runtime_path, extra_include_paths, optimize, extra_compiler_flags](ByteString input_filename, ByteString output_filename) -> ErrorOr<JaktInternal::DynamicArray<ByteString>> {
 {
 return TRY((platform__unknown_compiler::run_compiler(cxx_compiler_path,input_filename,output_filename,runtime_path,extra_include_paths,DynamicArray<ByteString>::create_with({}),DynamicArray<ByteString>::create_with({}),optimize,extra_compiler_flags,use_ccache)));
 }
 }
 )))))), ErrorOr<void>{}; }();
-if (__jakt_var_968.is_error()) {{
+if (__jakt_var_969.is_error()) {{
 return static_cast<int>(1);
 }
 }
@@ -1770,8 +1770,8 @@ if (archive_link_support_libs){
 ((extra_arguments).push(((((runtime_lib_path).join(TRY((platform::library_name_for_target((ByteString::from_utf8_without_validation("main"sv)),target)))))).to_string())));
 ((extra_arguments).push(((((runtime_lib_path).join(TRY((platform::library_name_for_target((ByteString::from_utf8_without_validation("runtime"sv)),target)))))).to_string())));
 }
-auto __jakt_var_970 = [&]() -> ErrorOr<void> { return TRY((((builder).link_into_archive(TRY((archiver_path.try_value_or_lazy_evaluated([&]() -> ErrorOr<ByteString> { return (ByteString::from_utf8_without_validation("ar"sv)); }))),((((binary_dir).join((link_archive.value())))).to_string()),extra_arguments)))), ErrorOr<void>{}; }();
-if (__jakt_var_970.is_error()) {{
+auto __jakt_var_971 = [&]() -> ErrorOr<void> { return TRY((((builder).link_into_archive(TRY((archiver_path.try_value_or_lazy_evaluated([&]() -> ErrorOr<ByteString> { return (ByteString::from_utf8_without_validation("ar"sv)); }))),((((binary_dir).join((link_archive.value())))).to_string()),extra_arguments)))), ErrorOr<void>{}; }();
+if (__jakt_var_971.is_error()) {{
 return static_cast<int>(1);
 }
 }
@@ -1858,8 +1858,8 @@ ByteString arg = (_magic_value.value());
 }
 }
 
-auto __jakt_var_972 = [&]() -> ErrorOr<void> { return TRY((((builder).link_into_executable(cxx_compiler_path,output_filename,extra_arguments)))), ErrorOr<void>{}; }();
-if (__jakt_var_972.is_error()) {{
+auto __jakt_var_973 = [&]() -> ErrorOr<void> { return TRY((((builder).link_into_executable(cxx_compiler_path,output_filename,extra_arguments)))), ErrorOr<void>{}; }();
+if (__jakt_var_973.is_error()) {{
 return static_cast<int>(1);
 }
 }
@@ -2054,15 +2054,15 @@ return {};
 
 bool file_needs_updating(ByteString const path,ByteString const new_contents) {
 {
-JaktInternal::Optional<NonnullRefPtr<File>> maybe_file = ({ Optional<NonnullRefPtr<File>> __jakt_var_973;
-auto __jakt_var_974 = [&]() -> ErrorOr<NonnullRefPtr<File>> { return TRY((File::open_for_reading(path))); }();
-if (!__jakt_var_974.is_error()) __jakt_var_973 = __jakt_var_974.release_value();
-__jakt_var_973; });
+JaktInternal::Optional<NonnullRefPtr<File>> maybe_file = ({ Optional<NonnullRefPtr<File>> __jakt_var_974;
+auto __jakt_var_975 = [&]() -> ErrorOr<NonnullRefPtr<File>> { return TRY((File::open_for_reading(path))); }();
+if (!__jakt_var_975.is_error()) __jakt_var_974 = __jakt_var_975.release_value();
+__jakt_var_974; });
 if (((maybe_file).has_value())){
-JaktInternal::Optional<JaktInternal::DynamicArray<u8>> const contents = ({ Optional<JaktInternal::DynamicArray<u8>> __jakt_var_975;
-auto __jakt_var_976 = [&]() -> ErrorOr<JaktInternal::DynamicArray<u8>> { return TRY(((((maybe_file.value()))->read_all()))); }();
-if (!__jakt_var_976.is_error()) __jakt_var_975 = __jakt_var_976.release_value();
-__jakt_var_975; });
+JaktInternal::Optional<JaktInternal::DynamicArray<u8>> const contents = ({ Optional<JaktInternal::DynamicArray<u8>> __jakt_var_976;
+auto __jakt_var_977 = [&]() -> ErrorOr<JaktInternal::DynamicArray<u8>> { return TRY(((((maybe_file.value()))->read_all()))); }();
+if (!__jakt_var_977.is_error()) __jakt_var_976 = __jakt_var_977.release_value();
+__jakt_var_976; });
 if (((contents).has_value())){
 return [](ByteString const& self, ByteString rhs) -> bool {
 {

--- a/bootstrap/stage0/repl.cpp
+++ b/bootstrap/stage0/repl.cpp
@@ -157,7 +157,7 @@ return JaktInternal::ExplicitValue(TRY((repl::serialize_unary_operation(op,TRY((
 };/*case end*/
 case 8 /* JaktTuple */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.JaktTuple;JaktInternal::DynamicArray<NonnullRefPtr<typename types::CheckedExpression>> const& vals = __jakt_match_value.vals;
-return JaktInternal::ExplicitValue(({ Optional<ByteString> __jakt_var_927; {
+return JaktInternal::ExplicitValue(({ Optional<ByteString> __jakt_var_928; {
 ByteStringBuilder builder = ByteStringBuilder::create();
 ((builder).append((StringView::from_string_literal("("sv))));
 {
@@ -179,15 +179,15 @@ if (((i) != (static_cast<size_t>(0ULL)))){
 }
 
 ((builder).append((StringView::from_string_literal(")"sv))));
-__jakt_var_927 = ((builder).to_string()); goto __jakt_label_821;
+__jakt_var_928 = ((builder).to_string()); goto __jakt_label_822;
 
 }
-__jakt_label_821:; __jakt_var_927.release_value(); }));
+__jakt_label_822:; __jakt_var_928.release_value(); }));
 };/*case end*/
 case 9 /* Range */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Range;JaktInternal::Optional<NonnullRefPtr<typename types::CheckedExpression>> const& from = __jakt_match_value.from;
 JaktInternal::Optional<NonnullRefPtr<typename types::CheckedExpression>> const& to = __jakt_match_value.to;
-return JaktInternal::ExplicitValue(({ Optional<ByteString> __jakt_var_928; {
+return JaktInternal::ExplicitValue(({ Optional<ByteString> __jakt_var_929; {
 ByteString from_output = (ByteString::from_utf8_without_validation(""sv));
 if (((from).has_value())){
 (from_output = TRY((repl::serialize_ast_node((from.value())))));
@@ -196,14 +196,14 @@ ByteString to_output = (ByteString::from_utf8_without_validation(""sv));
 if (((to).has_value())){
 (to_output = TRY((repl::serialize_ast_node((to.value())))));
 }
-__jakt_var_928 = __jakt_format((StringView::from_string_literal("{}..{}"sv)),from_output,to_output); goto __jakt_label_822;
+__jakt_var_929 = __jakt_format((StringView::from_string_literal("{}..{}"sv)),from_output,to_output); goto __jakt_label_823;
 
 }
-__jakt_label_822:; __jakt_var_928.release_value(); }));
+__jakt_label_823:; __jakt_var_929.release_value(); }));
 };/*case end*/
 case 10 /* JaktArray */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.JaktArray;JaktInternal::DynamicArray<NonnullRefPtr<typename types::CheckedExpression>> const& vals = __jakt_match_value.vals;
-return JaktInternal::ExplicitValue(({ Optional<ByteString> __jakt_var_929; {
+return JaktInternal::ExplicitValue(({ Optional<ByteString> __jakt_var_930; {
 ByteStringBuilder builder = ByteStringBuilder::create();
 ((builder).append((StringView::from_string_literal("["sv))));
 {
@@ -225,14 +225,14 @@ if (((i) != (static_cast<size_t>(0ULL)))){
 }
 
 ((builder).append((StringView::from_string_literal("]"sv))));
-__jakt_var_929 = ((builder).to_string()); goto __jakt_label_823;
+__jakt_var_930 = ((builder).to_string()); goto __jakt_label_824;
 
 }
-__jakt_label_823:; __jakt_var_929.release_value(); }));
+__jakt_label_824:; __jakt_var_930.release_value(); }));
 };/*case end*/
 case 11 /* JaktSet */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.JaktSet;JaktInternal::DynamicArray<NonnullRefPtr<typename types::CheckedExpression>> const& vals = __jakt_match_value.vals;
-return JaktInternal::ExplicitValue(({ Optional<ByteString> __jakt_var_930; {
+return JaktInternal::ExplicitValue(({ Optional<ByteString> __jakt_var_931; {
 ByteStringBuilder builder = ByteStringBuilder::create();
 ((builder).append((StringView::from_string_literal("{"sv))));
 {
@@ -254,14 +254,14 @@ if (((i) != (static_cast<size_t>(0ULL)))){
 }
 
 ((builder).append((StringView::from_string_literal("}"sv))));
-__jakt_var_930 = ((builder).to_string()); goto __jakt_label_824;
+__jakt_var_931 = ((builder).to_string()); goto __jakt_label_825;
 
 }
-__jakt_label_824:; __jakt_var_930.release_value(); }));
+__jakt_label_825:; __jakt_var_931.release_value(); }));
 };/*case end*/
 case 12 /* JaktDictionary */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.JaktDictionary;JaktInternal::DynamicArray<JaktInternal::Tuple<NonnullRefPtr<typename types::CheckedExpression>,NonnullRefPtr<typename types::CheckedExpression>>> const& vals = __jakt_match_value.vals;
-return JaktInternal::ExplicitValue(({ Optional<ByteString> __jakt_var_931; {
+return JaktInternal::ExplicitValue(({ Optional<ByteString> __jakt_var_932; {
 ByteStringBuilder builder = ByteStringBuilder::create();
 ((builder).append((StringView::from_string_literal("["sv))));
 {
@@ -286,10 +286,10 @@ JaktInternal::Tuple<NonnullRefPtr<typename types::CheckedExpression>,NonnullRefP
 }
 
 ((builder).append((StringView::from_string_literal("]"sv))));
-__jakt_var_931 = ((builder).to_string()); goto __jakt_label_825;
+__jakt_var_932 = ((builder).to_string()); goto __jakt_label_826;
 
 }
-__jakt_label_825:; __jakt_var_931.release_value(); }));
+__jakt_label_826:; __jakt_var_932.release_value(); }));
 };/*case end*/
 case 13 /* IndexedExpression */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.IndexedExpression;NonnullRefPtr<typename types::CheckedExpression> const& expr = __jakt_match_value.expr;
@@ -314,7 +314,7 @@ return JaktInternal::ExplicitValue(__jakt_format((StringView::from_string_litera
 case 23 /* NamespacedVar */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.NamespacedVar;JaktInternal::DynamicArray<types::CheckedNamespace> const& namespaces = __jakt_match_value.namespaces;
 NonnullRefPtr<types::CheckedVariable> const& var = __jakt_match_value.var;
-return JaktInternal::ExplicitValue(({ Optional<ByteString> __jakt_var_932; {
+return JaktInternal::ExplicitValue(({ Optional<ByteString> __jakt_var_933; {
 ByteStringBuilder builder = ByteStringBuilder::create();
 {
 JaktInternal::ArrayIterator<types::CheckedNamespace> _magic = ((namespaces).iterator());
@@ -333,10 +333,10 @@ types::CheckedNamespace namespace_ = (_magic_value.value());
 }
 
 ((builder).append(((var)->name)));
-__jakt_var_932 = ((builder).to_string()); goto __jakt_label_826;
+__jakt_var_933 = ((builder).to_string()); goto __jakt_label_827;
 
 }
-__jakt_label_826:; __jakt_var_932.release_value(); }));
+__jakt_label_827:; __jakt_var_933.release_value(); }));
 };/*case end*/
 case 24 /* Var */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Var;NonnullRefPtr<types::CheckedVariable> const& var = __jakt_match_value.var;
@@ -355,7 +355,7 @@ return JaktInternal::ExplicitValue(__jakt_format((StringView::from_string_litera
 };/*case end*/
 case 21 /* Call */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Call;types::CheckedCall const& call = __jakt_match_value.call;
-return JaktInternal::ExplicitValue(({ Optional<ByteString> __jakt_var_933; {
+return JaktInternal::ExplicitValue(({ Optional<ByteString> __jakt_var_934; {
 ByteStringBuilder builder = ByteStringBuilder::create();
 {
 JaktInternal::ArrayIterator<types::ResolvedNamespace> _magic = ((((call).namespace_)).iterator());
@@ -399,10 +399,10 @@ if ((!(((((arg).template get<0>())).is_empty())))){
 }
 
 ((builder).append((StringView::from_string_literal(")"sv))));
-__jakt_var_933 = ((builder).to_string()); goto __jakt_label_827;
+__jakt_var_934 = ((builder).to_string()); goto __jakt_label_828;
 
 }
-__jakt_label_827:; __jakt_var_933.release_value(); }));
+__jakt_label_828:; __jakt_var_934.release_value(); }));
 };/*case end*/
 case 34 /* Garbage */: {
 return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("<Garbage>"sv)));
@@ -601,7 +601,7 @@ return (infallible_enum_cast<jakt__prelude__operators::Ordering>((JaktInternal::
 }
 (((((*this).compiler))->current_file) = ((*this).file_id));
 (((((*this).compiler))->current_file_contents) = bytes_);
-ScopeGuard __jakt_var_934([&] {
+ScopeGuard __jakt_var_935([&] {
 {
 JaktInternal::DynamicArray<error::JaktError> const arr = DynamicArray<error::JaktError>::create_with({});
 (((((*this).compiler))->errors) = arr);
@@ -609,14 +609,14 @@ JaktInternal::DynamicArray<error::JaktError> const arr = DynamicArray<error::Jak
 
 });
 {
-JaktInternal::ArrayIterator<lexer::Token> _magic = ((({ Optional<JaktInternal::DynamicArray<lexer::Token>> __jakt_var_935;
-auto __jakt_var_936 = [&]() -> ErrorOr<JaktInternal::DynamicArray<lexer::Token>> { return lexer::Lexer::lex(((*this).compiler)); }();
-if (__jakt_var_936.is_error()) {{
+JaktInternal::ArrayIterator<lexer::Token> _magic = ((({ Optional<JaktInternal::DynamicArray<lexer::Token>> __jakt_var_936;
+auto __jakt_var_937 = [&]() -> ErrorOr<JaktInternal::DynamicArray<lexer::Token>> { return lexer::Lexer::lex(((*this).compiler)); }();
+if (__jakt_var_937.is_error()) {{
 return {};
 }
-} else {__jakt_var_935 = __jakt_var_936.release_value();
+} else {__jakt_var_936 = __jakt_var_937.release_value();
 }
-__jakt_var_935.release_value(); })).iterator());
+__jakt_var_936.release_value(); })).iterator());
 for (;;){
 JaktInternal::Optional<lexer::Token> const _magic_value = ((_magic).next());
 if ((!(((_magic_value).has_value())))){
@@ -892,7 +892,7 @@ return {};
 }
 ;
 repl_backend__default::Editor editor = TRY((repl_backend__default::Editor::create((ByteString::from_utf8_without_validation("> "sv)),((syntax_highlight_handler)))));
-ScopeGuard __jakt_var_937([&] {
+ScopeGuard __jakt_var_938([&] {
 ((editor).destroy());
 });
 for (;;){
@@ -901,15 +901,15 @@ TRY((((((*this).compiler))->print_errors())));
 JaktInternal::DynamicArray<error::JaktError> const arr = DynamicArray<error::JaktError>::create_with({});
 (((((*this).compiler))->errors) = arr);
 }
-repl_backend__common::LineResult const line_result = ({ Optional<repl_backend__common::LineResult> __jakt_var_938;
-auto __jakt_var_939 = [&]() -> ErrorOr<repl_backend__common::LineResult> { return TRY((((editor).get_line(JaktInternal::OptionalNone())))); }();
-if (__jakt_var_939.is_error()) {auto error = __jakt_var_939.release_error();
+repl_backend__common::LineResult const line_result = ({ Optional<repl_backend__common::LineResult> __jakt_var_939;
+auto __jakt_var_940 = [&]() -> ErrorOr<repl_backend__common::LineResult> { return TRY((((editor).get_line(JaktInternal::OptionalNone())))); }();
+if (__jakt_var_940.is_error()) {auto error = __jakt_var_940.release_error();
 {
 return {};
 }
-} else {__jakt_var_938 = __jakt_var_939.release_value();
+} else {__jakt_var_939 = __jakt_var_940.release_value();
 }
-__jakt_var_938.release_value(); });
+__jakt_var_939.release_value(); });
 if (((line_result).__jakt_init_index() == 0 /* Line */)){
 ByteString const line = (line_result).as.Line.value;
 if (((line) == ((ByteString::from_utf8_without_validation("\n"sv))))){
@@ -920,14 +920,14 @@ break;
 }
 (((((*this).compiler))->current_file) = ((*this).file_id));
 (((((*this).compiler))->current_file_contents) = repl::REPL::line_to_bytes(line));
-JaktInternal::DynamicArray<lexer::Token> tokens = ({ Optional<JaktInternal::DynamicArray<lexer::Token>> __jakt_var_940;
-auto __jakt_var_941 = [&]() -> ErrorOr<JaktInternal::DynamicArray<lexer::Token>> { return lexer::Lexer::lex(((*this).compiler)); }();
-if (__jakt_var_941.is_error()) {{
+JaktInternal::DynamicArray<lexer::Token> tokens = ({ Optional<JaktInternal::DynamicArray<lexer::Token>> __jakt_var_941;
+auto __jakt_var_942 = [&]() -> ErrorOr<JaktInternal::DynamicArray<lexer::Token>> { return lexer::Lexer::lex(((*this).compiler)); }();
+if (__jakt_var_942.is_error()) {{
 continue;
 }
-} else {__jakt_var_940 = __jakt_var_941.release_value();
+} else {__jakt_var_941 = __jakt_var_942.release_value();
 }
-__jakt_var_940.release_value(); });
+__jakt_var_941.release_value(); });
 if (((tokens).is_empty())){
 continue;
 }
@@ -935,28 +935,28 @@ if ((!(repl::REPL::check_parens(tokens)))){
 ByteStringBuilder builder = ByteStringBuilder::create();
 ((builder).append(line));
 while ((!(repl::REPL::check_parens(tokens)))){
-repl_backend__common::LineResult const line_result = ({ Optional<repl_backend__common::LineResult> __jakt_var_942;
-auto __jakt_var_943 = [&]() -> ErrorOr<repl_backend__common::LineResult> { return TRY((((editor).get_line((ByteString::from_utf8_without_validation(".."sv)))))); }();
-if (__jakt_var_943.is_error()) {auto error = __jakt_var_943.release_error();
+repl_backend__common::LineResult const line_result = ({ Optional<repl_backend__common::LineResult> __jakt_var_943;
+auto __jakt_var_944 = [&]() -> ErrorOr<repl_backend__common::LineResult> { return TRY((((editor).get_line((ByteString::from_utf8_without_validation(".."sv)))))); }();
+if (__jakt_var_944.is_error()) {auto error = __jakt_var_944.release_error();
 {
 return {};
 }
-} else {__jakt_var_942 = __jakt_var_943.release_value();
+} else {__jakt_var_943 = __jakt_var_944.release_value();
 }
-__jakt_var_942.release_value(); });
+__jakt_var_943.release_value(); });
 if (((line_result).__jakt_init_index() == 0 /* Line */)){
 ByteString const line = (line_result).as.Line.value;
 ((builder).append(line));
 (((((*this).compiler))->current_file) = ((*this).file_id));
 (((((*this).compiler))->current_file_contents) = repl::REPL::line_to_bytes(((builder).to_string())));
-(tokens = ({ Optional<JaktInternal::DynamicArray<lexer::Token>> __jakt_var_944;
-auto __jakt_var_945 = [&]() -> ErrorOr<JaktInternal::DynamicArray<lexer::Token>> { return lexer::Lexer::lex(((*this).compiler)); }();
-if (__jakt_var_945.is_error()) {{
+(tokens = ({ Optional<JaktInternal::DynamicArray<lexer::Token>> __jakt_var_945;
+auto __jakt_var_946 = [&]() -> ErrorOr<JaktInternal::DynamicArray<lexer::Token>> { return lexer::Lexer::lex(((*this).compiler)); }();
+if (__jakt_var_946.is_error()) {{
 continue;
 }
-} else {__jakt_var_944 = __jakt_var_945.release_value();
+} else {__jakt_var_945 = __jakt_var_946.release_value();
 }
-__jakt_var_944.release_value(); }));
+__jakt_var_945.release_value(); }));
 }
 else {
 return {};
@@ -967,20 +967,20 @@ return {};
 parser::Parser parser = parser::Parser(static_cast<size_t>(0ULL),tokens,((*this).compiler),true,static_cast<size_t>(0ULL));
 lexer::Token const first_token = (((tokens).first()).value());
 if (((((((((((first_token).__jakt_init_index() == 75 /* Fn */) || ((first_token).__jakt_init_index() == 76 /* Comptime */)) || ((first_token).__jakt_init_index() == 97 /* Struct */)) || ((first_token).__jakt_init_index() == 65 /* Class */)) || ((first_token).__jakt_init_index() == 71 /* Enum */)) || ((first_token).__jakt_init_index() == 62 /* Boxed */)) || ((first_token).__jakt_init_index() == 86 /* Namespace */)) || ((first_token).__jakt_init_index() == 78 /* Import */)) || ((first_token).__jakt_init_index() == 111 /* Trait */))){
-parser::ParsedNamespace const parsed_namespace = ({ Optional<parser::ParsedNamespace> __jakt_var_946;
-auto __jakt_var_947 = [&]() -> ErrorOr<parser::ParsedNamespace> { return TRY((((parser).parse_namespace(false)))); }();
-if (__jakt_var_947.is_error()) {{
+parser::ParsedNamespace const parsed_namespace = ({ Optional<parser::ParsedNamespace> __jakt_var_947;
+auto __jakt_var_948 = [&]() -> ErrorOr<parser::ParsedNamespace> { return TRY((((parser).parse_namespace(false)))); }();
+if (__jakt_var_948.is_error()) {{
 TRY((((*this).handle_possible_error())));
 continue;
 }
-} else {__jakt_var_946 = __jakt_var_947.release_value();
+} else {__jakt_var_947 = __jakt_var_948.release_value();
 }
-__jakt_var_946.release_value(); });
+__jakt_var_947.release_value(); });
 if (TRY((((*this).handle_possible_error())))){
 continue;
 }
-auto __jakt_var_949 = [&]() -> ErrorOr<void> { return TRY((((((*this).typechecker)).typecheck_module(parsed_namespace,((*this).root_scope_id))))), ErrorOr<void>{}; }();
-if (__jakt_var_949.is_error()) {{
+auto __jakt_var_950 = [&]() -> ErrorOr<void> { return TRY((((((*this).typechecker)).typecheck_module(parsed_namespace,((*this).root_scope_id))))), ErrorOr<void>{}; }();
+if (__jakt_var_950.is_error()) {{
 TRY((((*this).handle_possible_error())));
 continue;
 }
@@ -989,40 +989,40 @@ continue;
 TRY((((*this).handle_possible_error())));
 continue;
 }
-NonnullRefPtr<typename parser::ParsedStatement> const parsed_statement = ({ Optional<NonnullRefPtr<typename parser::ParsedStatement>> __jakt_var_950;
-auto __jakt_var_951 = [&]() -> ErrorOr<NonnullRefPtr<typename parser::ParsedStatement>> { return TRY((((parser).parse_statement(true)))); }();
-if (__jakt_var_951.is_error()) {{
+NonnullRefPtr<typename parser::ParsedStatement> const parsed_statement = ({ Optional<NonnullRefPtr<typename parser::ParsedStatement>> __jakt_var_951;
+auto __jakt_var_952 = [&]() -> ErrorOr<NonnullRefPtr<typename parser::ParsedStatement>> { return TRY((((parser).parse_statement(true)))); }();
+if (__jakt_var_952.is_error()) {{
 TRY((((*this).handle_possible_error())));
 continue;
 }
-} else {__jakt_var_950 = __jakt_var_951.release_value();
+} else {__jakt_var_951 = __jakt_var_952.release_value();
 }
-__jakt_var_950.release_value(); });
+__jakt_var_951.release_value(); });
 if (TRY((((*this).handle_possible_error())))){
 continue;
 }
-NonnullRefPtr<typename types::CheckedStatement> const checked_statement = ({ Optional<NonnullRefPtr<typename types::CheckedStatement>> __jakt_var_952;
-auto __jakt_var_953 = [&]() -> ErrorOr<NonnullRefPtr<typename types::CheckedStatement>> { return TRY((((((*this).typechecker)).typecheck_statement(parsed_statement,((*this).root_scope_id),types::SafetyMode::Safe(),JaktInternal::OptionalNone())))); }();
-if (__jakt_var_953.is_error()) {{
+NonnullRefPtr<typename types::CheckedStatement> const checked_statement = ({ Optional<NonnullRefPtr<typename types::CheckedStatement>> __jakt_var_953;
+auto __jakt_var_954 = [&]() -> ErrorOr<NonnullRefPtr<typename types::CheckedStatement>> { return TRY((((((*this).typechecker)).typecheck_statement(parsed_statement,((*this).root_scope_id),types::SafetyMode::Safe(),JaktInternal::OptionalNone())))); }();
+if (__jakt_var_954.is_error()) {{
 TRY((((*this).handle_possible_error())));
 continue;
 }
-} else {__jakt_var_952 = __jakt_var_953.release_value();
+} else {__jakt_var_953 = __jakt_var_954.release_value();
 }
-__jakt_var_952.release_value(); });
+__jakt_var_953.release_value(); });
 if (TRY((((*this).handle_possible_error())))){
 continue;
 }
 NonnullRefPtr<interpreter::Interpreter> interpreter = ((((*this).typechecker)).interpreter());
-interpreter::StatementResult const result = ({ Optional<interpreter::StatementResult> __jakt_var_954;
-auto __jakt_var_955 = [&]() -> ErrorOr<interpreter::StatementResult> { return TRY((((interpreter)->execute_statement(checked_statement,((*this).root_interpreter_scope),utility::Span(((*this).file_id),static_cast<size_t>(0ULL),((line).length())))))); }();
-if (__jakt_var_955.is_error()) {{
+interpreter::StatementResult const result = ({ Optional<interpreter::StatementResult> __jakt_var_955;
+auto __jakt_var_956 = [&]() -> ErrorOr<interpreter::StatementResult> { return TRY((((interpreter)->execute_statement(checked_statement,((*this).root_interpreter_scope),utility::Span(((*this).file_id),static_cast<size_t>(0ULL),((line).length())))))); }();
+if (__jakt_var_956.is_error()) {{
 TRY((((*this).handle_possible_error())));
 continue;
 }
-} else {__jakt_var_954 = __jakt_var_955.release_value();
+} else {__jakt_var_955 = __jakt_var_956.release_value();
 }
-__jakt_var_954.release_value(); });
+__jakt_var_955.release_value(); });
 if (TRY((((*this).handle_possible_error())))){
 continue;
 }

--- a/selfhost/codegen.jakt
+++ b/selfhost/codegen.jakt
@@ -36,49 +36,44 @@ fn is_return_allowed(anon allowed_control_exits: AllowedControlExits) -> bool =>
 
 struct ControlFlowState {
     allowed_exits: AllowedControlExits
-    /// Whether `break` and `continue` should use `return ExplicitValueOrControlFlow` instead of
-    /// C++'s `break`/`continue`.
-    passes_through_match: bool
     passes_through_try: bool
-    match_nest_level: usize
+    // whether the current scope is a match IIFE
+    directly_inside_match: bool = false
+    // whether any outer scope is a match IIFE
+    indirectly_inside_match: bool = false
 
     fn no_control_flow() -> ControlFlowState {
         return ControlFlowState(
             allowed_exits: AllowedControlExits::Nothing
-            passes_through_match: false
             passes_through_try: false
-            match_nest_level: 0
+            directly_inside_match: false
+            indirectly_inside_match: false
         )
     }
     fn enter_function(this) -> ControlFlowState {
         return ControlFlowState(
             allowed_exits: AllowedControlExits::JustReturn
-            passes_through_match: false
             passes_through_try: false
-            match_nest_level: .match_nest_level
+            indirectly_inside_match: false
+            directly_inside_match: false
         )
     }
     fn enter_loop(this) -> ControlFlowState {
         return ControlFlowState(
             allowed_exits: AllowedControlExits::AtLoop
-            passes_through_match: false
             passes_through_try: .passes_through_try
-            match_nest_level: 0
+            indirectly_inside_match: .indirectly_inside_match
+            directly_inside_match: false
         )
     }
     fn enter_match(this) -> ControlFlowState {
-        mut level = .match_nest_level
-        if .passes_through_match {
-            level = .match_nest_level + 1
-        }
         return ControlFlowState(
             allowed_exits: .allowed_exits.allow_return()
-            passes_through_match: true
             passes_through_try: .passes_through_try
-            match_nest_level: level
+            directly_inside_match: true
+            indirectly_inside_match: true
         )
     }
-    fn is_match_nested(this) -> bool => .match_nest_level != 0
 
     // Instead of trying to use `release_return()` which returns `void`, we'll
     // directly construct a `ExplicitValueOrControlFlow<MatchResult, void>` so
@@ -97,52 +92,47 @@ struct ControlFlowState {
         }
     }
 
+    // apply control flow macro to a match, from outside its scope
     fn apply_control_flow_macro(this, anon x: String, func_return_type: TypeId, func_can_throw: bool, cpp_match_result_type: String) throws -> String {
-        if are_loop_exits_allowed(.allowed_exits) {
-            if .is_match_nested() {
+        let handle_loop_controls = match are_loop_exits_allowed(.allowed_exits) {
+            // Not inside a loop, so the inner match better not yield those
+            // values, since there's no one that can catch them.
+            // In practice it's impossible because break/continue is guaranteed
+            // by the typechecker to only appear within loop contexts.
+            false => ""
+            // there's a loop somewhere up there.
+            true => {
+                let (break_stmt, continue_stmt) = match .directly_inside_match {
+                    // This match has to forward the loop break/continues
+                    true => ("return JaktInternal::LoopBreak {}", "return JaktInternal::LoopContinue {}")
+                    // This is the loop that the inner match wants to modify the control flow of.
+                    false => ("break", "continue")
 
-                return format(
-                    "({{
-    auto&& _jakt_value = {};
-    if (_jakt_value.is_return())
-        return {};
-    if (_jakt_value.is_loop_break())
-        return JaktInternal::LoopBreak {{}};
+                }
+                yield format("if (_jakt_value.is_loop_break())
+        {};
     if (_jakt_value.is_loop_continue())
-        return JaktInternal::LoopContinue {{}};
-    _jakt_value.release_value();
-}})",
-                    x,
-                    nested_release_return_expr(func_return_type, func_can_throw, cpp_match_result_type)
-                )
+        {};
+    ", break_stmt, continue_stmt)
             }
-            return format(
-                "({{
-    auto&& _jakt_value = {};
-    if (_jakt_value.is_return())
-        return _jakt_value.release_return();
-    if (_jakt_value.is_loop_break())
-        break;
-    if (_jakt_value.is_loop_continue())
-        continue;
-    _jakt_value.release_value();
-}})",
-                x
-            )
         }
-        return format(
-            "({{
-    auto&& _jakt_value = {};
+
+        // Make sure we don't return 'void' when forwarding a return inside a match IIFE.
+        let forward_return_expr = match .indirectly_inside_match {
+            true => nested_release_return_expr(func_return_type, func_can_throw, cpp_match_result_type)
+            false => "_jakt_value.release_return()"
+        }
+
+        return format("({{
+    auto&& _jakt_value = {0};
     if (_jakt_value.is_return())
-        return {};
-    _jakt_value.release_value();
+        return {1};
+    {2}_jakt_value.release_value();
 }})",
-            x,
-            match .is_match_nested() {
-                false => "_jakt_value.release_return()",
-                true => nested_release_return_expr(func_return_type, func_can_throw, cpp_match_result_type),
-            }
+            x, forward_return_expr, handle_loop_controls
         )
+
+
     }
 }
 
@@ -291,12 +281,7 @@ struct CodeGenerator {
         mut generator = CodeGenerator(
             compiler
             program
-            control_flow_state: ControlFlowState(
-                allowed_exits: AllowedControlExits::Nothing
-                passes_through_match: false
-                passes_through_try: false
-                match_nest_level: 0
-            )
+            control_flow_state: ControlFlowState::no_control_flow()
             entered_yieldable_blocks: []
             deferred_output: ""
             current_function: None
@@ -3013,7 +2998,8 @@ struct CodeGenerator {
                 output += try_var
                 output += " = [&]() -> ErrorOr<void> {"
                 let last_control_flow = .control_flow_state
-                .control_flow_state.passes_through_match = false
+                .control_flow_state.directly_inside_match = false
+                .control_flow_state.indirectly_inside_match = false
                 .control_flow_state.passes_through_try = true
                 output += .codegen_statement(statement: stmt)
                 output += ";"
@@ -3043,7 +3029,8 @@ struct CodeGenerator {
                 let try_var = .fresh_var()
 
                 let last_control_flow = .control_flow_state
-                .control_flow_state.passes_through_match = false
+                .control_flow_state.directly_inside_match = false
+                .control_flow_state.indirectly_inside_match = false
                 .control_flow_state.passes_through_try = true
                 defer {
                     .control_flow_state = last_control_flow
@@ -3128,6 +3115,7 @@ struct CodeGenerator {
         .control_flow_state = .control_flow_state.enter_match()
         mut output = ""
 
+        let cpp_match_result_type = .codegen_type(type_id)
         let expr_type = .program.get_type(expr.type())
         if expr_type is Enum(enum_id) {
             output += .codegen_enum_match(
@@ -3135,6 +3123,7 @@ struct CodeGenerator {
                 expr
                 match_cases
                 type_id
+                cpp_match_result_type
                 all_variants_constant
             )
         } else {
@@ -3142,14 +3131,20 @@ struct CodeGenerator {
                 expr
                 cases: match_cases
                 return_type_id: type_id
+                cpp_match_result_type
                 all_variants_constant
             )
         }
         .control_flow_state = last_control_flow
-        return output
+        return .control_flow_state.apply_control_flow_macro(
+            output,
+            func_return_type: .current_function!.return_type_id,
+            func_can_throw: .current_function!.can_throw,
+            cpp_match_result_type
+        )
     }
 
-    fn codegen_generic_match(mut this, expr: CheckedExpression, cases: [CheckedMatchCase], return_type_id: TypeId, all_variants_constant: bool) throws -> String {
+    fn codegen_generic_match(mut this, expr: CheckedExpression, cases: [CheckedMatchCase], return_type_id: TypeId, cpp_match_result_type: String, all_variants_constant: bool) throws -> String {
         mut output = ""
 
         mut is_generic_enum: bool = false
@@ -3161,7 +3156,6 @@ struct CodeGenerator {
         }
         let match_values_all_constant = all_variants_constant and not is_generic_enum
 
-        let cpp_match_result_type = .codegen_type(return_type_id)
 
         // TODO: Use switch statement if all values are constant
         output += format(
@@ -3308,21 +3302,14 @@ struct CodeGenerator {
 
         output += "}())"
 
-        return .control_flow_state.apply_control_flow_macro(
-            output,
-            func_return_type: .current_function!.return_type_id,
-            func_can_throw: .current_function!.can_throw,
-            cpp_match_result_type
-        )
+        return output
     }
 
-    fn codegen_enum_match(mut this, enum_: CheckedEnum, expr: CheckedExpression, match_cases: [CheckedMatchCase], type_id: TypeId, all_variants_constant: bool) throws -> String {
+    fn codegen_enum_match(mut this, enum_: CheckedEnum, expr: CheckedExpression, match_cases: [CheckedMatchCase], type_id: TypeId, cpp_match_result_type: String, all_variants_constant: bool) throws -> String {
         mut output = ""
 
         let subject = .codegen_expression(expr)
         let needs_deref = enum_.is_boxed and subject != "*this"
-
-        let cpp_match_result_type = .codegen_type(type_id)
 
         if enum_.underlying_type_id == void_type_id() {
             output += "([&]() -> JaktInternal::ExplicitValueOrControlFlow<"
@@ -3457,12 +3444,7 @@ struct CodeGenerator {
             output += "}()\n)"
         }
 
-        return .control_flow_state.apply_control_flow_macro(
-            output,
-            func_return_type: .current_function!.return_type_id,
-            func_can_throw: .current_function!.can_throw,
-            cpp_match_result_type
-        )
+        return output
     }
 
     fn codegen_match_body(mut this, body: CheckedMatchBody, return_type_id: TypeId) throws -> String {
@@ -4179,11 +4161,11 @@ struct CodeGenerator {
 
         output += match statement {
             Throw(expr) => "return " + .codegen_expression(expr) + ";"
-            Continue => match .control_flow_state.passes_through_match {
+            Continue => match .control_flow_state.directly_inside_match {
                 true => "return JaktInternal::LoopContinue{};"
                 false => "continue;"
             }
-            Break => match .control_flow_state.passes_through_match {
+            Break => match .control_flow_state.directly_inside_match {
                 true => "return JaktInternal::LoopBreak{};"
                 false => "break;"
             }
@@ -4196,7 +4178,8 @@ struct CodeGenerator {
                 let last_control_flow = .control_flow_state
                 let old_inside_defer = .inside_defer
 
-                .control_flow_state.passes_through_match = false
+                .control_flow_state.directly_inside_match = false
+                .control_flow_state.indirectly_inside_match = false
                 .inside_defer = true
 
                 output += .codegen_statement(statement)
@@ -4222,7 +4205,7 @@ struct CodeGenerator {
                     false => "return " + .codegen_expression(val!) + ";"
                 }
                 false => {
-                    yield match .current_function!.can_throw {
+                    yield match .current_function!.can_throw or .control_flow_state.indirectly_inside_match {
                         true => "return {};"
                         false => "return;"
                     }

--- a/tests/codegen/nested_loop_in_match.jakt
+++ b/tests/codegen/nested_loop_in_match.jakt
@@ -1,0 +1,27 @@
+/// Expect:
+/// - output: "no boog!\n"
+
+// Adapted from #1520.
+
+fn boog() {
+    match 1 {
+        else => {
+            loop {
+                // This match should yield nothing,
+                // and should not interfere with the outer match.
+                match 1 {
+                    else => {
+                        println("no boog!")
+                    }
+                }
+                // This return should not be naked in the C++,
+                // since we're inside a match.
+                return
+            }
+        }
+    }
+}
+
+fn main() {
+    boog()
+}


### PR DESCRIPTION
ControlFlowState was handling control flow forwarding in an error-prone and unintuitive manner. It also was being used to apply control flow forwarding from the scope of the match IIFE that is being called, instead of the state of the outer scope, which is where the calling and forwarding takes place.

The only tracking that is needed to apply control flow forwarding is the following two things about the parent scope:
    1. Is the current scope the outer loop where continue/break is handled or should it forward the special LoopContinue/LoopBreak signaling types?
    2. Is the current scope the function scope to return from or should it forward the special signaling return from `ExplicitValueOrControlFlow`?

Fixes #1520.