### PR TITLE
selfhost: Use default initializers in a lot more places

### DIFF
--- a/selfhost/cpp_import/clang.jakt
+++ b/selfhost/cpp_import/clang.jakt
@@ -537,8 +537,6 @@ class CppImportProcessor {
                     generics: FunctionGenerics(
                         base_scope_id: scope_id
                         base_params: function_params
-                        params: []
-                        specializations: []
                     )
                     block: CheckedBlock(
                         statements: []
@@ -1536,7 +1534,6 @@ class CppImportProcessor {
                 base_scope_id: function_scope
                 base_params: params
                 params: .function_generic_parameters_from(template_parameters?.params)
-                specializations: []
             )
             block: CheckedBlock(
                 statements: []
@@ -2118,7 +2115,6 @@ class CppImportProcessor {
                     base_scope_id: function_scope
                     base_params: params
                     params: generic_params
-                    specializations: []
                 )
                 block: CheckedBlock(
                     statements: []

--- a/selfhost/cpp_import/clang.jakt
+++ b/selfhost/cpp_import/clang.jakt
@@ -539,11 +539,8 @@ class CppImportProcessor {
                         base_params: function_params
                     )
                     block: CheckedBlock(
-                        statements: []
                         scope_id
                         control_flow: BlockControlFlow::MayReturn
-                        yielded_type: None
-                        yielded_none: false
                     )
                     can_throw: false
                     type: FunctionType::Normal
@@ -1536,11 +1533,8 @@ class CppImportProcessor {
                 params: .function_generic_parameters_from(template_parameters?.params)
             )
             block: CheckedBlock(
-                statements: []
                 scope_id: function_scope
                 control_flow: BlockControlFlow::MayReturn
-                yielded_type: None
-                yielded_none: false
             )
             can_throw: function_throws
             type: match kind {
@@ -2117,11 +2111,8 @@ class CppImportProcessor {
                     params: generic_params
                 )
                 block: CheckedBlock(
-                    statements: []
                     scope_id: function_scope
                     control_flow: BlockControlFlow::MayReturn
-                    yielded_type: None
-                    yielded_none: false
                 )
                 can_throw: is_class
                 type: FunctionType::ImplicitConstructor

--- a/selfhost/cpp_import/clang.jakt
+++ b/selfhost/cpp_import/clang.jakt
@@ -1665,12 +1665,8 @@ class CppImportProcessor {
             let the_enum = CheckedEnum(
                 name
                 name_span: empty_span()
-                generic_parameters: []
-                variants: []
-                fields: []
                 scope_id: enum_scope
                 definition_linkage: DefinitionLinkage::External
-                trait_implementations: [:]
                 record_type: RecordType::ValueEnum(
                     underlying_type: ParsedType::Empty
                     variants: []
@@ -1717,12 +1713,9 @@ class CppImportProcessor {
         module.enums[enum_id.id] = CheckedEnum(
             name
             name_span: empty_span()
-            generic_parameters: []
             variants
-            fields: []
             scope_id: enum_scope
             definition_linkage: DefinitionLinkage::External
-            trait_implementations: [:]
             record_type: RecordType::ValueEnum(
                 underlying_type: ParsedType::Empty
                 variants: []
@@ -1901,10 +1894,8 @@ class CppImportProcessor {
                 name_span: empty_span()
                 generic_parameters: generic_parameters ?? empty_parameters
                 generic_parameter_defaults
-                fields: []
                 scope_id: struct_scope
                 definition_linkage: DefinitionLinkage::External
-                trait_implementations: [:]
                 record_type: RecordType::Struct(fields: [], super_type: None)
                 type_id: struct_type_id
                 super_struct_id: None

--- a/selfhost/cpp_import/libcpp.jakt
+++ b/selfhost/cpp_import/libcpp.jakt
@@ -321,11 +321,8 @@ fn process_cpp_declaration(
                     base_params: params
                 )
                 block: CheckedBlock(
-                    statements: []
                     scope_id: function_scope
                     control_flow: BlockControlFlow::MayReturn
-                    yielded_type: None
-                    yielded_none: false
                 )
                 can_throw: false // FIXME: ErrorOr
                 type: match fd.is_constructor() {

--- a/selfhost/cpp_import/libcpp.jakt
+++ b/selfhost/cpp_import/libcpp.jakt
@@ -319,8 +319,6 @@ fn process_cpp_declaration(
                 generics: FunctionGenerics(
                     base_scope_id: function_scope
                     base_params: params
-                    params: []
-                    specializations: []
                 )
                 block: CheckedBlock(
                     statements: []

--- a/selfhost/cpp_import/libcpp.jakt
+++ b/selfhost/cpp_import/libcpp.jakt
@@ -443,11 +443,9 @@ fn process_cpp_declaration(
             mut struct_ = CheckedStruct(
                 name: sd.full_name()
                 name_span: span
-                generic_parameters: []
                 fields
                 scope_id: struct_scope
                 definition_linkage: DefinitionLinkage::External
-                trait_implementations: [:]
                 record_type: RecordType::Struct(fields: [], super_type: None)
                 type_id: struct_type_id
                 super_struct_id: None

--- a/selfhost/formatter.jakt
+++ b/selfhost/formatter.jakt
@@ -112,8 +112,8 @@ enum State {
 struct FormattedToken {
     token: Token
     indent: usize
-    trailing_trivia: [u8]
-    preceding_trivia: [u8]
+    trailing_trivia: [u8] = []
+    preceding_trivia: [u8] = []
 
     fn debug_text(this) throws -> String => match .token {
         Identifier(name) => format("Identifier: {}", name)
@@ -293,12 +293,10 @@ struct Stage0 {
         return FormattedToken(
             token
             indent: .indent
-            trailing_trivia: []
-            preceding_trivia: []
         )
     }
 
-    private fn formatted_token(this, anon token: Token, trailing_trivia: [u8], preceding_trivia: [u8]) -> FormattedToken {
+    private fn formatted_token(this, anon token: Token, trailing_trivia: [u8] = [], preceding_trivia: [u8] = []) -> FormattedToken {
         return FormattedToken(
             token
             indent: .indent
@@ -405,7 +403,7 @@ struct Stage0 {
                 trailing_trivia.push(b' ')
             }
 
-            yield .formatted_token(token, trailing_trivia, preceding_trivia: [])
+            yield .formatted_token(token, trailing_trivia)
         }
         else => {
             .pop_state()
@@ -428,7 +426,7 @@ struct Stage0 {
                 }
                 else => {}
             }
-            yield .formatted_token(token, trailing_trivia: [b' '], preceding_trivia: [])
+            yield .formatted_token(token, trailing_trivia: [b' '])
         }
         Identifier(name) => {
             if name == "type" and .peek() is Identifier {
@@ -439,7 +437,7 @@ struct Stage0 {
                     generic_nesting: 0uz
                     is_extern
                 ))
-                return .formatted_token(token, trailing_trivia: [b' '], preceding_trivia: [])
+                return .formatted_token(token, trailing_trivia: [b' '])
             }
             yield .formatted_token(token)
         }
@@ -457,7 +455,7 @@ struct Stage0 {
                 trailing_trivia.push(b' ')
             }
 
-            yield .formatted_token(token, trailing_trivia, preceding_trivia: [])
+            yield .formatted_token(token, trailing_trivia)
         }
         LSquare => {
             .replace_state(State::Toplevel(
@@ -517,7 +515,7 @@ struct Stage0 {
                 open_squares
                 is_extern
             ))
-            yield .formatted_token(token, trailing_trivia: [], preceding_trivia: [b' '])
+            yield .formatted_token(token, preceding_trivia: [b' '])
         }
         RCurly => {
             if open_curlies == 0 {
@@ -544,20 +542,20 @@ struct Stage0 {
                 seen_start: false
             ))
 
-            yield .formatted_token(token, trailing_trivia: [b' '], preceding_trivia: [])
+            yield .formatted_token(token, trailing_trivia: [b' '])
         }
         Import => {
             .push_state(State::Import(
                 is_extern: .peek() is Extern
             ))
-            yield .formatted_token(token, trailing_trivia: [b' '], preceding_trivia: [])
+            yield .formatted_token(token, trailing_trivia: [b' '])
         }
-        Public | Private | Virtual | Override | Boxed | Unsafe => .formatted_token(token, trailing_trivia: [b' '], preceding_trivia: [])
+        Public | Private | Virtual | Override | Boxed | Unsafe => .formatted_token(token, trailing_trivia: [b' '])
         Restricted => {
             .push_state(State::RestrictionList)
             yield .formatted_token(token)
         }
-        Comma => .formatted_token(token, trailing_trivia: [b' '], preceding_trivia: [])
+        Comma => .formatted_token(token, trailing_trivia: [b' '])
         Equal => {
             .push_state(State::StatementContext(
                 open_parens: 0
@@ -579,7 +577,7 @@ struct Stage0 {
         is_extern: bool
         token: Token
     ) throws -> FormattedToken? => match token {
-        Extern | As => .formatted_token(token, trailing_trivia: [b' '], preceding_trivia: [])
+        Extern | As => .formatted_token(token, trailing_trivia: [b' '])
         Identifier => {
             if not is_extern and .peek() is LParen {
                 return .formatted_token(token)
@@ -593,7 +591,7 @@ struct Stage0 {
                 .pop_state()
             }
 
-            yield .formatted_token(token, trailing_trivia: [b' '], preceding_trivia: [])
+            yield .formatted_token(token, trailing_trivia: [b' '])
         }
         LParen => .formatted_token(token)
         LCurly => {
@@ -621,11 +619,10 @@ struct Stage0 {
                     Eol => []
                     else => [b' ']
                 }
-                preceding_trivia: []
             )
         }
         ColonColon => .formatted_token(token)
-        else => .formatted_token(token, trailing_trivia: [b' '], preceding_trivia: [])
+        else => .formatted_token(token, trailing_trivia: [b' '])
     }
 
     private fn next_in_implements_context(
@@ -651,7 +648,7 @@ struct Stage0 {
         }
         Comma => {
             .replace_state(State::ImportList(emitted_comma: true))
-            yield .formatted_token(token, trailing_trivia: [b' '], preceding_trivia: [])
+            yield .formatted_token(token, trailing_trivia: [b' '])
         }
         Eol => {
             // Drop Eols, we'll regenerate them if needed.
@@ -754,12 +751,12 @@ struct Stage0 {
 
             if .peek() is Implements {
                 .push_state(State::Implements)
-                return .formatted_token(token, trailing_trivia: [b' '], preceding_trivia: [])
+                return .formatted_token(token, trailing_trivia: [b' '])
             }
 
             yield .formatted_token(token)
         }
-        Comma => .formatted_token(token, trailing_trivia: [b' '], preceding_trivia: [])
+        Comma => .formatted_token(token, trailing_trivia: [b' '])
         RCurly => {
             .pop_state()
             yield .formatted_token(token)
@@ -768,12 +765,12 @@ struct Stage0 {
             .pop_state()
             yield .formatted_token(token)
         }
-        Public | Private | Virtual | Override => .formatted_token(token, trailing_trivia: [b' '], preceding_trivia: [])
+        Public | Private | Virtual | Override => .formatted_token(token, trailing_trivia: [b' '])
         Restricted => {
             .push_state(State::RestrictionList)
             yield .formatted_token(token)
         }
-        Requires => .formatted_token(token, trailing_trivia: [], preceding_trivia: [b' '])
+        Requires => .formatted_token(token, preceding_trivia: [b' '])
         else => .formatted_token(token)
     }
 
@@ -790,7 +787,6 @@ struct Stage0 {
 
                 yield .formatted_token(
                     token
-                    trailing_trivia: []
                     preceding_trivia: match .peek(offset: -1) {
                         Eol | LCurly => []
                         else => [b' ']
@@ -813,10 +809,10 @@ struct Stage0 {
                     preceding_trivia: [b' ']
                 )
             }
-            Colon => .formatted_token(token, trailing_trivia: [b' '], preceding_trivia: [])
+            Colon => .formatted_token(token, trailing_trivia: [b' '])
             Equal => .formatted_token(token, trailing_trivia: [b' '], preceding_trivia: [b' '])
             Identifier => .formatted_token(token)
-            else => .formatted_token(token, trailing_trivia: [b' '], preceding_trivia: [])
+            else => .formatted_token(token, trailing_trivia: [b' '])
         }
         Function(arrow, indented) => match token {
             FatArrow => {
@@ -876,7 +872,6 @@ struct Stage0 {
                     Throws => [b' ']
                     else => []
                 }
-                preceding_trivia: []
             )
             LCurly => {
                 .push_state(State::StatementContext(
@@ -889,7 +884,7 @@ struct Stage0 {
                     expression_mode: ExpressionMode::OutsideExpression
                     dedents_on_open_curly: 0
                 ))
-                yield .formatted_token(token, trailing_trivia: [], preceding_trivia: [b' '])
+                yield .formatted_token(token, preceding_trivia: [b' '])
             }
             RCurly => {
                 .pop_state()
@@ -948,7 +943,7 @@ struct Stage0 {
             .push_state(State::VariableDeclaration(
                 open_parens: 0
             ))
-            yield .formatted_token(token, trailing_trivia: [b' '], preceding_trivia: [])
+            yield .formatted_token(token, trailing_trivia: [b' '])
         }
         Mut => {
             .replace_state(State::StatementContext(
@@ -967,7 +962,7 @@ struct Stage0 {
                     open_parens: 0
                 ))
             }
-            yield .formatted_token(token, trailing_trivia: [b' '], preceding_trivia: [])
+            yield .formatted_token(token, trailing_trivia: [b' '])
         }
         Match | For | While | If | Try | Loop | Guard | Defer => {
             let added_indent = match token {
@@ -993,7 +988,7 @@ struct Stage0 {
             ))
             indent_change += (added_indent as! i64)
 
-            yield .formatted_token(token, trailing_trivia: [b' '], preceding_trivia: [])
+            yield .formatted_token(token, trailing_trivia: [b' '])
         }
         Catch | Else => {
             .replace_state(State::StatementContext(
@@ -1090,7 +1085,7 @@ struct Stage0 {
 
             yield match .peek() {
                 Eol => .formatted_token(token)
-                else => .formatted_token(token, trailing_trivia: [b' '], preceding_trivia: [])
+                else => .formatted_token(token, trailing_trivia: [b' '])
             }
         }
         Return | Throw | Yield => match .peek() {
@@ -1119,7 +1114,7 @@ struct Stage0 {
                     dedents_on_open_curly
                 ))
 
-                yield .formatted_token(token, trailing_trivia: [b' '], preceding_trivia: [])
+                yield .formatted_token(token, trailing_trivia: [b' '])
             }
         }
         FatArrow => {
@@ -1271,7 +1266,6 @@ struct Stage0 {
 
             yield .formatted_token(
                 token
-                trailing_trivia: []
                 preceding_trivia: match .peek(offset: -1) {
                     Eol | LCurly => []
                     else => [b' ']
@@ -1290,10 +1284,10 @@ struct Stage0 {
                 dedents_on_open_curly
             ))
 
-            yield .formatted_token(token, trailing_trivia: [b' '], preceding_trivia: [])
+            yield .formatted_token(token, trailing_trivia: [b' '])
         }
         Sizeof => {
-            yield .formatted_token(token, trailing_trivia: [b' '], preceding_trivia: [])
+            yield .formatted_token(token, trailing_trivia: [b' '])
         }
         Colon => {
             .replace_state(State::StatementContext(
@@ -1313,7 +1307,6 @@ struct Stage0 {
                     RSquare => []
                     else => [b' ']
                 }
-                preceding_trivia: []
             )
         }
         // Shared unary and binary ops
@@ -1401,7 +1394,7 @@ struct Stage0 {
             preceding_trivia: [b' ']
         )
         QuestionMark | ExclamationPoint => match .peek(offset: -1) {
-            As => .formatted_token(token, trailing_trivia: [b' '], preceding_trivia: [])
+            As => .formatted_token(token, trailing_trivia: [b' '])
             else => .formatted_token(token)
         }
         Identifier | Number => {
@@ -1418,7 +1411,7 @@ struct Stage0 {
                     expression_mode: ExpressionMode::InExpression
                     dedents_on_open_curly
                 ))
-                return .formatted_token(token: Token::Comma(token.span()), trailing_trivia: [b' '], preceding_trivia: [])
+                return .formatted_token(token: Token::Comma(token.span()), trailing_trivia: [b' '])
             }
             .replace_state(State::StatementContext(
                 open_parens
@@ -1499,7 +1492,7 @@ struct Stage0 {
                 }
             }
 
-            yield .formatted_token(token, trailing_trivia: [b' '], preceding_trivia: [])
+            yield .formatted_token(token, trailing_trivia: [b' '])
         }
         Raw => {
             .replace_state(State::StatementContext(
@@ -1512,7 +1505,7 @@ struct Stage0 {
                 expression_mode: ExpressionMode::AtExpressionStart
                 dedents_on_open_curly
             ))
-            yield .formatted_token(token, trailing_trivia: [b' '], preceding_trivia: [])
+            yield .formatted_token(token, trailing_trivia: [b' '])
         }
         Reflect => {
             .replace_state(State::TypeContext(
@@ -1527,7 +1520,6 @@ struct Stage0 {
                 token
                 indent: .indent
                 trailing_trivia: [b' ']
-                preceding_trivia: []
             )
         }
         else => {
@@ -1581,7 +1573,7 @@ struct Stage0 {
                 seen_start: false
             ))
 
-            yield .formatted_token(token, trailing_trivia: [b' '], preceding_trivia: [])
+            yield .formatted_token(token, trailing_trivia: [b' '])
         }
         else => .formatted_token(token)
     }
@@ -1599,7 +1591,7 @@ struct Stage0 {
                 open_angles: 0
                 seen_start: false
             ))
-            yield .formatted_token(token, trailing_trivia: [b' '], preceding_trivia: [])
+            yield .formatted_token(token, trailing_trivia: [b' '])
         }
         LParen => {
             .replace_state(State::VariableDeclaration(
@@ -1622,7 +1614,7 @@ struct Stage0 {
             .pop_state()
             yield .formatted_token(token, trailing_trivia: [b' '], preceding_trivia: [b' '])
         }
-        Comma => .formatted_token(token, trailing_trivia: [b' '], preceding_trivia: [])
+        Comma => .formatted_token(token, trailing_trivia: [b' '])
         else => .formatted_token(token)
     }
 
@@ -1638,11 +1630,11 @@ struct Stage0 {
                 open_angles: 0
                 seen_start: false
             ))
-            yield .formatted_token(token, trailing_trivia: [b' '], preceding_trivia: [])
+            yield .formatted_token(token, trailing_trivia: [b' '])
         }
         RParen => {
             .pop_state()
-            yield .formatted_token(token, trailing_trivia: [b' '], preceding_trivia: [])
+            yield .formatted_token(token, trailing_trivia: [b' '])
         }
         else => .formatted_token(token)
     }
@@ -1652,7 +1644,7 @@ struct Stage0 {
         open_parens: usize
         token: Token
     ) throws -> FormattedToken? => match token {
-        Anon | Mut => .formatted_token(token, trailing_trivia: [b' '], preceding_trivia: [])
+        Anon | Mut => .formatted_token(token, trailing_trivia: [b' '])
         Colon => {
             .push_state(State::TypeContext(
                 open_parens: 0
@@ -1662,9 +1654,9 @@ struct Stage0 {
                 seen_start: false
             ))
 
-            yield .formatted_token(token, trailing_trivia: [b' '], preceding_trivia: [])
+            yield .formatted_token(token, trailing_trivia: [b' '])
         }
-        Comma => .formatted_token(token, trailing_trivia: [b' '], preceding_trivia: [])
+        Comma => .formatted_token(token, trailing_trivia: [b' '])
         Equal => {
             .push_state(State::StatementContext(
                 open_parens: 0
@@ -1891,7 +1883,7 @@ struct Stage0 {
                 open_angles
                 seen_start: true
             ))
-            yield .formatted_token(token, trailing_trivia: [b' '], preceding_trivia: [])
+            yield .formatted_token(token, trailing_trivia: [b' '])
         }
         Ampersand => {
             .replace_state(State::TypeContext(
@@ -1931,7 +1923,7 @@ struct Stage0 {
                 seen_start: false
             ))
 
-            yield .formatted_token(token, trailing_trivia: [b' '], preceding_trivia: [])
+            yield .formatted_token(token, trailing_trivia: [b' '])
         }
         Identifier => {
             .replace_state(State::TypeContext(
@@ -1943,7 +1935,7 @@ struct Stage0 {
             ))
             yield .formatted_token(token)
         }
-        Weak => .formatted_token(token, trailing_trivia: [b' '], preceding_trivia: [])
+        Weak => .formatted_token(token, trailing_trivia: [b' '])
         Equal | Arrow | FatArrow => {
             .pop_state()
             .index--
@@ -1961,7 +1953,7 @@ struct Stage0 {
             yield .formatted_token(token)
         }
         Comma | Mut => {
-            yield .formatted_token(token, trailing_trivia: [b' '], preceding_trivia: [])
+            yield .formatted_token(token, trailing_trivia: [b' '])
         }
         else => {
             yield .formatted_token(token)
@@ -2026,7 +2018,6 @@ struct Stage0 {
                     Throws => [b' ']
                     else => []
                 }
-                preceding_trivia: []
             )
         }
         Throws => .formatted_token(token)
@@ -2156,7 +2147,7 @@ struct Stage0 {
             eprintln()
             eprintln(
                 "Token: {} -- Indent: {}",
-                FormattedToken(token, indent: 0, trailing_trivia: [], preceding_trivia: []).debug_text(),
+                FormattedToken(token, indent: 0).debug_text(),
                 .indent
             )
             for state in .states {
@@ -2217,33 +2208,23 @@ struct ReflowState {
 
 struct Formatter implements(ThrowingIterable<[FormattedToken]>) {
     token_provider: Stage0
-    current_line: [ReflowState]
-    current_line_length: usize
     max_allowed_line_length: usize
-    breakable_points_in_current_line: [BreakablePoint]
-    tokens_to_reflow: [ReflowState]
-    replace_commas_in_enclosure: [Token?]
-    enclosures_to_ignore: usize
-    in_condition_expr: bool
-    in_condition_expr_indented: bool
-    logical_break_indent: usize?
-    empty_line_count: usize
+    current_line: [ReflowState] = []
+    current_line_length: usize = 0
+    breakable_points_in_current_line: [BreakablePoint] = []
+    tokens_to_reflow: [ReflowState] = []
+    replace_commas_in_enclosure: [Token?] = []
+    enclosures_to_ignore: usize = 0
+    in_condition_expr: bool = false
+    in_condition_expr_indented: bool = false
+    logical_break_indent: usize? = None
+    empty_line_count: usize = 0
 
     fn for_tokens(tokens: [Token], debug: bool = false, max_allowed_line_length: usize = 120uz) throws -> Formatter {
         let none: Token? = None
         return Formatter(
             token_provider: Stage0::for_tokens(tokens, debug)
-            current_line: []
-            current_line_length: 0
             max_allowed_line_length
-            breakable_points_in_current_line: []
-            tokens_to_reflow: []
-            replace_commas_in_enclosure: [none]
-            enclosures_to_ignore: 0
-            in_condition_expr: false
-            in_condition_expr_indented: false
-            logical_break_indent: None
-            empty_line_count: 0
         )
     }
 
@@ -2548,8 +2529,6 @@ struct Formatter implements(ThrowingIterable<[FormattedToken]>) {
                         let new_token = FormattedToken(
                             token: newline
                             indent: .logical_break_indent!
-                            trailing_trivia: []
-                            preceding_trivia: []
                         )
                         .current_line.push(ReflowState(
                             token: new_token
@@ -2601,8 +2580,6 @@ struct Formatter implements(ThrowingIterable<[FormattedToken]>) {
                             token: FormattedToken(
                                 token: newline
                                 indent: maybe_next_underlying_token!.indent
-                                trailing_trivia: []
-                                preceding_trivia: []
                             )
                             state: final_state
                             enclosures_to_ignore: .enclosures_to_ignore

--- a/selfhost/interpreter.jakt
+++ b/selfhost/interpreter.jakt
@@ -550,11 +550,9 @@ fn value_to_checked_expression(anon this_value: Value, anon mut interpreter: Int
             namespace_
             name
             args
-            type_args: []
             function_id: constructor
             return_type: struct_.type_id
             callee_throws: callee.can_throw
-            external_name: None
         )
 
         yield CheckedExpression::Call(
@@ -602,11 +600,9 @@ fn value_to_checked_expression(anon this_value: Value, anon mut interpreter: Int
             namespace_
             name: callee.name
             args
-            type_args: []
             function_id: constructor
             return_type: enum_.type_id
             callee_throws: callee.can_throw
-            external_name: None
         )
 
         yield CheckedExpression::Call(
@@ -1279,7 +1275,6 @@ class Interpreter {
                     function_id: call.function_id
                     return_type: call.return_type
                     callee_throws: call.callee_throws
-                    external_name: None
                 )
                 span
                 type_id
@@ -1303,7 +1298,6 @@ class Interpreter {
                     function_id: call.function_id
                     return_type: call.return_type
                     callee_throws: call.callee_throws
-                    external_name: None
                 )
                 span
                 is_optional

--- a/selfhost/interpreter.jakt
+++ b/selfhost/interpreter.jakt
@@ -3708,8 +3708,6 @@ class Interpreter {
                             statements: [else_statement!]
                             scope_id: then_block.scope_id
                             control_flow: BlockControlFlow::MayReturn
-                            yielded_type: None
-                            yielded_none: false
                         ))
                         false => None
                     }

--- a/selfhost/interpreter.jakt
+++ b/selfhost/interpreter.jakt
@@ -774,8 +774,8 @@ enum Deferred {
 class InterpreterScope {
     public bindings: [String:Value]
     public parent: InterpreterScope?
-    public type_bindings: [TypeId:TypeId]
-    public defers: [Deferred]
+    public type_bindings: [TypeId:TypeId] = [:]
+    public defers: [Deferred] = []
 
     public fn create(
         bindings: [String:Value] = [:]
@@ -785,7 +785,6 @@ class InterpreterScope {
         bindings
         parent
         type_bindings
-        defers: []
     )
 
     public fn from_runtime_scope(scope_id: ScopeId, program: CheckedProgram, parent: InterpreterScope? = None) -> InterpreterScope {
@@ -816,8 +815,6 @@ class InterpreterScope {
         return InterpreterScope(
             bindings
             parent
-            type_bindings: [:]
-            defers: []
         )
     }
 

--- a/selfhost/interpreter.jakt
+++ b/selfhost/interpreter.jakt
@@ -731,8 +731,6 @@ fn value_to_checked_expression(anon this_value: Value, anon mut interpreter: Int
             generics: FunctionGenerics(
                 base_scope_id: inherited_scope_id
                 base_params: checked_params
-                params: []
-                specializations: []
             )
             block: new_block
             can_throw

--- a/selfhost/parser.jakt
+++ b/selfhost/parser.jakt
@@ -240,10 +240,10 @@ enum IncludeAction {
 }
 
 struct ParsedExternImport {
-    is_c: bool
-    assigned_namespace: ParsedNamespace
-    before_include: [IncludeAction]
-    after_include: [IncludeAction]
+    is_c: bool = false
+    assigned_namespace: ParsedNamespace = ParsedNamespace()
+    before_include: [IncludeAction] = []
+    after_include: [IncludeAction] = []
     should_auto_import: bool = false
 
     fn get_path(this) -> String => .assigned_namespace.import_path_if_extern!
@@ -256,25 +256,25 @@ struct ParsedExternImport {
 }
 
 struct ParsedAlias {
-    alias_name: ParsedName?
-    target: [ParsedNameWithGenericParameters]
+    alias_name: ParsedName? = None
+    target: [ParsedNameWithGenericParameters] = []
 }
 
 struct ParsedNamespace {
-    name: String?
-    name_span: Span?
-    functions: [ParsedFunction]
-    records: [ParsedRecord]
-    traits: [ParsedTrait]
-    external_trait_implementations: [ParsedExternalTraitImplementation]
-    namespaces: [ParsedNamespace]
-    aliases: [ParsedAlias]
-    module_imports: [ParsedModuleImport]
-    extern_imports: [ParsedExternImport]
-    import_path_if_extern: String?
-    generating_import_extern_before_include: [IncludeAction]
-    generating_import_extern_after_include: [IncludeAction]
-    forall_chunks: [([ParsedGenericParameter], ParsedNamespace)]
+    name: String? = None
+    name_span: Span? = None
+    functions: [ParsedFunction] = []
+    records: [ParsedRecord] = []
+    traits: [ParsedTrait] = []
+    external_trait_implementations: [ParsedExternalTraitImplementation] = []
+    namespaces: [ParsedNamespace] = []
+    aliases: [ParsedAlias] = []
+    module_imports: [ParsedModuleImport] = []
+    extern_imports: [ParsedExternImport] = []
+    import_path_if_extern: String? = None
+    generating_import_extern_before_include: [IncludeAction] = []
+    generating_import_extern_after_include: [IncludeAction] = []
+    forall_chunks: [([ParsedGenericParameter], ParsedNamespace)] = []
     is_generated_code: bool = false
     is_auto_extern_imported: bool = false
 
@@ -504,15 +504,15 @@ enum ParsedTraitRequirements {
 struct ParsedTrait {
     name: String
     name_span: Span
-    generic_parameters: [ParsedGenericParameter]
+    generic_parameters: [ParsedGenericParameter] = []
 
     requirements: ParsedTraitRequirements
 }
 
 struct ParsedExternalTraitImplementation {
     for_type: ParsedType
-    traits: [ParsedNameWithGenericParameters]
-    methods: [ParsedMethod]
+    traits: [ParsedNameWithGenericParameters] = []
+    methods: [ParsedMethod] = []
 }
 
 struct ParsedBlock {
@@ -1750,22 +1750,7 @@ struct Parser {
     }
 
     public fn parse_namespace(mut this, process_only_one_entity: bool = false) throws -> ParsedNamespace {
-        mut parsed_namespace = ParsedNamespace(
-            name: None
-            name_span: None
-            functions: []
-            records: []
-            traits: []
-            external_trait_implementations: []
-            namespaces: []
-            aliases: []
-            module_imports: []
-            extern_imports: []
-            import_path_if_extern: None
-            generating_import_extern_before_include: []
-            generating_import_extern_after_include: []
-            forall_chunks: []
-        )
+        mut parsed_namespace = ParsedNamespace()
 
         mut active_attributes: [ParsedAttribute] = []
         mut saw_an_entity = false
@@ -2412,10 +2397,7 @@ struct Parser {
 
     fn parse_using(mut this) throws -> ParsedAlias {
         // (using) qualified_name [as Ident]
-        mut alias = ParsedAlias(
-            alias_name: None
-            target: []
-        )
+        mut alias = ParsedAlias()
 
         loop {
             match .current() {
@@ -2508,18 +2490,14 @@ struct Parser {
         let trait_list = .parse_trait_list()
         if not trait_list.has_value() {
             .error("Expected non-empty trait list", .current().span())
-            return ParsedExternalTraitImplementation(
-                for_type: type_name
-                traits: []
-                methods: []
-            )
+            return ParsedExternalTraitImplementation(for_type: type_name)
         }
 
         .skip_newlines()
 
         guard .current() is LCurly else {
             .error("Expected ‘{’", .current().span())
-            return ParsedExternalTraitImplementation(for_type: type_name, traits: trait_list!, methods: [])
+            return ParsedExternalTraitImplementation(for_type: type_name, traits: trait_list!)
         }
 
         let (fields, methods, records) = .parse_struct_class_body(
@@ -2672,27 +2650,7 @@ struct Parser {
 
     fn parse_extern_import(mut this, parent: &mut ParsedNamespace) throws -> ParsedExternImport {
         // import extern . [c] "<path>" [as <alias-name>] namespace?
-        mut parsed_import = ParsedExternImport(
-            is_c: false
-            assigned_namespace: ParsedNamespace(
-                name: None
-                name_span: None
-                functions: []
-                records: []
-                traits: []
-                external_trait_implementations: []
-                namespaces: []
-                aliases: []
-                module_imports: []
-                extern_imports: []
-                import_path_if_extern: None
-                generating_import_extern_before_include: []
-                generating_import_extern_after_include: []
-                forall_chunks: []
-            )
-            before_include: []
-            after_include: []
-        )
+        mut parsed_import = ParsedExternImport()
 
         if .current() is Identifier(name, span) {
             .index++

--- a/selfhost/parser.jakt
+++ b/selfhost/parser.jakt
@@ -1462,10 +1462,10 @@ struct ParsedVariable {
 }
 
 struct ParsedCall {
-    namespace_: [String]
-    name: String
-    args: [(String, Span, ParsedExpression)]
-    type_args: [ParsedType]
+    namespace_: [String] = []
+    name: String = ""
+    args: [(String, Span, ParsedExpression)] = []
+    type_args: [ParsedType] = []
 
     fn equals(this, anon rhs_parsed_call: ParsedCall) -> bool {
         if .name != rhs_parsed_call.name {
@@ -6148,12 +6148,7 @@ struct Parser {
     }
 
     fn parse_call(mut this) throws -> ParsedCall? {
-        mut call = ParsedCall(
-            namespace_: []
-            name: ""
-            args: []
-            type_args: []
-        )
+        mut call = ParsedCall()
 
         guard .current() is Identifier(name) else {
             .error("Expected function call", .current().span())

--- a/selfhost/parser.jakt
+++ b/selfhost/parser.jakt
@@ -407,9 +407,9 @@ struct ParsedFunction {
     name: String
     name_span: Span
     visibility: Visibility
-    params: [ParsedParameter]
-    generic_parameters: [ParsedGenericParameter]
-    block: ParsedBlock
+    params: [ParsedParameter] = []
+    generic_parameters: [ParsedGenericParameter] = []
+    block: ParsedBlock = ParsedBlock()
     return_type: ParsedType
     return_type_span: Span
     can_throw: bool
@@ -516,7 +516,7 @@ struct ParsedExternalTraitImplementation {
 }
 
 struct ParsedBlock {
-    stmts: [ParsedStatement]
+    stmts: [ParsedStatement] = []
 
     fn equals(this, anon rhs_block: ParsedBlock) -> bool {
         if .stmts.size() != rhs_block.stmts.size() {
@@ -3956,9 +3956,6 @@ struct Parser {
             name: "",
             name_span: .empty_span(),
             visibility,
-            params: [],
-            generic_parameters: [],
-            block: ParsedBlock(stmts: []),
             return_type: ParsedType::Empty,
             return_type_span: .span(start: 0, end: 0),
             can_throw: false,
@@ -4481,7 +4478,7 @@ struct Parser {
 
     fn parse_block(mut this) throws -> ParsedBlock {
         let start = .current().span()
-        mut block = ParsedBlock(stmts: [])
+        mut block = ParsedBlock()
 
         if .eof() {
             .error("Incomplete block", start)
@@ -4657,7 +4654,7 @@ struct Parser {
         }
         let else_block = .parse_block()
 
-        mut remaining_code = ParsedBlock(stmts: [])
+        mut remaining_code = ParsedBlock()
 
         while not .eof() {
             match .current() {

--- a/selfhost/parser.jakt
+++ b/selfhost/parser.jakt
@@ -370,13 +370,13 @@ enum RecordType {
 struct ParsedRecord {
     name: String
     name_span: Span
-    generic_parameters: [ParsedGenericParameter]
+    generic_parameters: [ParsedGenericParameter] = []
     definition_linkage: DefinitionLinkage
     // if not empty, must have at least one value.
-    implements_list: [ParsedNameWithGenericParameters]?
-    methods: [ParsedMethod]
+    implements_list: [ParsedNameWithGenericParameters]? = None
+    methods: [ParsedMethod] = []
     record_type: RecordType
-    nested_records: [ParsedRecord]
+    nested_records: [ParsedRecord] = []
 
     external_name: ExternalName? = None
 }
@@ -2628,12 +2628,8 @@ struct Parser {
             yield ParsedRecord(
                 name: "",
                 name_span: .empty_span(),
-                generic_parameters: [],
                 definition_linkage,
-                implements_list: None,
-                methods: [],
                 record_type: RecordType::Garbage
-                nested_records: []
             )
         }
     }
@@ -3365,12 +3361,8 @@ struct Parser {
         mut parsed_enum = ParsedRecord(
             name: "",
             name_span: .empty_span(),
-            generic_parameters: [],
             definition_linkage,
-            implements_list: None,
-            methods: [],
             record_type: RecordType::Garbage
-            nested_records: []
         )
         mut underlying_type: ParsedType? = None
         if .current() is Enum {
@@ -3649,12 +3641,8 @@ struct Parser {
         mut parsed_struct = ParsedRecord(
             name: "",
             name_span: .empty_span(),
-            generic_parameters: [],
             definition_linkage,
-            implements_list: None,
-            methods: [],
             record_type: RecordType::Garbage
-            nested_records: []
         )
         if .current() is Struct {
             .index++
@@ -3717,12 +3705,8 @@ struct Parser {
         mut parsed_class = ParsedRecord(
             name: "",
             name_span: .empty_span(),
-            generic_parameters: [],
             definition_linkage,
-            implements_list: None,
-            methods: [],
             record_type: RecordType::Garbage
-            nested_records: []
         )
         mut super_type: ParsedType? = None
         if .current() is Class {

--- a/selfhost/repl.jakt
+++ b/selfhost/repl.jakt
@@ -202,17 +202,9 @@ struct REPL {
             compiler
             program: CheckedProgram(compiler),
             current_module_id: placeholder_module_id,
-            current_struct_type_id: TypeId::none()
-            current_function_id: None
-            inside_defer: false
-            checkidx: 0uz
-            ignore_errors: false
             dump_type_hints: compiler.dump_type_hints
             dump_try_hints: compiler.dump_try_hints
-            lambda_count: 0
-            generic_inferences: GenericInferences(values: [:])
             root_module_name
-            cpp_import_cache: [:]
         )
 
         compiler.current_file = file_id

--- a/selfhost/repl.jakt
+++ b/selfhost/repl.jakt
@@ -200,7 +200,7 @@ struct REPL {
 
         mut typechecker = Typechecker(
             compiler
-            program: CheckedProgram(compiler, modules: [], loaded_modules: [:]),
+            program: CheckedProgram(compiler),
             current_module_id: placeholder_module_id,
             current_struct_type_id: TypeId::none()
             current_function_id: None

--- a/selfhost/typechecker.jakt
+++ b/selfhost/typechecker.jakt
@@ -2396,10 +2396,8 @@ struct Typechecker {
             name: parsed_trait.name
             name_span: parsed_trait.name_span
             generic_parameters
-            fields: []
             scope_id: trait_scope_id
             definition_linkage: DefinitionLinkage::External
-            trait_implementations: [:]
             record_type: RecordType::Struct(fields: [], super_type: None)
             type_id: trait_type_id
             super_struct_id: None
@@ -2487,12 +2485,8 @@ struct Typechecker {
         module.enums.push(CheckedEnum(
             name: parsed_record.name
             name_span: parsed_record.name_span
-            generic_parameters: []
-            variants: []
-            fields: []
             scope_id: .prelude_scope_id()
             definition_linkage: parsed_record.definition_linkage
-            trait_implementations: [:]
             record_type: parsed_record.record_type
             underlying_type_id: enum_type_id
             type_id: enum_type_id
@@ -2564,12 +2558,9 @@ struct Typechecker {
         module.enums[enum_id.id] = CheckedEnum(
             name: parsed_record.name
             name_span: parsed_record.name_span
-            generic_parameters: []
-            variants: []
             fields: checked_fields
             scope_id: enum_scope_id
             definition_linkage: parsed_record.definition_linkage
-            trait_implementations: [:]
             record_type: parsed_record.record_type
             underlying_type_id
             type_id: enum_type_id
@@ -3077,11 +3068,8 @@ struct Typechecker {
         module.structures[struct_id.id] = CheckedStruct(
             name: parsed_record.name
             name_span: parsed_record.name_span
-            generic_parameters: []
-            fields: []
             scope_id: struct_scope_id
             definition_linkage: parsed_record.definition_linkage
-            trait_implementations: [:]
             record_type: parsed_record.record_type
             type_id: struct_type_id
             super_struct_id
@@ -3229,14 +3217,10 @@ struct Typechecker {
         module.structures.push(CheckedStruct(
             name: parsed_record.name
             name_span: parsed_record.name_span
-            generic_parameters: []
-            fields: []
             scope_id: struct_scope_id
             definition_linkage: parsed_record.definition_linkage
-            trait_implementations: [:]
             record_type: parsed_record.record_type
             type_id: struct_type_id
-            super_struct_id: None
             external_name: parsed_record.external_name
         ))
 

--- a/selfhost/typechecker.jakt
+++ b/selfhost/typechecker.jakt
@@ -6546,12 +6546,7 @@ struct Typechecker {
                 // We need to call the `.iterator()` method on the iterable
                 expression_to_iterate = ParsedExpression::MethodCall(
                     expr: range
-                    call: ParsedCall(
-                        namespace_: []
-                        name: "iterator"
-                        args: []
-                        type_args: []
-                    )
+                    call: ParsedCall(name: "iterator")
                     is_optional: false
                     span: name_span
                 )
@@ -6625,12 +6620,7 @@ struct Typechecker {
                                             name: "_magic",
                                             span: name_span
                                         ),
-                                        call: ParsedCall(
-                                            namespace_: [],
-                                            name: "next",
-                                            args: [],
-                                            type_args: []
-                                        ),
+                                        call: ParsedCall(name: "next")
                                         is_optional: false
                                         span: name_span
                                     )
@@ -6644,12 +6634,7 @@ struct Typechecker {
                                                 name: "_magic_value",
                                                 span: name_span
                                             ),
-                                            call: ParsedCall(
-                                                namespace_: [],
-                                                name: "has_value",
-                                                args: [],
-                                                type_args: []
-                                            )
+                                            call: ParsedCall(name: "has_value")
                                             is_optional: false
                                             span: name_span
                                         ),
@@ -8897,7 +8882,7 @@ struct Typechecker {
             return CheckedExpression::NamespacedVar(namespaces: checked_namespaces, var: var!, span)
         }
 
-        let implicit_constructor_call = ParsedCall(namespace_, name, args: [], type_args: [])
+        let implicit_constructor_call = ParsedCall(namespace_, name)
         let call_expression = .typecheck_call(call: implicit_constructor_call, caller_scope_id: scope_id, span, this_expr: None, parent_id: None, safety_mode, type_hint, must_be_enum_constructor: true)
         let type_id = call_expression.type()
         let call = match call_expression {

--- a/selfhost/typechecker.jakt
+++ b/selfhost/typechecker.jakt
@@ -183,7 +183,7 @@ struct Typechecker {
 
         mut typechecker = Typechecker(
             compiler
-            program: CheckedProgram(compiler, modules: [], loaded_modules: [:]),
+            program: CheckedProgram(compiler),
             current_module_id: placeholder_module_id,
             current_struct_type_id: TypeId::none()
             current_function_id: None

--- a/selfhost/typechecker.jakt
+++ b/selfhost/typechecker.jakt
@@ -2665,11 +2665,8 @@ struct Typechecker {
                     base_scope_id: method_scope_id
                 )
                 block: CheckedBlock(
-                    statements: []
                     scope_id: block_scope_id
                     control_flow: BlockControlFlow::MayReturn
-                    yielded_type: TypeId::none()
-                    yielded_none: false
                 )
                 can_throw: func.can_throw
                 type: func.type
@@ -2878,11 +2875,8 @@ struct Typechecker {
                     base_params: constructor_parameters
                 )
                 block: CheckedBlock(
-                    statements: []
                     scope_id: block_scope_id
                     control_flow: BlockControlFlow::MayReturn
-                    yielded_type: TypeId::none()
-                    yielded_none: false
                 )
                 can_throw: false
                 type: FunctionType::ImplicitConstructor
@@ -3813,11 +3807,8 @@ struct Typechecker {
                                     base_params: params
                                 )
                                 block: CheckedBlock(
-                                    statements: []
                                     scope_id: block_scope_id
                                     control_flow: BlockControlFlow::MayReturn
-                                    yielded_type: TypeId::none()
-                                    yielded_none: false
                                 ),
                                 can_throw: false
                                 type: FunctionType::ImplicitEnumConstructor
@@ -3877,11 +3868,8 @@ struct Typechecker {
                                     base_params: params
                                 )
                                 block: CheckedBlock(
-                                    statements: [],
                                     scope_id: block_scope_id
                                     control_flow: BlockControlFlow::AlwaysReturns
-                                    yielded_type: TypeId::none()
-                                    yielded_none: false
                                 ),
                                 can_throw: false
                                 type: FunctionType::ImplicitEnumConstructor
@@ -3926,11 +3914,8 @@ struct Typechecker {
                                     base_params: params
                                 )
                                 block: CheckedBlock(
-                                    statements: []
                                     scope_id: block_scope_id
                                     control_flow: BlockControlFlow::AlwaysReturns
-                                    yielded_type: TypeId::none()
-                                    yielded_none: false
                                 ),
                                 can_throw: false
                                 type: FunctionType::ImplicitEnumConstructor
@@ -4264,11 +4249,8 @@ struct Typechecker {
             params: []
             generics: generics!
             block: CheckedBlock(
-                statements: []
                 scope_id: block_scope_id
                 control_flow: BlockControlFlow::MayReturn
-                yielded_type: TypeId::none()
-                yielded_none: false
             )
             can_throw: parsed_function.can_throw
             type: parsed_function.type
@@ -5502,11 +5484,8 @@ struct Typechecker {
         let parent_throws = .get_scope(parent_scope_id).can_throw
         let block_scope_id = .create_scope(parent_scope_id, can_throw: parent_throws, debug_name: "block")
         mut checked_block = CheckedBlock(
-            statements: []
             scope_id: block_scope_id
             control_flow: BlockControlFlow::MayReturn
-            yielded_type: TypeId::none()
-            yielded_none: false
         )
         for parsed_statement in parsed_block.stmts {
             if not checked_block.control_flow.is_reachable() {
@@ -5819,11 +5798,8 @@ struct Typechecker {
                         base_params: checked_params
                     )
                     block: CheckedBlock(
-                        statements: []
                         scope_id
                         control_flow: BlockControlFlow::MayReturn
-                        yielded_type: None
-                        yielded_none: false
                     )
                     can_throw
                     type: FunctionType::Expression

--- a/selfhost/typechecker.jakt
+++ b/selfhost/typechecker.jakt
@@ -126,20 +126,19 @@ struct Typechecker {
     compiler: Compiler
     program: CheckedProgram
     current_module_id: ModuleId
-    current_struct_type_id: TypeId?
-    current_function_id: FunctionId?
-    inside_defer: bool
-    checkidx: usize
-    ignore_errors: bool
-    dump_type_hints: bool
-    dump_try_hints: bool
-    lambda_count: u64
-    generic_inferences: GenericInferences
+    current_struct_type_id: TypeId? = None
+    current_function_id: FunctionId? = None
+    inside_defer: bool = false
+    ignore_errors: bool = false
+    dump_type_hints: bool = false
+    dump_try_hints: bool = false
+    lambda_count: u64 = 0
+    generic_inferences: GenericInferences = GenericInferences()
     self_type_id: TypeId? = None
     root_module_name: String
     in_comptime_function_call: bool = false
     had_an_error: bool = false
-    cpp_import_cache: [String:ScopeId]
+    cpp_import_cache: [String:ScopeId] = [:]
     cpp_import_processor: CppImportProcessor? = None
 
     fn set_self_type_id(mut this, anon type_id: TypeId) {
@@ -185,17 +184,9 @@ struct Typechecker {
             compiler
             program: CheckedProgram(compiler),
             current_module_id: placeholder_module_id,
-            current_struct_type_id: TypeId::none()
-            current_function_id: None
-            inside_defer: false
-            checkidx: 0uz
-            ignore_errors: false
             dump_type_hints: compiler.dump_type_hints
             dump_try_hints: compiler.dump_try_hints
-            lambda_count: 0
-            generic_inferences: GenericInferences(values: [:])
             root_module_name
-            cpp_import_cache: [:]
         )
 
         typechecker.include_prelude()

--- a/selfhost/typechecker.jakt
+++ b/selfhost/typechecker.jakt
@@ -2663,9 +2663,6 @@ struct Typechecker {
                 params: []
                 generics: FunctionGenerics(
                     base_scope_id: method_scope_id
-                    base_params: []
-                    params: []
-                    specializations: []
                 )
                 block: CheckedBlock(
                     statements: []
@@ -2879,8 +2876,6 @@ struct Typechecker {
                 generics: FunctionGenerics(
                     base_scope_id: function_scope_id
                     base_params: constructor_parameters
-                    params: []
-                    specializations: []
                 )
                 block: CheckedBlock(
                     statements: []
@@ -3816,8 +3811,6 @@ struct Typechecker {
                                 generics: FunctionGenerics(
                                     base_scope_id: function_scope_id
                                     base_params: params
-                                    params: []
-                                    specializations: []
                                 )
                                 block: CheckedBlock(
                                     statements: []
@@ -3882,8 +3875,6 @@ struct Typechecker {
                                 generics: FunctionGenerics(
                                     base_scope_id: function_scope_id
                                     base_params: params
-                                    params: []
-                                    specializations: []
                                 )
                                 block: CheckedBlock(
                                     statements: [],
@@ -3933,8 +3924,6 @@ struct Typechecker {
                                 generics: FunctionGenerics(
                                     base_scope_id: function_scope_id
                                     base_params: params
-                                    params: []
-                                    specializations: []
                                 )
                                 block: CheckedBlock(
                                     statements: []
@@ -4249,9 +4238,6 @@ struct Typechecker {
         if not generics.has_value() {
             generics = FunctionGenerics(
                 base_scope_id: function_scope_id
-                base_params: []
-                params: []
-                specializations: []
             )
 
             base_definition = true
@@ -5831,8 +5817,6 @@ struct Typechecker {
                     generics: FunctionGenerics(
                         base_scope_id: scope_id
                         base_params: checked_params
-                        params: []
-                        specializations: []
                     )
                     block: CheckedBlock(
                         statements: []

--- a/selfhost/typechecker.jakt
+++ b/selfhost/typechecker.jakt
@@ -357,10 +357,6 @@ struct Typechecker {
         let module = Module(
             id: module_id,
             name: name,
-            functions: [],
-            structures: [],
-            enums: [],
-            scopes: [],
             types: [ // FIXME: use general builtin types array
                 Type::Void,
                 Type::Bool,
@@ -381,11 +377,7 @@ struct Typechecker {
                 Type::Unknown,
                 Type::Never
             ],
-            traits: [],
-            variables: [],
-            imports: [],
             resolved_import_path: path ?? .compiler.current_file_path()!.to_string(),
-            builtin_implementation_structs: [:]
             is_root: is_root,
         )
         .program.modules.push(module)

--- a/selfhost/typechecker.jakt
+++ b/selfhost/typechecker.jakt
@@ -6330,10 +6330,8 @@ struct Typechecker {
                         type_id = implementation_function.return_type_id
 
                         mut call_expression = CheckedCall(
-                            namespace_: []
                             name: function_name
                             args: [("", checked_rhs)]
-                            type_args: []
                             function_id: implementation_function_id
                             return_type: type_id
                             callee_throws: implementation_function.can_throw
@@ -9092,14 +9090,12 @@ struct Typechecker {
         return CheckedExpression::MethodCall(
             expr: checked_expr
             call: CheckedCall(
-                namespace_: []
                 name: call.name
                 args: checked_args
                 type_args: checked_type_args
                 function_id: None
                 return_type: unknown_type_id()
                 callee_throws: false
-                external_name: None
             )
             span
             is_optional
@@ -10702,7 +10698,6 @@ struct Typechecker {
                         function_id: None,
                         return_type: builtin(BuiltinType::Unknown),
                         callee_throws
-                        external_name: None
                     ),
                     span,
                     type_id: builtin(BuiltinType::Unknown)

--- a/selfhost/types.jakt
+++ b/selfhost/types.jakt
@@ -652,18 +652,19 @@ struct ResolvedForallChunk {
 class Module {
     public id: ModuleId
     public name: String
-    public functions: [CheckedFunction]
-    public structures: [CheckedStruct]
-    public enums: [CheckedEnum]
-    public scopes: [Scope]
     public types: [Type]
-    public traits: [CheckedTrait]
-    public variables: [CheckedVariable]
-    public imports: [ModuleId]
     public resolved_import_path: String
-    public builtin_implementation_structs: [usize:StructId]
-
     public is_root: bool
+
+    public functions: [CheckedFunction] = []
+    public structures: [CheckedStruct] = []
+    public enums: [CheckedEnum] = []
+    public scopes: [Scope] = []
+    public traits: [CheckedTrait] = []
+    public variables: [CheckedVariable] = []
+    public imports: [ModuleId] = []
+    public builtin_implementation_structs: [usize:StructId] = [:]
+
     public fn is_prelude(this) -> bool => .id.id == 0
 
     public fn new_type_variable(mut this, implemented_traits: [TypeId]? = None) -> TypeId {
@@ -1745,10 +1746,6 @@ class CheckedProgram {
         let module = Module(
             id: module_id,
             name: name,
-            functions: [],
-            structures: [],
-            enums: [],
-            scopes: [],
             types: [ // FIXME: use general builtin types array
                 Type::Void,
                 Type::Bool,
@@ -1769,11 +1766,7 @@ class CheckedProgram {
                 Type::Unknown,
                 Type::Never
             ],
-            traits: [],
-            variables: [],
-            imports: [],
             resolved_import_path: path ?? .compiler.current_file_path()!.to_string(),
-            builtin_implementation_structs: [:]
             is_root: is_root,
         )
         .modules.push(module)

--- a/selfhost/types.jakt
+++ b/selfhost/types.jakt
@@ -1712,15 +1712,15 @@ struct ResolvedNamespace {
 }
 
 struct CheckedCall {
-    namespace_: [ResolvedNamespace]
+    namespace_: [ResolvedNamespace] = []
     name: String,
     args: [(String, CheckedExpression)]
-    type_args: [TypeId]
+    type_args: [TypeId] = []
     function_id: FunctionId?
     return_type: TypeId
     callee_throws: bool
 
-    external_name: ExternalName?
+    external_name: ExternalName? = None
     force_inline: InlineState = InlineState::Default
 
     fn name_for_codegen(this) -> ExternalName => .external_name ?? ExternalName::Plain(.name)

--- a/selfhost/types.jakt
+++ b/selfhost/types.jakt
@@ -78,7 +78,7 @@ enum StructLikeId {
 }
 
 struct GenericInferences {
-    values: [TypeId:TypeId]
+    values: [TypeId:TypeId] = [:]
 
     fn set(mut this, anon key: TypeId, anon value: TypeId) {
         if key == value {

--- a/selfhost/types.jakt
+++ b/selfhost/types.jakt
@@ -1244,15 +1244,15 @@ struct CheckedField {
 struct CheckedStruct {
     name: String
     name_span: Span
-    generic_parameters: [CheckedGenericParameter]
+    generic_parameters: [CheckedGenericParameter] = []
     generic_parameter_defaults: [TypeId?]? = None
-    fields: [CheckedField]
+    fields: [CheckedField] = []
     scope_id: ScopeId
     definition_linkage: DefinitionLinkage
-    trait_implementations: [String:[(TraitId, [TypeId])]]
+    trait_implementations: [String:[(TraitId, [TypeId])]] = [:]
     record_type: RecordType
     type_id: TypeId
-    super_struct_id: StructId?
+    super_struct_id: StructId? = None
 
     external_name: ExternalName? = None
     implements_type: TypeId? = None
@@ -1263,12 +1263,12 @@ struct CheckedStruct {
 struct CheckedEnum {
     name: String
     name_span: Span
-    generic_parameters: [CheckedGenericParameter]
-    variants: [CheckedEnumVariant]
-    fields: [CheckedField]
+    generic_parameters: [CheckedGenericParameter] = []
+    variants: [CheckedEnumVariant] = []
+    fields: [CheckedField] = []
     scope_id: ScopeId
     definition_linkage: DefinitionLinkage
-    trait_implementations: [String:[(TraitId, [TypeId])]]
+    trait_implementations: [String:[(TraitId, [TypeId])]] = [:]
     record_type: RecordType
     underlying_type_id: TypeId
     type_id: TypeId
@@ -1916,8 +1916,6 @@ class CheckedProgram {
         let struct_ = CheckedStruct(
             name: format("Builtin_{}", builtin.constructor_name())
             name_span
-            generic_parameters: []
-            fields: []
             scope_id
             definition_linkage: DefinitionLinkage::External
             trait_implementations

--- a/selfhost/types.jakt
+++ b/selfhost/types.jakt
@@ -942,9 +942,9 @@ class CheckedFunction {
 
 class FunctionGenerics {
     public base_scope_id: ScopeId
-    public base_params: [CheckedParameter]
-    public params: [FunctionGenericParameter]
-    public specializations: [[TypeId]]
+    public base_params: [CheckedParameter] = []
+    public params: [FunctionGenericParameter] = []
+    public specializations: [[TypeId]] = []
 
     public fn is_specialized_for_types(this, types: [TypeId]) -> bool {
         if types.size() == 0 {

--- a/selfhost/types.jakt
+++ b/selfhost/types.jakt
@@ -1224,11 +1224,11 @@ enum BlockControlFlow {
 }
 
 struct CheckedBlock {
-    statements: [CheckedStatement]
+    statements: [CheckedStatement] = []
     scope_id: ScopeId
     control_flow: BlockControlFlow
-    yielded_type: TypeId?
-    yielded_none: bool
+    yielded_type: TypeId? = None
+    yielded_none: bool = false
 }
 
 struct FieldRecord {

--- a/selfhost/types.jakt
+++ b/selfhost/types.jakt
@@ -601,38 +601,38 @@ struct SpecializedType {
 }
 
 class Scope {
-    public namespace_name: String?
-    public external_name: ExternalName?
-
-    public vars: [String: VarId]
-    public comptime_bindings: [String: Value]
-    public structs: [String: StructId]
-    public functions: [String: [FunctionId]]
-    public enums: [String: EnumId]
-    public types: [String: TypeId]
-    public traits: [String: TraitId]
-    public imports: [String: ModuleId] // FIXME: Span
-    public aliases: [String: ScopeId]
     public parent: ScopeId?
-    public alias_scope: ScopeId? = None
-    public children: [ScopeId]
     public can_throw: bool
-    public import_path_if_extern: String?
-    public alias_path: [ResolvedNamespace]? = None
-    public after_extern_include: [IncludeAction]
-    public before_extern_include: [IncludeAction]
-
     public debug_name: String
-    public resolution_mixins: [ScopeId]
+    public is_block_scope: bool
+    public is_from_generated_code: bool
+
+    public namespace_name: String? = None
+    public external_name: ExternalName? = None
+
+    public vars: [String: VarId] = [:]
+    public comptime_bindings: [String: Value] = [:]
+    public structs: [String: StructId] = [:]
+    public functions: [String: [FunctionId]] = [:]
+    public enums: [String: EnumId] = [:]
+    public types: [String: TypeId] = [:]
+    public traits: [String: TraitId] = [:]
+    public imports: [String: ModuleId] = [:] // FIXME: Span
+    public aliases: [String: ScopeId] = [:]
+    
+    public alias_scope: ScopeId? = None
+    public children: [ScopeId] = []
+    public import_path_if_extern: String? = None
+    public alias_path: [ResolvedNamespace]? = None
+    public after_extern_include: [IncludeAction] = []
+    public before_extern_include: [IncludeAction] = []
+    public resolution_mixins: [ScopeId] = []
 
     // Set if this scope corresponds to a type, as opposed to a block or a namespace.
     public relevant_type_id: TypeId? = None
 
-    public is_block_scope: bool = true
-
     public resolved_forall_chunks: [ResolvedForallChunk]? = None
-    public explicitly_specialized_types: [String:SpecializedType]
-    public is_from_generated_code: bool = false
+    public explicitly_specialized_types: [String:SpecializedType] = [:]
 
     public fn namespace_name_for_codegen(this) -> ExternalName? {
         if .external_name.has_value() { return .external_name }
@@ -1736,8 +1736,8 @@ fn builtin(anon builtin: BuiltinType) -> TypeId {
 // This is the "result" object produced by type-checking.
 class CheckedProgram {
     public compiler: Compiler
-    public modules: [Module]
-    public loaded_modules: [String: LoadedModule]
+    public modules: [Module] = []
+    public loaded_modules: [String: LoadedModule] = [:]
 
     public fn create_module(mut this, name: String, is_root: bool, path: String? = None) -> ModuleId {
         let new_id = .modules.size()
@@ -1823,30 +1823,11 @@ class CheckedProgram {
             is_from_generated_code = scope.is_from_generated_code
         }
 
-        let none_string: String? = None
-
         let scope = Scope(
-            namespace_name: none_string
-            external_name: None
-            vars: [:]
-            comptime_bindings: [:]
-            structs: [:]
-            functions: [:]
-            enums: [:]
-            types: [:]
-            traits: [:]
-            imports: [:]
-            aliases: [:]
             parent: parent_scope_id
-            children: []
             can_throw
-            import_path_if_extern: None
-            after_extern_include: []
-            before_extern_include: []
             debug_name
-            resolution_mixins: []
             is_block_scope: for_block
-            explicitly_specialized_types: [:]
             is_from_generated_code
         )
 


### PR DESCRIPTION
Now that we are free to use `[]` and `[:]` in default initializers anywhere, we can use them a *lot* more and cut down on verbose initialization code.