### PR TITLE
Some things to make the compiler faster when built in debug

### DIFF
--- a/bootstrap/stage0/build.cpp
+++ b/bootstrap/stage0/build.cpp
@@ -201,7 +201,7 @@ return Error::from_errno(static_cast<i32>(1));
 }
 }
 
-ByteString const built_object = ((((binary_dir).join(((TRY((((jakt__path::Path::from_string(file_name)).replace_extension((ByteString::must_from_utf8("o"sv))))))).to_string())))).to_string());
+ByteString const built_object = ((((binary_dir).join(((TRY((((jakt__path::Path::from_string(file_name)).replace_extension((ByteString::from_utf8_without_validation("o"sv))))))).to_string())))).to_string());
 ((((*this).linked_files)).push(built_object));
 JaktInternal::DynamicArray<ByteString> const args = TRY((compiler_invocation(((((binary_dir).join(file_name))).to_string()),built_object)));
 size_t const id = TRY((((((*this).pool)).run(args))));
@@ -246,10 +246,10 @@ JaktInternal::DynamicArray<ByteString> args = DynamicArray<ByteString>::create_w
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<ByteString,ErrorOr<void>>{
 auto __jakt_enum_value = (((extra_arguments).size()));
 if (__jakt_enum_value == static_cast<size_t>(0ULL)) {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("cr"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("cr"sv)));
 }
 else {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("crT"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("crT"sv)));
 }
 }());
     if (_jakt_value.is_return())
@@ -284,7 +284,7 @@ return {};
 
 ErrorOr<void> build::Builder::link_into_executable(ByteString const cxx_compiler_path,ByteString const output_filename,JaktInternal::DynamicArray<ByteString> const extra_arguments) {
 {
-JaktInternal::DynamicArray<ByteString> args = DynamicArray<ByteString>::create_with({cxx_compiler_path, (ByteString::must_from_utf8("-o"sv)), output_filename});
+JaktInternal::DynamicArray<ByteString> args = DynamicArray<ByteString>::create_with({cxx_compiler_path, (ByteString::from_utf8_without_validation("-o"sv)), output_filename});
 {
 JaktInternal::ArrayIterator<ByteString> _magic = ((((*this).linked_files)).iterator());
 for (;;){

--- a/bootstrap/stage0/codegen.cpp
+++ b/bootstrap/stage0/codegen.cpp
@@ -66,7 +66,7 @@ if ((returns_void && (!(func_can_throw)))){
 return __jakt_format((StringView::from_string_literal("JaktInternal::ExplicitValueOrControlFlow<{}, void>()"sv)),cpp_match_result_type);
 }
 else {
-return (ByteString::must_from_utf8("_jakt_value.release_return()"sv));
+return (ByteString::from_utf8_without_validation("_jakt_value.release_return()"sv));
 }
 
 }
@@ -84,7 +84,7 @@ return __jakt_format((StringView::from_string_literal("({{\n    auto&& _jakt_val
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<ByteString,ErrorOr<ByteString>>{
 auto __jakt_enum_value = (((*this).is_match_nested()));
 if (__jakt_enum_value == false) {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("_jakt_value.release_return()"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("_jakt_value.release_return()"sv)));
 }
 else if (__jakt_enum_value == true) {
 return JaktInternal::ExplicitValue(codegen::ControlFlowState::nested_release_return_expr(func_return_type,func_can_throw,cpp_match_result_type));
@@ -127,7 +127,7 @@ TRY((((*this).gather_line_spans())));
 }
 size_t const file_idx = ((((span).file_id)).id);
 if ((!(((((*this).line_spans)).contains(file_idx))))){
-return (ByteString::must_from_utf8(""sv));
+return (ByteString::from_utf8_without_validation(""sv));
 }
 size_t line_index = static_cast<size_t>(0ULL);
 while ([](size_t const& self, size_t rhs) -> bool {
@@ -167,7 +167,7 @@ return __jakt_format((StringView::from_string_literal("{} \"{}\""sv)),JaktIntern
 }
 ((line_index) += (static_cast<size_t>(1ULL)));
 }
-utility::panic((ByteString::must_from_utf8("Reached end of file and could not find index"sv)));
+utility::panic((ByteString::from_utf8_without_validation("Reached end of file and could not find index"sv)));
 }
 }
 
@@ -182,7 +182,7 @@ break;
 }
 JaktInternal::Tuple<ByteString,utility::FileId> file = (_magic_value.value());
 {
-if (((((file).template get<0>())) == ((ByteString::must_from_utf8("__prelude__"sv))))){
+if (((((file).template get<0>())) == ((ByteString::from_utf8_without_validation("__prelude__"sv))))){
 continue;
 }
 TRY((((((*this).compiler))->set_current_file(((file).template get<1>())))));
@@ -265,9 +265,9 @@ builder.append(")"sv);return builder.to_string(); }
 ByteString codegen::CodeGenerator::current_error_handler() const {
 {
 if ((((*this).inside_defer) || ((((((*this).current_function)).has_value()) && (((((((*this).current_function).value()))->return_type_id)).equals(types::never_type_id()))) && (!(((((*this).control_flow_state)).passes_through_try)))))){
-return (ByteString::must_from_utf8("MUST"sv));
+return (ByteString::from_utf8_without_validation("MUST"sv));
 }
-return (ByteString::must_from_utf8("TRY"sv));
+return (ByteString::from_utf8_without_validation("TRY"sv));
 }
 }
 
@@ -364,51 +364,51 @@ if (((module_in_degrees) == (static_cast<i64>(1LL)))){
 if (((((sorted_modules).size())) == (((((((*this).program))->modules)).size())))){
 return sorted_modules;
 }
-utility::panic((ByteString::must_from_utf8("Cyclic module imports"sv)));
+utility::panic((ByteString::from_utf8_without_validation("Cyclic module imports"sv)));
 }
 }
 
 ErrorOr<JaktInternal::Dictionary<ByteString,JaktInternal::Tuple<ByteString,ByteString>>> codegen::CodeGenerator::generate(NonnullRefPtr<compiler::Compiler> const compiler,NonnullRefPtr<types::CheckedProgram> const program,bool const debug_info) {
 {
-codegen::CodeGenerator generator = codegen::CodeGenerator(compiler,program,codegen::ControlFlowState(codegen::AllowedControlExits::Nothing(),false,false,static_cast<size_t>(0ULL)),DynamicArray<JaktInternal::Tuple<ByteString,ByteString>>::create_with({}),(ByteString::must_from_utf8(""sv)),JaktInternal::OptionalNone(),false,codegen::CodegenDebugInfo(compiler,Dictionary<size_t, JaktInternal::DynamicArray<codegen::LineSpan>>::create_with_entries({}),debug_info),DynamicArray<ByteString>::create_with({}),static_cast<size_t>(0ULL),static_cast<size_t>(0ULL),JaktInternal::OptionalNone(),JaktInternal::OptionalNone());
+codegen::CodeGenerator generator = codegen::CodeGenerator(compiler,program,codegen::ControlFlowState(codegen::AllowedControlExits::Nothing(),false,false,static_cast<size_t>(0ULL)),DynamicArray<JaktInternal::Tuple<ByteString,ByteString>>::create_with({}),(ByteString::from_utf8_without_validation(""sv)),JaktInternal::OptionalNone(),false,codegen::CodegenDebugInfo(compiler,Dictionary<size_t, JaktInternal::DynamicArray<codegen::LineSpan>>::create_with_entries({}),debug_info),DynamicArray<ByteString>::create_with({}),static_cast<size_t>(0ULL),static_cast<size_t>(0ULL),JaktInternal::OptionalNone(),JaktInternal::OptionalNone());
 JaktInternal::Dictionary<ByteString,JaktInternal::Tuple<ByteString,ByteString>> result = Dictionary<ByteString, JaktInternal::Tuple<ByteString,ByteString>>::create_with_entries({});
-ByteString output = (ByteString::must_from_utf8(""sv));
+ByteString output = (ByteString::from_utf8_without_validation(""sv));
 [](ByteString& self, ByteString rhs) -> void {
 {
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8("#pragma once\n"sv)));
+(output,(ByteString::from_utf8_without_validation("#pragma once\n"sv)));
 [](ByteString& self, ByteString rhs) -> void {
 {
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8("#include <lib.h>\n"sv)));
+(output,(ByteString::from_utf8_without_validation("#include <lib.h>\n"sv)));
 [](ByteString& self, ByteString rhs) -> void {
 {
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8("#ifdef _WIN32\n"sv)));
+(output,(ByteString::from_utf8_without_validation("#ifdef _WIN32\n"sv)));
 [](ByteString& self, ByteString rhs) -> void {
 {
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8("extern \"C\" __cdecl int SetConsoleOutputCP(unsigned int code_page);\n"sv)));
+(output,(ByteString::from_utf8_without_validation("extern \"C\" __cdecl int SetConsoleOutputCP(unsigned int code_page);\n"sv)));
 [](ByteString& self, ByteString rhs) -> void {
 {
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8("const unsigned int CP_UTF8 = 65001;\n"sv)));
+(output,(ByteString::from_utf8_without_validation("const unsigned int CP_UTF8 = 65001;\n"sv)));
 [](ByteString& self, ByteString rhs) -> void {
 {
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8("#endif\n"sv)));
+(output,(ByteString::from_utf8_without_validation("#endif\n"sv)));
 JaktInternal::DynamicArray<ids::ModuleId> const sorted_modules = ((generator).topologically_sort_modules());
 JaktInternal::Dictionary<ByteString,JaktInternal::Tuple<ByteString,ByteString>> imported_paths = Dictionary<ByteString, JaktInternal::Tuple<ByteString,ByteString>>::create_with_entries({});
 {
@@ -443,8 +443,8 @@ ids::ScopeId child = (_magic_value.value());
 
 if (((((scope)->import_path_if_extern)).has_value())){
 ByteString const path = (((scope)->import_path_if_extern).value());
-ByteString before = (ByteString::must_from_utf8(""sv));
-ByteString after = (ByteString::must_from_utf8(""sv));
+ByteString before = (ByteString::from_utf8_without_validation(""sv));
+ByteString after = (ByteString::from_utf8_without_validation(""sv));
 {
 JaktInternal::ArrayIterator<parser::IncludeAction> _magic = ((((scope)->before_extern_include)).iterator());
 for (;;){
@@ -479,7 +479,7 @@ ByteString const& value = __jakt_match_value.value;
 (self = ((self) + (rhs)));
 }
 }
-(before,(ByteString::must_from_utf8("#endif\n"sv)));
+(before,(ByteString::from_utf8_without_validation("#endif\n"sv)));
 [](ByteString& self, ByteString rhs) -> void {
 {
 (self = ((self) + (rhs)));
@@ -509,7 +509,7 @@ auto&& __jakt_match_value = __jakt_match_variant.as.Undefine;ByteString const& n
 (self = ((self) + (rhs)));
 }
 }
-(before,(ByteString::must_from_utf8("#endif\n"sv)));
+(before,(ByteString::from_utf8_without_validation("#endif\n"sv)));
 }
 return JaktInternal::ExplicitValue<void>();
 };/*case end*/
@@ -563,7 +563,7 @@ ByteString const& value = __jakt_match_value.value;
 (self = ((self) + (rhs)));
 }
 }
-(after,(ByteString::must_from_utf8("#endif\n"sv)));
+(after,(ByteString::from_utf8_without_validation("#endif\n"sv)));
 [](ByteString& self, ByteString rhs) -> void {
 {
 (self = ((self) + (rhs)));
@@ -593,7 +593,7 @@ auto&& __jakt_match_value = __jakt_match_variant.as.Undefine;ByteString const& n
 (self = ((self) + (rhs)));
 }
 }
-(after,(ByteString::must_from_utf8("#endif\n"sv)));
+(after,(ByteString::from_utf8_without_validation("#endif\n"sv)));
 }
 return JaktInternal::ExplicitValue<void>();
 };/*case end*/
@@ -662,7 +662,7 @@ JaktInternal::Tuple<ByteString,ByteString> const actions = ((jakt__path__actions
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8("namespace Jakt {\n"sv)));
+(output,(ByteString::from_utf8_without_validation("namespace Jakt {\n"sv)));
 {
 JaktInternal::Range<size_t> _magic = (JaktInternal::Range<size_t>{static_cast<size_t>(((sorted_modules).size())),static_cast<size_t>(static_cast<size_t>(0ULL))});
 for (;;){
@@ -696,8 +696,8 @@ NonnullRefPtr<types::Scope> const scope = ((((generator).program))->get_scope(sc
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8("} // namespace Jakt\n"sv)));
-((result).set((ByteString::must_from_utf8("__unified_forward.h"sv)),(Tuple{output, (((((compiler)->current_file_path()).value())).to_string())})));
+(output,(ByteString::from_utf8_without_validation("} // namespace Jakt\n"sv)));
+((result).set((ByteString::from_utf8_without_validation("__unified_forward.h"sv)),(Tuple{output, (((((compiler)->current_file_path()).value())).to_string())})));
 {
 JaktInternal::ArrayIterator<bool> _magic = ((DynamicArray<bool>::create_with({true, false})).iterator());
 for (;;){
@@ -725,13 +725,13 @@ NonnullRefPtr<types::Module> const module = ((((((generator).program))->modules)
 ByteString const header_name = __jakt_format((StringView::from_string_literal("{}.h"sv)),((module)->name));
 ByteString const impl_name = __jakt_format((StringView::from_string_literal("{}.cpp"sv)),((module)->name));
 if (as_forward){
-(output = (ByteString::must_from_utf8("#pragma once\n"sv)));
+(output = (ByteString::from_utf8_without_validation("#pragma once\n"sv)));
 [](ByteString& self, ByteString rhs) -> void {
 {
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8("#include \"__unified_forward.h\"\n"sv)));
+(output,(ByteString::from_utf8_without_validation("#include \"__unified_forward.h\"\n"sv)));
 }
 else {
 (output = __jakt_format((StringView::from_string_literal("#include \"{}\"\n"sv)),header_name));
@@ -794,7 +794,7 @@ ByteString const& value = __jakt_match_value.value;
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8("#endif\n"sv)));
+(output,(ByteString::from_utf8_without_validation("#endif\n"sv)));
 [](ByteString& self, ByteString rhs) -> void {
 {
 (self = ((self) + (rhs)));
@@ -824,7 +824,7 @@ auto&& __jakt_match_value = __jakt_match_variant.as.Undefine;ByteString const& n
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8("#endif\n"sv)));
+(output,(ByteString::from_utf8_without_validation("#endif\n"sv)));
 }
 return JaktInternal::ExplicitValue<void>();
 };/*case end*/
@@ -884,7 +884,7 @@ ByteString const& value = __jakt_match_value.value;
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8("#endif\n"sv)));
+(output,(ByteString::from_utf8_without_validation("#endif\n"sv)));
 [](ByteString& self, ByteString rhs) -> void {
 {
 (self = ((self) + (rhs)));
@@ -914,7 +914,7 @@ auto&& __jakt_match_value = __jakt_match_variant.as.Undefine;ByteString const& n
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8("#endif\n"sv)));
+(output,(ByteString::from_utf8_without_validation("#endif\n"sv)));
 }
 return JaktInternal::ExplicitValue<void>();
 };/*case end*/
@@ -940,7 +940,7 @@ if (has_name){
 (self = ((self) + (rhs)));
 }
 }
-(output,(((((ByteString::must_from_utf8(" } // namespace "sv))) + ((((scope)->namespace_name).value())))) + ((ByteString::must_from_utf8("\n"sv)))));
+(output,(((((ByteString::from_utf8_without_validation(" } // namespace "sv))) + ((((scope)->namespace_name).value())))) + ((ByteString::from_utf8_without_validation("\n"sv)))));
 }
 }
 }
@@ -975,7 +975,7 @@ NonnullRefPtr<types::Module> const module = ((((((generator).program))->modules)
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8("namespace Jakt {\n"sv)));
+(output,(ByteString::from_utf8_without_validation("namespace Jakt {\n"sv)));
 if ((!(((module)->is_root)))){
 ((((generator).namespace_stack)).push(((module)->name)));
 }
@@ -994,13 +994,13 @@ JaktInternal::Optional<ByteString> const dummy = ((((generator).namespace_stack)
 }
 }
 (output,((generator).deferred_output));
-(((generator).deferred_output) = (ByteString::must_from_utf8(""sv)));
+(((generator).deferred_output) = (ByteString::from_utf8_without_validation(""sv)));
 [](ByteString& self, ByteString rhs) -> void {
 {
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8("} // namespace Jakt\n"sv)));
+(output,(ByteString::from_utf8_without_validation("} // namespace Jakt\n"sv)));
 if (as_forward){
 ((result).set(header_name,(Tuple{output, ((module)->resolved_import_path)})));
 }
@@ -1032,7 +1032,7 @@ NonnullRefPtr<types::Module> const module = ((((((generator).program))->modules)
 ByteString const header_name = __jakt_format((StringView::from_string_literal("{}.h"sv)),((module)->name));
 ByteString const impl_name = __jakt_format((StringView::from_string_literal("{}_specializations.cpp"sv)),((module)->name));
 if (((i) == (static_cast<size_t>(0ULL)))){
-(output = (ByteString::must_from_utf8(""sv)));
+(output = (ByteString::from_utf8_without_validation(""sv)));
 }
 else {
 (output = __jakt_format((StringView::from_string_literal("#include \"{}\"\n"sv)),header_name));
@@ -1069,7 +1069,7 @@ NonnullRefPtr<types::Scope> const scope = ((((generator).program))->get_scope(sc
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8("namespace Jakt {\n"sv)));
+(output,(ByteString::from_utf8_without_validation("namespace Jakt {\n"sv)));
 if ((!(((module)->is_root)))){
 ((((generator).namespace_stack)).push(((module)->name)));
 }
@@ -1088,13 +1088,13 @@ JaktInternal::Optional<ByteString> const dummy = ((((generator).namespace_stack)
 }
 }
 (output,((generator).deferred_output));
-(((generator).deferred_output) = (ByteString::must_from_utf8(""sv)));
+(((generator).deferred_output) = (ByteString::from_utf8_without_validation(""sv)));
 [](ByteString& self, ByteString rhs) -> void {
 {
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8("} // namespace Jakt\n"sv)));
+(output,(ByteString::from_utf8_without_validation("} // namespace Jakt\n"sv)));
 ((result).set(impl_name,(Tuple{output, ((module)->resolved_import_path)})));
 }
 
@@ -1367,7 +1367,7 @@ if ((((((struct_).definition_linkage)).__jakt_init_index() == 1 /* External */) 
 return (!(((self) == (rhs))));
 }
 }
-(((struct_).name),(ByteString::must_from_utf8("Optional"sv))))){
+(((struct_).name),(ByteString::from_utf8_without_validation("Optional"sv))))){
 return dependencies;
 }
 if ((((((struct_).record_type)).__jakt_init_index() == 1 /* Class */) && (!(top_level)))){
@@ -1538,10 +1538,10 @@ return JaktInternal::ExplicitValue(false);
 }))))){
 return JaktInternal::OptionalNone();
 }
-ByteString output = (ByteString::must_from_utf8(""sv));
+ByteString output = (ByteString::from_utf8_without_validation(""sv));
 bool const is_full_respecialization = ((*this).is_full_respecialization(((((((function)->generics))->specializations))[(((function)->specialization_index).value())])));
 if ((define_pass && is_full_respecialization)){
-(output = (ByteString::must_from_utf8("template<"sv)));
+(output = (ByteString::from_utf8_without_validation("template<"sv)));
 bool first = true;
 {
 JaktInternal::ArrayIterator<ids::TypeId> _magic = ((((((((function)->generics))->specializations))[(((function)->specialization_index).value())])).iterator());
@@ -1563,7 +1563,7 @@ else {
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8(", "sv)));
+(output,(ByteString::from_utf8_without_validation(", "sv)));
 }
 
 [](ByteString& self, ByteString rhs) -> void {
@@ -1583,7 +1583,7 @@ else {
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8(">\n"sv)));
+(output,(ByteString::from_utf8_without_validation(">\n"sv)));
 [](ByteString& self, ByteString rhs) -> void {
 {
 (self = ((self) + (rhs)));
@@ -1619,14 +1619,14 @@ ids::TypeId arg = (_magic_value.value());
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8("\ntemplate<> "sv)));
+(output,(ByteString::from_utf8_without_validation("\ntemplate<> "sv)));
 if (((((function)->return_type_id)).equals(types::never_type_id()))){
 [](ByteString& self, ByteString rhs) -> void {
 {
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8("[[noreturn]] "sv)));
+(output,(ByteString::from_utf8_without_validation("[[noreturn]] "sv)));
 }
 [](ByteString& self, ByteString rhs) -> void {
 {
@@ -1653,7 +1653,7 @@ VERIFY_NOT_REACHED();
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8(" "sv)));
+(output,(ByteString::from_utf8_without_validation(" "sv)));
 ByteString const qualifier = ({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<ByteString,ErrorOr<JaktInternal::Optional<ByteString>>>{
 auto __jakt_enum_value = (((containing_struct).has_value()));
@@ -1661,7 +1661,7 @@ if (__jakt_enum_value == true) {
 return JaktInternal::ExplicitValue(TRY((((*this).codegen_type_possibly_as_namespace((containing_struct.value()),true)))));
 }
 else if (__jakt_enum_value == false) {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8(""sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation(""sv)));
 }
 VERIFY_NOT_REACHED();
 }());
@@ -1681,7 +1681,7 @@ if ((!(((qualifier).is_empty())))){
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8("::"sv)));
+(output,(ByteString::from_utf8_without_validation("::"sv)));
 }
 [](ByteString& self, ByteString rhs) -> void {
 {
@@ -1694,7 +1694,7 @@ if ((!(((qualifier).is_empty())))){
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8("<"sv)));
+(output,(ByteString::from_utf8_without_validation("<"sv)));
 bool first = true;
 {
 JaktInternal::ArrayIterator<ids::TypeId> _magic = ((((((((function)->generics))->specializations))[(((function)->specialization_index).value())])).iterator());
@@ -1714,7 +1714,7 @@ else {
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8(", "sv)));
+(output,(ByteString::from_utf8_without_validation(", "sv)));
 }
 
 [](ByteString& self, ByteString rhs) -> void {
@@ -1733,7 +1733,7 @@ else {
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8(">("sv)));
+(output,(ByteString::from_utf8_without_validation(">("sv)));
 (first = true);
 {
 JaktInternal::ArrayIterator<types::CheckedParameter> _magic = ((((function)->params)).iterator());
@@ -1745,7 +1745,7 @@ break;
 types::CheckedParameter param = (_magic_value.value());
 {
 NonnullRefPtr<types::CheckedVariable> const variable = ((param).variable);
-if (((((variable)->name)) == ((ByteString::must_from_utf8("this"sv))))){
+if (((((variable)->name)) == ((ByteString::from_utf8_without_validation("this"sv))))){
 continue;
 }
 if ((!(first))){
@@ -1754,7 +1754,7 @@ if ((!(first))){
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8(","sv)));
+(output,(ByteString::from_utf8_without_validation(","sv)));
 }
 else {
 (first = false);
@@ -1772,14 +1772,14 @@ NonnullRefPtr<typename types::Type> const variable_type = ((((*this).program))->
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8(" "sv)));
+(output,(ByteString::from_utf8_without_validation(" "sv)));
 if (((!(((variable)->is_mutable))) && (!((((variable_type)->__jakt_init_index() == 28 /* Reference */) || ((variable_type)->__jakt_init_index() == 29 /* MutableReference */)))))){
 [](ByteString& self, ByteString rhs) -> void {
 {
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8("const "sv)));
+(output,(ByteString::from_utf8_without_validation("const "sv)));
 }
 [](ByteString& self, ByteString rhs) -> void {
 {
@@ -1797,21 +1797,21 @@ if (((!(((variable)->is_mutable))) && (!((((variable_type)->__jakt_init_index() 
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8(")"sv)));
+(output,(ByteString::from_utf8_without_validation(")"sv)));
 if (((!(((function)->is_static()))) && (!(((function)->is_mutating()))))){
 [](ByteString& self, ByteString rhs) -> void {
 {
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8(" const"sv)));
+(output,(ByteString::from_utf8_without_validation(" const"sv)));
 }
 [](ByteString& self, ByteString rhs) -> void {
 {
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8(";\n"sv)));
+(output,(ByteString::from_utf8_without_validation(";\n"sv)));
 }
 else {
 (output = __jakt_format((StringView::from_string_literal("\n/* specialisation {} of function {} omitted, not fully specialized: {} */\n"sv)),(((function)->specialization_index).value()),((function)->name),((((((function)->generics))->specializations))[(((function)->specialization_index).value())])));
@@ -1824,17 +1824,17 @@ return output;
 ErrorOr<ByteString> codegen::CodeGenerator::codegen_namespace_specializations(NonnullRefPtr<types::Scope> const scope,NonnullRefPtr<types::Module> const current_module) {
 {
 if ((((((scope)->alias_path)).has_value()) || ((((scope)->import_path_if_extern)).has_value()))){
-return (ByteString::must_from_utf8(""sv));
+return (ByteString::from_utf8_without_validation(""sv));
 }
 JaktInternal::Set<ids::TypeId> seen_types = Set<ids::TypeId>::create_with_values({});
-ByteString output = (ByteString::must_from_utf8(""sv));
+ByteString output = (ByteString::from_utf8_without_validation(""sv));
 if (((((scope)->namespace_name)).has_value())){
 [](ByteString& self, ByteString rhs) -> void {
 {
 (self = ((self) + (rhs)));
 }
 }
-(output,(((((ByteString::must_from_utf8("namespace "sv))) + ((((scope)->namespace_name).value())))) + ((ByteString::must_from_utf8(" {\n"sv)))));
+(output,(((((ByteString::from_utf8_without_validation("namespace "sv))) + ((((scope)->namespace_name).value())))) + ((ByteString::from_utf8_without_validation(" {\n"sv)))));
 }
 {
 JaktInternal::ArrayIterator<bool> _magic = ((DynamicArray<bool>::create_with({false, true})).iterator());
@@ -2057,7 +2057,7 @@ if (((((scope)->namespace_name)).has_value())){
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8("}\n"sv)));
+(output,(ByteString::from_utf8_without_validation("}\n"sv)));
 }
 return output;
 }
@@ -2066,18 +2066,18 @@ return output;
 ErrorOr<ByteString> codegen::CodeGenerator::codegen_namespace(NonnullRefPtr<types::Scope> const scope,NonnullRefPtr<types::Module> const current_module,bool const as_forward) {
 {
 if ((((((scope)->alias_path)).has_value()) || ((((scope)->import_path_if_extern)).has_value()))){
-return (ByteString::must_from_utf8(""sv));
+return (ByteString::from_utf8_without_validation(""sv));
 }
 JaktInternal::Set<ids::TypeId> seen_types = Set<ids::TypeId>::create_with_values({});
 if (as_forward){
-ByteString output = (ByteString::must_from_utf8(""sv));
+ByteString output = (ByteString::from_utf8_without_validation(""sv));
 if (((((scope)->namespace_name)).has_value())){
 [](ByteString& self, ByteString rhs) -> void {
 {
 (self = ((self) + (rhs)));
 }
 }
-(output,(((((ByteString::must_from_utf8("namespace "sv))) + ((((scope)->namespace_name).value())))) + ((ByteString::must_from_utf8(" {\n"sv)))));
+(output,(((((ByteString::from_utf8_without_validation("namespace "sv))) + ((((scope)->namespace_name).value())))) + ((ByteString::from_utf8_without_validation(" {\n"sv)))));
 }
 JaktInternal::Dictionary<ids::TypeId,JaktInternal::DynamicArray<ids::TypeId>> const dependency_graph = TRY((((*this).produce_codegen_dependency_graph(scope))));
 {
@@ -2207,7 +2207,7 @@ continue;
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8("\n"sv)));
+(output,(ByteString::from_utf8_without_validation("\n"sv)));
 }
 
 }
@@ -2244,7 +2244,7 @@ continue;
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8("\n"sv)));
+(output,(ByteString::from_utf8_without_validation("\n"sv)));
 }
 
 }
@@ -2340,18 +2340,18 @@ if (((((scope)->namespace_name)).has_value())){
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8("}\n"sv)));
+(output,(ByteString::from_utf8_without_validation("}\n"sv)));
 }
 return output;
 }
-ByteString output = (ByteString::must_from_utf8(""sv));
+ByteString output = (ByteString::from_utf8_without_validation(""sv));
 if (((((scope)->namespace_name)).has_value())){
 [](ByteString& self, ByteString rhs) -> void {
 {
 (self = ((self) + (rhs)));
 }
 }
-(output,(((((ByteString::must_from_utf8("namespace "sv))) + ((((scope)->namespace_name).value())))) + ((ByteString::must_from_utf8(" {\n"sv)))));
+(output,(((((ByteString::from_utf8_without_validation("namespace "sv))) + ((((scope)->namespace_name).value())))) + ((ByteString::from_utf8_without_validation(" {\n"sv)))));
 }
 {
 JaktInternal::DictionaryIterator<ByteString,JaktInternal::DynamicArray<ids::FunctionId>> _magic = ((((scope)->functions)).iterator());
@@ -2402,7 +2402,7 @@ if (((((((function)->generics))->params)).is_empty())){
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8("\n"sv)));
+(output,(ByteString::from_utf8_without_validation("\n"sv)));
 }
 }
 
@@ -2487,7 +2487,7 @@ if (((((function)->type)).__jakt_init_index() == 2 /* ImplicitConstructor */)){
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8("\n"sv)));
+(output,(ByteString::from_utf8_without_validation("\n"sv)));
 }
 else if (((((function)->type)).__jakt_init_index() == 1 /* Destructor */)){
 [](ByteString& self, ByteString rhs) -> void {
@@ -2501,7 +2501,7 @@ else if (((((function)->type)).__jakt_init_index() == 1 /* Destructor */)){
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8("\n"sv)));
+(output,(ByteString::from_utf8_without_validation("\n"sv)));
 }
 else if (((!(((((function)->type)).__jakt_init_index() == 3 /* ImplicitEnumConstructor */))) && ((!(((function)->is_comptime))) && ((((((function)->generics))->params)).is_empty())))){
 [](ByteString& self, ByteString rhs) -> void {
@@ -2515,7 +2515,7 @@ else if (((!(((((function)->type)).__jakt_init_index() == 3 /* ImplicitEnumConst
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8("\n"sv)));
+(output,(ByteString::from_utf8_without_validation("\n"sv)));
 }
 }
 
@@ -2591,7 +2591,7 @@ JaktInternal::DynamicArray<JaktInternal::Tuple<ByteString,JaktInternal::DynamicA
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8("}\n"sv)));
+(output,(ByteString::from_utf8_without_validation("}\n"sv)));
 }
 NonnullRefPtr<types::Scope> const scope = ((((*this).program))->get_scope(((enum_).scope_id)));
 {
@@ -2634,7 +2634,7 @@ if (((!(((((function)->type)).__jakt_init_index() == 2 /* ImplicitConstructor */
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8("\n"sv)));
+(output,(ByteString::from_utf8_without_validation("\n"sv)));
 }
 }
 
@@ -2683,7 +2683,7 @@ if (((((scope)->namespace_name)).has_value())){
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8("}\n"sv)));
+(output,(ByteString::from_utf8_without_validation("}\n"sv)));
 }
 return output;
 }
@@ -2692,16 +2692,16 @@ return output;
 ErrorOr<ByteString> codegen::CodeGenerator::codegen_namespace_predecl(NonnullRefPtr<types::Scope> const scope,NonnullRefPtr<types::Module> const current_module) {
 {
 if ((((((scope)->alias_path)).has_value()) || ((((scope)->import_path_if_extern)).has_value()))){
-return (ByteString::must_from_utf8(""sv));
+return (ByteString::from_utf8_without_validation(""sv));
 }
-ByteString output = (ByteString::must_from_utf8(""sv));
+ByteString output = (ByteString::from_utf8_without_validation(""sv));
 if (((((scope)->namespace_name)).has_value())){
 [](ByteString& self, ByteString rhs) -> void {
 {
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8("namespace "sv)));
+(output,(ByteString::from_utf8_without_validation("namespace "sv)));
 [](ByteString& self, ByteString rhs) -> void {
 {
 (self = ((self) + (rhs)));
@@ -2713,7 +2713,7 @@ if (((((scope)->namespace_name)).has_value())){
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8(" {\n"sv)));
+(output,(ByteString::from_utf8_without_validation(" {\n"sv)));
 }
 {
 JaktInternal::DictionaryIterator<ByteString,ids::StructId> _magic = ((((scope)->structs)).iterator());
@@ -2743,7 +2743,7 @@ types::CheckedStruct const struct_ = ((((*this).program))->get_struct(struct_id)
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8("\n"sv)));
+(output,(ByteString::from_utf8_without_validation("\n"sv)));
 }
 
 }
@@ -2777,7 +2777,7 @@ types::CheckedEnum const enum_ = ((((*this).program))->get_enum(enum_id));
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8("\n"sv)));
+(output,(ByteString::from_utf8_without_validation("\n"sv)));
 }
 
 }
@@ -2842,7 +2842,7 @@ if (((!(((((function)->type)).__jakt_init_index() == 2 /* ImplicitConstructor */
 return (!(((self) == (rhs))));
 }
 }
-(((((function)->name_for_codegen())).as_name_for_use()),(ByteString::must_from_utf8("main"sv))) && ((((((function)->generics))->params)).is_empty()))))){
+(((((function)->name_for_codegen())).as_name_for_use()),(ByteString::from_utf8_without_validation("main"sv))) && ((((((function)->generics))->params)).is_empty()))))){
 [](ByteString& self, ByteString rhs) -> void {
 {
 (self = ((self) + (rhs)));
@@ -2854,7 +2854,7 @@ return (!(((self) == (rhs))));
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8("\n"sv)));
+(output,(ByteString::from_utf8_without_validation("\n"sv)));
 }
 }
 
@@ -2872,7 +2872,7 @@ if (((((scope)->namespace_name)).has_value())){
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8("}\n"sv)));
+(output,(ByteString::from_utf8_without_validation("}\n"sv)));
 }
 return output;
 }
@@ -2938,7 +2938,7 @@ return TRY((((*this).codegen_template_parameter_names(parameters,((names))))));
 
 ErrorOr<ByteString> codegen::CodeGenerator::codegen_template_parameter_names(JaktInternal::DynamicArray<ids::TypeId> const parameters,JaktInternal::DynamicArray<ByteString>& names) {
 {
-ByteString output = (ByteString::must_from_utf8(""sv));
+ByteString output = (ByteString::from_utf8_without_validation(""sv));
 bool first = true;
 {
 JaktInternal::ArrayIterator<ids::TypeId> _magic = ((parameters).iterator());
@@ -2958,7 +2958,7 @@ else {
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8(","sv)));
+(output,(ByteString::from_utf8_without_validation(","sv)));
 }
 
 if (((((((*this).program))->get_type(id)))->__jakt_init_index() == 18 /* TypeVariable */)){
@@ -2969,7 +2969,7 @@ if (is_value){
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8("auto "sv)));
+(output,(ByteString::from_utf8_without_validation("auto "sv)));
 }
 else {
 [](ByteString& self, ByteString rhs) -> void {
@@ -2977,7 +2977,7 @@ else {
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8("typename "sv)));
+(output,(ByteString::from_utf8_without_validation("typename "sv)));
 }
 
 }
@@ -2987,7 +2987,7 @@ else {
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8("typename "sv)));
+(output,(ByteString::from_utf8_without_validation("typename "sv)));
 }
 
 ByteString const name = TRY((((*this).codegen_type(id))));
@@ -3009,14 +3009,14 @@ return output;
 
 ErrorOr<ByteString> codegen::CodeGenerator::codegen_function_generic_parameters(NonnullRefPtr<types::CheckedFunction> const function) {
 {
-ByteString output = (ByteString::must_from_utf8(""sv));
+ByteString output = (ByteString::from_utf8_without_validation(""sv));
 if ((!(((((((function)->generics))->params)).is_empty())))){
 [](ByteString& self, ByteString rhs) -> void {
 {
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8("template <"sv)));
+(output,(ByteString::from_utf8_without_validation("template <"sv)));
 [](ByteString& self, ByteString rhs) -> void {
 {
 (self = ((self) + (rhs)));
@@ -3028,7 +3028,7 @@ if ((!(((((((function)->generics))->params)).is_empty())))){
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8(">\n"sv)));
+(output,(ByteString::from_utf8_without_validation(">\n"sv)));
 }
 return output;
 }
@@ -3036,18 +3036,18 @@ return output;
 
 ErrorOr<ByteString> codegen::CodeGenerator::codegen_function_predecl(NonnullRefPtr<types::CheckedFunction> const function,bool const as_method,bool const allow_generics) {
 {
-ByteString output = (ByteString::must_from_utf8(""sv));
+ByteString output = (ByteString::from_utf8_without_validation(""sv));
 if (((allow_generics || (!(((((((function)->generics))->params)).is_empty())))) && ((((function)->linkage)).__jakt_init_index() == 1 /* External */))){
-return (ByteString::must_from_utf8(""sv));
+return (ByteString::from_utf8_without_validation(""sv));
 }
 if (((function)->is_comptime)){
-return (ByteString::must_from_utf8(""sv));
+return (ByteString::from_utf8_without_validation(""sv));
 }
 if (((((function)->force_inline)).__jakt_init_index() == 2 /* ForceInline */)){
-return (ByteString::must_from_utf8(""sv));
+return (ByteString::from_utf8_without_validation(""sv));
 }
 if (((((function)->type)).__jakt_init_index() == 2 /* ImplicitConstructor */)){
-return (ByteString::must_from_utf8(""sv));
+return (ByteString::from_utf8_without_validation(""sv));
 }
 if (((((function)->linkage)).__jakt_init_index() == 1 /* External */)){
 [](ByteString& self, ByteString rhs) -> void {
@@ -3055,7 +3055,7 @@ if (((((function)->linkage)).__jakt_init_index() == 1 /* External */)){
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8("extern "sv)));
+(output,(ByteString::from_utf8_without_validation("extern "sv)));
 }
 [](ByteString& self, ByteString rhs) -> void {
 {
@@ -3069,15 +3069,15 @@ if (((((function)->return_type_id)).equals(types::never_type_id()))){
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8("[[noreturn]] "sv)));
+(output,(ByteString::from_utf8_without_validation("[[noreturn]] "sv)));
 }
-if (((TRY((((((function)->name_for_codegen())).as_name_for_definition())))) == ((ByteString::must_from_utf8("main"sv))))){
+if (((TRY((((((function)->name_for_codegen())).as_name_for_definition())))) == ((ByteString::from_utf8_without_validation("main"sv))))){
 [](ByteString& self, ByteString rhs) -> void {
 {
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8("ErrorOr<int>"sv)));
+(output,(ByteString::from_utf8_without_validation("ErrorOr<int>"sv)));
 }
 else {
 if ((as_method && ((function)->is_static()))){
@@ -3086,7 +3086,7 @@ if ((as_method && ((function)->is_static()))){
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8("static "sv)));
+(output,(ByteString::from_utf8_without_validation("static "sv)));
 }
 if (((function)->is_virtual)){
 [](ByteString& self, ByteString rhs) -> void {
@@ -3094,7 +3094,7 @@ if (((function)->is_virtual)){
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8("virtual "sv)));
+(output,(ByteString::from_utf8_without_validation("virtual "sv)));
 }
 ByteString const naked_return_type = TRY((((*this).codegen_type(((function)->return_type_id)))));
 ByteString const return_type = ({
@@ -3125,7 +3125,7 @@ VERIFY_NOT_REACHED();
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8(" "sv)));
+(output,(ByteString::from_utf8_without_validation(" "sv)));
 [](ByteString& self, ByteString rhs) -> void {
 {
 (self = ((self) + (rhs)));
@@ -3137,7 +3137,7 @@ VERIFY_NOT_REACHED();
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8("("sv)));
+(output,(ByteString::from_utf8_without_validation("("sv)));
 bool first = true;
 {
 JaktInternal::ArrayIterator<types::CheckedParameter> _magic = ((((function)->params)).iterator());
@@ -3148,7 +3148,7 @@ break;
 }
 types::CheckedParameter param = (_magic_value.value());
 {
-if ((first && ((((((param).variable))->name)) == ((ByteString::must_from_utf8("this"sv)))))){
+if ((first && ((((((param).variable))->name)) == ((ByteString::from_utf8_without_validation("this"sv)))))){
 continue;
 }
 if (first){
@@ -3160,7 +3160,7 @@ else {
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8(", "sv)));
+(output,(ByteString::from_utf8_without_validation(", "sv)));
 }
 
 NonnullRefPtr<typename types::Type> const param_type = ((((*this).program))->get_type(((((param).variable))->type_id)));
@@ -3175,14 +3175,14 @@ NonnullRefPtr<typename types::Type> const param_type = ((((*this).program))->get
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8(" "sv)));
+(output,(ByteString::from_utf8_without_validation(" "sv)));
 if (((!(((((param).variable))->is_mutable))) && (!((((param_type)->__jakt_init_index() == 28 /* Reference */) || ((param_type)->__jakt_init_index() == 29 /* MutableReference */)))))){
 [](ByteString& self, ByteString rhs) -> void {
 {
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8("const "sv)));
+(output,(ByteString::from_utf8_without_validation("const "sv)));
 }
 [](ByteString& self, ByteString rhs) -> void {
 {
@@ -3200,14 +3200,14 @@ if (((!(((((param).variable))->is_mutable))) && (!((((param_type)->__jakt_init_i
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8(")"sv)));
+(output,(ByteString::from_utf8_without_validation(")"sv)));
 if (((!(((function)->is_static()))) && (!(((function)->is_mutating()))))){
 [](ByteString& self, ByteString rhs) -> void {
 {
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8(" const"sv)));
+(output,(ByteString::from_utf8_without_validation(" const"sv)));
 }
 if (((function)->is_override)){
 [](ByteString& self, ByteString rhs) -> void {
@@ -3215,20 +3215,20 @@ if (((function)->is_override)){
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8(" override"sv)));
+(output,(ByteString::from_utf8_without_validation(" override"sv)));
 }
 [](ByteString& self, ByteString rhs) -> void {
 {
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8(";"sv)));
+(output,(ByteString::from_utf8_without_validation(";"sv)));
 [](ByteString& self, ByteString rhs) -> void {
 {
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8("\n"sv)));
+(output,(ByteString::from_utf8_without_validation("\n"sv)));
 return output;
 }
 }
@@ -3236,16 +3236,16 @@ return output;
 ErrorOr<ByteString> codegen::CodeGenerator::codegen_struct_predecl(types::CheckedStruct const struct_) {
 {
 if (((((struct_).definition_linkage)).__jakt_init_index() == 1 /* External */)){
-return (ByteString::must_from_utf8(""sv));
+return (ByteString::from_utf8_without_validation(""sv));
 }
-ByteString output = (ByteString::must_from_utf8(""sv));
+ByteString output = (ByteString::from_utf8_without_validation(""sv));
 if ((!(((((struct_).generic_parameters)).is_empty())))){
 [](ByteString& self, ByteString rhs) -> void {
 {
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8("template <"sv)));
+(output,(ByteString::from_utf8_without_validation("template <"sv)));
 [](ByteString& self, ByteString rhs) -> void {
 {
 (self = ((self) + (rhs)));
@@ -3257,7 +3257,7 @@ if ((!(((((struct_).generic_parameters)).is_empty())))){
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8(">"sv)));
+(output,(ByteString::from_utf8_without_validation(">"sv)));
 }
 [](ByteString& self, ByteString rhs) -> void {
 {
@@ -3269,13 +3269,13 @@ if ((!(((((struct_).generic_parameters)).is_empty())))){
 auto&& __jakt_match_variant = ((struct_).record_type);
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 1 /* Class */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("class "sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("class "sv)));
 };/*case end*/
 case 0 /* Struct */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("struct "sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("struct "sv)));
 };/*case end*/
 default: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8(""sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation(""sv)));
 };/*case end*/
 }/*switch end*/
 }()
@@ -3295,20 +3295,20 @@ return JaktInternal::ExplicitValue((ByteString::must_from_utf8(""sv)));
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8(";"sv)));
+(output,(ByteString::from_utf8_without_validation(";"sv)));
 return output;
 }
 }
 
 ErrorOr<ByteString> codegen::CodeGenerator::codegen_struct(types::CheckedStruct const struct_) {
 {
-ByteString output = (ByteString::must_from_utf8(""sv));
+ByteString output = (ByteString::from_utf8_without_validation(""sv));
 if (((((struct_).definition_linkage)).__jakt_init_index() == 1 /* External */)){
-return (ByteString::must_from_utf8(""sv));
+return (ByteString::from_utf8_without_validation(""sv));
 }
 bool struct_is_generic = false;
 JaktInternal::DynamicArray<ByteString> generic_parameter_names = DynamicArray<ByteString>::create_with({});
-ByteString template_parameters = (ByteString::must_from_utf8(""sv));
+ByteString template_parameters = (ByteString::from_utf8_without_validation(""sv));
 if ((!(((((struct_).generic_parameters)).is_empty())))){
 (struct_is_generic = true);
 (template_parameters = TRY((((*this).codegen_template_parameter_names(((struct_).generic_parameters),((generic_parameter_names)))))));
@@ -3325,7 +3325,7 @@ auto&& __jakt_match_variant = ((struct_).record_type);
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 1 /* Class */: {
 {
-ByteString class_name_with_generics = (ByteString::must_from_utf8(""sv));
+ByteString class_name_with_generics = (ByteString::from_utf8_without_validation(""sv));
 [](ByteString& self, ByteString rhs) -> void {
 {
 (self = ((self) + (rhs)));
@@ -3348,7 +3348,7 @@ if ((!(first))){
 (self = ((self) + (rhs)));
 }
 }
-(class_name_with_generics,(ByteString::must_from_utf8(", "sv)));
+(class_name_with_generics,(ByteString::from_utf8_without_validation(", "sv)));
 }
 else {
 [](ByteString& self, ByteString rhs) -> void {
@@ -3356,7 +3356,7 @@ else {
 (self = ((self) + (rhs)));
 }
 }
-(class_name_with_generics,(ByteString::must_from_utf8("<"sv)));
+(class_name_with_generics,(ByteString::from_utf8_without_validation("<"sv)));
 (first = false);
 }
 
@@ -3377,7 +3377,7 @@ if ((!(((((struct_).generic_parameters)).is_empty())))){
 (self = ((self) + (rhs)));
 }
 }
-(class_name_with_generics,(ByteString::must_from_utf8(">"sv)));
+(class_name_with_generics,(ByteString::from_utf8_without_validation(">"sv)));
 }
 [](ByteString& self, ByteString rhs) -> void {
 {
@@ -3415,7 +3415,7 @@ else {
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8("{\n"sv)));
+(output,(ByteString::from_utf8_without_validation("{\n"sv)));
 NonnullRefPtr<types::Scope> const scope = ((((*this).program))->get_scope(((struct_).scope_id)));
 bool has_destructor = false;
 {
@@ -3460,7 +3460,7 @@ if ((!(has_destructor))){
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8("  public:\n"sv)));
+(output,(ByteString::from_utf8_without_validation("  public:\n"sv)));
 [](ByteString& self, ByteString rhs) -> void {
 {
 (self = ((self) + (rhs)));
@@ -3492,25 +3492,25 @@ if (((((struct_).super_struct_id)).has_value())){
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8(" {\n"sv)));
+(output,(ByteString::from_utf8_without_validation(" {\n"sv)));
 [](ByteString& self, ByteString rhs) -> void {
 {
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8("  public:\n"sv)));
+(output,(ByteString::from_utf8_without_validation("  public:\n"sv)));
 }
 return JaktInternal::ExplicitValue<void>();
 };/*case end*/
 case 3 /* SumEnum */: {
 {
-utility::todo((ByteString::must_from_utf8("codegen_struct SumEnum"sv)));
+utility::todo((ByteString::from_utf8_without_validation("codegen_struct SumEnum"sv)));
 }
 return JaktInternal::ExplicitValue<void>();
 };/*case end*/
 case 2 /* ValueEnum */: {
 {
-utility::todo((ByteString::must_from_utf8("codegen_struct ValueEnum"sv)));
+utility::todo((ByteString::from_utf8_without_validation("codegen_struct ValueEnum"sv)));
 }
 return JaktInternal::ExplicitValue<void>();
 };/*case end*/
@@ -3539,7 +3539,7 @@ case 2 /* Restricted */: {
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8("public: "sv)));
+(output,(ByteString::from_utf8_without_validation("public: "sv)));
 }
 return JaktInternal::ExplicitValue<void>();
 };/*case end*/
@@ -3550,7 +3550,7 @@ case 0 /* Public */: {
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8("public: "sv)));
+(output,(ByteString::from_utf8_without_validation("public: "sv)));
 }
 return JaktInternal::ExplicitValue<void>();
 };/*case end*/
@@ -3561,7 +3561,7 @@ case 1 /* Private */: {
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8("private: "sv)));
+(output,(ByteString::from_utf8_without_validation("private: "sv)));
 }
 return JaktInternal::ExplicitValue<void>();
 };/*case end*/
@@ -3598,7 +3598,7 @@ TRY((set_access_level(((variable)->visibility))));
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8(" "sv)));
+(output,(ByteString::from_utf8_without_validation(" "sv)));
 [](ByteString& self, ByteString rhs) -> void {
 {
 (self = ((self) + (rhs)));
@@ -3610,7 +3610,7 @@ TRY((set_access_level(((variable)->visibility))));
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8(";"sv)));
+(output,(ByteString::from_utf8_without_validation(";"sv)));
 }
 
 }
@@ -3669,7 +3669,7 @@ else {
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8("\n"sv)));
+(output,(ByteString::from_utf8_without_validation("\n"sv)));
 }
 else if (((((function)->type)).__jakt_init_index() == 2 /* ImplicitConstructor */)){
 if (((((struct_).generic_parameters)).is_empty())){
@@ -3694,7 +3694,7 @@ else {
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8("\n"sv)));
+(output,(ByteString::from_utf8_without_validation("\n"sv)));
 }
 else if (((((function)->force_inline)).__jakt_init_index() == 1 /* MakeDefinitionAvailable */)){
 [](ByteString& self, ByteString rhs) -> void {
@@ -3739,7 +3739,7 @@ if (((((struct_).generic_parameters)).is_empty())){
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8("ByteString debug_description() const;\n"sv)));
+(output,(ByteString::from_utf8_without_validation("ByteString debug_description() const;\n"sv)));
 }
 else {
 [](ByteString& self, ByteString rhs) -> void {
@@ -3755,7 +3755,7 @@ else {
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8("};"sv)));
+(output,(ByteString::from_utf8_without_validation("};"sv)));
 [](ByteString& self, ByteString rhs) -> void {
 {
 (self = ((self) + (rhs)));
@@ -3768,7 +3768,7 @@ return output;
 
 ErrorOr<ByteString> codegen::CodeGenerator::codegen_enum_predecl(types::CheckedEnum const enum_) {
 {
-ByteString output = (ByteString::must_from_utf8(""sv));
+ByteString output = (ByteString::from_utf8_without_validation(""sv));
 if ([](ids::TypeId const& self, ids::TypeId rhs) -> bool {
 {
 return (!(((self).equals(rhs))));
@@ -3779,7 +3779,7 @@ if (((((*this).program))->is_integer(((enum_).underlying_type_id)))){
 return __jakt_format((StringView::from_string_literal("enum class {}: {};"sv)),((enum_).name),TRY((((*this).codegen_type(((enum_).underlying_type_id))))));
 }
 else {
-utility::todo((ByteString::must_from_utf8("Enums with a non-integer underlying type"sv)));
+utility::todo((ByteString::from_utf8_without_validation("Enums with a non-integer underlying type"sv)));
 }
 
 }
@@ -3805,7 +3805,7 @@ return output;
 
 ErrorOr<ByteString> codegen::CodeGenerator::codegen_enum(types::CheckedEnum const enum_) {
 {
-ByteString output = (ByteString::must_from_utf8(""sv));
+ByteString output = (ByteString::from_utf8_without_validation(""sv));
 if ([](ids::TypeId const& self, ids::TypeId rhs) -> bool {
 {
 return (!(((self).equals(rhs))));
@@ -3818,7 +3818,7 @@ if (((((*this).program))->is_integer(((enum_).underlying_type_id)))){
 (self = ((self) + (rhs)));
 }
 }
-(output,(((((((((ByteString::must_from_utf8("enum class "sv))) + (((enum_).name)))) + ((ByteString::must_from_utf8(": "sv))))) + (TRY((((*this).codegen_type(((enum_).underlying_type_id)))))))) + ((ByteString::must_from_utf8(" {\n"sv)))));
+(output,(((((((((ByteString::from_utf8_without_validation("enum class "sv))) + (((enum_).name)))) + ((ByteString::from_utf8_without_validation(": "sv))))) + (TRY((((*this).codegen_type(((enum_).underlying_type_id)))))))) + ((ByteString::from_utf8_without_validation(" {\n"sv)))));
 {
 JaktInternal::ArrayIterator<types::CheckedEnumVariant> _magic = ((((enum_).variants)).iterator());
 for (;;){
@@ -3840,7 +3840,7 @@ switch(__jakt_match_variant.__jakt_init_index()) {
 case 2 /* WithValue */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.WithValue;ByteString const& name = __jakt_match_value.name;
 NonnullRefPtr<typename types::CheckedExpression> const& expr = __jakt_match_value.expr;
-return JaktInternal::ExplicitValue(((((((name) + ((ByteString::must_from_utf8(" = "sv))))) + (TRY((((*this).codegen_expression(expr))))))) + ((ByteString::must_from_utf8(",\n"sv)))));
+return JaktInternal::ExplicitValue(((((((name) + ((ByteString::from_utf8_without_validation(" = "sv))))) + (TRY((((*this).codegen_expression(expr))))))) + ((ByteString::from_utf8_without_validation(",\n"sv)))));
 };/*case end*/
 default: {
 {
@@ -3863,24 +3863,24 @@ utility::todo(__jakt_format((StringView::from_string_literal("codegen_enum can't
 }
 }
 
-return ((output) + ((ByteString::must_from_utf8("};\n"sv))));
+return ((output) + ((ByteString::from_utf8_without_validation("};\n"sv))));
 }
 else {
-utility::todo((ByteString::must_from_utf8("Enums with a non-integer underlying type"sv)));
+utility::todo((ByteString::from_utf8_without_validation("Enums with a non-integer underlying type"sv)));
 }
 
 }
 bool const is_generic = (!(((((enum_).generic_parameters)).is_empty())));
 JaktInternal::DynamicArray<ByteString> generic_parameter_names = DynamicArray<ByteString>::create_with({});
 ByteString template_args = TRY((((*this).codegen_template_parameter_names(((enum_).generic_parameters),((generic_parameter_names))))));
-ByteString const generic_parameter_list = utility::join(generic_parameter_names,(ByteString::must_from_utf8(", "sv)));
+ByteString const generic_parameter_list = utility::join(generic_parameter_names,(ByteString::from_utf8_without_validation(", "sv)));
 if (is_generic){
 [](ByteString& self, ByteString rhs) -> void {
 {
 (self = ((self) + (rhs)));
 }
 }
-(output,(((((ByteString::must_from_utf8("template<"sv))) + (template_args))) + ((ByteString::must_from_utf8(">\n"sv)))));
+(output,(((((ByteString::from_utf8_without_validation("template<"sv))) + (template_args))) + ((ByteString::from_utf8_without_validation(">\n"sv)))));
 }
 [](ByteString& self, ByteString rhs) -> void {
 {
@@ -3901,36 +3901,36 @@ if (is_generic){
 (self = ((self) + (rhs)));
 }
 }
-(output,__jakt_format((StringView::from_string_literal("<{}>"sv)),utility::join(generic_parameter_names,(ByteString::must_from_utf8(", "sv)))));
+(output,__jakt_format((StringView::from_string_literal("<{}>"sv)),utility::join(generic_parameter_names,(ByteString::from_utf8_without_validation(", "sv)))));
 }
 [](ByteString& self, ByteString rhs) -> void {
 {
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8(">"sv)));
+(output,(ByteString::from_utf8_without_validation(">"sv)));
 }
 [](ByteString& self, ByteString rhs) -> void {
 {
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8(" {\n"sv)));
+(output,(ByteString::from_utf8_without_validation(" {\n"sv)));
 size_t const max_index_value = ((((enum_).variants)).size());
 ByteString const index_type = ({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<ByteString,ErrorOr<ByteString>>{
 auto __jakt_enum_value = (max_index_value);
 if (__jakt_enum_value >= static_cast<size_t>(0ULL)&& __jakt_enum_value < static_cast<size_t>(256ULL)) {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("u8"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("u8"sv)));
 }
 else if (__jakt_enum_value >= static_cast<size_t>(256ULL)&& __jakt_enum_value < static_cast<size_t>(65536ULL)) {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("u16"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("u16"sv)));
 }
 else if (__jakt_enum_value >= static_cast<size_t>(65536ULL)&& __jakt_enum_value < static_cast<size_t>(4294967296ULL)) {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("u32"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("u32"sv)));
 }
 else {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("size_t"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("size_t"sv)));
 }
 }());
     if (_jakt_value.is_return())
@@ -3953,19 +3953,19 @@ if ((!(((common_fields).is_empty())))){
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8("union CommonData {\n"sv)));
+(output,(ByteString::from_utf8_without_validation("union CommonData {\n"sv)));
 [](ByteString& self, ByteString rhs) -> void {
 {
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8("u8 __jakt_uninit_common;\n"sv)));
+(output,(ByteString::from_utf8_without_validation("u8 __jakt_uninit_common;\n"sv)));
 [](ByteString& self, ByteString rhs) -> void {
 {
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8("struct {\n"sv)));
+(output,(ByteString::from_utf8_without_validation("struct {\n"sv)));
 {
 JaktInternal::ArrayIterator<JaktInternal::Tuple<ByteString,ByteString>> _magic = ((common_fields).iterator());
 for (;;){
@@ -3995,38 +3995,38 @@ ByteString const type = ((jakt__field_name__type__).template get<1>());
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8("} init_common;\n"sv)));
+(output,(ByteString::from_utf8_without_validation("} init_common;\n"sv)));
 [](ByteString& self, ByteString rhs) -> void {
 {
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8("constexpr CommonData() {}\n"sv)));
+(output,(ByteString::from_utf8_without_validation("constexpr CommonData() {}\n"sv)));
 [](ByteString& self, ByteString rhs) -> void {
 {
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8("~CommonData() {}\n"sv)));
+(output,(ByteString::from_utf8_without_validation("~CommonData() {}\n"sv)));
 [](ByteString& self, ByteString rhs) -> void {
 {
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8("} common;\n"sv)));
+(output,(ByteString::from_utf8_without_validation("} common;\n"sv)));
 }
 [](ByteString& self, ByteString rhs) -> void {
 {
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8("union VariantData {\n"sv)));
+(output,(ByteString::from_utf8_without_validation("union VariantData {\n"sv)));
 [](ByteString& self, ByteString rhs) -> void {
 {
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8("u8 __jakt_uninit_value;\n"sv)));
+(output,(ByteString::from_utf8_without_validation("u8 __jakt_uninit_value;\n"sv)));
 {
 JaktInternal::Range<size_t> _magic = (JaktInternal::Range<size_t>{static_cast<size_t>(static_cast<size_t>(0ULL)),static_cast<size_t>(((((enum_).variants)).size()))});
 for (;;){
@@ -4044,7 +4044,7 @@ if ((!(((fields).is_empty())))){
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8("struct {\n"sv)));
+(output,(ByteString::from_utf8_without_validation("struct {\n"sv)));
 {
 JaktInternal::ArrayIterator<JaktInternal::Tuple<ByteString,ByteString>> _magic = ((fields).iterator());
 for (;;){
@@ -4086,19 +4086,19 @@ ByteString const field_type = ((jakt__field_name__field_type__).template get<1>(
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8("constexpr VariantData() {}\n"sv)));
+(output,(ByteString::from_utf8_without_validation("constexpr VariantData() {}\n"sv)));
 [](ByteString& self, ByteString rhs) -> void {
 {
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8("~VariantData() {}\n"sv)));
+(output,(ByteString::from_utf8_without_validation("~VariantData() {}\n"sv)));
 [](ByteString& self, ByteString rhs) -> void {
 {
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8("} as;\n"sv)));
+(output,(ByteString::from_utf8_without_validation("} as;\n"sv)));
 [](ByteString& self, ByteString rhs) -> void {
 {
 (self = ((self) + (rhs)));
@@ -4111,7 +4111,7 @@ if (((((enum_).generic_parameters)).is_empty())){
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8("ByteString debug_description() const;\n"sv)));
+(output,(ByteString::from_utf8_without_validation("ByteString debug_description() const;\n"sv)));
 }
 else {
 [](ByteString& self, ByteString rhs) -> void {
@@ -4141,20 +4141,20 @@ if (is_generic){
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8("private: void __jakt_destroy_variant() {\n"sv)));
+(output,(ByteString::from_utf8_without_validation("private: void __jakt_destroy_variant() {\n"sv)));
 ((*this).codegen_enum_destroy_variant(enum_,((output))));
 [](ByteString& self, ByteString rhs) -> void {
 {
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8("}\n"sv)));
+(output,(ByteString::from_utf8_without_validation("}\n"sv)));
 [](ByteString& self, ByteString rhs) -> void {
 {
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8("public:\n"sv)));
+(output,(ByteString::from_utf8_without_validation("public:\n"sv)));
 }
 else {
 {
@@ -4176,7 +4176,7 @@ codegen::CodeGenerator::codegen_enum_constructor_decl(((enum_).name),variant_nam
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8(";\n"sv)));
+(output,(ByteString::from_utf8_without_validation(";\n"sv)));
 }
 
 }
@@ -4217,13 +4217,13 @@ codegen::CodeGenerator::codegen_enum_constructor_decl(((enum_).name),variant_nam
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8("private: void __jakt_destroy_variant();\n"sv)));
+(output,(ByteString::from_utf8_without_validation("private: void __jakt_destroy_variant();\n"sv)));
 [](ByteString& self, ByteString rhs) -> void {
 {
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8("public:\n"sv)));
+(output,(ByteString::from_utf8_without_validation("public:\n"sv)));
 }
 
 NonnullRefPtr<types::Scope> const enum_scope = ((((*this).program))->get_scope(((enum_).scope_id)));
@@ -4298,7 +4298,7 @@ continue;
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8("};\n"sv)));
+(output,(ByteString::from_utf8_without_validation("};\n"sv)));
 [](ByteString& self, ByteString rhs) -> void {
 {
 (self = ((self) + (rhs)));
@@ -4316,7 +4316,7 @@ void codegen::CodeGenerator::codegen_enum_constructor_decl(ByteString const enum
 (self = ((self) + (rhs)));
 }
 }
-(((output)),(ByteString::must_from_utf8("[[nodiscard]] "sv)));
+(((output)),(ByteString::from_utf8_without_validation("[[nodiscard]] "sv)));
 if (is_inline){
 [](ByteString& self, ByteString rhs) -> void {
 {
@@ -4436,7 +4436,7 @@ ByteString const type = ((name_type_).template get<1>());
 (self = ((self) + (rhs)));
 }
 }
-(((output)),(ByteString::must_from_utf8(")"sv)));
+(((output)),(ByteString::from_utf8_without_validation(")"sv)));
 }
 }
 
@@ -4613,14 +4613,14 @@ ByteString const name = ((((variable)->name_for_codegen())).as_name_for_use());
 }
 
 if (is_constructor){
-((*this).codegen_for_enum_variants(((enum_)),((placement_new)),(ByteString::must_from_utf8("rhs.__jakt_init_index()"sv)),((builder))));
+((*this).codegen_for_enum_variants(((enum_)),((placement_new)),(ByteString::from_utf8_without_validation("rhs.__jakt_init_index()"sv)),((builder))));
 }
 else {
 ((builder).append((StringView::from_string_literal("if (this->__jakt_variant_index != rhs.__jakt_variant_index) {\n"sv))));
 ((builder).append((StringView::from_string_literal("this->__jakt_destroy_variant();\n"sv))));
-((*this).codegen_for_enum_variants(((enum_)),((placement_new)),(ByteString::must_from_utf8("rhs.__jakt_init_index()"sv)),((builder))));
+((*this).codegen_for_enum_variants(((enum_)),((placement_new)),(ByteString::from_utf8_without_validation("rhs.__jakt_init_index()"sv)),((builder))));
 ((builder).append((StringView::from_string_literal("} else {\n"sv))));
-((*this).codegen_for_enum_variants(((enum_)),((assign)),(ByteString::must_from_utf8("rhs.__jakt_init_index()"sv)),((builder))));
+((*this).codegen_for_enum_variants(((enum_)),((assign)),(ByteString::from_utf8_without_validation("rhs.__jakt_init_index()"sv)),((builder))));
 ((builder).append((StringView::from_string_literal("}\n"sv))));
 }
 
@@ -4632,7 +4632,7 @@ return ((builder).to_string());
 
 ByteString codegen::CodeGenerator::codegen_enum_constructors(types::CheckedEnum const enum_,bool const is_inside_struct,JaktInternal::Optional<ByteString> const generic_parameter_list,JaktInternal::DynamicArray<JaktInternal::Tuple<ByteString,JaktInternal::DynamicArray<JaktInternal::Tuple<ByteString,ByteString>>>> const variant_field_list,JaktInternal::DynamicArray<JaktInternal::Tuple<ByteString,ByteString>> const common_fields) const {
 {
-ByteString output = (ByteString::must_from_utf8(""sv));
+ByteString output = (ByteString::from_utf8_without_validation(""sv));
 bool const is_generic = (!(((((enum_).generic_parameters)).is_empty())));
 ByteString const ctor_result_type = codegen::CodeGenerator::enum_constructor_result_type(enum_,generic_parameter_list);
 ByteString const ctor_type = ({
@@ -4654,10 +4654,10 @@ JaktInternal::Tuple<ByteString,ByteString> const declare_uninit_deref_uninit_ = 
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<JaktInternal::Tuple<ByteString,ByteString>,ByteString>{
 auto __jakt_enum_value = (((enum_).is_boxed));
 if (__jakt_enum_value == true) {
-return JaktInternal::ExplicitValue((Tuple{__jakt_format((StringView::from_string_literal("NonnullRefPtr<{0}> __jakt_uninit_enum = adopt_ref(*new {0});\n"sv)),ctor_type), (ByteString::must_from_utf8("__jakt_uninit_enum->"sv))}));
+return JaktInternal::ExplicitValue((Tuple{__jakt_format((StringView::from_string_literal("NonnullRefPtr<{0}> __jakt_uninit_enum = adopt_ref(*new {0});\n"sv)),ctor_type), (ByteString::from_utf8_without_validation("__jakt_uninit_enum->"sv))}));
 }
 else if (__jakt_enum_value == false) {
-return JaktInternal::ExplicitValue((Tuple{__jakt_format((StringView::from_string_literal("{} __jakt_uninit_enum;\n"sv)),((enum_).name)), (ByteString::must_from_utf8("__jakt_uninit_enum."sv))}));
+return JaktInternal::ExplicitValue((Tuple{__jakt_format((StringView::from_string_literal("{} __jakt_uninit_enum;\n"sv)),((enum_).name)), (ByteString::from_utf8_without_validation("__jakt_uninit_enum."sv))}));
 }
 VERIFY_NOT_REACHED();
 }());
@@ -4694,7 +4694,7 @@ codegen::CodeGenerator::codegen_enum_constructor_decl(((enum_).name),variant_nam
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8("{\n"sv)));
+(output,(ByteString::from_utf8_without_validation("{\n"sv)));
 [](ByteString& self, ByteString rhs) -> void {
 {
 (self = ((self) + (rhs)));
@@ -4754,13 +4754,13 @@ ByteString const name = ((field).template get<0>());
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8("return __jakt_uninit_enum;\n"sv)));
+(output,(ByteString::from_utf8_without_validation("return __jakt_uninit_enum;\n"sv)));
 [](ByteString& self, ByteString rhs) -> void {
 {
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8("}\n"sv)));
+(output,(ByteString::from_utf8_without_validation("}\n"sv)));
 }
 
 }
@@ -4788,7 +4788,7 @@ else {
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8("{\n"sv)));
+(output,(ByteString::from_utf8_without_validation("{\n"sv)));
 [](ByteString& self, ByteString rhs) -> void {
 {
 (self = ((self) + (rhs)));
@@ -4800,13 +4800,13 @@ else {
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8("return *this;\n"sv)));
+(output,(ByteString::from_utf8_without_validation("return *this;\n"sv)));
 [](ByteString& self, ByteString rhs) -> void {
 {
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8("}\n"sv)));
+(output,(ByteString::from_utf8_without_validation("}\n"sv)));
 if (is_inside_struct){
 [](ByteString& self, ByteString rhs) -> void {
 {
@@ -4852,7 +4852,7 @@ else {
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8("{\n"sv)));
+(output,(ByteString::from_utf8_without_validation("{\n"sv)));
 [](ByteString& self, ByteString rhs) -> void {
 {
 (self = ((self) + (rhs)));
@@ -4864,13 +4864,13 @@ else {
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8("return *this;\n"sv)));
+(output,(ByteString::from_utf8_without_validation("return *this;\n"sv)));
 [](ByteString& self, ByteString rhs) -> void {
 {
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8("}\n"sv)));
+(output,(ByteString::from_utf8_without_validation("}\n"sv)));
 if (is_inside_struct){
 [](ByteString& self, ByteString rhs) -> void {
 {
@@ -4893,7 +4893,7 @@ else {
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8("{\n"sv)));
+(output,(ByteString::from_utf8_without_validation("{\n"sv)));
 [](ByteString& self, ByteString rhs) -> void {
 {
 (self = ((self) + (rhs)));
@@ -4905,11 +4905,11 @@ else {
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8("}\n"sv)));
+(output,(ByteString::from_utf8_without_validation("}\n"sv)));
 return output;
 }
 else {
-utility::panic((ByteString::must_from_utf8("Out of line constructor cannot be generated for generic enum"sv)));
+utility::panic((ByteString::from_utf8_without_validation("Out of line constructor cannot be generated for generic enum"sv)));
 }
 
 }
@@ -4989,7 +4989,7 @@ auto&& __jakt_match_value = __jakt_match_variant.as.Typed;ByteString const& name
 ids::TypeId const& type_id = __jakt_match_value.type_id;
 return JaktInternal::ExplicitValue(({ Optional<JaktInternal::DynamicArray<JaktInternal::Tuple<ByteString,ByteString>>> __jakt_var_620; {
 JaktInternal::DynamicArray<JaktInternal::Tuple<ByteString,ByteString>> fields = DynamicArray<JaktInternal::Tuple<ByteString,ByteString>>::create_with({});
-((fields).push((Tuple{(ByteString::must_from_utf8("value"sv)), TRY((((*this).codegen_type(type_id))))})));
+((fields).push((Tuple{(ByteString::from_utf8_without_validation("value"sv)), TRY((((*this).codegen_type(type_id))))})));
 __jakt_var_620 = fields; goto __jakt_label_521;
 
 }
@@ -5028,7 +5028,7 @@ return ({
 auto&& __jakt_match_variant = *((((*this).program))->get_type(id));
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 13 /* JaktString */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("ByteString"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("ByteString"sv)));
 };/*case end*/
 case 20 /* GenericInstance */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.GenericInstance;ids::StructId const& id = __jakt_match_value.id;
@@ -5038,7 +5038,7 @@ __jakt_var_621 = ({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<JaktInternal::Optional<ByteString>,JaktInternal::Optional<ByteString>>{
 auto __jakt_enum_value = (((((struct_).record_type)).__jakt_init_index() == 1 /* Class */));
 if (__jakt_enum_value == true) {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("NonnullRefPtr"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("NonnullRefPtr"sv)));
 }
 else if (__jakt_enum_value == false) {
 return JaktInternal::ExplicitValue(((((struct_).name_for_codegen())).as_name_for_use()));
@@ -5061,7 +5061,7 @@ __jakt_var_622 = ({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<JaktInternal::Optional<ByteString>,JaktInternal::Optional<ByteString>>{
 auto __jakt_enum_value = (((((struct_).record_type)).__jakt_init_index() == 1 /* Class */));
 if (__jakt_enum_value == true) {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("NonnullRefPtr"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("NonnullRefPtr"sv)));
 }
 else if (__jakt_enum_value == false) {
 return JaktInternal::ExplicitValue(((((struct_).name_for_codegen())).as_name_for_use()));
@@ -5084,7 +5084,7 @@ __jakt_var_623 = ({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<JaktInternal::Optional<ByteString>,JaktInternal::Optional<ByteString>>{
 auto __jakt_enum_value = (((((struct_).record_type)).__jakt_init_index() == 1 /* Class */));
 if (__jakt_enum_value == true) {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("NonnullRefPtr"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("NonnullRefPtr"sv)));
 }
 else if (__jakt_enum_value == false) {
 return JaktInternal::ExplicitValue(((((struct_).name_for_codegen())).as_name_for_use()));
@@ -5111,7 +5111,7 @@ __jakt_var_624 = ({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<JaktInternal::Optional<ByteString>,JaktInternal::Optional<ByteString>>{
 auto __jakt_enum_value = (((enum_).is_boxed));
 if (__jakt_enum_value == true) {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("NonnullRefPtr"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("NonnullRefPtr"sv)));
 }
 else if (__jakt_enum_value == false) {
 return JaktInternal::ExplicitValue(((enum_).name));
@@ -5134,7 +5134,7 @@ __jakt_var_625 = ({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<JaktInternal::Optional<ByteString>,JaktInternal::Optional<ByteString>>{
 auto __jakt_enum_value = (((enum_).is_boxed));
 if (__jakt_enum_value == true) {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("NonnullRefPtr"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("NonnullRefPtr"sv)));
 }
 else if (__jakt_enum_value == false) {
 return JaktInternal::ExplicitValue(((enum_).name));
@@ -5188,7 +5188,7 @@ size_t const common_field_count = ((((enum_).fields)).size());
 (self = ((self) + (rhs)));
 }
 }
-(((output)),(ByteString::must_from_utf8("switch (this->__jakt_init_index()) {\n"sv)));
+(((output)),(ByteString::from_utf8_without_validation("switch (this->__jakt_init_index()) {\n"sv)));
 {
 JaktInternal::Range<size_t> _magic = (JaktInternal::Range<size_t>{static_cast<size_t>(static_cast<size_t>(0ULL)),static_cast<size_t>(((((enum_).variants)).size()))});
 for (;;){
@@ -5283,7 +5283,7 @@ default: VERIFY_NOT_REACHED();}/*switch end*/
 (self = ((self) + (rhs)));
 }
 }
-(((output)),(ByteString::must_from_utf8("break;\n"sv)));
+(((output)),(ByteString::from_utf8_without_validation("break;\n"sv)));
 }
 
 }
@@ -5294,7 +5294,7 @@ default: VERIFY_NOT_REACHED();}/*switch end*/
 (self = ((self) + (rhs)));
 }
 }
-(((output)),(ByteString::must_from_utf8("}\n"sv)));
+(((output)),(ByteString::from_utf8_without_validation("}\n"sv)));
 }
 }
 
@@ -5305,13 +5305,13 @@ void codegen::CodeGenerator::codegen_enum_destructor_body(types::CheckedEnum con
 (self = ((self) + (rhs)));
 }
 }
-(((output)),(ByteString::must_from_utf8("{\n"sv)));
+(((output)),(ByteString::from_utf8_without_validation("{\n"sv)));
 [](ByteString& self, ByteString rhs) -> void {
 {
 (self = ((self) + (rhs)));
 }
 }
-(((output)),(ByteString::must_from_utf8("if (this->__jakt_variant_index == 0) return;\n"sv)));
+(((output)),(ByteString::from_utf8_without_validation("if (this->__jakt_variant_index == 0) return;\n"sv)));
 size_t const common_field_count = ((((enum_).fields)).size());
 {
 JaktInternal::ArrayIterator<types::CheckedField> _magic = ((((enum_).fields)).iterator());
@@ -5343,26 +5343,26 @@ ByteString const name = (ds.value());
 (self = ((self) + (rhs)));
 }
 }
-(((output)),(ByteString::must_from_utf8("this->__jakt_destroy_variant();\n"sv)));
+(((output)),(ByteString::from_utf8_without_validation("this->__jakt_destroy_variant();\n"sv)));
 [](ByteString& self, ByteString rhs) -> void {
 {
 (self = ((self) + (rhs)));
 }
 }
-(((output)),(ByteString::must_from_utf8("}\n"sv)));
+(((output)),(ByteString::from_utf8_without_validation("}\n"sv)));
 }
 }
 
 ErrorOr<ByteString> codegen::CodeGenerator::codegen_debug_description_getter(types::CheckedStruct const struct_,bool const is_inline) {
 {
-ByteString output = (ByteString::must_from_utf8(""sv));
+ByteString output = (ByteString::from_utf8_without_validation(""sv));
 if (((!(is_inline)) && (!(((((struct_).generic_parameters)).is_empty()))))){
 [](ByteString& self, ByteString rhs) -> void {
 {
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8("template <"sv)));
+(output,(ByteString::from_utf8_without_validation("template <"sv)));
 [](ByteString& self, ByteString rhs) -> void {
 {
 (self = ((self) + (rhs)));
@@ -5374,14 +5374,14 @@ if (((!(is_inline)) && (!(((((struct_).generic_parameters)).is_empty()))))){
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8(">\n"sv)));
+(output,(ByteString::from_utf8_without_validation(">\n"sv)));
 }
 [](ByteString& self, ByteString rhs) -> void {
 {
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8("ByteString "sv)));
+(output,(ByteString::from_utf8_without_validation("ByteString "sv)));
 if ((!(is_inline))){
 [](ByteString& self, ByteString rhs) -> void {
 {
@@ -5394,20 +5394,20 @@ if ((!(is_inline))){
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8("::"sv)));
+(output,(ByteString::from_utf8_without_validation("::"sv)));
 }
 [](ByteString& self, ByteString rhs) -> void {
 {
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8("debug_description() const { "sv)));
+(output,(ByteString::from_utf8_without_validation("debug_description() const { "sv)));
 [](ByteString& self, ByteString rhs) -> void {
 {
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8("auto builder = ByteStringBuilder::create();"sv)));
+(output,(ByteString::from_utf8_without_validation("auto builder = ByteStringBuilder::create();"sv)));
 [](ByteString& self, ByteString rhs) -> void {
 {
 (self = ((self) + (rhs)));
@@ -5419,13 +5419,13 @@ if ((!(is_inline))){
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8("{\n"sv)));
+(output,(ByteString::from_utf8_without_validation("{\n"sv)));
 [](ByteString& self, ByteString rhs) -> void {
 {
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8("JaktInternal::PrettyPrint::ScopedLevelIncrease increase_indent {};\n"sv)));
+(output,(ByteString::from_utf8_without_validation("JaktInternal::PrettyPrint::ScopedLevelIncrease increase_indent {};\n"sv)));
 size_t i = static_cast<size_t>(0ULL);
 {
 JaktInternal::ArrayIterator<types::CheckedField> _magic = ((((struct_).fields)).iterator());
@@ -5442,7 +5442,7 @@ NonnullRefPtr<types::CheckedVariable> const field_var = ((((*this).program))->ge
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8("JaktInternal::PrettyPrint::must_output_indentation(builder);\n"sv)));
+(output,(ByteString::from_utf8_without_validation("JaktInternal::PrettyPrint::must_output_indentation(builder);\n"sv)));
 [](ByteString& self, ByteString rhs) -> void {
 {
 (self = ((self) + (rhs)));
@@ -5455,7 +5455,7 @@ if (TRY((((((*this).program))->is_string(((field_var)->type_id)))))){
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8("\\\"{}\\\""sv)));
+(output,(ByteString::from_utf8_without_validation("\\\"{}\\\""sv)));
 }
 else {
 [](ByteString& self, ByteString rhs) -> void {
@@ -5463,7 +5463,7 @@ else {
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8("{}"sv)));
+(output,(ByteString::from_utf8_without_validation("{}"sv)));
 }
 
 if (((i) != (JaktInternal::checked_sub(((((struct_).fields)).size()),static_cast<size_t>(1ULL))))){
@@ -5472,14 +5472,14 @@ if (((i) != (JaktInternal::checked_sub(((((struct_).fields)).size()),static_cast
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8(", "sv)));
+(output,(ByteString::from_utf8_without_validation(", "sv)));
 }
 [](ByteString& self, ByteString rhs) -> void {
 {
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8("\", "sv)));
+(output,(ByteString::from_utf8_without_validation("\", "sv)));
 [](ByteString& self, ByteString rhs) -> void {
 {
 (self = ((self) + (rhs)));
@@ -5496,10 +5496,10 @@ return JaktInternal::ExplicitValue(({
 auto&& __jakt_match_variant = ((((((*this).program))->get_struct(struct_id))).record_type);
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 1 /* Class */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("*"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("*"sv)));
 };/*case end*/
 default: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8(""sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation(""sv)));
 };/*case end*/
 }/*switch end*/
 }()
@@ -5514,7 +5514,7 @@ return JaktInternal::ExplicitValue((ByteString::must_from_utf8(""sv)));
 }));
 };/*case end*/
 default: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8(""sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation(""sv)));
 };/*case end*/
 }/*switch end*/
 }()
@@ -5532,7 +5532,7 @@ return JaktInternal::ExplicitValue((ByteString::must_from_utf8(""sv)));
 (self = ((self) + (rhs)));
 }
 }
-(output,((((((field_var)->name_for_codegen())).as_name_for_use())) + ((ByteString::must_from_utf8(");\n"sv)))));
+(output,((((((field_var)->name_for_codegen())).as_name_for_use())) + ((ByteString::from_utf8_without_validation(");\n"sv)))));
 ((i++));
 }
 
@@ -5544,39 +5544,39 @@ return JaktInternal::ExplicitValue((ByteString::must_from_utf8(""sv)));
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8("}\n"sv)));
+(output,(ByteString::from_utf8_without_validation("}\n"sv)));
 [](ByteString& self, ByteString rhs) -> void {
 {
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8("builder.append(\")\"sv);"sv)));
+(output,(ByteString::from_utf8_without_validation("builder.append(\")\"sv);"sv)));
 [](ByteString& self, ByteString rhs) -> void {
 {
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8("return builder.to_string();"sv)));
+(output,(ByteString::from_utf8_without_validation("return builder.to_string();"sv)));
 [](ByteString& self, ByteString rhs) -> void {
 {
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8(" }\n"sv)));
+(output,(ByteString::from_utf8_without_validation(" }\n"sv)));
 return output;
 }
 }
 
 ErrorOr<ByteString> codegen::CodeGenerator::codegen_enum_debug_description_getter(types::CheckedEnum const enum_,bool const is_inline) {
 {
-ByteString output = (ByteString::must_from_utf8(""sv));
+ByteString output = (ByteString::from_utf8_without_validation(""sv));
 if (((!(is_inline)) && (!(((((enum_).generic_parameters)).is_empty()))))){
 [](ByteString& self, ByteString rhs) -> void {
 {
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8("template <"sv)));
+(output,(ByteString::from_utf8_without_validation("template <"sv)));
 [](ByteString& self, ByteString rhs) -> void {
 {
 (self = ((self) + (rhs)));
@@ -5588,14 +5588,14 @@ if (((!(is_inline)) && (!(((((enum_).generic_parameters)).is_empty()))))){
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8(">\n"sv)));
+(output,(ByteString::from_utf8_without_validation(">\n"sv)));
 }
 [](ByteString& self, ByteString rhs) -> void {
 {
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8("ByteString "sv)));
+(output,(ByteString::from_utf8_without_validation("ByteString "sv)));
 if ((!(is_inline))){
 [](ByteString& self, ByteString rhs) -> void {
 {
@@ -5608,26 +5608,26 @@ if ((!(is_inline))){
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8("::"sv)));
+(output,(ByteString::from_utf8_without_validation("::"sv)));
 }
 [](ByteString& self, ByteString rhs) -> void {
 {
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8("debug_description() const {\n"sv)));
+(output,(ByteString::from_utf8_without_validation("debug_description() const {\n"sv)));
 [](ByteString& self, ByteString rhs) -> void {
 {
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8("auto builder = ByteStringBuilder::create();\n"sv)));
+(output,(ByteString::from_utf8_without_validation("auto builder = ByteStringBuilder::create();\n"sv)));
 [](ByteString& self, ByteString rhs) -> void {
 {
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8("switch (this->__jakt_init_index()) {"sv)));
+(output,(ByteString::from_utf8_without_validation("switch (this->__jakt_init_index()) {"sv)));
 size_t const common_field_count = ((((enum_).fields)).size());
 {
 JaktInternal::Range<size_t> _magic = (JaktInternal::Range<size_t>{static_cast<size_t>(static_cast<size_t>(0ULL)),static_cast<size_t>(((((enum_).variants)).size()))});
@@ -5670,19 +5670,19 @@ auto&& __jakt_match_value = __jakt_match_variant.as.StructLike;JaktInternal::Dyn
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8("builder.append(\"(\"sv);\n"sv)));
+(output,(ByteString::from_utf8_without_validation("builder.append(\"(\"sv);\n"sv)));
 [](ByteString& self, ByteString rhs) -> void {
 {
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8("{\n"sv)));
+(output,(ByteString::from_utf8_without_validation("{\n"sv)));
 [](ByteString& self, ByteString rhs) -> void {
 {
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8("JaktInternal::PrettyPrint::ScopedLevelIncrease increase_indent {};\n"sv)));
+(output,(ByteString::from_utf8_without_validation("JaktInternal::PrettyPrint::ScopedLevelIncrease increase_indent {};\n"sv)));
 size_t i = static_cast<size_t>(0ULL);
 {
 JaktInternal::ArrayIterator<ids::VarId> _magic = ((fields).iterator());
@@ -5698,7 +5698,7 @@ ids::VarId field = (_magic_value.value());
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8("JaktInternal::PrettyPrint::must_output_indentation(builder);\n"sv)));
+(output,(ByteString::from_utf8_without_validation("JaktInternal::PrettyPrint::must_output_indentation(builder);\n"sv)));
 NonnullRefPtr<types::CheckedVariable> const var = ((((*this).program))->get_variable(field));
 if (TRY((((((*this).program))->is_string(((var)->type_id)))))){
 [](ByteString& self, ByteString rhs) -> void {
@@ -5723,7 +5723,7 @@ if (((i) != (JaktInternal::checked_sub(((fields).size()),static_cast<size_t>(1UL
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8(", "sv)));
+(output,(ByteString::from_utf8_without_validation(", "sv)));
 }
 if ([](size_t const& self, size_t rhs) -> bool {
 {
@@ -5763,13 +5763,13 @@ else {
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8("}\n"sv)));
+(output,(ByteString::from_utf8_without_validation("}\n"sv)));
 [](ByteString& self, ByteString rhs) -> void {
 {
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8("builder.append(\")\"sv);\n"sv)));
+(output,(ByteString::from_utf8_without_validation("builder.append(\")\"sv);\n"sv)));
 }
 return JaktInternal::ExplicitValue<void>();
 };/*case end*/
@@ -5794,7 +5794,7 @@ if (TRY((((((*this).program))->is_string(type_id))))){
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8("builder.appendff(\"(\\\"{}\\\")\", that.value);\n"sv)));
+(output,(ByteString::from_utf8_without_validation("builder.appendff(\"(\\\"{}\\\")\", that.value);\n"sv)));
 }
 else {
 [](ByteString& self, ByteString rhs) -> void {
@@ -5802,7 +5802,7 @@ else {
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8("builder.appendff(\"({})\", that.value);\n"sv)));
+(output,(ByteString::from_utf8_without_validation("builder.appendff(\"({})\", that.value);\n"sv)));
 }
 
 }
@@ -5835,7 +5835,7 @@ return JaktInternal::ExplicitValue<void>();
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8("break;}\n"sv)));
+(output,(ByteString::from_utf8_without_validation("break;}\n"sv)));
 }
 
 }
@@ -5846,16 +5846,16 @@ return JaktInternal::ExplicitValue<void>();
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8("}\nreturn builder.to_string();\n}\n"sv)));
+(output,(ByteString::from_utf8_without_validation("}\nreturn builder.to_string();\n}\n"sv)));
 return output;
 }
 }
 
 ByteString codegen::CodeGenerator::codegen_ak_formatter(ByteString const name,JaktInternal::DynamicArray<ByteString> const generic_parameter_names,ByteString const template_args) {
 {
-ByteString output = (ByteString::must_from_utf8(""sv));
-ByteString const generic_type_args = utility::join(generic_parameter_names,(ByteString::must_from_utf8(", "sv)));
-ByteString qualified_name = (ByteString::must_from_utf8(""sv));
+ByteString output = (ByteString::from_utf8_without_validation(""sv));
+ByteString const generic_type_args = utility::join(generic_parameter_names,(ByteString::from_utf8_without_validation(", "sv)));
+ByteString qualified_name = (ByteString::from_utf8_without_validation(""sv));
 {
 JaktInternal::ArrayIterator<ByteString> _magic = ((((*this).namespace_stack)).iterator());
 for (;;){
@@ -5895,7 +5895,7 @@ if ((!(((generic_parameter_names).is_empty())))){
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8("} // namespace Jakt\n"sv)));
+(output,(ByteString::from_utf8_without_validation("} // namespace Jakt\n"sv)));
 [](ByteString& self, ByteString rhs) -> void {
 {
 (self = ((self) + (rhs)));
@@ -5913,7 +5913,7 @@ if ((!(((generic_parameter_names).is_empty())))){
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8("{\n"sv)));
+(output,(ByteString::from_utf8_without_validation("{\n"sv)));
 [](ByteString& self, ByteString rhs) -> void {
 {
 (self = ((self) + (rhs)));
@@ -5925,32 +5925,32 @@ if ((!(((generic_parameter_names).is_empty())))){
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8("JaktInternal::PrettyPrint::ScopedEnable pretty_print_enable { m_alternative_form };"sv)));
+(output,(ByteString::from_utf8_without_validation("JaktInternal::PrettyPrint::ScopedEnable pretty_print_enable { m_alternative_form };"sv)));
 [](ByteString& self, ByteString rhs) -> void {
 {
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8("Jakt::ErrorOr<void> format_error = Jakt::Formatter<Jakt::StringView>::format(builder, value.debug_description());"sv)));
+(output,(ByteString::from_utf8_without_validation("Jakt::ErrorOr<void> format_error = Jakt::Formatter<Jakt::StringView>::format(builder, value.debug_description());"sv)));
 [](ByteString& self, ByteString rhs) -> void {
 {
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8("return format_error;"sv)));
+(output,(ByteString::from_utf8_without_validation("return format_error;"sv)));
 [](ByteString& self, ByteString rhs) -> void {
 {
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8("}\n"sv)));
+(output,(ByteString::from_utf8_without_validation("}\n"sv)));
 [](ByteString& self, ByteString rhs) -> void {
 {
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8("};\n"sv)));
-return ((output) + ((ByteString::must_from_utf8("namespace Jakt {\n"sv))));
+(output,(ByteString::from_utf8_without_validation("};\n"sv)));
+return ((output) + ((ByteString::from_utf8_without_validation("namespace Jakt {\n"sv))));
 }
 }
 
@@ -6002,7 +6002,7 @@ auto&& __jakt_match_value = __jakt_match_variant.as.Range;JaktInternal::Optional
 JaktInternal::Optional<NonnullRefPtr<typename types::CheckedExpression>> const& to = __jakt_match_value.to;
 ids::TypeId const& type_id = __jakt_match_value.type_id;
 return JaktInternal::ExplicitValue(({ Optional<ByteString> __jakt_var_628; {
-ByteString output = (ByteString::must_from_utf8(""sv));
+ByteString output = (ByteString::from_utf8_without_validation(""sv));
 NonnullRefPtr<typename types::Type> const type = ((((*this).program))->get_type(type_id));
 ids::TypeId const index_type = ({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<ids::TypeId, ErrorOr<ByteString>>{
@@ -6015,7 +6015,7 @@ return JaktInternal::ExplicitValue(((args)[static_cast<i64>(0LL)]));
 };/*case end*/
 default: {
 {
-utility::panic((ByteString::must_from_utf8("Internal error: range expression doesn't have Range type"sv)));
+utility::panic((ByteString::from_utf8_without_validation("Internal error: range expression doesn't have Range type"sv)));
 }
 };/*case end*/
 }/*switch end*/
@@ -6030,7 +6030,7 @@ utility::panic((ByteString::must_from_utf8("Internal error: range expression doe
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8("("sv)));
+(output,(ByteString::from_utf8_without_validation("("sv)));
 [](ByteString& self, ByteString rhs) -> void {
 {
 (self = ((self) + (rhs)));
@@ -6042,13 +6042,13 @@ utility::panic((ByteString::must_from_utf8("Internal error: range expression doe
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8("{"sv)));
+(output,(ByteString::from_utf8_without_validation("{"sv)));
 [](ByteString& self, ByteString rhs) -> void {
 {
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8("static_cast<"sv)));
+(output,(ByteString::from_utf8_without_validation("static_cast<"sv)));
 [](ByteString& self, ByteString rhs) -> void {
 {
 (self = ((self) + (rhs)));
@@ -6060,7 +6060,7 @@ utility::panic((ByteString::must_from_utf8("Internal error: range expression doe
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8(">("sv)));
+(output,(ByteString::from_utf8_without_validation(">("sv)));
 if (((from).has_value())){
 [](ByteString& self, ByteString rhs) -> void {
 {
@@ -6075,7 +6075,7 @@ else {
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8("0LL"sv)));
+(output,(ByteString::from_utf8_without_validation("0LL"sv)));
 }
 
 [](ByteString& self, ByteString rhs) -> void {
@@ -6083,7 +6083,7 @@ else {
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8("),static_cast<"sv)));
+(output,(ByteString::from_utf8_without_validation("),static_cast<"sv)));
 [](ByteString& self, ByteString rhs) -> void {
 {
 (self = ((self) + (rhs)));
@@ -6095,7 +6095,7 @@ else {
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8(">("sv)));
+(output,(ByteString::from_utf8_without_validation(">("sv)));
 if (((to).has_value())){
 [](ByteString& self, ByteString rhs) -> void {
 {
@@ -6110,7 +6110,7 @@ else {
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8("9223372036854775807LL"sv)));
+(output,(ByteString::from_utf8_without_validation("9223372036854775807LL"sv)));
 }
 
 [](ByteString& self, ByteString rhs) -> void {
@@ -6118,41 +6118,41 @@ else {
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8(")})"sv)));
+(output,(ByteString::from_utf8_without_validation(")})"sv)));
 __jakt_var_628 = output; goto __jakt_label_528;
 
 }
 __jakt_label_528:; __jakt_var_628.release_value(); }));
 };/*case end*/
 case 25 /* OptionalNone */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("JaktInternal::OptionalNone()"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("JaktInternal::OptionalNone()"sv)));
 };/*case end*/
 case 26 /* OptionalSome */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.OptionalSome;NonnullRefPtr<typename types::CheckedExpression> const& expr = __jakt_match_value.expr;
 ids::TypeId const& type_id = __jakt_match_value.type_id;
-return JaktInternal::ExplicitValue((((((((((ByteString::must_from_utf8("static_cast<"sv))) + (TRY((((*this).codegen_type(type_id))))))) + ((ByteString::must_from_utf8(">("sv))))) + (TRY((((*this).codegen_expression(expr))))))) + ((ByteString::must_from_utf8(")"sv)))));
+return JaktInternal::ExplicitValue((((((((((ByteString::from_utf8_without_validation("static_cast<"sv))) + (TRY((((*this).codegen_type(type_id))))))) + ((ByteString::from_utf8_without_validation(">("sv))))) + (TRY((((*this).codegen_expression(expr))))))) + ((ByteString::from_utf8_without_validation(")"sv)))));
 };/*case end*/
 case 27 /* ForcedUnwrap */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.ForcedUnwrap;NonnullRefPtr<typename types::CheckedExpression> const& expr = __jakt_match_value.expr;
 ids::TypeId const& type_id = __jakt_match_value.type_id;
-return JaktInternal::ExplicitValue((((((ByteString::must_from_utf8("("sv))) + (TRY((((*this).codegen_expression(expr))))))) + ((ByteString::must_from_utf8(".value())"sv)))));
+return JaktInternal::ExplicitValue((((((ByteString::from_utf8_without_validation("("sv))) + (TRY((((*this).codegen_expression(expr))))))) + ((ByteString::from_utf8_without_validation(".value())"sv)))));
 };/*case end*/
 case 2 /* QuotedString */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.QuotedString;types::CheckedStringLiteral const& val = __jakt_match_value.val;
 return JaktInternal::ExplicitValue(({ Optional<ByteString> __jakt_var_629; {
 ByteString const original_string = ((val).to_string());
-ByteString const escaped_value = ((original_string).replace((ByteString::must_from_utf8("\n"sv)),(ByteString::must_from_utf8("\\n"sv))));
+ByteString const escaped_value = ((original_string).replace((ByteString::from_utf8_without_validation("\n"sv)),(ByteString::from_utf8_without_validation("\\n"sv))));
 __jakt_var_629 = ({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<ByteString,ErrorOr<ByteString>>{
 auto __jakt_enum_value = (((((val).type_id)).equals(types::builtin(types::BuiltinType::JaktString()))));
 if (__jakt_enum_value == true) {
-return JaktInternal::ExplicitValue((((((ByteString::must_from_utf8("Jakt::ByteString(\""sv))) + (escaped_value))) + ((ByteString::must_from_utf8("\"sv)"sv)))));
+return JaktInternal::ExplicitValue((((((ByteString::from_utf8_without_validation("Jakt::ByteString(\""sv))) + (escaped_value))) + ((ByteString::from_utf8_without_validation("\"sv)"sv)))));
 }
 else if (__jakt_enum_value == false) {
 return JaktInternal::ExplicitValue(({ Optional<ByteString> __jakt_var_630; {
-JaktInternal::Optional<JaktInternal::DynamicArray<ids::FunctionId>> const ids = TRY((((((*this).program))->find_functions_with_name_in_scope(((((*this).program))->find_type_scope_id(((val).type_id))),(ByteString::must_from_utf8("from_string_literal"sv)),false,JaktInternal::OptionalNone()))));
+JaktInternal::Optional<JaktInternal::DynamicArray<ids::FunctionId>> const ids = TRY((((((*this).program))->find_functions_with_name_in_scope(((((*this).program))->find_type_scope_id(((val).type_id))),(ByteString::from_utf8_without_validation("from_string_literal"sv)),false,JaktInternal::OptionalNone()))));
 if (((!(((ids).has_value()))) || (((ids.value())).is_empty()))){
-utility::panic((ByteString::must_from_utf8("Internal error: couldn't find a 'from_string_literal' function despite passing typecheck"sv)));
+utility::panic((ByteString::from_utf8_without_validation("Internal error: couldn't find a 'from_string_literal' function despite passing typecheck"sv)));
 }
 ByteString const name = ((((((((*this).program))->get_function((((ids.value()))[static_cast<i64>(0LL)]))))->name_for_codegen())).as_name_for_use());
 ByteString const error_handler = ({
@@ -6162,7 +6162,7 @@ if (__jakt_enum_value == true) {
 return JaktInternal::ExplicitValue(((*this).current_error_handler()));
 }
 else {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8(""sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation(""sv)));
 }
 }());
     if (_jakt_value.is_return())
@@ -6186,15 +6186,15 @@ __jakt_label_529:; __jakt_var_629.release_value(); }));
 };/*case end*/
 case 3 /* ByteConstant */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.ByteConstant;ByteString const& val = __jakt_match_value.val;
-return JaktInternal::ExplicitValue((((((ByteString::must_from_utf8("static_cast<u8>(u8'"sv))) + (val))) + ((ByteString::must_from_utf8("')"sv)))));
+return JaktInternal::ExplicitValue((((((ByteString::from_utf8_without_validation("static_cast<u8>(u8'"sv))) + (val))) + ((ByteString::from_utf8_without_validation("')"sv)))));
 };/*case end*/
 case 5 /* CCharacterConstant */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.CCharacterConstant;ByteString const& val = __jakt_match_value.val;
-return JaktInternal::ExplicitValue((((((ByteString::must_from_utf8("'"sv))) + (val))) + ((ByteString::must_from_utf8("'"sv)))));
+return JaktInternal::ExplicitValue((((((ByteString::from_utf8_without_validation("'"sv))) + (val))) + ((ByteString::from_utf8_without_validation("'"sv)))));
 };/*case end*/
 case 4 /* CharacterConstant */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.CharacterConstant;ByteString const& val = __jakt_match_value.val;
-return JaktInternal::ExplicitValue((((((ByteString::must_from_utf8("static_cast<u32>(U'"sv))) + (val))) + ((ByteString::must_from_utf8("')"sv)))));
+return JaktInternal::ExplicitValue((((((ByteString::from_utf8_without_validation("static_cast<u32>(U'"sv))) + (val))) + ((ByteString::from_utf8_without_validation("')"sv)))));
 };/*case end*/
 case 24 /* Var */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Var;NonnullRefPtr<types::CheckedVariable> const& var = __jakt_match_value.var;
@@ -6203,8 +6203,8 @@ ByteString const name = ((((var)->name_for_codegen())).as_name_for_use());
 __jakt_var_631 = ({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<ByteString,ErrorOr<ByteString>>{
 auto __jakt_enum_value = (name);
-if (__jakt_enum_value == (ByteString::must_from_utf8("this"sv))) {
-return JaktInternal::ExplicitValue(TRY((((*this).this_replacement).try_value_or_lazy_evaluated([&]() -> ErrorOr<ByteString> { return (ByteString::must_from_utf8("*this"sv)); }))));
+if (__jakt_enum_value == (ByteString::from_utf8_without_validation("this"sv))) {
+return JaktInternal::ExplicitValue(TRY((((*this).this_replacement).try_value_or_lazy_evaluated([&]() -> ErrorOr<ByteString> { return (ByteString::from_utf8_without_validation("*this"sv)); }))));
 }
 else {
 return JaktInternal::ExplicitValue(name);
@@ -6221,12 +6221,12 @@ __jakt_label_531:; __jakt_var_631.release_value(); }));
 case 13 /* IndexedExpression */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.IndexedExpression;NonnullRefPtr<typename types::CheckedExpression> const& expr = __jakt_match_value.expr;
 NonnullRefPtr<typename types::CheckedExpression> const& index = __jakt_match_value.index;
-return JaktInternal::ExplicitValue((((((((((ByteString::must_from_utf8("(("sv))) + (TRY((((*this).codegen_expression(expr))))))) + ((ByteString::must_from_utf8(")["sv))))) + (TRY((((*this).codegen_expression(index))))))) + ((ByteString::must_from_utf8("])"sv)))));
+return JaktInternal::ExplicitValue((((((((((ByteString::from_utf8_without_validation("(("sv))) + (TRY((((*this).codegen_expression(expr))))))) + ((ByteString::from_utf8_without_validation(")["sv))))) + (TRY((((*this).codegen_expression(index))))))) + ((ByteString::from_utf8_without_validation("])"sv)))));
 };/*case end*/
 case 14 /* IndexedDictionary */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.IndexedDictionary;NonnullRefPtr<typename types::CheckedExpression> const& expr = __jakt_match_value.expr;
 NonnullRefPtr<typename types::CheckedExpression> const& index = __jakt_match_value.index;
-return JaktInternal::ExplicitValue((((((((((ByteString::must_from_utf8("(("sv))) + (TRY((((*this).codegen_expression(expr))))))) + ((ByteString::must_from_utf8(")["sv))))) + (TRY((((*this).codegen_expression(index))))))) + ((ByteString::must_from_utf8("])"sv)))));
+return JaktInternal::ExplicitValue((((((((((ByteString::from_utf8_without_validation("(("sv))) + (TRY((((*this).codegen_expression(expr))))))) + ((ByteString::from_utf8_without_validation(")["sv))))) + (TRY((((*this).codegen_expression(index))))))) + ((ByteString::from_utf8_without_validation("])"sv)))));
 };/*case end*/
 case 15 /* IndexedTuple */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.IndexedTuple;NonnullRefPtr<typename types::CheckedExpression> const& expr = __jakt_match_value.expr;
@@ -6254,14 +6254,14 @@ ByteString const& name = __jakt_match_value.name;
 JaktInternal::Optional<ids::VarId> const& index = __jakt_match_value.index;
 bool const& is_optional = __jakt_match_value.is_optional;
 return JaktInternal::ExplicitValue(({ Optional<ByteString> __jakt_var_632; {
-ByteString output = (ByteString::must_from_utf8(""sv));
+ByteString output = (ByteString::from_utf8_without_validation(""sv));
 ByteString const object = TRY((((*this).codegen_expression(expr))));
 [](ByteString& self, ByteString rhs) -> void {
 {
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8("(("sv)));
+(output,(ByteString::from_utf8_without_validation("(("sv)));
 [](ByteString& self, ByteString rhs) -> void {
 {
 (self = ((self) + (rhs)));
@@ -6273,7 +6273,7 @@ ByteString const object = TRY((((*this).codegen_expression(expr))));
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8(")"sv)));
+(output,(ByteString::from_utf8_without_validation(")"sv)));
 ByteString const var_name = ({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<ByteString,ErrorOr<ByteString>>{
 auto __jakt_enum_value = (((index).has_value()));
@@ -6301,7 +6301,7 @@ case 26 /* RawPtr */: {
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8("->"sv)));
+(output,(ByteString::from_utf8_without_validation("->"sv)));
 }
 return JaktInternal::ExplicitValue<void>();
 };/*case end*/
@@ -6314,13 +6314,13 @@ if ((((((structure).record_type)).__jakt_init_index() == 1 /* Class */) && [](By
 return (!(((self) == (rhs))));
 }
 }
-(object,(ByteString::must_from_utf8("*this"sv))))){
+(object,(ByteString::from_utf8_without_validation("*this"sv))))){
 [](ByteString& self, ByteString rhs) -> void {
 {
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8("->"sv)));
+(output,(ByteString::from_utf8_without_validation("->"sv)));
 }
 else {
 [](ByteString& self, ByteString rhs) -> void {
@@ -6328,7 +6328,7 @@ else {
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8("."sv)));
+(output,(ByteString::from_utf8_without_validation("."sv)));
 }
 
 }
@@ -6343,13 +6343,13 @@ if ((((((structure).record_type)).__jakt_init_index() == 1 /* Class */) && [](By
 return (!(((self) == (rhs))));
 }
 }
-(object,(ByteString::must_from_utf8("*this"sv))))){
+(object,(ByteString::from_utf8_without_validation("*this"sv))))){
 [](ByteString& self, ByteString rhs) -> void {
 {
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8("->"sv)));
+(output,(ByteString::from_utf8_without_validation("->"sv)));
 }
 else {
 [](ByteString& self, ByteString rhs) -> void {
@@ -6357,7 +6357,7 @@ else {
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8("."sv)));
+(output,(ByteString::from_utf8_without_validation("."sv)));
 }
 
 }
@@ -6370,7 +6370,7 @@ default: {
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8("."sv)));
+(output,(ByteString::from_utf8_without_validation("."sv)));
 }
 return JaktInternal::ExplicitValue<void>();
 };/*case end*/
@@ -6387,8 +6387,8 @@ if (is_optional){
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8("map([](auto& _value) { return _value"sv)));
-ByteString access_operator = (ByteString::must_from_utf8("."sv));
+(output,(ByteString::from_utf8_without_validation("map([](auto& _value) { return _value"sv)));
+ByteString access_operator = (ByteString::from_utf8_without_validation("."sv));
 if (((expression_type)->__jakt_init_index() == 20 /* GenericInstance */)){
 JaktInternal::DynamicArray<ids::TypeId> const args = (expression_type)->as.GenericInstance.args;
 if ([](size_t const& self, size_t rhs) -> bool {
@@ -6410,7 +6410,7 @@ case 24 /* Struct */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Struct;ids::StructId const& id = __jakt_match_value.value;
 {
 if (((((((((*this).program))->get_struct(id))).record_type)).__jakt_init_index() == 1 /* Class */)){
-(access_operator = (ByteString::must_from_utf8("->"sv)));
+(access_operator = (ByteString::from_utf8_without_validation("->"sv)));
 }
 }
 return JaktInternal::ExplicitValue<void>();
@@ -6419,7 +6419,7 @@ case 20 /* GenericInstance */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.GenericInstance;ids::StructId const& id = __jakt_match_value.id;
 {
 if (((((((((*this).program))->get_struct(id))).record_type)).__jakt_init_index() == 1 /* Class */)){
-(access_operator = (ByteString::must_from_utf8("->"sv)));
+(access_operator = (ByteString::from_utf8_without_validation("->"sv)));
 }
 }
 return JaktInternal::ExplicitValue<void>();
@@ -6455,7 +6455,7 @@ return JaktInternal::ExplicitValue<void>();
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8("; })"sv)));
+(output,(ByteString::from_utf8_without_validation("; })"sv)));
 }
 else {
 [](ByteString& self, ByteString rhs) -> void {
@@ -6471,7 +6471,7 @@ else {
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8(")"sv)));
+(output,(ByteString::from_utf8_without_validation(")"sv)));
 __jakt_var_632 = output; goto __jakt_label_532;
 
 }
@@ -6482,14 +6482,14 @@ auto&& __jakt_match_value = __jakt_match_variant.as.IndexedCommonEnumMember;Nonn
 ByteString const& index = __jakt_match_value.index;
 bool const& is_optional = __jakt_match_value.is_optional;
 return JaktInternal::ExplicitValue(({ Optional<ByteString> __jakt_var_633; {
-ByteString output = (ByteString::must_from_utf8(""sv));
+ByteString output = (ByteString::from_utf8_without_validation(""sv));
 ByteString const object = TRY((((*this).codegen_expression(expr))));
 [](ByteString& self, ByteString rhs) -> void {
 {
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8("(("sv)));
+(output,(ByteString::from_utf8_without_validation("(("sv)));
 [](ByteString& self, ByteString rhs) -> void {
 {
 (self = ((self) + (rhs)));
@@ -6501,7 +6501,7 @@ ByteString const object = TRY((((*this).codegen_expression(expr))));
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8(")"sv)));
+(output,(ByteString::from_utf8_without_validation(")"sv)));
 ({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<void, ErrorOr<ByteString>>{
 auto&& __jakt_match_variant = *((((*this).program))->get_type(((expr)->type())));
@@ -6513,7 +6513,7 @@ case 26 /* RawPtr */: {
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8("->"sv)));
+(output,(ByteString::from_utf8_without_validation("->"sv)));
 }
 return JaktInternal::ExplicitValue<void>();
 };/*case end*/
@@ -6528,13 +6528,13 @@ if ((is_boxed && [](ByteString const& self, ByteString rhs) -> bool {
 return (!(((self) == (rhs))));
 }
 }
-(object,(ByteString::must_from_utf8("*this"sv))))){
+(object,(ByteString::from_utf8_without_validation("*this"sv))))){
 [](ByteString& self, ByteString rhs) -> void {
 {
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8("->common.init_common."sv)));
+(output,(ByteString::from_utf8_without_validation("->common.init_common."sv)));
 }
 else {
 [](ByteString& self, ByteString rhs) -> void {
@@ -6542,7 +6542,7 @@ else {
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8(".common.init_common."sv)));
+(output,(ByteString::from_utf8_without_validation(".common.init_common."sv)));
 }
 
 }
@@ -6552,7 +6552,7 @@ else {
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8(".common.init_common."sv)));
+(output,(ByteString::from_utf8_without_validation(".common.init_common."sv)));
 }
 
 }
@@ -6569,13 +6569,13 @@ if ((is_boxed && [](ByteString const& self, ByteString rhs) -> bool {
 return (!(((self) == (rhs))));
 }
 }
-(object,(ByteString::must_from_utf8("*this"sv))))){
+(object,(ByteString::from_utf8_without_validation("*this"sv))))){
 [](ByteString& self, ByteString rhs) -> void {
 {
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8("->common.init_common."sv)));
+(output,(ByteString::from_utf8_without_validation("->common.init_common."sv)));
 }
 else {
 [](ByteString& self, ByteString rhs) -> void {
@@ -6583,7 +6583,7 @@ else {
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8(".common.init_common."sv)));
+(output,(ByteString::from_utf8_without_validation(".common.init_common."sv)));
 }
 
 }
@@ -6593,7 +6593,7 @@ else {
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8(".common.init_common."sv)));
+(output,(ByteString::from_utf8_without_validation(".common.init_common."sv)));
 }
 
 }
@@ -6606,7 +6606,7 @@ default: {
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8("."sv)));
+(output,(ByteString::from_utf8_without_validation("."sv)));
 }
 return JaktInternal::ExplicitValue<void>();
 };/*case end*/
@@ -6623,7 +6623,7 @@ if (is_optional){
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8("map([](auto& _value) { return _value."sv)));
+(output,(ByteString::from_utf8_without_validation("map([](auto& _value) { return _value."sv)));
 [](ByteString& self, ByteString rhs) -> void {
 {
 (self = ((self) + (rhs)));
@@ -6635,7 +6635,7 @@ if (is_optional){
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8("; })"sv)));
+(output,(ByteString::from_utf8_without_validation("; })"sv)));
 }
 else {
 [](ByteString& self, ByteString rhs) -> void {
@@ -6651,7 +6651,7 @@ else {
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8(")"sv)));
+(output,(ByteString::from_utf8_without_validation(")"sv)));
 __jakt_var_633 = output; goto __jakt_label_533;
 
 }
@@ -6659,7 +6659,7 @@ __jakt_label_533:; __jakt_var_633.release_value(); }));
 };/*case end*/
 case 18 /* ComptimeIndex */: {
 {
-utility::panic((ByteString::must_from_utf8("Internal error: ComptimeIndex should have been replaced by now"sv)));
+utility::panic((ByteString::from_utf8_without_validation("Internal error: ComptimeIndex should have been replaced by now"sv)));
 }
 };/*case end*/
 case 28 /* Block */: {
@@ -6682,10 +6682,10 @@ return JaktInternal::ExplicitValue(({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<ByteString,ErrorOr<ByteString>>{
 auto __jakt_enum_value = (val);
 if (__jakt_enum_value == true) {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("true"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("true"sv)));
 }
 else {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("false"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("false"sv)));
 }
 }());
     if (_jakt_value.is_return())
@@ -6698,7 +6698,7 @@ auto&& __jakt_match_value = __jakt_match_variant.as.UnaryOp;NonnullRefPtr<typena
 types::CheckedUnaryOperator const& op = __jakt_match_value.op;
 ids::TypeId const& type_id = __jakt_match_value.type_id;
 return JaktInternal::ExplicitValue(({ Optional<ByteString> __jakt_var_634; {
-ByteString output = (ByteString::must_from_utf8("("sv));
+ByteString output = (ByteString::from_utf8_without_validation("("sv));
 [](ByteString& self, ByteString rhs) -> void {
 {
 (self = ((self) + (rhs)));
@@ -6709,13 +6709,13 @@ ByteString output = (ByteString::must_from_utf8("("sv));
 auto&& __jakt_match_variant = op;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 0 /* PreIncrement */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("++"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("++"sv)));
 };/*case end*/
 case 2 /* PreDecrement */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("--"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("--"sv)));
 };/*case end*/
 case 4 /* Negate */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("-"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("-"sv)));
 };/*case end*/
 case 5 /* Dereference */: {
 return JaktInternal::ExplicitValue(({
@@ -6723,10 +6723,10 @@ return JaktInternal::ExplicitValue(({
 auto&& __jakt_match_variant = *((((*this).program))->get_type(((expr)->type())));
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 26 /* RawPtr */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("*"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("*"sv)));
 };/*case end*/
 default: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8(""sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation(""sv)));
 };/*case end*/
 }/*switch end*/
 }()
@@ -6741,10 +6741,10 @@ return JaktInternal::ExplicitValue(({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<ByteString,ErrorOr<ByteString>>{
 auto __jakt_enum_value = (((((((*this).program))->get_type(((expr)->type()))))->is_boxed(((*this).program))));
 if (__jakt_enum_value == true) {
-return JaktInternal::ExplicitValue((((((((ByteString::must_from_utf8("const_cast<"sv))) + (TRY((((*this).codegen_type_possibly_as_namespace(type_id,true))))))) + ((ByteString::must_from_utf8(">("sv))))) + ((ByteString::must_from_utf8("&*"sv)))));
+return JaktInternal::ExplicitValue((((((((ByteString::from_utf8_without_validation("const_cast<"sv))) + (TRY((((*this).codegen_type_possibly_as_namespace(type_id,true))))))) + ((ByteString::from_utf8_without_validation(">("sv))))) + ((ByteString::from_utf8_without_validation("&*"sv)))));
 }
 else if (__jakt_enum_value == false) {
-return JaktInternal::ExplicitValue((((((((ByteString::must_from_utf8("const_cast<"sv))) + (TRY((((*this).codegen_type(type_id))))))) + ((ByteString::must_from_utf8(">("sv))))) + ((ByteString::must_from_utf8("&"sv)))));
+return JaktInternal::ExplicitValue((((((((ByteString::from_utf8_without_validation("const_cast<"sv))) + (TRY((((*this).codegen_type(type_id))))))) + ((ByteString::from_utf8_without_validation(">("sv))))) + ((ByteString::from_utf8_without_validation("&"sv)))));
 }
 VERIFY_NOT_REACHED();
 }());
@@ -6754,13 +6754,13 @@ VERIFY_NOT_REACHED();
 }));
 };/*case end*/
 case 9 /* LogicalNot */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("!"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("!"sv)));
 };/*case end*/
 case 10 /* BitwiseNot */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("~"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("~"sv)));
 };/*case end*/
 case 16 /* Sizeof */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("sizeof"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("sizeof"sv)));
 };/*case end*/
 case 12 /* Is */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Is;ids::TypeId const& type_id = __jakt_match_value.value;
@@ -6788,13 +6788,13 @@ return JaktInternal::ExplicitValue(TRY((((*this).codegen_type(type_id)))));
         return _jakt_value.release_return();
     _jakt_value.release_value();
 });
-__jakt_var_635 = (((((ByteString::must_from_utf8("is<"sv))) + (is_type))) + ((ByteString::must_from_utf8(">("sv)))); goto __jakt_label_535;
+__jakt_var_635 = (((((ByteString::from_utf8_without_validation("is<"sv))) + (is_type))) + ((ByteString::from_utf8_without_validation(">("sv)))); goto __jakt_label_535;
 
 }
 __jakt_label_535:; __jakt_var_635.release_value(); }));
 };/*case end*/
 case 15 /* IsNone */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("!"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("!"sv)));
 };/*case end*/
 case 11 /* TypeCast */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.TypeCast;types::CheckedTypeCast const& cast = __jakt_match_value.value;
@@ -6817,7 +6817,7 @@ return JaktInternal::ExplicitValue(((args)[static_cast<i64>(0LL)]));
 };/*case end*/
 default: {
 {
-utility::panic((ByteString::must_from_utf8("Fallible type cast must have Optional result."sv)));
+utility::panic((ByteString::from_utf8_without_validation("Fallible type cast must have Optional result."sv)));
 }
 };/*case end*/
 }/*switch end*/
@@ -6827,21 +6827,21 @@ utility::panic((ByteString::must_from_utf8("Fallible type cast must have Optiona
         return _jakt_value.release_return();
     _jakt_value.release_value();
 });
-ByteString cast_type = (ByteString::must_from_utf8("dynamic_cast"sv));
+ByteString cast_type = (ByteString::from_utf8_without_validation("dynamic_cast"sv));
 if (((((((*this).program))->get_type(type_id)))->__jakt_init_index() == 24 /* Struct */)){
 ids::StructId const struct_id = (((((*this).program))->get_type(type_id)))->as.Struct.value;
 if (((((((((*this).program))->get_struct(struct_id))).record_type)).__jakt_init_index() == 1 /* Class */)){
 (final_type_id = type_id);
-(cast_type = (ByteString::must_from_utf8("fallible_class_cast"sv)));
+(cast_type = (ByteString::from_utf8_without_validation("fallible_class_cast"sv)));
 }
 else if (((((*this).program))->is_integer(type_id))){
 (final_type_id = type_id);
-(cast_type = (ByteString::must_from_utf8("fallible_integer_cast"sv)));
+(cast_type = (ByteString::from_utf8_without_validation("fallible_integer_cast"sv)));
 }
 }
 else if (((((*this).program))->is_integer(type_id))){
 (final_type_id = type_id);
-(cast_type = (ByteString::must_from_utf8("fallible_integer_cast"sv)));
+(cast_type = (ByteString::from_utf8_without_validation("fallible_integer_cast"sv)));
 }
 __jakt_var_638 = cast_type; goto __jakt_label_538;
 
@@ -6850,29 +6850,29 @@ __jakt_label_538:; __jakt_var_638.release_value(); }));
 };/*case end*/
 case 1 /* Infallible */: {
 return JaktInternal::ExplicitValue(({ Optional<ByteString> __jakt_var_639; {
-ByteString cast_type = (ByteString::must_from_utf8("verify_cast"sv));
+ByteString cast_type = (ByteString::from_utf8_without_validation("verify_cast"sv));
 if (((((expr)->type())).equals(types::unknown_type_id()))){
-(cast_type = (ByteString::must_from_utf8("assert_type"sv)));
+(cast_type = (ByteString::from_utf8_without_validation("assert_type"sv)));
 }
 else if (((type)->is_boxed(((*this).program)))){
-(cast_type = (ByteString::must_from_utf8("infallible_class_cast"sv)));
+(cast_type = (ByteString::from_utf8_without_validation("infallible_class_cast"sv)));
 }
 else if (((((*this).program))->is_integer(type_id))){
-(cast_type = (ByteString::must_from_utf8("infallible_integer_cast"sv)));
+(cast_type = (ByteString::from_utf8_without_validation("infallible_integer_cast"sv)));
 }
 else if (((type)->__jakt_init_index() == 25 /* Enum */)){
 ids::EnumId const enum_id = (type)->as.Enum.value;
 if (((((*this).program))->is_integer(((((((*this).program))->get_enum(enum_id))).underlying_type_id)))){
-(cast_type = (ByteString::must_from_utf8("infallible_enum_cast"sv)));
+(cast_type = (ByteString::from_utf8_without_validation("infallible_enum_cast"sv)));
 }
 else if (((type)->__jakt_init_index() == 26 /* RawPtr */)){
 ids::TypeId const inner = (type)->as.RawPtr.value;
-(cast_type = (ByteString::must_from_utf8("reinterpret_cast"sv)));
+(cast_type = (ByteString::from_utf8_without_validation("reinterpret_cast"sv)));
 }
 }
 else if (((type)->__jakt_init_index() == 26 /* RawPtr */)){
 ids::TypeId const inner = (type)->as.RawPtr.value;
-(cast_type = (ByteString::must_from_utf8("reinterpret_cast"sv)));
+(cast_type = (ByteString::from_utf8_without_validation("reinterpret_cast"sv)));
 }
 __jakt_var_639 = cast_type; goto __jakt_label_539;
 
@@ -6886,13 +6886,13 @@ default: VERIFY_NOT_REACHED();}/*switch end*/
         return _jakt_value.release_return();
     _jakt_value.release_value();
 });
-__jakt_var_637 = ((((((cast_type) + ((ByteString::must_from_utf8("<"sv))))) + (TRY((((*this).codegen_type(final_type_id))))))) + ((ByteString::must_from_utf8(">("sv)))); goto __jakt_label_537;
+__jakt_var_637 = ((((((cast_type) + ((ByteString::from_utf8_without_validation("<"sv))))) + (TRY((((*this).codegen_type(final_type_id))))))) + ((ByteString::from_utf8_without_validation(">("sv)))); goto __jakt_label_537;
 
 }
 __jakt_label_537:; __jakt_var_637.release_value(); }));
 };/*case end*/
 default: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8(""sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation(""sv)));
 };/*case end*/
 }/*switch end*/
 }()
@@ -6906,7 +6906,7 @@ return JaktInternal::ExplicitValue((ByteString::must_from_utf8(""sv)));
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8("("sv)));
+(output,(ByteString::from_utf8_without_validation("("sv)));
 ByteString const object = ({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<ByteString, ErrorOr<ByteString>>{
 auto&& __jakt_match_variant = op;
@@ -6941,23 +6941,23 @@ return JaktInternal::ExplicitValue(TRY((((*this).codegen_expression(expr)))));
 auto&& __jakt_match_variant = op;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 1 /* PostIncrement */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("++)"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("++)"sv)));
 };/*case end*/
 case 3 /* PostDecrement */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("--)"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("--)"sv)));
 };/*case end*/
 case 11 /* TypeCast */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("))"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("))"sv)));
 };/*case end*/
 case 12 /* Is */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("))"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("))"sv)));
 };/*case end*/
 case 13 /* IsEnumVariant */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.IsEnumVariant;types::CheckedEnumVariant const& enum_variant = __jakt_match_value.enum_variant;
 ids::TypeId const& enum_type_id = __jakt_match_value.type_id;
 return JaktInternal::ExplicitValue(({ Optional<ByteString> __jakt_var_640; {
 ByteString const name = ((enum_variant).name());
-ByteString suffix = (ByteString::must_from_utf8(")"sv));
+ByteString suffix = (ByteString::from_utf8_without_validation(")"sv));
 types::CheckedEnum const enum_ = ((((*this).program))->get_enum(({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<ids::EnumId, ErrorOr<ByteString>>{
 auto&& __jakt_match_variant = *((((*this).program))->get_type(enum_type_id));
@@ -6994,13 +6994,13 @@ if ((is_boxed && [](ByteString const& self, ByteString rhs) -> bool {
 return (!(((self) == (rhs))));
 }
 }
-(object,(ByteString::must_from_utf8("*this"sv))))){
+(object,(ByteString::from_utf8_without_validation("*this"sv))))){
 [](ByteString& self, ByteString rhs) -> void {
 {
 (self = ((self) + (rhs)));
 }
 }
-(suffix,(ByteString::must_from_utf8("->"sv)));
+(suffix,(ByteString::from_utf8_without_validation("->"sv)));
 }
 else {
 [](ByteString& self, ByteString rhs) -> void {
@@ -7008,7 +7008,7 @@ else {
 (self = ((self) + (rhs)));
 }
 }
-(suffix,(ByteString::must_from_utf8("."sv)));
+(suffix,(ByteString::from_utf8_without_validation("."sv)));
 }
 
 i64 variant_index = static_cast<i64>(0LL);
@@ -7069,16 +7069,16 @@ __jakt_var_640 = suffix; goto __jakt_label_540;
 __jakt_label_540:; __jakt_var_640.release_value(); }));
 };/*case end*/
 case 14 /* IsSome */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8(").has_value()"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation(").has_value()"sv)));
 };/*case end*/
 case 15 /* IsNone */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8(").has_value()"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation(").has_value()"sv)));
 };/*case end*/
 case 6 /* RawAddress */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("))"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("))"sv)));
 };/*case end*/
 default: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8(")"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation(")"sv)));
 };/*case end*/
 }/*switch end*/
 }()
@@ -7092,7 +7092,7 @@ return JaktInternal::ExplicitValue((ByteString::must_from_utf8(")"sv)));
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8(")"sv)));
+(output,(ByteString::from_utf8_without_validation(")"sv)));
 __jakt_var_634 = output; goto __jakt_label_534;
 
 }
@@ -7114,16 +7114,16 @@ ByteString const suffix = ({
 auto&& __jakt_match_variant = val;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 3 /* I64 */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("LL"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("LL"sv)));
 };/*case end*/
 case 7 /* U64 */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("ULL"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("ULL"sv)));
 };/*case end*/
 case 8 /* USize */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("ULL"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("ULL"sv)));
 };/*case end*/
 default: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8(""sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation(""sv)));
 };/*case end*/
 }/*switch end*/
 }()
@@ -7137,7 +7137,7 @@ ByteString const type_name = ({
 auto&& __jakt_match_variant = val;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 8 /* USize */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("size_t"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("size_t"sv)));
 };/*case end*/
 default: {
 return JaktInternal::ExplicitValue(TRY((((*this).codegen_type(type_id)))));
@@ -7212,7 +7212,7 @@ case 23 /* NamespacedVar */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.NamespacedVar;JaktInternal::DynamicArray<types::CheckedNamespace> const& namespaces = __jakt_match_value.namespaces;
 NonnullRefPtr<types::CheckedVariable> const& var = __jakt_match_value.var;
 return JaktInternal::ExplicitValue(({ Optional<ByteString> __jakt_var_642; {
-ByteString output = (ByteString::must_from_utf8(""sv));
+ByteString output = (ByteString::from_utf8_without_validation(""sv));
 if (((((var)->name_for_codegen())).is_scopable())){
 if (((((var)->owner_scope)).has_value())){
 (output = TRY((((*this).codegen_namespace_qualifier((((var)->owner_scope).value()),false,JaktInternal::OptionalNone(),JaktInternal::OptionalNone())))));
@@ -7232,7 +7232,7 @@ types::CheckedNamespace ns = (_magic_value.value());
 (self = ((self) + (rhs)));
 }
 }
-(output,((((ns).name)) + ((ByteString::must_from_utf8("::"sv)))));
+(output,((((ns).name)) + ((ByteString::from_utf8_without_validation("::"sv)))));
 }
 
 }
@@ -7261,7 +7261,7 @@ return JaktInternal::ExplicitValue(({ Optional<ByteString> __jakt_var_643; {
 ByteString const var_name = TRY((((*this).codegen_expression(expr))));
 ByteString const enum_type = TRY((((*this).codegen_type_possibly_as_namespace(((expr)->type()),true))));
 ByteString const variant_name = ((enum_variant).name());
-ByteString arg_name = (ByteString::must_from_utf8("value"sv));
+ByteString arg_name = (ByteString::from_utf8_without_validation("value"sv));
 if (((enum_variant).__jakt_init_index() == 3 /* StructLike */)){
 (arg_name = ((arg).name).value_or_lazy_evaluated([&] { return ((arg).binding); }));
 }
@@ -7270,10 +7270,10 @@ ByteString const cpp_deref_operator = ({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<ByteString,ErrorOr<ByteString>>{
 auto __jakt_enum_value = (((enum_).is_boxed));
 if (__jakt_enum_value == true) {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("->"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("->"sv)));
 }
 else {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("."sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("."sv)));
 }
 }());
     if (_jakt_value.is_return())
@@ -7292,7 +7292,7 @@ types::CheckedField field = (_magic_value.value());
 {
 ByteString const field_name = ((((((((*this).program))->get_variable(((field).variable_id))))->name_for_codegen())).as_name_for_use());
 if (((field_name) == (arg_name))){
-(section = (ByteString::must_from_utf8("common.init_common"sv)));
+(section = (ByteString::from_utf8_without_validation("common.init_common"sv)));
 }
 }
 
@@ -7311,7 +7311,7 @@ utility::Span const& span = __jakt_match_value.span;
 ids::TypeId const& type_id = __jakt_match_value.type_id;
 ids::TypeId const& inner_type_id = __jakt_match_value.inner_type_id;
 return JaktInternal::ExplicitValue(({ Optional<ByteString> __jakt_var_644; {
-ByteString output = (ByteString::must_from_utf8(""sv));
+ByteString output = (ByteString::from_utf8_without_validation(""sv));
 if (((repeat).has_value())){
 NonnullRefPtr<typename types::CheckedExpression> const repeat_val = ((repeat).value());
 [](ByteString& self, ByteString rhs) -> void {
@@ -7319,7 +7319,7 @@ NonnullRefPtr<typename types::CheckedExpression> const repeat_val = ((repeat).va
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8("DynamicArray<"sv)));
+(output,(ByteString::from_utf8_without_validation("DynamicArray<"sv)));
 [](ByteString& self, ByteString rhs) -> void {
 {
 (self = ((self) + (rhs)));
@@ -7331,7 +7331,7 @@ NonnullRefPtr<typename types::CheckedExpression> const repeat_val = ((repeat).va
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8(">::filled("sv)));
+(output,(ByteString::from_utf8_without_validation(">::filled("sv)));
 [](ByteString& self, ByteString rhs) -> void {
 {
 (self = ((self) + (rhs)));
@@ -7343,7 +7343,7 @@ NonnullRefPtr<typename types::CheckedExpression> const repeat_val = ((repeat).va
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8(", "sv)));
+(output,(ByteString::from_utf8_without_validation(", "sv)));
 [](ByteString& self, ByteString rhs) -> void {
 {
 (self = ((self) + (rhs)));
@@ -7355,7 +7355,7 @@ NonnullRefPtr<typename types::CheckedExpression> const repeat_val = ((repeat).va
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8(")"sv)));
+(output,(ByteString::from_utf8_without_validation(")"sv)));
 }
 else {
 [](ByteString& self, ByteString rhs) -> void {
@@ -7363,7 +7363,7 @@ else {
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8("DynamicArray<"sv)));
+(output,(ByteString::from_utf8_without_validation("DynamicArray<"sv)));
 [](ByteString& self, ByteString rhs) -> void {
 {
 (self = ((self) + (rhs)));
@@ -7375,7 +7375,7 @@ else {
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8(">::create_with({"sv)));
+(output,(ByteString::from_utf8_without_validation(">::create_with({"sv)));
 bool first = true;
 {
 JaktInternal::ArrayIterator<NonnullRefPtr<typename types::CheckedExpression>> _magic = ((vals).iterator());
@@ -7392,7 +7392,7 @@ if ((!(first))){
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8(", "sv)));
+(output,(ByteString::from_utf8_without_validation(", "sv)));
 }
 else {
 (first = false);
@@ -7414,7 +7414,7 @@ else {
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8("})"sv)));
+(output,(ByteString::from_utf8_without_validation("})"sv)));
 }
 
 __jakt_var_644 = output; goto __jakt_label_544;
@@ -7450,7 +7450,7 @@ if ((!(first))){
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8(", "sv)));
+(output,(ByteString::from_utf8_without_validation(", "sv)));
 }
 else {
 (first = false);
@@ -7461,7 +7461,7 @@ else {
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8("{"sv)));
+(output,(ByteString::from_utf8_without_validation("{"sv)));
 [](ByteString& self, ByteString rhs) -> void {
 {
 (self = ((self) + (rhs)));
@@ -7473,7 +7473,7 @@ else {
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8(", "sv)));
+(output,(ByteString::from_utf8_without_validation(", "sv)));
 [](ByteString& self, ByteString rhs) -> void {
 {
 (self = ((self) + (rhs)));
@@ -7485,7 +7485,7 @@ else {
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8("}"sv)));
+(output,(ByteString::from_utf8_without_validation("}"sv)));
 }
 
 }
@@ -7496,7 +7496,7 @@ else {
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8("})"sv)));
+(output,(ByteString::from_utf8_without_validation("})"sv)));
 __jakt_var_645 = output; goto __jakt_label_545;
 
 }
@@ -7508,7 +7508,7 @@ utility::Span const& span = __jakt_match_value.span;
 ids::TypeId const& type_id = __jakt_match_value.type_id;
 ids::TypeId const& inner_type_id = __jakt_match_value.inner_type_id;
 return JaktInternal::ExplicitValue(({ Optional<ByteString> __jakt_var_646; {
-ByteString output = (ByteString::must_from_utf8(""sv));
+ByteString output = (ByteString::from_utf8_without_validation(""sv));
 [](ByteString& self, ByteString rhs) -> void {
 {
 (self = ((self) + (rhs)));
@@ -7531,7 +7531,7 @@ if ((!(first))){
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8(", "sv)));
+(output,(ByteString::from_utf8_without_validation(", "sv)));
 }
 else {
 (first = false);
@@ -7553,7 +7553,7 @@ else {
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8("})"sv)));
+(output,(ByteString::from_utf8_without_validation("})"sv)));
 __jakt_var_646 = output; goto __jakt_label_546;
 
 }
@@ -7564,13 +7564,13 @@ auto&& __jakt_match_value = __jakt_match_variant.as.JaktTuple;JaktInternal::Dyna
 utility::Span const& span = __jakt_match_value.span;
 ids::TypeId const& type_id = __jakt_match_value.type_id;
 return JaktInternal::ExplicitValue(({ Optional<ByteString> __jakt_var_647; {
-ByteString output = (ByteString::must_from_utf8(""sv));
+ByteString output = (ByteString::from_utf8_without_validation(""sv));
 [](ByteString& self, ByteString rhs) -> void {
 {
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8("(Tuple{"sv)));
+(output,(ByteString::from_utf8_without_validation("(Tuple{"sv)));
 bool first = true;
 {
 JaktInternal::ArrayIterator<NonnullRefPtr<typename types::CheckedExpression>> _magic = ((vals).iterator());
@@ -7587,7 +7587,7 @@ if ((!(first))){
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8(", "sv)));
+(output,(ByteString::from_utf8_without_validation(", "sv)));
 }
 else {
 (first = false);
@@ -7609,7 +7609,7 @@ else {
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8("})"sv)));
+(output,(ByteString::from_utf8_without_validation("})"sv)));
 __jakt_var_647 = output; goto __jakt_label_547;
 
 }
@@ -7617,7 +7617,7 @@ __jakt_label_547:; __jakt_var_647.release_value(); }));
 };/*case end*/
 case 30 /* DependentFunction */: {
 {
-((((*this).compiler))->panic((ByteString::must_from_utf8("Dependent functions should have been resolved by now"sv))));
+((((*this).compiler))->panic((ByteString::from_utf8_without_validation("Dependent functions should have been resolved by now"sv))));
 }
 };/*case end*/
 case 29 /* Function */: {
@@ -7646,7 +7646,7 @@ case 0 /* ByValue */: {
 return JaktInternal::ExplicitValue(((capture).common.init_common.name));
 };/*case end*/
 case 4 /* AllByReference */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("&"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("&"sv)));
 };/*case end*/
 default: {
 return JaktInternal::ExplicitValue(__jakt_format((StringView::from_string_literal("&{}"sv)),((capture).common.init_common.name)));
@@ -7703,7 +7703,7 @@ codegen::ControlFlowState const last_control_flow = ((*this).control_flow_state)
 ScopeGuard __jakt_var_649([&] {
 (((*this).control_flow_state) = last_control_flow);
 });
-ByteString block_output = (ByteString::must_from_utf8(""sv));
+ByteString block_output = (ByteString::from_utf8_without_validation(""sv));
 if (((pseudo_function_id).has_value())){
 NonnullRefPtr<types::CheckedFunction> const function = ((((*this).program))->get_function((pseudo_function_id.value())));
 JaktInternal::Optional<NonnullRefPtr<types::CheckedFunction>> const previous_function = ((*this).current_function);
@@ -7717,7 +7717,7 @@ else {
 (block_output = TRY((((*this).codegen_lambda_block(can_throw,block,return_type_id)))));
 }
 
-__jakt_var_648 = __jakt_format((StringView::from_string_literal("[{}]({}) -> {} {}"sv)),utility::join(generated_captures,(ByteString::must_from_utf8(", "sv))),utility::join(generated_params,(ByteString::must_from_utf8(", "sv))),return_type,block_output); goto __jakt_label_548;
+__jakt_var_648 = __jakt_format((StringView::from_string_literal("[{}]({}) -> {} {}"sv)),utility::join(generated_captures,(ByteString::from_utf8_without_validation(", "sv))),utility::join(generated_params,(ByteString::from_utf8_without_validation(", "sv))),return_type,block_output); goto __jakt_label_548;
 
 }
 __jakt_label_548:; __jakt_var_648.release_value(); }));
@@ -7728,14 +7728,14 @@ ByteString const& error_name = __jakt_match_value.error_name;
 types::CheckedBlock const& catch_block = __jakt_match_value.catch_block;
 utility::Span const& span = __jakt_match_value.span;
 return JaktInternal::ExplicitValue(({ Optional<ByteString> __jakt_var_651; {
-ByteString output = (ByteString::must_from_utf8(""sv));
+ByteString output = (ByteString::from_utf8_without_validation(""sv));
 ByteString const try_var = ((*this).fresh_var());
 [](ByteString& self, ByteString rhs) -> void {
 {
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8("auto "sv)));
+(output,(ByteString::from_utf8_without_validation("auto "sv)));
 [](ByteString& self, ByteString rhs) -> void {
 {
 (self = ((self) + (rhs)));
@@ -7747,7 +7747,7 @@ ByteString const try_var = ((*this).fresh_var());
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8(" = [&]() -> ErrorOr<void> {"sv)));
+(output,(ByteString::from_utf8_without_validation(" = [&]() -> ErrorOr<void> {"sv)));
 codegen::ControlFlowState const last_control_flow = ((*this).control_flow_state);
 (((((*this).control_flow_state)).passes_through_match) = false);
 (((((*this).control_flow_state)).passes_through_try) = true);
@@ -7762,25 +7762,25 @@ codegen::ControlFlowState const last_control_flow = ((*this).control_flow_state)
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8(";"sv)));
+(output,(ByteString::from_utf8_without_validation(";"sv)));
 [](ByteString& self, ByteString rhs) -> void {
 {
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8("return {};"sv)));
+(output,(ByteString::from_utf8_without_validation("return {};"sv)));
 [](ByteString& self, ByteString rhs) -> void {
 {
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8("}();\n"sv)));
+(output,(ByteString::from_utf8_without_validation("}();\n"sv)));
 [](ByteString& self, ByteString rhs) -> void {
 {
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8("if ("sv)));
+(output,(ByteString::from_utf8_without_validation("if ("sv)));
 [](ByteString& self, ByteString rhs) -> void {
 {
 (self = ((self) + (rhs)));
@@ -7792,14 +7792,14 @@ codegen::ControlFlowState const last_control_flow = ((*this).control_flow_state)
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8(".is_error()) {"sv)));
+(output,(ByteString::from_utf8_without_validation(".is_error()) {"sv)));
 if ((!(((error_name).is_empty())))){
 [](ByteString& self, ByteString rhs) -> void {
 {
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8("auto "sv)));
+(output,(ByteString::from_utf8_without_validation("auto "sv)));
 [](ByteString& self, ByteString rhs) -> void {
 {
 (self = ((self) + (rhs)));
@@ -7811,7 +7811,7 @@ if ((!(((error_name).is_empty())))){
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8(" = "sv)));
+(output,(ByteString::from_utf8_without_validation(" = "sv)));
 [](ByteString& self, ByteString rhs) -> void {
 {
 (self = ((self) + (rhs)));
@@ -7823,7 +7823,7 @@ if ((!(((error_name).is_empty())))){
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8(".release_error();"sv)));
+(output,(ByteString::from_utf8_without_validation(".release_error();"sv)));
 }
 [](ByteString& self, ByteString rhs) -> void {
 {
@@ -7837,7 +7837,7 @@ if ((!(((error_name).is_empty())))){
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8("}"sv)));
+(output,(ByteString::from_utf8_without_validation("}"sv)));
 __jakt_var_651 = output; goto __jakt_label_549;
 
 }
@@ -7851,7 +7851,7 @@ utility::Span const& span = __jakt_match_value.span;
 ids::TypeId const& type_id = __jakt_match_value.type_id;
 ids::TypeId const& inner_type_id = __jakt_match_value.inner_type_id;
 return JaktInternal::ExplicitValue(({ Optional<ByteString> __jakt_var_652; {
-ByteString output = (ByteString::must_from_utf8(""sv));
+ByteString output = (ByteString::from_utf8_without_validation(""sv));
 ByteString const fresh_var = ((*this).fresh_var());
 bool const is_void = ((inner_type_id).equals(types::void_type_id()));
 ByteString const try_var = ((*this).fresh_var());
@@ -7870,7 +7870,7 @@ if ((!(is_void))){
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8("({ Optional<"sv)));
+(output,(ByteString::from_utf8_without_validation("({ Optional<"sv)));
 [](ByteString& self, ByteString rhs) -> void {
 {
 (self = ((self) + (rhs)));
@@ -7882,7 +7882,7 @@ if ((!(is_void))){
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8("> "sv)));
+(output,(ByteString::from_utf8_without_validation("> "sv)));
 [](ByteString& self, ByteString rhs) -> void {
 {
 (self = ((self) + (rhs)));
@@ -7894,14 +7894,14 @@ if ((!(is_void))){
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8(";\n"sv)));
+(output,(ByteString::from_utf8_without_validation(";\n"sv)));
 }
 [](ByteString& self, ByteString rhs) -> void {
 {
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8("auto "sv)));
+(output,(ByteString::from_utf8_without_validation("auto "sv)));
 [](ByteString& self, ByteString rhs) -> void {
 {
 (self = ((self) + (rhs)));
@@ -7913,7 +7913,7 @@ if ((!(is_void))){
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8(" = [&]() -> ErrorOr<"sv)));
+(output,(ByteString::from_utf8_without_validation(" = [&]() -> ErrorOr<"sv)));
 [](ByteString& self, ByteString rhs) -> void {
 {
 (self = ((self) + (rhs)));
@@ -7925,7 +7925,7 @@ if ((!(is_void))){
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8("> { return "sv)));
+(output,(ByteString::from_utf8_without_validation("> { return "sv)));
 [](ByteString& self, ByteString rhs) -> void {
 {
 (self = ((self) + (rhs)));
@@ -7938,21 +7938,21 @@ if (is_void){
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8(", ErrorOr<void>{}"sv)));
+(output,(ByteString::from_utf8_without_validation(", ErrorOr<void>{}"sv)));
 }
 [](ByteString& self, ByteString rhs) -> void {
 {
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8("; }();\n"sv)));
+(output,(ByteString::from_utf8_without_validation("; }();\n"sv)));
 if (((catch_block).has_value())){
 [](ByteString& self, ByteString rhs) -> void {
 {
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8("if ("sv)));
+(output,(ByteString::from_utf8_without_validation("if ("sv)));
 [](ByteString& self, ByteString rhs) -> void {
 {
 (self = ((self) + (rhs)));
@@ -7964,14 +7964,14 @@ if (((catch_block).has_value())){
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8(".is_error()) {"sv)));
+(output,(ByteString::from_utf8_without_validation(".is_error()) {"sv)));
 if (((catch_name).has_value())){
 [](ByteString& self, ByteString rhs) -> void {
 {
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8("auto "sv)));
+(output,(ByteString::from_utf8_without_validation("auto "sv)));
 [](ByteString& self, ByteString rhs) -> void {
 {
 (self = ((self) + (rhs)));
@@ -7983,7 +7983,7 @@ if (((catch_name).has_value())){
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8(" = "sv)));
+(output,(ByteString::from_utf8_without_validation(" = "sv)));
 [](ByteString& self, ByteString rhs) -> void {
 {
 (self = ((self) + (rhs)));
@@ -7995,7 +7995,7 @@ if (((catch_name).has_value())){
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8(".release_error();\n"sv)));
+(output,(ByteString::from_utf8_without_validation(".release_error();\n"sv)));
 }
 if ((((((catch_block.value())).yielded_type)).has_value())){
 [](ByteString& self, ByteString rhs) -> void {
@@ -8009,7 +8009,7 @@ if ((((((catch_block.value())).yielded_type)).has_value())){
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8(" = ("sv)));
+(output,(ByteString::from_utf8_without_validation(" = ("sv)));
 [](ByteString& self, ByteString rhs) -> void {
 {
 (self = ((self) + (rhs)));
@@ -8021,7 +8021,7 @@ if ((((((catch_block.value())).yielded_type)).has_value())){
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8(");\n"sv)));
+(output,(ByteString::from_utf8_without_validation(");\n"sv)));
 }
 else {
 [](ByteString& self, ByteString rhs) -> void {
@@ -8038,7 +8038,7 @@ if ((!(is_void))){
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8("} else {"sv)));
+(output,(ByteString::from_utf8_without_validation("} else {"sv)));
 [](ByteString& self, ByteString rhs) -> void {
 {
 (self = ((self) + (rhs)));
@@ -8050,7 +8050,7 @@ if ((!(is_void))){
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8(" = "sv)));
+(output,(ByteString::from_utf8_without_validation(" = "sv)));
 [](ByteString& self, ByteString rhs) -> void {
 {
 (self = ((self) + (rhs)));
@@ -8062,14 +8062,14 @@ if ((!(is_void))){
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8(".release_value();\n"sv)));
+(output,(ByteString::from_utf8_without_validation(".release_value();\n"sv)));
 }
 [](ByteString& self, ByteString rhs) -> void {
 {
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8("}\n"sv)));
+(output,(ByteString::from_utf8_without_validation("}\n"sv)));
 }
 else if ((!(is_void))){
 [](ByteString& self, ByteString rhs) -> void {
@@ -8077,7 +8077,7 @@ else if ((!(is_void))){
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8("if (!"sv)));
+(output,(ByteString::from_utf8_without_validation("if (!"sv)));
 [](ByteString& self, ByteString rhs) -> void {
 {
 (self = ((self) + (rhs)));
@@ -8089,7 +8089,7 @@ else if ((!(is_void))){
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8(".is_error()) "sv)));
+(output,(ByteString::from_utf8_without_validation(".is_error()) "sv)));
 [](ByteString& self, ByteString rhs) -> void {
 {
 (self = ((self) + (rhs)));
@@ -8101,7 +8101,7 @@ else if ((!(is_void))){
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8(" = "sv)));
+(output,(ByteString::from_utf8_without_validation(" = "sv)));
 [](ByteString& self, ByteString rhs) -> void {
 {
 (self = ((self) + (rhs)));
@@ -8113,7 +8113,7 @@ else if ((!(is_void))){
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8(".release_value();\n"sv)));
+(output,(ByteString::from_utf8_without_validation(".release_value();\n"sv)));
 }
 if ((!(is_void))){
 [](ByteString& self, ByteString rhs) -> void {
@@ -8128,14 +8128,14 @@ if (((catch_block).has_value())){
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8(".release_value()"sv)));
+(output,(ByteString::from_utf8_without_validation(".release_value()"sv)));
 }
 [](ByteString& self, ByteString rhs) -> void {
 {
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8("; })"sv)));
+(output,(ByteString::from_utf8_without_validation("; })"sv)));
 }
 __jakt_var_652 = output; goto __jakt_label_550;
 
@@ -8162,7 +8162,7 @@ ErrorOr<ByteString> codegen::CodeGenerator::codegen_match(NonnullRefPtr<typename
 {
 codegen::ControlFlowState const last_control_flow = ((*this).control_flow_state);
 (((*this).control_flow_state) = ((((*this).control_flow_state)).enter_match()));
-ByteString output = (ByteString::must_from_utf8(""sv));
+ByteString output = (ByteString::from_utf8_without_validation(""sv));
 NonnullRefPtr<typename types::Type> const expr_type = ((((*this).program))->get_type(((expr)->type())));
 if (((expr_type)->__jakt_init_index() == 25 /* Enum */)){
 ids::EnumId const enum_id = (expr_type)->as.Enum.value;
@@ -8189,7 +8189,7 @@ return output;
 
 ErrorOr<ByteString> codegen::CodeGenerator::codegen_generic_match(NonnullRefPtr<typename types::CheckedExpression> const expr,JaktInternal::DynamicArray<types::CheckedMatchCase> const cases,ids::TypeId const return_type_id,bool const all_variants_constant) {
 {
-ByteString output = (ByteString::must_from_utf8(""sv));
+ByteString output = (ByteString::from_utf8_without_validation(""sv));
 bool is_generic_enum = false;
 {
 JaktInternal::ArrayIterator<types::CheckedMatchCase> _magic = ((cases).iterator());
@@ -8216,14 +8216,14 @@ ByteString const cpp_match_result_type = TRY((((*this).codegen_type(return_type_
 (self = ((self) + (rhs)));
 }
 }
-(output,((__jakt_format((StringView::from_string_literal("([&]() -> JaktInternal::ExplicitValueOrControlFlow<{},{}>"sv)),cpp_match_result_type,TRY((((*this).codegen_function_return_type((((*this).current_function).value()))))))) + ((ByteString::must_from_utf8("{\n"sv)))));
+(output,((__jakt_format((StringView::from_string_literal("([&]() -> JaktInternal::ExplicitValueOrControlFlow<{},{}>"sv)),cpp_match_result_type,TRY((((*this).codegen_function_return_type((((*this).current_function).value()))))))) + ((ByteString::from_utf8_without_validation("{\n"sv)))));
 if (is_generic_enum){
 [](ByteString& self, ByteString rhs) -> void {
 {
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8("auto&& __jakt_enum_value = JaktInternal::deref_if_ref_pointer("sv)));
+(output,(ByteString::from_utf8_without_validation("auto&& __jakt_enum_value = JaktInternal::deref_if_ref_pointer("sv)));
 }
 else {
 [](ByteString& self, ByteString rhs) -> void {
@@ -8231,7 +8231,7 @@ else {
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8("auto __jakt_enum_value = ("sv)));
+(output,(ByteString::from_utf8_without_validation("auto __jakt_enum_value = ("sv)));
 }
 
 [](ByteString& self, ByteString rhs) -> void {
@@ -8245,7 +8245,7 @@ else {
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8(");\n"sv)));
+(output,(ByteString::from_utf8_without_validation(");\n"sv)));
 bool has_default = false;
 bool first = true;
 {
@@ -8322,7 +8322,7 @@ break;
 }
 }
 (output,__jakt_format((StringView::from_string_literal("if (__jakt_enum_value.__jakt_init_index() == {} /* {} */) {{\n"sv)),variant_index,name));
-ByteString variant_type_name = (ByteString::must_from_utf8(""sv));
+ByteString variant_type_name = (ByteString::from_utf8_without_validation(""sv));
 ByteString const qualifier = TRY((((*this).codegen_type_possibly_as_namespace(subject_type_id,true))));
 if ((!(((qualifier).is_empty())))){
 [](ByteString& self, ByteString rhs) -> void {
@@ -8330,7 +8330,7 @@ if ((!(((qualifier).is_empty())))){
 (self = ((self) + (rhs)));
 }
 }
-(variant_type_name,(ByteString::must_from_utf8("typename JaktInternal::RemoveRefPtr<"sv)));
+(variant_type_name,(ByteString::from_utf8_without_validation("typename JaktInternal::RemoveRefPtr<"sv)));
 [](ByteString& self, ByteString rhs) -> void {
 {
 (self = ((self) + (rhs)));
@@ -8342,7 +8342,7 @@ if ((!(((qualifier).is_empty())))){
 (self = ((self) + (rhs)));
 }
 }
-(variant_type_name,(ByteString::must_from_utf8(">::"sv)));
+(variant_type_name,(ByteString::from_utf8_without_validation(">::"sv)));
 }
 [](ByteString& self, ByteString rhs) -> void {
 {
@@ -8356,7 +8356,7 @@ if ((!(((args).is_empty())))){
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8("auto& __jakt_match_value = __jakt_enum_value.as."sv)));
+(output,(ByteString::from_utf8_without_validation("auto& __jakt_match_value = __jakt_enum_value.as."sv)));
 [](ByteString& self, ByteString rhs) -> void {
 {
 (self = ((self) + (rhs)));
@@ -8368,7 +8368,7 @@ if ((!(((args).is_empty())))){
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8(";\n"sv)));
+(output,(ByteString::from_utf8_without_validation(";\n"sv)));
 {
 JaktInternal::ArrayIterator<parser::EnumVariantPatternArgument> _magic = ((args).iterator());
 for (;;){
@@ -8383,7 +8383,7 @@ parser::EnumVariantPatternArgument arg = (_magic_value.value());
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8("auto& "sv)));
+(output,(ByteString::from_utf8_without_validation("auto& "sv)));
 [](ByteString& self, ByteString rhs) -> void {
 {
 (self = ((self) + (rhs)));
@@ -8395,19 +8395,19 @@ parser::EnumVariantPatternArgument arg = (_magic_value.value());
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8(" = __jakt_match_value."sv)));
+(output,(ByteString::from_utf8_without_validation(" = __jakt_match_value."sv)));
 [](ByteString& self, ByteString rhs) -> void {
 {
 (self = ((self) + (rhs)));
 }
 }
-(output,TRY((((arg).name).try_value_or_lazy_evaluated([&]() -> ErrorOr<ByteString> { return (ByteString::must_from_utf8("value"sv)); }))));
+(output,TRY((((arg).name).try_value_or_lazy_evaluated([&]() -> ErrorOr<ByteString> { return (ByteString::from_utf8_without_validation("value"sv)); }))));
 [](ByteString& self, ByteString rhs) -> void {
 {
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8(";\n"sv)));
+(output,(ByteString::from_utf8_without_validation(";\n"sv)));
 }
 
 }
@@ -8445,7 +8445,7 @@ NonnullRefPtr<typename types::CheckedStatement> default_ = (_magic_value.value()
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8("}\n"sv)));
+(output,(ByteString::from_utf8_without_validation("}\n"sv)));
 }
 return JaktInternal::ExplicitValue<void>();
 };/*case end*/
@@ -8455,7 +8455,7 @@ types::CheckedMatchBody const& body = __jakt_match_value.body;
 utility::Span const& marker_span = __jakt_match_value.marker_span;
 {
 if (has_arguments){
-utility::panic((ByteString::must_from_utf8("Bindings should not be present in a generic else"sv)));
+utility::panic((ByteString::from_utf8_without_validation("Bindings should not be present in a generic else"sv)));
 }
 (has_default = true);
 if (first){
@@ -8464,7 +8464,7 @@ if (first){
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8("{"sv)));
+(output,(ByteString::from_utf8_without_validation("{"sv)));
 }
 else {
 [](ByteString& self, ByteString rhs) -> void {
@@ -8472,7 +8472,7 @@ else {
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8("else {\n"sv)));
+(output,(ByteString::from_utf8_without_validation("else {\n"sv)));
 }
 
 {
@@ -8506,7 +8506,7 @@ NonnullRefPtr<typename types::CheckedStatement> default_ = (_magic_value.value()
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8("}\n"sv)));
+(output,(ByteString::from_utf8_without_validation("}\n"sv)));
 }
 return JaktInternal::ExplicitValue<void>();
 };/*case end*/
@@ -8521,7 +8521,7 @@ if ((!(first))){
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8("else "sv)));
+(output,(ByteString::from_utf8_without_validation("else "sv)));
 }
 if (((expression)->__jakt_init_index() == 9 /* Range */)){
 JaktInternal::Optional<NonnullRefPtr<typename types::CheckedExpression>> const from = (expression)->as.Range.from;
@@ -8531,14 +8531,14 @@ JaktInternal::Optional<NonnullRefPtr<typename types::CheckedExpression>> const t
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8("if (__jakt_enum_value"sv)));
+(output,(ByteString::from_utf8_without_validation("if (__jakt_enum_value"sv)));
 if (((from).has_value())){
 [](ByteString& self, ByteString rhs) -> void {
 {
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8(" >= "sv)));
+(output,(ByteString::from_utf8_without_validation(" >= "sv)));
 [](ByteString& self, ByteString rhs) -> void {
 {
 (self = ((self) + (rhs)));
@@ -8553,14 +8553,14 @@ if (((from).has_value())){
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8("&& __jakt_enum_value "sv)));
+(output,(ByteString::from_utf8_without_validation("&& __jakt_enum_value "sv)));
 }
 [](ByteString& self, ByteString rhs) -> void {
 {
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8("< "sv)));
+(output,(ByteString::from_utf8_without_validation("< "sv)));
 [](ByteString& self, ByteString rhs) -> void {
 {
 (self = ((self) + (rhs)));
@@ -8575,7 +8575,7 @@ else {
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8("if (__jakt_enum_value == "sv)));
+(output,(ByteString::from_utf8_without_validation("if (__jakt_enum_value == "sv)));
 [](ByteString& self, ByteString rhs) -> void {
 {
 (self = ((self) + (rhs)));
@@ -8589,7 +8589,7 @@ else {
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8(") {\n"sv)));
+(output,(ByteString::from_utf8_without_validation(") {\n"sv)));
 [](ByteString& self, ByteString rhs) -> void {
 {
 (self = ((self) + (rhs)));
@@ -8601,7 +8601,7 @@ else {
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8("}\n"sv)));
+(output,(ByteString::from_utf8_without_validation("}\n"sv)));
 }
 return JaktInternal::ExplicitValue<void>();
 };/*case end*/
@@ -8623,7 +8623,7 @@ ByteString const type_name = TRY((((*this).codegen_type_possibly_as_namespace(ty
 (self = ((self) + (rhs)));
 }
 }
-(output,__jakt_format((StringView::from_string_literal("auto {} = NonnullRefPtr {{ *static_cast<RawPtr<{}>>(__jakt_enum_value.ptr()) }};\n"sv)),TRY((((rebind_name).map([](auto& _value) { return _value.name; })).try_value_or_lazy_evaluated([&]() -> ErrorOr<ByteString> { return (ByteString::must_from_utf8("__jakt_match_value"sv)); }))),type_name));
+(output,__jakt_format((StringView::from_string_literal("auto {} = NonnullRefPtr {{ *static_cast<RawPtr<{}>>(__jakt_enum_value.ptr()) }};\n"sv)),TRY((((rebind_name).map([](auto& _value) { return _value.name; })).try_value_or_lazy_evaluated([&]() -> ErrorOr<ByteString> { return (ByteString::from_utf8_without_validation("__jakt_match_value"sv)); }))),type_name));
 {
 JaktInternal::ArrayIterator<NonnullRefPtr<typename types::CheckedStatement>> _magic = ((defaults).iterator());
 for (;;){
@@ -8655,7 +8655,7 @@ NonnullRefPtr<typename types::CheckedStatement> default_ = (_magic_value.value()
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8("}\n"sv)));
+(output,(ByteString::from_utf8_without_validation("}\n"sv)));
 }
 return JaktInternal::ExplicitValue<void>();
 };/*case end*/
@@ -8682,7 +8682,7 @@ if ((((return_type_id).equals(types::void_type_id())) || ((return_type_id).equal
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8("return JaktInternal::ExplicitValue<void>();\n"sv)));
+(output,(ByteString::from_utf8_without_validation("return JaktInternal::ExplicitValue<void>();\n"sv)));
 }
 else if ((!(has_default))){
 [](ByteString& self, ByteString rhs) -> void {
@@ -8690,28 +8690,28 @@ else if ((!(has_default))){
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8("VERIFY_NOT_REACHED();\n"sv)));
+(output,(ByteString::from_utf8_without_validation("VERIFY_NOT_REACHED();\n"sv)));
 }
 [](ByteString& self, ByteString rhs) -> void {
 {
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8("}())"sv)));
+(output,(ByteString::from_utf8_without_validation("}())"sv)));
 return TRY((((((*this).control_flow_state)).apply_control_flow_macro(output,(((((*this).current_function).value()))->return_type_id),(((((*this).current_function).value()))->can_throw),cpp_match_result_type))));
 }
 }
 
 ErrorOr<ByteString> codegen::CodeGenerator::codegen_enum_match(types::CheckedEnum const enum_,NonnullRefPtr<typename types::CheckedExpression> const expr,JaktInternal::DynamicArray<types::CheckedMatchCase> const match_cases,ids::TypeId const type_id,bool const all_variants_constant) {
 {
-ByteString output = (ByteString::must_from_utf8(""sv));
+ByteString output = (ByteString::from_utf8_without_validation(""sv));
 ByteString const subject = TRY((((*this).codegen_expression(expr))));
 bool const needs_deref = (((enum_).is_boxed) && [](ByteString const& self, ByteString rhs) -> bool {
 {
 return (!(((self) == (rhs))));
 }
 }
-(subject,(ByteString::must_from_utf8("*this"sv))));
+(subject,(ByteString::from_utf8_without_validation("*this"sv))));
 ByteString const cpp_match_result_type = TRY((((*this).codegen_type(type_id))));
 if (((((enum_).underlying_type_id)).equals(types::void_type_id()))){
 [](ByteString& self, ByteString rhs) -> void {
@@ -8719,7 +8719,7 @@ if (((((enum_).underlying_type_id)).equals(types::void_type_id()))){
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8("([&]() -> JaktInternal::ExplicitValueOrControlFlow<"sv)));
+(output,(ByteString::from_utf8_without_validation("([&]() -> JaktInternal::ExplicitValueOrControlFlow<"sv)));
 [](ByteString& self, ByteString rhs) -> void {
 {
 (self = ((self) + (rhs)));
@@ -8731,7 +8731,7 @@ if (((((enum_).underlying_type_id)).equals(types::void_type_id()))){
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8(", "sv)));
+(output,(ByteString::from_utf8_without_validation(", "sv)));
 [](ByteString& self, ByteString rhs) -> void {
 {
 (self = ((self) + (rhs)));
@@ -8743,33 +8743,33 @@ if (((((enum_).underlying_type_id)).equals(types::void_type_id()))){
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8(">{\n"sv)));
+(output,(ByteString::from_utf8_without_validation(">{\n"sv)));
 [](ByteString& self, ByteString rhs) -> void {
 {
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8("auto&& __jakt_match_variant = "sv)));
+(output,(ByteString::from_utf8_without_validation("auto&& __jakt_match_variant = "sv)));
 if (needs_deref){
 [](ByteString& self, ByteString rhs) -> void {
 {
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8("*"sv)));
+(output,(ByteString::from_utf8_without_validation("*"sv)));
 }
 [](ByteString& self, ByteString rhs) -> void {
 {
 (self = ((self) + (rhs)));
 }
 }
-(output,((TRY((((*this).codegen_expression(expr))))) + ((ByteString::must_from_utf8(";\n"sv)))));
+(output,((TRY((((*this).codegen_expression(expr))))) + ((ByteString::from_utf8_without_validation(";\n"sv)))));
 [](ByteString& self, ByteString rhs) -> void {
 {
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8("switch(__jakt_match_variant.__jakt_init_index()) {\n"sv)));
+(output,(ByteString::from_utf8_without_validation("switch(__jakt_match_variant.__jakt_init_index()) {\n"sv)));
 bool has_default = false;
 {
 JaktInternal::ArrayIterator<types::CheckedMatchCase> _magic = ((match_cases).iterator());
@@ -8803,7 +8803,7 @@ return JaktInternal::ExplicitValue(id);
 };/*case end*/
 default: {
 {
-utility::panic((ByteString::must_from_utf8("Expected enum type"sv)));
+utility::panic((ByteString::from_utf8_without_validation("Expected enum type"sv)));
 }
 };/*case end*/
 }/*switch end*/
@@ -8824,7 +8824,7 @@ types::CheckedEnumVariant const variant = ((((match_case_enum).variants))[index]
 (self = ((self) + (rhs)));
 }
 }
-(output,((__jakt_format((StringView::from_string_literal("case {} /* {} */: "sv)),index,((variant).name()))) + ((ByteString::must_from_utf8("{\n"sv)))));
+(output,((__jakt_format((StringView::from_string_literal("case {} /* {} */: "sv)),index,((variant).name()))) + ((ByteString::from_utf8_without_validation("{\n"sv)))));
 ({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<void, ErrorOr<ByteString>>{
 auto&& __jakt_match_variant = variant;
@@ -8860,14 +8860,14 @@ if ((!(((var)->is_mutable)))){
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8(" const"sv)));
+(output,(ByteString::from_utf8_without_validation(" const"sv)));
 }
 [](ByteString& self, ByteString rhs) -> void {
 {
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8("& "sv)));
+(output,(ByteString::from_utf8_without_validation("& "sv)));
 [](ByteString& self, ByteString rhs) -> void {
 {
 (self = ((self) + (rhs)));
@@ -8879,7 +8879,7 @@ if ((!(((var)->is_mutable)))){
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8(" = __jakt_match_value.value;\n"sv)));
+(output,(ByteString::from_utf8_without_validation(" = __jakt_match_value.value;\n"sv)));
 }
 }
 return JaktInternal::ExplicitValue<void>();
@@ -8917,14 +8917,14 @@ if ((!(((var)->is_mutable)))){
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8(" const"sv)));
+(output,(ByteString::from_utf8_without_validation(" const"sv)));
 }
 [](ByteString& self, ByteString rhs) -> void {
 {
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8("& "sv)));
+(output,(ByteString::from_utf8_without_validation("& "sv)));
 [](ByteString& self, ByteString rhs) -> void {
 {
 (self = ((self) + (rhs)));
@@ -8936,7 +8936,7 @@ if ((!(((var)->is_mutable)))){
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8(" = __jakt_match_value."sv)));
+(output,(ByteString::from_utf8_without_validation(" = __jakt_match_value."sv)));
 [](ByteString& self, ByteString rhs) -> void {
 {
 (self = ((self) + (rhs)));
@@ -8948,7 +8948,7 @@ if ((!(((var)->is_mutable)))){
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8(";\n"sv)));
+(output,(ByteString::from_utf8_without_validation(";\n"sv)));
 }
 
 }
@@ -9006,7 +9006,7 @@ NonnullRefPtr<typename types::CheckedStatement> default_ = (_magic_value.value()
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8("};/*case end*/\n"sv)));
+(output,(ByteString::from_utf8_without_validation("};/*case end*/\n"sv)));
 }
 return JaktInternal::ExplicitValue<void>();
 };/*case end*/
@@ -9019,7 +9019,7 @@ auto&& __jakt_match_value = __jakt_match_variant.as.CatchAll;types::CheckedMatch
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8("default: {\n"sv)));
+(output,(ByteString::from_utf8_without_validation("default: {\n"sv)));
 {
 JaktInternal::ArrayIterator<NonnullRefPtr<typename types::CheckedStatement>> _magic = ((((match_case).common.init_common.defaults)).iterator());
 for (;;){
@@ -9051,13 +9051,13 @@ NonnullRefPtr<typename types::CheckedStatement> default_ = (_magic_value.value()
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8("};/*case end*/\n"sv)));
+(output,(ByteString::from_utf8_without_validation("};/*case end*/\n"sv)));
 }
 return JaktInternal::ExplicitValue<void>();
 };/*case end*/
 default: {
 {
-utility::panic((ByteString::must_from_utf8("Matching enum subject with non-enum value"sv)));
+utility::panic((ByteString::from_utf8_without_validation("Matching enum subject with non-enum value"sv)));
 }
 return JaktInternal::ExplicitValue<void>();
 };/*case end*/
@@ -9079,27 +9079,27 @@ return JaktInternal::ExplicitValue<void>();
 
 if ((!(has_default))){
 if (((((((enum_).variants)).size())) != (((match_cases).size())))){
-utility::panic((ByteString::must_from_utf8("Inexhaustive match statement"sv)));
+utility::panic((ByteString::from_utf8_without_validation("Inexhaustive match statement"sv)));
 }
 [](ByteString& self, ByteString rhs) -> void {
 {
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8("default: VERIFY_NOT_REACHED();"sv)));
+(output,(ByteString::from_utf8_without_validation("default: VERIFY_NOT_REACHED();"sv)));
 }
 [](ByteString& self, ByteString rhs) -> void {
 {
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8("}/*switch end*/\n"sv)));
+(output,(ByteString::from_utf8_without_validation("}/*switch end*/\n"sv)));
 [](ByteString& self, ByteString rhs) -> void {
 {
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8("}()\n)"sv)));
+(output,(ByteString::from_utf8_without_validation("}()\n)"sv)));
 }
 else {
 [](ByteString& self, ByteString rhs) -> void {
@@ -9107,7 +9107,7 @@ else {
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8("([&]() -> JaktInternal::ExplicitValueOrControlFlow<"sv)));
+(output,(ByteString::from_utf8_without_validation("([&]() -> JaktInternal::ExplicitValueOrControlFlow<"sv)));
 [](ByteString& self, ByteString rhs) -> void {
 {
 (self = ((self) + (rhs)));
@@ -9119,7 +9119,7 @@ else {
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8(", "sv)));
+(output,(ByteString::from_utf8_without_validation(", "sv)));
 [](ByteString& self, ByteString rhs) -> void {
 {
 (self = ((self) + (rhs)));
@@ -9131,13 +9131,13 @@ else {
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8(">{\n"sv)));
+(output,(ByteString::from_utf8_without_validation(">{\n"sv)));
 [](ByteString& self, ByteString rhs) -> void {
 {
 (self = ((self) + (rhs)));
 }
 }
-(output,(((((ByteString::must_from_utf8("switch ("sv))) + (TRY((((*this).codegen_expression(expr))))))) + ((ByteString::must_from_utf8(") {\n"sv)))));
+(output,(((((ByteString::from_utf8_without_validation("switch ("sv))) + (TRY((((*this).codegen_expression(expr))))))) + ((ByteString::from_utf8_without_validation(") {\n"sv)))));
 {
 JaktInternal::ArrayIterator<types::CheckedMatchCase> _magic = ((match_cases).iterator());
 for (;;){
@@ -9160,7 +9160,7 @@ types::CheckedMatchBody const& body = __jakt_match_value.body;
 (self = ((self) + (rhs)));
 }
 }
-(output,(((((((((ByteString::must_from_utf8("case "sv))) + (((enum_).name)))) + ((ByteString::must_from_utf8("::"sv))))) + (name))) + ((ByteString::must_from_utf8(": {\n"sv)))));
+(output,(((((((((ByteString::from_utf8_without_validation("case "sv))) + (((enum_).name)))) + ((ByteString::from_utf8_without_validation("::"sv))))) + (name))) + ((ByteString::from_utf8_without_validation(": {\n"sv)))));
 [](ByteString& self, ByteString rhs) -> void {
 {
 (self = ((self) + (rhs)));
@@ -9172,7 +9172,7 @@ types::CheckedMatchBody const& body = __jakt_match_value.body;
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8("}\n"sv)));
+(output,(ByteString::from_utf8_without_validation("}\n"sv)));
 }
 return JaktInternal::ExplicitValue<void>();
 };/*case end*/
@@ -9184,7 +9184,7 @@ auto&& __jakt_match_value = __jakt_match_variant.as.CatchAll;types::CheckedMatch
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8("default: {\n"sv)));
+(output,(ByteString::from_utf8_without_validation("default: {\n"sv)));
 [](ByteString& self, ByteString rhs) -> void {
 {
 (self = ((self) + (rhs)));
@@ -9196,7 +9196,7 @@ auto&& __jakt_match_value = __jakt_match_variant.as.CatchAll;types::CheckedMatch
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8("}\n"sv)));
+(output,(ByteString::from_utf8_without_validation("}\n"sv)));
 }
 return JaktInternal::ExplicitValue<void>();
 };/*case end*/
@@ -9227,13 +9227,13 @@ return JaktInternal::ExplicitValue<void>();
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8("}/*switch end*/\n"sv)));
+(output,(ByteString::from_utf8_without_validation("}/*switch end*/\n"sv)));
 [](ByteString& self, ByteString rhs) -> void {
 {
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8("}()\n)"sv)));
+(output,(ByteString::from_utf8_without_validation("}()\n)"sv)));
 }
 
 return TRY((((((*this).control_flow_state)).apply_control_flow_macro(output,(((((*this).current_function).value()))->return_type_id),(((((*this).current_function).value()))->can_throw),cpp_match_result_type))));
@@ -9242,7 +9242,7 @@ return TRY((((((*this).control_flow_state)).apply_control_flow_macro(output,((((
 
 ErrorOr<ByteString> codegen::CodeGenerator::codegen_match_body(types::CheckedMatchBody const body,ids::TypeId const return_type_id) {
 {
-ByteString output = (ByteString::must_from_utf8(""sv));
+ByteString output = (ByteString::from_utf8_without_validation(""sv));
 ({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<void, ErrorOr<ByteString>>{
 auto&& __jakt_match_variant = body;
@@ -9262,7 +9262,7 @@ if ((((return_type_id).equals(types::void_type_id())) || ((return_type_id).equal
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8("return JaktInternal::ExplicitValue<void>();\n"sv)));
+(output,(ByteString::from_utf8_without_validation("return JaktInternal::ExplicitValue<void>();\n"sv)));
 }
 }
 return JaktInternal::ExplicitValue<void>();
@@ -9276,7 +9276,7 @@ if (((((((expr)->type())).equals(types::void_type_id())) || ((((expr)->type())).
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8("return ("sv)));
+(output,(ByteString::from_utf8_without_validation("return ("sv)));
 [](ByteString& self, ByteString rhs) -> void {
 {
 (self = ((self) + (rhs)));
@@ -9288,7 +9288,7 @@ if (((((((expr)->type())).equals(types::void_type_id())) || ((((expr)->type())).
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8("), JaktInternal::ExplicitValue<void>();\n"sv)));
+(output,(ByteString::from_utf8_without_validation("), JaktInternal::ExplicitValue<void>();\n"sv)));
 }
 else {
 [](ByteString& self, ByteString rhs) -> void {
@@ -9296,7 +9296,7 @@ else {
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8("return JaktInternal::ExplicitValue("sv)));
+(output,(ByteString::from_utf8_without_validation("return JaktInternal::ExplicitValue("sv)));
 [](ByteString& self, ByteString rhs) -> void {
 {
 (self = ((self) + (rhs)));
@@ -9308,7 +9308,7 @@ else {
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8(");\n"sv)));
+(output,(ByteString::from_utf8_without_validation(");\n"sv)));
 }
 
 }
@@ -9327,8 +9327,8 @@ return output;
 
 ErrorOr<ByteString> codegen::CodeGenerator::codegen_function_return_type(NonnullRefPtr<types::CheckedFunction> const function) {
 {
-if ((((function)->is_static()) && ((((((function)->name_for_codegen())).as_name_for_use())) == ((ByteString::must_from_utf8("main"sv)))))){
-return (ByteString::must_from_utf8("ErrorOr<int>"sv));
+if ((((function)->is_static()) && ((((((function)->name_for_codegen())).as_name_for_use())) == ((ByteString::from_utf8_without_validation("main"sv)))))){
+return (ByteString::from_utf8_without_validation("ErrorOr<int>"sv));
 }
 ByteString const type_name = TRY((((*this).codegen_type(((function)->return_type_id)))));
 if (((function)->can_throw)){
@@ -9348,7 +9348,7 @@ if (((((op).op)).__jakt_init_index() == 20 /* NoneCoalescing */)){
 ids::TypeId const rhs_type_id = ((rhs)->type());
 NonnullRefPtr<typename types::Type> const rhs_type = ((((*this).program))->get_type(rhs_type_id));
 bool const rhs_can_throw = ((rhs)->can_throw());
-ByteString output = (ByteString::must_from_utf8(""sv));
+ByteString output = (ByteString::from_utf8_without_validation(""sv));
 if (rhs_can_throw){
 [](ByteString& self, ByteString rhs) -> void {
 {
@@ -9361,7 +9361,7 @@ if (rhs_can_throw){
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8("(("sv)));
+(output,(ByteString::from_utf8_without_validation("(("sv)));
 }
 [](ByteString& self, ByteString rhs) -> void {
 {
@@ -9371,14 +9371,14 @@ if (rhs_can_throw){
 (output,TRY((((*this).codegen_expression(lhs)))));
 if (((rhs_type)->__jakt_init_index() == 20 /* GenericInstance */)){
 ids::StructId const id = (rhs_type)->as.GenericInstance.id;
-if (((TRY((((((((((*this).program))->get_struct(id))).name_for_codegen())).as_name_for_definition())))) == ((ByteString::must_from_utf8("Optional"sv))))){
+if (((TRY((((((((((*this).program))->get_struct(id))).name_for_codegen())).as_name_for_definition())))) == ((ByteString::from_utf8_without_validation("Optional"sv))))){
 if (rhs_can_throw){
 [](ByteString& self, ByteString rhs) -> void {
 {
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8(".try_value_or_lazy_evaluated_optional"sv)));
+(output,(ByteString::from_utf8_without_validation(".try_value_or_lazy_evaluated_optional"sv)));
 }
 else {
 [](ByteString& self, ByteString rhs) -> void {
@@ -9386,28 +9386,7 @@ else {
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8(".value_or_lazy_evaluated_optional"sv)));
-}
-
-}
-else {
-if (rhs_can_throw){
-[](ByteString& self, ByteString rhs) -> void {
-{
-(self = ((self) + (rhs)));
-}
-}
-(output,(ByteString::must_from_utf8(".try_value_or_lazy_evaluated"sv)));
-}
-else {
-[](ByteString& self, ByteString rhs) -> void {
-{
-(self = ((self) + (rhs)));
-}
-}
-(output,(ByteString::must_from_utf8(".value_or_lazy_evaluated"sv)));
-}
-
+(output,(ByteString::from_utf8_without_validation(".value_or_lazy_evaluated_optional"sv)));
 }
 
 }
@@ -9418,7 +9397,7 @@ if (rhs_can_throw){
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8(".try_value_or_lazy_evaluated"sv)));
+(output,(ByteString::from_utf8_without_validation(".try_value_or_lazy_evaluated"sv)));
 }
 else {
 [](ByteString& self, ByteString rhs) -> void {
@@ -9426,7 +9405,28 @@ else {
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8(".value_or_lazy_evaluated"sv)));
+(output,(ByteString::from_utf8_without_validation(".value_or_lazy_evaluated"sv)));
+}
+
+}
+
+}
+else {
+if (rhs_can_throw){
+[](ByteString& self, ByteString rhs) -> void {
+{
+(self = ((self) + (rhs)));
+}
+}
+(output,(ByteString::from_utf8_without_validation(".try_value_or_lazy_evaluated"sv)));
+}
+else {
+[](ByteString& self, ByteString rhs) -> void {
+{
+(self = ((self) + (rhs)));
+}
+}
+(output,(ByteString::from_utf8_without_validation(".value_or_lazy_evaluated"sv)));
 }
 
 }
@@ -9437,7 +9437,7 @@ if (rhs_can_throw){
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8("([&]() -> ErrorOr<"sv)));
+(output,(ByteString::from_utf8_without_validation("([&]() -> ErrorOr<"sv)));
 [](ByteString& self, ByteString rhs) -> void {
 {
 (self = ((self) + (rhs)));
@@ -9449,7 +9449,7 @@ if (rhs_can_throw){
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8("> { return "sv)));
+(output,(ByteString::from_utf8_without_validation("> { return "sv)));
 }
 else {
 [](ByteString& self, ByteString rhs) -> void {
@@ -9457,7 +9457,7 @@ else {
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8("([&] { return "sv)));
+(output,(ByteString::from_utf8_without_validation("([&] { return "sv)));
 }
 
 [](ByteString& self, ByteString rhs) -> void {
@@ -9471,14 +9471,14 @@ else {
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8("; })"sv)));
+(output,(ByteString::from_utf8_without_validation("; })"sv)));
 if (rhs_can_throw){
 [](ByteString& self, ByteString rhs) -> void {
 {
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8("))"sv)));
+(output,(ByteString::from_utf8_without_validation("))"sv)));
 }
 return output;
 }
@@ -9487,7 +9487,7 @@ ByteString const var = ((*this).fresh_var());
 return __jakt_format((StringView::from_string_literal("({{ auto&& {0} = {1}; if (!{0}.has_value()) {0} = {2}; }})"sv)),var,TRY((((*this).codegen_expression(lhs)))),TRY((((*this).codegen_expression(rhs)))));
 }
 if (((((op).op)).__jakt_init_index() == 17 /* ArithmeticRightShift */)){
-ByteString output = (ByteString::must_from_utf8("JaktInternal::arithmetic_shift_right("sv));
+ByteString output = (ByteString::from_utf8_without_validation("JaktInternal::arithmetic_shift_right("sv));
 [](ByteString& self, ByteString rhs) -> void {
 {
 (self = ((self) + (rhs)));
@@ -9499,7 +9499,7 @@ ByteString output = (ByteString::must_from_utf8("JaktInternal::arithmetic_shift_
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8(","sv)));
+(output,(ByteString::from_utf8_without_validation(","sv)));
 [](ByteString& self, ByteString rhs) -> void {
 {
 (self = ((self) + (rhs)));
@@ -9511,7 +9511,7 @@ ByteString output = (ByteString::must_from_utf8("JaktInternal::arithmetic_shift_
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8(")"sv)));
+(output,(ByteString::from_utf8_without_validation(")"sv)));
 return output;
 }
 if ((((((op).op)).__jakt_init_index() == 21 /* Assign */) && ((lhs)->__jakt_init_index() == 14 /* IndexedDictionary */))){
@@ -9527,10 +9527,10 @@ switch(__jakt_match_variant.__jakt_init_index()) {
 case 0 /* Add */: {
 {
 if (((((*this).compiler))->optimize)){
-return (((((ByteString::must_from_utf8("("sv))) + (TRY((((*this).codegen_unchecked_binary_op(lhs,rhs,((op).op),type_id))))))) + ((ByteString::must_from_utf8(")"sv))));
+return (((((ByteString::from_utf8_without_validation("("sv))) + (TRY((((*this).codegen_unchecked_binary_op(lhs,rhs,((op).op),type_id))))))) + ((ByteString::from_utf8_without_validation(")"sv))));
 }
 else {
-return (((((ByteString::must_from_utf8("("sv))) + (TRY((((*this).codegen_checked_binary_op(lhs,rhs,((op).op),type_id))))))) + ((ByteString::must_from_utf8(")"sv))));
+return (((((ByteString::from_utf8_without_validation("("sv))) + (TRY((((*this).codegen_checked_binary_op(lhs,rhs,((op).op),type_id))))))) + ((ByteString::from_utf8_without_validation(")"sv))));
 }
 
 }
@@ -9539,10 +9539,10 @@ return JaktInternal::ExplicitValue<void>();
 case 1 /* Subtract */: {
 {
 if (((((*this).compiler))->optimize)){
-return (((((ByteString::must_from_utf8("("sv))) + (TRY((((*this).codegen_unchecked_binary_op(lhs,rhs,((op).op),type_id))))))) + ((ByteString::must_from_utf8(")"sv))));
+return (((((ByteString::from_utf8_without_validation("("sv))) + (TRY((((*this).codegen_unchecked_binary_op(lhs,rhs,((op).op),type_id))))))) + ((ByteString::from_utf8_without_validation(")"sv))));
 }
 else {
-return (((((ByteString::must_from_utf8("("sv))) + (TRY((((*this).codegen_checked_binary_op(lhs,rhs,((op).op),type_id))))))) + ((ByteString::must_from_utf8(")"sv))));
+return (((((ByteString::from_utf8_without_validation("("sv))) + (TRY((((*this).codegen_checked_binary_op(lhs,rhs,((op).op),type_id))))))) + ((ByteString::from_utf8_without_validation(")"sv))));
 }
 
 }
@@ -9551,10 +9551,10 @@ return JaktInternal::ExplicitValue<void>();
 case 2 /* Multiply */: {
 {
 if (((((*this).compiler))->optimize)){
-return (((((ByteString::must_from_utf8("("sv))) + (TRY((((*this).codegen_unchecked_binary_op(lhs,rhs,((op).op),type_id))))))) + ((ByteString::must_from_utf8(")"sv))));
+return (((((ByteString::from_utf8_without_validation("("sv))) + (TRY((((*this).codegen_unchecked_binary_op(lhs,rhs,((op).op),type_id))))))) + ((ByteString::from_utf8_without_validation(")"sv))));
 }
 else {
-return (((((ByteString::must_from_utf8("("sv))) + (TRY((((*this).codegen_checked_binary_op(lhs,rhs,((op).op),type_id))))))) + ((ByteString::must_from_utf8(")"sv))));
+return (((((ByteString::from_utf8_without_validation("("sv))) + (TRY((((*this).codegen_checked_binary_op(lhs,rhs,((op).op),type_id))))))) + ((ByteString::from_utf8_without_validation(")"sv))));
 }
 
 }
@@ -9563,10 +9563,10 @@ return JaktInternal::ExplicitValue<void>();
 case 3 /* Divide */: {
 {
 if (((((*this).compiler))->optimize)){
-return (((((ByteString::must_from_utf8("("sv))) + (TRY((((*this).codegen_unchecked_binary_op(lhs,rhs,((op).op),type_id))))))) + ((ByteString::must_from_utf8(")"sv))));
+return (((((ByteString::from_utf8_without_validation("("sv))) + (TRY((((*this).codegen_unchecked_binary_op(lhs,rhs,((op).op),type_id))))))) + ((ByteString::from_utf8_without_validation(")"sv))));
 }
 else {
-return (((((ByteString::must_from_utf8("("sv))) + (TRY((((*this).codegen_checked_binary_op(lhs,rhs,((op).op),type_id))))))) + ((ByteString::must_from_utf8(")"sv))));
+return (((((ByteString::from_utf8_without_validation("("sv))) + (TRY((((*this).codegen_checked_binary_op(lhs,rhs,((op).op),type_id))))))) + ((ByteString::from_utf8_without_validation(")"sv))));
 }
 
 }
@@ -9575,10 +9575,10 @@ return JaktInternal::ExplicitValue<void>();
 case 4 /* Modulo */: {
 {
 if (((((*this).compiler))->optimize)){
-return (((((ByteString::must_from_utf8("("sv))) + (TRY((((*this).codegen_unchecked_binary_op(lhs,rhs,((op).op),type_id))))))) + ((ByteString::must_from_utf8(")"sv))));
+return (((((ByteString::from_utf8_without_validation("("sv))) + (TRY((((*this).codegen_unchecked_binary_op(lhs,rhs,((op).op),type_id))))))) + ((ByteString::from_utf8_without_validation(")"sv))));
 }
 else {
-return (((((ByteString::must_from_utf8("("sv))) + (TRY((((*this).codegen_checked_binary_op(lhs,rhs,((op).op),type_id))))))) + ((ByteString::must_from_utf8(")"sv))));
+return (((((ByteString::from_utf8_without_validation("("sv))) + (TRY((((*this).codegen_checked_binary_op(lhs,rhs,((op).op),type_id))))))) + ((ByteString::from_utf8_without_validation(")"sv))));
 }
 
 }
@@ -9587,10 +9587,10 @@ return JaktInternal::ExplicitValue<void>();
 case 27 /* AddAssign */: {
 {
 if (((((*this).compiler))->optimize)){
-return (((((ByteString::must_from_utf8("("sv))) + (TRY((((*this).codegen_unchecked_binary_op_assignment(lhs,rhs,((op).op),type_id))))))) + ((ByteString::must_from_utf8(")"sv))));
+return (((((ByteString::from_utf8_without_validation("("sv))) + (TRY((((*this).codegen_unchecked_binary_op_assignment(lhs,rhs,((op).op),type_id))))))) + ((ByteString::from_utf8_without_validation(")"sv))));
 }
 else {
-return (((((ByteString::must_from_utf8("("sv))) + (TRY((((*this).codegen_checked_binary_op_assignment(lhs,rhs,((op).op),type_id))))))) + ((ByteString::must_from_utf8(")"sv))));
+return (((((ByteString::from_utf8_without_validation("("sv))) + (TRY((((*this).codegen_checked_binary_op_assignment(lhs,rhs,((op).op),type_id))))))) + ((ByteString::from_utf8_without_validation(")"sv))));
 }
 
 }
@@ -9599,10 +9599,10 @@ return JaktInternal::ExplicitValue<void>();
 case 28 /* SubtractAssign */: {
 {
 if (((((*this).compiler))->optimize)){
-return (((((ByteString::must_from_utf8("("sv))) + (TRY((((*this).codegen_unchecked_binary_op_assignment(lhs,rhs,((op).op),type_id))))))) + ((ByteString::must_from_utf8(")"sv))));
+return (((((ByteString::from_utf8_without_validation("("sv))) + (TRY((((*this).codegen_unchecked_binary_op_assignment(lhs,rhs,((op).op),type_id))))))) + ((ByteString::from_utf8_without_validation(")"sv))));
 }
 else {
-return (((((ByteString::must_from_utf8("("sv))) + (TRY((((*this).codegen_checked_binary_op_assignment(lhs,rhs,((op).op),type_id))))))) + ((ByteString::must_from_utf8(")"sv))));
+return (((((ByteString::from_utf8_without_validation("("sv))) + (TRY((((*this).codegen_checked_binary_op_assignment(lhs,rhs,((op).op),type_id))))))) + ((ByteString::from_utf8_without_validation(")"sv))));
 }
 
 }
@@ -9611,10 +9611,10 @@ return JaktInternal::ExplicitValue<void>();
 case 29 /* MultiplyAssign */: {
 {
 if (((((*this).compiler))->optimize)){
-return (((((ByteString::must_from_utf8("("sv))) + (TRY((((*this).codegen_unchecked_binary_op_assignment(lhs,rhs,((op).op),type_id))))))) + ((ByteString::must_from_utf8(")"sv))));
+return (((((ByteString::from_utf8_without_validation("("sv))) + (TRY((((*this).codegen_unchecked_binary_op_assignment(lhs,rhs,((op).op),type_id))))))) + ((ByteString::from_utf8_without_validation(")"sv))));
 }
 else {
-return (((((ByteString::must_from_utf8("("sv))) + (TRY((((*this).codegen_checked_binary_op_assignment(lhs,rhs,((op).op),type_id))))))) + ((ByteString::must_from_utf8(")"sv))));
+return (((((ByteString::from_utf8_without_validation("("sv))) + (TRY((((*this).codegen_checked_binary_op_assignment(lhs,rhs,((op).op),type_id))))))) + ((ByteString::from_utf8_without_validation(")"sv))));
 }
 
 }
@@ -9623,10 +9623,10 @@ return JaktInternal::ExplicitValue<void>();
 case 31 /* DivideAssign */: {
 {
 if (((((*this).compiler))->optimize)){
-return (((((ByteString::must_from_utf8("("sv))) + (TRY((((*this).codegen_unchecked_binary_op_assignment(lhs,rhs,((op).op),type_id))))))) + ((ByteString::must_from_utf8(")"sv))));
+return (((((ByteString::from_utf8_without_validation("("sv))) + (TRY((((*this).codegen_unchecked_binary_op_assignment(lhs,rhs,((op).op),type_id))))))) + ((ByteString::from_utf8_without_validation(")"sv))));
 }
 else {
-return (((((ByteString::must_from_utf8("("sv))) + (TRY((((*this).codegen_checked_binary_op_assignment(lhs,rhs,((op).op),type_id))))))) + ((ByteString::must_from_utf8(")"sv))));
+return (((((ByteString::from_utf8_without_validation("("sv))) + (TRY((((*this).codegen_checked_binary_op_assignment(lhs,rhs,((op).op),type_id))))))) + ((ByteString::from_utf8_without_validation(")"sv))));
 }
 
 }
@@ -9635,10 +9635,10 @@ return JaktInternal::ExplicitValue<void>();
 case 30 /* ModuloAssign */: {
 {
 if (((((*this).compiler))->optimize)){
-return (((((ByteString::must_from_utf8("("sv))) + (TRY((((*this).codegen_unchecked_binary_op_assignment(lhs,rhs,((op).op),type_id))))))) + ((ByteString::must_from_utf8(")"sv))));
+return (((((ByteString::from_utf8_without_validation("("sv))) + (TRY((((*this).codegen_unchecked_binary_op_assignment(lhs,rhs,((op).op),type_id))))))) + ((ByteString::from_utf8_without_validation(")"sv))));
 }
 else {
-return (((((ByteString::must_from_utf8("("sv))) + (TRY((((*this).codegen_checked_binary_op_assignment(lhs,rhs,((op).op),type_id))))))) + ((ByteString::must_from_utf8(")"sv))));
+return (((((ByteString::from_utf8_without_validation("("sv))) + (TRY((((*this).codegen_checked_binary_op_assignment(lhs,rhs,((op).op),type_id))))))) + ((ByteString::from_utf8_without_validation(")"sv))));
 }
 
 }
@@ -9657,7 +9657,7 @@ return JaktInternal::ExplicitValue<void>();
     _jakt_value.release_value();
 });
 }
-ByteString output = (ByteString::must_from_utf8("("sv));
+ByteString output = (ByteString::from_utf8_without_validation("("sv));
 [](ByteString& self, ByteString rhs) -> void {
 {
 (self = ((self) + (rhs)));
@@ -9674,94 +9674,94 @@ ByteString output = (ByteString::must_from_utf8("("sv));
 auto&& __jakt_match_variant = ((op).op);
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 0 /* Add */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8(" + "sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation(" + "sv)));
 };/*case end*/
 case 1 /* Subtract */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8(" - "sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation(" - "sv)));
 };/*case end*/
 case 2 /* Multiply */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8(" * "sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation(" * "sv)));
 };/*case end*/
 case 4 /* Modulo */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8(" % "sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation(" % "sv)));
 };/*case end*/
 case 3 /* Divide */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8(" / "sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation(" / "sv)));
 };/*case end*/
 case 21 /* Assign */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8(" = "sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation(" = "sv)));
 };/*case end*/
 case 27 /* AddAssign */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8(" += "sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation(" += "sv)));
 };/*case end*/
 case 28 /* SubtractAssign */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8(" -= "sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation(" -= "sv)));
 };/*case end*/
 case 29 /* MultiplyAssign */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8(" *= "sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation(" *= "sv)));
 };/*case end*/
 case 30 /* ModuloAssign */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8(" %= "sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation(" %= "sv)));
 };/*case end*/
 case 31 /* DivideAssign */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8(" /= "sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation(" /= "sv)));
 };/*case end*/
 case 22 /* BitwiseAndAssign */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8(" &= "sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation(" &= "sv)));
 };/*case end*/
 case 23 /* BitwiseOrAssign */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8(" |= "sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation(" |= "sv)));
 };/*case end*/
 case 24 /* BitwiseXorAssign */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8(" ^= "sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation(" ^= "sv)));
 };/*case end*/
 case 25 /* BitwiseLeftShiftAssign */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8(" <<= "sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation(" <<= "sv)));
 };/*case end*/
 case 26 /* BitwiseRightShiftAssign */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8(" >>= "sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation(" >>= "sv)));
 };/*case end*/
 case 9 /* Equal */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8(" == "sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation(" == "sv)));
 };/*case end*/
 case 10 /* NotEqual */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8(" != "sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation(" != "sv)));
 };/*case end*/
 case 5 /* LessThan */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8(" < "sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation(" < "sv)));
 };/*case end*/
 case 6 /* LessThanOrEqual */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8(" <= "sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation(" <= "sv)));
 };/*case end*/
 case 7 /* GreaterThan */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8(" > "sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation(" > "sv)));
 };/*case end*/
 case 8 /* GreaterThanOrEqual */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8(" >= "sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation(" >= "sv)));
 };/*case end*/
 case 18 /* LogicalAnd */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8(" && "sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation(" && "sv)));
 };/*case end*/
 case 19 /* LogicalOr */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8(" || "sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation(" || "sv)));
 };/*case end*/
 case 11 /* BitwiseAnd */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8(" & "sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation(" & "sv)));
 };/*case end*/
 case 13 /* BitwiseOr */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8(" | "sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation(" | "sv)));
 };/*case end*/
 case 12 /* BitwiseXor */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8(" ^ "sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation(" ^ "sv)));
 };/*case end*/
 case 16 /* ArithmeticLeftShift */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8(" << "sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation(" << "sv)));
 };/*case end*/
 case 14 /* BitwiseLeftShift */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8(" << "sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation(" << "sv)));
 };/*case end*/
 case 15 /* BitwiseRightShift */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8(" >> "sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation(" >> "sv)));
 };/*case end*/
 default: {
 {
@@ -9786,14 +9786,14 @@ utility::todo(__jakt_format((StringView::from_string_literal("codegen_binary_exp
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8(")"sv)));
+(output,(ByteString::from_utf8_without_validation(")"sv)));
 return output;
 }
 }
 
 ErrorOr<ByteString> codegen::CodeGenerator::codegen_unchecked_binary_op(NonnullRefPtr<typename types::CheckedExpression> const lhs,NonnullRefPtr<typename types::CheckedExpression> const rhs,parser::BinaryOperator const op,ids::TypeId const type_id) {
 {
-ByteString output = (ByteString::must_from_utf8("static_cast<"sv));
+ByteString output = (ByteString::from_utf8_without_validation("static_cast<"sv));
 [](ByteString& self, ByteString rhs) -> void {
 {
 (self = ((self) + (rhs)));
@@ -9805,7 +9805,7 @@ ByteString output = (ByteString::must_from_utf8("static_cast<"sv));
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8(">("sv)));
+(output,(ByteString::from_utf8_without_validation(">("sv)));
 [](ByteString& self, ByteString rhs) -> void {
 {
 (self = ((self) + (rhs)));
@@ -9822,19 +9822,19 @@ ByteString output = (ByteString::must_from_utf8("static_cast<"sv));
 auto&& __jakt_match_variant = op;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 0 /* Add */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8(" + "sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation(" + "sv)));
 };/*case end*/
 case 1 /* Subtract */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8(" - "sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation(" - "sv)));
 };/*case end*/
 case 2 /* Multiply */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8(" * "sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation(" * "sv)));
 };/*case end*/
 case 3 /* Divide */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8(" / "sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation(" / "sv)));
 };/*case end*/
 case 4 /* Modulo */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8(" % "sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation(" % "sv)));
 };/*case end*/
 default: {
 {
@@ -9859,20 +9859,20 @@ utility::panic(__jakt_format((StringView::from_string_literal("Checked binary op
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8(")"sv)));
+(output,(ByteString::from_utf8_without_validation(")"sv)));
 return output;
 }
 }
 
 ErrorOr<ByteString> codegen::CodeGenerator::codegen_checked_binary_op(NonnullRefPtr<typename types::CheckedExpression> const lhs,NonnullRefPtr<typename types::CheckedExpression> const rhs,parser::BinaryOperator const op,ids::TypeId const type_id) {
 {
-ByteString output = (ByteString::must_from_utf8(""sv));
+ByteString output = (ByteString::from_utf8_without_validation(""sv));
 [](ByteString& self, ByteString rhs) -> void {
 {
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8("JaktInternal::"sv)));
+(output,(ByteString::from_utf8_without_validation("JaktInternal::"sv)));
 [](ByteString& self, ByteString rhs) -> void {
 {
 (self = ((self) + (rhs)));
@@ -9883,19 +9883,19 @@ ByteString output = (ByteString::must_from_utf8(""sv));
 auto&& __jakt_match_variant = op;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 0 /* Add */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("checked_add"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("checked_add"sv)));
 };/*case end*/
 case 1 /* Subtract */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("checked_sub"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("checked_sub"sv)));
 };/*case end*/
 case 2 /* Multiply */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("checked_mul"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("checked_mul"sv)));
 };/*case end*/
 case 3 /* Divide */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("checked_div"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("checked_div"sv)));
 };/*case end*/
 case 4 /* Modulo */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("checked_mod"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("checked_mod"sv)));
 };/*case end*/
 default: {
 {
@@ -9914,7 +9914,7 @@ utility::panic(__jakt_format((StringView::from_string_literal("Checked binary op
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8("<"sv)));
+(output,(ByteString::from_utf8_without_validation("<"sv)));
 [](ByteString& self, ByteString rhs) -> void {
 {
 (self = ((self) + (rhs)));
@@ -9926,7 +9926,7 @@ utility::panic(__jakt_format((StringView::from_string_literal("Checked binary op
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8(">("sv)));
+(output,(ByteString::from_utf8_without_validation(">("sv)));
 [](ByteString& self, ByteString rhs) -> void {
 {
 (self = ((self) + (rhs)));
@@ -9938,7 +9938,7 @@ utility::panic(__jakt_format((StringView::from_string_literal("Checked binary op
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8(","sv)));
+(output,(ByteString::from_utf8_without_validation(","sv)));
 [](ByteString& self, ByteString rhs) -> void {
 {
 (self = ((self) + (rhs)));
@@ -9950,26 +9950,26 @@ utility::panic(__jakt_format((StringView::from_string_literal("Checked binary op
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8(")"sv)));
+(output,(ByteString::from_utf8_without_validation(")"sv)));
 return output;
 }
 }
 
 ErrorOr<ByteString> codegen::CodeGenerator::codegen_unchecked_binary_op_assignment(NonnullRefPtr<typename types::CheckedExpression> const lhs,NonnullRefPtr<typename types::CheckedExpression> const rhs,parser::BinaryOperator const op,ids::TypeId const type_id) {
 {
-ByteString output = (ByteString::must_from_utf8(""sv));
+ByteString output = (ByteString::from_utf8_without_validation(""sv));
 [](ByteString& self, ByteString rhs) -> void {
 {
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8("{"sv)));
+(output,(ByteString::from_utf8_without_validation("{"sv)));
 [](ByteString& self, ByteString rhs) -> void {
 {
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8("auto& _jakt_ref = "sv)));
+(output,(ByteString::from_utf8_without_validation("auto& _jakt_ref = "sv)));
 [](ByteString& self, ByteString rhs) -> void {
 {
 (self = ((self) + (rhs)));
@@ -9981,13 +9981,13 @@ ByteString output = (ByteString::must_from_utf8(""sv));
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8(";"sv)));
+(output,(ByteString::from_utf8_without_validation(";"sv)));
 [](ByteString& self, ByteString rhs) -> void {
 {
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8("_jakt_ref = static_cast<"sv)));
+(output,(ByteString::from_utf8_without_validation("_jakt_ref = static_cast<"sv)));
 [](ByteString& self, ByteString rhs) -> void {
 {
 (self = ((self) + (rhs)));
@@ -9999,7 +9999,7 @@ ByteString output = (ByteString::must_from_utf8(""sv));
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8(">(_jakt_ref "sv)));
+(output,(ByteString::from_utf8_without_validation(">(_jakt_ref "sv)));
 [](ByteString& self, ByteString rhs) -> void {
 {
 (self = ((self) + (rhs)));
@@ -10010,19 +10010,19 @@ ByteString output = (ByteString::must_from_utf8(""sv));
 auto&& __jakt_match_variant = op;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 27 /* AddAssign */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8(" + "sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation(" + "sv)));
 };/*case end*/
 case 28 /* SubtractAssign */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8(" - "sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation(" - "sv)));
 };/*case end*/
 case 29 /* MultiplyAssign */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8(" * "sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation(" * "sv)));
 };/*case end*/
 case 31 /* DivideAssign */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8(" / "sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation(" / "sv)));
 };/*case end*/
 case 30 /* ModuloAssign */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8(" % "sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation(" % "sv)));
 };/*case end*/
 default: {
 {
@@ -10047,32 +10047,32 @@ utility::panic(__jakt_format((StringView::from_string_literal("Checked binary op
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8(");"sv)));
+(output,(ByteString::from_utf8_without_validation(");"sv)));
 [](ByteString& self, ByteString rhs) -> void {
 {
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8("}"sv)));
+(output,(ByteString::from_utf8_without_validation("}"sv)));
 return output;
 }
 }
 
 ErrorOr<ByteString> codegen::CodeGenerator::codegen_checked_binary_op_assignment(NonnullRefPtr<typename types::CheckedExpression> const lhs,NonnullRefPtr<typename types::CheckedExpression> const rhs,parser::BinaryOperator const op,ids::TypeId const type_id) {
 {
-ByteString output = (ByteString::must_from_utf8(""sv));
+ByteString output = (ByteString::from_utf8_without_validation(""sv));
 [](ByteString& self, ByteString rhs) -> void {
 {
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8("{"sv)));
+(output,(ByteString::from_utf8_without_validation("{"sv)));
 [](ByteString& self, ByteString rhs) -> void {
 {
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8("auto& _jakt_ref = "sv)));
+(output,(ByteString::from_utf8_without_validation("auto& _jakt_ref = "sv)));
 [](ByteString& self, ByteString rhs) -> void {
 {
 (self = ((self) + (rhs)));
@@ -10084,13 +10084,13 @@ ByteString output = (ByteString::must_from_utf8(""sv));
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8(";"sv)));
+(output,(ByteString::from_utf8_without_validation(";"sv)));
 [](ByteString& self, ByteString rhs) -> void {
 {
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8("_jakt_ref = JaktInternal::"sv)));
+(output,(ByteString::from_utf8_without_validation("_jakt_ref = JaktInternal::"sv)));
 [](ByteString& self, ByteString rhs) -> void {
 {
 (self = ((self) + (rhs)));
@@ -10101,19 +10101,19 @@ ByteString output = (ByteString::must_from_utf8(""sv));
 auto&& __jakt_match_variant = op;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 27 /* AddAssign */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("checked_add"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("checked_add"sv)));
 };/*case end*/
 case 28 /* SubtractAssign */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("checked_sub"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("checked_sub"sv)));
 };/*case end*/
 case 29 /* MultiplyAssign */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("checked_mul"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("checked_mul"sv)));
 };/*case end*/
 case 31 /* DivideAssign */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("checked_div"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("checked_div"sv)));
 };/*case end*/
 case 30 /* ModuloAssign */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("checked_mod"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("checked_mod"sv)));
 };/*case end*/
 default: {
 {
@@ -10132,7 +10132,7 @@ utility::panic(__jakt_format((StringView::from_string_literal("Checked binary op
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8("<"sv)));
+(output,(ByteString::from_utf8_without_validation("<"sv)));
 [](ByteString& self, ByteString rhs) -> void {
 {
 (self = ((self) + (rhs)));
@@ -10144,7 +10144,7 @@ utility::panic(__jakt_format((StringView::from_string_literal("Checked binary op
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8(">(_jakt_ref, "sv)));
+(output,(ByteString::from_utf8_without_validation(">(_jakt_ref, "sv)));
 [](ByteString& self, ByteString rhs) -> void {
 {
 (self = ((self) + (rhs)));
@@ -10156,20 +10156,20 @@ utility::panic(__jakt_format((StringView::from_string_literal("Checked binary op
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8(");"sv)));
+(output,(ByteString::from_utf8_without_validation(");"sv)));
 [](ByteString& self, ByteString rhs) -> void {
 {
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8("}"sv)));
+(output,(ByteString::from_utf8_without_validation("}"sv)));
 return output;
 }
 }
 
 ErrorOr<ByteString> codegen::CodeGenerator::codegen_method_call(NonnullRefPtr<typename types::CheckedExpression> const expr,types::CheckedCall const call,bool const is_optional) {
 {
-ByteString output = (ByteString::must_from_utf8(""sv));
+ByteString output = (ByteString::from_utf8_without_validation(""sv));
 if (((call).callee_throws)){
 [](ByteString& self, ByteString rhs) -> void {
 {
@@ -10182,7 +10182,7 @@ if (((call).callee_throws)){
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8("(("sv)));
+(output,(ByteString::from_utf8_without_validation("(("sv)));
 }
 ByteString const object = TRY((((*this).codegen_expression_and_deref_if_generic_and_needed(expr))));
 if ((((((call).function_id)).has_value()) && ((((call).force_inline)).__jakt_init_index() == 2 /* ForceInline */))){
@@ -10203,7 +10203,7 @@ VERIFY_NOT_REACHED();
         return _jakt_value.release_return();
     _jakt_value.release_value();
 });
-NonnullRefPtr<types::CheckedVariable> const var = types::CheckedVariable::__jakt_create((ByteString::must_from_utf8("self"sv)),((((*this).program))->find_or_add_type_id(reference_type,((((expr)->type())).module),false)),is_mutable,((expr)->span()),JaktInternal::OptionalNone(),types::CheckedVisibility::Public(),JaktInternal::OptionalNone(),JaktInternal::OptionalNone(),JaktInternal::OptionalNone());
+NonnullRefPtr<types::CheckedVariable> const var = types::CheckedVariable::__jakt_create((ByteString::from_utf8_without_validation("self"sv)),((((*this).program))->find_or_add_type_id(reference_type,((((expr)->type())).module),false)),is_mutable,((expr)->span()),JaktInternal::OptionalNone(),types::CheckedVisibility::Public(),JaktInternal::OptionalNone(),JaktInternal::OptionalNone(),JaktInternal::OptionalNone());
 JaktInternal::DynamicArray<types::CheckedParameter> params = DynamicArray<types::CheckedParameter>::create_with({types::CheckedParameter(false,var,JaktInternal::OptionalNone())});
 {
 JaktInternal::ArrayIterator<types::CheckedParameter> _magic = ((((((function)->params))[(JaktInternal::Range<i64>{static_cast<i64>(static_cast<i64>(1LL)),static_cast<i64>(9223372036854775807LL)})])).iterator());
@@ -10226,7 +10226,7 @@ abort();
 }
 NonnullRefPtr<typename types::CheckedExpression> const lambda = types::CheckedExpression::Function(JaktInternal::OptionalNone(),DynamicArray<types::CheckedCapture>::create_with({}),params,((function)->can_throw),((function)->return_type_id),((function)->block),((expr)->span()),types::unknown_type_id(),((call).function_id),((function)->function_scope_id));
 JaktInternal::Optional<ByteString> const old_this_replacement = ((*this).this_replacement);
-(((*this).this_replacement) = (ByteString::must_from_utf8("self"sv)));
+(((*this).this_replacement) = (ByteString::from_utf8_without_validation("self"sv)));
 [](ByteString& self, ByteString rhs) -> void {
 {
 (self = ((self) + (rhs)));
@@ -10239,7 +10239,7 @@ JaktInternal::Optional<ByteString> const old_this_replacement = ((*this).this_re
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8("("sv)));
+(output,(ByteString::from_utf8_without_validation("("sv)));
 [](ByteString& self, ByteString rhs) -> void {
 {
 (self = ((self) + (rhs)));
@@ -10264,7 +10264,7 @@ NonnullRefPtr<typename types::CheckedExpression> const arg = ((jakt_____arg__).t
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8(","sv)));
+(output,(ByteString::from_utf8_without_validation(","sv)));
 [](ByteString& self, ByteString rhs) -> void {
 {
 (self = ((self) + (rhs)));
@@ -10281,14 +10281,14 @@ NonnullRefPtr<typename types::CheckedExpression> const arg = ((jakt_____arg__).t
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8(")"sv)));
+(output,(ByteString::from_utf8_without_validation(")"sv)));
 if (((call).callee_throws)){
 [](ByteString& self, ByteString rhs) -> void {
 {
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8("))"sv)));
+(output,(ByteString::from_utf8_without_validation("))"sv)));
 }
 return output;
 }
@@ -10299,7 +10299,7 @@ ByteString const field_accessor = ({
 auto&& __jakt_match_variant = name;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 2 /* Operator */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8(""sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation(""sv)));
 };/*case end*/
 default: {
 return JaktInternal::ExplicitValue(({
@@ -10307,7 +10307,7 @@ return JaktInternal::ExplicitValue(({
 auto&& __jakt_match_variant = *expression_type;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 26 /* RawPtr */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("->"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("->"sv)));
 };/*case end*/
 case 24 /* Struct */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Struct;ids::StructId const& id = __jakt_match_value.value;
@@ -10318,12 +10318,12 @@ auto __jakt_enum_value = ((((((((((*this).program))->get_struct(id))).record_typ
 return (!(((self) == (rhs))));
 }
 }
-(object,(ByteString::must_from_utf8("*this"sv)))));
+(object,(ByteString::from_utf8_without_validation("*this"sv)))));
 if (__jakt_enum_value == true) {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("->"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("->"sv)));
 }
 else if (__jakt_enum_value == false) {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("."sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("."sv)));
 }
 VERIFY_NOT_REACHED();
 }());
@@ -10341,12 +10341,12 @@ auto __jakt_enum_value = ((((((((((*this).program))->get_struct(id))).record_typ
 return (!(((self) == (rhs))));
 }
 }
-(object,(ByteString::must_from_utf8("*this"sv)))));
+(object,(ByteString::from_utf8_without_validation("*this"sv)))));
 if (__jakt_enum_value == true) {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("->"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("->"sv)));
 }
 else if (__jakt_enum_value == false) {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("."sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("."sv)));
 }
 VERIFY_NOT_REACHED();
 }());
@@ -10364,12 +10364,12 @@ auto __jakt_enum_value = ((((((((*this).program))->get_enum(id))).is_boxed) && [
 return (!(((self) == (rhs))));
 }
 }
-(object,(ByteString::must_from_utf8("*this"sv)))));
+(object,(ByteString::from_utf8_without_validation("*this"sv)))));
 if (__jakt_enum_value == true) {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("->"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("->"sv)));
 }
 else if (__jakt_enum_value == false) {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("."sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("."sv)));
 }
 VERIFY_NOT_REACHED();
 }());
@@ -10383,10 +10383,10 @@ return JaktInternal::ExplicitValue(({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<ByteString,ErrorOr<ByteString>>{
 auto __jakt_enum_value = ((((expression_type)->is_builtin()) && (!(((expression_type)->__jakt_init_index() == 13 /* JaktString */)))));
 if (__jakt_enum_value == true) {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8(""sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation(""sv)));
 }
 else if (__jakt_enum_value == false) {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("."sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("."sv)));
 }
 VERIFY_NOT_REACHED();
 }());
@@ -10428,7 +10428,7 @@ if ((!(((generic_parameters).is_empty())))){
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8("template "sv)));
+(output,(ByteString::from_utf8_without_validation("template "sv)));
 }
 [](ByteString& self, ByteString rhs) -> void {
 {
@@ -10458,7 +10458,7 @@ ids::TypeId gen_param = (_magic_value.value());
 (self = ((self) + (rhs)));
 }
 }
-(output,__jakt_format((StringView::from_string_literal("<{}>"sv)),utility::join(types,(ByteString::must_from_utf8(", "sv)))));
+(output,__jakt_format((StringView::from_string_literal("<{}>"sv)),utility::join(types,(ByteString::from_utf8_without_validation(", "sv)))));
 }
 }
 return {};
@@ -10471,7 +10471,7 @@ if (is_called_as_method){
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8("(("sv)));
+(output,(ByteString::from_utf8_without_validation("(("sv)));
 [](ByteString& self, ByteString rhs) -> void {
 {
 (self = ((self) + (rhs)));
@@ -10483,7 +10483,7 @@ if (is_called_as_method){
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8(")"sv)));
+(output,(ByteString::from_utf8_without_validation(")"sv)));
 [](ByteString& self, ByteString rhs) -> void {
 {
 (self = ((self) + (rhs)));
@@ -10498,7 +10498,7 @@ TRY((generate_method_name()));
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8("("sv)));
+(output,(ByteString::from_utf8_without_validation("("sv)));
 [](ByteString& self, ByteString rhs) -> void {
 {
 (self = ((self) + (rhs)));
@@ -10513,8 +10513,8 @@ if (is_optional){
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8("map([&](auto& _value) { return _value"sv)));
-ByteString access_operator = (ByteString::must_from_utf8("."sv));
+(output,(ByteString::from_utf8_without_validation("map([&](auto& _value) { return _value"sv)));
+ByteString access_operator = (ByteString::from_utf8_without_validation("."sv));
 if (((expression_type)->__jakt_init_index() == 20 /* GenericInstance */)){
 JaktInternal::DynamicArray<ids::TypeId> const args = (expression_type)->as.GenericInstance.args;
 if ([](size_t const& self, size_t rhs) -> bool {
@@ -10536,7 +10536,7 @@ case 24 /* Struct */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Struct;ids::StructId const& id = __jakt_match_value.value;
 {
 if (((((((((*this).program))->get_struct(id))).record_type)).__jakt_init_index() == 1 /* Class */)){
-(access_operator = (ByteString::must_from_utf8("->"sv)));
+(access_operator = (ByteString::from_utf8_without_validation("->"sv)));
 }
 }
 return JaktInternal::ExplicitValue<void>();
@@ -10545,7 +10545,7 @@ case 20 /* GenericInstance */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.GenericInstance;ids::StructId const& id = __jakt_match_value.id;
 {
 if (((((((((*this).program))->get_struct(id))).record_type)).__jakt_init_index() == 1 /* Class */)){
-(access_operator = (ByteString::must_from_utf8("->"sv)));
+(access_operator = (ByteString::from_utf8_without_validation("->"sv)));
 }
 }
 return JaktInternal::ExplicitValue<void>();
@@ -10578,7 +10578,7 @@ TRY((generate_method_name()));
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8("("sv)));
+(output,(ByteString::from_utf8_without_validation("("sv)));
 }
 bool first = is_called_as_method;
 {
@@ -10603,7 +10603,7 @@ else {
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8(","sv)));
+(output,(ByteString::from_utf8_without_validation(","sv)));
 }
 
 [](ByteString& self, ByteString rhs) -> void {
@@ -10623,7 +10623,7 @@ if (is_called_as_method){
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8(")"sv)));
+(output,(ByteString::from_utf8_without_validation(")"sv)));
 }
 if (is_optional){
 [](ByteString& self, ByteString rhs) -> void {
@@ -10631,21 +10631,21 @@ if (is_optional){
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8("; })"sv)));
+(output,(ByteString::from_utf8_without_validation("; })"sv)));
 }
 [](ByteString& self, ByteString rhs) -> void {
 {
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8(")"sv)));
+(output,(ByteString::from_utf8_without_validation(")"sv)));
 if (((call).callee_throws)){
 [](ByteString& self, ByteString rhs) -> void {
 {
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8("))"sv)));
+(output,(ByteString::from_utf8_without_validation("))"sv)));
 }
 return output;
 }
@@ -10653,7 +10653,7 @@ return output;
 
 ErrorOr<ByteString> codegen::CodeGenerator::codegen_call(types::CheckedCall const call) {
 {
-ByteString output = (ByteString::must_from_utf8(""sv));
+ByteString output = (ByteString::from_utf8_without_validation(""sv));
 if ((((((call).function_id)).has_value()) && ((((((*this).program))->get_function((((call).function_id).value()))))->is_comptime))){
 return __jakt_format((StringView::from_string_literal("fail_comptime_call<{}, \"Comptime function {} called outside Jakt compiler\">()"sv)),TRY((((*this).codegen_type(((call).return_type))))),((call).name));
 }
@@ -10669,33 +10669,33 @@ if (((call).callee_throws)){
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8("(("sv)));
+(output,(ByteString::from_utf8_without_validation("(("sv)));
 }
 ({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<void,ErrorOr<ByteString>>{
 auto __jakt_enum_value = (((call).name));
-if (__jakt_enum_value == (ByteString::must_from_utf8("print"sv))) {
+if (__jakt_enum_value == (ByteString::from_utf8_without_validation("print"sv))) {
 {
 ByteString const helper = ({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<ByteString,ErrorOr<ByteString>>{
 auto __jakt_enum_value = (((call).name));
-if (__jakt_enum_value == (ByteString::must_from_utf8("print"sv))) {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("out"sv)));
+if (__jakt_enum_value == (ByteString::from_utf8_without_validation("print"sv))) {
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("out"sv)));
 }
-else if (__jakt_enum_value == (ByteString::must_from_utf8("println"sv))) {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("outln"sv)));
+else if (__jakt_enum_value == (ByteString::from_utf8_without_validation("println"sv))) {
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("outln"sv)));
 }
-else if (__jakt_enum_value == (ByteString::must_from_utf8("eprint"sv))) {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("warn"sv)));
+else if (__jakt_enum_value == (ByteString::from_utf8_without_validation("eprint"sv))) {
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("warn"sv)));
 }
-else if (__jakt_enum_value == (ByteString::must_from_utf8("eprintln"sv))) {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("warnln"sv)));
+else if (__jakt_enum_value == (ByteString::from_utf8_without_validation("eprintln"sv))) {
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("warnln"sv)));
 }
-else if (__jakt_enum_value == (ByteString::must_from_utf8("format"sv))) {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("__jakt_format"sv)));
+else if (__jakt_enum_value == (ByteString::from_utf8_without_validation("format"sv))) {
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("__jakt_format"sv)));
 }
 else {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8(""sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation(""sv)));
 }
 }());
     if (_jakt_value.is_return())
@@ -10713,7 +10713,7 @@ return JaktInternal::ExplicitValue((ByteString::must_from_utf8(""sv)));
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8("("sv)));
+(output,(ByteString::from_utf8_without_validation("("sv)));
 {
 JaktInternal::Range<size_t> _magic = (JaktInternal::Range<size_t>{static_cast<size_t>(static_cast<size_t>(0ULL)),static_cast<size_t>(((((call).args)).size()))});
 for (;;){
@@ -10739,7 +10739,7 @@ if (((i) != (JaktInternal::checked_sub(((((call).args)).size()),static_cast<size
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8(","sv)));
+(output,(ByteString::from_utf8_without_validation(","sv)));
 }
 }
 
@@ -10751,32 +10751,32 @@ if (((i) != (JaktInternal::checked_sub(((((call).args)).size()),static_cast<size
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8(")"sv)));
+(output,(ByteString::from_utf8_without_validation(")"sv)));
 }
 return JaktInternal::ExplicitValue<void>();
 }
-else if (__jakt_enum_value == (ByteString::must_from_utf8("println"sv))) {
+else if (__jakt_enum_value == (ByteString::from_utf8_without_validation("println"sv))) {
 {
 ByteString const helper = ({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<ByteString,ErrorOr<ByteString>>{
 auto __jakt_enum_value = (((call).name));
-if (__jakt_enum_value == (ByteString::must_from_utf8("print"sv))) {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("out"sv)));
+if (__jakt_enum_value == (ByteString::from_utf8_without_validation("print"sv))) {
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("out"sv)));
 }
-else if (__jakt_enum_value == (ByteString::must_from_utf8("println"sv))) {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("outln"sv)));
+else if (__jakt_enum_value == (ByteString::from_utf8_without_validation("println"sv))) {
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("outln"sv)));
 }
-else if (__jakt_enum_value == (ByteString::must_from_utf8("eprint"sv))) {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("warn"sv)));
+else if (__jakt_enum_value == (ByteString::from_utf8_without_validation("eprint"sv))) {
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("warn"sv)));
 }
-else if (__jakt_enum_value == (ByteString::must_from_utf8("eprintln"sv))) {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("warnln"sv)));
+else if (__jakt_enum_value == (ByteString::from_utf8_without_validation("eprintln"sv))) {
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("warnln"sv)));
 }
-else if (__jakt_enum_value == (ByteString::must_from_utf8("format"sv))) {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("__jakt_format"sv)));
+else if (__jakt_enum_value == (ByteString::from_utf8_without_validation("format"sv))) {
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("__jakt_format"sv)));
 }
 else {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8(""sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation(""sv)));
 }
 }());
     if (_jakt_value.is_return())
@@ -10794,7 +10794,7 @@ return JaktInternal::ExplicitValue((ByteString::must_from_utf8(""sv)));
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8("("sv)));
+(output,(ByteString::from_utf8_without_validation("("sv)));
 {
 JaktInternal::Range<size_t> _magic = (JaktInternal::Range<size_t>{static_cast<size_t>(static_cast<size_t>(0ULL)),static_cast<size_t>(((((call).args)).size()))});
 for (;;){
@@ -10820,7 +10820,7 @@ if (((i) != (JaktInternal::checked_sub(((((call).args)).size()),static_cast<size
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8(","sv)));
+(output,(ByteString::from_utf8_without_validation(","sv)));
 }
 }
 
@@ -10832,32 +10832,32 @@ if (((i) != (JaktInternal::checked_sub(((((call).args)).size()),static_cast<size
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8(")"sv)));
+(output,(ByteString::from_utf8_without_validation(")"sv)));
 }
 return JaktInternal::ExplicitValue<void>();
 }
-else if (__jakt_enum_value == (ByteString::must_from_utf8("eprintln"sv))) {
+else if (__jakt_enum_value == (ByteString::from_utf8_without_validation("eprintln"sv))) {
 {
 ByteString const helper = ({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<ByteString,ErrorOr<ByteString>>{
 auto __jakt_enum_value = (((call).name));
-if (__jakt_enum_value == (ByteString::must_from_utf8("print"sv))) {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("out"sv)));
+if (__jakt_enum_value == (ByteString::from_utf8_without_validation("print"sv))) {
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("out"sv)));
 }
-else if (__jakt_enum_value == (ByteString::must_from_utf8("println"sv))) {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("outln"sv)));
+else if (__jakt_enum_value == (ByteString::from_utf8_without_validation("println"sv))) {
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("outln"sv)));
 }
-else if (__jakt_enum_value == (ByteString::must_from_utf8("eprint"sv))) {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("warn"sv)));
+else if (__jakt_enum_value == (ByteString::from_utf8_without_validation("eprint"sv))) {
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("warn"sv)));
 }
-else if (__jakt_enum_value == (ByteString::must_from_utf8("eprintln"sv))) {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("warnln"sv)));
+else if (__jakt_enum_value == (ByteString::from_utf8_without_validation("eprintln"sv))) {
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("warnln"sv)));
 }
-else if (__jakt_enum_value == (ByteString::must_from_utf8("format"sv))) {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("__jakt_format"sv)));
+else if (__jakt_enum_value == (ByteString::from_utf8_without_validation("format"sv))) {
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("__jakt_format"sv)));
 }
 else {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8(""sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation(""sv)));
 }
 }());
     if (_jakt_value.is_return())
@@ -10875,7 +10875,7 @@ return JaktInternal::ExplicitValue((ByteString::must_from_utf8(""sv)));
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8("("sv)));
+(output,(ByteString::from_utf8_without_validation("("sv)));
 {
 JaktInternal::Range<size_t> _magic = (JaktInternal::Range<size_t>{static_cast<size_t>(static_cast<size_t>(0ULL)),static_cast<size_t>(((((call).args)).size()))});
 for (;;){
@@ -10901,7 +10901,7 @@ if (((i) != (JaktInternal::checked_sub(((((call).args)).size()),static_cast<size
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8(","sv)));
+(output,(ByteString::from_utf8_without_validation(","sv)));
 }
 }
 
@@ -10913,32 +10913,32 @@ if (((i) != (JaktInternal::checked_sub(((((call).args)).size()),static_cast<size
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8(")"sv)));
+(output,(ByteString::from_utf8_without_validation(")"sv)));
 }
 return JaktInternal::ExplicitValue<void>();
 }
-else if (__jakt_enum_value == (ByteString::must_from_utf8("eprint"sv))) {
+else if (__jakt_enum_value == (ByteString::from_utf8_without_validation("eprint"sv))) {
 {
 ByteString const helper = ({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<ByteString,ErrorOr<ByteString>>{
 auto __jakt_enum_value = (((call).name));
-if (__jakt_enum_value == (ByteString::must_from_utf8("print"sv))) {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("out"sv)));
+if (__jakt_enum_value == (ByteString::from_utf8_without_validation("print"sv))) {
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("out"sv)));
 }
-else if (__jakt_enum_value == (ByteString::must_from_utf8("println"sv))) {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("outln"sv)));
+else if (__jakt_enum_value == (ByteString::from_utf8_without_validation("println"sv))) {
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("outln"sv)));
 }
-else if (__jakt_enum_value == (ByteString::must_from_utf8("eprint"sv))) {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("warn"sv)));
+else if (__jakt_enum_value == (ByteString::from_utf8_without_validation("eprint"sv))) {
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("warn"sv)));
 }
-else if (__jakt_enum_value == (ByteString::must_from_utf8("eprintln"sv))) {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("warnln"sv)));
+else if (__jakt_enum_value == (ByteString::from_utf8_without_validation("eprintln"sv))) {
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("warnln"sv)));
 }
-else if (__jakt_enum_value == (ByteString::must_from_utf8("format"sv))) {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("__jakt_format"sv)));
+else if (__jakt_enum_value == (ByteString::from_utf8_without_validation("format"sv))) {
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("__jakt_format"sv)));
 }
 else {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8(""sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation(""sv)));
 }
 }());
     if (_jakt_value.is_return())
@@ -10956,7 +10956,7 @@ return JaktInternal::ExplicitValue((ByteString::must_from_utf8(""sv)));
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8("("sv)));
+(output,(ByteString::from_utf8_without_validation("("sv)));
 {
 JaktInternal::Range<size_t> _magic = (JaktInternal::Range<size_t>{static_cast<size_t>(static_cast<size_t>(0ULL)),static_cast<size_t>(((((call).args)).size()))});
 for (;;){
@@ -10982,7 +10982,7 @@ if (((i) != (JaktInternal::checked_sub(((((call).args)).size()),static_cast<size
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8(","sv)));
+(output,(ByteString::from_utf8_without_validation(","sv)));
 }
 }
 
@@ -10994,32 +10994,32 @@ if (((i) != (JaktInternal::checked_sub(((((call).args)).size()),static_cast<size
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8(")"sv)));
+(output,(ByteString::from_utf8_without_validation(")"sv)));
 }
 return JaktInternal::ExplicitValue<void>();
 }
-else if (__jakt_enum_value == (ByteString::must_from_utf8("format"sv))) {
+else if (__jakt_enum_value == (ByteString::from_utf8_without_validation("format"sv))) {
 {
 ByteString const helper = ({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<ByteString,ErrorOr<ByteString>>{
 auto __jakt_enum_value = (((call).name));
-if (__jakt_enum_value == (ByteString::must_from_utf8("print"sv))) {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("out"sv)));
+if (__jakt_enum_value == (ByteString::from_utf8_without_validation("print"sv))) {
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("out"sv)));
 }
-else if (__jakt_enum_value == (ByteString::must_from_utf8("println"sv))) {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("outln"sv)));
+else if (__jakt_enum_value == (ByteString::from_utf8_without_validation("println"sv))) {
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("outln"sv)));
 }
-else if (__jakt_enum_value == (ByteString::must_from_utf8("eprint"sv))) {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("warn"sv)));
+else if (__jakt_enum_value == (ByteString::from_utf8_without_validation("eprint"sv))) {
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("warn"sv)));
 }
-else if (__jakt_enum_value == (ByteString::must_from_utf8("eprintln"sv))) {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("warnln"sv)));
+else if (__jakt_enum_value == (ByteString::from_utf8_without_validation("eprintln"sv))) {
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("warnln"sv)));
 }
-else if (__jakt_enum_value == (ByteString::must_from_utf8("format"sv))) {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("__jakt_format"sv)));
+else if (__jakt_enum_value == (ByteString::from_utf8_without_validation("format"sv))) {
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("__jakt_format"sv)));
 }
 else {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8(""sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation(""sv)));
 }
 }());
     if (_jakt_value.is_return())
@@ -11037,7 +11037,7 @@ return JaktInternal::ExplicitValue((ByteString::must_from_utf8(""sv)));
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8("("sv)));
+(output,(ByteString::from_utf8_without_validation("("sv)));
 {
 JaktInternal::Range<size_t> _magic = (JaktInternal::Range<size_t>{static_cast<size_t>(static_cast<size_t>(0ULL)),static_cast<size_t>(((((call).args)).size()))});
 for (;;){
@@ -11063,7 +11063,7 @@ if (((i) != (JaktInternal::checked_sub(((((call).args)).size()),static_cast<size
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8(","sv)));
+(output,(ByteString::from_utf8_without_validation(","sv)));
 }
 }
 
@@ -11075,7 +11075,7 @@ if (((i) != (JaktInternal::checked_sub(((((call).args)).size()),static_cast<size
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8(")"sv)));
+(output,(ByteString::from_utf8_without_validation(")"sv)));
 }
 return JaktInternal::ExplicitValue<void>();
 }
@@ -11115,7 +11115,7 @@ if (((((struct_).record_type)).__jakt_init_index() == 1 /* Class */)){
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8("::__jakt_create"sv)));
+(output,(ByteString::from_utf8_without_validation("::__jakt_create"sv)));
 }
 else {
 [](ByteString& self, ByteString rhs) -> void {
@@ -11146,7 +11146,7 @@ if (((((struct_).record_type)).__jakt_init_index() == 1 /* Class */)){
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8("<"sv)));
+(output,(ByteString::from_utf8_without_validation("<"sv)));
 bool first = true;
 {
 JaktInternal::ArrayIterator<ids::TypeId> _magic = ((args).iterator());
@@ -11163,7 +11163,7 @@ if ((!(first))){
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8(", "sv)));
+(output,(ByteString::from_utf8_without_validation(", "sv)));
 }
 else {
 (first = false);
@@ -11185,7 +11185,7 @@ else {
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8(">::__jakt_create"sv)));
+(output,(ByteString::from_utf8_without_validation(">::__jakt_create"sv)));
 }
 else {
 [](ByteString& self, ByteString rhs) -> void {
@@ -11199,7 +11199,7 @@ else {
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8("<"sv)));
+(output,(ByteString::from_utf8_without_validation("<"sv)));
 bool first = true;
 {
 JaktInternal::ArrayIterator<ids::TypeId> _magic = ((args).iterator());
@@ -11216,7 +11216,7 @@ if ((!(first))){
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8(", "sv)));
+(output,(ByteString::from_utf8_without_validation(", "sv)));
 }
 else {
 (first = false);
@@ -11238,7 +11238,7 @@ else {
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8(">"sv)));
+(output,(ByteString::from_utf8_without_validation(">"sv)));
 }
 
 }
@@ -11246,7 +11246,7 @@ return JaktInternal::ExplicitValue<void>();
 };/*case end*/
 default: {
 {
-utility::panic((ByteString::must_from_utf8("Should be unreachable"sv)));
+utility::panic((ByteString::from_utf8_without_validation("Should be unreachable"sv)));
 }
 return JaktInternal::ExplicitValue<void>();
 };/*case end*/
@@ -11279,20 +11279,20 @@ NonnullRefPtr<types::Module> const enum_type_module = ((((*this).program))->get_
 (self = ((self) + (rhs)));
 }
 }
-(output,(((ByteString::must_from_utf8("::"sv))) + (((((call).name_for_codegen())).as_name_for_use()))));
+(output,(((ByteString::from_utf8_without_validation("::"sv))) + (((((call).name_for_codegen())).as_name_for_use()))));
 }
 return JaktInternal::ExplicitValue<void>();
 };/*case end*/
 case 21 /* GenericEnumInstance */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.GenericEnumInstance;ids::EnumId const& id = __jakt_match_value.id;
 {
-utility::todo((ByteString::must_from_utf8("codegen generic enum instance"sv)));
+utility::todo((ByteString::from_utf8_without_validation("codegen generic enum instance"sv)));
 }
 return JaktInternal::ExplicitValue<void>();
 };/*case end*/
 default: {
 {
-utility::panic((ByteString::must_from_utf8("constructor expected enum type"sv)));
+utility::panic((ByteString::from_utf8_without_validation("constructor expected enum type"sv)));
 }
 return JaktInternal::ExplicitValue<void>();
 };/*case end*/
@@ -11358,7 +11358,7 @@ ids::TypeId gen_param = (_magic_value.value());
 (self = ((self) + (rhs)));
 }
 }
-(output,__jakt_format((StringView::from_string_literal("<{}>"sv)),utility::join(types,(ByteString::must_from_utf8(", "sv)))));
+(output,__jakt_format((StringView::from_string_literal("<{}>"sv)),utility::join(types,(ByteString::from_utf8_without_validation(", "sv)))));
 }
 JaktInternal::DynamicArray<ByteString> arguments = DynamicArray<ByteString>::create_with({});
 {
@@ -11381,7 +11381,7 @@ JaktInternal::Tuple<ByteString,NonnullRefPtr<typename types::CheckedExpression>>
 (self = ((self) + (rhs)));
 }
 }
-(output,__jakt_format((StringView::from_string_literal("({})"sv)),utility::join(arguments,(ByteString::must_from_utf8(","sv)))));
+(output,__jakt_format((StringView::from_string_literal("({})"sv)),utility::join(arguments,(ByteString::from_utf8_without_validation(","sv)))));
 }
 return JaktInternal::ExplicitValue<void>();
 }
@@ -11397,7 +11397,7 @@ if (((call).callee_throws)){
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8("))"sv)));
+(output,(ByteString::from_utf8_without_validation("))"sv)));
 }
 return output;
 }
@@ -11411,7 +11411,7 @@ if (((((func)->owner_scope)).has_value())){
 return TRY((((*this).codegen_namespace_qualifier((((func)->owner_scope).value()),false,((((call).name_for_codegen())).as_name_for_use()),((func)->owner_scope_generics)))));
 }
 }
-ByteString output = (ByteString::must_from_utf8(""sv));
+ByteString output = (ByteString::from_utf8_without_validation(""sv));
 size_t index = static_cast<size_t>(0ULL);
 {
 JaktInternal::ArrayIterator<types::ResolvedNamespace> _magic = ((((call).namespace_)).iterator());
@@ -11437,7 +11437,7 @@ if (((((namespace_).generic_parameters)).has_value())){
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8("<"sv)));
+(output,(ByteString::from_utf8_without_validation("<"sv)));
 size_t i = static_cast<size_t>(0ULL);
 {
 JaktInternal::ArrayIterator<ids::TypeId> _magic = (((((namespace_).generic_parameters).value())).iterator());
@@ -11460,7 +11460,7 @@ if (((i) != (JaktInternal::checked_sub((((((namespace_).generic_parameters).valu
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8(","sv)));
+(output,(ByteString::from_utf8_without_validation(","sv)));
 }
 (++(i));
 }
@@ -11473,14 +11473,14 @@ if (((i) != (JaktInternal::checked_sub((((((namespace_).generic_parameters).valu
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8(">"sv)));
+(output,(ByteString::from_utf8_without_validation(">"sv)));
 }
 [](ByteString& self, ByteString rhs) -> void {
 {
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8("::"sv)));
+(output,(ByteString::from_utf8_without_validation("::"sv)));
 (++(index));
 }
 
@@ -11493,7 +11493,7 @@ return output;
 
 ErrorOr<ByteString> codegen::CodeGenerator::codegen_block(types::CheckedBlock const block) {
 {
-ByteString output = (ByteString::must_from_utf8(""sv));
+ByteString output = (ByteString::from_utf8_without_validation(""sv));
 if (((((block).yielded_type)).has_value())){
 ids::TypeId const yielded_type = (((block).yielded_type).value());
 ByteString const type_output = TRY((((*this).codegen_type(yielded_type))));
@@ -11505,7 +11505,7 @@ ByteString const fresh_label = ((*this).fresh_label());
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8("({ Optional<"sv)));
+(output,(ByteString::from_utf8_without_validation("({ Optional<"sv)));
 [](ByteString& self, ByteString rhs) -> void {
 {
 (self = ((self) + (rhs)));
@@ -11517,7 +11517,7 @@ ByteString const fresh_label = ((*this).fresh_label());
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8("> "sv)));
+(output,(ByteString::from_utf8_without_validation("> "sv)));
 [](ByteString& self, ByteString rhs) -> void {
 {
 (self = ((self) + (rhs)));
@@ -11529,14 +11529,14 @@ ByteString const fresh_label = ((*this).fresh_label());
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8("; "sv)));
+(output,(ByteString::from_utf8_without_validation("; "sv)));
 }
 [](ByteString& self, ByteString rhs) -> void {
 {
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8("{\n"sv)));
+(output,(ByteString::from_utf8_without_validation("{\n"sv)));
 {
 JaktInternal::ArrayIterator<NonnullRefPtr<typename types::CheckedStatement>> _magic = ((((block).statements)).iterator());
 for (;;){
@@ -11562,7 +11562,7 @@ NonnullRefPtr<typename types::CheckedStatement> statement = (_magic_value.value(
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8("}\n"sv)));
+(output,(ByteString::from_utf8_without_validation("}\n"sv)));
 if (((((block).yielded_type)).has_value())){
 JaktInternal::Tuple<ByteString,ByteString> const var_label_ = (((((*this).entered_yieldable_blocks)).pop()).value());
 ByteString const var = ((var_label_).template get<0>());
@@ -11579,7 +11579,7 @@ ByteString const label = ((var_label_).template get<1>());
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8(":; "sv)));
+(output,(ByteString::from_utf8_without_validation(":; "sv)));
 [](ByteString& self, ByteString rhs) -> void {
 {
 (self = ((self) + (rhs)));
@@ -11592,14 +11592,14 @@ if ((!(((block).yielded_none)))){
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8(".release_value()"sv)));
+(output,(ByteString::from_utf8_without_validation(".release_value()"sv)));
 }
 [](ByteString& self, ByteString rhs) -> void {
 {
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8("; })"sv)));
+(output,(ByteString::from_utf8_without_validation("; })"sv)));
 }
 return output;
 }
@@ -11608,7 +11608,7 @@ return output;
 ErrorOr<ByteString> codegen::CodeGenerator::codegen_statement(NonnullRefPtr<typename types::CheckedStatement> const statement) {
 {
 bool add_newline = true;
-ByteString output = (ByteString::must_from_utf8(""sv));
+ByteString output = (ByteString::from_utf8_without_validation(""sv));
 if ((((((*this).debug_info)).statement_span_comments) && (((((statement)->span())).has_value()) && add_newline))){
 [](ByteString& self, ByteString rhs) -> void {
 {
@@ -11628,17 +11628,17 @@ auto&& __jakt_match_variant = *statement;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 11 /* Throw */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Throw;NonnullRefPtr<typename types::CheckedExpression> const& expr = __jakt_match_value.expr;
-return JaktInternal::ExplicitValue((((((ByteString::must_from_utf8("return "sv))) + (TRY((((*this).codegen_expression(expr))))))) + ((ByteString::must_from_utf8(";"sv)))));
+return JaktInternal::ExplicitValue((((((ByteString::from_utf8_without_validation("return "sv))) + (TRY((((*this).codegen_expression(expr))))))) + ((ByteString::from_utf8_without_validation(";"sv)))));
 };/*case end*/
 case 10 /* Continue */: {
 return JaktInternal::ExplicitValue(({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<ByteString,ErrorOr<ByteString>>{
 auto __jakt_enum_value = (((((*this).control_flow_state)).passes_through_match));
 if (__jakt_enum_value == true) {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("return JaktInternal::LoopContinue{};"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("return JaktInternal::LoopContinue{};"sv)));
 }
 else if (__jakt_enum_value == false) {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("continue;"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("continue;"sv)));
 }
 VERIFY_NOT_REACHED();
 }());
@@ -11652,10 +11652,10 @@ return JaktInternal::ExplicitValue(({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<ByteString,ErrorOr<ByteString>>{
 auto __jakt_enum_value = (((((*this).control_flow_state)).passes_through_match));
 if (__jakt_enum_value == true) {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("return JaktInternal::LoopBreak{};"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("return JaktInternal::LoopBreak{};"sv)));
 }
 else if (__jakt_enum_value == false) {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("break;"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("break;"sv)));
 }
 VERIFY_NOT_REACHED();
 }());
@@ -11666,18 +11666,18 @@ VERIFY_NOT_REACHED();
 };/*case end*/
 case 0 /* Expression */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Expression;NonnullRefPtr<typename types::CheckedExpression> const& expr = __jakt_match_value.expr;
-return JaktInternal::ExplicitValue(((TRY((((*this).codegen_expression(expr))))) + ((ByteString::must_from_utf8(";"sv)))));
+return JaktInternal::ExplicitValue(((TRY((((*this).codegen_expression(expr))))) + ((ByteString::from_utf8_without_validation(";"sv)))));
 };/*case end*/
 case 1 /* Defer */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Defer;NonnullRefPtr<typename types::CheckedStatement> const& statement = __jakt_match_value.statement;
 return JaktInternal::ExplicitValue(({ Optional<ByteString> __jakt_var_654; {
-ByteString output = (ByteString::must_from_utf8(""sv));
+ByteString output = (ByteString::from_utf8_without_validation(""sv));
 [](ByteString& self, ByteString rhs) -> void {
 {
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8("ScopeGuard "sv)));
+(output,(ByteString::from_utf8_without_validation("ScopeGuard "sv)));
 [](ByteString& self, ByteString rhs) -> void {
 {
 (self = ((self) + (rhs)));
@@ -11689,7 +11689,7 @@ ByteString output = (ByteString::must_from_utf8(""sv));
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8("([&] {\n"sv)));
+(output,(ByteString::from_utf8_without_validation("([&] {\n"sv)));
 codegen::ControlFlowState const last_control_flow = ((*this).control_flow_state);
 bool const old_inside_defer = ((*this).inside_defer);
 (((((*this).control_flow_state)).passes_through_match) = false);
@@ -11705,7 +11705,7 @@ bool const old_inside_defer = ((*this).inside_defer);
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8("});"sv)));
+(output,(ByteString::from_utf8_without_validation("});"sv)));
 (((*this).control_flow_state) = last_control_flow);
 (((*this).inside_defer) = old_inside_defer);
 __jakt_var_654 = output; goto __jakt_label_551;
@@ -11725,21 +11725,21 @@ auto __jakt_enum_value = ((((((*this).current_function).value()))->can_throw));
 if (__jakt_enum_value == true) {
 return JaktInternal::ExplicitValue(({ Optional<ByteString> __jakt_var_655; {
 NonnullRefPtr<typename types::Type> const type = ((((*this).program))->get_type((((val.value()))->type())));
-ByteString result = (ByteString::must_from_utf8(""sv));
+ByteString result = (ByteString::from_utf8_without_validation(""sv));
 if ((((type)->__jakt_init_index() == 0 /* Void */) || ((type)->__jakt_init_index() == 17 /* Never */))){
-(result = ((TRY((((*this).codegen_expression((val.value())))))) + ((ByteString::must_from_utf8("; return {}"sv)))));
+(result = ((TRY((((*this).codegen_expression((val.value())))))) + ((ByteString::from_utf8_without_validation("; return {}"sv)))));
 }
 else {
-(result = (((ByteString::must_from_utf8("return "sv))) + (TRY((((*this).codegen_expression((val.value()))))))));
+(result = (((ByteString::from_utf8_without_validation("return "sv))) + (TRY((((*this).codegen_expression((val.value()))))))));
 }
 
-__jakt_var_655 = ((result) + ((ByteString::must_from_utf8(";"sv)))); goto __jakt_label_552;
+__jakt_var_655 = ((result) + ((ByteString::from_utf8_without_validation(";"sv)))); goto __jakt_label_552;
 
 }
 __jakt_label_552:; __jakt_var_655.release_value(); }));
 }
 else if (__jakt_enum_value == false) {
-return JaktInternal::ExplicitValue((((((ByteString::must_from_utf8("return "sv))) + (TRY((((*this).codegen_expression((val.value())))))))) + ((ByteString::must_from_utf8(";"sv)))));
+return JaktInternal::ExplicitValue((((((ByteString::from_utf8_without_validation("return "sv))) + (TRY((((*this).codegen_expression((val.value())))))))) + ((ByteString::from_utf8_without_validation(";"sv)))));
 }
 VERIFY_NOT_REACHED();
 }());
@@ -11754,10 +11754,10 @@ __jakt_var_656 = ({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<ByteString,ErrorOr<ByteString>>{
 auto __jakt_enum_value = ((((((*this).current_function).value()))->can_throw));
 if (__jakt_enum_value == true) {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("return {};"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("return {};"sv)));
 }
 else if (__jakt_enum_value == false) {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("return;"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("return;"sv)));
 }
 VERIFY_NOT_REACHED();
 }());
@@ -11779,7 +11779,7 @@ VERIFY_NOT_REACHED();
 case 6 /* Loop */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Loop;types::CheckedBlock const& block = __jakt_match_value.block;
 return JaktInternal::ExplicitValue(({ Optional<ByteString> __jakt_var_657; {
-ByteString output = (ByteString::must_from_utf8(""sv));
+ByteString output = (ByteString::from_utf8_without_validation(""sv));
 if ((((((*this).debug_info)).statement_span_comments) && ((((statement)->span())).has_value()))){
 [](ByteString& self, ByteString rhs) -> void {
 {
@@ -11793,7 +11793,7 @@ if ((((((*this).debug_info)).statement_span_comments) && ((((statement)->span())
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8("for (;;)"sv)));
+(output,(ByteString::from_utf8_without_validation("for (;;)"sv)));
 (add_newline = false);
 codegen::ControlFlowState const last_control_flow = ((*this).control_flow_state);
 (((*this).control_flow_state) = ((last_control_flow).enter_loop()));
@@ -11814,7 +11814,7 @@ case 7 /* While */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.While;NonnullRefPtr<typename types::CheckedExpression> const& condition = __jakt_match_value.condition;
 types::CheckedBlock const& block = __jakt_match_value.block;
 return JaktInternal::ExplicitValue(({ Optional<ByteString> __jakt_var_658; {
-ByteString output = (ByteString::must_from_utf8(""sv));
+ByteString output = (ByteString::from_utf8_without_validation(""sv));
 if ((((((*this).debug_info)).statement_span_comments) && ((((statement)->span())).has_value()))){
 [](ByteString& self, ByteString rhs) -> void {
 {
@@ -11828,7 +11828,7 @@ if ((((((*this).debug_info)).statement_span_comments) && ((((statement)->span())
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8("while ("sv)));
+(output,(ByteString::from_utf8_without_validation("while ("sv)));
 [](ByteString& self, ByteString rhs) -> void {
 {
 (self = ((self) + (rhs)));
@@ -11840,7 +11840,7 @@ if ((((((*this).debug_info)).statement_span_comments) && ((((statement)->span())
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8(")"sv)));
+(output,(ByteString::from_utf8_without_validation(")"sv)));
 {
 codegen::ControlFlowState const last_control_flow = ((*this).control_flow_state);
 (((*this).control_flow_state) = ((last_control_flow).enter_loop()));
@@ -11866,14 +11866,14 @@ return JaktInternal::ExplicitValue(TRY((((*this).codegen_block(block)))));
 };/*case end*/
 case 14 /* Garbage */: {
 {
-utility::panic((ByteString::must_from_utf8("Garbage statement in codegen"sv)));
+utility::panic((ByteString::from_utf8_without_validation("Garbage statement in codegen"sv)));
 }
 };/*case end*/
 case 2 /* DestructuringAssignment */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.DestructuringAssignment;JaktInternal::DynamicArray<NonnullRefPtr<typename types::CheckedStatement>> const& vars = __jakt_match_value.vars;
 NonnullRefPtr<typename types::CheckedStatement> const& var_decl = __jakt_match_value.var_decl;
 return JaktInternal::ExplicitValue(({ Optional<ByteString> __jakt_var_659; {
-ByteString output = (ByteString::must_from_utf8(""sv));
+ByteString output = (ByteString::from_utf8_without_validation(""sv));
 [](ByteString& self, ByteString rhs) -> void {
 {
 (self = ((self) + (rhs)));
@@ -11910,7 +11910,7 @@ auto&& __jakt_match_value = __jakt_match_variant.as.VarDecl;ids::VarId const& va
 NonnullRefPtr<typename types::CheckedExpression> const& init = __jakt_match_value.init;
 return JaktInternal::ExplicitValue(({ Optional<ByteString> __jakt_var_660; {
 NonnullRefPtr<types::CheckedVariable> const var = ((((*this).program))->get_variable(var_id));
-ByteString output = (ByteString::must_from_utf8(""sv));
+ByteString output = (ByteString::from_utf8_without_validation(""sv));
 NonnullRefPtr<typename types::Type> const var_type = ((((*this).program))->get_type(((var)->type_id)));
 [](ByteString& self, ByteString rhs) -> void {
 {
@@ -11923,14 +11923,14 @@ NonnullRefPtr<typename types::Type> const var_type = ((((*this).program))->get_t
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8(" "sv)));
+(output,(ByteString::from_utf8_without_validation(" "sv)));
 if (((!(((var)->is_mutable))) && (!((((var_type)->__jakt_init_index() == 28 /* Reference */) || ((var_type)->__jakt_init_index() == 29 /* MutableReference */)))))){
 [](ByteString& self, ByteString rhs) -> void {
 {
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8("const "sv)));
+(output,(ByteString::from_utf8_without_validation("const "sv)));
 }
 [](ByteString& self, ByteString rhs) -> void {
 {
@@ -11943,7 +11943,7 @@ if (((!(((var)->is_mutable))) && (!((((var_type)->__jakt_init_index() == 28 /* R
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8(" = "sv)));
+(output,(ByteString::from_utf8_without_validation(" = "sv)));
 [](ByteString& self, ByteString rhs) -> void {
 {
 (self = ((self) + (rhs)));
@@ -11955,7 +11955,7 @@ if (((!(((var)->is_mutable))) && (!((((var_type)->__jakt_init_index() == 28 /* R
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8(";"sv)));
+(output,(ByteString::from_utf8_without_validation(";"sv)));
 __jakt_var_660 = output; goto __jakt_label_557;
 
 }
@@ -11964,7 +11964,7 @@ __jakt_label_557:; __jakt_var_660.release_value(); }));
 case 13 /* InlineCpp */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.InlineCpp;JaktInternal::DynamicArray<ByteString> const& lines = __jakt_match_value.lines;
 return JaktInternal::ExplicitValue(({ Optional<ByteString> __jakt_var_661; {
-ByteString output = (ByteString::must_from_utf8(""sv));
+ByteString output = (ByteString::from_utf8_without_validation(""sv));
 {
 JaktInternal::ArrayIterator<ByteString> _magic = ((lines).iterator());
 for (;;){
@@ -11975,8 +11975,8 @@ break;
 ByteString line = (_magic_value.value());
 {
 ByteString escaped_line = line;
-(escaped_line = ((escaped_line).replace((ByteString::must_from_utf8("\\\""sv)),(ByteString::must_from_utf8("\""sv)))));
-(escaped_line = ((escaped_line).replace((ByteString::must_from_utf8("\\\\"sv)),(ByteString::must_from_utf8("\\"sv)))));
+(escaped_line = ((escaped_line).replace((ByteString::from_utf8_without_validation("\\\""sv)),(ByteString::from_utf8_without_validation("\""sv)))));
+(escaped_line = ((escaped_line).replace((ByteString::from_utf8_without_validation("\\\\"sv)),(ByteString::from_utf8_without_validation("\\"sv)))));
 [](ByteString& self, ByteString rhs) -> void {
 {
 (self = ((self) + (rhs)));
@@ -11998,7 +11998,7 @@ auto&& __jakt_match_value = __jakt_match_variant.as.If;NonnullRefPtr<typename ty
 types::CheckedBlock const& then_block = __jakt_match_value.then_block;
 JaktInternal::Optional<NonnullRefPtr<typename types::CheckedStatement>> const& else_statement = __jakt_match_value.else_statement;
 return JaktInternal::ExplicitValue(({ Optional<ByteString> __jakt_var_662; {
-ByteString output = (ByteString::must_from_utf8(""sv));
+ByteString output = (ByteString::from_utf8_without_validation(""sv));
 if ((((((*this).debug_info)).statement_span_comments) && ((((statement)->span())).has_value()))){
 [](ByteString& self, ByteString rhs) -> void {
 {
@@ -12012,7 +12012,7 @@ if ((((((*this).debug_info)).statement_span_comments) && ((((statement)->span())
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8("if ("sv)));
+(output,(ByteString::from_utf8_without_validation("if ("sv)));
 [](ByteString& self, ByteString rhs) -> void {
 {
 (self = ((self) + (rhs)));
@@ -12024,7 +12024,7 @@ if ((((((*this).debug_info)).statement_span_comments) && ((((statement)->span())
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8(")"sv)));
+(output,(ByteString::from_utf8_without_validation(")"sv)));
 [](ByteString& self, ByteString rhs) -> void {
 {
 (self = ((self) + (rhs)));
@@ -12040,10 +12040,10 @@ if ((((((*this).debug_info)).statement_span_comments) && ((((statement)->span())
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<ByteString,ErrorOr<ByteString>>{
 auto __jakt_enum_value = (((else_statement).has_value()));
 if (__jakt_enum_value == true) {
-return JaktInternal::ExplicitValue((((ByteString::must_from_utf8("else "sv))) + (TRY((((*this).codegen_statement((else_statement.value()))))))));
+return JaktInternal::ExplicitValue((((ByteString::from_utf8_without_validation("else "sv))) + (TRY((((*this).codegen_statement((else_statement.value()))))))));
 }
 else if (__jakt_enum_value == false) {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8(""sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation(""sv)));
 }
 VERIFY_NOT_REACHED();
 }());
@@ -12061,9 +12061,9 @@ case 12 /* Yield */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Yield;NonnullRefPtr<typename types::CheckedExpression> const& expr = __jakt_match_value.expr;
 utility::Span const& span = __jakt_match_value.span;
 return JaktInternal::ExplicitValue(({ Optional<ByteString> __jakt_var_663; {
-ByteString output = (ByteString::must_from_utf8(""sv));
+ByteString output = (ByteString::from_utf8_without_validation(""sv));
 if (((((((*this).entered_yieldable_blocks)).size())) == (static_cast<size_t>(0ULL)))){
-utility::panic((ByteString::must_from_utf8("Must be in a block to yield"sv)));
+utility::panic((ByteString::from_utf8_without_validation("Must be in a block to yield"sv)));
 }
 JaktInternal::Tuple<ByteString,ByteString> const var_name_end_label_ = (((((*this).entered_yieldable_blocks)).last()).value());
 ByteString const var_name = ((var_name_end_label_).template get<0>());
@@ -12080,7 +12080,7 @@ ByteString const end_label = ((var_name_end_label_).template get<1>());
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8(" = "sv)));
+(output,(ByteString::from_utf8_without_validation(" = "sv)));
 [](ByteString& self, ByteString rhs) -> void {
 {
 (self = ((self) + (rhs)));
@@ -12092,7 +12092,7 @@ ByteString const end_label = ((var_name_end_label_).template get<1>());
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8("; goto "sv)));
+(output,(ByteString::from_utf8_without_validation("; goto "sv)));
 [](ByteString& self, ByteString rhs) -> void {
 {
 (self = ((self) + (rhs)));
@@ -12104,7 +12104,7 @@ ByteString const end_label = ((var_name_end_label_).template get<1>());
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8(";\n"sv)));
+(output,(ByteString::from_utf8_without_validation(";\n"sv)));
 __jakt_var_663 = output; goto __jakt_label_560;
 
 }
@@ -12123,7 +12123,7 @@ if (add_newline){
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8("\n"sv)));
+(output,(ByteString::from_utf8_without_validation("\n"sv)));
 }
 return output;
 }
@@ -12137,14 +12137,14 @@ return TRY((((*this).codegen_type_possibly_as_namespace(type_id,false))));
 
 ErrorOr<ByteString> codegen::CodeGenerator::codegen_type_possibly_as_namespace(ids::TypeId const type_id,bool const as_namespace) {
 {
-ByteString qualifiers = (ByteString::must_from_utf8(""sv));
+ByteString qualifiers = (ByteString::from_utf8_without_validation(""sv));
 if (((!(as_namespace)) && ((((((((*this).program))->get_type(type_id)))->common.init_common.qualifiers)).is_immutable))){
 [](ByteString& self, ByteString rhs) -> void {
 {
 (self = ((self) + (rhs)));
 }
 }
-(qualifiers,(ByteString::must_from_utf8(" const"sv)));
+(qualifiers,(ByteString::from_utf8_without_validation(" const"sv)));
 }
 if (((((*this).generic_inferences)).has_value())){
 JaktInternal::Dictionary<ids::TypeId,ids::TypeId> const mappings = (((*this).generic_inferences).value());
@@ -12158,55 +12158,55 @@ return ((({
 auto&& __jakt_match_variant = *((((*this).program))->get_type(type_id));
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 0 /* Void */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("void"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("void"sv)));
 };/*case end*/
 case 1 /* Bool */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("bool"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("bool"sv)));
 };/*case end*/
 case 2 /* U8 */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("u8"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("u8"sv)));
 };/*case end*/
 case 3 /* U16 */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("u16"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("u16"sv)));
 };/*case end*/
 case 4 /* U32 */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("u32"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("u32"sv)));
 };/*case end*/
 case 5 /* U64 */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("u64"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("u64"sv)));
 };/*case end*/
 case 6 /* I8 */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("i8"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("i8"sv)));
 };/*case end*/
 case 7 /* I16 */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("i16"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("i16"sv)));
 };/*case end*/
 case 8 /* I32 */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("i32"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("i32"sv)));
 };/*case end*/
 case 9 /* I64 */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("i64"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("i64"sv)));
 };/*case end*/
 case 10 /* F32 */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("f32"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("f32"sv)));
 };/*case end*/
 case 11 /* F64 */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("f64"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("f64"sv)));
 };/*case end*/
 case 12 /* Usize */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("size_t"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("size_t"sv)));
 };/*case end*/
 case 13 /* JaktString */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("ByteString"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("ByteString"sv)));
 };/*case end*/
 case 14 /* CChar */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("char"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("char"sv)));
 };/*case end*/
 case 15 /* CInt */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("int"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("int"sv)));
 };/*case end*/
 case 17 /* Never */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("void"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("void"sv)));
 };/*case end*/
 case 32 /* Const */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Const;types::Value const& value = __jakt_match_value.value;
@@ -12234,10 +12234,10 @@ return JaktInternal::ExplicitValue(({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<ByteString,ErrorOr<ByteString>>{
 auto __jakt_enum_value = (((((((*this).program))->get_type(type_id)))->is_boxed(((*this).program))));
 if (__jakt_enum_value == true) {
-return JaktInternal::ExplicitValue(((TRY((((*this).codegen_type_possibly_as_namespace(type_id,true))))) + ((ByteString::must_from_utf8("*"sv)))));
+return JaktInternal::ExplicitValue(((TRY((((*this).codegen_type_possibly_as_namespace(type_id,true))))) + ((ByteString::from_utf8_without_validation("*"sv)))));
 }
 else if (__jakt_enum_value == false) {
-return JaktInternal::ExplicitValue(((TRY((((*this).codegen_type(type_id))))) + ((ByteString::must_from_utf8("*"sv)))));
+return JaktInternal::ExplicitValue(((TRY((((*this).codegen_type(type_id))))) + ((ByteString::from_utf8_without_validation("*"sv)))));
 }
 VERIFY_NOT_REACHED();
 }());
@@ -12248,11 +12248,11 @@ VERIFY_NOT_REACHED();
 };/*case end*/
 case 28 /* Reference */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Reference;ids::TypeId const& type_id = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(((TRY((((*this).codegen_type(type_id))))) + ((ByteString::must_from_utf8(" const&"sv)))));
+return JaktInternal::ExplicitValue(((TRY((((*this).codegen_type(type_id))))) + ((ByteString::from_utf8_without_validation(" const&"sv)))));
 };/*case end*/
 case 29 /* MutableReference */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.MutableReference;ids::TypeId const& type_id = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(((TRY((((*this).codegen_type(type_id))))) + ((ByteString::must_from_utf8("&"sv)))));
+return JaktInternal::ExplicitValue(((TRY((((*this).codegen_type(type_id))))) + ((ByteString::from_utf8_without_validation("&"sv)))));
 };/*case end*/
 case 23 /* GenericResolvedType */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.GenericResolvedType;ids::StructId const& id = __jakt_match_value.id;
@@ -12305,14 +12305,14 @@ auto&& __jakt_match_value = __jakt_match_variant.as.Function;JaktInternal::Dynam
 bool const& can_throw = __jakt_match_value.can_throw;
 ids::TypeId const& return_type_id = __jakt_match_value.return_type_id;
 return JaktInternal::ExplicitValue(({ Optional<ByteString> __jakt_var_666; {
-ByteString output = (ByteString::must_from_utf8("Function<"sv));
+ByteString output = (ByteString::from_utf8_without_validation("Function<"sv));
 if (can_throw){
 [](ByteString& self, ByteString rhs) -> void {
 {
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8("ErrorOr<"sv)));
+(output,(ByteString::from_utf8_without_validation("ErrorOr<"sv)));
 }
 [](ByteString& self, ByteString rhs) -> void {
 {
@@ -12326,14 +12326,14 @@ if (can_throw){
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8(">"sv)));
+(output,(ByteString::from_utf8_without_validation(">"sv)));
 }
 [](ByteString& self, ByteString rhs) -> void {
 {
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8("("sv)));
+(output,(ByteString::from_utf8_without_validation("("sv)));
 bool first = true;
 {
 JaktInternal::ArrayIterator<ids::TypeId> _magic = ((params).iterator());
@@ -12353,7 +12353,7 @@ else {
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8(", "sv)));
+(output,(ByteString::from_utf8_without_validation(", "sv)));
 }
 
 [](ByteString& self, ByteString rhs) -> void {
@@ -12372,7 +12372,7 @@ else {
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8(")>"sv)));
+(output,(ByteString::from_utf8_without_validation(")>"sv)));
 __jakt_var_666 = output; goto __jakt_label_563;
 
 }
@@ -12380,12 +12380,12 @@ __jakt_label_563:; __jakt_var_666.release_value(); }));
 };/*case end*/
 case 22 /* GenericTraitInstance */: {
 {
-utility::panic((ByteString::must_from_utf8("Generic trait instance in codegen"sv)));
+utility::panic((ByteString::from_utf8_without_validation("Generic trait instance in codegen"sv)));
 }
 };/*case end*/
 default: {
 return JaktInternal::ExplicitValue(({ Optional<ByteString> __jakt_var_667; {
-__jakt_var_667 = (ByteString::must_from_utf8("auto"sv)); goto __jakt_label_564;
+__jakt_var_667 = (ByteString::from_utf8_without_validation("auto"sv)); goto __jakt_label_564;
 
 }
 __jakt_label_564:; __jakt_var_667.release_value(); }));
@@ -12402,16 +12402,16 @@ __jakt_label_564:; __jakt_var_667.release_value(); }));
 
 ErrorOr<ByteString> codegen::CodeGenerator::codegen_generic_type_instance(ids::StructId const id,JaktInternal::DynamicArray<ids::TypeId> const args,bool const as_namespace) {
 {
-ByteString output = (ByteString::must_from_utf8(""sv));
+ByteString output = (ByteString::from_utf8_without_validation(""sv));
 NonnullRefPtr<types::Module> const type_module = ((((*this).program))->get_module(((id).module)));
-ByteString namespace_ = (ByteString::must_from_utf8(""sv));
+ByteString namespace_ = (ByteString::from_utf8_without_validation(""sv));
 if (((type_module)->is_prelude())){
 [](ByteString& self, ByteString rhs) -> void {
 {
 (self = ((self) + (rhs)));
 }
 }
-(namespace_,(ByteString::must_from_utf8("JaktInternal::"sv)));
+(namespace_,(ByteString::from_utf8_without_validation("JaktInternal::"sv)));
 }
 JaktInternal::Optional<ids::StructId> const inner_weak_ptr_struct_id = TRY((((((*this).program))->check_and_extract_weak_ptr(id,args))));
 if (((inner_weak_ptr_struct_id).has_value())){
@@ -12420,7 +12420,7 @@ if (((inner_weak_ptr_struct_id).has_value())){
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8("WeakPtr<"sv)));
+(output,(ByteString::from_utf8_without_validation("WeakPtr<"sv)));
 [](ByteString& self, ByteString rhs) -> void {
 {
 (self = ((self) + (rhs)));
@@ -12446,7 +12446,7 @@ types::CheckedStruct const struct_ = ((((*this).program))->get_struct(inner_stru
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8(">"sv)));
+(output,(ByteString::from_utf8_without_validation(">"sv)));
 }
 else {
 types::CheckedStruct const struct_ = ((((*this).program))->get_struct(id));
@@ -12457,7 +12457,7 @@ if (acquired_by_ref){
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8("NonnullRefPtr<"sv)));
+(output,(ByteString::from_utf8_without_validation("NonnullRefPtr<"sv)));
 }
 [](ByteString& self, ByteString rhs) -> void {
 {
@@ -12482,7 +12482,7 @@ if (acquired_by_ref){
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8("<"sv)));
+(output,(ByteString::from_utf8_without_validation("<"sv)));
 bool first = true;
 {
 JaktInternal::ArrayIterator<ids::TypeId> _magic = ((args).iterator());
@@ -12499,7 +12499,7 @@ if ((!(first))){
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8(","sv)));
+(output,(ByteString::from_utf8_without_validation(","sv)));
 }
 else {
 (first = false);
@@ -12521,14 +12521,14 @@ else {
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8(">"sv)));
+(output,(ByteString::from_utf8_without_validation(">"sv)));
 if (acquired_by_ref){
 [](ByteString& self, ByteString rhs) -> void {
 {
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8(">"sv)));
+(output,(ByteString::from_utf8_without_validation(">"sv)));
 }
 }
 
@@ -12538,7 +12538,7 @@ return output;
 
 ErrorOr<ByteString> codegen::CodeGenerator::codegen_generic_enum_instance(ids::EnumId const id,JaktInternal::DynamicArray<ids::TypeId> const args,bool const as_namespace) {
 {
-ByteString output = (ByteString::must_from_utf8(""sv));
+ByteString output = (ByteString::from_utf8_without_validation(""sv));
 bool close_tag = false;
 types::CheckedEnum const enum_ = ((((*this).program))->get_enum(id));
 if (((!(as_namespace)) && ((enum_).is_boxed))){
@@ -12547,7 +12547,7 @@ if (((!(as_namespace)) && ((enum_).is_boxed))){
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8("NonnullRefPtr<"sv)));
+(output,(ByteString::from_utf8_without_validation("NonnullRefPtr<"sv)));
 ByteString const qualifier = TRY((((*this).codegen_namespace_qualifier(((enum_).scope_id),true,JaktInternal::OptionalNone(),JaktInternal::OptionalNone()))));
 if ((!(((qualifier).is_empty())))){
 [](ByteString& self, ByteString rhs) -> void {
@@ -12555,7 +12555,7 @@ if ((!(((qualifier).is_empty())))){
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8("typename "sv)));
+(output,(ByteString::from_utf8_without_validation("typename "sv)));
 [](ByteString& self, ByteString rhs) -> void {
 {
 (self = ((self) + (rhs)));
@@ -12580,7 +12580,7 @@ if ((!(as_namespace))){
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8("typename "sv)));
+(output,(ByteString::from_utf8_without_validation("typename "sv)));
 }
 [](ByteString& self, ByteString rhs) -> void {
 {
@@ -12602,7 +12602,7 @@ if ((!(as_namespace))){
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8("<"sv)));
+(output,(ByteString::from_utf8_without_validation("<"sv)));
 bool first = true;
 {
 JaktInternal::ArrayIterator<ids::TypeId> _magic = ((args).iterator());
@@ -12619,7 +12619,7 @@ if ((!(first))){
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8(", "sv)));
+(output,(ByteString::from_utf8_without_validation(", "sv)));
 }
 else {
 (first = false);
@@ -12641,14 +12641,14 @@ else {
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8(">"sv)));
+(output,(ByteString::from_utf8_without_validation(">"sv)));
 if (close_tag){
 [](ByteString& self, ByteString rhs) -> void {
 {
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8(">"sv)));
+(output,(ByteString::from_utf8_without_validation(">"sv)));
 }
 return output;
 }
@@ -12656,7 +12656,7 @@ return output;
 
 ErrorOr<ByteString> codegen::CodeGenerator::codegen_namespace_qualifier(ids::ScopeId const scope_id,bool const skip_current,JaktInternal::Optional<ByteString> const possible_constructor_name,JaktInternal::Optional<JaktInternal::Dictionary<ids::TypeId,ids::TypeId>> const generic_mappings) {
 {
-ByteString output = (ByteString::must_from_utf8(""sv));
+ByteString output = (ByteString::from_utf8_without_validation(""sv));
 JaktInternal::Optional<ids::ScopeId> current_scope_id = ({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<JaktInternal::Optional<ids::ScopeId>,ErrorOr<ByteString>>{
 auto __jakt_enum_value = (skip_current);
@@ -12694,7 +12694,7 @@ ByteString const args = ({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<ByteString,ErrorOr<ByteString>>{
 auto __jakt_enum_value = (((((scope)->relevant_type_id)).has_value()));
 if (__jakt_enum_value == false) {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8(""sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation(""sv)));
 }
 else if (__jakt_enum_value == true) {
 return JaktInternal::ExplicitValue(({ Optional<ByteString> __jakt_var_669; {
@@ -12772,7 +12772,7 @@ return type_id;
 ErrorOr<ByteString> codegen::CodeGenerator::codegen_function(NonnullRefPtr<types::CheckedFunction> const function,bool const as_method) {
 {
 if (((function)->is_comptime)){
-return (ByteString::must_from_utf8(""sv));
+return (ByteString::from_utf8_without_validation(""sv));
 }
 return TRY((((*this).codegen_function_in_namespace(function,JaktInternal::OptionalNone(),as_method,false,JaktInternal::OptionalNone()))));
 }
@@ -12780,7 +12780,7 @@ return TRY((((*this).codegen_function_in_namespace(function,JaktInternal::Option
 
 ErrorOr<ByteString> codegen::CodeGenerator::codegen_struct_type(ids::StructId const id,bool const as_namespace) {
 {
-ByteString output = (ByteString::must_from_utf8(""sv));
+ByteString output = (ByteString::from_utf8_without_validation(""sv));
 NonnullRefPtr<types::Module> const type_module = ((((*this).program))->get_module(((id).module)));
 types::CheckedStruct const checked_struct = ((((*this).program))->get_struct(id));
 if (((!(as_namespace)) && ((((checked_struct).record_type)).__jakt_init_index() == 1 /* Class */))){
@@ -12789,7 +12789,7 @@ if (((!(as_namespace)) && ((((checked_struct).record_type)).__jakt_init_index() 
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8("NonnullRefPtr<"sv)));
+(output,(ByteString::from_utf8_without_validation("NonnullRefPtr<"sv)));
 [](ByteString& self, ByteString rhs) -> void {
 {
 (self = ((self) + (rhs)));
@@ -12807,7 +12807,7 @@ if (((!(as_namespace)) && ((((checked_struct).record_type)).__jakt_init_index() 
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8(">"sv)));
+(output,(ByteString::from_utf8_without_validation(">"sv)));
 }
 else {
 [](ByteString& self, ByteString rhs) -> void {
@@ -12830,7 +12830,7 @@ return output;
 
 ErrorOr<ByteString> codegen::CodeGenerator::codegen_enum_type(ids::EnumId const id,bool const as_namespace) {
 {
-ByteString output = (ByteString::must_from_utf8(""sv));
+ByteString output = (ByteString::from_utf8_without_validation(""sv));
 NonnullRefPtr<types::Module> const type_module = ((((*this).program))->get_module(((id).module)));
 types::CheckedEnum const checked_enum = ((((*this).program))->get_enum(id));
 if (((!(as_namespace)) && ((checked_enum).is_boxed))){
@@ -12839,7 +12839,7 @@ if (((!(as_namespace)) && ((checked_enum).is_boxed))){
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8("NonnullRefPtr<"sv)));
+(output,(ByteString::from_utf8_without_validation("NonnullRefPtr<"sv)));
 ByteString const qualifier = TRY((((*this).codegen_namespace_qualifier(((checked_enum).scope_id),true,JaktInternal::OptionalNone(),JaktInternal::OptionalNone()))));
 if ((!(((qualifier).is_empty())))){
 [](ByteString& self, ByteString rhs) -> void {
@@ -12847,7 +12847,7 @@ if ((!(((qualifier).is_empty())))){
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8("typename "sv)));
+(output,(ByteString::from_utf8_without_validation("typename "sv)));
 [](ByteString& self, ByteString rhs) -> void {
 {
 (self = ((self) + (rhs)));
@@ -12866,7 +12866,7 @@ if ((!(((qualifier).is_empty())))){
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8(">"sv)));
+(output,(ByteString::from_utf8_without_validation(">"sv)));
 }
 else {
 ByteString const qualifier = TRY((((*this).codegen_namespace_qualifier(((checked_enum).scope_id),true,JaktInternal::OptionalNone(),JaktInternal::OptionalNone()))));
@@ -12892,26 +12892,26 @@ return output;
 
 ErrorOr<ByteString> codegen::CodeGenerator::codegen_destructor_predecl(types::CheckedStruct const& struct_) {
 {
-ByteString output = (ByteString::must_from_utf8(""sv));
+ByteString output = (ByteString::from_utf8_without_validation(""sv));
 [](ByteString& self, ByteString rhs) -> void {
 {
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8("public:\n"sv)));
+(output,(ByteString::from_utf8_without_validation("public:\n"sv)));
 [](ByteString& self, ByteString rhs) -> void {
 {
 (self = ((self) + (rhs)));
 }
 }
-(output,(((((ByteString::must_from_utf8("    ~"sv))) + (TRY((((((((struct_))).name_for_codegen())).as_name_for_definition())))))) + ((ByteString::must_from_utf8("();\n"sv)))));
+(output,(((((ByteString::from_utf8_without_validation("    ~"sv))) + (TRY((((((((struct_))).name_for_codegen())).as_name_for_definition())))))) + ((ByteString::from_utf8_without_validation("();\n"sv)))));
 return output;
 }
 }
 
 ErrorOr<ByteString> codegen::CodeGenerator::codegen_destructor(types::CheckedStruct const& struct_,NonnullRefPtr<types::CheckedFunction> const& function,bool const is_inline) {
 {
-ByteString output = (ByteString::must_from_utf8(""sv));
+ByteString output = (ByteString::from_utf8_without_validation(""sv));
 ByteString const qualified_name = TRY((((*this).codegen_type_possibly_as_namespace(((((struct_))).type_id),true))));
 if (((!(is_inline)) && (!(((((((struct_))).generic_parameters)).is_empty()))))){
 [](ByteString& self, ByteString rhs) -> void {
@@ -12919,7 +12919,7 @@ if (((!(is_inline)) && (!(((((((struct_))).generic_parameters)).is_empty()))))){
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8("template <"sv)));
+(output,(ByteString::from_utf8_without_validation("template <"sv)));
 [](ByteString& self, ByteString rhs) -> void {
 {
 (self = ((self) + (rhs)));
@@ -12931,7 +12931,7 @@ if (((!(is_inline)) && (!(((((((struct_))).generic_parameters)).is_empty()))))){
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8(">\n"sv)));
+(output,(ByteString::from_utf8_without_validation(">\n"sv)));
 }
 if (is_inline){
 [](ByteString& self, ByteString rhs) -> void {
@@ -12968,13 +12968,13 @@ if (((type_)->__jakt_init_index() == 24 /* Struct */)){
 ids::StructId const struct_id = (type_)->as.Struct.value;
 types::CheckedStruct const structure = ((((*this).program))->get_struct(struct_id));
 if (((((structure).record_type)).__jakt_init_index() == 1 /* Class */)){
-ByteString output = (ByteString::must_from_utf8(""sv));
+ByteString output = (ByteString::from_utf8_without_validation(""sv));
 [](ByteString& self, ByteString rhs) -> void {
 {
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8("protected:\n"sv)));
+(output,(ByteString::from_utf8_without_validation("protected:\n"sv)));
 [](ByteString& self, ByteString rhs) -> void {
 {
 (self = ((self) + (rhs)));
@@ -12997,7 +12997,7 @@ if ((!(first))){
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8(", "sv)));
+(output,(ByteString::from_utf8_without_validation(", "sv)));
 }
 else {
 (first = false);
@@ -13015,7 +13015,7 @@ ids::TypeId const param_type_id = ((((param).variable))->type_id);
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8(" a_"sv)));
+(output,(ByteString::from_utf8_without_validation(" a_"sv)));
 [](ByteString& self, ByteString rhs) -> void {
 {
 (self = ((self) + (rhs)));
@@ -13032,8 +13032,8 @@ ids::TypeId const param_type_id = ((((param).variable))->type_id);
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8(");\n"sv)));
-ByteString class_name_with_generics = (ByteString::must_from_utf8(""sv));
+(output,(ByteString::from_utf8_without_validation(");\n"sv)));
+ByteString class_name_with_generics = (ByteString::from_utf8_without_validation(""sv));
 [](ByteString& self, ByteString rhs) -> void {
 {
 (self = ((self) + (rhs)));
@@ -13056,7 +13056,7 @@ if ((!(first))){
 (self = ((self) + (rhs)));
 }
 }
-(class_name_with_generics,(ByteString::must_from_utf8(", "sv)));
+(class_name_with_generics,(ByteString::from_utf8_without_validation(", "sv)));
 }
 else {
 [](ByteString& self, ByteString rhs) -> void {
@@ -13064,7 +13064,7 @@ else {
 (self = ((self) + (rhs)));
 }
 }
-(class_name_with_generics,(ByteString::must_from_utf8("<"sv)));
+(class_name_with_generics,(ByteString::from_utf8_without_validation("<"sv)));
 (first = false);
 }
 
@@ -13085,14 +13085,14 @@ if ((!(((((structure).generic_parameters)).is_empty())))){
 (self = ((self) + (rhs)));
 }
 }
-(class_name_with_generics,(ByteString::must_from_utf8(">"sv)));
+(class_name_with_generics,(ByteString::from_utf8_without_validation(">"sv)));
 }
 [](ByteString& self, ByteString rhs) -> void {
 {
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8("public:\n"sv)));
+(output,(ByteString::from_utf8_without_validation("public:\n"sv)));
 [](ByteString& self, ByteString rhs) -> void {
 {
 (self = ((self) + (rhs)));
@@ -13104,7 +13104,7 @@ if ((!(((((structure).generic_parameters)).is_empty())))){
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8("("sv)));
+(output,(ByteString::from_utf8_without_validation("("sv)));
 (first = true);
 {
 JaktInternal::ArrayIterator<types::CheckedParameter> _magic = ((((function)->params)).iterator());
@@ -13121,7 +13121,7 @@ if ((!(first))){
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8(", "sv)));
+(output,(ByteString::from_utf8_without_validation(", "sv)));
 }
 else {
 (first = false);
@@ -13138,7 +13138,7 @@ else {
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8(" "sv)));
+(output,(ByteString::from_utf8_without_validation(" "sv)));
 [](ByteString& self, ByteString rhs) -> void {
 {
 (self = ((self) + (rhs)));
@@ -13155,10 +13155,10 @@ else {
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8(");\n"sv)));
+(output,(ByteString::from_utf8_without_validation(");\n"sv)));
 return output;
 }
-ByteString output = (ByteString::must_from_utf8(""sv));
+ByteString output = (ByteString::from_utf8_without_validation(""sv));
 [](ByteString& self, ByteString rhs) -> void {
 {
 (self = ((self) + (rhs)));
@@ -13170,7 +13170,7 @@ ByteString output = (ByteString::must_from_utf8(""sv));
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8("("sv)));
+(output,(ByteString::from_utf8_without_validation("("sv)));
 bool first = true;
 {
 JaktInternal::ArrayIterator<types::CheckedParameter> _magic = ((((function)->params)).iterator());
@@ -13187,7 +13187,7 @@ if ((!(first))){
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8(", "sv)));
+(output,(ByteString::from_utf8_without_validation(", "sv)));
 }
 else {
 (first = false);
@@ -13204,7 +13204,7 @@ else {
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8(" a_"sv)));
+(output,(ByteString::from_utf8_without_validation(" a_"sv)));
 [](ByteString& self, ByteString rhs) -> void {
 {
 (self = ((self) + (rhs)));
@@ -13221,11 +13221,11 @@ else {
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8(");\n"sv)));
+(output,(ByteString::from_utf8_without_validation(");\n"sv)));
 return output;
 }
 else {
-utility::panic((ByteString::must_from_utf8("internal error: call to a constructor, but not a struct/class type"sv)));
+utility::panic((ByteString::from_utf8_without_validation("internal error: call to a constructor, but not a struct/class type"sv)));
 }
 
 }
@@ -13239,14 +13239,14 @@ if (((type_)->__jakt_init_index() == 24 /* Struct */)){
 ids::StructId const struct_id = (type_)->as.Struct.value;
 types::CheckedStruct const structure = ((((*this).program))->get_struct(struct_id));
 ByteString const qualified_name = TRY((((*this).codegen_type_possibly_as_namespace(type_id,true))));
-ByteString output = (ByteString::must_from_utf8(""sv));
+ByteString output = (ByteString::from_utf8_without_validation(""sv));
 if (((!(is_inline)) && (!(((((structure).generic_parameters)).is_empty()))))){
 [](ByteString& self, ByteString rhs) -> void {
 {
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8("template <"sv)));
+(output,(ByteString::from_utf8_without_validation("template <"sv)));
 [](ByteString& self, ByteString rhs) -> void {
 {
 (self = ((self) + (rhs)));
@@ -13258,7 +13258,7 @@ if (((!(is_inline)) && (!(((((structure).generic_parameters)).is_empty()))))){
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8(">\n"sv)));
+(output,(ByteString::from_utf8_without_validation(">\n"sv)));
 }
 if ((((((structure).record_type)).__jakt_init_index() == 1 /* Class */) || ((((structure).record_type)).__jakt_init_index() == 0 /* Struct */))){
 if (is_inline){
@@ -13273,7 +13273,7 @@ if (is_inline){
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8("("sv)));
+(output,(ByteString::from_utf8_without_validation("("sv)));
 }
 else {
 [](ByteString& self, ByteString rhs) -> void {
@@ -13300,7 +13300,7 @@ if ((!(first))){
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8(", "sv)));
+(output,(ByteString::from_utf8_without_validation(", "sv)));
 }
 else {
 (first = false);
@@ -13318,7 +13318,7 @@ ids::TypeId const param_type_id = ((((param).variable))->type_id);
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8(" a_"sv)));
+(output,(ByteString::from_utf8_without_validation(" a_"sv)));
 [](ByteString& self, ByteString rhs) -> void {
 {
 (self = ((self) + (rhs)));
@@ -13335,14 +13335,14 @@ ids::TypeId const param_type_id = ((((param).variable))->type_id);
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8(")"sv)));
+(output,(ByteString::from_utf8_without_validation(")"sv)));
 if ((!(((((function)->params)).is_empty())))){
 [](ByteString& self, ByteString rhs) -> void {
 {
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8(": "sv)));
+(output,(ByteString::from_utf8_without_validation(": "sv)));
 JaktInternal::DynamicArray<ByteString> initializers = DynamicArray<ByteString>::create_with({});
 size_t const parent_constructor_parameter_count = JaktInternal::checked_sub(((((function)->params)).size()),((((structure).fields)).size()));
 if ([](size_t const& self, size_t rhs) -> bool {
@@ -13356,7 +13356,7 @@ return (infallible_enum_cast<jakt__prelude__operators::Ordering>((JaktInternal::
 }
 }
 (parent_constructor_parameter_count,static_cast<size_t>(0ULL))){
-ByteString parent_initializer = (ByteString::must_from_utf8(""sv));
+ByteString parent_initializer = (ByteString::from_utf8_without_validation(""sv));
 [](ByteString& self, ByteString rhs) -> void {
 {
 (self = ((self) + (rhs)));
@@ -13368,7 +13368,7 @@ ByteString parent_initializer = (ByteString::must_from_utf8(""sv));
 (self = ((self) + (rhs)));
 }
 }
-(parent_initializer,(ByteString::must_from_utf8("("sv)));
+(parent_initializer,(ByteString::from_utf8_without_validation("("sv)));
 JaktInternal::DynamicArray<ByteString> strings = DynamicArray<ByteString>::create_with({});
 {
 JaktInternal::ArrayIterator<types::CheckedParameter> _magic = ((((((function)->params))[(JaktInternal::Range<size_t>{static_cast<size_t>(static_cast<size_t>(0ULL)),static_cast<size_t>(parent_constructor_parameter_count)})])).iterator());
@@ -13379,7 +13379,7 @@ break;
 }
 types::CheckedParameter param = (_magic_value.value());
 {
-((strings).push((((((ByteString::must_from_utf8("move(a_"sv))) + (((((((param).variable))->name_for_codegen())).as_name_for_use())))) + ((ByteString::must_from_utf8(")"sv))))));
+((strings).push((((((ByteString::from_utf8_without_validation("move(a_"sv))) + (((((((param).variable))->name_for_codegen())).as_name_for_use())))) + ((ByteString::from_utf8_without_validation(")"sv))))));
 }
 
 }
@@ -13390,13 +13390,13 @@ types::CheckedParameter param = (_magic_value.value());
 (self = ((self) + (rhs)));
 }
 }
-(parent_initializer,utility::join(strings,(ByteString::must_from_utf8(", "sv))));
+(parent_initializer,utility::join(strings,(ByteString::from_utf8_without_validation(", "sv))));
 [](ByteString& self, ByteString rhs) -> void {
 {
 (self = ((self) + (rhs)));
 }
 }
-(parent_initializer,(ByteString::must_from_utf8(")"sv)));
+(parent_initializer,(ByteString::from_utf8_without_validation(")"sv)));
 ((initializers).push(parent_initializer));
 }
 {
@@ -13409,7 +13409,7 @@ break;
 size_t i = (_magic_value.value());
 {
 types::CheckedParameter const param = ((((function)->params))[i]);
-((initializers).push(((((((((((((param).variable))->name_for_codegen())).as_name_for_use())) + ((ByteString::must_from_utf8("(move(a_"sv))))) + (((((((param).variable))->name_for_codegen())).as_name_for_use())))) + ((ByteString::must_from_utf8("))"sv))))));
+((initializers).push(((((((((((((param).variable))->name_for_codegen())).as_name_for_use())) + ((ByteString::from_utf8_without_validation("(move(a_"sv))))) + (((((((param).variable))->name_for_codegen())).as_name_for_use())))) + ((ByteString::from_utf8_without_validation("))"sv))))));
 }
 
 }
@@ -13420,16 +13420,16 @@ types::CheckedParameter const param = ((((function)->params))[i]);
 (self = ((self) + (rhs)));
 }
 }
-(output,utility::join(initializers,(ByteString::must_from_utf8(", "sv))));
+(output,utility::join(initializers,(ByteString::from_utf8_without_validation(", "sv))));
 }
 [](ByteString& self, ByteString rhs) -> void {
 {
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8("{}\n"sv)));
+(output,(ByteString::from_utf8_without_validation("{}\n"sv)));
 if (((((structure).record_type)).__jakt_init_index() == 1 /* Class */)){
-ByteString class_name_with_generics = (ByteString::must_from_utf8(""sv));
+ByteString class_name_with_generics = (ByteString::from_utf8_without_validation(""sv));
 [](ByteString& self, ByteString rhs) -> void {
 {
 (self = ((self) + (rhs)));
@@ -13452,7 +13452,7 @@ if ((!(first))){
 (self = ((self) + (rhs)));
 }
 }
-(class_name_with_generics,(ByteString::must_from_utf8(", "sv)));
+(class_name_with_generics,(ByteString::from_utf8_without_validation(", "sv)));
 }
 else {
 [](ByteString& self, ByteString rhs) -> void {
@@ -13460,7 +13460,7 @@ else {
 (self = ((self) + (rhs)));
 }
 }
-(class_name_with_generics,(ByteString::must_from_utf8("<"sv)));
+(class_name_with_generics,(ByteString::from_utf8_without_validation("<"sv)));
 (first = false);
 }
 
@@ -13481,7 +13481,7 @@ if ((!(((((structure).generic_parameters)).is_empty())))){
 (self = ((self) + (rhs)));
 }
 }
-(class_name_with_generics,(ByteString::must_from_utf8(">"sv)));
+(class_name_with_generics,(ByteString::from_utf8_without_validation(">"sv)));
 }
 if (is_inline){
 [](ByteString& self, ByteString rhs) -> void {
@@ -13489,16 +13489,16 @@ if (is_inline){
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8("static "sv)));
+(output,(ByteString::from_utf8_without_validation("static "sv)));
 }
 ByteString const qualified_namespace = ({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<ByteString,ErrorOr<ByteString>>{
 auto __jakt_enum_value = (is_inline);
 if (__jakt_enum_value == true) {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8(""sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation(""sv)));
 }
 else if (__jakt_enum_value == false) {
-return JaktInternal::ExplicitValue(((qualified_name) + ((ByteString::must_from_utf8("::"sv)))));
+return JaktInternal::ExplicitValue(((qualified_name) + ((ByteString::from_utf8_without_validation("::"sv)))));
 }
 VERIFY_NOT_REACHED();
 }());
@@ -13517,7 +13517,7 @@ VERIFY_NOT_REACHED();
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8("("sv)));
+(output,(ByteString::from_utf8_without_validation("("sv)));
 (first = true);
 {
 JaktInternal::ArrayIterator<types::CheckedParameter> _magic = ((((function)->params)).iterator());
@@ -13534,7 +13534,7 @@ if ((!(first))){
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8(", "sv)));
+(output,(ByteString::from_utf8_without_validation(", "sv)));
 }
 else {
 (first = false);
@@ -13551,7 +13551,7 @@ else {
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8(" "sv)));
+(output,(ByteString::from_utf8_without_validation(" "sv)));
 [](ByteString& self, ByteString rhs) -> void {
 {
 (self = ((self) + (rhs)));
@@ -13585,7 +13585,7 @@ if ((!(first))){
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8(", "sv)));
+(output,(ByteString::from_utf8_without_validation(", "sv)));
 }
 else {
 (first = false);
@@ -13596,7 +13596,7 @@ else {
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8("move("sv)));
+(output,(ByteString::from_utf8_without_validation("move("sv)));
 [](ByteString& self, ByteString rhs) -> void {
 {
 (self = ((self) + (rhs)));
@@ -13608,7 +13608,7 @@ else {
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8(")"sv)));
+(output,(ByteString::from_utf8_without_validation(")"sv)));
 }
 
 }
@@ -13619,7 +13619,7 @@ else {
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8(")); return o; }"sv)));
+(output,(ByteString::from_utf8_without_validation(")); return o; }"sv)));
 }
 return output;
 }
@@ -13635,7 +13635,7 @@ if ((!(is_inline))){
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8("::"sv)));
+(output,(ByteString::from_utf8_without_validation("::"sv)));
 }
 [](ByteString& self, ByteString rhs) -> void {
 {
@@ -13648,7 +13648,7 @@ if ((!(is_inline))){
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8("("sv)));
+(output,(ByteString::from_utf8_without_validation("("sv)));
 bool first = true;
 {
 JaktInternal::ArrayIterator<types::CheckedParameter> _magic = ((((function)->params)).iterator());
@@ -13665,7 +13665,7 @@ if ((!(first))){
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8(", "sv)));
+(output,(ByteString::from_utf8_without_validation(", "sv)));
 }
 else {
 (first = false);
@@ -13682,7 +13682,7 @@ else {
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8(" a_"sv)));
+(output,(ByteString::from_utf8_without_validation(" a_"sv)));
 [](ByteString& self, ByteString rhs) -> void {
 {
 (self = ((self) + (rhs)));
@@ -13699,14 +13699,14 @@ else {
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8(") "sv)));
+(output,(ByteString::from_utf8_without_validation(") "sv)));
 if ((!(((((function)->params)).is_empty())))){
 [](ByteString& self, ByteString rhs) -> void {
 {
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8(":"sv)));
+(output,(ByteString::from_utf8_without_validation(":"sv)));
 }
 (first = true);
 {
@@ -13724,7 +13724,7 @@ if ((!(first))){
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8(", "sv)));
+(output,(ByteString::from_utf8_without_validation(", "sv)));
 }
 else {
 (first = false);
@@ -13741,7 +13741,7 @@ else {
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8("(move(a_"sv)));
+(output,(ByteString::from_utf8_without_validation("(move(a_"sv)));
 [](ByteString& self, ByteString rhs) -> void {
 {
 (self = ((self) + (rhs)));
@@ -13753,7 +13753,7 @@ else {
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8("))"sv)));
+(output,(ByteString::from_utf8_without_validation("))"sv)));
 }
 
 }
@@ -13764,11 +13764,11 @@ else {
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8("{}\n"sv)));
+(output,(ByteString::from_utf8_without_validation("{}\n"sv)));
 return output;
 }
 else {
-utility::panic((ByteString::must_from_utf8("internal error: call to a constructor, but not a struct/class type"sv)));
+utility::panic((ByteString::from_utf8_without_validation("internal error: call to a constructor, but not a struct/class type"sv)));
 }
 
 }
@@ -13778,13 +13778,13 @@ ErrorOr<ByteString> codegen::CodeGenerator::codegen_function_in_namespace(Nonnul
 {
 if ((!(((((((function)->generics))->params)).is_empty())))){
 if (((((function)->linkage)).__jakt_init_index() == 1 /* External */)){
-return (ByteString::must_from_utf8(""sv));
+return (ByteString::from_utf8_without_validation(""sv));
 }
 }
 if (((((function)->force_inline)).__jakt_init_index() == 2 /* ForceInline */)){
-return (ByteString::must_from_utf8(""sv));
+return (ByteString::from_utf8_without_validation(""sv));
 }
-ByteString output = (ByteString::must_from_utf8(""sv));
+ByteString output = (ByteString::from_utf8_without_validation(""sv));
 if ((!(skip_template))){
 [](ByteString& self, ByteString rhs) -> void {
 {
@@ -13793,14 +13793,14 @@ if ((!(skip_template))){
 }
 (output,TRY((((*this).codegen_function_generic_parameters(function)))));
 }
-bool const is_main = (((((((function)->name_for_codegen())).as_name_for_use())) == ((ByteString::must_from_utf8("main"sv)))) && (!(((containing_struct).has_value()))));
+bool const is_main = (((((((function)->name_for_codegen())).as_name_for_use())) == ((ByteString::from_utf8_without_validation("main"sv)))) && (!(((containing_struct).has_value()))));
 if (((((function)->force_inline)).__jakt_init_index() == 1 /* MakeDefinitionAvailable */)){
 [](ByteString& self, ByteString rhs) -> void {
 {
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8("__attribute__((always_inline)) inline "sv)));
+(output,(ByteString::from_utf8_without_validation("__attribute__((always_inline)) inline "sv)));
 }
 if (((((function)->return_type_id)).equals(types::never_type_id()))){
 [](ByteString& self, ByteString rhs) -> void {
@@ -13808,7 +13808,7 @@ if (((((function)->return_type_id)).equals(types::never_type_id()))){
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8("[[noreturn]] "sv)));
+(output,(ByteString::from_utf8_without_validation("[[noreturn]] "sv)));
 }
 if (is_main){
 [](ByteString& self, ByteString rhs) -> void {
@@ -13816,7 +13816,7 @@ if (is_main){
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8("ErrorOr<int>"sv)));
+(output,(ByteString::from_utf8_without_validation("ErrorOr<int>"sv)));
 }
 else {
 if ((as_method && ((function)->is_static()))){
@@ -13825,7 +13825,7 @@ if ((as_method && ((function)->is_static()))){
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8("static "sv)));
+(output,(ByteString::from_utf8_without_validation("static "sv)));
 }
 if ((!(((((function)->type)).__jakt_init_index() == 1 /* Destructor */)))){
 [](ByteString& self, ByteString rhs) -> void {
@@ -13856,14 +13856,14 @@ VERIFY_NOT_REACHED();
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8(" "sv)));
+(output,(ByteString::from_utf8_without_validation(" "sv)));
 if (is_main){
 [](ByteString& self, ByteString rhs) -> void {
 {
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8("main"sv)));
+(output,(ByteString::from_utf8_without_validation("main"sv)));
 }
 else {
 ByteString const qualifier = ({
@@ -13873,7 +13873,7 @@ if (__jakt_enum_value == true) {
 return JaktInternal::ExplicitValue(TRY((((*this).codegen_type_possibly_as_namespace((containing_struct.value()),true)))));
 }
 else if (__jakt_enum_value == false) {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8(""sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation(""sv)));
 }
 VERIFY_NOT_REACHED();
 }());
@@ -13893,7 +13893,7 @@ if ((!(((qualifier).is_empty())))){
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8("::"sv)));
+(output,(ByteString::from_utf8_without_validation("::"sv)));
 }
 if (((((function)->type)).__jakt_init_index() == 1 /* Destructor */)){
 if (((((((*this).program))->get_type((containing_struct.value()))))->__jakt_init_index() == 24 /* Struct */)){
@@ -13903,10 +13903,10 @@ ids::StructId const struct_id = (((((*this).program))->get_type((containing_stru
 (self = ((self) + (rhs)));
 }
 }
-(output,(((ByteString::must_from_utf8("~"sv))) + (TRY((((((((((*this).program))->get_struct(struct_id))).name_for_codegen())).as_name_for_definition()))))));
+(output,(((ByteString::from_utf8_without_validation("~"sv))) + (TRY((((((((((*this).program))->get_struct(struct_id))).name_for_codegen())).as_name_for_definition()))))));
 }
 else {
-utility::panic((ByteString::must_from_utf8("Destructor doesn't have a containing struct"sv)));
+utility::panic((ByteString::from_utf8_without_validation("Destructor doesn't have a containing struct"sv)));
 }
 
 }
@@ -13927,7 +13927,7 @@ if (((explicit_generic_instantiation).has_value())){
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8("<"sv)));
+(output,(ByteString::from_utf8_without_validation("<"sv)));
 bool first = true;
 {
 JaktInternal::ArrayIterator<ids::TypeId> _magic = (((explicit_generic_instantiation.value())).iterator());
@@ -13944,7 +13944,7 @@ if ((!(first))){
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8(", "sv)));
+(output,(ByteString::from_utf8_without_validation(", "sv)));
 }
 else {
 (first = false);
@@ -13966,21 +13966,21 @@ else {
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8(">"sv)));
+(output,(ByteString::from_utf8_without_validation(">"sv)));
 }
 [](ByteString& self, ByteString rhs) -> void {
 {
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8("("sv)));
+(output,(ByteString::from_utf8_without_validation("("sv)));
 if ((is_main && ((((function)->params)).is_empty()))){
 [](ByteString& self, ByteString rhs) -> void {
 {
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8("DynamicArray<ByteString>"sv)));
+(output,(ByteString::from_utf8_without_validation("DynamicArray<ByteString>"sv)));
 }
 bool first = true;
 {
@@ -13993,7 +13993,7 @@ break;
 types::CheckedParameter param = (_magic_value.value());
 {
 NonnullRefPtr<types::CheckedVariable> const variable = ((param).variable);
-if (((((variable)->name)) == ((ByteString::must_from_utf8("this"sv))))){
+if (((((variable)->name)) == ((ByteString::from_utf8_without_validation("this"sv))))){
 continue;
 }
 if ((!(first))){
@@ -14002,7 +14002,7 @@ if ((!(first))){
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8(","sv)));
+(output,(ByteString::from_utf8_without_validation(","sv)));
 }
 else {
 (first = false);
@@ -14020,14 +14020,14 @@ NonnullRefPtr<typename types::Type> const variable_type = ((((*this).program))->
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8(" "sv)));
+(output,(ByteString::from_utf8_without_validation(" "sv)));
 if (((!(((variable)->is_mutable))) && (!((((variable_type)->__jakt_init_index() == 28 /* Reference */) || ((variable_type)->__jakt_init_index() == 29 /* MutableReference */)))))){
 [](ByteString& self, ByteString rhs) -> void {
 {
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8("const "sv)));
+(output,(ByteString::from_utf8_without_validation("const "sv)));
 }
 [](ByteString& self, ByteString rhs) -> void {
 {
@@ -14045,28 +14045,28 @@ if (((!(((variable)->is_mutable))) && (!((((variable_type)->__jakt_init_index() 
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8(")"sv)));
+(output,(ByteString::from_utf8_without_validation(")"sv)));
 if (((!(((function)->is_static()))) && (!(((function)->is_mutating()))))){
 [](ByteString& self, ByteString rhs) -> void {
 {
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8(" const"sv)));
+(output,(ByteString::from_utf8_without_validation(" const"sv)));
 }
 [](ByteString& self, ByteString rhs) -> void {
 {
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8(" {\n"sv)));
+(output,(ByteString::from_utf8_without_validation(" {\n"sv)));
 if (is_main){
 [](ByteString& self, ByteString rhs) -> void {
 {
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8("\n\n            #ifdef _WIN32\n            SetConsoleOutputCP(CP_UTF8);\n            // Enable buffering to prevent VS from chopping up UTF-8 byte sequences\n            setvbuf(stdout, nullptr, _IOFBF, 1000);\n            #endif\n"sv)));
+(output,(ByteString::from_utf8_without_validation("\n\n            #ifdef _WIN32\n            SetConsoleOutputCP(CP_UTF8);\n            // Enable buffering to prevent VS from chopping up UTF-8 byte sequences\n            setvbuf(stdout, nullptr, _IOFBF, 1000);\n            #endif\n"sv)));
 }
 codegen::ControlFlowState const last_control_flow = ((*this).control_flow_state);
 (((*this).control_flow_state) = ((last_control_flow).enter_function()));
@@ -14084,7 +14084,7 @@ if (is_main){
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8("return 0;\n"sv)));
+(output,(ByteString::from_utf8_without_validation("return 0;\n"sv)));
 }
 else {
 if ((((function)->can_throw) && ((((function)->return_type_id)).equals(types::builtin(types::BuiltinType::Void()))))){
@@ -14093,7 +14093,7 @@ if ((((function)->can_throw) && ((((function)->return_type_id)).equals(types::bu
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8("return {};\n"sv)));
+(output,(ByteString::from_utf8_without_validation("return {};\n"sv)));
 }
 }
 
@@ -14102,14 +14102,14 @@ if ((((function)->can_throw) && ((((function)->return_type_id)).equals(types::bu
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8("}\n"sv)));
+(output,(ByteString::from_utf8_without_validation("}\n"sv)));
 return output;
 }
 }
 
 ErrorOr<ByteString> codegen::CodeGenerator::codegen_lambda_block(bool const can_throw,types::CheckedBlock const block,ids::TypeId const return_type_id) {
 {
-ByteString output = (ByteString::must_from_utf8("{\n"sv));
+ByteString output = (ByteString::from_utf8_without_validation("{\n"sv));
 [](ByteString& self, ByteString rhs) -> void {
 {
 (self = ((self) + (rhs)));
@@ -14122,14 +14122,14 @@ if ((can_throw && ((return_type_id).equals(types::builtin(types::BuiltinType::Vo
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8("return {};\n"sv)));
+(output,(ByteString::from_utf8_without_validation("return {};\n"sv)));
 }
 [](ByteString& self, ByteString rhs) -> void {
 {
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8("}\n"sv)));
+(output,(ByteString::from_utf8_without_validation("}\n"sv)));
 return output;
 }
 }

--- a/bootstrap/stage0/compiler.cpp
+++ b/bootstrap/stage0/compiler.cpp
@@ -189,7 +189,7 @@ return (warnln((StringView::from_string_literal("\u001b[31;1mError\u001b[0m Coul
 }
 else {
 {
-utility::panic((ByteString::must_from_utf8("Incurred unrecognized error while trying to open file"sv)));
+utility::panic((ByteString::from_utf8_without_validation("Incurred unrecognized error while trying to open file"sv)));
 }
 return JaktInternal::ExplicitValue<void>();
 }
@@ -230,7 +230,7 @@ outln((StringView::from_string_literal("{}"sv)),message);
 
 ErrorOr<void> compiler::Compiler::load_prelude() {
 {
-ByteString const module_name = (ByteString::must_from_utf8("__prelude__"sv));
+ByteString const module_name = (ByteString::from_utf8_without_validation("__prelude__"sv));
 jakt__path::Path const file_name = jakt__path::Path::from_string(module_name);
 ((*this).get_file_id_or_register(file_name));
 }
@@ -242,7 +242,7 @@ ErrorOr<JaktInternal::Optional<jakt__path::Path>> compiler::Compiler::search_for
 ByteStringBuilder builder = ByteStringBuilder::create();
 ((builder).append(static_cast<u8>(47)));
 ByteString const separator = ((builder).to_string());
-ByteString const module_name = ((input_module_name).replace((ByteString::must_from_utf8("::"sv)),separator));
+ByteString const module_name = ((input_module_name).replace((ByteString::from_utf8_without_validation("::"sv)),separator));
 if ((!(relative_import))){
 {
 JaktInternal::ArrayIterator<ByteString> _magic = ((((*this).include_paths)).iterator());
@@ -253,7 +253,7 @@ break;
 }
 ByteString include_path = (_magic_value.value());
 {
-jakt__path::Path const candidate_path = jakt__path::Path::from_parts(DynamicArray<ByteString>::create_with({include_path, ((module_name) + ((ByteString::must_from_utf8(".jakt"sv))))}));
+jakt__path::Path const candidate_path = jakt__path::Path::from_parts(DynamicArray<ByteString>::create_with({include_path, ((module_name) + ((ByteString::from_utf8_without_validation(".jakt"sv))))}));
 if (((candidate_path).exists())){
 return candidate_path;
 }
@@ -263,15 +263,15 @@ return candidate_path;
 }
 
 }
-ByteString const standard_module_name = (ByteString::must_from_utf8("jakt"sv));
+ByteString const standard_module_name = (ByteString::from_utf8_without_validation("jakt"sv));
 if (((module_name).starts_with(standard_module_name))){
 ByteString const std_module_name_path = ((module_name).substring(JaktInternal::checked_add(((standard_module_name).length()),static_cast<size_t>(1ULL)),JaktInternal::checked_sub(((module_name).length()),JaktInternal::checked_add(((standard_module_name).length()),static_cast<size_t>(1ULL)))));
-jakt__path::Path const candidate_path = jakt__path::Path::from_parts(DynamicArray<ByteString>::create_with({((((*this).std_include_path)).to_string()), ((std_module_name_path) + ((ByteString::must_from_utf8(".jakt"sv))))}));
+jakt__path::Path const candidate_path = jakt__path::Path::from_parts(DynamicArray<ByteString>::create_with({((((*this).std_include_path)).to_string()), ((std_module_name_path) + ((ByteString::from_utf8_without_validation(".jakt"sv))))}));
 if (((candidate_path).exists())){
 return candidate_path;
 }
 }
-return TRY((((*this).find_in_search_paths(jakt__path::Path::from_string(((module_name) + ((ByteString::must_from_utf8(".jakt"sv))))),relative_import,parent_path_count))));
+return TRY((((*this).find_in_search_paths(jakt__path::Path::from_string(((module_name) + ((ByteString::from_utf8_without_validation(".jakt"sv))))),relative_import,parent_path_count))));
 }
 }
 

--- a/bootstrap/stage0/error.cpp
+++ b/bootstrap/stage0/error.cpp
@@ -748,10 +748,10 @@ return ({
 auto&& __jakt_match_variant = *this;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 0 /* Hint */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("Hint"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("Hint"sv)));
 };/*case end*/
 case 1 /* Error */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("Error"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("Error"sv)));
 };/*case end*/
 default: VERIFY_NOT_REACHED();}/*switch end*/
 }()
@@ -770,10 +770,10 @@ return ({
 auto&& __jakt_match_variant = *this;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 0 /* Hint */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("94"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("94"sv)));
 };/*case end*/
 case 1 /* Error */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("31"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("31"sv)));
 };/*case end*/
 default: VERIFY_NOT_REACHED();}/*switch end*/
 }()

--- a/bootstrap/stage0/formatter.cpp
+++ b/bootstrap/stage0/formatter.cpp
@@ -63,10 +63,10 @@ return JaktInternal::ExplicitValue(__jakt_format((StringView::from_string_litera
 };/*case end*/
 case 55 /* Eol */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Eol;JaktInternal::Optional<ByteString> const& comment = __jakt_match_value.comment;
-return JaktInternal::ExplicitValue(__jakt_format((StringView::from_string_literal("Eol: {}"sv)),TRY((comment.try_value_or_lazy_evaluated([&]() -> ErrorOr<ByteString> { return (ByteString::must_from_utf8(""sv)); })))));
+return JaktInternal::ExplicitValue(__jakt_format((StringView::from_string_literal("Eol: {}"sv)),TRY((comment.try_value_or_lazy_evaluated([&]() -> ErrorOr<ByteString> { return (ByteString::from_utf8_without_validation(""sv)); })))));
 };/*case end*/
 case 56 /* Eof */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("Eof"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("Eof"sv)));
 };/*case end*/
 default: {
 return JaktInternal::ExplicitValue(TRY((((*this).token_text()))));
@@ -90,7 +90,7 @@ switch(__jakt_match_variant.__jakt_init_index()) {
 case 0 /* SingleQuotedString */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.SingleQuotedString;ByteString const& quote = __jakt_match_value.quote;
 JaktInternal::Optional<ByteString> const& prefix = __jakt_match_value.prefix;
-return JaktInternal::ExplicitValue(__jakt_format((StringView::from_string_literal("{}'{}'"sv)),TRY((prefix.try_value_or_lazy_evaluated([&]() -> ErrorOr<ByteString> { return (ByteString::must_from_utf8(""sv)); }))),quote));
+return JaktInternal::ExplicitValue(__jakt_format((StringView::from_string_literal("{}'{}'"sv)),TRY((prefix.try_value_or_lazy_evaluated([&]() -> ErrorOr<ByteString> { return (ByteString::from_utf8_without_validation(""sv)); }))),quote));
 };/*case end*/
 case 1 /* QuotedString */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.QuotedString;ByteString const& quote = __jakt_match_value.quote;
@@ -107,331 +107,331 @@ auto&& __jakt_match_value = __jakt_match_variant.as.Identifier;ByteString const&
 return JaktInternal::ExplicitValue(name);
 };/*case end*/
 case 4 /* Semicolon */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8(";"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation(";"sv)));
 };/*case end*/
 case 5 /* Colon */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8(":"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation(":"sv)));
 };/*case end*/
 case 6 /* ColonColon */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("::"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("::"sv)));
 };/*case end*/
 case 7 /* LParen */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("("sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("("sv)));
 };/*case end*/
 case 8 /* RParen */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8(")"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation(")"sv)));
 };/*case end*/
 case 9 /* LCurly */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("{"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("{"sv)));
 };/*case end*/
 case 10 /* RCurly */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("}"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("}"sv)));
 };/*case end*/
 case 11 /* LSquare */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("["sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("["sv)));
 };/*case end*/
 case 12 /* RSquare */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("]"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("]"sv)));
 };/*case end*/
 case 13 /* PercentSign */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("%"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("%"sv)));
 };/*case end*/
 case 14 /* Plus */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("+"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("+"sv)));
 };/*case end*/
 case 15 /* Minus */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("-"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("-"sv)));
 };/*case end*/
 case 16 /* Equal */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("="sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("="sv)));
 };/*case end*/
 case 17 /* PlusEqual */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("+="sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("+="sv)));
 };/*case end*/
 case 18 /* PlusPlus */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("++"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("++"sv)));
 };/*case end*/
 case 19 /* MinusEqual */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("-="sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("-="sv)));
 };/*case end*/
 case 20 /* MinusMinus */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("--"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("--"sv)));
 };/*case end*/
 case 21 /* AsteriskEqual */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("*="sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("*="sv)));
 };/*case end*/
 case 22 /* ForwardSlashEqual */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("/="sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("/="sv)));
 };/*case end*/
 case 23 /* PercentSignEqual */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("%="sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("%="sv)));
 };/*case end*/
 case 24 /* NotEqual */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("!="sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("!="sv)));
 };/*case end*/
 case 25 /* DoubleEqual */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("=="sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("=="sv)));
 };/*case end*/
 case 26 /* GreaterThan */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8(">"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation(">"sv)));
 };/*case end*/
 case 27 /* GreaterThanOrEqual */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8(">="sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation(">="sv)));
 };/*case end*/
 case 28 /* LessThan */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("<"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("<"sv)));
 };/*case end*/
 case 29 /* LessThanOrEqual */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("<="sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("<="sv)));
 };/*case end*/
 case 30 /* LeftArithmeticShift */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("<<<"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("<<<"sv)));
 };/*case end*/
 case 31 /* LeftShift */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("<<"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("<<"sv)));
 };/*case end*/
 case 32 /* LeftShiftEqual */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("<<="sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("<<="sv)));
 };/*case end*/
 case 33 /* RightShift */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8(">>"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation(">>"sv)));
 };/*case end*/
 case 34 /* RightArithmeticShift */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8(">>>"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation(">>>"sv)));
 };/*case end*/
 case 35 /* RightShiftEqual */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8(">>="sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation(">>="sv)));
 };/*case end*/
 case 36 /* Asterisk */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("*"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("*"sv)));
 };/*case end*/
 case 37 /* Ampersand */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("&"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("&"sv)));
 };/*case end*/
 case 38 /* AmpersandEqual */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("&="sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("&="sv)));
 };/*case end*/
 case 39 /* AmpersandAmpersand */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("&&"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("&&"sv)));
 };/*case end*/
 case 40 /* Pipe */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("|"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("|"sv)));
 };/*case end*/
 case 41 /* PipeEqual */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("|="sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("|="sv)));
 };/*case end*/
 case 42 /* PipePipe */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("||"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("||"sv)));
 };/*case end*/
 case 43 /* Caret */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("^"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("^"sv)));
 };/*case end*/
 case 44 /* CaretEqual */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("^="sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("^="sv)));
 };/*case end*/
 case 45 /* Dollar */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("$"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("$"sv)));
 };/*case end*/
 case 46 /* Tilde */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("~"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("~"sv)));
 };/*case end*/
 case 47 /* ForwardSlash */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("/"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("/"sv)));
 };/*case end*/
 case 48 /* ExclamationPoint */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("!"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("!"sv)));
 };/*case end*/
 case 49 /* QuestionMark */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("?"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("?"sv)));
 };/*case end*/
 case 50 /* QuestionMarkQuestionMark */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("??"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("??"sv)));
 };/*case end*/
 case 51 /* QuestionMarkQuestionMarkEqual */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("??="sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("??="sv)));
 };/*case end*/
 case 52 /* Comma */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8(","sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation(","sv)));
 };/*case end*/
 case 53 /* Dot */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("."sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("."sv)));
 };/*case end*/
 case 54 /* DotDot */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8(".."sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation(".."sv)));
 };/*case end*/
 case 55 /* Eol */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8(""sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation(""sv)));
 };/*case end*/
 case 56 /* Eof */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8(""sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation(""sv)));
 };/*case end*/
 case 57 /* FatArrow */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("=>"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("=>"sv)));
 };/*case end*/
 case 58 /* Arrow */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("->"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("->"sv)));
 };/*case end*/
 case 59 /* And */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("and"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("and"sv)));
 };/*case end*/
 case 60 /* Anon */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("anon"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("anon"sv)));
 };/*case end*/
 case 61 /* As */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("as"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("as"sv)));
 };/*case end*/
 case 62 /* Boxed */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("boxed"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("boxed"sv)));
 };/*case end*/
 case 63 /* Break */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("break"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("break"sv)));
 };/*case end*/
 case 64 /* Catch */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("catch"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("catch"sv)));
 };/*case end*/
 case 65 /* Class */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("class"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("class"sv)));
 };/*case end*/
 case 66 /* Continue */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("continue"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("continue"sv)));
 };/*case end*/
 case 67 /* Cpp */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("cpp"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("cpp"sv)));
 };/*case end*/
 case 68 /* Defer */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("defer"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("defer"sv)));
 };/*case end*/
 case 69 /* Destructor */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("destructor"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("destructor"sv)));
 };/*case end*/
 case 70 /* Else */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("else"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("else"sv)));
 };/*case end*/
 case 71 /* Enum */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("enum"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("enum"sv)));
 };/*case end*/
 case 72 /* Extern */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("extern"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("extern"sv)));
 };/*case end*/
 case 73 /* False */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("false"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("false"sv)));
 };/*case end*/
 case 74 /* For */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("for"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("for"sv)));
 };/*case end*/
 case 75 /* Fn */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("fn"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("fn"sv)));
 };/*case end*/
 case 76 /* Comptime */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("comptime"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("comptime"sv)));
 };/*case end*/
 case 77 /* If */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("if"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("if"sv)));
 };/*case end*/
 case 78 /* Import */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("import"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("import"sv)));
 };/*case end*/
 case 79 /* Relative */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("relative"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("relative"sv)));
 };/*case end*/
 case 80 /* In */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("in"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("in"sv)));
 };/*case end*/
 case 81 /* Is */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("is"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("is"sv)));
 };/*case end*/
 case 82 /* Let */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("let"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("let"sv)));
 };/*case end*/
 case 83 /* Loop */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("loop"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("loop"sv)));
 };/*case end*/
 case 84 /* Match */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("match"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("match"sv)));
 };/*case end*/
 case 85 /* Mut */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("mut"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("mut"sv)));
 };/*case end*/
 case 86 /* Namespace */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("namespace"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("namespace"sv)));
 };/*case end*/
 case 87 /* Not */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("not"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("not"sv)));
 };/*case end*/
 case 88 /* Or */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("or"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("or"sv)));
 };/*case end*/
 case 90 /* Private */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("private"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("private"sv)));
 };/*case end*/
 case 91 /* Public */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("public"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("public"sv)));
 };/*case end*/
 case 92 /* Raw */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("raw"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("raw"sv)));
 };/*case end*/
 case 94 /* Return */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("return"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("return"sv)));
 };/*case end*/
 case 95 /* Restricted */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("restricted"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("restricted"sv)));
 };/*case end*/
 case 96 /* Sizeof */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("sizeof"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("sizeof"sv)));
 };/*case end*/
 case 97 /* Struct */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("struct"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("struct"sv)));
 };/*case end*/
 case 98 /* This */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("this"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("this"sv)));
 };/*case end*/
 case 99 /* Throw */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("throw"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("throw"sv)));
 };/*case end*/
 case 100 /* Throws */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("throws"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("throws"sv)));
 };/*case end*/
 case 101 /* True */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("true"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("true"sv)));
 };/*case end*/
 case 102 /* Try */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("try"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("try"sv)));
 };/*case end*/
 case 103 /* Unsafe */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("unsafe"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("unsafe"sv)));
 };/*case end*/
 case 105 /* Weak */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("weak"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("weak"sv)));
 };/*case end*/
 case 106 /* While */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("while"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("while"sv)));
 };/*case end*/
 case 107 /* Yield */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("yield"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("yield"sv)));
 };/*case end*/
 case 108 /* Guard */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("guard"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("guard"sv)));
 };/*case end*/
 case 89 /* Override */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("override"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("override"sv)));
 };/*case end*/
 case 104 /* Virtual */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("virtual"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("virtual"sv)));
 };/*case end*/
 case 109 /* Implements */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("implements"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("implements"sv)));
 };/*case end*/
 case 110 /* Requires */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("requires"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("requires"sv)));
 };/*case end*/
 case 111 /* Trait */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("trait"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("trait"sv)));
 };/*case end*/
 case 93 /* Reflect */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("reflect"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("reflect"sv)));
 };/*case end*/
 case 112 /* Garbage */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8(""sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation(""sv)));
 };/*case end*/
 default: VERIFY_NOT_REACHED();}/*switch end*/
 }()
@@ -710,7 +710,7 @@ __jakt_label_569:; __jakt_var_674.release_value(); }));
 case 3 /* Identifier */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Identifier;ByteString const& name = __jakt_match_value.name;
 return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_675; {
-if ((((name) == ((ByteString::must_from_utf8("type"sv)))) && ((((*this).peek(static_cast<i64>(0LL)))).__jakt_init_index() == 3 /* Identifier */))){
+if ((((name) == ((ByteString::from_utf8_without_validation("type"sv)))) && ((((*this).peek(static_cast<i64>(0LL)))).__jakt_init_index() == 3 /* Identifier */))){
 TRY((((*this).push_state(formatter::State::EntityDeclaration(formatter::Entity::from_token(((token))),true,false,static_cast<size_t>(0ULL),is_extern)))));
 return ((*this).formatted_token(token,DynamicArray<u8>::create_with({static_cast<u8>(u8' ')}),DynamicArray<u8>::create_with({})));
 }
@@ -1080,7 +1080,7 @@ return TRY((((*this).next())));
 default: {
 return JaktInternal::ExplicitValue(({ Optional<formatter::FormattedToken> __jakt_var_699; {
 JaktInternal::DynamicArray<ByteString> collection = DynamicArray<ByteString>::create_with({});
-ByteString output = (ByteString::must_from_utf8(""sv));
+ByteString output = (ByteString::from_utf8_without_validation(""sv));
 utility::Span const span = ((token).span());
 lexer::Token local_token = token;
 while ((!(((local_token).__jakt_init_index() == 10 /* RCurly */)))){
@@ -1121,7 +1121,7 @@ return (infallible_enum_cast<jakt__prelude__operators::Ordering>((JaktInternal::
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8("\n"sv)));
+(output,(ByteString::from_utf8_without_validation("\n"sv)));
 {
 JaktInternal::Range<size_t> _magic = (JaktInternal::Range<size_t>{static_cast<size_t>(static_cast<size_t>(0ULL)),static_cast<size_t>(indent_amount)});
 for (;;){
@@ -1136,7 +1136,7 @@ size_t i = (_magic_value.value());
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8(" "sv)));
+(output,(ByteString::from_utf8_without_validation(" "sv)));
 }
 
 }
@@ -1150,7 +1150,7 @@ else if ((!(first))){
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8(", "sv)));
+(output,(ByteString::from_utf8_without_validation(", "sv)));
 ((current_len) += (static_cast<size_t>(2ULL)));
 }
 else {
@@ -1179,22 +1179,22 @@ break;
 }
 size_t i = (_magic_value.value());
 {
-(output = (((ByteString::must_from_utf8(" "sv))) + (output)));
+(output = (((ByteString::from_utf8_without_validation(" "sv))) + (output)));
 }
 
 }
 }
 
-(output = (((ByteString::must_from_utf8("\n"sv))) + (output)));
+(output = (((ByteString::from_utf8_without_validation("\n"sv))) + (output)));
 [](ByteString& self, ByteString rhs) -> void {
 {
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8("\n"sv)));
+(output,(ByteString::from_utf8_without_validation("\n"sv)));
 }
 else {
-(output = (((((ByteString::must_from_utf8(" "sv))) + (output))) + ((ByteString::must_from_utf8(" "sv)))));
+(output = (((((ByteString::from_utf8_without_validation(" "sv))) + (output))) + ((ByteString::from_utf8_without_validation(" "sv)))));
 }
 
 ((*this).pop_state());
@@ -7144,46 +7144,46 @@ return ({
 auto&& __jakt_match_variant = *this;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 0 /* Toplevel */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("toplevel"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("toplevel"sv)));
 };/*case end*/
 case 1 /* Extern */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("extern"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("extern"sv)));
 };/*case end*/
 case 2 /* Import */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("import"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("import"sv)));
 };/*case end*/
 case 3 /* ImportList */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("import list"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("import list"sv)));
 };/*case end*/
 case 5 /* Implements */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("implements"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("implements"sv)));
 };/*case end*/
 case 4 /* EntityDeclaration */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("entity declaration"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("entity declaration"sv)));
 };/*case end*/
 case 6 /* CaptureList */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("capture list"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("capture list"sv)));
 };/*case end*/
 case 7 /* ParameterList */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("parameter list"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("parameter list"sv)));
 };/*case end*/
 case 8 /* RestrictionList */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("restriction list"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("restriction list"sv)));
 };/*case end*/
 case 9 /* EntityDefinition */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("entity definition"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("entity definition"sv)));
 };/*case end*/
 case 10 /* StatementContext */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("statement context"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("statement context"sv)));
 };/*case end*/
 case 11 /* MatchPattern */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("match pattern"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("match pattern"sv)));
 };/*case end*/
 case 12 /* VariableDeclaration */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("variable declaration"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("variable declaration"sv)));
 };/*case end*/
 case 13 /* GenericCallTypeParams */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("generic call type params"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("generic call type params"sv)));
 };/*case end*/
 case 14 /* TypeContext */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.TypeContext;size_t const& open_parens = __jakt_match_value.open_parens;
@@ -7194,7 +7194,7 @@ bool const& seen_start = __jakt_match_value.seen_start;
 return JaktInternal::ExplicitValue(__jakt_format((StringView::from_string_literal("type context (p{} c{} s{} a{} s:{})"sv)),open_parens,open_curlies,open_squares,open_angles,seen_start));
 };/*case end*/
 case 15 /* FunctionTypeContext */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("function type context"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("function type context"sv)));
 };/*case end*/
 default: VERIFY_NOT_REACHED();}/*switch end*/
 }()

--- a/bootstrap/stage0/git.cpp
+++ b/bootstrap/stage0/git.cpp
@@ -3,7 +3,7 @@ namespace Jakt {
 namespace git {
 ErrorOr<ByteString> commit_hash() {
 {
-ByteString const hash = (ByteString::must_from_utf8("877b5f147549ef4d786f92f204f5208e27ad596f"sv));
+ByteString const hash = (ByteString::from_utf8_without_validation("a0c80d988ed0ac2f8450b077be12ced5df95394a"sv));
 return hash;
 }
 }

--- a/bootstrap/stage0/ide.cpp
+++ b/bootstrap/stage0/ide.cpp
@@ -28,7 +28,7 @@ break;
 }
 parser::ParsedFunction function = (_magic_value.value());
 {
-((symbols).push(ide::function_to_symbol(function,(ByteString::must_from_utf8("function"sv)))));
+((symbols).push(ide::function_to_symbol(function,(ByteString::from_utf8_without_validation("function"sv)))));
 }
 
 }
@@ -66,7 +66,7 @@ ide::JaktSymbol child = (_magic_value.value());
 }
 }
 
-return DynamicArray<ide::JaktSymbol>::create_with({ide::JaktSymbol((((namespace_).name).value()),JaktInternal::OptionalNone(),(ByteString::must_from_utf8("namespace"sv)),namespace_span,(((namespace_).name_span).value()),symbols)});
+return DynamicArray<ide::JaktSymbol>::create_with({ide::JaktSymbol((((namespace_).name).value()),JaktInternal::OptionalNone(),(ByteString::from_utf8_without_validation("namespace"sv)),namespace_span,(((namespace_).name_span).value()),symbols)});
 }
 else {
 return symbols;
@@ -95,13 +95,13 @@ break;
 }
 parser::ParsedField field = (_magic_value.value());
 {
-((children).push(ide::JaktSymbol(((((field).var_decl)).name),JaktInternal::OptionalNone(),(ByteString::must_from_utf8("field"sv)),((((field).var_decl)).span),((((field).var_decl)).span),DynamicArray<ide::JaktSymbol>::create_with({}))));
+((children).push(ide::JaktSymbol(((((field).var_decl)).name),JaktInternal::OptionalNone(),(ByteString::from_utf8_without_validation("field"sv)),((((field).var_decl)).span),((((field).var_decl)).span),DynamicArray<ide::JaktSymbol>::create_with({}))));
 }
 
 }
 }
 
-__jakt_var_876 = (ByteString::must_from_utf8("struct"sv)); goto __jakt_label_770;
+__jakt_var_876 = (ByteString::from_utf8_without_validation("struct"sv)); goto __jakt_label_770;
 
 }
 __jakt_label_770:; __jakt_var_876.release_value(); }));
@@ -118,13 +118,13 @@ break;
 }
 parser::ParsedField field = (_magic_value.value());
 {
-((children).push(ide::JaktSymbol(((((field).var_decl)).name),JaktInternal::OptionalNone(),(ByteString::must_from_utf8("field"sv)),((((field).var_decl)).span),((((field).var_decl)).span),DynamicArray<ide::JaktSymbol>::create_with({}))));
+((children).push(ide::JaktSymbol(((((field).var_decl)).name),JaktInternal::OptionalNone(),(ByteString::from_utf8_without_validation("field"sv)),((((field).var_decl)).span),((((field).var_decl)).span),DynamicArray<ide::JaktSymbol>::create_with({}))));
 }
 
 }
 }
 
-__jakt_var_877 = (ByteString::must_from_utf8("class"sv)); goto __jakt_label_771;
+__jakt_var_877 = (ByteString::from_utf8_without_validation("class"sv)); goto __jakt_label_771;
 
 }
 __jakt_label_771:; __jakt_var_877.release_value(); }));
@@ -141,13 +141,13 @@ break;
 }
 parser::ValueEnumVariant variant = (_magic_value.value());
 {
-((children).push(ide::JaktSymbol(((variant).name),JaktInternal::OptionalNone(),(ByteString::must_from_utf8("enum-member"sv)),((variant).span),((variant).span),DynamicArray<ide::JaktSymbol>::create_with({}))));
+((children).push(ide::JaktSymbol(((variant).name),JaktInternal::OptionalNone(),(ByteString::from_utf8_without_validation("enum-member"sv)),((variant).span),((variant).span),DynamicArray<ide::JaktSymbol>::create_with({}))));
 }
 
 }
 }
 
-__jakt_var_878 = (ByteString::must_from_utf8("enum"sv)); goto __jakt_label_772;
+__jakt_var_878 = (ByteString::from_utf8_without_validation("enum"sv)); goto __jakt_label_772;
 
 }
 __jakt_label_772:; __jakt_var_878.release_value(); }));
@@ -180,8 +180,8 @@ if ([](ByteString const& self, ByteString rhs) -> bool {
 return (!(((self) == (rhs))));
 }
 }
-(((param).name),(ByteString::must_from_utf8(""sv)))){
-((variant_children).push(ide::JaktSymbol(((param).name),JaktInternal::OptionalNone(),(ByteString::must_from_utf8("field"sv)),((param).span),((param).span),DynamicArray<ide::JaktSymbol>::create_with({}))));
+(((param).name),(ByteString::from_utf8_without_validation(""sv)))){
+((variant_children).push(ide::JaktSymbol(((param).name),JaktInternal::OptionalNone(),(ByteString::from_utf8_without_validation("field"sv)),((param).span),((param).span),DynamicArray<ide::JaktSymbol>::create_with({}))));
 }
 }
 
@@ -189,19 +189,19 @@ return (!(((self) == (rhs))));
 }
 
 }
-((children).push(ide::JaktSymbol(((variant).name),JaktInternal::OptionalNone(),(ByteString::must_from_utf8("enum-member"sv)),((variant).span),((variant).span),variant_children)));
+((children).push(ide::JaktSymbol(((variant).name),JaktInternal::OptionalNone(),(ByteString::from_utf8_without_validation("enum-member"sv)),((variant).span),((variant).span),variant_children)));
 }
 
 }
 }
 
-__jakt_var_879 = (ByteString::must_from_utf8("enum"sv)); goto __jakt_label_773;
+__jakt_var_879 = (ByteString::from_utf8_without_validation("enum"sv)); goto __jakt_label_773;
 
 }
 __jakt_label_773:; __jakt_var_879.release_value(); }));
 };/*case end*/
 case 4 /* Garbage */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("garbage"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("garbage"sv)));
 };/*case end*/
 default: VERIFY_NOT_REACHED();}/*switch end*/
 }()
@@ -219,7 +219,7 @@ break;
 }
 parser::ParsedMethod method = (_magic_value.value());
 {
-ide::JaktSymbol const function_symbol = ide::function_to_symbol(((method).parsed_function),(ByteString::must_from_utf8("method"sv)));
+ide::JaktSymbol const function_symbol = ide::function_to_symbol(((method).parsed_function),(ByteString::from_utf8_without_validation("method"sv)));
 ((children).push(function_symbol));
 (record_span = parser::merge_spans(record_span,((function_symbol).range)));
 }
@@ -297,13 +297,13 @@ return span;
 
 ErrorOr<utility::Span> find_type_definition_for_type_id(NonnullRefPtr<types::CheckedProgram> const program,ids::TypeId const type_id,utility::Span const span) {
 {
-ids::StructId const array_struct_id = TRY((((program)->find_struct_in_prelude((ByteString::must_from_utf8("Array"sv))))));
-ids::StructId const dictionary_struct_id = TRY((((program)->find_struct_in_prelude((ByteString::must_from_utf8("Dictionary"sv))))));
-ids::StructId const optional_struct_id = TRY((((program)->find_struct_in_prelude((ByteString::must_from_utf8("Optional"sv))))));
-ids::StructId const range_struct_id = TRY((((program)->find_struct_in_prelude((ByteString::must_from_utf8("Range"sv))))));
-ids::StructId const set_struct_id = TRY((((program)->find_struct_in_prelude((ByteString::must_from_utf8("Set"sv))))));
-ids::StructId const tuple_struct_id = TRY((((program)->find_struct_in_prelude((ByteString::must_from_utf8("Tuple"sv))))));
-ids::StructId const weak_ptr_struct_id = TRY((((program)->find_struct_in_prelude((ByteString::must_from_utf8("WeakPtr"sv))))));
+ids::StructId const array_struct_id = TRY((((program)->find_struct_in_prelude((ByteString::from_utf8_without_validation("Array"sv))))));
+ids::StructId const dictionary_struct_id = TRY((((program)->find_struct_in_prelude((ByteString::from_utf8_without_validation("Dictionary"sv))))));
+ids::StructId const optional_struct_id = TRY((((program)->find_struct_in_prelude((ByteString::from_utf8_without_validation("Optional"sv))))));
+ids::StructId const range_struct_id = TRY((((program)->find_struct_in_prelude((ByteString::from_utf8_without_validation("Range"sv))))));
+ids::StructId const set_struct_id = TRY((((program)->find_struct_in_prelude((ByteString::from_utf8_without_validation("Set"sv))))));
+ids::StructId const tuple_struct_id = TRY((((program)->find_struct_in_prelude((ByteString::from_utf8_without_validation("Tuple"sv))))));
+ids::StructId const weak_ptr_struct_id = TRY((((program)->find_struct_in_prelude((ByteString::from_utf8_without_validation("WeakPtr"sv))))));
 return ({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<utility::Span, ErrorOr<utility::Span>>{
 auto&& __jakt_match_variant = *((program)->get_type(type_id));
@@ -542,7 +542,7 @@ __jakt_label_780:; __jakt_var_886.release_value(); }));
 case 3 /* NameSet */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.NameSet;JaktInternal::DynamicArray<ByteString> const& names = __jakt_match_value.value;
 return JaktInternal::ExplicitValue(({ Optional<JaktInternal::Optional<ByteString>> __jakt_var_887; {
-ByteString output = (ByteString::must_from_utf8(""sv));
+ByteString output = (ByteString::from_utf8_without_validation(""sv));
 bool first = true;
 {
 JaktInternal::ArrayIterator<ByteString> _magic = ((names).iterator());
@@ -559,7 +559,7 @@ if ((!(first))){
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8(" | "sv)));
+(output,(ByteString::from_utf8_without_validation(" | "sv)));
 }
 else {
 (first = false);
@@ -716,7 +716,7 @@ ids::FunctionId function_id = (_magic_value.value());
 NonnullRefPtr<types::CheckedFunction> const checked_function = ((program)->get_function(function_id));
 if (((((((checked_function)->params)).first())).has_value())){
 types::CheckedParameter const param = (((((checked_function)->params)).first()).value());
-if (((((((param).variable))->name)) == ((ByteString::must_from_utf8("this"sv))))){
+if (((((((param).variable))->name)) == ((ByteString::from_utf8_without_validation("this"sv))))){
 ByteString full_call = ((checked_function)->name);
 bool first = true;
 [](ByteString& self, ByteString rhs) -> void {
@@ -724,7 +724,7 @@ bool first = true;
 (self = ((self) + (rhs)));
 }
 }
-(full_call,(ByteString::must_from_utf8("("sv)));
+(full_call,(ByteString::from_utf8_without_validation("("sv)));
 JaktInternal::ArrayIterator<types::CheckedParameter> iter = ((((checked_function)->params)).iterator());
 JaktInternal::Optional<types::CheckedParameter> const dummy = ((iter).next());
 {
@@ -742,7 +742,7 @@ if ((!(first))){
 (self = ((self) + (rhs)));
 }
 }
-(full_call,(ByteString::must_from_utf8(", "sv)));
+(full_call,(ByteString::from_utf8_without_validation(", "sv)));
 }
 else {
 (first = false);
@@ -764,7 +764,7 @@ else {
 (self = ((self) + (rhs)));
 }
 }
-(full_call,(ByteString::must_from_utf8(")"sv)));
+(full_call,(ByteString::from_utf8_without_validation(")"sv)));
 ((output).push(full_call));
 }
 }
@@ -2080,7 +2080,7 @@ return JaktInternal::ExplicitValue<void>();
         return _jakt_value.release_return();
     _jakt_value.release_value();
 });
-ByteString generic_parameters = (ByteString::must_from_utf8(""sv));
+ByteString generic_parameters = (ByteString::from_utf8_without_validation(""sv));
 bool is_first_param = true;
 if ((!(((((((checked_function)->generics))->params)).is_empty())))){
 [](ByteString& self, ByteString rhs) -> void {
@@ -2088,7 +2088,7 @@ if ((!(((((((checked_function)->generics))->params)).is_empty())))){
 (self = ((self) + (rhs)));
 }
 }
-(generic_parameters,(ByteString::must_from_utf8("<"sv)));
+(generic_parameters,(ByteString::from_utf8_without_validation("<"sv)));
 {
 JaktInternal::ArrayIterator<types::FunctionGenericParameter> _magic = ((((((checked_function)->generics))->params)).iterator());
 for (;;){
@@ -2103,10 +2103,10 @@ ByteString const separator = ({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<ByteString,ErrorOr<ByteString>>{
 auto __jakt_enum_value = (is_first_param);
 if (__jakt_enum_value == true) {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8(""sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation(""sv)));
 }
 else if (__jakt_enum_value == false) {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8(", "sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation(", "sv)));
 }
 VERIFY_NOT_REACHED();
 }());
@@ -2135,9 +2135,9 @@ VERIFY_NOT_REACHED();
 (self = ((self) + (rhs)));
 }
 }
-(generic_parameters,(ByteString::must_from_utf8(">"sv)));
+(generic_parameters,(ByteString::from_utf8_without_validation(">"sv)));
 }
-ByteString parameters = (ByteString::must_from_utf8(""sv));
+ByteString parameters = (ByteString::from_utf8_without_validation(""sv));
 (is_first_param = true);
 {
 JaktInternal::ArrayIterator<types::CheckedParameter> _magic = ((((checked_function)->params)).iterator());
@@ -2152,10 +2152,10 @@ ByteString const anon_value = ({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<ByteString,ErrorOr<ByteString>>{
 auto __jakt_enum_value = (((param).requires_label));
 if (__jakt_enum_value == true) {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8(""sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation(""sv)));
 }
 else if (__jakt_enum_value == false) {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("anon "sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("anon "sv)));
 }
 VERIFY_NOT_REACHED();
 }());
@@ -2171,10 +2171,10 @@ ByteString const is_mutable = ({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<ByteString,ErrorOr<ByteString>>{
 auto __jakt_enum_value = (((((param).variable))->is_mutable));
 if (__jakt_enum_value == true) {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("mut "sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("mut "sv)));
 }
 else if (__jakt_enum_value == false) {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8(""sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation(""sv)));
 }
 VERIFY_NOT_REACHED();
 }());
@@ -2192,21 +2192,21 @@ if ([](ByteString const& self, ByteString rhs) -> bool {
 return (!(((self) == (rhs))));
 }
 }
-(variable_type,(ByteString::must_from_utf8("void"sv)))){
-(variable_type = (((ByteString::must_from_utf8(": "sv))) + (variable_type)));
+(variable_type,(ByteString::from_utf8_without_validation("void"sv)))){
+(variable_type = (((ByteString::from_utf8_without_validation(": "sv))) + (variable_type)));
 }
 else {
-(variable_type = (ByteString::must_from_utf8(""sv)));
+(variable_type = (ByteString::from_utf8_without_validation(""sv)));
 }
 
 ByteString const separator = ({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<ByteString,ErrorOr<ByteString>>{
 auto __jakt_enum_value = (is_first_param);
 if (__jakt_enum_value == true) {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8(""sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation(""sv)));
 }
 else if (__jakt_enum_value == false) {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8(", "sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation(", "sv)));
 }
 VERIFY_NOT_REACHED();
 }());
@@ -2237,7 +2237,7 @@ if (is_first_param){
 (self = ((self) + (rhs)));
 }
 }
-(parameters,(ByteString::must_from_utf8(".."sv)));
+(parameters,(ByteString::from_utf8_without_validation(".."sv)));
 }
 else {
 [](ByteString& self, ByteString rhs) -> void {
@@ -2245,7 +2245,7 @@ else {
 (self = ((self) + (rhs)));
 }
 }
-(parameters,(ByteString::must_from_utf8(", .."sv)));
+(parameters,(ByteString::from_utf8_without_validation(", .."sv)));
 }
 
 }
@@ -2253,10 +2253,10 @@ ByteString const throws_str = ({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<ByteString,ErrorOr<ByteString>>{
 auto __jakt_enum_value = (((checked_function)->can_throw));
 if (__jakt_enum_value == true) {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8(" throws"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation(" throws"sv)));
 }
 else if (__jakt_enum_value == false) {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8(""sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation(""sv)));
 }
 VERIFY_NOT_REACHED();
 }());
@@ -2270,11 +2270,11 @@ if ([](ByteString const& self, ByteString rhs) -> bool {
 return (!(((self) == (rhs))));
 }
 }
-(returns,(ByteString::must_from_utf8("void"sv)))){
-(returns = (((ByteString::must_from_utf8(" -> "sv))) + (returns)));
+(returns,(ByteString::from_utf8_without_validation("void"sv)))){
+(returns = (((ByteString::from_utf8_without_validation(" -> "sv))) + (returns)));
 }
 else {
-(returns = (ByteString::must_from_utf8(""sv)));
+(returns = (ByteString::from_utf8_without_validation(""sv)));
 }
 
 return __jakt_format((StringView::from_string_literal("fn {}{}({}){}{}"sv)),((checked_function)->name),generic_parameters,parameters,throws_str,returns);
@@ -2294,13 +2294,13 @@ ByteString const mut_string = ({
 auto&& __jakt_match_variant = mutability;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 2 /* Mutable */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("mut"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("mut"sv)));
 };/*case end*/
 case 1 /* Immutable */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("let"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("let"sv)));
 };/*case end*/
 default: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8(""sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation(""sv)));
 };/*case end*/
 }/*switch end*/
 }()
@@ -2317,7 +2317,7 @@ __jakt_label_809:; __jakt_var_915.release_value(); }));
 };/*case end*/
 case 1 /* Field */: {
 {
-ByteString record_string = (ByteString::must_from_utf8(""sv));
+ByteString record_string = (ByteString::from_utf8_without_validation(""sv));
 if (((struct_type_id).has_value())){
 (record_string = TRY((ide::get_type_signature(program,(struct_type_id.value())))));
 }
@@ -2326,13 +2326,13 @@ ByteString const visibility_string = ({
 auto&& __jakt_match_variant = visibility;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 1 /* Public */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("public "sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("public "sv)));
 };/*case end*/
 case 2 /* Private */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("private "sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("private "sv)));
 };/*case end*/
 default: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8(""sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation(""sv)));
 };/*case end*/
 }/*switch end*/
 }()
@@ -2347,7 +2347,7 @@ if ([](ByteString const& self, ByteString rhs) -> bool {
 return (!(((self) == (rhs))));
 }
 }
-(record_string,(ByteString::must_from_utf8(""sv)))){
+(record_string,(ByteString::from_utf8_without_validation(""sv)))){
 return __jakt_format((StringView::from_string_literal("{}\\n\\t{}{}: {}"sv)),record_string,visibility_string,name,type_name);
 }
 else {
@@ -2368,78 +2368,78 @@ default: VERIFY_NOT_REACHED();}/*switch end*/
 
 ErrorOr<ByteString> get_type_signature(NonnullRefPtr<types::CheckedProgram> const program,ids::TypeId const type_id) {
 {
-ids::StructId const array_struct_id = TRY((((program)->find_struct_in_prelude((ByteString::must_from_utf8("Array"sv))))));
-ids::StructId const dictionary_struct_id = TRY((((program)->find_struct_in_prelude((ByteString::must_from_utf8("Dictionary"sv))))));
-ids::StructId const optional_struct_id = TRY((((program)->find_struct_in_prelude((ByteString::must_from_utf8("Optional"sv))))));
-ids::StructId const range_struct_id = TRY((((program)->find_struct_in_prelude((ByteString::must_from_utf8("Range"sv))))));
-ids::StructId const set_struct_id = TRY((((program)->find_struct_in_prelude((ByteString::must_from_utf8("Set"sv))))));
-ids::StructId const tuple_struct_id = TRY((((program)->find_struct_in_prelude((ByteString::must_from_utf8("Tuple"sv))))));
-ids::StructId const weak_ptr_struct_id = TRY((((program)->find_struct_in_prelude((ByteString::must_from_utf8("WeakPtr"sv))))));
+ids::StructId const array_struct_id = TRY((((program)->find_struct_in_prelude((ByteString::from_utf8_without_validation("Array"sv))))));
+ids::StructId const dictionary_struct_id = TRY((((program)->find_struct_in_prelude((ByteString::from_utf8_without_validation("Dictionary"sv))))));
+ids::StructId const optional_struct_id = TRY((((program)->find_struct_in_prelude((ByteString::from_utf8_without_validation("Optional"sv))))));
+ids::StructId const range_struct_id = TRY((((program)->find_struct_in_prelude((ByteString::from_utf8_without_validation("Range"sv))))));
+ids::StructId const set_struct_id = TRY((((program)->find_struct_in_prelude((ByteString::from_utf8_without_validation("Set"sv))))));
+ids::StructId const tuple_struct_id = TRY((((program)->find_struct_in_prelude((ByteString::from_utf8_without_validation("Tuple"sv))))));
+ids::StructId const weak_ptr_struct_id = TRY((((program)->find_struct_in_prelude((ByteString::from_utf8_without_validation("WeakPtr"sv))))));
 NonnullRefPtr<typename types::Type> const type = ((program)->get_type(type_id));
 return ({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<ByteString, ErrorOr<ByteString>>{
 auto&& __jakt_match_variant = *type;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 17 /* Never */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("never"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("never"sv)));
 };/*case end*/
 case 0 /* Void */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("void"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("void"sv)));
 };/*case end*/
 case 1 /* Bool */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("bool"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("bool"sv)));
 };/*case end*/
 case 2 /* U8 */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("u8"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("u8"sv)));
 };/*case end*/
 case 3 /* U16 */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("u16"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("u16"sv)));
 };/*case end*/
 case 4 /* U32 */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("u32"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("u32"sv)));
 };/*case end*/
 case 5 /* U64 */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("u64"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("u64"sv)));
 };/*case end*/
 case 6 /* I8 */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("i8"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("i8"sv)));
 };/*case end*/
 case 7 /* I16 */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("i16"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("i16"sv)));
 };/*case end*/
 case 8 /* I32 */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("i32"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("i32"sv)));
 };/*case end*/
 case 9 /* I64 */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("i64"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("i64"sv)));
 };/*case end*/
 case 10 /* F32 */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("f32"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("f32"sv)));
 };/*case end*/
 case 11 /* F64 */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("f64"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("f64"sv)));
 };/*case end*/
 case 12 /* Usize */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("usize"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("usize"sv)));
 };/*case end*/
 case 13 /* JaktString */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("String"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("String"sv)));
 };/*case end*/
 case 15 /* CInt */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("c_int"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("c_int"sv)));
 };/*case end*/
 case 14 /* CChar */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("c_char"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("c_char"sv)));
 };/*case end*/
 case 18 /* TypeVariable */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.TypeVariable;ByteString const& name = __jakt_match_value.name;
 return JaktInternal::ExplicitValue(name);
 };/*case end*/
 case 16 /* Unknown */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8(""sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation(""sv)));
 };/*case end*/
 case 31 /* Self */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("Self"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("Self"sv)));
 };/*case end*/
 case 27 /* Trait */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Trait;ids::TraitId const& trait_id = __jakt_match_value.value;
@@ -2452,7 +2452,7 @@ return JaktInternal::ExplicitValue(__jakt_format((StringView::from_string_litera
 };/*case end*/
 case 32 /* Const */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Const;types::Value const& value = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(TRY((types::comptime_format_impl((ByteString::must_from_utf8("const {}"sv)),((DynamicArray<types::Value>::create_with({value}))[(JaktInternal::Range<i64>{static_cast<i64>(0LL),static_cast<i64>(9223372036854775807LL)})]),((program))))));
+return JaktInternal::ExplicitValue(TRY((types::comptime_format_impl((ByteString::from_utf8_without_validation("const {}"sv)),((DynamicArray<types::Value>::create_with({value}))[(JaktInternal::Range<i64>{static_cast<i64>(0LL),static_cast<i64>(9223372036854775807LL)})]),((program))))));
 };/*case end*/
 case 30 /* Function */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Function;JaktInternal::DynamicArray<ids::TypeId> const& params = __jakt_match_value.params;
@@ -2475,14 +2475,14 @@ ids::TypeId x = (_magic_value.value());
 }
 
 ByteString const return_type = TRY((((program)->type_name(return_type_id,false))));
-__jakt_var_916 = __jakt_format((StringView::from_string_literal("fn({}) -> {}"sv)),utility::join(param_names,(ByteString::must_from_utf8(", "sv))),return_type); goto __jakt_label_810;
+__jakt_var_916 = __jakt_format((StringView::from_string_literal("fn({}) -> {}"sv)),utility::join(param_names,(ByteString::from_utf8_without_validation(", "sv))),return_type); goto __jakt_label_810;
 
 }
 __jakt_label_810:; __jakt_var_916.release_value(); }));
 };/*case end*/
 case 26 /* RawPtr */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.RawPtr;ids::TypeId const& type_id = __jakt_match_value.value;
-return JaktInternal::ExplicitValue((((ByteString::must_from_utf8("raw "sv))) + (TRY((ide::get_type_signature(program,type_id))))));
+return JaktInternal::ExplicitValue((((ByteString::from_utf8_without_validation("raw "sv))) + (TRY((ide::get_type_signature(program,type_id))))));
 };/*case end*/
 case 25 /* Enum */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Enum;ids::EnumId const& id = __jakt_match_value.value;
@@ -2492,16 +2492,16 @@ __jakt_var_917 = ((((({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<ByteString,ErrorOr<ByteString>>{
 auto __jakt_enum_value = (((enum_).is_boxed));
 if (__jakt_enum_value == true) {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("boxed "sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("boxed "sv)));
 }
 else {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8(""sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation(""sv)));
 }
 }());
     if (_jakt_value.is_return())
         return _jakt_value.release_return();
     _jakt_value.release_value();
-})) + ((ByteString::must_from_utf8("enum "sv))))) + (((enum_).name))); goto __jakt_label_811;
+})) + ((ByteString::from_utf8_without_validation("enum "sv))))) + (((enum_).name))); goto __jakt_label_811;
 
 }
 __jakt_label_811:; __jakt_var_917.release_value(); }));
@@ -2515,14 +2515,14 @@ __jakt_var_918 = ((({
 auto&& __jakt_match_variant = ((struct_).record_type);
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 1 /* Class */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("class "sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("class "sv)));
 };/*case end*/
 case 0 /* Struct */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("struct "sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("struct "sv)));
 };/*case end*/
 default: {
 {
-utility::panic((ByteString::must_from_utf8("unreachable: should've been struct"sv)));
+utility::panic((ByteString::from_utf8_without_validation("unreachable: should've been struct"sv)));
 }
 };/*case end*/
 }/*switch end*/
@@ -2547,7 +2547,7 @@ ByteString output = ((record).name);
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8("<"sv)));
+(output,(ByteString::from_utf8_without_validation("<"sv)));
 if ((!(((args).is_empty())))){
 [](ByteString& self, ByteString rhs) -> void {
 {
@@ -2569,7 +2569,7 @@ size_t i = (_magic_value.value());
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8(", "sv)));
+(output,(ByteString::from_utf8_without_validation(", "sv)));
 [](ByteString& self, ByteString rhs) -> void {
 {
 (self = ((self) + (rhs)));
@@ -2582,7 +2582,7 @@ size_t i = (_magic_value.value());
 }
 
 }
-__jakt_var_919 = ((output) + ((ByteString::must_from_utf8(">"sv)))); goto __jakt_label_813;
+__jakt_var_919 = ((output) + ((ByteString::from_utf8_without_validation(">"sv)))); goto __jakt_label_813;
 
 }
 __jakt_label_813:; __jakt_var_919.release_value(); }));
@@ -2592,21 +2592,21 @@ auto&& __jakt_match_value = __jakt_match_variant.as.GenericEnumInstance;ids::Enu
 JaktInternal::DynamicArray<ids::TypeId> const& args = __jakt_match_value.args;
 return JaktInternal::ExplicitValue(({ Optional<ByteString> __jakt_var_920; {
 types::CheckedEnum const enum_ = ((program)->get_enum(id));
-ByteString output = (ByteString::must_from_utf8(""sv));
+ByteString output = (ByteString::from_utf8_without_validation(""sv));
 if (((enum_).is_boxed)){
 [](ByteString& self, ByteString rhs) -> void {
 {
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8("boxed "sv)));
+(output,(ByteString::from_utf8_without_validation("boxed "sv)));
 }
 [](ByteString& self, ByteString rhs) -> void {
 {
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8("enum "sv)));
+(output,(ByteString::from_utf8_without_validation("enum "sv)));
 [](ByteString& self, ByteString rhs) -> void {
 {
 (self = ((self) + (rhs)));
@@ -2618,7 +2618,7 @@ if (((enum_).is_boxed)){
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8("<"sv)));
+(output,(ByteString::from_utf8_without_validation("<"sv)));
 if ((!(((args).is_empty())))){
 [](ByteString& self, ByteString rhs) -> void {
 {
@@ -2640,7 +2640,7 @@ size_t i = (_magic_value.value());
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8(", "sv)));
+(output,(ByteString::from_utf8_without_validation(", "sv)));
 [](ByteString& self, ByteString rhs) -> void {
 {
 (self = ((self) + (rhs)));
@@ -2653,7 +2653,7 @@ size_t i = (_magic_value.value());
 }
 
 }
-__jakt_var_920 = ((output) + ((ByteString::must_from_utf8(">"sv)))); goto __jakt_label_814;
+__jakt_var_920 = ((output) + ((ByteString::from_utf8_without_validation(">"sv)))); goto __jakt_label_814;
 
 }
 __jakt_label_814:; __jakt_var_920.release_value(); }));
@@ -2663,13 +2663,13 @@ auto&& __jakt_match_value = __jakt_match_variant.as.GenericTraitInstance;ids::Tr
 JaktInternal::DynamicArray<ids::TypeId> const& args = __jakt_match_value.args;
 return JaktInternal::ExplicitValue(({ Optional<ByteString> __jakt_var_921; {
 NonnullRefPtr<types::CheckedTrait> const trait_ = ((program)->get_trait(id));
-ByteString output = (ByteString::must_from_utf8(""sv));
+ByteString output = (ByteString::from_utf8_without_validation(""sv));
 [](ByteString& self, ByteString rhs) -> void {
 {
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8("trait "sv)));
+(output,(ByteString::from_utf8_without_validation("trait "sv)));
 [](ByteString& self, ByteString rhs) -> void {
 {
 (self = ((self) + (rhs)));
@@ -2681,7 +2681,7 @@ ByteString output = (ByteString::must_from_utf8(""sv));
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8("<"sv)));
+(output,(ByteString::from_utf8_without_validation("<"sv)));
 if ((!(((args).is_empty())))){
 [](ByteString& self, ByteString rhs) -> void {
 {
@@ -2703,7 +2703,7 @@ size_t i = (_magic_value.value());
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8(", "sv)));
+(output,(ByteString::from_utf8_without_validation(", "sv)));
 [](ByteString& self, ByteString rhs) -> void {
 {
 (self = ((self) + (rhs)));
@@ -2716,7 +2716,7 @@ size_t i = (_magic_value.value());
 }
 
 }
-__jakt_var_921 = ((output) + ((ByteString::must_from_utf8(">"sv)))); goto __jakt_label_815;
+__jakt_var_921 = ((output) + ((ByteString::from_utf8_without_validation(">"sv)))); goto __jakt_label_815;
 
 }
 __jakt_label_815:; __jakt_var_921.release_value(); }));
@@ -2727,7 +2727,7 @@ JaktInternal::DynamicArray<ids::TypeId> const& args = __jakt_match_value.args;
 return JaktInternal::ExplicitValue(({ Optional<ByteString> __jakt_var_922; {
 if (((id).equals(array_struct_id))){
 if (((args).is_empty())){
-return (ByteString::must_from_utf8("[]"sv));
+return (ByteString::from_utf8_without_validation("[]"sv));
 }
 return __jakt_format((StringView::from_string_literal("[{}]"sv)),TRY((ide::get_type_signature(program,((args)[static_cast<i64>(0LL)])))));
 }
@@ -2743,30 +2743,30 @@ return (infallible_enum_cast<jakt__prelude__operators::Ordering>((JaktInternal::
 }
 }
 (((args).size()),static_cast<size_t>(2ULL))){
-return (ByteString::must_from_utf8("[:]"sv));
+return (ByteString::from_utf8_without_validation("[:]"sv));
 }
 return __jakt_format((StringView::from_string_literal("[{}: {}]"sv)),TRY((ide::get_type_signature(program,((args)[static_cast<i64>(0LL)])))),TRY((ide::get_type_signature(program,((args)[static_cast<i64>(1LL)])))));
 }
 if (((id).equals(optional_struct_id))){
 if (((args).is_empty())){
-return (ByteString::must_from_utf8(""sv));
+return (ByteString::from_utf8_without_validation(""sv));
 }
 return __jakt_format((StringView::from_string_literal("{}?"sv)),TRY((ide::get_type_signature(program,((args)[static_cast<i64>(0LL)])))));
 }
 if (((id).equals(range_struct_id))){
 if (((args).is_empty())){
-return (ByteString::must_from_utf8(""sv));
+return (ByteString::from_utf8_without_validation(""sv));
 }
 return __jakt_format((StringView::from_string_literal("{}..{}"sv)),TRY((ide::get_type_signature(program,((args)[static_cast<i64>(0LL)])))),TRY((((program)->type_name(((args)[static_cast<i64>(0LL)]),false)))));
 }
 if (((id).equals(set_struct_id))){
 if (((args).is_empty())){
-return (ByteString::must_from_utf8(""sv));
+return (ByteString::from_utf8_without_validation(""sv));
 }
 return __jakt_format((StringView::from_string_literal("{{{}}}"sv)),TRY((ide::get_type_signature(program,((args)[static_cast<i64>(0LL)])))));
 }
 if (((id).equals(tuple_struct_id))){
-ByteString output = (ByteString::must_from_utf8("("sv));
+ByteString output = (ByteString::from_utf8_without_validation("("sv));
 if ((!(((args).is_empty())))){
 [](ByteString& self, ByteString rhs) -> void {
 {
@@ -2788,7 +2788,7 @@ size_t i = (_magic_value.value());
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8(", "sv)));
+(output,(ByteString::from_utf8_without_validation(", "sv)));
 [](ByteString& self, ByteString rhs) -> void {
 {
 (self = ((self) + (rhs)));
@@ -2801,11 +2801,11 @@ size_t i = (_magic_value.value());
 }
 
 }
-return ((output) + ((ByteString::must_from_utf8(")"sv))));
+return ((output) + ((ByteString::from_utf8_without_validation(")"sv))));
 }
 if (((id).equals(weak_ptr_struct_id))){
 if (((args).is_empty())){
-return (ByteString::must_from_utf8(""sv));
+return (ByteString::from_utf8_without_validation(""sv));
 }
 return __jakt_format((StringView::from_string_literal("weak {}"sv)),TRY((ide::get_type_signature(program,((args)[static_cast<i64>(0LL)])))));
 }
@@ -2815,23 +2815,23 @@ ByteString output = ({
 auto&& __jakt_match_variant = ((record).record_type);
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 1 /* Class */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("class "sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("class "sv)));
 };/*case end*/
 case 0 /* Struct */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("struct "sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("struct "sv)));
 };/*case end*/
 case 2 /* ValueEnum */: {
 {
-utility::panic((ByteString::must_from_utf8("unreachable: can't be an enum"sv)));
+utility::panic((ByteString::from_utf8_without_validation("unreachable: can't be an enum"sv)));
 }
 };/*case end*/
 case 3 /* SumEnum */: {
 {
-utility::panic((ByteString::must_from_utf8("unreachable: can't be an enum"sv)));
+utility::panic((ByteString::from_utf8_without_validation("unreachable: can't be an enum"sv)));
 }
 };/*case end*/
 case 4 /* Garbage */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8(""sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation(""sv)));
 };/*case end*/
 default: VERIFY_NOT_REACHED();}/*switch end*/
 }()
@@ -2851,7 +2851,7 @@ default: VERIFY_NOT_REACHED();}/*switch end*/
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8("<"sv)));
+(output,(ByteString::from_utf8_without_validation("<"sv)));
 if ((!(((args).is_empty())))){
 [](ByteString& self, ByteString rhs) -> void {
 {
@@ -2873,7 +2873,7 @@ size_t i = (_magic_value.value());
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8(", "sv)));
+(output,(ByteString::from_utf8_without_validation(", "sv)));
 [](ByteString& self, ByteString rhs) -> void {
 {
 (self = ((self) + (rhs)));
@@ -2886,7 +2886,7 @@ size_t i = (_magic_value.value());
 }
 
 }
-__jakt_var_922 = ((output) + ((ByteString::must_from_utf8(">"sv)))); goto __jakt_label_816;
+__jakt_var_922 = ((output) + ((ByteString::from_utf8_without_validation(">"sv)))); goto __jakt_label_816;
 
 }
 __jakt_label_816:; __jakt_var_922.release_value(); }));
@@ -2917,7 +2917,7 @@ ByteString output = TRY((ide::get_type_signature(program,type_id)));
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8("::"sv)));
+(output,(ByteString::from_utf8_without_validation("::"sv)));
 [](ByteString& self, ByteString rhs) -> void {
 {
 (self = ((self) + (rhs)));
@@ -2930,7 +2930,7 @@ if ((!(((variants).is_empty())))){
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8("("sv)));
+(output,(ByteString::from_utf8_without_validation("("sv)));
 bool first = true;
 {
 JaktInternal::ArrayIterator<JaktInternal::Tuple<JaktInternal::Optional<ByteString>,ids::TypeId>> _magic = ((variants).iterator());
@@ -2954,7 +2954,7 @@ else {
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8(", "sv)));
+(output,(ByteString::from_utf8_without_validation(", "sv)));
 }
 
 if (((variant_name).has_value())){
@@ -2969,7 +2969,7 @@ if (((variant_name).has_value())){
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8(": "sv)));
+(output,(ByteString::from_utf8_without_validation(": "sv)));
 }
 [](ByteString& self, ByteString rhs) -> void {
 {
@@ -2987,7 +2987,7 @@ if (((variant_name).has_value())){
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8(")"sv)));
+(output,(ByteString::from_utf8_without_validation(")"sv)));
 }
 if (((number_constant).has_value())){
 [](ByteString& self, ByteString rhs) -> void {
@@ -2995,7 +2995,7 @@ if (((number_constant).has_value())){
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8(" = "sv)));
+(output,(ByteString::from_utf8_without_validation(" = "sv)));
 ({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<void, ErrorOr<ByteString>>{
 auto&& __jakt_match_variant = (number_constant.value());
@@ -3170,7 +3170,7 @@ default: VERIFY_NOT_REACHED();}/*switch end*/
 }
 }
 
-return (ByteString::must_from_utf8(""sv));
+return (ByteString::from_utf8_without_validation(""sv));
 }
 }
 
@@ -3230,13 +3230,13 @@ return ide::Usage::EnumVariant(span,name,type_id,variants,number_constant);
 }
 }
 
-utility::panic((ByteString::must_from_utf8("unreachable: should have found variant"sv)));
+utility::panic((ByteString::from_utf8_without_validation("unreachable: should have found variant"sv)));
 }
 
 }
 }
 
-utility::panic((ByteString::must_from_utf8("unreachable: should have found variant"sv)));
+utility::panic((ByteString::from_utf8_without_validation("unreachable: should have found variant"sv)));
 }
 }
 
@@ -3316,7 +3316,7 @@ ByteString output = TRY((ide::get_type_signature(program,type_id)));
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8("("sv)));
+(output,(ByteString::from_utf8_without_validation("("sv)));
 bool first = true;
 {
 JaktInternal::ArrayIterator<types::CheckedField> _magic = ((((struct_).fields)).iterator());
@@ -3336,7 +3336,7 @@ else {
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8(", "sv)));
+(output,(ByteString::from_utf8_without_validation(", "sv)));
 }
 
 NonnullRefPtr<types::CheckedVariable> const variable = ((program)->get_variable(((field).variable_id)));
@@ -3346,7 +3346,7 @@ if (((variable)->is_mutable)){
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8("mut "sv)));
+(output,(ByteString::from_utf8_without_validation("mut "sv)));
 }
 [](ByteString& self, ByteString rhs) -> void {
 {
@@ -3364,7 +3364,7 @@ if (((variable)->is_mutable)){
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8(")"sv)));
+(output,(ByteString::from_utf8_without_validation(")"sv)));
 return output;
 }
 }
@@ -3372,7 +3372,7 @@ return output;
 }
 }
 
-return (ByteString::must_from_utf8(""sv));
+return (ByteString::from_utf8_without_validation(""sv));
 }
 }
 
@@ -3420,7 +3420,7 @@ ide::JaktSymbol child = (_magic_value.value());
 }
 }
 
-((json_builder).append(__jakt_format((StringView::from_string_literal("\"children\": [{}]"sv)),utility::join(child_symbols,(ByteString::must_from_utf8(","sv))))));
+((json_builder).append(__jakt_format((StringView::from_string_literal("\"children\": [{}]"sv)),utility::join(child_symbols,(ByteString::from_utf8_without_validation(","sv))))));
 ((json_builder).append((StringView::from_string_literal("}"sv))));
 return ((json_builder).to_string());
 }

--- a/bootstrap/stage0/interpreter.cpp
+++ b/bootstrap/stage0/interpreter.cpp
@@ -1322,7 +1322,7 @@ auto&& __jakt_match_variant = *type;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 20 /* GenericInstance */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.GenericInstance;ids::StructId const& id = __jakt_match_value.id;
-return JaktInternal::ExplicitValue(((id).equals(TRY((((((interpreter)->program))->find_struct_in_prelude((ByteString::must_from_utf8("Optional"sv)))))))));
+return JaktInternal::ExplicitValue(((id).equals(TRY((((((interpreter)->program))->find_struct_in_prelude((ByteString::from_utf8_without_validation("Optional"sv)))))))));
 };/*case end*/
 default: {
 return JaktInternal::ExplicitValue(false);
@@ -1777,7 +1777,7 @@ auto&& __jakt_match_variant = *((this_value).impl);
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 0 /* Void */: {
 {
-TRY((((interpreter)->error((ByteString::must_from_utf8("Cannot convert void to expression"sv)),((this_value).span)))));
+TRY((((interpreter)->error((ByteString::from_utf8_without_validation("Cannot convert void to expression"sv)),((this_value).span)))));
 return Error::__jakt_from_string_literal((StringView::from_string_literal("Invalid type"sv)));
 }
 };/*case end*/
@@ -1831,11 +1831,11 @@ return JaktInternal::ExplicitValue(types::CheckedExpression::NumericConstant(Jak
 };/*case end*/
 case 13 /* JaktString */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.JaktString;ByteString const& x = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(types::CheckedExpression::QuotedString(JaktInternal::OptionalNone(),types::CheckedStringLiteral(types::StringLiteral::Static(utility::escape_for_quotes(x)),((((interpreter)->program))->find_or_add_type_id(types::Type::Struct(parser::CheckedQualifiers(false),TRY((((((interpreter)->program))->find_struct_in_prelude((ByteString::must_from_utf8("String"sv))))))),((((interpreter)->program))->prelude_module_id()),false)),false),((this_value).span)));
+return JaktInternal::ExplicitValue(types::CheckedExpression::QuotedString(JaktInternal::OptionalNone(),types::CheckedStringLiteral(types::StringLiteral::Static(utility::escape_for_quotes(x)),((((interpreter)->program))->find_or_add_type_id(types::Type::Struct(parser::CheckedQualifiers(false),TRY((((((interpreter)->program))->find_struct_in_prelude((ByteString::from_utf8_without_validation("String"sv))))))),((((interpreter)->program))->prelude_module_id()),false)),false),((this_value).span)));
 };/*case end*/
 case 14 /* StringView */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.StringView;ByteString const& x = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(types::CheckedExpression::QuotedString(JaktInternal::OptionalNone(),types::CheckedStringLiteral(types::StringLiteral::Static(utility::escape_for_quotes(x)),((((interpreter)->program))->find_or_add_type_id(types::Type::Struct(parser::CheckedQualifiers(false),TRY((((((interpreter)->program))->find_struct_in_prelude((ByteString::must_from_utf8("StringView"sv))))))),((((interpreter)->program))->prelude_module_id()),false)),false),((this_value).span)));
+return JaktInternal::ExplicitValue(types::CheckedExpression::QuotedString(JaktInternal::OptionalNone(),types::CheckedStringLiteral(types::StringLiteral::Static(utility::escape_for_quotes(x)),((((interpreter)->program))->find_or_add_type_id(types::Type::Struct(parser::CheckedQualifiers(false),TRY((((((interpreter)->program))->find_struct_in_prelude((ByteString::from_utf8_without_validation("StringView"sv))))))),((((interpreter)->program))->prelude_module_id()),false)),false),((this_value).span)));
 };/*case end*/
 case 15 /* CChar */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.CChar;char const& x = __jakt_match_value.value;
@@ -1853,7 +1853,7 @@ auto&& __jakt_match_value = __jakt_match_variant.as.OptionalSome;types::Value co
 return JaktInternal::ExplicitValue(({ Optional<NonnullRefPtr<typename types::CheckedExpression>> __jakt_var_192; {
 NonnullRefPtr<typename types::CheckedExpression> const expr = TRY((interpreter::value_to_checked_expression(value,interpreter)));
 ids::TypeId const inner_type_id = ((expr)->type());
-ids::StructId const optional_struct_id = TRY((((((interpreter)->program))->find_struct_in_prelude((ByteString::must_from_utf8("Optional"sv))))));
+ids::StructId const optional_struct_id = TRY((((((interpreter)->program))->find_struct_in_prelude((ByteString::from_utf8_without_validation("Optional"sv))))));
 NonnullRefPtr<typename types::Type> const type = types::Type::GenericInstance(parser::CheckedQualifiers(false),optional_struct_id,DynamicArray<ids::TypeId>::create_with({inner_type_id}));
 ids::TypeId const type_id = ((interpreter)->find_or_add_type_id(type));
 __jakt_var_192 = types::CheckedExpression::OptionalSome(JaktInternal::OptionalNone(),expr,((this_value).span),type_id); goto __jakt_label_178;
@@ -1892,7 +1892,7 @@ ids::StructId const& struct_id = __jakt_match_value.struct_id;
 JaktInternal::Optional<ids::FunctionId> const& constructor = __jakt_match_value.constructor;
 return JaktInternal::ExplicitValue(({ Optional<NonnullRefPtr<typename types::CheckedExpression>> __jakt_var_194; {
 if ((!(((constructor).has_value())))){
-TRY((((interpreter)->error_with_hint((ByteString::must_from_utf8("Cannot convert struct to expression without constructor"sv)),((this_value).span),(ByteString::must_from_utf8("Given struct cannot be created from its contents in any known way"sv)),((this_value).span)))));
+TRY((((interpreter)->error_with_hint((ByteString::from_utf8_without_validation("Cannot convert struct to expression without constructor"sv)),((this_value).span),(ByteString::from_utf8_without_validation("Given struct cannot be created from its contents in any known way"sv)),((this_value).span)))));
 return Error::__jakt_from_string_literal((StringView::from_string_literal("Invalid type"sv)));
 }
 JaktInternal::DynamicArray<NonnullRefPtr<typename types::CheckedExpression>> materialised_fields = DynamicArray<NonnullRefPtr<typename types::CheckedExpression>>::create_with({});
@@ -1949,7 +1949,7 @@ return (infallible_enum_cast<jakt__prelude__operators::Ordering>((JaktInternal::
 }
 }
 (((materialised_fields).size()),((((callee)->params)).size()))){
-TRY((((interpreter)->error_with_hint((ByteString::must_from_utf8("Too many arguments for constructor"sv)),((this_value).span),__jakt_format((StringView::from_string_literal("Expected at most {} arguments, got {}"sv)),((((callee)->params)).size()),((materialised_fields).size())),((this_value).span)))));
+TRY((((interpreter)->error_with_hint((ByteString::from_utf8_without_validation("Too many arguments for constructor"sv)),((this_value).span),__jakt_format((StringView::from_string_literal("Expected at most {} arguments, got {}"sv)),((((callee)->params)).size()),((materialised_fields).size())),((this_value).span)))));
 return Error::__jakt_from_string_literal((StringView::from_string_literal("Invalid type"sv)));
 }
 ByteString const name = ((struct_).name);
@@ -1983,7 +1983,7 @@ ids::StructId const& struct_id = __jakt_match_value.struct_id;
 JaktInternal::Optional<ids::FunctionId> const& constructor = __jakt_match_value.constructor;
 return JaktInternal::ExplicitValue(({ Optional<NonnullRefPtr<typename types::CheckedExpression>> __jakt_var_195; {
 if ((!(((constructor).has_value())))){
-TRY((((interpreter)->error_with_hint((ByteString::must_from_utf8("Cannot convert struct to expression without constructor"sv)),((this_value).span),(ByteString::must_from_utf8("Given struct cannot be created from its contents in any known way"sv)),((this_value).span)))));
+TRY((((interpreter)->error_with_hint((ByteString::from_utf8_without_validation("Cannot convert struct to expression without constructor"sv)),((this_value).span),(ByteString::from_utf8_without_validation("Given struct cannot be created from its contents in any known way"sv)),((this_value).span)))));
 return Error::__jakt_from_string_literal((StringView::from_string_literal("Invalid type"sv)));
 }
 JaktInternal::DynamicArray<NonnullRefPtr<typename types::CheckedExpression>> materialised_fields = DynamicArray<NonnullRefPtr<typename types::CheckedExpression>>::create_with({});
@@ -2040,7 +2040,7 @@ return (infallible_enum_cast<jakt__prelude__operators::Ordering>((JaktInternal::
 }
 }
 (((materialised_fields).size()),((((callee)->params)).size()))){
-TRY((((interpreter)->error_with_hint((ByteString::must_from_utf8("Too many arguments for constructor"sv)),((this_value).span),__jakt_format((StringView::from_string_literal("Expected at most {} arguments, got {}"sv)),((((callee)->params)).size()),((materialised_fields).size())),((this_value).span)))));
+TRY((((interpreter)->error_with_hint((ByteString::from_utf8_without_validation("Too many arguments for constructor"sv)),((this_value).span),__jakt_format((StringView::from_string_literal("Expected at most {} arguments, got {}"sv)),((((callee)->params)).size()),((materialised_fields).size())),((this_value).span)))));
 return Error::__jakt_from_string_literal((StringView::from_string_literal("Invalid type"sv)));
 }
 ByteString const name = ((struct_).name);
@@ -2128,7 +2128,7 @@ break;
 size_t i = (_magic_value.value());
 {
 NonnullRefPtr<typename types::CheckedExpression> const arg = ((materialised_fields)[i]);
-((args).push((Tuple{(ByteString::must_from_utf8(""sv)), arg})));
+((args).push((Tuple{(ByteString::from_utf8_without_validation(""sv)), arg})));
 }
 
 }
@@ -2171,7 +2171,7 @@ return JaktInternal::ExplicitValue(((args)[static_cast<i64>(0LL)]));
 };/*case end*/
 default: {
 {
-utility::panic((ByteString::must_from_utf8("Expected generic instance of Array while materialising an array"sv)));
+utility::panic((ByteString::from_utf8_without_validation("Expected generic instance of Array while materialising an array"sv)));
 }
 };/*case end*/
 }/*switch end*/
@@ -2217,7 +2217,7 @@ return JaktInternal::ExplicitValue((Tuple{((args)[static_cast<i64>(0LL)]), ((arg
 };/*case end*/
 default: {
 {
-utility::panic((ByteString::must_from_utf8("Expected generic instance of Dictionary while materialising an array"sv)));
+utility::panic((ByteString::from_utf8_without_validation("Expected generic instance of Dictionary while materialising an array"sv)));
 }
 };/*case end*/
 }/*switch end*/
@@ -2265,7 +2265,7 @@ return JaktInternal::ExplicitValue(((args)[static_cast<i64>(0LL)]));
 };/*case end*/
 default: {
 {
-utility::panic((ByteString::must_from_utf8("Expected generic instance of Set while materialising an array"sv)));
+utility::panic((ByteString::from_utf8_without_validation("Expected generic instance of Set while materialising an array"sv)));
 }
 };/*case end*/
 }/*switch end*/
@@ -2313,7 +2313,7 @@ ids::VarId const var_id = ((((((interpreter)->program))->get_module(((type_id).m
 
 ((statements).push_values(((((block).statements)))));
 types::CheckedBlock const new_block = types::CheckedBlock(statements,inherited_scope_id,((block).control_flow),((block).yielded_type),((block).yielded_none));
-NonnullRefPtr<types::CheckedFunction> const checked_function = types::CheckedFunction::__jakt_create((ByteString::must_from_utf8("synthetic_lambda"sv)),((this_value).span),types::CheckedVisibility::Public(),return_type_id,JaktInternal::OptionalNone(),checked_params,types::FunctionGenerics::__jakt_create(inherited_scope_id,checked_params,DynamicArray<types::FunctionGenericParameter>::create_with({}),DynamicArray<JaktInternal::DynamicArray<ids::TypeId>>::create_with({})),new_block,can_throw,parser::FunctionType::Expression(),parser::FunctionLinkage::Internal(),inherited_scope_id,JaktInternal::OptionalNone(),true,JaktInternal::OptionalNone(),false,false,false,false,false,JaktInternal::OptionalNone(),JaktInternal::OptionalNone(),JaktInternal::OptionalNone(),false,JaktInternal::OptionalNone(),JaktInternal::OptionalNone(),JaktInternal::OptionalNone(),parser::InlineState::Default());
+NonnullRefPtr<types::CheckedFunction> const checked_function = types::CheckedFunction::__jakt_create((ByteString::from_utf8_without_validation("synthetic_lambda"sv)),((this_value).span),types::CheckedVisibility::Public(),return_type_id,JaktInternal::OptionalNone(),checked_params,types::FunctionGenerics::__jakt_create(inherited_scope_id,checked_params,DynamicArray<types::FunctionGenericParameter>::create_with({}),DynamicArray<JaktInternal::DynamicArray<ids::TypeId>>::create_with({})),new_block,can_throw,parser::FunctionType::Expression(),parser::FunctionLinkage::Internal(),inherited_scope_id,JaktInternal::OptionalNone(),true,JaktInternal::OptionalNone(),false,false,false,false,false,JaktInternal::OptionalNone(),JaktInternal::OptionalNone(),JaktInternal::OptionalNone(),false,JaktInternal::OptionalNone(),JaktInternal::OptionalNone(),JaktInternal::OptionalNone(),parser::InlineState::Default());
 Function<ErrorOr<ids::FunctionId>(NonnullRefPtr<types::CheckedFunction>)> const& register_function = ((((((interpreter)->typecheck_functions))->register_function)));
 ids::FunctionId const pseudo_function_id = TRY((register_function(checked_function)));
 __jakt_var_200 = types::CheckedExpression::Function(JaktInternal::OptionalNone(),DynamicArray<types::CheckedCapture>::create_with({}),checked_params,can_throw,return_type_id,new_block,((this_value).span),type_id,pseudo_function_id,scope_id); goto __jakt_label_186;
@@ -2979,7 +2979,7 @@ auto&& __jakt_match_value = __jakt_match_variant.as.StringValue;ByteString const
 {
 ids::TypeId const checked_expr_type_id = ((scope)->map_type(((expr)->type())));
 NonnullRefPtr<typename types::Type> const checked_expr_type = ((((*this).program))->get_type(checked_expr_type_id));
-ids::StructId const optional_struct_id = TRY((((((*this).program))->find_struct_in_prelude((ByteString::must_from_utf8("Optional"sv))))));
+ids::StructId const optional_struct_id = TRY((((((*this).program))->find_struct_in_prelude((ByteString::from_utf8_without_validation("Optional"sv))))));
 ({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<void, ErrorOr<NonnullRefPtr<typename types::CheckedExpression>>>{
 auto&& __jakt_match_variant = *checked_expr_type;
@@ -2991,7 +2991,7 @@ JaktInternal::DynamicArray<ids::TypeId> const& args = __jakt_match_value.args;
 ids::TypeId type_id = checked_expr_type_id;
 if (is_optional){
 if ((!(((id).equals(optional_struct_id))))){
-TRY((((*this).error((ByteString::must_from_utf8("Optional chaining is only allowed on optional types"sv)),span))));
+TRY((((*this).error((ByteString::from_utf8_without_validation("Optional chaining is only allowed on optional types"sv)),span))));
 return Error::__jakt_from_string_literal((StringView::from_string_literal("Invalid operation"sv)));
 }
 (type_id = ((args)[static_cast<i64>(0LL)]));
@@ -3083,7 +3083,7 @@ case 24 /* Struct */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Struct;ids::StructId const& struct_id = __jakt_match_value.value;
 {
 if (is_optional){
-TRY((((*this).error((ByteString::must_from_utf8("Optional chaining is not allowed on non-optional types"sv)),span))));
+TRY((((*this).error((ByteString::from_utf8_without_validation("Optional chaining is not allowed on non-optional types"sv)),span))));
 return Error::__jakt_from_string_literal((StringView::from_string_literal("Invalid operation"sv)));
 }
 types::CheckedStruct const structure = ((((*this).program))->get_struct(struct_id));
@@ -3131,7 +3131,7 @@ return JaktInternal::ExplicitValue<void>();
 case 2 /* UnsignedNumericValue */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.UnsignedNumericValue;u64 const& val = __jakt_match_value.value;
 {
-TRY((((*this).error((ByteString::must_from_utf8("Unimplemented expression"sv)),span))));
+TRY((((*this).error((ByteString::from_utf8_without_validation("Unimplemented expression"sv)),span))));
 return Error::__jakt_from_string_literal((StringView::from_string_literal("Not yet implemented"sv)));
 }
 return JaktInternal::ExplicitValue<void>();
@@ -3139,7 +3139,7 @@ return JaktInternal::ExplicitValue<void>();
 case 1 /* SignedNumericValue */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.SignedNumericValue;i64 const& val = __jakt_match_value.value;
 {
-TRY((((*this).error((ByteString::must_from_utf8("Unimplemented expression"sv)),span))));
+TRY((((*this).error((ByteString::from_utf8_without_validation("Unimplemented expression"sv)),span))));
 return Error::__jakt_from_string_literal((StringView::from_string_literal("Not yet implemented"sv)));
 }
 return JaktInternal::ExplicitValue<void>();
@@ -3332,7 +3332,7 @@ if (((((namespace_).size())) != (static_cast<size_t>(1ULL)))){
 return ({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<interpreter::StatementResult,ErrorOr<interpreter::StatementResult>>{
 auto __jakt_enum_value = (prelude_function);
-if (__jakt_enum_value == (ByteString::must_from_utf8("format"sv))) {
+if (__jakt_enum_value == (ByteString::from_utf8_without_validation("format"sv))) {
 return JaktInternal::ExplicitValue(({ Optional<interpreter::StatementResult> __jakt_var_207; {
 ByteString const format_string = ({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<ByteString, ErrorOr<interpreter::StatementResult>>{
@@ -3360,7 +3360,7 @@ __jakt_var_207 = interpreter::StatementResult::JustValue(types::Value(types::Val
 }
 __jakt_label_193:; __jakt_var_207.release_value(); }));
 }
-else if (__jakt_enum_value == (ByteString::must_from_utf8("println"sv))) {
+else if (__jakt_enum_value == (ByteString::from_utf8_without_validation("println"sv))) {
 return JaktInternal::ExplicitValue(({ Optional<interpreter::StatementResult> __jakt_var_208; {
 ByteString const format_string = ({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<ByteString, ErrorOr<interpreter::StatementResult>>{
@@ -3387,13 +3387,13 @@ ByteString const formatted_string = TRY((types::comptime_format_impl(format_stri
 ({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<void,ErrorOr<interpreter::StatementResult>>{
 auto __jakt_enum_value = (prelude_function);
-if (__jakt_enum_value == (ByteString::must_from_utf8("println"sv))) {
+if (__jakt_enum_value == (ByteString::from_utf8_without_validation("println"sv))) {
 return (outln((StringView::from_string_literal("{}"sv)),formatted_string)), JaktInternal::ExplicitValue<void>();
 }
-else if (__jakt_enum_value == (ByteString::must_from_utf8("eprintln"sv))) {
+else if (__jakt_enum_value == (ByteString::from_utf8_without_validation("eprintln"sv))) {
 return (warnln((StringView::from_string_literal("{}"sv)),formatted_string)), JaktInternal::ExplicitValue<void>();
 }
-else if (__jakt_enum_value == (ByteString::must_from_utf8("print"sv))) {
+else if (__jakt_enum_value == (ByteString::from_utf8_without_validation("print"sv))) {
 return (out((StringView::from_string_literal("{}"sv)),formatted_string)), JaktInternal::ExplicitValue<void>();
 }
 else {
@@ -3410,7 +3410,7 @@ __jakt_var_208 = interpreter::StatementResult::JustValue(types::Value(types::Val
 }
 __jakt_label_194:; __jakt_var_208.release_value(); }));
 }
-else if (__jakt_enum_value == (ByteString::must_from_utf8("eprintln"sv))) {
+else if (__jakt_enum_value == (ByteString::from_utf8_without_validation("eprintln"sv))) {
 return JaktInternal::ExplicitValue(({ Optional<interpreter::StatementResult> __jakt_var_209; {
 ByteString const format_string = ({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<ByteString, ErrorOr<interpreter::StatementResult>>{
@@ -3437,13 +3437,13 @@ ByteString const formatted_string = TRY((types::comptime_format_impl(format_stri
 ({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<void,ErrorOr<interpreter::StatementResult>>{
 auto __jakt_enum_value = (prelude_function);
-if (__jakt_enum_value == (ByteString::must_from_utf8("println"sv))) {
+if (__jakt_enum_value == (ByteString::from_utf8_without_validation("println"sv))) {
 return (outln((StringView::from_string_literal("{}"sv)),formatted_string)), JaktInternal::ExplicitValue<void>();
 }
-else if (__jakt_enum_value == (ByteString::must_from_utf8("eprintln"sv))) {
+else if (__jakt_enum_value == (ByteString::from_utf8_without_validation("eprintln"sv))) {
 return (warnln((StringView::from_string_literal("{}"sv)),formatted_string)), JaktInternal::ExplicitValue<void>();
 }
-else if (__jakt_enum_value == (ByteString::must_from_utf8("print"sv))) {
+else if (__jakt_enum_value == (ByteString::from_utf8_without_validation("print"sv))) {
 return (out((StringView::from_string_literal("{}"sv)),formatted_string)), JaktInternal::ExplicitValue<void>();
 }
 else {
@@ -3460,7 +3460,7 @@ __jakt_var_209 = interpreter::StatementResult::JustValue(types::Value(types::Val
 }
 __jakt_label_195:; __jakt_var_209.release_value(); }));
 }
-else if (__jakt_enum_value == (ByteString::must_from_utf8("print"sv))) {
+else if (__jakt_enum_value == (ByteString::from_utf8_without_validation("print"sv))) {
 return JaktInternal::ExplicitValue(({ Optional<interpreter::StatementResult> __jakt_var_210; {
 ByteString const format_string = ({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<ByteString, ErrorOr<interpreter::StatementResult>>{
@@ -3487,13 +3487,13 @@ ByteString const formatted_string = TRY((types::comptime_format_impl(format_stri
 ({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<void,ErrorOr<interpreter::StatementResult>>{
 auto __jakt_enum_value = (prelude_function);
-if (__jakt_enum_value == (ByteString::must_from_utf8("println"sv))) {
+if (__jakt_enum_value == (ByteString::from_utf8_without_validation("println"sv))) {
 return (outln((StringView::from_string_literal("{}"sv)),formatted_string)), JaktInternal::ExplicitValue<void>();
 }
-else if (__jakt_enum_value == (ByteString::must_from_utf8("eprintln"sv))) {
+else if (__jakt_enum_value == (ByteString::from_utf8_without_validation("eprintln"sv))) {
 return (warnln((StringView::from_string_literal("{}"sv)),formatted_string)), JaktInternal::ExplicitValue<void>();
 }
-else if (__jakt_enum_value == (ByteString::must_from_utf8("print"sv))) {
+else if (__jakt_enum_value == (ByteString::from_utf8_without_validation("print"sv))) {
 return (out((StringView::from_string_literal("{}"sv)),formatted_string)), JaktInternal::ExplicitValue<void>();
 }
 else {
@@ -3510,7 +3510,7 @@ __jakt_var_210 = interpreter::StatementResult::JustValue(types::Value(types::Val
 }
 __jakt_label_196:; __jakt_var_210.release_value(); }));
 }
-else if (__jakt_enum_value == (ByteString::must_from_utf8("eprint"sv))) {
+else if (__jakt_enum_value == (ByteString::from_utf8_without_validation("eprint"sv))) {
 return JaktInternal::ExplicitValue(({ Optional<interpreter::StatementResult> __jakt_var_211; {
 ByteString const format_string = ({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<ByteString, ErrorOr<interpreter::StatementResult>>{
@@ -3537,13 +3537,13 @@ ByteString const formatted_string = TRY((types::comptime_format_impl(format_stri
 ({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<void,ErrorOr<interpreter::StatementResult>>{
 auto __jakt_enum_value = (prelude_function);
-if (__jakt_enum_value == (ByteString::must_from_utf8("println"sv))) {
+if (__jakt_enum_value == (ByteString::from_utf8_without_validation("println"sv))) {
 return (outln((StringView::from_string_literal("{}"sv)),formatted_string)), JaktInternal::ExplicitValue<void>();
 }
-else if (__jakt_enum_value == (ByteString::must_from_utf8("eprintln"sv))) {
+else if (__jakt_enum_value == (ByteString::from_utf8_without_validation("eprintln"sv))) {
 return (warnln((StringView::from_string_literal("{}"sv)),formatted_string)), JaktInternal::ExplicitValue<void>();
 }
-else if (__jakt_enum_value == (ByteString::must_from_utf8("print"sv))) {
+else if (__jakt_enum_value == (ByteString::from_utf8_without_validation("print"sv))) {
 return (out((StringView::from_string_literal("{}"sv)),formatted_string)), JaktInternal::ExplicitValue<void>();
 }
 else {
@@ -3560,16 +3560,16 @@ __jakt_var_211 = interpreter::StatementResult::JustValue(types::Value(types::Val
 }
 __jakt_label_197:; __jakt_var_211.release_value(); }));
 }
-else if (__jakt_enum_value == (ByteString::must_from_utf8("as_saturated"sv))) {
+else if (__jakt_enum_value == (ByteString::from_utf8_without_validation("as_saturated"sv))) {
 return JaktInternal::ExplicitValue(({ Optional<interpreter::StatementResult> __jakt_var_212; {
-NonnullRefPtr<types::CheckedFunction> const function = ((((*this).program))->get_function((((TRY((((((*this).program))->find_functions_with_name_in_scope(((((*this).program))->prelude_scope_id()),(ByteString::must_from_utf8("as_saturated"sv)),false,JaktInternal::OptionalNone())))).value()))[static_cast<i64>(0LL)])));
+NonnullRefPtr<types::CheckedFunction> const function = ((((*this).program))->get_function((((TRY((((((*this).program))->find_functions_with_name_in_scope(((((*this).program))->prelude_scope_id()),(ByteString::from_utf8_without_validation("as_saturated"sv)),false,JaktInternal::OptionalNone())))).value()))[static_cast<i64>(0LL)])));
 JaktInternal::Optional<ids::TypeId> const output_type_id = ((type_bindings).get(((((((((function)->generics))->params))[static_cast<i64>(0LL)])).type_id())));
 __jakt_var_212 = interpreter::StatementResult::JustValue(TRY((interpreter::cast_value_to_type(((arguments)[static_cast<i64>(0LL)]),(output_type_id.value()),*this,true)))); goto __jakt_label_198;
 
 }
 __jakt_label_198:; __jakt_var_212.release_value(); }));
 }
-else if (__jakt_enum_value == (ByteString::must_from_utf8("unchecked_mul"sv))) {
+else if (__jakt_enum_value == (ByteString::from_utf8_without_validation("unchecked_mul"sv))) {
 return JaktInternal::ExplicitValue(({ Optional<interpreter::StatementResult> __jakt_var_213; {
 types::Value const lhs_value = ((arguments)[static_cast<i64>(0LL)]);
 types::Value const rhs_value = ((arguments)[static_cast<i64>(1LL)]);
@@ -3859,7 +3859,7 @@ return Error::__jakt_from_string_literal((StringView::from_string_literal("Inval
 }
 __jakt_label_199:; __jakt_var_213.release_value(); }));
 }
-else if (__jakt_enum_value == (ByteString::must_from_utf8("unchecked_add"sv))) {
+else if (__jakt_enum_value == (ByteString::from_utf8_without_validation("unchecked_add"sv))) {
 return JaktInternal::ExplicitValue(({ Optional<interpreter::StatementResult> __jakt_var_214; {
 types::Value const lhs_value = ((arguments)[static_cast<i64>(0LL)]);
 types::Value const rhs_value = ((arguments)[static_cast<i64>(1LL)]);
@@ -4149,10 +4149,10 @@ return Error::__jakt_from_string_literal((StringView::from_string_literal("Inval
 }
 __jakt_label_200:; __jakt_var_214.release_value(); }));
 }
-else if (__jakt_enum_value == (ByteString::must_from_utf8("___jakt_get_target_triple_string"sv))) {
+else if (__jakt_enum_value == (ByteString::from_utf8_without_validation("___jakt_get_target_triple_string"sv))) {
 return JaktInternal::ExplicitValue(interpreter::StatementResult::JustValue(types::Value(types::ValueImpl::JaktString(TRY((((((*this).compiler))->target_triple).try_value_or_lazy_evaluated([&]() -> ErrorOr<ByteString> { return TRY((___jakt_get_target_triple_string())); })))),call_span)));
 }
-else if (__jakt_enum_value == (ByteString::must_from_utf8("___jakt_get_user_configuration_value"sv))) {
+else if (__jakt_enum_value == (ByteString::from_utf8_without_validation("___jakt_get_user_configuration_value"sv))) {
 return JaktInternal::ExplicitValue(({ Optional<interpreter::StatementResult> __jakt_var_215; {
 NonnullRefPtr<typename types::ValueImpl> impl = types::ValueImpl::OptionalNone();
 JaktInternal::Optional<ByteString> const value = ((((((*this).compiler))->user_configuration)).get(TRY((((*this).string_from_value(((arguments)[static_cast<i64>(0LL)])))))));
@@ -4164,38 +4164,38 @@ __jakt_var_215 = interpreter::StatementResult::JustValue(types::Value(impl,call_
 }
 __jakt_label_201:; __jakt_var_215.release_value(); }));
 }
-else if (__jakt_enum_value == (ByteString::must_from_utf8("abort"sv))) {
+else if (__jakt_enum_value == (ByteString::from_utf8_without_validation("abort"sv))) {
 {
 abort();
 }
 }
-else if (__jakt_enum_value == (ByteString::must_from_utf8("Set"sv))) {
+else if (__jakt_enum_value == (ByteString::from_utf8_without_validation("Set"sv))) {
 return JaktInternal::ExplicitValue(({ Optional<interpreter::StatementResult> __jakt_var_216; {
 if (((((type_bindings).size())) != (static_cast<size_t>(1ULL)))){
-TRY((((*this).error((ByteString::must_from_utf8("Set constructor expects one generic argument"sv)),call_span))));
+TRY((((*this).error((ByteString::from_utf8_without_validation("Set constructor expects one generic argument"sv)),call_span))));
 return Error::__jakt_from_string_literal((StringView::from_string_literal("Invalid type"sv)));
 }
-ids::StructId const set_struct_id = TRY((((((*this).program))->find_struct_in_prelude((ByteString::must_from_utf8("Set"sv))))));
+ids::StructId const set_struct_id = TRY((((((*this).program))->find_struct_in_prelude((ByteString::from_utf8_without_validation("Set"sv))))));
 ids::TypeId const type_id = ((*this).find_or_add_type_id(types::Type::GenericInstance(parser::CheckedQualifiers(false),set_struct_id,DynamicArray<ids::TypeId>::create_with({(((type_bindings).get(((((type_bindings).keys()))[static_cast<i64>(0LL)]))).value())}))));
 __jakt_var_216 = interpreter::StatementResult::JustValue(types::Value(types::ValueImpl::JaktSet(DynamicArray<types::Value>::create_with({}),type_id),call_span)); goto __jakt_label_202;
 
 }
 __jakt_label_202:; __jakt_var_216.release_value(); }));
 }
-else if (__jakt_enum_value == (ByteString::must_from_utf8("Dictionary"sv))) {
+else if (__jakt_enum_value == (ByteString::from_utf8_without_validation("Dictionary"sv))) {
 return JaktInternal::ExplicitValue(({ Optional<interpreter::StatementResult> __jakt_var_217; {
 if (((((type_bindings).size())) != (static_cast<size_t>(2ULL)))){
-TRY((((*this).error((ByteString::must_from_utf8("Dictionary constructor expects two generic argumenst"sv)),call_span))));
+TRY((((*this).error((ByteString::from_utf8_without_validation("Dictionary constructor expects two generic argumenst"sv)),call_span))));
 return Error::__jakt_from_string_literal((StringView::from_string_literal("Invalid type"sv)));
 }
-ids::StructId const dictionary_struct_id = TRY((((((*this).program))->find_struct_in_prelude((ByteString::must_from_utf8("Dictionary"sv))))));
+ids::StructId const dictionary_struct_id = TRY((((((*this).program))->find_struct_in_prelude((ByteString::from_utf8_without_validation("Dictionary"sv))))));
 ids::TypeId const type_id = ((*this).find_or_add_type_id(types::Type::GenericInstance(parser::CheckedQualifiers(false),dictionary_struct_id,DynamicArray<ids::TypeId>::create_with({(((type_bindings).get(((((type_bindings).keys()))[static_cast<i64>(0LL)]))).value()), (((type_bindings).get(((((type_bindings).keys()))[static_cast<i64>(1LL)]))).value())}))));
 __jakt_var_217 = interpreter::StatementResult::JustValue(types::Value(types::ValueImpl::JaktDictionary(DynamicArray<types::Value>::create_with({}),DynamicArray<types::Value>::create_with({}),type_id),call_span)); goto __jakt_label_203;
 
 }
 __jakt_label_203:; __jakt_var_217.release_value(); }));
 }
-else if (__jakt_enum_value == (ByteString::must_from_utf8("from_string_literal"sv))) {
+else if (__jakt_enum_value == (ByteString::from_utf8_without_validation("from_string_literal"sv))) {
 return JaktInternal::ExplicitValue(({ Optional<interpreter::StatementResult> __jakt_var_218; {
 __jakt_var_218 = interpreter::StatementResult::JustValue(((arguments)[static_cast<i64>(0LL)])); goto __jakt_label_204;
 
@@ -4217,35 +4217,35 @@ return Error::__jakt_from_string_literal((StringView::from_string_literal("Not y
 return ({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<interpreter::StatementResult,ErrorOr<interpreter::StatementResult>>{
 auto __jakt_enum_value = (((((namespace_)[static_cast<i64>(0LL)])).name));
-if (__jakt_enum_value == (ByteString::must_from_utf8("Error"sv))) {
+if (__jakt_enum_value == (ByteString::from_utf8_without_validation("Error"sv))) {
 return JaktInternal::ExplicitValue(({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<interpreter::StatementResult,ErrorOr<interpreter::StatementResult>>{
 auto __jakt_enum_value = (prelude_function);
-if (__jakt_enum_value == (ByteString::must_from_utf8("from_errno"sv))) {
+if (__jakt_enum_value == (ByteString::from_utf8_without_validation("from_errno"sv))) {
 return JaktInternal::ExplicitValue(({ Optional<interpreter::StatementResult> __jakt_var_219; {
 types::Value const err = ((arguments)[static_cast<i64>(0LL)]);
-ids::StructId const error_struct_id = TRY((((((*this).program))->find_struct_in_prelude((ByteString::must_from_utf8("Error"sv))))));
+ids::StructId const error_struct_id = TRY((((((*this).program))->find_struct_in_prelude((ByteString::from_utf8_without_validation("Error"sv))))));
 types::CheckedStruct const error_struct = ((((*this).program))->get_struct(error_struct_id));
 NonnullRefPtr<types::Scope> const scope = ((((*this).program))->get_scope(((error_struct).scope_id)));
-JaktInternal::Optional<JaktInternal::DynamicArray<ids::FunctionId>> const constructors = ((((scope)->functions)).get((ByteString::must_from_utf8("from_errno"sv))));
+JaktInternal::Optional<JaktInternal::DynamicArray<ids::FunctionId>> const constructors = ((((scope)->functions)).get((ByteString::from_utf8_without_validation("from_errno"sv))));
 __jakt_var_219 = interpreter::StatementResult::JustValue(types::Value(types::ValueImpl::Struct(DynamicArray<types::Value>::create_with({err}),error_struct_id,(((constructors.value()))[static_cast<i64>(0LL)])),call_span)); goto __jakt_label_205;
 
 }
 __jakt_label_205:; __jakt_var_219.release_value(); }));
 }
-else if (__jakt_enum_value == (ByteString::must_from_utf8("from_string_literal"sv))) {
+else if (__jakt_enum_value == (ByteString::from_utf8_without_validation("from_string_literal"sv))) {
 return JaktInternal::ExplicitValue(({ Optional<interpreter::StatementResult> __jakt_var_220; {
 types::Value const err = ((arguments)[static_cast<i64>(0LL)]);
-ids::StructId const error_struct_id = TRY((((((*this).program))->find_struct_in_prelude((ByteString::must_from_utf8("Error"sv))))));
+ids::StructId const error_struct_id = TRY((((((*this).program))->find_struct_in_prelude((ByteString::from_utf8_without_validation("Error"sv))))));
 types::CheckedStruct const error_struct = ((((*this).program))->get_struct(error_struct_id));
 NonnullRefPtr<types::Scope> const scope = ((((*this).program))->get_scope(((error_struct).scope_id)));
-JaktInternal::Optional<JaktInternal::DynamicArray<ids::FunctionId>> const constructors = ((((scope)->functions)).get((ByteString::must_from_utf8("from_string_literal"sv))));
+JaktInternal::Optional<JaktInternal::DynamicArray<ids::FunctionId>> const constructors = ((((scope)->functions)).get((ByteString::from_utf8_without_validation("from_string_literal"sv))));
 __jakt_var_220 = interpreter::StatementResult::JustValue(types::Value(types::ValueImpl::Struct(DynamicArray<types::Value>::create_with({err}),error_struct_id,(((constructors.value()))[static_cast<i64>(0LL)])),call_span)); goto __jakt_label_206;
 
 }
 __jakt_label_206:; __jakt_var_220.release_value(); }));
 }
-else if (__jakt_enum_value == (ByteString::must_from_utf8("code"sv))) {
+else if (__jakt_enum_value == (ByteString::from_utf8_without_validation("code"sv))) {
 return JaktInternal::ExplicitValue(({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<interpreter::StatementResult, ErrorOr<interpreter::StatementResult>>{
 auto&& __jakt_match_variant = *(((this_argument.value())).impl);
@@ -4300,11 +4300,11 @@ return Error::__jakt_from_string_literal((StringView::from_string_literal("Not y
     _jakt_value.release_value();
 }));
 }
-else if (__jakt_enum_value == (ByteString::must_from_utf8("File"sv))) {
+else if (__jakt_enum_value == (ByteString::from_utf8_without_validation("File"sv))) {
 return JaktInternal::ExplicitValue(({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<interpreter::StatementResult,ErrorOr<interpreter::StatementResult>>{
 auto __jakt_enum_value = (prelude_function);
-if (__jakt_enum_value == (ByteString::must_from_utf8("open_for_reading"sv))) {
+if (__jakt_enum_value == (ByteString::from_utf8_without_validation("open_for_reading"sv))) {
 return JaktInternal::ExplicitValue(({ Optional<interpreter::StatementResult> __jakt_var_221; {
 ByteString const requested_path = ({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<ByteString, ErrorOr<interpreter::StatementResult>>{
@@ -4332,16 +4332,16 @@ types::Value const path_value = types::Value(types::ValueImpl::JaktString(((path
 if ((!(((path).exists())))){
 return interpreter::StatementResult::Throw(TRY((((*this).error_value(__jakt_format((StringView::from_string_literal("Could not find file at path {}"sv)),((path).to_string())),call_span)))));
 }
-ids::StructId const file_struct_id = TRY((((((*this).program))->find_struct_in_prelude((ByteString::must_from_utf8("File"sv))))));
+ids::StructId const file_struct_id = TRY((((((*this).program))->find_struct_in_prelude((ByteString::from_utf8_without_validation("File"sv))))));
 types::CheckedStruct const file_struct = ((((*this).program))->get_struct(file_struct_id));
 NonnullRefPtr<types::Scope> const scope = ((((*this).program))->get_scope(((file_struct).scope_id)));
-JaktInternal::Optional<JaktInternal::DynamicArray<ids::FunctionId>> const constructors = ((((scope)->functions)).get((ByteString::must_from_utf8("open_for_reading"sv))));
+JaktInternal::Optional<JaktInternal::DynamicArray<ids::FunctionId>> const constructors = ((((scope)->functions)).get((ByteString::from_utf8_without_validation("open_for_reading"sv))));
 __jakt_var_221 = interpreter::StatementResult::JustValue(types::Value(types::ValueImpl::Struct(DynamicArray<types::Value>::create_with({path_value}),file_struct_id,(((constructors.value()))[static_cast<i64>(0LL)])),call_span)); goto __jakt_label_207;
 
 }
 __jakt_label_207:; __jakt_var_221.release_value(); }));
 }
-else if (__jakt_enum_value == (ByteString::must_from_utf8("open_for_writing"sv))) {
+else if (__jakt_enum_value == (ByteString::from_utf8_without_validation("open_for_writing"sv))) {
 return JaktInternal::ExplicitValue(({ Optional<interpreter::StatementResult> __jakt_var_222; {
 ByteString const requested_path = ({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<ByteString, ErrorOr<interpreter::StatementResult>>{
@@ -4369,16 +4369,16 @@ types::Value const path_value = types::Value(types::ValueImpl::JaktString(((path
 if ((!(((path).exists())))){
 return interpreter::StatementResult::Throw(TRY((((*this).error_value(__jakt_format((StringView::from_string_literal("Could not find file at path {}"sv)),((path).to_string())),call_span)))));
 }
-ids::StructId const file_struct_id = TRY((((((*this).program))->find_struct_in_prelude((ByteString::must_from_utf8("File"sv))))));
+ids::StructId const file_struct_id = TRY((((((*this).program))->find_struct_in_prelude((ByteString::from_utf8_without_validation("File"sv))))));
 types::CheckedStruct const file_struct = ((((*this).program))->get_struct(file_struct_id));
 NonnullRefPtr<types::Scope> const scope = ((((*this).program))->get_scope(((file_struct).scope_id)));
-JaktInternal::Optional<JaktInternal::DynamicArray<ids::FunctionId>> const constructor = ((((scope)->functions)).get((ByteString::must_from_utf8("open_for_writing"sv))));
+JaktInternal::Optional<JaktInternal::DynamicArray<ids::FunctionId>> const constructor = ((((scope)->functions)).get((ByteString::from_utf8_without_validation("open_for_writing"sv))));
 __jakt_var_222 = interpreter::StatementResult::JustValue(types::Value(types::ValueImpl::Struct(DynamicArray<types::Value>::create_with({path_value}),file_struct_id,(((constructor.value()))[static_cast<i64>(0LL)])),call_span)); goto __jakt_label_208;
 
 }
 __jakt_label_208:; __jakt_var_222.release_value(); }));
 }
-else if (__jakt_enum_value == (ByteString::must_from_utf8("read_all"sv))) {
+else if (__jakt_enum_value == (ByteString::from_utf8_without_validation("read_all"sv))) {
 return JaktInternal::ExplicitValue(({ Optional<interpreter::StatementResult> __jakt_var_223; {
 ByteString const path = ({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<ByteString, ErrorOr<interpreter::StatementResult>>{
@@ -4396,7 +4396,7 @@ return JaktInternal::ExplicitValue(x);
 };/*case end*/
 default: {
 {
-utility::panic((ByteString::must_from_utf8("invalid type for File::read_all"sv)));
+utility::panic((ByteString::from_utf8_without_validation("invalid type for File::read_all"sv)));
 }
 };/*case end*/
 }/*switch end*/
@@ -4420,10 +4420,10 @@ return Error::__jakt_from_string_literal((StringView::from_string_literal("Inval
         return _jakt_value.release_return();
     _jakt_value.release_value();
 });
-ids::StructId const file_struct_id = TRY((((((*this).program))->find_struct_in_prelude((ByteString::must_from_utf8("File"sv))))));
+ids::StructId const file_struct_id = TRY((((((*this).program))->find_struct_in_prelude((ByteString::from_utf8_without_validation("File"sv))))));
 types::CheckedStruct const file_struct = ((((*this).program))->get_struct(file_struct_id));
 NonnullRefPtr<types::Scope> const scope = ((((*this).program))->get_scope(((file_struct).scope_id)));
-ids::FunctionId const open_for_reading = (((((((scope)->functions)).get((ByteString::must_from_utf8("open_for_reading"sv)))).value()))[static_cast<i64>(0LL)]);
+ids::FunctionId const open_for_reading = (((((((scope)->functions)).get((ByteString::from_utf8_without_validation("open_for_reading"sv)))).value()))[static_cast<i64>(0LL)]);
 ({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<void, ErrorOr<interpreter::StatementResult>>{
 auto&& __jakt_match_variant = *(((this_argument.value())).impl);
@@ -4432,7 +4432,7 @@ case 17 /* Struct */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Struct;JaktInternal::Optional<ids::FunctionId> const& constructor = __jakt_match_value.constructor;
 {
 if (((!(((constructor).has_value()))) || (!((((constructor.value())).equals(open_for_reading)))))){
-TRY((((*this).error((ByteString::must_from_utf8("Cannot read from a file not opened for reading"sv)),call_span))));
+TRY((((*this).error((ByteString::from_utf8_without_validation("Cannot read from a file not opened for reading"sv)),call_span))));
 return Error::__jakt_from_string_literal((StringView::from_string_literal("Invalid type"sv)));
 }
 }
@@ -4440,7 +4440,7 @@ return JaktInternal::ExplicitValue<void>();
 };/*case end*/
 default: {
 {
-utility::panic((ByteString::must_from_utf8("expected struct as this argument"sv)));
+utility::panic((ByteString::from_utf8_without_validation("expected struct as this argument"sv)));
 }
 return JaktInternal::ExplicitValue<void>();
 };/*case end*/
@@ -4468,13 +4468,13 @@ u8 byte = (_magic_value.value());
 }
 }
 
-ids::StructId const array_struct_id = TRY((((((*this).program))->find_struct_in_prelude((ByteString::must_from_utf8("Array"sv))))));
+ids::StructId const array_struct_id = TRY((((((*this).program))->find_struct_in_prelude((ByteString::from_utf8_without_validation("Array"sv))))));
 __jakt_var_223 = interpreter::StatementResult::JustValue(types::Value(types::ValueImpl::JaktArray(result_values,((*this).find_or_add_type_id(types::Type::GenericInstance(parser::CheckedQualifiers(false),array_struct_id,DynamicArray<ids::TypeId>::create_with({types::builtin(types::BuiltinType::U8())}))))),call_span)); goto __jakt_label_209;
 
 }
 __jakt_label_209:; __jakt_var_223.release_value(); }));
 }
-else if (__jakt_enum_value == (ByteString::must_from_utf8("read"sv))) {
+else if (__jakt_enum_value == (ByteString::from_utf8_without_validation("read"sv))) {
 return JaktInternal::ExplicitValue(({ Optional<interpreter::StatementResult> __jakt_var_224; {
 ByteString const path = ({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<ByteString, ErrorOr<interpreter::StatementResult>>{
@@ -4492,7 +4492,7 @@ return JaktInternal::ExplicitValue(x);
 };/*case end*/
 default: {
 {
-utility::panic((ByteString::must_from_utf8("invalid type for File::read"sv)));
+utility::panic((ByteString::from_utf8_without_validation("invalid type for File::read"sv)));
 }
 };/*case end*/
 }/*switch end*/
@@ -4516,10 +4516,10 @@ return Error::__jakt_from_string_literal((StringView::from_string_literal("Inval
         return _jakt_value.release_return();
     _jakt_value.release_value();
 });
-ids::StructId const file_struct_id = TRY((((((*this).program))->find_struct_in_prelude((ByteString::must_from_utf8("File"sv))))));
+ids::StructId const file_struct_id = TRY((((((*this).program))->find_struct_in_prelude((ByteString::from_utf8_without_validation("File"sv))))));
 types::CheckedStruct const file_struct = ((((*this).program))->get_struct(file_struct_id));
 NonnullRefPtr<types::Scope> const scope = ((((*this).program))->get_scope(((file_struct).scope_id)));
-ids::FunctionId const open_for_reading = (((((((scope)->functions)).get((ByteString::must_from_utf8("open_for_reading"sv)))).value()))[static_cast<i64>(0LL)]);
+ids::FunctionId const open_for_reading = (((((((scope)->functions)).get((ByteString::from_utf8_without_validation("open_for_reading"sv)))).value()))[static_cast<i64>(0LL)]);
 ({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<void, ErrorOr<interpreter::StatementResult>>{
 auto&& __jakt_match_variant = *(((this_argument.value())).impl);
@@ -4528,7 +4528,7 @@ case 17 /* Struct */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Struct;JaktInternal::Optional<ids::FunctionId> const& constructor = __jakt_match_value.constructor;
 {
 if (((!(((constructor).has_value()))) || (!((((constructor.value())).equals(open_for_reading)))))){
-TRY((((*this).error((ByteString::must_from_utf8("Cannot read from a file not opened for reading"sv)),call_span))));
+TRY((((*this).error((ByteString::from_utf8_without_validation("Cannot read from a file not opened for reading"sv)),call_span))));
 return Error::__jakt_from_string_literal((StringView::from_string_literal("Invalid type"sv)));
 }
 }
@@ -4536,7 +4536,7 @@ return JaktInternal::ExplicitValue<void>();
 };/*case end*/
 default: {
 {
-utility::panic((ByteString::must_from_utf8("expected struct as this argument"sv)));
+utility::panic((ByteString::from_utf8_without_validation("expected struct as this argument"sv)));
 }
 return JaktInternal::ExplicitValue<void>();
 };/*case end*/
@@ -4591,7 +4591,7 @@ __jakt_var_224 = interpreter::StatementResult::JustValue(types::Value(types::Val
 }
 __jakt_label_210:; __jakt_var_224.release_value(); }));
 }
-else if (__jakt_enum_value == (ByteString::must_from_utf8("exists"sv))) {
+else if (__jakt_enum_value == (ByteString::from_utf8_without_validation("exists"sv))) {
 return JaktInternal::ExplicitValue(({ Optional<interpreter::StatementResult> __jakt_var_225; {
 ByteString const requested_path = ({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<ByteString, ErrorOr<interpreter::StatementResult>>{
@@ -4620,7 +4620,7 @@ __jakt_var_225 = interpreter::StatementResult::JustValue(types::Value(types::Val
 }
 __jakt_label_211:; __jakt_var_225.release_value(); }));
 }
-else if (__jakt_enum_value == (ByteString::must_from_utf8("write"sv))) {
+else if (__jakt_enum_value == (ByteString::from_utf8_without_validation("write"sv))) {
 return JaktInternal::ExplicitValue(({ Optional<interpreter::StatementResult> __jakt_var_226; {
 ByteString const path = ({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<ByteString, ErrorOr<interpreter::StatementResult>>{
@@ -4638,7 +4638,7 @@ return JaktInternal::ExplicitValue(x);
 };/*case end*/
 default: {
 {
-utility::panic((ByteString::must_from_utf8("invalid type for File::write"sv)));
+utility::panic((ByteString::from_utf8_without_validation("invalid type for File::write"sv)));
 }
 };/*case end*/
 }/*switch end*/
@@ -4662,10 +4662,10 @@ return Error::__jakt_from_string_literal((StringView::from_string_literal("Inval
         return _jakt_value.release_return();
     _jakt_value.release_value();
 });
-ids::StructId const file_struct_id = TRY((((((*this).program))->find_struct_in_prelude((ByteString::must_from_utf8("File"sv))))));
+ids::StructId const file_struct_id = TRY((((((*this).program))->find_struct_in_prelude((ByteString::from_utf8_without_validation("File"sv))))));
 types::CheckedStruct const file_struct = ((((*this).program))->get_struct(file_struct_id));
 NonnullRefPtr<types::Scope> const scope = ((((*this).program))->get_scope(((file_struct).scope_id)));
-ids::FunctionId const open_for_writing = (((((((scope)->functions)).get((ByteString::must_from_utf8("open_for_writing"sv)))).value()))[static_cast<i64>(0LL)]);
+ids::FunctionId const open_for_writing = (((((((scope)->functions)).get((ByteString::from_utf8_without_validation("open_for_writing"sv)))).value()))[static_cast<i64>(0LL)]);
 ({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<void, ErrorOr<interpreter::StatementResult>>{
 auto&& __jakt_match_variant = *(((this_argument.value())).impl);
@@ -4674,7 +4674,7 @@ case 17 /* Struct */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Struct;JaktInternal::Optional<ids::FunctionId> const& constructor = __jakt_match_value.constructor;
 {
 if (((!(((constructor).has_value()))) || (!((((constructor.value())).equals(open_for_writing)))))){
-TRY((((*this).error((ByteString::must_from_utf8("Cannot write to a file not opened for writing"sv)),call_span))));
+TRY((((*this).error((ByteString::from_utf8_without_validation("Cannot write to a file not opened for writing"sv)),call_span))));
 return Error::__jakt_from_string_literal((StringView::from_string_literal("Invalid type"sv)));
 }
 }
@@ -4682,7 +4682,7 @@ return JaktInternal::ExplicitValue<void>();
 };/*case end*/
 default: {
 {
-utility::panic((ByteString::must_from_utf8("expected struct as this argument"sv)));
+utility::panic((ByteString::from_utf8_without_validation("expected struct as this argument"sv)));
 }
 return JaktInternal::ExplicitValue<void>();
 };/*case end*/
@@ -4735,7 +4735,7 @@ return JaktInternal::ExplicitValue(x);
 };/*case end*/
 default: {
 {
-utility::panic((ByteString::must_from_utf8("expected byte"sv)));
+utility::panic((ByteString::from_utf8_without_validation("expected byte"sv)));
 }
 };/*case end*/
 }/*switch end*/
@@ -4772,19 +4772,19 @@ return Error::__jakt_from_string_literal((StringView::from_string_literal("Not y
     _jakt_value.release_value();
 }));
 }
-else if (__jakt_enum_value == (ByteString::must_from_utf8("StringBuilder"sv))) {
+else if (__jakt_enum_value == (ByteString::from_utf8_without_validation("StringBuilder"sv))) {
 return JaktInternal::ExplicitValue(({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<interpreter::StatementResult,ErrorOr<interpreter::StatementResult>>{
 auto __jakt_enum_value = (prelude_function);
-if (__jakt_enum_value == (ByteString::must_from_utf8("create"sv))) {
+if (__jakt_enum_value == (ByteString::from_utf8_without_validation("create"sv))) {
 return JaktInternal::ExplicitValue(({ Optional<interpreter::StatementResult> __jakt_var_227; {
-ids::StructId const string_builder_struct_id = TRY((((((*this).program))->find_struct_in_prelude((ByteString::must_from_utf8("StringBuilder"sv))))));
-__jakt_var_227 = interpreter::StatementResult::JustValue(types::Value(types::ValueImpl::Struct(DynamicArray<types::Value>::create_with({types::Value(types::ValueImpl::JaktString((ByteString::must_from_utf8(""sv))),call_span)}),string_builder_struct_id,JaktInternal::OptionalNone()),call_span)); goto __jakt_label_213;
+ids::StructId const string_builder_struct_id = TRY((((((*this).program))->find_struct_in_prelude((ByteString::from_utf8_without_validation("StringBuilder"sv))))));
+__jakt_var_227 = interpreter::StatementResult::JustValue(types::Value(types::ValueImpl::Struct(DynamicArray<types::Value>::create_with({types::Value(types::ValueImpl::JaktString((ByteString::from_utf8_without_validation(""sv))),call_span)}),string_builder_struct_id,JaktInternal::OptionalNone()),call_span)); goto __jakt_label_213;
 
 }
 __jakt_label_213:; __jakt_var_227.release_value(); }));
 }
-else if (__jakt_enum_value == (ByteString::must_from_utf8("append"sv))) {
+else if (__jakt_enum_value == (ByteString::from_utf8_without_validation("append"sv))) {
 return JaktInternal::ExplicitValue(({ Optional<interpreter::StatementResult> __jakt_var_228; {
 JaktInternal::Tuple<JaktInternal::DynamicArray<types::Value>,ByteString> fields_current_string_ = ({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<JaktInternal::Tuple<JaktInternal::DynamicArray<types::Value>,ByteString>, ErrorOr<interpreter::StatementResult>>{
@@ -4802,7 +4802,7 @@ return JaktInternal::ExplicitValue((Tuple{fields, value}));
 };/*case end*/
 default: {
 {
-utility::panic((ByteString::must_from_utf8("Invalid use of prelude StringBuilder"sv)));
+utility::panic((ByteString::from_utf8_without_validation("Invalid use of prelude StringBuilder"sv)));
 }
 };/*case end*/
 }/*switch end*/
@@ -4834,7 +4834,7 @@ ByteStringBuilder builder = ByteStringBuilder::create();
 ({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<void,ErrorOr<interpreter::StatementResult>>{
 auto __jakt_enum_value = (prelude_function);
-if (__jakt_enum_value == (ByteString::must_from_utf8("append"sv))) {
+if (__jakt_enum_value == (ByteString::from_utf8_without_validation("append"sv))) {
 return (({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<void, ErrorOr<interpreter::StatementResult>>{
 auto&& __jakt_match_variant = *((((arguments)[static_cast<i64>(0LL)])).impl);
@@ -4866,7 +4866,7 @@ return JaktInternal::ExplicitValue<void>();
     _jakt_value.release_value();
 })), JaktInternal::ExplicitValue<void>();
 }
-else if (__jakt_enum_value == (ByteString::must_from_utf8("append_escaped_for_json"sv))) {
+else if (__jakt_enum_value == (ByteString::from_utf8_without_validation("append_escaped_for_json"sv))) {
 return (((builder).append_escaped_for_json(({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<ByteString, ErrorOr<interpreter::StatementResult>>{
 auto&& __jakt_match_variant = *((((arguments)[static_cast<i64>(0LL)])).impl);
@@ -4877,7 +4877,7 @@ return JaktInternal::ExplicitValue(value);
 };/*case end*/
 default: {
 {
-TRY((((*this).error((ByteString::must_from_utf8("Invalid use of StringBuilder::append_escaped_for_json()"sv)),call_span))));
+TRY((((*this).error((ByteString::from_utf8_without_validation("Invalid use of StringBuilder::append_escaped_for_json()"sv)),call_span))));
 return Error::__jakt_from_string_literal((StringView::from_string_literal("Invalid type"sv)));
 }
 };/*case end*/
@@ -4889,7 +4889,7 @@ return Error::__jakt_from_string_literal((StringView::from_string_literal("Inval
     _jakt_value.release_value();
 })))), JaktInternal::ExplicitValue<void>();
 }
-else if (__jakt_enum_value == (ByteString::must_from_utf8("append_code_point"sv))) {
+else if (__jakt_enum_value == (ByteString::from_utf8_without_validation("append_code_point"sv))) {
 return (((builder).append_code_point(({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<u32, ErrorOr<interpreter::StatementResult>>{
 auto&& __jakt_match_variant = *((((arguments)[static_cast<i64>(0LL)])).impl);
@@ -4900,7 +4900,7 @@ return JaktInternal::ExplicitValue(value);
 };/*case end*/
 default: {
 {
-TRY((((*this).error((ByteString::must_from_utf8("Invalid use of StringBuilder::append_code_point()"sv)),call_span))));
+TRY((((*this).error((ByteString::from_utf8_without_validation("Invalid use of StringBuilder::append_code_point()"sv)),call_span))));
 return Error::__jakt_from_string_literal((StringView::from_string_literal("Invalid type"sv)));
 }
 };/*case end*/
@@ -4930,7 +4930,7 @@ __jakt_var_228 = interpreter::StatementResult::JustValue(types::Value(types::Val
 }
 __jakt_label_214:; __jakt_var_228.release_value(); }));
 }
-else if (__jakt_enum_value == (ByteString::must_from_utf8("append_code_point"sv))) {
+else if (__jakt_enum_value == (ByteString::from_utf8_without_validation("append_code_point"sv))) {
 return JaktInternal::ExplicitValue(({ Optional<interpreter::StatementResult> __jakt_var_229; {
 JaktInternal::Tuple<JaktInternal::DynamicArray<types::Value>,ByteString> fields_current_string_ = ({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<JaktInternal::Tuple<JaktInternal::DynamicArray<types::Value>,ByteString>, ErrorOr<interpreter::StatementResult>>{
@@ -4948,7 +4948,7 @@ return JaktInternal::ExplicitValue((Tuple{fields, value}));
 };/*case end*/
 default: {
 {
-utility::panic((ByteString::must_from_utf8("Invalid use of prelude StringBuilder"sv)));
+utility::panic((ByteString::from_utf8_without_validation("Invalid use of prelude StringBuilder"sv)));
 }
 };/*case end*/
 }/*switch end*/
@@ -4980,7 +4980,7 @@ ByteStringBuilder builder = ByteStringBuilder::create();
 ({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<void,ErrorOr<interpreter::StatementResult>>{
 auto __jakt_enum_value = (prelude_function);
-if (__jakt_enum_value == (ByteString::must_from_utf8("append"sv))) {
+if (__jakt_enum_value == (ByteString::from_utf8_without_validation("append"sv))) {
 return (({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<void, ErrorOr<interpreter::StatementResult>>{
 auto&& __jakt_match_variant = *((((arguments)[static_cast<i64>(0LL)])).impl);
@@ -5012,7 +5012,7 @@ return JaktInternal::ExplicitValue<void>();
     _jakt_value.release_value();
 })), JaktInternal::ExplicitValue<void>();
 }
-else if (__jakt_enum_value == (ByteString::must_from_utf8("append_escaped_for_json"sv))) {
+else if (__jakt_enum_value == (ByteString::from_utf8_without_validation("append_escaped_for_json"sv))) {
 return (((builder).append_escaped_for_json(({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<ByteString, ErrorOr<interpreter::StatementResult>>{
 auto&& __jakt_match_variant = *((((arguments)[static_cast<i64>(0LL)])).impl);
@@ -5023,7 +5023,7 @@ return JaktInternal::ExplicitValue(value);
 };/*case end*/
 default: {
 {
-TRY((((*this).error((ByteString::must_from_utf8("Invalid use of StringBuilder::append_escaped_for_json()"sv)),call_span))));
+TRY((((*this).error((ByteString::from_utf8_without_validation("Invalid use of StringBuilder::append_escaped_for_json()"sv)),call_span))));
 return Error::__jakt_from_string_literal((StringView::from_string_literal("Invalid type"sv)));
 }
 };/*case end*/
@@ -5035,7 +5035,7 @@ return Error::__jakt_from_string_literal((StringView::from_string_literal("Inval
     _jakt_value.release_value();
 })))), JaktInternal::ExplicitValue<void>();
 }
-else if (__jakt_enum_value == (ByteString::must_from_utf8("append_code_point"sv))) {
+else if (__jakt_enum_value == (ByteString::from_utf8_without_validation("append_code_point"sv))) {
 return (((builder).append_code_point(({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<u32, ErrorOr<interpreter::StatementResult>>{
 auto&& __jakt_match_variant = *((((arguments)[static_cast<i64>(0LL)])).impl);
@@ -5046,7 +5046,7 @@ return JaktInternal::ExplicitValue(value);
 };/*case end*/
 default: {
 {
-TRY((((*this).error((ByteString::must_from_utf8("Invalid use of StringBuilder::append_code_point()"sv)),call_span))));
+TRY((((*this).error((ByteString::from_utf8_without_validation("Invalid use of StringBuilder::append_code_point()"sv)),call_span))));
 return Error::__jakt_from_string_literal((StringView::from_string_literal("Invalid type"sv)));
 }
 };/*case end*/
@@ -5076,7 +5076,7 @@ __jakt_var_229 = interpreter::StatementResult::JustValue(types::Value(types::Val
 }
 __jakt_label_215:; __jakt_var_229.release_value(); }));
 }
-else if (__jakt_enum_value == (ByteString::must_from_utf8("append_escaped_for_json"sv))) {
+else if (__jakt_enum_value == (ByteString::from_utf8_without_validation("append_escaped_for_json"sv))) {
 return JaktInternal::ExplicitValue(({ Optional<interpreter::StatementResult> __jakt_var_230; {
 JaktInternal::Tuple<JaktInternal::DynamicArray<types::Value>,ByteString> fields_current_string_ = ({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<JaktInternal::Tuple<JaktInternal::DynamicArray<types::Value>,ByteString>, ErrorOr<interpreter::StatementResult>>{
@@ -5094,7 +5094,7 @@ return JaktInternal::ExplicitValue((Tuple{fields, value}));
 };/*case end*/
 default: {
 {
-utility::panic((ByteString::must_from_utf8("Invalid use of prelude StringBuilder"sv)));
+utility::panic((ByteString::from_utf8_without_validation("Invalid use of prelude StringBuilder"sv)));
 }
 };/*case end*/
 }/*switch end*/
@@ -5126,7 +5126,7 @@ ByteStringBuilder builder = ByteStringBuilder::create();
 ({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<void,ErrorOr<interpreter::StatementResult>>{
 auto __jakt_enum_value = (prelude_function);
-if (__jakt_enum_value == (ByteString::must_from_utf8("append"sv))) {
+if (__jakt_enum_value == (ByteString::from_utf8_without_validation("append"sv))) {
 return (({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<void, ErrorOr<interpreter::StatementResult>>{
 auto&& __jakt_match_variant = *((((arguments)[static_cast<i64>(0LL)])).impl);
@@ -5158,7 +5158,7 @@ return JaktInternal::ExplicitValue<void>();
     _jakt_value.release_value();
 })), JaktInternal::ExplicitValue<void>();
 }
-else if (__jakt_enum_value == (ByteString::must_from_utf8("append_escaped_for_json"sv))) {
+else if (__jakt_enum_value == (ByteString::from_utf8_without_validation("append_escaped_for_json"sv))) {
 return (((builder).append_escaped_for_json(({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<ByteString, ErrorOr<interpreter::StatementResult>>{
 auto&& __jakt_match_variant = *((((arguments)[static_cast<i64>(0LL)])).impl);
@@ -5169,7 +5169,7 @@ return JaktInternal::ExplicitValue(value);
 };/*case end*/
 default: {
 {
-TRY((((*this).error((ByteString::must_from_utf8("Invalid use of StringBuilder::append_escaped_for_json()"sv)),call_span))));
+TRY((((*this).error((ByteString::from_utf8_without_validation("Invalid use of StringBuilder::append_escaped_for_json()"sv)),call_span))));
 return Error::__jakt_from_string_literal((StringView::from_string_literal("Invalid type"sv)));
 }
 };/*case end*/
@@ -5181,7 +5181,7 @@ return Error::__jakt_from_string_literal((StringView::from_string_literal("Inval
     _jakt_value.release_value();
 })))), JaktInternal::ExplicitValue<void>();
 }
-else if (__jakt_enum_value == (ByteString::must_from_utf8("append_code_point"sv))) {
+else if (__jakt_enum_value == (ByteString::from_utf8_without_validation("append_code_point"sv))) {
 return (((builder).append_code_point(({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<u32, ErrorOr<interpreter::StatementResult>>{
 auto&& __jakt_match_variant = *((((arguments)[static_cast<i64>(0LL)])).impl);
@@ -5192,7 +5192,7 @@ return JaktInternal::ExplicitValue(value);
 };/*case end*/
 default: {
 {
-TRY((((*this).error((ByteString::must_from_utf8("Invalid use of StringBuilder::append_code_point()"sv)),call_span))));
+TRY((((*this).error((ByteString::from_utf8_without_validation("Invalid use of StringBuilder::append_code_point()"sv)),call_span))));
 return Error::__jakt_from_string_literal((StringView::from_string_literal("Invalid type"sv)));
 }
 };/*case end*/
@@ -5222,7 +5222,7 @@ __jakt_var_230 = interpreter::StatementResult::JustValue(types::Value(types::Val
 }
 __jakt_label_216:; __jakt_var_230.release_value(); }));
 }
-else if (__jakt_enum_value == (ByteString::must_from_utf8("to_string"sv))) {
+else if (__jakt_enum_value == (ByteString::from_utf8_without_validation("to_string"sv))) {
 return JaktInternal::ExplicitValue(({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<interpreter::StatementResult, ErrorOr<interpreter::StatementResult>>{
 auto&& __jakt_match_variant = *(((this_argument.value())).impl);
@@ -5245,7 +5245,7 @@ return Error::__jakt_from_string_literal((StringView::from_string_literal("Not y
     _jakt_value.release_value();
 }));
 }
-else if (__jakt_enum_value == (ByteString::must_from_utf8("is_empty"sv))) {
+else if (__jakt_enum_value == (ByteString::from_utf8_without_validation("is_empty"sv))) {
 return JaktInternal::ExplicitValue(({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<interpreter::StatementResult, ErrorOr<interpreter::StatementResult>>{
 auto&& __jakt_match_variant = *(((this_argument.value())).impl);
@@ -5262,7 +5262,7 @@ return JaktInternal::ExplicitValue(interpreter::StatementResult::JustValue(types
 };/*case end*/
 default: {
 {
-utility::panic((ByteString::must_from_utf8("Invalid use of prelude StringBuilder"sv)));
+utility::panic((ByteString::from_utf8_without_validation("Invalid use of prelude StringBuilder"sv)));
 }
 };/*case end*/
 }/*switch end*/
@@ -5287,7 +5287,7 @@ return Error::__jakt_from_string_literal((StringView::from_string_literal("Not y
     _jakt_value.release_value();
 }));
 }
-else if (__jakt_enum_value == (ByteString::must_from_utf8("length"sv))) {
+else if (__jakt_enum_value == (ByteString::from_utf8_without_validation("length"sv))) {
 return JaktInternal::ExplicitValue(({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<interpreter::StatementResult, ErrorOr<interpreter::StatementResult>>{
 auto&& __jakt_match_variant = *(((this_argument.value())).impl);
@@ -5304,7 +5304,7 @@ return JaktInternal::ExplicitValue(interpreter::StatementResult::JustValue(types
 };/*case end*/
 default: {
 {
-utility::panic((ByteString::must_from_utf8("Invalid use of prelude StringBuilder"sv)));
+utility::panic((ByteString::from_utf8_without_validation("Invalid use of prelude StringBuilder"sv)));
 }
 };/*case end*/
 }/*switch end*/
@@ -5329,7 +5329,7 @@ return Error::__jakt_from_string_literal((StringView::from_string_literal("Not y
     _jakt_value.release_value();
 }));
 }
-else if (__jakt_enum_value == (ByteString::must_from_utf8("clear"sv))) {
+else if (__jakt_enum_value == (ByteString::from_utf8_without_validation("clear"sv))) {
 return JaktInternal::ExplicitValue(({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<interpreter::StatementResult, ErrorOr<interpreter::StatementResult>>{
 auto&& __jakt_match_variant = *(((this_argument.value())).impl);
@@ -5338,7 +5338,7 @@ case 17 /* Struct */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Struct;JaktInternal::DynamicArray<types::Value> const& fields = __jakt_match_value.fields;
 return JaktInternal::ExplicitValue(({ Optional<interpreter::StatementResult> __jakt_var_231; {
 JaktInternal::DynamicArray<types::Value> mutable_fields = fields;
-(((((mutable_fields)[static_cast<i64>(0LL)])).impl) = types::ValueImpl::JaktString((ByteString::must_from_utf8(""sv))));
+(((((mutable_fields)[static_cast<i64>(0LL)])).impl) = types::ValueImpl::JaktString((ByteString::from_utf8_without_validation(""sv))));
 __jakt_var_231 = interpreter::StatementResult::JustValue(types::Value(types::ValueImpl::Void(),call_span)); goto __jakt_label_217;
 
 }
@@ -5370,24 +5370,24 @@ return Error::__jakt_from_string_literal((StringView::from_string_literal("Not y
     _jakt_value.release_value();
 }));
 }
-else if (__jakt_enum_value == (ByteString::must_from_utf8("Dictionary"sv))) {
+else if (__jakt_enum_value == (ByteString::from_utf8_without_validation("Dictionary"sv))) {
 return JaktInternal::ExplicitValue(({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<interpreter::StatementResult,ErrorOr<interpreter::StatementResult>>{
 auto __jakt_enum_value = (prelude_function);
-if (__jakt_enum_value == (ByteString::must_from_utf8("Dictionary"sv))) {
+if (__jakt_enum_value == (ByteString::from_utf8_without_validation("Dictionary"sv))) {
 return JaktInternal::ExplicitValue(({ Optional<interpreter::StatementResult> __jakt_var_232; {
 if (((((type_bindings).size())) != (static_cast<size_t>(2ULL)))){
-TRY((((*this).error((ByteString::must_from_utf8("Dictionary constructor expects two generic argumenst"sv)),call_span))));
+TRY((((*this).error((ByteString::from_utf8_without_validation("Dictionary constructor expects two generic argumenst"sv)),call_span))));
 return Error::__jakt_from_string_literal((StringView::from_string_literal("Invalid type"sv)));
 }
-ids::StructId const dictionary_struct_id = TRY((((((*this).program))->find_struct_in_prelude((ByteString::must_from_utf8("Dictionary"sv))))));
+ids::StructId const dictionary_struct_id = TRY((((((*this).program))->find_struct_in_prelude((ByteString::from_utf8_without_validation("Dictionary"sv))))));
 ids::TypeId const type_id = ((*this).find_or_add_type_id(types::Type::GenericInstance(parser::CheckedQualifiers(false),dictionary_struct_id,DynamicArray<ids::TypeId>::create_with({(((type_bindings).get(((((type_bindings).keys()))[static_cast<i64>(0LL)]))).value()), (((type_bindings).get(((((type_bindings).keys()))[static_cast<i64>(1LL)]))).value())}))));
 __jakt_var_232 = interpreter::StatementResult::JustValue(types::Value(types::ValueImpl::JaktDictionary(DynamicArray<types::Value>::create_with({}),DynamicArray<types::Value>::create_with({}),type_id),call_span)); goto __jakt_label_218;
 
 }
 __jakt_label_218:; __jakt_var_232.release_value(); }));
 }
-else if (__jakt_enum_value == (ByteString::must_from_utf8("get"sv))) {
+else if (__jakt_enum_value == (ByteString::from_utf8_without_validation("get"sv))) {
 return JaktInternal::ExplicitValue(({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<interpreter::StatementResult, ErrorOr<interpreter::StatementResult>>{
 auto&& __jakt_match_variant = *(((this_argument.value())).impl);
@@ -5435,7 +5435,7 @@ __jakt_label_219:; __jakt_var_233.release_value(); }));
 };/*case end*/
 default: {
 {
-utility::panic((ByteString::must_from_utf8("Invalid use of Dictionary::get()"sv)));
+utility::panic((ByteString::from_utf8_without_validation("Invalid use of Dictionary::get()"sv)));
 }
 };/*case end*/
 }/*switch end*/
@@ -5446,7 +5446,7 @@ utility::panic((ByteString::must_from_utf8("Invalid use of Dictionary::get()"sv)
     _jakt_value.release_value();
 }));
 }
-else if (__jakt_enum_value == (ByteString::must_from_utf8("set"sv))) {
+else if (__jakt_enum_value == (ByteString::from_utf8_without_validation("set"sv))) {
 return JaktInternal::ExplicitValue(({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<interpreter::StatementResult, ErrorOr<interpreter::StatementResult>>{
 auto&& __jakt_match_variant = *(((this_argument.value())).impl);
@@ -5491,7 +5491,7 @@ __jakt_label_220:; __jakt_var_234.release_value(); }));
 };/*case end*/
 default: {
 {
-utility::panic((ByteString::must_from_utf8("Invalid use of Dictionary::set()"sv)));
+utility::panic((ByteString::from_utf8_without_validation("Invalid use of Dictionary::set()"sv)));
 }
 };/*case end*/
 }/*switch end*/
@@ -5502,7 +5502,7 @@ utility::panic((ByteString::must_from_utf8("Invalid use of Dictionary::set()"sv)
     _jakt_value.release_value();
 }));
 }
-else if (__jakt_enum_value == (ByteString::must_from_utf8("is_empty"sv))) {
+else if (__jakt_enum_value == (ByteString::from_utf8_without_validation("is_empty"sv))) {
 return JaktInternal::ExplicitValue(({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<interpreter::StatementResult, ErrorOr<interpreter::StatementResult>>{
 auto&& __jakt_match_variant = *(((this_argument.value())).impl);
@@ -5514,7 +5514,7 @@ return JaktInternal::ExplicitValue(interpreter::StatementResult::JustValue(types
 };/*case end*/
 default: {
 {
-utility::panic((ByteString::must_from_utf8("Invalid use of Dictionary::is_empty()"sv)));
+utility::panic((ByteString::from_utf8_without_validation("Invalid use of Dictionary::is_empty()"sv)));
 }
 };/*case end*/
 }/*switch end*/
@@ -5525,7 +5525,7 @@ utility::panic((ByteString::must_from_utf8("Invalid use of Dictionary::is_empty(
     _jakt_value.release_value();
 }));
 }
-else if (__jakt_enum_value == (ByteString::must_from_utf8("contains"sv))) {
+else if (__jakt_enum_value == (ByteString::from_utf8_without_validation("contains"sv))) {
 return JaktInternal::ExplicitValue(({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<interpreter::StatementResult, ErrorOr<interpreter::StatementResult>>{
 auto&& __jakt_match_variant = *(((this_argument.value())).impl);
@@ -5559,7 +5559,7 @@ __jakt_label_221:; __jakt_var_235.release_value(); }));
 };/*case end*/
 default: {
 {
-utility::panic((ByteString::must_from_utf8("Invalid use of Dictionary::contains()"sv)));
+utility::panic((ByteString::from_utf8_without_validation("Invalid use of Dictionary::contains()"sv)));
 }
 };/*case end*/
 }/*switch end*/
@@ -5570,7 +5570,7 @@ utility::panic((ByteString::must_from_utf8("Invalid use of Dictionary::contains(
     _jakt_value.release_value();
 }));
 }
-else if (__jakt_enum_value == (ByteString::must_from_utf8("remove"sv))) {
+else if (__jakt_enum_value == (ByteString::from_utf8_without_validation("remove"sv))) {
 return JaktInternal::ExplicitValue(({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<interpreter::StatementResult, ErrorOr<interpreter::StatementResult>>{
 auto&& __jakt_match_variant = *(((this_argument.value())).impl);
@@ -5648,7 +5648,7 @@ __jakt_label_222:; __jakt_var_236.release_value(); }));
 };/*case end*/
 default: {
 {
-utility::panic((ByteString::must_from_utf8("Invalid use of Dictionary::remove()"sv)));
+utility::panic((ByteString::from_utf8_without_validation("Invalid use of Dictionary::remove()"sv)));
 }
 };/*case end*/
 }/*switch end*/
@@ -5659,7 +5659,7 @@ utility::panic((ByteString::must_from_utf8("Invalid use of Dictionary::remove()"
     _jakt_value.release_value();
 }));
 }
-else if (__jakt_enum_value == (ByteString::must_from_utf8("ensure_capacity"sv))) {
+else if (__jakt_enum_value == (ByteString::from_utf8_without_validation("ensure_capacity"sv))) {
 return JaktInternal::ExplicitValue(({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<interpreter::StatementResult, ErrorOr<interpreter::StatementResult>>{
 auto&& __jakt_match_variant = *(((this_argument.value())).impl);
@@ -5685,7 +5685,7 @@ __jakt_label_223:; __jakt_var_237.release_value(); }));
 };/*case end*/
 default: {
 {
-TRY((((*this).error((ByteString::must_from_utf8("Dictionary::ensure_capacity must be called with a usize"sv)),((((arguments)[static_cast<i64>(0LL)])).span)))));
+TRY((((*this).error((ByteString::from_utf8_without_validation("Dictionary::ensure_capacity must be called with a usize"sv)),((((arguments)[static_cast<i64>(0LL)])).span)))));
 return Error::__jakt_from_string_literal((StringView::from_string_literal("Invalid type"sv)));
 }
 };/*case end*/
@@ -5699,7 +5699,7 @@ return Error::__jakt_from_string_literal((StringView::from_string_literal("Inval
 };/*case end*/
 default: {
 {
-utility::panic((ByteString::must_from_utf8("Invalid use of Dictionary::ensure_capacity()"sv)));
+utility::panic((ByteString::from_utf8_without_validation("Invalid use of Dictionary::ensure_capacity()"sv)));
 }
 };/*case end*/
 }/*switch end*/
@@ -5710,7 +5710,7 @@ utility::panic((ByteString::must_from_utf8("Invalid use of Dictionary::ensure_ca
     _jakt_value.release_value();
 }));
 }
-else if (__jakt_enum_value == (ByteString::must_from_utf8("capacity"sv))) {
+else if (__jakt_enum_value == (ByteString::from_utf8_without_validation("capacity"sv))) {
 return JaktInternal::ExplicitValue(({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<interpreter::StatementResult, ErrorOr<interpreter::StatementResult>>{
 auto&& __jakt_match_variant = *(((this_argument.value())).impl);
@@ -5721,7 +5721,7 @@ return JaktInternal::ExplicitValue(interpreter::StatementResult::JustValue(types
 };/*case end*/
 default: {
 {
-utility::panic((ByteString::must_from_utf8("Invalid use of Dictionary::capacity()"sv)));
+utility::panic((ByteString::from_utf8_without_validation("Invalid use of Dictionary::capacity()"sv)));
 }
 };/*case end*/
 }/*switch end*/
@@ -5732,7 +5732,7 @@ utility::panic((ByteString::must_from_utf8("Invalid use of Dictionary::capacity(
     _jakt_value.release_value();
 }));
 }
-else if (__jakt_enum_value == (ByteString::must_from_utf8("clear"sv))) {
+else if (__jakt_enum_value == (ByteString::from_utf8_without_validation("clear"sv))) {
 return JaktInternal::ExplicitValue(({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<interpreter::StatementResult, ErrorOr<interpreter::StatementResult>>{
 auto&& __jakt_match_variant = *(((this_argument.value())).impl);
@@ -5752,7 +5752,7 @@ __jakt_label_224:; __jakt_var_238.release_value(); }));
 };/*case end*/
 default: {
 {
-utility::panic((ByteString::must_from_utf8("Invalid use of Dictionary::clear()"sv)));
+utility::panic((ByteString::from_utf8_without_validation("Invalid use of Dictionary::clear()"sv)));
 }
 };/*case end*/
 }/*switch end*/
@@ -5763,7 +5763,7 @@ utility::panic((ByteString::must_from_utf8("Invalid use of Dictionary::clear()"s
     _jakt_value.release_value();
 }));
 }
-else if (__jakt_enum_value == (ByteString::must_from_utf8("size"sv))) {
+else if (__jakt_enum_value == (ByteString::from_utf8_without_validation("size"sv))) {
 return JaktInternal::ExplicitValue(({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<interpreter::StatementResult, ErrorOr<interpreter::StatementResult>>{
 auto&& __jakt_match_variant = *(((this_argument.value())).impl);
@@ -5774,7 +5774,7 @@ return JaktInternal::ExplicitValue(interpreter::StatementResult::JustValue(types
 };/*case end*/
 default: {
 {
-utility::panic((ByteString::must_from_utf8("Invalid use of Dictionary::size()"sv)));
+utility::panic((ByteString::from_utf8_without_validation("Invalid use of Dictionary::size()"sv)));
 }
 };/*case end*/
 }/*switch end*/
@@ -5785,7 +5785,7 @@ utility::panic((ByteString::must_from_utf8("Invalid use of Dictionary::size()"sv
     _jakt_value.release_value();
 }));
 }
-else if (__jakt_enum_value == (ByteString::must_from_utf8("keys"sv))) {
+else if (__jakt_enum_value == (ByteString::from_utf8_without_validation("keys"sv))) {
 return JaktInternal::ExplicitValue(({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<interpreter::StatementResult, ErrorOr<interpreter::StatementResult>>{
 auto&& __jakt_match_variant = *(((this_argument.value())).impl);
@@ -5804,7 +5804,7 @@ return JaktInternal::ExplicitValue(args);
 };/*case end*/
 default: {
 {
-utility::panic((ByteString::must_from_utf8("expected generic instance"sv)));
+utility::panic((ByteString::from_utf8_without_validation("expected generic instance"sv)));
 }
 };/*case end*/
 }/*switch end*/
@@ -5819,7 +5819,7 @@ __jakt_var_239 = ({
 auto __jakt_enum_value = (((((generics).size())) == (static_cast<size_t>(2ULL))));
 if (__jakt_enum_value == true) {
 return JaktInternal::ExplicitValue(({ Optional<interpreter::StatementResult> __jakt_var_240; {
-ids::StructId const array_struct_id = TRY((((((*this).program))->find_struct_in_prelude((ByteString::must_from_utf8("Array"sv))))));
+ids::StructId const array_struct_id = TRY((((((*this).program))->find_struct_in_prelude((ByteString::from_utf8_without_validation("Array"sv))))));
 ids::TypeId const type_id = ((*this).find_or_add_type_id(types::Type::GenericInstance(parser::CheckedQualifiers(false),array_struct_id,DynamicArray<ids::TypeId>::create_with({((generics)[static_cast<i64>(0LL)])}))));
 __jakt_var_240 = interpreter::StatementResult::JustValue(types::Value(types::ValueImpl::JaktArray(keys,type_id),call_span)); goto __jakt_label_226;
 
@@ -5828,7 +5828,7 @@ __jakt_label_226:; __jakt_var_240.release_value(); }));
 }
 else {
 {
-utility::panic((ByteString::must_from_utf8("dictionary should have 2 generic args. one for keys, one for values"sv)));
+utility::panic((ByteString::from_utf8_without_validation("dictionary should have 2 generic args. one for keys, one for values"sv)));
 }
 }
 }());
@@ -5842,7 +5842,7 @@ __jakt_label_225:; __jakt_var_239.release_value(); }));
 };/*case end*/
 default: {
 {
-utility::panic((ByteString::must_from_utf8("Invalid use of Dictionary::keys()"sv)));
+utility::panic((ByteString::from_utf8_without_validation("Invalid use of Dictionary::keys()"sv)));
 }
 };/*case end*/
 }/*switch end*/
@@ -5853,14 +5853,14 @@ utility::panic((ByteString::must_from_utf8("Invalid use of Dictionary::keys()"sv
     _jakt_value.release_value();
 }));
 }
-else if (__jakt_enum_value == (ByteString::must_from_utf8("iterator"sv))) {
+else if (__jakt_enum_value == (ByteString::from_utf8_without_validation("iterator"sv))) {
 return JaktInternal::ExplicitValue(({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<interpreter::StatementResult, ErrorOr<interpreter::StatementResult>>{
 auto&& __jakt_match_variant = *(((this_argument.value())).impl);
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 21 /* JaktDictionary */: {
 return JaktInternal::ExplicitValue(({ Optional<interpreter::StatementResult> __jakt_var_241; {
-ids::StructId const struct_id = TRY((((((*this).program))->find_struct_in_prelude((ByteString::must_from_utf8("DictionaryIterator"sv))))));
+ids::StructId const struct_id = TRY((((((*this).program))->find_struct_in_prelude((ByteString::from_utf8_without_validation("DictionaryIterator"sv))))));
 __jakt_var_241 = interpreter::StatementResult::JustValue(types::Value(types::ValueImpl::Struct(DynamicArray<types::Value>::create_with({(this_argument.value()), types::Value(types::ValueImpl::USize(static_cast<size_t>(0ULL)),call_span)}),struct_id,JaktInternal::OptionalNone()),call_span)); goto __jakt_label_227;
 
 }
@@ -5868,7 +5868,7 @@ __jakt_label_227:; __jakt_var_241.release_value(); }));
 };/*case end*/
 default: {
 {
-utility::panic((ByteString::must_from_utf8("Invalid use of Dictionary::iterator()"sv)));
+utility::panic((ByteString::from_utf8_without_validation("Invalid use of Dictionary::iterator()"sv)));
 }
 };/*case end*/
 }/*switch end*/
@@ -5891,18 +5891,18 @@ return Error::__jakt_from_string_literal((StringView::from_string_literal("Not y
     _jakt_value.release_value();
 }));
 }
-else if (__jakt_enum_value == (ByteString::must_from_utf8("Array"sv))) {
+else if (__jakt_enum_value == (ByteString::from_utf8_without_validation("Array"sv))) {
 return JaktInternal::ExplicitValue(({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<interpreter::StatementResult,ErrorOr<interpreter::StatementResult>>{
 auto __jakt_enum_value = (prelude_function);
-if (__jakt_enum_value == (ByteString::must_from_utf8("iterator"sv))) {
+if (__jakt_enum_value == (ByteString::from_utf8_without_validation("iterator"sv))) {
 return JaktInternal::ExplicitValue(({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<interpreter::StatementResult, ErrorOr<interpreter::StatementResult>>{
 auto&& __jakt_match_variant = *(((this_argument.value())).impl);
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 20 /* JaktArray */: {
 return JaktInternal::ExplicitValue(({ Optional<interpreter::StatementResult> __jakt_var_242; {
-ids::StructId const struct_id = TRY((((((*this).program))->find_struct_in_prelude((ByteString::must_from_utf8("ArrayIterator"sv))))));
+ids::StructId const struct_id = TRY((((((*this).program))->find_struct_in_prelude((ByteString::from_utf8_without_validation("ArrayIterator"sv))))));
 __jakt_var_242 = interpreter::StatementResult::JustValue(types::Value(types::ValueImpl::Struct(DynamicArray<types::Value>::create_with({(this_argument.value()), types::Value(types::ValueImpl::USize(static_cast<size_t>(0ULL)),call_span)}),struct_id,JaktInternal::OptionalNone()),call_span)); goto __jakt_label_228;
 
 }
@@ -5910,7 +5910,7 @@ __jakt_label_228:; __jakt_var_242.release_value(); }));
 };/*case end*/
 default: {
 {
-utility::panic((ByteString::must_from_utf8("Invalid use of Array::iterator()"sv)));
+utility::panic((ByteString::from_utf8_without_validation("Invalid use of Array::iterator()"sv)));
 }
 };/*case end*/
 }/*switch end*/
@@ -5921,7 +5921,7 @@ utility::panic((ByteString::must_from_utf8("Invalid use of Array::iterator()"sv)
     _jakt_value.release_value();
 }));
 }
-else if (__jakt_enum_value == (ByteString::must_from_utf8("size"sv))) {
+else if (__jakt_enum_value == (ByteString::from_utf8_without_validation("size"sv))) {
 return JaktInternal::ExplicitValue(({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<interpreter::StatementResult, ErrorOr<interpreter::StatementResult>>{
 auto&& __jakt_match_variant = *(((this_argument.value())).impl);
@@ -5936,7 +5936,7 @@ __jakt_label_229:; __jakt_var_243.release_value(); }));
 };/*case end*/
 default: {
 {
-utility::panic((ByteString::must_from_utf8("Invalid use of Array::size()"sv)));
+utility::panic((ByteString::from_utf8_without_validation("Invalid use of Array::size()"sv)));
 }
 };/*case end*/
 }/*switch end*/
@@ -5947,7 +5947,7 @@ utility::panic((ByteString::must_from_utf8("Invalid use of Array::size()"sv)));
     _jakt_value.release_value();
 }));
 }
-else if (__jakt_enum_value == (ByteString::must_from_utf8("push"sv))) {
+else if (__jakt_enum_value == (ByteString::from_utf8_without_validation("push"sv))) {
 return JaktInternal::ExplicitValue(({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<interpreter::StatementResult, ErrorOr<interpreter::StatementResult>>{
 auto&& __jakt_match_variant = *(((this_argument.value())).impl);
@@ -5964,7 +5964,7 @@ __jakt_label_230:; __jakt_var_244.release_value(); }));
 };/*case end*/
 default: {
 {
-utility::panic((ByteString::must_from_utf8("Invalid use of Array::push()"sv)));
+utility::panic((ByteString::from_utf8_without_validation("Invalid use of Array::push()"sv)));
 }
 };/*case end*/
 }/*switch end*/
@@ -5975,7 +5975,7 @@ utility::panic((ByteString::must_from_utf8("Invalid use of Array::push()"sv)));
     _jakt_value.release_value();
 }));
 }
-else if (__jakt_enum_value == (ByteString::must_from_utf8("push_values"sv))) {
+else if (__jakt_enum_value == (ByteString::from_utf8_without_validation("push_values"sv))) {
 return JaktInternal::ExplicitValue(({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<interpreter::StatementResult, ErrorOr<interpreter::StatementResult>>{
 auto&& __jakt_match_variant = *(((this_argument.value())).impl);
@@ -6010,7 +6010,7 @@ types::Value value = (_magic_value.value());
 return JaktInternal::ExplicitValue<void>();
 };/*case end*/
 default: {
-return (TRY((((*this).error((ByteString::must_from_utf8("Only argument to push_values needs to be another Array"sv)),call_span))))), JaktInternal::ExplicitValue<void>();
+return (TRY((((*this).error((ByteString::from_utf8_without_validation("Only argument to push_values needs to be another Array"sv)),call_span))))), JaktInternal::ExplicitValue<void>();
 };/*case end*/
 }/*switch end*/
 }()
@@ -6026,7 +6026,7 @@ __jakt_label_231:; __jakt_var_245.release_value(); }));
 };/*case end*/
 default: {
 {
-utility::panic((ByteString::must_from_utf8("Invalid use of Array::push_values()"sv)));
+utility::panic((ByteString::from_utf8_without_validation("Invalid use of Array::push_values()"sv)));
 }
 };/*case end*/
 }/*switch end*/
@@ -6037,7 +6037,7 @@ utility::panic((ByteString::must_from_utf8("Invalid use of Array::push_values()"
     _jakt_value.release_value();
 }));
 }
-else if (__jakt_enum_value == (ByteString::must_from_utf8("pop"sv))) {
+else if (__jakt_enum_value == (ByteString::from_utf8_without_validation("pop"sv))) {
 return JaktInternal::ExplicitValue(({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<interpreter::StatementResult, ErrorOr<interpreter::StatementResult>>{
 auto&& __jakt_match_variant = *(((this_argument.value())).impl);
@@ -6068,7 +6068,7 @@ __jakt_label_232:; __jakt_var_246.release_value(); }));
 };/*case end*/
 default: {
 {
-utility::panic((ByteString::must_from_utf8("Invalid use of Array::push()"sv)));
+utility::panic((ByteString::from_utf8_without_validation("Invalid use of Array::push()"sv)));
 }
 };/*case end*/
 }/*switch end*/
@@ -6079,7 +6079,7 @@ utility::panic((ByteString::must_from_utf8("Invalid use of Array::push()"sv)));
     _jakt_value.release_value();
 }));
 }
-else if (__jakt_enum_value == (ByteString::must_from_utf8("first"sv))) {
+else if (__jakt_enum_value == (ByteString::from_utf8_without_validation("first"sv))) {
 return JaktInternal::ExplicitValue(({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<interpreter::StatementResult, ErrorOr<interpreter::StatementResult>>{
 auto&& __jakt_match_variant = *(((this_argument.value())).impl);
@@ -6110,7 +6110,7 @@ __jakt_label_233:; __jakt_var_247.release_value(); }));
 };/*case end*/
 default: {
 {
-utility::panic((ByteString::must_from_utf8("Invalid use of Array::push()"sv)));
+utility::panic((ByteString::from_utf8_without_validation("Invalid use of Array::push()"sv)));
 }
 };/*case end*/
 }/*switch end*/
@@ -6121,7 +6121,7 @@ utility::panic((ByteString::must_from_utf8("Invalid use of Array::push()"sv)));
     _jakt_value.release_value();
 }));
 }
-else if (__jakt_enum_value == (ByteString::must_from_utf8("last"sv))) {
+else if (__jakt_enum_value == (ByteString::from_utf8_without_validation("last"sv))) {
 return JaktInternal::ExplicitValue(({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<interpreter::StatementResult, ErrorOr<interpreter::StatementResult>>{
 auto&& __jakt_match_variant = *(((this_argument.value())).impl);
@@ -6152,7 +6152,7 @@ __jakt_label_234:; __jakt_var_248.release_value(); }));
 };/*case end*/
 default: {
 {
-utility::panic((ByteString::must_from_utf8("Invalid use of Array::push()"sv)));
+utility::panic((ByteString::from_utf8_without_validation("Invalid use of Array::push()"sv)));
 }
 };/*case end*/
 }/*switch end*/
@@ -6163,7 +6163,7 @@ utility::panic((ByteString::must_from_utf8("Invalid use of Array::push()"sv)));
     _jakt_value.release_value();
 }));
 }
-else if (__jakt_enum_value == (ByteString::must_from_utf8("contains"sv))) {
+else if (__jakt_enum_value == (ByteString::from_utf8_without_validation("contains"sv))) {
 return JaktInternal::ExplicitValue(({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<interpreter::StatementResult, ErrorOr<interpreter::StatementResult>>{
 auto&& __jakt_match_variant = *(((this_argument.value())).impl);
@@ -6197,7 +6197,7 @@ __jakt_label_235:; __jakt_var_249.release_value(); }));
 };/*case end*/
 default: {
 {
-utility::panic((ByteString::must_from_utf8("Invalid use of Array::contains()"sv)));
+utility::panic((ByteString::from_utf8_without_validation("Invalid use of Array::contains()"sv)));
 }
 };/*case end*/
 }/*switch end*/
@@ -6208,7 +6208,7 @@ utility::panic((ByteString::must_from_utf8("Invalid use of Array::contains()"sv)
     _jakt_value.release_value();
 }));
 }
-else if (__jakt_enum_value == (ByteString::must_from_utf8("is_empty"sv))) {
+else if (__jakt_enum_value == (ByteString::from_utf8_without_validation("is_empty"sv))) {
 return JaktInternal::ExplicitValue(({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<interpreter::StatementResult, ErrorOr<interpreter::StatementResult>>{
 auto&& __jakt_match_variant = *(((this_argument.value())).impl);
@@ -6219,7 +6219,7 @@ return JaktInternal::ExplicitValue(interpreter::StatementResult::JustValue(types
 };/*case end*/
 default: {
 {
-utility::panic((ByteString::must_from_utf8("Invalid use of Array::is_empty()"sv)));
+utility::panic((ByteString::from_utf8_without_validation("Invalid use of Array::is_empty()"sv)));
 }
 };/*case end*/
 }/*switch end*/
@@ -6230,7 +6230,7 @@ utility::panic((ByteString::must_from_utf8("Invalid use of Array::is_empty()"sv)
     _jakt_value.release_value();
 }));
 }
-else if (__jakt_enum_value == (ByteString::must_from_utf8("capacity"sv))) {
+else if (__jakt_enum_value == (ByteString::from_utf8_without_validation("capacity"sv))) {
 return JaktInternal::ExplicitValue(({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<interpreter::StatementResult, ErrorOr<interpreter::StatementResult>>{
 auto&& __jakt_match_variant = *(((this_argument.value())).impl);
@@ -6245,7 +6245,7 @@ __jakt_label_236:; __jakt_var_250.release_value(); }));
 };/*case end*/
 default: {
 {
-utility::panic((ByteString::must_from_utf8("Invalid use of Array::capacity()"sv)));
+utility::panic((ByteString::from_utf8_without_validation("Invalid use of Array::capacity()"sv)));
 }
 };/*case end*/
 }/*switch end*/
@@ -6256,7 +6256,7 @@ utility::panic((ByteString::must_from_utf8("Invalid use of Array::capacity()"sv)
     _jakt_value.release_value();
 }));
 }
-else if (__jakt_enum_value == (ByteString::must_from_utf8("ensure_capacity"sv))) {
+else if (__jakt_enum_value == (ByteString::from_utf8_without_validation("ensure_capacity"sv))) {
 return JaktInternal::ExplicitValue(({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<interpreter::StatementResult, ErrorOr<interpreter::StatementResult>>{
 auto&& __jakt_match_variant = *(((this_argument.value())).impl);
@@ -6279,7 +6279,7 @@ __jakt_label_237:; __jakt_var_251.release_value(); }));
 };/*case end*/
 default: {
 {
-TRY((((*this).error((ByteString::must_from_utf8("Array::ensure_capacity must be called with a usize"sv)),((((arguments)[static_cast<i64>(0LL)])).span)))));
+TRY((((*this).error((ByteString::from_utf8_without_validation("Array::ensure_capacity must be called with a usize"sv)),((((arguments)[static_cast<i64>(0LL)])).span)))));
 return Error::__jakt_from_string_literal((StringView::from_string_literal("Invalid type"sv)));
 }
 };/*case end*/
@@ -6293,7 +6293,7 @@ return Error::__jakt_from_string_literal((StringView::from_string_literal("Inval
 };/*case end*/
 default: {
 {
-utility::panic((ByteString::must_from_utf8("Invalid use of Array::ensure_capacity()"sv)));
+utility::panic((ByteString::from_utf8_without_validation("Invalid use of Array::ensure_capacity()"sv)));
 }
 };/*case end*/
 }/*switch end*/
@@ -6304,7 +6304,7 @@ utility::panic((ByteString::must_from_utf8("Invalid use of Array::ensure_capacit
     _jakt_value.release_value();
 }));
 }
-else if (__jakt_enum_value == (ByteString::must_from_utf8("add_capacity"sv))) {
+else if (__jakt_enum_value == (ByteString::from_utf8_without_validation("add_capacity"sv))) {
 return JaktInternal::ExplicitValue(({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<interpreter::StatementResult, ErrorOr<interpreter::StatementResult>>{
 auto&& __jakt_match_variant = *(((this_argument.value())).impl);
@@ -6327,7 +6327,7 @@ __jakt_label_238:; __jakt_var_252.release_value(); }));
 };/*case end*/
 default: {
 {
-TRY((((*this).error((ByteString::must_from_utf8("Array::add_capacity must be called with a usize"sv)),((((arguments)[static_cast<i64>(0LL)])).span)))));
+TRY((((*this).error((ByteString::from_utf8_without_validation("Array::add_capacity must be called with a usize"sv)),((((arguments)[static_cast<i64>(0LL)])).span)))));
 return Error::__jakt_from_string_literal((StringView::from_string_literal("Invalid type"sv)));
 }
 };/*case end*/
@@ -6341,7 +6341,7 @@ return Error::__jakt_from_string_literal((StringView::from_string_literal("Inval
 };/*case end*/
 default: {
 {
-utility::panic((ByteString::must_from_utf8("Invalid use of Array::add_capacity()"sv)));
+utility::panic((ByteString::from_utf8_without_validation("Invalid use of Array::add_capacity()"sv)));
 }
 };/*case end*/
 }/*switch end*/
@@ -6352,7 +6352,7 @@ utility::panic((ByteString::must_from_utf8("Invalid use of Array::add_capacity()
     _jakt_value.release_value();
 }));
 }
-else if (__jakt_enum_value == (ByteString::must_from_utf8("shrink"sv))) {
+else if (__jakt_enum_value == (ByteString::from_utf8_without_validation("shrink"sv))) {
 return JaktInternal::ExplicitValue(({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<interpreter::StatementResult, ErrorOr<interpreter::StatementResult>>{
 auto&& __jakt_match_variant = *(((this_argument.value())).impl);
@@ -6375,7 +6375,7 @@ __jakt_label_239:; __jakt_var_253.release_value(); }));
 };/*case end*/
 default: {
 {
-TRY((((*this).error((ByteString::must_from_utf8("Array::shrink must be called with a usize"sv)),((((arguments)[static_cast<i64>(0LL)])).span)))));
+TRY((((*this).error((ByteString::from_utf8_without_validation("Array::shrink must be called with a usize"sv)),((((arguments)[static_cast<i64>(0LL)])).span)))));
 return Error::__jakt_from_string_literal((StringView::from_string_literal("Invalid type"sv)));
 }
 };/*case end*/
@@ -6389,7 +6389,7 @@ return Error::__jakt_from_string_literal((StringView::from_string_literal("Inval
 };/*case end*/
 default: {
 {
-utility::panic((ByteString::must_from_utf8("Invalid use of Array::shrink()"sv)));
+utility::panic((ByteString::from_utf8_without_validation("Invalid use of Array::shrink()"sv)));
 }
 };/*case end*/
 }/*switch end*/
@@ -6412,11 +6412,11 @@ return Error::__jakt_from_string_literal((StringView::from_string_literal("Not y
     _jakt_value.release_value();
 }));
 }
-else if (__jakt_enum_value == (ByteString::must_from_utf8("ArrayIterator"sv))) {
+else if (__jakt_enum_value == (ByteString::from_utf8_without_validation("ArrayIterator"sv))) {
 return JaktInternal::ExplicitValue(({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<interpreter::StatementResult,ErrorOr<interpreter::StatementResult>>{
 auto __jakt_enum_value = (prelude_function);
-if (__jakt_enum_value == (ByteString::must_from_utf8("next"sv))) {
+if (__jakt_enum_value == (ByteString::from_utf8_without_validation("next"sv))) {
 return JaktInternal::ExplicitValue(({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<interpreter::StatementResult, ErrorOr<interpreter::StatementResult>>{
 auto&& __jakt_match_variant = *(((this_argument.value())).impl);
@@ -6434,7 +6434,7 @@ return JaktInternal::ExplicitValue(value);
 };/*case end*/
 default: {
 {
-utility::panic((ByteString::must_from_utf8("Invalid ArrayIterator index configuration"sv)));
+utility::panic((ByteString::from_utf8_without_validation("Invalid ArrayIterator index configuration"sv)));
 }
 };/*case end*/
 }/*switch end*/
@@ -6483,7 +6483,7 @@ return JaktInternal::ExplicitValue(types::Value(types::ValueImpl::OptionalNone()
 };/*case end*/
 default: {
 {
-utility::panic((ByteString::must_from_utf8("Invalid ArrayIterator configuration"sv)));
+utility::panic((ByteString::from_utf8_without_validation("Invalid ArrayIterator configuration"sv)));
 }
 };/*case end*/
 }/*switch end*/
@@ -6499,7 +6499,7 @@ __jakt_label_240:; __jakt_var_254.release_value(); }));
 };/*case end*/
 default: {
 {
-utility::panic((ByteString::must_from_utf8("Invalid ArrayIterator configuration"sv)));
+utility::panic((ByteString::from_utf8_without_validation("Invalid ArrayIterator configuration"sv)));
 }
 };/*case end*/
 }/*switch end*/
@@ -6522,11 +6522,11 @@ return Error::__jakt_from_string_literal((StringView::from_string_literal("Not y
     _jakt_value.release_value();
 }));
 }
-else if (__jakt_enum_value == (ByteString::must_from_utf8("Range"sv))) {
+else if (__jakt_enum_value == (ByteString::from_utf8_without_validation("Range"sv))) {
 return JaktInternal::ExplicitValue(({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<interpreter::StatementResult,ErrorOr<interpreter::StatementResult>>{
 auto __jakt_enum_value = (prelude_function);
-if (__jakt_enum_value == (ByteString::must_from_utf8("next"sv))) {
+if (__jakt_enum_value == (ByteString::from_utf8_without_validation("next"sv))) {
 return JaktInternal::ExplicitValue(({ Optional<interpreter::StatementResult> __jakt_var_256; {
 JaktInternal::DynamicArray<types::Value> fields = ({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<JaktInternal::DynamicArray<types::Value>, ErrorOr<interpreter::StatementResult>>{
@@ -6538,7 +6538,7 @@ return JaktInternal::ExplicitValue(fields);
 };/*case end*/
 default: {
 {
-utility::panic((ByteString::must_from_utf8("Invalid use of Range::next()"sv)));
+utility::panic((ByteString::from_utf8_without_validation("Invalid use of Range::next()"sv)));
 }
 };/*case end*/
 }/*switch end*/
@@ -6590,7 +6590,7 @@ return JaktInternal::ExplicitValue((infallible_integer_cast<u64>((x))));
 };/*case end*/
 default: {
 {
-utility::panic((ByteString::must_from_utf8("Invalid type for comptime range"sv)));
+utility::panic((ByteString::from_utf8_without_validation("Invalid type for comptime range"sv)));
 }
 };/*case end*/
 }/*switch end*/
@@ -6642,7 +6642,7 @@ return JaktInternal::ExplicitValue((infallible_integer_cast<u64>((x))));
 };/*case end*/
 default: {
 {
-utility::panic((ByteString::must_from_utf8("Invalid type for comptime range"sv)));
+utility::panic((ByteString::from_utf8_without_validation("Invalid type for comptime range"sv)));
 }
 };/*case end*/
 }/*switch end*/
@@ -6677,7 +6677,7 @@ __jakt_var_256 = interpreter::StatementResult::JustValue(types::Value(types::Val
 }
 __jakt_label_242:; __jakt_var_256.release_value(); }));
 }
-else if (__jakt_enum_value == (ByteString::must_from_utf8("inclusive"sv))) {
+else if (__jakt_enum_value == (ByteString::from_utf8_without_validation("inclusive"sv))) {
 return JaktInternal::ExplicitValue(({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<interpreter::StatementResult, ErrorOr<interpreter::StatementResult>>{
 auto&& __jakt_match_variant = *(((this_argument.value())).impl);
@@ -6730,7 +6730,7 @@ return JaktInternal::ExplicitValue((infallible_integer_cast<u64>((x))));
 };/*case end*/
 default: {
 {
-utility::panic((ByteString::must_from_utf8("Invalid type for comptime range"sv)));
+utility::panic((ByteString::from_utf8_without_validation("Invalid type for comptime range"sv)));
 }
 };/*case end*/
 }/*switch end*/
@@ -6748,7 +6748,7 @@ __jakt_label_243:; __jakt_var_257.release_value(); }));
 };/*case end*/
 default: {
 {
-utility::panic((ByteString::must_from_utf8("Invalid use of Range::inclusive()"sv)));
+utility::panic((ByteString::from_utf8_without_validation("Invalid use of Range::inclusive()"sv)));
 }
 };/*case end*/
 }/*switch end*/
@@ -6759,7 +6759,7 @@ utility::panic((ByteString::must_from_utf8("Invalid use of Range::inclusive()"sv
     _jakt_value.release_value();
 }));
 }
-else if (__jakt_enum_value == (ByteString::must_from_utf8("exclusive"sv))) {
+else if (__jakt_enum_value == (ByteString::from_utf8_without_validation("exclusive"sv))) {
 return JaktInternal::ExplicitValue(({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<interpreter::StatementResult, ErrorOr<interpreter::StatementResult>>{
 auto&& __jakt_match_variant = *(((this_argument.value())).impl);
@@ -6769,7 +6769,7 @@ return JaktInternal::ExplicitValue(interpreter::StatementResult::JustValue((this
 };/*case end*/
 default: {
 {
-utility::panic((ByteString::must_from_utf8("Invalid use of Range::exclusive()"sv)));
+utility::panic((ByteString::from_utf8_without_validation("Invalid use of Range::exclusive()"sv)));
 }
 };/*case end*/
 }/*switch end*/
@@ -6792,11 +6792,11 @@ return Error::__jakt_from_string_literal((StringView::from_string_literal("Not y
     _jakt_value.release_value();
 }));
 }
-else if (__jakt_enum_value == (ByteString::must_from_utf8("String"sv))) {
+else if (__jakt_enum_value == (ByteString::from_utf8_without_validation("String"sv))) {
 return JaktInternal::ExplicitValue(({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<interpreter::StatementResult,ErrorOr<interpreter::StatementResult>>{
 auto __jakt_enum_value = (prelude_function);
-if (__jakt_enum_value == (ByteString::must_from_utf8("is_empty"sv))) {
+if (__jakt_enum_value == (ByteString::from_utf8_without_validation("is_empty"sv))) {
 return JaktInternal::ExplicitValue(({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<interpreter::StatementResult, ErrorOr<interpreter::StatementResult>>{
 auto&& __jakt_match_variant = *(((this_argument.value())).impl);
@@ -6807,7 +6807,7 @@ return JaktInternal::ExplicitValue(interpreter::StatementResult::JustValue(types
 };/*case end*/
 default: {
 {
-utility::panic((ByteString::must_from_utf8("Invalid String"sv)));
+utility::panic((ByteString::from_utf8_without_validation("Invalid String"sv)));
 }
 };/*case end*/
 }/*switch end*/
@@ -6818,7 +6818,7 @@ utility::panic((ByteString::must_from_utf8("Invalid String"sv)));
     _jakt_value.release_value();
 }));
 }
-else if (__jakt_enum_value == (ByteString::must_from_utf8("length"sv))) {
+else if (__jakt_enum_value == (ByteString::from_utf8_without_validation("length"sv))) {
 return JaktInternal::ExplicitValue(({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<interpreter::StatementResult, ErrorOr<interpreter::StatementResult>>{
 auto&& __jakt_match_variant = *(((this_argument.value())).impl);
@@ -6829,7 +6829,7 @@ return JaktInternal::ExplicitValue(interpreter::StatementResult::JustValue(types
 };/*case end*/
 default: {
 {
-utility::panic((ByteString::must_from_utf8("Invalid String"sv)));
+utility::panic((ByteString::from_utf8_without_validation("Invalid String"sv)));
 }
 };/*case end*/
 }/*switch end*/
@@ -6840,7 +6840,7 @@ utility::panic((ByteString::must_from_utf8("Invalid String"sv)));
     _jakt_value.release_value();
 }));
 }
-else if (__jakt_enum_value == (ByteString::must_from_utf8("hash"sv))) {
+else if (__jakt_enum_value == (ByteString::from_utf8_without_validation("hash"sv))) {
 return JaktInternal::ExplicitValue(({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<interpreter::StatementResult, ErrorOr<interpreter::StatementResult>>{
 auto&& __jakt_match_variant = *(((this_argument.value())).impl);
@@ -6851,7 +6851,7 @@ return JaktInternal::ExplicitValue(interpreter::StatementResult::JustValue(types
 };/*case end*/
 default: {
 {
-utility::panic((ByteString::must_from_utf8("Invalid String"sv)));
+utility::panic((ByteString::from_utf8_without_validation("Invalid String"sv)));
 }
 };/*case end*/
 }/*switch end*/
@@ -6862,7 +6862,7 @@ utility::panic((ByteString::must_from_utf8("Invalid String"sv)));
     _jakt_value.release_value();
 }));
 }
-else if (__jakt_enum_value == (ByteString::must_from_utf8("substring"sv))) {
+else if (__jakt_enum_value == (ByteString::from_utf8_without_validation("substring"sv))) {
 return JaktInternal::ExplicitValue(({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<interpreter::StatementResult, ErrorOr<interpreter::StatementResult>>{
 auto&& __jakt_match_variant = *(((this_argument.value())).impl);
@@ -6926,7 +6926,7 @@ __jakt_label_248:; __jakt_var_262.release_value(); }));
 };/*case end*/
 default: {
 {
-TRY((((*this).error((ByteString::must_from_utf8("String::substring must be called with unsigned arguments"sv)),((((arguments)[static_cast<i64>(1LL)])).span)))));
+TRY((((*this).error((ByteString::from_utf8_without_validation("String::substring must be called with unsigned arguments"sv)),((((arguments)[static_cast<i64>(1LL)])).span)))));
 return Error::__jakt_from_string_literal((StringView::from_string_literal("Invalid type"sv)));
 }
 };/*case end*/
@@ -6991,7 +6991,7 @@ __jakt_label_253:; __jakt_var_267.release_value(); }));
 };/*case end*/
 default: {
 {
-TRY((((*this).error((ByteString::must_from_utf8("String::substring must be called with unsigned arguments"sv)),((((arguments)[static_cast<i64>(1LL)])).span)))));
+TRY((((*this).error((ByteString::from_utf8_without_validation("String::substring must be called with unsigned arguments"sv)),((((arguments)[static_cast<i64>(1LL)])).span)))));
 return Error::__jakt_from_string_literal((StringView::from_string_literal("Invalid type"sv)));
 }
 };/*case end*/
@@ -7056,7 +7056,7 @@ __jakt_label_258:; __jakt_var_272.release_value(); }));
 };/*case end*/
 default: {
 {
-TRY((((*this).error((ByteString::must_from_utf8("String::substring must be called with unsigned arguments"sv)),((((arguments)[static_cast<i64>(1LL)])).span)))));
+TRY((((*this).error((ByteString::from_utf8_without_validation("String::substring must be called with unsigned arguments"sv)),((((arguments)[static_cast<i64>(1LL)])).span)))));
 return Error::__jakt_from_string_literal((StringView::from_string_literal("Invalid type"sv)));
 }
 };/*case end*/
@@ -7121,7 +7121,7 @@ __jakt_label_263:; __jakt_var_277.release_value(); }));
 };/*case end*/
 default: {
 {
-TRY((((*this).error((ByteString::must_from_utf8("String::substring must be called with unsigned arguments"sv)),((((arguments)[static_cast<i64>(1LL)])).span)))));
+TRY((((*this).error((ByteString::from_utf8_without_validation("String::substring must be called with unsigned arguments"sv)),((((arguments)[static_cast<i64>(1LL)])).span)))));
 return Error::__jakt_from_string_literal((StringView::from_string_literal("Invalid type"sv)));
 }
 };/*case end*/
@@ -7186,7 +7186,7 @@ __jakt_label_268:; __jakt_var_282.release_value(); }));
 };/*case end*/
 default: {
 {
-TRY((((*this).error((ByteString::must_from_utf8("String::substring must be called with unsigned arguments"sv)),((((arguments)[static_cast<i64>(1LL)])).span)))));
+TRY((((*this).error((ByteString::from_utf8_without_validation("String::substring must be called with unsigned arguments"sv)),((((arguments)[static_cast<i64>(1LL)])).span)))));
 return Error::__jakt_from_string_literal((StringView::from_string_literal("Invalid type"sv)));
 }
 };/*case end*/
@@ -7200,7 +7200,7 @@ return Error::__jakt_from_string_literal((StringView::from_string_literal("Inval
 };/*case end*/
 default: {
 {
-TRY((((*this).error((ByteString::must_from_utf8("String::substring must be called with unsigned arguments"sv)),((((arguments)[static_cast<i64>(0LL)])).span)))));
+TRY((((*this).error((ByteString::from_utf8_without_validation("String::substring must be called with unsigned arguments"sv)),((((arguments)[static_cast<i64>(0LL)])).span)))));
 return Error::__jakt_from_string_literal((StringView::from_string_literal("Invalid type"sv)));
 }
 };/*case end*/
@@ -7214,7 +7214,7 @@ return Error::__jakt_from_string_literal((StringView::from_string_literal("Inval
 };/*case end*/
 default: {
 {
-utility::panic((ByteString::must_from_utf8("Invalid String"sv)));
+utility::panic((ByteString::from_utf8_without_validation("Invalid String"sv)));
 }
 };/*case end*/
 }/*switch end*/
@@ -7225,7 +7225,7 @@ utility::panic((ByteString::must_from_utf8("Invalid String"sv)));
     _jakt_value.release_value();
 }));
 }
-else if (__jakt_enum_value == (ByteString::must_from_utf8("number"sv))) {
+else if (__jakt_enum_value == (ByteString::from_utf8_without_validation("number"sv))) {
 return JaktInternal::ExplicitValue(({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<interpreter::StatementResult, ErrorOr<interpreter::StatementResult>>{
 auto&& __jakt_match_variant = *((((arguments)[static_cast<i64>(0LL)])).impl);
@@ -7260,19 +7260,19 @@ return JaktInternal::ExplicitValue(interpreter::StatementResult::JustValue(types
 };/*case end*/
 case 12 /* USize */: {
 {
-TRY((((*this).error((ByteString::must_from_utf8("String::number must not be called with a usize or u64"sv)),((((arguments)[static_cast<i64>(0LL)])).span)))));
+TRY((((*this).error((ByteString::from_utf8_without_validation("String::number must not be called with a usize or u64"sv)),((((arguments)[static_cast<i64>(0LL)])).span)))));
 return Error::__jakt_from_string_literal((StringView::from_string_literal("Invalid type"sv)));
 }
 };/*case end*/
 case 5 /* U64 */: {
 {
-TRY((((*this).error((ByteString::must_from_utf8("String::number must not be called with a usize or u64"sv)),((((arguments)[static_cast<i64>(0LL)])).span)))));
+TRY((((*this).error((ByteString::from_utf8_without_validation("String::number must not be called with a usize or u64"sv)),((((arguments)[static_cast<i64>(0LL)])).span)))));
 return Error::__jakt_from_string_literal((StringView::from_string_literal("Invalid type"sv)));
 }
 };/*case end*/
 default: {
 {
-TRY((((*this).error((ByteString::must_from_utf8("String::number must be called with an integer"sv)),((((arguments)[static_cast<i64>(0LL)])).span)))));
+TRY((((*this).error((ByteString::from_utf8_without_validation("String::number must be called with an integer"sv)),((((arguments)[static_cast<i64>(0LL)])).span)))));
 return Error::__jakt_from_string_literal((StringView::from_string_literal("Invalid type"sv)));
 }
 };/*case end*/
@@ -7284,7 +7284,7 @@ return Error::__jakt_from_string_literal((StringView::from_string_literal("Inval
     _jakt_value.release_value();
 }));
 }
-else if (__jakt_enum_value == (ByteString::must_from_utf8("to_uint"sv))) {
+else if (__jakt_enum_value == (ByteString::from_utf8_without_validation("to_uint"sv))) {
 return JaktInternal::ExplicitValue(({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<interpreter::StatementResult, ErrorOr<interpreter::StatementResult>>{
 auto&& __jakt_match_variant = *(((this_argument.value())).impl);
@@ -7313,7 +7313,7 @@ __jakt_label_269:; __jakt_var_283.release_value(); }));
 };/*case end*/
 default: {
 {
-utility::panic((ByteString::must_from_utf8("Invalid String"sv)));
+utility::panic((ByteString::from_utf8_without_validation("Invalid String"sv)));
 }
 };/*case end*/
 }/*switch end*/
@@ -7324,7 +7324,7 @@ utility::panic((ByteString::must_from_utf8("Invalid String"sv)));
     _jakt_value.release_value();
 }));
 }
-else if (__jakt_enum_value == (ByteString::must_from_utf8("to_int"sv))) {
+else if (__jakt_enum_value == (ByteString::from_utf8_without_validation("to_int"sv))) {
 return JaktInternal::ExplicitValue(({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<interpreter::StatementResult, ErrorOr<interpreter::StatementResult>>{
 auto&& __jakt_match_variant = *(((this_argument.value())).impl);
@@ -7354,7 +7354,7 @@ __jakt_label_270:; __jakt_var_284.release_value(); }));
 };/*case end*/
 default: {
 {
-utility::panic((ByteString::must_from_utf8("Invalid String"sv)));
+utility::panic((ByteString::from_utf8_without_validation("Invalid String"sv)));
 }
 };/*case end*/
 }/*switch end*/
@@ -7365,7 +7365,7 @@ utility::panic((ByteString::must_from_utf8("Invalid String"sv)));
     _jakt_value.release_value();
 }));
 }
-else if (__jakt_enum_value == (ByteString::must_from_utf8("is_whitespace"sv))) {
+else if (__jakt_enum_value == (ByteString::from_utf8_without_validation("is_whitespace"sv))) {
 return JaktInternal::ExplicitValue(({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<interpreter::StatementResult, ErrorOr<interpreter::StatementResult>>{
 auto&& __jakt_match_variant = *(((this_argument.value())).impl);
@@ -7376,7 +7376,7 @@ return JaktInternal::ExplicitValue(interpreter::StatementResult::JustValue(types
 };/*case end*/
 default: {
 {
-utility::panic((ByteString::must_from_utf8("Invalid String"sv)));
+utility::panic((ByteString::from_utf8_without_validation("Invalid String"sv)));
 }
 };/*case end*/
 }/*switch end*/
@@ -7387,7 +7387,7 @@ utility::panic((ByteString::must_from_utf8("Invalid String"sv)));
     _jakt_value.release_value();
 }));
 }
-else if (__jakt_enum_value == (ByteString::must_from_utf8("contains"sv))) {
+else if (__jakt_enum_value == (ByteString::from_utf8_without_validation("contains"sv))) {
 return JaktInternal::ExplicitValue(({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<interpreter::StatementResult, ErrorOr<interpreter::StatementResult>>{
 auto&& __jakt_match_variant = *(((this_argument.value())).impl);
@@ -7404,7 +7404,7 @@ return JaktInternal::ExplicitValue(interpreter::StatementResult::JustValue(types
 };/*case end*/
 default: {
 {
-TRY((((*this).error((ByteString::must_from_utf8("String::contains must be called with a string"sv)),((((arguments)[static_cast<i64>(0LL)])).span)))));
+TRY((((*this).error((ByteString::from_utf8_without_validation("String::contains must be called with a string"sv)),((((arguments)[static_cast<i64>(0LL)])).span)))));
 return Error::__jakt_from_string_literal((StringView::from_string_literal("Invalid type"sv)));
 }
 };/*case end*/
@@ -7418,7 +7418,7 @@ return Error::__jakt_from_string_literal((StringView::from_string_literal("Inval
 };/*case end*/
 default: {
 {
-utility::panic((ByteString::must_from_utf8("Invalid String"sv)));
+utility::panic((ByteString::from_utf8_without_validation("Invalid String"sv)));
 }
 };/*case end*/
 }/*switch end*/
@@ -7429,7 +7429,7 @@ utility::panic((ByteString::must_from_utf8("Invalid String"sv)));
     _jakt_value.release_value();
 }));
 }
-else if (__jakt_enum_value == (ByteString::must_from_utf8("replace"sv))) {
+else if (__jakt_enum_value == (ByteString::from_utf8_without_validation("replace"sv))) {
 return JaktInternal::ExplicitValue(({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<interpreter::StatementResult, ErrorOr<interpreter::StatementResult>>{
 auto&& __jakt_match_variant = *(((this_argument.value())).impl);
@@ -7452,7 +7452,7 @@ return JaktInternal::ExplicitValue(interpreter::StatementResult::JustValue(types
 };/*case end*/
 default: {
 {
-TRY((((*this).error((ByteString::must_from_utf8("String::replace must be called with strings"sv)),((((arguments)[static_cast<i64>(1LL)])).span)))));
+TRY((((*this).error((ByteString::from_utf8_without_validation("String::replace must be called with strings"sv)),((((arguments)[static_cast<i64>(1LL)])).span)))));
 return Error::__jakt_from_string_literal((StringView::from_string_literal("Invalid type"sv)));
 }
 };/*case end*/
@@ -7466,7 +7466,7 @@ return Error::__jakt_from_string_literal((StringView::from_string_literal("Inval
 };/*case end*/
 default: {
 {
-TRY((((*this).error((ByteString::must_from_utf8("String::replace must be called with strings"sv)),((((arguments)[static_cast<i64>(0LL)])).span)))));
+TRY((((*this).error((ByteString::from_utf8_without_validation("String::replace must be called with strings"sv)),((((arguments)[static_cast<i64>(0LL)])).span)))));
 return Error::__jakt_from_string_literal((StringView::from_string_literal("Invalid type"sv)));
 }
 };/*case end*/
@@ -7480,7 +7480,7 @@ return Error::__jakt_from_string_literal((StringView::from_string_literal("Inval
 };/*case end*/
 default: {
 {
-utility::panic((ByteString::must_from_utf8("Invalid String"sv)));
+utility::panic((ByteString::from_utf8_without_validation("Invalid String"sv)));
 }
 };/*case end*/
 }/*switch end*/
@@ -7491,7 +7491,7 @@ utility::panic((ByteString::must_from_utf8("Invalid String"sv)));
     _jakt_value.release_value();
 }));
 }
-else if (__jakt_enum_value == (ByteString::must_from_utf8("byte_at"sv))) {
+else if (__jakt_enum_value == (ByteString::from_utf8_without_validation("byte_at"sv))) {
 return JaktInternal::ExplicitValue(({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<interpreter::StatementResult, ErrorOr<interpreter::StatementResult>>{
 auto&& __jakt_match_variant = *(((this_argument.value())).impl);
@@ -7524,7 +7524,7 @@ return JaktInternal::ExplicitValue(interpreter::StatementResult::JustValue(types
 };/*case end*/
 default: {
 {
-TRY((((*this).error((ByteString::must_from_utf8("String::byte_at must be called with an unsigned integer"sv)),((((arguments)[static_cast<i64>(0LL)])).span)))));
+TRY((((*this).error((ByteString::from_utf8_without_validation("String::byte_at must be called with an unsigned integer"sv)),((((arguments)[static_cast<i64>(0LL)])).span)))));
 return Error::__jakt_from_string_literal((StringView::from_string_literal("Invalid type"sv)));
 }
 };/*case end*/
@@ -7538,7 +7538,7 @@ return Error::__jakt_from_string_literal((StringView::from_string_literal("Inval
 };/*case end*/
 default: {
 {
-utility::panic((ByteString::must_from_utf8("Invalid String"sv)));
+utility::panic((ByteString::from_utf8_without_validation("Invalid String"sv)));
 }
 };/*case end*/
 }/*switch end*/
@@ -7549,7 +7549,7 @@ utility::panic((ByteString::must_from_utf8("Invalid String"sv)));
     _jakt_value.release_value();
 }));
 }
-else if (__jakt_enum_value == (ByteString::must_from_utf8("split"sv))) {
+else if (__jakt_enum_value == (ByteString::from_utf8_without_validation("split"sv))) {
 return JaktInternal::ExplicitValue(({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<interpreter::StatementResult, ErrorOr<interpreter::StatementResult>>{
 auto&& __jakt_match_variant = *(((this_argument.value())).impl);
@@ -7580,7 +7580,7 @@ ByteString value = (_magic_value.value());
 }
 }
 
-ids::StructId const array_struct_id = TRY((((((*this).program))->find_struct_in_prelude((ByteString::must_from_utf8("Array"sv))))));
+ids::StructId const array_struct_id = TRY((((((*this).program))->find_struct_in_prelude((ByteString::from_utf8_without_validation("Array"sv))))));
 __jakt_var_285 = interpreter::StatementResult::JustValue(types::Value(types::ValueImpl::JaktArray(result,((*this).find_or_add_type_id(types::Type::GenericInstance(parser::CheckedQualifiers(false),array_struct_id,DynamicArray<ids::TypeId>::create_with({TRY((((*this).string_type())))}))))),call_span)); goto __jakt_label_271;
 
 }
@@ -7588,7 +7588,7 @@ __jakt_label_271:; __jakt_var_285.release_value(); }));
 };/*case end*/
 default: {
 {
-TRY((((*this).error((ByteString::must_from_utf8("String::split must be called with a c_char"sv)),((((arguments)[static_cast<i64>(0LL)])).span)))));
+TRY((((*this).error((ByteString::from_utf8_without_validation("String::split must be called with a c_char"sv)),((((arguments)[static_cast<i64>(0LL)])).span)))));
 return Error::__jakt_from_string_literal((StringView::from_string_literal("Invalid type"sv)));
 }
 };/*case end*/
@@ -7602,7 +7602,7 @@ return Error::__jakt_from_string_literal((StringView::from_string_literal("Inval
 };/*case end*/
 default: {
 {
-utility::panic((ByteString::must_from_utf8("Invalid String"sv)));
+utility::panic((ByteString::from_utf8_without_validation("Invalid String"sv)));
 }
 };/*case end*/
 }/*switch end*/
@@ -7613,7 +7613,7 @@ utility::panic((ByteString::must_from_utf8("Invalid String"sv)));
     _jakt_value.release_value();
 }));
 }
-else if (__jakt_enum_value == (ByteString::must_from_utf8("starts_with"sv))) {
+else if (__jakt_enum_value == (ByteString::from_utf8_without_validation("starts_with"sv))) {
 return JaktInternal::ExplicitValue(({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<interpreter::StatementResult, ErrorOr<interpreter::StatementResult>>{
 auto&& __jakt_match_variant = *(((this_argument.value())).impl);
@@ -7630,7 +7630,7 @@ return JaktInternal::ExplicitValue(interpreter::StatementResult::JustValue(types
 };/*case end*/
 default: {
 {
-TRY((((*this).error((ByteString::must_from_utf8("String::starts_with must be called with a string"sv)),((((arguments)[static_cast<i64>(0LL)])).span)))));
+TRY((((*this).error((ByteString::from_utf8_without_validation("String::starts_with must be called with a string"sv)),((((arguments)[static_cast<i64>(0LL)])).span)))));
 return Error::__jakt_from_string_literal((StringView::from_string_literal("Invalid type"sv)));
 }
 };/*case end*/
@@ -7644,7 +7644,7 @@ return Error::__jakt_from_string_literal((StringView::from_string_literal("Inval
 };/*case end*/
 default: {
 {
-utility::panic((ByteString::must_from_utf8("Invalid String"sv)));
+utility::panic((ByteString::from_utf8_without_validation("Invalid String"sv)));
 }
 };/*case end*/
 }/*switch end*/
@@ -7655,7 +7655,7 @@ utility::panic((ByteString::must_from_utf8("Invalid String"sv)));
     _jakt_value.release_value();
 }));
 }
-else if (__jakt_enum_value == (ByteString::must_from_utf8("ends_with"sv))) {
+else if (__jakt_enum_value == (ByteString::from_utf8_without_validation("ends_with"sv))) {
 return JaktInternal::ExplicitValue(({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<interpreter::StatementResult, ErrorOr<interpreter::StatementResult>>{
 auto&& __jakt_match_variant = *(((this_argument.value())).impl);
@@ -7672,7 +7672,7 @@ return JaktInternal::ExplicitValue(interpreter::StatementResult::JustValue(types
 };/*case end*/
 default: {
 {
-TRY((((*this).error((ByteString::must_from_utf8("String::ends_with must be called with a string"sv)),((((arguments)[static_cast<i64>(0LL)])).span)))));
+TRY((((*this).error((ByteString::from_utf8_without_validation("String::ends_with must be called with a string"sv)),((((arguments)[static_cast<i64>(0LL)])).span)))));
 return Error::__jakt_from_string_literal((StringView::from_string_literal("Invalid type"sv)));
 }
 };/*case end*/
@@ -7686,7 +7686,7 @@ return Error::__jakt_from_string_literal((StringView::from_string_literal("Inval
 };/*case end*/
 default: {
 {
-utility::panic((ByteString::must_from_utf8("Invalid String"sv)));
+utility::panic((ByteString::from_utf8_without_validation("Invalid String"sv)));
 }
 };/*case end*/
 }/*switch end*/
@@ -7697,10 +7697,10 @@ utility::panic((ByteString::must_from_utf8("Invalid String"sv)));
     _jakt_value.release_value();
 }));
 }
-else if (__jakt_enum_value == (ByteString::must_from_utf8("repeated"sv))) {
+else if (__jakt_enum_value == (ByteString::from_utf8_without_validation("repeated"sv))) {
 return JaktInternal::ExplicitValue(({ Optional<interpreter::StatementResult> __jakt_var_286; {
 if (((((arguments).size())) != (static_cast<size_t>(2ULL)))){
-TRY((((*this).error((ByteString::must_from_utf8("String::repeated must be called with a c_char and a usize"sv)),call_span))));
+TRY((((*this).error((ByteString::from_utf8_without_validation("String::repeated must be called with a c_char and a usize"sv)),call_span))));
 return Error::__jakt_from_string_literal((StringView::from_string_literal("Invalid type"sv)));
 }
 JaktInternal::Tuple<char,size_t> const character_count_ = ({
@@ -7719,7 +7719,7 @@ return JaktInternal::ExplicitValue((Tuple{arg, c}));
 };/*case end*/
 default: {
 {
-TRY((((*this).error((ByteString::must_from_utf8("String::repeated must be called with a usize"sv)),((((arguments)[static_cast<i64>(1LL)])).span)))));
+TRY((((*this).error((ByteString::from_utf8_without_validation("String::repeated must be called with a usize"sv)),((((arguments)[static_cast<i64>(1LL)])).span)))));
 return Error::__jakt_from_string_literal((StringView::from_string_literal("Invalid type"sv)));
 }
 };/*case end*/
@@ -7733,7 +7733,7 @@ return Error::__jakt_from_string_literal((StringView::from_string_literal("Inval
 };/*case end*/
 default: {
 {
-TRY((((*this).error((ByteString::must_from_utf8("String::repeated must be called with a c_char"sv)),((((arguments)[static_cast<i64>(0LL)])).span)))));
+TRY((((*this).error((ByteString::from_utf8_without_validation("String::repeated must be called with a c_char"sv)),((((arguments)[static_cast<i64>(0LL)])).span)))));
 return Error::__jakt_from_string_literal((StringView::from_string_literal("Invalid type"sv)));
 }
 };/*case end*/
@@ -7764,24 +7764,24 @@ return Error::__jakt_from_string_literal((StringView::from_string_literal("Not y
     _jakt_value.release_value();
 }));
 }
-else if (__jakt_enum_value == (ByteString::must_from_utf8("Set"sv))) {
+else if (__jakt_enum_value == (ByteString::from_utf8_without_validation("Set"sv))) {
 return JaktInternal::ExplicitValue(({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<interpreter::StatementResult,ErrorOr<interpreter::StatementResult>>{
 auto __jakt_enum_value = (prelude_function);
-if (__jakt_enum_value == (ByteString::must_from_utf8("Set"sv))) {
+if (__jakt_enum_value == (ByteString::from_utf8_without_validation("Set"sv))) {
 return JaktInternal::ExplicitValue(({ Optional<interpreter::StatementResult> __jakt_var_287; {
 if (((((type_bindings).size())) != (static_cast<size_t>(1ULL)))){
-TRY((((*this).error((ByteString::must_from_utf8("Set constructor expects one generic argument"sv)),call_span))));
+TRY((((*this).error((ByteString::from_utf8_without_validation("Set constructor expects one generic argument"sv)),call_span))));
 return Error::__jakt_from_string_literal((StringView::from_string_literal("Invalid type"sv)));
 }
-ids::StructId const set_struct_id = TRY((((((*this).program))->find_struct_in_prelude((ByteString::must_from_utf8("Set"sv))))));
+ids::StructId const set_struct_id = TRY((((((*this).program))->find_struct_in_prelude((ByteString::from_utf8_without_validation("Set"sv))))));
 ids::TypeId const type_id = ((*this).find_or_add_type_id(types::Type::GenericInstance(parser::CheckedQualifiers(false),set_struct_id,DynamicArray<ids::TypeId>::create_with({(((type_bindings).get(((((type_bindings).keys()))[static_cast<i64>(0LL)]))).value())}))));
 __jakt_var_287 = interpreter::StatementResult::JustValue(types::Value(types::ValueImpl::JaktSet(DynamicArray<types::Value>::create_with({}),type_id),call_span)); goto __jakt_label_273;
 
 }
 __jakt_label_273:; __jakt_var_287.release_value(); }));
 }
-else if (__jakt_enum_value == (ByteString::must_from_utf8("is_empty"sv))) {
+else if (__jakt_enum_value == (ByteString::from_utf8_without_validation("is_empty"sv))) {
 return JaktInternal::ExplicitValue(({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<interpreter::StatementResult, ErrorOr<interpreter::StatementResult>>{
 auto&& __jakt_match_variant = *(((this_argument.value())).impl);
@@ -7792,7 +7792,7 @@ return JaktInternal::ExplicitValue(interpreter::StatementResult::JustValue(types
 };/*case end*/
 default: {
 {
-utility::panic((ByteString::must_from_utf8("Invalid Set"sv)));
+utility::panic((ByteString::from_utf8_without_validation("Invalid Set"sv)));
 }
 };/*case end*/
 }/*switch end*/
@@ -7803,7 +7803,7 @@ utility::panic((ByteString::must_from_utf8("Invalid Set"sv)));
     _jakt_value.release_value();
 }));
 }
-else if (__jakt_enum_value == (ByteString::must_from_utf8("contains"sv))) {
+else if (__jakt_enum_value == (ByteString::from_utf8_without_validation("contains"sv))) {
 return JaktInternal::ExplicitValue(({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<interpreter::StatementResult, ErrorOr<interpreter::StatementResult>>{
 auto&& __jakt_match_variant = *(((this_argument.value())).impl);
@@ -7837,7 +7837,7 @@ __jakt_label_274:; __jakt_var_288.release_value(); }));
 };/*case end*/
 default: {
 {
-utility::panic((ByteString::must_from_utf8("Invalid Set"sv)));
+utility::panic((ByteString::from_utf8_without_validation("Invalid Set"sv)));
 }
 };/*case end*/
 }/*switch end*/
@@ -7848,7 +7848,7 @@ utility::panic((ByteString::must_from_utf8("Invalid Set"sv)));
     _jakt_value.release_value();
 }));
 }
-else if (__jakt_enum_value == (ByteString::must_from_utf8("add"sv))) {
+else if (__jakt_enum_value == (ByteString::from_utf8_without_validation("add"sv))) {
 return JaktInternal::ExplicitValue(({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<interpreter::StatementResult, ErrorOr<interpreter::StatementResult>>{
 auto&& __jakt_match_variant = *(((this_argument.value())).impl);
@@ -7865,7 +7865,7 @@ __jakt_label_275:; __jakt_var_289.release_value(); }));
 };/*case end*/
 default: {
 {
-utility::panic((ByteString::must_from_utf8("Invalid Set"sv)));
+utility::panic((ByteString::from_utf8_without_validation("Invalid Set"sv)));
 }
 };/*case end*/
 }/*switch end*/
@@ -7876,7 +7876,7 @@ utility::panic((ByteString::must_from_utf8("Invalid Set"sv)));
     _jakt_value.release_value();
 }));
 }
-else if (__jakt_enum_value == (ByteString::must_from_utf8("remove"sv))) {
+else if (__jakt_enum_value == (ByteString::from_utf8_without_validation("remove"sv))) {
 return JaktInternal::ExplicitValue(({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<interpreter::StatementResult, ErrorOr<interpreter::StatementResult>>{
 auto&& __jakt_match_variant = *(((this_argument.value())).impl);
@@ -7929,7 +7929,7 @@ __jakt_label_276:; __jakt_var_290.release_value(); }));
 };/*case end*/
 default: {
 {
-utility::panic((ByteString::must_from_utf8("Invalid Set"sv)));
+utility::panic((ByteString::from_utf8_without_validation("Invalid Set"sv)));
 }
 };/*case end*/
 }/*switch end*/
@@ -7940,7 +7940,7 @@ utility::panic((ByteString::must_from_utf8("Invalid Set"sv)));
     _jakt_value.release_value();
 }));
 }
-else if (__jakt_enum_value == (ByteString::must_from_utf8("clear"sv))) {
+else if (__jakt_enum_value == (ByteString::from_utf8_without_validation("clear"sv))) {
 return JaktInternal::ExplicitValue(({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<interpreter::StatementResult, ErrorOr<interpreter::StatementResult>>{
 auto&& __jakt_match_variant = *(((this_argument.value())).impl);
@@ -7957,7 +7957,7 @@ __jakt_label_277:; __jakt_var_291.release_value(); }));
 };/*case end*/
 default: {
 {
-utility::panic((ByteString::must_from_utf8("Invalid Set"sv)));
+utility::panic((ByteString::from_utf8_without_validation("Invalid Set"sv)));
 }
 };/*case end*/
 }/*switch end*/
@@ -7968,7 +7968,7 @@ utility::panic((ByteString::must_from_utf8("Invalid Set"sv)));
     _jakt_value.release_value();
 }));
 }
-else if (__jakt_enum_value == (ByteString::must_from_utf8("size"sv))) {
+else if (__jakt_enum_value == (ByteString::from_utf8_without_validation("size"sv))) {
 return JaktInternal::ExplicitValue(({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<interpreter::StatementResult, ErrorOr<interpreter::StatementResult>>{
 auto&& __jakt_match_variant = *(((this_argument.value())).impl);
@@ -7979,7 +7979,7 @@ return JaktInternal::ExplicitValue(interpreter::StatementResult::JustValue(types
 };/*case end*/
 default: {
 {
-utility::panic((ByteString::must_from_utf8("Invalid Set"sv)));
+utility::panic((ByteString::from_utf8_without_validation("Invalid Set"sv)));
 }
 };/*case end*/
 }/*switch end*/
@@ -7990,7 +7990,7 @@ utility::panic((ByteString::must_from_utf8("Invalid Set"sv)));
     _jakt_value.release_value();
 }));
 }
-else if (__jakt_enum_value == (ByteString::must_from_utf8("capacity"sv))) {
+else if (__jakt_enum_value == (ByteString::from_utf8_without_validation("capacity"sv))) {
 return JaktInternal::ExplicitValue(({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<interpreter::StatementResult, ErrorOr<interpreter::StatementResult>>{
 auto&& __jakt_match_variant = *(((this_argument.value())).impl);
@@ -8001,7 +8001,7 @@ return JaktInternal::ExplicitValue(interpreter::StatementResult::JustValue(types
 };/*case end*/
 default: {
 {
-utility::panic((ByteString::must_from_utf8("Invalid Set"sv)));
+utility::panic((ByteString::from_utf8_without_validation("Invalid Set"sv)));
 }
 };/*case end*/
 }/*switch end*/
@@ -8012,7 +8012,7 @@ utility::panic((ByteString::must_from_utf8("Invalid Set"sv)));
     _jakt_value.release_value();
 }));
 }
-else if (__jakt_enum_value == (ByteString::must_from_utf8("ensure_capacity"sv))) {
+else if (__jakt_enum_value == (ByteString::from_utf8_without_validation("ensure_capacity"sv))) {
 return JaktInternal::ExplicitValue(({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<interpreter::StatementResult, ErrorOr<interpreter::StatementResult>>{
 auto&& __jakt_match_variant = *(((this_argument.value())).impl);
@@ -8035,7 +8035,7 @@ __jakt_label_278:; __jakt_var_292.release_value(); }));
 };/*case end*/
 default: {
 {
-TRY((((*this).error((ByteString::must_from_utf8("Set::ensure_capacity must be called with a usize"sv)),((((arguments)[static_cast<i64>(0LL)])).span)))));
+TRY((((*this).error((ByteString::from_utf8_without_validation("Set::ensure_capacity must be called with a usize"sv)),((((arguments)[static_cast<i64>(0LL)])).span)))));
 return Error::__jakt_from_string_literal((StringView::from_string_literal("Invalid type"sv)));
 }
 };/*case end*/
@@ -8049,7 +8049,7 @@ return Error::__jakt_from_string_literal((StringView::from_string_literal("Inval
 };/*case end*/
 default: {
 {
-utility::panic((ByteString::must_from_utf8("Invalid Set"sv)));
+utility::panic((ByteString::from_utf8_without_validation("Invalid Set"sv)));
 }
 };/*case end*/
 }/*switch end*/
@@ -8060,14 +8060,14 @@ utility::panic((ByteString::must_from_utf8("Invalid Set"sv)));
     _jakt_value.release_value();
 }));
 }
-else if (__jakt_enum_value == (ByteString::must_from_utf8("iterator"sv))) {
+else if (__jakt_enum_value == (ByteString::from_utf8_without_validation("iterator"sv))) {
 return JaktInternal::ExplicitValue(({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<interpreter::StatementResult, ErrorOr<interpreter::StatementResult>>{
 auto&& __jakt_match_variant = *(((this_argument.value())).impl);
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 22 /* JaktSet */: {
 return JaktInternal::ExplicitValue(({ Optional<interpreter::StatementResult> __jakt_var_293; {
-ids::StructId const struct_id = TRY((((((*this).program))->find_struct_in_prelude((ByteString::must_from_utf8("SetIterator"sv))))));
+ids::StructId const struct_id = TRY((((((*this).program))->find_struct_in_prelude((ByteString::from_utf8_without_validation("SetIterator"sv))))));
 __jakt_var_293 = interpreter::StatementResult::JustValue(types::Value(types::ValueImpl::Struct(DynamicArray<types::Value>::create_with({(this_argument.value()), types::Value(types::ValueImpl::USize(static_cast<size_t>(0ULL)),call_span)}),struct_id,JaktInternal::OptionalNone()),call_span)); goto __jakt_label_279;
 
 }
@@ -8075,7 +8075,7 @@ __jakt_label_279:; __jakt_var_293.release_value(); }));
 };/*case end*/
 default: {
 {
-utility::panic((ByteString::must_from_utf8("Invalid use of Set::iterator()"sv)));
+utility::panic((ByteString::from_utf8_without_validation("Invalid use of Set::iterator()"sv)));
 }
 };/*case end*/
 }/*switch end*/
@@ -8098,11 +8098,11 @@ return Error::__jakt_from_string_literal((StringView::from_string_literal("Not y
     _jakt_value.release_value();
 }));
 }
-else if (__jakt_enum_value == (ByteString::must_from_utf8("SetIterator"sv))) {
+else if (__jakt_enum_value == (ByteString::from_utf8_without_validation("SetIterator"sv))) {
 return JaktInternal::ExplicitValue(({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<interpreter::StatementResult,ErrorOr<interpreter::StatementResult>>{
 auto __jakt_enum_value = (prelude_function);
-if (__jakt_enum_value == (ByteString::must_from_utf8("next"sv))) {
+if (__jakt_enum_value == (ByteString::from_utf8_without_validation("next"sv))) {
 return JaktInternal::ExplicitValue(({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<interpreter::StatementResult, ErrorOr<interpreter::StatementResult>>{
 auto&& __jakt_match_variant = *(((this_argument.value())).impl);
@@ -8120,7 +8120,7 @@ return JaktInternal::ExplicitValue(value);
 };/*case end*/
 default: {
 {
-utility::panic((ByteString::must_from_utf8("Invalid SetIterator index configuration"sv)));
+utility::panic((ByteString::from_utf8_without_validation("Invalid SetIterator index configuration"sv)));
 }
 };/*case end*/
 }/*switch end*/
@@ -8169,7 +8169,7 @@ return JaktInternal::ExplicitValue(types::Value(types::ValueImpl::OptionalNone()
 };/*case end*/
 default: {
 {
-utility::panic((ByteString::must_from_utf8("Invalid SetIterator configuration"sv)));
+utility::panic((ByteString::from_utf8_without_validation("Invalid SetIterator configuration"sv)));
 }
 };/*case end*/
 }/*switch end*/
@@ -8185,7 +8185,7 @@ __jakt_label_280:; __jakt_var_294.release_value(); }));
 };/*case end*/
 default: {
 {
-utility::panic((ByteString::must_from_utf8("Invalid SetIterator configuration"sv)));
+utility::panic((ByteString::from_utf8_without_validation("Invalid SetIterator configuration"sv)));
 }
 };/*case end*/
 }/*switch end*/
@@ -8208,11 +8208,11 @@ return Error::__jakt_from_string_literal((StringView::from_string_literal("Not y
     _jakt_value.release_value();
 }));
 }
-else if (__jakt_enum_value == (ByteString::must_from_utf8("DictionaryIterator"sv))) {
+else if (__jakt_enum_value == (ByteString::from_utf8_without_validation("DictionaryIterator"sv))) {
 return JaktInternal::ExplicitValue(({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<interpreter::StatementResult,ErrorOr<interpreter::StatementResult>>{
 auto __jakt_enum_value = (prelude_function);
-if (__jakt_enum_value == (ByteString::must_from_utf8("next"sv))) {
+if (__jakt_enum_value == (ByteString::from_utf8_without_validation("next"sv))) {
 return JaktInternal::ExplicitValue(({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<interpreter::StatementResult, ErrorOr<interpreter::StatementResult>>{
 auto&& __jakt_match_variant = *(((this_argument.value())).impl);
@@ -8230,7 +8230,7 @@ return JaktInternal::ExplicitValue(value);
 };/*case end*/
 default: {
 {
-utility::panic((ByteString::must_from_utf8("Invalid DictionaryIterator index configuration"sv)));
+utility::panic((ByteString::from_utf8_without_validation("Invalid DictionaryIterator index configuration"sv)));
 }
 };/*case end*/
 }/*switch end*/
@@ -8285,7 +8285,7 @@ return JaktInternal::ExplicitValue(args);
 };/*case end*/
 default: {
 {
-utility::panic((ByteString::must_from_utf8("expected generic instance"sv)));
+utility::panic((ByteString::from_utf8_without_validation("expected generic instance"sv)));
 }
 };/*case end*/
 }/*switch end*/
@@ -8295,7 +8295,7 @@ utility::panic((ByteString::must_from_utf8("expected generic instance"sv)));
         return _jakt_value.release_return();
     _jakt_value.release_value();
 });
-ids::StructId const tuple_struct_id = TRY((((((*this).program))->find_struct_in_prelude((ByteString::must_from_utf8("Tuple"sv))))));
+ids::StructId const tuple_struct_id = TRY((((((*this).program))->find_struct_in_prelude((ByteString::from_utf8_without_validation("Tuple"sv))))));
 ids::TypeId const tuple_type_id = ((*this).find_or_add_type_id(types::Type::GenericInstance(parser::CheckedQualifiers(false),tuple_struct_id,generics)));
 __jakt_var_297 = types::Value(types::ValueImpl::OptionalSome(types::Value(types::ValueImpl::JaktTuple(DynamicArray<types::Value>::create_with({((keys)[index]), ((values)[index])}),tuple_type_id),call_span)),call_span); goto __jakt_label_283;
 
@@ -8314,7 +8314,7 @@ VERIFY_NOT_REACHED();
 };/*case end*/
 default: {
 {
-utility::panic((ByteString::must_from_utf8("Invalid DictionaryIterator configuration"sv)));
+utility::panic((ByteString::from_utf8_without_validation("Invalid DictionaryIterator configuration"sv)));
 }
 };/*case end*/
 }/*switch end*/
@@ -8330,7 +8330,7 @@ __jakt_label_282:; __jakt_var_296.release_value(); }));
 };/*case end*/
 default: {
 {
-utility::panic((ByteString::must_from_utf8("Invalid DictionaryIterator configuration"sv)));
+utility::panic((ByteString::from_utf8_without_validation("Invalid DictionaryIterator configuration"sv)));
 }
 };/*case end*/
 }/*switch end*/
@@ -8353,11 +8353,11 @@ return Error::__jakt_from_string_literal((StringView::from_string_literal("Not y
     _jakt_value.release_value();
 }));
 }
-else if (__jakt_enum_value == (ByteString::must_from_utf8("Optional"sv))) {
+else if (__jakt_enum_value == (ByteString::from_utf8_without_validation("Optional"sv))) {
 return JaktInternal::ExplicitValue(({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<interpreter::StatementResult,ErrorOr<interpreter::StatementResult>>{
 auto __jakt_enum_value = (prelude_function);
-if (__jakt_enum_value == (ByteString::must_from_utf8("has_value"sv))) {
+if (__jakt_enum_value == (ByteString::from_utf8_without_validation("has_value"sv))) {
 return JaktInternal::ExplicitValue(({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<interpreter::StatementResult, ErrorOr<interpreter::StatementResult>>{
 auto&& __jakt_match_variant = *(((this_argument.value())).impl);
@@ -8370,7 +8370,7 @@ return JaktInternal::ExplicitValue(interpreter::StatementResult::JustValue(types
 };/*case end*/
 default: {
 {
-utility::panic((ByteString::must_from_utf8("Invalid Optional configuration"sv)));
+utility::panic((ByteString::from_utf8_without_validation("Invalid Optional configuration"sv)));
 }
 };/*case end*/
 }/*switch end*/
@@ -8381,7 +8381,7 @@ utility::panic((ByteString::must_from_utf8("Invalid Optional configuration"sv)))
     _jakt_value.release_value();
 }));
 }
-else if (__jakt_enum_value == (ByteString::must_from_utf8("value"sv))) {
+else if (__jakt_enum_value == (ByteString::from_utf8_without_validation("value"sv))) {
 return JaktInternal::ExplicitValue(({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<interpreter::StatementResult, ErrorOr<interpreter::StatementResult>>{
 auto&& __jakt_match_variant = *(((this_argument.value())).impl);
@@ -8398,7 +8398,7 @@ return Error::__jakt_from_string_literal((StringView::from_string_literal("Attem
 };/*case end*/
 default: {
 {
-utility::panic((ByteString::must_from_utf8("Invalid Optional configuration"sv)));
+utility::panic((ByteString::from_utf8_without_validation("Invalid Optional configuration"sv)));
 }
 };/*case end*/
 }/*switch end*/
@@ -8409,7 +8409,7 @@ utility::panic((ByteString::must_from_utf8("Invalid Optional configuration"sv)))
     _jakt_value.release_value();
 }));
 }
-else if (__jakt_enum_value == (ByteString::must_from_utf8("map"sv))) {
+else if (__jakt_enum_value == (ByteString::from_utf8_without_validation("map"sv))) {
 return JaktInternal::ExplicitValue(({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<interpreter::StatementResult, ErrorOr<interpreter::StatementResult>>{
 auto&& __jakt_match_variant = *(((this_argument.value())).impl);
@@ -8484,7 +8484,7 @@ __jakt_label_285:; __jakt_var_299.release_value(); }));
 }
 else {
 {
-utility::panic((ByteString::must_from_utf8("Invalid mapper type in Optional::map"sv)));
+utility::panic((ByteString::from_utf8_without_validation("Invalid mapper type in Optional::map"sv)));
 }
 }
 }());
@@ -8501,7 +8501,7 @@ return JaktInternal::ExplicitValue(interpreter::StatementResult::JustValue((this
 };/*case end*/
 default: {
 {
-utility::panic((ByteString::must_from_utf8("Invalid Optional configuration"sv)));
+utility::panic((ByteString::from_utf8_without_validation("Invalid Optional configuration"sv)));
 }
 };/*case end*/
 }/*switch end*/
@@ -8512,7 +8512,7 @@ utility::panic((ByteString::must_from_utf8("Invalid Optional configuration"sv)))
     _jakt_value.release_value();
 }));
 }
-else if (__jakt_enum_value == (ByteString::must_from_utf8("value_or"sv))) {
+else if (__jakt_enum_value == (ByteString::from_utf8_without_validation("value_or"sv))) {
 return JaktInternal::ExplicitValue(({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<interpreter::StatementResult, ErrorOr<interpreter::StatementResult>>{
 auto&& __jakt_match_variant = *(((this_argument.value())).impl);
@@ -8526,7 +8526,7 @@ return JaktInternal::ExplicitValue(interpreter::StatementResult::JustValue(((arg
 };/*case end*/
 default: {
 {
-utility::panic((ByteString::must_from_utf8("Invalid Optional configuration"sv)));
+utility::panic((ByteString::from_utf8_without_validation("Invalid Optional configuration"sv)));
 }
 };/*case end*/
 }/*switch end*/
@@ -8586,13 +8586,13 @@ return Error::__jakt_from_string_literal((StringView::from_string_literal("Attem
 (is_prelude_function = true);
 }
 if (((((function_to_run)->is_static())) == (((this_argument).has_value())))){
-ByteString expected = (ByteString::must_from_utf8("did not expect"sv));
+ByteString expected = (ByteString::from_utf8_without_validation("did not expect"sv));
 if ((!(((function_to_run)->is_static())))){
-(expected = (ByteString::must_from_utf8("expected"sv)));
+(expected = (ByteString::from_utf8_without_validation("expected"sv)));
 }
-ByteString not_provided = (ByteString::must_from_utf8(" not"sv));
+ByteString not_provided = (ByteString::from_utf8_without_validation(" not"sv));
 if (((this_argument).has_value())){
-(not_provided = (ByteString::must_from_utf8(""sv)));
+(not_provided = (ByteString::from_utf8_without_validation(""sv)));
 }
 ((((((*this).compiler))->errors)).push(error::JaktError::Message(__jakt_format((StringView::from_string_literal("function call {} a this argument, yet one was{} provided"sv)),expected,not_provided),((function_to_run)->name_span))));
 return Error::__jakt_from_string_literal((StringView::from_string_literal("Invalid this argument"sv)));
@@ -8615,7 +8615,7 @@ switch(__jakt_match_variant.__jakt_init_index()) {
 case 13 /* JaktString */: {
 {
 JaktInternal::DynamicArray<ids::TypeId> const generic_parameters = DynamicArray<ids::TypeId>::create_with({});
-((effective_namespace).push(types::ResolvedNamespace((ByteString::must_from_utf8("String"sv)),JaktInternal::OptionalNone(),generic_parameters)));
+((effective_namespace).push(types::ResolvedNamespace((ByteString::from_utf8_without_validation("String"sv)),JaktInternal::OptionalNone(),generic_parameters)));
 }
 return JaktInternal::ExplicitValue<void>();
 };/*case end*/
@@ -8632,7 +8632,7 @@ return JaktInternal::ExplicitValue(args);
 };/*case end*/
 default: {
 {
-TRY((((*this).error((ByteString::must_from_utf8("Attempted to call a prelude function  on a non-generic array"sv)),call_span))));
+TRY((((*this).error((ByteString::from_utf8_without_validation("Attempted to call a prelude function  on a non-generic array"sv)),call_span))));
 return Error::__jakt_from_string_literal((StringView::from_string_literal("Invalid type"sv)));
 }
 };/*case end*/
@@ -8643,7 +8643,7 @@ return Error::__jakt_from_string_literal((StringView::from_string_literal("Inval
         return _jakt_value.release_return();
     _jakt_value.release_value();
 });
-((effective_namespace).push(types::ResolvedNamespace((ByteString::must_from_utf8("Array"sv)),JaktInternal::OptionalNone(),generic_parameters)));
+((effective_namespace).push(types::ResolvedNamespace((ByteString::from_utf8_without_validation("Array"sv)),JaktInternal::OptionalNone(),generic_parameters)));
 }
 return JaktInternal::ExplicitValue<void>();
 };/*case end*/
@@ -8660,7 +8660,7 @@ return JaktInternal::ExplicitValue(args);
 };/*case end*/
 default: {
 {
-TRY((((*this).error((ByteString::must_from_utf8("Attempted to call a prelude function  on a non-generic dictionary"sv)),call_span))));
+TRY((((*this).error((ByteString::from_utf8_without_validation("Attempted to call a prelude function  on a non-generic dictionary"sv)),call_span))));
 return Error::__jakt_from_string_literal((StringView::from_string_literal("Invalid type"sv)));
 }
 };/*case end*/
@@ -8671,7 +8671,7 @@ return Error::__jakt_from_string_literal((StringView::from_string_literal("Inval
         return _jakt_value.release_return();
     _jakt_value.release_value();
 });
-((effective_namespace).push(types::ResolvedNamespace((ByteString::must_from_utf8("Dictionary"sv)),JaktInternal::OptionalNone(),generic_parameters)));
+((effective_namespace).push(types::ResolvedNamespace((ByteString::from_utf8_without_validation("Dictionary"sv)),JaktInternal::OptionalNone(),generic_parameters)));
 }
 return JaktInternal::ExplicitValue<void>();
 };/*case end*/
@@ -8680,10 +8680,10 @@ auto&& __jakt_match_value = __jakt_match_variant.as.JaktSet;ids::TypeId const& t
 {
 if (((((((*this).program))->get_type(type_id)))->__jakt_init_index() == 20 /* GenericInstance */)){
 JaktInternal::DynamicArray<ids::TypeId> const generic_parameters = (((((*this).program))->get_type(type_id)))->as.GenericInstance.args;
-((effective_namespace).push(types::ResolvedNamespace((ByteString::must_from_utf8("Set"sv)),JaktInternal::OptionalNone(),generic_parameters)));
+((effective_namespace).push(types::ResolvedNamespace((ByteString::from_utf8_without_validation("Set"sv)),JaktInternal::OptionalNone(),generic_parameters)));
 }
 else {
-TRY((((*this).error((ByteString::must_from_utf8("Attempted to call a prelude function  on a non-generic set"sv)),call_span))));
+TRY((((*this).error((ByteString::from_utf8_without_validation("Attempted to call a prelude function  on a non-generic set"sv)),call_span))));
 return Error::__jakt_from_string_literal((StringView::from_string_literal("Invalid type"sv)));
 }
 
@@ -8717,20 +8717,20 @@ return JaktInternal::ExplicitValue<void>();
 case 25 /* OptionalNone */: {
 {
 JaktInternal::DynamicArray<ids::TypeId> const generic_parameters = DynamicArray<ids::TypeId>::create_with({});
-((effective_namespace).push(types::ResolvedNamespace((ByteString::must_from_utf8("Optional"sv)),JaktInternal::OptionalNone(),generic_parameters)));
+((effective_namespace).push(types::ResolvedNamespace((ByteString::from_utf8_without_validation("Optional"sv)),JaktInternal::OptionalNone(),generic_parameters)));
 }
 return JaktInternal::ExplicitValue<void>();
 };/*case end*/
 case 24 /* OptionalSome */: {
 {
 JaktInternal::DynamicArray<ids::TypeId> const generic_parameters = DynamicArray<ids::TypeId>::create_with({});
-((effective_namespace).push(types::ResolvedNamespace((ByteString::must_from_utf8("Optional"sv)),JaktInternal::OptionalNone(),generic_parameters)));
+((effective_namespace).push(types::ResolvedNamespace((ByteString::from_utf8_without_validation("Optional"sv)),JaktInternal::OptionalNone(),generic_parameters)));
 }
 return JaktInternal::ExplicitValue<void>();
 };/*case end*/
 default: {
 {
-TRY((((*this).error((ByteString::must_from_utf8("Attempted to call an instance method on a non-struct/enum type"sv)),call_span))));
+TRY((((*this).error((ByteString::from_utf8_without_validation("Attempted to call an instance method on a non-struct/enum type"sv)),call_span))));
 return Error::__jakt_from_string_literal((StringView::from_string_literal("Invalid type"sv)));
 }
 return JaktInternal::ExplicitValue<void>();
@@ -8766,17 +8766,17 @@ return JaktInternal::ExplicitValue(interpreter::ExecutionResult::Throw(value));
 };/*case end*/
 case 3 /* Continue */: {
 {
-utility::panic((ByteString::must_from_utf8("Invalid control flow"sv)));
+utility::panic((ByteString::from_utf8_without_validation("Invalid control flow"sv)));
 }
 };/*case end*/
 case 4 /* Break */: {
 {
-utility::panic((ByteString::must_from_utf8("Invalid control flow"sv)));
+utility::panic((ByteString::from_utf8_without_validation("Invalid control flow"sv)));
 }
 };/*case end*/
 case 2 /* Yield */: {
 {
-utility::panic((ByteString::must_from_utf8("Invalid control flow"sv)));
+utility::panic((ByteString::from_utf8_without_validation("Invalid control flow"sv)));
 }
 };/*case end*/
 default: VERIFY_NOT_REACHED();}/*switch end*/
@@ -8821,7 +8821,7 @@ types::Value const param_value = ((arguments)[JaktInternal::checked_sub(i,this_o
 }
 
 if (((this_argument).has_value())){
-((((scope)->bindings)).set((ByteString::must_from_utf8("this"sv)),(this_argument.value())));
+((((scope)->bindings)).set((ByteString::from_utf8_without_validation("this"sv)),(this_argument.value())));
 }
 interpreter::StatementResult const blk = TRY((((*this).execute_block(((function_to_run)->block),scope,call_span))));
 if (((blk).__jakt_init_index() == 5 /* JustValue */)){
@@ -8849,17 +8849,17 @@ return JaktInternal::ExplicitValue(interpreter::ExecutionResult::Throw(value));
 };/*case end*/
 case 3 /* Continue */: {
 {
-utility::panic((ByteString::must_from_utf8("Invalid control flow"sv)));
+utility::panic((ByteString::from_utf8_without_validation("Invalid control flow"sv)));
 }
 };/*case end*/
 case 4 /* Break */: {
 {
-utility::panic((ByteString::must_from_utf8("Invalid control flow"sv)));
+utility::panic((ByteString::from_utf8_without_validation("Invalid control flow"sv)));
 }
 };/*case end*/
 case 2 /* Yield */: {
 {
-utility::panic((ByteString::must_from_utf8("Invalid control flow"sv)));
+utility::panic((ByteString::from_utf8_without_validation("Invalid control flow"sv)));
 }
 };/*case end*/
 default: VERIFY_NOT_REACHED();}/*switch end*/
@@ -8902,7 +8902,7 @@ types::Value const param_value = ((arguments)[JaktInternal::checked_sub(i,this_o
 }
 
 if (((this_argument).has_value())){
-((((scope)->bindings)).set((ByteString::must_from_utf8("this"sv)),(this_argument.value())));
+((((scope)->bindings)).set((ByteString::from_utf8_without_validation("this"sv)),(this_argument.value())));
 }
 return ({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<interpreter::ExecutionResult, ErrorOr<interpreter::ExecutionResult>>{
@@ -8922,17 +8922,17 @@ return JaktInternal::ExplicitValue(interpreter::ExecutionResult::Throw(value));
 };/*case end*/
 case 3 /* Continue */: {
 {
-utility::panic((ByteString::must_from_utf8("Invalid control flow"sv)));
+utility::panic((ByteString::from_utf8_without_validation("Invalid control flow"sv)));
 }
 };/*case end*/
 case 4 /* Break */: {
 {
-utility::panic((ByteString::must_from_utf8("Invalid control flow"sv)));
+utility::panic((ByteString::from_utf8_without_validation("Invalid control flow"sv)));
 }
 };/*case end*/
 case 2 /* Yield */: {
 {
-utility::panic((ByteString::must_from_utf8("Invalid control flow"sv)));
+utility::panic((ByteString::from_utf8_without_validation("Invalid control flow"sv)));
 }
 };/*case end*/
 default: VERIFY_NOT_REACHED();}/*switch end*/
@@ -8975,7 +8975,7 @@ types::Value const param_value = ((arguments)[JaktInternal::checked_sub(i,this_o
 }
 
 if (((this_argument).has_value())){
-((((scope)->bindings)).set((ByteString::must_from_utf8("this"sv)),(this_argument.value())));
+((((scope)->bindings)).set((ByteString::from_utf8_without_validation("this"sv)),(this_argument.value())));
 }
 return ({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<interpreter::ExecutionResult, ErrorOr<interpreter::ExecutionResult>>{
@@ -8995,17 +8995,17 @@ return JaktInternal::ExplicitValue(interpreter::ExecutionResult::Throw(value));
 };/*case end*/
 case 3 /* Continue */: {
 {
-utility::panic((ByteString::must_from_utf8("Invalid control flow"sv)));
+utility::panic((ByteString::from_utf8_without_validation("Invalid control flow"sv)));
 }
 };/*case end*/
 case 4 /* Break */: {
 {
-utility::panic((ByteString::must_from_utf8("Invalid control flow"sv)));
+utility::panic((ByteString::from_utf8_without_validation("Invalid control flow"sv)));
 }
 };/*case end*/
 case 2 /* Yield */: {
 {
-utility::panic((ByteString::must_from_utf8("Invalid control flow"sv)));
+utility::panic((ByteString::from_utf8_without_validation("Invalid control flow"sv)));
 }
 };/*case end*/
 default: VERIFY_NOT_REACHED();}/*switch end*/
@@ -9233,7 +9233,7 @@ return JaktInternal::ExplicitValue<void>();
 };/*case end*/
 case 2 /* Yield */: {
 {
-utility::panic((ByteString::must_from_utf8("Invalid control flow"sv)));
+utility::panic((ByteString::from_utf8_without_validation("Invalid control flow"sv)));
 }
 return JaktInternal::ExplicitValue<void>();
 };/*case end*/
@@ -9295,7 +9295,7 @@ return JaktInternal::ExplicitValue<void>();
 };/*case end*/
 case 2 /* Yield */: {
 {
-utility::panic((ByteString::must_from_utf8("Invalid control flow"sv)));
+utility::panic((ByteString::from_utf8_without_validation("Invalid control flow"sv)));
 }
 return JaktInternal::ExplicitValue<void>();
 };/*case end*/
@@ -9312,7 +9312,7 @@ default: VERIFY_NOT_REACHED();}/*switch end*/
 });
 }
 else {
-utility::panic((ByteString::must_from_utf8("expected vardecl"sv)));
+utility::panic((ByteString::from_utf8_without_validation("expected vardecl"sv)));
 }
 
 }
@@ -9322,7 +9322,7 @@ utility::panic((ByteString::must_from_utf8("expected vardecl"sv)));
 
 }
 else {
-utility::panic((ByteString::must_from_utf8("expected vardecl"sv)));
+utility::panic((ByteString::from_utf8_without_validation("expected vardecl"sv)));
 }
 
 }
@@ -9380,7 +9380,7 @@ return JaktInternal::ExplicitValue<void>();
 };/*case end*/
 case 2 /* Yield */: {
 {
-utility::panic((ByteString::must_from_utf8("Invalid control flow"sv)));
+utility::panic((ByteString::from_utf8_without_validation("Invalid control flow"sv)));
 }
 return JaktInternal::ExplicitValue<void>();
 };/*case end*/
@@ -9452,7 +9452,7 @@ return interpreter::StatementResult::Break();
 };/*case end*/
 case 2 /* Yield */: {
 {
-utility::panic((ByteString::must_from_utf8("Invalid control flow"sv)));
+utility::panic((ByteString::from_utf8_without_validation("Invalid control flow"sv)));
 }
 };/*case end*/
 default: VERIFY_NOT_REACHED();}/*switch end*/
@@ -9515,7 +9515,7 @@ return JaktInternal::ExplicitValue(interpreter::StatementResult::Break());
 };/*case end*/
 case 2 /* Yield */: {
 {
-utility::panic((ByteString::must_from_utf8("Invalid control flow"sv)));
+utility::panic((ByteString::from_utf8_without_validation("Invalid control flow"sv)));
 }
 };/*case end*/
 default: VERIFY_NOT_REACHED();}/*switch end*/
@@ -9583,7 +9583,7 @@ return JaktInternal::ExplicitValue<void>();
 };/*case end*/
 case 2 /* Yield */: {
 {
-utility::panic((ByteString::must_from_utf8("Invalid control flow"sv)));
+utility::panic((ByteString::from_utf8_without_validation("Invalid control flow"sv)));
 }
 return JaktInternal::ExplicitValue<void>();
 };/*case end*/
@@ -9652,7 +9652,7 @@ return JaktInternal::ExplicitValue<void>();
 };/*case end*/
 case 2 /* Yield */: {
 {
-utility::panic((ByteString::must_from_utf8("Invalid control flow"sv)));
+utility::panic((ByteString::from_utf8_without_validation("Invalid control flow"sv)));
 }
 return JaktInternal::ExplicitValue<void>();
 };/*case end*/
@@ -9704,7 +9704,7 @@ return JaktInternal::ExplicitValue<void>();
 };/*case end*/
 case 2 /* Yield */: {
 {
-utility::panic((ByteString::must_from_utf8("Invalid control flow"sv)));
+utility::panic((ByteString::from_utf8_without_validation("Invalid control flow"sv)));
 }
 return JaktInternal::ExplicitValue<void>();
 };/*case end*/
@@ -9751,7 +9751,7 @@ return JaktInternal::ExplicitValue(interpreter::StatementResult::Break());
 };/*case end*/
 case 2 /* Yield */: {
 {
-utility::panic((ByteString::must_from_utf8("Invalid control flow"sv)));
+utility::panic((ByteString::from_utf8_without_validation("Invalid control flow"sv)));
 }
 };/*case end*/
 default: VERIFY_NOT_REACHED();}/*switch end*/
@@ -9819,7 +9819,7 @@ return JaktInternal::ExplicitValue<void>();
 };/*case end*/
 case 2 /* Yield */: {
 {
-utility::panic((ByteString::must_from_utf8("Invalid control flow"sv)));
+utility::panic((ByteString::from_utf8_without_validation("Invalid control flow"sv)));
 }
 return JaktInternal::ExplicitValue<void>();
 };/*case end*/
@@ -9872,7 +9872,7 @@ return JaktInternal::ExplicitValue<void>();
 };/*case end*/
 case 2 /* Yield */: {
 {
-utility::panic((ByteString::must_from_utf8("Invalid control flow"sv)));
+utility::panic((ByteString::from_utf8_without_validation("Invalid control flow"sv)));
 }
 return JaktInternal::ExplicitValue<void>();
 };/*case end*/
@@ -9886,11 +9886,11 @@ default: VERIFY_NOT_REACHED();}/*switch end*/
 };/*case end*/
 case 13 /* InlineCpp */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.InlineCpp;utility::Span const& span = __jakt_match_value.span;
-return (TRY((((*this).error((ByteString::must_from_utf8("Cannot run inline cpp at compile time"sv)),span))))), JaktInternal::ExplicitValue<void>();
+return (TRY((((*this).error((ByteString::from_utf8_without_validation("Cannot run inline cpp at compile time"sv)),span))))), JaktInternal::ExplicitValue<void>();
 };/*case end*/
 case 14 /* Garbage */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Garbage;utility::Span const& span = __jakt_match_value.value;
-return (TRY((((*this).error((ByteString::must_from_utf8("Cannot run invalid statements at compile time"sv)),span))))), JaktInternal::ExplicitValue<void>();
+return (TRY((((*this).error((ByteString::from_utf8_without_validation("Cannot run invalid statements at compile time"sv)),span))))), JaktInternal::ExplicitValue<void>();
 };/*case end*/
 default: VERIFY_NOT_REACHED();}/*switch end*/
 }()
@@ -15368,7 +15368,7 @@ return JaktInternal::ExplicitValue((Tuple{fields, struct_id}));
 };/*case end*/
 default: {
 {
-utility::panic((ByteString::must_from_utf8("Invalid left-hand side in assignment"sv)));
+utility::panic((ByteString::from_utf8_without_validation("Invalid left-hand side in assignment"sv)));
 }
 };/*case end*/
 }/*switch end*/
@@ -15381,7 +15381,7 @@ utility::panic((ByteString::must_from_utf8("Invalid left-hand side in assignment
 };/*case end*/
 default: {
 {
-utility::panic((ByteString::must_from_utf8("Should not be happening here"sv)));
+utility::panic((ByteString::from_utf8_without_validation("Should not be happening here"sv)));
 }
 };/*case end*/
 }/*switch end*/
@@ -15439,7 +15439,7 @@ return JaktInternal::ExplicitValue((Tuple{fields, enum_id}));
 };/*case end*/
 default: {
 {
-utility::panic((ByteString::must_from_utf8("Invalid left-hand side in assignment"sv)));
+utility::panic((ByteString::from_utf8_without_validation("Invalid left-hand side in assignment"sv)));
 }
 };/*case end*/
 }/*switch end*/
@@ -15452,7 +15452,7 @@ utility::panic((ByteString::must_from_utf8("Invalid left-hand side in assignment
 };/*case end*/
 default: {
 {
-utility::panic((ByteString::must_from_utf8("Should not be happening here"sv)));
+utility::panic((ByteString::from_utf8_without_validation("Should not be happening here"sv)));
 }
 };/*case end*/
 }/*switch end*/
@@ -15603,7 +15603,7 @@ return interpreter::StatementResult::Break();
 case 2 /* Yield */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Yield;types::Value const& expr = __jakt_match_value.value;
 {
-utility::panic((ByteString::must_from_utf8("Invalid control flow"sv)));
+utility::panic((ByteString::from_utf8_without_validation("Invalid control flow"sv)));
 }
 };/*case end*/
 default: VERIFY_NOT_REACHED();}/*switch end*/
@@ -15656,7 +15656,7 @@ return interpreter::StatementResult::Break();
 case 2 /* Yield */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Yield;types::Value const& expr = __jakt_match_value.value;
 {
-utility::panic((ByteString::must_from_utf8("Invalid control flow"sv)));
+utility::panic((ByteString::from_utf8_without_validation("Invalid control flow"sv)));
 }
 };/*case end*/
 default: VERIFY_NOT_REACHED();}/*switch end*/
@@ -15673,7 +15673,7 @@ return JaktInternal::ExplicitValue(value);
 };/*case end*/
 default: {
 {
-utility::panic((ByteString::must_from_utf8("Invalid left-hand side of NoneCoalescing"sv)));
+utility::panic((ByteString::from_utf8_without_validation("Invalid left-hand side of NoneCoalescing"sv)));
 }
 };/*case end*/
 }/*switch end*/
@@ -15723,7 +15723,7 @@ return interpreter::StatementResult::Break();
 case 2 /* Yield */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Yield;types::Value const& expr = __jakt_match_value.value;
 {
-utility::panic((ByteString::must_from_utf8("Invalid control flow"sv)));
+utility::panic((ByteString::from_utf8_without_validation("Invalid control flow"sv)));
 }
 };/*case end*/
 default: VERIFY_NOT_REACHED();}/*switch end*/
@@ -15740,7 +15740,7 @@ return JaktInternal::ExplicitValue(value);
 };/*case end*/
 default: {
 {
-utility::panic((ByteString::must_from_utf8("Invalid left-hand side of NoneCoalescing"sv)));
+utility::panic((ByteString::from_utf8_without_validation("Invalid left-hand side of NoneCoalescing"sv)));
 }
 };/*case end*/
 }/*switch end*/
@@ -15795,7 +15795,7 @@ return interpreter::StatementResult::Break();
 case 2 /* Yield */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Yield;types::Value const& expr = __jakt_match_value.value;
 {
-utility::panic((ByteString::must_from_utf8("Invalid control flow"sv)));
+utility::panic((ByteString::from_utf8_without_validation("Invalid control flow"sv)));
 }
 };/*case end*/
 default: VERIFY_NOT_REACHED();}/*switch end*/
@@ -15873,7 +15873,7 @@ return interpreter::StatementResult::Break();
 case 2 /* Yield */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Yield;types::Value const& expr = __jakt_match_value.value;
 {
-utility::panic((ByteString::must_from_utf8("Invalid control flow"sv)));
+utility::panic((ByteString::from_utf8_without_validation("Invalid control flow"sv)));
 }
 };/*case end*/
 default: VERIFY_NOT_REACHED();}/*switch end*/
@@ -15942,7 +15942,7 @@ return interpreter::StatementResult::Break();
 case 2 /* Yield */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Yield;types::Value const& expr = __jakt_match_value.value;
 {
-utility::panic((ByteString::must_from_utf8("Invalid control flow"sv)));
+utility::panic((ByteString::from_utf8_without_validation("Invalid control flow"sv)));
 }
 };/*case end*/
 default: VERIFY_NOT_REACHED();}/*switch end*/
@@ -16123,7 +16123,7 @@ return interpreter::StatementResult::Break();
 case 2 /* Yield */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Yield;types::Value const& expr = __jakt_match_value.value;
 {
-utility::panic((ByteString::must_from_utf8("Invalid control flow"sv)));
+utility::panic((ByteString::from_utf8_without_validation("Invalid control flow"sv)));
 }
 };/*case end*/
 default: VERIFY_NOT_REACHED();}/*switch end*/
@@ -16786,7 +16786,7 @@ return interpreter::StatementResult::Break();
 case 2 /* Yield */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Yield;types::Value const& expr = __jakt_match_value.value;
 {
-utility::panic((ByteString::must_from_utf8("Invalid control flow"sv)));
+utility::panic((ByteString::from_utf8_without_validation("Invalid control flow"sv)));
 }
 };/*case end*/
 default: VERIFY_NOT_REACHED();}/*switch end*/
@@ -16799,7 +16799,7 @@ default: VERIFY_NOT_REACHED();}/*switch end*/
 }
 else if (__jakt_enum_value == false) {
 {
-TRY((((*this).error((ByteString::must_from_utf8("Partial ranges are not implemented"sv)),span))));
+TRY((((*this).error((ByteString::from_utf8_without_validation("Partial ranges are not implemented"sv)),span))));
 return Error::__jakt_from_string_literal((StringView::from_string_literal("Not yet implemented"sv)));
 }
 }
@@ -16846,7 +16846,7 @@ return interpreter::StatementResult::Break();
 case 2 /* Yield */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Yield;types::Value const& expr = __jakt_match_value.value;
 {
-utility::panic((ByteString::must_from_utf8("Invalid control flow"sv)));
+utility::panic((ByteString::from_utf8_without_validation("Invalid control flow"sv)));
 }
 };/*case end*/
 default: VERIFY_NOT_REACHED();}/*switch end*/
@@ -16859,7 +16859,7 @@ default: VERIFY_NOT_REACHED();}/*switch end*/
 }
 else if (__jakt_enum_value == false) {
 {
-TRY((((*this).error((ByteString::must_from_utf8("Partial ranges are not implemented"sv)),span))));
+TRY((((*this).error((ByteString::from_utf8_without_validation("Partial ranges are not implemented"sv)),span))));
 return Error::__jakt_from_string_literal((StringView::from_string_literal("Not yet implemented"sv)));
 }
 }
@@ -16869,8 +16869,8 @@ VERIFY_NOT_REACHED();
         return _jakt_value.release_return();
     _jakt_value.release_value();
 });
-ids::StructId const range_struct_id = TRY((((((*this).program))->find_struct_in_prelude((ByteString::must_from_utf8("Range"sv))))));
-JaktInternal::DynamicArray<ids::FunctionId> const range_constructors = (TRY((((((*this).program))->find_functions_with_name_in_scope(((((((*this).program))->get_struct(range_struct_id))).scope_id),(ByteString::must_from_utf8("Range"sv)),false,JaktInternal::OptionalNone())))).value());
+ids::StructId const range_struct_id = TRY((((((*this).program))->find_struct_in_prelude((ByteString::from_utf8_without_validation("Range"sv))))));
+JaktInternal::DynamicArray<ids::FunctionId> const range_constructors = (TRY((((((*this).program))->find_functions_with_name_in_scope(((((((*this).program))->get_struct(range_struct_id))).scope_id),(ByteString::from_utf8_without_validation("Range"sv)),false,JaktInternal::OptionalNone())))).value());
 __jakt_var_356 = interpreter::StatementResult::JustValue(types::Value(types::ValueImpl::Struct(DynamicArray<types::Value>::create_with({start, end}),range_struct_id,((range_constructors)[static_cast<i64>(0LL)])),span)); goto __jakt_label_336;
 
 }
@@ -16924,7 +16924,7 @@ return interpreter::StatementResult::Break();
 case 2 /* Yield */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Yield;types::Value const& expr = __jakt_match_value.value;
 {
-utility::panic((ByteString::must_from_utf8("Invalid control flow"sv)));
+utility::panic((ByteString::from_utf8_without_validation("Invalid control flow"sv)));
 }
 };/*case end*/
 default: VERIFY_NOT_REACHED();}/*switch end*/
@@ -16994,7 +16994,7 @@ return interpreter::StatementResult::Break();
 case 2 /* Yield */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Yield;types::Value const& expr = __jakt_match_value.value;
 {
-utility::panic((ByteString::must_from_utf8("Invalid control flow"sv)));
+utility::panic((ByteString::from_utf8_without_validation("Invalid control flow"sv)));
 }
 };/*case end*/
 default: VERIFY_NOT_REACHED();}/*switch end*/
@@ -17092,7 +17092,7 @@ return interpreter::StatementResult::Break();
 case 2 /* Yield */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Yield;types::Value const& expr = __jakt_match_value.value;
 {
-utility::panic((ByteString::must_from_utf8("Invalid control flow"sv)));
+utility::panic((ByteString::from_utf8_without_validation("Invalid control flow"sv)));
 }
 };/*case end*/
 default: VERIFY_NOT_REACHED();}/*switch end*/
@@ -17110,7 +17110,7 @@ switch(__jakt_match_variant.__jakt_init_index()) {
 case 13 /* JaktString */: {
 {
 JaktInternal::DynamicArray<ids::TypeId> const generic_parameters = DynamicArray<ids::TypeId>::create_with({});
-((effective_namespace).push(types::ResolvedNamespace((ByteString::must_from_utf8("String"sv)),JaktInternal::OptionalNone(),generic_parameters)));
+((effective_namespace).push(types::ResolvedNamespace((ByteString::from_utf8_without_validation("String"sv)),JaktInternal::OptionalNone(),generic_parameters)));
 }
 return JaktInternal::ExplicitValue<void>();
 };/*case end*/
@@ -17127,7 +17127,7 @@ return JaktInternal::ExplicitValue(args);
 };/*case end*/
 default: {
 {
-TRY((((*this).error((ByteString::must_from_utf8("Attempted to call a prelude function  on a non-generic array"sv)),((this_argument).span)))));
+TRY((((*this).error((ByteString::from_utf8_without_validation("Attempted to call a prelude function  on a non-generic array"sv)),((this_argument).span)))));
 return Error::__jakt_from_string_literal((StringView::from_string_literal("Invalid type"sv)));
 }
 };/*case end*/
@@ -17138,7 +17138,7 @@ return Error::__jakt_from_string_literal((StringView::from_string_literal("Inval
         return _jakt_value.release_return();
     _jakt_value.release_value();
 });
-((effective_namespace).push(types::ResolvedNamespace((ByteString::must_from_utf8("Array"sv)),JaktInternal::OptionalNone(),generic_parameters)));
+((effective_namespace).push(types::ResolvedNamespace((ByteString::from_utf8_without_validation("Array"sv)),JaktInternal::OptionalNone(),generic_parameters)));
 }
 return JaktInternal::ExplicitValue<void>();
 };/*case end*/
@@ -17155,7 +17155,7 @@ return JaktInternal::ExplicitValue(args);
 };/*case end*/
 default: {
 {
-TRY((((*this).error((ByteString::must_from_utf8("Attempted to call a prelude function  on a non-generic dictionary"sv)),((this_argument).span)))));
+TRY((((*this).error((ByteString::from_utf8_without_validation("Attempted to call a prelude function  on a non-generic dictionary"sv)),((this_argument).span)))));
 return Error::__jakt_from_string_literal((StringView::from_string_literal("Invalid type"sv)));
 }
 };/*case end*/
@@ -17166,7 +17166,7 @@ return Error::__jakt_from_string_literal((StringView::from_string_literal("Inval
         return _jakt_value.release_return();
     _jakt_value.release_value();
 });
-((effective_namespace).push(types::ResolvedNamespace((ByteString::must_from_utf8("Dictionary"sv)),JaktInternal::OptionalNone(),generic_parameters)));
+((effective_namespace).push(types::ResolvedNamespace((ByteString::from_utf8_without_validation("Dictionary"sv)),JaktInternal::OptionalNone(),generic_parameters)));
 }
 return JaktInternal::ExplicitValue<void>();
 };/*case end*/
@@ -17175,10 +17175,10 @@ auto&& __jakt_match_value = __jakt_match_variant.as.JaktSet;ids::TypeId const& t
 {
 if (((((((*this).program))->get_type(type_id)))->__jakt_init_index() == 20 /* GenericInstance */)){
 JaktInternal::DynamicArray<ids::TypeId> const generic_parameters = (((((*this).program))->get_type(type_id)))->as.GenericInstance.args;
-((effective_namespace).push(types::ResolvedNamespace((ByteString::must_from_utf8("Set"sv)),JaktInternal::OptionalNone(),generic_parameters)));
+((effective_namespace).push(types::ResolvedNamespace((ByteString::from_utf8_without_validation("Set"sv)),JaktInternal::OptionalNone(),generic_parameters)));
 }
 else {
-TRY((((*this).error((ByteString::must_from_utf8("Attempted to call a prelude function  on a non-generic set"sv)),((this_argument).span)))));
+TRY((((*this).error((ByteString::from_utf8_without_validation("Attempted to call a prelude function  on a non-generic set"sv)),((this_argument).span)))));
 return Error::__jakt_from_string_literal((StringView::from_string_literal("Invalid type"sv)));
 }
 
@@ -17212,20 +17212,20 @@ return JaktInternal::ExplicitValue<void>();
 case 25 /* OptionalNone */: {
 {
 JaktInternal::DynamicArray<ids::TypeId> const generic_parameters = DynamicArray<ids::TypeId>::create_with({});
-((effective_namespace).push(types::ResolvedNamespace((ByteString::must_from_utf8("Optional"sv)),JaktInternal::OptionalNone(),generic_parameters)));
+((effective_namespace).push(types::ResolvedNamespace((ByteString::from_utf8_without_validation("Optional"sv)),JaktInternal::OptionalNone(),generic_parameters)));
 }
 return JaktInternal::ExplicitValue<void>();
 };/*case end*/
 case 24 /* OptionalSome */: {
 {
 JaktInternal::DynamicArray<ids::TypeId> const generic_parameters = DynamicArray<ids::TypeId>::create_with({});
-((effective_namespace).push(types::ResolvedNamespace((ByteString::must_from_utf8("Optional"sv)),JaktInternal::OptionalNone(),generic_parameters)));
+((effective_namespace).push(types::ResolvedNamespace((ByteString::from_utf8_without_validation("Optional"sv)),JaktInternal::OptionalNone(),generic_parameters)));
 }
 return JaktInternal::ExplicitValue<void>();
 };/*case end*/
 default: {
 {
-TRY((((*this).error((ByteString::must_from_utf8("Attempted to call an instance method on a non-struct/enum type"sv)),((this_argument).span)))));
+TRY((((*this).error((ByteString::from_utf8_without_validation("Attempted to call an instance method on a non-struct/enum type"sv)),((this_argument).span)))));
 return Error::__jakt_from_string_literal((StringView::from_string_literal("Invalid type"sv)));
 }
 return JaktInternal::ExplicitValue<void>();
@@ -17281,7 +17281,7 @@ return interpreter::StatementResult::Break();
 case 2 /* Yield */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Yield;types::Value const& expr = __jakt_match_value.value;
 {
-utility::panic((ByteString::must_from_utf8("Invalid control flow"sv)));
+utility::panic((ByteString::from_utf8_without_validation("Invalid control flow"sv)));
 }
 };/*case end*/
 default: VERIFY_NOT_REACHED();}/*switch end*/
@@ -17346,7 +17346,7 @@ return interpreter::StatementResult::Break();
 case 2 /* Yield */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Yield;types::Value const& expr = __jakt_match_value.value;
 {
-utility::panic((ByteString::must_from_utf8("Invalid control flow"sv)));
+utility::panic((ByteString::from_utf8_without_validation("Invalid control flow"sv)));
 }
 };/*case end*/
 default: VERIFY_NOT_REACHED();}/*switch end*/
@@ -17440,7 +17440,7 @@ return interpreter::StatementResult::Break();
 case 2 /* Yield */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Yield;types::Value const& expr = __jakt_match_value.value;
 {
-utility::panic((ByteString::must_from_utf8("Invalid control flow"sv)));
+utility::panic((ByteString::from_utf8_without_validation("Invalid control flow"sv)));
 }
 };/*case end*/
 default: VERIFY_NOT_REACHED();}/*switch end*/
@@ -17451,7 +17451,7 @@ default: VERIFY_NOT_REACHED();}/*switch end*/
     _jakt_value.release_value();
 });
 if (((((value).impl))->__jakt_init_index() == 25 /* OptionalNone */)){
-TRY((((*this).error((ByteString::must_from_utf8("Attempted to unwrap an optional value that was None"sv)),((value).span)))));
+TRY((((*this).error((ByteString::from_utf8_without_validation("Attempted to unwrap an optional value that was None"sv)),((value).span)))));
 return Error::__jakt_from_string_literal((StringView::from_string_literal("Invalid type"sv)));
 }
 __jakt_var_359 = ({
@@ -17464,7 +17464,7 @@ return JaktInternal::ExplicitValue(interpreter::StatementResult::JustValue(value
 };/*case end*/
 default: {
 {
-TRY((((*this).error((ByteString::must_from_utf8("Invalid type for unwrap"sv)),((value).span)))));
+TRY((((*this).error((ByteString::from_utf8_without_validation("Invalid type for unwrap"sv)),((value).span)))));
 return Error::__jakt_from_string_literal((StringView::from_string_literal("Invalid type"sv)));
 }
 };/*case end*/
@@ -17531,7 +17531,7 @@ return interpreter::StatementResult::Break();
 case 2 /* Yield */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Yield;types::Value const& expr = __jakt_match_value.value;
 {
-utility::panic((ByteString::must_from_utf8("Invalid control flow"sv)));
+utility::panic((ByteString::from_utf8_without_validation("Invalid control flow"sv)));
 }
 };/*case end*/
 default: VERIFY_NOT_REACHED();}/*switch end*/
@@ -17574,7 +17574,7 @@ return interpreter::StatementResult::Break();
 case 2 /* Yield */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Yield;types::Value const& expr = __jakt_match_value.value;
 {
-utility::panic((ByteString::must_from_utf8("Invalid control flow"sv)));
+utility::panic((ByteString::from_utf8_without_validation("Invalid control flow"sv)));
 }
 };/*case end*/
 default: VERIFY_NOT_REACHED();}/*switch end*/
@@ -17633,7 +17633,7 @@ return JaktInternal::ExplicitValue((infallible_integer_cast<u64>((x))));
 };/*case end*/
 default: {
 {
-utility::panic((ByteString::must_from_utf8("Invalid type for repeat"sv)));
+utility::panic((ByteString::from_utf8_without_validation("Invalid type for repeat"sv)));
 }
 };/*case end*/
 }/*switch end*/
@@ -17664,7 +17664,7 @@ __jakt_label_341:; __jakt_var_361.release_value(); }));
 };/*case end*/
 default: {
 {
-TRY((((*this).error((ByteString::must_from_utf8("Invalid or unsupported indexed expression"sv)),span))));
+TRY((((*this).error((ByteString::from_utf8_without_validation("Invalid or unsupported indexed expression"sv)),span))));
 return Error::__jakt_from_string_literal((StringView::from_string_literal("Invalid type"sv)));
 }
 };/*case end*/
@@ -17721,7 +17721,7 @@ return interpreter::StatementResult::Break();
 case 2 /* Yield */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Yield;types::Value const& expr = __jakt_match_value.value;
 {
-utility::panic((ByteString::must_from_utf8("Invalid control flow"sv)));
+utility::panic((ByteString::from_utf8_without_validation("Invalid control flow"sv)));
 }
 };/*case end*/
 default: VERIFY_NOT_REACHED();}/*switch end*/
@@ -17762,7 +17762,7 @@ break;
 }
 
 if ((!(((found_index).has_value())))){
-TRY((((*this).error((ByteString::must_from_utf8("Attempted to access a field that does not exist"sv)),((value).span)))));
+TRY((((*this).error((ByteString::from_utf8_without_validation("Attempted to access a field that does not exist"sv)),((value).span)))));
 return Error::__jakt_from_string_literal((StringView::from_string_literal("Invalid type"sv)));
 }
 __jakt_var_363 = interpreter::StatementResult::JustValue(((fields)[(found_index.value())])); goto __jakt_label_343;
@@ -17797,7 +17797,7 @@ break;
 }
 
 if ((!(((found_index).has_value())))){
-TRY((((*this).error((ByteString::must_from_utf8("Attempted to access a field that does not exist"sv)),((value).span)))));
+TRY((((*this).error((ByteString::from_utf8_without_validation("Attempted to access a field that does not exist"sv)),((value).span)))));
 return Error::__jakt_from_string_literal((StringView::from_string_literal("Invalid type"sv)));
 }
 __jakt_var_364 = interpreter::StatementResult::JustValue(((fields)[(found_index.value())])); goto __jakt_label_344;
@@ -17807,7 +17807,7 @@ __jakt_label_344:; __jakt_var_364.release_value(); }));
 };/*case end*/
 default: {
 {
-TRY((((*this).error((ByteString::must_from_utf8("Attempted to access a field on a non-struct/enum type"sv)),((value).span)))));
+TRY((((*this).error((ByteString::from_utf8_without_validation("Attempted to access a field on a non-struct/enum type"sv)),((value).span)))));
 return Error::__jakt_from_string_literal((StringView::from_string_literal("Invalid type"sv)));
 }
 };/*case end*/
@@ -17859,7 +17859,7 @@ return interpreter::StatementResult::Break();
 case 2 /* Yield */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Yield;types::Value const& expr = __jakt_match_value.value;
 {
-utility::panic((ByteString::must_from_utf8("Invalid control flow"sv)));
+utility::panic((ByteString::from_utf8_without_validation("Invalid control flow"sv)));
 }
 };/*case end*/
 default: VERIFY_NOT_REACHED();}/*switch end*/
@@ -17900,7 +17900,7 @@ break;
 }
 
 if ((!(((found_index).has_value())))){
-TRY((((*this).error((ByteString::must_from_utf8("Attempted to access a field that does not exist"sv)),((value).span)))));
+TRY((((*this).error((ByteString::from_utf8_without_validation("Attempted to access a field that does not exist"sv)),((value).span)))));
 return Error::__jakt_from_string_literal((StringView::from_string_literal("Invalid type"sv)));
 }
 __jakt_var_366 = interpreter::StatementResult::JustValue(((fields)[(found_index.value())])); goto __jakt_label_346;
@@ -17910,7 +17910,7 @@ __jakt_label_346:; __jakt_var_366.release_value(); }));
 };/*case end*/
 default: {
 {
-TRY((((*this).error((ByteString::must_from_utf8("Attempted to access a field on a non-struct/enum type"sv)),((value).span)))));
+TRY((((*this).error((ByteString::from_utf8_without_validation("Attempted to access a field on a non-struct/enum type"sv)),((value).span)))));
 return Error::__jakt_from_string_literal((StringView::from_string_literal("Invalid type"sv)));
 }
 };/*case end*/
@@ -17978,7 +17978,7 @@ return interpreter::StatementResult::Break();
 case 2 /* Yield */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Yield;types::Value const& expr = __jakt_match_value.value;
 {
-utility::panic((ByteString::must_from_utf8("Invalid control flow"sv)));
+utility::panic((ByteString::from_utf8_without_validation("Invalid control flow"sv)));
 }
 };/*case end*/
 default: VERIFY_NOT_REACHED();}/*switch end*/
@@ -18025,7 +18025,7 @@ return interpreter::StatementResult::Break();
 case 2 /* Yield */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Yield;types::Value const& expr = __jakt_match_value.value;
 {
-utility::panic((ByteString::must_from_utf8("Invalid control flow"sv)));
+utility::panic((ByteString::from_utf8_without_validation("Invalid control flow"sv)));
 }
 };/*case end*/
 default: VERIFY_NOT_REACHED();}/*switch end*/
@@ -18129,7 +18129,7 @@ case 24 /* Struct */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Struct;ids::StructId const& struct_id = __jakt_match_value.value;
 return JaktInternal::ExplicitValue(({ Optional<ids::FunctionId> __jakt_var_369; {
 NonnullRefPtr<types::Scope> const scope = ((((*this).program))->get_scope(((((((*this).program))->get_struct(struct_id))).scope_id)));
-JaktInternal::Optional<JaktInternal::DynamicArray<ids::FunctionId>> const overloads = ((((scope)->functions)).get((ByteString::must_from_utf8("from_string_literal"sv))));
+JaktInternal::Optional<JaktInternal::DynamicArray<ids::FunctionId>> const overloads = ((((scope)->functions)).get((ByteString::from_utf8_without_validation("from_string_literal"sv))));
 if ((!(((overloads).has_value())))){
 utility::panic(__jakt_format((StringView::from_string_literal("Failed to find a from_string_literal overload in {}"sv)),TRY((((((*this).program))->type_name(((val).type_id),false))))));
 }
@@ -18142,7 +18142,7 @@ case 20 /* GenericInstance */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.GenericInstance;ids::StructId const& struct_id = __jakt_match_value.id;
 return JaktInternal::ExplicitValue(({ Optional<ids::FunctionId> __jakt_var_370; {
 NonnullRefPtr<types::Scope> const scope = ((((*this).program))->get_scope(((((((*this).program))->get_struct(struct_id))).scope_id)));
-JaktInternal::Optional<JaktInternal::DynamicArray<ids::FunctionId>> const overloads = ((((scope)->functions)).get((ByteString::must_from_utf8("from_string_literal"sv))));
+JaktInternal::Optional<JaktInternal::DynamicArray<ids::FunctionId>> const overloads = ((((scope)->functions)).get((ByteString::from_utf8_without_validation("from_string_literal"sv))));
 if ((!(((overloads).has_value())))){
 utility::panic(__jakt_format((StringView::from_string_literal("Failed to find a from_string_literal overload in {}"sv)),TRY((((((*this).program))->type_name(((val).type_id),false))))));
 }
@@ -18155,9 +18155,9 @@ case 25 /* Enum */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Enum;ids::EnumId const& enum_id = __jakt_match_value.value;
 return JaktInternal::ExplicitValue(({ Optional<ids::FunctionId> __jakt_var_371; {
 NonnullRefPtr<types::Scope> const scope = ((((*this).program))->get_scope(((((((*this).program))->get_enum(enum_id))).scope_id)));
-JaktInternal::Optional<JaktInternal::DynamicArray<ids::FunctionId>> const overloads = ((((scope)->functions)).get((ByteString::must_from_utf8("from_string_literal"sv))));
+JaktInternal::Optional<JaktInternal::DynamicArray<ids::FunctionId>> const overloads = ((((scope)->functions)).get((ByteString::from_utf8_without_validation("from_string_literal"sv))));
 if ((!(((overloads).has_value())))){
-utility::panic((ByteString::must_from_utf8("Failed to find a from_string_literal overload"sv)));
+utility::panic((ByteString::from_utf8_without_validation("Failed to find a from_string_literal overload"sv)));
 }
 __jakt_var_371 = ((((overloads.value())).first()).value()); goto __jakt_label_351;
 
@@ -18168,9 +18168,9 @@ case 21 /* GenericEnumInstance */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.GenericEnumInstance;ids::EnumId const& enum_id = __jakt_match_value.id;
 return JaktInternal::ExplicitValue(({ Optional<ids::FunctionId> __jakt_var_372; {
 NonnullRefPtr<types::Scope> const scope = ((((*this).program))->get_scope(((((((*this).program))->get_enum(enum_id))).scope_id)));
-JaktInternal::Optional<JaktInternal::DynamicArray<ids::FunctionId>> const overloads = ((((scope)->functions)).get((ByteString::must_from_utf8("from_string_literal"sv))));
+JaktInternal::Optional<JaktInternal::DynamicArray<ids::FunctionId>> const overloads = ((((scope)->functions)).get((ByteString::from_utf8_without_validation("from_string_literal"sv))));
 if ((!(((overloads).has_value())))){
-utility::panic((ByteString::must_from_utf8("Failed to find a from_string_literal overload"sv)));
+utility::panic((ByteString::from_utf8_without_validation("Failed to find a from_string_literal overload"sv)));
 }
 __jakt_var_372 = ((((overloads.value())).first()).value()); goto __jakt_label_352;
 
@@ -18233,7 +18233,7 @@ return JaktInternal::ExplicitValue(({ Optional<interpreter::StatementResult> __j
 DeprecatedStringCodePointIterator code_points = ((val).code_points());
 JaktInternal::Optional<u32> const code_point = ((code_points).next());
 if ((!(((code_point).has_value())))){
-TRY((((*this).error((ByteString::must_from_utf8("Invalid character constant"sv)),span))));
+TRY((((*this).error((ByteString::from_utf8_without_validation("Invalid character constant"sv)),span))));
 return Error::__jakt_from_string_literal((StringView::from_string_literal("Invalid character constant"sv)));
 }
 __jakt_var_373 = interpreter::StatementResult::JustValue(types::Value(types::ValueImpl::U32((code_point.value())),span)); goto __jakt_label_353;
@@ -18311,7 +18311,7 @@ return JaktInternal::ExplicitValue((infallible_integer_cast<size_t>((x))));
 };/*case end*/
 default: {
 {
-utility::panic((ByteString::must_from_utf8("Invalid type for repeat"sv)));
+utility::panic((ByteString::from_utf8_without_validation("Invalid type for repeat"sv)));
 }
 };/*case end*/
 }/*switch end*/
@@ -18335,7 +18335,7 @@ return interpreter::StatementResult::Break();
 case 2 /* Yield */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Yield;types::Value const& expr = __jakt_match_value.value;
 {
-utility::panic((ByteString::must_from_utf8("Invalid control flow"sv)));
+utility::panic((ByteString::from_utf8_without_validation("Invalid control flow"sv)));
 }
 };/*case end*/
 default: VERIFY_NOT_REACHED();}/*switch end*/
@@ -18378,7 +18378,7 @@ return interpreter::StatementResult::Break();
 case 2 /* Yield */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Yield;types::Value const& expr = __jakt_match_value.value;
 {
-utility::panic((ByteString::must_from_utf8("Invalid control flow"sv)));
+utility::panic((ByteString::from_utf8_without_validation("Invalid control flow"sv)));
 }
 };/*case end*/
 default: VERIFY_NOT_REACHED();}/*switch end*/
@@ -18438,7 +18438,7 @@ return interpreter::StatementResult::Break();
 case 2 /* Yield */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Yield;types::Value const& expr = __jakt_match_value.value;
 {
-utility::panic((ByteString::must_from_utf8("Invalid control flow"sv)));
+utility::panic((ByteString::from_utf8_without_validation("Invalid control flow"sv)));
 }
 };/*case end*/
 default: VERIFY_NOT_REACHED();}/*switch end*/
@@ -18505,7 +18505,7 @@ return interpreter::StatementResult::Break();
 };/*case end*/
 case 2 /* Yield */: {
 {
-utility::panic((ByteString::must_from_utf8("Invalid control flow"sv)));
+utility::panic((ByteString::from_utf8_without_validation("Invalid control flow"sv)));
 }
 };/*case end*/
 default: VERIFY_NOT_REACHED();}/*switch end*/
@@ -18528,7 +18528,7 @@ __jakt_label_357:; __jakt_var_377.release_value(); }));
 }
 else {
 {
-utility::panic((ByteString::must_from_utf8("expected tuple"sv)));
+utility::panic((ByteString::from_utf8_without_validation("expected tuple"sv)));
 }
 }
 }());
@@ -18578,7 +18578,7 @@ return interpreter::StatementResult::Break();
 };/*case end*/
 case 2 /* Yield */: {
 {
-utility::panic((ByteString::must_from_utf8("Invalid control flow"sv)));
+utility::panic((ByteString::from_utf8_without_validation("Invalid control flow"sv)));
 }
 };/*case end*/
 default: VERIFY_NOT_REACHED();}/*switch end*/
@@ -18642,7 +18642,7 @@ return JaktInternal::ExplicitValue<void>();
 case 2 /* ClassInstance */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.ClassInstance;utility::Span const& marker_span = __jakt_match_value.marker_span;
 {
-TRY((((*this).error((ByteString::must_from_utf8("Value matches are not allowed on enums"sv)),marker_span))));
+TRY((((*this).error((ByteString::from_utf8_without_validation("Value matches are not allowed on enums"sv)),marker_span))));
 return Error::__jakt_from_string_literal((StringView::from_string_literal("Invalid type"sv)));
 }
 return JaktInternal::ExplicitValue<void>();
@@ -18650,7 +18650,7 @@ return JaktInternal::ExplicitValue<void>();
 case 1 /* Expression */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Expression;utility::Span const& marker_span = __jakt_match_value.marker_span;
 {
-TRY((((*this).error((ByteString::must_from_utf8("Value matches are not allowed on enums"sv)),marker_span))));
+TRY((((*this).error((ByteString::from_utf8_without_validation("Value matches are not allowed on enums"sv)),marker_span))));
 return Error::__jakt_from_string_literal((StringView::from_string_literal("Invalid type"sv)));
 }
 return JaktInternal::ExplicitValue<void>();
@@ -18682,7 +18682,7 @@ default: VERIFY_NOT_REACHED();}/*switch end*/
 }
 
 if (((!(((catch_all_case).has_value()))) && (!(((found_body).has_value()))))){
-TRY((((*this).error((ByteString::must_from_utf8("Match is not exhaustive"sv)),(span.value())))));
+TRY((((*this).error((ByteString::from_utf8_without_validation("Match is not exhaustive"sv)),(span.value())))));
 return Error::__jakt_from_string_literal((StringView::from_string_literal("Invalid type"sv)));
 }
 (found_body = found_body.value_or_lazy_evaluated([&] { return (catch_all_case.value()); }));
@@ -18922,7 +18922,7 @@ return interpreter::StatementResult::Break();
 };/*case end*/
 case 2 /* Yield */: {
 {
-utility::panic((ByteString::must_from_utf8("Invalid control flow"sv)));
+utility::panic((ByteString::from_utf8_without_validation("Invalid control flow"sv)));
 }
 };/*case end*/
 default: VERIFY_NOT_REACHED();}/*switch end*/
@@ -18957,7 +18957,7 @@ return JaktInternal::ExplicitValue<void>();
 case 2 /* ClassInstance */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.ClassInstance;utility::Span const& marker_span = __jakt_match_value.marker_span;
 {
-TRY((((*this).error((ByteString::must_from_utf8("Class instance matches are not implemented yet"sv)),marker_span))));
+TRY((((*this).error((ByteString::from_utf8_without_validation("Class instance matches are not implemented yet"sv)),marker_span))));
 return Error::__jakt_from_string_literal((StringView::from_string_literal("Invalid type"sv)));
 }
 return JaktInternal::ExplicitValue<void>();
@@ -19135,7 +19135,7 @@ return interpreter::StatementResult::Break();
 };/*case end*/
 case 2 /* Yield */: {
 {
-utility::panic((ByteString::must_from_utf8("Invalid control flow"sv)));
+utility::panic((ByteString::from_utf8_without_validation("Invalid control flow"sv)));
 }
 };/*case end*/
 default: VERIFY_NOT_REACHED();}/*switch end*/
@@ -19287,7 +19287,7 @@ return interpreter::StatementResult::Break();
 };/*case end*/
 case 2 /* Yield */: {
 {
-utility::panic((ByteString::must_from_utf8("Invalid control flow"sv)));
+utility::panic((ByteString::from_utf8_without_validation("Invalid control flow"sv)));
 }
 };/*case end*/
 default: VERIFY_NOT_REACHED();}/*switch end*/
@@ -19360,7 +19360,7 @@ return interpreter::StatementResult::Break();
 case 2 /* Yield */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Yield;types::Value const& expr = __jakt_match_value.value;
 {
-utility::panic((ByteString::must_from_utf8("Invalid control flow"sv)));
+utility::panic((ByteString::from_utf8_without_validation("Invalid control flow"sv)));
 }
 };/*case end*/
 default: VERIFY_NOT_REACHED();}/*switch end*/
@@ -19595,7 +19595,7 @@ return JaktInternal::ExplicitValue<void>();
 };/*case end*/
 case 2 /* Yield */: {
 {
-utility::panic((ByteString::must_from_utf8("Invalid control flow"sv)));
+utility::panic((ByteString::from_utf8_without_validation("Invalid control flow"sv)));
 }
 return JaktInternal::ExplicitValue<void>();
 };/*case end*/
@@ -19634,7 +19634,7 @@ return Error::__jakt_from_string_literal((StringView::from_string_literal("Not y
 
 ErrorOr<ids::TypeId> interpreter::Interpreter::array_type_of_struct(ids::StructId const struct_id) {
 {
-ids::StructId const array_struct_id = TRY((((((*this).program))->find_struct_in_prelude((ByteString::must_from_utf8("Array"sv))))));
+ids::StructId const array_struct_id = TRY((((((*this).program))->find_struct_in_prelude((ByteString::from_utf8_without_validation("Array"sv))))));
 NonnullRefPtr<typename types::Type> const type = types::Type::GenericInstance(parser::CheckedQualifiers(false),array_struct_id,DynamicArray<ids::TypeId>::create_with({((((((*this).program))->get_struct(struct_id))).type_id)}));
 return ((*this).find_or_add_type_id(type));
 }
@@ -19642,7 +19642,7 @@ return ((*this).find_or_add_type_id(type));
 
 ErrorOr<types::Value> interpreter::Interpreter::array_value_of_type(JaktInternal::DynamicArray<types::Value> const values,ids::TypeId const type,utility::Span const span) {
 {
-ids::StructId const array_struct_id = TRY((((((*this).program))->find_struct_in_prelude((ByteString::must_from_utf8("Array"sv))))));
+ids::StructId const array_struct_id = TRY((((((*this).program))->find_struct_in_prelude((ByteString::from_utf8_without_validation("Array"sv))))));
 NonnullRefPtr<typename types::Type> const array_type = types::Type::GenericInstance(parser::CheckedQualifiers(false),array_struct_id,DynamicArray<ids::TypeId>::create_with({type}));
 ids::TypeId const array_type_id = ((*this).find_or_add_type_id(array_type));
 return types::Value(types::ValueImpl::JaktArray(values,array_type_id),span);
@@ -19651,7 +19651,7 @@ return types::Value(types::ValueImpl::JaktArray(values,array_type_id),span);
 
 ErrorOr<ids::TypeId> interpreter::Interpreter::tuple_type(JaktInternal::DynamicArray<ids::TypeId> const members) {
 {
-ids::StructId const tuple_struct_id = TRY((((((*this).program))->find_struct_in_prelude((ByteString::must_from_utf8("Tuple"sv))))));
+ids::StructId const tuple_struct_id = TRY((((((*this).program))->find_struct_in_prelude((ByteString::from_utf8_without_validation("Tuple"sv))))));
 NonnullRefPtr<typename types::Type> const type = types::Type::GenericInstance(parser::CheckedQualifiers(false),tuple_struct_id,members);
 return ((*this).find_or_add_type_id(type));
 }
@@ -19671,15 +19671,15 @@ return types::Value(types::ValueImpl::Bool(value),span);
 
 ErrorOr<types::Value> interpreter::Interpreter::error_value(ByteString const string,utility::Span const span) {
 {
-ids::StructId const struct_id = TRY((((((*this).program))->find_struct_in_prelude((ByteString::must_from_utf8("Error"sv))))));
-ids::FunctionId const constructor = (TRY((((((*this).program))->find_function_in_scope(((((((*this).program))->get_struct(struct_id))).scope_id),(ByteString::must_from_utf8("from_string_literal"sv)),JaktInternal::OptionalNone())))).value());
+ids::StructId const struct_id = TRY((((((*this).program))->find_struct_in_prelude((ByteString::from_utf8_without_validation("Error"sv))))));
+ids::FunctionId const constructor = (TRY((((((*this).program))->find_function_in_scope(((((((*this).program))->get_struct(struct_id))).scope_id),(ByteString::from_utf8_without_validation("from_string_literal"sv)),JaktInternal::OptionalNone())))).value());
 return types::Value(types::ValueImpl::Struct(DynamicArray<types::Value>::create_with({TRY((((*this).string_value(string,span))))}),struct_id,constructor),span);
 }
 }
 
 ErrorOr<ids::TypeId> interpreter::Interpreter::string_type() {
 {
-ids::StructId const string_struct_id = TRY((((((*this).program))->find_struct_in_prelude((ByteString::must_from_utf8("String"sv))))));
+ids::StructId const string_struct_id = TRY((((((*this).program))->find_struct_in_prelude((ByteString::from_utf8_without_validation("String"sv))))));
 NonnullRefPtr<typename types::Type> const type = types::Type::Struct(parser::CheckedQualifiers(false),string_struct_id);
 return ((*this).find_or_add_type_id(type));
 }
@@ -19703,7 +19703,7 @@ return JaktInternal::ExplicitValue(x);
 };/*case end*/
 default: {
 {
-TRY((((*this).error((ByteString::must_from_utf8("Expected string value"sv)),((value).span)))));
+TRY((((*this).error((ByteString::from_utf8_without_validation("Expected string value"sv)),((value).span)))));
 return Error::__jakt_from_string_literal((StringView::from_string_literal("Invalid type"sv)));
 }
 };/*case end*/
@@ -19721,7 +19721,7 @@ ErrorOr<types::Value> interpreter::Interpreter::reflect_methods(ids::ScopeId con
 {
 ids::StructId const method_struct_id = ({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<ids::StructId, ErrorOr<types::Value>>{
-auto&& __jakt_match_variant = TRY((((((*this).program))->find_reflected_primitive((ByteString::must_from_utf8("Method"sv))))));
+auto&& __jakt_match_variant = TRY((((((*this).program))->find_reflected_primitive((ByteString::from_utf8_without_validation("Method"sv))))));
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 0 /* Struct */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Struct;ids::StructId const& id = __jakt_match_value.value;
@@ -19729,7 +19729,7 @@ return JaktInternal::ExplicitValue(id);
 };/*case end*/
 default: {
 {
-utility::panic((ByteString::must_from_utf8("Expected Method to be a struct"sv)));
+utility::panic((ByteString::from_utf8_without_validation("Expected Method to be a struct"sv)));
 }
 };/*case end*/
 }/*switch end*/
@@ -19741,7 +19741,7 @@ utility::panic((ByteString::must_from_utf8("Expected Method to be a struct"sv)))
 });
 ids::StructId const function_struct_id = ({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<ids::StructId, ErrorOr<types::Value>>{
-auto&& __jakt_match_variant = TRY((((((*this).program))->find_reflected_primitive((ByteString::must_from_utf8("Function"sv))))));
+auto&& __jakt_match_variant = TRY((((((*this).program))->find_reflected_primitive((ByteString::from_utf8_without_validation("Function"sv))))));
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 0 /* Struct */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Struct;ids::StructId const& id = __jakt_match_value.value;
@@ -19749,7 +19749,7 @@ return JaktInternal::ExplicitValue(id);
 };/*case end*/
 default: {
 {
-utility::panic((ByteString::must_from_utf8("Expected Function to be a struct"sv)));
+utility::panic((ByteString::from_utf8_without_validation("Expected Function to be a struct"sv)));
 }
 };/*case end*/
 }/*switch end*/
@@ -19759,11 +19759,11 @@ utility::panic((ByteString::must_from_utf8("Expected Function to be a struct"sv)
         return _jakt_value.release_return();
     _jakt_value.release_value();
 });
-ids::FunctionId const method_struct_constructor = (TRY((((((*this).program))->find_function_in_scope(((((((*this).program))->get_struct(method_struct_id))).scope_id),(ByteString::must_from_utf8("Method"sv)),JaktInternal::OptionalNone())))).value());
-ids::FunctionId const function_struct_constructor = (TRY((((((*this).program))->find_function_in_scope(((((((*this).program))->get_struct(function_struct_id))).scope_id),(ByteString::must_from_utf8("Function"sv)),JaktInternal::OptionalNone())))).value());
+ids::FunctionId const method_struct_constructor = (TRY((((((*this).program))->find_function_in_scope(((((((*this).program))->get_struct(method_struct_id))).scope_id),(ByteString::from_utf8_without_validation("Method"sv)),JaktInternal::OptionalNone())))).value());
+ids::FunctionId const function_struct_constructor = (TRY((((((*this).program))->find_function_in_scope(((((((*this).program))->get_struct(function_struct_id))).scope_id),(ByteString::from_utf8_without_validation("Function"sv)),JaktInternal::OptionalNone())))).value());
 ids::TypeId const type_type_id = ({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<ids::TypeId, ErrorOr<types::Value>>{
-auto&& __jakt_match_variant = TRY((((((*this).program))->find_reflected_primitive((ByteString::must_from_utf8("Type"sv))))));
+auto&& __jakt_match_variant = TRY((((((*this).program))->find_reflected_primitive((ByteString::from_utf8_without_validation("Type"sv))))));
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 1 /* Enum */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Enum;ids::EnumId const& id = __jakt_match_value.value;
@@ -19771,7 +19771,7 @@ return JaktInternal::ExplicitValue(((((((*this).program))->get_enum(id))).type_i
 };/*case end*/
 default: {
 {
-utility::panic((ByteString::must_from_utf8("Expected Type to be an enum"sv)));
+utility::panic((ByteString::from_utf8_without_validation("Expected Type to be an enum"sv)));
 }
 };/*case end*/
 }/*switch end*/
@@ -19826,7 +19826,7 @@ ErrorOr<JaktInternal::DynamicArray<types::Value>> interpreter::Interpreter::refl
 {
 ids::StructId const field_struct_id = ({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<ids::StructId, ErrorOr<JaktInternal::DynamicArray<types::Value>>>{
-auto&& __jakt_match_variant = TRY((((((*this).program))->find_reflected_primitive((ByteString::must_from_utf8("Field"sv))))));
+auto&& __jakt_match_variant = TRY((((((*this).program))->find_reflected_primitive((ByteString::from_utf8_without_validation("Field"sv))))));
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 0 /* Struct */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Struct;ids::StructId const& id = __jakt_match_value.value;
@@ -19834,7 +19834,7 @@ return JaktInternal::ExplicitValue(id);
 };/*case end*/
 default: {
 {
-utility::panic((ByteString::must_from_utf8("Expected Field to be a struct"sv)));
+utility::panic((ByteString::from_utf8_without_validation("Expected Field to be a struct"sv)));
 }
 };/*case end*/
 }/*switch end*/
@@ -19844,10 +19844,10 @@ utility::panic((ByteString::must_from_utf8("Expected Field to be a struct"sv)));
         return _jakt_value.release_return();
     _jakt_value.release_value();
 });
-ids::FunctionId const field_struct_constructor = (TRY((((((*this).program))->find_function_in_scope(((((((*this).program))->get_struct(field_struct_id))).scope_id),(ByteString::must_from_utf8("Field"sv)),JaktInternal::OptionalNone())))).value());
+ids::FunctionId const field_struct_constructor = (TRY((((((*this).program))->find_function_in_scope(((((((*this).program))->get_struct(field_struct_id))).scope_id),(ByteString::from_utf8_without_validation("Field"sv)),JaktInternal::OptionalNone())))).value());
 ids::EnumId const visibility_enum_id = ({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<ids::EnumId, ErrorOr<JaktInternal::DynamicArray<types::Value>>>{
-auto&& __jakt_match_variant = TRY((((((*this).program))->find_reflected_primitive((ByteString::must_from_utf8("Visibility"sv))))));
+auto&& __jakt_match_variant = TRY((((((*this).program))->find_reflected_primitive((ByteString::from_utf8_without_validation("Visibility"sv))))));
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 1 /* Enum */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Enum;ids::EnumId const& id = __jakt_match_value.value;
@@ -19855,7 +19855,7 @@ return JaktInternal::ExplicitValue(id);
 };/*case end*/
 default: {
 {
-utility::panic((ByteString::must_from_utf8("Expected Visibility to be an enum"sv)));
+utility::panic((ByteString::from_utf8_without_validation("Expected Visibility to be an enum"sv)));
 }
 };/*case end*/
 }/*switch end*/
@@ -19865,11 +19865,11 @@ utility::panic((ByteString::must_from_utf8("Expected Visibility to be an enum"sv
         return _jakt_value.release_return();
     _jakt_value.release_value();
 });
-ids::FunctionId const visibility_public_constructor = (TRY((((((*this).program))->find_function_in_scope(((((((*this).program))->get_enum(visibility_enum_id))).scope_id),(ByteString::must_from_utf8("Public"sv)),JaktInternal::OptionalNone())))).value());
-ids::FunctionId const visibility_private_constructor = (TRY((((((*this).program))->find_function_in_scope(((((((*this).program))->get_enum(visibility_enum_id))).scope_id),(ByteString::must_from_utf8("Private"sv)),JaktInternal::OptionalNone())))).value());
+ids::FunctionId const visibility_public_constructor = (TRY((((((*this).program))->find_function_in_scope(((((((*this).program))->get_enum(visibility_enum_id))).scope_id),(ByteString::from_utf8_without_validation("Public"sv)),JaktInternal::OptionalNone())))).value());
+ids::FunctionId const visibility_private_constructor = (TRY((((((*this).program))->find_function_in_scope(((((((*this).program))->get_enum(visibility_enum_id))).scope_id),(ByteString::from_utf8_without_validation("Private"sv)),JaktInternal::OptionalNone())))).value());
 ids::StructId const variable_declaration_struct_id = ({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<ids::StructId, ErrorOr<JaktInternal::DynamicArray<types::Value>>>{
-auto&& __jakt_match_variant = TRY((((((*this).program))->find_reflected_primitive((ByteString::must_from_utf8("VariableDeclaration"sv))))));
+auto&& __jakt_match_variant = TRY((((((*this).program))->find_reflected_primitive((ByteString::from_utf8_without_validation("VariableDeclaration"sv))))));
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 0 /* Struct */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Struct;ids::StructId const& id = __jakt_match_value.value;
@@ -19877,7 +19877,7 @@ return JaktInternal::ExplicitValue(id);
 };/*case end*/
 default: {
 {
-utility::panic((ByteString::must_from_utf8("Expected VariableDeclaration to be a struct"sv)));
+utility::panic((ByteString::from_utf8_without_validation("Expected VariableDeclaration to be a struct"sv)));
 }
 };/*case end*/
 }/*switch end*/
@@ -19887,7 +19887,7 @@ utility::panic((ByteString::must_from_utf8("Expected VariableDeclaration to be a
         return _jakt_value.release_return();
     _jakt_value.release_value();
 });
-ids::FunctionId const variable_declaration_struct_constructor = (TRY((((((*this).program))->find_function_in_scope(((((((*this).program))->get_struct(variable_declaration_struct_id))).scope_id),(ByteString::must_from_utf8("VariableDeclaration"sv)),JaktInternal::OptionalNone())))).value());
+ids::FunctionId const variable_declaration_struct_constructor = (TRY((((((*this).program))->find_function_in_scope(((((((*this).program))->get_struct(variable_declaration_struct_id))).scope_id),(ByteString::from_utf8_without_validation("VariableDeclaration"sv)),JaktInternal::OptionalNone())))).value());
 JaktInternal::DynamicArray<types::Value> record_type_fields = DynamicArray<types::Value>::create_with({});
 {
 JaktInternal::ArrayIterator<ids::VarId> _magic = ((fields).iterator());
@@ -19912,7 +19912,7 @@ return JaktInternal::ExplicitValue(visibility_private_constructor);
 };/*case end*/
 default: {
 {
-utility::panic((ByteString::must_from_utf8("Not implemented"sv)));
+utility::panic((ByteString::from_utf8_without_validation("Not implemented"sv)));
 }
 };/*case end*/
 }/*switch end*/
@@ -19940,7 +19940,7 @@ ErrorOr<JaktInternal::DynamicArray<types::Value>> interpreter::Interpreter::refl
 {
 ids::EnumId const sum_enum_variant_enum_id = ({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<ids::EnumId, ErrorOr<JaktInternal::DynamicArray<types::Value>>>{
-auto&& __jakt_match_variant = TRY((((((*this).program))->find_reflected_primitive((ByteString::must_from_utf8("SumEnumVariant"sv))))));
+auto&& __jakt_match_variant = TRY((((((*this).program))->find_reflected_primitive((ByteString::from_utf8_without_validation("SumEnumVariant"sv))))));
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 1 /* Enum */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Enum;ids::EnumId const& id = __jakt_match_value.value;
@@ -19948,7 +19948,7 @@ return JaktInternal::ExplicitValue(id);
 };/*case end*/
 default: {
 {
-utility::panic((ByteString::must_from_utf8("Expected SumEnumVariant to be an enum"sv)));
+utility::panic((ByteString::from_utf8_without_validation("Expected SumEnumVariant to be an enum"sv)));
 }
 };/*case end*/
 }/*switch end*/
@@ -19958,12 +19958,12 @@ utility::panic((ByteString::must_from_utf8("Expected SumEnumVariant to be an enu
         return _jakt_value.release_return();
     _jakt_value.release_value();
 });
-ids::FunctionId const typed_variant_constructor = (TRY((((((*this).program))->find_function_in_scope(((((((*this).program))->get_enum(sum_enum_variant_enum_id))).scope_id),(ByteString::must_from_utf8("Typed"sv)),JaktInternal::OptionalNone())))).value());
-ids::FunctionId const struct_like_variant_constructor = (TRY((((((*this).program))->find_function_in_scope(((((((*this).program))->get_enum(sum_enum_variant_enum_id))).scope_id),(ByteString::must_from_utf8("StructLike"sv)),JaktInternal::OptionalNone())))).value());
-ids::FunctionId const untyped_variant_constructor = (TRY((((((*this).program))->find_function_in_scope(((((((*this).program))->get_enum(sum_enum_variant_enum_id))).scope_id),(ByteString::must_from_utf8("Untyped"sv)),JaktInternal::OptionalNone())))).value());
+ids::FunctionId const typed_variant_constructor = (TRY((((((*this).program))->find_function_in_scope(((((((*this).program))->get_enum(sum_enum_variant_enum_id))).scope_id),(ByteString::from_utf8_without_validation("Typed"sv)),JaktInternal::OptionalNone())))).value());
+ids::FunctionId const struct_like_variant_constructor = (TRY((((((*this).program))->find_function_in_scope(((((((*this).program))->get_enum(sum_enum_variant_enum_id))).scope_id),(ByteString::from_utf8_without_validation("StructLike"sv)),JaktInternal::OptionalNone())))).value());
+ids::FunctionId const untyped_variant_constructor = (TRY((((((*this).program))->find_function_in_scope(((((((*this).program))->get_enum(sum_enum_variant_enum_id))).scope_id),(ByteString::from_utf8_without_validation("Untyped"sv)),JaktInternal::OptionalNone())))).value());
 ids::StructId const field_struct_id = ({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<ids::StructId, ErrorOr<JaktInternal::DynamicArray<types::Value>>>{
-auto&& __jakt_match_variant = TRY((((((*this).program))->find_reflected_primitive((ByteString::must_from_utf8("Field"sv))))));
+auto&& __jakt_match_variant = TRY((((((*this).program))->find_reflected_primitive((ByteString::from_utf8_without_validation("Field"sv))))));
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 0 /* Struct */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Struct;ids::StructId const& id = __jakt_match_value.value;
@@ -19971,7 +19971,7 @@ return JaktInternal::ExplicitValue(id);
 };/*case end*/
 default: {
 {
-utility::panic((ByteString::must_from_utf8("Expected Field to be a struct"sv)));
+utility::panic((ByteString::from_utf8_without_validation("Expected Field to be a struct"sv)));
 }
 };/*case end*/
 }/*switch end*/
@@ -20061,7 +20061,7 @@ ScopeGuard __jakt_var_396([&] {
 NonnullRefPtr<typename types::Type> const type = ((((*this).program))->get_type(mapped_type_id));
 ids::EnumId const reflected_enum_id = ({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<ids::EnumId, ErrorOr<types::Value>>{
-auto&& __jakt_match_variant = TRY((((((*this).program))->find_reflected_primitive((ByteString::must_from_utf8("Type"sv))))));
+auto&& __jakt_match_variant = TRY((((((*this).program))->find_reflected_primitive((ByteString::from_utf8_without_validation("Type"sv))))));
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 1 /* Enum */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Enum;ids::EnumId const& id = __jakt_match_value.value;
@@ -20069,7 +20069,7 @@ return JaktInternal::ExplicitValue(id);
 };/*case end*/
 default: {
 {
-utility::panic((ByteString::must_from_utf8("Expected Reflect::Type to be an enum"sv)));
+utility::panic((ByteString::from_utf8_without_validation("Expected Reflect::Type to be an enum"sv)));
 }
 };/*case end*/
 }/*switch end*/
@@ -20091,7 +20091,7 @@ case 0 /* Void */: {
 return JaktInternal::ExplicitValue(({ Optional<ids::FunctionId> __jakt_var_397; {
 JaktInternal::Optional<ids::FunctionId> const constructor = TRY((((((*this).program))->find_function_in_scope(((((((*this).program))->get_enum(reflected_enum_id))).scope_id),((type)->constructor_name()),JaktInternal::OptionalNone()))));
 if ((!(((constructor).has_value())))){
-TRY((((*this).error((ByteString::must_from_utf8("Attempted to access a variant that does not exist"sv)),span))));
+TRY((((*this).error((ByteString::from_utf8_without_validation("Attempted to access a variant that does not exist"sv)),span))));
 return Error::__jakt_from_string_literal((StringView::from_string_literal("Invalid type"sv)));
 }
 __jakt_var_397 = (constructor.value()); goto __jakt_label_373;
@@ -20103,7 +20103,7 @@ case 6 /* I8 */: {
 return JaktInternal::ExplicitValue(({ Optional<ids::FunctionId> __jakt_var_398; {
 JaktInternal::Optional<ids::FunctionId> const constructor = TRY((((((*this).program))->find_function_in_scope(((((((*this).program))->get_enum(reflected_enum_id))).scope_id),((type)->constructor_name()),JaktInternal::OptionalNone()))));
 if ((!(((constructor).has_value())))){
-TRY((((*this).error((ByteString::must_from_utf8("Attempted to access a variant that does not exist"sv)),span))));
+TRY((((*this).error((ByteString::from_utf8_without_validation("Attempted to access a variant that does not exist"sv)),span))));
 return Error::__jakt_from_string_literal((StringView::from_string_literal("Invalid type"sv)));
 }
 __jakt_var_398 = (constructor.value()); goto __jakt_label_374;
@@ -20115,7 +20115,7 @@ case 7 /* I16 */: {
 return JaktInternal::ExplicitValue(({ Optional<ids::FunctionId> __jakt_var_399; {
 JaktInternal::Optional<ids::FunctionId> const constructor = TRY((((((*this).program))->find_function_in_scope(((((((*this).program))->get_enum(reflected_enum_id))).scope_id),((type)->constructor_name()),JaktInternal::OptionalNone()))));
 if ((!(((constructor).has_value())))){
-TRY((((*this).error((ByteString::must_from_utf8("Attempted to access a variant that does not exist"sv)),span))));
+TRY((((*this).error((ByteString::from_utf8_without_validation("Attempted to access a variant that does not exist"sv)),span))));
 return Error::__jakt_from_string_literal((StringView::from_string_literal("Invalid type"sv)));
 }
 __jakt_var_399 = (constructor.value()); goto __jakt_label_375;
@@ -20127,7 +20127,7 @@ case 8 /* I32 */: {
 return JaktInternal::ExplicitValue(({ Optional<ids::FunctionId> __jakt_var_400; {
 JaktInternal::Optional<ids::FunctionId> const constructor = TRY((((((*this).program))->find_function_in_scope(((((((*this).program))->get_enum(reflected_enum_id))).scope_id),((type)->constructor_name()),JaktInternal::OptionalNone()))));
 if ((!(((constructor).has_value())))){
-TRY((((*this).error((ByteString::must_from_utf8("Attempted to access a variant that does not exist"sv)),span))));
+TRY((((*this).error((ByteString::from_utf8_without_validation("Attempted to access a variant that does not exist"sv)),span))));
 return Error::__jakt_from_string_literal((StringView::from_string_literal("Invalid type"sv)));
 }
 __jakt_var_400 = (constructor.value()); goto __jakt_label_376;
@@ -20139,7 +20139,7 @@ case 9 /* I64 */: {
 return JaktInternal::ExplicitValue(({ Optional<ids::FunctionId> __jakt_var_401; {
 JaktInternal::Optional<ids::FunctionId> const constructor = TRY((((((*this).program))->find_function_in_scope(((((((*this).program))->get_enum(reflected_enum_id))).scope_id),((type)->constructor_name()),JaktInternal::OptionalNone()))));
 if ((!(((constructor).has_value())))){
-TRY((((*this).error((ByteString::must_from_utf8("Attempted to access a variant that does not exist"sv)),span))));
+TRY((((*this).error((ByteString::from_utf8_without_validation("Attempted to access a variant that does not exist"sv)),span))));
 return Error::__jakt_from_string_literal((StringView::from_string_literal("Invalid type"sv)));
 }
 __jakt_var_401 = (constructor.value()); goto __jakt_label_377;
@@ -20151,7 +20151,7 @@ case 2 /* U8 */: {
 return JaktInternal::ExplicitValue(({ Optional<ids::FunctionId> __jakt_var_402; {
 JaktInternal::Optional<ids::FunctionId> const constructor = TRY((((((*this).program))->find_function_in_scope(((((((*this).program))->get_enum(reflected_enum_id))).scope_id),((type)->constructor_name()),JaktInternal::OptionalNone()))));
 if ((!(((constructor).has_value())))){
-TRY((((*this).error((ByteString::must_from_utf8("Attempted to access a variant that does not exist"sv)),span))));
+TRY((((*this).error((ByteString::from_utf8_without_validation("Attempted to access a variant that does not exist"sv)),span))));
 return Error::__jakt_from_string_literal((StringView::from_string_literal("Invalid type"sv)));
 }
 __jakt_var_402 = (constructor.value()); goto __jakt_label_378;
@@ -20163,7 +20163,7 @@ case 3 /* U16 */: {
 return JaktInternal::ExplicitValue(({ Optional<ids::FunctionId> __jakt_var_403; {
 JaktInternal::Optional<ids::FunctionId> const constructor = TRY((((((*this).program))->find_function_in_scope(((((((*this).program))->get_enum(reflected_enum_id))).scope_id),((type)->constructor_name()),JaktInternal::OptionalNone()))));
 if ((!(((constructor).has_value())))){
-TRY((((*this).error((ByteString::must_from_utf8("Attempted to access a variant that does not exist"sv)),span))));
+TRY((((*this).error((ByteString::from_utf8_without_validation("Attempted to access a variant that does not exist"sv)),span))));
 return Error::__jakt_from_string_literal((StringView::from_string_literal("Invalid type"sv)));
 }
 __jakt_var_403 = (constructor.value()); goto __jakt_label_379;
@@ -20175,7 +20175,7 @@ case 4 /* U32 */: {
 return JaktInternal::ExplicitValue(({ Optional<ids::FunctionId> __jakt_var_404; {
 JaktInternal::Optional<ids::FunctionId> const constructor = TRY((((((*this).program))->find_function_in_scope(((((((*this).program))->get_enum(reflected_enum_id))).scope_id),((type)->constructor_name()),JaktInternal::OptionalNone()))));
 if ((!(((constructor).has_value())))){
-TRY((((*this).error((ByteString::must_from_utf8("Attempted to access a variant that does not exist"sv)),span))));
+TRY((((*this).error((ByteString::from_utf8_without_validation("Attempted to access a variant that does not exist"sv)),span))));
 return Error::__jakt_from_string_literal((StringView::from_string_literal("Invalid type"sv)));
 }
 __jakt_var_404 = (constructor.value()); goto __jakt_label_380;
@@ -20187,7 +20187,7 @@ case 5 /* U64 */: {
 return JaktInternal::ExplicitValue(({ Optional<ids::FunctionId> __jakt_var_405; {
 JaktInternal::Optional<ids::FunctionId> const constructor = TRY((((((*this).program))->find_function_in_scope(((((((*this).program))->get_enum(reflected_enum_id))).scope_id),((type)->constructor_name()),JaktInternal::OptionalNone()))));
 if ((!(((constructor).has_value())))){
-TRY((((*this).error((ByteString::must_from_utf8("Attempted to access a variant that does not exist"sv)),span))));
+TRY((((*this).error((ByteString::from_utf8_without_validation("Attempted to access a variant that does not exist"sv)),span))));
 return Error::__jakt_from_string_literal((StringView::from_string_literal("Invalid type"sv)));
 }
 __jakt_var_405 = (constructor.value()); goto __jakt_label_381;
@@ -20199,7 +20199,7 @@ case 12 /* Usize */: {
 return JaktInternal::ExplicitValue(({ Optional<ids::FunctionId> __jakt_var_406; {
 JaktInternal::Optional<ids::FunctionId> const constructor = TRY((((((*this).program))->find_function_in_scope(((((((*this).program))->get_enum(reflected_enum_id))).scope_id),((type)->constructor_name()),JaktInternal::OptionalNone()))));
 if ((!(((constructor).has_value())))){
-TRY((((*this).error((ByteString::must_from_utf8("Attempted to access a variant that does not exist"sv)),span))));
+TRY((((*this).error((ByteString::from_utf8_without_validation("Attempted to access a variant that does not exist"sv)),span))));
 return Error::__jakt_from_string_literal((StringView::from_string_literal("Invalid type"sv)));
 }
 __jakt_var_406 = (constructor.value()); goto __jakt_label_382;
@@ -20211,7 +20211,7 @@ case 10 /* F32 */: {
 return JaktInternal::ExplicitValue(({ Optional<ids::FunctionId> __jakt_var_407; {
 JaktInternal::Optional<ids::FunctionId> const constructor = TRY((((((*this).program))->find_function_in_scope(((((((*this).program))->get_enum(reflected_enum_id))).scope_id),((type)->constructor_name()),JaktInternal::OptionalNone()))));
 if ((!(((constructor).has_value())))){
-TRY((((*this).error((ByteString::must_from_utf8("Attempted to access a variant that does not exist"sv)),span))));
+TRY((((*this).error((ByteString::from_utf8_without_validation("Attempted to access a variant that does not exist"sv)),span))));
 return Error::__jakt_from_string_literal((StringView::from_string_literal("Invalid type"sv)));
 }
 __jakt_var_407 = (constructor.value()); goto __jakt_label_383;
@@ -20223,7 +20223,7 @@ case 11 /* F64 */: {
 return JaktInternal::ExplicitValue(({ Optional<ids::FunctionId> __jakt_var_408; {
 JaktInternal::Optional<ids::FunctionId> const constructor = TRY((((((*this).program))->find_function_in_scope(((((((*this).program))->get_enum(reflected_enum_id))).scope_id),((type)->constructor_name()),JaktInternal::OptionalNone()))));
 if ((!(((constructor).has_value())))){
-TRY((((*this).error((ByteString::must_from_utf8("Attempted to access a variant that does not exist"sv)),span))));
+TRY((((*this).error((ByteString::from_utf8_without_validation("Attempted to access a variant that does not exist"sv)),span))));
 return Error::__jakt_from_string_literal((StringView::from_string_literal("Invalid type"sv)));
 }
 __jakt_var_408 = (constructor.value()); goto __jakt_label_384;
@@ -20235,7 +20235,7 @@ case 13 /* JaktString */: {
 return JaktInternal::ExplicitValue(({ Optional<ids::FunctionId> __jakt_var_409; {
 JaktInternal::Optional<ids::FunctionId> const constructor = TRY((((((*this).program))->find_function_in_scope(((((((*this).program))->get_enum(reflected_enum_id))).scope_id),((type)->constructor_name()),JaktInternal::OptionalNone()))));
 if ((!(((constructor).has_value())))){
-TRY((((*this).error((ByteString::must_from_utf8("Attempted to access a variant that does not exist"sv)),span))));
+TRY((((*this).error((ByteString::from_utf8_without_validation("Attempted to access a variant that does not exist"sv)),span))));
 return Error::__jakt_from_string_literal((StringView::from_string_literal("Invalid type"sv)));
 }
 __jakt_var_409 = (constructor.value()); goto __jakt_label_385;
@@ -20247,7 +20247,7 @@ case 14 /* CChar */: {
 return JaktInternal::ExplicitValue(({ Optional<ids::FunctionId> __jakt_var_410; {
 JaktInternal::Optional<ids::FunctionId> const constructor = TRY((((((*this).program))->find_function_in_scope(((((((*this).program))->get_enum(reflected_enum_id))).scope_id),((type)->constructor_name()),JaktInternal::OptionalNone()))));
 if ((!(((constructor).has_value())))){
-TRY((((*this).error((ByteString::must_from_utf8("Attempted to access a variant that does not exist"sv)),span))));
+TRY((((*this).error((ByteString::from_utf8_without_validation("Attempted to access a variant that does not exist"sv)),span))));
 return Error::__jakt_from_string_literal((StringView::from_string_literal("Invalid type"sv)));
 }
 __jakt_var_410 = (constructor.value()); goto __jakt_label_386;
@@ -20259,7 +20259,7 @@ case 15 /* CInt */: {
 return JaktInternal::ExplicitValue(({ Optional<ids::FunctionId> __jakt_var_411; {
 JaktInternal::Optional<ids::FunctionId> const constructor = TRY((((((*this).program))->find_function_in_scope(((((((*this).program))->get_enum(reflected_enum_id))).scope_id),((type)->constructor_name()),JaktInternal::OptionalNone()))));
 if ((!(((constructor).has_value())))){
-TRY((((*this).error((ByteString::must_from_utf8("Attempted to access a variant that does not exist"sv)),span))));
+TRY((((*this).error((ByteString::from_utf8_without_validation("Attempted to access a variant that does not exist"sv)),span))));
 return Error::__jakt_from_string_literal((StringView::from_string_literal("Invalid type"sv)));
 }
 __jakt_var_411 = (constructor.value()); goto __jakt_label_387;
@@ -20271,7 +20271,7 @@ case 1 /* Bool */: {
 return JaktInternal::ExplicitValue(({ Optional<ids::FunctionId> __jakt_var_412; {
 JaktInternal::Optional<ids::FunctionId> const constructor = TRY((((((*this).program))->find_function_in_scope(((((((*this).program))->get_enum(reflected_enum_id))).scope_id),((type)->constructor_name()),JaktInternal::OptionalNone()))));
 if ((!(((constructor).has_value())))){
-TRY((((*this).error((ByteString::must_from_utf8("Attempted to access a variant that does not exist"sv)),span))));
+TRY((((*this).error((ByteString::from_utf8_without_validation("Attempted to access a variant that does not exist"sv)),span))));
 return Error::__jakt_from_string_literal((StringView::from_string_literal("Invalid type"sv)));
 }
 __jakt_var_412 = (constructor.value()); goto __jakt_label_388;
@@ -20283,7 +20283,7 @@ case 16 /* Unknown */: {
 return JaktInternal::ExplicitValue(({ Optional<ids::FunctionId> __jakt_var_413; {
 JaktInternal::Optional<ids::FunctionId> const constructor = TRY((((((*this).program))->find_function_in_scope(((((((*this).program))->get_enum(reflected_enum_id))).scope_id),((type)->constructor_name()),JaktInternal::OptionalNone()))));
 if ((!(((constructor).has_value())))){
-TRY((((*this).error((ByteString::must_from_utf8("Attempted to access a variant that does not exist"sv)),span))));
+TRY((((*this).error((ByteString::from_utf8_without_validation("Attempted to access a variant that does not exist"sv)),span))));
 return Error::__jakt_from_string_literal((StringView::from_string_literal("Invalid type"sv)));
 }
 __jakt_var_413 = (constructor.value()); goto __jakt_label_389;
@@ -20295,7 +20295,7 @@ case 17 /* Never */: {
 return JaktInternal::ExplicitValue(({ Optional<ids::FunctionId> __jakt_var_414; {
 JaktInternal::Optional<ids::FunctionId> const constructor = TRY((((((*this).program))->find_function_in_scope(((((((*this).program))->get_enum(reflected_enum_id))).scope_id),((type)->constructor_name()),JaktInternal::OptionalNone()))));
 if ((!(((constructor).has_value())))){
-TRY((((*this).error((ByteString::must_from_utf8("Attempted to access a variant that does not exist"sv)),span))));
+TRY((((*this).error((ByteString::from_utf8_without_validation("Attempted to access a variant that does not exist"sv)),span))));
 return Error::__jakt_from_string_literal((StringView::from_string_literal("Invalid type"sv)));
 }
 __jakt_var_414 = (constructor.value()); goto __jakt_label_390;
@@ -20306,9 +20306,9 @@ __jakt_label_390:; __jakt_var_414.release_value(); }));
 case 18 /* TypeVariable */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.TypeVariable;ByteString const& name = __jakt_match_value.name;
 return JaktInternal::ExplicitValue(({ Optional<ids::FunctionId> __jakt_var_415; {
-JaktInternal::Optional<ids::FunctionId> const constructor = TRY((((((*this).program))->find_function_in_scope(((((((*this).program))->get_enum(reflected_enum_id))).scope_id),(ByteString::must_from_utf8("TypeVariable"sv)),JaktInternal::OptionalNone()))));
+JaktInternal::Optional<ids::FunctionId> const constructor = TRY((((((*this).program))->find_function_in_scope(((((((*this).program))->get_enum(reflected_enum_id))).scope_id),(ByteString::from_utf8_without_validation("TypeVariable"sv)),JaktInternal::OptionalNone()))));
 if ((!(((constructor).has_value())))){
-TRY((((*this).error((ByteString::must_from_utf8("Attempted to access a variant that does not exist"sv)),span))));
+TRY((((*this).error((ByteString::from_utf8_without_validation("Attempted to access a variant that does not exist"sv)),span))));
 return Error::__jakt_from_string_literal((StringView::from_string_literal("Invalid type"sv)));
 }
 (fields = DynamicArray<types::Value>::create_with({TRY((((*this).string_value(name,span))))}));
@@ -20351,14 +20351,14 @@ case 20 /* GenericInstance */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.GenericInstance;ids::StructId const& struct_id = __jakt_match_value.id;
 return JaktInternal::ExplicitValue(({ Optional<ids::FunctionId> __jakt_var_419; {
 types::CheckedStruct const subject_struct = ((((*this).program))->get_struct(struct_id));
-JaktInternal::Optional<ids::FunctionId> const constructor = TRY((((((*this).program))->find_function_in_scope(((((((*this).program))->get_enum(reflected_enum_id))).scope_id),(ByteString::must_from_utf8("StructureOrEnum"sv)),JaktInternal::OptionalNone()))));
+JaktInternal::Optional<ids::FunctionId> const constructor = TRY((((((*this).program))->find_function_in_scope(((((((*this).program))->get_enum(reflected_enum_id))).scope_id),(ByteString::from_utf8_without_validation("StructureOrEnum"sv)),JaktInternal::OptionalNone()))));
 if ((!(((constructor).has_value())))){
-TRY((((*this).error((ByteString::must_from_utf8("Attempted to access a variant that does not exist"sv)),span))));
+TRY((((*this).error((ByteString::from_utf8_without_validation("Attempted to access a variant that does not exist"sv)),span))));
 return Error::__jakt_from_string_literal((StringView::from_string_literal("Invalid type"sv)));
 }
 ids::StructId const record_struct_id = ({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<ids::StructId, ErrorOr<types::Value>>{
-auto&& __jakt_match_variant = TRY((((((*this).program))->find_reflected_primitive((ByteString::must_from_utf8("Record"sv))))));
+auto&& __jakt_match_variant = TRY((((((*this).program))->find_reflected_primitive((ByteString::from_utf8_without_validation("Record"sv))))));
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 0 /* Struct */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Struct;ids::StructId const& id = __jakt_match_value.value;
@@ -20366,7 +20366,7 @@ return JaktInternal::ExplicitValue(id);
 };/*case end*/
 default: {
 {
-utility::panic((ByteString::must_from_utf8("Expected Record to be a struct"sv)));
+utility::panic((ByteString::from_utf8_without_validation("Expected Record to be a struct"sv)));
 }
 };/*case end*/
 }/*switch end*/
@@ -20376,10 +20376,10 @@ utility::panic((ByteString::must_from_utf8("Expected Record to be a struct"sv)))
         return _jakt_value.release_return();
     _jakt_value.release_value();
 });
-ids::FunctionId const record_struct_constructor = (TRY((((((*this).program))->find_function_in_scope(((((((*this).program))->get_struct(record_struct_id))).scope_id),(ByteString::must_from_utf8("Record"sv)),JaktInternal::OptionalNone())))).value());
+ids::FunctionId const record_struct_constructor = (TRY((((((*this).program))->find_function_in_scope(((((((*this).program))->get_struct(record_struct_id))).scope_id),(ByteString::from_utf8_without_validation("Record"sv)),JaktInternal::OptionalNone())))).value());
 ids::EnumId const record_type_enum_id = ({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<ids::EnumId, ErrorOr<types::Value>>{
-auto&& __jakt_match_variant = TRY((((((*this).program))->find_reflected_primitive((ByteString::must_from_utf8("RecordType"sv))))));
+auto&& __jakt_match_variant = TRY((((((*this).program))->find_reflected_primitive((ByteString::from_utf8_without_validation("RecordType"sv))))));
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 1 /* Enum */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Enum;ids::EnumId const& id = __jakt_match_value.value;
@@ -20387,7 +20387,7 @@ return JaktInternal::ExplicitValue(id);
 };/*case end*/
 default: {
 {
-utility::panic((ByteString::must_from_utf8("Expected RecordType to be an enum"sv)));
+utility::panic((ByteString::from_utf8_without_validation("Expected RecordType to be an enum"sv)));
 }
 };/*case end*/
 }/*switch end*/
@@ -20397,7 +20397,7 @@ utility::panic((ByteString::must_from_utf8("Expected RecordType to be an enum"sv
         return _jakt_value.release_return();
     _jakt_value.release_value();
 });
-ids::FunctionId const record_type_struct_constructor = (TRY((((((*this).program))->find_function_in_scope(((((((*this).program))->get_enum(record_type_enum_id))).scope_id),(ByteString::must_from_utf8("Struct"sv)),JaktInternal::OptionalNone())))).value());
+ids::FunctionId const record_type_struct_constructor = (TRY((((((*this).program))->find_function_in_scope(((((((*this).program))->get_enum(record_type_enum_id))).scope_id),(ByteString::from_utf8_without_validation("Struct"sv)),JaktInternal::OptionalNone())))).value());
 types::Value const methods = TRY((((*this).reflect_methods(((subject_struct).scope_id),span,scope))));
 ids::TypeId const tuple_type = TRY((((*this).tuple_type(DynamicArray<ids::TypeId>::create_with({TRY((((*this).string_type()))), ((reflected_enum).type_id)})))));
 types::Value const generic_parameters = TRY((((*this).array_value_of_type(({
@@ -20428,7 +20428,7 @@ return JaktInternal::ExplicitValue(name);
 };/*case end*/
 default: {
 {
-utility::panic((ByteString::must_from_utf8("Unknown kind of generic parameter in struct definition"sv)));
+utility::panic((ByteString::from_utf8_without_validation("Unknown kind of generic parameter in struct definition"sv)));
 }
 };/*case end*/
 }/*switch end*/
@@ -20512,7 +20512,7 @@ types::CheckedField field = (_magic_value.value());
 JaktInternal::DynamicArray<types::Value> const record_type_fields = TRY((((*this).reflect_fields(reflected_fields,span,scope))));
 ids::StructId const field_struct_id = ({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<ids::StructId, ErrorOr<types::Value>>{
-auto&& __jakt_match_variant = TRY((((((*this).program))->find_reflected_primitive((ByteString::must_from_utf8("Field"sv))))));
+auto&& __jakt_match_variant = TRY((((((*this).program))->find_reflected_primitive((ByteString::from_utf8_without_validation("Field"sv))))));
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 0 /* Struct */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Struct;ids::StructId const& id = __jakt_match_value.value;
@@ -20520,7 +20520,7 @@ return JaktInternal::ExplicitValue(id);
 };/*case end*/
 default: {
 {
-utility::panic((ByteString::must_from_utf8("Expected Field to be a struct"sv)));
+utility::panic((ByteString::from_utf8_without_validation("Expected Field to be a struct"sv)));
 }
 };/*case end*/
 }/*switch end*/
@@ -20540,14 +20540,14 @@ case 24 /* Struct */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Struct;ids::StructId const& struct_id = __jakt_match_value.value;
 return JaktInternal::ExplicitValue(({ Optional<ids::FunctionId> __jakt_var_421; {
 types::CheckedStruct const subject_struct = ((((*this).program))->get_struct(struct_id));
-JaktInternal::Optional<ids::FunctionId> const constructor = TRY((((((*this).program))->find_function_in_scope(((((((*this).program))->get_enum(reflected_enum_id))).scope_id),(ByteString::must_from_utf8("StructureOrEnum"sv)),JaktInternal::OptionalNone()))));
+JaktInternal::Optional<ids::FunctionId> const constructor = TRY((((((*this).program))->find_function_in_scope(((((((*this).program))->get_enum(reflected_enum_id))).scope_id),(ByteString::from_utf8_without_validation("StructureOrEnum"sv)),JaktInternal::OptionalNone()))));
 if ((!(((constructor).has_value())))){
-TRY((((*this).error((ByteString::must_from_utf8("Attempted to access a variant that does not exist"sv)),span))));
+TRY((((*this).error((ByteString::from_utf8_without_validation("Attempted to access a variant that does not exist"sv)),span))));
 return Error::__jakt_from_string_literal((StringView::from_string_literal("Invalid type"sv)));
 }
 ids::StructId const record_struct_id = ({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<ids::StructId, ErrorOr<types::Value>>{
-auto&& __jakt_match_variant = TRY((((((*this).program))->find_reflected_primitive((ByteString::must_from_utf8("Record"sv))))));
+auto&& __jakt_match_variant = TRY((((((*this).program))->find_reflected_primitive((ByteString::from_utf8_without_validation("Record"sv))))));
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 0 /* Struct */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Struct;ids::StructId const& id = __jakt_match_value.value;
@@ -20555,7 +20555,7 @@ return JaktInternal::ExplicitValue(id);
 };/*case end*/
 default: {
 {
-utility::panic((ByteString::must_from_utf8("Expected Record to be a struct"sv)));
+utility::panic((ByteString::from_utf8_without_validation("Expected Record to be a struct"sv)));
 }
 };/*case end*/
 }/*switch end*/
@@ -20565,10 +20565,10 @@ utility::panic((ByteString::must_from_utf8("Expected Record to be a struct"sv)))
         return _jakt_value.release_return();
     _jakt_value.release_value();
 });
-ids::FunctionId const record_struct_constructor = (TRY((((((*this).program))->find_function_in_scope(((((((*this).program))->get_struct(record_struct_id))).scope_id),(ByteString::must_from_utf8("Record"sv)),JaktInternal::OptionalNone())))).value());
+ids::FunctionId const record_struct_constructor = (TRY((((((*this).program))->find_function_in_scope(((((((*this).program))->get_struct(record_struct_id))).scope_id),(ByteString::from_utf8_without_validation("Record"sv)),JaktInternal::OptionalNone())))).value());
 ids::EnumId const record_type_enum_id = ({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<ids::EnumId, ErrorOr<types::Value>>{
-auto&& __jakt_match_variant = TRY((((((*this).program))->find_reflected_primitive((ByteString::must_from_utf8("RecordType"sv))))));
+auto&& __jakt_match_variant = TRY((((((*this).program))->find_reflected_primitive((ByteString::from_utf8_without_validation("RecordType"sv))))));
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 1 /* Enum */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Enum;ids::EnumId const& id = __jakt_match_value.value;
@@ -20576,7 +20576,7 @@ return JaktInternal::ExplicitValue(id);
 };/*case end*/
 default: {
 {
-utility::panic((ByteString::must_from_utf8("Expected RecordType to be an enum"sv)));
+utility::panic((ByteString::from_utf8_without_validation("Expected RecordType to be an enum"sv)));
 }
 };/*case end*/
 }/*switch end*/
@@ -20586,7 +20586,7 @@ utility::panic((ByteString::must_from_utf8("Expected RecordType to be an enum"sv
         return _jakt_value.release_return();
     _jakt_value.release_value();
 });
-ids::FunctionId const record_type_struct_constructor = (TRY((((((*this).program))->find_function_in_scope(((((((*this).program))->get_enum(record_type_enum_id))).scope_id),(ByteString::must_from_utf8("Struct"sv)),JaktInternal::OptionalNone())))).value());
+ids::FunctionId const record_type_struct_constructor = (TRY((((((*this).program))->find_function_in_scope(((((((*this).program))->get_enum(record_type_enum_id))).scope_id),(ByteString::from_utf8_without_validation("Struct"sv)),JaktInternal::OptionalNone())))).value());
 types::Value const methods = TRY((((*this).reflect_methods(((subject_struct).scope_id),span,scope))));
 ids::TypeId const tuple_type = TRY((((*this).tuple_type(DynamicArray<ids::TypeId>::create_with({TRY((((*this).string_type()))), ((reflected_enum).type_id)})))));
 types::Value const generic_parameters = TRY((((*this).array_value_of_type(({
@@ -20617,7 +20617,7 @@ return JaktInternal::ExplicitValue(name);
 };/*case end*/
 default: {
 {
-utility::panic((ByteString::must_from_utf8("Unknown kind of generic parameter in struct definition"sv)));
+utility::panic((ByteString::from_utf8_without_validation("Unknown kind of generic parameter in struct definition"sv)));
 }
 };/*case end*/
 }/*switch end*/
@@ -20701,7 +20701,7 @@ types::CheckedField field = (_magic_value.value());
 JaktInternal::DynamicArray<types::Value> const record_type_fields = TRY((((*this).reflect_fields(reflected_fields,span,scope))));
 ids::StructId const field_struct_id = ({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<ids::StructId, ErrorOr<types::Value>>{
-auto&& __jakt_match_variant = TRY((((((*this).program))->find_reflected_primitive((ByteString::must_from_utf8("Field"sv))))));
+auto&& __jakt_match_variant = TRY((((((*this).program))->find_reflected_primitive((ByteString::from_utf8_without_validation("Field"sv))))));
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 0 /* Struct */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Struct;ids::StructId const& id = __jakt_match_value.value;
@@ -20709,7 +20709,7 @@ return JaktInternal::ExplicitValue(id);
 };/*case end*/
 default: {
 {
-utility::panic((ByteString::must_from_utf8("Expected Field to be a struct"sv)));
+utility::panic((ByteString::from_utf8_without_validation("Expected Field to be a struct"sv)));
 }
 };/*case end*/
 }/*switch end*/
@@ -20729,14 +20729,14 @@ case 21 /* GenericEnumInstance */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.GenericEnumInstance;ids::EnumId const& enum_id = __jakt_match_value.id;
 return JaktInternal::ExplicitValue(({ Optional<ids::FunctionId> __jakt_var_423; {
 types::CheckedEnum const subject_enum = ((((*this).program))->get_enum(enum_id));
-JaktInternal::Optional<ids::FunctionId> const constructor = TRY((((((*this).program))->find_function_in_scope(((((((*this).program))->get_enum(reflected_enum_id))).scope_id),(ByteString::must_from_utf8("StructureOrEnum"sv)),JaktInternal::OptionalNone()))));
+JaktInternal::Optional<ids::FunctionId> const constructor = TRY((((((*this).program))->find_function_in_scope(((((((*this).program))->get_enum(reflected_enum_id))).scope_id),(ByteString::from_utf8_without_validation("StructureOrEnum"sv)),JaktInternal::OptionalNone()))));
 if ((!(((constructor).has_value())))){
-TRY((((*this).error((ByteString::must_from_utf8("Attempted to access a variant that does not exist"sv)),span))));
+TRY((((*this).error((ByteString::from_utf8_without_validation("Attempted to access a variant that does not exist"sv)),span))));
 return Error::__jakt_from_string_literal((StringView::from_string_literal("Invalid type"sv)));
 }
 ids::StructId const record_struct_id = ({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<ids::StructId, ErrorOr<types::Value>>{
-auto&& __jakt_match_variant = TRY((((((*this).program))->find_reflected_primitive((ByteString::must_from_utf8("Record"sv))))));
+auto&& __jakt_match_variant = TRY((((((*this).program))->find_reflected_primitive((ByteString::from_utf8_without_validation("Record"sv))))));
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 0 /* Struct */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Struct;ids::StructId const& id = __jakt_match_value.value;
@@ -20744,7 +20744,7 @@ return JaktInternal::ExplicitValue(id);
 };/*case end*/
 default: {
 {
-utility::panic((ByteString::must_from_utf8("Expected Record to be a struct"sv)));
+utility::panic((ByteString::from_utf8_without_validation("Expected Record to be a struct"sv)));
 }
 };/*case end*/
 }/*switch end*/
@@ -20754,10 +20754,10 @@ utility::panic((ByteString::must_from_utf8("Expected Record to be a struct"sv)))
         return _jakt_value.release_return();
     _jakt_value.release_value();
 });
-ids::FunctionId const record_struct_constructor = (TRY((((((*this).program))->find_function_in_scope(((((((*this).program))->get_struct(record_struct_id))).scope_id),(ByteString::must_from_utf8("Record"sv)),JaktInternal::OptionalNone())))).value());
+ids::FunctionId const record_struct_constructor = (TRY((((((*this).program))->find_function_in_scope(((((((*this).program))->get_struct(record_struct_id))).scope_id),(ByteString::from_utf8_without_validation("Record"sv)),JaktInternal::OptionalNone())))).value());
 ids::EnumId const record_type_enum_id = ({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<ids::EnumId, ErrorOr<types::Value>>{
-auto&& __jakt_match_variant = TRY((((((*this).program))->find_reflected_primitive((ByteString::must_from_utf8("RecordType"sv))))));
+auto&& __jakt_match_variant = TRY((((((*this).program))->find_reflected_primitive((ByteString::from_utf8_without_validation("RecordType"sv))))));
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 1 /* Enum */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Enum;ids::EnumId const& id = __jakt_match_value.value;
@@ -20765,7 +20765,7 @@ return JaktInternal::ExplicitValue(id);
 };/*case end*/
 default: {
 {
-utility::panic((ByteString::must_from_utf8("Expected RecordType to be an enum"sv)));
+utility::panic((ByteString::from_utf8_without_validation("Expected RecordType to be an enum"sv)));
 }
 };/*case end*/
 }/*switch end*/
@@ -20780,10 +20780,10 @@ ids::FunctionId const record_type_struct_constructor = ({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<ids::FunctionId,ErrorOr<types::Value>>{
 auto __jakt_enum_value = (is_value_enum);
 if (__jakt_enum_value == true) {
-return JaktInternal::ExplicitValue((TRY((((((*this).program))->find_function_in_scope(((((((*this).program))->get_enum(record_type_enum_id))).scope_id),(ByteString::must_from_utf8("ValueEnum"sv)),JaktInternal::OptionalNone())))).value()));
+return JaktInternal::ExplicitValue((TRY((((((*this).program))->find_function_in_scope(((((((*this).program))->get_enum(record_type_enum_id))).scope_id),(ByteString::from_utf8_without_validation("ValueEnum"sv)),JaktInternal::OptionalNone())))).value()));
 }
 else {
-return JaktInternal::ExplicitValue((TRY((((((*this).program))->find_function_in_scope(((((((*this).program))->get_enum(record_type_enum_id))).scope_id),(ByteString::must_from_utf8("SumEnum"sv)),JaktInternal::OptionalNone())))).value()));
+return JaktInternal::ExplicitValue((TRY((((((*this).program))->find_function_in_scope(((((((*this).program))->get_enum(record_type_enum_id))).scope_id),(ByteString::from_utf8_without_validation("SumEnum"sv)),JaktInternal::OptionalNone())))).value()));
 }
 }());
     if (_jakt_value.is_return())
@@ -20820,7 +20820,7 @@ return JaktInternal::ExplicitValue(name);
 };/*case end*/
 default: {
 {
-utility::panic((ByteString::must_from_utf8("Unknown kind of generic parameter in struct definition"sv)));
+utility::panic((ByteString::from_utf8_without_validation("Unknown kind of generic parameter in struct definition"sv)));
 }
 };/*case end*/
 }/*switch end*/
@@ -20887,7 +20887,7 @@ return JaktInternal::ExplicitValue(DynamicArray<types::Value>::create_with({}));
 }),tuple_type,span))));
 JaktInternal::DynamicArray<types::Value> record_type_fields = DynamicArray<types::Value>::create_with({});
 if (is_value_enum){
-TRY((((*this).error((ByteString::must_from_utf8("Unimplemented reflected type: value enum"sv)),span))));
+TRY((((*this).error((ByteString::from_utf8_without_validation("Unimplemented reflected type: value enum"sv)),span))));
 return Error::__jakt_from_string_literal((StringView::from_string_literal("Not yet implemented"sv)));
 }
 else {
@@ -20896,7 +20896,7 @@ else {
 
 ids::StructId const field_struct_id = ({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<ids::StructId, ErrorOr<types::Value>>{
-auto&& __jakt_match_variant = TRY((((((*this).program))->find_reflected_primitive((ByteString::must_from_utf8("Field"sv))))));
+auto&& __jakt_match_variant = TRY((((((*this).program))->find_reflected_primitive((ByteString::from_utf8_without_validation("Field"sv))))));
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 0 /* Struct */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Struct;ids::StructId const& id = __jakt_match_value.value;
@@ -20904,7 +20904,7 @@ return JaktInternal::ExplicitValue(id);
 };/*case end*/
 default: {
 {
-utility::panic((ByteString::must_from_utf8("Expected Field to be a struct"sv)));
+utility::panic((ByteString::from_utf8_without_validation("Expected Field to be a struct"sv)));
 }
 };/*case end*/
 }/*switch end*/
@@ -20924,14 +20924,14 @@ case 25 /* Enum */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Enum;ids::EnumId const& enum_id = __jakt_match_value.value;
 return JaktInternal::ExplicitValue(({ Optional<ids::FunctionId> __jakt_var_425; {
 types::CheckedEnum const subject_enum = ((((*this).program))->get_enum(enum_id));
-JaktInternal::Optional<ids::FunctionId> const constructor = TRY((((((*this).program))->find_function_in_scope(((((((*this).program))->get_enum(reflected_enum_id))).scope_id),(ByteString::must_from_utf8("StructureOrEnum"sv)),JaktInternal::OptionalNone()))));
+JaktInternal::Optional<ids::FunctionId> const constructor = TRY((((((*this).program))->find_function_in_scope(((((((*this).program))->get_enum(reflected_enum_id))).scope_id),(ByteString::from_utf8_without_validation("StructureOrEnum"sv)),JaktInternal::OptionalNone()))));
 if ((!(((constructor).has_value())))){
-TRY((((*this).error((ByteString::must_from_utf8("Attempted to access a variant that does not exist"sv)),span))));
+TRY((((*this).error((ByteString::from_utf8_without_validation("Attempted to access a variant that does not exist"sv)),span))));
 return Error::__jakt_from_string_literal((StringView::from_string_literal("Invalid type"sv)));
 }
 ids::StructId const record_struct_id = ({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<ids::StructId, ErrorOr<types::Value>>{
-auto&& __jakt_match_variant = TRY((((((*this).program))->find_reflected_primitive((ByteString::must_from_utf8("Record"sv))))));
+auto&& __jakt_match_variant = TRY((((((*this).program))->find_reflected_primitive((ByteString::from_utf8_without_validation("Record"sv))))));
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 0 /* Struct */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Struct;ids::StructId const& id = __jakt_match_value.value;
@@ -20939,7 +20939,7 @@ return JaktInternal::ExplicitValue(id);
 };/*case end*/
 default: {
 {
-utility::panic((ByteString::must_from_utf8("Expected Record to be a struct"sv)));
+utility::panic((ByteString::from_utf8_without_validation("Expected Record to be a struct"sv)));
 }
 };/*case end*/
 }/*switch end*/
@@ -20949,10 +20949,10 @@ utility::panic((ByteString::must_from_utf8("Expected Record to be a struct"sv)))
         return _jakt_value.release_return();
     _jakt_value.release_value();
 });
-ids::FunctionId const record_struct_constructor = (TRY((((((*this).program))->find_function_in_scope(((((((*this).program))->get_struct(record_struct_id))).scope_id),(ByteString::must_from_utf8("Record"sv)),JaktInternal::OptionalNone())))).value());
+ids::FunctionId const record_struct_constructor = (TRY((((((*this).program))->find_function_in_scope(((((((*this).program))->get_struct(record_struct_id))).scope_id),(ByteString::from_utf8_without_validation("Record"sv)),JaktInternal::OptionalNone())))).value());
 ids::EnumId const record_type_enum_id = ({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<ids::EnumId, ErrorOr<types::Value>>{
-auto&& __jakt_match_variant = TRY((((((*this).program))->find_reflected_primitive((ByteString::must_from_utf8("RecordType"sv))))));
+auto&& __jakt_match_variant = TRY((((((*this).program))->find_reflected_primitive((ByteString::from_utf8_without_validation("RecordType"sv))))));
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 1 /* Enum */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Enum;ids::EnumId const& id = __jakt_match_value.value;
@@ -20960,7 +20960,7 @@ return JaktInternal::ExplicitValue(id);
 };/*case end*/
 default: {
 {
-utility::panic((ByteString::must_from_utf8("Expected RecordType to be an enum"sv)));
+utility::panic((ByteString::from_utf8_without_validation("Expected RecordType to be an enum"sv)));
 }
 };/*case end*/
 }/*switch end*/
@@ -20975,10 +20975,10 @@ ids::FunctionId const record_type_struct_constructor = ({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<ids::FunctionId,ErrorOr<types::Value>>{
 auto __jakt_enum_value = (is_value_enum);
 if (__jakt_enum_value == true) {
-return JaktInternal::ExplicitValue((TRY((((((*this).program))->find_function_in_scope(((((((*this).program))->get_enum(record_type_enum_id))).scope_id),(ByteString::must_from_utf8("ValueEnum"sv)),JaktInternal::OptionalNone())))).value()));
+return JaktInternal::ExplicitValue((TRY((((((*this).program))->find_function_in_scope(((((((*this).program))->get_enum(record_type_enum_id))).scope_id),(ByteString::from_utf8_without_validation("ValueEnum"sv)),JaktInternal::OptionalNone())))).value()));
 }
 else {
-return JaktInternal::ExplicitValue((TRY((((((*this).program))->find_function_in_scope(((((((*this).program))->get_enum(record_type_enum_id))).scope_id),(ByteString::must_from_utf8("SumEnum"sv)),JaktInternal::OptionalNone())))).value()));
+return JaktInternal::ExplicitValue((TRY((((((*this).program))->find_function_in_scope(((((((*this).program))->get_enum(record_type_enum_id))).scope_id),(ByteString::from_utf8_without_validation("SumEnum"sv)),JaktInternal::OptionalNone())))).value()));
 }
 }());
     if (_jakt_value.is_return())
@@ -21015,7 +21015,7 @@ return JaktInternal::ExplicitValue(name);
 };/*case end*/
 default: {
 {
-utility::panic((ByteString::must_from_utf8("Unknown kind of generic parameter in struct definition"sv)));
+utility::panic((ByteString::from_utf8_without_validation("Unknown kind of generic parameter in struct definition"sv)));
 }
 };/*case end*/
 }/*switch end*/
@@ -21082,7 +21082,7 @@ return JaktInternal::ExplicitValue(DynamicArray<types::Value>::create_with({}));
 }),tuple_type,span))));
 JaktInternal::DynamicArray<types::Value> record_type_fields = DynamicArray<types::Value>::create_with({});
 if (is_value_enum){
-TRY((((*this).error((ByteString::must_from_utf8("Unimplemented reflected type: value enum"sv)),span))));
+TRY((((*this).error((ByteString::from_utf8_without_validation("Unimplemented reflected type: value enum"sv)),span))));
 return Error::__jakt_from_string_literal((StringView::from_string_literal("Not yet implemented"sv)));
 }
 else {
@@ -21091,7 +21091,7 @@ else {
 
 ids::StructId const field_struct_id = ({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<ids::StructId, ErrorOr<types::Value>>{
-auto&& __jakt_match_variant = TRY((((((*this).program))->find_reflected_primitive((ByteString::must_from_utf8("Field"sv))))));
+auto&& __jakt_match_variant = TRY((((((*this).program))->find_reflected_primitive((ByteString::from_utf8_without_validation("Field"sv))))));
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 0 /* Struct */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Struct;ids::StructId const& id = __jakt_match_value.value;
@@ -21099,7 +21099,7 @@ return JaktInternal::ExplicitValue(id);
 };/*case end*/
 default: {
 {
-utility::panic((ByteString::must_from_utf8("Expected Field to be a struct"sv)));
+utility::panic((ByteString::from_utf8_without_validation("Expected Field to be a struct"sv)));
 }
 };/*case end*/
 }/*switch end*/
@@ -21117,9 +21117,9 @@ __jakt_label_401:; __jakt_var_425.release_value(); }));
 };/*case end*/
 case 30 /* Function */: {
 return JaktInternal::ExplicitValue(({ Optional<ids::FunctionId> __jakt_var_427; {
-JaktInternal::Optional<ids::FunctionId> const constructor = TRY((((((*this).program))->find_function_in_scope(((((((*this).program))->get_enum(reflected_enum_id))).scope_id),(ByteString::must_from_utf8("Function"sv)),JaktInternal::OptionalNone()))));
+JaktInternal::Optional<ids::FunctionId> const constructor = TRY((((((*this).program))->find_function_in_scope(((((((*this).program))->get_enum(reflected_enum_id))).scope_id),(ByteString::from_utf8_without_validation("Function"sv)),JaktInternal::OptionalNone()))));
 if ((!(((constructor).has_value())))){
-TRY((((*this).error((ByteString::must_from_utf8("Attempted to access a variant that does not exist"sv)),span))));
+TRY((((*this).error((ByteString::from_utf8_without_validation("Attempted to access a variant that does not exist"sv)),span))));
 return Error::__jakt_from_string_literal((StringView::from_string_literal("Invalid type"sv)));
 }
 (fields = DynamicArray<types::Value>::create_with({}));

--- a/bootstrap/stage0/jakt__arguments.cpp
+++ b/bootstrap/stage0/jakt__arguments.cpp
@@ -178,7 +178,7 @@ break;
 }
 ByteString arg = (_magic_value.value());
 {
-if (((arg) == ((ByteString::must_from_utf8("--"sv))))){
+if (((arg) == ((ByteString::from_utf8_without_validation("--"sv))))){
 (((parser).definitely_positional_args) = ((((((parser).args))[(JaktInternal::Range<size_t>{static_cast<size_t>(JaktInternal::checked_add(i,static_cast<size_t>(1ULL))),static_cast<size_t>(((((parser).args)).size()))})])).to_array()));
 (((parser).args) = ((((((parser).args))[(JaktInternal::Range<size_t>{static_cast<size_t>(static_cast<size_t>(0ULL)),static_cast<size_t>(i)})])).to_array()));
 break;

--- a/bootstrap/stage0/jakt__path.cpp
+++ b/bootstrap/stage0/jakt__path.cpp
@@ -17,7 +17,7 @@ return path;
 
 jakt__path::Path jakt__path::Path::from_parts(JaktInternal::DynamicArray<ByteString> const parts) {
 {
-jakt__path::Path path = jakt__path::Path((ByteString::must_from_utf8("."sv)));
+jakt__path::Path path = jakt__path::Path((ByteString::from_utf8_without_validation("."sv)));
 {
 JaktInternal::ArrayIterator<ByteString> _magic = ((parts).iterator());
 for (;;){
@@ -76,7 +76,7 @@ return ((*this).path);
 
 jakt__path::Path jakt__path::Path::join(ByteString const path) const {
 {
-if ((((((*this).path)) == ((ByteString::must_from_utf8("."sv)))) || ((((((*this).path)).length())) == (static_cast<size_t>(0ULL))))){
+if ((((((*this).path)) == ((ByteString::from_utf8_without_validation("."sv)))) || ((((((*this).path)).length())) == (static_cast<size_t>(0ULL))))){
 return jakt__path::Path(path);
 }
 if (((path).is_empty())){
@@ -104,7 +104,7 @@ return ((*this).join(((path).path)));
 
 bool jakt__path::Path::is_dot() const {
 {
-return (((((*this).path)) == ((ByteString::must_from_utf8("."sv)))) || ((((*this).path)) == ((ByteString::must_from_utf8(".."sv)))));
+return (((((*this).path)) == ((ByteString::from_utf8_without_validation("."sv)))) || ((((*this).path)) == ((ByteString::from_utf8_without_validation(".."sv)))));
 }
 }
 
@@ -131,7 +131,7 @@ return ((((*this).path)).substring(JaktInternal::checked_add(i,static_cast<size_
 }
 }
 
-return (ByteString::must_from_utf8(""sv));
+return (ByteString::from_utf8_without_validation(""sv));
 }
 }
 
@@ -166,11 +166,11 @@ ByteString const basename = ((*this).basename(true));
 ByteString const extension = ({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<ByteString,ErrorOr<jakt__path::Path>>{
 auto __jakt_enum_value = (new_extension);
-if (__jakt_enum_value == (ByteString::must_from_utf8(""sv))) {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8(""sv)));
+if (__jakt_enum_value == (ByteString::from_utf8_without_validation(""sv))) {
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation(""sv)));
 }
 else {
-return JaktInternal::ExplicitValue((((ByteString::must_from_utf8("."sv))) + (new_extension)));
+return JaktInternal::ExplicitValue((((ByteString::from_utf8_without_validation("."sv))) + (new_extension)));
 }
 }());
     if (_jakt_value.is_return())
@@ -184,8 +184,8 @@ return jakt__path::Path::from_parts(DynamicArray<ByteString>::create_with({((par
 jakt__path::Path jakt__path::Path::parent() const {
 {
 JaktInternal::Tuple<ByteString,ByteString> const parts = ((*this).split_at_last_slash());
-if (((((parts).template get<0>())) == ((ByteString::must_from_utf8(""sv))))){
-return jakt__path::Path((ByteString::must_from_utf8("."sv)));
+if (((((parts).template get<0>())) == ((ByteString::from_utf8_without_validation(""sv))))){
+return jakt__path::Path((ByteString::from_utf8_without_validation("."sv)));
 }
 return jakt__path::Path(((parts).template get<0>()));
 }
@@ -220,7 +220,7 @@ continue;
 }
 else {
 if (((i) == (static_cast<size_t>(0ULL)))){
-((parts).push((ByteString::must_from_utf8("/"sv))));
+((parts).push((ByteString::from_utf8_without_validation("/"sv))));
 }
 else {
 ((parts).push(((((*this).path)).substring(static_cast<size_t>(0ULL),i))));
@@ -267,7 +267,7 @@ ByteString const dir = ((((*this).path)).substring(static_cast<size_t>(0ULL),(la
 ByteString const base = ((((*this).path)).substring(JaktInternal::checked_add((last_slash.value()),static_cast<size_t>(1ULL)),JaktInternal::checked_sub(JaktInternal::checked_sub(len,(last_slash.value())),static_cast<size_t>(1ULL))));
 return (Tuple{dir, base});
 }
-return (Tuple{(ByteString::must_from_utf8(""sv)), ((*this).path)});
+return (Tuple{(ByteString::from_utf8_without_validation(""sv)), ((*this).path)});
 }
 }
 

--- a/bootstrap/stage0/jakt__platform.cpp
+++ b/bootstrap/stage0/jakt__platform.cpp
@@ -7,18 +7,18 @@ jakt__platform::Target const target = TRY((jakt__platform::Target::active()));
 return ({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<JaktInternal::DynamicArray<ByteString>,ErrorOr<JaktInternal::DynamicArray<ByteString>>>{
 auto __jakt_enum_value = (((target).os));
-if (__jakt_enum_value == (ByteString::must_from_utf8("windows"sv))) {
+if (__jakt_enum_value == (ByteString::from_utf8_without_validation("windows"sv))) {
 return JaktInternal::ExplicitValue(({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<JaktInternal::DynamicArray<ByteString>,ErrorOr<JaktInternal::DynamicArray<ByteString>>>{
 auto __jakt_enum_value = (((target).arch));
-if (__jakt_enum_value == (ByteString::must_from_utf8("x86_64"sv))) {
-return JaktInternal::ExplicitValue(DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("win64"sv)), (ByteString::must_from_utf8("windows"sv))}));
+if (__jakt_enum_value == (ByteString::from_utf8_without_validation("x86_64"sv))) {
+return JaktInternal::ExplicitValue(DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("win64"sv)), (ByteString::from_utf8_without_validation("windows"sv))}));
 }
-else if (__jakt_enum_value == (ByteString::must_from_utf8("i686"sv))) {
-return JaktInternal::ExplicitValue(DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("win32"sv)), (ByteString::must_from_utf8("windows"sv))}));
+else if (__jakt_enum_value == (ByteString::from_utf8_without_validation("i686"sv))) {
+return JaktInternal::ExplicitValue(DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("win32"sv)), (ByteString::from_utf8_without_validation("windows"sv))}));
 }
 else {
-return JaktInternal::ExplicitValue(DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("windows"sv))}));
+return JaktInternal::ExplicitValue(DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("windows"sv))}));
 }
 }());
     if (_jakt_value.is_return())
@@ -26,23 +26,23 @@ return JaktInternal::ExplicitValue(DynamicArray<ByteString>::create_with({(ByteS
     _jakt_value.release_value();
 }));
 }
-else if (__jakt_enum_value == (ByteString::must_from_utf8("darwin"sv))) {
-return JaktInternal::ExplicitValue(DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("darwin"sv)), (ByteString::must_from_utf8("posix"sv))}));
+else if (__jakt_enum_value == (ByteString::from_utf8_without_validation("darwin"sv))) {
+return JaktInternal::ExplicitValue(DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("darwin"sv)), (ByteString::from_utf8_without_validation("posix"sv))}));
 }
-else if (__jakt_enum_value == (ByteString::must_from_utf8("linux"sv))) {
-return JaktInternal::ExplicitValue(DynamicArray<ByteString>::create_with({((target).os), (ByteString::must_from_utf8("posix"sv))}));
+else if (__jakt_enum_value == (ByteString::from_utf8_without_validation("linux"sv))) {
+return JaktInternal::ExplicitValue(DynamicArray<ByteString>::create_with({((target).os), (ByteString::from_utf8_without_validation("posix"sv))}));
 }
-else if (__jakt_enum_value == (ByteString::must_from_utf8("openbsd"sv))) {
-return JaktInternal::ExplicitValue(DynamicArray<ByteString>::create_with({((target).os), (ByteString::must_from_utf8("posix"sv))}));
+else if (__jakt_enum_value == (ByteString::from_utf8_without_validation("openbsd"sv))) {
+return JaktInternal::ExplicitValue(DynamicArray<ByteString>::create_with({((target).os), (ByteString::from_utf8_without_validation("posix"sv))}));
 }
-else if (__jakt_enum_value == (ByteString::must_from_utf8("serenityos"sv))) {
-return JaktInternal::ExplicitValue(DynamicArray<ByteString>::create_with({((target).os), (ByteString::must_from_utf8("posix"sv))}));
+else if (__jakt_enum_value == (ByteString::from_utf8_without_validation("serenityos"sv))) {
+return JaktInternal::ExplicitValue(DynamicArray<ByteString>::create_with({((target).os), (ByteString::from_utf8_without_validation("posix"sv))}));
 }
-else if (__jakt_enum_value == (ByteString::must_from_utf8("serenity"sv))) {
-return JaktInternal::ExplicitValue(DynamicArray<ByteString>::create_with({((target).os), (ByteString::must_from_utf8("posix"sv))}));
+else if (__jakt_enum_value == (ByteString::from_utf8_without_validation("serenity"sv))) {
+return JaktInternal::ExplicitValue(DynamicArray<ByteString>::create_with({((target).os), (ByteString::from_utf8_without_validation("posix"sv))}));
 }
 else {
-return JaktInternal::ExplicitValue(DynamicArray<ByteString>::create_with({((target).os), (ByteString::must_from_utf8("unknown"sv))}));
+return JaktInternal::ExplicitValue(DynamicArray<ByteString>::create_with({((target).os), (ByteString::from_utf8_without_validation("unknown"sv))}));
 }
 }());
     if (_jakt_value.is_return())
@@ -154,10 +154,10 @@ ErrorOr<size_t> jakt__platform::Target::size_t_size() const {
 return ({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<size_t,ErrorOr<size_t>>{
 auto __jakt_enum_value = (((*this).arch));
-if (__jakt_enum_value == (ByteString::must_from_utf8("x86_64"sv))) {
+if (__jakt_enum_value == (ByteString::from_utf8_without_validation("x86_64"sv))) {
 return JaktInternal::ExplicitValue(static_cast<size_t>(8ULL));
 }
-else if (__jakt_enum_value == (ByteString::must_from_utf8("x86"sv))) {
+else if (__jakt_enum_value == (ByteString::from_utf8_without_validation("x86"sv))) {
 return JaktInternal::ExplicitValue(static_cast<size_t>(4ULL));
 }
 else {
@@ -178,10 +178,10 @@ ErrorOr<size_t> jakt__platform::Target::pointer_size() const {
 return ({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<size_t,ErrorOr<size_t>>{
 auto __jakt_enum_value = (((*this).arch));
-if (__jakt_enum_value == (ByteString::must_from_utf8("x86_64"sv))) {
+if (__jakt_enum_value == (ByteString::from_utf8_without_validation("x86_64"sv))) {
 return JaktInternal::ExplicitValue(static_cast<size_t>(8ULL));
 }
-else if (__jakt_enum_value == (ByteString::must_from_utf8("x86"sv))) {
+else if (__jakt_enum_value == (ByteString::from_utf8_without_validation("x86"sv))) {
 return JaktInternal::ExplicitValue(static_cast<size_t>(4ULL));
 }
 else {
@@ -202,10 +202,10 @@ ErrorOr<size_t> jakt__platform::Target::int_size() const {
 return ({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<size_t,ErrorOr<size_t>>{
 auto __jakt_enum_value = (((*this).arch));
-if (__jakt_enum_value == (ByteString::must_from_utf8("x86_64"sv))) {
+if (__jakt_enum_value == (ByteString::from_utf8_without_validation("x86_64"sv))) {
 return JaktInternal::ExplicitValue(static_cast<size_t>(4ULL));
 }
-else if (__jakt_enum_value == (ByteString::must_from_utf8("x86"sv))) {
+else if (__jakt_enum_value == (ByteString::from_utf8_without_validation("x86"sv))) {
 return JaktInternal::ExplicitValue(static_cast<size_t>(4ULL));
 }
 else {

--- a/bootstrap/stage0/jakt__platform__utility.cpp
+++ b/bootstrap/stage0/jakt__platform__utility.cpp
@@ -3,7 +3,7 @@ namespace Jakt {
 namespace jakt__platform__utility {
 ErrorOr<ByteString> join(JaktInternal::DynamicArray<ByteString> const strings,ByteString const separator) {
 {
-ByteString output = (ByteString::must_from_utf8(""sv));
+ByteString output = (ByteString::from_utf8_without_validation(""sv));
 size_t i = static_cast<size_t>(0ULL);
 {
 JaktInternal::ArrayIterator<ByteString> _magic = ((strings).iterator());

--- a/bootstrap/stage0/lexer.cpp
+++ b/bootstrap/stage0/lexer.cpp
@@ -17,7 +17,7 @@ builder.appendff("illegal_cpp_keywords: {}", illegal_cpp_keywords);
 builder.append(")"sv);return builder.to_string(); }
 JaktInternal::DynamicArray<lexer::Token> lexer::Lexer::lex(NonnullRefPtr<compiler::Compiler> const compiler) {
 {
-JaktInternal::Set<ByteString> const illegal_cpp_keywords = Set<ByteString>::create_with_values({(ByteString::must_from_utf8("alignas"sv)), (ByteString::must_from_utf8("alignof"sv)), (ByteString::must_from_utf8("and_eq"sv)), (ByteString::must_from_utf8("asm"sv)), (ByteString::must_from_utf8("auto"sv)), (ByteString::must_from_utf8("bitand"sv)), (ByteString::must_from_utf8("bitor"sv)), (ByteString::must_from_utf8("case"sv)), (ByteString::must_from_utf8("char"sv)), (ByteString::must_from_utf8("char8_t"sv)), (ByteString::must_from_utf8("char16_t"sv)), (ByteString::must_from_utf8("char32_t"sv)), (ByteString::must_from_utf8("compl"sv)), (ByteString::must_from_utf8("concept"sv)), (ByteString::must_from_utf8("consteval"sv)), (ByteString::must_from_utf8("constexpr"sv)), (ByteString::must_from_utf8("constinit"sv)), (ByteString::must_from_utf8("const_cast"sv)), (ByteString::must_from_utf8("co_await"sv)), (ByteString::must_from_utf8("co_return"sv)), (ByteString::must_from_utf8("co_yield"sv)), (ByteString::must_from_utf8("decltype"sv)), (ByteString::must_from_utf8("delete"sv)), (ByteString::must_from_utf8("do"sv)), (ByteString::must_from_utf8("double"sv)), (ByteString::must_from_utf8("dynamic_cast"sv)), (ByteString::must_from_utf8("explicit"sv)), (ByteString::must_from_utf8("export"sv)), (ByteString::must_from_utf8("float"sv)), (ByteString::must_from_utf8("friend"sv)), (ByteString::must_from_utf8("goto"sv)), (ByteString::must_from_utf8("int"sv)), (ByteString::must_from_utf8("long"sv)), (ByteString::must_from_utf8("mutable"sv)), (ByteString::must_from_utf8("new"sv)), (ByteString::must_from_utf8("noexcept"sv)), (ByteString::must_from_utf8("not_eq"sv)), (ByteString::must_from_utf8("nullptr"sv)), (ByteString::must_from_utf8("operator"sv)), (ByteString::must_from_utf8("or_eq"sv)), (ByteString::must_from_utf8("protected"sv)), (ByteString::must_from_utf8("register"sv)), (ByteString::must_from_utf8("reinterpret_cast"sv)), (ByteString::must_from_utf8("short"sv)), (ByteString::must_from_utf8("signed"sv)), (ByteString::must_from_utf8("static"sv)), (ByteString::must_from_utf8("static_assert"sv)), (ByteString::must_from_utf8("static_cast"sv)), (ByteString::must_from_utf8("switch"sv)), (ByteString::must_from_utf8("template"sv)), (ByteString::must_from_utf8("thread_local"sv)), (ByteString::must_from_utf8("typedef"sv)), (ByteString::must_from_utf8("typeid"sv)), (ByteString::must_from_utf8("typename"sv)), (ByteString::must_from_utf8("union"sv)), (ByteString::must_from_utf8("unsigned"sv)), (ByteString::must_from_utf8("using"sv)), (ByteString::must_from_utf8("volatile"sv)), (ByteString::must_from_utf8("wchar_t"sv)), (ByteString::must_from_utf8("xor"sv)), (ByteString::must_from_utf8("xor_eq"sv))});
+JaktInternal::Set<ByteString> const illegal_cpp_keywords = Set<ByteString>::create_with_values({(ByteString::from_utf8_without_validation("alignas"sv)), (ByteString::from_utf8_without_validation("alignof"sv)), (ByteString::from_utf8_without_validation("and_eq"sv)), (ByteString::from_utf8_without_validation("asm"sv)), (ByteString::from_utf8_without_validation("auto"sv)), (ByteString::from_utf8_without_validation("bitand"sv)), (ByteString::from_utf8_without_validation("bitor"sv)), (ByteString::from_utf8_without_validation("case"sv)), (ByteString::from_utf8_without_validation("char"sv)), (ByteString::from_utf8_without_validation("char8_t"sv)), (ByteString::from_utf8_without_validation("char16_t"sv)), (ByteString::from_utf8_without_validation("char32_t"sv)), (ByteString::from_utf8_without_validation("compl"sv)), (ByteString::from_utf8_without_validation("concept"sv)), (ByteString::from_utf8_without_validation("consteval"sv)), (ByteString::from_utf8_without_validation("constexpr"sv)), (ByteString::from_utf8_without_validation("constinit"sv)), (ByteString::from_utf8_without_validation("const_cast"sv)), (ByteString::from_utf8_without_validation("co_await"sv)), (ByteString::from_utf8_without_validation("co_return"sv)), (ByteString::from_utf8_without_validation("co_yield"sv)), (ByteString::from_utf8_without_validation("decltype"sv)), (ByteString::from_utf8_without_validation("delete"sv)), (ByteString::from_utf8_without_validation("do"sv)), (ByteString::from_utf8_without_validation("double"sv)), (ByteString::from_utf8_without_validation("dynamic_cast"sv)), (ByteString::from_utf8_without_validation("explicit"sv)), (ByteString::from_utf8_without_validation("export"sv)), (ByteString::from_utf8_without_validation("float"sv)), (ByteString::from_utf8_without_validation("friend"sv)), (ByteString::from_utf8_without_validation("goto"sv)), (ByteString::from_utf8_without_validation("int"sv)), (ByteString::from_utf8_without_validation("long"sv)), (ByteString::from_utf8_without_validation("mutable"sv)), (ByteString::from_utf8_without_validation("new"sv)), (ByteString::from_utf8_without_validation("noexcept"sv)), (ByteString::from_utf8_without_validation("not_eq"sv)), (ByteString::from_utf8_without_validation("nullptr"sv)), (ByteString::from_utf8_without_validation("operator"sv)), (ByteString::from_utf8_without_validation("or_eq"sv)), (ByteString::from_utf8_without_validation("protected"sv)), (ByteString::from_utf8_without_validation("register"sv)), (ByteString::from_utf8_without_validation("reinterpret_cast"sv)), (ByteString::from_utf8_without_validation("short"sv)), (ByteString::from_utf8_without_validation("signed"sv)), (ByteString::from_utf8_without_validation("static"sv)), (ByteString::from_utf8_without_validation("static_assert"sv)), (ByteString::from_utf8_without_validation("static_cast"sv)), (ByteString::from_utf8_without_validation("switch"sv)), (ByteString::from_utf8_without_validation("template"sv)), (ByteString::from_utf8_without_validation("thread_local"sv)), (ByteString::from_utf8_without_validation("typedef"sv)), (ByteString::from_utf8_without_validation("typeid"sv)), (ByteString::from_utf8_without_validation("typename"sv)), (ByteString::from_utf8_without_validation("union"sv)), (ByteString::from_utf8_without_validation("unsigned"sv)), (ByteString::from_utf8_without_validation("using"sv)), (ByteString::from_utf8_without_validation("volatile"sv)), (ByteString::from_utf8_without_validation("wchar_t"sv)), (ByteString::from_utf8_without_validation("xor"sv)), (ByteString::from_utf8_without_validation("xor_eq"sv))});
 lexer::Lexer lexer = lexer::Lexer(static_cast<size_t>(0ULL),((compiler)->current_file_contents),compiler,JaktInternal::OptionalNone(),illegal_cpp_keywords);
 JaktInternal::DynamicArray<lexer::Token> tokens = DynamicArray<lexer::Token>::create_with({});
 {
@@ -145,10 +145,10 @@ JaktInternal::Optional<ByteString> const prefix = ({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<JaktInternal::Optional<ByteString>,lexer::Token>{
 auto __jakt_enum_value = (((*this).peek()));
 if (__jakt_enum_value == static_cast<u8>(u8'b')) {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("b"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("b"sv)));
 }
 else if (__jakt_enum_value == static_cast<u8>(u8'c')) {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("c"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("c"sv)));
 }
 else {
 return JaktInternal::ExplicitValue(JaktInternal::OptionalNone());
@@ -197,7 +197,7 @@ if (((!(escaped)) && ((((*this).peek())) == (static_cast<u8>(u8'\\'))))){
 ((((*this).index)++));
 }
 if ((((*this).eof()) || ((((*this).peek())) != (static_cast<u8>(u8'\''))))){
-((*this).error((ByteString::must_from_utf8("Expected single quote"sv)),((*this).span(start,start))));
+((*this).error((ByteString::from_utf8_without_validation("Expected single quote"sv)),((*this).span(start,start))));
 }
 ((((*this).index)) += (static_cast<size_t>(1ULL)));
 ByteStringBuilder builder = ByteStringBuilder::create();
@@ -215,7 +215,7 @@ lexer::Token lexer::Lexer::lex_number_or_name() {
 {
 size_t const start = ((*this).index);
 if (((*this).eof())){
-((*this).error((ByteString::must_from_utf8("unexpected eof"sv)),((*this).span(start,start))));
+((*this).error((ByteString::from_utf8_without_validation("unexpected eof"sv)),((*this).span(start,start))));
 return lexer::Token::Garbage(JaktInternal::OptionalNone(),((*this).span(start,start)));
 }
 if (utility::is_ascii_digit(((*this).peek()))){
@@ -241,11 +241,11 @@ return (infallible_enum_cast<jakt__prelude__operators::Ordering>((JaktInternal::
 (self,rhs))))) != (static_cast<u8>(0)));
 }
 }
-(JaktInternal::checked_sub(end,start),static_cast<size_t>(6ULL)) && ((((string).substring(static_cast<size_t>(0ULL),static_cast<size_t>(6ULL)))) == ((ByteString::must_from_utf8("__jakt"sv)))))){
-((*this).error((ByteString::must_from_utf8("reserved identifier name"sv)),span));
+(JaktInternal::checked_sub(end,start),static_cast<size_t>(6ULL)) && ((((string).substring(static_cast<size_t>(0ULL),static_cast<size_t>(6ULL)))) == ((ByteString::from_utf8_without_validation("__jakt"sv)))))){
+((*this).error((ByteString::from_utf8_without_validation("reserved identifier name"sv)),span));
 }
 if (((((*this).illegal_cpp_keywords)).contains(string))){
-((*this).error((ByteString::must_from_utf8("C++ keywords are not allowed to be used as identifiers"sv)),span));
+((*this).error((ByteString::from_utf8_without_validation("C++ keywords are not allowed to be used as identifiers"sv)),span));
 }
 return lexer::Token::from_keyword_or_identifier(string,span);
 }
@@ -508,7 +508,7 @@ lexer::Token lexer::Lexer::lex_quoted_string(u8 const delimiter) {
 size_t const start = ((*this).index);
 (++(((*this).index)));
 if (((*this).eof())){
-((*this).error((ByteString::must_from_utf8("unexpected eof"sv)),((*this).span(start,start))));
+((*this).error((ByteString::from_utf8_without_validation("unexpected eof"sv)),((*this).span(start,start))));
 return lexer::Token::Garbage(JaktInternal::OptionalNone(),((*this).span(start,start)));
 }
 bool escaped = false;
@@ -5236,163 +5236,163 @@ lexer::Token lexer::Token::from_keyword_or_identifier(ByteString const string,ut
 return ({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<lexer::Token,lexer::Token>{
 auto __jakt_enum_value = (string);
-if (__jakt_enum_value == (ByteString::must_from_utf8("and"sv))) {
+if (__jakt_enum_value == (ByteString::from_utf8_without_validation("and"sv))) {
 return JaktInternal::ExplicitValue(lexer::Token::And(span));
 }
-else if (__jakt_enum_value == (ByteString::must_from_utf8("anon"sv))) {
+else if (__jakt_enum_value == (ByteString::from_utf8_without_validation("anon"sv))) {
 return JaktInternal::ExplicitValue(lexer::Token::Anon(span));
 }
-else if (__jakt_enum_value == (ByteString::must_from_utf8("as"sv))) {
+else if (__jakt_enum_value == (ByteString::from_utf8_without_validation("as"sv))) {
 return JaktInternal::ExplicitValue(lexer::Token::As(span));
 }
-else if (__jakt_enum_value == (ByteString::must_from_utf8("boxed"sv))) {
+else if (__jakt_enum_value == (ByteString::from_utf8_without_validation("boxed"sv))) {
 return JaktInternal::ExplicitValue(lexer::Token::Boxed(span));
 }
-else if (__jakt_enum_value == (ByteString::must_from_utf8("break"sv))) {
+else if (__jakt_enum_value == (ByteString::from_utf8_without_validation("break"sv))) {
 return JaktInternal::ExplicitValue(lexer::Token::Break(span));
 }
-else if (__jakt_enum_value == (ByteString::must_from_utf8("catch"sv))) {
+else if (__jakt_enum_value == (ByteString::from_utf8_without_validation("catch"sv))) {
 return JaktInternal::ExplicitValue(lexer::Token::Catch(span));
 }
-else if (__jakt_enum_value == (ByteString::must_from_utf8("class"sv))) {
+else if (__jakt_enum_value == (ByteString::from_utf8_without_validation("class"sv))) {
 return JaktInternal::ExplicitValue(lexer::Token::Class(span));
 }
-else if (__jakt_enum_value == (ByteString::must_from_utf8("continue"sv))) {
+else if (__jakt_enum_value == (ByteString::from_utf8_without_validation("continue"sv))) {
 return JaktInternal::ExplicitValue(lexer::Token::Continue(span));
 }
-else if (__jakt_enum_value == (ByteString::must_from_utf8("cpp"sv))) {
+else if (__jakt_enum_value == (ByteString::from_utf8_without_validation("cpp"sv))) {
 return JaktInternal::ExplicitValue(lexer::Token::Cpp(span));
 }
-else if (__jakt_enum_value == (ByteString::must_from_utf8("defer"sv))) {
+else if (__jakt_enum_value == (ByteString::from_utf8_without_validation("defer"sv))) {
 return JaktInternal::ExplicitValue(lexer::Token::Defer(span));
 }
-else if (__jakt_enum_value == (ByteString::must_from_utf8("destructor"sv))) {
+else if (__jakt_enum_value == (ByteString::from_utf8_without_validation("destructor"sv))) {
 return JaktInternal::ExplicitValue(lexer::Token::Destructor(span));
 }
-else if (__jakt_enum_value == (ByteString::must_from_utf8("else"sv))) {
+else if (__jakt_enum_value == (ByteString::from_utf8_without_validation("else"sv))) {
 return JaktInternal::ExplicitValue(lexer::Token::Else(span));
 }
-else if (__jakt_enum_value == (ByteString::must_from_utf8("enum"sv))) {
+else if (__jakt_enum_value == (ByteString::from_utf8_without_validation("enum"sv))) {
 return JaktInternal::ExplicitValue(lexer::Token::Enum(span));
 }
-else if (__jakt_enum_value == (ByteString::must_from_utf8("extern"sv))) {
+else if (__jakt_enum_value == (ByteString::from_utf8_without_validation("extern"sv))) {
 return JaktInternal::ExplicitValue(lexer::Token::Extern(span));
 }
-else if (__jakt_enum_value == (ByteString::must_from_utf8("false"sv))) {
+else if (__jakt_enum_value == (ByteString::from_utf8_without_validation("false"sv))) {
 return JaktInternal::ExplicitValue(lexer::Token::False(span));
 }
-else if (__jakt_enum_value == (ByteString::must_from_utf8("for"sv))) {
+else if (__jakt_enum_value == (ByteString::from_utf8_without_validation("for"sv))) {
 return JaktInternal::ExplicitValue(lexer::Token::For(span));
 }
-else if (__jakt_enum_value == (ByteString::must_from_utf8("fn"sv))) {
+else if (__jakt_enum_value == (ByteString::from_utf8_without_validation("fn"sv))) {
 return JaktInternal::ExplicitValue(lexer::Token::Fn(span));
 }
-else if (__jakt_enum_value == (ByteString::must_from_utf8("comptime"sv))) {
+else if (__jakt_enum_value == (ByteString::from_utf8_without_validation("comptime"sv))) {
 return JaktInternal::ExplicitValue(lexer::Token::Comptime(span));
 }
-else if (__jakt_enum_value == (ByteString::must_from_utf8("if"sv))) {
+else if (__jakt_enum_value == (ByteString::from_utf8_without_validation("if"sv))) {
 return JaktInternal::ExplicitValue(lexer::Token::If(span));
 }
-else if (__jakt_enum_value == (ByteString::must_from_utf8("import"sv))) {
+else if (__jakt_enum_value == (ByteString::from_utf8_without_validation("import"sv))) {
 return JaktInternal::ExplicitValue(lexer::Token::Import(span));
 }
-else if (__jakt_enum_value == (ByteString::must_from_utf8("relative"sv))) {
+else if (__jakt_enum_value == (ByteString::from_utf8_without_validation("relative"sv))) {
 return JaktInternal::ExplicitValue(lexer::Token::Relative(span));
 }
-else if (__jakt_enum_value == (ByteString::must_from_utf8("in"sv))) {
+else if (__jakt_enum_value == (ByteString::from_utf8_without_validation("in"sv))) {
 return JaktInternal::ExplicitValue(lexer::Token::In(span));
 }
-else if (__jakt_enum_value == (ByteString::must_from_utf8("is"sv))) {
+else if (__jakt_enum_value == (ByteString::from_utf8_without_validation("is"sv))) {
 return JaktInternal::ExplicitValue(lexer::Token::Is(span));
 }
-else if (__jakt_enum_value == (ByteString::must_from_utf8("let"sv))) {
+else if (__jakt_enum_value == (ByteString::from_utf8_without_validation("let"sv))) {
 return JaktInternal::ExplicitValue(lexer::Token::Let(span));
 }
-else if (__jakt_enum_value == (ByteString::must_from_utf8("loop"sv))) {
+else if (__jakt_enum_value == (ByteString::from_utf8_without_validation("loop"sv))) {
 return JaktInternal::ExplicitValue(lexer::Token::Loop(span));
 }
-else if (__jakt_enum_value == (ByteString::must_from_utf8("match"sv))) {
+else if (__jakt_enum_value == (ByteString::from_utf8_without_validation("match"sv))) {
 return JaktInternal::ExplicitValue(lexer::Token::Match(span));
 }
-else if (__jakt_enum_value == (ByteString::must_from_utf8("mut"sv))) {
+else if (__jakt_enum_value == (ByteString::from_utf8_without_validation("mut"sv))) {
 return JaktInternal::ExplicitValue(lexer::Token::Mut(span));
 }
-else if (__jakt_enum_value == (ByteString::must_from_utf8("namespace"sv))) {
+else if (__jakt_enum_value == (ByteString::from_utf8_without_validation("namespace"sv))) {
 return JaktInternal::ExplicitValue(lexer::Token::Namespace(span));
 }
-else if (__jakt_enum_value == (ByteString::must_from_utf8("not"sv))) {
+else if (__jakt_enum_value == (ByteString::from_utf8_without_validation("not"sv))) {
 return JaktInternal::ExplicitValue(lexer::Token::Not(span));
 }
-else if (__jakt_enum_value == (ByteString::must_from_utf8("or"sv))) {
+else if (__jakt_enum_value == (ByteString::from_utf8_without_validation("or"sv))) {
 return JaktInternal::ExplicitValue(lexer::Token::Or(span));
 }
-else if (__jakt_enum_value == (ByteString::must_from_utf8("override"sv))) {
+else if (__jakt_enum_value == (ByteString::from_utf8_without_validation("override"sv))) {
 return JaktInternal::ExplicitValue(lexer::Token::Override(span));
 }
-else if (__jakt_enum_value == (ByteString::must_from_utf8("private"sv))) {
+else if (__jakt_enum_value == (ByteString::from_utf8_without_validation("private"sv))) {
 return JaktInternal::ExplicitValue(lexer::Token::Private(span));
 }
-else if (__jakt_enum_value == (ByteString::must_from_utf8("public"sv))) {
+else if (__jakt_enum_value == (ByteString::from_utf8_without_validation("public"sv))) {
 return JaktInternal::ExplicitValue(lexer::Token::Public(span));
 }
-else if (__jakt_enum_value == (ByteString::must_from_utf8("raw"sv))) {
+else if (__jakt_enum_value == (ByteString::from_utf8_without_validation("raw"sv))) {
 return JaktInternal::ExplicitValue(lexer::Token::Raw(span));
 }
-else if (__jakt_enum_value == (ByteString::must_from_utf8("reflect"sv))) {
+else if (__jakt_enum_value == (ByteString::from_utf8_without_validation("reflect"sv))) {
 return JaktInternal::ExplicitValue(lexer::Token::Reflect(span));
 }
-else if (__jakt_enum_value == (ByteString::must_from_utf8("return"sv))) {
+else if (__jakt_enum_value == (ByteString::from_utf8_without_validation("return"sv))) {
 return JaktInternal::ExplicitValue(lexer::Token::Return(span));
 }
-else if (__jakt_enum_value == (ByteString::must_from_utf8("restricted"sv))) {
+else if (__jakt_enum_value == (ByteString::from_utf8_without_validation("restricted"sv))) {
 return JaktInternal::ExplicitValue(lexer::Token::Restricted(span));
 }
-else if (__jakt_enum_value == (ByteString::must_from_utf8("sizeof"sv))) {
+else if (__jakt_enum_value == (ByteString::from_utf8_without_validation("sizeof"sv))) {
 return JaktInternal::ExplicitValue(lexer::Token::Sizeof(span));
 }
-else if (__jakt_enum_value == (ByteString::must_from_utf8("struct"sv))) {
+else if (__jakt_enum_value == (ByteString::from_utf8_without_validation("struct"sv))) {
 return JaktInternal::ExplicitValue(lexer::Token::Struct(span));
 }
-else if (__jakt_enum_value == (ByteString::must_from_utf8("this"sv))) {
+else if (__jakt_enum_value == (ByteString::from_utf8_without_validation("this"sv))) {
 return JaktInternal::ExplicitValue(lexer::Token::This(span));
 }
-else if (__jakt_enum_value == (ByteString::must_from_utf8("throw"sv))) {
+else if (__jakt_enum_value == (ByteString::from_utf8_without_validation("throw"sv))) {
 return JaktInternal::ExplicitValue(lexer::Token::Throw(span));
 }
-else if (__jakt_enum_value == (ByteString::must_from_utf8("throws"sv))) {
+else if (__jakt_enum_value == (ByteString::from_utf8_without_validation("throws"sv))) {
 return JaktInternal::ExplicitValue(lexer::Token::Throws(span));
 }
-else if (__jakt_enum_value == (ByteString::must_from_utf8("true"sv))) {
+else if (__jakt_enum_value == (ByteString::from_utf8_without_validation("true"sv))) {
 return JaktInternal::ExplicitValue(lexer::Token::True(span));
 }
-else if (__jakt_enum_value == (ByteString::must_from_utf8("try"sv))) {
+else if (__jakt_enum_value == (ByteString::from_utf8_without_validation("try"sv))) {
 return JaktInternal::ExplicitValue(lexer::Token::Try(span));
 }
-else if (__jakt_enum_value == (ByteString::must_from_utf8("unsafe"sv))) {
+else if (__jakt_enum_value == (ByteString::from_utf8_without_validation("unsafe"sv))) {
 return JaktInternal::ExplicitValue(lexer::Token::Unsafe(span));
 }
-else if (__jakt_enum_value == (ByteString::must_from_utf8("virtual"sv))) {
+else if (__jakt_enum_value == (ByteString::from_utf8_without_validation("virtual"sv))) {
 return JaktInternal::ExplicitValue(lexer::Token::Virtual(span));
 }
-else if (__jakt_enum_value == (ByteString::must_from_utf8("weak"sv))) {
+else if (__jakt_enum_value == (ByteString::from_utf8_without_validation("weak"sv))) {
 return JaktInternal::ExplicitValue(lexer::Token::Weak(span));
 }
-else if (__jakt_enum_value == (ByteString::must_from_utf8("while"sv))) {
+else if (__jakt_enum_value == (ByteString::from_utf8_without_validation("while"sv))) {
 return JaktInternal::ExplicitValue(lexer::Token::While(span));
 }
-else if (__jakt_enum_value == (ByteString::must_from_utf8("yield"sv))) {
+else if (__jakt_enum_value == (ByteString::from_utf8_without_validation("yield"sv))) {
 return JaktInternal::ExplicitValue(lexer::Token::Yield(span));
 }
-else if (__jakt_enum_value == (ByteString::must_from_utf8("guard"sv))) {
+else if (__jakt_enum_value == (ByteString::from_utf8_without_validation("guard"sv))) {
 return JaktInternal::ExplicitValue(lexer::Token::Guard(span));
 }
-else if (__jakt_enum_value == (ByteString::must_from_utf8("requires"sv))) {
+else if (__jakt_enum_value == (ByteString::from_utf8_without_validation("requires"sv))) {
 return JaktInternal::ExplicitValue(lexer::Token::Requires(span));
 }
-else if (__jakt_enum_value == (ByteString::must_from_utf8("implements"sv))) {
+else if (__jakt_enum_value == (ByteString::from_utf8_without_validation("implements"sv))) {
 return JaktInternal::ExplicitValue(lexer::Token::Implements(span));
 }
-else if (__jakt_enum_value == (ByteString::must_from_utf8("trait"sv))) {
+else if (__jakt_enum_value == (ByteString::from_utf8_without_validation("trait"sv))) {
 return JaktInternal::ExplicitValue(lexer::Token::Trait(span));
 }
 else {
@@ -5550,16 +5550,16 @@ return ({
 auto&& __jakt_match_variant = *this;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 0 /* None */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8(""sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation(""sv)));
 };/*case end*/
 case 1 /* Hexadecimal */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("0x"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("0x"sv)));
 };/*case end*/
 case 2 /* Octal */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("0o"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("0o"sv)));
 };/*case end*/
 case 3 /* Binary */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("0b"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("0b"sv)));
 };/*case end*/
 default: VERIFY_NOT_REACHED();}/*switch end*/
 }()
@@ -5883,40 +5883,40 @@ return ({
 auto&& __jakt_match_variant = *this;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 0 /* None */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8(""sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation(""sv)));
 };/*case end*/
 case 1 /* UZ */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("uz"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("uz"sv)));
 };/*case end*/
 case 2 /* U8 */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("u8"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("u8"sv)));
 };/*case end*/
 case 3 /* U16 */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("u16"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("u16"sv)));
 };/*case end*/
 case 4 /* U32 */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("u32"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("u32"sv)));
 };/*case end*/
 case 5 /* U64 */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("u64"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("u64"sv)));
 };/*case end*/
 case 6 /* I8 */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("i8"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("i8"sv)));
 };/*case end*/
 case 7 /* I16 */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("i16"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("i16"sv)));
 };/*case end*/
 case 8 /* I32 */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("i32"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("i32"sv)));
 };/*case end*/
 case 9 /* I64 */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("i64"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("i64"sv)));
 };/*case end*/
 case 10 /* F32 */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("f32"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("f32"sv)));
 };/*case end*/
 case 11 /* F64 */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("f64"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("f64"sv)));
 };/*case end*/
 default: VERIFY_NOT_REACHED();}/*switch end*/
 }()

--- a/bootstrap/stage0/main.cpp
+++ b/bootstrap/stage0/main.cpp
@@ -2,428 +2,428 @@
 namespace Jakt {
 ByteString usage() {
 {
-return (ByteString::must_from_utf8("usage: jakt [cross] [-h] [OPTIONS] <filename>"sv));
+return (ByteString::from_utf8_without_validation("usage: jakt [cross] [-h] [OPTIONS] <filename>"sv));
 }
 }
 
 ByteString help() {
 {
-ByteString output = (ByteString::must_from_utf8(""sv));
+ByteString output = (ByteString::from_utf8_without_validation(""sv));
 [](ByteString& self, ByteString rhs) -> void {
 {
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8("Non-cross mode:\n"sv)));
+(output,(ByteString::from_utf8_without_validation("Non-cross mode:\n"sv)));
 [](ByteString& self, ByteString rhs) -> void {
 {
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8("= General:\n"sv)));
+(output,(ByteString::from_utf8_without_validation("= General:\n"sv)));
 [](ByteString& self, ByteString rhs) -> void {
 {
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8("  -h,--help\t\t\t\tPrint this help and exit.\n"sv)));
+(output,(ByteString::from_utf8_without_validation("  -h,--help\t\t\t\tPrint this help and exit.\n"sv)));
 [](ByteString& self, ByteString rhs) -> void {
 {
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8("  -v,--version\t\t\t\tPrint the compiler's version and exit.\n"sv)));
+(output,(ByteString::from_utf8_without_validation("  -v,--version\t\t\t\tPrint the compiler's version and exit.\n"sv)));
 [](ByteString& self, ByteString rhs) -> void {
 {
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8("  -cr,--compile-run\t\t\tBuild and run an executable file.\n"sv)));
+(output,(ByteString::from_utf8_without_validation("  -cr,--compile-run\t\t\tBuild and run an executable file.\n"sv)));
 [](ByteString& self, ByteString rhs) -> void {
 {
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8("  -r,--run\t\t\t\tRun the given file without compiling it (all positional arguments after the file name will be passed to main).\n"sv)));
+(output,(ByteString::from_utf8_without_validation("  -r,--run\t\t\t\tRun the given file without compiling it (all positional arguments after the file name will be passed to main).\n"sv)));
 [](ByteString& self, ByteString rhs) -> void {
 {
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8("  --repl\t\t\t\tStart a Read-Eval-Print loop session.\n"sv)));
+(output,(ByteString::from_utf8_without_validation("  --repl\t\t\t\tStart a Read-Eval-Print loop session.\n"sv)));
 [](ByteString& self, ByteString rhs) -> void {
 {
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8("  --create NAME\t\t\t\tCreate sample project in $PWD/NAME\n"sv)));
+(output,(ByteString::from_utf8_without_validation("  --create NAME\t\t\t\tCreate sample project in $PWD/NAME\n"sv)));
 [](ByteString& self, ByteString rhs) -> void {
 {
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8("= Compilation:\n"sv)));
+(output,(ByteString::from_utf8_without_validation("= Compilation:\n"sv)));
 [](ByteString& self, ByteString rhs) -> void {
 {
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8("  --config KEY=VALUE\t\t\tSet a user configuration value.\n"sv)));
+(output,(ByteString::from_utf8_without_validation("  --config KEY=VALUE\t\t\tSet a user configuration value.\n"sv)));
 [](ByteString& self, ByteString rhs) -> void {
 {
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8("  -c,--check-only\t\t\tOnly check the code for errors.\n"sv)));
+(output,(ByteString::from_utf8_without_validation("  -c,--check-only\t\t\tOnly check the code for errors.\n"sv)));
 [](ByteString& self, ByteString rhs) -> void {
 {
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8("  -d\t\t\t\t\tInsert debug statement spans in generated C++ code.\n"sv)));
+(output,(ByteString::from_utf8_without_validation("  -d\t\t\t\t\tInsert debug statement spans in generated C++ code.\n"sv)));
 [](ByteString& self, ByteString rhs) -> void {
 {
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8("  -O\t\t\t\t\tBuild an optimized executable.\n"sv)));
+(output,(ByteString::from_utf8_without_validation("  -O\t\t\t\t\tBuild an optimized executable.\n"sv)));
 [](ByteString& self, ByteString rhs) -> void {
 {
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8("  -S,--emit-cpp-source-only\t\tOnly output source (do not build).\n"sv)));
+(output,(ByteString::from_utf8_without_validation("  -S,--emit-cpp-source-only\t\tOnly output source (do not build).\n"sv)));
 [](ByteString& self, ByteString rhs) -> void {
 {
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8("  --ak-is-my-only-stdlib\t\tForget about interop, AK is the one and only STL.\n"sv)));
+(output,(ByteString::from_utf8_without_validation("  --ak-is-my-only-stdlib\t\tForget about interop, AK is the one and only STL.\n"sv)));
 [](ByteString& self, ByteString rhs) -> void {
 {
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8("  --cxx-compiler-path PATH\t\tPath of the C++ compiler to use when compiling the generated sources.\n\t\t\t\t\tDefaults to clang++.\n"sv)));
+(output,(ByteString::from_utf8_without_validation("  --cxx-compiler-path PATH\t\tPath of the C++ compiler to use when compiling the generated sources.\n\t\t\t\t\tDefaults to clang++.\n"sv)));
 [](ByteString& self, ByteString rhs) -> void {
 {
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8("  -M,--dep-file FILE\t\t\tEmit a depfile listing dependencies of the main output.\n"sv)));
+(output,(ByteString::from_utf8_without_validation("  -M,--dep-file FILE\t\t\tEmit a depfile listing dependencies of the main output.\n"sv)));
 [](ByteString& self, ByteString rhs) -> void {
 {
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8("  --extra-cpp-flagFLAG\t\t\tPass FLAG to the compiler. Can be specified multiple times.\n"sv)));
+(output,(ByteString::from_utf8_without_validation("  --extra-cpp-flagFLAG\t\t\tPass FLAG to the compiler. Can be specified multiple times.\n"sv)));
 [](ByteString& self, ByteString rhs) -> void {
 {
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8("  --use-ccache\t\t\t\tUse ccache when compiling.\n"sv)));
+(output,(ByteString::from_utf8_without_validation("  --use-ccache\t\t\t\tUse ccache when compiling.\n"sv)));
 [](ByteString& self, ByteString rhs) -> void {
 {
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8("  -o,--output-filename FILE\t\tName of the output binary.\n\t\t\t\t\tDefaults to the input-filename without the extension.\n"sv)));
+(output,(ByteString::from_utf8_without_validation("  -o,--output-filename FILE\t\tName of the output binary.\n\t\t\t\t\tDefaults to the input-filename without the extension.\n"sv)));
 [](ByteString& self, ByteString rhs) -> void {
 {
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8("  -B,--binary-dir PATH\t\t\tOutput directory for compiled files.\n\t\t\t\t\tDefaults to $PWD/build.\n"sv)));
+(output,(ByteString::from_utf8_without_validation("  -B,--binary-dir PATH\t\t\tOutput directory for compiled files.\n\t\t\t\t\tDefaults to $PWD/build.\n"sv)));
 [](ByteString& self, ByteString rhs) -> void {
 {
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8("  -I PATH\t\t\t\tAdd PATH to compiler's include list. Can be specified multiple times.\n"sv)));
+(output,(ByteString::from_utf8_without_validation("  -I PATH\t\t\t\tAdd PATH to compiler's include list. Can be specified multiple times.\n"sv)));
 [](ByteString& self, ByteString rhs) -> void {
 {
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8("  -J,--jobs NUMBER\t\t\tSpecify the number of jobs to run in parallel, defaults to 2 (1 on windows).\n"sv)));
+(output,(ByteString::from_utf8_without_validation("  -J,--jobs NUMBER\t\t\tSpecify the number of jobs to run in parallel, defaults to 2 (1 on windows).\n"sv)));
 [](ByteString& self, ByteString rhs) -> void {
 {
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8("  -L PATH\t\t\t\tAdd PATH to linker's search list. Can be specified multiple times.\n"sv)));
+(output,(ByteString::from_utf8_without_validation("  -L PATH\t\t\t\tAdd PATH to linker's search list. Can be specified multiple times.\n"sv)));
 [](ByteString& self, ByteString rhs) -> void {
 {
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8("  -l,--link-with LIB\t\t\tLink executable with LIB. Can be specified multiple times.\n"sv)));
+(output,(ByteString::from_utf8_without_validation("  -l,--link-with LIB\t\t\tLink executable with LIB. Can be specified multiple times.\n"sv)));
 [](ByteString& self, ByteString rhs) -> void {
 {
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8("  -T,--target-triple TARGET\t\tSpecify the target triple used for the build, defaults to native.\n"sv)));
+(output,(ByteString::from_utf8_without_validation("  -T,--target-triple TARGET\t\tSpecify the target triple used for the build, defaults to native.\n"sv)));
 [](ByteString& self, ByteString rhs) -> void {
 {
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8("  -WlARG\t\t\t\tPass ARG to the linker. Can be specified multiple times.\n"sv)));
+(output,(ByteString::from_utf8_without_validation("  -WlARG\t\t\t\tPass ARG to the linker. Can be specified multiple times.\n"sv)));
 [](ByteString& self, ByteString rhs) -> void {
 {
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8("  -X FILE\t\t\t\tPass FILE to the compiler. Can be specified multiple times.\n"sv)));
+(output,(ByteString::from_utf8_without_validation("  -X FILE\t\t\t\tPass FILE to the compiler. Can be specified multiple times.\n"sv)));
 [](ByteString& self, ByteString rhs) -> void {
 {
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8("= Debugging:\n"sv)));
+(output,(ByteString::from_utf8_without_validation("= Debugging:\n"sv)));
 [](ByteString& self, ByteString rhs) -> void {
 {
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8("  -dl\t\t\t\t\tPrint debug info for the lexer.\n"sv)));
+(output,(ByteString::from_utf8_without_validation("  -dl\t\t\t\t\tPrint debug info for the lexer.\n"sv)));
 [](ByteString& self, ByteString rhs) -> void {
 {
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8("  -dp\t\t\t\t\tPrint debug info for the parser.\n"sv)));
+(output,(ByteString::from_utf8_without_validation("  -dp\t\t\t\t\tPrint debug info for the parser.\n"sv)));
 [](ByteString& self, ByteString rhs) -> void {
 {
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8("  -dt\t\t\t\t\tPrint debug info for the typechecker.\n"sv)));
+(output,(ByteString::from_utf8_without_validation("  -dt\t\t\t\t\tPrint debug info for the typechecker.\n"sv)));
 [](ByteString& self, ByteString rhs) -> void {
 {
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8("  -fd,--format-debug\t\t\tOutput debug info for the formatter.\n"sv)));
+(output,(ByteString::from_utf8_without_validation("  -fd,--format-debug\t\t\tOutput debug info for the formatter.\n"sv)));
 [](ByteString& self, ByteString rhs) -> void {
 {
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8("  -p,--prettify-cpp-source\t\tRun emitted C++ source through clang-format.\n"sv)));
+(output,(ByteString::from_utf8_without_validation("  -p,--prettify-cpp-source\t\tRun emitted C++ source through clang-format.\n"sv)));
 [](ByteString& self, ByteString rhs) -> void {
 {
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8("  -D,--dot-clang-format-path PATH\tPath to the .clang-format file to use.\n\t\t\t\t\tDefaults to none, invoking clangs default .clang-format file handling.\n"sv)));
+(output,(ByteString::from_utf8_without_validation("  -D,--dot-clang-format-path PATH\tPath to the .clang-format file to use.\n\t\t\t\t\tDefaults to none, invoking clangs default .clang-format file handling.\n"sv)));
 [](ByteString& self, ByteString rhs) -> void {
 {
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8("  -F,--clang-format-path PATH\t\tPath to clang-format executable.\n\t\t\t\t\tDefaults to clang-format\n"sv)));
+(output,(ByteString::from_utf8_without_validation("  -F,--clang-format-path PATH\t\tPath to clang-format executable.\n\t\t\t\t\tDefaults to clang-format\n"sv)));
 [](ByteString& self, ByteString rhs) -> void {
 {
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8("  --debug-print\t\t\t\tOutput debug print.\n"sv)));
+(output,(ByteString::from_utf8_without_validation("  --debug-print\t\t\t\tOutput debug print.\n"sv)));
 [](ByteString& self, ByteString rhs) -> void {
 {
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8("= Formatting:\n"sv)));
+(output,(ByteString::from_utf8_without_validation("= Formatting:\n"sv)));
 [](ByteString& self, ByteString rhs) -> void {
 {
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8("  -f,--format\t\t\t\tFormat a file or directory and output the result.\n"sv)));
+(output,(ByteString::from_utf8_without_validation("  -f,--format\t\t\t\tFormat a file or directory and output the result.\n"sv)));
 [](ByteString& self, ByteString rhs) -> void {
 {
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8("  -fi,--format-inplace\t\t\tFormat a file or directory and save the result inplace.\n"sv)));
+(output,(ByteString::from_utf8_without_validation("  -fi,--format-inplace\t\t\tFormat a file or directory and save the result inplace.\n"sv)));
 [](ByteString& self, ByteString rhs) -> void {
 {
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8("  -fr,--format-range RANGE\t\tEmit part of the document with formatting applied.\n"sv)));
+(output,(ByteString::from_utf8_without_validation("  -fr,--format-range RANGE\t\tEmit part of the document with formatting applied.\n"sv)));
 [](ByteString& self, ByteString rhs) -> void {
 {
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8("= IDE integration:\n"sv)));
+(output,(ByteString::from_utf8_without_validation("= IDE integration:\n"sv)));
 [](ByteString& self, ByteString rhs) -> void {
 {
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8("  -e,--hover INDEX\t\t\tReturn the type of element at index.\n"sv)));
+(output,(ByteString::from_utf8_without_validation("  -e,--hover INDEX\t\t\tReturn the type of element at index.\n"sv)));
 [](ByteString& self, ByteString rhs) -> void {
 {
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8("  -g,--goto-def INDEX\t\t\tReturn the span for the definition at index.\n"sv)));
+(output,(ByteString::from_utf8_without_validation("  -g,--goto-def INDEX\t\t\tReturn the span for the definition at index.\n"sv)));
 [](ByteString& self, ByteString rhs) -> void {
 {
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8("  -H,--type-hints\t\t\tEmit machine-readable type hints (for IDE integration).\n"sv)));
+(output,(ByteString::from_utf8_without_validation("  -H,--type-hints\t\t\tEmit machine-readable type hints (for IDE integration).\n"sv)));
 [](ByteString& self, ByteString rhs) -> void {
 {
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8("  -m,--completions INDEX\t\tReturn dot completions at index.\n"sv)));
+(output,(ByteString::from_utf8_without_validation("  -m,--completions INDEX\t\tReturn dot completions at index.\n"sv)));
 [](ByteString& self, ByteString rhs) -> void {
 {
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8("  --print-symbols\t\t\tEmit a machine-readable (JSON) symbol tree.\n"sv)));
+(output,(ByteString::from_utf8_without_validation("  --print-symbols\t\t\tEmit a machine-readable (JSON) symbol tree.\n"sv)));
 [](ByteString& self, ByteString rhs) -> void {
 {
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8("  --try-hints\t\t\t\tEmit machine-readable try hints (for IDE integration).\n"sv)));
+(output,(ByteString::from_utf8_without_validation("  --try-hints\t\t\t\tEmit machine-readable try hints (for IDE integration).\n"sv)));
 [](ByteString& self, ByteString rhs) -> void {
 {
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8("  -t,--goto-type-def INDEX\t\tReturn the span for the type definition at index.\n"sv)));
+(output,(ByteString::from_utf8_without_validation("  -t,--goto-type-def INDEX\t\tReturn the span for the type definition at index.\n"sv)));
 [](ByteString& self, ByteString rhs) -> void {
 {
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8("= Misc:\n"sv)));
+(output,(ByteString::from_utf8_without_validation("= Misc:\n"sv)));
 [](ByteString& self, ByteString rhs) -> void {
 {
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8("  --discover\t\t\t\tDiscover all files in the project, print the dependencies and outputs, then exit.\n"sv)));
+(output,(ByteString::from_utf8_without_validation("  --discover\t\t\t\tDiscover all files in the project, print the dependencies and outputs, then exit.\n"sv)));
 [](ByteString& self, ByteString rhs) -> void {
 {
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8("  -j,--json-errors\t\t\tEmit machine-readable (JSON) errors.\n"sv)));
+(output,(ByteString::from_utf8_without_validation("  -j,--json-errors\t\t\tEmit machine-readable (JSON) errors.\n"sv)));
 [](ByteString& self, ByteString rhs) -> void {
 {
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8("  --runtime-library-path PATH\t\tSpecify the path to the runtime library.\n"sv)));
+(output,(ByteString::from_utf8_without_validation("  --runtime-library-path PATH\t\tSpecify the path to the runtime library.\n"sv)));
 [](ByteString& self, ByteString rhs) -> void {
 {
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8("  --runtime-path PATH\t\t\tSpecify the path to the host runtime headers.\n"sv)));
+(output,(ByteString::from_utf8_without_validation("  --runtime-path PATH\t\t\tSpecify the path to the host runtime headers.\n"sv)));
 [](ByteString& self, ByteString rhs) -> void {
 {
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8("  -R,--runtime-path PATH\t\tPath of the Jakt runtime headers.\n\t\t\t\t\tDefaults to $PWD/runtime.\n"sv)));
+(output,(ByteString::from_utf8_without_validation("  -R,--runtime-path PATH\t\tPath of the Jakt runtime headers.\n\t\t\t\t\tDefaults to $PWD/runtime.\n"sv)));
 [](ByteString& self, ByteString rhs) -> void {
 {
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8("  --assume-main-file-path PATH\t\tAssume the main file is at PATH.\n"sv)));
+(output,(ByteString::from_utf8_without_validation("  --assume-main-file-path PATH\t\tAssume the main file is at PATH.\n"sv)));
 [](ByteString& self, ByteString rhs) -> void {
 {
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8("\nCross mode:\n"sv)));
+(output,(ByteString::from_utf8_without_validation("\nCross mode:\n"sv)));
 [](ByteString& self, ByteString rhs) -> void {
 {
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8("All other given options and flags will be passed to the compiler invocation verbatim.\n"sv)));
+(output,(ByteString::from_utf8_without_validation("All other given options and flags will be passed to the compiler invocation verbatim.\n"sv)));
 [](ByteString& self, ByteString rhs) -> void {
 {
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8("  --source-file PATH\t\t\tSpecify the path to the source file to compile.\n"sv)));
+(output,(ByteString::from_utf8_without_validation("  --source-file PATH\t\t\tSpecify the path to the source file to compile.\n"sv)));
 [](ByteString& self, ByteString rhs) -> void {
 {
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8("  -T,--target-triple TARGET\t\tSpecify the target triple used for the build, defaults to native.\n"sv)));
+(output,(ByteString::from_utf8_without_validation("  -T,--target-triple TARGET\t\tSpecify the target triple used for the build, defaults to native.\n"sv)));
 [](ByteString& self, ByteString rhs) -> void {
 {
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8("  --sysroot PATH\t\t\tSpecify the sysroot used for the build.\n"sv)));
+(output,(ByteString::from_utf8_without_validation("  --sysroot PATH\t\t\tSpecify the sysroot used for the build.\n"sv)));
 [](ByteString& self, ByteString rhs) -> void {
 {
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8("  --system-include-dir PATH\t\tSpecify a system include directory to use.\n"sv)));
+(output,(ByteString::from_utf8_without_validation("  --system-include-dir PATH\t\tSpecify a system include directory to use.\n"sv)));
 [](ByteString& self, ByteString rhs) -> void {
 {
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8("  --system-lib-dir PATH\t\t\tSpecify a system library directory to use.\n"sv)));
+(output,(ByteString::from_utf8_without_validation("  --system-lib-dir PATH\t\t\tSpecify a system library directory to use.\n"sv)));
 [](ByteString& self, ByteString rhs) -> void {
 {
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8("  --compiler-include-dir PATH\t\tSpecify a compiler include directory to use.\n"sv)));
+(output,(ByteString::from_utf8_without_validation("  --compiler-include-dir PATH\t\tSpecify a compiler include directory to use.\n"sv)));
 [](ByteString& self, ByteString rhs) -> void {
 {
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8("  --compiler-lib-dir PATH\t\tSpecify a compiler library directory to use.\n"sv)));
+(output,(ByteString::from_utf8_without_validation("  --compiler-lib-dir PATH\t\tSpecify a compiler library directory to use.\n"sv)));
 [](ByteString& self, ByteString rhs) -> void {
 {
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8("  --install-root PATH\t\t\tSpecify the root directory to install to.\n"sv)));
+(output,(ByteString::from_utf8_without_validation("  --install-root PATH\t\t\tSpecify the root directory to install to.\n"sv)));
 [](ByteString& self, ByteString rhs) -> void {
 {
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8("  --only-support-libs\t\t\tOnly build and install support libraries for the target platform.\n"sv)));
+(output,(ByteString::from_utf8_without_validation("  --only-support-libs\t\t\tOnly build and install support libraries for the target platform.\n"sv)));
 [](ByteString& self, ByteString rhs) -> void {
 {
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8("  --runtime-lib-path PATH\t\tSpecify the path to the host runtime library.\n"sv)));
+(output,(ByteString::from_utf8_without_validation("  --runtime-lib-path PATH\t\tSpecify the path to the host runtime library.\n"sv)));
 return output;
 }
 }
 
 ByteString indent(size_t const level) {
 {
-ByteString output = (ByteString::must_from_utf8(""sv));
+ByteString output = (ByteString::from_utf8_without_validation(""sv));
 {
 JaktInternal::Range<size_t> _magic = (JaktInternal::Range<size_t>{static_cast<size_t>(static_cast<size_t>(0ULL)),static_cast<size_t>(level)});
 for (;;){
@@ -438,7 +438,7 @@ size_t i = (_magic_value.value());
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8("    "sv)));
+(output,(ByteString::from_utf8_without_validation("    "sv)));
 }
 
 }
@@ -513,7 +513,7 @@ return (infallible_enum_cast<jakt__prelude__operators::Ordering>((JaktInternal::
 warnln((StringView::from_string_literal("{}"sv)),usage());
 return static_cast<int>(1);
 }
-if (((((args)[static_cast<i64>(1LL)])) == ((ByteString::must_from_utf8("cross"sv))))){
+if (((((args)[static_cast<i64>(1LL)])) == ((ByteString::from_utf8_without_validation("cross"sv))))){
 return TRY((selfhost_crosscompiler_main(args)));
 }
 return TRY((compiler_main(args)));
@@ -524,7 +524,7 @@ return 0;
 ErrorOr<void> install(jakt__path::Path const from,jakt__path::Path const to) {
 {
 AK::Queue<JaktInternal::Tuple<jakt__path::Path,jakt__path::Path>> directories_to_copy = AK::Queue<JaktInternal::Tuple<jakt__path::Path,jakt__path::Path>>();
-((directories_to_copy).enqueue((Tuple{from, jakt__path::Path::from_string((ByteString::must_from_utf8("."sv)))})));
+((directories_to_copy).enqueue((Tuple{from, jakt__path::Path::from_string((ByteString::from_utf8_without_validation("."sv)))})));
 while ((!(((directories_to_copy).is_empty())))){
 JaktInternal::Tuple<jakt__path::Path,jakt__path::Path> const directory_relative_dir_ = ((directories_to_copy).dequeue());
 jakt__path::Path const directory = ((directory_relative_dir_).template get<0>());
@@ -626,85 +626,85 @@ ByteString const arg = ((args_to_process).dequeue());
 ({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<void,ErrorOr<int>>{
 auto __jakt_enum_value = (arg);
-if (__jakt_enum_value == (ByteString::must_from_utf8("--target-triple"sv))) {
+if (__jakt_enum_value == (ByteString::from_utf8_without_validation("--target-triple"sv))) {
 {
 (target_triple = ((args_to_process).dequeue()));
 }
 return JaktInternal::ExplicitValue<void>();
 }
-else if (__jakt_enum_value == (ByteString::must_from_utf8("-T"sv))) {
+else if (__jakt_enum_value == (ByteString::from_utf8_without_validation("-T"sv))) {
 {
 (target_triple = ((args_to_process).dequeue()));
 }
 return JaktInternal::ExplicitValue<void>();
 }
-else if (__jakt_enum_value == (ByteString::must_from_utf8("--sysroot"sv))) {
+else if (__jakt_enum_value == (ByteString::from_utf8_without_validation("--sysroot"sv))) {
 {
 (sysroot = ((args_to_process).dequeue()));
 }
 return JaktInternal::ExplicitValue<void>();
 }
-else if (__jakt_enum_value == (ByteString::must_from_utf8("--system-lib-dir"sv))) {
+else if (__jakt_enum_value == (ByteString::from_utf8_without_validation("--system-lib-dir"sv))) {
 {
 ((system_lib_dirs).push(((args_to_process).dequeue())));
 }
 return JaktInternal::ExplicitValue<void>();
 }
-else if (__jakt_enum_value == (ByteString::must_from_utf8("--system-include-dir"sv))) {
+else if (__jakt_enum_value == (ByteString::from_utf8_without_validation("--system-include-dir"sv))) {
 {
 ((system_include_dirs).push(((args_to_process).dequeue())));
 }
 return JaktInternal::ExplicitValue<void>();
 }
-else if (__jakt_enum_value == (ByteString::must_from_utf8("--compiler-include-dir"sv))) {
+else if (__jakt_enum_value == (ByteString::from_utf8_without_validation("--compiler-include-dir"sv))) {
 {
 (compiler_include_dir = ((args_to_process).dequeue()));
 }
 return JaktInternal::ExplicitValue<void>();
 }
-else if (__jakt_enum_value == (ByteString::must_from_utf8("--compiler-lib-dir"sv))) {
+else if (__jakt_enum_value == (ByteString::from_utf8_without_validation("--compiler-lib-dir"sv))) {
 {
 (compiler_lib_dir = ((args_to_process).dequeue()));
 }
 return JaktInternal::ExplicitValue<void>();
 }
-else if (__jakt_enum_value == (ByteString::must_from_utf8("--install-root"sv))) {
+else if (__jakt_enum_value == (ByteString::from_utf8_without_validation("--install-root"sv))) {
 {
 (install_root = ((args_to_process).dequeue()));
 }
 return JaktInternal::ExplicitValue<void>();
 }
-else if (__jakt_enum_value == (ByteString::must_from_utf8("--runtime-lib-path"sv))) {
+else if (__jakt_enum_value == (ByteString::from_utf8_without_validation("--runtime-lib-path"sv))) {
 {
 (runtime_lib_path = jakt__path::Path::from_string(((args_to_process).dequeue())));
 }
 return JaktInternal::ExplicitValue<void>();
 }
-else if (__jakt_enum_value == (ByteString::must_from_utf8("--runtime-path"sv))) {
+else if (__jakt_enum_value == (ByteString::from_utf8_without_validation("--runtime-path"sv))) {
 {
 (runtime_path = jakt__path::Path::from_string(((args_to_process).dequeue())));
 }
 return JaktInternal::ExplicitValue<void>();
 }
-else if (__jakt_enum_value == (ByteString::must_from_utf8("--source-file"sv))) {
+else if (__jakt_enum_value == (ByteString::from_utf8_without_validation("--source-file"sv))) {
 {
 (source_file = ((args_to_process).dequeue()));
 }
 return JaktInternal::ExplicitValue<void>();
 }
-else if (__jakt_enum_value == (ByteString::must_from_utf8("--output-filename"sv))) {
+else if (__jakt_enum_value == (ByteString::from_utf8_without_validation("--output-filename"sv))) {
 {
 (output_filename = ((args_to_process).dequeue()));
 }
 return JaktInternal::ExplicitValue<void>();
 }
-else if (__jakt_enum_value == (ByteString::must_from_utf8("-o"sv))) {
+else if (__jakt_enum_value == (ByteString::from_utf8_without_validation("-o"sv))) {
 {
 (output_filename = ((args_to_process).dequeue()));
 }
 return JaktInternal::ExplicitValue<void>();
 }
-else if (__jakt_enum_value == (ByteString::must_from_utf8("--only-support-libs"sv))) {
+else if (__jakt_enum_value == (ByteString::from_utf8_without_validation("--only-support-libs"sv))) {
 {
 (only_support_libs = true);
 }
@@ -741,32 +741,32 @@ return static_cast<int>(1);
 }
 ByteString const abbreviated_triple = TRY((((TRY((jakt__platform::Target::from_triple((target_triple.value()))))).name(true))));
 jakt__path::Path const install_dir = jakt__path::Path::from_string((install_root.value()));
-jakt__path::Path const install_lib_dir = ((((install_dir).join((ByteString::must_from_utf8("lib"sv))))).join((target_triple.value())));
-jakt__path::Path const install_runtime_dir = ((install_dir).join((ByteString::must_from_utf8("include/runtime"sv))));
-jakt__path::Path const install_bin_dir = ((install_dir).join((ByteString::must_from_utf8("bin"sv))));
+jakt__path::Path const install_lib_dir = ((((install_dir).join((ByteString::from_utf8_without_validation("lib"sv))))).join((target_triple.value())));
+jakt__path::Path const install_runtime_dir = ((install_dir).join((ByteString::from_utf8_without_validation("include/runtime"sv))));
+jakt__path::Path const install_bin_dir = ((install_dir).join((ByteString::from_utf8_without_validation("bin"sv))));
 jakt__path::Path const current_executable_path = jakt__path::Path::from_string(TRY((File::current_executable_path())));
 jakt__path::Path const local_install_base_path = ((((current_executable_path).parent())).parent());
 if ((!(runtime_path).has_value())){
-(runtime_path = ((local_install_base_path).join((ByteString::must_from_utf8("include/runtime"sv)))));
+(runtime_path = ((local_install_base_path).join((ByteString::from_utf8_without_validation("include/runtime"sv)))));
 }
 if ((!(runtime_lib_path).has_value())){
-(runtime_lib_path = ((((local_install_base_path).join((ByteString::must_from_utf8("lib"sv))))).join(TRY((((TRY((jakt__platform::Target::active()))).name(false)))))));
+(runtime_lib_path = ((((local_install_base_path).join((ByteString::from_utf8_without_validation("lib"sv))))).join(TRY((((TRY((jakt__platform::Target::active()))).name(false)))))));
 }
 Function<JaktInternal::DynamicArray<ByteString>()> const compiler_invocation_args = [&compiler_args, &abbreviated_triple, &sysroot, &compiler_include_dir, &compiler_lib_dir, &system_include_dirs, &system_lib_dirs, &runtime_lib_path, &runtime_path]() -> JaktInternal::DynamicArray<ByteString> {
 {
 JaktInternal::DynamicArray<ByteString> args = ((((compiler_args)[(JaktInternal::Range<i64>{static_cast<i64>(0LL),static_cast<i64>(9223372036854775807LL)})])).to_array());
-((args).push((ByteString::must_from_utf8("--target-triple"sv))));
+((args).push((ByteString::from_utf8_without_validation("--target-triple"sv))));
 ((args).push(__jakt_format((StringView::from_string_literal("{}-unknown"sv)),abbreviated_triple)));
 if (((sysroot).has_value())){
-((args).push((ByteString::must_from_utf8("--extra-cpp-flag"sv))));
+((args).push((ByteString::from_utf8_without_validation("--extra-cpp-flag"sv))));
 ((args).push(__jakt_format((StringView::from_string_literal("--sysroot={}"sv)),(sysroot.value()))));
 }
 if (((compiler_include_dir).has_value())){
-((args).push((ByteString::must_from_utf8("-I"sv))));
+((args).push((ByteString::from_utf8_without_validation("-I"sv))));
 ((args).push((compiler_include_dir.value())));
 }
 if (((compiler_lib_dir).has_value())){
-((args).push((ByteString::must_from_utf8("-L"sv))));
+((args).push((ByteString::from_utf8_without_validation("-L"sv))));
 ((args).push((compiler_lib_dir.value())));
 }
 {
@@ -778,7 +778,7 @@ break;
 }
 ByteString system_include_dir = (_magic_value.value());
 {
-((args).push((ByteString::must_from_utf8("-I"sv))));
+((args).push((ByteString::from_utf8_without_validation("-I"sv))));
 ((args).push(system_include_dir));
 }
 
@@ -794,7 +794,7 @@ break;
 }
 ByteString system_lib_dir = (_magic_value.value());
 {
-((args).push((ByteString::must_from_utf8("-L"sv))));
+((args).push((ByteString::from_utf8_without_validation("-L"sv))));
 ((args).push(system_lib_dir));
 }
 
@@ -802,11 +802,11 @@ ByteString system_lib_dir = (_magic_value.value());
 }
 
 if (((runtime_lib_path).has_value())){
-((args).push((ByteString::must_from_utf8("--runtime-library-path"sv))));
+((args).push((ByteString::from_utf8_without_validation("--runtime-library-path"sv))));
 ((args).push((((runtime_lib_path.value())).to_string())));
 }
 if (((runtime_path).has_value())){
-((args).push((ByteString::must_from_utf8("--runtime-path"sv))));
+((args).push((ByteString::from_utf8_without_validation("--runtime-path"sv))));
 ((args).push((((runtime_path.value())).to_string())));
 }
 return args;
@@ -834,33 +834,33 @@ break;
 }
 jakt__path::Path source = (_magic_value.value());
 {
-((invocation_args).push((ByteString::must_from_utf8("-X"sv))));
+((invocation_args).push((ByteString::from_utf8_without_validation("-X"sv))));
 ((invocation_args).push(((source).to_string())));
 }
 
 }
 }
 
-((invocation_args).push((ByteString::must_from_utf8("--static"sv))));
-((invocation_args).push((ByteString::must_from_utf8("--link-archive"sv))));
+((invocation_args).push((ByteString::from_utf8_without_validation("--static"sv))));
+((invocation_args).push((ByteString::from_utf8_without_validation("--link-archive"sv))));
 ((invocation_args).push(((target).to_string())));
-((invocation_args).push((ByteString::must_from_utf8("/dev/null"sv))));
+((invocation_args).push((ByteString::from_utf8_without_validation("/dev/null"sv))));
 return TRY((compiler_main(invocation_args)));
 }
 }
 ;
 if ((!(((runtime_archive_path).exists())))){
 warnln((StringView::from_string_literal("Building jakt runtime for target {}..."sv)),abbreviated_triple);
-JaktInternal::DynamicArray<jakt__path::Path> sources = DynamicArray<jakt__path::Path>::create_with({(((runtime_path.value())).join((ByteString::must_from_utf8("IO/File.cpp"sv))))});
-((sources).push_values(((TRY((find_with_extension((((runtime_path.value())).join((ByteString::must_from_utf8("AK"sv)))),(ByteString::must_from_utf8("cpp"sv)))))))));
-((sources).push_values(((TRY((find_with_extension((((runtime_path.value())).join((ByteString::must_from_utf8("Jakt"sv)))),(ByteString::must_from_utf8("cpp"sv)))))))));
+JaktInternal::DynamicArray<jakt__path::Path> sources = DynamicArray<jakt__path::Path>::create_with({(((runtime_path.value())).join((ByteString::from_utf8_without_validation("IO/File.cpp"sv))))});
+((sources).push_values(((TRY((find_with_extension((((runtime_path.value())).join((ByteString::from_utf8_without_validation("AK"sv)))),(ByteString::from_utf8_without_validation("cpp"sv)))))))));
+((sources).push_values(((TRY((find_with_extension((((runtime_path.value())).join((ByteString::from_utf8_without_validation("Jakt"sv)))),(ByteString::from_utf8_without_validation("cpp"sv)))))))));
 if (((TRY((build_archive(sources,runtime_archive_path)))) != (static_cast<int>(0)))){
 return static_cast<int>(1);
 }
 }
 if ((!(((main_archive_path).exists())))){
 warnln((StringView::from_string_literal("Building jakt main for target {}..."sv)),abbreviated_triple);
-JaktInternal::DynamicArray<jakt__path::Path> sources = DynamicArray<jakt__path::Path>::create_with({(((runtime_path.value())).join((ByteString::must_from_utf8("Main.cpp"sv))))});
+JaktInternal::DynamicArray<jakt__path::Path> sources = DynamicArray<jakt__path::Path>::create_with({(((runtime_path.value())).join((ByteString::from_utf8_without_validation("Main.cpp"sv))))});
 if (((TRY((build_archive(sources,main_archive_path)))) != (static_cast<int>(0)))){
 return static_cast<int>(1);
 }
@@ -871,7 +871,7 @@ if ((!(only_support_libs))){
 JaktInternal::DynamicArray<ByteString> compiler_args = compiler_invocation_args();
 jakt__path::Path const source_path = jakt__path::Path::from_string((source_file.value()));
 ((compiler_args).push(((source_path).to_string())));
-((compiler_args).push((ByteString::must_from_utf8("-o"sv))));
+((compiler_args).push((ByteString::from_utf8_without_validation("-o"sv))));
 ByteString const default_output_filename = ((((install_bin_dir).join(output_filename.value_or_lazy_evaluated([&] { return ((source_path).basename(true)); })))).to_string());
 ((compiler_args).push(default_output_filename));
 return TRY((compiler_main(compiler_args)));
@@ -952,85 +952,85 @@ return files_found;
 
 ByteString escape_for_depfile(ByteString const input) {
 {
-return ((((((input).replace((ByteString::must_from_utf8("$"sv)),(ByteString::must_from_utf8("$$"sv))))).replace((ByteString::must_from_utf8("#"sv)),(ByteString::must_from_utf8("\\#"sv))))).replace((ByteString::must_from_utf8(" "sv)),(ByteString::must_from_utf8("\\ "sv))));
+return ((((((input).replace((ByteString::from_utf8_without_validation("$"sv)),(ByteString::from_utf8_without_validation("$$"sv))))).replace((ByteString::from_utf8_without_validation("#"sv)),(ByteString::from_utf8_without_validation("\\#"sv))))).replace((ByteString::from_utf8_without_validation(" "sv)),(ByteString::from_utf8_without_validation("\\ "sv))));
 }
 }
 
 ErrorOr<int> compiler_main(JaktInternal::DynamicArray<ByteString> const args) {
 {
 jakt__arguments::ArgsParser args_parser = jakt__arguments::ArgsParser::from_args(args);
-if (TRY((((args_parser).flag(DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("-h"sv)), (ByteString::must_from_utf8("--help"sv))})))))){
+if (TRY((((args_parser).flag(DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("-h"sv)), (ByteString::from_utf8_without_validation("--help"sv))})))))){
 outln((StringView::from_string_literal("{}\n"sv)),usage());
 outln((StringView::from_string_literal("{}"sv)),help());
 return static_cast<int>(0);
 }
-if (TRY((((args_parser).flag(DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("-v"sv)), (ByteString::must_from_utf8("--version"sv))})))))){
+if (TRY((((args_parser).flag(DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("-v"sv)), (ByteString::from_utf8_without_validation("--version"sv))})))))){
 outln((StringView::from_string_literal("{}"sv)),TRY((git::commit_hash())));
 return static_cast<int>(0);
 }
 jakt__path::Path const current_executable_path = jakt__path::Path::from_string(TRY((File::current_executable_path())));
 jakt__path::Path const install_base_path = ((((current_executable_path).parent())).parent());
-jakt__path::Path const default_runtime_path = ((install_base_path).join((ByteString::must_from_utf8("include/runtime"sv))));
-jakt__path::Path const default_runtime_library_path = ((install_base_path).join((ByteString::must_from_utf8("lib"sv))));
+jakt__path::Path const default_runtime_path = ((install_base_path).join((ByteString::from_utf8_without_validation("include/runtime"sv))));
+jakt__path::Path const default_runtime_library_path = ((install_base_path).join((ByteString::from_utf8_without_validation("lib"sv))));
 ByteString const default_compiler_path = ({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<ByteString,ErrorOr<int>>{
 auto __jakt_enum_value = (false);
 if (__jakt_enum_value == true) {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("clang-cl"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("clang-cl"sv)));
 }
 else {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("clang++"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("clang++"sv)));
 }
 }());
     if (_jakt_value.is_return())
         return _jakt_value.release_return();
     _jakt_value.release_value();
 });
-bool const optimize = TRY((((args_parser).flag(DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("-O"sv))})))));
-bool const lexer_debug = TRY((((args_parser).flag(DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("-dl"sv))})))));
-bool const parser_debug = TRY((((args_parser).flag(DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("-dp"sv))})))));
-bool const typechecker_debug = TRY((((args_parser).flag(DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("-dt"sv))})))));
-bool const build_executable = (!(TRY((((args_parser).flag(DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("-S"sv)), (ByteString::must_from_utf8("--emit-cpp-source-only"sv))})))))));
-bool const run_executable = TRY((((args_parser).flag(DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("-cr"sv)), (ByteString::must_from_utf8("--compile-run"sv))})))));
-bool const codegen_debug = TRY((((args_parser).flag(DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("-d"sv))})))));
-bool const debug_print = TRY((((args_parser).flag(DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("--debug-print"sv))})))));
-bool const prettify_cpp_source = TRY((((args_parser).flag(DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("-p"sv)), (ByteString::must_from_utf8("--prettify-cpp-source"sv))})))));
-bool const json_errors = TRY((((args_parser).flag(DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("-j"sv)), (ByteString::must_from_utf8("--json-errors"sv))})))));
-bool const dump_type_hints = TRY((((args_parser).flag(DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("-H"sv)), (ByteString::must_from_utf8("--type-hints"sv))})))));
-bool const dump_try_hints = TRY((((args_parser).flag(DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("--try-hints"sv))})))));
-bool const check_only = TRY((((args_parser).flag(DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("-c"sv)), (ByteString::must_from_utf8("--check-only"sv))})))));
-JaktInternal::Optional<ByteString> const generate_depfile = TRY((((args_parser).option(DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("-M"sv)), (ByteString::must_from_utf8("--dep-file"sv))})))));
-JaktInternal::Optional<ByteString> const target_triple = TRY((((args_parser).option(DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("-T"sv)), (ByteString::must_from_utf8("--target-triple"sv))})))));
-ByteString const runtime_library_path = TRY((((args_parser).option(DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("-RLP"sv)), (ByteString::must_from_utf8("--runtime-library-path"sv))}))))).value_or_lazy_evaluated([&] { return ((default_runtime_library_path).to_string()); });
-ByteString compiler_job_count = TRY((TRY((((args_parser).option(DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("-J"sv)), (ByteString::must_from_utf8("--jobs"sv))}))))).try_value_or_lazy_evaluated([&]() -> ErrorOr<ByteString> { return (ByteString::must_from_utf8("2"sv)); })));
+bool const optimize = TRY((((args_parser).flag(DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("-O"sv))})))));
+bool const lexer_debug = TRY((((args_parser).flag(DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("-dl"sv))})))));
+bool const parser_debug = TRY((((args_parser).flag(DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("-dp"sv))})))));
+bool const typechecker_debug = TRY((((args_parser).flag(DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("-dt"sv))})))));
+bool const build_executable = (!(TRY((((args_parser).flag(DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("-S"sv)), (ByteString::from_utf8_without_validation("--emit-cpp-source-only"sv))})))))));
+bool const run_executable = TRY((((args_parser).flag(DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("-cr"sv)), (ByteString::from_utf8_without_validation("--compile-run"sv))})))));
+bool const codegen_debug = TRY((((args_parser).flag(DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("-d"sv))})))));
+bool const debug_print = TRY((((args_parser).flag(DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("--debug-print"sv))})))));
+bool const prettify_cpp_source = TRY((((args_parser).flag(DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("-p"sv)), (ByteString::from_utf8_without_validation("--prettify-cpp-source"sv))})))));
+bool const json_errors = TRY((((args_parser).flag(DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("-j"sv)), (ByteString::from_utf8_without_validation("--json-errors"sv))})))));
+bool const dump_type_hints = TRY((((args_parser).flag(DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("-H"sv)), (ByteString::from_utf8_without_validation("--type-hints"sv))})))));
+bool const dump_try_hints = TRY((((args_parser).flag(DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("--try-hints"sv))})))));
+bool const check_only = TRY((((args_parser).flag(DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("-c"sv)), (ByteString::from_utf8_without_validation("--check-only"sv))})))));
+JaktInternal::Optional<ByteString> const generate_depfile = TRY((((args_parser).option(DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("-M"sv)), (ByteString::from_utf8_without_validation("--dep-file"sv))})))));
+JaktInternal::Optional<ByteString> const target_triple = TRY((((args_parser).option(DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("-T"sv)), (ByteString::from_utf8_without_validation("--target-triple"sv))})))));
+ByteString const runtime_library_path = TRY((((args_parser).option(DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("-RLP"sv)), (ByteString::from_utf8_without_validation("--runtime-library-path"sv))}))))).value_or_lazy_evaluated([&] { return ((default_runtime_library_path).to_string()); });
+ByteString compiler_job_count = TRY((TRY((((args_parser).option(DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("-J"sv)), (ByteString::from_utf8_without_validation("--jobs"sv))}))))).try_value_or_lazy_evaluated([&]() -> ErrorOr<ByteString> { return (ByteString::from_utf8_without_validation("2"sv)); })));
 if (false){
-(compiler_job_count = (ByteString::must_from_utf8("1"sv)));
+(compiler_job_count = (ByteString::from_utf8_without_validation("1"sv)));
 }
-ByteString const clang_format_path = TRY((TRY((((args_parser).option(DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("-F"sv)), (ByteString::must_from_utf8("--clang-format-path"sv))}))))).try_value_or_lazy_evaluated([&]() -> ErrorOr<ByteString> { return (ByteString::must_from_utf8("clang-format"sv)); })));
-ByteString const runtime_path = TRY((((args_parser).option(DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("-R"sv)), (ByteString::must_from_utf8("--runtime-path"sv))}))))).value_or_lazy_evaluated([&] { return ((default_runtime_path).to_string()); });
-JaktInternal::Optional<ByteString> const assume_main_file_path = TRY((((args_parser).option(DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("--assume-main-file-path"sv))})))));
-jakt__path::Path const binary_dir = jakt__path::Path::from_string(TRY((TRY((((args_parser).option(DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("-B"sv)), (ByteString::must_from_utf8("--binary-dir"sv))}))))).try_value_or_lazy_evaluated([&]() -> ErrorOr<ByteString> { return (ByteString::must_from_utf8("build"sv)); }))));
-JaktInternal::Optional<ByteString> const dot_clang_format_path = TRY((((args_parser).option(DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("-D"sv)), (ByteString::must_from_utf8("--dot-clang-format-path"sv))})))));
-ByteString const cxx_compiler_path = TRY((((args_parser).option(DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("-C"sv)), (ByteString::must_from_utf8("--cxx-compiler-path"sv))}))))).value_or_lazy_evaluated([&] { return default_compiler_path; });
-JaktInternal::Optional<ByteString> const archiver_path = TRY((((args_parser).option(DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("-A"sv)), (ByteString::must_from_utf8("--archiver"sv))})))));
-JaktInternal::Optional<ByteString> const link_archive = TRY((((args_parser).option(DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("-a"sv)), (ByteString::must_from_utf8("--link-archive"sv))})))));
-bool const archive_link_support_libs = TRY((((args_parser).flag(DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("--archive-link-support-libs"sv))})))));
-bool const build_static = TRY((((args_parser).flag(DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("--static"sv))})))));
-JaktInternal::DynamicArray<ByteString> const extra_include_paths = TRY((((args_parser).option_multiple(DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("-I"sv))})))));
-JaktInternal::DynamicArray<ByteString> const extra_lib_paths = TRY((((args_parser).option_multiple(DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("-L"sv))})))));
-JaktInternal::DynamicArray<ByteString> const extra_link_libs = TRY((((args_parser).option_multiple(DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("-l"sv))})))));
-JaktInternal::DynamicArray<ByteString> const extra_linker_args = TRY((((args_parser).option_multiple(DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("-Wl"sv))})))));
-JaktInternal::DynamicArray<ByteString> const extra_cpp_files = TRY((((args_parser).option_multiple(DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("-X"sv))})))));
-JaktInternal::DynamicArray<ByteString> const extra_cpp_flags = TRY((((args_parser).option_multiple(DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("--extra-cpp-flag"sv))})))));
-JaktInternal::Optional<ByteString> const set_output_filename = TRY((((args_parser).option(DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("-o"sv)), (ByteString::must_from_utf8("--output-filename"sv))})))));
-JaktInternal::Optional<ByteString> const goto_def = TRY((((args_parser).option(DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("-g"sv)), (ByteString::must_from_utf8("--goto-def"sv))})))));
-JaktInternal::Optional<ByteString> const goto_type_def = TRY((((args_parser).option(DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("-t"sv)), (ByteString::must_from_utf8("--goto-type-def"sv))})))));
-JaktInternal::Optional<ByteString> const hover = TRY((((args_parser).option(DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("-e"sv)), (ByteString::must_from_utf8("--hover"sv))})))));
-JaktInternal::Optional<ByteString> const completions = TRY((((args_parser).option(DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("-m"sv)), (ByteString::must_from_utf8("--completions"sv))})))));
-bool const print_symbols = TRY((((args_parser).flag(DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("--print-symbols"sv))})))));
-JaktInternal::Optional<ByteString> const project_name = TRY((((args_parser).option(DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("--create"sv))})))));
-bool const use_ccache = TRY((((args_parser).flag(DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("--use-ccache"sv))})))));
-JaktInternal::DynamicArray<ByteString> const user_configuration_specs = TRY((((args_parser).option_multiple(DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("--config"sv))})))));
+ByteString const clang_format_path = TRY((TRY((((args_parser).option(DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("-F"sv)), (ByteString::from_utf8_without_validation("--clang-format-path"sv))}))))).try_value_or_lazy_evaluated([&]() -> ErrorOr<ByteString> { return (ByteString::from_utf8_without_validation("clang-format"sv)); })));
+ByteString const runtime_path = TRY((((args_parser).option(DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("-R"sv)), (ByteString::from_utf8_without_validation("--runtime-path"sv))}))))).value_or_lazy_evaluated([&] { return ((default_runtime_path).to_string()); });
+JaktInternal::Optional<ByteString> const assume_main_file_path = TRY((((args_parser).option(DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("--assume-main-file-path"sv))})))));
+jakt__path::Path const binary_dir = jakt__path::Path::from_string(TRY((TRY((((args_parser).option(DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("-B"sv)), (ByteString::from_utf8_without_validation("--binary-dir"sv))}))))).try_value_or_lazy_evaluated([&]() -> ErrorOr<ByteString> { return (ByteString::from_utf8_without_validation("build"sv)); }))));
+JaktInternal::Optional<ByteString> const dot_clang_format_path = TRY((((args_parser).option(DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("-D"sv)), (ByteString::from_utf8_without_validation("--dot-clang-format-path"sv))})))));
+ByteString const cxx_compiler_path = TRY((((args_parser).option(DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("-C"sv)), (ByteString::from_utf8_without_validation("--cxx-compiler-path"sv))}))))).value_or_lazy_evaluated([&] { return default_compiler_path; });
+JaktInternal::Optional<ByteString> const archiver_path = TRY((((args_parser).option(DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("-A"sv)), (ByteString::from_utf8_without_validation("--archiver"sv))})))));
+JaktInternal::Optional<ByteString> const link_archive = TRY((((args_parser).option(DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("-a"sv)), (ByteString::from_utf8_without_validation("--link-archive"sv))})))));
+bool const archive_link_support_libs = TRY((((args_parser).flag(DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("--archive-link-support-libs"sv))})))));
+bool const build_static = TRY((((args_parser).flag(DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("--static"sv))})))));
+JaktInternal::DynamicArray<ByteString> const extra_include_paths = TRY((((args_parser).option_multiple(DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("-I"sv))})))));
+JaktInternal::DynamicArray<ByteString> const extra_lib_paths = TRY((((args_parser).option_multiple(DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("-L"sv))})))));
+JaktInternal::DynamicArray<ByteString> const extra_link_libs = TRY((((args_parser).option_multiple(DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("-l"sv))})))));
+JaktInternal::DynamicArray<ByteString> const extra_linker_args = TRY((((args_parser).option_multiple(DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("-Wl"sv))})))));
+JaktInternal::DynamicArray<ByteString> const extra_cpp_files = TRY((((args_parser).option_multiple(DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("-X"sv))})))));
+JaktInternal::DynamicArray<ByteString> const extra_cpp_flags = TRY((((args_parser).option_multiple(DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("--extra-cpp-flag"sv))})))));
+JaktInternal::Optional<ByteString> const set_output_filename = TRY((((args_parser).option(DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("-o"sv)), (ByteString::from_utf8_without_validation("--output-filename"sv))})))));
+JaktInternal::Optional<ByteString> const goto_def = TRY((((args_parser).option(DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("-g"sv)), (ByteString::from_utf8_without_validation("--goto-def"sv))})))));
+JaktInternal::Optional<ByteString> const goto_type_def = TRY((((args_parser).option(DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("-t"sv)), (ByteString::from_utf8_without_validation("--goto-type-def"sv))})))));
+JaktInternal::Optional<ByteString> const hover = TRY((((args_parser).option(DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("-e"sv)), (ByteString::from_utf8_without_validation("--hover"sv))})))));
+JaktInternal::Optional<ByteString> const completions = TRY((((args_parser).option(DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("-m"sv)), (ByteString::from_utf8_without_validation("--completions"sv))})))));
+bool const print_symbols = TRY((((args_parser).flag(DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("--print-symbols"sv))})))));
+JaktInternal::Optional<ByteString> const project_name = TRY((((args_parser).option(DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("--create"sv))})))));
+bool const use_ccache = TRY((((args_parser).flag(DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("--use-ccache"sv))})))));
+JaktInternal::DynamicArray<ByteString> const user_configuration_specs = TRY((((args_parser).option_multiple(DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("--config"sv))})))));
 JaktInternal::Dictionary<ByteString,ByteString> user_configuration = Dictionary<ByteString, ByteString>::create_with_entries({});
 {
 JaktInternal::ArrayIterator<ByteString> _magic = ((user_configuration_specs).iterator());
@@ -1047,7 +1047,7 @@ JaktInternal::DynamicArray<ByteString> const parts = ((spec).split('='));
 auto __jakt_enum_value = (((parts).size()));
 if (__jakt_enum_value == static_cast<size_t>(1ULL)) {
 {
-user_configuration.set(((parts)[static_cast<i64>(0LL)]), (ByteString::must_from_utf8("true"sv)));
+user_configuration.set(((parts)[static_cast<i64>(0LL)]), (ByteString::from_utf8_without_validation("true"sv)));
 }
 return JaktInternal::ExplicitValue<void>();
 }
@@ -1079,13 +1079,13 @@ return JaktInternal::ExplicitValue<void>();
 }
 }
 
-bool const interpret_run = TRY((((args_parser).flag(DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("-r"sv)), (ByteString::must_from_utf8("--run"sv))})))));
-bool const format = TRY((((args_parser).flag(DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("-f"sv)), (ByteString::must_from_utf8("--format"sv))})))));
-bool const format_inplace = TRY((((args_parser).flag(DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("-fi"sv)), (ByteString::must_from_utf8("--format-inplace"sv))})))));
-bool const format_debug = TRY((((args_parser).flag(DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("-fd"sv)), (ByteString::must_from_utf8("--format-debug"sv))})))));
-ByteString const input_format_range = TRY((TRY((((args_parser).option(DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("-fr"sv)), (ByteString::must_from_utf8("--format-range"sv))}))))).try_value_or_lazy_evaluated([&]() -> ErrorOr<ByteString> { return (ByteString::must_from_utf8(""sv)); })));
-bool const ak_stdlib = TRY((((args_parser).flag(DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("--ak-is-my-only-stdlib"sv))})))));
-bool const discover_only = TRY((((args_parser).flag(DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("--discover"sv))})))));
+bool const interpret_run = TRY((((args_parser).flag(DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("-r"sv)), (ByteString::from_utf8_without_validation("--run"sv))})))));
+bool const format = TRY((((args_parser).flag(DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("-f"sv)), (ByteString::from_utf8_without_validation("--format"sv))})))));
+bool const format_inplace = TRY((((args_parser).flag(DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("-fi"sv)), (ByteString::from_utf8_without_validation("--format-inplace"sv))})))));
+bool const format_debug = TRY((((args_parser).flag(DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("-fd"sv)), (ByteString::from_utf8_without_validation("--format-debug"sv))})))));
+ByteString const input_format_range = TRY((TRY((((args_parser).option(DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("-fr"sv)), (ByteString::from_utf8_without_validation("--format-range"sv))}))))).try_value_or_lazy_evaluated([&]() -> ErrorOr<ByteString> { return (ByteString::from_utf8_without_validation(""sv)); })));
+bool const ak_stdlib = TRY((((args_parser).flag(DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("--ak-is-my-only-stdlib"sv))})))));
+bool const discover_only = TRY((((args_parser).flag(DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("--discover"sv))})))));
 size_t const max_concurrent = (infallible_integer_cast<size_t>((({ Optional<u32> __jakt_var_961;
 auto __jakt_var_962 = [&]() -> ErrorOr<u32> { return TRY((value_or_throw<u32>(((compiler_job_count).to_uint())))); }();
 if (__jakt_var_962.is_error()) {{
@@ -1095,8 +1095,8 @@ return static_cast<int>(1);
 } else {__jakt_var_961 = __jakt_var_962.release_value();
 }
 __jakt_var_961.release_value(); }))));
-if (TRY((((args_parser).flag(DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("--repl"sv))})))))){
-repl::REPL repl = TRY((repl::REPL::create(jakt__path::Path::from_parts(DynamicArray<ByteString>::create_with({runtime_path, (ByteString::must_from_utf8("jaktlib"sv))})),target_triple,user_configuration)));
+if (TRY((((args_parser).flag(DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("--repl"sv))})))))){
+repl::REPL repl = TRY((repl::REPL::create(jakt__path::Path::from_parts(DynamicArray<ByteString>::create_with({runtime_path, (ByteString::from_utf8_without_validation("jaktlib"sv))})),target_triple,user_configuration)));
 TRY((((repl).run())));
 return static_cast<int>(0);
 }
@@ -1152,7 +1152,7 @@ jakt__path::Path const file_path = jakt__path::Path::from_string((file_name.valu
 ByteString const guessed_output_filename = ((file_path).basename(true));
 ByteString const output_filename = ((((binary_dir).join(set_output_filename.value_or_lazy_evaluated([&] { return guessed_output_filename; })))).to_string());
 JaktInternal::DynamicArray<error::JaktError> errors = DynamicArray<error::JaktError>::create_with({});
-NonnullRefPtr<compiler::Compiler> compiler = compiler::Compiler::__jakt_create(DynamicArray<jakt__path::Path>::create_with({}),Dictionary<ByteString, utility::FileId>::create_with_entries({}),DynamicArray<error::JaktError>::create_with({}),JaktInternal::OptionalNone(),DynamicArray<u8>::create_with({}),lexer_debug,parser_debug,false,debug_print,jakt__path::Path::from_parts(DynamicArray<ByteString>::create_with({runtime_path, (ByteString::must_from_utf8("jaktlib"sv))})),extra_include_paths,json_errors,dump_type_hints,dump_try_hints,optimize,target_triple,user_configuration,binary_dir,({
+NonnullRefPtr<compiler::Compiler> compiler = compiler::Compiler::__jakt_create(DynamicArray<jakt__path::Path>::create_with({}),Dictionary<ByteString, utility::FileId>::create_with_entries({}),DynamicArray<error::JaktError>::create_with({}),JaktInternal::OptionalNone(),DynamicArray<u8>::create_with({}),lexer_debug,parser_debug,false,debug_print,jakt__path::Path::from_parts(DynamicArray<ByteString>::create_with({runtime_path, (ByteString::from_utf8_without_validation("jaktlib"sv))})),extra_include_paths,json_errors,dump_type_hints,dump_try_hints,optimize,target_triple,user_configuration,binary_dir,({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<JaktInternal::Optional<jakt__path::Path>,ErrorOr<int>>{
 auto __jakt_enum_value = (((assume_main_file_path).has_value()));
 if (__jakt_enum_value == true) {
@@ -1169,7 +1169,7 @@ VERIFY_NOT_REACHED();
 }));
 TRY((((compiler)->load_prelude())));
 if (((format || format_debug) || format_inplace)){
-NonnullRefPtr<jakt__file_iterator::RecursiveFileIterator> const directory_or_file_paths = TRY((jakt__file_iterator::RecursiveFileIterator::make(file_path,(ByteString::must_from_utf8("jakt"sv)))));
+NonnullRefPtr<jakt__file_iterator::RecursiveFileIterator> const directory_or_file_paths = TRY((jakt__file_iterator::RecursiveFileIterator::make(file_path,(ByteString::from_utf8_without_validation("jakt"sv)))));
 {
 NonnullRefPtr<jakt__file_iterator::RecursiveFileIterator> _magic = directory_or_file_paths;
 for (;;){
@@ -1243,7 +1243,7 @@ ide::JaktSymbol symbol = (_magic_value.value());
 }
 }
 
-outln((StringView::from_string_literal("[{}]"sv)),utility::join(symbol_representations,(ByteString::must_from_utf8(","sv))));
+outln((StringView::from_string_literal("[{}]"sv)),utility::join(symbol_representations,(ByteString::from_utf8_without_validation(","sv))));
 return static_cast<int>(0);
 }
 typechecker::Typechecker typechecker = TRY((typechecker::Typechecker::typecheck(compiler,parsed_namespace)));
@@ -1286,7 +1286,7 @@ JaktInternal::Tuple<ByteString,JaktInternal::DynamicArray<ids::FunctionId>> cons
 ByteString const function_name = ((jakt__function_name__overload_set__).template get<0>());
 JaktInternal::DynamicArray<ids::FunctionId> const overload_set = ((jakt__function_name__overload_set__).template get<1>());
 
-if (((function_name) == ((ByteString::must_from_utf8("main"sv))))){
+if (((function_name) == ((ByteString::from_utf8_without_validation("main"sv))))){
 (main_function_id = ((overload_set)[static_cast<i64>(0LL)]));
 break;
 }
@@ -1508,7 +1508,7 @@ JaktInternal::Tuple<ByteString,ByteString> const __module_file_path_ = contents_
 ByteString const _ = ((__module_file_path_).template get<0>());
 ByteString const module_file_path = ((__module_file_path_).template get<1>());
 
-if (((module_file_path) == ((ByteString::must_from_utf8("__prelude__"sv))))){
+if (((module_file_path) == ((ByteString::from_utf8_without_validation("__prelude__"sv))))){
 continue;
 }
 jakt__path::Path const path = ((binary_dir).join(file));
@@ -1548,7 +1548,7 @@ JaktInternal::Tuple<ByteString,ByteString> const contents_module_file_path_ = co
 ByteString const contents = ((contents_module_file_path_).template get<0>());
 ByteString const module_file_path = ((contents_module_file_path_).template get<1>());
 
-if (((module_file_path) == ((ByteString::must_from_utf8("__prelude__"sv))))){
+if (((module_file_path) == ((ByteString::from_utf8_without_validation("__prelude__"sv))))){
 continue;
 }
 ByteString const file = escape_for_depfile(module_file_path);
@@ -1679,7 +1679,7 @@ JaktInternal::Tuple<ByteString,JaktInternal::Tuple<ByteString,ByteString>> const
 ByteString const file_name = ((jakt__file_name_____).template get<0>());
 JaktInternal::Tuple<ByteString,ByteString> const _ = ((jakt__file_name_____).template get<1>());
 
-if (((file_name).ends_with((ByteString::must_from_utf8(".h"sv))))){
+if (((file_name).ends_with((ByteString::from_utf8_without_validation(".h"sv))))){
 continue;
 }
 ((files).push(file_name));
@@ -1704,21 +1704,21 @@ ByteString file = (_magic_value.value());
 }
 
 build::Builder builder = TRY((build::Builder::for_building(files,max_concurrent)));
-JaktInternal::DynamicArray<ByteString> extra_compiler_flags = DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("-c"sv))});
+JaktInternal::DynamicArray<ByteString> extra_compiler_flags = DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("-c"sv))});
 if (ak_stdlib){
-((extra_compiler_flags).push((ByteString::must_from_utf8("-DJAKT_USING_AK_AS_STANDARD_LIBRARY=1"sv))));
+((extra_compiler_flags).push((ByteString::from_utf8_without_validation("-DJAKT_USING_AK_AS_STANDARD_LIBRARY=1"sv))));
 }
 if (build_static){
-((extra_compiler_flags).push((ByteString::must_from_utf8("-static"sv))));
+((extra_compiler_flags).push((ByteString::from_utf8_without_validation("-static"sv))));
 }
 if (((target_triple).has_value())){
-if ((TRY((compiler_is((ByteString::must_from_utf8("clang++"sv))))) && [](ByteString const& self, ByteString rhs) -> bool {
+if ((TRY((compiler_is((ByteString::from_utf8_without_validation("clang++"sv))))) && [](ByteString const& self, ByteString rhs) -> bool {
 {
 return (!(((self) == (rhs))));
 }
 }
 ((target_triple.value()),TRY((((TRY((jakt__platform::Target::active()))).name(false))))))){
-((extra_compiler_flags).push((ByteString::must_from_utf8("-target"sv))));
+((extra_compiler_flags).push((ByteString::from_utf8_without_validation("-target"sv))));
 ((extra_compiler_flags).push((target_triple.value())));
 }
 }
@@ -1767,10 +1767,10 @@ VERIFY_NOT_REACHED();
 if (((link_archive).has_value())){
 JaktInternal::DynamicArray<ByteString> extra_arguments = DynamicArray<ByteString>::create_with({});
 if (archive_link_support_libs){
-((extra_arguments).push(((((runtime_lib_path).join(TRY((platform::library_name_for_target((ByteString::must_from_utf8("main"sv)),target)))))).to_string())));
-((extra_arguments).push(((((runtime_lib_path).join(TRY((platform::library_name_for_target((ByteString::must_from_utf8("runtime"sv)),target)))))).to_string())));
+((extra_arguments).push(((((runtime_lib_path).join(TRY((platform::library_name_for_target((ByteString::from_utf8_without_validation("main"sv)),target)))))).to_string())));
+((extra_arguments).push(((((runtime_lib_path).join(TRY((platform::library_name_for_target((ByteString::from_utf8_without_validation("runtime"sv)),target)))))).to_string())));
 }
-auto __jakt_var_970 = [&]() -> ErrorOr<void> { return TRY((((builder).link_into_archive(TRY((archiver_path.try_value_or_lazy_evaluated([&]() -> ErrorOr<ByteString> { return (ByteString::must_from_utf8("ar"sv)); }))),((((binary_dir).join((link_archive.value())))).to_string()),extra_arguments)))), ErrorOr<void>{}; }();
+auto __jakt_var_970 = [&]() -> ErrorOr<void> { return TRY((((builder).link_into_archive(TRY((archiver_path.try_value_or_lazy_evaluated([&]() -> ErrorOr<ByteString> { return (ByteString::from_utf8_without_validation("ar"sv)); }))),((((binary_dir).join((link_archive.value())))).to_string()),extra_arguments)))), ErrorOr<void>{}; }();
 if (__jakt_var_970.is_error()) {{
 return static_cast<int>(1);
 }
@@ -1778,7 +1778,7 @@ return static_cast<int>(1);
 ;
 }
 else {
-JaktInternal::DynamicArray<ByteString> extra_arguments = DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("-g"sv))});
+JaktInternal::DynamicArray<ByteString> extra_arguments = DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("-g"sv))});
 {
 JaktInternal::ArrayIterator<ByteString> _magic = ((extra_cpp_flags).iterator());
 for (;;){
@@ -1795,18 +1795,18 @@ ByteString flag = (_magic_value.value());
 }
 
 if (((target_triple).has_value())){
-if ((TRY((compiler_is((ByteString::must_from_utf8("clang++"sv))))) && [](ByteString const& self, ByteString rhs) -> bool {
+if ((TRY((compiler_is((ByteString::from_utf8_without_validation("clang++"sv))))) && [](ByteString const& self, ByteString rhs) -> bool {
 {
 return (!(((self) == (rhs))));
 }
 }
 ((target_triple.value()),TRY((((TRY((jakt__platform::Target::active()))).name(false))))))){
-((extra_arguments).push((ByteString::must_from_utf8("-target"sv))));
+((extra_arguments).push((ByteString::from_utf8_without_validation("-target"sv))));
 ((extra_arguments).push(TRY((((target).name(true))))));
 }
 }
-((extra_arguments).push(((((runtime_lib_path).join(TRY((platform::library_name_for_target((ByteString::must_from_utf8("main"sv)),target)))))).to_string())));
-((extra_arguments).push(((((runtime_lib_path).join(TRY((platform::library_name_for_target((ByteString::must_from_utf8("runtime"sv)),target)))))).to_string())));
+((extra_arguments).push(((((runtime_lib_path).join(TRY((platform::library_name_for_target((ByteString::from_utf8_without_validation("main"sv)),target)))))).to_string())));
+((extra_arguments).push(((((runtime_lib_path).join(TRY((platform::library_name_for_target((ByteString::from_utf8_without_validation("runtime"sv)),target)))))).to_string())));
 {
 JaktInternal::ArrayIterator<ByteString> _magic = ((extra_lib_paths).iterator());
 for (;;){
@@ -1816,7 +1816,7 @@ break;
 }
 ByteString path = (_magic_value.value());
 {
-((extra_arguments).push((ByteString::must_from_utf8("-L"sv))));
+((extra_arguments).push((ByteString::from_utf8_without_validation("-L"sv))));
 ((extra_arguments).push(path));
 }
 
@@ -1832,16 +1832,16 @@ break;
 }
 ByteString lib = (_magic_value.value());
 {
-((extra_arguments).push((ByteString::must_from_utf8("-l"sv))));
+((extra_arguments).push((ByteString::from_utf8_without_validation("-l"sv))));
 ((extra_arguments).push(lib));
 }
 
 }
 }
 
-if ((false && TRY((compiler_is((ByteString::must_from_utf8("clang-cl"sv))))))){
-((extra_arguments).push((ByteString::must_from_utf8("/link"sv))));
-((extra_arguments).push((ByteString::must_from_utf8("/subsystem:console"sv))));
+if ((false && TRY((compiler_is((ByteString::from_utf8_without_validation("clang-cl"sv))))))){
+((extra_arguments).push((ByteString::from_utf8_without_validation("/link"sv))));
+((extra_arguments).push((ByteString::from_utf8_without_validation("/subsystem:console"sv))));
 }
 {
 JaktInternal::ArrayIterator<ByteString> _magic = ((extra_linker_args).iterator());
@@ -1930,16 +1930,16 @@ ByteString const space = ({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<ByteString,ErrorOr<void>>{
 auto __jakt_enum_value = (next_char);
 if (__jakt_enum_value == static_cast<u8>(u8' ')) {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8(""sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation(""sv)));
 }
 else if (__jakt_enum_value == static_cast<u8>(u8'\t')) {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8(""sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation(""sv)));
 }
 else if (__jakt_enum_value == static_cast<u8>(u8'/')) {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8(""sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation(""sv)));
 }
 else {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8(" "sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation(" "sv)));
 }
 }());
     if (_jakt_value.is_return())
@@ -1957,7 +1957,7 @@ if (__jakt_enum_value == true) {
 return JaktInternal::ExplicitValue(indent(((formatted_token).indent)));
 }
 else {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8(" "sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation(" "sv)));
 }
 }());
     if (_jakt_value.is_return())

--- a/bootstrap/stage0/parser.cpp
+++ b/bootstrap/stage0/parser.cpp
@@ -1231,7 +1231,7 @@ switch(__jakt_match_variant.__jakt_init_index()) {
 case 111 /* Trait */: {
 {
 if ((!(((active_attributes).is_empty())))){
-((*this).error((ByteString::must_from_utf8("Cannot apply attributes to trait declarations"sv)),((((active_attributes)[static_cast<i64>(0LL)])).span)));
+((*this).error((ByteString::from_utf8_without_validation("Cannot apply attributes to trait declarations"sv)),((((active_attributes)[static_cast<i64>(0LL)])).span)));
 (active_attributes = DynamicArray<parser::ParsedAttribute>::create_with({}));
 }
 ((((*this).index)++));
@@ -1245,10 +1245,10 @@ auto&& __jakt_match_value = __jakt_match_variant.as.Identifier;ByteString const&
 return (({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<void,ErrorOr<parser::ParsedNamespace>>{
 auto __jakt_enum_value = (name);
-if (__jakt_enum_value == (ByteString::must_from_utf8("type"sv))) {
+if (__jakt_enum_value == (ByteString::from_utf8_without_validation("type"sv))) {
 {
 if ((!(((active_attributes).is_empty())))){
-((*this).error((ByteString::must_from_utf8("Cannot apply attributes to external trait declarations"sv)),((((active_attributes)[static_cast<i64>(0LL)])).span)));
+((*this).error((ByteString::from_utf8_without_validation("Cannot apply attributes to external trait declarations"sv)),((((active_attributes)[static_cast<i64>(0LL)])).span)));
 (active_attributes = DynamicArray<parser::ParsedAttribute>::create_with({}));
 }
 ((((*this).index)++));
@@ -1257,10 +1257,10 @@ if ((!(((active_attributes).is_empty())))){
 }
 return JaktInternal::ExplicitValue<void>();
 }
-else if (__jakt_enum_value == (ByteString::must_from_utf8("use"sv))) {
+else if (__jakt_enum_value == (ByteString::from_utf8_without_validation("use"sv))) {
 {
 if ((!(((active_attributes).is_empty())))){
-((*this).error((ByteString::must_from_utf8("Cannot apply attributes to use declarations"sv)),((((active_attributes)[static_cast<i64>(0LL)])).span)));
+((*this).error((ByteString::from_utf8_without_validation("Cannot apply attributes to use declarations"sv)),((((active_attributes)[static_cast<i64>(0LL)])).span)));
 (active_attributes = DynamicArray<parser::ParsedAttribute>::create_with({}));
 }
 ((((*this).index)++));
@@ -1269,10 +1269,10 @@ if ((!(((active_attributes).is_empty())))){
 }
 return JaktInternal::ExplicitValue<void>();
 }
-else if (__jakt_enum_value == (ByteString::must_from_utf8("forall"sv))) {
+else if (__jakt_enum_value == (ByteString::from_utf8_without_validation("forall"sv))) {
 {
 if ((!(((active_attributes).is_empty())))){
-((*this).error((ByteString::must_from_utf8("Cannot apply attributes to forall declarations"sv)),((((active_attributes)[static_cast<i64>(0LL)])).span)));
+((*this).error((ByteString::from_utf8_without_validation("Cannot apply attributes to forall declarations"sv)),((((active_attributes)[static_cast<i64>(0LL)])).span)));
 (active_attributes = DynamicArray<parser::ParsedAttribute>::create_with({}));
 }
 ((((*this).index)++));
@@ -1284,7 +1284,7 @@ return JaktInternal::ExplicitValue<void>();
 else {
 {
 (active_attributes = DynamicArray<parser::ParsedAttribute>::create_with({}));
-((*this).error((ByteString::must_from_utf8("Unexpected token (expected keyword)"sv)),((((*this).current())).span())));
+((*this).error((ByteString::from_utf8_without_validation("Unexpected token (expected keyword)"sv)),((((*this).current())).span())));
 return JaktInternal::LoopBreak{};
 }
 return JaktInternal::ExplicitValue<void>();
@@ -1303,7 +1303,7 @@ return JaktInternal::ExplicitValue<void>();
 case 78 /* Import */: {
 {
 if ((!(((active_attributes).is_empty())))){
-((*this).error((ByteString::must_from_utf8("Cannot apply attributes to imports"sv)),((((active_attributes)[static_cast<i64>(0LL)])).span)));
+((*this).error((ByteString::from_utf8_without_validation("Cannot apply attributes to imports"sv)),((((active_attributes)[static_cast<i64>(0LL)])).span)));
 (active_attributes = DynamicArray<parser::ParsedAttribute>::create_with({}));
 }
 ((((*this).index)++));
@@ -1319,7 +1319,7 @@ if (((((*this).peek(static_cast<size_t>(1ULL)))).__jakt_init_index() == 11 /* LS
 ((*this).parse_attribute_list(((active_attributes))));
 }
 else {
-((*this).error((ByteString::must_from_utf8("Unexpected token (expected ‘[[’)"sv)),((((*this).current())).span())));
+((*this).error((ByteString::from_utf8_without_validation("Unexpected token (expected ‘[[’)"sv)),((((*this).current())).span())));
 ((((*this).index)) += (static_cast<size_t>(1ULL)));
 }
 
@@ -1337,7 +1337,7 @@ TRY((((*this).apply_attributes(((parsed_function)),((active_attributes))))));
 (saw_an_entity = true);
 }
 else {
-((*this).error((ByteString::must_from_utf8("Expected 'fn' after 'unsafe'"sv)),((((*this).current())).span())));
+((*this).error((ByteString::from_utf8_without_validation("Expected 'fn' after 'unsafe'"sv)),((((*this).current())).span())));
 }
 
 }
@@ -1439,7 +1439,7 @@ if (((((*this).current())).__jakt_init_index() == 9 /* LCurly */)){
 ((((*this).index)++));
 }
 else {
-((*this).error((ByteString::must_from_utf8("Expected ‘{’"sv)),((((*this).current())).span())));
+((*this).error((ByteString::from_utf8_without_validation("Expected ‘{’"sv)),((((*this).current())).span())));
 }
 
 parser::ParsedNamespace namespace_ = TRY((((*this).parse_namespace(false))));
@@ -1447,7 +1447,7 @@ if (((((*this).current())).__jakt_init_index() == 10 /* RCurly */)){
 ((((*this).index)++));
 }
 else {
-((*this).error((ByteString::must_from_utf8("Incomplete namespace"sv)),((((*this).previous())).span())));
+((*this).error((ByteString::from_utf8_without_validation("Incomplete namespace"sv)),((((*this).previous())).span())));
 }
 
 if (((name).has_value())){
@@ -1479,7 +1479,7 @@ TRY((((*this).apply_attributes(((parsed_function)),((active_attributes))))));
 (saw_an_entity = true);
 }
 else {
-((*this).error((ByteString::must_from_utf8("Expected 'fn' after 'unsafe'"sv)),((((*this).current())).span())));
+((*this).error((ByteString::from_utf8_without_validation("Expected 'fn' after 'unsafe'"sv)),((((*this).current())).span())));
 }
 
 }
@@ -1528,7 +1528,7 @@ return JaktInternal::ExplicitValue<void>();
 default: {
 {
 (active_attributes = DynamicArray<parser::ParsedAttribute>::create_with({}));
-((*this).error((ByteString::must_from_utf8("Unexpected keyword"sv)),((((*this).current())).span())));
+((*this).error((ByteString::from_utf8_without_validation("Unexpected keyword"sv)),((((*this).current())).span())));
 }
 return JaktInternal::ExplicitValue<void>();
 };/*case end*/
@@ -1560,7 +1560,7 @@ return JaktInternal::ExplicitValue<void>();
 };/*case end*/
 default: {
 {
-((*this).error((ByteString::must_from_utf8("Unexpected token (expected keyword)"sv)),((((*this).current())).span())));
+((*this).error((ByteString::from_utf8_without_validation("Unexpected token (expected keyword)"sv)),((((*this).current())).span())));
 return JaktInternal::LoopBreak{};
 }
 return JaktInternal::ExplicitValue<void>();
@@ -1595,7 +1595,7 @@ parser::ParsedAttribute attribute = (_magic_value.value());
 ({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<void,ErrorOr<void>>{
 auto __jakt_enum_value = (((attribute).name));
-if (__jakt_enum_value == (ByteString::must_from_utf8("extern_import"sv))) {
+if (__jakt_enum_value == (ByteString::from_utf8_without_validation("extern_import"sv))) {
 {
 if ((!(((((attribute).assigned_value)).has_value())))){
 {
@@ -1610,23 +1610,23 @@ parser::ParsedAttributeArgument argument = (_magic_value.value());
 ({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<void,ErrorOr<void>>{
 auto __jakt_enum_value = (((argument).name));
-if (__jakt_enum_value == (ByteString::must_from_utf8("from"sv))) {
+if (__jakt_enum_value == (ByteString::from_utf8_without_validation("from"sv))) {
 {
 (((((namespace_))).import_path_if_extern) = ((argument).assigned_value));
 }
 return JaktInternal::ExplicitValue<void>();
 }
-else if (__jakt_enum_value == (ByteString::must_from_utf8("define_before"sv))) {
+else if (__jakt_enum_value == (ByteString::from_utf8_without_validation("define_before"sv))) {
 {
 if (((((argument).assigned_value)).has_value())){
-if (((((argument).name)).starts_with((ByteString::must_from_utf8("define"sv))))){
+if (((((argument).name)).starts_with((ByteString::from_utf8_without_validation("define"sv))))){
 JaktInternal::DynamicArray<ByteString> const parts = (((((argument).assigned_value).value())).split('='));
 if (((((parts).size())) != (static_cast<size_t>(2ULL)))){
 ((*this).error(__jakt_format((StringView::from_string_literal("The argument '{}' expects a value in the form 'name=value'"sv)),((argument).name)),((argument).span)));
 return JaktInternal::LoopContinue{};
 }
 parser::IncludeAction const action = parser::IncludeAction::Define(((parts)[static_cast<i64>(0LL)]),((attribute).span),((parts)[static_cast<i64>(1LL)]));
-if (((((argument).name)).ends_with((ByteString::must_from_utf8("before"sv))))){
+if (((((argument).name)).ends_with((ByteString::from_utf8_without_validation("before"sv))))){
 ((((((namespace_))).generating_import_extern_before_include)).push(action));
 }
 else {
@@ -1636,7 +1636,7 @@ else {
 }
 else {
 parser::IncludeAction const action = parser::IncludeAction::Undefine((((argument).assigned_value).value()),((attribute).span));
-if (((((argument).name)).ends_with((ByteString::must_from_utf8("before"sv))))){
+if (((((argument).name)).ends_with((ByteString::from_utf8_without_validation("before"sv))))){
 ((((((namespace_))).generating_import_extern_before_include)).push(action));
 }
 else {
@@ -1654,17 +1654,17 @@ return JaktInternal::LoopContinue{};
 }
 return JaktInternal::ExplicitValue<void>();
 }
-else if (__jakt_enum_value == (ByteString::must_from_utf8("undefine_before"sv))) {
+else if (__jakt_enum_value == (ByteString::from_utf8_without_validation("undefine_before"sv))) {
 {
 if (((((argument).assigned_value)).has_value())){
-if (((((argument).name)).starts_with((ByteString::must_from_utf8("define"sv))))){
+if (((((argument).name)).starts_with((ByteString::from_utf8_without_validation("define"sv))))){
 JaktInternal::DynamicArray<ByteString> const parts = (((((argument).assigned_value).value())).split('='));
 if (((((parts).size())) != (static_cast<size_t>(2ULL)))){
 ((*this).error(__jakt_format((StringView::from_string_literal("The argument '{}' expects a value in the form 'name=value'"sv)),((argument).name)),((argument).span)));
 return JaktInternal::LoopContinue{};
 }
 parser::IncludeAction const action = parser::IncludeAction::Define(((parts)[static_cast<i64>(0LL)]),((attribute).span),((parts)[static_cast<i64>(1LL)]));
-if (((((argument).name)).ends_with((ByteString::must_from_utf8("before"sv))))){
+if (((((argument).name)).ends_with((ByteString::from_utf8_without_validation("before"sv))))){
 ((((((namespace_))).generating_import_extern_before_include)).push(action));
 }
 else {
@@ -1674,7 +1674,7 @@ else {
 }
 else {
 parser::IncludeAction const action = parser::IncludeAction::Undefine((((argument).assigned_value).value()),((attribute).span));
-if (((((argument).name)).ends_with((ByteString::must_from_utf8("before"sv))))){
+if (((((argument).name)).ends_with((ByteString::from_utf8_without_validation("before"sv))))){
 ((((((namespace_))).generating_import_extern_before_include)).push(action));
 }
 else {
@@ -1692,17 +1692,17 @@ return JaktInternal::LoopContinue{};
 }
 return JaktInternal::ExplicitValue<void>();
 }
-else if (__jakt_enum_value == (ByteString::must_from_utf8("define_after"sv))) {
+else if (__jakt_enum_value == (ByteString::from_utf8_without_validation("define_after"sv))) {
 {
 if (((((argument).assigned_value)).has_value())){
-if (((((argument).name)).starts_with((ByteString::must_from_utf8("define"sv))))){
+if (((((argument).name)).starts_with((ByteString::from_utf8_without_validation("define"sv))))){
 JaktInternal::DynamicArray<ByteString> const parts = (((((argument).assigned_value).value())).split('='));
 if (((((parts).size())) != (static_cast<size_t>(2ULL)))){
 ((*this).error(__jakt_format((StringView::from_string_literal("The argument '{}' expects a value in the form 'name=value'"sv)),((argument).name)),((argument).span)));
 return JaktInternal::LoopContinue{};
 }
 parser::IncludeAction const action = parser::IncludeAction::Define(((parts)[static_cast<i64>(0LL)]),((attribute).span),((parts)[static_cast<i64>(1LL)]));
-if (((((argument).name)).ends_with((ByteString::must_from_utf8("before"sv))))){
+if (((((argument).name)).ends_with((ByteString::from_utf8_without_validation("before"sv))))){
 ((((((namespace_))).generating_import_extern_before_include)).push(action));
 }
 else {
@@ -1712,7 +1712,7 @@ else {
 }
 else {
 parser::IncludeAction const action = parser::IncludeAction::Undefine((((argument).assigned_value).value()),((attribute).span));
-if (((((argument).name)).ends_with((ByteString::must_from_utf8("before"sv))))){
+if (((((argument).name)).ends_with((ByteString::from_utf8_without_validation("before"sv))))){
 ((((((namespace_))).generating_import_extern_before_include)).push(action));
 }
 else {
@@ -1730,17 +1730,17 @@ return JaktInternal::LoopContinue{};
 }
 return JaktInternal::ExplicitValue<void>();
 }
-else if (__jakt_enum_value == (ByteString::must_from_utf8("undefine_after"sv))) {
+else if (__jakt_enum_value == (ByteString::from_utf8_without_validation("undefine_after"sv))) {
 {
 if (((((argument).assigned_value)).has_value())){
-if (((((argument).name)).starts_with((ByteString::must_from_utf8("define"sv))))){
+if (((((argument).name)).starts_with((ByteString::from_utf8_without_validation("define"sv))))){
 JaktInternal::DynamicArray<ByteString> const parts = (((((argument).assigned_value).value())).split('='));
 if (((((parts).size())) != (static_cast<size_t>(2ULL)))){
 ((*this).error(__jakt_format((StringView::from_string_literal("The argument '{}' expects a value in the form 'name=value'"sv)),((argument).name)),((argument).span)));
 return JaktInternal::LoopContinue{};
 }
 parser::IncludeAction const action = parser::IncludeAction::Define(((parts)[static_cast<i64>(0LL)]),((attribute).span),((parts)[static_cast<i64>(1LL)]));
-if (((((argument).name)).ends_with((ByteString::must_from_utf8("before"sv))))){
+if (((((argument).name)).ends_with((ByteString::from_utf8_without_validation("before"sv))))){
 ((((((namespace_))).generating_import_extern_before_include)).push(action));
 }
 else {
@@ -1750,7 +1750,7 @@ else {
 }
 else {
 parser::IncludeAction const action = parser::IncludeAction::Undefine((((argument).assigned_value).value()),((attribute).span));
-if (((((argument).name)).ends_with((ByteString::must_from_utf8("before"sv))))){
+if (((((argument).name)).ends_with((ByteString::from_utf8_without_validation("before"sv))))){
 ((((((namespace_))).generating_import_extern_before_include)).push(action));
 }
 else {
@@ -1798,7 +1798,7 @@ return JaktInternal::LoopContinue{};
 }
 return JaktInternal::ExplicitValue<void>();
 }
-else if (__jakt_enum_value == (ByteString::must_from_utf8("generated"sv))) {
+else if (__jakt_enum_value == (ByteString::from_utf8_without_validation("generated"sv))) {
 {
 if ((!(((((attribute).assigned_value)).has_value())))){
 (((((namespace_))).is_generated_code) = true);
@@ -1850,18 +1850,18 @@ parser::ParsedAttribute attribute = (_magic_value.value());
 ({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<void,ErrorOr<void>>{
 auto __jakt_enum_value = (((attribute).name));
-if (__jakt_enum_value == (ByteString::must_from_utf8("name"sv))) {
+if (__jakt_enum_value == (ByteString::from_utf8_without_validation("name"sv))) {
 {
 if (((((attribute).assigned_value)).has_value())){
 if (((((((((field))).var_decl)).external_name)).has_value())){
 ((*this).error(__jakt_format((StringView::from_string_literal("The attribute '{}' cannot be applied more than once"sv)),((attribute).name)),((attribute).span)));
 return JaktInternal::LoopContinue{};
 }
-if (((((((attribute).assigned_value).value())).starts_with((ByteString::must_from_utf8("operator("sv)))) && (((((attribute).assigned_value).value())).ends_with((ByteString::must_from_utf8(")"sv)))))){
+if (((((((attribute).assigned_value).value())).starts_with((ByteString::from_utf8_without_validation("operator("sv)))) && (((((attribute).assigned_value).value())).ends_with((ByteString::from_utf8_without_validation(")"sv)))))){
 ByteString const operator_name = (((((attribute).assigned_value).value())).substring(static_cast<size_t>(9ULL),JaktInternal::checked_sub((((((attribute).assigned_value).value())).length()),static_cast<size_t>(10ULL))));
 (((((((field))).var_decl)).external_name) = parser::ExternalName::Operator(operator_name,false));
 }
-else if (((((((attribute).assigned_value).value())).starts_with((ByteString::must_from_utf8("prefix-operator("sv)))) && (((((attribute).assigned_value).value())).ends_with((ByteString::must_from_utf8(")"sv)))))){
+else if (((((((attribute).assigned_value).value())).starts_with((ByteString::from_utf8_without_validation("prefix-operator("sv)))) && (((((attribute).assigned_value).value())).ends_with((ByteString::from_utf8_without_validation(")"sv)))))){
 ByteString const operator_name = (((((attribute).assigned_value).value())).substring(static_cast<size_t>(16ULL),JaktInternal::checked_sub((((((attribute).assigned_value).value())).length()),static_cast<size_t>(17ULL))));
 (((((((field))).var_decl)).external_name) = parser::ExternalName::Operator(operator_name,true));
 }
@@ -1917,18 +1917,18 @@ parser::ParsedAttribute attribute = (_magic_value.value());
 ({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<void,ErrorOr<void>>{
 auto __jakt_enum_value = (((attribute).name));
-if (__jakt_enum_value == (ByteString::must_from_utf8("name"sv))) {
+if (__jakt_enum_value == (ByteString::from_utf8_without_validation("name"sv))) {
 {
 if (((((attribute).assigned_value)).has_value())){
 if (((((((parsed_function))).external_name)).has_value())){
 ((*this).error(__jakt_format((StringView::from_string_literal("The attribute '{}' cannot be applied more than once"sv)),((attribute).name)),((attribute).span)));
 return JaktInternal::LoopContinue{};
 }
-if (((((((attribute).assigned_value).value())).starts_with((ByteString::must_from_utf8("operator("sv)))) && (((((attribute).assigned_value).value())).ends_with((ByteString::must_from_utf8(")"sv)))))){
+if (((((((attribute).assigned_value).value())).starts_with((ByteString::from_utf8_without_validation("operator("sv)))) && (((((attribute).assigned_value).value())).ends_with((ByteString::from_utf8_without_validation(")"sv)))))){
 ByteString const operator_name = (((((attribute).assigned_value).value())).substring(static_cast<size_t>(9ULL),JaktInternal::checked_sub((((((attribute).assigned_value).value())).length()),static_cast<size_t>(10ULL))));
 (((((parsed_function))).external_name) = parser::ExternalName::Operator(operator_name,false));
 }
-else if (((((((attribute).assigned_value).value())).starts_with((ByteString::must_from_utf8("prefix-operator("sv)))) && (((((attribute).assigned_value).value())).ends_with((ByteString::must_from_utf8(")"sv)))))){
+else if (((((((attribute).assigned_value).value())).starts_with((ByteString::from_utf8_without_validation("prefix-operator("sv)))) && (((((attribute).assigned_value).value())).ends_with((ByteString::from_utf8_without_validation(")"sv)))))){
 ByteString const operator_name = (((((attribute).assigned_value).value())).substring(static_cast<size_t>(16ULL),JaktInternal::checked_sub((((((attribute).assigned_value).value())).length()),static_cast<size_t>(17ULL))));
 (((((parsed_function))).external_name) = parser::ExternalName::Operator(operator_name,true));
 }
@@ -1945,7 +1945,7 @@ return JaktInternal::LoopContinue{};
 }
 return JaktInternal::ExplicitValue<void>();
 }
-else if (__jakt_enum_value == (ByteString::must_from_utf8("deprecated"sv))) {
+else if (__jakt_enum_value == (ByteString::from_utf8_without_validation("deprecated"sv))) {
 {
 if (((((((parsed_function))).deprecated_message)).has_value())){
 ((*this).error(__jakt_format((StringView::from_string_literal("The attribute '{}' cannot be applied more than once"sv)),((attribute).name)),((attribute).span)));
@@ -1956,7 +1956,7 @@ ByteString const message = ((((((attribute).arguments)).first())).map([](auto& _
 }
 return JaktInternal::ExplicitValue<void>();
 }
-else if (__jakt_enum_value == (ByteString::must_from_utf8("inline"sv))) {
+else if (__jakt_enum_value == (ByteString::from_utf8_without_validation("inline"sv))) {
 {
 if ((!(((((((parsed_function))).force_inline)).__jakt_init_index() == 0 /* Default */)))){
 ((*this).error(__jakt_format((StringView::from_string_literal("The attribute '{}' cannot be applied more than once"sv)),((attribute).name)),((attribute).span)));
@@ -1964,17 +1964,17 @@ return JaktInternal::LoopContinue{};
 }
 parser::InlineState const inline_state = ({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<parser::InlineState,ErrorOr<void>>{
-auto __jakt_enum_value = (TRY((((((((attribute).arguments)).first())).map([](auto& _value) { return _value.name; })).try_value_or_lazy_evaluated([&]() -> ErrorOr<ByteString> { return (ByteString::must_from_utf8(""sv)); }))));
-if (__jakt_enum_value == (ByteString::must_from_utf8("never"sv))) {
+auto __jakt_enum_value = (TRY((((((((attribute).arguments)).first())).map([](auto& _value) { return _value.name; })).try_value_or_lazy_evaluated([&]() -> ErrorOr<ByteString> { return (ByteString::from_utf8_without_validation(""sv)); }))));
+if (__jakt_enum_value == (ByteString::from_utf8_without_validation("never"sv))) {
 return JaktInternal::ExplicitValue(parser::InlineState::Default());
 }
-else if (__jakt_enum_value == (ByteString::must_from_utf8(""sv))) {
+else if (__jakt_enum_value == (ByteString::from_utf8_without_validation(""sv))) {
 return JaktInternal::ExplicitValue(parser::InlineState::ForceInline());
 }
-else if (__jakt_enum_value == (ByteString::must_from_utf8("always"sv))) {
+else if (__jakt_enum_value == (ByteString::from_utf8_without_validation("always"sv))) {
 return JaktInternal::ExplicitValue(parser::InlineState::ForceInline());
 }
-else if (__jakt_enum_value == (ByteString::must_from_utf8("make_available"sv))) {
+else if (__jakt_enum_value == (ByteString::from_utf8_without_validation("make_available"sv))) {
 return JaktInternal::ExplicitValue(parser::InlineState::MakeDefinitionAvailable());
 }
 else {
@@ -1996,7 +1996,7 @@ return JaktInternal::LoopContinue{};
 }
 return JaktInternal::ExplicitValue<void>();
 }
-else if (__jakt_enum_value == (ByteString::must_from_utf8("stores_arguments"sv))) {
+else if (__jakt_enum_value == (ByteString::from_utf8_without_validation("stores_arguments"sv))) {
 {
 JaktInternal::DynamicArray<JaktInternal::Tuple<size_t,parser::ArgumentStoreLevel>> stores_arguments = DynamicArray<JaktInternal::Tuple<size_t,parser::ArgumentStoreLevel>>::create_with({});
 {
@@ -2109,15 +2109,15 @@ parser::ParsedAttribute attribute = (_magic_value.value());
 ({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<void,ErrorOr<void>>{
 auto __jakt_enum_value = (((attribute).name));
-if (__jakt_enum_value == (ByteString::must_from_utf8("name"sv))) {
+if (__jakt_enum_value == (ByteString::from_utf8_without_validation("name"sv))) {
 {
 if (((((attribute).assigned_value)).has_value())){
 if (((((((parsed_record))).external_name)).has_value())){
 ((*this).error(__jakt_format((StringView::from_string_literal("The attribute '{}' cannot be applied more than once"sv)),((attribute).name)),((attribute).span)));
 return JaktInternal::LoopContinue{};
 }
-if (((((((attribute).assigned_value).value())).starts_with((ByteString::must_from_utf8("operator("sv)))) && (((((attribute).assigned_value).value())).ends_with((ByteString::must_from_utf8(")"sv)))))){
-((*this).error((ByteString::must_from_utf8("A record cannot be renamed to an operator"sv)),((attribute).span)));
+if (((((((attribute).assigned_value).value())).starts_with((ByteString::from_utf8_without_validation("operator("sv)))) && (((((attribute).assigned_value).value())).ends_with((ByteString::from_utf8_without_validation(")"sv)))))){
+((*this).error((ByteString::from_utf8_without_validation("A record cannot be renamed to an operator"sv)),((attribute).span)));
 return JaktInternal::LoopContinue{};
 }
 (((((parsed_record))).external_name) = parser::ExternalName::Plain((((attribute).assigned_value).value())));
@@ -2167,7 +2167,7 @@ if ((((((*this).current())).__jakt_init_index() == 12 /* RSquare */) && ((((*thi
 ((((*this).index)) += (static_cast<size_t>(2ULL)));
 }
 else {
-((*this).error((ByteString::must_from_utf8("Expected ‘]]’"sv)),((((*this).current())).span())));
+((*this).error((ByteString::from_utf8_without_validation("Expected ‘]]’"sv)),((((*this).current())).span())));
 }
 
 }
@@ -2192,14 +2192,14 @@ __jakt_label_4:; __jakt_var_9.release_value(); }));
 case 98 /* This */: {
 return JaktInternal::ExplicitValue(({ Optional<ByteString> __jakt_var_10; {
 ((((*this).index)++));
-__jakt_var_10 = (ByteString::must_from_utf8("this"sv)); goto __jakt_label_5;
+__jakt_var_10 = (ByteString::from_utf8_without_validation("this"sv)); goto __jakt_label_5;
 
 }
 __jakt_label_5:; __jakt_var_10.release_value(); }));
 };/*case end*/
 default: {
 {
-((*this).error((ByteString::must_from_utf8("Expected identifier"sv)),((((*this).current())).span())));
+((*this).error((ByteString::from_utf8_without_validation("Expected identifier"sv)),((((*this).current())).span())));
 ((((*this).index)++));
 return JaktInternal::OptionalNone();
 }
@@ -2232,7 +2232,7 @@ __jakt_label_6:; __jakt_var_11.release_value(); }));
 case 98 /* This */: {
 return JaktInternal::ExplicitValue(({ Optional<ByteString> __jakt_var_12; {
 ((((*this).index)++));
-__jakt_var_12 = (ByteString::must_from_utf8("this"sv)); goto __jakt_label_7;
+__jakt_var_12 = (ByteString::from_utf8_without_validation("this"sv)); goto __jakt_label_7;
 
 }
 __jakt_label_7:; __jakt_var_12.release_value(); }));
@@ -2248,7 +2248,7 @@ __jakt_label_8:; __jakt_var_13.release_value(); }));
 };/*case end*/
 default: {
 {
-((*this).error((ByteString::must_from_utf8("Expected identifier or string literal"sv)),((((*this).current())).span())));
+((*this).error((ByteString::from_utf8_without_validation("Expected identifier or string literal"sv)),((((*this).current())).span())));
 return JaktInternal::OptionalNone();
 }
 };/*case end*/
@@ -2282,7 +2282,7 @@ __jakt_label_9:; __jakt_var_14.release_value(); }));
 case 98 /* This */: {
 return JaktInternal::ExplicitValue(({ Optional<ByteString> __jakt_var_15; {
 ((((*this).index)++));
-__jakt_var_15 = (ByteString::must_from_utf8("this"sv)); goto __jakt_label_10;
+__jakt_var_15 = (ByteString::from_utf8_without_validation("this"sv)); goto __jakt_label_10;
 
 }
 __jakt_label_10:; __jakt_var_15.release_value(); }));
@@ -2298,7 +2298,7 @@ __jakt_label_11:; __jakt_var_16.release_value(); }));
 };/*case end*/
 default: {
 {
-((*this).error((ByteString::must_from_utf8("Expected identifier or string literal"sv)),((((*this).current())).span())));
+((*this).error((ByteString::from_utf8_without_validation("Expected identifier or string literal"sv)),((((*this).current())).span())));
 return JaktInternal::OptionalNone();
 }
 };/*case end*/
@@ -2319,7 +2319,7 @@ if (((((*this).current())).__jakt_init_index() == 52 /* Comma */)){
 ((((*this).index)++));
 }
 else if ((!(((((*this).current())).__jakt_init_index() == 8 /* RParen */)))){
-((*this).error((ByteString::must_from_utf8("Expected ‘,’ or ‘)’"sv)),((((*this).current())).span())));
+((*this).error((ByteString::from_utf8_without_validation("Expected ‘,’ or ‘)’"sv)),((((*this).current())).span())));
 break;
 }
 }
@@ -2327,7 +2327,7 @@ if (((((*this).current())).__jakt_init_index() == 8 /* RParen */)){
 ((((*this).index)++));
 }
 else {
-((*this).error((ByteString::must_from_utf8("Expected ‘)’"sv)),((((*this).current())).span())));
+((*this).error((ByteString::from_utf8_without_validation("Expected ‘)’"sv)),((((*this).current())).span())));
 }
 
 }
@@ -2350,7 +2350,7 @@ __jakt_label_12:; __jakt_var_17.release_value(); }));
 case 98 /* This */: {
 return JaktInternal::ExplicitValue(({ Optional<ByteString> __jakt_var_18; {
 ((((*this).index)++));
-__jakt_var_18 = (ByteString::must_from_utf8("this"sv)); goto __jakt_label_13;
+__jakt_var_18 = (ByteString::from_utf8_without_validation("this"sv)); goto __jakt_label_13;
 
 }
 __jakt_label_13:; __jakt_var_18.release_value(); }));
@@ -2366,7 +2366,7 @@ __jakt_label_14:; __jakt_var_19.release_value(); }));
 };/*case end*/
 default: {
 return JaktInternal::ExplicitValue(({ Optional<ByteString> __jakt_var_20; {
-((*this).error((ByteString::must_from_utf8("Expected identifier or string literal"sv)),((((*this).current())).span())));
+((*this).error((ByteString::from_utf8_without_validation("Expected identifier or string literal"sv)),((((*this).current())).span())));
 __jakt_var_20 = JaktInternal::OptionalNone(); goto __jakt_label_15;
 
 }
@@ -2462,7 +2462,7 @@ default: {
 size_t const index_before = ((*this).index);
 NonnullRefPtr<typename parser::ParsedType> const inner_type = TRY((((*this).parse_typename())));
 if (((index_before) == (((*this).index)))){
-((*this).error((ByteString::must_from_utf8("Expected type name"sv)),((((*this).current())).span())));
+((*this).error((ByteString::from_utf8_without_validation("Expected type name"sv)),((((*this).current())).span())));
 return JaktInternal::LoopBreak{};
 }
 ((((parsed_name).generic_parameters)).push(inner_type));
@@ -2489,7 +2489,7 @@ return JaktInternal::ExplicitValue<void>();
 case 0 /* SingleQuotedString */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.SingleQuotedString;utility::Span const& span = __jakt_match_value.span;
 {
-((*this).error((ByteString::must_from_utf8("Expected alias target name"sv)),span));
+((*this).error((ByteString::from_utf8_without_validation("Expected alias target name"sv)),span));
 return JaktInternal::LoopBreak{};
 }
 return JaktInternal::ExplicitValue<void>();
@@ -2497,7 +2497,7 @@ return JaktInternal::ExplicitValue<void>();
 case 1 /* QuotedString */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.QuotedString;utility::Span const& span = __jakt_match_value.span;
 {
-((*this).error((ByteString::must_from_utf8("Expected alias target name"sv)),span));
+((*this).error((ByteString::from_utf8_without_validation("Expected alias target name"sv)),span));
 return JaktInternal::LoopBreak{};
 }
 return JaktInternal::ExplicitValue<void>();
@@ -2505,7 +2505,7 @@ return JaktInternal::ExplicitValue<void>();
 case 2 /* Number */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Number;utility::Span const& span = __jakt_match_value.span;
 {
-((*this).error((ByteString::must_from_utf8("Expected alias target name"sv)),span));
+((*this).error((ByteString::from_utf8_without_validation("Expected alias target name"sv)),span));
 return JaktInternal::LoopBreak{};
 }
 return JaktInternal::ExplicitValue<void>();
@@ -2513,7 +2513,7 @@ return JaktInternal::ExplicitValue<void>();
 case 4 /* Semicolon */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Semicolon;utility::Span const& span = __jakt_match_value.value;
 {
-((*this).error((ByteString::must_from_utf8("Expected alias target name"sv)),span));
+((*this).error((ByteString::from_utf8_without_validation("Expected alias target name"sv)),span));
 return JaktInternal::LoopBreak{};
 }
 return JaktInternal::ExplicitValue<void>();
@@ -2521,7 +2521,7 @@ return JaktInternal::ExplicitValue<void>();
 case 5 /* Colon */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Colon;utility::Span const& span = __jakt_match_value.value;
 {
-((*this).error((ByteString::must_from_utf8("Expected alias target name"sv)),span));
+((*this).error((ByteString::from_utf8_without_validation("Expected alias target name"sv)),span));
 return JaktInternal::LoopBreak{};
 }
 return JaktInternal::ExplicitValue<void>();
@@ -2529,7 +2529,7 @@ return JaktInternal::ExplicitValue<void>();
 case 7 /* LParen */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.LParen;utility::Span const& span = __jakt_match_value.value;
 {
-((*this).error((ByteString::must_from_utf8("Expected alias target name"sv)),span));
+((*this).error((ByteString::from_utf8_without_validation("Expected alias target name"sv)),span));
 return JaktInternal::LoopBreak{};
 }
 return JaktInternal::ExplicitValue<void>();
@@ -2537,7 +2537,7 @@ return JaktInternal::ExplicitValue<void>();
 case 8 /* RParen */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.RParen;utility::Span const& span = __jakt_match_value.value;
 {
-((*this).error((ByteString::must_from_utf8("Expected alias target name"sv)),span));
+((*this).error((ByteString::from_utf8_without_validation("Expected alias target name"sv)),span));
 return JaktInternal::LoopBreak{};
 }
 return JaktInternal::ExplicitValue<void>();
@@ -2545,7 +2545,7 @@ return JaktInternal::ExplicitValue<void>();
 case 9 /* LCurly */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.LCurly;utility::Span const& span = __jakt_match_value.value;
 {
-((*this).error((ByteString::must_from_utf8("Expected alias target name"sv)),span));
+((*this).error((ByteString::from_utf8_without_validation("Expected alias target name"sv)),span));
 return JaktInternal::LoopBreak{};
 }
 return JaktInternal::ExplicitValue<void>();
@@ -2553,7 +2553,7 @@ return JaktInternal::ExplicitValue<void>();
 case 10 /* RCurly */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.RCurly;utility::Span const& span = __jakt_match_value.value;
 {
-((*this).error((ByteString::must_from_utf8("Expected alias target name"sv)),span));
+((*this).error((ByteString::from_utf8_without_validation("Expected alias target name"sv)),span));
 return JaktInternal::LoopBreak{};
 }
 return JaktInternal::ExplicitValue<void>();
@@ -2561,7 +2561,7 @@ return JaktInternal::ExplicitValue<void>();
 case 11 /* LSquare */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.LSquare;utility::Span const& span = __jakt_match_value.value;
 {
-((*this).error((ByteString::must_from_utf8("Expected alias target name"sv)),span));
+((*this).error((ByteString::from_utf8_without_validation("Expected alias target name"sv)),span));
 return JaktInternal::LoopBreak{};
 }
 return JaktInternal::ExplicitValue<void>();
@@ -2569,7 +2569,7 @@ return JaktInternal::ExplicitValue<void>();
 case 12 /* RSquare */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.RSquare;utility::Span const& span = __jakt_match_value.value;
 {
-((*this).error((ByteString::must_from_utf8("Expected alias target name"sv)),span));
+((*this).error((ByteString::from_utf8_without_validation("Expected alias target name"sv)),span));
 return JaktInternal::LoopBreak{};
 }
 return JaktInternal::ExplicitValue<void>();
@@ -2577,7 +2577,7 @@ return JaktInternal::ExplicitValue<void>();
 case 13 /* PercentSign */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.PercentSign;utility::Span const& span = __jakt_match_value.value;
 {
-((*this).error((ByteString::must_from_utf8("Expected alias target name"sv)),span));
+((*this).error((ByteString::from_utf8_without_validation("Expected alias target name"sv)),span));
 return JaktInternal::LoopBreak{};
 }
 return JaktInternal::ExplicitValue<void>();
@@ -2585,7 +2585,7 @@ return JaktInternal::ExplicitValue<void>();
 case 14 /* Plus */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Plus;utility::Span const& span = __jakt_match_value.value;
 {
-((*this).error((ByteString::must_from_utf8("Expected alias target name"sv)),span));
+((*this).error((ByteString::from_utf8_without_validation("Expected alias target name"sv)),span));
 return JaktInternal::LoopBreak{};
 }
 return JaktInternal::ExplicitValue<void>();
@@ -2593,7 +2593,7 @@ return JaktInternal::ExplicitValue<void>();
 case 15 /* Minus */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Minus;utility::Span const& span = __jakt_match_value.value;
 {
-((*this).error((ByteString::must_from_utf8("Expected alias target name"sv)),span));
+((*this).error((ByteString::from_utf8_without_validation("Expected alias target name"sv)),span));
 return JaktInternal::LoopBreak{};
 }
 return JaktInternal::ExplicitValue<void>();
@@ -2601,7 +2601,7 @@ return JaktInternal::ExplicitValue<void>();
 case 16 /* Equal */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Equal;utility::Span const& span = __jakt_match_value.value;
 {
-((*this).error((ByteString::must_from_utf8("Expected alias target name"sv)),span));
+((*this).error((ByteString::from_utf8_without_validation("Expected alias target name"sv)),span));
 return JaktInternal::LoopBreak{};
 }
 return JaktInternal::ExplicitValue<void>();
@@ -2609,7 +2609,7 @@ return JaktInternal::ExplicitValue<void>();
 case 17 /* PlusEqual */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.PlusEqual;utility::Span const& span = __jakt_match_value.value;
 {
-((*this).error((ByteString::must_from_utf8("Expected alias target name"sv)),span));
+((*this).error((ByteString::from_utf8_without_validation("Expected alias target name"sv)),span));
 return JaktInternal::LoopBreak{};
 }
 return JaktInternal::ExplicitValue<void>();
@@ -2617,7 +2617,7 @@ return JaktInternal::ExplicitValue<void>();
 case 18 /* PlusPlus */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.PlusPlus;utility::Span const& span = __jakt_match_value.value;
 {
-((*this).error((ByteString::must_from_utf8("Expected alias target name"sv)),span));
+((*this).error((ByteString::from_utf8_without_validation("Expected alias target name"sv)),span));
 return JaktInternal::LoopBreak{};
 }
 return JaktInternal::ExplicitValue<void>();
@@ -2625,7 +2625,7 @@ return JaktInternal::ExplicitValue<void>();
 case 19 /* MinusEqual */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.MinusEqual;utility::Span const& span = __jakt_match_value.value;
 {
-((*this).error((ByteString::must_from_utf8("Expected alias target name"sv)),span));
+((*this).error((ByteString::from_utf8_without_validation("Expected alias target name"sv)),span));
 return JaktInternal::LoopBreak{};
 }
 return JaktInternal::ExplicitValue<void>();
@@ -2633,7 +2633,7 @@ return JaktInternal::ExplicitValue<void>();
 case 20 /* MinusMinus */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.MinusMinus;utility::Span const& span = __jakt_match_value.value;
 {
-((*this).error((ByteString::must_from_utf8("Expected alias target name"sv)),span));
+((*this).error((ByteString::from_utf8_without_validation("Expected alias target name"sv)),span));
 return JaktInternal::LoopBreak{};
 }
 return JaktInternal::ExplicitValue<void>();
@@ -2641,7 +2641,7 @@ return JaktInternal::ExplicitValue<void>();
 case 21 /* AsteriskEqual */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.AsteriskEqual;utility::Span const& span = __jakt_match_value.value;
 {
-((*this).error((ByteString::must_from_utf8("Expected alias target name"sv)),span));
+((*this).error((ByteString::from_utf8_without_validation("Expected alias target name"sv)),span));
 return JaktInternal::LoopBreak{};
 }
 return JaktInternal::ExplicitValue<void>();
@@ -2649,7 +2649,7 @@ return JaktInternal::ExplicitValue<void>();
 case 22 /* ForwardSlashEqual */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.ForwardSlashEqual;utility::Span const& span = __jakt_match_value.value;
 {
-((*this).error((ByteString::must_from_utf8("Expected alias target name"sv)),span));
+((*this).error((ByteString::from_utf8_without_validation("Expected alias target name"sv)),span));
 return JaktInternal::LoopBreak{};
 }
 return JaktInternal::ExplicitValue<void>();
@@ -2657,7 +2657,7 @@ return JaktInternal::ExplicitValue<void>();
 case 23 /* PercentSignEqual */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.PercentSignEqual;utility::Span const& span = __jakt_match_value.value;
 {
-((*this).error((ByteString::must_from_utf8("Expected alias target name"sv)),span));
+((*this).error((ByteString::from_utf8_without_validation("Expected alias target name"sv)),span));
 return JaktInternal::LoopBreak{};
 }
 return JaktInternal::ExplicitValue<void>();
@@ -2665,7 +2665,7 @@ return JaktInternal::ExplicitValue<void>();
 case 24 /* NotEqual */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.NotEqual;utility::Span const& span = __jakt_match_value.value;
 {
-((*this).error((ByteString::must_from_utf8("Expected alias target name"sv)),span));
+((*this).error((ByteString::from_utf8_without_validation("Expected alias target name"sv)),span));
 return JaktInternal::LoopBreak{};
 }
 return JaktInternal::ExplicitValue<void>();
@@ -2673,7 +2673,7 @@ return JaktInternal::ExplicitValue<void>();
 case 25 /* DoubleEqual */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.DoubleEqual;utility::Span const& span = __jakt_match_value.value;
 {
-((*this).error((ByteString::must_from_utf8("Expected alias target name"sv)),span));
+((*this).error((ByteString::from_utf8_without_validation("Expected alias target name"sv)),span));
 return JaktInternal::LoopBreak{};
 }
 return JaktInternal::ExplicitValue<void>();
@@ -2681,7 +2681,7 @@ return JaktInternal::ExplicitValue<void>();
 case 26 /* GreaterThan */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.GreaterThan;utility::Span const& span = __jakt_match_value.value;
 {
-((*this).error((ByteString::must_from_utf8("Expected alias target name"sv)),span));
+((*this).error((ByteString::from_utf8_without_validation("Expected alias target name"sv)),span));
 return JaktInternal::LoopBreak{};
 }
 return JaktInternal::ExplicitValue<void>();
@@ -2689,7 +2689,7 @@ return JaktInternal::ExplicitValue<void>();
 case 27 /* GreaterThanOrEqual */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.GreaterThanOrEqual;utility::Span const& span = __jakt_match_value.value;
 {
-((*this).error((ByteString::must_from_utf8("Expected alias target name"sv)),span));
+((*this).error((ByteString::from_utf8_without_validation("Expected alias target name"sv)),span));
 return JaktInternal::LoopBreak{};
 }
 return JaktInternal::ExplicitValue<void>();
@@ -2697,7 +2697,7 @@ return JaktInternal::ExplicitValue<void>();
 case 28 /* LessThan */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.LessThan;utility::Span const& span = __jakt_match_value.value;
 {
-((*this).error((ByteString::must_from_utf8("Expected alias target name"sv)),span));
+((*this).error((ByteString::from_utf8_without_validation("Expected alias target name"sv)),span));
 return JaktInternal::LoopBreak{};
 }
 return JaktInternal::ExplicitValue<void>();
@@ -2705,7 +2705,7 @@ return JaktInternal::ExplicitValue<void>();
 case 29 /* LessThanOrEqual */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.LessThanOrEqual;utility::Span const& span = __jakt_match_value.value;
 {
-((*this).error((ByteString::must_from_utf8("Expected alias target name"sv)),span));
+((*this).error((ByteString::from_utf8_without_validation("Expected alias target name"sv)),span));
 return JaktInternal::LoopBreak{};
 }
 return JaktInternal::ExplicitValue<void>();
@@ -2713,7 +2713,7 @@ return JaktInternal::ExplicitValue<void>();
 case 30 /* LeftArithmeticShift */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.LeftArithmeticShift;utility::Span const& span = __jakt_match_value.value;
 {
-((*this).error((ByteString::must_from_utf8("Expected alias target name"sv)),span));
+((*this).error((ByteString::from_utf8_without_validation("Expected alias target name"sv)),span));
 return JaktInternal::LoopBreak{};
 }
 return JaktInternal::ExplicitValue<void>();
@@ -2721,7 +2721,7 @@ return JaktInternal::ExplicitValue<void>();
 case 31 /* LeftShift */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.LeftShift;utility::Span const& span = __jakt_match_value.value;
 {
-((*this).error((ByteString::must_from_utf8("Expected alias target name"sv)),span));
+((*this).error((ByteString::from_utf8_without_validation("Expected alias target name"sv)),span));
 return JaktInternal::LoopBreak{};
 }
 return JaktInternal::ExplicitValue<void>();
@@ -2729,7 +2729,7 @@ return JaktInternal::ExplicitValue<void>();
 case 32 /* LeftShiftEqual */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.LeftShiftEqual;utility::Span const& span = __jakt_match_value.value;
 {
-((*this).error((ByteString::must_from_utf8("Expected alias target name"sv)),span));
+((*this).error((ByteString::from_utf8_without_validation("Expected alias target name"sv)),span));
 return JaktInternal::LoopBreak{};
 }
 return JaktInternal::ExplicitValue<void>();
@@ -2737,7 +2737,7 @@ return JaktInternal::ExplicitValue<void>();
 case 33 /* RightShift */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.RightShift;utility::Span const& span = __jakt_match_value.value;
 {
-((*this).error((ByteString::must_from_utf8("Expected alias target name"sv)),span));
+((*this).error((ByteString::from_utf8_without_validation("Expected alias target name"sv)),span));
 return JaktInternal::LoopBreak{};
 }
 return JaktInternal::ExplicitValue<void>();
@@ -2745,7 +2745,7 @@ return JaktInternal::ExplicitValue<void>();
 case 34 /* RightArithmeticShift */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.RightArithmeticShift;utility::Span const& span = __jakt_match_value.value;
 {
-((*this).error((ByteString::must_from_utf8("Expected alias target name"sv)),span));
+((*this).error((ByteString::from_utf8_without_validation("Expected alias target name"sv)),span));
 return JaktInternal::LoopBreak{};
 }
 return JaktInternal::ExplicitValue<void>();
@@ -2753,7 +2753,7 @@ return JaktInternal::ExplicitValue<void>();
 case 35 /* RightShiftEqual */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.RightShiftEqual;utility::Span const& span = __jakt_match_value.value;
 {
-((*this).error((ByteString::must_from_utf8("Expected alias target name"sv)),span));
+((*this).error((ByteString::from_utf8_without_validation("Expected alias target name"sv)),span));
 return JaktInternal::LoopBreak{};
 }
 return JaktInternal::ExplicitValue<void>();
@@ -2761,7 +2761,7 @@ return JaktInternal::ExplicitValue<void>();
 case 36 /* Asterisk */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Asterisk;utility::Span const& span = __jakt_match_value.value;
 {
-((*this).error((ByteString::must_from_utf8("Expected alias target name"sv)),span));
+((*this).error((ByteString::from_utf8_without_validation("Expected alias target name"sv)),span));
 return JaktInternal::LoopBreak{};
 }
 return JaktInternal::ExplicitValue<void>();
@@ -2769,7 +2769,7 @@ return JaktInternal::ExplicitValue<void>();
 case 37 /* Ampersand */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Ampersand;utility::Span const& span = __jakt_match_value.value;
 {
-((*this).error((ByteString::must_from_utf8("Expected alias target name"sv)),span));
+((*this).error((ByteString::from_utf8_without_validation("Expected alias target name"sv)),span));
 return JaktInternal::LoopBreak{};
 }
 return JaktInternal::ExplicitValue<void>();
@@ -2777,7 +2777,7 @@ return JaktInternal::ExplicitValue<void>();
 case 38 /* AmpersandEqual */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.AmpersandEqual;utility::Span const& span = __jakt_match_value.value;
 {
-((*this).error((ByteString::must_from_utf8("Expected alias target name"sv)),span));
+((*this).error((ByteString::from_utf8_without_validation("Expected alias target name"sv)),span));
 return JaktInternal::LoopBreak{};
 }
 return JaktInternal::ExplicitValue<void>();
@@ -2785,7 +2785,7 @@ return JaktInternal::ExplicitValue<void>();
 case 39 /* AmpersandAmpersand */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.AmpersandAmpersand;utility::Span const& span = __jakt_match_value.value;
 {
-((*this).error((ByteString::must_from_utf8("Expected alias target name"sv)),span));
+((*this).error((ByteString::from_utf8_without_validation("Expected alias target name"sv)),span));
 return JaktInternal::LoopBreak{};
 }
 return JaktInternal::ExplicitValue<void>();
@@ -2793,7 +2793,7 @@ return JaktInternal::ExplicitValue<void>();
 case 40 /* Pipe */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Pipe;utility::Span const& span = __jakt_match_value.value;
 {
-((*this).error((ByteString::must_from_utf8("Expected alias target name"sv)),span));
+((*this).error((ByteString::from_utf8_without_validation("Expected alias target name"sv)),span));
 return JaktInternal::LoopBreak{};
 }
 return JaktInternal::ExplicitValue<void>();
@@ -2801,7 +2801,7 @@ return JaktInternal::ExplicitValue<void>();
 case 41 /* PipeEqual */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.PipeEqual;utility::Span const& span = __jakt_match_value.value;
 {
-((*this).error((ByteString::must_from_utf8("Expected alias target name"sv)),span));
+((*this).error((ByteString::from_utf8_without_validation("Expected alias target name"sv)),span));
 return JaktInternal::LoopBreak{};
 }
 return JaktInternal::ExplicitValue<void>();
@@ -2809,7 +2809,7 @@ return JaktInternal::ExplicitValue<void>();
 case 42 /* PipePipe */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.PipePipe;utility::Span const& span = __jakt_match_value.value;
 {
-((*this).error((ByteString::must_from_utf8("Expected alias target name"sv)),span));
+((*this).error((ByteString::from_utf8_without_validation("Expected alias target name"sv)),span));
 return JaktInternal::LoopBreak{};
 }
 return JaktInternal::ExplicitValue<void>();
@@ -2817,7 +2817,7 @@ return JaktInternal::ExplicitValue<void>();
 case 43 /* Caret */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Caret;utility::Span const& span = __jakt_match_value.value;
 {
-((*this).error((ByteString::must_from_utf8("Expected alias target name"sv)),span));
+((*this).error((ByteString::from_utf8_without_validation("Expected alias target name"sv)),span));
 return JaktInternal::LoopBreak{};
 }
 return JaktInternal::ExplicitValue<void>();
@@ -2825,7 +2825,7 @@ return JaktInternal::ExplicitValue<void>();
 case 44 /* CaretEqual */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.CaretEqual;utility::Span const& span = __jakt_match_value.value;
 {
-((*this).error((ByteString::must_from_utf8("Expected alias target name"sv)),span));
+((*this).error((ByteString::from_utf8_without_validation("Expected alias target name"sv)),span));
 return JaktInternal::LoopBreak{};
 }
 return JaktInternal::ExplicitValue<void>();
@@ -2833,7 +2833,7 @@ return JaktInternal::ExplicitValue<void>();
 case 45 /* Dollar */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Dollar;utility::Span const& span = __jakt_match_value.value;
 {
-((*this).error((ByteString::must_from_utf8("Expected alias target name"sv)),span));
+((*this).error((ByteString::from_utf8_without_validation("Expected alias target name"sv)),span));
 return JaktInternal::LoopBreak{};
 }
 return JaktInternal::ExplicitValue<void>();
@@ -2841,7 +2841,7 @@ return JaktInternal::ExplicitValue<void>();
 case 46 /* Tilde */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Tilde;utility::Span const& span = __jakt_match_value.value;
 {
-((*this).error((ByteString::must_from_utf8("Expected alias target name"sv)),span));
+((*this).error((ByteString::from_utf8_without_validation("Expected alias target name"sv)),span));
 return JaktInternal::LoopBreak{};
 }
 return JaktInternal::ExplicitValue<void>();
@@ -2849,7 +2849,7 @@ return JaktInternal::ExplicitValue<void>();
 case 47 /* ForwardSlash */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.ForwardSlash;utility::Span const& span = __jakt_match_value.value;
 {
-((*this).error((ByteString::must_from_utf8("Expected alias target name"sv)),span));
+((*this).error((ByteString::from_utf8_without_validation("Expected alias target name"sv)),span));
 return JaktInternal::LoopBreak{};
 }
 return JaktInternal::ExplicitValue<void>();
@@ -2857,7 +2857,7 @@ return JaktInternal::ExplicitValue<void>();
 case 48 /* ExclamationPoint */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.ExclamationPoint;utility::Span const& span = __jakt_match_value.value;
 {
-((*this).error((ByteString::must_from_utf8("Expected alias target name"sv)),span));
+((*this).error((ByteString::from_utf8_without_validation("Expected alias target name"sv)),span));
 return JaktInternal::LoopBreak{};
 }
 return JaktInternal::ExplicitValue<void>();
@@ -2865,7 +2865,7 @@ return JaktInternal::ExplicitValue<void>();
 case 49 /* QuestionMark */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.QuestionMark;utility::Span const& span = __jakt_match_value.value;
 {
-((*this).error((ByteString::must_from_utf8("Expected alias target name"sv)),span));
+((*this).error((ByteString::from_utf8_without_validation("Expected alias target name"sv)),span));
 return JaktInternal::LoopBreak{};
 }
 return JaktInternal::ExplicitValue<void>();
@@ -2873,7 +2873,7 @@ return JaktInternal::ExplicitValue<void>();
 case 50 /* QuestionMarkQuestionMark */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.QuestionMarkQuestionMark;utility::Span const& span = __jakt_match_value.value;
 {
-((*this).error((ByteString::must_from_utf8("Expected alias target name"sv)),span));
+((*this).error((ByteString::from_utf8_without_validation("Expected alias target name"sv)),span));
 return JaktInternal::LoopBreak{};
 }
 return JaktInternal::ExplicitValue<void>();
@@ -2881,7 +2881,7 @@ return JaktInternal::ExplicitValue<void>();
 case 51 /* QuestionMarkQuestionMarkEqual */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.QuestionMarkQuestionMarkEqual;utility::Span const& span = __jakt_match_value.value;
 {
-((*this).error((ByteString::must_from_utf8("Expected alias target name"sv)),span));
+((*this).error((ByteString::from_utf8_without_validation("Expected alias target name"sv)),span));
 return JaktInternal::LoopBreak{};
 }
 return JaktInternal::ExplicitValue<void>();
@@ -2889,7 +2889,7 @@ return JaktInternal::ExplicitValue<void>();
 case 52 /* Comma */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Comma;utility::Span const& span = __jakt_match_value.value;
 {
-((*this).error((ByteString::must_from_utf8("Expected alias target name"sv)),span));
+((*this).error((ByteString::from_utf8_without_validation("Expected alias target name"sv)),span));
 return JaktInternal::LoopBreak{};
 }
 return JaktInternal::ExplicitValue<void>();
@@ -2897,7 +2897,7 @@ return JaktInternal::ExplicitValue<void>();
 case 53 /* Dot */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Dot;utility::Span const& span = __jakt_match_value.value;
 {
-((*this).error((ByteString::must_from_utf8("Expected alias target name"sv)),span));
+((*this).error((ByteString::from_utf8_without_validation("Expected alias target name"sv)),span));
 return JaktInternal::LoopBreak{};
 }
 return JaktInternal::ExplicitValue<void>();
@@ -2905,7 +2905,7 @@ return JaktInternal::ExplicitValue<void>();
 case 54 /* DotDot */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.DotDot;utility::Span const& span = __jakt_match_value.value;
 {
-((*this).error((ByteString::must_from_utf8("Expected alias target name"sv)),span));
+((*this).error((ByteString::from_utf8_without_validation("Expected alias target name"sv)),span));
 return JaktInternal::LoopBreak{};
 }
 return JaktInternal::ExplicitValue<void>();
@@ -2913,7 +2913,7 @@ return JaktInternal::ExplicitValue<void>();
 case 57 /* FatArrow */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.FatArrow;utility::Span const& span = __jakt_match_value.value;
 {
-((*this).error((ByteString::must_from_utf8("Expected alias target name"sv)),span));
+((*this).error((ByteString::from_utf8_without_validation("Expected alias target name"sv)),span));
 return JaktInternal::LoopBreak{};
 }
 return JaktInternal::ExplicitValue<void>();
@@ -2921,7 +2921,7 @@ return JaktInternal::ExplicitValue<void>();
 case 58 /* Arrow */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Arrow;utility::Span const& span = __jakt_match_value.value;
 {
-((*this).error((ByteString::must_from_utf8("Expected alias target name"sv)),span));
+((*this).error((ByteString::from_utf8_without_validation("Expected alias target name"sv)),span));
 return JaktInternal::LoopBreak{};
 }
 return JaktInternal::ExplicitValue<void>();
@@ -2929,7 +2929,7 @@ return JaktInternal::ExplicitValue<void>();
 case 59 /* And */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.And;utility::Span const& span = __jakt_match_value.value;
 {
-((*this).error((ByteString::must_from_utf8("Expected alias target name"sv)),span));
+((*this).error((ByteString::from_utf8_without_validation("Expected alias target name"sv)),span));
 return JaktInternal::LoopBreak{};
 }
 return JaktInternal::ExplicitValue<void>();
@@ -2937,7 +2937,7 @@ return JaktInternal::ExplicitValue<void>();
 case 60 /* Anon */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Anon;utility::Span const& span = __jakt_match_value.value;
 {
-((*this).error((ByteString::must_from_utf8("Expected alias target name"sv)),span));
+((*this).error((ByteString::from_utf8_without_validation("Expected alias target name"sv)),span));
 return JaktInternal::LoopBreak{};
 }
 return JaktInternal::ExplicitValue<void>();
@@ -2945,7 +2945,7 @@ return JaktInternal::ExplicitValue<void>();
 case 62 /* Boxed */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Boxed;utility::Span const& span = __jakt_match_value.value;
 {
-((*this).error((ByteString::must_from_utf8("Expected alias target name"sv)),span));
+((*this).error((ByteString::from_utf8_without_validation("Expected alias target name"sv)),span));
 return JaktInternal::LoopBreak{};
 }
 return JaktInternal::ExplicitValue<void>();
@@ -2953,7 +2953,7 @@ return JaktInternal::ExplicitValue<void>();
 case 63 /* Break */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Break;utility::Span const& span = __jakt_match_value.value;
 {
-((*this).error((ByteString::must_from_utf8("Expected alias target name"sv)),span));
+((*this).error((ByteString::from_utf8_without_validation("Expected alias target name"sv)),span));
 return JaktInternal::LoopBreak{};
 }
 return JaktInternal::ExplicitValue<void>();
@@ -2961,7 +2961,7 @@ return JaktInternal::ExplicitValue<void>();
 case 64 /* Catch */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Catch;utility::Span const& span = __jakt_match_value.value;
 {
-((*this).error((ByteString::must_from_utf8("Expected alias target name"sv)),span));
+((*this).error((ByteString::from_utf8_without_validation("Expected alias target name"sv)),span));
 return JaktInternal::LoopBreak{};
 }
 return JaktInternal::ExplicitValue<void>();
@@ -2969,7 +2969,7 @@ return JaktInternal::ExplicitValue<void>();
 case 65 /* Class */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Class;utility::Span const& span = __jakt_match_value.value;
 {
-((*this).error((ByteString::must_from_utf8("Expected alias target name"sv)),span));
+((*this).error((ByteString::from_utf8_without_validation("Expected alias target name"sv)),span));
 return JaktInternal::LoopBreak{};
 }
 return JaktInternal::ExplicitValue<void>();
@@ -2977,7 +2977,7 @@ return JaktInternal::ExplicitValue<void>();
 case 66 /* Continue */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Continue;utility::Span const& span = __jakt_match_value.value;
 {
-((*this).error((ByteString::must_from_utf8("Expected alias target name"sv)),span));
+((*this).error((ByteString::from_utf8_without_validation("Expected alias target name"sv)),span));
 return JaktInternal::LoopBreak{};
 }
 return JaktInternal::ExplicitValue<void>();
@@ -2985,7 +2985,7 @@ return JaktInternal::ExplicitValue<void>();
 case 67 /* Cpp */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Cpp;utility::Span const& span = __jakt_match_value.value;
 {
-((*this).error((ByteString::must_from_utf8("Expected alias target name"sv)),span));
+((*this).error((ByteString::from_utf8_without_validation("Expected alias target name"sv)),span));
 return JaktInternal::LoopBreak{};
 }
 return JaktInternal::ExplicitValue<void>();
@@ -2993,7 +2993,7 @@ return JaktInternal::ExplicitValue<void>();
 case 68 /* Defer */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Defer;utility::Span const& span = __jakt_match_value.value;
 {
-((*this).error((ByteString::must_from_utf8("Expected alias target name"sv)),span));
+((*this).error((ByteString::from_utf8_without_validation("Expected alias target name"sv)),span));
 return JaktInternal::LoopBreak{};
 }
 return JaktInternal::ExplicitValue<void>();
@@ -3001,7 +3001,7 @@ return JaktInternal::ExplicitValue<void>();
 case 69 /* Destructor */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Destructor;utility::Span const& span = __jakt_match_value.value;
 {
-((*this).error((ByteString::must_from_utf8("Expected alias target name"sv)),span));
+((*this).error((ByteString::from_utf8_without_validation("Expected alias target name"sv)),span));
 return JaktInternal::LoopBreak{};
 }
 return JaktInternal::ExplicitValue<void>();
@@ -3009,7 +3009,7 @@ return JaktInternal::ExplicitValue<void>();
 case 70 /* Else */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Else;utility::Span const& span = __jakt_match_value.value;
 {
-((*this).error((ByteString::must_from_utf8("Expected alias target name"sv)),span));
+((*this).error((ByteString::from_utf8_without_validation("Expected alias target name"sv)),span));
 return JaktInternal::LoopBreak{};
 }
 return JaktInternal::ExplicitValue<void>();
@@ -3017,7 +3017,7 @@ return JaktInternal::ExplicitValue<void>();
 case 71 /* Enum */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Enum;utility::Span const& span = __jakt_match_value.value;
 {
-((*this).error((ByteString::must_from_utf8("Expected alias target name"sv)),span));
+((*this).error((ByteString::from_utf8_without_validation("Expected alias target name"sv)),span));
 return JaktInternal::LoopBreak{};
 }
 return JaktInternal::ExplicitValue<void>();
@@ -3025,7 +3025,7 @@ return JaktInternal::ExplicitValue<void>();
 case 72 /* Extern */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Extern;utility::Span const& span = __jakt_match_value.value;
 {
-((*this).error((ByteString::must_from_utf8("Expected alias target name"sv)),span));
+((*this).error((ByteString::from_utf8_without_validation("Expected alias target name"sv)),span));
 return JaktInternal::LoopBreak{};
 }
 return JaktInternal::ExplicitValue<void>();
@@ -3033,7 +3033,7 @@ return JaktInternal::ExplicitValue<void>();
 case 73 /* False */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.False;utility::Span const& span = __jakt_match_value.value;
 {
-((*this).error((ByteString::must_from_utf8("Expected alias target name"sv)),span));
+((*this).error((ByteString::from_utf8_without_validation("Expected alias target name"sv)),span));
 return JaktInternal::LoopBreak{};
 }
 return JaktInternal::ExplicitValue<void>();
@@ -3041,7 +3041,7 @@ return JaktInternal::ExplicitValue<void>();
 case 74 /* For */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.For;utility::Span const& span = __jakt_match_value.value;
 {
-((*this).error((ByteString::must_from_utf8("Expected alias target name"sv)),span));
+((*this).error((ByteString::from_utf8_without_validation("Expected alias target name"sv)),span));
 return JaktInternal::LoopBreak{};
 }
 return JaktInternal::ExplicitValue<void>();
@@ -3049,7 +3049,7 @@ return JaktInternal::ExplicitValue<void>();
 case 75 /* Fn */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Fn;utility::Span const& span = __jakt_match_value.value;
 {
-((*this).error((ByteString::must_from_utf8("Expected alias target name"sv)),span));
+((*this).error((ByteString::from_utf8_without_validation("Expected alias target name"sv)),span));
 return JaktInternal::LoopBreak{};
 }
 return JaktInternal::ExplicitValue<void>();
@@ -3057,7 +3057,7 @@ return JaktInternal::ExplicitValue<void>();
 case 76 /* Comptime */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Comptime;utility::Span const& span = __jakt_match_value.value;
 {
-((*this).error((ByteString::must_from_utf8("Expected alias target name"sv)),span));
+((*this).error((ByteString::from_utf8_without_validation("Expected alias target name"sv)),span));
 return JaktInternal::LoopBreak{};
 }
 return JaktInternal::ExplicitValue<void>();
@@ -3065,7 +3065,7 @@ return JaktInternal::ExplicitValue<void>();
 case 77 /* If */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.If;utility::Span const& span = __jakt_match_value.value;
 {
-((*this).error((ByteString::must_from_utf8("Expected alias target name"sv)),span));
+((*this).error((ByteString::from_utf8_without_validation("Expected alias target name"sv)),span));
 return JaktInternal::LoopBreak{};
 }
 return JaktInternal::ExplicitValue<void>();
@@ -3073,7 +3073,7 @@ return JaktInternal::ExplicitValue<void>();
 case 78 /* Import */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Import;utility::Span const& span = __jakt_match_value.value;
 {
-((*this).error((ByteString::must_from_utf8("Expected alias target name"sv)),span));
+((*this).error((ByteString::from_utf8_without_validation("Expected alias target name"sv)),span));
 return JaktInternal::LoopBreak{};
 }
 return JaktInternal::ExplicitValue<void>();
@@ -3081,7 +3081,7 @@ return JaktInternal::ExplicitValue<void>();
 case 79 /* Relative */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Relative;utility::Span const& span = __jakt_match_value.value;
 {
-((*this).error((ByteString::must_from_utf8("Expected alias target name"sv)),span));
+((*this).error((ByteString::from_utf8_without_validation("Expected alias target name"sv)),span));
 return JaktInternal::LoopBreak{};
 }
 return JaktInternal::ExplicitValue<void>();
@@ -3089,7 +3089,7 @@ return JaktInternal::ExplicitValue<void>();
 case 80 /* In */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.In;utility::Span const& span = __jakt_match_value.value;
 {
-((*this).error((ByteString::must_from_utf8("Expected alias target name"sv)),span));
+((*this).error((ByteString::from_utf8_without_validation("Expected alias target name"sv)),span));
 return JaktInternal::LoopBreak{};
 }
 return JaktInternal::ExplicitValue<void>();
@@ -3097,7 +3097,7 @@ return JaktInternal::ExplicitValue<void>();
 case 81 /* Is */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Is;utility::Span const& span = __jakt_match_value.value;
 {
-((*this).error((ByteString::must_from_utf8("Expected alias target name"sv)),span));
+((*this).error((ByteString::from_utf8_without_validation("Expected alias target name"sv)),span));
 return JaktInternal::LoopBreak{};
 }
 return JaktInternal::ExplicitValue<void>();
@@ -3105,7 +3105,7 @@ return JaktInternal::ExplicitValue<void>();
 case 82 /* Let */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Let;utility::Span const& span = __jakt_match_value.value;
 {
-((*this).error((ByteString::must_from_utf8("Expected alias target name"sv)),span));
+((*this).error((ByteString::from_utf8_without_validation("Expected alias target name"sv)),span));
 return JaktInternal::LoopBreak{};
 }
 return JaktInternal::ExplicitValue<void>();
@@ -3113,7 +3113,7 @@ return JaktInternal::ExplicitValue<void>();
 case 83 /* Loop */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Loop;utility::Span const& span = __jakt_match_value.value;
 {
-((*this).error((ByteString::must_from_utf8("Expected alias target name"sv)),span));
+((*this).error((ByteString::from_utf8_without_validation("Expected alias target name"sv)),span));
 return JaktInternal::LoopBreak{};
 }
 return JaktInternal::ExplicitValue<void>();
@@ -3121,7 +3121,7 @@ return JaktInternal::ExplicitValue<void>();
 case 84 /* Match */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Match;utility::Span const& span = __jakt_match_value.value;
 {
-((*this).error((ByteString::must_from_utf8("Expected alias target name"sv)),span));
+((*this).error((ByteString::from_utf8_without_validation("Expected alias target name"sv)),span));
 return JaktInternal::LoopBreak{};
 }
 return JaktInternal::ExplicitValue<void>();
@@ -3129,7 +3129,7 @@ return JaktInternal::ExplicitValue<void>();
 case 85 /* Mut */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Mut;utility::Span const& span = __jakt_match_value.value;
 {
-((*this).error((ByteString::must_from_utf8("Expected alias target name"sv)),span));
+((*this).error((ByteString::from_utf8_without_validation("Expected alias target name"sv)),span));
 return JaktInternal::LoopBreak{};
 }
 return JaktInternal::ExplicitValue<void>();
@@ -3137,7 +3137,7 @@ return JaktInternal::ExplicitValue<void>();
 case 86 /* Namespace */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Namespace;utility::Span const& span = __jakt_match_value.value;
 {
-((*this).error((ByteString::must_from_utf8("Expected alias target name"sv)),span));
+((*this).error((ByteString::from_utf8_without_validation("Expected alias target name"sv)),span));
 return JaktInternal::LoopBreak{};
 }
 return JaktInternal::ExplicitValue<void>();
@@ -3145,7 +3145,7 @@ return JaktInternal::ExplicitValue<void>();
 case 87 /* Not */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Not;utility::Span const& span = __jakt_match_value.value;
 {
-((*this).error((ByteString::must_from_utf8("Expected alias target name"sv)),span));
+((*this).error((ByteString::from_utf8_without_validation("Expected alias target name"sv)),span));
 return JaktInternal::LoopBreak{};
 }
 return JaktInternal::ExplicitValue<void>();
@@ -3153,7 +3153,7 @@ return JaktInternal::ExplicitValue<void>();
 case 88 /* Or */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Or;utility::Span const& span = __jakt_match_value.value;
 {
-((*this).error((ByteString::must_from_utf8("Expected alias target name"sv)),span));
+((*this).error((ByteString::from_utf8_without_validation("Expected alias target name"sv)),span));
 return JaktInternal::LoopBreak{};
 }
 return JaktInternal::ExplicitValue<void>();
@@ -3161,7 +3161,7 @@ return JaktInternal::ExplicitValue<void>();
 case 89 /* Override */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Override;utility::Span const& span = __jakt_match_value.value;
 {
-((*this).error((ByteString::must_from_utf8("Expected alias target name"sv)),span));
+((*this).error((ByteString::from_utf8_without_validation("Expected alias target name"sv)),span));
 return JaktInternal::LoopBreak{};
 }
 return JaktInternal::ExplicitValue<void>();
@@ -3169,7 +3169,7 @@ return JaktInternal::ExplicitValue<void>();
 case 90 /* Private */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Private;utility::Span const& span = __jakt_match_value.value;
 {
-((*this).error((ByteString::must_from_utf8("Expected alias target name"sv)),span));
+((*this).error((ByteString::from_utf8_without_validation("Expected alias target name"sv)),span));
 return JaktInternal::LoopBreak{};
 }
 return JaktInternal::ExplicitValue<void>();
@@ -3177,7 +3177,7 @@ return JaktInternal::ExplicitValue<void>();
 case 91 /* Public */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Public;utility::Span const& span = __jakt_match_value.value;
 {
-((*this).error((ByteString::must_from_utf8("Expected alias target name"sv)),span));
+((*this).error((ByteString::from_utf8_without_validation("Expected alias target name"sv)),span));
 return JaktInternal::LoopBreak{};
 }
 return JaktInternal::ExplicitValue<void>();
@@ -3185,7 +3185,7 @@ return JaktInternal::ExplicitValue<void>();
 case 92 /* Raw */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Raw;utility::Span const& span = __jakt_match_value.value;
 {
-((*this).error((ByteString::must_from_utf8("Expected alias target name"sv)),span));
+((*this).error((ByteString::from_utf8_without_validation("Expected alias target name"sv)),span));
 return JaktInternal::LoopBreak{};
 }
 return JaktInternal::ExplicitValue<void>();
@@ -3193,7 +3193,7 @@ return JaktInternal::ExplicitValue<void>();
 case 93 /* Reflect */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Reflect;utility::Span const& span = __jakt_match_value.value;
 {
-((*this).error((ByteString::must_from_utf8("Expected alias target name"sv)),span));
+((*this).error((ByteString::from_utf8_without_validation("Expected alias target name"sv)),span));
 return JaktInternal::LoopBreak{};
 }
 return JaktInternal::ExplicitValue<void>();
@@ -3201,7 +3201,7 @@ return JaktInternal::ExplicitValue<void>();
 case 94 /* Return */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Return;utility::Span const& span = __jakt_match_value.value;
 {
-((*this).error((ByteString::must_from_utf8("Expected alias target name"sv)),span));
+((*this).error((ByteString::from_utf8_without_validation("Expected alias target name"sv)),span));
 return JaktInternal::LoopBreak{};
 }
 return JaktInternal::ExplicitValue<void>();
@@ -3209,7 +3209,7 @@ return JaktInternal::ExplicitValue<void>();
 case 95 /* Restricted */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Restricted;utility::Span const& span = __jakt_match_value.value;
 {
-((*this).error((ByteString::must_from_utf8("Expected alias target name"sv)),span));
+((*this).error((ByteString::from_utf8_without_validation("Expected alias target name"sv)),span));
 return JaktInternal::LoopBreak{};
 }
 return JaktInternal::ExplicitValue<void>();
@@ -3217,7 +3217,7 @@ return JaktInternal::ExplicitValue<void>();
 case 96 /* Sizeof */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Sizeof;utility::Span const& span = __jakt_match_value.value;
 {
-((*this).error((ByteString::must_from_utf8("Expected alias target name"sv)),span));
+((*this).error((ByteString::from_utf8_without_validation("Expected alias target name"sv)),span));
 return JaktInternal::LoopBreak{};
 }
 return JaktInternal::ExplicitValue<void>();
@@ -3225,7 +3225,7 @@ return JaktInternal::ExplicitValue<void>();
 case 97 /* Struct */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Struct;utility::Span const& span = __jakt_match_value.value;
 {
-((*this).error((ByteString::must_from_utf8("Expected alias target name"sv)),span));
+((*this).error((ByteString::from_utf8_without_validation("Expected alias target name"sv)),span));
 return JaktInternal::LoopBreak{};
 }
 return JaktInternal::ExplicitValue<void>();
@@ -3233,7 +3233,7 @@ return JaktInternal::ExplicitValue<void>();
 case 98 /* This */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.This;utility::Span const& span = __jakt_match_value.value;
 {
-((*this).error((ByteString::must_from_utf8("Expected alias target name"sv)),span));
+((*this).error((ByteString::from_utf8_without_validation("Expected alias target name"sv)),span));
 return JaktInternal::LoopBreak{};
 }
 return JaktInternal::ExplicitValue<void>();
@@ -3241,7 +3241,7 @@ return JaktInternal::ExplicitValue<void>();
 case 99 /* Throw */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Throw;utility::Span const& span = __jakt_match_value.value;
 {
-((*this).error((ByteString::must_from_utf8("Expected alias target name"sv)),span));
+((*this).error((ByteString::from_utf8_without_validation("Expected alias target name"sv)),span));
 return JaktInternal::LoopBreak{};
 }
 return JaktInternal::ExplicitValue<void>();
@@ -3249,7 +3249,7 @@ return JaktInternal::ExplicitValue<void>();
 case 100 /* Throws */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Throws;utility::Span const& span = __jakt_match_value.value;
 {
-((*this).error((ByteString::must_from_utf8("Expected alias target name"sv)),span));
+((*this).error((ByteString::from_utf8_without_validation("Expected alias target name"sv)),span));
 return JaktInternal::LoopBreak{};
 }
 return JaktInternal::ExplicitValue<void>();
@@ -3257,7 +3257,7 @@ return JaktInternal::ExplicitValue<void>();
 case 101 /* True */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.True;utility::Span const& span = __jakt_match_value.value;
 {
-((*this).error((ByteString::must_from_utf8("Expected alias target name"sv)),span));
+((*this).error((ByteString::from_utf8_without_validation("Expected alias target name"sv)),span));
 return JaktInternal::LoopBreak{};
 }
 return JaktInternal::ExplicitValue<void>();
@@ -3265,7 +3265,7 @@ return JaktInternal::ExplicitValue<void>();
 case 102 /* Try */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Try;utility::Span const& span = __jakt_match_value.value;
 {
-((*this).error((ByteString::must_from_utf8("Expected alias target name"sv)),span));
+((*this).error((ByteString::from_utf8_without_validation("Expected alias target name"sv)),span));
 return JaktInternal::LoopBreak{};
 }
 return JaktInternal::ExplicitValue<void>();
@@ -3273,7 +3273,7 @@ return JaktInternal::ExplicitValue<void>();
 case 103 /* Unsafe */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Unsafe;utility::Span const& span = __jakt_match_value.value;
 {
-((*this).error((ByteString::must_from_utf8("Expected alias target name"sv)),span));
+((*this).error((ByteString::from_utf8_without_validation("Expected alias target name"sv)),span));
 return JaktInternal::LoopBreak{};
 }
 return JaktInternal::ExplicitValue<void>();
@@ -3281,7 +3281,7 @@ return JaktInternal::ExplicitValue<void>();
 case 104 /* Virtual */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Virtual;utility::Span const& span = __jakt_match_value.value;
 {
-((*this).error((ByteString::must_from_utf8("Expected alias target name"sv)),span));
+((*this).error((ByteString::from_utf8_without_validation("Expected alias target name"sv)),span));
 return JaktInternal::LoopBreak{};
 }
 return JaktInternal::ExplicitValue<void>();
@@ -3289,7 +3289,7 @@ return JaktInternal::ExplicitValue<void>();
 case 105 /* Weak */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Weak;utility::Span const& span = __jakt_match_value.value;
 {
-((*this).error((ByteString::must_from_utf8("Expected alias target name"sv)),span));
+((*this).error((ByteString::from_utf8_without_validation("Expected alias target name"sv)),span));
 return JaktInternal::LoopBreak{};
 }
 return JaktInternal::ExplicitValue<void>();
@@ -3297,7 +3297,7 @@ return JaktInternal::ExplicitValue<void>();
 case 106 /* While */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.While;utility::Span const& span = __jakt_match_value.value;
 {
-((*this).error((ByteString::must_from_utf8("Expected alias target name"sv)),span));
+((*this).error((ByteString::from_utf8_without_validation("Expected alias target name"sv)),span));
 return JaktInternal::LoopBreak{};
 }
 return JaktInternal::ExplicitValue<void>();
@@ -3305,7 +3305,7 @@ return JaktInternal::ExplicitValue<void>();
 case 107 /* Yield */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Yield;utility::Span const& span = __jakt_match_value.value;
 {
-((*this).error((ByteString::must_from_utf8("Expected alias target name"sv)),span));
+((*this).error((ByteString::from_utf8_without_validation("Expected alias target name"sv)),span));
 return JaktInternal::LoopBreak{};
 }
 return JaktInternal::ExplicitValue<void>();
@@ -3313,7 +3313,7 @@ return JaktInternal::ExplicitValue<void>();
 case 108 /* Guard */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Guard;utility::Span const& span = __jakt_match_value.value;
 {
-((*this).error((ByteString::must_from_utf8("Expected alias target name"sv)),span));
+((*this).error((ByteString::from_utf8_without_validation("Expected alias target name"sv)),span));
 return JaktInternal::LoopBreak{};
 }
 return JaktInternal::ExplicitValue<void>();
@@ -3321,7 +3321,7 @@ return JaktInternal::ExplicitValue<void>();
 case 109 /* Implements */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Implements;utility::Span const& span = __jakt_match_value.value;
 {
-((*this).error((ByteString::must_from_utf8("Expected alias target name"sv)),span));
+((*this).error((ByteString::from_utf8_without_validation("Expected alias target name"sv)),span));
 return JaktInternal::LoopBreak{};
 }
 return JaktInternal::ExplicitValue<void>();
@@ -3329,7 +3329,7 @@ return JaktInternal::ExplicitValue<void>();
 case 110 /* Requires */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Requires;utility::Span const& span = __jakt_match_value.value;
 {
-((*this).error((ByteString::must_from_utf8("Expected alias target name"sv)),span));
+((*this).error((ByteString::from_utf8_without_validation("Expected alias target name"sv)),span));
 return JaktInternal::LoopBreak{};
 }
 return JaktInternal::ExplicitValue<void>();
@@ -3337,7 +3337,7 @@ return JaktInternal::ExplicitValue<void>();
 case 111 /* Trait */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Trait;utility::Span const& span = __jakt_match_value.value;
 {
-((*this).error((ByteString::must_from_utf8("Expected alias target name"sv)),span));
+((*this).error((ByteString::from_utf8_without_validation("Expected alias target name"sv)),span));
 return JaktInternal::LoopBreak{};
 }
 return JaktInternal::ExplicitValue<void>();
@@ -3345,7 +3345,7 @@ return JaktInternal::ExplicitValue<void>();
 case 112 /* Garbage */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Garbage;utility::Span const& span = __jakt_match_value.span;
 {
-((*this).error((ByteString::must_from_utf8("Expected alias target name"sv)),span));
+((*this).error((ByteString::from_utf8_without_validation("Expected alias target name"sv)),span));
 return JaktInternal::LoopBreak{};
 }
 return JaktInternal::ExplicitValue<void>();
@@ -3364,7 +3364,7 @@ default: VERIFY_NOT_REACHED();}/*switch end*/
 }
 if (((((*this).previous())).__jakt_init_index() == 6 /* ColonColon */)){
 utility::Span const span = (((*this).previous())).as.ColonColon.value;
-((*this).error((ByteString::must_from_utf8("Expected alias target name"sv)),span));
+((*this).error((ByteString::from_utf8_without_validation("Expected alias target name"sv)),span));
 }
 if (((((*this).current())).__jakt_init_index() == 61 /* As */)){
 ((((*this).index)++));
@@ -3384,784 +3384,784 @@ return JaktInternal::ExplicitValue<void>();
 case 0 /* SingleQuotedString */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.SingleQuotedString;utility::Span const& span = __jakt_match_value.span;
 {
-((*this).error((ByteString::must_from_utf8("Expected alias name"sv)),span));
+((*this).error((ByteString::from_utf8_without_validation("Expected alias name"sv)),span));
 }
 return JaktInternal::ExplicitValue<void>();
 };/*case end*/
 case 1 /* QuotedString */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.QuotedString;utility::Span const& span = __jakt_match_value.span;
 {
-((*this).error((ByteString::must_from_utf8("Expected alias name"sv)),span));
+((*this).error((ByteString::from_utf8_without_validation("Expected alias name"sv)),span));
 }
 return JaktInternal::ExplicitValue<void>();
 };/*case end*/
 case 2 /* Number */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Number;utility::Span const& span = __jakt_match_value.span;
 {
-((*this).error((ByteString::must_from_utf8("Expected alias name"sv)),span));
+((*this).error((ByteString::from_utf8_without_validation("Expected alias name"sv)),span));
 }
 return JaktInternal::ExplicitValue<void>();
 };/*case end*/
 case 4 /* Semicolon */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Semicolon;utility::Span const& span = __jakt_match_value.value;
 {
-((*this).error((ByteString::must_from_utf8("Expected alias name"sv)),span));
+((*this).error((ByteString::from_utf8_without_validation("Expected alias name"sv)),span));
 }
 return JaktInternal::ExplicitValue<void>();
 };/*case end*/
 case 5 /* Colon */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Colon;utility::Span const& span = __jakt_match_value.value;
 {
-((*this).error((ByteString::must_from_utf8("Expected alias name"sv)),span));
+((*this).error((ByteString::from_utf8_without_validation("Expected alias name"sv)),span));
 }
 return JaktInternal::ExplicitValue<void>();
 };/*case end*/
 case 6 /* ColonColon */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.ColonColon;utility::Span const& span = __jakt_match_value.value;
 {
-((*this).error((ByteString::must_from_utf8("Expected alias name"sv)),span));
+((*this).error((ByteString::from_utf8_without_validation("Expected alias name"sv)),span));
 }
 return JaktInternal::ExplicitValue<void>();
 };/*case end*/
 case 7 /* LParen */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.LParen;utility::Span const& span = __jakt_match_value.value;
 {
-((*this).error((ByteString::must_from_utf8("Expected alias name"sv)),span));
+((*this).error((ByteString::from_utf8_without_validation("Expected alias name"sv)),span));
 }
 return JaktInternal::ExplicitValue<void>();
 };/*case end*/
 case 8 /* RParen */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.RParen;utility::Span const& span = __jakt_match_value.value;
 {
-((*this).error((ByteString::must_from_utf8("Expected alias name"sv)),span));
+((*this).error((ByteString::from_utf8_without_validation("Expected alias name"sv)),span));
 }
 return JaktInternal::ExplicitValue<void>();
 };/*case end*/
 case 9 /* LCurly */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.LCurly;utility::Span const& span = __jakt_match_value.value;
 {
-((*this).error((ByteString::must_from_utf8("Expected alias name"sv)),span));
+((*this).error((ByteString::from_utf8_without_validation("Expected alias name"sv)),span));
 }
 return JaktInternal::ExplicitValue<void>();
 };/*case end*/
 case 10 /* RCurly */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.RCurly;utility::Span const& span = __jakt_match_value.value;
 {
-((*this).error((ByteString::must_from_utf8("Expected alias name"sv)),span));
+((*this).error((ByteString::from_utf8_without_validation("Expected alias name"sv)),span));
 }
 return JaktInternal::ExplicitValue<void>();
 };/*case end*/
 case 11 /* LSquare */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.LSquare;utility::Span const& span = __jakt_match_value.value;
 {
-((*this).error((ByteString::must_from_utf8("Expected alias name"sv)),span));
+((*this).error((ByteString::from_utf8_without_validation("Expected alias name"sv)),span));
 }
 return JaktInternal::ExplicitValue<void>();
 };/*case end*/
 case 12 /* RSquare */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.RSquare;utility::Span const& span = __jakt_match_value.value;
 {
-((*this).error((ByteString::must_from_utf8("Expected alias name"sv)),span));
+((*this).error((ByteString::from_utf8_without_validation("Expected alias name"sv)),span));
 }
 return JaktInternal::ExplicitValue<void>();
 };/*case end*/
 case 13 /* PercentSign */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.PercentSign;utility::Span const& span = __jakt_match_value.value;
 {
-((*this).error((ByteString::must_from_utf8("Expected alias name"sv)),span));
+((*this).error((ByteString::from_utf8_without_validation("Expected alias name"sv)),span));
 }
 return JaktInternal::ExplicitValue<void>();
 };/*case end*/
 case 14 /* Plus */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Plus;utility::Span const& span = __jakt_match_value.value;
 {
-((*this).error((ByteString::must_from_utf8("Expected alias name"sv)),span));
+((*this).error((ByteString::from_utf8_without_validation("Expected alias name"sv)),span));
 }
 return JaktInternal::ExplicitValue<void>();
 };/*case end*/
 case 15 /* Minus */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Minus;utility::Span const& span = __jakt_match_value.value;
 {
-((*this).error((ByteString::must_from_utf8("Expected alias name"sv)),span));
+((*this).error((ByteString::from_utf8_without_validation("Expected alias name"sv)),span));
 }
 return JaktInternal::ExplicitValue<void>();
 };/*case end*/
 case 16 /* Equal */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Equal;utility::Span const& span = __jakt_match_value.value;
 {
-((*this).error((ByteString::must_from_utf8("Expected alias name"sv)),span));
+((*this).error((ByteString::from_utf8_without_validation("Expected alias name"sv)),span));
 }
 return JaktInternal::ExplicitValue<void>();
 };/*case end*/
 case 17 /* PlusEqual */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.PlusEqual;utility::Span const& span = __jakt_match_value.value;
 {
-((*this).error((ByteString::must_from_utf8("Expected alias name"sv)),span));
+((*this).error((ByteString::from_utf8_without_validation("Expected alias name"sv)),span));
 }
 return JaktInternal::ExplicitValue<void>();
 };/*case end*/
 case 18 /* PlusPlus */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.PlusPlus;utility::Span const& span = __jakt_match_value.value;
 {
-((*this).error((ByteString::must_from_utf8("Expected alias name"sv)),span));
+((*this).error((ByteString::from_utf8_without_validation("Expected alias name"sv)),span));
 }
 return JaktInternal::ExplicitValue<void>();
 };/*case end*/
 case 19 /* MinusEqual */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.MinusEqual;utility::Span const& span = __jakt_match_value.value;
 {
-((*this).error((ByteString::must_from_utf8("Expected alias name"sv)),span));
+((*this).error((ByteString::from_utf8_without_validation("Expected alias name"sv)),span));
 }
 return JaktInternal::ExplicitValue<void>();
 };/*case end*/
 case 20 /* MinusMinus */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.MinusMinus;utility::Span const& span = __jakt_match_value.value;
 {
-((*this).error((ByteString::must_from_utf8("Expected alias name"sv)),span));
+((*this).error((ByteString::from_utf8_without_validation("Expected alias name"sv)),span));
 }
 return JaktInternal::ExplicitValue<void>();
 };/*case end*/
 case 21 /* AsteriskEqual */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.AsteriskEqual;utility::Span const& span = __jakt_match_value.value;
 {
-((*this).error((ByteString::must_from_utf8("Expected alias name"sv)),span));
+((*this).error((ByteString::from_utf8_without_validation("Expected alias name"sv)),span));
 }
 return JaktInternal::ExplicitValue<void>();
 };/*case end*/
 case 22 /* ForwardSlashEqual */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.ForwardSlashEqual;utility::Span const& span = __jakt_match_value.value;
 {
-((*this).error((ByteString::must_from_utf8("Expected alias name"sv)),span));
+((*this).error((ByteString::from_utf8_without_validation("Expected alias name"sv)),span));
 }
 return JaktInternal::ExplicitValue<void>();
 };/*case end*/
 case 23 /* PercentSignEqual */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.PercentSignEqual;utility::Span const& span = __jakt_match_value.value;
 {
-((*this).error((ByteString::must_from_utf8("Expected alias name"sv)),span));
+((*this).error((ByteString::from_utf8_without_validation("Expected alias name"sv)),span));
 }
 return JaktInternal::ExplicitValue<void>();
 };/*case end*/
 case 24 /* NotEqual */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.NotEqual;utility::Span const& span = __jakt_match_value.value;
 {
-((*this).error((ByteString::must_from_utf8("Expected alias name"sv)),span));
+((*this).error((ByteString::from_utf8_without_validation("Expected alias name"sv)),span));
 }
 return JaktInternal::ExplicitValue<void>();
 };/*case end*/
 case 25 /* DoubleEqual */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.DoubleEqual;utility::Span const& span = __jakt_match_value.value;
 {
-((*this).error((ByteString::must_from_utf8("Expected alias name"sv)),span));
+((*this).error((ByteString::from_utf8_without_validation("Expected alias name"sv)),span));
 }
 return JaktInternal::ExplicitValue<void>();
 };/*case end*/
 case 26 /* GreaterThan */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.GreaterThan;utility::Span const& span = __jakt_match_value.value;
 {
-((*this).error((ByteString::must_from_utf8("Expected alias name"sv)),span));
+((*this).error((ByteString::from_utf8_without_validation("Expected alias name"sv)),span));
 }
 return JaktInternal::ExplicitValue<void>();
 };/*case end*/
 case 27 /* GreaterThanOrEqual */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.GreaterThanOrEqual;utility::Span const& span = __jakt_match_value.value;
 {
-((*this).error((ByteString::must_from_utf8("Expected alias name"sv)),span));
+((*this).error((ByteString::from_utf8_without_validation("Expected alias name"sv)),span));
 }
 return JaktInternal::ExplicitValue<void>();
 };/*case end*/
 case 28 /* LessThan */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.LessThan;utility::Span const& span = __jakt_match_value.value;
 {
-((*this).error((ByteString::must_from_utf8("Expected alias name"sv)),span));
+((*this).error((ByteString::from_utf8_without_validation("Expected alias name"sv)),span));
 }
 return JaktInternal::ExplicitValue<void>();
 };/*case end*/
 case 29 /* LessThanOrEqual */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.LessThanOrEqual;utility::Span const& span = __jakt_match_value.value;
 {
-((*this).error((ByteString::must_from_utf8("Expected alias name"sv)),span));
+((*this).error((ByteString::from_utf8_without_validation("Expected alias name"sv)),span));
 }
 return JaktInternal::ExplicitValue<void>();
 };/*case end*/
 case 30 /* LeftArithmeticShift */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.LeftArithmeticShift;utility::Span const& span = __jakt_match_value.value;
 {
-((*this).error((ByteString::must_from_utf8("Expected alias name"sv)),span));
+((*this).error((ByteString::from_utf8_without_validation("Expected alias name"sv)),span));
 }
 return JaktInternal::ExplicitValue<void>();
 };/*case end*/
 case 31 /* LeftShift */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.LeftShift;utility::Span const& span = __jakt_match_value.value;
 {
-((*this).error((ByteString::must_from_utf8("Expected alias name"sv)),span));
+((*this).error((ByteString::from_utf8_without_validation("Expected alias name"sv)),span));
 }
 return JaktInternal::ExplicitValue<void>();
 };/*case end*/
 case 32 /* LeftShiftEqual */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.LeftShiftEqual;utility::Span const& span = __jakt_match_value.value;
 {
-((*this).error((ByteString::must_from_utf8("Expected alias name"sv)),span));
+((*this).error((ByteString::from_utf8_without_validation("Expected alias name"sv)),span));
 }
 return JaktInternal::ExplicitValue<void>();
 };/*case end*/
 case 33 /* RightShift */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.RightShift;utility::Span const& span = __jakt_match_value.value;
 {
-((*this).error((ByteString::must_from_utf8("Expected alias name"sv)),span));
+((*this).error((ByteString::from_utf8_without_validation("Expected alias name"sv)),span));
 }
 return JaktInternal::ExplicitValue<void>();
 };/*case end*/
 case 34 /* RightArithmeticShift */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.RightArithmeticShift;utility::Span const& span = __jakt_match_value.value;
 {
-((*this).error((ByteString::must_from_utf8("Expected alias name"sv)),span));
+((*this).error((ByteString::from_utf8_without_validation("Expected alias name"sv)),span));
 }
 return JaktInternal::ExplicitValue<void>();
 };/*case end*/
 case 35 /* RightShiftEqual */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.RightShiftEqual;utility::Span const& span = __jakt_match_value.value;
 {
-((*this).error((ByteString::must_from_utf8("Expected alias name"sv)),span));
+((*this).error((ByteString::from_utf8_without_validation("Expected alias name"sv)),span));
 }
 return JaktInternal::ExplicitValue<void>();
 };/*case end*/
 case 36 /* Asterisk */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Asterisk;utility::Span const& span = __jakt_match_value.value;
 {
-((*this).error((ByteString::must_from_utf8("Expected alias name"sv)),span));
+((*this).error((ByteString::from_utf8_without_validation("Expected alias name"sv)),span));
 }
 return JaktInternal::ExplicitValue<void>();
 };/*case end*/
 case 37 /* Ampersand */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Ampersand;utility::Span const& span = __jakt_match_value.value;
 {
-((*this).error((ByteString::must_from_utf8("Expected alias name"sv)),span));
+((*this).error((ByteString::from_utf8_without_validation("Expected alias name"sv)),span));
 }
 return JaktInternal::ExplicitValue<void>();
 };/*case end*/
 case 38 /* AmpersandEqual */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.AmpersandEqual;utility::Span const& span = __jakt_match_value.value;
 {
-((*this).error((ByteString::must_from_utf8("Expected alias name"sv)),span));
+((*this).error((ByteString::from_utf8_without_validation("Expected alias name"sv)),span));
 }
 return JaktInternal::ExplicitValue<void>();
 };/*case end*/
 case 39 /* AmpersandAmpersand */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.AmpersandAmpersand;utility::Span const& span = __jakt_match_value.value;
 {
-((*this).error((ByteString::must_from_utf8("Expected alias name"sv)),span));
+((*this).error((ByteString::from_utf8_without_validation("Expected alias name"sv)),span));
 }
 return JaktInternal::ExplicitValue<void>();
 };/*case end*/
 case 40 /* Pipe */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Pipe;utility::Span const& span = __jakt_match_value.value;
 {
-((*this).error((ByteString::must_from_utf8("Expected alias name"sv)),span));
+((*this).error((ByteString::from_utf8_without_validation("Expected alias name"sv)),span));
 }
 return JaktInternal::ExplicitValue<void>();
 };/*case end*/
 case 41 /* PipeEqual */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.PipeEqual;utility::Span const& span = __jakt_match_value.value;
 {
-((*this).error((ByteString::must_from_utf8("Expected alias name"sv)),span));
+((*this).error((ByteString::from_utf8_without_validation("Expected alias name"sv)),span));
 }
 return JaktInternal::ExplicitValue<void>();
 };/*case end*/
 case 42 /* PipePipe */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.PipePipe;utility::Span const& span = __jakt_match_value.value;
 {
-((*this).error((ByteString::must_from_utf8("Expected alias name"sv)),span));
+((*this).error((ByteString::from_utf8_without_validation("Expected alias name"sv)),span));
 }
 return JaktInternal::ExplicitValue<void>();
 };/*case end*/
 case 43 /* Caret */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Caret;utility::Span const& span = __jakt_match_value.value;
 {
-((*this).error((ByteString::must_from_utf8("Expected alias name"sv)),span));
+((*this).error((ByteString::from_utf8_without_validation("Expected alias name"sv)),span));
 }
 return JaktInternal::ExplicitValue<void>();
 };/*case end*/
 case 44 /* CaretEqual */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.CaretEqual;utility::Span const& span = __jakt_match_value.value;
 {
-((*this).error((ByteString::must_from_utf8("Expected alias name"sv)),span));
+((*this).error((ByteString::from_utf8_without_validation("Expected alias name"sv)),span));
 }
 return JaktInternal::ExplicitValue<void>();
 };/*case end*/
 case 45 /* Dollar */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Dollar;utility::Span const& span = __jakt_match_value.value;
 {
-((*this).error((ByteString::must_from_utf8("Expected alias name"sv)),span));
+((*this).error((ByteString::from_utf8_without_validation("Expected alias name"sv)),span));
 }
 return JaktInternal::ExplicitValue<void>();
 };/*case end*/
 case 46 /* Tilde */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Tilde;utility::Span const& span = __jakt_match_value.value;
 {
-((*this).error((ByteString::must_from_utf8("Expected alias name"sv)),span));
+((*this).error((ByteString::from_utf8_without_validation("Expected alias name"sv)),span));
 }
 return JaktInternal::ExplicitValue<void>();
 };/*case end*/
 case 47 /* ForwardSlash */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.ForwardSlash;utility::Span const& span = __jakt_match_value.value;
 {
-((*this).error((ByteString::must_from_utf8("Expected alias name"sv)),span));
+((*this).error((ByteString::from_utf8_without_validation("Expected alias name"sv)),span));
 }
 return JaktInternal::ExplicitValue<void>();
 };/*case end*/
 case 48 /* ExclamationPoint */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.ExclamationPoint;utility::Span const& span = __jakt_match_value.value;
 {
-((*this).error((ByteString::must_from_utf8("Expected alias name"sv)),span));
+((*this).error((ByteString::from_utf8_without_validation("Expected alias name"sv)),span));
 }
 return JaktInternal::ExplicitValue<void>();
 };/*case end*/
 case 49 /* QuestionMark */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.QuestionMark;utility::Span const& span = __jakt_match_value.value;
 {
-((*this).error((ByteString::must_from_utf8("Expected alias name"sv)),span));
+((*this).error((ByteString::from_utf8_without_validation("Expected alias name"sv)),span));
 }
 return JaktInternal::ExplicitValue<void>();
 };/*case end*/
 case 50 /* QuestionMarkQuestionMark */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.QuestionMarkQuestionMark;utility::Span const& span = __jakt_match_value.value;
 {
-((*this).error((ByteString::must_from_utf8("Expected alias name"sv)),span));
+((*this).error((ByteString::from_utf8_without_validation("Expected alias name"sv)),span));
 }
 return JaktInternal::ExplicitValue<void>();
 };/*case end*/
 case 51 /* QuestionMarkQuestionMarkEqual */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.QuestionMarkQuestionMarkEqual;utility::Span const& span = __jakt_match_value.value;
 {
-((*this).error((ByteString::must_from_utf8("Expected alias name"sv)),span));
+((*this).error((ByteString::from_utf8_without_validation("Expected alias name"sv)),span));
 }
 return JaktInternal::ExplicitValue<void>();
 };/*case end*/
 case 52 /* Comma */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Comma;utility::Span const& span = __jakt_match_value.value;
 {
-((*this).error((ByteString::must_from_utf8("Expected alias name"sv)),span));
+((*this).error((ByteString::from_utf8_without_validation("Expected alias name"sv)),span));
 }
 return JaktInternal::ExplicitValue<void>();
 };/*case end*/
 case 53 /* Dot */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Dot;utility::Span const& span = __jakt_match_value.value;
 {
-((*this).error((ByteString::must_from_utf8("Expected alias name"sv)),span));
+((*this).error((ByteString::from_utf8_without_validation("Expected alias name"sv)),span));
 }
 return JaktInternal::ExplicitValue<void>();
 };/*case end*/
 case 54 /* DotDot */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.DotDot;utility::Span const& span = __jakt_match_value.value;
 {
-((*this).error((ByteString::must_from_utf8("Expected alias name"sv)),span));
+((*this).error((ByteString::from_utf8_without_validation("Expected alias name"sv)),span));
 }
 return JaktInternal::ExplicitValue<void>();
 };/*case end*/
 case 55 /* Eol */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Eol;utility::Span const& span = __jakt_match_value.span;
 {
-((*this).error((ByteString::must_from_utf8("Expected alias name"sv)),span));
+((*this).error((ByteString::from_utf8_without_validation("Expected alias name"sv)),span));
 }
 return JaktInternal::ExplicitValue<void>();
 };/*case end*/
 case 56 /* Eof */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Eof;utility::Span const& span = __jakt_match_value.value;
 {
-((*this).error((ByteString::must_from_utf8("Expected alias name"sv)),span));
+((*this).error((ByteString::from_utf8_without_validation("Expected alias name"sv)),span));
 }
 return JaktInternal::ExplicitValue<void>();
 };/*case end*/
 case 57 /* FatArrow */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.FatArrow;utility::Span const& span = __jakt_match_value.value;
 {
-((*this).error((ByteString::must_from_utf8("Expected alias name"sv)),span));
+((*this).error((ByteString::from_utf8_without_validation("Expected alias name"sv)),span));
 }
 return JaktInternal::ExplicitValue<void>();
 };/*case end*/
 case 58 /* Arrow */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Arrow;utility::Span const& span = __jakt_match_value.value;
 {
-((*this).error((ByteString::must_from_utf8("Expected alias name"sv)),span));
+((*this).error((ByteString::from_utf8_without_validation("Expected alias name"sv)),span));
 }
 return JaktInternal::ExplicitValue<void>();
 };/*case end*/
 case 59 /* And */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.And;utility::Span const& span = __jakt_match_value.value;
 {
-((*this).error((ByteString::must_from_utf8("Expected alias name"sv)),span));
+((*this).error((ByteString::from_utf8_without_validation("Expected alias name"sv)),span));
 }
 return JaktInternal::ExplicitValue<void>();
 };/*case end*/
 case 60 /* Anon */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Anon;utility::Span const& span = __jakt_match_value.value;
 {
-((*this).error((ByteString::must_from_utf8("Expected alias name"sv)),span));
+((*this).error((ByteString::from_utf8_without_validation("Expected alias name"sv)),span));
 }
 return JaktInternal::ExplicitValue<void>();
 };/*case end*/
 case 61 /* As */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.As;utility::Span const& span = __jakt_match_value.value;
 {
-((*this).error((ByteString::must_from_utf8("Expected alias name"sv)),span));
+((*this).error((ByteString::from_utf8_without_validation("Expected alias name"sv)),span));
 }
 return JaktInternal::ExplicitValue<void>();
 };/*case end*/
 case 62 /* Boxed */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Boxed;utility::Span const& span = __jakt_match_value.value;
 {
-((*this).error((ByteString::must_from_utf8("Expected alias name"sv)),span));
+((*this).error((ByteString::from_utf8_without_validation("Expected alias name"sv)),span));
 }
 return JaktInternal::ExplicitValue<void>();
 };/*case end*/
 case 63 /* Break */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Break;utility::Span const& span = __jakt_match_value.value;
 {
-((*this).error((ByteString::must_from_utf8("Expected alias name"sv)),span));
+((*this).error((ByteString::from_utf8_without_validation("Expected alias name"sv)),span));
 }
 return JaktInternal::ExplicitValue<void>();
 };/*case end*/
 case 64 /* Catch */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Catch;utility::Span const& span = __jakt_match_value.value;
 {
-((*this).error((ByteString::must_from_utf8("Expected alias name"sv)),span));
+((*this).error((ByteString::from_utf8_without_validation("Expected alias name"sv)),span));
 }
 return JaktInternal::ExplicitValue<void>();
 };/*case end*/
 case 65 /* Class */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Class;utility::Span const& span = __jakt_match_value.value;
 {
-((*this).error((ByteString::must_from_utf8("Expected alias name"sv)),span));
+((*this).error((ByteString::from_utf8_without_validation("Expected alias name"sv)),span));
 }
 return JaktInternal::ExplicitValue<void>();
 };/*case end*/
 case 66 /* Continue */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Continue;utility::Span const& span = __jakt_match_value.value;
 {
-((*this).error((ByteString::must_from_utf8("Expected alias name"sv)),span));
+((*this).error((ByteString::from_utf8_without_validation("Expected alias name"sv)),span));
 }
 return JaktInternal::ExplicitValue<void>();
 };/*case end*/
 case 67 /* Cpp */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Cpp;utility::Span const& span = __jakt_match_value.value;
 {
-((*this).error((ByteString::must_from_utf8("Expected alias name"sv)),span));
+((*this).error((ByteString::from_utf8_without_validation("Expected alias name"sv)),span));
 }
 return JaktInternal::ExplicitValue<void>();
 };/*case end*/
 case 68 /* Defer */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Defer;utility::Span const& span = __jakt_match_value.value;
 {
-((*this).error((ByteString::must_from_utf8("Expected alias name"sv)),span));
+((*this).error((ByteString::from_utf8_without_validation("Expected alias name"sv)),span));
 }
 return JaktInternal::ExplicitValue<void>();
 };/*case end*/
 case 69 /* Destructor */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Destructor;utility::Span const& span = __jakt_match_value.value;
 {
-((*this).error((ByteString::must_from_utf8("Expected alias name"sv)),span));
+((*this).error((ByteString::from_utf8_without_validation("Expected alias name"sv)),span));
 }
 return JaktInternal::ExplicitValue<void>();
 };/*case end*/
 case 70 /* Else */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Else;utility::Span const& span = __jakt_match_value.value;
 {
-((*this).error((ByteString::must_from_utf8("Expected alias name"sv)),span));
+((*this).error((ByteString::from_utf8_without_validation("Expected alias name"sv)),span));
 }
 return JaktInternal::ExplicitValue<void>();
 };/*case end*/
 case 71 /* Enum */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Enum;utility::Span const& span = __jakt_match_value.value;
 {
-((*this).error((ByteString::must_from_utf8("Expected alias name"sv)),span));
+((*this).error((ByteString::from_utf8_without_validation("Expected alias name"sv)),span));
 }
 return JaktInternal::ExplicitValue<void>();
 };/*case end*/
 case 72 /* Extern */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Extern;utility::Span const& span = __jakt_match_value.value;
 {
-((*this).error((ByteString::must_from_utf8("Expected alias name"sv)),span));
+((*this).error((ByteString::from_utf8_without_validation("Expected alias name"sv)),span));
 }
 return JaktInternal::ExplicitValue<void>();
 };/*case end*/
 case 73 /* False */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.False;utility::Span const& span = __jakt_match_value.value;
 {
-((*this).error((ByteString::must_from_utf8("Expected alias name"sv)),span));
+((*this).error((ByteString::from_utf8_without_validation("Expected alias name"sv)),span));
 }
 return JaktInternal::ExplicitValue<void>();
 };/*case end*/
 case 74 /* For */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.For;utility::Span const& span = __jakt_match_value.value;
 {
-((*this).error((ByteString::must_from_utf8("Expected alias name"sv)),span));
+((*this).error((ByteString::from_utf8_without_validation("Expected alias name"sv)),span));
 }
 return JaktInternal::ExplicitValue<void>();
 };/*case end*/
 case 75 /* Fn */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Fn;utility::Span const& span = __jakt_match_value.value;
 {
-((*this).error((ByteString::must_from_utf8("Expected alias name"sv)),span));
+((*this).error((ByteString::from_utf8_without_validation("Expected alias name"sv)),span));
 }
 return JaktInternal::ExplicitValue<void>();
 };/*case end*/
 case 76 /* Comptime */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Comptime;utility::Span const& span = __jakt_match_value.value;
 {
-((*this).error((ByteString::must_from_utf8("Expected alias name"sv)),span));
+((*this).error((ByteString::from_utf8_without_validation("Expected alias name"sv)),span));
 }
 return JaktInternal::ExplicitValue<void>();
 };/*case end*/
 case 77 /* If */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.If;utility::Span const& span = __jakt_match_value.value;
 {
-((*this).error((ByteString::must_from_utf8("Expected alias name"sv)),span));
+((*this).error((ByteString::from_utf8_without_validation("Expected alias name"sv)),span));
 }
 return JaktInternal::ExplicitValue<void>();
 };/*case end*/
 case 78 /* Import */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Import;utility::Span const& span = __jakt_match_value.value;
 {
-((*this).error((ByteString::must_from_utf8("Expected alias name"sv)),span));
+((*this).error((ByteString::from_utf8_without_validation("Expected alias name"sv)),span));
 }
 return JaktInternal::ExplicitValue<void>();
 };/*case end*/
 case 79 /* Relative */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Relative;utility::Span const& span = __jakt_match_value.value;
 {
-((*this).error((ByteString::must_from_utf8("Expected alias name"sv)),span));
+((*this).error((ByteString::from_utf8_without_validation("Expected alias name"sv)),span));
 }
 return JaktInternal::ExplicitValue<void>();
 };/*case end*/
 case 80 /* In */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.In;utility::Span const& span = __jakt_match_value.value;
 {
-((*this).error((ByteString::must_from_utf8("Expected alias name"sv)),span));
+((*this).error((ByteString::from_utf8_without_validation("Expected alias name"sv)),span));
 }
 return JaktInternal::ExplicitValue<void>();
 };/*case end*/
 case 81 /* Is */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Is;utility::Span const& span = __jakt_match_value.value;
 {
-((*this).error((ByteString::must_from_utf8("Expected alias name"sv)),span));
+((*this).error((ByteString::from_utf8_without_validation("Expected alias name"sv)),span));
 }
 return JaktInternal::ExplicitValue<void>();
 };/*case end*/
 case 82 /* Let */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Let;utility::Span const& span = __jakt_match_value.value;
 {
-((*this).error((ByteString::must_from_utf8("Expected alias name"sv)),span));
+((*this).error((ByteString::from_utf8_without_validation("Expected alias name"sv)),span));
 }
 return JaktInternal::ExplicitValue<void>();
 };/*case end*/
 case 83 /* Loop */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Loop;utility::Span const& span = __jakt_match_value.value;
 {
-((*this).error((ByteString::must_from_utf8("Expected alias name"sv)),span));
+((*this).error((ByteString::from_utf8_without_validation("Expected alias name"sv)),span));
 }
 return JaktInternal::ExplicitValue<void>();
 };/*case end*/
 case 84 /* Match */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Match;utility::Span const& span = __jakt_match_value.value;
 {
-((*this).error((ByteString::must_from_utf8("Expected alias name"sv)),span));
+((*this).error((ByteString::from_utf8_without_validation("Expected alias name"sv)),span));
 }
 return JaktInternal::ExplicitValue<void>();
 };/*case end*/
 case 85 /* Mut */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Mut;utility::Span const& span = __jakt_match_value.value;
 {
-((*this).error((ByteString::must_from_utf8("Expected alias name"sv)),span));
+((*this).error((ByteString::from_utf8_without_validation("Expected alias name"sv)),span));
 }
 return JaktInternal::ExplicitValue<void>();
 };/*case end*/
 case 86 /* Namespace */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Namespace;utility::Span const& span = __jakt_match_value.value;
 {
-((*this).error((ByteString::must_from_utf8("Expected alias name"sv)),span));
+((*this).error((ByteString::from_utf8_without_validation("Expected alias name"sv)),span));
 }
 return JaktInternal::ExplicitValue<void>();
 };/*case end*/
 case 87 /* Not */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Not;utility::Span const& span = __jakt_match_value.value;
 {
-((*this).error((ByteString::must_from_utf8("Expected alias name"sv)),span));
+((*this).error((ByteString::from_utf8_without_validation("Expected alias name"sv)),span));
 }
 return JaktInternal::ExplicitValue<void>();
 };/*case end*/
 case 88 /* Or */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Or;utility::Span const& span = __jakt_match_value.value;
 {
-((*this).error((ByteString::must_from_utf8("Expected alias name"sv)),span));
+((*this).error((ByteString::from_utf8_without_validation("Expected alias name"sv)),span));
 }
 return JaktInternal::ExplicitValue<void>();
 };/*case end*/
 case 89 /* Override */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Override;utility::Span const& span = __jakt_match_value.value;
 {
-((*this).error((ByteString::must_from_utf8("Expected alias name"sv)),span));
+((*this).error((ByteString::from_utf8_without_validation("Expected alias name"sv)),span));
 }
 return JaktInternal::ExplicitValue<void>();
 };/*case end*/
 case 90 /* Private */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Private;utility::Span const& span = __jakt_match_value.value;
 {
-((*this).error((ByteString::must_from_utf8("Expected alias name"sv)),span));
+((*this).error((ByteString::from_utf8_without_validation("Expected alias name"sv)),span));
 }
 return JaktInternal::ExplicitValue<void>();
 };/*case end*/
 case 91 /* Public */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Public;utility::Span const& span = __jakt_match_value.value;
 {
-((*this).error((ByteString::must_from_utf8("Expected alias name"sv)),span));
+((*this).error((ByteString::from_utf8_without_validation("Expected alias name"sv)),span));
 }
 return JaktInternal::ExplicitValue<void>();
 };/*case end*/
 case 92 /* Raw */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Raw;utility::Span const& span = __jakt_match_value.value;
 {
-((*this).error((ByteString::must_from_utf8("Expected alias name"sv)),span));
+((*this).error((ByteString::from_utf8_without_validation("Expected alias name"sv)),span));
 }
 return JaktInternal::ExplicitValue<void>();
 };/*case end*/
 case 93 /* Reflect */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Reflect;utility::Span const& span = __jakt_match_value.value;
 {
-((*this).error((ByteString::must_from_utf8("Expected alias name"sv)),span));
+((*this).error((ByteString::from_utf8_without_validation("Expected alias name"sv)),span));
 }
 return JaktInternal::ExplicitValue<void>();
 };/*case end*/
 case 94 /* Return */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Return;utility::Span const& span = __jakt_match_value.value;
 {
-((*this).error((ByteString::must_from_utf8("Expected alias name"sv)),span));
+((*this).error((ByteString::from_utf8_without_validation("Expected alias name"sv)),span));
 }
 return JaktInternal::ExplicitValue<void>();
 };/*case end*/
 case 95 /* Restricted */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Restricted;utility::Span const& span = __jakt_match_value.value;
 {
-((*this).error((ByteString::must_from_utf8("Expected alias name"sv)),span));
+((*this).error((ByteString::from_utf8_without_validation("Expected alias name"sv)),span));
 }
 return JaktInternal::ExplicitValue<void>();
 };/*case end*/
 case 96 /* Sizeof */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Sizeof;utility::Span const& span = __jakt_match_value.value;
 {
-((*this).error((ByteString::must_from_utf8("Expected alias name"sv)),span));
+((*this).error((ByteString::from_utf8_without_validation("Expected alias name"sv)),span));
 }
 return JaktInternal::ExplicitValue<void>();
 };/*case end*/
 case 97 /* Struct */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Struct;utility::Span const& span = __jakt_match_value.value;
 {
-((*this).error((ByteString::must_from_utf8("Expected alias name"sv)),span));
+((*this).error((ByteString::from_utf8_without_validation("Expected alias name"sv)),span));
 }
 return JaktInternal::ExplicitValue<void>();
 };/*case end*/
 case 98 /* This */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.This;utility::Span const& span = __jakt_match_value.value;
 {
-((*this).error((ByteString::must_from_utf8("Expected alias name"sv)),span));
+((*this).error((ByteString::from_utf8_without_validation("Expected alias name"sv)),span));
 }
 return JaktInternal::ExplicitValue<void>();
 };/*case end*/
 case 99 /* Throw */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Throw;utility::Span const& span = __jakt_match_value.value;
 {
-((*this).error((ByteString::must_from_utf8("Expected alias name"sv)),span));
+((*this).error((ByteString::from_utf8_without_validation("Expected alias name"sv)),span));
 }
 return JaktInternal::ExplicitValue<void>();
 };/*case end*/
 case 100 /* Throws */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Throws;utility::Span const& span = __jakt_match_value.value;
 {
-((*this).error((ByteString::must_from_utf8("Expected alias name"sv)),span));
+((*this).error((ByteString::from_utf8_without_validation("Expected alias name"sv)),span));
 }
 return JaktInternal::ExplicitValue<void>();
 };/*case end*/
 case 101 /* True */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.True;utility::Span const& span = __jakt_match_value.value;
 {
-((*this).error((ByteString::must_from_utf8("Expected alias name"sv)),span));
+((*this).error((ByteString::from_utf8_without_validation("Expected alias name"sv)),span));
 }
 return JaktInternal::ExplicitValue<void>();
 };/*case end*/
 case 102 /* Try */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Try;utility::Span const& span = __jakt_match_value.value;
 {
-((*this).error((ByteString::must_from_utf8("Expected alias name"sv)),span));
+((*this).error((ByteString::from_utf8_without_validation("Expected alias name"sv)),span));
 }
 return JaktInternal::ExplicitValue<void>();
 };/*case end*/
 case 103 /* Unsafe */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Unsafe;utility::Span const& span = __jakt_match_value.value;
 {
-((*this).error((ByteString::must_from_utf8("Expected alias name"sv)),span));
+((*this).error((ByteString::from_utf8_without_validation("Expected alias name"sv)),span));
 }
 return JaktInternal::ExplicitValue<void>();
 };/*case end*/
 case 104 /* Virtual */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Virtual;utility::Span const& span = __jakt_match_value.value;
 {
-((*this).error((ByteString::must_from_utf8("Expected alias name"sv)),span));
+((*this).error((ByteString::from_utf8_without_validation("Expected alias name"sv)),span));
 }
 return JaktInternal::ExplicitValue<void>();
 };/*case end*/
 case 105 /* Weak */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Weak;utility::Span const& span = __jakt_match_value.value;
 {
-((*this).error((ByteString::must_from_utf8("Expected alias name"sv)),span));
+((*this).error((ByteString::from_utf8_without_validation("Expected alias name"sv)),span));
 }
 return JaktInternal::ExplicitValue<void>();
 };/*case end*/
 case 106 /* While */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.While;utility::Span const& span = __jakt_match_value.value;
 {
-((*this).error((ByteString::must_from_utf8("Expected alias name"sv)),span));
+((*this).error((ByteString::from_utf8_without_validation("Expected alias name"sv)),span));
 }
 return JaktInternal::ExplicitValue<void>();
 };/*case end*/
 case 107 /* Yield */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Yield;utility::Span const& span = __jakt_match_value.value;
 {
-((*this).error((ByteString::must_from_utf8("Expected alias name"sv)),span));
+((*this).error((ByteString::from_utf8_without_validation("Expected alias name"sv)),span));
 }
 return JaktInternal::ExplicitValue<void>();
 };/*case end*/
 case 108 /* Guard */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Guard;utility::Span const& span = __jakt_match_value.value;
 {
-((*this).error((ByteString::must_from_utf8("Expected alias name"sv)),span));
+((*this).error((ByteString::from_utf8_without_validation("Expected alias name"sv)),span));
 }
 return JaktInternal::ExplicitValue<void>();
 };/*case end*/
 case 109 /* Implements */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Implements;utility::Span const& span = __jakt_match_value.value;
 {
-((*this).error((ByteString::must_from_utf8("Expected alias name"sv)),span));
+((*this).error((ByteString::from_utf8_without_validation("Expected alias name"sv)),span));
 }
 return JaktInternal::ExplicitValue<void>();
 };/*case end*/
 case 110 /* Requires */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Requires;utility::Span const& span = __jakt_match_value.value;
 {
-((*this).error((ByteString::must_from_utf8("Expected alias name"sv)),span));
+((*this).error((ByteString::from_utf8_without_validation("Expected alias name"sv)),span));
 }
 return JaktInternal::ExplicitValue<void>();
 };/*case end*/
 case 111 /* Trait */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Trait;utility::Span const& span = __jakt_match_value.value;
 {
-((*this).error((ByteString::must_from_utf8("Expected alias name"sv)),span));
+((*this).error((ByteString::from_utf8_without_validation("Expected alias name"sv)),span));
 }
 return JaktInternal::ExplicitValue<void>();
 };/*case end*/
 case 112 /* Garbage */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Garbage;utility::Span const& span = __jakt_match_value.span;
 {
-((*this).error((ByteString::must_from_utf8("Expected alias name"sv)),span));
+((*this).error((ByteString::from_utf8_without_validation("Expected alias name"sv)),span));
 }
 return JaktInternal::ExplicitValue<void>();
 };/*case end*/
@@ -4185,12 +4185,12 @@ if (((((*this).current())).__jakt_init_index() == 109 /* Implements */)){
 ((((*this).index)++));
 }
 else {
-((*this).error((ByteString::must_from_utf8("Expected ‘implements’"sv)),((((*this).current())).span())));
+((*this).error((ByteString::from_utf8_without_validation("Expected ‘implements’"sv)),((((*this).current())).span())));
 }
 
 JaktInternal::Optional<JaktInternal::DynamicArray<parser::ParsedNameWithGenericParameters>> const trait_list = TRY((((*this).parse_trait_list())));
 if ((!(((trait_list).has_value())))){
-((*this).error((ByteString::must_from_utf8("Expected non-empty trait list"sv)),((((*this).current())).span())));
+((*this).error((ByteString::from_utf8_without_validation("Expected non-empty trait list"sv)),((((*this).current())).span())));
 return parser::ParsedExternalTraitImplementation(type_name,DynamicArray<parser::ParsedNameWithGenericParameters>::create_with({}),DynamicArray<parser::ParsedMethod>::create_with({}));
 }
 ((*this).skip_newlines());
@@ -4201,15 +4201,15 @@ JaktInternal::DynamicArray<parser::ParsedMethod> const methods = ((fields_method
 JaktInternal::DynamicArray<parser::ParsedRecord> const records = ((fields_methods_records_).template get<2>());
 
 if ((!(((records).is_empty())))){
-((*this).error((ByteString::must_from_utf8("External trait implementations cannot have nested records"sv)),((((records)[static_cast<i64>(0LL)])).name_span)));
+((*this).error((ByteString::from_utf8_without_validation("External trait implementations cannot have nested records"sv)),((((records)[static_cast<i64>(0LL)])).name_span)));
 }
 if ((!(((fields).is_empty())))){
-((*this).error((ByteString::must_from_utf8("External trait implementations cannot have fields"sv)),((((((fields)[static_cast<i64>(0LL)])).var_decl)).span)));
+((*this).error((ByteString::from_utf8_without_validation("External trait implementations cannot have fields"sv)),((((((fields)[static_cast<i64>(0LL)])).var_decl)).span)));
 }
 return parser::ParsedExternalTraitImplementation(type_name,(trait_list.value()),methods);
 }
 else {
-((*this).error((ByteString::must_from_utf8("Expected ‘{’"sv)),((((*this).current())).span())));
+((*this).error((ByteString::from_utf8_without_validation("Expected ‘{’"sv)),((((*this).current())).span())));
 return parser::ParsedExternalTraitImplementation(type_name,(trait_list.value()),DynamicArray<parser::ParsedMethod>::create_with({}));
 }
 
@@ -4218,7 +4218,7 @@ return parser::ParsedExternalTraitImplementation(type_name,(trait_list.value()),
 
 ErrorOr<parser::ParsedTrait> parser::Parser::parse_trait() {
 {
-parser::ParsedTrait parsed_trait = parser::ParsedTrait((ByteString::must_from_utf8(""sv)),((*this).empty_span()),DynamicArray<parser::ParsedGenericParameter>::create_with({}),parser::ParsedTraitRequirements::Nothing());
+parser::ParsedTrait parsed_trait = parser::ParsedTrait((ByteString::from_utf8_without_validation(""sv)),((*this).empty_span()),DynamicArray<parser::ParsedGenericParameter>::create_with({}),parser::ParsedTraitRequirements::Nothing());
 if (((((*this).current())).__jakt_init_index() == 3 /* Identifier */)){
 ByteString const name = (((*this).current())).as.Identifier.name;
 utility::Span const name_span = (((*this).current())).as.Identifier.span;
@@ -4252,7 +4252,7 @@ return JaktInternal::ExplicitValue<void>();
 case 56 /* Eof */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Eof;utility::Span const& span = __jakt_match_value.value;
 {
-((*this).error((ByteString::must_from_utf8("Expected '}' to close the trait body"sv)),span));
+((*this).error((ByteString::from_utf8_without_validation("Expected '}' to close the trait body"sv)),span));
 }
 return JaktInternal::ExplicitValue<void>();
 };/*case end*/
@@ -4263,7 +4263,7 @@ if (((((*this).peek(static_cast<size_t>(1ULL)))).__jakt_init_index() == 11 /* LS
 ((*this).parse_attribute_list(((active_attributes))));
 }
 else {
-((*this).error((ByteString::must_from_utf8("Unexpected token (expected ‘[[’)"sv)),((((*this).current())).span())));
+((*this).error((ByteString::from_utf8_without_validation("Unexpected token (expected ‘[[’)"sv)),((((*this).current())).span())));
 ((((*this).index)) += (static_cast<size_t>(1ULL)));
 }
 
@@ -4292,7 +4292,7 @@ return JaktInternal::ExplicitValue<void>();
 case 0 /* SingleQuotedString */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.SingleQuotedString;utility::Span const& span = __jakt_match_value.span;
 {
-((*this).error_with_hint((ByteString::must_from_utf8("Expected 'function' keyword inside trait definition"sv)),span,__jakt_format((StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv)),((parsed_trait).name)),((parsed_trait).name_span)));
+((*this).error_with_hint((ByteString::from_utf8_without_validation("Expected 'function' keyword inside trait definition"sv)),span,__jakt_format((StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv)),((parsed_trait).name)),((parsed_trait).name_span)));
 return parsed_trait;
 }
 return JaktInternal::ExplicitValue<void>();
@@ -4300,7 +4300,7 @@ return JaktInternal::ExplicitValue<void>();
 case 1 /* QuotedString */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.QuotedString;utility::Span const& span = __jakt_match_value.span;
 {
-((*this).error_with_hint((ByteString::must_from_utf8("Expected 'function' keyword inside trait definition"sv)),span,__jakt_format((StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv)),((parsed_trait).name)),((parsed_trait).name_span)));
+((*this).error_with_hint((ByteString::from_utf8_without_validation("Expected 'function' keyword inside trait definition"sv)),span,__jakt_format((StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv)),((parsed_trait).name)),((parsed_trait).name_span)));
 return parsed_trait;
 }
 return JaktInternal::ExplicitValue<void>();
@@ -4308,7 +4308,7 @@ return JaktInternal::ExplicitValue<void>();
 case 2 /* Number */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Number;utility::Span const& span = __jakt_match_value.span;
 {
-((*this).error_with_hint((ByteString::must_from_utf8("Expected 'function' keyword inside trait definition"sv)),span,__jakt_format((StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv)),((parsed_trait).name)),((parsed_trait).name_span)));
+((*this).error_with_hint((ByteString::from_utf8_without_validation("Expected 'function' keyword inside trait definition"sv)),span,__jakt_format((StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv)),((parsed_trait).name)),((parsed_trait).name_span)));
 return parsed_trait;
 }
 return JaktInternal::ExplicitValue<void>();
@@ -4316,7 +4316,7 @@ return JaktInternal::ExplicitValue<void>();
 case 3 /* Identifier */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Identifier;utility::Span const& span = __jakt_match_value.span;
 {
-((*this).error_with_hint((ByteString::must_from_utf8("Expected 'function' keyword inside trait definition"sv)),span,__jakt_format((StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv)),((parsed_trait).name)),((parsed_trait).name_span)));
+((*this).error_with_hint((ByteString::from_utf8_without_validation("Expected 'function' keyword inside trait definition"sv)),span,__jakt_format((StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv)),((parsed_trait).name)),((parsed_trait).name_span)));
 return parsed_trait;
 }
 return JaktInternal::ExplicitValue<void>();
@@ -4324,7 +4324,7 @@ return JaktInternal::ExplicitValue<void>();
 case 4 /* Semicolon */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Semicolon;utility::Span const& span = __jakt_match_value.value;
 {
-((*this).error_with_hint((ByteString::must_from_utf8("Expected 'function' keyword inside trait definition"sv)),span,__jakt_format((StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv)),((parsed_trait).name)),((parsed_trait).name_span)));
+((*this).error_with_hint((ByteString::from_utf8_without_validation("Expected 'function' keyword inside trait definition"sv)),span,__jakt_format((StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv)),((parsed_trait).name)),((parsed_trait).name_span)));
 return parsed_trait;
 }
 return JaktInternal::ExplicitValue<void>();
@@ -4332,7 +4332,7 @@ return JaktInternal::ExplicitValue<void>();
 case 5 /* Colon */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Colon;utility::Span const& span = __jakt_match_value.value;
 {
-((*this).error_with_hint((ByteString::must_from_utf8("Expected 'function' keyword inside trait definition"sv)),span,__jakt_format((StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv)),((parsed_trait).name)),((parsed_trait).name_span)));
+((*this).error_with_hint((ByteString::from_utf8_without_validation("Expected 'function' keyword inside trait definition"sv)),span,__jakt_format((StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv)),((parsed_trait).name)),((parsed_trait).name_span)));
 return parsed_trait;
 }
 return JaktInternal::ExplicitValue<void>();
@@ -4340,7 +4340,7 @@ return JaktInternal::ExplicitValue<void>();
 case 6 /* ColonColon */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.ColonColon;utility::Span const& span = __jakt_match_value.value;
 {
-((*this).error_with_hint((ByteString::must_from_utf8("Expected 'function' keyword inside trait definition"sv)),span,__jakt_format((StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv)),((parsed_trait).name)),((parsed_trait).name_span)));
+((*this).error_with_hint((ByteString::from_utf8_without_validation("Expected 'function' keyword inside trait definition"sv)),span,__jakt_format((StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv)),((parsed_trait).name)),((parsed_trait).name_span)));
 return parsed_trait;
 }
 return JaktInternal::ExplicitValue<void>();
@@ -4348,7 +4348,7 @@ return JaktInternal::ExplicitValue<void>();
 case 7 /* LParen */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.LParen;utility::Span const& span = __jakt_match_value.value;
 {
-((*this).error_with_hint((ByteString::must_from_utf8("Expected 'function' keyword inside trait definition"sv)),span,__jakt_format((StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv)),((parsed_trait).name)),((parsed_trait).name_span)));
+((*this).error_with_hint((ByteString::from_utf8_without_validation("Expected 'function' keyword inside trait definition"sv)),span,__jakt_format((StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv)),((parsed_trait).name)),((parsed_trait).name_span)));
 return parsed_trait;
 }
 return JaktInternal::ExplicitValue<void>();
@@ -4356,7 +4356,7 @@ return JaktInternal::ExplicitValue<void>();
 case 8 /* RParen */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.RParen;utility::Span const& span = __jakt_match_value.value;
 {
-((*this).error_with_hint((ByteString::must_from_utf8("Expected 'function' keyword inside trait definition"sv)),span,__jakt_format((StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv)),((parsed_trait).name)),((parsed_trait).name_span)));
+((*this).error_with_hint((ByteString::from_utf8_without_validation("Expected 'function' keyword inside trait definition"sv)),span,__jakt_format((StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv)),((parsed_trait).name)),((parsed_trait).name_span)));
 return parsed_trait;
 }
 return JaktInternal::ExplicitValue<void>();
@@ -4364,7 +4364,7 @@ return JaktInternal::ExplicitValue<void>();
 case 9 /* LCurly */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.LCurly;utility::Span const& span = __jakt_match_value.value;
 {
-((*this).error_with_hint((ByteString::must_from_utf8("Expected 'function' keyword inside trait definition"sv)),span,__jakt_format((StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv)),((parsed_trait).name)),((parsed_trait).name_span)));
+((*this).error_with_hint((ByteString::from_utf8_without_validation("Expected 'function' keyword inside trait definition"sv)),span,__jakt_format((StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv)),((parsed_trait).name)),((parsed_trait).name_span)));
 return parsed_trait;
 }
 return JaktInternal::ExplicitValue<void>();
@@ -4372,7 +4372,7 @@ return JaktInternal::ExplicitValue<void>();
 case 12 /* RSquare */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.RSquare;utility::Span const& span = __jakt_match_value.value;
 {
-((*this).error_with_hint((ByteString::must_from_utf8("Expected 'function' keyword inside trait definition"sv)),span,__jakt_format((StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv)),((parsed_trait).name)),((parsed_trait).name_span)));
+((*this).error_with_hint((ByteString::from_utf8_without_validation("Expected 'function' keyword inside trait definition"sv)),span,__jakt_format((StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv)),((parsed_trait).name)),((parsed_trait).name_span)));
 return parsed_trait;
 }
 return JaktInternal::ExplicitValue<void>();
@@ -4380,7 +4380,7 @@ return JaktInternal::ExplicitValue<void>();
 case 13 /* PercentSign */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.PercentSign;utility::Span const& span = __jakt_match_value.value;
 {
-((*this).error_with_hint((ByteString::must_from_utf8("Expected 'function' keyword inside trait definition"sv)),span,__jakt_format((StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv)),((parsed_trait).name)),((parsed_trait).name_span)));
+((*this).error_with_hint((ByteString::from_utf8_without_validation("Expected 'function' keyword inside trait definition"sv)),span,__jakt_format((StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv)),((parsed_trait).name)),((parsed_trait).name_span)));
 return parsed_trait;
 }
 return JaktInternal::ExplicitValue<void>();
@@ -4388,7 +4388,7 @@ return JaktInternal::ExplicitValue<void>();
 case 14 /* Plus */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Plus;utility::Span const& span = __jakt_match_value.value;
 {
-((*this).error_with_hint((ByteString::must_from_utf8("Expected 'function' keyword inside trait definition"sv)),span,__jakt_format((StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv)),((parsed_trait).name)),((parsed_trait).name_span)));
+((*this).error_with_hint((ByteString::from_utf8_without_validation("Expected 'function' keyword inside trait definition"sv)),span,__jakt_format((StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv)),((parsed_trait).name)),((parsed_trait).name_span)));
 return parsed_trait;
 }
 return JaktInternal::ExplicitValue<void>();
@@ -4396,7 +4396,7 @@ return JaktInternal::ExplicitValue<void>();
 case 15 /* Minus */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Minus;utility::Span const& span = __jakt_match_value.value;
 {
-((*this).error_with_hint((ByteString::must_from_utf8("Expected 'function' keyword inside trait definition"sv)),span,__jakt_format((StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv)),((parsed_trait).name)),((parsed_trait).name_span)));
+((*this).error_with_hint((ByteString::from_utf8_without_validation("Expected 'function' keyword inside trait definition"sv)),span,__jakt_format((StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv)),((parsed_trait).name)),((parsed_trait).name_span)));
 return parsed_trait;
 }
 return JaktInternal::ExplicitValue<void>();
@@ -4404,7 +4404,7 @@ return JaktInternal::ExplicitValue<void>();
 case 16 /* Equal */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Equal;utility::Span const& span = __jakt_match_value.value;
 {
-((*this).error_with_hint((ByteString::must_from_utf8("Expected 'function' keyword inside trait definition"sv)),span,__jakt_format((StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv)),((parsed_trait).name)),((parsed_trait).name_span)));
+((*this).error_with_hint((ByteString::from_utf8_without_validation("Expected 'function' keyword inside trait definition"sv)),span,__jakt_format((StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv)),((parsed_trait).name)),((parsed_trait).name_span)));
 return parsed_trait;
 }
 return JaktInternal::ExplicitValue<void>();
@@ -4412,7 +4412,7 @@ return JaktInternal::ExplicitValue<void>();
 case 17 /* PlusEqual */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.PlusEqual;utility::Span const& span = __jakt_match_value.value;
 {
-((*this).error_with_hint((ByteString::must_from_utf8("Expected 'function' keyword inside trait definition"sv)),span,__jakt_format((StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv)),((parsed_trait).name)),((parsed_trait).name_span)));
+((*this).error_with_hint((ByteString::from_utf8_without_validation("Expected 'function' keyword inside trait definition"sv)),span,__jakt_format((StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv)),((parsed_trait).name)),((parsed_trait).name_span)));
 return parsed_trait;
 }
 return JaktInternal::ExplicitValue<void>();
@@ -4420,7 +4420,7 @@ return JaktInternal::ExplicitValue<void>();
 case 18 /* PlusPlus */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.PlusPlus;utility::Span const& span = __jakt_match_value.value;
 {
-((*this).error_with_hint((ByteString::must_from_utf8("Expected 'function' keyword inside trait definition"sv)),span,__jakt_format((StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv)),((parsed_trait).name)),((parsed_trait).name_span)));
+((*this).error_with_hint((ByteString::from_utf8_without_validation("Expected 'function' keyword inside trait definition"sv)),span,__jakt_format((StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv)),((parsed_trait).name)),((parsed_trait).name_span)));
 return parsed_trait;
 }
 return JaktInternal::ExplicitValue<void>();
@@ -4428,7 +4428,7 @@ return JaktInternal::ExplicitValue<void>();
 case 19 /* MinusEqual */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.MinusEqual;utility::Span const& span = __jakt_match_value.value;
 {
-((*this).error_with_hint((ByteString::must_from_utf8("Expected 'function' keyword inside trait definition"sv)),span,__jakt_format((StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv)),((parsed_trait).name)),((parsed_trait).name_span)));
+((*this).error_with_hint((ByteString::from_utf8_without_validation("Expected 'function' keyword inside trait definition"sv)),span,__jakt_format((StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv)),((parsed_trait).name)),((parsed_trait).name_span)));
 return parsed_trait;
 }
 return JaktInternal::ExplicitValue<void>();
@@ -4436,7 +4436,7 @@ return JaktInternal::ExplicitValue<void>();
 case 20 /* MinusMinus */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.MinusMinus;utility::Span const& span = __jakt_match_value.value;
 {
-((*this).error_with_hint((ByteString::must_from_utf8("Expected 'function' keyword inside trait definition"sv)),span,__jakt_format((StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv)),((parsed_trait).name)),((parsed_trait).name_span)));
+((*this).error_with_hint((ByteString::from_utf8_without_validation("Expected 'function' keyword inside trait definition"sv)),span,__jakt_format((StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv)),((parsed_trait).name)),((parsed_trait).name_span)));
 return parsed_trait;
 }
 return JaktInternal::ExplicitValue<void>();
@@ -4444,7 +4444,7 @@ return JaktInternal::ExplicitValue<void>();
 case 21 /* AsteriskEqual */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.AsteriskEqual;utility::Span const& span = __jakt_match_value.value;
 {
-((*this).error_with_hint((ByteString::must_from_utf8("Expected 'function' keyword inside trait definition"sv)),span,__jakt_format((StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv)),((parsed_trait).name)),((parsed_trait).name_span)));
+((*this).error_with_hint((ByteString::from_utf8_without_validation("Expected 'function' keyword inside trait definition"sv)),span,__jakt_format((StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv)),((parsed_trait).name)),((parsed_trait).name_span)));
 return parsed_trait;
 }
 return JaktInternal::ExplicitValue<void>();
@@ -4452,7 +4452,7 @@ return JaktInternal::ExplicitValue<void>();
 case 22 /* ForwardSlashEqual */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.ForwardSlashEqual;utility::Span const& span = __jakt_match_value.value;
 {
-((*this).error_with_hint((ByteString::must_from_utf8("Expected 'function' keyword inside trait definition"sv)),span,__jakt_format((StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv)),((parsed_trait).name)),((parsed_trait).name_span)));
+((*this).error_with_hint((ByteString::from_utf8_without_validation("Expected 'function' keyword inside trait definition"sv)),span,__jakt_format((StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv)),((parsed_trait).name)),((parsed_trait).name_span)));
 return parsed_trait;
 }
 return JaktInternal::ExplicitValue<void>();
@@ -4460,7 +4460,7 @@ return JaktInternal::ExplicitValue<void>();
 case 23 /* PercentSignEqual */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.PercentSignEqual;utility::Span const& span = __jakt_match_value.value;
 {
-((*this).error_with_hint((ByteString::must_from_utf8("Expected 'function' keyword inside trait definition"sv)),span,__jakt_format((StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv)),((parsed_trait).name)),((parsed_trait).name_span)));
+((*this).error_with_hint((ByteString::from_utf8_without_validation("Expected 'function' keyword inside trait definition"sv)),span,__jakt_format((StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv)),((parsed_trait).name)),((parsed_trait).name_span)));
 return parsed_trait;
 }
 return JaktInternal::ExplicitValue<void>();
@@ -4468,7 +4468,7 @@ return JaktInternal::ExplicitValue<void>();
 case 24 /* NotEqual */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.NotEqual;utility::Span const& span = __jakt_match_value.value;
 {
-((*this).error_with_hint((ByteString::must_from_utf8("Expected 'function' keyword inside trait definition"sv)),span,__jakt_format((StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv)),((parsed_trait).name)),((parsed_trait).name_span)));
+((*this).error_with_hint((ByteString::from_utf8_without_validation("Expected 'function' keyword inside trait definition"sv)),span,__jakt_format((StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv)),((parsed_trait).name)),((parsed_trait).name_span)));
 return parsed_trait;
 }
 return JaktInternal::ExplicitValue<void>();
@@ -4476,7 +4476,7 @@ return JaktInternal::ExplicitValue<void>();
 case 25 /* DoubleEqual */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.DoubleEqual;utility::Span const& span = __jakt_match_value.value;
 {
-((*this).error_with_hint((ByteString::must_from_utf8("Expected 'function' keyword inside trait definition"sv)),span,__jakt_format((StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv)),((parsed_trait).name)),((parsed_trait).name_span)));
+((*this).error_with_hint((ByteString::from_utf8_without_validation("Expected 'function' keyword inside trait definition"sv)),span,__jakt_format((StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv)),((parsed_trait).name)),((parsed_trait).name_span)));
 return parsed_trait;
 }
 return JaktInternal::ExplicitValue<void>();
@@ -4484,7 +4484,7 @@ return JaktInternal::ExplicitValue<void>();
 case 26 /* GreaterThan */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.GreaterThan;utility::Span const& span = __jakt_match_value.value;
 {
-((*this).error_with_hint((ByteString::must_from_utf8("Expected 'function' keyword inside trait definition"sv)),span,__jakt_format((StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv)),((parsed_trait).name)),((parsed_trait).name_span)));
+((*this).error_with_hint((ByteString::from_utf8_without_validation("Expected 'function' keyword inside trait definition"sv)),span,__jakt_format((StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv)),((parsed_trait).name)),((parsed_trait).name_span)));
 return parsed_trait;
 }
 return JaktInternal::ExplicitValue<void>();
@@ -4492,7 +4492,7 @@ return JaktInternal::ExplicitValue<void>();
 case 27 /* GreaterThanOrEqual */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.GreaterThanOrEqual;utility::Span const& span = __jakt_match_value.value;
 {
-((*this).error_with_hint((ByteString::must_from_utf8("Expected 'function' keyword inside trait definition"sv)),span,__jakt_format((StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv)),((parsed_trait).name)),((parsed_trait).name_span)));
+((*this).error_with_hint((ByteString::from_utf8_without_validation("Expected 'function' keyword inside trait definition"sv)),span,__jakt_format((StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv)),((parsed_trait).name)),((parsed_trait).name_span)));
 return parsed_trait;
 }
 return JaktInternal::ExplicitValue<void>();
@@ -4500,7 +4500,7 @@ return JaktInternal::ExplicitValue<void>();
 case 28 /* LessThan */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.LessThan;utility::Span const& span = __jakt_match_value.value;
 {
-((*this).error_with_hint((ByteString::must_from_utf8("Expected 'function' keyword inside trait definition"sv)),span,__jakt_format((StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv)),((parsed_trait).name)),((parsed_trait).name_span)));
+((*this).error_with_hint((ByteString::from_utf8_without_validation("Expected 'function' keyword inside trait definition"sv)),span,__jakt_format((StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv)),((parsed_trait).name)),((parsed_trait).name_span)));
 return parsed_trait;
 }
 return JaktInternal::ExplicitValue<void>();
@@ -4508,7 +4508,7 @@ return JaktInternal::ExplicitValue<void>();
 case 29 /* LessThanOrEqual */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.LessThanOrEqual;utility::Span const& span = __jakt_match_value.value;
 {
-((*this).error_with_hint((ByteString::must_from_utf8("Expected 'function' keyword inside trait definition"sv)),span,__jakt_format((StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv)),((parsed_trait).name)),((parsed_trait).name_span)));
+((*this).error_with_hint((ByteString::from_utf8_without_validation("Expected 'function' keyword inside trait definition"sv)),span,__jakt_format((StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv)),((parsed_trait).name)),((parsed_trait).name_span)));
 return parsed_trait;
 }
 return JaktInternal::ExplicitValue<void>();
@@ -4516,7 +4516,7 @@ return JaktInternal::ExplicitValue<void>();
 case 30 /* LeftArithmeticShift */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.LeftArithmeticShift;utility::Span const& span = __jakt_match_value.value;
 {
-((*this).error_with_hint((ByteString::must_from_utf8("Expected 'function' keyword inside trait definition"sv)),span,__jakt_format((StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv)),((parsed_trait).name)),((parsed_trait).name_span)));
+((*this).error_with_hint((ByteString::from_utf8_without_validation("Expected 'function' keyword inside trait definition"sv)),span,__jakt_format((StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv)),((parsed_trait).name)),((parsed_trait).name_span)));
 return parsed_trait;
 }
 return JaktInternal::ExplicitValue<void>();
@@ -4524,7 +4524,7 @@ return JaktInternal::ExplicitValue<void>();
 case 31 /* LeftShift */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.LeftShift;utility::Span const& span = __jakt_match_value.value;
 {
-((*this).error_with_hint((ByteString::must_from_utf8("Expected 'function' keyword inside trait definition"sv)),span,__jakt_format((StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv)),((parsed_trait).name)),((parsed_trait).name_span)));
+((*this).error_with_hint((ByteString::from_utf8_without_validation("Expected 'function' keyword inside trait definition"sv)),span,__jakt_format((StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv)),((parsed_trait).name)),((parsed_trait).name_span)));
 return parsed_trait;
 }
 return JaktInternal::ExplicitValue<void>();
@@ -4532,7 +4532,7 @@ return JaktInternal::ExplicitValue<void>();
 case 32 /* LeftShiftEqual */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.LeftShiftEqual;utility::Span const& span = __jakt_match_value.value;
 {
-((*this).error_with_hint((ByteString::must_from_utf8("Expected 'function' keyword inside trait definition"sv)),span,__jakt_format((StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv)),((parsed_trait).name)),((parsed_trait).name_span)));
+((*this).error_with_hint((ByteString::from_utf8_without_validation("Expected 'function' keyword inside trait definition"sv)),span,__jakt_format((StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv)),((parsed_trait).name)),((parsed_trait).name_span)));
 return parsed_trait;
 }
 return JaktInternal::ExplicitValue<void>();
@@ -4540,7 +4540,7 @@ return JaktInternal::ExplicitValue<void>();
 case 33 /* RightShift */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.RightShift;utility::Span const& span = __jakt_match_value.value;
 {
-((*this).error_with_hint((ByteString::must_from_utf8("Expected 'function' keyword inside trait definition"sv)),span,__jakt_format((StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv)),((parsed_trait).name)),((parsed_trait).name_span)));
+((*this).error_with_hint((ByteString::from_utf8_without_validation("Expected 'function' keyword inside trait definition"sv)),span,__jakt_format((StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv)),((parsed_trait).name)),((parsed_trait).name_span)));
 return parsed_trait;
 }
 return JaktInternal::ExplicitValue<void>();
@@ -4548,7 +4548,7 @@ return JaktInternal::ExplicitValue<void>();
 case 34 /* RightArithmeticShift */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.RightArithmeticShift;utility::Span const& span = __jakt_match_value.value;
 {
-((*this).error_with_hint((ByteString::must_from_utf8("Expected 'function' keyword inside trait definition"sv)),span,__jakt_format((StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv)),((parsed_trait).name)),((parsed_trait).name_span)));
+((*this).error_with_hint((ByteString::from_utf8_without_validation("Expected 'function' keyword inside trait definition"sv)),span,__jakt_format((StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv)),((parsed_trait).name)),((parsed_trait).name_span)));
 return parsed_trait;
 }
 return JaktInternal::ExplicitValue<void>();
@@ -4556,7 +4556,7 @@ return JaktInternal::ExplicitValue<void>();
 case 35 /* RightShiftEqual */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.RightShiftEqual;utility::Span const& span = __jakt_match_value.value;
 {
-((*this).error_with_hint((ByteString::must_from_utf8("Expected 'function' keyword inside trait definition"sv)),span,__jakt_format((StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv)),((parsed_trait).name)),((parsed_trait).name_span)));
+((*this).error_with_hint((ByteString::from_utf8_without_validation("Expected 'function' keyword inside trait definition"sv)),span,__jakt_format((StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv)),((parsed_trait).name)),((parsed_trait).name_span)));
 return parsed_trait;
 }
 return JaktInternal::ExplicitValue<void>();
@@ -4564,7 +4564,7 @@ return JaktInternal::ExplicitValue<void>();
 case 36 /* Asterisk */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Asterisk;utility::Span const& span = __jakt_match_value.value;
 {
-((*this).error_with_hint((ByteString::must_from_utf8("Expected 'function' keyword inside trait definition"sv)),span,__jakt_format((StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv)),((parsed_trait).name)),((parsed_trait).name_span)));
+((*this).error_with_hint((ByteString::from_utf8_without_validation("Expected 'function' keyword inside trait definition"sv)),span,__jakt_format((StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv)),((parsed_trait).name)),((parsed_trait).name_span)));
 return parsed_trait;
 }
 return JaktInternal::ExplicitValue<void>();
@@ -4572,7 +4572,7 @@ return JaktInternal::ExplicitValue<void>();
 case 37 /* Ampersand */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Ampersand;utility::Span const& span = __jakt_match_value.value;
 {
-((*this).error_with_hint((ByteString::must_from_utf8("Expected 'function' keyword inside trait definition"sv)),span,__jakt_format((StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv)),((parsed_trait).name)),((parsed_trait).name_span)));
+((*this).error_with_hint((ByteString::from_utf8_without_validation("Expected 'function' keyword inside trait definition"sv)),span,__jakt_format((StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv)),((parsed_trait).name)),((parsed_trait).name_span)));
 return parsed_trait;
 }
 return JaktInternal::ExplicitValue<void>();
@@ -4580,7 +4580,7 @@ return JaktInternal::ExplicitValue<void>();
 case 38 /* AmpersandEqual */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.AmpersandEqual;utility::Span const& span = __jakt_match_value.value;
 {
-((*this).error_with_hint((ByteString::must_from_utf8("Expected 'function' keyword inside trait definition"sv)),span,__jakt_format((StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv)),((parsed_trait).name)),((parsed_trait).name_span)));
+((*this).error_with_hint((ByteString::from_utf8_without_validation("Expected 'function' keyword inside trait definition"sv)),span,__jakt_format((StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv)),((parsed_trait).name)),((parsed_trait).name_span)));
 return parsed_trait;
 }
 return JaktInternal::ExplicitValue<void>();
@@ -4588,7 +4588,7 @@ return JaktInternal::ExplicitValue<void>();
 case 39 /* AmpersandAmpersand */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.AmpersandAmpersand;utility::Span const& span = __jakt_match_value.value;
 {
-((*this).error_with_hint((ByteString::must_from_utf8("Expected 'function' keyword inside trait definition"sv)),span,__jakt_format((StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv)),((parsed_trait).name)),((parsed_trait).name_span)));
+((*this).error_with_hint((ByteString::from_utf8_without_validation("Expected 'function' keyword inside trait definition"sv)),span,__jakt_format((StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv)),((parsed_trait).name)),((parsed_trait).name_span)));
 return parsed_trait;
 }
 return JaktInternal::ExplicitValue<void>();
@@ -4596,7 +4596,7 @@ return JaktInternal::ExplicitValue<void>();
 case 40 /* Pipe */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Pipe;utility::Span const& span = __jakt_match_value.value;
 {
-((*this).error_with_hint((ByteString::must_from_utf8("Expected 'function' keyword inside trait definition"sv)),span,__jakt_format((StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv)),((parsed_trait).name)),((parsed_trait).name_span)));
+((*this).error_with_hint((ByteString::from_utf8_without_validation("Expected 'function' keyword inside trait definition"sv)),span,__jakt_format((StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv)),((parsed_trait).name)),((parsed_trait).name_span)));
 return parsed_trait;
 }
 return JaktInternal::ExplicitValue<void>();
@@ -4604,7 +4604,7 @@ return JaktInternal::ExplicitValue<void>();
 case 41 /* PipeEqual */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.PipeEqual;utility::Span const& span = __jakt_match_value.value;
 {
-((*this).error_with_hint((ByteString::must_from_utf8("Expected 'function' keyword inside trait definition"sv)),span,__jakt_format((StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv)),((parsed_trait).name)),((parsed_trait).name_span)));
+((*this).error_with_hint((ByteString::from_utf8_without_validation("Expected 'function' keyword inside trait definition"sv)),span,__jakt_format((StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv)),((parsed_trait).name)),((parsed_trait).name_span)));
 return parsed_trait;
 }
 return JaktInternal::ExplicitValue<void>();
@@ -4612,7 +4612,7 @@ return JaktInternal::ExplicitValue<void>();
 case 42 /* PipePipe */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.PipePipe;utility::Span const& span = __jakt_match_value.value;
 {
-((*this).error_with_hint((ByteString::must_from_utf8("Expected 'function' keyword inside trait definition"sv)),span,__jakt_format((StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv)),((parsed_trait).name)),((parsed_trait).name_span)));
+((*this).error_with_hint((ByteString::from_utf8_without_validation("Expected 'function' keyword inside trait definition"sv)),span,__jakt_format((StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv)),((parsed_trait).name)),((parsed_trait).name_span)));
 return parsed_trait;
 }
 return JaktInternal::ExplicitValue<void>();
@@ -4620,7 +4620,7 @@ return JaktInternal::ExplicitValue<void>();
 case 43 /* Caret */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Caret;utility::Span const& span = __jakt_match_value.value;
 {
-((*this).error_with_hint((ByteString::must_from_utf8("Expected 'function' keyword inside trait definition"sv)),span,__jakt_format((StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv)),((parsed_trait).name)),((parsed_trait).name_span)));
+((*this).error_with_hint((ByteString::from_utf8_without_validation("Expected 'function' keyword inside trait definition"sv)),span,__jakt_format((StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv)),((parsed_trait).name)),((parsed_trait).name_span)));
 return parsed_trait;
 }
 return JaktInternal::ExplicitValue<void>();
@@ -4628,7 +4628,7 @@ return JaktInternal::ExplicitValue<void>();
 case 44 /* CaretEqual */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.CaretEqual;utility::Span const& span = __jakt_match_value.value;
 {
-((*this).error_with_hint((ByteString::must_from_utf8("Expected 'function' keyword inside trait definition"sv)),span,__jakt_format((StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv)),((parsed_trait).name)),((parsed_trait).name_span)));
+((*this).error_with_hint((ByteString::from_utf8_without_validation("Expected 'function' keyword inside trait definition"sv)),span,__jakt_format((StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv)),((parsed_trait).name)),((parsed_trait).name_span)));
 return parsed_trait;
 }
 return JaktInternal::ExplicitValue<void>();
@@ -4636,7 +4636,7 @@ return JaktInternal::ExplicitValue<void>();
 case 45 /* Dollar */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Dollar;utility::Span const& span = __jakt_match_value.value;
 {
-((*this).error_with_hint((ByteString::must_from_utf8("Expected 'function' keyword inside trait definition"sv)),span,__jakt_format((StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv)),((parsed_trait).name)),((parsed_trait).name_span)));
+((*this).error_with_hint((ByteString::from_utf8_without_validation("Expected 'function' keyword inside trait definition"sv)),span,__jakt_format((StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv)),((parsed_trait).name)),((parsed_trait).name_span)));
 return parsed_trait;
 }
 return JaktInternal::ExplicitValue<void>();
@@ -4644,7 +4644,7 @@ return JaktInternal::ExplicitValue<void>();
 case 46 /* Tilde */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Tilde;utility::Span const& span = __jakt_match_value.value;
 {
-((*this).error_with_hint((ByteString::must_from_utf8("Expected 'function' keyword inside trait definition"sv)),span,__jakt_format((StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv)),((parsed_trait).name)),((parsed_trait).name_span)));
+((*this).error_with_hint((ByteString::from_utf8_without_validation("Expected 'function' keyword inside trait definition"sv)),span,__jakt_format((StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv)),((parsed_trait).name)),((parsed_trait).name_span)));
 return parsed_trait;
 }
 return JaktInternal::ExplicitValue<void>();
@@ -4652,7 +4652,7 @@ return JaktInternal::ExplicitValue<void>();
 case 47 /* ForwardSlash */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.ForwardSlash;utility::Span const& span = __jakt_match_value.value;
 {
-((*this).error_with_hint((ByteString::must_from_utf8("Expected 'function' keyword inside trait definition"sv)),span,__jakt_format((StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv)),((parsed_trait).name)),((parsed_trait).name_span)));
+((*this).error_with_hint((ByteString::from_utf8_without_validation("Expected 'function' keyword inside trait definition"sv)),span,__jakt_format((StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv)),((parsed_trait).name)),((parsed_trait).name_span)));
 return parsed_trait;
 }
 return JaktInternal::ExplicitValue<void>();
@@ -4660,7 +4660,7 @@ return JaktInternal::ExplicitValue<void>();
 case 48 /* ExclamationPoint */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.ExclamationPoint;utility::Span const& span = __jakt_match_value.value;
 {
-((*this).error_with_hint((ByteString::must_from_utf8("Expected 'function' keyword inside trait definition"sv)),span,__jakt_format((StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv)),((parsed_trait).name)),((parsed_trait).name_span)));
+((*this).error_with_hint((ByteString::from_utf8_without_validation("Expected 'function' keyword inside trait definition"sv)),span,__jakt_format((StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv)),((parsed_trait).name)),((parsed_trait).name_span)));
 return parsed_trait;
 }
 return JaktInternal::ExplicitValue<void>();
@@ -4668,7 +4668,7 @@ return JaktInternal::ExplicitValue<void>();
 case 49 /* QuestionMark */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.QuestionMark;utility::Span const& span = __jakt_match_value.value;
 {
-((*this).error_with_hint((ByteString::must_from_utf8("Expected 'function' keyword inside trait definition"sv)),span,__jakt_format((StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv)),((parsed_trait).name)),((parsed_trait).name_span)));
+((*this).error_with_hint((ByteString::from_utf8_without_validation("Expected 'function' keyword inside trait definition"sv)),span,__jakt_format((StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv)),((parsed_trait).name)),((parsed_trait).name_span)));
 return parsed_trait;
 }
 return JaktInternal::ExplicitValue<void>();
@@ -4676,7 +4676,7 @@ return JaktInternal::ExplicitValue<void>();
 case 50 /* QuestionMarkQuestionMark */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.QuestionMarkQuestionMark;utility::Span const& span = __jakt_match_value.value;
 {
-((*this).error_with_hint((ByteString::must_from_utf8("Expected 'function' keyword inside trait definition"sv)),span,__jakt_format((StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv)),((parsed_trait).name)),((parsed_trait).name_span)));
+((*this).error_with_hint((ByteString::from_utf8_without_validation("Expected 'function' keyword inside trait definition"sv)),span,__jakt_format((StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv)),((parsed_trait).name)),((parsed_trait).name_span)));
 return parsed_trait;
 }
 return JaktInternal::ExplicitValue<void>();
@@ -4684,7 +4684,7 @@ return JaktInternal::ExplicitValue<void>();
 case 51 /* QuestionMarkQuestionMarkEqual */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.QuestionMarkQuestionMarkEqual;utility::Span const& span = __jakt_match_value.value;
 {
-((*this).error_with_hint((ByteString::must_from_utf8("Expected 'function' keyword inside trait definition"sv)),span,__jakt_format((StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv)),((parsed_trait).name)),((parsed_trait).name_span)));
+((*this).error_with_hint((ByteString::from_utf8_without_validation("Expected 'function' keyword inside trait definition"sv)),span,__jakt_format((StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv)),((parsed_trait).name)),((parsed_trait).name_span)));
 return parsed_trait;
 }
 return JaktInternal::ExplicitValue<void>();
@@ -4692,7 +4692,7 @@ return JaktInternal::ExplicitValue<void>();
 case 52 /* Comma */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Comma;utility::Span const& span = __jakt_match_value.value;
 {
-((*this).error_with_hint((ByteString::must_from_utf8("Expected 'function' keyword inside trait definition"sv)),span,__jakt_format((StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv)),((parsed_trait).name)),((parsed_trait).name_span)));
+((*this).error_with_hint((ByteString::from_utf8_without_validation("Expected 'function' keyword inside trait definition"sv)),span,__jakt_format((StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv)),((parsed_trait).name)),((parsed_trait).name_span)));
 return parsed_trait;
 }
 return JaktInternal::ExplicitValue<void>();
@@ -4700,7 +4700,7 @@ return JaktInternal::ExplicitValue<void>();
 case 53 /* Dot */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Dot;utility::Span const& span = __jakt_match_value.value;
 {
-((*this).error_with_hint((ByteString::must_from_utf8("Expected 'function' keyword inside trait definition"sv)),span,__jakt_format((StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv)),((parsed_trait).name)),((parsed_trait).name_span)));
+((*this).error_with_hint((ByteString::from_utf8_without_validation("Expected 'function' keyword inside trait definition"sv)),span,__jakt_format((StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv)),((parsed_trait).name)),((parsed_trait).name_span)));
 return parsed_trait;
 }
 return JaktInternal::ExplicitValue<void>();
@@ -4708,7 +4708,7 @@ return JaktInternal::ExplicitValue<void>();
 case 54 /* DotDot */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.DotDot;utility::Span const& span = __jakt_match_value.value;
 {
-((*this).error_with_hint((ByteString::must_from_utf8("Expected 'function' keyword inside trait definition"sv)),span,__jakt_format((StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv)),((parsed_trait).name)),((parsed_trait).name_span)));
+((*this).error_with_hint((ByteString::from_utf8_without_validation("Expected 'function' keyword inside trait definition"sv)),span,__jakt_format((StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv)),((parsed_trait).name)),((parsed_trait).name_span)));
 return parsed_trait;
 }
 return JaktInternal::ExplicitValue<void>();
@@ -4716,7 +4716,7 @@ return JaktInternal::ExplicitValue<void>();
 case 57 /* FatArrow */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.FatArrow;utility::Span const& span = __jakt_match_value.value;
 {
-((*this).error_with_hint((ByteString::must_from_utf8("Expected 'function' keyword inside trait definition"sv)),span,__jakt_format((StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv)),((parsed_trait).name)),((parsed_trait).name_span)));
+((*this).error_with_hint((ByteString::from_utf8_without_validation("Expected 'function' keyword inside trait definition"sv)),span,__jakt_format((StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv)),((parsed_trait).name)),((parsed_trait).name_span)));
 return parsed_trait;
 }
 return JaktInternal::ExplicitValue<void>();
@@ -4724,7 +4724,7 @@ return JaktInternal::ExplicitValue<void>();
 case 58 /* Arrow */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Arrow;utility::Span const& span = __jakt_match_value.value;
 {
-((*this).error_with_hint((ByteString::must_from_utf8("Expected 'function' keyword inside trait definition"sv)),span,__jakt_format((StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv)),((parsed_trait).name)),((parsed_trait).name_span)));
+((*this).error_with_hint((ByteString::from_utf8_without_validation("Expected 'function' keyword inside trait definition"sv)),span,__jakt_format((StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv)),((parsed_trait).name)),((parsed_trait).name_span)));
 return parsed_trait;
 }
 return JaktInternal::ExplicitValue<void>();
@@ -4732,7 +4732,7 @@ return JaktInternal::ExplicitValue<void>();
 case 59 /* And */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.And;utility::Span const& span = __jakt_match_value.value;
 {
-((*this).error_with_hint((ByteString::must_from_utf8("Expected 'function' keyword inside trait definition"sv)),span,__jakt_format((StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv)),((parsed_trait).name)),((parsed_trait).name_span)));
+((*this).error_with_hint((ByteString::from_utf8_without_validation("Expected 'function' keyword inside trait definition"sv)),span,__jakt_format((StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv)),((parsed_trait).name)),((parsed_trait).name_span)));
 return parsed_trait;
 }
 return JaktInternal::ExplicitValue<void>();
@@ -4740,7 +4740,7 @@ return JaktInternal::ExplicitValue<void>();
 case 60 /* Anon */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Anon;utility::Span const& span = __jakt_match_value.value;
 {
-((*this).error_with_hint((ByteString::must_from_utf8("Expected 'function' keyword inside trait definition"sv)),span,__jakt_format((StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv)),((parsed_trait).name)),((parsed_trait).name_span)));
+((*this).error_with_hint((ByteString::from_utf8_without_validation("Expected 'function' keyword inside trait definition"sv)),span,__jakt_format((StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv)),((parsed_trait).name)),((parsed_trait).name_span)));
 return parsed_trait;
 }
 return JaktInternal::ExplicitValue<void>();
@@ -4748,7 +4748,7 @@ return JaktInternal::ExplicitValue<void>();
 case 61 /* As */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.As;utility::Span const& span = __jakt_match_value.value;
 {
-((*this).error_with_hint((ByteString::must_from_utf8("Expected 'function' keyword inside trait definition"sv)),span,__jakt_format((StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv)),((parsed_trait).name)),((parsed_trait).name_span)));
+((*this).error_with_hint((ByteString::from_utf8_without_validation("Expected 'function' keyword inside trait definition"sv)),span,__jakt_format((StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv)),((parsed_trait).name)),((parsed_trait).name_span)));
 return parsed_trait;
 }
 return JaktInternal::ExplicitValue<void>();
@@ -4756,7 +4756,7 @@ return JaktInternal::ExplicitValue<void>();
 case 62 /* Boxed */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Boxed;utility::Span const& span = __jakt_match_value.value;
 {
-((*this).error_with_hint((ByteString::must_from_utf8("Expected 'function' keyword inside trait definition"sv)),span,__jakt_format((StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv)),((parsed_trait).name)),((parsed_trait).name_span)));
+((*this).error_with_hint((ByteString::from_utf8_without_validation("Expected 'function' keyword inside trait definition"sv)),span,__jakt_format((StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv)),((parsed_trait).name)),((parsed_trait).name_span)));
 return parsed_trait;
 }
 return JaktInternal::ExplicitValue<void>();
@@ -4764,7 +4764,7 @@ return JaktInternal::ExplicitValue<void>();
 case 63 /* Break */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Break;utility::Span const& span = __jakt_match_value.value;
 {
-((*this).error_with_hint((ByteString::must_from_utf8("Expected 'function' keyword inside trait definition"sv)),span,__jakt_format((StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv)),((parsed_trait).name)),((parsed_trait).name_span)));
+((*this).error_with_hint((ByteString::from_utf8_without_validation("Expected 'function' keyword inside trait definition"sv)),span,__jakt_format((StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv)),((parsed_trait).name)),((parsed_trait).name_span)));
 return parsed_trait;
 }
 return JaktInternal::ExplicitValue<void>();
@@ -4772,7 +4772,7 @@ return JaktInternal::ExplicitValue<void>();
 case 64 /* Catch */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Catch;utility::Span const& span = __jakt_match_value.value;
 {
-((*this).error_with_hint((ByteString::must_from_utf8("Expected 'function' keyword inside trait definition"sv)),span,__jakt_format((StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv)),((parsed_trait).name)),((parsed_trait).name_span)));
+((*this).error_with_hint((ByteString::from_utf8_without_validation("Expected 'function' keyword inside trait definition"sv)),span,__jakt_format((StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv)),((parsed_trait).name)),((parsed_trait).name_span)));
 return parsed_trait;
 }
 return JaktInternal::ExplicitValue<void>();
@@ -4780,7 +4780,7 @@ return JaktInternal::ExplicitValue<void>();
 case 65 /* Class */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Class;utility::Span const& span = __jakt_match_value.value;
 {
-((*this).error_with_hint((ByteString::must_from_utf8("Expected 'function' keyword inside trait definition"sv)),span,__jakt_format((StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv)),((parsed_trait).name)),((parsed_trait).name_span)));
+((*this).error_with_hint((ByteString::from_utf8_without_validation("Expected 'function' keyword inside trait definition"sv)),span,__jakt_format((StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv)),((parsed_trait).name)),((parsed_trait).name_span)));
 return parsed_trait;
 }
 return JaktInternal::ExplicitValue<void>();
@@ -4788,7 +4788,7 @@ return JaktInternal::ExplicitValue<void>();
 case 66 /* Continue */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Continue;utility::Span const& span = __jakt_match_value.value;
 {
-((*this).error_with_hint((ByteString::must_from_utf8("Expected 'function' keyword inside trait definition"sv)),span,__jakt_format((StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv)),((parsed_trait).name)),((parsed_trait).name_span)));
+((*this).error_with_hint((ByteString::from_utf8_without_validation("Expected 'function' keyword inside trait definition"sv)),span,__jakt_format((StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv)),((parsed_trait).name)),((parsed_trait).name_span)));
 return parsed_trait;
 }
 return JaktInternal::ExplicitValue<void>();
@@ -4796,7 +4796,7 @@ return JaktInternal::ExplicitValue<void>();
 case 67 /* Cpp */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Cpp;utility::Span const& span = __jakt_match_value.value;
 {
-((*this).error_with_hint((ByteString::must_from_utf8("Expected 'function' keyword inside trait definition"sv)),span,__jakt_format((StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv)),((parsed_trait).name)),((parsed_trait).name_span)));
+((*this).error_with_hint((ByteString::from_utf8_without_validation("Expected 'function' keyword inside trait definition"sv)),span,__jakt_format((StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv)),((parsed_trait).name)),((parsed_trait).name_span)));
 return parsed_trait;
 }
 return JaktInternal::ExplicitValue<void>();
@@ -4804,7 +4804,7 @@ return JaktInternal::ExplicitValue<void>();
 case 68 /* Defer */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Defer;utility::Span const& span = __jakt_match_value.value;
 {
-((*this).error_with_hint((ByteString::must_from_utf8("Expected 'function' keyword inside trait definition"sv)),span,__jakt_format((StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv)),((parsed_trait).name)),((parsed_trait).name_span)));
+((*this).error_with_hint((ByteString::from_utf8_without_validation("Expected 'function' keyword inside trait definition"sv)),span,__jakt_format((StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv)),((parsed_trait).name)),((parsed_trait).name_span)));
 return parsed_trait;
 }
 return JaktInternal::ExplicitValue<void>();
@@ -4812,7 +4812,7 @@ return JaktInternal::ExplicitValue<void>();
 case 69 /* Destructor */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Destructor;utility::Span const& span = __jakt_match_value.value;
 {
-((*this).error_with_hint((ByteString::must_from_utf8("Expected 'function' keyword inside trait definition"sv)),span,__jakt_format((StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv)),((parsed_trait).name)),((parsed_trait).name_span)));
+((*this).error_with_hint((ByteString::from_utf8_without_validation("Expected 'function' keyword inside trait definition"sv)),span,__jakt_format((StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv)),((parsed_trait).name)),((parsed_trait).name_span)));
 return parsed_trait;
 }
 return JaktInternal::ExplicitValue<void>();
@@ -4820,7 +4820,7 @@ return JaktInternal::ExplicitValue<void>();
 case 70 /* Else */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Else;utility::Span const& span = __jakt_match_value.value;
 {
-((*this).error_with_hint((ByteString::must_from_utf8("Expected 'function' keyword inside trait definition"sv)),span,__jakt_format((StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv)),((parsed_trait).name)),((parsed_trait).name_span)));
+((*this).error_with_hint((ByteString::from_utf8_without_validation("Expected 'function' keyword inside trait definition"sv)),span,__jakt_format((StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv)),((parsed_trait).name)),((parsed_trait).name_span)));
 return parsed_trait;
 }
 return JaktInternal::ExplicitValue<void>();
@@ -4828,7 +4828,7 @@ return JaktInternal::ExplicitValue<void>();
 case 71 /* Enum */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Enum;utility::Span const& span = __jakt_match_value.value;
 {
-((*this).error_with_hint((ByteString::must_from_utf8("Expected 'function' keyword inside trait definition"sv)),span,__jakt_format((StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv)),((parsed_trait).name)),((parsed_trait).name_span)));
+((*this).error_with_hint((ByteString::from_utf8_without_validation("Expected 'function' keyword inside trait definition"sv)),span,__jakt_format((StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv)),((parsed_trait).name)),((parsed_trait).name_span)));
 return parsed_trait;
 }
 return JaktInternal::ExplicitValue<void>();
@@ -4836,7 +4836,7 @@ return JaktInternal::ExplicitValue<void>();
 case 72 /* Extern */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Extern;utility::Span const& span = __jakt_match_value.value;
 {
-((*this).error_with_hint((ByteString::must_from_utf8("Expected 'function' keyword inside trait definition"sv)),span,__jakt_format((StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv)),((parsed_trait).name)),((parsed_trait).name_span)));
+((*this).error_with_hint((ByteString::from_utf8_without_validation("Expected 'function' keyword inside trait definition"sv)),span,__jakt_format((StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv)),((parsed_trait).name)),((parsed_trait).name_span)));
 return parsed_trait;
 }
 return JaktInternal::ExplicitValue<void>();
@@ -4844,7 +4844,7 @@ return JaktInternal::ExplicitValue<void>();
 case 73 /* False */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.False;utility::Span const& span = __jakt_match_value.value;
 {
-((*this).error_with_hint((ByteString::must_from_utf8("Expected 'function' keyword inside trait definition"sv)),span,__jakt_format((StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv)),((parsed_trait).name)),((parsed_trait).name_span)));
+((*this).error_with_hint((ByteString::from_utf8_without_validation("Expected 'function' keyword inside trait definition"sv)),span,__jakt_format((StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv)),((parsed_trait).name)),((parsed_trait).name_span)));
 return parsed_trait;
 }
 return JaktInternal::ExplicitValue<void>();
@@ -4852,7 +4852,7 @@ return JaktInternal::ExplicitValue<void>();
 case 74 /* For */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.For;utility::Span const& span = __jakt_match_value.value;
 {
-((*this).error_with_hint((ByteString::must_from_utf8("Expected 'function' keyword inside trait definition"sv)),span,__jakt_format((StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv)),((parsed_trait).name)),((parsed_trait).name_span)));
+((*this).error_with_hint((ByteString::from_utf8_without_validation("Expected 'function' keyword inside trait definition"sv)),span,__jakt_format((StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv)),((parsed_trait).name)),((parsed_trait).name_span)));
 return parsed_trait;
 }
 return JaktInternal::ExplicitValue<void>();
@@ -4860,7 +4860,7 @@ return JaktInternal::ExplicitValue<void>();
 case 76 /* Comptime */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Comptime;utility::Span const& span = __jakt_match_value.value;
 {
-((*this).error_with_hint((ByteString::must_from_utf8("Expected 'function' keyword inside trait definition"sv)),span,__jakt_format((StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv)),((parsed_trait).name)),((parsed_trait).name_span)));
+((*this).error_with_hint((ByteString::from_utf8_without_validation("Expected 'function' keyword inside trait definition"sv)),span,__jakt_format((StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv)),((parsed_trait).name)),((parsed_trait).name_span)));
 return parsed_trait;
 }
 return JaktInternal::ExplicitValue<void>();
@@ -4868,7 +4868,7 @@ return JaktInternal::ExplicitValue<void>();
 case 77 /* If */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.If;utility::Span const& span = __jakt_match_value.value;
 {
-((*this).error_with_hint((ByteString::must_from_utf8("Expected 'function' keyword inside trait definition"sv)),span,__jakt_format((StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv)),((parsed_trait).name)),((parsed_trait).name_span)));
+((*this).error_with_hint((ByteString::from_utf8_without_validation("Expected 'function' keyword inside trait definition"sv)),span,__jakt_format((StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv)),((parsed_trait).name)),((parsed_trait).name_span)));
 return parsed_trait;
 }
 return JaktInternal::ExplicitValue<void>();
@@ -4876,7 +4876,7 @@ return JaktInternal::ExplicitValue<void>();
 case 78 /* Import */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Import;utility::Span const& span = __jakt_match_value.value;
 {
-((*this).error_with_hint((ByteString::must_from_utf8("Expected 'function' keyword inside trait definition"sv)),span,__jakt_format((StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv)),((parsed_trait).name)),((parsed_trait).name_span)));
+((*this).error_with_hint((ByteString::from_utf8_without_validation("Expected 'function' keyword inside trait definition"sv)),span,__jakt_format((StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv)),((parsed_trait).name)),((parsed_trait).name_span)));
 return parsed_trait;
 }
 return JaktInternal::ExplicitValue<void>();
@@ -4884,7 +4884,7 @@ return JaktInternal::ExplicitValue<void>();
 case 79 /* Relative */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Relative;utility::Span const& span = __jakt_match_value.value;
 {
-((*this).error_with_hint((ByteString::must_from_utf8("Expected 'function' keyword inside trait definition"sv)),span,__jakt_format((StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv)),((parsed_trait).name)),((parsed_trait).name_span)));
+((*this).error_with_hint((ByteString::from_utf8_without_validation("Expected 'function' keyword inside trait definition"sv)),span,__jakt_format((StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv)),((parsed_trait).name)),((parsed_trait).name_span)));
 return parsed_trait;
 }
 return JaktInternal::ExplicitValue<void>();
@@ -4892,7 +4892,7 @@ return JaktInternal::ExplicitValue<void>();
 case 80 /* In */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.In;utility::Span const& span = __jakt_match_value.value;
 {
-((*this).error_with_hint((ByteString::must_from_utf8("Expected 'function' keyword inside trait definition"sv)),span,__jakt_format((StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv)),((parsed_trait).name)),((parsed_trait).name_span)));
+((*this).error_with_hint((ByteString::from_utf8_without_validation("Expected 'function' keyword inside trait definition"sv)),span,__jakt_format((StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv)),((parsed_trait).name)),((parsed_trait).name_span)));
 return parsed_trait;
 }
 return JaktInternal::ExplicitValue<void>();
@@ -4900,7 +4900,7 @@ return JaktInternal::ExplicitValue<void>();
 case 81 /* Is */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Is;utility::Span const& span = __jakt_match_value.value;
 {
-((*this).error_with_hint((ByteString::must_from_utf8("Expected 'function' keyword inside trait definition"sv)),span,__jakt_format((StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv)),((parsed_trait).name)),((parsed_trait).name_span)));
+((*this).error_with_hint((ByteString::from_utf8_without_validation("Expected 'function' keyword inside trait definition"sv)),span,__jakt_format((StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv)),((parsed_trait).name)),((parsed_trait).name_span)));
 return parsed_trait;
 }
 return JaktInternal::ExplicitValue<void>();
@@ -4908,7 +4908,7 @@ return JaktInternal::ExplicitValue<void>();
 case 82 /* Let */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Let;utility::Span const& span = __jakt_match_value.value;
 {
-((*this).error_with_hint((ByteString::must_from_utf8("Expected 'function' keyword inside trait definition"sv)),span,__jakt_format((StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv)),((parsed_trait).name)),((parsed_trait).name_span)));
+((*this).error_with_hint((ByteString::from_utf8_without_validation("Expected 'function' keyword inside trait definition"sv)),span,__jakt_format((StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv)),((parsed_trait).name)),((parsed_trait).name_span)));
 return parsed_trait;
 }
 return JaktInternal::ExplicitValue<void>();
@@ -4916,7 +4916,7 @@ return JaktInternal::ExplicitValue<void>();
 case 83 /* Loop */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Loop;utility::Span const& span = __jakt_match_value.value;
 {
-((*this).error_with_hint((ByteString::must_from_utf8("Expected 'function' keyword inside trait definition"sv)),span,__jakt_format((StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv)),((parsed_trait).name)),((parsed_trait).name_span)));
+((*this).error_with_hint((ByteString::from_utf8_without_validation("Expected 'function' keyword inside trait definition"sv)),span,__jakt_format((StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv)),((parsed_trait).name)),((parsed_trait).name_span)));
 return parsed_trait;
 }
 return JaktInternal::ExplicitValue<void>();
@@ -4924,7 +4924,7 @@ return JaktInternal::ExplicitValue<void>();
 case 84 /* Match */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Match;utility::Span const& span = __jakt_match_value.value;
 {
-((*this).error_with_hint((ByteString::must_from_utf8("Expected 'function' keyword inside trait definition"sv)),span,__jakt_format((StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv)),((parsed_trait).name)),((parsed_trait).name_span)));
+((*this).error_with_hint((ByteString::from_utf8_without_validation("Expected 'function' keyword inside trait definition"sv)),span,__jakt_format((StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv)),((parsed_trait).name)),((parsed_trait).name_span)));
 return parsed_trait;
 }
 return JaktInternal::ExplicitValue<void>();
@@ -4932,7 +4932,7 @@ return JaktInternal::ExplicitValue<void>();
 case 85 /* Mut */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Mut;utility::Span const& span = __jakt_match_value.value;
 {
-((*this).error_with_hint((ByteString::must_from_utf8("Expected 'function' keyword inside trait definition"sv)),span,__jakt_format((StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv)),((parsed_trait).name)),((parsed_trait).name_span)));
+((*this).error_with_hint((ByteString::from_utf8_without_validation("Expected 'function' keyword inside trait definition"sv)),span,__jakt_format((StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv)),((parsed_trait).name)),((parsed_trait).name_span)));
 return parsed_trait;
 }
 return JaktInternal::ExplicitValue<void>();
@@ -4940,7 +4940,7 @@ return JaktInternal::ExplicitValue<void>();
 case 86 /* Namespace */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Namespace;utility::Span const& span = __jakt_match_value.value;
 {
-((*this).error_with_hint((ByteString::must_from_utf8("Expected 'function' keyword inside trait definition"sv)),span,__jakt_format((StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv)),((parsed_trait).name)),((parsed_trait).name_span)));
+((*this).error_with_hint((ByteString::from_utf8_without_validation("Expected 'function' keyword inside trait definition"sv)),span,__jakt_format((StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv)),((parsed_trait).name)),((parsed_trait).name_span)));
 return parsed_trait;
 }
 return JaktInternal::ExplicitValue<void>();
@@ -4948,7 +4948,7 @@ return JaktInternal::ExplicitValue<void>();
 case 87 /* Not */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Not;utility::Span const& span = __jakt_match_value.value;
 {
-((*this).error_with_hint((ByteString::must_from_utf8("Expected 'function' keyword inside trait definition"sv)),span,__jakt_format((StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv)),((parsed_trait).name)),((parsed_trait).name_span)));
+((*this).error_with_hint((ByteString::from_utf8_without_validation("Expected 'function' keyword inside trait definition"sv)),span,__jakt_format((StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv)),((parsed_trait).name)),((parsed_trait).name_span)));
 return parsed_trait;
 }
 return JaktInternal::ExplicitValue<void>();
@@ -4956,7 +4956,7 @@ return JaktInternal::ExplicitValue<void>();
 case 88 /* Or */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Or;utility::Span const& span = __jakt_match_value.value;
 {
-((*this).error_with_hint((ByteString::must_from_utf8("Expected 'function' keyword inside trait definition"sv)),span,__jakt_format((StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv)),((parsed_trait).name)),((parsed_trait).name_span)));
+((*this).error_with_hint((ByteString::from_utf8_without_validation("Expected 'function' keyword inside trait definition"sv)),span,__jakt_format((StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv)),((parsed_trait).name)),((parsed_trait).name_span)));
 return parsed_trait;
 }
 return JaktInternal::ExplicitValue<void>();
@@ -4964,7 +4964,7 @@ return JaktInternal::ExplicitValue<void>();
 case 89 /* Override */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Override;utility::Span const& span = __jakt_match_value.value;
 {
-((*this).error_with_hint((ByteString::must_from_utf8("Expected 'function' keyword inside trait definition"sv)),span,__jakt_format((StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv)),((parsed_trait).name)),((parsed_trait).name_span)));
+((*this).error_with_hint((ByteString::from_utf8_without_validation("Expected 'function' keyword inside trait definition"sv)),span,__jakt_format((StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv)),((parsed_trait).name)),((parsed_trait).name_span)));
 return parsed_trait;
 }
 return JaktInternal::ExplicitValue<void>();
@@ -4972,7 +4972,7 @@ return JaktInternal::ExplicitValue<void>();
 case 90 /* Private */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Private;utility::Span const& span = __jakt_match_value.value;
 {
-((*this).error_with_hint((ByteString::must_from_utf8("Expected 'function' keyword inside trait definition"sv)),span,__jakt_format((StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv)),((parsed_trait).name)),((parsed_trait).name_span)));
+((*this).error_with_hint((ByteString::from_utf8_without_validation("Expected 'function' keyword inside trait definition"sv)),span,__jakt_format((StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv)),((parsed_trait).name)),((parsed_trait).name_span)));
 return parsed_trait;
 }
 return JaktInternal::ExplicitValue<void>();
@@ -4980,7 +4980,7 @@ return JaktInternal::ExplicitValue<void>();
 case 91 /* Public */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Public;utility::Span const& span = __jakt_match_value.value;
 {
-((*this).error_with_hint((ByteString::must_from_utf8("Expected 'function' keyword inside trait definition"sv)),span,__jakt_format((StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv)),((parsed_trait).name)),((parsed_trait).name_span)));
+((*this).error_with_hint((ByteString::from_utf8_without_validation("Expected 'function' keyword inside trait definition"sv)),span,__jakt_format((StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv)),((parsed_trait).name)),((parsed_trait).name_span)));
 return parsed_trait;
 }
 return JaktInternal::ExplicitValue<void>();
@@ -4988,7 +4988,7 @@ return JaktInternal::ExplicitValue<void>();
 case 92 /* Raw */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Raw;utility::Span const& span = __jakt_match_value.value;
 {
-((*this).error_with_hint((ByteString::must_from_utf8("Expected 'function' keyword inside trait definition"sv)),span,__jakt_format((StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv)),((parsed_trait).name)),((parsed_trait).name_span)));
+((*this).error_with_hint((ByteString::from_utf8_without_validation("Expected 'function' keyword inside trait definition"sv)),span,__jakt_format((StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv)),((parsed_trait).name)),((parsed_trait).name_span)));
 return parsed_trait;
 }
 return JaktInternal::ExplicitValue<void>();
@@ -4996,7 +4996,7 @@ return JaktInternal::ExplicitValue<void>();
 case 93 /* Reflect */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Reflect;utility::Span const& span = __jakt_match_value.value;
 {
-((*this).error_with_hint((ByteString::must_from_utf8("Expected 'function' keyword inside trait definition"sv)),span,__jakt_format((StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv)),((parsed_trait).name)),((parsed_trait).name_span)));
+((*this).error_with_hint((ByteString::from_utf8_without_validation("Expected 'function' keyword inside trait definition"sv)),span,__jakt_format((StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv)),((parsed_trait).name)),((parsed_trait).name_span)));
 return parsed_trait;
 }
 return JaktInternal::ExplicitValue<void>();
@@ -5004,7 +5004,7 @@ return JaktInternal::ExplicitValue<void>();
 case 94 /* Return */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Return;utility::Span const& span = __jakt_match_value.value;
 {
-((*this).error_with_hint((ByteString::must_from_utf8("Expected 'function' keyword inside trait definition"sv)),span,__jakt_format((StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv)),((parsed_trait).name)),((parsed_trait).name_span)));
+((*this).error_with_hint((ByteString::from_utf8_without_validation("Expected 'function' keyword inside trait definition"sv)),span,__jakt_format((StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv)),((parsed_trait).name)),((parsed_trait).name_span)));
 return parsed_trait;
 }
 return JaktInternal::ExplicitValue<void>();
@@ -5012,7 +5012,7 @@ return JaktInternal::ExplicitValue<void>();
 case 95 /* Restricted */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Restricted;utility::Span const& span = __jakt_match_value.value;
 {
-((*this).error_with_hint((ByteString::must_from_utf8("Expected 'function' keyword inside trait definition"sv)),span,__jakt_format((StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv)),((parsed_trait).name)),((parsed_trait).name_span)));
+((*this).error_with_hint((ByteString::from_utf8_without_validation("Expected 'function' keyword inside trait definition"sv)),span,__jakt_format((StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv)),((parsed_trait).name)),((parsed_trait).name_span)));
 return parsed_trait;
 }
 return JaktInternal::ExplicitValue<void>();
@@ -5020,7 +5020,7 @@ return JaktInternal::ExplicitValue<void>();
 case 96 /* Sizeof */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Sizeof;utility::Span const& span = __jakt_match_value.value;
 {
-((*this).error_with_hint((ByteString::must_from_utf8("Expected 'function' keyword inside trait definition"sv)),span,__jakt_format((StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv)),((parsed_trait).name)),((parsed_trait).name_span)));
+((*this).error_with_hint((ByteString::from_utf8_without_validation("Expected 'function' keyword inside trait definition"sv)),span,__jakt_format((StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv)),((parsed_trait).name)),((parsed_trait).name_span)));
 return parsed_trait;
 }
 return JaktInternal::ExplicitValue<void>();
@@ -5028,7 +5028,7 @@ return JaktInternal::ExplicitValue<void>();
 case 97 /* Struct */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Struct;utility::Span const& span = __jakt_match_value.value;
 {
-((*this).error_with_hint((ByteString::must_from_utf8("Expected 'function' keyword inside trait definition"sv)),span,__jakt_format((StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv)),((parsed_trait).name)),((parsed_trait).name_span)));
+((*this).error_with_hint((ByteString::from_utf8_without_validation("Expected 'function' keyword inside trait definition"sv)),span,__jakt_format((StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv)),((parsed_trait).name)),((parsed_trait).name_span)));
 return parsed_trait;
 }
 return JaktInternal::ExplicitValue<void>();
@@ -5036,7 +5036,7 @@ return JaktInternal::ExplicitValue<void>();
 case 98 /* This */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.This;utility::Span const& span = __jakt_match_value.value;
 {
-((*this).error_with_hint((ByteString::must_from_utf8("Expected 'function' keyword inside trait definition"sv)),span,__jakt_format((StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv)),((parsed_trait).name)),((parsed_trait).name_span)));
+((*this).error_with_hint((ByteString::from_utf8_without_validation("Expected 'function' keyword inside trait definition"sv)),span,__jakt_format((StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv)),((parsed_trait).name)),((parsed_trait).name_span)));
 return parsed_trait;
 }
 return JaktInternal::ExplicitValue<void>();
@@ -5044,7 +5044,7 @@ return JaktInternal::ExplicitValue<void>();
 case 99 /* Throw */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Throw;utility::Span const& span = __jakt_match_value.value;
 {
-((*this).error_with_hint((ByteString::must_from_utf8("Expected 'function' keyword inside trait definition"sv)),span,__jakt_format((StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv)),((parsed_trait).name)),((parsed_trait).name_span)));
+((*this).error_with_hint((ByteString::from_utf8_without_validation("Expected 'function' keyword inside trait definition"sv)),span,__jakt_format((StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv)),((parsed_trait).name)),((parsed_trait).name_span)));
 return parsed_trait;
 }
 return JaktInternal::ExplicitValue<void>();
@@ -5052,7 +5052,7 @@ return JaktInternal::ExplicitValue<void>();
 case 100 /* Throws */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Throws;utility::Span const& span = __jakt_match_value.value;
 {
-((*this).error_with_hint((ByteString::must_from_utf8("Expected 'function' keyword inside trait definition"sv)),span,__jakt_format((StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv)),((parsed_trait).name)),((parsed_trait).name_span)));
+((*this).error_with_hint((ByteString::from_utf8_without_validation("Expected 'function' keyword inside trait definition"sv)),span,__jakt_format((StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv)),((parsed_trait).name)),((parsed_trait).name_span)));
 return parsed_trait;
 }
 return JaktInternal::ExplicitValue<void>();
@@ -5060,7 +5060,7 @@ return JaktInternal::ExplicitValue<void>();
 case 101 /* True */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.True;utility::Span const& span = __jakt_match_value.value;
 {
-((*this).error_with_hint((ByteString::must_from_utf8("Expected 'function' keyword inside trait definition"sv)),span,__jakt_format((StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv)),((parsed_trait).name)),((parsed_trait).name_span)));
+((*this).error_with_hint((ByteString::from_utf8_without_validation("Expected 'function' keyword inside trait definition"sv)),span,__jakt_format((StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv)),((parsed_trait).name)),((parsed_trait).name_span)));
 return parsed_trait;
 }
 return JaktInternal::ExplicitValue<void>();
@@ -5068,7 +5068,7 @@ return JaktInternal::ExplicitValue<void>();
 case 102 /* Try */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Try;utility::Span const& span = __jakt_match_value.value;
 {
-((*this).error_with_hint((ByteString::must_from_utf8("Expected 'function' keyword inside trait definition"sv)),span,__jakt_format((StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv)),((parsed_trait).name)),((parsed_trait).name_span)));
+((*this).error_with_hint((ByteString::from_utf8_without_validation("Expected 'function' keyword inside trait definition"sv)),span,__jakt_format((StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv)),((parsed_trait).name)),((parsed_trait).name_span)));
 return parsed_trait;
 }
 return JaktInternal::ExplicitValue<void>();
@@ -5076,7 +5076,7 @@ return JaktInternal::ExplicitValue<void>();
 case 103 /* Unsafe */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Unsafe;utility::Span const& span = __jakt_match_value.value;
 {
-((*this).error_with_hint((ByteString::must_from_utf8("Expected 'function' keyword inside trait definition"sv)),span,__jakt_format((StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv)),((parsed_trait).name)),((parsed_trait).name_span)));
+((*this).error_with_hint((ByteString::from_utf8_without_validation("Expected 'function' keyword inside trait definition"sv)),span,__jakt_format((StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv)),((parsed_trait).name)),((parsed_trait).name_span)));
 return parsed_trait;
 }
 return JaktInternal::ExplicitValue<void>();
@@ -5084,7 +5084,7 @@ return JaktInternal::ExplicitValue<void>();
 case 104 /* Virtual */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Virtual;utility::Span const& span = __jakt_match_value.value;
 {
-((*this).error_with_hint((ByteString::must_from_utf8("Expected 'function' keyword inside trait definition"sv)),span,__jakt_format((StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv)),((parsed_trait).name)),((parsed_trait).name_span)));
+((*this).error_with_hint((ByteString::from_utf8_without_validation("Expected 'function' keyword inside trait definition"sv)),span,__jakt_format((StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv)),((parsed_trait).name)),((parsed_trait).name_span)));
 return parsed_trait;
 }
 return JaktInternal::ExplicitValue<void>();
@@ -5092,7 +5092,7 @@ return JaktInternal::ExplicitValue<void>();
 case 105 /* Weak */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Weak;utility::Span const& span = __jakt_match_value.value;
 {
-((*this).error_with_hint((ByteString::must_from_utf8("Expected 'function' keyword inside trait definition"sv)),span,__jakt_format((StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv)),((parsed_trait).name)),((parsed_trait).name_span)));
+((*this).error_with_hint((ByteString::from_utf8_without_validation("Expected 'function' keyword inside trait definition"sv)),span,__jakt_format((StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv)),((parsed_trait).name)),((parsed_trait).name_span)));
 return parsed_trait;
 }
 return JaktInternal::ExplicitValue<void>();
@@ -5100,7 +5100,7 @@ return JaktInternal::ExplicitValue<void>();
 case 106 /* While */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.While;utility::Span const& span = __jakt_match_value.value;
 {
-((*this).error_with_hint((ByteString::must_from_utf8("Expected 'function' keyword inside trait definition"sv)),span,__jakt_format((StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv)),((parsed_trait).name)),((parsed_trait).name_span)));
+((*this).error_with_hint((ByteString::from_utf8_without_validation("Expected 'function' keyword inside trait definition"sv)),span,__jakt_format((StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv)),((parsed_trait).name)),((parsed_trait).name_span)));
 return parsed_trait;
 }
 return JaktInternal::ExplicitValue<void>();
@@ -5108,7 +5108,7 @@ return JaktInternal::ExplicitValue<void>();
 case 107 /* Yield */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Yield;utility::Span const& span = __jakt_match_value.value;
 {
-((*this).error_with_hint((ByteString::must_from_utf8("Expected 'function' keyword inside trait definition"sv)),span,__jakt_format((StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv)),((parsed_trait).name)),((parsed_trait).name_span)));
+((*this).error_with_hint((ByteString::from_utf8_without_validation("Expected 'function' keyword inside trait definition"sv)),span,__jakt_format((StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv)),((parsed_trait).name)),((parsed_trait).name_span)));
 return parsed_trait;
 }
 return JaktInternal::ExplicitValue<void>();
@@ -5116,7 +5116,7 @@ return JaktInternal::ExplicitValue<void>();
 case 108 /* Guard */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Guard;utility::Span const& span = __jakt_match_value.value;
 {
-((*this).error_with_hint((ByteString::must_from_utf8("Expected 'function' keyword inside trait definition"sv)),span,__jakt_format((StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv)),((parsed_trait).name)),((parsed_trait).name_span)));
+((*this).error_with_hint((ByteString::from_utf8_without_validation("Expected 'function' keyword inside trait definition"sv)),span,__jakt_format((StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv)),((parsed_trait).name)),((parsed_trait).name_span)));
 return parsed_trait;
 }
 return JaktInternal::ExplicitValue<void>();
@@ -5124,7 +5124,7 @@ return JaktInternal::ExplicitValue<void>();
 case 109 /* Implements */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Implements;utility::Span const& span = __jakt_match_value.value;
 {
-((*this).error_with_hint((ByteString::must_from_utf8("Expected 'function' keyword inside trait definition"sv)),span,__jakt_format((StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv)),((parsed_trait).name)),((parsed_trait).name_span)));
+((*this).error_with_hint((ByteString::from_utf8_without_validation("Expected 'function' keyword inside trait definition"sv)),span,__jakt_format((StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv)),((parsed_trait).name)),((parsed_trait).name_span)));
 return parsed_trait;
 }
 return JaktInternal::ExplicitValue<void>();
@@ -5132,7 +5132,7 @@ return JaktInternal::ExplicitValue<void>();
 case 110 /* Requires */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Requires;utility::Span const& span = __jakt_match_value.value;
 {
-((*this).error_with_hint((ByteString::must_from_utf8("Expected 'function' keyword inside trait definition"sv)),span,__jakt_format((StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv)),((parsed_trait).name)),((parsed_trait).name_span)));
+((*this).error_with_hint((ByteString::from_utf8_without_validation("Expected 'function' keyword inside trait definition"sv)),span,__jakt_format((StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv)),((parsed_trait).name)),((parsed_trait).name_span)));
 return parsed_trait;
 }
 return JaktInternal::ExplicitValue<void>();
@@ -5140,7 +5140,7 @@ return JaktInternal::ExplicitValue<void>();
 case 111 /* Trait */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Trait;utility::Span const& span = __jakt_match_value.value;
 {
-((*this).error_with_hint((ByteString::must_from_utf8("Expected 'function' keyword inside trait definition"sv)),span,__jakt_format((StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv)),((parsed_trait).name)),((parsed_trait).name_span)));
+((*this).error_with_hint((ByteString::from_utf8_without_validation("Expected 'function' keyword inside trait definition"sv)),span,__jakt_format((StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv)),((parsed_trait).name)),((parsed_trait).name_span)));
 return parsed_trait;
 }
 return JaktInternal::ExplicitValue<void>();
@@ -5148,7 +5148,7 @@ return JaktInternal::ExplicitValue<void>();
 case 112 /* Garbage */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Garbage;utility::Span const& span = __jakt_match_value.span;
 {
-((*this).error_with_hint((ByteString::must_from_utf8("Expected 'function' keyword inside trait definition"sv)),span,__jakt_format((StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv)),((parsed_trait).name)),((parsed_trait).name_span)));
+((*this).error_with_hint((ByteString::from_utf8_without_validation("Expected 'function' keyword inside trait definition"sv)),span,__jakt_format((StringView::from_string_literal("Inside '{}' trait's definition only function declarations can appear"sv)),((parsed_trait).name)),((parsed_trait).name_span)));
 return parsed_trait;
 }
 return JaktInternal::ExplicitValue<void>();
@@ -5179,7 +5179,7 @@ return JaktInternal::ExplicitValue<void>();
 };/*case end*/
 default: {
 {
-((*this).error((ByteString::must_from_utf8("Expected '{' to enter the body of the trait, or '=' to specify trait requirements"sv)),((((*this).current())).span())));
+((*this).error((ByteString::from_utf8_without_validation("Expected '{' to enter the body of the trait, or '=' to specify trait requirements"sv)),((((*this).current())).span())));
 return parsed_trait;
 }
 return JaktInternal::ExplicitValue<void>();
@@ -5194,7 +5194,7 @@ return JaktInternal::ExplicitValue<void>();
 return parsed_trait;
 }
 else {
-((*this).error((ByteString::must_from_utf8("Expected trait name"sv)),((((*this).current())).span())));
+((*this).error((ByteString::from_utf8_without_validation("Expected trait name"sv)),((((*this).current())).span())));
 return parsed_trait;
 }
 
@@ -5226,8 +5226,8 @@ __jakt_label_16:; __jakt_var_21.release_value(); }));
 };/*case end*/
 default: {
 return JaktInternal::ExplicitValue(({ Optional<parser::ParsedRecord> __jakt_var_22; {
-((*this).error((ByteString::must_from_utf8("Expected `struct`, `class`, `enum`, or `boxed`"sv)),((((*this).current())).span())));
-__jakt_var_22 = parser::ParsedRecord((ByteString::must_from_utf8(""sv)),((*this).empty_span()),DynamicArray<parser::ParsedGenericParameter>::create_with({}),definition_linkage,JaktInternal::OptionalNone(),DynamicArray<parser::ParsedMethod>::create_with({}),parser::RecordType::Garbage(),DynamicArray<parser::ParsedRecord>::create_with({}),JaktInternal::OptionalNone()); goto __jakt_label_17;
+((*this).error((ByteString::from_utf8_without_validation("Expected `struct`, `class`, `enum`, or `boxed`"sv)),((((*this).current())).span())));
+__jakt_var_22 = parser::ParsedRecord((ByteString::from_utf8_without_validation(""sv)),((*this).empty_span()),DynamicArray<parser::ParsedGenericParameter>::create_with({}),definition_linkage,JaktInternal::OptionalNone(),DynamicArray<parser::ParsedMethod>::create_with({}),parser::RecordType::Garbage(),DynamicArray<parser::ParsedRecord>::create_with({}),JaktInternal::OptionalNone()); goto __jakt_label_17;
 
 }
 __jakt_label_17:; __jakt_var_22.release_value(); }));
@@ -5263,11 +5263,11 @@ if (((((*this).current())).__jakt_init_index() == 3 /* Identifier */)){
 ByteString const name = (((*this).current())).as.Identifier.name;
 utility::Span const span = (((*this).current())).as.Identifier.span;
 ((((*this).index)++));
-if ((((name) == ((ByteString::must_from_utf8("c"sv)))) || ((name) == ((ByteString::must_from_utf8("C"sv)))))){
+if ((((name) == ((ByteString::from_utf8_without_validation("c"sv)))) || ((name) == ((ByteString::from_utf8_without_validation("C"sv)))))){
 (((parsed_import).is_c) = true);
 }
 else {
-((*this).error((ByteString::must_from_utf8("Expected 'c' or path after `import extern`"sv)),((((*this).current())).span())));
+((*this).error((ByteString::from_utf8_without_validation("Expected 'c' or path after `import extern`"sv)),((((*this).current())).span())));
 }
 
 }
@@ -5287,8 +5287,8 @@ __jakt_label_18:; __jakt_var_23.release_value(); }));
 };/*case end*/
 default: {
 return JaktInternal::ExplicitValue(({ Optional<ByteString> __jakt_var_24; {
-((*this).error((ByteString::must_from_utf8("Expected path after `import extern`"sv)),((((*this).current())).span())));
-__jakt_var_24 = (ByteString::must_from_utf8(""sv)); goto __jakt_label_19;
+((*this).error((ByteString::from_utf8_without_validation("Expected path after `import extern`"sv)),((((*this).current())).span())));
+__jakt_var_24 = (ByteString::from_utf8_without_validation(""sv)); goto __jakt_label_19;
 
 }
 __jakt_label_19:; __jakt_var_24.release_value(); }));
@@ -5310,7 +5310,7 @@ utility::Span const span = (((*this).current())).as.Identifier.span;
 (((((parsed_import).assigned_namespace)).name_span) = span);
 }
 else {
-((*this).error((ByteString::must_from_utf8("Expected name after 'as' keyword to name the extern import"sv)),((((*this).current())).span())));
+((*this).error((ByteString::from_utf8_without_validation("Expected name after 'as' keyword to name the extern import"sv)),((((*this).current())).span())));
 }
 
 }
@@ -5324,7 +5324,7 @@ if (((((*this).current())).__jakt_init_index() == 10 /* RCurly */)){
 ((((*this).index)++));
 }
 else {
-((*this).error((ByteString::must_from_utf8("Expected '}' to end namespace for the extern import"sv)),((((*this).current())).span())));
+((*this).error((ByteString::from_utf8_without_validation("Expected '}' to end namespace for the extern import"sv)),((((*this).current())).span())));
 }
 
 }
@@ -5343,7 +5343,7 @@ ByteString const name = (((*this).current())).as.Identifier.name;
 ({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<void,ErrorOr<parser::ParsedExternImport>>{
 auto __jakt_enum_value = (name);
-if (__jakt_enum_value == (ByteString::must_from_utf8("before_include"sv))) {
+if (__jakt_enum_value == (ByteString::from_utf8_without_validation("before_include"sv))) {
 {
 ((((*this).index)++));
 JaktInternal::Optional<JaktInternal::DynamicArray<parser::IncludeAction>> const actions = TRY((((*this).parse_include_action())));
@@ -5353,7 +5353,7 @@ if (((actions).has_value())){
 }
 return JaktInternal::ExplicitValue<void>();
 }
-else if (__jakt_enum_value == (ByteString::must_from_utf8("after_include"sv))) {
+else if (__jakt_enum_value == (ByteString::from_utf8_without_validation("after_include"sv))) {
 {
 ((((*this).index)++));
 JaktInternal::Optional<JaktInternal::DynamicArray<parser::IncludeAction>> const actions = TRY((((*this).parse_include_action())));
@@ -5397,7 +5397,7 @@ ByteString const name = (((*this).current())).as.Identifier.name;
 ({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<void,ErrorOr<JaktInternal::Optional<JaktInternal::DynamicArray<parser::IncludeAction>>>>{
 auto __jakt_enum_value = (name);
-if (__jakt_enum_value == (ByteString::must_from_utf8("define"sv))) {
+if (__jakt_enum_value == (ByteString::from_utf8_without_validation("define"sv))) {
 {
 ((((*this).index)++));
 ((*this).skip_newlines());
@@ -5406,7 +5406,7 @@ if (((((*this).current())).__jakt_init_index() == 9 /* LCurly */)){
 ((*this).skip_newlines());
 }
 else {
-((*this).error((ByteString::must_from_utf8("Expected '{' to start define action"sv)),((((*this).current())).span())));
+((*this).error((ByteString::from_utf8_without_validation("Expected '{' to start define action"sv)),((((*this).current())).span())));
 return JaktInternal::OptionalNone();
 }
 
@@ -5421,7 +5421,7 @@ if (((((*this).current())).__jakt_init_index() == 16 /* Equal */)){
 ((((*this).index)++));
 }
 else {
-((*this).error((ByteString::must_from_utf8("Expected '=' to assign value to defined symbols"sv)),((((*this).current())).span())));
+((*this).error((ByteString::from_utf8_without_validation("Expected '=' to assign value to defined symbols"sv)),((((*this).current())).span())));
 continue;
 }
 
@@ -5440,8 +5440,8 @@ __jakt_label_20:; __jakt_var_25.release_value(); }));
 };/*case end*/
 default: {
 return JaktInternal::ExplicitValue(({ Optional<ByteString> __jakt_var_26; {
-((*this).error((ByteString::must_from_utf8("Expected quoted string to assign value to defined symbols"sv)),((((*this).current())).span())));
-__jakt_var_26 = (ByteString::must_from_utf8(""sv)); goto __jakt_label_21;
+((*this).error((ByteString::from_utf8_without_validation("Expected quoted string to assign value to defined symbols"sv)),((((*this).current())).span())));
+__jakt_var_26 = (ByteString::from_utf8_without_validation(""sv)); goto __jakt_label_21;
 
 }
 __jakt_label_21:; __jakt_var_26.release_value(); }));
@@ -5473,14 +5473,14 @@ if (((((*this).current())).__jakt_init_index() == 10 /* RCurly */)){
 ((((*this).index)++));
 }
 else {
-((*this).error((ByteString::must_from_utf8("Expected '}' to end define action"sv)),((((*this).current())).span())));
+((*this).error((ByteString::from_utf8_without_validation("Expected '}' to end define action"sv)),((((*this).current())).span())));
 }
 
 return static_cast<JaktInternal::Optional<JaktInternal::DynamicArray<parser::IncludeAction>>>(defines);
 }
 return JaktInternal::ExplicitValue<void>();
 }
-else if (__jakt_enum_value == (ByteString::must_from_utf8("undefine"sv))) {
+else if (__jakt_enum_value == (ByteString::from_utf8_without_validation("undefine"sv))) {
 {
 ((((*this).index)++));
 ((*this).skip_newlines());
@@ -5489,7 +5489,7 @@ if (((((*this).current())).__jakt_init_index() == 9 /* LCurly */)){
 ((*this).skip_newlines());
 }
 else {
-((*this).error((ByteString::must_from_utf8("Expected '{' to start undefine include action"sv)),((((*this).current())).span())));
+((*this).error((ByteString::from_utf8_without_validation("Expected '{' to start undefine include action"sv)),((((*this).current())).span())));
 return JaktInternal::OptionalNone();
 }
 
@@ -5515,7 +5515,7 @@ if (((((*this).current())).__jakt_init_index() == 10 /* RCurly */)){
 ((((*this).index)++));
 }
 else {
-((*this).error((ByteString::must_from_utf8("Expected '}' to end undefine action"sv)),((((*this).current())).span())));
+((*this).error((ByteString::from_utf8_without_validation("Expected '}' to end undefine action"sv)),((((*this).current())).span())));
 }
 
 return static_cast<JaktInternal::Optional<JaktInternal::DynamicArray<parser::IncludeAction>>>(defines);
@@ -5533,11 +5533,11 @@ return JaktInternal::ExplicitValue<void>();
         return _jakt_value.release_return();
     _jakt_value.release_value();
 });
-((*this).error((ByteString::must_from_utf8("Expected 'define' or 'undefine' in include action"sv)),((((*this).current())).span())));
+((*this).error((ByteString::from_utf8_without_validation("Expected 'define' or 'undefine' in include action"sv)),((((*this).current())).span())));
 return JaktInternal::OptionalNone();
 }
 else {
-((*this).error((ByteString::must_from_utf8("Expected 'define' or 'undefine' in include action"sv)),((((*this).current())).span())));
+((*this).error((ByteString::from_utf8_without_validation("Expected 'define' or 'undefine' in include action"sv)),((((*this).current())).span())));
 return JaktInternal::OptionalNone();
 }
 
@@ -5546,13 +5546,13 @@ return JaktInternal::OptionalNone();
 
 ErrorOr<parser::ParsedModuleImport> parser::Parser::parse_module_import() {
 {
-parser::ParsedModuleImport parsed_import = parser::ParsedModuleImport(parser::ImportName::Literal((ByteString::must_from_utf8(""sv)),((*this).empty_span())),JaktInternal::OptionalNone(),parser::ImportList::List(DynamicArray<parser::ImportName>::create_with({})),false,static_cast<size_t>(0ULL));
+parser::ParsedModuleImport parsed_import = parser::ParsedModuleImport(parser::ImportName::Literal((ByteString::from_utf8_without_validation(""sv)),((*this).empty_span())),JaktInternal::OptionalNone(),parser::ImportList::List(DynamicArray<parser::ImportName>::create_with({})),false,static_cast<size_t>(0ULL));
 if (((((*this).current())).__jakt_init_index() == 79 /* Relative */)){
 (((parsed_import).relative_path) = true);
 ((((*this).index)++));
 if (((((*this).current())).__jakt_init_index() == 3 /* Identifier */)){
 ByteString const name = (((*this).current())).as.Identifier.name;
-if (((name) == ((ByteString::must_from_utf8("parent"sv))))){
+if (((name) == ((ByteString::from_utf8_without_validation("parent"sv))))){
 ((((*this).index)++));
 ((((parsed_import).parent_path_count)++));
 while (((((*this).current())).__jakt_init_index() == 6 /* ColonColon */)){
@@ -5569,7 +5569,7 @@ if ([](ByteString const& self, ByteString rhs) -> bool {
 return (!(((self) == (rhs))));
 }
 }
-(name,(ByteString::must_from_utf8("parent"sv)))){
+(name,(ByteString::from_utf8_without_validation("parent"sv)))){
 return JaktInternal::LoopBreak{};
 }
 ((((*this).index)++));
@@ -5621,7 +5621,7 @@ parser::NumericConstant const val = (numeric_constant)->as.NumericConstant.val;
 (((parsed_import).parent_path_count) = ((val).to_usize()));
 }
 else {
-((*this).error((ByteString::must_from_utf8("Invalid Numeric Constant"sv)),span));
+((*this).error((ByteString::from_utf8_without_validation("Invalid Numeric Constant"sv)),span));
 return JaktInternal::LoopBreak{};
 }
 
@@ -5695,7 +5695,7 @@ return JaktInternal::ExplicitValue(parser::ImportName::Literal(name,span));
 };/*case end*/
 default: {
 {
-((*this).error((ByteString::must_from_utf8("Expected module name"sv)),((((*this).current())).span())));
+((*this).error((ByteString::from_utf8_without_validation("Expected module name"sv)),((((*this).current())).span())));
 return parsed_import;
 }
 };/*case end*/
@@ -5720,7 +5720,7 @@ while (((((*this).current())).__jakt_init_index() == 6 /* ColonColon */)){
 (self = ((self) + (rhs)));
 }
 }
-(module_name,(ByteString::must_from_utf8("::"sv)));
+(module_name,(ByteString::from_utf8_without_validation("::"sv)));
 ({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<void, ErrorOr<parser::ParsedModuleImport>>{
 auto&& __jakt_match_variant = ((*this).current());
@@ -5754,7 +5754,7 @@ return JaktInternal::ExplicitValue<void>();
 };/*case end*/
 default: {
 {
-((*this).error((ByteString::must_from_utf8("Expected module name fragment"sv)),((((*this).current())).span())));
+((*this).error((ByteString::from_utf8_without_validation("Expected module name fragment"sv)),((((*this).current())).span())));
 return parsed_import;
 }
 return JaktInternal::ExplicitValue<void>();
@@ -5782,7 +5782,7 @@ utility::Span const span = (((*this).current())).as.Identifier.span;
 (((parsed_import).alias_name) = parser::ImportName::Literal(name,span));
 }
 else {
-((*this).error((ByteString::must_from_utf8("Expected name"sv)),((((*this).current())).span())));
+((*this).error((ByteString::from_utf8_without_validation("Expected name"sv)),((((*this).current())).span())));
 ((((*this).index)++));
 }
 
@@ -5791,7 +5791,7 @@ if (((*this).eol())){
 return parsed_import;
 }
 if ((!(((((*this).current())).__jakt_init_index() == 9 /* LCurly */)))){
-((*this).error((ByteString::must_from_utf8("Expected '{'"sv)),((((*this).current())).span())));
+((*this).error((ByteString::from_utf8_without_validation("Expected '{'"sv)),((((*this).current())).span())));
 }
 ((((*this).index)++));
 while ((!(((*this).eof())))){
@@ -5809,7 +5809,7 @@ JaktInternal::DynamicArray<parser::ImportName> mutable_names = names;
 ((mutable_names).push(parser::ImportName::Literal(name,span)));
 }
 else {
-((*this).error_with_hint(__jakt_format((StringView::from_string_literal("Already importing everything from '{}'"sv)),((((parsed_import).module_name)).literal_name())),((((*this).current())).span()),(ByteString::must_from_utf8("Remove the '*' to import specific names"sv)),((((*this).current())).span())));
+((*this).error_with_hint(__jakt_format((StringView::from_string_literal("Already importing everything from '{}'"sv)),((((parsed_import).module_name)).literal_name())),((((*this).current())).span()),(ByteString::from_utf8_without_validation("Remove the '*' to import specific names"sv)),((((*this).current())).span())));
 }
 
 ((((*this).index)++));
@@ -5869,7 +5869,7 @@ return JaktInternal::ExplicitValue<void>();
 };/*case end*/
 default: {
 {
-((*this).error((ByteString::must_from_utf8("Expected import symbol"sv)),((((*this).current())).span())));
+((*this).error((ByteString::from_utf8_without_validation("Expected import symbol"sv)),((((*this).current())).span())));
 ((((*this).index)++));
 }
 return JaktInternal::ExplicitValue<void>();
@@ -5898,12 +5898,12 @@ if (((((*this).current())).__jakt_init_index() == 9 /* LCurly */)){
 ((((*this).index)++));
 }
 else {
-((*this).error((ByteString::must_from_utf8("Expected `{` to start the enum body"sv)),((((*this).current())).span())));
+((*this).error((ByteString::from_utf8_without_validation("Expected `{` to start the enum body"sv)),((((*this).current())).span())));
 }
 
 ((*this).skip_newlines());
 if (((*this).eof())){
-((*this).error((ByteString::must_from_utf8("Incomplete enum definition, expected variant name"sv)),((((*this).previous())).span())));
+((*this).error((ByteString::from_utf8_without_validation("Incomplete enum definition, expected variant name"sv)),((((*this).previous())).span())));
 return (Tuple{variants, methods});
 }
 JaktInternal::Optional<parser::Visibility> last_visibility = JaktInternal::OptionalNone();
@@ -5952,7 +5952,7 @@ case 90 /* Private */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Private;utility::Span const& span = __jakt_match_value.value;
 {
 if (((last_visibility).has_value())){
-((*this).error_with_hint((ByteString::must_from_utf8("Multiple visibility modifiers on one field or method are not allowed"sv)),span,(ByteString::must_from_utf8("Previous modifier is here"sv)),(last_visibility_span.value())));
+((*this).error_with_hint((ByteString::from_utf8_without_validation("Multiple visibility modifiers on one field or method are not allowed"sv)),span,(ByteString::from_utf8_without_validation("Previous modifier is here"sv)),(last_visibility_span.value())));
 }
 (last_visibility = parser::Visibility::Private());
 (last_visibility_span = span);
@@ -5964,7 +5964,7 @@ case 91 /* Public */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Public;utility::Span const& span = __jakt_match_value.value;
 {
 if (((last_visibility).has_value())){
-((*this).error_with_hint((ByteString::must_from_utf8("Multiple visibility modifiers on one field or method are not allowed"sv)),span,(ByteString::must_from_utf8("Previous modifier is here"sv)),(last_visibility_span.value())));
+((*this).error_with_hint((ByteString::from_utf8_without_validation("Multiple visibility modifiers on one field or method are not allowed"sv)),span,(ByteString::from_utf8_without_validation("Previous modifier is here"sv)),(last_visibility_span.value())));
 }
 (last_visibility = parser::Visibility::Public());
 (last_visibility_span = span);
@@ -5997,7 +5997,7 @@ default: VERIFY_NOT_REACHED();}/*switch end*/
     _jakt_value.release_value();
 });
 if ((((function_linkage).__jakt_init_index() == 1 /* External */) && is_comptime)){
-((*this).error((ByteString::must_from_utf8("External functions cannot be comptime"sv)),((((*this).current())).span())));
+((*this).error((ByteString::from_utf8_without_validation("External functions cannot be comptime"sv)),((((*this).current())).span())));
 }
 parser::Visibility const visibility = last_visibility.value_or_lazy_evaluated([&] { return parser::Visibility::Public(); });
 (last_visibility = JaktInternal::OptionalNone());
@@ -6032,7 +6032,7 @@ default: VERIFY_NOT_REACHED();}/*switch end*/
     _jakt_value.release_value();
 });
 if ((((function_linkage).__jakt_init_index() == 1 /* External */) && is_comptime)){
-((*this).error((ByteString::must_from_utf8("External functions cannot be comptime"sv)),((((*this).current())).span())));
+((*this).error((ByteString::from_utf8_without_validation("External functions cannot be comptime"sv)),((((*this).current())).span())));
 }
 parser::Visibility const visibility = last_visibility.value_or_lazy_evaluated([&] { return parser::Visibility::Public(); });
 (last_visibility = JaktInternal::OptionalNone());
@@ -6044,7 +6044,7 @@ return JaktInternal::ExplicitValue<void>();
 };/*case end*/
 default: {
 {
-((*this).error((ByteString::must_from_utf8("Expected identifier or the end of enum block"sv)),((((*this).current())).span())));
+((*this).error((ByteString::from_utf8_without_validation("Expected identifier or the end of enum block"sv)),((((*this).current())).span())));
 ((((*this).index)++));
 }
 return JaktInternal::ExplicitValue<void>();
@@ -6062,12 +6062,12 @@ return JaktInternal::ExplicitValue<void>();
 });
 }
 if ((!(((((*this).current())).__jakt_init_index() == 10 /* RCurly */)))){
-((*this).error((ByteString::must_from_utf8("Invalid enum definition, expected `}`"sv)),((((*this).current())).span())));
+((*this).error((ByteString::from_utf8_without_validation("Invalid enum definition, expected `}`"sv)),((((*this).current())).span())));
 return (Tuple{variants, methods});
 }
 ((((*this).index)++));
 if (((variants).is_empty())){
-((*this).error((ByteString::must_from_utf8("Empty enums are not allowed"sv)),((partial_enum).name_span)));
+((*this).error((ByteString::from_utf8_without_validation("Empty enums are not allowed"sv)),((partial_enum).name_span)));
 }
 return (Tuple{variants, methods});
 }
@@ -6084,12 +6084,12 @@ if (((((*this).current())).__jakt_init_index() == 9 /* LCurly */)){
 ((((*this).index)++));
 }
 else {
-((*this).error((ByteString::must_from_utf8("Expected `{` to start the enum body"sv)),((((*this).current())).span())));
+((*this).error((ByteString::from_utf8_without_validation("Expected `{` to start the enum body"sv)),((((*this).current())).span())));
 }
 
 ((*this).skip_newlines());
 if (((*this).eof())){
-((*this).error((ByteString::must_from_utf8("Incomplete enum definition, expected variant or field name"sv)),((((*this).previous())).span())));
+((*this).error((ByteString::from_utf8_without_validation("Incomplete enum definition, expected variant or field name"sv)),((((*this).previous())).span())));
 return (Tuple{variants, fields, methods, records});
 }
 JaktInternal::Optional<parser::Visibility> last_visibility = JaktInternal::OptionalNone();
@@ -6104,7 +6104,7 @@ switch(__jakt_match_variant.__jakt_init_index()) {
 case 72 /* Extern */: {
 {
 if (last_extern){
-((*this).error((ByteString::must_from_utf8("Multiple extern modifiers are not allowed"sv)),((((*this).current())).span())));
+((*this).error((ByteString::from_utf8_without_validation("Multiple extern modifiers are not allowed"sv)),((((*this).current())).span())));
 }
 (last_extern = true);
 ((((*this).index)++));
@@ -6116,17 +6116,17 @@ auto&& __jakt_match_value = __jakt_match_variant.as.Identifier;ByteString const&
 utility::Span const& span = __jakt_match_value.span;
 {
 if (last_extern){
-((*this).error((ByteString::must_from_utf8("An enum variant or common field cannot be extern"sv)),span));
+((*this).error((ByteString::from_utf8_without_validation("An enum variant or common field cannot be extern"sv)),span));
 (last_extern = false);
 }
 if ((!(((active_attributes).is_empty())))){
-((*this).error((ByteString::must_from_utf8("An enum variant or common field cannot have attributes"sv)),span));
+((*this).error((ByteString::from_utf8_without_validation("An enum variant or common field cannot have attributes"sv)),span));
 (active_attributes = DynamicArray<parser::ParsedAttribute>::create_with({}));
 }
 if (((((*this).peek(static_cast<size_t>(1ULL)))).__jakt_init_index() == 5 /* Colon */)){
 parser::ParsedField const field = TRY((((*this).parse_field(last_visibility.value_or_lazy_evaluated([&] { return parser::Visibility::Public(); })))));
 if (seen_a_variant){
-((*this).error_with_hint((ByteString::must_from_utf8("Common enum fields must be declared before variants"sv)),span,(ByteString::must_from_utf8("Previous variant is here"sv)),(((((variants).last()).value())).span)));
+((*this).error_with_hint((ByteString::from_utf8_without_validation("Common enum fields must be declared before variants"sv)),span,(ByteString::from_utf8_without_validation("Previous variant is here"sv)),(((((variants).last()).value())).span)));
 }
 else {
 ((fields).push(field));
@@ -6152,14 +6152,14 @@ ByteString const name = (((var_decl).parsed_type))->as.Name.name;
 utility::Span const span = (((var_decl).parsed_type))->as.Name.span;
 (((var_decl).inlay_span) = span);
 if ((((name) == (((partial_enum).name))) && (!(is_boxed)))){
-((*this).error((ByteString::must_from_utf8("use 'boxed enum' to make the enum recursive"sv)),((var_decl).span)));
+((*this).error((ByteString::from_utf8_without_validation("use 'boxed enum' to make the enum recursive"sv)),((var_decl).span)));
 }
 }
 ((var_decls).push(var_decl));
 continue;
 }
 else {
-((*this).error((ByteString::must_from_utf8("Enum variant missing type"sv)),((((*this).current())).span())));
+((*this).error((ByteString::from_utf8_without_validation("Enum variant missing type"sv)),((((*this).current())).span())));
 ((((*this).index)++));
 continue;
 }
@@ -6171,19 +6171,19 @@ auto&& __jakt_match_variant = ((*this).current());
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 3 /* Identifier */: {
 {
-((var_decls).push(parser::ParsedVarDecl((ByteString::must_from_utf8(""sv)),TRY((((*this).parse_typename()))),false,JaktInternal::OptionalNone(),((((*this).current())).span()),JaktInternal::OptionalNone())));
+((var_decls).push(parser::ParsedVarDecl((ByteString::from_utf8_without_validation(""sv)),TRY((((*this).parse_typename()))),false,JaktInternal::OptionalNone(),((((*this).current())).span()),JaktInternal::OptionalNone())));
 }
 return JaktInternal::ExplicitValue<void>();
 };/*case end*/
 case 11 /* LSquare */: {
 {
-((var_decls).push(parser::ParsedVarDecl((ByteString::must_from_utf8(""sv)),TRY((((*this).parse_typename()))),false,JaktInternal::OptionalNone(),((((*this).current())).span()),JaktInternal::OptionalNone())));
+((var_decls).push(parser::ParsedVarDecl((ByteString::from_utf8_without_validation(""sv)),TRY((((*this).parse_typename()))),false,JaktInternal::OptionalNone(),((((*this).current())).span()),JaktInternal::OptionalNone())));
 }
 return JaktInternal::ExplicitValue<void>();
 };/*case end*/
 case 9 /* LCurly */: {
 {
-((var_decls).push(parser::ParsedVarDecl((ByteString::must_from_utf8(""sv)),TRY((((*this).parse_typename()))),false,JaktInternal::OptionalNone(),((((*this).current())).span()),JaktInternal::OptionalNone())));
+((var_decls).push(parser::ParsedVarDecl((ByteString::from_utf8_without_validation(""sv)),TRY((((*this).parse_typename()))),false,JaktInternal::OptionalNone(),((((*this).current())).span()),JaktInternal::OptionalNone())));
 }
 return JaktInternal::ExplicitValue<void>();
 };/*case end*/
@@ -6303,7 +6303,7 @@ if (((((*this).peek(static_cast<size_t>(1ULL)))).__jakt_init_index() == 11 /* LS
 ((*this).parse_attribute_list(((active_attributes))));
 }
 else {
-((*this).error((ByteString::must_from_utf8("Unexpected token (expected ‘[[’)"sv)),((((*this).current())).span())));
+((*this).error((ByteString::from_utf8_without_validation("Unexpected token (expected ‘[[’)"sv)),((((*this).current())).span())));
 ((((*this).index)) += (static_cast<size_t>(1ULL)));
 }
 
@@ -6314,7 +6314,7 @@ case 90 /* Private */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Private;utility::Span const& span = __jakt_match_value.value;
 {
 if (((last_visibility).has_value())){
-((*this).error_with_hint((ByteString::must_from_utf8("Multiple visibility modifiers on one field or method are not allowed"sv)),span,(ByteString::must_from_utf8("Previous modifier is here"sv)),(last_visibility_span.value())));
+((*this).error_with_hint((ByteString::from_utf8_without_validation("Multiple visibility modifiers on one field or method are not allowed"sv)),span,(ByteString::from_utf8_without_validation("Previous modifier is here"sv)),(last_visibility_span.value())));
 }
 (last_visibility = parser::Visibility::Private());
 (last_visibility_span = span);
@@ -6326,7 +6326,7 @@ case 91 /* Public */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Public;utility::Span const& span = __jakt_match_value.value;
 {
 if (((last_visibility).has_value())){
-((*this).error_with_hint((ByteString::must_from_utf8("Multiple visibility modifiers on one field or method are not allowed"sv)),span,(ByteString::must_from_utf8("Previous modifier is here"sv)),(last_visibility_span.value())));
+((*this).error_with_hint((ByteString::from_utf8_without_validation("Multiple visibility modifiers on one field or method are not allowed"sv)),span,(ByteString::from_utf8_without_validation("Previous modifier is here"sv)),(last_visibility_span.value())));
 }
 (last_visibility = parser::Visibility::Public());
 (last_visibility_span = span);
@@ -6377,7 +6377,7 @@ VERIFY_NOT_REACHED();
     _jakt_value.release_value();
 });
 if ((((function_linkage).__jakt_init_index() == 1 /* External */) && is_comptime)){
-((*this).error((ByteString::must_from_utf8("External functions cannot be comptime"sv)),((((*this).current())).span())));
+((*this).error((ByteString::from_utf8_without_validation("External functions cannot be comptime"sv)),((((*this).current())).span())));
 }
 parser::Visibility const visibility = last_visibility.value_or_lazy_evaluated([&] { return parser::Visibility::Public(); });
 (last_visibility = JaktInternal::OptionalNone());
@@ -6432,7 +6432,7 @@ VERIFY_NOT_REACHED();
     _jakt_value.release_value();
 });
 if ((((function_linkage).__jakt_init_index() == 1 /* External */) && is_comptime)){
-((*this).error((ByteString::must_from_utf8("External functions cannot be comptime"sv)),((((*this).current())).span())));
+((*this).error((ByteString::from_utf8_without_validation("External functions cannot be comptime"sv)),((((*this).current())).span())));
 }
 parser::Visibility const visibility = last_visibility.value_or_lazy_evaluated([&] { return parser::Visibility::Public(); });
 (last_visibility = JaktInternal::OptionalNone());
@@ -6447,7 +6447,7 @@ return JaktInternal::ExplicitValue<void>();
 case 97 /* Struct */: {
 {
 if (((last_visibility).has_value())){
-((*this).error((ByteString::must_from_utf8("Nested types cannot have visibility modifiers"sv)),((((*this).current())).span())));
+((*this).error((ByteString::from_utf8_without_validation("Nested types cannot have visibility modifiers"sv)),((((*this).current())).span())));
 (last_visibility = JaktInternal::OptionalNone());
 }
 parser::ParsedRecord parsed_record = TRY((((*this).parse_record(({
@@ -6478,7 +6478,7 @@ return JaktInternal::ExplicitValue<void>();
 case 71 /* Enum */: {
 {
 if (((last_visibility).has_value())){
-((*this).error((ByteString::must_from_utf8("Nested types cannot have visibility modifiers"sv)),((((*this).current())).span())));
+((*this).error((ByteString::from_utf8_without_validation("Nested types cannot have visibility modifiers"sv)),((((*this).current())).span())));
 (last_visibility = JaktInternal::OptionalNone());
 }
 parser::ParsedRecord parsed_record = TRY((((*this).parse_record(({
@@ -6509,7 +6509,7 @@ return JaktInternal::ExplicitValue<void>();
 case 62 /* Boxed */: {
 {
 if (((last_visibility).has_value())){
-((*this).error((ByteString::must_from_utf8("Nested types cannot have visibility modifiers"sv)),((((*this).current())).span())));
+((*this).error((ByteString::from_utf8_without_validation("Nested types cannot have visibility modifiers"sv)),((((*this).current())).span())));
 (last_visibility = JaktInternal::OptionalNone());
 }
 parser::ParsedRecord parsed_record = TRY((((*this).parse_record(({
@@ -6540,7 +6540,7 @@ return JaktInternal::ExplicitValue<void>();
 case 65 /* Class */: {
 {
 if (((last_visibility).has_value())){
-((*this).error((ByteString::must_from_utf8("Nested types cannot have visibility modifiers"sv)),((((*this).current())).span())));
+((*this).error((ByteString::from_utf8_without_validation("Nested types cannot have visibility modifiers"sv)),((((*this).current())).span())));
 (last_visibility = JaktInternal::OptionalNone());
 }
 parser::ParsedRecord parsed_record = TRY((((*this).parse_record(({
@@ -6570,7 +6570,7 @@ return JaktInternal::ExplicitValue<void>();
 };/*case end*/
 default: {
 {
-((*this).error((ByteString::must_from_utf8("Expected identifier or the end of enum block"sv)),((((*this).current())).span())));
+((*this).error((ByteString::from_utf8_without_validation("Expected identifier or the end of enum block"sv)),((((*this).current())).span())));
 ((((*this).index)++));
 }
 return JaktInternal::ExplicitValue<void>();
@@ -6588,12 +6588,12 @@ return JaktInternal::ExplicitValue<void>();
 });
 }
 if ((!(((((*this).current())).__jakt_init_index() == 10 /* RCurly */)))){
-((*this).error((ByteString::must_from_utf8("Invalid enum definition, expected `}`"sv)),((((*this).current())).span())));
+((*this).error((ByteString::from_utf8_without_validation("Invalid enum definition, expected `}`"sv)),((((*this).current())).span())));
 return (Tuple{variants, fields, methods, records});
 }
 ((((*this).index)++));
 if (((variants).is_empty())){
-((*this).error((ByteString::must_from_utf8("Empty enums are not allowed"sv)),((partial_enum).name_span)));
+((*this).error((ByteString::from_utf8_without_validation("Empty enums are not allowed"sv)),((partial_enum).name_span)));
 }
 return (Tuple{variants, fields, methods, records});
 }
@@ -6601,18 +6601,18 @@ return (Tuple{variants, fields, methods, records});
 
 ErrorOr<parser::ParsedRecord> parser::Parser::parse_enum(parser::DefinitionLinkage const definition_linkage,bool const is_boxed) {
 {
-parser::ParsedRecord parsed_enum = parser::ParsedRecord((ByteString::must_from_utf8(""sv)),((*this).empty_span()),DynamicArray<parser::ParsedGenericParameter>::create_with({}),definition_linkage,JaktInternal::OptionalNone(),DynamicArray<parser::ParsedMethod>::create_with({}),parser::RecordType::Garbage(),DynamicArray<parser::ParsedRecord>::create_with({}),JaktInternal::OptionalNone());
+parser::ParsedRecord parsed_enum = parser::ParsedRecord((ByteString::from_utf8_without_validation(""sv)),((*this).empty_span()),DynamicArray<parser::ParsedGenericParameter>::create_with({}),definition_linkage,JaktInternal::OptionalNone(),DynamicArray<parser::ParsedMethod>::create_with({}),parser::RecordType::Garbage(),DynamicArray<parser::ParsedRecord>::create_with({}),JaktInternal::OptionalNone());
 JaktInternal::Optional<NonnullRefPtr<typename parser::ParsedType>> underlying_type = JaktInternal::OptionalNone();
 if (((((*this).current())).__jakt_init_index() == 71 /* Enum */)){
 ((((*this).index)++));
 }
 else {
-((*this).error((ByteString::must_from_utf8("Expected ‘enum’ keyword"sv)),((((*this).current())).span())));
+((*this).error((ByteString::from_utf8_without_validation("Expected ‘enum’ keyword"sv)),((((*this).current())).span())));
 return parsed_enum;
 }
 
 if (((*this).eof())){
-((*this).error((ByteString::must_from_utf8("Incomplete enum definition, expected name"sv)),((((*this).current())).span())));
+((*this).error((ByteString::from_utf8_without_validation("Incomplete enum definition, expected name"sv)),((((*this).current())).span())));
 return parsed_enum;
 }
 if (((((*this).current())).__jakt_init_index() == 3 /* Identifier */)){
@@ -6623,11 +6623,11 @@ utility::Span const span = (((*this).current())).as.Identifier.span;
 ((((*this).index)++));
 }
 else {
-((*this).error((ByteString::must_from_utf8("Incomplete enum definition, expected name"sv)),((((*this).current())).span())));
+((*this).error((ByteString::from_utf8_without_validation("Incomplete enum definition, expected name"sv)),((((*this).current())).span())));
 }
 
 if (((*this).eof())){
-((*this).error((ByteString::must_from_utf8("Incomplete enum definition, expected generic parameters or underlying type or body"sv)),((((*this).current())).span())));
+((*this).error((ByteString::from_utf8_without_validation("Incomplete enum definition, expected generic parameters or underlying type or body"sv)),((((*this).current())).span())));
 return parsed_enum;
 }
 if (((((*this).current())).__jakt_init_index() == 28 /* LessThan */)){
@@ -6638,19 +6638,19 @@ if (((((*this).current())).__jakt_init_index() == 109 /* Implements */)){
 (((parsed_enum).implements_list) = TRY((((*this).parse_trait_list()))));
 }
 if (((*this).eof())){
-((*this).error((ByteString::must_from_utf8("Incomplete enum definition, expected underlying type or body"sv)),((((*this).current())).span())));
+((*this).error((ByteString::from_utf8_without_validation("Incomplete enum definition, expected underlying type or body"sv)),((((*this).current())).span())));
 return parsed_enum;
 }
 if (((((*this).current())).__jakt_init_index() == 5 /* Colon */)){
 if (is_boxed){
-((*this).error((ByteString::must_from_utf8("Invalid enum definition: Value enums must not have an underlying type"sv)),((((*this).current())).span())));
+((*this).error((ByteString::from_utf8_without_validation("Invalid enum definition: Value enums must not have an underlying type"sv)),((((*this).current())).span())));
 }
 ((((*this).index)++));
 (underlying_type = TRY((((*this).parse_typename()))));
 }
 ((*this).skip_newlines());
 if (((*this).eof())){
-((*this).error((ByteString::must_from_utf8("Incomplete enum definition, expected body"sv)),((((*this).current())).span())));
+((*this).error((ByteString::from_utf8_without_validation("Incomplete enum definition, expected body"sv)),((((*this).current())).span())));
 return parsed_enum;
 }
 if (((underlying_type).has_value())){
@@ -6683,7 +6683,7 @@ if (((((*this).current())).__jakt_init_index() == 9 /* LCurly */)){
 ((((*this).index)++));
 }
 else {
-((*this).error((ByteString::must_from_utf8("Expected ‘{’"sv)),((((*this).current())).span())));
+((*this).error((ByteString::from_utf8_without_validation("Expected ‘{’"sv)),((((*this).current())).span())));
 }
 
 JaktInternal::DynamicArray<parser::ParsedField> fields = DynamicArray<parser::ParsedField>::create_with({});
@@ -6705,10 +6705,10 @@ switch(__jakt_match_variant.__jakt_init_index()) {
 case 10 /* RCurly */: {
 {
 if (((last_visibility).has_value())){
-((*this).error((ByteString::must_from_utf8("Expected function or parameter after visibility modifier"sv)),((token).span())));
+((*this).error((ByteString::from_utf8_without_validation("Expected function or parameter after visibility modifier"sv)),((token).span())));
 }
 if ((!(((active_attributes).is_empty())))){
-((*this).error((ByteString::must_from_utf8("Expected function after attribute"sv)),((token).span())));
+((*this).error((ByteString::from_utf8_without_validation("Expected function after attribute"sv)),((token).span())));
 }
 ((((*this).index)++));
 return (Tuple{fields, methods, records});
@@ -6738,7 +6738,7 @@ case 91 /* Public */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Public;utility::Span const& span = __jakt_match_value.value;
 {
 if (((last_visibility).has_value())){
-((*this).error_with_hint((ByteString::must_from_utf8("Multiple visibility modifiers on one field or method are not allowed"sv)),span,(ByteString::must_from_utf8("Previous modifier is here"sv)),(last_visibility_span.value())));
+((*this).error_with_hint((ByteString::from_utf8_without_validation("Multiple visibility modifiers on one field or method are not allowed"sv)),span,(ByteString::from_utf8_without_validation("Previous modifier is here"sv)),(last_visibility_span.value())));
 }
 (last_visibility = parser::Visibility::Public());
 (last_visibility_span = span);
@@ -6750,7 +6750,7 @@ case 90 /* Private */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Private;utility::Span const& span = __jakt_match_value.value;
 {
 if (((last_visibility).has_value())){
-((*this).error_with_hint((ByteString::must_from_utf8("Multiple visibility modifiers on one field or method are not allowed"sv)),span,(ByteString::must_from_utf8("Previous modifier is here"sv)),(last_visibility_span.value())));
+((*this).error_with_hint((ByteString::from_utf8_without_validation("Multiple visibility modifiers on one field or method are not allowed"sv)),span,(ByteString::from_utf8_without_validation("Previous modifier is here"sv)),(last_visibility_span.value())));
 }
 (last_visibility = parser::Visibility::Private());
 (last_visibility_span = span);
@@ -6762,7 +6762,7 @@ case 95 /* Restricted */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Restricted;utility::Span const& span = __jakt_match_value.value;
 {
 if (((last_visibility).has_value())){
-((*this).error_with_hint((ByteString::must_from_utf8("Multiple visibility modifiers on one field or method are not allowed"sv)),span,(ByteString::must_from_utf8("Previous modifier is here"sv)),(last_visibility_span.value())));
+((*this).error_with_hint((ByteString::from_utf8_without_validation("Multiple visibility modifiers on one field or method are not allowed"sv)),span,(ByteString::from_utf8_without_validation("Previous modifier is here"sv)),(last_visibility_span.value())));
 }
 (last_visibility = TRY((((*this).parse_restricted_visibility_modifier()))));
 (last_visibility_span = span);
@@ -6776,7 +6776,7 @@ if (((((*this).peek(static_cast<size_t>(1ULL)))).__jakt_init_index() == 11 /* LS
 ((*this).parse_attribute_list(((active_attributes))));
 }
 else {
-((*this).error((ByteString::must_from_utf8("Unexpected token (expected ‘[[’)"sv)),((((*this).current())).span())));
+((*this).error((ByteString::from_utf8_without_validation("Unexpected token (expected ‘[[’)"sv)),((((*this).current())).span())));
 ((((*this).index)) += (static_cast<size_t>(1ULL)));
 }
 
@@ -6789,12 +6789,12 @@ parser::Visibility const visibility = last_visibility.value_or_lazy_evaluated([&
 (last_visibility = JaktInternal::OptionalNone());
 (last_visibility_span = JaktInternal::OptionalNone());
 if ((last_virtual || last_override)){
-((*this).error((ByteString::must_from_utf8("Fields cannot be ‘virtual’ or ‘override’"sv)),((((*this).current())).span())));
+((*this).error((ByteString::from_utf8_without_validation("Fields cannot be ‘virtual’ or ‘override’"sv)),((((*this).current())).span())));
 }
 (last_virtual = false);
 (last_override = false);
 if (last_extern){
-((*this).error((ByteString::must_from_utf8("Fields cannot be ‘extern’"sv)),((((*this).current())).span())));
+((*this).error((ByteString::from_utf8_without_validation("Fields cannot be ‘extern’"sv)),((((*this).current())).span())));
 }
 (last_extern = false);
 parser::ParsedField field = TRY((((*this).parse_field(visibility))));
@@ -6849,7 +6849,7 @@ default: VERIFY_NOT_REACHED();}/*switch end*/
 });
 (last_extern = false);
 if ((((function_linkage).__jakt_init_index() == 1 /* External */) && is_comptime)){
-((*this).error((ByteString::must_from_utf8("External functions cannot be comptime"sv)),((((*this).current())).span())));
+((*this).error((ByteString::from_utf8_without_validation("External functions cannot be comptime"sv)),((((*this).current())).span())));
 }
 parser::Visibility const visibility = last_visibility.value_or_lazy_evaluated([&] { return default_visibility; });
 (last_visibility = JaktInternal::OptionalNone());
@@ -6910,7 +6910,7 @@ default: VERIFY_NOT_REACHED();}/*switch end*/
 });
 (last_extern = false);
 if ((((function_linkage).__jakt_init_index() == 1 /* External */) && is_comptime)){
-((*this).error((ByteString::must_from_utf8("External functions cannot be comptime"sv)),((((*this).current())).span())));
+((*this).error((ByteString::from_utf8_without_validation("External functions cannot be comptime"sv)),((((*this).current())).span())));
 }
 parser::Visibility const visibility = last_visibility.value_or_lazy_evaluated([&] { return default_visibility; });
 (last_visibility = JaktInternal::OptionalNone());
@@ -6971,7 +6971,7 @@ default: VERIFY_NOT_REACHED();}/*switch end*/
 });
 (last_extern = false);
 if ((((function_linkage).__jakt_init_index() == 1 /* External */) && is_comptime)){
-((*this).error((ByteString::must_from_utf8("External functions cannot be comptime"sv)),((((*this).current())).span())));
+((*this).error((ByteString::from_utf8_without_validation("External functions cannot be comptime"sv)),((((*this).current())).span())));
 }
 parser::Visibility const visibility = last_visibility.value_or_lazy_evaluated([&] { return default_visibility; });
 (last_visibility = JaktInternal::OptionalNone());
@@ -7004,12 +7004,12 @@ return JaktInternal::ExplicitValue<void>();
 case 97 /* Struct */: {
 {
 if ((last_virtual || last_override)){
-((*this).error((ByteString::must_from_utf8("Nested types cannot be ‘virtual’ or ‘override’"sv)),((((*this).current())).span())));
+((*this).error((ByteString::from_utf8_without_validation("Nested types cannot be ‘virtual’ or ‘override’"sv)),((((*this).current())).span())));
 (last_virtual = false);
 (last_override = false);
 }
 if (((last_visibility).has_value())){
-((*this).error((ByteString::must_from_utf8("Nested types cannot have visibility modifiers"sv)),((((*this).current())).span())));
+((*this).error((ByteString::from_utf8_without_validation("Nested types cannot have visibility modifiers"sv)),((((*this).current())).span())));
 (last_visibility = JaktInternal::OptionalNone());
 }
 parser::ParsedRecord parsed_record = TRY((((*this).parse_record(({
@@ -7040,12 +7040,12 @@ return JaktInternal::ExplicitValue<void>();
 case 71 /* Enum */: {
 {
 if ((last_virtual || last_override)){
-((*this).error((ByteString::must_from_utf8("Nested types cannot be ‘virtual’ or ‘override’"sv)),((((*this).current())).span())));
+((*this).error((ByteString::from_utf8_without_validation("Nested types cannot be ‘virtual’ or ‘override’"sv)),((((*this).current())).span())));
 (last_virtual = false);
 (last_override = false);
 }
 if (((last_visibility).has_value())){
-((*this).error((ByteString::must_from_utf8("Nested types cannot have visibility modifiers"sv)),((((*this).current())).span())));
+((*this).error((ByteString::from_utf8_without_validation("Nested types cannot have visibility modifiers"sv)),((((*this).current())).span())));
 (last_visibility = JaktInternal::OptionalNone());
 }
 parser::ParsedRecord parsed_record = TRY((((*this).parse_record(({
@@ -7076,12 +7076,12 @@ return JaktInternal::ExplicitValue<void>();
 case 62 /* Boxed */: {
 {
 if ((last_virtual || last_override)){
-((*this).error((ByteString::must_from_utf8("Nested types cannot be ‘virtual’ or ‘override’"sv)),((((*this).current())).span())));
+((*this).error((ByteString::from_utf8_without_validation("Nested types cannot be ‘virtual’ or ‘override’"sv)),((((*this).current())).span())));
 (last_virtual = false);
 (last_override = false);
 }
 if (((last_visibility).has_value())){
-((*this).error((ByteString::must_from_utf8("Nested types cannot have visibility modifiers"sv)),((((*this).current())).span())));
+((*this).error((ByteString::from_utf8_without_validation("Nested types cannot have visibility modifiers"sv)),((((*this).current())).span())));
 (last_visibility = JaktInternal::OptionalNone());
 }
 parser::ParsedRecord parsed_record = TRY((((*this).parse_record(({
@@ -7112,12 +7112,12 @@ return JaktInternal::ExplicitValue<void>();
 case 65 /* Class */: {
 {
 if ((last_virtual || last_override)){
-((*this).error((ByteString::must_from_utf8("Nested types cannot be ‘virtual’ or ‘override’"sv)),((((*this).current())).span())));
+((*this).error((ByteString::from_utf8_without_validation("Nested types cannot be ‘virtual’ or ‘override’"sv)),((((*this).current())).span())));
 (last_virtual = false);
 (last_override = false);
 }
 if (((last_visibility).has_value())){
-((*this).error((ByteString::must_from_utf8("Nested types cannot have visibility modifiers"sv)),((((*this).current())).span())));
+((*this).error((ByteString::from_utf8_without_validation("Nested types cannot have visibility modifiers"sv)),((((*this).current())).span())));
 (last_visibility = JaktInternal::OptionalNone());
 }
 parser::ParsedRecord parsed_record = TRY((((*this).parse_record(({
@@ -7169,10 +7169,10 @@ return JaktInternal::ExplicitValue<void>();
 });
 }
 if (is_class){
-((*this).error((ByteString::must_from_utf8("Incomplete class body, expected ‘}’"sv)),((((*this).current())).span())));
+((*this).error((ByteString::from_utf8_without_validation("Incomplete class body, expected ‘}’"sv)),((((*this).current())).span())));
 }
 else {
-((*this).error((ByteString::must_from_utf8("Incomplete struct body, expected ‘}’"sv)),((((*this).current())).span())));
+((*this).error((ByteString::from_utf8_without_validation("Incomplete struct body, expected ‘}’"sv)),((((*this).current())).span())));
 }
 
 return (Tuple{fields, methods, records});
@@ -7181,17 +7181,17 @@ return (Tuple{fields, methods, records});
 
 ErrorOr<parser::ParsedRecord> parser::Parser::parse_struct(parser::DefinitionLinkage const definition_linkage) {
 {
-parser::ParsedRecord parsed_struct = parser::ParsedRecord((ByteString::must_from_utf8(""sv)),((*this).empty_span()),DynamicArray<parser::ParsedGenericParameter>::create_with({}),definition_linkage,JaktInternal::OptionalNone(),DynamicArray<parser::ParsedMethod>::create_with({}),parser::RecordType::Garbage(),DynamicArray<parser::ParsedRecord>::create_with({}),JaktInternal::OptionalNone());
+parser::ParsedRecord parsed_struct = parser::ParsedRecord((ByteString::from_utf8_without_validation(""sv)),((*this).empty_span()),DynamicArray<parser::ParsedGenericParameter>::create_with({}),definition_linkage,JaktInternal::OptionalNone(),DynamicArray<parser::ParsedMethod>::create_with({}),parser::RecordType::Garbage(),DynamicArray<parser::ParsedRecord>::create_with({}),JaktInternal::OptionalNone());
 if (((((*this).current())).__jakt_init_index() == 97 /* Struct */)){
 ((((*this).index)++));
 }
 else {
-((*this).error((ByteString::must_from_utf8("Expected `struct` keyword"sv)),((((*this).current())).span())));
+((*this).error((ByteString::from_utf8_without_validation("Expected `struct` keyword"sv)),((((*this).current())).span())));
 return parsed_struct;
 }
 
 if (((*this).eof())){
-((*this).error((ByteString::must_from_utf8("Incomplete struct definition, expected name"sv)),((((*this).current())).span())));
+((*this).error((ByteString::from_utf8_without_validation("Incomplete struct definition, expected name"sv)),((((*this).current())).span())));
 return parsed_struct;
 }
 if (((((*this).current())).__jakt_init_index() == 3 /* Identifier */)){
@@ -7202,11 +7202,11 @@ utility::Span const span = (((*this).current())).as.Identifier.span;
 (((parsed_struct).name_span) = span);
 }
 else {
-((*this).error((ByteString::must_from_utf8("Incomplete struct definition, expected name"sv)),((((*this).current())).span())));
+((*this).error((ByteString::from_utf8_without_validation("Incomplete struct definition, expected name"sv)),((((*this).current())).span())));
 }
 
 if (((*this).eof())){
-((*this).error((ByteString::must_from_utf8("Incomplete struct definition, expected generic parameters or body"sv)),((((*this).current())).span())));
+((*this).error((ByteString::from_utf8_without_validation("Incomplete struct definition, expected generic parameters or body"sv)),((((*this).current())).span())));
 return parsed_struct;
 }
 (((parsed_struct).generic_parameters) = TRY((((*this).parse_generic_parameters()))));
@@ -7221,7 +7221,7 @@ if (((((*this).current())).__jakt_init_index() == 5 /* Colon */)){
 }
 ((*this).skip_newlines());
 if (((*this).eof())){
-((*this).error((ByteString::must_from_utf8("Incomplete struct definition, expected body"sv)),((((*this).current())).span())));
+((*this).error((ByteString::from_utf8_without_validation("Incomplete struct definition, expected body"sv)),((((*this).current())).span())));
 return parsed_struct;
 }
 JaktInternal::Tuple<JaktInternal::DynamicArray<parser::ParsedField>,JaktInternal::DynamicArray<parser::ParsedMethod>,JaktInternal::DynamicArray<parser::ParsedRecord>> const fields_methods_records_ = TRY((((*this).parse_struct_class_body(definition_linkage,parser::Visibility::Public(),false))));
@@ -7238,18 +7238,18 @@ return parsed_struct;
 
 ErrorOr<parser::ParsedRecord> parser::Parser::parse_class(parser::DefinitionLinkage const definition_linkage) {
 {
-parser::ParsedRecord parsed_class = parser::ParsedRecord((ByteString::must_from_utf8(""sv)),((*this).empty_span()),DynamicArray<parser::ParsedGenericParameter>::create_with({}),definition_linkage,JaktInternal::OptionalNone(),DynamicArray<parser::ParsedMethod>::create_with({}),parser::RecordType::Garbage(),DynamicArray<parser::ParsedRecord>::create_with({}),JaktInternal::OptionalNone());
+parser::ParsedRecord parsed_class = parser::ParsedRecord((ByteString::from_utf8_without_validation(""sv)),((*this).empty_span()),DynamicArray<parser::ParsedGenericParameter>::create_with({}),definition_linkage,JaktInternal::OptionalNone(),DynamicArray<parser::ParsedMethod>::create_with({}),parser::RecordType::Garbage(),DynamicArray<parser::ParsedRecord>::create_with({}),JaktInternal::OptionalNone());
 JaktInternal::Optional<NonnullRefPtr<typename parser::ParsedType>> super_type = JaktInternal::OptionalNone();
 if (((((*this).current())).__jakt_init_index() == 65 /* Class */)){
 ((((*this).index)++));
 }
 else {
-((*this).error((ByteString::must_from_utf8("Expected `class` keyword"sv)),((((*this).current())).span())));
+((*this).error((ByteString::from_utf8_without_validation("Expected `class` keyword"sv)),((((*this).current())).span())));
 return parsed_class;
 }
 
 if (((*this).eof())){
-((*this).error((ByteString::must_from_utf8("Incomplete class definition, expected name"sv)),((((*this).current())).span())));
+((*this).error((ByteString::from_utf8_without_validation("Incomplete class definition, expected name"sv)),((((*this).current())).span())));
 return parsed_class;
 }
 if (((((*this).current())).__jakt_init_index() == 3 /* Identifier */)){
@@ -7260,11 +7260,11 @@ utility::Span const span = (((*this).current())).as.Identifier.span;
 (((parsed_class).name_span) = span);
 }
 else {
-((*this).error((ByteString::must_from_utf8("Incomplete class definition, expected name"sv)),((((*this).current())).span())));
+((*this).error((ByteString::from_utf8_without_validation("Incomplete class definition, expected name"sv)),((((*this).current())).span())));
 }
 
 if (((*this).eof())){
-((*this).error((ByteString::must_from_utf8("Incomplete class definition, expected generic parameters or super class or body"sv)),((((*this).current())).span())));
+((*this).error((ByteString::from_utf8_without_validation("Incomplete class definition, expected generic parameters or super class or body"sv)),((((*this).current())).span())));
 return parsed_class;
 }
 (((parsed_class).generic_parameters) = TRY((((*this).parse_generic_parameters()))));
@@ -7273,7 +7273,7 @@ if (((((*this).current())).__jakt_init_index() == 109 /* Implements */)){
 (((parsed_class).implements_list) = TRY((((*this).parse_trait_list()))));
 }
 if (((*this).eof())){
-((*this).error((ByteString::must_from_utf8("Incomplete class definition, expected super class or body"sv)),((((*this).current())).span())));
+((*this).error((ByteString::from_utf8_without_validation("Incomplete class definition, expected super class or body"sv)),((((*this).current())).span())));
 return parsed_class;
 }
 if (((((*this).current())).__jakt_init_index() == 5 /* Colon */)){
@@ -7282,7 +7282,7 @@ if (((((*this).current())).__jakt_init_index() == 5 /* Colon */)){
 }
 ((*this).skip_newlines());
 if (((*this).eof())){
-((*this).error((ByteString::must_from_utf8("Incomplete class definition, expected body"sv)),((((*this).current())).span())));
+((*this).error((ByteString::from_utf8_without_validation("Incomplete class definition, expected body"sv)),((((*this).current())).span())));
 return parsed_class;
 }
 JaktInternal::Tuple<JaktInternal::DynamicArray<parser::ParsedField>,JaktInternal::DynamicArray<parser::ParsedMethod>,JaktInternal::DynamicArray<parser::ParsedRecord>> const fields_methods_records_ = TRY((((*this).parse_struct_class_body(definition_linkage,parser::Visibility::Private(),true))));
@@ -7341,7 +7341,7 @@ if ((!(for_trailing_closure))){
 return JaktInternal::LoopBreak{};
 }
 if ((!(error))){
-((*this).error((ByteString::must_from_utf8("Expected parameter"sv)),((((*this).current())).span())));
+((*this).error((ByteString::from_utf8_without_validation("Expected parameter"sv)),((((*this).current())).span())));
 (error = true);
 }
 ((((*this).index)++));
@@ -7355,7 +7355,7 @@ if (for_trailing_closure){
 return JaktInternal::LoopBreak{};
 }
 if ((!(error))){
-((*this).error((ByteString::must_from_utf8("Expected parameter"sv)),((((*this).current())).span())));
+((*this).error((ByteString::from_utf8_without_validation("Expected parameter"sv)),((((*this).current())).span())));
 (error = true);
 }
 ((((*this).index)++));
@@ -7365,7 +7365,7 @@ return JaktInternal::ExplicitValue<void>();
 case 52 /* Comma */: {
 {
 if (((!(parameter_complete)) && (!(error)))){
-((*this).error((ByteString::must_from_utf8("Expected parameter"sv)),((((*this).current())).span())));
+((*this).error((ByteString::from_utf8_without_validation("Expected parameter"sv)),((((*this).current())).span())));
 (error = true);
 }
 ((((*this).index)++));
@@ -7378,7 +7378,7 @@ return JaktInternal::ExplicitValue<void>();
 case 55 /* Eol */: {
 {
 if (((!(parameter_complete)) && (!(error)))){
-((*this).error((ByteString::must_from_utf8("Expected parameter"sv)),((((*this).current())).span())));
+((*this).error((ByteString::from_utf8_without_validation("Expected parameter"sv)),((((*this).current())).span())));
 (error = true);
 }
 ((((*this).index)++));
@@ -7391,15 +7391,15 @@ return JaktInternal::ExplicitValue<void>();
 case 54 /* DotDot */: {
 {
 if (((result).has_varargs)){
-((*this).error((ByteString::must_from_utf8("Multiple varargs cannot be present in one parameter list"sv)),((((*this).current())).span())));
+((*this).error((ByteString::from_utf8_without_validation("Multiple varargs cannot be present in one parameter list"sv)),((((*this).current())).span())));
 (error = true);
 }
 if (current_param_is_mutable){
-((*this).error((ByteString::must_from_utf8("A variadic argument cannot be mutable"sv)),((((*this).current())).span())));
+((*this).error((ByteString::from_utf8_without_validation("A variadic argument cannot be mutable"sv)),((((*this).current())).span())));
 (error = true);
 }
 if ((!(current_param_requires_label))){
-((*this).error((ByteString::must_from_utf8("A variadic argument cannot be anonymous"sv)),((((*this).current())).span())));
+((*this).error((ByteString::from_utf8_without_validation("A variadic argument cannot be anonymous"sv)),((((*this).current())).span())));
 (error = true);
 }
 (((result).has_varargs) = true);
@@ -7413,19 +7413,19 @@ return JaktInternal::ExplicitValue<void>();
 case 60 /* Anon */: {
 {
 if (((result).has_varargs)){
-((*this).error((ByteString::must_from_utf8("A variadic argument may only appear at the end of a parameter list"sv)),((((*this).current())).span())));
+((*this).error((ByteString::from_utf8_without_validation("A variadic argument may only appear at the end of a parameter list"sv)),((((*this).current())).span())));
 (error = true);
 }
 if ((parameter_complete && (!(error)))){
-((*this).error((ByteString::must_from_utf8("‘anon’ must appear at start of parameter declaration, not the end"sv)),((((*this).current())).span())));
+((*this).error((ByteString::from_utf8_without_validation("‘anon’ must appear at start of parameter declaration, not the end"sv)),((((*this).current())).span())));
 (error = true);
 }
 if ((current_param_is_mutable && (!(error)))){
-((*this).error((ByteString::must_from_utf8("‘anon’ must appear before ‘mut’"sv)),((((*this).current())).span())));
+((*this).error((ByteString::from_utf8_without_validation("‘anon’ must appear before ‘mut’"sv)),((((*this).current())).span())));
 (error = true);
 }
 if (((!(current_param_requires_label)) && (!(error)))){
-((*this).error((ByteString::must_from_utf8("‘anon’ cannot appear multiple times in one parameter declaration"sv)),((((*this).current())).span())));
+((*this).error((ByteString::from_utf8_without_validation("‘anon’ cannot appear multiple times in one parameter declaration"sv)),((((*this).current())).span())));
 (error = true);
 }
 ((((*this).index)++));
@@ -7436,15 +7436,15 @@ return JaktInternal::ExplicitValue<void>();
 case 85 /* Mut */: {
 {
 if (((result).has_varargs)){
-((*this).error((ByteString::must_from_utf8("A variadic argument may only appear at the end of a parameter list"sv)),((((*this).current())).span())));
+((*this).error((ByteString::from_utf8_without_validation("A variadic argument may only appear at the end of a parameter list"sv)),((((*this).current())).span())));
 (error = true);
 }
 if ((parameter_complete && (!(error)))){
-((*this).error((ByteString::must_from_utf8("‘mut’ must appear at start of parameter declaration, not the end"sv)),((((*this).current())).span())));
+((*this).error((ByteString::from_utf8_without_validation("‘mut’ must appear at start of parameter declaration, not the end"sv)),((((*this).current())).span())));
 (error = true);
 }
 if ((current_param_is_mutable && (!(error)))){
-((*this).error((ByteString::must_from_utf8("‘mut’ cannot appear multiple times in one parameter declaration"sv)),((((*this).current())).span())));
+((*this).error((ByteString::from_utf8_without_validation("‘mut’ cannot appear multiple times in one parameter declaration"sv)),((((*this).current())).span())));
 (error = true);
 }
 ((((*this).index)++));
@@ -7455,10 +7455,10 @@ return JaktInternal::ExplicitValue<void>();
 case 98 /* This */: {
 {
 if (((result).has_varargs)){
-((*this).error((ByteString::must_from_utf8("A variadic argument may only appear at the end of a parameter list"sv)),((((*this).current())).span())));
+((*this).error((ByteString::from_utf8_without_validation("A variadic argument may only appear at the end of a parameter list"sv)),((((*this).current())).span())));
 (error = true);
 }
-((((result).parameters)).push(parser::ParsedParameter(false,parser::ParsedVariable((ByteString::must_from_utf8("this"sv)),parser::ParsedType::Empty(JaktInternal::OptionalNone()),current_param_is_mutable,((((*this).current())).span())),JaktInternal::OptionalNone(),((((*this).current())).span()))));
+((((result).parameters)).push(parser::ParsedParameter(false,parser::ParsedVariable((ByteString::from_utf8_without_validation("this"sv)),parser::ParsedType::Empty(JaktInternal::OptionalNone()),current_param_is_mutable,((((*this).current())).span())),JaktInternal::OptionalNone(),((((*this).current())).span()))));
 ((((*this).index)++));
 (parameter_complete = true);
 }
@@ -7469,7 +7469,7 @@ auto&& __jakt_match_value = __jakt_match_variant.as.Identifier;ByteString const&
 utility::Span const& span = __jakt_match_value.span;
 {
 if (((result).has_varargs)){
-((*this).error((ByteString::must_from_utf8("A variadic argument may only appear at the end of a parameter list"sv)),((((*this).current())).span())));
+((*this).error((ByteString::from_utf8_without_validation("A variadic argument may only appear at the end of a parameter list"sv)),((((*this).current())).span())));
 (error = true);
 }
 parser::ParsedVarDecl const var_decl = TRY((((*this).parse_variable_declaration(current_param_is_mutable))));
@@ -7486,7 +7486,7 @@ return JaktInternal::ExplicitValue<void>();
 default: {
 {
 if ((!(error))){
-((*this).error((ByteString::must_from_utf8("Expected parameter"sv)),((((*this).current())).span())));
+((*this).error((ByteString::from_utf8_without_validation("Expected parameter"sv)),((((*this).current())).span())));
 (error = true);
 }
 ((((*this).index)++));
@@ -7511,20 +7511,20 @@ return result;
 
 ErrorOr<parser::ParsedFunction> parser::Parser::parse_function(parser::FunctionLinkage const linkage,parser::Visibility const visibility,bool const is_comptime,bool const is_destructor,bool const is_unsafe,bool const allow_missing_body) {
 {
-parser::ParsedFunction parsed_function = parser::ParsedFunction(((((*this).next_function_id)++)),(ByteString::must_from_utf8(""sv)),((*this).empty_span()),visibility,DynamicArray<parser::ParsedParameter>::create_with({}),DynamicArray<parser::ParsedGenericParameter>::create_with({}),parser::ParsedBlock(DynamicArray<NonnullRefPtr<typename parser::ParsedStatement>>::create_with({})),parser::ParsedType::Empty(JaktInternal::OptionalNone()),((*this).span(static_cast<size_t>(0ULL),static_cast<size_t>(0ULL))),false,parser::FunctionType::Normal(),linkage,false,is_comptime,false,is_unsafe,false,false,JaktInternal::OptionalNone(),JaktInternal::OptionalNone(),JaktInternal::OptionalNone(),parser::InlineState::Default());
+parser::ParsedFunction parsed_function = parser::ParsedFunction(((((*this).next_function_id)++)),(ByteString::from_utf8_without_validation(""sv)),((*this).empty_span()),visibility,DynamicArray<parser::ParsedParameter>::create_with({}),DynamicArray<parser::ParsedGenericParameter>::create_with({}),parser::ParsedBlock(DynamicArray<NonnullRefPtr<typename parser::ParsedStatement>>::create_with({})),parser::ParsedType::Empty(JaktInternal::OptionalNone()),((*this).span(static_cast<size_t>(0ULL),static_cast<size_t>(0ULL))),false,parser::FunctionType::Normal(),linkage,false,is_comptime,false,is_unsafe,false,false,JaktInternal::OptionalNone(),JaktInternal::OptionalNone(),JaktInternal::OptionalNone(),parser::InlineState::Default());
 if (is_destructor){
 (((parsed_function).type) = parser::FunctionType::Destructor());
-((((parsed_function).params)).push(parser::ParsedParameter(false,parser::ParsedVariable((ByteString::must_from_utf8("this"sv)),parser::ParsedType::Empty(JaktInternal::OptionalNone()),true,((((*this).current())).span())),JaktInternal::OptionalNone(),((((*this).current())).span()))));
+((((parsed_function).params)).push(parser::ParsedParameter(false,parser::ParsedVariable((ByteString::from_utf8_without_validation("this"sv)),parser::ParsedType::Empty(JaktInternal::OptionalNone()),true,((((*this).current())).span())),JaktInternal::OptionalNone(),((((*this).current())).span()))));
 }
 if ((!(is_destructor))){
 ((((*this).index)++));
 }
 if (((*this).eof())){
-((*this).error((ByteString::must_from_utf8("Incomplete function definition"sv)),((((*this).current())).span())));
+((*this).error((ByteString::from_utf8_without_validation("Incomplete function definition"sv)),((((*this).current())).span())));
 return parsed_function;
 }
 if (is_destructor){
-(((parsed_function).name) = (ByteString::must_from_utf8("~"sv)));
+(((parsed_function).name) = (ByteString::from_utf8_without_validation("~"sv)));
 (((parsed_function).name_span) = ((((*this).previous())).span()));
 }
 else {
@@ -7534,7 +7534,7 @@ ByteString const name = (((*this).current())).as.Identifier.name;
 (((parsed_function).name_span) = ((((*this).current())).span()));
 }
 else {
-((*this).error((ByteString::must_from_utf8("Incomplete function definition"sv)),((((*this).current())).span())));
+((*this).error((ByteString::from_utf8_without_validation("Incomplete function definition"sv)),((((*this).current())).span())));
 return parsed_function;
 }
 
@@ -7545,18 +7545,18 @@ if ((!(is_destructor))){
 (((parsed_function).generic_parameters) = TRY((((*this).parse_generic_parameters()))));
 }
 if (((*this).eof())){
-((*this).error((ByteString::must_from_utf8("Incomplete function"sv)),((((*this).current())).span())));
+((*this).error((ByteString::from_utf8_without_validation("Incomplete function"sv)),((((*this).current())).span())));
 }
 if ((!(is_destructor))){
 parser::ParsedFunctionParameters const fn_parameters = TRY((((*this).parse_function_parameters(false))));
 (((parsed_function).params) = ((fn_parameters).parameters));
 (((parsed_function).has_varargs) = ((fn_parameters).has_varargs));
 }
-(((parsed_function).is_jakt_main) = ((((parsed_function).name)) == ((ByteString::must_from_utf8("main"sv)))));
+(((parsed_function).is_jakt_main) = ((((parsed_function).name)) == ((ByteString::from_utf8_without_validation("main"sv)))));
 bool can_throw = ((parsed_function).is_jakt_main);
 if (((((*this).current())).__jakt_init_index() == 100 /* Throws */)){
 if (is_destructor){
-((*this).error((ByteString::must_from_utf8("Destructor cannot throw"sv)),((((*this).current())).span())));
+((*this).error((ByteString::from_utf8_without_validation("Destructor cannot throw"sv)),((((*this).current())).span())));
 }
 else {
 (can_throw = true);
@@ -7573,7 +7573,7 @@ utility::Span const start = ((((*this).current())).span());
 }
 else {
 if (((parsed_function).is_jakt_main)){
-(((parsed_function).return_type) = parser::ParsedType::Name(JaktInternal::OptionalNone(),(ByteString::must_from_utf8("c_int"sv)),((((*this).previous())).span())));
+(((parsed_function).return_type) = parser::ParsedType::Name(JaktInternal::OptionalNone(),(ByteString::from_utf8_without_validation("c_int"sv)),((((*this).previous())).span())));
 }
 (((parsed_function).return_type_span) = ((((*this).previous())).span()));
 }
@@ -7616,7 +7616,7 @@ ErrorOr<parser::ParsedField> parser::Parser::parse_field(parser::Visibility cons
 {
 parser::ParsedVarDecl const parsed_variable_declaration = TRY((((*this).parse_variable_declaration(true))));
 if (((((parsed_variable_declaration).parsed_type))->__jakt_init_index() == 15 /* Empty */)){
-((*this).error((ByteString::must_from_utf8("Field missing type"sv)),((parsed_variable_declaration).span)));
+((*this).error((ByteString::from_utf8_without_validation("Field missing type"sv)),((parsed_variable_declaration).span)));
 }
 JaktInternal::Optional<NonnullRefPtr<typename parser::ParsedExpression>> default_value = JaktInternal::OptionalNone();
 if (((((*this).peek(static_cast<size_t>(0ULL)))).__jakt_init_index() == 16 /* Equal */)){
@@ -7670,7 +7670,7 @@ default: {
 size_t index_before = ((*this).index);
 ((params).push(TRY((((*this).parse_typename())))));
 if (((((*this).index)) == (index_before))){
-((*this).error((ByteString::must_from_utf8("Expected type parameter"sv)),((((*this).current())).span())));
+((*this).error((ByteString::from_utf8_without_validation("Expected type parameter"sv)),((((*this).current())).span())));
 return JaktInternal::LoopBreak{};
 }
 if (((((*this).current())).__jakt_init_index() == 52 /* Comma */)){
@@ -7692,7 +7692,7 @@ return JaktInternal::ExplicitValue<void>();
 });
 }
 if ((!(saw_ending_bracket))){
-((*this).error((ByteString::must_from_utf8("Expected `>` after type parameters"sv)),((((*this).current())).span())));
+((*this).error((ByteString::from_utf8_without_validation("Expected `>` after type parameters"sv)),((((*this).current())).span())));
 }
 }
 return params;
@@ -7718,7 +7718,7 @@ ByteString const name = (((*this).current())).as.Identifier.name;
 (result = parser::ParsedType::DependentType(JaktInternal::OptionalNone(),result,name,parser::merge_spans(((base)->span()),((((*this).current())).span()))));
 }
 else {
-((*this).error((ByteString::must_from_utf8("Expected identifier after `::`"sv)),((((*this).current())).span())));
+((*this).error((ByteString::from_utf8_without_validation("Expected identifier after `::`"sv)),((((*this).current())).span())));
 (done = true);
 }
 
@@ -7768,7 +7768,7 @@ if (((((*this).current())).__jakt_init_index() == 85 /* Mut */)){
 }
 if (((((*this).current())).__jakt_init_index() == 3 /* Identifier */)){
 ByteString const name = (((*this).current())).as.Identifier.name;
-if (((name) == ((ByteString::must_from_utf8("const"sv))))){
+if (((name) == ((ByteString::from_utf8_without_validation("const"sv))))){
 (((qualifiers).is_immutable) = true);
 ((((*this).index)++));
 }
@@ -7875,7 +7875,7 @@ if (((((*this).previous())).__jakt_init_index() == 6 /* ColonColon */)){
 ((((*this).index)++));
 }
 else {
-((*this).error((ByteString::must_from_utf8("Expected ‘::’ here"sv)),utility::Span(((span).file_id),((span).start),((span).start))));
+((*this).error((ByteString::from_utf8_without_validation("Expected ‘::’ here"sv)),utility::Span(((span).file_id),((span).start),((span).start))));
 return JaktInternal::LoopBreak{};
 }
 
@@ -7888,7 +7888,7 @@ if (((((*this).previous())).__jakt_init_index() == 3 /* Identifier */)){
 ((((*this).index)++));
 }
 else {
-((*this).error((ByteString::must_from_utf8("Expected name after"sv)),span));
+((*this).error((ByteString::from_utf8_without_validation("Expected name after"sv)),span));
 return JaktInternal::LoopBreak{};
 }
 
@@ -7928,7 +7928,7 @@ utility::Span const start = ((((*this).current())).span());
 ((((*this).index)++));
 parser::ParsedFunctionParameters const fn_parameters = TRY((((*this).parse_function_parameters(false))));
 if (((fn_parameters).has_varargs)){
-((*this).error((ByteString::must_from_utf8("Function type cannot have variadic arguments"sv)),((((*this).current())).span())));
+((*this).error((ByteString::from_utf8_without_validation("Function type cannot have variadic arguments"sv)),((((*this).current())).span())));
 }
 bool const can_throw = ((((*this).current())).__jakt_init_index() == 100 /* Throws */);
 if (can_throw){
@@ -7940,7 +7940,7 @@ if (((((*this).current())).__jakt_init_index() == 58 /* Arrow */)){
 (return_type = TRY((((*this).parse_typename()))));
 }
 else {
-((*this).error((ByteString::must_from_utf8("Expected '->'"sv)),((((*this).current())).span())));
+((*this).error((ByteString::from_utf8_without_validation("Expected '->'"sv)),((((*this).current())).span())));
 }
 
 __jakt_var_31 = parser::ParsedType::Function(qualifiers,((fn_parameters).parameters),can_throw,return_type,parser::merge_spans(start,((return_type)->span()))); goto __jakt_label_26;
@@ -7950,7 +7950,7 @@ __jakt_label_26:; __jakt_var_31.release_value(); }));
 };/*case end*/
 default: {
 return JaktInternal::ExplicitValue(({ Optional<NonnullRefPtr<typename parser::ParsedType>> __jakt_var_32; {
-((*this).error((ByteString::must_from_utf8("Expected type name"sv)),((((*this).current())).span())));
+((*this).error((ByteString::from_utf8_without_validation("Expected type name"sv)),((((*this).current())).span())));
 __jakt_var_32 = parser::ParsedType::Empty(qualifiers); goto __jakt_label_27;
 
 }
@@ -7997,7 +7997,7 @@ return JaktInternal::ExplicitValue<void>();
 };/*case end*/
 default: {
 {
-((*this).error((ByteString::must_from_utf8("Expected close of destructuring assignment block"sv)),((((*this).current())).span())));
+((*this).error((ByteString::from_utf8_without_validation("Expected close of destructuring assignment block"sv)),((((*this).current())).span())));
 (var_declarations = DynamicArray<parser::ParsedVarDecl>::create_with({}));
 return JaktInternal::LoopBreak{};
 }
@@ -8034,12 +8034,12 @@ return parser::ParsedVarDecl(name,parser::ParsedType::Empty(JaktInternal::Option
 
 NonnullRefPtr<typename parser::ParsedType> const parsed_type = TRY((((*this).parse_typename())));
 if ((is_mutable && (((parsed_type)->__jakt_init_index() == 8 /* Reference */) || ((parsed_type)->__jakt_init_index() == 9 /* MutableReference */)))){
-((*this).error((ByteString::must_from_utf8("Reference parameter can not be mutable"sv)),span));
+((*this).error((ByteString::from_utf8_without_validation("Reference parameter can not be mutable"sv)),span));
 }
 return parser::ParsedVarDecl(name,parsed_type,is_mutable,JaktInternal::OptionalNone(),span,JaktInternal::OptionalNone());
 }
 else {
-return parser::ParsedVarDecl((ByteString::must_from_utf8(""sv)),parser::ParsedType::Empty(JaktInternal::OptionalNone()),false,JaktInternal::OptionalNone(),span,JaktInternal::OptionalNone());
+return parser::ParsedVarDecl((ByteString::from_utf8_without_validation(""sv)),parser::ParsedType::Empty(JaktInternal::OptionalNone()),false,JaktInternal::OptionalNone(),span,JaktInternal::OptionalNone());
 }
 
 }
@@ -8089,12 +8089,12 @@ if (((((*this).current())).__jakt_init_index() == 12 /* RSquare */)){
 ((((*this).index)++));
 }
 else {
-((*this).error((ByteString::must_from_utf8("Expected ']'"sv)),((((*this).current())).span())));
+((*this).error((ByteString::from_utf8_without_validation("Expected ']'"sv)),((((*this).current())).span())));
 }
 
 return parser::ParsedType::Dictionary(qualifiers,inner,value,parser::merge_spans(start,((((*this).current())).span())));
 }
-((*this).error((ByteString::must_from_utf8("Expected shorthand type"sv)),((((*this).current())).span())));
+((*this).error((ByteString::from_utf8_without_validation("Expected shorthand type"sv)),((((*this).current())).span())));
 return parser::ParsedType::Empty(qualifiers);
 }
 }
@@ -8110,7 +8110,7 @@ if (((((*this).current())).__jakt_init_index() == 10 /* RCurly */)){
 ((((*this).index)++));
 return parser::ParsedType::Set(qualifiers,inner,parser::merge_spans(start,((((*this).current())).span())));
 }
-((*this).error((ByteString::must_from_utf8("Expected '}'"sv)),((((*this).current())).span())));
+((*this).error((ByteString::from_utf8_without_validation("Expected '}'"sv)),((((*this).current())).span())));
 return parser::ParsedType::Empty(qualifiers);
 }
 }
@@ -8136,7 +8136,7 @@ break;
 }
 ((types).push(type));
 }
-((*this).error((ByteString::must_from_utf8("Expected ‘)’"sv)),((((*this).current())).span())));
+((*this).error((ByteString::from_utf8_without_validation("Expected ‘)’"sv)),((((*this).current())).span())));
 return parser::ParsedType::Empty(qualifiers);
 }
 }
@@ -8146,7 +8146,7 @@ ErrorOr<parser::ParsedBlock> parser::Parser::parse_block() {
 utility::Span const start = ((((*this).current())).span());
 parser::ParsedBlock block = parser::ParsedBlock(DynamicArray<NonnullRefPtr<typename parser::ParsedStatement>>::create_with({}));
 if (((*this).eof())){
-((*this).error((ByteString::must_from_utf8("Incomplete block"sv)),start));
+((*this).error((ByteString::from_utf8_without_validation("Incomplete block"sv)),start));
 return block;
 }
 ((*this).skip_newlines());
@@ -8154,7 +8154,7 @@ if (((((*this).current())).__jakt_init_index() == 9 /* LCurly */)){
 ((((*this).index)++));
 }
 else {
-((*this).error((ByteString::must_from_utf8("Expected '{'"sv)),start));
+((*this).error((ByteString::from_utf8_without_validation("Expected '{'"sv)),start));
 }
 
 while ((!(((*this).eof())))){
@@ -8199,7 +8199,7 @@ return JaktInternal::ExplicitValue<void>();
     _jakt_value.release_value();
 });
 }
-((*this).error((ByteString::must_from_utf8("Expected complete block"sv)),((((*this).current())).span())));
+((*this).error((ByteString::from_utf8_without_validation("Expected complete block"sv)),((((*this).current())).span())));
 return block;
 }
 }
@@ -8310,7 +8310,7 @@ return JaktInternal::ExplicitValue(({ Optional<NonnullRefPtr<typename parser::Pa
 ((((*this).index)++));
 NonnullRefPtr<typename parser::ParsedExpression> const expr = TRY((((*this).parse_expression(false,false))));
 if ((!(inside_block))){
-((*this).error((ByteString::must_from_utf8("‘yield’ can only be used inside a block"sv)),parser::merge_spans(start,((expr)->span()))));
+((*this).error((ByteString::from_utf8_without_validation("‘yield’ can only be used inside a block"sv)),parser::merge_spans(start,((expr)->span()))));
 }
 __jakt_var_42 = parser::ParsedStatement::Yield(expr,parser::merge_spans(start,((((*this).previous())).span()))); goto __jakt_label_37;
 
@@ -8353,8 +8353,8 @@ bool const is_mutable = ((((*this).current())).__jakt_init_index() == 85 /* Mut 
 ((((*this).index)++));
 JaktInternal::DynamicArray<parser::ParsedVarDecl> vars = DynamicArray<parser::ParsedVarDecl>::create_with({});
 bool is_destructuring_assingment = false;
-ByteString tuple_var_name = (ByteString::must_from_utf8(""sv));
-parser::ParsedVarDecl tuple_var_decl = parser::ParsedVarDecl((ByteString::must_from_utf8(""sv)),parser::ParsedType::Empty(JaktInternal::OptionalNone()),is_mutable,JaktInternal::OptionalNone(),((((*this).current())).span()),JaktInternal::OptionalNone());
+ByteString tuple_var_name = (ByteString::from_utf8_without_validation(""sv));
+parser::ParsedVarDecl tuple_var_decl = parser::ParsedVarDecl((ByteString::from_utf8_without_validation(""sv)),parser::ParsedType::Empty(JaktInternal::OptionalNone()),is_mutable,JaktInternal::OptionalNone(),((((*this).current())).span()),JaktInternal::OptionalNone());
 if (((((*this).current())).__jakt_init_index() == 7 /* LParen */)){
 (vars = ((TRY((((*this).parse_destructuring_assignment(is_mutable))))).var_decls));
 {
@@ -8377,7 +8377,7 @@ parser::ParsedVarDecl var = (_magic_value.value());
 (self = ((self) + (rhs)));
 }
 }
-(tuple_var_name,(ByteString::must_from_utf8("_"sv)));
+(tuple_var_name,(ByteString::from_utf8_without_validation("_"sv)));
 }
 
 }
@@ -8404,7 +8404,7 @@ __jakt_label_40:; __jakt_var_45.release_value(); }));
 };/*case end*/
 default: {
 return JaktInternal::ExplicitValue(({ Optional<NonnullRefPtr<typename parser::ParsedExpression>> __jakt_var_46; {
-((*this).error((ByteString::must_from_utf8("Expected initializer"sv)),((((*this).current())).span())));
+((*this).error((ByteString::from_utf8_without_validation("Expected initializer"sv)),((((*this).current())).span())));
 __jakt_var_46 = parser::ParsedExpression::Garbage(((((*this).current())).span())); goto __jakt_label_41;
 
 }
@@ -8433,8 +8433,8 @@ bool const is_mutable = ((((*this).current())).__jakt_init_index() == 85 /* Mut 
 ((((*this).index)++));
 JaktInternal::DynamicArray<parser::ParsedVarDecl> vars = DynamicArray<parser::ParsedVarDecl>::create_with({});
 bool is_destructuring_assingment = false;
-ByteString tuple_var_name = (ByteString::must_from_utf8(""sv));
-parser::ParsedVarDecl tuple_var_decl = parser::ParsedVarDecl((ByteString::must_from_utf8(""sv)),parser::ParsedType::Empty(JaktInternal::OptionalNone()),is_mutable,JaktInternal::OptionalNone(),((((*this).current())).span()),JaktInternal::OptionalNone());
+ByteString tuple_var_name = (ByteString::from_utf8_without_validation(""sv));
+parser::ParsedVarDecl tuple_var_decl = parser::ParsedVarDecl((ByteString::from_utf8_without_validation(""sv)),parser::ParsedType::Empty(JaktInternal::OptionalNone()),is_mutable,JaktInternal::OptionalNone(),((((*this).current())).span()),JaktInternal::OptionalNone());
 if (((((*this).current())).__jakt_init_index() == 7 /* LParen */)){
 (vars = ((TRY((((*this).parse_destructuring_assignment(is_mutable))))).var_decls));
 {
@@ -8457,7 +8457,7 @@ parser::ParsedVarDecl var = (_magic_value.value());
 (self = ((self) + (rhs)));
 }
 }
-(tuple_var_name,(ByteString::must_from_utf8("_"sv)));
+(tuple_var_name,(ByteString::from_utf8_without_validation("_"sv)));
 }
 
 }
@@ -8484,7 +8484,7 @@ __jakt_label_43:; __jakt_var_48.release_value(); }));
 };/*case end*/
 default: {
 return JaktInternal::ExplicitValue(({ Optional<NonnullRefPtr<typename parser::ParsedExpression>> __jakt_var_49; {
-((*this).error((ByteString::must_from_utf8("Expected initializer"sv)),((((*this).current())).span())));
+((*this).error((ByteString::from_utf8_without_validation("Expected initializer"sv)),((((*this).current())).span())));
 __jakt_var_49 = parser::ParsedExpression::Garbage(((((*this).current())).span())); goto __jakt_label_44;
 
 }
@@ -8554,7 +8554,7 @@ if (((((*this).current())).__jakt_init_index() == 70 /* Else */)){
 ((((*this).index)++));
 }
 else {
-((*this).error((ByteString::must_from_utf8("Expected `else` keyword"sv)),((((*this).current())).span())));
+((*this).error((ByteString::from_utf8_without_validation("Expected `else` keyword"sv)),((((*this).current())).span())));
 }
 
 parser::ParsedBlock const else_block = TRY((((*this).parse_block())));
@@ -8608,7 +8608,7 @@ ErrorOr<NonnullRefPtr<typename parser::ParsedExpression>> parser::Parser::parse_
 {
 utility::Span const start_span = ((((*this).current())).span());
 NonnullRefPtr<typename parser::ParsedStatement> const stmt = TRY((((*this).parse_statement(false))));
-ByteString error_name = (ByteString::must_from_utf8(""sv));
+ByteString error_name = (ByteString::from_utf8_without_validation(""sv));
 utility::Span error_span = ((((*this).current())).span());
 if (((((*this).current())).__jakt_init_index() == 64 /* Catch */)){
 ((((*this).index)++));
@@ -8620,7 +8620,7 @@ ByteString const name = (((*this).current())).as.Identifier.name;
 }
 }
 else {
-((*this).error((ByteString::must_from_utf8("Expected ‘catch’"sv)),((((*this).current())).span())));
+((*this).error((ByteString::from_utf8_without_validation("Expected ‘catch’"sv)),((((*this).current())).span())));
 }
 
 parser::ParsedBlock const catch_block = TRY((((*this).parse_block())));
@@ -8632,7 +8632,7 @@ ErrorOr<NonnullRefPtr<typename parser::ParsedStatement>> parser::Parser::parse_f
 {
 utility::Span const start_span = ((((*this).current())).span());
 ((((*this).index)++));
-ByteString iterator_name = (ByteString::must_from_utf8(""sv));
+ByteString iterator_name = (ByteString::from_utf8_without_validation(""sv));
 JaktInternal::DynamicArray<parser::ParsedVarDecl> destructured_var_decls = DynamicArray<parser::ParsedVarDecl>::create_with({});
 utility::Span name_span = ((((*this).current())).span());
 ({
@@ -8651,7 +8651,7 @@ case 7 /* LParen */: {
 {
 parser::ParsedVarDeclTuple const destructured_assignment = TRY((((*this).parse_destructuring_assignment(false))));
 (destructured_var_decls = ((destructured_assignment).var_decls));
-ByteString tuple_var_name = (ByteString::must_from_utf8(""sv));
+ByteString tuple_var_name = (ByteString::from_utf8_without_validation(""sv));
 {
 JaktInternal::ArrayIterator<parser::ParsedVarDecl> _magic = ((destructured_var_decls).iterator());
 for (;;){
@@ -8672,7 +8672,7 @@ parser::ParsedVarDecl var = (_magic_value.value());
 (self = ((self) + (rhs)));
 }
 }
-(tuple_var_name,(ByteString::must_from_utf8("__"sv)));
+(tuple_var_name,(ByteString::from_utf8_without_validation("__"sv)));
 }
 
 }
@@ -8685,7 +8685,7 @@ return JaktInternal::ExplicitValue<void>();
 };/*case end*/
 default: {
 {
-((*this).error((ByteString::must_from_utf8("Expected iterator name or destructuring pattern"sv)),((((*this).current())).span())));
+((*this).error((ByteString::from_utf8_without_validation("Expected iterator name or destructuring pattern"sv)),((((*this).current())).span())));
 return parser::ParsedStatement::Garbage(parser::merge_spans(start_span,((((*this).current())).span())));
 }
 return JaktInternal::ExplicitValue<void>();
@@ -8701,7 +8701,7 @@ if (((((*this).current())).__jakt_init_index() == 80 /* In */)){
 ((((*this).index)++));
 }
 else {
-((*this).error((ByteString::must_from_utf8("Expected ‘in’"sv)),((((*this).current())).span())));
+((*this).error((ByteString::from_utf8_without_validation("Expected ‘in’"sv)),((((*this).current())).span())));
 return parser::ParsedStatement::Garbage(parser::merge_spans(start_span,((((*this).current())).span())));
 }
 
@@ -8723,7 +8723,7 @@ return (infallible_enum_cast<jakt__prelude__operators::Ordering>((JaktInternal::
 }
 (((destructured_var_decls).size()),static_cast<size_t>(0ULL))){
 (is_destructuring = true);
-ByteString tuple_var_name = (ByteString::must_from_utf8("jakt__"sv));
+ByteString tuple_var_name = (ByteString::from_utf8_without_validation("jakt__"sv));
 [](ByteString& self, ByteString rhs) -> void {
 {
 (self = ((self) + (rhs)));
@@ -8746,7 +8746,7 @@ return parser::ParsedStatement::For(iterator_name,name_span,is_destructuring,ran
 ErrorOr<NonnullRefPtr<typename parser::ParsedStatement>> parser::Parser::parse_if_statement() {
 {
 if ((!(((((*this).current())).__jakt_init_index() == 77 /* If */)))){
-((*this).error((ByteString::must_from_utf8("Expected ‘if’ statement"sv)),((((*this).current())).span())));
+((*this).error((ByteString::from_utf8_without_validation("Expected ‘if’ statement"sv)),((((*this).current())).span())));
 return parser::ParsedStatement::Garbage(((((*this).current())).span()));
 }
 utility::Span const start_span = ((((*this).current())).span());
@@ -8775,7 +8775,7 @@ case 9 /* LCurly */: {
 {
 parser::ParsedBlock const block = TRY((((*this).parse_block())));
 if (((then_block).equals(block))){
-((*this).error((ByteString::must_from_utf8("if and else have identical blocks"sv)),((((*this).current())).span())));
+((*this).error((ByteString::from_utf8_without_validation("if and else have identical blocks"sv)),((((*this).current())).span())));
 }
 (else_statement = parser::ParsedStatement::Block(block,parser::merge_spans(start_span,((((*this).previous())).span()))));
 }
@@ -8783,7 +8783,7 @@ return JaktInternal::ExplicitValue<void>();
 };/*case end*/
 default: {
 {
-((*this).error((ByteString::must_from_utf8("‘else’ missing ‘if’ or block"sv)),((((*this).previous())).span())));
+((*this).error((ByteString::from_utf8_without_validation("‘else’ missing ‘if’ or block"sv)),((((*this).previous())).span())));
 }
 return JaktInternal::ExplicitValue<void>();
 };/*case end*/
@@ -8880,7 +8880,7 @@ return JaktInternal::ExplicitValue<void>();
 };/*case end*/
 default: {
 {
-((((*this).compiler))->panic((ByteString::must_from_utf8("operator is not an operator"sv))));
+((((*this).compiler))->panic((ByteString::from_utf8_without_validation("operator is not an operator"sv))));
 }
 return JaktInternal::ExplicitValue<void>();
 };/*case end*/
@@ -8929,7 +8929,7 @@ return JaktInternal::ExplicitValue<void>();
 };/*case end*/
 default: {
 {
-((((*this).compiler))->panic((ByteString::must_from_utf8("operator is not an operator"sv))));
+((((*this).compiler))->panic((ByteString::from_utf8_without_validation("operator is not an operator"sv))));
 }
 return JaktInternal::ExplicitValue<void>();
 };/*case end*/
@@ -8958,7 +8958,7 @@ switch(__jakt_match_variant.__jakt_init_index()) {
 case 53 /* Dot */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Dot;utility::Span const& span = __jakt_match_value.value;
 return JaktInternal::ExplicitValue(({ Optional<NonnullRefPtr<typename parser::ParsedExpression>> __jakt_var_52; {
-__jakt_var_52 = parser::ParsedExpression::Var((ByteString::must_from_utf8("this"sv)),span); goto __jakt_label_47;
+__jakt_var_52 = parser::ParsedExpression::Var((ByteString::from_utf8_without_validation("this"sv)),span); goto __jakt_label_47;
 
 }
 __jakt_label_47:; __jakt_var_52.release_value(); }));
@@ -9056,7 +9056,7 @@ case 98 /* This */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.This;utility::Span const& span = __jakt_match_value.value;
 return JaktInternal::ExplicitValue(({ Optional<NonnullRefPtr<typename parser::ParsedExpression>> __jakt_var_59; {
 ((((*this).index)++));
-__jakt_var_59 = parser::ParsedExpression::Var((ByteString::must_from_utf8("this"sv)),span); goto __jakt_label_54;
+__jakt_var_59 = parser::ParsedExpression::Var((ByteString::from_utf8_without_validation("this"sv)),span); goto __jakt_label_54;
 
 }
 __jakt_label_54:; __jakt_var_59.release_value(); }));
@@ -9114,7 +9114,7 @@ auto&& __jakt_match_value = __jakt_match_variant.as.Identifier;ByteString const&
 utility::Span const& span = __jakt_match_value.span;
 return JaktInternal::ExplicitValue(({ Optional<NonnullRefPtr<typename parser::ParsedExpression>> __jakt_var_64; {
 if (((((*this).peek(static_cast<size_t>(1ULL)))).__jakt_init_index() == 7 /* LParen */)){
-if (((name) == ((ByteString::must_from_utf8("Some"sv))))){
+if (((name) == ((ByteString::from_utf8_without_validation("Some"sv))))){
 ((((*this).index)++));
 NonnullRefPtr<typename parser::ParsedExpression> const expr = TRY((((*this).parse_expression(false,false))));
 return parser::ParsedExpression::OptionalSome(expr,span);
@@ -9130,7 +9130,7 @@ if ((!(((call).has_value())))){
 return ({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<NonnullRefPtr<typename parser::ParsedExpression>,ErrorOr<NonnullRefPtr<typename parser::ParsedExpression>>>{
 auto __jakt_enum_value = (name);
-if (__jakt_enum_value == (ByteString::must_from_utf8("None"sv))) {
+if (__jakt_enum_value == (ByteString::from_utf8_without_validation("None"sv))) {
 return JaktInternal::ExplicitValue(parser::ParsedExpression::OptionalNone(span));
 }
 else {
@@ -9145,7 +9145,7 @@ return JaktInternal::ExplicitValue(parser::ParsedExpression::Var(name,span));
 return parser::ParsedExpression::Call((call.value()),span);
 }
 ((((*this).index)++));
-if (((name) == ((ByteString::must_from_utf8("None"sv))))){
+if (((name) == ((ByteString::from_utf8_without_validation("None"sv))))){
 return parser::ParsedExpression::OptionalNone(span);
 }
 __jakt_var_64 = parser::ParsedExpression::Var(name,span); goto __jakt_label_59;
@@ -9220,7 +9220,7 @@ return JaktInternal::ExplicitValue<void>();
 });
 }
 if (((*this).eof())){
-((*this).error((ByteString::must_from_utf8("Expected ')'"sv)),((((*this).current())).span())));
+((*this).error((ByteString::from_utf8_without_validation("Expected ')'"sv)),((((*this).current())).span())));
 }
 (expr = parser::ParsedExpression::JaktTuple(tuple_exprs,parser::merge_spans(start_span,end_span)));
 }
@@ -9228,7 +9228,7 @@ return JaktInternal::ExplicitValue<void>();
 };/*case end*/
 default: {
 {
-((*this).error((ByteString::must_from_utf8("Expected ')'"sv)),((((*this).current())).span())));
+((*this).error((ByteString::from_utf8_without_validation("Expected ')'"sv)),((((*this).current())).span())));
 }
 return JaktInternal::ExplicitValue<void>();
 };/*case end*/
@@ -9262,7 +9262,7 @@ return JaktInternal::ExplicitValue(parser::UnaryOperator::Negate());
 };/*case end*/
 default: {
 {
-((((*this).compiler))->panic((ByteString::must_from_utf8("unreachable"sv))));
+((((*this).compiler))->panic((ByteString::from_utf8_without_validation("unreachable"sv))));
 }
 };/*case end*/
 }/*switch end*/
@@ -9299,7 +9299,7 @@ return JaktInternal::ExplicitValue(parser::UnaryOperator::Negate());
 };/*case end*/
 default: {
 {
-((((*this).compiler))->panic((ByteString::must_from_utf8("unreachable"sv))));
+((((*this).compiler))->panic((ByteString::from_utf8_without_validation("unreachable"sv))));
 }
 };/*case end*/
 }/*switch end*/
@@ -9336,7 +9336,7 @@ return JaktInternal::ExplicitValue(parser::UnaryOperator::Negate());
 };/*case end*/
 default: {
 {
-((((*this).compiler))->panic((ByteString::must_from_utf8("unreachable"sv))));
+((((*this).compiler))->panic((ByteString::from_utf8_without_validation("unreachable"sv))));
 }
 };/*case end*/
 }/*switch end*/
@@ -9395,7 +9395,7 @@ default: {
 return JaktInternal::ExplicitValue(({ Optional<NonnullRefPtr<typename parser::ParsedExpression>> __jakt_var_72; {
 utility::Span const span = ((((*this).current())).span());
 ((((*this).index)++));
-((*this).error((ByteString::must_from_utf8("Unsupported expression"sv)),span));
+((*this).error((ByteString::from_utf8_without_validation("Unsupported expression"sv)),span));
 __jakt_var_72 = parser::ParsedExpression::Garbage(span); goto __jakt_label_67;
 
 }
@@ -9940,7 +9940,7 @@ return JaktInternal::ExplicitValue<void>();
 };/*case end*/
 case 98 /* This */: {
 {
-((captures).push(parser::ParsedCapture::ByValue((ByteString::must_from_utf8("this"sv)),((((*this).current())).span()))));
+((captures).push(parser::ParsedCapture::ByValue((ByteString::from_utf8_without_validation("this"sv)),((((*this).current())).span()))));
 ((((*this).index)++));
 }
 return JaktInternal::ExplicitValue<void>();
@@ -9996,7 +9996,7 @@ if (can_throw){
 ((((*this).index)++));
 }
 if (((fn_parameters).has_varargs)){
-((*this).error((ByteString::must_from_utf8("Anonymous functions cannot have varargs"sv)),((((*this).current())).span())));
+((*this).error((ByteString::from_utf8_without_validation("Anonymous functions cannot have varargs"sv)),((((*this).current())).span())));
 }
 NonnullRefPtr<typename parser::ParsedType> return_type = ({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<NonnullRefPtr<typename parser::ParsedType>, ErrorOr<NonnullRefPtr<typename parser::ParsedExpression>>>{
@@ -10137,7 +10137,7 @@ ErrorOr<NonnullRefPtr<typename parser::ParsedExpression>> parser::Parser::parse_
 {
 utility::Span const start = ((((*this).current())).span());
 if ((!(((((*this).current())).__jakt_init_index() == 9 /* LCurly */)))){
-((*this).error((ByteString::must_from_utf8("Expected ‘{’"sv)),((((*this).current())).span())));
+((*this).error((ByteString::from_utf8_without_validation("Expected ‘{’"sv)),((((*this).current())).span())));
 return parser::ParsedExpression::Garbage(((((*this).current())).span()));
 }
 ((((*this).index)++));
@@ -10200,7 +10200,7 @@ return (infallible_enum_cast<jakt__prelude__operators::Ordering>((JaktInternal::
 }
 }
 (end,((((*this).tokens)).size())) || (!(((((((*this).tokens))[end])).__jakt_init_index() == 10 /* RCurly */))))){
-((*this).error((ByteString::must_from_utf8("Expected ‘}’ to close the set"sv)),((((((*this).tokens))[end])).span())));
+((*this).error((ByteString::from_utf8_without_validation("Expected ‘}’ to close the set"sv)),((((((*this).tokens))[end])).span())));
 }
 return parser::ParsedExpression::Set(output,parser::merge_spans(start,((((((*this).tokens))[end])).span())));
 }
@@ -10326,7 +10326,7 @@ __jakt_label_78:; __jakt_var_83.release_value(); }));
 };/*case end*/
 default: {
 return JaktInternal::ExplicitValue(({ Optional<parser::TypeCast> __jakt_var_84; {
-((*this).error_with_hint((ByteString::must_from_utf8("Invalid cast syntax"sv)),cast_span,(ByteString::must_from_utf8("Use `as!` for an infallible cast, or `as?` for a fallible cast"sv)),((((*this).previous())).span())));
+((*this).error_with_hint((ByteString::from_utf8_without_validation("Invalid cast syntax"sv)),cast_span,(ByteString::from_utf8_without_validation("Use `as!` for an infallible cast, or `as?` for a fallible cast"sv)),((((*this).previous())).span())));
 __jakt_var_84 = parser::TypeCast::Fallible(TRY((((*this).parse_typename())))); goto __jakt_label_79;
 
 }
@@ -10378,7 +10378,7 @@ bool const is_optional = ((((*this).current())).__jakt_init_index() == 49 /* Que
 if (is_optional){
 ((((*this).index)++));
 if ((!(((((*this).current())).__jakt_init_index() == 53 /* Dot */)))){
-((*this).error((ByteString::must_from_utf8("Expected ‘.’ after ‘?’ for optional chaining access"sv)),((((*this).current())).span())));
+((*this).error((ByteString::from_utf8_without_validation("Expected ‘.’ after ‘?’ for optional chaining access"sv)),((((*this).current())).span())));
 }
 }
 ((((*this).index)++));
@@ -10407,7 +10407,7 @@ __jakt_label_83:; __jakt_var_88.release_value(); }));
 }
 else {
 {
-((*this).error((ByteString::must_from_utf8("Invalid Numeric Constant"sv)),span));
+((*this).error((ByteString::from_utf8_without_validation("Invalid Numeric Constant"sv)),span));
 return expr;
 }
 }
@@ -10498,7 +10498,7 @@ return JaktInternal::ExplicitValue(({ Optional<NonnullRefPtr<typename parser::Pa
 ((((*this).index)++));
 NonnullRefPtr<typename parser::ParsedExpression> const index = TRY((((*this).parse_expression(false,false))));
 if ((!(((((*this).current())).__jakt_init_index() == 12 /* RSquare */)))){
-((*this).error((ByteString::must_from_utf8("Expected ‘]’ to close the index"sv)),((((*this).current())).span())));
+((*this).error((ByteString::from_utf8_without_validation("Expected ‘]’ to close the index"sv)),((((*this).current())).span())));
 }
 ((((*this).index)++));
 __jakt_var_93 = parser::ParsedExpression::ComptimeIndex(result,index,is_optional,parser::merge_spans(start,((((*this).previous())).span()))); goto __jakt_label_88;
@@ -10508,7 +10508,7 @@ __jakt_label_88:; __jakt_var_93.release_value(); }));
 };/*case end*/
 default: {
 return JaktInternal::ExplicitValue(({ Optional<NonnullRefPtr<typename parser::ParsedExpression>> __jakt_var_94; {
-((*this).error((ByteString::must_from_utf8("Unsupported dot operation"sv)),((((*this).current())).span())));
+((*this).error((ByteString::from_utf8_without_validation("Unsupported dot operation"sv)),((((*this).current())).span())));
 ((((*this).index)++));
 __jakt_var_94 = result; goto __jakt_label_89;
 
@@ -10536,7 +10536,7 @@ bool const is_optional = ((((*this).current())).__jakt_init_index() == 49 /* Que
 if (is_optional){
 ((((*this).index)++));
 if ((!(((((*this).current())).__jakt_init_index() == 53 /* Dot */)))){
-((*this).error((ByteString::must_from_utf8("Expected ‘.’ after ‘?’ for optional chaining access"sv)),((((*this).current())).span())));
+((*this).error((ByteString::from_utf8_without_validation("Expected ‘.’ after ‘?’ for optional chaining access"sv)),((((*this).current())).span())));
 }
 }
 ((((*this).index)++));
@@ -10565,7 +10565,7 @@ __jakt_label_92:; __jakt_var_97.release_value(); }));
 }
 else {
 {
-((*this).error((ByteString::must_from_utf8("Invalid Numeric Constant"sv)),span));
+((*this).error((ByteString::from_utf8_without_validation("Invalid Numeric Constant"sv)),span));
 return expr;
 }
 }
@@ -10656,7 +10656,7 @@ return JaktInternal::ExplicitValue(({ Optional<NonnullRefPtr<typename parser::Pa
 ((((*this).index)++));
 NonnullRefPtr<typename parser::ParsedExpression> const index = TRY((((*this).parse_expression(false,false))));
 if ((!(((((*this).current())).__jakt_init_index() == 12 /* RSquare */)))){
-((*this).error((ByteString::must_from_utf8("Expected ‘]’ to close the index"sv)),((((*this).current())).span())));
+((*this).error((ByteString::from_utf8_without_validation("Expected ‘]’ to close the index"sv)),((((*this).current())).span())));
 }
 ((((*this).index)++));
 __jakt_var_102 = parser::ParsedExpression::ComptimeIndex(result,index,is_optional,parser::merge_spans(start,((((*this).previous())).span()))); goto __jakt_label_97;
@@ -10666,7 +10666,7 @@ __jakt_label_97:; __jakt_var_102.release_value(); }));
 };/*case end*/
 default: {
 return JaktInternal::ExplicitValue(({ Optional<NonnullRefPtr<typename parser::ParsedExpression>> __jakt_var_103; {
-((*this).error((ByteString::must_from_utf8("Unsupported dot operation"sv)),((((*this).current())).span())));
+((*this).error((ByteString::from_utf8_without_validation("Unsupported dot operation"sv)),((((*this).current())).span())));
 ((((*this).index)++));
 __jakt_var_103 = result; goto __jakt_label_98;
 
@@ -10696,7 +10696,7 @@ if (((((*this).current())).__jakt_init_index() == 12 /* RSquare */)){
 ((((*this).index)++));
 }
 else {
-((*this).error((ByteString::must_from_utf8("Expected ']'"sv)),((((*this).current())).span())));
+((*this).error((ByteString::from_utf8_without_validation("Expected ']'"sv)),((((*this).current())).span())));
 }
 
 size_t const end = JaktInternal::checked_sub(((*this).index),static_cast<size_t>(1ULL));
@@ -10735,7 +10735,7 @@ ByteString const name = (expr)->as.Var.name;
 ((namespace_).push(name));
 }
 else {
-((*this).error((ByteString::must_from_utf8("Expected namespace"sv)),((expr)->span())));
+((*this).error((ByteString::from_utf8_without_validation("Expected namespace"sv)),((expr)->span())));
 }
 
 while ((!(((*this).eof())))){
@@ -10764,7 +10764,7 @@ ByteString const name = (((*this).previous())).as.Identifier.name;
 ((namespace_).push(name));
 }
 else {
-((*this).error((ByteString::must_from_utf8("Expected namespace"sv)),((expr)->span())));
+((*this).error((ByteString::from_utf8_without_validation("Expected namespace"sv)),((expr)->span())));
 }
 
 ((((*this).index)++));
@@ -10775,12 +10775,12 @@ return parser::ParsedExpression::NamespacedVar(current_name,namespace_,parser::m
 
 }
 else {
-((*this).error((ByteString::must_from_utf8("Unsupported static method call"sv)),((((*this).current())).span())));
+((*this).error((ByteString::from_utf8_without_validation("Unsupported static method call"sv)),((((*this).current())).span())));
 return expr;
 }
 
 }
-((*this).error((ByteString::must_from_utf8("Incomplete static method call"sv)),((((*this).current())).span())));
+((*this).error((ByteString::from_utf8_without_validation("Incomplete static method call"sv)),((((*this).current())).span())));
 return expr;
 }
 }
@@ -10839,7 +10839,7 @@ return JaktInternal::ExplicitValue(parser::BinaryOperator::BitwiseAnd());
 };/*case end*/
 case 39 /* AmpersandAmpersand */: {
 return JaktInternal::ExplicitValue(({ Optional<parser::BinaryOperator> __jakt_var_105; {
-((*this).error((ByteString::must_from_utf8("‘&&’ is not allowed, use ‘and’ instead"sv)),span));
+((*this).error((ByteString::from_utf8_without_validation("‘&&’ is not allowed, use ‘and’ instead"sv)),span));
 __jakt_var_105 = parser::BinaryOperator::LogicalAnd(); goto __jakt_label_100;
 
 }
@@ -10850,7 +10850,7 @@ return JaktInternal::ExplicitValue(parser::BinaryOperator::BitwiseOr());
 };/*case end*/
 case 42 /* PipePipe */: {
 return JaktInternal::ExplicitValue(({ Optional<parser::BinaryOperator> __jakt_var_106; {
-((*this).error((ByteString::must_from_utf8("‘||’ is not allowed, use ‘or’ instead"sv)),span));
+((*this).error((ByteString::from_utf8_without_validation("‘||’ is not allowed, use ‘or’ instead"sv)),span));
 __jakt_var_106 = parser::BinaryOperator::LogicalOr(); goto __jakt_label_101;
 
 }
@@ -10921,7 +10921,7 @@ return parser::ParsedExpression::Garbage(span);
 });
 ((((*this).index)++));
 if (((!(allow_assignments)) && ((op).is_assignment()))){
-((*this).error((ByteString::must_from_utf8("Assignment is not allowed in this position"sv)),span));
+((*this).error((ByteString::from_utf8_without_validation("Assignment is not allowed in this position"sv)),span));
 return parser::ParsedExpression::Operator(op,span);
 }
 return parser::ParsedExpression::Operator(op,span);
@@ -10967,7 +10967,7 @@ break;
 size_t k = (_magic_value.value());
 {
 if (((((cases)[i])).has_equal_pattern(((cases)[k])))){
-((*this).error_with_hint((ByteString::must_from_utf8("Duplicated match pattern"sv)),((((cases)[k])).marker_span),(ByteString::must_from_utf8("Original pattern here"sv)),((((cases)[i])).marker_span)));
+((*this).error_with_hint((ByteString::from_utf8_without_validation("Duplicated match pattern"sv)),((((cases)[k])).marker_span),(ByteString::from_utf8_without_validation("Original pattern here"sv)),((((cases)[i])).marker_span)));
 }
 }
 
@@ -10989,7 +10989,7 @@ ErrorOr<JaktInternal::DynamicArray<parser::ParsedMatchCase>> parser::Parser::par
 JaktInternal::DynamicArray<parser::ParsedMatchCase> cases = DynamicArray<parser::ParsedMatchCase>::create_with({});
 ((*this).skip_newlines());
 if ((!(((((*this).current())).__jakt_init_index() == 9 /* LCurly */)))){
-((*this).error((ByteString::must_from_utf8("Expected ‘{’"sv)),((((*this).current())).span())));
+((*this).error((ByteString::from_utf8_without_validation("Expected ‘{’"sv)),((((*this).current())).span())));
 return cases;
 }
 ((((*this).index)++));
@@ -11003,7 +11003,7 @@ if (((((*this).current())).__jakt_init_index() == 57 /* FatArrow */)){
 ((((*this).index)++));
 }
 else {
-((*this).error((ByteString::must_from_utf8("Expected ‘=>’"sv)),((((*this).current())).span())));
+((*this).error((ByteString::from_utf8_without_validation("Expected ‘=>’"sv)),((((*this).current())).span())));
 }
 
 ((*this).skip_newlines());
@@ -11053,7 +11053,7 @@ if ((((((*this).current())).__jakt_init_index() == 55 /* Eol */) || ((((*this).c
 }
 ((*this).skip_newlines());
 if ((!(((((*this).current())).__jakt_init_index() == 10 /* RCurly */)))){
-((*this).error((ByteString::must_from_utf8("Expected ‘}’"sv)),((((*this).current())).span())));
+((*this).error((ByteString::from_utf8_without_validation("Expected ‘}’"sv)),((((*this).current())).span())));
 }
 ((((*this).index)++));
 return cases;
@@ -11073,11 +11073,11 @@ JaktInternal::Dictionary<ByteString,parser::ParsedPatternDefault> defaults = ((p
 ((*this).skip_newlines());
 if (((((*this).current())).__jakt_init_index() == 3 /* Identifier */)){
 ByteString const name = (((*this).current())).as.Identifier.name;
-if (((name) == ((ByteString::must_from_utf8("default"sv))))){
+if (((name) == ((ByteString::from_utf8_without_validation("default"sv))))){
 JaktInternal::Dictionary<ByteString,parser::ParsedPatternDefault> defaults = ((pattern).common.init_common.defaults);
 ((((*this).index)) += (static_cast<size_t>(1ULL)));
 if ((!(((((*this).current())).__jakt_init_index() == 7 /* LParen */)))){
-((*this).error((ByteString::must_from_utf8("Expected '(' after 'default'"sv)),((((*this).current())).span())));
+((*this).error((ByteString::from_utf8_without_validation("Expected '(' after 'default'"sv)),((((*this).current())).span())));
 continue;
 }
 ((((*this).index)) += (static_cast<size_t>(1ULL)));
@@ -11101,7 +11101,7 @@ __jakt_label_102:; __jakt_var_108.release_value(); }));
 };/*case end*/
 default: {
 return JaktInternal::ExplicitValue(({ Optional<NonnullRefPtr<typename parser::ParsedExpression>> __jakt_var_109; {
-((*this).error((ByteString::must_from_utf8("Expected initializer"sv)),((((*this).current())).span())));
+((*this).error((ByteString::from_utf8_without_validation("Expected initializer"sv)),((((*this).current())).span())));
 __jakt_var_109 = parser::ParsedExpression::Garbage(((((*this).current())).span())); goto __jakt_label_103;
 
 }
@@ -11124,7 +11124,7 @@ if (((((*this).current())).__jakt_init_index() == 8 /* RParen */)){
 ((((*this).index)) += (static_cast<size_t>(1ULL)));
 }
 else {
-((*this).error((ByteString::must_from_utf8("Expected a ')' to end 'defaults' list"sv)),((((*this).current())).span())));
+((*this).error((ByteString::from_utf8_without_validation("Expected a ')' to end 'defaults' list"sv)),((((*this).current())).span())));
 }
 
 }
@@ -11234,7 +11234,7 @@ __jakt_label_105:; __jakt_var_111.release_value(); }));
 };/*case end*/
 default: {
 return JaktInternal::ExplicitValue(({ Optional<parser::ParsedMatchPattern> __jakt_var_112; {
-((*this).error((ByteString::must_from_utf8("Expected pattern or ‘else’"sv)),((((*this).current())).span())));
+((*this).error((ByteString::from_utf8_without_validation("Expected pattern or ‘else’"sv)),((((*this).current())).span())));
 __jakt_var_112 = parser::ParsedMatchPattern::Invalid(Dictionary<ByteString, parser::ParsedPatternDefault>::create_with_entries({})); goto __jakt_label_106;
 
 }
@@ -11292,7 +11292,7 @@ utility::Span const span = ((((*this).current())).span());
 ((variant_arguments).push(parser::EnumVariantPatternArgument(static_cast<JaktInternal::Optional<ByteString>>(arg_name),static_cast<JaktInternal::Optional<utility::Span>>(arg_name_span),arg_binding,span,is_reference,is_mutable)));
 }
 else {
-((*this).error((ByteString::must_from_utf8("Expected binding after ‘:’"sv)),((((*this).current())).span())));
+((*this).error((ByteString::from_utf8_without_validation("Expected binding after ‘:’"sv)),((((*this).current())).span())));
 }
 
 }
@@ -11321,7 +11321,7 @@ return JaktInternal::ExplicitValue<void>();
 };/*case end*/
 default: {
 {
-((*this).error((ByteString::must_from_utf8("Expected pattern argument name"sv)),((((*this).current())).span())));
+((*this).error((ByteString::from_utf8_without_validation("Expected pattern argument name"sv)),((((*this).current())).span())));
 return JaktInternal::LoopBreak{};
 }
 return JaktInternal::ExplicitValue<void>();
@@ -11345,7 +11345,7 @@ return variant_arguments;
 
 ErrorOr<JaktInternal::Optional<parser::ParsedCall>> parser::Parser::parse_call() {
 {
-parser::ParsedCall call = parser::ParsedCall(DynamicArray<ByteString>::create_with({}),(ByteString::must_from_utf8(""sv)),DynamicArray<JaktInternal::Tuple<ByteString,utility::Span,NonnullRefPtr<typename parser::ParsedExpression>>>::create_with({}),DynamicArray<NonnullRefPtr<typename parser::ParsedType>>::create_with({}));
+parser::ParsedCall call = parser::ParsedCall(DynamicArray<ByteString>::create_with({}),(ByteString::from_utf8_without_validation(""sv)),DynamicArray<JaktInternal::Tuple<ByteString,utility::Span,NonnullRefPtr<typename parser::ParsedExpression>>>::create_with({}),DynamicArray<NonnullRefPtr<typename parser::ParsedType>>::create_with({}));
 if (((((*this).current())).__jakt_init_index() == 3 /* Identifier */)){
 ByteString const name = (((*this).current())).as.Identifier.name;
 (((call).name) = name);
@@ -11417,7 +11417,7 @@ if (((((*this).current())).__jakt_init_index() == 7 /* LParen */)){
 }
 else {
 (((*this).index) = index_reset);
-((*this).error((ByteString::must_from_utf8("Expected '('"sv)),((((*this).current())).span())));
+((*this).error((ByteString::from_utf8_without_validation("Expected '('"sv)),((((*this).current())).span())));
 return JaktInternal::OptionalNone();
 }
 
@@ -11505,14 +11505,14 @@ return JaktInternal::ExplicitValue<void>();
 });
 if (((((*this).current())).__jakt_init_index() == 9 /* LCurly */)){
 if (has_varargs){
-((*this).error((ByteString::must_from_utf8("Function expressions cannot have varargs"sv)),((((*this).current())).span())));
+((*this).error((ByteString::from_utf8_without_validation("Function expressions cannot have varargs"sv)),((((*this).current())).span())));
 }
 (block = TRY((((*this).parse_block()))));
 utility::Span const span = parser::merge_spans(start,((((*this).current())).span()));
-JaktInternal::DynamicArray<parser::ParsedCapture> const captures = DynamicArray<parser::ParsedCapture>::create_with({parser::ParsedCapture::AllByReference((ByteString::must_from_utf8(""sv)),((*this).empty_span()))});
+JaktInternal::DynamicArray<parser::ParsedCapture> const captures = DynamicArray<parser::ParsedCapture>::create_with({parser::ParsedCapture::AllByReference((ByteString::from_utf8_without_validation(""sv)),((*this).empty_span()))});
 NonnullRefPtr<typename parser::ParsedExpression> const trailing_closure = parser::ParsedExpression::Function(captures,params,false,false,parser::ParsedType::Empty(JaktInternal::OptionalNone()),(block.value()),span);
 NonnullRefPtr<typename parser::ParsedExpression> const reference_to_closure = parser::ParsedExpression::UnaryOp(trailing_closure,parser::UnaryOperator::Reference(),span);
-((((call).args)).push((Tuple{(ByteString::must_from_utf8(""sv)), ((*this).empty_span()), reference_to_closure})));
+((((call).args)).push((Tuple{(ByteString::from_utf8_without_validation(""sv)), ((*this).empty_span()), reference_to_closure})));
 }
 else {
 (((*this).index) = start_index);
@@ -11524,7 +11524,7 @@ return call;
 return call;
 }
 else {
-((*this).error((ByteString::must_from_utf8("Expected function call"sv)),((((*this).current())).span())));
+((*this).error((ByteString::from_utf8_without_validation("Expected function call"sv)),((((*this).current())).span())));
 return call;
 }
 
@@ -11566,7 +11566,7 @@ return JaktInternal::ExplicitValue<void>();
 case 56 /* Eof */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Eof;utility::Span const& span = __jakt_match_value.value;
 {
-((*this).error((ByteString::must_from_utf8("Expected ')' to close the trait list"sv)),span));
+((*this).error((ByteString::from_utf8_without_validation("Expected ')' to close the trait list"sv)),span));
 return JaktInternal::LoopBreak{};
 }
 return JaktInternal::ExplicitValue<void>();
@@ -11592,7 +11592,7 @@ return JaktInternal::ExplicitValue<void>();
 case 0 /* SingleQuotedString */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.SingleQuotedString;utility::Span const& span = __jakt_match_value.span;
 {
-((*this).error((ByteString::must_from_utf8("Expected trait name"sv)),span));
+((*this).error((ByteString::from_utf8_without_validation("Expected trait name"sv)),span));
 return JaktInternal::LoopBreak{};
 }
 return JaktInternal::ExplicitValue<void>();
@@ -11600,7 +11600,7 @@ return JaktInternal::ExplicitValue<void>();
 case 1 /* QuotedString */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.QuotedString;utility::Span const& span = __jakt_match_value.span;
 {
-((*this).error((ByteString::must_from_utf8("Expected trait name"sv)),span));
+((*this).error((ByteString::from_utf8_without_validation("Expected trait name"sv)),span));
 return JaktInternal::LoopBreak{};
 }
 return JaktInternal::ExplicitValue<void>();
@@ -11608,7 +11608,7 @@ return JaktInternal::ExplicitValue<void>();
 case 2 /* Number */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Number;utility::Span const& span = __jakt_match_value.span;
 {
-((*this).error((ByteString::must_from_utf8("Expected trait name"sv)),span));
+((*this).error((ByteString::from_utf8_without_validation("Expected trait name"sv)),span));
 return JaktInternal::LoopBreak{};
 }
 return JaktInternal::ExplicitValue<void>();
@@ -11616,7 +11616,7 @@ return JaktInternal::ExplicitValue<void>();
 case 4 /* Semicolon */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Semicolon;utility::Span const& span = __jakt_match_value.value;
 {
-((*this).error((ByteString::must_from_utf8("Expected trait name"sv)),span));
+((*this).error((ByteString::from_utf8_without_validation("Expected trait name"sv)),span));
 return JaktInternal::LoopBreak{};
 }
 return JaktInternal::ExplicitValue<void>();
@@ -11624,7 +11624,7 @@ return JaktInternal::ExplicitValue<void>();
 case 5 /* Colon */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Colon;utility::Span const& span = __jakt_match_value.value;
 {
-((*this).error((ByteString::must_from_utf8("Expected trait name"sv)),span));
+((*this).error((ByteString::from_utf8_without_validation("Expected trait name"sv)),span));
 return JaktInternal::LoopBreak{};
 }
 return JaktInternal::ExplicitValue<void>();
@@ -11632,7 +11632,7 @@ return JaktInternal::ExplicitValue<void>();
 case 6 /* ColonColon */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.ColonColon;utility::Span const& span = __jakt_match_value.value;
 {
-((*this).error((ByteString::must_from_utf8("Expected trait name"sv)),span));
+((*this).error((ByteString::from_utf8_without_validation("Expected trait name"sv)),span));
 return JaktInternal::LoopBreak{};
 }
 return JaktInternal::ExplicitValue<void>();
@@ -11640,7 +11640,7 @@ return JaktInternal::ExplicitValue<void>();
 case 7 /* LParen */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.LParen;utility::Span const& span = __jakt_match_value.value;
 {
-((*this).error((ByteString::must_from_utf8("Expected trait name"sv)),span));
+((*this).error((ByteString::from_utf8_without_validation("Expected trait name"sv)),span));
 return JaktInternal::LoopBreak{};
 }
 return JaktInternal::ExplicitValue<void>();
@@ -11648,7 +11648,7 @@ return JaktInternal::ExplicitValue<void>();
 case 9 /* LCurly */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.LCurly;utility::Span const& span = __jakt_match_value.value;
 {
-((*this).error((ByteString::must_from_utf8("Expected trait name"sv)),span));
+((*this).error((ByteString::from_utf8_without_validation("Expected trait name"sv)),span));
 return JaktInternal::LoopBreak{};
 }
 return JaktInternal::ExplicitValue<void>();
@@ -11656,7 +11656,7 @@ return JaktInternal::ExplicitValue<void>();
 case 10 /* RCurly */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.RCurly;utility::Span const& span = __jakt_match_value.value;
 {
-((*this).error((ByteString::must_from_utf8("Expected trait name"sv)),span));
+((*this).error((ByteString::from_utf8_without_validation("Expected trait name"sv)),span));
 return JaktInternal::LoopBreak{};
 }
 return JaktInternal::ExplicitValue<void>();
@@ -11664,7 +11664,7 @@ return JaktInternal::ExplicitValue<void>();
 case 11 /* LSquare */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.LSquare;utility::Span const& span = __jakt_match_value.value;
 {
-((*this).error((ByteString::must_from_utf8("Expected trait name"sv)),span));
+((*this).error((ByteString::from_utf8_without_validation("Expected trait name"sv)),span));
 return JaktInternal::LoopBreak{};
 }
 return JaktInternal::ExplicitValue<void>();
@@ -11672,7 +11672,7 @@ return JaktInternal::ExplicitValue<void>();
 case 12 /* RSquare */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.RSquare;utility::Span const& span = __jakt_match_value.value;
 {
-((*this).error((ByteString::must_from_utf8("Expected trait name"sv)),span));
+((*this).error((ByteString::from_utf8_without_validation("Expected trait name"sv)),span));
 return JaktInternal::LoopBreak{};
 }
 return JaktInternal::ExplicitValue<void>();
@@ -11680,7 +11680,7 @@ return JaktInternal::ExplicitValue<void>();
 case 13 /* PercentSign */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.PercentSign;utility::Span const& span = __jakt_match_value.value;
 {
-((*this).error((ByteString::must_from_utf8("Expected trait name"sv)),span));
+((*this).error((ByteString::from_utf8_without_validation("Expected trait name"sv)),span));
 return JaktInternal::LoopBreak{};
 }
 return JaktInternal::ExplicitValue<void>();
@@ -11688,7 +11688,7 @@ return JaktInternal::ExplicitValue<void>();
 case 14 /* Plus */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Plus;utility::Span const& span = __jakt_match_value.value;
 {
-((*this).error((ByteString::must_from_utf8("Expected trait name"sv)),span));
+((*this).error((ByteString::from_utf8_without_validation("Expected trait name"sv)),span));
 return JaktInternal::LoopBreak{};
 }
 return JaktInternal::ExplicitValue<void>();
@@ -11696,7 +11696,7 @@ return JaktInternal::ExplicitValue<void>();
 case 15 /* Minus */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Minus;utility::Span const& span = __jakt_match_value.value;
 {
-((*this).error((ByteString::must_from_utf8("Expected trait name"sv)),span));
+((*this).error((ByteString::from_utf8_without_validation("Expected trait name"sv)),span));
 return JaktInternal::LoopBreak{};
 }
 return JaktInternal::ExplicitValue<void>();
@@ -11704,7 +11704,7 @@ return JaktInternal::ExplicitValue<void>();
 case 16 /* Equal */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Equal;utility::Span const& span = __jakt_match_value.value;
 {
-((*this).error((ByteString::must_from_utf8("Expected trait name"sv)),span));
+((*this).error((ByteString::from_utf8_without_validation("Expected trait name"sv)),span));
 return JaktInternal::LoopBreak{};
 }
 return JaktInternal::ExplicitValue<void>();
@@ -11712,7 +11712,7 @@ return JaktInternal::ExplicitValue<void>();
 case 17 /* PlusEqual */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.PlusEqual;utility::Span const& span = __jakt_match_value.value;
 {
-((*this).error((ByteString::must_from_utf8("Expected trait name"sv)),span));
+((*this).error((ByteString::from_utf8_without_validation("Expected trait name"sv)),span));
 return JaktInternal::LoopBreak{};
 }
 return JaktInternal::ExplicitValue<void>();
@@ -11720,7 +11720,7 @@ return JaktInternal::ExplicitValue<void>();
 case 18 /* PlusPlus */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.PlusPlus;utility::Span const& span = __jakt_match_value.value;
 {
-((*this).error((ByteString::must_from_utf8("Expected trait name"sv)),span));
+((*this).error((ByteString::from_utf8_without_validation("Expected trait name"sv)),span));
 return JaktInternal::LoopBreak{};
 }
 return JaktInternal::ExplicitValue<void>();
@@ -11728,7 +11728,7 @@ return JaktInternal::ExplicitValue<void>();
 case 19 /* MinusEqual */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.MinusEqual;utility::Span const& span = __jakt_match_value.value;
 {
-((*this).error((ByteString::must_from_utf8("Expected trait name"sv)),span));
+((*this).error((ByteString::from_utf8_without_validation("Expected trait name"sv)),span));
 return JaktInternal::LoopBreak{};
 }
 return JaktInternal::ExplicitValue<void>();
@@ -11736,7 +11736,7 @@ return JaktInternal::ExplicitValue<void>();
 case 20 /* MinusMinus */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.MinusMinus;utility::Span const& span = __jakt_match_value.value;
 {
-((*this).error((ByteString::must_from_utf8("Expected trait name"sv)),span));
+((*this).error((ByteString::from_utf8_without_validation("Expected trait name"sv)),span));
 return JaktInternal::LoopBreak{};
 }
 return JaktInternal::ExplicitValue<void>();
@@ -11744,7 +11744,7 @@ return JaktInternal::ExplicitValue<void>();
 case 21 /* AsteriskEqual */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.AsteriskEqual;utility::Span const& span = __jakt_match_value.value;
 {
-((*this).error((ByteString::must_from_utf8("Expected trait name"sv)),span));
+((*this).error((ByteString::from_utf8_without_validation("Expected trait name"sv)),span));
 return JaktInternal::LoopBreak{};
 }
 return JaktInternal::ExplicitValue<void>();
@@ -11752,7 +11752,7 @@ return JaktInternal::ExplicitValue<void>();
 case 22 /* ForwardSlashEqual */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.ForwardSlashEqual;utility::Span const& span = __jakt_match_value.value;
 {
-((*this).error((ByteString::must_from_utf8("Expected trait name"sv)),span));
+((*this).error((ByteString::from_utf8_without_validation("Expected trait name"sv)),span));
 return JaktInternal::LoopBreak{};
 }
 return JaktInternal::ExplicitValue<void>();
@@ -11760,7 +11760,7 @@ return JaktInternal::ExplicitValue<void>();
 case 23 /* PercentSignEqual */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.PercentSignEqual;utility::Span const& span = __jakt_match_value.value;
 {
-((*this).error((ByteString::must_from_utf8("Expected trait name"sv)),span));
+((*this).error((ByteString::from_utf8_without_validation("Expected trait name"sv)),span));
 return JaktInternal::LoopBreak{};
 }
 return JaktInternal::ExplicitValue<void>();
@@ -11768,7 +11768,7 @@ return JaktInternal::ExplicitValue<void>();
 case 24 /* NotEqual */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.NotEqual;utility::Span const& span = __jakt_match_value.value;
 {
-((*this).error((ByteString::must_from_utf8("Expected trait name"sv)),span));
+((*this).error((ByteString::from_utf8_without_validation("Expected trait name"sv)),span));
 return JaktInternal::LoopBreak{};
 }
 return JaktInternal::ExplicitValue<void>();
@@ -11776,7 +11776,7 @@ return JaktInternal::ExplicitValue<void>();
 case 25 /* DoubleEqual */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.DoubleEqual;utility::Span const& span = __jakt_match_value.value;
 {
-((*this).error((ByteString::must_from_utf8("Expected trait name"sv)),span));
+((*this).error((ByteString::from_utf8_without_validation("Expected trait name"sv)),span));
 return JaktInternal::LoopBreak{};
 }
 return JaktInternal::ExplicitValue<void>();
@@ -11784,7 +11784,7 @@ return JaktInternal::ExplicitValue<void>();
 case 26 /* GreaterThan */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.GreaterThan;utility::Span const& span = __jakt_match_value.value;
 {
-((*this).error((ByteString::must_from_utf8("Expected trait name"sv)),span));
+((*this).error((ByteString::from_utf8_without_validation("Expected trait name"sv)),span));
 return JaktInternal::LoopBreak{};
 }
 return JaktInternal::ExplicitValue<void>();
@@ -11792,7 +11792,7 @@ return JaktInternal::ExplicitValue<void>();
 case 27 /* GreaterThanOrEqual */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.GreaterThanOrEqual;utility::Span const& span = __jakt_match_value.value;
 {
-((*this).error((ByteString::must_from_utf8("Expected trait name"sv)),span));
+((*this).error((ByteString::from_utf8_without_validation("Expected trait name"sv)),span));
 return JaktInternal::LoopBreak{};
 }
 return JaktInternal::ExplicitValue<void>();
@@ -11800,7 +11800,7 @@ return JaktInternal::ExplicitValue<void>();
 case 28 /* LessThan */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.LessThan;utility::Span const& span = __jakt_match_value.value;
 {
-((*this).error((ByteString::must_from_utf8("Expected trait name"sv)),span));
+((*this).error((ByteString::from_utf8_without_validation("Expected trait name"sv)),span));
 return JaktInternal::LoopBreak{};
 }
 return JaktInternal::ExplicitValue<void>();
@@ -11808,7 +11808,7 @@ return JaktInternal::ExplicitValue<void>();
 case 29 /* LessThanOrEqual */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.LessThanOrEqual;utility::Span const& span = __jakt_match_value.value;
 {
-((*this).error((ByteString::must_from_utf8("Expected trait name"sv)),span));
+((*this).error((ByteString::from_utf8_without_validation("Expected trait name"sv)),span));
 return JaktInternal::LoopBreak{};
 }
 return JaktInternal::ExplicitValue<void>();
@@ -11816,7 +11816,7 @@ return JaktInternal::ExplicitValue<void>();
 case 30 /* LeftArithmeticShift */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.LeftArithmeticShift;utility::Span const& span = __jakt_match_value.value;
 {
-((*this).error((ByteString::must_from_utf8("Expected trait name"sv)),span));
+((*this).error((ByteString::from_utf8_without_validation("Expected trait name"sv)),span));
 return JaktInternal::LoopBreak{};
 }
 return JaktInternal::ExplicitValue<void>();
@@ -11824,7 +11824,7 @@ return JaktInternal::ExplicitValue<void>();
 case 31 /* LeftShift */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.LeftShift;utility::Span const& span = __jakt_match_value.value;
 {
-((*this).error((ByteString::must_from_utf8("Expected trait name"sv)),span));
+((*this).error((ByteString::from_utf8_without_validation("Expected trait name"sv)),span));
 return JaktInternal::LoopBreak{};
 }
 return JaktInternal::ExplicitValue<void>();
@@ -11832,7 +11832,7 @@ return JaktInternal::ExplicitValue<void>();
 case 32 /* LeftShiftEqual */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.LeftShiftEqual;utility::Span const& span = __jakt_match_value.value;
 {
-((*this).error((ByteString::must_from_utf8("Expected trait name"sv)),span));
+((*this).error((ByteString::from_utf8_without_validation("Expected trait name"sv)),span));
 return JaktInternal::LoopBreak{};
 }
 return JaktInternal::ExplicitValue<void>();
@@ -11840,7 +11840,7 @@ return JaktInternal::ExplicitValue<void>();
 case 33 /* RightShift */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.RightShift;utility::Span const& span = __jakt_match_value.value;
 {
-((*this).error((ByteString::must_from_utf8("Expected trait name"sv)),span));
+((*this).error((ByteString::from_utf8_without_validation("Expected trait name"sv)),span));
 return JaktInternal::LoopBreak{};
 }
 return JaktInternal::ExplicitValue<void>();
@@ -11848,7 +11848,7 @@ return JaktInternal::ExplicitValue<void>();
 case 34 /* RightArithmeticShift */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.RightArithmeticShift;utility::Span const& span = __jakt_match_value.value;
 {
-((*this).error((ByteString::must_from_utf8("Expected trait name"sv)),span));
+((*this).error((ByteString::from_utf8_without_validation("Expected trait name"sv)),span));
 return JaktInternal::LoopBreak{};
 }
 return JaktInternal::ExplicitValue<void>();
@@ -11856,7 +11856,7 @@ return JaktInternal::ExplicitValue<void>();
 case 35 /* RightShiftEqual */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.RightShiftEqual;utility::Span const& span = __jakt_match_value.value;
 {
-((*this).error((ByteString::must_from_utf8("Expected trait name"sv)),span));
+((*this).error((ByteString::from_utf8_without_validation("Expected trait name"sv)),span));
 return JaktInternal::LoopBreak{};
 }
 return JaktInternal::ExplicitValue<void>();
@@ -11864,7 +11864,7 @@ return JaktInternal::ExplicitValue<void>();
 case 36 /* Asterisk */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Asterisk;utility::Span const& span = __jakt_match_value.value;
 {
-((*this).error((ByteString::must_from_utf8("Expected trait name"sv)),span));
+((*this).error((ByteString::from_utf8_without_validation("Expected trait name"sv)),span));
 return JaktInternal::LoopBreak{};
 }
 return JaktInternal::ExplicitValue<void>();
@@ -11872,7 +11872,7 @@ return JaktInternal::ExplicitValue<void>();
 case 37 /* Ampersand */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Ampersand;utility::Span const& span = __jakt_match_value.value;
 {
-((*this).error((ByteString::must_from_utf8("Expected trait name"sv)),span));
+((*this).error((ByteString::from_utf8_without_validation("Expected trait name"sv)),span));
 return JaktInternal::LoopBreak{};
 }
 return JaktInternal::ExplicitValue<void>();
@@ -11880,7 +11880,7 @@ return JaktInternal::ExplicitValue<void>();
 case 38 /* AmpersandEqual */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.AmpersandEqual;utility::Span const& span = __jakt_match_value.value;
 {
-((*this).error((ByteString::must_from_utf8("Expected trait name"sv)),span));
+((*this).error((ByteString::from_utf8_without_validation("Expected trait name"sv)),span));
 return JaktInternal::LoopBreak{};
 }
 return JaktInternal::ExplicitValue<void>();
@@ -11888,7 +11888,7 @@ return JaktInternal::ExplicitValue<void>();
 case 39 /* AmpersandAmpersand */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.AmpersandAmpersand;utility::Span const& span = __jakt_match_value.value;
 {
-((*this).error((ByteString::must_from_utf8("Expected trait name"sv)),span));
+((*this).error((ByteString::from_utf8_without_validation("Expected trait name"sv)),span));
 return JaktInternal::LoopBreak{};
 }
 return JaktInternal::ExplicitValue<void>();
@@ -11896,7 +11896,7 @@ return JaktInternal::ExplicitValue<void>();
 case 40 /* Pipe */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Pipe;utility::Span const& span = __jakt_match_value.value;
 {
-((*this).error((ByteString::must_from_utf8("Expected trait name"sv)),span));
+((*this).error((ByteString::from_utf8_without_validation("Expected trait name"sv)),span));
 return JaktInternal::LoopBreak{};
 }
 return JaktInternal::ExplicitValue<void>();
@@ -11904,7 +11904,7 @@ return JaktInternal::ExplicitValue<void>();
 case 41 /* PipeEqual */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.PipeEqual;utility::Span const& span = __jakt_match_value.value;
 {
-((*this).error((ByteString::must_from_utf8("Expected trait name"sv)),span));
+((*this).error((ByteString::from_utf8_without_validation("Expected trait name"sv)),span));
 return JaktInternal::LoopBreak{};
 }
 return JaktInternal::ExplicitValue<void>();
@@ -11912,7 +11912,7 @@ return JaktInternal::ExplicitValue<void>();
 case 42 /* PipePipe */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.PipePipe;utility::Span const& span = __jakt_match_value.value;
 {
-((*this).error((ByteString::must_from_utf8("Expected trait name"sv)),span));
+((*this).error((ByteString::from_utf8_without_validation("Expected trait name"sv)),span));
 return JaktInternal::LoopBreak{};
 }
 return JaktInternal::ExplicitValue<void>();
@@ -11920,7 +11920,7 @@ return JaktInternal::ExplicitValue<void>();
 case 43 /* Caret */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Caret;utility::Span const& span = __jakt_match_value.value;
 {
-((*this).error((ByteString::must_from_utf8("Expected trait name"sv)),span));
+((*this).error((ByteString::from_utf8_without_validation("Expected trait name"sv)),span));
 return JaktInternal::LoopBreak{};
 }
 return JaktInternal::ExplicitValue<void>();
@@ -11928,7 +11928,7 @@ return JaktInternal::ExplicitValue<void>();
 case 44 /* CaretEqual */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.CaretEqual;utility::Span const& span = __jakt_match_value.value;
 {
-((*this).error((ByteString::must_from_utf8("Expected trait name"sv)),span));
+((*this).error((ByteString::from_utf8_without_validation("Expected trait name"sv)),span));
 return JaktInternal::LoopBreak{};
 }
 return JaktInternal::ExplicitValue<void>();
@@ -11936,7 +11936,7 @@ return JaktInternal::ExplicitValue<void>();
 case 45 /* Dollar */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Dollar;utility::Span const& span = __jakt_match_value.value;
 {
-((*this).error((ByteString::must_from_utf8("Expected trait name"sv)),span));
+((*this).error((ByteString::from_utf8_without_validation("Expected trait name"sv)),span));
 return JaktInternal::LoopBreak{};
 }
 return JaktInternal::ExplicitValue<void>();
@@ -11944,7 +11944,7 @@ return JaktInternal::ExplicitValue<void>();
 case 46 /* Tilde */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Tilde;utility::Span const& span = __jakt_match_value.value;
 {
-((*this).error((ByteString::must_from_utf8("Expected trait name"sv)),span));
+((*this).error((ByteString::from_utf8_without_validation("Expected trait name"sv)),span));
 return JaktInternal::LoopBreak{};
 }
 return JaktInternal::ExplicitValue<void>();
@@ -11952,7 +11952,7 @@ return JaktInternal::ExplicitValue<void>();
 case 47 /* ForwardSlash */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.ForwardSlash;utility::Span const& span = __jakt_match_value.value;
 {
-((*this).error((ByteString::must_from_utf8("Expected trait name"sv)),span));
+((*this).error((ByteString::from_utf8_without_validation("Expected trait name"sv)),span));
 return JaktInternal::LoopBreak{};
 }
 return JaktInternal::ExplicitValue<void>();
@@ -11960,7 +11960,7 @@ return JaktInternal::ExplicitValue<void>();
 case 48 /* ExclamationPoint */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.ExclamationPoint;utility::Span const& span = __jakt_match_value.value;
 {
-((*this).error((ByteString::must_from_utf8("Expected trait name"sv)),span));
+((*this).error((ByteString::from_utf8_without_validation("Expected trait name"sv)),span));
 return JaktInternal::LoopBreak{};
 }
 return JaktInternal::ExplicitValue<void>();
@@ -11968,7 +11968,7 @@ return JaktInternal::ExplicitValue<void>();
 case 49 /* QuestionMark */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.QuestionMark;utility::Span const& span = __jakt_match_value.value;
 {
-((*this).error((ByteString::must_from_utf8("Expected trait name"sv)),span));
+((*this).error((ByteString::from_utf8_without_validation("Expected trait name"sv)),span));
 return JaktInternal::LoopBreak{};
 }
 return JaktInternal::ExplicitValue<void>();
@@ -11976,7 +11976,7 @@ return JaktInternal::ExplicitValue<void>();
 case 50 /* QuestionMarkQuestionMark */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.QuestionMarkQuestionMark;utility::Span const& span = __jakt_match_value.value;
 {
-((*this).error((ByteString::must_from_utf8("Expected trait name"sv)),span));
+((*this).error((ByteString::from_utf8_without_validation("Expected trait name"sv)),span));
 return JaktInternal::LoopBreak{};
 }
 return JaktInternal::ExplicitValue<void>();
@@ -11984,7 +11984,7 @@ return JaktInternal::ExplicitValue<void>();
 case 51 /* QuestionMarkQuestionMarkEqual */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.QuestionMarkQuestionMarkEqual;utility::Span const& span = __jakt_match_value.value;
 {
-((*this).error((ByteString::must_from_utf8("Expected trait name"sv)),span));
+((*this).error((ByteString::from_utf8_without_validation("Expected trait name"sv)),span));
 return JaktInternal::LoopBreak{};
 }
 return JaktInternal::ExplicitValue<void>();
@@ -11992,7 +11992,7 @@ return JaktInternal::ExplicitValue<void>();
 case 53 /* Dot */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Dot;utility::Span const& span = __jakt_match_value.value;
 {
-((*this).error((ByteString::must_from_utf8("Expected trait name"sv)),span));
+((*this).error((ByteString::from_utf8_without_validation("Expected trait name"sv)),span));
 return JaktInternal::LoopBreak{};
 }
 return JaktInternal::ExplicitValue<void>();
@@ -12000,7 +12000,7 @@ return JaktInternal::ExplicitValue<void>();
 case 54 /* DotDot */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.DotDot;utility::Span const& span = __jakt_match_value.value;
 {
-((*this).error((ByteString::must_from_utf8("Expected trait name"sv)),span));
+((*this).error((ByteString::from_utf8_without_validation("Expected trait name"sv)),span));
 return JaktInternal::LoopBreak{};
 }
 return JaktInternal::ExplicitValue<void>();
@@ -12008,7 +12008,7 @@ return JaktInternal::ExplicitValue<void>();
 case 57 /* FatArrow */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.FatArrow;utility::Span const& span = __jakt_match_value.value;
 {
-((*this).error((ByteString::must_from_utf8("Expected trait name"sv)),span));
+((*this).error((ByteString::from_utf8_without_validation("Expected trait name"sv)),span));
 return JaktInternal::LoopBreak{};
 }
 return JaktInternal::ExplicitValue<void>();
@@ -12016,7 +12016,7 @@ return JaktInternal::ExplicitValue<void>();
 case 58 /* Arrow */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Arrow;utility::Span const& span = __jakt_match_value.value;
 {
-((*this).error((ByteString::must_from_utf8("Expected trait name"sv)),span));
+((*this).error((ByteString::from_utf8_without_validation("Expected trait name"sv)),span));
 return JaktInternal::LoopBreak{};
 }
 return JaktInternal::ExplicitValue<void>();
@@ -12024,7 +12024,7 @@ return JaktInternal::ExplicitValue<void>();
 case 59 /* And */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.And;utility::Span const& span = __jakt_match_value.value;
 {
-((*this).error((ByteString::must_from_utf8("Expected trait name"sv)),span));
+((*this).error((ByteString::from_utf8_without_validation("Expected trait name"sv)),span));
 return JaktInternal::LoopBreak{};
 }
 return JaktInternal::ExplicitValue<void>();
@@ -12032,7 +12032,7 @@ return JaktInternal::ExplicitValue<void>();
 case 60 /* Anon */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Anon;utility::Span const& span = __jakt_match_value.value;
 {
-((*this).error((ByteString::must_from_utf8("Expected trait name"sv)),span));
+((*this).error((ByteString::from_utf8_without_validation("Expected trait name"sv)),span));
 return JaktInternal::LoopBreak{};
 }
 return JaktInternal::ExplicitValue<void>();
@@ -12040,7 +12040,7 @@ return JaktInternal::ExplicitValue<void>();
 case 61 /* As */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.As;utility::Span const& span = __jakt_match_value.value;
 {
-((*this).error((ByteString::must_from_utf8("Expected trait name"sv)),span));
+((*this).error((ByteString::from_utf8_without_validation("Expected trait name"sv)),span));
 return JaktInternal::LoopBreak{};
 }
 return JaktInternal::ExplicitValue<void>();
@@ -12048,7 +12048,7 @@ return JaktInternal::ExplicitValue<void>();
 case 62 /* Boxed */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Boxed;utility::Span const& span = __jakt_match_value.value;
 {
-((*this).error((ByteString::must_from_utf8("Expected trait name"sv)),span));
+((*this).error((ByteString::from_utf8_without_validation("Expected trait name"sv)),span));
 return JaktInternal::LoopBreak{};
 }
 return JaktInternal::ExplicitValue<void>();
@@ -12056,7 +12056,7 @@ return JaktInternal::ExplicitValue<void>();
 case 63 /* Break */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Break;utility::Span const& span = __jakt_match_value.value;
 {
-((*this).error((ByteString::must_from_utf8("Expected trait name"sv)),span));
+((*this).error((ByteString::from_utf8_without_validation("Expected trait name"sv)),span));
 return JaktInternal::LoopBreak{};
 }
 return JaktInternal::ExplicitValue<void>();
@@ -12064,7 +12064,7 @@ return JaktInternal::ExplicitValue<void>();
 case 64 /* Catch */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Catch;utility::Span const& span = __jakt_match_value.value;
 {
-((*this).error((ByteString::must_from_utf8("Expected trait name"sv)),span));
+((*this).error((ByteString::from_utf8_without_validation("Expected trait name"sv)),span));
 return JaktInternal::LoopBreak{};
 }
 return JaktInternal::ExplicitValue<void>();
@@ -12072,7 +12072,7 @@ return JaktInternal::ExplicitValue<void>();
 case 65 /* Class */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Class;utility::Span const& span = __jakt_match_value.value;
 {
-((*this).error((ByteString::must_from_utf8("Expected trait name"sv)),span));
+((*this).error((ByteString::from_utf8_without_validation("Expected trait name"sv)),span));
 return JaktInternal::LoopBreak{};
 }
 return JaktInternal::ExplicitValue<void>();
@@ -12080,7 +12080,7 @@ return JaktInternal::ExplicitValue<void>();
 case 66 /* Continue */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Continue;utility::Span const& span = __jakt_match_value.value;
 {
-((*this).error((ByteString::must_from_utf8("Expected trait name"sv)),span));
+((*this).error((ByteString::from_utf8_without_validation("Expected trait name"sv)),span));
 return JaktInternal::LoopBreak{};
 }
 return JaktInternal::ExplicitValue<void>();
@@ -12088,7 +12088,7 @@ return JaktInternal::ExplicitValue<void>();
 case 67 /* Cpp */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Cpp;utility::Span const& span = __jakt_match_value.value;
 {
-((*this).error((ByteString::must_from_utf8("Expected trait name"sv)),span));
+((*this).error((ByteString::from_utf8_without_validation("Expected trait name"sv)),span));
 return JaktInternal::LoopBreak{};
 }
 return JaktInternal::ExplicitValue<void>();
@@ -12096,7 +12096,7 @@ return JaktInternal::ExplicitValue<void>();
 case 68 /* Defer */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Defer;utility::Span const& span = __jakt_match_value.value;
 {
-((*this).error((ByteString::must_from_utf8("Expected trait name"sv)),span));
+((*this).error((ByteString::from_utf8_without_validation("Expected trait name"sv)),span));
 return JaktInternal::LoopBreak{};
 }
 return JaktInternal::ExplicitValue<void>();
@@ -12104,7 +12104,7 @@ return JaktInternal::ExplicitValue<void>();
 case 69 /* Destructor */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Destructor;utility::Span const& span = __jakt_match_value.value;
 {
-((*this).error((ByteString::must_from_utf8("Expected trait name"sv)),span));
+((*this).error((ByteString::from_utf8_without_validation("Expected trait name"sv)),span));
 return JaktInternal::LoopBreak{};
 }
 return JaktInternal::ExplicitValue<void>();
@@ -12112,7 +12112,7 @@ return JaktInternal::ExplicitValue<void>();
 case 70 /* Else */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Else;utility::Span const& span = __jakt_match_value.value;
 {
-((*this).error((ByteString::must_from_utf8("Expected trait name"sv)),span));
+((*this).error((ByteString::from_utf8_without_validation("Expected trait name"sv)),span));
 return JaktInternal::LoopBreak{};
 }
 return JaktInternal::ExplicitValue<void>();
@@ -12120,7 +12120,7 @@ return JaktInternal::ExplicitValue<void>();
 case 71 /* Enum */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Enum;utility::Span const& span = __jakt_match_value.value;
 {
-((*this).error((ByteString::must_from_utf8("Expected trait name"sv)),span));
+((*this).error((ByteString::from_utf8_without_validation("Expected trait name"sv)),span));
 return JaktInternal::LoopBreak{};
 }
 return JaktInternal::ExplicitValue<void>();
@@ -12128,7 +12128,7 @@ return JaktInternal::ExplicitValue<void>();
 case 72 /* Extern */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Extern;utility::Span const& span = __jakt_match_value.value;
 {
-((*this).error((ByteString::must_from_utf8("Expected trait name"sv)),span));
+((*this).error((ByteString::from_utf8_without_validation("Expected trait name"sv)),span));
 return JaktInternal::LoopBreak{};
 }
 return JaktInternal::ExplicitValue<void>();
@@ -12136,7 +12136,7 @@ return JaktInternal::ExplicitValue<void>();
 case 73 /* False */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.False;utility::Span const& span = __jakt_match_value.value;
 {
-((*this).error((ByteString::must_from_utf8("Expected trait name"sv)),span));
+((*this).error((ByteString::from_utf8_without_validation("Expected trait name"sv)),span));
 return JaktInternal::LoopBreak{};
 }
 return JaktInternal::ExplicitValue<void>();
@@ -12144,7 +12144,7 @@ return JaktInternal::ExplicitValue<void>();
 case 74 /* For */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.For;utility::Span const& span = __jakt_match_value.value;
 {
-((*this).error((ByteString::must_from_utf8("Expected trait name"sv)),span));
+((*this).error((ByteString::from_utf8_without_validation("Expected trait name"sv)),span));
 return JaktInternal::LoopBreak{};
 }
 return JaktInternal::ExplicitValue<void>();
@@ -12152,7 +12152,7 @@ return JaktInternal::ExplicitValue<void>();
 case 75 /* Fn */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Fn;utility::Span const& span = __jakt_match_value.value;
 {
-((*this).error((ByteString::must_from_utf8("Expected trait name"sv)),span));
+((*this).error((ByteString::from_utf8_without_validation("Expected trait name"sv)),span));
 return JaktInternal::LoopBreak{};
 }
 return JaktInternal::ExplicitValue<void>();
@@ -12160,7 +12160,7 @@ return JaktInternal::ExplicitValue<void>();
 case 76 /* Comptime */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Comptime;utility::Span const& span = __jakt_match_value.value;
 {
-((*this).error((ByteString::must_from_utf8("Expected trait name"sv)),span));
+((*this).error((ByteString::from_utf8_without_validation("Expected trait name"sv)),span));
 return JaktInternal::LoopBreak{};
 }
 return JaktInternal::ExplicitValue<void>();
@@ -12168,7 +12168,7 @@ return JaktInternal::ExplicitValue<void>();
 case 77 /* If */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.If;utility::Span const& span = __jakt_match_value.value;
 {
-((*this).error((ByteString::must_from_utf8("Expected trait name"sv)),span));
+((*this).error((ByteString::from_utf8_without_validation("Expected trait name"sv)),span));
 return JaktInternal::LoopBreak{};
 }
 return JaktInternal::ExplicitValue<void>();
@@ -12176,7 +12176,7 @@ return JaktInternal::ExplicitValue<void>();
 case 78 /* Import */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Import;utility::Span const& span = __jakt_match_value.value;
 {
-((*this).error((ByteString::must_from_utf8("Expected trait name"sv)),span));
+((*this).error((ByteString::from_utf8_without_validation("Expected trait name"sv)),span));
 return JaktInternal::LoopBreak{};
 }
 return JaktInternal::ExplicitValue<void>();
@@ -12184,7 +12184,7 @@ return JaktInternal::ExplicitValue<void>();
 case 79 /* Relative */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Relative;utility::Span const& span = __jakt_match_value.value;
 {
-((*this).error((ByteString::must_from_utf8("Expected trait name"sv)),span));
+((*this).error((ByteString::from_utf8_without_validation("Expected trait name"sv)),span));
 return JaktInternal::LoopBreak{};
 }
 return JaktInternal::ExplicitValue<void>();
@@ -12192,7 +12192,7 @@ return JaktInternal::ExplicitValue<void>();
 case 80 /* In */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.In;utility::Span const& span = __jakt_match_value.value;
 {
-((*this).error((ByteString::must_from_utf8("Expected trait name"sv)),span));
+((*this).error((ByteString::from_utf8_without_validation("Expected trait name"sv)),span));
 return JaktInternal::LoopBreak{};
 }
 return JaktInternal::ExplicitValue<void>();
@@ -12200,7 +12200,7 @@ return JaktInternal::ExplicitValue<void>();
 case 81 /* Is */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Is;utility::Span const& span = __jakt_match_value.value;
 {
-((*this).error((ByteString::must_from_utf8("Expected trait name"sv)),span));
+((*this).error((ByteString::from_utf8_without_validation("Expected trait name"sv)),span));
 return JaktInternal::LoopBreak{};
 }
 return JaktInternal::ExplicitValue<void>();
@@ -12208,7 +12208,7 @@ return JaktInternal::ExplicitValue<void>();
 case 82 /* Let */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Let;utility::Span const& span = __jakt_match_value.value;
 {
-((*this).error((ByteString::must_from_utf8("Expected trait name"sv)),span));
+((*this).error((ByteString::from_utf8_without_validation("Expected trait name"sv)),span));
 return JaktInternal::LoopBreak{};
 }
 return JaktInternal::ExplicitValue<void>();
@@ -12216,7 +12216,7 @@ return JaktInternal::ExplicitValue<void>();
 case 83 /* Loop */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Loop;utility::Span const& span = __jakt_match_value.value;
 {
-((*this).error((ByteString::must_from_utf8("Expected trait name"sv)),span));
+((*this).error((ByteString::from_utf8_without_validation("Expected trait name"sv)),span));
 return JaktInternal::LoopBreak{};
 }
 return JaktInternal::ExplicitValue<void>();
@@ -12224,7 +12224,7 @@ return JaktInternal::ExplicitValue<void>();
 case 84 /* Match */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Match;utility::Span const& span = __jakt_match_value.value;
 {
-((*this).error((ByteString::must_from_utf8("Expected trait name"sv)),span));
+((*this).error((ByteString::from_utf8_without_validation("Expected trait name"sv)),span));
 return JaktInternal::LoopBreak{};
 }
 return JaktInternal::ExplicitValue<void>();
@@ -12232,7 +12232,7 @@ return JaktInternal::ExplicitValue<void>();
 case 85 /* Mut */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Mut;utility::Span const& span = __jakt_match_value.value;
 {
-((*this).error((ByteString::must_from_utf8("Expected trait name"sv)),span));
+((*this).error((ByteString::from_utf8_without_validation("Expected trait name"sv)),span));
 return JaktInternal::LoopBreak{};
 }
 return JaktInternal::ExplicitValue<void>();
@@ -12240,7 +12240,7 @@ return JaktInternal::ExplicitValue<void>();
 case 86 /* Namespace */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Namespace;utility::Span const& span = __jakt_match_value.value;
 {
-((*this).error((ByteString::must_from_utf8("Expected trait name"sv)),span));
+((*this).error((ByteString::from_utf8_without_validation("Expected trait name"sv)),span));
 return JaktInternal::LoopBreak{};
 }
 return JaktInternal::ExplicitValue<void>();
@@ -12248,7 +12248,7 @@ return JaktInternal::ExplicitValue<void>();
 case 87 /* Not */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Not;utility::Span const& span = __jakt_match_value.value;
 {
-((*this).error((ByteString::must_from_utf8("Expected trait name"sv)),span));
+((*this).error((ByteString::from_utf8_without_validation("Expected trait name"sv)),span));
 return JaktInternal::LoopBreak{};
 }
 return JaktInternal::ExplicitValue<void>();
@@ -12256,7 +12256,7 @@ return JaktInternal::ExplicitValue<void>();
 case 88 /* Or */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Or;utility::Span const& span = __jakt_match_value.value;
 {
-((*this).error((ByteString::must_from_utf8("Expected trait name"sv)),span));
+((*this).error((ByteString::from_utf8_without_validation("Expected trait name"sv)),span));
 return JaktInternal::LoopBreak{};
 }
 return JaktInternal::ExplicitValue<void>();
@@ -12264,7 +12264,7 @@ return JaktInternal::ExplicitValue<void>();
 case 89 /* Override */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Override;utility::Span const& span = __jakt_match_value.value;
 {
-((*this).error((ByteString::must_from_utf8("Expected trait name"sv)),span));
+((*this).error((ByteString::from_utf8_without_validation("Expected trait name"sv)),span));
 return JaktInternal::LoopBreak{};
 }
 return JaktInternal::ExplicitValue<void>();
@@ -12272,7 +12272,7 @@ return JaktInternal::ExplicitValue<void>();
 case 90 /* Private */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Private;utility::Span const& span = __jakt_match_value.value;
 {
-((*this).error((ByteString::must_from_utf8("Expected trait name"sv)),span));
+((*this).error((ByteString::from_utf8_without_validation("Expected trait name"sv)),span));
 return JaktInternal::LoopBreak{};
 }
 return JaktInternal::ExplicitValue<void>();
@@ -12280,7 +12280,7 @@ return JaktInternal::ExplicitValue<void>();
 case 91 /* Public */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Public;utility::Span const& span = __jakt_match_value.value;
 {
-((*this).error((ByteString::must_from_utf8("Expected trait name"sv)),span));
+((*this).error((ByteString::from_utf8_without_validation("Expected trait name"sv)),span));
 return JaktInternal::LoopBreak{};
 }
 return JaktInternal::ExplicitValue<void>();
@@ -12288,7 +12288,7 @@ return JaktInternal::ExplicitValue<void>();
 case 92 /* Raw */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Raw;utility::Span const& span = __jakt_match_value.value;
 {
-((*this).error((ByteString::must_from_utf8("Expected trait name"sv)),span));
+((*this).error((ByteString::from_utf8_without_validation("Expected trait name"sv)),span));
 return JaktInternal::LoopBreak{};
 }
 return JaktInternal::ExplicitValue<void>();
@@ -12296,7 +12296,7 @@ return JaktInternal::ExplicitValue<void>();
 case 93 /* Reflect */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Reflect;utility::Span const& span = __jakt_match_value.value;
 {
-((*this).error((ByteString::must_from_utf8("Expected trait name"sv)),span));
+((*this).error((ByteString::from_utf8_without_validation("Expected trait name"sv)),span));
 return JaktInternal::LoopBreak{};
 }
 return JaktInternal::ExplicitValue<void>();
@@ -12304,7 +12304,7 @@ return JaktInternal::ExplicitValue<void>();
 case 94 /* Return */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Return;utility::Span const& span = __jakt_match_value.value;
 {
-((*this).error((ByteString::must_from_utf8("Expected trait name"sv)),span));
+((*this).error((ByteString::from_utf8_without_validation("Expected trait name"sv)),span));
 return JaktInternal::LoopBreak{};
 }
 return JaktInternal::ExplicitValue<void>();
@@ -12312,7 +12312,7 @@ return JaktInternal::ExplicitValue<void>();
 case 95 /* Restricted */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Restricted;utility::Span const& span = __jakt_match_value.value;
 {
-((*this).error((ByteString::must_from_utf8("Expected trait name"sv)),span));
+((*this).error((ByteString::from_utf8_without_validation("Expected trait name"sv)),span));
 return JaktInternal::LoopBreak{};
 }
 return JaktInternal::ExplicitValue<void>();
@@ -12320,7 +12320,7 @@ return JaktInternal::ExplicitValue<void>();
 case 96 /* Sizeof */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Sizeof;utility::Span const& span = __jakt_match_value.value;
 {
-((*this).error((ByteString::must_from_utf8("Expected trait name"sv)),span));
+((*this).error((ByteString::from_utf8_without_validation("Expected trait name"sv)),span));
 return JaktInternal::LoopBreak{};
 }
 return JaktInternal::ExplicitValue<void>();
@@ -12328,7 +12328,7 @@ return JaktInternal::ExplicitValue<void>();
 case 97 /* Struct */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Struct;utility::Span const& span = __jakt_match_value.value;
 {
-((*this).error((ByteString::must_from_utf8("Expected trait name"sv)),span));
+((*this).error((ByteString::from_utf8_without_validation("Expected trait name"sv)),span));
 return JaktInternal::LoopBreak{};
 }
 return JaktInternal::ExplicitValue<void>();
@@ -12336,7 +12336,7 @@ return JaktInternal::ExplicitValue<void>();
 case 98 /* This */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.This;utility::Span const& span = __jakt_match_value.value;
 {
-((*this).error((ByteString::must_from_utf8("Expected trait name"sv)),span));
+((*this).error((ByteString::from_utf8_without_validation("Expected trait name"sv)),span));
 return JaktInternal::LoopBreak{};
 }
 return JaktInternal::ExplicitValue<void>();
@@ -12344,7 +12344,7 @@ return JaktInternal::ExplicitValue<void>();
 case 99 /* Throw */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Throw;utility::Span const& span = __jakt_match_value.value;
 {
-((*this).error((ByteString::must_from_utf8("Expected trait name"sv)),span));
+((*this).error((ByteString::from_utf8_without_validation("Expected trait name"sv)),span));
 return JaktInternal::LoopBreak{};
 }
 return JaktInternal::ExplicitValue<void>();
@@ -12352,7 +12352,7 @@ return JaktInternal::ExplicitValue<void>();
 case 100 /* Throws */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Throws;utility::Span const& span = __jakt_match_value.value;
 {
-((*this).error((ByteString::must_from_utf8("Expected trait name"sv)),span));
+((*this).error((ByteString::from_utf8_without_validation("Expected trait name"sv)),span));
 return JaktInternal::LoopBreak{};
 }
 return JaktInternal::ExplicitValue<void>();
@@ -12360,7 +12360,7 @@ return JaktInternal::ExplicitValue<void>();
 case 101 /* True */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.True;utility::Span const& span = __jakt_match_value.value;
 {
-((*this).error((ByteString::must_from_utf8("Expected trait name"sv)),span));
+((*this).error((ByteString::from_utf8_without_validation("Expected trait name"sv)),span));
 return JaktInternal::LoopBreak{};
 }
 return JaktInternal::ExplicitValue<void>();
@@ -12368,7 +12368,7 @@ return JaktInternal::ExplicitValue<void>();
 case 102 /* Try */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Try;utility::Span const& span = __jakt_match_value.value;
 {
-((*this).error((ByteString::must_from_utf8("Expected trait name"sv)),span));
+((*this).error((ByteString::from_utf8_without_validation("Expected trait name"sv)),span));
 return JaktInternal::LoopBreak{};
 }
 return JaktInternal::ExplicitValue<void>();
@@ -12376,7 +12376,7 @@ return JaktInternal::ExplicitValue<void>();
 case 103 /* Unsafe */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Unsafe;utility::Span const& span = __jakt_match_value.value;
 {
-((*this).error((ByteString::must_from_utf8("Expected trait name"sv)),span));
+((*this).error((ByteString::from_utf8_without_validation("Expected trait name"sv)),span));
 return JaktInternal::LoopBreak{};
 }
 return JaktInternal::ExplicitValue<void>();
@@ -12384,7 +12384,7 @@ return JaktInternal::ExplicitValue<void>();
 case 104 /* Virtual */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Virtual;utility::Span const& span = __jakt_match_value.value;
 {
-((*this).error((ByteString::must_from_utf8("Expected trait name"sv)),span));
+((*this).error((ByteString::from_utf8_without_validation("Expected trait name"sv)),span));
 return JaktInternal::LoopBreak{};
 }
 return JaktInternal::ExplicitValue<void>();
@@ -12392,7 +12392,7 @@ return JaktInternal::ExplicitValue<void>();
 case 105 /* Weak */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Weak;utility::Span const& span = __jakt_match_value.value;
 {
-((*this).error((ByteString::must_from_utf8("Expected trait name"sv)),span));
+((*this).error((ByteString::from_utf8_without_validation("Expected trait name"sv)),span));
 return JaktInternal::LoopBreak{};
 }
 return JaktInternal::ExplicitValue<void>();
@@ -12400,7 +12400,7 @@ return JaktInternal::ExplicitValue<void>();
 case 106 /* While */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.While;utility::Span const& span = __jakt_match_value.value;
 {
-((*this).error((ByteString::must_from_utf8("Expected trait name"sv)),span));
+((*this).error((ByteString::from_utf8_without_validation("Expected trait name"sv)),span));
 return JaktInternal::LoopBreak{};
 }
 return JaktInternal::ExplicitValue<void>();
@@ -12408,7 +12408,7 @@ return JaktInternal::ExplicitValue<void>();
 case 107 /* Yield */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Yield;utility::Span const& span = __jakt_match_value.value;
 {
-((*this).error((ByteString::must_from_utf8("Expected trait name"sv)),span));
+((*this).error((ByteString::from_utf8_without_validation("Expected trait name"sv)),span));
 return JaktInternal::LoopBreak{};
 }
 return JaktInternal::ExplicitValue<void>();
@@ -12416,7 +12416,7 @@ return JaktInternal::ExplicitValue<void>();
 case 108 /* Guard */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Guard;utility::Span const& span = __jakt_match_value.value;
 {
-((*this).error((ByteString::must_from_utf8("Expected trait name"sv)),span));
+((*this).error((ByteString::from_utf8_without_validation("Expected trait name"sv)),span));
 return JaktInternal::LoopBreak{};
 }
 return JaktInternal::ExplicitValue<void>();
@@ -12424,7 +12424,7 @@ return JaktInternal::ExplicitValue<void>();
 case 109 /* Implements */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Implements;utility::Span const& span = __jakt_match_value.value;
 {
-((*this).error((ByteString::must_from_utf8("Expected trait name"sv)),span));
+((*this).error((ByteString::from_utf8_without_validation("Expected trait name"sv)),span));
 return JaktInternal::LoopBreak{};
 }
 return JaktInternal::ExplicitValue<void>();
@@ -12432,7 +12432,7 @@ return JaktInternal::ExplicitValue<void>();
 case 110 /* Requires */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Requires;utility::Span const& span = __jakt_match_value.value;
 {
-((*this).error((ByteString::must_from_utf8("Expected trait name"sv)),span));
+((*this).error((ByteString::from_utf8_without_validation("Expected trait name"sv)),span));
 return JaktInternal::LoopBreak{};
 }
 return JaktInternal::ExplicitValue<void>();
@@ -12440,7 +12440,7 @@ return JaktInternal::ExplicitValue<void>();
 case 111 /* Trait */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Trait;utility::Span const& span = __jakt_match_value.value;
 {
-((*this).error((ByteString::must_from_utf8("Expected trait name"sv)),span));
+((*this).error((ByteString::from_utf8_without_validation("Expected trait name"sv)),span));
 return JaktInternal::LoopBreak{};
 }
 return JaktInternal::ExplicitValue<void>();
@@ -12448,7 +12448,7 @@ return JaktInternal::ExplicitValue<void>();
 case 112 /* Garbage */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Garbage;utility::Span const& span = __jakt_match_value.span;
 {
-((*this).error((ByteString::must_from_utf8("Expected trait name"sv)),span));
+((*this).error((ByteString::from_utf8_without_validation("Expected trait name"sv)),span));
 return JaktInternal::LoopBreak{};
 }
 return JaktInternal::ExplicitValue<void>();
@@ -12466,7 +12466,7 @@ default: VERIFY_NOT_REACHED();}/*switch end*/
 });
 }
 if (((result).is_empty())){
-((*this).error((ByteString::must_from_utf8("Expected trait list to have at least one trait inside it"sv)),((((*this).previous())).span())));
+((*this).error((ByteString::from_utf8_without_validation("Expected trait list to have at least one trait inside it"sv)),((((*this).previous())).span())));
 return JaktInternal::OptionalNone();
 }
 else {
@@ -12475,7 +12475,7 @@ return static_cast<JaktInternal::Optional<JaktInternal::DynamicArray<parser::Par
 
 }
 else {
-((*this).error((ByteString::must_from_utf8("Expected '(' to start the trait list"sv)),((((*this).current())).span())));
+((*this).error((ByteString::from_utf8_without_validation("Expected '(' to start the trait list"sv)),((((*this).current())).span())));
 return JaktInternal::OptionalNone();
 }
 
@@ -12543,14 +12543,14 @@ return JaktInternal::ExplicitValue<void>();
 };/*case end*/
 case 112 /* Garbage */: {
 {
-((*this).error((ByteString::must_from_utf8("Expected `>` to end the generic parameters"sv)),((((*this).current())).span())));
+((*this).error((ByteString::from_utf8_without_validation("Expected `>` to end the generic parameters"sv)),((((*this).current())).span())));
 return generic_parameters;
 }
 return JaktInternal::ExplicitValue<void>();
 };/*case end*/
 default: {
 {
-((*this).error((ByteString::must_from_utf8("Expected generic parameter name"sv)),((((*this).current())).span())));
+((*this).error((ByteString::from_utf8_without_validation("Expected generic parameter name"sv)),((((*this).current())).span())));
 return generic_parameters;
 }
 return JaktInternal::ExplicitValue<void>();
@@ -12568,7 +12568,7 @@ return JaktInternal::ExplicitValue<void>();
 });
 }
 if ((!(saw_ending_bracket))){
-((*this).error((ByteString::must_from_utf8("Expected `>` to end the generic parameters"sv)),((((*this).current())).span())));
+((*this).error((ByteString::from_utf8_without_validation("Expected `>` to end the generic parameters"sv)),((((*this).current())).span())));
 return generic_parameters;
 }
 return generic_parameters;
@@ -12582,7 +12582,7 @@ ByteString const name = (((*this).current())).as.Identifier.name;
 ((((*this).index)) += (static_cast<size_t>(2ULL)));
 return name;
 }
-return (ByteString::must_from_utf8(""sv));
+return (ByteString::from_utf8_without_validation(""sv));
 }
 }
 
@@ -12594,7 +12594,7 @@ if (((((*this).current())).__jakt_init_index() == 7 /* LParen */)){
 ((((*this).index)++));
 }
 else {
-((*this).error((ByteString::must_from_utf8("Expected ‘(’"sv)),((((*this).current())).span())));
+((*this).error((ByteString::from_utf8_without_validation("Expected ‘(’"sv)),((((*this).current())).span())));
 return parser::Visibility::Restricted(DynamicArray<parser::VisibilityRestriction>::create_with({}),restricted_span);
 }
 
@@ -12628,7 +12628,7 @@ if (expect_comma){
 (expect_comma = false);
 }
 else {
-((*this).error((ByteString::must_from_utf8("Unexpected comma"sv)),span));
+((*this).error((ByteString::from_utf8_without_validation("Unexpected comma"sv)),span));
 }
 
 ((((*this).index)++));
@@ -12638,7 +12638,7 @@ return JaktInternal::ExplicitValue<void>();
 default: {
 {
 if (expect_comma){
-((*this).error((ByteString::must_from_utf8("Expected comma"sv)),((((*this).current())).span())));
+((*this).error((ByteString::from_utf8_without_validation("Expected comma"sv)),((((*this).current())).span())));
 }
 ((*this).skip_newlines());
 JaktInternal::DynamicArray<ByteString> names = DynamicArray<ByteString>::create_with({});
@@ -12661,7 +12661,7 @@ break;
 
 }
 if (((names).is_empty())){
-((*this).error((ByteString::must_from_utf8("Expected identifier"sv)),((((*this).current())).span())));
+((*this).error((ByteString::from_utf8_without_validation("Expected identifier"sv)),((((*this).current())).span())));
 }
 else {
 ByteString const name = (((names).pop()).value());
@@ -12686,13 +12686,13 @@ return JaktInternal::ExplicitValue<void>();
 }
 (((restricted_span).end) = ((((((*this).current())).span())).end));
 if (((whitelist).is_empty())){
-((*this).error_with_hint((ByteString::must_from_utf8("Restriction list cannot be empty"sv)),restricted_span,(ByteString::must_from_utf8("Did you mean to use ‘private’ instead of ‘restricted’?"sv)),restricted_span));
+((*this).error_with_hint((ByteString::from_utf8_without_validation("Restriction list cannot be empty"sv)),restricted_span,(ByteString::from_utf8_without_validation("Did you mean to use ‘private’ instead of ‘restricted’?"sv)),restricted_span));
 }
 if (((((*this).current())).__jakt_init_index() == 8 /* RParen */)){
 ((((*this).index)++));
 }
 else {
-((*this).error((ByteString::must_from_utf8("Expected ‘)’"sv)),((((*this).current())).span())));
+((*this).error((ByteString::from_utf8_without_validation("Expected ‘)’"sv)),((((*this).current())).span())));
 }
 
 return parser::Visibility::Restricted(whitelist,restricted_span);
@@ -12704,7 +12704,7 @@ ErrorOr<NonnullRefPtr<typename parser::ParsedExpression>> parser::Parser::parse_
 bool is_dictionary = false;
 utility::Span const start = ((((*this).current())).span());
 if ((!(((((*this).current())).__jakt_init_index() == 11 /* LSquare */)))){
-((*this).error((ByteString::must_from_utf8("Expected ‘[’"sv)),((((*this).current())).span())));
+((*this).error((ByteString::from_utf8_without_validation("Expected ‘[’"sv)),((((*this).current())).span())));
 return parser::ParsedExpression::Garbage(((((*this).current())).span()));
 }
 ((((*this).index)++));
@@ -12742,7 +12742,7 @@ if (((((output).size())) == (static_cast<size_t>(1ULL)))){
 (fill_size_expr = TRY((((*this).parse_expression(false,false)))));
 }
 else {
-((*this).error((ByteString::must_from_utf8("Can't fill an Array with more than one expression"sv)),((((*this).current())).span())));
+((*this).error((ByteString::from_utf8_without_validation("Can't fill an Array with more than one expression"sv)),((((*this).current())).span())));
 ((((*this).index)++));
 }
 
@@ -12759,12 +12759,12 @@ if (((((*this).current())).__jakt_init_index() == 12 /* RSquare */)){
 return JaktInternal::LoopBreak{};
 }
 else {
-((*this).error((ByteString::must_from_utf8("Expected ‘]’"sv)),((((*this).current())).span())));
+((*this).error((ByteString::from_utf8_without_validation("Expected ‘]’"sv)),((((*this).current())).span())));
 }
 
 }
 else {
-((*this).error((ByteString::must_from_utf8("Missing key in dictionary literal"sv)),((((*this).current())).span())));
+((*this).error((ByteString::from_utf8_without_validation("Missing key in dictionary literal"sv)),((((*this).current())).span())));
 }
 
 }
@@ -12778,12 +12778,12 @@ return JaktInternal::LoopBreak{};
 }
 if (((((*this).current())).__jakt_init_index() == 5 /* Colon */)){
 if ((!(((output).is_empty())))){
-((*this).error((ByteString::must_from_utf8("Mixing dictionary and array values"sv)),((((*this).current())).span())));
+((*this).error((ByteString::from_utf8_without_validation("Mixing dictionary and array values"sv)),((((*this).current())).span())));
 }
 (is_dictionary = true);
 ((((*this).index)++));
 if (((*this).eof())){
-((*this).error((ByteString::must_from_utf8("Key missing value in dictionary"sv)),((((*this).current())).span())));
+((*this).error((ByteString::from_utf8_without_validation("Key missing value in dictionary"sv)),((((*this).current())).span())));
 return parser::ParsedExpression::Garbage(((((*this).current())).span()));
 }
 NonnullRefPtr<typename parser::ParsedExpression> const value = TRY((((*this).parse_expression(false,false))));
@@ -12819,7 +12819,7 @@ return (infallible_enum_cast<jakt__prelude__operators::Ordering>((JaktInternal::
 }
 }
 (end,((((*this).tokens)).size())) || (!(((((((*this).tokens))[end])).__jakt_init_index() == 12 /* RSquare */))))){
-((*this).error((ByteString::must_from_utf8("Expected ‘]’ to close the array"sv)),((((((*this).tokens))[end])).span())));
+((*this).error((ByteString::from_utf8_without_validation("Expected ‘]’ to close the array"sv)),((((((*this).tokens))[end])).span())));
 }
 if (is_dictionary){
 return parser::ParsedExpression::JaktDictionary(dict_output,parser::merge_spans(start,((((((*this).tokens))[end])).span())));
@@ -13010,7 +13010,7 @@ return JaktInternal::ExplicitValue(name);
 };/*case end*/
 case 2 /* Operator */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Operator;ByteString const& name = __jakt_match_value.name;
-return JaktInternal::ExplicitValue((((ByteString::must_from_utf8("operator"sv))) + (name)));
+return JaktInternal::ExplicitValue((((ByteString::from_utf8_without_validation("operator"sv))) + (name)));
 };/*case end*/
 default: VERIFY_NOT_REACHED();}/*switch end*/
 }()
@@ -13885,7 +13885,7 @@ ByteString const name = (*this).as.Literal.name;
 return name;
 }
 else {
-utility::panic((ByteString::must_from_utf8("Cannot get literal name of non-literal import name"sv)));
+utility::panic((ByteString::from_utf8_without_validation("Cannot get literal name of non-literal import name"sv)));
 }
 
 }
@@ -14509,19 +14509,19 @@ return ({
 auto&& __jakt_match_variant = *this;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 0 /* Struct */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("struct"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("struct"sv)));
 };/*case end*/
 case 1 /* Class */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("class"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("class"sv)));
 };/*case end*/
 case 2 /* ValueEnum */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("value enum"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("value enum"sv)));
 };/*case end*/
 case 3 /* SumEnum */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("sum enum"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("sum enum"sv)));
 };/*case end*/
 case 4 /* Garbage */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("<garbage record type>"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("<garbage record type>"sv)));
 };/*case end*/
 default: VERIFY_NOT_REACHED();}/*switch end*/
 }()

--- a/bootstrap/stage0/platform.cpp
+++ b/bootstrap/stage0/platform.cpp
@@ -7,7 +7,7 @@ ByteString const target_name = TRY((((target).name(false))));
 return __jakt_format((StringView::from_string_literal("{}/{}"sv)),target_name,({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<ByteString,ErrorOr<ByteString>>{
 auto __jakt_enum_value = (((target).os));
-if (__jakt_enum_value == (ByteString::must_from_utf8("windows"sv))) {
+if (__jakt_enum_value == (ByteString::from_utf8_without_validation("windows"sv))) {
 return JaktInternal::ExplicitValue(__jakt_format((StringView::from_string_literal("jakt_{}_{}.lib"sv)),name,target_name));
 }
 else {

--- a/bootstrap/stage0/project.cpp
+++ b/bootstrap/stage0/project.cpp
@@ -10,10 +10,10 @@ builder.append(")"sv);return builder.to_string(); }
 ErrorOr<void> project::Project::populate() const {
 {
 ByteString const current_directory = TRY((jakt__platform__unknown_fs::current_directory()));
-ByteString const project_directory = ((((current_directory) + ((ByteString::must_from_utf8("/"sv))))) + (((*this).name)));
+ByteString const project_directory = ((((current_directory) + ((ByteString::from_utf8_without_validation("/"sv))))) + (((*this).name)));
 outln((StringView::from_string_literal("Creating jakt project in {}.."sv)),project_directory);
 TRY((jakt__platform__unknown_fs::make_directory(project_directory)));
-TRY((jakt__platform__unknown_fs::make_directory(((project_directory) + ((ByteString::must_from_utf8("/src"sv)))))));
+TRY((jakt__platform__unknown_fs::make_directory(((project_directory) + ((ByteString::from_utf8_without_validation("/src"sv)))))));
 out((StringView::from_string_literal("\tGenerating CMakeLists.txt..."sv)));
 TRY((((*this).create_template_cmake_lists(project_directory))));
 outln((StringView::from_string_literal(" done"sv)));
@@ -30,26 +30,26 @@ return {};
 
 ErrorOr<void> project::Project::create_template_cmake_lists(ByteString const project_directory) const {
 {
-ByteString const cml_contents = (((((((((ByteString::must_from_utf8("cmake_minimum_required(VERSION 3.20)\nproject("sv))) + (((*this).name)))) + ((ByteString::must_from_utf8("\n   VERSION 1.0.0\n   LANGUAGES CXX\n)\n\nfind_package(Jakt REQUIRED)\n\nadd_jakt_executable("sv))))) + (((*this).name)))) + ((ByteString::must_from_utf8("\n   MAIN_SOURCE src/main.jakt\n   MODULE_SOURCES\n     src/second_module.jakt\n)\n"sv))));
-TRY((utility::write_to_file(cml_contents,((project_directory) + ((ByteString::must_from_utf8("/CMakeLists.txt"sv)))))));
+ByteString const cml_contents = (((((((((ByteString::from_utf8_without_validation("cmake_minimum_required(VERSION 3.20)\nproject("sv))) + (((*this).name)))) + ((ByteString::from_utf8_without_validation("\n   VERSION 1.0.0\n   LANGUAGES CXX\n)\n\nfind_package(Jakt REQUIRED)\n\nadd_jakt_executable("sv))))) + (((*this).name)))) + ((ByteString::from_utf8_without_validation("\n   MAIN_SOURCE src/main.jakt\n   MODULE_SOURCES\n     src/second_module.jakt\n)\n"sv))));
+TRY((utility::write_to_file(cml_contents,((project_directory) + ((ByteString::from_utf8_without_validation("/CMakeLists.txt"sv)))))));
 }
 return {};
 }
 
 ErrorOr<void> project::Project::create_sample_jakt_files(ByteString const project_directory) const {
 {
-ByteString const main_jakt = (ByteString::must_from_utf8("import second_module { get_string }\n\nfn main() throws -> c_int {\n    println(\"{}!\", get_string())\n    return 0\n}\n"sv));
-ByteString const second_module_jakt = (ByteString::must_from_utf8("fn get_string() throws -> String {\n    return \"Hello, World\"\n}\n"sv));
-TRY((utility::write_to_file(main_jakt,((project_directory) + ((ByteString::must_from_utf8("/src/main.jakt"sv)))))));
-TRY((utility::write_to_file(second_module_jakt,((project_directory) + ((ByteString::must_from_utf8("/src/second_module.jakt"sv)))))));
+ByteString const main_jakt = (ByteString::from_utf8_without_validation("import second_module { get_string }\n\nfn main() throws -> c_int {\n    println(\"{}!\", get_string())\n    return 0\n}\n"sv));
+ByteString const second_module_jakt = (ByteString::from_utf8_without_validation("fn get_string() throws -> String {\n    return \"Hello, World\"\n}\n"sv));
+TRY((utility::write_to_file(main_jakt,((project_directory) + ((ByteString::from_utf8_without_validation("/src/main.jakt"sv)))))));
+TRY((utility::write_to_file(second_module_jakt,((project_directory) + ((ByteString::from_utf8_without_validation("/src/second_module.jakt"sv)))))));
 }
 return {};
 }
 
 ErrorOr<void> project::Project::create_readme(ByteString const project_directory) const {
 {
-ByteString const readme_text = (((((((((ByteString::must_from_utf8("# Example Jakt Project\n\nThis example jakt project has two modules, hurray!\n\n## Building with jakt\n\n```console\njakt src/main.jakt -o "sv))) + (((*this).name)))) + ((ByteString::must_from_utf8("\n```\n\n## Building with CMake\n\nMake sure to install the ``jakt`` compiler somewhere. For example, ``/path/to/jakt-install``.\n\nThis can be done by cloning ``jakt``, and running the following commands from its directory:\n\n```console\njakt> cmake -GNinja -B build -DCMAKE_CXX_COMPILER=clang++ -DCMAKE_INSTALL_PREFIX=/path/to/jakt-install\njakt> cmake --build build\njakt> cmake --install build\n```\n\nNext you can build this project by configuring CMake to know where to find the ``jakt`` cmake helper scripts.\n\n```console\n> cmake -GNinja -B build -DCMAKE_CXX_COMPILER=clang++ -DCMAKE_PREFIX_PATH=/path/to/jakt-install\n> cmake --build build\n```\n\n## Running the application\n\nAfter building, the program will be in the ``build`` directory\n\n```console\n./build/"sv))))) + (((*this).name)))) + ((ByteString::must_from_utf8("\n```\n\nWhich should print:\n\n```console\nHello, World!\n```\n"sv))));
-TRY((utility::write_to_file(readme_text,((project_directory) + ((ByteString::must_from_utf8("/README.md"sv)))))));
+ByteString const readme_text = (((((((((ByteString::from_utf8_without_validation("# Example Jakt Project\n\nThis example jakt project has two modules, hurray!\n\n## Building with jakt\n\n```console\njakt src/main.jakt -o "sv))) + (((*this).name)))) + ((ByteString::from_utf8_without_validation("\n```\n\n## Building with CMake\n\nMake sure to install the ``jakt`` compiler somewhere. For example, ``/path/to/jakt-install``.\n\nThis can be done by cloning ``jakt``, and running the following commands from its directory:\n\n```console\njakt> cmake -GNinja -B build -DCMAKE_CXX_COMPILER=clang++ -DCMAKE_INSTALL_PREFIX=/path/to/jakt-install\njakt> cmake --build build\njakt> cmake --install build\n```\n\nNext you can build this project by configuring CMake to know where to find the ``jakt`` cmake helper scripts.\n\n```console\n> cmake -GNinja -B build -DCMAKE_CXX_COMPILER=clang++ -DCMAKE_PREFIX_PATH=/path/to/jakt-install\n> cmake --build build\n```\n\n## Running the application\n\nAfter building, the program will be in the ``build`` directory\n\n```console\n./build/"sv))))) + (((*this).name)))) + ((ByteString::from_utf8_without_validation("\n```\n\nWhich should print:\n\n```console\nHello, World!\n```\n"sv))));
+TRY((utility::write_to_file(readme_text,((project_directory) + ((ByteString::from_utf8_without_validation("/README.md"sv)))))));
 }
 return {};
 }

--- a/bootstrap/stage0/repl.cpp
+++ b/bootstrap/stage0/repl.cpp
@@ -8,40 +8,40 @@ return ({
 auto&& __jakt_match_variant = op;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 0 /* PreIncrement */: {
-return JaktInternal::ExplicitValue((((ByteString::must_from_utf8("++"sv))) + (expr)));
+return JaktInternal::ExplicitValue((((ByteString::from_utf8_without_validation("++"sv))) + (expr)));
 };/*case end*/
 case 1 /* PostIncrement */: {
-return JaktInternal::ExplicitValue(((expr) + ((ByteString::must_from_utf8("++"sv)))));
+return JaktInternal::ExplicitValue(((expr) + ((ByteString::from_utf8_without_validation("++"sv)))));
 };/*case end*/
 case 2 /* PreDecrement */: {
-return JaktInternal::ExplicitValue((((ByteString::must_from_utf8("--"sv))) + (expr)));
+return JaktInternal::ExplicitValue((((ByteString::from_utf8_without_validation("--"sv))) + (expr)));
 };/*case end*/
 case 3 /* PostDecrement */: {
-return JaktInternal::ExplicitValue(((expr) + ((ByteString::must_from_utf8("--"sv)))));
+return JaktInternal::ExplicitValue(((expr) + ((ByteString::from_utf8_without_validation("--"sv)))));
 };/*case end*/
 case 4 /* Negate */: {
-return JaktInternal::ExplicitValue((((ByteString::must_from_utf8("-"sv))) + (expr)));
+return JaktInternal::ExplicitValue((((ByteString::from_utf8_without_validation("-"sv))) + (expr)));
 };/*case end*/
 case 5 /* Dereference */: {
-return JaktInternal::ExplicitValue((((ByteString::must_from_utf8("*"sv))) + (expr)));
+return JaktInternal::ExplicitValue((((ByteString::from_utf8_without_validation("*"sv))) + (expr)));
 };/*case end*/
 case 6 /* RawAddress */: {
-return JaktInternal::ExplicitValue((((ByteString::must_from_utf8("&raw "sv))) + (expr)));
+return JaktInternal::ExplicitValue((((ByteString::from_utf8_without_validation("&raw "sv))) + (expr)));
 };/*case end*/
 case 7 /* Reference */: {
-return JaktInternal::ExplicitValue((((ByteString::must_from_utf8("&"sv))) + (expr)));
+return JaktInternal::ExplicitValue((((ByteString::from_utf8_without_validation("&"sv))) + (expr)));
 };/*case end*/
 case 8 /* MutableReference */: {
-return JaktInternal::ExplicitValue((((ByteString::must_from_utf8("&mut "sv))) + (expr)));
+return JaktInternal::ExplicitValue((((ByteString::from_utf8_without_validation("&mut "sv))) + (expr)));
 };/*case end*/
 case 9 /* LogicalNot */: {
-return JaktInternal::ExplicitValue((((ByteString::must_from_utf8("not "sv))) + (expr)));
+return JaktInternal::ExplicitValue((((ByteString::from_utf8_without_validation("not "sv))) + (expr)));
 };/*case end*/
 case 10 /* BitwiseNot */: {
-return JaktInternal::ExplicitValue((((ByteString::must_from_utf8("~"sv))) + (expr)));
+return JaktInternal::ExplicitValue((((ByteString::from_utf8_without_validation("~"sv))) + (expr)));
 };/*case end*/
 default: {
-return JaktInternal::ExplicitValue((((((ByteString::must_from_utf8("(<Unimplemented unary operator> "sv))) + (expr))) + ((ByteString::must_from_utf8(")"sv)))));
+return JaktInternal::ExplicitValue((((((ByteString::from_utf8_without_validation("(<Unimplemented unary operator> "sv))) + (expr))) + ((ByteString::from_utf8_without_validation(")"sv)))));
 };/*case end*/
 }/*switch end*/
 }()
@@ -188,11 +188,11 @@ case 9 /* Range */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Range;JaktInternal::Optional<NonnullRefPtr<typename types::CheckedExpression>> const& from = __jakt_match_value.from;
 JaktInternal::Optional<NonnullRefPtr<typename types::CheckedExpression>> const& to = __jakt_match_value.to;
 return JaktInternal::ExplicitValue(({ Optional<ByteString> __jakt_var_928; {
-ByteString from_output = (ByteString::must_from_utf8(""sv));
+ByteString from_output = (ByteString::from_utf8_without_validation(""sv));
 if (((from).has_value())){
 (from_output = TRY((repl::serialize_ast_node((from.value())))));
 }
-ByteString to_output = (ByteString::must_from_utf8(""sv));
+ByteString to_output = (ByteString::from_utf8_without_validation(""sv));
 if (((to).has_value())){
 (to_output = TRY((repl::serialize_ast_node((to.value())))));
 }
@@ -343,7 +343,7 @@ auto&& __jakt_match_value = __jakt_match_variant.as.Var;NonnullRefPtr<types::Che
 return JaktInternal::ExplicitValue(((var)->name));
 };/*case end*/
 case 25 /* OptionalNone */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("None"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("None"sv)));
 };/*case end*/
 case 26 /* OptionalSome */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.OptionalSome;NonnullRefPtr<typename types::CheckedExpression> const& expr = __jakt_match_value.expr;
@@ -405,10 +405,10 @@ __jakt_var_933 = ((builder).to_string()); goto __jakt_label_827;
 __jakt_label_827:; __jakt_var_933.release_value(); }));
 };/*case end*/
 case 34 /* Garbage */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("<Garbage>"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("<Garbage>"sv)));
 };/*case end*/
 default: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("<Unimplemented>"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("<Unimplemented>"sv)));
 };/*case end*/
 }/*switch end*/
 }()
@@ -436,11 +436,11 @@ builder.appendff("file_id: {}", file_id);
 builder.append(")"sv);return builder.to_string(); }
 ErrorOr<repl::REPL> repl::REPL::create(jakt__path::Path const runtime_path,JaktInternal::Optional<ByteString> const target_triple,JaktInternal::Dictionary<ByteString,ByteString> const user_configuration) {
 {
-NonnullRefPtr<compiler::Compiler> compiler = compiler::Compiler::__jakt_create(DynamicArray<jakt__path::Path>::create_with({}),Dictionary<ByteString, utility::FileId>::create_with_entries({}),DynamicArray<error::JaktError>::create_with({}),JaktInternal::OptionalNone(),DynamicArray<u8>::create_with({}),false,false,false,false,runtime_path,DynamicArray<ByteString>::create_with({}),false,false,false,false,target_triple,user_configuration,jakt__path::Path::from_string((ByteString::must_from_utf8("build"sv))),jakt__path::Path::from_string((ByteString::must_from_utf8("repl.jakt"sv))));
+NonnullRefPtr<compiler::Compiler> compiler = compiler::Compiler::__jakt_create(DynamicArray<jakt__path::Path>::create_with({}),Dictionary<ByteString, utility::FileId>::create_with_entries({}),DynamicArray<error::JaktError>::create_with({}),JaktInternal::OptionalNone(),DynamicArray<u8>::create_with({}),false,false,false,false,runtime_path,DynamicArray<ByteString>::create_with({}),false,false,false,false,target_triple,user_configuration,jakt__path::Path::from_string((ByteString::from_utf8_without_validation("build"sv))),jakt__path::Path::from_string((ByteString::from_utf8_without_validation("repl.jakt"sv))));
 TRY((((compiler)->load_prelude())));
-utility::FileId const file_id = ((compiler)->get_file_id_or_register(jakt__path::Path::from_string((ByteString::must_from_utf8("<repl>"sv)))));
+utility::FileId const file_id = ((compiler)->get_file_id_or_register(jakt__path::Path::from_string((ByteString::from_utf8_without_validation("<repl>"sv)))));
 ids::ModuleId const placeholder_module_id = ids::ModuleId(static_cast<size_t>(0ULL));
-ByteString const root_module_name = (ByteString::must_from_utf8("repl"sv));
+ByteString const root_module_name = (ByteString::from_utf8_without_validation("repl"sv));
 typechecker::Typechecker typechecker = typechecker::Typechecker(compiler,types::CheckedProgram::__jakt_create(compiler,DynamicArray<NonnullRefPtr<types::Module>>::create_with({}),Dictionary<ByteString, types::LoadedModule>::create_with_entries({})),placeholder_module_id,ids::TypeId::none(),JaktInternal::OptionalNone(),false,static_cast<size_t>(0ULL),false,((compiler)->dump_type_hints),((compiler)->dump_try_hints),static_cast<u64>(0ULL),types::GenericInferences(Dictionary<ids::TypeId, ids::TypeId>::create_with_entries({})),JaktInternal::OptionalNone(),root_module_name,false,false,Dictionary<ByteString, ids::ScopeId>::create_with_entries({}),JaktInternal::OptionalNone());
 (((compiler)->current_file) = file_id);
 TRY((((typechecker).include_prelude())));
@@ -448,8 +448,8 @@ ids::ModuleId const root_module_id = ((typechecker).create_module(root_module_na
 (((typechecker).current_module_id) = root_module_id);
 ((((typechecker).program))->set_loaded_module(root_module_name,types::LoadedModule(root_module_id,file_id)));
 ids::ScopeId const PRELUDE_SCOPE_ID = ((typechecker).prelude_scope_id());
-ids::ScopeId const root_scope_id = ((typechecker).create_scope(PRELUDE_SCOPE_ID,true,(ByteString::must_from_utf8("root"sv)),true));
-TRY((((typechecker).typecheck_module_import(parser::ParsedModuleImport(parser::ImportName::Literal((ByteString::must_from_utf8("jakt::prelude::prelude"sv)),utility::Span(utility::FileId(static_cast<size_t>(0ULL)),static_cast<size_t>(0ULL),static_cast<size_t>(0ULL))),JaktInternal::OptionalNone(),parser::ImportList::All(),false,static_cast<size_t>(0ULL)),root_scope_id))));
+ids::ScopeId const root_scope_id = ((typechecker).create_scope(PRELUDE_SCOPE_ID,true,(ByteString::from_utf8_without_validation("root"sv)),true));
+TRY((((typechecker).typecheck_module_import(parser::ParsedModuleImport(parser::ImportName::Literal((ByteString::from_utf8_without_validation("jakt::prelude::prelude"sv)),utility::Span(utility::FileId(static_cast<size_t>(0ULL)),static_cast<size_t>(0ULL),static_cast<size_t>(0ULL))),JaktInternal::OptionalNone(),parser::ImportList::All(),false,static_cast<size_t>(0ULL)),root_scope_id))));
 NonnullRefPtr<interpreter::InterpreterScope> const root_interpreter_scope = interpreter::InterpreterScope::create(Dictionary<ByteString, types::Value>::create_with_entries({}),JaktInternal::OptionalNone(),Dictionary<ids::TypeId, ids::TypeId>::create_with_entries({}));
 return repl::REPL(compiler,typechecker,root_scope_id,root_interpreter_scope,file_id);
 }
@@ -891,7 +891,7 @@ return JaktInternal::ExplicitValue<void>();
 return {};
 }
 ;
-repl_backend__default::Editor editor = TRY((repl_backend__default::Editor::create((ByteString::must_from_utf8("> "sv)),((syntax_highlight_handler)))));
+repl_backend__default::Editor editor = TRY((repl_backend__default::Editor::create((ByteString::from_utf8_without_validation("> "sv)),((syntax_highlight_handler)))));
 ScopeGuard __jakt_var_937([&] {
 ((editor).destroy());
 });
@@ -912,10 +912,10 @@ return {};
 __jakt_var_938.release_value(); });
 if (((line_result).__jakt_init_index() == 0 /* Line */)){
 ByteString const line = (line_result).as.Line.value;
-if (((line) == ((ByteString::must_from_utf8("\n"sv))))){
+if (((line) == ((ByteString::from_utf8_without_validation("\n"sv))))){
 continue;
 }
-if (((line) == ((ByteString::must_from_utf8(".exit\n"sv))))){
+if (((line) == ((ByteString::from_utf8_without_validation(".exit\n"sv))))){
 break;
 }
 (((((*this).compiler))->current_file) = ((*this).file_id));
@@ -936,7 +936,7 @@ ByteStringBuilder builder = ByteStringBuilder::create();
 ((builder).append(line));
 while ((!(repl::REPL::check_parens(tokens)))){
 repl_backend__common::LineResult const line_result = ({ Optional<repl_backend__common::LineResult> __jakt_var_942;
-auto __jakt_var_943 = [&]() -> ErrorOr<repl_backend__common::LineResult> { return TRY((((editor).get_line((ByteString::must_from_utf8(".."sv)))))); }();
+auto __jakt_var_943 = [&]() -> ErrorOr<repl_backend__common::LineResult> { return TRY((((editor).get_line((ByteString::from_utf8_without_validation(".."sv)))))); }();
 if (__jakt_var_943.is_error()) {auto error = __jakt_var_943.release_error();
 {
 return {};
@@ -1097,7 +1097,7 @@ return JaktInternal::ExplicitValue(TRY((repl::serialize_ast_node(TRY((interprete
 };/*case end*/
 case 1 /* Throw */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Throw;types::Value const& value = __jakt_match_value.value;
-return JaktInternal::ExplicitValue((((ByteString::must_from_utf8("throw "sv))) + (TRY((repl::serialize_ast_node(TRY((interpreter::value_to_checked_expression(value,interpreter)))))))));
+return JaktInternal::ExplicitValue((((ByteString::from_utf8_without_validation("throw "sv))) + (TRY((repl::serialize_ast_node(TRY((interpreter::value_to_checked_expression(value,interpreter)))))))));
 };/*case end*/
 case 4 /* Break */: {
 {

--- a/bootstrap/stage0/repl_backend__default.cpp
+++ b/bootstrap/stage0/repl_backend__default.cpp
@@ -13,7 +13,7 @@ builder.appendff("prompt: \"{}\"", prompt);
 builder.append(")"sv);return builder.to_string(); }
 ErrorOr<repl_backend__default::Editor> repl_backend__default::Editor::create(ByteString const prompt,Function<ErrorOr<void>(repl_backend__default::Editor&)> const& syntax_highlight_handler) {
 {
-FILE* std_in = fopen((((ByteString::must_from_utf8("/dev/stdin"sv))).characters()),(((ByteString::must_from_utf8("r"sv))).characters()));
+FILE* std_in = fopen((((ByteString::from_utf8_without_validation("/dev/stdin"sv))).characters()),(((ByteString::from_utf8_without_validation("r"sv))).characters()));
 if ((std_in == jakt__platform__utility::null<FILE*>())){
 warnln((StringView::from_string_literal("Could not open /dev/stdin for reading"sv)));
 return Error::from_errno(static_cast<i32>(42));

--- a/bootstrap/stage0/runtime/AK/ByteString.h
+++ b/bootstrap/stage0/runtime/AK/ByteString.h
@@ -91,6 +91,7 @@ public:
     static ErrorOr<ByteString> from_utf8(ReadonlyBytes);
     static ErrorOr<ByteString> from_utf8(StringView string) { return from_utf8(string.bytes()); }
     static ByteString must_from_utf8(StringView string) { return MUST(from_utf8(string)); }
+    static ByteString from_utf8_without_validation(StringView string) { return ByteString { string }; }
 
     [[nodiscard]] static ByteString repeated(char, size_t count);
     [[nodiscard]] static ByteString repeated(StringView, size_t count);

--- a/bootstrap/stage0/runtime/AK/Checked.h
+++ b/bootstrap/stage0/runtime/AK/Checked.h
@@ -348,6 +348,9 @@ public:
     {
 #if __has_builtin(__builtin_add_overflow_p)
         return __builtin_add_overflow_p(u, v, (T)0);
+#elif __has_builtin(__builtin_add_overflow)
+        T result;
+        return __builtin_add_overflow(u, v, &result);
 #else
         Checked checked;
         checked = u;
@@ -385,6 +388,9 @@ public:
     {
 #if __has_builtin(__builtin_mul_overflow_p)
         return __builtin_mul_overflow_p(u, v, (T)0);
+#elif __has_builtin(__builtin_mul_overflow)
+        T result;
+        return __builtin_mul_overflow(u, v, &result);
 #else
         Checked checked;
         checked = u;

--- a/bootstrap/stage0/runtime/jaktlib/prelude/string.jakt
+++ b/bootstrap/stage0/runtime/jaktlib/prelude/string.jakt
@@ -11,6 +11,6 @@ type StringView implements(FromStringLiteral) {
 }
 
 type String implements(FromStringLiteral) {
-    [[name=must_from_utf8]]
+    [[name=from_utf8_without_validation]]
     extern fn from_string_literal(anon string: StringView) -> String
 }

--- a/bootstrap/stage0/typechecker.cpp
+++ b/bootstrap/stage0/typechecker.cpp
@@ -30,9 +30,9 @@ return defines;
 ErrorOr<void> dump_scope(ids::ScopeId const scope_id,NonnullRefPtr<types::CheckedProgram> const& program,i64 const indent) {
 {
 NonnullRefPtr<types::Scope> scope = ((((program)))->get_scope(scope_id));
-warnln((StringView::from_string_literal("{: >{}}Scope (ns={}) {}"sv)),(ByteString::must_from_utf8(""sv)),indent,((scope)->namespace_name),((scope)->debug_name));
+warnln((StringView::from_string_literal("{: >{}}Scope (ns={}) {}"sv)),(ByteString::from_utf8_without_validation(""sv)),indent,((scope)->namespace_name),((scope)->debug_name));
 i64 const cindent = JaktInternal::checked_add(indent,static_cast<i64>(2LL));
-warnln((StringView::from_string_literal("{: >{}}Types:"sv)),(ByteString::must_from_utf8(""sv)),cindent);
+warnln((StringView::from_string_literal("{: >{}}Types:"sv)),(ByteString::from_utf8_without_validation(""sv)),cindent);
 {
 JaktInternal::DictionaryIterator<ByteString,ids::TypeId> _magic = ((((scope)->types)).iterator());
 for (;;){
@@ -47,13 +47,13 @@ ByteString const name = ((jakt__name__type_id__).template get<0>());
 ids::TypeId const type_id = ((jakt__name__type_id__).template get<1>());
 
 NonnullRefPtr<typename types::Type> const type = ((((program)))->get_type(type_id));
-warnln((StringView::from_string_literal("{: >{}}{}: {}"sv)),(ByteString::must_from_utf8(""sv)),JaktInternal::checked_add(cindent,static_cast<i64>(2LL)),name,TRY((((((program)))->type_name(type_id,true)))));
+warnln((StringView::from_string_literal("{: >{}}{}: {}"sv)),(ByteString::from_utf8_without_validation(""sv)),JaktInternal::checked_add(cindent,static_cast<i64>(2LL)),name,TRY((((((program)))->type_name(type_id,true)))));
 }
 
 }
 }
 
-warnln((StringView::from_string_literal("{: >{}}Specializations:"sv)),(ByteString::must_from_utf8(""sv)),cindent);
+warnln((StringView::from_string_literal("{: >{}}Specializations:"sv)),(ByteString::from_utf8_without_validation(""sv)),cindent);
 {
 JaktInternal::DictionaryIterator<ByteString,types::SpecializedType> _magic = ((((scope)->explicitly_specialized_types)).iterator());
 for (;;){
@@ -68,7 +68,7 @@ ByteString const name = ((jakt__name__type__).template get<0>());
 types::SpecializedType const type = ((jakt__name__type__).template get<1>());
 
 ByteString const type_name = TRY((((((program)))->type_name(((type).type_id),true))));
-ByteString args = (ByteString::must_from_utf8(""sv));
+ByteString args = (ByteString::from_utf8_without_validation(""sv));
 {
 JaktInternal::ArrayIterator<ids::TypeId> _magic = ((((type).arguments)).iterator());
 for (;;){
@@ -78,19 +78,19 @@ break;
 }
 ids::TypeId arg = (_magic_value.value());
 {
-(args = ((((args) + (TRY((((((program)))->type_name(arg,true))))))) + ((ByteString::must_from_utf8(", "sv)))));
+(args = ((((args) + (TRY((((((program)))->type_name(arg,true))))))) + ((ByteString::from_utf8_without_validation(", "sv)))));
 }
 
 }
 }
 
-warnln((StringView::from_string_literal("{: >{}}{}<{}> = {}"sv)),(ByteString::must_from_utf8(""sv)),JaktInternal::checked_add(cindent,static_cast<i64>(2LL)),name,args,type_name);
+warnln((StringView::from_string_literal("{: >{}}{}<{}> = {}"sv)),(ByteString::from_utf8_without_validation(""sv)),JaktInternal::checked_add(cindent,static_cast<i64>(2LL)),name,args,type_name);
 }
 
 }
 }
 
-warnln((StringView::from_string_literal("{: >{}}Variables:"sv)),(ByteString::must_from_utf8(""sv)),cindent);
+warnln((StringView::from_string_literal("{: >{}}Variables:"sv)),(ByteString::from_utf8_without_validation(""sv)),cindent);
 {
 JaktInternal::DictionaryIterator<ByteString,ids::VarId> _magic = ((((scope)->vars)).iterator());
 for (;;){
@@ -105,13 +105,13 @@ ByteString const name = ((jakt__name__var_id__).template get<0>());
 ids::VarId const var_id = ((jakt__name__var_id__).template get<1>());
 
 NonnullRefPtr<types::CheckedVariable> const var = ((((program)))->get_variable(var_id));
-warnln((StringView::from_string_literal("{: >{}}{}: {}"sv)),(ByteString::must_from_utf8(""sv)),JaktInternal::checked_add(cindent,static_cast<i64>(2LL)),name,TRY((((((program)))->type_name(((var)->type_id),true)))));
+warnln((StringView::from_string_literal("{: >{}}{}: {}"sv)),(ByteString::from_utf8_without_validation(""sv)),JaktInternal::checked_add(cindent,static_cast<i64>(2LL)),name,TRY((((((program)))->type_name(((var)->type_id),true)))));
 }
 
 }
 }
 
-warnln((StringView::from_string_literal("{: >{}}Functions:"sv)),(ByteString::must_from_utf8(""sv)),cindent);
+warnln((StringView::from_string_literal("{: >{}}Functions:"sv)),(ByteString::from_utf8_without_validation(""sv)),cindent);
 {
 JaktInternal::DictionaryIterator<ByteString,JaktInternal::DynamicArray<ids::FunctionId>> _magic = ((((scope)->functions)).iterator());
 for (;;){
@@ -125,7 +125,7 @@ JaktInternal::Tuple<ByteString,JaktInternal::DynamicArray<ids::FunctionId>> cons
 ByteString const name = ((jakt__name__ids__).template get<0>());
 JaktInternal::DynamicArray<ids::FunctionId> const ids = ((jakt__name__ids__).template get<1>());
 
-warnln((StringView::from_string_literal("{: >{}}{}:"sv)),(ByteString::must_from_utf8(""sv)),JaktInternal::checked_add(cindent,static_cast<i64>(2LL)),name);
+warnln((StringView::from_string_literal("{: >{}}{}:"sv)),(ByteString::from_utf8_without_validation(""sv)),JaktInternal::checked_add(cindent,static_cast<i64>(2LL)),name);
 {
 JaktInternal::ArrayIterator<ids::FunctionId> _magic = ((ids).iterator());
 for (;;){
@@ -136,7 +136,7 @@ break;
 ids::FunctionId id = (_magic_value.value());
 {
 NonnullRefPtr<types::CheckedFunction> const function = ((((program)))->get_function(id));
-ByteString args = (ByteString::must_from_utf8(""sv));
+ByteString args = (ByteString::from_utf8_without_validation(""sv));
 {
 JaktInternal::ArrayIterator<types::CheckedParameter> _magic = ((((function)->params)).iterator());
 for (;;){
@@ -146,13 +146,13 @@ break;
 }
 types::CheckedParameter arg = (_magic_value.value());
 {
-(args = ((((args) + (TRY((((((program)))->type_name(((((arg).variable))->type_id),true))))))) + ((ByteString::must_from_utf8(", "sv)))));
+(args = ((((args) + (TRY((((((program)))->type_name(((((arg).variable))->type_id),true))))))) + ((ByteString::from_utf8_without_validation(", "sv)))));
 }
 
 }
 }
 
-ByteString generics = (ByteString::must_from_utf8(""sv));
+ByteString generics = (ByteString::from_utf8_without_validation(""sv));
 {
 JaktInternal::ArrayIterator<types::FunctionGenericParameter> _magic = ((((((function)->generics))->params)).iterator());
 for (;;){
@@ -162,7 +162,7 @@ break;
 }
 types::FunctionGenericParameter generic = (_magic_value.value());
 {
-(generics = ((((generics) + (TRY((((((program)))->type_name(((generic).type_id()),true))))))) + ((ByteString::must_from_utf8(", "sv)))));
+(generics = ((((generics) + (TRY((((((program)))->type_name(((generic).type_id()),true))))))) + ((ByteString::from_utf8_without_validation(", "sv)))));
 }
 
 }
@@ -171,7 +171,7 @@ types::FunctionGenericParameter generic = (_magic_value.value());
 if ((!(((generics).is_empty())))){
 (generics = __jakt_format((StringView::from_string_literal("<{}>"sv)),generics));
 }
-warnln((StringView::from_string_literal("{: >{}}fn{}({}) -> {}"sv)),(ByteString::must_from_utf8(""sv)),JaktInternal::checked_add(cindent,static_cast<i64>(4LL)),generics,args,TRY((((((program)))->type_name(((function)->return_type_id),true)))));
+warnln((StringView::from_string_literal("{: >{}}fn{}({}) -> {}"sv)),(ByteString::from_utf8_without_validation(""sv)),JaktInternal::checked_add(cindent,static_cast<i64>(4LL)),generics,args,TRY((((((program)))->type_name(((function)->return_type_id),true)))));
 }
 
 }
@@ -182,7 +182,7 @@ warnln((StringView::from_string_literal("{: >{}}fn{}({}) -> {}"sv)),(ByteString:
 }
 }
 
-warnln((StringView::from_string_literal("{: >{}}Structs:"sv)),(ByteString::must_from_utf8(""sv)),cindent);
+warnln((StringView::from_string_literal("{: >{}}Structs:"sv)),(ByteString::from_utf8_without_validation(""sv)),cindent);
 {
 JaktInternal::DictionaryIterator<ByteString,ids::StructId> _magic = ((((scope)->structs)).iterator());
 for (;;){
@@ -197,13 +197,13 @@ ByteString const name = ((jakt__name__id__).template get<0>());
 ids::StructId const id = ((jakt__name__id__).template get<1>());
 
 types::CheckedStruct const struct_ = ((((program)))->get_struct(id));
-warnln((StringView::from_string_literal("{: >{}}{}@{}: {}"sv)),(ByteString::must_from_utf8(""sv)),JaktInternal::checked_add(cindent,static_cast<i64>(2LL)),((id).id),((id).module),((struct_).name));
+warnln((StringView::from_string_literal("{: >{}}{}@{}: {}"sv)),(ByteString::from_utf8_without_validation(""sv)),JaktInternal::checked_add(cindent,static_cast<i64>(2LL)),((id).id),((id).module),((struct_).name));
 }
 
 }
 }
 
-warnln((StringView::from_string_literal("{: >{}}Aliases:"sv)),(ByteString::must_from_utf8(""sv)),cindent);
+warnln((StringView::from_string_literal("{: >{}}Aliases:"sv)),(ByteString::from_utf8_without_validation(""sv)),cindent);
 {
 JaktInternal::DictionaryIterator<ByteString,ids::ScopeId> _magic = ((((scope)->aliases)).iterator());
 for (;;){
@@ -218,13 +218,13 @@ ByteString const name = ((jakt__name__id__).template get<0>());
 ids::ScopeId const id = ((jakt__name__id__).template get<1>());
 
 NonnullRefPtr<types::Scope> const scope = ((((program)))->get_scope(id));
-warnln((StringView::from_string_literal("{: >{}}{}: {}"sv)),(ByteString::must_from_utf8(""sv)),JaktInternal::checked_add(cindent,static_cast<i64>(2LL)),name,((scope)->debug_name));
+warnln((StringView::from_string_literal("{: >{}}{}: {}"sv)),(ByteString::from_utf8_without_validation(""sv)),JaktInternal::checked_add(cindent,static_cast<i64>(2LL)),name,((scope)->debug_name));
 }
 
 }
 }
 
-warnln((StringView::from_string_literal("{: >{}}Children:"sv)),(ByteString::must_from_utf8(""sv)),cindent);
+warnln((StringView::from_string_literal("{: >{}}Children:"sv)),(ByteString::from_utf8_without_validation(""sv)),cindent);
 {
 JaktInternal::ArrayIterator<ids::ScopeId> _magic = ((((scope)->children)).iterator());
 for (;;){
@@ -367,7 +367,7 @@ ErrorOr<typechecker::Typechecker> typechecker::Typechecker::typecheck(NonnullRef
 {
 JaktInternal::Optional<utility::FileId> const input_file = ((compiler)->current_file);
 if ((!(((input_file).has_value())))){
-((compiler)->panic((ByteString::must_from_utf8("trying to typecheck a non-existent file"sv))));
+((compiler)->panic((ByteString::from_utf8_without_validation("trying to typecheck a non-existent file"sv))));
 }
 ByteString const true_module_name = ((((((compiler)->files))[(((input_file.value())).id)])).basename(true));
 ids::ModuleId const placeholder_module_id = ids::ModuleId(static_cast<size_t>(0ULL));
@@ -380,8 +380,8 @@ TRY((((compiler)->set_current_file((input_file.value())))));
 types::LoadedModule const loaded_module = types::LoadedModule(root_module_id,(input_file.value()));
 ((((typechecker).program))->set_loaded_module(true_module_name,loaded_module));
 ids::ScopeId const PRELUDE_SCOPE_ID = ((typechecker).prelude_scope_id());
-ids::ScopeId const root_scope_id = ((typechecker).create_scope(PRELUDE_SCOPE_ID,false,(ByteString::must_from_utf8("root"sv)),false));
-TRY((((typechecker).typecheck_module_import(parser::ParsedModuleImport(parser::ImportName::Literal((ByteString::must_from_utf8("jakt::prelude::prelude"sv)),utility::Span(utility::FileId(static_cast<size_t>(0ULL)),static_cast<size_t>(0ULL),static_cast<size_t>(0ULL))),JaktInternal::OptionalNone(),parser::ImportList::All(),false,static_cast<size_t>(0ULL)),root_scope_id))));
+ids::ScopeId const root_scope_id = ((typechecker).create_scope(PRELUDE_SCOPE_ID,false,(ByteString::from_utf8_without_validation("root"sv)),false));
+TRY((((typechecker).typecheck_module_import(parser::ParsedModuleImport(parser::ImportName::Literal((ByteString::from_utf8_without_validation("jakt::prelude::prelude"sv)),utility::Span(utility::FileId(static_cast<size_t>(0ULL)),static_cast<size_t>(0ULL),static_cast<size_t>(0ULL))),JaktInternal::OptionalNone(),parser::ImportList::All(),false,static_cast<size_t>(0ULL)),root_scope_id))));
 {
 JaktInternal::DictionaryIterator<size_t,ids::StructId> _magic = ((((((((((typechecker).program))->modules))[static_cast<i64>(0LL)]))->builtin_implementation_structs)).iterator());
 for (;;){
@@ -536,7 +536,7 @@ if (((root_module).has_value())){
 utility::FileId const file_id = (((root_module.value())).file_id);
 return (((((*this).compiler))->get_file_path(file_id)).value());
 }
-return jakt__path::Path::from_string((ByteString::must_from_utf8("."sv)));
+return jakt__path::Path::from_string((ByteString::from_utf8_without_validation("."sv)));
 }
 }
 
@@ -636,7 +636,7 @@ return module_id;
 
 ErrorOr<void> typechecker::Typechecker::include_prelude() {
 {
-ByteString const module_name = (ByteString::must_from_utf8("__prelude__"sv));
+ByteString const module_name = (ByteString::from_utf8_without_validation("__prelude__"sv));
 jakt__path::Path const file_name = jakt__path::Path::from_string(module_name);
 JaktInternal::DynamicArray<u8> const file_contents = DynamicArray<u8>::create_with({static_cast<u8>(101), static_cast<u8>(120), static_cast<u8>(116), static_cast<u8>(101), static_cast<u8>(114), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(115), static_cast<u8>(116), static_cast<u8>(114), static_cast<u8>(117), static_cast<u8>(99), static_cast<u8>(116), static_cast<u8>(32), static_cast<u8>(79), static_cast<u8>(112), static_cast<u8>(116), static_cast<u8>(105), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(97), static_cast<u8>(108), static_cast<u8>(60), static_cast<u8>(84), static_cast<u8>(62), static_cast<u8>(32), static_cast<u8>(123), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(102), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(104), static_cast<u8>(97), static_cast<u8>(115), static_cast<u8>(95), static_cast<u8>(118), static_cast<u8>(97), static_cast<u8>(108), static_cast<u8>(117), static_cast<u8>(101), static_cast<u8>(40), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(105), static_cast<u8>(115), static_cast<u8>(41), static_cast<u8>(32), static_cast<u8>(45), static_cast<u8>(62), static_cast<u8>(32), static_cast<u8>(98), static_cast<u8>(111), static_cast<u8>(111), static_cast<u8>(108), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(102), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(118), static_cast<u8>(97), static_cast<u8>(108), static_cast<u8>(117), static_cast<u8>(101), static_cast<u8>(40), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(105), static_cast<u8>(115), static_cast<u8>(41), static_cast<u8>(32), static_cast<u8>(45), static_cast<u8>(62), static_cast<u8>(32), static_cast<u8>(84), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(102), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(118), static_cast<u8>(97), static_cast<u8>(108), static_cast<u8>(117), static_cast<u8>(101), static_cast<u8>(95), static_cast<u8>(111), static_cast<u8>(114), static_cast<u8>(40), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(105), static_cast<u8>(115), static_cast<u8>(44), static_cast<u8>(32), static_cast<u8>(97), static_cast<u8>(110), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(120), static_cast<u8>(58), static_cast<u8>(32), static_cast<u8>(84), static_cast<u8>(41), static_cast<u8>(32), static_cast<u8>(45), static_cast<u8>(62), static_cast<u8>(32), static_cast<u8>(84), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(102), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(79), static_cast<u8>(112), static_cast<u8>(116), static_cast<u8>(105), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(97), static_cast<u8>(108), static_cast<u8>(60), static_cast<u8>(83), static_cast<u8>(62), static_cast<u8>(40), static_cast<u8>(97), static_cast<u8>(110), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(120), static_cast<u8>(58), static_cast<u8>(32), static_cast<u8>(83), static_cast<u8>(41), static_cast<u8>(32), static_cast<u8>(45), static_cast<u8>(62), static_cast<u8>(32), static_cast<u8>(79), static_cast<u8>(112), static_cast<u8>(116), static_cast<u8>(105), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(97), static_cast<u8>(108), static_cast<u8>(60), static_cast<u8>(83), static_cast<u8>(62), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(102), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(109), static_cast<u8>(97), static_cast<u8>(112), static_cast<u8>(60), static_cast<u8>(85), static_cast<u8>(62), static_cast<u8>(40), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(105), static_cast<u8>(115), static_cast<u8>(44), static_cast<u8>(32), static_cast<u8>(97), static_cast<u8>(110), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(109), static_cast<u8>(97), static_cast<u8>(112), static_cast<u8>(112), static_cast<u8>(101), static_cast<u8>(114), static_cast<u8>(58), static_cast<u8>(32), static_cast<u8>(102), static_cast<u8>(110), static_cast<u8>(40), static_cast<u8>(97), static_cast<u8>(110), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(120), static_cast<u8>(58), static_cast<u8>(32), static_cast<u8>(38), static_cast<u8>(84), static_cast<u8>(41), static_cast<u8>(32), static_cast<u8>(45), static_cast<u8>(62), static_cast<u8>(32), static_cast<u8>(85), static_cast<u8>(41), static_cast<u8>(32), static_cast<u8>(45), static_cast<u8>(62), static_cast<u8>(32), static_cast<u8>(79), static_cast<u8>(112), static_cast<u8>(116), static_cast<u8>(105), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(97), static_cast<u8>(108), static_cast<u8>(60), static_cast<u8>(85), static_cast<u8>(62), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(102), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(109), static_cast<u8>(97), static_cast<u8>(112), static_cast<u8>(60), static_cast<u8>(85), static_cast<u8>(62), static_cast<u8>(40), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(105), static_cast<u8>(115), static_cast<u8>(44), static_cast<u8>(32), static_cast<u8>(97), static_cast<u8>(110), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(109), static_cast<u8>(97), static_cast<u8>(112), static_cast<u8>(112), static_cast<u8>(101), static_cast<u8>(114), static_cast<u8>(58), static_cast<u8>(32), static_cast<u8>(102), static_cast<u8>(110), static_cast<u8>(40), static_cast<u8>(97), static_cast<u8>(110), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(120), static_cast<u8>(58), static_cast<u8>(32), static_cast<u8>(38), static_cast<u8>(84), static_cast<u8>(41), static_cast<u8>(32), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(114), static_cast<u8>(111), static_cast<u8>(119), static_cast<u8>(115), static_cast<u8>(32), static_cast<u8>(45), static_cast<u8>(62), static_cast<u8>(32), static_cast<u8>(85), static_cast<u8>(41), static_cast<u8>(32), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(114), static_cast<u8>(111), static_cast<u8>(119), static_cast<u8>(115), static_cast<u8>(32), static_cast<u8>(45), static_cast<u8>(62), static_cast<u8>(32), static_cast<u8>(79), static_cast<u8>(112), static_cast<u8>(116), static_cast<u8>(105), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(97), static_cast<u8>(108), static_cast<u8>(60), static_cast<u8>(85), static_cast<u8>(62), static_cast<u8>(10), static_cast<u8>(125), static_cast<u8>(10), static_cast<u8>(10), static_cast<u8>(101), static_cast<u8>(120), static_cast<u8>(116), static_cast<u8>(101), static_cast<u8>(114), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(115), static_cast<u8>(116), static_cast<u8>(114), static_cast<u8>(117), static_cast<u8>(99), static_cast<u8>(116), static_cast<u8>(32), static_cast<u8>(65), static_cast<u8>(114), static_cast<u8>(114), static_cast<u8>(97), static_cast<u8>(121), static_cast<u8>(73), static_cast<u8>(116), static_cast<u8>(101), static_cast<u8>(114), static_cast<u8>(97), static_cast<u8>(116), static_cast<u8>(111), static_cast<u8>(114), static_cast<u8>(60), static_cast<u8>(84), static_cast<u8>(62), static_cast<u8>(32), static_cast<u8>(123), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(102), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(110), static_cast<u8>(101), static_cast<u8>(120), static_cast<u8>(116), static_cast<u8>(40), static_cast<u8>(109), static_cast<u8>(117), static_cast<u8>(116), static_cast<u8>(32), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(105), static_cast<u8>(115), static_cast<u8>(41), static_cast<u8>(32), static_cast<u8>(45), static_cast<u8>(62), static_cast<u8>(32), static_cast<u8>(84), static_cast<u8>(63), static_cast<u8>(10), static_cast<u8>(125), static_cast<u8>(10), static_cast<u8>(10), static_cast<u8>(91), static_cast<u8>(91), static_cast<u8>(110), static_cast<u8>(97), static_cast<u8>(109), static_cast<u8>(101), static_cast<u8>(61), static_cast<u8>(68), static_cast<u8>(121), static_cast<u8>(110), static_cast<u8>(97), static_cast<u8>(109), static_cast<u8>(105), static_cast<u8>(99), static_cast<u8>(65), static_cast<u8>(114), static_cast<u8>(114), static_cast<u8>(97), static_cast<u8>(121), static_cast<u8>(93), static_cast<u8>(93), static_cast<u8>(10), static_cast<u8>(101), static_cast<u8>(120), static_cast<u8>(116), static_cast<u8>(101), static_cast<u8>(114), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(115), static_cast<u8>(116), static_cast<u8>(114), static_cast<u8>(117), static_cast<u8>(99), static_cast<u8>(116), static_cast<u8>(32), static_cast<u8>(65), static_cast<u8>(114), static_cast<u8>(114), static_cast<u8>(97), static_cast<u8>(121), static_cast<u8>(60), static_cast<u8>(84), static_cast<u8>(62), static_cast<u8>(32), static_cast<u8>(123), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(102), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(105), static_cast<u8>(115), static_cast<u8>(95), static_cast<u8>(101), static_cast<u8>(109), static_cast<u8>(112), static_cast<u8>(116), static_cast<u8>(121), static_cast<u8>(40), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(105), static_cast<u8>(115), static_cast<u8>(41), static_cast<u8>(32), static_cast<u8>(45), static_cast<u8>(62), static_cast<u8>(32), static_cast<u8>(98), static_cast<u8>(111), static_cast<u8>(111), static_cast<u8>(108), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(102), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(99), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(116), static_cast<u8>(97), static_cast<u8>(105), static_cast<u8>(110), static_cast<u8>(115), static_cast<u8>(40), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(105), static_cast<u8>(115), static_cast<u8>(44), static_cast<u8>(32), static_cast<u8>(97), static_cast<u8>(110), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(118), static_cast<u8>(97), static_cast<u8>(108), static_cast<u8>(117), static_cast<u8>(101), static_cast<u8>(58), static_cast<u8>(32), static_cast<u8>(84), static_cast<u8>(41), static_cast<u8>(32), static_cast<u8>(45), static_cast<u8>(62), static_cast<u8>(32), static_cast<u8>(98), static_cast<u8>(111), static_cast<u8>(111), static_cast<u8>(108), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(102), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(115), static_cast<u8>(105), static_cast<u8>(122), static_cast<u8>(101), static_cast<u8>(40), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(105), static_cast<u8>(115), static_cast<u8>(41), static_cast<u8>(32), static_cast<u8>(45), static_cast<u8>(62), static_cast<u8>(32), static_cast<u8>(117), static_cast<u8>(115), static_cast<u8>(105), static_cast<u8>(122), static_cast<u8>(101), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(102), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(99), static_cast<u8>(97), static_cast<u8>(112), static_cast<u8>(97), static_cast<u8>(99), static_cast<u8>(105), static_cast<u8>(116), static_cast<u8>(121), static_cast<u8>(40), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(105), static_cast<u8>(115), static_cast<u8>(41), static_cast<u8>(32), static_cast<u8>(45), static_cast<u8>(62), static_cast<u8>(32), static_cast<u8>(117), static_cast<u8>(115), static_cast<u8>(105), static_cast<u8>(122), static_cast<u8>(101), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(102), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(101), static_cast<u8>(110), static_cast<u8>(115), static_cast<u8>(117), static_cast<u8>(114), static_cast<u8>(101), static_cast<u8>(95), static_cast<u8>(99), static_cast<u8>(97), static_cast<u8>(112), static_cast<u8>(97), static_cast<u8>(99), static_cast<u8>(105), static_cast<u8>(116), static_cast<u8>(121), static_cast<u8>(40), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(105), static_cast<u8>(115), static_cast<u8>(44), static_cast<u8>(32), static_cast<u8>(97), static_cast<u8>(110), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(99), static_cast<u8>(97), static_cast<u8>(112), static_cast<u8>(97), static_cast<u8>(99), static_cast<u8>(105), static_cast<u8>(116), static_cast<u8>(121), static_cast<u8>(58), static_cast<u8>(32), static_cast<u8>(117), static_cast<u8>(115), static_cast<u8>(105), static_cast<u8>(122), static_cast<u8>(101), static_cast<u8>(41), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(102), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(97), static_cast<u8>(100), static_cast<u8>(100), static_cast<u8>(95), static_cast<u8>(99), static_cast<u8>(97), static_cast<u8>(112), static_cast<u8>(97), static_cast<u8>(99), static_cast<u8>(105), static_cast<u8>(116), static_cast<u8>(121), static_cast<u8>(40), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(105), static_cast<u8>(115), static_cast<u8>(44), static_cast<u8>(32), static_cast<u8>(97), static_cast<u8>(110), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(99), static_cast<u8>(97), static_cast<u8>(112), static_cast<u8>(97), static_cast<u8>(99), static_cast<u8>(105), static_cast<u8>(116), static_cast<u8>(121), static_cast<u8>(58), static_cast<u8>(32), static_cast<u8>(117), static_cast<u8>(115), static_cast<u8>(105), static_cast<u8>(122), static_cast<u8>(101), static_cast<u8>(41), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(102), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(114), static_cast<u8>(101), static_cast<u8>(115), static_cast<u8>(105), static_cast<u8>(122), static_cast<u8>(101), static_cast<u8>(40), static_cast<u8>(109), static_cast<u8>(117), static_cast<u8>(116), static_cast<u8>(32), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(105), static_cast<u8>(115), static_cast<u8>(44), static_cast<u8>(32), static_cast<u8>(97), static_cast<u8>(110), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(115), static_cast<u8>(105), static_cast<u8>(122), static_cast<u8>(101), static_cast<u8>(58), static_cast<u8>(32), static_cast<u8>(117), static_cast<u8>(115), static_cast<u8>(105), static_cast<u8>(122), static_cast<u8>(101), static_cast<u8>(41), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(102), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(115), static_cast<u8>(104), static_cast<u8>(114), static_cast<u8>(105), static_cast<u8>(110), static_cast<u8>(107), static_cast<u8>(40), static_cast<u8>(109), static_cast<u8>(117), static_cast<u8>(116), static_cast<u8>(32), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(105), static_cast<u8>(115), static_cast<u8>(44), static_cast<u8>(32), static_cast<u8>(97), static_cast<u8>(110), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(115), static_cast<u8>(105), static_cast<u8>(122), static_cast<u8>(101), static_cast<u8>(58), static_cast<u8>(32), static_cast<u8>(117), static_cast<u8>(115), static_cast<u8>(105), static_cast<u8>(122), static_cast<u8>(101), static_cast<u8>(41), static_cast<u8>(32), static_cast<u8>(45), static_cast<u8>(62), static_cast<u8>(32), static_cast<u8>(118), static_cast<u8>(111), static_cast<u8>(105), static_cast<u8>(100), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(102), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(112), static_cast<u8>(117), static_cast<u8>(115), static_cast<u8>(104), static_cast<u8>(40), static_cast<u8>(109), static_cast<u8>(117), static_cast<u8>(116), static_cast<u8>(32), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(105), static_cast<u8>(115), static_cast<u8>(44), static_cast<u8>(32), static_cast<u8>(97), static_cast<u8>(110), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(118), static_cast<u8>(97), static_cast<u8>(108), static_cast<u8>(117), static_cast<u8>(101), static_cast<u8>(58), static_cast<u8>(32), static_cast<u8>(84), static_cast<u8>(41), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(102), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(112), static_cast<u8>(117), static_cast<u8>(115), static_cast<u8>(104), static_cast<u8>(95), static_cast<u8>(118), static_cast<u8>(97), static_cast<u8>(108), static_cast<u8>(117), static_cast<u8>(101), static_cast<u8>(115), static_cast<u8>(40), static_cast<u8>(109), static_cast<u8>(117), static_cast<u8>(116), static_cast<u8>(32), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(105), static_cast<u8>(115), static_cast<u8>(44), static_cast<u8>(32), static_cast<u8>(97), static_cast<u8>(110), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(111), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(101), static_cast<u8>(114), static_cast<u8>(58), static_cast<u8>(32), static_cast<u8>(38), static_cast<u8>(65), static_cast<u8>(114), static_cast<u8>(114), static_cast<u8>(97), static_cast<u8>(121), static_cast<u8>(60), static_cast<u8>(84), static_cast<u8>(62), static_cast<u8>(41), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(102), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(112), static_cast<u8>(111), static_cast<u8>(112), static_cast<u8>(40), static_cast<u8>(109), static_cast<u8>(117), static_cast<u8>(116), static_cast<u8>(32), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(105), static_cast<u8>(115), static_cast<u8>(41), static_cast<u8>(32), static_cast<u8>(45), static_cast<u8>(62), static_cast<u8>(32), static_cast<u8>(84), static_cast<u8>(63), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(102), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(105), static_cast<u8>(116), static_cast<u8>(101), static_cast<u8>(114), static_cast<u8>(97), static_cast<u8>(116), static_cast<u8>(111), static_cast<u8>(114), static_cast<u8>(40), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(105), static_cast<u8>(115), static_cast<u8>(41), static_cast<u8>(32), static_cast<u8>(45), static_cast<u8>(62), static_cast<u8>(32), static_cast<u8>(65), static_cast<u8>(114), static_cast<u8>(114), static_cast<u8>(97), static_cast<u8>(121), static_cast<u8>(73), static_cast<u8>(116), static_cast<u8>(101), static_cast<u8>(114), static_cast<u8>(97), static_cast<u8>(116), static_cast<u8>(111), static_cast<u8>(114), static_cast<u8>(60), static_cast<u8>(84), static_cast<u8>(62), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(102), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(102), static_cast<u8>(105), static_cast<u8>(114), static_cast<u8>(115), static_cast<u8>(116), static_cast<u8>(40), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(105), static_cast<u8>(115), static_cast<u8>(41), static_cast<u8>(32), static_cast<u8>(45), static_cast<u8>(62), static_cast<u8>(32), static_cast<u8>(84), static_cast<u8>(63), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(102), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(108), static_cast<u8>(97), static_cast<u8>(115), static_cast<u8>(116), static_cast<u8>(40), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(105), static_cast<u8>(115), static_cast<u8>(41), static_cast<u8>(32), static_cast<u8>(45), static_cast<u8>(62), static_cast<u8>(32), static_cast<u8>(84), static_cast<u8>(63), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(102), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(105), static_cast<u8>(110), static_cast<u8>(115), static_cast<u8>(101), static_cast<u8>(114), static_cast<u8>(116), static_cast<u8>(40), static_cast<u8>(109), static_cast<u8>(117), static_cast<u8>(116), static_cast<u8>(32), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(105), static_cast<u8>(115), static_cast<u8>(44), static_cast<u8>(32), static_cast<u8>(98), static_cast<u8>(101), static_cast<u8>(102), static_cast<u8>(111), static_cast<u8>(114), static_cast<u8>(101), static_cast<u8>(95), static_cast<u8>(105), static_cast<u8>(110), static_cast<u8>(100), static_cast<u8>(101), static_cast<u8>(120), static_cast<u8>(58), static_cast<u8>(32), static_cast<u8>(117), static_cast<u8>(115), static_cast<u8>(105), static_cast<u8>(122), static_cast<u8>(101), static_cast<u8>(44), static_cast<u8>(32), static_cast<u8>(118), static_cast<u8>(97), static_cast<u8>(108), static_cast<u8>(117), static_cast<u8>(101), static_cast<u8>(58), static_cast<u8>(32), static_cast<u8>(84), static_cast<u8>(41), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(102), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(117), static_cast<u8>(110), static_cast<u8>(115), static_cast<u8>(97), static_cast<u8>(102), static_cast<u8>(101), static_cast<u8>(95), static_cast<u8>(100), static_cast<u8>(97), static_cast<u8>(116), static_cast<u8>(97), static_cast<u8>(40), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(105), static_cast<u8>(115), static_cast<u8>(41), static_cast<u8>(32), static_cast<u8>(45), static_cast<u8>(62), static_cast<u8>(32), static_cast<u8>(114), static_cast<u8>(97), static_cast<u8>(119), static_cast<u8>(32), static_cast<u8>(84), static_cast<u8>(10), static_cast<u8>(125), static_cast<u8>(10), static_cast<u8>(10), static_cast<u8>(101), static_cast<u8>(120), static_cast<u8>(116), static_cast<u8>(101), static_cast<u8>(114), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(115), static_cast<u8>(116), static_cast<u8>(114), static_cast<u8>(117), static_cast<u8>(99), static_cast<u8>(116), static_cast<u8>(32), static_cast<u8>(65), static_cast<u8>(114), static_cast<u8>(114), static_cast<u8>(97), static_cast<u8>(121), static_cast<u8>(83), static_cast<u8>(108), static_cast<u8>(105), static_cast<u8>(99), static_cast<u8>(101), static_cast<u8>(60), static_cast<u8>(84), static_cast<u8>(62), static_cast<u8>(32), static_cast<u8>(123), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(102), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(105), static_cast<u8>(115), static_cast<u8>(95), static_cast<u8>(101), static_cast<u8>(109), static_cast<u8>(112), static_cast<u8>(116), static_cast<u8>(121), static_cast<u8>(40), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(105), static_cast<u8>(115), static_cast<u8>(41), static_cast<u8>(32), static_cast<u8>(45), static_cast<u8>(62), static_cast<u8>(32), static_cast<u8>(98), static_cast<u8>(111), static_cast<u8>(111), static_cast<u8>(108), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(102), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(99), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(116), static_cast<u8>(97), static_cast<u8>(105), static_cast<u8>(110), static_cast<u8>(115), static_cast<u8>(40), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(105), static_cast<u8>(115), static_cast<u8>(44), static_cast<u8>(32), static_cast<u8>(97), static_cast<u8>(110), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(118), static_cast<u8>(97), static_cast<u8>(108), static_cast<u8>(117), static_cast<u8>(101), static_cast<u8>(58), static_cast<u8>(32), static_cast<u8>(84), static_cast<u8>(41), static_cast<u8>(32), static_cast<u8>(45), static_cast<u8>(62), static_cast<u8>(32), static_cast<u8>(98), static_cast<u8>(111), static_cast<u8>(111), static_cast<u8>(108), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(102), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(115), static_cast<u8>(105), static_cast<u8>(122), static_cast<u8>(101), static_cast<u8>(40), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(105), static_cast<u8>(115), static_cast<u8>(41), static_cast<u8>(32), static_cast<u8>(45), static_cast<u8>(62), static_cast<u8>(32), static_cast<u8>(117), static_cast<u8>(115), static_cast<u8>(105), static_cast<u8>(122), static_cast<u8>(101), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(102), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(105), static_cast<u8>(116), static_cast<u8>(101), static_cast<u8>(114), static_cast<u8>(97), static_cast<u8>(116), static_cast<u8>(111), static_cast<u8>(114), static_cast<u8>(40), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(105), static_cast<u8>(115), static_cast<u8>(41), static_cast<u8>(32), static_cast<u8>(45), static_cast<u8>(62), static_cast<u8>(32), static_cast<u8>(65), static_cast<u8>(114), static_cast<u8>(114), static_cast<u8>(97), static_cast<u8>(121), static_cast<u8>(73), static_cast<u8>(116), static_cast<u8>(101), static_cast<u8>(114), static_cast<u8>(97), static_cast<u8>(116), static_cast<u8>(111), static_cast<u8>(114), static_cast<u8>(60), static_cast<u8>(84), static_cast<u8>(62), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(102), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(116), static_cast<u8>(111), static_cast<u8>(95), static_cast<u8>(97), static_cast<u8>(114), static_cast<u8>(114), static_cast<u8>(97), static_cast<u8>(121), static_cast<u8>(40), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(105), static_cast<u8>(115), static_cast<u8>(41), static_cast<u8>(32), static_cast<u8>(45), static_cast<u8>(62), static_cast<u8>(32), static_cast<u8>(65), static_cast<u8>(114), static_cast<u8>(114), static_cast<u8>(97), static_cast<u8>(121), static_cast<u8>(60), static_cast<u8>(84), static_cast<u8>(62), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(102), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(102), static_cast<u8>(105), static_cast<u8>(114), static_cast<u8>(115), static_cast<u8>(116), static_cast<u8>(40), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(105), static_cast<u8>(115), static_cast<u8>(41), static_cast<u8>(32), static_cast<u8>(45), static_cast<u8>(62), static_cast<u8>(32), static_cast<u8>(84), static_cast<u8>(63), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(102), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(108), static_cast<u8>(97), static_cast<u8>(115), static_cast<u8>(116), static_cast<u8>(40), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(105), static_cast<u8>(115), static_cast<u8>(41), static_cast<u8>(32), static_cast<u8>(45), static_cast<u8>(62), static_cast<u8>(32), static_cast<u8>(84), static_cast<u8>(63), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(102), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(117), static_cast<u8>(110), static_cast<u8>(115), static_cast<u8>(97), static_cast<u8>(102), static_cast<u8>(101), static_cast<u8>(95), static_cast<u8>(100), static_cast<u8>(97), static_cast<u8>(116), static_cast<u8>(97), static_cast<u8>(40), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(105), static_cast<u8>(115), static_cast<u8>(41), static_cast<u8>(32), static_cast<u8>(45), static_cast<u8>(62), static_cast<u8>(32), static_cast<u8>(114), static_cast<u8>(97), static_cast<u8>(119), static_cast<u8>(32), static_cast<u8>(84), static_cast<u8>(10), static_cast<u8>(125), static_cast<u8>(10), static_cast<u8>(10), static_cast<u8>(91), static_cast<u8>(91), static_cast<u8>(110), static_cast<u8>(97), static_cast<u8>(109), static_cast<u8>(101), static_cast<u8>(61), static_cast<u8>(68), static_cast<u8>(101), static_cast<u8>(112), static_cast<u8>(114), static_cast<u8>(101), static_cast<u8>(99), static_cast<u8>(97), static_cast<u8>(116), static_cast<u8>(101), static_cast<u8>(100), static_cast<u8>(83), static_cast<u8>(116), static_cast<u8>(114), static_cast<u8>(105), static_cast<u8>(110), static_cast<u8>(103), static_cast<u8>(67), static_cast<u8>(111), static_cast<u8>(100), static_cast<u8>(101), static_cast<u8>(80), static_cast<u8>(111), static_cast<u8>(105), static_cast<u8>(110), static_cast<u8>(116), static_cast<u8>(73), static_cast<u8>(116), static_cast<u8>(101), static_cast<u8>(114), static_cast<u8>(97), static_cast<u8>(116), static_cast<u8>(111), static_cast<u8>(114), static_cast<u8>(93), static_cast<u8>(93), static_cast<u8>(10), static_cast<u8>(101), static_cast<u8>(120), static_cast<u8>(116), static_cast<u8>(101), static_cast<u8>(114), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(115), static_cast<u8>(116), static_cast<u8>(114), static_cast<u8>(117), static_cast<u8>(99), static_cast<u8>(116), static_cast<u8>(32), static_cast<u8>(67), static_cast<u8>(111), static_cast<u8>(100), static_cast<u8>(101), static_cast<u8>(80), static_cast<u8>(111), static_cast<u8>(105), static_cast<u8>(110), static_cast<u8>(116), static_cast<u8>(73), static_cast<u8>(116), static_cast<u8>(101), static_cast<u8>(114), static_cast<u8>(97), static_cast<u8>(116), static_cast<u8>(111), static_cast<u8>(114), static_cast<u8>(32), static_cast<u8>(123), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(102), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(110), static_cast<u8>(101), static_cast<u8>(120), static_cast<u8>(116), static_cast<u8>(40), static_cast<u8>(109), static_cast<u8>(117), static_cast<u8>(116), static_cast<u8>(32), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(105), static_cast<u8>(115), static_cast<u8>(41), static_cast<u8>(32), static_cast<u8>(45), static_cast<u8>(62), static_cast<u8>(32), static_cast<u8>(117), static_cast<u8>(51), static_cast<u8>(50), static_cast<u8>(63), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(102), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(112), static_cast<u8>(101), static_cast<u8>(101), static_cast<u8>(107), static_cast<u8>(40), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(105), static_cast<u8>(115), static_cast<u8>(41), static_cast<u8>(32), static_cast<u8>(45), static_cast<u8>(62), static_cast<u8>(32), static_cast<u8>(117), static_cast<u8>(51), static_cast<u8>(50), static_cast<u8>(63), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(102), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(98), static_cast<u8>(121), static_cast<u8>(116), static_cast<u8>(101), static_cast<u8>(95), static_cast<u8>(111), static_cast<u8>(102), static_cast<u8>(102), static_cast<u8>(115), static_cast<u8>(101), static_cast<u8>(116), static_cast<u8>(40), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(105), static_cast<u8>(115), static_cast<u8>(41), static_cast<u8>(32), static_cast<u8>(45), static_cast<u8>(62), static_cast<u8>(32), static_cast<u8>(117), static_cast<u8>(115), static_cast<u8>(105), static_cast<u8>(122), static_cast<u8>(101), static_cast<u8>(10), static_cast<u8>(125), static_cast<u8>(10), static_cast<u8>(10), static_cast<u8>(91), static_cast<u8>(91), static_cast<u8>(110), static_cast<u8>(97), static_cast<u8>(109), static_cast<u8>(101), static_cast<u8>(61), static_cast<u8>(66), static_cast<u8>(121), static_cast<u8>(116), static_cast<u8>(101), static_cast<u8>(83), static_cast<u8>(116), static_cast<u8>(114), static_cast<u8>(105), static_cast<u8>(110), static_cast<u8>(103), static_cast<u8>(93), static_cast<u8>(93), static_cast<u8>(10), static_cast<u8>(101), static_cast<u8>(120), static_cast<u8>(116), static_cast<u8>(101), static_cast<u8>(114), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(115), static_cast<u8>(116), static_cast<u8>(114), static_cast<u8>(117), static_cast<u8>(99), static_cast<u8>(116), static_cast<u8>(32), static_cast<u8>(83), static_cast<u8>(116), static_cast<u8>(114), static_cast<u8>(105), static_cast<u8>(110), static_cast<u8>(103), static_cast<u8>(32), static_cast<u8>(123), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(102), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(99), static_cast<u8>(111), static_cast<u8>(100), static_cast<u8>(101), static_cast<u8>(95), static_cast<u8>(112), static_cast<u8>(111), static_cast<u8>(105), static_cast<u8>(110), static_cast<u8>(116), static_cast<u8>(115), static_cast<u8>(40), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(105), static_cast<u8>(115), static_cast<u8>(41), static_cast<u8>(32), static_cast<u8>(45), static_cast<u8>(62), static_cast<u8>(32), static_cast<u8>(67), static_cast<u8>(111), static_cast<u8>(100), static_cast<u8>(101), static_cast<u8>(80), static_cast<u8>(111), static_cast<u8>(105), static_cast<u8>(110), static_cast<u8>(116), static_cast<u8>(73), static_cast<u8>(116), static_cast<u8>(101), static_cast<u8>(114), static_cast<u8>(97), static_cast<u8>(116), static_cast<u8>(111), static_cast<u8>(114), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(102), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(102), static_cast<u8>(114), static_cast<u8>(111), static_cast<u8>(109), static_cast<u8>(95), static_cast<u8>(117), static_cast<u8>(116), static_cast<u8>(102), static_cast<u8>(56), static_cast<u8>(40), static_cast<u8>(97), static_cast<u8>(110), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(98), static_cast<u8>(121), static_cast<u8>(116), static_cast<u8>(101), static_cast<u8>(115), static_cast<u8>(58), static_cast<u8>(32), static_cast<u8>(91), static_cast<u8>(117), static_cast<u8>(56), static_cast<u8>(93), static_cast<u8>(41), static_cast<u8>(32), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(114), static_cast<u8>(111), static_cast<u8>(119), static_cast<u8>(115), static_cast<u8>(32), static_cast<u8>(45), static_cast<u8>(62), static_cast<u8>(32), static_cast<u8>(83), static_cast<u8>(116), static_cast<u8>(114), static_cast<u8>(105), static_cast<u8>(110), static_cast<u8>(103), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(102), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(110), static_cast<u8>(117), static_cast<u8>(109), static_cast<u8>(98), static_cast<u8>(101), static_cast<u8>(114), static_cast<u8>(40), static_cast<u8>(97), static_cast<u8>(110), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(110), static_cast<u8>(117), static_cast<u8>(109), static_cast<u8>(98), static_cast<u8>(101), static_cast<u8>(114), static_cast<u8>(58), static_cast<u8>(32), static_cast<u8>(105), static_cast<u8>(54), static_cast<u8>(52), static_cast<u8>(41), static_cast<u8>(32), static_cast<u8>(45), static_cast<u8>(62), static_cast<u8>(32), static_cast<u8>(83), static_cast<u8>(116), static_cast<u8>(114), static_cast<u8>(105), static_cast<u8>(110), static_cast<u8>(103), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(102), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(115), static_cast<u8>(112), static_cast<u8>(108), static_cast<u8>(105), static_cast<u8>(116), static_cast<u8>(40), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(105), static_cast<u8>(115), static_cast<u8>(44), static_cast<u8>(32), static_cast<u8>(97), static_cast<u8>(110), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(99), static_cast<u8>(58), static_cast<u8>(32), static_cast<u8>(99), static_cast<u8>(95), static_cast<u8>(99), static_cast<u8>(104), static_cast<u8>(97), static_cast<u8>(114), static_cast<u8>(41), static_cast<u8>(32), static_cast<u8>(45), static_cast<u8>(62), static_cast<u8>(32), static_cast<u8>(91), static_cast<u8>(83), static_cast<u8>(116), static_cast<u8>(114), static_cast<u8>(105), static_cast<u8>(110), static_cast<u8>(103), static_cast<u8>(93), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(91), static_cast<u8>(91), static_cast<u8>(110), static_cast<u8>(97), static_cast<u8>(109), static_cast<u8>(101), static_cast<u8>(61), static_cast<u8>(99), static_cast<u8>(104), static_cast<u8>(97), static_cast<u8>(114), static_cast<u8>(97), static_cast<u8>(99), static_cast<u8>(116), static_cast<u8>(101), static_cast<u8>(114), static_cast<u8>(115), static_cast<u8>(93), static_cast<u8>(93), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(102), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(99), static_cast<u8>(95), static_cast<u8>(115), static_cast<u8>(116), static_cast<u8>(114), static_cast<u8>(105), static_cast<u8>(110), static_cast<u8>(103), static_cast<u8>(40), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(105), static_cast<u8>(115), static_cast<u8>(41), static_cast<u8>(32), static_cast<u8>(45), static_cast<u8>(62), static_cast<u8>(32), static_cast<u8>(114), static_cast<u8>(97), static_cast<u8>(119), static_cast<u8>(32), static_cast<u8>(99), static_cast<u8>(95), static_cast<u8>(99), static_cast<u8>(104), static_cast<u8>(97), static_cast<u8>(114), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(102), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(116), static_cast<u8>(111), static_cast<u8>(95), static_cast<u8>(105), static_cast<u8>(110), static_cast<u8>(116), static_cast<u8>(40), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(105), static_cast<u8>(115), static_cast<u8>(41), static_cast<u8>(32), static_cast<u8>(45), static_cast<u8>(62), static_cast<u8>(32), static_cast<u8>(105), static_cast<u8>(51), static_cast<u8>(50), static_cast<u8>(63), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(102), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(116), static_cast<u8>(111), static_cast<u8>(95), static_cast<u8>(117), static_cast<u8>(105), static_cast<u8>(110), static_cast<u8>(116), static_cast<u8>(40), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(105), static_cast<u8>(115), static_cast<u8>(41), static_cast<u8>(32), static_cast<u8>(45), static_cast<u8>(62), static_cast<u8>(32), static_cast<u8>(117), static_cast<u8>(51), static_cast<u8>(50), static_cast<u8>(63), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(102), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(105), static_cast<u8>(115), static_cast<u8>(95), static_cast<u8>(119), static_cast<u8>(104), static_cast<u8>(105), static_cast<u8>(116), static_cast<u8>(101), static_cast<u8>(115), static_cast<u8>(112), static_cast<u8>(97), static_cast<u8>(99), static_cast<u8>(101), static_cast<u8>(40), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(105), static_cast<u8>(115), static_cast<u8>(41), static_cast<u8>(32), static_cast<u8>(45), static_cast<u8>(62), static_cast<u8>(32), static_cast<u8>(98), static_cast<u8>(111), static_cast<u8>(111), static_cast<u8>(108), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(102), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(104), static_cast<u8>(97), static_cast<u8>(115), static_cast<u8>(104), static_cast<u8>(40), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(105), static_cast<u8>(115), static_cast<u8>(41), static_cast<u8>(32), static_cast<u8>(45), static_cast<u8>(62), static_cast<u8>(32), static_cast<u8>(117), static_cast<u8>(51), static_cast<u8>(50), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(102), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(115), static_cast<u8>(117), static_cast<u8>(98), static_cast<u8>(115), static_cast<u8>(116), static_cast<u8>(114), static_cast<u8>(105), static_cast<u8>(110), static_cast<u8>(103), static_cast<u8>(40), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(105), static_cast<u8>(115), static_cast<u8>(44), static_cast<u8>(32), static_cast<u8>(115), static_cast<u8>(116), static_cast<u8>(97), static_cast<u8>(114), static_cast<u8>(116), static_cast<u8>(58), static_cast<u8>(32), static_cast<u8>(117), static_cast<u8>(115), static_cast<u8>(105), static_cast<u8>(122), static_cast<u8>(101), static_cast<u8>(44), static_cast<u8>(32), static_cast<u8>(108), static_cast<u8>(101), static_cast<u8>(110), static_cast<u8>(103), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(58), static_cast<u8>(32), static_cast<u8>(117), static_cast<u8>(115), static_cast<u8>(105), static_cast<u8>(122), static_cast<u8>(101), static_cast<u8>(41), static_cast<u8>(32), static_cast<u8>(45), static_cast<u8>(62), static_cast<u8>(32), static_cast<u8>(83), static_cast<u8>(116), static_cast<u8>(114), static_cast<u8>(105), static_cast<u8>(110), static_cast<u8>(103), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(102), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(114), static_cast<u8>(101), static_cast<u8>(112), static_cast<u8>(101), static_cast<u8>(97), static_cast<u8>(116), static_cast<u8>(101), static_cast<u8>(100), static_cast<u8>(40), static_cast<u8>(99), static_cast<u8>(104), static_cast<u8>(97), static_cast<u8>(114), static_cast<u8>(97), static_cast<u8>(99), static_cast<u8>(116), static_cast<u8>(101), static_cast<u8>(114), static_cast<u8>(58), static_cast<u8>(32), static_cast<u8>(99), static_cast<u8>(95), static_cast<u8>(99), static_cast<u8>(104), static_cast<u8>(97), static_cast<u8>(114), static_cast<u8>(44), static_cast<u8>(32), static_cast<u8>(99), static_cast<u8>(111), static_cast<u8>(117), static_cast<u8>(110), static_cast<u8>(116), static_cast<u8>(58), static_cast<u8>(32), static_cast<u8>(117), static_cast<u8>(115), static_cast<u8>(105), static_cast<u8>(122), static_cast<u8>(101), static_cast<u8>(41), static_cast<u8>(32), static_cast<u8>(45), static_cast<u8>(62), static_cast<u8>(32), static_cast<u8>(83), static_cast<u8>(116), static_cast<u8>(114), static_cast<u8>(105), static_cast<u8>(110), static_cast<u8>(103), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(102), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(105), static_cast<u8>(115), static_cast<u8>(95), static_cast<u8>(101), static_cast<u8>(109), static_cast<u8>(112), static_cast<u8>(116), static_cast<u8>(121), static_cast<u8>(40), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(105), static_cast<u8>(115), static_cast<u8>(41), static_cast<u8>(32), static_cast<u8>(45), static_cast<u8>(62), static_cast<u8>(32), static_cast<u8>(98), static_cast<u8>(111), static_cast<u8>(111), static_cast<u8>(108), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(102), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(108), static_cast<u8>(101), static_cast<u8>(110), static_cast<u8>(103), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(40), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(105), static_cast<u8>(115), static_cast<u8>(41), static_cast<u8>(32), static_cast<u8>(45), static_cast<u8>(62), static_cast<u8>(32), static_cast<u8>(117), static_cast<u8>(115), static_cast<u8>(105), static_cast<u8>(122), static_cast<u8>(101), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(102), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(98), static_cast<u8>(121), static_cast<u8>(116), static_cast<u8>(101), static_cast<u8>(95), static_cast<u8>(97), static_cast<u8>(116), static_cast<u8>(40), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(105), static_cast<u8>(115), static_cast<u8>(44), static_cast<u8>(32), static_cast<u8>(97), static_cast<u8>(110), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(105), static_cast<u8>(110), static_cast<u8>(100), static_cast<u8>(101), static_cast<u8>(120), static_cast<u8>(58), static_cast<u8>(32), static_cast<u8>(117), static_cast<u8>(115), static_cast<u8>(105), static_cast<u8>(122), static_cast<u8>(101), static_cast<u8>(41), static_cast<u8>(32), static_cast<u8>(45), static_cast<u8>(62), static_cast<u8>(32), static_cast<u8>(117), static_cast<u8>(56), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(102), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(99), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(116), static_cast<u8>(97), static_cast<u8>(105), static_cast<u8>(110), static_cast<u8>(115), static_cast<u8>(40), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(105), static_cast<u8>(115), static_cast<u8>(44), static_cast<u8>(32), static_cast<u8>(97), static_cast<u8>(110), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(110), static_cast<u8>(101), static_cast<u8>(101), static_cast<u8>(100), static_cast<u8>(108), static_cast<u8>(101), static_cast<u8>(58), static_cast<u8>(32), static_cast<u8>(83), static_cast<u8>(116), static_cast<u8>(114), static_cast<u8>(105), static_cast<u8>(110), static_cast<u8>(103), static_cast<u8>(41), static_cast<u8>(32), static_cast<u8>(45), static_cast<u8>(62), static_cast<u8>(32), static_cast<u8>(98), static_cast<u8>(111), static_cast<u8>(111), static_cast<u8>(108), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(102), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(114), static_cast<u8>(101), static_cast<u8>(112), static_cast<u8>(108), static_cast<u8>(97), static_cast<u8>(99), static_cast<u8>(101), static_cast<u8>(40), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(105), static_cast<u8>(115), static_cast<u8>(44), static_cast<u8>(32), static_cast<u8>(114), static_cast<u8>(101), static_cast<u8>(112), static_cast<u8>(108), static_cast<u8>(97), static_cast<u8>(99), static_cast<u8>(101), static_cast<u8>(58), static_cast<u8>(32), static_cast<u8>(83), static_cast<u8>(116), static_cast<u8>(114), static_cast<u8>(105), static_cast<u8>(110), static_cast<u8>(103), static_cast<u8>(44), static_cast<u8>(32), static_cast<u8>(119), static_cast<u8>(105), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(58), static_cast<u8>(32), static_cast<u8>(83), static_cast<u8>(116), static_cast<u8>(114), static_cast<u8>(105), static_cast<u8>(110), static_cast<u8>(103), static_cast<u8>(41), static_cast<u8>(32), static_cast<u8>(45), static_cast<u8>(62), static_cast<u8>(32), static_cast<u8>(83), static_cast<u8>(116), static_cast<u8>(114), static_cast<u8>(105), static_cast<u8>(110), static_cast<u8>(103), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(102), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(115), static_cast<u8>(116), static_cast<u8>(97), static_cast<u8>(114), static_cast<u8>(116), static_cast<u8>(115), static_cast<u8>(95), static_cast<u8>(119), static_cast<u8>(105), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(40), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(105), static_cast<u8>(115), static_cast<u8>(44), static_cast<u8>(32), static_cast<u8>(97), static_cast<u8>(110), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(110), static_cast<u8>(101), static_cast<u8>(101), static_cast<u8>(100), static_cast<u8>(108), static_cast<u8>(101), static_cast<u8>(58), static_cast<u8>(32), static_cast<u8>(83), static_cast<u8>(116), static_cast<u8>(114), static_cast<u8>(105), static_cast<u8>(110), static_cast<u8>(103), static_cast<u8>(41), static_cast<u8>(32), static_cast<u8>(45), static_cast<u8>(62), static_cast<u8>(32), static_cast<u8>(98), static_cast<u8>(111), static_cast<u8>(111), static_cast<u8>(108), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(102), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(101), static_cast<u8>(110), static_cast<u8>(100), static_cast<u8>(115), static_cast<u8>(95), static_cast<u8>(119), static_cast<u8>(105), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(40), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(105), static_cast<u8>(115), static_cast<u8>(44), static_cast<u8>(32), static_cast<u8>(97), static_cast<u8>(110), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(110), static_cast<u8>(101), static_cast<u8>(101), static_cast<u8>(100), static_cast<u8>(108), static_cast<u8>(101), static_cast<u8>(58), static_cast<u8>(32), static_cast<u8>(83), static_cast<u8>(116), static_cast<u8>(114), static_cast<u8>(105), static_cast<u8>(110), static_cast<u8>(103), static_cast<u8>(41), static_cast<u8>(32), static_cast<u8>(45), static_cast<u8>(62), static_cast<u8>(32), static_cast<u8>(98), static_cast<u8>(111), static_cast<u8>(111), static_cast<u8>(108), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(102), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(99), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(116), static_cast<u8>(97), static_cast<u8>(105), static_cast<u8>(110), static_cast<u8>(115), static_cast<u8>(40), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(105), static_cast<u8>(115), static_cast<u8>(44), static_cast<u8>(32), static_cast<u8>(97), static_cast<u8>(110), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(110), static_cast<u8>(101), static_cast<u8>(101), static_cast<u8>(100), static_cast<u8>(108), static_cast<u8>(101), static_cast<u8>(58), static_cast<u8>(32), static_cast<u8>(83), static_cast<u8>(116), static_cast<u8>(114), static_cast<u8>(105), static_cast<u8>(110), static_cast<u8>(103), static_cast<u8>(86), static_cast<u8>(105), static_cast<u8>(101), static_cast<u8>(119), static_cast<u8>(41), static_cast<u8>(32), static_cast<u8>(45), static_cast<u8>(62), static_cast<u8>(32), static_cast<u8>(98), static_cast<u8>(111), static_cast<u8>(111), static_cast<u8>(108), static_cast<u8>(10), static_cast<u8>(125), static_cast<u8>(10), static_cast<u8>(10), static_cast<u8>(91), static_cast<u8>(91), static_cast<u8>(110), static_cast<u8>(97), static_cast<u8>(109), static_cast<u8>(101), static_cast<u8>(61), static_cast<u8>(66), static_cast<u8>(121), static_cast<u8>(116), static_cast<u8>(101), static_cast<u8>(83), static_cast<u8>(116), static_cast<u8>(114), static_cast<u8>(105), static_cast<u8>(110), static_cast<u8>(103), static_cast<u8>(66), static_cast<u8>(117), static_cast<u8>(105), static_cast<u8>(108), static_cast<u8>(100), static_cast<u8>(101), static_cast<u8>(114), static_cast<u8>(93), static_cast<u8>(93), static_cast<u8>(10), static_cast<u8>(101), static_cast<u8>(120), static_cast<u8>(116), static_cast<u8>(101), static_cast<u8>(114), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(115), static_cast<u8>(116), static_cast<u8>(114), static_cast<u8>(117), static_cast<u8>(99), static_cast<u8>(116), static_cast<u8>(32), static_cast<u8>(83), static_cast<u8>(116), static_cast<u8>(114), static_cast<u8>(105), static_cast<u8>(110), static_cast<u8>(103), static_cast<u8>(66), static_cast<u8>(117), static_cast<u8>(105), static_cast<u8>(108), static_cast<u8>(100), static_cast<u8>(101), static_cast<u8>(114), static_cast<u8>(32), static_cast<u8>(123), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(102), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(97), static_cast<u8>(112), static_cast<u8>(112), static_cast<u8>(101), static_cast<u8>(110), static_cast<u8>(100), static_cast<u8>(40), static_cast<u8>(109), static_cast<u8>(117), static_cast<u8>(116), static_cast<u8>(32), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(105), static_cast<u8>(115), static_cast<u8>(44), static_cast<u8>(32), static_cast<u8>(97), static_cast<u8>(110), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(98), static_cast<u8>(58), static_cast<u8>(32), static_cast<u8>(117), static_cast<u8>(56), static_cast<u8>(41), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(102), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(97), static_cast<u8>(112), static_cast<u8>(112), static_cast<u8>(101), static_cast<u8>(110), static_cast<u8>(100), static_cast<u8>(40), static_cast<u8>(109), static_cast<u8>(117), static_cast<u8>(116), static_cast<u8>(32), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(105), static_cast<u8>(115), static_cast<u8>(44), static_cast<u8>(32), static_cast<u8>(97), static_cast<u8>(110), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(115), static_cast<u8>(58), static_cast<u8>(32), static_cast<u8>(83), static_cast<u8>(116), static_cast<u8>(114), static_cast<u8>(105), static_cast<u8>(110), static_cast<u8>(103), static_cast<u8>(86), static_cast<u8>(105), static_cast<u8>(101), static_cast<u8>(119), static_cast<u8>(41), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(102), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(97), static_cast<u8>(112), static_cast<u8>(112), static_cast<u8>(101), static_cast<u8>(110), static_cast<u8>(100), static_cast<u8>(40), static_cast<u8>(109), static_cast<u8>(117), static_cast<u8>(116), static_cast<u8>(32), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(105), static_cast<u8>(115), static_cast<u8>(44), static_cast<u8>(32), static_cast<u8>(97), static_cast<u8>(110), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(115), static_cast<u8>(58), static_cast<u8>(32), static_cast<u8>(83), static_cast<u8>(116), static_cast<u8>(114), static_cast<u8>(105), static_cast<u8>(110), static_cast<u8>(103), static_cast<u8>(41), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(102), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(97), static_cast<u8>(112), static_cast<u8>(112), static_cast<u8>(101), static_cast<u8>(110), static_cast<u8>(100), static_cast<u8>(40), static_cast<u8>(109), static_cast<u8>(117), static_cast<u8>(116), static_cast<u8>(32), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(105), static_cast<u8>(115), static_cast<u8>(44), static_cast<u8>(32), static_cast<u8>(115), static_cast<u8>(116), static_cast<u8>(114), static_cast<u8>(105), static_cast<u8>(110), static_cast<u8>(103), static_cast<u8>(58), static_cast<u8>(32), static_cast<u8>(114), static_cast<u8>(97), static_cast<u8>(119), static_cast<u8>(32), static_cast<u8>(99), static_cast<u8>(95), static_cast<u8>(99), static_cast<u8>(104), static_cast<u8>(97), static_cast<u8>(114), static_cast<u8>(44), static_cast<u8>(32), static_cast<u8>(115), static_cast<u8>(105), static_cast<u8>(122), static_cast<u8>(101), static_cast<u8>(58), static_cast<u8>(32), static_cast<u8>(117), static_cast<u8>(115), static_cast<u8>(105), static_cast<u8>(122), static_cast<u8>(101), static_cast<u8>(41), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(91), static_cast<u8>(91), static_cast<u8>(110), static_cast<u8>(97), static_cast<u8>(109), static_cast<u8>(101), static_cast<u8>(61), static_cast<u8>(97), static_cast<u8>(112), static_cast<u8>(112), static_cast<u8>(101), static_cast<u8>(110), static_cast<u8>(100), static_cast<u8>(95), static_cast<u8>(99), static_cast<u8>(111), static_cast<u8>(100), static_cast<u8>(101), static_cast<u8>(95), static_cast<u8>(112), static_cast<u8>(111), static_cast<u8>(105), static_cast<u8>(110), static_cast<u8>(116), static_cast<u8>(93), static_cast<u8>(93), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(102), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(97), static_cast<u8>(112), static_cast<u8>(112), static_cast<u8>(101), static_cast<u8>(110), static_cast<u8>(100), static_cast<u8>(40), static_cast<u8>(109), static_cast<u8>(117), static_cast<u8>(116), static_cast<u8>(32), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(105), static_cast<u8>(115), static_cast<u8>(44), static_cast<u8>(32), static_cast<u8>(97), static_cast<u8>(110), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(99), static_cast<u8>(111), static_cast<u8>(100), static_cast<u8>(101), static_cast<u8>(95), static_cast<u8>(112), static_cast<u8>(111), static_cast<u8>(105), static_cast<u8>(110), static_cast<u8>(116), static_cast<u8>(58), static_cast<u8>(32), static_cast<u8>(117), static_cast<u8>(51), static_cast<u8>(50), static_cast<u8>(41), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(102), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(97), static_cast<u8>(112), static_cast<u8>(112), static_cast<u8>(101), static_cast<u8>(110), static_cast<u8>(100), static_cast<u8>(95), static_cast<u8>(101), static_cast<u8>(115), static_cast<u8>(99), static_cast<u8>(97), static_cast<u8>(112), static_cast<u8>(101), static_cast<u8>(100), static_cast<u8>(95), static_cast<u8>(102), static_cast<u8>(111), static_cast<u8>(114), static_cast<u8>(95), static_cast<u8>(106), static_cast<u8>(115), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(40), static_cast<u8>(109), static_cast<u8>(117), static_cast<u8>(116), static_cast<u8>(32), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(105), static_cast<u8>(115), static_cast<u8>(44), static_cast<u8>(32), static_cast<u8>(97), static_cast<u8>(110), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(115), static_cast<u8>(58), static_cast<u8>(32), static_cast<u8>(83), static_cast<u8>(116), static_cast<u8>(114), static_cast<u8>(105), static_cast<u8>(110), static_cast<u8>(103), static_cast<u8>(41), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(102), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(116), static_cast<u8>(111), static_cast<u8>(95), static_cast<u8>(115), static_cast<u8>(116), static_cast<u8>(114), static_cast<u8>(105), static_cast<u8>(110), static_cast<u8>(103), static_cast<u8>(40), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(105), static_cast<u8>(115), static_cast<u8>(41), static_cast<u8>(32), static_cast<u8>(45), static_cast<u8>(62), static_cast<u8>(32), static_cast<u8>(83), static_cast<u8>(116), static_cast<u8>(114), static_cast<u8>(105), static_cast<u8>(110), static_cast<u8>(103), static_cast<u8>(10), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(102), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(105), static_cast<u8>(115), static_cast<u8>(95), static_cast<u8>(101), static_cast<u8>(109), static_cast<u8>(112), static_cast<u8>(116), static_cast<u8>(121), static_cast<u8>(40), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(105), static_cast<u8>(115), static_cast<u8>(41), static_cast<u8>(32), static_cast<u8>(45), static_cast<u8>(62), static_cast<u8>(32), static_cast<u8>(98), static_cast<u8>(111), static_cast<u8>(111), static_cast<u8>(108), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(102), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(108), static_cast<u8>(101), static_cast<u8>(110), static_cast<u8>(103), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(40), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(105), static_cast<u8>(115), static_cast<u8>(41), static_cast<u8>(32), static_cast<u8>(45), static_cast<u8>(62), static_cast<u8>(32), static_cast<u8>(117), static_cast<u8>(115), static_cast<u8>(105), static_cast<u8>(122), static_cast<u8>(101), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(102), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(99), static_cast<u8>(108), static_cast<u8>(101), static_cast<u8>(97), static_cast<u8>(114), static_cast<u8>(40), static_cast<u8>(109), static_cast<u8>(117), static_cast<u8>(116), static_cast<u8>(32), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(105), static_cast<u8>(115), static_cast<u8>(41), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(102), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(99), static_cast<u8>(114), static_cast<u8>(101), static_cast<u8>(97), static_cast<u8>(116), static_cast<u8>(101), static_cast<u8>(40), static_cast<u8>(41), static_cast<u8>(32), static_cast<u8>(45), static_cast<u8>(62), static_cast<u8>(32), static_cast<u8>(83), static_cast<u8>(116), static_cast<u8>(114), static_cast<u8>(105), static_cast<u8>(110), static_cast<u8>(103), static_cast<u8>(66), static_cast<u8>(117), static_cast<u8>(105), static_cast<u8>(108), static_cast<u8>(100), static_cast<u8>(101), static_cast<u8>(114), static_cast<u8>(10), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(47), static_cast<u8>(47), static_cast<u8>(32), static_cast<u8>(68), static_cast<u8>(101), static_cast<u8>(112), static_cast<u8>(114), static_cast<u8>(101), static_cast<u8>(99), static_cast<u8>(97), static_cast<u8>(116), static_cast<u8>(101), static_cast<u8>(100), static_cast<u8>(32), static_cast<u8>(65), static_cast<u8>(80), static_cast<u8>(73), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(102), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(97), static_cast<u8>(112), static_cast<u8>(112), static_cast<u8>(101), static_cast<u8>(110), static_cast<u8>(100), static_cast<u8>(95), static_cast<u8>(99), static_cast<u8>(95), static_cast<u8>(115), static_cast<u8>(116), static_cast<u8>(114), static_cast<u8>(105), static_cast<u8>(110), static_cast<u8>(103), static_cast<u8>(40), static_cast<u8>(109), static_cast<u8>(117), static_cast<u8>(116), static_cast<u8>(32), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(105), static_cast<u8>(115), static_cast<u8>(44), static_cast<u8>(32), static_cast<u8>(97), static_cast<u8>(110), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(115), static_cast<u8>(58), static_cast<u8>(32), static_cast<u8>(114), static_cast<u8>(97), static_cast<u8>(119), static_cast<u8>(32), static_cast<u8>(99), static_cast<u8>(95), static_cast<u8>(99), static_cast<u8>(104), static_cast<u8>(97), static_cast<u8>(114), static_cast<u8>(41), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(102), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(97), static_cast<u8>(112), static_cast<u8>(112), static_cast<u8>(101), static_cast<u8>(110), static_cast<u8>(100), static_cast<u8>(95), static_cast<u8>(99), static_cast<u8>(111), static_cast<u8>(100), static_cast<u8>(101), static_cast<u8>(95), static_cast<u8>(112), static_cast<u8>(111), static_cast<u8>(105), static_cast<u8>(110), static_cast<u8>(116), static_cast<u8>(40), static_cast<u8>(109), static_cast<u8>(117), static_cast<u8>(116), static_cast<u8>(32), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(105), static_cast<u8>(115), static_cast<u8>(44), static_cast<u8>(32), static_cast<u8>(97), static_cast<u8>(110), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(99), static_cast<u8>(111), static_cast<u8>(100), static_cast<u8>(101), static_cast<u8>(95), static_cast<u8>(112), static_cast<u8>(111), static_cast<u8>(105), static_cast<u8>(110), static_cast<u8>(116), static_cast<u8>(58), static_cast<u8>(32), static_cast<u8>(117), static_cast<u8>(51), static_cast<u8>(50), static_cast<u8>(41), static_cast<u8>(10), static_cast<u8>(125), static_cast<u8>(10), static_cast<u8>(10), static_cast<u8>(101), static_cast<u8>(120), static_cast<u8>(116), static_cast<u8>(101), static_cast<u8>(114), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(115), static_cast<u8>(116), static_cast<u8>(114), static_cast<u8>(117), static_cast<u8>(99), static_cast<u8>(116), static_cast<u8>(32), static_cast<u8>(87), static_cast<u8>(101), static_cast<u8>(97), static_cast<u8>(107), static_cast<u8>(80), static_cast<u8>(116), static_cast<u8>(114), static_cast<u8>(60), static_cast<u8>(84), static_cast<u8>(62), static_cast<u8>(32), static_cast<u8>(123), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(102), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(104), static_cast<u8>(97), static_cast<u8>(115), static_cast<u8>(95), static_cast<u8>(118), static_cast<u8>(97), static_cast<u8>(108), static_cast<u8>(117), static_cast<u8>(101), static_cast<u8>(40), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(105), static_cast<u8>(115), static_cast<u8>(41), static_cast<u8>(32), static_cast<u8>(45), static_cast<u8>(62), static_cast<u8>(32), static_cast<u8>(98), static_cast<u8>(111), static_cast<u8>(111), static_cast<u8>(108), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(102), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(99), static_cast<u8>(108), static_cast<u8>(101), static_cast<u8>(97), static_cast<u8>(114), static_cast<u8>(40), static_cast<u8>(109), static_cast<u8>(117), static_cast<u8>(116), static_cast<u8>(32), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(105), static_cast<u8>(115), static_cast<u8>(41), static_cast<u8>(10), static_cast<u8>(125), static_cast<u8>(10), static_cast<u8>(10), static_cast<u8>(101), static_cast<u8>(120), static_cast<u8>(116), static_cast<u8>(101), static_cast<u8>(114), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(115), static_cast<u8>(116), static_cast<u8>(114), static_cast<u8>(117), static_cast<u8>(99), static_cast<u8>(116), static_cast<u8>(32), static_cast<u8>(84), static_cast<u8>(117), static_cast<u8>(112), static_cast<u8>(108), static_cast<u8>(101), static_cast<u8>(32), static_cast<u8>(123), static_cast<u8>(125), static_cast<u8>(10), static_cast<u8>(10), static_cast<u8>(101), static_cast<u8>(120), static_cast<u8>(116), static_cast<u8>(101), static_cast<u8>(114), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(115), static_cast<u8>(116), static_cast<u8>(114), static_cast<u8>(117), static_cast<u8>(99), static_cast<u8>(116), static_cast<u8>(32), static_cast<u8>(68), static_cast<u8>(105), static_cast<u8>(99), static_cast<u8>(116), static_cast<u8>(105), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(97), static_cast<u8>(114), static_cast<u8>(121), static_cast<u8>(73), static_cast<u8>(116), static_cast<u8>(101), static_cast<u8>(114), static_cast<u8>(97), static_cast<u8>(116), static_cast<u8>(111), static_cast<u8>(114), static_cast<u8>(60), static_cast<u8>(75), static_cast<u8>(44), static_cast<u8>(32), static_cast<u8>(86), static_cast<u8>(62), static_cast<u8>(32), static_cast<u8>(123), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(102), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(110), static_cast<u8>(101), static_cast<u8>(120), static_cast<u8>(116), static_cast<u8>(40), static_cast<u8>(109), static_cast<u8>(117), static_cast<u8>(116), static_cast<u8>(32), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(105), static_cast<u8>(115), static_cast<u8>(41), static_cast<u8>(32), static_cast<u8>(45), static_cast<u8>(62), static_cast<u8>(32), static_cast<u8>(40), static_cast<u8>(75), static_cast<u8>(44), static_cast<u8>(32), static_cast<u8>(86), static_cast<u8>(41), static_cast<u8>(63), static_cast<u8>(10), static_cast<u8>(125), static_cast<u8>(10), static_cast<u8>(10), static_cast<u8>(101), static_cast<u8>(120), static_cast<u8>(116), static_cast<u8>(101), static_cast<u8>(114), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(115), static_cast<u8>(116), static_cast<u8>(114), static_cast<u8>(117), static_cast<u8>(99), static_cast<u8>(116), static_cast<u8>(32), static_cast<u8>(68), static_cast<u8>(105), static_cast<u8>(99), static_cast<u8>(116), static_cast<u8>(105), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(97), static_cast<u8>(114), static_cast<u8>(121), static_cast<u8>(60), static_cast<u8>(75), static_cast<u8>(44), static_cast<u8>(32), static_cast<u8>(86), static_cast<u8>(62), static_cast<u8>(32), static_cast<u8>(123), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(102), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(105), static_cast<u8>(115), static_cast<u8>(95), static_cast<u8>(101), static_cast<u8>(109), static_cast<u8>(112), static_cast<u8>(116), static_cast<u8>(121), static_cast<u8>(40), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(105), static_cast<u8>(115), static_cast<u8>(41), static_cast<u8>(32), static_cast<u8>(45), static_cast<u8>(62), static_cast<u8>(32), static_cast<u8>(98), static_cast<u8>(111), static_cast<u8>(111), static_cast<u8>(108), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(102), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(103), static_cast<u8>(101), static_cast<u8>(116), static_cast<u8>(40), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(105), static_cast<u8>(115), static_cast<u8>(44), static_cast<u8>(32), static_cast<u8>(97), static_cast<u8>(110), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(107), static_cast<u8>(101), static_cast<u8>(121), static_cast<u8>(58), static_cast<u8>(32), static_cast<u8>(75), static_cast<u8>(41), static_cast<u8>(32), static_cast<u8>(45), static_cast<u8>(62), static_cast<u8>(32), static_cast<u8>(86), static_cast<u8>(63), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(102), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(99), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(116), static_cast<u8>(97), static_cast<u8>(105), static_cast<u8>(110), static_cast<u8>(115), static_cast<u8>(40), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(105), static_cast<u8>(115), static_cast<u8>(44), static_cast<u8>(32), static_cast<u8>(97), static_cast<u8>(110), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(107), static_cast<u8>(101), static_cast<u8>(121), static_cast<u8>(58), static_cast<u8>(32), static_cast<u8>(75), static_cast<u8>(41), static_cast<u8>(32), static_cast<u8>(45), static_cast<u8>(62), static_cast<u8>(32), static_cast<u8>(98), static_cast<u8>(111), static_cast<u8>(111), static_cast<u8>(108), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(102), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(115), static_cast<u8>(101), static_cast<u8>(116), static_cast<u8>(40), static_cast<u8>(109), static_cast<u8>(117), static_cast<u8>(116), static_cast<u8>(32), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(105), static_cast<u8>(115), static_cast<u8>(44), static_cast<u8>(32), static_cast<u8>(97), static_cast<u8>(110), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(107), static_cast<u8>(101), static_cast<u8>(121), static_cast<u8>(58), static_cast<u8>(32), static_cast<u8>(75), static_cast<u8>(44), static_cast<u8>(32), static_cast<u8>(97), static_cast<u8>(110), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(118), static_cast<u8>(97), static_cast<u8>(108), static_cast<u8>(117), static_cast<u8>(101), static_cast<u8>(58), static_cast<u8>(32), static_cast<u8>(86), static_cast<u8>(41), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(102), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(114), static_cast<u8>(101), static_cast<u8>(109), static_cast<u8>(111), static_cast<u8>(118), static_cast<u8>(101), static_cast<u8>(40), static_cast<u8>(109), static_cast<u8>(117), static_cast<u8>(116), static_cast<u8>(32), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(105), static_cast<u8>(115), static_cast<u8>(44), static_cast<u8>(32), static_cast<u8>(97), static_cast<u8>(110), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(107), static_cast<u8>(101), static_cast<u8>(121), static_cast<u8>(58), static_cast<u8>(32), static_cast<u8>(75), static_cast<u8>(41), static_cast<u8>(32), static_cast<u8>(45), static_cast<u8>(62), static_cast<u8>(32), static_cast<u8>(98), static_cast<u8>(111), static_cast<u8>(111), static_cast<u8>(108), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(102), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(101), static_cast<u8>(110), static_cast<u8>(115), static_cast<u8>(117), static_cast<u8>(114), static_cast<u8>(101), static_cast<u8>(95), static_cast<u8>(99), static_cast<u8>(97), static_cast<u8>(112), static_cast<u8>(97), static_cast<u8>(99), static_cast<u8>(105), static_cast<u8>(116), static_cast<u8>(121), static_cast<u8>(40), static_cast<u8>(109), static_cast<u8>(117), static_cast<u8>(116), static_cast<u8>(32), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(105), static_cast<u8>(115), static_cast<u8>(44), static_cast<u8>(32), static_cast<u8>(97), static_cast<u8>(110), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(99), static_cast<u8>(97), static_cast<u8>(112), static_cast<u8>(97), static_cast<u8>(99), static_cast<u8>(105), static_cast<u8>(116), static_cast<u8>(121), static_cast<u8>(58), static_cast<u8>(32), static_cast<u8>(117), static_cast<u8>(115), static_cast<u8>(105), static_cast<u8>(122), static_cast<u8>(101), static_cast<u8>(41), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(102), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(99), static_cast<u8>(108), static_cast<u8>(101), static_cast<u8>(97), static_cast<u8>(114), static_cast<u8>(40), static_cast<u8>(109), static_cast<u8>(117), static_cast<u8>(116), static_cast<u8>(32), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(105), static_cast<u8>(115), static_cast<u8>(41), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(102), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(115), static_cast<u8>(105), static_cast<u8>(122), static_cast<u8>(101), static_cast<u8>(40), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(105), static_cast<u8>(115), static_cast<u8>(41), static_cast<u8>(32), static_cast<u8>(45), static_cast<u8>(62), static_cast<u8>(32), static_cast<u8>(117), static_cast<u8>(115), static_cast<u8>(105), static_cast<u8>(122), static_cast<u8>(101), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(102), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(99), static_cast<u8>(97), static_cast<u8>(112), static_cast<u8>(97), static_cast<u8>(99), static_cast<u8>(105), static_cast<u8>(116), static_cast<u8>(121), static_cast<u8>(40), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(105), static_cast<u8>(115), static_cast<u8>(41), static_cast<u8>(32), static_cast<u8>(45), static_cast<u8>(62), static_cast<u8>(32), static_cast<u8>(117), static_cast<u8>(115), static_cast<u8>(105), static_cast<u8>(122), static_cast<u8>(101), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(102), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(107), static_cast<u8>(101), static_cast<u8>(121), static_cast<u8>(115), static_cast<u8>(40), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(105), static_cast<u8>(115), static_cast<u8>(41), static_cast<u8>(32), static_cast<u8>(45), static_cast<u8>(62), static_cast<u8>(32), static_cast<u8>(91), static_cast<u8>(75), static_cast<u8>(93), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(102), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(104), static_cast<u8>(97), static_cast<u8>(115), static_cast<u8>(104), static_cast<u8>(40), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(105), static_cast<u8>(115), static_cast<u8>(41), static_cast<u8>(32), static_cast<u8>(45), static_cast<u8>(62), static_cast<u8>(32), static_cast<u8>(117), static_cast<u8>(51), static_cast<u8>(50), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(102), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(68), static_cast<u8>(105), static_cast<u8>(99), static_cast<u8>(116), static_cast<u8>(105), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(97), static_cast<u8>(114), static_cast<u8>(121), static_cast<u8>(60), static_cast<u8>(65), static_cast<u8>(44), static_cast<u8>(32), static_cast<u8>(66), static_cast<u8>(62), static_cast<u8>(40), static_cast<u8>(41), static_cast<u8>(32), static_cast<u8>(45), static_cast<u8>(62), static_cast<u8>(32), static_cast<u8>(68), static_cast<u8>(105), static_cast<u8>(99), static_cast<u8>(116), static_cast<u8>(105), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(97), static_cast<u8>(114), static_cast<u8>(121), static_cast<u8>(60), static_cast<u8>(65), static_cast<u8>(44), static_cast<u8>(32), static_cast<u8>(66), static_cast<u8>(62), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(102), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(105), static_cast<u8>(116), static_cast<u8>(101), static_cast<u8>(114), static_cast<u8>(97), static_cast<u8>(116), static_cast<u8>(111), static_cast<u8>(114), static_cast<u8>(40), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(105), static_cast<u8>(115), static_cast<u8>(41), static_cast<u8>(32), static_cast<u8>(45), static_cast<u8>(62), static_cast<u8>(32), static_cast<u8>(68), static_cast<u8>(105), static_cast<u8>(99), static_cast<u8>(116), static_cast<u8>(105), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(97), static_cast<u8>(114), static_cast<u8>(121), static_cast<u8>(73), static_cast<u8>(116), static_cast<u8>(101), static_cast<u8>(114), static_cast<u8>(97), static_cast<u8>(116), static_cast<u8>(111), static_cast<u8>(114), static_cast<u8>(60), static_cast<u8>(75), static_cast<u8>(44), static_cast<u8>(32), static_cast<u8>(86), static_cast<u8>(62), static_cast<u8>(10), static_cast<u8>(125), static_cast<u8>(10), static_cast<u8>(10), static_cast<u8>(101), static_cast<u8>(120), static_cast<u8>(116), static_cast<u8>(101), static_cast<u8>(114), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(115), static_cast<u8>(116), static_cast<u8>(114), static_cast<u8>(117), static_cast<u8>(99), static_cast<u8>(116), static_cast<u8>(32), static_cast<u8>(83), static_cast<u8>(101), static_cast<u8>(116), static_cast<u8>(73), static_cast<u8>(116), static_cast<u8>(101), static_cast<u8>(114), static_cast<u8>(97), static_cast<u8>(116), static_cast<u8>(111), static_cast<u8>(114), static_cast<u8>(60), static_cast<u8>(84), static_cast<u8>(62), static_cast<u8>(32), static_cast<u8>(123), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(102), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(110), static_cast<u8>(101), static_cast<u8>(120), static_cast<u8>(116), static_cast<u8>(40), static_cast<u8>(109), static_cast<u8>(117), static_cast<u8>(116), static_cast<u8>(32), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(105), static_cast<u8>(115), static_cast<u8>(41), static_cast<u8>(32), static_cast<u8>(45), static_cast<u8>(62), static_cast<u8>(32), static_cast<u8>(84), static_cast<u8>(63), static_cast<u8>(10), static_cast<u8>(125), static_cast<u8>(10), static_cast<u8>(10), static_cast<u8>(101), static_cast<u8>(120), static_cast<u8>(116), static_cast<u8>(101), static_cast<u8>(114), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(115), static_cast<u8>(116), static_cast<u8>(114), static_cast<u8>(117), static_cast<u8>(99), static_cast<u8>(116), static_cast<u8>(32), static_cast<u8>(83), static_cast<u8>(101), static_cast<u8>(116), static_cast<u8>(60), static_cast<u8>(86), static_cast<u8>(62), static_cast<u8>(32), static_cast<u8>(123), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(102), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(105), static_cast<u8>(115), static_cast<u8>(95), static_cast<u8>(101), static_cast<u8>(109), static_cast<u8>(112), static_cast<u8>(116), static_cast<u8>(121), static_cast<u8>(40), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(105), static_cast<u8>(115), static_cast<u8>(41), static_cast<u8>(32), static_cast<u8>(45), static_cast<u8>(62), static_cast<u8>(32), static_cast<u8>(98), static_cast<u8>(111), static_cast<u8>(111), static_cast<u8>(108), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(102), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(99), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(116), static_cast<u8>(97), static_cast<u8>(105), static_cast<u8>(110), static_cast<u8>(115), static_cast<u8>(40), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(105), static_cast<u8>(115), static_cast<u8>(44), static_cast<u8>(32), static_cast<u8>(97), static_cast<u8>(110), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(118), static_cast<u8>(97), static_cast<u8>(108), static_cast<u8>(117), static_cast<u8>(101), static_cast<u8>(58), static_cast<u8>(32), static_cast<u8>(86), static_cast<u8>(41), static_cast<u8>(32), static_cast<u8>(45), static_cast<u8>(62), static_cast<u8>(32), static_cast<u8>(98), static_cast<u8>(111), static_cast<u8>(111), static_cast<u8>(108), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(102), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(97), static_cast<u8>(100), static_cast<u8>(100), static_cast<u8>(40), static_cast<u8>(109), static_cast<u8>(117), static_cast<u8>(116), static_cast<u8>(32), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(105), static_cast<u8>(115), static_cast<u8>(44), static_cast<u8>(32), static_cast<u8>(97), static_cast<u8>(110), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(118), static_cast<u8>(97), static_cast<u8>(108), static_cast<u8>(117), static_cast<u8>(101), static_cast<u8>(58), static_cast<u8>(32), static_cast<u8>(86), static_cast<u8>(41), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(102), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(114), static_cast<u8>(101), static_cast<u8>(109), static_cast<u8>(111), static_cast<u8>(118), static_cast<u8>(101), static_cast<u8>(40), static_cast<u8>(109), static_cast<u8>(117), static_cast<u8>(116), static_cast<u8>(32), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(105), static_cast<u8>(115), static_cast<u8>(44), static_cast<u8>(32), static_cast<u8>(97), static_cast<u8>(110), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(118), static_cast<u8>(97), static_cast<u8>(108), static_cast<u8>(117), static_cast<u8>(101), static_cast<u8>(58), static_cast<u8>(32), static_cast<u8>(86), static_cast<u8>(41), static_cast<u8>(32), static_cast<u8>(45), static_cast<u8>(62), static_cast<u8>(32), static_cast<u8>(98), static_cast<u8>(111), static_cast<u8>(111), static_cast<u8>(108), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(102), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(101), static_cast<u8>(110), static_cast<u8>(115), static_cast<u8>(117), static_cast<u8>(114), static_cast<u8>(101), static_cast<u8>(95), static_cast<u8>(99), static_cast<u8>(97), static_cast<u8>(112), static_cast<u8>(97), static_cast<u8>(99), static_cast<u8>(105), static_cast<u8>(116), static_cast<u8>(121), static_cast<u8>(40), static_cast<u8>(109), static_cast<u8>(117), static_cast<u8>(116), static_cast<u8>(32), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(105), static_cast<u8>(115), static_cast<u8>(44), static_cast<u8>(32), static_cast<u8>(97), static_cast<u8>(110), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(99), static_cast<u8>(97), static_cast<u8>(112), static_cast<u8>(97), static_cast<u8>(99), static_cast<u8>(105), static_cast<u8>(116), static_cast<u8>(121), static_cast<u8>(58), static_cast<u8>(32), static_cast<u8>(117), static_cast<u8>(115), static_cast<u8>(105), static_cast<u8>(122), static_cast<u8>(101), static_cast<u8>(41), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(102), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(99), static_cast<u8>(108), static_cast<u8>(101), static_cast<u8>(97), static_cast<u8>(114), static_cast<u8>(40), static_cast<u8>(109), static_cast<u8>(117), static_cast<u8>(116), static_cast<u8>(32), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(105), static_cast<u8>(115), static_cast<u8>(41), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(102), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(115), static_cast<u8>(105), static_cast<u8>(122), static_cast<u8>(101), static_cast<u8>(40), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(105), static_cast<u8>(115), static_cast<u8>(41), static_cast<u8>(32), static_cast<u8>(45), static_cast<u8>(62), static_cast<u8>(32), static_cast<u8>(117), static_cast<u8>(115), static_cast<u8>(105), static_cast<u8>(122), static_cast<u8>(101), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(102), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(99), static_cast<u8>(97), static_cast<u8>(112), static_cast<u8>(97), static_cast<u8>(99), static_cast<u8>(105), static_cast<u8>(116), static_cast<u8>(121), static_cast<u8>(40), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(105), static_cast<u8>(115), static_cast<u8>(41), static_cast<u8>(32), static_cast<u8>(45), static_cast<u8>(62), static_cast<u8>(32), static_cast<u8>(117), static_cast<u8>(115), static_cast<u8>(105), static_cast<u8>(122), static_cast<u8>(101), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(102), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(104), static_cast<u8>(97), static_cast<u8>(115), static_cast<u8>(104), static_cast<u8>(40), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(105), static_cast<u8>(115), static_cast<u8>(41), static_cast<u8>(32), static_cast<u8>(45), static_cast<u8>(62), static_cast<u8>(32), static_cast<u8>(117), static_cast<u8>(51), static_cast<u8>(50), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(102), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(83), static_cast<u8>(101), static_cast<u8>(116), static_cast<u8>(60), static_cast<u8>(65), static_cast<u8>(62), static_cast<u8>(40), static_cast<u8>(41), static_cast<u8>(32), static_cast<u8>(45), static_cast<u8>(62), static_cast<u8>(32), static_cast<u8>(83), static_cast<u8>(101), static_cast<u8>(116), static_cast<u8>(60), static_cast<u8>(65), static_cast<u8>(62), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(102), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(105), static_cast<u8>(116), static_cast<u8>(101), static_cast<u8>(114), static_cast<u8>(97), static_cast<u8>(116), static_cast<u8>(111), static_cast<u8>(114), static_cast<u8>(40), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(105), static_cast<u8>(115), static_cast<u8>(41), static_cast<u8>(32), static_cast<u8>(45), static_cast<u8>(62), static_cast<u8>(32), static_cast<u8>(83), static_cast<u8>(101), static_cast<u8>(116), static_cast<u8>(73), static_cast<u8>(116), static_cast<u8>(101), static_cast<u8>(114), static_cast<u8>(97), static_cast<u8>(116), static_cast<u8>(111), static_cast<u8>(114), static_cast<u8>(60), static_cast<u8>(86), static_cast<u8>(62), static_cast<u8>(10), static_cast<u8>(125), static_cast<u8>(10), static_cast<u8>(10), static_cast<u8>(101), static_cast<u8>(120), static_cast<u8>(116), static_cast<u8>(101), static_cast<u8>(114), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(115), static_cast<u8>(116), static_cast<u8>(114), static_cast<u8>(117), static_cast<u8>(99), static_cast<u8>(116), static_cast<u8>(32), static_cast<u8>(82), static_cast<u8>(97), static_cast<u8>(110), static_cast<u8>(103), static_cast<u8>(101), static_cast<u8>(60), static_cast<u8>(84), static_cast<u8>(62), static_cast<u8>(32), static_cast<u8>(123), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(102), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(82), static_cast<u8>(97), static_cast<u8>(110), static_cast<u8>(103), static_cast<u8>(101), static_cast<u8>(60), static_cast<u8>(85), static_cast<u8>(62), static_cast<u8>(40), static_cast<u8>(97), static_cast<u8>(110), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(115), static_cast<u8>(116), static_cast<u8>(97), static_cast<u8>(114), static_cast<u8>(116), static_cast<u8>(58), static_cast<u8>(32), static_cast<u8>(85), static_cast<u8>(44), static_cast<u8>(32), static_cast<u8>(97), static_cast<u8>(110), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(101), static_cast<u8>(110), static_cast<u8>(100), static_cast<u8>(58), static_cast<u8>(32), static_cast<u8>(85), static_cast<u8>(41), static_cast<u8>(32), static_cast<u8>(45), static_cast<u8>(62), static_cast<u8>(32), static_cast<u8>(82), static_cast<u8>(97), static_cast<u8>(110), static_cast<u8>(103), static_cast<u8>(101), static_cast<u8>(60), static_cast<u8>(85), static_cast<u8>(62), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(102), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(110), static_cast<u8>(101), static_cast<u8>(120), static_cast<u8>(116), static_cast<u8>(40), static_cast<u8>(109), static_cast<u8>(117), static_cast<u8>(116), static_cast<u8>(32), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(105), static_cast<u8>(115), static_cast<u8>(41), static_cast<u8>(32), static_cast<u8>(45), static_cast<u8>(62), static_cast<u8>(32), static_cast<u8>(84), static_cast<u8>(63), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(102), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(105), static_cast<u8>(110), static_cast<u8>(99), static_cast<u8>(108), static_cast<u8>(117), static_cast<u8>(115), static_cast<u8>(105), static_cast<u8>(118), static_cast<u8>(101), static_cast<u8>(40), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(105), static_cast<u8>(115), static_cast<u8>(41), static_cast<u8>(32), static_cast<u8>(45), static_cast<u8>(62), static_cast<u8>(32), static_cast<u8>(82), static_cast<u8>(97), static_cast<u8>(110), static_cast<u8>(103), static_cast<u8>(101), static_cast<u8>(60), static_cast<u8>(84), static_cast<u8>(62), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(102), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(101), static_cast<u8>(120), static_cast<u8>(99), static_cast<u8>(108), static_cast<u8>(117), static_cast<u8>(115), static_cast<u8>(105), static_cast<u8>(118), static_cast<u8>(101), static_cast<u8>(40), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(105), static_cast<u8>(115), static_cast<u8>(41), static_cast<u8>(32), static_cast<u8>(45), static_cast<u8>(62), static_cast<u8>(32), static_cast<u8>(82), static_cast<u8>(97), static_cast<u8>(110), static_cast<u8>(103), static_cast<u8>(101), static_cast<u8>(60), static_cast<u8>(84), static_cast<u8>(62), static_cast<u8>(10), static_cast<u8>(125), static_cast<u8>(10), static_cast<u8>(10), static_cast<u8>(101), static_cast<u8>(120), static_cast<u8>(116), static_cast<u8>(101), static_cast<u8>(114), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(115), static_cast<u8>(116), static_cast<u8>(114), static_cast<u8>(117), static_cast<u8>(99), static_cast<u8>(116), static_cast<u8>(32), static_cast<u8>(83), static_cast<u8>(116), static_cast<u8>(114), static_cast<u8>(105), static_cast<u8>(110), static_cast<u8>(103), static_cast<u8>(86), static_cast<u8>(105), static_cast<u8>(101), static_cast<u8>(119), static_cast<u8>(32), static_cast<u8>(123), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(102), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(108), static_cast<u8>(101), static_cast<u8>(110), static_cast<u8>(103), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(40), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(105), static_cast<u8>(115), static_cast<u8>(41), static_cast<u8>(32), static_cast<u8>(45), static_cast<u8>(62), static_cast<u8>(32), static_cast<u8>(117), static_cast<u8>(115), static_cast<u8>(105), static_cast<u8>(122), static_cast<u8>(101), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(91), static_cast<u8>(91), static_cast<u8>(110), static_cast<u8>(97), static_cast<u8>(109), static_cast<u8>(101), static_cast<u8>(61), static_cast<u8>(34), static_cast<u8>(111), static_cast<u8>(112), static_cast<u8>(101), static_cast<u8>(114), static_cast<u8>(97), static_cast<u8>(116), static_cast<u8>(111), static_cast<u8>(114), static_cast<u8>(91), static_cast<u8>(93), static_cast<u8>(34), static_cast<u8>(93), static_cast<u8>(93), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(102), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(98), static_cast<u8>(121), static_cast<u8>(116), static_cast<u8>(101), static_cast<u8>(95), static_cast<u8>(97), static_cast<u8>(116), static_cast<u8>(40), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(105), static_cast<u8>(115), static_cast<u8>(44), static_cast<u8>(32), static_cast<u8>(97), static_cast<u8>(110), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(105), static_cast<u8>(110), static_cast<u8>(100), static_cast<u8>(101), static_cast<u8>(120), static_cast<u8>(58), static_cast<u8>(32), static_cast<u8>(117), static_cast<u8>(115), static_cast<u8>(105), static_cast<u8>(122), static_cast<u8>(101), static_cast<u8>(41), static_cast<u8>(32), static_cast<u8>(45), static_cast<u8>(62), static_cast<u8>(32), static_cast<u8>(117), static_cast<u8>(56), static_cast<u8>(10), static_cast<u8>(125), static_cast<u8>(10), static_cast<u8>(10), static_cast<u8>(101), static_cast<u8>(120), static_cast<u8>(116), static_cast<u8>(101), static_cast<u8>(114), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(115), static_cast<u8>(116), static_cast<u8>(114), static_cast<u8>(117), static_cast<u8>(99), static_cast<u8>(116), static_cast<u8>(32), static_cast<u8>(69), static_cast<u8>(114), static_cast<u8>(114), static_cast<u8>(111), static_cast<u8>(114), static_cast<u8>(32), static_cast<u8>(123), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(102), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(99), static_cast<u8>(111), static_cast<u8>(100), static_cast<u8>(101), static_cast<u8>(40), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(105), static_cast<u8>(115), static_cast<u8>(41), static_cast<u8>(32), static_cast<u8>(45), static_cast<u8>(62), static_cast<u8>(32), static_cast<u8>(105), static_cast<u8>(51), static_cast<u8>(50), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(91), static_cast<u8>(91), static_cast<u8>(110), static_cast<u8>(97), static_cast<u8>(109), static_cast<u8>(101), static_cast<u8>(61), static_cast<u8>(115), static_cast<u8>(116), static_cast<u8>(114), static_cast<u8>(105), static_cast<u8>(110), static_cast<u8>(103), static_cast<u8>(95), static_cast<u8>(108), static_cast<u8>(105), static_cast<u8>(116), static_cast<u8>(101), static_cast<u8>(114), static_cast<u8>(97), static_cast<u8>(108), static_cast<u8>(93), static_cast<u8>(93), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(102), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(115), static_cast<u8>(116), static_cast<u8>(114), static_cast<u8>(105), static_cast<u8>(110), static_cast<u8>(103), static_cast<u8>(40), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(105), static_cast<u8>(115), static_cast<u8>(41), static_cast<u8>(32), static_cast<u8>(45), static_cast<u8>(62), static_cast<u8>(32), static_cast<u8>(83), static_cast<u8>(116), static_cast<u8>(114), static_cast<u8>(105), static_cast<u8>(110), static_cast<u8>(103), static_cast<u8>(86), static_cast<u8>(105), static_cast<u8>(101), static_cast<u8>(119), static_cast<u8>(10), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(102), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(102), static_cast<u8>(114), static_cast<u8>(111), static_cast<u8>(109), static_cast<u8>(95), static_cast<u8>(101), static_cast<u8>(114), static_cast<u8>(114), static_cast<u8>(110), static_cast<u8>(111), static_cast<u8>(40), static_cast<u8>(97), static_cast<u8>(110), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(101), static_cast<u8>(114), static_cast<u8>(114), static_cast<u8>(110), static_cast<u8>(111), static_cast<u8>(58), static_cast<u8>(32), static_cast<u8>(105), static_cast<u8>(51), static_cast<u8>(50), static_cast<u8>(41), static_cast<u8>(32), static_cast<u8>(45), static_cast<u8>(62), static_cast<u8>(32), static_cast<u8>(69), static_cast<u8>(114), static_cast<u8>(114), static_cast<u8>(111), static_cast<u8>(114), static_cast<u8>(10), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(91), static_cast<u8>(91), static_cast<u8>(110), static_cast<u8>(97), static_cast<u8>(109), static_cast<u8>(101), static_cast<u8>(61), static_cast<u8>(34), static_cast<u8>(95), static_cast<u8>(95), static_cast<u8>(106), static_cast<u8>(97), static_cast<u8>(107), static_cast<u8>(116), static_cast<u8>(95), static_cast<u8>(102), static_cast<u8>(114), static_cast<u8>(111), static_cast<u8>(109), static_cast<u8>(95), static_cast<u8>(115), static_cast<u8>(116), static_cast<u8>(114), static_cast<u8>(105), static_cast<u8>(110), static_cast<u8>(103), static_cast<u8>(95), static_cast<u8>(108), static_cast<u8>(105), static_cast<u8>(116), static_cast<u8>(101), static_cast<u8>(114), static_cast<u8>(97), static_cast<u8>(108), static_cast<u8>(34), static_cast<u8>(93), static_cast<u8>(93), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(102), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(102), static_cast<u8>(114), static_cast<u8>(111), static_cast<u8>(109), static_cast<u8>(95), static_cast<u8>(115), static_cast<u8>(116), static_cast<u8>(114), static_cast<u8>(105), static_cast<u8>(110), static_cast<u8>(103), static_cast<u8>(95), static_cast<u8>(108), static_cast<u8>(105), static_cast<u8>(116), static_cast<u8>(101), static_cast<u8>(114), static_cast<u8>(97), static_cast<u8>(108), static_cast<u8>(40), static_cast<u8>(97), static_cast<u8>(110), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(115), static_cast<u8>(116), static_cast<u8>(114), static_cast<u8>(105), static_cast<u8>(110), static_cast<u8>(103), static_cast<u8>(58), static_cast<u8>(32), static_cast<u8>(83), static_cast<u8>(116), static_cast<u8>(114), static_cast<u8>(105), static_cast<u8>(110), static_cast<u8>(103), static_cast<u8>(86), static_cast<u8>(105), static_cast<u8>(101), static_cast<u8>(119), static_cast<u8>(41), static_cast<u8>(32), static_cast<u8>(45), static_cast<u8>(62), static_cast<u8>(32), static_cast<u8>(69), static_cast<u8>(114), static_cast<u8>(114), static_cast<u8>(111), static_cast<u8>(114), static_cast<u8>(10), static_cast<u8>(125), static_cast<u8>(10), static_cast<u8>(10), static_cast<u8>(101), static_cast<u8>(120), static_cast<u8>(116), static_cast<u8>(101), static_cast<u8>(114), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(99), static_cast<u8>(108), static_cast<u8>(97), static_cast<u8>(115), static_cast<u8>(115), static_cast<u8>(32), static_cast<u8>(70), static_cast<u8>(105), static_cast<u8>(108), static_cast<u8>(101), static_cast<u8>(32), static_cast<u8>(123), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(112), static_cast<u8>(117), static_cast<u8>(98), static_cast<u8>(108), static_cast<u8>(105), static_cast<u8>(99), static_cast<u8>(32), static_cast<u8>(102), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(111), static_cast<u8>(112), static_cast<u8>(101), static_cast<u8>(110), static_cast<u8>(95), static_cast<u8>(102), static_cast<u8>(111), static_cast<u8>(114), static_cast<u8>(95), static_cast<u8>(114), static_cast<u8>(101), static_cast<u8>(97), static_cast<u8>(100), static_cast<u8>(105), static_cast<u8>(110), static_cast<u8>(103), static_cast<u8>(40), static_cast<u8>(97), static_cast<u8>(110), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(112), static_cast<u8>(97), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(58), static_cast<u8>(32), static_cast<u8>(83), static_cast<u8>(116), static_cast<u8>(114), static_cast<u8>(105), static_cast<u8>(110), static_cast<u8>(103), static_cast<u8>(41), static_cast<u8>(32), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(114), static_cast<u8>(111), static_cast<u8>(119), static_cast<u8>(115), static_cast<u8>(32), static_cast<u8>(45), static_cast<u8>(62), static_cast<u8>(32), static_cast<u8>(70), static_cast<u8>(105), static_cast<u8>(108), static_cast<u8>(101), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(112), static_cast<u8>(117), static_cast<u8>(98), static_cast<u8>(108), static_cast<u8>(105), static_cast<u8>(99), static_cast<u8>(32), static_cast<u8>(102), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(111), static_cast<u8>(112), static_cast<u8>(101), static_cast<u8>(110), static_cast<u8>(95), static_cast<u8>(102), static_cast<u8>(111), static_cast<u8>(114), static_cast<u8>(95), static_cast<u8>(119), static_cast<u8>(114), static_cast<u8>(105), static_cast<u8>(116), static_cast<u8>(105), static_cast<u8>(110), static_cast<u8>(103), static_cast<u8>(40), static_cast<u8>(97), static_cast<u8>(110), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(112), static_cast<u8>(97), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(58), static_cast<u8>(32), static_cast<u8>(83), static_cast<u8>(116), static_cast<u8>(114), static_cast<u8>(105), static_cast<u8>(110), static_cast<u8>(103), static_cast<u8>(41), static_cast<u8>(32), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(114), static_cast<u8>(111), static_cast<u8>(119), static_cast<u8>(115), static_cast<u8>(32), static_cast<u8>(45), static_cast<u8>(62), static_cast<u8>(32), static_cast<u8>(70), static_cast<u8>(105), static_cast<u8>(108), static_cast<u8>(101), static_cast<u8>(10), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(112), static_cast<u8>(117), static_cast<u8>(98), static_cast<u8>(108), static_cast<u8>(105), static_cast<u8>(99), static_cast<u8>(32), static_cast<u8>(102), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(114), static_cast<u8>(101), static_cast<u8>(97), static_cast<u8>(100), static_cast<u8>(40), static_cast<u8>(109), static_cast<u8>(117), static_cast<u8>(116), static_cast<u8>(32), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(105), static_cast<u8>(115), static_cast<u8>(44), static_cast<u8>(32), static_cast<u8>(97), static_cast<u8>(110), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(98), static_cast<u8>(117), static_cast<u8>(102), static_cast<u8>(102), static_cast<u8>(101), static_cast<u8>(114), static_cast<u8>(58), static_cast<u8>(32), static_cast<u8>(91), static_cast<u8>(117), static_cast<u8>(56), static_cast<u8>(93), static_cast<u8>(41), static_cast<u8>(32), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(114), static_cast<u8>(111), static_cast<u8>(119), static_cast<u8>(115), static_cast<u8>(32), static_cast<u8>(45), static_cast<u8>(62), static_cast<u8>(32), static_cast<u8>(117), static_cast<u8>(115), static_cast<u8>(105), static_cast<u8>(122), static_cast<u8>(101), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(112), static_cast<u8>(117), static_cast<u8>(98), static_cast<u8>(108), static_cast<u8>(105), static_cast<u8>(99), static_cast<u8>(32), static_cast<u8>(102), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(119), static_cast<u8>(114), static_cast<u8>(105), static_cast<u8>(116), static_cast<u8>(101), static_cast<u8>(40), static_cast<u8>(109), static_cast<u8>(117), static_cast<u8>(116), static_cast<u8>(32), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(105), static_cast<u8>(115), static_cast<u8>(44), static_cast<u8>(32), static_cast<u8>(97), static_cast<u8>(110), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(100), static_cast<u8>(97), static_cast<u8>(116), static_cast<u8>(97), static_cast<u8>(58), static_cast<u8>(32), static_cast<u8>(91), static_cast<u8>(117), static_cast<u8>(56), static_cast<u8>(93), static_cast<u8>(41), static_cast<u8>(32), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(114), static_cast<u8>(111), static_cast<u8>(119), static_cast<u8>(115), static_cast<u8>(32), static_cast<u8>(45), static_cast<u8>(62), static_cast<u8>(32), static_cast<u8>(117), static_cast<u8>(115), static_cast<u8>(105), static_cast<u8>(122), static_cast<u8>(101), static_cast<u8>(10), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(112), static_cast<u8>(117), static_cast<u8>(98), static_cast<u8>(108), static_cast<u8>(105), static_cast<u8>(99), static_cast<u8>(32), static_cast<u8>(102), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(114), static_cast<u8>(101), static_cast<u8>(97), static_cast<u8>(100), static_cast<u8>(95), static_cast<u8>(97), static_cast<u8>(108), static_cast<u8>(108), static_cast<u8>(40), static_cast<u8>(109), static_cast<u8>(117), static_cast<u8>(116), static_cast<u8>(32), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(105), static_cast<u8>(115), static_cast<u8>(41), static_cast<u8>(32), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(114), static_cast<u8>(111), static_cast<u8>(119), static_cast<u8>(115), static_cast<u8>(32), static_cast<u8>(45), static_cast<u8>(62), static_cast<u8>(32), static_cast<u8>(91), static_cast<u8>(117), static_cast<u8>(56), static_cast<u8>(93), static_cast<u8>(10), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(112), static_cast<u8>(117), static_cast<u8>(98), static_cast<u8>(108), static_cast<u8>(105), static_cast<u8>(99), static_cast<u8>(32), static_cast<u8>(102), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(101), static_cast<u8>(120), static_cast<u8>(105), static_cast<u8>(115), static_cast<u8>(116), static_cast<u8>(115), static_cast<u8>(40), static_cast<u8>(97), static_cast<u8>(110), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(112), static_cast<u8>(97), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(58), static_cast<u8>(32), static_cast<u8>(83), static_cast<u8>(116), static_cast<u8>(114), static_cast<u8>(105), static_cast<u8>(110), static_cast<u8>(103), static_cast<u8>(41), static_cast<u8>(32), static_cast<u8>(45), static_cast<u8>(62), static_cast<u8>(32), static_cast<u8>(98), static_cast<u8>(111), static_cast<u8>(111), static_cast<u8>(108), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(112), static_cast<u8>(117), static_cast<u8>(98), static_cast<u8>(108), static_cast<u8>(105), static_cast<u8>(99), static_cast<u8>(32), static_cast<u8>(102), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(99), static_cast<u8>(117), static_cast<u8>(114), static_cast<u8>(114), static_cast<u8>(101), static_cast<u8>(110), static_cast<u8>(116), static_cast<u8>(95), static_cast<u8>(101), static_cast<u8>(120), static_cast<u8>(101), static_cast<u8>(99), static_cast<u8>(117), static_cast<u8>(116), static_cast<u8>(97), static_cast<u8>(98), static_cast<u8>(108), static_cast<u8>(101), static_cast<u8>(95), static_cast<u8>(112), static_cast<u8>(97), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(40), static_cast<u8>(41), static_cast<u8>(32), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(114), static_cast<u8>(111), static_cast<u8>(119), static_cast<u8>(115), static_cast<u8>(32), static_cast<u8>(45), static_cast<u8>(62), static_cast<u8>(32), static_cast<u8>(83), static_cast<u8>(116), static_cast<u8>(114), static_cast<u8>(105), static_cast<u8>(110), static_cast<u8>(103), static_cast<u8>(10), static_cast<u8>(125), static_cast<u8>(10), static_cast<u8>(10), static_cast<u8>(101), static_cast<u8>(120), static_cast<u8>(116), static_cast<u8>(101), static_cast<u8>(114), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(102), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(95), static_cast<u8>(95), static_cast<u8>(95), static_cast<u8>(106), static_cast<u8>(97), static_cast<u8>(107), static_cast<u8>(116), static_cast<u8>(95), static_cast<u8>(103), static_cast<u8>(101), static_cast<u8>(116), static_cast<u8>(95), static_cast<u8>(116), static_cast<u8>(97), static_cast<u8>(114), static_cast<u8>(103), static_cast<u8>(101), static_cast<u8>(116), static_cast<u8>(95), static_cast<u8>(116), static_cast<u8>(114), static_cast<u8>(105), static_cast<u8>(112), static_cast<u8>(108), static_cast<u8>(101), static_cast<u8>(95), static_cast<u8>(115), static_cast<u8>(116), static_cast<u8>(114), static_cast<u8>(105), static_cast<u8>(110), static_cast<u8>(103), static_cast<u8>(40), static_cast<u8>(41), static_cast<u8>(32), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(114), static_cast<u8>(111), static_cast<u8>(119), static_cast<u8>(115), static_cast<u8>(32), static_cast<u8>(45), static_cast<u8>(62), static_cast<u8>(32), static_cast<u8>(83), static_cast<u8>(116), static_cast<u8>(114), static_cast<u8>(105), static_cast<u8>(110), static_cast<u8>(103), static_cast<u8>(10), static_cast<u8>(10), static_cast<u8>(101), static_cast<u8>(120), static_cast<u8>(116), static_cast<u8>(101), static_cast<u8>(114), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(102), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(97), static_cast<u8>(98), static_cast<u8>(111), static_cast<u8>(114), static_cast<u8>(116), static_cast<u8>(40), static_cast<u8>(41), static_cast<u8>(32), static_cast<u8>(45), static_cast<u8>(62), static_cast<u8>(32), static_cast<u8>(110), static_cast<u8>(101), static_cast<u8>(118), static_cast<u8>(101), static_cast<u8>(114), static_cast<u8>(10), static_cast<u8>(101), static_cast<u8>(120), static_cast<u8>(116), static_cast<u8>(101), static_cast<u8>(114), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(102), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(97), static_cast<u8>(115), static_cast<u8>(95), static_cast<u8>(115), static_cast<u8>(97), static_cast<u8>(116), static_cast<u8>(117), static_cast<u8>(114), static_cast<u8>(97), static_cast<u8>(116), static_cast<u8>(101), static_cast<u8>(100), static_cast<u8>(60), static_cast<u8>(85), static_cast<u8>(44), static_cast<u8>(32), static_cast<u8>(84), static_cast<u8>(62), static_cast<u8>(40), static_cast<u8>(97), static_cast<u8>(110), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(105), static_cast<u8>(110), static_cast<u8>(112), static_cast<u8>(117), static_cast<u8>(116), static_cast<u8>(58), static_cast<u8>(32), static_cast<u8>(84), static_cast<u8>(41), static_cast<u8>(32), static_cast<u8>(45), static_cast<u8>(62), static_cast<u8>(32), static_cast<u8>(85), static_cast<u8>(10), static_cast<u8>(101), static_cast<u8>(120), static_cast<u8>(116), static_cast<u8>(101), static_cast<u8>(114), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(102), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(97), static_cast<u8>(115), static_cast<u8>(95), static_cast<u8>(116), static_cast<u8>(114), static_cast<u8>(117), static_cast<u8>(110), static_cast<u8>(99), static_cast<u8>(97), static_cast<u8>(116), static_cast<u8>(101), static_cast<u8>(100), static_cast<u8>(60), static_cast<u8>(85), static_cast<u8>(44), static_cast<u8>(32), static_cast<u8>(84), static_cast<u8>(62), static_cast<u8>(40), static_cast<u8>(97), static_cast<u8>(110), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(105), static_cast<u8>(110), static_cast<u8>(112), static_cast<u8>(117), static_cast<u8>(116), static_cast<u8>(58), static_cast<u8>(32), static_cast<u8>(84), static_cast<u8>(41), static_cast<u8>(32), static_cast<u8>(45), static_cast<u8>(62), static_cast<u8>(32), static_cast<u8>(85), static_cast<u8>(10), static_cast<u8>(101), static_cast<u8>(120), static_cast<u8>(116), static_cast<u8>(101), static_cast<u8>(114), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(102), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(117), static_cast<u8>(110), static_cast<u8>(99), static_cast<u8>(104), static_cast<u8>(101), static_cast<u8>(99), static_cast<u8>(107), static_cast<u8>(101), static_cast<u8>(100), static_cast<u8>(95), static_cast<u8>(97), static_cast<u8>(100), static_cast<u8>(100), static_cast<u8>(60), static_cast<u8>(84), static_cast<u8>(62), static_cast<u8>(40), static_cast<u8>(97), static_cast<u8>(110), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(97), static_cast<u8>(58), static_cast<u8>(32), static_cast<u8>(84), static_cast<u8>(44), static_cast<u8>(32), static_cast<u8>(97), static_cast<u8>(110), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(98), static_cast<u8>(58), static_cast<u8>(32), static_cast<u8>(84), static_cast<u8>(41), static_cast<u8>(32), static_cast<u8>(45), static_cast<u8>(62), static_cast<u8>(32), static_cast<u8>(84), static_cast<u8>(10), static_cast<u8>(101), static_cast<u8>(120), static_cast<u8>(116), static_cast<u8>(101), static_cast<u8>(114), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(102), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(117), static_cast<u8>(110), static_cast<u8>(99), static_cast<u8>(104), static_cast<u8>(101), static_cast<u8>(99), static_cast<u8>(107), static_cast<u8>(101), static_cast<u8>(100), static_cast<u8>(95), static_cast<u8>(115), static_cast<u8>(117), static_cast<u8>(98), static_cast<u8>(60), static_cast<u8>(84), static_cast<u8>(62), static_cast<u8>(40), static_cast<u8>(97), static_cast<u8>(110), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(97), static_cast<u8>(58), static_cast<u8>(32), static_cast<u8>(84), static_cast<u8>(44), static_cast<u8>(32), static_cast<u8>(97), static_cast<u8>(110), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(98), static_cast<u8>(58), static_cast<u8>(32), static_cast<u8>(84), static_cast<u8>(41), static_cast<u8>(32), static_cast<u8>(45), static_cast<u8>(62), static_cast<u8>(32), static_cast<u8>(84), static_cast<u8>(10), static_cast<u8>(101), static_cast<u8>(120), static_cast<u8>(116), static_cast<u8>(101), static_cast<u8>(114), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(102), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(117), static_cast<u8>(110), static_cast<u8>(99), static_cast<u8>(104), static_cast<u8>(101), static_cast<u8>(99), static_cast<u8>(107), static_cast<u8>(101), static_cast<u8>(100), static_cast<u8>(95), static_cast<u8>(109), static_cast<u8>(117), static_cast<u8>(108), static_cast<u8>(60), static_cast<u8>(84), static_cast<u8>(62), static_cast<u8>(40), static_cast<u8>(97), static_cast<u8>(110), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(97), static_cast<u8>(58), static_cast<u8>(32), static_cast<u8>(84), static_cast<u8>(44), static_cast<u8>(32), static_cast<u8>(97), static_cast<u8>(110), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(98), static_cast<u8>(58), static_cast<u8>(32), static_cast<u8>(84), static_cast<u8>(41), static_cast<u8>(32), static_cast<u8>(45), static_cast<u8>(62), static_cast<u8>(32), static_cast<u8>(84), static_cast<u8>(10), static_cast<u8>(101), static_cast<u8>(120), static_cast<u8>(116), static_cast<u8>(101), static_cast<u8>(114), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(102), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(117), static_cast<u8>(110), static_cast<u8>(99), static_cast<u8>(104), static_cast<u8>(101), static_cast<u8>(99), static_cast<u8>(107), static_cast<u8>(101), static_cast<u8>(100), static_cast<u8>(95), static_cast<u8>(100), static_cast<u8>(105), static_cast<u8>(118), static_cast<u8>(60), static_cast<u8>(84), static_cast<u8>(62), static_cast<u8>(40), static_cast<u8>(97), static_cast<u8>(110), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(97), static_cast<u8>(58), static_cast<u8>(32), static_cast<u8>(84), static_cast<u8>(44), static_cast<u8>(32), static_cast<u8>(97), static_cast<u8>(110), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(98), static_cast<u8>(58), static_cast<u8>(32), static_cast<u8>(84), static_cast<u8>(41), static_cast<u8>(32), static_cast<u8>(45), static_cast<u8>(62), static_cast<u8>(32), static_cast<u8>(84), static_cast<u8>(10), static_cast<u8>(10), static_cast<u8>(110), static_cast<u8>(97), static_cast<u8>(109), static_cast<u8>(101), static_cast<u8>(115), static_cast<u8>(112), static_cast<u8>(97), static_cast<u8>(99), static_cast<u8>(101), static_cast<u8>(32), static_cast<u8>(82), static_cast<u8>(101), static_cast<u8>(102), static_cast<u8>(108), static_cast<u8>(101), static_cast<u8>(99), static_cast<u8>(116), static_cast<u8>(32), static_cast<u8>(123), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(115), static_cast<u8>(116), static_cast<u8>(114), static_cast<u8>(117), static_cast<u8>(99), static_cast<u8>(116), static_cast<u8>(32), static_cast<u8>(83), static_cast<u8>(112), static_cast<u8>(97), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(123), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(115), static_cast<u8>(116), static_cast<u8>(97), static_cast<u8>(114), static_cast<u8>(116), static_cast<u8>(58), static_cast<u8>(32), static_cast<u8>(117), static_cast<u8>(115), static_cast<u8>(105), static_cast<u8>(122), static_cast<u8>(101), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(101), static_cast<u8>(110), static_cast<u8>(100), static_cast<u8>(58), static_cast<u8>(32), static_cast<u8>(117), static_cast<u8>(115), static_cast<u8>(105), static_cast<u8>(122), static_cast<u8>(101), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(102), static_cast<u8>(105), static_cast<u8>(108), static_cast<u8>(101), static_cast<u8>(58), static_cast<u8>(32), static_cast<u8>(83), static_cast<u8>(116), static_cast<u8>(114), static_cast<u8>(105), static_cast<u8>(110), static_cast<u8>(103), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(125), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(101), static_cast<u8>(110), static_cast<u8>(117), static_cast<u8>(109), static_cast<u8>(32), static_cast<u8>(86), static_cast<u8>(105), static_cast<u8>(115), static_cast<u8>(105), static_cast<u8>(98), static_cast<u8>(105), static_cast<u8>(108), static_cast<u8>(105), static_cast<u8>(116), static_cast<u8>(121), static_cast<u8>(32), static_cast<u8>(123), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(80), static_cast<u8>(117), static_cast<u8>(98), static_cast<u8>(108), static_cast<u8>(105), static_cast<u8>(99), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(80), static_cast<u8>(114), static_cast<u8>(105), static_cast<u8>(118), static_cast<u8>(97), static_cast<u8>(116), static_cast<u8>(101), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(47), static_cast<u8>(47), static_cast<u8>(32), static_cast<u8>(82), static_cast<u8>(101), static_cast<u8>(115), static_cast<u8>(116), static_cast<u8>(114), static_cast<u8>(105), static_cast<u8>(99), static_cast<u8>(116), static_cast<u8>(101), static_cast<u8>(100), static_cast<u8>(40), static_cast<u8>(119), static_cast<u8>(104), static_cast<u8>(105), static_cast<u8>(116), static_cast<u8>(101), static_cast<u8>(108), static_cast<u8>(105), static_cast<u8>(115), static_cast<u8>(116), static_cast<u8>(58), static_cast<u8>(32), static_cast<u8>(91), static_cast<u8>(82), static_cast<u8>(101), static_cast<u8>(102), static_cast<u8>(108), static_cast<u8>(101), static_cast<u8>(99), static_cast<u8>(116), static_cast<u8>(58), static_cast<u8>(58), static_cast<u8>(84), static_cast<u8>(121), static_cast<u8>(112), static_cast<u8>(101), static_cast<u8>(93), static_cast<u8>(41), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(125), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(115), static_cast<u8>(116), static_cast<u8>(114), static_cast<u8>(117), static_cast<u8>(99), static_cast<u8>(116), static_cast<u8>(32), static_cast<u8>(86), static_cast<u8>(97), static_cast<u8>(114), static_cast<u8>(105), static_cast<u8>(97), static_cast<u8>(98), static_cast<u8>(108), static_cast<u8>(101), static_cast<u8>(68), static_cast<u8>(101), static_cast<u8>(99), static_cast<u8>(108), static_cast<u8>(97), static_cast<u8>(114), static_cast<u8>(97), static_cast<u8>(116), static_cast<u8>(105), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(123), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(110), static_cast<u8>(97), static_cast<u8>(109), static_cast<u8>(101), static_cast<u8>(58), static_cast<u8>(32), static_cast<u8>(83), static_cast<u8>(116), static_cast<u8>(114), static_cast<u8>(105), static_cast<u8>(110), static_cast<u8>(103), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(116), static_cast<u8>(121), static_cast<u8>(112), static_cast<u8>(101), static_cast<u8>(58), static_cast<u8>(32), static_cast<u8>(82), static_cast<u8>(101), static_cast<u8>(102), static_cast<u8>(108), static_cast<u8>(101), static_cast<u8>(99), static_cast<u8>(116), static_cast<u8>(58), static_cast<u8>(58), static_cast<u8>(84), static_cast<u8>(121), static_cast<u8>(112), static_cast<u8>(101), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(105), static_cast<u8>(115), static_cast<u8>(95), static_cast<u8>(109), static_cast<u8>(117), static_cast<u8>(116), static_cast<u8>(97), static_cast<u8>(98), static_cast<u8>(108), static_cast<u8>(101), static_cast<u8>(58), static_cast<u8>(32), static_cast<u8>(98), static_cast<u8>(111), static_cast<u8>(111), static_cast<u8>(108), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(125), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(115), static_cast<u8>(116), static_cast<u8>(114), static_cast<u8>(117), static_cast<u8>(99), static_cast<u8>(116), static_cast<u8>(32), static_cast<u8>(70), static_cast<u8>(105), static_cast<u8>(101), static_cast<u8>(108), static_cast<u8>(100), static_cast<u8>(32), static_cast<u8>(123), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(118), static_cast<u8>(97), static_cast<u8>(114), static_cast<u8>(105), static_cast<u8>(97), static_cast<u8>(98), static_cast<u8>(108), static_cast<u8>(101), static_cast<u8>(58), static_cast<u8>(32), static_cast<u8>(82), static_cast<u8>(101), static_cast<u8>(102), static_cast<u8>(108), static_cast<u8>(101), static_cast<u8>(99), static_cast<u8>(116), static_cast<u8>(58), static_cast<u8>(58), static_cast<u8>(86), static_cast<u8>(97), static_cast<u8>(114), static_cast<u8>(105), static_cast<u8>(97), static_cast<u8>(98), static_cast<u8>(108), static_cast<u8>(101), static_cast<u8>(68), static_cast<u8>(101), static_cast<u8>(99), static_cast<u8>(108), static_cast<u8>(97), static_cast<u8>(114), static_cast<u8>(97), static_cast<u8>(116), static_cast<u8>(105), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(118), static_cast<u8>(105), static_cast<u8>(115), static_cast<u8>(105), static_cast<u8>(98), static_cast<u8>(105), static_cast<u8>(108), static_cast<u8>(105), static_cast<u8>(116), static_cast<u8>(121), static_cast<u8>(58), static_cast<u8>(32), static_cast<u8>(82), static_cast<u8>(101), static_cast<u8>(102), static_cast<u8>(108), static_cast<u8>(101), static_cast<u8>(99), static_cast<u8>(116), static_cast<u8>(58), static_cast<u8>(58), static_cast<u8>(86), static_cast<u8>(105), static_cast<u8>(115), static_cast<u8>(105), static_cast<u8>(98), static_cast<u8>(105), static_cast<u8>(108), static_cast<u8>(105), static_cast<u8>(116), static_cast<u8>(121), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(47), static_cast<u8>(47), static_cast<u8>(32), static_cast<u8>(99), static_cast<u8>(111), static_cast<u8>(109), static_cast<u8>(112), static_cast<u8>(116), static_cast<u8>(105), static_cast<u8>(109), static_cast<u8>(101), static_cast<u8>(32), static_cast<u8>(115), static_cast<u8>(101), static_cast<u8>(116), static_cast<u8>(116), static_cast<u8>(101), static_cast<u8>(114), static_cast<u8>(60), static_cast<u8>(84), static_cast<u8>(44), static_cast<u8>(32), static_cast<u8>(85), static_cast<u8>(62), static_cast<u8>(40), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(105), static_cast<u8>(115), static_cast<u8>(41), static_cast<u8>(32), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(114), static_cast<u8>(111), static_cast<u8>(119), static_cast<u8>(115), static_cast<u8>(32), static_cast<u8>(123), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(47), static_cast<u8>(47), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(108), static_cast<u8>(101), static_cast<u8>(116), static_cast<u8>(32), static_cast<u8>(110), static_cast<u8>(97), static_cast<u8>(109), static_cast<u8>(101), static_cast<u8>(32), static_cast<u8>(61), static_cast<u8>(32), static_cast<u8>(46), static_cast<u8>(118), static_cast<u8>(97), static_cast<u8>(114), static_cast<u8>(105), static_cast<u8>(97), static_cast<u8>(98), static_cast<u8>(108), static_cast<u8>(101), static_cast<u8>(46), static_cast<u8>(110), static_cast<u8>(97), static_cast<u8>(109), static_cast<u8>(101), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(47), static_cast<u8>(47), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(114), static_cast<u8>(101), static_cast<u8>(116), static_cast<u8>(117), static_cast<u8>(114), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(102), static_cast<u8>(110), static_cast<u8>(91), static_cast<u8>(110), static_cast<u8>(97), static_cast<u8>(109), static_cast<u8>(101), static_cast<u8>(93), static_cast<u8>(40), static_cast<u8>(97), static_cast<u8>(110), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(115), static_cast<u8>(58), static_cast<u8>(32), static_cast<u8>(38), static_cast<u8>(109), static_cast<u8>(117), static_cast<u8>(116), static_cast<u8>(32), static_cast<u8>(84), static_cast<u8>(44), static_cast<u8>(32), static_cast<u8>(97), static_cast<u8>(110), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(118), static_cast<u8>(97), static_cast<u8>(108), static_cast<u8>(117), static_cast<u8>(101), static_cast<u8>(58), static_cast<u8>(32), static_cast<u8>(85), static_cast<u8>(41), static_cast<u8>(32), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(114), static_cast<u8>(111), static_cast<u8>(119), static_cast<u8>(115), static_cast<u8>(32), static_cast<u8>(123), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(47), static_cast<u8>(47), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(82), static_cast<u8>(101), static_cast<u8>(102), static_cast<u8>(108), static_cast<u8>(101), static_cast<u8>(99), static_cast<u8>(116), static_cast<u8>(58), static_cast<u8>(58), static_cast<u8>(73), static_cast<u8>(110), static_cast<u8>(116), static_cast<u8>(101), static_cast<u8>(114), static_cast<u8>(110), static_cast<u8>(97), static_cast<u8>(108), static_cast<u8>(58), static_cast<u8>(58), static_cast<u8>(115), static_cast<u8>(101), static_cast<u8>(116), static_cast<u8>(95), static_cast<u8>(102), static_cast<u8>(105), static_cast<u8>(101), static_cast<u8>(108), static_cast<u8>(100), static_cast<u8>(40), static_cast<u8>(110), static_cast<u8>(97), static_cast<u8>(109), static_cast<u8>(101), static_cast<u8>(44), static_cast<u8>(32), static_cast<u8>(115), static_cast<u8>(44), static_cast<u8>(32), static_cast<u8>(118), static_cast<u8>(97), static_cast<u8>(108), static_cast<u8>(117), static_cast<u8>(101), static_cast<u8>(41), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(47), static_cast<u8>(47), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(125), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(47), static_cast<u8>(47), static_cast<u8>(32), static_cast<u8>(125), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(125), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(115), static_cast<u8>(116), static_cast<u8>(114), static_cast<u8>(117), static_cast<u8>(99), static_cast<u8>(116), static_cast<u8>(32), static_cast<u8>(77), static_cast<u8>(101), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(111), static_cast<u8>(100), static_cast<u8>(32), static_cast<u8>(123), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(102), static_cast<u8>(117), static_cast<u8>(110), static_cast<u8>(99), static_cast<u8>(116), static_cast<u8>(105), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(58), static_cast<u8>(32), static_cast<u8>(82), static_cast<u8>(101), static_cast<u8>(102), static_cast<u8>(108), static_cast<u8>(101), static_cast<u8>(99), static_cast<u8>(116), static_cast<u8>(58), static_cast<u8>(58), static_cast<u8>(70), static_cast<u8>(117), static_cast<u8>(110), static_cast<u8>(99), static_cast<u8>(116), static_cast<u8>(105), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(118), static_cast<u8>(105), static_cast<u8>(115), static_cast<u8>(105), static_cast<u8>(98), static_cast<u8>(105), static_cast<u8>(108), static_cast<u8>(105), static_cast<u8>(116), static_cast<u8>(121), static_cast<u8>(58), static_cast<u8>(32), static_cast<u8>(82), static_cast<u8>(101), static_cast<u8>(102), static_cast<u8>(108), static_cast<u8>(101), static_cast<u8>(99), static_cast<u8>(116), static_cast<u8>(58), static_cast<u8>(58), static_cast<u8>(86), static_cast<u8>(105), static_cast<u8>(115), static_cast<u8>(105), static_cast<u8>(98), static_cast<u8>(105), static_cast<u8>(108), static_cast<u8>(105), static_cast<u8>(116), static_cast<u8>(121), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(125), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(115), static_cast<u8>(116), static_cast<u8>(114), static_cast<u8>(117), static_cast<u8>(99), static_cast<u8>(116), static_cast<u8>(32), static_cast<u8>(70), static_cast<u8>(117), static_cast<u8>(110), static_cast<u8>(99), static_cast<u8>(116), static_cast<u8>(105), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(123), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(110), static_cast<u8>(97), static_cast<u8>(109), static_cast<u8>(101), static_cast<u8>(58), static_cast<u8>(32), static_cast<u8>(83), static_cast<u8>(116), static_cast<u8>(114), static_cast<u8>(105), static_cast<u8>(110), static_cast<u8>(103), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(47), static_cast<u8>(47), static_cast<u8>(32), static_cast<u8>(112), static_cast<u8>(97), static_cast<u8>(114), static_cast<u8>(97), static_cast<u8>(109), static_cast<u8>(101), static_cast<u8>(116), static_cast<u8>(101), static_cast<u8>(114), static_cast<u8>(115), static_cast<u8>(58), static_cast<u8>(32), static_cast<u8>(91), static_cast<u8>(82), static_cast<u8>(101), static_cast<u8>(102), static_cast<u8>(108), static_cast<u8>(101), static_cast<u8>(99), static_cast<u8>(116), static_cast<u8>(58), static_cast<u8>(58), static_cast<u8>(80), static_cast<u8>(97), static_cast<u8>(114), static_cast<u8>(97), static_cast<u8>(109), static_cast<u8>(101), static_cast<u8>(116), static_cast<u8>(101), static_cast<u8>(114), static_cast<u8>(93), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(103), static_cast<u8>(101), static_cast<u8>(110), static_cast<u8>(101), static_cast<u8>(114), static_cast<u8>(105), static_cast<u8>(99), static_cast<u8>(95), static_cast<u8>(112), static_cast<u8>(97), static_cast<u8>(114), static_cast<u8>(97), static_cast<u8>(109), static_cast<u8>(101), static_cast<u8>(116), static_cast<u8>(101), static_cast<u8>(114), static_cast<u8>(115), static_cast<u8>(58), static_cast<u8>(32), static_cast<u8>(91), static_cast<u8>(83), static_cast<u8>(116), static_cast<u8>(114), static_cast<u8>(105), static_cast<u8>(110), static_cast<u8>(103), static_cast<u8>(93), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(47), static_cast<u8>(47), static_cast<u8>(32), static_cast<u8>(98), static_cast<u8>(108), static_cast<u8>(111), static_cast<u8>(99), static_cast<u8>(107), static_cast<u8>(58), static_cast<u8>(32), static_cast<u8>(82), static_cast<u8>(101), static_cast<u8>(102), static_cast<u8>(108), static_cast<u8>(101), static_cast<u8>(99), static_cast<u8>(116), static_cast<u8>(58), static_cast<u8>(58), static_cast<u8>(66), static_cast<u8>(108), static_cast<u8>(111), static_cast<u8>(99), static_cast<u8>(107), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(114), static_cast<u8>(101), static_cast<u8>(116), static_cast<u8>(117), static_cast<u8>(114), static_cast<u8>(110), static_cast<u8>(95), static_cast<u8>(116), static_cast<u8>(121), static_cast<u8>(112), static_cast<u8>(101), static_cast<u8>(58), static_cast<u8>(32), static_cast<u8>(82), static_cast<u8>(101), static_cast<u8>(102), static_cast<u8>(108), static_cast<u8>(101), static_cast<u8>(99), static_cast<u8>(116), static_cast<u8>(58), static_cast<u8>(58), static_cast<u8>(84), static_cast<u8>(121), static_cast<u8>(112), static_cast<u8>(101), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(99), static_cast<u8>(97), static_cast<u8>(110), static_cast<u8>(95), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(114), static_cast<u8>(111), static_cast<u8>(119), static_cast<u8>(58), static_cast<u8>(32), static_cast<u8>(98), static_cast<u8>(111), static_cast<u8>(111), static_cast<u8>(108), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(105), static_cast<u8>(115), static_cast<u8>(95), static_cast<u8>(99), static_cast<u8>(111), static_cast<u8>(109), static_cast<u8>(112), static_cast<u8>(116), static_cast<u8>(105), static_cast<u8>(109), static_cast<u8>(101), static_cast<u8>(58), static_cast<u8>(32), static_cast<u8>(98), static_cast<u8>(111), static_cast<u8>(111), static_cast<u8>(108), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(125), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(101), static_cast<u8>(110), static_cast<u8>(117), static_cast<u8>(109), static_cast<u8>(32), static_cast<u8>(83), static_cast<u8>(117), static_cast<u8>(109), static_cast<u8>(69), static_cast<u8>(110), static_cast<u8>(117), static_cast<u8>(109), static_cast<u8>(86), static_cast<u8>(97), static_cast<u8>(114), static_cast<u8>(105), static_cast<u8>(97), static_cast<u8>(110), static_cast<u8>(116), static_cast<u8>(32), static_cast<u8>(123), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(83), static_cast<u8>(116), static_cast<u8>(114), static_cast<u8>(117), static_cast<u8>(99), static_cast<u8>(116), static_cast<u8>(76), static_cast<u8>(105), static_cast<u8>(107), static_cast<u8>(101), static_cast<u8>(40), static_cast<u8>(110), static_cast<u8>(97), static_cast<u8>(109), static_cast<u8>(101), static_cast<u8>(58), static_cast<u8>(32), static_cast<u8>(83), static_cast<u8>(116), static_cast<u8>(114), static_cast<u8>(105), static_cast<u8>(110), static_cast<u8>(103), static_cast<u8>(44), static_cast<u8>(32), static_cast<u8>(102), static_cast<u8>(105), static_cast<u8>(101), static_cast<u8>(108), static_cast<u8>(100), static_cast<u8>(115), static_cast<u8>(58), static_cast<u8>(32), static_cast<u8>(91), static_cast<u8>(82), static_cast<u8>(101), static_cast<u8>(102), static_cast<u8>(108), static_cast<u8>(101), static_cast<u8>(99), static_cast<u8>(116), static_cast<u8>(58), static_cast<u8>(58), static_cast<u8>(70), static_cast<u8>(105), static_cast<u8>(101), static_cast<u8>(108), static_cast<u8>(100), static_cast<u8>(93), static_cast<u8>(41), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(84), static_cast<u8>(121), static_cast<u8>(112), static_cast<u8>(101), static_cast<u8>(100), static_cast<u8>(40), static_cast<u8>(110), static_cast<u8>(97), static_cast<u8>(109), static_cast<u8>(101), static_cast<u8>(58), static_cast<u8>(32), static_cast<u8>(83), static_cast<u8>(116), static_cast<u8>(114), static_cast<u8>(105), static_cast<u8>(110), static_cast<u8>(103), static_cast<u8>(44), static_cast<u8>(32), static_cast<u8>(116), static_cast<u8>(121), static_cast<u8>(112), static_cast<u8>(101), static_cast<u8>(58), static_cast<u8>(32), static_cast<u8>(82), static_cast<u8>(101), static_cast<u8>(102), static_cast<u8>(108), static_cast<u8>(101), static_cast<u8>(99), static_cast<u8>(116), static_cast<u8>(58), static_cast<u8>(58), static_cast<u8>(84), static_cast<u8>(121), static_cast<u8>(112), static_cast<u8>(101), static_cast<u8>(41), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(85), static_cast<u8>(110), static_cast<u8>(116), static_cast<u8>(121), static_cast<u8>(112), static_cast<u8>(101), static_cast<u8>(100), static_cast<u8>(40), static_cast<u8>(110), static_cast<u8>(97), static_cast<u8>(109), static_cast<u8>(101), static_cast<u8>(58), static_cast<u8>(32), static_cast<u8>(83), static_cast<u8>(116), static_cast<u8>(114), static_cast<u8>(105), static_cast<u8>(110), static_cast<u8>(103), static_cast<u8>(41), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(125), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(101), static_cast<u8>(110), static_cast<u8>(117), static_cast<u8>(109), static_cast<u8>(32), static_cast<u8>(82), static_cast<u8>(101), static_cast<u8>(99), static_cast<u8>(111), static_cast<u8>(114), static_cast<u8>(100), static_cast<u8>(84), static_cast<u8>(121), static_cast<u8>(112), static_cast<u8>(101), static_cast<u8>(32), static_cast<u8>(123), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(83), static_cast<u8>(116), static_cast<u8>(114), static_cast<u8>(117), static_cast<u8>(99), static_cast<u8>(116), static_cast<u8>(40), static_cast<u8>(102), static_cast<u8>(105), static_cast<u8>(101), static_cast<u8>(108), static_cast<u8>(100), static_cast<u8>(115), static_cast<u8>(58), static_cast<u8>(32), static_cast<u8>(91), static_cast<u8>(82), static_cast<u8>(101), static_cast<u8>(102), static_cast<u8>(108), static_cast<u8>(101), static_cast<u8>(99), static_cast<u8>(116), static_cast<u8>(58), static_cast<u8>(58), static_cast<u8>(70), static_cast<u8>(105), static_cast<u8>(101), static_cast<u8>(108), static_cast<u8>(100), static_cast<u8>(93), static_cast<u8>(41), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(67), static_cast<u8>(108), static_cast<u8>(97), static_cast<u8>(115), static_cast<u8>(115), static_cast<u8>(40), static_cast<u8>(102), static_cast<u8>(105), static_cast<u8>(101), static_cast<u8>(108), static_cast<u8>(100), static_cast<u8>(115), static_cast<u8>(58), static_cast<u8>(32), static_cast<u8>(91), static_cast<u8>(82), static_cast<u8>(101), static_cast<u8>(102), static_cast<u8>(108), static_cast<u8>(101), static_cast<u8>(99), static_cast<u8>(116), static_cast<u8>(58), static_cast<u8>(58), static_cast<u8>(70), static_cast<u8>(105), static_cast<u8>(101), static_cast<u8>(108), static_cast<u8>(100), static_cast<u8>(93), static_cast<u8>(41), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(47), static_cast<u8>(47), static_cast<u8>(32), static_cast<u8>(86), static_cast<u8>(97), static_cast<u8>(108), static_cast<u8>(117), static_cast<u8>(101), static_cast<u8>(69), static_cast<u8>(110), static_cast<u8>(117), static_cast<u8>(109), static_cast<u8>(40), static_cast<u8>(117), static_cast<u8>(110), static_cast<u8>(100), static_cast<u8>(101), static_cast<u8>(114), static_cast<u8>(108), static_cast<u8>(121), static_cast<u8>(105), static_cast<u8>(110), static_cast<u8>(103), static_cast<u8>(95), static_cast<u8>(116), static_cast<u8>(121), static_cast<u8>(112), static_cast<u8>(101), static_cast<u8>(58), static_cast<u8>(32), static_cast<u8>(82), static_cast<u8>(101), static_cast<u8>(102), static_cast<u8>(108), static_cast<u8>(101), static_cast<u8>(99), static_cast<u8>(116), static_cast<u8>(58), static_cast<u8>(58), static_cast<u8>(84), static_cast<u8>(121), static_cast<u8>(112), static_cast<u8>(101), static_cast<u8>(44), static_cast<u8>(32), static_cast<u8>(118), static_cast<u8>(97), static_cast<u8>(114), static_cast<u8>(105), static_cast<u8>(97), static_cast<u8>(110), static_cast<u8>(116), static_cast<u8>(115), static_cast<u8>(58), static_cast<u8>(32), static_cast<u8>(91), static_cast<u8>(82), static_cast<u8>(101), static_cast<u8>(102), static_cast<u8>(108), static_cast<u8>(101), static_cast<u8>(99), static_cast<u8>(116), static_cast<u8>(58), static_cast<u8>(58), static_cast<u8>(86), static_cast<u8>(97), static_cast<u8>(108), static_cast<u8>(117), static_cast<u8>(101), static_cast<u8>(69), static_cast<u8>(110), static_cast<u8>(117), static_cast<u8>(109), static_cast<u8>(86), static_cast<u8>(97), static_cast<u8>(114), static_cast<u8>(105), static_cast<u8>(97), static_cast<u8>(110), static_cast<u8>(116), static_cast<u8>(93), static_cast<u8>(41), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(83), static_cast<u8>(117), static_cast<u8>(109), static_cast<u8>(69), static_cast<u8>(110), static_cast<u8>(117), static_cast<u8>(109), static_cast<u8>(40), static_cast<u8>(105), static_cast<u8>(115), static_cast<u8>(95), static_cast<u8>(98), static_cast<u8>(111), static_cast<u8>(120), static_cast<u8>(101), static_cast<u8>(100), static_cast<u8>(58), static_cast<u8>(32), static_cast<u8>(98), static_cast<u8>(111), static_cast<u8>(111), static_cast<u8>(108), static_cast<u8>(44), static_cast<u8>(32), static_cast<u8>(118), static_cast<u8>(97), static_cast<u8>(114), static_cast<u8>(105), static_cast<u8>(97), static_cast<u8>(110), static_cast<u8>(116), static_cast<u8>(115), static_cast<u8>(58), static_cast<u8>(32), static_cast<u8>(91), static_cast<u8>(82), static_cast<u8>(101), static_cast<u8>(102), static_cast<u8>(108), static_cast<u8>(101), static_cast<u8>(99), static_cast<u8>(116), static_cast<u8>(58), static_cast<u8>(58), static_cast<u8>(83), static_cast<u8>(117), static_cast<u8>(109), static_cast<u8>(69), static_cast<u8>(110), static_cast<u8>(117), static_cast<u8>(109), static_cast<u8>(86), static_cast<u8>(97), static_cast<u8>(114), static_cast<u8>(105), static_cast<u8>(97), static_cast<u8>(110), static_cast<u8>(116), static_cast<u8>(93), static_cast<u8>(41), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(125), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(115), static_cast<u8>(116), static_cast<u8>(114), static_cast<u8>(117), static_cast<u8>(99), static_cast<u8>(116), static_cast<u8>(32), static_cast<u8>(82), static_cast<u8>(101), static_cast<u8>(99), static_cast<u8>(111), static_cast<u8>(114), static_cast<u8>(100), static_cast<u8>(32), static_cast<u8>(123), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(110), static_cast<u8>(97), static_cast<u8>(109), static_cast<u8>(101), static_cast<u8>(58), static_cast<u8>(32), static_cast<u8>(83), static_cast<u8>(116), static_cast<u8>(114), static_cast<u8>(105), static_cast<u8>(110), static_cast<u8>(103), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(109), static_cast<u8>(101), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(111), static_cast<u8>(100), static_cast<u8>(115), static_cast<u8>(58), static_cast<u8>(32), static_cast<u8>(91), static_cast<u8>(82), static_cast<u8>(101), static_cast<u8>(102), static_cast<u8>(108), static_cast<u8>(101), static_cast<u8>(99), static_cast<u8>(116), static_cast<u8>(58), static_cast<u8>(58), static_cast<u8>(77), static_cast<u8>(101), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(111), static_cast<u8>(100), static_cast<u8>(93), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(103), static_cast<u8>(101), static_cast<u8>(110), static_cast<u8>(101), static_cast<u8>(114), static_cast<u8>(105), static_cast<u8>(99), static_cast<u8>(95), static_cast<u8>(109), static_cast<u8>(97), static_cast<u8>(112), static_cast<u8>(112), static_cast<u8>(105), static_cast<u8>(110), static_cast<u8>(103), static_cast<u8>(115), static_cast<u8>(58), static_cast<u8>(32), static_cast<u8>(91), static_cast<u8>(40), static_cast<u8>(83), static_cast<u8>(116), static_cast<u8>(114), static_cast<u8>(105), static_cast<u8>(110), static_cast<u8>(103), static_cast<u8>(44), static_cast<u8>(32), static_cast<u8>(82), static_cast<u8>(101), static_cast<u8>(102), static_cast<u8>(108), static_cast<u8>(101), static_cast<u8>(99), static_cast<u8>(116), static_cast<u8>(58), static_cast<u8>(58), static_cast<u8>(84), static_cast<u8>(121), static_cast<u8>(112), static_cast<u8>(101), static_cast<u8>(41), static_cast<u8>(93), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(114), static_cast<u8>(101), static_cast<u8>(99), static_cast<u8>(111), static_cast<u8>(114), static_cast<u8>(100), static_cast<u8>(95), static_cast<u8>(116), static_cast<u8>(121), static_cast<u8>(112), static_cast<u8>(101), static_cast<u8>(58), static_cast<u8>(32), static_cast<u8>(82), static_cast<u8>(101), static_cast<u8>(102), static_cast<u8>(108), static_cast<u8>(101), static_cast<u8>(99), static_cast<u8>(116), static_cast<u8>(58), static_cast<u8>(58), static_cast<u8>(82), static_cast<u8>(101), static_cast<u8>(99), static_cast<u8>(111), static_cast<u8>(114), static_cast<u8>(100), static_cast<u8>(84), static_cast<u8>(121), static_cast<u8>(112), static_cast<u8>(101), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(125), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(98), static_cast<u8>(111), static_cast<u8>(120), static_cast<u8>(101), static_cast<u8>(100), static_cast<u8>(32), static_cast<u8>(101), static_cast<u8>(110), static_cast<u8>(117), static_cast<u8>(109), static_cast<u8>(32), static_cast<u8>(84), static_cast<u8>(121), static_cast<u8>(112), static_cast<u8>(101), static_cast<u8>(32), static_cast<u8>(123), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(86), static_cast<u8>(111), static_cast<u8>(105), static_cast<u8>(100), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(66), static_cast<u8>(111), static_cast<u8>(111), static_cast<u8>(108), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(85), static_cast<u8>(56), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(85), static_cast<u8>(49), static_cast<u8>(54), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(85), static_cast<u8>(51), static_cast<u8>(50), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(85), static_cast<u8>(54), static_cast<u8>(52), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(73), static_cast<u8>(56), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(73), static_cast<u8>(49), static_cast<u8>(54), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(73), static_cast<u8>(51), static_cast<u8>(50), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(73), static_cast<u8>(54), static_cast<u8>(52), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(70), static_cast<u8>(51), static_cast<u8>(50), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(70), static_cast<u8>(54), static_cast<u8>(52), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(85), static_cast<u8>(115), static_cast<u8>(105), static_cast<u8>(122), static_cast<u8>(101), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(74), static_cast<u8>(97), static_cast<u8>(107), static_cast<u8>(116), static_cast<u8>(83), static_cast<u8>(116), static_cast<u8>(114), static_cast<u8>(105), static_cast<u8>(110), static_cast<u8>(103), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(67), static_cast<u8>(67), static_cast<u8>(104), static_cast<u8>(97), static_cast<u8>(114), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(67), static_cast<u8>(73), static_cast<u8>(110), static_cast<u8>(116), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(85), static_cast<u8>(110), static_cast<u8>(107), static_cast<u8>(110), static_cast<u8>(111), static_cast<u8>(119), static_cast<u8>(110), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(78), static_cast<u8>(101), static_cast<u8>(118), static_cast<u8>(101), static_cast<u8>(114), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(83), static_cast<u8>(116), static_cast<u8>(114), static_cast<u8>(117), static_cast<u8>(99), static_cast<u8>(116), static_cast<u8>(117), static_cast<u8>(114), static_cast<u8>(101), static_cast<u8>(79), static_cast<u8>(114), static_cast<u8>(69), static_cast<u8>(110), static_cast<u8>(117), static_cast<u8>(109), static_cast<u8>(40), static_cast<u8>(82), static_cast<u8>(101), static_cast<u8>(102), static_cast<u8>(108), static_cast<u8>(101), static_cast<u8>(99), static_cast<u8>(116), static_cast<u8>(58), static_cast<u8>(58), static_cast<u8>(82), static_cast<u8>(101), static_cast<u8>(99), static_cast<u8>(111), static_cast<u8>(114), static_cast<u8>(100), static_cast<u8>(41), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(84), static_cast<u8>(121), static_cast<u8>(112), static_cast<u8>(101), static_cast<u8>(86), static_cast<u8>(97), static_cast<u8>(114), static_cast<u8>(105), static_cast<u8>(97), static_cast<u8>(98), static_cast<u8>(108), static_cast<u8>(101), static_cast<u8>(40), static_cast<u8>(83), static_cast<u8>(116), static_cast<u8>(114), static_cast<u8>(105), static_cast<u8>(110), static_cast<u8>(103), static_cast<u8>(41), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(82), static_cast<u8>(97), static_cast<u8>(119), static_cast<u8>(80), static_cast<u8>(116), static_cast<u8>(114), static_cast<u8>(40), static_cast<u8>(82), static_cast<u8>(101), static_cast<u8>(102), static_cast<u8>(108), static_cast<u8>(101), static_cast<u8>(99), static_cast<u8>(116), static_cast<u8>(58), static_cast<u8>(58), static_cast<u8>(84), static_cast<u8>(121), static_cast<u8>(112), static_cast<u8>(101), static_cast<u8>(41), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(82), static_cast<u8>(101), static_cast<u8>(102), static_cast<u8>(101), static_cast<u8>(114), static_cast<u8>(101), static_cast<u8>(110), static_cast<u8>(99), static_cast<u8>(101), static_cast<u8>(40), static_cast<u8>(82), static_cast<u8>(101), static_cast<u8>(102), static_cast<u8>(108), static_cast<u8>(101), static_cast<u8>(99), static_cast<u8>(116), static_cast<u8>(58), static_cast<u8>(58), static_cast<u8>(84), static_cast<u8>(121), static_cast<u8>(112), static_cast<u8>(101), static_cast<u8>(41), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(77), static_cast<u8>(117), static_cast<u8>(116), static_cast<u8>(97), static_cast<u8>(98), static_cast<u8>(108), static_cast<u8>(101), static_cast<u8>(82), static_cast<u8>(101), static_cast<u8>(102), static_cast<u8>(101), static_cast<u8>(114), static_cast<u8>(101), static_cast<u8>(110), static_cast<u8>(99), static_cast<u8>(101), static_cast<u8>(40), static_cast<u8>(82), static_cast<u8>(101), static_cast<u8>(102), static_cast<u8>(108), static_cast<u8>(101), static_cast<u8>(99), static_cast<u8>(116), static_cast<u8>(58), static_cast<u8>(58), static_cast<u8>(84), static_cast<u8>(121), static_cast<u8>(112), static_cast<u8>(101), static_cast<u8>(41), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(70), static_cast<u8>(117), static_cast<u8>(110), static_cast<u8>(99), static_cast<u8>(116), static_cast<u8>(105), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(10), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(102), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(110), static_cast<u8>(97), static_cast<u8>(109), static_cast<u8>(101), static_cast<u8>(40), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(105), static_cast<u8>(115), static_cast<u8>(41), static_cast<u8>(32), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(114), static_cast<u8>(111), static_cast<u8>(119), static_cast<u8>(115), static_cast<u8>(32), static_cast<u8>(61), static_cast<u8>(62), static_cast<u8>(32), static_cast<u8>(109), static_cast<u8>(97), static_cast<u8>(116), static_cast<u8>(99), static_cast<u8>(104), static_cast<u8>(32), static_cast<u8>(116), static_cast<u8>(104), static_cast<u8>(105), static_cast<u8>(115), static_cast<u8>(32), static_cast<u8>(123), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(86), static_cast<u8>(111), static_cast<u8>(105), static_cast<u8>(100), static_cast<u8>(32), static_cast<u8>(61), static_cast<u8>(62), static_cast<u8>(32), static_cast<u8>(34), static_cast<u8>(118), static_cast<u8>(111), static_cast<u8>(105), static_cast<u8>(100), static_cast<u8>(34), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(66), static_cast<u8>(111), static_cast<u8>(111), static_cast<u8>(108), static_cast<u8>(32), static_cast<u8>(61), static_cast<u8>(62), static_cast<u8>(32), static_cast<u8>(34), static_cast<u8>(98), static_cast<u8>(111), static_cast<u8>(111), static_cast<u8>(108), static_cast<u8>(34), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(85), static_cast<u8>(56), static_cast<u8>(32), static_cast<u8>(61), static_cast<u8>(62), static_cast<u8>(32), static_cast<u8>(34), static_cast<u8>(117), static_cast<u8>(56), static_cast<u8>(34), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(85), static_cast<u8>(49), static_cast<u8>(54), static_cast<u8>(32), static_cast<u8>(61), static_cast<u8>(62), static_cast<u8>(32), static_cast<u8>(34), static_cast<u8>(117), static_cast<u8>(49), static_cast<u8>(54), static_cast<u8>(34), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(85), static_cast<u8>(51), static_cast<u8>(50), static_cast<u8>(32), static_cast<u8>(61), static_cast<u8>(62), static_cast<u8>(32), static_cast<u8>(34), static_cast<u8>(117), static_cast<u8>(51), static_cast<u8>(50), static_cast<u8>(34), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(85), static_cast<u8>(54), static_cast<u8>(52), static_cast<u8>(32), static_cast<u8>(61), static_cast<u8>(62), static_cast<u8>(32), static_cast<u8>(34), static_cast<u8>(117), static_cast<u8>(54), static_cast<u8>(52), static_cast<u8>(34), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(73), static_cast<u8>(56), static_cast<u8>(32), static_cast<u8>(61), static_cast<u8>(62), static_cast<u8>(32), static_cast<u8>(34), static_cast<u8>(105), static_cast<u8>(56), static_cast<u8>(34), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(73), static_cast<u8>(49), static_cast<u8>(54), static_cast<u8>(32), static_cast<u8>(61), static_cast<u8>(62), static_cast<u8>(32), static_cast<u8>(34), static_cast<u8>(105), static_cast<u8>(49), static_cast<u8>(54), static_cast<u8>(34), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(73), static_cast<u8>(51), static_cast<u8>(50), static_cast<u8>(32), static_cast<u8>(61), static_cast<u8>(62), static_cast<u8>(32), static_cast<u8>(34), static_cast<u8>(105), static_cast<u8>(51), static_cast<u8>(50), static_cast<u8>(34), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(73), static_cast<u8>(54), static_cast<u8>(52), static_cast<u8>(32), static_cast<u8>(61), static_cast<u8>(62), static_cast<u8>(32), static_cast<u8>(34), static_cast<u8>(105), static_cast<u8>(54), static_cast<u8>(52), static_cast<u8>(34), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(70), static_cast<u8>(51), static_cast<u8>(50), static_cast<u8>(32), static_cast<u8>(61), static_cast<u8>(62), static_cast<u8>(32), static_cast<u8>(34), static_cast<u8>(102), static_cast<u8>(51), static_cast<u8>(50), static_cast<u8>(34), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(70), static_cast<u8>(54), static_cast<u8>(52), static_cast<u8>(32), static_cast<u8>(61), static_cast<u8>(62), static_cast<u8>(32), static_cast<u8>(34), static_cast<u8>(102), static_cast<u8>(54), static_cast<u8>(52), static_cast<u8>(34), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(85), static_cast<u8>(115), static_cast<u8>(105), static_cast<u8>(122), static_cast<u8>(101), static_cast<u8>(32), static_cast<u8>(61), static_cast<u8>(62), static_cast<u8>(32), static_cast<u8>(34), static_cast<u8>(117), static_cast<u8>(115), static_cast<u8>(105), static_cast<u8>(122), static_cast<u8>(101), static_cast<u8>(34), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(74), static_cast<u8>(97), static_cast<u8>(107), static_cast<u8>(116), static_cast<u8>(83), static_cast<u8>(116), static_cast<u8>(114), static_cast<u8>(105), static_cast<u8>(110), static_cast<u8>(103), static_cast<u8>(32), static_cast<u8>(61), static_cast<u8>(62), static_cast<u8>(32), static_cast<u8>(34), static_cast<u8>(83), static_cast<u8>(116), static_cast<u8>(114), static_cast<u8>(105), static_cast<u8>(110), static_cast<u8>(103), static_cast<u8>(34), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(67), static_cast<u8>(67), static_cast<u8>(104), static_cast<u8>(97), static_cast<u8>(114), static_cast<u8>(32), static_cast<u8>(61), static_cast<u8>(62), static_cast<u8>(32), static_cast<u8>(34), static_cast<u8>(99), static_cast<u8>(95), static_cast<u8>(99), static_cast<u8>(104), static_cast<u8>(97), static_cast<u8>(114), static_cast<u8>(34), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(67), static_cast<u8>(73), static_cast<u8>(110), static_cast<u8>(116), static_cast<u8>(32), static_cast<u8>(61), static_cast<u8>(62), static_cast<u8>(32), static_cast<u8>(34), static_cast<u8>(99), static_cast<u8>(95), static_cast<u8>(105), static_cast<u8>(110), static_cast<u8>(116), static_cast<u8>(34), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(85), static_cast<u8>(110), static_cast<u8>(107), static_cast<u8>(110), static_cast<u8>(111), static_cast<u8>(119), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(61), static_cast<u8>(62), static_cast<u8>(32), static_cast<u8>(34), static_cast<u8>(117), static_cast<u8>(110), static_cast<u8>(107), static_cast<u8>(110), static_cast<u8>(111), static_cast<u8>(119), static_cast<u8>(110), static_cast<u8>(34), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(78), static_cast<u8>(101), static_cast<u8>(118), static_cast<u8>(101), static_cast<u8>(114), static_cast<u8>(32), static_cast<u8>(61), static_cast<u8>(62), static_cast<u8>(32), static_cast<u8>(34), static_cast<u8>(110), static_cast<u8>(101), static_cast<u8>(118), static_cast<u8>(101), static_cast<u8>(114), static_cast<u8>(34), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(83), static_cast<u8>(116), static_cast<u8>(114), static_cast<u8>(117), static_cast<u8>(99), static_cast<u8>(116), static_cast<u8>(117), static_cast<u8>(114), static_cast<u8>(101), static_cast<u8>(79), static_cast<u8>(114), static_cast<u8>(69), static_cast<u8>(110), static_cast<u8>(117), static_cast<u8>(109), static_cast<u8>(40), static_cast<u8>(114), static_cast<u8>(101), static_cast<u8>(99), static_cast<u8>(111), static_cast<u8>(114), static_cast<u8>(100), static_cast<u8>(41), static_cast<u8>(32), static_cast<u8>(61), static_cast<u8>(62), static_cast<u8>(32), static_cast<u8>(102), static_cast<u8>(111), static_cast<u8>(114), static_cast<u8>(109), static_cast<u8>(97), static_cast<u8>(116), static_cast<u8>(40), static_cast<u8>(34), static_cast<u8>(115), static_cast<u8>(116), static_cast<u8>(114), static_cast<u8>(117), static_cast<u8>(99), static_cast<u8>(116), static_cast<u8>(32), static_cast<u8>(123), static_cast<u8>(125), static_cast<u8>(34), static_cast<u8>(44), static_cast<u8>(32), static_cast<u8>(114), static_cast<u8>(101), static_cast<u8>(99), static_cast<u8>(111), static_cast<u8>(114), static_cast<u8>(100), static_cast<u8>(46), static_cast<u8>(110), static_cast<u8>(97), static_cast<u8>(109), static_cast<u8>(101), static_cast<u8>(41), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(84), static_cast<u8>(121), static_cast<u8>(112), static_cast<u8>(101), static_cast<u8>(86), static_cast<u8>(97), static_cast<u8>(114), static_cast<u8>(105), static_cast<u8>(97), static_cast<u8>(98), static_cast<u8>(108), static_cast<u8>(101), static_cast<u8>(40), static_cast<u8>(110), static_cast<u8>(97), static_cast<u8>(109), static_cast<u8>(101), static_cast<u8>(41), static_cast<u8>(32), static_cast<u8>(61), static_cast<u8>(62), static_cast<u8>(32), static_cast<u8>(102), static_cast<u8>(111), static_cast<u8>(114), static_cast<u8>(109), static_cast<u8>(97), static_cast<u8>(116), static_cast<u8>(40), static_cast<u8>(34), static_cast<u8>(123), static_cast<u8>(125), static_cast<u8>(34), static_cast<u8>(44), static_cast<u8>(32), static_cast<u8>(110), static_cast<u8>(97), static_cast<u8>(109), static_cast<u8>(101), static_cast<u8>(41), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(82), static_cast<u8>(97), static_cast<u8>(119), static_cast<u8>(80), static_cast<u8>(116), static_cast<u8>(114), static_cast<u8>(40), static_cast<u8>(116), static_cast<u8>(121), static_cast<u8>(112), static_cast<u8>(101), static_cast<u8>(41), static_cast<u8>(32), static_cast<u8>(61), static_cast<u8>(62), static_cast<u8>(32), static_cast<u8>(102), static_cast<u8>(111), static_cast<u8>(114), static_cast<u8>(109), static_cast<u8>(97), static_cast<u8>(116), static_cast<u8>(40), static_cast<u8>(34), static_cast<u8>(114), static_cast<u8>(97), static_cast<u8>(119), static_cast<u8>(32), static_cast<u8>(123), static_cast<u8>(125), static_cast<u8>(34), static_cast<u8>(44), static_cast<u8>(32), static_cast<u8>(116), static_cast<u8>(121), static_cast<u8>(112), static_cast<u8>(101), static_cast<u8>(46), static_cast<u8>(110), static_cast<u8>(97), static_cast<u8>(109), static_cast<u8>(101), static_cast<u8>(40), static_cast<u8>(41), static_cast<u8>(41), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(82), static_cast<u8>(101), static_cast<u8>(102), static_cast<u8>(101), static_cast<u8>(114), static_cast<u8>(101), static_cast<u8>(110), static_cast<u8>(99), static_cast<u8>(101), static_cast<u8>(40), static_cast<u8>(116), static_cast<u8>(121), static_cast<u8>(112), static_cast<u8>(101), static_cast<u8>(41), static_cast<u8>(32), static_cast<u8>(61), static_cast<u8>(62), static_cast<u8>(32), static_cast<u8>(102), static_cast<u8>(111), static_cast<u8>(114), static_cast<u8>(109), static_cast<u8>(97), static_cast<u8>(116), static_cast<u8>(40), static_cast<u8>(34), static_cast<u8>(38), static_cast<u8>(32), static_cast<u8>(123), static_cast<u8>(125), static_cast<u8>(34), static_cast<u8>(44), static_cast<u8>(32), static_cast<u8>(116), static_cast<u8>(121), static_cast<u8>(112), static_cast<u8>(101), static_cast<u8>(46), static_cast<u8>(110), static_cast<u8>(97), static_cast<u8>(109), static_cast<u8>(101), static_cast<u8>(40), static_cast<u8>(41), static_cast<u8>(41), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(77), static_cast<u8>(117), static_cast<u8>(116), static_cast<u8>(97), static_cast<u8>(98), static_cast<u8>(108), static_cast<u8>(101), static_cast<u8>(82), static_cast<u8>(101), static_cast<u8>(102), static_cast<u8>(101), static_cast<u8>(114), static_cast<u8>(101), static_cast<u8>(110), static_cast<u8>(99), static_cast<u8>(101), static_cast<u8>(40), static_cast<u8>(116), static_cast<u8>(121), static_cast<u8>(112), static_cast<u8>(101), static_cast<u8>(41), static_cast<u8>(32), static_cast<u8>(61), static_cast<u8>(62), static_cast<u8>(32), static_cast<u8>(102), static_cast<u8>(111), static_cast<u8>(114), static_cast<u8>(109), static_cast<u8>(97), static_cast<u8>(116), static_cast<u8>(40), static_cast<u8>(34), static_cast<u8>(38), static_cast<u8>(109), static_cast<u8>(117), static_cast<u8>(116), static_cast<u8>(32), static_cast<u8>(123), static_cast<u8>(125), static_cast<u8>(34), static_cast<u8>(44), static_cast<u8>(32), static_cast<u8>(116), static_cast<u8>(121), static_cast<u8>(112), static_cast<u8>(101), static_cast<u8>(46), static_cast<u8>(110), static_cast<u8>(97), static_cast<u8>(109), static_cast<u8>(101), static_cast<u8>(40), static_cast<u8>(41), static_cast<u8>(41), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(70), static_cast<u8>(117), static_cast<u8>(110), static_cast<u8>(99), static_cast<u8>(116), static_cast<u8>(105), static_cast<u8>(111), static_cast<u8>(110), static_cast<u8>(32), static_cast<u8>(61), static_cast<u8>(62), static_cast<u8>(32), static_cast<u8>(34), static_cast<u8>(102), static_cast<u8>(110), static_cast<u8>(34), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(125), static_cast<u8>(10), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(32), static_cast<u8>(125), static_cast<u8>(10), static_cast<u8>(125), static_cast<u8>(10), static_cast<u8>(10)});
 JaktInternal::Optional<utility::FileId> const old_file_id = ((((*this).compiler))->current_file);
@@ -654,7 +654,7 @@ utility::FileId const file_id = ((((*this).compiler))->get_file_id_or_register(f
 ids::ModuleId const prelude_module_id = ((*this).create_module(module_name,false,JaktInternal::OptionalNone()));
 (((*this).current_module_id) = prelude_module_id);
 ((((*this).program))->set_loaded_module(module_name,types::LoadedModule(prelude_module_id,file_id)));
-ids::ScopeId const prelude_scope_id = ((*this).create_scope(JaktInternal::OptionalNone(),false,(ByteString::must_from_utf8("prelude"sv)),false));
+ids::ScopeId const prelude_scope_id = ((*this).create_scope(JaktInternal::OptionalNone(),false,(ByteString::from_utf8_without_validation("prelude"sv)),false));
 JaktInternal::DynamicArray<lexer::Token> const tokens = lexer::Lexer::lex(((*this).compiler));
 if (((((*this).compiler))->dump_lexer)){
 {
@@ -943,7 +943,7 @@ if (((function_to_add)->signature_matches(existing_function,false))){
 if (((((*this).get_scope(parent_scope_id)))->is_from_generated_code)){
 continue;
 }
-((*this).error_with_hint(__jakt_format((StringView::from_string_literal("Redefinition of function ‘{}’."sv)),((function_to_add)->name)),(((((function_to_add)->parsed_function).value())).name_span),(ByteString::must_from_utf8("Previous definition is here"sv)),(((((existing_function)->parsed_function).value())).name_span)));
+((*this).error_with_hint(__jakt_format((StringView::from_string_literal("Redefinition of function ‘{}’."sv)),((function_to_add)->name)),(((((function_to_add)->parsed_function).value())).name_span),(ByteString::from_utf8_without_validation("Previous definition is here"sv)),(((((existing_function)->parsed_function).value())).name_span)));
 }
 }
 
@@ -972,7 +972,7 @@ NonnullRefPtr<types::Scope> scope = ((*this).get_scope(scope_id));
 JaktInternal::Optional<ids::VarId> const existing_var = ((((scope)->vars)).get(name));
 if (((existing_var).has_value())){
 NonnullRefPtr<types::CheckedVariable> const variable_ = ((*this).get_variable((existing_var.value())));
-((*this).error_with_hint(__jakt_format((StringView::from_string_literal("Redefinition of variable ‘{}’"sv)),name),span,(ByteString::must_from_utf8("previous definition here"sv)),((variable_)->definition_span)));
+((*this).error_with_hint(__jakt_format((StringView::from_string_literal("Redefinition of variable ‘{}’"sv)),name),span,(ByteString::from_utf8_without_validation("previous definition here"sv)),((variable_)->definition_span)));
 }
 ((((scope)->vars)).set(name,var_id));
 ((((*this).program))->set_owner_scope_if_needed(scope_id,var_id));
@@ -985,7 +985,7 @@ bool typechecker::Typechecker::add_comptime_binding_to_scope(ids::ScopeId const 
 NonnullRefPtr<types::Scope> scope = ((*this).get_scope(scope_id));
 JaktInternal::Optional<types::Value> const existing_binding = ((((scope)->comptime_bindings)).get(name));
 if (((existing_binding).has_value())){
-((*this).error_with_hint(__jakt_format((StringView::from_string_literal("Redefinition of comptime variable ‘{}’"sv)),name),span,(ByteString::must_from_utf8("previous definition here"sv)),(((existing_binding.value())).span)));
+((*this).error_with_hint(__jakt_format((StringView::from_string_literal("Redefinition of comptime variable ‘{}’"sv)),name),span,(ByteString::from_utf8_without_validation("previous definition here"sv)),(((existing_binding.value())).span)));
 }
 ((((scope)->comptime_bindings)).set(name,value));
 return true;
@@ -1094,7 +1094,7 @@ return TRY((((((*this).program))->find_struct_in_scope(scope_id,name,false,root_
 
 ErrorOr<NonnullRefPtr<typename types::Type>> typechecker::Typechecker::unwrap_type_from_optional_if_needed(NonnullRefPtr<typename types::Type> const type) const {
 {
-ids::StructId const optional_struct_id = TRY((((*this).find_struct_in_prelude((ByteString::must_from_utf8("Optional"sv))))));
+ids::StructId const optional_struct_id = TRY((((*this).find_struct_in_prelude((ByteString::from_utf8_without_validation("Optional"sv))))));
 if (((type)->__jakt_init_index() == 20 /* GenericInstance */)){
 ids::StructId const id = (type)->as.GenericInstance.id;
 JaktInternal::DynamicArray<ids::TypeId> const args = (type)->as.GenericInstance.args;
@@ -1296,7 +1296,7 @@ case 0 /* Struct */: {
 return JaktInternal::ExplicitValue(({ Optional<types::StructLikeId> __jakt_var_433; {
 JaktInternal::Optional<ids::StructId> const struct_id = TRY((((*this).find_struct_in_scope(scope_id,((record).name),JaktInternal::OptionalNone()))));
 if ((!(((struct_id).has_value())))){
-((((*this).compiler))->panic((ByteString::must_from_utf8("can't find previously added struct"sv))));
+((((*this).compiler))->panic((ByteString::from_utf8_without_validation("can't find previously added struct"sv))));
 }
 TRY((((*this).typecheck_struct_fields(record,(struct_id.value())))));
 __jakt_var_433 = types::StructLikeId::Struct(JaktInternal::OptionalNone(),(struct_id.value())); goto __jakt_label_405;
@@ -1308,7 +1308,7 @@ case 1 /* Class */: {
 return JaktInternal::ExplicitValue(({ Optional<types::StructLikeId> __jakt_var_434; {
 JaktInternal::Optional<ids::StructId> const struct_id = TRY((((*this).find_struct_in_scope(scope_id,((record).name),JaktInternal::OptionalNone()))));
 if ((!(((struct_id).has_value())))){
-((((*this).compiler))->panic((ByteString::must_from_utf8("can't find previously added struct"sv))));
+((((*this).compiler))->panic((ByteString::from_utf8_without_validation("can't find previously added struct"sv))));
 }
 TRY((((*this).typecheck_struct_fields(record,(struct_id.value())))));
 __jakt_var_434 = types::StructLikeId::Struct(JaktInternal::OptionalNone(),(struct_id.value())); goto __jakt_label_406;
@@ -1320,7 +1320,7 @@ case 2 /* ValueEnum */: {
 return JaktInternal::ExplicitValue(({ Optional<types::StructLikeId> __jakt_var_435; {
 JaktInternal::Optional<ids::EnumId> const enum_id = TRY((((((*this).program))->find_enum_in_scope(scope_id,((record).name),false,JaktInternal::OptionalNone()))));
 if ((!(((enum_id).has_value())))){
-((((*this).compiler))->panic((ByteString::must_from_utf8("can't find previously added enum"sv))));
+((((*this).compiler))->panic((ByteString::from_utf8_without_validation("can't find previously added enum"sv))));
 }
 __jakt_var_435 = types::StructLikeId::Enum(JaktInternal::OptionalNone(),(enum_id.value())); goto __jakt_label_407;
 
@@ -1331,7 +1331,7 @@ case 3 /* SumEnum */: {
 return JaktInternal::ExplicitValue(({ Optional<types::StructLikeId> __jakt_var_436; {
 JaktInternal::Optional<ids::EnumId> const enum_id = TRY((((((*this).program))->find_enum_in_scope(scope_id,((record).name),false,JaktInternal::OptionalNone()))));
 if ((!(((enum_id).has_value())))){
-((((*this).compiler))->panic((ByteString::must_from_utf8("can't find previously added enum"sv))));
+((((*this).compiler))->panic((ByteString::from_utf8_without_validation("can't find previously added enum"sv))));
 }
 __jakt_var_436 = types::StructLikeId::Enum(JaktInternal::OptionalNone(),(enum_id.value())); goto __jakt_label_408;
 
@@ -1378,7 +1378,7 @@ return {};
 ErrorOr<void> typechecker::Typechecker::warn_about_unimplemented_nested_record(parser::ParsedRecord const record) {
 {
 if (((((record).definition_linkage)).__jakt_init_index() == 0 /* Internal */)){
-((*this).error((ByteString::must_from_utf8("Only external nested types are currently supported"sv)),((record).name_span)));
+((*this).error((ByteString::from_utf8_without_validation("Only external nested types are currently supported"sv)),((record).name_span)));
 }
 }
 return {};
@@ -1409,7 +1409,7 @@ return JaktInternal::ExplicitValue(fields);
 };/*case end*/
 default: {
 {
-((((*this).compiler))->panic((ByteString::must_from_utf8("typecheck_struct_fields cannot handle non-structs"sv))));
+((((*this).compiler))->panic((ByteString::from_utf8_without_validation("typecheck_struct_fields cannot handle non-structs"sv))));
 }
 };/*case end*/
 }/*switch end*/
@@ -1481,7 +1481,7 @@ auto&& __jakt_match_value = __jakt_match_variant.as.Comptime;NonnullRefPtr<typen
 return JaktInternal::ExplicitValue(({ Optional<JaktInternal::Optional<JaktInternal::DynamicArray<JaktInternal::Tuple<ByteString,utility::Span>>>> __jakt_var_438; {
 NonnullRefPtr<interpreter::Interpreter> interpreter = ((*this).interpreter());
 NonnullRefPtr<interpreter::InterpreterScope> eval_scope = interpreter::InterpreterScope::from_runtime_scope(scope_id,((*this).program),JaktInternal::OptionalNone());
-ids::ScopeId const exec_scope = ((*this).create_scope(scope_id,true,(ByteString::must_from_utf8("comptime-import"sv)),true));
+ids::ScopeId const exec_scope = ((*this).create_scope(scope_id,true,(ByteString::from_utf8_without_validation("comptime-import"sv)),true));
 interpreter::StatementResult const result = TRY((((interpreter)->execute_expression(TRY((((*this).typecheck_expression(expression,exec_scope,types::SafetyMode::Safe(),JaktInternal::OptionalNone())))),eval_scope))));
 __jakt_var_438 = ({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<JaktInternal::Optional<JaktInternal::DynamicArray<JaktInternal::Tuple<ByteString,utility::Span>>>, ErrorOr<void>>{
@@ -1489,7 +1489,7 @@ auto&& __jakt_match_variant = result;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 0 /* Return */: {
 return JaktInternal::ExplicitValue(({ Optional<JaktInternal::DynamicArray<JaktInternal::Tuple<ByteString,utility::Span>>> __jakt_var_439; {
-((*this).error_with_hint((ByteString::must_from_utf8("module name must evaluate to a string literal or an array of strings"sv)),((expression)->span()),(ByteString::must_from_utf8("this expression evaluates to an invalid value"sv)),((expression)->span())));
+((*this).error_with_hint((ByteString::from_utf8_without_validation("module name must evaluate to a string literal or an array of strings"sv)),((expression)->span()),(ByteString::from_utf8_without_validation("this expression evaluates to an invalid value"sv)),((expression)->span())));
 __jakt_var_439 = JaktInternal::OptionalNone(); goto __jakt_label_410;
 
 }
@@ -1497,7 +1497,7 @@ __jakt_label_410:; __jakt_var_439; }));
 };/*case end*/
 case 2 /* Yield */: {
 return JaktInternal::ExplicitValue(({ Optional<JaktInternal::DynamicArray<JaktInternal::Tuple<ByteString,utility::Span>>> __jakt_var_440; {
-((*this).error_with_hint((ByteString::must_from_utf8("module name must evaluate to a string literal or an array of strings"sv)),((expression)->span()),(ByteString::must_from_utf8("this expression evaluates to an invalid value"sv)),((expression)->span())));
+((*this).error_with_hint((ByteString::from_utf8_without_validation("module name must evaluate to a string literal or an array of strings"sv)),((expression)->span()),(ByteString::from_utf8_without_validation("this expression evaluates to an invalid value"sv)),((expression)->span())));
 __jakt_var_440 = JaktInternal::OptionalNone(); goto __jakt_label_411;
 
 }
@@ -1505,7 +1505,7 @@ __jakt_label_411:; __jakt_var_440; }));
 };/*case end*/
 case 3 /* Continue */: {
 return JaktInternal::ExplicitValue(({ Optional<JaktInternal::DynamicArray<JaktInternal::Tuple<ByteString,utility::Span>>> __jakt_var_441; {
-((*this).error_with_hint((ByteString::must_from_utf8("module name must evaluate to a string literal or an array of strings"sv)),((expression)->span()),(ByteString::must_from_utf8("this expression evaluates to an invalid value"sv)),((expression)->span())));
+((*this).error_with_hint((ByteString::from_utf8_without_validation("module name must evaluate to a string literal or an array of strings"sv)),((expression)->span()),(ByteString::from_utf8_without_validation("this expression evaluates to an invalid value"sv)),((expression)->span())));
 __jakt_var_441 = JaktInternal::OptionalNone(); goto __jakt_label_412;
 
 }
@@ -1513,7 +1513,7 @@ __jakt_label_412:; __jakt_var_441; }));
 };/*case end*/
 case 4 /* Break */: {
 return JaktInternal::ExplicitValue(({ Optional<JaktInternal::DynamicArray<JaktInternal::Tuple<ByteString,utility::Span>>> __jakt_var_442; {
-((*this).error_with_hint((ByteString::must_from_utf8("module name must evaluate to a string literal or an array of strings"sv)),((expression)->span()),(ByteString::must_from_utf8("this expression evaluates to an invalid value"sv)),((expression)->span())));
+((*this).error_with_hint((ByteString::from_utf8_without_validation("module name must evaluate to a string literal or an array of strings"sv)),((expression)->span()),(ByteString::from_utf8_without_validation("this expression evaluates to an invalid value"sv)),((expression)->span())));
 __jakt_var_442 = JaktInternal::OptionalNone(); goto __jakt_label_413;
 
 }
@@ -1522,7 +1522,7 @@ __jakt_label_413:; __jakt_var_442; }));
 case 1 /* Throw */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Throw;types::Value const& error = __jakt_match_value.value;
 return JaktInternal::ExplicitValue(({ Optional<JaktInternal::DynamicArray<JaktInternal::Tuple<ByteString,utility::Span>>> __jakt_var_443; {
-((*this).error_with_hint((ByteString::must_from_utf8("module name must evaluate to a string literal or an array of strings"sv)),((expression)->span()),__jakt_format((StringView::from_string_literal("this expression threw an error: {}"sv)),error),((expression)->span())));
+((*this).error_with_hint((ByteString::from_utf8_without_validation("module name must evaluate to a string literal or an array of strings"sv)),((expression)->span()),__jakt_format((StringView::from_string_literal("this expression threw an error: {}"sv)),error),((expression)->span())));
 __jakt_var_443 = JaktInternal::OptionalNone(); goto __jakt_label_414;
 
 }
@@ -1542,7 +1542,7 @@ case 20 /* JaktArray */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.JaktArray;JaktInternal::DynamicArray<types::Value> const& values = __jakt_match_value.values;
 return JaktInternal::ExplicitValue(({ Optional<JaktInternal::Optional<JaktInternal::DynamicArray<JaktInternal::Tuple<ByteString,utility::Span>>>> __jakt_var_444; {
 if (((values).is_empty())){
-((*this).error_with_hint((ByteString::must_from_utf8("module name must evaluate to a string literal or an array of strings"sv)),((expression)->span()),(ByteString::must_from_utf8("this expression evaluates to an empty array"sv)),((expression)->span())));
+((*this).error_with_hint((ByteString::from_utf8_without_validation("module name must evaluate to a string literal or an array of strings"sv)),((expression)->span()),(ByteString::from_utf8_without_validation("this expression evaluates to an empty array"sv)),((expression)->span())));
 }
 JaktInternal::DynamicArray<JaktInternal::Tuple<ByteString,utility::Span>> result = DynamicArray<JaktInternal::Tuple<ByteString,utility::Span>>::create_with({});
 {
@@ -1564,7 +1564,7 @@ return (((result).push((Tuple{string, ((value).span)})))), JaktInternal::Explici
 };/*case end*/
 default: {
 {
-((*this).error_with_hint((ByteString::must_from_utf8("module name must evaluate to a string literal or an array of strings"sv)),((value).span),(ByteString::must_from_utf8("this expression evaluates to an invalid value"sv)),((value).span)));
+((*this).error_with_hint((ByteString::from_utf8_without_validation("module name must evaluate to a string literal or an array of strings"sv)),((value).span),(ByteString::from_utf8_without_validation("this expression evaluates to an invalid value"sv)),((value).span)));
 }
 return JaktInternal::ExplicitValue<void>();
 };/*case end*/
@@ -1591,7 +1591,7 @@ __jakt_label_415:; __jakt_var_444.release_value(); }));
 };/*case end*/
 default: {
 return JaktInternal::ExplicitValue(({ Optional<JaktInternal::DynamicArray<JaktInternal::Tuple<ByteString,utility::Span>>> __jakt_var_445; {
-((*this).error_with_hint((ByteString::must_from_utf8("module name must evaluate to a string literal"sv)),((expression)->span()),(ByteString::must_from_utf8("this expression evaluates to a non-string value"sv)),((expression)->span())));
+((*this).error_with_hint((ByteString::from_utf8_without_validation("module name must evaluate to a string literal"sv)),((expression)->span()),(ByteString::from_utf8_without_validation("this expression evaluates to a non-string value"sv)),((expression)->span())));
 __jakt_var_445 = JaktInternal::OptionalNone(); goto __jakt_label_416;
 
 }
@@ -1650,7 +1650,7 @@ if (__jakt_enum_value == true) {
 return JaktInternal::ExplicitValue((maybe_file_name.value()));
 }
 else if (__jakt_enum_value == false) {
-return JaktInternal::ExplicitValue(TRY((((((((((*this).get_root_path())).parent())).join(((name_and_span).template get<0>())))).replace_extension((ByteString::must_from_utf8("jakt"sv)))))));
+return JaktInternal::ExplicitValue(TRY((((((((((*this).get_root_path())).parent())).join(((name_and_span).template get<0>())))).replace_extension((ByteString::from_utf8_without_validation("jakt"sv)))))));
 }
 VERIFY_NOT_REACHED();
 }());
@@ -1678,14 +1678,14 @@ break;
 }
 
 if ((!(((module_name_and_span).has_value())))){
-((*this).error(__jakt_format((StringView::from_string_literal("No module in module set {{{}}} was found"sv)),utility::join(names,(ByteString::must_from_utf8(", "sv)))),((((import_).module_name)).span())));
+((*this).error(__jakt_format((StringView::from_string_literal("No module in module set {{{}}} was found"sv)),utility::join(names,(ByteString::from_utf8_without_validation(", "sv)))),((((import_).module_name)).span())));
 return {};
 }
 JaktInternal::Tuple<ByteString,utility::Span> const module_name_module_span_ = (module_name_and_span.value());
 ByteString const module_name = ((module_name_module_span_).template get<0>());
 utility::Span const module_span = ((module_name_module_span_).template get<1>());
 
-ByteString const sanitized_module_name = ((module_name).replace((ByteString::must_from_utf8(":"sv)),(ByteString::must_from_utf8("_"sv))));
+ByteString const sanitized_module_name = ((module_name).replace((ByteString::from_utf8_without_validation(":"sv)),(ByteString::from_utf8_without_validation("_"sv))));
 ids::ModuleId imported_module_id = ids::ModuleId(static_cast<size_t>(0ULL));
 JaktInternal::Optional<types::LoadedModule> maybe_loaded_module = ((((*this).program))->get_loaded_module(sanitized_module_name));
 if ((!(((maybe_loaded_module).has_value())))){
@@ -1697,7 +1697,7 @@ if (__jakt_enum_value == true) {
 return JaktInternal::ExplicitValue((maybe_file_name.value()));
 }
 else if (__jakt_enum_value == false) {
-return JaktInternal::ExplicitValue(TRY((((((((((*this).get_root_path())).parent())).join(module_name))).replace_extension((ByteString::must_from_utf8("jakt"sv)))))));
+return JaktInternal::ExplicitValue(TRY((((((((((*this).get_root_path())).parent())).join(module_name))).replace_extension((ByteString::from_utf8_without_validation("jakt"sv)))))));
 }
 VERIFY_NOT_REACHED();
 }());
@@ -1971,13 +1971,13 @@ break;
 parser::ParsedFunction f = (_magic_value.value());
 {
 if ((!(((((f).linkage)).__jakt_init_index() == 1 /* External */)))){
-((*this).error((ByteString::must_from_utf8("Expected all functions in an `import extern` to be be external"sv)),((f).name_span)));
+((*this).error((ByteString::from_utf8_without_validation("Expected all functions in an `import extern` to be be external"sv)),((f).name_span)));
 }
 if ((((import_).is_c) && (!(((((f).generic_parameters)).is_empty()))))){
-((*this).error_with_hint(__jakt_format((StringView::from_string_literal("imported function '{}' is declared to have C linkage, but is generic"sv)),((f).name)),((f).name_span),(ByteString::must_from_utf8("this function may not be generic"sv)),((f).name_span)));
+((*this).error_with_hint(__jakt_format((StringView::from_string_literal("imported function '{}' is declared to have C linkage, but is generic"sv)),((f).name)),((f).name_span),(ByteString::from_utf8_without_validation("this function may not be generic"sv)),((f).name_span)));
 }
 if ((!(((((((f).block)).stmts)).is_empty())))){
-((*this).error((ByteString::must_from_utf8("imported extern function is not allowed to have a body"sv)),((f).name_span)));
+((*this).error((ByteString::from_utf8_without_validation("imported extern function is not allowed to have a body"sv)),((f).name_span)));
 }
 }
 
@@ -1994,7 +1994,7 @@ break;
 parser::ParsedRecord record = (_magic_value.value());
 {
 if ((!(((((record).definition_linkage)).__jakt_init_index() == 1 /* External */)))){
-((*this).error((ByteString::must_from_utf8("Expected all records in an `import extern` to be external"sv)),((record).name_span)));
+((*this).error((ByteString::from_utf8_without_validation("Expected all records in an `import extern` to be external"sv)),((record).name_span)));
 }
 if ((((import_).is_c) && (!(((((record).generic_parameters)).is_empty()))))){
 ((*this).error_with_hint(__jakt_format((StringView::from_string_literal("imported {} '{}' is declared to have C linkage, but is generic"sv)),((((record).record_type)).record_type_name()),((record).name)),((record).name_span),__jakt_format((StringView::from_string_literal("this {} may not be generic"sv)),((((record).record_type)).record_type_name())),((record).name_span)));
@@ -2046,7 +2046,7 @@ NonnullRefPtr<types::Scope> scope = ((*this).get_scope(scope_id));
 ((((scope)->resolution_mixins)).push(import_scope_id));
 if (((((((extern_import).assigned_namespace)).name)).has_value())){
 (((((*this).get_scope(import_scope_id)))->namespace_name) = (((((extern_import).assigned_namespace)).name).value()));
-(((((*this).get_scope(import_scope_id)))->external_name) = parser::ExternalName::Plain((ByteString::must_from_utf8(""sv))));
+(((((*this).get_scope(import_scope_id)))->external_name) = parser::ExternalName::Plain((ByteString::from_utf8_without_validation(""sv))));
 }
 continue;
 }
@@ -2057,7 +2057,7 @@ continue;
 }
 
 if ((!(((coalesced_imports).is_empty())))){
-ids::ScopeId const child_scope_id = ((*this).create_scope(((*this).root_scope_id()),false,(ByteString::must_from_utf8("coalesced-extern-imports"sv)),false));
+ids::ScopeId const child_scope_id = ((*this).create_scope(((*this).root_scope_id()),false,(ByteString::from_utf8_without_validation("coalesced-extern-imports"sv)),false));
 {
 NonnullRefPtr<types::Scope> scope = ((*this).get_scope(scope_id));
 ((((scope)->resolution_mixins)).push(child_scope_id));
@@ -2201,7 +2201,7 @@ ids::ScopeId const import_scope_id = ({ Optional<ids::ScopeId> __jakt_var_446;
 auto __jakt_var_447 = [&]() -> ErrorOr<ids::ScopeId> { return TRY((((*this).cache_or_process_cpp_import(output,child_scope_id,false,Dictionary<ByteString, ByteString>::create_with_entries({}))))); }();
 if (__jakt_var_447.is_error()) {auto e = __jakt_var_447.release_error();
 {
-if (((ByteString::must_from_utf8(((e).string_literal()))) == (ByteString::must_from_utf8(cpp_import__common::CppImportErrors::path_not_found())))){
+if (((ByteString::from_utf8_without_validation(((e).string_literal()))) == (ByteString::from_utf8_without_validation(cpp_import__common::CppImportErrors::path_not_found())))){
 {
 JaktInternal::ArrayIterator<parser::ParsedExternImport> _magic = ((imports).iterator());
 for (;;){
@@ -2211,7 +2211,7 @@ break;
 }
 parser::ParsedExternImport import_ = (_magic_value.value());
 {
-((*this).error_with_hint(__jakt_format((StringView::from_string_literal("Could not find imported extern file '{}'"sv)),((import_).get_path())),(((((import_).assigned_namespace)).name_span).value()),(ByteString::must_from_utf8("make sure the file exists and is in the include path"sv)),(((((import_).assigned_namespace)).name_span).value())));
+((*this).error_with_hint(__jakt_format((StringView::from_string_literal("Could not find imported extern file '{}'"sv)),((import_).get_path())),(((((import_).assigned_namespace)).name_span).value()),(ByteString::from_utf8_without_validation("make sure the file exists and is in the include path"sv)),(((((import_).assigned_namespace)).name_span).value())));
 }
 
 }
@@ -2332,7 +2332,7 @@ case 0 /* Struct */: {
 return JaktInternal::ExplicitValue(({ Optional<types::StructLikeId> __jakt_var_449; {
 JaktInternal::Optional<ids::StructId> const struct_id = TRY((((*this).find_struct_in_scope(scope_id,((record).name),JaktInternal::OptionalNone()))));
 if ((!(((struct_id).has_value())))){
-((((*this).compiler))->panic((ByteString::must_from_utf8("can't find previously added struct"sv))));
+((((*this).compiler))->panic((ByteString::from_utf8_without_validation("can't find previously added struct"sv))));
 }
 TRY((((*this).typecheck_struct_constructor(record,(struct_id.value()),scope_id))));
 __jakt_var_449 = types::StructLikeId::Struct(JaktInternal::OptionalNone(),(struct_id.value())); goto __jakt_label_417;
@@ -2344,7 +2344,7 @@ case 1 /* Class */: {
 return JaktInternal::ExplicitValue(({ Optional<types::StructLikeId> __jakt_var_450; {
 JaktInternal::Optional<ids::StructId> const struct_id = TRY((((*this).find_struct_in_scope(scope_id,((record).name),JaktInternal::OptionalNone()))));
 if ((!(((struct_id).has_value())))){
-((((*this).compiler))->panic((ByteString::must_from_utf8("can't find previously added struct"sv))));
+((((*this).compiler))->panic((ByteString::from_utf8_without_validation("can't find previously added struct"sv))));
 }
 TRY((((*this).typecheck_struct_constructor(record,(struct_id.value()),scope_id))));
 __jakt_var_450 = types::StructLikeId::Struct(JaktInternal::OptionalNone(),(struct_id.value())); goto __jakt_label_418;
@@ -2356,7 +2356,7 @@ case 3 /* SumEnum */: {
 return JaktInternal::ExplicitValue(({ Optional<types::StructLikeId> __jakt_var_451; {
 JaktInternal::Optional<ids::EnumId> const enum_id = TRY((((((*this).program))->find_enum_in_scope(scope_id,((record).name),false,JaktInternal::OptionalNone()))));
 if ((!(((enum_id).has_value())))){
-((((*this).compiler))->panic((ByteString::must_from_utf8("can't find previously added enum"sv))));
+((((*this).compiler))->panic((ByteString::from_utf8_without_validation("can't find previously added enum"sv))));
 }
 TRY((((*this).typecheck_enum_constructor(record,(enum_id.value()),scope_id))));
 __jakt_var_451 = types::StructLikeId::Enum(JaktInternal::OptionalNone(),(enum_id.value())); goto __jakt_label_419;
@@ -2368,7 +2368,7 @@ case 2 /* ValueEnum */: {
 return JaktInternal::ExplicitValue(({ Optional<types::StructLikeId> __jakt_var_452; {
 JaktInternal::Optional<ids::EnumId> const enum_id = TRY((((((*this).program))->find_enum_in_scope(scope_id,((record).name),false,JaktInternal::OptionalNone()))));
 if ((!(((enum_id).has_value())))){
-((((*this).compiler))->panic((ByteString::must_from_utf8("can't find previously added enum"sv))));
+((((*this).compiler))->panic((ByteString::from_utf8_without_validation("can't find previously added enum"sv))));
 }
 TRY((((*this).typecheck_enum_constructor(record,(enum_id.value()),scope_id))));
 __jakt_var_452 = types::StructLikeId::Enum(JaktInternal::OptionalNone(),(enum_id.value())); goto __jakt_label_420;
@@ -2897,7 +2897,7 @@ break;
 }
 parser::ParsedNamespace namespace_ = (_magic_value.value());
 {
-ByteString debug_name = (ByteString::must_from_utf8("namespace("sv));
+ByteString debug_name = (ByteString::from_utf8_without_validation("namespace("sv));
 if (((((namespace_).name)).has_value())){
 [](ByteString& self, ByteString rhs) -> void {
 {
@@ -2912,7 +2912,7 @@ else {
 (self = ((self) + (rhs)));
 }
 }
-(debug_name,(ByteString::must_from_utf8("unnamed-namespace"sv)));
+(debug_name,(ByteString::from_utf8_without_validation("unnamed-namespace"sv)));
 }
 
 [](ByteString& self, ByteString rhs) -> void {
@@ -2920,7 +2920,7 @@ else {
 (self = ((self) + (rhs)));
 }
 }
-(debug_name,(ByteString::must_from_utf8(")"sv)));
+(debug_name,(ByteString::from_utf8_without_validation(")"sv)));
 JaktInternal::Optional<ids::ScopeId> existing_scope_id = ({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<JaktInternal::Optional<ids::ScopeId>,ErrorOr<void>>{
 auto __jakt_enum_value = (((((namespace_).name)).has_value()));
@@ -2948,7 +2948,7 @@ if (((((namespace_).import_path_if_extern)).has_value())){
 (self = ((self) + (rhs)));
 }
 }
-(debug_name,(ByteString::must_from_utf8(" (extern "sv)));
+(debug_name,(ByteString::from_utf8_without_validation(" (extern "sv)));
 [](ByteString& self, ByteString rhs) -> void {
 {
 (self = ((self) + (rhs)));
@@ -2960,7 +2960,7 @@ if (((((namespace_).import_path_if_extern)).has_value())){
 (self = ((self) + (rhs)));
 }
 }
-(debug_name,(ByteString::must_from_utf8(")"sv)));
+(debug_name,(ByteString::from_utf8_without_validation(")"sv)));
 }
 ids::ScopeId const parent_scope_id = ({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<ids::ScopeId,ErrorOr<void>>{
@@ -3220,7 +3220,7 @@ if (((trait_id).has_value())){
 TRY((((*this).typecheck_trait(parsed_trait,(trait_id.value()),scope_id,true))));
 }
 else {
-((((*this).compiler))->panic((ByteString::must_from_utf8("can't find trait that has been previous added"sv))));
+((((*this).compiler))->panic((ByteString::from_utf8_without_validation("can't find trait that has been previous added"sv))));
 }
 
 }
@@ -3353,13 +3353,13 @@ continue;
 ((named_requirements).push((Tuple{((parameter).name), ((parameter).span), trait_requirements})));
 }
 else {
-((*this).error_with_hint(__jakt_format((StringView::from_string_literal("forall type '{}' is not allowed to be unconditional"sv)),((parameter).name)),((parameter).span),(ByteString::must_from_utf8("Try adding a 'requires' clause to the this type"sv)),((parameter).span)));
+((*this).error_with_hint(__jakt_format((StringView::from_string_literal("forall type '{}' is not allowed to be unconditional"sv)),((parameter).name)),((parameter).span),(ByteString::from_utf8_without_validation("Try adding a 'requires' clause to the this type"sv)),((parameter).span)));
 continue;
 }
 
 }
 else {
-((*this).error_with_hint(__jakt_format((StringView::from_string_literal("forall type '{}' is not allowed to be unconditional"sv)),((parameter).name)),((parameter).span),(ByteString::must_from_utf8("Try adding a 'requires' clause to the this type"sv)),((parameter).span)));
+((*this).error_with_hint(__jakt_format((StringView::from_string_literal("forall type '{}' is not allowed to be unconditional"sv)),((parameter).name)),((parameter).span),(ByteString::from_utf8_without_validation("Try adding a 'requires' clause to the this type"sv)),((parameter).span)));
 continue;
 }
 
@@ -3691,7 +3691,7 @@ break;
 parser::ParsedMethod method = (_magic_value.value());
 {
 JaktInternal::Optional<ids::TypeId> this_arg_type_id = JaktInternal::OptionalNone();
-if (((TRY((((((((((((method).parsed_function)).params)).first())).map([](auto& _value) { return _value.variable; }))).map([](auto& _value) { return _value.name; })).try_value_or_lazy_evaluated([&]() -> ErrorOr<ByteString> { return (ByteString::must_from_utf8(""sv)); })))) == ((ByteString::must_from_utf8("this"sv))))){
+if (((TRY((((((((((((method).parsed_function)).params)).first())).map([](auto& _value) { return _value.variable; }))).map([](auto& _value) { return _value.name; })).try_value_or_lazy_evaluated([&]() -> ErrorOr<ByteString> { return (ByteString::from_utf8_without_validation(""sv)); })))) == ((ByteString::from_utf8_without_validation("this"sv))))){
 (this_arg_type_id = ({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<JaktInternal::Optional<ids::TypeId>, ErrorOr<void>>{
 auto&& __jakt_match_variant = *((*this).get_type(for_type));
@@ -3784,7 +3784,7 @@ return {};
 ErrorOr<void> typechecker::Typechecker::typecheck_trait_predecl(parser::ParsedTrait const parsed_trait,ids::ScopeId const scope_id) {
 {
 ids::ScopeId const trait_scope_id = ((*this).create_scope(scope_id,false,__jakt_format((StringView::from_string_literal("trait({})"sv)),((parsed_trait).name)),false));
-TRY((((*this).add_type_to_scope(trait_scope_id,(ByteString::must_from_utf8("Self"sv)),((*this).find_or_add_type_id(types::Type::Self(parser::CheckedQualifiers(false)))),((parsed_trait).name_span)))));
+TRY((((*this).add_type_to_scope(trait_scope_id,(ByteString::from_utf8_without_validation("Self"sv)),((*this).find_or_add_type_id(types::Type::Self(parser::CheckedQualifiers(false)))),((parsed_trait).name_span)))));
 NonnullRefPtr<types::CheckedTrait> checked_trait = types::CheckedTrait::__jakt_create(((parsed_trait).name),((parsed_trait).name_span),({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<types::CheckedTraitRequirements, ErrorOr<void>>{
 auto&& __jakt_match_variant = ((parsed_trait).requirements);
@@ -3861,7 +3861,7 @@ parser::ParsedFunction parsed_function = (_magic_value.value());
 ids::ScopeId const method_scope_id = ((*this).create_scope(trait_scope_id,((parsed_function).can_throw),__jakt_format((StringView::from_string_literal("trait-method({}::{})"sv)),((parsed_trait).name),((parsed_function).name)),true));
 ids::FunctionId const function_id = ((((((*this).program))->get_module(((*this).current_module_id))))->next_function_id());
 JaktInternal::Optional<ids::TypeId> this_arg_type_id = JaktInternal::OptionalNone();
-if (((!(((((parsed_function).params)).is_empty()))) && (((((((((((parsed_function).params)).first()).value())).variable)).name)) == ((ByteString::must_from_utf8("this"sv)))))){
+if (((!(((((parsed_function).params)).is_empty()))) && (((((((((((parsed_function).params)).first()).value())).variable)).name)) == ((ByteString::from_utf8_without_validation("this"sv)))))){
 (this_arg_type_id = struct_type_id);
 }
 TRY((((*this).typecheck_function_predecl(parsed_function,trait_scope_id,this_arg_type_id,JaktInternal::OptionalNone(),JaktInternal::OptionalNone()))));
@@ -4120,7 +4120,7 @@ ids::ScopeId const block_scope_id = ((*this).create_scope(method_scope_id,((func
 bool const is_generic = ((!(((((parsed_record).generic_parameters)).is_empty()))) || (!(((((func).generic_parameters)).is_empty()))));
 bool has_varargs = ((((method).parsed_function)).has_varargs);
 if ((has_varargs && ((((((method).parsed_function)).linkage)).__jakt_init_index() == 0 /* Internal */))){
-((*this).error((ByteString::must_from_utf8("Only external functions are allowed to be declared using varargs"sv)),((((method).parsed_function)).name_span)));
+((*this).error((ByteString::from_utf8_without_validation("Only external functions are allowed to be declared using varargs"sv)),((((method).parsed_function)).name_span)));
 (has_varargs = false);
 }
 NonnullRefPtr<types::CheckedFunction> checked_function = types::CheckedFunction::__jakt_create(((func).name),((func).name_span),TRY((((*this).typecheck_visibility(((method).visibility),scope_id)))),types::unknown_type_id(),JaktInternal::OptionalNone(),DynamicArray<types::CheckedParameter>::create_with({}),types::FunctionGenerics::__jakt_create(method_scope_id,DynamicArray<types::CheckedParameter>::create_with({}),DynamicArray<types::FunctionGenericParameter>::create_with({}),DynamicArray<JaktInternal::DynamicArray<ids::TypeId>>::create_with({})),types::CheckedBlock(DynamicArray<NonnullRefPtr<typename types::CheckedStatement>>::create_with({}),block_scope_id,types::BlockControlFlow::MayReturn(),ids::TypeId::none(),false),((func).can_throw),((func).type),((func).linkage),method_scope_id,JaktInternal::OptionalNone(),((!(is_generic)) || is_extern),func,((func).is_comptime),false,false,((func).is_unsafe),has_varargs,JaktInternal::OptionalNone(),JaktInternal::OptionalNone(),JaktInternal::OptionalNone(),false,JaktInternal::OptionalNone(),JaktInternal::OptionalNone(),JaktInternal::OptionalNone(),parser::InlineState::Default());
@@ -4161,7 +4161,7 @@ break;
 }
 parser::ParsedParameter param = (_magic_value.value());
 {
-if (((((((param).variable)).name)) == ((ByteString::must_from_utf8("this"sv))))){
+if (((((((param).variable)).name)) == ((ByteString::from_utf8_without_validation("this"sv))))){
 NonnullRefPtr<types::CheckedVariable> const checked_variable = types::CheckedVariable::__jakt_create(((((param).variable)).name),enum_type_id,((((param).variable)).is_mutable),((((param).variable)).span),JaktInternal::OptionalNone(),types::CheckedVisibility::Public(),JaktInternal::OptionalNone(),JaktInternal::OptionalNone(),JaktInternal::OptionalNone());
 ((checked_function)->add_param(types::CheckedParameter(((param).requires_label),checked_variable,JaktInternal::OptionalNone())));
 }
@@ -4592,7 +4592,7 @@ ids::StructId const struct_id = (super_type)->as.Struct.value;
 (super_struct_id = struct_id);
 }
 else {
-((*this).error((ByteString::must_from_utf8("Class can only inherit from another class"sv)),(((super_parsed_type.value()))->span())));
+((*this).error((ByteString::from_utf8_without_validation("Class can only inherit from another class"sv)),(((super_parsed_type.value()))->span())));
 }
 
 }
@@ -4624,7 +4624,7 @@ ids::StructId const struct_id = (super_type)->as.Struct.value;
 (super_struct_id = struct_id);
 }
 else {
-((*this).error((ByteString::must_from_utf8("Struct can only inherit from another struct"sv)),(((super_parsed_type.value()))->span())));
+((*this).error((ByteString::from_utf8_without_validation("Struct can only inherit from another struct"sv)),(((super_parsed_type.value()))->span())));
 }
 
 }
@@ -4644,7 +4644,7 @@ return JaktInternal::ExplicitValue<void>();
 };/*case end*/
 default: {
 {
-utility::panic((ByteString::must_from_utf8("Expected Struct or Class in typecheck_struct_predecl"sv)));
+utility::panic((ByteString::from_utf8_without_validation("Expected Struct or Class in typecheck_struct_predecl"sv)));
 }
 return JaktInternal::ExplicitValue<void>();
 };/*case end*/
@@ -4728,10 +4728,10 @@ NonnullRefPtr<types::CheckedFunction> checked_function = ((*this).get_function(f
 (((checked_function)->is_virtual) = ((method).is_virtual));
 (((checked_function)->visibility) = TRY((((*this).typecheck_visibility(((method).visibility),struct_scope_id)))));
 if ((((checked_function)->is_virtual) && ((checked_function)->is_static()))){
-((*this).error((ByteString::must_from_utf8("Functions cannot be both virtual and static"sv)),((checked_function)->name_span)));
+((*this).error((ByteString::from_utf8_without_validation("Functions cannot be both virtual and static"sv)),((checked_function)->name_span)));
 }
 if ((((checked_function)->is_override) && ((checked_function)->is_static()))){
-((*this).error((ByteString::must_from_utf8("Functions cannot be both override and static"sv)),((checked_function)->name_span)));
+((*this).error((ByteString::from_utf8_without_validation("Functions cannot be both override and static"sv)),((checked_function)->name_span)));
 }
 }
 
@@ -5408,7 +5408,7 @@ case 0 /* Struct */: {
 return JaktInternal::ExplicitValue(({ Optional<types::StructLikeId> __jakt_var_492; {
 JaktInternal::Optional<ids::StructId> const struct_id = TRY((((*this).find_struct_in_scope(scope_id,((record).name),JaktInternal::OptionalNone()))));
 if ((!(((struct_id).has_value())))){
-((((*this).compiler))->panic((ByteString::must_from_utf8("can't find struct that has been previous added"sv))));
+((((*this).compiler))->panic((ByteString::from_utf8_without_validation("can't find struct that has been previous added"sv))));
 }
 TRY((((*this).typecheck_struct(record,(struct_id.value()),scope_id))));
 __jakt_var_492 = types::StructLikeId::Struct(JaktInternal::OptionalNone(),(struct_id.value())); goto __jakt_label_440;
@@ -5420,7 +5420,7 @@ case 1 /* Class */: {
 return JaktInternal::ExplicitValue(({ Optional<types::StructLikeId> __jakt_var_493; {
 JaktInternal::Optional<ids::StructId> const struct_id = TRY((((*this).find_struct_in_scope(scope_id,((record).name),JaktInternal::OptionalNone()))));
 if ((!(((struct_id).has_value())))){
-((((*this).compiler))->panic((ByteString::must_from_utf8("can't find struct that has been previous added"sv))));
+((((*this).compiler))->panic((ByteString::from_utf8_without_validation("can't find struct that has been previous added"sv))));
 }
 TRY((((*this).typecheck_struct(record,(struct_id.value()),scope_id))));
 __jakt_var_493 = types::StructLikeId::Struct(JaktInternal::OptionalNone(),(struct_id.value())); goto __jakt_label_441;
@@ -5432,7 +5432,7 @@ case 3 /* SumEnum */: {
 return JaktInternal::ExplicitValue(({ Optional<types::StructLikeId> __jakt_var_494; {
 JaktInternal::Optional<ids::EnumId> const enum_id = TRY((((((*this).program))->find_enum_in_scope(scope_id,((record).name),false,JaktInternal::OptionalNone()))));
 if ((!(((enum_id).has_value())))){
-((((*this).compiler))->panic((ByteString::must_from_utf8("can't find enum that has been previous added"sv))));
+((((*this).compiler))->panic((ByteString::from_utf8_without_validation("can't find enum that has been previous added"sv))));
 }
 TRY((((*this).typecheck_enum(record,(enum_id.value()),scope_id))));
 __jakt_var_494 = types::StructLikeId::Enum(JaktInternal::OptionalNone(),(enum_id.value())); goto __jakt_label_442;
@@ -5444,7 +5444,7 @@ case 2 /* ValueEnum */: {
 return JaktInternal::ExplicitValue(({ Optional<types::StructLikeId> __jakt_var_495; {
 JaktInternal::Optional<ids::EnumId> const enum_id = TRY((((((*this).program))->find_enum_in_scope(scope_id,((record).name),false,JaktInternal::OptionalNone()))));
 if ((!(((enum_id).has_value())))){
-((((*this).compiler))->panic((ByteString::must_from_utf8("can't find enum that has been previous added"sv))));
+((((*this).compiler))->panic((ByteString::from_utf8_without_validation("can't find enum that has been previous added"sv))));
 }
 TRY((((*this).typecheck_enum(record,(enum_id.value()),scope_id))));
 __jakt_var_495 = types::StructLikeId::Enum(JaktInternal::OptionalNone(),(enum_id.value())); goto __jakt_label_443;
@@ -5499,7 +5499,7 @@ if (((trait_id).has_value())){
 TRY((((*this).typecheck_trait(parsed_trait,(trait_id.value()),scope_id,false))));
 }
 else {
-((((*this).compiler))->panic((ByteString::must_from_utf8("can't find trait that has been previous added"sv))));
+((((*this).compiler))->panic((ByteString::from_utf8_without_validation("can't find trait that has been previous added"sv))));
 }
 
 }
@@ -5559,7 +5559,7 @@ break;
 }
 parser::ParsedMethod method = (_magic_value.value());
 {
-if (((TRY((((((((((((method).parsed_function)).params)).first())).map([](auto& _value) { return _value.variable; }))).map([](auto& _value) { return _value.name; })).try_value_or_lazy_evaluated([&]() -> ErrorOr<ByteString> { return (ByteString::must_from_utf8(""sv)); })))) == ((ByteString::must_from_utf8("this"sv))))){
+if (((TRY((((((((((((method).parsed_function)).params)).first())).map([](auto& _value) { return _value.variable; }))).map([](auto& _value) { return _value.name; })).try_value_or_lazy_evaluated([&]() -> ErrorOr<ByteString> { return (ByteString::from_utf8_without_validation(""sv)); })))) == ((ByteString::from_utf8_without_validation("this"sv))))){
 TRY((((*this).typecheck_method(((method).parsed_function),types::StructLikeId::Struct(JaktInternal::OptionalNone(),struct_id)))));
 }
 else {
@@ -5587,7 +5587,7 @@ break;
 }
 parser::ParsedMethod method = (_magic_value.value());
 {
-if (((TRY((((((((((((method).parsed_function)).params)).first())).map([](auto& _value) { return _value.variable; }))).map([](auto& _value) { return _value.name; })).try_value_or_lazy_evaluated([&]() -> ErrorOr<ByteString> { return (ByteString::must_from_utf8(""sv)); })))) == ((ByteString::must_from_utf8("this"sv))))){
+if (((TRY((((((((((((method).parsed_function)).params)).first())).map([](auto& _value) { return _value.variable; }))).map([](auto& _value) { return _value.name; })).try_value_or_lazy_evaluated([&]() -> ErrorOr<ByteString> { return (ByteString::from_utf8_without_validation(""sv)); })))) == ((ByteString::from_utf8_without_validation("this"sv))))){
 TRY((((*this).typecheck_method(((method).parsed_function),types::StructLikeId::Struct(JaktInternal::OptionalNone(),struct_id)))));
 }
 else {
@@ -5615,7 +5615,7 @@ break;
 }
 parser::ParsedMethod method = (_magic_value.value());
 {
-if (((TRY((((((((((((method).parsed_function)).params)).first())).map([](auto& _value) { return _value.variable; }))).map([](auto& _value) { return _value.name; })).try_value_or_lazy_evaluated([&]() -> ErrorOr<ByteString> { return (ByteString::must_from_utf8(""sv)); })))) == ((ByteString::must_from_utf8("this"sv))))){
+if (((TRY((((((((((((method).parsed_function)).params)).first())).map([](auto& _value) { return _value.variable; }))).map([](auto& _value) { return _value.name; })).try_value_or_lazy_evaluated([&]() -> ErrorOr<ByteString> { return (ByteString::from_utf8_without_validation(""sv)); })))) == ((ByteString::from_utf8_without_validation("this"sv))))){
 TRY((((*this).typecheck_method(((method).parsed_function),types::StructLikeId::Enum(JaktInternal::OptionalNone(),enum_id)))));
 }
 else {
@@ -5643,7 +5643,7 @@ break;
 }
 parser::ParsedMethod method = (_magic_value.value());
 {
-if (((TRY((((((((((((method).parsed_function)).params)).first())).map([](auto& _value) { return _value.variable; }))).map([](auto& _value) { return _value.name; })).try_value_or_lazy_evaluated([&]() -> ErrorOr<ByteString> { return (ByteString::must_from_utf8(""sv)); })))) == ((ByteString::must_from_utf8("this"sv))))){
+if (((TRY((((((((((((method).parsed_function)).params)).first())).map([](auto& _value) { return _value.variable; }))).map([](auto& _value) { return _value.name; })).try_value_or_lazy_evaluated([&]() -> ErrorOr<ByteString> { return (ByteString::from_utf8_without_validation(""sv)); })))) == ((ByteString::from_utf8_without_validation("this"sv))))){
 TRY((((*this).typecheck_method(((method).parsed_function),types::StructLikeId::Enum(JaktInternal::OptionalNone(),enum_id)))));
 }
 else {
@@ -5769,7 +5769,7 @@ return JaktInternal::ExplicitValue(JaktInternal::checked_add(val,static_cast<u64
 case 2 /* Floating */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Floating;f64 const& val = __jakt_match_value.value;
 {
-utility::todo((ByteString::must_from_utf8("Implement floats"sv)));
+utility::todo((ByteString::from_utf8_without_validation("Implement floats"sv)));
 }
 };/*case end*/
 default: VERIFY_NOT_REACHED();}/*switch end*/
@@ -5867,8 +5867,8 @@ return (infallible_enum_cast<jakt__prelude__operators::Ordering>((JaktInternal::
 return (!(((self) == (rhs))));
 }
 }
-((((((((variant).params).value()))[static_cast<i64>(0LL)])).name),(ByteString::must_from_utf8(""sv))));
-bool const is_typed = ((((((variant).params)).has_value()) && (((((((variant).params).value())).size())) == (static_cast<size_t>(1ULL)))) && (((((((((variant).params).value()))[static_cast<i64>(0LL)])).name)) == ((ByteString::must_from_utf8(""sv)))));
+((((((((variant).params).value()))[static_cast<i64>(0LL)])).name),(ByteString::from_utf8_without_validation(""sv))));
+bool const is_typed = ((((((variant).params)).has_value()) && (((((((variant).params).value())).size())) == (static_cast<size_t>(1ULL)))) && (((((((((variant).params).value()))[static_cast<i64>(0LL)])).name)) == ((ByteString::from_utf8_without_validation(""sv)))));
 if (is_structlike){
 JaktInternal::Set<ByteString> seen_fields = Set<ByteString>::create_with_values({});
 {
@@ -6006,7 +6006,7 @@ JaktInternal::Optional<JaktInternal::DynamicArray<ids::FunctionId>> const maybe_
 if ((!(((maybe_enum_variant_constructor).has_value())))){
 ids::ScopeId const function_scope_id = ((*this).create_scope(parent_scope_id,false,__jakt_format((StringView::from_string_literal("enum-variant-constructor({}::{})"sv)),((enum_).name),((variant).name)),true));
 ids::ScopeId const block_scope_id = ((*this).create_scope(function_scope_id,false,__jakt_format((StringView::from_string_literal("enum-variant-constructor-block({}::{})"sv)),((enum_).name),((variant).name)),true));
-NonnullRefPtr<types::CheckedVariable> const variable = types::CheckedVariable::__jakt_create((ByteString::must_from_utf8("value"sv)),type_id,false,((param).span),JaktInternal::OptionalNone(),types::CheckedVisibility::Public(),JaktInternal::OptionalNone(),JaktInternal::OptionalNone(),JaktInternal::OptionalNone());
+NonnullRefPtr<types::CheckedVariable> const variable = types::CheckedVariable::__jakt_create((ByteString::from_utf8_without_validation("value"sv)),type_id,false,((param).span),JaktInternal::OptionalNone(),types::CheckedVisibility::Public(),JaktInternal::OptionalNone(),JaktInternal::OptionalNone(),JaktInternal::OptionalNone());
 ((params).push(types::CheckedParameter(false,variable,JaktInternal::OptionalNone())));
 NonnullRefPtr<types::CheckedFunction> const checked_function = types::CheckedFunction::__jakt_create(((variant).name),((variant).span),types::CheckedVisibility::Public(),((*this).find_or_add_type_id(types::Type::Enum(parser::CheckedQualifiers(false),enum_id))),JaktInternal::OptionalNone(),params,types::FunctionGenerics::__jakt_create(function_scope_id,params,DynamicArray<types::FunctionGenericParameter>::create_with({}),DynamicArray<JaktInternal::DynamicArray<ids::TypeId>>::create_with({})),types::CheckedBlock(DynamicArray<NonnullRefPtr<typename types::CheckedStatement>>::create_with({}),block_scope_id,types::BlockControlFlow::AlwaysReturns(),ids::TypeId::none(),false),false,parser::FunctionType::ImplicitEnumConstructor(),parser::FunctionLinkage::Internal(),function_scope_id,JaktInternal::OptionalNone(),true,JaktInternal::OptionalNone(),false,false,false,false,false,JaktInternal::OptionalNone(),JaktInternal::OptionalNone(),JaktInternal::OptionalNone(),false,JaktInternal::OptionalNone(),JaktInternal::OptionalNone(),JaktInternal::OptionalNone(),parser::InlineState::Default());
 ids::FunctionId const function_id = ((module)->add_function(checked_function));
@@ -6187,13 +6187,13 @@ if (((override_target).has_value())){
 JaktInternal::Optional<ids::FunctionId> const method_id = TRY((((*this).find_function_matching_signature_in_scope(parent_scope_id,((method).parsed_function)))));
 NonnullRefPtr<types::CheckedFunction> const method_function = ((*this).get_function((method_id.value())));
 if ((!(((((method_function)->return_type_id)).equals((((override_target.value()))->return_type_id)))))){
-((*this).error((ByteString::must_from_utf8("Override function return type does not match virtual function"sv)),((method_function)->return_type_span).value_or_lazy_evaluated([&] { return ((method_function)->name_span); })));
+((*this).error((ByteString::from_utf8_without_validation("Override function return type does not match virtual function"sv)),((method_function)->return_type_span).value_or_lazy_evaluated([&] { return ((method_function)->name_span); })));
 }
 if (((((method_function)->can_throw)) != ((((override_target.value()))->can_throw)))){
-((*this).error((ByteString::must_from_utf8("Override function throwability does not match virtual function"sv)),((method_function)->name_span)));
+((*this).error((ByteString::from_utf8_without_validation("Override function throwability does not match virtual function"sv)),((method_function)->name_span)));
 }
 if (((((((method_function)->params)).size())) != ((((((override_target.value()))->params)).size())))){
-((*this).error((ByteString::must_from_utf8("Override function parameters do not match virtual function"sv)),((method_function)->name_span)));
+((*this).error((ByteString::from_utf8_without_validation("Override function parameters do not match virtual function"sv)),((method_function)->name_span)));
 return {};
 }
 {
@@ -6208,13 +6208,13 @@ size_t param_index = (_magic_value.value());
 types::CheckedParameter const method_param = ((((method_function)->params))[param_index]);
 types::CheckedParameter const virtual_param = (((((override_target.value()))->params))[param_index]);
 if (((((((virtual_param).variable))->is_mutable)) != (((((method_param).variable))->is_mutable)))){
-((*this).error((ByteString::must_from_utf8("Override function parameter mutability does not match virtual function"sv)),((((method_param).variable))->definition_span)));
+((*this).error((ByteString::from_utf8_without_validation("Override function parameter mutability does not match virtual function"sv)),((((method_param).variable))->definition_span)));
 }
-if ((((param_index) == (static_cast<size_t>(0ULL))) && ((((((method_param).variable))->name)) == ((ByteString::must_from_utf8("this"sv)))))){
+if ((((param_index) == (static_cast<size_t>(0ULL))) && ((((((method_param).variable))->name)) == ((ByteString::from_utf8_without_validation("this"sv)))))){
 continue;
 }
 if ((!(((((((method_param).variable))->type_id)).equals(((((virtual_param).variable))->type_id)))))){
-((*this).error((ByteString::must_from_utf8("Override function parameter type does not match virtual function"sv)),((((method_param).variable))->type_span).value_or_lazy_evaluated([&] { return ((((method_param).variable))->definition_span); })));
+((*this).error((ByteString::from_utf8_without_validation("Override function parameter type does not match virtual function"sv)),((((method_param).variable))->type_span).value_or_lazy_evaluated([&] { return ((((method_param).variable))->definition_span); })));
 }
 }
 
@@ -6223,20 +6223,20 @@ if ((!(((((((method_param).variable))->type_id)).equals(((((virtual_param).varia
 
 }
 else {
-((*this).error((ByteString::must_from_utf8("Missing virtual for override"sv)),((((method).parsed_function)).name_span)));
+((*this).error((ByteString::from_utf8_without_validation("Missing virtual for override"sv)),((((method).parsed_function)).name_span)));
 return {};
 }
 
 }
 else {
-((*this).error((ByteString::must_from_utf8("Missing virtual for override"sv)),((((method).parsed_function)).name_span)));
+((*this).error((ByteString::from_utf8_without_validation("Missing virtual for override"sv)),((((method).parsed_function)).name_span)));
 return {};
 }
 
 }
 else {
 if (((all_virtuals).contains(((((method).parsed_function)).name)))){
-((*this).error((ByteString::must_from_utf8("Missing override keyword on function that is virtual"sv)),((((method).parsed_function)).name_span)));
+((*this).error((ByteString::from_utf8_without_validation("Missing override keyword on function that is virtual"sv)),((((method).parsed_function)).name_span)));
 }
 return {};
 }
@@ -6309,7 +6309,7 @@ else {
 ErrorOr<types::CheckedParameter> typechecker::Typechecker::typecheck_parameter(parser::ParsedParameter const parameter,ids::ScopeId const scope_id,bool const first,JaktInternal::Optional<ids::TypeId> const this_arg_type_id,JaktInternal::Optional<ids::ScopeId> const check_scope) {
 {
 ids::TypeId type_id = TRY((((*this).typecheck_typename(((((parameter).variable)).parsed_type),scope_id,((((parameter).variable)).name)))));
-if ((first && ((((((parameter).variable)).name)) == ((ByteString::must_from_utf8("this"sv)))))){
+if ((first && ((((((parameter).variable)).name)) == ((ByteString::from_utf8_without_validation("this"sv)))))){
 if (((this_arg_type_id).has_value())){
 (type_id = (this_arg_type_id.value()));
 }
@@ -6317,7 +6317,7 @@ if (((this_arg_type_id).has_value())){
 if (((((((*this).get_type(type_id)))->common.init_common.qualifiers)).is_immutable)){
 (type_id = ((*this).with_qualifiers(parser::CheckedQualifiers(false),type_id)));
 if (((((parameter).variable)).is_mutable)){
-((*this).error((ByteString::must_from_utf8("Cannot have a mutable binding to an immutable parameter"sv)),((((parameter).variable)).span)));
+((*this).error((ByteString::from_utf8_without_validation("Cannot have a mutable binding to an immutable parameter"sv)),((((parameter).variable)).span)));
 }
 }
 NonnullRefPtr<types::CheckedVariable> const variable = types::CheckedVariable::__jakt_create(((((parameter).variable)).name),type_id,((((parameter).variable)).is_mutable),((((parameter).variable)).span),JaktInternal::OptionalNone(),types::CheckedVisibility::Public(),JaktInternal::OptionalNone(),JaktInternal::OptionalNone(),JaktInternal::OptionalNone());
@@ -6423,7 +6423,7 @@ bool const is_generic_function = (!(((((parsed_function).generic_parameters)).is
 bool const is_generic = (is_generic_function || (((this_arg_type_id).has_value()) && ((((*this).get_type((this_arg_type_id.value()))))->__jakt_init_index() == 20 /* GenericInstance */)));
 bool has_varargs = ((parsed_function).has_varargs);
 if ((has_varargs && ((((parsed_function).linkage)).__jakt_init_index() == 0 /* Internal */))){
-((*this).error((ByteString::must_from_utf8("Only external functions are allowed to be declared using varargs"sv)),((parsed_function).name_span)));
+((*this).error((ByteString::from_utf8_without_validation("Only external functions are allowed to be declared using varargs"sv)),((parsed_function).name_span)));
 (has_varargs = false);
 }
 NonnullRefPtr<types::CheckedFunction> checked_function = types::CheckedFunction::__jakt_create(((parsed_function).name),((parsed_function).name_span),TRY((((*this).typecheck_visibility(((parsed_function).visibility),parent_scope_id)))),types::unknown_type_id(),((parsed_function).return_type_span),DynamicArray<types::CheckedParameter>::create_with({}),(generics.value()),types::CheckedBlock(DynamicArray<NonnullRefPtr<typename types::CheckedStatement>>::create_with({}),block_scope_id,types::BlockControlFlow::MayReturn(),ids::TypeId::none(),false),((parsed_function).can_throw),((parsed_function).type),((parsed_function).linkage),function_scope_id,JaktInternal::OptionalNone(),((!(is_generic)) || (!(base_definition))),parsed_function,((parsed_function).is_comptime),false,false,((parsed_function).is_unsafe),has_varargs,JaktInternal::OptionalNone(),JaktInternal::OptionalNone(),JaktInternal::OptionalNone(),false,((parsed_function).external_name),((parsed_function).deprecated_message),JaktInternal::OptionalNone(),((parsed_function).force_inline));
@@ -6527,7 +6527,7 @@ return (infallible_enum_cast<jakt__prelude__operators::Ordering>((JaktInternal::
 }
 }
 (index,((((checked_function)->params)).size()))){
-((((*this).compiler))->panic((ByteString::must_from_utf8("stores_argument() index out of bounds"sv))));
+((((*this).compiler))->panic((ByteString::from_utf8_without_validation("stores_argument() index out of bounds"sv))));
 }
 ({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<void, ErrorOr<ids::FunctionId>>{
@@ -6545,7 +6545,7 @@ return JaktInternal::ExplicitValue<void>();
 };/*case end*/
 default: {
 {
-((*this).error_with_hint((ByteString::must_from_utf8("This parameter is not a reference"sv)),((((((((checked_function)->params))[index])).variable))->definition_span),(ByteString::must_from_utf8("stores_argument() may only be used to declare reference lifetime requirements"sv)),((((((((checked_function)->params))[index])).variable))->definition_span)));
+((*this).error_with_hint((ByteString::from_utf8_without_validation("This parameter is not a reference"sv)),((((((((checked_function)->params))[index])).variable))->definition_span),(ByteString::from_utf8_without_validation("stores_argument() may only be used to declare reference lifetime requirements"sv)),((((((((checked_function)->params))[index])).variable))->definition_span)));
 }
 return JaktInternal::ExplicitValue<void>();
 };/*case end*/
@@ -6577,7 +6577,7 @@ types::CheckedBlock const block = TRY((((*this).typecheck_block(((parsed_functio
 if (((*this).had_an_error)){
 (function_return_type_id = types::void_type_id());
 (((*this).ignore_errors) = false);
-((*this).error_with_hint((ByteString::must_from_utf8("Can't infer the return type of this function"sv)),((parsed_function).return_type_span),(ByteString::must_from_utf8("Try adding an explicit return type to the function here"sv)),((parsed_function).return_type_span)));
+((*this).error_with_hint((ByteString::from_utf8_without_validation("Can't infer the return type of this function"sv)),((parsed_function).return_type_span),(ByteString::from_utf8_without_validation("Try adding an explicit return type to the function here"sv)),((parsed_function).return_type_span)));
 }
 else {
 (function_return_type_id = ((*this).infer_function_return_type(block)));
@@ -6741,7 +6741,7 @@ case 0 /* Nothing */: {
 ByteString const trait_name = ((trait_)->name);
 JaktInternal::Optional<JaktInternal::DynamicArray<JaktInternal::Tuple<ids::TraitId,JaktInternal::DynamicArray<ids::TypeId>>>> const implemented_trait = ((implemented_traits).get(trait_name));
 if (((!(((implemented_trait).has_value()))) || (!((((((((implemented_trait.value())).first())).map([](auto& _value) { return _value.template get<0>(); }))).map([&](auto& _value) { return _value.equals(constraint); })).value_or_lazy_evaluated([&] { return false; }))))){
-((*this).error_with_hint(__jakt_format((StringView::from_string_literal("Cannot use ‘{}’ here as it doesn't implement the trait ‘{}’"sv)),TRY((((*this).type_name(generic_argument,false)))),trait_name),arg_span,(ByteString::must_from_utf8("Consider implementing the required trait for this type"sv)),decl_span));
+((*this).error_with_hint(__jakt_format((StringView::from_string_literal("Cannot use ‘{}’ here as it doesn't implement the trait ‘{}’"sv)),TRY((((*this).type_name(generic_argument,false)))),trait_name),arg_span,(ByteString::from_utf8_without_validation("Consider implementing the required trait for this type"sv)),decl_span));
 }
 }
 return JaktInternal::ExplicitValue<void>();
@@ -6751,7 +6751,7 @@ case 1 /* Methods */: {
 ByteString const trait_name = ((trait_)->name);
 JaktInternal::Optional<JaktInternal::DynamicArray<JaktInternal::Tuple<ids::TraitId,JaktInternal::DynamicArray<ids::TypeId>>>> const implemented_trait = ((implemented_traits).get(trait_name));
 if (((!(((implemented_trait).has_value()))) || (!((((((((implemented_trait.value())).first())).map([](auto& _value) { return _value.template get<0>(); }))).map([&](auto& _value) { return _value.equals(constraint); })).value_or_lazy_evaluated([&] { return false; }))))){
-((*this).error_with_hint(__jakt_format((StringView::from_string_literal("Cannot use ‘{}’ here as it doesn't implement the trait ‘{}’"sv)),TRY((((*this).type_name(generic_argument,false)))),trait_name),arg_span,(ByteString::must_from_utf8("Consider implementing the required trait for this type"sv)),decl_span));
+((*this).error_with_hint(__jakt_format((StringView::from_string_literal("Cannot use ‘{}’ here as it doesn't implement the trait ‘{}’"sv)),TRY((((*this).type_name(generic_argument,false)))),trait_name),arg_span,(ByteString::from_utf8_without_validation("Consider implementing the required trait for this type"sv)),decl_span));
 }
 }
 return JaktInternal::ExplicitValue<void>();
@@ -6868,7 +6868,7 @@ ScopeGuard __jakt_var_505([&] {
 NonnullRefPtr<types::Module> module = ((*this).current_module());
 ids::FunctionId const new_function_id = ((module)->next_function_id());
 parser::ParsedFunction parsed_function = ((checked_function)->to_parsed_function());
-ByteString arg_names = (ByteString::must_from_utf8(""sv));
+ByteString arg_names = (ByteString::from_utf8_without_validation(""sv));
 {
 JaktInternal::ArrayIterator<ids::TypeId> _magic = ((generic_arguments).iterator());
 for (;;){
@@ -6884,7 +6884,7 @@ if ((!(((arg_names).is_empty())))){
 (self = ((self) + (rhs)));
 }
 }
-(arg_names,(ByteString::must_from_utf8(", "sv)));
+(arg_names,(ByteString::from_utf8_without_validation(", "sv)));
 }
 [](ByteString& self, ByteString rhs) -> void {
 {
@@ -7172,8 +7172,8 @@ return function_id;
 
 ErrorOr<void> typechecker::Typechecker::typecheck_jakt_main(parser::ParsedFunction const parsed_function,ids::ScopeId const parent_scope_id) {
 {
-ByteString const param_type_error = (ByteString::must_from_utf8("Main function must take a single array of strings as its parameter"sv));
-JaktInternal::Optional<JaktInternal::DynamicArray<ids::FunctionId>> const func_ids = TRY((((*this).find_functions_with_name_in_scope(parent_scope_id,(ByteString::must_from_utf8("main"sv)),JaktInternal::OptionalNone()))));
+ByteString const param_type_error = (ByteString::from_utf8_without_validation("Main function must take a single array of strings as its parameter"sv));
+JaktInternal::Optional<JaktInternal::DynamicArray<ids::FunctionId>> const func_ids = TRY((((*this).find_functions_with_name_in_scope(parent_scope_id,(ByteString::from_utf8_without_validation("main"sv)),JaktInternal::OptionalNone()))));
 if ([](size_t const& self, size_t rhs) -> bool {
 {
 return (((infallible_integer_cast<u8>(([](size_t const& self, size_t rhs) -> jakt__prelude__operators::Ordering {
@@ -7185,7 +7185,7 @@ return (infallible_enum_cast<jakt__prelude__operators::Ordering>((JaktInternal::
 }
 }
 ((((func_ids.value())).size()),static_cast<size_t>(1ULL))){
-((*this).error((ByteString::must_from_utf8("Function 'main' declared multiple times."sv)),((parsed_function).name_span)));
+((*this).error((ByteString::from_utf8_without_validation("Function 'main' declared multiple times."sv)),((parsed_function).name_span)));
 }
 if ([](size_t const& self, size_t rhs) -> bool {
 {
@@ -7212,7 +7212,7 @@ if ([](ByteString const& self, ByteString rhs) -> bool {
 return (!(((self) == (rhs))));
 }
 }
-(name,(ByteString::must_from_utf8("String"sv)))){
+(name,(ByteString::from_utf8_without_validation("String"sv)))){
 ((*this).error(param_type_error,span));
 }
 }
@@ -7226,7 +7226,7 @@ else {
 }
 
 }
-ByteString const return_type_error = (ByteString::must_from_utf8("Main function must return c_int"sv));
+ByteString const return_type_error = (ByteString::from_utf8_without_validation("Main function must return c_int"sv));
 ({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<void, ErrorOr<void>>{
 auto&& __jakt_match_variant = *((parsed_function).return_type);
@@ -7245,7 +7245,7 @@ if ([](ByteString const& self, ByteString rhs) -> bool {
 return (!(((self) == (rhs))));
 }
 }
-(name,(ByteString::must_from_utf8("c_int"sv)))){
+(name,(ByteString::from_utf8_without_validation("c_int"sv)))){
 ((*this).error(return_type_error,span));
 }
 }
@@ -7296,7 +7296,7 @@ return {};
 JaktInternal::Optional<ids::FunctionId> const function_id = TRY((((*this).find_function_matching_signature_in_scope(parent_scope_id,parsed_function))));
 if (((function_id).has_value())){
 (((*this).current_function_id) = (function_id.value()));
-if (((((parsed_function).name)) == ((ByteString::must_from_utf8("main"sv))))){
+if (((((parsed_function).name)) == ((ByteString::from_utf8_without_validation("main"sv))))){
 TRY((((*this).typecheck_jakt_main(parsed_function,parent_scope_id))));
 }
 NonnullRefPtr<types::CheckedFunction> checked_function = ((*this).get_function((function_id.value())));
@@ -7304,7 +7304,7 @@ ids::ScopeId const function_scope_id = ((checked_function)->function_scope_id);
 parser::FunctionLinkage const function_linkage = ((checked_function)->linkage);
 if (((checked_function)->is_fully_checked)){
 if ((!(((((*this).get_scope(parent_scope_id)))->is_from_generated_code)))){
-((*this).error_with_hint(__jakt_format((StringView::from_string_literal("Function ‘{}’ is already defined"sv)),((parsed_function).name)),((parsed_function).name_span),(ByteString::must_from_utf8("Try removing this definition"sv)),(((((checked_function)->parsed_function).value())).name_span)));
+((*this).error_with_hint(__jakt_format((StringView::from_string_literal("Function ‘{}’ is already defined"sv)),((parsed_function).name)),((parsed_function).name_span),(ByteString::from_utf8_without_validation("Try removing this definition"sv)),(((((checked_function)->parsed_function).value())).name_span)));
 }
 return {};
 }
@@ -7335,7 +7335,7 @@ if (((!(((parsed_function).is_fat_arrow))) && (((((parsed_function).return_type)
 return (!(((self) == (rhs))));
 }
 }
-(((parsed_function).name),(ByteString::must_from_utf8("main"sv)))))){
+(((parsed_function).name),(ByteString::from_utf8_without_validation("main"sv)))))){
 (function_return_type_id = types::void_type_id());
 }
 if (((function_return_type_id).equals(types::never_type_id()))){
@@ -7344,7 +7344,7 @@ NonnullRefPtr<types::Scope> scope = ((*this).get_scope(function_scope_id));
 }
 types::CheckedBlock const block = TRY((((*this).typecheck_block(((parsed_function).block),function_scope_id,types::SafetyMode::Safe(),JaktInternal::OptionalNone()))));
 if (((((block).yielded_type)).has_value())){
-((*this).error_with_hint((ByteString::must_from_utf8("Functions are not allowed to yield values"sv)),(((((parsed_function).block)).find_yield_span()).value()),(ByteString::must_from_utf8("You might want to return instead"sv)),(((((parsed_function).block)).find_yield_keyword_span()).value())));
+((*this).error_with_hint((ByteString::from_utf8_without_validation("Functions are not allowed to yield values"sv)),(((((parsed_function).block)).find_yield_span()).value()),(ByteString::from_utf8_without_validation("You might want to return instead"sv)),(((((parsed_function).block)).find_yield_keyword_span()).value())));
 }
 ids::TypeId const return_type_id = ({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<ids::TypeId,ErrorOr<void>>{
@@ -7362,10 +7362,10 @@ return JaktInternal::ExplicitValue(TRY((((*this).resolve_type_var(function_retur
 });
 if (((!(((function_linkage).__jakt_init_index() == 1 /* External */))) && ((!(((return_type_id).equals(types::void_type_id())))) && (!(((((block).control_flow)).always_transfers_control())))))){
 if ((((return_type_id).equals(types::never_type_id())) && (!(((((block).control_flow)).never_returns()))))){
-((*this).error((ByteString::must_from_utf8("Control reaches end of never-returning function"sv)),((parsed_function).name_span)));
+((*this).error((ByteString::from_utf8_without_validation("Control reaches end of never-returning function"sv)),((parsed_function).name_span)));
 }
 else if (((!(((((block).control_flow)).never_returns()))) && (!(((parsed_function).is_jakt_main))))){
-((*this).error((ByteString::must_from_utf8("Control reaches end of non-void function"sv)),((parsed_function).name_span)));
+((*this).error((ByteString::from_utf8_without_validation("Control reaches end of non-void function"sv)),((parsed_function).name_span)));
 }
 }
 (((checked_function)->block) = block);
@@ -7644,7 +7644,7 @@ return true;
 }
 if (((lhs_type)->__jakt_init_index() == 31 /* Self */)){
 if ((!(((((*this).self_type_id)).has_value())))){
-((*this).error((ByteString::must_from_utf8("Invalid use of the 'Self' type"sv)),span));
+((*this).error((ByteString::from_utf8_without_validation("Invalid use of the 'Self' type"sv)),span));
 }
 else {
 return TRY((((*this).check_types_for_compat((((*this).self_type_id).value()),rhs_type_id,generic_inferences,span))));
@@ -7653,7 +7653,7 @@ return TRY((((*this).check_types_for_compat((((*this).self_type_id).value()),rhs
 }
 if (((rhs_type)->__jakt_init_index() == 31 /* Self */)){
 if ((!(((((*this).self_type_id)).has_value())))){
-((*this).error((ByteString::must_from_utf8("Invalid use of the 'Self' type"sv)),span));
+((*this).error((ByteString::from_utf8_without_validation("Invalid use of the 'Self' type"sv)),span));
 }
 else {
 return TRY((((*this).check_types_for_compat(lhs_type_id,(((*this).self_type_id).value()),generic_inferences,span))));
@@ -7671,13 +7671,13 @@ if (((((rhs).impl))->equals(((lhs).impl)))){
 return true;
 }
 NonnullRefPtr<interpreter::Interpreter> const interpreter = ((*this).interpreter());
-((*this).error(__jakt_format((StringView::from_string_literal("Literal type value mismatch: expected '{}', found '{}'"sv)),TRY((types::comptime_format_impl((ByteString::must_from_utf8("{}"sv)),((DynamicArray<types::Value>::create_with({lhs}))[(JaktInternal::Range<i64>{static_cast<i64>(0LL),static_cast<i64>(9223372036854775807LL)})]),((((*this).program)))))),TRY((types::comptime_format_impl((ByteString::must_from_utf8("{}"sv)),((DynamicArray<types::Value>::create_with({rhs}))[(JaktInternal::Range<i64>{static_cast<i64>(0LL),static_cast<i64>(9223372036854775807LL)})]),((((*this).program))))))),span));
+((*this).error(__jakt_format((StringView::from_string_literal("Literal type value mismatch: expected '{}', found '{}'"sv)),TRY((types::comptime_format_impl((ByteString::from_utf8_without_validation("{}"sv)),((DynamicArray<types::Value>::create_with({lhs}))[(JaktInternal::Range<i64>{static_cast<i64>(0LL),static_cast<i64>(9223372036854775807LL)})]),((((*this).program)))))),TRY((types::comptime_format_impl((ByteString::from_utf8_without_validation("{}"sv)),((DynamicArray<types::Value>::create_with({rhs}))[(JaktInternal::Range<i64>{static_cast<i64>(0LL),static_cast<i64>(9223372036854775807LL)})]),((((*this).program))))))),span));
 return false;
 }
 }
-ids::StructId const optional_struct_id = TRY((((*this).find_struct_in_prelude((ByteString::must_from_utf8("Optional"sv))))));
-ids::StructId const weakptr_struct_id = TRY((((*this).find_struct_in_prelude((ByteString::must_from_utf8("WeakPtr"sv))))));
-ids::StructId const array_struct_id = TRY((((*this).find_struct_in_prelude((ByteString::must_from_utf8("Array"sv))))));
+ids::StructId const optional_struct_id = TRY((((*this).find_struct_in_prelude((ByteString::from_utf8_without_validation("Optional"sv))))));
+ids::StructId const weakptr_struct_id = TRY((((*this).find_struct_in_prelude((ByteString::from_utf8_without_validation("WeakPtr"sv))))));
+ids::StructId const array_struct_id = TRY((((*this).find_struct_in_prelude((ByteString::from_utf8_without_validation("Array"sv))))));
 ({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<void, ErrorOr<bool>>{
 auto&& __jakt_match_variant = *lhs_type;
@@ -7776,10 +7776,10 @@ ByteString const lhs_throw = ({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<ByteString,ErrorOr<bool>>{
 auto __jakt_enum_value = (lhs_can_throw);
 if (__jakt_enum_value == true) {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("Yes"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("Yes"sv)));
 }
 else {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("No"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("No"sv)));
 }
 }());
     if (_jakt_value.is_return())
@@ -7790,10 +7790,10 @@ ByteString const rhs_throw = ({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<ByteString,ErrorOr<bool>>{
 auto __jakt_enum_value = (rhs_can_throw);
 if (__jakt_enum_value == true) {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("Yes"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("Yes"sv)));
 }
 else if (__jakt_enum_value == false) {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("No"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("No"sv)));
 }
 VERIFY_NOT_REACHED();
 }());
@@ -8272,7 +8272,7 @@ return TRY((((((*this).program))->substitute_typevars_in_type(type_id,generic_in
 ErrorOr<types::CheckedBlock> typechecker::Typechecker::typecheck_block(parser::ParsedBlock const parsed_block,ids::ScopeId const parent_scope_id,types::SafetyMode const safety_mode,JaktInternal::Optional<ids::TypeId> const yield_type_hint) {
 {
 bool const parent_throws = ((((*this).get_scope(parent_scope_id)))->can_throw);
-ids::ScopeId const block_scope_id = ((*this).create_scope(parent_scope_id,parent_throws,(ByteString::must_from_utf8("block"sv)),true));
+ids::ScopeId const block_scope_id = ((*this).create_scope(parent_scope_id,parent_throws,(ByteString::from_utf8_without_validation("block"sv)),true));
 types::CheckedBlock checked_block = types::CheckedBlock(DynamicArray<NonnullRefPtr<typename types::CheckedStatement>>::create_with({}),block_scope_id,types::BlockControlFlow::MayReturn(),ids::TypeId::none(),false);
 {
 JaktInternal::ArrayIterator<NonnullRefPtr<typename parser::ParsedStatement>> _magic = ((((parsed_block).stmts)).iterator());
@@ -8284,7 +8284,7 @@ break;
 NonnullRefPtr<typename parser::ParsedStatement> parsed_statement = (_magic_value.value());
 {
 if ((!(((((checked_block).control_flow)).is_reachable())))){
-((*this).error((ByteString::must_from_utf8("Unreachable code"sv)),((parsed_statement)->span())));
+((*this).error((ByteString::from_utf8_without_validation("Unreachable code"sv)),((parsed_statement)->span())));
 }
 NonnullRefPtr<typename types::CheckedStatement> const checked_statement = TRY((((*this).typecheck_statement(parsed_statement,block_scope_id,safety_mode,yield_type_hint))));
 (((checked_block).control_flow) = ((((checked_block).control_flow)).updated(((*this).statement_control_flow(checked_statement)))));
@@ -8379,7 +8379,7 @@ break;
 }
 
 }
-return utility::join(ss,(ByteString::must_from_utf8(" -> "sv)));
+return utility::join(ss,(ByteString::from_utf8_without_validation(" -> "sv)));
 }
 }
 
@@ -8427,7 +8427,7 @@ if ((((value).has_value()) && (((value.value())).__jakt_init_index() == 5 /* Jus
 types::Value const resolved_value = ((value.value())).as.JustValue.value;
 return ((*this).find_or_add_type_id(types::Type::Const(parser::CheckedQualifiers(false),resolved_value)));
 }
-((*this).error((ByteString::must_from_utf8("Could not evaluate const expression"sv)),((expr)->span())));
+((*this).error((ByteString::from_utf8_without_validation("Could not evaluate const expression"sv)),((expr)->span())));
 return ((*this).find_or_add_type_id(types::Type::Unknown(parser::CheckedQualifiers(false))));
 }
 };/*case end*/
@@ -8523,52 +8523,52 @@ return ((*this).with_qualifiers(((*this).typecheck_type_qualifiers(((parsed_type
 __jakt_var_514 = ({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<ids::TypeId,ErrorOr<ids::TypeId>>{
 auto __jakt_enum_value = (name);
-if (__jakt_enum_value == (ByteString::must_from_utf8("i8"sv))) {
+if (__jakt_enum_value == (ByteString::from_utf8_without_validation("i8"sv))) {
 return JaktInternal::ExplicitValue(types::builtin(types::BuiltinType::I8()));
 }
-else if (__jakt_enum_value == (ByteString::must_from_utf8("i16"sv))) {
+else if (__jakt_enum_value == (ByteString::from_utf8_without_validation("i16"sv))) {
 return JaktInternal::ExplicitValue(types::builtin(types::BuiltinType::I16()));
 }
-else if (__jakt_enum_value == (ByteString::must_from_utf8("i32"sv))) {
+else if (__jakt_enum_value == (ByteString::from_utf8_without_validation("i32"sv))) {
 return JaktInternal::ExplicitValue(types::builtin(types::BuiltinType::I32()));
 }
-else if (__jakt_enum_value == (ByteString::must_from_utf8("i64"sv))) {
+else if (__jakt_enum_value == (ByteString::from_utf8_without_validation("i64"sv))) {
 return JaktInternal::ExplicitValue(types::builtin(types::BuiltinType::I64()));
 }
-else if (__jakt_enum_value == (ByteString::must_from_utf8("u8"sv))) {
+else if (__jakt_enum_value == (ByteString::from_utf8_without_validation("u8"sv))) {
 return JaktInternal::ExplicitValue(types::builtin(types::BuiltinType::U8()));
 }
-else if (__jakt_enum_value == (ByteString::must_from_utf8("u16"sv))) {
+else if (__jakt_enum_value == (ByteString::from_utf8_without_validation("u16"sv))) {
 return JaktInternal::ExplicitValue(types::builtin(types::BuiltinType::U16()));
 }
-else if (__jakt_enum_value == (ByteString::must_from_utf8("u32"sv))) {
+else if (__jakt_enum_value == (ByteString::from_utf8_without_validation("u32"sv))) {
 return JaktInternal::ExplicitValue(types::builtin(types::BuiltinType::U32()));
 }
-else if (__jakt_enum_value == (ByteString::must_from_utf8("u64"sv))) {
+else if (__jakt_enum_value == (ByteString::from_utf8_without_validation("u64"sv))) {
 return JaktInternal::ExplicitValue(types::builtin(types::BuiltinType::U64()));
 }
-else if (__jakt_enum_value == (ByteString::must_from_utf8("f32"sv))) {
+else if (__jakt_enum_value == (ByteString::from_utf8_without_validation("f32"sv))) {
 return JaktInternal::ExplicitValue(types::builtin(types::BuiltinType::F32()));
 }
-else if (__jakt_enum_value == (ByteString::must_from_utf8("f64"sv))) {
+else if (__jakt_enum_value == (ByteString::from_utf8_without_validation("f64"sv))) {
 return JaktInternal::ExplicitValue(types::builtin(types::BuiltinType::F64()));
 }
-else if (__jakt_enum_value == (ByteString::must_from_utf8("c_char"sv))) {
+else if (__jakt_enum_value == (ByteString::from_utf8_without_validation("c_char"sv))) {
 return JaktInternal::ExplicitValue(types::builtin(types::BuiltinType::CChar()));
 }
-else if (__jakt_enum_value == (ByteString::must_from_utf8("c_int"sv))) {
+else if (__jakt_enum_value == (ByteString::from_utf8_without_validation("c_int"sv))) {
 return JaktInternal::ExplicitValue(types::builtin(types::BuiltinType::CInt()));
 }
-else if (__jakt_enum_value == (ByteString::must_from_utf8("usize"sv))) {
+else if (__jakt_enum_value == (ByteString::from_utf8_without_validation("usize"sv))) {
 return JaktInternal::ExplicitValue(types::builtin(types::BuiltinType::Usize()));
 }
-else if (__jakt_enum_value == (ByteString::must_from_utf8("bool"sv))) {
+else if (__jakt_enum_value == (ByteString::from_utf8_without_validation("bool"sv))) {
 return JaktInternal::ExplicitValue(types::builtin(types::BuiltinType::Bool()));
 }
-else if (__jakt_enum_value == (ByteString::must_from_utf8("void"sv))) {
+else if (__jakt_enum_value == (ByteString::from_utf8_without_validation("void"sv))) {
 return JaktInternal::ExplicitValue(types::builtin(types::BuiltinType::Void()));
 }
-else if (__jakt_enum_value == (ByteString::must_from_utf8("never"sv))) {
+else if (__jakt_enum_value == (ByteString::from_utf8_without_validation("never"sv))) {
 return JaktInternal::ExplicitValue(types::builtin(types::BuiltinType::Never()));
 }
 else {
@@ -8576,7 +8576,7 @@ return JaktInternal::ExplicitValue(({ Optional<ids::TypeId> __jakt_var_515; {
 if (((maybe_type_and_scope).has_value())){
 return (((maybe_type_and_scope.value())).template get<0>());
 }
-if ((((((*this).get_scope(scope_id)))->is_from_generated_code) && ((name) == ((ByteString::must_from_utf8("unknown"sv)))))){
+if ((((((*this).get_scope(scope_id)))->is_from_generated_code) && ((name) == ((ByteString::from_utf8_without_validation("unknown"sv)))))){
 return types::builtin(types::BuiltinType::Unknown());
 }
 ((*this).error(__jakt_format((StringView::from_string_literal("Unknown type ‘{}’ in scope {}"sv)),name,((*this).debug_description_of(scope_id))),span));
@@ -8621,7 +8621,7 @@ NonnullRefPtr<typename parser::ParsedType> parsed_type = (_magic_value.value());
 }
 }
 
-ids::StructId const tuple_struct_id = TRY((((*this).find_struct_in_prelude((ByteString::must_from_utf8("Tuple"sv))))));
+ids::StructId const tuple_struct_id = TRY((((*this).find_struct_in_prelude((ByteString::from_utf8_without_validation("Tuple"sv))))));
 __jakt_var_517 = ((*this).find_or_add_type_id(types::Type::GenericInstance(parser::CheckedQualifiers(false),tuple_struct_id,checked_types))); goto __jakt_label_455;
 
 }
@@ -8632,7 +8632,7 @@ auto&& __jakt_match_value = __jakt_match_variant.as.JaktArray;NonnullRefPtr<type
 utility::Span const& span = __jakt_match_value.span;
 return JaktInternal::ExplicitValue(({ Optional<ids::TypeId> __jakt_var_518; {
 ids::TypeId const inner_type_id = TRY((((*this).typecheck_typename(inner,scope_id,name))));
-ids::StructId const array_struct_id = TRY((((*this).find_struct_in_prelude((ByteString::must_from_utf8("Array"sv))))));
+ids::StructId const array_struct_id = TRY((((*this).find_struct_in_prelude((ByteString::from_utf8_without_validation("Array"sv))))));
 __jakt_var_518 = ((*this).find_or_add_type_id(types::Type::GenericInstance(parser::CheckedQualifiers(false),array_struct_id,DynamicArray<ids::TypeId>::create_with({inner_type_id})))); goto __jakt_label_456;
 
 }
@@ -8645,9 +8645,9 @@ utility::Span const& span = __jakt_match_value.span;
 return JaktInternal::ExplicitValue(({ Optional<ids::TypeId> __jakt_var_519; {
 ids::TypeId const key_type_id = TRY((((*this).typecheck_typename(key,scope_id,name))));
 ids::TypeId const value_type_id = TRY((((*this).typecheck_typename(value,scope_id,name))));
-ids::StructId const dict_struct_id = TRY((((*this).find_struct_in_prelude((ByteString::must_from_utf8("Dictionary"sv))))));
-TRY((((*this).ensure_type_implements_trait(key_type_id,(ByteString::must_from_utf8("Hashable"sv)),JaktInternal::OptionalNone(),scope_id,span))));
-TRY((((*this).ensure_type_implements_trait(key_type_id,(ByteString::must_from_utf8("Equal"sv)),DynamicArray<ids::TypeId>::create_with({key_type_id}),scope_id,span))));
+ids::StructId const dict_struct_id = TRY((((*this).find_struct_in_prelude((ByteString::from_utf8_without_validation("Dictionary"sv))))));
+TRY((((*this).ensure_type_implements_trait(key_type_id,(ByteString::from_utf8_without_validation("Hashable"sv)),JaktInternal::OptionalNone(),scope_id,span))));
+TRY((((*this).ensure_type_implements_trait(key_type_id,(ByteString::from_utf8_without_validation("Equal"sv)),DynamicArray<ids::TypeId>::create_with({key_type_id}),scope_id,span))));
 __jakt_var_519 = ((*this).find_or_add_type_id(types::Type::GenericInstance(parser::CheckedQualifiers(false),dict_struct_id,DynamicArray<ids::TypeId>::create_with({key_type_id, value_type_id})))); goto __jakt_label_457;
 
 }
@@ -8658,9 +8658,9 @@ auto&& __jakt_match_value = __jakt_match_variant.as.Set;NonnullRefPtr<typename p
 utility::Span const& span = __jakt_match_value.span;
 return JaktInternal::ExplicitValue(({ Optional<ids::TypeId> __jakt_var_520; {
 ids::TypeId const inner_type_id = TRY((((*this).typecheck_typename(inner,scope_id,name))));
-ids::StructId const set_struct_id = TRY((((*this).find_struct_in_prelude((ByteString::must_from_utf8("Set"sv))))));
-TRY((((*this).ensure_type_implements_trait(inner_type_id,(ByteString::must_from_utf8("Hashable"sv)),JaktInternal::OptionalNone(),scope_id,span))));
-TRY((((*this).ensure_type_implements_trait(inner_type_id,(ByteString::must_from_utf8("Equal"sv)),DynamicArray<ids::TypeId>::create_with({inner_type_id}),scope_id,span))));
+ids::StructId const set_struct_id = TRY((((*this).find_struct_in_prelude((ByteString::from_utf8_without_validation("Set"sv))))));
+TRY((((*this).ensure_type_implements_trait(inner_type_id,(ByteString::from_utf8_without_validation("Hashable"sv)),JaktInternal::OptionalNone(),scope_id,span))));
+TRY((((*this).ensure_type_implements_trait(inner_type_id,(ByteString::from_utf8_without_validation("Equal"sv)),DynamicArray<ids::TypeId>::create_with({inner_type_id}),scope_id,span))));
 __jakt_var_520 = ((*this).find_or_add_type_id(types::Type::GenericInstance(parser::CheckedQualifiers(false),set_struct_id,DynamicArray<ids::TypeId>::create_with({inner_type_id})))); goto __jakt_label_458;
 
 }
@@ -8671,7 +8671,7 @@ auto&& __jakt_match_value = __jakt_match_variant.as.Optional;NonnullRefPtr<typen
 utility::Span const& span = __jakt_match_value.span;
 return JaktInternal::ExplicitValue(({ Optional<ids::TypeId> __jakt_var_521; {
 ids::TypeId const inner_type_id = TRY((((*this).typecheck_typename(inner,scope_id,name))));
-ids::StructId const optional_struct_id = TRY((((*this).find_struct_in_prelude((ByteString::must_from_utf8("Optional"sv))))));
+ids::StructId const optional_struct_id = TRY((((*this).find_struct_in_prelude((ByteString::from_utf8_without_validation("Optional"sv))))));
 __jakt_var_521 = ((*this).find_or_add_type_id(types::Type::GenericInstance(parser::CheckedQualifiers(false),optional_struct_id,DynamicArray<ids::TypeId>::create_with({inner_type_id})))); goto __jakt_label_459;
 
 }
@@ -8682,7 +8682,7 @@ auto&& __jakt_match_value = __jakt_match_variant.as.WeakPtr;NonnullRefPtr<typena
 utility::Span const& span = __jakt_match_value.span;
 return JaktInternal::ExplicitValue(({ Optional<ids::TypeId> __jakt_var_522; {
 ids::TypeId const inner_type_id = TRY((((*this).typecheck_typename(inner,scope_id,name))));
-ids::StructId const weakptr_struct_id = TRY((((*this).find_struct_in_prelude((ByteString::must_from_utf8("WeakPtr"sv))))));
+ids::StructId const weakptr_struct_id = TRY((((*this).find_struct_in_prelude((ByteString::from_utf8_without_validation("WeakPtr"sv))))));
 __jakt_var_522 = ((*this).find_or_add_type_id(types::Type::GenericInstance(parser::CheckedQualifiers(false),weakptr_struct_id,DynamicArray<ids::TypeId>::create_with({inner_type_id})))); goto __jakt_label_460;
 
 }
@@ -8741,7 +8741,7 @@ else {
 return JaktInternal::ExplicitValue(TRY((({ Optional<ByteString> __jakt_var_526;
 auto __jakt_var_527 = [&]() -> ErrorOr<ByteString> { return __jakt_format((StringView::from_string_literal("lambda{}"sv)),((((*this).lambda_count)++))); }();
 if (!__jakt_var_527.is_error()) __jakt_var_526 = __jakt_var_527.release_value();
-__jakt_var_526; }).try_value_or_lazy_evaluated([&]() -> ErrorOr<ByteString> { return (ByteString::must_from_utf8(""sv)); }))));
+__jakt_var_526; }).try_value_or_lazy_evaluated([&]() -> ErrorOr<ByteString> { return (ByteString::from_utf8_without_validation(""sv)); }))));
 }
 }());
     if (_jakt_value.is_return())
@@ -9008,11 +9008,11 @@ case 0 /* PreIncrement */: {
 {
 if (((*this).is_integer(expr_type_id))){
 if ((!(((checked_expr)->is_mutable(((*this).program)))))){
-((*this).error((ByteString::must_from_utf8("Increment/decrement of immutable variable"sv)),span));
+((*this).error((ByteString::from_utf8_without_validation("Increment/decrement of immutable variable"sv)),span));
 }
 }
 else {
-((*this).error((ByteString::must_from_utf8("Increment/decrement of non-numeric value"sv)),span));
+((*this).error((ByteString::from_utf8_without_validation("Increment/decrement of non-numeric value"sv)),span));
 }
 
 }
@@ -9022,11 +9022,11 @@ case 1 /* PostIncrement */: {
 {
 if (((*this).is_integer(expr_type_id))){
 if ((!(((checked_expr)->is_mutable(((*this).program)))))){
-((*this).error((ByteString::must_from_utf8("Increment/decrement of immutable variable"sv)),span));
+((*this).error((ByteString::from_utf8_without_validation("Increment/decrement of immutable variable"sv)),span));
 }
 }
 else {
-((*this).error((ByteString::must_from_utf8("Increment/decrement of non-numeric value"sv)),span));
+((*this).error((ByteString::from_utf8_without_validation("Increment/decrement of non-numeric value"sv)),span));
 }
 
 }
@@ -9036,11 +9036,11 @@ case 2 /* PreDecrement */: {
 {
 if (((*this).is_integer(expr_type_id))){
 if ((!(((checked_expr)->is_mutable(((*this).program)))))){
-((*this).error((ByteString::must_from_utf8("Increment/decrement of immutable variable"sv)),span));
+((*this).error((ByteString::from_utf8_without_validation("Increment/decrement of immutable variable"sv)),span));
 }
 }
 else {
-((*this).error((ByteString::must_from_utf8("Increment/decrement of non-numeric value"sv)),span));
+((*this).error((ByteString::from_utf8_without_validation("Increment/decrement of non-numeric value"sv)),span));
 }
 
 }
@@ -9050,11 +9050,11 @@ case 3 /* PostDecrement */: {
 {
 if (((*this).is_integer(expr_type_id))){
 if ((!(((checked_expr)->is_mutable(((*this).program)))))){
-((*this).error((ByteString::must_from_utf8("Increment/decrement of immutable variable"sv)),span));
+((*this).error((ByteString::from_utf8_without_validation("Increment/decrement of immutable variable"sv)),span));
 }
 }
 else {
-((*this).error((ByteString::must_from_utf8("Increment/decrement of non-numeric value"sv)),span));
+((*this).error((ByteString::from_utf8_without_validation("Increment/decrement of non-numeric value"sv)),span));
 }
 
 }
@@ -9063,7 +9063,7 @@ return JaktInternal::ExplicitValue<void>();
 case 9 /* LogicalNot */: {
 {
 if ((!(TRY((((*this).check_types_for_compat(types::builtin(types::BuiltinType::Bool()),((checked_expr)->type()),((((*this).generic_inferences))),span))))))){
-((*this).error((ByteString::must_from_utf8("Cannot use a logical Not on a value of non-boolean type"sv)),span));
+((*this).error((ByteString::from_utf8_without_validation("Cannot use a logical Not on a value of non-boolean type"sv)),span));
 }
 return types::CheckedExpression::UnaryOp(JaktInternal::OptionalNone(),checked_expr,checked_op,span,expr_type_id);
 }
@@ -9133,7 +9133,7 @@ return JaktInternal::ExplicitValue<void>();
 case 8 /* MutableReference */: {
 {
 if ((!(((checked_expr)->is_mutable(((*this).program)))))){
-((*this).error((ByteString::must_from_utf8("Cannot make mutable reference to immutable value"sv)),span));
+((*this).error((ByteString::from_utf8_without_validation("Cannot make mutable reference to immutable value"sv)),span));
 }
 return types::CheckedExpression::UnaryOp(JaktInternal::OptionalNone(),checked_expr,checked_op,span,((*this).find_or_add_type_id(types::Type::MutableReference(parser::CheckedQualifiers(false),expr_type_id))));
 }
@@ -9149,7 +9149,7 @@ case 26 /* RawPtr */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.RawPtr;ids::TypeId const& type_id = __jakt_match_value.value;
 {
 if (((safety_mode).__jakt_init_index() == 0 /* Safe */)){
-((*this).error((ByteString::must_from_utf8("Dereference of raw pointer outside of unsafe block"sv)),span));
+((*this).error((ByteString::from_utf8_without_validation("Dereference of raw pointer outside of unsafe block"sv)),span));
 }
 return types::CheckedExpression::UnaryOp(JaktInternal::OptionalNone(),checked_expr,checked_op,span,type_id);
 }
@@ -9275,7 +9275,7 @@ return JaktInternal::ExplicitValue(types::CheckedNumericConstant::I64((infallibl
 };/*case end*/
 default: {
 {
-utility::panic((ByteString::must_from_utf8("Unreachable"sv)));
+utility::panic((ByteString::from_utf8_without_validation("Unreachable"sv)));
 }
 };/*case end*/
 }/*switch end*/
@@ -9309,12 +9309,12 @@ if (((checked_lhs)->__jakt_init_index() == 24 /* Var */)){
 NonnullRefPtr<types::CheckedVariable> const var = (checked_lhs)->as.Var.var;
 utility::Span const span = (checked_lhs)->as.Var.span;
 if ((!(((var)->is_mutable)))){
-((*this).error_with_hint((ByteString::must_from_utf8("left-hand side of ??= must be a mutable variable"sv)),span,(ByteString::must_from_utf8("This variable isn't marked as mutable"sv)),((var)->definition_span)));
+((*this).error_with_hint((ByteString::from_utf8_without_validation("left-hand side of ??= must be a mutable variable"sv)),span,(ByteString::from_utf8_without_validation("This variable isn't marked as mutable"sv)),((var)->definition_span)));
 return (Tuple{checked_operator, types::unknown_type_id()});
 }
 }
 else {
-((*this).error((ByteString::must_from_utf8("left-hand side of ??= must be a mutable variable"sv)),span));
+((*this).error((ByteString::from_utf8_without_validation("left-hand side of ??= must be a mutable variable"sv)),span));
 return (Tuple{checked_operator, types::unknown_type_id()});
 }
 
@@ -9322,7 +9322,7 @@ return (Tuple{checked_operator, types::unknown_type_id()});
 if (((((*this).get_type(lhs_type_id)))->__jakt_init_index() == 20 /* GenericInstance */)){
 ids::StructId const id = (((*this).get_type(lhs_type_id)))->as.GenericInstance.id;
 JaktInternal::DynamicArray<ids::TypeId> const args = (((*this).get_type(lhs_type_id)))->as.GenericInstance.args;
-if (((id).equals(TRY((((*this).find_struct_in_prelude((ByteString::must_from_utf8("Optional"sv))))))))){
+if (((id).equals(TRY((((*this).find_struct_in_prelude((ByteString::from_utf8_without_validation("Optional"sv))))))))){
 if (((lhs_type_id).equals(rhs_type_id))){
 return (Tuple{checked_operator, lhs_type_id});
 }
@@ -9332,12 +9332,12 @@ return (Tuple{checked_operator, inner_type_id});
 }
 }
 else {
-((*this).error_with_hint(__jakt_format((StringView::from_string_literal("None coalescing (??) with incompatible types (‘{}’ and ‘{}’)"sv)),TRY((((*this).type_name(lhs_type_id,false)))),TRY((((*this).type_name(rhs_type_id,false))))),span,(ByteString::must_from_utf8("Left side of ?? must be an Optional but isn't"sv)),lhs_span));
+((*this).error_with_hint(__jakt_format((StringView::from_string_literal("None coalescing (??) with incompatible types (‘{}’ and ‘{}’)"sv)),TRY((((*this).type_name(lhs_type_id,false)))),TRY((((*this).type_name(rhs_type_id,false))))),span,(ByteString::from_utf8_without_validation("Left side of ?? must be an Optional but isn't"sv)),lhs_span));
 }
 
 }
 else {
-((*this).error_with_hint(__jakt_format((StringView::from_string_literal("None coalescing (??) with incompatible types (‘{}’ and ‘{}’)"sv)),TRY((((*this).type_name(lhs_type_id,false)))),TRY((((*this).type_name(rhs_type_id,false))))),span,(ByteString::must_from_utf8("Left side of ?? must be an Optional but isn't"sv)),lhs_span));
+((*this).error_with_hint(__jakt_format((StringView::from_string_literal("None coalescing (??) with incompatible types (‘{}’ and ‘{}’)"sv)),TRY((((*this).type_name(lhs_type_id,false)))),TRY((((*this).type_name(rhs_type_id,false))))),span,(ByteString::from_utf8_without_validation("Left side of ?? must be an Optional but isn't"sv)),lhs_span));
 }
 
 ((*this).error(__jakt_format((StringView::from_string_literal("None coalescing (??) with incompatible types (‘{}’ and ‘{}’)"sv)),TRY((((*this).type_name(lhs_type_id,false)))),TRY((((*this).type_name(rhs_type_id,false))))),span));
@@ -9352,12 +9352,12 @@ if (((checked_lhs)->__jakt_init_index() == 24 /* Var */)){
 NonnullRefPtr<types::CheckedVariable> const var = (checked_lhs)->as.Var.var;
 utility::Span const span = (checked_lhs)->as.Var.span;
 if ((!(((var)->is_mutable)))){
-((*this).error_with_hint((ByteString::must_from_utf8("left-hand side of ??= must be a mutable variable"sv)),span,(ByteString::must_from_utf8("This variable isn't marked as mutable"sv)),((var)->definition_span)));
+((*this).error_with_hint((ByteString::from_utf8_without_validation("left-hand side of ??= must be a mutable variable"sv)),span,(ByteString::from_utf8_without_validation("This variable isn't marked as mutable"sv)),((var)->definition_span)));
 return (Tuple{checked_operator, types::unknown_type_id()});
 }
 }
 else {
-((*this).error((ByteString::must_from_utf8("left-hand side of ??= must be a mutable variable"sv)),span));
+((*this).error((ByteString::from_utf8_without_validation("left-hand side of ??= must be a mutable variable"sv)),span));
 return (Tuple{checked_operator, types::unknown_type_id()});
 }
 
@@ -9365,7 +9365,7 @@ return (Tuple{checked_operator, types::unknown_type_id()});
 if (((((*this).get_type(lhs_type_id)))->__jakt_init_index() == 20 /* GenericInstance */)){
 ids::StructId const id = (((*this).get_type(lhs_type_id)))->as.GenericInstance.id;
 JaktInternal::DynamicArray<ids::TypeId> const args = (((*this).get_type(lhs_type_id)))->as.GenericInstance.args;
-if (((id).equals(TRY((((*this).find_struct_in_prelude((ByteString::must_from_utf8("Optional"sv))))))))){
+if (((id).equals(TRY((((*this).find_struct_in_prelude((ByteString::from_utf8_without_validation("Optional"sv))))))))){
 if (((lhs_type_id).equals(rhs_type_id))){
 return (Tuple{checked_operator, lhs_type_id});
 }
@@ -9375,12 +9375,12 @@ return (Tuple{checked_operator, inner_type_id});
 }
 }
 else {
-((*this).error_with_hint(__jakt_format((StringView::from_string_literal("None coalescing (??) with incompatible types (‘{}’ and ‘{}’)"sv)),TRY((((*this).type_name(lhs_type_id,false)))),TRY((((*this).type_name(rhs_type_id,false))))),span,(ByteString::must_from_utf8("Left side of ?? must be an Optional but isn't"sv)),lhs_span));
+((*this).error_with_hint(__jakt_format((StringView::from_string_literal("None coalescing (??) with incompatible types (‘{}’ and ‘{}’)"sv)),TRY((((*this).type_name(lhs_type_id,false)))),TRY((((*this).type_name(rhs_type_id,false))))),span,(ByteString::from_utf8_without_validation("Left side of ?? must be an Optional but isn't"sv)),lhs_span));
 }
 
 }
 else {
-((*this).error_with_hint(__jakt_format((StringView::from_string_literal("None coalescing (??) with incompatible types (‘{}’ and ‘{}’)"sv)),TRY((((*this).type_name(lhs_type_id,false)))),TRY((((*this).type_name(rhs_type_id,false))))),span,(ByteString::must_from_utf8("Left side of ?? must be an Optional but isn't"sv)),lhs_span));
+((*this).error_with_hint(__jakt_format((StringView::from_string_literal("None coalescing (??) with incompatible types (‘{}’ and ‘{}’)"sv)),TRY((((*this).type_name(lhs_type_id,false)))),TRY((((*this).type_name(rhs_type_id,false))))),span,(ByteString::from_utf8_without_validation("Left side of ?? must be an Optional but isn't"sv)),lhs_span));
 }
 
 ((*this).error(__jakt_format((StringView::from_string_literal("None coalescing (??) with incompatible types (‘{}’ and ‘{}’)"sv)),TRY((((*this).type_name(lhs_type_id,false)))),TRY((((*this).type_name(rhs_type_id,false))))),span));
@@ -9391,10 +9391,10 @@ return JaktInternal::ExplicitValue<void>();
 case 18 /* LogicalAnd */: {
 {
 if ((!(((lhs_type_id).equals(types::builtin(types::BuiltinType::Bool())))))){
-((*this).error((ByteString::must_from_utf8("left side of logical binary operation is not a boolean"sv)),lhs_span));
+((*this).error((ByteString::from_utf8_without_validation("left side of logical binary operation is not a boolean"sv)),lhs_span));
 }
 if ((!(((rhs_type_id).equals(types::builtin(types::BuiltinType::Bool())))))){
-((*this).error((ByteString::must_from_utf8("right side of logical binary operation is not a boolean"sv)),rhs_span));
+((*this).error((ByteString::from_utf8_without_validation("right side of logical binary operation is not a boolean"sv)),rhs_span));
 }
 (type_id = types::builtin(types::BuiltinType::Bool()));
 }
@@ -9403,10 +9403,10 @@ return JaktInternal::ExplicitValue<void>();
 case 19 /* LogicalOr */: {
 {
 if ((!(((lhs_type_id).equals(types::builtin(types::BuiltinType::Bool())))))){
-((*this).error((ByteString::must_from_utf8("left side of logical binary operation is not a boolean"sv)),lhs_span));
+((*this).error((ByteString::from_utf8_without_validation("left side of logical binary operation is not a boolean"sv)),lhs_span));
 }
 if ((!(((rhs_type_id).equals(types::builtin(types::BuiltinType::Bool())))))){
-((*this).error((ByteString::must_from_utf8("right side of logical binary operation is not a boolean"sv)),rhs_span));
+((*this).error((ByteString::from_utf8_without_validation("right side of logical binary operation is not a boolean"sv)),rhs_span));
 }
 (type_id = types::builtin(types::BuiltinType::Bool()));
 }
@@ -9415,7 +9415,7 @@ return JaktInternal::ExplicitValue<void>();
 case 21 /* Assign */: {
 {
 if ((!(((checked_lhs)->is_mutable(((*this).program)))))){
-((*this).error((ByteString::must_from_utf8("Assignment to immutable variable"sv)),((checked_lhs)->span())));
+((*this).error((ByteString::from_utf8_without_validation("Assignment to immutable variable"sv)),((checked_lhs)->span())));
 return (Tuple{checked_operator, lhs_type_id});
 }
 if (((checked_rhs)->__jakt_init_index() == 25 /* OptionalNone */)){
@@ -9424,15 +9424,15 @@ ids::TypeId const type_id = (checked_rhs)->as.OptionalNone.type_id;
 if (((((*this).get_type(lhs_type_id)))->__jakt_init_index() == 20 /* GenericInstance */)){
 ids::StructId const id = (((*this).get_type(lhs_type_id)))->as.GenericInstance.id;
 JaktInternal::DynamicArray<ids::TypeId> const args = (((*this).get_type(lhs_type_id)))->as.GenericInstance.args;
-if (((id).equals(TRY((((*this).find_struct_in_prelude((ByteString::must_from_utf8("Optional"sv))))))))){
+if (((id).equals(TRY((((*this).find_struct_in_prelude((ByteString::from_utf8_without_validation("Optional"sv))))))))){
 return (Tuple{checked_operator, lhs_type_id});
 }
-if ((!(((id).equals(TRY((((*this).find_struct_in_prelude((ByteString::must_from_utf8("WeakPtr"sv))))))))))){
-((*this).error((ByteString::must_from_utf8("Cannot assign None to a non-optional type"sv)),span));
+if ((!(((id).equals(TRY((((*this).find_struct_in_prelude((ByteString::from_utf8_without_validation("WeakPtr"sv))))))))))){
+((*this).error((ByteString::from_utf8_without_validation("Cannot assign None to a non-optional type"sv)),span));
 }
 }
 else {
-((*this).error((ByteString::must_from_utf8("Cannot assign None to a non-optional type"sv)),span));
+((*this).error((ByteString::from_utf8_without_validation("Cannot assign None to a non-optional type"sv)),span));
 }
 
 }
@@ -9440,7 +9440,7 @@ NonnullRefPtr<typename types::Type> const lhs_type = TRY((((*this).unwrap_type_f
 if (((lhs_type)->__jakt_init_index() == 20 /* GenericInstance */)){
 ids::StructId const id = (lhs_type)->as.GenericInstance.id;
 JaktInternal::DynamicArray<ids::TypeId> const args = (lhs_type)->as.GenericInstance.args;
-if ((((((((((*this).program))->get_struct(id))).name)) == ((ByteString::must_from_utf8("WeakPtr"sv)))) && (!(((lhs_type_id).equals(rhs_type_id)))))){
+if ((((((((((*this).program))->get_struct(id))).name)) == ((ByteString::from_utf8_without_validation("WeakPtr"sv)))) && (!(((lhs_type_id).equals(rhs_type_id)))))){
 JaktInternal::Optional<ids::TypeId> const unified_type = TRY((((*this).unify(((args)[static_cast<i64>(0LL)]),lhs_span,((checked_rhs)->type()),rhs_span))));
 if (((unified_type).has_value())){
 return (Tuple{checked_operator, (unified_type.value())});
@@ -9464,67 +9464,67 @@ JaktInternal::Tuple<JaktInternal::DynamicArray<ByteString>,bool> const trait_nam
 auto&& __jakt_match_variant = op;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 0 /* Add */: {
-return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("Add"sv)), (ByteString::must_from_utf8("ThrowingAdd"sv))}), false}));
+return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("Add"sv)), (ByteString::from_utf8_without_validation("ThrowingAdd"sv))}), false}));
 };/*case end*/
 case 1 /* Subtract */: {
-return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("Subtract"sv)), (ByteString::must_from_utf8("ThrowingSubtract"sv))}), false}));
+return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("Subtract"sv)), (ByteString::from_utf8_without_validation("ThrowingSubtract"sv))}), false}));
 };/*case end*/
 case 2 /* Multiply */: {
-return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("Multiply"sv)), (ByteString::must_from_utf8("ThrowingMultiply"sv))}), false}));
+return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("Multiply"sv)), (ByteString::from_utf8_without_validation("ThrowingMultiply"sv))}), false}));
 };/*case end*/
 case 3 /* Divide */: {
-return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("Divide"sv)), (ByteString::must_from_utf8("ThrowingDivide"sv))}), false}));
+return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("Divide"sv)), (ByteString::from_utf8_without_validation("ThrowingDivide"sv))}), false}));
 };/*case end*/
 case 4 /* Modulo */: {
-return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("Modulo"sv)), (ByteString::must_from_utf8("ThrowingModulo"sv))}), false}));
+return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("Modulo"sv)), (ByteString::from_utf8_without_validation("ThrowingModulo"sv))}), false}));
 };/*case end*/
 case 5 /* LessThan */: {
-return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("Compare"sv)), (ByteString::must_from_utf8("ThrowingCompare"sv))}), false}));
+return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("Compare"sv)), (ByteString::from_utf8_without_validation("ThrowingCompare"sv))}), false}));
 };/*case end*/
 case 6 /* LessThanOrEqual */: {
-return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("Compare"sv)), (ByteString::must_from_utf8("ThrowingCompare"sv))}), false}));
+return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("Compare"sv)), (ByteString::from_utf8_without_validation("ThrowingCompare"sv))}), false}));
 };/*case end*/
 case 7 /* GreaterThan */: {
-return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("Compare"sv)), (ByteString::must_from_utf8("ThrowingCompare"sv))}), false}));
+return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("Compare"sv)), (ByteString::from_utf8_without_validation("ThrowingCompare"sv))}), false}));
 };/*case end*/
 case 8 /* GreaterThanOrEqual */: {
-return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("Compare"sv)), (ByteString::must_from_utf8("ThrowingCompare"sv))}), false}));
+return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("Compare"sv)), (ByteString::from_utf8_without_validation("ThrowingCompare"sv))}), false}));
 };/*case end*/
 case 9 /* Equal */: {
-return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("Equal"sv)), (ByteString::must_from_utf8("ThrowingEqual"sv))}), false}));
+return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("Equal"sv)), (ByteString::from_utf8_without_validation("ThrowingEqual"sv))}), false}));
 };/*case end*/
 case 10 /* NotEqual */: {
-return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("Equal"sv)), (ByteString::must_from_utf8("ThrowingEqual"sv))}), false}));
+return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("Equal"sv)), (ByteString::from_utf8_without_validation("ThrowingEqual"sv))}), false}));
 };/*case end*/
 case 27 /* AddAssign */: {
-return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("AddAssign"sv)), (ByteString::must_from_utf8("ThrowingAddAssign"sv))}), true}));
+return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("AddAssign"sv)), (ByteString::from_utf8_without_validation("ThrowingAddAssign"sv))}), true}));
 };/*case end*/
 case 28 /* SubtractAssign */: {
-return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("SubtractAssign"sv)), (ByteString::must_from_utf8("ThrowingSubtractAssign"sv))}), true}));
+return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("SubtractAssign"sv)), (ByteString::from_utf8_without_validation("ThrowingSubtractAssign"sv))}), true}));
 };/*case end*/
 case 29 /* MultiplyAssign */: {
-return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("MultiplyAssign"sv)), (ByteString::must_from_utf8("ThrowingMultiplyAssign"sv))}), true}));
+return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("MultiplyAssign"sv)), (ByteString::from_utf8_without_validation("ThrowingMultiplyAssign"sv))}), true}));
 };/*case end*/
 case 31 /* DivideAssign */: {
-return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("DivideAssign"sv)), (ByteString::must_from_utf8("ThrowingDivideAssign"sv))}), true}));
+return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("DivideAssign"sv)), (ByteString::from_utf8_without_validation("ThrowingDivideAssign"sv))}), true}));
 };/*case end*/
 case 30 /* ModuloAssign */: {
-return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("ModuloAssign"sv)), (ByteString::must_from_utf8("ThrowingModuloAssign"sv))}), true}));
+return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("ModuloAssign"sv)), (ByteString::from_utf8_without_validation("ThrowingModuloAssign"sv))}), true}));
 };/*case end*/
 case 22 /* BitwiseAndAssign */: {
-return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("BitwiseAndAssign"sv)), (ByteString::must_from_utf8("ThrowingBitwiseAndAssign"sv))}), true}));
+return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("BitwiseAndAssign"sv)), (ByteString::from_utf8_without_validation("ThrowingBitwiseAndAssign"sv))}), true}));
 };/*case end*/
 case 23 /* BitwiseOrAssign */: {
-return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("BitwiseOrAssign"sv)), (ByteString::must_from_utf8("ThrowingBitwiseOrAssign"sv))}), true}));
+return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("BitwiseOrAssign"sv)), (ByteString::from_utf8_without_validation("ThrowingBitwiseOrAssign"sv))}), true}));
 };/*case end*/
 case 24 /* BitwiseXorAssign */: {
-return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("BitwiseXorAssign"sv)), (ByteString::must_from_utf8("ThrowingBitwiseXorAssign"sv))}), true}));
+return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("BitwiseXorAssign"sv)), (ByteString::from_utf8_without_validation("ThrowingBitwiseXorAssign"sv))}), true}));
 };/*case end*/
 case 25 /* BitwiseLeftShiftAssign */: {
-return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("BitwiseLeftShiftAssign"sv)), (ByteString::must_from_utf8("ThrowingBitwiseLeftShiftAssign"sv))}), true}));
+return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("BitwiseLeftShiftAssign"sv)), (ByteString::from_utf8_without_validation("ThrowingBitwiseLeftShiftAssign"sv))}), true}));
 };/*case end*/
 case 26 /* BitwiseRightShiftAssign */: {
-return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("BitwiseRightShiftAssign"sv)), (ByteString::must_from_utf8("ThrowingBitwiseRightShiftAssign"sv))}), true}));
+return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("BitwiseRightShiftAssign"sv)), (ByteString::from_utf8_without_validation("ThrowingBitwiseRightShiftAssign"sv))}), true}));
 };/*case end*/
 default: {
 return JaktInternal::ExplicitValue((Tuple{empty_array, false}));
@@ -9544,70 +9544,70 @@ ByteString const function_name = ({
 auto&& __jakt_match_variant = op;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 0 /* Add */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("add"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("add"sv)));
 };/*case end*/
 case 1 /* Subtract */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("subtract"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("subtract"sv)));
 };/*case end*/
 case 2 /* Multiply */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("multiply"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("multiply"sv)));
 };/*case end*/
 case 3 /* Divide */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("divide"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("divide"sv)));
 };/*case end*/
 case 4 /* Modulo */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("modulo"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("modulo"sv)));
 };/*case end*/
 case 5 /* LessThan */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("less_than"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("less_than"sv)));
 };/*case end*/
 case 6 /* LessThanOrEqual */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("less_than_or_equal"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("less_than_or_equal"sv)));
 };/*case end*/
 case 7 /* GreaterThan */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("greater_than"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("greater_than"sv)));
 };/*case end*/
 case 8 /* GreaterThanOrEqual */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("greater_than_or_equal"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("greater_than_or_equal"sv)));
 };/*case end*/
 case 9 /* Equal */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("equals"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("equals"sv)));
 };/*case end*/
 case 10 /* NotEqual */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("not_equals"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("not_equals"sv)));
 };/*case end*/
 case 27 /* AddAssign */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("add_assign"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("add_assign"sv)));
 };/*case end*/
 case 28 /* SubtractAssign */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("subtract_assign"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("subtract_assign"sv)));
 };/*case end*/
 case 29 /* MultiplyAssign */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("multiply_assign"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("multiply_assign"sv)));
 };/*case end*/
 case 31 /* DivideAssign */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("divide_assign"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("divide_assign"sv)));
 };/*case end*/
 case 30 /* ModuloAssign */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("modulo_assign"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("modulo_assign"sv)));
 };/*case end*/
 case 22 /* BitwiseAndAssign */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("bitwise_and_assign"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("bitwise_and_assign"sv)));
 };/*case end*/
 case 23 /* BitwiseOrAssign */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("bitwise_or_assign"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("bitwise_or_assign"sv)));
 };/*case end*/
 case 24 /* BitwiseXorAssign */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("bitwise_xor_assign"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("bitwise_xor_assign"sv)));
 };/*case end*/
 case 25 /* BitwiseLeftShiftAssign */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("bitwise_left_shift_assign"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("bitwise_left_shift_assign"sv)));
 };/*case end*/
 case 26 /* BitwiseRightShiftAssign */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("bitwise_right_shift_assign"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("bitwise_right_shift_assign"sv)));
 };/*case end*/
 default: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8(""sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation(""sv)));
 };/*case end*/
 }/*switch end*/
 }()
@@ -9619,8 +9619,8 @@ return JaktInternal::ExplicitValue((ByteString::must_from_utf8(""sv)));
 JaktInternal::Optional<typechecker::TraitImplementationDescriptor> const add_trait_implementation = TRY((((*this).find_any_singular_trait_implementation(lhs_type_id,trait_names,scope_id,lhs_span,DynamicArray<ids::TypeId>::create_with({rhs_type_id})))));
 if (((add_trait_implementation).has_value())){
 typechecker::TraitImplementationDescriptor const implementation = (add_trait_implementation.value());
-if ((((((implementation).trait_name)).starts_with((ByteString::must_from_utf8("Throwing"sv)))) && (!(((scope)->can_throw))))){
-((*this).error((ByteString::must_from_utf8("Call to function that may throw needs to be in a try statement or a function marked as throws"sv)),span));
+if ((((((implementation).trait_name)).starts_with((ByteString::from_utf8_without_validation("Throwing"sv)))) && (!(((scope)->can_throw))))){
+((*this).error((ByteString::from_utf8_without_validation("Call to function that may throw needs to be in a try statement or a function marked as throws"sv)),span));
 }
 JaktInternal::Tuple<JaktInternal::Optional<types::StructLikeId>,bool> const parent_id___ = TRY((((*this).struct_like_id_from_type_id(lhs_type_id,scope_id,span,false,true))));
 JaktInternal::Optional<types::StructLikeId> const parent_id = ((parent_id___).template get<0>());
@@ -9631,15 +9631,15 @@ if (((implementation_function_id).has_value())){
 NonnullRefPtr<types::CheckedFunction> const implementation_function = ((*this).get_function((implementation_function_id.value())));
 if ((((implementation_function)->is_mutating()) && (!(((checked_lhs)->is_mutable(((*this).program))))))){
 if (is_assignment){
-((*this).error((ByteString::must_from_utf8("Assignment to immutable variable"sv)),span));
+((*this).error((ByteString::from_utf8_without_validation("Assignment to immutable variable"sv)),span));
 }
 else {
-((*this).error((ByteString::must_from_utf8("Cannot call mutating function on an immutable object instance"sv)),span));
+((*this).error((ByteString::from_utf8_without_validation("Cannot call mutating function on an immutable object instance"sv)),span));
 }
 
 }
 (type_id = ((implementation_function)->return_type_id));
-types::CheckedCall call_expression = types::CheckedCall(DynamicArray<types::ResolvedNamespace>::create_with({}),function_name,DynamicArray<JaktInternal::Tuple<ByteString,NonnullRefPtr<typename types::CheckedExpression>>>::create_with({(Tuple{(ByteString::must_from_utf8(""sv)), checked_rhs})}),DynamicArray<ids::TypeId>::create_with({}),implementation_function_id,type_id,((implementation_function)->can_throw),((implementation_function)->external_name),((implementation_function)->force_inline));
+types::CheckedCall call_expression = types::CheckedCall(DynamicArray<types::ResolvedNamespace>::create_with({}),function_name,DynamicArray<JaktInternal::Tuple<ByteString,NonnullRefPtr<typename types::CheckedExpression>>>::create_with({(Tuple{(ByteString::from_utf8_without_validation(""sv)), checked_rhs})}),DynamicArray<ids::TypeId>::create_with({}),implementation_function_id,type_id,((implementation_function)->can_throw),((implementation_function)->external_name),((implementation_function)->force_inline));
 (((checked_operator).trait_implementation) = types::OperatorTraitImplementation(((implementation).trait_id),((implementation).implemented_type_args),call_expression));
 }
 else {
@@ -9716,67 +9716,67 @@ JaktInternal::Tuple<JaktInternal::DynamicArray<ByteString>,bool> const trait_nam
 auto&& __jakt_match_variant = op;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 0 /* Add */: {
-return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("Add"sv)), (ByteString::must_from_utf8("ThrowingAdd"sv))}), false}));
+return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("Add"sv)), (ByteString::from_utf8_without_validation("ThrowingAdd"sv))}), false}));
 };/*case end*/
 case 1 /* Subtract */: {
-return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("Subtract"sv)), (ByteString::must_from_utf8("ThrowingSubtract"sv))}), false}));
+return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("Subtract"sv)), (ByteString::from_utf8_without_validation("ThrowingSubtract"sv))}), false}));
 };/*case end*/
 case 2 /* Multiply */: {
-return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("Multiply"sv)), (ByteString::must_from_utf8("ThrowingMultiply"sv))}), false}));
+return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("Multiply"sv)), (ByteString::from_utf8_without_validation("ThrowingMultiply"sv))}), false}));
 };/*case end*/
 case 3 /* Divide */: {
-return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("Divide"sv)), (ByteString::must_from_utf8("ThrowingDivide"sv))}), false}));
+return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("Divide"sv)), (ByteString::from_utf8_without_validation("ThrowingDivide"sv))}), false}));
 };/*case end*/
 case 4 /* Modulo */: {
-return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("Modulo"sv)), (ByteString::must_from_utf8("ThrowingModulo"sv))}), false}));
+return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("Modulo"sv)), (ByteString::from_utf8_without_validation("ThrowingModulo"sv))}), false}));
 };/*case end*/
 case 5 /* LessThan */: {
-return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("Compare"sv)), (ByteString::must_from_utf8("ThrowingCompare"sv))}), false}));
+return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("Compare"sv)), (ByteString::from_utf8_without_validation("ThrowingCompare"sv))}), false}));
 };/*case end*/
 case 6 /* LessThanOrEqual */: {
-return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("Compare"sv)), (ByteString::must_from_utf8("ThrowingCompare"sv))}), false}));
+return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("Compare"sv)), (ByteString::from_utf8_without_validation("ThrowingCompare"sv))}), false}));
 };/*case end*/
 case 7 /* GreaterThan */: {
-return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("Compare"sv)), (ByteString::must_from_utf8("ThrowingCompare"sv))}), false}));
+return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("Compare"sv)), (ByteString::from_utf8_without_validation("ThrowingCompare"sv))}), false}));
 };/*case end*/
 case 8 /* GreaterThanOrEqual */: {
-return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("Compare"sv)), (ByteString::must_from_utf8("ThrowingCompare"sv))}), false}));
+return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("Compare"sv)), (ByteString::from_utf8_without_validation("ThrowingCompare"sv))}), false}));
 };/*case end*/
 case 9 /* Equal */: {
-return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("Equal"sv)), (ByteString::must_from_utf8("ThrowingEqual"sv))}), false}));
+return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("Equal"sv)), (ByteString::from_utf8_without_validation("ThrowingEqual"sv))}), false}));
 };/*case end*/
 case 10 /* NotEqual */: {
-return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("Equal"sv)), (ByteString::must_from_utf8("ThrowingEqual"sv))}), false}));
+return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("Equal"sv)), (ByteString::from_utf8_without_validation("ThrowingEqual"sv))}), false}));
 };/*case end*/
 case 27 /* AddAssign */: {
-return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("AddAssign"sv)), (ByteString::must_from_utf8("ThrowingAddAssign"sv))}), true}));
+return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("AddAssign"sv)), (ByteString::from_utf8_without_validation("ThrowingAddAssign"sv))}), true}));
 };/*case end*/
 case 28 /* SubtractAssign */: {
-return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("SubtractAssign"sv)), (ByteString::must_from_utf8("ThrowingSubtractAssign"sv))}), true}));
+return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("SubtractAssign"sv)), (ByteString::from_utf8_without_validation("ThrowingSubtractAssign"sv))}), true}));
 };/*case end*/
 case 29 /* MultiplyAssign */: {
-return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("MultiplyAssign"sv)), (ByteString::must_from_utf8("ThrowingMultiplyAssign"sv))}), true}));
+return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("MultiplyAssign"sv)), (ByteString::from_utf8_without_validation("ThrowingMultiplyAssign"sv))}), true}));
 };/*case end*/
 case 31 /* DivideAssign */: {
-return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("DivideAssign"sv)), (ByteString::must_from_utf8("ThrowingDivideAssign"sv))}), true}));
+return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("DivideAssign"sv)), (ByteString::from_utf8_without_validation("ThrowingDivideAssign"sv))}), true}));
 };/*case end*/
 case 30 /* ModuloAssign */: {
-return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("ModuloAssign"sv)), (ByteString::must_from_utf8("ThrowingModuloAssign"sv))}), true}));
+return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("ModuloAssign"sv)), (ByteString::from_utf8_without_validation("ThrowingModuloAssign"sv))}), true}));
 };/*case end*/
 case 22 /* BitwiseAndAssign */: {
-return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("BitwiseAndAssign"sv)), (ByteString::must_from_utf8("ThrowingBitwiseAndAssign"sv))}), true}));
+return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("BitwiseAndAssign"sv)), (ByteString::from_utf8_without_validation("ThrowingBitwiseAndAssign"sv))}), true}));
 };/*case end*/
 case 23 /* BitwiseOrAssign */: {
-return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("BitwiseOrAssign"sv)), (ByteString::must_from_utf8("ThrowingBitwiseOrAssign"sv))}), true}));
+return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("BitwiseOrAssign"sv)), (ByteString::from_utf8_without_validation("ThrowingBitwiseOrAssign"sv))}), true}));
 };/*case end*/
 case 24 /* BitwiseXorAssign */: {
-return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("BitwiseXorAssign"sv)), (ByteString::must_from_utf8("ThrowingBitwiseXorAssign"sv))}), true}));
+return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("BitwiseXorAssign"sv)), (ByteString::from_utf8_without_validation("ThrowingBitwiseXorAssign"sv))}), true}));
 };/*case end*/
 case 25 /* BitwiseLeftShiftAssign */: {
-return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("BitwiseLeftShiftAssign"sv)), (ByteString::must_from_utf8("ThrowingBitwiseLeftShiftAssign"sv))}), true}));
+return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("BitwiseLeftShiftAssign"sv)), (ByteString::from_utf8_without_validation("ThrowingBitwiseLeftShiftAssign"sv))}), true}));
 };/*case end*/
 case 26 /* BitwiseRightShiftAssign */: {
-return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("BitwiseRightShiftAssign"sv)), (ByteString::must_from_utf8("ThrowingBitwiseRightShiftAssign"sv))}), true}));
+return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("BitwiseRightShiftAssign"sv)), (ByteString::from_utf8_without_validation("ThrowingBitwiseRightShiftAssign"sv))}), true}));
 };/*case end*/
 default: {
 return JaktInternal::ExplicitValue((Tuple{empty_array, false}));
@@ -9796,70 +9796,70 @@ ByteString const function_name = ({
 auto&& __jakt_match_variant = op;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 0 /* Add */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("add"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("add"sv)));
 };/*case end*/
 case 1 /* Subtract */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("subtract"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("subtract"sv)));
 };/*case end*/
 case 2 /* Multiply */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("multiply"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("multiply"sv)));
 };/*case end*/
 case 3 /* Divide */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("divide"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("divide"sv)));
 };/*case end*/
 case 4 /* Modulo */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("modulo"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("modulo"sv)));
 };/*case end*/
 case 5 /* LessThan */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("less_than"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("less_than"sv)));
 };/*case end*/
 case 6 /* LessThanOrEqual */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("less_than_or_equal"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("less_than_or_equal"sv)));
 };/*case end*/
 case 7 /* GreaterThan */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("greater_than"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("greater_than"sv)));
 };/*case end*/
 case 8 /* GreaterThanOrEqual */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("greater_than_or_equal"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("greater_than_or_equal"sv)));
 };/*case end*/
 case 9 /* Equal */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("equals"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("equals"sv)));
 };/*case end*/
 case 10 /* NotEqual */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("not_equals"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("not_equals"sv)));
 };/*case end*/
 case 27 /* AddAssign */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("add_assign"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("add_assign"sv)));
 };/*case end*/
 case 28 /* SubtractAssign */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("subtract_assign"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("subtract_assign"sv)));
 };/*case end*/
 case 29 /* MultiplyAssign */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("multiply_assign"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("multiply_assign"sv)));
 };/*case end*/
 case 31 /* DivideAssign */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("divide_assign"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("divide_assign"sv)));
 };/*case end*/
 case 30 /* ModuloAssign */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("modulo_assign"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("modulo_assign"sv)));
 };/*case end*/
 case 22 /* BitwiseAndAssign */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("bitwise_and_assign"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("bitwise_and_assign"sv)));
 };/*case end*/
 case 23 /* BitwiseOrAssign */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("bitwise_or_assign"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("bitwise_or_assign"sv)));
 };/*case end*/
 case 24 /* BitwiseXorAssign */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("bitwise_xor_assign"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("bitwise_xor_assign"sv)));
 };/*case end*/
 case 25 /* BitwiseLeftShiftAssign */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("bitwise_left_shift_assign"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("bitwise_left_shift_assign"sv)));
 };/*case end*/
 case 26 /* BitwiseRightShiftAssign */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("bitwise_right_shift_assign"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("bitwise_right_shift_assign"sv)));
 };/*case end*/
 default: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8(""sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation(""sv)));
 };/*case end*/
 }/*switch end*/
 }()
@@ -9871,8 +9871,8 @@ return JaktInternal::ExplicitValue((ByteString::must_from_utf8(""sv)));
 JaktInternal::Optional<typechecker::TraitImplementationDescriptor> const add_trait_implementation = TRY((((*this).find_any_singular_trait_implementation(lhs_type_id,trait_names,scope_id,lhs_span,DynamicArray<ids::TypeId>::create_with({rhs_type_id})))));
 if (((add_trait_implementation).has_value())){
 typechecker::TraitImplementationDescriptor const implementation = (add_trait_implementation.value());
-if ((((((implementation).trait_name)).starts_with((ByteString::must_from_utf8("Throwing"sv)))) && (!(((scope)->can_throw))))){
-((*this).error((ByteString::must_from_utf8("Call to function that may throw needs to be in a try statement or a function marked as throws"sv)),span));
+if ((((((implementation).trait_name)).starts_with((ByteString::from_utf8_without_validation("Throwing"sv)))) && (!(((scope)->can_throw))))){
+((*this).error((ByteString::from_utf8_without_validation("Call to function that may throw needs to be in a try statement or a function marked as throws"sv)),span));
 }
 JaktInternal::Tuple<JaktInternal::Optional<types::StructLikeId>,bool> const parent_id___ = TRY((((*this).struct_like_id_from_type_id(lhs_type_id,scope_id,span,false,true))));
 JaktInternal::Optional<types::StructLikeId> const parent_id = ((parent_id___).template get<0>());
@@ -9883,15 +9883,15 @@ if (((implementation_function_id).has_value())){
 NonnullRefPtr<types::CheckedFunction> const implementation_function = ((*this).get_function((implementation_function_id.value())));
 if ((((implementation_function)->is_mutating()) && (!(((checked_lhs)->is_mutable(((*this).program))))))){
 if (is_assignment){
-((*this).error((ByteString::must_from_utf8("Assignment to immutable variable"sv)),span));
+((*this).error((ByteString::from_utf8_without_validation("Assignment to immutable variable"sv)),span));
 }
 else {
-((*this).error((ByteString::must_from_utf8("Cannot call mutating function on an immutable object instance"sv)),span));
+((*this).error((ByteString::from_utf8_without_validation("Cannot call mutating function on an immutable object instance"sv)),span));
 }
 
 }
 (type_id = ((implementation_function)->return_type_id));
-types::CheckedCall call_expression = types::CheckedCall(DynamicArray<types::ResolvedNamespace>::create_with({}),function_name,DynamicArray<JaktInternal::Tuple<ByteString,NonnullRefPtr<typename types::CheckedExpression>>>::create_with({(Tuple{(ByteString::must_from_utf8(""sv)), checked_rhs})}),DynamicArray<ids::TypeId>::create_with({}),implementation_function_id,type_id,((implementation_function)->can_throw),((implementation_function)->external_name),((implementation_function)->force_inline));
+types::CheckedCall call_expression = types::CheckedCall(DynamicArray<types::ResolvedNamespace>::create_with({}),function_name,DynamicArray<JaktInternal::Tuple<ByteString,NonnullRefPtr<typename types::CheckedExpression>>>::create_with({(Tuple{(ByteString::from_utf8_without_validation(""sv)), checked_rhs})}),DynamicArray<ids::TypeId>::create_with({}),implementation_function_id,type_id,((implementation_function)->can_throw),((implementation_function)->external_name),((implementation_function)->force_inline));
 (((checked_operator).trait_implementation) = types::OperatorTraitImplementation(((implementation).trait_id),((implementation).implemented_type_args),call_expression));
 }
 else {
@@ -9968,67 +9968,67 @@ JaktInternal::Tuple<JaktInternal::DynamicArray<ByteString>,bool> const trait_nam
 auto&& __jakt_match_variant = op;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 0 /* Add */: {
-return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("Add"sv)), (ByteString::must_from_utf8("ThrowingAdd"sv))}), false}));
+return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("Add"sv)), (ByteString::from_utf8_without_validation("ThrowingAdd"sv))}), false}));
 };/*case end*/
 case 1 /* Subtract */: {
-return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("Subtract"sv)), (ByteString::must_from_utf8("ThrowingSubtract"sv))}), false}));
+return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("Subtract"sv)), (ByteString::from_utf8_without_validation("ThrowingSubtract"sv))}), false}));
 };/*case end*/
 case 2 /* Multiply */: {
-return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("Multiply"sv)), (ByteString::must_from_utf8("ThrowingMultiply"sv))}), false}));
+return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("Multiply"sv)), (ByteString::from_utf8_without_validation("ThrowingMultiply"sv))}), false}));
 };/*case end*/
 case 3 /* Divide */: {
-return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("Divide"sv)), (ByteString::must_from_utf8("ThrowingDivide"sv))}), false}));
+return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("Divide"sv)), (ByteString::from_utf8_without_validation("ThrowingDivide"sv))}), false}));
 };/*case end*/
 case 4 /* Modulo */: {
-return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("Modulo"sv)), (ByteString::must_from_utf8("ThrowingModulo"sv))}), false}));
+return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("Modulo"sv)), (ByteString::from_utf8_without_validation("ThrowingModulo"sv))}), false}));
 };/*case end*/
 case 5 /* LessThan */: {
-return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("Compare"sv)), (ByteString::must_from_utf8("ThrowingCompare"sv))}), false}));
+return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("Compare"sv)), (ByteString::from_utf8_without_validation("ThrowingCompare"sv))}), false}));
 };/*case end*/
 case 6 /* LessThanOrEqual */: {
-return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("Compare"sv)), (ByteString::must_from_utf8("ThrowingCompare"sv))}), false}));
+return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("Compare"sv)), (ByteString::from_utf8_without_validation("ThrowingCompare"sv))}), false}));
 };/*case end*/
 case 7 /* GreaterThan */: {
-return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("Compare"sv)), (ByteString::must_from_utf8("ThrowingCompare"sv))}), false}));
+return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("Compare"sv)), (ByteString::from_utf8_without_validation("ThrowingCompare"sv))}), false}));
 };/*case end*/
 case 8 /* GreaterThanOrEqual */: {
-return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("Compare"sv)), (ByteString::must_from_utf8("ThrowingCompare"sv))}), false}));
+return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("Compare"sv)), (ByteString::from_utf8_without_validation("ThrowingCompare"sv))}), false}));
 };/*case end*/
 case 9 /* Equal */: {
-return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("Equal"sv)), (ByteString::must_from_utf8("ThrowingEqual"sv))}), false}));
+return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("Equal"sv)), (ByteString::from_utf8_without_validation("ThrowingEqual"sv))}), false}));
 };/*case end*/
 case 10 /* NotEqual */: {
-return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("Equal"sv)), (ByteString::must_from_utf8("ThrowingEqual"sv))}), false}));
+return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("Equal"sv)), (ByteString::from_utf8_without_validation("ThrowingEqual"sv))}), false}));
 };/*case end*/
 case 27 /* AddAssign */: {
-return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("AddAssign"sv)), (ByteString::must_from_utf8("ThrowingAddAssign"sv))}), true}));
+return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("AddAssign"sv)), (ByteString::from_utf8_without_validation("ThrowingAddAssign"sv))}), true}));
 };/*case end*/
 case 28 /* SubtractAssign */: {
-return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("SubtractAssign"sv)), (ByteString::must_from_utf8("ThrowingSubtractAssign"sv))}), true}));
+return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("SubtractAssign"sv)), (ByteString::from_utf8_without_validation("ThrowingSubtractAssign"sv))}), true}));
 };/*case end*/
 case 29 /* MultiplyAssign */: {
-return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("MultiplyAssign"sv)), (ByteString::must_from_utf8("ThrowingMultiplyAssign"sv))}), true}));
+return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("MultiplyAssign"sv)), (ByteString::from_utf8_without_validation("ThrowingMultiplyAssign"sv))}), true}));
 };/*case end*/
 case 31 /* DivideAssign */: {
-return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("DivideAssign"sv)), (ByteString::must_from_utf8("ThrowingDivideAssign"sv))}), true}));
+return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("DivideAssign"sv)), (ByteString::from_utf8_without_validation("ThrowingDivideAssign"sv))}), true}));
 };/*case end*/
 case 30 /* ModuloAssign */: {
-return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("ModuloAssign"sv)), (ByteString::must_from_utf8("ThrowingModuloAssign"sv))}), true}));
+return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("ModuloAssign"sv)), (ByteString::from_utf8_without_validation("ThrowingModuloAssign"sv))}), true}));
 };/*case end*/
 case 22 /* BitwiseAndAssign */: {
-return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("BitwiseAndAssign"sv)), (ByteString::must_from_utf8("ThrowingBitwiseAndAssign"sv))}), true}));
+return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("BitwiseAndAssign"sv)), (ByteString::from_utf8_without_validation("ThrowingBitwiseAndAssign"sv))}), true}));
 };/*case end*/
 case 23 /* BitwiseOrAssign */: {
-return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("BitwiseOrAssign"sv)), (ByteString::must_from_utf8("ThrowingBitwiseOrAssign"sv))}), true}));
+return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("BitwiseOrAssign"sv)), (ByteString::from_utf8_without_validation("ThrowingBitwiseOrAssign"sv))}), true}));
 };/*case end*/
 case 24 /* BitwiseXorAssign */: {
-return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("BitwiseXorAssign"sv)), (ByteString::must_from_utf8("ThrowingBitwiseXorAssign"sv))}), true}));
+return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("BitwiseXorAssign"sv)), (ByteString::from_utf8_without_validation("ThrowingBitwiseXorAssign"sv))}), true}));
 };/*case end*/
 case 25 /* BitwiseLeftShiftAssign */: {
-return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("BitwiseLeftShiftAssign"sv)), (ByteString::must_from_utf8("ThrowingBitwiseLeftShiftAssign"sv))}), true}));
+return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("BitwiseLeftShiftAssign"sv)), (ByteString::from_utf8_without_validation("ThrowingBitwiseLeftShiftAssign"sv))}), true}));
 };/*case end*/
 case 26 /* BitwiseRightShiftAssign */: {
-return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("BitwiseRightShiftAssign"sv)), (ByteString::must_from_utf8("ThrowingBitwiseRightShiftAssign"sv))}), true}));
+return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("BitwiseRightShiftAssign"sv)), (ByteString::from_utf8_without_validation("ThrowingBitwiseRightShiftAssign"sv))}), true}));
 };/*case end*/
 default: {
 return JaktInternal::ExplicitValue((Tuple{empty_array, false}));
@@ -10048,70 +10048,70 @@ ByteString const function_name = ({
 auto&& __jakt_match_variant = op;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 0 /* Add */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("add"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("add"sv)));
 };/*case end*/
 case 1 /* Subtract */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("subtract"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("subtract"sv)));
 };/*case end*/
 case 2 /* Multiply */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("multiply"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("multiply"sv)));
 };/*case end*/
 case 3 /* Divide */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("divide"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("divide"sv)));
 };/*case end*/
 case 4 /* Modulo */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("modulo"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("modulo"sv)));
 };/*case end*/
 case 5 /* LessThan */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("less_than"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("less_than"sv)));
 };/*case end*/
 case 6 /* LessThanOrEqual */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("less_than_or_equal"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("less_than_or_equal"sv)));
 };/*case end*/
 case 7 /* GreaterThan */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("greater_than"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("greater_than"sv)));
 };/*case end*/
 case 8 /* GreaterThanOrEqual */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("greater_than_or_equal"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("greater_than_or_equal"sv)));
 };/*case end*/
 case 9 /* Equal */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("equals"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("equals"sv)));
 };/*case end*/
 case 10 /* NotEqual */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("not_equals"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("not_equals"sv)));
 };/*case end*/
 case 27 /* AddAssign */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("add_assign"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("add_assign"sv)));
 };/*case end*/
 case 28 /* SubtractAssign */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("subtract_assign"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("subtract_assign"sv)));
 };/*case end*/
 case 29 /* MultiplyAssign */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("multiply_assign"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("multiply_assign"sv)));
 };/*case end*/
 case 31 /* DivideAssign */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("divide_assign"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("divide_assign"sv)));
 };/*case end*/
 case 30 /* ModuloAssign */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("modulo_assign"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("modulo_assign"sv)));
 };/*case end*/
 case 22 /* BitwiseAndAssign */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("bitwise_and_assign"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("bitwise_and_assign"sv)));
 };/*case end*/
 case 23 /* BitwiseOrAssign */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("bitwise_or_assign"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("bitwise_or_assign"sv)));
 };/*case end*/
 case 24 /* BitwiseXorAssign */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("bitwise_xor_assign"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("bitwise_xor_assign"sv)));
 };/*case end*/
 case 25 /* BitwiseLeftShiftAssign */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("bitwise_left_shift_assign"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("bitwise_left_shift_assign"sv)));
 };/*case end*/
 case 26 /* BitwiseRightShiftAssign */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("bitwise_right_shift_assign"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("bitwise_right_shift_assign"sv)));
 };/*case end*/
 default: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8(""sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation(""sv)));
 };/*case end*/
 }/*switch end*/
 }()
@@ -10123,8 +10123,8 @@ return JaktInternal::ExplicitValue((ByteString::must_from_utf8(""sv)));
 JaktInternal::Optional<typechecker::TraitImplementationDescriptor> const add_trait_implementation = TRY((((*this).find_any_singular_trait_implementation(lhs_type_id,trait_names,scope_id,lhs_span,DynamicArray<ids::TypeId>::create_with({rhs_type_id})))));
 if (((add_trait_implementation).has_value())){
 typechecker::TraitImplementationDescriptor const implementation = (add_trait_implementation.value());
-if ((((((implementation).trait_name)).starts_with((ByteString::must_from_utf8("Throwing"sv)))) && (!(((scope)->can_throw))))){
-((*this).error((ByteString::must_from_utf8("Call to function that may throw needs to be in a try statement or a function marked as throws"sv)),span));
+if ((((((implementation).trait_name)).starts_with((ByteString::from_utf8_without_validation("Throwing"sv)))) && (!(((scope)->can_throw))))){
+((*this).error((ByteString::from_utf8_without_validation("Call to function that may throw needs to be in a try statement or a function marked as throws"sv)),span));
 }
 JaktInternal::Tuple<JaktInternal::Optional<types::StructLikeId>,bool> const parent_id___ = TRY((((*this).struct_like_id_from_type_id(lhs_type_id,scope_id,span,false,true))));
 JaktInternal::Optional<types::StructLikeId> const parent_id = ((parent_id___).template get<0>());
@@ -10135,15 +10135,15 @@ if (((implementation_function_id).has_value())){
 NonnullRefPtr<types::CheckedFunction> const implementation_function = ((*this).get_function((implementation_function_id.value())));
 if ((((implementation_function)->is_mutating()) && (!(((checked_lhs)->is_mutable(((*this).program))))))){
 if (is_assignment){
-((*this).error((ByteString::must_from_utf8("Assignment to immutable variable"sv)),span));
+((*this).error((ByteString::from_utf8_without_validation("Assignment to immutable variable"sv)),span));
 }
 else {
-((*this).error((ByteString::must_from_utf8("Cannot call mutating function on an immutable object instance"sv)),span));
+((*this).error((ByteString::from_utf8_without_validation("Cannot call mutating function on an immutable object instance"sv)),span));
 }
 
 }
 (type_id = ((implementation_function)->return_type_id));
-types::CheckedCall call_expression = types::CheckedCall(DynamicArray<types::ResolvedNamespace>::create_with({}),function_name,DynamicArray<JaktInternal::Tuple<ByteString,NonnullRefPtr<typename types::CheckedExpression>>>::create_with({(Tuple{(ByteString::must_from_utf8(""sv)), checked_rhs})}),DynamicArray<ids::TypeId>::create_with({}),implementation_function_id,type_id,((implementation_function)->can_throw),((implementation_function)->external_name),((implementation_function)->force_inline));
+types::CheckedCall call_expression = types::CheckedCall(DynamicArray<types::ResolvedNamespace>::create_with({}),function_name,DynamicArray<JaktInternal::Tuple<ByteString,NonnullRefPtr<typename types::CheckedExpression>>>::create_with({(Tuple{(ByteString::from_utf8_without_validation(""sv)), checked_rhs})}),DynamicArray<ids::TypeId>::create_with({}),implementation_function_id,type_id,((implementation_function)->can_throw),((implementation_function)->external_name),((implementation_function)->force_inline));
 (((checked_operator).trait_implementation) = types::OperatorTraitImplementation(((implementation).trait_id),((implementation).implemented_type_args),call_expression));
 }
 else {
@@ -10220,67 +10220,67 @@ JaktInternal::Tuple<JaktInternal::DynamicArray<ByteString>,bool> const trait_nam
 auto&& __jakt_match_variant = op;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 0 /* Add */: {
-return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("Add"sv)), (ByteString::must_from_utf8("ThrowingAdd"sv))}), false}));
+return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("Add"sv)), (ByteString::from_utf8_without_validation("ThrowingAdd"sv))}), false}));
 };/*case end*/
 case 1 /* Subtract */: {
-return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("Subtract"sv)), (ByteString::must_from_utf8("ThrowingSubtract"sv))}), false}));
+return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("Subtract"sv)), (ByteString::from_utf8_without_validation("ThrowingSubtract"sv))}), false}));
 };/*case end*/
 case 2 /* Multiply */: {
-return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("Multiply"sv)), (ByteString::must_from_utf8("ThrowingMultiply"sv))}), false}));
+return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("Multiply"sv)), (ByteString::from_utf8_without_validation("ThrowingMultiply"sv))}), false}));
 };/*case end*/
 case 3 /* Divide */: {
-return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("Divide"sv)), (ByteString::must_from_utf8("ThrowingDivide"sv))}), false}));
+return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("Divide"sv)), (ByteString::from_utf8_without_validation("ThrowingDivide"sv))}), false}));
 };/*case end*/
 case 4 /* Modulo */: {
-return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("Modulo"sv)), (ByteString::must_from_utf8("ThrowingModulo"sv))}), false}));
+return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("Modulo"sv)), (ByteString::from_utf8_without_validation("ThrowingModulo"sv))}), false}));
 };/*case end*/
 case 5 /* LessThan */: {
-return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("Compare"sv)), (ByteString::must_from_utf8("ThrowingCompare"sv))}), false}));
+return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("Compare"sv)), (ByteString::from_utf8_without_validation("ThrowingCompare"sv))}), false}));
 };/*case end*/
 case 6 /* LessThanOrEqual */: {
-return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("Compare"sv)), (ByteString::must_from_utf8("ThrowingCompare"sv))}), false}));
+return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("Compare"sv)), (ByteString::from_utf8_without_validation("ThrowingCompare"sv))}), false}));
 };/*case end*/
 case 7 /* GreaterThan */: {
-return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("Compare"sv)), (ByteString::must_from_utf8("ThrowingCompare"sv))}), false}));
+return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("Compare"sv)), (ByteString::from_utf8_without_validation("ThrowingCompare"sv))}), false}));
 };/*case end*/
 case 8 /* GreaterThanOrEqual */: {
-return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("Compare"sv)), (ByteString::must_from_utf8("ThrowingCompare"sv))}), false}));
+return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("Compare"sv)), (ByteString::from_utf8_without_validation("ThrowingCompare"sv))}), false}));
 };/*case end*/
 case 9 /* Equal */: {
-return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("Equal"sv)), (ByteString::must_from_utf8("ThrowingEqual"sv))}), false}));
+return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("Equal"sv)), (ByteString::from_utf8_without_validation("ThrowingEqual"sv))}), false}));
 };/*case end*/
 case 10 /* NotEqual */: {
-return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("Equal"sv)), (ByteString::must_from_utf8("ThrowingEqual"sv))}), false}));
+return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("Equal"sv)), (ByteString::from_utf8_without_validation("ThrowingEqual"sv))}), false}));
 };/*case end*/
 case 27 /* AddAssign */: {
-return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("AddAssign"sv)), (ByteString::must_from_utf8("ThrowingAddAssign"sv))}), true}));
+return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("AddAssign"sv)), (ByteString::from_utf8_without_validation("ThrowingAddAssign"sv))}), true}));
 };/*case end*/
 case 28 /* SubtractAssign */: {
-return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("SubtractAssign"sv)), (ByteString::must_from_utf8("ThrowingSubtractAssign"sv))}), true}));
+return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("SubtractAssign"sv)), (ByteString::from_utf8_without_validation("ThrowingSubtractAssign"sv))}), true}));
 };/*case end*/
 case 29 /* MultiplyAssign */: {
-return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("MultiplyAssign"sv)), (ByteString::must_from_utf8("ThrowingMultiplyAssign"sv))}), true}));
+return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("MultiplyAssign"sv)), (ByteString::from_utf8_without_validation("ThrowingMultiplyAssign"sv))}), true}));
 };/*case end*/
 case 31 /* DivideAssign */: {
-return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("DivideAssign"sv)), (ByteString::must_from_utf8("ThrowingDivideAssign"sv))}), true}));
+return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("DivideAssign"sv)), (ByteString::from_utf8_without_validation("ThrowingDivideAssign"sv))}), true}));
 };/*case end*/
 case 30 /* ModuloAssign */: {
-return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("ModuloAssign"sv)), (ByteString::must_from_utf8("ThrowingModuloAssign"sv))}), true}));
+return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("ModuloAssign"sv)), (ByteString::from_utf8_without_validation("ThrowingModuloAssign"sv))}), true}));
 };/*case end*/
 case 22 /* BitwiseAndAssign */: {
-return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("BitwiseAndAssign"sv)), (ByteString::must_from_utf8("ThrowingBitwiseAndAssign"sv))}), true}));
+return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("BitwiseAndAssign"sv)), (ByteString::from_utf8_without_validation("ThrowingBitwiseAndAssign"sv))}), true}));
 };/*case end*/
 case 23 /* BitwiseOrAssign */: {
-return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("BitwiseOrAssign"sv)), (ByteString::must_from_utf8("ThrowingBitwiseOrAssign"sv))}), true}));
+return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("BitwiseOrAssign"sv)), (ByteString::from_utf8_without_validation("ThrowingBitwiseOrAssign"sv))}), true}));
 };/*case end*/
 case 24 /* BitwiseXorAssign */: {
-return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("BitwiseXorAssign"sv)), (ByteString::must_from_utf8("ThrowingBitwiseXorAssign"sv))}), true}));
+return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("BitwiseXorAssign"sv)), (ByteString::from_utf8_without_validation("ThrowingBitwiseXorAssign"sv))}), true}));
 };/*case end*/
 case 25 /* BitwiseLeftShiftAssign */: {
-return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("BitwiseLeftShiftAssign"sv)), (ByteString::must_from_utf8("ThrowingBitwiseLeftShiftAssign"sv))}), true}));
+return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("BitwiseLeftShiftAssign"sv)), (ByteString::from_utf8_without_validation("ThrowingBitwiseLeftShiftAssign"sv))}), true}));
 };/*case end*/
 case 26 /* BitwiseRightShiftAssign */: {
-return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("BitwiseRightShiftAssign"sv)), (ByteString::must_from_utf8("ThrowingBitwiseRightShiftAssign"sv))}), true}));
+return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("BitwiseRightShiftAssign"sv)), (ByteString::from_utf8_without_validation("ThrowingBitwiseRightShiftAssign"sv))}), true}));
 };/*case end*/
 default: {
 return JaktInternal::ExplicitValue((Tuple{empty_array, false}));
@@ -10300,70 +10300,70 @@ ByteString const function_name = ({
 auto&& __jakt_match_variant = op;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 0 /* Add */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("add"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("add"sv)));
 };/*case end*/
 case 1 /* Subtract */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("subtract"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("subtract"sv)));
 };/*case end*/
 case 2 /* Multiply */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("multiply"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("multiply"sv)));
 };/*case end*/
 case 3 /* Divide */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("divide"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("divide"sv)));
 };/*case end*/
 case 4 /* Modulo */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("modulo"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("modulo"sv)));
 };/*case end*/
 case 5 /* LessThan */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("less_than"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("less_than"sv)));
 };/*case end*/
 case 6 /* LessThanOrEqual */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("less_than_or_equal"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("less_than_or_equal"sv)));
 };/*case end*/
 case 7 /* GreaterThan */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("greater_than"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("greater_than"sv)));
 };/*case end*/
 case 8 /* GreaterThanOrEqual */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("greater_than_or_equal"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("greater_than_or_equal"sv)));
 };/*case end*/
 case 9 /* Equal */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("equals"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("equals"sv)));
 };/*case end*/
 case 10 /* NotEqual */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("not_equals"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("not_equals"sv)));
 };/*case end*/
 case 27 /* AddAssign */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("add_assign"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("add_assign"sv)));
 };/*case end*/
 case 28 /* SubtractAssign */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("subtract_assign"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("subtract_assign"sv)));
 };/*case end*/
 case 29 /* MultiplyAssign */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("multiply_assign"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("multiply_assign"sv)));
 };/*case end*/
 case 31 /* DivideAssign */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("divide_assign"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("divide_assign"sv)));
 };/*case end*/
 case 30 /* ModuloAssign */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("modulo_assign"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("modulo_assign"sv)));
 };/*case end*/
 case 22 /* BitwiseAndAssign */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("bitwise_and_assign"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("bitwise_and_assign"sv)));
 };/*case end*/
 case 23 /* BitwiseOrAssign */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("bitwise_or_assign"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("bitwise_or_assign"sv)));
 };/*case end*/
 case 24 /* BitwiseXorAssign */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("bitwise_xor_assign"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("bitwise_xor_assign"sv)));
 };/*case end*/
 case 25 /* BitwiseLeftShiftAssign */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("bitwise_left_shift_assign"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("bitwise_left_shift_assign"sv)));
 };/*case end*/
 case 26 /* BitwiseRightShiftAssign */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("bitwise_right_shift_assign"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("bitwise_right_shift_assign"sv)));
 };/*case end*/
 default: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8(""sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation(""sv)));
 };/*case end*/
 }/*switch end*/
 }()
@@ -10375,8 +10375,8 @@ return JaktInternal::ExplicitValue((ByteString::must_from_utf8(""sv)));
 JaktInternal::Optional<typechecker::TraitImplementationDescriptor> const add_trait_implementation = TRY((((*this).find_any_singular_trait_implementation(lhs_type_id,trait_names,scope_id,lhs_span,DynamicArray<ids::TypeId>::create_with({rhs_type_id})))));
 if (((add_trait_implementation).has_value())){
 typechecker::TraitImplementationDescriptor const implementation = (add_trait_implementation.value());
-if ((((((implementation).trait_name)).starts_with((ByteString::must_from_utf8("Throwing"sv)))) && (!(((scope)->can_throw))))){
-((*this).error((ByteString::must_from_utf8("Call to function that may throw needs to be in a try statement or a function marked as throws"sv)),span));
+if ((((((implementation).trait_name)).starts_with((ByteString::from_utf8_without_validation("Throwing"sv)))) && (!(((scope)->can_throw))))){
+((*this).error((ByteString::from_utf8_without_validation("Call to function that may throw needs to be in a try statement or a function marked as throws"sv)),span));
 }
 JaktInternal::Tuple<JaktInternal::Optional<types::StructLikeId>,bool> const parent_id___ = TRY((((*this).struct_like_id_from_type_id(lhs_type_id,scope_id,span,false,true))));
 JaktInternal::Optional<types::StructLikeId> const parent_id = ((parent_id___).template get<0>());
@@ -10387,15 +10387,15 @@ if (((implementation_function_id).has_value())){
 NonnullRefPtr<types::CheckedFunction> const implementation_function = ((*this).get_function((implementation_function_id.value())));
 if ((((implementation_function)->is_mutating()) && (!(((checked_lhs)->is_mutable(((*this).program))))))){
 if (is_assignment){
-((*this).error((ByteString::must_from_utf8("Assignment to immutable variable"sv)),span));
+((*this).error((ByteString::from_utf8_without_validation("Assignment to immutable variable"sv)),span));
 }
 else {
-((*this).error((ByteString::must_from_utf8("Cannot call mutating function on an immutable object instance"sv)),span));
+((*this).error((ByteString::from_utf8_without_validation("Cannot call mutating function on an immutable object instance"sv)),span));
 }
 
 }
 (type_id = ((implementation_function)->return_type_id));
-types::CheckedCall call_expression = types::CheckedCall(DynamicArray<types::ResolvedNamespace>::create_with({}),function_name,DynamicArray<JaktInternal::Tuple<ByteString,NonnullRefPtr<typename types::CheckedExpression>>>::create_with({(Tuple{(ByteString::must_from_utf8(""sv)), checked_rhs})}),DynamicArray<ids::TypeId>::create_with({}),implementation_function_id,type_id,((implementation_function)->can_throw),((implementation_function)->external_name),((implementation_function)->force_inline));
+types::CheckedCall call_expression = types::CheckedCall(DynamicArray<types::ResolvedNamespace>::create_with({}),function_name,DynamicArray<JaktInternal::Tuple<ByteString,NonnullRefPtr<typename types::CheckedExpression>>>::create_with({(Tuple{(ByteString::from_utf8_without_validation(""sv)), checked_rhs})}),DynamicArray<ids::TypeId>::create_with({}),implementation_function_id,type_id,((implementation_function)->can_throw),((implementation_function)->external_name),((implementation_function)->force_inline));
 (((checked_operator).trait_implementation) = types::OperatorTraitImplementation(((implementation).trait_id),((implementation).implemented_type_args),call_expression));
 }
 else {
@@ -10472,67 +10472,67 @@ JaktInternal::Tuple<JaktInternal::DynamicArray<ByteString>,bool> const trait_nam
 auto&& __jakt_match_variant = op;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 0 /* Add */: {
-return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("Add"sv)), (ByteString::must_from_utf8("ThrowingAdd"sv))}), false}));
+return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("Add"sv)), (ByteString::from_utf8_without_validation("ThrowingAdd"sv))}), false}));
 };/*case end*/
 case 1 /* Subtract */: {
-return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("Subtract"sv)), (ByteString::must_from_utf8("ThrowingSubtract"sv))}), false}));
+return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("Subtract"sv)), (ByteString::from_utf8_without_validation("ThrowingSubtract"sv))}), false}));
 };/*case end*/
 case 2 /* Multiply */: {
-return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("Multiply"sv)), (ByteString::must_from_utf8("ThrowingMultiply"sv))}), false}));
+return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("Multiply"sv)), (ByteString::from_utf8_without_validation("ThrowingMultiply"sv))}), false}));
 };/*case end*/
 case 3 /* Divide */: {
-return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("Divide"sv)), (ByteString::must_from_utf8("ThrowingDivide"sv))}), false}));
+return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("Divide"sv)), (ByteString::from_utf8_without_validation("ThrowingDivide"sv))}), false}));
 };/*case end*/
 case 4 /* Modulo */: {
-return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("Modulo"sv)), (ByteString::must_from_utf8("ThrowingModulo"sv))}), false}));
+return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("Modulo"sv)), (ByteString::from_utf8_without_validation("ThrowingModulo"sv))}), false}));
 };/*case end*/
 case 5 /* LessThan */: {
-return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("Compare"sv)), (ByteString::must_from_utf8("ThrowingCompare"sv))}), false}));
+return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("Compare"sv)), (ByteString::from_utf8_without_validation("ThrowingCompare"sv))}), false}));
 };/*case end*/
 case 6 /* LessThanOrEqual */: {
-return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("Compare"sv)), (ByteString::must_from_utf8("ThrowingCompare"sv))}), false}));
+return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("Compare"sv)), (ByteString::from_utf8_without_validation("ThrowingCompare"sv))}), false}));
 };/*case end*/
 case 7 /* GreaterThan */: {
-return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("Compare"sv)), (ByteString::must_from_utf8("ThrowingCompare"sv))}), false}));
+return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("Compare"sv)), (ByteString::from_utf8_without_validation("ThrowingCompare"sv))}), false}));
 };/*case end*/
 case 8 /* GreaterThanOrEqual */: {
-return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("Compare"sv)), (ByteString::must_from_utf8("ThrowingCompare"sv))}), false}));
+return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("Compare"sv)), (ByteString::from_utf8_without_validation("ThrowingCompare"sv))}), false}));
 };/*case end*/
 case 9 /* Equal */: {
-return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("Equal"sv)), (ByteString::must_from_utf8("ThrowingEqual"sv))}), false}));
+return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("Equal"sv)), (ByteString::from_utf8_without_validation("ThrowingEqual"sv))}), false}));
 };/*case end*/
 case 10 /* NotEqual */: {
-return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("Equal"sv)), (ByteString::must_from_utf8("ThrowingEqual"sv))}), false}));
+return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("Equal"sv)), (ByteString::from_utf8_without_validation("ThrowingEqual"sv))}), false}));
 };/*case end*/
 case 27 /* AddAssign */: {
-return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("AddAssign"sv)), (ByteString::must_from_utf8("ThrowingAddAssign"sv))}), true}));
+return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("AddAssign"sv)), (ByteString::from_utf8_without_validation("ThrowingAddAssign"sv))}), true}));
 };/*case end*/
 case 28 /* SubtractAssign */: {
-return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("SubtractAssign"sv)), (ByteString::must_from_utf8("ThrowingSubtractAssign"sv))}), true}));
+return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("SubtractAssign"sv)), (ByteString::from_utf8_without_validation("ThrowingSubtractAssign"sv))}), true}));
 };/*case end*/
 case 29 /* MultiplyAssign */: {
-return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("MultiplyAssign"sv)), (ByteString::must_from_utf8("ThrowingMultiplyAssign"sv))}), true}));
+return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("MultiplyAssign"sv)), (ByteString::from_utf8_without_validation("ThrowingMultiplyAssign"sv))}), true}));
 };/*case end*/
 case 31 /* DivideAssign */: {
-return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("DivideAssign"sv)), (ByteString::must_from_utf8("ThrowingDivideAssign"sv))}), true}));
+return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("DivideAssign"sv)), (ByteString::from_utf8_without_validation("ThrowingDivideAssign"sv))}), true}));
 };/*case end*/
 case 30 /* ModuloAssign */: {
-return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("ModuloAssign"sv)), (ByteString::must_from_utf8("ThrowingModuloAssign"sv))}), true}));
+return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("ModuloAssign"sv)), (ByteString::from_utf8_without_validation("ThrowingModuloAssign"sv))}), true}));
 };/*case end*/
 case 22 /* BitwiseAndAssign */: {
-return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("BitwiseAndAssign"sv)), (ByteString::must_from_utf8("ThrowingBitwiseAndAssign"sv))}), true}));
+return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("BitwiseAndAssign"sv)), (ByteString::from_utf8_without_validation("ThrowingBitwiseAndAssign"sv))}), true}));
 };/*case end*/
 case 23 /* BitwiseOrAssign */: {
-return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("BitwiseOrAssign"sv)), (ByteString::must_from_utf8("ThrowingBitwiseOrAssign"sv))}), true}));
+return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("BitwiseOrAssign"sv)), (ByteString::from_utf8_without_validation("ThrowingBitwiseOrAssign"sv))}), true}));
 };/*case end*/
 case 24 /* BitwiseXorAssign */: {
-return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("BitwiseXorAssign"sv)), (ByteString::must_from_utf8("ThrowingBitwiseXorAssign"sv))}), true}));
+return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("BitwiseXorAssign"sv)), (ByteString::from_utf8_without_validation("ThrowingBitwiseXorAssign"sv))}), true}));
 };/*case end*/
 case 25 /* BitwiseLeftShiftAssign */: {
-return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("BitwiseLeftShiftAssign"sv)), (ByteString::must_from_utf8("ThrowingBitwiseLeftShiftAssign"sv))}), true}));
+return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("BitwiseLeftShiftAssign"sv)), (ByteString::from_utf8_without_validation("ThrowingBitwiseLeftShiftAssign"sv))}), true}));
 };/*case end*/
 case 26 /* BitwiseRightShiftAssign */: {
-return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("BitwiseRightShiftAssign"sv)), (ByteString::must_from_utf8("ThrowingBitwiseRightShiftAssign"sv))}), true}));
+return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("BitwiseRightShiftAssign"sv)), (ByteString::from_utf8_without_validation("ThrowingBitwiseRightShiftAssign"sv))}), true}));
 };/*case end*/
 default: {
 return JaktInternal::ExplicitValue((Tuple{empty_array, false}));
@@ -10552,70 +10552,70 @@ ByteString const function_name = ({
 auto&& __jakt_match_variant = op;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 0 /* Add */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("add"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("add"sv)));
 };/*case end*/
 case 1 /* Subtract */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("subtract"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("subtract"sv)));
 };/*case end*/
 case 2 /* Multiply */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("multiply"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("multiply"sv)));
 };/*case end*/
 case 3 /* Divide */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("divide"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("divide"sv)));
 };/*case end*/
 case 4 /* Modulo */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("modulo"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("modulo"sv)));
 };/*case end*/
 case 5 /* LessThan */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("less_than"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("less_than"sv)));
 };/*case end*/
 case 6 /* LessThanOrEqual */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("less_than_or_equal"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("less_than_or_equal"sv)));
 };/*case end*/
 case 7 /* GreaterThan */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("greater_than"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("greater_than"sv)));
 };/*case end*/
 case 8 /* GreaterThanOrEqual */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("greater_than_or_equal"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("greater_than_or_equal"sv)));
 };/*case end*/
 case 9 /* Equal */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("equals"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("equals"sv)));
 };/*case end*/
 case 10 /* NotEqual */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("not_equals"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("not_equals"sv)));
 };/*case end*/
 case 27 /* AddAssign */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("add_assign"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("add_assign"sv)));
 };/*case end*/
 case 28 /* SubtractAssign */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("subtract_assign"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("subtract_assign"sv)));
 };/*case end*/
 case 29 /* MultiplyAssign */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("multiply_assign"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("multiply_assign"sv)));
 };/*case end*/
 case 31 /* DivideAssign */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("divide_assign"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("divide_assign"sv)));
 };/*case end*/
 case 30 /* ModuloAssign */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("modulo_assign"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("modulo_assign"sv)));
 };/*case end*/
 case 22 /* BitwiseAndAssign */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("bitwise_and_assign"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("bitwise_and_assign"sv)));
 };/*case end*/
 case 23 /* BitwiseOrAssign */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("bitwise_or_assign"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("bitwise_or_assign"sv)));
 };/*case end*/
 case 24 /* BitwiseXorAssign */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("bitwise_xor_assign"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("bitwise_xor_assign"sv)));
 };/*case end*/
 case 25 /* BitwiseLeftShiftAssign */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("bitwise_left_shift_assign"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("bitwise_left_shift_assign"sv)));
 };/*case end*/
 case 26 /* BitwiseRightShiftAssign */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("bitwise_right_shift_assign"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("bitwise_right_shift_assign"sv)));
 };/*case end*/
 default: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8(""sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation(""sv)));
 };/*case end*/
 }/*switch end*/
 }()
@@ -10627,8 +10627,8 @@ return JaktInternal::ExplicitValue((ByteString::must_from_utf8(""sv)));
 JaktInternal::Optional<typechecker::TraitImplementationDescriptor> const add_trait_implementation = TRY((((*this).find_any_singular_trait_implementation(lhs_type_id,trait_names,scope_id,lhs_span,DynamicArray<ids::TypeId>::create_with({rhs_type_id})))));
 if (((add_trait_implementation).has_value())){
 typechecker::TraitImplementationDescriptor const implementation = (add_trait_implementation.value());
-if ((((((implementation).trait_name)).starts_with((ByteString::must_from_utf8("Throwing"sv)))) && (!(((scope)->can_throw))))){
-((*this).error((ByteString::must_from_utf8("Call to function that may throw needs to be in a try statement or a function marked as throws"sv)),span));
+if ((((((implementation).trait_name)).starts_with((ByteString::from_utf8_without_validation("Throwing"sv)))) && (!(((scope)->can_throw))))){
+((*this).error((ByteString::from_utf8_without_validation("Call to function that may throw needs to be in a try statement or a function marked as throws"sv)),span));
 }
 JaktInternal::Tuple<JaktInternal::Optional<types::StructLikeId>,bool> const parent_id___ = TRY((((*this).struct_like_id_from_type_id(lhs_type_id,scope_id,span,false,true))));
 JaktInternal::Optional<types::StructLikeId> const parent_id = ((parent_id___).template get<0>());
@@ -10639,15 +10639,15 @@ if (((implementation_function_id).has_value())){
 NonnullRefPtr<types::CheckedFunction> const implementation_function = ((*this).get_function((implementation_function_id.value())));
 if ((((implementation_function)->is_mutating()) && (!(((checked_lhs)->is_mutable(((*this).program))))))){
 if (is_assignment){
-((*this).error((ByteString::must_from_utf8("Assignment to immutable variable"sv)),span));
+((*this).error((ByteString::from_utf8_without_validation("Assignment to immutable variable"sv)),span));
 }
 else {
-((*this).error((ByteString::must_from_utf8("Cannot call mutating function on an immutable object instance"sv)),span));
+((*this).error((ByteString::from_utf8_without_validation("Cannot call mutating function on an immutable object instance"sv)),span));
 }
 
 }
 (type_id = ((implementation_function)->return_type_id));
-types::CheckedCall call_expression = types::CheckedCall(DynamicArray<types::ResolvedNamespace>::create_with({}),function_name,DynamicArray<JaktInternal::Tuple<ByteString,NonnullRefPtr<typename types::CheckedExpression>>>::create_with({(Tuple{(ByteString::must_from_utf8(""sv)), checked_rhs})}),DynamicArray<ids::TypeId>::create_with({}),implementation_function_id,type_id,((implementation_function)->can_throw),((implementation_function)->external_name),((implementation_function)->force_inline));
+types::CheckedCall call_expression = types::CheckedCall(DynamicArray<types::ResolvedNamespace>::create_with({}),function_name,DynamicArray<JaktInternal::Tuple<ByteString,NonnullRefPtr<typename types::CheckedExpression>>>::create_with({(Tuple{(ByteString::from_utf8_without_validation(""sv)), checked_rhs})}),DynamicArray<ids::TypeId>::create_with({}),implementation_function_id,type_id,((implementation_function)->can_throw),((implementation_function)->external_name),((implementation_function)->force_inline));
 (((checked_operator).trait_implementation) = types::OperatorTraitImplementation(((implementation).trait_id),((implementation).implemented_type_args),call_expression));
 }
 else {
@@ -10724,67 +10724,67 @@ JaktInternal::Tuple<JaktInternal::DynamicArray<ByteString>,bool> const trait_nam
 auto&& __jakt_match_variant = op;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 0 /* Add */: {
-return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("Add"sv)), (ByteString::must_from_utf8("ThrowingAdd"sv))}), false}));
+return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("Add"sv)), (ByteString::from_utf8_without_validation("ThrowingAdd"sv))}), false}));
 };/*case end*/
 case 1 /* Subtract */: {
-return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("Subtract"sv)), (ByteString::must_from_utf8("ThrowingSubtract"sv))}), false}));
+return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("Subtract"sv)), (ByteString::from_utf8_without_validation("ThrowingSubtract"sv))}), false}));
 };/*case end*/
 case 2 /* Multiply */: {
-return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("Multiply"sv)), (ByteString::must_from_utf8("ThrowingMultiply"sv))}), false}));
+return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("Multiply"sv)), (ByteString::from_utf8_without_validation("ThrowingMultiply"sv))}), false}));
 };/*case end*/
 case 3 /* Divide */: {
-return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("Divide"sv)), (ByteString::must_from_utf8("ThrowingDivide"sv))}), false}));
+return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("Divide"sv)), (ByteString::from_utf8_without_validation("ThrowingDivide"sv))}), false}));
 };/*case end*/
 case 4 /* Modulo */: {
-return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("Modulo"sv)), (ByteString::must_from_utf8("ThrowingModulo"sv))}), false}));
+return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("Modulo"sv)), (ByteString::from_utf8_without_validation("ThrowingModulo"sv))}), false}));
 };/*case end*/
 case 5 /* LessThan */: {
-return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("Compare"sv)), (ByteString::must_from_utf8("ThrowingCompare"sv))}), false}));
+return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("Compare"sv)), (ByteString::from_utf8_without_validation("ThrowingCompare"sv))}), false}));
 };/*case end*/
 case 6 /* LessThanOrEqual */: {
-return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("Compare"sv)), (ByteString::must_from_utf8("ThrowingCompare"sv))}), false}));
+return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("Compare"sv)), (ByteString::from_utf8_without_validation("ThrowingCompare"sv))}), false}));
 };/*case end*/
 case 7 /* GreaterThan */: {
-return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("Compare"sv)), (ByteString::must_from_utf8("ThrowingCompare"sv))}), false}));
+return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("Compare"sv)), (ByteString::from_utf8_without_validation("ThrowingCompare"sv))}), false}));
 };/*case end*/
 case 8 /* GreaterThanOrEqual */: {
-return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("Compare"sv)), (ByteString::must_from_utf8("ThrowingCompare"sv))}), false}));
+return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("Compare"sv)), (ByteString::from_utf8_without_validation("ThrowingCompare"sv))}), false}));
 };/*case end*/
 case 9 /* Equal */: {
-return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("Equal"sv)), (ByteString::must_from_utf8("ThrowingEqual"sv))}), false}));
+return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("Equal"sv)), (ByteString::from_utf8_without_validation("ThrowingEqual"sv))}), false}));
 };/*case end*/
 case 10 /* NotEqual */: {
-return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("Equal"sv)), (ByteString::must_from_utf8("ThrowingEqual"sv))}), false}));
+return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("Equal"sv)), (ByteString::from_utf8_without_validation("ThrowingEqual"sv))}), false}));
 };/*case end*/
 case 27 /* AddAssign */: {
-return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("AddAssign"sv)), (ByteString::must_from_utf8("ThrowingAddAssign"sv))}), true}));
+return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("AddAssign"sv)), (ByteString::from_utf8_without_validation("ThrowingAddAssign"sv))}), true}));
 };/*case end*/
 case 28 /* SubtractAssign */: {
-return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("SubtractAssign"sv)), (ByteString::must_from_utf8("ThrowingSubtractAssign"sv))}), true}));
+return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("SubtractAssign"sv)), (ByteString::from_utf8_without_validation("ThrowingSubtractAssign"sv))}), true}));
 };/*case end*/
 case 29 /* MultiplyAssign */: {
-return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("MultiplyAssign"sv)), (ByteString::must_from_utf8("ThrowingMultiplyAssign"sv))}), true}));
+return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("MultiplyAssign"sv)), (ByteString::from_utf8_without_validation("ThrowingMultiplyAssign"sv))}), true}));
 };/*case end*/
 case 31 /* DivideAssign */: {
-return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("DivideAssign"sv)), (ByteString::must_from_utf8("ThrowingDivideAssign"sv))}), true}));
+return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("DivideAssign"sv)), (ByteString::from_utf8_without_validation("ThrowingDivideAssign"sv))}), true}));
 };/*case end*/
 case 30 /* ModuloAssign */: {
-return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("ModuloAssign"sv)), (ByteString::must_from_utf8("ThrowingModuloAssign"sv))}), true}));
+return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("ModuloAssign"sv)), (ByteString::from_utf8_without_validation("ThrowingModuloAssign"sv))}), true}));
 };/*case end*/
 case 22 /* BitwiseAndAssign */: {
-return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("BitwiseAndAssign"sv)), (ByteString::must_from_utf8("ThrowingBitwiseAndAssign"sv))}), true}));
+return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("BitwiseAndAssign"sv)), (ByteString::from_utf8_without_validation("ThrowingBitwiseAndAssign"sv))}), true}));
 };/*case end*/
 case 23 /* BitwiseOrAssign */: {
-return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("BitwiseOrAssign"sv)), (ByteString::must_from_utf8("ThrowingBitwiseOrAssign"sv))}), true}));
+return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("BitwiseOrAssign"sv)), (ByteString::from_utf8_without_validation("ThrowingBitwiseOrAssign"sv))}), true}));
 };/*case end*/
 case 24 /* BitwiseXorAssign */: {
-return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("BitwiseXorAssign"sv)), (ByteString::must_from_utf8("ThrowingBitwiseXorAssign"sv))}), true}));
+return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("BitwiseXorAssign"sv)), (ByteString::from_utf8_without_validation("ThrowingBitwiseXorAssign"sv))}), true}));
 };/*case end*/
 case 25 /* BitwiseLeftShiftAssign */: {
-return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("BitwiseLeftShiftAssign"sv)), (ByteString::must_from_utf8("ThrowingBitwiseLeftShiftAssign"sv))}), true}));
+return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("BitwiseLeftShiftAssign"sv)), (ByteString::from_utf8_without_validation("ThrowingBitwiseLeftShiftAssign"sv))}), true}));
 };/*case end*/
 case 26 /* BitwiseRightShiftAssign */: {
-return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("BitwiseRightShiftAssign"sv)), (ByteString::must_from_utf8("ThrowingBitwiseRightShiftAssign"sv))}), true}));
+return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("BitwiseRightShiftAssign"sv)), (ByteString::from_utf8_without_validation("ThrowingBitwiseRightShiftAssign"sv))}), true}));
 };/*case end*/
 default: {
 return JaktInternal::ExplicitValue((Tuple{empty_array, false}));
@@ -10804,70 +10804,70 @@ ByteString const function_name = ({
 auto&& __jakt_match_variant = op;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 0 /* Add */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("add"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("add"sv)));
 };/*case end*/
 case 1 /* Subtract */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("subtract"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("subtract"sv)));
 };/*case end*/
 case 2 /* Multiply */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("multiply"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("multiply"sv)));
 };/*case end*/
 case 3 /* Divide */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("divide"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("divide"sv)));
 };/*case end*/
 case 4 /* Modulo */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("modulo"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("modulo"sv)));
 };/*case end*/
 case 5 /* LessThan */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("less_than"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("less_than"sv)));
 };/*case end*/
 case 6 /* LessThanOrEqual */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("less_than_or_equal"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("less_than_or_equal"sv)));
 };/*case end*/
 case 7 /* GreaterThan */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("greater_than"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("greater_than"sv)));
 };/*case end*/
 case 8 /* GreaterThanOrEqual */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("greater_than_or_equal"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("greater_than_or_equal"sv)));
 };/*case end*/
 case 9 /* Equal */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("equals"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("equals"sv)));
 };/*case end*/
 case 10 /* NotEqual */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("not_equals"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("not_equals"sv)));
 };/*case end*/
 case 27 /* AddAssign */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("add_assign"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("add_assign"sv)));
 };/*case end*/
 case 28 /* SubtractAssign */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("subtract_assign"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("subtract_assign"sv)));
 };/*case end*/
 case 29 /* MultiplyAssign */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("multiply_assign"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("multiply_assign"sv)));
 };/*case end*/
 case 31 /* DivideAssign */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("divide_assign"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("divide_assign"sv)));
 };/*case end*/
 case 30 /* ModuloAssign */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("modulo_assign"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("modulo_assign"sv)));
 };/*case end*/
 case 22 /* BitwiseAndAssign */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("bitwise_and_assign"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("bitwise_and_assign"sv)));
 };/*case end*/
 case 23 /* BitwiseOrAssign */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("bitwise_or_assign"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("bitwise_or_assign"sv)));
 };/*case end*/
 case 24 /* BitwiseXorAssign */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("bitwise_xor_assign"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("bitwise_xor_assign"sv)));
 };/*case end*/
 case 25 /* BitwiseLeftShiftAssign */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("bitwise_left_shift_assign"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("bitwise_left_shift_assign"sv)));
 };/*case end*/
 case 26 /* BitwiseRightShiftAssign */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("bitwise_right_shift_assign"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("bitwise_right_shift_assign"sv)));
 };/*case end*/
 default: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8(""sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation(""sv)));
 };/*case end*/
 }/*switch end*/
 }()
@@ -10879,8 +10879,8 @@ return JaktInternal::ExplicitValue((ByteString::must_from_utf8(""sv)));
 JaktInternal::Optional<typechecker::TraitImplementationDescriptor> const add_trait_implementation = TRY((((*this).find_any_singular_trait_implementation(lhs_type_id,trait_names,scope_id,lhs_span,DynamicArray<ids::TypeId>::create_with({rhs_type_id})))));
 if (((add_trait_implementation).has_value())){
 typechecker::TraitImplementationDescriptor const implementation = (add_trait_implementation.value());
-if ((((((implementation).trait_name)).starts_with((ByteString::must_from_utf8("Throwing"sv)))) && (!(((scope)->can_throw))))){
-((*this).error((ByteString::must_from_utf8("Call to function that may throw needs to be in a try statement or a function marked as throws"sv)),span));
+if ((((((implementation).trait_name)).starts_with((ByteString::from_utf8_without_validation("Throwing"sv)))) && (!(((scope)->can_throw))))){
+((*this).error((ByteString::from_utf8_without_validation("Call to function that may throw needs to be in a try statement or a function marked as throws"sv)),span));
 }
 JaktInternal::Tuple<JaktInternal::Optional<types::StructLikeId>,bool> const parent_id___ = TRY((((*this).struct_like_id_from_type_id(lhs_type_id,scope_id,span,false,true))));
 JaktInternal::Optional<types::StructLikeId> const parent_id = ((parent_id___).template get<0>());
@@ -10891,15 +10891,15 @@ if (((implementation_function_id).has_value())){
 NonnullRefPtr<types::CheckedFunction> const implementation_function = ((*this).get_function((implementation_function_id.value())));
 if ((((implementation_function)->is_mutating()) && (!(((checked_lhs)->is_mutable(((*this).program))))))){
 if (is_assignment){
-((*this).error((ByteString::must_from_utf8("Assignment to immutable variable"sv)),span));
+((*this).error((ByteString::from_utf8_without_validation("Assignment to immutable variable"sv)),span));
 }
 else {
-((*this).error((ByteString::must_from_utf8("Cannot call mutating function on an immutable object instance"sv)),span));
+((*this).error((ByteString::from_utf8_without_validation("Cannot call mutating function on an immutable object instance"sv)),span));
 }
 
 }
 (type_id = ((implementation_function)->return_type_id));
-types::CheckedCall call_expression = types::CheckedCall(DynamicArray<types::ResolvedNamespace>::create_with({}),function_name,DynamicArray<JaktInternal::Tuple<ByteString,NonnullRefPtr<typename types::CheckedExpression>>>::create_with({(Tuple{(ByteString::must_from_utf8(""sv)), checked_rhs})}),DynamicArray<ids::TypeId>::create_with({}),implementation_function_id,type_id,((implementation_function)->can_throw),((implementation_function)->external_name),((implementation_function)->force_inline));
+types::CheckedCall call_expression = types::CheckedCall(DynamicArray<types::ResolvedNamespace>::create_with({}),function_name,DynamicArray<JaktInternal::Tuple<ByteString,NonnullRefPtr<typename types::CheckedExpression>>>::create_with({(Tuple{(ByteString::from_utf8_without_validation(""sv)), checked_rhs})}),DynamicArray<ids::TypeId>::create_with({}),implementation_function_id,type_id,((implementation_function)->can_throw),((implementation_function)->external_name),((implementation_function)->force_inline));
 (((checked_operator).trait_implementation) = types::OperatorTraitImplementation(((implementation).trait_id),((implementation).implemented_type_args),call_expression));
 }
 else {
@@ -10976,67 +10976,67 @@ JaktInternal::Tuple<JaktInternal::DynamicArray<ByteString>,bool> const trait_nam
 auto&& __jakt_match_variant = op;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 0 /* Add */: {
-return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("Add"sv)), (ByteString::must_from_utf8("ThrowingAdd"sv))}), false}));
+return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("Add"sv)), (ByteString::from_utf8_without_validation("ThrowingAdd"sv))}), false}));
 };/*case end*/
 case 1 /* Subtract */: {
-return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("Subtract"sv)), (ByteString::must_from_utf8("ThrowingSubtract"sv))}), false}));
+return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("Subtract"sv)), (ByteString::from_utf8_without_validation("ThrowingSubtract"sv))}), false}));
 };/*case end*/
 case 2 /* Multiply */: {
-return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("Multiply"sv)), (ByteString::must_from_utf8("ThrowingMultiply"sv))}), false}));
+return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("Multiply"sv)), (ByteString::from_utf8_without_validation("ThrowingMultiply"sv))}), false}));
 };/*case end*/
 case 3 /* Divide */: {
-return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("Divide"sv)), (ByteString::must_from_utf8("ThrowingDivide"sv))}), false}));
+return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("Divide"sv)), (ByteString::from_utf8_without_validation("ThrowingDivide"sv))}), false}));
 };/*case end*/
 case 4 /* Modulo */: {
-return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("Modulo"sv)), (ByteString::must_from_utf8("ThrowingModulo"sv))}), false}));
+return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("Modulo"sv)), (ByteString::from_utf8_without_validation("ThrowingModulo"sv))}), false}));
 };/*case end*/
 case 5 /* LessThan */: {
-return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("Compare"sv)), (ByteString::must_from_utf8("ThrowingCompare"sv))}), false}));
+return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("Compare"sv)), (ByteString::from_utf8_without_validation("ThrowingCompare"sv))}), false}));
 };/*case end*/
 case 6 /* LessThanOrEqual */: {
-return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("Compare"sv)), (ByteString::must_from_utf8("ThrowingCompare"sv))}), false}));
+return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("Compare"sv)), (ByteString::from_utf8_without_validation("ThrowingCompare"sv))}), false}));
 };/*case end*/
 case 7 /* GreaterThan */: {
-return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("Compare"sv)), (ByteString::must_from_utf8("ThrowingCompare"sv))}), false}));
+return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("Compare"sv)), (ByteString::from_utf8_without_validation("ThrowingCompare"sv))}), false}));
 };/*case end*/
 case 8 /* GreaterThanOrEqual */: {
-return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("Compare"sv)), (ByteString::must_from_utf8("ThrowingCompare"sv))}), false}));
+return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("Compare"sv)), (ByteString::from_utf8_without_validation("ThrowingCompare"sv))}), false}));
 };/*case end*/
 case 9 /* Equal */: {
-return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("Equal"sv)), (ByteString::must_from_utf8("ThrowingEqual"sv))}), false}));
+return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("Equal"sv)), (ByteString::from_utf8_without_validation("ThrowingEqual"sv))}), false}));
 };/*case end*/
 case 10 /* NotEqual */: {
-return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("Equal"sv)), (ByteString::must_from_utf8("ThrowingEqual"sv))}), false}));
+return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("Equal"sv)), (ByteString::from_utf8_without_validation("ThrowingEqual"sv))}), false}));
 };/*case end*/
 case 27 /* AddAssign */: {
-return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("AddAssign"sv)), (ByteString::must_from_utf8("ThrowingAddAssign"sv))}), true}));
+return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("AddAssign"sv)), (ByteString::from_utf8_without_validation("ThrowingAddAssign"sv))}), true}));
 };/*case end*/
 case 28 /* SubtractAssign */: {
-return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("SubtractAssign"sv)), (ByteString::must_from_utf8("ThrowingSubtractAssign"sv))}), true}));
+return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("SubtractAssign"sv)), (ByteString::from_utf8_without_validation("ThrowingSubtractAssign"sv))}), true}));
 };/*case end*/
 case 29 /* MultiplyAssign */: {
-return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("MultiplyAssign"sv)), (ByteString::must_from_utf8("ThrowingMultiplyAssign"sv))}), true}));
+return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("MultiplyAssign"sv)), (ByteString::from_utf8_without_validation("ThrowingMultiplyAssign"sv))}), true}));
 };/*case end*/
 case 31 /* DivideAssign */: {
-return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("DivideAssign"sv)), (ByteString::must_from_utf8("ThrowingDivideAssign"sv))}), true}));
+return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("DivideAssign"sv)), (ByteString::from_utf8_without_validation("ThrowingDivideAssign"sv))}), true}));
 };/*case end*/
 case 30 /* ModuloAssign */: {
-return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("ModuloAssign"sv)), (ByteString::must_from_utf8("ThrowingModuloAssign"sv))}), true}));
+return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("ModuloAssign"sv)), (ByteString::from_utf8_without_validation("ThrowingModuloAssign"sv))}), true}));
 };/*case end*/
 case 22 /* BitwiseAndAssign */: {
-return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("BitwiseAndAssign"sv)), (ByteString::must_from_utf8("ThrowingBitwiseAndAssign"sv))}), true}));
+return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("BitwiseAndAssign"sv)), (ByteString::from_utf8_without_validation("ThrowingBitwiseAndAssign"sv))}), true}));
 };/*case end*/
 case 23 /* BitwiseOrAssign */: {
-return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("BitwiseOrAssign"sv)), (ByteString::must_from_utf8("ThrowingBitwiseOrAssign"sv))}), true}));
+return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("BitwiseOrAssign"sv)), (ByteString::from_utf8_without_validation("ThrowingBitwiseOrAssign"sv))}), true}));
 };/*case end*/
 case 24 /* BitwiseXorAssign */: {
-return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("BitwiseXorAssign"sv)), (ByteString::must_from_utf8("ThrowingBitwiseXorAssign"sv))}), true}));
+return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("BitwiseXorAssign"sv)), (ByteString::from_utf8_without_validation("ThrowingBitwiseXorAssign"sv))}), true}));
 };/*case end*/
 case 25 /* BitwiseLeftShiftAssign */: {
-return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("BitwiseLeftShiftAssign"sv)), (ByteString::must_from_utf8("ThrowingBitwiseLeftShiftAssign"sv))}), true}));
+return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("BitwiseLeftShiftAssign"sv)), (ByteString::from_utf8_without_validation("ThrowingBitwiseLeftShiftAssign"sv))}), true}));
 };/*case end*/
 case 26 /* BitwiseRightShiftAssign */: {
-return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("BitwiseRightShiftAssign"sv)), (ByteString::must_from_utf8("ThrowingBitwiseRightShiftAssign"sv))}), true}));
+return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("BitwiseRightShiftAssign"sv)), (ByteString::from_utf8_without_validation("ThrowingBitwiseRightShiftAssign"sv))}), true}));
 };/*case end*/
 default: {
 return JaktInternal::ExplicitValue((Tuple{empty_array, false}));
@@ -11056,70 +11056,70 @@ ByteString const function_name = ({
 auto&& __jakt_match_variant = op;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 0 /* Add */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("add"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("add"sv)));
 };/*case end*/
 case 1 /* Subtract */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("subtract"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("subtract"sv)));
 };/*case end*/
 case 2 /* Multiply */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("multiply"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("multiply"sv)));
 };/*case end*/
 case 3 /* Divide */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("divide"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("divide"sv)));
 };/*case end*/
 case 4 /* Modulo */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("modulo"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("modulo"sv)));
 };/*case end*/
 case 5 /* LessThan */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("less_than"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("less_than"sv)));
 };/*case end*/
 case 6 /* LessThanOrEqual */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("less_than_or_equal"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("less_than_or_equal"sv)));
 };/*case end*/
 case 7 /* GreaterThan */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("greater_than"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("greater_than"sv)));
 };/*case end*/
 case 8 /* GreaterThanOrEqual */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("greater_than_or_equal"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("greater_than_or_equal"sv)));
 };/*case end*/
 case 9 /* Equal */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("equals"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("equals"sv)));
 };/*case end*/
 case 10 /* NotEqual */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("not_equals"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("not_equals"sv)));
 };/*case end*/
 case 27 /* AddAssign */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("add_assign"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("add_assign"sv)));
 };/*case end*/
 case 28 /* SubtractAssign */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("subtract_assign"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("subtract_assign"sv)));
 };/*case end*/
 case 29 /* MultiplyAssign */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("multiply_assign"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("multiply_assign"sv)));
 };/*case end*/
 case 31 /* DivideAssign */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("divide_assign"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("divide_assign"sv)));
 };/*case end*/
 case 30 /* ModuloAssign */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("modulo_assign"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("modulo_assign"sv)));
 };/*case end*/
 case 22 /* BitwiseAndAssign */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("bitwise_and_assign"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("bitwise_and_assign"sv)));
 };/*case end*/
 case 23 /* BitwiseOrAssign */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("bitwise_or_assign"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("bitwise_or_assign"sv)));
 };/*case end*/
 case 24 /* BitwiseXorAssign */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("bitwise_xor_assign"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("bitwise_xor_assign"sv)));
 };/*case end*/
 case 25 /* BitwiseLeftShiftAssign */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("bitwise_left_shift_assign"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("bitwise_left_shift_assign"sv)));
 };/*case end*/
 case 26 /* BitwiseRightShiftAssign */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("bitwise_right_shift_assign"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("bitwise_right_shift_assign"sv)));
 };/*case end*/
 default: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8(""sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation(""sv)));
 };/*case end*/
 }/*switch end*/
 }()
@@ -11131,8 +11131,8 @@ return JaktInternal::ExplicitValue((ByteString::must_from_utf8(""sv)));
 JaktInternal::Optional<typechecker::TraitImplementationDescriptor> const add_trait_implementation = TRY((((*this).find_any_singular_trait_implementation(lhs_type_id,trait_names,scope_id,lhs_span,DynamicArray<ids::TypeId>::create_with({rhs_type_id})))));
 if (((add_trait_implementation).has_value())){
 typechecker::TraitImplementationDescriptor const implementation = (add_trait_implementation.value());
-if ((((((implementation).trait_name)).starts_with((ByteString::must_from_utf8("Throwing"sv)))) && (!(((scope)->can_throw))))){
-((*this).error((ByteString::must_from_utf8("Call to function that may throw needs to be in a try statement or a function marked as throws"sv)),span));
+if ((((((implementation).trait_name)).starts_with((ByteString::from_utf8_without_validation("Throwing"sv)))) && (!(((scope)->can_throw))))){
+((*this).error((ByteString::from_utf8_without_validation("Call to function that may throw needs to be in a try statement or a function marked as throws"sv)),span));
 }
 JaktInternal::Tuple<JaktInternal::Optional<types::StructLikeId>,bool> const parent_id___ = TRY((((*this).struct_like_id_from_type_id(lhs_type_id,scope_id,span,false,true))));
 JaktInternal::Optional<types::StructLikeId> const parent_id = ((parent_id___).template get<0>());
@@ -11143,15 +11143,15 @@ if (((implementation_function_id).has_value())){
 NonnullRefPtr<types::CheckedFunction> const implementation_function = ((*this).get_function((implementation_function_id.value())));
 if ((((implementation_function)->is_mutating()) && (!(((checked_lhs)->is_mutable(((*this).program))))))){
 if (is_assignment){
-((*this).error((ByteString::must_from_utf8("Assignment to immutable variable"sv)),span));
+((*this).error((ByteString::from_utf8_without_validation("Assignment to immutable variable"sv)),span));
 }
 else {
-((*this).error((ByteString::must_from_utf8("Cannot call mutating function on an immutable object instance"sv)),span));
+((*this).error((ByteString::from_utf8_without_validation("Cannot call mutating function on an immutable object instance"sv)),span));
 }
 
 }
 (type_id = ((implementation_function)->return_type_id));
-types::CheckedCall call_expression = types::CheckedCall(DynamicArray<types::ResolvedNamespace>::create_with({}),function_name,DynamicArray<JaktInternal::Tuple<ByteString,NonnullRefPtr<typename types::CheckedExpression>>>::create_with({(Tuple{(ByteString::must_from_utf8(""sv)), checked_rhs})}),DynamicArray<ids::TypeId>::create_with({}),implementation_function_id,type_id,((implementation_function)->can_throw),((implementation_function)->external_name),((implementation_function)->force_inline));
+types::CheckedCall call_expression = types::CheckedCall(DynamicArray<types::ResolvedNamespace>::create_with({}),function_name,DynamicArray<JaktInternal::Tuple<ByteString,NonnullRefPtr<typename types::CheckedExpression>>>::create_with({(Tuple{(ByteString::from_utf8_without_validation(""sv)), checked_rhs})}),DynamicArray<ids::TypeId>::create_with({}),implementation_function_id,type_id,((implementation_function)->can_throw),((implementation_function)->external_name),((implementation_function)->force_inline));
 (((checked_operator).trait_implementation) = types::OperatorTraitImplementation(((implementation).trait_id),((implementation).implemented_type_args),call_expression));
 }
 else {
@@ -11228,67 +11228,67 @@ JaktInternal::Tuple<JaktInternal::DynamicArray<ByteString>,bool> const trait_nam
 auto&& __jakt_match_variant = op;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 0 /* Add */: {
-return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("Add"sv)), (ByteString::must_from_utf8("ThrowingAdd"sv))}), false}));
+return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("Add"sv)), (ByteString::from_utf8_without_validation("ThrowingAdd"sv))}), false}));
 };/*case end*/
 case 1 /* Subtract */: {
-return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("Subtract"sv)), (ByteString::must_from_utf8("ThrowingSubtract"sv))}), false}));
+return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("Subtract"sv)), (ByteString::from_utf8_without_validation("ThrowingSubtract"sv))}), false}));
 };/*case end*/
 case 2 /* Multiply */: {
-return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("Multiply"sv)), (ByteString::must_from_utf8("ThrowingMultiply"sv))}), false}));
+return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("Multiply"sv)), (ByteString::from_utf8_without_validation("ThrowingMultiply"sv))}), false}));
 };/*case end*/
 case 3 /* Divide */: {
-return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("Divide"sv)), (ByteString::must_from_utf8("ThrowingDivide"sv))}), false}));
+return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("Divide"sv)), (ByteString::from_utf8_without_validation("ThrowingDivide"sv))}), false}));
 };/*case end*/
 case 4 /* Modulo */: {
-return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("Modulo"sv)), (ByteString::must_from_utf8("ThrowingModulo"sv))}), false}));
+return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("Modulo"sv)), (ByteString::from_utf8_without_validation("ThrowingModulo"sv))}), false}));
 };/*case end*/
 case 5 /* LessThan */: {
-return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("Compare"sv)), (ByteString::must_from_utf8("ThrowingCompare"sv))}), false}));
+return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("Compare"sv)), (ByteString::from_utf8_without_validation("ThrowingCompare"sv))}), false}));
 };/*case end*/
 case 6 /* LessThanOrEqual */: {
-return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("Compare"sv)), (ByteString::must_from_utf8("ThrowingCompare"sv))}), false}));
+return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("Compare"sv)), (ByteString::from_utf8_without_validation("ThrowingCompare"sv))}), false}));
 };/*case end*/
 case 7 /* GreaterThan */: {
-return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("Compare"sv)), (ByteString::must_from_utf8("ThrowingCompare"sv))}), false}));
+return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("Compare"sv)), (ByteString::from_utf8_without_validation("ThrowingCompare"sv))}), false}));
 };/*case end*/
 case 8 /* GreaterThanOrEqual */: {
-return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("Compare"sv)), (ByteString::must_from_utf8("ThrowingCompare"sv))}), false}));
+return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("Compare"sv)), (ByteString::from_utf8_without_validation("ThrowingCompare"sv))}), false}));
 };/*case end*/
 case 9 /* Equal */: {
-return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("Equal"sv)), (ByteString::must_from_utf8("ThrowingEqual"sv))}), false}));
+return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("Equal"sv)), (ByteString::from_utf8_without_validation("ThrowingEqual"sv))}), false}));
 };/*case end*/
 case 10 /* NotEqual */: {
-return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("Equal"sv)), (ByteString::must_from_utf8("ThrowingEqual"sv))}), false}));
+return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("Equal"sv)), (ByteString::from_utf8_without_validation("ThrowingEqual"sv))}), false}));
 };/*case end*/
 case 27 /* AddAssign */: {
-return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("AddAssign"sv)), (ByteString::must_from_utf8("ThrowingAddAssign"sv))}), true}));
+return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("AddAssign"sv)), (ByteString::from_utf8_without_validation("ThrowingAddAssign"sv))}), true}));
 };/*case end*/
 case 28 /* SubtractAssign */: {
-return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("SubtractAssign"sv)), (ByteString::must_from_utf8("ThrowingSubtractAssign"sv))}), true}));
+return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("SubtractAssign"sv)), (ByteString::from_utf8_without_validation("ThrowingSubtractAssign"sv))}), true}));
 };/*case end*/
 case 29 /* MultiplyAssign */: {
-return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("MultiplyAssign"sv)), (ByteString::must_from_utf8("ThrowingMultiplyAssign"sv))}), true}));
+return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("MultiplyAssign"sv)), (ByteString::from_utf8_without_validation("ThrowingMultiplyAssign"sv))}), true}));
 };/*case end*/
 case 31 /* DivideAssign */: {
-return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("DivideAssign"sv)), (ByteString::must_from_utf8("ThrowingDivideAssign"sv))}), true}));
+return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("DivideAssign"sv)), (ByteString::from_utf8_without_validation("ThrowingDivideAssign"sv))}), true}));
 };/*case end*/
 case 30 /* ModuloAssign */: {
-return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("ModuloAssign"sv)), (ByteString::must_from_utf8("ThrowingModuloAssign"sv))}), true}));
+return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("ModuloAssign"sv)), (ByteString::from_utf8_without_validation("ThrowingModuloAssign"sv))}), true}));
 };/*case end*/
 case 22 /* BitwiseAndAssign */: {
-return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("BitwiseAndAssign"sv)), (ByteString::must_from_utf8("ThrowingBitwiseAndAssign"sv))}), true}));
+return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("BitwiseAndAssign"sv)), (ByteString::from_utf8_without_validation("ThrowingBitwiseAndAssign"sv))}), true}));
 };/*case end*/
 case 23 /* BitwiseOrAssign */: {
-return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("BitwiseOrAssign"sv)), (ByteString::must_from_utf8("ThrowingBitwiseOrAssign"sv))}), true}));
+return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("BitwiseOrAssign"sv)), (ByteString::from_utf8_without_validation("ThrowingBitwiseOrAssign"sv))}), true}));
 };/*case end*/
 case 24 /* BitwiseXorAssign */: {
-return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("BitwiseXorAssign"sv)), (ByteString::must_from_utf8("ThrowingBitwiseXorAssign"sv))}), true}));
+return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("BitwiseXorAssign"sv)), (ByteString::from_utf8_without_validation("ThrowingBitwiseXorAssign"sv))}), true}));
 };/*case end*/
 case 25 /* BitwiseLeftShiftAssign */: {
-return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("BitwiseLeftShiftAssign"sv)), (ByteString::must_from_utf8("ThrowingBitwiseLeftShiftAssign"sv))}), true}));
+return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("BitwiseLeftShiftAssign"sv)), (ByteString::from_utf8_without_validation("ThrowingBitwiseLeftShiftAssign"sv))}), true}));
 };/*case end*/
 case 26 /* BitwiseRightShiftAssign */: {
-return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("BitwiseRightShiftAssign"sv)), (ByteString::must_from_utf8("ThrowingBitwiseRightShiftAssign"sv))}), true}));
+return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("BitwiseRightShiftAssign"sv)), (ByteString::from_utf8_without_validation("ThrowingBitwiseRightShiftAssign"sv))}), true}));
 };/*case end*/
 default: {
 return JaktInternal::ExplicitValue((Tuple{empty_array, false}));
@@ -11308,70 +11308,70 @@ ByteString const function_name = ({
 auto&& __jakt_match_variant = op;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 0 /* Add */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("add"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("add"sv)));
 };/*case end*/
 case 1 /* Subtract */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("subtract"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("subtract"sv)));
 };/*case end*/
 case 2 /* Multiply */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("multiply"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("multiply"sv)));
 };/*case end*/
 case 3 /* Divide */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("divide"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("divide"sv)));
 };/*case end*/
 case 4 /* Modulo */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("modulo"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("modulo"sv)));
 };/*case end*/
 case 5 /* LessThan */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("less_than"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("less_than"sv)));
 };/*case end*/
 case 6 /* LessThanOrEqual */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("less_than_or_equal"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("less_than_or_equal"sv)));
 };/*case end*/
 case 7 /* GreaterThan */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("greater_than"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("greater_than"sv)));
 };/*case end*/
 case 8 /* GreaterThanOrEqual */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("greater_than_or_equal"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("greater_than_or_equal"sv)));
 };/*case end*/
 case 9 /* Equal */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("equals"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("equals"sv)));
 };/*case end*/
 case 10 /* NotEqual */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("not_equals"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("not_equals"sv)));
 };/*case end*/
 case 27 /* AddAssign */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("add_assign"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("add_assign"sv)));
 };/*case end*/
 case 28 /* SubtractAssign */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("subtract_assign"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("subtract_assign"sv)));
 };/*case end*/
 case 29 /* MultiplyAssign */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("multiply_assign"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("multiply_assign"sv)));
 };/*case end*/
 case 31 /* DivideAssign */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("divide_assign"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("divide_assign"sv)));
 };/*case end*/
 case 30 /* ModuloAssign */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("modulo_assign"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("modulo_assign"sv)));
 };/*case end*/
 case 22 /* BitwiseAndAssign */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("bitwise_and_assign"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("bitwise_and_assign"sv)));
 };/*case end*/
 case 23 /* BitwiseOrAssign */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("bitwise_or_assign"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("bitwise_or_assign"sv)));
 };/*case end*/
 case 24 /* BitwiseXorAssign */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("bitwise_xor_assign"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("bitwise_xor_assign"sv)));
 };/*case end*/
 case 25 /* BitwiseLeftShiftAssign */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("bitwise_left_shift_assign"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("bitwise_left_shift_assign"sv)));
 };/*case end*/
 case 26 /* BitwiseRightShiftAssign */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("bitwise_right_shift_assign"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("bitwise_right_shift_assign"sv)));
 };/*case end*/
 default: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8(""sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation(""sv)));
 };/*case end*/
 }/*switch end*/
 }()
@@ -11383,8 +11383,8 @@ return JaktInternal::ExplicitValue((ByteString::must_from_utf8(""sv)));
 JaktInternal::Optional<typechecker::TraitImplementationDescriptor> const add_trait_implementation = TRY((((*this).find_any_singular_trait_implementation(lhs_type_id,trait_names,scope_id,lhs_span,DynamicArray<ids::TypeId>::create_with({rhs_type_id})))));
 if (((add_trait_implementation).has_value())){
 typechecker::TraitImplementationDescriptor const implementation = (add_trait_implementation.value());
-if ((((((implementation).trait_name)).starts_with((ByteString::must_from_utf8("Throwing"sv)))) && (!(((scope)->can_throw))))){
-((*this).error((ByteString::must_from_utf8("Call to function that may throw needs to be in a try statement or a function marked as throws"sv)),span));
+if ((((((implementation).trait_name)).starts_with((ByteString::from_utf8_without_validation("Throwing"sv)))) && (!(((scope)->can_throw))))){
+((*this).error((ByteString::from_utf8_without_validation("Call to function that may throw needs to be in a try statement or a function marked as throws"sv)),span));
 }
 JaktInternal::Tuple<JaktInternal::Optional<types::StructLikeId>,bool> const parent_id___ = TRY((((*this).struct_like_id_from_type_id(lhs_type_id,scope_id,span,false,true))));
 JaktInternal::Optional<types::StructLikeId> const parent_id = ((parent_id___).template get<0>());
@@ -11395,15 +11395,15 @@ if (((implementation_function_id).has_value())){
 NonnullRefPtr<types::CheckedFunction> const implementation_function = ((*this).get_function((implementation_function_id.value())));
 if ((((implementation_function)->is_mutating()) && (!(((checked_lhs)->is_mutable(((*this).program))))))){
 if (is_assignment){
-((*this).error((ByteString::must_from_utf8("Assignment to immutable variable"sv)),span));
+((*this).error((ByteString::from_utf8_without_validation("Assignment to immutable variable"sv)),span));
 }
 else {
-((*this).error((ByteString::must_from_utf8("Cannot call mutating function on an immutable object instance"sv)),span));
+((*this).error((ByteString::from_utf8_without_validation("Cannot call mutating function on an immutable object instance"sv)),span));
 }
 
 }
 (type_id = ((implementation_function)->return_type_id));
-types::CheckedCall call_expression = types::CheckedCall(DynamicArray<types::ResolvedNamespace>::create_with({}),function_name,DynamicArray<JaktInternal::Tuple<ByteString,NonnullRefPtr<typename types::CheckedExpression>>>::create_with({(Tuple{(ByteString::must_from_utf8(""sv)), checked_rhs})}),DynamicArray<ids::TypeId>::create_with({}),implementation_function_id,type_id,((implementation_function)->can_throw),((implementation_function)->external_name),((implementation_function)->force_inline));
+types::CheckedCall call_expression = types::CheckedCall(DynamicArray<types::ResolvedNamespace>::create_with({}),function_name,DynamicArray<JaktInternal::Tuple<ByteString,NonnullRefPtr<typename types::CheckedExpression>>>::create_with({(Tuple{(ByteString::from_utf8_without_validation(""sv)), checked_rhs})}),DynamicArray<ids::TypeId>::create_with({}),implementation_function_id,type_id,((implementation_function)->can_throw),((implementation_function)->external_name),((implementation_function)->force_inline));
 (((checked_operator).trait_implementation) = types::OperatorTraitImplementation(((implementation).trait_id),((implementation).implemented_type_args),call_expression));
 }
 else {
@@ -11480,67 +11480,67 @@ JaktInternal::Tuple<JaktInternal::DynamicArray<ByteString>,bool> const trait_nam
 auto&& __jakt_match_variant = op;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 0 /* Add */: {
-return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("Add"sv)), (ByteString::must_from_utf8("ThrowingAdd"sv))}), false}));
+return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("Add"sv)), (ByteString::from_utf8_without_validation("ThrowingAdd"sv))}), false}));
 };/*case end*/
 case 1 /* Subtract */: {
-return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("Subtract"sv)), (ByteString::must_from_utf8("ThrowingSubtract"sv))}), false}));
+return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("Subtract"sv)), (ByteString::from_utf8_without_validation("ThrowingSubtract"sv))}), false}));
 };/*case end*/
 case 2 /* Multiply */: {
-return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("Multiply"sv)), (ByteString::must_from_utf8("ThrowingMultiply"sv))}), false}));
+return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("Multiply"sv)), (ByteString::from_utf8_without_validation("ThrowingMultiply"sv))}), false}));
 };/*case end*/
 case 3 /* Divide */: {
-return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("Divide"sv)), (ByteString::must_from_utf8("ThrowingDivide"sv))}), false}));
+return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("Divide"sv)), (ByteString::from_utf8_without_validation("ThrowingDivide"sv))}), false}));
 };/*case end*/
 case 4 /* Modulo */: {
-return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("Modulo"sv)), (ByteString::must_from_utf8("ThrowingModulo"sv))}), false}));
+return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("Modulo"sv)), (ByteString::from_utf8_without_validation("ThrowingModulo"sv))}), false}));
 };/*case end*/
 case 5 /* LessThan */: {
-return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("Compare"sv)), (ByteString::must_from_utf8("ThrowingCompare"sv))}), false}));
+return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("Compare"sv)), (ByteString::from_utf8_without_validation("ThrowingCompare"sv))}), false}));
 };/*case end*/
 case 6 /* LessThanOrEqual */: {
-return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("Compare"sv)), (ByteString::must_from_utf8("ThrowingCompare"sv))}), false}));
+return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("Compare"sv)), (ByteString::from_utf8_without_validation("ThrowingCompare"sv))}), false}));
 };/*case end*/
 case 7 /* GreaterThan */: {
-return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("Compare"sv)), (ByteString::must_from_utf8("ThrowingCompare"sv))}), false}));
+return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("Compare"sv)), (ByteString::from_utf8_without_validation("ThrowingCompare"sv))}), false}));
 };/*case end*/
 case 8 /* GreaterThanOrEqual */: {
-return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("Compare"sv)), (ByteString::must_from_utf8("ThrowingCompare"sv))}), false}));
+return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("Compare"sv)), (ByteString::from_utf8_without_validation("ThrowingCompare"sv))}), false}));
 };/*case end*/
 case 9 /* Equal */: {
-return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("Equal"sv)), (ByteString::must_from_utf8("ThrowingEqual"sv))}), false}));
+return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("Equal"sv)), (ByteString::from_utf8_without_validation("ThrowingEqual"sv))}), false}));
 };/*case end*/
 case 10 /* NotEqual */: {
-return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("Equal"sv)), (ByteString::must_from_utf8("ThrowingEqual"sv))}), false}));
+return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("Equal"sv)), (ByteString::from_utf8_without_validation("ThrowingEqual"sv))}), false}));
 };/*case end*/
 case 27 /* AddAssign */: {
-return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("AddAssign"sv)), (ByteString::must_from_utf8("ThrowingAddAssign"sv))}), true}));
+return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("AddAssign"sv)), (ByteString::from_utf8_without_validation("ThrowingAddAssign"sv))}), true}));
 };/*case end*/
 case 28 /* SubtractAssign */: {
-return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("SubtractAssign"sv)), (ByteString::must_from_utf8("ThrowingSubtractAssign"sv))}), true}));
+return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("SubtractAssign"sv)), (ByteString::from_utf8_without_validation("ThrowingSubtractAssign"sv))}), true}));
 };/*case end*/
 case 29 /* MultiplyAssign */: {
-return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("MultiplyAssign"sv)), (ByteString::must_from_utf8("ThrowingMultiplyAssign"sv))}), true}));
+return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("MultiplyAssign"sv)), (ByteString::from_utf8_without_validation("ThrowingMultiplyAssign"sv))}), true}));
 };/*case end*/
 case 31 /* DivideAssign */: {
-return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("DivideAssign"sv)), (ByteString::must_from_utf8("ThrowingDivideAssign"sv))}), true}));
+return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("DivideAssign"sv)), (ByteString::from_utf8_without_validation("ThrowingDivideAssign"sv))}), true}));
 };/*case end*/
 case 30 /* ModuloAssign */: {
-return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("ModuloAssign"sv)), (ByteString::must_from_utf8("ThrowingModuloAssign"sv))}), true}));
+return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("ModuloAssign"sv)), (ByteString::from_utf8_without_validation("ThrowingModuloAssign"sv))}), true}));
 };/*case end*/
 case 22 /* BitwiseAndAssign */: {
-return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("BitwiseAndAssign"sv)), (ByteString::must_from_utf8("ThrowingBitwiseAndAssign"sv))}), true}));
+return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("BitwiseAndAssign"sv)), (ByteString::from_utf8_without_validation("ThrowingBitwiseAndAssign"sv))}), true}));
 };/*case end*/
 case 23 /* BitwiseOrAssign */: {
-return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("BitwiseOrAssign"sv)), (ByteString::must_from_utf8("ThrowingBitwiseOrAssign"sv))}), true}));
+return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("BitwiseOrAssign"sv)), (ByteString::from_utf8_without_validation("ThrowingBitwiseOrAssign"sv))}), true}));
 };/*case end*/
 case 24 /* BitwiseXorAssign */: {
-return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("BitwiseXorAssign"sv)), (ByteString::must_from_utf8("ThrowingBitwiseXorAssign"sv))}), true}));
+return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("BitwiseXorAssign"sv)), (ByteString::from_utf8_without_validation("ThrowingBitwiseXorAssign"sv))}), true}));
 };/*case end*/
 case 25 /* BitwiseLeftShiftAssign */: {
-return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("BitwiseLeftShiftAssign"sv)), (ByteString::must_from_utf8("ThrowingBitwiseLeftShiftAssign"sv))}), true}));
+return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("BitwiseLeftShiftAssign"sv)), (ByteString::from_utf8_without_validation("ThrowingBitwiseLeftShiftAssign"sv))}), true}));
 };/*case end*/
 case 26 /* BitwiseRightShiftAssign */: {
-return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("BitwiseRightShiftAssign"sv)), (ByteString::must_from_utf8("ThrowingBitwiseRightShiftAssign"sv))}), true}));
+return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("BitwiseRightShiftAssign"sv)), (ByteString::from_utf8_without_validation("ThrowingBitwiseRightShiftAssign"sv))}), true}));
 };/*case end*/
 default: {
 return JaktInternal::ExplicitValue((Tuple{empty_array, false}));
@@ -11560,70 +11560,70 @@ ByteString const function_name = ({
 auto&& __jakt_match_variant = op;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 0 /* Add */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("add"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("add"sv)));
 };/*case end*/
 case 1 /* Subtract */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("subtract"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("subtract"sv)));
 };/*case end*/
 case 2 /* Multiply */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("multiply"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("multiply"sv)));
 };/*case end*/
 case 3 /* Divide */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("divide"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("divide"sv)));
 };/*case end*/
 case 4 /* Modulo */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("modulo"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("modulo"sv)));
 };/*case end*/
 case 5 /* LessThan */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("less_than"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("less_than"sv)));
 };/*case end*/
 case 6 /* LessThanOrEqual */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("less_than_or_equal"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("less_than_or_equal"sv)));
 };/*case end*/
 case 7 /* GreaterThan */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("greater_than"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("greater_than"sv)));
 };/*case end*/
 case 8 /* GreaterThanOrEqual */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("greater_than_or_equal"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("greater_than_or_equal"sv)));
 };/*case end*/
 case 9 /* Equal */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("equals"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("equals"sv)));
 };/*case end*/
 case 10 /* NotEqual */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("not_equals"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("not_equals"sv)));
 };/*case end*/
 case 27 /* AddAssign */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("add_assign"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("add_assign"sv)));
 };/*case end*/
 case 28 /* SubtractAssign */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("subtract_assign"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("subtract_assign"sv)));
 };/*case end*/
 case 29 /* MultiplyAssign */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("multiply_assign"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("multiply_assign"sv)));
 };/*case end*/
 case 31 /* DivideAssign */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("divide_assign"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("divide_assign"sv)));
 };/*case end*/
 case 30 /* ModuloAssign */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("modulo_assign"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("modulo_assign"sv)));
 };/*case end*/
 case 22 /* BitwiseAndAssign */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("bitwise_and_assign"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("bitwise_and_assign"sv)));
 };/*case end*/
 case 23 /* BitwiseOrAssign */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("bitwise_or_assign"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("bitwise_or_assign"sv)));
 };/*case end*/
 case 24 /* BitwiseXorAssign */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("bitwise_xor_assign"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("bitwise_xor_assign"sv)));
 };/*case end*/
 case 25 /* BitwiseLeftShiftAssign */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("bitwise_left_shift_assign"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("bitwise_left_shift_assign"sv)));
 };/*case end*/
 case 26 /* BitwiseRightShiftAssign */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("bitwise_right_shift_assign"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("bitwise_right_shift_assign"sv)));
 };/*case end*/
 default: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8(""sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation(""sv)));
 };/*case end*/
 }/*switch end*/
 }()
@@ -11635,8 +11635,8 @@ return JaktInternal::ExplicitValue((ByteString::must_from_utf8(""sv)));
 JaktInternal::Optional<typechecker::TraitImplementationDescriptor> const add_trait_implementation = TRY((((*this).find_any_singular_trait_implementation(lhs_type_id,trait_names,scope_id,lhs_span,DynamicArray<ids::TypeId>::create_with({rhs_type_id})))));
 if (((add_trait_implementation).has_value())){
 typechecker::TraitImplementationDescriptor const implementation = (add_trait_implementation.value());
-if ((((((implementation).trait_name)).starts_with((ByteString::must_from_utf8("Throwing"sv)))) && (!(((scope)->can_throw))))){
-((*this).error((ByteString::must_from_utf8("Call to function that may throw needs to be in a try statement or a function marked as throws"sv)),span));
+if ((((((implementation).trait_name)).starts_with((ByteString::from_utf8_without_validation("Throwing"sv)))) && (!(((scope)->can_throw))))){
+((*this).error((ByteString::from_utf8_without_validation("Call to function that may throw needs to be in a try statement or a function marked as throws"sv)),span));
 }
 JaktInternal::Tuple<JaktInternal::Optional<types::StructLikeId>,bool> const parent_id___ = TRY((((*this).struct_like_id_from_type_id(lhs_type_id,scope_id,span,false,true))));
 JaktInternal::Optional<types::StructLikeId> const parent_id = ((parent_id___).template get<0>());
@@ -11647,15 +11647,15 @@ if (((implementation_function_id).has_value())){
 NonnullRefPtr<types::CheckedFunction> const implementation_function = ((*this).get_function((implementation_function_id.value())));
 if ((((implementation_function)->is_mutating()) && (!(((checked_lhs)->is_mutable(((*this).program))))))){
 if (is_assignment){
-((*this).error((ByteString::must_from_utf8("Assignment to immutable variable"sv)),span));
+((*this).error((ByteString::from_utf8_without_validation("Assignment to immutable variable"sv)),span));
 }
 else {
-((*this).error((ByteString::must_from_utf8("Cannot call mutating function on an immutable object instance"sv)),span));
+((*this).error((ByteString::from_utf8_without_validation("Cannot call mutating function on an immutable object instance"sv)),span));
 }
 
 }
 (type_id = ((implementation_function)->return_type_id));
-types::CheckedCall call_expression = types::CheckedCall(DynamicArray<types::ResolvedNamespace>::create_with({}),function_name,DynamicArray<JaktInternal::Tuple<ByteString,NonnullRefPtr<typename types::CheckedExpression>>>::create_with({(Tuple{(ByteString::must_from_utf8(""sv)), checked_rhs})}),DynamicArray<ids::TypeId>::create_with({}),implementation_function_id,type_id,((implementation_function)->can_throw),((implementation_function)->external_name),((implementation_function)->force_inline));
+types::CheckedCall call_expression = types::CheckedCall(DynamicArray<types::ResolvedNamespace>::create_with({}),function_name,DynamicArray<JaktInternal::Tuple<ByteString,NonnullRefPtr<typename types::CheckedExpression>>>::create_with({(Tuple{(ByteString::from_utf8_without_validation(""sv)), checked_rhs})}),DynamicArray<ids::TypeId>::create_with({}),implementation_function_id,type_id,((implementation_function)->can_throw),((implementation_function)->external_name),((implementation_function)->force_inline));
 (((checked_operator).trait_implementation) = types::OperatorTraitImplementation(((implementation).trait_id),((implementation).implemented_type_args),call_expression));
 }
 else {
@@ -11732,67 +11732,67 @@ JaktInternal::Tuple<JaktInternal::DynamicArray<ByteString>,bool> const trait_nam
 auto&& __jakt_match_variant = op;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 0 /* Add */: {
-return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("Add"sv)), (ByteString::must_from_utf8("ThrowingAdd"sv))}), false}));
+return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("Add"sv)), (ByteString::from_utf8_without_validation("ThrowingAdd"sv))}), false}));
 };/*case end*/
 case 1 /* Subtract */: {
-return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("Subtract"sv)), (ByteString::must_from_utf8("ThrowingSubtract"sv))}), false}));
+return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("Subtract"sv)), (ByteString::from_utf8_without_validation("ThrowingSubtract"sv))}), false}));
 };/*case end*/
 case 2 /* Multiply */: {
-return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("Multiply"sv)), (ByteString::must_from_utf8("ThrowingMultiply"sv))}), false}));
+return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("Multiply"sv)), (ByteString::from_utf8_without_validation("ThrowingMultiply"sv))}), false}));
 };/*case end*/
 case 3 /* Divide */: {
-return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("Divide"sv)), (ByteString::must_from_utf8("ThrowingDivide"sv))}), false}));
+return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("Divide"sv)), (ByteString::from_utf8_without_validation("ThrowingDivide"sv))}), false}));
 };/*case end*/
 case 4 /* Modulo */: {
-return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("Modulo"sv)), (ByteString::must_from_utf8("ThrowingModulo"sv))}), false}));
+return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("Modulo"sv)), (ByteString::from_utf8_without_validation("ThrowingModulo"sv))}), false}));
 };/*case end*/
 case 5 /* LessThan */: {
-return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("Compare"sv)), (ByteString::must_from_utf8("ThrowingCompare"sv))}), false}));
+return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("Compare"sv)), (ByteString::from_utf8_without_validation("ThrowingCompare"sv))}), false}));
 };/*case end*/
 case 6 /* LessThanOrEqual */: {
-return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("Compare"sv)), (ByteString::must_from_utf8("ThrowingCompare"sv))}), false}));
+return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("Compare"sv)), (ByteString::from_utf8_without_validation("ThrowingCompare"sv))}), false}));
 };/*case end*/
 case 7 /* GreaterThan */: {
-return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("Compare"sv)), (ByteString::must_from_utf8("ThrowingCompare"sv))}), false}));
+return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("Compare"sv)), (ByteString::from_utf8_without_validation("ThrowingCompare"sv))}), false}));
 };/*case end*/
 case 8 /* GreaterThanOrEqual */: {
-return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("Compare"sv)), (ByteString::must_from_utf8("ThrowingCompare"sv))}), false}));
+return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("Compare"sv)), (ByteString::from_utf8_without_validation("ThrowingCompare"sv))}), false}));
 };/*case end*/
 case 9 /* Equal */: {
-return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("Equal"sv)), (ByteString::must_from_utf8("ThrowingEqual"sv))}), false}));
+return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("Equal"sv)), (ByteString::from_utf8_without_validation("ThrowingEqual"sv))}), false}));
 };/*case end*/
 case 10 /* NotEqual */: {
-return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("Equal"sv)), (ByteString::must_from_utf8("ThrowingEqual"sv))}), false}));
+return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("Equal"sv)), (ByteString::from_utf8_without_validation("ThrowingEqual"sv))}), false}));
 };/*case end*/
 case 27 /* AddAssign */: {
-return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("AddAssign"sv)), (ByteString::must_from_utf8("ThrowingAddAssign"sv))}), true}));
+return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("AddAssign"sv)), (ByteString::from_utf8_without_validation("ThrowingAddAssign"sv))}), true}));
 };/*case end*/
 case 28 /* SubtractAssign */: {
-return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("SubtractAssign"sv)), (ByteString::must_from_utf8("ThrowingSubtractAssign"sv))}), true}));
+return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("SubtractAssign"sv)), (ByteString::from_utf8_without_validation("ThrowingSubtractAssign"sv))}), true}));
 };/*case end*/
 case 29 /* MultiplyAssign */: {
-return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("MultiplyAssign"sv)), (ByteString::must_from_utf8("ThrowingMultiplyAssign"sv))}), true}));
+return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("MultiplyAssign"sv)), (ByteString::from_utf8_without_validation("ThrowingMultiplyAssign"sv))}), true}));
 };/*case end*/
 case 31 /* DivideAssign */: {
-return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("DivideAssign"sv)), (ByteString::must_from_utf8("ThrowingDivideAssign"sv))}), true}));
+return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("DivideAssign"sv)), (ByteString::from_utf8_without_validation("ThrowingDivideAssign"sv))}), true}));
 };/*case end*/
 case 30 /* ModuloAssign */: {
-return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("ModuloAssign"sv)), (ByteString::must_from_utf8("ThrowingModuloAssign"sv))}), true}));
+return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("ModuloAssign"sv)), (ByteString::from_utf8_without_validation("ThrowingModuloAssign"sv))}), true}));
 };/*case end*/
 case 22 /* BitwiseAndAssign */: {
-return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("BitwiseAndAssign"sv)), (ByteString::must_from_utf8("ThrowingBitwiseAndAssign"sv))}), true}));
+return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("BitwiseAndAssign"sv)), (ByteString::from_utf8_without_validation("ThrowingBitwiseAndAssign"sv))}), true}));
 };/*case end*/
 case 23 /* BitwiseOrAssign */: {
-return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("BitwiseOrAssign"sv)), (ByteString::must_from_utf8("ThrowingBitwiseOrAssign"sv))}), true}));
+return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("BitwiseOrAssign"sv)), (ByteString::from_utf8_without_validation("ThrowingBitwiseOrAssign"sv))}), true}));
 };/*case end*/
 case 24 /* BitwiseXorAssign */: {
-return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("BitwiseXorAssign"sv)), (ByteString::must_from_utf8("ThrowingBitwiseXorAssign"sv))}), true}));
+return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("BitwiseXorAssign"sv)), (ByteString::from_utf8_without_validation("ThrowingBitwiseXorAssign"sv))}), true}));
 };/*case end*/
 case 25 /* BitwiseLeftShiftAssign */: {
-return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("BitwiseLeftShiftAssign"sv)), (ByteString::must_from_utf8("ThrowingBitwiseLeftShiftAssign"sv))}), true}));
+return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("BitwiseLeftShiftAssign"sv)), (ByteString::from_utf8_without_validation("ThrowingBitwiseLeftShiftAssign"sv))}), true}));
 };/*case end*/
 case 26 /* BitwiseRightShiftAssign */: {
-return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("BitwiseRightShiftAssign"sv)), (ByteString::must_from_utf8("ThrowingBitwiseRightShiftAssign"sv))}), true}));
+return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("BitwiseRightShiftAssign"sv)), (ByteString::from_utf8_without_validation("ThrowingBitwiseRightShiftAssign"sv))}), true}));
 };/*case end*/
 default: {
 return JaktInternal::ExplicitValue((Tuple{empty_array, false}));
@@ -11812,70 +11812,70 @@ ByteString const function_name = ({
 auto&& __jakt_match_variant = op;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 0 /* Add */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("add"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("add"sv)));
 };/*case end*/
 case 1 /* Subtract */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("subtract"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("subtract"sv)));
 };/*case end*/
 case 2 /* Multiply */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("multiply"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("multiply"sv)));
 };/*case end*/
 case 3 /* Divide */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("divide"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("divide"sv)));
 };/*case end*/
 case 4 /* Modulo */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("modulo"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("modulo"sv)));
 };/*case end*/
 case 5 /* LessThan */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("less_than"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("less_than"sv)));
 };/*case end*/
 case 6 /* LessThanOrEqual */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("less_than_or_equal"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("less_than_or_equal"sv)));
 };/*case end*/
 case 7 /* GreaterThan */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("greater_than"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("greater_than"sv)));
 };/*case end*/
 case 8 /* GreaterThanOrEqual */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("greater_than_or_equal"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("greater_than_or_equal"sv)));
 };/*case end*/
 case 9 /* Equal */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("equals"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("equals"sv)));
 };/*case end*/
 case 10 /* NotEqual */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("not_equals"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("not_equals"sv)));
 };/*case end*/
 case 27 /* AddAssign */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("add_assign"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("add_assign"sv)));
 };/*case end*/
 case 28 /* SubtractAssign */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("subtract_assign"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("subtract_assign"sv)));
 };/*case end*/
 case 29 /* MultiplyAssign */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("multiply_assign"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("multiply_assign"sv)));
 };/*case end*/
 case 31 /* DivideAssign */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("divide_assign"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("divide_assign"sv)));
 };/*case end*/
 case 30 /* ModuloAssign */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("modulo_assign"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("modulo_assign"sv)));
 };/*case end*/
 case 22 /* BitwiseAndAssign */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("bitwise_and_assign"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("bitwise_and_assign"sv)));
 };/*case end*/
 case 23 /* BitwiseOrAssign */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("bitwise_or_assign"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("bitwise_or_assign"sv)));
 };/*case end*/
 case 24 /* BitwiseXorAssign */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("bitwise_xor_assign"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("bitwise_xor_assign"sv)));
 };/*case end*/
 case 25 /* BitwiseLeftShiftAssign */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("bitwise_left_shift_assign"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("bitwise_left_shift_assign"sv)));
 };/*case end*/
 case 26 /* BitwiseRightShiftAssign */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("bitwise_right_shift_assign"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("bitwise_right_shift_assign"sv)));
 };/*case end*/
 default: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8(""sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation(""sv)));
 };/*case end*/
 }/*switch end*/
 }()
@@ -11887,8 +11887,8 @@ return JaktInternal::ExplicitValue((ByteString::must_from_utf8(""sv)));
 JaktInternal::Optional<typechecker::TraitImplementationDescriptor> const add_trait_implementation = TRY((((*this).find_any_singular_trait_implementation(lhs_type_id,trait_names,scope_id,lhs_span,DynamicArray<ids::TypeId>::create_with({rhs_type_id})))));
 if (((add_trait_implementation).has_value())){
 typechecker::TraitImplementationDescriptor const implementation = (add_trait_implementation.value());
-if ((((((implementation).trait_name)).starts_with((ByteString::must_from_utf8("Throwing"sv)))) && (!(((scope)->can_throw))))){
-((*this).error((ByteString::must_from_utf8("Call to function that may throw needs to be in a try statement or a function marked as throws"sv)),span));
+if ((((((implementation).trait_name)).starts_with((ByteString::from_utf8_without_validation("Throwing"sv)))) && (!(((scope)->can_throw))))){
+((*this).error((ByteString::from_utf8_without_validation("Call to function that may throw needs to be in a try statement or a function marked as throws"sv)),span));
 }
 JaktInternal::Tuple<JaktInternal::Optional<types::StructLikeId>,bool> const parent_id___ = TRY((((*this).struct_like_id_from_type_id(lhs_type_id,scope_id,span,false,true))));
 JaktInternal::Optional<types::StructLikeId> const parent_id = ((parent_id___).template get<0>());
@@ -11899,15 +11899,15 @@ if (((implementation_function_id).has_value())){
 NonnullRefPtr<types::CheckedFunction> const implementation_function = ((*this).get_function((implementation_function_id.value())));
 if ((((implementation_function)->is_mutating()) && (!(((checked_lhs)->is_mutable(((*this).program))))))){
 if (is_assignment){
-((*this).error((ByteString::must_from_utf8("Assignment to immutable variable"sv)),span));
+((*this).error((ByteString::from_utf8_without_validation("Assignment to immutable variable"sv)),span));
 }
 else {
-((*this).error((ByteString::must_from_utf8("Cannot call mutating function on an immutable object instance"sv)),span));
+((*this).error((ByteString::from_utf8_without_validation("Cannot call mutating function on an immutable object instance"sv)),span));
 }
 
 }
 (type_id = ((implementation_function)->return_type_id));
-types::CheckedCall call_expression = types::CheckedCall(DynamicArray<types::ResolvedNamespace>::create_with({}),function_name,DynamicArray<JaktInternal::Tuple<ByteString,NonnullRefPtr<typename types::CheckedExpression>>>::create_with({(Tuple{(ByteString::must_from_utf8(""sv)), checked_rhs})}),DynamicArray<ids::TypeId>::create_with({}),implementation_function_id,type_id,((implementation_function)->can_throw),((implementation_function)->external_name),((implementation_function)->force_inline));
+types::CheckedCall call_expression = types::CheckedCall(DynamicArray<types::ResolvedNamespace>::create_with({}),function_name,DynamicArray<JaktInternal::Tuple<ByteString,NonnullRefPtr<typename types::CheckedExpression>>>::create_with({(Tuple{(ByteString::from_utf8_without_validation(""sv)), checked_rhs})}),DynamicArray<ids::TypeId>::create_with({}),implementation_function_id,type_id,((implementation_function)->can_throw),((implementation_function)->external_name),((implementation_function)->force_inline));
 (((checked_operator).trait_implementation) = types::OperatorTraitImplementation(((implementation).trait_id),((implementation).implemented_type_args),call_expression));
 }
 else {
@@ -11984,67 +11984,67 @@ JaktInternal::Tuple<JaktInternal::DynamicArray<ByteString>,bool> const trait_nam
 auto&& __jakt_match_variant = op;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 0 /* Add */: {
-return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("Add"sv)), (ByteString::must_from_utf8("ThrowingAdd"sv))}), false}));
+return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("Add"sv)), (ByteString::from_utf8_without_validation("ThrowingAdd"sv))}), false}));
 };/*case end*/
 case 1 /* Subtract */: {
-return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("Subtract"sv)), (ByteString::must_from_utf8("ThrowingSubtract"sv))}), false}));
+return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("Subtract"sv)), (ByteString::from_utf8_without_validation("ThrowingSubtract"sv))}), false}));
 };/*case end*/
 case 2 /* Multiply */: {
-return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("Multiply"sv)), (ByteString::must_from_utf8("ThrowingMultiply"sv))}), false}));
+return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("Multiply"sv)), (ByteString::from_utf8_without_validation("ThrowingMultiply"sv))}), false}));
 };/*case end*/
 case 3 /* Divide */: {
-return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("Divide"sv)), (ByteString::must_from_utf8("ThrowingDivide"sv))}), false}));
+return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("Divide"sv)), (ByteString::from_utf8_without_validation("ThrowingDivide"sv))}), false}));
 };/*case end*/
 case 4 /* Modulo */: {
-return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("Modulo"sv)), (ByteString::must_from_utf8("ThrowingModulo"sv))}), false}));
+return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("Modulo"sv)), (ByteString::from_utf8_without_validation("ThrowingModulo"sv))}), false}));
 };/*case end*/
 case 5 /* LessThan */: {
-return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("Compare"sv)), (ByteString::must_from_utf8("ThrowingCompare"sv))}), false}));
+return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("Compare"sv)), (ByteString::from_utf8_without_validation("ThrowingCompare"sv))}), false}));
 };/*case end*/
 case 6 /* LessThanOrEqual */: {
-return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("Compare"sv)), (ByteString::must_from_utf8("ThrowingCompare"sv))}), false}));
+return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("Compare"sv)), (ByteString::from_utf8_without_validation("ThrowingCompare"sv))}), false}));
 };/*case end*/
 case 7 /* GreaterThan */: {
-return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("Compare"sv)), (ByteString::must_from_utf8("ThrowingCompare"sv))}), false}));
+return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("Compare"sv)), (ByteString::from_utf8_without_validation("ThrowingCompare"sv))}), false}));
 };/*case end*/
 case 8 /* GreaterThanOrEqual */: {
-return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("Compare"sv)), (ByteString::must_from_utf8("ThrowingCompare"sv))}), false}));
+return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("Compare"sv)), (ByteString::from_utf8_without_validation("ThrowingCompare"sv))}), false}));
 };/*case end*/
 case 9 /* Equal */: {
-return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("Equal"sv)), (ByteString::must_from_utf8("ThrowingEqual"sv))}), false}));
+return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("Equal"sv)), (ByteString::from_utf8_without_validation("ThrowingEqual"sv))}), false}));
 };/*case end*/
 case 10 /* NotEqual */: {
-return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("Equal"sv)), (ByteString::must_from_utf8("ThrowingEqual"sv))}), false}));
+return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("Equal"sv)), (ByteString::from_utf8_without_validation("ThrowingEqual"sv))}), false}));
 };/*case end*/
 case 27 /* AddAssign */: {
-return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("AddAssign"sv)), (ByteString::must_from_utf8("ThrowingAddAssign"sv))}), true}));
+return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("AddAssign"sv)), (ByteString::from_utf8_without_validation("ThrowingAddAssign"sv))}), true}));
 };/*case end*/
 case 28 /* SubtractAssign */: {
-return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("SubtractAssign"sv)), (ByteString::must_from_utf8("ThrowingSubtractAssign"sv))}), true}));
+return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("SubtractAssign"sv)), (ByteString::from_utf8_without_validation("ThrowingSubtractAssign"sv))}), true}));
 };/*case end*/
 case 29 /* MultiplyAssign */: {
-return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("MultiplyAssign"sv)), (ByteString::must_from_utf8("ThrowingMultiplyAssign"sv))}), true}));
+return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("MultiplyAssign"sv)), (ByteString::from_utf8_without_validation("ThrowingMultiplyAssign"sv))}), true}));
 };/*case end*/
 case 31 /* DivideAssign */: {
-return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("DivideAssign"sv)), (ByteString::must_from_utf8("ThrowingDivideAssign"sv))}), true}));
+return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("DivideAssign"sv)), (ByteString::from_utf8_without_validation("ThrowingDivideAssign"sv))}), true}));
 };/*case end*/
 case 30 /* ModuloAssign */: {
-return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("ModuloAssign"sv)), (ByteString::must_from_utf8("ThrowingModuloAssign"sv))}), true}));
+return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("ModuloAssign"sv)), (ByteString::from_utf8_without_validation("ThrowingModuloAssign"sv))}), true}));
 };/*case end*/
 case 22 /* BitwiseAndAssign */: {
-return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("BitwiseAndAssign"sv)), (ByteString::must_from_utf8("ThrowingBitwiseAndAssign"sv))}), true}));
+return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("BitwiseAndAssign"sv)), (ByteString::from_utf8_without_validation("ThrowingBitwiseAndAssign"sv))}), true}));
 };/*case end*/
 case 23 /* BitwiseOrAssign */: {
-return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("BitwiseOrAssign"sv)), (ByteString::must_from_utf8("ThrowingBitwiseOrAssign"sv))}), true}));
+return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("BitwiseOrAssign"sv)), (ByteString::from_utf8_without_validation("ThrowingBitwiseOrAssign"sv))}), true}));
 };/*case end*/
 case 24 /* BitwiseXorAssign */: {
-return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("BitwiseXorAssign"sv)), (ByteString::must_from_utf8("ThrowingBitwiseXorAssign"sv))}), true}));
+return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("BitwiseXorAssign"sv)), (ByteString::from_utf8_without_validation("ThrowingBitwiseXorAssign"sv))}), true}));
 };/*case end*/
 case 25 /* BitwiseLeftShiftAssign */: {
-return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("BitwiseLeftShiftAssign"sv)), (ByteString::must_from_utf8("ThrowingBitwiseLeftShiftAssign"sv))}), true}));
+return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("BitwiseLeftShiftAssign"sv)), (ByteString::from_utf8_without_validation("ThrowingBitwiseLeftShiftAssign"sv))}), true}));
 };/*case end*/
 case 26 /* BitwiseRightShiftAssign */: {
-return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("BitwiseRightShiftAssign"sv)), (ByteString::must_from_utf8("ThrowingBitwiseRightShiftAssign"sv))}), true}));
+return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("BitwiseRightShiftAssign"sv)), (ByteString::from_utf8_without_validation("ThrowingBitwiseRightShiftAssign"sv))}), true}));
 };/*case end*/
 default: {
 return JaktInternal::ExplicitValue((Tuple{empty_array, false}));
@@ -12064,70 +12064,70 @@ ByteString const function_name = ({
 auto&& __jakt_match_variant = op;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 0 /* Add */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("add"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("add"sv)));
 };/*case end*/
 case 1 /* Subtract */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("subtract"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("subtract"sv)));
 };/*case end*/
 case 2 /* Multiply */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("multiply"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("multiply"sv)));
 };/*case end*/
 case 3 /* Divide */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("divide"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("divide"sv)));
 };/*case end*/
 case 4 /* Modulo */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("modulo"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("modulo"sv)));
 };/*case end*/
 case 5 /* LessThan */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("less_than"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("less_than"sv)));
 };/*case end*/
 case 6 /* LessThanOrEqual */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("less_than_or_equal"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("less_than_or_equal"sv)));
 };/*case end*/
 case 7 /* GreaterThan */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("greater_than"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("greater_than"sv)));
 };/*case end*/
 case 8 /* GreaterThanOrEqual */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("greater_than_or_equal"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("greater_than_or_equal"sv)));
 };/*case end*/
 case 9 /* Equal */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("equals"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("equals"sv)));
 };/*case end*/
 case 10 /* NotEqual */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("not_equals"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("not_equals"sv)));
 };/*case end*/
 case 27 /* AddAssign */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("add_assign"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("add_assign"sv)));
 };/*case end*/
 case 28 /* SubtractAssign */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("subtract_assign"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("subtract_assign"sv)));
 };/*case end*/
 case 29 /* MultiplyAssign */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("multiply_assign"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("multiply_assign"sv)));
 };/*case end*/
 case 31 /* DivideAssign */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("divide_assign"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("divide_assign"sv)));
 };/*case end*/
 case 30 /* ModuloAssign */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("modulo_assign"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("modulo_assign"sv)));
 };/*case end*/
 case 22 /* BitwiseAndAssign */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("bitwise_and_assign"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("bitwise_and_assign"sv)));
 };/*case end*/
 case 23 /* BitwiseOrAssign */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("bitwise_or_assign"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("bitwise_or_assign"sv)));
 };/*case end*/
 case 24 /* BitwiseXorAssign */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("bitwise_xor_assign"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("bitwise_xor_assign"sv)));
 };/*case end*/
 case 25 /* BitwiseLeftShiftAssign */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("bitwise_left_shift_assign"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("bitwise_left_shift_assign"sv)));
 };/*case end*/
 case 26 /* BitwiseRightShiftAssign */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("bitwise_right_shift_assign"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("bitwise_right_shift_assign"sv)));
 };/*case end*/
 default: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8(""sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation(""sv)));
 };/*case end*/
 }/*switch end*/
 }()
@@ -12139,8 +12139,8 @@ return JaktInternal::ExplicitValue((ByteString::must_from_utf8(""sv)));
 JaktInternal::Optional<typechecker::TraitImplementationDescriptor> const add_trait_implementation = TRY((((*this).find_any_singular_trait_implementation(lhs_type_id,trait_names,scope_id,lhs_span,DynamicArray<ids::TypeId>::create_with({rhs_type_id})))));
 if (((add_trait_implementation).has_value())){
 typechecker::TraitImplementationDescriptor const implementation = (add_trait_implementation.value());
-if ((((((implementation).trait_name)).starts_with((ByteString::must_from_utf8("Throwing"sv)))) && (!(((scope)->can_throw))))){
-((*this).error((ByteString::must_from_utf8("Call to function that may throw needs to be in a try statement or a function marked as throws"sv)),span));
+if ((((((implementation).trait_name)).starts_with((ByteString::from_utf8_without_validation("Throwing"sv)))) && (!(((scope)->can_throw))))){
+((*this).error((ByteString::from_utf8_without_validation("Call to function that may throw needs to be in a try statement or a function marked as throws"sv)),span));
 }
 JaktInternal::Tuple<JaktInternal::Optional<types::StructLikeId>,bool> const parent_id___ = TRY((((*this).struct_like_id_from_type_id(lhs_type_id,scope_id,span,false,true))));
 JaktInternal::Optional<types::StructLikeId> const parent_id = ((parent_id___).template get<0>());
@@ -12151,15 +12151,15 @@ if (((implementation_function_id).has_value())){
 NonnullRefPtr<types::CheckedFunction> const implementation_function = ((*this).get_function((implementation_function_id.value())));
 if ((((implementation_function)->is_mutating()) && (!(((checked_lhs)->is_mutable(((*this).program))))))){
 if (is_assignment){
-((*this).error((ByteString::must_from_utf8("Assignment to immutable variable"sv)),span));
+((*this).error((ByteString::from_utf8_without_validation("Assignment to immutable variable"sv)),span));
 }
 else {
-((*this).error((ByteString::must_from_utf8("Cannot call mutating function on an immutable object instance"sv)),span));
+((*this).error((ByteString::from_utf8_without_validation("Cannot call mutating function on an immutable object instance"sv)),span));
 }
 
 }
 (type_id = ((implementation_function)->return_type_id));
-types::CheckedCall call_expression = types::CheckedCall(DynamicArray<types::ResolvedNamespace>::create_with({}),function_name,DynamicArray<JaktInternal::Tuple<ByteString,NonnullRefPtr<typename types::CheckedExpression>>>::create_with({(Tuple{(ByteString::must_from_utf8(""sv)), checked_rhs})}),DynamicArray<ids::TypeId>::create_with({}),implementation_function_id,type_id,((implementation_function)->can_throw),((implementation_function)->external_name),((implementation_function)->force_inline));
+types::CheckedCall call_expression = types::CheckedCall(DynamicArray<types::ResolvedNamespace>::create_with({}),function_name,DynamicArray<JaktInternal::Tuple<ByteString,NonnullRefPtr<typename types::CheckedExpression>>>::create_with({(Tuple{(ByteString::from_utf8_without_validation(""sv)), checked_rhs})}),DynamicArray<ids::TypeId>::create_with({}),implementation_function_id,type_id,((implementation_function)->can_throw),((implementation_function)->external_name),((implementation_function)->force_inline));
 (((checked_operator).trait_implementation) = types::OperatorTraitImplementation(((implementation).trait_id),((implementation).implemented_type_args),call_expression));
 }
 else {
@@ -12236,67 +12236,67 @@ JaktInternal::Tuple<JaktInternal::DynamicArray<ByteString>,bool> const trait_nam
 auto&& __jakt_match_variant = op;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 0 /* Add */: {
-return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("Add"sv)), (ByteString::must_from_utf8("ThrowingAdd"sv))}), false}));
+return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("Add"sv)), (ByteString::from_utf8_without_validation("ThrowingAdd"sv))}), false}));
 };/*case end*/
 case 1 /* Subtract */: {
-return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("Subtract"sv)), (ByteString::must_from_utf8("ThrowingSubtract"sv))}), false}));
+return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("Subtract"sv)), (ByteString::from_utf8_without_validation("ThrowingSubtract"sv))}), false}));
 };/*case end*/
 case 2 /* Multiply */: {
-return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("Multiply"sv)), (ByteString::must_from_utf8("ThrowingMultiply"sv))}), false}));
+return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("Multiply"sv)), (ByteString::from_utf8_without_validation("ThrowingMultiply"sv))}), false}));
 };/*case end*/
 case 3 /* Divide */: {
-return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("Divide"sv)), (ByteString::must_from_utf8("ThrowingDivide"sv))}), false}));
+return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("Divide"sv)), (ByteString::from_utf8_without_validation("ThrowingDivide"sv))}), false}));
 };/*case end*/
 case 4 /* Modulo */: {
-return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("Modulo"sv)), (ByteString::must_from_utf8("ThrowingModulo"sv))}), false}));
+return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("Modulo"sv)), (ByteString::from_utf8_without_validation("ThrowingModulo"sv))}), false}));
 };/*case end*/
 case 5 /* LessThan */: {
-return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("Compare"sv)), (ByteString::must_from_utf8("ThrowingCompare"sv))}), false}));
+return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("Compare"sv)), (ByteString::from_utf8_without_validation("ThrowingCompare"sv))}), false}));
 };/*case end*/
 case 6 /* LessThanOrEqual */: {
-return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("Compare"sv)), (ByteString::must_from_utf8("ThrowingCompare"sv))}), false}));
+return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("Compare"sv)), (ByteString::from_utf8_without_validation("ThrowingCompare"sv))}), false}));
 };/*case end*/
 case 7 /* GreaterThan */: {
-return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("Compare"sv)), (ByteString::must_from_utf8("ThrowingCompare"sv))}), false}));
+return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("Compare"sv)), (ByteString::from_utf8_without_validation("ThrowingCompare"sv))}), false}));
 };/*case end*/
 case 8 /* GreaterThanOrEqual */: {
-return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("Compare"sv)), (ByteString::must_from_utf8("ThrowingCompare"sv))}), false}));
+return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("Compare"sv)), (ByteString::from_utf8_without_validation("ThrowingCompare"sv))}), false}));
 };/*case end*/
 case 9 /* Equal */: {
-return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("Equal"sv)), (ByteString::must_from_utf8("ThrowingEqual"sv))}), false}));
+return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("Equal"sv)), (ByteString::from_utf8_without_validation("ThrowingEqual"sv))}), false}));
 };/*case end*/
 case 10 /* NotEqual */: {
-return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("Equal"sv)), (ByteString::must_from_utf8("ThrowingEqual"sv))}), false}));
+return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("Equal"sv)), (ByteString::from_utf8_without_validation("ThrowingEqual"sv))}), false}));
 };/*case end*/
 case 27 /* AddAssign */: {
-return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("AddAssign"sv)), (ByteString::must_from_utf8("ThrowingAddAssign"sv))}), true}));
+return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("AddAssign"sv)), (ByteString::from_utf8_without_validation("ThrowingAddAssign"sv))}), true}));
 };/*case end*/
 case 28 /* SubtractAssign */: {
-return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("SubtractAssign"sv)), (ByteString::must_from_utf8("ThrowingSubtractAssign"sv))}), true}));
+return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("SubtractAssign"sv)), (ByteString::from_utf8_without_validation("ThrowingSubtractAssign"sv))}), true}));
 };/*case end*/
 case 29 /* MultiplyAssign */: {
-return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("MultiplyAssign"sv)), (ByteString::must_from_utf8("ThrowingMultiplyAssign"sv))}), true}));
+return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("MultiplyAssign"sv)), (ByteString::from_utf8_without_validation("ThrowingMultiplyAssign"sv))}), true}));
 };/*case end*/
 case 31 /* DivideAssign */: {
-return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("DivideAssign"sv)), (ByteString::must_from_utf8("ThrowingDivideAssign"sv))}), true}));
+return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("DivideAssign"sv)), (ByteString::from_utf8_without_validation("ThrowingDivideAssign"sv))}), true}));
 };/*case end*/
 case 30 /* ModuloAssign */: {
-return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("ModuloAssign"sv)), (ByteString::must_from_utf8("ThrowingModuloAssign"sv))}), true}));
+return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("ModuloAssign"sv)), (ByteString::from_utf8_without_validation("ThrowingModuloAssign"sv))}), true}));
 };/*case end*/
 case 22 /* BitwiseAndAssign */: {
-return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("BitwiseAndAssign"sv)), (ByteString::must_from_utf8("ThrowingBitwiseAndAssign"sv))}), true}));
+return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("BitwiseAndAssign"sv)), (ByteString::from_utf8_without_validation("ThrowingBitwiseAndAssign"sv))}), true}));
 };/*case end*/
 case 23 /* BitwiseOrAssign */: {
-return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("BitwiseOrAssign"sv)), (ByteString::must_from_utf8("ThrowingBitwiseOrAssign"sv))}), true}));
+return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("BitwiseOrAssign"sv)), (ByteString::from_utf8_without_validation("ThrowingBitwiseOrAssign"sv))}), true}));
 };/*case end*/
 case 24 /* BitwiseXorAssign */: {
-return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("BitwiseXorAssign"sv)), (ByteString::must_from_utf8("ThrowingBitwiseXorAssign"sv))}), true}));
+return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("BitwiseXorAssign"sv)), (ByteString::from_utf8_without_validation("ThrowingBitwiseXorAssign"sv))}), true}));
 };/*case end*/
 case 25 /* BitwiseLeftShiftAssign */: {
-return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("BitwiseLeftShiftAssign"sv)), (ByteString::must_from_utf8("ThrowingBitwiseLeftShiftAssign"sv))}), true}));
+return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("BitwiseLeftShiftAssign"sv)), (ByteString::from_utf8_without_validation("ThrowingBitwiseLeftShiftAssign"sv))}), true}));
 };/*case end*/
 case 26 /* BitwiseRightShiftAssign */: {
-return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("BitwiseRightShiftAssign"sv)), (ByteString::must_from_utf8("ThrowingBitwiseRightShiftAssign"sv))}), true}));
+return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("BitwiseRightShiftAssign"sv)), (ByteString::from_utf8_without_validation("ThrowingBitwiseRightShiftAssign"sv))}), true}));
 };/*case end*/
 default: {
 return JaktInternal::ExplicitValue((Tuple{empty_array, false}));
@@ -12316,70 +12316,70 @@ ByteString const function_name = ({
 auto&& __jakt_match_variant = op;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 0 /* Add */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("add"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("add"sv)));
 };/*case end*/
 case 1 /* Subtract */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("subtract"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("subtract"sv)));
 };/*case end*/
 case 2 /* Multiply */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("multiply"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("multiply"sv)));
 };/*case end*/
 case 3 /* Divide */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("divide"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("divide"sv)));
 };/*case end*/
 case 4 /* Modulo */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("modulo"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("modulo"sv)));
 };/*case end*/
 case 5 /* LessThan */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("less_than"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("less_than"sv)));
 };/*case end*/
 case 6 /* LessThanOrEqual */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("less_than_or_equal"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("less_than_or_equal"sv)));
 };/*case end*/
 case 7 /* GreaterThan */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("greater_than"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("greater_than"sv)));
 };/*case end*/
 case 8 /* GreaterThanOrEqual */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("greater_than_or_equal"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("greater_than_or_equal"sv)));
 };/*case end*/
 case 9 /* Equal */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("equals"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("equals"sv)));
 };/*case end*/
 case 10 /* NotEqual */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("not_equals"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("not_equals"sv)));
 };/*case end*/
 case 27 /* AddAssign */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("add_assign"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("add_assign"sv)));
 };/*case end*/
 case 28 /* SubtractAssign */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("subtract_assign"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("subtract_assign"sv)));
 };/*case end*/
 case 29 /* MultiplyAssign */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("multiply_assign"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("multiply_assign"sv)));
 };/*case end*/
 case 31 /* DivideAssign */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("divide_assign"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("divide_assign"sv)));
 };/*case end*/
 case 30 /* ModuloAssign */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("modulo_assign"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("modulo_assign"sv)));
 };/*case end*/
 case 22 /* BitwiseAndAssign */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("bitwise_and_assign"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("bitwise_and_assign"sv)));
 };/*case end*/
 case 23 /* BitwiseOrAssign */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("bitwise_or_assign"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("bitwise_or_assign"sv)));
 };/*case end*/
 case 24 /* BitwiseXorAssign */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("bitwise_xor_assign"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("bitwise_xor_assign"sv)));
 };/*case end*/
 case 25 /* BitwiseLeftShiftAssign */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("bitwise_left_shift_assign"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("bitwise_left_shift_assign"sv)));
 };/*case end*/
 case 26 /* BitwiseRightShiftAssign */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("bitwise_right_shift_assign"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("bitwise_right_shift_assign"sv)));
 };/*case end*/
 default: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8(""sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation(""sv)));
 };/*case end*/
 }/*switch end*/
 }()
@@ -12391,8 +12391,8 @@ return JaktInternal::ExplicitValue((ByteString::must_from_utf8(""sv)));
 JaktInternal::Optional<typechecker::TraitImplementationDescriptor> const add_trait_implementation = TRY((((*this).find_any_singular_trait_implementation(lhs_type_id,trait_names,scope_id,lhs_span,DynamicArray<ids::TypeId>::create_with({rhs_type_id})))));
 if (((add_trait_implementation).has_value())){
 typechecker::TraitImplementationDescriptor const implementation = (add_trait_implementation.value());
-if ((((((implementation).trait_name)).starts_with((ByteString::must_from_utf8("Throwing"sv)))) && (!(((scope)->can_throw))))){
-((*this).error((ByteString::must_from_utf8("Call to function that may throw needs to be in a try statement or a function marked as throws"sv)),span));
+if ((((((implementation).trait_name)).starts_with((ByteString::from_utf8_without_validation("Throwing"sv)))) && (!(((scope)->can_throw))))){
+((*this).error((ByteString::from_utf8_without_validation("Call to function that may throw needs to be in a try statement or a function marked as throws"sv)),span));
 }
 JaktInternal::Tuple<JaktInternal::Optional<types::StructLikeId>,bool> const parent_id___ = TRY((((*this).struct_like_id_from_type_id(lhs_type_id,scope_id,span,false,true))));
 JaktInternal::Optional<types::StructLikeId> const parent_id = ((parent_id___).template get<0>());
@@ -12403,15 +12403,15 @@ if (((implementation_function_id).has_value())){
 NonnullRefPtr<types::CheckedFunction> const implementation_function = ((*this).get_function((implementation_function_id.value())));
 if ((((implementation_function)->is_mutating()) && (!(((checked_lhs)->is_mutable(((*this).program))))))){
 if (is_assignment){
-((*this).error((ByteString::must_from_utf8("Assignment to immutable variable"sv)),span));
+((*this).error((ByteString::from_utf8_without_validation("Assignment to immutable variable"sv)),span));
 }
 else {
-((*this).error((ByteString::must_from_utf8("Cannot call mutating function on an immutable object instance"sv)),span));
+((*this).error((ByteString::from_utf8_without_validation("Cannot call mutating function on an immutable object instance"sv)),span));
 }
 
 }
 (type_id = ((implementation_function)->return_type_id));
-types::CheckedCall call_expression = types::CheckedCall(DynamicArray<types::ResolvedNamespace>::create_with({}),function_name,DynamicArray<JaktInternal::Tuple<ByteString,NonnullRefPtr<typename types::CheckedExpression>>>::create_with({(Tuple{(ByteString::must_from_utf8(""sv)), checked_rhs})}),DynamicArray<ids::TypeId>::create_with({}),implementation_function_id,type_id,((implementation_function)->can_throw),((implementation_function)->external_name),((implementation_function)->force_inline));
+types::CheckedCall call_expression = types::CheckedCall(DynamicArray<types::ResolvedNamespace>::create_with({}),function_name,DynamicArray<JaktInternal::Tuple<ByteString,NonnullRefPtr<typename types::CheckedExpression>>>::create_with({(Tuple{(ByteString::from_utf8_without_validation(""sv)), checked_rhs})}),DynamicArray<ids::TypeId>::create_with({}),implementation_function_id,type_id,((implementation_function)->can_throw),((implementation_function)->external_name),((implementation_function)->force_inline));
 (((checked_operator).trait_implementation) = types::OperatorTraitImplementation(((implementation).trait_id),((implementation).implemented_type_args),call_expression));
 }
 else {
@@ -12488,67 +12488,67 @@ JaktInternal::Tuple<JaktInternal::DynamicArray<ByteString>,bool> const trait_nam
 auto&& __jakt_match_variant = op;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 0 /* Add */: {
-return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("Add"sv)), (ByteString::must_from_utf8("ThrowingAdd"sv))}), false}));
+return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("Add"sv)), (ByteString::from_utf8_without_validation("ThrowingAdd"sv))}), false}));
 };/*case end*/
 case 1 /* Subtract */: {
-return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("Subtract"sv)), (ByteString::must_from_utf8("ThrowingSubtract"sv))}), false}));
+return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("Subtract"sv)), (ByteString::from_utf8_without_validation("ThrowingSubtract"sv))}), false}));
 };/*case end*/
 case 2 /* Multiply */: {
-return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("Multiply"sv)), (ByteString::must_from_utf8("ThrowingMultiply"sv))}), false}));
+return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("Multiply"sv)), (ByteString::from_utf8_without_validation("ThrowingMultiply"sv))}), false}));
 };/*case end*/
 case 3 /* Divide */: {
-return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("Divide"sv)), (ByteString::must_from_utf8("ThrowingDivide"sv))}), false}));
+return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("Divide"sv)), (ByteString::from_utf8_without_validation("ThrowingDivide"sv))}), false}));
 };/*case end*/
 case 4 /* Modulo */: {
-return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("Modulo"sv)), (ByteString::must_from_utf8("ThrowingModulo"sv))}), false}));
+return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("Modulo"sv)), (ByteString::from_utf8_without_validation("ThrowingModulo"sv))}), false}));
 };/*case end*/
 case 5 /* LessThan */: {
-return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("Compare"sv)), (ByteString::must_from_utf8("ThrowingCompare"sv))}), false}));
+return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("Compare"sv)), (ByteString::from_utf8_without_validation("ThrowingCompare"sv))}), false}));
 };/*case end*/
 case 6 /* LessThanOrEqual */: {
-return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("Compare"sv)), (ByteString::must_from_utf8("ThrowingCompare"sv))}), false}));
+return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("Compare"sv)), (ByteString::from_utf8_without_validation("ThrowingCompare"sv))}), false}));
 };/*case end*/
 case 7 /* GreaterThan */: {
-return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("Compare"sv)), (ByteString::must_from_utf8("ThrowingCompare"sv))}), false}));
+return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("Compare"sv)), (ByteString::from_utf8_without_validation("ThrowingCompare"sv))}), false}));
 };/*case end*/
 case 8 /* GreaterThanOrEqual */: {
-return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("Compare"sv)), (ByteString::must_from_utf8("ThrowingCompare"sv))}), false}));
+return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("Compare"sv)), (ByteString::from_utf8_without_validation("ThrowingCompare"sv))}), false}));
 };/*case end*/
 case 9 /* Equal */: {
-return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("Equal"sv)), (ByteString::must_from_utf8("ThrowingEqual"sv))}), false}));
+return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("Equal"sv)), (ByteString::from_utf8_without_validation("ThrowingEqual"sv))}), false}));
 };/*case end*/
 case 10 /* NotEqual */: {
-return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("Equal"sv)), (ByteString::must_from_utf8("ThrowingEqual"sv))}), false}));
+return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("Equal"sv)), (ByteString::from_utf8_without_validation("ThrowingEqual"sv))}), false}));
 };/*case end*/
 case 27 /* AddAssign */: {
-return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("AddAssign"sv)), (ByteString::must_from_utf8("ThrowingAddAssign"sv))}), true}));
+return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("AddAssign"sv)), (ByteString::from_utf8_without_validation("ThrowingAddAssign"sv))}), true}));
 };/*case end*/
 case 28 /* SubtractAssign */: {
-return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("SubtractAssign"sv)), (ByteString::must_from_utf8("ThrowingSubtractAssign"sv))}), true}));
+return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("SubtractAssign"sv)), (ByteString::from_utf8_without_validation("ThrowingSubtractAssign"sv))}), true}));
 };/*case end*/
 case 29 /* MultiplyAssign */: {
-return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("MultiplyAssign"sv)), (ByteString::must_from_utf8("ThrowingMultiplyAssign"sv))}), true}));
+return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("MultiplyAssign"sv)), (ByteString::from_utf8_without_validation("ThrowingMultiplyAssign"sv))}), true}));
 };/*case end*/
 case 31 /* DivideAssign */: {
-return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("DivideAssign"sv)), (ByteString::must_from_utf8("ThrowingDivideAssign"sv))}), true}));
+return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("DivideAssign"sv)), (ByteString::from_utf8_without_validation("ThrowingDivideAssign"sv))}), true}));
 };/*case end*/
 case 30 /* ModuloAssign */: {
-return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("ModuloAssign"sv)), (ByteString::must_from_utf8("ThrowingModuloAssign"sv))}), true}));
+return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("ModuloAssign"sv)), (ByteString::from_utf8_without_validation("ThrowingModuloAssign"sv))}), true}));
 };/*case end*/
 case 22 /* BitwiseAndAssign */: {
-return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("BitwiseAndAssign"sv)), (ByteString::must_from_utf8("ThrowingBitwiseAndAssign"sv))}), true}));
+return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("BitwiseAndAssign"sv)), (ByteString::from_utf8_without_validation("ThrowingBitwiseAndAssign"sv))}), true}));
 };/*case end*/
 case 23 /* BitwiseOrAssign */: {
-return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("BitwiseOrAssign"sv)), (ByteString::must_from_utf8("ThrowingBitwiseOrAssign"sv))}), true}));
+return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("BitwiseOrAssign"sv)), (ByteString::from_utf8_without_validation("ThrowingBitwiseOrAssign"sv))}), true}));
 };/*case end*/
 case 24 /* BitwiseXorAssign */: {
-return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("BitwiseXorAssign"sv)), (ByteString::must_from_utf8("ThrowingBitwiseXorAssign"sv))}), true}));
+return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("BitwiseXorAssign"sv)), (ByteString::from_utf8_without_validation("ThrowingBitwiseXorAssign"sv))}), true}));
 };/*case end*/
 case 25 /* BitwiseLeftShiftAssign */: {
-return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("BitwiseLeftShiftAssign"sv)), (ByteString::must_from_utf8("ThrowingBitwiseLeftShiftAssign"sv))}), true}));
+return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("BitwiseLeftShiftAssign"sv)), (ByteString::from_utf8_without_validation("ThrowingBitwiseLeftShiftAssign"sv))}), true}));
 };/*case end*/
 case 26 /* BitwiseRightShiftAssign */: {
-return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("BitwiseRightShiftAssign"sv)), (ByteString::must_from_utf8("ThrowingBitwiseRightShiftAssign"sv))}), true}));
+return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("BitwiseRightShiftAssign"sv)), (ByteString::from_utf8_without_validation("ThrowingBitwiseRightShiftAssign"sv))}), true}));
 };/*case end*/
 default: {
 return JaktInternal::ExplicitValue((Tuple{empty_array, false}));
@@ -12568,70 +12568,70 @@ ByteString const function_name = ({
 auto&& __jakt_match_variant = op;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 0 /* Add */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("add"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("add"sv)));
 };/*case end*/
 case 1 /* Subtract */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("subtract"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("subtract"sv)));
 };/*case end*/
 case 2 /* Multiply */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("multiply"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("multiply"sv)));
 };/*case end*/
 case 3 /* Divide */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("divide"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("divide"sv)));
 };/*case end*/
 case 4 /* Modulo */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("modulo"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("modulo"sv)));
 };/*case end*/
 case 5 /* LessThan */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("less_than"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("less_than"sv)));
 };/*case end*/
 case 6 /* LessThanOrEqual */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("less_than_or_equal"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("less_than_or_equal"sv)));
 };/*case end*/
 case 7 /* GreaterThan */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("greater_than"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("greater_than"sv)));
 };/*case end*/
 case 8 /* GreaterThanOrEqual */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("greater_than_or_equal"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("greater_than_or_equal"sv)));
 };/*case end*/
 case 9 /* Equal */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("equals"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("equals"sv)));
 };/*case end*/
 case 10 /* NotEqual */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("not_equals"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("not_equals"sv)));
 };/*case end*/
 case 27 /* AddAssign */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("add_assign"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("add_assign"sv)));
 };/*case end*/
 case 28 /* SubtractAssign */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("subtract_assign"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("subtract_assign"sv)));
 };/*case end*/
 case 29 /* MultiplyAssign */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("multiply_assign"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("multiply_assign"sv)));
 };/*case end*/
 case 31 /* DivideAssign */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("divide_assign"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("divide_assign"sv)));
 };/*case end*/
 case 30 /* ModuloAssign */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("modulo_assign"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("modulo_assign"sv)));
 };/*case end*/
 case 22 /* BitwiseAndAssign */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("bitwise_and_assign"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("bitwise_and_assign"sv)));
 };/*case end*/
 case 23 /* BitwiseOrAssign */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("bitwise_or_assign"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("bitwise_or_assign"sv)));
 };/*case end*/
 case 24 /* BitwiseXorAssign */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("bitwise_xor_assign"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("bitwise_xor_assign"sv)));
 };/*case end*/
 case 25 /* BitwiseLeftShiftAssign */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("bitwise_left_shift_assign"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("bitwise_left_shift_assign"sv)));
 };/*case end*/
 case 26 /* BitwiseRightShiftAssign */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("bitwise_right_shift_assign"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("bitwise_right_shift_assign"sv)));
 };/*case end*/
 default: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8(""sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation(""sv)));
 };/*case end*/
 }/*switch end*/
 }()
@@ -12643,8 +12643,8 @@ return JaktInternal::ExplicitValue((ByteString::must_from_utf8(""sv)));
 JaktInternal::Optional<typechecker::TraitImplementationDescriptor> const add_trait_implementation = TRY((((*this).find_any_singular_trait_implementation(lhs_type_id,trait_names,scope_id,lhs_span,DynamicArray<ids::TypeId>::create_with({rhs_type_id})))));
 if (((add_trait_implementation).has_value())){
 typechecker::TraitImplementationDescriptor const implementation = (add_trait_implementation.value());
-if ((((((implementation).trait_name)).starts_with((ByteString::must_from_utf8("Throwing"sv)))) && (!(((scope)->can_throw))))){
-((*this).error((ByteString::must_from_utf8("Call to function that may throw needs to be in a try statement or a function marked as throws"sv)),span));
+if ((((((implementation).trait_name)).starts_with((ByteString::from_utf8_without_validation("Throwing"sv)))) && (!(((scope)->can_throw))))){
+((*this).error((ByteString::from_utf8_without_validation("Call to function that may throw needs to be in a try statement or a function marked as throws"sv)),span));
 }
 JaktInternal::Tuple<JaktInternal::Optional<types::StructLikeId>,bool> const parent_id___ = TRY((((*this).struct_like_id_from_type_id(lhs_type_id,scope_id,span,false,true))));
 JaktInternal::Optional<types::StructLikeId> const parent_id = ((parent_id___).template get<0>());
@@ -12655,15 +12655,15 @@ if (((implementation_function_id).has_value())){
 NonnullRefPtr<types::CheckedFunction> const implementation_function = ((*this).get_function((implementation_function_id.value())));
 if ((((implementation_function)->is_mutating()) && (!(((checked_lhs)->is_mutable(((*this).program))))))){
 if (is_assignment){
-((*this).error((ByteString::must_from_utf8("Assignment to immutable variable"sv)),span));
+((*this).error((ByteString::from_utf8_without_validation("Assignment to immutable variable"sv)),span));
 }
 else {
-((*this).error((ByteString::must_from_utf8("Cannot call mutating function on an immutable object instance"sv)),span));
+((*this).error((ByteString::from_utf8_without_validation("Cannot call mutating function on an immutable object instance"sv)),span));
 }
 
 }
 (type_id = ((implementation_function)->return_type_id));
-types::CheckedCall call_expression = types::CheckedCall(DynamicArray<types::ResolvedNamespace>::create_with({}),function_name,DynamicArray<JaktInternal::Tuple<ByteString,NonnullRefPtr<typename types::CheckedExpression>>>::create_with({(Tuple{(ByteString::must_from_utf8(""sv)), checked_rhs})}),DynamicArray<ids::TypeId>::create_with({}),implementation_function_id,type_id,((implementation_function)->can_throw),((implementation_function)->external_name),((implementation_function)->force_inline));
+types::CheckedCall call_expression = types::CheckedCall(DynamicArray<types::ResolvedNamespace>::create_with({}),function_name,DynamicArray<JaktInternal::Tuple<ByteString,NonnullRefPtr<typename types::CheckedExpression>>>::create_with({(Tuple{(ByteString::from_utf8_without_validation(""sv)), checked_rhs})}),DynamicArray<ids::TypeId>::create_with({}),implementation_function_id,type_id,((implementation_function)->can_throw),((implementation_function)->external_name),((implementation_function)->force_inline));
 (((checked_operator).trait_implementation) = types::OperatorTraitImplementation(((implementation).trait_id),((implementation).implemented_type_args),call_expression));
 }
 else {
@@ -12740,67 +12740,67 @@ JaktInternal::Tuple<JaktInternal::DynamicArray<ByteString>,bool> const trait_nam
 auto&& __jakt_match_variant = op;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 0 /* Add */: {
-return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("Add"sv)), (ByteString::must_from_utf8("ThrowingAdd"sv))}), false}));
+return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("Add"sv)), (ByteString::from_utf8_without_validation("ThrowingAdd"sv))}), false}));
 };/*case end*/
 case 1 /* Subtract */: {
-return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("Subtract"sv)), (ByteString::must_from_utf8("ThrowingSubtract"sv))}), false}));
+return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("Subtract"sv)), (ByteString::from_utf8_without_validation("ThrowingSubtract"sv))}), false}));
 };/*case end*/
 case 2 /* Multiply */: {
-return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("Multiply"sv)), (ByteString::must_from_utf8("ThrowingMultiply"sv))}), false}));
+return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("Multiply"sv)), (ByteString::from_utf8_without_validation("ThrowingMultiply"sv))}), false}));
 };/*case end*/
 case 3 /* Divide */: {
-return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("Divide"sv)), (ByteString::must_from_utf8("ThrowingDivide"sv))}), false}));
+return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("Divide"sv)), (ByteString::from_utf8_without_validation("ThrowingDivide"sv))}), false}));
 };/*case end*/
 case 4 /* Modulo */: {
-return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("Modulo"sv)), (ByteString::must_from_utf8("ThrowingModulo"sv))}), false}));
+return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("Modulo"sv)), (ByteString::from_utf8_without_validation("ThrowingModulo"sv))}), false}));
 };/*case end*/
 case 5 /* LessThan */: {
-return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("Compare"sv)), (ByteString::must_from_utf8("ThrowingCompare"sv))}), false}));
+return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("Compare"sv)), (ByteString::from_utf8_without_validation("ThrowingCompare"sv))}), false}));
 };/*case end*/
 case 6 /* LessThanOrEqual */: {
-return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("Compare"sv)), (ByteString::must_from_utf8("ThrowingCompare"sv))}), false}));
+return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("Compare"sv)), (ByteString::from_utf8_without_validation("ThrowingCompare"sv))}), false}));
 };/*case end*/
 case 7 /* GreaterThan */: {
-return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("Compare"sv)), (ByteString::must_from_utf8("ThrowingCompare"sv))}), false}));
+return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("Compare"sv)), (ByteString::from_utf8_without_validation("ThrowingCompare"sv))}), false}));
 };/*case end*/
 case 8 /* GreaterThanOrEqual */: {
-return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("Compare"sv)), (ByteString::must_from_utf8("ThrowingCompare"sv))}), false}));
+return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("Compare"sv)), (ByteString::from_utf8_without_validation("ThrowingCompare"sv))}), false}));
 };/*case end*/
 case 9 /* Equal */: {
-return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("Equal"sv)), (ByteString::must_from_utf8("ThrowingEqual"sv))}), false}));
+return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("Equal"sv)), (ByteString::from_utf8_without_validation("ThrowingEqual"sv))}), false}));
 };/*case end*/
 case 10 /* NotEqual */: {
-return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("Equal"sv)), (ByteString::must_from_utf8("ThrowingEqual"sv))}), false}));
+return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("Equal"sv)), (ByteString::from_utf8_without_validation("ThrowingEqual"sv))}), false}));
 };/*case end*/
 case 27 /* AddAssign */: {
-return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("AddAssign"sv)), (ByteString::must_from_utf8("ThrowingAddAssign"sv))}), true}));
+return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("AddAssign"sv)), (ByteString::from_utf8_without_validation("ThrowingAddAssign"sv))}), true}));
 };/*case end*/
 case 28 /* SubtractAssign */: {
-return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("SubtractAssign"sv)), (ByteString::must_from_utf8("ThrowingSubtractAssign"sv))}), true}));
+return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("SubtractAssign"sv)), (ByteString::from_utf8_without_validation("ThrowingSubtractAssign"sv))}), true}));
 };/*case end*/
 case 29 /* MultiplyAssign */: {
-return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("MultiplyAssign"sv)), (ByteString::must_from_utf8("ThrowingMultiplyAssign"sv))}), true}));
+return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("MultiplyAssign"sv)), (ByteString::from_utf8_without_validation("ThrowingMultiplyAssign"sv))}), true}));
 };/*case end*/
 case 31 /* DivideAssign */: {
-return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("DivideAssign"sv)), (ByteString::must_from_utf8("ThrowingDivideAssign"sv))}), true}));
+return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("DivideAssign"sv)), (ByteString::from_utf8_without_validation("ThrowingDivideAssign"sv))}), true}));
 };/*case end*/
 case 30 /* ModuloAssign */: {
-return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("ModuloAssign"sv)), (ByteString::must_from_utf8("ThrowingModuloAssign"sv))}), true}));
+return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("ModuloAssign"sv)), (ByteString::from_utf8_without_validation("ThrowingModuloAssign"sv))}), true}));
 };/*case end*/
 case 22 /* BitwiseAndAssign */: {
-return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("BitwiseAndAssign"sv)), (ByteString::must_from_utf8("ThrowingBitwiseAndAssign"sv))}), true}));
+return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("BitwiseAndAssign"sv)), (ByteString::from_utf8_without_validation("ThrowingBitwiseAndAssign"sv))}), true}));
 };/*case end*/
 case 23 /* BitwiseOrAssign */: {
-return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("BitwiseOrAssign"sv)), (ByteString::must_from_utf8("ThrowingBitwiseOrAssign"sv))}), true}));
+return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("BitwiseOrAssign"sv)), (ByteString::from_utf8_without_validation("ThrowingBitwiseOrAssign"sv))}), true}));
 };/*case end*/
 case 24 /* BitwiseXorAssign */: {
-return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("BitwiseXorAssign"sv)), (ByteString::must_from_utf8("ThrowingBitwiseXorAssign"sv))}), true}));
+return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("BitwiseXorAssign"sv)), (ByteString::from_utf8_without_validation("ThrowingBitwiseXorAssign"sv))}), true}));
 };/*case end*/
 case 25 /* BitwiseLeftShiftAssign */: {
-return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("BitwiseLeftShiftAssign"sv)), (ByteString::must_from_utf8("ThrowingBitwiseLeftShiftAssign"sv))}), true}));
+return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("BitwiseLeftShiftAssign"sv)), (ByteString::from_utf8_without_validation("ThrowingBitwiseLeftShiftAssign"sv))}), true}));
 };/*case end*/
 case 26 /* BitwiseRightShiftAssign */: {
-return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("BitwiseRightShiftAssign"sv)), (ByteString::must_from_utf8("ThrowingBitwiseRightShiftAssign"sv))}), true}));
+return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("BitwiseRightShiftAssign"sv)), (ByteString::from_utf8_without_validation("ThrowingBitwiseRightShiftAssign"sv))}), true}));
 };/*case end*/
 default: {
 return JaktInternal::ExplicitValue((Tuple{empty_array, false}));
@@ -12820,70 +12820,70 @@ ByteString const function_name = ({
 auto&& __jakt_match_variant = op;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 0 /* Add */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("add"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("add"sv)));
 };/*case end*/
 case 1 /* Subtract */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("subtract"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("subtract"sv)));
 };/*case end*/
 case 2 /* Multiply */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("multiply"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("multiply"sv)));
 };/*case end*/
 case 3 /* Divide */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("divide"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("divide"sv)));
 };/*case end*/
 case 4 /* Modulo */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("modulo"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("modulo"sv)));
 };/*case end*/
 case 5 /* LessThan */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("less_than"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("less_than"sv)));
 };/*case end*/
 case 6 /* LessThanOrEqual */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("less_than_or_equal"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("less_than_or_equal"sv)));
 };/*case end*/
 case 7 /* GreaterThan */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("greater_than"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("greater_than"sv)));
 };/*case end*/
 case 8 /* GreaterThanOrEqual */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("greater_than_or_equal"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("greater_than_or_equal"sv)));
 };/*case end*/
 case 9 /* Equal */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("equals"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("equals"sv)));
 };/*case end*/
 case 10 /* NotEqual */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("not_equals"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("not_equals"sv)));
 };/*case end*/
 case 27 /* AddAssign */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("add_assign"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("add_assign"sv)));
 };/*case end*/
 case 28 /* SubtractAssign */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("subtract_assign"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("subtract_assign"sv)));
 };/*case end*/
 case 29 /* MultiplyAssign */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("multiply_assign"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("multiply_assign"sv)));
 };/*case end*/
 case 31 /* DivideAssign */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("divide_assign"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("divide_assign"sv)));
 };/*case end*/
 case 30 /* ModuloAssign */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("modulo_assign"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("modulo_assign"sv)));
 };/*case end*/
 case 22 /* BitwiseAndAssign */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("bitwise_and_assign"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("bitwise_and_assign"sv)));
 };/*case end*/
 case 23 /* BitwiseOrAssign */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("bitwise_or_assign"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("bitwise_or_assign"sv)));
 };/*case end*/
 case 24 /* BitwiseXorAssign */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("bitwise_xor_assign"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("bitwise_xor_assign"sv)));
 };/*case end*/
 case 25 /* BitwiseLeftShiftAssign */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("bitwise_left_shift_assign"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("bitwise_left_shift_assign"sv)));
 };/*case end*/
 case 26 /* BitwiseRightShiftAssign */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("bitwise_right_shift_assign"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("bitwise_right_shift_assign"sv)));
 };/*case end*/
 default: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8(""sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation(""sv)));
 };/*case end*/
 }/*switch end*/
 }()
@@ -12895,8 +12895,8 @@ return JaktInternal::ExplicitValue((ByteString::must_from_utf8(""sv)));
 JaktInternal::Optional<typechecker::TraitImplementationDescriptor> const add_trait_implementation = TRY((((*this).find_any_singular_trait_implementation(lhs_type_id,trait_names,scope_id,lhs_span,DynamicArray<ids::TypeId>::create_with({rhs_type_id})))));
 if (((add_trait_implementation).has_value())){
 typechecker::TraitImplementationDescriptor const implementation = (add_trait_implementation.value());
-if ((((((implementation).trait_name)).starts_with((ByteString::must_from_utf8("Throwing"sv)))) && (!(((scope)->can_throw))))){
-((*this).error((ByteString::must_from_utf8("Call to function that may throw needs to be in a try statement or a function marked as throws"sv)),span));
+if ((((((implementation).trait_name)).starts_with((ByteString::from_utf8_without_validation("Throwing"sv)))) && (!(((scope)->can_throw))))){
+((*this).error((ByteString::from_utf8_without_validation("Call to function that may throw needs to be in a try statement or a function marked as throws"sv)),span));
 }
 JaktInternal::Tuple<JaktInternal::Optional<types::StructLikeId>,bool> const parent_id___ = TRY((((*this).struct_like_id_from_type_id(lhs_type_id,scope_id,span,false,true))));
 JaktInternal::Optional<types::StructLikeId> const parent_id = ((parent_id___).template get<0>());
@@ -12907,15 +12907,15 @@ if (((implementation_function_id).has_value())){
 NonnullRefPtr<types::CheckedFunction> const implementation_function = ((*this).get_function((implementation_function_id.value())));
 if ((((implementation_function)->is_mutating()) && (!(((checked_lhs)->is_mutable(((*this).program))))))){
 if (is_assignment){
-((*this).error((ByteString::must_from_utf8("Assignment to immutable variable"sv)),span));
+((*this).error((ByteString::from_utf8_without_validation("Assignment to immutable variable"sv)),span));
 }
 else {
-((*this).error((ByteString::must_from_utf8("Cannot call mutating function on an immutable object instance"sv)),span));
+((*this).error((ByteString::from_utf8_without_validation("Cannot call mutating function on an immutable object instance"sv)),span));
 }
 
 }
 (type_id = ((implementation_function)->return_type_id));
-types::CheckedCall call_expression = types::CheckedCall(DynamicArray<types::ResolvedNamespace>::create_with({}),function_name,DynamicArray<JaktInternal::Tuple<ByteString,NonnullRefPtr<typename types::CheckedExpression>>>::create_with({(Tuple{(ByteString::must_from_utf8(""sv)), checked_rhs})}),DynamicArray<ids::TypeId>::create_with({}),implementation_function_id,type_id,((implementation_function)->can_throw),((implementation_function)->external_name),((implementation_function)->force_inline));
+types::CheckedCall call_expression = types::CheckedCall(DynamicArray<types::ResolvedNamespace>::create_with({}),function_name,DynamicArray<JaktInternal::Tuple<ByteString,NonnullRefPtr<typename types::CheckedExpression>>>::create_with({(Tuple{(ByteString::from_utf8_without_validation(""sv)), checked_rhs})}),DynamicArray<ids::TypeId>::create_with({}),implementation_function_id,type_id,((implementation_function)->can_throw),((implementation_function)->external_name),((implementation_function)->force_inline));
 (((checked_operator).trait_implementation) = types::OperatorTraitImplementation(((implementation).trait_id),((implementation).implemented_type_args),call_expression));
 }
 else {
@@ -12992,67 +12992,67 @@ JaktInternal::Tuple<JaktInternal::DynamicArray<ByteString>,bool> const trait_nam
 auto&& __jakt_match_variant = op;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 0 /* Add */: {
-return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("Add"sv)), (ByteString::must_from_utf8("ThrowingAdd"sv))}), false}));
+return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("Add"sv)), (ByteString::from_utf8_without_validation("ThrowingAdd"sv))}), false}));
 };/*case end*/
 case 1 /* Subtract */: {
-return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("Subtract"sv)), (ByteString::must_from_utf8("ThrowingSubtract"sv))}), false}));
+return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("Subtract"sv)), (ByteString::from_utf8_without_validation("ThrowingSubtract"sv))}), false}));
 };/*case end*/
 case 2 /* Multiply */: {
-return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("Multiply"sv)), (ByteString::must_from_utf8("ThrowingMultiply"sv))}), false}));
+return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("Multiply"sv)), (ByteString::from_utf8_without_validation("ThrowingMultiply"sv))}), false}));
 };/*case end*/
 case 3 /* Divide */: {
-return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("Divide"sv)), (ByteString::must_from_utf8("ThrowingDivide"sv))}), false}));
+return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("Divide"sv)), (ByteString::from_utf8_without_validation("ThrowingDivide"sv))}), false}));
 };/*case end*/
 case 4 /* Modulo */: {
-return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("Modulo"sv)), (ByteString::must_from_utf8("ThrowingModulo"sv))}), false}));
+return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("Modulo"sv)), (ByteString::from_utf8_without_validation("ThrowingModulo"sv))}), false}));
 };/*case end*/
 case 5 /* LessThan */: {
-return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("Compare"sv)), (ByteString::must_from_utf8("ThrowingCompare"sv))}), false}));
+return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("Compare"sv)), (ByteString::from_utf8_without_validation("ThrowingCompare"sv))}), false}));
 };/*case end*/
 case 6 /* LessThanOrEqual */: {
-return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("Compare"sv)), (ByteString::must_from_utf8("ThrowingCompare"sv))}), false}));
+return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("Compare"sv)), (ByteString::from_utf8_without_validation("ThrowingCompare"sv))}), false}));
 };/*case end*/
 case 7 /* GreaterThan */: {
-return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("Compare"sv)), (ByteString::must_from_utf8("ThrowingCompare"sv))}), false}));
+return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("Compare"sv)), (ByteString::from_utf8_without_validation("ThrowingCompare"sv))}), false}));
 };/*case end*/
 case 8 /* GreaterThanOrEqual */: {
-return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("Compare"sv)), (ByteString::must_from_utf8("ThrowingCompare"sv))}), false}));
+return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("Compare"sv)), (ByteString::from_utf8_without_validation("ThrowingCompare"sv))}), false}));
 };/*case end*/
 case 9 /* Equal */: {
-return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("Equal"sv)), (ByteString::must_from_utf8("ThrowingEqual"sv))}), false}));
+return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("Equal"sv)), (ByteString::from_utf8_without_validation("ThrowingEqual"sv))}), false}));
 };/*case end*/
 case 10 /* NotEqual */: {
-return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("Equal"sv)), (ByteString::must_from_utf8("ThrowingEqual"sv))}), false}));
+return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("Equal"sv)), (ByteString::from_utf8_without_validation("ThrowingEqual"sv))}), false}));
 };/*case end*/
 case 27 /* AddAssign */: {
-return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("AddAssign"sv)), (ByteString::must_from_utf8("ThrowingAddAssign"sv))}), true}));
+return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("AddAssign"sv)), (ByteString::from_utf8_without_validation("ThrowingAddAssign"sv))}), true}));
 };/*case end*/
 case 28 /* SubtractAssign */: {
-return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("SubtractAssign"sv)), (ByteString::must_from_utf8("ThrowingSubtractAssign"sv))}), true}));
+return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("SubtractAssign"sv)), (ByteString::from_utf8_without_validation("ThrowingSubtractAssign"sv))}), true}));
 };/*case end*/
 case 29 /* MultiplyAssign */: {
-return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("MultiplyAssign"sv)), (ByteString::must_from_utf8("ThrowingMultiplyAssign"sv))}), true}));
+return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("MultiplyAssign"sv)), (ByteString::from_utf8_without_validation("ThrowingMultiplyAssign"sv))}), true}));
 };/*case end*/
 case 31 /* DivideAssign */: {
-return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("DivideAssign"sv)), (ByteString::must_from_utf8("ThrowingDivideAssign"sv))}), true}));
+return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("DivideAssign"sv)), (ByteString::from_utf8_without_validation("ThrowingDivideAssign"sv))}), true}));
 };/*case end*/
 case 30 /* ModuloAssign */: {
-return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("ModuloAssign"sv)), (ByteString::must_from_utf8("ThrowingModuloAssign"sv))}), true}));
+return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("ModuloAssign"sv)), (ByteString::from_utf8_without_validation("ThrowingModuloAssign"sv))}), true}));
 };/*case end*/
 case 22 /* BitwiseAndAssign */: {
-return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("BitwiseAndAssign"sv)), (ByteString::must_from_utf8("ThrowingBitwiseAndAssign"sv))}), true}));
+return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("BitwiseAndAssign"sv)), (ByteString::from_utf8_without_validation("ThrowingBitwiseAndAssign"sv))}), true}));
 };/*case end*/
 case 23 /* BitwiseOrAssign */: {
-return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("BitwiseOrAssign"sv)), (ByteString::must_from_utf8("ThrowingBitwiseOrAssign"sv))}), true}));
+return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("BitwiseOrAssign"sv)), (ByteString::from_utf8_without_validation("ThrowingBitwiseOrAssign"sv))}), true}));
 };/*case end*/
 case 24 /* BitwiseXorAssign */: {
-return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("BitwiseXorAssign"sv)), (ByteString::must_from_utf8("ThrowingBitwiseXorAssign"sv))}), true}));
+return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("BitwiseXorAssign"sv)), (ByteString::from_utf8_without_validation("ThrowingBitwiseXorAssign"sv))}), true}));
 };/*case end*/
 case 25 /* BitwiseLeftShiftAssign */: {
-return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("BitwiseLeftShiftAssign"sv)), (ByteString::must_from_utf8("ThrowingBitwiseLeftShiftAssign"sv))}), true}));
+return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("BitwiseLeftShiftAssign"sv)), (ByteString::from_utf8_without_validation("ThrowingBitwiseLeftShiftAssign"sv))}), true}));
 };/*case end*/
 case 26 /* BitwiseRightShiftAssign */: {
-return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("BitwiseRightShiftAssign"sv)), (ByteString::must_from_utf8("ThrowingBitwiseRightShiftAssign"sv))}), true}));
+return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("BitwiseRightShiftAssign"sv)), (ByteString::from_utf8_without_validation("ThrowingBitwiseRightShiftAssign"sv))}), true}));
 };/*case end*/
 default: {
 return JaktInternal::ExplicitValue((Tuple{empty_array, false}));
@@ -13072,70 +13072,70 @@ ByteString const function_name = ({
 auto&& __jakt_match_variant = op;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 0 /* Add */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("add"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("add"sv)));
 };/*case end*/
 case 1 /* Subtract */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("subtract"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("subtract"sv)));
 };/*case end*/
 case 2 /* Multiply */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("multiply"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("multiply"sv)));
 };/*case end*/
 case 3 /* Divide */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("divide"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("divide"sv)));
 };/*case end*/
 case 4 /* Modulo */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("modulo"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("modulo"sv)));
 };/*case end*/
 case 5 /* LessThan */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("less_than"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("less_than"sv)));
 };/*case end*/
 case 6 /* LessThanOrEqual */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("less_than_or_equal"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("less_than_or_equal"sv)));
 };/*case end*/
 case 7 /* GreaterThan */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("greater_than"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("greater_than"sv)));
 };/*case end*/
 case 8 /* GreaterThanOrEqual */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("greater_than_or_equal"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("greater_than_or_equal"sv)));
 };/*case end*/
 case 9 /* Equal */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("equals"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("equals"sv)));
 };/*case end*/
 case 10 /* NotEqual */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("not_equals"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("not_equals"sv)));
 };/*case end*/
 case 27 /* AddAssign */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("add_assign"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("add_assign"sv)));
 };/*case end*/
 case 28 /* SubtractAssign */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("subtract_assign"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("subtract_assign"sv)));
 };/*case end*/
 case 29 /* MultiplyAssign */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("multiply_assign"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("multiply_assign"sv)));
 };/*case end*/
 case 31 /* DivideAssign */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("divide_assign"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("divide_assign"sv)));
 };/*case end*/
 case 30 /* ModuloAssign */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("modulo_assign"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("modulo_assign"sv)));
 };/*case end*/
 case 22 /* BitwiseAndAssign */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("bitwise_and_assign"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("bitwise_and_assign"sv)));
 };/*case end*/
 case 23 /* BitwiseOrAssign */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("bitwise_or_assign"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("bitwise_or_assign"sv)));
 };/*case end*/
 case 24 /* BitwiseXorAssign */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("bitwise_xor_assign"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("bitwise_xor_assign"sv)));
 };/*case end*/
 case 25 /* BitwiseLeftShiftAssign */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("bitwise_left_shift_assign"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("bitwise_left_shift_assign"sv)));
 };/*case end*/
 case 26 /* BitwiseRightShiftAssign */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("bitwise_right_shift_assign"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("bitwise_right_shift_assign"sv)));
 };/*case end*/
 default: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8(""sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation(""sv)));
 };/*case end*/
 }/*switch end*/
 }()
@@ -13147,8 +13147,8 @@ return JaktInternal::ExplicitValue((ByteString::must_from_utf8(""sv)));
 JaktInternal::Optional<typechecker::TraitImplementationDescriptor> const add_trait_implementation = TRY((((*this).find_any_singular_trait_implementation(lhs_type_id,trait_names,scope_id,lhs_span,DynamicArray<ids::TypeId>::create_with({rhs_type_id})))));
 if (((add_trait_implementation).has_value())){
 typechecker::TraitImplementationDescriptor const implementation = (add_trait_implementation.value());
-if ((((((implementation).trait_name)).starts_with((ByteString::must_from_utf8("Throwing"sv)))) && (!(((scope)->can_throw))))){
-((*this).error((ByteString::must_from_utf8("Call to function that may throw needs to be in a try statement or a function marked as throws"sv)),span));
+if ((((((implementation).trait_name)).starts_with((ByteString::from_utf8_without_validation("Throwing"sv)))) && (!(((scope)->can_throw))))){
+((*this).error((ByteString::from_utf8_without_validation("Call to function that may throw needs to be in a try statement or a function marked as throws"sv)),span));
 }
 JaktInternal::Tuple<JaktInternal::Optional<types::StructLikeId>,bool> const parent_id___ = TRY((((*this).struct_like_id_from_type_id(lhs_type_id,scope_id,span,false,true))));
 JaktInternal::Optional<types::StructLikeId> const parent_id = ((parent_id___).template get<0>());
@@ -13159,15 +13159,15 @@ if (((implementation_function_id).has_value())){
 NonnullRefPtr<types::CheckedFunction> const implementation_function = ((*this).get_function((implementation_function_id.value())));
 if ((((implementation_function)->is_mutating()) && (!(((checked_lhs)->is_mutable(((*this).program))))))){
 if (is_assignment){
-((*this).error((ByteString::must_from_utf8("Assignment to immutable variable"sv)),span));
+((*this).error((ByteString::from_utf8_without_validation("Assignment to immutable variable"sv)),span));
 }
 else {
-((*this).error((ByteString::must_from_utf8("Cannot call mutating function on an immutable object instance"sv)),span));
+((*this).error((ByteString::from_utf8_without_validation("Cannot call mutating function on an immutable object instance"sv)),span));
 }
 
 }
 (type_id = ((implementation_function)->return_type_id));
-types::CheckedCall call_expression = types::CheckedCall(DynamicArray<types::ResolvedNamespace>::create_with({}),function_name,DynamicArray<JaktInternal::Tuple<ByteString,NonnullRefPtr<typename types::CheckedExpression>>>::create_with({(Tuple{(ByteString::must_from_utf8(""sv)), checked_rhs})}),DynamicArray<ids::TypeId>::create_with({}),implementation_function_id,type_id,((implementation_function)->can_throw),((implementation_function)->external_name),((implementation_function)->force_inline));
+types::CheckedCall call_expression = types::CheckedCall(DynamicArray<types::ResolvedNamespace>::create_with({}),function_name,DynamicArray<JaktInternal::Tuple<ByteString,NonnullRefPtr<typename types::CheckedExpression>>>::create_with({(Tuple{(ByteString::from_utf8_without_validation(""sv)), checked_rhs})}),DynamicArray<ids::TypeId>::create_with({}),implementation_function_id,type_id,((implementation_function)->can_throw),((implementation_function)->external_name),((implementation_function)->force_inline));
 (((checked_operator).trait_implementation) = types::OperatorTraitImplementation(((implementation).trait_id),((implementation).implemented_type_args),call_expression));
 }
 else {
@@ -13244,67 +13244,67 @@ JaktInternal::Tuple<JaktInternal::DynamicArray<ByteString>,bool> const trait_nam
 auto&& __jakt_match_variant = op;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 0 /* Add */: {
-return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("Add"sv)), (ByteString::must_from_utf8("ThrowingAdd"sv))}), false}));
+return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("Add"sv)), (ByteString::from_utf8_without_validation("ThrowingAdd"sv))}), false}));
 };/*case end*/
 case 1 /* Subtract */: {
-return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("Subtract"sv)), (ByteString::must_from_utf8("ThrowingSubtract"sv))}), false}));
+return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("Subtract"sv)), (ByteString::from_utf8_without_validation("ThrowingSubtract"sv))}), false}));
 };/*case end*/
 case 2 /* Multiply */: {
-return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("Multiply"sv)), (ByteString::must_from_utf8("ThrowingMultiply"sv))}), false}));
+return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("Multiply"sv)), (ByteString::from_utf8_without_validation("ThrowingMultiply"sv))}), false}));
 };/*case end*/
 case 3 /* Divide */: {
-return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("Divide"sv)), (ByteString::must_from_utf8("ThrowingDivide"sv))}), false}));
+return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("Divide"sv)), (ByteString::from_utf8_without_validation("ThrowingDivide"sv))}), false}));
 };/*case end*/
 case 4 /* Modulo */: {
-return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("Modulo"sv)), (ByteString::must_from_utf8("ThrowingModulo"sv))}), false}));
+return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("Modulo"sv)), (ByteString::from_utf8_without_validation("ThrowingModulo"sv))}), false}));
 };/*case end*/
 case 5 /* LessThan */: {
-return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("Compare"sv)), (ByteString::must_from_utf8("ThrowingCompare"sv))}), false}));
+return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("Compare"sv)), (ByteString::from_utf8_without_validation("ThrowingCompare"sv))}), false}));
 };/*case end*/
 case 6 /* LessThanOrEqual */: {
-return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("Compare"sv)), (ByteString::must_from_utf8("ThrowingCompare"sv))}), false}));
+return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("Compare"sv)), (ByteString::from_utf8_without_validation("ThrowingCompare"sv))}), false}));
 };/*case end*/
 case 7 /* GreaterThan */: {
-return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("Compare"sv)), (ByteString::must_from_utf8("ThrowingCompare"sv))}), false}));
+return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("Compare"sv)), (ByteString::from_utf8_without_validation("ThrowingCompare"sv))}), false}));
 };/*case end*/
 case 8 /* GreaterThanOrEqual */: {
-return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("Compare"sv)), (ByteString::must_from_utf8("ThrowingCompare"sv))}), false}));
+return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("Compare"sv)), (ByteString::from_utf8_without_validation("ThrowingCompare"sv))}), false}));
 };/*case end*/
 case 9 /* Equal */: {
-return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("Equal"sv)), (ByteString::must_from_utf8("ThrowingEqual"sv))}), false}));
+return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("Equal"sv)), (ByteString::from_utf8_without_validation("ThrowingEqual"sv))}), false}));
 };/*case end*/
 case 10 /* NotEqual */: {
-return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("Equal"sv)), (ByteString::must_from_utf8("ThrowingEqual"sv))}), false}));
+return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("Equal"sv)), (ByteString::from_utf8_without_validation("ThrowingEqual"sv))}), false}));
 };/*case end*/
 case 27 /* AddAssign */: {
-return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("AddAssign"sv)), (ByteString::must_from_utf8("ThrowingAddAssign"sv))}), true}));
+return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("AddAssign"sv)), (ByteString::from_utf8_without_validation("ThrowingAddAssign"sv))}), true}));
 };/*case end*/
 case 28 /* SubtractAssign */: {
-return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("SubtractAssign"sv)), (ByteString::must_from_utf8("ThrowingSubtractAssign"sv))}), true}));
+return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("SubtractAssign"sv)), (ByteString::from_utf8_without_validation("ThrowingSubtractAssign"sv))}), true}));
 };/*case end*/
 case 29 /* MultiplyAssign */: {
-return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("MultiplyAssign"sv)), (ByteString::must_from_utf8("ThrowingMultiplyAssign"sv))}), true}));
+return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("MultiplyAssign"sv)), (ByteString::from_utf8_without_validation("ThrowingMultiplyAssign"sv))}), true}));
 };/*case end*/
 case 31 /* DivideAssign */: {
-return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("DivideAssign"sv)), (ByteString::must_from_utf8("ThrowingDivideAssign"sv))}), true}));
+return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("DivideAssign"sv)), (ByteString::from_utf8_without_validation("ThrowingDivideAssign"sv))}), true}));
 };/*case end*/
 case 30 /* ModuloAssign */: {
-return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("ModuloAssign"sv)), (ByteString::must_from_utf8("ThrowingModuloAssign"sv))}), true}));
+return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("ModuloAssign"sv)), (ByteString::from_utf8_without_validation("ThrowingModuloAssign"sv))}), true}));
 };/*case end*/
 case 22 /* BitwiseAndAssign */: {
-return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("BitwiseAndAssign"sv)), (ByteString::must_from_utf8("ThrowingBitwiseAndAssign"sv))}), true}));
+return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("BitwiseAndAssign"sv)), (ByteString::from_utf8_without_validation("ThrowingBitwiseAndAssign"sv))}), true}));
 };/*case end*/
 case 23 /* BitwiseOrAssign */: {
-return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("BitwiseOrAssign"sv)), (ByteString::must_from_utf8("ThrowingBitwiseOrAssign"sv))}), true}));
+return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("BitwiseOrAssign"sv)), (ByteString::from_utf8_without_validation("ThrowingBitwiseOrAssign"sv))}), true}));
 };/*case end*/
 case 24 /* BitwiseXorAssign */: {
-return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("BitwiseXorAssign"sv)), (ByteString::must_from_utf8("ThrowingBitwiseXorAssign"sv))}), true}));
+return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("BitwiseXorAssign"sv)), (ByteString::from_utf8_without_validation("ThrowingBitwiseXorAssign"sv))}), true}));
 };/*case end*/
 case 25 /* BitwiseLeftShiftAssign */: {
-return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("BitwiseLeftShiftAssign"sv)), (ByteString::must_from_utf8("ThrowingBitwiseLeftShiftAssign"sv))}), true}));
+return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("BitwiseLeftShiftAssign"sv)), (ByteString::from_utf8_without_validation("ThrowingBitwiseLeftShiftAssign"sv))}), true}));
 };/*case end*/
 case 26 /* BitwiseRightShiftAssign */: {
-return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("BitwiseRightShiftAssign"sv)), (ByteString::must_from_utf8("ThrowingBitwiseRightShiftAssign"sv))}), true}));
+return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("BitwiseRightShiftAssign"sv)), (ByteString::from_utf8_without_validation("ThrowingBitwiseRightShiftAssign"sv))}), true}));
 };/*case end*/
 default: {
 return JaktInternal::ExplicitValue((Tuple{empty_array, false}));
@@ -13324,70 +13324,70 @@ ByteString const function_name = ({
 auto&& __jakt_match_variant = op;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 0 /* Add */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("add"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("add"sv)));
 };/*case end*/
 case 1 /* Subtract */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("subtract"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("subtract"sv)));
 };/*case end*/
 case 2 /* Multiply */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("multiply"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("multiply"sv)));
 };/*case end*/
 case 3 /* Divide */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("divide"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("divide"sv)));
 };/*case end*/
 case 4 /* Modulo */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("modulo"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("modulo"sv)));
 };/*case end*/
 case 5 /* LessThan */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("less_than"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("less_than"sv)));
 };/*case end*/
 case 6 /* LessThanOrEqual */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("less_than_or_equal"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("less_than_or_equal"sv)));
 };/*case end*/
 case 7 /* GreaterThan */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("greater_than"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("greater_than"sv)));
 };/*case end*/
 case 8 /* GreaterThanOrEqual */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("greater_than_or_equal"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("greater_than_or_equal"sv)));
 };/*case end*/
 case 9 /* Equal */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("equals"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("equals"sv)));
 };/*case end*/
 case 10 /* NotEqual */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("not_equals"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("not_equals"sv)));
 };/*case end*/
 case 27 /* AddAssign */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("add_assign"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("add_assign"sv)));
 };/*case end*/
 case 28 /* SubtractAssign */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("subtract_assign"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("subtract_assign"sv)));
 };/*case end*/
 case 29 /* MultiplyAssign */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("multiply_assign"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("multiply_assign"sv)));
 };/*case end*/
 case 31 /* DivideAssign */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("divide_assign"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("divide_assign"sv)));
 };/*case end*/
 case 30 /* ModuloAssign */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("modulo_assign"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("modulo_assign"sv)));
 };/*case end*/
 case 22 /* BitwiseAndAssign */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("bitwise_and_assign"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("bitwise_and_assign"sv)));
 };/*case end*/
 case 23 /* BitwiseOrAssign */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("bitwise_or_assign"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("bitwise_or_assign"sv)));
 };/*case end*/
 case 24 /* BitwiseXorAssign */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("bitwise_xor_assign"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("bitwise_xor_assign"sv)));
 };/*case end*/
 case 25 /* BitwiseLeftShiftAssign */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("bitwise_left_shift_assign"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("bitwise_left_shift_assign"sv)));
 };/*case end*/
 case 26 /* BitwiseRightShiftAssign */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("bitwise_right_shift_assign"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("bitwise_right_shift_assign"sv)));
 };/*case end*/
 default: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8(""sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation(""sv)));
 };/*case end*/
 }/*switch end*/
 }()
@@ -13399,8 +13399,8 @@ return JaktInternal::ExplicitValue((ByteString::must_from_utf8(""sv)));
 JaktInternal::Optional<typechecker::TraitImplementationDescriptor> const add_trait_implementation = TRY((((*this).find_any_singular_trait_implementation(lhs_type_id,trait_names,scope_id,lhs_span,DynamicArray<ids::TypeId>::create_with({rhs_type_id})))));
 if (((add_trait_implementation).has_value())){
 typechecker::TraitImplementationDescriptor const implementation = (add_trait_implementation.value());
-if ((((((implementation).trait_name)).starts_with((ByteString::must_from_utf8("Throwing"sv)))) && (!(((scope)->can_throw))))){
-((*this).error((ByteString::must_from_utf8("Call to function that may throw needs to be in a try statement or a function marked as throws"sv)),span));
+if ((((((implementation).trait_name)).starts_with((ByteString::from_utf8_without_validation("Throwing"sv)))) && (!(((scope)->can_throw))))){
+((*this).error((ByteString::from_utf8_without_validation("Call to function that may throw needs to be in a try statement or a function marked as throws"sv)),span));
 }
 JaktInternal::Tuple<JaktInternal::Optional<types::StructLikeId>,bool> const parent_id___ = TRY((((*this).struct_like_id_from_type_id(lhs_type_id,scope_id,span,false,true))));
 JaktInternal::Optional<types::StructLikeId> const parent_id = ((parent_id___).template get<0>());
@@ -13411,15 +13411,15 @@ if (((implementation_function_id).has_value())){
 NonnullRefPtr<types::CheckedFunction> const implementation_function = ((*this).get_function((implementation_function_id.value())));
 if ((((implementation_function)->is_mutating()) && (!(((checked_lhs)->is_mutable(((*this).program))))))){
 if (is_assignment){
-((*this).error((ByteString::must_from_utf8("Assignment to immutable variable"sv)),span));
+((*this).error((ByteString::from_utf8_without_validation("Assignment to immutable variable"sv)),span));
 }
 else {
-((*this).error((ByteString::must_from_utf8("Cannot call mutating function on an immutable object instance"sv)),span));
+((*this).error((ByteString::from_utf8_without_validation("Cannot call mutating function on an immutable object instance"sv)),span));
 }
 
 }
 (type_id = ((implementation_function)->return_type_id));
-types::CheckedCall call_expression = types::CheckedCall(DynamicArray<types::ResolvedNamespace>::create_with({}),function_name,DynamicArray<JaktInternal::Tuple<ByteString,NonnullRefPtr<typename types::CheckedExpression>>>::create_with({(Tuple{(ByteString::must_from_utf8(""sv)), checked_rhs})}),DynamicArray<ids::TypeId>::create_with({}),implementation_function_id,type_id,((implementation_function)->can_throw),((implementation_function)->external_name),((implementation_function)->force_inline));
+types::CheckedCall call_expression = types::CheckedCall(DynamicArray<types::ResolvedNamespace>::create_with({}),function_name,DynamicArray<JaktInternal::Tuple<ByteString,NonnullRefPtr<typename types::CheckedExpression>>>::create_with({(Tuple{(ByteString::from_utf8_without_validation(""sv)), checked_rhs})}),DynamicArray<ids::TypeId>::create_with({}),implementation_function_id,type_id,((implementation_function)->can_throw),((implementation_function)->external_name),((implementation_function)->force_inline));
 (((checked_operator).trait_implementation) = types::OperatorTraitImplementation(((implementation).trait_id),((implementation).implemented_type_args),call_expression));
 }
 else {
@@ -13496,67 +13496,67 @@ JaktInternal::Tuple<JaktInternal::DynamicArray<ByteString>,bool> const trait_nam
 auto&& __jakt_match_variant = op;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 0 /* Add */: {
-return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("Add"sv)), (ByteString::must_from_utf8("ThrowingAdd"sv))}), false}));
+return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("Add"sv)), (ByteString::from_utf8_without_validation("ThrowingAdd"sv))}), false}));
 };/*case end*/
 case 1 /* Subtract */: {
-return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("Subtract"sv)), (ByteString::must_from_utf8("ThrowingSubtract"sv))}), false}));
+return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("Subtract"sv)), (ByteString::from_utf8_without_validation("ThrowingSubtract"sv))}), false}));
 };/*case end*/
 case 2 /* Multiply */: {
-return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("Multiply"sv)), (ByteString::must_from_utf8("ThrowingMultiply"sv))}), false}));
+return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("Multiply"sv)), (ByteString::from_utf8_without_validation("ThrowingMultiply"sv))}), false}));
 };/*case end*/
 case 3 /* Divide */: {
-return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("Divide"sv)), (ByteString::must_from_utf8("ThrowingDivide"sv))}), false}));
+return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("Divide"sv)), (ByteString::from_utf8_without_validation("ThrowingDivide"sv))}), false}));
 };/*case end*/
 case 4 /* Modulo */: {
-return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("Modulo"sv)), (ByteString::must_from_utf8("ThrowingModulo"sv))}), false}));
+return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("Modulo"sv)), (ByteString::from_utf8_without_validation("ThrowingModulo"sv))}), false}));
 };/*case end*/
 case 5 /* LessThan */: {
-return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("Compare"sv)), (ByteString::must_from_utf8("ThrowingCompare"sv))}), false}));
+return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("Compare"sv)), (ByteString::from_utf8_without_validation("ThrowingCompare"sv))}), false}));
 };/*case end*/
 case 6 /* LessThanOrEqual */: {
-return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("Compare"sv)), (ByteString::must_from_utf8("ThrowingCompare"sv))}), false}));
+return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("Compare"sv)), (ByteString::from_utf8_without_validation("ThrowingCompare"sv))}), false}));
 };/*case end*/
 case 7 /* GreaterThan */: {
-return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("Compare"sv)), (ByteString::must_from_utf8("ThrowingCompare"sv))}), false}));
+return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("Compare"sv)), (ByteString::from_utf8_without_validation("ThrowingCompare"sv))}), false}));
 };/*case end*/
 case 8 /* GreaterThanOrEqual */: {
-return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("Compare"sv)), (ByteString::must_from_utf8("ThrowingCompare"sv))}), false}));
+return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("Compare"sv)), (ByteString::from_utf8_without_validation("ThrowingCompare"sv))}), false}));
 };/*case end*/
 case 9 /* Equal */: {
-return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("Equal"sv)), (ByteString::must_from_utf8("ThrowingEqual"sv))}), false}));
+return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("Equal"sv)), (ByteString::from_utf8_without_validation("ThrowingEqual"sv))}), false}));
 };/*case end*/
 case 10 /* NotEqual */: {
-return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("Equal"sv)), (ByteString::must_from_utf8("ThrowingEqual"sv))}), false}));
+return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("Equal"sv)), (ByteString::from_utf8_without_validation("ThrowingEqual"sv))}), false}));
 };/*case end*/
 case 27 /* AddAssign */: {
-return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("AddAssign"sv)), (ByteString::must_from_utf8("ThrowingAddAssign"sv))}), true}));
+return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("AddAssign"sv)), (ByteString::from_utf8_without_validation("ThrowingAddAssign"sv))}), true}));
 };/*case end*/
 case 28 /* SubtractAssign */: {
-return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("SubtractAssign"sv)), (ByteString::must_from_utf8("ThrowingSubtractAssign"sv))}), true}));
+return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("SubtractAssign"sv)), (ByteString::from_utf8_without_validation("ThrowingSubtractAssign"sv))}), true}));
 };/*case end*/
 case 29 /* MultiplyAssign */: {
-return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("MultiplyAssign"sv)), (ByteString::must_from_utf8("ThrowingMultiplyAssign"sv))}), true}));
+return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("MultiplyAssign"sv)), (ByteString::from_utf8_without_validation("ThrowingMultiplyAssign"sv))}), true}));
 };/*case end*/
 case 31 /* DivideAssign */: {
-return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("DivideAssign"sv)), (ByteString::must_from_utf8("ThrowingDivideAssign"sv))}), true}));
+return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("DivideAssign"sv)), (ByteString::from_utf8_without_validation("ThrowingDivideAssign"sv))}), true}));
 };/*case end*/
 case 30 /* ModuloAssign */: {
-return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("ModuloAssign"sv)), (ByteString::must_from_utf8("ThrowingModuloAssign"sv))}), true}));
+return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("ModuloAssign"sv)), (ByteString::from_utf8_without_validation("ThrowingModuloAssign"sv))}), true}));
 };/*case end*/
 case 22 /* BitwiseAndAssign */: {
-return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("BitwiseAndAssign"sv)), (ByteString::must_from_utf8("ThrowingBitwiseAndAssign"sv))}), true}));
+return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("BitwiseAndAssign"sv)), (ByteString::from_utf8_without_validation("ThrowingBitwiseAndAssign"sv))}), true}));
 };/*case end*/
 case 23 /* BitwiseOrAssign */: {
-return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("BitwiseOrAssign"sv)), (ByteString::must_from_utf8("ThrowingBitwiseOrAssign"sv))}), true}));
+return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("BitwiseOrAssign"sv)), (ByteString::from_utf8_without_validation("ThrowingBitwiseOrAssign"sv))}), true}));
 };/*case end*/
 case 24 /* BitwiseXorAssign */: {
-return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("BitwiseXorAssign"sv)), (ByteString::must_from_utf8("ThrowingBitwiseXorAssign"sv))}), true}));
+return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("BitwiseXorAssign"sv)), (ByteString::from_utf8_without_validation("ThrowingBitwiseXorAssign"sv))}), true}));
 };/*case end*/
 case 25 /* BitwiseLeftShiftAssign */: {
-return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("BitwiseLeftShiftAssign"sv)), (ByteString::must_from_utf8("ThrowingBitwiseLeftShiftAssign"sv))}), true}));
+return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("BitwiseLeftShiftAssign"sv)), (ByteString::from_utf8_without_validation("ThrowingBitwiseLeftShiftAssign"sv))}), true}));
 };/*case end*/
 case 26 /* BitwiseRightShiftAssign */: {
-return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("BitwiseRightShiftAssign"sv)), (ByteString::must_from_utf8("ThrowingBitwiseRightShiftAssign"sv))}), true}));
+return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("BitwiseRightShiftAssign"sv)), (ByteString::from_utf8_without_validation("ThrowingBitwiseRightShiftAssign"sv))}), true}));
 };/*case end*/
 default: {
 return JaktInternal::ExplicitValue((Tuple{empty_array, false}));
@@ -13576,70 +13576,70 @@ ByteString const function_name = ({
 auto&& __jakt_match_variant = op;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 0 /* Add */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("add"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("add"sv)));
 };/*case end*/
 case 1 /* Subtract */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("subtract"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("subtract"sv)));
 };/*case end*/
 case 2 /* Multiply */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("multiply"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("multiply"sv)));
 };/*case end*/
 case 3 /* Divide */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("divide"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("divide"sv)));
 };/*case end*/
 case 4 /* Modulo */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("modulo"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("modulo"sv)));
 };/*case end*/
 case 5 /* LessThan */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("less_than"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("less_than"sv)));
 };/*case end*/
 case 6 /* LessThanOrEqual */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("less_than_or_equal"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("less_than_or_equal"sv)));
 };/*case end*/
 case 7 /* GreaterThan */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("greater_than"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("greater_than"sv)));
 };/*case end*/
 case 8 /* GreaterThanOrEqual */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("greater_than_or_equal"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("greater_than_or_equal"sv)));
 };/*case end*/
 case 9 /* Equal */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("equals"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("equals"sv)));
 };/*case end*/
 case 10 /* NotEqual */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("not_equals"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("not_equals"sv)));
 };/*case end*/
 case 27 /* AddAssign */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("add_assign"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("add_assign"sv)));
 };/*case end*/
 case 28 /* SubtractAssign */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("subtract_assign"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("subtract_assign"sv)));
 };/*case end*/
 case 29 /* MultiplyAssign */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("multiply_assign"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("multiply_assign"sv)));
 };/*case end*/
 case 31 /* DivideAssign */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("divide_assign"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("divide_assign"sv)));
 };/*case end*/
 case 30 /* ModuloAssign */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("modulo_assign"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("modulo_assign"sv)));
 };/*case end*/
 case 22 /* BitwiseAndAssign */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("bitwise_and_assign"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("bitwise_and_assign"sv)));
 };/*case end*/
 case 23 /* BitwiseOrAssign */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("bitwise_or_assign"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("bitwise_or_assign"sv)));
 };/*case end*/
 case 24 /* BitwiseXorAssign */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("bitwise_xor_assign"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("bitwise_xor_assign"sv)));
 };/*case end*/
 case 25 /* BitwiseLeftShiftAssign */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("bitwise_left_shift_assign"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("bitwise_left_shift_assign"sv)));
 };/*case end*/
 case 26 /* BitwiseRightShiftAssign */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("bitwise_right_shift_assign"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("bitwise_right_shift_assign"sv)));
 };/*case end*/
 default: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8(""sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation(""sv)));
 };/*case end*/
 }/*switch end*/
 }()
@@ -13651,8 +13651,8 @@ return JaktInternal::ExplicitValue((ByteString::must_from_utf8(""sv)));
 JaktInternal::Optional<typechecker::TraitImplementationDescriptor> const add_trait_implementation = TRY((((*this).find_any_singular_trait_implementation(lhs_type_id,trait_names,scope_id,lhs_span,DynamicArray<ids::TypeId>::create_with({rhs_type_id})))));
 if (((add_trait_implementation).has_value())){
 typechecker::TraitImplementationDescriptor const implementation = (add_trait_implementation.value());
-if ((((((implementation).trait_name)).starts_with((ByteString::must_from_utf8("Throwing"sv)))) && (!(((scope)->can_throw))))){
-((*this).error((ByteString::must_from_utf8("Call to function that may throw needs to be in a try statement or a function marked as throws"sv)),span));
+if ((((((implementation).trait_name)).starts_with((ByteString::from_utf8_without_validation("Throwing"sv)))) && (!(((scope)->can_throw))))){
+((*this).error((ByteString::from_utf8_without_validation("Call to function that may throw needs to be in a try statement or a function marked as throws"sv)),span));
 }
 JaktInternal::Tuple<JaktInternal::Optional<types::StructLikeId>,bool> const parent_id___ = TRY((((*this).struct_like_id_from_type_id(lhs_type_id,scope_id,span,false,true))));
 JaktInternal::Optional<types::StructLikeId> const parent_id = ((parent_id___).template get<0>());
@@ -13663,15 +13663,15 @@ if (((implementation_function_id).has_value())){
 NonnullRefPtr<types::CheckedFunction> const implementation_function = ((*this).get_function((implementation_function_id.value())));
 if ((((implementation_function)->is_mutating()) && (!(((checked_lhs)->is_mutable(((*this).program))))))){
 if (is_assignment){
-((*this).error((ByteString::must_from_utf8("Assignment to immutable variable"sv)),span));
+((*this).error((ByteString::from_utf8_without_validation("Assignment to immutable variable"sv)),span));
 }
 else {
-((*this).error((ByteString::must_from_utf8("Cannot call mutating function on an immutable object instance"sv)),span));
+((*this).error((ByteString::from_utf8_without_validation("Cannot call mutating function on an immutable object instance"sv)),span));
 }
 
 }
 (type_id = ((implementation_function)->return_type_id));
-types::CheckedCall call_expression = types::CheckedCall(DynamicArray<types::ResolvedNamespace>::create_with({}),function_name,DynamicArray<JaktInternal::Tuple<ByteString,NonnullRefPtr<typename types::CheckedExpression>>>::create_with({(Tuple{(ByteString::must_from_utf8(""sv)), checked_rhs})}),DynamicArray<ids::TypeId>::create_with({}),implementation_function_id,type_id,((implementation_function)->can_throw),((implementation_function)->external_name),((implementation_function)->force_inline));
+types::CheckedCall call_expression = types::CheckedCall(DynamicArray<types::ResolvedNamespace>::create_with({}),function_name,DynamicArray<JaktInternal::Tuple<ByteString,NonnullRefPtr<typename types::CheckedExpression>>>::create_with({(Tuple{(ByteString::from_utf8_without_validation(""sv)), checked_rhs})}),DynamicArray<ids::TypeId>::create_with({}),implementation_function_id,type_id,((implementation_function)->can_throw),((implementation_function)->external_name),((implementation_function)->force_inline));
 (((checked_operator).trait_implementation) = types::OperatorTraitImplementation(((implementation).trait_id),((implementation).implemented_type_args),call_expression));
 }
 else {
@@ -13748,67 +13748,67 @@ JaktInternal::Tuple<JaktInternal::DynamicArray<ByteString>,bool> const trait_nam
 auto&& __jakt_match_variant = op;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 0 /* Add */: {
-return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("Add"sv)), (ByteString::must_from_utf8("ThrowingAdd"sv))}), false}));
+return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("Add"sv)), (ByteString::from_utf8_without_validation("ThrowingAdd"sv))}), false}));
 };/*case end*/
 case 1 /* Subtract */: {
-return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("Subtract"sv)), (ByteString::must_from_utf8("ThrowingSubtract"sv))}), false}));
+return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("Subtract"sv)), (ByteString::from_utf8_without_validation("ThrowingSubtract"sv))}), false}));
 };/*case end*/
 case 2 /* Multiply */: {
-return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("Multiply"sv)), (ByteString::must_from_utf8("ThrowingMultiply"sv))}), false}));
+return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("Multiply"sv)), (ByteString::from_utf8_without_validation("ThrowingMultiply"sv))}), false}));
 };/*case end*/
 case 3 /* Divide */: {
-return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("Divide"sv)), (ByteString::must_from_utf8("ThrowingDivide"sv))}), false}));
+return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("Divide"sv)), (ByteString::from_utf8_without_validation("ThrowingDivide"sv))}), false}));
 };/*case end*/
 case 4 /* Modulo */: {
-return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("Modulo"sv)), (ByteString::must_from_utf8("ThrowingModulo"sv))}), false}));
+return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("Modulo"sv)), (ByteString::from_utf8_without_validation("ThrowingModulo"sv))}), false}));
 };/*case end*/
 case 5 /* LessThan */: {
-return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("Compare"sv)), (ByteString::must_from_utf8("ThrowingCompare"sv))}), false}));
+return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("Compare"sv)), (ByteString::from_utf8_without_validation("ThrowingCompare"sv))}), false}));
 };/*case end*/
 case 6 /* LessThanOrEqual */: {
-return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("Compare"sv)), (ByteString::must_from_utf8("ThrowingCompare"sv))}), false}));
+return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("Compare"sv)), (ByteString::from_utf8_without_validation("ThrowingCompare"sv))}), false}));
 };/*case end*/
 case 7 /* GreaterThan */: {
-return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("Compare"sv)), (ByteString::must_from_utf8("ThrowingCompare"sv))}), false}));
+return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("Compare"sv)), (ByteString::from_utf8_without_validation("ThrowingCompare"sv))}), false}));
 };/*case end*/
 case 8 /* GreaterThanOrEqual */: {
-return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("Compare"sv)), (ByteString::must_from_utf8("ThrowingCompare"sv))}), false}));
+return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("Compare"sv)), (ByteString::from_utf8_without_validation("ThrowingCompare"sv))}), false}));
 };/*case end*/
 case 9 /* Equal */: {
-return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("Equal"sv)), (ByteString::must_from_utf8("ThrowingEqual"sv))}), false}));
+return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("Equal"sv)), (ByteString::from_utf8_without_validation("ThrowingEqual"sv))}), false}));
 };/*case end*/
 case 10 /* NotEqual */: {
-return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("Equal"sv)), (ByteString::must_from_utf8("ThrowingEqual"sv))}), false}));
+return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("Equal"sv)), (ByteString::from_utf8_without_validation("ThrowingEqual"sv))}), false}));
 };/*case end*/
 case 27 /* AddAssign */: {
-return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("AddAssign"sv)), (ByteString::must_from_utf8("ThrowingAddAssign"sv))}), true}));
+return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("AddAssign"sv)), (ByteString::from_utf8_without_validation("ThrowingAddAssign"sv))}), true}));
 };/*case end*/
 case 28 /* SubtractAssign */: {
-return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("SubtractAssign"sv)), (ByteString::must_from_utf8("ThrowingSubtractAssign"sv))}), true}));
+return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("SubtractAssign"sv)), (ByteString::from_utf8_without_validation("ThrowingSubtractAssign"sv))}), true}));
 };/*case end*/
 case 29 /* MultiplyAssign */: {
-return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("MultiplyAssign"sv)), (ByteString::must_from_utf8("ThrowingMultiplyAssign"sv))}), true}));
+return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("MultiplyAssign"sv)), (ByteString::from_utf8_without_validation("ThrowingMultiplyAssign"sv))}), true}));
 };/*case end*/
 case 31 /* DivideAssign */: {
-return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("DivideAssign"sv)), (ByteString::must_from_utf8("ThrowingDivideAssign"sv))}), true}));
+return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("DivideAssign"sv)), (ByteString::from_utf8_without_validation("ThrowingDivideAssign"sv))}), true}));
 };/*case end*/
 case 30 /* ModuloAssign */: {
-return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("ModuloAssign"sv)), (ByteString::must_from_utf8("ThrowingModuloAssign"sv))}), true}));
+return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("ModuloAssign"sv)), (ByteString::from_utf8_without_validation("ThrowingModuloAssign"sv))}), true}));
 };/*case end*/
 case 22 /* BitwiseAndAssign */: {
-return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("BitwiseAndAssign"sv)), (ByteString::must_from_utf8("ThrowingBitwiseAndAssign"sv))}), true}));
+return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("BitwiseAndAssign"sv)), (ByteString::from_utf8_without_validation("ThrowingBitwiseAndAssign"sv))}), true}));
 };/*case end*/
 case 23 /* BitwiseOrAssign */: {
-return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("BitwiseOrAssign"sv)), (ByteString::must_from_utf8("ThrowingBitwiseOrAssign"sv))}), true}));
+return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("BitwiseOrAssign"sv)), (ByteString::from_utf8_without_validation("ThrowingBitwiseOrAssign"sv))}), true}));
 };/*case end*/
 case 24 /* BitwiseXorAssign */: {
-return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("BitwiseXorAssign"sv)), (ByteString::must_from_utf8("ThrowingBitwiseXorAssign"sv))}), true}));
+return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("BitwiseXorAssign"sv)), (ByteString::from_utf8_without_validation("ThrowingBitwiseXorAssign"sv))}), true}));
 };/*case end*/
 case 25 /* BitwiseLeftShiftAssign */: {
-return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("BitwiseLeftShiftAssign"sv)), (ByteString::must_from_utf8("ThrowingBitwiseLeftShiftAssign"sv))}), true}));
+return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("BitwiseLeftShiftAssign"sv)), (ByteString::from_utf8_without_validation("ThrowingBitwiseLeftShiftAssign"sv))}), true}));
 };/*case end*/
 case 26 /* BitwiseRightShiftAssign */: {
-return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("BitwiseRightShiftAssign"sv)), (ByteString::must_from_utf8("ThrowingBitwiseRightShiftAssign"sv))}), true}));
+return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("BitwiseRightShiftAssign"sv)), (ByteString::from_utf8_without_validation("ThrowingBitwiseRightShiftAssign"sv))}), true}));
 };/*case end*/
 default: {
 return JaktInternal::ExplicitValue((Tuple{empty_array, false}));
@@ -13828,70 +13828,70 @@ ByteString const function_name = ({
 auto&& __jakt_match_variant = op;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 0 /* Add */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("add"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("add"sv)));
 };/*case end*/
 case 1 /* Subtract */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("subtract"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("subtract"sv)));
 };/*case end*/
 case 2 /* Multiply */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("multiply"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("multiply"sv)));
 };/*case end*/
 case 3 /* Divide */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("divide"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("divide"sv)));
 };/*case end*/
 case 4 /* Modulo */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("modulo"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("modulo"sv)));
 };/*case end*/
 case 5 /* LessThan */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("less_than"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("less_than"sv)));
 };/*case end*/
 case 6 /* LessThanOrEqual */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("less_than_or_equal"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("less_than_or_equal"sv)));
 };/*case end*/
 case 7 /* GreaterThan */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("greater_than"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("greater_than"sv)));
 };/*case end*/
 case 8 /* GreaterThanOrEqual */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("greater_than_or_equal"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("greater_than_or_equal"sv)));
 };/*case end*/
 case 9 /* Equal */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("equals"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("equals"sv)));
 };/*case end*/
 case 10 /* NotEqual */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("not_equals"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("not_equals"sv)));
 };/*case end*/
 case 27 /* AddAssign */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("add_assign"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("add_assign"sv)));
 };/*case end*/
 case 28 /* SubtractAssign */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("subtract_assign"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("subtract_assign"sv)));
 };/*case end*/
 case 29 /* MultiplyAssign */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("multiply_assign"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("multiply_assign"sv)));
 };/*case end*/
 case 31 /* DivideAssign */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("divide_assign"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("divide_assign"sv)));
 };/*case end*/
 case 30 /* ModuloAssign */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("modulo_assign"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("modulo_assign"sv)));
 };/*case end*/
 case 22 /* BitwiseAndAssign */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("bitwise_and_assign"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("bitwise_and_assign"sv)));
 };/*case end*/
 case 23 /* BitwiseOrAssign */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("bitwise_or_assign"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("bitwise_or_assign"sv)));
 };/*case end*/
 case 24 /* BitwiseXorAssign */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("bitwise_xor_assign"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("bitwise_xor_assign"sv)));
 };/*case end*/
 case 25 /* BitwiseLeftShiftAssign */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("bitwise_left_shift_assign"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("bitwise_left_shift_assign"sv)));
 };/*case end*/
 case 26 /* BitwiseRightShiftAssign */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("bitwise_right_shift_assign"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("bitwise_right_shift_assign"sv)));
 };/*case end*/
 default: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8(""sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation(""sv)));
 };/*case end*/
 }/*switch end*/
 }()
@@ -13903,8 +13903,8 @@ return JaktInternal::ExplicitValue((ByteString::must_from_utf8(""sv)));
 JaktInternal::Optional<typechecker::TraitImplementationDescriptor> const add_trait_implementation = TRY((((*this).find_any_singular_trait_implementation(lhs_type_id,trait_names,scope_id,lhs_span,DynamicArray<ids::TypeId>::create_with({rhs_type_id})))));
 if (((add_trait_implementation).has_value())){
 typechecker::TraitImplementationDescriptor const implementation = (add_trait_implementation.value());
-if ((((((implementation).trait_name)).starts_with((ByteString::must_from_utf8("Throwing"sv)))) && (!(((scope)->can_throw))))){
-((*this).error((ByteString::must_from_utf8("Call to function that may throw needs to be in a try statement or a function marked as throws"sv)),span));
+if ((((((implementation).trait_name)).starts_with((ByteString::from_utf8_without_validation("Throwing"sv)))) && (!(((scope)->can_throw))))){
+((*this).error((ByteString::from_utf8_without_validation("Call to function that may throw needs to be in a try statement or a function marked as throws"sv)),span));
 }
 JaktInternal::Tuple<JaktInternal::Optional<types::StructLikeId>,bool> const parent_id___ = TRY((((*this).struct_like_id_from_type_id(lhs_type_id,scope_id,span,false,true))));
 JaktInternal::Optional<types::StructLikeId> const parent_id = ((parent_id___).template get<0>());
@@ -13915,15 +13915,15 @@ if (((implementation_function_id).has_value())){
 NonnullRefPtr<types::CheckedFunction> const implementation_function = ((*this).get_function((implementation_function_id.value())));
 if ((((implementation_function)->is_mutating()) && (!(((checked_lhs)->is_mutable(((*this).program))))))){
 if (is_assignment){
-((*this).error((ByteString::must_from_utf8("Assignment to immutable variable"sv)),span));
+((*this).error((ByteString::from_utf8_without_validation("Assignment to immutable variable"sv)),span));
 }
 else {
-((*this).error((ByteString::must_from_utf8("Cannot call mutating function on an immutable object instance"sv)),span));
+((*this).error((ByteString::from_utf8_without_validation("Cannot call mutating function on an immutable object instance"sv)),span));
 }
 
 }
 (type_id = ((implementation_function)->return_type_id));
-types::CheckedCall call_expression = types::CheckedCall(DynamicArray<types::ResolvedNamespace>::create_with({}),function_name,DynamicArray<JaktInternal::Tuple<ByteString,NonnullRefPtr<typename types::CheckedExpression>>>::create_with({(Tuple{(ByteString::must_from_utf8(""sv)), checked_rhs})}),DynamicArray<ids::TypeId>::create_with({}),implementation_function_id,type_id,((implementation_function)->can_throw),((implementation_function)->external_name),((implementation_function)->force_inline));
+types::CheckedCall call_expression = types::CheckedCall(DynamicArray<types::ResolvedNamespace>::create_with({}),function_name,DynamicArray<JaktInternal::Tuple<ByteString,NonnullRefPtr<typename types::CheckedExpression>>>::create_with({(Tuple{(ByteString::from_utf8_without_validation(""sv)), checked_rhs})}),DynamicArray<ids::TypeId>::create_with({}),implementation_function_id,type_id,((implementation_function)->can_throw),((implementation_function)->external_name),((implementation_function)->force_inline));
 (((checked_operator).trait_implementation) = types::OperatorTraitImplementation(((implementation).trait_id),((implementation).implemented_type_args),call_expression));
 }
 else {
@@ -14000,67 +14000,67 @@ JaktInternal::Tuple<JaktInternal::DynamicArray<ByteString>,bool> const trait_nam
 auto&& __jakt_match_variant = op;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 0 /* Add */: {
-return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("Add"sv)), (ByteString::must_from_utf8("ThrowingAdd"sv))}), false}));
+return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("Add"sv)), (ByteString::from_utf8_without_validation("ThrowingAdd"sv))}), false}));
 };/*case end*/
 case 1 /* Subtract */: {
-return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("Subtract"sv)), (ByteString::must_from_utf8("ThrowingSubtract"sv))}), false}));
+return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("Subtract"sv)), (ByteString::from_utf8_without_validation("ThrowingSubtract"sv))}), false}));
 };/*case end*/
 case 2 /* Multiply */: {
-return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("Multiply"sv)), (ByteString::must_from_utf8("ThrowingMultiply"sv))}), false}));
+return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("Multiply"sv)), (ByteString::from_utf8_without_validation("ThrowingMultiply"sv))}), false}));
 };/*case end*/
 case 3 /* Divide */: {
-return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("Divide"sv)), (ByteString::must_from_utf8("ThrowingDivide"sv))}), false}));
+return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("Divide"sv)), (ByteString::from_utf8_without_validation("ThrowingDivide"sv))}), false}));
 };/*case end*/
 case 4 /* Modulo */: {
-return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("Modulo"sv)), (ByteString::must_from_utf8("ThrowingModulo"sv))}), false}));
+return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("Modulo"sv)), (ByteString::from_utf8_without_validation("ThrowingModulo"sv))}), false}));
 };/*case end*/
 case 5 /* LessThan */: {
-return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("Compare"sv)), (ByteString::must_from_utf8("ThrowingCompare"sv))}), false}));
+return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("Compare"sv)), (ByteString::from_utf8_without_validation("ThrowingCompare"sv))}), false}));
 };/*case end*/
 case 6 /* LessThanOrEqual */: {
-return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("Compare"sv)), (ByteString::must_from_utf8("ThrowingCompare"sv))}), false}));
+return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("Compare"sv)), (ByteString::from_utf8_without_validation("ThrowingCompare"sv))}), false}));
 };/*case end*/
 case 7 /* GreaterThan */: {
-return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("Compare"sv)), (ByteString::must_from_utf8("ThrowingCompare"sv))}), false}));
+return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("Compare"sv)), (ByteString::from_utf8_without_validation("ThrowingCompare"sv))}), false}));
 };/*case end*/
 case 8 /* GreaterThanOrEqual */: {
-return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("Compare"sv)), (ByteString::must_from_utf8("ThrowingCompare"sv))}), false}));
+return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("Compare"sv)), (ByteString::from_utf8_without_validation("ThrowingCompare"sv))}), false}));
 };/*case end*/
 case 9 /* Equal */: {
-return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("Equal"sv)), (ByteString::must_from_utf8("ThrowingEqual"sv))}), false}));
+return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("Equal"sv)), (ByteString::from_utf8_without_validation("ThrowingEqual"sv))}), false}));
 };/*case end*/
 case 10 /* NotEqual */: {
-return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("Equal"sv)), (ByteString::must_from_utf8("ThrowingEqual"sv))}), false}));
+return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("Equal"sv)), (ByteString::from_utf8_without_validation("ThrowingEqual"sv))}), false}));
 };/*case end*/
 case 27 /* AddAssign */: {
-return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("AddAssign"sv)), (ByteString::must_from_utf8("ThrowingAddAssign"sv))}), true}));
+return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("AddAssign"sv)), (ByteString::from_utf8_without_validation("ThrowingAddAssign"sv))}), true}));
 };/*case end*/
 case 28 /* SubtractAssign */: {
-return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("SubtractAssign"sv)), (ByteString::must_from_utf8("ThrowingSubtractAssign"sv))}), true}));
+return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("SubtractAssign"sv)), (ByteString::from_utf8_without_validation("ThrowingSubtractAssign"sv))}), true}));
 };/*case end*/
 case 29 /* MultiplyAssign */: {
-return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("MultiplyAssign"sv)), (ByteString::must_from_utf8("ThrowingMultiplyAssign"sv))}), true}));
+return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("MultiplyAssign"sv)), (ByteString::from_utf8_without_validation("ThrowingMultiplyAssign"sv))}), true}));
 };/*case end*/
 case 31 /* DivideAssign */: {
-return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("DivideAssign"sv)), (ByteString::must_from_utf8("ThrowingDivideAssign"sv))}), true}));
+return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("DivideAssign"sv)), (ByteString::from_utf8_without_validation("ThrowingDivideAssign"sv))}), true}));
 };/*case end*/
 case 30 /* ModuloAssign */: {
-return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("ModuloAssign"sv)), (ByteString::must_from_utf8("ThrowingModuloAssign"sv))}), true}));
+return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("ModuloAssign"sv)), (ByteString::from_utf8_without_validation("ThrowingModuloAssign"sv))}), true}));
 };/*case end*/
 case 22 /* BitwiseAndAssign */: {
-return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("BitwiseAndAssign"sv)), (ByteString::must_from_utf8("ThrowingBitwiseAndAssign"sv))}), true}));
+return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("BitwiseAndAssign"sv)), (ByteString::from_utf8_without_validation("ThrowingBitwiseAndAssign"sv))}), true}));
 };/*case end*/
 case 23 /* BitwiseOrAssign */: {
-return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("BitwiseOrAssign"sv)), (ByteString::must_from_utf8("ThrowingBitwiseOrAssign"sv))}), true}));
+return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("BitwiseOrAssign"sv)), (ByteString::from_utf8_without_validation("ThrowingBitwiseOrAssign"sv))}), true}));
 };/*case end*/
 case 24 /* BitwiseXorAssign */: {
-return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("BitwiseXorAssign"sv)), (ByteString::must_from_utf8("ThrowingBitwiseXorAssign"sv))}), true}));
+return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("BitwiseXorAssign"sv)), (ByteString::from_utf8_without_validation("ThrowingBitwiseXorAssign"sv))}), true}));
 };/*case end*/
 case 25 /* BitwiseLeftShiftAssign */: {
-return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("BitwiseLeftShiftAssign"sv)), (ByteString::must_from_utf8("ThrowingBitwiseLeftShiftAssign"sv))}), true}));
+return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("BitwiseLeftShiftAssign"sv)), (ByteString::from_utf8_without_validation("ThrowingBitwiseLeftShiftAssign"sv))}), true}));
 };/*case end*/
 case 26 /* BitwiseRightShiftAssign */: {
-return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("BitwiseRightShiftAssign"sv)), (ByteString::must_from_utf8("ThrowingBitwiseRightShiftAssign"sv))}), true}));
+return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("BitwiseRightShiftAssign"sv)), (ByteString::from_utf8_without_validation("ThrowingBitwiseRightShiftAssign"sv))}), true}));
 };/*case end*/
 default: {
 return JaktInternal::ExplicitValue((Tuple{empty_array, false}));
@@ -14080,70 +14080,70 @@ ByteString const function_name = ({
 auto&& __jakt_match_variant = op;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 0 /* Add */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("add"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("add"sv)));
 };/*case end*/
 case 1 /* Subtract */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("subtract"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("subtract"sv)));
 };/*case end*/
 case 2 /* Multiply */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("multiply"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("multiply"sv)));
 };/*case end*/
 case 3 /* Divide */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("divide"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("divide"sv)));
 };/*case end*/
 case 4 /* Modulo */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("modulo"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("modulo"sv)));
 };/*case end*/
 case 5 /* LessThan */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("less_than"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("less_than"sv)));
 };/*case end*/
 case 6 /* LessThanOrEqual */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("less_than_or_equal"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("less_than_or_equal"sv)));
 };/*case end*/
 case 7 /* GreaterThan */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("greater_than"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("greater_than"sv)));
 };/*case end*/
 case 8 /* GreaterThanOrEqual */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("greater_than_or_equal"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("greater_than_or_equal"sv)));
 };/*case end*/
 case 9 /* Equal */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("equals"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("equals"sv)));
 };/*case end*/
 case 10 /* NotEqual */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("not_equals"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("not_equals"sv)));
 };/*case end*/
 case 27 /* AddAssign */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("add_assign"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("add_assign"sv)));
 };/*case end*/
 case 28 /* SubtractAssign */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("subtract_assign"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("subtract_assign"sv)));
 };/*case end*/
 case 29 /* MultiplyAssign */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("multiply_assign"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("multiply_assign"sv)));
 };/*case end*/
 case 31 /* DivideAssign */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("divide_assign"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("divide_assign"sv)));
 };/*case end*/
 case 30 /* ModuloAssign */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("modulo_assign"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("modulo_assign"sv)));
 };/*case end*/
 case 22 /* BitwiseAndAssign */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("bitwise_and_assign"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("bitwise_and_assign"sv)));
 };/*case end*/
 case 23 /* BitwiseOrAssign */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("bitwise_or_assign"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("bitwise_or_assign"sv)));
 };/*case end*/
 case 24 /* BitwiseXorAssign */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("bitwise_xor_assign"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("bitwise_xor_assign"sv)));
 };/*case end*/
 case 25 /* BitwiseLeftShiftAssign */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("bitwise_left_shift_assign"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("bitwise_left_shift_assign"sv)));
 };/*case end*/
 case 26 /* BitwiseRightShiftAssign */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("bitwise_right_shift_assign"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("bitwise_right_shift_assign"sv)));
 };/*case end*/
 default: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8(""sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation(""sv)));
 };/*case end*/
 }/*switch end*/
 }()
@@ -14155,8 +14155,8 @@ return JaktInternal::ExplicitValue((ByteString::must_from_utf8(""sv)));
 JaktInternal::Optional<typechecker::TraitImplementationDescriptor> const add_trait_implementation = TRY((((*this).find_any_singular_trait_implementation(lhs_type_id,trait_names,scope_id,lhs_span,DynamicArray<ids::TypeId>::create_with({rhs_type_id})))));
 if (((add_trait_implementation).has_value())){
 typechecker::TraitImplementationDescriptor const implementation = (add_trait_implementation.value());
-if ((((((implementation).trait_name)).starts_with((ByteString::must_from_utf8("Throwing"sv)))) && (!(((scope)->can_throw))))){
-((*this).error((ByteString::must_from_utf8("Call to function that may throw needs to be in a try statement or a function marked as throws"sv)),span));
+if ((((((implementation).trait_name)).starts_with((ByteString::from_utf8_without_validation("Throwing"sv)))) && (!(((scope)->can_throw))))){
+((*this).error((ByteString::from_utf8_without_validation("Call to function that may throw needs to be in a try statement or a function marked as throws"sv)),span));
 }
 JaktInternal::Tuple<JaktInternal::Optional<types::StructLikeId>,bool> const parent_id___ = TRY((((*this).struct_like_id_from_type_id(lhs_type_id,scope_id,span,false,true))));
 JaktInternal::Optional<types::StructLikeId> const parent_id = ((parent_id___).template get<0>());
@@ -14167,15 +14167,15 @@ if (((implementation_function_id).has_value())){
 NonnullRefPtr<types::CheckedFunction> const implementation_function = ((*this).get_function((implementation_function_id.value())));
 if ((((implementation_function)->is_mutating()) && (!(((checked_lhs)->is_mutable(((*this).program))))))){
 if (is_assignment){
-((*this).error((ByteString::must_from_utf8("Assignment to immutable variable"sv)),span));
+((*this).error((ByteString::from_utf8_without_validation("Assignment to immutable variable"sv)),span));
 }
 else {
-((*this).error((ByteString::must_from_utf8("Cannot call mutating function on an immutable object instance"sv)),span));
+((*this).error((ByteString::from_utf8_without_validation("Cannot call mutating function on an immutable object instance"sv)),span));
 }
 
 }
 (type_id = ((implementation_function)->return_type_id));
-types::CheckedCall call_expression = types::CheckedCall(DynamicArray<types::ResolvedNamespace>::create_with({}),function_name,DynamicArray<JaktInternal::Tuple<ByteString,NonnullRefPtr<typename types::CheckedExpression>>>::create_with({(Tuple{(ByteString::must_from_utf8(""sv)), checked_rhs})}),DynamicArray<ids::TypeId>::create_with({}),implementation_function_id,type_id,((implementation_function)->can_throw),((implementation_function)->external_name),((implementation_function)->force_inline));
+types::CheckedCall call_expression = types::CheckedCall(DynamicArray<types::ResolvedNamespace>::create_with({}),function_name,DynamicArray<JaktInternal::Tuple<ByteString,NonnullRefPtr<typename types::CheckedExpression>>>::create_with({(Tuple{(ByteString::from_utf8_without_validation(""sv)), checked_rhs})}),DynamicArray<ids::TypeId>::create_with({}),implementation_function_id,type_id,((implementation_function)->can_throw),((implementation_function)->external_name),((implementation_function)->force_inline));
 (((checked_operator).trait_implementation) = types::OperatorTraitImplementation(((implementation).trait_id),((implementation).implemented_type_args),call_expression));
 }
 else {
@@ -14252,67 +14252,67 @@ JaktInternal::Tuple<JaktInternal::DynamicArray<ByteString>,bool> const trait_nam
 auto&& __jakt_match_variant = op;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 0 /* Add */: {
-return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("Add"sv)), (ByteString::must_from_utf8("ThrowingAdd"sv))}), false}));
+return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("Add"sv)), (ByteString::from_utf8_without_validation("ThrowingAdd"sv))}), false}));
 };/*case end*/
 case 1 /* Subtract */: {
-return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("Subtract"sv)), (ByteString::must_from_utf8("ThrowingSubtract"sv))}), false}));
+return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("Subtract"sv)), (ByteString::from_utf8_without_validation("ThrowingSubtract"sv))}), false}));
 };/*case end*/
 case 2 /* Multiply */: {
-return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("Multiply"sv)), (ByteString::must_from_utf8("ThrowingMultiply"sv))}), false}));
+return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("Multiply"sv)), (ByteString::from_utf8_without_validation("ThrowingMultiply"sv))}), false}));
 };/*case end*/
 case 3 /* Divide */: {
-return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("Divide"sv)), (ByteString::must_from_utf8("ThrowingDivide"sv))}), false}));
+return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("Divide"sv)), (ByteString::from_utf8_without_validation("ThrowingDivide"sv))}), false}));
 };/*case end*/
 case 4 /* Modulo */: {
-return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("Modulo"sv)), (ByteString::must_from_utf8("ThrowingModulo"sv))}), false}));
+return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("Modulo"sv)), (ByteString::from_utf8_without_validation("ThrowingModulo"sv))}), false}));
 };/*case end*/
 case 5 /* LessThan */: {
-return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("Compare"sv)), (ByteString::must_from_utf8("ThrowingCompare"sv))}), false}));
+return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("Compare"sv)), (ByteString::from_utf8_without_validation("ThrowingCompare"sv))}), false}));
 };/*case end*/
 case 6 /* LessThanOrEqual */: {
-return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("Compare"sv)), (ByteString::must_from_utf8("ThrowingCompare"sv))}), false}));
+return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("Compare"sv)), (ByteString::from_utf8_without_validation("ThrowingCompare"sv))}), false}));
 };/*case end*/
 case 7 /* GreaterThan */: {
-return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("Compare"sv)), (ByteString::must_from_utf8("ThrowingCompare"sv))}), false}));
+return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("Compare"sv)), (ByteString::from_utf8_without_validation("ThrowingCompare"sv))}), false}));
 };/*case end*/
 case 8 /* GreaterThanOrEqual */: {
-return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("Compare"sv)), (ByteString::must_from_utf8("ThrowingCompare"sv))}), false}));
+return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("Compare"sv)), (ByteString::from_utf8_without_validation("ThrowingCompare"sv))}), false}));
 };/*case end*/
 case 9 /* Equal */: {
-return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("Equal"sv)), (ByteString::must_from_utf8("ThrowingEqual"sv))}), false}));
+return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("Equal"sv)), (ByteString::from_utf8_without_validation("ThrowingEqual"sv))}), false}));
 };/*case end*/
 case 10 /* NotEqual */: {
-return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("Equal"sv)), (ByteString::must_from_utf8("ThrowingEqual"sv))}), false}));
+return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("Equal"sv)), (ByteString::from_utf8_without_validation("ThrowingEqual"sv))}), false}));
 };/*case end*/
 case 27 /* AddAssign */: {
-return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("AddAssign"sv)), (ByteString::must_from_utf8("ThrowingAddAssign"sv))}), true}));
+return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("AddAssign"sv)), (ByteString::from_utf8_without_validation("ThrowingAddAssign"sv))}), true}));
 };/*case end*/
 case 28 /* SubtractAssign */: {
-return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("SubtractAssign"sv)), (ByteString::must_from_utf8("ThrowingSubtractAssign"sv))}), true}));
+return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("SubtractAssign"sv)), (ByteString::from_utf8_without_validation("ThrowingSubtractAssign"sv))}), true}));
 };/*case end*/
 case 29 /* MultiplyAssign */: {
-return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("MultiplyAssign"sv)), (ByteString::must_from_utf8("ThrowingMultiplyAssign"sv))}), true}));
+return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("MultiplyAssign"sv)), (ByteString::from_utf8_without_validation("ThrowingMultiplyAssign"sv))}), true}));
 };/*case end*/
 case 31 /* DivideAssign */: {
-return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("DivideAssign"sv)), (ByteString::must_from_utf8("ThrowingDivideAssign"sv))}), true}));
+return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("DivideAssign"sv)), (ByteString::from_utf8_without_validation("ThrowingDivideAssign"sv))}), true}));
 };/*case end*/
 case 30 /* ModuloAssign */: {
-return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("ModuloAssign"sv)), (ByteString::must_from_utf8("ThrowingModuloAssign"sv))}), true}));
+return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("ModuloAssign"sv)), (ByteString::from_utf8_without_validation("ThrowingModuloAssign"sv))}), true}));
 };/*case end*/
 case 22 /* BitwiseAndAssign */: {
-return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("BitwiseAndAssign"sv)), (ByteString::must_from_utf8("ThrowingBitwiseAndAssign"sv))}), true}));
+return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("BitwiseAndAssign"sv)), (ByteString::from_utf8_without_validation("ThrowingBitwiseAndAssign"sv))}), true}));
 };/*case end*/
 case 23 /* BitwiseOrAssign */: {
-return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("BitwiseOrAssign"sv)), (ByteString::must_from_utf8("ThrowingBitwiseOrAssign"sv))}), true}));
+return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("BitwiseOrAssign"sv)), (ByteString::from_utf8_without_validation("ThrowingBitwiseOrAssign"sv))}), true}));
 };/*case end*/
 case 24 /* BitwiseXorAssign */: {
-return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("BitwiseXorAssign"sv)), (ByteString::must_from_utf8("ThrowingBitwiseXorAssign"sv))}), true}));
+return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("BitwiseXorAssign"sv)), (ByteString::from_utf8_without_validation("ThrowingBitwiseXorAssign"sv))}), true}));
 };/*case end*/
 case 25 /* BitwiseLeftShiftAssign */: {
-return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("BitwiseLeftShiftAssign"sv)), (ByteString::must_from_utf8("ThrowingBitwiseLeftShiftAssign"sv))}), true}));
+return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("BitwiseLeftShiftAssign"sv)), (ByteString::from_utf8_without_validation("ThrowingBitwiseLeftShiftAssign"sv))}), true}));
 };/*case end*/
 case 26 /* BitwiseRightShiftAssign */: {
-return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("BitwiseRightShiftAssign"sv)), (ByteString::must_from_utf8("ThrowingBitwiseRightShiftAssign"sv))}), true}));
+return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("BitwiseRightShiftAssign"sv)), (ByteString::from_utf8_without_validation("ThrowingBitwiseRightShiftAssign"sv))}), true}));
 };/*case end*/
 default: {
 return JaktInternal::ExplicitValue((Tuple{empty_array, false}));
@@ -14332,70 +14332,70 @@ ByteString const function_name = ({
 auto&& __jakt_match_variant = op;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 0 /* Add */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("add"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("add"sv)));
 };/*case end*/
 case 1 /* Subtract */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("subtract"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("subtract"sv)));
 };/*case end*/
 case 2 /* Multiply */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("multiply"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("multiply"sv)));
 };/*case end*/
 case 3 /* Divide */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("divide"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("divide"sv)));
 };/*case end*/
 case 4 /* Modulo */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("modulo"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("modulo"sv)));
 };/*case end*/
 case 5 /* LessThan */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("less_than"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("less_than"sv)));
 };/*case end*/
 case 6 /* LessThanOrEqual */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("less_than_or_equal"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("less_than_or_equal"sv)));
 };/*case end*/
 case 7 /* GreaterThan */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("greater_than"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("greater_than"sv)));
 };/*case end*/
 case 8 /* GreaterThanOrEqual */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("greater_than_or_equal"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("greater_than_or_equal"sv)));
 };/*case end*/
 case 9 /* Equal */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("equals"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("equals"sv)));
 };/*case end*/
 case 10 /* NotEqual */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("not_equals"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("not_equals"sv)));
 };/*case end*/
 case 27 /* AddAssign */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("add_assign"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("add_assign"sv)));
 };/*case end*/
 case 28 /* SubtractAssign */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("subtract_assign"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("subtract_assign"sv)));
 };/*case end*/
 case 29 /* MultiplyAssign */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("multiply_assign"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("multiply_assign"sv)));
 };/*case end*/
 case 31 /* DivideAssign */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("divide_assign"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("divide_assign"sv)));
 };/*case end*/
 case 30 /* ModuloAssign */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("modulo_assign"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("modulo_assign"sv)));
 };/*case end*/
 case 22 /* BitwiseAndAssign */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("bitwise_and_assign"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("bitwise_and_assign"sv)));
 };/*case end*/
 case 23 /* BitwiseOrAssign */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("bitwise_or_assign"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("bitwise_or_assign"sv)));
 };/*case end*/
 case 24 /* BitwiseXorAssign */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("bitwise_xor_assign"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("bitwise_xor_assign"sv)));
 };/*case end*/
 case 25 /* BitwiseLeftShiftAssign */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("bitwise_left_shift_assign"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("bitwise_left_shift_assign"sv)));
 };/*case end*/
 case 26 /* BitwiseRightShiftAssign */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("bitwise_right_shift_assign"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("bitwise_right_shift_assign"sv)));
 };/*case end*/
 default: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8(""sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation(""sv)));
 };/*case end*/
 }/*switch end*/
 }()
@@ -14407,8 +14407,8 @@ return JaktInternal::ExplicitValue((ByteString::must_from_utf8(""sv)));
 JaktInternal::Optional<typechecker::TraitImplementationDescriptor> const add_trait_implementation = TRY((((*this).find_any_singular_trait_implementation(lhs_type_id,trait_names,scope_id,lhs_span,DynamicArray<ids::TypeId>::create_with({rhs_type_id})))));
 if (((add_trait_implementation).has_value())){
 typechecker::TraitImplementationDescriptor const implementation = (add_trait_implementation.value());
-if ((((((implementation).trait_name)).starts_with((ByteString::must_from_utf8("Throwing"sv)))) && (!(((scope)->can_throw))))){
-((*this).error((ByteString::must_from_utf8("Call to function that may throw needs to be in a try statement or a function marked as throws"sv)),span));
+if ((((((implementation).trait_name)).starts_with((ByteString::from_utf8_without_validation("Throwing"sv)))) && (!(((scope)->can_throw))))){
+((*this).error((ByteString::from_utf8_without_validation("Call to function that may throw needs to be in a try statement or a function marked as throws"sv)),span));
 }
 JaktInternal::Tuple<JaktInternal::Optional<types::StructLikeId>,bool> const parent_id___ = TRY((((*this).struct_like_id_from_type_id(lhs_type_id,scope_id,span,false,true))));
 JaktInternal::Optional<types::StructLikeId> const parent_id = ((parent_id___).template get<0>());
@@ -14419,15 +14419,15 @@ if (((implementation_function_id).has_value())){
 NonnullRefPtr<types::CheckedFunction> const implementation_function = ((*this).get_function((implementation_function_id.value())));
 if ((((implementation_function)->is_mutating()) && (!(((checked_lhs)->is_mutable(((*this).program))))))){
 if (is_assignment){
-((*this).error((ByteString::must_from_utf8("Assignment to immutable variable"sv)),span));
+((*this).error((ByteString::from_utf8_without_validation("Assignment to immutable variable"sv)),span));
 }
 else {
-((*this).error((ByteString::must_from_utf8("Cannot call mutating function on an immutable object instance"sv)),span));
+((*this).error((ByteString::from_utf8_without_validation("Cannot call mutating function on an immutable object instance"sv)),span));
 }
 
 }
 (type_id = ((implementation_function)->return_type_id));
-types::CheckedCall call_expression = types::CheckedCall(DynamicArray<types::ResolvedNamespace>::create_with({}),function_name,DynamicArray<JaktInternal::Tuple<ByteString,NonnullRefPtr<typename types::CheckedExpression>>>::create_with({(Tuple{(ByteString::must_from_utf8(""sv)), checked_rhs})}),DynamicArray<ids::TypeId>::create_with({}),implementation_function_id,type_id,((implementation_function)->can_throw),((implementation_function)->external_name),((implementation_function)->force_inline));
+types::CheckedCall call_expression = types::CheckedCall(DynamicArray<types::ResolvedNamespace>::create_with({}),function_name,DynamicArray<JaktInternal::Tuple<ByteString,NonnullRefPtr<typename types::CheckedExpression>>>::create_with({(Tuple{(ByteString::from_utf8_without_validation(""sv)), checked_rhs})}),DynamicArray<ids::TypeId>::create_with({}),implementation_function_id,type_id,((implementation_function)->can_throw),((implementation_function)->external_name),((implementation_function)->force_inline));
 (((checked_operator).trait_implementation) = types::OperatorTraitImplementation(((implementation).trait_id),((implementation).implemented_type_args),call_expression));
 }
 else {
@@ -14504,67 +14504,67 @@ JaktInternal::Tuple<JaktInternal::DynamicArray<ByteString>,bool> const trait_nam
 auto&& __jakt_match_variant = op;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 0 /* Add */: {
-return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("Add"sv)), (ByteString::must_from_utf8("ThrowingAdd"sv))}), false}));
+return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("Add"sv)), (ByteString::from_utf8_without_validation("ThrowingAdd"sv))}), false}));
 };/*case end*/
 case 1 /* Subtract */: {
-return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("Subtract"sv)), (ByteString::must_from_utf8("ThrowingSubtract"sv))}), false}));
+return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("Subtract"sv)), (ByteString::from_utf8_without_validation("ThrowingSubtract"sv))}), false}));
 };/*case end*/
 case 2 /* Multiply */: {
-return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("Multiply"sv)), (ByteString::must_from_utf8("ThrowingMultiply"sv))}), false}));
+return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("Multiply"sv)), (ByteString::from_utf8_without_validation("ThrowingMultiply"sv))}), false}));
 };/*case end*/
 case 3 /* Divide */: {
-return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("Divide"sv)), (ByteString::must_from_utf8("ThrowingDivide"sv))}), false}));
+return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("Divide"sv)), (ByteString::from_utf8_without_validation("ThrowingDivide"sv))}), false}));
 };/*case end*/
 case 4 /* Modulo */: {
-return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("Modulo"sv)), (ByteString::must_from_utf8("ThrowingModulo"sv))}), false}));
+return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("Modulo"sv)), (ByteString::from_utf8_without_validation("ThrowingModulo"sv))}), false}));
 };/*case end*/
 case 5 /* LessThan */: {
-return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("Compare"sv)), (ByteString::must_from_utf8("ThrowingCompare"sv))}), false}));
+return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("Compare"sv)), (ByteString::from_utf8_without_validation("ThrowingCompare"sv))}), false}));
 };/*case end*/
 case 6 /* LessThanOrEqual */: {
-return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("Compare"sv)), (ByteString::must_from_utf8("ThrowingCompare"sv))}), false}));
+return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("Compare"sv)), (ByteString::from_utf8_without_validation("ThrowingCompare"sv))}), false}));
 };/*case end*/
 case 7 /* GreaterThan */: {
-return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("Compare"sv)), (ByteString::must_from_utf8("ThrowingCompare"sv))}), false}));
+return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("Compare"sv)), (ByteString::from_utf8_without_validation("ThrowingCompare"sv))}), false}));
 };/*case end*/
 case 8 /* GreaterThanOrEqual */: {
-return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("Compare"sv)), (ByteString::must_from_utf8("ThrowingCompare"sv))}), false}));
+return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("Compare"sv)), (ByteString::from_utf8_without_validation("ThrowingCompare"sv))}), false}));
 };/*case end*/
 case 9 /* Equal */: {
-return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("Equal"sv)), (ByteString::must_from_utf8("ThrowingEqual"sv))}), false}));
+return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("Equal"sv)), (ByteString::from_utf8_without_validation("ThrowingEqual"sv))}), false}));
 };/*case end*/
 case 10 /* NotEqual */: {
-return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("Equal"sv)), (ByteString::must_from_utf8("ThrowingEqual"sv))}), false}));
+return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("Equal"sv)), (ByteString::from_utf8_without_validation("ThrowingEqual"sv))}), false}));
 };/*case end*/
 case 27 /* AddAssign */: {
-return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("AddAssign"sv)), (ByteString::must_from_utf8("ThrowingAddAssign"sv))}), true}));
+return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("AddAssign"sv)), (ByteString::from_utf8_without_validation("ThrowingAddAssign"sv))}), true}));
 };/*case end*/
 case 28 /* SubtractAssign */: {
-return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("SubtractAssign"sv)), (ByteString::must_from_utf8("ThrowingSubtractAssign"sv))}), true}));
+return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("SubtractAssign"sv)), (ByteString::from_utf8_without_validation("ThrowingSubtractAssign"sv))}), true}));
 };/*case end*/
 case 29 /* MultiplyAssign */: {
-return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("MultiplyAssign"sv)), (ByteString::must_from_utf8("ThrowingMultiplyAssign"sv))}), true}));
+return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("MultiplyAssign"sv)), (ByteString::from_utf8_without_validation("ThrowingMultiplyAssign"sv))}), true}));
 };/*case end*/
 case 31 /* DivideAssign */: {
-return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("DivideAssign"sv)), (ByteString::must_from_utf8("ThrowingDivideAssign"sv))}), true}));
+return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("DivideAssign"sv)), (ByteString::from_utf8_without_validation("ThrowingDivideAssign"sv))}), true}));
 };/*case end*/
 case 30 /* ModuloAssign */: {
-return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("ModuloAssign"sv)), (ByteString::must_from_utf8("ThrowingModuloAssign"sv))}), true}));
+return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("ModuloAssign"sv)), (ByteString::from_utf8_without_validation("ThrowingModuloAssign"sv))}), true}));
 };/*case end*/
 case 22 /* BitwiseAndAssign */: {
-return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("BitwiseAndAssign"sv)), (ByteString::must_from_utf8("ThrowingBitwiseAndAssign"sv))}), true}));
+return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("BitwiseAndAssign"sv)), (ByteString::from_utf8_without_validation("ThrowingBitwiseAndAssign"sv))}), true}));
 };/*case end*/
 case 23 /* BitwiseOrAssign */: {
-return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("BitwiseOrAssign"sv)), (ByteString::must_from_utf8("ThrowingBitwiseOrAssign"sv))}), true}));
+return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("BitwiseOrAssign"sv)), (ByteString::from_utf8_without_validation("ThrowingBitwiseOrAssign"sv))}), true}));
 };/*case end*/
 case 24 /* BitwiseXorAssign */: {
-return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("BitwiseXorAssign"sv)), (ByteString::must_from_utf8("ThrowingBitwiseXorAssign"sv))}), true}));
+return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("BitwiseXorAssign"sv)), (ByteString::from_utf8_without_validation("ThrowingBitwiseXorAssign"sv))}), true}));
 };/*case end*/
 case 25 /* BitwiseLeftShiftAssign */: {
-return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("BitwiseLeftShiftAssign"sv)), (ByteString::must_from_utf8("ThrowingBitwiseLeftShiftAssign"sv))}), true}));
+return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("BitwiseLeftShiftAssign"sv)), (ByteString::from_utf8_without_validation("ThrowingBitwiseLeftShiftAssign"sv))}), true}));
 };/*case end*/
 case 26 /* BitwiseRightShiftAssign */: {
-return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("BitwiseRightShiftAssign"sv)), (ByteString::must_from_utf8("ThrowingBitwiseRightShiftAssign"sv))}), true}));
+return JaktInternal::ExplicitValue((Tuple{DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("BitwiseRightShiftAssign"sv)), (ByteString::from_utf8_without_validation("ThrowingBitwiseRightShiftAssign"sv))}), true}));
 };/*case end*/
 default: {
 return JaktInternal::ExplicitValue((Tuple{empty_array, false}));
@@ -14584,70 +14584,70 @@ ByteString const function_name = ({
 auto&& __jakt_match_variant = op;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 0 /* Add */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("add"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("add"sv)));
 };/*case end*/
 case 1 /* Subtract */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("subtract"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("subtract"sv)));
 };/*case end*/
 case 2 /* Multiply */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("multiply"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("multiply"sv)));
 };/*case end*/
 case 3 /* Divide */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("divide"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("divide"sv)));
 };/*case end*/
 case 4 /* Modulo */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("modulo"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("modulo"sv)));
 };/*case end*/
 case 5 /* LessThan */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("less_than"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("less_than"sv)));
 };/*case end*/
 case 6 /* LessThanOrEqual */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("less_than_or_equal"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("less_than_or_equal"sv)));
 };/*case end*/
 case 7 /* GreaterThan */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("greater_than"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("greater_than"sv)));
 };/*case end*/
 case 8 /* GreaterThanOrEqual */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("greater_than_or_equal"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("greater_than_or_equal"sv)));
 };/*case end*/
 case 9 /* Equal */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("equals"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("equals"sv)));
 };/*case end*/
 case 10 /* NotEqual */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("not_equals"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("not_equals"sv)));
 };/*case end*/
 case 27 /* AddAssign */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("add_assign"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("add_assign"sv)));
 };/*case end*/
 case 28 /* SubtractAssign */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("subtract_assign"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("subtract_assign"sv)));
 };/*case end*/
 case 29 /* MultiplyAssign */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("multiply_assign"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("multiply_assign"sv)));
 };/*case end*/
 case 31 /* DivideAssign */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("divide_assign"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("divide_assign"sv)));
 };/*case end*/
 case 30 /* ModuloAssign */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("modulo_assign"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("modulo_assign"sv)));
 };/*case end*/
 case 22 /* BitwiseAndAssign */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("bitwise_and_assign"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("bitwise_and_assign"sv)));
 };/*case end*/
 case 23 /* BitwiseOrAssign */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("bitwise_or_assign"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("bitwise_or_assign"sv)));
 };/*case end*/
 case 24 /* BitwiseXorAssign */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("bitwise_xor_assign"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("bitwise_xor_assign"sv)));
 };/*case end*/
 case 25 /* BitwiseLeftShiftAssign */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("bitwise_left_shift_assign"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("bitwise_left_shift_assign"sv)));
 };/*case end*/
 case 26 /* BitwiseRightShiftAssign */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("bitwise_right_shift_assign"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("bitwise_right_shift_assign"sv)));
 };/*case end*/
 default: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8(""sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation(""sv)));
 };/*case end*/
 }/*switch end*/
 }()
@@ -14659,8 +14659,8 @@ return JaktInternal::ExplicitValue((ByteString::must_from_utf8(""sv)));
 JaktInternal::Optional<typechecker::TraitImplementationDescriptor> const add_trait_implementation = TRY((((*this).find_any_singular_trait_implementation(lhs_type_id,trait_names,scope_id,lhs_span,DynamicArray<ids::TypeId>::create_with({rhs_type_id})))));
 if (((add_trait_implementation).has_value())){
 typechecker::TraitImplementationDescriptor const implementation = (add_trait_implementation.value());
-if ((((((implementation).trait_name)).starts_with((ByteString::must_from_utf8("Throwing"sv)))) && (!(((scope)->can_throw))))){
-((*this).error((ByteString::must_from_utf8("Call to function that may throw needs to be in a try statement or a function marked as throws"sv)),span));
+if ((((((implementation).trait_name)).starts_with((ByteString::from_utf8_without_validation("Throwing"sv)))) && (!(((scope)->can_throw))))){
+((*this).error((ByteString::from_utf8_without_validation("Call to function that may throw needs to be in a try statement or a function marked as throws"sv)),span));
 }
 JaktInternal::Tuple<JaktInternal::Optional<types::StructLikeId>,bool> const parent_id___ = TRY((((*this).struct_like_id_from_type_id(lhs_type_id,scope_id,span,false,true))));
 JaktInternal::Optional<types::StructLikeId> const parent_id = ((parent_id___).template get<0>());
@@ -14671,15 +14671,15 @@ if (((implementation_function_id).has_value())){
 NonnullRefPtr<types::CheckedFunction> const implementation_function = ((*this).get_function((implementation_function_id.value())));
 if ((((implementation_function)->is_mutating()) && (!(((checked_lhs)->is_mutable(((*this).program))))))){
 if (is_assignment){
-((*this).error((ByteString::must_from_utf8("Assignment to immutable variable"sv)),span));
+((*this).error((ByteString::from_utf8_without_validation("Assignment to immutable variable"sv)),span));
 }
 else {
-((*this).error((ByteString::must_from_utf8("Cannot call mutating function on an immutable object instance"sv)),span));
+((*this).error((ByteString::from_utf8_without_validation("Cannot call mutating function on an immutable object instance"sv)),span));
 }
 
 }
 (type_id = ((implementation_function)->return_type_id));
-types::CheckedCall call_expression = types::CheckedCall(DynamicArray<types::ResolvedNamespace>::create_with({}),function_name,DynamicArray<JaktInternal::Tuple<ByteString,NonnullRefPtr<typename types::CheckedExpression>>>::create_with({(Tuple{(ByteString::must_from_utf8(""sv)), checked_rhs})}),DynamicArray<ids::TypeId>::create_with({}),implementation_function_id,type_id,((implementation_function)->can_throw),((implementation_function)->external_name),((implementation_function)->force_inline));
+types::CheckedCall call_expression = types::CheckedCall(DynamicArray<types::ResolvedNamespace>::create_with({}),function_name,DynamicArray<JaktInternal::Tuple<ByteString,NonnullRefPtr<typename types::CheckedExpression>>>::create_with({(Tuple{(ByteString::from_utf8_without_validation(""sv)), checked_rhs})}),DynamicArray<ids::TypeId>::create_with({}),implementation_function_id,type_id,((implementation_function)->can_throw),((implementation_function)->external_name),((implementation_function)->force_inline));
 (((checked_operator).trait_implementation) = types::OperatorTraitImplementation(((implementation).trait_id),((implementation).implemented_type_args),call_expression));
 }
 else {
@@ -14945,7 +14945,7 @@ return JaktInternal::ExplicitValue<void>();
 
 types::CheckedBlock const checked_else_block = TRY((((*this).typecheck_block(else_block,scope_id,safety_mode,JaktInternal::OptionalNone()))));
 if (((!(seen_scope_exit)) && ((((checked_else_block).control_flow)).may_return()))){
-((*this).error((ByteString::must_from_utf8("Else block of guard must either `return`, `break`, `continue`, or `throw`"sv)),span));
+((*this).error((ByteString::from_utf8_without_validation("Else block of guard must either `return`, `break`, `continue`, or `throw`"sv)),span));
 }
 JaktInternal::Tuple<NonnullRefPtr<typename parser::ParsedExpression>,JaktInternal::Optional<parser::ParsedBlock>,JaktInternal::Optional<NonnullRefPtr<typename parser::ParsedStatement>>> const new_condition_new_then_block_new_else_statement_ = TRY((((*this).expand_context_for_bindings(expr,JaktInternal::OptionalNone(),remaining_code,parser::ParsedStatement::Block(else_block,span),scope_id,span))));
 NonnullRefPtr<typename parser::ParsedExpression> const new_condition = ((new_condition_new_then_block_new_else_statement_).template get<0>());
@@ -14954,7 +14954,7 @@ JaktInternal::Optional<NonnullRefPtr<typename parser::ParsedStatement>> const ne
 
 NonnullRefPtr<typename types::CheckedExpression> const checked_condition = TRY((((*this).typecheck_expression_and_dereference_if_needed(new_condition,scope_id,safety_mode,JaktInternal::OptionalNone(),span))));
 if ((!(((((checked_condition)->type())).equals(types::builtin(types::BuiltinType::Bool())))))){
-((*this).error((ByteString::must_from_utf8("Condition must be a boolean expression"sv)),((new_condition)->span())));
+((*this).error((ByteString::from_utf8_without_validation("Condition must be a boolean expression"sv)),((new_condition)->span())));
 }
 types::CheckedBlock const checked_block = TRY((((*this).typecheck_block((new_then_block.value()),scope_id,safety_mode,JaktInternal::OptionalNone()))));
 JaktInternal::Optional<NonnullRefPtr<typename types::CheckedStatement>> checked_else = JaktInternal::OptionalNone();
@@ -14972,20 +14972,20 @@ ErrorOr<NonnullRefPtr<typename types::CheckedStatement>> typechecker::Typechecke
 {
 JaktInternal::Optional<utility::Span> const maybe_span = ((block).find_yield_span());
 if (((maybe_span).has_value())){
-((*this).error((ByteString::must_from_utf8("a 'for' loop block is not allowed to yield values"sv)),(maybe_span.value())));
+((*this).error((ByteString::from_utf8_without_validation("a 'for' loop block is not allowed to yield values"sv)),(maybe_span.value())));
 }
 NonnullRefPtr<typename types::CheckedExpression> iterable_expr = TRY((((*this).typecheck_expression_and_dereference_if_needed(range,scope_id,safety_mode,JaktInternal::OptionalNone(),span))));
 ids::TypeId resolved_iterable_result_type = types::unknown_type_id();
 NonnullRefPtr<typename parser::ParsedExpression> expression_to_iterate = range;
-JaktInternal::Optional<typechecker::TraitImplementationDescriptor> const iterable_trait_implementation = TRY((((*this).find_any_singular_trait_implementation(((iterable_expr)->type()),DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("Iterable"sv)), (ByteString::must_from_utf8("ThrowingIterable"sv))}),scope_id,((iterable_expr)->span()),JaktInternal::OptionalNone()))));
+JaktInternal::Optional<typechecker::TraitImplementationDescriptor> const iterable_trait_implementation = TRY((((*this).find_any_singular_trait_implementation(((iterable_expr)->type()),DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("Iterable"sv)), (ByteString::from_utf8_without_validation("ThrowingIterable"sv))}),scope_id,((iterable_expr)->span()),JaktInternal::OptionalNone()))));
 if ((!(((iterable_trait_implementation).has_value())))){
-JaktInternal::Optional<typechecker::TraitImplementationDescriptor> const into_iterator_trait_implementation = TRY((((*this).find_any_singular_trait_implementation(((iterable_expr)->type()),DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("IntoIterator"sv)), (ByteString::must_from_utf8("IntoThrowingIterator"sv))}),scope_id,((iterable_expr)->span()),JaktInternal::OptionalNone()))));
+JaktInternal::Optional<typechecker::TraitImplementationDescriptor> const into_iterator_trait_implementation = TRY((((*this).find_any_singular_trait_implementation(((iterable_expr)->type()),DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("IntoIterator"sv)), (ByteString::from_utf8_without_validation("IntoThrowingIterator"sv))}),scope_id,((iterable_expr)->span()),JaktInternal::OptionalNone()))));
 if ((!(((into_iterator_trait_implementation).has_value())))){
-((*this).error_with_hint((ByteString::must_from_utf8("Iterable expression is not iterable"sv)),((range)->span()),__jakt_format((StringView::from_string_literal("Consider implementing (Throwing)Iterable<T> or Into(Throwing)Iterator<T> for the type of this expression (‘{}’)"sv)),TRY((((*this).type_name(((iterable_expr)->type()),false))))),((range)->span())));
+((*this).error_with_hint((ByteString::from_utf8_without_validation("Iterable expression is not iterable"sv)),((range)->span()),__jakt_format((StringView::from_string_literal("Consider implementing (Throwing)Iterable<T> or Into(Throwing)Iterator<T> for the type of this expression (‘{}’)"sv)),TRY((((*this).type_name(((iterable_expr)->type()),false))))),((range)->span())));
 }
 else {
 (resolved_iterable_result_type = (((((into_iterator_trait_implementation.value())).implemented_type_args))[static_cast<i64>(0LL)]));
-(expression_to_iterate = parser::ParsedExpression::MethodCall(range,parser::ParsedCall(DynamicArray<ByteString>::create_with({}),(ByteString::must_from_utf8("iterator"sv)),DynamicArray<JaktInternal::Tuple<ByteString,utility::Span,NonnullRefPtr<typename parser::ParsedExpression>>>::create_with({}),DynamicArray<NonnullRefPtr<typename parser::ParsedType>>::create_with({})),false,name_span));
+(expression_to_iterate = parser::ParsedExpression::MethodCall(range,parser::ParsedCall(DynamicArray<ByteString>::create_with({}),(ByteString::from_utf8_without_validation("iterator"sv)),DynamicArray<JaktInternal::Tuple<ByteString,utility::Span,NonnullRefPtr<typename parser::ParsedExpression>>>::create_with({}),DynamicArray<NonnullRefPtr<typename parser::ParsedType>>::create_with({})),false,name_span));
 }
 
 }
@@ -14993,7 +14993,7 @@ else {
 (resolved_iterable_result_type = (((((iterable_trait_implementation.value())).implemented_type_args))[static_cast<i64>(0LL)]));
 }
 
-NonnullRefPtr<typename parser::ParsedStatement> const rewritten_statement = parser::ParsedStatement::Block(parser::ParsedBlock(DynamicArray<NonnullRefPtr<typename parser::ParsedStatement>>::create_with({parser::ParsedStatement::VarDecl(parser::ParsedVarDecl((ByteString::must_from_utf8("_magic"sv)),parser::ParsedType::Empty(JaktInternal::OptionalNone()),true,JaktInternal::OptionalNone(),name_span,JaktInternal::OptionalNone()),expression_to_iterate,span), parser::ParsedStatement::Loop(parser::ParsedBlock(DynamicArray<NonnullRefPtr<typename parser::ParsedStatement>>::create_with({parser::ParsedStatement::VarDecl(parser::ParsedVarDecl((ByteString::must_from_utf8("_magic_value"sv)),parser::ParsedType::Empty(JaktInternal::OptionalNone()),false,JaktInternal::OptionalNone(),name_span,JaktInternal::OptionalNone()),parser::ParsedExpression::MethodCall(parser::ParsedExpression::Var((ByteString::must_from_utf8("_magic"sv)),name_span),parser::ParsedCall(DynamicArray<ByteString>::create_with({}),(ByteString::must_from_utf8("next"sv)),DynamicArray<JaktInternal::Tuple<ByteString,utility::Span,NonnullRefPtr<typename parser::ParsedExpression>>>::create_with({}),DynamicArray<NonnullRefPtr<typename parser::ParsedType>>::create_with({})),false,name_span),span), parser::ParsedStatement::If(parser::ParsedExpression::UnaryOp(parser::ParsedExpression::MethodCall(parser::ParsedExpression::Var((ByteString::must_from_utf8("_magic_value"sv)),name_span),parser::ParsedCall(DynamicArray<ByteString>::create_with({}),(ByteString::must_from_utf8("has_value"sv)),DynamicArray<JaktInternal::Tuple<ByteString,utility::Span,NonnullRefPtr<typename parser::ParsedExpression>>>::create_with({}),DynamicArray<NonnullRefPtr<typename parser::ParsedType>>::create_with({})),false,name_span),parser::UnaryOperator::LogicalNot(),name_span),parser::ParsedBlock(DynamicArray<NonnullRefPtr<typename parser::ParsedStatement>>::create_with({parser::ParsedStatement::Break(span)})),JaktInternal::OptionalNone(),span), parser::ParsedStatement::VarDecl(parser::ParsedVarDecl(iterator_name,parser::ParsedType::Empty(JaktInternal::OptionalNone()),true,({
+NonnullRefPtr<typename parser::ParsedStatement> const rewritten_statement = parser::ParsedStatement::Block(parser::ParsedBlock(DynamicArray<NonnullRefPtr<typename parser::ParsedStatement>>::create_with({parser::ParsedStatement::VarDecl(parser::ParsedVarDecl((ByteString::from_utf8_without_validation("_magic"sv)),parser::ParsedType::Empty(JaktInternal::OptionalNone()),true,JaktInternal::OptionalNone(),name_span,JaktInternal::OptionalNone()),expression_to_iterate,span), parser::ParsedStatement::Loop(parser::ParsedBlock(DynamicArray<NonnullRefPtr<typename parser::ParsedStatement>>::create_with({parser::ParsedStatement::VarDecl(parser::ParsedVarDecl((ByteString::from_utf8_without_validation("_magic_value"sv)),parser::ParsedType::Empty(JaktInternal::OptionalNone()),false,JaktInternal::OptionalNone(),name_span,JaktInternal::OptionalNone()),parser::ParsedExpression::MethodCall(parser::ParsedExpression::Var((ByteString::from_utf8_without_validation("_magic"sv)),name_span),parser::ParsedCall(DynamicArray<ByteString>::create_with({}),(ByteString::from_utf8_without_validation("next"sv)),DynamicArray<JaktInternal::Tuple<ByteString,utility::Span,NonnullRefPtr<typename parser::ParsedExpression>>>::create_with({}),DynamicArray<NonnullRefPtr<typename parser::ParsedType>>::create_with({})),false,name_span),span), parser::ParsedStatement::If(parser::ParsedExpression::UnaryOp(parser::ParsedExpression::MethodCall(parser::ParsedExpression::Var((ByteString::from_utf8_without_validation("_magic_value"sv)),name_span),parser::ParsedCall(DynamicArray<ByteString>::create_with({}),(ByteString::from_utf8_without_validation("has_value"sv)),DynamicArray<JaktInternal::Tuple<ByteString,utility::Span,NonnullRefPtr<typename parser::ParsedExpression>>>::create_with({}),DynamicArray<NonnullRefPtr<typename parser::ParsedType>>::create_with({})),false,name_span),parser::UnaryOperator::LogicalNot(),name_span),parser::ParsedBlock(DynamicArray<NonnullRefPtr<typename parser::ParsedStatement>>::create_with({parser::ParsedStatement::Break(span)})),JaktInternal::OptionalNone(),span), parser::ParsedStatement::VarDecl(parser::ParsedVarDecl(iterator_name,parser::ParsedType::Empty(JaktInternal::OptionalNone()),true,({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<JaktInternal::Optional<utility::Span>,ErrorOr<NonnullRefPtr<typename types::CheckedStatement>>>{
 auto __jakt_enum_value = (is_destructuring);
 if (__jakt_enum_value == true) {
@@ -15007,7 +15007,7 @@ VERIFY_NOT_REACHED();
     if (_jakt_value.is_return())
         return _jakt_value.release_return();
     _jakt_value.release_value();
-}),name_span,JaktInternal::OptionalNone()),parser::ParsedExpression::ForcedUnwrap(parser::ParsedExpression::Var((ByteString::must_from_utf8("_magic_value"sv)),name_span),name_span),span), parser::ParsedStatement::Block(block,span)})),span)})),span);
+}),name_span,JaktInternal::OptionalNone()),parser::ParsedExpression::ForcedUnwrap(parser::ParsedExpression::Var((ByteString::from_utf8_without_validation("_magic_value"sv)),name_span),name_span),span), parser::ParsedStatement::Block(block,span)})),span)})),span);
 return TRY((((*this).typecheck_statement(rewritten_statement,scope_id,safety_mode,JaktInternal::OptionalNone()))));
 }
 }
@@ -15126,11 +15126,11 @@ JaktInternal::Optional<NonnullRefPtr<typename parser::ParsedStatement>> const ne
 
 NonnullRefPtr<typename types::CheckedExpression> const checked_condition = TRY((((*this).typecheck_expression_and_dereference_if_needed(new_condition,scope_id,safety_mode,JaktInternal::OptionalNone(),span))));
 if ((!(((((checked_condition)->type())).equals(types::builtin(types::BuiltinType::Bool())))))){
-((*this).error((ByteString::must_from_utf8("Condition must be a boolean expression"sv)),((new_condition)->span())));
+((*this).error((ByteString::from_utf8_without_validation("Condition must be a boolean expression"sv)),((new_condition)->span())));
 }
 types::CheckedBlock const checked_block = TRY((((*this).typecheck_block((new_then_block.value()),scope_id,safety_mode,JaktInternal::OptionalNone()))));
 if (((((checked_block).yielded_type)).has_value())){
-((*this).error((ByteString::must_from_utf8("An 'if' block is not allowed to yield values"sv)),((((new_then_block.value())).find_yield_span()).value())));
+((*this).error((ByteString::from_utf8_without_validation("An 'if' block is not allowed to yield values"sv)),((((new_then_block.value())).find_yield_span()).value())));
 }
 JaktInternal::Optional<NonnullRefPtr<typename types::CheckedStatement>> checked_else = JaktInternal::OptionalNone();
 if (((new_else_statement).has_value())){
@@ -15153,7 +15153,7 @@ NonnullRefPtr<typename types::CheckedExpression> const init = (checked_tuple_var
 (tuple_var_id = var_id);
 }
 else {
-((*this).error((ByteString::must_from_utf8("Destructuting assignment should be a variable declaration"sv)),span));
+((*this).error((ByteString::from_utf8_without_validation("Destructuting assignment should be a variable declaration"sv)),span));
 }
 
 JaktInternal::DynamicArray<ids::TypeId> inner_types = DynamicArray<ids::TypeId>::create_with({});
@@ -15163,7 +15163,7 @@ JaktInternal::DynamicArray<ids::TypeId> const args = (tuple_type)->as.GenericIns
 (inner_types = args);
 }
 else {
-((*this).error((ByteString::must_from_utf8("Tuple Type should be Generic Instance"sv)),span));
+((*this).error((ByteString::from_utf8_without_validation("Tuple Type should be Generic Instance"sv)),span));
 }
 
 NonnullRefPtr<types::CheckedVariable> const tuple_variable = ((((*this).program))->get_variable(tuple_var_id));
@@ -15188,7 +15188,7 @@ NonnullRefPtr<typename parser::ParsedExpression> const init = parser::ParsedExpr
 
 }
 else {
-((*this).error((ByteString::must_from_utf8("Tuple inner types sould have same size as tuple members"sv)),span));
+((*this).error((ByteString::from_utf8_without_validation("Tuple inner types sould have same size as tuple members"sv)),span));
 }
 
 return types::CheckedStatement::DestructuringAssignment(var_decls,checked_tuple_var_decl,span);
@@ -15609,26 +15609,26 @@ ids::TypeId lhs_type_id = TRY((((*this).typecheck_typename(((var).parsed_type),s
 NonnullRefPtr<typename types::CheckedExpression> checked_expr = TRY((((*this).typecheck_expression(init,scope_id,safety_mode,lhs_type_id))));
 ids::TypeId const rhs_type_id = ((checked_expr)->type());
 if (((rhs_type_id).equals(types::void_type_id()))){
-((*this).error((ByteString::must_from_utf8("Cannot assign `void` to a variable"sv)),((checked_expr)->span())));
+((*this).error((ByteString::from_utf8_without_validation("Cannot assign `void` to a variable"sv)),((checked_expr)->span())));
 }
 if (((((((*this).get_type(lhs_type_id)))->common.init_common.qualifiers)).is_immutable)){
 (lhs_type_id = ((*this).with_qualifiers(parser::CheckedQualifiers(false),lhs_type_id)));
 if (((var).is_mutable)){
-((*this).error((ByteString::must_from_utf8("Cannot have a mutable binding to an immutable object"sv)),((var).span)));
+((*this).error((ByteString::from_utf8_without_validation("Cannot have a mutable binding to an immutable object"sv)),((var).span)));
 }
 }
 if ((((lhs_type_id).equals(types::unknown_type_id())) && (!(((rhs_type_id).equals(types::unknown_type_id())))))){
 (lhs_type_id = rhs_type_id);
 }
-ids::StructId const weak_ptr_struct_id = TRY((((*this).find_struct_in_prelude((ByteString::must_from_utf8("WeakPtr"sv))))));
-ids::StructId const optional_struct_id = TRY((((*this).find_struct_in_prelude((ByteString::must_from_utf8("Optional"sv))))));
+ids::StructId const weak_ptr_struct_id = TRY((((*this).find_struct_in_prelude((ByteString::from_utf8_without_validation("WeakPtr"sv))))));
+ids::StructId const optional_struct_id = TRY((((*this).find_struct_in_prelude((ByteString::from_utf8_without_validation("Optional"sv))))));
 if (((*this).type_contains_reference(lhs_type_id))){
 JaktInternal::Tuple<JaktInternal::Optional<ids::ScopeId>,NonnullRefPtr<typename types::CheckedExpression>> const init_scope_id_cause_expr_ = TRY((((*this).required_scope_id_in_hierarchy_for(checked_expr,scope_id))));
 JaktInternal::Optional<ids::ScopeId> const init_scope_id = ((init_scope_id_cause_expr_).template get<0>());
 NonnullRefPtr<typename types::CheckedExpression> const cause_expr = ((init_scope_id_cause_expr_).template get<1>());
 
 if (((*this).scope_lifetime_subsumes(scope_id,init_scope_id))){
-((*this).error_with_hint((ByteString::must_from_utf8("Cannot assign a reference to a variable that outlives the reference"sv)),((checked_expr)->span()),(ByteString::must_from_utf8("Limited by this expression's lifetime"sv)),((cause_expr)->span())));
+((*this).error_with_hint((ByteString::from_utf8_without_validation("Cannot assign a reference to a variable that outlives the reference"sv)),((checked_expr)->span()),(ByteString::from_utf8_without_validation("Limited by this expression's lifetime"sv)),((cause_expr)->span())));
 }
 }
 NonnullRefPtr<typename types::Type> const lhs_type = ((*this).get_type(lhs_type_id));
@@ -15639,11 +15639,11 @@ if (((lhs_type)->__jakt_init_index() == 20 /* GenericInstance */)){
 ids::StructId const id = (lhs_type)->as.GenericInstance.id;
 JaktInternal::DynamicArray<ids::TypeId> const args = (lhs_type)->as.GenericInstance.args;
 if ((!((((id).equals(optional_struct_id)) || ((id).equals(weak_ptr_struct_id)))))){
-((*this).error((ByteString::must_from_utf8("Cannot assign None to a non-optional type"sv)),span));
+((*this).error((ByteString::from_utf8_without_validation("Cannot assign None to a non-optional type"sv)),span));
 }
 }
 else {
-((*this).error((ByteString::must_from_utf8("Cannot assign None to a non-optional type"sv)),span));
+((*this).error((ByteString::from_utf8_without_validation("Cannot assign None to a non-optional type"sv)),span));
 }
 
 }
@@ -15721,11 +15721,11 @@ ErrorOr<NonnullRefPtr<typename types::CheckedStatement>> typechecker::Typechecke
 {
 NonnullRefPtr<typename types::CheckedExpression> const checked_condition = TRY((((*this).typecheck_expression_and_dereference_if_needed(condition,scope_id,safety_mode,JaktInternal::OptionalNone(),span))));
 if ((!(((((checked_condition)->type())).equals(types::builtin(types::BuiltinType::Bool())))))){
-((*this).error((ByteString::must_from_utf8("Condition must be a boolean expression"sv)),((condition)->span())));
+((*this).error((ByteString::from_utf8_without_validation("Condition must be a boolean expression"sv)),((condition)->span())));
 }
 types::CheckedBlock const checked_block = TRY((((*this).typecheck_block(block,scope_id,safety_mode,JaktInternal::OptionalNone()))));
 if (((((checked_block).yielded_type)).has_value())){
-((*this).error((ByteString::must_from_utf8("A ‘while’ block is not allowed to yield values"sv)),(((block).find_yield_span()).value())));
+((*this).error((ByteString::from_utf8_without_validation("A ‘while’ block is not allowed to yield values"sv)),(((block).find_yield_span()).value())));
 }
 return types::CheckedStatement::While(checked_condition,checked_block,span);
 }
@@ -15733,18 +15733,18 @@ return types::CheckedStatement::While(checked_condition,checked_block,span);
 
 ErrorOr<NonnullRefPtr<typename types::CheckedExpression>> typechecker::Typechecker::typecheck_try_block(NonnullRefPtr<typename parser::ParsedStatement> const stmt,ByteString const error_name,utility::Span const error_span,parser::ParsedBlock const catch_block,ids::ScopeId const scope_id,types::SafetyMode const safety_mode,utility::Span const span) {
 {
-ids::ScopeId const try_scope_id = ((*this).create_scope(scope_id,true,(ByteString::must_from_utf8("try"sv)),true));
+ids::ScopeId const try_scope_id = ((*this).create_scope(scope_id,true,(ByteString::from_utf8_without_validation("try"sv)),true));
 NonnullRefPtr<typename types::CheckedStatement> const checked_stmt = TRY((((*this).typecheck_statement(stmt,try_scope_id,safety_mode,JaktInternal::OptionalNone()))));
-ids::StructId const error_struct_id = TRY((((*this).find_struct_in_prelude((ByteString::must_from_utf8("Error"sv))))));
+ids::StructId const error_struct_id = TRY((((*this).find_struct_in_prelude((ByteString::from_utf8_without_validation("Error"sv))))));
 NonnullRefPtr<types::CheckedVariable> const error_decl = types::CheckedVariable::__jakt_create(error_name,((((*this).get_struct(error_struct_id))).type_id),false,error_span,JaktInternal::OptionalNone(),types::CheckedVisibility::Public(),JaktInternal::OptionalNone(),JaktInternal::OptionalNone(),JaktInternal::OptionalNone());
 NonnullRefPtr<types::Module> module = ((*this).current_module());
 ids::VarId const error_id = ((module)->add_variable(error_decl));
 NonnullRefPtr<types::Scope> const parent_scope = ((*this).get_scope(scope_id));
-ids::ScopeId const catch_scope_id = ((*this).create_scope(scope_id,((parent_scope)->can_throw),(ByteString::must_from_utf8("catch"sv)),true));
+ids::ScopeId const catch_scope_id = ((*this).create_scope(scope_id,((parent_scope)->can_throw),(ByteString::from_utf8_without_validation("catch"sv)),true));
 ((*this).add_var_to_scope(catch_scope_id,error_name,error_id,error_span));
 types::CheckedBlock const checked_catch_block = TRY((((*this).typecheck_block(catch_block,catch_scope_id,safety_mode,JaktInternal::OptionalNone()))));
 if (((((checked_catch_block).yielded_type)).has_value())){
-((*this).error((ByteString::must_from_utf8("A ‘catch’ block as part of a try block is not allowed to yield values"sv)),(((catch_block).find_yield_span()).value())));
+((*this).error((ByteString::from_utf8_without_validation("A ‘catch’ block as part of a try block is not allowed to yield values"sv)),(((catch_block).find_yield_span()).value())));
 }
 return types::CheckedExpression::TryBlock(JaktInternal::OptionalNone(),checked_stmt,checked_catch_block,error_name,error_span,span,types::void_type_id());
 }
@@ -15752,21 +15752,21 @@ return types::CheckedExpression::TryBlock(JaktInternal::OptionalNone(),checked_s
 
 ErrorOr<NonnullRefPtr<typename types::CheckedExpression>> typechecker::Typechecker::typecheck_try(NonnullRefPtr<typename parser::ParsedExpression> const expr,JaktInternal::Optional<parser::ParsedBlock> const catch_block,JaktInternal::Optional<utility::Span> const catch_span,JaktInternal::Optional<ByteString> const catch_name,ids::ScopeId const scope_id,types::SafetyMode const safety_mode,utility::Span const span,JaktInternal::Optional<ids::TypeId> const type_hint) {
 {
-ids::ScopeId const try_scope_id = ((*this).create_scope(scope_id,true,(ByteString::must_from_utf8("try"sv)),true));
+ids::ScopeId const try_scope_id = ((*this).create_scope(scope_id,true,(ByteString::from_utf8_without_validation("try"sv)),true));
 NonnullRefPtr<typename types::CheckedExpression> const checked_expr = TRY((((*this).typecheck_expression(expr,try_scope_id,safety_mode,type_hint))));
-ids::StructId const error_struct_id = TRY((((*this).find_struct_in_prelude((ByteString::must_from_utf8("Error"sv))))));
+ids::StructId const error_struct_id = TRY((((*this).find_struct_in_prelude((ByteString::from_utf8_without_validation("Error"sv))))));
 NonnullRefPtr<types::Module> module = ((*this).current_module());
 JaktInternal::Optional<types::CheckedBlock> checked_catch_block = JaktInternal::OptionalNone();
 ids::TypeId const expression_type_id = ((checked_expr)->type());
-ids::StructId const optional_struct_id = TRY((((*this).find_struct_in_prelude((ByteString::must_from_utf8("Optional"sv))))));
+ids::StructId const optional_struct_id = TRY((((*this).find_struct_in_prelude((ByteString::from_utf8_without_validation("Optional"sv))))));
 NonnullRefPtr<typename types::Type> const optional_type = types::Type::GenericInstance(parser::CheckedQualifiers(false),optional_struct_id,DynamicArray<ids::TypeId>::create_with({expression_type_id}));
 ids::TypeId const optional_type_id = ((*this).find_or_add_type_id(optional_type));
 ids::TypeId type_id = optional_type_id;
 if (((catch_block).has_value())){
 NonnullRefPtr<types::Scope> const parent_scope = ((*this).get_scope(scope_id));
-ids::ScopeId const catch_scope_id = ((*this).create_scope(scope_id,((parent_scope)->can_throw),(ByteString::must_from_utf8("catch"sv)),true));
+ids::ScopeId const catch_scope_id = ((*this).create_scope(scope_id,((parent_scope)->can_throw),(ByteString::from_utf8_without_validation("catch"sv)),true));
 if (((catch_name).has_value())){
-ids::StructId const error_struct_id = TRY((((*this).find_struct_in_prelude((ByteString::must_from_utf8("Error"sv))))));
+ids::StructId const error_struct_id = TRY((((*this).find_struct_in_prelude((ByteString::from_utf8_without_validation("Error"sv))))));
 NonnullRefPtr<types::CheckedVariable> const error_decl = types::CheckedVariable::__jakt_create((catch_name.value()),((((*this).get_struct(error_struct_id))).type_id),false,span,JaktInternal::OptionalNone(),types::CheckedVisibility::Public(),JaktInternal::OptionalNone(),JaktInternal::OptionalNone(),JaktInternal::OptionalNone());
 NonnullRefPtr<types::Module> module = ((*this).current_module());
 ids::VarId const error_id = ((module)->add_variable(error_decl));
@@ -15784,7 +15784,7 @@ else {
 }
 else {
 if ((!(((expression_type_id).equals(types::builtin(types::BuiltinType::Void())))))){
-((*this).error((ByteString::must_from_utf8("In a try expression that returns a value, 'catch' block must either yield a value or transfer control flow"sv)),catch_span.value_or_lazy_evaluated([&] { return span; })));
+((*this).error((ByteString::from_utf8_without_validation("In a try expression that returns a value, 'catch' block must either yield a value or transfer control flow"sv)),catch_span.value_or_lazy_evaluated([&] { return span; })));
 }
 }
 
@@ -15797,13 +15797,13 @@ return types::CheckedExpression::Try(JaktInternal::OptionalNone(),checked_expr,c
 ErrorOr<NonnullRefPtr<typename types::CheckedStatement>> typechecker::Typechecker::typecheck_throw(NonnullRefPtr<typename parser::ParsedExpression> const expr,ids::ScopeId const scope_id,types::SafetyMode const safety_mode,utility::Span const span) {
 {
 NonnullRefPtr<typename types::CheckedExpression> const checked_expr = TRY((((*this).typecheck_expression_and_dereference_if_needed(expr,scope_id,safety_mode,JaktInternal::OptionalNone(),span))));
-ids::TypeId const error_type_id = TRY((((*this).find_type_in_prelude((ByteString::must_from_utf8("Error"sv))))));
+ids::TypeId const error_type_id = TRY((((*this).find_type_in_prelude((ByteString::from_utf8_without_validation("Error"sv))))));
 if ((!(((((checked_expr)->type())).equals(error_type_id))))){
-((*this).error((ByteString::must_from_utf8("throw expression does not produce an error"sv)),((expr)->span())));
+((*this).error((ByteString::from_utf8_without_validation("throw expression does not produce an error"sv)),((expr)->span())));
 }
 NonnullRefPtr<types::Scope> const scope = ((*this).get_scope(scope_id));
 if ((!(((scope)->can_throw)))){
-((*this).error((ByteString::must_from_utf8("Throw statement needs to be in a try statement or a function marked as throws"sv)),((expr)->span())));
+((*this).error((ByteString::from_utf8_without_validation("Throw statement needs to be in a try statement or a function marked as throws"sv)),((expr)->span())));
 }
 return types::CheckedStatement::Throw(checked_expr,span);
 }
@@ -15813,7 +15813,7 @@ ErrorOr<NonnullRefPtr<typename types::CheckedStatement>> typechecker::Typechecke
 {
 types::CheckedBlock const checked_block = TRY((((*this).typecheck_block(parsed_block,scope_id,safety_mode,JaktInternal::OptionalNone()))));
 if (((((checked_block).yielded_type)).has_value())){
-((*this).error((ByteString::must_from_utf8("A ‘loop’ block is not allowed to yield values"sv)),(((parsed_block).find_yield_span()).value())));
+((*this).error((ByteString::from_utf8_without_validation("A ‘loop’ block is not allowed to yield values"sv)),(((parsed_block).find_yield_span()).value())));
 }
 return types::CheckedStatement::Loop(checked_block,span);
 }
@@ -15830,7 +15830,7 @@ NonnullRefPtr<typename types::CheckedStatement> const checked_statement = TRY(((
 if (((checked_statement)->__jakt_init_index() == 5 /* Block */)){
 types::CheckedBlock const block = (checked_statement)->as.Block.block;
 if (((((block).yielded_type)).has_value())){
-((*this).error((ByteString::must_from_utf8("‘yield’ inside ‘defer’ is meaningless"sv)),span));
+((*this).error((ByteString::from_utf8_without_validation("‘yield’ inside ‘defer’ is meaningless"sv)),span));
 }
 }
 return types::CheckedStatement::Defer(checked_statement,span);
@@ -15841,7 +15841,7 @@ ErrorOr<NonnullRefPtr<typename types::CheckedStatement>> typechecker::Typechecke
 {
 types::CheckedBlock const checked_block = TRY((((*this).typecheck_block(parsed_block,scope_id,safety_mode,JaktInternal::OptionalNone()))));
 if (((((checked_block).yielded_type)).has_value())){
-((*this).error((ByteString::must_from_utf8("A block used as a statement cannot yield values, as the value cannot be observed in any way"sv)),(((parsed_block).find_yield_span()).value())));
+((*this).error((ByteString::from_utf8_without_validation("A block used as a statement cannot yield values, as the value cannot be observed in any way"sv)),(((parsed_block).find_yield_span()).value())));
 }
 return types::CheckedStatement::Block(checked_block,span);
 }
@@ -15850,7 +15850,7 @@ return types::CheckedStatement::Block(checked_block,span);
 ErrorOr<NonnullRefPtr<typename types::CheckedStatement>> typechecker::Typechecker::typecheck_inline_cpp(parser::ParsedBlock const block,utility::Span const span,types::SafetyMode const safety_mode) {
 {
 if (((safety_mode).__jakt_init_index() == 0 /* Safe */)){
-((*this).error((ByteString::must_from_utf8("Use of inline cpp block outside of unsafe block"sv)),span));
+((*this).error((ByteString::from_utf8_without_validation("Use of inline cpp block outside of unsafe block"sv)),span));
 }
 JaktInternal::DynamicArray<ByteString> strings = DynamicArray<ByteString>::create_with({});
 {
@@ -15870,12 +15870,12 @@ utility::Span const span = (expr)->as.QuotedString.span;
 ((strings).push(val));
 }
 else {
-((*this).error((ByteString::must_from_utf8("Expected block of strings"sv)),span));
+((*this).error((ByteString::from_utf8_without_validation("Expected block of strings"sv)),span));
 }
 
 }
 else {
-((*this).error((ByteString::must_from_utf8("Expected block of strings"sv)),span));
+((*this).error((ByteString::from_utf8_without_validation("Expected block of strings"sv)),span));
 }
 
 }
@@ -15890,7 +15890,7 @@ return types::CheckedStatement::InlineCpp(strings,span);
 ErrorOr<NonnullRefPtr<typename types::CheckedStatement>> typechecker::Typechecker::typecheck_return(JaktInternal::Optional<NonnullRefPtr<typename parser::ParsedExpression>> const expr,utility::Span const span,ids::ScopeId const scope_id,types::SafetyMode const safety_mode) {
 {
 if (((*this).inside_defer)){
-((*this).error((ByteString::must_from_utf8("‘return’ is not allowed inside ‘defer’"sv)),span));
+((*this).error((ByteString::from_utf8_without_validation("‘return’ is not allowed inside ‘defer’"sv)),span));
 }
 if ((!(((expr).has_value())))){
 if (((((*this).current_function_id)).has_value())){
@@ -15903,7 +15903,7 @@ if (((!(((return_type)->__jakt_init_index() == 0 /* Void */))) && (!(((return_ty
 return types::CheckedStatement::Return(JaktInternal::OptionalNone(),span);
 }
 if (((!((((((*this).current_function_id)).has_value()) && ((((*this).get_function((((*this).current_function_id).value()))))->is_comptime)))) && (((expr.value()))->__jakt_init_index() == 25 /* Function */))){
-((*this).error((ByteString::must_from_utf8("Returning a function is not currently supported"sv)),span));
+((*this).error((ByteString::from_utf8_without_validation("Returning a function is not currently supported"sv)),span));
 }
 JaktInternal::Optional<ids::TypeId> type_hint = JaktInternal::OptionalNone();
 if (((((*this).current_function_id)).has_value())){
@@ -15921,12 +15921,12 @@ utility::Span const span = (checked_expr)->as.OptionalNone.span;
 if (((((*this).get_type((type_hint.value()))))->__jakt_init_index() == 20 /* GenericInstance */)){
 ids::StructId const id = (((*this).get_type((type_hint.value()))))->as.GenericInstance.id;
 JaktInternal::DynamicArray<ids::TypeId> const args = (((*this).get_type((type_hint.value()))))->as.GenericInstance.args;
-if (((!(((id).equals(TRY((((*this).find_struct_in_prelude((ByteString::must_from_utf8("Optional"sv)))))))))) && (!(((id).equals(TRY((((*this).find_struct_in_prelude((ByteString::must_from_utf8("WeakPtr"sv)))))))))))){
-((*this).error((ByteString::must_from_utf8("Cannot assign None to a non-optional type"sv)),span));
+if (((!(((id).equals(TRY((((*this).find_struct_in_prelude((ByteString::from_utf8_without_validation("Optional"sv)))))))))) && (!(((id).equals(TRY((((*this).find_struct_in_prelude((ByteString::from_utf8_without_validation("WeakPtr"sv)))))))))))){
+((*this).error((ByteString::from_utf8_without_validation("Cannot assign None to a non-optional type"sv)),span));
 }
 }
 else {
-((*this).error((ByteString::must_from_utf8("Cannot assign None to a non-optional type"sv)),span));
+((*this).error((ByteString::from_utf8_without_validation("Cannot assign None to a non-optional type"sv)),span));
 }
 
 }
@@ -16023,7 +16023,7 @@ ErrorOr<NonnullRefPtr<typename types::CheckedExpression>> typechecker::Typecheck
 NonnullRefPtr<typename types::CheckedExpression> const checked_expr = TRY((((*this).typecheck_expression_and_dereference_if_needed(expr,scope_id,safety_mode,JaktInternal::OptionalNone(),span))));
 ids::TypeId const checked_expr_type_id = ((checked_expr)->type());
 NonnullRefPtr<typename types::Type> const checked_expr_type = ((*this).get_type(checked_expr_type_id));
-ids::StructId const optional_struct_id = TRY((((*this).find_struct_in_prelude((ByteString::must_from_utf8("Optional"sv))))));
+ids::StructId const optional_struct_id = TRY((((*this).find_struct_in_prelude((ByteString::from_utf8_without_validation("Optional"sv))))));
 ({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<void, ErrorOr<NonnullRefPtr<typename types::CheckedExpression>>>{
 auto&& __jakt_match_variant = *checked_expr_type;
@@ -16035,7 +16035,7 @@ JaktInternal::DynamicArray<ids::TypeId> const& args = __jakt_match_value.args;
 ids::TypeId type_id = checked_expr_type_id;
 if (is_optional){
 if ((!(((id).equals(optional_struct_id))))){
-((*this).error((ByteString::must_from_utf8("Optional chaining is only allowed on optional types"sv)),span));
+((*this).error((ByteString::from_utf8_without_validation("Optional chaining is only allowed on optional types"sv)),span));
 return types::CheckedExpression::IndexedStruct(JaktInternal::OptionalNone(),checked_expr,field_name,JaktInternal::OptionalNone(),span,is_optional,types::unknown_type_id());
 }
 (type_id = ((args)[static_cast<i64>(0LL)]));
@@ -16191,7 +16191,7 @@ case 24 /* Struct */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Struct;ids::StructId const& struct_id = __jakt_match_value.value;
 {
 if (is_optional){
-((*this).error((ByteString::must_from_utf8("Optional chaining is not allowed on non-optional types"sv)),span));
+((*this).error((ByteString::from_utf8_without_validation("Optional chaining is not allowed on non-optional types"sv)),span));
 }
 types::CheckedStruct const structure = ((*this).get_struct(struct_id));
 JaktInternal::Optional<types::FieldRecord> const field_record = ((*this).lookup_struct_field(struct_id,field_name));
@@ -16210,7 +16210,7 @@ auto&& __jakt_match_value = __jakt_match_variant.as.GenericEnumInstance;ids::Enu
 JaktInternal::DynamicArray<ids::TypeId> const& args = __jakt_match_value.args;
 {
 if (is_optional){
-((*this).error((ByteString::must_from_utf8("Optional chaining is not allowed on non-optional types"sv)),span));
+((*this).error((ByteString::from_utf8_without_validation("Optional chaining is not allowed on non-optional types"sv)),span));
 }
 JaktInternal::Dictionary<ids::TypeId,ids::TypeId> const checkpoint = ((((*this).generic_inferences)).perform_checkpoint(false));
 ScopeGuard __jakt_var_540([&] {
@@ -16250,7 +16250,7 @@ auto&& __jakt_match_value = __jakt_match_variant.as.Enum;ids::EnumId const& enum
 JaktInternal::DynamicArray<ids::TypeId> const args = DynamicArray<ids::TypeId>::create_with({});
 {
 if (is_optional){
-((*this).error((ByteString::must_from_utf8("Optional chaining is not allowed on non-optional types"sv)),span));
+((*this).error((ByteString::from_utf8_without_validation("Optional chaining is not allowed on non-optional types"sv)),span));
 }
 JaktInternal::Dictionary<ids::TypeId,ids::TypeId> const checkpoint = ((((*this).generic_inferences)).perform_checkpoint(false));
 ScopeGuard __jakt_var_541([&] {
@@ -16302,15 +16302,15 @@ return types::CheckedExpression::IndexedStruct(JaktInternal::OptionalNone(),chec
 ErrorOr<NonnullRefPtr<typename types::CheckedExpression>> typechecker::Typechecker::typecheck_indexed_tuple(NonnullRefPtr<typename parser::ParsedExpression> const expr,size_t const index,ids::ScopeId const scope_id,bool const is_optional,types::SafetyMode const safety_mode,utility::Span const span) {
 {
 NonnullRefPtr<typename types::CheckedExpression> const checked_expr = TRY((((*this).typecheck_expression_and_dereference_if_needed(expr,scope_id,safety_mode,JaktInternal::OptionalNone(),span))));
-ids::StructId const tuple_struct_id = TRY((((*this).find_struct_in_prelude((ByteString::must_from_utf8("Tuple"sv))))));
-ids::StructId const optional_struct_id = TRY((((*this).find_struct_in_prelude((ByteString::must_from_utf8("Optional"sv))))));
+ids::StructId const tuple_struct_id = TRY((((*this).find_struct_in_prelude((ByteString::from_utf8_without_validation("Tuple"sv))))));
+ids::StructId const optional_struct_id = TRY((((*this).find_struct_in_prelude((ByteString::from_utf8_without_validation("Optional"sv))))));
 ids::TypeId expr_type_id = types::unknown_type_id();
 if (((((*this).get_type(((checked_expr)->type()))))->__jakt_init_index() == 20 /* GenericInstance */)){
 ids::StructId const id = (((*this).get_type(((checked_expr)->type()))))->as.GenericInstance.id;
 JaktInternal::DynamicArray<ids::TypeId> const args = (((*this).get_type(((checked_expr)->type()))))->as.GenericInstance.args;
 if (((id).equals(tuple_struct_id))){
 if (is_optional){
-((*this).error((ByteString::must_from_utf8("Optional chaining is not allowed on a non-optional tuple type"sv)),span));
+((*this).error((ByteString::from_utf8_without_validation("Optional chaining is not allowed on a non-optional tuple type"sv)),span));
 }
 if ([](size_t const& self, size_t rhs) -> bool {
 {
@@ -16323,7 +16323,7 @@ return (infallible_enum_cast<jakt__prelude__operators::Ordering>((JaktInternal::
 }
 }
 (index,((args).size()))){
-((*this).error((ByteString::must_from_utf8("Tuple index past the end of the tuple"sv)),span));
+((*this).error((ByteString::from_utf8_without_validation("Tuple index past the end of the tuple"sv)),span));
 }
 else {
 (expr_type_id = ((args)[index]));
@@ -16347,7 +16347,7 @@ return (infallible_enum_cast<jakt__prelude__operators::Ordering>((JaktInternal::
 }
 }
 (index,((args).size()))){
-((*this).error((ByteString::must_from_utf8("Optional-chained tuple index past the end of the tuple"sv)),span));
+((*this).error((ByteString::from_utf8_without_validation("Optional-chained tuple index past the end of the tuple"sv)),span));
 }
 else {
 (expr_type_id = ((*this).find_or_add_type_id(types::Type::GenericInstance(parser::CheckedQualifiers(false),optional_struct_id,DynamicArray<ids::TypeId>::create_with({((args)[index])})))));
@@ -16356,16 +16356,16 @@ else {
 }
 }
 else {
-((*this).error((ByteString::must_from_utf8("Optional-chained tuple index used on non-tuple value"sv)),span));
+((*this).error((ByteString::from_utf8_without_validation("Optional-chained tuple index used on non-tuple value"sv)),span));
 }
 
 }
 }
 else if (is_optional){
-((*this).error((ByteString::must_from_utf8("Optional-chained tuple index used on non-tuple value"sv)),span));
+((*this).error((ByteString::from_utf8_without_validation("Optional-chained tuple index used on non-tuple value"sv)),span));
 }
 else {
-((*this).error((ByteString::must_from_utf8("Tuple index used on non-tuple value"sv)),span));
+((*this).error((ByteString::from_utf8_without_validation("Tuple index used on non-tuple value"sv)),span));
 }
 
 return types::CheckedExpression::IndexedTuple(JaktInternal::OptionalNone(),checked_expr,index,span,is_optional,expr_type_id);
@@ -16507,7 +16507,7 @@ return JaktInternal::ExplicitValue<void>();
 case 2 /* Restricted */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Restricted;JaktInternal::DynamicArray<NonnullRefPtr<typename types::MaybeResolvedScope>> const& scopes = __jakt_match_value.scopes;
 {
-TRY((((*this).check_restricted_access(accessor,(ByteString::must_from_utf8("field"sv)),accessee,((member)->name),scopes,span))));
+TRY((((*this).check_restricted_access(accessor,(ByteString::from_utf8_without_validation("field"sv)),accessee,((member)->name),scopes,span))));
 }
 return JaktInternal::ExplicitValue<void>();
 };/*case end*/
@@ -16537,7 +16537,7 @@ case 1 /* Private */: {
 {
 if ((!(((*this).scope_can_access(accessor,accessee))))){
 if ((!(((((method)->type)).__jakt_init_index() == 0 /* Normal */)))){
-((*this).error_with_hint(__jakt_format((StringView::from_string_literal("Can't access constructor ‘{}’, because it is marked private"sv)),((method)->name)),span,(ByteString::must_from_utf8("Private constructors are created if any fields are private"sv)),span));
+((*this).error_with_hint(__jakt_format((StringView::from_string_literal("Can't access constructor ‘{}’, because it is marked private"sv)),((method)->name)),span,(ByteString::from_utf8_without_validation("Private constructors are created if any fields are private"sv)),span));
 }
 else {
 ((*this).error(__jakt_format((StringView::from_string_literal("Can't access method ‘{}’, because it is marked private"sv)),((method)->name)),span));
@@ -16550,7 +16550,7 @@ return JaktInternal::ExplicitValue<void>();
 case 2 /* Restricted */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Restricted;JaktInternal::DynamicArray<NonnullRefPtr<typename types::MaybeResolvedScope>> const& scopes = __jakt_match_value.scopes;
 {
-TRY((((*this).check_restricted_access(accessor,(ByteString::must_from_utf8("function"sv)),accessee,((method)->name),scopes,span))));
+TRY((((*this).check_restricted_access(accessor,(ByteString::from_utf8_without_validation("function"sv)),accessee,((method)->name),scopes,span))));
 }
 return JaktInternal::ExplicitValue<void>();
 };/*case end*/
@@ -16673,7 +16673,7 @@ return (infallible_enum_cast<jakt__prelude__operators::Ordering>((JaktInternal::
 }
 }
 (val,(infallible_integer_cast<i64>((((type_)->max()))))))){
-((*this).error_with_hint((ByteString::must_from_utf8("Integer promotion failed"sv)),span,__jakt_format((StringView::from_string_literal("Cannot fit value into range [{}, {}] of type {}."sv)),((type_)->min()),((type_)->max()),TRY((((*this).type_name(builtin_typeid,false))))),span));
+((*this).error_with_hint((ByteString::from_utf8_without_validation("Integer promotion failed"sv)),span,__jakt_format((StringView::from_string_literal("Cannot fit value into range [{}, {}] of type {}."sv)),((type_)->min()),((type_)->max()),TRY((((*this).type_name(builtin_typeid,false))))),span));
 }
 else {
 (expr = types::CheckedExpression::NumericConstant(JaktInternal::OptionalNone(),types::CheckedNumericConstant::I8((infallible_integer_cast<i8>((val)))),span,types::builtin(types::BuiltinType::I8())));
@@ -16704,7 +16704,7 @@ return (infallible_enum_cast<jakt__prelude__operators::Ordering>((JaktInternal::
 }
 }
 (val,(infallible_integer_cast<i64>((((type_)->max()))))))){
-((*this).error_with_hint((ByteString::must_from_utf8("Integer promotion failed"sv)),span,__jakt_format((StringView::from_string_literal("Cannot fit value into range [{}, {}] of type {}."sv)),((type_)->min()),((type_)->max()),TRY((((*this).type_name(builtin_typeid,false))))),span));
+((*this).error_with_hint((ByteString::from_utf8_without_validation("Integer promotion failed"sv)),span,__jakt_format((StringView::from_string_literal("Cannot fit value into range [{}, {}] of type {}."sv)),((type_)->min()),((type_)->max()),TRY((((*this).type_name(builtin_typeid,false))))),span));
 }
 else {
 (expr = types::CheckedExpression::NumericConstant(JaktInternal::OptionalNone(),types::CheckedNumericConstant::I16((infallible_integer_cast<i16>((val)))),span,types::builtin(types::BuiltinType::I16())));
@@ -16735,7 +16735,7 @@ return (infallible_enum_cast<jakt__prelude__operators::Ordering>((JaktInternal::
 }
 }
 (val,(infallible_integer_cast<i64>((((type_)->max()))))))){
-((*this).error_with_hint((ByteString::must_from_utf8("Integer promotion failed"sv)),span,__jakt_format((StringView::from_string_literal("Cannot fit value into range [{}, {}] of type {}."sv)),((type_)->min()),((type_)->max()),TRY((((*this).type_name(builtin_typeid,false))))),span));
+((*this).error_with_hint((ByteString::from_utf8_without_validation("Integer promotion failed"sv)),span,__jakt_format((StringView::from_string_literal("Cannot fit value into range [{}, {}] of type {}."sv)),((type_)->min()),((type_)->max()),TRY((((*this).type_name(builtin_typeid,false))))),span));
 }
 else {
 (expr = types::CheckedExpression::NumericConstant(JaktInternal::OptionalNone(),types::CheckedNumericConstant::I32((infallible_integer_cast<i32>((val)))),span,types::builtin(types::BuiltinType::I32())));
@@ -16766,7 +16766,7 @@ return (infallible_enum_cast<jakt__prelude__operators::Ordering>((JaktInternal::
 }
 }
 (val,(infallible_integer_cast<i64>((((type_)->max()))))))){
-((*this).error_with_hint((ByteString::must_from_utf8("Integer promotion failed"sv)),span,__jakt_format((StringView::from_string_literal("Cannot fit value into range [{}, {}] of type {}."sv)),((type_)->min()),((type_)->max()),TRY((((*this).type_name(builtin_typeid,false))))),span));
+((*this).error_with_hint((ByteString::from_utf8_without_validation("Integer promotion failed"sv)),span,__jakt_format((StringView::from_string_literal("Cannot fit value into range [{}, {}] of type {}."sv)),((type_)->min()),((type_)->max()),TRY((((*this).type_name(builtin_typeid,false))))),span));
 }
 else {
 (expr = types::CheckedExpression::NumericConstant(JaktInternal::OptionalNone(),types::CheckedNumericConstant::U8((infallible_integer_cast<u8>((val)))),span,types::builtin(types::BuiltinType::U8())));
@@ -16797,7 +16797,7 @@ return (infallible_enum_cast<jakt__prelude__operators::Ordering>((JaktInternal::
 }
 }
 (val,(infallible_integer_cast<i64>((((type_)->max()))))))){
-((*this).error_with_hint((ByteString::must_from_utf8("Integer promotion failed"sv)),span,__jakt_format((StringView::from_string_literal("Cannot fit value into range [{}, {}] of type {}."sv)),((type_)->min()),((type_)->max()),TRY((((*this).type_name(builtin_typeid,false))))),span));
+((*this).error_with_hint((ByteString::from_utf8_without_validation("Integer promotion failed"sv)),span,__jakt_format((StringView::from_string_literal("Cannot fit value into range [{}, {}] of type {}."sv)),((type_)->min()),((type_)->max()),TRY((((*this).type_name(builtin_typeid,false))))),span));
 }
 else {
 (expr = types::CheckedExpression::NumericConstant(JaktInternal::OptionalNone(),types::CheckedNumericConstant::U16((infallible_integer_cast<u16>((val)))),span,types::builtin(types::BuiltinType::U16())));
@@ -16828,7 +16828,7 @@ return (infallible_enum_cast<jakt__prelude__operators::Ordering>((JaktInternal::
 }
 }
 (val,(infallible_integer_cast<i64>((((type_)->max()))))))){
-((*this).error_with_hint((ByteString::must_from_utf8("Integer promotion failed"sv)),span,__jakt_format((StringView::from_string_literal("Cannot fit value into range [{}, {}] of type {}."sv)),((type_)->min()),((type_)->max()),TRY((((*this).type_name(builtin_typeid,false))))),span));
+((*this).error_with_hint((ByteString::from_utf8_without_validation("Integer promotion failed"sv)),span,__jakt_format((StringView::from_string_literal("Cannot fit value into range [{}, {}] of type {}."sv)),((type_)->min()),((type_)->max()),TRY((((*this).type_name(builtin_typeid,false))))),span));
 }
 else {
 (expr = types::CheckedExpression::NumericConstant(JaktInternal::OptionalNone(),types::CheckedNumericConstant::U32((infallible_integer_cast<u32>((val)))),span,types::builtin(types::BuiltinType::U32())));
@@ -16849,7 +16849,7 @@ return (infallible_enum_cast<jakt__prelude__operators::Ordering>((JaktInternal::
 }
 }
 (val,static_cast<i64>(0LL))){
-((*this).error_with_hint((ByteString::must_from_utf8("Integer promotion failed"sv)),span,__jakt_format((StringView::from_string_literal("Cannot fit value into range [{}, {}] of type {}."sv)),((type_)->min()),((type_)->max()),TRY((((*this).type_name(builtin_typeid,false))))),span));
+((*this).error_with_hint((ByteString::from_utf8_without_validation("Integer promotion failed"sv)),span,__jakt_format((StringView::from_string_literal("Cannot fit value into range [{}, {}] of type {}."sv)),((type_)->min()),((type_)->max()),TRY((((*this).type_name(builtin_typeid,false))))),span));
 }
 else {
 (expr = types::CheckedExpression::NumericConstant(JaktInternal::OptionalNone(),types::CheckedNumericConstant::U64((infallible_integer_cast<u64>((val)))),span,types::builtin(types::BuiltinType::U64())));
@@ -16870,7 +16870,7 @@ return (infallible_enum_cast<jakt__prelude__operators::Ordering>((JaktInternal::
 }
 }
 (val,static_cast<i64>(0LL))){
-((*this).error_with_hint((ByteString::must_from_utf8("Integer promotion failed"sv)),span,__jakt_format((StringView::from_string_literal("Cannot fit value into range [{}, {}] of type {}."sv)),((type_)->min()),((type_)->max()),TRY((((*this).type_name(builtin_typeid,false))))),span));
+((*this).error_with_hint((ByteString::from_utf8_without_validation("Integer promotion failed"sv)),span,__jakt_format((StringView::from_string_literal("Cannot fit value into range [{}, {}] of type {}."sv)),((type_)->min()),((type_)->max()),TRY((((*this).type_name(builtin_typeid,false))))),span));
 }
 else {
 (expr = types::CheckedExpression::NumericConstant(JaktInternal::OptionalNone(),types::CheckedNumericConstant::USize((infallible_integer_cast<u64>((val)))),span,types::builtin(types::BuiltinType::Usize())));
@@ -16891,7 +16891,7 @@ return (infallible_enum_cast<jakt__prelude__operators::Ordering>((JaktInternal::
 }
 }
 (val,static_cast<i64>(0LL))){
-((*this).error_with_hint((ByteString::must_from_utf8("Integer promotion failed"sv)),span,__jakt_format((StringView::from_string_literal("Cannot fit value into range [{}, {}] of type {}."sv)),((type_)->min()),((type_)->max()),TRY((((*this).type_name(builtin_typeid,false))))),span));
+((*this).error_with_hint((ByteString::from_utf8_without_validation("Integer promotion failed"sv)),span,__jakt_format((StringView::from_string_literal("Cannot fit value into range [{}, {}] of type {}."sv)),((type_)->min()),((type_)->max()),TRY((((*this).type_name(builtin_typeid,false))))),span));
 }
 else {
 (expr = types::CheckedExpression::NumericConstant(JaktInternal::OptionalNone(),types::CheckedNumericConstant::I32((infallible_integer_cast<i32>((val)))),span,types::builtin(types::BuiltinType::CInt())));
@@ -16922,7 +16922,7 @@ return (infallible_enum_cast<jakt__prelude__operators::Ordering>((JaktInternal::
 }
 }
 (val,static_cast<i64>(255LL)))){
-((*this).error_with_hint((ByteString::must_from_utf8("Integer promotion failed"sv)),span,__jakt_format((StringView::from_string_literal("Cannot fit value into range [{}, {}] of type {}."sv)),((type_)->min()),((type_)->max()),TRY((((*this).type_name(builtin_typeid,false))))),span));
+((*this).error_with_hint((ByteString::from_utf8_without_validation("Integer promotion failed"sv)),span,__jakt_format((StringView::from_string_literal("Cannot fit value into range [{}, {}] of type {}."sv)),((type_)->min()),((type_)->max()),TRY((((*this).type_name(builtin_typeid,false))))),span));
 }
 else {
 (expr = types::CheckedExpression::NumericConstant(JaktInternal::OptionalNone(),types::CheckedNumericConstant::U8((infallible_integer_cast<u8>((val)))),span,types::builtin(types::BuiltinType::CChar())));
@@ -16953,7 +16953,7 @@ return (infallible_enum_cast<jakt__prelude__operators::Ordering>((JaktInternal::
 }
 }
 (((type_)->max()),val)){
-((*this).error_with_hint((ByteString::must_from_utf8("Integer promotion failed"sv)),span,__jakt_format((StringView::from_string_literal("Cannot fit value into range [{}, {}] of type {}."sv)),((type_)->min()),((type_)->max()),TRY((((*this).type_name(builtin_typeid,false))))),span));
+((*this).error_with_hint((ByteString::from_utf8_without_validation("Integer promotion failed"sv)),span,__jakt_format((StringView::from_string_literal("Cannot fit value into range [{}, {}] of type {}."sv)),((type_)->min()),((type_)->max()),TRY((((*this).type_name(builtin_typeid,false))))),span));
 }
 else {
 (expr = types::CheckedExpression::NumericConstant(JaktInternal::OptionalNone(),types::CheckedNumericConstant::I8((infallible_integer_cast<i8>((val)))),span,types::builtin(types::BuiltinType::I8())));
@@ -16974,7 +16974,7 @@ return (infallible_enum_cast<jakt__prelude__operators::Ordering>((JaktInternal::
 }
 }
 (((type_)->max()),val)){
-((*this).error_with_hint((ByteString::must_from_utf8("Integer promotion failed"sv)),span,__jakt_format((StringView::from_string_literal("Cannot fit value into range [{}, {}] of type {}."sv)),((type_)->min()),((type_)->max()),TRY((((*this).type_name(builtin_typeid,false))))),span));
+((*this).error_with_hint((ByteString::from_utf8_without_validation("Integer promotion failed"sv)),span,__jakt_format((StringView::from_string_literal("Cannot fit value into range [{}, {}] of type {}."sv)),((type_)->min()),((type_)->max()),TRY((((*this).type_name(builtin_typeid,false))))),span));
 }
 else {
 (expr = types::CheckedExpression::NumericConstant(JaktInternal::OptionalNone(),types::CheckedNumericConstant::I16((infallible_integer_cast<i16>((val)))),span,types::builtin(types::BuiltinType::I16())));
@@ -16995,7 +16995,7 @@ return (infallible_enum_cast<jakt__prelude__operators::Ordering>((JaktInternal::
 }
 }
 (((type_)->max()),val)){
-((*this).error_with_hint((ByteString::must_from_utf8("Integer promotion failed"sv)),span,__jakt_format((StringView::from_string_literal("Cannot fit value into range [{}, {}] of type {}."sv)),((type_)->min()),((type_)->max()),TRY((((*this).type_name(builtin_typeid,false))))),span));
+((*this).error_with_hint((ByteString::from_utf8_without_validation("Integer promotion failed"sv)),span,__jakt_format((StringView::from_string_literal("Cannot fit value into range [{}, {}] of type {}."sv)),((type_)->min()),((type_)->max()),TRY((((*this).type_name(builtin_typeid,false))))),span));
 }
 else {
 (expr = types::CheckedExpression::NumericConstant(JaktInternal::OptionalNone(),types::CheckedNumericConstant::I32((infallible_integer_cast<i32>((val)))),span,types::builtin(types::BuiltinType::I32())));
@@ -17016,7 +17016,7 @@ return (infallible_enum_cast<jakt__prelude__operators::Ordering>((JaktInternal::
 }
 }
 (((type_)->max()),val)){
-((*this).error_with_hint((ByteString::must_from_utf8("Integer promotion failed"sv)),span,__jakt_format((StringView::from_string_literal("Cannot fit value into range [{}, {}] of type {}."sv)),((type_)->min()),((type_)->max()),TRY((((*this).type_name(builtin_typeid,false))))),span));
+((*this).error_with_hint((ByteString::from_utf8_without_validation("Integer promotion failed"sv)),span,__jakt_format((StringView::from_string_literal("Cannot fit value into range [{}, {}] of type {}."sv)),((type_)->min()),((type_)->max()),TRY((((*this).type_name(builtin_typeid,false))))),span));
 }
 else {
 (expr = types::CheckedExpression::NumericConstant(JaktInternal::OptionalNone(),types::CheckedNumericConstant::U8((infallible_integer_cast<u8>((val)))),span,types::builtin(types::BuiltinType::U8())));
@@ -17037,7 +17037,7 @@ return (infallible_enum_cast<jakt__prelude__operators::Ordering>((JaktInternal::
 }
 }
 (((type_)->max()),val)){
-((*this).error_with_hint((ByteString::must_from_utf8("Integer promotion failed"sv)),span,__jakt_format((StringView::from_string_literal("Cannot fit value into range [{}, {}] of type {}."sv)),((type_)->min()),((type_)->max()),TRY((((*this).type_name(builtin_typeid,false))))),span));
+((*this).error_with_hint((ByteString::from_utf8_without_validation("Integer promotion failed"sv)),span,__jakt_format((StringView::from_string_literal("Cannot fit value into range [{}, {}] of type {}."sv)),((type_)->min()),((type_)->max()),TRY((((*this).type_name(builtin_typeid,false))))),span));
 }
 else {
 (expr = types::CheckedExpression::NumericConstant(JaktInternal::OptionalNone(),types::CheckedNumericConstant::U16((infallible_integer_cast<u16>((val)))),span,types::builtin(types::BuiltinType::U16())));
@@ -17058,7 +17058,7 @@ return (infallible_enum_cast<jakt__prelude__operators::Ordering>((JaktInternal::
 }
 }
 (((type_)->max()),val)){
-((*this).error_with_hint((ByteString::must_from_utf8("Integer promotion failed"sv)),span,__jakt_format((StringView::from_string_literal("Cannot fit value into range [{}, {}] of type {}."sv)),((type_)->min()),((type_)->max()),TRY((((*this).type_name(builtin_typeid,false))))),span));
+((*this).error_with_hint((ByteString::from_utf8_without_validation("Integer promotion failed"sv)),span,__jakt_format((StringView::from_string_literal("Cannot fit value into range [{}, {}] of type {}."sv)),((type_)->min()),((type_)->max()),TRY((((*this).type_name(builtin_typeid,false))))),span));
 }
 else {
 (expr = types::CheckedExpression::NumericConstant(JaktInternal::OptionalNone(),types::CheckedNumericConstant::U32((infallible_integer_cast<u32>((val)))),span,types::builtin(types::BuiltinType::U32())));
@@ -17088,7 +17088,7 @@ return (infallible_enum_cast<jakt__prelude__operators::Ordering>((JaktInternal::
 }
 }
 (val,static_cast<u64>(255ULL))){
-((*this).error_with_hint((ByteString::must_from_utf8("Integer promotion failed"sv)),span,__jakt_format((StringView::from_string_literal("Cannot fit value into range [{}, {}] of type {}."sv)),((type_)->min()),((type_)->max()),TRY((((*this).type_name(builtin_typeid,false))))),span));
+((*this).error_with_hint((ByteString::from_utf8_without_validation("Integer promotion failed"sv)),span,__jakt_format((StringView::from_string_literal("Cannot fit value into range [{}, {}] of type {}."sv)),((type_)->min()),((type_)->max()),TRY((((*this).type_name(builtin_typeid,false))))),span));
 }
 else {
 (expr = types::CheckedExpression::NumericConstant(JaktInternal::OptionalNone(),types::CheckedNumericConstant::U8((infallible_integer_cast<u8>((val)))),span,types::builtin(types::BuiltinType::CChar())));
@@ -17110,7 +17110,7 @@ case 20 /* GenericInstance */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.GenericInstance;ids::StructId const& id = __jakt_match_value.id;
 JaktInternal::DynamicArray<ids::TypeId> const& args = __jakt_match_value.args;
 return JaktInternal::ExplicitValue(({ Optional<ids::TypeId> __jakt_var_545; {
-if (((id).equals(TRY((((*this).find_struct_in_prelude((ByteString::must_from_utf8("Optional"sv))))))))){
+if (((id).equals(TRY((((*this).find_struct_in_prelude((ByteString::from_utf8_without_validation("Optional"sv))))))))){
 return ((args)[static_cast<i64>(0LL)]);
 }
 __jakt_var_545 = type_id; goto __jakt_label_471;
@@ -17165,7 +17165,7 @@ if (__jakt_enum_value == true) {
 return JaktInternal::ExplicitValue(types::StructLikeId::Struct(JaktInternal::OptionalNone(),((((*this).program))->builtin_implementation_struct(((type)->as_builtin_type()),((((*this).program))->prelude_module_id())))));
 }
 else if (__jakt_enum_value == false) {
-return JaktInternal::ExplicitValue(static_cast<JaktInternal::Optional<types::StructLikeId>>(types::StructLikeId::Struct(JaktInternal::OptionalNone(),TRY((((*this).find_struct_in_prelude((ByteString::must_from_utf8("String"sv)))))))));
+return JaktInternal::ExplicitValue(static_cast<JaktInternal::Optional<types::StructLikeId>>(types::StructLikeId::Struct(JaktInternal::OptionalNone(),TRY((((*this).find_struct_in_prelude((ByteString::from_utf8_without_validation("String"sv)))))))));
 }
 VERIFY_NOT_REACHED();
 }());
@@ -17183,7 +17183,7 @@ __jakt_var_546 = ({
 auto __jakt_enum_value = (for_optional_chain);
 if (__jakt_enum_value == true) {
 return JaktInternal::ExplicitValue(({ Optional<JaktInternal::Optional<types::StructLikeId>> __jakt_var_547; {
-ids::StructId const optional_struct_id = TRY((((*this).find_struct_in_prelude((ByteString::must_from_utf8("Optional"sv))))));
+ids::StructId const optional_struct_id = TRY((((*this).find_struct_in_prelude((ByteString::from_utf8_without_validation("Optional"sv))))));
 JaktInternal::Optional<types::StructLikeId> struct_id = JaktInternal::OptionalNone();
 if ((!(((id).equals(optional_struct_id))))){
 ((*this).error(__jakt_format((StringView::from_string_literal("Can't use ‘{}’ as an optional type in optional chained call"sv)),((((*this).get_struct(id))).name)),span));
@@ -17212,7 +17212,7 @@ return JaktInternal::ExplicitValue(types::StructLikeId::Enum(JaktInternal::Optio
 };/*case end*/
 default: {
 return JaktInternal::ExplicitValue(({ Optional<types::StructLikeId> __jakt_var_548; {
-((*this).error((ByteString::must_from_utf8("Can't use non-struct type as an optional type in optional chained call"sv)),span));
+((*this).error((ByteString::from_utf8_without_validation("Can't use non-struct type as an optional type in optional chained call"sv)),span));
 (found_optional = false);
 __jakt_var_548 = types::StructLikeId::Struct(JaktInternal::OptionalNone(),optional_struct_id); goto __jakt_label_474;
 
@@ -17369,7 +17369,7 @@ JaktInternal::Optional<ids::TypeId> type_hint_unwrapped = type_hint;
 if ((((type_hint).has_value()) && ((((*this).get_type((type_hint.value()))))->__jakt_init_index() == 20 /* GenericInstance */))){
 ids::StructId const id = (((*this).get_type((type_hint.value()))))->as.GenericInstance.id;
 JaktInternal::DynamicArray<ids::TypeId> const args = (((*this).get_type((type_hint.value()))))->as.GenericInstance.args;
-ids::StructId const optional_struct_id = TRY((((*this).find_struct_in_prelude((ByteString::must_from_utf8("Optional"sv))))));
+ids::StructId const optional_struct_id = TRY((((*this).find_struct_in_prelude((ByteString::from_utf8_without_validation("Optional"sv))))));
 if (((id).equals(optional_struct_id))){
 (type_hint_unwrapped = ((args)[static_cast<i64>(0LL)]));
 }
@@ -17447,14 +17447,14 @@ JaktInternal::Optional<ByteString> const& prefix = __jakt_match_value.prefix;
 utility::Span const& span = __jakt_match_value.span;
 return JaktInternal::ExplicitValue(({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<NonnullRefPtr<typename types::CheckedExpression>,ErrorOr<NonnullRefPtr<typename types::CheckedExpression>>>{
-auto __jakt_enum_value = (TRY((prefix.try_value_or_lazy_evaluated([&]() -> ErrorOr<ByteString> { return (ByteString::must_from_utf8(""sv)); }))));
-if (__jakt_enum_value == (ByteString::must_from_utf8(""sv))) {
+auto __jakt_enum_value = (TRY((prefix.try_value_or_lazy_evaluated([&]() -> ErrorOr<ByteString> { return (ByteString::from_utf8_without_validation(""sv)); }))));
+if (__jakt_enum_value == (ByteString::from_utf8_without_validation(""sv))) {
 return JaktInternal::ExplicitValue(types::CheckedExpression::CharacterConstant(JaktInternal::OptionalNone(),val,span));
 }
-else if (__jakt_enum_value == (ByteString::must_from_utf8("b"sv))) {
+else if (__jakt_enum_value == (ByteString::from_utf8_without_validation("b"sv))) {
 return JaktInternal::ExplicitValue(types::CheckedExpression::ByteConstant(JaktInternal::OptionalNone(),val,span));
 }
-else if (__jakt_enum_value == (ByteString::must_from_utf8("c"sv))) {
+else if (__jakt_enum_value == (ByteString::from_utf8_without_validation("c"sv))) {
 return JaktInternal::ExplicitValue(types::CheckedExpression::CCharacterConstant(JaktInternal::OptionalNone(),val,span));
 }
 else {
@@ -17478,28 +17478,28 @@ auto __jakt_enum_value = ((((type_hint).has_value()) && (!((((type_hint.value())
 if (__jakt_enum_value == true) {
 return JaktInternal::ExplicitValue(({ Optional<NonnullRefPtr<typename types::CheckedExpression>> __jakt_var_553; {
 ids::TypeId type_id = TRY((((*this).strip_optional_from_type(((((*this).generic_inferences)).map((type_hint.value())))))));
-ids::TypeId const prelude_string_type_id = TRY((((*this).prelude_struct_type_named((ByteString::must_from_utf8("String"sv))))));
-ids::TypeId const prelude_string_view_type_id = TRY((((*this).prelude_struct_type_named((ByteString::must_from_utf8("StringView"sv))))));
+ids::TypeId const prelude_string_type_id = TRY((((*this).prelude_struct_type_named((ByteString::from_utf8_without_validation("String"sv))))));
+ids::TypeId const prelude_string_view_type_id = TRY((((*this).prelude_struct_type_named((ByteString::from_utf8_without_validation("StringView"sv))))));
 bool may_throw = false;
 if (((!(((type_id).equals(prelude_string_type_id)))) && (!(((type_id).equals(prelude_string_view_type_id)))))){
 if (((((*this).get_type(type_id)))->is_concrete())){
-JaktInternal::Optional<typechecker::TraitImplementationDescriptor> const trait_implementation = TRY((((*this).find_any_singular_trait_implementation(type_id,DynamicArray<ByteString>::create_with({(ByteString::must_from_utf8("FromStringLiteral"sv)), (ByteString::must_from_utf8("ThrowingFromStringLiteral"sv))}),scope_id,span,JaktInternal::OptionalNone()))));
+JaktInternal::Optional<typechecker::TraitImplementationDescriptor> const trait_implementation = TRY((((*this).find_any_singular_trait_implementation(type_id,DynamicArray<ByteString>::create_with({(ByteString::from_utf8_without_validation("FromStringLiteral"sv)), (ByteString::from_utf8_without_validation("ThrowingFromStringLiteral"sv))}),scope_id,span,JaktInternal::OptionalNone()))));
 if ((!(((trait_implementation).has_value())))){
 ((*this).error_with_hint(__jakt_format((StringView::from_string_literal("Type {} cannot be used as an overloaded string literal type"sv)),TRY((((*this).type_name(type_id,true))))),span,__jakt_format((StringView::from_string_literal("Consider implementing the FromStringLiteral trait for {}"sv)),TRY((((*this).type_name(type_id,false))))),span));
 (type_id = prelude_string_type_id);
 }
 else {
-(may_throw = (((((trait_implementation.value())).trait_name)) == ((ByteString::must_from_utf8("ThrowingFromStringLiteral"sv)))));
+(may_throw = (((((trait_implementation.value())).trait_name)) == ((ByteString::from_utf8_without_validation("ThrowingFromStringLiteral"sv)))));
 }
 
 }
 else if ((!(((((*this).get_type(type_id)))->is_concrete())))){
-(type_id = TRY((((*this).prelude_struct_type_named((ByteString::must_from_utf8("String"sv)))))));
+(type_id = TRY((((*this).prelude_struct_type_named((ByteString::from_utf8_without_validation("String"sv)))))));
 }
 }
 TRY((((*this).unify((type_hint.value()),span,type_id,span))));
 if ((may_throw && (!(((((*this).get_scope(scope_id)))->can_throw))))){
-((*this).error((ByteString::must_from_utf8("Operation that may throw needs to be in a try statement or a function marked as throws"sv)),span));
+((*this).error((ByteString::from_utf8_without_validation("Operation that may throw needs to be in a try statement or a function marked as throws"sv)),span));
 }
 __jakt_var_553 = types::CheckedExpression::QuotedString(JaktInternal::OptionalNone(),types::CheckedStringLiteral(types::StringLiteral::Static(val),type_id,may_throw),span); goto __jakt_label_479;
 
@@ -17508,7 +17508,7 @@ __jakt_label_479:; __jakt_var_553.release_value(); }));
 }
 else {
 return JaktInternal::ExplicitValue(({ Optional<NonnullRefPtr<typename types::CheckedExpression>> __jakt_var_554; {
-__jakt_var_554 = types::CheckedExpression::QuotedString(JaktInternal::OptionalNone(),types::CheckedStringLiteral(types::StringLiteral::Static(val),TRY((((*this).prelude_struct_type_named((ByteString::must_from_utf8("String"sv)))))),false),span); goto __jakt_label_480;
+__jakt_var_554 = types::CheckedExpression::QuotedString(JaktInternal::OptionalNone(),types::CheckedStringLiteral(types::StringLiteral::Static(val),TRY((((*this).prelude_struct_type_named((ByteString::from_utf8_without_validation("String"sv)))))),false),span); goto __jakt_label_480;
 
 }
 __jakt_label_480:; __jakt_var_554.release_value(); }));
@@ -17559,7 +17559,7 @@ auto&& __jakt_match_value = __jakt_match_variant.as.Call;types::CheckedCall cons
 return JaktInternal::ExplicitValue(({ Optional<NonnullRefPtr<typename types::CheckedExpression>> __jakt_var_557; {
 ids::TypeId result_type = ((call).return_type);
 if (is_optional){
-ids::StructId const optional_struct_id = TRY((((*this).find_struct_in_prelude((ByteString::must_from_utf8("Optional"sv))))));
+ids::StructId const optional_struct_id = TRY((((*this).find_struct_in_prelude((ByteString::from_utf8_without_validation("Optional"sv))))));
 (result_type = ((*this).find_or_add_type_id(types::Type::GenericInstance(parser::CheckedQualifiers(false),optional_struct_id,DynamicArray<ids::TypeId>::create_with({result_type})))));
 }
 __jakt_var_557 = types::CheckedExpression::MethodCall(JaktInternal::OptionalNone(),checked_expr,call,span,is_optional,result_type); goto __jakt_label_483;
@@ -17569,7 +17569,7 @@ __jakt_label_483:; __jakt_var_557.release_value(); }));
 };/*case end*/
 default: {
 {
-((((*this).compiler))->panic((ByteString::must_from_utf8("typecheck_call should return `CheckedExpression::Call()`"sv))));
+((((*this).compiler))->panic((ByteString::from_utf8_without_validation("typecheck_call should return `CheckedExpression::Call()`"sv))));
 }
 };/*case end*/
 }/*switch end*/
@@ -17613,7 +17613,7 @@ JaktInternal::Optional<ids::TypeId> values_type_id = JaktInternal::OptionalNone(
 if ((((from).has_value()) && ((to).has_value()))){
 (values_type_id = TRY((((*this).unify((from_type.value()),from_span,to_type,from_span)))));
 if ((!(((values_type_id).has_value())))){
-((*this).error((ByteString::must_from_utf8("Range values differ in types"sv)),span));
+((*this).error((ByteString::from_utf8_without_validation("Range values differ in types"sv)),span));
 }
 }
 else if (((from).has_value())){
@@ -17622,7 +17622,7 @@ else if (((from).has_value())){
 else if (((to).has_value())){
 (values_type_id = to_type);
 }
-ids::StructId const range_struct_id = TRY((((*this).find_struct_in_prelude((ByteString::must_from_utf8("Range"sv))))));
+ids::StructId const range_struct_id = TRY((((*this).find_struct_in_prelude((ByteString::from_utf8_without_validation("Range"sv))))));
 NonnullRefPtr<typename types::Type> const range_type = types::Type::GenericInstance(parser::CheckedQualifiers(false),range_struct_id,DynamicArray<ids::TypeId>::create_with({((values_type_id).value_or(types::builtin(types::BuiltinType::I64())))}));
 ids::TypeId const type_id = ((*this).find_or_add_type_id(range_type));
 __jakt_var_558 = types::CheckedExpression::Range(JaktInternal::OptionalNone(),checked_from,checked_to,span,type_id); goto __jakt_label_484;
@@ -17636,7 +17636,7 @@ utility::Span const& span = __jakt_match_value.span;
 return JaktInternal::ExplicitValue(({ Optional<NonnullRefPtr<typename types::CheckedExpression>> __jakt_var_559; {
 ids::EnumId const reflected_type_enum_id = ({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<ids::EnumId, ErrorOr<NonnullRefPtr<typename types::CheckedExpression>>>{
-auto&& __jakt_match_variant = TRY((((((*this).program))->find_reflected_primitive((ByteString::must_from_utf8("Type"sv))))));
+auto&& __jakt_match_variant = TRY((((((*this).program))->find_reflected_primitive((ByteString::from_utf8_without_validation("Type"sv))))));
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 1 /* Enum */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Enum;ids::EnumId const& id = __jakt_match_value.value;
@@ -17644,7 +17644,7 @@ return JaktInternal::ExplicitValue(id);
 };/*case end*/
 default: {
 {
-((((*this).compiler))->panic((ByteString::must_from_utf8("unreachable"sv))));
+((((*this).compiler))->panic((ByteString::from_utf8_without_validation("unreachable"sv))));
 }
 };/*case end*/
 }/*switch end*/
@@ -17732,7 +17732,7 @@ auto&& __jakt_match_variant = cast;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 0 /* Fallible */: {
 return JaktInternal::ExplicitValue(({ Optional<types::CheckedTypeCast> __jakt_var_562; {
-ids::StructId const optional_struct_id = TRY((((*this).find_struct_in_prelude((ByteString::must_from_utf8("Optional"sv))))));
+ids::StructId const optional_struct_id = TRY((((*this).find_struct_in_prelude((ByteString::from_utf8_without_validation("Optional"sv))))));
 NonnullRefPtr<typename types::Type> const optional_type = types::Type::GenericInstance(parser::CheckedQualifiers(false),optional_struct_id,DynamicArray<ids::TypeId>::create_with({type_id}));
 ids::TypeId const optional_type_id = ((*this).find_or_add_type_id(optional_type));
 __jakt_var_562 = types::CheckedTypeCast::Fallible(optional_type_id); goto __jakt_label_488;
@@ -17833,8 +17833,8 @@ if (((!(exists)) && ((type_id).equals(types::unknown_type_id())))){
 ((*this).error(__jakt_format((StringView::from_string_literal("Enum variant {} does not exist on {}"sv)),name,TRY((((*this).type_name(expr_type_id,false))))),span));
 }
 }
-else if ((((name) == ((ByteString::must_from_utf8("Some"sv)))) || ((name) == ((ByteString::must_from_utf8("None"sv)))))){
-ids::StructId const optional_struct_id = TRY((((*this).find_struct_in_prelude((ByteString::must_from_utf8("Optional"sv))))));
+else if ((((name) == ((ByteString::from_utf8_without_validation("Some"sv)))) || ((name) == ((ByteString::from_utf8_without_validation("None"sv)))))){
+ids::StructId const optional_struct_id = TRY((((*this).find_struct_in_prelude((ByteString::from_utf8_without_validation("Optional"sv))))));
 NonnullRefPtr<typename types::Type> const checked_expr_type = ((*this).get_type(((checked_expr)->type())));
 if ((!(((checked_expr_type)->__jakt_init_index() == 20 /* GenericInstance */)))){
 ((*this).error(__jakt_format((StringView::from_string_literal("The left-hand side of an `is {}` statement must have a {} variant"sv)),name,name),((checked_expr)->span())));
@@ -17842,15 +17842,15 @@ if ((!(((checked_expr_type)->__jakt_init_index() == 20 /* GenericInstance */))))
 (operator_is = ({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<types::CheckedUnaryOperator,ErrorOr<NonnullRefPtr<typename types::CheckedExpression>>>{
 auto __jakt_enum_value = (name);
-if (__jakt_enum_value == (ByteString::must_from_utf8("Some"sv))) {
+if (__jakt_enum_value == (ByteString::from_utf8_without_validation("Some"sv))) {
 return JaktInternal::ExplicitValue(types::CheckedUnaryOperator::IsSome());
 }
-else if (__jakt_enum_value == (ByteString::must_from_utf8("None"sv))) {
+else if (__jakt_enum_value == (ByteString::from_utf8_without_validation("None"sv))) {
 return JaktInternal::ExplicitValue(types::CheckedUnaryOperator::IsNone());
 }
 else {
 {
-utility::panic((ByteString::must_from_utf8("unreachable"sv)));
+utility::panic((ByteString::from_utf8_without_validation("unreachable"sv)));
 }
 }
 }());
@@ -17864,7 +17864,7 @@ else if (((type_id).equals(types::unknown_type_id()))){
 }
 }
 else {
-((*this).error((ByteString::must_from_utf8("The right-hand side of an `is` operator must be a type name or enum variant"sv)),span));
+((*this).error((ByteString::from_utf8_without_validation("The right-hand side of an `is` operator must be a type name or enum variant"sv)),span));
 }
 
 __jakt_var_564 = operator_is; goto __jakt_label_490;
@@ -17928,7 +17928,7 @@ ids::TypeId const hint = (((checked_lhs.value()))->type());
 if ((((*this).type_contains_reference((((original_checked_lhs.value()))->type()))) && ((rhs)->__jakt_init_index() == 11 /* UnaryOp */))){
 parser::UnaryOperator const op = (rhs)->as.UnaryOp.op;
 if ((((op).__jakt_init_index() == 7 /* Reference */) || ((op).__jakt_init_index() == 8 /* MutableReference */))){
-((*this).error_with_hint((ByteString::must_from_utf8("Attempt to rebind a reference will result in write-through"sv)),span,(ByteString::must_from_utf8("This reference will be immediately dereferenced and then assigned"sv)),((rhs)->span())));
+((*this).error_with_hint((ByteString::from_utf8_without_validation("Attempt to rebind a reference will result in write-through"sv)),span,(ByteString::from_utf8_without_validation("This reference will be immediately dereferenced and then assigned"sv)),((rhs)->span())));
 }
 }
 JaktInternal::Tuple<types::CheckedBinaryOperator,ids::TypeId> const checked_operator_output_type_ = TRY((((*this).typecheck_binary_operation((checked_lhs.value()),op,(checked_rhs.value()),scope_id,span))));
@@ -17947,7 +17947,7 @@ JaktInternal::Optional<ids::TypeId> type_hint_unwrapped = type_hint;
 if ((((type_hint).has_value()) && ((((*this).get_type((type_hint.value()))))->__jakt_init_index() == 20 /* GenericInstance */))){
 ids::StructId const id = (((*this).get_type((type_hint.value()))))->as.GenericInstance.id;
 JaktInternal::DynamicArray<ids::TypeId> const args = (((*this).get_type((type_hint.value()))))->as.GenericInstance.args;
-ids::StructId const optional_struct_id = TRY((((*this).find_struct_in_prelude((ByteString::must_from_utf8("Optional"sv))))));
+ids::StructId const optional_struct_id = TRY((((*this).find_struct_in_prelude((ByteString::from_utf8_without_validation("Optional"sv))))));
 if (((id).equals(optional_struct_id))){
 (type_hint_unwrapped = ((args)[static_cast<i64>(0LL)]));
 }
@@ -17963,7 +17963,7 @@ utility::Span const& span = __jakt_match_value.span;
 return JaktInternal::ExplicitValue(({ Optional<NonnullRefPtr<typename types::CheckedExpression>> __jakt_var_567; {
 NonnullRefPtr<typename types::CheckedExpression> const checked_expr = TRY((((*this).typecheck_expression(expr,scope_id,safety_mode,JaktInternal::OptionalNone()))));
 ids::TypeId const type_id = ((checked_expr)->type());
-ids::StructId const optional_struct_id = TRY((((*this).find_struct_in_prelude((ByteString::must_from_utf8("Optional"sv))))));
+ids::StructId const optional_struct_id = TRY((((*this).find_struct_in_prelude((ByteString::from_utf8_without_validation("Optional"sv))))));
 NonnullRefPtr<typename types::Type> const optional_type = types::Type::GenericInstance(parser::CheckedQualifiers(false),optional_struct_id,DynamicArray<ids::TypeId>::create_with({type_id}));
 ids::TypeId const optional_type_id = ((*this).find_or_add_type_id(optional_type));
 __jakt_var_567 = types::CheckedExpression::OptionalSome(JaktInternal::OptionalNone(),checked_expr,span,optional_type_id); goto __jakt_label_493;
@@ -18003,8 +18003,8 @@ utility::Span const& span = __jakt_match_value.span;
 return JaktInternal::ExplicitValue(({ Optional<NonnullRefPtr<typename types::CheckedExpression>> __jakt_var_569; {
 NonnullRefPtr<typename types::CheckedExpression> const checked_expr = TRY((((*this).typecheck_expression_and_dereference_if_needed(expr,scope_id,safety_mode,JaktInternal::OptionalNone(),span))));
 NonnullRefPtr<typename types::Type> const type = ((*this).get_type(((checked_expr)->type())));
-ids::StructId const optional_struct_id = TRY((((*this).find_struct_in_prelude((ByteString::must_from_utf8("Optional"sv))))));
-ids::StructId const weakptr_struct_id = TRY((((*this).find_struct_in_prelude((ByteString::must_from_utf8("WeakPtr"sv))))));
+ids::StructId const optional_struct_id = TRY((((*this).find_struct_in_prelude((ByteString::from_utf8_without_validation("Optional"sv))))));
+ids::StructId const weakptr_struct_id = TRY((((*this).find_struct_in_prelude((ByteString::from_utf8_without_validation("WeakPtr"sv))))));
 ids::TypeId const type_id = ({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<ids::TypeId, ErrorOr<NonnullRefPtr<typename types::CheckedExpression>>>{
 auto&& __jakt_match_variant = *type;
@@ -18018,7 +18018,7 @@ if ((((id).equals(optional_struct_id)) || ((id).equals(weakptr_struct_id)))){
 (inner_type_id = ((args)[static_cast<i64>(0LL)]));
 }
 else {
-((*this).error((ByteString::must_from_utf8("Forced unwrap only works on Optional"sv)),span));
+((*this).error((ByteString::from_utf8_without_validation("Forced unwrap only works on Optional"sv)),span));
 }
 
 __jakt_var_570 = inner_type_id; goto __jakt_label_496;
@@ -18028,7 +18028,7 @@ __jakt_label_496:; __jakt_var_570.release_value(); }));
 };/*case end*/
 default: {
 return JaktInternal::ExplicitValue(({ Optional<ids::TypeId> __jakt_var_571; {
-((*this).error((ByteString::must_from_utf8("Forced unwrap only works on Optional"sv)),span));
+((*this).error((ByteString::from_utf8_without_validation("Forced unwrap only works on Optional"sv)),span));
 __jakt_var_571 = types::unknown_type_id(); goto __jakt_label_497;
 
 }
@@ -18059,7 +18059,7 @@ return JaktInternal::ExplicitValue(({ Optional<NonnullRefPtr<typename types::Che
 ids::TypeId const VOID_TYPE_ID = types::builtin(types::BuiltinType::Void());
 JaktInternal::DynamicArray<NonnullRefPtr<typename types::CheckedExpression>> checked_values = DynamicArray<NonnullRefPtr<typename types::CheckedExpression>>::create_with({});
 JaktInternal::DynamicArray<ids::TypeId> checked_types = DynamicArray<ids::TypeId>::create_with({});
-ids::StructId const optional_struct_id = TRY((((*this).find_struct_in_prelude((ByteString::must_from_utf8("Optional"sv))))));
+ids::StructId const optional_struct_id = TRY((((*this).find_struct_in_prelude((ByteString::from_utf8_without_validation("Optional"sv))))));
 {
 JaktInternal::ArrayIterator<NonnullRefPtr<typename parser::ParsedExpression>> _magic = ((values).iterator());
 for (;;){
@@ -18072,7 +18072,7 @@ NonnullRefPtr<typename parser::ParsedExpression> value = (_magic_value.value());
 NonnullRefPtr<typename types::CheckedExpression> const checked_value = TRY((((*this).typecheck_expression(value,scope_id,safety_mode,JaktInternal::OptionalNone()))));
 ids::TypeId const type_id = ((checked_value)->type());
 if (((type_id).equals(VOID_TYPE_ID))){
-((*this).error((ByteString::must_from_utf8("Cannot create a tuple that contains a value of type void"sv)),((value)->span())));
+((*this).error((ByteString::from_utf8_without_validation("Cannot create a tuple that contains a value of type void"sv)),((value)->span())));
 }
 ((checked_types).push(type_id));
 ((checked_values).push(checked_value));
@@ -18130,7 +18130,7 @@ ids::TypeId const optional_type_id = ((*this).find_or_add_type_id(optional_type)
 
 }
 }
-ids::StructId const tuple_struct_id = TRY((((*this).find_struct_in_prelude((ByteString::must_from_utf8("Tuple"sv))))));
+ids::StructId const tuple_struct_id = TRY((((*this).find_struct_in_prelude((ByteString::from_utf8_without_validation("Tuple"sv))))));
 ids::TypeId const type_id = ((*this).find_or_add_type_id(types::Type::GenericInstance(parser::CheckedQualifiers(false),tuple_struct_id,checked_types)));
 if (((type_hint).has_value())){
 TRY((((*this).check_types_for_compat((type_hint.value()),type_id,((((*this).generic_inferences))),span))));
@@ -18155,9 +18155,9 @@ case 20 /* GenericInstance */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.GenericInstance;ids::StructId const& id = __jakt_match_value.id;
 JaktInternal::DynamicArray<ids::TypeId> const& args = __jakt_match_value.args;
 return JaktInternal::ExplicitValue(({ Optional<NonnullRefPtr<typename types::CheckedExpression>> __jakt_var_574; {
-ids::StructId const array_struct_id = TRY((((*this).find_struct_in_prelude((ByteString::must_from_utf8("Array"sv))))));
-ids::StructId const array_slice_struct_id = TRY((((*this).find_struct_in_prelude((ByteString::must_from_utf8("ArraySlice"sv))))));
-ids::StructId const dictionary_struct_id = TRY((((*this).find_struct_in_prelude((ByteString::must_from_utf8("Dictionary"sv))))));
+ids::StructId const array_struct_id = TRY((((*this).find_struct_in_prelude((ByteString::from_utf8_without_validation("Array"sv))))));
+ids::StructId const array_slice_struct_id = TRY((((*this).find_struct_in_prelude((ByteString::from_utf8_without_validation("ArraySlice"sv))))));
+ids::StructId const dictionary_struct_id = TRY((((*this).find_struct_in_prelude((ByteString::from_utf8_without_validation("Dictionary"sv))))));
 NonnullRefPtr<typename types::CheckedExpression> result = types::CheckedExpression::Garbage(JaktInternal::OptionalNone(),span,types::builtin(types::BuiltinType::Void()));
 if ((((id).equals(array_struct_id)) || ((id).equals(array_slice_struct_id)))){
 if ((((*this).is_integer(((checked_index)->type()))) || ((checked_index)->__jakt_init_index() == 9 /* Range */))){
@@ -18167,7 +18167,7 @@ auto&& __jakt_match_variant = *checked_index;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 9 /* Range */: {
 return JaktInternal::ExplicitValue(({ Optional<ids::TypeId> __jakt_var_575; {
-ids::StructId const array_slice_struct_id = TRY((((*this).find_struct_in_prelude((ByteString::must_from_utf8("ArraySlice"sv))))));
+ids::StructId const array_slice_struct_id = TRY((((*this).find_struct_in_prelude((ByteString::from_utf8_without_validation("ArraySlice"sv))))));
 __jakt_var_575 = ((*this).find_or_add_type_id(types::Type::GenericInstance(parser::CheckedQualifiers(false),array_slice_struct_id,args))); goto __jakt_label_501;
 
 }
@@ -18186,7 +18186,7 @@ return JaktInternal::ExplicitValue(((args)[static_cast<i64>(0LL)]));
 (result = types::CheckedExpression::IndexedExpression(JaktInternal::OptionalNone(),checked_base,checked_index,span,type_id));
 }
 else {
-((*this).error((ByteString::must_from_utf8("Index must be an integer or a range"sv)),span));
+((*this).error((ByteString::from_utf8_without_validation("Index must be an integer or a range"sv)),span));
 }
 
 }
@@ -18200,7 +18200,7 @@ __jakt_label_500:; __jakt_var_574.release_value(); }));
 };/*case end*/
 default: {
 return JaktInternal::ExplicitValue(({ Optional<NonnullRefPtr<typename types::CheckedExpression>> __jakt_var_576; {
-((*this).error((ByteString::must_from_utf8("Index used on value that cannot be indexed"sv)),span));
+((*this).error((ByteString::from_utf8_without_validation("Index used on value that cannot be indexed"sv)),span));
 __jakt_var_576 = types::CheckedExpression::Garbage(JaktInternal::OptionalNone(),span,types::builtin(types::BuiltinType::Void())); goto __jakt_label_502;
 
 }
@@ -18247,7 +18247,7 @@ NonnullRefPtr<typename parser::ParsedType> const& enum_variant = __jakt_match_va
 utility::Span const& span = __jakt_match_value.span;
 return JaktInternal::ExplicitValue(({ Optional<NonnullRefPtr<typename types::CheckedExpression>> __jakt_var_577; {
 NonnullRefPtr<typename types::CheckedExpression> const checked_expr = TRY((((*this).typecheck_expression_and_dereference_if_needed(inner_expr,scope_id,safety_mode,JaktInternal::OptionalNone(),span))));
-types::CheckedEnumVariantBinding checked_binding = types::CheckedEnumVariantBinding((ByteString::must_from_utf8(""sv)),(ByteString::must_from_utf8(""sv)),types::unknown_type_id(),span);
+types::CheckedEnumVariantBinding checked_binding = types::CheckedEnumVariantBinding((ByteString::from_utf8_without_validation(""sv)),(ByteString::from_utf8_without_validation(""sv)),types::unknown_type_id(),span);
 JaktInternal::Optional<types::CheckedEnumVariant> checked_enum_variant = JaktInternal::OptionalNone();
 ({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<void, ErrorOr<NonnullRefPtr<typename types::CheckedExpression>>>{
@@ -18398,7 +18398,7 @@ return JaktInternal::ExplicitValue(TRY((((*this).typecheck_expression(expr,scope
 };/*case end*/
 case 13 /* Operator */: {
 {
-((((*this).compiler))->panic((ByteString::must_from_utf8("idk how to handle this thing"sv))));
+((((*this).compiler))->panic((ByteString::from_utf8_without_validation("idk how to handle this thing"sv))));
 }
 };/*case end*/
 default: VERIFY_NOT_REACHED();}/*switch end*/
@@ -18523,6 +18523,9 @@ if (((((bindings).size())) != (static_cast<size_t>(1ULL)))){
 ((*this).error(__jakt_format((StringView::from_string_literal("Enum variant ‘{}’ must have exactly one argument"sv)),((variant).name())),span));
 return JaktInternal::OptionalNone();
 }
+if (((*this).dump_type_hints)){
+TRY((((*this).dump_type_hint(type_id,((((bindings)[static_cast<i64>(0LL)])).span)))));
+}
 return DynamicArray<types::CheckedEnumVariantBinding>::create_with({types::CheckedEnumVariantBinding(JaktInternal::OptionalNone(),((((bindings)[static_cast<i64>(0LL)])).binding),type_id,span)});
 }
 if (((variant).__jakt_init_index() == 3 /* StructLike */)){
@@ -18566,6 +18569,9 @@ NonnullRefPtr<types::CheckedVariable> var = (_magic_value.value());
 ByteString const binding_name = ((binding).name).value_or_lazy_evaluated([&] { return ((binding).binding); });
 ids::TypeId const type_id = ((var)->type_id);
 if (((binding_name) == (((var)->name)))){
+if (((*this).dump_type_hints)){
+TRY((((*this).dump_type_hint(type_id,((binding).span)))));
+}
 ((checked_enum_variant_bindings).push(types::CheckedEnumVariantBinding(((binding).name),((binding).binding),type_id,span)));
 (found = true);
 break;
@@ -18627,7 +18633,7 @@ return JaktInternal::ExplicitValue((Tuple{return_type_id, pseudo_function_id}));
 };/*case end*/
 default: {
 {
-((((*this).compiler))->panic((ByteString::must_from_utf8("Expected the just-checked function to be of a function type"sv))));
+((((*this).compiler))->panic((ByteString::from_utf8_without_validation("Expected the just-checked function to be of a function type"sv))));
 }
 };/*case end*/
 }/*switch end*/
@@ -18647,7 +18653,7 @@ while (((effective_namespace_parent_scope)->is_block_scope)){
 (effective_namespace_parent_scope_id = (((effective_namespace_parent_scope)->parent).value()));
 (effective_namespace_parent_scope = ((*this).get_scope(effective_namespace_parent_scope_id)));
 }
-ids::ScopeId lambda_scope_id = ((*this).create_scope(effective_namespace_parent_scope_id,can_throw,(ByteString::must_from_utf8("lambda"sv)),true));
+ids::ScopeId lambda_scope_id = ((*this).create_scope(effective_namespace_parent_scope_id,can_throw,(ByteString::from_utf8_without_validation("lambda"sv)),true));
 bool is_capturing_everything = false;
 JaktInternal::DynamicArray<types::CheckedCapture> checked_captures = DynamicArray<types::CheckedCapture>::create_with({});
 bool has_dependent_capture = false;
@@ -18661,10 +18667,10 @@ break;
 parser::ParsedCapture capture = (_magic_value.value());
 {
 if (((capture).__jakt_init_index() == 4 /* AllByReference */)){
-((checked_captures).push(types::CheckedCapture::AllByReference((ByteString::must_from_utf8(""sv)),((capture).common.init_common.span))));
+((checked_captures).push(types::CheckedCapture::AllByReference((ByteString::from_utf8_without_validation(""sv)),((capture).common.init_common.span))));
 if ((!(is_capturing_everything))){
 (is_capturing_everything = true);
-(lambda_scope_id = ((*this).create_scope(scope_id,can_throw,(ByteString::must_from_utf8("lambda"sv)),true)));
+(lambda_scope_id = ((*this).create_scope(scope_id,can_throw,(ByteString::from_utf8_without_validation("lambda"sv)),true)));
 }
 }
 else if (((TRY((((*this).find_var_in_scope(scope_id,((capture).common.init_common.name),JaktInternal::OptionalNone()))))).has_value())){
@@ -18696,7 +18702,7 @@ __jakt_label_504:; __jakt_var_579.release_value(); }));
 };/*case end*/
 case 4 /* AllByReference */: {
 {
-((((*this).compiler))->panic((ByteString::must_from_utf8("AllByReference capture should not be looked up by name"sv))));
+((((*this).compiler))->panic((ByteString::from_utf8_without_validation("AllByReference capture should not be looked up by name"sv))));
 }
 };/*case end*/
 default: VERIFY_NOT_REACHED();}/*switch end*/
@@ -18712,7 +18718,7 @@ default: VERIFY_NOT_REACHED();}/*switch end*/
 })));
 if ((!(is_capturing_everything))){
 NonnullRefPtr<types::CheckedVariable> const var = (TRY((((*this).find_var_in_scope(scope_id,((capture).common.init_common.name),JaktInternal::OptionalNone())))).value());
-bool const is_this = ((((var)->name)) == ((ByteString::must_from_utf8("this"sv))));
+bool const is_this = ((((var)->name)) == ((ByteString::from_utf8_without_validation("this"sv))));
 ids::VarId const var_id = ((module)->add_variable(types::CheckedVariable::__jakt_create(name,((var)->type_id),(((var)->is_mutable) && ((is_this || ((capture).__jakt_init_index() == 1 /* ByReference */)) || ((capture).__jakt_init_index() == 2 /* ByMutableReference */))),((var)->definition_span),((var)->type_span),((var)->visibility),((var)->owner_scope),JaktInternal::OptionalNone(),JaktInternal::OptionalNone())));
 ((*this).add_var_to_scope(lambda_scope_id,name,var_id,span));
 }
@@ -18794,7 +18800,7 @@ return JaktInternal::ExplicitValue(((*this).find_or_add_type_id(types::Type::Fun
 };/*case end*/
 default: {
 {
-((((*this).compiler))->panic((ByteString::must_from_utf8("Expected the just-checked function to be of a function type"sv))));
+((((*this).compiler))->panic((ByteString::from_utf8_without_validation("Expected the just-checked function to be of a function type"sv))));
 }
 };/*case end*/
 }/*switch end*/
@@ -18900,7 +18906,7 @@ return JaktInternal::ExplicitValue(call);
 };/*case end*/
 default: {
 {
-((((*this).compiler))->panic((ByteString::must_from_utf8("typecheck_call returned something other than a CheckedCall"sv))));
+((((*this).compiler))->panic((ByteString::from_utf8_without_validation("typecheck_call returned something other than a CheckedCall"sv))));
 }
 };/*case end*/
 }/*switch end*/
@@ -18930,7 +18936,7 @@ if ((!(((*this).is_integer(fill_size_type))))){
 }
 (repeat = fill_size_checked);
 }
-ids::StructId const array_struct_id = TRY((((*this).find_struct_in_prelude((ByteString::must_from_utf8("Array"sv))))));
+ids::StructId const array_struct_id = TRY((((*this).find_struct_in_prelude((ByteString::from_utf8_without_validation("Array"sv))))));
 ids::TypeId inner_type_id = types::unknown_type_id();
 JaktInternal::Optional<utility::Span> inferred_type_span = JaktInternal::OptionalNone();
 JaktInternal::Optional<ids::TypeId> inner_hint = JaktInternal::OptionalNone();
@@ -18951,7 +18957,7 @@ NonnullRefPtr<typename parser::ParsedExpression> value = (_magic_value.value());
 NonnullRefPtr<typename types::CheckedExpression> const checked_expr = TRY((((*this).typecheck_expression(value,scope_id,safety_mode,inner_hint))));
 ids::TypeId const current_value_type_id = ((checked_expr)->type());
 if (((current_value_type_id).equals(types::void_type_id()))){
-((*this).error((ByteString::must_from_utf8("Cannot create an array with values of type void\n"sv)),span));
+((*this).error((ByteString::from_utf8_without_validation("Cannot create an array with values of type void\n"sv)),span));
 }
 if (((inner_type_id).equals(types::unknown_type_id()))){
 (inner_type_id = current_value_type_id);
@@ -18971,7 +18977,7 @@ if (((inner_hint).has_value())){
 (inner_type_id = (inner_hint.value()));
 }
 else if ((((type_hint).has_value()) && (((type_hint.value())).equals(types::unknown_type_id())))){
-((*this).error((ByteString::must_from_utf8("Cannot infer generic type for Array<T>"sv)),span));
+((*this).error((ByteString::from_utf8_without_validation("Cannot infer generic type for Array<T>"sv)),span));
 }
 }
 ids::TypeId const type_id = ((*this).find_or_add_type_id(types::Type::GenericInstance(parser::CheckedQualifiers(false),array_struct_id,DynamicArray<ids::TypeId>::create_with({inner_type_id}))));
@@ -18987,7 +18993,7 @@ ErrorOr<NonnullRefPtr<typename types::CheckedExpression>> typechecker::Typecheck
 ids::TypeId inner_type_id = types::unknown_type_id();
 JaktInternal::Optional<utility::Span> inner_type_span = JaktInternal::OptionalNone();
 JaktInternal::DynamicArray<NonnullRefPtr<typename types::CheckedExpression>> output = DynamicArray<NonnullRefPtr<typename types::CheckedExpression>>::create_with({});
-ids::StructId const set_struct_id = TRY((((*this).find_struct_in_prelude((ByteString::must_from_utf8("Set"sv))))));
+ids::StructId const set_struct_id = TRY((((*this).find_struct_in_prelude((ByteString::from_utf8_without_validation("Set"sv))))));
 JaktInternal::Optional<ids::TypeId> inner_hint = JaktInternal::OptionalNone();
 JaktInternal::Optional<JaktInternal::DynamicArray<ids::TypeId>> const type_hint_ids = TRY((((*this).get_type_ids_from_type_hint_if_struct_ids_match(type_hint,set_struct_id))));
 if (((type_hint_ids).has_value())){
@@ -19006,7 +19012,7 @@ NonnullRefPtr<typename types::CheckedExpression> const checked_value = TRY((((*t
 ids::TypeId const current_value_type_id = ((checked_value)->type());
 if (((inner_type_id).equals(types::unknown_type_id()))){
 if ((((current_value_type_id).equals(types::void_type_id())) || ((current_value_type_id).equals(types::unknown_type_id())))){
-((*this).error((ByteString::must_from_utf8("Cannot create a set with values of type void"sv)),((value)->span())));
+((*this).error((ByteString::from_utf8_without_validation("Cannot create a set with values of type void"sv)),((value)->span())));
 }
 (inner_type_id = current_value_type_id);
 (inner_type_span = ((value)->span()));
@@ -19026,13 +19032,13 @@ if (((inner_hint).has_value())){
 (inner_type_id = (inner_hint.value()));
 }
 else {
-((*this).error((ByteString::must_from_utf8("Cannot infer generic type for Set<T>"sv)),span));
+((*this).error((ByteString::from_utf8_without_validation("Cannot infer generic type for Set<T>"sv)),span));
 }
 
 }
 if ((!(((inner_type_id).equals(types::unknown_type_id()))))){
-TRY((((*this).ensure_type_implements_trait(inner_type_id,(ByteString::must_from_utf8("Hashable"sv)),JaktInternal::OptionalNone(),scope_id,span))));
-TRY((((*this).ensure_type_implements_trait(inner_type_id,(ByteString::must_from_utf8("Equal"sv)),DynamicArray<ids::TypeId>::create_with({inner_type_id}),scope_id,span))));
+TRY((((*this).ensure_type_implements_trait(inner_type_id,(ByteString::from_utf8_without_validation("Hashable"sv)),JaktInternal::OptionalNone(),scope_id,span))));
+TRY((((*this).ensure_type_implements_trait(inner_type_id,(ByteString::from_utf8_without_validation("Equal"sv)),DynamicArray<ids::TypeId>::create_with({inner_type_id}),scope_id,span))));
 }
 ids::TypeId const type_id = ((*this).find_or_add_type_id(types::Type::GenericInstance(parser::CheckedQualifiers(false),set_struct_id,DynamicArray<ids::TypeId>::create_with({inner_type_id}))));
 return types::CheckedExpression::JaktSet(JaktInternal::OptionalNone(),output,span,type_id,inner_type_id);
@@ -19196,7 +19202,7 @@ continue;
 }
 }
 
-((*this).error_with_hint(__jakt_format((StringView::from_string_literal("Match case argument '{}' for struct-like enum variant '{}' cannot be anon"sv)),((arg).binding),name),((arg).span),__jakt_format((StringView::from_string_literal("Available arguments for '{}' are: {}\n"sv)),name,utility::join(unused_field_names,(ByteString::must_from_utf8(", "sv)))),((arg).span)));
+((*this).error_with_hint(__jakt_format((StringView::from_string_literal("Match case argument '{}' for struct-like enum variant '{}' cannot be anon"sv)),((arg).binding),name),((arg).span),__jakt_format((StringView::from_string_literal("Available arguments for '{}' are: {}\n"sv)),name,utility::join(unused_field_names,(ByteString::from_utf8_without_validation(", "sv)))),((arg).span)));
 continue;
 }
 }
@@ -19437,10 +19443,10 @@ auto&& __jakt_match_value = __jakt_match_variant.as.CatchAll;JaktInternal::Dynam
 utility::Span const& arguments_span = __jakt_match_value.arguments_span;
 {
 if (((current_case_index) != (JaktInternal::checked_sub(case_count,static_cast<size_t>(1ULL))))){
-((*this).error((ByteString::must_from_utf8("Match else case is only allowed as the last case"sv)),((case_).marker_span)));
+((*this).error((ByteString::from_utf8_without_validation("Match else case is only allowed as the last case"sv)),((case_).marker_span)));
 }
 if (seen_catch_all){
-((*this).error((ByteString::must_from_utf8("Multiple catch-all cases in match are not allowed"sv)),((case_).marker_span)));
+((*this).error((ByteString::from_utf8_without_validation("Multiple catch-all cases in match are not allowed"sv)),((case_).marker_span)));
 }
 else {
 (seen_catch_all = true);
@@ -19488,7 +19494,7 @@ if (((covered_name).has_value())){
 
 }
 else {
-ids::ScopeId const new_scope_id = ((*this).create_scope(scope_id,((((*this).get_scope(scope_id)))->can_throw),(ByteString::must_from_utf8("catch-all"sv)),true));
+ids::ScopeId const new_scope_id = ((*this).create_scope(scope_id,((((*this).get_scope(scope_id)))->can_throw),(ByteString::from_utf8_without_validation("catch-all"sv)),true));
 JaktInternal::DynamicArray<NonnullRefPtr<typename types::CheckedStatement>> defaults = DynamicArray<NonnullRefPtr<typename types::CheckedStatement>>::create_with({});
 {
 JaktInternal::DictionaryIterator<ByteString,parser::ParsedPatternDefault> _magic = ((((pattern).common.init_common.defaults)).iterator());
@@ -19595,11 +19601,11 @@ return (infallible_enum_cast<jakt__prelude__operators::Ordering>((JaktInternal::
 }
 (((missing_variants).size()),static_cast<size_t>(0ULL))){
 if ((!(seen_catch_all))){
-((*this).error(__jakt_format((StringView::from_string_literal("Match expression is not exhaustive, missing variants are: {}"sv)),utility::join(missing_variants,(ByteString::must_from_utf8(", "sv)))),span));
+((*this).error(__jakt_format((StringView::from_string_literal("Match expression is not exhaustive, missing variants are: {}"sv)),utility::join(missing_variants,(ByteString::from_utf8_without_validation(", "sv)))),span));
 }
 }
 else if ((seen_catch_all && (!(expanded_catch_all)))){
-((*this).error((ByteString::must_from_utf8("All variants are covered, but an irrefutable pattern is also present"sv)),span));
+((*this).error((ByteString::from_utf8_without_validation("All variants are covered, but an irrefutable pattern is also present"sv)),span));
 }
 }
 return JaktInternal::ExplicitValue<void>();
@@ -19702,10 +19708,10 @@ auto&& __jakt_match_value = __jakt_match_variant.as.CatchAll;JaktInternal::Dynam
 utility::Span const& arguments_span = __jakt_match_value.arguments_span;
 {
 if (((current_case_index) != (JaktInternal::checked_sub(case_count,static_cast<size_t>(1ULL))))){
-((*this).error((ByteString::must_from_utf8("Match else case is only allowed as the last case"sv)),((case_).marker_span)));
+((*this).error((ByteString::from_utf8_without_validation("Match else case is only allowed as the last case"sv)),((case_).marker_span)));
 }
 if (seen_catch_all){
-((*this).error((ByteString::must_from_utf8("Multiple catch-all cases in match are not allowed"sv)),((case_).marker_span)));
+((*this).error((ByteString::from_utf8_without_validation("Multiple catch-all cases in match are not allowed"sv)),((case_).marker_span)));
 }
 else {
 (seen_catch_all = true);
@@ -19753,7 +19759,7 @@ if (((covered_name).has_value())){
 
 }
 else {
-ids::ScopeId const new_scope_id = ((*this).create_scope(scope_id,((((*this).get_scope(scope_id)))->can_throw),(ByteString::must_from_utf8("catch-all"sv)),true));
+ids::ScopeId const new_scope_id = ((*this).create_scope(scope_id,((((*this).get_scope(scope_id)))->can_throw),(ByteString::from_utf8_without_validation("catch-all"sv)),true));
 JaktInternal::DynamicArray<NonnullRefPtr<typename types::CheckedStatement>> defaults = DynamicArray<NonnullRefPtr<typename types::CheckedStatement>>::create_with({});
 {
 JaktInternal::DictionaryIterator<ByteString,parser::ParsedPatternDefault> _magic = ((((pattern).common.init_common.defaults)).iterator());
@@ -19860,18 +19866,18 @@ return (infallible_enum_cast<jakt__prelude__operators::Ordering>((JaktInternal::
 }
 (((missing_variants).size()),static_cast<size_t>(0ULL))){
 if ((!(seen_catch_all))){
-((*this).error(__jakt_format((StringView::from_string_literal("Match expression is not exhaustive, missing variants are: {}"sv)),utility::join(missing_variants,(ByteString::must_from_utf8(", "sv)))),span));
+((*this).error(__jakt_format((StringView::from_string_literal("Match expression is not exhaustive, missing variants are: {}"sv)),utility::join(missing_variants,(ByteString::from_utf8_without_validation(", "sv)))),span));
 }
 }
 else if ((seen_catch_all && (!(expanded_catch_all)))){
-((*this).error((ByteString::must_from_utf8("All variants are covered, but an irrefutable pattern is also present"sv)),span));
+((*this).error((ByteString::from_utf8_without_validation("All variants are covered, but an irrefutable pattern is also present"sv)),span));
 }
 }
 return JaktInternal::ExplicitValue<void>();
 };/*case end*/
 case 0 /* Void */: {
 {
-((*this).error((ByteString::must_from_utf8("Can't match on 'void' type"sv)),((checked_expr)->span())));
+((*this).error((ByteString::from_utf8_without_validation("Can't match on 'void' type"sv)),((checked_expr)->span())));
 }
 return JaktInternal::ExplicitValue<void>();
 };/*case end*/
@@ -19895,7 +19901,7 @@ return JaktInternal::ExplicitValue((Tuple{id, ((*this).struct_inheritance_chain(
 };/*case end*/
 default: {
 {
-((((*this).compiler))->panic((ByteString::must_from_utf8("Expected struct or generic instance in inheritance-style match expression"sv))));
+((((*this).compiler))->panic((ByteString::from_utf8_without_validation("Expected struct or generic instance in inheritance-style match expression"sv))));
 }
 };/*case end*/
 }/*switch end*/
@@ -19957,14 +19963,14 @@ JaktInternal::Tuple<ByteString,utility::Span> name = (_magic_value.value());
 
 ids::TypeId const type = TRY((((*this).typecheck_typename(parser::ParsedType::NamespacedName(JaktInternal::OptionalNone(),(((names).last()).value()),((((names)[(JaktInternal::Range<size_t>{static_cast<size_t>(0LL),static_cast<size_t>(JaktInternal::checked_sub(((names).size()),static_cast<size_t>(1ULL)))})])).to_array()),DynamicArray<NonnullRefPtr<typename parser::ParsedType>>::create_with({}),((case_).marker_span)),scope_id,JaktInternal::OptionalNone()))));
 if (seen_catch_all){
-((*this).error_with_hint((ByteString::must_from_utf8("This case is unreachable because a catch-all case is present before it"sv)),((case_).marker_span),({
+((*this).error_with_hint((ByteString::from_utf8_without_validation("This case is unreachable because a catch-all case is present before it"sv)),((case_).marker_span),({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<ByteString,ErrorOr<NonnullRefPtr<typename types::CheckedExpression>>>{
 auto __jakt_enum_value = (catch_all_matches_original_type);
 if (__jakt_enum_value == true) {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("Catch-all case matching the original subject type seen here"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("Catch-all case matching the original subject type seen here"sv)));
 }
 else if (__jakt_enum_value == false) {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("Catch-all case seen here"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("Catch-all case seen here"sv)));
 }
 VERIFY_NOT_REACHED();
 }());
@@ -20002,7 +20008,7 @@ return {};
 ;
 if (((type).equals(subject_type_id))){
 if (seen_catch_all){
-((*this).error((ByteString::must_from_utf8("Multiple catch-all cases in match are not allowed"sv)),((case_).marker_span)));
+((*this).error((ByteString::from_utf8_without_validation("Multiple catch-all cases in match are not allowed"sv)),((case_).marker_span)));
 }
 else {
 (seen_catch_all = true);
@@ -20068,14 +20074,14 @@ ids::ScopeId const new_scope_id = ((*this).create_scope(scope_id,((((*this).get_
 JaktInternal::Optional<types::ClassInstanceRebind> rebind_name = JaktInternal::OptionalNone();
 if ((!(((variant_arguments).is_empty())))){
 if (((((variant_arguments).size())) != (static_cast<size_t>(1ULL)))){
-((*this).error((ByteString::must_from_utf8("Class instance matches may only have one match argument (the name to rebind to)"sv)),arguments_span));
+((*this).error((ByteString::from_utf8_without_validation("Class instance matches may only have one match argument (the name to rebind to)"sv)),arguments_span));
 }
 parser::EnumVariantPatternArgument const arg = ((variant_arguments)[static_cast<i64>(0LL)]);
 (rebind_name = types::ClassInstanceRebind(((arg).name_in_enum()),((arg).name_in_enum_span()),((arg).is_mutable),((arg).is_reference)));
 NonnullRefPtr<types::Module> module = ((*this).current_module());
 ids::VarId const variable_id = ((module)->add_variable(types::CheckedVariable::__jakt_create((((rebind_name.value())).name),type,(((rebind_name.value())).is_mutable),(((rebind_name.value())).name_span),((case_).marker_span),types::CheckedVisibility::Public(),JaktInternal::OptionalNone(),JaktInternal::OptionalNone(),JaktInternal::OptionalNone())));
 if (((((rebind_name.value())).is_mutable) && (!(((checked_expr)->is_mutable(((*this).program))))))){
-((*this).error((ByteString::must_from_utf8("Cannot call mutating method on an immutable object instance"sv)),span));
+((*this).error((ByteString::from_utf8_without_validation("Cannot call mutating method on an immutable object instance"sv)),span));
 }
 ((*this).add_var_to_scope(new_scope_id,(((rebind_name.value())).name),variable_id,(((rebind_name.value())).name_span)));
 }
@@ -20093,14 +20099,14 @@ auto&& __jakt_match_value = __jakt_match_variant.as.CatchAll;JaktInternal::Dynam
 utility::Span const& arguments_span = __jakt_match_value.arguments_span;
 {
 if (seen_catch_all){
-((*this).error((ByteString::must_from_utf8("Multiple catch-all cases in match are not allowed"sv)),((case_).marker_span)));
+((*this).error((ByteString::from_utf8_without_validation("Multiple catch-all cases in match are not allowed"sv)),((case_).marker_span)));
 }
 else {
 (seen_catch_all = true);
 (catch_all_marker_span = ((case_).marker_span));
-ids::ScopeId const new_scope_id = ((*this).create_scope(scope_id,((((*this).get_scope(scope_id)))->can_throw),(ByteString::must_from_utf8("class-variant(else)"sv)),true));
+ids::ScopeId const new_scope_id = ((*this).create_scope(scope_id,((((*this).get_scope(scope_id)))->can_throw),(ByteString::from_utf8_without_validation("class-variant(else)"sv)),true));
 if ((!(((variant_arguments).is_empty())))){
-((*this).error((ByteString::must_from_utf8("Catch-all cases in class instance matches cannot have arguments"sv)),arguments_span));
+((*this).error((ByteString::from_utf8_without_validation("Catch-all cases in class instance matches cannot have arguments"sv)),arguments_span));
 }
 JaktInternal::Tuple<types::CheckedMatchBody,JaktInternal::Optional<ids::TypeId>> const checked_body_result_type_ = TRY((((*this).typecheck_match_body(((case_).body),new_scope_id,safety_mode,((((*this).generic_inferences))),final_result_type,((case_).marker_span)))));
 types::CheckedMatchBody const checked_body = ((checked_body_result_type_).template get<0>());
@@ -20115,7 +20121,7 @@ return JaktInternal::ExplicitValue<void>();
 };/*case end*/
 default: {
 {
-((*this).error((ByteString::must_from_utf8("Only named types and 'else' patterns are allowed in class instance match expressions"sv)),((case_).marker_span)));
+((*this).error((ByteString::from_utf8_without_validation("Only named types and 'else' patterns are allowed in class instance match expressions"sv)),((case_).marker_span)));
 }
 return JaktInternal::ExplicitValue<void>();
 };/*case end*/
@@ -20232,10 +20238,10 @@ JaktInternal::DynamicArray<parser::EnumVariantPatternArgument> const& variant_ar
 utility::Span const& arguments_span = __jakt_match_value.arguments_span;
 {
 if (is_value_match){
-((*this).error((ByteString::must_from_utf8("Cannot have an enum match case in a match expression containing value matches"sv)),((case_).marker_span)));
+((*this).error((ByteString::from_utf8_without_validation("Cannot have an enum match case in a match expression containing value matches"sv)),((case_).marker_span)));
 }
 if (((((variant_names).size())) == (static_cast<size_t>(0ULL)))){
-((((*this).compiler))->panic((ByteString::must_from_utf8("typecheck_match - else - EnumVariant - variant_names.size() == 0"sv))));
+((((*this).compiler))->panic((ByteString::from_utf8_without_validation("typecheck_match - else - EnumVariant - variant_names.size() == 0"sv))));
 }
 (is_enum_match = true);
 ids::ScopeId const new_scope_id = ((*this).create_scope(scope_id,((((*this).get_scope(scope_id)))->can_throw),__jakt_format((StringView::from_string_literal("catch-enum-variant({})"sv)),variant_names),true));
@@ -20274,11 +20280,11 @@ case 2 /* CatchAll */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.CatchAll;JaktInternal::DynamicArray<parser::EnumVariantPatternArgument> const& variant_arguments = __jakt_match_value.variant_arguments;
 {
 if (((current_case_index) != (JaktInternal::checked_sub(case_count,static_cast<size_t>(1ULL))))){
-((*this).error((ByteString::must_from_utf8("Match else case is only allowed as the last case"sv)),((case_).marker_span)));
+((*this).error((ByteString::from_utf8_without_validation("Match else case is only allowed as the last case"sv)),((case_).marker_span)));
 }
 (catch_all_span = ((case_).marker_span));
 if (seen_catch_all){
-((*this).error((ByteString::must_from_utf8("Multiple catch-all cases in match are not allowed"sv)),((case_).marker_span)));
+((*this).error((ByteString::from_utf8_without_validation("Multiple catch-all cases in match are not allowed"sv)),((case_).marker_span)));
 }
 else {
 (seen_catch_all = true);
@@ -20287,11 +20293,11 @@ else {
 if (((((variant_arguments).size())) != (static_cast<size_t>(0ULL)))){
 bool const old_ignore_errors = ((*this).ignore_errors);
 (((*this).ignore_errors) = false);
-((*this).error((ByteString::must_from_utf8("Bindings aren't allowed in a generic else"sv)),((case_).marker_span)));
+((*this).error((ByteString::from_utf8_without_validation("Bindings aren't allowed in a generic else"sv)),((case_).marker_span)));
 (((*this).ignore_errors) = old_ignore_errors);
 (((*this).had_an_error) = false);
 }
-ids::ScopeId const new_scope_id = ((*this).create_scope(scope_id,((((*this).get_scope(scope_id)))->can_throw),(ByteString::must_from_utf8("catch-all"sv)),true));
+ids::ScopeId const new_scope_id = ((*this).create_scope(scope_id,((((*this).get_scope(scope_id)))->can_throw),(ByteString::from_utf8_without_validation("catch-all"sv)),true));
 JaktInternal::DynamicArray<NonnullRefPtr<typename types::CheckedStatement>> defaults = DynamicArray<NonnullRefPtr<typename types::CheckedStatement>>::create_with({});
 {
 JaktInternal::DictionaryIterator<ByteString,parser::ParsedPatternDefault> _magic = ((((pattern).common.init_common.defaults)).iterator());
@@ -20327,7 +20333,7 @@ case 1 /* Expression */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Expression;NonnullRefPtr<typename parser::ParsedExpression> const& expr = __jakt_match_value.value;
 {
 if (is_enum_match){
-((*this).error((ByteString::must_from_utf8("Cannot have a value match case in a match expression containing enum matches"sv)),((case_).marker_span)));
+((*this).error((ByteString::from_utf8_without_validation("Cannot have a value match case in a match expression containing enum matches"sv)),((case_).marker_span)));
 }
 (is_value_match = true);
 JaktInternal::Tuple<NonnullRefPtr<typename parser::ParsedExpression>,JaktInternal::Optional<parser::ParsedBlock>,JaktInternal::Optional<NonnullRefPtr<typename parser::ParsedStatement>>> const new_condition_new_then_block_new_else_statement_ = TRY((((*this).expand_context_for_bindings(expr,JaktInternal::OptionalNone(),JaktInternal::OptionalNone(),JaktInternal::OptionalNone(),scope_id,span))));
@@ -20362,14 +20368,14 @@ else if (((to).has_value())){
 }
 }
 else {
-((*this).error((ByteString::must_from_utf8("There has to be at least a 'from', or a 'to' in a range expression"sv)),((expr)->span())));
+((*this).error((ByteString::from_utf8_without_validation("There has to be at least a 'from', or a 'to' in a range expression"sv)),((expr)->span())));
 return JaktInternal::LoopContinue{};
 }
 
 }
 TRY((((*this).check_types_for_compat(expression_type,subject_type_id,((((*this).generic_inferences))),((case_).marker_span)))));
 if ((!(((((pattern).common.init_common.defaults)).is_empty())))){
-((*this).error((ByteString::must_from_utf8("Expression patterns cannot have default bindings"sv)),((case_).marker_span)));
+((*this).error((ByteString::from_utf8_without_validation("Expression patterns cannot have default bindings"sv)),((case_).marker_span)));
 }
 ids::ScopeId const new_scope_id = ((*this).create_scope(scope_id,((((*this).get_scope(scope_id)))->can_throw),__jakt_format((StringView::from_string_literal("catch-expression({})"sv)),expr),true));
 JaktInternal::Tuple<types::CheckedMatchBody,JaktInternal::Optional<ids::TypeId>> const checked_body_result_type_ = TRY((((*this).typecheck_match_body(((case_).body),new_scope_id,safety_mode,((((*this).generic_inferences))),final_result_type,((case_).marker_span)))));
@@ -20410,10 +20416,10 @@ return JaktInternal::ExplicitValue<void>();
 }
 
 if ((is_value_match && (!((seen_catch_all || ((is_boolean_match && seen_true) && seen_false)))))){
-((*this).error((ByteString::must_from_utf8("Match expression is not exhaustive, a value match must contain an irrefutable 'else' pattern"sv)),span));
+((*this).error((ByteString::from_utf8_without_validation("Match expression is not exhaustive, a value match must contain an irrefutable 'else' pattern"sv)),span));
 }
 if ((is_value_match && (seen_catch_all && (is_boolean_match && (seen_true && seen_false))))){
-((*this).error((ByteString::must_from_utf8("All cases are covered, but an irrefutable pattern is also present"sv)),(catch_all_span.value())));
+((*this).error((ByteString::from_utf8_without_validation("All cases are covered, but an irrefutable pattern is also present"sv)),(catch_all_span.value())));
 }
 }
 return JaktInternal::ExplicitValue<void>();
@@ -20500,7 +20506,7 @@ return (Tuple{checked_match_body, result_type});
 
 ErrorOr<NonnullRefPtr<typename types::CheckedExpression>> typechecker::Typechecker::typecheck_dictionary(JaktInternal::DynamicArray<JaktInternal::Tuple<NonnullRefPtr<typename parser::ParsedExpression>,NonnullRefPtr<typename parser::ParsedExpression>>> const values,utility::Span const span,ids::ScopeId const scope_id,types::SafetyMode const safety_mode,JaktInternal::Optional<ids::TypeId> const type_hint) {
 {
-ids::StructId const dictionary_struct_id = TRY((((*this).find_struct_in_prelude((ByteString::must_from_utf8("Dictionary"sv))))));
+ids::StructId const dictionary_struct_id = TRY((((*this).find_struct_in_prelude((ByteString::from_utf8_without_validation("Dictionary"sv))))));
 JaktInternal::DynamicArray<JaktInternal::Tuple<NonnullRefPtr<typename types::CheckedExpression>,NonnullRefPtr<typename types::CheckedExpression>>> checked_kv_pairs = DynamicArray<JaktInternal::Tuple<NonnullRefPtr<typename types::CheckedExpression>,NonnullRefPtr<typename types::CheckedExpression>>>::create_with({});
 ids::TypeId key_type_id = types::unknown_type_id();
 JaktInternal::Optional<utility::Span> key_type_span = JaktInternal::OptionalNone();
@@ -20533,10 +20539,10 @@ ids::TypeId const current_value_type_id = ((checked_value)->type());
 ids::TypeId const VOID_TYPE_ID = types::builtin(types::BuiltinType::Void());
 if ((((key_type_id).equals(types::unknown_type_id())) && ((value_type_id).equals(types::unknown_type_id())))){
 if (((current_key_type_id).equals(VOID_TYPE_ID))){
-((*this).error((ByteString::must_from_utf8("Can't create a dictionary with keys of type void"sv)),((key)->span())));
+((*this).error((ByteString::from_utf8_without_validation("Can't create a dictionary with keys of type void"sv)),((key)->span())));
 }
 if (((current_value_type_id).equals(VOID_TYPE_ID))){
-((*this).error((ByteString::must_from_utf8("Can't create a dictionary with values of type void"sv)),((value)->span())));
+((*this).error((ByteString::from_utf8_without_validation("Can't create a dictionary with values of type void"sv)),((value)->span())));
 }
 (key_type_id = current_key_type_id);
 (key_type_span = static_cast<JaktInternal::Optional<utility::Span>>(((key)->span())));
@@ -20567,20 +20573,20 @@ if (((key_hint).has_value())){
 (key_type_id = (key_hint.value()));
 }
 else {
-((*this).error((ByteString::must_from_utf8("Cannot infer key type for Dictionary<K, V>"sv)),span));
+((*this).error((ByteString::from_utf8_without_validation("Cannot infer key type for Dictionary<K, V>"sv)),span));
 }
 
 }
 if ((!(((key_type_id).equals(types::unknown_type_id()))))){
-TRY((((*this).ensure_type_implements_trait(key_type_id,(ByteString::must_from_utf8("Hashable"sv)),JaktInternal::OptionalNone(),scope_id,span))));
-TRY((((*this).ensure_type_implements_trait(key_type_id,(ByteString::must_from_utf8("Equal"sv)),DynamicArray<ids::TypeId>::create_with({key_type_id}),scope_id,span))));
+TRY((((*this).ensure_type_implements_trait(key_type_id,(ByteString::from_utf8_without_validation("Hashable"sv)),JaktInternal::OptionalNone(),scope_id,span))));
+TRY((((*this).ensure_type_implements_trait(key_type_id,(ByteString::from_utf8_without_validation("Equal"sv)),DynamicArray<ids::TypeId>::create_with({key_type_id}),scope_id,span))));
 }
 if (((value_type_id).equals(types::unknown_type_id()))){
 if (((value_hint).has_value())){
 (value_type_id = (value_hint.value()));
 }
 else {
-((*this).error((ByteString::must_from_utf8("Cannot infer value type for Dictionary"sv)),span));
+((*this).error((ByteString::from_utf8_without_validation("Cannot infer value type for Dictionary"sv)),span));
 }
 
 }
@@ -20691,7 +20697,7 @@ return JaktInternal::ExplicitValue<void>();
     _jakt_value.release_value();
 });
 }
-((*this).error(__jakt_format((StringView::from_string_literal("Not a namespace, enum, class, or struct: ‘{}’"sv)),utility::join(((call).namespace_),(ByteString::must_from_utf8("::"sv)))),span));
+((*this).error(__jakt_format((StringView::from_string_literal("Not a namespace, enum, class, or struct: ‘{}’"sv)),utility::join(((call).namespace_),(ByteString::from_utf8_without_validation("::"sv)))),span));
 }
 
 }
@@ -20886,7 +20892,7 @@ return (infallible_enum_cast<jakt__prelude__operators::Ordering>((JaktInternal::
 }
 }
 (((((((callee_candidate)->generics))->params)).size()),type_arg_index)){
-((*this).error((ByteString::must_from_utf8("Trying to access generic parameter out of bounds"sv)),((parsed_type)->span())));
+((*this).error((ByteString::from_utf8_without_validation("Trying to access generic parameter out of bounds"sv)),((parsed_type)->span())));
 continue;
 }
 ids::TypeId const typevar_type_id = ((((((((callee_candidate)->generics))->params))[type_arg_index])).type_id());
@@ -20928,18 +20934,18 @@ continue;
 
 }
 if (((callee_candidate)->is_static())){
-((*this).error((ByteString::must_from_utf8("Cannot call static method on an instance of an object"sv)),span));
+((*this).error((ByteString::from_utf8_without_validation("Cannot call static method on an instance of an object"sv)),span));
 }
 else {
 (arg_offset = static_cast<size_t>(1ULL));
 }
 
 if ((((callee_candidate)->is_mutating()) && (!((((this_expr.value()))->is_mutable(((*this).program))))))){
-((*this).error((ByteString::must_from_utf8("Cannot call mutating method on an immutable object instance"sv)),span));
+((*this).error((ByteString::from_utf8_without_validation("Cannot call mutating method on an immutable object instance"sv)),span));
 }
 }
 else if ((!(((callee_candidate)->is_static())))){
-((*this).error_with_hint((ByteString::must_from_utf8("Cannot call an instance method statically"sv)),span,(ByteString::must_from_utf8("Add a dot before the method name to call an instance method"sv)),span));
+((*this).error_with_hint((ByteString::from_utf8_without_validation("Cannot call an instance method statically"sv)),span,(ByteString::from_utf8_without_validation("Add a dot before the method name to call an instance method"sv)),span));
 }
 i64 total_function_specificity = static_cast<i64>(0LL);
 JaktInternal::DynamicArray<JaktInternal::Tuple<ByteString,utility::Span,NonnullRefPtr<typename types::CheckedExpression>>> const resolved_args = TRY((((*this).resolve_default_params(((((callee_candidate)->generics))->base_params),((callee_candidate)->has_varargs),((call).args),caller_scope_id,safety_mode,arg_offset,span))));
@@ -21189,19 +21195,19 @@ ScopeGuard __jakt_var_587([&] {
 bool const is_print_like = (((((call).namespace_)).is_empty()) && ({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<bool,ErrorOr<NonnullRefPtr<typename types::CheckedExpression>>>{
 auto __jakt_enum_value = (((call).name));
-if (__jakt_enum_value == (ByteString::must_from_utf8("print"sv))) {
+if (__jakt_enum_value == (ByteString::from_utf8_without_validation("print"sv))) {
 return JaktInternal::ExplicitValue(true);
 }
-else if (__jakt_enum_value == (ByteString::must_from_utf8("println"sv))) {
+else if (__jakt_enum_value == (ByteString::from_utf8_without_validation("println"sv))) {
 return JaktInternal::ExplicitValue(true);
 }
-else if (__jakt_enum_value == (ByteString::must_from_utf8("eprintln"sv))) {
+else if (__jakt_enum_value == (ByteString::from_utf8_without_validation("eprintln"sv))) {
 return JaktInternal::ExplicitValue(true);
 }
-else if (__jakt_enum_value == (ByteString::must_from_utf8("eprint"sv))) {
+else if (__jakt_enum_value == (ByteString::from_utf8_without_validation("eprint"sv))) {
 return JaktInternal::ExplicitValue(true);
 }
-else if (__jakt_enum_value == (ByteString::must_from_utf8("format"sv))) {
+else if (__jakt_enum_value == (ByteString::from_utf8_without_validation("format"sv))) {
 return JaktInternal::ExplicitValue(true);
 }
 else {
@@ -21346,7 +21352,7 @@ auto __jakt_enum_value = (first);
 if (__jakt_enum_value == true) {
 return JaktInternal::ExplicitValue(({ Optional<JaktInternal::Optional<ids::TypeId>> __jakt_var_592; {
 (first = false);
-__jakt_var_592 = static_cast<JaktInternal::Optional<ids::TypeId>>(TRY((((*this).prelude_struct_type_named((ByteString::must_from_utf8("StringView"sv))))))); goto __jakt_label_511;
+__jakt_var_592 = static_cast<JaktInternal::Optional<ids::TypeId>>(TRY((((*this).prelude_struct_type_named((ByteString::from_utf8_without_validation("StringView"sv))))))); goto __jakt_label_511;
 
 }
 __jakt_label_511:; __jakt_var_592.release_value(); }));
@@ -21371,8 +21377,8 @@ NonnullRefPtr<typename types::CheckedExpression> const checked_arg = TRY((((*thi
 }
 }
 
-if (((((call).name)) == ((ByteString::must_from_utf8("format"sv))))){
-(return_type = TRY((((*this).prelude_struct_type_named((ByteString::must_from_utf8("String"sv)))))));
+if (((((call).name)) == ((ByteString::from_utf8_without_validation("format"sv))))){
+(return_type = TRY((((*this).prelude_struct_type_named((ByteString::from_utf8_without_validation("String"sv)))))));
 }
 }
 else {
@@ -21473,7 +21479,7 @@ default: VERIFY_NOT_REACHED();}/*switch end*/
 
 if ((!(((resolved_function_id).has_value())))){
 if ((!(((resolved_function_id_candidates).is_empty())))){
-((*this).error((ByteString::must_from_utf8("No function with matching signature found."sv)),span));
+((*this).error((ByteString::from_utf8_without_validation("No function with matching signature found."sv)),span));
 {
 JaktInternal::ArrayIterator<error::JaktError> _magic = ((errors_while_trying_to_find_matching_function).iterator());
 for (;;){
@@ -21548,7 +21554,7 @@ NonnullRefPtr<types::CheckedFunction> const callee = ((*this).get_function((reso
 (callee_throws = ((callee)->can_throw));
 (return_type = ((callee)->return_type_id));
 if ((((callee)->is_unsafe) && ((safety_mode).__jakt_init_index() == 0 /* Safe */))){
-((*this).error((ByteString::must_from_utf8("Cannot call unsafe function in safe context"sv)),span));
+((*this).error((ByteString::from_utf8_without_validation("Cannot call unsafe function in safe context"sv)),span));
 }
 if ((((type_hint).has_value()) && (!(((((type_hint).value())).equals(types::unknown_type_id())))))){
 bool const old_ignore_errors = ((*this).ignore_errors);
@@ -21582,7 +21588,7 @@ if (((substitution).has_value())){
 ((generic_arguments).push((substitution.value())));
 }
 else if ((!(((*this).in_comptime_function_call)))){
-((*this).error((ByteString::must_from_utf8("Not all generic parameters have known types"sv)),span));
+((*this).error((ByteString::from_utf8_without_validation("Not all generic parameters have known types"sv)),span));
 }
 else {
 ((generic_arguments).push(((generic_typevar).type_id())));
@@ -21606,7 +21612,7 @@ TRY((((*this).check_types_for_compat((type_hint.value()),return_type,((((*this).
 
 (return_type = TRY((((*this).substitute_typevars_in_type(return_type,((*this).generic_inferences))))));
 if ((callee_throws && (!(((((*this).get_scope(caller_scope_id)))->can_throw))))){
-((*this).error((ByteString::must_from_utf8("Call to function that may throw needs to be in a try statement or a function marked as throws"sv)),span));
+((*this).error((ByteString::from_utf8_without_validation("Call to function that may throw needs to be in a try statement or a function marked as throws"sv)),span));
 }
 if (((generic_checked_function_to_instantiate).has_value())){
 if (((maybe_this_type_id).has_value())){
@@ -21693,7 +21699,7 @@ default: VERIFY_NOT_REACHED();}/*switch end*/
     _jakt_value.release_value();
 });
 if (((*this).scope_lifetime_subsumes(stored_scope_id,arg_scope_id))){
-((*this).error((ByteString::must_from_utf8("Cannot pass this argument by reference, it is not guaranteed to outlive the object it will be stored in"sv)),((TRY((resolve_arg(index))))->span())));
+((*this).error((ByteString::from_utf8_without_validation("Cannot pass this argument by reference, it is not guaranteed to outlive the object it will be stored in"sv)),((TRY((resolve_arg(index))))->span())));
 }
 }
 
@@ -21758,14 +21764,14 @@ types::Value const value = (evaluated_this).as.Throw.value;
 ((*this).error(__jakt_format((StringView::from_string_literal("Error executing this expression (evaluation threw {})"sv)),value),(((this_expr.value()))->span())));
 }
 else {
-((*this).error((ByteString::must_from_utf8("Invalid this expression"sv)),(((this_expr.value()))->span())));
+((*this).error((ByteString::from_utf8_without_validation("Invalid this expression"sv)),(((this_expr.value()))->span())));
 }
 
 }
 
 ;return {};}();
 if (__jakt_var_594.is_error()) {{
-((*this).error((ByteString::must_from_utf8("Error executing this expression"sv)),(((this_expr.value()))->span())));
+((*this).error((ByteString::from_utf8_without_validation("Error executing this expression"sv)),(((this_expr.value()))->span())));
 }
 };
 }
@@ -21781,7 +21787,7 @@ JaktInternal::Tuple<ByteString,NonnullRefPtr<typename types::CheckedExpression>>
 interpreter::StatementResult const value = ({ Optional<interpreter::StatementResult> __jakt_var_595;
 auto __jakt_var_596 = [&]() -> ErrorOr<interpreter::StatementResult> { return TRY((((interpreter)->execute_expression(((argument).template get<1>()),eval_scope)))); }();
 if (__jakt_var_596.is_error()) {{
-((*this).error((ByteString::must_from_utf8("Error in argument"sv)),span));
+((*this).error((ByteString::from_utf8_without_validation("Error in argument"sv)),span));
 continue;
 }
 } else {__jakt_var_595 = __jakt_var_596.release_value();
@@ -22114,7 +22120,7 @@ NonnullRefPtr<typename parser::ParsedExpression> const expr = ((jakt__name__span
 return resolved_args;
 }
 else {
-((*this).error((ByteString::must_from_utf8("Wrong number of arguments"sv)),span));
+((*this).error((ByteString::from_utf8_without_validation("Wrong number of arguments"sv)),span));
 return DynamicArray<JaktInternal::Tuple<ByteString,utility::Span,NonnullRefPtr<typename types::CheckedExpression>>>::create_with({});
 }
 
@@ -22211,7 +22217,7 @@ return JaktInternal::ExplicitValue<void>();
         return _jakt_value.release_return();
     _jakt_value.release_value();
 });
-return (ByteString::must_from_utf8(""sv));
+return (ByteString::from_utf8_without_validation(""sv));
 }
 }
 
@@ -22623,7 +22629,7 @@ if (((first)->is_static())){
 if (((second)->is_static())){
 }
 else {
-((*this).error((ByteString::must_from_utf8("Function signatures don't match: one is static and the other isn't"sv)),((first)->name_span)));
+((*this).error((ByteString::from_utf8_without_validation("Function signatures don't match: one is static and the other isn't"sv)),((first)->name_span)));
 return false;
 }
 
@@ -22634,13 +22640,13 @@ if (((((first)->is_mutating())) == (((second)->is_mutating())))){
 (arg_start = static_cast<size_t>(1ULL));
 }
 else {
-((*this).error((ByteString::must_from_utf8("Function signatures don't match: one is mutating and the other isn't"sv)),((first)->name_span)));
+((*this).error((ByteString::from_utf8_without_validation("Function signatures don't match: one is mutating and the other isn't"sv)),((first)->name_span)));
 return false;
 }
 
 }
 else {
-((*this).error((ByteString::must_from_utf8("Function signatures don't match: one is static and the other isn't"sv)),((first)->name_span)));
+((*this).error((ByteString::from_utf8_without_validation("Function signatures don't match: one is static and the other isn't"sv)),((first)->name_span)));
 return false;
 }
 
@@ -22669,13 +22675,13 @@ return false;
 return true;
 }
 else {
-((*this).error((ByteString::must_from_utf8("Function signatures don't match: different number of parameters"sv)),((first)->name_span)));
+((*this).error((ByteString::from_utf8_without_validation("Function signatures don't match: different number of parameters"sv)),((first)->name_span)));
 return false;
 }
 
 }
 else {
-((*this).error((ByteString::must_from_utf8("Function signatures don't match: one can throw and the other can't"sv)),((first)->name_span)));
+((*this).error((ByteString::from_utf8_without_validation("Function signatures don't match: one can throw and the other can't"sv)),((first)->name_span)));
 return false;
 }
 
@@ -22834,7 +22840,7 @@ if (((already_implemented_for).has_value())){
 }
 else if (((private_matching_method).has_value())){
 utility::Span const span = (private_matching_method.value());
-((((typechecker))).error_with_hint(__jakt_format((StringView::from_string_literal("Implementation of ‘{}’ for trait ‘{}’ is valid but is not public"sv)),method_name,trait_name),span,(ByteString::must_from_utf8("Consider adding ‘public’ to make the method accessible"sv)),span));
+((((typechecker))).error_with_hint(__jakt_format((StringView::from_string_literal("Implementation of ‘{}’ for trait ‘{}’ is valid but is not public"sv)),method_name,trait_name),span,(ByteString::from_utf8_without_validation("Consider adding ‘public’ to make the method accessible"sv)),span));
 }
 else {
 NonnullRefPtr<types::CheckedFunction> const func = ((((typechecker))).get_function(trait_method_id));
@@ -22846,12 +22852,12 @@ JaktInternal::Tuple<utility::Span,JaktInternal::DynamicArray<error::JaktError>> 
 utility::Span const method_span = ((method_span_errors_).template get<0>());
 JaktInternal::DynamicArray<error::JaktError> const errors = ((method_span_errors_).template get<1>());
 
-((((typechecker))).error_with_hint(__jakt_format((StringView::from_string_literal("Missing implementation for method ‘{}’ of trait ‘{}’ on type ‘{}’"sv)),method_name,trait_name,TRY((((((typechecker))).type_name(trait_type_id,false))))),record_decl_span,(ByteString::must_from_utf8("The method is declared here, but its signature doesn't match"sv)),method_span));
+((((typechecker))).error_with_hint(__jakt_format((StringView::from_string_literal("Missing implementation for method ‘{}’ of trait ‘{}’ on type ‘{}’"sv)),method_name,trait_name,TRY((((((typechecker))).type_name(trait_type_id,false))))),record_decl_span,(ByteString::from_utf8_without_validation("The method is declared here, but its signature doesn't match"sv)),method_span));
 ((((((((typechecker))).compiler))->errors)).push_values(((errors))));
 }
 else {
 utility::Span const trait_method_span = ((((((typechecker))).get_function(trait_method_id)))->name_span);
-((((typechecker))).error_with_hint(__jakt_format((StringView::from_string_literal("Missing implementation for method ‘{}’ of trait ‘{}’"sv)),method_name,trait_name),record_decl_span,(ByteString::must_from_utf8("Consider implementing the method with the signature specified here"sv)),trait_method_span));
+((((typechecker))).error_with_hint(__jakt_format((StringView::from_string_literal("Missing implementation for method ‘{}’ of trait ‘{}’"sv)),method_name,trait_name),record_decl_span,(ByteString::from_utf8_without_validation("Consider implementing the method with the signature specified here"sv)),trait_method_span));
 }
 
 }

--- a/bootstrap/stage0/types.cpp
+++ b/bootstrap/stage0/types.cpp
@@ -96,7 +96,7 @@ auto&& __jakt_match_value = __jakt_match_variant.as.StringView;ByteString const&
 return JaktInternal::ExplicitValue(__jakt_format(format_string,v));
 };/*case end*/
 case 0 /* Void */: {
-return JaktInternal::ExplicitValue(__jakt_format(format_string,(ByteString::must_from_utf8("(void)"sv))));
+return JaktInternal::ExplicitValue(__jakt_format(format_string,(ByteString::from_utf8_without_validation("(void)"sv))));
 };/*case end*/
 case 17 /* Struct */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Struct;JaktInternal::DynamicArray<types::Value> const& fields = __jakt_match_value.fields;
@@ -341,7 +341,7 @@ auto&& __jakt_match_value = __jakt_match_variant.as.OptionalSome;types::Value co
 return JaktInternal::ExplicitValue(TRY((types::format_value_impl(__jakt_format((StringView::from_string_literal("Some({})"sv)),format_string),value,program))));
 };/*case end*/
 case 25 /* OptionalNone */: {
-return JaktInternal::ExplicitValue(__jakt_format(format_string,(ByteString::must_from_utf8("None"sv))));
+return JaktInternal::ExplicitValue(__jakt_format(format_string,(ByteString::from_utf8_without_validation("None"sv))));
 };/*case end*/
 case 26 /* JaktTuple */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.JaktTuple;JaktInternal::DynamicArray<types::Value> const& fields = __jakt_match_value.fields;
@@ -1336,7 +1336,7 @@ return [](ByteString const& self, ByteString rhs) -> bool {
 return (!(((self) == (rhs))));
 }
 }
-(((((((((*this).params))[static_cast<i64>(0LL)])).variable))->name),(ByteString::must_from_utf8("this"sv)));
+(((((((((*this).params))[static_cast<i64>(0LL)])).variable))->name),(ByteString::from_utf8_without_validation("this"sv)));
 }
 }
 
@@ -1356,7 +1356,7 @@ return (infallible_enum_cast<jakt__prelude__operators::Ordering>((JaktInternal::
 return false;
 }
 NonnullRefPtr<types::CheckedVariable> const first_param_variable = ((((((*this).params))[static_cast<i64>(0LL)])).variable);
-return (((((first_param_variable)->name)) == ((ByteString::must_from_utf8("this"sv)))) && ((first_param_variable)->is_mutable));
+return (((((first_param_variable)->name)) == ((ByteString::from_utf8_without_validation("this"sv)))) && ((first_param_variable)->is_mutable));
 }
 }
 
@@ -1383,7 +1383,7 @@ return ((((*this).generics))->is_specialized_for_types(types));
 parser::ParsedFunction types::CheckedFunction::to_parsed_function() const {
 {
 if ((!(((((*this).parsed_function)).has_value())))){
-utility::panic((ByteString::must_from_utf8("to_parsed_function() called on a synthetic function"sv)));
+utility::panic((ByteString::from_utf8_without_validation("to_parsed_function() called on a synthetic function"sv)));
 }
 return (((*this).parsed_function).value());
 }
@@ -1816,7 +1816,7 @@ break;
 }
 
 }
-return utility::join(ss,(ByteString::must_from_utf8(" -> "sv)));
+return utility::join(ss,(ByteString::from_utf8_without_validation(" -> "sv)));
 }
 }
 
@@ -2068,20 +2068,6 @@ return ((((((((*this).modules))[((((id).module)).id)]))->structures))[((id).id)]
 
 NonnullRefPtr<types::Scope> types::CheckedProgram::get_scope(ids::ScopeId const id) const {
 {
-size_t const max_scope = JaktInternal::checked_sub(((((((((*this).modules))[((((id).module_id)).id)]))->scopes)).size()),static_cast<size_t>(1ULL));
-if ([](size_t const& self, size_t rhs) -> bool {
-{
-return (((infallible_integer_cast<u8>(([](size_t const& self, size_t rhs) -> jakt__prelude__operators::Ordering {
-{
-return (infallible_enum_cast<jakt__prelude__operators::Ordering>((JaktInternal::compare(self,rhs))));
-}
-}
-(self,rhs))))) == (static_cast<u8>(2)));
-}
-}
-(((id).id),max_scope)){
-((((*this).compiler))->panic(__jakt_format((StringView::from_string_literal("scope_id {} does not exist in module"sv)),id)));
-}
 return ((((((((*this).modules))[((((id).module_id)).id)]))->scopes))[((id).id)]);
 }
 }
@@ -2462,7 +2448,7 @@ return JaktInternal::ExplicitValue(true);
 };/*case end*/
 case 24 /* Struct */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Struct;ids::StructId const& struct_id = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(((TRY((((*this).find_struct_in_prelude((ByteString::must_from_utf8("String"sv))))))).equals(struct_id)));
+return JaktInternal::ExplicitValue(((TRY((((*this).find_struct_in_prelude((ByteString::from_utf8_without_validation("String"sv))))))).equals(struct_id)));
 };/*case end*/
 default: {
 return JaktInternal::ExplicitValue(false);
@@ -2804,7 +2790,7 @@ return utility::IterationDecision<bool>::Continue();
 ErrorOr<types::StructOrEnumId> types::CheckedProgram::find_reflected_primitive(ByteString const primitive) const {
 {
 ids::ScopeId const scope_id = ((*this).prelude_scope_id());
-JaktInternal::Optional<JaktInternal::Tuple<ids::ScopeId,bool>> const maybe_namespace = TRY((((*this).find_namespace_in_scope(scope_id,(ByteString::must_from_utf8("Reflect"sv)),false,true,JaktInternal::OptionalNone()))));
+JaktInternal::Optional<JaktInternal::Tuple<ids::ScopeId,bool>> const maybe_namespace = TRY((((*this).find_namespace_in_scope(scope_id,(ByteString::from_utf8_without_validation("Reflect"sv)),false,true,JaktInternal::OptionalNone()))));
 if ((!(((maybe_namespace).has_value())))){
 ((((*this).compiler))->panic(__jakt_format((StringView::from_string_literal("internal error: builtin namespace 'Reflect' not found"sv)))));
 }
@@ -3020,7 +3006,7 @@ return (Tuple{result_ids, (result_scope.value())});
 
 ErrorOr<JaktInternal::Optional<ids::StructId>> types::CheckedProgram::check_and_extract_weak_ptr(ids::StructId const struct_id,JaktInternal::DynamicArray<ids::TypeId> const args) const {
 {
-ids::StructId const weak_ptr_struct_id = TRY((((*this).find_struct_in_prelude((ByteString::must_from_utf8("WeakPtr"sv))))));
+ids::StructId const weak_ptr_struct_id = TRY((((*this).find_struct_in_prelude((ByteString::from_utf8_without_validation("WeakPtr"sv))))));
 if (((struct_id).equals(weak_ptr_struct_id))){
 if (((((args).size())) != (static_cast<size_t>(1ULL)))){
 ((((*this).compiler))->panic(__jakt_format((StringView::from_string_literal("Internal error: Generic type is WeakPtr but there are not exactly 1 type parameter. There are {} parameters."sv)),((args).size()))));
@@ -3047,10 +3033,10 @@ return ((((({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<ByteString,ErrorOr<ByteString>>{
 auto __jakt_enum_value = (((((type)->common.init_common.qualifiers)).is_immutable));
 if (__jakt_enum_value == true) {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("const "sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("const "sv)));
 }
 else if (__jakt_enum_value == false) {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8(""sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation(""sv)));
 }
 VERIFY_NOT_REACHED();
 }());
@@ -3066,10 +3052,10 @@ return JaktInternal::ExplicitValue(((__jakt_format((StringView::from_string_lite
 auto&& __jakt_match_variant = *type;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 18 /* TypeVariable */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("var "sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("var "sv)));
 };/*case end*/
 default: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8(""sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation(""sv)));
 };/*case end*/
 }/*switch end*/
 }()
@@ -3080,7 +3066,7 @@ return JaktInternal::ExplicitValue((ByteString::must_from_utf8(""sv)));
 }))));
 }
 else {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8(""sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation(""sv)));
 }
 }());
     if (_jakt_value.is_return())
@@ -3091,58 +3077,58 @@ return JaktInternal::ExplicitValue((ByteString::must_from_utf8(""sv)));
 auto&& __jakt_match_variant = *type;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 17 /* Never */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("never"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("never"sv)));
 };/*case end*/
 case 10 /* F32 */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("f32"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("f32"sv)));
 };/*case end*/
 case 11 /* F64 */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("f64"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("f64"sv)));
 };/*case end*/
 case 6 /* I8 */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("i8"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("i8"sv)));
 };/*case end*/
 case 7 /* I16 */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("i16"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("i16"sv)));
 };/*case end*/
 case 8 /* I32 */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("i32"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("i32"sv)));
 };/*case end*/
 case 9 /* I64 */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("i64"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("i64"sv)));
 };/*case end*/
 case 2 /* U8 */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("u8"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("u8"sv)));
 };/*case end*/
 case 3 /* U16 */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("u16"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("u16"sv)));
 };/*case end*/
 case 4 /* U32 */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("u32"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("u32"sv)));
 };/*case end*/
 case 5 /* U64 */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("u64"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("u64"sv)));
 };/*case end*/
 case 12 /* Usize */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("usize"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("usize"sv)));
 };/*case end*/
 case 14 /* CChar */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("c_char"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("c_char"sv)));
 };/*case end*/
 case 15 /* CInt */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("c_int"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("c_int"sv)));
 };/*case end*/
 case 1 /* Bool */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("bool"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("bool"sv)));
 };/*case end*/
 case 0 /* Void */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("void"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("void"sv)));
 };/*case end*/
 case 16 /* Unknown */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("unknown"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("unknown"sv)));
 };/*case end*/
 case 13 /* JaktString */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("builtin(String)"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("builtin(String)"sv)));
 };/*case end*/
 case 19 /* Dependent */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Dependent;ids::TypeId const& namespace_type = __jakt_match_value.namespace_type;
@@ -3154,7 +3140,7 @@ auto&& __jakt_match_value = __jakt_match_variant.as.Trait;ids::TraitId const& id
 return JaktInternal::ExplicitValue(((((*this).get_trait(id)))->name));
 };/*case end*/
 case 31 /* Self */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("Self"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("Self"sv)));
 };/*case end*/
 case 30 /* Function */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Function;JaktInternal::DynamicArray<ids::TypeId> const& params = __jakt_match_value.params;
@@ -3177,7 +3163,7 @@ ids::TypeId x = (_magic_value.value());
 }
 
 ByteString const return_type = TRY((((*this).type_name(return_type_id,debug_mode))));
-__jakt_var_140 = __jakt_format((StringView::from_string_literal("fn({}) -> {}"sv)),utility::join(param_names,(ByteString::must_from_utf8(", "sv))),return_type); goto __jakt_label_134;
+__jakt_var_140 = __jakt_format((StringView::from_string_literal("fn({}) -> {}"sv)),utility::join(param_names,(ByteString::from_utf8_without_validation(", "sv))),return_type); goto __jakt_label_134;
 
 }
 __jakt_label_134:; __jakt_var_140.release_value(); }));
@@ -3200,7 +3186,7 @@ ByteString output = __jakt_format((StringView::from_string_literal("enum {}"sv))
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8("<"sv)));
+(output,(ByteString::from_utf8_without_validation("<"sv)));
 bool first = true;
 {
 JaktInternal::ArrayIterator<ids::TypeId> _magic = ((args).iterator());
@@ -3217,7 +3203,7 @@ if ((!(first))){
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8(", "sv)));
+(output,(ByteString::from_utf8_without_validation(", "sv)));
 }
 else {
 (first = false);
@@ -3239,7 +3225,7 @@ else {
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8(">"sv)));
+(output,(ByteString::from_utf8_without_validation(">"sv)));
 __jakt_var_141 = output; goto __jakt_label_135;
 
 }
@@ -3255,7 +3241,7 @@ ByteString output = __jakt_format((StringView::from_string_literal("trait {}"sv)
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8("<"sv)));
+(output,(ByteString::from_utf8_without_validation("<"sv)));
 bool first = true;
 {
 JaktInternal::ArrayIterator<ids::TypeId> _magic = ((args).iterator());
@@ -3272,7 +3258,7 @@ if ((!(first))){
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8(", "sv)));
+(output,(ByteString::from_utf8_without_validation(", "sv)));
 }
 else {
 (first = false);
@@ -3294,7 +3280,7 @@ else {
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8(">"sv)));
+(output,(ByteString::from_utf8_without_validation(">"sv)));
 __jakt_var_142 = output; goto __jakt_label_136;
 
 }
@@ -3304,14 +3290,14 @@ case 20 /* GenericInstance */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.GenericInstance;ids::StructId const& id = __jakt_match_value.id;
 JaktInternal::DynamicArray<ids::TypeId> const& args = __jakt_match_value.args;
 return JaktInternal::ExplicitValue(({ Optional<ByteString> __jakt_var_143; {
-ids::StructId const array_struct_id = TRY((((*this).find_struct_in_prelude((ByteString::must_from_utf8("Array"sv))))));
-ids::StructId const dictionary_struct_id = TRY((((*this).find_struct_in_prelude((ByteString::must_from_utf8("Dictionary"sv))))));
-ids::StructId const optional_struct_id = TRY((((*this).find_struct_in_prelude((ByteString::must_from_utf8("Optional"sv))))));
-ids::StructId const range_struct_id = TRY((((*this).find_struct_in_prelude((ByteString::must_from_utf8("Range"sv))))));
-ids::StructId const set_struct_id = TRY((((*this).find_struct_in_prelude((ByteString::must_from_utf8("Set"sv))))));
-ids::StructId const tuple_struct_id = TRY((((*this).find_struct_in_prelude((ByteString::must_from_utf8("Tuple"sv))))));
-ids::StructId const weak_ptr_struct_id = TRY((((*this).find_struct_in_prelude((ByteString::must_from_utf8("WeakPtr"sv))))));
-ByteString output = (ByteString::must_from_utf8(""sv));
+ids::StructId const array_struct_id = TRY((((*this).find_struct_in_prelude((ByteString::from_utf8_without_validation("Array"sv))))));
+ids::StructId const dictionary_struct_id = TRY((((*this).find_struct_in_prelude((ByteString::from_utf8_without_validation("Dictionary"sv))))));
+ids::StructId const optional_struct_id = TRY((((*this).find_struct_in_prelude((ByteString::from_utf8_without_validation("Optional"sv))))));
+ids::StructId const range_struct_id = TRY((((*this).find_struct_in_prelude((ByteString::from_utf8_without_validation("Range"sv))))));
+ids::StructId const set_struct_id = TRY((((*this).find_struct_in_prelude((ByteString::from_utf8_without_validation("Set"sv))))));
+ids::StructId const tuple_struct_id = TRY((((*this).find_struct_in_prelude((ByteString::from_utf8_without_validation("Tuple"sv))))));
+ids::StructId const weak_ptr_struct_id = TRY((((*this).find_struct_in_prelude((ByteString::from_utf8_without_validation("WeakPtr"sv))))));
+ByteString output = (ByteString::from_utf8_without_validation(""sv));
 if (((id).equals(array_struct_id))){
 (output = __jakt_format((StringView::from_string_literal("[{}]"sv)),TRY((((*this).type_name(((args)[static_cast<i64>(0LL)]),debug_mode))))));
 }
@@ -3328,7 +3314,7 @@ else if (((id).equals(set_struct_id))){
 (output = __jakt_format((StringView::from_string_literal("{{{}}}"sv)),TRY((((*this).type_name(((args)[static_cast<i64>(0LL)]),debug_mode))))));
 }
 else if (((id).equals(tuple_struct_id))){
-(output = (ByteString::must_from_utf8("("sv)));
+(output = (ByteString::from_utf8_without_validation("("sv)));
 bool first = true;
 {
 JaktInternal::ArrayIterator<ids::TypeId> _magic = ((args).iterator());
@@ -3345,7 +3331,7 @@ if ((!(first))){
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8(", "sv)));
+(output,(ByteString::from_utf8_without_validation(", "sv)));
 }
 else {
 (first = false);
@@ -3367,7 +3353,7 @@ else {
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8(")"sv)));
+(output,(ByteString::from_utf8_without_validation(")"sv)));
 }
 else if (((id).equals(weak_ptr_struct_id))){
 (output = __jakt_format((StringView::from_string_literal("weak {}"sv)),TRY((((*this).type_name(((args)[static_cast<i64>(0LL)]),debug_mode))))));
@@ -3380,7 +3366,7 @@ types::CheckedStruct const structure = ((*this).get_struct(id));
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8("<"sv)));
+(output,(ByteString::from_utf8_without_validation("<"sv)));
 bool first = true;
 {
 JaktInternal::ArrayIterator<ids::TypeId> _magic = ((args).iterator());
@@ -3397,7 +3383,7 @@ if ((!(first))){
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8(", "sv)));
+(output,(ByteString::from_utf8_without_validation(", "sv)));
 }
 else {
 (first = false);
@@ -3419,7 +3405,7 @@ else {
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8(">"sv)));
+(output,(ByteString::from_utf8_without_validation(">"sv)));
 }
 
 __jakt_var_143 = output; goto __jakt_label_137;
@@ -3438,7 +3424,7 @@ bool first = true;
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8("<"sv)));
+(output,(ByteString::from_utf8_without_validation("<"sv)));
 {
 JaktInternal::ArrayIterator<ids::TypeId> _magic = ((args).iterator());
 for (;;){
@@ -3454,7 +3440,7 @@ if ((!(first))){
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8(", "sv)));
+(output,(ByteString::from_utf8_without_validation(", "sv)));
 }
 else {
 (first = false);
@@ -3476,7 +3462,7 @@ else {
 (self = ((self) + (rhs)));
 }
 }
-(output,(ByteString::must_from_utf8(">"sv)));
+(output,(ByteString::from_utf8_without_validation(">"sv)));
 __jakt_var_144 = output; goto __jakt_label_138;
 
 }
@@ -3500,7 +3486,7 @@ return JaktInternal::ExplicitValue(__jakt_format((StringView::from_string_litera
 };/*case end*/
 case 32 /* Const */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Const;types::Value const& value = __jakt_match_value.value;
-return JaktInternal::ExplicitValue(TRY((types::comptime_format_impl((ByteString::must_from_utf8("comptime {}"sv)),((DynamicArray<types::Value>::create_with({value}))[(JaktInternal::Range<i64>{static_cast<i64>(0LL),static_cast<i64>(9223372036854775807LL)})]),((*this))))));
+return JaktInternal::ExplicitValue(TRY((types::comptime_format_impl((ByteString::from_utf8_without_validation("comptime {}"sv)),((DynamicArray<types::Value>::create_with({value}))[(JaktInternal::Range<i64>{static_cast<i64>(0LL),static_cast<i64>(9223372036854775807LL)})]),((*this))))));
 };/*case end*/
 default: VERIFY_NOT_REACHED();}/*switch end*/
 }()
@@ -3884,88 +3870,88 @@ return ({
 auto&& __jakt_match_variant = *((*this).impl);
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 0 /* Void */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("void"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("void"sv)));
 };/*case end*/
 case 1 /* Bool */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("bool"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("bool"sv)));
 };/*case end*/
 case 2 /* U8 */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("u8"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("u8"sv)));
 };/*case end*/
 case 3 /* U16 */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("u16"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("u16"sv)));
 };/*case end*/
 case 4 /* U32 */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("u32"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("u32"sv)));
 };/*case end*/
 case 5 /* U64 */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("u64"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("u64"sv)));
 };/*case end*/
 case 6 /* I8 */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("i18"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("i18"sv)));
 };/*case end*/
 case 7 /* I16 */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("i16"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("i16"sv)));
 };/*case end*/
 case 8 /* I32 */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("i32"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("i32"sv)));
 };/*case end*/
 case 9 /* I64 */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("i64"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("i64"sv)));
 };/*case end*/
 case 10 /* F32 */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("f32"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("f32"sv)));
 };/*case end*/
 case 11 /* F64 */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("f64"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("f64"sv)));
 };/*case end*/
 case 12 /* USize */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("usize"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("usize"sv)));
 };/*case end*/
 case 13 /* JaktString */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("String"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("String"sv)));
 };/*case end*/
 case 14 /* StringView */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("StringView"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("StringView"sv)));
 };/*case end*/
 case 15 /* CChar */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("c_char"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("c_char"sv)));
 };/*case end*/
 case 16 /* CInt */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("c_int"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("c_int"sv)));
 };/*case end*/
 case 17 /* Struct */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("struct <T>"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("struct <T>"sv)));
 };/*case end*/
 case 18 /* Class */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("class <T>"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("class <T>"sv)));
 };/*case end*/
 case 19 /* Enum */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("enum <T>"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("enum <T>"sv)));
 };/*case end*/
 case 20 /* JaktArray */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("Array"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("Array"sv)));
 };/*case end*/
 case 21 /* JaktDictionary */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("Dictionary"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("Dictionary"sv)));
 };/*case end*/
 case 22 /* JaktSet */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("Set"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("Set"sv)));
 };/*case end*/
 case 23 /* RawPtr */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("raw <T>"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("raw <T>"sv)));
 };/*case end*/
 case 24 /* OptionalSome */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("Some"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("Some"sv)));
 };/*case end*/
 case 25 /* OptionalNone */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("None"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("None"sv)));
 };/*case end*/
 case 26 /* JaktTuple */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("Tuple"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("Tuple"sv)));
 };/*case end*/
 case 27 /* Function */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("Function"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("Function"sv)));
 };/*case end*/
 default: VERIFY_NOT_REACHED();}/*switch end*/
 }()
@@ -5318,58 +5304,58 @@ return ({
 auto&& __jakt_match_variant = *this;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 0 /* Void */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("Void"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("Void"sv)));
 };/*case end*/
 case 1 /* Bool */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("Bool"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("Bool"sv)));
 };/*case end*/
 case 2 /* U8 */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("U8"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("U8"sv)));
 };/*case end*/
 case 3 /* U16 */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("U16"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("U16"sv)));
 };/*case end*/
 case 4 /* U32 */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("U32"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("U32"sv)));
 };/*case end*/
 case 5 /* U64 */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("U64"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("U64"sv)));
 };/*case end*/
 case 6 /* I8 */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("I8"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("I8"sv)));
 };/*case end*/
 case 7 /* I16 */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("I16"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("I16"sv)));
 };/*case end*/
 case 8 /* I32 */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("I32"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("I32"sv)));
 };/*case end*/
 case 9 /* I64 */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("I64"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("I64"sv)));
 };/*case end*/
 case 10 /* F32 */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("F32"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("F32"sv)));
 };/*case end*/
 case 11 /* F64 */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("F64"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("F64"sv)));
 };/*case end*/
 case 12 /* Usize */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("Usize"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("Usize"sv)));
 };/*case end*/
 case 13 /* JaktString */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("JaktString"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("JaktString"sv)));
 };/*case end*/
 case 14 /* CChar */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("CChar"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("CChar"sv)));
 };/*case end*/
 case 15 /* CInt */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("CInt"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("CInt"sv)));
 };/*case end*/
 case 16 /* Unknown */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("Unknown"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("Unknown"sv)));
 };/*case end*/
 case 17 /* Never */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("Never"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("Never"sv)));
 };/*case end*/
 default: VERIFY_NOT_REACHED();}/*switch end*/
 }()
@@ -6707,103 +6693,103 @@ return ({
 auto&& __jakt_match_variant = *this;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 0 /* Void */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("Void"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("Void"sv)));
 };/*case end*/
 case 1 /* Bool */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("Bool"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("Bool"sv)));
 };/*case end*/
 case 2 /* U8 */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("U8"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("U8"sv)));
 };/*case end*/
 case 3 /* U16 */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("U16"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("U16"sv)));
 };/*case end*/
 case 4 /* U32 */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("U32"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("U32"sv)));
 };/*case end*/
 case 5 /* U64 */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("U64"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("U64"sv)));
 };/*case end*/
 case 6 /* I8 */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("I8"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("I8"sv)));
 };/*case end*/
 case 7 /* I16 */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("I16"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("I16"sv)));
 };/*case end*/
 case 8 /* I32 */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("I32"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("I32"sv)));
 };/*case end*/
 case 9 /* I64 */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("I64"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("I64"sv)));
 };/*case end*/
 case 10 /* F32 */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("F32"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("F32"sv)));
 };/*case end*/
 case 11 /* F64 */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("F64"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("F64"sv)));
 };/*case end*/
 case 12 /* Usize */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("Usize"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("Usize"sv)));
 };/*case end*/
 case 13 /* JaktString */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("JaktString"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("JaktString"sv)));
 };/*case end*/
 case 14 /* CChar */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("CChar"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("CChar"sv)));
 };/*case end*/
 case 15 /* CInt */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("CInt"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("CInt"sv)));
 };/*case end*/
 case 16 /* Unknown */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("Unknown"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("Unknown"sv)));
 };/*case end*/
 case 17 /* Never */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("Never"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("Never"sv)));
 };/*case end*/
 case 18 /* TypeVariable */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("TypeVariable"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("TypeVariable"sv)));
 };/*case end*/
 case 19 /* Dependent */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("Dependent"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("Dependent"sv)));
 };/*case end*/
 case 20 /* GenericInstance */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("GenericInstance"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("GenericInstance"sv)));
 };/*case end*/
 case 21 /* GenericEnumInstance */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("GenericEnumInstance"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("GenericEnumInstance"sv)));
 };/*case end*/
 case 22 /* GenericTraitInstance */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("GenericTraitInstance"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("GenericTraitInstance"sv)));
 };/*case end*/
 case 23 /* GenericResolvedType */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("GenericResolvedType"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("GenericResolvedType"sv)));
 };/*case end*/
 case 24 /* Struct */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("Struct"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("Struct"sv)));
 };/*case end*/
 case 25 /* Enum */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("Enum"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("Enum"sv)));
 };/*case end*/
 case 26 /* RawPtr */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("RawPtr"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("RawPtr"sv)));
 };/*case end*/
 case 27 /* Trait */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("Trait"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("Trait"sv)));
 };/*case end*/
 case 28 /* Reference */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("Reference"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("Reference"sv)));
 };/*case end*/
 case 29 /* MutableReference */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("MutableReference"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("MutableReference"sv)));
 };/*case end*/
 case 30 /* Function */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("Function"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("Function"sv)));
 };/*case end*/
 case 31 /* Self */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("Self"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("Self"sv)));
 };/*case end*/
 case 32 /* Const */: {
-return JaktInternal::ExplicitValue((ByteString::must_from_utf8("Const"sv)));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("Const"sv)));
 };/*case end*/
 default: VERIFY_NOT_REACHED();}/*switch end*/
 }()
@@ -10897,7 +10883,7 @@ auto&& __jakt_match_variant = *type_;
 switch(__jakt_match_variant.__jakt_init_index()) {
 case 10 /* F32 */: {
 {
-utility::todo((ByteString::must_from_utf8("Implement casting f32 to f64"sv)));
+utility::todo((ByteString::from_utf8_without_validation("Implement casting f32 to f64"sv)));
 }
 };/*case end*/
 case 11 /* F64 */: {
@@ -10941,7 +10927,7 @@ return JaktInternal::ExplicitValue((infallible_integer_cast<size_t>((value))));
 case 2 /* Floating */: {
 auto&& __jakt_match_value = __jakt_match_variant.as.Floating;f64 const& value = __jakt_match_value.value;
 {
-utility::panic((ByteString::must_from_utf8("to_usize on a floating point constant"sv)));
+utility::panic((ByteString::from_utf8_without_validation("to_usize on a floating point constant"sv)));
 }
 };/*case end*/
 default: VERIFY_NOT_REACHED();}/*switch end*/
@@ -15884,7 +15870,7 @@ __jakt_label_153:; __jakt_var_159.release_value(); }));
 }
 else {
 {
-utility::panic((ByteString::must_from_utf8("Try block doesn't have a block"sv)));
+utility::panic((ByteString::from_utf8_without_validation("Try block doesn't have a block"sv)));
 }
 }
 }());
@@ -17085,7 +17071,7 @@ case 12 /* USize */: {
 return JaktInternal::ExplicitValue(types::builtin(types::BuiltinType::Usize()));
 };/*case end*/
 case 13 /* JaktString */: {
-return JaktInternal::ExplicitValue((TRY((((((program)))->find_type_in_scope(((((program)))->prelude_scope_id()),(ByteString::must_from_utf8("String"sv)),false,JaktInternal::OptionalNone())))).value()));
+return JaktInternal::ExplicitValue((TRY((((((program)))->find_type_in_scope(((((program)))->prelude_scope_id()),(ByteString::from_utf8_without_validation("String"sv)),false,JaktInternal::OptionalNone())))).value()));
 };/*case end*/
 case 14 /* StringView */: {
 return JaktInternal::ExplicitValue(types::builtin(types::BuiltinType::JaktString()));
@@ -17110,7 +17096,7 @@ return JaktInternal::ExplicitValue(((((program)))->find_or_add_type_id(types::Ty
 };/*case end*/
 default: {
 {
-utility::panic((ByteString::must_from_utf8("Reflected value type not implemented"sv)));
+utility::panic((ByteString::from_utf8_without_validation("Reflected value type not implemented"sv)));
 }
 };/*case end*/
 }/*switch end*/

--- a/bootstrap/stage0/utility.cpp
+++ b/bootstrap/stage0/utility.cpp
@@ -39,7 +39,7 @@ return ((builder).to_string());
 
 ByteString join(JaktInternal::DynamicArray<ByteString> const strings,ByteString const separator) {
 {
-ByteString output = (ByteString::must_from_utf8(""sv));
+ByteString output = (ByteString::from_utf8_without_validation(""sv));
 size_t i = static_cast<size_t>(0ULL);
 {
 JaktInternal::ArrayIterator<ByteString> _magic = ((strings).iterator());

--- a/runtime/jaktlib/prelude/string.jakt
+++ b/runtime/jaktlib/prelude/string.jakt
@@ -11,6 +11,6 @@ type StringView implements(FromStringLiteral) {
 }
 
 type String implements(FromStringLiteral) {
-    [[name=must_from_utf8]]
+    [[name=from_utf8_without_validation]]
     extern fn from_string_literal(anon string: StringView) -> String
 }

--- a/selfhost/types.jakt
+++ b/selfhost/types.jakt
@@ -1965,15 +1965,7 @@ class CheckedProgram {
     public fn get_type(this, anon id: TypeId) -> Type => .modules[id.module.id].types[id.id]
     public fn get_enum(this, anon id: EnumId) -> CheckedEnum => .modules[id.module.id].enums[id.id]
     public fn get_struct(this, anon id: StructId) -> CheckedStruct => .modules[id.module.id].structures[id.id]
-    public fn get_scope(this, anon id: ScopeId) -> Scope {
-        let max_scope = .modules[id.module_id.id].scopes.size() - 1
-        if id.id > max_scope {
-            .compiler.panic(format("scope_id {} does not exist in module", id))
-        }
-
-        return .modules[id.module_id.id].scopes[id.id]
-    }
-
+    public fn get_scope(this, anon id: ScopeId) -> Scope => .modules[id.module_id.id].scopes[id.id]
     public fn get_trait(this, anon id: TraitId) -> CheckedTrait => .modules[id.module.id].traits[id.id]
 
     public fn prelude_scope_id(this) -> ScopeId => ScopeId(module_id: ModuleId(id: 0), id: 0)


### PR DESCRIPTION
Together with https://github.com/SerenityOS/serenity/pull/22377 these changes make compiling the compiler with itself in debug mode ~44% faster.

```
$ time build/bin/jakt_before -S selfhost/main.jakt 
real    0m23,247s
user    0m22,917s
sys    0m0,212s

$ time build/bin/jakt_after -S selfhost/main.jakt 
real    0m16,072s
user    0m15,875s
sys    0m0,192s
```