### PR TITLE
typechecker: Disallow usage of 'continue' and 'break' outside of loops

### DIFF
--- a/selfhost/typechecker.jakt
+++ b/selfhost/typechecker.jakt
@@ -74,6 +74,12 @@ enum BreakContinueLegalityTracker {
     Defer
 }
 
+enum ReturnLegalityTracker {
+    None,
+    Lambda,
+    Defer
+}
+
 enum NumericOrStringValue {
     StringValue(String)
     SignedNumericValue(i64)
@@ -134,8 +140,8 @@ struct Typechecker {
     current_module_id: ModuleId
     current_struct_type_id: TypeId? = None
     current_function_id: FunctionId? = None
-    inside_defer: bool = false
     break_continue_tracker: BreakContinueLegalityTracker = BreakContinueLegalityTracker::None
+    return_tracker: ReturnLegalityTracker = ReturnLegalityTracker::None
     ignore_errors: bool = false
     dump_type_hints: bool = false
     dump_try_hints: bool = false
@@ -7310,13 +7316,14 @@ struct Typechecker {
     }
 
     fn typecheck_defer(mut this, statement: ParsedStatement, scope_id: ScopeId, safety_mode: SafetyMode, span: Span) throws -> CheckedStatement {
+        let previous_return_tracker = .return_tracker
+        .return_tracker = ReturnLegalityTracker::Defer
+        defer .return_tracker = previous_return_tracker
+
         let previous_break_continue_tracker = .break_continue_tracker
         .break_continue_tracker = BreakContinueLegalityTracker::Defer
         defer .break_continue_tracker = previous_break_continue_tracker
 
-        let was_inside_defer = .inside_defer
-        .inside_defer = true
-        defer .inside_defer = was_inside_defer
         let checked_statement = .typecheck_statement(statement, scope_id, safety_mode)
         if checked_statement is Block(block) and block.yielded_type.has_value() {
             .error("‘yield’ inside ‘defer’ is meaningless", span)
@@ -7351,9 +7358,10 @@ struct Typechecker {
     }
 
     fn typecheck_return(mut this, expr: ParsedExpression?, span: Span, scope_id: ScopeId, safety_mode: SafetyMode) throws -> CheckedStatement {
-        if .inside_defer {
+        if .return_tracker is Defer {
             .error("‘return’ is not allowed inside ‘defer’", span)
         }
+
         if not expr.has_value() {
             if .current_function_id.has_value() {
                 let current_function = .get_function(.current_function_id!)
@@ -8727,6 +8735,10 @@ struct Typechecker {
         scope_id: ScopeId
         safety_mode: SafetyMode
     ) throws -> CheckedExpression {
+        let previous_return_tracker = .return_tracker
+        .return_tracker = ReturnLegalityTracker::Lambda
+        defer .return_tracker = previous_return_tracker
+
         let synthetic_type = ParsedType::Function(
             params
             can_throw

--- a/selfhost/typechecker.jakt
+++ b/selfhost/typechecker.jakt
@@ -6402,7 +6402,7 @@ struct Typechecker {
         Throw(expr, span) => .typecheck_throw(expr, scope_id, safety_mode, span)
         While(condition, block, span) => .typecheck_while(condition, block, scope_id, safety_mode, span)
         Continue(span) => .typecheck_continue(span)
-        Break(span) => CheckedStatement::Break(span)
+        Break(span) => .typecheck_break(span)
         VarDecl(var, init, span) => .typecheck_var_decl(var, init, scope_id, safety_mode, span)
         DestructuringAssignment(vars, var_decl, span) => .typecheck_destructuring_assignment(vars, var_decl, scope_id, safety_mode, span)
         If(condition, then_block, else_statement, span) => .typecheck_if(condition, then_block, else_statement, scope_id, safety_mode, span)
@@ -6421,6 +6421,18 @@ struct Typechecker {
         }
 
         return CheckedStatement::Continue(span)
+    }
+
+    fn typecheck_break(mut this, span: Span) -> CheckedStatement {
+        if not .break_continue_tracker is AnyLoop {
+            if .break_continue_tracker is Defer {
+                .error("‘break’ inside loop cannot be deferred", span)
+            } else {
+                .error("‘break’ statements can only be used inside loops", span)
+            }
+        }
+
+        return CheckedStatement::Break(span)
     }
 
     fn typecheck_guard(mut this, expr: ParsedExpression, else_block: ParsedBlock, remaining_code: ParsedBlock, scope_id: ScopeId, safety_mode: SafetyMode, span: Span) throws -> CheckedStatement {

--- a/selfhost/typechecker.jakt
+++ b/selfhost/typechecker.jakt
@@ -68,6 +68,12 @@ struct ImportRestrictions {
     )
 }
 
+enum BreakContinueLegalityTracker {
+    None,
+    AnyLoop,
+    Defer
+}
+
 enum NumericOrStringValue {
     StringValue(String)
     SignedNumericValue(i64)
@@ -129,6 +135,7 @@ struct Typechecker {
     current_struct_type_id: TypeId? = None
     current_function_id: FunctionId? = None
     inside_defer: bool = false
+    break_continue_tracker: BreakContinueLegalityTracker = BreakContinueLegalityTracker::None
     ignore_errors: bool = false
     dump_type_hints: bool = false
     dump_try_hints: bool = false
@@ -6482,6 +6489,10 @@ struct Typechecker {
         safety_mode: SafetyMode
         span: Span
     ) throws -> CheckedStatement {
+        let previous_break_continue_tracker = .break_continue_tracker
+        .break_continue_tracker = BreakContinueLegalityTracker::AnyLoop
+        defer .break_continue_tracker = previous_break_continue_tracker
+
         let maybe_span = block.find_yield_span()
         if maybe_span.has_value() {
             .error("a 'for' loop block is not allowed to yield values", maybe_span!)
@@ -7148,6 +7159,10 @@ struct Typechecker {
     }
 
     fn typecheck_while(mut this, condition: ParsedExpression, block: ParsedBlock, scope_id: ScopeId, safety_mode: SafetyMode, span: Span) throws -> CheckedStatement {
+        let previous_break_continue_tracker = .break_continue_tracker
+        .break_continue_tracker = BreakContinueLegalityTracker::AnyLoop
+        defer .break_continue_tracker = previous_break_continue_tracker
+
         let checked_condition = .typecheck_expression_and_dereference_if_needed(condition, scope_id, safety_mode, type_hint: None, span)
         if not checked_condition.type().equals(builtin(BuiltinType::Bool)) {
             .error("Condition must be a boolean expression", condition.span())
@@ -7259,6 +7274,10 @@ struct Typechecker {
     }
 
     fn typecheck_loop(mut this, parsed_block: ParsedBlock, scope_id: ScopeId, safety_mode: SafetyMode, span: Span) throws -> CheckedStatement {
+        let previous_break_continue_tracker = .break_continue_tracker
+        .break_continue_tracker = BreakContinueLegalityTracker::AnyLoop
+        defer .break_continue_tracker = previous_break_continue_tracker
+
         let checked_block = .typecheck_block(parsed_block, parent_scope_id: scope_id, safety_mode)
         if checked_block.yielded_type.has_value() {
             .error("A ‘loop’ block is not allowed to yield values", parsed_block.find_yield_span()!)
@@ -7267,6 +7286,10 @@ struct Typechecker {
     }
 
     fn typecheck_defer(mut this, statement: ParsedStatement, scope_id: ScopeId, safety_mode: SafetyMode, span: Span) throws -> CheckedStatement {
+        let previous_break_continue_tracker = .break_continue_tracker
+        .break_continue_tracker = BreakContinueLegalityTracker::Defer
+        defer .break_continue_tracker = previous_break_continue_tracker
+
         let was_inside_defer = .inside_defer
         .inside_defer = true
         defer .inside_defer = was_inside_defer

--- a/selfhost/typechecker.jakt
+++ b/selfhost/typechecker.jakt
@@ -6401,7 +6401,7 @@ struct Typechecker {
         Loop(block, span) => .typecheck_loop(parsed_block: block, scope_id, safety_mode, span)
         Throw(expr, span) => .typecheck_throw(expr, scope_id, safety_mode, span)
         While(condition, block, span) => .typecheck_while(condition, block, scope_id, safety_mode, span)
-        Continue(span) => CheckedStatement::Continue(span)
+        Continue(span) => .typecheck_continue(span)
         Break(span) => CheckedStatement::Break(span)
         VarDecl(var, init, span) => .typecheck_var_decl(var, init, scope_id, safety_mode, span)
         DestructuringAssignment(vars, var_decl, span) => .typecheck_destructuring_assignment(vars, var_decl, scope_id, safety_mode, span)
@@ -6409,6 +6409,18 @@ struct Typechecker {
         Garbage(span) => CheckedStatement::Garbage(span)
         For(iterator_name, name_span, is_destructuring, range, block, span) => .typecheck_for(iterator_name, name_span, is_destructuring, range, block, scope_id, safety_mode, span)
         Guard(expr, else_block, remaining_code, span) => .typecheck_guard(expr, else_block, remaining_code, scope_id, safety_mode, span)
+    }
+
+    fn typecheck_continue(mut this, span: Span) -> CheckedStatement {
+        if not .break_continue_tracker is AnyLoop {
+            if .break_continue_tracker is Defer {
+                .error("‘continue’ inside loop cannot be deferred", span)
+            } else {
+                .error("‘continue’ statements can only be used inside loops", span)
+            }
+        }
+
+        return CheckedStatement::Continue(span)
     }
 
     fn typecheck_guard(mut this, expr: ParsedExpression, else_block: ParsedBlock, remaining_code: ParsedBlock, scope_id: ScopeId, safety_mode: SafetyMode, span: Span) throws -> CheckedStatement {

--- a/tests/typechecker/break_inside_defer.jakt
+++ b/tests/typechecker/break_inside_defer.jakt
@@ -1,0 +1,14 @@
+/// Expect:
+/// - error: "‘break’ inside loop cannot be deferred"
+
+fn test() {
+    for i in 1..2 {
+        defer {
+            break
+        }
+    }
+}
+
+fn main() {
+    test()
+}

--- a/tests/typechecker/break_inside_loop_inside_defer.jakt
+++ b/tests/typechecker/break_inside_loop_inside_defer.jakt
@@ -1,0 +1,19 @@
+/// Expect:
+/// - output: "1\n2\n"
+
+fn test() {
+    for i in 1..2 {
+        defer {
+            for j in 1..2 {
+                println("2")
+                break
+            }
+        }
+
+        println("1")
+    }
+}
+
+fn main() {
+    test()
+}

--- a/tests/typechecker/break_outside_loop.jakt
+++ b/tests/typechecker/break_outside_loop.jakt
@@ -1,0 +1,6 @@
+/// Expect:
+/// - error: "‘break’ statements can only be used inside loops"
+
+fn main() {
+    break
+}

--- a/tests/typechecker/continue_inside_defer.jakt
+++ b/tests/typechecker/continue_inside_defer.jakt
@@ -1,0 +1,14 @@
+/// Expect:
+/// - error: "‘continue’ inside loop cannot be deferred"
+
+fn test() {
+    for i in 1..2 {
+        defer {
+            continue
+        }
+    }
+}
+
+fn main() {
+    test()
+}

--- a/tests/typechecker/continue_inside_loop_inside_defer.jakt
+++ b/tests/typechecker/continue_inside_loop_inside_defer.jakt
@@ -1,0 +1,19 @@
+/// Expect:
+/// - output: "1\n2\n"
+
+fn test() {
+    for i in 1..2 {
+        defer {
+            for j in 1..2 {
+                println("2")
+                continue
+            }
+        }
+
+        println("1")
+    }
+}
+
+fn main() {
+    test()
+}

--- a/tests/typechecker/continue_outside_loop.jakt
+++ b/tests/typechecker/continue_outside_loop.jakt
@@ -1,0 +1,6 @@
+/// Expect:
+/// - error: "‘continue’ statements can only be used inside loops"
+
+fn main() {
+    continue
+}

--- a/tests/typechecker/return_in_lambda_in_defer.jakt
+++ b/tests/typechecker/return_in_lambda_in_defer.jakt
@@ -1,0 +1,13 @@
+/// Expect:
+/// - output: "PASS\n"
+
+fn test() {
+    defer {
+        let x = fn() { println("PASS") return }
+        x()
+    }
+}
+
+fn main() {
+    test()
+}


### PR DESCRIPTION
Fixes #1531