### PR TITLE
types: Don't assume all string literals will throw

### DIFF
--- a/selfhost/types.jakt
+++ b/selfhost/types.jakt
@@ -1651,9 +1651,7 @@ boxed enum CheckedExpression {
 
     fn can_throw(this) -> bool => match this {
         Call(call) | MethodCall(call) => call.callee_throws
-        // FIXME: This could be a 'StringView' or something that implements FromStringLiteral, which does not throw.
-        //        For now, we have to assume the worst.
-        QuotedString => true
+        QuotedString(val) => val.may_throw
         else => false
     }
 

--- a/tests/typechecker/string_literal_throw.jakt
+++ b/tests/typechecker/string_literal_throw.jakt
@@ -1,0 +1,22 @@
+/// Expect:
+/// - output: ""
+
+struct Throwsy implements(ThrowingFromStringLiteral) {
+    fn from_string_literal(anon s: StringView) throws -> Throwsy {
+        return Throwsy()
+    }
+}
+
+// Adapted from #1530.
+fn boog() {
+    let x: String? = None
+    let y = x ?? ""
+}
+
+fn throwsy_boog() {
+    let x: Throwsy? = None
+    let y = try x ?? ""
+}
+
+fn main() {
+}


### PR DESCRIPTION
The information is already available, use that instead of assuming the worst.
Fixes #1530.