### PR TITLE
 codegen: Ensure return is forwarded with the correct type

### DIFF
--- a/bootstrap/stage0/codegen.cpp
+++ b/bootstrap/stage0/codegen.cpp
@@ -49,20 +49,7 @@ return codegen::ControlFlowState(((((*this).allowed_exits)).allow_return()),((*t
 }
 }
 
-ByteString codegen::ControlFlowState::nested_release_return_expr(ids::TypeId const func_return_type,bool const func_can_throw,ByteString const cpp_match_result_type) {
-{
-bool const returns_void = ((((func_return_type).equals(types::void_type_id())) || ((func_return_type).equals(types::unknown_type_id()))) || ((func_return_type).equals(types::never_type_id())));
-if ((returns_void && (!(func_can_throw)))){
-return __jakt_format((StringView::from_string_literal("JaktInternal::ExplicitValueOrControlFlow<{}, void>()"sv)),cpp_match_result_type);
-}
-else {
-return (ByteString::from_utf8_without_validation("_jakt_value.release_return()"sv));
-}
-
-}
-}
-
-ErrorOr<ByteString> codegen::ControlFlowState::apply_control_flow_macro(ByteString const x,ids::TypeId const func_return_type,bool const func_can_throw,ByteString const cpp_match_result_type) const {
+ErrorOr<ByteString> codegen::ControlFlowState::apply_control_flow_macro(ByteString const x,ids::TypeId const func_return_type,bool const func_can_throw) const {
 {
 ByteString const handle_loop_controls = ({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<ByteString,ErrorOr<ByteString>>{
@@ -101,11 +88,13 @@ VERIFY_NOT_REACHED();
         return _jakt_value.release_return();
     _jakt_value.release_value();
 });
+bool const cpp_func_returns_void = ((!(func_can_throw)) && ((((func_return_type).equals(types::void_type_id())) || ((func_return_type).equals(types::unknown_type_id()))) || ((func_return_type).equals(types::never_type_id()))));
+bool const substitute_naked_return = (((*this).indirectly_inside_match) && cpp_func_returns_void);
 ByteString const forward_return_expr = ({
     auto&& _jakt_value = ([&]() -> JaktInternal::ExplicitValueOrControlFlow<ByteString,ErrorOr<ByteString>>{
-auto __jakt_enum_value = (((*this).indirectly_inside_match));
+auto __jakt_enum_value = (substitute_naked_return);
 if (__jakt_enum_value == true) {
-return JaktInternal::ExplicitValue(codegen::ControlFlowState::nested_release_return_expr(func_return_type,func_can_throw,cpp_match_result_type));
+return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("{}"sv)));
 }
 else if (__jakt_enum_value == false) {
 return JaktInternal::ExplicitValue((ByteString::from_utf8_without_validation("_jakt_value.release_return()"sv)));
@@ -8208,7 +8197,7 @@ else {
 }
 
 (((*this).control_flow_state) = last_control_flow);
-return TRY((((((*this).control_flow_state)).apply_control_flow_macro(output,(((((*this).current_function).value()))->return_type_id),(((((*this).current_function).value()))->can_throw),cpp_match_result_type))));
+return TRY((((((*this).control_flow_state)).apply_control_flow_macro(output,(((((*this).current_function).value()))->return_type_id),(((((*this).current_function).value()))->can_throw)))));
 }
 }
 

--- a/bootstrap/stage0/codegen.h
+++ b/bootstrap/stage0/codegen.h
@@ -36,8 +36,7 @@ public: codegen::AllowedControlExits allowed_exits;public: bool passes_through_t
 public: codegen::ControlFlowState enter_function() const;
 public: codegen::ControlFlowState enter_loop() const;
 public: codegen::ControlFlowState enter_match() const;
-public: static ByteString nested_release_return_expr(ids::TypeId const func_return_type, bool const func_can_throw, ByteString const cpp_match_result_type);
-public: ErrorOr<ByteString> apply_control_flow_macro(ByteString const x, ids::TypeId const func_return_type, bool const func_can_throw, ByteString const cpp_match_result_type) const;
+public: ErrorOr<ByteString> apply_control_flow_macro(ByteString const x, ids::TypeId const func_return_type, bool const func_can_throw) const;
 public: ControlFlowState(codegen::AllowedControlExits a_allowed_exits, bool a_passes_through_try, bool a_directly_inside_match, bool a_indirectly_inside_match);
 
 public: ByteString debug_description() const;

--- a/bootstrap/stage0/git.cpp
+++ b/bootstrap/stage0/git.cpp
@@ -3,7 +3,7 @@ namespace Jakt {
 namespace git {
 ErrorOr<ByteString> commit_hash() {
 {
-ByteString const hash = (ByteString::from_utf8_without_validation("66f2ff20007adf10661688c7d809caa058c02f6e"sv));
+ByteString const hash = (ByteString::from_utf8_without_validation("e1c337f69b3aa344d5a6f3b3b78544b4d7c58745"sv));
 return hash;
 }
 }

--- a/selfhost/codegen.jakt
+++ b/selfhost/codegen.jakt
@@ -75,25 +75,8 @@ struct ControlFlowState {
         )
     }
 
-    // Instead of trying to use `release_return()` which returns `void`, we'll
-    // directly construct a `ExplicitValueOrControlFlow<MatchResult, void>` so
-    // that the compiler doesn't try to construct one from a `void` value,
-    // which it doesn't know how to do.
-    fn nested_release_return_expr(func_return_type: TypeId, func_can_throw: bool, cpp_match_result_type: String) -> String {
-
-        let returns_void = func_return_type == void_type_id() or func_return_type == unknown_type_id() or func_return_type == never_type_id()
-
-        // The C++ function won't return 'void' if it can throw, but rather
-        // `ErrorOr`.
-        if returns_void and not func_can_throw {
-            return format("JaktInternal::ExplicitValueOrControlFlow<{}, void>()", cpp_match_result_type)
-        } else {
-            return "_jakt_value.release_return()"
-        }
-    }
-
     // apply control flow macro to a match, from outside its scope
-    fn apply_control_flow_macro(this, anon x: String, func_return_type: TypeId, func_can_throw: bool, cpp_match_result_type: String) throws -> String {
+    fn apply_control_flow_macro(this, anon x: String, func_return_type: TypeId, func_can_throw: bool) throws -> String {
         let handle_loop_controls = match are_loop_exits_allowed(.allowed_exits) {
             // Not inside a loop, so the inner match better not yield those
             // values, since there's no one that can catch them.
@@ -117,9 +100,18 @@ struct ControlFlowState {
             }
         }
 
+        let cpp_func_returns_void = not func_can_throw and (
+            func_return_type == void_type_id() or
+            func_return_type == unknown_type_id() or
+            func_return_type == never_type_id())
+
         // Make sure we don't return 'void' when forwarding a return inside a match IIFE.
-        let forward_return_expr = match .indirectly_inside_match {
-            true => nested_release_return_expr(func_return_type, func_can_throw, cpp_match_result_type)
+        // We'll have to use {} like in the codegen for return, to construct an
+        // `ExplicitValueOrControlFlow` that signals that we want to return from
+        // the top-level function.
+        let substitute_naked_return = .indirectly_inside_match and cpp_func_returns_void
+        let forward_return_expr = match substitute_naked_return {
+            true => "{}"
             false => "_jakt_value.release_return()"
         }
 
@@ -3140,7 +3132,6 @@ struct CodeGenerator {
             output,
             func_return_type: .current_function!.return_type_id,
             func_can_throw: .current_function!.can_throw,
-            cpp_match_result_type
         )
     }
 

--- a/tests/codegen/nested_loop_in_match_with_nonvoid.jakt
+++ b/tests/codegen/nested_loop_in_match_with_nonvoid.jakt
@@ -1,0 +1,24 @@
+/// Expect:
+/// - output: "not a boog!\n"
+
+// The sample should compile without errors.
+// Brought up by #1525.
+
+fn boog() {
+    loop {
+        match 1 {
+            else => {
+                match 1 {
+                    else => 0
+                }
+            }
+        }
+        // Ensure yielding from a match doesn't return from the function.
+        println("not a boog!")
+        break
+    }
+}
+
+fn main() {
+    boog()
+}


### PR DESCRIPTION
On #1523 I forgot to update the forwarded returns from matches to be the same as
the return codegen.

Fixes #1525.
